### PR TITLE
Remove mention of sprite atlas limitation from iOS points guide

### DIFF
--- a/platform/ios/docs/guides/Adding Points to a Map.md
+++ b/platform/ios/docs/guides/Adding Points to a Map.md
@@ -36,7 +36,6 @@ By default, annotations added to the map are displayed with a red pin ([example]
 
 * Annotation images are purely static and cannot be animated
 * No control over z-ordering
-* Limits to the number and size of images you can add
 
 ### Annotation Views (`MGLAnnotationView`)
 


### PR DESCRIPTION
The total size of the sprite sheet is no longer limited to the extent that it was before, now that #9213 has landed, fixing #3185. This change updates the guide that helps developers choose between the different annotation mechanisms, removing the sprite atlas limitation from the list of cons for MGLPointAnnotation. (In fact, this was also a limitation of the runtime styling approach, but we neglected to mention that.)

/cc @ericrwolfe @jfirebaugh