### PR TITLE
[android] - publish SNAPSHOT from release 5.1.0 branch

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -133,4 +133,4 @@ jobs:
       - deploy:
           name: Publish to Maven
           command: |
-            if [ "${CIRCLE_BRANCH}" == "release-android-v5.1.0-beta.2" ]; then make run-android-upload-archives ; fi
+            if [ "${CIRCLE_BRANCH}" == "release-ios-v3.6.0-android-v5.1.0" ]; then make run-android-upload-archives ; fi


### PR DESCRIPTION
Follow up from #8976, where we altered the CircleCI configuration to release a beta build from the specific release branch. Now that this has happened. The configuration should be updated to build SNAPSHOT from the default 5.1.0 release branch (when a PR is merged to that branch).

@zugaldia, I added a note in https://github.com/mapbox/mapbox-gl-native/issues/8390#issuecomment-301407876 to update the release documentation with a step-by-step guide related to the CircleCI.   