### PR TITLE
Rework eglDisplay and eglContext construction/destruction

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -57,9 +57,6 @@ final class NativeMapView {
   // Device density
   private final float pixelRatio;
 
-  // Listeners for Map change events
-  private CopyOnWriteArrayList<MapView.OnMapChangedListener> onMapChangedListeners;
-
   // Listener invoked to return a bitmap of the map
   private MapboxMap.SnapshotReadyCallback snapshotReadyCallback;
 
@@ -76,7 +73,6 @@ final class NativeMapView {
     fileSource = FileSource.getInstance(context);
 
     pixelRatio = context.getResources().getDisplayMetrics().density;
-    onMapChangedListeners = new CopyOnWriteArrayList<>();
     this.mapView = mapView;
 
     String programCacheDir = context.getCacheDir().getAbsolutePath();
@@ -887,14 +883,8 @@ final class NativeMapView {
   }
 
   protected void onMapChanged(int rawChange) {
-    if (onMapChangedListeners != null) {
-      for (MapView.OnMapChangedListener onMapChangedListener : onMapChangedListeners) {
-        try {
-          onMapChangedListener.onMapChanged(rawChange);
-        } catch (RuntimeException err) {
-          Timber.e("Exception (%s) in MapView.OnMapChangedListener: %s", err.getClass(), err.getMessage());
-        }
-      }
+    if (mapView != null) {
+      mapView.onMapChange(rawChange);
     }
   }
 
@@ -1130,11 +1120,15 @@ final class NativeMapView {
   //
 
   void addOnMapChangedListener(@NonNull MapView.OnMapChangedListener listener) {
-    onMapChangedListeners.add(listener);
+    if (mapView != null) {
+      mapView.addOnMapChangedListener(listener);
+    }
   }
 
   void removeOnMapChangedListener(@NonNull MapView.OnMapChangedListener listener) {
-    onMapChangedListeners.remove(listener);
+    if (mapView != null) {
+      mapView.removeOnMapChangedListener(listener);
+    }
   }
 
   //

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_internal.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_internal.xml
@@ -1,13 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <SurfaceView
-        android:id="@+id/surfaceView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:contentDescription="@null"
-        android:visibility="gone"/>
-
     <FrameLayout
         android:id="@+id/markerViewContainer"
         android:layout_width="match_parent"

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/ids.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="surfaceView" type="id" />
+</resources>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -415,6 +415,28 @@
                 android:value=".activity.FeatureOverviewActivity"/>
         </activity>
         <activity
+            android:name=".activity.maplayout.MapChangeActivity"
+            android:description="@string/description_map_change"
+            android:label="@string/activity_map_change">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_maplayout"/>
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".activity.FeatureOverviewActivity"/>
+        </activity>
+        <activity
+            android:name=".activity.maplayout.VisibilityChangeActivity"
+            android:description="@string/description_visibility_map"
+            android:label="@string/activity_map_visibility">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_maplayout"/>
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".activity.FeatureOverviewActivity"/>
+        </activity>
+        <activity
             android:name=".activity.style.RuntimeStyleActivity"
             android:description="@string/description_runtime_style"
             android:label="@string/activity_runtime_style">

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/MapChangeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/MapChangeActivity.java
@@ -1,0 +1,127 @@
+package com.mapbox.mapboxsdk.testapp.activity.maplayout;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.testapp.R;
+
+import timber.log.Timber;
+
+/**
+ * Test activity showcasing how to listen to map change events.
+ */
+public class MapChangeActivity extends AppCompatActivity {
+
+  private MapView mapView;
+  private MapboxMap mapboxMap;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_map_simple);
+
+    mapView = (MapView) findViewById(R.id.mapView);
+    mapView.addOnMapChangedListener(new MapView.OnMapChangedListener() {
+      @Override
+      public void onMapChanged(int change) {
+        Timber.e("OnMapChange: %s", resolveMapChange(change));
+      }
+    });
+
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+      public void onMapReady(MapboxMap map) {
+        mapboxMap = map;
+        mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(
+          new LatLng(55.754020, 37.620948), 12), 9000);
+      }
+    });
+  }
+
+  private String resolveMapChange(int change) {
+    switch (change) {
+      case MapView.REGION_WILL_CHANGE:
+        return "Region will change";
+      case MapView.REGION_WILL_CHANGE_ANIMATED:
+        return "Region will change animated";
+      case MapView.REGION_IS_CHANGING:
+        return "Region is changing";
+      case MapView.REGION_DID_CHANGE:
+        return "Region did change";
+      case MapView.REGION_DID_CHANGE_ANIMATED:
+        return "Region did change animated";
+      case MapView.WILL_START_LOADING_MAP:
+        return "Will start loading map";
+      case MapView.DID_FINISH_LOADING_MAP:
+        return "Did finish loading map";
+      case MapView.DID_FAIL_LOADING_MAP:
+        return "Did fail loading map";
+      case MapView.WILL_START_RENDERING_FRAME:
+        return "Will start rendering frame";
+      case MapView.DID_FINISH_RENDERING_FRAME:
+        return "Did finish rendering frame";
+      case MapView.DID_FINISH_RENDERING_FRAME_FULLY_RENDERED:
+        return "Did finish rendering frame fully rendered";
+      case MapView.WILL_START_RENDERING_MAP:
+        return "Will start rendering map";
+      case MapView.DID_FINISH_RENDERING_MAP:
+        return "Did finish rendering map";
+      case MapView.DID_FINISH_RENDERING_MAP_FULLY_RENDERED:
+        return "Did finish rendering map fully rendered";
+      case MapView.DID_FINISH_LOADING_STYLE:
+        return "Did finish loading style";
+      case MapView.SOURCE_DID_CHANGE:
+        return "Source did change";
+      default:
+        throw new RuntimeException("Unsupported map type with int value: " + change);
+    }
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/VisibilityChangeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/VisibilityChangeActivity.java
@@ -1,0 +1,126 @@
+package com.mapbox.mapboxsdk.testapp.activity.maplayout;
+
+import android.os.Bundle;
+import android.os.Handler;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.testapp.R;
+
+/**
+ * Test activity showcasing visibility changes to the mapview.
+ */
+public class VisibilityChangeActivity extends AppCompatActivity {
+
+  private MapView mapView;
+  private MapboxMap mapboxMap;
+  private Handler handler = new Handler();
+  private Runnable runnable;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_map_visibility);
+
+    mapView = (MapView) findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+      public void onMapReady(MapboxMap map) {
+        mapboxMap = map;
+        mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(
+          new LatLng(55.754020, 37.620948), 12), 9000);
+      }
+    });
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+    handler.post(runnable = new VisibilityRunner(mapView, findViewById(R.id.viewParent), handler));
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  private static class VisibilityRunner implements Runnable {
+
+    private MapView mapView;
+    private View viewParent;
+    private Handler handler;
+    private int counter;
+
+    VisibilityRunner(MapView mapView, View viewParent, Handler handler) {
+      this.mapView = mapView;
+      this.viewParent = viewParent;
+      this.handler = handler;
+    }
+
+    @Override
+    public void run() {
+      if (mapView != null && viewParent != null) {
+        if (counter == 0 || counter % 2 == 0) {
+          viewParent.setVisibility(View.VISIBLE);
+          mapView.setVisibility(View.VISIBLE);
+        } else {
+          if (counter == 1 || counter == 3) {
+            mapView.setVisibility(counter == 1 ? View.GONE : View.INVISIBLE);
+          } else if (counter == 5 || counter == 7) {
+            viewParent.setVisibility(counter == 5 ? View.GONE : View.INVISIBLE);
+          }
+        }
+
+        // update counter
+        if (counter == 7) {
+          counter = 0;
+        } else {
+          counter++;
+        }
+      }
+      handler.postDelayed(this, 1500);
+    }
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    if (runnable != null) {
+      handler.removeCallbacks(runnable);
+      runnable = null;
+    }
+    mapView.onStop();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_map_visibility.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_map_visibility.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/viewParent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".activity.maplayout.SimpleMapActivity">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="invisible"/>
+
+</LinearLayout>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
@@ -53,6 +53,8 @@
     <string name="activity_add_sprite">Add Custom Sprite</string>
     <string name="activity_navigation_drawer">Android SDK View integration</string>
     <string name="activity_simple_map">Simple Map</string>
+    <string name="activity_map_change">Map Change Events</string>
+    <string name="activity_map_visibility">Visibility Map</string>
     <string name="activity_map_in_dialog">Dialog with map</string>
     <string name="activity_marker_view_rectangle">Marker views in rectangle</string>
     <string name="activity_url_transform">Url transform</string>
@@ -109,6 +111,8 @@
     <string name="description_query_rendered_features_box_highlight">Hightligh buildings in box</string>
     <string name="description_query_source_features">Query source for features</string>
     <string name="description_simple_map">Shows a simple map</string>
+    <string name="description_map_change">Logs map change events to Logcat</string>
+    <string name="description_visibility_map">Changes visibility of map and view parent</string>
     <string name="description_add_remove_markers">Based on zoom level</string>
     <string name="description_style_file">Use a local file as the style</string>
     <string name="description_map_in_dialog">Display a map inside a dialog fragment</string>


### PR DESCRIPTION
This PR reworks the way we handle `eglDisplay` and `eglContext` creation and destruction. 
Main purpose of this change is to eliminate state and resolve edge case crashes.

![ezgif com-video-to-gif 56](https://user-images.githubusercontent.com/2151639/27805357-81d1355e-6034-11e7-8e3e-4a078601b8f8.gif)


## Simplified egl state
Before this PR, a couple of code paths were possible related to egl state management. 
This is now simplified and build around the `SurfaceView` callbacks:

```java
    @Override
    public void surfaceCreated(SurfaceHolder holder) {
      if (nativeMapView == null) {
        nativeMapView = new NativeMapView(MapView.this);
        nativeMapView.initializeDisplay();
        nativeMapView.initializeContext();
        nativeMapView.createSurface(surface = holder.getSurface());
        nativeMapView.resizeView(getWidth(), getHeight());
        initialiseMap();
      }
    }

    @Override
    public void surfaceDestroyed(SurfaceHolder holder) {
      if (nativeMapView != null) {
        mapboxMap.onStop();
        nativeMapView.destroySurface();
        surface.release();
        surface = null;
        nativeMapView.terminateContext();
        nativeMapView.terminateDisplay();
        nativeMapView.destroy();
        nativeMapView = null;
      }
    }

```

This means that an application going into background will go through the same lifecycle as an Activity that is being recreated through rotation. We aren't retaining the map object, eglDisplay and eglContext anymore in the former use-case and this streamlines invoking above code blocks when a map is no longer visible on the screen. 

## Visibility state of MapView

We used to rely on View inflation to create the map object and trigger Surface creation. With this PR, we are relying on `OnVisibilityChange` which allows to have finer grain control over when callbacks in above section occur and unblocks toggling the visibility of the MapView and having it hidden at Activity startup. 

## Measured ViewHierarchy

Since we postpone creating the map object, we are slower in loading the style and thus slower in invoking the `OnMapReady` callback for the user. This has the benefit that view hierarchy has been measured and we can remove the workarounds we have in place for them. 

## Additional test Activities

On top of the SDK changes, 2 test activities were added to facilitate testing of this PR. 

cc @ivovandongen @mapbox/android @kkaefer 