### PR TITLE
Refactor ClipID generation

### DIFF
--- a/src/mbgl/algorithm/generate_clip_ids.cpp
+++ b/src/mbgl/algorithm/generate_clip_ids.cpp
@@ -31,14 +31,14 @@ bool ClipIDGenerator::Leaf::operator==(const Leaf& other) const {
     return children == other.children;
 }
 
-std::map<UnwrappedTileID, ClipID> ClipIDGenerator::getStencils() const {
-    std::map<UnwrappedTileID, ClipID> stencils;
+std::map<UnwrappedTileID, ClipID> ClipIDGenerator::getClipIDs() const {
+    std::map<UnwrappedTileID, ClipID> clipIDs;
 
     // Merge everything.
     for (auto& pair : pool) {
         auto& id = pair.first;
         auto& leaf = pair.second;
-        auto res = stencils.emplace(id, leaf.clip);
+        auto res = clipIDs.emplace(id, leaf.clip);
         if (!res.second) {
             // Merge with the existing ClipID when there was already an element with the
             // same tile ID.
@@ -46,14 +46,14 @@ std::map<UnwrappedTileID, ClipID> ClipIDGenerator::getStencils() const {
         }
     }
 
-    for (auto it = stencils.begin(); it != stencils.end(); ++it) {
+    for (auto it = clipIDs.begin(); it != clipIDs.end(); ++it) {
         auto& childId = it->first;
         auto& childClip = it->second;
 
         // Loop through all preceding stencils, and find all parents.
 
         for (auto parentIt = std::reverse_iterator<decltype(it)>(it);
-             parentIt != stencils.rend(); ++parentIt) {
+             parentIt != clipIDs.rend(); ++parentIt) {
             auto& parentId = parentIt->first;
             if (childId.isChildOf(parentId)) {
                 // Once we have a parent, we add the bits  that this ID hasn't set yet.
@@ -66,11 +66,11 @@ std::map<UnwrappedTileID, ClipID> ClipIDGenerator::getStencils() const {
     }
 
     // Remove tiles that are entirely covered by children.
-    util::erase_if(stencils, [&](const auto& stencil) {
-        return algorithm::coveredByChildren(stencil.first, stencils);
+    util::erase_if(clipIDs, [&](const auto& stencil) {
+        return algorithm::coveredByChildren(stencil.first, clipIDs);
     });
 
-    return stencils;
+    return clipIDs;
 }
 
 } // namespace algorithm

--- a/src/mbgl/algorithm/generate_clip_ids.hpp
+++ b/src/mbgl/algorithm/generate_clip_ids.hpp
@@ -3,9 +3,9 @@
 #include <mbgl/tile/tile_id.hpp>
 #include <mbgl/util/clip_id.hpp>
 
-#include <unordered_set>
+#include <set>
 #include <vector>
-#include <unordered_map>
+#include <map>
 
 namespace mbgl {
 namespace algorithm {
@@ -17,12 +17,12 @@ private:
         void add(const CanonicalTileID &p);
         bool operator==(const Leaf &other) const;
 
-        std::unordered_set<CanonicalTileID> children;
+        std::set<CanonicalTileID> children;
         ClipID& clip;
     };
 
     uint8_t bit_offset = 0;
-    std::unordered_multimap<UnwrappedTileID, Leaf> pool;
+    std::multimap<UnwrappedTileID, Leaf> pool;
 
 public:
     template <typename Renderable>

--- a/src/mbgl/algorithm/generate_clip_ids.hpp
+++ b/src/mbgl/algorithm/generate_clip_ids.hpp
@@ -28,7 +28,7 @@ public:
     template <typename Renderable>
     void update(std::vector<std::reference_wrapper<Renderable>> renderables);
 
-    std::map<UnwrappedTileID, ClipID> getStencils() const;
+    std::map<UnwrappedTileID, ClipID> getClipIDs() const;
 };
 
 } // namespace algorithm

--- a/src/mbgl/algorithm/generate_clip_ids.hpp
+++ b/src/mbgl/algorithm/generate_clip_ids.hpp
@@ -25,8 +25,8 @@ private:
     std::unordered_multimap<UnwrappedTileID, Leaf> pool;
 
 public:
-    template <typename Renderables>
-    void update(Renderables& renderables);
+    template <typename Renderable>
+    void update(std::vector<std::reference_wrapper<Renderable>> renderables);
 
     std::map<UnwrappedTileID, ClipID> getStencils() const;
 };

--- a/src/mbgl/algorithm/generate_clip_ids_impl.hpp
+++ b/src/mbgl/algorithm/generate_clip_ids_impl.hpp
@@ -7,14 +7,16 @@
 namespace mbgl {
 namespace algorithm {
 
-template <typename Renderables>
-void ClipIDGenerator::update(Renderables& renderables) {
+template <typename Renderable>
+void ClipIDGenerator::update(std::vector<std::reference_wrapper<Renderable>> renderables) {
     std::size_t size = 0;
+
+    std::sort(renderables.begin(), renderables.end(),
+              [](const auto& a, const auto& b) { return a.get().id < b.get().id; });
 
     const auto end = renderables.end();
     for (auto it = renderables.begin(); it != end; it++) {
-        auto& tileID = it->first;
-        auto& renderable = it->second;
+        auto& renderable = it->get();
         if (!renderable.used) {
             continue;
         }
@@ -28,17 +30,17 @@ void ClipIDGenerator::update(Renderables& renderables) {
         // can never be children of the current wrap.
         auto child_it = std::next(it);
         const auto children_end = std::lower_bound(
-            child_it, end, UnwrappedTileID{ static_cast<int16_t>(tileID.wrap + 1), { 0, 0, 0 } },
-            [](auto& a, auto& b) { return a.first < b; });
+            child_it, end, UnwrappedTileID{ static_cast<int16_t>(renderable.id.wrap + 1), { 0, 0, 0 } },
+            [](auto& a, auto& b) { return a.get().id < b; });
         for (; child_it != children_end; ++child_it) {
-            auto& childTileID = child_it->first;
-            if (childTileID.isChildOf(tileID)) {
+            auto& childTileID = child_it->get().id;
+            if (childTileID.isChildOf(it->get().id)) {
                 leaf.add(childTileID.canonical);
             }
         }
 
         // Find a leaf with matching children.
-        for (auto its = pool.equal_range(tileID); its.first != its.second; ++its.first) {
+        for (auto its = pool.equal_range(renderable.id); its.first != its.second; ++its.first) {
             auto& existing = its.first->second;
             if (existing == leaf) {
                 leaf.clip = existing.clip;
@@ -50,7 +52,7 @@ void ClipIDGenerator::update(Renderables& renderables) {
             size++;
         }
 
-        pool.emplace(tileID, std::move(leaf));
+        pool.emplace(renderable.id, std::move(leaf));
     }
 
     if (size > 0) {
@@ -60,8 +62,8 @@ void ClipIDGenerator::update(Renderables& renderables) {
         // We are starting our count with 1 since we need at least 1 bit set to distinguish between
         // areas without any tiles whatsoever and the current area.
         uint8_t count = 1;
-        for (auto& pair : renderables) {
-            auto& renderable = pair.second;
+        for (auto& it : renderables) {
+            auto& renderable = it.get();
             if (!renderable.used) {
                 continue;
             }

--- a/src/mbgl/annotation/render_annotation_source.cpp
+++ b/src/mbgl/annotation/render_annotation_source.cpp
@@ -53,7 +53,7 @@ void RenderAnnotationSource::finishRender(Painter& painter) {
     tilePyramid.finishRender(painter);
 }
 
-std::map<UnwrappedTileID, RenderTile>& RenderAnnotationSource::getRenderTiles() {
+std::vector<std::reference_wrapper<RenderTile>> RenderAnnotationSource::getRenderTiles() {
     return tilePyramid.getRenderTiles();
 }
 

--- a/src/mbgl/annotation/render_annotation_source.hpp
+++ b/src/mbgl/annotation/render_annotation_source.hpp
@@ -21,7 +21,7 @@ public:
     void startRender(Painter&) final;
     void finishRender(Painter&) final;
 
-    std::map<UnwrappedTileID, RenderTile>& getRenderTiles() final;
+    std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() final;
 
     std::unordered_map<std::string, std::vector<Feature>>
     queryRenderedFeatures(const ScreenLineString& geometry,

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -198,9 +198,9 @@ void Painter::render(RenderStyle& style, const FrameData& frame_, View& view) {
 
         MBGL_DEBUG_GROUP(context, "clipping masks");
 
-        for (const auto& stencil : clipIDGenerator.getStencils()) {
-            MBGL_DEBUG_GROUP(context, std::string{ "mask: " } + util::toString(stencil.first));
-            renderClippingMask(stencil.first, stencil.second);
+        for (const auto& clipID : clipIDGenerator.getClipIDs()) {
+            MBGL_DEBUG_GROUP(context, std::string{ "mask: " } + util::toString(clipID.first));
+            renderClippingMask(clipID.first, clipID.second);
         }
     }
 

--- a/src/mbgl/renderer/render_source.hpp
+++ b/src/mbgl/renderer/render_source.hpp
@@ -57,7 +57,8 @@ public:
     virtual void startRender(Painter&) = 0;
     virtual void finishRender(Painter&) = 0;
 
-    virtual std::map<UnwrappedTileID, RenderTile>& getRenderTiles() = 0;
+    // Returns an unsorted list of RenderTiles.
+    virtual std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() = 0;
 
     virtual std::unordered_map<std::string, std::vector<Feature>>
     queryRenderedFeatures(const ScreenLineString& geometry,

--- a/src/mbgl/renderer/render_style.cpp
+++ b/src/mbgl/renderer/render_style.cpp
@@ -309,16 +309,12 @@ RenderData RenderStyle::getRenderData(MapDebugOptions debugOptions, float angle)
             continue;
         }
 
-        auto& renderTiles = source->getRenderTiles();
         const bool symbolLayer = layer->is<RenderSymbolLayer>();
 
-        // Sort symbol tiles in opposite y position, so tiles with overlapping
-        // symbols are drawn on top of each other, with lower symbols being
-        // drawn on top of higher symbols.
-        std::vector<std::reference_wrapper<RenderTile>> sortedTiles;
-        std::transform(renderTiles.begin(), renderTiles.end(), std::back_inserter(sortedTiles),
-                [](auto& pair) { return std::ref(pair.second); });
+        auto sortedTiles = source->getRenderTiles();
         if (symbolLayer) {
+            // Sort symbol tiles in opposite y position, so tiles with overlapping symbols are drawn
+            // on top of each other, with lower symbols being drawn on top of higher symbols.
             std::sort(sortedTiles.begin(), sortedTiles.end(),
                       [angle](const RenderTile& a, const RenderTile& b) {
                 Point<float> pa(a.id.canonical.x, a.id.canonical.y);

--- a/src/mbgl/renderer/render_tile.hpp
+++ b/src/mbgl/renderer/render_tile.hpp
@@ -13,7 +13,7 @@ class Tile;
 class TransformState;
 class Painter;
 
-class RenderTile {
+class RenderTile final {
 public:
     RenderTile(UnwrappedTileID id_, Tile& tile_) : id(std::move(id_)), tile(tile_) {}
     RenderTile(const RenderTile&) = delete;

--- a/src/mbgl/renderer/sources/render_geojson_source.cpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.cpp
@@ -68,7 +68,7 @@ void RenderGeoJSONSource::finishRender(Painter& painter) {
     tilePyramid.finishRender(painter);
 }
 
-std::map<UnwrappedTileID, RenderTile>& RenderGeoJSONSource::getRenderTiles() {
+std::vector<std::reference_wrapper<RenderTile>> RenderGeoJSONSource::getRenderTiles() {
     return tilePyramid.getRenderTiles();
 }
 

--- a/src/mbgl/renderer/sources/render_geojson_source.hpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.hpp
@@ -25,7 +25,7 @@ public:
     void startRender(Painter&) final;
     void finishRender(Painter&) final;
 
-    std::map<UnwrappedTileID, RenderTile>& getRenderTiles() final;
+    std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() final;
 
     std::unordered_map<std::string, std::vector<Feature>>
     queryRenderedFeatures(const ScreenLineString& geometry,

--- a/src/mbgl/renderer/sources/render_image_source.hpp
+++ b/src/mbgl/renderer/sources/render_image_source.hpp
@@ -30,8 +30,8 @@ public:
                 bool needsRelayout,
                 const TileParameters&) final;
 
-    std::map<UnwrappedTileID, RenderTile>& getRenderTiles() final {
-        return tiles;
+    std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() final {
+        return {};
     }
 
     std::unordered_map<std::string, std::vector<Feature>>
@@ -48,7 +48,6 @@ public:
 
 private:
     const style::ImageSource::Impl& impl() const;
-    std::map<UnwrappedTileID, RenderTile> tiles;
 
     std::vector<UnwrappedTileID> tileIds;
     std::unique_ptr<RasterBucket> bucket;

--- a/src/mbgl/renderer/sources/render_raster_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_source.cpp
@@ -64,7 +64,7 @@ void RenderRasterSource::finishRender(Painter& painter) {
     tilePyramid.finishRender(painter);
 }
 
-std::map<UnwrappedTileID, RenderTile>& RenderRasterSource::getRenderTiles() {
+std::vector<std::reference_wrapper<RenderTile>> RenderRasterSource::getRenderTiles() {
     return tilePyramid.getRenderTiles();
 }
 

--- a/src/mbgl/renderer/sources/render_raster_source.hpp
+++ b/src/mbgl/renderer/sources/render_raster_source.hpp
@@ -21,7 +21,7 @@ public:
     void startRender(Painter&) final;
     void finishRender(Painter&) final;
 
-    std::map<UnwrappedTileID, RenderTile>& getRenderTiles() final;
+    std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() final;
 
     std::unordered_map<std::string, std::vector<Feature>>
     queryRenderedFeatures(const ScreenLineString& geometry,

--- a/src/mbgl/renderer/sources/render_vector_source.cpp
+++ b/src/mbgl/renderer/sources/render_vector_source.cpp
@@ -69,7 +69,7 @@ void RenderVectorSource::finishRender(Painter& painter) {
     tilePyramid.finishRender(painter);
 }
 
-std::map<UnwrappedTileID, RenderTile>& RenderVectorSource::getRenderTiles() {
+std::vector<std::reference_wrapper<RenderTile>> RenderVectorSource::getRenderTiles() {
     return tilePyramid.getRenderTiles();
 }
 

--- a/src/mbgl/renderer/sources/render_vector_source.hpp
+++ b/src/mbgl/renderer/sources/render_vector_source.hpp
@@ -21,7 +21,7 @@ public:
     void startRender(Painter&) final;
     void finishRender(Painter&) final;
 
-    std::map<UnwrappedTileID, RenderTile>& getRenderTiles() final;
+    std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() final;
 
     std::unordered_map<std::string, std::vector<Feature>>
     queryRenderedFeatures(const ScreenLineString& geometry,

--- a/src/mbgl/renderer/tile_pyramid.hpp
+++ b/src/mbgl/renderer/tile_pyramid.hpp
@@ -45,7 +45,7 @@ public:
     void startRender(Painter&);
     void finishRender(Painter&);
 
-    std::map<UnwrappedTileID, RenderTile>& getRenderTiles();
+    std::vector<std::reference_wrapper<RenderTile>> getRenderTiles();
 
     std::unordered_map<std::string, std::vector<Feature>>
     queryRenderedFeatures(const ScreenLineString& geometry,
@@ -68,7 +68,7 @@ public:
     std::map<OverscaledTileID, std::unique_ptr<Tile>> tiles;
     TileCache cache;
 
-    std::map<UnwrappedTileID, RenderTile> renderTiles;
+    std::vector<RenderTile> renderTiles;
 
     TileObserver* observer = nullptr;
 };

--- a/test/algorithm/generate_clip_ids.test.cpp
+++ b/test/algorithm/generate_clip_ids.test.cpp
@@ -5,6 +5,7 @@
 using namespace mbgl;
 
 struct Renderable {
+    UnwrappedTileID id;
     ClipID clip;
     bool used = true;
 
@@ -14,59 +15,28 @@ struct Renderable {
 };
 
 ::std::ostream& operator<<(::std::ostream& os, const Renderable& rhs) {
-    return os << "ClipID(" << rhs.clip << ")";
+    return os << "Renderable{ " << rhs.id <<  ", " << rhs.clip << " }";
 }
 
-namespace {
-
-// void print(const std::map<UnwrappedTileID, Renderable>& renderables) {
-//     std::cout << "    EXPECT_EQ(decltype(renderables)({" << std::endl;
-//     for (auto& pair : renderables) {
-//         std::cout << "              { UnwrappedTileID{ " << int(pair.first.canonical.z) << ", "
-//                   << (int64_t(pair.first.canonical.x) +
-//                       pair.first.wrap * (1ll << pair.first.canonical.z))
-//                   << ", " << pair.first.canonical.y << " }, Renderable{ ClipID{ \""
-//                   << pair.second.clip.mask << "\", \"" << pair.second.clip.reference << "\" } } },"
-//                   << std::endl;
-//     }
-//     std::cout << "          })," << std::endl;
-//     std::cout << "          renderables);" << std::endl;
-// }
-
-// void print(const std::map<UnwrappedTileID, ClipID>& stencils) {
-//     std::cout << "    EXPECT_EQ(decltype(stencils)({" << std::endl;
-//     for (auto& pair : stencils) {
-//         std::cout << "              { UnwrappedTileID{ " << int(pair.first.canonical.z) << ", "
-//                   << (int64_t(pair.first.canonical.x) +
-//                       pair.first.wrap * (1ll << pair.first.canonical.z))
-//                   << ", " << pair.first.canonical.y << " }, ClipID{ \"" << pair.second.mask
-//                   << "\", \"" << pair.second.reference << "\" } }," << std::endl;
-//     }
-//     std::cout << "          })," << std::endl;
-//     std::cout << "          stencils);" << std::endl;
-// }
-
-} // end namespace
-
 TEST(GenerateClipIDs, ParentAndFourChildren) {
-    std::map<UnwrappedTileID, Renderable> renderables{
-        { UnwrappedTileID{ 0, 0, 0 }, Renderable{ {} } },
+    std::vector<Renderable> renderables{
+        Renderable{ UnwrappedTileID{ 0, 0, 0 }, {} },
         // All four covering children
-        { UnwrappedTileID{ 1, 0, 0 }, Renderable{ {} } },
-        { UnwrappedTileID{ 1, 0, 1 }, Renderable{ {} } },
-        { UnwrappedTileID{ 1, 1, 0 }, Renderable{ {} } },
-        { UnwrappedTileID{ 1, 1, 1 }, Renderable{ {} } },
+        Renderable{ UnwrappedTileID{ 1, 0, 0 }, {} },
+        Renderable{ UnwrappedTileID{ 1, 0, 1 }, {} },
+        Renderable{ UnwrappedTileID{ 1, 1, 0 }, {} },
+        Renderable{ UnwrappedTileID{ 1, 1, 1 }, {} },
     };
 
     algorithm::ClipIDGenerator generator;
-    generator.update(renderables);
+    generator.update<Renderable>({ renderables.begin(), renderables.end() });
 
     EXPECT_EQ(decltype(renderables)({
-                  { UnwrappedTileID{ 0, 0, 0 }, Renderable{ ClipID{ "00000111", "00000001" } } },
-                  { UnwrappedTileID{ 1, 0, 0 }, Renderable{ ClipID{ "00000111", "00000010" } } },
-                  { UnwrappedTileID{ 1, 0, 1 }, Renderable{ ClipID{ "00000111", "00000011" } } },
-                  { UnwrappedTileID{ 1, 1, 0 }, Renderable{ ClipID{ "00000111", "00000100" } } },
-                  { UnwrappedTileID{ 1, 1, 1 }, Renderable{ ClipID{ "00000111", "00000101" } } },
+                  Renderable{ UnwrappedTileID{ 0, 0, 0 }, ClipID{ "00000111", "00000001" } },
+                  Renderable{ UnwrappedTileID{ 1, 0, 0 }, ClipID{ "00000111", "00000010" } },
+                  Renderable{ UnwrappedTileID{ 1, 0, 1 }, ClipID{ "00000111", "00000011" } },
+                  Renderable{ UnwrappedTileID{ 1, 1, 0 }, ClipID{ "00000111", "00000100" } },
+                  Renderable{ UnwrappedTileID{ 1, 1, 1 }, ClipID{ "00000111", "00000101" } },
               }),
               renderables);
 
@@ -82,23 +52,23 @@ TEST(GenerateClipIDs, ParentAndFourChildren) {
 }
 
 TEST(GenerateClipIDs, ParentAndFourChildrenNegative) {
-    std::map<UnwrappedTileID, Renderable> renderables{
-        { UnwrappedTileID{ 1, -2, 0 }, Renderable{ {} } },
-        { UnwrappedTileID{ 1, -2, 1 }, Renderable{ {} } },
-        { UnwrappedTileID{ 1, -1, 0 }, Renderable{ {} } },
-        { UnwrappedTileID{ 1, -1, 1 }, Renderable{ {} } },
-        { UnwrappedTileID{ 0, -1, 0 }, Renderable{ {} } },
+    std::vector<Renderable> renderables{
+        Renderable{ UnwrappedTileID{ 1, -2, 0 }, {} },
+        Renderable{ UnwrappedTileID{ 1, -2, 1 }, {} },
+        Renderable{ UnwrappedTileID{ 1, -1, 0 }, {} },
+        Renderable{ UnwrappedTileID{ 1, -1, 1 }, {} },
+        Renderable{ UnwrappedTileID{ 0, -1, 0 }, {} },
     };
 
     algorithm::ClipIDGenerator generator;
-    generator.update(renderables);
+    generator.update<Renderable>({ renderables.begin(), renderables.end() });
 
     EXPECT_EQ(decltype(renderables)({
-                  { UnwrappedTileID{ 0, -1, 0 }, Renderable{ ClipID{ "00000111", "00000001" } } },
-                  { UnwrappedTileID{ 1, -2, 0 }, Renderable{ ClipID{ "00000111", "00000010" } } },
-                  { UnwrappedTileID{ 1, -2, 1 }, Renderable{ ClipID{ "00000111", "00000011" } } },
-                  { UnwrappedTileID{ 1, -1, 0 }, Renderable{ ClipID{ "00000111", "00000100" } } },
-                  { UnwrappedTileID{ 1, -1, 1 }, Renderable{ ClipID{ "00000111", "00000101" } } },
+                  Renderable{ UnwrappedTileID{ 1, -2, 0 }, ClipID{ "00000111", "00000010" } },
+                  Renderable{ UnwrappedTileID{ 1, -2, 1 }, ClipID{ "00000111", "00000011" } },
+                  Renderable{ UnwrappedTileID{ 1, -1, 0 }, ClipID{ "00000111", "00000100" } },
+                  Renderable{ UnwrappedTileID{ 1, -1, 1 }, ClipID{ "00000111", "00000101" } },
+                  Renderable{ UnwrappedTileID{ 0, -1, 0 }, ClipID{ "00000111", "00000001" } },
               }),
               renderables);
 
@@ -113,23 +83,23 @@ TEST(GenerateClipIDs, ParentAndFourChildrenNegative) {
 }
 
 TEST(GenerateClipIDs, NegativeParentAndMissingLevel) {
-    std::map<UnwrappedTileID, Renderable> renderables{
-        { UnwrappedTileID{ 1, -1, 0 }, Renderable{ {} } },
-        { UnwrappedTileID{ 2, -1, 0 }, Renderable{ {} } },
-        { UnwrappedTileID{ 2, -2, 1 }, Renderable{ {} } },
-        { UnwrappedTileID{ 2, -1, 1 }, Renderable{ {} } },
-        { UnwrappedTileID{ 2, -2, 0 }, Renderable{ {} } },
+    std::vector<Renderable> renderables{
+        Renderable{ UnwrappedTileID{ 1, -1, 0 }, {} },
+        Renderable{ UnwrappedTileID{ 2, -1, 0 }, {} },
+        Renderable{ UnwrappedTileID{ 2, -2, 1 }, {} },
+        Renderable{ UnwrappedTileID{ 2, -1, 1 }, {} },
+        Renderable{ UnwrappedTileID{ 2, -2, 0 }, {} },
     };
 
     algorithm::ClipIDGenerator generator;
-    generator.update(renderables);
+    generator.update<Renderable>({ renderables.begin(), renderables.end() });
 
     EXPECT_EQ(decltype(renderables)({
-                  { UnwrappedTileID{ 1, -1, 0 }, Renderable{ ClipID{ "00000111", "00000001" } } },
-                  { UnwrappedTileID{ 2, -2, 0 }, Renderable{ ClipID{ "00000111", "00000010" } } },
-                  { UnwrappedTileID{ 2, -2, 1 }, Renderable{ ClipID{ "00000111", "00000011" } } },
-                  { UnwrappedTileID{ 2, -1, 0 }, Renderable{ ClipID{ "00000111", "00000100" } } },
-                  { UnwrappedTileID{ 2, -1, 1 }, Renderable{ ClipID{ "00000111", "00000101" } } },
+                  Renderable{ UnwrappedTileID{ 1, -1, 0 }, ClipID{ "00000111", "00000001" } },
+                  Renderable{ UnwrappedTileID{ 2, -1, 0 }, ClipID{ "00000111", "00000100" } },
+                  Renderable{ UnwrappedTileID{ 2, -2, 1 }, ClipID{ "00000111", "00000011" } },
+                  Renderable{ UnwrappedTileID{ 2, -1, 1 }, ClipID{ "00000111", "00000101" } },
+                  Renderable{ UnwrappedTileID{ 2, -2, 0 }, ClipID{ "00000111", "00000010" } },
               }),
               renderables);
 
@@ -144,29 +114,29 @@ TEST(GenerateClipIDs, NegativeParentAndMissingLevel) {
 }
 
 TEST(GenerateClipIDs, SevenOnSameLevel) {
-    std::map<UnwrappedTileID, Renderable> renderables{
+    std::vector<Renderable> renderables{
         // first column
-        { UnwrappedTileID{ 2, 0, 0 }, Renderable{ {} } },
-        { UnwrappedTileID{ 2, 0, 1 }, Renderable{ {} } },
-        { UnwrappedTileID{ 2, 0, 2 }, Renderable{ {} } },
+        Renderable{ UnwrappedTileID{ 2, 0, 0 }, {} },
+        Renderable{ UnwrappedTileID{ 2, 0, 1 }, {} },
+        Renderable{ UnwrappedTileID{ 2, 0, 2 }, {} },
         // second column
-        { UnwrappedTileID{ 2, 1, 0 }, Renderable{ {} } },
-        { UnwrappedTileID{ 2, 1, 1 }, Renderable{ {} } },
-        { UnwrappedTileID{ 2, 1, 2 }, Renderable{ {} } },
+        Renderable{ UnwrappedTileID{ 2, 1, 0 }, {} },
+        Renderable{ UnwrappedTileID{ 2, 1, 1 }, {} },
+        Renderable{ UnwrappedTileID{ 2, 1, 2 }, {} },
         // third column
-        { UnwrappedTileID{ 2, 2, 0 }, Renderable{ {} } },
+        Renderable{ UnwrappedTileID{ 2, 2, 0 }, {} },
     };
 
     algorithm::ClipIDGenerator generator;
-    generator.update(renderables);
+    generator.update<Renderable>({ renderables.begin(), renderables.end() });
     EXPECT_EQ(decltype(renderables)({
-                  { UnwrappedTileID{ 2, 0, 0 }, Renderable{ ClipID{ "00000111", "00000001" } } },
-                  { UnwrappedTileID{ 2, 0, 1 }, Renderable{ ClipID{ "00000111", "00000010" } } },
-                  { UnwrappedTileID{ 2, 0, 2 }, Renderable{ ClipID{ "00000111", "00000011" } } },
-                  { UnwrappedTileID{ 2, 1, 0 }, Renderable{ ClipID{ "00000111", "00000100" } } },
-                  { UnwrappedTileID{ 2, 1, 1 }, Renderable{ ClipID{ "00000111", "00000101" } } },
-                  { UnwrappedTileID{ 2, 1, 2 }, Renderable{ ClipID{ "00000111", "00000110" } } },
-                  { UnwrappedTileID{ 2, 2, 0 }, Renderable{ ClipID{ "00000111", "00000111" } } },
+                  Renderable{ UnwrappedTileID{ 2, 0, 0 }, ClipID{ "00000111", "00000001" } },
+                  Renderable{ UnwrappedTileID{ 2, 0, 1 }, ClipID{ "00000111", "00000010" } },
+                  Renderable{ UnwrappedTileID{ 2, 0, 2 }, ClipID{ "00000111", "00000011" } },
+                  Renderable{ UnwrappedTileID{ 2, 1, 0 }, ClipID{ "00000111", "00000100" } },
+                  Renderable{ UnwrappedTileID{ 2, 1, 1 }, ClipID{ "00000111", "00000101" } },
+                  Renderable{ UnwrappedTileID{ 2, 1, 2 }, ClipID{ "00000111", "00000110" } },
+                  Renderable{ UnwrappedTileID{ 2, 2, 0 }, ClipID{ "00000111", "00000111" } },
               }),
               renderables);
 
@@ -184,42 +154,42 @@ TEST(GenerateClipIDs, SevenOnSameLevel) {
 }
 
 TEST(GenerateClipIDs, MultipleLevels) {
-    std::map<UnwrappedTileID, Renderable> renderables{
-        { UnwrappedTileID{ 2, 0, 0 }, Renderable{ {} } },
+    std::vector<Renderable> renderables{
+        Renderable{ UnwrappedTileID{ 2, 0, 0 }, {} },
         // begin subtiles of (2/0/0)
-        { UnwrappedTileID{ 3, 0, 0 }, Renderable{ {} } },
-        { UnwrappedTileID{ 3, 0, 1 }, Renderable{ {} } },
+        Renderable{ UnwrappedTileID{ 3, 0, 0 }, {} },
+        Renderable{ UnwrappedTileID{ 3, 0, 1 }, {} },
         // begin subtiles of (3/0/1)
-        { UnwrappedTileID{ 4, 0, 2 }, Renderable{ {} } },
-        { UnwrappedTileID{ 4, 1, 2 }, Renderable{ {} } },
-        { UnwrappedTileID{ 4, 0, 3 }, Renderable{ {} } },
-        { UnwrappedTileID{ 4, 1, 3 }, Renderable{ {} } },
+        Renderable{ UnwrappedTileID{ 4, 0, 2 }, {} },
+        Renderable{ UnwrappedTileID{ 4, 1, 2 }, {} },
+        Renderable{ UnwrappedTileID{ 4, 0, 3 }, {} },
+        Renderable{ UnwrappedTileID{ 4, 1, 3 }, {} },
         // end subtiles of (3/0/1)
-        { UnwrappedTileID{ 3, 1, 0 }, Renderable{ {} } },
-        { UnwrappedTileID{ 3, 1, 1 }, Renderable{ {} } },
+        Renderable{ UnwrappedTileID{ 3, 1, 0 }, {} },
+        Renderable{ UnwrappedTileID{ 3, 1, 1 }, {} },
         // end subtiles of (2/0/0)
-        { UnwrappedTileID{ 2, 1, 0 }, Renderable{ {} } },
+        Renderable{ UnwrappedTileID{ 2, 1, 0 }, {} },
         // begin subtiles of (2/1/0)
-        { UnwrappedTileID{ 3, 2, 0 }, Renderable{ {} } },
-        { UnwrappedTileID{ 3, 2, 1 }, Renderable{ {} } },
+        Renderable{ UnwrappedTileID{ 3, 2, 0 }, {} },
+        Renderable{ UnwrappedTileID{ 3, 2, 1 }, {} },
         // end subtiles of (2/1/0)
     };
 
     algorithm::ClipIDGenerator generator;
-    generator.update(renderables);
+    generator.update<Renderable>({ renderables.begin(), renderables.end() });
     ASSERT_EQ(decltype(renderables)({
-                  { UnwrappedTileID{ 2, 0, 0 }, Renderable{ ClipID{ "00001111", "00000001" } } },
-                  { UnwrappedTileID{ 2, 1, 0 }, Renderable{ ClipID{ "00001111", "00000010" } } },
-                  { UnwrappedTileID{ 3, 0, 0 }, Renderable{ ClipID{ "00001111", "00000011" } } },
-                  { UnwrappedTileID{ 3, 0, 1 }, Renderable{ ClipID{ "00001111", "00000100" } } },
-                  { UnwrappedTileID{ 3, 1, 0 }, Renderable{ ClipID{ "00001111", "00000101" } } },
-                  { UnwrappedTileID{ 3, 1, 1 }, Renderable{ ClipID{ "00001111", "00000110" } } },
-                  { UnwrappedTileID{ 3, 2, 0 }, Renderable{ ClipID{ "00001111", "00000111" } } },
-                  { UnwrappedTileID{ 3, 2, 1 }, Renderable{ ClipID{ "00001111", "00001000" } } },
-                  { UnwrappedTileID{ 4, 0, 2 }, Renderable{ ClipID{ "00001111", "00001001" } } },
-                  { UnwrappedTileID{ 4, 0, 3 }, Renderable{ ClipID{ "00001111", "00001010" } } },
-                  { UnwrappedTileID{ 4, 1, 2 }, Renderable{ ClipID{ "00001111", "00001011" } } },
-                  { UnwrappedTileID{ 4, 1, 3 }, Renderable{ ClipID{ "00001111", "00001100" } } },
+                  Renderable{ UnwrappedTileID{ 2, 0, 0 }, ClipID{ "00001111", "00000001" } },
+                  Renderable{ UnwrappedTileID{ 3, 0, 0 }, ClipID{ "00001111", "00000011" } },
+                  Renderable{ UnwrappedTileID{ 3, 0, 1 }, ClipID{ "00001111", "00000100" } },
+                  Renderable{ UnwrappedTileID{ 4, 0, 2 }, ClipID{ "00001111", "00001001" } },
+                  Renderable{ UnwrappedTileID{ 4, 1, 2 }, ClipID{ "00001111", "00001011" } },
+                  Renderable{ UnwrappedTileID{ 4, 0, 3 }, ClipID{ "00001111", "00001010" } },
+                  Renderable{ UnwrappedTileID{ 4, 1, 3 }, ClipID{ "00001111", "00001100" } },
+                  Renderable{ UnwrappedTileID{ 3, 1, 0 }, ClipID{ "00001111", "00000101" } },
+                  Renderable{ UnwrappedTileID{ 3, 1, 1 }, ClipID{ "00001111", "00000110" } },
+                  Renderable{ UnwrappedTileID{ 2, 1, 0 }, ClipID{ "00001111", "00000010" } },
+                  Renderable{ UnwrappedTileID{ 3, 2, 0 }, ClipID{ "00001111", "00000111" } },
+                  Renderable{ UnwrappedTileID{ 3, 2, 1 }, ClipID{ "00001111", "00001000" } },
               }),
               renderables);
 
@@ -240,37 +210,37 @@ TEST(GenerateClipIDs, MultipleLevels) {
 }
 
 TEST(GenerateClipIDs, Bug206) {
-    std::map<UnwrappedTileID, Renderable> renderables{
-        { UnwrappedTileID{ 10, 162, 395 }, Renderable{ {} } },
-        { UnwrappedTileID{ 10, 162, 396 }, Renderable{ {} } },
-        { UnwrappedTileID{ 10, 163, 395 }, Renderable{ {} } },
+    std::vector<Renderable> renderables{
+        Renderable{ UnwrappedTileID{ 10, 162, 395 }, {} },
+        Renderable{ UnwrappedTileID{ 10, 162, 396 }, {} },
+        Renderable{ UnwrappedTileID{ 10, 163, 395 }, {} },
         // begin subtiles of (10/163/395)
-        { UnwrappedTileID{ 11, 326, 791 }, Renderable{ {} } },
-        { UnwrappedTileID{ 12, 654, 1582 }, Renderable{ {} } },
-        { UnwrappedTileID{ 12, 654, 1583 }, Renderable{ {} } },
-        { UnwrappedTileID{ 12, 655, 1582 }, Renderable{ {} } },
-        { UnwrappedTileID{ 12, 655, 1583 }, Renderable{ {} } },
+        Renderable{ UnwrappedTileID{ 11, 326, 791 }, {} },
+        Renderable{ UnwrappedTileID{ 12, 654, 1582 }, {} },
+        Renderable{ UnwrappedTileID{ 12, 654, 1583 }, {} },
+        Renderable{ UnwrappedTileID{ 12, 655, 1582 }, {} },
+        Renderable{ UnwrappedTileID{ 12, 655, 1583 }, {} },
         // end subtiles of (10/163/395)
-        { UnwrappedTileID{ 10, 163, 396 }, Renderable{ {} } },
-        { UnwrappedTileID{ 10, 164, 395 }, Renderable{ {} } },
-        { UnwrappedTileID{ 10, 164, 396 }, Renderable{ {} } },
+        Renderable{ UnwrappedTileID{ 10, 163, 396 }, {} },
+        Renderable{ UnwrappedTileID{ 10, 164, 395 }, {} },
+        Renderable{ UnwrappedTileID{ 10, 164, 396 }, {} },
     };
 
     algorithm::ClipIDGenerator generator;
-    generator.update(renderables);
+    generator.update<Renderable>({ renderables.begin(), renderables.end() });
     EXPECT_EQ(
         decltype(renderables)({
-            { UnwrappedTileID{ 10, 162, 395 }, Renderable{ ClipID{ "00001111", "00000001" } } },
-            { UnwrappedTileID{ 10, 162, 396 }, Renderable{ ClipID{ "00001111", "00000010" } } },
-            { UnwrappedTileID{ 10, 163, 395 }, Renderable{ ClipID{ "00001111", "00000011" } } },
-            { UnwrappedTileID{ 10, 163, 396 }, Renderable{ ClipID{ "00001111", "00000100" } } },
-            { UnwrappedTileID{ 10, 164, 395 }, Renderable{ ClipID{ "00001111", "00000101" } } },
-            { UnwrappedTileID{ 10, 164, 396 }, Renderable{ ClipID{ "00001111", "00000110" } } },
-            { UnwrappedTileID{ 11, 326, 791 }, Renderable{ ClipID{ "00001111", "00000111" } } },
-            { UnwrappedTileID{ 12, 654, 1582 }, Renderable{ ClipID{ "00001111", "00001000" } } },
-            { UnwrappedTileID{ 12, 654, 1583 }, Renderable{ ClipID{ "00001111", "00001001" } } },
-            { UnwrappedTileID{ 12, 655, 1582 }, Renderable{ ClipID{ "00001111", "00001010" } } },
-            { UnwrappedTileID{ 12, 655, 1583 }, Renderable{ ClipID{ "00001111", "00001011" } } },
+            Renderable{ UnwrappedTileID{ 10, 162, 395 }, ClipID{ "00001111", "00000001" } },
+            Renderable{ UnwrappedTileID{ 10, 162, 396 }, ClipID{ "00001111", "00000010" } },
+            Renderable{ UnwrappedTileID{ 10, 163, 395 }, ClipID{ "00001111", "00000011" } },
+            Renderable{ UnwrappedTileID{ 11, 326, 791 }, ClipID{ "00001111", "00000111" } },
+            Renderable{ UnwrappedTileID{ 12, 654, 1582 }, ClipID{ "00001111", "00001000" } },
+            Renderable{ UnwrappedTileID{ 12, 654, 1583 }, ClipID{ "00001111", "00001001" } },
+            Renderable{ UnwrappedTileID{ 12, 655, 1582 }, ClipID{ "00001111", "00001010" } },
+            Renderable{ UnwrappedTileID{ 12, 655, 1583 }, ClipID{ "00001111", "00001011" } },
+            Renderable{ UnwrappedTileID{ 10, 163, 396 }, ClipID{ "00001111", "00000100" } },
+            Renderable{ UnwrappedTileID{ 10, 164, 395 }, ClipID{ "00001111", "00000101" } },
+            Renderable{ UnwrappedTileID{ 10, 164, 396 }, ClipID{ "00001111", "00000110" } },
         }),
         renderables);
 
@@ -292,53 +262,53 @@ TEST(GenerateClipIDs, Bug206) {
 }
 
 TEST(GenerateClipIDs, MultipleSources) {
-    std::map<UnwrappedTileID, Renderable> renderables1{
-        { UnwrappedTileID{ 0, 0, 0 }, Renderable{ {} } },
-        { UnwrappedTileID{ 1, 1, 1 }, Renderable{ {} } },
+    std::vector<Renderable> renderables1{
+        Renderable{ UnwrappedTileID{ 0, 0, 0 }, {} },
+        Renderable{ UnwrappedTileID{ 1, 1, 1 }, {} },
         // Differing children
-        { UnwrappedTileID{ 2, 2, 1 }, Renderable{ {} } },
-        { UnwrappedTileID{ 2, 2, 2 }, Renderable{ {} } },
+        Renderable{ UnwrappedTileID{ 2, 2, 1 }, {} },
+        Renderable{ UnwrappedTileID{ 2, 2, 2 }, {} },
     };
-    std::map<UnwrappedTileID, Renderable> renderables2{
-        { UnwrappedTileID{ 0, 0, 0 }, Renderable{ {} } },
-        { UnwrappedTileID{ 1, 1, 1 }, Renderable{ {} } },
+    std::vector<Renderable> renderables2{
+        Renderable{ UnwrappedTileID{ 0, 0, 0 }, {} },
+        Renderable{ UnwrappedTileID{ 1, 1, 1 }, {} },
         // Differing children
-        { UnwrappedTileID{ 2, 1, 1 }, Renderable{ {} } },
-        { UnwrappedTileID{ 2, 2, 2 }, Renderable{ {} } },
+        Renderable{ UnwrappedTileID{ 2, 1, 1 }, {} },
+        Renderable{ UnwrappedTileID{ 2, 2, 2 }, {} },
     };
-    std::map<UnwrappedTileID, Renderable> renderables3{
-        { UnwrappedTileID{ 1, 0, 0 }, Renderable{ {} } },
-        { UnwrappedTileID{ 1, 0, 1 }, Renderable{ {} } },
-        { UnwrappedTileID{ 1, 1, 0 }, Renderable{ {} } },
-        { UnwrappedTileID{ 1, 1, 1 }, Renderable{ {} } },
+    std::vector<Renderable> renderables3{
+        Renderable{ UnwrappedTileID{ 1, 0, 0 }, {} },
+        Renderable{ UnwrappedTileID{ 1, 0, 1 }, {} },
+        Renderable{ UnwrappedTileID{ 1, 1, 0 }, {} },
+        Renderable{ UnwrappedTileID{ 1, 1, 1 }, {} },
         // Differing children
-        { UnwrappedTileID{ 2, 1, 1 }, Renderable{ {} } },
+        Renderable{ UnwrappedTileID{ 2, 1, 1 }, {} },
     };
 
     algorithm::ClipIDGenerator generator;
-    generator.update(renderables1);
-    generator.update(renderables2);
-    generator.update(renderables3);
+    generator.update<Renderable>({ renderables1.begin(), renderables1.end() });
+    generator.update<Renderable>({ renderables2.begin(), renderables2.end() });
+    generator.update<Renderable>({ renderables3.begin(), renderables3.end() });
     EXPECT_EQ(decltype(renderables1)({
-                  { UnwrappedTileID{ 0, 0, 0 }, Renderable{ ClipID{ "00000111", "00000001" } } },
-                  { UnwrappedTileID{ 1, 1, 1 }, Renderable{ ClipID{ "00000111", "00000010" } } },
-                  { UnwrappedTileID{ 2, 2, 1 }, Renderable{ ClipID{ "00000111", "00000011" } } },
-                  { UnwrappedTileID{ 2, 2, 2 }, Renderable{ ClipID{ "00000111", "00000100" } } },
+                  Renderable{ UnwrappedTileID{ 0, 0, 0 }, ClipID{ "00000111", "00000001" } },
+                  Renderable{ UnwrappedTileID{ 1, 1, 1 }, ClipID{ "00000111", "00000010" } },
+                  Renderable{ UnwrappedTileID{ 2, 2, 1 }, ClipID{ "00000111", "00000011" } },
+                  Renderable{ UnwrappedTileID{ 2, 2, 2 }, ClipID{ "00000111", "00000100" } },
               }),
               renderables1);
     EXPECT_EQ(decltype(renderables2)({
-                  { UnwrappedTileID{ 0, 0, 0 }, Renderable{ ClipID{ "00011000", "00001000" } } },
-                  { UnwrappedTileID{ 1, 1, 1 }, Renderable{ ClipID{ "00011111", "00000010" } } },
-                  { UnwrappedTileID{ 2, 1, 1 }, Renderable{ ClipID{ "00011000", "00010000" } } },
-                  { UnwrappedTileID{ 2, 2, 2 }, Renderable{ ClipID{ "00011111", "00000100" } } },
+                  Renderable{ UnwrappedTileID{ 0, 0, 0 }, ClipID{ "00011000", "00001000" } },
+                  Renderable{ UnwrappedTileID{ 1, 1, 1 }, ClipID{ "00011111", "00000010" } },
+                  Renderable{ UnwrappedTileID{ 2, 1, 1 }, ClipID{ "00011000", "00010000" } },
+                  Renderable{ UnwrappedTileID{ 2, 2, 2 }, ClipID{ "00011111", "00000100" } },
               }),
               renderables2);
     EXPECT_EQ(decltype(renderables3)({
-                  { UnwrappedTileID{ 1, 0, 0 }, Renderable{ ClipID{ "11100000", "00100000" } } },
-                  { UnwrappedTileID{ 1, 0, 1 }, Renderable{ ClipID{ "11100000", "01000000" } } },
-                  { UnwrappedTileID{ 1, 1, 0 }, Renderable{ ClipID{ "11100000", "01100000" } } },
-                  { UnwrappedTileID{ 1, 1, 1 }, Renderable{ ClipID{ "11100000", "10000000" } } },
-                  { UnwrappedTileID{ 2, 1, 1 }, Renderable{ ClipID{ "11111000", "00010000" } } },
+                  Renderable{ UnwrappedTileID{ 1, 0, 0 }, ClipID{ "11100000", "00100000" } },
+                  Renderable{ UnwrappedTileID{ 1, 0, 1 }, ClipID{ "11100000", "01000000" } },
+                  Renderable{ UnwrappedTileID{ 1, 1, 0 }, ClipID{ "11100000", "01100000" } },
+                  Renderable{ UnwrappedTileID{ 1, 1, 1 }, ClipID{ "11100000", "10000000" } },
+                  Renderable{ UnwrappedTileID{ 2, 1, 1 }, ClipID{ "11111000", "00010000" } },
               }),
               renderables3);
 
@@ -356,27 +326,28 @@ TEST(GenerateClipIDs, MultipleSources) {
 }
 
 TEST(GenerateClipIDs, DuplicateIDs) {
-    std::map<UnwrappedTileID, Renderable> renderables1{
-        { UnwrappedTileID{ 2, 0, 0 }, Renderable{ {} } },
-        { UnwrappedTileID{ 2, 0, 1 }, Renderable{ {} } },
+    std::vector<Renderable> renderables1{
+        Renderable{ UnwrappedTileID{ 2, 0, 0 }, {} },
+        Renderable{ UnwrappedTileID{ 2, 0, 1 }, {} },
     };
-    std::map<UnwrappedTileID, Renderable> renderables2{
-        { UnwrappedTileID{ 2, 0, 0 }, Renderable{ {} } },
-        { UnwrappedTileID{ 2, 0, 1 }, Renderable{ {} } },
-        { UnwrappedTileID{ 2, 0, 1 }, Renderable{ {} } },
+    std::vector<Renderable> renderables2{
+        Renderable{ UnwrappedTileID{ 2, 0, 0 }, {} },
+        Renderable{ UnwrappedTileID{ 2, 0, 1 }, {} },
+        Renderable{ UnwrappedTileID{ 2, 0, 1 }, {} },
     };
 
     algorithm::ClipIDGenerator generator;
-    generator.update(renderables1);
-    generator.update(renderables2);
+    generator.update<Renderable>({ renderables1.begin(), renderables1.end() });
+    generator.update<Renderable>({ renderables2.begin(), renderables2.end() });
     EXPECT_EQ(decltype(renderables1)({
-                  { UnwrappedTileID{ 2, 0, 0 }, Renderable{ ClipID{ "00000011", "00000001" } } },
-                  { UnwrappedTileID{ 2, 0, 1 }, Renderable{ ClipID{ "00000011", "00000010" } } },
+                  Renderable{ UnwrappedTileID{ 2, 0, 0 }, ClipID{ "00000011", "00000001" } },
+                  Renderable{ UnwrappedTileID{ 2, 0, 1 }, ClipID{ "00000011", "00000010" } },
               }),
               renderables1);
     EXPECT_EQ(decltype(renderables2)({
-                  { UnwrappedTileID{ 2, 0, 0 }, Renderable{ ClipID{ "00000011", "00000001" } } },
-                  { UnwrappedTileID{ 2, 0, 1 }, Renderable{ ClipID{ "00000011", "00000010" } } },
+                  Renderable{ UnwrappedTileID{ 2, 0, 0 }, ClipID{ "00000011", "00000001" } },
+                  Renderable{ UnwrappedTileID{ 2, 0, 1 }, ClipID{ "00000011", "00000010" } },
+                  Renderable{ UnwrappedTileID{ 2, 0, 1 }, ClipID{ "00000011", "00000010" } },
               }),
               renderables2);
 
@@ -389,33 +360,33 @@ TEST(GenerateClipIDs, DuplicateIDs) {
 }
 
 TEST(GenerateClipIDs, SecondSourceHasParentOfFirstSource) {
-    std::map<UnwrappedTileID, Renderable> renderables1{
-        { UnwrappedTileID{ 1, 0, 0 }, Renderable{ {} } },
+    std::vector<Renderable> renderables1{
+        Renderable{ UnwrappedTileID{ 1, 0, 0 }, {} },
     };
-    std::map<UnwrappedTileID, Renderable> renderables2{
-        { UnwrappedTileID{ 0, 0, 0 }, Renderable{ {} } },
+    std::vector<Renderable> renderables2{
+        Renderable{ UnwrappedTileID{ 0, 0, 0 }, {} },
         // Same as in renderables1, but has a parent that it knocks out.
-        { UnwrappedTileID{ 1, 0, 0 }, Renderable{ {} } },
+        Renderable{ UnwrappedTileID{ 1, 0, 0 }, {} },
     };
-    std::map<UnwrappedTileID, Renderable> renderables3{
-        { UnwrappedTileID{ 0, 0, 0 }, Renderable{ {} } },
+    std::vector<Renderable> renderables3{
+        Renderable{ UnwrappedTileID{ 0, 0, 0 }, {} },
     };
 
     algorithm::ClipIDGenerator generator;
-    generator.update(renderables1);
-    generator.update(renderables2);
-    generator.update(renderables3);
+    generator.update<Renderable>({ renderables1.begin(), renderables1.end() });
+    generator.update<Renderable>({ renderables2.begin(), renderables2.end() });
+    generator.update<Renderable>({ renderables3.begin(), renderables3.end() });
     EXPECT_EQ(decltype(renderables1)({
-                  { UnwrappedTileID{ 1, 0, 0 }, Renderable{ ClipID{ "00000001", "00000001" } } },
+                  Renderable{ UnwrappedTileID{ 1, 0, 0 }, ClipID{ "00000001", "00000001" } },
               }),
               renderables1);
     EXPECT_EQ(decltype(renderables2)({
-                  { UnwrappedTileID{ 0, 0, 0 }, Renderable{ ClipID{ "00000010", "00000010" } } },
-                  { UnwrappedTileID{ 1, 0, 0 }, Renderable{ ClipID{ "00000011", "00000001" } } },
+                  Renderable{ UnwrappedTileID{ 0, 0, 0 }, ClipID{ "00000010", "00000010" } },
+                  Renderable{ UnwrappedTileID{ 1, 0, 0 }, ClipID{ "00000011", "00000001" } },
               }),
               renderables2);
     EXPECT_EQ(decltype(renderables3)({
-                  { UnwrappedTileID{ 0, 0, 0 }, Renderable{ ClipID{ "00000100", "00000100" } } },
+                  Renderable{ UnwrappedTileID{ 0, 0, 0 }, ClipID{ "00000100", "00000100" } },
               }),
               renderables3);
 

--- a/test/algorithm/generate_clip_ids.test.cpp
+++ b/test/algorithm/generate_clip_ids.test.cpp
@@ -10,7 +10,7 @@ struct Renderable {
     bool used = true;
 
     bool operator==(const Renderable& rhs) const {
-        return clip == rhs.clip;
+        return id == rhs.id && clip == rhs.clip;
     }
 };
 

--- a/test/algorithm/generate_clip_ids.test.cpp
+++ b/test/algorithm/generate_clip_ids.test.cpp
@@ -40,15 +40,15 @@ TEST(GenerateClipIDs, ParentAndFourChildren) {
               }),
               renderables);
 
-    const auto stencils = generator.getStencils();
-    EXPECT_EQ(decltype(stencils)({
+    const auto clipIDs = generator.getClipIDs();
+    EXPECT_EQ(decltype(clipIDs)({
                   // 0/0/0 is missing because it is covered by children.
                   { UnwrappedTileID{ 1, 0, 0 }, ClipID{ "00000111", "00000010" } },
                   { UnwrappedTileID{ 1, 0, 1 }, ClipID{ "00000111", "00000011" } },
                   { UnwrappedTileID{ 1, 1, 0 }, ClipID{ "00000111", "00000100" } },
                   { UnwrappedTileID{ 1, 1, 1 }, ClipID{ "00000111", "00000101" } },
               }),
-              stencils);
+              clipIDs);
 }
 
 TEST(GenerateClipIDs, ParentAndFourChildrenNegative) {
@@ -72,14 +72,14 @@ TEST(GenerateClipIDs, ParentAndFourChildrenNegative) {
               }),
               renderables);
 
-    const auto stencils = generator.getStencils();
-    EXPECT_EQ(decltype(stencils)({
+    const auto clipIDs = generator.getClipIDs();
+    EXPECT_EQ(decltype(clipIDs)({
                   { UnwrappedTileID{ 1, -2, 0 }, ClipID{ "00000111", "00000010" } },
                   { UnwrappedTileID{ 1, -2, 1 }, ClipID{ "00000111", "00000011" } },
                   { UnwrappedTileID{ 1, -1, 0 }, ClipID{ "00000111", "00000100" } },
                   { UnwrappedTileID{ 1, -1, 1 }, ClipID{ "00000111", "00000101" } },
               }),
-              stencils);
+              clipIDs);
 }
 
 TEST(GenerateClipIDs, NegativeParentAndMissingLevel) {
@@ -103,14 +103,14 @@ TEST(GenerateClipIDs, NegativeParentAndMissingLevel) {
               }),
               renderables);
 
-    const auto stencils = generator.getStencils();
-    EXPECT_EQ(decltype(stencils)({
+    const auto clipIDs = generator.getClipIDs();
+    EXPECT_EQ(decltype(clipIDs)({
                   { UnwrappedTileID{ 2, -2, 0 }, ClipID{ "00000111", "00000010" } },
                   { UnwrappedTileID{ 2, -2, 1 }, ClipID{ "00000111", "00000011" } },
                   { UnwrappedTileID{ 2, -1, 0 }, ClipID{ "00000111", "00000100" } },
                   { UnwrappedTileID{ 2, -1, 1 }, ClipID{ "00000111", "00000101" } },
               }),
-              stencils);
+              clipIDs);
 }
 
 TEST(GenerateClipIDs, SevenOnSameLevel) {
@@ -140,8 +140,8 @@ TEST(GenerateClipIDs, SevenOnSameLevel) {
               }),
               renderables);
 
-    const auto stencils = generator.getStencils();
-    EXPECT_EQ(decltype(stencils)({
+    const auto clipIDs = generator.getClipIDs();
+    EXPECT_EQ(decltype(clipIDs)({
                   { UnwrappedTileID{ 2, 0, 0 }, ClipID{ "00000111", "00000001" } },
                   { UnwrappedTileID{ 2, 0, 1 }, ClipID{ "00000111", "00000010" } },
                   { UnwrappedTileID{ 2, 0, 2 }, ClipID{ "00000111", "00000011" } },
@@ -150,7 +150,7 @@ TEST(GenerateClipIDs, SevenOnSameLevel) {
                   { UnwrappedTileID{ 2, 1, 2 }, ClipID{ "00000111", "00000110" } },
                   { UnwrappedTileID{ 2, 2, 0 }, ClipID{ "00000111", "00000111" } },
               }),
-              stencils);
+              clipIDs);
 }
 
 TEST(GenerateClipIDs, MultipleLevels) {
@@ -193,8 +193,8 @@ TEST(GenerateClipIDs, MultipleLevels) {
               }),
               renderables);
 
-    const auto stencils = generator.getStencils();
-    EXPECT_EQ(decltype(stencils)({
+    const auto clipIDs = generator.getClipIDs();
+    EXPECT_EQ(decltype(clipIDs)({
                   { UnwrappedTileID{ 2, 1, 0 }, ClipID{ "00001111", "00000010" } },
                   { UnwrappedTileID{ 3, 0, 0 }, ClipID{ "00001111", "00000011" } },
                   { UnwrappedTileID{ 3, 1, 0 }, ClipID{ "00001111", "00000101" } },
@@ -206,7 +206,7 @@ TEST(GenerateClipIDs, MultipleLevels) {
                   { UnwrappedTileID{ 4, 1, 2 }, ClipID{ "00001111", "00001011" } },
                   { UnwrappedTileID{ 4, 1, 3 }, ClipID{ "00001111", "00001100" } },
               }),
-              stencils);
+              clipIDs);
 }
 
 TEST(GenerateClipIDs, Bug206) {
@@ -244,8 +244,8 @@ TEST(GenerateClipIDs, Bug206) {
         }),
         renderables);
 
-    const auto stencils = generator.getStencils();
-    EXPECT_EQ(decltype(stencils)({
+    const auto clipIDs = generator.getClipIDs();
+    EXPECT_EQ(decltype(clipIDs)({
                   { UnwrappedTileID{ 10, 162, 395 }, ClipID{ "00001111", "00000001" } },
                   { UnwrappedTileID{ 10, 162, 396 }, ClipID{ "00001111", "00000010" } },
                   { UnwrappedTileID{ 10, 163, 395 }, ClipID{ "00001111", "00000011" } },
@@ -258,7 +258,7 @@ TEST(GenerateClipIDs, Bug206) {
                   { UnwrappedTileID{ 12, 655, 1582 }, ClipID{ "00001111", "00001010" } },
                   { UnwrappedTileID{ 12, 655, 1583 }, ClipID{ "00001111", "00001011" } },
               }),
-              stencils);
+              clipIDs);
 }
 
 TEST(GenerateClipIDs, MultipleSources) {
@@ -312,8 +312,8 @@ TEST(GenerateClipIDs, MultipleSources) {
               }),
               renderables3);
 
-    const auto stencils = generator.getStencils();
-    EXPECT_EQ(decltype(stencils)({
+    const auto clipIDs = generator.getClipIDs();
+    EXPECT_EQ(decltype(clipIDs)({
                   { UnwrappedTileID{ 1, 0, 0 }, ClipID{ "11111111", "00101001" } },
                   { UnwrappedTileID{ 1, 0, 1 }, ClipID{ "11111111", "01001001" } },
                   { UnwrappedTileID{ 1, 1, 0 }, ClipID{ "11111111", "01101001" } },
@@ -322,7 +322,7 @@ TEST(GenerateClipIDs, MultipleSources) {
                   { UnwrappedTileID{ 2, 2, 1 }, ClipID{ "11111111", "01101011" } },
                   { UnwrappedTileID{ 2, 2, 2 }, ClipID{ "11111111", "10000100" } },
               }),
-              stencils);
+              clipIDs);
 }
 
 TEST(GenerateClipIDs, DuplicateIDs) {
@@ -351,12 +351,12 @@ TEST(GenerateClipIDs, DuplicateIDs) {
               }),
               renderables2);
 
-    const auto stencils = generator.getStencils();
-    EXPECT_EQ(decltype(stencils)({
+    const auto clipIDs = generator.getClipIDs();
+    EXPECT_EQ(decltype(clipIDs)({
                   { UnwrappedTileID{ 2, 0, 0 }, ClipID{ "00000011", "00000001" } },
                   { UnwrappedTileID{ 2, 0, 1 }, ClipID{ "00000011", "00000010" } },
               }),
-              stencils);
+              clipIDs);
 }
 
 TEST(GenerateClipIDs, SecondSourceHasParentOfFirstSource) {
@@ -390,10 +390,10 @@ TEST(GenerateClipIDs, SecondSourceHasParentOfFirstSource) {
               }),
               renderables3);
 
-    const auto stencils = generator.getStencils();
-    EXPECT_EQ(decltype(stencils)({
+    const auto clipIDs = generator.getClipIDs();
+    EXPECT_EQ(decltype(clipIDs)({
                   { UnwrappedTileID{ 0, 0, 0 }, ClipID{ "00000110", "00000110" } },
                   { UnwrappedTileID{ 1, 0, 0 }, ClipID{ "00000111", "00000101" } },
               }),
-              stencils);
+              clipIDs);
 }


### PR DESCRIPTION
This is a leftover for another refactor that I attempted, but I think it's useful to have it, since it removes the `std::map<>` in favor of a vector. This is possible because we don't do lookups in the `map` and don't rely on its uniqueness property.