### PR TITLE
MarkerView deselect events with OnMarkerViewClickListener

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AnnotationManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AnnotationManager.java
@@ -670,12 +670,15 @@ class AnnotationManager {
       for (Marker nearbyMarker : nearbyMarkers) {
         for (Marker selectedMarker : selectedMarkers) {
           if (nearbyMarker.equals(selectedMarker)) {
-            if (onMarkerClickListener != null) {
-              // end developer has provided a custom click listener
+            if (nearbyMarker instanceof MarkerView) {
+              handledDefaultClick = markerViewManager.onClickMarkerView((MarkerView) nearbyMarker);
+            } else if (onMarkerClickListener != null) {
               handledDefaultClick = onMarkerClickListener.onMarkerClick(nearbyMarker);
-              if (!handledDefaultClick) {
-                deselectMarker(nearbyMarker);
-              }
+            }
+
+            if (!handledDefaultClick) {
+              // only deselect marker if user didn't handle the click event themselves
+              deselectMarker(nearbyMarker);
             }
             return true;
           }


### PR DESCRIPTION
This PR corrects OnMarkerViewClickListener integration when deselecting a Marker.
I was underway of refactoring parts of the AnnoationManager for readability but remembered @Guardiola31337 picking up a part of this in #8261 (which isn't on the target branch). This PR just fixes up the related business logic, we can revisit the refactor when we merge back to master.

Closes #8991 