### PR TITLE
Make destructor virtual to avoid object splicing during destructor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ endif(WITH_COVERAGE)
 
 set(CMAKE_CONFIGURATION_TYPES Debug Release)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -ftemplate-depth=1024 -Wall -Wextra -Wshadow -Werror -Wno-variadic-macros -Wno-unknown-pragmas")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -ftemplate-depth=1024 -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Werror -Wno-variadic-macros -Wno-unknown-pragmas")
 if(APPLE)
     # -Wno-error=unused-command-line-argument is required due to https://llvm.org/bugs/show_bug.cgi?id=7798
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=unused-command-line-argument")

--- a/include/mbgl/map/map_observer.hpp
+++ b/include/mbgl/map/map_observer.hpp
@@ -10,6 +10,8 @@ namespace mbgl {
 
 class MapObserver {
 public:
+    virtual ~MapObserver() = default;
+
     static MapObserver& nullObserver() {
         static MapObserver mapObserver;
         return mapObserver;

--- a/src/mbgl/programs/symbol_program.hpp
+++ b/src/mbgl/programs/symbol_program.hpp
@@ -93,6 +93,8 @@ public:
 // particular attribute & uniform logic needed by each possible type of the {Text,Icon}Size properties.
 class SymbolSizeBinder {
 public:
+    virtual ~SymbolSizeBinder() = default;
+
     using Uniforms = gl::Uniforms<
         uniforms::u_is_size_zoom_constant,
         uniforms::u_is_size_feature_constant,
@@ -129,7 +131,7 @@ Range<float> getCoveringStops(Stops s, float lowerZoom, float upperZoom) {
     };
 }
 
-class ConstantSymbolSizeBinder : public SymbolSizeBinder {
+class ConstantSymbolSizeBinder final : public SymbolSizeBinder {
 public:
     using PropertyValue = variant<float, style::CameraFunction<float>>;
     
@@ -198,7 +200,7 @@ public:
     optional<style::CameraFunction<float>> function;
 };
 
-class SourceFunctionSymbolSizeBinder : public SymbolSizeBinder {
+class SourceFunctionSymbolSizeBinder final : public SymbolSizeBinder {
 public:
     using Vertex = gl::detail::Vertex<gl::Attribute<uint16_t, 1>>;
     using VertexVector = gl::VertexVector<Vertex>;
@@ -251,7 +253,7 @@ public:
     optional<VertexBuffer> buffer;
 };
 
-class CompositeFunctionSymbolSizeBinder: public SymbolSizeBinder {
+class CompositeFunctionSymbolSizeBinder final : public SymbolSizeBinder {
 public:
     using Vertex = SymbolSizeAttributes::Vertex;
     using VertexVector = gl::VertexVector<Vertex>;

--- a/src/mbgl/sprite/sprite_atlas.hpp
+++ b/src/mbgl/sprite/sprite_atlas.hpp
@@ -36,6 +36,7 @@ using IconDependencies = std::set<std::string>;
 
 class IconRequestor {
 public:
+    virtual ~IconRequestor() = default;
     virtual void onIconsAvailable(IconMap) = 0;
 };
 

--- a/src/mbgl/style/sources/geojson_source_impl.hpp
+++ b/src/mbgl/style/sources/geojson_source_impl.hpp
@@ -13,6 +13,7 @@ namespace style {
 
 class GeoJSONData {
 public:
+    virtual ~GeoJSONData() = default;
     virtual mapbox::geometry::feature_collection<int16_t> getTile(const CanonicalTileID&) = 0;
 };
 

--- a/src/mbgl/text/glyph_atlas.hpp
+++ b/src/mbgl/text/glyph_atlas.hpp
@@ -29,6 +29,7 @@ class Context;
 
 class GlyphRequestor {
 public:
+    virtual ~GlyphRequestor() = default;
     virtual void onGlyphsAvailable(GlyphPositionMap) = 0;
 };
     


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gl-native/commit/3f0c89d633a5056006557ad5f4b9e446807d00ee introduced a `GeoJSONData` object that is held in a `unique_ptr`, and has two child classes with data members. However, the `unique_ptr` created only holds the parent object, and it doesn't have a a `virtual` destructor, which means that during destruction, it'll only delete the base class part of the object (probably empty due to [empty base optimization](http://en.cppreference.com/w/cpp/language/ebo)), which leaves the other data members defined by the child classes (`GeoJSONVT` or `Supercluster`) allocated, creating a memory leak.

/cc @tmpsantos @bsudekum