### PR TITLE
Leave Image objects in a valid state after premultiply/unpremultiply

### DIFF
--- a/src/mbgl/util/premultiply.cpp
+++ b/src/mbgl/util/premultiply.cpp
@@ -9,6 +9,7 @@ PremultipliedImage premultiply(UnassociatedImage&& src) {
     PremultipliedImage dst;
 
     dst.size = src.size;
+    src.size = { 0, 0 };
     dst.data = std::move(src.data);
 
     uint8_t* data = dst.data.get();
@@ -29,6 +30,7 @@ UnassociatedImage unpremultiply(PremultipliedImage&& src) {
     UnassociatedImage dst;
 
     dst.size = src.size;
+    src.size = { 0, 0 };
     dst.data = std::move(src.data);
 
     uint8_t* data = dst.data.get();

--- a/test/util/image.test.cpp
+++ b/test/util/image.test.cpp
@@ -142,4 +142,8 @@ TEST(Image, Premultiply) {
     EXPECT_EQ(127, image.data[1]);
     EXPECT_EQ(127, image.data[2]);
     EXPECT_EQ(128, image.data[3]);
+    EXPECT_EQ(1u, image.size.width);
+    EXPECT_EQ(1u, image.size.height);
+    EXPECT_EQ(0u, rgba.size.width);
+    EXPECT_EQ(0u, rgba.size.height);
 }


### PR DESCRIPTION
Follow up to https://github.com/mapbox/mapbox-gl-native/commit/5c52401d5504ab4b84d1510042c6b97504c50933