### PR TITLE
[android] Custom location engine activity null check

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/userlocation/MockLocationEngine.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/userlocation/MockLocationEngine.java
@@ -63,7 +63,9 @@ public class MockLocationEngine extends LocationEngine {
 
   @Override
   public void removeLocationUpdates() {
-    handler.removeCallbacksAndMessages(null);
+    if (handler != null) {
+      handler.removeCallbacksAndMessages(null);
+    }
   }
 
   private Location getNextLocation() {


### PR DESCRIPTION
- Prevents `NullPointerException` in `CustomLocationEngineActivity`.

cc/ @tobrun 