### PR TITLE
[android] Annotate Mapbox class with @UiThread

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
@@ -24,6 +24,7 @@ import com.mapbox.services.android.telemetry.location.LocationEnginePriority;
  * connectivity state.
  * </p>
  */
+@UiThread
 public final class Mapbox {
 
   private static Mapbox INSTANCE;


### PR DESCRIPTION
Per https://github.com/mapbox/mapbox-gl-native/issues/7660#issuecomment-295353101

- Annotates Mapbox class with @UiThread to make clear that it's required to be started from the main thread as it loads the native library for connectivity change events

cc/ @tobrun 