### PR TITLE
Thread safe Default File Source

### DIFF
--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -140,9 +140,9 @@ public:
     class Impl;
 
 private:
+    // Shared so destruction is done on this thread
+    const std::shared_ptr<FileSource> assetFileSource;
     const std::unique_ptr<util::Thread<Impl>> thread;
-    const std::unique_ptr<FileSource> assetFileSource;
-    const std::unique_ptr<FileSource> localFileSource;
     std::string cachedBaseURL = mbgl::util::API_BASE_URL;
     std::string cachedAccessToken;
 };

--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -5,6 +5,7 @@
 #include <mbgl/util/constants.hpp>
 
 #include <vector>
+#include <mutex>
 
 namespace mbgl {
 
@@ -34,10 +35,10 @@ public:
     }
 
     void setAPIBaseURL(const std::string&);
-    std::string getAPIBaseURL() const;
+    std::string getAPIBaseURL();
 
     void setAccessToken(const std::string&);
-    std::string getAccessToken() const;
+    std::string getAccessToken();
 
     void setResourceTransform(std::function<std::string(Resource::Kind, std::string&&)>);
 
@@ -143,7 +144,11 @@ private:
     // Shared so destruction is done on this thread
     const std::shared_ptr<FileSource> assetFileSource;
     const std::unique_ptr<util::Thread<Impl>> thread;
+
+    std::mutex cachedBaseURLMutex;
     std::string cachedBaseURL = mbgl::util::API_BASE_URL;
+
+    std::mutex cachedAccessTokenMutex;
     std::string cachedAccessToken;
 };
 

--- a/platform/default/default_file_source.cpp
+++ b/platform/default/default_file_source.cpp
@@ -197,19 +197,29 @@ DefaultFileSource::~DefaultFileSource() = default;
 
 void DefaultFileSource::setAPIBaseURL(const std::string& baseURL) {
     thread->invoke(&Impl::setAPIBaseURL, baseURL);
-    cachedBaseURL = baseURL;
+
+    {
+        std::lock_guard<std::mutex> lock(cachedBaseURLMutex);
+        cachedBaseURL = baseURL;
+    }
 }
 
-std::string DefaultFileSource::getAPIBaseURL() const {
+std::string DefaultFileSource::getAPIBaseURL() {
+    std::lock_guard<std::mutex> lock(cachedBaseURLMutex);
     return cachedBaseURL;
 }
 
 void DefaultFileSource::setAccessToken(const std::string& accessToken) {
     thread->invoke(&Impl::setAccessToken, accessToken);
-    cachedAccessToken = accessToken;
+
+    {
+        std::lock_guard<std::mutex> lock(cachedAccessTokenMutex);
+        cachedAccessToken = accessToken;
+    }
 }
 
-std::string DefaultFileSource::getAccessToken() const {
+std::string DefaultFileSource::getAccessToken() {
+    std::lock_guard<std::mutex> lock(cachedAccessTokenMutex);
     return cachedAccessToken;
 }
 


### PR DESCRIPTION
Makes sure that DefaultFileSource can be used concurrently. Enables us to use the DefaultFileSource from multiple threads fro a-sync rendering #8820 