### PR TITLE
[core] Fix iterator invalidation in erase_if

### DIFF
--- a/src/mbgl/util/std.hpp
+++ b/src/mbgl/util/std.hpp
@@ -8,10 +8,10 @@ namespace mbgl {
 namespace util {
 
 template <typename Container, typename ForwardIterator, typename Predicate>
-void erase_if(Container &container, ForwardIterator it, const ForwardIterator end, Predicate pred) {
-    while (it != end) {
+void erase_if(Container &container, ForwardIterator it, Predicate pred) {
+    while (it != container.end()) {
         if (pred(*it)) {
-            container.erase(it++);
+            it = container.erase(it);
         } else {
             ++it;
         }
@@ -20,7 +20,7 @@ void erase_if(Container &container, ForwardIterator it, const ForwardIterator en
 
 template <typename Container, typename Predicate>
 void erase_if(Container &container, Predicate pred) {
-    erase_if(container, container.begin(), container.end(), pred);
+    erase_if(container, container.begin(), pred);
 }
 
 } // namespace util


### PR DESCRIPTION
`vector::erase` invalidates iterators. It's not safe for `erase_if` to cache the end iterator nor increment, then erase.

Fixes #9384.