### PR TITLE
[core] Fix composite function approximation for non-integer stops

### DIFF
--- a/src/mbgl/renderer/paint_property_binder.hpp
+++ b/src/mbgl/renderer/paint_property_binder.hpp
@@ -189,11 +189,11 @@ public:
     CompositeFunctionPaintPropertyBinder(style::CompositeFunction<T> function_, float zoom, T defaultValue_)
         : function(std::move(function_)),
           defaultValue(std::move(defaultValue_)),
-          coveringRanges(function.coveringRanges(zoom)) {
+          rangeOfCoveringRanges(function.rangeOfCoveringRanges({zoom, zoom + 1})) {
     }
 
     void populateVertexVector(const GeometryTileFeature& feature, std::size_t length) override {
-        Range<T> range = function.evaluate(std::get<1>(coveringRanges), feature, defaultValue);
+        Range<T> range = function.evaluate(rangeOfCoveringRanges, feature, defaultValue);
         this->statistics.add(range.min);
         this->statistics.add(range.max);
         AttributeValue value = zoomInterpolatedAttributeValue(
@@ -217,7 +217,7 @@ public:
     }
 
     float interpolationFactor(float currentZoom) const override {
-        return util::interpolationFactor(1.0f, std::get<0>(coveringRanges), currentZoom);
+        return util::interpolationFactor(1.0f, { rangeOfCoveringRanges.min.zoom, rangeOfCoveringRanges.max.zoom }, currentZoom);
     }
 
     T uniformValue(const PossiblyEvaluatedPropertyValue<T>& currentValue) const override {
@@ -230,10 +230,10 @@ public:
     }
 
 private:
-    using InnerStops = typename style::CompositeFunction<T>::InnerStops;
     style::CompositeFunction<T> function;
     T defaultValue;
-    std::tuple<Range<float>, Range<InnerStops>> coveringRanges;
+    using CoveringRanges = typename style::CompositeFunction<T>::CoveringRanges;
+    Range<CoveringRanges> rangeOfCoveringRanges;
     gl::VertexVector<Vertex> vertexVector;
     optional<gl::VertexBuffer<Vertex>> vertexBuffer;
 };

--- a/test/style/function/composite_function.test.cpp
+++ b/test/style/function/composite_function.test.cpp
@@ -44,3 +44,28 @@ TEST(CompositeFunction, ZoomInterpolation) {
     }), 0.0f)
     .evaluate(0.0f, oneInteger, -1.0f)) << "Should interpolate TO the first stop";
 }
+
+TEST(CompositeFunction, Issue8460) {
+    CompositeFunction<float> fn1("property", CompositeExponentialStops<float>({
+        {15.0f, {{uint64_t(1), 0.0f}}},
+        {15.2f, {{uint64_t(1), 600.0f}}},
+    }), 0.0f);
+
+    EXPECT_NEAR(  0.0f, fn1.evaluate(15.0f, oneInteger, -1.0f), 0.00);
+    EXPECT_NEAR(300.0f, fn1.evaluate(15.1f, oneInteger, -1.0f), 0.01);
+    EXPECT_NEAR(600.0f, fn1.evaluate(15.2f, oneInteger, -1.0f), 0.00);
+    EXPECT_NEAR(600.0f, fn1.evaluate(16.0f, oneInteger, -1.0f), 0.00);
+
+    CompositeFunction<float> fn2("property", CompositeExponentialStops<float>({
+        {15.0f, {{uint64_t(1), 0.0f}}},
+        {15.2f, {{uint64_t(1), 300.0f}}},
+        {18.0f, {{uint64_t(1), 600.0f}}},
+    }), 0.0f);
+
+    EXPECT_NEAR(  0.0f, fn2.evaluate(15.0f, oneInteger, -1.0f), 0.00);
+    EXPECT_NEAR(150.0f, fn2.evaluate(15.1f, oneInteger, -1.0f), 0.01);
+    EXPECT_NEAR(300.0f, fn2.evaluate(15.2f, oneInteger, -1.0f), 0.00);
+    EXPECT_NEAR(385.71f, fn2.evaluate(16.0f, oneInteger, -1.0f), 0.01);
+    EXPECT_NEAR(600.0f, fn2.evaluate(18.0f, oneInteger, -1.0f), 0.00);
+    EXPECT_NEAR(600.0f, fn2.evaluate(19.0f, oneInteger, -1.0f), 0.00);
+}


### PR DESCRIPTION
Fixes #8460 by effectively evaluating the composite function for a given feature at both z and z + 1.

The [added integration tests](https://github.com/mapbox/mapbox-gl-js/pull/4845) are the relevant ones. I added some C++ unit tests for completeness, but they use a form of evaluation that gave the expected results even before this change.