### PR TITLE
[android] - bump tools and support lib version due to SNAPSHOT dependencies

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -6,9 +6,7 @@ dependencies {
     compile rootProject.ext.dep.supportDesign
     compile rootProject.ext.dep.timber
     compile rootProject.ext.dep.okhttp3
-    compile(rootProject.ext.dep.lost) {
-        exclude module: 'support-compat'
-    }
+    compile rootProject.ext.dep.lost
 
     // Mapbox Android Services (GeoJSON support)
     compile(rootProject.ext.dep.mapboxJavaGeoJSON) {

--- a/platform/android/dependencies.gradle
+++ b/platform/android/dependencies.gradle
@@ -2,13 +2,13 @@ ext {
     minSdkVersion = 15
     targetSdkVersion = 25
     compileSdkVersion = 25
-    buildToolsVersion = "25.0.2"
+    buildToolsVersion = "25.0.3"
 
     versionCode = 11
     versionName = "5.0.0"
 
     mapboxServicesVersion = "2.2.0-SNAPSHOT"
-    supportLibVersion = "25.1.0"
+    supportLibVersion = "25.3.1"
     wearableVersion = '2.0.0'
     espressoVersion = '2.2.2'
     testRunnerVersion = '0.5'

--- a/platform/android/dependencies.gradle
+++ b/platform/android/dependencies.gradle
@@ -2,7 +2,7 @@ ext {
     minSdkVersion = 15
     targetSdkVersion = 25
     compileSdkVersion = 25
-    buildToolsVersion = "25.0.3"
+    buildToolsVersion = "25.0.2"
 
     versionCode = 11
     versionName = "5.0.0"


### PR DESCRIPTION
Unblocks https://github.com/mapbox/mapbox-gl-native/pull/9045, more information in https://github.com/mapbox/mapbox-gl-native/pull/9045#issuecomment-302612989. 

