### PR TITLE
[core] generate uniforms for DataDrivenPaintProperty

### DIFF
--- a/scripts/generate-style-code.js
+++ b/scripts/generate-style-code.js
@@ -53,7 +53,7 @@ global.evaluatedType = function (property) {
   }
 };
 
-function attributeType(property, type) {
+function attributeUniformType(property, type) {
     const attributeNameExceptions = {
       'text-opacity': 'opacity',
       'icon-opacity': 'opacity',
@@ -64,11 +64,12 @@ function attributeType(property, type) {
       'text-halo-blur': 'halo_blur',
       'icon-halo-blur': 'halo_blur',
       'text-halo-width': 'halo_width',
-      'icon-halo-width': 'halo_width'
+      'icon-halo-width': 'halo_width',
+      'line-gap-width': 'gapwidth'
     }
     const name = attributeNameExceptions[property.name] ||
         property.name.replace(type + '-', '').replace(/-/g, '_');
-    return `attributes::a_${name}${name === 'offset' ? '<1>' : ''}`;
+    return `attributes::a_${name}${name === 'offset' ? '<1>' : ''}, uniforms::u_${name}`;
 }
 
 global.layoutPropertyType = function (property) {
@@ -81,7 +82,7 @@ global.layoutPropertyType = function (property) {
 
 global.paintPropertyType = function (property, type) {
   if (isDataDriven(property)) {
-    return `DataDrivenPaintProperty<${evaluatedType(property)}, ${attributeType(property, type)}>`;
+    return `DataDrivenPaintProperty<${evaluatedType(property)}, ${attributeUniformType(property, type)}>`;
   } else if (/-pattern$/.test(property.name) || property.name === 'line-dasharray') {
     return `CrossFadedPaintProperty<${evaluatedType(property)}>`;
   } else {

--- a/src/mbgl/style/layers/background_layer_properties.hpp
+++ b/src/mbgl/style/layers/background_layer_properties.hpp
@@ -7,6 +7,7 @@
 #include <mbgl/style/paint_property.hpp>
 #include <mbgl/style/properties.hpp>
 #include <mbgl/programs/attributes.hpp>
+#include <mbgl/programs/uniforms.hpp>
 
 namespace mbgl {
 namespace style {

--- a/src/mbgl/style/layers/layer_properties.hpp.ejs
+++ b/src/mbgl/style/layers/layer_properties.hpp.ejs
@@ -12,6 +12,7 @@
 #include <mbgl/style/paint_property.hpp>
 #include <mbgl/style/properties.hpp>
 #include <mbgl/programs/attributes.hpp>
+#include <mbgl/programs/uniforms.hpp>
 
 namespace mbgl {
 namespace style {

--- a/src/mbgl/style/layers/raster_layer_properties.hpp
+++ b/src/mbgl/style/layers/raster_layer_properties.hpp
@@ -7,6 +7,7 @@
 #include <mbgl/style/paint_property.hpp>
 #include <mbgl/style/properties.hpp>
 #include <mbgl/programs/attributes.hpp>
+#include <mbgl/programs/uniforms.hpp>
 
 namespace mbgl {
 namespace style {


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gl-native/commit/2c6fcd9f44ff93593a3f21c9f993a1eb4b299bb4 did not add uniform generation to `generate-style-code.js`, causing `make style-code` to generate incorrect properties files.