### PR TITLE
Store vertex attribute binding to prevent duplicate binds

### DIFF
--- a/src/mbgl/gl/attribute.cpp
+++ b/src/mbgl/gl/attribute.cpp
@@ -29,6 +29,7 @@ void VariableAttributeBinding<T, N>::bind(Context& context,
     }
     context.vertexBuffer = vertexBuffer;
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(location));
+    oldBinding = *this;
     MBGL_CHECK_ERROR(glVertexAttribPointer(
         location,
         static_cast<GLint>(attributeSize),


### PR DESCRIPTION
We have an `oldBinding` value that we use for checking whether the vertex attribute was already
bound to the current VAO, but we never set the state. Additionally, we're also checking whether
the previous state was already any binding (`optional` is set), and don't re-enable the vertex
attribute array. Additionally, we now only disable the vertex attribute array when the previous
state was in fact an array attribute. We still don't deduplicate constant `glVertexAttrib*` calls,
but that's a little trickier.