### PR TITLE
Merge release-ios-v3.5.0-android-v5.0.0 into master (after iOS SDK v3.5.4)

### DIFF
--- a/platform/darwin/src/MGLStyleLayer.h
+++ b/platform/darwin/src/MGLStyleLayer.h
@@ -45,12 +45,12 @@ MGL_EXPORT
 @property (nonatomic, assign, getter=isVisible) BOOL visible;
 
 /**
- The maximum zoom level at which the layer gets parsed and appears.
+ The maximum zoom level at which the layer gets parsed and appears. This value is a floating-point number.
  */
 @property (nonatomic, assign) float maximumZoomLevel;
 
 /**
- The minimum zoom level at which the layer gets parsed and appears.
+ The minimum zoom level at which the layer gets parsed and appears. This value is a floating-point number.
  */
 @property (nonatomic, assign) float minimumZoomLevel;
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -37,6 +37,14 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * The error passed into `-[MGLMapViewDelegate mapViewDidFailLoadingMap:withError:]` now includes a more specific description and failure reason. ([#8418](https://github.com/mapbox/mapbox-gl-native/pull/8418))
 * Fixed an issue rendering polylines that contain duplicate vertices. ([#8808](https://github.com/mapbox/mapbox-gl-native/pull/8808))
 
+## 3.5.4 - May 9, 2017
+
+* Fixed an issue that caused view backed annotations to become detached from the map view during pan gestures combined with animations of annotation view size or when the annotation view had no size but contained subviews with a non-zero size. ([#8926](https://github.com/mapbox/mapbox-gl-native/pull/8926))
+
+## 3.5.3 - May 2, 2017
+
+* Fixed an issue that prevented the attribution `UIAlertController` from showing in modal hierarchies. ([#8837](https://github.com/mapbox/mapbox-gl-native/pull/8837))
+
 ## 3.5.2 - April 7, 2017
 
 * Fixed an issue that caused a crash when the user location annotation was presenting a callout view and the map was moved. ([#8686](https://github.com/mapbox/mapbox-gl-native/pull/8686))


### PR DESCRIPTION
Merged the release-ios-v3.5.0-android-v5.0.0 branch as of db7bb509e95d737199efa73a47bdcc973966ed97 into the master branch as of 8c75001443d5b91059f90aadbec126e47f6fc64b. Effectively, this merge brings in a commit that snuck into #8842 and changelog updates.

I’ll cherry-pick these commits into the release-ios-v3.6.0-android-v5.1.0 branch afterwards.

/cc @boundsj @jmkiley