### PR TITLE
More robust Mapbox Streets label localization

### DIFF
--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -1397,19 +1397,20 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
 
 - (NSString *)bestLanguageForUser
 {
-    NSArray *supportedLanguages = @[ @"en", @"es", @"fr", @"de", @"ru", @"zh" ];
-    NSArray<NSString *> *preferredLanguages = [NSLocale preferredLanguages];
-    NSString *bestLanguage;
+    // https://www.mapbox.com/vector-tiles/mapbox-streets-v7/#overview
+    NSArray *supportedLanguages = @[ @"ar", @"en", @"es", @"fr", @"de", @"pt", @"ru", @"zh", @"zh-Hans" ];
+    NSArray<NSString *> *preferredLanguages = [NSBundle preferredLocalizationsFromArray:supportedLanguages forPreferences:[NSLocale preferredLanguages]];
+    NSString *mostSpecificLanguage;
 
-    for (NSString *language in preferredLanguages) {
-        NSString *thisLanguage = [[NSLocale localeWithLocaleIdentifier:language] objectForKey:NSLocaleLanguageCode];
-        if ([supportedLanguages containsObject:thisLanguage]) {
-            bestLanguage = thisLanguage;
-            break;
+    for (NSString *language in preferredLanguages)
+    {
+        if (language.length > mostSpecificLanguage.length)
+        {
+            mostSpecificLanguage = language;
         }
     }
 
-    return bestLanguage ?: @"en";
+    return mostSpecificLanguage ?: @"en";
 }
 
 - (IBAction)startWorldTour

--- a/platform/macos/app/MGLVectorSource+MBXAdditions.h
+++ b/platform/macos/app/MGLVectorSource+MBXAdditions.h
@@ -4,7 +4,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MGLVectorSource (MBXAdditions)
 
-+ (nullable NSString *)preferredMapboxStreetsLanguage;
++ (NSString *)preferredMapboxStreetsLanguage;
 
 - (NS_DICTIONARY_OF(NSString *, NSString *) *)localizedKeysByKeyForPreferredLanguage:(nullable NSString *)preferredLanguage;
 

--- a/platform/macos/app/MGLVectorSource+MBXAdditions.m
+++ b/platform/macos/app/MGLVectorSource+MBXAdditions.m
@@ -7,19 +7,23 @@
     static dispatch_once_t onceToken;
     static NS_SET_OF(NSString *) *mapboxStreetsLanguages;
     dispatch_once(&onceToken, ^{
-        mapboxStreetsLanguages = [NSSet setWithObjects:@"en", @"es", @"fr", @"de", @"ru", @"zh", nil];
+        // https://www.mapbox.com/vector-tiles/mapbox-streets-v7/#overview
+        mapboxStreetsLanguages = [NSSet setWithObjects:@"ar", @"de", @"en", @"es", @"fr", @"pt", @"ru", @"zh", @"zh-Hans", nil];
     });
     return mapboxStreetsLanguages;
 }
 
-+ (nullable NSString *)preferredMapboxStreetsLanguage {
-    for (NSString *language in [NSLocale preferredLanguages]) {
-        NSString *languageCode = [[NSLocale localeWithLocaleIdentifier:language] objectForKey:NSLocaleLanguageCode];
-        if ([[MGLVectorSource mapboxStreetsLanguages] containsObject:languageCode]) {
-            return languageCode;
++ (NSString *)preferredMapboxStreetsLanguage {
+    NSArray<NSString *> *supportedLanguages = [MGLVectorSource mapboxStreetsLanguages].allObjects;
+    NSArray<NSString *> *preferredLanguages = [NSBundle preferredLocalizationsFromArray:supportedLanguages
+                                                                         forPreferences:[NSLocale preferredLanguages]];
+    NSString *mostSpecificLanguage;
+    for (NSString *language in preferredLanguages) {
+        if (language.length > mostSpecificLanguage.length) {
+            mostSpecificLanguage = language;
         }
     }
-    return nil;
+    return mostSpecificLanguage ?: @"en";
 }
 
 - (BOOL)isMapboxStreets {

--- a/platform/macos/app/MapDocument.m
+++ b/platform/macos/app/MapDocument.m
@@ -345,7 +345,7 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
 
 - (void)updateLabels {
     MGLStyle *style = self.mapView.style;
-    NSString *preferredLanguage = _isLocalizingLabels ? ([MGLVectorSource preferredMapboxStreetsLanguage] ?: @"en") : nil;
+    NSString *preferredLanguage = _isLocalizingLabels ? [MGLVectorSource preferredMapboxStreetsLanguage] : nil;
     NSMutableDictionary *localizedKeysByKeyBySourceIdentifier = [NSMutableDictionary dictionary];
     for (MGLSymbolStyleLayer *layer in style.layers) {
         if (![layer isKindOfClass:[MGLSymbolStyleLayer class]]) {
@@ -855,8 +855,7 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
         if (menuItem.tag) {
             NSLocale *locale = [NSLocale localeWithLocaleIdentifier:[NSBundle mainBundle].developmentLocalization];
             NSString *preferredLanguage = [MGLVectorSource preferredMapboxStreetsLanguage];
-            menuItem.enabled = !!preferredLanguage;
-            menuItem.title = [locale displayNameForKey:NSLocaleIdentifier value:preferredLanguage ?: @"Preferred Language"];
+            menuItem.title = [locale displayNameForKey:NSLocaleIdentifier value:preferredLanguage];
         }
         return YES;
     }


### PR DESCRIPTION
Rely on NSBundle to select the most appropriate locale based on the user’s preferred languages. This code is used in iosapp’s “Label Countries In” demonstration and macosapp’s View ‣ Labels In setting. (#7031 tracks folding that logic into the SDKs proper.)

Added Arabic, Portuguese, and Simplified Chinese to the list of languages with specialized fields in the Mapbox Streets source, based on [this revised document](https://www.mapbox.com/vector-tiles/mapbox-streets-v7/#overview). The previous logic was insufficient for choosing between `zh` and `zh-Hans`.

/cc @friedbunny