### PR TITLE
Avoid creating InfoWindow iterator if no InfoWindows are shown

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/InfoWindowManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/InfoWindowManager.java
@@ -22,7 +22,8 @@ import java.util.List;
  */
 class InfoWindowManager {
 
-  private List<InfoWindow> infoWindows;
+  private final List<InfoWindow> infoWindows = new ArrayList<>();
+
   private MapboxMap.InfoWindowAdapter infoWindowAdapter;
   private boolean allowConcurrentMultipleInfoWindows;
 
@@ -30,13 +31,11 @@ class InfoWindowManager {
   private MapboxMap.OnInfoWindowLongClickListener onInfoWindowLongClickListener;
   private MapboxMap.OnInfoWindowCloseListener onInfoWindowCloseListener;
 
-  InfoWindowManager() {
-    this.infoWindows = new ArrayList<>();
-  }
-
   void update() {
-    for (InfoWindow infoWindow : infoWindows) {
-      infoWindow.update();
+    if (!infoWindows.isEmpty()) {
+      for (InfoWindow infoWindow : infoWindows) {
+        infoWindow.update();
+      }
     }
   }
 
@@ -54,10 +53,6 @@ class InfoWindowManager {
 
   boolean isAllowConcurrentMultipleOpenInfoWindows() {
     return allowConcurrentMultipleInfoWindows;
-  }
-
-  List<InfoWindow> getInfoWindows() {
-    return infoWindows;
   }
 
   boolean isInfoWindowValidForMarker(@NonNull Marker marker) {


### PR DESCRIPTION
Every time we receive a region change event, we are synchronizing Android SDK view components on top of the map. With profiling of gestures in #9476, I'm noticing we are allocating iterators for InfoWindows while no InfoWindows are shown. Checking for an empty avoids creating unneeded allocations.