### PR TITLE
[core] Don't unnecessarily request glyphs for verticalized punctuation.

### DIFF
--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -136,12 +136,17 @@ SymbolLayout::SymbolLayout(const BucketParameters& parameters,
             }
 
             ft.text = applyArabicShaping(util::utf8_to_utf16::convert(u8string));
+            const bool canVerticalizeText = layout.get<TextRotationAlignment>() == AlignmentType::Map
+                                         && layout.get<SymbolPlacement>() == SymbolPlacementType::Line
+                                         && util::i18n::allowsVerticalWritingMode(*ft.text);
 
             // Loop through all characters of this text and collect unique codepoints.
             for (char16_t chr : *ft.text) {
                 glyphDependencies[layout.get<TextFont>()].insert(chr);
-                if (char16_t verticalChr = util::i18n::verticalizePunctuation(chr)) {
-                    glyphDependencies[layout.get<TextFont>()].insert(verticalChr);
+                if (canVerticalizeText) {
+                    if (char16_t verticalChr = util::i18n::verticalizePunctuation(chr)) {
+                        glyphDependencies[layout.get<TextFont>()].insert(verticalChr);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes issue #8982.

The upshot of this is basically that Latin text should just require a single page of Latin glyphs, not an extra page of full-width punctuation.

Nice catch, @mb12!