### PR TITLE
Add `-fvisibility=hidden` for all macOS targets to avoid linker warnings

### DIFF
--- a/platform/macos/config.cmake
+++ b/platform/macos/config.cmake
@@ -92,6 +92,9 @@ macro(mbgl_platform_glfw)
     target_link_libraries(mbgl-glfw
         PRIVATE mbgl-loop-darwin
     )
+    target_compile_options(mbgl-glfw
+        PRIVATE -fvisibility=hidden
+    )
 endmacro()
 
 
@@ -99,12 +102,18 @@ macro(mbgl_platform_render)
     target_link_libraries(mbgl-render
         PRIVATE mbgl-loop-darwin
     )
+    target_compile_options(mbgl-render
+        PRIVATE -fvisibility=hidden
+    )
 endmacro()
 
 
 macro(mbgl_platform_offline)
     target_link_libraries(mbgl-offline
         PRIVATE mbgl-loop-darwin
+    )
+    target_compile_options(mbgl-offline
+        PRIVATE -fvisibility=hidden
     )
 endmacro()
 


### PR DESCRIPTION
We are already compiling core and tests with `-fvisibility=hidden`, but not the glfw/render/offline targets. This leads to linker warnings like this:


> Direct access in function `mbgl::Tileset const& mapbox::util::variant<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, mbgl::Tileset>::get<mbgl::Tileset, (void*)0>() const` from file `.../build/macos/Debug/libmbgl-core.a(offline_download.o)` to global weak symbol `typeinfo for mapbox::util::bad_variant_access` from file `.../build/macos/mbgl.build/Debug/mbgl-glfw.build/Objects-normal/x86_64/glfw_view.o` means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.