### PR TITLE
Restore LatLngBounds conversion, add regression test

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/geometry/LatLngBoundsTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/geometry/LatLngBoundsTest.java
@@ -1,0 +1,40 @@
+package com.mapbox.mapboxsdk.testapp.geometry;
+
+import android.support.test.espresso.UiController;
+
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.geometry.LatLngBounds;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.testapp.action.MapboxMapAction;
+import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
+import com.mapbox.mapboxsdk.testapp.activity.feature.QueryRenderedFeaturesBoxHighlightActivity;
+
+import org.junit.Test;
+
+/**
+ * Instrumentation test to validate integration of LatLngBounds
+ */
+public class LatLngBoundsTest extends BaseActivityTest {
+
+  @Override
+  protected Class getActivityClass() {
+    return QueryRenderedFeaturesBoxHighlightActivity.class;
+  }
+
+  @Test
+  public void testLatLngBounds() {
+    // regression test for #9322
+    validateTestSetup();
+    MapboxMapAction.invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
+      @Override
+      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
+        LatLngBounds bounds = new LatLngBounds.Builder()
+          .include(new LatLng(48.8589506, 2.2773457))
+          .include(new LatLng(47.2383171, -1.6309316))
+          .build();
+        mapboxMap.moveCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0));
+      }
+    });
+  }
+}

--- a/platform/android/src/geometry/lat_lng_bounds.cpp
+++ b/platform/android/src/geometry/lat_lng_bounds.cpp
@@ -9,10 +9,10 @@ jni::Object<LatLngBounds> LatLngBounds::New(jni::JNIEnv& env, mbgl::LatLngBounds
 }
 
 mbgl::LatLngBounds LatLngBounds::getLatLngBounds(jni::JNIEnv& env, jni::Object<LatLngBounds> bounds) {
-    static auto swLat = LatLngBounds::javaClass.GetField<jni::jdouble>(env, "mLatSouth");
-    static auto swLon = LatLngBounds::javaClass.GetField<jni::jdouble>(env, "mLonWest");
-    static auto neLat = LatLngBounds::javaClass.GetField<jni::jdouble>(env, "mLatNorth");
-    static auto neLon = LatLngBounds::javaClass.GetField<jni::jdouble>(env, "mLonEast");
+    static auto swLat = LatLngBounds::javaClass.GetField<jni::jdouble>(env, "latitudeSouth");
+    static auto swLon = LatLngBounds::javaClass.GetField<jni::jdouble>(env, "longitudeWest");
+    static auto neLat = LatLngBounds::javaClass.GetField<jni::jdouble>(env, "latitudeNorth");
+    static auto neLon = LatLngBounds::javaClass.GetField<jni::jdouble>(env, "longitudeEast");
     return mbgl::LatLngBounds::hull(
         { bounds.Get(env, swLat), bounds.Get(env, swLon) },
         { bounds.Get(env, neLat), bounds.Get(env, neLon) }


### PR DESCRIPTION
Closes #9322, PR fixes LatLngBounds conversion from java to c++.
This went unnoticed as the crash only shows at runtime due to reflection. 
To future prove this conversion, I added a regression test.