### PR TITLE
[darwin] Assign threads more specific names

### DIFF
--- a/platform/darwin/src/nsthread.mm
+++ b/platform/darwin/src/nsthread.mm
@@ -15,7 +15,8 @@ std::string getCurrentThreadName() {
 }
 
 void setCurrentThreadName(const std::string& name) {
-    pthread_setname_np(name.c_str());
+    std::string qualifiedName = "com.mapbox.mbgl." + name;
+    pthread_setname_np(qualifiedName.c_str());
 }
 
 void makeThreadLowPriority() {


### PR DESCRIPTION
Gives core threads on the darwin platforms fully qualified names by adding the `com.mapbox.mbgl` prefix. This helps distinguish our threads during debugging and in crash reports. It also aligns us with platform naming conventions.

I’ve made this specific to darwin for now because I’m not certain it's a useful change for all platforms. If we wanted to add a thread name prefix on all platforms, I’m guessing we’d do it [here](https://github.com/mapbox/mapbox-gl-native/blob/c437079486b5401665df5e90929953cfbd341191/src/mbgl/util/thread.hpp#L47) — happy to make that change, if people want it.

![screen_shot_2017-06-22_at_12_00_47_am](https://user-images.githubusercontent.com/1198851/27416982-d8ea9dc6-56de-11e7-96da-7851bdb8b027.png)

/cc @tmpsantos @kkaefer @jfirebaugh @tobrun 