### PR TITLE
Make node release binaries debuggable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ matrix:
       dist: trusty
       language: node
       compiler: "egl-node4-clang39-release"
-      env: BUILDTYPE=Release _CXX=clang++-3.9 _CC=clang-3.9 WITH_EGL=1
+      env: BUILDTYPE=RelWithDebInfo _CXX=clang++-3.9 _CC=clang-3.9 WITH_EGL=1
       addons: *clang39
       before_script:
         # fglrx causes the GLX extension to be unavailable
@@ -147,7 +147,7 @@ matrix:
       dist: trusty
       language: node
       compiler: "egl-node6-clang39-release"
-      env: BUILDTYPE=Release _CXX=clang++-3.9 _CC=clang-3.9 WITH_EGL=1
+      env: BUILDTYPE=RelWithDebInfo _CXX=clang++-3.9 _CC=clang-3.9 WITH_EGL=1
       addons: *clang39
       before_script:
         # fglrx causes the GLX extension to be unavailable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ if(APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=unused-command-line-argument")
 endif()
 set(CMAKE_CXX_FLAGS_RELEASE "-Os -DNDEBUG")
+SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -DNDEBUG")
 
 if(CMAKE_COMPILER_IS_GNUCXX)
     # https://svn.boost.org/trac/boost/ticket/9240

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,10 @@ export BUILDTYPE ?= Debug
 export WITH_CXX11ABI ?= $(shell scripts/check-cxx11abi.sh)
 
 ifeq ($(BUILDTYPE), Release)
+else ifeq ($(BUILDTYPE), RelWithDebInfo)
 else ifeq ($(BUILDTYPE), Debug)
 else
-  $(error BUILDTYPE must be Debug or Release)
+  $(error BUILDTYPE must be Debug, Release or RelWithDebInfo)
 endif
 
 buildtype := $(shell echo "$(BUILDTYPE)" | tr "[A-Z]" "[a-z]")

--- a/platform/node/bitrise.yml
+++ b/platform/node/bitrise.yml
@@ -64,7 +64,7 @@ workflows:
             brew install cmake awscli node@4 node@6
             brew link node@4 --force
             gem install xcpretty --no-rdoc --no-ri
-            export BUILDTYPE=Release
+            export BUILDTYPE=RelWithDebInfo
             export PUBLISH=true
             make test-node && ./platform/node/scripts/after_success.sh
             brew unlink node@4

--- a/platform/node/scripts/after_success.sh
+++ b/platform/node/scripts/after_success.sh
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 if [[ -n ${PUBLISH:-} ]]; then
-    if [[ "${BUILDTYPE}" == "Release" ]]; then
+    if [[ "${BUILDTYPE}" == "RelWithDebInfo" ]]; then
         ./node_modules/.bin/node-pre-gyp package publish info
     else
         ./node_modules/.bin/node-pre-gyp package publish info --debug

--- a/platform/node/scripts/after_success.sh
+++ b/platform/node/scripts/after_success.sh
@@ -6,7 +6,10 @@ set -o pipefail
 if [[ -n ${PUBLISH:-} ]]; then
     if [[ "${BUILDTYPE}" == "RelWithDebInfo" ]]; then
         ./node_modules/.bin/node-pre-gyp package publish info
-    else
+    elif [[ "${BUILDTYPE}" == "Debug" ]]; then
         ./node_modules/.bin/node-pre-gyp package publish info --debug
+    else
+        echo "error: must provide either Debug or RelWithDebInfo for BUILDTYPE"
+        exit 1
     fi
 fi


### PR DESCRIPTION
This change makes Node release binaries a little bit more debuggable. Now when there is a crash in production, we should get more information including line numbers. There is no speed implications here, the only downside is an increase in binary size (currently, release binaries are ~2mb).

/cc @tmpsantos @brunoabinader 