### PR TITLE
[core] Trim StyleObserver interface

### DIFF
--- a/src/mbgl/style/observer.hpp
+++ b/src/mbgl/style/observer.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <mbgl/text/glyph_atlas_observer.hpp>
-#include <mbgl/sprite/sprite_loader_observer.hpp>
 #include <mbgl/style/source_observer.hpp>
 #include <mbgl/map/update.hpp>
 
@@ -10,9 +8,7 @@
 namespace mbgl {
 namespace style {
 
-class Observer : public GlyphAtlasObserver,
-                 public SpriteLoaderObserver,
-                 public SourceObserver {
+class Observer : public SourceObserver {
 public:
     virtual void onUpdate(Update) {}
     virtual void onStyleError(std::exception_ptr) {}

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -729,15 +729,10 @@ void Style::setObserver(style::Observer* observer_) {
     observer = observer_;
 }
 
-void Style::onGlyphsLoaded(const FontStack& fontStack, const GlyphRange& glyphRange) {
-    observer->onGlyphsLoaded(fontStack, glyphRange);
-}
-
 void Style::onGlyphsError(const FontStack& fontStack, const GlyphRange& glyphRange, std::exception_ptr error) {
     lastError = error;
     Log::Error(Event::Style, "Failed to load glyph range %d-%d for font stack %s: %s",
                glyphRange.first, glyphRange.second, fontStackToString(fontStack).c_str(), util::toString(error).c_str());
-    observer->onGlyphsError(fontStack, glyphRange, error);
     observer->onResourceError(error);
 }
 
@@ -789,14 +784,12 @@ void Style::onSpriteLoaded(SpriteLoader::Images&& images) {
     spriteAtlas->onSpriteLoaded(std::move(addedImages));
 
     // Update observer
-    observer->onSpriteLoaded(std::move(images));
     observer->onUpdate(Update::Repaint); // For *-pattern properties.
 }
 
 void Style::onSpriteError(std::exception_ptr error) {
     lastError = error;
     Log::Error(Event::Style, "Failed to load sprite: %s", util::toString(error).c_str());
-    observer->onSpriteError(error);
     observer->onResourceError(error);
 }
 

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -154,8 +154,7 @@ private:
 
     std::vector<std::unique_ptr<Layer>>::const_iterator findLayer(const std::string& layerID) const;
 
-    // GlyphStoreObserver implementation.
-    void onGlyphsLoaded(const FontStack&, const GlyphRange&) override;
+    // GlyphAtlasObserver implementation.
     void onGlyphsError(const FontStack&, const GlyphRange&, std::exception_ptr) override;
 
     // SpriteLoaderObserver implementation.

--- a/test/sprite/sprite_loader.test.cpp
+++ b/test/sprite/sprite_loader.test.cpp
@@ -1,9 +1,9 @@
 #include <mbgl/test/util.hpp>
 #include <mbgl/test/fixture_log_observer.hpp>
 #include <mbgl/test/stub_file_source.hpp>
-#include <mbgl/test/stub_style_observer.hpp>
 
 #include <mbgl/sprite/sprite_loader.hpp>
+#include <mbgl/sprite/sprite_loader_observer.hpp>
 #include <mbgl/sprite/sprite_parser.hpp>
 #include <mbgl/util/io.hpp>
 #include <mbgl/util/image.hpp>
@@ -14,6 +14,21 @@
 #include <utility>
 
 using namespace mbgl;
+using namespace mbgl::style;
+
+class StubSpriteLoaderObserver : public SpriteLoaderObserver {
+public:
+    void onSpriteLoaded(Images&& images) override {
+        if (spriteLoaded) spriteLoaded(std::move(images));
+    }
+
+    void onSpriteError(std::exception_ptr error) override {
+        if (spriteError) spriteError(error);
+    }
+
+    std::function<void (Images&&)> spriteLoaded;
+    std::function<void (std::exception_ptr)> spriteError;
+};
 
 class SpriteLoaderTest {
 public:
@@ -21,7 +36,7 @@ public:
 
     util::RunLoop loop;
     StubFileSource fileSource;
-    StubStyleObserver observer;
+    StubSpriteLoaderObserver observer;
     ThreadPool threadPool { 1 };
     SpriteLoader spriteLoader{ 1 };
 

--- a/test/src/mbgl/test/stub_style_observer.hpp
+++ b/test/src/mbgl/test/stub_style_observer.hpp
@@ -10,22 +10,6 @@ using namespace mbgl::style;
  */
 class StubStyleObserver : public style::Observer {
 public:
-    void onGlyphsLoaded(const FontStack& fontStack, const GlyphRange& glyphRange) override {
-        if (glyphsLoaded) glyphsLoaded(fontStack, glyphRange);
-    }
-
-    void onGlyphsError(const FontStack& fontStack, const GlyphRange& glyphRange, std::exception_ptr error) override {
-        if (glyphsError) glyphsError(fontStack, glyphRange, error);
-    }
-
-    void onSpriteLoaded(Images&& images) override {
-        if (spriteLoaded) spriteLoaded(std::move(images));
-    }
-
-    void onSpriteError(std::exception_ptr error) override {
-        if (spriteError) spriteError(error);
-    }
-
     void onSourceLoaded(Source& source) override {
         if (sourceLoaded) sourceLoaded(source);
     }
@@ -46,10 +30,6 @@ public:
         if (resourceError) resourceError(error);
     };
 
-    std::function<void (const FontStack&, const GlyphRange&)> glyphsLoaded;
-    std::function<void (const FontStack&, const GlyphRange&, std::exception_ptr)> glyphsError;
-    std::function<void (Images&&)> spriteLoaded;
-    std::function<void (std::exception_ptr)> spriteError;
     std::function<void (Source&)> sourceLoaded;
     std::function<void (Source&)> sourceChanged;
     std::function<void (Source&, std::exception_ptr)> sourceError;

--- a/test/text/glyph_atlas.test.cpp
+++ b/test/text/glyph_atlas.test.cpp
@@ -1,6 +1,5 @@
 #include <mbgl/test/util.hpp>
 #include <mbgl/test/stub_file_source.hpp>
-#include <mbgl/test/stub_style_observer.hpp>
 
 #include <mbgl/text/glyph_atlas.hpp>
 #include <mbgl/util/run_loop.hpp>
@@ -9,6 +8,20 @@
 #include <mbgl/util/logging.hpp>
 
 using namespace mbgl;
+
+class StubGlyphAtlasObserver : public GlyphAtlasObserver {
+public:
+    void onGlyphsLoaded(const FontStack& fontStack, const GlyphRange& glyphRange) override {
+        if (glyphsLoaded) glyphsLoaded(fontStack, glyphRange);
+    }
+
+    void onGlyphsError(const FontStack& fontStack, const GlyphRange& glyphRange, std::exception_ptr error) override {
+        if (glyphsError) glyphsError(fontStack, glyphRange, error);
+    }
+
+    std::function<void (const FontStack&, const GlyphRange&)> glyphsLoaded;
+    std::function<void (const FontStack&, const GlyphRange&, std::exception_ptr)> glyphsError;
+};
 
 class StubGlyphRequestor : public GlyphRequestor {
 public:
@@ -23,7 +36,7 @@ class GlyphAtlasTest {
 public:
     util::RunLoop loop;
     StubFileSource fileSource;
-    StubStyleObserver observer;
+    StubGlyphAtlasObserver observer;
     StubGlyphRequestor requestor;
     GlyphAtlas glyphAtlas{ { 32, 32 }, fileSource };
 


### PR DESCRIPTION
It doesn't need to inherit from SpriteLoaderObserver and GlyphAtlasObserver.