### PR TITLE
[core] Reserve space for index/vertex items when possible

### DIFF
--- a/src/mbgl/gl/index_buffer.hpp
+++ b/src/mbgl/gl/index_buffer.hpp
@@ -14,6 +14,10 @@ class IndexVector {
 public:
     static constexpr std::size_t groupSize = DrawMode::bufferGroupSize;
 
+    void reserve(std::size_t size) {
+        v.reserve(size);
+    }
+
     template <class... Args>
     void emplace_back(Args&&... args) {
         static_assert(sizeof...(args) == groupSize, "wrong buffer element count");

--- a/src/mbgl/gl/vertex_buffer.hpp
+++ b/src/mbgl/gl/vertex_buffer.hpp
@@ -16,6 +16,10 @@ public:
     using Vertex = V;
     static constexpr std::size_t groupSize = DrawMode::bufferGroupSize;
 
+    void reserve(std::size_t size) {
+        v.reserve(size);
+    }
+
     template <class... Args>
     void emplace_back(Args&&... args) {
         static_assert(sizeof...(args) == groupSize, "wrong buffer element count");

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -501,6 +501,8 @@ std::unique_ptr<SymbolBucket> SymbolLayout::place(CollisionTile& collisionTile) 
             const float placementZoom = util::max(util::log2(glyphScale) + zoom, 0.0f);
             collisionTile.insertFeature(symbolInstance.textCollisionFeature, glyphScale, layout.get<TextIgnorePlacement>());
             if (glyphScale < collisionTile.maxScale) {
+                bucket->text.vertices.reserve(bucket->text.vertices.vertexSize() + (symbolInstance.glyphQuads.size() * 4));
+                bucket->text.triangles.reserve(bucket->text.triangles.indexSize() + (symbolInstance.glyphQuads.size() * 2));
                 for (const auto& symbol : symbolInstance.glyphQuads) {
                     addSymbol(
                         bucket->text, *bucket->textSizeBinder, symbol, feature, placementZoom,
@@ -621,6 +623,8 @@ void SymbolLayout::addToDebugBuffers(CollisionTile& collisionTile, SymbolBucket&
 
     for (const SymbolInstance &symbolInstance : symbolInstances) {
         auto populateCollisionBox = [&](const auto& feature) {
+            collisionBox.vertices.reserve(collisionBox.vertices.vertexSize() + (feature.boxes.size() * 4));
+            collisionBox.lines.reserve(collisionBox.lines.indexSize() + (feature.boxes.size() * 4));
             for (const CollisionBox &box : feature.boxes) {
                 auto& anchor = box.anchor;
 

--- a/src/mbgl/renderer/buckets/debug_bucket.cpp
+++ b/src/mbgl/renderer/buckets/debug_bucket.cpp
@@ -34,6 +34,8 @@ DebugBucket::DebugBucket(const OverscaledTileID& id,
             optional<Point<int16_t>> prev;
 
             const glyph& glyph = simplex[c - 32];
+            vertices.reserve(vertices.vertexSize() + (glyph.length / 2) + 1);
+            indices.reserve(indices.indexSize() + (glyph.length / 2) + 1);
             for (int32_t j = 0; j < glyph.length; j += 2) {
                 if (glyph.data[j] == -1 && glyph.data[j + 1] == -1) {
                     prev = {};

--- a/src/mbgl/renderer/buckets/fill_bucket.cpp
+++ b/src/mbgl/renderer/buckets/fill_bucket.cpp
@@ -61,6 +61,9 @@ void FillBucket::addFeature(const GeometryTileFeature& feature,
             if (nVertices == 0)
                 continue;
 
+            vertices.reserve(vertices.vertexSize() + nVertices);
+            lines.reserve(lines.indexSize() + nVertices);
+
             if (lineSegments.empty() || lineSegments.back().vertexLength + nVertices > std::numeric_limits<uint16_t>::max()) {
                 lineSegments.emplace_back(vertices.vertexSize(), lines.indexSize());
             }
@@ -94,6 +97,7 @@ void FillBucket::addFeature(const GeometryTileFeature& feature,
         assert(triangleSegment.vertexLength <= std::numeric_limits<uint16_t>::max());
         uint16_t triangleIndex = triangleSegment.vertexLength;
 
+        triangles.reserve(triangles.indexSize() + (nIndicies / 3) + 1);
         for (uint32_t i = 0; i < nIndicies; i += 3) {
             triangles.emplace_back(triangleIndex + indices[i],
                                    triangleIndex + indices[i + 1],

--- a/src/mbgl/renderer/buckets/line_bucket.cpp
+++ b/src/mbgl/renderer/buckets/line_bucket.cpp
@@ -379,6 +379,7 @@ void LineBucket::addGeometry(const GeometryCoordinates& coordinates, FeatureType
     assert(segment.vertexLength <= std::numeric_limits<uint16_t>::max());
     uint16_t index = segment.vertexLength;
 
+    triangles.reserve(triangles.indexSize() + triangleStore.size());
     for (const auto& triangle : triangleStore) {
         triangles.emplace_back(index + triangle.a, index + triangle.b, index + triangle.c);
     }


### PR DESCRIPTION
In cases where the number of index/vertex vector items is known beforehand e.g. when inserting elements on a loop, we can eliminate reallocations and thus optimize memory allocations for some items in symbol, fill, line and debug buckets.

Spin-off from my debugging efforts on #9148.