### PR TITLE
Check source usage before removal

### DIFF
--- a/include/mbgl/style/layer.hpp
+++ b/include/mbgl/style/layer.hpp
@@ -6,8 +6,10 @@
 #include <mbgl/style/layer_type.hpp>
 #include <mbgl/style/types.hpp>
 
+#include <cassert>
 #include <memory>
 #include <string>
+#include <stdexcept>
 
 namespace mbgl {
 namespace style {
@@ -89,6 +91,11 @@ public:
         case LayerType::FillExtrusion:
             return std::forward<V>(visitor)(*as<FillExtrusionLayer>());
         }
+
+
+        // Not reachable, but placate GCC.
+        assert(false);
+        throw new std::runtime_error("unknown layer type");
     }
 
     LayerType getType() const;

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RuntimeStyleTests.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RuntimeStyleTests.java
@@ -12,6 +12,7 @@ import com.mapbox.mapboxsdk.style.layers.CannotAddLayerException;
 import com.mapbox.mapboxsdk.style.layers.CircleLayer;
 import com.mapbox.mapboxsdk.style.layers.FillLayer;
 import com.mapbox.mapboxsdk.style.layers.Layer;
+import com.mapbox.mapboxsdk.style.layers.LineLayer;
 import com.mapbox.mapboxsdk.style.layers.Property;
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.mapboxsdk.style.sources.CannotAddSourceException;
@@ -221,6 +222,23 @@ public class RuntimeStyleTests extends BaseActivityTest {
     assertNull(source.getUrl());
     source.setUrl(new URL("http://mapbox.com/my-file.json"));
     assertEquals("http://mapbox.com/my-file.json", source.getUrl());
+  }
+
+  @Test
+  public void testRemoveSourceInUse() {
+    validateTestSetup();
+
+    onView(withId(R.id.mapView)).perform(new BaseViewAction() {
+
+      @Override
+      public void perform(UiController uiController, View view) {
+        mapboxMap.addSource(new VectorSource("my-source", "mapbox://mapbox.mapbox-terrain-v2"));
+        mapboxMap.addLayer(new LineLayer("my-layer", "my-source"));
+        mapboxMap.removeSource("my-source");
+        assertNotNull(mapboxMap.getSource("my-source"));
+      }
+
+    });
   }
 
   /**

--- a/platform/darwin/test/MGLStyleTests.mm
+++ b/platform/darwin/test/MGLStyleTests.mm
@@ -240,6 +240,22 @@
     XCTAssertTrue([[self.style sourceWithIdentifier:shapeSource.identifier] isMemberOfClass:[MGLVectorSource class]]);
 }
 
+- (void)testRemovingSourceInUse {
+    // Add a raster source
+    MGLRasterSource *rasterSource = [[MGLRasterSource alloc] initWithIdentifier:@"some-identifier" tileURLTemplates:@[] options:nil];
+    [self.style addSource:rasterSource];
+    
+    // Add a layer using it
+    MGLFillStyleLayer *fillLayer = [[MGLFillStyleLayer alloc] initWithIdentifier:@"fillLayer" source:rasterSource];
+    [self.style addLayer:fillLayer];
+
+    // Attempt to remove the raster source
+    [self.style removeSource:rasterSource];
+    
+    // Ensure it is still there
+    XCTAssertTrue([[self.style sourceWithIdentifier:rasterSource.identifier] isMemberOfClass:[MGLRasterSource class]]);
+}
+
 - (void)testLayers {
     NSArray<MGLStyleLayer *> *initialLayers = self.style.layers;
     if ([initialLayers.firstObject.identifier isEqualToString:@"com.mapbox.annotations.points"]) {

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -158,7 +158,30 @@ void Style::addSource(std::unique_ptr<Source> source) {
     sources.emplace_back(std::move(source));
 }
 
+struct SourceIdUsageEvaluator {
+    const std::string& sourceId;
+
+    bool operator()(BackgroundLayer&) { return false; }
+    bool operator()(CustomLayer&) { return false; }
+
+    template <class LayerType>
+    bool operator()(LayerType& layer) {
+        return layer.getSourceID() == sourceId;
+    }
+};
+
 std::unique_ptr<Source> Style::removeSource(const std::string& id) {
+    // Check if source is in use
+    SourceIdUsageEvaluator sourceIdEvaluator {id};
+    auto layerIt = std::find_if(layers.begin(), layers.end(), [&](const auto& layer) {
+        return layer->accept(sourceIdEvaluator);
+    });
+
+    if (layerIt != layers.end()) {
+        Log::Warning(Event::General, "Source '%s' is in use, cannot remove", id.c_str());
+        return nullptr;
+    }
+
     auto it = std::find_if(sources.begin(), sources.end(), [&](const auto& source) {
         return source->getID() == id;
     });


### PR DESCRIPTION
Closes #9121

I opted to log a warning instead of throwing an exception. I can see it going both ways though.