### PR TITLE
[build] Update GLFW to 2017-07-13-67c9155

### DIFF
--- a/cmake/glfw.cmake
+++ b/cmake/glfw.cmake
@@ -10,17 +10,6 @@ target_sources(mbgl-glfw
     PRIVATE platform/default/mbgl/util/default_styles.hpp
 )
 
-# Our GL implementation is internal to mbgl-core, which causes the GL header to
-# be included after GLFW's own header. They both attempt to define GLAPIENTRY,
-# but unfortunately the GL header doesn't check if it was previously defined,
-# causing a macro redefinition compiler error.
-# There is no particular compiler warning flag to ignore this check on GCC
-# neither it does accept ignoring '-Werror' via diagnostics pragmas. We can
-# only suppress this by either replacing the header path inclusion from -I to
-# -isystem, or completely suppressing errors. Until the former solution is not
-# available, we'll suppress the errors from that definition file.
-set_source_files_properties(platform/glfw/glfw_view.cpp PROPERTIES COMPILE_FLAGS -Wno-error)
-
 target_compile_options(mbgl-glfw
     PRIVATE -fvisibility-inlines-hidden
 )

--- a/platform/linux/config.cmake
+++ b/platform/linux/config.cmake
@@ -1,4 +1,4 @@
-mason_use(glfw VERSION 2017-02-09-77a8f10)
+mason_use(glfw VERSION 2017-07-13-67c9155)
 mason_use(mesa VERSION 13.0.4)
 mason_use(boost_libprogram_options VERSION 1.62.0${MASON_CXXABI_SUFFIX})
 mason_use(sqlite VERSION 3.14.2)

--- a/platform/macos/config.cmake
+++ b/platform/macos/config.cmake
@@ -1,6 +1,6 @@
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.10)
 
-mason_use(glfw VERSION 2017-02-09-77a8f10)
+mason_use(glfw VERSION 2017-07-13-67c9155)
 mason_use(boost_libprogram_options VERSION 1.62.0)
 mason_use(gtest VERSION 1.8.0)
 mason_use(benchmark VERSION 1.0.0-1)


### PR DESCRIPTION
This GLFW version properly attempts to define GLAPIENTRY (if not previously defined) only _after_ including the GL headers. With this fix, we no longer need to workaround on `glfw_view.cpp` by adding `-Wno-error` as compilation parameter.