### PR TITLE
Update MAS version to 2.1.2

### DIFF
--- a/platform/android/dependencies.gradle
+++ b/platform/android/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
     versionCode = 11
     versionName = "5.0.0"
 
-    mapboxServicesVersion = "2.1.1"
+    mapboxServicesVersion = "2.1.2"
     supportLibVersion = "25.3.1"
     wearableVersion = '2.0.0'
     espressoVersion = '2.2.2'


### PR DESCRIPTION
Today we released MAS v2.1.2 https://github.com/mapbox/mapbox-java/issues/487, this fixes https://github.com/mapbox/mapbox-gl-native/issues/9288.