### PR TITLE
Enable property functions for line-width

### DIFF
--- a/include/mbgl/annotation/annotation.hpp
+++ b/include/mbgl/annotation/annotation.hpp
@@ -31,7 +31,7 @@ class LineAnnotation {
 public:
     ShapeAnnotationGeometry geometry;
     style::DataDrivenPropertyValue<float> opacity { 1.0f };
-    style::PropertyValue<float> width { 1.0f };
+    style::DataDrivenPropertyValue<float> width { 1.0f };
     style::DataDrivenPropertyValue<Color> color { Color::black() };
 };
 

--- a/include/mbgl/style/conversion/make_property_setters.hpp
+++ b/include/mbgl/style/conversion/make_property_setters.hpp
@@ -99,7 +99,7 @@ auto makePaintPropertySetters() {
     result["line-translate-transition"] = &setTransition<V, LineLayer, &LineLayer::setLineTranslateTransition>;
     result["line-translate-anchor"] = &setProperty<V, LineLayer, PropertyValue<TranslateAnchorType>, &LineLayer::setLineTranslateAnchor>;
     result["line-translate-anchor-transition"] = &setTransition<V, LineLayer, &LineLayer::setLineTranslateAnchorTransition>;
-    result["line-width"] = &setProperty<V, LineLayer, PropertyValue<float>, &LineLayer::setLineWidth>;
+    result["line-width"] = &setProperty<V, LineLayer, DataDrivenPropertyValue<float>, &LineLayer::setLineWidth>;
     result["line-width-transition"] = &setTransition<V, LineLayer, &LineLayer::setLineWidthTransition>;
     result["line-gap-width"] = &setProperty<V, LineLayer, DataDrivenPropertyValue<float>, &LineLayer::setLineGapWidth>;
     result["line-gap-width-transition"] = &setTransition<V, LineLayer, &LineLayer::setLineGapWidthTransition>;

--- a/include/mbgl/style/conversion/make_property_setters.hpp.ejs
+++ b/include/mbgl/style/conversion/make_property_setters.hpp.ejs
@@ -34,10 +34,10 @@ auto makePaintPropertySetters() {
     std::unordered_map<std::string, PropertySetter<V>> result;
 
 <% for (const layer of locals.layers) { -%>
-<% for (const property of layer.paintProperties) { -%>
+<% for (const property of layer.paintProperties) { if (!property.skip) { -%>
     result["<%- property.name %>"] = &setProperty<V, <%- camelize(layer.type) %>Layer, <%- propertyValueType(property) %>, &<%- camelize(layer.type) %>Layer::set<%- camelize(property.name) %>>;
     result["<%- property.name %>-transition"] = &setTransition<V, <%- camelize(layer.type) %>Layer, &<%- camelize(layer.type) %>Layer::set<%- camelize(property.name) %>Transition>;
-<% } -%>
+<% }} -%>
 
 <% } -%>
     return result;

--- a/include/mbgl/style/data_driven_property_value.hpp
+++ b/include/mbgl/style/data_driven_property_value.hpp
@@ -49,7 +49,15 @@ public:
     bool isZoomConstant() const {
         return !value.template is<CameraFunction<T>>() && !value.template is<CompositeFunction<T>>();
     }
-    
+
+    void useIntegerZoom() {
+        if (value.template is<CompositeFunction<T>>()) {
+            value.template get<CompositeFunction<T>>().useIntegerZoom = true;
+        } else if (value.template is<CameraFunction<T>>()) {
+            value.template get<CameraFunction<T>>().useIntegerZoom = true;
+        }
+    }
+
     template <class... Ts>
     auto match(Ts&&... ts) const {
         return value.match(std::forward<Ts>(ts)...);

--- a/include/mbgl/style/function/camera_function.hpp
+++ b/include/mbgl/style/function/camera_function.hpp
@@ -35,6 +35,7 @@ public:
     }
 
     Stops stops;
+    bool useIntegerZoom = false;
 };
 
 } // namespace style

--- a/include/mbgl/style/function/composite_function.hpp
+++ b/include/mbgl/style/function/composite_function.hpp
@@ -115,6 +115,7 @@ public:
     std::string property;
     Stops stops;
     optional<T> defaultValue;
+    bool useIntegerZoom = false;
 };
 
 } // namespace style

