### PR TITLE
[core] annotation manager thread safety

### DIFF
--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -22,6 +22,8 @@ set(MBGL_CORE_FILES
     src/mbgl/annotation/annotation_manager.hpp
     src/mbgl/annotation/annotation_source.cpp
     src/mbgl/annotation/annotation_source.hpp
+    src/mbgl/annotation/annotation_source_impl.cpp
+    src/mbgl/annotation/annotation_source_impl.hpp
     src/mbgl/annotation/annotation_tile.cpp
     src/mbgl/annotation/annotation_tile.hpp
     src/mbgl/annotation/fill_annotation_impl.cpp
@@ -30,10 +32,12 @@ set(MBGL_CORE_FILES
     src/mbgl/annotation/line_annotation_impl.hpp
     src/mbgl/annotation/render_annotation_source.cpp
     src/mbgl/annotation/render_annotation_source.hpp
+    src/mbgl/annotation/shape_annotation_feature.cpp
+    src/mbgl/annotation/shape_annotation_feature.hpp
     src/mbgl/annotation/shape_annotation_impl.cpp
     src/mbgl/annotation/shape_annotation_impl.hpp
-    src/mbgl/annotation/symbol_annotation_impl.cpp
-    src/mbgl/annotation/symbol_annotation_impl.hpp
+    src/mbgl/annotation/symbol_annotation_feature.cpp
+    src/mbgl/annotation/symbol_annotation_feature.hpp
 
     # csscolorparser
     src/csscolorparser/csscolorparser.cpp

--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -1,15 +1,12 @@
 #include <mbgl/annotation/annotation_manager.hpp>
 #include <mbgl/annotation/annotation_source.hpp>
-#include <mbgl/annotation/annotation_tile.hpp>
-#include <mbgl/annotation/symbol_annotation_impl.hpp>
+#include <mbgl/annotation/annotation_source_impl.hpp>
 #include <mbgl/annotation/line_annotation_impl.hpp>
 #include <mbgl/annotation/fill_annotation_impl.hpp>
+
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/layers/symbol_layer.hpp>
 #include <mbgl/style/layers/symbol_layer_impl.hpp>
-#include <mbgl/storage/file_source.hpp>
-
-#include <boost/function_output_iterator.hpp>
 
 namespace mbgl {
 
@@ -18,212 +15,203 @@ using namespace style;
 const std::string AnnotationManager::SourceID = "com.mapbox.annotations";
 const std::string AnnotationManager::PointLayerID = "com.mapbox.annotations.points";
 
-AnnotationManager::AnnotationManager() = default;
+AnnotationManager::AnnotationManager()
+        : ownedSource(std::make_unique<AnnotationSource>()), source(ownedSource.get()) {
+};
+
 AnnotationManager::~AnnotationManager() = default;
 
-AnnotationID AnnotationManager::addAnnotation(const Annotation& annotation, const uint8_t maxZoom) {
+AnnotationID AnnotationManager::addAnnotation(const Annotation &annotation, const uint8_t maxZoom) {
     AnnotationID id = nextID++;
-    Annotation::visit(annotation, [&] (const auto& annotation_) {
+    Annotation::visit(annotation, [&](const auto &annotation_) {
         this->add(id, annotation_, maxZoom);
     });
     return id;
 }
 
-Update AnnotationManager::updateAnnotation(const AnnotationID& id, const Annotation& annotation, const uint8_t maxZoom) {
-    return Annotation::visit(annotation, [&] (const auto& annotation_) {
+void AnnotationManager::updateAnnotation(const AnnotationID &id, const Annotation &annotation,
+                                         const uint8_t maxZoom) {
+    return Annotation::visit(annotation, [&](const auto &annotation_) {
         return this->update(id, annotation_, maxZoom);
     });
 }
 
-void AnnotationManager::removeAnnotation(const AnnotationID& id) {
-    if (symbolAnnotations.find(id) != symbolAnnotations.end()) {
-        symbolTree.remove(symbolAnnotations.at(id));
-        symbolAnnotations.erase(id);
-    } else if (shapeAnnotations.find(id) != shapeAnnotations.end()) {
-        obsoleteShapeAnnotationLayers.insert(shapeAnnotations.at(id)->layerID);
-        shapeAnnotations.erase(id);
-    } else {
-        assert(false); // Should never happen
+void AnnotationManager::removeAnnotation(const AnnotationID &id) {
+    // Remove from source
+    sourceImpl = source->removeAnnotation(id);
+
+    // Remove from shapes
+    auto it = shapeAnnotations.find(id);
+    if (it != shapeAnnotations.end()) {
+        auto removedLayer = it->second->layerID;
+        shapeAnnotations.erase(it);
+        if (style) {
+            style->removeLayer(removedLayer);
+        }
     }
 }
 
-void AnnotationManager::add(const AnnotationID& id, const SymbolAnnotation& annotation, const uint8_t) {
-    auto impl = std::make_shared<SymbolAnnotationImpl>(id, annotation);
-    symbolTree.insert(impl);
-    symbolAnnotations.emplace(id, impl);
+void AnnotationManager::add(const AnnotationID &id,
+                            const SymbolAnnotation &annotation,
+                            const uint8_t) {
+    sourceImpl = source->addAnnotation(id, annotation);
 }
 
-void AnnotationManager::add(const AnnotationID& id, const LineAnnotation& annotation, const uint8_t maxZoom) {
-    ShapeAnnotationImpl& impl = *shapeAnnotations.emplace(id,
-        std::make_unique<LineAnnotationImpl>(id, annotation, maxZoom)).first->second;
-    obsoleteShapeAnnotationLayers.erase(impl.layerID);
+void AnnotationManager::add(const AnnotationID &id, const LineAnnotation &annotation,
+                            const uint8_t maxZoom) {
+    // Add to source
+    sourceImpl = source->addAnnotation(id, annotation.geometry, maxZoom);
+
+    // Add to collection
+    ShapeAnnotationImpl &impl = *shapeAnnotations
+            .emplace(id,
+                     std::make_unique<LineAnnotationImpl>(id, annotation, maxZoom)).first->second;
+
+    if (style) {
+        impl.updateStyle(*style);
+    }
 }
 
-void AnnotationManager::add(const AnnotationID& id, const FillAnnotation& annotation, const uint8_t maxZoom) {
-    ShapeAnnotationImpl& impl = *shapeAnnotations.emplace(id,
-        std::make_unique<FillAnnotationImpl>(id, annotation, maxZoom)).first->second;
-    obsoleteShapeAnnotationLayers.erase(impl.layerID);
+void AnnotationManager::add(const AnnotationID &id, const FillAnnotation &annotation,
+                            const uint8_t maxZoom) {
+    // Add to source
+    sourceImpl = source->addAnnotation(id, annotation.geometry, maxZoom);
+
+    // Add to collection
+    ShapeAnnotationImpl &impl = *shapeAnnotations
+            .emplace(id,
+                     std::make_unique<FillAnnotationImpl>(id, annotation, maxZoom)).first->second;
+
+    if (style) {
+        impl.updateStyle(*style);
+    }
 }
 
-Update AnnotationManager::update(const AnnotationID& id, const SymbolAnnotation& annotation, const uint8_t maxZoom) {
-    Update result = Update::Nothing;
-
-    auto it = symbolAnnotations.find(id);
-    if (it == symbolAnnotations.end()) {
-        assert(false); // Attempt to update a non-existent symbol annotation
-        return result;
-    }
-
-    const SymbolAnnotation& existing = it->second->annotation;
-
-    if (existing.geometry != annotation.geometry) {
-        result |= Update::AnnotationData;
-    }
-
-    if (existing.icon != annotation.icon) {
-        result |= Update::AnnotationData | Update::AnnotationStyle;
-    }
-
-    if (result != Update::Nothing) {
-        removeAndAdd(id, annotation, maxZoom);
-    }
-
-    return result;
+void AnnotationManager::update(const AnnotationID &id,
+                               const SymbolAnnotation &annotation,
+                               const uint8_t) {
+    sourceImpl = source->updateAnnotation(id, annotation);
 }
 
-Update AnnotationManager::update(const AnnotationID& id, const LineAnnotation& annotation, const uint8_t maxZoom) {
+void AnnotationManager::update(const AnnotationID &id,
+                               const LineAnnotation &annotation,
+                               const uint8_t maxZoom) {
     auto it = shapeAnnotations.find(id);
     if (it == shapeAnnotations.end()) {
         assert(false); // Attempt to update a non-existent shape annotation
-        return Update::Nothing;
     }
-    removeAndAdd(id, annotation, maxZoom);
-    return Update::AnnotationData | Update::AnnotationStyle;
+
+    // Update in collection
+    shapeAnnotations.erase(it);
+    ShapeAnnotationImpl &impl = *shapeAnnotations
+            .emplace(id,
+                     std::make_unique<LineAnnotationImpl>(id, annotation, maxZoom)).first->second;
+
+    // Update in source
+    sourceImpl = source->updateAnnotation(id, annotation.geometry, maxZoom);
+
+    // Update layer
+    if (style) {
+        impl.updateStyle(*style);
+    }
 }
 
-Update AnnotationManager::update(const AnnotationID& id, const FillAnnotation& annotation, const uint8_t maxZoom) {
+void AnnotationManager::update(const AnnotationID &id,
+                               const FillAnnotation &annotation,
+                               const uint8_t maxZoom) {
     auto it = shapeAnnotations.find(id);
     if (it == shapeAnnotations.end()) {
         assert(false); // Attempt to update a non-existent shape annotation
-        return Update::Nothing;
-    }
-    removeAndAdd(id, annotation, maxZoom);
-    return Update::AnnotationData | Update::AnnotationStyle;
-}
-
-void AnnotationManager::removeAndAdd(const AnnotationID& id, const Annotation& annotation, const uint8_t maxZoom) {
-    removeAnnotation(id);
-    Annotation::visit(annotation, [&] (const auto& annotation_) {
-        this->add(id, annotation_, maxZoom);
-    });
-}
-
-std::unique_ptr<AnnotationTileData> AnnotationManager::getTileData(const CanonicalTileID& tileID) {
-    if (symbolAnnotations.empty() && shapeAnnotations.empty())
-        return nullptr;
-
-    auto tileData = std::make_unique<AnnotationTileData>();
-
-    AnnotationTileLayer& pointLayer = tileData->layers.emplace(PointLayerID, PointLayerID).first->second;
-
-    LatLngBounds tileBounds(tileID);
-
-    symbolTree.query(boost::geometry::index::intersects(tileBounds),
-        boost::make_function_output_iterator([&](const auto& val){
-            val->updateLayer(tileID, pointLayer);
-        }));
-
-    for (const auto& shape : shapeAnnotations) {
-        shape.second->updateTileData(tileID, *tileData);
     }
 
-    return tileData;
-}
+    // Update in collection
+    shapeAnnotations.erase(it);
+    ShapeAnnotationImpl &impl = *shapeAnnotations
+            .emplace(id,
+                     std::make_unique<FillAnnotationImpl>(id, annotation, maxZoom)).first->second;
 
-void AnnotationManager::updateStyle(Style& style) {
-    // Create annotation source, point layer, and point bucket
-    if (!style.getSource(SourceID)) {
-        style.addSource(std::make_unique<AnnotationSource>());
+    // Update in source
+    sourceImpl = source->updateAnnotation(id, annotation.geometry, maxZoom);
 
-        std::unique_ptr<SymbolLayer> layer = std::make_unique<SymbolLayer>(PointLayerID, SourceID);
-
-        layer->setSourceLayer(PointLayerID);
-        layer->setIconImage({SourceID + ".{sprite}"});
-        layer->setIconAllowOverlap(true);
-        layer->setIconIgnorePlacement(true);
-
-        style.addLayer(std::move(layer));
+    // Update layer
+    if (style) {
+        impl.updateStyle(*style);
     }
-
-    for (const auto& shape : shapeAnnotations) {
-        shape.second->updateStyle(style);
-    }
-
-    for (const auto& image : images) {
-        // Call addImage even for images we may have previously added, because we must support
-        // addAnnotationImage being used to update an existing image. Creating a new image is
-        // relatively cheap, as it copies only the Immutable reference. (We can't keep track
-        // of which images need to be added because we don't know if the style is the same
-        // instance as in the last updateStyle call. If it's a new style, we need to add all
-        // images.)
-        style.addImage(std::make_unique<style::Image>(image.second));
-    }
-
-    for (const auto& layer : obsoleteShapeAnnotationLayers) {
-        if (style.getLayer(layer)) {
-            style.removeLayer(layer);
-        }
-    }
-
-    for (const auto& image : obsoleteImages) {
-        if (style.getImage(image)) {
-            style.removeImage(image);
-        }
-    }
-
-    obsoleteShapeAnnotationLayers.clear();
-    obsoleteImages.clear();
-}
-
-void AnnotationManager::updateData() {
-    for (auto& tile : tiles) {
-        tile->setData(getTileData(tile->id.canonical));
-    }
-}
-
-void AnnotationManager::addTile(AnnotationTile& tile) {
-    tiles.insert(&tile);
-    tile.setData(getTileData(tile.id.canonical));
-}
-
-void AnnotationManager::removeTile(AnnotationTile& tile) {
-    tiles.erase(&tile);
 }
 
 // To ensure that annotation images do not collide with images from the style,
 // we prefix input image IDs with "com.mapbox.annotations".
-static std::string prefixedImageID(const std::string& id) {
+static std::string prefixedImageID(const std::string &id) {
     return AnnotationManager::SourceID + "." + id;
 }
 
 void AnnotationManager::addImage(std::unique_ptr<style::Image> image) {
     const std::string id = prefixedImageID(image->getID());
     images.erase(id);
-    images.emplace(id,
-        style::Image(id, image->getImage().clone(), image->getPixelRatio(), image->isSdf()));
-    obsoleteImages.erase(id);
+    auto it = images.emplace(
+            id,
+            style::Image(id, image->getImage().clone(), image->getPixelRatio(), image->isSdf())
+    );
+
+    if (style) {
+        style->addImage(std::make_unique<style::Image>(it.first->second));
+    }
 }
 
-void AnnotationManager::removeImage(const std::string& id_) {
+void AnnotationManager::removeImage(const std::string &id_) {
     const std::string id = prefixedImageID(id_);
     images.erase(id);
-    obsoleteImages.insert(id);
+
+    if (style) {
+        style->removeImage(id);
+    }
 }
 
-double AnnotationManager::getTopOffsetPixelsForImage(const std::string& id_) {
+double AnnotationManager::getTopOffsetPixelsForImage(const std::string &id_) {
     const std::string id = prefixedImageID(id_);
     auto it = images.find(id);
-    return it != images.end() ? -(it->second.getImage().size.height / it->second.getPixelRatio()) / 2 : 0;
+    return it != images.end() ?
+           -(it->second.getImage().size.height / it->second.getPixelRatio()) / 2 :
+           0;
+}
+
+void AnnotationManager::onStyleLoaded(style::Style &style_) {
+    style = &style_;
+
+    // Add the annotation source
+    if (ownedSource) {
+        style->addSource(std::move(ownedSource));
+    } else {
+        style->addSource(sourceImpl ?
+                         std::make_unique<AnnotationSource>(*sourceImpl) :
+                         std::make_unique<AnnotationSource>());
+    }
+
+    source = style->getSource(SourceID)->as<AnnotationSource>();
+
+    // Add the Symbol Layer
+    std::unique_ptr<SymbolLayer> layer = std::make_unique<SymbolLayer>(PointLayerID, SourceID);
+    layer->setSourceLayer(PointLayerID);
+    layer->setIconImage({SourceID + ".{sprite}"});
+    layer->setIconAllowOverlap(true);
+    layer->setIconIgnorePlacement(true);
+    style->addLayer(std::move(layer));
+
+    // Add all images
+    for (const auto &image : images) {
+        // Call addImage even for images we may have previously added, because we must support
+        // addAnnotationImage being used to update an existing image. Creating a new image is
+        // relatively cheap, as it copies only the Immutable reference. (We can't keep track
+        // of which images need to be added because we don't know if the style is the same
+        // instance as in the last updateStyle call. If it's a new style, we need to add all
+        // images.)
+        style->addImage(std::make_unique<style::Image>(image.second));
+    }
+
+    // Add all layers for shape annotations
+    for (auto &entry : shapeAnnotations) {
+        entry.second->updateStyle(*style);
+    }
 }
 
 } // namespace mbgl

--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -21,22 +21,22 @@ AnnotationManager::AnnotationManager()
 
 AnnotationManager::~AnnotationManager() = default;
 
-AnnotationID AnnotationManager::addAnnotation(const Annotation &annotation, const uint8_t maxZoom) {
+AnnotationID AnnotationManager::addAnnotation(const Annotation& annotation, const uint8_t maxZoom) {
     AnnotationID id = nextID++;
-    Annotation::visit(annotation, [&](const auto &annotation_) {
+    Annotation::visit(annotation, [&](const auto& annotation_) {
         this->add(id, annotation_, maxZoom);
     });
     return id;
 }
 
-void AnnotationManager::updateAnnotation(const AnnotationID &id, const Annotation &annotation,
+void AnnotationManager::updateAnnotation(const AnnotationID& id, const Annotation& annotation,
                                          const uint8_t maxZoom) {
-    return Annotation::visit(annotation, [&](const auto &annotation_) {
+    return Annotation::visit(annotation, [&](const auto& annotation_) {
         return this->update(id, annotation_, maxZoom);
     });
 }
 
-void AnnotationManager::removeAnnotation(const AnnotationID &id) {
+void AnnotationManager::removeAnnotation(const AnnotationID& id) {
     // Remove from source
     sourceImpl = source->removeAnnotation(id);
 
@@ -51,19 +51,20 @@ void AnnotationManager::removeAnnotation(const AnnotationID &id) {
     }
 }
 
-void AnnotationManager::add(const AnnotationID &id,
-                            const SymbolAnnotation &annotation,
+void AnnotationManager::add(const AnnotationID& id,
+                            const SymbolAnnotation& annotation,
                             const uint8_t) {
     sourceImpl = source->addAnnotation(id, annotation);
 }
 
-void AnnotationManager::add(const AnnotationID &id, const LineAnnotation &annotation,
+void AnnotationManager::add(const AnnotationID& id,
+                            const LineAnnotation& annotation,
                             const uint8_t maxZoom) {
     // Add to source
     sourceImpl = source->addAnnotation(id, annotation.geometry, maxZoom);
 
     // Add to collection
-    ShapeAnnotationImpl &impl = *shapeAnnotations
+    ShapeAnnotationImpl& impl = *shapeAnnotations
             .emplace(id,
                      std::make_unique<LineAnnotationImpl>(id, annotation, maxZoom)).first->second;
 
@@ -72,13 +73,13 @@ void AnnotationManager::add(const AnnotationID &id, const LineAnnotation &annota
     }
 }
 
-void AnnotationManager::add(const AnnotationID &id, const FillAnnotation &annotation,
+void AnnotationManager::add(const AnnotationID& id, const FillAnnotation& annotation,
                             const uint8_t maxZoom) {
     // Add to source
     sourceImpl = source->addAnnotation(id, annotation.geometry, maxZoom);
 
     // Add to collection
-    ShapeAnnotationImpl &impl = *shapeAnnotations
+    ShapeAnnotationImpl& impl = *shapeAnnotations
             .emplace(id,
                      std::make_unique<FillAnnotationImpl>(id, annotation, maxZoom)).first->second;
 
@@ -87,14 +88,14 @@ void AnnotationManager::add(const AnnotationID &id, const FillAnnotation &annota
     }
 }
 
-void AnnotationManager::update(const AnnotationID &id,
-                               const SymbolAnnotation &annotation,
+void AnnotationManager::update(const AnnotationID& id,
+                               const SymbolAnnotation& annotation,
                                const uint8_t) {
     sourceImpl = source->updateAnnotation(id, annotation);
 }
 
-void AnnotationManager::update(const AnnotationID &id,
-                               const LineAnnotation &annotation,
+void AnnotationManager::update(const AnnotationID& id,
+                               const LineAnnotation& annotation,
                                const uint8_t maxZoom) {
     auto it = shapeAnnotations.find(id);
     if (it == shapeAnnotations.end()) {
@@ -103,7 +104,7 @@ void AnnotationManager::update(const AnnotationID &id,
 
     // Update in collection
     shapeAnnotations.erase(it);
-    ShapeAnnotationImpl &impl = *shapeAnnotations
+    ShapeAnnotationImpl& impl = *shapeAnnotations
             .emplace(id,
                      std::make_unique<LineAnnotationImpl>(id, annotation, maxZoom)).first->second;
 
@@ -116,8 +117,8 @@ void AnnotationManager::update(const AnnotationID &id,
     }
 }
 
-void AnnotationManager::update(const AnnotationID &id,
-                               const FillAnnotation &annotation,
+void AnnotationManager::update(const AnnotationID& id,
+                               const FillAnnotation& annotation,
                                const uint8_t maxZoom) {
     auto it = shapeAnnotations.find(id);
     if (it == shapeAnnotations.end()) {
@@ -126,7 +127,7 @@ void AnnotationManager::update(const AnnotationID &id,
 
     // Update in collection
     shapeAnnotations.erase(it);
-    ShapeAnnotationImpl &impl = *shapeAnnotations
+    ShapeAnnotationImpl& impl = *shapeAnnotations
             .emplace(id,
                      std::make_unique<FillAnnotationImpl>(id, annotation, maxZoom)).first->second;
 
@@ -141,7 +142,7 @@ void AnnotationManager::update(const AnnotationID &id,
 
 // To ensure that annotation images do not collide with images from the style,
 // we prefix input image IDs with "com.mapbox.annotations".
-static std::string prefixedImageID(const std::string &id) {
+static std::string prefixedImageID(const std::string& id) {
     return AnnotationManager::SourceID + "." + id;
 }
 
@@ -158,7 +159,7 @@ void AnnotationManager::addImage(std::unique_ptr<style::Image> image) {
     }
 }
 
-void AnnotationManager::removeImage(const std::string &id_) {
+void AnnotationManager::removeImage(const std::string& id_) {
     const std::string id = prefixedImageID(id_);
     images.erase(id);
 
@@ -167,7 +168,7 @@ void AnnotationManager::removeImage(const std::string &id_) {
     }
 }
 
-double AnnotationManager::getTopOffsetPixelsForImage(const std::string &id_) {
+double AnnotationManager::getTopOffsetPixelsForImage(const std::string& id_) {
     const std::string id = prefixedImageID(id_);
     auto it = images.find(id);
     return it != images.end() ?
@@ -175,7 +176,7 @@ double AnnotationManager::getTopOffsetPixelsForImage(const std::string &id_) {
            0;
 }
 
-void AnnotationManager::onStyleLoaded(style::Style &style_) {
+void AnnotationManager::onStyleLoaded(style::Style& style_) {
     style = &style_;
 
     // Add the annotation source
@@ -198,7 +199,7 @@ void AnnotationManager::onStyleLoaded(style::Style &style_) {
     style->addLayer(std::move(layer));
 
     // Add all images
-    for (const auto &image : images) {
+    for (const auto& image : images) {
         // Call addImage even for images we may have previously added, because we must support
         // addAnnotationImage being used to update an existing image. Creating a new image is
         // relatively cheap, as it copies only the Immutable reference. (We can't keep track
@@ -209,7 +210,7 @@ void AnnotationManager::onStyleLoaded(style::Style &style_) {
     }
 
     // Add all layers for shape annotations
-    for (auto &entry : shapeAnnotations) {
+    for (auto& entry : shapeAnnotations) {
         entry.second->updateStyle(*style);
     }
 }

--- a/src/mbgl/annotation/annotation_source.cpp
+++ b/src/mbgl/annotation/annotation_source.cpp
@@ -1,24 +1,112 @@
 #include <mbgl/annotation/annotation_source.hpp>
-#include <mbgl/annotation/annotation_manager.hpp>
+#include <mbgl/annotation/symbol_annotation_feature.hpp>
+#include <mbgl/annotation/shape_annotation_feature.hpp>
+#include <mbgl/annotation/annotation_source_impl.hpp>
+#include <mbgl/style/source_observer.hpp>
 
 namespace mbgl {
 
 using namespace style;
 
 AnnotationSource::AnnotationSource()
-    : Source(makeMutable<Impl>()) {
+        : Source(makeMutable<Impl>()) {
 }
 
-AnnotationSource::Impl::Impl()
-    : Source::Impl(SourceType::Annotations, AnnotationManager::SourceID) {
+AnnotationSource::AnnotationSource(Immutable <Impl> impl)
+        : Source(std::move(impl)) {
 }
 
-void AnnotationSource::loadDescription(FileSource&) {
+Immutable<AnnotationSource::Impl> AnnotationSource::addAnnotation(const AnnotationID &id,
+                                                                  ShapeAnnotationGeometry geometry,
+                                                                  const uint8_t maxZoom) {
+    Mutable <Impl> mutableImpl = makeMutable<Impl>(impl());
+    mutableImpl->getData()->shapeAnnotations.emplace(
+            id,
+            std::make_shared<ShapeAnnotationFeature>(id, std::move(geometry), maxZoom));
+    baseImpl = Immutable<Source::Impl>(std::move(mutableImpl));
+
+    observer->onSourceChanged(*this);
+
+    return makeMutable<Impl>(impl());
+};
+
+Immutable<AnnotationSource::Impl> AnnotationSource::addAnnotation(const AnnotationID &id, const SymbolAnnotation &annotation) {
+    auto feature = std::make_shared<SymbolAnnotationFeature>(id, annotation);
+
+    Mutable <Impl> mutableImpl = makeMutable<Impl>(impl());
+    mutableImpl->getData()->symbolTree.insert(feature);
+    mutableImpl->getData()->symbolAnnotations.emplace(id, feature);
+    baseImpl = Immutable<Source::Impl>(std::move(mutableImpl));
+
+    observer->onSourceChanged(*this);
+
+    return makeMutable<Impl>(impl());
+};
+
+Immutable<AnnotationSource::Impl> AnnotationSource::updateAnnotation(const AnnotationID &id,
+                                                                     ShapeAnnotationGeometry geometry,
+                                                                     const uint8_t maxZoom) {
+    Mutable <Impl> mutableImpl = makeMutable<Impl>(impl());
+    mutableImpl->getData()->shapeAnnotations.erase(id);
+    mutableImpl->getData()->shapeAnnotations.emplace(
+            id,
+            std::make_shared<ShapeAnnotationFeature>(id, std::move(geometry), maxZoom));
+    baseImpl = Immutable<Source::Impl>(std::move(mutableImpl));
+
+    observer->onSourceChanged(*this);
+
+    return makeMutable<Impl>(impl());
+};
+
+Immutable<AnnotationSource::Impl> AnnotationSource::updateAnnotation(const AnnotationID &id, const SymbolAnnotation &annotation) {
+    auto it = impl().getData()->symbolAnnotations.find(id);
+    if (it == impl().getData()->symbolAnnotations.end()) {
+        // Attempt to update a non-existent symbol annotation
+        assert(false);
+    } else if (it->second->annotation.geometry != annotation.geometry ||
+               it->second->annotation.icon != annotation.icon) {
+        Mutable<Impl> mutableImpl = makeMutable<Impl>(impl());
+        auto data = mutableImpl->getData();
+
+        // Remove / add, update
+        data->symbolTree.remove(it->second);
+        auto feature = std::make_shared<SymbolAnnotationFeature>(id, annotation);
+        data->symbolTree.insert(feature);
+        data->symbolAnnotations[id] = std::move(feature);
+
+        baseImpl = Immutable<Source::Impl>(std::move(mutableImpl));
+        observer->onSourceChanged(*this);
+    }
+
+    return makeMutable<Impl>(impl());
+};
+
+Immutable<AnnotationSource::Impl> AnnotationSource::removeAnnotation(const AnnotationID& id) {
+    Mutable <Impl> mutableImpl = makeMutable<Impl>(impl());
+    auto data = mutableImpl->getData();
+
+    if (data->symbolAnnotations.find(id) != data->symbolAnnotations.end()) {
+        data->symbolTree.remove(data->symbolAnnotations.at(id));
+        data->symbolAnnotations.erase(id);
+    } else if (data->shapeAnnotations.find(id) !=data->shapeAnnotations.end()) {
+        data->shapeAnnotations.erase(id);
+    } else {
+        assert(false); // Should never happen
+    }
+
+    baseImpl = Immutable<Source::Impl>(std::move(mutableImpl));
+
+    observer->onSourceChanged(*this);
+
+    return makeMutable<Impl>(impl());
+};
+
+const AnnotationSource::Impl &AnnotationSource::impl() const {
+    return static_cast<const Impl &>(*baseImpl);
+}
+
+void AnnotationSource::loadDescription(FileSource &) {
     loaded = true;
-}
-
-optional<std::string> AnnotationSource::Impl::getAttribution() const {
-    return {};
 }
 
 } // namespace mbgl

--- a/src/mbgl/annotation/annotation_source.hpp
+++ b/src/mbgl/annotation/annotation_source.hpp
@@ -1,28 +1,44 @@
 #pragma once
 
+#include <mbgl/annotation/annotation.hpp>
 #include <mbgl/style/source.hpp>
-#include <mbgl/style/source_impl.hpp>
+
+#include <memory>
 
 namespace mbgl {
 
+class ShapeAnnotationFeature;
+class SymbolAnnotationFeature;
+
 class AnnotationSource : public style::Source {
 public:
-    AnnotationSource();
-
     class Impl;
+
+    AnnotationSource();
+    AnnotationSource(Immutable<Impl>);
+
+    Immutable<Impl> addAnnotation(const AnnotationID&, ShapeAnnotationGeometry, const uint8_t maxZoom);
+    Immutable<Impl> addAnnotation(const AnnotationID&, const SymbolAnnotation&);
+
+    Immutable<Impl> updateAnnotation(const AnnotationID&,
+                                     ShapeAnnotationGeometry,
+                                     const uint8_t);
+    Immutable<Impl> updateAnnotation(const AnnotationID&, const SymbolAnnotation&);
+
+    Immutable<Impl> removeAnnotation(const AnnotationID&);
+
     const Impl& impl() const;
 
-private:
     void loadDescription(FileSource&) final;
 
-    Mutable<Impl> mutableImpl() const;
 };
 
-class AnnotationSource::Impl : public style::Source::Impl {
-public:
-    Impl();
+namespace style {
 
-    optional<std::string> getAttribution() const final;
-};
+template<>
+inline bool Source::is<AnnotationSource>() const {
+    return getType() == SourceType::Annotations;
+}
 
+} // namespace style
 } // namespace mbgl

--- a/src/mbgl/annotation/annotation_source_impl.cpp
+++ b/src/mbgl/annotation/annotation_source_impl.cpp
@@ -1,0 +1,53 @@
+#include <mbgl/annotation/annotation_source_impl.hpp>
+#include <mbgl/annotation/annotation_manager.hpp>
+#include <mbgl/annotation/annotation_tile.hpp>
+
+#include <boost/function_output_iterator.hpp>
+
+namespace mbgl {
+
+using namespace style;
+
+std::unique_ptr<AnnotationTileData> AnnotationData::getTile(const CanonicalTileID& tileID) const {
+    if (symbolAnnotations.empty() && shapeAnnotations.empty())
+        return nullptr;
+
+    auto tileData = std::make_unique<AnnotationTileData>();
+
+    AnnotationTileLayer& pointLayer = tileData->layers.emplace(
+            AnnotationManager::PointLayerID,
+            AnnotationManager::PointLayerID
+    ).first->second;
+
+    LatLngBounds tileBounds(tileID);
+
+    symbolTree.query(boost::geometry::index::intersects(tileBounds),
+                     boost::make_function_output_iterator([&](const auto& val){
+                         val->updateTileLayer(tileID, pointLayer);
+                     }));
+
+    for (const auto& shape : shapeAnnotations) {
+        shape.second->updateTileData(tileID, *tileData);
+    }
+
+    return tileData;
+}
+
+AnnotationSource::Impl::Impl()
+    : Source::Impl(SourceType::Annotations, AnnotationManager::SourceID) {
+
+}
+
+const AnnotationData* AnnotationSource::Impl::getData() const {
+    return &data;
+}
+
+AnnotationData* AnnotationSource::Impl::getData() {
+    return &data;
+}
+
+optional<std::string> AnnotationSource::Impl::getAttribution() const {
+    return {};
+}
+
+} // namespace mbgl

--- a/src/mbgl/annotation/annotation_source_impl.hpp
+++ b/src/mbgl/annotation/annotation_source_impl.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <mbgl/annotation/annotation_source.hpp>
+#include <mbgl/annotation/shape_annotation_feature.hpp>
+#include <mbgl/annotation/symbol_annotation_feature.hpp>
+#include <mbgl/style/source_impl.hpp>
+#include <mbgl/util/optional.hpp>
+
+#include <memory>
+
+namespace mbgl {
+
+class AnnotationSource;
+class AnnotationTileData;
+class AnnotationTileLayer;
+class CanonicalTileID;
+//class ShapeAnnotationFeature;
+//class SymbolAnnotationFeature;
+
+class AnnotationData {
+public:
+    AnnotationData() = default;
+    AnnotationData(const AnnotationData&) = default;
+    ~AnnotationData() = default;
+
+    std::unique_ptr<AnnotationTileData> getTile(const CanonicalTileID&) const;
+
+private:
+    using SymbolAnnotationTree = boost::geometry::index::rtree<std::shared_ptr<const SymbolAnnotationFeature>, boost::geometry::index::rstar<16, 4>>;
+    // Unlike std::unordered_map, std::map is guaranteed to sort by AnnotationID, ensuring that older annotations are below newer annotations.
+    // <https://github.com/mapbox/mapbox-gl-native/issues/5691>
+    using SymbolAnnotationMap = std::map<const AnnotationID, std::shared_ptr<const SymbolAnnotationFeature>>;
+    using ShapeAnnotationMap = std::map<const AnnotationID, std::shared_ptr<const ShapeAnnotationFeature>>;
+
+    SymbolAnnotationTree symbolTree;
+    SymbolAnnotationMap symbolAnnotations;
+    ShapeAnnotationMap shapeAnnotations;
+
+    friend class AnnotationSource;
+};
+
+class AnnotationSource::Impl : public style::Source::Impl {
+public:
+    Impl();
+    Impl(const Impl&) = default;
+
+    AnnotationData* getData();
+    const AnnotationData* getData() const;
+
+    optional<std::string> getAttribution() const final;
+
+private:
+    AnnotationData data;
+
+};
+
+} // namespace mbgl

--- a/src/mbgl/annotation/annotation_tile.cpp
+++ b/src/mbgl/annotation/annotation_tile.cpp
@@ -1,33 +1,28 @@
 #include <mbgl/annotation/annotation_tile.hpp>
 #include <mbgl/annotation/annotation_manager.hpp>
-#include <mbgl/util/constants.hpp>
-#include <mbgl/storage/file_source.hpp>
 #include <mbgl/renderer/tile_parameters.hpp>
-
-#include <utility>
 
 namespace mbgl {
 
-AnnotationTile::AnnotationTile(const OverscaledTileID& overscaledTileID,
-                               const TileParameters& parameters)
-    : GeometryTile(overscaledTileID, AnnotationManager::SourceID, parameters),
-      annotationManager(parameters.annotationManager) {
-    annotationManager.addTile(*this);
+AnnotationTile::AnnotationTile(const OverscaledTileID &overscaledTileID,
+                               const TileParameters &parameters,
+                               std::unique_ptr<const AnnotationTileData> _data)
+        : GeometryTile(overscaledTileID, AnnotationManager::SourceID, parameters) {
+
+    setData(std::move(_data));
 }
 
-AnnotationTile::~AnnotationTile() {
-    annotationManager.removeTile(*this);
-}
+AnnotationTile::~AnnotationTile() = default;
 
 void AnnotationTile::setNecessity(Necessity) {}
 
 AnnotationTileFeature::AnnotationTileFeature(const AnnotationID id_,
                                              FeatureType type_, GeometryCollection geometries_,
                                              std::unordered_map<std::string, std::string> properties_)
-    : id(id_),
-      type(type_),
-      properties(std::move(properties_)),
-      geometries(std::move(geometries_)) {}
+        : id(id_),
+          type(type_),
+          properties(std::move(properties_)),
+          geometries(std::move(geometries_)) {}
 
 optional<Value> AnnotationTileFeature::getValue(const std::string& key) const {
     auto it = properties.find(key);
@@ -38,7 +33,7 @@ optional<Value> AnnotationTileFeature::getValue(const std::string& key) const {
 }
 
 AnnotationTileLayer::AnnotationTileLayer(std::string name_)
-    : name(std::move(name_)) {}
+        : name(std::move(name_)) {}
 
 std::unique_ptr<GeometryTileData> AnnotationTileData::clone() const {
     return std::make_unique<AnnotationTileData>(*this);

--- a/src/mbgl/annotation/annotation_tile.cpp
+++ b/src/mbgl/annotation/annotation_tile.cpp
@@ -4,8 +4,8 @@
 
 namespace mbgl {
 
-AnnotationTile::AnnotationTile(const OverscaledTileID &overscaledTileID,
-                               const TileParameters &parameters,
+AnnotationTile::AnnotationTile(const OverscaledTileID& overscaledTileID,
+                               const TileParameters& parameters,
                                std::unique_ptr<const AnnotationTileData> _data)
         : GeometryTile(overscaledTileID, AnnotationManager::SourceID, parameters) {
 

--- a/src/mbgl/annotation/annotation_tile.hpp
+++ b/src/mbgl/annotation/annotation_tile.hpp
@@ -6,19 +6,17 @@
 
 namespace mbgl {
 
-class AnnotationManager;
+class AnnotationTileData;
 class TileParameters;
 
 class AnnotationTile : public GeometryTile {
 public:
     AnnotationTile(const OverscaledTileID&,
-                   const TileParameters&);
+                   const TileParameters&,
+                   std::unique_ptr<const AnnotationTileData> data);
     ~AnnotationTile() override;
 
     void setNecessity(Necessity) final;
-
-private:
-    AnnotationManager& annotationManager;
 };
 
 class AnnotationTileFeature : public GeometryTileFeature {
@@ -55,6 +53,10 @@ private:
     std::string name;
 };
 
+/**
+ * Holds the layers for a AnnotationTile. One layer per shape geometry
+ * and a single layer for all symbol geometries
+ */
 class AnnotationTileData : public GeometryTileData {
 public:
     std::unique_ptr<GeometryTileData> clone() const override;

--- a/src/mbgl/annotation/fill_annotation_impl.cpp
+++ b/src/mbgl/annotation/fill_annotation_impl.cpp
@@ -7,9 +7,13 @@ namespace mbgl {
 
 using namespace style;
 
-FillAnnotationImpl::FillAnnotationImpl(AnnotationID id_, FillAnnotation annotation_, uint8_t maxZoom_)
-    : ShapeAnnotationImpl(id_, maxZoom_),
-      annotation({ ShapeAnnotationGeometry::visit(annotation_.geometry, CloseShapeAnnotation{}), annotation_.opacity, annotation_.color, annotation_.outlineColor }) {
+FillAnnotationImpl::FillAnnotationImpl(const AnnotationID& id_,
+                                       const FillAnnotation &annotation_,
+                                       const uint8_t maxZoom_)
+        : ShapeAnnotationImpl(id_, maxZoom_)
+        , opacity(annotation_.opacity)
+        , color(annotation_.color)
+        , outlineColor(annotation_.outlineColor) {
 }
 
 void FillAnnotationImpl::updateStyle(Style& style) const {
@@ -21,14 +25,10 @@ void FillAnnotationImpl::updateStyle(Style& style) const {
         layer = style.addLayer(std::move(newLayer), AnnotationManager::PointLayerID);
     }
 
-    auto* fillLayer = layer->as<FillLayer>();
-    fillLayer->setFillOpacity(annotation.opacity);
-    fillLayer->setFillColor(annotation.color);
-    fillLayer->setFillOutlineColor(annotation.outlineColor);
-}
-
-const ShapeAnnotationGeometry& FillAnnotationImpl::geometry() const {
-    return annotation.geometry;
+    auto *fillLayer = layer->as<FillLayer>();
+    fillLayer->setFillOpacity(opacity);
+    fillLayer->setFillColor(color);
+    fillLayer->setFillOutlineColor(outlineColor);
 }
 
 } // namespace mbgl

--- a/src/mbgl/annotation/fill_annotation_impl.hpp
+++ b/src/mbgl/annotation/fill_annotation_impl.hpp
@@ -5,15 +5,19 @@
 
 namespace mbgl {
 
+/**
+ * Holds the data needed to update the style for this fill annotation.
+ */
 class FillAnnotationImpl : public ShapeAnnotationImpl {
 public:
-    FillAnnotationImpl(AnnotationID, FillAnnotation, uint8_t maxZoom);
+    FillAnnotationImpl(const AnnotationID&, const FillAnnotation&, const uint8_t maxZoom);
 
     void updateStyle(style::Style&) const final;
-    const ShapeAnnotationGeometry& geometry() const final;
 
 private:
-    const FillAnnotation annotation;
+    style::DataDrivenPropertyValue<float> opacity { 1.0f };
+    style::DataDrivenPropertyValue<Color> color { Color::black() };
+    style::DataDrivenPropertyValue<Color> outlineColor {};
 };
 
 } // namespace mbgl

--- a/src/mbgl/annotation/line_annotation_impl.cpp
+++ b/src/mbgl/annotation/line_annotation_impl.cpp
@@ -7,9 +7,13 @@ namespace mbgl {
 
 using namespace style;
 
-LineAnnotationImpl::LineAnnotationImpl(AnnotationID id_, LineAnnotation annotation_, uint8_t maxZoom_)
-    : ShapeAnnotationImpl(id_, maxZoom_),
-      annotation({ ShapeAnnotationGeometry::visit(annotation_.geometry, CloseShapeAnnotation{}), annotation_.opacity, annotation_.width, annotation_.color }) {
+LineAnnotationImpl::LineAnnotationImpl(const AnnotationID& id_,
+                                       const LineAnnotation& annotation_,
+                                       const uint8_t maxZoom_)
+        : ShapeAnnotationImpl(id_, maxZoom_)
+        , opacity(annotation_.opacity)
+        , width(annotation_.width)
+        , color(annotation_.color) {
 }
 
 void LineAnnotationImpl::updateStyle(Style& style) const {
@@ -22,14 +26,10 @@ void LineAnnotationImpl::updateStyle(Style& style) const {
         layer = style.addLayer(std::move(newLayer), AnnotationManager::PointLayerID);
     }
 
-    auto* lineLayer = layer->as<LineLayer>();
-    lineLayer->setLineOpacity(annotation.opacity);
-    lineLayer->setLineWidth(annotation.width);
-    lineLayer->setLineColor(annotation.color);
-}
-
-const ShapeAnnotationGeometry& LineAnnotationImpl::geometry() const {
-    return annotation.geometry;
+    auto *lineLayer = layer->as<LineLayer>();
+    lineLayer->setLineOpacity(opacity);
+    lineLayer->setLineWidth(width);
+    lineLayer->setLineColor(color);
 }
 
 } // namespace mbgl

--- a/src/mbgl/annotation/line_annotation_impl.hpp
+++ b/src/mbgl/annotation/line_annotation_impl.hpp
@@ -1,19 +1,23 @@
 #pragma once
 
-#include <mbgl/annotation/shape_annotation_impl.hpp>
 #include <mbgl/annotation/annotation.hpp>
+#include <mbgl/annotation/shape_annotation_impl.hpp>
 
 namespace mbgl {
 
+/**
+ * Holds the data needed to update the style for this line annotation.
+ */
 class LineAnnotationImpl : public ShapeAnnotationImpl {
 public:
-    LineAnnotationImpl(AnnotationID, LineAnnotation, uint8_t maxZoom);
+    LineAnnotationImpl(const AnnotationID&, const LineAnnotation&, const uint8_t maxZoom);
 
     void updateStyle(style::Style&) const final;
-    const ShapeAnnotationGeometry& geometry() const final;
 
 private:
-    const LineAnnotation annotation;
+    style::DataDrivenPropertyValue<float> opacity { 1.0f };
+    style::PropertyValue<float> width { 1.0f };
+    style::DataDrivenPropertyValue<Color> color { Color::black() };
 };
 
 } // namespace mbgl

--- a/src/mbgl/annotation/render_annotation_source.hpp
+++ b/src/mbgl/annotation/render_annotation_source.hpp
@@ -3,8 +3,11 @@
 #include <mbgl/renderer/render_source.hpp>
 #include <mbgl/renderer/tile_pyramid.hpp>
 #include <mbgl/annotation/annotation_source.hpp>
+#include <mbgl/annotation/annotation_source_impl.hpp>
 
 namespace mbgl {
+
+class AnnotationData;
 
 class RenderAnnotationSource : public RenderSource {
 public:
@@ -43,6 +46,7 @@ private:
     const AnnotationSource::Impl& impl() const;
 
     TilePyramid tilePyramid;
+    const AnnotationData* data;
 };
 
 template <>

--- a/src/mbgl/annotation/shape_annotation_feature.cpp
+++ b/src/mbgl/annotation/shape_annotation_feature.cpp
@@ -1,0 +1,99 @@
+#include <mbgl/annotation/shape_annotation_feature.hpp>
+#include <mbgl/annotation/annotation_tile.hpp>
+#include <mbgl/tile/tile_id.hpp>
+#include <mbgl/math/wrap.hpp>
+#include <mbgl/math/clamp.hpp>
+#include <mbgl/util/string.hpp>
+#include <mbgl/util/constants.hpp>
+#include <mbgl/util/geometry.hpp>
+
+namespace mbgl {
+
+using namespace style;
+namespace geojsonvt = mapbox::geojsonvt;
+
+/**
+ * Ensures (multi-)polygons are properly closed
+ */
+struct CloseShapeAnnotation {
+    ShapeAnnotationGeometry operator()(const mbgl::LineString<double> &geom) const {
+        return geom;
+    }
+    ShapeAnnotationGeometry operator()(const mbgl::MultiLineString<double> &geom) const {
+        return geom;
+    }
+    ShapeAnnotationGeometry operator()(const mbgl::Polygon<double> &geom) const {
+        mbgl::Polygon<double> closed = geom;
+        for (auto &ring : closed) {
+            if (!ring.empty() && ring.front() != ring.back()) {
+                ring.emplace_back(ring.front());
+            }
+        }
+        return closed;
+    }
+    ShapeAnnotationGeometry operator()(const mbgl::MultiPolygon<double> &geom) const {
+        mbgl::MultiPolygon<double> closed = geom;
+        for (auto &polygon : closed) {
+            for (auto &ring : polygon) {
+                if (!ring.empty() && ring.front() != ring.back()) {
+                    ring.emplace_back(ring.front());
+                }
+            }
+        }
+        return closed;
+    }
+};
+
+ShapeAnnotationFeature::ShapeAnnotationFeature(const AnnotationID& id_, ShapeAnnotationGeometry geometry_, const uint8_t maxZoom_)
+        : id(id_)
+        , geometry(std::move(geometry_))
+        , maxZoom(maxZoom_)
+        , layerID("com.mapbox.annotations.shape." + util::toString(id)) {
+
+    static const double baseTolerance = 4;
+
+    // Close geometry rings properly
+    ShapeAnnotationGeometry closed = ShapeAnnotationGeometry::visit(geometry, CloseShapeAnnotation {});
+
+    // Convert to feature collection
+    mapbox::geometry::feature_collection<double> features;
+    features.emplace_back(ShapeAnnotationGeometry::visit(closed, [] (auto&& geom) {
+        return Feature { std::move(geom) };
+    }));
+
+    // Create vector tiler
+    mapbox::geojsonvt::Options options;
+    options.maxZoom = maxZoom;
+    options.buffer = 255u;
+    options.extent = util::EXTENT;
+    options.tolerance = baseTolerance;
+    shapeTiler = std::make_unique<mapbox::geojsonvt::GeoJSONVT>(features, options);
+}
+
+void ShapeAnnotationFeature::updateTileData(const CanonicalTileID& tileID, AnnotationTileData& data) const {
+
+    const auto& shapeTile = shapeTiler->getTile(tileID.z, tileID.x, tileID.y);
+    if (shapeTile.features.empty()) {
+        return;
+    }
+
+    AnnotationTileLayer& layer = data.layers.emplace(layerID, layerID).first->second;
+
+    ToGeometryCollection toGeometryCollection;
+    ToFeatureType toFeatureType;
+    for (const auto& shapeFeature : shapeTile.features) {
+        FeatureType featureType = apply_visitor(toFeatureType, shapeFeature.geometry);
+        GeometryCollection renderGeometry = apply_visitor(toGeometryCollection, shapeFeature.geometry);
+
+        assert(featureType != FeatureType::Unknown);
+
+        // https://github.com/mapbox/geojson-vt-cpp/issues/44
+        if (featureType == FeatureType::Polygon) {
+            renderGeometry = fixupPolygons(renderGeometry);
+        }
+
+        layer.features.emplace_back(id, featureType, renderGeometry);
+    }
+}
+
+} // namespace mbgl

--- a/src/mbgl/annotation/shape_annotation_feature.cpp
+++ b/src/mbgl/annotation/shape_annotation_feature.cpp
@@ -16,25 +16,28 @@ namespace geojsonvt = mapbox::geojsonvt;
  * Ensures (multi-)polygons are properly closed
  */
 struct CloseShapeAnnotation {
-    ShapeAnnotationGeometry operator()(const mbgl::LineString<double> &geom) const {
+    ShapeAnnotationGeometry operator()(const mbgl::LineString<double>& geom) const {
         return geom;
     }
-    ShapeAnnotationGeometry operator()(const mbgl::MultiLineString<double> &geom) const {
+
+    ShapeAnnotationGeometry operator()(const mbgl::MultiLineString<double>& geom) const {
         return geom;
     }
-    ShapeAnnotationGeometry operator()(const mbgl::Polygon<double> &geom) const {
+
+    ShapeAnnotationGeometry operator()(const mbgl::Polygon<double>& geom) const {
         mbgl::Polygon<double> closed = geom;
-        for (auto &ring : closed) {
+        for (auto& ring : closed) {
             if (!ring.empty() && ring.front() != ring.back()) {
                 ring.emplace_back(ring.front());
             }
         }
         return closed;
     }
-    ShapeAnnotationGeometry operator()(const mbgl::MultiPolygon<double> &geom) const {
+
+    ShapeAnnotationGeometry operator()(const mbgl::MultiPolygon<double>& geom) const {
         mbgl::MultiPolygon<double> closed = geom;
-        for (auto &polygon : closed) {
-            for (auto &ring : polygon) {
+        for (auto& polygon : closed) {
+            for (auto& ring : polygon) {
                 if (!ring.empty() && ring.front() != ring.back()) {
                     ring.emplace_back(ring.front());
                 }
@@ -44,21 +47,22 @@ struct CloseShapeAnnotation {
     }
 };
 
-ShapeAnnotationFeature::ShapeAnnotationFeature(const AnnotationID& id_, ShapeAnnotationGeometry geometry_, const uint8_t maxZoom_)
-        : id(id_)
-        , geometry(std::move(geometry_))
-        , maxZoom(maxZoom_)
-        , layerID("com.mapbox.annotations.shape." + util::toString(id)) {
+ShapeAnnotationFeature::ShapeAnnotationFeature(const AnnotationID& id_,
+                                               ShapeAnnotationGeometry geometry_,
+                                               const uint8_t maxZoom_)
+        : id(id_), geometry(std::move(geometry_)), maxZoom(maxZoom_),
+          layerID("com.mapbox.annotations.shape." + util::toString(id)) {
 
     static const double baseTolerance = 4;
 
     // Close geometry rings properly
-    ShapeAnnotationGeometry closed = ShapeAnnotationGeometry::visit(geometry, CloseShapeAnnotation {});
+    ShapeAnnotationGeometry closed = ShapeAnnotationGeometry::visit(geometry,
+                                                                    CloseShapeAnnotation {});
 
     // Convert to feature collection
     mapbox::geometry::feature_collection<double> features;
-    features.emplace_back(ShapeAnnotationGeometry::visit(closed, [] (auto&& geom) {
-        return Feature { std::move(geom) };
+    features.emplace_back(ShapeAnnotationGeometry::visit(closed, [](auto&& geom) {
+        return Feature {std::move(geom)};
     }));
 
     // Create vector tiler
@@ -70,7 +74,8 @@ ShapeAnnotationFeature::ShapeAnnotationFeature(const AnnotationID& id_, ShapeAnn
     shapeTiler = std::make_unique<mapbox::geojsonvt::GeoJSONVT>(features, options);
 }
 
-void ShapeAnnotationFeature::updateTileData(const CanonicalTileID& tileID, AnnotationTileData& data) const {
+void ShapeAnnotationFeature::updateTileData(const CanonicalTileID& tileID,
+                                            AnnotationTileData& data) const {
 
     const auto& shapeTile = shapeTiler->getTile(tileID.z, tileID.x, tileID.y);
     if (shapeTile.features.empty()) {
@@ -83,7 +88,8 @@ void ShapeAnnotationFeature::updateTileData(const CanonicalTileID& tileID, Annot
     ToFeatureType toFeatureType;
     for (const auto& shapeFeature : shapeTile.features) {
         FeatureType featureType = apply_visitor(toFeatureType, shapeFeature.geometry);
-        GeometryCollection renderGeometry = apply_visitor(toGeometryCollection, shapeFeature.geometry);
+        GeometryCollection renderGeometry = apply_visitor(toGeometryCollection,
+                                                          shapeFeature.geometry);
 
         assert(featureType != FeatureType::Unknown);
 

--- a/src/mbgl/annotation/shape_annotation_feature.hpp
+++ b/src/mbgl/annotation/shape_annotation_feature.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <mapbox/geojsonvt.hpp>
+
+#include <mbgl/annotation/annotation.hpp>
+#include <mbgl/util/geometry.hpp>
+
+#include <string>
+#include <memory>
+
+namespace mbgl {
+
+class AnnotationTileData;
+class CanonicalTileID;
+
+/**
+ * Constains the geometry for this shape annotation and caches the
+ * vector tile information created from it used to create render tiles.
+ */
+class ShapeAnnotationFeature {
+public:
+    ShapeAnnotationFeature(const AnnotationID&, ShapeAnnotationGeometry, const uint8_t maxZoom);
+    ~ShapeAnnotationFeature() = default;
+
+    void updateTileData(const CanonicalTileID&, AnnotationTileData&) const;
+
+    const AnnotationID id;
+
+private:
+    const ShapeAnnotationGeometry geometry;
+    const uint8_t maxZoom;
+    const std::string layerID;
+    std::unique_ptr<mapbox::geojsonvt::GeoJSONVT> shapeTiler;
+};
+
+} // namespace mbgl

--- a/src/mbgl/annotation/shape_annotation_impl.cpp
+++ b/src/mbgl/annotation/shape_annotation_impl.cpp
@@ -1,60 +1,13 @@
 #include <mbgl/annotation/shape_annotation_impl.hpp>
-#include <mbgl/annotation/annotation_tile.hpp>
-#include <mbgl/tile/tile_id.hpp>
-#include <mbgl/math/wrap.hpp>
-#include <mbgl/math/clamp.hpp>
 #include <mbgl/util/string.hpp>
-#include <mbgl/util/constants.hpp>
-#include <mbgl/util/geometry.hpp>
 
 namespace mbgl {
 
-using namespace style;
-namespace geojsonvt = mapbox::geojsonvt;
-
 ShapeAnnotationImpl::ShapeAnnotationImpl(const AnnotationID id_, const uint8_t maxZoom_)
-    : id(id_),
-      maxZoom(maxZoom_),
-      layerID("com.mapbox.annotations.shape." + util::toString(id)) {
-}
+        : id(id_)
+        , maxZoom(maxZoom_)
+        , layerID("com.mapbox.annotations.shape." + util::toString(id)){
+};
 
-void ShapeAnnotationImpl::updateTileData(const CanonicalTileID& tileID, AnnotationTileData& data) {
-    static const double baseTolerance = 4;
-
-    if (!shapeTiler) {
-        mapbox::geometry::feature_collection<double> features;
-        features.emplace_back(ShapeAnnotationGeometry::visit(geometry(), [] (auto&& geom) {
-            return Feature { std::move(geom) };
-        }));
-        mapbox::geojsonvt::Options options;
-        options.maxZoom = maxZoom;
-        options.buffer = 255u;
-        options.extent = util::EXTENT;
-        options.tolerance = baseTolerance;
-        shapeTiler = std::make_unique<mapbox::geojsonvt::GeoJSONVT>(features, options);
-    }
-
-    const auto& shapeTile = shapeTiler->getTile(tileID.z, tileID.x, tileID.y);
-    if (shapeTile.features.empty())
-        return;
-
-    AnnotationTileLayer& layer = data.layers.emplace(layerID, layerID).first->second;
-
-    ToGeometryCollection toGeometryCollection;
-    ToFeatureType toFeatureType;
-    for (const auto& shapeFeature : shapeTile.features) {
-        FeatureType featureType = apply_visitor(toFeatureType, shapeFeature.geometry);
-        GeometryCollection renderGeometry = apply_visitor(toGeometryCollection, shapeFeature.geometry);
-
-        assert(featureType != FeatureType::Unknown);
-
-        // https://github.com/mapbox/geojson-vt-cpp/issues/44
-        if (featureType == FeatureType::Polygon) {
-            renderGeometry = fixupPolygons(renderGeometry);
-        }
-
-        layer.features.emplace_back(id, featureType, renderGeometry);
-    }
-}
 
 } // namespace mbgl

--- a/src/mbgl/annotation/shape_annotation_impl.hpp
+++ b/src/mbgl/annotation/shape_annotation_impl.hpp
@@ -1,65 +1,28 @@
 #pragma once
 
-#include <mapbox/geojsonvt.hpp>
-
 #include <mbgl/annotation/annotation.hpp>
-#include <mbgl/util/geometry.hpp>
 
 #include <string>
-#include <memory>
 
 namespace mbgl {
-
-class AnnotationTileData;
-class CanonicalTileID;
 
 namespace style {
 class Style;
 } // namespace style
 
+/**
+ * Holds the data needed to update the style for this shape annotation.
+ */
 class ShapeAnnotationImpl {
 public:
-    ShapeAnnotationImpl(const AnnotationID, const uint8_t maxZoom);
+    ShapeAnnotationImpl(const AnnotationID, const uint8_t);
     virtual ~ShapeAnnotationImpl() = default;
 
     virtual void updateStyle(style::Style&) const = 0;
-    virtual const ShapeAnnotationGeometry& geometry() const = 0;
-
-    void updateTileData(const CanonicalTileID&, AnnotationTileData&);
 
     const AnnotationID id;
     const uint8_t maxZoom;
     const std::string layerID;
-    std::unique_ptr<mapbox::geojsonvt::GeoJSONVT> shapeTiler;
-};
-
-struct CloseShapeAnnotation {
-    ShapeAnnotationGeometry operator()(const mbgl::LineString<double> &geom) const {
-        return geom;
-    }
-    ShapeAnnotationGeometry operator()(const mbgl::MultiLineString<double> &geom) const {
-        return geom;
-    }
-    ShapeAnnotationGeometry operator()(const mbgl::Polygon<double> &geom) const {
-        mbgl::Polygon<double> closed = geom;
-        for (auto &ring : closed) {
-            if (!ring.empty() && ring.front() != ring.back()) {
-                ring.emplace_back(ring.front());
-            }
-        }
-        return closed;
-    }
-    ShapeAnnotationGeometry operator()(const mbgl::MultiPolygon<double> &geom) const {
-        mbgl::MultiPolygon<double> closed = geom;
-        for (auto &polygon : closed) {
-            for (auto &ring : polygon) {
-                if (!ring.empty() && ring.front() != ring.back()) {
-                    ring.emplace_back(ring.front());
-                }
-            }
-        }
-        return closed;
-    }
 };
 
 } // namespace mbgl

--- a/src/mbgl/annotation/symbol_annotation_feature.cpp
+++ b/src/mbgl/annotation/symbol_annotation_feature.cpp
@@ -1,4 +1,4 @@
-#include <mbgl/annotation/symbol_annotation_impl.hpp>
+#include <mbgl/annotation/symbol_annotation_feature.hpp>
 #include <mbgl/annotation/annotation_tile.hpp>
 #include <mbgl/tile/tile_id.hpp>
 #include <mbgl/math/clamp.hpp>
@@ -6,12 +6,12 @@
 
 namespace mbgl {
 
-SymbolAnnotationImpl::SymbolAnnotationImpl(AnnotationID id_, SymbolAnnotation annotation_)
-: id(id_),
-  annotation(std::move(annotation_)) {
+SymbolAnnotationFeature::SymbolAnnotationFeature(const AnnotationID& id_, const SymbolAnnotation& annotation_)
+        : id(id_)
+        , annotation(std::move(annotation_)) {
 }
 
-void SymbolAnnotationImpl::updateLayer(const CanonicalTileID& tileID, AnnotationTileLayer& layer) const {
+void SymbolAnnotationFeature::updateTileLayer(const CanonicalTileID& tileID, AnnotationTileLayer& layer) const {
     std::unordered_map<std::string, std::string> featureProperties;
     featureProperties.emplace("sprite", annotation.icon.empty() ? std::string("default_marker") : annotation.icon);
 

--- a/src/mbgl/annotation/symbol_annotation_feature.hpp
+++ b/src/mbgl/annotation/symbol_annotation_feature.hpp
@@ -31,11 +31,14 @@ namespace mbgl {
 class AnnotationTileLayer;
 class CanonicalTileID;
 
-class SymbolAnnotationImpl {
+/**
+ * Contains the geometry and icon name for this symbol feature
+ */
+class SymbolAnnotationFeature {
 public:
-    SymbolAnnotationImpl(AnnotationID, SymbolAnnotation);
+    SymbolAnnotationFeature(const AnnotationID&, const SymbolAnnotation&);
 
-    void updateLayer(const CanonicalTileID&, AnnotationTileLayer&) const;
+    void updateTileLayer(const CanonicalTileID&, AnnotationTileLayer&) const;
 
     const AnnotationID id;
     const SymbolAnnotation annotation;
@@ -82,9 +85,9 @@ struct indexed_access<mbgl::LatLngBounds, max_corner, D>
 namespace index {
 
 template <>
-struct indexable<std::shared_ptr<const mbgl::SymbolAnnotationImpl>> {
+struct indexable<std::shared_ptr<const mbgl::SymbolAnnotationFeature>> {
     using result_type = mbgl::LatLng;
-    mbgl::LatLng operator()(const std::shared_ptr<const mbgl::SymbolAnnotationImpl>& v) const {
+    mbgl::LatLng operator()(const std::shared_ptr<const mbgl::SymbolAnnotationFeature>& v) const {
         const mbgl::Point<double>& p = v->annotation.geometry;
         return mbgl::LatLng(p.y, p.x);
     }

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -406,6 +406,8 @@ void Map::Impl::loadStyleJSON(const std::string& json) {
         map.setBearing(map.getDefaultBearing());
         map.setPitch(map.getDefaultPitch());
     }
+    
+    onUpdate(Update::Repaint);
 }
 
 std::string Map::getStyleURL() const {
@@ -793,10 +795,12 @@ LatLng Map::latLngForPixel(const ScreenCoordinate& pixel) const {
 
 void Map::addAnnotationImage(std::unique_ptr<style::Image> image) {
     impl->annotationManager.addImage(std::move(image));
+    impl->onUpdate(Update::Repaint);
 }
 
 void Map::removeAnnotationImage(const std::string& id) {
     impl->annotationManager.removeImage(id);
+    impl->onUpdate(Update::Repaint);
 }
 
 double Map::getTopOffsetPixelsForAnnotationImage(const std::string& id) {
@@ -805,15 +809,18 @@ double Map::getTopOffsetPixelsForAnnotationImage(const std::string& id) {
 
 AnnotationID Map::addAnnotation(const Annotation& annotation) {
     auto result = impl->annotationManager.addAnnotation(annotation, getMaxZoom());
+    impl->onUpdate(Update::Repaint);
     return result;
 }
 
 void Map::updateAnnotation(AnnotationID id, const Annotation& annotation) {
     impl->annotationManager.updateAnnotation(id, annotation, getMaxZoom());
+    impl->onUpdate(Update::Repaint);
 }
 
 void Map::removeAnnotation(AnnotationID annotation) {
     impl->annotationManager.removeAnnotation(annotation);
+    impl->onUpdate(Update::Repaint);
 }
 
 #pragma mark - Feature query api

--- a/src/mbgl/map/update.hpp
+++ b/src/mbgl/map/update.hpp
@@ -6,9 +6,7 @@ namespace mbgl {
 
 enum class Update {
     Nothing                   = 0,
-    Repaint                   = 1 << 0,
-    AnnotationStyle           = 1 << 6,
-    AnnotationData            = 1 << 7
+    Repaint                   = 1 << 0
 };
 
 constexpr Update operator|(Update lhs, Update rhs) {

--- a/src/mbgl/renderer/render_source.cpp
+++ b/src/mbgl/renderer/render_source.cpp
@@ -3,7 +3,6 @@
 #include <mbgl/renderer/sources/render_geojson_source.hpp>
 #include <mbgl/renderer/sources/render_raster_source.hpp>
 #include <mbgl/renderer/sources/render_vector_source.hpp>
-#include <mbgl/renderer/tile_parameters.hpp>
 #include <mbgl/annotation/render_annotation_source.hpp>
 #include <mbgl/renderer/sources/render_image_source.hpp>
 #include <mbgl/tile/tile.hpp>

--- a/src/mbgl/renderer/render_style.cpp
+++ b/src/mbgl/renderer/render_style.cpp
@@ -99,7 +99,6 @@ void RenderStyle::update(const UpdateParameters& parameters) {
         parameters.scheduler,
         parameters.fileSource,
         parameters.mode,
-        parameters.annotationManager,
         *spriteAtlas,
         *glyphAtlas
     };

--- a/src/mbgl/renderer/tile_parameters.hpp
+++ b/src/mbgl/renderer/tile_parameters.hpp
@@ -19,7 +19,6 @@ public:
     Scheduler& workerScheduler;
     FileSource& fileSource;
     const MapMode mode;
-    AnnotationManager& annotationManager;
     SpriteAtlas& spriteAtlas;
     GlyphAtlas& glyphAtlas;
 };

--- a/src/mbgl/renderer/update_parameters.hpp
+++ b/src/mbgl/renderer/update_parameters.hpp
@@ -28,7 +28,6 @@ public:
 
     Scheduler& scheduler;
     FileSource& fileSource;
-    AnnotationManager& annotationManager;
 };
 
 } // namespace mbgl

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -29,7 +29,6 @@
 #include <mbgl/util/range.hpp>
 
 #include <mbgl/map/transform.hpp>
-#include <mbgl/annotation/annotation_manager.hpp>
 #include <mbgl/annotation/annotation_source.hpp>
 #include <mbgl/sprite/sprite_atlas.hpp>
 #include <mbgl/text/glyph_atlas.hpp>
@@ -47,7 +46,6 @@ public:
     Transform transform;
     TransformState transformState;
     ThreadPool threadPool { 1 };
-    AnnotationManager annotationManager;
     SpriteAtlas spriteAtlas;
     GlyphAtlas glyphAtlas { { 512, 512, }, fileSource };
 
@@ -58,7 +56,6 @@ public:
         threadPool,
         fileSource,
         MapMode::Continuous,
-        annotationManager,
         spriteAtlas,
         glyphAtlas
     };

--- a/test/tile/annotation_tile.test.cpp
+++ b/test/tile/annotation_tile.test.cpp
@@ -10,7 +10,6 @@
 #include <mbgl/map/query.hpp>
 #include <mbgl/text/collision_tile.hpp>
 #include <mbgl/geometry/feature_index.hpp>
-#include <mbgl/annotation/annotation_manager.hpp>
 #include <mbgl/annotation/annotation_tile.hpp>
 #include <mbgl/sprite/sprite_atlas.hpp>
 #include <mbgl/text/glyph_atlas.hpp>
@@ -25,7 +24,6 @@ public:
     TransformState transformState;
     util::RunLoop loop;
     ThreadPool threadPool { 1 };
-    AnnotationManager annotationManager;
     RenderStyle style { threadPool, fileSource };
     SpriteAtlas spriteAtlas;
     GlyphAtlas glyphAtlas { { 512, 512, }, fileSource };
@@ -37,7 +35,6 @@ public:
         threadPool,
         fileSource,
         MapMode::Continuous,
-        annotationManager,
         spriteAtlas,
         glyphAtlas
     };
@@ -46,7 +43,7 @@ public:
 // Don't query stale collision tile
 TEST(AnnotationTile, Issue8289) {
     AnnotationTileTest test;
-    AnnotationTile tile(OverscaledTileID(0, 0, 0), test.tileParameters);
+    AnnotationTile tile(OverscaledTileID(0, 0, 0), test.tileParameters, std::make_unique<AnnotationTileData>());
 
     auto data = std::make_unique<AnnotationTileData>();
     data->layers.emplace("test", AnnotationTileLayer("test"));

--- a/test/tile/geojson_tile.test.cpp
+++ b/test/tile/geojson_tile.test.cpp
@@ -9,7 +9,6 @@
 #include <mbgl/map/transform.hpp>
 #include <mbgl/renderer/tile_parameters.hpp>
 #include <mbgl/style/layers/circle_layer.hpp>
-#include <mbgl/annotation/annotation_manager.hpp>
 #include <mbgl/sprite/sprite_atlas.hpp>
 #include <mbgl/text/glyph_atlas.hpp>
 
@@ -24,7 +23,6 @@ public:
     TransformState transformState;
     util::RunLoop loop;
     ThreadPool threadPool { 1 };
-    AnnotationManager annotationManager;
     SpriteAtlas spriteAtlas;
     GlyphAtlas glyphAtlas { { 512, 512, }, fileSource };
     Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };
@@ -36,7 +34,6 @@ public:
         threadPool,
         fileSource,
         MapMode::Continuous,
-        annotationManager,
         spriteAtlas,
         glyphAtlas
     };

--- a/test/tile/raster_tile.test.cpp
+++ b/test/tile/raster_tile.test.cpp
@@ -6,7 +6,6 @@
 #include <mbgl/util/default_thread_pool.hpp>
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/map/transform.hpp>
-#include <mbgl/annotation/annotation_manager.hpp>
 #include <mbgl/renderer/tile_parameters.hpp>
 #include <mbgl/renderer/buckets/raster_bucket.hpp>
 #include <mbgl/sprite/sprite_atlas.hpp>
@@ -20,7 +19,6 @@ public:
     TransformState transformState;
     util::RunLoop loop;
     ThreadPool threadPool { 1 };
-    AnnotationManager annotationManager;
     SpriteAtlas spriteAtlas;
     GlyphAtlas glyphAtlas { { 512, 512, }, fileSource };
     Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };
@@ -32,7 +30,6 @@ public:
         threadPool,
         fileSource,
         MapMode::Continuous,
-        annotationManager,
         spriteAtlas,
         glyphAtlas
     };

--- a/test/tile/vector_tile.test.cpp
+++ b/test/tile/vector_tile.test.cpp
@@ -12,7 +12,6 @@
 #include <mbgl/renderer/buckets/symbol_bucket.hpp>
 #include <mbgl/text/collision_tile.hpp>
 #include <mbgl/geometry/feature_index.hpp>
-#include <mbgl/annotation/annotation_manager.hpp>
 #include <mbgl/sprite/sprite_atlas.hpp>
 #include <mbgl/text/glyph_atlas.hpp>
 
@@ -26,7 +25,6 @@ public:
     TransformState transformState;
     util::RunLoop loop;
     ThreadPool threadPool { 1 };
-    AnnotationManager annotationManager;
     SpriteAtlas spriteAtlas;
     GlyphAtlas glyphAtlas { { 512, 512, }, fileSource };
     Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };
@@ -38,7 +36,6 @@ public:
         threadPool,
         fileSource,
         MapMode::Continuous,
-        annotationManager,
         spriteAtlas,
         glyphAtlas
     };


### PR DESCRIPTION
Cuts up the annotation manager so is thread safe (#8820); 
- moves data into the source
- moves the tile generation into the render source
- style updates are done immediately if a current style is loaded and/or done when a (new) style is loaded instead of mutating the style on render

TODO:
- [ ] Moving the data into the Source means it is copied on every mutation, this is less performant for bulk operations. We should probably support bulk operations explicitly to avoid multiple sequential copies in those cases.
- [ ] Currently some platforms (ios/macos most notably) execute fairly heavy UI operations on `SourceObserver::onSourceChanged` callbacks. When mutating the `AnnotationSource` rapidly, this is quite the bottleneck. Since these callbacks are needed to signal changes for style diffing, we need to make sure any other operations either use a different signal or guard better from redundantly executing.

Fixes:
- https://github.com/mapbox/mapbox-gl-native/issues/8799
