### PR TITLE
Update Activity test generation 

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/FillExtrusionActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/FillExtrusionActivity.java
@@ -26,6 +26,7 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionOpa
 public class FillExtrusionActivity extends AppCompatActivity {
 
   private MapView mapView;
+  private MapboxMap mapboxMap;
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
@@ -36,8 +37,8 @@ public class FillExtrusionActivity extends AppCompatActivity {
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(new OnMapReadyCallback() {
       @Override
-      public void onMapReady(@NonNull
-                             final MapboxMap map) {
+      public void onMapReady(@NonNull final MapboxMap map) {
+        mapboxMap = map;
         Polygon domTower = Polygon.fromCoordinates(new double[][][] {
           new double[][] {
             new double[] {
@@ -66,7 +67,7 @@ public class FillExtrusionActivity extends AppCompatActivity {
         GeoJsonSource source = new GeoJsonSource("extrusion-source", domTower);
         map.addSource(source);
 
-        map.addLayer(
+        mapboxMap.addLayer(
           new FillExtrusionLayer("extrusion-layer", source.getId())
             .withProperties(
               fillExtrusionHeight(40f),
@@ -75,7 +76,7 @@ public class FillExtrusionActivity extends AppCompatActivity {
             )
         );
 
-        map.animateCamera(
+        mapboxMap.animateCamera(
           CameraUpdateFactory.newCameraPosition(
             new CameraPosition.Builder()
               .target(new LatLng(52.09071040847704, 5.12112557888031))

--- a/platform/android/scripts/generate-test-code.js
+++ b/platform/android/scripts/generate-test-code.js
@@ -14,7 +14,7 @@ global.camelize = function (str) {
 }
 
 
-const excludeActivities = ["DeleteRegionActivity","RealTimeGeoJsonActivity","UpdateMetadataActivity","CarDrivingActivity","MyLocationTrackingModeActivity","MyLocationToggleActivity","MyLocationTintActivity","MyLocationDrawableActivity","DoubleMapActivity", "LocationPickerActivity","GeoJsonClusteringActivity","RuntimeStyleTestActivity", "AnimatedMarkerActivity", "ViewPagerActivity","MapFragmentActivity","SupportMapFragmentActivity","SnapshotActivity","NavigationDrawerActivity", "QueryRenderedFeaturesBoxHighlightActivity", "MultiMapActivity", "MapInDialogActivity", "SimpleMapActivity"];
+const excludeActivities = ["BaseLocationActivity","MockLocationEngine","DeleteRegionActivity","RealTimeGeoJsonActivity","UpdateMetadataActivity","CarDrivingActivity","MyLocationTrackingModeActivity","MyLocationToggleActivity","MyLocationTintActivity","MyLocationDrawableActivity","DoubleMapActivity", "LocationPickerActivity","GeoJsonClusteringActivity","RuntimeStyleTestActivity", "AnimatedMarkerActivity", "ViewPagerActivity","MapFragmentActivity","SupportMapFragmentActivity","SnapshotActivity","NavigationDrawerActivity", "QueryRenderedFeaturesBoxHighlightActivity", "MultiMapActivity", "MapInDialogActivity", "SimpleMapActivity"];
 const appBasePath = 'platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity';
 const testBasePath = 'platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/activity/gen';
 const subPackages = fs.readdirSync(appBasePath);


### PR DESCRIPTION
This PR fixes up test activity generation (see `platform/android/scripts/generate-test-code.js`).
 - exclude non testable classes
 - make FillExtrusionActivity conform to test activity setup