### PR TITLE
[core] RenderLayer to manager RenderTiles

### DIFF
--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -13,6 +13,7 @@
 
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/layer_impl.hpp>
+#include <mbgl/style/layers/custom_layer_impl.hpp>
 
 #include <mbgl/tile/tile.hpp>
 #include <mbgl/renderer/layers/render_background_layer.hpp>
@@ -179,12 +180,7 @@ void Painter::render(const Style& style, const FrameData& frame_, View& view, Sp
         annotationSpriteAtlas.upload(context, 0);
 
         for (const auto& item : order) {
-            for (const auto& tileRef : item.tiles) {
-                const auto& bucket = tileRef.get().tile.getBucket(*item.layer.baseImpl);
-                if (bucket && bucket->needsUpload()) {
-                    bucket->upload(context);
-                }
-            }
+            item.layer.uploadBuckets(context, item.source);
         }
     }
 
@@ -336,13 +332,7 @@ void Painter::renderPass(PaintParameters& parameters,
             context.setDepthMode(depthModeForSublayer(0, gl::DepthMode::ReadWrite));
             context.clear(Color{ 0.0f, 0.0f, 0.0f, 0.0f }, 1.0f, {});
 
-            for (auto& tileRef : item.tiles) {
-                auto& tile = tileRef.get();
-
-                MBGL_DEBUG_GROUP(context, layer.baseImpl->id + " - " + util::toString(tile.id));
-                auto bucket = tile.tile.getBucket(*layer.baseImpl);
-                bucket->render(*this, parameters, layer, tile);
-            }
+            renderItem(parameters, item);
 
             parameters.view.bind();
             context.bindTexture(extrusionTexture->getTexture());
@@ -364,18 +354,19 @@ void Painter::renderPass(PaintParameters& parameters,
                 ExtrusionTextureProgram::PaintPropertyBinders{ properties, 0 }, properties,
                 state.getZoom());
         } else {
-            for (auto& tileRef : item.tiles) {
-                auto& tile = tileRef.get();
-                MBGL_DEBUG_GROUP(context, layer.baseImpl->id + " - " + util::toString(tile.id));
-                auto bucket = tile.tile.getBucket(*layer.baseImpl);
-                bucket->render(*this, parameters, layer, tile);
-            }
+            renderItem(parameters, item);
         }
     }
 
     if (debug::renderTree) {
         Log::Info(Event::Render, "%*s%s", --indent * 4, "", "}");
     }
+}
+
+void Painter::renderItem(PaintParameters& parameters, const RenderItem& item) {
+    RenderLayer& layer = item.layer;
+    MBGL_DEBUG_GROUP(context, layer.getID());
+    layer.render(*this, parameters, item.source);
 }
 
 mat4 Painter::matrixForTile(const UnwrappedTileID& tileID) {

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -94,6 +94,8 @@ public:
     void renderRaster(PaintParameters&, RasterBucket&, const RenderRasterLayer&, const RenderTile&);
     void renderBackground(PaintParameters&, const RenderBackgroundLayer&);
 
+    void renderItem(PaintParameters&, const RenderItem&);
+
 #ifndef NDEBUG
     // Renders tile clip boundaries, using stencil buffer to calculate fill color.
     void renderClipMasks(PaintParameters&);
@@ -104,8 +106,6 @@ public:
     bool needsAnimation() const;
 
 private:
-    std::vector<RenderItem> determineRenderOrder(const style::Style&);
-
     template <class Iterator>
     void renderPass(PaintParameters&,
                     RenderPass,

--- a/src/mbgl/renderer/render_item.hpp
+++ b/src/mbgl/renderer/render_item.hpp
@@ -17,13 +17,13 @@ namespace style {
 
 class RenderItem {
 public:
-    RenderItem(const RenderLayer& layer_,
-               std::vector<std::reference_wrapper<RenderTile>> tiles_ = {})
-        : layer(layer_), tiles(std::move(tiles_)) {
+    RenderItem(RenderLayer& layer_,
+               RenderSource* renderSource_)
+        : layer(layer_), source(renderSource_) {
     }
 
-    const RenderLayer& layer;
-    std::vector<std::reference_wrapper<RenderTile>> tiles;
+    RenderLayer& layer;
+    RenderSource* source;
 };
 
 class RenderData {

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -14,6 +14,14 @@ class Bucket;
 class BucketParameters;
 class TransitionParameters;
 class PropertyEvaluationParameters;
+class Painter;
+class PaintParameters;
+class RenderSource;
+class RenderTile;
+
+namespace gl {
+class Context;
+}   // namespace gl
 
 class RenderLayer {
 protected:
@@ -58,6 +66,8 @@ public:
     // Checks whether this layer can be rendered.
     bool needsRendering(float zoom) const;
 
+    virtual void uploadBuckets(gl::Context&, RenderSource* source);
+    virtual void render(Painter& , PaintParameters& , RenderSource* source);
     // Check wether the given geometry intersects
     // with the feature
     virtual bool queryIntersectsFeature(
@@ -69,6 +79,7 @@ public:
 
     virtual std::unique_ptr<Bucket> createBucket(const BucketParameters&, const std::vector<const RenderLayer*>&) const = 0;
 
+    void setRenderTiles(std::vector<std::reference_wrapper<RenderTile>>);
     // Private implementation
     Immutable<style::Layer::Impl> baseImpl;
     void setImpl(Immutable<style::Layer::Impl>);
@@ -79,6 +90,10 @@ protected:
     // Stores what render passes this layer is currently enabled for. This depends on the
     // evaluated StyleProperties object and is updated accordingly.
     RenderPass passes = RenderPass::None;
+
+    //Stores current set of tiles to be rendered for this layer.
+    std::vector<std::reference_wrapper<RenderTile>> renderTiles;
+
 };
 
 } // namespace mbgl


### PR DESCRIPTION
This PR moves RenderTile ownership to RenderLayers. This allows moving the management of layer-specific behaviors for RenderItem's from Painter to the individual RenderLayers.

This is also needed to allow layers to have different behaviors based on the source type, as needed for ImageSource