### PR TITLE
Bump clang-tidy version to 4.0.0 + tidiness check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,2 +1,2 @@
-Checks: 'modernize-*,misc-static-assert,llvm-namespace-comment,-clang-analyzer-security.insecureAPI.rand,-clang-analyzer-core.uninitialized.UndefReturn,-clang-analyzer-core.StackAddressEscape,-clang-analyzer-core.CallAndMessage,-clang-diagnostic-unused-command-line-argument,-clang-analyzer-core.uninitialized.*'
+Checks: 'modernize-*,misc-static-assert,llvm-namespace-comment,-clang-analyzer-security.insecureAPI.rand,-clang-analyzer-core.uninitialized.UndefReturn,-clang-analyzer-core.StackAddressEscape,-clang-analyzer-core.CallAndMessage,-clang-diagnostic-unused-command-line-argument,-clang-analyzer-core.uninitialized.*,-clang-analyzer-core.NullDereference,-clang-analyzer-core.NonNullParamChecker'
 HeaderFilterRegex: '\/mbgl\/'

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,13 +70,14 @@ after_success:
 
 matrix:
   include:
-    # LLVM 3.8.0 - clang-{format,tidy}
+    # Clang 3.9.0 / clang-{format,tidy} 4.0.0
     - os: linux
-      sudo: false
+      sudo: required
       dist: trusty
       language: cpp
-      env: _CXX=c++ _CC=cc
       compiler: "check"
+      env: _CXX=clang++-3.9 _CC=clang-3.9
+      addons: *clang39
       script:
         - git fetch origin master:refs/remotes/origin/master
         - make check

--- a/include/mbgl/map/query.hpp
+++ b/include/mbgl/map/query.hpp
@@ -30,4 +30,4 @@ public:
     optional<style::Filter> filter;
 };
 
-}
+} // namespace mbgl

--- a/include/mbgl/style/conversion/filter.hpp
+++ b/include/mbgl/style/conversion/filter.hpp
@@ -57,7 +57,7 @@ public:
            return convertUnaryFilter<NotHasFilter, NotHasIdentifierFilter>(value, error);
         }
 
-        error = { "filter operator must be one of \"==\", \"!=\", \">\", \">=\", \"<\", \"<=\", \"in\", \"!in\", \"all\", \"any\", \"none\", \"has\", or \"!has\"" };
+        error = { R"(filter operator must be one of "==", "!=", ">", ">=", "<", "<=", "in", "!in", "all", "any", "none", "has", or "!has")" };
         return {};
     }
 

