### PR TITLE
[android] - feature - pre camera move listener

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
@@ -1,19 +1,27 @@
 package com.mapbox.mapboxsdk.maps;
 
+import android.support.annotation.NonNull;
+
+import static com.mapbox.mapboxsdk.camera.CameraPosition;
 import static com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraIdleListener;
 import static com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraMoveCanceledListener;
 import static com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraMoveStartedListener;
 import static com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraMoveListener;
 
-class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, MapboxMap.OnCameraMoveListener,
+class CameraChangeDispatcher implements MapboxMap.OnPreCameraMoveListener, MapboxMap.OnCameraMoveStartedListener, MapboxMap.OnCameraMoveListener,
   MapboxMap.OnCameraMoveCanceledListener, OnCameraIdleListener {
 
   private boolean idle = true;
 
+  private MapboxMap.OnPreCameraMoveListener onPreCameraMoveListener;
   private OnCameraMoveStartedListener onCameraMoveStartedListener;
   private OnCameraMoveCanceledListener onCameraMoveCanceledListener;
   private OnCameraMoveListener onCameraMoveListener;
   private OnCameraIdleListener onCameraIdleListener;
+
+  void setOnPreCameraMoveListener(MapboxMap.OnPreCameraMoveListener onPreCameraMoveListener) {
+    this.onPreCameraMoveListener = onPreCameraMoveListener;
+  }
 
   void setOnCameraMoveStartedListener(OnCameraMoveStartedListener onCameraMoveStartedListener) {
     this.onCameraMoveStartedListener = onCameraMoveStartedListener;
@@ -29,6 +37,16 @@ class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, M
 
   void setOnCameraIdleListener(OnCameraIdleListener onCameraIdleListener) {
     this.onCameraIdleListener = onCameraIdleListener;
+  }
+
+  @NonNull
+  @Override
+  public CameraPosition onPreCameraMove(CameraPosition cameraPosition, float duration, int reason) {
+    if (onPreCameraMoveListener != null) {
+      return onPreCameraMoveListener.onPreCameraMove(cameraPosition, duration, reason);
+    }
+
+    return cameraPosition;
   }
 
   @Override

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1653,6 +1653,17 @@ public final class MapboxMap {
   }
 
   /**
+   * Sets a callback that is invoked when camera is about to move. {@link OnPreCameraMoveListener#onPreCameraMove(CameraPosition)}
+   * will let you change {@link CameraPosition} before it is dispatched.
+   *
+   * @param listener the listener to notify
+   */
+  @UiThread
+  public void setOnPreCameraMoveListener(@Nullable OnPreCameraMoveListener listener) {
+    cameraChangeDispatcher.setOnPreCameraMoveListener(listener);
+  }
+
+  /**
    * Sets a callback that is invoked when camera movement has ended.
    *
    * @param listener the listener to notify
@@ -2019,6 +2030,27 @@ public final class MapboxMap {
      * @param position The CameraPosition at the end of the last camera change.
      */
     void onCameraChange(CameraPosition position);
+  }
+
+  /**
+   * Interface definition for a callback to be invoked when when camera is about to move
+   * and {@link CameraPosition} object is already prepared.
+   */
+  public interface OnPreCameraMoveListener {
+
+    /**
+     * <p>Called when camera move is about to start.
+     * On this point we can change camera's destination parameters
+     * before they are dispatched.</p>
+     * <p>
+     * <p>This callback <b>is not called</b> for animations started by gestures.</p>
+     *
+     * @param cameraPosition currently generated destination
+     * @param duration       duration of animation (ms)
+     * @param reason         the reason for the camera change
+     * @return modified camera destination, or if you don't want to change anything - return provided {@link CameraPosition}
+     */
+    CameraPosition onPreCameraMove(CameraPosition cameraPosition, float duration, int reason);
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
@@ -96,6 +96,8 @@ final class Transform implements MapView.OnMapChangedListener {
     if (!cameraPosition.equals(this.cameraPosition)) {
       trackingSettings.resetTrackingModesIfRequired(this.cameraPosition, cameraPosition, false);
       cancelTransitions();
+      cameraPosition = cameraChangeDispatcher.onPreCameraMove(
+        cameraPosition, 0, OnCameraMoveStartedListener.REASON_API_ANIMATION);
       cameraChangeDispatcher.onCameraMoveStarted(OnCameraMoveStartedListener.REASON_API_ANIMATION);
       mapView.jumpTo(cameraPosition.bearing, cameraPosition.target, cameraPosition.tilt, cameraPosition.zoom);
       if (callback != null) {
@@ -112,6 +114,8 @@ final class Transform implements MapView.OnMapChangedListener {
     if (!cameraPosition.equals(this.cameraPosition)) {
       trackingSettings.resetTrackingModesIfRequired(this.cameraPosition, cameraPosition, isDismissable);
       cancelTransitions();
+      cameraPosition = cameraChangeDispatcher.onPreCameraMove(
+        cameraPosition, durationMs, OnCameraMoveStartedListener.REASON_API_ANIMATION);
       cameraChangeDispatcher.onCameraMoveStarted(OnCameraMoveStartedListener.REASON_API_ANIMATION);
 
       if (callback != null) {
@@ -130,6 +134,8 @@ final class Transform implements MapView.OnMapChangedListener {
     if (!cameraPosition.equals(this.cameraPosition)) {
       trackingSettings.resetTrackingModesIfRequired(this.cameraPosition, cameraPosition, false);
       cancelTransitions();
+      cameraPosition = cameraChangeDispatcher.onPreCameraMove(
+        cameraPosition, durationMs, OnCameraMoveStartedListener.REASON_API_ANIMATION);
       cameraChangeDispatcher.onCameraMoveStarted(OnCameraMoveStartedListener.REASON_API_ANIMATION);
 
       if (callback != null) {


### PR DESCRIPTION
When I was tinkering a bit with SDK I came to the conclusion it would be nice to have some control over programmatically invoked camera changes, check out this PR and let me know what you think.

Use case example:
When we are tracking location programmatically invoked camera changes are often being canceled by new location samples (which are starting new animation, therefore canceling ongoing one) and in the result we did not zoom to the level we wanted to. If we could supervise camera movement, we could adjust animation that canceled our zoom to apply remaining difference in `onPreCameraMove()`.

`onPreCameraMove()` **won't** fire for gesture-invoked animations.