### PR TITLE
[ios] Fallback to Mapbox.bundle as the framework bundle

### DIFF
--- a/platform/darwin/src/NSBundle+MGLAdditions.h
+++ b/platform/darwin/src/NSBundle+MGLAdditions.h
@@ -36,10 +36,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nullable NS_DICTIONARY_OF(NSString *, id) *)mgl_frameworkInfoDictionary;
 
-/// The relative path to the directory containing the SDK’s resource files, or
-/// `nil` if the files are located directly within the bundle’s root directory.
-@property (readonly, copy, nullable) NSString *mgl_resourcesDirectory;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/NSBundle+MGLAdditions.m
+++ b/platform/darwin/src/NSBundle+MGLAdditions.m
@@ -7,10 +7,13 @@
 + (instancetype)mgl_frameworkBundle {
     NSBundle *bundle = [self bundleForClass:[MGLAccountManager class]];
 
-    if (![bundle.infoDictionary[@"CFBundlePackageType"] isEqualToString:@"FMWK"] && [bundle pathForResource:@"Mapbox" ofType:@"bundle"]) {
+    if (![bundle.infoDictionary[@"CFBundlePackageType"] isEqualToString:@"FMWK"]) {
         // For static frameworks, the bundle is the containing application
         // bundle but the resources are in Mapbox.bundle.
-        bundle = [self bundleWithPath:[bundle pathForResource:@"Mapbox" ofType:@"bundle"]];
+        NSString *bundlePath = [bundle pathForResource:@"Mapbox" ofType:@"bundle"];
+        if (bundlePath) {
+            bundle = [self bundleWithPath:bundlePath];
+        }
     }
 
     return bundle;

--- a/platform/darwin/src/NSBundle+MGLAdditions.m
+++ b/platform/darwin/src/NSBundle+MGLAdditions.m
@@ -13,6 +13,9 @@
         NSString *bundlePath = [bundle pathForResource:@"Mapbox" ofType:@"bundle"];
         if (bundlePath) {
             bundle = [self bundleWithPath:bundlePath];
+        } else {
+            [NSException raise:@"MGLBundleNotFoundException" format:
+             @"The Mapbox framework bundle could not be found. If using the Mapbox iOS SDK as a static framework, make sure that Mapbox.bundle is copied into the root of the app bundle."];
         }
     }
 

--- a/platform/darwin/src/NSBundle+MGLAdditions.m
+++ b/platform/darwin/src/NSBundle+MGLAdditions.m
@@ -6,12 +6,13 @@
 
 + (instancetype)mgl_frameworkBundle {
     NSBundle *bundle = [self bundleForClass:[MGLAccountManager class]];
-    if (![bundle.infoDictionary[@"CFBundlePackageType"] isEqualToString:@"FMWK"] && !bundle.mgl_resourcesDirectory) {
+
+    if (![bundle.infoDictionary[@"CFBundlePackageType"] isEqualToString:@"FMWK"] && [bundle pathForResource:@"Mapbox" ofType:@"bundle"]) {
         // For static frameworks, the bundle is the containing application
-        // bundle but the resources are still in the framework bundle.
-        bundle = [NSBundle bundleWithPath:[bundle.privateFrameworksPath
-                                           stringByAppendingPathComponent:@"Mapbox.framework"]];
+        // bundle but the resources are in Mapbox.bundle.
+        bundle = [self bundleWithPath:[bundle pathForResource:@"Mapbox" ofType:@"bundle"]];
     }
+
     return bundle;
 }
 
@@ -21,18 +22,7 @@
 
 + (nullable NS_DICTIONARY_OF(NSString *, id) *)mgl_frameworkInfoDictionary {
     NSBundle *bundle = self.mgl_frameworkBundle;
-    if (bundle.mgl_resourcesDirectory) {
-        NSString *infoPlistPath = [bundle pathForResource:@"Info"
-                                                   ofType:@"plist"
-                                              inDirectory:bundle.mgl_resourcesDirectory];
-        return [NSDictionary dictionaryWithContentsOfFile:infoPlistPath];
-    } else {
-        return bundle.infoDictionary;
-    }
-}
-
-- (NSString *)mgl_resourcesDirectory {
-    return [self pathForResource:@"Mapbox" ofType:@"bundle"] ? @"Mapbox.bundle" : nil;
+    return bundle.infoDictionary;
 }
 
 @end

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -37,6 +37,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * The error passed into `-[MGLMapViewDelegate mapViewDidFailLoadingMap:withError:]` now includes a more specific description and failure reason. ([#8418](https://github.com/mapbox/mapbox-gl-native/pull/8418))
 * Fixed an issue rendering polylines that contain duplicate vertices. ([#8808](https://github.com/mapbox/mapbox-gl-native/pull/8808))
 * Fixed a bug which caused the compass and other ornaments to underlap navigation and tab bars. ([#7716](https://github.com/mapbox/mapbox-gl-native/pull/7716))
+* Fixed an issue in the static framework where localizations would never load. ([#9074](https://github.com/mapbox/mapbox-gl-native/pull/9074))
 
 ## 3.5.4 - May 9, 2017
 

--- a/platform/ios/src/MGLAPIClient.m
+++ b/platform/ios/src/MGLAPIClient.m
@@ -117,7 +117,7 @@ static NSString * const MGLAPIClientHTTPMethodPost = @"POST";
 
 - (void)loadCertificate:(NSData **)certificate withResource:(NSString *)resource {
     NSBundle *frameworkBundle = [NSBundle mgl_frameworkBundle];
-    NSString *cerPath = [frameworkBundle pathForResource:resource ofType:@"der" inDirectory:frameworkBundle.mgl_resourcesDirectory];
+    NSString *cerPath = [frameworkBundle pathForResource:resource ofType:@"der"];
     if (cerPath != nil) {
         *certificate = [NSData dataWithContentsOfFile:cerPath];
     }

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -5293,8 +5293,7 @@ public:
     NSString *extension = imageName.pathExtension.length ? imageName.pathExtension : @"png";
     NSBundle *bundle = [NSBundle mgl_frameworkBundle];
     NSString *path = [bundle pathForResource:imageName.stringByDeletingPathExtension
-                                      ofType:extension
-                                 inDirectory:bundle.mgl_resourcesDirectory];
+                                      ofType:extension];
     if ( ! path)
     {
         [NSException raise:@"Resource not found" format:


### PR DESCRIPTION
Fixes #9072 and unblocks #9060. When using the static framework, load resources from Mapbox.bundle.

/cc @boundsj @1ec5