### PR TITLE
[android] Fix custom marker views anchor issue

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
@@ -10,6 +10,7 @@ import android.support.v4.util.LongSparseArray;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
 import android.widget.ImageView;
 
 import com.mapbox.mapboxsdk.R;
@@ -33,6 +34,15 @@ import java.util.Map;
 public class MarkerViewManager implements MapView.OnMapChangedListener {
 
   private final ViewGroup markerViewContainer;
+  private final ViewTreeObserver.OnPreDrawListener markerViewPreDrawObserver =
+    new ViewTreeObserver.OnPreDrawListener() {
+      @Override
+      public boolean onPreDraw() {
+        invalidateViewMarkersInVisibleRegion();
+        markerViewContainer.getViewTreeObserver().removeOnPreDrawListener(markerViewPreDrawObserver);
+        return false;
+      }
+    };
   private final Map<MarkerView, View> markerViewMap = new HashMap<>();
   private final LongSparseArray<OnMarkerViewAddedListener> markerViewAddedListenerMap = new LongSparseArray<>();
   private final List<MapboxMap.MarkerViewAdapter> markerViewAdapters = new ArrayList<>();
@@ -180,14 +190,16 @@ public class MarkerViewManager implements MapView.OnMapChangedListener {
         PointF point = mapboxMap.getProjection().toScreenLocation(marker.getPosition());
         if (marker.getOffsetX() == MapboxConstants.UNMEASURED) {
           // ensure view is measured first
+          // #6805 invalidate marker views to ensure convertView width and height
+          // values are properly measured and up to date
           if (marker.getWidth() == 0) {
-            convertView.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED);
-            if (convertView.getMeasuredWidth() != 0) {
-              marker.setWidth(convertView.getMeasuredWidth());
-              marker.setHeight(convertView.getMeasuredHeight());
-            }
+            convertView.getViewTreeObserver().addOnPreDrawListener(markerViewPreDrawObserver);
           }
         }
+
+        marker.setWidth(convertView.getWidth());
+        marker.setHeight(convertView.getHeight());
+
         if (marker.getWidth() != 0) {
           int x = (int) (marker.getAnchorU() * marker.getWidth());
           int y = (int) (marker.getAnchorV() * marker.getHeight());


### PR DESCRIPTION
Fixes #6805 and #8798

- Adds a marker view pre draw observer (`ViewTreeObserver.OnPreDrawListener`) which invalidates marker views to ensure `convertView` width and height values are properly measured and up to date when `updateMarkerViewsPosition`.

cc/ @tobrun 