### PR TITLE
[android] - correct bearing conversion when animating the map with ju…

### DIFF
--- a/platform/android/src/map/camera_position.cpp
+++ b/platform/android/src/map/camera_position.cpp
@@ -12,7 +12,7 @@ jni::Object<CameraPosition> CameraPosition::New(jni::JNIEnv &env, mbgl::CameraOp
     center.wrap();
 
     // convert bearing, core ranges from [−π rad, π rad], android from 0 to 360 degrees
-    double bearing_degrees = options.angle.value_or(0) * 180.0 / M_PI;
+    double bearing_degrees = (options.angle.value_or(0) * 180.0 / M_PI) + 180;
     while (bearing_degrees > 360) {
         bearing_degrees -= 360;
     }

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -385,7 +385,7 @@ void NativeMapView::moveBy(jni::JNIEnv&, jni::jdouble dx, jni::jdouble dy, jni::
 void NativeMapView::jumpTo(jni::JNIEnv&, jni::jdouble angle, jni::jdouble latitude, jni::jdouble longitude, jni::jdouble pitch, jni::jdouble zoom) {
     mbgl::CameraOptions options;
     if (angle != -1) {
-        options.angle = (-angle * M_PI) / 180;
+        options.angle = (angle - 180 * M_PI) / 180;
     }
     options.center = mbgl::LatLng(latitude, longitude);
     options.padding = insets;
@@ -402,7 +402,7 @@ void NativeMapView::jumpTo(jni::JNIEnv&, jni::jdouble angle, jni::jdouble latitu
 void NativeMapView::easeTo(jni::JNIEnv&, jni::jdouble angle, jni::jdouble latitude, jni::jdouble longitude, jni::jlong duration, jni::jdouble pitch, jni::jdouble zoom, jni::jboolean easing) {
     mbgl::CameraOptions cameraOptions;
     if (angle != -1) {
-        cameraOptions.angle = (-angle * M_PI) / 180;
+        cameraOptions.angle = (angle - 180 * M_PI) / 180;
     }
     cameraOptions.center = mbgl::LatLng(latitude, longitude);
     cameraOptions.padding = insets;
@@ -426,7 +426,7 @@ void NativeMapView::easeTo(jni::JNIEnv&, jni::jdouble angle, jni::jdouble latitu
 void NativeMapView::flyTo(jni::JNIEnv&, jni::jdouble angle, jni::jdouble latitude, jni::jdouble longitude, jni::jlong duration, jni::jdouble pitch, jni::jdouble zoom) {
     mbgl::CameraOptions cameraOptions;
     if (angle != -1) {
-        cameraOptions.angle = (-angle * M_PI) / 180 ;
+        cameraOptions.angle = (angle - 180 * M_PI / 180);
     }
     cameraOptions.center = mbgl::LatLng(latitude, longitude);
     cameraOptions.padding = insets;


### PR DESCRIPTION
closes #9011,
With migration of the camera position to c++ we noticed the conversion of the core bearing to java bearing was incorrect. While we fixed this from c++ to java, the other way around wasn't validated. This patch fixes up both directions to take in account that core ranges from -180 to 180 degrees while the android binding uses 0 to 360 degrees. 