### PR TITLE
[core] Replace inline SpriteAtlas updates with diffing

### DIFF
--- a/src/mbgl/renderer/style_diff.cpp
+++ b/src/mbgl/renderer/style_diff.cpp
@@ -6,14 +6,9 @@
 
 namespace mbgl {
 
-template <class T>
-StyleDifference<T> diff(const std::vector<T>& a, const std::vector<T>& b) {
+template <class T, class Eq>
+StyleDifference<T> diff(const std::vector<T>& a, const std::vector<T>& b, const Eq& eq) {
     std::vector<T> lcs;
-
-    auto eq = [] (const T& lhs, const T& rhs) {
-        return std::tie(lhs->id, lhs->type)
-            == std::tie(rhs->id, rhs->type);
-    };
 
     longest_common_subsequence(a.begin(), a.end(), b.begin(), b.end(), std::back_inserter(lcs), eq);
 
@@ -43,14 +38,27 @@ StyleDifference<T> diff(const std::vector<T>& a, const std::vector<T>& b) {
     return result;
 }
 
+ImageDifference diffImages(const std::vector<ImmutableImage>& a,
+                           const std::vector<ImmutableImage>& b) {
+    return diff(a, b, [] (const ImmutableImage& lhs, const ImmutableImage& rhs) {
+        return lhs->id == rhs->id;
+    });
+}
+
 SourceDifference diffSources(const std::vector<ImmutableSource>& a,
                              const std::vector<ImmutableSource>& b) {
-    return diff(a, b);
+    return diff(a, b, [] (const ImmutableSource& lhs, const ImmutableSource& rhs) {
+        return std::tie(lhs->id, lhs->type)
+            == std::tie(rhs->id, rhs->type);
+    });
 }
 
 LayerDifference diffLayers(const std::vector<ImmutableLayer>& a,
                            const std::vector<ImmutableLayer>& b) {
-    return diff(a, b);
+    return diff(a, b, [] (const ImmutableLayer& lhs, const ImmutableLayer& rhs) {
+        return std::tie(lhs->id, lhs->type)
+            == std::tie(rhs->id, rhs->type);
+    });
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/style_diff.hpp
+++ b/src/mbgl/renderer/style_diff.hpp
@@ -1,3 +1,4 @@
+#include <mbgl/style/image_impl.hpp>
 #include <mbgl/style/source_impl.hpp>
 #include <mbgl/style/layer_impl.hpp>
 #include <mbgl/util/immutable.hpp>
@@ -14,6 +15,12 @@ public:
     std::unordered_map<std::string, T> removed;
     std::unordered_map<std::string, T> changed;
 };
+
+using ImmutableImage = Immutable<style::Image::Impl>;
+using ImageDifference = StyleDifference<ImmutableImage>;
+
+ImageDifference diffImages(const std::vector<ImmutableImage>&,
+                           const std::vector<ImmutableImage>&);
 
 using ImmutableSource = Immutable<style::Source::Impl>;
 using SourceDifference = StyleDifference<ImmutableSource>;

--- a/src/mbgl/sprite/sprite_atlas.hpp
+++ b/src/mbgl/sprite/sprite_atlas.hpp
@@ -73,7 +73,9 @@ public:
     void dumpDebugLogs() const;
 
     const style::Image::Impl* getImage(const std::string&) const;
+
     void addImage(Immutable<style::Image::Impl>);
+    void updateImage(Immutable<style::Image::Impl>);
     void removeImage(const std::string&);
 
     void getIcons(IconRequestor&, IconDependencies);

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/style/layer_observer.hpp>
 #include <mbgl/style/light_observer.hpp>
 #include <mbgl/style/update_batch.hpp>
+#include <mbgl/style/image.hpp>
 #include <mbgl/renderer/render_source.hpp>
 #include <mbgl/renderer/render_source_observer.hpp>
 #include <mbgl/renderer/render_layer.hpp>
@@ -138,6 +139,7 @@ private:
     double defaultBearing = 0;
     double defaultPitch = 0;
 
+    std::vector<Immutable<Image::Impl>> imageImpls;
     std::vector<Immutable<Source::Impl>> sourceImpls;
     std::vector<Immutable<Layer::Impl>> layerImpls;
 
@@ -179,6 +181,7 @@ private:
 
     UpdateBatch updateBatch;
     ZoomHistory zoomHistory;
+    bool spriteLoaded = false;
 
 public:
     bool loaded = false;

--- a/test/sprite/sprite_atlas.test.cpp
+++ b/test/sprite/sprite_atlas.test.cpp
@@ -98,7 +98,7 @@ TEST(SpriteAtlas, Updates) {
     for (size_t i = 0; i < image2.bytes(); i++) {
         image2.data.get()[i] = 255;
     }
-    atlas.addImage(makeMutable<style::Image::Impl>("one", std::move(image2), 1));
+    atlas.updateImage(makeMutable<style::Image::Impl>("one", std::move(image2), 1));
 
     test::checkImage("test/fixtures/sprite_atlas/updates_after", atlas.getAtlasImage());
 }


### PR DESCRIPTION
Use style diffing to resolve updates to images and updates that require reloading tiles.