### PR TITLE
[build] Don't run Travis 'check' build on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,9 @@ matrix:
       script:
         - git fetch origin master:refs/remotes/origin/master
         - make check
+      branches:
+        except:
+          - master
 
     # EGL - Node v4 - Clang 3.9 - Release
     - os: linux

--- a/scripts/clang-tools.sh
+++ b/scripts/clang-tools.sh
@@ -37,7 +37,7 @@ function run_clang_tidy_diff() {
                 ${CLANG_TIDY_PREFIX}/share/clang-tidy-diff.py \
                     -clang-tidy-binary ${CLANG_TIDY} \
                     2>/dev/null)
-    if [[ -n $OUTPUT ]]; then
+    if [[ -n $OUTPUT ]] && [[ $OUTPUT != "No relevant changes found." ]]; then
         echo -e "${OUTPUT}"
         exit 1
     fi


### PR DESCRIPTION
Fixed an issue where no clang-tidy issues found causes the build to fail - also disables the check when running on `master` branch - that's a no-op.