### PR TITLE
Allow delegate to keep wandering pinch from panning map

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -43,6 +43,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Corrected the size of MGLMapView’s compass. ([#9060](https://github.com/mapbox/mapbox-gl-native/pull/9060))
 * The Improve This Map button in the attribution action sheet now leads to a feedback tool that matches MGLMapView’s rotation and pitch. `-[MGLAttributionInfo feedbackURLAtCenterCoordinate:zoomLevel:]` no longer respects the feedback URL specified in TileJSON. ([#9078](https://github.com/mapbox/mapbox-gl-native/pull/9078))
 * Fixed an issue when user starts tracking position and stops manually the animation. ([#7916](https://github.com/mapbox/mapbox-gl-native/pull/7916))
+* `-[MGLMapViewDelegate mapView:shouldChangeFromCamera:toCamera:]` can now block any panning caused by a pinch gesture. ([#9344](https://github.com/mapbox/mapbox-gl-native/pull/9344))
 
 ### Other changes
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1306,16 +1306,16 @@ public:
             [self.delegate mapView:self shouldChangeFromCamera:oldCamera toCamera:toCamera])
         {
             _mbglMap->setZoom(zoom, mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y });
-        }
-        // The gesture recognizer only reports the gesture’s current center
-        // point, so use the previous center point to anchor the transition.
-        // If the number of touches has changed, the remembered center point is
-        // meaningless.
-        if (self.userTrackingMode == MGLUserTrackingModeNone && pinch.numberOfTouches == _previousPinchNumberOfTouches)
-        {
-            CLLocationCoordinate2D centerCoordinate = _previousPinchCenterCoordinate;
-            _mbglMap->setLatLng(MGLLatLngFromLocationCoordinate2D(centerCoordinate),
-                                mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y });
+            // The gesture recognizer only reports the gesture’s current center
+            // point, so use the previous center point to anchor the transition.
+            // If the number of touches has changed, the remembered center point is
+            // meaningless.
+            if (self.userTrackingMode == MGLUserTrackingModeNone && pinch.numberOfTouches == _previousPinchNumberOfTouches)
+            {
+                CLLocationCoordinate2D centerCoordinate = _previousPinchCenterCoordinate;
+                _mbglMap->setLatLng(MGLLatLngFromLocationCoordinate2D(centerCoordinate),
+                                    mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y });
+            }
         }
         [self cameraIsChanging];
     }


### PR DESCRIPTION
MGLMapView consults MGLMapViewDelegate about whether to zoom the map in response to a pinch gesture, but it should also account for the delegate’s response when panning the map due to the pinch’s center point wandering.

Fixes #9168.

/cc @fabian-guerra @jmkiley