### PR TITLE
Transform::flyTo invalid zoom checks

### DIFF
--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -293,6 +293,11 @@ void Transform::flyTo(const CameraOptions &camera, const AnimationOptions &anima
         Point<double> framePoint = util::interpolate(startPoint, endPoint, us);
         double frameZoom = startZoom + state.scaleZoom(1 / w(s));
 
+        // Zoom can be NaN if size is empty.
+        if (std::isnan(frameZoom)) {
+            frameZoom = zoom;
+        }
+
         // Convert to geographic coordinates and set the new viewpoint.
         LatLng frameLatLng = Projection::unproject(framePoint, startScale);
         state.setLatLngZoom(frameLatLng, frameZoom);

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -358,7 +358,7 @@ void TransformState::setLatLngZoom(const LatLng& latLng, double zoom) {
         constrained = bounds->constrain(latLng);
     }
 
-    double newScale = zoomScale(zoom);
+    double newScale = util::clamp(zoomScale(zoom), min_scale, max_scale);
     const double newWorldSize = newScale * util::tileSize;
     Bc = newWorldSize / util::DEGREES_MAX;
     Cc = newWorldSize / util::M2PI;

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -36,6 +36,11 @@ TEST(Transform, InvalidZoom) {
     cameraOptions.center = LatLng { util::LATITUDE_MAX, util::LONGITUDE_MAX };
     cameraOptions.zoom = transform.getState().getMaxZoom();
 
+    // Executing flyTo with an empty size causes frameZoom to be NaN.
+    transform.flyTo(cameraOptions);
+    transform.updateTransitions(transform.getTransitionStart() + transform.getTransitionDuration());
+    ASSERT_DOUBLE_EQ(transform.getZoom(), transform.getState().getMaxZoom());
+
     // Executing flyTo with maximum zoom level to the same zoom level causes
     // frameZoom to be bigger than maximum zoom.
     transform.resize(Size { 100, 100 });

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -28,6 +28,22 @@ TEST(Transform, InvalidZoom) {
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(1, transform.getZoom());
+
+    transform.setZoom(transform.getState().getMaxZoom() + 0.1);
+    ASSERT_DOUBLE_EQ(transform.getZoom(), transform.getState().getMaxZoom());
+
+    CameraOptions cameraOptions;
+    cameraOptions.center = LatLng { util::LATITUDE_MAX, util::LONGITUDE_MAX };
+    cameraOptions.zoom = transform.getState().getMaxZoom();
+
+    // Executing flyTo with maximum zoom level to the same zoom level causes
+    // frameZoom to be bigger than maximum zoom.
+    transform.resize(Size { 100, 100 });
+    transform.flyTo(cameraOptions);
+    transform.updateTransitions(transform.getTransitionStart() + transform.getTransitionDuration());
+
+    ASSERT_TRUE(transform.getState().valid());
+    ASSERT_DOUBLE_EQ(transform.getState().getMaxZoom(), transform.getZoom());
 }
 
 


### PR DESCRIPTION
Whilst `Transform::easeTo` interpolates the zoom from initial to end values (thus never breaching the end value threshold), `Transform::flyTo` has a "bounce" effect on zoom in some circumstances, by applying a formula on each frame rendering that calculates a new zoom value.

In a particular case e.g. executing `flyTo` with camera options' zoom level set to the maximum value, the zoom value sometimes goes above the maximum zoom threshold, causing the transform state to become invalid, thus causing this crash in `tileCover`:
> mbgl-glfw: ../../../src/mbgl/util/tile_cover.cpp:159: std::vector<mbgl::UnwrappedTileID>
> mbgl::util::tileCover(const mbgl::TransformState&, int32_t): Assertion `state.valid()' failed.

This PR introduces a clamping to scale boundaries in `TransformState::setLatLngZoom`, and also a check if the frameZoom is NaN in `flyTo` (which can occur if the transform state size is empty).