### PR TITLE
Release node-v3.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-native",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Renders map tiles with Mapbox GL",
   "keywords": [
     "mapbox",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.5.2 - May 18, 2017
+
+- Fixed a memory leak ([#8884](https://github.com/mapbox/mapbox-gl-native/pull/9035))
+
+
 # 3.5.1 - May 8, 2017
 
 - Adds Node v6 binaries. **Note, Node v4 binaries will be removed on August 1st.** ([#8884](https://github.com/mapbox/mapbox-gl-native/pull/8884))


### PR DESCRIPTION
Most significant change is fixing the memory leak found in https://github.com/mapbox/mapbox-gl-native/pull/9035

