### PR TITLE
Bucket test updates

### DIFF
--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -28,6 +28,9 @@ public:
     Bucket() = default;
     virtual ~Bucket() = default;
 
+    // Feature geometries are also used to populate the feature index.
+    // Obtaining these is a costly operation, so we do it only once, and
+    // pass-by-const-ref the geometries as a second parameter.
     virtual void addFeature(const GeometryTileFeature&,
                             const GeometryCollection&) {};
 
@@ -46,7 +49,7 @@ public:
     };
 
     bool needsUpload() const {
-        return !uploaded;
+        return hasData() && !uploaded;
     }
 
 protected:

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -69,8 +69,7 @@ void SymbolBucket::render(Painter& painter,
 }
 
 bool SymbolBucket::hasData() const {
-    assert(false); // Should be calling SymbolLayout::has{Text,Icon,CollisonBox}Data() instead.
-    return false;
+    return hasTextData() || hasIconData() || hasCollisionBoxData();
 }
 
 bool SymbolBucket::hasTextData() const {

--- a/test/gl/bucket.test.cpp
+++ b/test/gl/bucket.test.cpp
@@ -1,4 +1,5 @@
 #include <mbgl/test/util.hpp>
+#include <mbgl/test/stub_geometry_tile_feature.hpp>
 
 #include <mbgl/renderer/buckets/circle_bucket.hpp>
 #include <mbgl/renderer/buckets/fill_bucket.hpp>
@@ -14,20 +15,53 @@
 using namespace mbgl;
 
 TEST(Buckets, CircleBucket) {
+    gl::Context context;
     CircleBucket bucket { { {0, 0, 0}, MapMode::Still, 1.0 }, {} };
     ASSERT_FALSE(bucket.hasData());
+    ASSERT_FALSE(bucket.needsUpload());
+
+    GeometryCollection point { { { 0, 0 } } };
+    bucket.addFeature(StubGeometryTileFeature { {}, FeatureType::Point, point, {} }, point);
+    ASSERT_TRUE(bucket.hasData());
+    ASSERT_TRUE(bucket.needsUpload());
+
+    bucket.upload(context);
+    ASSERT_TRUE(bucket.hasData());
     ASSERT_FALSE(bucket.needsUpload());
 }
 
 TEST(Buckets, FillBucket) {
+    gl::Context context;
     FillBucket bucket { { {0, 0, 0}, MapMode::Still, 1.0 }, {} };
     ASSERT_FALSE(bucket.hasData());
+    ASSERT_FALSE(bucket.needsUpload());
+
+    GeometryCollection polygon { { { 0, 0 }, { 0, 1 }, { 1, 1 } } };
+    bucket.addFeature(StubGeometryTileFeature { {}, FeatureType::Polygon, polygon, {} }, polygon);
+    ASSERT_TRUE(bucket.hasData());
+    ASSERT_TRUE(bucket.needsUpload());
+
+    bucket.upload(context);
     ASSERT_FALSE(bucket.needsUpload());
 }
 
 TEST(Buckets, LineBucket) {
+    gl::Context context;
     LineBucket bucket { { {0, 0, 0}, MapMode::Still, 1.0 }, {}, {} };
     ASSERT_FALSE(bucket.hasData());
+    ASSERT_FALSE(bucket.needsUpload());
+
+    // Ignore invalid feature type.
+    GeometryCollection point { { { 0, 0 } } };
+    bucket.addFeature(StubGeometryTileFeature { {}, FeatureType::Point, point, {} }, point);
+    ASSERT_FALSE(bucket.hasData());
+
+    GeometryCollection line { { { 0, 0 }, { 1, 1 } } };
+    bucket.addFeature(StubGeometryTileFeature { {}, FeatureType::LineString, line, {} }, line);
+    ASSERT_TRUE(bucket.hasData());
+    ASSERT_TRUE(bucket.needsUpload());
+
+    bucket.upload(context);
     ASSERT_FALSE(bucket.needsUpload());
 }
 
@@ -36,11 +70,26 @@ TEST(Buckets, SymbolBucket) {
     bool sdfIcons = false;
     bool iconsNeedLinear = false;
 
+    gl::Context context;
     SymbolBucket bucket { layout, {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear };
     ASSERT_FALSE(bucket.hasIconData());
     ASSERT_FALSE(bucket.hasTextData());
     ASSERT_FALSE(bucket.hasCollisionBoxData());
     ASSERT_FALSE(bucket.hasData());
+    ASSERT_FALSE(bucket.needsUpload());
+
+    // SymbolBucket::addFeature() is a no-op.
+    GeometryCollection point { { { 0, 0 } } };
+    bucket.addFeature(StubGeometryTileFeature { {}, FeatureType::Point, point, {} }, point);
+    ASSERT_FALSE(bucket.hasData());
+    ASSERT_FALSE(bucket.needsUpload());
+
+    bucket.text.segments.emplace_back(0, 0);
+    ASSERT_TRUE(bucket.hasTextData());
+    ASSERT_TRUE(bucket.hasData());
+    ASSERT_TRUE(bucket.needsUpload());
+
+    bucket.upload(context);
     ASSERT_FALSE(bucket.needsUpload());
 }
 
@@ -48,6 +97,7 @@ TEST(Buckets, RasterBucket) {
     gl::Context context;
     UnassociatedImage rgba({ 1, 1 });
 
+    // RasterBucket::hasData() is always true.
     RasterBucket bucket = { std::move(rgba) };
     ASSERT_TRUE(bucket.hasData());
     ASSERT_TRUE(bucket.needsUpload());

--- a/test/gl/bucket.test.cpp
+++ b/test/gl/bucket.test.cpp
@@ -16,16 +16,19 @@ using namespace mbgl;
 TEST(Buckets, CircleBucket) {
     CircleBucket bucket { { {0, 0, 0}, MapMode::Still, 1.0 }, {} };
     ASSERT_FALSE(bucket.hasData());
+    ASSERT_FALSE(bucket.needsUpload());
 }
 
 TEST(Buckets, FillBucket) {
     FillBucket bucket { { {0, 0, 0}, MapMode::Still, 1.0 }, {} };
     ASSERT_FALSE(bucket.hasData());
+    ASSERT_FALSE(bucket.needsUpload());
 }
 
 TEST(Buckets, LineBucket) {
     LineBucket bucket { { {0, 0, 0}, MapMode::Still, 1.0 }, {}, {} };
     ASSERT_FALSE(bucket.hasData());
+    ASSERT_FALSE(bucket.needsUpload());
 }
 
 TEST(Buckets, SymbolBucket) {
@@ -37,6 +40,8 @@ TEST(Buckets, SymbolBucket) {
     ASSERT_FALSE(bucket.hasIconData());
     ASSERT_FALSE(bucket.hasTextData());
     ASSERT_FALSE(bucket.hasCollisionBoxData());
+    ASSERT_FALSE(bucket.hasData());
+    ASSERT_FALSE(bucket.needsUpload());
 }
 
 TEST(Buckets, RasterBucket) {
@@ -44,6 +49,7 @@ TEST(Buckets, RasterBucket) {
     UnassociatedImage rgba({ 1, 1 });
 
     RasterBucket bucket = { std::move(rgba) };
+    ASSERT_TRUE(bucket.hasData());
     ASSERT_TRUE(bucket.needsUpload());
 
     bucket.upload(context);

--- a/test/src/mbgl/test/stub_geometry_tile_feature.hpp
+++ b/test/src/mbgl/test/stub_geometry_tile_feature.hpp
@@ -9,6 +9,13 @@ public:
         : properties(std::move(properties_)) {
     }
 
+    StubGeometryTileFeature(optional<FeatureIdentifier> id_, FeatureType type_, GeometryCollection geometry_, PropertyMap properties_)
+        : properties(std::move(properties_)),
+          id(std::move(id_)),
+          type(type_),
+          geometry(std::move(geometry_)) {
+    }
+
     PropertyMap properties;
     optional<FeatureIdentifier> id = {};
     FeatureType type = FeatureType::Point;

--- a/test/util/merge_lines.test.cpp
+++ b/test/util/merge_lines.test.cpp
@@ -1,4 +1,5 @@
 #include <mbgl/test/util.hpp>
+#include <mbgl/test/stub_geometry_tile_feature.hpp>
 
 #include <mbgl/layout/merge_lines.hpp>
 #include <mbgl/layout/symbol_feature.hpp>
@@ -9,40 +10,12 @@ const std::u16string bbb = u"b";
 
 using namespace mbgl;
 
-class GeometryTileFeatureStub : public GeometryTileFeature {
-public:
-    GeometryTileFeatureStub(optional<FeatureIdentifier> id_, FeatureType type_, GeometryCollection geometry_,
-                  std::unordered_map<std::string, Value> properties_) :
-        id(std::move(id_)),
-        type(type_),
-        geometry(std::move(geometry_)),
-        properties(std::move(properties_))
-    {}
-    
-    FeatureType getType() const override { return type; }
-    optional<Value> getValue(const std::string& key) const override {
-        auto it = properties.find(key);
-        if (it != properties.end()) {
-            return it->second;
-        }
-        return {};
-    };
-    std::unordered_map<std::string,Value> getProperties() const override { return properties; };
-    optional<FeatureIdentifier> getID() const override { return id; };
-    GeometryCollection getGeometries() const override { return geometry; };
-    
-    optional<FeatureIdentifier> id;
-    FeatureType type;
-    GeometryCollection geometry;
-    std::unordered_map<std::string,Value> properties;
-};
-
 class SymbolFeatureStub : public SymbolFeature {
 public:
     SymbolFeatureStub(optional<FeatureIdentifier> id_, FeatureType type_, GeometryCollection geometry_,
                             std::unordered_map<std::string, Value> properties_, optional<std::u16string> text_,
                             optional<std::string> icon_, std::size_t index_) :
-        SymbolFeature(std::make_unique<GeometryTileFeatureStub>(id_, type_, geometry_, properties_))
+        SymbolFeature(std::make_unique<StubGeometryTileFeature>(id_, type_, geometry_, properties_))
     {
         text = text_;
         icon = icon_;
@@ -60,7 +33,7 @@ TEST(MergeLines, SameText) {
     input1.push_back(SymbolFeatureStub({}, FeatureType::LineString, {{{6, 0}, {7, 0}, {8, 0}}}, {}, aaa, {}, 0));
     input1.push_back(SymbolFeatureStub({}, FeatureType::LineString, {{{5, 0}, {6, 0}}}, {}, aaa, {}, 0));
 
-    const std::vector<GeometryTileFeatureStub> expected1 = {
+    const std::vector<StubGeometryTileFeature> expected1 = {
         { {}, FeatureType::LineString, {{{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}}}, {} },
         { {}, FeatureType::LineString, {{{4, 0}, {5, 0}, {6, 0}}}, {} },
         { {}, FeatureType::LineString, {{{5, 0}, {6, 0}, {7, 0}, {8, 0}, {9, 0}}}, {} },
@@ -83,7 +56,7 @@ TEST(MergeLines, BothEnds) {
     input2.push_back(SymbolFeatureStub { {}, FeatureType::LineString, {{{4, 0}, {5, 0}, {6, 0}}}, {}, aaa, {}, 0 });
     input2.push_back(SymbolFeatureStub { {}, FeatureType::LineString, {{{2, 0}, {3, 0}, {4, 0}}}, {}, aaa, {}, 0 });
 
-    const std::vector<GeometryTileFeatureStub> expected2 = {
+    const std::vector<StubGeometryTileFeature> expected2 = {
         { {}, FeatureType::LineString, {{{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}, {5, 0}, {6, 0}}}, {} },
         { {}, FeatureType::LineString, {{}}, {} },
         { {}, FeatureType::LineString, {{}}, {} }
@@ -103,7 +76,7 @@ TEST(MergeLines, CircularLines) {
     input3.push_back(SymbolFeatureStub { {}, FeatureType::LineString, {{{2, 0}, {3, 0}, {4, 0}}}, {}, aaa, {}, 0 });
     input3.push_back(SymbolFeatureStub { {}, FeatureType::LineString, {{{4, 0}, {0, 0}}}, {}, aaa, {}, 0 });
 
-    const std::vector<GeometryTileFeatureStub> expected3 = {
+    const std::vector<StubGeometryTileFeature> expected3 = {
         { {}, FeatureType::LineString, {{{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}, {0, 0}}}, {} },
         { {}, FeatureType::LineString, {{}}, {} },
         { {}, FeatureType::LineString, {{}}, {} }
@@ -120,7 +93,7 @@ TEST(MergeLines, EmptyOuterGeometry) {
     std::vector<mbgl::SymbolFeature> input;
     input.push_back(SymbolFeatureStub { {}, FeatureType::LineString, {}, {}, aaa, {}, 0 });
 
-    const std::vector<GeometryTileFeatureStub> expected = { { {}, FeatureType::LineString, {}, {} } };
+    const std::vector<StubGeometryTileFeature> expected = { { {}, FeatureType::LineString, {}, {} } };
 
     mbgl::util::mergeLines(input);
 
@@ -131,7 +104,7 @@ TEST(MergeLines, EmptyInnerGeometry) {
     std::vector<mbgl::SymbolFeature> input;
     input.push_back(SymbolFeatureStub { {}, FeatureType::LineString, {{}}, {}, aaa, {}, 0 });
 
-    const std::vector<GeometryTileFeatureStub> expected = { { {}, FeatureType::LineString, {{}}, {} } };
+    const std::vector<StubGeometryTileFeature> expected = { { {}, FeatureType::LineString, {{}}, {} } };
 
     mbgl::util::mergeLines(input);
 


### PR DESCRIPTION
Another spin-off from #9148, this PR adds simple bucket feature insertion tests, and also:
- Check if bucket contains data in `Bucket::needsUpload()`
- Remove redundant `GeometryCollection` param in `Bucket::addFeature()`