### PR TITLE
#9021: Fixed static framework size 

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -47,6 +47,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * The error passed into `-[MGLMapViewDelegate mapViewDidFailLoadingMap:withError:]` now includes a more specific description and failure reason. ([#8418](https://github.com/mapbox/mapbox-gl-native/pull/8418))
 * Improved CPU and battery performance while animating a tilted map’s camera in an area with many labels. ([#9031](https://github.com/mapbox/mapbox-gl-native/pull/9031))
 * Fixed an issue rendering polylines that contain duplicate vertices. ([#8808](https://github.com/mapbox/mapbox-gl-native/pull/8808))
+* Fixed static framework size by using correct llvm flags on release scheme for strip command. ([#9021](https://github.com/mapbox/mapbox-gl-native/issues/9021))
 
 ## 3.5.4 - May 9, 2017
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Xcode 8.0 or higher is now recommended for using this SDK. ([#8775](https://github.com/mapbox/mapbox-gl-native/pull/8775))
 * Fixed an issue in the static framework where localizations would never load. ([#9074](https://github.com/mapbox/mapbox-gl-native/pull/9074))
 * Updated MGLMapView’s logo view to display [the new Mapbox logo](https://www.mapbox.com/blog/new-mapbox-logo/). ([#8771](https://github.com/mapbox/mapbox-gl-native/pull/8771), [#8773](https://github.com/mapbox/mapbox-gl-native/pull/8773))
+* Reduced dynamic and static framework sizes by more aggressively stripping symbols. ([#9021](https://github.com/mapbox/mapbox-gl-native/issues/9021))
 
 ### Styles
 
@@ -47,7 +48,6 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * The error passed into `-[MGLMapViewDelegate mapViewDidFailLoadingMap:withError:]` now includes a more specific description and failure reason. ([#8418](https://github.com/mapbox/mapbox-gl-native/pull/8418))
 * Improved CPU and battery performance while animating a tilted map’s camera in an area with many labels. ([#9031](https://github.com/mapbox/mapbox-gl-native/pull/9031))
 * Fixed an issue rendering polylines that contain duplicate vertices. ([#8808](https://github.com/mapbox/mapbox-gl-native/pull/8808))
-* Fixed static framework size by using correct llvm flags on release scheme for strip command. ([#9021](https://github.com/mapbox/mapbox-gl-native/issues/9021))
 
 ## 3.5.4 - May 9, 2017
 

--- a/platform/ios/config.cmake
+++ b/platform/ios/config.cmake
@@ -7,6 +7,10 @@ macro(mbgl_platform_core)
     set_xcode_property(mbgl-core ENABLE_BITCODE "YES")
     set_xcode_property(mbgl-core BITCODE_GENERATION_MODE bitcode)
     set_xcode_property(mbgl-core ONLY_ACTIVE_ARCH $<$<CONFIG:Debug>:YES>)
+    set_xcode_property(mbgl-core GCC_SYMBOLS_PRIVATE_EXTERN $<$<CONFIG:Debug>:NO>)
+    set_xcode_property(mbgl-core GCC_GENERATE_DEBUGGING_SYMBOLS $<$<CONFIG:Debug>:YES>)
+    set_xcode_property(mbgl-core GCC_SYMBOLS_PRIVATE_EXTERN $<$<CONFIG:Release>:YES>)
+    set_xcode_property(mbgl-core GCC_GENERATE_DEBUGGING_SYMBOLS $<$<CONFIG:Release>:NO>)
 
     target_sources(mbgl-core
         # Loop

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -2837,6 +2837,8 @@
 			baseConfigurationReference = 55D8C9941D0F133500F42F10 /* config.xcconfig */;
 			buildSettings = {
 				BITCODE_GENERATION_MODE = bitcode;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(mbgl_core_INCLUDE_DIRECTORIES)",
 					"$(polylabel_INCLUDE_DIRECTORIES)",


### PR DESCRIPTION
Fix #9021 by using correct llvm flags on release scheme for strip command.