### PR TITLE
[android] - remove conversion from pixels to dp

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -621,7 +621,7 @@ final class NativeMapView {
     if (isDestroyedOn("getMetersPerPixelAtLatitude")) {
       return 0;
     }
-    return nativeGetMetersPerPixelAtLatitude(lat, getZoom()) / pixelRatio;
+    return nativeGetMetersPerPixelAtLatitude(lat, getZoom());
   }
 
   public ProjectedMeters projectedMetersForLatLng(LatLng latLng) {


### PR DESCRIPTION
Did some test with the iOS binding to validate change from #9048. 
The requested change in https://github.com/mapbox/mapbox-gl-native/issues/8990 wasn't valid. 
Reverts #9048 and closes #8990.