--- a/include/mbgl/style/conversion/function.hpp
+++ b/include/mbgl/style/conversion/function.hpp
@@ -218,7 +218,7 @@ optional<optional<T>> convertDefaultValue(const V& value, Error& error) {
 
     auto defaultValue = convert<T>(*defaultValueValue, error);
     if (!defaultValue) {
-        error = { "wrong type for \"default\": " + error.message };
+        error = { R"(wrong type for "default": )" + error.message };
         return {};
     }
 

--- a/include/mbgl/style/conversion/property_setter.hpp
+++ b/include/mbgl/style/conversion/property_setter.hpp
@@ -21,7 +21,7 @@ using PaintPropertySetter = optional<Error> (*) (Layer&, const V&, const optiona
 
 template <class V, class L, class PropertyValue, void (L::*setter)(PropertyValue)>
 optional<Error> setLayoutProperty(Layer& layer, const V& value) {
-    L* typedLayer = layer.as<L>();
+    auto* typedLayer = layer.as<L>();
     if (!typedLayer) {
         return Error { "layer doesn't support this property" };
     }
@@ -38,7 +38,7 @@ optional<Error> setLayoutProperty(Layer& layer, const V& value) {
 
 template <class V, class L, class PropertyValue, void (L::*setter)(PropertyValue, const optional<std::string>&)>
 optional<Error> setPaintProperty(Layer& layer, const V& value, const optional<std::string>& klass) {
-    L* typedLayer = layer.as<L>();
+    auto* typedLayer = layer.as<L>();
     if (!typedLayer) {
         return Error { "layer doesn't support this property" };
     }
@@ -55,7 +55,7 @@ optional<Error> setPaintProperty(Layer& layer, const V& value, const optional<st
 
 template <class V, class L, void (L::*setter)(const TransitionOptions&, const optional<std::string>&)>
 optional<Error> setTransition(Layer& layer, const V& value, const optional<std::string>& klass) {
-    L* typedLayer = layer.as<L>();
+    auto* typedLayer = layer.as<L>();
     if (!typedLayer) {
         return Error { "layer doesn't support this property" };
     }

--- a/include/mbgl/util/noncopyable.hpp
+++ b/include/mbgl/util/noncopyable.hpp
@@ -7,11 +7,13 @@ namespace non_copyable_
 
 class noncopyable
 {
+public:
+    noncopyable( noncopyable const& ) = delete;
+    noncopyable& operator=(noncopyable const& ) = delete;
+
 protected:
     constexpr noncopyable() = default;
     ~noncopyable() = default;
-    noncopyable( noncopyable const& ) = delete;
-    noncopyable& operator=(noncopyable const& ) = delete;
 };
 } // namespace non_copyable_
 

--- a/include/mbgl/util/noncopyable.hpp
+++ b/include/mbgl/util/noncopyable.hpp
@@ -17,7 +17,7 @@ protected:
 };
 } // namespace non_copyable_
 
-typedef non_copyable_::noncopyable noncopyable;
+using noncopyable = non_copyable_::noncopyable;
 
 } // namespace util
 } // namespace mbgl

--- a/include/mbgl/util/range.hpp
+++ b/include/mbgl/util/range.hpp
@@ -1,3 +1,5 @@
+#include <utility>
+
 #pragma once
 
 namespace mbgl {
@@ -5,8 +7,8 @@ namespace mbgl {
 template <class T>
 class Range {
 public:
-    constexpr Range(const T& min_, const T& max_)
-        : min(min_), max(max_) {}
+    constexpr Range(T min_, T max_)
+        : min(std::move(min_)), max(std::move(max_)) {}
 
     T min;
     T max;

--- a/include/mbgl/util/run_loop.hpp
+++ b/include/mbgl/util/run_loop.hpp
@@ -16,7 +16,7 @@
 namespace mbgl {
 namespace util {
 
-typedef void * LOOP_HANDLE;
+using LOOP_HANDLE = void *;
 
 class RunLoop : public Scheduler,
                 private util::noncopyable {

--- a/platform/default/async_task.cpp
+++ b/platform/default/async_task.cpp
@@ -16,7 +16,7 @@ public:
         : async(new uv_async_t),
           task(std::move(fn)) {
 
-        uv_loop_t* loop = reinterpret_cast<uv_loop_t*>(RunLoop::getLoopHandle());
+        auto* loop = reinterpret_cast<uv_loop_t*>(RunLoop::getLoopHandle());
         if (uv_async_init(loop, async, asyncCallback) != 0) {
             throw std::runtime_error("Failed to initialize async.");
         }

--- a/platform/default/bidi.cpp
+++ b/platform/default/bidi.cpp
@@ -30,7 +30,7 @@ std::u16string applyArabicShaping(const std::u16string& input) {
     UErrorCode errorCode = U_ZERO_ERROR;
 
     const int32_t outputLength =
-        u_shapeArabic(mbgl::utf16char_cast<const UChar*>(input.c_str()), static_cast<int32_t>(input.size()), NULL, 0,
+        u_shapeArabic(mbgl::utf16char_cast<const UChar*>(input.c_str()), static_cast<int32_t>(input.size()), nullptr, 0,
                       (U_SHAPE_LETTERS_SHAPE & U_SHAPE_LETTERS_MASK) |
                           (U_SHAPE_TEXT_DIRECTION_LOGICAL & U_SHAPE_TEXT_DIRECTION_MASK),
                       &errorCode);
@@ -57,7 +57,7 @@ void BiDi::mergeParagraphLineBreaks(std::set<size_t>& lineBreakPoints) {
     for (int32_t i = 0; i < paragraphCount; i++) {
         UErrorCode errorCode = U_ZERO_ERROR;
         int32_t paragraphEndIndex;
-        ubidi_getParagraphByIndex(impl->bidiText, i, NULL, &paragraphEndIndex, NULL, &errorCode);
+        ubidi_getParagraphByIndex(impl->bidiText, i, nullptr, &paragraphEndIndex, nullptr, &errorCode);
 
         if (U_FAILURE(errorCode)) {
             throw std::runtime_error(std::string("ProcessedBiDiText::mergeParagraphLineBreaks: ") +
@@ -92,7 +92,7 @@ std::vector<std::u16string> BiDi::processText(const std::u16string& input,
     UErrorCode errorCode = U_ZERO_ERROR;
 
     ubidi_setPara(impl->bidiText, mbgl::utf16char_cast<const UChar*>(input.c_str()), static_cast<int32_t>(input.size()),
-                  UBIDI_DEFAULT_LTR, NULL, &errorCode);
+                  UBIDI_DEFAULT_LTR, nullptr, &errorCode);
 
     if (U_FAILURE(errorCode)) {
         throw std::runtime_error(std::string("BiDi::processText: ") + u_errorName(errorCode));

--- a/platform/default/image.cpp
+++ b/platform/default/image.cpp
@@ -12,7 +12,7 @@ PremultipliedImage decodePNG(const uint8_t*, size_t);
 PremultipliedImage decodeJPEG(const uint8_t*, size_t);
 
 PremultipliedImage decodeImage(const std::string& string) {
-    const uint8_t* data = reinterpret_cast<const uint8_t*>(string.data());
+    const auto* data = reinterpret_cast<const uint8_t*>(string.data());
     const size_t size = string.size();
 
 #if !defined(__ANDROID__) && !defined(__APPLE__)

--- a/platform/default/jpeg_reader.cpp
+++ b/platform/default/jpeg_reader.cpp
@@ -21,12 +21,12 @@ struct jpeg_stream_wrapper {
 };
 
 static void init_source(j_decompress_ptr cinfo) {
-    jpeg_stream_wrapper* wrap = reinterpret_cast<jpeg_stream_wrapper*>(cinfo->src);
+    auto* wrap = reinterpret_cast<jpeg_stream_wrapper*>(cinfo->src);
     wrap->stream->seekg(0, std::ios_base::beg);
 }
 
 static boolean fill_input_buffer(j_decompress_ptr cinfo) {
-    jpeg_stream_wrapper* wrap = reinterpret_cast<jpeg_stream_wrapper*>(cinfo->src);
+    auto* wrap = reinterpret_cast<jpeg_stream_wrapper*>(cinfo->src);
     wrap->stream->read(reinterpret_cast<char*>(&wrap->buffer[0]), BUF_SIZE);
     std::streamsize size = wrap->stream->gcount();
     wrap->manager.next_input_byte = wrap->buffer.data();
@@ -36,7 +36,7 @@ static boolean fill_input_buffer(j_decompress_ptr cinfo) {
 
 static void skip(j_decompress_ptr cinfo, long count) {
     if (count <= 0) return; // A zero or negative skip count should be treated as a no-op.
-    jpeg_stream_wrapper* wrap = reinterpret_cast<jpeg_stream_wrapper*>(cinfo->src);
+    auto* wrap = reinterpret_cast<jpeg_stream_wrapper*>(cinfo->src);
 
     if (wrap->manager.bytes_in_buffer > 0 && count < static_cast<long>(wrap->manager.bytes_in_buffer))
     {
@@ -59,7 +59,7 @@ static void attach_stream(j_decompress_ptr cinfo, std::istream* in) {
         cinfo->src = (struct jpeg_source_mgr *)
             (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_PERMANENT, sizeof(jpeg_stream_wrapper));
     }
-    jpeg_stream_wrapper * src = reinterpret_cast<jpeg_stream_wrapper*> (cinfo->src);
+    auto * src = reinterpret_cast<jpeg_stream_wrapper*> (cinfo->src);
     src->manager.init_source = init_source;
     src->manager.fill_input_buffer = fill_input_buffer;
     src->manager.skip_input_data = skip;

--- a/platform/default/mbgl/gl/headless_backend.cpp
+++ b/platform/default/mbgl/gl/headless_backend.cpp
@@ -9,8 +9,7 @@
 
 namespace mbgl {
 
-HeadlessBackend::HeadlessBackend() {
-}
+HeadlessBackend::HeadlessBackend() = default;
 
 HeadlessBackend::HeadlessBackend(std::shared_ptr<HeadlessDisplay> display_)
         : display(std::move(display_)) {

--- a/platform/default/mbgl/gl/headless_backend.hpp
+++ b/platform/default/mbgl/gl/headless_backend.hpp
@@ -20,7 +20,7 @@ public:
     void invalidate() override;
 
     struct Impl {
-        virtual ~Impl() {}
+        virtual ~Impl() = default;
         virtual void activateContext() = 0;
         virtual void deactivateContext() {}
     };

--- a/platform/default/mbgl/gl/offscreen_view.hpp
+++ b/platform/default/mbgl/gl/offscreen_view.hpp
@@ -12,7 +12,7 @@ class Context;
 class OffscreenView : public View {
 public:
     OffscreenView(gl::Context&, Size size = { 256, 256 });
-    ~OffscreenView();
+    ~OffscreenView() override;
 
     void bind() override;
 

--- a/platform/default/mbgl/storage/offline_download.cpp
+++ b/platform/default/mbgl/storage/offline_download.cpp
@@ -76,8 +76,7 @@ OfflineRegionStatus OfflineDownload::getStatus() const {
         switch (type) {
         case SourceType::Vector:
         case SourceType::Raster: {
-            style::TileSourceImpl* tileSource =
-                static_cast<style::TileSourceImpl*>(source->baseImpl.get());
+            auto* tileSource = static_cast<style::TileSourceImpl*>(source->baseImpl.get());
             const variant<std::string, Tileset>& urlOrTileset = tileSource->getURLOrTileset();
             const uint16_t tileSize = tileSource->getTileSize();
 
@@ -86,7 +85,7 @@ OfflineRegionStatus OfflineDownload::getStatus() const {
                     definition.tileCover(type, tileSize, urlOrTileset.get<Tileset>().zoomRange).size();
             } else {
                 result.requiredResourceCount += 1;
-                const std::string& url = urlOrTileset.get<std::string>();
+                const auto& url = urlOrTileset.get<std::string>();
                 optional<Response> sourceResponse = offlineDatabase.get(Resource::source(url));
                 if (sourceResponse) {
                     style::conversion::Error error;
@@ -103,7 +102,7 @@ OfflineRegionStatus OfflineDownload::getStatus() const {
         }
 
         case SourceType::GeoJSON: {
-            style::GeoJSONSource* geojsonSource = source->as<style::GeoJSONSource>();
+            auto* geojsonSource = source->as<style::GeoJSONSource>();
             if (geojsonSource->getURL()) {
                 result.requiredResourceCount += 1;
             }
@@ -151,7 +150,7 @@ void OfflineDownload::activateDownload() {
                 if (urlOrTileset.is<Tileset>()) {
                     queueTiles(type, tileSize, urlOrTileset.get<Tileset>());
                 } else {
-                    const std::string& url = urlOrTileset.get<std::string>();
+                    const auto& url = urlOrTileset.get<std::string>();
                     status.requiredResourceCountIsPrecise = false;
                     status.requiredResourceCount++;
                     requiredSourceURLs.insert(url);
@@ -174,7 +173,7 @@ void OfflineDownload::activateDownload() {
             }
 
             case SourceType::GeoJSON: {
-                style::GeoJSONSource::Impl* geojsonSource =
+                auto* geojsonSource =
                     static_cast<style::GeoJSONSource::Impl*>(source->baseImpl.get());
 
                 if (geojsonSource->getURL()) {

--- a/platform/default/png_reader.cpp
+++ b/platform/default/png_reader.cpp
@@ -40,7 +40,7 @@ static void user_warning_fn(png_structp, png_const_charp warning_msg) {
 }
 
 static void png_read_data(png_structp png_ptr, png_bytep data, png_size_t length) {
-    std::istream* fin = reinterpret_cast<std::istream*>(png_get_io_ptr(png_ptr));
+    auto* fin = reinterpret_cast<std::istream*>(png_get_io_ptr(png_ptr));
     fin->read(reinterpret_cast<char*>(data), length);
     std::streamsize read_count = fin->gcount();
     if (read_count < 0 || static_cast<png_size_t>(read_count) != length)

--- a/platform/default/sqlite3.cpp
+++ b/platform/default/sqlite3.cpp
@@ -314,7 +314,7 @@ template <> std::string Statement::get(int offset) {
 
 template <> std::vector<uint8_t> Statement::get(int offset) {
     assert(impl);
-    const uint8_t* begin = reinterpret_cast<const uint8_t*>(sqlite3_column_blob(impl->stmt, offset));
+    const auto* begin = reinterpret_cast<const uint8_t*>(sqlite3_column_blob(impl->stmt, offset));
     const uint8_t* end   = begin + sqlite3_column_bytes(impl->stmt, offset);
     return { begin, end };
 }

--- a/platform/default/sqlite3.cpp
+++ b/platform/default/sqlite3.cpp
@@ -107,8 +107,7 @@ Database &Database::operator=(Database &&other) {
     return *this;
 }
 
-Database::~Database() {
-}
+Database::~Database() = default;
 
 void Database::setBusyTimeout(std::chrono::milliseconds timeout) {
     assert(impl);
@@ -151,8 +150,7 @@ Statement &Statement::operator=(Statement &&other) {
     return *this;
 }
 
-Statement::~Statement() {
-}
+Statement::~Statement() = default;
 
 template <> void Statement::bind(int offset, std::nullptr_t) {
     assert(impl);

--- a/platform/default/timer.cpp
+++ b/platform/default/timer.cpp
@@ -10,7 +10,7 @@ namespace util {
 class Timer::Impl {
 public:
     Impl() : timer(new uv_timer_t) {
-        uv_loop_t* loop = reinterpret_cast<uv_loop_t*>(RunLoop::getLoopHandle());
+        auto* loop = reinterpret_cast<uv_loop_t*>(RunLoop::getLoopHandle());
         if (uv_timer_init(loop, timer) != 0) {
             throw std::runtime_error("Failed to initialize timer.");
         }

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -145,7 +145,7 @@ void GLFWView::bind() {
 }
 
 void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, int mods) {
-    GLFWView *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
+    auto *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
 
     if (action == GLFW_RELEASE) {
         switch (key) {
@@ -356,7 +356,7 @@ void GLFWView::popAnnotation() {
 }
 
 void GLFWView::onScroll(GLFWwindow *window, double /*xOffset*/, double yOffset) {
-    GLFWView *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
+    auto *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
     double delta = yOffset * 40;
 
     bool isWheel = delta != 0 && std::fmod(delta, 4.000244140625) == 0;
@@ -378,14 +378,14 @@ void GLFWView::onScroll(GLFWwindow *window, double /*xOffset*/, double yOffset) 
 }
 
 void GLFWView::onWindowResize(GLFWwindow *window, int width, int height) {
-    GLFWView *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
+    auto *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
     view->width = width;
     view->height = height;
     view->map->setSize({ static_cast<uint32_t>(view->width), static_cast<uint32_t>(view->height) });
 }
 
 void GLFWView::onFramebufferResize(GLFWwindow *window, int width, int height) {
-    GLFWView *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
+    auto *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
     view->fbWidth = width;
     view->fbHeight = height;
     view->bind();
@@ -398,7 +398,7 @@ void GLFWView::onFramebufferResize(GLFWwindow *window, int width, int height) {
 }
 
 void GLFWView::onMouseClick(GLFWwindow *window, int button, int action, int modifiers) {
-    GLFWView *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
+    auto *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
 
     if (button == GLFW_MOUSE_BUTTON_RIGHT ||
         (button == GLFW_MOUSE_BUTTON_LEFT && modifiers & GLFW_MOD_CONTROL)) {
@@ -426,7 +426,7 @@ void GLFWView::onMouseClick(GLFWwindow *window, int button, int action, int modi
 }
 
 void GLFWView::onMouseMove(GLFWwindow *window, double x, double y) {
-    GLFWView *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
+    auto *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
     if (view->tracking) {
         double dx = x - view->lastX;
         double dy = y - view->lastY;

--- a/platform/glfw/main.cpp
+++ b/platform/glfw/main.cpp
@@ -19,7 +19,7 @@ namespace {
 
 GLFWView* view = nullptr;
 
-}
+} // namespace
 
 void quit_handler(int) {
     if (view) {

--- a/platform/glfw/main.cpp
+++ b/platform/glfw/main.cpp
@@ -39,15 +39,15 @@ int main(int argc, char *argv[]) {
     bool skipConfig = false;
 
     const struct option long_options[] = {
-        {"fullscreen", no_argument, 0, 'f'},
-        {"benchmark", no_argument, 0, 'b'},
-        {"style", required_argument, 0, 's'},
-        {"lon", required_argument, 0, 'x'},
-        {"lat", required_argument, 0, 'y'},
-        {"zoom", required_argument, 0, 'z'},
-        {"bearing", required_argument, 0, 'r'},
-        {"pitch", required_argument, 0, 'p'},
-        {0, 0, 0, 0}
+        {"fullscreen", no_argument, nullptr, 'f'},
+        {"benchmark", no_argument, nullptr, 'b'},
+        {"style", required_argument, nullptr, 's'},
+        {"lon", required_argument, nullptr, 'x'},
+        {"lat", required_argument, nullptr, 'y'},
+        {"zoom", required_argument, nullptr, 'z'},
+        {"bearing", required_argument, nullptr, 'r'},
+        {"pitch", required_argument, nullptr, 'p'},
+        {nullptr, 0, nullptr, 0}
     };
 
     while (true) {
@@ -57,7 +57,7 @@ int main(int argc, char *argv[]) {
         switch (opt)
         {
         case 0:
-            if (long_options[option_index].flag != 0)
+            if (long_options[option_index].flag != nullptr)
                 break;
         case 'f':
             fullscreen = true;
@@ -99,7 +99,7 @@ int main(int argc, char *argv[]) {
     sigIntHandler.sa_handler = quit_handler;
     sigemptyset(&sigIntHandler.sa_mask);
     sigIntHandler.sa_flags = 0;
-    sigaction(SIGINT, &sigIntHandler, NULL);
+    sigaction(SIGINT, &sigIntHandler, nullptr);
 
     if (benchmark) {
         mbgl::Log::Info(mbgl::Event::General, "BENCHMARK MODE: Some optimizations are disabled.");

--- a/platform/glfw/main.cpp
+++ b/platform/glfw/main.cpp
@@ -194,7 +194,7 @@ int main(int argc, char *argv[]) {
         settings.save();
     }
     mbgl::Log::Info(mbgl::Event::General,
-                    "Exit location: --lat=\"%f\" --lon=\"%f\" --zoom=\"%f\" --bearing \"%f\"",
+                    R"(Exit location: --lat="%f" --lon="%f" --zoom="%f" --bearing "%f")",
                     settings.latitude, settings.longitude, settings.zoom, settings.bearing);
 
     view = nullptr;

--- a/platform/glfw/main.cpp
+++ b/platform/glfw/main.cpp
@@ -7,7 +7,7 @@
 #include <mbgl/util/default_thread_pool.hpp>
 #include <mbgl/storage/default_file_source.hpp>
 
-#include <signal.h>
+#include <csignal>
 #include <getopt.h>
 #include <fstream>
 #include <sstream>

--- a/platform/linux/src/headless_backend_glx.cpp
+++ b/platform/linux/src/headless_backend_glx.cpp
@@ -58,8 +58,8 @@ bool HeadlessBackend::hasDisplay() {
 void HeadlessBackend::createContext() {
     assert(!hasContext());
 
-    Display* xDisplay = display->attribute<Display*>();
-    GLXFBConfig* fbConfigs = display->attribute<GLXFBConfig*>();
+    auto* xDisplay = display->attribute<Display*>();
+    auto* fbConfigs = display->attribute<GLXFBConfig*>();
 
     // Try to create a legacy context.
     GLXContext glContext = glXCreateNewContext(xDisplay, fbConfigs[0], GLX_RGBA_TYPE, None, True);

--- a/platform/linux/src/headless_backend_glx.cpp
+++ b/platform/linux/src/headless_backend_glx.cpp
@@ -17,7 +17,7 @@ struct GLXImpl : public HeadlessBackend::Impl {
               fbConfigs(fbConfigs_) {
     }
 
-    ~GLXImpl() {
+    ~GLXImpl() override {
         if (glxPbuffer) {
             glXDestroyPbuffer(xDisplay, glxPbuffer);
         }

--- a/platform/linux/src/headless_backend_glx.cpp
+++ b/platform/linux/src/headless_backend_glx.cpp
@@ -81,7 +81,7 @@ void HeadlessBackend::createContext() {
     };
     GLXPbuffer glxPbuffer = glXCreatePbuffer(xDisplay, fbConfigs[0], pbufferAttributes);
 
-    impl.reset(new GLXImpl(glContext, glxPbuffer, xDisplay, fbConfigs));
+    impl = std::make_unique<mbgl::GLXImpl>(glContext, glxPbuffer, xDisplay, fbConfigs);
 }
 
 } // namespace mbgl

--- a/platform/linux/src/headless_display_glx.cpp
+++ b/platform/linux/src/headless_display_glx.cpp
@@ -27,7 +27,7 @@ HeadlessDisplay::Impl::Impl() {
         throw std::runtime_error("Failed to open X display.");
     }
 
-    const char *extensions = reinterpret_cast<const char *>(glXQueryServerString(xDisplay, DefaultScreen(xDisplay), GLX_EXTENSIONS));
+    const auto *extensions = reinterpret_cast<const char *>(glXQueryServerString(xDisplay, DefaultScreen(xDisplay), GLX_EXTENSIONS));
     if (!extensions) {
         throw std::runtime_error("Cannot read GLX extensions.");
     }

--- a/platform/linux/src/headless_display_glx.cpp
+++ b/platform/linux/src/headless_display_glx.cpp
@@ -73,7 +73,6 @@ HeadlessDisplay::HeadlessDisplay()
     : impl(std::make_unique<Impl>()) {
 }
 
-HeadlessDisplay::~HeadlessDisplay() {
-}
+HeadlessDisplay::~HeadlessDisplay() = default;
 
 } // namespace mbgl

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -278,7 +278,7 @@ NodeMap::RenderOptions NodeMap::ParseOptions(v8::Local<v8::Object> obj) {
         const int length = classes->Length();
         options.classes.reserve(length);
         for (int i = 0; i < length; i++) {
-            options.classes.push_back(std::string { *Nan::Utf8String(Nan::To<v8::String>(Nan::Get(classes, i).ToLocalChecked()).ToLocalChecked()) });
+            options.classes.emplace_back(std::string { *Nan::Utf8String(Nan::To<v8::String>(Nan::Get(classes, i).ToLocalChecked()).ToLocalChecked()) });
         }
     }
 
@@ -947,7 +947,7 @@ void NodeMap::QueryRenderedFeatures(const Nan::FunctionCallbackInfo<v8::Value>& 
             auto layers = layersOption.As<v8::Array>();
             std::vector<std::string> layersVec;
             for (uint32_t i=0; i < layers->Length(); i++) {
-                layersVec.push_back(*Nan::Utf8String(Nan::Get(layers,i).ToLocalChecked()));
+                layersVec.emplace_back(*Nan::Utf8String(Nan::Get(layers,i).ToLocalChecked()));
             }
             queryOptions.layerIDs = layersVec;
         }

--- a/src/csscolorparser/csscolorparser.cpp
+++ b/src/csscolorparser/csscolorparser.cpp
@@ -110,9 +110,6 @@ const NamedColor namedColors[] = {
     { "yellow", { 255, 255, 0, 1 } }, { "yellowgreen", { 154, 205, 50, 1 } }
 };
 
-const size_t namedColorCount = sizeof (namedColors) / sizeof (NamedColor);
-
-
 template <typename T>
 uint8_t clamp_css_byte(T i) {  // Clamp to integer 0 .. 255.
     i = ::round(i);  // Seems to be what Chrome does (vs truncation).

--- a/src/csscolorparser/csscolorparser.cpp
+++ b/src/csscolorparser/csscolorparser.cpp
@@ -186,9 +186,9 @@ optional<Color> parse(const std::string& css_str) {
     std::transform(str.begin(), str.end(), str.begin(), ::tolower);
 
 
-    for (size_t i = 0; i < namedColorCount; i++) {
-        if (str == namedColors[i].name) {
-            return { namedColors[i].color };
+    for (const auto& namedColor : namedColors) {
+        if (str == namedColor.name) {
+            return { namedColor.color };
         }
     }
 

--- a/src/mbgl/annotation/fill_annotation_impl.cpp
+++ b/src/mbgl/annotation/fill_annotation_impl.cpp
@@ -21,7 +21,7 @@ void FillAnnotationImpl::updateStyle(Style& style) const {
         layer = style.addLayer(std::move(newLayer), AnnotationManager::PointLayerID);
     }
 
-    FillLayer* fillLayer = layer->as<FillLayer>();
+    auto* fillLayer = layer->as<FillLayer>();
     fillLayer->setFillOpacity(annotation.opacity);
     fillLayer->setFillColor(annotation.color);
     fillLayer->setFillOutlineColor(annotation.outlineColor);

--- a/src/mbgl/annotation/line_annotation_impl.cpp
+++ b/src/mbgl/annotation/line_annotation_impl.cpp
@@ -22,7 +22,7 @@ void LineAnnotationImpl::updateStyle(Style& style) const {
         layer = style.addLayer(std::move(newLayer), AnnotationManager::PointLayerID);
     }
 
-    LineLayer* lineLayer = layer->as<LineLayer>();
+    auto* lineLayer = layer->as<LineLayer>();
     lineLayer->setLineOpacity(annotation.opacity);
     lineLayer->setLineWidth(annotation.width);
     lineLayer->setLineColor(annotation.color);

--- a/src/mbgl/annotation/symbol_annotation_impl.hpp
+++ b/src/mbgl/annotation/symbol_annotation_impl.hpp
@@ -26,10 +26,6 @@
 #include <boost/geometry/index/rtree.hpp>
 #pragma GCC diagnostic pop
 
-// Make Boost Geometry aware of our LatLng type
-BOOST_GEOMETRY_REGISTER_POINT_2D_CONST(mbgl::LatLng, double, boost::geometry::cs::cartesian, longitude(), latitude())
-BOOST_GEOMETRY_REGISTER_BOX(mbgl::LatLngBounds, mbgl::LatLng, southwest(), northeast())
-
 namespace mbgl {
 
 class AnnotationTileLayer;
@@ -47,9 +43,42 @@ public:
 
 } // namespace mbgl
 
-// Tell Boost Geometry how to access a std::shared_ptr<mbgl::SymbolAnnotation> object.
 namespace boost {
 namespace geometry {
+
+// Make Boost Geometry aware of our LatLng type
+namespace traits {
+
+template<> struct tag<mbgl::LatLng> { using type = point_tag; };
+template<> struct dimension<mbgl::LatLng> : boost::mpl::int_<2> {};
+template<> struct coordinate_type<mbgl::LatLng> { using type = double; };
+template<> struct coordinate_system<mbgl::LatLng> { using type = boost::geometry::cs::cartesian; };
+
+template<> struct access<mbgl::LatLng, 0> { static inline double get(mbgl::LatLng const& p) { return p.longitude(); } };
+template<> struct access<mbgl::LatLng, 1> { static inline double get(mbgl::LatLng const& p) { return p.latitude(); } };
+
+template<> struct tag<mbgl::LatLngBounds> { using type = box_tag; };
+template<> struct point_type<mbgl::LatLngBounds> { using type = mbgl::LatLng; };
+
+template <size_t D>
+struct indexed_access<mbgl::LatLngBounds, min_corner, D>
+{
+    using ct = coordinate_type<mbgl::LatLng>::type;
+    static inline ct get(mbgl::LatLngBounds const& b) { return geometry::get<D>(b.southwest()); }
+    static inline void set(mbgl::LatLngBounds& b, ct const& value) { geometry::set<D>(b.southwest(), value); }
+};
+
+template <size_t D>
+struct indexed_access<mbgl::LatLngBounds, max_corner, D>
+{
+    using ct = coordinate_type<mbgl::LatLng>::type;
+    static inline ct get(mbgl::LatLngBounds const& b) { return geometry::get<D>(b.northeast());  }
+    static inline void set(mbgl::LatLngBounds& b, ct const& value) { geometry::set<D>(b.northeast(), value); }
+};
+
+} // namespace traits
+
+// Tell Boost Geometry how to access a std::shared_ptr<mbgl::SymbolAnnotation> object.
 namespace index {
 
 template <>
@@ -61,6 +90,7 @@ struct indexable<std::shared_ptr<const mbgl::SymbolAnnotationImpl>> {
     }
 };
 
-} // end namespace index
-} // end namespace geometry
-} // end namespace boost
+} // namespace index
+
+} // namespace geometry
+} // namespace boost

--- a/src/mbgl/geometry/anchor.hpp
+++ b/src/mbgl/geometry/anchor.hpp
@@ -17,6 +17,6 @@ public:
         : point(x_, y_), angle(angle_), scale(scale_), segment(segment_) {}
 };
 
-typedef std::vector<Anchor> Anchors;
+using Anchors = std::vector<Anchor>;
 
 } // namespace mbgl

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -45,7 +45,7 @@ Context::~Context() {
 }
 
 void Context::initializeExtensions(const std::function<gl::ProcAddress(const char*)>& getProcAddress) {
-    if (const char* extensions =
+    if (const auto* extensions =
             reinterpret_cast<const char*>(MBGL_CHECK_ERROR(glGetString(GL_EXTENSIONS)))) {
 
         auto fn = [&](
@@ -94,7 +94,7 @@ UniqueShader Context::createShader(ShaderType type, const std::string& source) {
     UniqueShader result { MBGL_CHECK_ERROR(glCreateShader(static_cast<GLenum>(type))), { this } };
 
     const GLchar* sources = source.data();
-    const GLsizei lengths = static_cast<GLsizei>(source.length());
+    const auto lengths = static_cast<GLsizei>(source.length());
     MBGL_CHECK_ERROR(glShaderSource(result, 1, &sources, &lengths));
     MBGL_CHECK_ERROR(glCompileShader(result));
 

--- a/src/mbgl/gl/debugging_extension.hpp
+++ b/src/mbgl/gl/debugging_extension.hpp
@@ -53,13 +53,13 @@ namespace extension {
 
 class Debugging {
 public:
-    typedef void (*Callback)(GLenum source,
-                             GLenum type,
-                             GLuint id,
-                             GLenum severity,
-                             GLsizei length,
-                             const GLchar* message,
-                             const void* userParam);
+    using Callback = void (*)(GLenum source,
+                              GLenum type,
+                              GLuint id,
+                              GLenum severity,
+                              GLsizei length,
+                              const GLchar* message,
+                              const void* userParam);
 
     static void DebugCallback(GLenum source,
                               GLenum type,

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -27,6 +27,7 @@
 #include <mbgl/actor/scheduler.hpp>
 #include <mbgl/util/logging.hpp>
 #include <mbgl/math/log2.hpp>
+#include <utility>
 
 namespace mbgl {
 
@@ -58,7 +59,7 @@ public:
          GLContextMode,
          ConstrainMode,
          ViewportMode,
-         const std::string& programCacheDir);
+         std::string programCacheDir);
 
     void onSourceChanged(style::Source&) override;
     void onUpdate(Update) override;
@@ -139,7 +140,7 @@ Map::Impl::Impl(Map& map_,
                 GLContextMode contextMode_,
                 ConstrainMode constrainMode_,
                 ViewportMode viewportMode_,
-                const std::string& programCacheDir_)
+                std::string programCacheDir_)
     : map(map_),
       observer(backend_),
       backend(backend_),
@@ -151,7 +152,7 @@ Map::Impl::Impl(Map& map_,
       mode(mode_),
       contextMode(contextMode_),
       pixelRatio(pixelRatio_),
-      programCacheDir(programCacheDir_),
+      programCacheDir(std::move(programCacheDir_)),
       annotationManager(std::make_unique<AnnotationManager>(pixelRatio)),
       asyncInvalidate([this] {
           if (mode == MapMode::Continuous) {

--- a/src/mbgl/programs/binary_program.cpp
+++ b/src/mbgl/programs/binary_program.cpp
@@ -2,6 +2,7 @@
 
 #include <protozero/pbf_reader.hpp>
 #include <protozero/pbf_writer.hpp>
+#include <utility>
 
 template <class Binding>
 static std::pair<const std::string, Binding> parseBinding(protozero::pbf_reader&& pbf) {
@@ -64,12 +65,12 @@ BinaryProgram::BinaryProgram(std::string&& data) {
 BinaryProgram::BinaryProgram(
     gl::BinaryProgramFormat binaryFormat_,
     std::string&& binaryCode_,
-    const std::string& binaryIdentifier_,
+    std::string binaryIdentifier_,
     std::vector<std::pair<const std::string, gl::AttributeLocation>>&& attributes_,
     std::vector<std::pair<const std::string, gl::UniformLocation>>&& uniforms_)
     : binaryFormat(binaryFormat_),
       binaryCode(std::move(binaryCode_)),
-      binaryIdentifier(binaryIdentifier_),
+      binaryIdentifier(std::move(binaryIdentifier_)),
       attributes(std::move(attributes_)),
       uniforms(std::move(uniforms_)) {
 }

--- a/src/mbgl/programs/binary_program.hpp
+++ b/src/mbgl/programs/binary_program.hpp
@@ -14,7 +14,7 @@ public:
 
     BinaryProgram(gl::BinaryProgramFormat,
                   std::string&& binaryCode,
-                  const std::string& binaryIdentifier,
+                  std::string binaryIdentifier,
                   std::vector<std::pair<const std::string, gl::AttributeLocation>>&&,
                   std::vector<std::pair<const std::string, gl::UniformLocation>>&&);
 

--- a/src/mbgl/programs/program_parameters.hpp
+++ b/src/mbgl/programs/program_parameters.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <utility>
 
 namespace mbgl {
 
@@ -8,8 +9,8 @@ class ProgramParameters {
 public:
     ProgramParameters(float pixelRatio_ = 1.0,
                       bool overdraw_ = false,
-                      const std::string& cacheDir_ = "")
-        : pixelRatio(pixelRatio_), overdraw(overdraw_), cacheDir(cacheDir_) {
+                      std::string cacheDir_ = "")
+        : pixelRatio(pixelRatio_), overdraw(overdraw_), cacheDir(std::move(cacheDir_)) {
     }
 
     const float pixelRatio;

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -183,7 +183,7 @@ void LineBucket::addGeometry(const GeometryCoordinates& coordinates, FeatureType
         const bool isSharpCorner = cosHalfAngle < COS_HALF_SHARP_CORNER && prevCoordinate && nextCoordinate;
 
         if (isSharpCorner && i > first) {
-            const double prevSegmentLength = util::dist<double>(*currentCoordinate, *prevCoordinate);
+            const auto prevSegmentLength = util::dist<double>(*currentCoordinate, *prevCoordinate);
             if (prevSegmentLength > 2.0 * sharpCornerOffset) {
                 GeometryCoordinate newPrevVertex = *currentCoordinate - convertPoint<int16_t>(util::round(convertPoint<double>(*currentCoordinate - *prevCoordinate) * (sharpCornerOffset / prevSegmentLength)));
                 distance += util::dist<double>(newPrevVertex, *prevCoordinate);
@@ -356,7 +356,7 @@ void LineBucket::addGeometry(const GeometryCoordinates& coordinates, FeatureType
         }
 
         if (isSharpCorner && i < len - 1) {
-            const double nextSegmentLength = util::dist<double>(*currentCoordinate, *nextCoordinate);
+            const auto nextSegmentLength = util::dist<double>(*currentCoordinate, *nextCoordinate);
             if (nextSegmentLength > 2 * sharpCornerOffset) {
                 GeometryCoordinate newCurrentVertex = *currentCoordinate + convertPoint<int16_t>(util::round(convertPoint<double>(*nextCoordinate - *currentCoordinate) * (sharpCornerOffset / nextSegmentLength)));
                 distance += util::dist<double>(newCurrentVertex, *currentCoordinate);

--- a/src/mbgl/renderer/render_background_layer.cpp
+++ b/src/mbgl/renderer/render_background_layer.cpp
@@ -34,4 +34,4 @@ bool RenderBackgroundLayer::hasTransition() const {
     return unevaluated.hasTransition();
 }
 
-}
+} // namespace mbgl

--- a/src/mbgl/renderer/render_background_layer.hpp
+++ b/src/mbgl/renderer/render_background_layer.hpp
@@ -32,4 +32,4 @@ inline bool RenderLayer::is<RenderBackgroundLayer>() const {
     return type == style::LayerType::Background;
 }
 
-}
+} // namespace mbgl

--- a/src/mbgl/renderer/render_circle_layer.cpp
+++ b/src/mbgl/renderer/render_circle_layer.cpp
@@ -64,4 +64,4 @@ bool RenderCircleLayer::queryIntersectsFeature(
     return util::polygonIntersectsBufferedMultiPoint(translatedQueryGeometry.value_or(queryGeometry), feature.getGeometries(), circleRadius);
 }
 
-}
+} // namespace mbgl

--- a/src/mbgl/renderer/render_circle_layer.hpp
+++ b/src/mbgl/renderer/render_circle_layer.hpp
@@ -39,4 +39,4 @@ inline bool RenderLayer::is<RenderCircleLayer>() const {
     return type == style::LayerType::Circle;
 }
 
-}
+} // namespace mbgl

--- a/src/mbgl/renderer/render_custom_layer.cpp
+++ b/src/mbgl/renderer/render_custom_layer.cpp
@@ -26,4 +26,4 @@ std::unique_ptr<Bucket> RenderCustomLayer::createBucket(const BucketParameters&,
     return nullptr;
 }
     
-}
+} // namespace mbgl

--- a/src/mbgl/renderer/render_custom_layer.hpp
+++ b/src/mbgl/renderer/render_custom_layer.hpp
@@ -27,4 +27,4 @@ inline bool RenderLayer::is<RenderCustomLayer>() const {
     return type == style::LayerType::Custom;
 }
 
-}
+} // namespace mbgl

--- a/src/mbgl/renderer/render_fill_layer.cpp
+++ b/src/mbgl/renderer/render_fill_layer.cpp
@@ -68,4 +68,4 @@ bool RenderFillLayer::queryIntersectsFeature(
 }
 
 
-}
+} // namespace mbgl

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -22,4 +22,4 @@ bool RenderLayer::needsRendering(float zoom) const {
            && baseImpl.maxZoom >= zoom;
 }
 
-}
+} // namespace mbgl

--- a/src/mbgl/renderer/render_source.cpp
+++ b/src/mbgl/renderer/render_source.cpp
@@ -23,4 +23,4 @@ void RenderSource::onTileError(Tile& tile, std::exception_ptr error) {
     observer->onTileError(*this, tile.id, error);
 }
 
-}
+} // namespace mbgl

--- a/src/mbgl/renderer/render_source.hpp
+++ b/src/mbgl/renderer/render_source.hpp
@@ -30,7 +30,7 @@ class ClipIDGenerator;
 class RenderSource : protected TileObserver {
 public:
     RenderSource(const style::Source::Impl&);
-    virtual ~RenderSource() = default;
+    ~RenderSource() override = default;
 
     virtual bool isLoaded() const = 0;
 

--- a/src/mbgl/sprite/sprite_atlas.hpp
+++ b/src/mbgl/sprite/sprite_atlas.hpp
@@ -38,8 +38,8 @@ public:
     float height;
 };
 
-typedef std::map<std::string, SpriteAtlasElement> IconMap;
-typedef std::set<std::string> IconDependencies;
+using IconMap = std::map<std::string, SpriteAtlasElement>;
+using IconDependencies = std::set<std::string>;
 
 class IconRequestor {
 public:

--- a/src/mbgl/style/class_dictionary.cpp
+++ b/src/mbgl/style/class_dictionary.cpp
@@ -18,7 +18,7 @@ ClassDictionary &ClassDictionary::Get() {
         });
     });
 
-    ClassDictionary *ptr = reinterpret_cast<ClassDictionary *>(pthread_getspecific(store_key));
+    auto *ptr = reinterpret_cast<ClassDictionary *>(pthread_getspecific(store_key));
     if (ptr == nullptr) {
         ptr = new ClassDictionary();
         pthread_setspecific(store_key, ptr);
@@ -31,7 +31,7 @@ ClassID ClassDictionary::lookup(const std::string &class_name) {
     auto it = store.find(class_name);
     if (it == store.end()) {
         // Insert the class name into the store.
-        ClassID id = ClassID(uint32_t(ClassID::Named) + offset++);
+        auto id = ClassID(uint32_t(ClassID::Named) + offset++);
         store.emplace(class_name, id);
         return id;
     } else {

--- a/src/mbgl/style/class_dictionary.cpp
+++ b/src/mbgl/style/class_dictionary.cpp
@@ -5,7 +5,7 @@
 namespace mbgl {
 namespace style {
 
-ClassDictionary::ClassDictionary() {}
+ClassDictionary::ClassDictionary() = default;
 
 ClassDictionary &ClassDictionary::Get() {
     static pthread_once_t store_once = PTHREAD_ONCE_INIT;

--- a/src/mbgl/style/function/identity_stops.cpp
+++ b/src/mbgl/style/function/identity_stops.cpp
@@ -51,10 +51,11 @@ optional<std::array<float, 2>> IdentityStops<std::array<float, 2>>::evaluate(con
         return {};
     }
 
-    return {{{
+    std::array<float, 2> array {{
         *numericValue<float>(vector[0]),
         *numericValue<float>(vector[1])
-    }}};
+    }};
+    return array;
 }
 
 } // namespace style

--- a/src/mbgl/style/function/identity_stops.cpp
+++ b/src/mbgl/style/function/identity_stops.cpp
@@ -46,7 +46,7 @@ optional<std::array<float, 2>> IdentityStops<std::array<float, 2>>::evaluate(con
         return {};
     }
 
-    const std::vector<Value>& vector = value.get<std::vector<Value>>();
+    const auto& vector = value.get<std::vector<Value>>();
     if (vector.size() != 2 || !numericValue<float>(vector[0]) || !numericValue<float>(vector[1])) {
         return {};
     }

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -87,7 +87,7 @@ Style::~Style() {
     }
 
     for (const auto& layer : layers) {
-        if (CustomLayer* customLayer = layer->as<CustomLayer>()) {
+        if (auto* customLayer = layer->as<CustomLayer>()) {
             customLayer->impl->deinitialize();
         }
     }
@@ -258,7 +258,7 @@ Layer* Style::addLayer(std::unique_ptr<Layer> layer, optional<std::string> befor
         throw std::runtime_error(std::string{"Layer "} + layer->getID() + " already exists");
     }
 
-    if (CustomLayer* customLayer = layer->as<CustomLayer>()) {
+    if (auto* customLayer = layer->as<CustomLayer>()) {
         customLayer->impl->initialize();
     }
 
@@ -280,7 +280,7 @@ std::unique_ptr<Layer> Style::removeLayer(const std::string& id) {
 
     auto layer = std::move(*it);
 
-    if (CustomLayer* customLayer = layer->as<CustomLayer>()) {
+    if (auto* customLayer = layer->as<CustomLayer>()) {
         customLayer->impl->deinitialize();
     }
 

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -583,8 +583,8 @@ RenderData Style::getRenderData(MapDebugOptions debugOptions, float angle) const
         }
 
         std::vector<std::reference_wrapper<RenderTile>> sortedTilesForInsertion;
-        for (auto tileIt = sortedTiles.begin(); tileIt != sortedTiles.end(); ++tileIt) {
-            auto& tile = tileIt->get();
+        for (auto& sortedTile : sortedTiles) {
+            auto& tile = sortedTile.get();
             if (!tile.tile.isRenderable()) {
                 continue;
             }

--- a/src/mbgl/style/tile_source_impl.cpp
+++ b/src/mbgl/style/tile_source_impl.cpp
@@ -29,7 +29,7 @@ void TileSourceImpl::loadDescription(FileSource& fileSource) {
         return;
     }
 
-    const std::string& url = urlOrTileset.get<std::string>();
+    const auto& url = urlOrTileset.get<std::string>();
     req = fileSource.request(Resource::source(url), [this, url](Response res) {
         if (res.error) {
             observer->onSourceError(base, std::make_exception_ptr(std::runtime_error(res.error->message)));

--- a/src/mbgl/text/collision_feature.cpp
+++ b/src/mbgl/text/collision_feature.cpp
@@ -71,7 +71,7 @@ void CollisionFeature::bboxifyLabel(const GeometryCoordinates& line, GeometryCoo
         p = line[index];
     } while (anchorDistance > -labelLength / 2);
 
-    float segmentLength = util::dist<float>(line[index], line[index + 1]);
+    auto segmentLength = util::dist<float>(line[index], line[index + 1]);
 
     for (unsigned int i = 0; i < nBoxes; i++) {
         // the distance the box will be from the anchor

--- a/src/mbgl/text/collision_feature.hpp
+++ b/src/mbgl/text/collision_feature.hpp
@@ -34,7 +34,7 @@ public:
 class CollisionFeature {
 public:
     enum class AlignmentType : bool {
-        Straight = 0,
+        Straight = false,
         Curved
     };
 

--- a/src/mbgl/text/collision_tile.hpp
+++ b/src/mbgl/text/collision_tile.hpp
@@ -28,10 +28,10 @@ namespace mbgl {
 namespace bg = boost::geometry;
 namespace bgm = bg::model;
 namespace bgi = bg::index;
-typedef bgm::point<float, 2, bg::cs::cartesian> CollisionPoint;
-typedef bgm::box<CollisionPoint> Box;
-typedef std::tuple<Box, CollisionBox, IndexedSubfeature> CollisionTreeBox;
-typedef bgi::rtree<CollisionTreeBox, bgi::linear<16, 4>> Tree;
+using CollisionPoint = bgm::point<float, 2, bg::cs::cartesian>;
+using Box = bgm::box<CollisionPoint>;
+using CollisionTreeBox = std::tuple<Box, CollisionBox, IndexedSubfeature>;
+using Tree = bgi::rtree<CollisionTreeBox, bgi::linear<16, 4>>;
 
 class IndexedSubfeature;
 

--- a/src/mbgl/text/get_anchors.cpp
+++ b/src/mbgl/text/get_anchors.cpp
@@ -34,7 +34,7 @@ static Anchors resample(const GeometryCoordinates& line,
         const GeometryCoordinate& a = *(it);
         const GeometryCoordinate& b = *(it + 1);
 
-        const float segmentDist = util::dist<float>(a, b);
+        const auto segmentDist = util::dist<float>(a, b);
         const float angle = util::angle_to(b, a);
 
         while (markedDistance + spacing < distance + segmentDist) {

--- a/src/mbgl/text/glyph.hpp
+++ b/src/mbgl/text/glyph.hpp
@@ -13,8 +13,8 @@
 
 namespace mbgl {
 
-typedef char16_t GlyphID;
-typedef std::set<GlyphID> GlyphIDs;
+using GlyphID = char16_t;
+using GlyphIDs = std::set<GlyphID>;
     
 // Note: this only works for the BMP
 GlyphRange getGlyphRange(GlyphID glyph);
@@ -40,8 +40,8 @@ struct Glyph {
     GlyphMetrics metrics;
 };
 
-typedef std::map<GlyphID, optional<Glyph>> GlyphPositions;
-typedef std::map<FontStack, GlyphPositions> GlyphPositionMap;
+using GlyphPositions = std::map<GlyphID, optional<Glyph>>;
+using GlyphPositionMap = std::map<FontStack, GlyphPositions>;
 
 class PositionedGlyph {
 public:
@@ -97,8 +97,7 @@ constexpr WritingModeType operator~(WritingModeType value) {
     return WritingModeType(~mbgl::underlying_type(value));
 }
 
-typedef std::map<FontStack,GlyphIDs> GlyphDependencies;
-typedef std::map<FontStack,GlyphRangeSet> GlyphRangeDependencies;
-
+using GlyphDependencies = std::map<FontStack,GlyphIDs>;
+using GlyphRangeDependencies = std::map<FontStack,GlyphRangeSet>;
 
 } // end namespace mbgl

--- a/src/mbgl/text/glyph.hpp
+++ b/src/mbgl/text/glyph.hpp
@@ -58,14 +58,14 @@ enum class WritingModeType : uint8_t;
 
 class Shaping {
     public:
-    explicit Shaping() : top(0), bottom(0), left(0), right(0) {}
+    explicit Shaping() = default;
     explicit Shaping(float x, float y, WritingModeType writingMode_)
         : top(y), bottom(y), left(x), right(x), writingMode(writingMode_) {}
     std::vector<PositionedGlyph> positionedGlyphs;
-    int32_t top;
-    int32_t bottom;
-    int32_t left;
-    int32_t right;
+    int32_t top = 0;
+    int32_t bottom = 0;
+    int32_t left = 0;
+    int32_t right = 0;
     WritingModeType writingMode;
 
     explicit operator bool() const { return !positionedGlyphs.empty(); }

--- a/src/mbgl/text/glyph_atlas.cpp
+++ b/src/mbgl/text/glyph_atlas.cpp
@@ -207,8 +207,8 @@ Rect<uint16_t> GlyphAtlas::addGlyph(GlyphValue& value) {
 }
 
 void GlyphAtlas::removeGlyphValues(GlyphRequestor& requestor, std::map<GlyphID, GlyphValue>& values) {
-    for (auto it = values.begin(); it != values.end(); it++) {
-        GlyphValue& value = it->second;
+    for (auto& it : values) {
+        GlyphValue& value = it.second;
         if (value.ids.erase(&requestor) && value.ids.empty() && value.rect) {
             const Rect<uint16_t>& rect = *value.rect;
 
@@ -228,8 +228,8 @@ void GlyphAtlas::removeGlyphValues(GlyphRequestor& requestor, std::map<GlyphID, 
 }
 
 void GlyphAtlas::removePendingRanges(mbgl::GlyphRequestor& requestor, std::map<GlyphRange, GlyphRequest>& ranges) {
-    for (auto it = ranges.begin(); it != ranges.end(); it++) {
-        it->second.requestors.erase(&requestor);
+    for (auto& range : ranges) {
+        range.second.requestors.erase(&requestor);
     }
 }
 

--- a/src/mbgl/text/glyph_range.hpp
+++ b/src/mbgl/text/glyph_range.hpp
@@ -7,7 +7,7 @@
 
 namespace mbgl {
 
-typedef std::pair<uint16_t, uint16_t> GlyphRange;
+using GlyphRange = std::pair<uint16_t, uint16_t>;
 
 struct GlyphRangeHash {
     std::size_t operator()(const GlyphRange& glyphRange) const {
@@ -15,7 +15,7 @@ struct GlyphRangeHash {
     }
 };
 
-typedef std::unordered_set<GlyphRange, GlyphRangeHash> GlyphRangeSet;
+using GlyphRangeSet = std::unordered_set<GlyphRange, GlyphRangeHash>;
 
 constexpr uint32_t GLYPHS_PER_GLYPH_RANGE = 256;
 constexpr uint32_t GLYPH_RANGES_PER_FONT_STACK = 256;

--- a/src/mbgl/text/quads.cpp
+++ b/src/mbgl/text/quads.cpp
@@ -177,7 +177,7 @@ inline Point<float> getVirtualSegmentAnchor(const Point<float>& segmentBegin, co
 inline float getMinScaleForSegment(const float glyphDistanceFromAnchor,
                          const Point<float>& segmentAnchor,
                          const Point<float>& segmentEnd) {
-    const float distanceFromAnchorToEnd = util::dist<float>(segmentAnchor, segmentEnd);
+    const auto distanceFromAnchorToEnd = util::dist<float>(segmentAnchor, segmentEnd);
     return glyphDistanceFromAnchor / distanceFromAnchorToEnd;
 }
 

--- a/src/mbgl/text/quads.cpp
+++ b/src/mbgl/text/quads.cpp
@@ -108,7 +108,7 @@ struct GlyphInstance {
     const float angle = 0.0f;
 };
 
-typedef std::vector<GlyphInstance> GlyphInstances;
+using GlyphInstances = std::vector<GlyphInstance>;
     
 struct VirtualSegment {
     Point<float> anchor;

--- a/src/mbgl/text/quads.hpp
+++ b/src/mbgl/text/quads.hpp
@@ -49,7 +49,7 @@ public:
     WritingModeType writingMode;
 };
 
-typedef std::vector<SymbolQuad> SymbolQuads;
+using SymbolQuads = std::vector<SymbolQuad>;
 
 SymbolQuad getIconQuad(const Anchor& anchor,
                        const PositionedIcon& shapedIcon,

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -47,10 +47,14 @@ GeometryTile::GeometryTile(const OverscaledTileID& id_,
 GeometryTile::~GeometryTile() {
     glyphAtlas.removeGlyphs(*this);
     spriteAtlas.removeRequestor(*this);
-    cancel();
+    markObsolete();
 }
 
 void GeometryTile::cancel() {
+    markObsolete();
+}
+
+void GeometryTile::markObsolete() {
     obsolete = true;
 }
 

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -87,6 +87,8 @@ protected:
     }
 
 private:
+    void markObsolete();
+
     const std::string sourceID;
     style::Style& style;
 

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -34,8 +34,7 @@ GeometryTileWorker::GeometryTileWorker(ActorRef<GeometryTileWorker> self_,
       mode(mode_) {
 }
 
-GeometryTileWorker::~GeometryTileWorker() {
-}
+GeometryTileWorker::~GeometryTileWorker() = default;
 
 /*
    GeometryTileWorker is a state machine. This is its transition diagram.

--- a/src/mbgl/tile/vector_tile.cpp
+++ b/src/mbgl/tile/vector_tile.cpp
@@ -162,7 +162,7 @@ optional<Value> VectorTileFeature::getValue(const std::string& key) const {
     auto start_itr = tags_iter.begin();
     const auto & end_itr = tags_iter.end();
     while (start_itr != end_itr) {
-        uint32_t tag_key = static_cast<uint32_t>(*start_itr++);
+        auto tag_key = static_cast<uint32_t>(*start_itr++);
 
         if (layerData->keysMap.size() <= tag_key) {
             throw std::runtime_error("feature referenced out of range key");
@@ -172,7 +172,7 @@ optional<Value> VectorTileFeature::getValue(const std::string& key) const {
             throw std::runtime_error("uneven number of feature tag ids");
         }
 
-        uint32_t tag_val = static_cast<uint32_t>(*start_itr++);;
+        auto tag_val = static_cast<uint32_t>(*start_itr++);;
         if (layerData->values.size() <= tag_val) {
             throw std::runtime_error("feature referenced out of range value");
         }
@@ -190,11 +190,11 @@ std::unordered_map<std::string,Value> VectorTileFeature::getProperties() const {
     auto start_itr = tags_iter.begin();
     const auto & end_itr = tags_iter.end();
     while (start_itr != end_itr) {
-        uint32_t tag_key = static_cast<uint32_t>(*start_itr++);
+        auto tag_key = static_cast<uint32_t>(*start_itr++);
         if (start_itr == end_itr) {
             throw std::runtime_error("uneven number of feature tag ids");
         }
-        uint32_t tag_val = static_cast<uint32_t>(*start_itr++);
+        auto tag_val = static_cast<uint32_t>(*start_itr++);
         properties[layerData->keys.at(tag_key)] = layerData->values.at(tag_val);
     }
     return properties;
@@ -219,7 +219,7 @@ GeometryCollection VectorTileFeature::getGeometries() const {
     auto g_itr = geometry_iter.begin();
     while (g_itr != geometry_iter.end()) {
         if (length == 0) {
-            uint32_t cmd_length = static_cast<uint32_t>(*g_itr++);
+            auto cmd_length = static_cast<uint32_t>(*g_itr++);
             cmd = cmd_length & 0x7;
             length = cmd_length >> 3;
         }

--- a/src/mbgl/util/i18n.cpp
+++ b/src/mbgl/util/i18n.cpp
@@ -310,7 +310,7 @@ const std::map<char16_t, char16_t> verticalPunctuation = {
     { u'｛', u'︷' }, { u'｜', u'―' },  { u'｝', u'︸' }, { u'｟', u'︵' }, { u'｠', u'︶' },
     { u'｡', u'︒' },  { u'｢', u'﹁' },  { u'｣', u'﹂' },
 };
-}
+} // namespace
 
 namespace mbgl {
 namespace util {

--- a/src/mbgl/util/intersection_tests.cpp
+++ b/src/mbgl/util/intersection_tests.cpp
@@ -19,7 +19,7 @@ bool polygonContainsPoint(const GeometryCoordinates& ring, const GeometryCoordin
 // Code from http://stackoverflow.com/a/1501725/331379.
 float distToSegmentSquared(const GeometryCoordinate& p, const GeometryCoordinate& v, const GeometryCoordinate& w) {
     if (v == w) return util::distSqr<float>(p, v);
-    const float l2 = util::distSqr<float>(v, w);
+    const auto l2 = util::distSqr<float>(v, w);
     const float t = float((p.x - v.x) * (w.x - v.x) + (p.y - v.y) * (w.y - v.y)) / l2;
     if (t < 0) return util::distSqr<float>(p, v);
     if (t > 1) return util::distSqr<float>(p, w);

--- a/src/mbgl/util/mat2.hpp
+++ b/src/mbgl/util/mat2.hpp
@@ -26,7 +26,7 @@
 
 namespace mbgl {
 
-typedef std::array<double, 4> mat2;
+using mat2 = std::array<double, 4>;
 
 namespace matrix {
 

--- a/src/mbgl/util/offscreen_texture.hpp
+++ b/src/mbgl/util/offscreen_texture.hpp
@@ -20,7 +20,7 @@ public:
     OffscreenTexture(gl::Context&,
                      Size size = { 256, 256 },
                      OffscreenTextureAttachment type = OffscreenTextureAttachment::None);
-    ~OffscreenTexture();
+    ~OffscreenTexture() override;
     OffscreenTexture(OffscreenTexture&&);
     OffscreenTexture& operator=(OffscreenTexture&&);
 

--- a/src/mbgl/util/thread.hpp
+++ b/src/mbgl/util/thread.hpp
@@ -26,6 +26,11 @@ namespace util {
 template <class Object>
 class Thread {
 public:
+    Thread(const Thread&) = delete;
+    Thread(Thread&&) = delete;
+    Thread& operator=(const Thread&) = delete;
+    Thread& operator=(Thread&&) = delete;
+
     template <class... Args>
     Thread(const ThreadContext&, Args&&... args);
     ~Thread();
@@ -90,11 +95,6 @@ public:
 
 private:
     MBGL_STORE_THREAD(tid);
-
-    Thread(const Thread&) = delete;
-    Thread(Thread&&) = delete;
-    Thread& operator=(const Thread&) = delete;
-    Thread& operator=(Thread&&) = delete;
 
     template <typename Fn>
     auto bind(Fn fn) {

--- a/src/mbgl/util/thread_local.hpp
+++ b/src/mbgl/util/thread_local.hpp
@@ -32,7 +32,7 @@ public:
     }
 
     T* get() {
-        T* ret = reinterpret_cast<T*>(pthread_getspecific(key));
+        auto* ret = reinterpret_cast<T*>(pthread_getspecific(key));
         if (!ret) {
             return nullptr;
         }

--- a/test/.clang-tidy
+++ b/test/.clang-tidy
@@ -1,0 +1,2 @@
+Checks: 'modernize-*,-modernize-use-equals-delete,-modernize-use-equals-default,misc-static-assert,llvm-namespace-comment,-clang-analyzer-security.insecureAPI.rand,-clang-analyzer-core.uninitialized.UndefReturn,-clang-analyzer-core.StackAddressEscape,-clang-analyzer-core.CallAndMessage,-clang-diagnostic-unused-command-line-argument,-clang-analyzer-core.uninitialized.*,-clang-analyzer-core.NullDereference,-clang-analyzer-core.NonNullParamChecker'
+HeaderFilterRegex: '\/mbgl\/'

--- a/test/src/mbgl/test/fixture_log_observer.cpp
+++ b/test/src/mbgl/test/fixture_log_observer.cpp
@@ -15,9 +15,6 @@ bool FixtureLog::Message::operator==(const Message& rhs) const {
     return severity == rhs.severity && event == rhs.event && code == rhs.code && msg == rhs.msg;
 }
 
-FixtureLog::Message::Message() : severity(), event(), code(), msg() {
-}
-
 FixtureLog::Observer::Observer(FixtureLog* log_) : log(log_) {
 }
 

--- a/test/src/mbgl/test/fixture_log_observer.cpp
+++ b/test/src/mbgl/test/fixture_log_observer.cpp
@@ -94,10 +94,10 @@ std::vector<FixtureLog::Message> FixtureLogObserver::unchecked() const {
 }
 
 ::std::ostream& operator<<(::std::ostream& os, const FixtureLog::Message& message) {
-    os << "[\"" << Enum<EventSeverity>::toString(message.severity) << "\", \"";
-    os << Enum<Event>::toString(message.event) << "\"";
+    os << R"([")" << Enum<EventSeverity>::toString(message.severity) << R"(", ")";
+    os << Enum<Event>::toString(message.event) << R"(")";
     os << ", " << message.code;
-    os << ", \"" << message.msg << "\"";
+    os << R"(, ")" << message.msg << R"(")";
     return os << "]" << std::endl;
 }
 

--- a/test/src/mbgl/test/fixture_log_observer.hpp
+++ b/test/src/mbgl/test/fixture_log_observer.hpp
@@ -12,15 +12,15 @@ namespace mbgl {
 class FixtureLog {
 public:
     struct Message {
+        Message() = default;
         Message(EventSeverity severity_, Event event_, int64_t code_, std::string msg_);
-        Message();
 
         bool operator==(const Message& rhs) const;
 
-        const EventSeverity severity;
-        const Event event;
-        const int64_t code;
-        const std::string msg;
+        const EventSeverity severity {};
+        const Event event {};
+        const int64_t code {};
+        const std::string msg {};
 
         mutable bool checked = false;
     };

--- a/test/src/mbgl/test/getrss.cpp
+++ b/test/src/mbgl/test/getrss.cpp
@@ -80,8 +80,8 @@ size_t getCurrentRSS( )
 #elif defined(__linux__) || defined(__linux) || defined(linux) || defined(__gnu_linux__)
 	/* Linux ---------------------------------------------------- */
 	long rss = 0L;
-	FILE* fp = NULL;
-	if ( (fp = fopen( "/proc/self/statm", "r" )) == NULL )
+	FILE* fp = nullptr;
+	if ( (fp = fopen( "/proc/self/statm", "r" )) == nullptr )
 		return (size_t)0L;		/* Can't open? */
 	if ( fscanf( fp, "%*s%ld", &rss ) != 1 )
 	{

--- a/test/src/mbgl/test/getrss.hpp
+++ b/test/src/mbgl/test/getrss.hpp
@@ -41,5 +41,5 @@ size_t getPeakRSS();
  */
 size_t getCurrentRSS();
 
-}
-}
+} // namespace test
+} // namespace mbgl

--- a/test/storage/local_file_source.test.cpp
+++ b/test/storage/local_file_source.test.cpp
@@ -3,7 +3,7 @@
 #include <mbgl/util/run_loop.hpp>
 
 #include <unistd.h>
-#include <limits.h>
+#include <climits>
 #include <gtest/gtest.h>
 
 namespace {

--- a/test/style/conversion/function.test.cpp
+++ b/test/style/conversion/function.test.cpp
@@ -19,26 +19,26 @@ TEST(StyleConversion, Function) {
         return convert<CameraFunction<float>, JSValue>(doc, error);
     };
 
-    auto fn1 = parseFunction("{\"stops\":[]}");
+    auto fn1 = parseFunction(R"({"stops":[]})");
     ASSERT_FALSE(fn1);
     ASSERT_EQ("function must have at least one stop", error.message);
 
-    auto fn2 = parseFunction("{\"stops\":[1]}");
+    auto fn2 = parseFunction(R"({"stops":[1]})");
     ASSERT_FALSE(fn2);
     ASSERT_EQ("function stop must be an array", error.message);
 
-    auto fn3 = parseFunction("{\"stops\":[[]]}");
+    auto fn3 = parseFunction(R"({"stops":[[]]})");
     ASSERT_FALSE(fn3);
     ASSERT_EQ("function stop must have two elements", error.message);
 
-    auto fn4 = parseFunction("{\"stops\":[[-1,-1]]}");
+    auto fn4 = parseFunction(R"({"stops":[[-1,-1]]})");
     ASSERT_TRUE(bool(fn4));
 
-    auto fn5 = parseFunction("{\"stops\":[[0,1,2]]}");
+    auto fn5 = parseFunction(R"({"stops":[[0,1,2]]})");
     ASSERT_FALSE(fn5);
     ASSERT_EQ("function stop must have two elements", error.message);
 
-    auto fn6 = parseFunction("{\"stops\":[[0,\"x\"]]}");
+    auto fn6 = parseFunction(R"({"stops":[[0,"x"]]})");
     ASSERT_FALSE(fn6);
     ASSERT_EQ("value must be a number", error.message);
 
@@ -50,7 +50,7 @@ TEST(StyleConversion, Function) {
     ASSERT_FALSE(fn8);
     ASSERT_EQ("function must be an object", error.message);
 
-    auto fn9 = parseFunction("{\"stops\":[[0,0]],\"base\":false}");
+    auto fn9 = parseFunction(R"({"stops":[[0,0]],"base":false})");
     ASSERT_FALSE(fn9);
     ASSERT_EQ("function base must be a number", error.message);
 }

--- a/test/style/conversion/light.test.cpp
+++ b/test/style/conversion/light.test.cpp
@@ -30,7 +30,7 @@ TEST(StyleConversion, Light) {
     }
 
     {
-        auto light = parseLight("{\"color\":{\"stops\":[[14,\"blue\"],[16,\"red\"]]},\"intensity\":0.3,\"position\":[3,90,90]}");
+        auto light = parseLight(R"({"color":{"stops":[[14,"blue"],[16,"red"]]},"intensity":0.3,"position":[3,90,90]})");
         ASSERT_TRUE((bool) light);
 
         ASSERT_TRUE(light->getAnchor().isUndefined());
@@ -54,7 +54,7 @@ TEST(StyleConversion, Light) {
     }
 
     {
-        auto light = parseLight("{\"color\":\"blue\",\"intensity\":0.3,\"color-transition\":{\"duration\":1000}}");
+        auto light = parseLight(R"({"color":"blue","intensity":0.3,"color-transition":{"duration":1000}})");
         ASSERT_TRUE((bool) light);
 
         ASSERT_FALSE(light->getColor().isUndefined());
@@ -65,35 +65,35 @@ TEST(StyleConversion, Light) {
     }
 
     {
-        auto light = parseLight("{\"intensity\":false}");
+        auto light = parseLight(R"({"intensity":false})");
 
         ASSERT_FALSE((bool) light);
         ASSERT_EQ("value must be a number", error.message);
     }
 
     {
-        auto light = parseLight("{\"intensity\":{\"stops\":[[15,\"red\"],[17,\"blue\"]]}}");
+        auto light = parseLight(R"({"intensity":{"stops":[[15,"red"],[17,"blue"]]}})");
 
         ASSERT_FALSE((bool) light);
         ASSERT_EQ("value must be a number", error.message);
     }
 
     {
-        auto light = parseLight("{\"color\":5}");
+        auto light = parseLight(R"({"color":5})");
 
         ASSERT_FALSE((bool) light);
         ASSERT_EQ("value must be a string", error.message);
     }
 
     {
-        auto light = parseLight("{\"position\":[0,5]}");
+        auto light = parseLight(R"({"position":[0,5]})");
 
         ASSERT_FALSE((bool) light);
         ASSERT_EQ("value must be an array of 3 numbers", error.message);
     }
 
     {
-        auto light = parseLight("{\"anchor\":\"something\"}");
+        auto light = parseLight(R"({"anchor":"something"})");
 
         ASSERT_FALSE((bool) light);
         ASSERT_EQ("value must be a valid enumeration value", error.message);

--- a/test/style/filter.test.cpp
+++ b/test/style/filter.test.cpp
@@ -29,13 +29,13 @@ Feature feature(const PropertyMap& properties, const Geometry<double>& geometry 
 }
 
 TEST(Filter, EqualsString) {
-    Filter f = parse("[\"==\", \"foo\", \"bar\"]");
+    Filter f = parse(R"(["==", "foo", "bar"])");
     ASSERT_TRUE(f(feature({{ "foo", std::string("bar") }})));
     ASSERT_FALSE(f(feature({{ "foo", std::string("baz") }})));
 }
 
 TEST(Filter, EqualsNumber) {
-    Filter f = parse("[\"==\", \"foo\", 0]");
+    Filter f = parse(R"(["==", "foo", 0])");
     ASSERT_TRUE(f(feature({{ "foo", int64_t(0) }})));
     ASSERT_TRUE(f(feature({{ "foo", uint64_t(0) }})));
     ASSERT_TRUE(f(feature({{ "foo", double(0) }})));
@@ -50,13 +50,13 @@ TEST(Filter, EqualsNumber) {
 }
 
 TEST(Filter, EqualsType) {
-    Filter f = parse("[\"==\", \"$type\", \"LineString\"]");
+    Filter f = parse(R"(["==", "$type", "LineString"])");
     ASSERT_FALSE(f(feature({{}}, Point<double>())));
     ASSERT_TRUE(f(feature({{}}, LineString<double>())));
 }
 
 TEST(Filter, InType) {
-    Filter f = parse("[\"in\", \"$type\", \"LineString\", \"Polygon\"]");
+    Filter f = parse(R"(["in", "$type", "LineString", "Polygon"])");
     ASSERT_FALSE(f(feature({{}}, Point<double>())));
     ASSERT_TRUE(f(feature({{}}, LineString<double>())));
     ASSERT_TRUE(f(feature({{}}, Polygon<double>())));

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -413,7 +413,7 @@ TEST(Source, GeoJSonSourceUrlUpdate) {
     test.fileSource.sourceResponse = [&] (const Resource& resource) {
         EXPECT_EQ("url", resource.url);
         Response response;
-        response.data = std::make_unique<std::string>("{\"geometry\": {\"type\": \"Point\", \"coordinates\": [1.1, 1.1]}, \"type\": \"Feature\", \"properties\": {}}");
+        response.data = std::make_unique<std::string>(R"({"geometry": {"type": "Point", "coordinates": [1.1, 1.1]}, "type": "Feature", "properties": {}})");
         return response;
     };
 

--- a/test/style/style_parser.test.cpp
+++ b/test/style/style_parser.test.cpp
@@ -16,8 +16,8 @@
 
 using namespace mbgl;
 
-typedef std::pair<uint32_t, std::string> Message;
-typedef std::vector<Message> Messages;
+using Message = std::pair<uint32_t, std::string>;
+using Messages = std::vector<Message>;
 
 class StyleParserTest : public ::testing::TestWithParam<std::string> {};
 

--- a/test/tile/annotation_tile.test.cpp
+++ b/test/tile/annotation_tile.test.cpp
@@ -45,7 +45,7 @@ TEST(AnnotationTile, Issue8289) {
 
     auto data = std::make_unique<AnnotationTileData>();
     data->layers.emplace("test", AnnotationTileLayer("test"));
-    data->layers.at("test").features.push_back(AnnotationTileFeature(0, FeatureType::Point, GeometryCollection()));
+    data->layers.at("test").features.emplace_back(0, FeatureType::Point, GeometryCollection());
 
     // Simulate layout and placement of a symbol layer.
     tile.onLayout(GeometryTile::LayoutResult {

--- a/test/util/memory.test.cpp
+++ b/test/util/memory.test.cpp
@@ -17,7 +17,7 @@
 #include <unordered_map>
 #include <utility>
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <unistd.h>
 
 using namespace mbgl;

--- a/test/util/merge_lines.test.cpp
+++ b/test/util/merge_lines.test.cpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/layout/merge_lines.hpp>
 #include <mbgl/layout/symbol_feature.hpp>
+#include <utility>
 
 const std::u16string aaa = u"a";
 const std::u16string bbb = u"b";
@@ -12,10 +13,10 @@ class GeometryTileFeatureStub : public GeometryTileFeature {
 public:
     GeometryTileFeatureStub(optional<FeatureIdentifier> id_, FeatureType type_, GeometryCollection geometry_,
                   std::unordered_map<std::string, Value> properties_) :
-        id(id_),
+        id(std::move(id_)),
         type(type_),
-        geometry(geometry_),
-        properties(properties_)
+        geometry(std::move(geometry_)),
+        properties(std::move(properties_))
     {}
     
     FeatureType getType() const override { return type; }


### PR DESCRIPTION
This PR:
- Bumps updated clang-tidy from llvm 4.0.0, making use of its python scripts for running clang-tidy in parallel (_run-clang-tidy.py_) and for running clang-tidy only on the specified changes (_clang-tidy-diff.py_) i.e. changes made by the current branch from upstream master branch.
- Runs a tidiness check on the entire codebase
 - Applies suggestions made by clang-tidy (patches marked with `[tidy]`)
 - Fixes some potential bugs and cleanups (patches marked with `[core]`) reported by clang-tidy.

Next:
- @kkaefer suggested integrating the warnings generated by clang-tidy e.g. in our Travis CI tidy build into Danger to have them posted as inline comments on the PR.

Caveats:
- Discuss whether to disable more of the `modernize-*` clang-tidy checks e.g. some of them are probably too pedantic for some developers.