### PR TITLE
Fix javadoc comment for public setOfflineMapboxTileCountLimit method

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
@@ -236,10 +236,11 @@ public class OfflineManager {
     return LatLngBounds.world().contains(definition.getBounds());
   }
 
-  /*
-  * Changing or bypassing this limit without permission from Mapbox is prohibited
-  * by the Mapbox Terms of Service.
-  */
+  /**
+   * Changing or bypassing this limit without permission from Mapbox is prohibited
+   * by the Mapbox Terms of Service.
+   * @param limit the new tile count limit.
+   */
   public native void setOfflineMapboxTileCountLimit(long limit);
 
   private native void initialize(FileSource fileSource);


### PR DESCRIPTION
It's a public method, its comment should be a Javadoc comment.
