### PR TITLE
[core] Reduce number of varyings to 8 or less

### DIFF
--- a/src/mbgl/shaders/line.cpp
+++ b/src/mbgl/shaders/line.cpp
@@ -44,17 +44,15 @@ attribute lowp vec2 a_opacity;
 varying lowp float opacity;
 uniform lowp float a_gapwidth_t;
 attribute mediump vec2 a_gapwidth;
-varying mediump float gapwidth;
 uniform lowp float a_offset_t;
 attribute lowp vec2 a_offset;
-varying lowp float offset;
 
 void main() {
     color = unpack_mix_vec4(a_color, a_color_t);
     blur = unpack_mix_vec2(a_blur, a_blur_t);
     opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
-    gapwidth = unpack_mix_vec2(a_gapwidth, a_gapwidth_t);
-    offset = unpack_mix_vec2(a_offset, a_offset_t);
+    mediump float gapwidth = unpack_mix_vec2(a_gapwidth, a_gapwidth_t);
+    lowp float offset = unpack_mix_vec2(a_offset, a_offset_t);
 
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;

--- a/src/mbgl/shaders/line_pattern.cpp
+++ b/src/mbgl/shaders/line_pattern.cpp
@@ -44,16 +44,14 @@ attribute lowp vec2 a_opacity;
 varying lowp float opacity;
 uniform lowp float a_offset_t;
 attribute lowp vec2 a_offset;
-varying lowp float offset;
 uniform lowp float a_gapwidth_t;
 attribute mediump vec2 a_gapwidth;
-varying mediump float gapwidth;
 
 void main() {
     blur = unpack_mix_vec2(a_blur, a_blur_t);
     opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
-    offset = unpack_mix_vec2(a_offset, a_offset_t);
-    gapwidth = unpack_mix_vec2(a_gapwidth, a_gapwidth_t);
+    lowp float offset = unpack_mix_vec2(a_offset, a_offset_t);
+    mediump float gapwidth = unpack_mix_vec2(a_gapwidth, a_gapwidth_t);
 
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;

--- a/src/mbgl/shaders/line_sdf.cpp
+++ b/src/mbgl/shaders/line_sdf.cpp
@@ -52,17 +52,15 @@ attribute lowp vec2 a_opacity;
 varying lowp float opacity;
 uniform lowp float a_gapwidth_t;
 attribute mediump vec2 a_gapwidth;
-varying mediump float gapwidth;
 uniform lowp float a_offset_t;
 attribute lowp vec2 a_offset;
-varying lowp float offset;
 
 void main() {
     color = unpack_mix_vec4(a_color, a_color_t);
     blur = unpack_mix_vec2(a_blur, a_blur_t);
     opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
-    gapwidth = unpack_mix_vec2(a_gapwidth, a_gapwidth_t);
-    offset = unpack_mix_vec2(a_offset, a_offset_t);
+    mediump float gapwidth = unpack_mix_vec2(a_gapwidth, a_gapwidth_t);
+    lowp float offset = unpack_mix_vec2(a_offset, a_offset_t);
 
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;


### PR DESCRIPTION
For `#pragma`s, don't generate varyings for attributes that aren't used by the fragment shader. Pack other varyings more tightly.

I did some hand-editing of generated shader code because gl-native is out of sync with gl-js shaders.

Fixes #9209.