### PR TITLE
Enable property functions for line-width

### DIFF
--- a/include/mbgl/annotation/annotation.hpp
+++ b/include/mbgl/annotation/annotation.hpp
@@ -31,7 +31,7 @@ class LineAnnotation {
 public:
     ShapeAnnotationGeometry geometry;
     style::DataDrivenPropertyValue<float> opacity { 1.0f };
-    style::PropertyValue<float> width { 1.0f };
+    style::DataDrivenPropertyValue<float> width { 1.0f };
     style::DataDrivenPropertyValue<Color> color { Color::black() };
 };
 

--- a/include/mbgl/style/conversion/make_property_setters.hpp
+++ b/include/mbgl/style/conversion/make_property_setters.hpp
@@ -99,7 +99,7 @@ auto makePaintPropertySetters() {
     result["line-translate-transition"] = &setTransition<V, LineLayer, &LineLayer::setLineTranslateTransition>;
     result["line-translate-anchor"] = &setProperty<V, LineLayer, PropertyValue<TranslateAnchorType>, &LineLayer::setLineTranslateAnchor>;
     result["line-translate-anchor-transition"] = &setTransition<V, LineLayer, &LineLayer::setLineTranslateAnchorTransition>;
-    result["line-width"] = &setProperty<V, LineLayer, PropertyValue<float>, &LineLayer::setLineWidth>;
+    result["line-width"] = &setProperty<V, LineLayer, DataDrivenPropertyValue<float>, &LineLayer::setLineWidth>;
     result["line-width-transition"] = &setTransition<V, LineLayer, &LineLayer::setLineWidthTransition>;
     result["line-gap-width"] = &setProperty<V, LineLayer, DataDrivenPropertyValue<float>, &LineLayer::setLineGapWidth>;
     result["line-gap-width-transition"] = &setTransition<V, LineLayer, &LineLayer::setLineGapWidthTransition>;

--- a/include/mbgl/style/data_driven_property_value.hpp
+++ b/include/mbgl/style/data_driven_property_value.hpp
@@ -49,7 +49,7 @@ public:
     bool isZoomConstant() const {
         return !value.template is<CameraFunction<T>>() && !value.template is<CompositeFunction<T>>();
     }
-    
+
     template <class... Ts>
     auto match(Ts&&... ts) const {
         return value.match(std::forward<Ts>(ts)...);

--- a/include/mbgl/style/function/camera_function.hpp
+++ b/include/mbgl/style/function/camera_function.hpp
@@ -35,6 +35,7 @@ public:
     }
 
     Stops stops;
+    bool useIntegerZoom = false;
 };
 
 } // namespace style

--- a/include/mbgl/style/function/composite_function.hpp
+++ b/include/mbgl/style/function/composite_function.hpp
@@ -135,6 +135,7 @@ public:
     std::string property;
     Stops stops;
     optional<T> defaultValue;
+    bool useIntegerZoom = false;
 
 private:
     T evaluateFinal(const CoveringRanges& ranges, const Value& value, T finalDefaultValue) const {

--- a/include/mbgl/style/function/source_function.hpp
+++ b/include/mbgl/style/function/source_function.hpp
@@ -53,6 +53,7 @@ public:
     std::string property;
     Stops stops;
     optional<T> defaultValue;
+    bool useIntegerZoom = false;
 };
 
 } // namespace style

--- a/include/mbgl/style/layers/line_layer.hpp
+++ b/include/mbgl/style/layers/line_layer.hpp
@@ -80,9 +80,9 @@ public:
     void setLineTranslateAnchorTransition(const TransitionOptions&);
     TransitionOptions getLineTranslateAnchorTransition() const;
 
