### PR TITLE
[core][ios][macos][android] Improve ImageSource performance

### DIFF
--- a/include/mbgl/style/sources/image_source.hpp
+++ b/include/mbgl/style/sources/image_source.hpp
@@ -18,7 +18,7 @@ public:
     optional<std::string> getURL() const;
     void setURL(const std::string& url);
 
-    void setImage(UnassociatedImage&&);
+    void setImage(PremultipliedImage&&);
 
     void setCoordinates(const std::array<LatLng, 4>&);
     std::array<LatLng, 4> getCoordinates() const;

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/AnimatedImageSourceActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/AnimatedImageSourceActivity.java
@@ -1,10 +1,16 @@
 package com.mapbox.mapboxsdk.testapp.activity.style;
 
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 
+import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.geometry.LatLngQuad;
 import com.mapbox.mapboxsdk.maps.MapView;
@@ -106,17 +112,27 @@ public class AnimatedImageSourceActivity extends AppCompatActivity implements On
 
     private MapboxMap mapboxMap;
     private Handler handler;
-    private int[] drawables;
+    private Bitmap[] drawables;
     private int drawableIndex;
+
+    Bitmap getBitmap(int resourceId) {
+      Context context = Mapbox.getApplicationContext();
+      Drawable drawable = ContextCompat.getDrawable(context, resourceId);
+      if (drawable instanceof BitmapDrawable) {
+        BitmapDrawable bitmapDrawable = (BitmapDrawable) drawable;
+        return bitmapDrawable.getBitmap();
+      }
+      return null;
+    }
 
     RefreshImageRunnable(MapboxMap mapboxMap, Handler handler) {
       this.mapboxMap = mapboxMap;
       this.handler = handler;
-      drawables = new int[4];
-      drawables[0] = R.drawable.southeast_radar_0;
-      drawables[1] = R.drawable.southeast_radar_1;
-      drawables[2] = R.drawable.southeast_radar_2;
-      drawables[3] = R.drawable.southeast_radar_3;
+      drawables = new Bitmap[4];
+      drawables[0] = getBitmap(R.drawable.southeast_radar_0);
+      drawables[1] = getBitmap(R.drawable.southeast_radar_1);
+      drawables[2] = getBitmap(R.drawable.southeast_radar_2);
+      drawables[3] = getBitmap(R.drawable.southeast_radar_3);
       drawableIndex = 1;
     }
 

--- a/platform/android/src/style/sources/image_source.cpp
+++ b/platform/android/src/style/sources/image_source.cpp
@@ -40,8 +40,7 @@ namespace android {
     }
 
     void ImageSource::setImage(jni::JNIEnv& env, jni::Object<Bitmap> bitmap) {
-        UnassociatedImage image = util::unpremultiply(Bitmap::GetImage(env, bitmap));
-        source.as<mbgl::style::ImageSource>()->setImage(std:: move(image));
+        source.as<mbgl::style::ImageSource>()->setImage(Bitmap::GetImage(env, bitmap));
     }
 
     jni::Class<ImageSource> ImageSource::javaClass;

--- a/platform/darwin/src/MGLImageSource.mm
+++ b/platform/darwin/src/MGLImageSource.mm
@@ -60,10 +60,9 @@
 
 - (void)setImage:(MGLImage *)image {
     if (image != nullptr) {
-        mbgl::UnassociatedImage unassociatedImage = mbgl::util::unpremultiply(image.mgl_premultipliedImage);
-        self.rawSource->setImage(std::move(unassociatedImage));
+        self.rawSource->setImage(image.mgl_premultipliedImage);
     } else {
-        self.rawSource->setImage(mbgl::UnassociatedImage({0,0}));
+        self.rawSource->setImage(mbgl::PremultipliedImage({0,0}));
     }
     _image = image;
 }

