### PR TITLE
[core] Do not assume POSIX threads

### DIFF
--- a/platform/android/config.cmake
+++ b/platform/android/config.cmake
@@ -55,6 +55,7 @@ macro(mbgl_platform_core)
         PRIVATE platform/android/src/thread.cpp
         PRIVATE platform/default/string_stdlib.cpp
         PRIVATE platform/default/bidi.cpp
+        PRIVATE platform/default/thread_local.cpp
         PRIVATE platform/default/utf.cpp
 
         # Image handling

--- a/platform/default/thread_local.cpp
+++ b/platform/default/thread_local.cpp
@@ -1,0 +1,62 @@
+#include <mbgl/util/thread_local.hpp>
+
+#include <mbgl/map/backend_scope.hpp>
+#include <mbgl/util/logging.hpp>
+#include <mbgl/util/run_loop.hpp>
+
+#include <stdexcept>
+#include <cassert>
+
+#include <pthread.h>
+
+namespace mbgl {
+namespace util {
+
+template <class T>
+class ThreadLocal<T>::Impl {
+public:
+    pthread_key_t key;
+};
+
+template <class T>
+ThreadLocal<T>::ThreadLocal() : impl(std::make_unique<Impl>()) {
+    int ret = pthread_key_create(&impl->key, [](void *) {});
+
+    if (ret) {
+        throw std::runtime_error("Failed to init local storage key.");
+    }
+}
+
+template <class T>
+ThreadLocal<T>::~ThreadLocal() {
+    delete get();
+
+    if (pthread_key_delete(impl->key)) {
+        Log::Error(Event::General, "Failed to delete local storage key.");
+        assert(false);
+    }
+}
+
+template <class T>
+T* ThreadLocal<T>::get() {
+    auto* ret = reinterpret_cast<T*>(pthread_getspecific(impl->key));
+    if (!ret) {
+        return nullptr;
+    }
+
+    return ret;
+}
+
+template <class T>
+void ThreadLocal<T>::set(T* ptr) {
+    if (pthread_setspecific(impl->key, ptr)) {
+        throw std::runtime_error("Failed to set local storage.");
+    }
+}
+
+template class ThreadLocal<RunLoop>;
+template class ThreadLocal<BackendScope>;
+template class ThreadLocal<int>; // For unit tests
+
+} // namespace util
+} // namespace mbgl

--- a/platform/ios/config.cmake
+++ b/platform/ios/config.cmake
@@ -41,6 +41,7 @@ macro(mbgl_platform_core)
         PRIVATE platform/darwin/src/nsthread.mm
         PRIVATE platform/darwin/src/string_nsstring.mm
         PRIVATE platform/default/bidi.cpp
+        PRIVATE platform/default/thread_local.cpp
         PRIVATE platform/default/utf.cpp
 
         # Image handling

--- a/platform/linux/config.cmake
+++ b/platform/linux/config.cmake
@@ -69,6 +69,7 @@ macro(mbgl_platform_core)
         PRIVATE platform/default/string_stdlib.cpp
         PRIVATE platform/default/thread.cpp
         PRIVATE platform/default/bidi.cpp
+        PRIVATE platform/default/thread_local.cpp
         PRIVATE platform/default/utf.cpp
 
         # Image handling

--- a/platform/macos/config.cmake
+++ b/platform/macos/config.cmake
@@ -37,6 +37,7 @@ macro(mbgl_platform_core)
         PRIVATE platform/darwin/src/nsthread.mm
         PRIVATE platform/darwin/src/string_nsstring.mm
         PRIVATE platform/default/bidi.cpp
+        PRIVATE platform/default/thread_local.cpp
         PRIVATE platform/default/utf.cpp
 
         # Image handling

--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -37,7 +37,7 @@ set(MBGL_QT_FILES
     PRIVATE platform/default/mbgl/util/default_thread_pool.hpp
 
     # Thread
-    PRIVATE platform/default/thread_local.cpp
+    PRIVATE platform/qt/src/thread_local.cpp
 
     # Platform integration
     PRIVATE platform/qt/src/async_task.cpp

--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -96,12 +96,16 @@ if (MASON_PLATFORM STREQUAL "osx" OR MASON_PLATFORM STREQUAL "ios")
         PRIVATE "-framework Foundation"
         PRIVATE "-framework OpenGL"
     )
