### PR TITLE
[core] Trigger repaint on source changes

### DIFF
--- a/src/mbgl/style/sources/geojson_source.cpp
+++ b/src/mbgl/style/sources/geojson_source.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/style/sources/geojson_source.hpp>
 #include <mbgl/style/sources/geojson_source_impl.hpp>
+#include <mbgl/style/source_observer.hpp>
 
 namespace mbgl {
 namespace style {
@@ -16,6 +17,7 @@ void GeoJSONSource::setURL(const std::string& url) {
 
 void GeoJSONSource::setGeoJSON(const mapbox::geojson::geojson& geoJSON) {
     impl->setGeoJSON(geoJSON);
+    impl->observer->onSourceChanged(*this);
 }
 
 optional<std::string> GeoJSONSource::getURL() const {

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -725,6 +725,7 @@ void Style::onSourceLoaded(Source& source) {
 
 void Style::onSourceChanged(Source& source) {
     observer->onSourceChanged(source);
+    observer->onUpdate(Update::Repaint);
 }
 
 void Style::onSourceError(Source& source, std::exception_ptr error) {


### PR DESCRIPTION
Cherry-picks a33cad98557f2d15bfb578e4795b130d25a2def2 to the release branch. Fixes #9229.

I wrote (and on the master branch, will merge) an integration test for this, but it already passes because `Update::Repaint` is triggered for other reasons. @boundsj, can you please manually confirm the fix on iOS?