### PR TITLE
[build] Unbreak Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+group: deprecated-2017Q2
+
 git:
   submodules: false
 


### PR DESCRIPTION
Travis rolled out [new Ubuntu Trusty 14.04 images](https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch). They broke our Qt4 build with errors like:

```
CMake Error at cmake/core.cmake:1 (add_library):
  Target "mbgl-core" links to target "Qt4::QtOpenGL" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?
```

This reverts to the working images until we can figure out a better solution.