### PR TITLE
Rewire map initialisation

### DIFF
--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -86,6 +86,10 @@ NativeMapView::NativeMapView(jni::JNIEnv& _env,
                                                   static_cast<uint32_t>(height) }, pixelRatio,
                                       fileSource, *threadPool, MapMode::Continuous,
                                       ConstrainMode::HeightOnly, ViewportMode::Default);
+
+    // initialize egl components
+    _initializeDisplay();
+    _initializeContext();
 }
 
 /**
@@ -253,22 +257,6 @@ void NativeMapView::onSourceChanged(mbgl::style::Source&) {
 }
 
 // JNI Methods //
-
-void NativeMapView::initializeDisplay(jni::JNIEnv&) {
-    _initializeDisplay();
-}
-
-void NativeMapView::terminateDisplay(jni::JNIEnv&) {
-    _terminateDisplay();
-}
-
-void NativeMapView::initializeContext(jni::JNIEnv&) {
-    _initializeContext();
-}
-
-void NativeMapView::terminateContext(jni::JNIEnv&) {
-    _terminateContext();
-}
 
 void NativeMapView::createSurface(jni::JNIEnv& env, jni::Object<> _surface) {
     _createSurface(ANativeWindow_fromSurface(&env, jni::Unwrap(*_surface)));
@@ -1471,10 +1459,6 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
             METHOD(&NativeMapView::update, "nativeUpdate"),
             METHOD(&NativeMapView::resizeView, "nativeResizeView"),
             METHOD(&NativeMapView::resizeFramebuffer, "nativeResizeFramebuffer"),
-            METHOD(&NativeMapView::initializeDisplay, "nativeInitializeDisplay"),
-            METHOD(&NativeMapView::terminateDisplay, "nativeTerminateDisplay"),
-            METHOD(&NativeMapView::initializeContext, "nativeInitializeContext"),
-            METHOD(&NativeMapView::terminateContext, "nativeTerminateContext"),
             METHOD(&NativeMapView::createSurface, "nativeCreateSurface"),
             METHOD(&NativeMapView::destroySurface, "nativeDestroySurface"),
             METHOD(&NativeMapView::getStyleUrl, "nativeGetStyleUrl"),

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -85,8 +85,6 @@ public:
 
     // JNI //
 
-    void destroy(jni::JNIEnv&);
-
     void render(jni::JNIEnv&);
 
     void update(jni::JNIEnv&);
@@ -94,14 +92,6 @@ public:
     void resizeView(jni::JNIEnv&, int, int);
 
     void resizeFramebuffer(jni::JNIEnv&, int, int);
-
-    void initializeDisplay(jni::JNIEnv&);
-
-    void terminateDisplay(jni::JNIEnv&);
-
-    void initializeContext(jni::JNIEnv&);
-
-    void terminateContext(jni::JNIEnv&);
 
     void createSurface(jni::JNIEnv&, jni::Object<>);
 


### PR DESCRIPTION
This PR rewrites the way we do map initialisation. Before this PR we created the map object when the hosting MapView was inflated. This PR now postpones creating the map object until the Surface of the MapView is ready. A benefit of this is that the view will be measured by the time that MapboxMap will be created and thus removes the necessity of posting the OnMapReadyCallback invocations. 

Closes #9136 