### PR TITLE
[core] GL performance fixes

### DIFF
--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -150,6 +150,7 @@ set(MBGL_CORE_FILES
     src/mbgl/programs/line_program.cpp
     src/mbgl/programs/line_program.hpp
     src/mbgl/programs/program.hpp
+    src/mbgl/programs/program_parameters.cpp
     src/mbgl/programs/program_parameters.hpp
     src/mbgl/programs/programs.hpp
     src/mbgl/programs/raster_program.cpp

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -44,7 +44,7 @@ public:
                  GLContextMode contextMode = GLContextMode::Unique,
                  ConstrainMode constrainMode = ConstrainMode::HeightOnly,
                  ViewportMode viewportMode = ViewportMode::Default,
-                 const std::string& programCacheDir = "");
+                 const optional<std::string>& programCacheDir = {});
     ~Map();
 
     // Register a callback that will get called (on the render thread) when all resources have

--- a/src/mbgl/gl/attribute.cpp
+++ b/src/mbgl/gl/attribute.cpp
@@ -29,6 +29,7 @@ void VariableAttributeBinding<T, N>::bind(Context& context,
     }
     context.vertexBuffer = vertexBuffer;
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(location));
+    oldBinding = *this;
     MBGL_CHECK_ERROR(glVertexAttribPointer(
         location,
         static_cast<GLint>(attributeSize),

--- a/src/mbgl/gl/program.hpp
+++ b/src/mbgl/gl/program.hpp
@@ -55,10 +55,10 @@ public:
                 shaders::vertexSource(programParameters, vertexSource_);
             const std::string fragmentSource =
                 shaders::fragmentSource(programParameters, fragmentSource_);
-            const std::string cachePath =
-                shaders::programCachePath(programParameters, name);
             const std::string identifier =
                 shaders::programIdentifier(vertexSource, fragmentSource_);
+
+            const std::string cachePath = programParameters.cachePath(name);
 
             try {
                 if (auto cachedBinaryProgram = util::readFile(cachePath)) {

--- a/src/mbgl/gl/uniform.hpp
+++ b/src/mbgl/gl/uniform.hpp
@@ -30,7 +30,7 @@ public:
     class State {
     public:
         void operator=(const Value& value) {
-            if (!current || *current != value.t) {
+            if (location >= 0 && (!current || *current != value.t)) {
                 current = value.t;
                 bindUniform(location, value.t);
             }

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -58,7 +58,7 @@ public:
          GLContextMode,
          ConstrainMode,
          ViewportMode,
-         const std::string& programCacheDir);
+         optional<std::string> programCacheDir);
 
     void onSourceChanged(style::Source&) override;
     void onUpdate(Update) override;
@@ -83,7 +83,7 @@ public:
     const MapMode mode;
     const GLContextMode contextMode;
     const float pixelRatio;
-    const std::string programCacheDir;
+    const optional<std::string> programCacheDir;
 
     MapDebugOptions debugOptions { MapDebugOptions::NoDebug };
 
@@ -116,7 +116,7 @@ Map::Map(Backend& backend,
          GLContextMode contextMode,
          ConstrainMode constrainMode,
          ViewportMode viewportMode,
-         const std::string& programCacheDir)
+         const optional<std::string>& programCacheDir)
     : impl(std::make_unique<Impl>(*this,
                                   backend,
                                   pixelRatio,
@@ -139,7 +139,7 @@ Map::Impl::Impl(Map& map_,
                 GLContextMode contextMode_,
                 ConstrainMode constrainMode_,
                 ViewportMode viewportMode_,
-                const std::string& programCacheDir_)
+                optional<std::string> programCacheDir_)
     : map(map_),
       observer(backend_),
       backend(backend_),

--- a/src/mbgl/programs/program.hpp
+++ b/src/mbgl/programs/program.hpp
@@ -9,18 +9,21 @@
 #include <mbgl/shaders/shaders.hpp>
 #include <mbgl/util/io.hpp>
 
+#include <unordered_map>
+
 namespace mbgl {
 
 template <class Shaders,
           class Primitive,
           class LayoutAttrs,
           class Uniforms,
-          class PaintProperties>
+          class PaintProps>
 class Program {
 public:
     using LayoutAttributes = LayoutAttrs;
     using LayoutVertex = typename LayoutAttributes::Vertex;
 
+    using PaintProperties = PaintProps;
     using PaintPropertyBinders = typename PaintProperties::Binders;
     using PaintAttributes = typename PaintPropertyBinders::Attributes;
     using Attributes = gl::ConcatenateAttributes<LayoutAttributes, PaintAttributes>;
@@ -69,6 +72,36 @@ public:
             segments
         );
     }
+};
+
+template <class Program>
+class ProgramMap {
+public:
+    using PaintProperties = typename Program::PaintProperties;
+    using PaintPropertyBinders = typename Program::PaintPropertyBinders;
+    using Bitset = typename PaintPropertyBinders::Bitset;
+
+    ProgramMap(gl::Context& context_, ProgramParameters parameters_)
+        : context(context_),
+          parameters(std::move(parameters_)) {
+    }
+
+    Program& get(const typename PaintProperties::Evaluated& currentProperties) {
+        Bitset bits = PaintPropertyBinders::constants(currentProperties);
+        auto it = programs.find(bits);
+        if (it != programs.end()) {
+            return it->second;
+        }
+        return programs.emplace(std::piecewise_construct,
+                                std::forward_as_tuple(bits),
+                                std::forward_as_tuple(context,
+                                    parameters.withAdditionalDefines(PaintPropertyBinders::defines(currentProperties)))).first->second;
+    }
+
+private:
+    gl::Context& context;
+    ProgramParameters parameters;
+    std::unordered_map<Bitset, Program> programs;
 };
 
 } // namespace mbgl

--- a/src/mbgl/programs/program.hpp
+++ b/src/mbgl/programs/program.hpp
@@ -62,7 +62,7 @@ public:
             std::move(stencilMode),
             std::move(colorMode),
             uniformValues
-                .concat(paintPropertyBinders.uniformValues(currentZoom)),
+                .concat(paintPropertyBinders.uniformValues(currentZoom, currentProperties)),
             LayoutAttributes::allVariableBindings(layoutVertexBuffer)
                 .concat(paintPropertyBinders.attributeBindings(currentProperties)),
             indexBuffer,

--- a/src/mbgl/programs/program_parameters.cpp
+++ b/src/mbgl/programs/program_parameters.cpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 ProgramParameters::ProgramParameters(const float pixelRatio,
                                      const bool overdraw,
-                                     std::string cacheDir_)
+                                     optional<std::string> cacheDir_)
     : defines([&] {
           std::ostringstream ss;
           ss.imbue(std::locale("C"));
@@ -18,15 +18,31 @@ ProgramParameters::ProgramParameters(const float pixelRatio,
           }
           return ss.str();
       }()),
-      hash(std::hash<std::string>()(defines)),
       cacheDir(std::move(cacheDir_)) {
 }
 
-std::string ProgramParameters::cachePath(const char* name) const {
-    std::ostringstream ss;
-    ss << cacheDir << "/com.mapbox.gl.shader." << name << "." << std::setfill('0')
-       << std::setw(sizeof(size_t) * 2) << std::hex << hash << ".pbf";
-    return ss.str();
+const std::string& ProgramParameters::getDefines() const {
+    return defines;
+}
+
+optional<std::string> ProgramParameters::cachePath(const char* name) const {
+    if (!cacheDir) {
+        return {};
+    } else {
+        std::ostringstream ss;
+        ss << *cacheDir << "/com.mapbox.gl.shader." << name << "." << std::setfill('0')
+           << std::setw(sizeof(size_t) * 2) << std::hex << std::hash<std::string>()(defines) << ".pbf";
+        return ss.str();
+    }
+}
+
+ProgramParameters ProgramParameters::withAdditionalDefines(const std::vector<std::string>& additionalDefines) const {
+    ProgramParameters result(*this);
+    for (const auto& define : additionalDefines) {
+        result.defines += define;
+        result.defines += "\n";
+    }
+    return result;
 }
 
 } // namespace mbgl

--- a/src/mbgl/programs/program_parameters.cpp
+++ b/src/mbgl/programs/program_parameters.cpp
@@ -1,0 +1,32 @@
+#include <mbgl/programs/program_parameters.hpp>
+
+#include <iomanip>
+#include <sstream>
+
+namespace mbgl {
+
+ProgramParameters::ProgramParameters(const float pixelRatio,
+                                     const bool overdraw,
+                                     std::string cacheDir_)
+    : defines([&] {
+          std::ostringstream ss;
+          ss.imbue(std::locale("C"));
+          ss.setf(std::ios_base::showpoint);
+          ss << "#define DEVICE_PIXEL_RATIO " << pixelRatio << std::endl;
+          if (overdraw) {
+              ss << "#define OVERDRAW_INSPECTOR" << std::endl;
+          }
+          return ss.str();
+      }()),
+      hash(std::hash<std::string>()(defines)),
+      cacheDir(std::move(cacheDir_)) {
+}
+
+std::string ProgramParameters::cachePath(const char* name) const {
+    std::ostringstream ss;
+    ss << cacheDir << "/com.mapbox.gl.shader." << name << "." << std::setfill('0')
+       << std::setw(sizeof(size_t) * 2) << std::hex << hash << ".pbf";
+    return ss.str();
+}
+
+} // namespace mbgl

--- a/src/mbgl/programs/program_parameters.hpp
+++ b/src/mbgl/programs/program_parameters.hpp
@@ -1,20 +1,24 @@
 #pragma once
 
+#include <mbgl/util/optional.hpp>
+
 #include <string>
+#include <vector>
 
 namespace mbgl {
 
 class ProgramParameters {
 public:
-    ProgramParameters(float pixelRatio, bool overdraw, std::string cacheDir);
+    ProgramParameters(float pixelRatio, bool overdraw, optional<std::string> cacheDir);
 
-    const std::string defines;
+    const std::string& getDefines() const;
+    optional<std::string> cachePath(const char* name) const;
 
-    std::string cachePath(const char* name) const;
+    ProgramParameters withAdditionalDefines(const std::vector<std::string>& defines) const;
 
 private:
-    const std::size_t hash;
-    const std::string cacheDir;
+    std::string defines;
+    optional<std::string> cacheDir;
 };
 
 } // namespace mbgl

--- a/src/mbgl/programs/program_parameters.hpp
+++ b/src/mbgl/programs/program_parameters.hpp
@@ -6,16 +6,15 @@ namespace mbgl {
 
 class ProgramParameters {
 public:
-    ProgramParameters(float pixelRatio_ = 1.0,
-                      bool overdraw_ = false,
-                      const std::string& cacheDir_ = "")
-        : pixelRatio(pixelRatio_), overdraw(overdraw_), cacheDir(cacheDir_) {
-    }
+    ProgramParameters(float pixelRatio, bool overdraw, std::string cacheDir);
 
-    const float pixelRatio;
-    const bool overdraw;
+    const std::string defines;
+
+    std::string cachePath(const char* name) const;
+
+private:
+    const std::size_t hash;
     const std::string cacheDir;
 };
 
 } // namespace mbgl
-

--- a/src/mbgl/programs/programs.hpp
+++ b/src/mbgl/programs/programs.hpp
@@ -31,8 +31,8 @@ public:
           symbolIcon(context, programParameters),
           symbolIconSDF(context, programParameters),
           symbolGlyph(context, programParameters),
-          debug(context, ProgramParameters(programParameters.pixelRatio, false, programParameters.cacheDir)),
-          collisionBox(context, ProgramParameters(programParameters.pixelRatio, false, programParameters.cacheDir)) {
+          debug(context, programParameters),
+          collisionBox(context, programParameters) {
     }
 
     CircleProgram circle;

--- a/src/mbgl/programs/programs.hpp
+++ b/src/mbgl/programs/programs.hpp
@@ -35,21 +35,21 @@ public:
           collisionBox(context, programParameters) {
     }
 
-    CircleProgram circle;
+    ProgramMap<CircleProgram> circle;
     ExtrusionTextureProgram extrusionTexture;
-    FillProgram fill;
-    FillExtrusionProgram fillExtrusion;
-    FillExtrusionPatternProgram fillExtrusionPattern;
-    FillPatternProgram fillPattern;
-    FillOutlineProgram fillOutline;
-    FillOutlinePatternProgram fillOutlinePattern;
-    LineProgram line;
-    LineSDFProgram lineSDF;
-    LinePatternProgram linePattern;
+    ProgramMap<FillProgram> fill;
+    ProgramMap<FillExtrusionProgram> fillExtrusion;
+    ProgramMap<FillExtrusionPatternProgram> fillExtrusionPattern;
+    ProgramMap<FillPatternProgram> fillPattern;
+    ProgramMap<FillOutlineProgram> fillOutline;
+    ProgramMap<FillOutlinePatternProgram> fillOutlinePattern;
+    ProgramMap<LineProgram> line;
+    ProgramMap<LineSDFProgram> lineSDF;
+    ProgramMap<LinePatternProgram> linePattern;
     RasterProgram raster;
-    SymbolIconProgram symbolIcon;
-    SymbolSDFIconProgram symbolIconSDF;
-    SymbolSDFTextProgram symbolGlyph;
+    ProgramMap<SymbolIconProgram> symbolIcon;
+    ProgramMap<SymbolSDFIconProgram> symbolIconSDF;
+    ProgramMap<SymbolSDFTextProgram> symbolGlyph;
 
     DebugProgram debug;
     CollisionBoxProgram collisionBox;

--- a/src/mbgl/programs/symbol_program.hpp
+++ b/src/mbgl/programs/symbol_program.hpp
@@ -324,7 +324,7 @@ template <class Shaders,
           class Primitive,
           class LayoutAttrs,
           class Uniforms,
-          class PaintProperties>
+          class PaintProps>
 class SymbolProgram {
 public:
     using LayoutAttributes = LayoutAttrs;
@@ -332,6 +332,7 @@ public:
     
     using LayoutAndSizeAttributes = gl::ConcatenateAttributes<LayoutAttributes, SymbolSizeAttributes>;
 
+    using PaintProperties = PaintProps;
     using PaintPropertyBinders = typename PaintProperties::Binders;
     using PaintAttributes = typename PaintPropertyBinders::Attributes;
     using Attributes = gl::ConcatenateAttributes<LayoutAndSizeAttributes, PaintAttributes>;

--- a/src/mbgl/programs/symbol_program.hpp
+++ b/src/mbgl/programs/symbol_program.hpp
@@ -377,7 +377,7 @@ public:
             std::move(colorMode),
             uniformValues
                 .concat(symbolSizeBinder.uniformValues(currentZoom))
-                .concat(paintPropertyBinders.uniformValues(currentZoom)),
+                .concat(paintPropertyBinders.uniformValues(currentZoom, currentProperties)),
             LayoutAttributes::allVariableBindings(layoutVertexBuffer)
                 .concat(symbolSizeBinder.attributeBindings(currentSizeValue))
                 .concat(paintPropertyBinders.attributeBindings(currentProperties)),

--- a/src/mbgl/programs/uniforms.hpp
+++ b/src/mbgl/programs/uniforms.hpp
@@ -16,7 +16,19 @@ MBGL_DEFINE_UNIFORM_SCALAR(float, u_blur);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_zoom);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_pitch);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_bearing);
-
+MBGL_DEFINE_UNIFORM_SCALAR(float, u_radius);
+MBGL_DEFINE_UNIFORM_SCALAR(float, u_stroke_width);
+MBGL_DEFINE_UNIFORM_SCALAR(Color, u_stroke_color);
+MBGL_DEFINE_UNIFORM_SCALAR(float, u_stroke_opacity);
+MBGL_DEFINE_UNIFORM_SCALAR(Color, u_fill_color);
+MBGL_DEFINE_UNIFORM_SCALAR(Color, u_halo_color);
+MBGL_DEFINE_UNIFORM_SCALAR(float, u_halo_width);
+MBGL_DEFINE_UNIFORM_SCALAR(float, u_halo_blur);
+MBGL_DEFINE_UNIFORM_SCALAR(Color, u_outline_color);
+MBGL_DEFINE_UNIFORM_SCALAR(float, u_height);
+MBGL_DEFINE_UNIFORM_SCALAR(float, u_base);
+MBGL_DEFINE_UNIFORM_SCALAR(float, u_gap_width);
+MBGL_DEFINE_UNIFORM_SCALAR(float, u_offset);
 MBGL_DEFINE_UNIFORM_SCALAR(Size, u_world);
 
 MBGL_DEFINE_UNIFORM_VECTOR(float, 2, u_extrude_scale);

--- a/src/mbgl/renderer/frame_history.cpp
+++ b/src/mbgl/renderer/frame_history.cpp
@@ -39,14 +39,14 @@ void FrameHistory::record(const TimePoint& now, float zoom, const Duration& dura
     for (int16_t z = 0; z <= 255; z++) {
         std::chrono::duration<float> timeDiff = now - changeTimes[z];
         int32_t opacityChange = (duration == Milliseconds(0) ? 1 : (timeDiff / duration)) * 255;
-        if (z <= zoomIndex) {
-            opacities.data[z] = util::min(255, changeOpacities[z] + opacityChange);
-        } else {
-            opacities.data[z] = util::max(0, changeOpacities[z] - opacityChange);
+        uint8_t opacity = z <= zoomIndex
+            ? util::min(255, changeOpacities[z] + opacityChange)
+            : util::max(0, changeOpacities[z] - opacityChange);
+        if (opacities.data[z] != opacity) {
+            opacities.data[z] = opacity;
+            dirty = true;
         }
     }
-
-    dirty = true;
 
     if (zoomIndex != previousZoomIndex) {
         previousZoomIndex = zoomIndex;

--- a/src/mbgl/renderer/paint_property_binder.hpp
+++ b/src/mbgl/renderer/paint_property_binder.hpp
@@ -6,6 +6,8 @@
 #include <mbgl/util/type_list.hpp>
 #include <mbgl/renderer/paint_property_statistics.hpp>
 
+#include <bitset>
+
 namespace mbgl {
 
 /*
@@ -54,8 +56,7 @@ std::array<float, N*2> zoomInterpolatedAttributeValue(const std::array<float, N>
 
    * For _constant_ properties -- those whose value is a constant, or the constant
      result of evaluating a camera function at a particular camera position -- we
-     don't need a vertex buffer, and can instead use a constant attribute binding
-     via the `glVertexAttrib*` family of functions.
+     don't need a vertex buffer, and instead use a uniform.
    * For source functions, we use a vertex buffer with a single attribute value,
      the evaluated result of the source function for the given feature.
    * For composite functions, we use a vertex buffer with two attributes: min and
@@ -66,15 +67,8 @@ std::array<float, N*2> zoomInterpolatedAttributeValue(const std::array<float, N>
      between the min and max value at the final displayed zoom level. The use of a
      uniform allows us to cheaply update the value on every frame.
 
-   Note that the shader source is the same regardless of the strategy used to bind
-   the attribute -- in all cases the attribute is declared as a vec2, in order to
-   support composite min and max values (color attributes use a vec4 with special
-   packing). When the constant or source function strategies are used, the
-   interpolation uniform value is set to zero, and the second attribute element is
-   unused. This differs from the GL JS implementation, which dynamically generates
-   shader source based on the strategy used. We found that in WebGL, using
-   `glVertexAttrib*` was unnacceptably slow. Additionally, in GL Native we have
-   implemented binary shader caching, which works better if the shaders are constant.
+   Note that the shader source varies depending on whether we're using a uniform or
+   attribute. Like GL JS, we dynamically compile shaders at runtime to accomodate this.
 */
 template <class T, class A>
 class PaintPropertyBinder {
@@ -170,9 +164,13 @@ public:
         return 0.0f;
     }
 
-    T uniformValue(const PossiblyEvaluatedPropertyValue<T>&) const override {
-        // Uniform values for vertex attribute arrays are unused.
-        return {};
+    T uniformValue(const PossiblyEvaluatedPropertyValue<T>& currentValue) const override {
+        if (currentValue.isConstant()) {
+            return *currentValue.constant();
+        } else {
+            // Uniform values for vertex attribute arrays are unused.
+            return {};
+        }
     }
 
 private:
@@ -230,9 +228,13 @@ public:
         return util::interpolationFactor(1.0f, std::get<0>(coveringRanges), currentZoom);
     }
 
-    T uniformValue(const PossiblyEvaluatedPropertyValue<T>&) const override {
-        // Uniform values for vertex attribute arrays are unused.
-        return {};
+    T uniformValue(const PossiblyEvaluatedPropertyValue<T>& currentValue) const override {
+        if (currentValue.isConstant()) {
+            return *currentValue.constant();
+        } else {
+            // Uniform values for vertex attribute arrays are unused.
+            return {};
+        }
     }
 
 private:
@@ -340,6 +342,30 @@ public:
     template <class P>
     const auto& statistics() const {
         return binders.template get<P>()->statistics;
+    }
+
+
+    using Bitset = std::bitset<sizeof...(Ps)>;
+
+    template <class EvaluatedProperties>
+    static Bitset constants(const EvaluatedProperties& currentProperties) {
+        Bitset result;
+        util::ignore({
+            result.set(TypeIndex<Ps, Ps...>::value,
+                       currentProperties.template get<Ps>().isConstant())...
+        });
+        return result;
+    }
+
+    template <class EvaluatedProperties>
+    static std::vector<std::string> defines(const EvaluatedProperties& currentProperties) {
+        std::vector<std::string> result;
+        util::ignore({
+            (result.push_back(currentProperties.template get<Ps>().isConstant()
+                ? std::string("#define HAS_UNIFORM_") + Ps::Uniform::name()
+                : std::string()), 0)...
+        });
+        return result;
     }
 
 private:

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -93,7 +93,7 @@ static gl::VertexVector<ExtrusionTextureLayoutVertex> extrusionTextureVertices()
 Painter::Painter(gl::Context& context_,
                  const TransformState& state_,
                  float pixelRatio,
-                 const std::string& programCacheDir)
+                 const optional<std::string>& programCacheDir)
     : context(context_),
       state(state_),
       tileVertexBuffer(context.createVertexBuffer(tileVertices())),

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -74,7 +74,7 @@ struct FrameData {
 
 class Painter : private util::noncopyable {
 public:
-    Painter(gl::Context&, const TransformState&, float pixelRatio, const std::string& programCacheDir);
+    Painter(gl::Context&, const TransformState&, float pixelRatio, const optional<std::string>& programCacheDir);
     ~Painter();
 
     void render(const style::Style&,

--- a/src/mbgl/renderer/painter_background.cpp
+++ b/src/mbgl/renderer/painter_background.cpp
@@ -33,7 +33,7 @@ void Painter::renderBackground(PaintParameters& parameters, const RenderBackgrou
         spriteAtlas->bind(true, context, 0);
 
         for (const auto& tileID : util::tileCover(state, state.getIntegerZoom())) {
-            parameters.programs.fillPattern.draw(
+            parameters.programs.fillPattern.get(properties).draw(
                 context,
                 gl::Triangles(),
                 depthModeForSublayer(0, gl::DepthMode::ReadOnly),
@@ -58,7 +58,7 @@ void Painter::renderBackground(PaintParameters& parameters, const RenderBackgrou
         }
     } else {
         for (const auto& tileID : util::tileCover(state, state.getIntegerZoom())) {
-            parameters.programs.fill.draw(
+            parameters.programs.fill.get(properties).draw(
                 context,
                 gl::Triangles(),
                 depthModeForSublayer(0, gl::DepthMode::ReadOnly),

--- a/src/mbgl/renderer/painter_circle.cpp
+++ b/src/mbgl/renderer/painter_circle.cpp
@@ -23,7 +23,7 @@ void Painter::renderCircle(PaintParameters& parameters,
     const CirclePaintProperties::Evaluated& properties = layer.evaluated;
     const bool scaleWithMap = properties.get<CirclePitchScale>() == CirclePitchScaleType::Map;
 
-    parameters.programs.circle.draw(
+    parameters.programs.circle.get(properties).draw(
         context,
         gl::Triangles(),
         depthModeForSublayer(0, gl::DepthMode::ReadOnly),

--- a/src/mbgl/renderer/painter_clipping.cpp
+++ b/src/mbgl/renderer/painter_clipping.cpp
@@ -8,7 +8,7 @@ namespace mbgl {
 void Painter::renderClippingMask(const UnwrappedTileID& tileID, const ClipID& clip) {
     static const style::FillPaintProperties::Evaluated properties {};
     static const FillProgram::PaintPropertyBinders paintAttibuteData(properties, 0);
-    programs->fill.draw(
+    programs->fill.get(properties).draw(
         context,
         gl::Triangles(),
         gl::DepthMode::disabled(),

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -38,7 +38,7 @@ void Painter::renderFill(PaintParameters& parameters,
                          const auto& drawMode,
                          const auto& indexBuffer,
                          const auto& segments) {
-            program.draw(
+            program.get(properties).draw(
                 context,
                 drawMode,
                 depthModeForSublayer(sublayer, gl::DepthMode::ReadWrite),
@@ -85,7 +85,7 @@ void Painter::renderFill(PaintParameters& parameters,
                          const auto& drawMode,
                          const auto& indexBuffer,
                          const auto& segments) {
-            program.draw(
+            program.get(properties).draw(
                 context,
                 drawMode,
                 depthModeForSublayer(sublayer, gl::DepthMode::ReadWrite),

--- a/src/mbgl/renderer/painter_fill_extrusion.cpp
+++ b/src/mbgl/renderer/painter_fill_extrusion.cpp
@@ -36,7 +36,7 @@ void Painter::renderFillExtrusion(PaintParameters& parameters,
 
         spriteAtlas->bind(true, context, 0);
 
-        parameters.programs.fillExtrusionPattern.draw(
+        parameters.programs.fillExtrusionPattern.get(properties).draw(
             context,
             gl::Triangles(),
             depthModeForSublayer(0, gl::DepthMode::ReadWrite),
@@ -62,7 +62,7 @@ void Painter::renderFillExtrusion(PaintParameters& parameters,
             state.getZoom());
 
     } else {
-        parameters.programs.fillExtrusion.draw(
+        parameters.programs.fillExtrusion.get(properties).draw(
             context,
             gl::Triangles(),
             depthModeForSublayer(0, gl::DepthMode::ReadWrite),

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -24,7 +24,7 @@ void Painter::renderLine(PaintParameters& parameters,
     const LinePaintProperties::Evaluated& properties = layer.evaluated;
 
     auto draw = [&] (auto& program, auto&& uniformValues) {
-        program.draw(
+        program.get(properties).draw(
             context,
             gl::Triangles(),
             depthModeForSublayer(0, gl::DepthMode::ReadOnly),

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -41,7 +41,7 @@ void Painter::renderSymbol(PaintParameters& parameters,
         // We clip symbols to their tile extent in still mode.
         const bool needsClipping = frame.mapMode == MapMode::Still;
 
-        program.draw(
+        program.get(paintProperties).draw(
             context,
             gl::Triangles(),
             values_.pitchAlignment == AlignmentType::Map

--- a/src/mbgl/shaders/circle.cpp
+++ b/src/mbgl/shaders/circle.cpp
@@ -13,38 +13,108 @@ uniform vec2 u_extrude_scale;
 
 attribute vec2 a_pos;
 
+
+#ifndef HAS_UNIFORM_u_color
 uniform lowp float a_color_t;
 attribute highp vec4 a_color;
 varying highp vec4 color;
+#else
+uniform highp vec4 u_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_radius
 uniform lowp float a_radius_t;
 attribute mediump vec2 a_radius;
 varying mediump float radius;
+#else
+uniform mediump float u_radius;
+#endif
+
+#ifndef HAS_UNIFORM_u_blur
 uniform lowp float a_blur_t;
 attribute lowp vec2 a_blur;
 varying lowp float blur;
+#else
+uniform lowp float u_blur;
+#endif
+
+#ifndef HAS_UNIFORM_u_opacity
 uniform lowp float a_opacity_t;
 attribute lowp vec2 a_opacity;
 varying lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
+
+#ifndef HAS_UNIFORM_u_stroke_color
 uniform lowp float a_stroke_color_t;
 attribute highp vec4 a_stroke_color;
 varying highp vec4 stroke_color;
+#else
+uniform highp vec4 u_stroke_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_stroke_width
 uniform lowp float a_stroke_width_t;
 attribute mediump vec2 a_stroke_width;
 varying mediump float stroke_width;
+#else
+uniform mediump float u_stroke_width;
+#endif
+
+#ifndef HAS_UNIFORM_u_stroke_opacity
 uniform lowp float a_stroke_opacity_t;
 attribute lowp vec2 a_stroke_opacity;
 varying lowp float stroke_opacity;
+#else
+uniform lowp float u_stroke_opacity;
+#endif
 
 varying vec3 v_data;
 
 void main(void) {
+
+#ifndef HAS_UNIFORM_u_color
     color = unpack_mix_vec4(a_color, a_color_t);
+#else
+    highp vec4 color = u_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_radius
     radius = unpack_mix_vec2(a_radius, a_radius_t);
+#else
+    mediump float radius = u_radius;
+#endif
+
+#ifndef HAS_UNIFORM_u_blur
     blur = unpack_mix_vec2(a_blur, a_blur_t);
+#else
+    lowp float blur = u_blur;
+#endif
+
+#ifndef HAS_UNIFORM_u_opacity
     opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
+#else
+    lowp float opacity = u_opacity;
+#endif
+
+#ifndef HAS_UNIFORM_u_stroke_color
     stroke_color = unpack_mix_vec4(a_stroke_color, a_stroke_color_t);
+#else
+    highp vec4 stroke_color = u_stroke_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_stroke_width
     stroke_width = unpack_mix_vec2(a_stroke_width, a_stroke_width_t);
+#else
+    mediump float stroke_width = u_stroke_width;
+#endif
+
+#ifndef HAS_UNIFORM_u_stroke_opacity
     stroke_opacity = unpack_mix_vec2(a_stroke_opacity, a_stroke_opacity_t);
+#else
+    lowp float stroke_opacity = u_stroke_opacity;
+#endif
 
     // unencode the extrusion vector that we snuck into the a_pos vector
     vec2 extrude = vec2(mod(a_pos, 2.0) * 2.0 - 1.0);
@@ -69,24 +139,80 @@ void main(void) {
 
 )MBGL_SHADER";
 const char* circle::fragmentSource = R"MBGL_SHADER(
+
+#ifndef HAS_UNIFORM_u_color
 varying highp vec4 color;
+#else
+uniform highp vec4 u_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_radius
 varying mediump float radius;
+#else
+uniform mediump float u_radius;
+#endif
+
+#ifndef HAS_UNIFORM_u_blur
 varying lowp float blur;
+#else
+uniform lowp float u_blur;
+#endif
+
+#ifndef HAS_UNIFORM_u_opacity
 varying lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
+
+#ifndef HAS_UNIFORM_u_stroke_color
 varying highp vec4 stroke_color;
+#else
+uniform highp vec4 u_stroke_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_stroke_width
 varying mediump float stroke_width;
+#else
+uniform mediump float u_stroke_width;
+#endif
+
+#ifndef HAS_UNIFORM_u_stroke_opacity
 varying lowp float stroke_opacity;
+#else
+uniform lowp float u_stroke_opacity;
+#endif
 
 varying vec3 v_data;
 
 void main() {
-    
-    
-    
-    
-    
-    
-    
+
+#ifdef HAS_UNIFORM_u_color
+    highp vec4 color = u_color;
+#endif
+
+#ifdef HAS_UNIFORM_u_radius
+    mediump float radius = u_radius;
+#endif
+
+#ifdef HAS_UNIFORM_u_blur
+    lowp float blur = u_blur;
+#endif
+
+#ifdef HAS_UNIFORM_u_opacity
+    lowp float opacity = u_opacity;
+#endif
+
+#ifdef HAS_UNIFORM_u_stroke_color
+    highp vec4 stroke_color = u_stroke_color;
+#endif
+
+#ifdef HAS_UNIFORM_u_stroke_width
+    mediump float stroke_width = u_stroke_width;
+#endif
+
+#ifdef HAS_UNIFORM_u_stroke_opacity
+    lowp float stroke_opacity = u_stroke_opacity;
+#endif
 
     vec2 extrude = v_data.xy;
     float extrude_length = length(extrude);

--- a/src/mbgl/shaders/fill.cpp
+++ b/src/mbgl/shaders/fill.cpp
@@ -11,28 +11,64 @@ attribute vec2 a_pos;
 
 uniform mat4 u_matrix;
 
+
+#ifndef HAS_UNIFORM_u_color
 uniform lowp float a_color_t;
 attribute highp vec4 a_color;
 varying highp vec4 color;
+#else
+uniform highp vec4 u_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_opacity
 uniform lowp float a_opacity_t;
 attribute lowp vec2 a_opacity;
 varying lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
 
 void main() {
+
+#ifndef HAS_UNIFORM_u_color
     color = unpack_mix_vec4(a_color, a_color_t);
+#else
+    highp vec4 color = u_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_opacity
     opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
+#else
+    lowp float opacity = u_opacity;
+#endif
 
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
 }
 
 )MBGL_SHADER";
 const char* fill::fragmentSource = R"MBGL_SHADER(
+
+#ifndef HAS_UNIFORM_u_color
 varying highp vec4 color;
+#else
+uniform highp vec4 u_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_opacity
 varying lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
 
 void main() {
-    
-    
+
+#ifdef HAS_UNIFORM_u_color
+    highp vec4 color = u_color;
+#endif
+
+#ifdef HAS_UNIFORM_u_opacity
+    lowp float opacity = u_opacity;
+#endif
 
     gl_FragColor = color * opacity;
 

--- a/src/mbgl/shaders/fill_extrusion.cpp
+++ b/src/mbgl/shaders/fill_extrusion.cpp
@@ -18,21 +18,51 @@ attribute float a_edgedistance;
 
 varying vec4 v_color;
 
+
+#ifndef HAS_UNIFORM_u_base
 uniform lowp float a_base_t;
 attribute lowp vec2 a_base;
 varying lowp float base;
+#else
+uniform lowp float u_base;
+#endif
+
+#ifndef HAS_UNIFORM_u_height
 uniform lowp float a_height_t;
 attribute lowp vec2 a_height;
 varying lowp float height;
+#else
+uniform lowp float u_height;
+#endif
 
+
+#ifndef HAS_UNIFORM_u_color
 uniform lowp float a_color_t;
 attribute highp vec4 a_color;
 varying highp vec4 color;
+#else
+uniform highp vec4 u_color;
+#endif
 
 void main() {
+
+#ifndef HAS_UNIFORM_u_base
     base = unpack_mix_vec2(a_base, a_base_t);
+#else
+    lowp float base = u_base;
+#endif
+
+#ifndef HAS_UNIFORM_u_height
     height = unpack_mix_vec2(a_height, a_height_t);
+#else
+    lowp float height = u_height;
+#endif
+
+#ifndef HAS_UNIFORM_u_color
     color = unpack_mix_vec4(a_color, a_color_t);
+#else
+    highp vec4 color = u_color;
+#endif
 
     base = max(0.0, base);
     height = max(0.0, height);
@@ -76,14 +106,38 @@ void main() {
 )MBGL_SHADER";
 const char* fill_extrusion::fragmentSource = R"MBGL_SHADER(
 varying vec4 v_color;
+
+#ifndef HAS_UNIFORM_u_base
 varying lowp float base;
+#else
+uniform lowp float u_base;
+#endif
+
+#ifndef HAS_UNIFORM_u_height
 varying lowp float height;
+#else
+uniform lowp float u_height;
+#endif
+
+#ifndef HAS_UNIFORM_u_color
 varying highp vec4 color;
+#else
+uniform highp vec4 u_color;
+#endif
 
 void main() {
-    
-    
-    
+
+#ifdef HAS_UNIFORM_u_base
+    lowp float base = u_base;
+#endif
+
+#ifdef HAS_UNIFORM_u_height
+    lowp float height = u_height;
+#endif
+
+#ifdef HAS_UNIFORM_u_color
+    highp vec4 color = u_color;
+#endif
 
     gl_FragColor = v_color;
 

--- a/src/mbgl/shaders/fill_extrusion_pattern.cpp
+++ b/src/mbgl/shaders/fill_extrusion_pattern.cpp
@@ -30,16 +30,36 @@ varying vec2 v_pos_b;
 varying vec4 v_lighting;
 varying float v_directional;
 
+
+#ifndef HAS_UNIFORM_u_base
 uniform lowp float a_base_t;
 attribute lowp vec2 a_base;
 varying lowp float base;
+#else
+uniform lowp float u_base;
+#endif
+
+#ifndef HAS_UNIFORM_u_height
 uniform lowp float a_height_t;
 attribute lowp vec2 a_height;
 varying lowp float height;
+#else
+uniform lowp float u_height;
+#endif
 
 void main() {
+
+#ifndef HAS_UNIFORM_u_base
     base = unpack_mix_vec2(a_base, a_base_t);
+#else
+    lowp float base = u_base;
+#endif
+
+#ifndef HAS_UNIFORM_u_height
     height = unpack_mix_vec2(a_height, a_height_t);
+#else
+    lowp float height = u_height;
+#endif
 
     base = max(0.0, base);
     height = max(0.0, height);
@@ -81,12 +101,28 @@ varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 varying vec4 v_lighting;
 
+
+#ifndef HAS_UNIFORM_u_base
 varying lowp float base;
+#else
+uniform lowp float u_base;
+#endif
+
+#ifndef HAS_UNIFORM_u_height
 varying lowp float height;
+#else
+uniform lowp float u_height;
+#endif
 
 void main() {
-    
-    
+
+#ifdef HAS_UNIFORM_u_base
+    lowp float base = u_base;
+#endif
+
+#ifdef HAS_UNIFORM_u_height
+    lowp float height = u_height;
+#endif
 
     vec2 imagecoord = mod(v_pos_a, 1.0);
     vec2 pos = mix(u_pattern_tl_a, u_pattern_br_a, imagecoord);

--- a/src/mbgl/shaders/fill_outline.cpp
+++ b/src/mbgl/shaders/fill_outline.cpp
@@ -14,16 +14,36 @@ uniform vec2 u_world;
 
 varying vec2 v_pos;
 
+
+#ifndef HAS_UNIFORM_u_outline_color
 uniform lowp float a_outline_color_t;
 attribute highp vec4 a_outline_color;
 varying highp vec4 outline_color;
+#else
+uniform highp vec4 u_outline_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_opacity
 uniform lowp float a_opacity_t;
 attribute lowp vec2 a_opacity;
 varying lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
 
 void main() {
+
+#ifndef HAS_UNIFORM_u_outline_color
     outline_color = unpack_mix_vec4(a_outline_color, a_outline_color_t);
+#else
+    highp vec4 outline_color = u_outline_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_opacity
     opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
+#else
+    lowp float opacity = u_opacity;
+#endif
 
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
     v_pos = (gl_Position.xy / gl_Position.w + 1.0) / 2.0 * u_world;
@@ -31,14 +51,30 @@ void main() {
 
 )MBGL_SHADER";
 const char* fill_outline::fragmentSource = R"MBGL_SHADER(
+
+#ifndef HAS_UNIFORM_u_outline_color
 varying highp vec4 outline_color;
+#else
+uniform highp vec4 u_outline_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_opacity
 varying lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
 
 varying vec2 v_pos;
 
 void main() {
-    
-    
+
+#ifdef HAS_UNIFORM_u_outline_color
+    highp vec4 outline_color = u_outline_color;
+#endif
+
+#ifdef HAS_UNIFORM_u_opacity
+    lowp float opacity = u_opacity;
+#endif
 
     float dist = length(v_pos - gl_FragCoord.xy);
     float alpha = smoothstep(1.0, 0.0, dist);

--- a/src/mbgl/shaders/fill_outline_pattern.cpp
+++ b/src/mbgl/shaders/fill_outline_pattern.cpp
@@ -23,12 +23,22 @@ varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 varying vec2 v_pos;
 
+
+#ifndef HAS_UNIFORM_u_opacity
 uniform lowp float a_opacity_t;
 attribute lowp vec2 a_opacity;
 varying lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
 
 void main() {
+
+#ifndef HAS_UNIFORM_u_opacity
     opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
+#else
+    lowp float opacity = u_opacity;
+#endif
 
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
 
@@ -52,10 +62,18 @@ varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 varying vec2 v_pos;
 
+
+#ifndef HAS_UNIFORM_u_opacity
 varying lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
 
 void main() {
-    
+
+#ifdef HAS_UNIFORM_u_opacity
+    lowp float opacity = u_opacity;
+#endif
 
     vec2 imagecoord = mod(v_pos_a, 1.0);
     vec2 pos = mix(u_pattern_tl_a, u_pattern_br_a, imagecoord);

--- a/src/mbgl/shaders/fill_pattern.cpp
+++ b/src/mbgl/shaders/fill_pattern.cpp
@@ -21,12 +21,22 @@ attribute vec2 a_pos;
 varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 
+
+#ifndef HAS_UNIFORM_u_opacity
 uniform lowp float a_opacity_t;
 attribute lowp vec2 a_opacity;
 varying lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
 
 void main() {
+
+#ifndef HAS_UNIFORM_u_opacity
     opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
+#else
+    lowp float opacity = u_opacity;
+#endif
 
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
 
@@ -47,10 +57,18 @@ uniform sampler2D u_image;
 varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 
+
+#ifndef HAS_UNIFORM_u_opacity
 varying lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
 
 void main() {
-    
+
+#ifdef HAS_UNIFORM_u_opacity
+    lowp float opacity = u_opacity;
+#endif
 
     vec2 imagecoord = mod(v_pos_a, 1.0);
     vec2 pos = mix(u_pattern_tl_a, u_pattern_br_a, imagecoord);

--- a/src/mbgl/shaders/line.cpp
+++ b/src/mbgl/shaders/line.cpp
@@ -33,26 +33,76 @@ varying vec2 v_normal;
 varying vec2 v_width2;
 varying float v_gamma_scale;
 
+
+#ifndef HAS_UNIFORM_u_color
 uniform lowp float a_color_t;
 attribute highp vec4 a_color;
 varying highp vec4 color;
+#else
+uniform highp vec4 u_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_blur
 uniform lowp float a_blur_t;
 attribute lowp vec2 a_blur;
 varying lowp float blur;
+#else
+uniform lowp float u_blur;
+#endif
+
+#ifndef HAS_UNIFORM_u_opacity
 uniform lowp float a_opacity_t;
 attribute lowp vec2 a_opacity;
 varying lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
+
+#ifndef HAS_UNIFORM_u_gapwidth
 uniform lowp float a_gapwidth_t;
 attribute mediump vec2 a_gapwidth;
+#else
+uniform mediump float u_gapwidth;
+#endif
+
+#ifndef HAS_UNIFORM_u_offset
 uniform lowp float a_offset_t;
 attribute lowp vec2 a_offset;
+#else
+uniform lowp float u_offset;
+#endif
 
 void main() {
+
+#ifndef HAS_UNIFORM_u_color
     color = unpack_mix_vec4(a_color, a_color_t);
+#else
+    highp vec4 color = u_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_blur
     blur = unpack_mix_vec2(a_blur, a_blur_t);
+#else
+    lowp float blur = u_blur;
+#endif
+
+#ifndef HAS_UNIFORM_u_opacity
     opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
+#else
+    lowp float opacity = u_opacity;
+#endif
+
+#ifndef HAS_UNIFORM_u_gapwidth
     mediump float gapwidth = unpack_mix_vec2(a_gapwidth, a_gapwidth_t);
+#else
+    mediump float gapwidth = u_gapwidth;
+#endif
+
+#ifndef HAS_UNIFORM_u_offset
     lowp float offset = unpack_mix_vec2(a_offset, a_offset_t);
+#else
+    lowp float offset = u_offset;
+#endif
 
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;
@@ -103,18 +153,42 @@ void main() {
 
 )MBGL_SHADER";
 const char* line::fragmentSource = R"MBGL_SHADER(
+
+#ifndef HAS_UNIFORM_u_color
 varying highp vec4 color;
+#else
+uniform highp vec4 u_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_blur
 varying lowp float blur;
+#else
+uniform lowp float u_blur;
+#endif
+
+#ifndef HAS_UNIFORM_u_opacity
 varying lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
 
 varying vec2 v_width2;
 varying vec2 v_normal;
 varying float v_gamma_scale;
 
 void main() {
-    
-    
-    
+
+#ifdef HAS_UNIFORM_u_color
+    highp vec4 color = u_color;
+#endif
+
+#ifdef HAS_UNIFORM_u_blur
+    lowp float blur = u_blur;
+#endif
+
+#ifdef HAS_UNIFORM_u_opacity
+    lowp float opacity = u_opacity;
+#endif
 
     // Calculate the distance of the pixel from the line in pixels.
     float dist = length(v_normal) * v_width2.s;

--- a/src/mbgl/shaders/line.cpp
+++ b/src/mbgl/shaders/line.cpp
@@ -44,17 +44,15 @@ attribute lowp vec2 a_opacity;
 varying lowp float opacity;
 uniform lowp float a_gapwidth_t;
 attribute mediump vec2 a_gapwidth;
-varying mediump float gapwidth;
 uniform lowp float a_offset_t;
 attribute lowp vec2 a_offset;
-varying lowp float offset;
 
 void main() {
     color = unpack_mix_vec4(a_color, a_color_t);
     blur = unpack_mix_vec2(a_blur, a_blur_t);
     opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
-    gapwidth = unpack_mix_vec2(a_gapwidth, a_gapwidth_t);
-    offset = unpack_mix_vec2(a_offset, a_offset_t);
+    mediump float gapwidth = unpack_mix_vec2(a_gapwidth, a_gapwidth_t);
+    lowp float offset = unpack_mix_vec2(a_offset, a_offset_t);
 
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;

--- a/src/mbgl/shaders/line_pattern.cpp
+++ b/src/mbgl/shaders/line_pattern.cpp
@@ -36,22 +36,62 @@ varying vec2 v_width2;
 varying float v_linesofar;
 varying float v_gamma_scale;
 
+
+#ifndef HAS_UNIFORM_u_blur
 uniform lowp float a_blur_t;
 attribute lowp vec2 a_blur;
 varying lowp float blur;
+#else
+uniform lowp float u_blur;
+#endif
+
+#ifndef HAS_UNIFORM_u_opacity
 uniform lowp float a_opacity_t;
 attribute lowp vec2 a_opacity;
 varying lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
+
+#ifndef HAS_UNIFORM_u_offset
 uniform lowp float a_offset_t;
 attribute lowp vec2 a_offset;
+#else
+uniform lowp float u_offset;
+#endif
+
+#ifndef HAS_UNIFORM_u_gapwidth
 uniform lowp float a_gapwidth_t;
 attribute mediump vec2 a_gapwidth;
+#else
+uniform mediump float u_gapwidth;
+#endif
 
 void main() {
+
+#ifndef HAS_UNIFORM_u_blur
     blur = unpack_mix_vec2(a_blur, a_blur_t);
+#else
+    lowp float blur = u_blur;
+#endif
+
+#ifndef HAS_UNIFORM_u_opacity
     opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
+#else
+    lowp float opacity = u_opacity;
+#endif
+
+#ifndef HAS_UNIFORM_u_offset
     lowp float offset = unpack_mix_vec2(a_offset, a_offset_t);
+#else
+    lowp float offset = u_offset;
+#endif
+
+#ifndef HAS_UNIFORM_u_gapwidth
     mediump float gapwidth = unpack_mix_vec2(a_gapwidth, a_gapwidth_t);
+#else
+    mediump float gapwidth = u_gapwidth;
+#endif
 
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;
@@ -118,12 +158,28 @@ varying vec2 v_width2;
 varying float v_linesofar;
 varying float v_gamma_scale;
 
+
+#ifndef HAS_UNIFORM_u_blur
 varying lowp float blur;
+#else
+uniform lowp float u_blur;
+#endif
+
+#ifndef HAS_UNIFORM_u_opacity
 varying lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
 
 void main() {
-    
-    
+
+#ifdef HAS_UNIFORM_u_blur
+    lowp float blur = u_blur;
+#endif
+
+#ifdef HAS_UNIFORM_u_opacity
+    lowp float opacity = u_opacity;
+#endif
 
     // Calculate the distance of the pixel from the line in pixels.
     float dist = length(v_normal) * v_width2.s;

--- a/src/mbgl/shaders/line_pattern.cpp
+++ b/src/mbgl/shaders/line_pattern.cpp
@@ -44,16 +44,14 @@ attribute lowp vec2 a_opacity;
 varying lowp float opacity;
 uniform lowp float a_offset_t;
 attribute lowp vec2 a_offset;
-varying lowp float offset;
 uniform lowp float a_gapwidth_t;
 attribute mediump vec2 a_gapwidth;
-varying mediump float gapwidth;
 
 void main() {
     blur = unpack_mix_vec2(a_blur, a_blur_t);
     opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
-    offset = unpack_mix_vec2(a_offset, a_offset_t);
-    gapwidth = unpack_mix_vec2(a_gapwidth, a_gapwidth_t);
+    lowp float offset = unpack_mix_vec2(a_offset, a_offset_t);
+    mediump float gapwidth = unpack_mix_vec2(a_gapwidth, a_gapwidth_t);
 
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;

--- a/src/mbgl/shaders/line_sdf.cpp
+++ b/src/mbgl/shaders/line_sdf.cpp
@@ -41,26 +41,76 @@ varying vec2 v_tex_a;
 varying vec2 v_tex_b;
 varying float v_gamma_scale;
 
+
+#ifndef HAS_UNIFORM_u_color
 uniform lowp float a_color_t;
 attribute highp vec4 a_color;
 varying highp vec4 color;
+#else
+uniform highp vec4 u_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_blur
 uniform lowp float a_blur_t;
 attribute lowp vec2 a_blur;
 varying lowp float blur;
+#else
+uniform lowp float u_blur;
+#endif
+
+#ifndef HAS_UNIFORM_u_opacity
 uniform lowp float a_opacity_t;
 attribute lowp vec2 a_opacity;
 varying lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
+
+#ifndef HAS_UNIFORM_u_gapwidth
 uniform lowp float a_gapwidth_t;
 attribute mediump vec2 a_gapwidth;
+#else
+uniform mediump float u_gapwidth;
+#endif
+
+#ifndef HAS_UNIFORM_u_offset
 uniform lowp float a_offset_t;
 attribute lowp vec2 a_offset;
+#else
+uniform lowp float u_offset;
+#endif
 
 void main() {
+
+#ifndef HAS_UNIFORM_u_color
     color = unpack_mix_vec4(a_color, a_color_t);
+#else
+    highp vec4 color = u_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_blur
     blur = unpack_mix_vec2(a_blur, a_blur_t);
+#else
+    lowp float blur = u_blur;
+#endif
+
+#ifndef HAS_UNIFORM_u_opacity
     opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
+#else
+    lowp float opacity = u_opacity;
+#endif
+
+#ifndef HAS_UNIFORM_u_gapwidth
     mediump float gapwidth = unpack_mix_vec2(a_gapwidth, a_gapwidth_t);
+#else
+    mediump float gapwidth = u_gapwidth;
+#endif
+
+#ifndef HAS_UNIFORM_u_offset
     lowp float offset = unpack_mix_vec2(a_offset, a_offset_t);
+#else
+    lowp float offset = u_offset;
+#endif
 
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;
@@ -125,14 +175,38 @@ varying vec2 v_tex_a;
 varying vec2 v_tex_b;
 varying float v_gamma_scale;
 
+
+#ifndef HAS_UNIFORM_u_color
 varying highp vec4 color;
+#else
+uniform highp vec4 u_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_blur
 varying lowp float blur;
+#else
+uniform lowp float u_blur;
+#endif
+
+#ifndef HAS_UNIFORM_u_opacity
 varying lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
 
 void main() {
-    
-    
-    
+
+#ifdef HAS_UNIFORM_u_color
+    highp vec4 color = u_color;
+#endif
+
+#ifdef HAS_UNIFORM_u_blur
+    lowp float blur = u_blur;
+#endif
+
+#ifdef HAS_UNIFORM_u_opacity
+    lowp float opacity = u_opacity;
+#endif
 
     // Calculate the distance of the pixel from the line in pixels.
     float dist = length(v_normal) * v_width2.s;

--- a/src/mbgl/shaders/line_sdf.cpp
+++ b/src/mbgl/shaders/line_sdf.cpp
@@ -52,17 +52,15 @@ attribute lowp vec2 a_opacity;
 varying lowp float opacity;
 uniform lowp float a_gapwidth_t;
 attribute mediump vec2 a_gapwidth;
-varying mediump float gapwidth;
 uniform lowp float a_offset_t;
 attribute lowp vec2 a_offset;
-varying lowp float offset;
 
 void main() {
     color = unpack_mix_vec4(a_color, a_color_t);
     blur = unpack_mix_vec2(a_blur, a_blur_t);
     opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
-    gapwidth = unpack_mix_vec2(a_gapwidth, a_gapwidth_t);
-    offset = unpack_mix_vec2(a_offset, a_offset_t);
+    mediump float gapwidth = unpack_mix_vec2(a_gapwidth, a_gapwidth_t);
+    lowp float offset = unpack_mix_vec2(a_offset, a_offset_t);
 
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;

--- a/src/mbgl/shaders/shaders.cpp
+++ b/src/mbgl/shaders/shaders.cpp
@@ -10,11 +10,11 @@ namespace mbgl {
 namespace shaders {
 
 std::string fragmentSource(const ProgramParameters& parameters, const char* fragmentSource) {
-    return parameters.defines + fragmentPrelude + fragmentSource;
+    return parameters.getDefines() + fragmentPrelude + fragmentSource;
 }
 
 std::string vertexSource(const ProgramParameters& parameters, const char* vertexSource) {
-    return parameters.defines + vertexPrelude + vertexSource;
+    return parameters.getDefines() + vertexPrelude + vertexSource;
 }
 
 std::string programIdentifier(const std::string& vertexSource, const std::string& fragmentSource) {

--- a/src/mbgl/shaders/shaders.cpp
+++ b/src/mbgl/shaders/shaders.cpp
@@ -9,30 +9,12 @@
 namespace mbgl {
 namespace shaders {
 
-static std::string pixelRatioDefine(const ProgramParameters& parameters) {
-    std::ostringstream pixelRatioSS;
-    pixelRatioSS.imbue(std::locale("C"));
-    pixelRatioSS.setf(std::ios_base::showpoint);
-    pixelRatioSS << parameters.pixelRatio;
-    return std::string("#define DEVICE_PIXEL_RATIO ") + pixelRatioSS.str() + "\n";
-}
-
 std::string fragmentSource(const ProgramParameters& parameters, const char* fragmentSource) {
-    std::string source = pixelRatioDefine(parameters) + fragmentPrelude + fragmentSource;
-    if (parameters.overdraw) {
-        assert(source.find("#ifdef OVERDRAW_INSPECTOR") != std::string::npos);
-        source.replace(source.find_first_of('\n'), 1, "\n#define OVERDRAW_INSPECTOR\n");
-    }
-    return source;
+    return parameters.defines + fragmentPrelude + fragmentSource;
 }
 
 std::string vertexSource(const ProgramParameters& parameters, const char* vertexSource) {
-    return pixelRatioDefine(parameters) + vertexPrelude + vertexSource;
-}
-
-std::string programCachePath(const ProgramParameters& parameters, const char* name) {
-    return parameters.cacheDir + "/com.mapbox.gl.shader." + name +
-           (parameters.overdraw ? ".overdraw.pbf" : ".pbf");
+    return parameters.defines + vertexPrelude + vertexSource;
 }
 
 std::string programIdentifier(const std::string& vertexSource, const std::string& fragmentSource) {

--- a/src/mbgl/shaders/shaders.hpp
+++ b/src/mbgl/shaders/shaders.hpp
@@ -10,7 +10,6 @@ namespace shaders {
 
 std::string fragmentSource(const ProgramParameters&, const char* fragmentSource);
 std::string vertexSource(const ProgramParameters&, const char* vertexSource);
-std::string programCachePath(const ProgramParameters&, const char* name);
 std::string programIdentifier(const std::string& vertexSource, const std::string& fragmentSource);
 
 } // namespace shaders

--- a/src/mbgl/shaders/symbol_icon.cpp
+++ b/src/mbgl/shaders/symbol_icon.cpp
@@ -19,9 +19,14 @@ uniform mediump float u_size_t; // used to interpolate between zoom stops when s
 uniform mediump float u_size; // used when size is both zoom and feature constant
 uniform mediump float u_layout_size; // used when size is feature constant
 
+
+#ifndef HAS_UNIFORM_u_opacity
 uniform lowp float a_opacity_t;
 attribute lowp vec2 a_opacity;
 varying lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
 
 // matrix is for the vertex position.
 uniform mat4 u_matrix;
@@ -37,7 +42,12 @@ varying vec2 v_tex;
 varying vec2 v_fade_tex;
 
 void main() {
+
+#ifndef HAS_UNIFORM_u_opacity
     opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
+#else
+    lowp float opacity = u_opacity;
+#endif
 
     vec2 a_pos = a_pos_offset.xy;
     vec2 a_offset = a_pos_offset.zw;
@@ -97,13 +107,21 @@ const char* symbol_icon::fragmentSource = R"MBGL_SHADER(
 uniform sampler2D u_texture;
 uniform sampler2D u_fadetexture;
 
+
+#ifndef HAS_UNIFORM_u_opacity
 varying lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
 
 varying vec2 v_tex;
 varying vec2 v_fade_tex;
 
 void main() {
-    
+
+#ifdef HAS_UNIFORM_u_opacity
+    lowp float opacity = u_opacity;
+#endif
 
     lowp float alpha = texture2D(u_fadetexture, v_fade_tex).a * opacity;
     gl_FragColor = texture2D(u_texture, v_tex) * alpha;

--- a/src/mbgl/shaders/symbol_sdf.cpp
+++ b/src/mbgl/shaders/symbol_sdf.cpp
@@ -27,21 +27,46 @@ uniform mediump float u_size_t; // used to interpolate between zoom stops when s
 uniform mediump float u_size; // used when size is both zoom and feature constant
 uniform mediump float u_layout_size; // used when size is feature constant
 
+
+#ifndef HAS_UNIFORM_u_fill_color
 uniform lowp float a_fill_color_t;
 attribute highp vec4 a_fill_color;
 varying highp vec4 fill_color;
+#else
+uniform highp vec4 u_fill_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_halo_color
 uniform lowp float a_halo_color_t;
 attribute highp vec4 a_halo_color;
 varying highp vec4 halo_color;
+#else
+uniform highp vec4 u_halo_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_opacity
 uniform lowp float a_opacity_t;
 attribute lowp vec2 a_opacity;
 varying lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
+
+#ifndef HAS_UNIFORM_u_halo_width
 uniform lowp float a_halo_width_t;
 attribute lowp vec2 a_halo_width;
 varying lowp float halo_width;
+#else
+uniform lowp float u_halo_width;
+#endif
+
+#ifndef HAS_UNIFORM_u_halo_blur
 uniform lowp float a_halo_blur_t;
 attribute lowp vec2 a_halo_blur;
 varying lowp float halo_blur;
+#else
+uniform lowp float u_halo_blur;
+#endif
 
 // matrix is for the vertex position.
 uniform mat4 u_matrix;
@@ -61,11 +86,36 @@ varying vec4 v_data0;
 varying vec2 v_data1;
 
 void main() {
+
+#ifndef HAS_UNIFORM_u_fill_color
     fill_color = unpack_mix_vec4(a_fill_color, a_fill_color_t);
+#else
+    highp vec4 fill_color = u_fill_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_halo_color
     halo_color = unpack_mix_vec4(a_halo_color, a_halo_color_t);
+#else
+    highp vec4 halo_color = u_halo_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_opacity
     opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
+#else
+    lowp float opacity = u_opacity;
+#endif
+
+#ifndef HAS_UNIFORM_u_halo_width
     halo_width = unpack_mix_vec2(a_halo_width, a_halo_width_t);
+#else
+    lowp float halo_width = u_halo_width;
+#endif
+
+#ifndef HAS_UNIFORM_u_halo_blur
     halo_blur = unpack_mix_vec2(a_halo_blur, a_halo_blur_t);
+#else
+    lowp float halo_blur = u_halo_blur;
+#endif
 
     vec2 a_pos = a_pos_offset.xy;
     vec2 a_offset = a_pos_offset.zw;
@@ -170,11 +220,36 @@ const char* symbol_sdf::fragmentSource = R"MBGL_SHADER(
 #define EDGE_GAMMA 0.105/DEVICE_PIXEL_RATIO
 
 uniform bool u_is_halo;
+
+#ifndef HAS_UNIFORM_u_fill_color
 varying highp vec4 fill_color;
+#else
+uniform highp vec4 u_fill_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_halo_color
 varying highp vec4 halo_color;
+#else
+uniform highp vec4 u_halo_color;
+#endif
+
+#ifndef HAS_UNIFORM_u_opacity
 varying lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
+
+#ifndef HAS_UNIFORM_u_halo_width
 varying lowp float halo_width;
+#else
+uniform lowp float u_halo_width;
+#endif
+
+#ifndef HAS_UNIFORM_u_halo_blur
 varying lowp float halo_blur;
+#else
+uniform lowp float u_halo_blur;
+#endif
 
 uniform sampler2D u_texture;
 uniform sampler2D u_fadetexture;
@@ -185,11 +260,26 @@ varying vec4 v_data0;
 varying vec2 v_data1;
 
 void main() {
-    
-    
-    
-    
-    
+
+#ifdef HAS_UNIFORM_u_fill_color
+    highp vec4 fill_color = u_fill_color;
+#endif
+
+#ifdef HAS_UNIFORM_u_halo_color
+    highp vec4 halo_color = u_halo_color;
+#endif
+
+#ifdef HAS_UNIFORM_u_opacity
+    lowp float opacity = u_opacity;
+#endif
+
+#ifdef HAS_UNIFORM_u_halo_width
+    lowp float halo_width = u_halo_width;
+#endif
+
+#ifdef HAS_UNIFORM_u_halo_blur
+    lowp float halo_blur = u_halo_blur;
+#endif
 
     vec2 tex = v_data0.xy;
     vec2 fade_tex = v_data0.zw;

--- a/src/mbgl/style/layers/circle_layer_properties.hpp
+++ b/src/mbgl/style/layers/circle_layer_properties.hpp
@@ -6,23 +6,24 @@
 #include <mbgl/style/layout_property.hpp>
 #include <mbgl/style/paint_property.hpp>
 #include <mbgl/programs/attributes.hpp>
+#include <mbgl/programs/uniforms.hpp>
 
 namespace mbgl {
 namespace style {
 
-struct CircleRadius : DataDrivenPaintProperty<float, attributes::a_radius> {
+struct CircleRadius : DataDrivenPaintProperty<float, attributes::a_radius, uniforms::u_radius> {
     static float defaultValue() { return 5; }
 };
 
-struct CircleColor : DataDrivenPaintProperty<Color, attributes::a_color> {
+struct CircleColor : DataDrivenPaintProperty<Color, attributes::a_color, uniforms::u_color> {
     static Color defaultValue() { return Color::black(); }
 };
 
-struct CircleBlur : DataDrivenPaintProperty<float, attributes::a_blur> {
+struct CircleBlur : DataDrivenPaintProperty<float, attributes::a_blur, uniforms::u_blur> {
     static float defaultValue() { return 0; }
 };
 
-struct CircleOpacity : DataDrivenPaintProperty<float, attributes::a_opacity> {
+struct CircleOpacity : DataDrivenPaintProperty<float, attributes::a_opacity, uniforms::u_opacity> {
     static float defaultValue() { return 1; }
 };
 
@@ -38,15 +39,15 @@ struct CirclePitchScale : PaintProperty<CirclePitchScaleType> {
     static CirclePitchScaleType defaultValue() { return CirclePitchScaleType::Map; }
 };
 
-struct CircleStrokeWidth : DataDrivenPaintProperty<float, attributes::a_stroke_width> {
+struct CircleStrokeWidth : DataDrivenPaintProperty<float, attributes::a_stroke_width, uniforms::u_stroke_width> {
     static float defaultValue() { return 0; }
 };
 
-struct CircleStrokeColor : DataDrivenPaintProperty<Color, attributes::a_stroke_color> {
+struct CircleStrokeColor : DataDrivenPaintProperty<Color, attributes::a_stroke_color, uniforms::u_stroke_color> {
     static Color defaultValue() { return Color::black(); }
 };
 
-struct CircleStrokeOpacity : DataDrivenPaintProperty<float, attributes::a_stroke_opacity> {
+struct CircleStrokeOpacity : DataDrivenPaintProperty<float, attributes::a_stroke_opacity, uniforms::u_stroke_opacity> {
     static float defaultValue() { return 1; }
 };
 

--- a/src/mbgl/style/layers/fill_extrusion_layer_properties.hpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer_properties.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/style/layout_property.hpp>
 #include <mbgl/style/paint_property.hpp>
 #include <mbgl/programs/attributes.hpp>
+#include <mbgl/programs/uniforms.hpp>
 
 namespace mbgl {
 namespace style {
@@ -14,7 +15,7 @@ struct FillExtrusionOpacity : PaintProperty<float> {
     static float defaultValue() { return 1; }
 };
 
-struct FillExtrusionColor : DataDrivenPaintProperty<Color, attributes::a_color> {
+struct FillExtrusionColor : DataDrivenPaintProperty<Color, attributes::a_color, uniforms::u_color> {
     static Color defaultValue() { return Color::black(); }
 };
 
@@ -30,11 +31,11 @@ struct FillExtrusionPattern : CrossFadedPaintProperty<std::string> {
     static std::string defaultValue() { return ""; }
 };
 
-struct FillExtrusionHeight : DataDrivenPaintProperty<float, attributes::a_height> {
+struct FillExtrusionHeight : DataDrivenPaintProperty<float, attributes::a_height, uniforms::u_height> {
     static float defaultValue() { return 0; }
 };
 
-struct FillExtrusionBase : DataDrivenPaintProperty<float, attributes::a_base> {
+struct FillExtrusionBase : DataDrivenPaintProperty<float, attributes::a_base, uniforms::u_base> {
     static float defaultValue() { return 0; }
 };
 

--- a/src/mbgl/style/layers/fill_layer_properties.hpp
+++ b/src/mbgl/style/layers/fill_layer_properties.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/style/layout_property.hpp>
 #include <mbgl/style/paint_property.hpp>
 #include <mbgl/programs/attributes.hpp>
+#include <mbgl/programs/uniforms.hpp>
 
 namespace mbgl {
 namespace style {
@@ -14,15 +15,15 @@ struct FillAntialias : PaintProperty<bool> {
     static bool defaultValue() { return true; }
 };
 
-struct FillOpacity : DataDrivenPaintProperty<float, attributes::a_opacity> {
+struct FillOpacity : DataDrivenPaintProperty<float, attributes::a_opacity, uniforms::u_opacity> {
     static float defaultValue() { return 1; }
 };
 
-struct FillColor : DataDrivenPaintProperty<Color, attributes::a_color> {
+struct FillColor : DataDrivenPaintProperty<Color, attributes::a_color, uniforms::u_color> {
     static Color defaultValue() { return Color::black(); }
 };
 
-struct FillOutlineColor : DataDrivenPaintProperty<Color, attributes::a_outline_color> {
+struct FillOutlineColor : DataDrivenPaintProperty<Color, attributes::a_outline_color, uniforms::u_outline_color> {
     static Color defaultValue() { return {}; }
 };
 

--- a/src/mbgl/style/layers/line_layer_properties.hpp
+++ b/src/mbgl/style/layers/line_layer_properties.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/style/layout_property.hpp>
 #include <mbgl/style/paint_property.hpp>
 #include <mbgl/programs/attributes.hpp>
+#include <mbgl/programs/uniforms.hpp>
 
 namespace mbgl {
 namespace style {
@@ -30,11 +31,11 @@ struct LineRoundLimit : LayoutProperty<float> {
     static float defaultValue() { return 1; }
 };
 
-struct LineOpacity : DataDrivenPaintProperty<float, attributes::a_opacity> {
+struct LineOpacity : DataDrivenPaintProperty<float, attributes::a_opacity, uniforms::u_opacity> {
     static float defaultValue() { return 1; }
 };
 
-struct LineColor : DataDrivenPaintProperty<Color, attributes::a_color> {
+struct LineColor : DataDrivenPaintProperty<Color, attributes::a_color, uniforms::u_color> {
     static Color defaultValue() { return Color::black(); }
 };
 
@@ -50,15 +51,15 @@ struct LineWidth : PaintProperty<float> {
     static float defaultValue() { return 1; }
 };
 
-struct LineGapWidth : DataDrivenPaintProperty<float, attributes::a_gap_width> {
+struct LineGapWidth : DataDrivenPaintProperty<float, attributes::a_gap_width, uniforms::u_gap_width> {
     static float defaultValue() { return 0; }
 };
 
-struct LineOffset : DataDrivenPaintProperty<float, attributes::a_offset<1>> {
+struct LineOffset : DataDrivenPaintProperty<float, attributes::a_offset<1>, uniforms::u_offset> {
     static float defaultValue() { return 0; }
 };
 
-struct LineBlur : DataDrivenPaintProperty<float, attributes::a_blur> {
+struct LineBlur : DataDrivenPaintProperty<float, attributes::a_blur, uniforms::u_blur> {
     static float defaultValue() { return 0; }
 };
 

--- a/src/mbgl/style/layers/symbol_layer_properties.hpp
+++ b/src/mbgl/style/layers/symbol_layer_properties.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/style/layout_property.hpp>
 #include <mbgl/style/paint_property.hpp>
 #include <mbgl/programs/attributes.hpp>
+#include <mbgl/programs/uniforms.hpp>
 
 namespace mbgl {
 namespace style {
@@ -180,23 +181,23 @@ struct TextOptional : LayoutProperty<bool> {
     static bool defaultValue() { return false; }
 };
 
-struct IconOpacity : DataDrivenPaintProperty<float, attributes::a_opacity> {
+struct IconOpacity : DataDrivenPaintProperty<float, attributes::a_opacity, uniforms::u_opacity> {
     static float defaultValue() { return 1; }
 };
 
-struct IconColor : DataDrivenPaintProperty<Color, attributes::a_fill_color> {
+struct IconColor : DataDrivenPaintProperty<Color, attributes::a_fill_color, uniforms::u_fill_color> {
     static Color defaultValue() { return Color::black(); }
 };
 
-struct IconHaloColor : DataDrivenPaintProperty<Color, attributes::a_halo_color> {
+struct IconHaloColor : DataDrivenPaintProperty<Color, attributes::a_halo_color, uniforms::u_halo_color> {
     static Color defaultValue() { return {}; }
 };
 
-struct IconHaloWidth : DataDrivenPaintProperty<float, attributes::a_halo_width> {
+struct IconHaloWidth : DataDrivenPaintProperty<float, attributes::a_halo_width, uniforms::u_halo_width> {
     static float defaultValue() { return 0; }
 };
 
-struct IconHaloBlur : DataDrivenPaintProperty<float, attributes::a_halo_blur> {
+struct IconHaloBlur : DataDrivenPaintProperty<float, attributes::a_halo_blur, uniforms::u_halo_blur> {
     static float defaultValue() { return 0; }
 };
 
@@ -208,23 +209,23 @@ struct IconTranslateAnchor : PaintProperty<TranslateAnchorType> {
     static TranslateAnchorType defaultValue() { return TranslateAnchorType::Map; }
 };
 
-struct TextOpacity : DataDrivenPaintProperty<float, attributes::a_opacity> {
+struct TextOpacity : DataDrivenPaintProperty<float, attributes::a_opacity, uniforms::u_opacity> {
     static float defaultValue() { return 1; }
 };
 
-struct TextColor : DataDrivenPaintProperty<Color, attributes::a_fill_color> {
+struct TextColor : DataDrivenPaintProperty<Color, attributes::a_fill_color, uniforms::u_fill_color> {
     static Color defaultValue() { return Color::black(); }
 };
 
-struct TextHaloColor : DataDrivenPaintProperty<Color, attributes::a_halo_color> {
+struct TextHaloColor : DataDrivenPaintProperty<Color, attributes::a_halo_color, uniforms::u_halo_color> {
     static Color defaultValue() { return {}; }
 };
 
-struct TextHaloWidth : DataDrivenPaintProperty<float, attributes::a_halo_width> {
+struct TextHaloWidth : DataDrivenPaintProperty<float, attributes::a_halo_width, uniforms::u_halo_width> {
     static float defaultValue() { return 0; }
 };
 
-struct TextHaloBlur : DataDrivenPaintProperty<float, attributes::a_halo_blur> {
+struct TextHaloBlur : DataDrivenPaintProperty<float, attributes::a_halo_blur, uniforms::u_halo_blur> {
     static float defaultValue() { return 0; }
 };
 

--- a/src/mbgl/style/paint_property.hpp
+++ b/src/mbgl/style/paint_property.hpp
@@ -92,7 +92,7 @@ public:
     static constexpr bool IsDataDriven = false;
 };
 
-template <class T, class A>
+template <class T, class A, class U>
 class DataDrivenPaintProperty {
 public:
     using ValueType = DataDrivenPropertyValue<T>;
@@ -104,6 +104,7 @@ public:
 
     using Type = T;
     using Attribute = A;
+    using Uniform = U;
 };
 
 template <class T>


### PR DESCRIPTION
Cherry-picks the following OpenGL performance and compatibility fixes to the release branch:

* #9251 -- Reduce number of varyings to 8 or less
* #9181 -- Store vertex attribute binding to prevent duplicate binds
* #9185 -- Dynamically compile shaders with uniforms instead of attributes for DDS
* #9257 -- Don't upload the FrameHistory texture in frames where it's not changing

```
2017-06-13 12:17:58.318728-0700 Bench GL[7283:1811481] | paris      | 60.0 fps |
2017-06-13 12:17:58.318824-0700 Bench GL[7283:1811481] | paris2     | 60.0 fps |
2017-06-13 12:17:58.318910-0700 Bench GL[7283:1811481] | alps       | 60.2 fps |
2017-06-13 12:17:58.318992-0700 Bench GL[7283:1811481] | us east    | 60.1 fps |
2017-06-13 12:17:58.319074-0700 Bench GL[7283:1811481] | greater la | 60.1 fps |
2017-06-13 12:17:58.319212-0700 Bench GL[7283:1811481] | sf         | 60.1 fps |
2017-06-13 12:17:58.319564-0700 Bench GL[7283:1811481] | oakland    | 60.2 fps |
2017-06-13 12:17:58.319654-0700 Bench GL[7283:1811481] | germany    | 59.9 fps |
2017-06-13 12:17:58.319726-0700 Bench GL[7283:1811481] Total FPS: 480.6
2017-06-13 12:17:58.319797-0700 Bench GL[7283:1811481] Average FPS: 60.1
```