-else()
+elseif (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
     list(APPEND MBGL_QT_FILES
         PRIVATE platform/default/thread.cpp
     )
     list(APPEND MBGL_QT_LIBRARIES
         PRIVATE -lGL
+    )
+elseif (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+    list(APPEND MBGL_QT_FILES
+        PRIVATE platform/qt/src/thread.cpp
     )
 endif()
 

--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -36,6 +36,9 @@ set(MBGL_QT_FILES
     PRIVATE platform/default/mbgl/util/default_thread_pool.cpp
     PRIVATE platform/default/mbgl/util/default_thread_pool.hpp
 
+    # Thread
+    PRIVATE platform/default/thread_local.cpp
+
     # Platform integration
     PRIVATE platform/qt/src/async_task.cpp
     PRIVATE platform/qt/src/async_task_impl.hpp

--- a/platform/qt/src/thread.cpp
+++ b/platform/qt/src/thread.cpp
@@ -1,0 +1,19 @@
+#include <mbgl/util/platform.hpp>
+
+#include <string>
+
+namespace mbgl {
+namespace platform {
+
+std::string getCurrentThreadName() {
+    return "unknown";
+}
+
+void setCurrentThreadName(const std::string&) {
+}
+
+void makeThreadLowPriority() {
+}
+
+} // namespace platform
+} // namespace mbgl

--- a/platform/qt/src/thread_local.cpp
+++ b/platform/qt/src/thread_local.cpp
@@ -1,0 +1,44 @@
+#include <mbgl/util/thread_local.hpp>
+
+#include <mbgl/util/run_loop.hpp>
+#include <mbgl/map/backend_scope.hpp>
+
+#include <array>
+
+#include <QThreadStorage>
+
+namespace mbgl {
+namespace util {
+
+template <class T>
+class ThreadLocal<T>::Impl {
+public:
+    QThreadStorage<std::array<T*, 1>> local;
+};
+
+template <class T>
+ThreadLocal<T>::ThreadLocal() : impl(std::make_unique<Impl>()) {
+    set(nullptr);
+}
+
+template <class T>
+ThreadLocal<T>::~ThreadLocal() {
+    delete get();
+}
+
+template <class T>
+T* ThreadLocal<T>::get() {
+    return impl->local.localData()[0];
+}
+
+template <class T>
+void ThreadLocal<T>::set(T* ptr) {
+   impl->local.localData()[0] = ptr;
+}
+
+template class ThreadLocal<RunLoop>;
+template class ThreadLocal<BackendScope>;
+template class ThreadLocal<int>; // For unit tests
+
+} // namespace util
+} // namespace mbgl

--- a/src/mbgl/util/thread_local.hpp
+++ b/src/mbgl/util/thread_local.hpp
@@ -1,12 +1,8 @@
 #pragma once
 
-#include <mbgl/util/logging.hpp>
 #include <mbgl/util/noncopyable.hpp>
 
-#include <cassert>
-#include <stdexcept>
-
-#include <pthread.h>
+#include <memory>
 
 namespace mbgl {
 namespace util {
@@ -14,40 +10,20 @@ namespace util {
 template <class T>
 class ThreadLocal : public noncopyable {
 public:
-    ThreadLocal() {
-        int ret = pthread_key_create(&key, [](void *ptr) {
-            delete reinterpret_cast<T *>(ptr);
-        });
-
-        if (ret) {
-            throw std::runtime_error("Failed to init local storage key.");
-        }
+    ThreadLocal(T* val) {
+        ThreadLocal();
+        set(val);
     }
 
-    ~ThreadLocal() {
-        if (pthread_key_delete(key)) {
-            Log::Error(Event::General, "Failed to delete local storage key.");
-            assert(false);
-        }
-    }
+    ThreadLocal();
+    ~ThreadLocal();
 
-    T* get() {
-        auto* ret = reinterpret_cast<T*>(pthread_getspecific(key));
-        if (!ret) {
-            return nullptr;
-        }
-
-        return ret;
-    }
-
-    void set(T* ptr) {
-        if (pthread_setspecific(key, ptr)) {
-            throw std::runtime_error("Failed to set local storage.");
-        }
-    }
+    T* get();
+    void set(T* ptr);
 
 private:
-    pthread_key_t key;
+    class Impl;
+    std::unique_ptr<Impl> impl;
 };
 
 } // namespace util


### PR DESCRIPTION
This is important to get Mapbox GL running on Windows via the
Qt platform. We could use C++11 thread_local but sadly is not
widely supported.