### PR TITLE
[android] - run style instrumentation tests on CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -99,6 +99,7 @@ jobs:
             rm secret.json
       - run:
           name: Run instrumentation tests on Firebase
+          no_output_timeout: 1200
           shell: /bin/bash -euo pipefail
           command: |
             gcloud firebase test android models list
@@ -106,7 +107,7 @@ jobs:
               --app platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/MapboxGLAndroidSDKTestApp-debug.apk \
               --test platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/MapboxGLAndroidSDKTestApp-debug-androidTest.apk \
               --device-ids shamu --os-version-ids 22 --locales en --orientations portrait --timeout 15m \
-              --test-targets "class com.mapbox.mapboxsdk.testapp.maps.widgets.LogoTest" 2>&1 | tee firebase.log) || EXIT_CODE=$?
+              --test-targets "package com.mapbox.mapboxsdk.testapp.style" 2>&1 | tee firebase.log) || EXIT_CODE=$?
 
             FIREBASE_TEST_BUCKET=$(sed -n 's|^.*\[https://console.developers.google.com/storage/browser/\([^]]*\).*|gs://\1|p' firebase.log)
             echo "Downloading from: ${FIREBASE_TEST_BUCKET}"


### PR DESCRIPTION
We recently fixed the source of our flaky tests in #9198. Time to scale the amount of tests we run on CI. This PR enables testing the full `com.mapbox.mapboxsdk.testapp.style` package instead of 1 regression test. This  will help detect regressions faster with recent core changes related to async rendering. 


