### PR TITLE
Revert "[core] Factor timePoint initialization"

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -226,9 +226,7 @@ void Map::Impl::render(View& view) {
         return;
     }
 
-    TimePoint timePoint = mode == MapMode::Continuous
-        ? Clock::now()
-        : Clock::time_point::max();
+    TimePoint timePoint = Clock::now();
 
     transform.updateTransitions(timePoint);
 

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -306,13 +306,13 @@ void Style::update(const UpdateParameters& parameters) {
     const bool zoomChanged = zoomHistory.update(parameters.transformState.getZoom(), parameters.timePoint);
 
     const TransitionParameters transitionParameters {
-        parameters.timePoint,
+        parameters.mode == MapMode::Continuous ? parameters.timePoint : Clock::time_point::max(),
         parameters.mode == MapMode::Continuous ? transitionOptions : TransitionOptions()
     };
 
     const PropertyEvaluationParameters evaluationParameters {
         zoomHistory,
-        parameters.timePoint,
+        parameters.mode == MapMode::Continuous ? parameters.timePoint : Clock::time_point::max(),
         parameters.mode == MapMode::Continuous ? util::DEFAULT_FADE_DURATION : Duration::zero()
     };
 


### PR DESCRIPTION
This reverts commit 3790caafa3c98706c5cf0618c8aec592b2780bba.

From initial investigations, `timePoint` is used elsewhere other than in `TransitionParameters` and `PropertyEvaluationParameters`, and being its value `Clock::time_point::max()` causes a stall in the styling mechanism in some cases. This probably needs further investigation.

Fixes #9106.

/cc @bsudekum 