--- a/platform/macos/src/NSImage+MGLAdditions.mm
+++ b/platform/macos/src/NSImage+MGLAdditions.mm
@@ -42,15 +42,8 @@
 }
 
 - (mbgl::PremultipliedImage)mgl_premultipliedImage {
-    // Create a bitmap image representation from the image, respecting backing
-    // scale factor and any resizing done on the image at runtime.
-    // http://www.cocoabuilder.com/archive/cocoa/82430-nsimage-getting-raw-bitmap-data.html#82431
-    [self lockFocus];
-    NSBitmapImageRep *rep = [[NSBitmapImageRep alloc] initWithFocusedViewRect:{ NSZeroPoint, self.size }];
-    [self unlockFocus];
-
-    mbgl::PremultipliedImage cPremultipliedImage({ static_cast<uint32_t>(rep.pixelsWide), static_cast<uint32_t>(rep.pixelsHigh) });
-    std::copy(rep.bitmapData, rep.bitmapData + cPremultipliedImage.bytes(), cPremultipliedImage.data.get());
-    return cPremultipliedImage;
+    CGImageRef ref = [self CGImageForProposedRect:nullptr context:nullptr hints:nullptr];
+    return MGLPremultipliedImageFromCGImage(ref);
 }
+
 @end

--- a/src/mbgl/renderer/buckets/raster_bucket.cpp
+++ b/src/mbgl/renderer/buckets/raster_bucket.cpp
@@ -9,12 +9,19 @@ namespace mbgl {
 
 using namespace style;
 
-RasterBucket::RasterBucket(UnassociatedImage&& image_) : image(std::move(image_)) {
+RasterBucket::RasterBucket(UnassociatedImage&& image_) {
+    image = std::make_shared<UnassociatedImage>(std::move(image_));
 }
 
+RasterBucket::RasterBucket(std::shared_ptr<UnassociatedImage> image_): image(image_) {
+
+}
 void RasterBucket::upload(gl::Context& context) {
+    if (!hasData()) {
+        return;
+    }
     if (!texture) {
-        texture = context.createTexture(image);
+        texture = context.createTexture(*image);
     }
     if (!vertices.empty()) {
         vertexBuffer = context.createVertexBuffer(std::move(vertices));
@@ -32,6 +39,12 @@ void RasterBucket::clear() {
 
     uploaded = false;
 }
+
+void RasterBucket::setImage(std::shared_ptr<UnassociatedImage> image_) {
+    image = std::move(image_);
+    texture = {};
+    uploaded = false;
+}
 void RasterBucket::render(Painter& painter,
                           PaintParameters& parameters,
                           const RenderLayer& layer,
@@ -47,7 +60,7 @@ void RasterBucket::render(Painter& painter,
 }
 
 bool RasterBucket::hasData() const {
-    return true;
+    return !!image;
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/buckets/raster_bucket.cpp
+++ b/src/mbgl/renderer/buckets/raster_bucket.cpp
@@ -9,11 +9,11 @@ namespace mbgl {
 
 using namespace style;
 
-RasterBucket::RasterBucket(UnassociatedImage&& image_) {
-    image = std::make_shared<UnassociatedImage>(std::move(image_));
+RasterBucket::RasterBucket(PremultipliedImage&& image_) {
+    image = std::make_shared<PremultipliedImage>(std::move(image_));
 }
 
-RasterBucket::RasterBucket(std::shared_ptr<UnassociatedImage> image_): image(image_) {
+RasterBucket::RasterBucket(std::shared_ptr<PremultipliedImage> image_): image(image_) {
 
 }
 void RasterBucket::upload(gl::Context& context) {
@@ -40,7 +40,7 @@ void RasterBucket::clear() {
     uploaded = false;
 }
 
-void RasterBucket::setImage(std::shared_ptr<UnassociatedImage> image_) {
+void RasterBucket::setImage(std::shared_ptr<PremultipliedImage> image_) {
     image = std::move(image_);
     texture = {};
     uploaded = false;

--- a/src/mbgl/renderer/buckets/raster_bucket.hpp
+++ b/src/mbgl/renderer/buckets/raster_bucket.hpp
@@ -13,8 +13,8 @@ namespace mbgl {
 
 class RasterBucket : public Bucket {
 public:
-    RasterBucket(UnassociatedImage&&);
-    RasterBucket(std::shared_ptr<UnassociatedImage>);
+    RasterBucket(PremultipliedImage&&);
+    RasterBucket(std::shared_ptr<PremultipliedImage>);
     void upload(gl::Context&) override;
     void render(Painter&, PaintParameters&, const RenderLayer&, const RenderTile&) override;
     void render(Painter& painter,
@@ -24,8 +24,8 @@ public:
     bool hasData() const override;
 
     void clear();
-    void setImage(std::shared_ptr<UnassociatedImage>);
-    std::shared_ptr<UnassociatedImage> image;
+    void setImage(std::shared_ptr<PremultipliedImage>);
+    std::shared_ptr<PremultipliedImage> image;
     optional<gl::Texture> texture;
 
     // Bucket specific vertices are used for Image Sources only

--- a/src/mbgl/renderer/buckets/raster_bucket.hpp
+++ b/src/mbgl/renderer/buckets/raster_bucket.hpp
@@ -14,7 +14,7 @@ namespace mbgl {
 class RasterBucket : public Bucket {
 public:
     RasterBucket(UnassociatedImage&&);
-
+    RasterBucket(std::shared_ptr<UnassociatedImage>);
     void upload(gl::Context&) override;
     void render(Painter&, PaintParameters&, const RenderLayer&, const RenderTile&) override;
     void render(Painter& painter,
@@ -24,7 +24,8 @@ public:
     bool hasData() const override;
 
     void clear();
-    UnassociatedImage image;
+    void setImage(std::shared_ptr<UnassociatedImage>);
+    std::shared_ptr<UnassociatedImage> image;
     optional<gl::Texture> texture;
 
     // Bucket specific vertices are used for Image Sources only

--- a/src/mbgl/renderer/sources/render_image_source.cpp
+++ b/src/mbgl/renderer/sources/render_image_source.cpp
@@ -14,7 +14,7 @@ namespace mbgl {
 using namespace style;
 
 RenderImageSource::RenderImageSource(Immutable<style::ImageSource::Impl> impl_)
-    : RenderSource(impl_), shouldRender(false) {
+    : RenderSource(impl_) {
 }
 
 RenderImageSource::~RenderImageSource() = default;
@@ -42,13 +42,13 @@ void RenderImageSource::startRender(Painter& painter) {
         matrices.push_back(matrix);
     }
 
-    if (bucket->needsUpload() && shouldRender) {
+    if (bucket->needsUpload()) {
         bucket->upload(painter.context);
     }
 }
 
 void RenderImageSource::finishRender(Painter& painter) {
-    if (!isLoaded() || !shouldRender) {
+    if (!isLoaded()) {
         return;
     }
     for (auto matrix : matrices) {
@@ -73,15 +73,24 @@ void RenderImageSource::update(Immutable<style::Source::Impl> baseImpl_,
                                const bool needsRendering,
                                const bool,
                                const TileParameters& parameters) {
-    std::swap(baseImpl, baseImpl_);
-
     enabled = needsRendering;
+    if (!needsRendering) {
+        return;
+    }
 
     auto transformState = parameters.transformState;
-    auto size = transformState.getSize();
-    double viewportHeight = size.height;
+    std::swap(baseImpl, baseImpl_);
 
     auto coords = impl().getCoordinates();
+    std::shared_ptr<UnassociatedImage> image = impl().getImage();
+
+    if (!image || !image->valid()) {
+        enabled = false;
+        return;
+    }
+
+    auto size = transformState.getSize();
+    const double viewportHeight = size.height;
 
     // Compute the screen coordinates at wrap=0 for the given LatLng
     ScreenCoordinate nePixel = { -INFINITY, -INFINITY };
@@ -94,38 +103,51 @@ void RenderImageSource::update(Immutable<style::Source::Impl> baseImpl_,
         swPixel.y = std::min(swPixel.y, viewportHeight - pixel.y);
         nePixel.y = std::max(nePixel.y, viewportHeight - pixel.y);
     }
-    double width = nePixel.x - swPixel.x;
-    double height = nePixel.y - swPixel.y;
+    const double width = nePixel.x - swPixel.x;
+    const double height = nePixel.y - swPixel.y;
 
     // Don't bother drawing the ImageSource unless it occupies >4 screen pixels
-    shouldRender = (width * height > 4);
-    if (!shouldRender) {
+    enabled = (width * height > 4);
+    if (!enabled) {
         return;
     }
 
     // Calculate the optimum zoom level to determine the tile ids to use for transforms
     double minScale = INFINITY;
-    if (width > 0 || height > 0) {
-        double scaleX = double(size.width) / width;
-        double scaleY = double(size.height) / height;
-        minScale = util::min(scaleX, scaleY);
-    }
+    double scaleX = double(size.width) / width;
+    double scaleY = double(size.height) / height;
+    minScale = util::min(scaleX, scaleY);
     double zoom = transformState.getZoom() + util::log2(minScale);
-    zoom = util::clamp(zoom, transformState.getMinZoom(), transformState.getMaxZoom());
-
+    zoom = std::floor(util::clamp(zoom, transformState.getMinZoom(), transformState.getMaxZoom()));
     auto imageBounds = LatLngBounds::hull(coords[0], coords[1]);
     imageBounds.extend(coords[2]);
     imageBounds.extend(coords[3]);
-    auto tileCover = util::tileCover(imageBounds, ::floor(zoom));
+    auto tileCover = util::tileCover(imageBounds, zoom);
     tileIds.clear();
     tileIds.push_back(tileCover[0]);
+    bool hasVisibleTile = false;
 
     // Add additional wrapped tile ids if neccessary
     auto idealTiles = util::tileCover(transformState, transformState.getZoom());
     for (auto tile : idealTiles) {
         if (tile.wrap != 0 && tileCover[0].canonical.isChildOf(tile.canonical)) {
             tileIds.push_back({ tile.wrap, tileCover[0].canonical });
+            hasVisibleTile = true;
         }
+        else if (!hasVisibleTile) {
+            for (auto coveringTile: tileCover) {
+                if(coveringTile.canonical == tile.canonical ||
+                    coveringTile.canonical.isChildOf(tile.canonical) ||
+                    tile.canonical.isChildOf(coveringTile.canonical)) {
+                    hasVisibleTile = true;
+                }
+            }
+        }
+    }
+
+    enabled = hasVisibleTile;
+    if (!enabled) {
+        return;
     }
 
     // Calculate Geometry Coordinates based on tile cover at ideal zoom
@@ -135,16 +157,13 @@ void RenderImageSource::update(Immutable<style::Source::Impl> baseImpl_,
         auto gc = TileCoordinate::toGeometryCoordinate(tileIds[0], tc.p);
         geomCoords.push_back(gc);
     }
-    
-    const UnassociatedImage& image = impl().getImage();
-    if (!image.valid()) {
-        return;
-    }
-    
-    if (!bucket || image != bucket->image) {
-        bucket = std::make_unique<RasterBucket>(image.clone());
+    if (!bucket) {
+        bucket = std::make_unique<RasterBucket>(image);
     } else {
         bucket->clear();
+        if (image != bucket->image) {
+            bucket->setImage(image);
+        }
     }
 
     // Set Bucket Vertices, Indices, and segments
@@ -166,7 +185,7 @@ void RenderImageSource::update(Immutable<style::Source::Impl> baseImpl_,
 void RenderImageSource::render(Painter& painter,
                                PaintParameters& parameters,
                                const RenderLayer& layer) {
-    if (isLoaded() && !bucket->needsUpload() && shouldRender) {
+    if (isEnabled() && isLoaded() && !bucket->needsUpload()) {
         for (auto matrix : matrices) {
             bucket->render(painter, parameters, layer, matrix);
         }

--- a/src/mbgl/renderer/sources/render_image_source.cpp
+++ b/src/mbgl/renderer/sources/render_image_source.cpp
@@ -82,7 +82,7 @@ void RenderImageSource::update(Immutable<style::Source::Impl> baseImpl_,
     std::swap(baseImpl, baseImpl_);
 
     auto coords = impl().getCoordinates();
-    std::shared_ptr<UnassociatedImage> image = impl().getImage();
+    std::shared_ptr<PremultipliedImage> image = impl().getImage();
 
     if (!image || !image->valid()) {
         enabled = false;

--- a/src/mbgl/renderer/sources/render_image_source.hpp
+++ b/src/mbgl/renderer/sources/render_image_source.hpp
@@ -8,6 +8,7 @@ namespace mbgl {
 class RenderLayer;
 class PaintParameters;
 class RasterBucket;
+class LatLng;
 
 namespace gl {
 class Context;
@@ -52,7 +53,6 @@ private:
     std::vector<UnwrappedTileID> tileIds;
     std::unique_ptr<RasterBucket> bucket;
     std::vector<mat4> matrices;
-    bool shouldRender;
 };
 
 template <>

--- a/src/mbgl/shaders/raster.cpp
+++ b/src/mbgl/shaders/raster.cpp
@@ -45,6 +45,12 @@ void main() {
     // read and cross-fade colors from the main and parent tiles
     vec4 color0 = texture2D(u_image0, v_pos0);
     vec4 color1 = texture2D(u_image1, v_pos1);
+    if (color0.a > 0.0) {
+        color0.rgb = color0.rgb / color0.a;
+    }
+    if (color1.a > 0.0) {
+        color1.rgb = color1.rgb / color1.a;
+    }
     vec4 color = mix(color0, color1, u_fade_t);
     color.a *= u_opacity;
     vec3 rgb = color.rgb;

--- a/src/mbgl/style/sources/image_source.cpp
+++ b/src/mbgl/style/sources/image_source.cpp
@@ -37,7 +37,7 @@ void ImageSource::setURL(const std::string& url_) {
     }
 }
 
-void ImageSource::setImage(UnassociatedImage&& image_) {
+void ImageSource::setImage(PremultipliedImage&& image_) {
     url = {};
     if (req) {
         req.reset();
@@ -70,8 +70,7 @@ void ImageSource::loadDescription(FileSource& fileSource) {
             observer->onSourceError(*this, std::make_exception_ptr(std::runtime_error("unexpectedly empty image url")));
         } else {
             try {
-                UnassociatedImage image = util::unpremultiply(decodeImage(*res.data));
-                baseImpl = makeMutable<Impl>(impl(), std::move(image));
+                baseImpl = makeMutable<Impl>(impl(), decodeImage(*res.data));
             } catch (...) {
                 observer->onSourceError(*this, std::current_exception());
             }

--- a/src/mbgl/style/sources/image_source_impl.cpp
+++ b/src/mbgl/style/sources/image_source_impl.cpp
@@ -12,17 +12,17 @@ ImageSource::Impl::Impl(std::string id_, std::array<LatLng, 4> coords_)
 ImageSource::Impl::Impl(const Impl& other, std::array<LatLng, 4> coords_)
     : Source::Impl(other),
     coords(std::move(coords_)),
-    image(other.image.clone()) {
+    image(other.image) {
 }
 
-ImageSource::Impl::Impl(const Impl& rhs, UnassociatedImage image_)
+ImageSource::Impl::Impl(const Impl& rhs, UnassociatedImage&& image_)
     : Source::Impl(rhs),
     coords(rhs.coords),
-    image(std::move(image_)) {
+    image(std::make_shared<UnassociatedImage>(std::move(image_))) {
 }
 ImageSource::Impl::~Impl() = default;
 
-const UnassociatedImage& ImageSource::Impl::getImage() const {
+std::shared_ptr<UnassociatedImage> ImageSource::Impl::getImage() const {
     return image;
 }
 

--- a/src/mbgl/style/sources/image_source_impl.cpp
+++ b/src/mbgl/style/sources/image_source_impl.cpp
@@ -15,14 +15,14 @@ ImageSource::Impl::Impl(const Impl& other, std::array<LatLng, 4> coords_)
     image(other.image) {
 }
 
-ImageSource::Impl::Impl(const Impl& rhs, UnassociatedImage&& image_)
+ImageSource::Impl::Impl(const Impl& rhs, PremultipliedImage&& image_)
     : Source::Impl(rhs),
     coords(rhs.coords),
-    image(std::make_shared<UnassociatedImage>(std::move(image_))) {
+    image(std::make_shared<PremultipliedImage>(std::move(image_))) {
 }
 ImageSource::Impl::~Impl() = default;
 
-std::shared_ptr<UnassociatedImage> ImageSource::Impl::getImage() const {
+std::shared_ptr<PremultipliedImage> ImageSource::Impl::getImage() const {
     return image;
 }
 

--- a/src/mbgl/style/sources/image_source_impl.hpp
+++ b/src/mbgl/style/sources/image_source_impl.hpp
@@ -13,17 +13,17 @@ class ImageSource::Impl : public Source::Impl {
 public:
     Impl(std::string id, std::array<LatLng, 4> coords);
     Impl(const Impl& rhs, std::array<LatLng, 4> coords);
-    Impl(const Impl& rhs, UnassociatedImage&& image);
+    Impl(const Impl& rhs, PremultipliedImage&& image);
 
     ~Impl() final;
 
-    std::shared_ptr<UnassociatedImage> getImage() const;
+    std::shared_ptr<PremultipliedImage> getImage() const;
     std::array<LatLng, 4> getCoordinates() const;
 
     optional<std::string> getAttribution() const final;
 private:
     std::array<LatLng, 4> coords;
-    std::shared_ptr<UnassociatedImage> image;
+    std::shared_ptr<PremultipliedImage> image;
 };
 
 } // namespace style

--- a/src/mbgl/style/sources/image_source_impl.hpp
+++ b/src/mbgl/style/sources/image_source_impl.hpp
@@ -13,17 +13,17 @@ class ImageSource::Impl : public Source::Impl {
 public:
     Impl(std::string id, std::array<LatLng, 4> coords);
     Impl(const Impl& rhs, std::array<LatLng, 4> coords);
-    Impl(const Impl& rhs, UnassociatedImage image);
+    Impl(const Impl& rhs, UnassociatedImage&& image);
 
     ~Impl() final;
 
-    const UnassociatedImage& getImage() const;
+    std::shared_ptr<UnassociatedImage> getImage() const;
     std::array<LatLng, 4> getCoordinates() const;
 
     optional<std::string> getAttribution() const final;
 private:
     std::array<LatLng, 4> coords;
-    UnassociatedImage image;
+    std::shared_ptr<UnassociatedImage> image;
 };
 
 } // namespace style

--- a/src/mbgl/tile/raster_tile_worker.cpp
+++ b/src/mbgl/tile/raster_tile_worker.cpp
@@ -17,7 +17,7 @@ void RasterTileWorker::parse(std::shared_ptr<const std::string> data) {
     }
 
     try {
-        auto bucket = std::make_unique<RasterBucket>(util::unpremultiply(decodeImage(*data)));
+        auto bucket = std::make_unique<RasterBucket>(decodeImage(*data));
         parent.invoke(&RasterTile::onParsed, std::move(bucket));
     } catch (...) {
         parent.invoke(&RasterTile::onError, std::current_exception());

--- a/test/gl/bucket.test.cpp
+++ b/test/gl/bucket.test.cpp
@@ -101,7 +101,7 @@ TEST(Buckets, SymbolBucket) {
 
 TEST(Buckets, RasterBucket) {
     gl::Context context;
-    UnassociatedImage rgba({ 1, 1 });
+    PremultipliedImage rgba({ 1, 1 });
 
     // RasterBucket::hasData() is always true.
     RasterBucket bucket = { std::move(rgba) };

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -531,7 +531,7 @@ TEST(Source, ImageSourceImageUpdate) {
 
     // Load initial, so the source state will be loaded=true
     source.loadDescription(test.fileSource);
-    UnassociatedImage rgba({ 1, 1 });
+    PremultipliedImage rgba({ 1, 1 });
     rgba.data[0] = 255;
     rgba.data[1] = 254;
     rgba.data[2] = 253;

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -535,7 +535,7 @@ TEST(Source, ImageSourceImageUpdate) {
     rgba.data[0] = 255;
     rgba.data[1] = 254;
     rgba.data[2] = 253;
-    rgba.data[3] = 128;
+    rgba.data[3] = 0;
 
     // Schedule an update
     test.loop.invoke([&] () {

--- a/test/tile/raster_tile.test.cpp
+++ b/test/tile/raster_tile.test.cpp
@@ -60,7 +60,7 @@ TEST(RasterTile, onError) {
 TEST(RasterTile, onParsed) {
     RasterTileTest test;
     RasterTile tile(OverscaledTileID(0, 0, 0), test.tileParameters, test.tileset);
-    tile.onParsed(std::make_unique<RasterBucket>(UnassociatedImage{}));
+    tile.onParsed(std::make_unique<RasterBucket>(PremultipliedImage{}));
     EXPECT_TRUE(tile.isRenderable());
     EXPECT_TRUE(tile.isLoaded());
     EXPECT_TRUE(tile.isComplete());


### PR DESCRIPTION
`ImageSource`'s runtime APIs are performing very poorly primarily due to poor management of image data. In addition, there are bottlenecks in the SDKs related to decoding the image data.

This addresses: #9304, #9070

### Remaining Tasks
- [x] Use shared_ptr for image 
- [x]	Speed up decode/decompression for iOS
- [x] Speed up decode/decompression for Android (cache bitmaps in test app)
- [x] Use pre-multiplied image. Reduce conversion
- [x] Skip rendering when not visible

### Future consideration
- PremultipliedImage/UnassociatedImage: Add support for different backing storage (#9333)
- Allow `ImageSource` to use `style::image`

/cc @kkaefer @ansis 