### PR TITLE
Add node-benchmark target and xcode scheme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,14 @@ run-benchmark: run-benchmark-.
 run-benchmark-%: benchmark
 	$(MACOS_OUTPUT_PATH)/$(BUILDTYPE)/mbgl-benchmark --benchmark_filter=$*
 
+.PHONY: node-benchmark
+node-benchmark: $(MACOS_PROJ_PATH)
+	set -o pipefail && $(MACOS_XCODEBUILD) -scheme 'node-benchmark' build $(XCPRETTY)
+
+.PHONY: run-node-benchmark
+run-node-benchmark: node-benchmark
+	node platform/node/test/benchmark.js
+
 .PHONY: glfw-app
 glfw-app: $(MACOS_PROJ_PATH)
 	set -o pipefail && $(MACOS_XCODEBUILD) -scheme 'mbgl-glfw' build $(XCPRETTY)

--- a/cmake/node.cmake
+++ b/cmake/node.cmake
@@ -87,3 +87,14 @@ xcode_create_scheme(
         "group"
         "test"
 )
+
+xcode_create_scheme(
+    TARGET mbgl-node
+    TYPE node
+    NAME "node-benchmark"
+    ARGS
+        "platform/node/test/benchmark.js"
+    OPTIONAL_ARGS
+        "group"
+        "test"
+)


### PR DESCRIPTION
Adds a make target for running the node benchmark script and a xcode scheme through cmake.