### PR TITLE
Verify that the active uniform types match our assumed types

### DIFF
--- a/src/mbgl/gl/types.hpp
+++ b/src/mbgl/gl/types.hpp
@@ -80,5 +80,25 @@ constexpr bool operator!=(const PixelStorageType& a, const PixelStorageType& b) 
 
 using BinaryProgramFormat = uint32_t;
 
+enum class UniformDataType : uint32_t {
+    Float = 0x1406,
+    FloatVec2 = 0x8B50,
+    FloatVec3 = 0x8B51,
+    FloatVec4 = 0x8B52,
+    Int = 0x1404,
+    IntVec2 = 0x8B53,
+    IntVec3 = 0x8B54,
+    IntVec4 = 0x8B55,
+    Bool = 0x8B56,
+    BoolVec2 = 0x8B57,
+    BoolVec3 = 0x8B58,
+    BoolVec4 = 0x8B59,
+    FloatMat2 = 0x8B5A,
+    FloatMat3 = 0x8B5B,
+    FloatMat4 = 0x8B5C,
+    Sampler2D = 0x8B5E,
+    SamplerCube = 0x8B60,
+};
+
 } // namespace gl
 } // namespace mbgl

--- a/src/mbgl/gl/uniform.hpp
+++ b/src/mbgl/gl/uniform.hpp
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <vector>
+#include <map>
 #include <functional>
 
 namespace mbgl {
@@ -22,10 +23,28 @@ public:
     T t;
 };
 
+class ActiveUniform {
+public:
+    std::size_t size;
+    UniformDataType type;
+};
+
+#ifndef NDEBUG
+
+template <class T>
+bool verifyUniform(const ActiveUniform&);
+
+using ActiveUniforms = std::map<std::string, ActiveUniform>;
+ActiveUniforms activeUniforms(ProgramID);
+
+#endif
+
 template <class Tag, class T>
 class Uniform {
 public:
     using Value = UniformValue<Tag, T>;
+
+    using Type = T;
 
     class State {
     public:
@@ -70,6 +89,18 @@ public:
     using NamedLocations = std::vector<std::pair<const std::string, UniformLocation>>;
 
     static State bindLocations(const ProgramID& id) {
+#ifndef NDEBUG
+        // Verify active uniform types match the enum
+        const auto active = activeUniforms(id);
+
+        util::ignore(
+            { // Some shader programs have uniforms declared, but not used, so they're not active.
+              // Therefore, we'll only verify them when they are indeed active.
+              (active.find(Us::name()) != active.end()
+                   ? verifyUniform<typename Us::Type>(active.at(Us::name()))
+                   : false)... });
+#endif
+
         return State { { uniformLocation(id, Us::name()) }... };
     }
 


### PR DESCRIPTION
Add debug-only code that verifies that the uniform types in the shader match the types that we are assuming when declaring our programs. Since there is no way to bail out of this, I added `assert`s and made it debug-only.