### PR TITLE
[benchmark] Fix build on GCC 5

### DIFF
--- a/benchmark/api/query.benchmark.cpp
+++ b/benchmark/api/query.benchmark.cpp
@@ -48,7 +48,7 @@ static void API_queryRenderedFeaturesAll(::benchmark::State& state) {
     QueryBenchmark bench;
 
     while (state.KeepRunning()) {
-        bench.map.queryRenderedFeatures(bench.box);
+        bench.map.queryRenderedFeatures(bench.box, {});
     }
 }
 


### PR DESCRIPTION
For some mysterious reason GCC 5 was complaining about the implicit default
value. Passing it explicitly fixes it.