### PR TITLE
[android] - correct source changed map event javadoc

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -774,7 +774,7 @@ public class MapView extends FrameLayout {
   public static final int DID_FINISH_LOADING_STYLE = 14;
 
   /**
-   * This {@link MapChange} is triggered when a source attribution changes.
+   * This {@link MapChange} is triggered when a source changes.
    * <p>
    * Register to {@link MapChange} events with {@link MapView#addOnMapChangedListener(OnMapChangedListener)}.
    * </p>


### PR DESCRIPTION
Capturing from @ivovandongen that source changes can also be triggered by data changes (eg. image source) (thus not only source attribution changes). This means that the javadoc is incorrect and needs to be altered.  