### PR TITLE
Circle: use workflows instead of a trigger build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,19 +1,13 @@
 version: 2
 
-jobs:
+workflows:
+  version: 2
+  default:
+    jobs:
+      - android-debug-arm-v7
+      - android-release-all
 
-# ------------------------------------------------------------------------------
-  build:
-    docker:
-      - image: mbgl/ci:trigger_job
-    working_directory: /
-    steps:
-      - deploy:
-          name: Trigger 'android-debug-arm-v7'
-          command: trigger_job android-debug-arm-v7
-      - deploy:
-          name: Trigger 'android-release-all'
-          command: trigger_job android-release-all
+jobs:
 
 # ------------------------------------------------------------------------------
   android-debug-arm-v7:


### PR DESCRIPTION
We don't need to go through the trigger image anymore.