### PR TITLE
[android] - invalidating MyLocationView bearing when not following position

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
@@ -461,7 +461,8 @@ public class MyLocationView extends View {
     this.location = location;
     myLocationBehavior.updateLatLng(location);
 
-    if (myBearingTrackingMode == MyBearingTracking.GPS && myLocationTrackingMode == MyLocationTracking.TRACKING_NONE) {
+    if (mapboxMap != null &&
+      myBearingTrackingMode == MyBearingTracking.GPS && myLocationTrackingMode == MyLocationTracking.TRACKING_NONE) {
       setBearing(mapboxMap.getCameraPosition().bearing);
     }
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
@@ -460,6 +460,10 @@ public class MyLocationView extends View {
 
     this.location = location;
     myLocationBehavior.updateLatLng(location);
+
+    if (myBearingTrackingMode == MyBearingTracking.GPS && myLocationTrackingMode == MyLocationTracking.TRACKING_NONE) {
+      setBearing(mapboxMap.getCameraPosition().bearing);
+    }
   }
 
   public void setMyBearingTrackingMode(@MyBearingTracking.Mode int myBearingTrackingMode) {


### PR DESCRIPTION
Fixing issues from #9132.
It's not perfect, because it's not animating bearing and uses `MapboxMap` reference, but still better than no bearing updates at all when location change occurs and `TRACKING_NONE` mode is on.
