### PR TITLE
[core] Fix conditional unitialized jump on RenderGeoJSONSource

### DIFF
--- a/src/mbgl/renderer/sources/render_geojson_source.hpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.hpp
@@ -43,7 +43,7 @@ private:
     const style::GeoJSONSource::Impl& impl() const;
 
     TilePyramid tilePyramid;
-    style::GeoJSONData* data;
+    style::GeoJSONData* data = nullptr;
 };
 
 template <>


### PR DESCRIPTION
```
==24942== Conditional jump or move depends on uninitialised value(s)
==24942==    at 0x7D943D: mbgl::RenderGeoJSONSource::update(mbgl::Immutable<mbgl::style::Source::Impl>, std::vector<mbgl::Immutable<mbgl::style::Layer::Impl>, std::allocator<mbgl::Immutable<mbgl::style::Layer::Impl> > > const&, bool, bool, mbgl::TileParameters const&) (in /home/tmpsantos/Projects/mapbox-gl-native/build/linux-x86_64/Release/mbgl-test)
==24942==    by 0x796445: mbgl::RenderStyle::update(mbgl::UpdateParameters const&) (in /home/tmpsantos/Projects/mapbox-gl-native/build/linux-x86_64/Release/mbgl-test)
==24942==    by 0x77E29D: mbgl::Map::Impl::render(mbgl::View&) (in /home/tmpsantos/Projects/mapbox-gl-native/build/linux-x86_64/Release/mbgl-test)
==24942==    by 0x77E559: mbgl::Map::Impl::renderStill() (in /home/tmpsantos/Projects/mapbox-gl-native/build/linux-x86_64/Release/mbgl-test)
==24942==    by 0xA39772: uv__async_event (async.c:98)
==24942==    by 0xA398F8: uv__async_io (async.c:138)
==24942==    by 0xA4375F: uv__io_poll (linux-core.c:380)
==24942==    by 0xA3A1F2: uv_run (core.c:354)
==24942==    by 0x61BADC: API_ZoomHistory_Test::TestBody() (in /home/tmpsantos/Projects/mapbox-gl-native/build/linux-x86_64/Release/mbgl-test)
==24942==    by 0x89FDE9: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /home/tmpsantos/Projects/mapbox-gl-native/build/linux-x86_64/Release/mbgl-test)
==24942==    by 0x885450: testing::Test::Run() (in /home/tmpsantos/Projects/mapbox-gl-native/build/linux-x86_64/Release/mbgl-test)
==24942==    by 0x88642F: testing::TestInfo::Run() (in /home/tmpsantos/Projects/mapbox-gl-native/build/linux-x86_64/Release/mbgl-test)
==24942==
```