### PR TITLE
[android] option to disable camera animation while following position

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
@@ -21,6 +21,7 @@ import android.view.Gravity;
 import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
+import com.mapbox.mapboxsdk.constants.MyLocationTracking;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
 
 import java.util.Arrays;
@@ -60,6 +61,8 @@ public class MapboxMapOptions implements Parcelable {
 
   private double minZoom = MapboxConstants.MINIMUM_ZOOM;
   private double maxZoom = MapboxConstants.MAXIMUM_ZOOM;
+
+  private boolean movementAnimationEnabled = true;
 
   private boolean rotateGesturesEnabled = true;
   private boolean scrollGesturesEnabled = true;
@@ -113,6 +116,8 @@ public class MapboxMapOptions implements Parcelable {
     attributionGravity = in.readInt();
     attributionMargins = in.createIntArray();
     attributionTintColor = in.readInt();
+
+    movementAnimationEnabled = in.readByte() != 0;
 
     minZoom = in.readDouble();
     maxZoom = in.readDouble();
@@ -732,6 +737,15 @@ public class MapboxMapOptions implements Parcelable {
   }
 
   /**
+   * Get camera animation state when using {@link MyLocationTracking#TRACKING_FOLLOW }.
+   *
+   * @return true if smooth transition animation enabled, false otherwise.
+   */
+  public boolean isMovementAnimationEnabled() {
+    return movementAnimationEnabled;
+  }
+
+  /**
    * Get the current configured visibility state for mapbox_compass_icon for a map view.
    *
    * @return Visibility state of the mapbox_compass_icon
@@ -1042,6 +1056,8 @@ public class MapboxMapOptions implements Parcelable {
     dest.writeDouble(minZoom);
     dest.writeDouble(maxZoom);
 
+    dest.writeByte((byte) (movementAnimationEnabled ? 1 : 0));
+
     dest.writeByte((byte) (rotateGesturesEnabled ? 1 : 0));
     dest.writeByte((byte) (scrollGesturesEnabled ? 1 : 0));
     dest.writeByte((byte) (tiltGesturesEnabled ? 1 : 0));
@@ -1115,6 +1131,9 @@ public class MapboxMapOptions implements Parcelable {
       return false;
     }
     if (Double.compare(options.maxZoom, maxZoom) != 0) {
+      return false;
+    }
+    if (movementAnimationEnabled != options.movementAnimationEnabled) {
       return false;
     }
     if (rotateGesturesEnabled != options.rotateGesturesEnabled) {
@@ -1211,6 +1230,7 @@ public class MapboxMapOptions implements Parcelable {
     result = 31 * result + (int) (temp ^ (temp >>> 32));
     temp = Double.doubleToLongBits(maxZoom);
     result = 31 * result + (int) (temp ^ (temp >>> 32));
+    result = 31 * result + (movementAnimationEnabled ? 1 : 0);
     result = 31 * result + (rotateGesturesEnabled ? 1 : 0);
     result = 31 * result + (scrollGesturesEnabled ? 1 : 0);
     result = 31 * result + (tiltGesturesEnabled ? 1 : 0);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
@@ -715,7 +715,7 @@ public class MyLocationView extends View {
       if (mode == MyLocationTracking.TRACKING_NONE) {
         return new MyLocationShowBehavior();
       } else {
-        return new MyLocationTrackingBehavior();
+        return new MyLocationTrackingBehavior(mapboxMap.getMyLocationViewSettings().isMovementAnimationEnabled());
       }
     }
   }
@@ -750,6 +750,12 @@ public class MyLocationView extends View {
   }
 
   private class MyLocationTrackingBehavior extends MyLocationBehavior implements MapboxMap.CancelableCallback {
+
+    private final boolean movementAnimationEnabled;
+
+    public MyLocationTrackingBehavior(boolean movementAnimationEnabled) {
+      this.movementAnimationEnabled = movementAnimationEnabled;
+    }
 
     @Override
     void updateLatLng(@NonNull Location location) {
@@ -791,7 +797,10 @@ public class MyLocationView extends View {
       // disable dismiss of tracking settings, enabled in #onFinish
       mapboxMap.getTrackingSettings().setDismissTrackingModeForCameraPositionChange(false);
       // ease to new camera position with a linear interpolator
-      mapboxMap.easeCamera(CameraUpdateFactory.newCameraPosition(builder.build()), animationDuration, false, this);
+      if (movementAnimationEnabled)
+        mapboxMap.easeCamera(CameraUpdateFactory.newCameraPosition(builder.build()), animationDuration, false, this);
+      else
+        mapboxMap.moveCamera(CameraUpdateFactory.newCameraPosition(builder.build()), this);
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationViewSettings.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationViewSettings.java
@@ -26,6 +26,8 @@ public class MyLocationViewSettings {
 
   private boolean enabled;
 
+  private boolean movementAnimationEnabled;
+
   //
   // Foreground
   //
@@ -88,6 +90,7 @@ public class MyLocationViewSettings {
     setBackgroundTintColor(options.getMyLocationBackgroundTintColor());
     setAccuracyAlpha(options.getMyLocationAccuracyAlpha());
     setAccuracyTintColor(options.getMyLocationAccuracyTintColor());
+    setMovementAnimationEnabled(options.isMovementAnimationEnabled());
   }
 
   /**
@@ -107,6 +110,24 @@ public class MyLocationViewSettings {
   public void setEnabled(boolean enabled) {
     this.enabled = enabled;
     myLocationView.setEnabled(enabled);
+  }
+
+  /**
+   * Check whether smooth camera movement on location change is enabled.
+   *
+   * @return true if is enabled, else otherwise.
+   */
+  public boolean isMovementAnimationEnabled() {
+    return movementAnimationEnabled;
+  }
+
+  /**
+   * Set whether smooth camera movement on location change (while using {@link MyLocationTracking#TRACKING_FOLLOW }) should be enabled or not.
+   *
+   * @param movementAnimationEnabled true (default value) if animation should be enabled, else otherwise.
+   */
+  public void setMovementAnimationEnabled(boolean movementAnimationEnabled) {
+    this.movementAnimationEnabled = movementAnimationEnabled;
   }
 
   /**


### PR DESCRIPTION
Hi guys,
when tracking user's location smooth camera movement is applied, but we noticed, that it eats up a lot of resources and drains battery a bit. That's why we figured it would be nice if there was an option to disable those animations and just jump straight to user's new location. I hope my changes fit your naming conventions and are in the right place.
By the way, could you give me some insight into why those camera animations are so heavy on resources?