### PR TITLE
[core] make{Glyph,Image}Atlas only once for any number of symbol layers

### DIFF
--- a/src/mbgl/layout/symbol_layout.hpp
+++ b/src/mbgl/layout/symbol_layout.hpp
@@ -40,13 +40,6 @@ public:
 
     bool hasSymbolInstances() const;
 
-    enum State {
-        Pending,  // Waiting for the necessary glyphs or icons to be available.
-        Placed    // The final positions have been determined, taking into account prior layers.
-    };
-
-    State state = Pending;
-
     std::map<std::string,
         std::pair<style::IconPaintProperties::PossiblyEvaluated, style::TextPaintProperties::PossiblyEvaluated>> layerPaintProperties;
 

--- a/src/mbgl/tile/geometry_tile_worker.hpp
+++ b/src/mbgl/tile/geometry_tile_worker.hpp
@@ -52,7 +52,6 @@ private:
    
     void symbolDependenciesChanged();
     bool hasPendingSymbolDependencies() const;
-    bool hasPendingSymbolLayouts() const;
 
     ActorRef<GeometryTileWorker> self;
     ActorRef<GeometryTile> parent;
@@ -77,6 +76,7 @@ private:
     optional<std::unique_ptr<const GeometryTileData>> data;
     optional<PlacementConfig> placementConfig;
 
+    bool symbolLayoutsNeedPreparation = false;
     std::vector<std::unique_ptr<SymbolLayout>> symbolLayouts;
     GlyphDependencies pendingGlyphDependencies;
     ImageDependencies pendingImageDependencies;


### PR DESCRIPTION
Fix an oversight from #9213 / f73f45107f02f5b1d945a7a41e3e6d1e88ecf9b8.