### PR TITLE
Fix crash in runtime style ui tests

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RuntimeStyleTests.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RuntimeStyleTests.java
@@ -199,29 +199,54 @@ public class RuntimeStyleTests extends BaseActivityTest {
   public void testVectorSourceUrlGetter() {
     validateTestSetup();
 
-    VectorSource source = new VectorSource("my-source", "mapbox://mapbox.mapbox-terrain-v2");
-    mapboxMap.addSource(source);
-    assertEquals("mapbox://mapbox.mapbox-terrain-v2", source.getUrl());
+    onView(withId(R.id.mapView)).perform(new BaseViewAction() {
+
+      @Override
+      public void perform(UiController uiController, View view) {
+        VectorSource source = new VectorSource("my-source", "mapbox://mapbox.mapbox-terrain-v2");
+        mapboxMap.addSource(source);
+        assertEquals("mapbox://mapbox.mapbox-terrain-v2", source.getUrl());
+      }
+
+    });
   }
 
   @Test
   public void testRasterSourceUrlGetter() {
     validateTestSetup();
 
-    RasterSource source = new RasterSource("my-source", "mapbox://mapbox.mapbox-terrain-v2");
-    mapboxMap.addSource(source);
-    assertEquals("mapbox://mapbox.mapbox-terrain-v2", source.getUrl());
+    onView(withId(R.id.mapView)).perform(new BaseViewAction() {
+
+      @Override
+      public void perform(UiController uiController, View view) {
+        RasterSource source = new RasterSource("my-source", "mapbox://mapbox.mapbox-terrain-v2");
+        mapboxMap.addSource(source);
+        assertEquals("mapbox://mapbox.mapbox-terrain-v2", source.getUrl());
+      }
+
+    });
   }
 
   @Test
-  public void testGeoJsonSourceUrlGetter() throws MalformedURLException {
+  public void testGeoJsonSourceUrlGetter() {
     validateTestSetup();
 
-    GeoJsonSource source = new GeoJsonSource("my-source");
-    mapboxMap.addSource(source);
-    assertNull(source.getUrl());
-    source.setUrl(new URL("http://mapbox.com/my-file.json"));
-    assertEquals("http://mapbox.com/my-file.json", source.getUrl());
+    onView(withId(R.id.mapView)).perform(new BaseViewAction() {
+
+      @Override
+      public void perform(UiController uiController, View view) {
+        GeoJsonSource source = new GeoJsonSource("my-source");
+        mapboxMap.addSource(source);
+        assertNull(source.getUrl());
+        try {
+          source.setUrl(new URL("http://mapbox.com/my-file.json"));
+        } catch (MalformedURLException err) {
+          assertTrue(err.getMessage(), false);
+        }
+        assertEquals("http://mapbox.com/my-file.json", source.getUrl());
+      }
+
+    });
   }
 
   @Test


### PR DESCRIPTION
On master the `RuntimeStyleTests` test suite is currently crashing after run. `testRemoveSourceInUse` is marked as failed, but actually some other test cases in that suite are to blame. 

Crash dump:

```
********** Crash dump: **********
Build fingerprint: 'google/sailfish/sailfish:7.1.2/N2G47O/3852959:user/release-keys'
pid: 12043, tid: 12070, name: DefaultFileSour  >>> com.mapbox.mapboxsdk.testapp <<<
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x20
Stack frame #00 pc 00047676  /system/lib/libc.so (pthread_mutex_lock+1)
Stack frame #01 pc 0061f0cd  /data/app/com.mapbox.mapboxsdk.testapp-2/lib/arm/libmapbox-gl.so: Routine std::__ndk1::__libcpp_mutex_lock(pthread_mutex_t*) at /Volumes/Android/buildbot/src/android/ndk-r14-release/external/libcxx/include/__threading_support:65
Stack frame #02 pc 002c5d43  /data/app/com.mapbox.mapboxsdk.testapp-2/lib/arm/libmapbox-gl.so: Routine lock_guard at /Users/ivo/Library/Android/sdk/ndk-bundle/sources/cxx-stl/llvm-libc++/include/__mutex_base:91
Stack frame #03 pc 002c5cb7  /data/app/com.mapbox.mapboxsdk.testapp-2/lib/arm/libmapbox-gl.so: Routine mbgl::util::RunLoop::push(std::__ndk1::shared_ptr<mbgl::WorkTask>) at /Users/ivo/git/mapbox-gl-native/platform/android/src/run_loop.cpp:216
Stack frame #04 pc 002e32c7  /data/app/com.mapbox.mapboxsdk.testapp-2/lib/arm/libmapbox-gl.so: Routine _ZN4mbgl4util7RunLoop6invokeIRKZNS_6detail27packageArgumentsAndCallbackINSt6__ndk15tupleIJOPZNS_17DefaultFileSource7requestERKNS_8ResourceENS5_8functionIFvNS_8ResponseEEEEE18DefaultFileRequestRS8_RSE_EEEJLj0ELj1EEEEDaNS5_10shared_ptrINS5_6atomicIbEEEEOT_NS5_16integer_sequenceIjJXspT0_EEEEEUlDpOT_E_JSC_EEEvSR_DpOT0_ at /Users/ivo/git/mapbox-gl-native/platform/android/MapboxGLAndroidSDK/.externalNativeBuild/cmake/debug/armeabi-v7a/../../../../../../../include/mbgl/util/run_loop.hpp:54
Stack frame #05 pc 002e3251  /data/app/com.mapbox.mapboxsdk.testapp-2/lib/arm/libmapbox-gl.so: Routine operator()<mbgl::Response> at /Users/ivo/git/mapbox-gl-native/platform/android/MapboxGLAndroidSDK/.externalNativeBuild/cmake/debug/armeabi-v7a/../../../../../../../include/mbgl/util/work_task_impl.hpp:86 (discriminator 1)
Stack frame #06 pc 002e31cb  /data/app/com.mapbox.mapboxsdk.testapp-2/lib/arm/libmapbox-gl.so: Routine _ZNSt6__ndk18__invokeIRZN4mbgl6detail27packageArgumentsAndCallbackINS_5tupleIJOPZNS1_17DefaultFileSource7requestERKNS1_8ResourceENS_8functionIFvNS1_8ResponseEEEEE18DefaultFileRequestRS6_RSC_EEEJLj0ELj1EEEEDaNS_10shared_ptrINS_6atomicIbEEEEOT_NS_16integer_sequenceIjJXspT0_EEEEEUlDpOT_E0_JSA_EEEDTclclsr3std6__ndk1E7forwardISO_Efp_Espclsr3std6__ndk1E7forwardIT0_Efp0_EEESP_DpOSX_ at /Users/ivo/Library/Android/sdk/ndk-bundle/sources/cxx-stl/llvm-libc++/include/type_traits:4287 (discriminator 2)
Stack frame #07 pc 002e3127  /data/app/com.mapbox.mapboxsdk.testapp-2/lib/arm/libmapbox-gl.so: Routine _ZNSt6__ndk110__function6__funcIZN4mbgl6detail27packageArgumentsAndCallbackINS_5tupleIJOPZNS2_17DefaultFileSource7requestERKNS2_8ResourceENS_8functionIFvNS2_8ResponseEEEEE18DefaultFileRequestRS7_RSD_EEEJLj0ELj1EEEEDaNS_10shared_ptrINS_6atomicIbEEEEOT_NS_16integer_sequenceIjJXspT0_EEEEEUlDpOT_E0_NS_9allocatorISW_EESC_EclEOSB_ at /Users/ivo/Library/Android/sdk/ndk-bundle/sources/cxx-stl/llvm-libc++/include/functional:1533 (discriminator 2)
Stack frame #08 pc 00196f27  /data/app/com.mapbox.mapboxsdk.testapp-2/lib/arm/libmapbox-gl.so: Routine std::__ndk1::function<void (std::exception_ptr)>::operator()(std::exception_ptr) const at /Users/ivo/Library/Android/sdk/ndk-bundle/sources/cxx-stl/llvm-libc++/include/functional:1896 (discriminator 1)
Stack frame #09 pc 002e1555  /data/app/com.mapbox.mapboxsdk.testapp-2/lib/arm/libmapbox-gl.so: Routine mbgl::DefaultFileSource::Impl::request(mbgl::AsyncRequest*, mbgl::Resource, std::__ndk1::function<void (mbgl::Response)>) at /Users/ivo/git/mapbox-gl-native/platform/default/default_file_source.cpp:137 (discriminator 2)
Stack frame #10 pc 002e2887  /data/app/com.mapbox.mapboxsdk.testapp-2/lib/arm/libmapbox-gl.so: Routine operator()<DefaultFileRequest *, mbgl::Resource, (lambda at ../../../../../../../include/mbgl/util/work_task_impl.hpp:84:15)> at /Users/ivo/git/mapbox-gl-native/platform/android/MapboxGLAndroidSDK/.externalNativeBuild/cmake/debug/armeabi-v7a/../../../../../../../src/mbgl/util/thread.hpp:102 (discriminator 4)
Stack frame #11 pc 002e27e1  /data/app/com.mapbox.mapboxsdk.testapp-2/lib/arm/libmapbox-gl.so: Routine _ZN4mbgl12WorkTaskImplIZNS_4util6ThreadINS_17DefaultFileSource4ImplEE4bindIMS4_FvPNS_12AsyncRequestENS_8ResourceENSt6__ndk18functionIFvNS_8ResponseEEEEEEEDaT_EUlDpOT_E_NSA_5tupleIJPZNS3_7requestERKS9_SE_E18DefaultFileRequestS9_ZNS_6detail27packageArgumentsAndCallbackINSN_IJOSR_RS9_RSE_EEEJLj0ELj1EEEEDaNSA_10shared_ptrINSA_6atomicIbEEEEOSI_NSA_16integer_sequenceIjJXspT0_EEEEEUlSL_E0_EEEE6invokeIJLj0ELj1ELj2EEEEvNS14_IjJXspT_EEEE at /Users/ivo/git/mapbox-gl-native/platform/android/MapboxGLAndroidSDK/.externalNativeBuild/cmake/debug/armeabi-v7a/../../../../../../../include/mbgl/util/work_task_impl.hpp:43 (discriminator 9)
Stack frame #12 pc 002e2757  /data/app/com.mapbox.mapboxsdk.testapp-2/lib/arm/libmapbox-gl.so: Routine _ZN4mbgl12WorkTaskImplIZNS_4util6ThreadINS_17DefaultFileSource4ImplEE4bindIMS4_FvPNS_12AsyncRequestENS_8ResourceENSt6__ndk18functionIFvNS_8ResponseEEEEEEEDaT_EUlDpOT_E_NSA_5tupleIJPZNS3_7requestERKS9_SE_E18DefaultFileRequestS9_ZNS_6detail27packageArgumentsAndCallbackINSN_IJOSR_RS9_RSE_EEEJLj0ELj1EEEEDaNSA_10shared_ptrINSA_6atomicIbEEEEOSI_NSA_16integer_sequenceIjJXspT0_EEEEEUlSL_E0_EEEEclEv at /Users/ivo/git/mapbox-gl-native/platform/android/MapboxGLAndroidSDK/.externalNativeBuild/cmake/debug/armeabi-v7a/../../../../../../../include/mbgl/util/work_task_impl.hpp:23
Stack frame #13 pc 002c616d  /data/app/com.mapbox.mapboxsdk.testapp-2/lib/arm/libmapbox-gl.so: Routine mbgl::util::RunLoop::process() at /Users/ivo/git/mapbox-gl-native/platform/android/MapboxGLAndroidSDK/.externalNativeBuild/cmake/debug/armeabi-v7a/../../../../../../../include/mbgl/util/run_loop.hpp:100 (discriminator 1)
Stack frame #14 pc 002c5fe7  /data/app/com.mapbox.mapboxsdk.testapp-2/lib/arm/libmapbox-gl.so: Routine mbgl::util::RunLoop::run() at /Users/ivo/git/mapbox-gl-native/platform/android/src/run_loop.cpp:229
Stack frame #15 pc 002dbbef  /data/app/com.mapbox.mapboxsdk.testapp-2/lib/arm/libmapbox-gl.so: Routine void mbgl::util::Thread<mbgl::DefaultFileSource::Impl>::run<std::__ndk1::tuple<std::__ndk1::shared_ptr<mbgl::FileSource> const&, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&, unsigned long long&>, 0u, 1u, 2u>(std::__ndk1::tuple<std::__ndk1::shared_ptr<mbgl::FileSource> const&, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&, unsigned long long&>&&, std::__ndk1::integer_sequence<unsigned int, 0u, 1u, 2u>) at /Users/ivo/git/mapbox-gl-native/platform/android/MapboxGLAndroidSDK/.externalNativeBuild/cmake/debug/armeabi-v7a/../../../../../../../src/mbgl/util/thread.hpp:151
Stack frame #16 pc 002dbb2d  /data/app/com.mapbox.mapboxsdk.testapp-2/lib/arm/libmapbox-gl.so: Routine operator() at /Users/ivo/git/mapbox-gl-native/platform/android/MapboxGLAndroidSDK/.externalNativeBuild/cmake/debug/armeabi-v7a/../../../../../../../src/mbgl/util/thread.hpp:135 (discriminator 1)
Stack frame #17 pc 002dba27  /data/app/com.mapbox.mapboxsdk.testapp-2/lib/arm/libmapbox-gl.so: Routine _ZNSt6__ndk18__invokeIZN4mbgl4util6ThreadINS1_17DefaultFileSource4ImplEEC1IJRKNS_10shared_ptrINS1_10FileSourceEEERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEERyEEERKNS2_13ThreadContextEDpOT_EUlvE_JEEEDTclclsr3std6__ndk1E7forwardIT_Efp_Espclsr3std6__ndk1E7forwardIT0_Efp0_EEEOST_DpOSU_ at /Users/ivo/Library/Android/sdk/ndk-bundle/sources/cxx-stl/llvm-libc++/include/type_traits:4287 (discriminator 1)
Stack frame #18 pc 00047093  /system/lib/libc.so (_ZL15__pthread_startPv+22)
Stack frame #19 pc 00019bdd  /system/lib/libc.so (__start_thread+6)
```