### PR TITLE
[core] Make TransformState LatLngBounds optional

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -102,8 +102,8 @@ public:
     void resetZoom();
 
     // Bounds
-    void setLatLngBounds(const LatLngBounds&);
-    LatLngBounds getLatLngBounds() const;
+    void setLatLngBounds(optional<LatLngBounds>);
+    optional<LatLngBounds> getLatLngBounds() const;
     void setMinZoom(double);
     double getMinZoom() const;
     void setMaxZoom(double);

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -615,11 +615,11 @@ void Map::resetZoom() {
 
 #pragma mark - Bounds
 
-LatLngBounds Map::getLatLngBounds() const {
+optional<LatLngBounds> Map::getLatLngBounds() const {
     return impl->transform.getState().getLatLngBounds();
 }
 
-void Map::setLatLngBounds(const LatLngBounds& bounds) {
+void Map::setLatLngBounds(optional<LatLngBounds> bounds) {
     impl->cameraMutated = true;
     impl->transform.setLatLngBounds(bounds);
     impl->onUpdate(Update::Repaint);

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -406,10 +406,11 @@ double Transform::getZoom() const {
 
 #pragma mark - Bounds
 
-void Transform::setLatLngBounds(const LatLngBounds& bounds) {
-    if (bounds.valid()) {
-        state.setLatLngBounds(bounds);
+void Transform::setLatLngBounds(optional<LatLngBounds> bounds) {
+    if (bounds && !bounds->valid()) {
+        throw std::runtime_error("failed to set bounds: bounds are invalid");
     }
+    state.setLatLngBounds(bounds);
 }
 
 void Transform::setMinZoom(const double minZoom) {

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -56,7 +56,7 @@ public:
 
     // Bounds
 
-    void setLatLngBounds(const LatLngBounds&);
+    void setLatLngBounds(optional<LatLngBounds>);
     void setMinZoom(double);
     void setMaxZoom(double);
     void setMinPitch(double);

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -142,12 +142,14 @@ double TransformState::getZoomFraction() const {
 
 #pragma mark - Bounds
 
-void TransformState::setLatLngBounds(const LatLngBounds& bounds_) {
-    bounds = bounds_;
-    setLatLngZoom(getLatLng(LatLng::Unwrapped), getZoom());
+void TransformState::setLatLngBounds(optional<LatLngBounds> bounds_) {
+    if (bounds_ != bounds) {
+        bounds = bounds_;
+        setLatLngZoom(getLatLng(LatLng::Unwrapped), getZoom());
+    }
 }
 
-LatLngBounds TransformState::getLatLngBounds() const {
+optional<LatLngBounds> TransformState::getLatLngBounds() const {
     return bounds;
 }
 
@@ -350,8 +352,11 @@ void TransformState::moveLatLng(const LatLng& latLng, const ScreenCoordinate& an
     setLatLngZoom(Projection::unproject(centerCoord + latLngCoord - anchorCoord, scale), getZoom());
 }
 
-void TransformState::setLatLngZoom(const LatLng &latLng, double zoom) {
-    const LatLng constrained = bounds.constrain(latLng);
+void TransformState::setLatLngZoom(const LatLng& latLng, double zoom) {
+    LatLng constrained = latLng;
+    if (bounds) {
+        constrained = bounds->constrain(latLng);
+    }
 
     double newScale = zoomScale(zoom);
     const double newWorldSize = newScale * util::tileSize;

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/geometry.hpp>
 #include <mbgl/util/constants.hpp>
+#include <mbgl/util/optional.hpp>
 #include <mbgl/util/projection.hpp>
 #include <mbgl/util/mat4.hpp>
 #include <mbgl/util/size.hpp>
@@ -50,8 +51,8 @@ public:
     double getZoomFraction() const;
 
     // Bounds
-    void setLatLngBounds(const LatLngBounds&);
-    LatLngBounds getLatLngBounds() const;
+    void setLatLngBounds(optional<LatLngBounds>);
+    optional<LatLngBounds> getLatLngBounds() const;
     void setMinZoom(double);
     double getMinZoom() const;
     void setMaxZoom(double);
@@ -89,7 +90,7 @@ private:
     bool rotatedNorth() const;
     void constrain(double& scale, double& x, double& y) const;
 
-    LatLngBounds bounds = LatLngBounds::world();
+    optional<LatLngBounds> bounds;
 
     // Limit the amount of zooming possible on the map.
     double min_scale = std::pow(2, 0);

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -537,12 +537,16 @@ TEST(Transform, LatLngBounds) {
     transform.setLatLngZoom({ 0, 0 }, transform.getState().getMaxZoom());
 
     // Default bounds.
-    ASSERT_EQ(transform.getState().getLatLngBounds(), LatLngBounds::world());
+    ASSERT_EQ(transform.getState().getLatLngBounds(), optional<LatLngBounds> {});
     ASSERT_EQ(transform.getLatLng(), nullIsland);
 
     // Invalid bounds.
-    transform.setLatLngBounds(LatLngBounds::empty());
-    ASSERT_EQ(transform.getState().getLatLngBounds(), LatLngBounds::world());
+    try {
+        transform.setLatLngBounds(LatLngBounds::empty());
+        ASSERT_TRUE(false) << "Should throw";
+    } catch (...) {
+        ASSERT_EQ(transform.getState().getLatLngBounds(), optional<LatLngBounds> {});
+    }
 
     transform.setLatLng(sanFrancisco);
     ASSERT_EQ(transform.getLatLng(), sanFrancisco);


### PR DESCRIPTION
Have `TransformState` bounds empty by default - bypassing the boundary check if not present in `TransformState::setLatLngBounds`. This was causing issues when e.g. panning over the dateline.

Fixes #8951.

/cc @friedbunny - can you please verify this on iOS?