--- a/include/mbgl/style/function/source_function.hpp
+++ b/include/mbgl/style/function/source_function.hpp
@@ -53,6 +53,7 @@ public:
     std::string property;
     Stops stops;
     optional<T> defaultValue;
+    bool useIntegerZoom = false;
 };
 
 } // namespace style

--- a/include/mbgl/style/layers/layer.hpp.ejs
+++ b/include/mbgl/style/layers/layer.hpp.ejs
@@ -63,14 +63,14 @@ public:
 <% } -%>
     // Paint properties
 
-<% for (const property of paintProperties) { -%>
+<% for (const property of paintProperties) { if (!property.skip) { -%>
     static <%- propertyValueType(property) %> getDefault<%- camelize(property.name) %>();
     <%- propertyValueType(property) %> get<%- camelize(property.name) %>() const;
     void set<%- camelize(property.name) %>(<%- propertyValueType(property) %>);
     void set<%- camelize(property.name) %>Transition(const TransitionOptions&);
     TransitionOptions get<%- camelize(property.name) %>Transition() const;
 
-<% } -%>
+<% }} -%>
     // Private implementation
 
     class Impl;

--- a/include/mbgl/style/layers/line_layer.hpp
+++ b/include/mbgl/style/layers/line_layer.hpp
@@ -80,9 +80,9 @@ public:
     void setLineTranslateAnchorTransition(const TransitionOptions&);
     TransitionOptions getLineTranslateAnchorTransition() const;
 
