### PR TITLE
[core] Block in Mailbox::close() until the mailbox isn't being sent a message

### DIFF
--- a/include/mbgl/actor/mailbox.hpp
+++ b/include/mbgl/actor/mailbox.hpp
@@ -23,8 +23,10 @@ public:
 private:
     Scheduler& scheduler;
 
-    std::mutex closingMutex;
-    bool closing { false };
+    std::mutex receivingMutex;
+    std::mutex pushingMutex;
+
+    bool closed { false };
 
     std::mutex queueMutex;
     std::queue<std::unique_ptr<Message>> queue;

--- a/src/mbgl/actor/mailbox.cpp
+++ b/src/mbgl/actor/mailbox.cpp
@@ -10,8 +10,23 @@ Mailbox::Mailbox(Scheduler& scheduler_)
     : scheduler(scheduler_) {
 }
 
+void Mailbox::close() {
+    // Block until neither receive() nor push() are in progress. Two mutexes are used because receive()
+    // must not block send(). Of the two, the receiving mutex must be acquired first, because that is
+    // the order that an actor will obtain them when it self-sends a message, and consistent lock
+    // acquisition order prevents deadlocks.
+    std::lock_guard<std::mutex> receivingLock(receivingMutex);
+    std::lock_guard<std::mutex> pushingLock(pushingMutex);
+
+    closed = true;
+}
+
 void Mailbox::push(std::unique_ptr<Message> message) {
-    assert(!closing);
+    std::lock_guard<std::mutex> pushingLock(pushingMutex);
+
+    if (closed) {
+        return;
+    }
 
     std::lock_guard<std::mutex> queueLock(queueMutex);
     bool wasEmpty = queue.empty();
@@ -21,16 +36,10 @@ void Mailbox::push(std::unique_ptr<Message> message) {
     }
 }
 
-void Mailbox::close() {
-    // Block until the scheduler is guaranteed not to be executing receive().
-    std::lock_guard<std::mutex> closingLock(closingMutex);
-    closing = true;
-}
-
 void Mailbox::receive() {
-    std::lock_guard<std::mutex> closingLock(closingMutex);
+    std::lock_guard<std::mutex> receivingLock(receivingMutex);
 
-    if (closing) {
+    if (closed) {
         return;
     }
 


### PR DESCRIPTION
Otherwise, an ActorRef that's in the process of sending a message could attempt to access an invalid Scheduler reference:

```
      Thread 1                     Thread 2
--------------------------------------------------
 Scheduler::Scheduler
     Actor::Actor
                              weakMailbox.lock()
     Actor::~Actor
 Scheduler::~Scheduler
                               mailbox->push()
                             scheduler.schedule() 💣
```

Fixes the issue described in https://github.com/mapbox/mapbox-gl-native/issues/8864#issuecomment-298784717.