### PR TITLE
[core] Eliminate round-trip through `Value` in `CameraFunction::evaluate`

### DIFF
--- a/cmake/test-files.cmake
+++ b/cmake/test-files.cmake
@@ -94,6 +94,8 @@ set(MBGL_TEST_FILES
     # style/function
     test/style/function/camera_function.test.cpp
     test/style/function/composite_function.test.cpp
+    test/style/function/exponential_stops.test.cpp
+    test/style/function/interval_stops.test.cpp
     test/style/function/source_function.test.cpp
 
     # style

--- a/include/mbgl/style/function/camera_function.hpp
+++ b/include/mbgl/style/function/camera_function.hpp
@@ -25,7 +25,7 @@ public:
 
     T evaluate(float zoom) const {
         return stops.match([&] (const auto& s) {
-            return s.evaluate(Value(double(zoom))).value_or(T());
+            return s.evaluate(zoom).value_or(T());
         });
     }
     

--- a/include/mbgl/style/function/exponential_stops.hpp
+++ b/include/mbgl/style/function/exponential_stops.hpp
@@ -22,26 +22,29 @@ public:
           base(base_) {
     }
 
-    optional<T> evaluate(const Value& value) const {
+    optional<T> evaluate(float z) const {
         if (stops.empty()) {
             assert(false);
             return T();
         }
 
-        optional<float> z = numericValue<float>(value);
-        if (!z) {
-            return T();
-        }
-
-        auto it = stops.upper_bound(*z);
+        auto it = stops.upper_bound(z);
         if (it == stops.end()) {
             return stops.rbegin()->second;
         } else if (it == stops.begin()) {
             return stops.begin()->second;
         } else {
             return util::interpolate(std::prev(it)->second, it->second,
-                util::interpolationFactor(base, { std::prev(it)->first, it->first }, *z));
+                util::interpolationFactor(base, { std::prev(it)->first, it->first }, z));
         }
+    }
+
+    optional<T> evaluate(const Value& value) const {
+        optional<float> z = numericValue<float>(value);
+        if (!z) {
+            return T();
+        }
+        return evaluate(*z);
     }
 
     friend bool operator==(const ExponentialStops& lhs,

--- a/include/mbgl/style/function/exponential_stops.hpp
+++ b/include/mbgl/style/function/exponential_stops.hpp
@@ -24,8 +24,7 @@ public:
 
     optional<T> evaluate(float z) const {
         if (stops.empty()) {
-            assert(false);
-            return T();
+            return {};
         }
 
         auto it = stops.upper_bound(z);
@@ -42,7 +41,7 @@ public:
     optional<T> evaluate(const Value& value) const {
         optional<float> z = numericValue<float>(value);
         if (!z) {
-            return T();
+            return {};
         }
         return evaluate(*z);
     }

--- a/include/mbgl/style/function/interval_stops.hpp
+++ b/include/mbgl/style/function/interval_stops.hpp
@@ -18,18 +18,13 @@ public:
         : stops(std::move(stops_)) {
     }
 
-    optional<T> evaluate(const Value& value) const {
+    optional<T> evaluate(float z) const {
         if (stops.empty()) {
             assert(false);
             return {};
         }
 
-        optional<float> z = numericValue<float>(value);
-        if (!z) {
-            return {};
-        }
-
-        auto it = stops.upper_bound(*z);
+        auto it = stops.upper_bound(z);
         if (it == stops.end()) {
             return stops.rbegin()->second;
         } else if (it == stops.begin()) {
@@ -37,6 +32,14 @@ public:
         } else {
             return std::prev(it)->second;
         }
+    }
+
+    optional<T> evaluate(const Value& value) const {
+        optional<float> z = numericValue<float>(value);
+        if (!z) {
+            return {};
+        }
+        return evaluate(*z);
     }
 
     friend bool operator==(const IntervalStops& lhs,

--- a/include/mbgl/style/function/interval_stops.hpp
+++ b/include/mbgl/style/function/interval_stops.hpp
@@ -20,7 +20,6 @@ public:
 
     optional<T> evaluate(float z) const {
         if (stops.empty()) {
-            assert(false);
             return {};
         }
 

--- a/test/style/function/exponential_stops.test.cpp
+++ b/test/style/function/exponential_stops.test.cpp
@@ -1,0 +1,20 @@
+#include <mbgl/test/util.hpp>
+
+#include <mbgl/style/function/exponential_stops.hpp>
+
+using namespace mbgl;
+using namespace mbgl::style;
+
+TEST(ExponentialStops, Empty) {
+    ExponentialStops<float> stops;
+    EXPECT_FALSE(bool(stops.evaluate(0)));
+}
+
+TEST(ExponentialStops, NonNumericInput) {
+    ExponentialStops<float> stops(std::map<float, float> {{0.0f, 0.0f}});
+    EXPECT_FALSE(bool(stops.evaluate(Value(NullValue()))));
+    EXPECT_FALSE(bool(stops.evaluate(Value(false))));
+    EXPECT_FALSE(bool(stops.evaluate(Value(std::string()))));
+    EXPECT_FALSE(bool(stops.evaluate(Value(std::vector<Value>()))));
+    EXPECT_FALSE(bool(stops.evaluate(Value(std::unordered_map<std::string, Value>()))));
+}

--- a/test/style/function/interval_stops.test.cpp
+++ b/test/style/function/interval_stops.test.cpp
@@ -1,0 +1,20 @@
+#include <mbgl/test/util.hpp>
+
+#include <mbgl/style/function/interval_stops.hpp>
+
+using namespace mbgl;
+using namespace mbgl::style;
+
+TEST(IntervalStops, Empty) {
+    IntervalStops<float> stops;
+    EXPECT_FALSE(bool(stops.evaluate(0)));
+}
+
+TEST(IntervalStops, NonNumericInput) {
+    IntervalStops<float> stops(std::map<float, float> {{0.0f, 0.0f}});
+    EXPECT_FALSE(bool(stops.evaluate(Value(NullValue()))));
+    EXPECT_FALSE(bool(stops.evaluate(Value(false))));
+    EXPECT_FALSE(bool(stops.evaluate(Value(std::string()))));
+    EXPECT_FALSE(bool(stops.evaluate(Value(std::vector<Value>()))));
+    EXPECT_FALSE(bool(stops.evaluate(Value(std::unordered_map<std::string, Value>()))));
+}


### PR DESCRIPTION
Small optimization I spotted doing some profiling.