-    static PropertyValue<float> getDefaultLineWidth();
-    PropertyValue<float> getLineWidth() const;
-    void setLineWidth(PropertyValue<float>);
+    static DataDrivenPropertyValue<float> getDefaultLineWidth();
+    DataDrivenPropertyValue<float> getLineWidth() const;
+    void setLineWidth(DataDrivenPropertyValue<float>);
     void setLineWidthTransition(const TransitionOptions&);
     TransitionOptions getLineWidthTransition() const;
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyFactory.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyFactory.java
@@ -322,11 +322,11 @@ public class PropertyFactory {
   /**
    * Stroke thickness.
    *
-   * @param <Z> the zoom parameter type
-   * @param function a wrapper {@link CameraFunction} for Float
+   * @param <T> the function input type
+   * @param function a wrapper function for Float
    * @return property wrapper around a Float function
    */
-  public static <Z extends Number> PropertyValue<CameraFunction<Z, Float>> lineWidth(CameraFunction<Z, Float> function) {
+  public static <T> PropertyValue<Function<T, Float>> lineWidth(Function<T, Float> function) {
     return new PaintPropertyValue<>("line-width", function);
   }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
@@ -697,6 +697,118 @@ public class LineLayerTest extends BaseActivityTest {
   }
 
   @Test
+  public void testLineWidthAsIdentitySourceFunction() {
+    validateTestSetup();
+    setupLayer();
+    Timber.i("line-width");
+    assertNotNull(layer);
+
+    // Set
+    layer.setProperties(
+      lineWidth(property("FeaturePropertyA", Stops.<Float>identity()))
+    );
+
+    // Verify
+    assertNotNull(layer.getLineWidth());
+    assertNotNull(layer.getLineWidth().getFunction());
+    assertEquals(SourceFunction.class, layer.getLineWidth().getFunction().getClass());
+    assertEquals("FeaturePropertyA", ((SourceFunction) layer.getLineWidth().getFunction()).getProperty());
+    assertEquals(IdentityStops.class, layer.getLineWidth().getFunction().getStops().getClass());
+  }
+
+  @Test
+  public void testLineWidthAsExponentialSourceFunction() {
+    validateTestSetup();
+    setupLayer();
+    Timber.i("line-width");
+    assertNotNull(layer);
+
+    // Set
+    layer.setProperties(
+      lineWidth(
+        property(
+          "FeaturePropertyA",
+          exponential(
+            stop(0.3f, lineWidth(0.3f))
+          ).withBase(0.5f)
+        )
+      )
+    );
+
+    // Verify
+    assertNotNull(layer.getLineWidth());
+    assertNotNull(layer.getLineWidth().getFunction());
+    assertEquals(SourceFunction.class, layer.getLineWidth().getFunction().getClass());
+    assertEquals("FeaturePropertyA", ((SourceFunction) layer.getLineWidth().getFunction()).getProperty());
+    assertEquals(ExponentialStops.class, layer.getLineWidth().getFunction().getStops().getClass());
+  }
+
+  @Test
+  public void testLineWidthAsCategoricalSourceFunction() {
+    validateTestSetup();
+    setupLayer();
+    Timber.i("line-width");
+    assertNotNull(layer);
+
+    // Set
+    layer.setProperties(
+      lineWidth(
+        property(
+          "FeaturePropertyA",
+          categorical(
+            stop(1.0f, lineWidth(0.3f))
+          )
+        ).withDefaultValue(lineWidth(0.3f))
+      )
+    );
+
+    // Verify
+    assertNotNull(layer.getLineWidth());
+    assertNotNull(layer.getLineWidth().getFunction());
+    assertEquals(SourceFunction.class, layer.getLineWidth().getFunction().getClass());
+    assertEquals("FeaturePropertyA", ((SourceFunction) layer.getLineWidth().getFunction()).getProperty());
+    assertEquals(CategoricalStops.class, layer.getLineWidth().getFunction().getStops().getClass());
+    assertNotNull(((SourceFunction) layer.getLineWidth().getFunction()).getDefaultValue());
+    assertNotNull(((SourceFunction) layer.getLineWidth().getFunction()).getDefaultValue().getValue());
+    assertEquals(0.3f, ((SourceFunction) layer.getLineWidth().getFunction()).getDefaultValue().getValue());
+  }
+
+  @Test
+  public void testLineWidthAsCompositeFunction() {
+    validateTestSetup();
+    setupLayer();
+    Timber.i("line-width");
+    assertNotNull(layer);
+
+    // Set
+    layer.setProperties(
+      lineWidth(
+        composite(
+          "FeaturePropertyA",
+          exponential(
+            stop(0, 0.3f, lineWidth(0.9f))
+          ).withBase(0.5f)
+        ).withDefaultValue(lineWidth(0.3f))
+      )
+    );
+
+    // Verify
+    assertNotNull(layer.getLineWidth());
+    assertNotNull(layer.getLineWidth().getFunction());
+    assertEquals(CompositeFunction.class, layer.getLineWidth().getFunction().getClass());
+    assertEquals("FeaturePropertyA", ((CompositeFunction) layer.getLineWidth().getFunction()).getProperty());
+    assertEquals(ExponentialStops.class, layer.getLineWidth().getFunction().getStops().getClass());
+    assertEquals(1, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).size());
+
+    ExponentialStops<Stop.CompositeValue<Float, Float>, Float> stops =
+      (ExponentialStops<Stop.CompositeValue<Float, Float>, Float>) layer.getLineWidth().getFunction().getStops();
+    Stop<Stop.CompositeValue<Float, Float>, Float> stop = stops.iterator().next();
+    assertEquals(0f, stop.in.zoom, 0.001);
+    assertEquals(0.3f, stop.in.value, 0.001f);
+    assertEquals(0.9f, stop.out, 0.001f);
+  }
+
+  @Test
   public void testLineGapWidthTransition() {
     validateTestSetup();
     setupLayer();

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -543,6 +543,15 @@ MGL_EXPORT
  * `MGLCameraStyleFunction` with an interpolation mode of:
    * `MGLInterpolationModeExponential`
    * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineWidth;
 

--- a/platform/darwin/src/MGLLineStyleLayer.mm
+++ b/platform/darwin/src/MGLLineStyleLayer.mm
@@ -480,7 +480,7 @@ namespace mbgl {
 - (void)setLineWidth:(MGLStyleValue<NSNumber *> *)lineWidth {
     MGLAssertStyleLayerIsValid();
 
-    auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toInterpolatablePropertyValue(lineWidth);
+    auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toDataDrivenPropertyValue(lineWidth);
     self.rawLayer->setLineWidth(mbglValue);
 }
 
@@ -489,9 +489,9 @@ namespace mbgl {
 
     auto propertyValue = self.rawLayer->getLineWidth();
     if (propertyValue.isUndefined()) {
-        return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(self.rawLayer->getDefaultLineWidth());
+        return MGLStyleValueTransformer<float, NSNumber *>().toDataDrivenStyleValue(self.rawLayer->getDefaultLineWidth());
     }
-    return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
+    return MGLStyleValueTransformer<float, NSNumber *>().toDataDrivenStyleValue(propertyValue);
 }
 
 - (void)setLineWidthTransition:(MGLTransition )transition {

--- a/platform/darwin/test/MGLLineStyleLayerTests.mm
+++ b/platform/darwin/test/MGLLineStyleLayerTests.mm
@@ -713,7 +713,7 @@
 
         MGLStyleValue<NSNumber *> *constantStyleValue = [MGLStyleValue<NSNumber *> valueWithRawValue:@0xff];
         layer.lineWidth = constantStyleValue;
-        mbgl::style::PropertyValue<float> propertyValue = { 0xff };
+        mbgl::style::DataDrivenPropertyValue<float> propertyValue = { 0xff };
         XCTAssertEqual(rawLayer->getLineWidth(), propertyValue,
                        @"Setting lineWidth to a constant value should update line-width.");
         XCTAssertEqualObjects(layer.lineWidth, constantStyleValue,
@@ -730,6 +730,29 @@
         XCTAssertEqualObjects(layer.lineWidth, functionStyleValue,
                               @"lineWidth should round-trip camera functions.");
 
+        functionStyleValue = [MGLStyleValue<NSNumber *> valueWithInterpolationMode:MGLInterpolationModeExponential sourceStops:@{@18: constantStyleValue} attributeName:@"keyName" options:nil];
+        layer.lineWidth = functionStyleValue;
+
+        mbgl::style::ExponentialStops<float> exponentialStops = { {{18, 0xff}}, 1.0 };
+        propertyValue = mbgl::style::SourceFunction<float> { "keyName", exponentialStops };
+
+        XCTAssertEqual(rawLayer->getLineWidth(), propertyValue,
+                       @"Setting lineWidth to a source function should update line-width.");
+        XCTAssertEqualObjects(layer.lineWidth, functionStyleValue,
+                              @"lineWidth should round-trip source functions.");
+
+        functionStyleValue = [MGLStyleValue<NSNumber *> valueWithInterpolationMode:MGLInterpolationModeExponential compositeStops:@{@10: @{@18: constantStyleValue}} attributeName:@"keyName" options:nil];
+        layer.lineWidth = functionStyleValue;
+
+        std::map<float, float> innerStops { {18, 0xff} };
+        mbgl::style::CompositeExponentialStops<float> compositeStops { { {10.0, innerStops} }, 1.0 };
+
+        propertyValue = mbgl::style::CompositeFunction<float> { "keyName", compositeStops };
+
+        XCTAssertEqual(rawLayer->getLineWidth(), propertyValue,
+                       @"Setting lineWidth to a composite function should update line-width.");
+        XCTAssertEqualObjects(layer.lineWidth, functionStyleValue,
+                              @"lineWidth should round-trip composite functions.");                                                                                                          
                               
 
         layer.lineWidth = nil;
@@ -737,11 +760,6 @@
                       @"Unsetting lineWidth should return line-width to the default value.");
         XCTAssertEqualObjects(layer.lineWidth, defaultStyleValue,
                               @"lineWidth should return the default value after being unset.");
-
-        functionStyleValue = [MGLStyleValue<NSNumber *> valueWithInterpolationMode:MGLInterpolationModeIdentity sourceStops:nil attributeName:@"" options:nil];
-        XCTAssertThrowsSpecificNamed(layer.lineWidth = functionStyleValue, NSException, NSInvalidArgumentException, @"MGLStyleValue should raise an exception if it is applied to a property that cannot support it");
-        functionStyleValue = [MGLStyleValue<NSNumber *> valueWithInterpolationMode:MGLInterpolationModeInterval compositeStops:@{@18: constantStyleValue} attributeName:@"" options:nil];
-        XCTAssertThrowsSpecificNamed(layer.lineWidth = functionStyleValue, NSException, NSInvalidArgumentException, @"MGLStyleValue should raise an exception if it is applied to a property that cannot support it");
         // Transition property test
         layer.lineWidthTransition = transitionTest;
         auto toptions = rawLayer->getLineWidthTransition();

--- a/scripts/generate-style-code.js
+++ b/scripts/generate-style-code.js
@@ -159,6 +159,12 @@ const layers = Object.keys(spec.layer.type.values).map((type) => {
   const paintProperties = Object.keys(spec[`paint_${type}`]).reduce((memo, name) => {
     spec[`paint_${type}`][name].name = name;
     memo.push(spec[`paint_${type}`][name]);
+    if (name === 'line-width') {
+      spec[`paint_${type}`]['line-floorwidth'] = Object.assign({}, spec[`paint_${type}`][name]);
+      spec[`paint_${type}`]['line-floorwidth'].name = 'line-floorwidth';
+      spec[`paint_${type}`]['line-floorwidth'].skip = true;
+      memo.push(spec[`paint_${type}`]['line-floorwidth']);
+    }
     return memo;
   }, []);
 

--- a/src/mbgl/programs/attributes.hpp
+++ b/src/mbgl/programs/attributes.hpp
@@ -96,6 +96,11 @@ struct a_width {
     using Type = gl::Attribute<float, 1>;
 };
 
+struct a_floorwidth {
+    static auto name() { return "a_floorwidth"; }
+    using Type = gl::Attribute<float, 1>;
+};
+
 struct a_height {
     static auto name() { return "a_height"; }
     using Type = gl::Attribute<float, 1>;

--- a/src/mbgl/programs/line_program.cpp
+++ b/src/mbgl/programs/line_program.cpp
@@ -25,7 +25,6 @@ Values makeValues(const LinePaintProperties::PossiblyEvaluated& properties,
                                   properties.get<LineTranslateAnchor>(),
                                   state)
         },
-        uniforms::u_width::Value{ properties.get<LineWidth>() },
         uniforms::u_ratio::Value{ 1.0f / tile.id.pixelsToTileUnits(1.0, state.getZoom()) },
         uniforms::u_gl_units_to_pixels::Value{{{ 1.0f / pixelsToGLUnits[0], 1.0f / pixelsToGLUnits[1] }}},
         std::forward<Args>(args)...
@@ -53,10 +52,9 @@ LineSDFProgram::uniformValues(const LinePaintProperties::PossiblyEvaluated& prop
                               const std::array<float, 2>& pixelsToGLUnits,
                               const LinePatternPos& posA,
                               const LinePatternPos& posB,
-                              float dashLineWidth,
                               float atlasWidth) {
-    const float widthA = posA.width * properties.get<LineDasharray>().fromScale * dashLineWidth;
-    const float widthB = posB.width * properties.get<LineDasharray>().toScale * dashLineWidth;
+    const float widthA = posA.width * properties.get<LineDasharray>().fromScale;
+    const float widthB = posB.width * properties.get<LineDasharray>().toScale;
 
     std::array<float, 2> scaleA {{
         1.0f / tile.id.pixelsToTileUnits(widthA, state.getIntegerZoom()),

--- a/src/mbgl/programs/line_program.hpp
+++ b/src/mbgl/programs/line_program.hpp
@@ -20,7 +20,6 @@ class SpriteAtlasElement;
 
 namespace uniforms {
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_ratio);
-MBGL_DEFINE_UNIFORM_SCALAR(float, u_width);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_tex_y_a);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_tex_y_b);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_sdfgamma);
@@ -41,7 +40,6 @@ class LineProgram : public Program<
     LineLayoutAttributes,
     gl::Uniforms<
         uniforms::u_matrix,
-        uniforms::u_width,
         uniforms::u_ratio,
         uniforms::u_gl_units_to_pixels>,
     style::LinePaintProperties>
@@ -103,7 +101,6 @@ class LinePatternProgram : public Program<
     LineLayoutAttributes,
     gl::Uniforms<
         uniforms::u_matrix,
-        uniforms::u_width,
         uniforms::u_ratio,
         uniforms::u_gl_units_to_pixels,
         uniforms::u_pattern_tl_a,
@@ -135,7 +132,6 @@ class LineSDFProgram : public Program<
     LineLayoutAttributes,
     gl::Uniforms<
         uniforms::u_matrix,
-        uniforms::u_width,
         uniforms::u_ratio,
         uniforms::u_gl_units_to_pixels,
         uniforms::u_patternscale_a,
@@ -157,7 +153,6 @@ public:
                                        const std::array<float, 2>& pixelsToGLUnits,
                                        const LinePatternPos& posA,
                                        const LinePatternPos& posB,
-                                       float dashLineWidth,
                                        float atlasWidth);
 };
 

--- a/src/mbgl/renderer/buckets/line_bucket.cpp
+++ b/src/mbgl/renderer/buckets/line_bucket.cpp
@@ -480,7 +480,7 @@ static float get(const RenderLineLayer& layer, const std::map<std::string, LineP
 }
 
 float LineBucket::getLineWidth(const RenderLineLayer& layer) const {
-    float lineWidth = layer.evaluated.get<LineWidth>();
+    float lineWidth = get<LineWidth>(layer, paintPropertyBinders);
     float gapWidth = get<LineGapWidth>(layer, paintPropertyBinders);
 
     if (gapWidth) {

--- a/src/mbgl/renderer/data_driven_property_evaluator.hpp
+++ b/src/mbgl/renderer/data_driven_property_evaluator.hpp
@@ -24,7 +24,11 @@ public:
     }
 
     ResultType operator()(const style::CameraFunction<T>& function) const {
-        return ResultType(function.evaluate(parameters.z));
+        if (!function.useIntegerZoom) {
+            return ResultType(function.evaluate(parameters.z));
+        } else {
+            return ResultType(function.evaluate(floor(parameters.z)));
+        }
     }
 
     template <class Function>

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -24,16 +24,11 @@ void RenderLineLayer::transition(const TransitionParameters& parameters) {
 }
 
 void RenderLineLayer::evaluate(const PropertyEvaluationParameters& parameters) {
-    // for scaling dasharrays
-    auto dashArrayParams = parameters;
-    dashArrayParams.z = std::floor(dashArrayParams.z);
-    dashLineWidth = unevaluated.evaluate<style::LineWidth>(dashArrayParams);
-
     evaluated = unevaluated.evaluate(parameters);
 
     passes = (evaluated.get<style::LineOpacity>().constantOr(1.0) > 0
               && evaluated.get<style::LineColor>().constantOr(Color::black()).a > 0
-              && evaluated.get<style::LineWidth>() > 0)
+              && evaluated.get<style::LineWidth>().constantOr(1.0) > 0)
              ? RenderPass::Translucent : RenderPass::None;
 }
 
@@ -102,7 +97,8 @@ bool RenderLineLayer::queryIntersectsFeature(
 }
 
 float RenderLineLayer::getLineWidth(const GeometryTileFeature& feature, const float zoom) const {
-    float lineWidth = evaluated.get<style::LineWidth>();
+    float lineWidth = evaluated.get<style::LineWidth>()
+            .evaluate(feature, zoom, style::LineWidth::defaultValue());
     float gapWidth = evaluated.get<style::LineGapWidth>()
             .evaluate(feature, zoom, style::LineGapWidth::defaultValue());
     if (gapWidth) {

--- a/src/mbgl/renderer/layers/render_line_layer.hpp
+++ b/src/mbgl/renderer/layers/render_line_layer.hpp
@@ -30,9 +30,6 @@ public:
 
     const style::LineLayer::Impl& impl() const;
 
-    // Special case
-    float dashLineWidth = 1;
-
 private:
     float getLineWidth(const GeometryTileFeature&, const float) const;
 };

--- a/src/mbgl/renderer/paint_property_binder.hpp
+++ b/src/mbgl/renderer/paint_property_binder.hpp
@@ -218,7 +218,11 @@ public:
     }
 
     float interpolationFactor(float currentZoom) const override {
-        return util::interpolationFactor(1.0f, std::get<0>(coveringRanges), currentZoom);
+        if (function.useIntegerZoom) {
+            return util::interpolationFactor(1.0f, std::get<0>(coveringRanges), floor(currentZoom));
+        } else {
+            return util::interpolationFactor(1.0f, std::get<0>(coveringRanges), currentZoom);
+        }
     }
 
 private:

--- a/src/mbgl/renderer/painters/painter_line.cpp
+++ b/src/mbgl/renderer/painters/painter_line.cpp
@@ -57,7 +57,6 @@ void Painter::renderLine(PaintParameters& parameters,
                  pixelsToGLUnits,
                  posA,
                  posB,
-                 layer.dashLineWidth,
                  lineAtlas->getSize().width));
 
     } else if (!properties.get<LinePattern>().from.empty()) {

--- a/src/mbgl/renderer/possibly_evaluated_property_value.hpp
+++ b/src/mbgl/renderer/possibly_evaluated_property_value.hpp
@@ -48,7 +48,13 @@ public:
                     return function.evaluate(feature, defaultValue);
                 },
                 [&] (const style::CompositeFunction<T>& function) {
-                    return function.evaluate(zoom, feature, defaultValue);
+                    return function.evaluate(floor(zoom), feature, defaultValue);
+                    // TODO when is this evaluate used? 
+//                    if (!function.useIntegerZoom) {
+//                        return function.evaluate(zoom, feature, defaultValue);
+//                    } else {
+//                        return function.evaluate(floor(zoom), feature, defaultValue);
+//                    }
                 }
         );
     }

