### PR TITLE
[android] - build SNAPSHOT from master

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -166,7 +166,7 @@ jobs:
       - deploy:
           name: Publish to Maven
           command: |
-            if [ "${CIRCLE_BRANCH}" == "release-ios-v3.6.0-android-v5.1.0" ]; then make run-android-upload-archives ; fi
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then make run-android-upload-archives ; fi
       - save_cache:
           key: v1-android-release-all
           paths:


### PR DESCRIPTION
Follow up & revert of #8958. Final release of 5.1.0 happened.
We can start building our SNAPSHOTS back from master.