### PR TITLE
[ios] Minimize tilt gesture delay

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -46,6 +46,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * The Improve This Map button in the attribution action sheet now leads to a feedback tool that matches MGLMapView’s rotation and pitch. `-[MGLAttributionInfo feedbackURLAtCenterCoordinate:zoomLevel:]` no longer respects the feedback URL specified in TileJSON. ([#9078](https://github.com/mapbox/mapbox-gl-native/pull/9078))
 * `-[MGLMapViewDelegate mapView:shouldChangeFromCamera:toCamera:]` can now block any panning caused by a pinch gesture. ([#9344](https://github.com/mapbox/mapbox-gl-native/pull/9344))
 * If the user taps on the map while it is flying to the user’s location, the user dot no longer appears in the incorrect location. ([#7916](https://github.com/mapbox/mapbox-gl-native/pull/7916))
+* Improved the responsiveness of the tilt gesture by reducing the initial recognition delay. ([#9386](https://github.com/mapbox/mapbox-gl-native/pull/9386))
 
 ### Other changes
 


### PR DESCRIPTION
Reduces the initial recognition delay of the two-finger drag tilt gesture from ~0.068s to ~0.031s. This is accomplished by:

1. Reversing the failure relationship between the tilt and two-finger tap recognizers.
2. Actually starting the tilt gesture on `UIGestureRecognizerStateBegan`.

With the addition of 3D extrusions in v3.6.x, the tilt gesture is going to be used more often. It would be nice if we could jam this into v3.6.0, but the subsequent patch release would be fine, too.

/cc @1ec5 @fabian-guerra @boundsj