--- a/src/mbgl/shaders/line.cpp
+++ b/src/mbgl/shaders/line.cpp
@@ -26,7 +26,6 @@ attribute vec4 a_data;
 
 uniform mat4 u_matrix;
 uniform mediump float u_ratio;
-uniform mediump float u_width;
 uniform vec2 u_gl_units_to_pixels;
 
 varying vec2 v_normal;
@@ -48,6 +47,9 @@ varying mediump float gapwidth;
 uniform lowp float a_offset_t;
 attribute lowp vec2 a_offset;
 varying lowp float offset;
+uniform lowp float a_width_t;
+attribute mediump vec2 a_width;
+varying mediump float width;
 
 void main() {
     color = unpack_mix_vec4(a_color, a_color_t);
@@ -55,6 +57,7 @@ void main() {
     opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
     gapwidth = unpack_mix_vec2(a_gapwidth, a_gapwidth_t);
     offset = unpack_mix_vec2(a_offset, a_offset_t);
+    width = unpack_mix_vec2(a_width, a_width_t);
 
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;
@@ -71,11 +74,11 @@ void main() {
     // these transformations used to be applied in the JS and native code bases. 
     // moved them into the shader for clarity and simplicity. 
     gapwidth = gapwidth / 2.0;
-    float width = u_width / 2.0;
+    float halfwidth = width / 2.0;
     offset = -1.0 * offset; 
 
     float inset = gapwidth + (gapwidth > 0.0 ? ANTIALIASING : 0.0);
-    float outset = gapwidth + width * (gapwidth > 0.0 ? 2.0 : 1.0) + ANTIALIASING;
+    float outset = gapwidth + halfwidth * (gapwidth > 0.0 ? 2.0 : 1.0) + ANTIALIASING;
 
     // Scale the extrusion vector down to a normal and then up by the line width
     // of this vertex.

--- a/src/mbgl/shaders/line_pattern.cpp
+++ b/src/mbgl/shaders/line_pattern.cpp
@@ -28,7 +28,6 @@ attribute vec4 a_data;
 
 uniform mat4 u_matrix;
 uniform mediump float u_ratio;
-uniform mediump float u_width;
 uniform vec2 u_gl_units_to_pixels;
 
 varying vec2 v_normal;
@@ -48,12 +47,16 @@ varying lowp float offset;
 uniform lowp float a_gapwidth_t;
 attribute mediump vec2 a_gapwidth;
 varying mediump float gapwidth;
+uniform lowp float a_width_t;
+attribute mediump vec2 a_width;
+varying mediump float width;
 
 void main() {
     blur = unpack_mix_vec2(a_blur, a_blur_t);
     opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
     offset = unpack_mix_vec2(a_offset, a_offset_t);
     gapwidth = unpack_mix_vec2(a_gapwidth, a_gapwidth_t);
+    width = unpack_mix_vec2(a_width, a_width_t);
 
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;
@@ -70,11 +73,11 @@ void main() {
     // these transformations used to be applied in the JS and native code bases. 
     // moved them into the shader for clarity and simplicity. 
     gapwidth = gapwidth / 2.0;
-    float width = u_width / 2.0;
+    float halfwidth = width / 2.0;
     offset = -1.0 * offset; 
 
     float inset = gapwidth + (gapwidth > 0.0 ? ANTIALIASING : 0.0);
-    float outset = gapwidth + width * (gapwidth > 0.0 ? 2.0 : 1.0) + ANTIALIASING;
+    float outset = gapwidth + halfwidth * (gapwidth > 0.0 ? 2.0 : 1.0) + ANTIALIASING;
 
     // Scale the extrusion vector down to a normal and then up by the line width
     // of this vertex.

--- a/src/mbgl/style/layers/layer.cpp.ejs
+++ b/src/mbgl/style/layers/layer.cpp.ejs
@@ -132,7 +132,7 @@ void <%- camelize(type) %>Layer::set<%- camelize(property.name) %>(<%- propertyV
 <% } -%>
 
 // Paint properties
-<% for (const property of paintProperties) { %>
+<% for (const property of paintProperties) { if (!property.skip) { %>
 <%- propertyValueType(property) %> <%- camelize(type) %>Layer::getDefault<%- camelize(property.name) %>() {
     return { <%- defaultValue(property) %> };
 }
@@ -146,6 +146,10 @@ void <%- camelize(type) %>Layer::set<%- camelize(property.name) %>(<%- propertyV
         return;
     auto impl_ = mutableImpl();
     impl_->paint.template get<<%- camelize(property.name) %>>().value = value;
+<% if (property.name === "line-width") { -%>
+    impl_->paint.template get<LineFloorwidth>().value = value;
+    impl_->paint.template get<LineFloorwidth>().value.useIntegerZoom();
+<% } -%>
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
@@ -159,7 +163,7 @@ void <%- camelize(type) %>Layer::set<%- camelize(property.name) %>Transition(con
 TransitionOptions <%- camelize(type) %>Layer::get<%- camelize(property.name) %>Transition() const {
     return impl().paint.template get<<%- camelize(property.name) %>>().options;
 }
-<% } -%>
+<% }} -%>
 
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -267,19 +267,21 @@ TransitionOptions LineLayer::getLineTranslateAnchorTransition() const {
     return impl().paint.template get<LineTranslateAnchor>().options;
 }
 
-PropertyValue<float> LineLayer::getDefaultLineWidth() {
+DataDrivenPropertyValue<float> LineLayer::getDefaultLineWidth() {
     return { 1 };
 }
 
-PropertyValue<float> LineLayer::getLineWidth() const {
+DataDrivenPropertyValue<float> LineLayer::getLineWidth() const {
     return impl().paint.template get<LineWidth>().value;
 }
 
-void LineLayer::setLineWidth(PropertyValue<float> value) {
+void LineLayer::setLineWidth(DataDrivenPropertyValue<float> value) {
     if (value == getLineWidth())
         return;
     auto impl_ = mutableImpl();
     impl_->paint.template get<LineWidth>().value = value;
+    impl_->paint.template get<LineFloorwidth>().value = value;
+    impl_->paint.template get<LineFloorwidth>().value.useIntegerZoom();
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }

--- a/src/mbgl/style/layers/line_layer_properties.hpp
+++ b/src/mbgl/style/layers/line_layer_properties.hpp
@@ -47,7 +47,11 @@ struct LineTranslateAnchor : PaintProperty<TranslateAnchorType> {
     static TranslateAnchorType defaultValue() { return TranslateAnchorType::Map; }
 };
 
-struct LineWidth : PaintProperty<float> {
+struct LineWidth : DataDrivenPaintProperty<float, attributes::a_width> {
+    static float defaultValue() { return 1; }
+};
+
+struct LineFloorwidth : DataDrivenPaintProperty<float, attributes::a_floorwidth> {
     static float defaultValue() { return 1; }
 };
 
@@ -84,6 +88,7 @@ class LinePaintProperties : public Properties<
     LineTranslate,
     LineTranslateAnchor,
     LineWidth,
+    LineFloorwidth,
     LineGapWidth,
     LineOffset,
     LineBlur,


### PR DESCRIPTION
Counterpart of https://github.com/mapbox/mapbox-gl-js/pull/4773.

To accomplish the same special casing here this PR
* adds a `line-floorwidth` property at runtime in `generate-style-code.js` when it encounters `line-width`, with a `skip: true` property used by other ejs files to selectively generate property classes
* the generated `LineLayer::setLineWidth` method sets `LineFloorwidth` as the same time as it sets `LineWidth`, and immediately marks that property to `useIntegerZoom()`:
* `DataDrivenPropertyValue::useIntegerZoom()` sets a `bool useIntegerZoom` on function values, which are used to determine whether to floor a zoom value in evaluating camera and composite functions

One thing I wasn't sure about was the `evaluate()` in `src/mbgl/renderer/possibly_evaluated_property_value.hpp` ([this TODO](https://github.com/mapbox/mapbox-gl-native/pull/9214/files#diff-9b2860a37a56a6fa6c2648fb5f05a292R52)) — in manually testing this with multiple combinations of constant/camera/source/composite functions, I never hit this breakpoint — how is this used, and is it also somewhere we should conditionally evaluate using integer zooms?