### PR TITLE
[core] Implement "smart setStyle"

### DIFF
--- a/include/mbgl/util/constants.hpp
+++ b/include/mbgl/util/constants.hpp
@@ -40,7 +40,7 @@ constexpr float  MAX_ZOOM_F = MAX_ZOOM;
 
 constexpr uint64_t DEFAULT_MAX_CACHE_SIZE = 50 * 1024 * 1024;
 
-constexpr Duration DEFAULT_FADE_DURATION = Milliseconds(300);
+constexpr Duration DEFAULT_TRANSITION_DURATION = Milliseconds(300);
 constexpr Seconds CLOCK_SKEW_RETRY_TIMEOUT { 30 };
 
 constexpr UnitBezier DEFAULT_TRANSITION_EASE = { 0, 0, 0.25, 1 };

--- a/platform/node/test/suite_implementation.js
+++ b/platform/node/test/suite_implementation.js
@@ -80,6 +80,11 @@ module.exports = function (style, options, callback) {
             });
 
             applyOperations(operations.slice(1), callback);
+
+        } else if (operation[0] === 'setStyle') {
+            map.load(operation[1]);
+            applyOperations(operations.slice(1), callback);
+
         } else {
             // Ensure that the next `map.render(options)` does not overwrite this change.
             if (operation[0] === 'setCenter') {

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -115,7 +115,7 @@ Painter::Painter(gl::Context& context_,
 Painter::~Painter() = default;
 
 bool Painter::needsAnimation() const {
-    return frameHistory.needsAnimation(util::DEFAULT_FADE_DURATION);
+    return frameHistory.needsAnimation(util::DEFAULT_TRANSITION_DURATION);
 }
 
 void Painter::cleanup() {
@@ -159,7 +159,7 @@ void Painter::render(RenderStyle& style, const FrameData& frame_, View& view) {
     }
 
     frameHistory.record(frame.timePoint, state.getZoom(),
-        frame.mapMode == MapMode::Continuous ? util::DEFAULT_FADE_DURATION : Milliseconds(0));
+        frame.mapMode == MapMode::Continuous ? util::DEFAULT_TRANSITION_DURATION : Milliseconds(0));
 
 
     // - UPLOAD PASS -------------------------------------------------------------------------------

--- a/src/mbgl/renderer/render_style.cpp
+++ b/src/mbgl/renderer/render_style.cpp
@@ -203,14 +203,15 @@ void RenderStyle::update(const UpdateParameters& parameters) {
                 continue;
             }
 
-            if (getRenderLayer(layer->id)->needsRendering(zoomHistory.lastZoom)) {
+            if (!needsRendering && getRenderLayer(layer->id)->needsRendering(zoomHistory.lastZoom)) {
                 needsRendering = true;
             }
 
-            if (hasLayoutDifference(layerDiff, layer->id) ||
+            if (!needsRelayout && (
+                hasLayoutDifference(layerDiff, layer->id) ||
                 !imageDiff.added.empty() ||
                 !imageDiff.removed.empty() ||
-                !imageDiff.changed.empty()) {
+                !imageDiff.changed.empty())) {
                 needsRelayout = true;
             }
 

--- a/src/mbgl/renderer/render_style.cpp
+++ b/src/mbgl/renderer/render_style.cpp
@@ -88,7 +88,7 @@ void RenderStyle::update(const UpdateParameters& parameters) {
     const PropertyEvaluationParameters evaluationParameters {
         zoomHistory,
         parameters.mode == MapMode::Continuous ? parameters.timePoint : Clock::time_point::max(),
-        parameters.mode == MapMode::Continuous ? util::DEFAULT_FADE_DURATION : Duration::zero()
+        parameters.mode == MapMode::Continuous ? util::DEFAULT_TRANSITION_DURATION : Duration::zero()
     };
 
     const TileParameters tileParameters {

--- a/src/mbgl/style/parser.cpp
+++ b/src/mbgl/style/parser.cpp
@@ -86,6 +86,10 @@ StyleParseResult Parser::parse(const std::string& json) {
         }
     }
 
+    if (document.HasMember("transition")) {
+        parseTransition(document["transition"]);
+    }
+
     if (document.HasMember("light")) {
         parseLight(document["light"]);
     }
@@ -113,6 +117,17 @@ StyleParseResult Parser::parse(const std::string& json) {
     }
 
     return nullptr;
+}
+
+void Parser::parseTransition(const JSValue& value) {
+    conversion::Error error;
+    optional<TransitionOptions> converted = conversion::convert<TransitionOptions>(value, error);
+    if (!converted) {
+        Log::Warning(Event::ParseStyle, error.message);
+        return;
+    }
+
+    transition = std::move(*converted);
 }
 
 void Parser::parseLight(const JSValue& value) {

--- a/src/mbgl/style/parser.hpp
+++ b/src/mbgl/style/parser.hpp
@@ -32,6 +32,7 @@ public:
     std::vector<std::unique_ptr<Source>> sources;
     std::vector<std::unique_ptr<Layer>> layers;
 
+    TransitionOptions transition;
     Light light;
 
     std::string name;
@@ -44,6 +45,7 @@ public:
     std::vector<FontStack> fontStacks() const;
 
 private:
+    void parseTransition(const JSValue&);
     void parseLight(const JSValue&);
     void parseSources(const JSValue&);
     void parseLayers(const JSValue&);

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -57,6 +57,7 @@ void Style::setJSON(const std::string& json) {
     images.clear();
 
     transitionOptions = {};
+    transitionOptions.duration = util::DEFAULT_TRANSITION_DURATION;
 
     Parser parser;
     auto error = parser.parse(json);

--- a/test/api/api_misuse.test.cpp
+++ b/test/api/api_misuse.test.cpp
@@ -44,31 +44,3 @@ TEST(API, RenderWithoutCallback) {
 
     EXPECT_EQ(log->count(logMessage), 1u);
 }
-
-TEST(API, RenderWithoutStyle) {
-    util::RunLoop loop;
-
-    HeadlessBackend backend { test::sharedDisplay() };
-    BackendScope scope { backend };
-    OffscreenView view { backend.getContext(), { 128, 512 } };
-    StubFileSource fileSource;
-    ThreadPool threadPool(4);
-
-    Map map(backend, view.getSize(), 1, fileSource, threadPool, MapMode::Still);
-
-    std::exception_ptr error;
-    map.renderStill(view, [&](std::exception_ptr error_) {
-        error = error_;
-        loop.stop();
-    });
-
-    loop.run();
-
-    try {
-        std::rethrow_exception(error);
-    } catch (const util::MisuseException& ex) {
-        EXPECT_EQ(std::string(ex.what()), "Map doesn't have a style");
-    } catch (const std::exception&) {
-        EXPECT_TRUE(false) << "Unhandled exception.";
-    }
-}


### PR DESCRIPTION
Implements automatic "smart setStyle" behavior for existing style-setting APIs: `Map::setStyleURL` and `Map::setStyleJSON`. Both of these APIs will now smoothly transition between the prior and new style (providing equivalent layers/sources/etc. use the same IDs).

![gl](https://user-images.githubusercontent.com/98601/27095790-cd3d4eb8-5023-11e7-937f-8f5ddf742c79.gif)

Besides the obvious behavioral change, several changes are worth calling out for consideration of their downstream impact:

* Paint property mutations now transition by default over a 300ms duration. This can be overridden via `Map::setTransitionOptions` (already existed), or within the style via the [`"transition"` property](https://www.mapbox.com/mapbox-gl-js/style-spec/#root-transition) (support added in this PR). A 300ms transition was always the intended default behavior according to the style specification, and is what's implemented in gl-js, but for whatever reason was not the default for gl-native. This change is included because it makes smart setStyle look cool.
* For `Map::setStyleURL`, the prior style remains in effect until the asynchronous network request for the new style has completed. Previously, the map would have an empty style in the interim. This caused flashing and flickering which, if not fixed, would be especially noticeable with smart setStyle.
* The internal `Style` object held by `Map` has a lifetime coincident with the `Map` lifetime itself. This was the most straightforward implementation of the prior point, but I think it's also a reasonable change on the grounds that it eliminates corner cases from the API. Specifically:
   * A `Map` now actually _has_ an (empty) style from the get go. Previously, runtime styling APIs were explicitly no-ops or errors prior to a style being loaded.
  * `Map::setStyleURL`/`setStyleJSON` update the existing internal style object in place, rather than creating a new one. There isn't currently a `Map::getStyle` method, so this is unlikely to be an externally visible change. If we add `Map::setStyle(std::unique_ptr<Style>)`, it _will_ replace the existing style object, rather than updating it in place.

Fixes #7893.

TODO:

* [x] Enable `set-style-*` integration tests and make sure they pass