### PR TITLE
Fix infinite loop zooming in past z23

### DIFF
--- a/platform/ios/src/MGLScaleBar.mm
+++ b/platform/ios/src/MGLScaleBar.mm
@@ -188,9 +188,9 @@ static const CGFloat MGLFeetPerMeter = 3.28084;
 
 - (MGLRow)preferredRow {
     CLLocationDistance maximumDistance = [self maximumWidth] * [self unitsPerPoint];
-    MGLRow row;
     
     BOOL useMetric = [self usesMetricSystem];
+    MGLRow row = useMetric ? MGLMetricTable[0] : MGLImperialTable[0];
     NSUInteger count = useMetric
     ? sizeof(MGLMetricTable) / sizeof(MGLMetricTable[0])
     : sizeof(MGLImperialTable) / sizeof(MGLImperialTable[0]);


### PR DESCRIPTION
At zoom levels where the minimum 1 meter or 4 feet would be wider than the scale bar’s maximum width, the local variable holding the preferred row was left undefined. A loop that later iterated based on this row would effectively iterate infinitely until memory pressure forces the system to quit the application. This change ensures that the preferred row is always set to a real value, avoiding the infinite loop.

As you can see from this screenshot of z25.5 in Svalbard, we could probably hide the scale bar at such ridiculously high zoom levels:

![svalbard](https://user-images.githubusercontent.com/1231218/27503250-67e459ee-582f-11e7-9c65-8f45bd0b1eee.png)

Here’s the [Versailles Orangerie](https://en.wikipedia.org/wiki/Versailles_Orangerie), one of the most intricately mapped places in OpenStreetMap, as seen in Mapbox Streets:

![versailles](https://user-images.githubusercontent.com/1231218/27503265-7dede598-582f-11e7-9625-caa74b3caf57.png)

Fixes #9359.

/cc @frederoni