### PR TITLE
[core] Disable scissor test when using offscreen texture

### DIFF
--- a/include/mbgl/map/backend.hpp
+++ b/include/mbgl/map/backend.hpp
@@ -61,7 +61,7 @@ protected:
     // Tells the renderer that OpenGL state has already been set by the windowing toolkit.
     // It sets the internal assumed state to the supplied values.
     void assumeFramebufferBinding(gl::FramebufferID fbo);
-    void assumeViewportSize(const Size&);
+    void assumeViewport(int32_t x, int32_t y, const Size&);
 
     // Returns true when assumed framebuffer binding hasn't changed from the implicit binding.
     bool implicitFramebufferBound();
@@ -69,7 +69,7 @@ protected:
     // Triggers an OpenGL state update if the internal assumed state doesn't match the
     // supplied values.
     void setFramebufferBinding(gl::FramebufferID fbo);
-    void setViewportSize(const Size&);
+    void setViewport(int32_t x, int32_t y, const Size&);
 
 protected:
     std::unique_ptr<gl::Context> context;

--- a/include/mbgl/map/backend.hpp
+++ b/include/mbgl/map/backend.hpp
@@ -62,6 +62,7 @@ protected:
     // It sets the internal assumed state to the supplied values.
     void assumeFramebufferBinding(gl::FramebufferID fbo);
     void assumeViewport(int32_t x, int32_t y, const Size&);
+    void assumeScissorTest(bool);
 
     // Returns true when assumed framebuffer binding hasn't changed from the implicit binding.
     bool implicitFramebufferBound();
@@ -70,6 +71,7 @@ protected:
     // supplied values.
     void setFramebufferBinding(gl::FramebufferID fbo);
     void setViewport(int32_t x, int32_t y, const Size&);
