### PR TITLE
Clip raster tiles

### DIFF
--- a/benchmark/parse/tile_mask.benchmark.cpp
+++ b/benchmark/parse/tile_mask.benchmark.cpp
@@ -1,0 +1,38 @@
+#include <benchmark/benchmark.h>
+
+#include <mbgl/algorithm/update_tile_masks.hpp>
+
+using namespace mbgl;
+
+class MaskedRenderable {
+public:
+    MaskedRenderable(const UnwrappedTileID& id_, TileMask&& mask_)
+        : id(id_), mask(std::move(mask_)) {
+    }
+
+    UnwrappedTileID id;
+    TileMask mask;
+    bool used = true;
+
+    void setMask(TileMask&& mask_) {
+        mask = std::move(mask_);
+    }
+};
+
+static void TileMaskGeneration(benchmark::State& state) {
+    std::vector<MaskedRenderable> renderables = {
+        MaskedRenderable{ UnwrappedTileID{ 12, 1028, 1456 }, {} },
+        MaskedRenderable{ UnwrappedTileID{ 13, 2056, 2912 }, {} },
+        MaskedRenderable{ UnwrappedTileID{ 13, 2056, 2913 }, {} },
+        MaskedRenderable{ UnwrappedTileID{ 14, 4112, 5824 }, {} },
+        MaskedRenderable{ UnwrappedTileID{ 14, 4112, 5827 }, {} },
+        MaskedRenderable{ UnwrappedTileID{ 14, 4114, 5824 }, {} },
+        MaskedRenderable{ UnwrappedTileID{ 14, 4114, 5825 }, {} },
+    };
+
+    while (state.KeepRunning()) {
+        algorithm::updateTileMasks<MaskedRenderable>({ renderables.begin(), renderables.end() });
+    }
+}
+
+BENCHMARK(TileMaskGeneration);

