### PR TITLE
make run-qt-test failure on macOS

### DIFF
--- a/platform/qt/test/qmapboxgl.cpp
+++ b/platform/qt/test/qmapboxgl.cpp
@@ -15,7 +15,7 @@ class QMapboxGLTest : public QObject, public ::testing::Test {
     Q_OBJECT
 
 public:
-    QMapboxGLTest() : fbo((assert(widget.context()->isValid()), widget.makeCurrent(), QSize(512, 512))), map(nullptr, settings) {
+    QMapboxGLTest() : size(512, 512), fbo((assert(widget.context()->isValid()), widget.makeCurrent(), size)), map(nullptr, settings, size) {
         connect(&map, SIGNAL(mapChanged(QMapboxGL::MapChange)),
                 this, SLOT(onMapChanged(QMapboxGL::MapChange)));
         connect(&map, SIGNAL(needsRendering()),
@@ -38,6 +38,7 @@ public:
 
 private:
     QGLWidget widget;
+    const QSize size;
     QGLFramebufferObject fbo;
 
 protected:


### PR DESCRIPTION
`make run-qt-test` fails for me on master:

```
[----------] 2 tests from QMapboxGLTest
[ RUN      ] QMapboxGLTest.styleJson
Assertion failed: (!size.isEmpty()), function QMapboxGL, file ../../../platform/qt/src/qmapboxgl.cpp, line 437.
make: *** [run-qt-test-*] Abort trap: 6
```

My environment:

```
11:44 $ qmake -v
QMake version 3.1
Using Qt version 5.9.0 in /usr/local/Cellar/qt/5.9.0_1/lib
```