### PR TITLE
[core] Enable prefetching for vector tiles

### DIFF
--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -99,15 +99,12 @@ void TilePyramid::update(const std::vector<Immutable<style::Layer::Impl>>& layer
         // Make sure we're not reparsing overzoomed raster tiles.
         if (type == SourceType::Raster) {
             tileZoom = idealZoom;
+        }
 
-            // FIXME: Prefetching is only enabled for raster
-            // tiles until we fix #7026.
-
-            // Request lower zoom level tiles (if configure to do so) in an attempt
-            // to show something on the screen faster at the cost of a little of bandwidth.
-            if (parameters.prefetchZoomDelta) {
-                panZoom = std::max<int32_t>(tileZoom - parameters.prefetchZoomDelta, zoomRange.min);
-            }
+        // Request lower zoom level tiles (if configure to do so) in an attempt
+        // to show something on the screen faster at the cost of a little of bandwidth.
+        if (parameters.prefetchZoomDelta) {
+            panZoom = std::max<int32_t>(tileZoom - parameters.prefetchZoomDelta, zoomRange.min);
 
             if (panZoom < tileZoom) {
                 panTiles = util::tileCover(parameters.transformState, panZoom);


### PR DESCRIPTION
Was not enabled because of label flickering.