--- a/cmake/benchmark-files.cmake
+++ b/cmake/benchmark-files.cmake
@@ -10,6 +10,7 @@ set(MBGL_BENCHMARK_FILES
 
     # parse
     benchmark/parse/filter.benchmark.cpp
+    benchmark/parse/tile_mask.benchmark.cpp
     benchmark/parse/vector_tile.benchmark.cpp
 
     # src

--- a/cmake/benchmark.cmake
+++ b/cmake/benchmark.cmake
@@ -19,6 +19,7 @@ target_link_libraries(mbgl-benchmark
     PRIVATE mbgl-core
 )
 
+target_add_mason_package(mbgl-benchmark PRIVATE boost)
 target_add_mason_package(mbgl-benchmark PRIVATE benchmark)
 target_add_mason_package(mbgl-benchmark PRIVATE rapidjson)
 target_add_mason_package(mbgl-benchmark PRIVATE protozero)

--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -15,6 +15,7 @@ set(MBGL_CORE_FILES
     src/mbgl/algorithm/generate_clip_ids.hpp
     src/mbgl/algorithm/generate_clip_ids_impl.hpp
     src/mbgl/algorithm/update_renderables.hpp
+    src/mbgl/algorithm/update_tile_masks.hpp
 
     # annotation
     include/mbgl/annotation/annotation.hpp
@@ -205,6 +206,7 @@ set(MBGL_CORE_FILES
     src/mbgl/renderer/renderer_observer.hpp
     src/mbgl/renderer/style_diff.cpp
     src/mbgl/renderer/style_diff.hpp
+    src/mbgl/renderer/tile_mask.hpp
     src/mbgl/renderer/tile_parameters.hpp
     src/mbgl/renderer/tile_pyramid.cpp
     src/mbgl/renderer/tile_pyramid.hpp

--- a/cmake/test-files.cmake
+++ b/cmake/test-files.cmake
@@ -10,6 +10,7 @@ set(MBGL_TEST_FILES
     test/algorithm/generate_clip_ids.test.cpp
     test/algorithm/mock.hpp
     test/algorithm/update_renderables.test.cpp
+    test/algorithm/update_tile_masks.test.cpp
 
     # api
     test/api/annotations.test.cpp

--- a/src/mbgl/algorithm/update_tile_masks.hpp
+++ b/src/mbgl/algorithm/update_tile_masks.hpp
@@ -1,0 +1,128 @@
+#pragma once
+
+#include <mbgl/renderer/tile_mask.hpp>
+
+#include <vector>
+#include <functional>
+#include <algorithm>
+
+namespace mbgl {
+namespace algorithm {
+
+namespace {
+
+template <typename Renderable>
+void computeTileMasks(
+    const CanonicalTileID& root,
+    const UnwrappedTileID ref,
+    typename std::vector<std::reference_wrapper<Renderable>>::const_iterator it,
+    const typename std::vector<std::reference_wrapper<Renderable>>::const_iterator end,
+    TileMask& mask) {
+    // If the reference or any of its children is found in the list, we need to recurse.
+    for (; it != end; ++it) {
+        auto& renderable = it->get();
+        if (!renderable.used) {
+            continue;
+        }
+        if (ref == renderable.id) {
+            // The current tile is masked out, so we don't need to add them to the mask set.
+            return;
+        } else if (renderable.id.isChildOf(ref)) {
+            // There's at least one child tile that is masked out, so recursively descend.
+            for (const auto& child : ref.children()) {
+                computeTileMasks<Renderable>(root, child, it, end, mask);
+            }
+            return;
+        }
+    }
+
+    // We couldn't find a child, so it's definitely a masked part.
+    // Compute the difference between the root tile ID and the reference tile ID, since TileMask
+    // elements are always relative (see below for explanation).
+    const uint8_t diffZ = ref.canonical.z - root.z;
+    mask.emplace(diffZ, ref.canonical.x - (root.x << diffZ), ref.canonical.y - (root.y << diffZ));
+}
+
+} // namespace
+
+// Updates the TileMasks for all renderables. Renderables are objects that have an UnwrappedTileID
+// property indicating where they should be rendered on the screen. A TileMask describes all regions
+// within that tile that are *not* covered by other Renderables.
+// Example: Renderables in our list are 2/1/3, 3/3/6, and 4/5/13. The schematic for creating the
+// TileMask for 2/1/3 looks like this:
+//
+//    ┌────────┬────────┬─────────────────┐
+//    │        │        │#################│
+//    │ 4/4/12 │ 4/5/12 │#################│
+//    │        │        │#################│
+//    ├──────3/2/6──────┤#####3/3/6#######│
+//    │        │########│#################│
+//    │ 4/4/13 │#4/5/13#│#################│
+//    │        │########│#################│
+//    ├────────┴──────2/1/3───────────────┤
+//    │                 │                 │
+//    │                 │                 │
+//    │                 │                 │
+//    │      3/2/7      │      3/3/7      │
+//    │                 │                 │
+//    │                 │                 │
+//    │                 │                 │
+//    └─────────────────┴─────────────────┘
+//
+// The TileMask for 2/1/3 thus consists of the tiles 4/4/12, 4/5/12, 4/4/13, 3/2/7, and 3/3/7,
+// but it does *not* include 4/5/13, and 3/3/6, since these are other Renderables.
+// A TileMask always contains TileIDs *relative* to the tile it is generated for, so 2/1/3 is
+// "subtracted" from these TileIDs. The final TileMask for 2/1/3 will thus be:
+//
+//    ┌────────┬────────┬─────────────────┐
+//    │        │        │#################│
+//    │ 2/0/0  │ 2/1/0  │#################│
+//    │        │        │#################│
+//    ├────────┼────────┤#################│
+//    │        │########│#################│
+//    │ 2/0/1  │########│#################│
+//    │        │########│#################│
+//    ├────────┴────────┼─────────────────┤
+//    │                 │                 │
+//    │                 │                 │
+//    │                 │                 │
+//    │      1/0/1      │      1/1/1      │
+//    │                 │                 │
+//    │                 │                 │
+//    │                 │                 │
+//    └─────────────────┴─────────────────┘
+//
+// Only other Renderables that are *children* of the Renderable we are generating the mask for will
+// be considered. For example, adding a Renderable with TileID 4/8/13 won't affect the TileMask for
+// 2/1/3, since it is not a descendant of it.
+template <typename Renderable>
+void updateTileMasks(std::vector<std::reference_wrapper<Renderable>> renderables) {
+    std::sort(renderables.begin(), renderables.end(),
+              [](const Renderable& a, const Renderable& b) { return a.id < b.id; });
+
+    TileMask mask;
+    const auto end = renderables.end();
+    for (auto it = renderables.begin(); it != end; it++) {
+        auto& renderable = it->get();
+        if (!renderable.used) {
+            continue;
+        }
+        // Try to add all remaining ids as children. We sorted the tile list
+        // by z earlier, so all preceding items cannot be children of the current
+        // tile. We also compute the lower bound of the next wrap, because items of the next wrap
+        // can never be children of the current wrap.
+        auto child_it = std::next(it);
+        const auto children_end = std::lower_bound(
+            child_it, end,
+            UnwrappedTileID{ static_cast<int16_t>(renderable.id.wrap + 1), { 0, 0, 0 } },
+            [](auto& a, auto& b) { return a.get().id < b; });
+
+        mask.clear();
+        computeTileMasks<Renderable>(renderable.id.canonical, renderable.id, child_it, children_end,
+                                     mask);
+        renderable.setMask(std::move(mask));
+    }
+}
+
+} // namespace algorithm
+} // namespace mbgl

--- a/src/mbgl/gl/index_buffer.hpp
+++ b/src/mbgl/gl/index_buffer.hpp
@@ -26,6 +26,7 @@ public:
     bool empty() const { return v.empty(); }
     void clear() { v.clear(); }
     const uint16_t* data() const { return v.data(); }
+    const std::vector<uint16_t>& vector() const { return v; }
 
 private:
     std::vector<uint16_t> v;

--- a/src/mbgl/gl/vertex_buffer.hpp
+++ b/src/mbgl/gl/vertex_buffer.hpp
@@ -28,6 +28,7 @@ public:
     bool empty() const { return v.empty(); }
     void clear() { v.clear(); }
     const Vertex* data() const { return v.data(); }
+    const std::vector<Vertex>& vector() const { return v; }
 
 private:
     std::vector<Vertex> v;

--- a/src/mbgl/renderer/buckets/raster_bucket.hpp
+++ b/src/mbgl/renderer/buckets/raster_bucket.hpp
@@ -5,6 +5,7 @@
 #include <mbgl/gl/vertex_buffer.hpp>
 #include <mbgl/programs/raster_program.hpp>
 #include <mbgl/renderer/bucket.hpp>
+#include <mbgl/renderer/tile_mask.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/mat4.hpp>
 #include <mbgl/util/optional.hpp>
@@ -21,8 +22,11 @@ public:
 
     void clear();
     void setImage(std::shared_ptr<PremultipliedImage>);
+    void setMask(TileMask&&);
+
     std::shared_ptr<PremultipliedImage> image;
     optional<gl::Texture> texture;
+    TileMask mask{ { 0, 0, 0 } };
 
     // Bucket specific vertices are used for Image Sources only
     // Raster Tile Sources use the default buffers from Painter

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -135,10 +135,19 @@ void RenderRasterLayer::render(PaintParameters& parameters, RenderSource* source
             parameters.context.bindTexture(*bucket.texture, 0, gl::TextureFilter::Linear);
             parameters.context.bindTexture(*bucket.texture, 1, gl::TextureFilter::Linear);
 
-            draw(tile.matrix,
-                 parameters.staticData.rasterVertexBuffer,
-                 parameters.staticData.quadTriangleIndexBuffer,
-                 parameters.staticData.rasterSegments);
+            if (bucket.vertexBuffer && bucket.indexBuffer && !bucket.segments.empty()) {
+                // Draw only the parts of the tile that aren't drawn by another tile in the layer.
+                draw(tile.matrix,
+                     *bucket.vertexBuffer,
+                     *bucket.indexBuffer,
+                     bucket.segments);
+            } else {
+                // Draw the full tile.
+                draw(tile.matrix,
+                     parameters.staticData.rasterVertexBuffer,
+                     parameters.staticData.quadTriangleIndexBuffer,
+                     parameters.staticData.rasterSegments);
+            }
         }
     }
 }

--- a/src/mbgl/renderer/render_tile.cpp
+++ b/src/mbgl/renderer/render_tile.cpp
@@ -52,6 +52,10 @@ mat4 RenderTile::translatedClipMatrix(const std::array<float, 2>& translation,
     return translateVtxMatrix(nearClippedMatrix, translation, anchor, state, false);
 }
 
+void RenderTile::setMask(TileMask&& mask) {
+    tile.setMask(std::move(mask));
+}
+
 void RenderTile::startRender(PaintParameters& parameters) {
     tile.upload(parameters.context);
 

--- a/src/mbgl/renderer/render_tile.hpp
+++ b/src/mbgl/renderer/render_tile.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/util/mat4.hpp>
 #include <mbgl/util/clip_id.hpp>
 #include <mbgl/style/types.hpp>
+#include <mbgl/renderer/tile_mask.hpp>
 
 #include <array>
 
@@ -36,6 +37,7 @@ public:
                               style::TranslateAnchorType anchor,
                               const TransformState&) const;
 
+    void setMask(TileMask&&);
     void startRender(PaintParameters&);
     void finishRender(PaintParameters&);
 

--- a/src/mbgl/renderer/sources/render_raster_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_source.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/renderer/sources/render_raster_source.hpp>
 #include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/tile/raster_tile.hpp>
+#include <mbgl/algorithm/update_tile_masks.hpp>
 
 namespace mbgl {
 
@@ -57,6 +58,7 @@ void RenderRasterSource::update(Immutable<style::Source::Impl> baseImpl_,
 }
 
 void RenderRasterSource::startRender(PaintParameters& parameters) {
+    algorithm::updateTileMasks(tilePyramid.getRenderTiles());
     tilePyramid.startRender(parameters);
 }
 

--- a/src/mbgl/renderer/tile_mask.hpp
+++ b/src/mbgl/renderer/tile_mask.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <mbgl/tile/tile_id.hpp>
+
+#include <set>
+
+namespace mbgl {
+
+// A TileMask is a set of TileIDs that describe what part of a tile should be rendered. It omits
+// those parts of the tile that are covered by other/better tiles. If the entire tile should be
+// rendered, it contains the { 0, 0, 0 } tile. If it's empty, no part of the tile will be rendered.
+// TileMasks are typically generated with algorithm::updateTileMasks().
+using TileMask = std::set<CanonicalTileID>;
+
+} // namespace mbgl

--- a/src/mbgl/tile/raster_tile.cpp
+++ b/src/mbgl/tile/raster_tile.cpp
@@ -41,7 +41,7 @@ void RasterTile::setData(std::shared_ptr<const std::string> data,
     worker.invoke(&RasterTileWorker::parse, data);
 }
 
-void RasterTile::onParsed(std::unique_ptr<Bucket> result) {
+void RasterTile::onParsed(std::unique_ptr<RasterBucket> result) {
     bucket = std::move(result);
     loaded = true;
     renderable = bucket ? true : false;
@@ -63,6 +63,12 @@ void RasterTile::upload(gl::Context& context) {
 
 Bucket* RasterTile::getBucket(const style::Layer::Impl&) const {
     return bucket.get();
+}
+
+void RasterTile::setMask(TileMask&& mask) {
+    if (bucket) {
+        bucket->setMask(std::move(mask));
+    }
 }
 
 void RasterTile::setNecessity(Necessity necessity) {

--- a/src/mbgl/tile/raster_tile.hpp
+++ b/src/mbgl/tile/raster_tile.hpp
@@ -9,6 +9,7 @@ namespace mbgl {
 
 class Tileset;
 class TileParameters;
+class RasterBucket;
 
 namespace style {
 class Layer;
@@ -33,7 +34,9 @@ public:
     void upload(gl::Context&) override;
     Bucket* getBucket(const style::Layer::Impl&) const override;
 
-    void onParsed(std::unique_ptr<Bucket> result);
+    void setMask(TileMask&&) override;
+
+    void onParsed(std::unique_ptr<RasterBucket> result);
     void onError(std::exception_ptr);
 
 private:
@@ -44,7 +47,7 @@ private:
 
     // Contains the Bucket object for the tile. Buckets are render
     // objects and they get added by tile parsing operations.
-    std::unique_ptr<Bucket> bucket;
+    std::unique_ptr<RasterBucket> bucket;
 };
 
 } // namespace mbgl

--- a/src/mbgl/tile/tile.hpp
+++ b/src/mbgl/tile/tile.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/util/feature.hpp>
 #include <mbgl/util/tile_coordinate.hpp>
 #include <mbgl/tile/tile_id.hpp>
+#include <mbgl/renderer/tile_mask.hpp>
 #include <mbgl/renderer/bucket.hpp>
 #include <mbgl/tile/geometry_tile_data.hpp>
 #include <mbgl/storage/resource.hpp>
@@ -54,6 +55,7 @@ public:
 
     virtual void setPlacementConfig(const PlacementConfig&) {}
     virtual void setLayers(const std::vector<Immutable<style::Layer::Impl>>&) {}
+    virtual void setMask(TileMask&&) {}
 
     virtual void queryRenderedFeatures(
             std::unordered_map<std::string, std::vector<Feature>>& result,

--- a/src/mbgl/tile/tile_id_io.cpp
+++ b/src/mbgl/tile/tile_id_io.cpp
@@ -6,6 +6,8 @@
 namespace mbgl {
 
 ::std::ostream& operator<<(::std::ostream& os, const CanonicalTileID& rhs) {
+    // Uncomment this to create code instead of shorthands.
+    // return os << "CanonicalTileID{ " << uint32_t(rhs.z) << ", " << rhs.x << ", " << rhs.y << " }";
     return os << uint32_t(rhs.z) << "/" << rhs.x << "/" << rhs.y;
 }
 
@@ -26,6 +28,9 @@ std::string toString(const OverscaledTileID& rhs) {
 } // namespace util
 
 ::std::ostream& operator<<(::std::ostream& os, const UnwrappedTileID& rhs) {
+    // Uncomment this to create code instead of shorthands.
+    // return os << "UnwrappedTileID{ " << uint32_t(rhs.wrap) << ", { " << uint32_t(rhs.canonical.z)
+    //           << ", " << rhs.canonical.x << ", " << rhs.canonical.y << " } }";
     return os << rhs.canonical << (rhs.wrap >= 0 ? "+" : "") << rhs.wrap;
 }
 

--- a/test/algorithm/update_tile_masks.test.cpp
+++ b/test/algorithm/update_tile_masks.test.cpp
@@ -1,0 +1,132 @@
+#include <mbgl/test/util.hpp>
+
+#include <mbgl/algorithm/update_tile_masks.hpp>
+
+using namespace mbgl;
+
+namespace {
+
+class MaskedRenderable {
+public:
+    MaskedRenderable(const UnwrappedTileID& id_, TileMask&& mask_)
+        : id(id_), mask(std::move(mask_)) {
+    }
+
+    UnwrappedTileID id;
+    TileMask mask;
+    bool used = true;
+
+    void setMask(TileMask&& mask_) {
+        mask = std::move(mask_);
+    }
+};
+
+bool operator==(const MaskedRenderable& lhs, const MaskedRenderable& rhs) {
+    return lhs.id == rhs.id && lhs.mask == rhs.mask;
+}
+
+::std::ostream& operator<<(::std::ostream& os, const MaskedRenderable& rhs) {
+    os << "MaskedRenderable{ " << rhs.id << ", { ";
+    bool first = true;
+    for (auto& id : rhs.mask) {
+        if (!first) {
+            os << ", ";
+        } else {
+            first = false;
+        }
+        os << id;
+    }
+    return os << " } }";
+}
+
+} // namespace
+
+void validate(const std::vector<MaskedRenderable> expected) {
+    std::vector<MaskedRenderable> actual = expected;
+    std::for_each(actual.begin(), actual.end(),
+                  [](auto& renderable) { renderable.mask.clear(); });
+    algorithm::updateTileMasks<MaskedRenderable>({ actual.begin(), actual.end() });
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(UpdateTileMasks, NoChildren) {
+    validate({
+        MaskedRenderable{ UnwrappedTileID{ 0, 0, 0 }, { CanonicalTileID{ 0, 0, 0 } } },
+    });
+
+    validate({
+        MaskedRenderable{ UnwrappedTileID{ 4, 3, 8 }, { CanonicalTileID{ 0, 0, 0 } } },
+    });
+
+    validate({
+        MaskedRenderable{ UnwrappedTileID{ 1, 0, 0 }, { CanonicalTileID{ 0, 0, 0 } } },
+        MaskedRenderable{ UnwrappedTileID{ 1, 1, 1 }, { CanonicalTileID{ 0, 0, 0 } } },
+    });
+
+    validate({
+        MaskedRenderable{ UnwrappedTileID{ 1, 0, 0 }, { CanonicalTileID{ 0, 0, 0 } } },
+        MaskedRenderable{ UnwrappedTileID{ 2, 2, 3 }, { CanonicalTileID{ 0, 0, 0 } } },
+    });
+}
+
+TEST(UpdateTileMasks, ParentAndFourChildren) {
+    validate({
+        // Mask is empty (== not rendered!) because we have four covering children.
+        MaskedRenderable{ UnwrappedTileID{ 0, 0, 0 }, {} },
+        // All four covering children
+        MaskedRenderable{ UnwrappedTileID{ 1, 0, 0 }, { CanonicalTileID{ 0, 0, 0 } } },
+        MaskedRenderable{ UnwrappedTileID{ 1, 0, 1 }, { CanonicalTileID{ 0, 0, 0 } } },
+        MaskedRenderable{ UnwrappedTileID{ 1, 1, 0 }, { CanonicalTileID{ 0, 0, 0 } } },
+        MaskedRenderable{ UnwrappedTileID{ 1, 1, 1 }, { CanonicalTileID{ 0, 0, 0 } } },
+    });
+}
+
+TEST(UpdateTileMasks, OneChild) {
+    validate({
+        MaskedRenderable{ UnwrappedTileID{ 0, 0, 0 },
+                          // Only render the three children that aren't covering the other tile.
+                          { CanonicalTileID{ 1, 0, 1 }, CanonicalTileID{ 1, 1, 0 },
+                            CanonicalTileID{ 1, 1, 1 } } },
+        MaskedRenderable{ UnwrappedTileID{ 1, 0, 0 }, { CanonicalTileID{ 0, 0, 0 } } },
+    });
+}
+
+TEST(UpdateTileMasks, Complex) {
+    validate({
+        MaskedRenderable{ UnwrappedTileID{ 0, 0, 0 },
+                          { CanonicalTileID{ 1, 0, 1 }, CanonicalTileID{ 1, 1, 0 },
+                            CanonicalTileID{ 2, 2, 3 }, CanonicalTileID{ 2, 3, 2 },
+                            CanonicalTileID{ 3, 6, 7 }, CanonicalTileID{ 3, 7, 6 } } },
+        MaskedRenderable{ UnwrappedTileID{ 0, { 1, 0, 0 } }, { CanonicalTileID{ 0, 0, 0 } } },
+        MaskedRenderable{ UnwrappedTileID{ 0, { 2, 2, 2 } }, { CanonicalTileID{ 0, 0, 0 } } },
+        MaskedRenderable{ UnwrappedTileID{ 0, { 3, 7, 7 } }, { CanonicalTileID{ 0, 0, 0 } } },
+        MaskedRenderable{ UnwrappedTileID{ 0, { 3, 6, 6 } }, { CanonicalTileID{ 0, 0, 0 } } },
+    });
+
+    validate({
+        MaskedRenderable{ UnwrappedTileID{ 0, 0, 0 },
+                          { CanonicalTileID{ 1, 0, 1 }, CanonicalTileID{ 1, 1, 0 },
+                            CanonicalTileID{ 1, 1, 1 }, CanonicalTileID{ 2, 0, 0 },
+                            CanonicalTileID{ 2, 0, 1 }, CanonicalTileID{ 2, 1, 0 },
+                            CanonicalTileID{ 3, 2, 3 }, CanonicalTileID{ 3, 3, 2 },
+                            CanonicalTileID{ 3, 3, 3 }, CanonicalTileID{ 4, 4, 5 },
+                            CanonicalTileID{ 4, 5, 4 }, CanonicalTileID{ 4, 5, 5 } } },
+        MaskedRenderable{ UnwrappedTileID{ 4, 4, 4 }, { CanonicalTileID{ 0, 0, 0 } } },
+    });
+
+    validate({
+        MaskedRenderable{ UnwrappedTileID{ 12, 1028, 1456 },
+                          { CanonicalTileID{ 1, 1, 1 }, CanonicalTileID{ 2, 3, 0 },
+                            CanonicalTileID{ 2, 3, 1 } } },
+        MaskedRenderable{ UnwrappedTileID{ 13, 2056, 2912 },
+                          { CanonicalTileID{ 1, 0, 1 }, CanonicalTileID{ 1, 1, 0 },
+                            CanonicalTileID{ 1, 1, 1 } } },
+        MaskedRenderable{ UnwrappedTileID{ 13, 2056, 2913 },
+                          { CanonicalTileID{ 1, 0, 0 }, CanonicalTileID{ 1, 1, 0 },
+                            CanonicalTileID{ 1, 1, 1 } } },
+        MaskedRenderable{ UnwrappedTileID{ 14, 4112, 5824 }, { CanonicalTileID{ 0, 0, 0 } } },
+        MaskedRenderable{ UnwrappedTileID{ 14, 4112, 5827 }, { CanonicalTileID{ 0, 0, 0 } } },
+        MaskedRenderable{ UnwrappedTileID{ 14, 4114, 5824 }, { CanonicalTileID{ 0, 0, 0 } } },
+        MaskedRenderable{ UnwrappedTileID{ 14, 4114, 5825 }, { CanonicalTileID{ 0, 0, 0 } } },
+    });
+}

--- a/test/gl/bucket.test.cpp
+++ b/test/gl/bucket.test.cpp
@@ -12,6 +12,26 @@
 
 #include <mbgl/map/mode.hpp>
 
+namespace mbgl {
+
+template <class Attributes>
+bool operator==(const Segment<Attributes>& lhs, const Segment<Attributes>& rhs) {
+    return std::tie(lhs.vertexOffset, lhs.indexOffset, lhs.vertexLength, lhs.indexLength) ==
+           std::tie(rhs.vertexOffset, rhs.indexOffset, rhs.vertexLength, rhs.indexLength);
+}
+
+namespace gl {
+namespace detail {
+
+template <class A1, class A2>
+bool operator==(const Vertex<A1, A2>& lhs, const Vertex<A1, A2>& rhs) {
+    return std::tie(lhs.a1, lhs.a2) == std::tie(rhs.a1, rhs.a2);
+}
+
+} // namespace detail
+} // namespace gl
+} // namespace mbgl
+
 using namespace mbgl;
 
 namespace {
@@ -114,3 +134,142 @@ TEST(Buckets, RasterBucket) {
     bucket.clear();
     ASSERT_TRUE(bucket.needsUpload());
 }
+
+TEST(Buckets, RasterBucketMaskEmpty) {
+    RasterBucket bucket{ nullptr };
+    bucket.setMask({});
+    EXPECT_EQ((std::vector<RasterLayoutVertex>{}), bucket.vertices.vector());
+    EXPECT_EQ((std::vector<uint16_t>{}), bucket.indices.vector());
+    SegmentVector<RasterAttributes> expectedSegments;
+    expectedSegments.emplace_back(0, 0, 0, 0);
+    EXPECT_EQ(expectedSegments, bucket.segments);
+}
+
+TEST(Buckets, RasterBucketMaskNoChildren) {
+    RasterBucket bucket{ nullptr };
+    bucket.setMask({ CanonicalTileID{ 0, 0, 0 } });
+
+    // A mask of 0/0/0 doesn't produce buffers since we're instead using the global shared buffers.
+    EXPECT_EQ((std::vector<RasterLayoutVertex>{}), bucket.vertices.vector());
+    EXPECT_EQ((std::vector<uint16_t>{}), bucket.indices.vector());
+    EXPECT_EQ((SegmentVector<RasterAttributes>{}), bucket.segments);
+}
+
+ TEST(Buckets, RasterBucketMaskTwoChildren) {
+     RasterBucket bucket{ nullptr };
+     bucket.setMask(
+         { CanonicalTileID{ 1, 0, 0 }, CanonicalTileID{ 1, 1, 1 } });
+
+     EXPECT_EQ(
+         (std::vector<RasterLayoutVertex>{
+             // 1/0/1
+             RasterProgram::layoutVertex({ 0, 0 }, { 0, 0 }),
+             RasterProgram::layoutVertex({ 4096, 0 }, { 16384, 0 }),
+             RasterProgram::layoutVertex({ 0, 4096 }, { 0, 16384 }),
+             RasterProgram::layoutVertex({ 4096, 4096 }, { 16384, 16384 }),
+
+             // 1/1/1
+             RasterProgram::layoutVertex({ 4096, 4096 }, { 16384, 16384 }),
+             RasterProgram::layoutVertex({ 8192, 4096 }, { 32768, 16384 }),
+             RasterProgram::layoutVertex({ 4096, 8192 }, { 16384, 32768 }),
+             RasterProgram::layoutVertex({ 8192, 8192 }, { 32768, 32768 }),
+         }),
+         bucket.vertices.vector());
+
+     EXPECT_EQ(
+         (std::vector<uint16_t>{
+             // 1/0/1
+             0, 1, 2,
+             1, 2, 3,
+
+             // 1/1/1
+             4, 5, 6,
+             5, 6, 7,
+         }),
+         bucket.indices.vector());
+
+
+     SegmentVector<RasterAttributes> expectedSegments;
+     expectedSegments.emplace_back(0, 0, 8, 12);
+     EXPECT_EQ(expectedSegments, bucket.segments);
+ }
+
+ TEST(Buckets, RasterBucketMaskComplex) {
+     RasterBucket bucket{ nullptr };
+     bucket.setMask(
+         { CanonicalTileID{ 1, 0, 1 }, CanonicalTileID{ 1, 1, 0 }, CanonicalTileID{ 2, 2, 3 },
+           CanonicalTileID{ 2, 3, 2 }, CanonicalTileID{ 3, 6, 7 }, CanonicalTileID{ 3, 7, 6 } });
+
+     EXPECT_EQ(
+         (std::vector<RasterLayoutVertex>{
+             // 1/0/1
+             RasterProgram::layoutVertex({ 0, 4096 }, { 0, 16384 }),
+             RasterProgram::layoutVertex({ 4096, 4096 }, { 16384, 16384 }),
+             RasterProgram::layoutVertex({ 0, 8192 }, { 0, 32768 }),
+             RasterProgram::layoutVertex({ 4096, 8192 }, { 16384, 32768 }),
+
+             // 1/1/0
+             RasterProgram::layoutVertex({ 4096, 0 }, { 16384, 0 }),
+             RasterProgram::layoutVertex({ 8192, 0 }, { 32768, 0 }),
+             RasterProgram::layoutVertex({ 4096, 4096 }, { 16384, 16384 }),
+             RasterProgram::layoutVertex({ 8192, 4096 }, { 32768, 16384 }),
+
+             // 2/2/3
+             RasterProgram::layoutVertex({ 4096, 6144 }, { 16384, 24576 }),
+             RasterProgram::layoutVertex({ 6144, 6144 }, { 24576, 24576 }),
+             RasterProgram::layoutVertex({ 4096, 8192 }, { 16384, 32768 }),
+             RasterProgram::layoutVertex({ 6144, 8192 }, { 24576, 32768 }),
+
+             // 2/3/2
+             RasterProgram::layoutVertex({ 6144, 4096 }, { 24576, 16384 }),
+             RasterProgram::layoutVertex({ 8192, 4096 }, { 32768, 16384 }),
+             RasterProgram::layoutVertex({ 6144, 6144 }, { 24576, 24576 }),
+             RasterProgram::layoutVertex({ 8192, 6144 }, { 32768, 24576 }),
+
+             // 3/6/7
+             RasterProgram::layoutVertex({ 6144, 7168 }, { 24576, 28672 }),
+             RasterProgram::layoutVertex({ 7168, 7168 }, { 28672, 28672 }),
+             RasterProgram::layoutVertex({ 6144, 8192 }, { 24576, 32768 }),
+             RasterProgram::layoutVertex({ 7168, 8192 }, { 28672, 32768 }),
+
+             // 3/7/6
+             RasterProgram::layoutVertex({ 7168, 6144 }, { 28672, 24576 }),
+             RasterProgram::layoutVertex({ 8192, 6144 }, { 32768, 24576 }),
+             RasterProgram::layoutVertex({ 7168, 7168 }, { 28672, 28672 }),
+             RasterProgram::layoutVertex({ 8192, 7168 }, { 32768, 28672 }),
+         }),
+         bucket.vertices.vector());
+
+     EXPECT_EQ(
+         (std::vector<uint16_t>{
+             // 1/0/1
+             0, 1, 2,
+             1, 2, 3,
+
+             // 1/1/0
+             4, 5, 6,
+             5, 6, 7,
+
+             // 2/2/3
+             8, 9, 10,
+             9, 10, 11,
+
+             // 2/3/2
+             12, 13, 14,
+             13, 14, 15,
+
+             // 3/6/7
+             16, 17, 18,
+             17, 18, 19,
+
+             // 3/7/6
+             20, 21, 22,
+             21, 22, 23,
+         }),
+         bucket.indices.vector());
+
+
+     SegmentVector<RasterAttributes> expectedSegments;
+     expectedSegments.emplace_back(0, 0, 24, 36);
+     EXPECT_EQ(expectedSegments, bucket.segments);
+ }


### PR DESCRIPTION
This changes our raster tile rendering to avoid rendering in the parts of a tile that have children for. It accomplishes this by generating vertex buffers that only have quads for the respective areas, rather than having one quad to fill the entire tile.

The first part of the PR refactors Vertex/Index/Segment vectors into their own `IndexedPrimitive`/`Drawable` classes. We can apply the same pattern for other buckets in a separate PR.

The algorithm works by recursively descending from the tile in question and generating a list of tiles that would cover the tile, but not any of its children.

Finally, we're computing vertex buffers with our new `IndexedPrimitive` class and store the vertex buffers in a repository object.

Remaining tasks:

- [x] Render test
- [x] Delete unused mask buffers

Fixes https://github.com/mapbox/mapbox-gl-native/issues/9415, https://github.com/mapbox/mapbox-gl-native/issues/7760, and https://github.com/mapbox/mapbox-gl-native/issues/8678