### PR TITLE
Location accuracy threshold

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
@@ -79,6 +79,7 @@ public class MapboxMapOptions implements Parcelable {
   private int[] myLocationBackgroundPadding;
   private int myLocationAccuracyTintColor;
   private int myLocationAccuracyAlpha;
+  private float myLocationAccuracyThreshold;
 
   private String apiBaseUrl;
 
@@ -148,6 +149,7 @@ public class MapboxMapOptions implements Parcelable {
     myLocationBackgroundPadding = in.createIntArray();
     myLocationAccuracyAlpha = in.readInt();
     myLocationAccuracyTintColor = in.readInt();
+    myLocationAccuracyThreshold = in.readFloat();
 
     style = in.readString();
     apiBaseUrl = in.readString();
@@ -291,6 +293,8 @@ public class MapboxMapOptions implements Parcelable {
       mapboxMapOptions.myLocationAccuracyTint(
         typedArray.getColor(R.styleable.mapbox_MapView_mapbox_myLocationAccuracyTintColor,
           ColorUtils.getPrimaryColor(context)));
+      mapboxMapOptions.myLocationAccuracyThreshold(
+        typedArray.getFloat(R.styleable.mapbox_MapView_mapbox_myLocationAccuracyThreshold, 0));
       mapboxMapOptions.textureMode(
         typedArray.getBoolean(R.styleable.mapbox_MapView_mapbox_renderTextureMode, false));
     } finally {
@@ -681,6 +685,17 @@ public class MapboxMapOptions implements Parcelable {
   }
 
   /**
+   * Set accuracy circle threshold. Circle won't be displayed if accuracy is below set value.
+   *
+   * @param myLocationAccuracyThreshold Value of accuracy (in meters), below which circle won't be displayed
+   * @return This
+   */
+  public MapboxMapOptions myLocationAccuracyThreshold(float myLocationAccuracyThreshold) {
+    this.myLocationAccuracyThreshold = myLocationAccuracyThreshold;
+    return this;
+  }
+
+  /**
    * Enable TextureView as rendered surface.
    * <p>
    * Since the 4.2.0 release we replaced our TextureView with an SurfaceView implemenation.
@@ -988,6 +1003,15 @@ public class MapboxMapOptions implements Parcelable {
   }
 
   /**
+   * Returns current accuracy threshold value (in meters).
+   *
+   * @return Value of accuracy threshold (in meters), below which circle won't be displayed
+   */
+  public float getMyLocationAccuracyThreshold() {
+    return myLocationAccuracyThreshold;
+  }
+
+  /**
    * Get the current configured debug state for a map view.
    *
    * @return True indicates debug is enabled.
@@ -1065,6 +1089,7 @@ public class MapboxMapOptions implements Parcelable {
     dest.writeIntArray(myLocationBackgroundPadding);
     dest.writeInt(myLocationAccuracyAlpha);
     dest.writeInt(myLocationAccuracyTintColor);
+    dest.writeFloat(myLocationAccuracyThreshold);
 
     dest.writeString(style);
     dest.writeString(apiBaseUrl);
@@ -1153,6 +1178,9 @@ public class MapboxMapOptions implements Parcelable {
     if (myLocationAccuracyAlpha != options.myLocationAccuracyAlpha) {
       return false;
     }
+    if (myLocationAccuracyThreshold != options.myLocationAccuracyThreshold) {
+      return false;
+    }
     if (cameraPosition != null ? !cameraPosition.equals(options.cameraPosition) : options.cameraPosition != null) {
       return false;
     }
@@ -1230,6 +1258,8 @@ public class MapboxMapOptions implements Parcelable {
     result = 31 * result + Arrays.hashCode(myLocationBackgroundPadding);
     result = 31 * result + myLocationAccuracyTintColor;
     result = 31 * result + myLocationAccuracyAlpha;
+    result = 31 * result + (myLocationAccuracyThreshold != +0.0f
+      ? Float.floatToIntBits(myLocationAccuracyThreshold) : 0);
     result = 31 * result + (apiBaseUrl != null ? apiBaseUrl.hashCode() : 0);
     result = 31 * result + (textureMode ? 1 : 0);
     result = 31 * result + (style != null ? style.hashCode() : 0);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
@@ -71,6 +71,7 @@ public class MyLocationView extends View {
 
   private float accuracy;
   private Paint accuracyPaint;
+  private float accuracyThreshold;
 
   private ValueAnimator locationChangeAnimator;
   private ValueAnimator accuracyAnimator;
@@ -592,6 +593,16 @@ public class MyLocationView extends View {
   }
 
   /**
+   * Set accuracy circle threshold. Circle won't be displayed if accuracy is below set value.
+   * For internal use only.
+   *
+   * @param accuracyThreshold Value below which circle won't be displayed
+   */
+  public void setAccuracyThreshold(float accuracyThreshold) {
+    this.accuracyThreshold = accuracyThreshold;
+  }
+
+  /**
    * Set the bearing tracking mode, for internal use only.
    *
    * @param myBearingTrackingMode The bearing tracking mode
@@ -928,10 +939,11 @@ public class MyLocationView extends View {
         accuracyAnimator.end();
       }
 
-      accuracyAnimator = ValueAnimator.ofFloat(accuracy, location.getAccuracy());
+      float newAccuracy = location.getAccuracy() >= accuracyThreshold ? location.getAccuracy() : 0f;
+      accuracyAnimator = ValueAnimator.ofFloat(accuracy, newAccuracy);
       accuracyAnimator.setDuration(750);
       accuracyAnimator.start();
-      accuracy = location.getAccuracy();
+      accuracy = newAccuracy;
     }
 
     abstract void invalidate();

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationViewSettings.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationViewSettings.java
@@ -51,6 +51,7 @@ public class MyLocationViewSettings {
   //
 
   private int accuracyAlpha;
+  private float accuracyThreshold = 0f;
 
   @ColorInt
   private int accuracyTintColor;
@@ -93,6 +94,7 @@ public class MyLocationViewSettings {
     setBackgroundTintColor(options.getMyLocationBackgroundTintColor());
     setAccuracyAlpha(options.getMyLocationAccuracyAlpha());
     setAccuracyTintColor(options.getMyLocationAccuracyTintColor());
+    setAccuracyThreshold(options.getMyLocationAccuracyThreshold());
   }
 
   /**
@@ -291,6 +293,25 @@ public class MyLocationViewSettings {
   public void setAccuracyTintColor(@ColorInt int accuracyTintColor) {
     this.accuracyTintColor = accuracyTintColor;
     myLocationView.setAccuracyTint(accuracyTintColor);
+  }
+
+  /**
+   * Returns current accuracy threshold value (in meters).
+   *
+   * @return Value of accuracy threshold (in meters), below which circle won't be displayed
+   */
+  public float getAccuracyThreshold() {
+    return accuracyThreshold;
+  }
+
+  /**
+   * Set accuracy circle threshold. Circle won't be displayed if accuracy is below set value.
+   *
+   * @param accuracyThreshold Value of accuracy (in meters), below which circle won't be displayed
+   */
+  public void setAccuracyThreshold(float accuracyThreshold) {
+    this.accuracyThreshold = accuracyThreshold;
+    myLocationView.setAccuracyThreshold(accuracyThreshold);
   }
 
   public void setTilt(double tilt) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/attrs.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/attrs.xml
@@ -40,6 +40,7 @@
         <attr name="mapbox_myLocationBackgroundMarginBottom" format="dimension"/>
         <attr name="mapbox_myLocationAccuracyTintColor" format="color"/>
         <attr name="mapbox_myLocationAccuracyAlpha" format="integer"/>
+        <attr name="mapbox_myLocationAccuracyThreshold" format="float"/>
 
         <!--Compass-->
         <attr name="mapbox_uiCompass" format="boolean"/>


### PR DESCRIPTION
Follow up from external PR in https://github.com/mapbox/mapbox-gl-native/pull/9465

> Our users were complaining about location accuracy circle being present all the time, so here's a simple option to disable it for location updates with decent enough accuracy.

cc @LukasPaczos 