### PR TITLE
Throttle tiles to redo symbol placement at most once every 300ms.

### DIFF
--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -593,6 +593,8 @@ set(MBGL_CORE_FILES
     src/mbgl/util/thread_context.cpp
     src/mbgl/util/thread_context.hpp
     src/mbgl/util/thread_local.hpp
+    src/mbgl/util/throttler.cpp
+    src/mbgl/util/throttler.hpp
     src/mbgl/util/tile_coordinate.hpp
     src/mbgl/util/tile_cover.cpp
     src/mbgl/util/tile_cover.hpp

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/text/glyph_atlas.hpp>
 #include <mbgl/text/placement_config.hpp>
 #include <mbgl/util/feature.hpp>
+#include <mbgl/util/throttler.hpp>
 #include <mbgl/actor/actor.hpp>
 
 #include <atomic>
@@ -88,6 +89,7 @@ protected:
 
 private:
     void markObsolete();
+    void invokePlacement();
 
     const std::string sourceID;
     style::Style& style;
@@ -110,6 +112,8 @@ private:
 
     std::unordered_map<std::string, std::shared_ptr<Bucket>> symbolBuckets;
     std::unique_ptr<CollisionTile> collisionTile;
+    
+    util::Throttler placementThrottler;
 };
 
 } // namespace mbgl

--- a/src/mbgl/util/throttler.cpp
+++ b/src/mbgl/util/throttler.cpp
@@ -1,0 +1,36 @@
+#include <mbgl/util/throttler.hpp>
+
+namespace mbgl {
+namespace util {
+
+Throttler::Throttler(Duration frequency_, std::function<void()>&& function_)
+    : frequency(frequency_)
+    , function(std::move(function_))
+    , pendingInvocation(false)
+    , lastInvocation(TimePoint::min())
+{}
+
+void Throttler::invoke() {
+    if (pendingInvocation) {
+        return;
+    }
+    
+    Duration timeToNextInvocation = lastInvocation == TimePoint::min()
+        ? Duration::zero()
+        : (lastInvocation + frequency) - Clock::now();
+    
+    if (timeToNextInvocation <= Duration::zero()) {
+        lastInvocation = Clock::now();
+        function();
+    } else {
+        pendingInvocation = true;
+        timer.start(timeToNextInvocation, Duration::zero(), [this]{
+            pendingInvocation = false;
+            lastInvocation = Clock::now();
+            function();
+        });
+    }
+}
+
+} // namespace util
+} // namespace mbgl

--- a/src/mbgl/util/throttler.hpp
+++ b/src/mbgl/util/throttler.hpp
@@ -1,0 +1,22 @@
+#include <mbgl/util/chrono.hpp>
+#include <mbgl/util/timer.hpp>
+
+namespace mbgl {
+namespace util {
+
+class Throttler {
+public:
+    Throttler(Duration frequency, std::function<void()>&& function);
+    
+    void invoke();
+private:
+    Duration frequency;
+    std::function<void()> function;
+    
+    Timer timer;
+    bool pendingInvocation;
+    TimePoint lastInvocation;
+};
+
+} // namespace util
+} // namespace mbgl


### PR DESCRIPTION
Whenever the position of the camera changes (change in pitch or bearing), we have to run the symbol placement logic in `GeometryTileWorker::attemptPlacement` in order to do collision detection for the new geometry. Collision detection is too expensive to do on every frame, so we do it asynchronously on the worker threads, and update the render thread with new collision information whenever it becomes available.

The current implementation has the worker threads run placement requests as frequently as possible: the idea is that even though we can't do collision detection synchronously, we want it to be "as close as possible" to avoid the temporary appearance of collisions as the map rotates. This means that when the camera position is continuously changing (maybe in a "route following" animation), CPU on the worker threads will always be maxed-out.

This PR changes the behavior to throttle placement to at most once every 300ms. The benefits are:

* Less CPU usage on the worker threads -> less heat/battery impact, especially in navigation use cases
* Modest increase in the "stability" of label placement. It is possible for labels to show along a very short part of an animation path. The visual experience of seeing labels quickly appear and disappear is jarring and we'd like to avoid it if possible -- by running placement less frequently, we reduce the number of these "short lived" labels we're likely to show/hide.

The drawback of this change is that it widens the window of time in which labels can collide on the map before we detect and remove them. In the worst case (a collision that occurs the frame after the last time we re-did placement), it will add 300ms to collision detection time, and in the average case it will add 150ms. I don't think this is too big a problem because:

* 300ms just isn't that long perceptually, and if two labels momentarily overlap before one is removed, the effect is not that visually jarring.
* Our asynchronous approach already tolerates a fair amount of lag in collision detection.

In my testing of this PR running the macOS app in the debugger, I haven't been able to perceive a degradation in collision detection, while worker thread CPU use during rotation/tilting is dramatically lower.

Fixes issue #8435: while this PR doesn't change the mailbox message coalescing behavior, the throttling effectively prevents a backlog of `onPlacement` messages from piling up.

This change supports the pitch-scaling changes in issue #8967: with pitch-scaling, we have to re-do placement whenever we pan a pitched map, and this keeps the amount of CPU dedicated to re-placement under control.