### PR TITLE
[core] Don't transition new layers on a setStyle operation

### DIFF
--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -5,7 +5,8 @@
 namespace mbgl {
 
 RenderBackgroundLayer::RenderBackgroundLayer(Immutable<style::BackgroundLayer::Impl> _impl)
-    : RenderLayer(style::LayerType::Background, _impl) {
+    : RenderLayer(style::LayerType::Background, _impl),
+      unevaluated(impl().paint.untransitioned()) {
 }
 
 const style::BackgroundLayer::Impl& RenderBackgroundLayer::impl() const {
@@ -19,7 +20,7 @@ std::unique_ptr<Bucket> RenderBackgroundLayer::createBucket(const BucketParamete
 }
 
 void RenderBackgroundLayer::transition(const TransitionParameters &parameters) {
-    unevaluated = impl().paint.transition(parameters, std::move(unevaluated));
+    unevaluated = impl().paint.transitioned(parameters, std::move(unevaluated));
 }
 
 void RenderBackgroundLayer::evaluate(const PropertyEvaluationParameters &parameters) {

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -8,7 +8,8 @@
 namespace mbgl {
 
 RenderCircleLayer::RenderCircleLayer(Immutable<style::CircleLayer::Impl> _impl)
-    : RenderLayer(style::LayerType::Circle, _impl) {
+    : RenderLayer(style::LayerType::Circle, _impl),
+      unevaluated(impl().paint.untransitioned()) {
 }
 
 const style::CircleLayer::Impl& RenderCircleLayer::impl() const {
@@ -20,7 +21,7 @@ std::unique_ptr<Bucket> RenderCircleLayer::createBucket(const BucketParameters& 
 }
 
 void RenderCircleLayer::transition(const TransitionParameters& parameters) {
-    unevaluated = impl().paint.transition(parameters, std::move(unevaluated));
+    unevaluated = impl().paint.transitioned(parameters, std::move(unevaluated));
 }
 
 void RenderCircleLayer::evaluate(const PropertyEvaluationParameters& parameters) {

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -8,7 +8,8 @@
 namespace mbgl {
 
 RenderFillExtrusionLayer::RenderFillExtrusionLayer(Immutable<style::FillExtrusionLayer::Impl> _impl)
-    : RenderLayer(style::LayerType::FillExtrusion, _impl) {
+    : RenderLayer(style::LayerType::FillExtrusion, _impl),
+      unevaluated(impl().paint.untransitioned()) {
 }
 
 const style::FillExtrusionLayer::Impl& RenderFillExtrusionLayer::impl() const {
@@ -20,7 +21,7 @@ std::unique_ptr<Bucket> RenderFillExtrusionLayer::createBucket(const BucketParam
 }
 
 void RenderFillExtrusionLayer::transition(const TransitionParameters& parameters) {
-    unevaluated = impl().paint.transition(parameters, std::move(unevaluated));
+    unevaluated = impl().paint.transitioned(parameters, std::move(unevaluated));
 }
 
 void RenderFillExtrusionLayer::evaluate(const PropertyEvaluationParameters& parameters) {

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -8,7 +8,8 @@
 namespace mbgl {
 
 RenderFillLayer::RenderFillLayer(Immutable<style::FillLayer::Impl> _impl)
-    : RenderLayer(style::LayerType::Fill, _impl) {
+    : RenderLayer(style::LayerType::Fill, _impl),
+      unevaluated(impl().paint.untransitioned()) {
 }
 
 const style::FillLayer::Impl& RenderFillLayer::impl() const {
@@ -20,7 +21,7 @@ std::unique_ptr<Bucket> RenderFillLayer::createBucket(const BucketParameters& pa
 }
 
 void RenderFillLayer::transition(const TransitionParameters& parameters) {
-    unevaluated = impl().paint.transition(parameters, std::move(unevaluated));
+    unevaluated = impl().paint.transitioned(parameters, std::move(unevaluated));
 }
 
 void RenderFillLayer::evaluate(const PropertyEvaluationParameters& parameters) {

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -8,7 +8,8 @@
 namespace mbgl {
 
 RenderLineLayer::RenderLineLayer(Immutable<style::LineLayer::Impl> _impl)
-    : RenderLayer(style::LayerType::Line, _impl) {
+    : RenderLayer(style::LayerType::Line, _impl),
+      unevaluated(impl().paint.untransitioned()) {
 }
 
 const style::LineLayer::Impl& RenderLineLayer::impl() const {
@@ -20,12 +21,11 @@ std::unique_ptr<Bucket> RenderLineLayer::createBucket(const BucketParameters& pa
 }
 
 void RenderLineLayer::transition(const TransitionParameters& parameters) {
-    unevaluated = impl().paint.transition(parameters, std::move(unevaluated));
+    unevaluated = impl().paint.transitioned(parameters, std::move(unevaluated));
 }
 
 void RenderLineLayer::evaluate(const PropertyEvaluationParameters& parameters) {
-    style::Properties<LineFloorwidth>::Unevaluated extra;
-    extra.get<LineFloorwidth>() = unevaluated.get<style::LineWidth>();
+    style::Properties<LineFloorwidth>::Unevaluated extra(unevaluated.get<style::LineWidth>());
 
     auto dashArrayParams = parameters;
     dashArrayParams.useIntegerZoom = true;

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -10,7 +10,8 @@
 namespace mbgl {
 
 RenderRasterLayer::RenderRasterLayer(Immutable<style::RasterLayer::Impl> _impl)
-    : RenderLayer(style::LayerType::Raster, _impl) {
+    : RenderLayer(style::LayerType::Raster, _impl),
+      unevaluated(impl().paint.untransitioned()) {
 }
 
 const style::RasterLayer::Impl& RenderRasterLayer::impl() const {
@@ -23,7 +24,7 @@ std::unique_ptr<Bucket> RenderRasterLayer::createBucket(const BucketParameters&,
 }
 
 void RenderRasterLayer::transition(const TransitionParameters& parameters) {
-    unevaluated = impl().paint.transition(parameters, std::move(unevaluated));
+    unevaluated = impl().paint.transitioned(parameters, std::move(unevaluated));
 }
 
 void RenderRasterLayer::evaluate(const PropertyEvaluationParameters& parameters) {

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -9,7 +9,8 @@
 namespace mbgl {
 
 RenderSymbolLayer::RenderSymbolLayer(Immutable<style::SymbolLayer::Impl> _impl)
-    : RenderLayer(style::LayerType::Symbol, _impl) {
+    : RenderLayer(style::LayerType::Symbol, _impl),
+      unevaluated(impl().paint.untransitioned()) {
 }
 
 const style::SymbolLayer::Impl& RenderSymbolLayer::impl() const {
@@ -34,7 +35,7 @@ std::unique_ptr<SymbolLayout> RenderSymbolLayer::createLayout(const BucketParame
 }
 
 void RenderSymbolLayer::transition(const TransitionParameters& parameters) {
-    unevaluated = impl().paint.transition(parameters, std::move(unevaluated));
+    unevaluated = impl().paint.transitioned(parameters, std::move(unevaluated));
 }
 
 void RenderSymbolLayer::evaluate(const PropertyEvaluationParameters& parameters) {

--- a/src/mbgl/renderer/render_light.cpp
+++ b/src/mbgl/renderer/render_light.cpp
@@ -3,11 +3,12 @@
 namespace mbgl {
 
 RenderLight::RenderLight(Immutable<style::Light::Impl> impl_)
-    : impl(std::move(impl_)) {
+    : impl(std::move(impl_)),
+      transitioning(impl->properties.untransitioned()) {
 }
 
 void RenderLight::transition(const TransitionParameters& parameters) {
-    transitioning = impl->properties.transition(parameters, std::move(transitioning));
+    transitioning = impl->properties.transitioned(parameters, std::move(transitioning));
 }
 
 void RenderLight::evaluate(const PropertyEvaluationParameters& parameters) {

--- a/src/mbgl/style/properties.hpp
+++ b/src/mbgl/style/properties.hpp
@@ -20,6 +20,10 @@ class Transitioning {
 public:
     Transitioning() = default;
 
+    explicit Transitioning(Value value_)
+        : value(std::move(value_)) {
+    }
+
     Transitioning(Value value_,
                   Transitioning<Value> prior_,
                   TransitionOptions transition,
@@ -125,7 +129,10 @@ public:
 
     class Evaluated : public Tuple<EvaluatedTypes> {
     public:
-        using Tuple<EvaluatedTypes>::Tuple;
+        template <class... Us>
+        Evaluated(Us&&... us)
+            : Tuple<EvaluatedTypes>(std::forward<Us>(us)...) {
+        }
     };
 
     class PossiblyEvaluated : public Tuple<PossiblyEvaluatedTypes> {
@@ -169,7 +176,10 @@ public:
 
     class Unevaluated : public Tuple<UnevaluatedTypes> {
     public:
-        using Tuple<UnevaluatedTypes>::Tuple;
+        template <class... Us>
+        Unevaluated(Us&&... us)
+            : Tuple<UnevaluatedTypes>(std::forward<Us>(us)...) {
+        }
 
         bool hasTransition() const {
             bool result = false;
@@ -200,12 +210,21 @@ public:
 
     class Transitionable : public Tuple<TransitionableTypes> {
     public:
-        using Tuple<TransitionableTypes>::Tuple;
+        template <class... Us>
+        Transitionable(Us&&... us)
+            : Tuple<TransitionableTypes>(std::forward<Us>(us)...) {
+        }
 
-        Unevaluated transition(const TransitionParameters& parameters, Unevaluated&& prior) const {
+        Unevaluated transitioned(const TransitionParameters& parameters, Unevaluated&& prior) const {
             return Unevaluated {
                 this->template get<Ps>()
                     .transition(parameters, std::move(prior.template get<Ps>()))...
+            };
+        }
+
+        Unevaluated untransitioned() const {
+            return Unevaluated {
+                typename Ps::UnevaluatedType(this->template get<Ps>().value)...
             };
         }
 


### PR DESCRIPTION
Fixes #9301. I opted not to implement transitioning opacity because:

* gl-js doesn't do that
* the new layers have to go through layout, so they wouldn't start rendering at the beginning of the transition anyway
* if we did that, we should also transition layers _out_, which is more difficult