### PR TITLE
Add -Wno-error=misleading-indentation to CmakeLists.txt

### DIFF
--- a/src/mbgl/annotation/symbol_annotation_impl.hpp
+++ b/src/mbgl/annotation/symbol_annotation_impl.hpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmisleading-indentation"
 #pragma GCC diagnostic ignored "-Wunused-function"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wunused-variable"

--- a/src/mbgl/text/collision_tile.hpp
+++ b/src/mbgl/text/collision_tile.hpp
@@ -5,6 +5,7 @@
 #include <mbgl/tile/geometry_tile_data.hpp>
 
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmisleading-indentation"
 #pragma GCC diagnostic ignored "-Wunused-function"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wunused-variable"


### PR DESCRIPTION
  Misleading indentation errors in Boost are being treated as errors
  on GCC 7, which prevents the npm install from succeeding.

Resolves #9268