-    static PropertyValue<float> getDefaultLineWidth();
-    PropertyValue<float> getLineWidth() const;
-    void setLineWidth(PropertyValue<float>);
+    static DataDrivenPropertyValue<float> getDefaultLineWidth();
+    DataDrivenPropertyValue<float> getLineWidth() const;
+    void setLineWidth(DataDrivenPropertyValue<float>);
     void setLineWidthTransition(const TransitionOptions&);
     TransitionOptions getLineWidthTransition() const;
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyFactory.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyFactory.java
@@ -322,11 +322,11 @@ public class PropertyFactory {
   /**
    * Stroke thickness.
    *
-   * @param <Z> the zoom parameter type
-   * @param function a wrapper {@link CameraFunction} for Float
+   * @param <T> the function input type
+   * @param function a wrapper function for Float
    * @return property wrapper around a Float function
    */
-  public static <Z extends Number> PropertyValue<CameraFunction<Z, Float>> lineWidth(CameraFunction<Z, Float> function) {
+  public static <T> PropertyValue<Function<T, Float>> lineWidth(Function<T, Float> function) {
     return new PaintPropertyValue<>("line-width", function);
   }
 
@@ -1676,7 +1676,7 @@ public class PropertyFactory {
   }
 
   /**
-   * Scale factor for icon. 1 is original size, 3 triples the size.
+   * Scales the original size of the icon by the provided factor. The new pixel size of the image will be the original pixel size multiplied by {@link PropertyFactory#iconSize}. 1 is the original size; 3 triples the size of the image.
    *
    * @param value a Float value
    * @return property wrapper around Float
@@ -1688,7 +1688,7 @@ public class PropertyFactory {
 
 
   /**
-   * Scale factor for icon. 1 is original size, 3 triples the size.
+   * Scales the original size of the icon by the provided factor. The new pixel size of the image will be the original pixel size multiplied by {@link PropertyFactory#iconSize}. 1 is the original size; 3 triples the size of the image.
    *
    * @param <T> the function input type
    * @param function a wrapper function for Float

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
@@ -697,6 +697,118 @@ public class LineLayerTest extends BaseActivityTest {
   }
 
   @Test
+  public void testLineWidthAsIdentitySourceFunction() {
+    validateTestSetup();
+    setupLayer();
+    Timber.i("line-width");
+    assertNotNull(layer);
+
+    // Set
+    layer.setProperties(
+      lineWidth(property("FeaturePropertyA", Stops.<Float>identity()))
+    );
+
+    // Verify
+    assertNotNull(layer.getLineWidth());
+    assertNotNull(layer.getLineWidth().getFunction());
+    assertEquals(SourceFunction.class, layer.getLineWidth().getFunction().getClass());
+    assertEquals("FeaturePropertyA", ((SourceFunction) layer.getLineWidth().getFunction()).getProperty());
+    assertEquals(IdentityStops.class, layer.getLineWidth().getFunction().getStops().getClass());
+  }
+
+  @Test
+  public void testLineWidthAsExponentialSourceFunction() {
+    validateTestSetup();
+    setupLayer();
+    Timber.i("line-width");
+    assertNotNull(layer);
+
+    // Set
+    layer.setProperties(
+      lineWidth(
+        property(
+          "FeaturePropertyA",
+          exponential(
+            stop(0.3f, lineWidth(0.3f))
+          ).withBase(0.5f)
+        )
+      )
+    );
+
+    // Verify
+    assertNotNull(layer.getLineWidth());
+    assertNotNull(layer.getLineWidth().getFunction());
+    assertEquals(SourceFunction.class, layer.getLineWidth().getFunction().getClass());
+    assertEquals("FeaturePropertyA", ((SourceFunction) layer.getLineWidth().getFunction()).getProperty());
+    assertEquals(ExponentialStops.class, layer.getLineWidth().getFunction().getStops().getClass());
+  }
+
+  @Test
+  public void testLineWidthAsCategoricalSourceFunction() {
+    validateTestSetup();
+    setupLayer();
+    Timber.i("line-width");
+    assertNotNull(layer);
+
+    // Set
+    layer.setProperties(
+      lineWidth(
+        property(
+          "FeaturePropertyA",
+          categorical(
+            stop(1.0f, lineWidth(0.3f))
+          )
+        ).withDefaultValue(lineWidth(0.3f))
+      )
+    );
+
+    // Verify
+    assertNotNull(layer.getLineWidth());
+    assertNotNull(layer.getLineWidth().getFunction());
+    assertEquals(SourceFunction.class, layer.getLineWidth().getFunction().getClass());
+    assertEquals("FeaturePropertyA", ((SourceFunction) layer.getLineWidth().getFunction()).getProperty());
+    assertEquals(CategoricalStops.class, layer.getLineWidth().getFunction().getStops().getClass());
+    assertNotNull(((SourceFunction) layer.getLineWidth().getFunction()).getDefaultValue());
+    assertNotNull(((SourceFunction) layer.getLineWidth().getFunction()).getDefaultValue().getValue());
+    assertEquals(0.3f, ((SourceFunction) layer.getLineWidth().getFunction()).getDefaultValue().getValue());
+  }
+
+  @Test
+  public void testLineWidthAsCompositeFunction() {
+    validateTestSetup();
+    setupLayer();
+    Timber.i("line-width");
+    assertNotNull(layer);
+
+    // Set
+    layer.setProperties(
+      lineWidth(
+        composite(
+          "FeaturePropertyA",
+          exponential(
+            stop(0, 0.3f, lineWidth(0.9f))
+          ).withBase(0.5f)
+        ).withDefaultValue(lineWidth(0.3f))
+      )
+    );
+
+    // Verify
+    assertNotNull(layer.getLineWidth());
+    assertNotNull(layer.getLineWidth().getFunction());
+    assertEquals(CompositeFunction.class, layer.getLineWidth().getFunction().getClass());
+    assertEquals("FeaturePropertyA", ((CompositeFunction) layer.getLineWidth().getFunction()).getProperty());
+    assertEquals(ExponentialStops.class, layer.getLineWidth().getFunction().getStops().getClass());
+    assertEquals(1, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).size());
+
+    ExponentialStops<Stop.CompositeValue<Float, Float>, Float> stops =
+      (ExponentialStops<Stop.CompositeValue<Float, Float>, Float>) layer.getLineWidth().getFunction().getStops();
+    Stop<Stop.CompositeValue<Float, Float>, Float> stop = stops.iterator().next();
+    assertEquals(0f, stop.in.zoom, 0.001);
+    assertEquals(0.3f, stop.in.value, 0.001f);
+    assertEquals(0.9f, stop.out, 0.001f);
+  }
+
+  @Test
   public void testLineGapWidthTransition() {
     validateTestSetup();
     setupLayer();

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -543,6 +543,15 @@ MGL_EXPORT
  * `MGLCameraStyleFunction` with an interpolation mode of:
    * `MGLInterpolationModeExponential`
    * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineWidth;
 

--- a/platform/darwin/src/MGLLineStyleLayer.mm
+++ b/platform/darwin/src/MGLLineStyleLayer.mm
@@ -480,7 +480,7 @@ namespace mbgl {
 - (void)setLineWidth:(MGLStyleValue<NSNumber *> *)lineWidth {
     MGLAssertStyleLayerIsValid();
 
-    auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toInterpolatablePropertyValue(lineWidth);
+    auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toDataDrivenPropertyValue(lineWidth);
     self.rawLayer->setLineWidth(mbglValue);
 }
 
@@ -489,9 +489,9 @@ namespace mbgl {
 
     auto propertyValue = self.rawLayer->getLineWidth();
     if (propertyValue.isUndefined()) {
-        return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(self.rawLayer->getDefaultLineWidth());
+        return MGLStyleValueTransformer<float, NSNumber *>().toDataDrivenStyleValue(self.rawLayer->getDefaultLineWidth());
     }
-    return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
+    return MGLStyleValueTransformer<float, NSNumber *>().toDataDrivenStyleValue(propertyValue);
 }
 
 - (void)setLineWidthTransition:(MGLTransition )transition {

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -533,7 +533,11 @@ MGL_EXPORT
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconRotationAlignment;
 
 /**
- Scale factor for icon. 1 is original size, 3 triples the size.
+ Scales the original size of the icon by the provided factor. The new point size
+ of the image will be the original point size multiplied by `iconSize`. 1 is the
+ original size; 3 triples the size of the image.
+ 
+ This property is measured in factor of the original icon sizes.
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset

--- a/platform/darwin/test/MGLLineStyleLayerTests.mm
+++ b/platform/darwin/test/MGLLineStyleLayerTests.mm
@@ -713,7 +713,7 @@
 
         MGLStyleValue<NSNumber *> *constantStyleValue = [MGLStyleValue<NSNumber *> valueWithRawValue:@0xff];
         layer.lineWidth = constantStyleValue;
-        mbgl::style::PropertyValue<float> propertyValue = { 0xff };
+        mbgl::style::DataDrivenPropertyValue<float> propertyValue = { 0xff };
         XCTAssertEqual(rawLayer->getLineWidth(), propertyValue,
                        @"Setting lineWidth to a constant value should update line-width.");
         XCTAssertEqualObjects(layer.lineWidth, constantStyleValue,
@@ -730,6 +730,29 @@
         XCTAssertEqualObjects(layer.lineWidth, functionStyleValue,
                               @"lineWidth should round-trip camera functions.");
 
+        functionStyleValue = [MGLStyleValue<NSNumber *> valueWithInterpolationMode:MGLInterpolationModeExponential sourceStops:@{@18: constantStyleValue} attributeName:@"keyName" options:nil];
+        layer.lineWidth = functionStyleValue;
+
+        mbgl::style::ExponentialStops<float> exponentialStops = { {{18, 0xff}}, 1.0 };
+        propertyValue = mbgl::style::SourceFunction<float> { "keyName", exponentialStops };
+
+        XCTAssertEqual(rawLayer->getLineWidth(), propertyValue,
+                       @"Setting lineWidth to a source function should update line-width.");
+        XCTAssertEqualObjects(layer.lineWidth, functionStyleValue,
+                              @"lineWidth should round-trip source functions.");
+
+        functionStyleValue = [MGLStyleValue<NSNumber *> valueWithInterpolationMode:MGLInterpolationModeExponential compositeStops:@{@10: @{@18: constantStyleValue}} attributeName:@"keyName" options:nil];
+        layer.lineWidth = functionStyleValue;
+
+        std::map<float, float> innerStops { {18, 0xff} };
+        mbgl::style::CompositeExponentialStops<float> compositeStops { { {10.0, innerStops} }, 1.0 };
+
+        propertyValue = mbgl::style::CompositeFunction<float> { "keyName", compositeStops };
+
+        XCTAssertEqual(rawLayer->getLineWidth(), propertyValue,
+                       @"Setting lineWidth to a composite function should update line-width.");
+        XCTAssertEqualObjects(layer.lineWidth, functionStyleValue,
+                              @"lineWidth should round-trip composite functions.");                                                                                                          
                               
 
         layer.lineWidth = nil;
@@ -737,11 +760,6 @@
                       @"Unsetting lineWidth should return line-width to the default value.");
         XCTAssertEqualObjects(layer.lineWidth, defaultStyleValue,
                               @"lineWidth should return the default value after being unset.");
-
-        functionStyleValue = [MGLStyleValue<NSNumber *> valueWithInterpolationMode:MGLInterpolationModeIdentity sourceStops:nil attributeName:@"" options:nil];
-        XCTAssertThrowsSpecificNamed(layer.lineWidth = functionStyleValue, NSException, NSInvalidArgumentException, @"MGLStyleValue should raise an exception if it is applied to a property that cannot support it");
-        functionStyleValue = [MGLStyleValue<NSNumber *> valueWithInterpolationMode:MGLInterpolationModeInterval compositeStops:@{@18: constantStyleValue} attributeName:@"" options:nil];
-        XCTAssertThrowsSpecificNamed(layer.lineWidth = functionStyleValue, NSException, NSInvalidArgumentException, @"MGLStyleValue should raise an exception if it is applied to a property that cannot support it");
         // Transition property test
         layer.lineWidthTransition = transitionTest;
         auto toptions = rawLayer->getLineWidthTransition();

--- a/src/mbgl/programs/attributes.hpp
+++ b/src/mbgl/programs/attributes.hpp
@@ -96,6 +96,11 @@ struct a_width {
     using Type = gl::Attribute<float, 1>;
 };
 
+struct a_floorwidth {
+    static auto name() { return "a_floorwidth"; }
+    using Type = gl::Attribute<float, 1>;
+};
+
 struct a_height {
     static auto name() { return "a_height"; }
     using Type = gl::Attribute<float, 1>;

--- a/src/mbgl/programs/line_program.cpp
+++ b/src/mbgl/programs/line_program.cpp
@@ -13,7 +13,7 @@ using namespace style;
 static_assert(sizeof(LineLayoutVertex) == 8, "expected LineLayoutVertex size");
 
 template <class Values, class...Args>
-Values makeValues(const LinePaintProperties::PossiblyEvaluated& properties,
+Values makeValues(const RenderLinePaintProperties::PossiblyEvaluated& properties,
                   const RenderTile& tile,
                   const TransformState& state,
                   const std::array<float, 2>& pixelsToGLUnits,
@@ -25,7 +25,6 @@ Values makeValues(const LinePaintProperties::PossiblyEvaluated& properties,
                                   properties.get<LineTranslateAnchor>(),
                                   state)
         },
-        uniforms::u_width::Value{ properties.get<LineWidth>() },
         uniforms::u_ratio::Value{ 1.0f / tile.id.pixelsToTileUnits(1.0, state.getZoom()) },
         uniforms::u_gl_units_to_pixels::Value{{{ 1.0f / pixelsToGLUnits[0], 1.0f / pixelsToGLUnits[1] }}},
         std::forward<Args>(args)...
@@ -33,7 +32,7 @@ Values makeValues(const LinePaintProperties::PossiblyEvaluated& properties,
 }
 
 LineProgram::UniformValues
-LineProgram::uniformValues(const LinePaintProperties::PossiblyEvaluated& properties,
+LineProgram::uniformValues(const RenderLinePaintProperties::PossiblyEvaluated& properties,
                            const RenderTile& tile,
                            const TransformState& state,
                            const std::array<float, 2>& pixelsToGLUnits) {
@@ -46,17 +45,16 @@ LineProgram::uniformValues(const LinePaintProperties::PossiblyEvaluated& propert
 }
 
 LineSDFProgram::UniformValues
-LineSDFProgram::uniformValues(const LinePaintProperties::PossiblyEvaluated& properties,
+LineSDFProgram::uniformValues(const RenderLinePaintProperties::PossiblyEvaluated& properties,
                               float pixelRatio,
                               const RenderTile& tile,
                               const TransformState& state,
                               const std::array<float, 2>& pixelsToGLUnits,
                               const LinePatternPos& posA,
                               const LinePatternPos& posB,
-                              float dashLineWidth,
                               float atlasWidth) {
-    const float widthA = posA.width * properties.get<LineDasharray>().fromScale * dashLineWidth;
-    const float widthB = posB.width * properties.get<LineDasharray>().toScale * dashLineWidth;
+    const float widthA = posA.width * properties.get<LineDasharray>().fromScale;
+    const float widthB = posB.width * properties.get<LineDasharray>().toScale;
 
     std::array<float, 2> scaleA {{
         1.0f / tile.id.pixelsToTileUnits(widthA, state.getIntegerZoom()),
@@ -84,7 +82,7 @@ LineSDFProgram::uniformValues(const LinePaintProperties::PossiblyEvaluated& prop
 }
 
 LinePatternProgram::UniformValues
-LinePatternProgram::uniformValues(const LinePaintProperties::PossiblyEvaluated& properties,
+LinePatternProgram::uniformValues(const RenderLinePaintProperties::PossiblyEvaluated& properties,
                                   const RenderTile& tile,
                                   const TransformState& state,
                                   const std::array<float, 2>& pixelsToGLUnits,

--- a/src/mbgl/programs/line_program.hpp
+++ b/src/mbgl/programs/line_program.hpp
@@ -7,7 +7,7 @@
 #include <mbgl/shaders/line_pattern.hpp>
 #include <mbgl/shaders/line_sdf.hpp>
 #include <mbgl/util/geometry.hpp>
-#include <mbgl/style/layers/line_layer_properties.hpp>
+#include <mbgl/renderer/layers/render_line_layer.hpp>
 
 #include <cmath>
 
@@ -20,7 +20,6 @@ class ImagePosition;
 
 namespace uniforms {
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_ratio);
-MBGL_DEFINE_UNIFORM_SCALAR(float, u_width);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_tex_y_a);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_tex_y_b);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_sdfgamma);
@@ -41,10 +40,9 @@ class LineProgram : public Program<
     LineLayoutAttributes,
     gl::Uniforms<
         uniforms::u_matrix,
-        uniforms::u_width,
         uniforms::u_ratio,
         uniforms::u_gl_units_to_pixels>,
-    style::LinePaintProperties>
+    RenderLinePaintProperties>
 {
 public:
     using Program::Program;
@@ -91,7 +89,7 @@ public:
      */
     static const int8_t extrudeScale = 63;
 
-    static UniformValues uniformValues(const style::LinePaintProperties::PossiblyEvaluated&,
+    static UniformValues uniformValues(const RenderLinePaintProperties::PossiblyEvaluated&,
                                        const RenderTile&,
                                        const TransformState&,
                                        const std::array<float, 2>& pixelsToGLUnits);
@@ -103,7 +101,6 @@ class LinePatternProgram : public Program<
     LineLayoutAttributes,
     gl::Uniforms<
         uniforms::u_matrix,
-        uniforms::u_width,
         uniforms::u_ratio,
         uniforms::u_gl_units_to_pixels,
         uniforms::u_pattern_tl_a,
@@ -115,12 +112,12 @@ class LinePatternProgram : public Program<
         uniforms::u_texsize,
         uniforms::u_fade,
         uniforms::u_image>,
-    style::LinePaintProperties>
+    RenderLinePaintProperties>
 {
 public:
     using Program::Program;
 
-    static UniformValues uniformValues(const style::LinePaintProperties::PossiblyEvaluated&,
+    static UniformValues uniformValues(const RenderLinePaintProperties::PossiblyEvaluated&,
                                        const RenderTile&,
                                        const TransformState&,
                                        const std::array<float, 2>& pixelsToGLUnits,
@@ -135,7 +132,6 @@ class LineSDFProgram : public Program<
     LineLayoutAttributes,
     gl::Uniforms<
         uniforms::u_matrix,
-        uniforms::u_width,
         uniforms::u_ratio,
         uniforms::u_gl_units_to_pixels,
         uniforms::u_patternscale_a,
@@ -145,19 +141,18 @@ class LineSDFProgram : public Program<
         uniforms::u_mix,
         uniforms::u_sdfgamma,
         uniforms::u_image>,
-    style::LinePaintProperties>
+    RenderLinePaintProperties>
 {
 public:
     using Program::Program;
 
-    static UniformValues uniformValues(const style::LinePaintProperties::PossiblyEvaluated&,
+    static UniformValues uniformValues(const RenderLinePaintProperties::PossiblyEvaluated&,
                                        float pixelRatio,
                                        const RenderTile&,
                                        const TransformState&,
                                        const std::array<float, 2>& pixelsToGLUnits,
                                        const LinePatternPos& posA,
                                        const LinePatternPos& posB,
-                                       float dashLineWidth,
                                        float atlasWidth);
 };
 

--- a/src/mbgl/programs/uniforms.hpp
+++ b/src/mbgl/programs/uniforms.hpp
@@ -27,6 +27,8 @@ MBGL_DEFINE_UNIFORM_SCALAR(float, u_halo_blur);
 MBGL_DEFINE_UNIFORM_SCALAR(Color, u_outline_color);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_height);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_base);
+MBGL_DEFINE_UNIFORM_SCALAR(float, u_width);
+MBGL_DEFINE_UNIFORM_SCALAR(float, u_floorwidth);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_gapwidth);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_offset);
 MBGL_DEFINE_UNIFORM_SCALAR(Size, u_world);

--- a/src/mbgl/renderer/buckets/line_bucket.cpp
+++ b/src/mbgl/renderer/buckets/line_bucket.cpp
@@ -480,7 +480,7 @@ static float get(const RenderLineLayer& layer, const std::map<std::string, LineP
 }
 
 float LineBucket::getLineWidth(const RenderLineLayer& layer) const {
-    float lineWidth = layer.evaluated.get<LineWidth>();
+    float lineWidth = get<LineWidth>(layer, paintPropertyBinders);
     float gapWidth = get<LineGapWidth>(layer, paintPropertyBinders);
 
     if (gapWidth) {

--- a/src/mbgl/renderer/data_driven_property_evaluator.hpp
+++ b/src/mbgl/renderer/data_driven_property_evaluator.hpp
@@ -24,12 +24,18 @@ public:
     }
 
     ResultType operator()(const style::CameraFunction<T>& function) const {
-        return ResultType(function.evaluate(parameters.z));
+        if (!parameters.useIntegerZoom) {
+            return ResultType(function.evaluate(parameters.z));
+        } else {
+            return ResultType(function.evaluate(floor(parameters.z)));
+        }
     }
 
     template <class Function>
     ResultType operator()(const Function& function) const {
-        return ResultType(function);
+        auto returnFunction = function;
+        returnFunction.useIntegerZoom = parameters.useIntegerZoom;
+        return ResultType(returnFunction);
     }
 
 private:

--- a/src/mbgl/renderer/layers/render_line_layer.hpp
+++ b/src/mbgl/renderer/layers/render_line_layer.hpp
@@ -3,8 +3,17 @@
 #include <mbgl/renderer/render_layer.hpp>
 #include <mbgl/style/layers/line_layer_impl.hpp>
 #include <mbgl/style/layers/line_layer_properties.hpp>
+#include <mbgl/programs/uniforms.hpp>
 
 namespace mbgl {
+
+struct LineFloorwidth : style::DataDrivenPaintProperty<float, attributes::a_floorwidth, uniforms::u_floorwidth> {
+    static float defaultValue() { return 1; }
+};
+
+class RenderLinePaintProperties : public style::ConcatenateProperties<
+    style::LinePaintProperties::PropertyTypes,
+    TypeList<LineFloorwidth>>::Type {};
 
 class RenderLineLayer: public RenderLayer {
 public:
@@ -26,12 +35,9 @@ public:
 
     // Paint properties
     style::LinePaintProperties::Unevaluated unevaluated;
-    style::LinePaintProperties::PossiblyEvaluated evaluated;
+    RenderLinePaintProperties::PossiblyEvaluated evaluated;
 
     const style::LineLayer::Impl& impl() const;
-
-    // Special case
-    float dashLineWidth = 1;
 
 private:
     float getLineWidth(const GeometryTileFeature&, const float) const;

--- a/src/mbgl/renderer/paint_property_binder.hpp
+++ b/src/mbgl/renderer/paint_property_binder.hpp
@@ -217,7 +217,11 @@ public:
     }
 
     float interpolationFactor(float currentZoom) const override {
-        return util::interpolationFactor(1.0f, { rangeOfCoveringRanges.min.zoom, rangeOfCoveringRanges.max.zoom }, currentZoom);
+        if (function.useIntegerZoom) {
+            return util::interpolationFactor(1.0f, { rangeOfCoveringRanges.min.zoom, rangeOfCoveringRanges.max.zoom }, std::floor(currentZoom));
+        } else {
+            return util::interpolationFactor(1.0f, { rangeOfCoveringRanges.min.zoom, rangeOfCoveringRanges.max.zoom }, currentZoom);
+        }
     }
 
     T uniformValue(const PossiblyEvaluatedPropertyValue<T>& currentValue) const override {

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -328,7 +328,7 @@ void Painter::renderPass(PaintParameters& parameters,
             mat4 viewportMat;
             matrix::ortho(viewportMat, 0, size.width, size.height, 0, 0, 1);
 
-            const Properties<>::PossiblyEvaluated properties{};
+            const Properties<>::PossiblyEvaluated properties;
 
             parameters.programs.extrusionTexture.draw(
                 context, gl::Triangles(), gl::DepthMode::disabled(), gl::StencilMode::disabled(),

--- a/src/mbgl/renderer/painters/painter_line.cpp
+++ b/src/mbgl/renderer/painters/painter_line.cpp
@@ -21,7 +21,7 @@ void Painter::renderLine(PaintParameters& parameters,
         return;
     }
 
-    const LinePaintProperties::PossiblyEvaluated& properties = layer.evaluated;
+    const RenderLinePaintProperties::PossiblyEvaluated& properties = layer.evaluated;
 
     auto draw = [&] (auto& program, auto&& uniformValues) {
         program.get(properties).draw(
@@ -57,7 +57,6 @@ void Painter::renderLine(PaintParameters& parameters,
                  pixelsToGLUnits,
                  posA,
                  posB,
-                 layer.dashLineWidth,
                  lineAtlas->getSize().width));
 
     } else if (!properties.get<LinePattern>().from.empty()) {

--- a/src/mbgl/renderer/possibly_evaluated_property_value.hpp
+++ b/src/mbgl/renderer/possibly_evaluated_property_value.hpp
@@ -19,7 +19,9 @@ private:
 
 public:
     PossiblyEvaluatedPropertyValue() = default;
-    PossiblyEvaluatedPropertyValue(Value v) : value(std::move(v)) {}
+    PossiblyEvaluatedPropertyValue(Value v, bool useIntegerZoom_ = false)
+        : value(std::move(v)),
+          useIntegerZoom(useIntegerZoom_) {}
 
     bool isConstant() const {
         return value.template is<T>();
@@ -48,10 +50,16 @@ public:
                     return function.evaluate(feature, defaultValue);
                 },
                 [&] (const style::CompositeFunction<T>& function) {
-                    return function.evaluate(zoom, feature, defaultValue);
+                    if (useIntegerZoom) {
+                        return function.evaluate(floor(zoom), feature, defaultValue);
+                    } else {
+                        return function.evaluate(zoom, feature, defaultValue);
+                    }
                 }
         );
     }
+
+    bool useIntegerZoom;
 };
 
 namespace util {

--- a/src/mbgl/renderer/property_evaluation_parameters.hpp
+++ b/src/mbgl/renderer/property_evaluation_parameters.hpp
@@ -11,20 +11,24 @@ public:
         : z(z_),
           now(Clock::time_point::max()),
           zoomHistory(),
-          defaultFadeDuration(0) {}
+          defaultFadeDuration(0),
+          useIntegerZoom(false) {}
 
     PropertyEvaluationParameters(ZoomHistory zoomHistory_,
                           TimePoint now_,
-                          Duration defaultFadeDuration_)
+                          Duration defaultFadeDuration_,
+                          bool useIntegerZoom_ = false)
         : z(zoomHistory_.lastZoom),
           now(std::move(now_)),
           zoomHistory(std::move(zoomHistory_)),
-          defaultFadeDuration(std::move(defaultFadeDuration_)) {}
+          defaultFadeDuration(std::move(defaultFadeDuration_)),
+          useIntegerZoom(useIntegerZoom_) {}
 
     float z;
     TimePoint now;
     ZoomHistory zoomHistory;
     Duration defaultFadeDuration;
+    bool useIntegerZoom;
 };
 
 } // namespace mbgl

--- a/src/mbgl/shaders/line.cpp
+++ b/src/mbgl/shaders/line.cpp
@@ -26,7 +26,6 @@ attribute vec4 a_data;
 
 uniform mat4 u_matrix;
 uniform mediump float u_ratio;
-uniform mediump float u_width;
 uniform vec2 u_gl_units_to_pixels;
 
 varying vec2 v_normal;
@@ -72,6 +71,13 @@ attribute lowp vec2 a_offset;
 uniform lowp float u_offset;
 #endif
 
+#ifndef HAS_UNIFORM_u_width
+uniform lowp float a_width_t;
+attribute mediump vec2 a_width;
+#else
+uniform mediump float u_width;
+#endif
+
 void main() {
 
 #ifndef HAS_UNIFORM_u_color
@@ -104,6 +110,12 @@ void main() {
     lowp float offset = u_offset;
 #endif
 
+#ifndef HAS_UNIFORM_u_width
+    mediump float width = unpack_mix_vec2(a_width, a_width_t);
+#else
+    mediump float width = u_width;
+#endif
+
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;
 
@@ -119,11 +131,11 @@ void main() {
     // these transformations used to be applied in the JS and native code bases. 
     // moved them into the shader for clarity and simplicity. 
     gapwidth = gapwidth / 2.0;
-    float width = u_width / 2.0;
+    float halfwidth = width / 2.0;
     offset = -1.0 * offset; 
 
     float inset = gapwidth + (gapwidth > 0.0 ? ANTIALIASING : 0.0);
-    float outset = gapwidth + width * (gapwidth > 0.0 ? 2.0 : 1.0) + ANTIALIASING;
+    float outset = gapwidth + halfwidth * (gapwidth > 0.0 ? 2.0 : 1.0) + ANTIALIASING;
 
     // Scale the extrusion vector down to a normal and then up by the line width
     // of this vertex.

--- a/src/mbgl/shaders/line_pattern.cpp
+++ b/src/mbgl/shaders/line_pattern.cpp
@@ -28,7 +28,6 @@ attribute vec4 a_data;
 
 uniform mat4 u_matrix;
 uniform mediump float u_ratio;
-uniform mediump float u_width;
 uniform vec2 u_gl_units_to_pixels;
 
 varying vec2 v_normal;
@@ -67,6 +66,13 @@ attribute mediump vec2 a_gapwidth;
 uniform mediump float u_gapwidth;
 #endif
 
+#ifndef HAS_UNIFORM_u_width
+uniform lowp float a_width_t;
+attribute mediump vec2 a_width;
+#else
+uniform mediump float u_width;
+#endif
+
 void main() {
 
 #ifndef HAS_UNIFORM_u_blur
@@ -93,6 +99,12 @@ void main() {
     mediump float gapwidth = u_gapwidth;
 #endif
 
+#ifndef HAS_UNIFORM_u_width
+    mediump float width = unpack_mix_vec2(a_width, a_width_t);
+#else
+    mediump float width = u_width;
+#endif
+
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;
     float a_linesofar = (floor(a_data.z / 4.0) + a_data.w * 64.0) * LINE_DISTANCE_SCALE;
@@ -108,11 +120,11 @@ void main() {
     // these transformations used to be applied in the JS and native code bases. 
     // moved them into the shader for clarity and simplicity. 
     gapwidth = gapwidth / 2.0;
-    float width = u_width / 2.0;
+    float halfwidth = width / 2.0;
     offset = -1.0 * offset; 
 
     float inset = gapwidth + (gapwidth > 0.0 ? ANTIALIASING : 0.0);
-    float outset = gapwidth + width * (gapwidth > 0.0 ? 2.0 : 1.0) + ANTIALIASING;
+    float outset = gapwidth + halfwidth * (gapwidth > 0.0 ? 2.0 : 1.0) + ANTIALIASING;
 
     // Scale the extrusion vector down to a normal and then up by the line width
     // of this vertex.

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -267,15 +267,15 @@ TransitionOptions LineLayer::getLineTranslateAnchorTransition() const {
     return impl().paint.template get<LineTranslateAnchor>().options;
 }
 
-PropertyValue<float> LineLayer::getDefaultLineWidth() {
+DataDrivenPropertyValue<float> LineLayer::getDefaultLineWidth() {
     return { 1 };
 }
 
-PropertyValue<float> LineLayer::getLineWidth() const {
+DataDrivenPropertyValue<float> LineLayer::getLineWidth() const {
     return impl().paint.template get<LineWidth>().value;
 }
 
-void LineLayer::setLineWidth(PropertyValue<float> value) {
+void LineLayer::setLineWidth(DataDrivenPropertyValue<float> value) {
     if (value == getLineWidth())
         return;
     auto impl_ = mutableImpl();

--- a/src/mbgl/style/layers/line_layer_properties.hpp
+++ b/src/mbgl/style/layers/line_layer_properties.hpp
@@ -48,7 +48,7 @@ struct LineTranslateAnchor : PaintProperty<TranslateAnchorType> {
     static TranslateAnchorType defaultValue() { return TranslateAnchorType::Map; }
 };
 
-struct LineWidth : PaintProperty<float> {
+struct LineWidth : DataDrivenPaintProperty<float, attributes::a_width, uniforms::u_width> {
     static float defaultValue() { return 1; }
 };
 

--- a/src/mbgl/style/properties.hpp
+++ b/src/mbgl/style/properties.hpp
@@ -130,7 +130,10 @@ public:
 
     class PossiblyEvaluated : public Tuple<PossiblyEvaluatedTypes> {
     public:
-        using Tuple<PossiblyEvaluatedTypes>::Tuple;
+        template <class... Us>
+        PossiblyEvaluated(Us&&... us)
+            : Tuple<PossiblyEvaluatedTypes>(std::forward<Us>(us)...) {
+        }
 
         template <class T>
         static T evaluate(float, const GeometryTileFeature&, const T& t, const T&) {
@@ -212,6 +215,14 @@ public:
             return result;
         }
     };
+};
+
+template <class...>
+struct ConcatenateProperties;
+
+template <class... As, class... Bs>
+struct ConcatenateProperties<TypeList<As...>, TypeList<Bs...>> {
+    using Type = Properties<As..., Bs...>;
 };
 
 } // namespace style


### PR DESCRIPTION
Supersedes https://github.com/mapbox/mapbox-gl-native/pull/9214 — this version uses no special case code generation. Instead it evaluates `LineFloorwidth` with a `bool useIntegerZoom = true` parameter, which is passed on to its function members, although I'm not sure if this might be sketchy (particularly in the spot where it copies `parameters.useIntegerZoom` to a copy of a const function argument [here](https://github.com/mapbox/mapbox-gl-native/compare/jfirebaugh-dds-line-width#diff-ce80d566e396a663c06a243257c087d2R36)) … ?