### PR TITLE
[core] Remove ambiguous get{Width,Height} accessors from style::Image

### DIFF
--- a/include/mbgl/style/image.hpp
+++ b/include/mbgl/style/image.hpp
@@ -22,9 +22,6 @@ public:
     // Whether this image should be interpreted as a signed distance field icon.
     bool isSdf() const;
 
-    float getWidth() const;
-    float getHeight() const;
-
     class Impl;
     Immutable<Impl> impl;
 };

--- a/platform/macos/src/NSImage+MGLAdditions.mm
+++ b/platform/macos/src/NSImage+MGLAdditions.mm
@@ -23,7 +23,9 @@
 
     NSBitmapImageRep *rep = [[NSBitmapImageRep alloc] initWithCGImage:image];
     CGImageRelease(image);
-    if (self = [self initWithSize:NSMakeSize(styleImage->getWidth(), styleImage->getHeight())]) {
+    CGFloat w = styleImage->getImage().size.width / styleImage->getPixelRatio();
+    CGFloat h = styleImage->getImage().size.height / styleImage->getPixelRatio();
+    if (self = [self initWithSize:NSMakeSize(w, h)]) {
         [self addRepresentation:rep];
         [self setTemplate:styleImage->isSdf()];
     }

--- a/src/mbgl/sprite/sprite_atlas.cpp
+++ b/src/mbgl/sprite/sprite_atlas.cpp
@@ -22,14 +22,12 @@ SpriteAtlasElement::SpriteAtlasElement(Rect<uint16_t> rect_,
     : pos(std::move(rect_)),
       sdf(image.sdf),
       relativePixelRatio(image.pixelRatio / pixelRatio),
-      width(image.image.size.width / image.pixelRatio),
-      height(image.image.size.height / image.pixelRatio) {
-
+      size{{image.image.size.width / image.pixelRatio,
+            image.image.size.height / image.pixelRatio}} {
 
     const float w = image.image.size.width / pixelRatio;
     const float h = image.image.size.height / pixelRatio;
 
-    size = {{ width, height }};
     tl   = {{ float(pos.x + padding)     / size_.width, float(pos.y + padding)     / size_.height }};
     br   = {{ float(pos.x + padding + w) / size_.width, float(pos.y + padding + h) / size_.height }};
 }

--- a/src/mbgl/sprite/sprite_atlas.cpp
+++ b/src/mbgl/sprite/sprite_atlas.cpp
@@ -22,14 +22,14 @@ SpriteAtlasElement::SpriteAtlasElement(Rect<uint16_t> rect_,
     : pos(std::move(rect_)),
       sdf(image.sdf),
       relativePixelRatio(image.pixelRatio / pixelRatio),
-      width(image.getWidth()),
-      height(image.getHeight()) {
+      width(image.image.size.width / image.pixelRatio),
+      height(image.image.size.height / image.pixelRatio) {
 
 
-    const float w = image.getWidth() * relativePixelRatio;
-    const float h = image.getHeight() * relativePixelRatio;
+    const float w = image.image.size.width / pixelRatio;
+    const float h = image.image.size.height / pixelRatio;
 
-    size = {{ float(image.getWidth()), image.getHeight() }};
+    size = {{ width, height }};
     tl   = {{ float(pos.x + padding)     / size_.width, float(pos.y + padding)     / size_.height }};
     br   = {{ float(pos.x + padding + w) / size_.width, float(pos.y + padding + h) / size_.height }};
 }

--- a/src/mbgl/sprite/sprite_atlas.hpp
+++ b/src/mbgl/sprite/sprite_atlas.hpp
@@ -29,8 +29,6 @@ public:
     std::array<float, 2> size;
     std::array<float, 2> tl;
     std::array<float, 2> br;
-    float width;
-    float height;
 };
 
 using IconMap = std::unordered_map<std::string, SpriteAtlasElement>;

--- a/src/mbgl/style/image.cpp
+++ b/src/mbgl/style/image.cpp
@@ -28,13 +28,5 @@ float Image::getPixelRatio() const {
     return impl->pixelRatio;
 }
 
-float Image::getWidth() const {
-    return impl->getWidth();
-}
-
-float Image::getHeight() const {
-    return impl->getHeight();
-}
-
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/image_impl.hpp
+++ b/src/mbgl/style/image_impl.hpp
@@ -18,9 +18,6 @@ public:
 
     // Whether this image should be interpreted as a signed distance field icon.
     const bool sdf;
-
-    float getWidth() const { return image.size.width / pixelRatio; }
-    float getHeight() const { return image.size.height / pixelRatio; }
 };
 
 } // namespace style

--- a/src/mbgl/text/shaping.cpp
+++ b/src/mbgl/text/shaping.cpp
@@ -17,10 +17,10 @@ optional<PositionedIcon> PositionedIcon::shapeIcon(const SpriteAtlasElement& ima
 
     float dx = iconOffset[0];
     float dy = iconOffset[1];
-    float x1 = dx - image.width/ 2.0f;
-    float x2 = x1 + image.width;
-    float y1 = dy - image.height / 2.0f;
-    float y2 = y1 + image.height;
+    float x1 = dx - image.size[0] / 2.0f;
+    float x2 = x1 + image.size[0];
+    float y1 = dy - image.size[1] / 2.0f;
+    float y2 = y1 + image.size[1];
 
     return { PositionedIcon { image, y1, y2, x1, x2, iconRotation } };
 }

--- a/test/sprite/sprite_atlas.test.cpp
+++ b/test/sprite/sprite_atlas.test.cpp
@@ -36,10 +36,10 @@ TEST(SpriteAtlas, Basic) {
     EXPECT_EQ(0, metro.pos.y);
     EXPECT_EQ(20, metro.pos.w);
     EXPECT_EQ(20, metro.pos.h);
-    EXPECT_EQ(18, metro.width);
-    EXPECT_EQ(18, metro.height);
-    EXPECT_EQ(18u, metro.width * imagePixelRatio);
-    EXPECT_EQ(18u, metro.height * imagePixelRatio);
+    EXPECT_EQ(18, metro.size[0]);
+    EXPECT_EQ(18, metro.size[1]);
+    EXPECT_EQ(18u, metro.size[0] * imagePixelRatio);
+    EXPECT_EQ(18u, metro.size[1] * imagePixelRatio);
     EXPECT_EQ(1.0f, imagePixelRatio);
 
 
@@ -93,10 +93,10 @@ TEST(SpriteAtlas, Size) {
     EXPECT_EQ(0, metro.pos.y);
     EXPECT_EQ(15, metro.pos.w);
     EXPECT_EQ(15, metro.pos.h);
-    EXPECT_EQ(18, metro.width);
-    EXPECT_EQ(18, metro.height);
-    EXPECT_EQ(18u, metro.width * imagePixelRatio);
-    EXPECT_EQ(18u, metro.height * imagePixelRatio);
+    EXPECT_EQ(18, metro.size[0]);
+    EXPECT_EQ(18, metro.size[1]);
+    EXPECT_EQ(18u, metro.size[0] * imagePixelRatio);
+    EXPECT_EQ(18u, metro.size[1] * imagePixelRatio);
     EXPECT_EQ(1.0f, imagePixelRatio);
 
     // Now the image was created lazily.
@@ -120,10 +120,10 @@ TEST(SpriteAtlas, Updates) {
     EXPECT_EQ(0, one.pos.y);
     EXPECT_EQ(18, one.pos.w);
     EXPECT_EQ(14, one.pos.h);
-    EXPECT_EQ(16, one.width);
-    EXPECT_EQ(12, one.height);
-    EXPECT_EQ(16u, one.width * imagePixelRatio);
-    EXPECT_EQ(12u, one.height * imagePixelRatio);
+    EXPECT_EQ(16, one.size[0]);
+    EXPECT_EQ(12, one.size[1]);
+    EXPECT_EQ(16u, one.size[0] * imagePixelRatio);
+    EXPECT_EQ(12u, one.size[1] * imagePixelRatio);
     EXPECT_EQ(1.0f, imagePixelRatio);
 
     // Now the image was created lazily.

--- a/test/sprite/sprite_parser.test.cpp
+++ b/test/sprite/sprite_parser.test.cpp
@@ -143,8 +143,6 @@ TEST(Sprite, SpriteImageCreation1x) {
     { // "museum_icon":{"x":177,"y":187,"width":18,"height":18,"pixelRatio":1,"sdf":false}
         const auto sprite = createStyleImage("test", image_1x, 177, 187, 18, 18, 1, false);
         ASSERT_TRUE(sprite.get());
-        EXPECT_EQ(18, sprite->getWidth());
-        EXPECT_EQ(18, sprite->getHeight());
         EXPECT_EQ(18u, sprite->getImage().size.width);
         EXPECT_EQ(18u, sprite->getImage().size.height);
         EXPECT_EQ(1, sprite->getPixelRatio());
@@ -159,8 +157,6 @@ TEST(Sprite, SpriteImageCreation2x) {
     // "museum_icon":{"x":354,"y":374,"width":36,"height":36,"pixelRatio":2,"sdf":false}
     const auto sprite = createStyleImage("test", image_2x, 354, 374, 36, 36, 2, false);
     ASSERT_TRUE(sprite.get());
-    EXPECT_EQ(18, sprite->getWidth());
-    EXPECT_EQ(18, sprite->getHeight());
     EXPECT_EQ(36u, sprite->getImage().size.width);
     EXPECT_EQ(36u, sprite->getImage().size.height);
     EXPECT_EQ(2, sprite->getPixelRatio());
@@ -174,8 +170,6 @@ TEST(Sprite, SpriteImageCreation1_5x) {
     // "museum_icon":{"x":354,"y":374,"width":36,"height":36,"pixelRatio":2,"sdf":false}
     const auto sprite = createStyleImage("test", image_2x, 354, 374, 36, 36, 1.5, false);
     ASSERT_TRUE(sprite.get());
-    EXPECT_EQ(24, sprite->getWidth());
-    EXPECT_EQ(24, sprite->getHeight());
     EXPECT_EQ(36u, sprite->getImage().size.width);
     EXPECT_EQ(36u, sprite->getImage().size.height);
     EXPECT_EQ(1.5, sprite->getPixelRatio());
@@ -185,8 +179,6 @@ TEST(Sprite, SpriteImageCreation1_5x) {
     // "hospital_icon":{"x":314,"y":518,"width":36,"height":36,"pixelRatio":2,"sdf":false}
     const auto sprite2 = createStyleImage("test", image_2x, 314, 518, 35, 35, 1.5, false);
     ASSERT_TRUE(sprite2.get());
-    EXPECT_EQ(float(35 / 1.5), sprite2->getWidth());
-    EXPECT_EQ(float(35 / 1.5), sprite2->getHeight());
     EXPECT_EQ(35u, sprite2->getImage().size.width);
     EXPECT_EQ(35u, sprite2->getImage().size.height);
     EXPECT_EQ(1.5, sprite2->getPixelRatio());
@@ -281,8 +273,6 @@ TEST(Sprite, SpriteParsing) {
 
     {
         auto& sprite = *std::find_if(images.begin(), images.end(), [] (const auto& image) { return image->getID() == "generic-metro"; });
-        EXPECT_EQ(18, sprite->getWidth());
-        EXPECT_EQ(18, sprite->getHeight());
         EXPECT_EQ(18u, sprite->getImage().size.width);
         EXPECT_EQ(18u, sprite->getImage().size.height);
         EXPECT_EQ(1, sprite->getPixelRatio());

--- a/test/style/style_image.test.cpp
+++ b/test/style/style_image.test.cpp
@@ -35,18 +35,14 @@ TEST(StyleImage, ZeroRatio) {
 
 TEST(StyleImage, Retina) {
     style::Image image("test", PremultipliedImage({ 32, 24 }), 2.0);
-    EXPECT_EQ(16, image.getWidth());
     EXPECT_EQ(32u, image.getImage().size.width);
-    EXPECT_EQ(12, image.getHeight());
     EXPECT_EQ(24u, image.getImage().size.height);
     EXPECT_EQ(2, image.getPixelRatio());
 }
 
 TEST(StyleImage, FractionalRatio) {
     style::Image image("test", PremultipliedImage({ 20, 12 }), 1.5);
-    EXPECT_EQ(float(20.0 / 1.5), image.getWidth());
     EXPECT_EQ(20u, image.getImage().size.width);
-    EXPECT_EQ(float(12.0 / 1.5), image.getHeight());
     EXPECT_EQ(12u, image.getImage().size.height);
     EXPECT_EQ(1.5, image.getPixelRatio());
 }


### PR DESCRIPTION
These methods were not named in a way that indicates they return dimensions divided by the pixel ratio. In the one place they were used, inlining the calculation eliminates redundant arithmetic operations anyway.