### PR TITLE
Prevent deadlock in self closing actors

### DIFF
--- a/include/mbgl/actor/mailbox.hpp
+++ b/include/mbgl/actor/mailbox.hpp
@@ -23,7 +23,7 @@ public:
 private:
     Scheduler& scheduler;
 
-    std::mutex receivingMutex;
+    std::recursive_mutex receivingMutex;
     std::mutex pushingMutex;
 
     bool closed { false };


### PR DESCRIPTION
Split off from #9100

Prevents deadlocking in `Mailbox::close()` when an actor releases a smart pointer to itself in a callback.