### PR TITLE
[android] - horizontally rotated in snapshot

### DIFF
--- a/platform/android/src/map/camera_position.cpp
+++ b/platform/android/src/map/camera_position.cpp
@@ -11,8 +11,9 @@ jni::Object<CameraPosition> CameraPosition::New(jni::JNIEnv &env, mbgl::CameraOp
     auto center = options.center.value();
     center.wrap();
 
-    // convert bearing, core ranges from [−π rad, π rad], android from 0 to 360 degrees
-    double bearing_degrees = (options.angle.value_or(0) * 180.0 / M_PI) + 180;
+    // convert bearing, measured in radians counterclockwise from true north.
+    // Wrapped to [−π rad, π rad). Android binding from 0 to 360 degrees
+    double bearing_degrees = -options.angle.value_or(-M_PI) * util::RAD2DEG;
     while (bearing_degrees > 360) {
         bearing_degrees -= 360;
     }
@@ -21,7 +22,7 @@ jni::Object<CameraPosition> CameraPosition::New(jni::JNIEnv &env, mbgl::CameraOp
     }
 
     // convert tilt, core ranges from  [0 rad, 1,0472 rad], android ranges from 0 to 60
-    double tilt_degrees = options.pitch.value_or(0) * 180 / M_PI;
+    double tilt_degrees = options.pitch.value_or(0) * util::RAD2DEG;
 
     return CameraPosition::javaClass.New(env, constructor, LatLng::New(env, center), options.zoom.value_or(0), tilt_degrees, bearing_degrees);
 }

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -385,12 +385,12 @@ void NativeMapView::moveBy(jni::JNIEnv&, jni::jdouble dx, jni::jdouble dy, jni::
 void NativeMapView::jumpTo(jni::JNIEnv&, jni::jdouble angle, jni::jdouble latitude, jni::jdouble longitude, jni::jdouble pitch, jni::jdouble zoom) {
     mbgl::CameraOptions options;
     if (angle != -1) {
-        options.angle = (angle - 180 * M_PI) / 180;
+        options.angle = -angle * util::DEG2RAD;
     }
     options.center = mbgl::LatLng(latitude, longitude);
     options.padding = insets;
     if (pitch != -1) {
-        options.pitch = pitch * M_PI / 180;
+        options.pitch = pitch * util::DEG2RAD;
     }
     if (zoom != -1) {
         options.zoom = zoom;
@@ -402,12 +402,12 @@ void NativeMapView::jumpTo(jni::JNIEnv&, jni::jdouble angle, jni::jdouble latitu
 void NativeMapView::easeTo(jni::JNIEnv&, jni::jdouble angle, jni::jdouble latitude, jni::jdouble longitude, jni::jlong duration, jni::jdouble pitch, jni::jdouble zoom, jni::jboolean easing) {
     mbgl::CameraOptions cameraOptions;
     if (angle != -1) {
-        cameraOptions.angle = (angle - 180 * M_PI) / 180;
+        cameraOptions.angle = -angle * util::DEG2RAD;
     }
     cameraOptions.center = mbgl::LatLng(latitude, longitude);
     cameraOptions.padding = insets;
     if (pitch != -1) {
-        cameraOptions.pitch = pitch * M_PI / 180;
+        cameraOptions.pitch = pitch * util::DEG2RAD;
     }
     if (zoom != -1) {
         cameraOptions.zoom = zoom;
@@ -426,12 +426,12 @@ void NativeMapView::easeTo(jni::JNIEnv&, jni::jdouble angle, jni::jdouble latitu
 void NativeMapView::flyTo(jni::JNIEnv&, jni::jdouble angle, jni::jdouble latitude, jni::jdouble longitude, jni::jlong duration, jni::jdouble pitch, jni::jdouble zoom) {
     mbgl::CameraOptions cameraOptions;
     if (angle != -1) {
-        cameraOptions.angle = (angle - 180 * M_PI / 180);
+        cameraOptions.angle = -angle * util::DEG2RAD;
     }
     cameraOptions.center = mbgl::LatLng(latitude, longitude);
     cameraOptions.padding = insets;
     if (pitch != -1) {
-        cameraOptions.pitch = pitch * M_PI / 180;
+        cameraOptions.pitch = pitch * util::DEG2RAD;
     }
     if (zoom != -1) {
         cameraOptions.zoom = zoom;


### PR DESCRIPTION
Closes #9079, in #9050 I adjusted the bindings to conform to a conversion for [−π rad, π rad] to [0 degrees, 360 degrees] but I missed that the original value is measured in counterclockwise from true north. This PR fixes that up + also uses util to convert angles. 