+    void setScissorTest(bool);
 
 protected:
     std::unique_ptr<gl::Context> context;

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -109,7 +109,7 @@ NativeMapView::~NativeMapView() {
  */
 void NativeMapView::bind() {
     setFramebufferBinding(0);
-    setViewportSize(getFramebufferSize());
+    setViewport(0, 0, getFramebufferSize());
 }
 
 /**
@@ -292,7 +292,7 @@ void NativeMapView::render(jni::JNIEnv& env) {
     BackendScope guard(*this);
 
     if (framebufferSizeChanged) {
-        setViewportSize(getFramebufferSize());
+        setViewport(0, 0, getFramebufferSize());
         framebufferSizeChanged = false;
     }
 
@@ -1430,7 +1430,7 @@ mbgl::Size NativeMapView::getFramebufferSize() const {
 
 void NativeMapView::updateAssumedState() {
     assumeFramebufferBinding(0);
-    assumeViewportSize(getFramebufferSize());
+    assumeViewport(0, 0, getFramebufferSize());
 }
 
 void NativeMapView::updateFps() {

--- a/platform/default/mbgl/gl/offscreen_view.cpp
+++ b/platform/default/mbgl/gl/offscreen_view.cpp
@@ -24,6 +24,7 @@ public:
             context.bindFramebuffer = framebuffer->framebuffer;
         }
 
+        context.scissorTest = false;
         context.viewport = { 0, 0, size };
     }
 

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -136,12 +136,12 @@ void GLFWView::setMap(mbgl::Map *map_) {
 
 void GLFWView::updateAssumedState() {
     assumeFramebufferBinding(0);
-    assumeViewportSize(getFramebufferSize());
+    assumeViewport(0, 0, getFramebufferSize());
 }
 
 void GLFWView::bind() {
     setFramebufferBinding(0);
-    setViewportSize(getFramebufferSize());
+    setViewport(0, 0, getFramebufferSize());
 }
 
 void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, int mods) {

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -5439,7 +5439,7 @@ public:
     /// context state with the anticipated values.
     void updateAssumedState() override {
         assumeFramebufferBinding(ImplicitFramebufferBinding);
-        assumeViewportSize(nativeView.framebufferSize);
+        assumeViewport(0, 0, nativeView.framebufferSize);
     }
 
     void bind() override {
@@ -5452,7 +5452,7 @@ public:
             updateAssumedState();
         } else {
             // Our framebuffer is still bound, but the viewport might have changed.
-            setViewportSize(nativeView.framebufferSize);
+            setViewport(0, 0, nativeView.framebufferSize);
         }
     }
 

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2888,12 +2888,12 @@ public:
     void updateAssumedState() override {
         glGetIntegerv(GL_FRAMEBUFFER_BINDING, &fbo);
         assumeFramebufferBinding(fbo);
-        assumeViewportSize(nativeView.framebufferSize);
+        assumeViewport(0, 0, nativeView.framebufferSize);
     }
 
     void bind() override {
         setFramebufferBinding(fbo);
-        setViewportSize(nativeView.framebufferSize);
+        setViewport(0, 0, nativeView.framebufferSize);
     }
 
     mbgl::PremultipliedImage readStillImage() {

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1506,12 +1506,12 @@ mbgl::Size QMapboxGLPrivate::framebufferSize() const {
 
 void QMapboxGLPrivate::updateAssumedState() {
     assumeFramebufferBinding(fbObject);
-    assumeViewportSize(framebufferSize());
+    assumeViewport(0, 0, framebufferSize());
 }
 
 void QMapboxGLPrivate::bind() {
     setFramebufferBinding(fbObject);
-    setViewportSize(framebufferSize());
+    setViewport(0, 0, framebufferSize());
 }
 
 void QMapboxGLPrivate::invalidate()

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -468,8 +468,8 @@ void Context::reset() {
 }
 
 void Context::setDirtyState() {
-    // Note: does not set viewport/bindFramebuffer to dirty since they are handled separately in
-    // the view object.
+    // Note: does not set viewport/scissorTest/bindFramebuffer to dirty
+    // since they are handled separately in the view object.
     stencilFunc.setDirty();
     stencilMask.setDirty();
     stencilTest.setDirty();

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -199,6 +199,7 @@ public:
     State<value::ActiveTexture> activeTexture;
     State<value::BindFramebuffer> bindFramebuffer;
     State<value::Viewport> viewport;
+    State<value::ScissorTest> scissorTest;
     std::array<State<value::BindTexture>, 2> texture;
     State<value::BindVertexArray, const Context&> vertexArrayObject { *this };
     State<value::Program> program;

--- a/src/mbgl/gl/value.cpp
+++ b/src/mbgl/gl/value.cpp
@@ -267,6 +267,18 @@ Viewport::Type Viewport::Get() {
              { static_cast<uint32_t>(viewport[2]), static_cast<uint32_t>(viewport[3]) } };
 }
 
+const constexpr ScissorTest::Type ScissorTest::Default;
+
+void ScissorTest::Set(const Type& value) {
+    MBGL_CHECK_ERROR(value ? glEnable(GL_SCISSOR_TEST) : glDisable(GL_SCISSOR_TEST));
+}
+
+ScissorTest::Type ScissorTest::Get() {
+    Type scissorTest;
+    MBGL_CHECK_ERROR(scissorTest = glIsEnabled(GL_SCISSOR_TEST));
+    return scissorTest;
+}
+
 const constexpr BindFramebuffer::Type BindFramebuffer::Default;
 
 void BindFramebuffer::Set(const Type& value) {

--- a/src/mbgl/gl/value.hpp
+++ b/src/mbgl/gl/value.hpp
@@ -182,6 +182,13 @@ struct Viewport {
     static Type Get();
 };
 
+struct ScissorTest {
+    using Type = bool;
+    static const constexpr Type Default = false;
+    static void Set(const Type&);
+    static Type Get();
+};
+
 constexpr bool operator!=(const Viewport::Type& a, const Viewport::Type& b) {
     return a.x != b.x || a.y != b.y || a.size != b.size;
 }

--- a/src/mbgl/map/backend.cpp
+++ b/src/mbgl/map/backend.cpp
@@ -38,6 +38,11 @@ void Backend::assumeViewport(int32_t x, int32_t y, const Size& size) {
     assert(gl::value::Viewport::Get() == getContext().viewport.getCurrentValue());
 }
 
+void Backend::assumeScissorTest(bool enabled) {
+    getContext().scissorTest.setCurrentValue(enabled);
+    assert(gl::value::ScissorTest::Get() == getContext().scissorTest.getCurrentValue());
+}
+
 bool Backend::implicitFramebufferBound() {
     return getContext().bindFramebuffer.getCurrentValue() == ImplicitFramebufferBinding;
 }
@@ -52,6 +57,11 @@ void Backend::setFramebufferBinding(const gl::FramebufferID fbo) {
 void Backend::setViewport(int32_t x, int32_t y, const Size& size) {
     getContext().viewport = { x, y, size };
     assert(gl::value::Viewport::Get() == getContext().viewport.getCurrentValue());
+}
+
+void Backend::setScissorTest(bool enabled) {
+    getContext().scissorTest = enabled;
+    assert(gl::value::ScissorTest::Get() == getContext().scissorTest.getCurrentValue());
 }
 
 Backend::~Backend() = default;

--- a/src/mbgl/map/backend.cpp
+++ b/src/mbgl/map/backend.cpp
@@ -32,8 +32,9 @@ void Backend::assumeFramebufferBinding(const gl::FramebufferID fbo) {
         assert(gl::value::BindFramebuffer::Get() == getContext().bindFramebuffer.getCurrentValue());
     }
 }
-void Backend::assumeViewportSize(const Size& size) {
-    getContext().viewport.setCurrentValue({ 0, 0, size });
+
+void Backend::assumeViewport(int32_t x, int32_t y, const Size& size) {
+    getContext().viewport.setCurrentValue({ x, y, size });
     assert(gl::value::Viewport::Get() == getContext().viewport.getCurrentValue());
 }
 
@@ -48,8 +49,8 @@ void Backend::setFramebufferBinding(const gl::FramebufferID fbo) {
     }
 }
 
-void Backend::setViewportSize(const Size& size) {
-    getContext().viewport = { 0, 0, size };
+void Backend::setViewport(int32_t x, int32_t y, const Size& size) {
+    getContext().viewport = { x, y, size };
     assert(gl::value::Viewport::Get() == getContext().viewport.getCurrentValue());
 }
 

--- a/src/mbgl/util/offscreen_texture.cpp
+++ b/src/mbgl/util/offscreen_texture.cpp
@@ -33,6 +33,7 @@ public:
         }
 
         context.activeTexture = 0;
+        context.scissorTest = false;
         context.viewport = { 0, 0, size };
     }
 

--- a/test/util/offscreen_texture.test.cpp
+++ b/test/util/offscreen_texture.test.cpp
@@ -14,6 +14,11 @@ TEST(OffscreenTexture, EmptyRed) {
     HeadlessBackend backend { test::sharedDisplay() };
     BackendScope scope { backend };
     OffscreenView view(backend.getContext(), { 512, 256 });
+
+    // Scissor test shouldn't leak after OffscreenView::bind().
+    MBGL_CHECK_ERROR(glScissor(64, 64, 128, 128));
+    backend.getContext().scissorTest.setCurrentValue(true);
+
     view.bind();
 
     MBGL_CHECK_ERROR(glClearColor(1.0f, 0.0f, 0.0f, 1.0f));
@@ -128,6 +133,11 @@ void main() {
     // Then, create a texture, bind it, and render yellow to that texture. This should not
     // affect the originally bound FBO.
     OffscreenTexture texture(context, { 128, 128 });
+
+    // Scissor test shouldn't leak after OffscreenTexture::bind().
+    MBGL_CHECK_ERROR(glScissor(32, 32, 64, 64));
+    context.scissorTest.setCurrentValue(true);
+
     texture.bind();
 
     context.clear(Color(), {}, {});


### PR DESCRIPTION
When scissor test is enabled e.g. when embedding our engine on third-party platforms, the scissor test ends up polluting the rendering of offscreen textures e.g. used when rendering fill extrusion layers. This PR:
- Adds convenience methods for assuming/setting viewport values with non-zero `x` and `y` values
- Adds convenience methods for assuming/setting scissor test values
- Makes sure scissor test is disabled when using offscreen textures for fill extrusion layer