### PR TITLE
Mutex guard annotation manager for cross thread usage

### DIFF
--- a/src/mbgl/annotation/annotation_manager.hpp
+++ b/src/mbgl/annotation/annotation_manager.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/map/update.hpp>
 #include <mbgl/util/noncopyable.hpp>
 
+#include <mutex>
 #include <string>
 #include <vector>
 #include <unordered_set>
@@ -56,7 +57,11 @@ private:
 
     void removeAndAdd(const AnnotationID&, const Annotation&, const uint8_t);
 
+    void remove(const AnnotationID&);
+
     std::unique_ptr<AnnotationTileData> getTileData(const CanonicalTileID&);
+
+    std::mutex mutex;
 
     AnnotationID nextID = 0;
 


### PR DESCRIPTION
Alternative for #9208 to make annotations thread safe for asynchronous rendering (#8820)