### PR TITLE
[build] Publish node packages with RelWithDebInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if(WITH_COVERAGE)
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
 endif(WITH_COVERAGE)
 
-set(CMAKE_CONFIGURATION_TYPES Debug Release Sanitize)
+set(CMAKE_CONFIGURATION_TYPES Debug Release RelWithDebugInfo Sanitize)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -ftemplate-depth=1024 -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Werror -Wno-variadic-macros -Wno-unknown-pragmas")
 if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
@@ -76,6 +76,7 @@ if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=unused-command-line-argument")
 endif()
 set(CMAKE_CXX_FLAGS_RELEASE "-Os -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -DNDEBUG")
 set(CMAKE_CXX_FLAGS_SANITIZE "-O1 -g -fno-omit-frame-pointer -fno-optimize-sibling-calls")
 
 

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@ export BUILDTYPE ?= Debug
 export WITH_CXX11ABI ?= $(shell scripts/check-cxx11abi.sh)
 
 ifeq ($(BUILDTYPE), Release)
+else ifeq ($(BUILDTYPE), RelWithDebInfo)
 else ifeq ($(BUILDTYPE), Sanitize)
 else ifeq ($(BUILDTYPE), Debug)
 else
-  $(error BUILDTYPE must be Debug, Sanitize or Release)
+  $(error BUILDTYPE must be Debug, Sanitize, Release or RelWithDebInfo)
 endif
 
 buildtype := $(shell echo "$(BUILDTYPE)" | tr "[A-Z]" "[a-z]")

--- a/circle.yml
+++ b/circle.yml
@@ -265,7 +265,7 @@ jobs:
     environment:
       LIBSYSCONFCPUS: 4
       JOBS: 4
-      BUILDTYPE: Release
+      BUILDTYPE: RelWithDebInfo
       WITH_EGL: 1
       PACKAGE_JSON_VERSION: $(node -e "console.log(require('./package.json').version)")
       PUBLISH: $([[ "${CIRCLE_BRANCH}" == "node-v${PACKAGE_JSON_VERSION}" ]] && echo true)
@@ -289,7 +289,7 @@ jobs:
     environment:
       LIBSYSCONFCPUS: 4
       JOBS: 4
-      BUILDTYPE: Release
+      BUILDTYPE: RelWithDebInfo
       WITH_EGL: 1
       PACKAGE_JSON_VERSION: $(node -e "console.log(require('./package.json').version)")
       PUBLISH: $([[ "${CIRCLE_BRANCH}" == "node-v${PACKAGE_JSON_VERSION}" ]] && echo true)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-native",
-  "version": "3.5.4",
+  "version": "3.5.5",
   "description": "Renders map tiles with Mapbox GL",
   "keywords": [
     "mapbox",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.5.5 - July 14, 2017
+- Provide debuggable release builds for node packages [#9497](https://github.com/mapbox/mapbox-gl-native/pull/9497)
+
 # 3.5.4 - June 6, 2017
 - Add support for ImageSource [#8968](https://github.com/mapbox/mapbox-gl-native/pull/8968)
 - Fixed an issue with `map.addImage()` which would cause added images to randomly be replaced with images found the style's sprite sheet ([#9119](https://github.com/mapbox/mapbox-gl-native/pull/9119))

--- a/platform/node/bitrise.yml
+++ b/platform/node/bitrise.yml
@@ -64,7 +64,7 @@ workflows:
             brew install cmake awscli node@4 node@6
             brew link node@4 --force
             gem install xcpretty --no-rdoc --no-ri
-            export BUILDTYPE=Release
+            export BUILDTYPE=RelWithDebInfo
             export PUBLISH=true
             make test-node && ./platform/node/scripts/after_success.sh
             brew unlink node@4

--- a/platform/node/scripts/after_success.sh
+++ b/platform/node/scripts/after_success.sh
@@ -3,10 +3,13 @@
 set -e
 set -o pipefail
 
-if [[ "${PUBLISH:-}" == "true" ]]; then
-    if [[ "${BUILDTYPE}" == "Release" ]]; then
+if [[ -n ${PUBLISH:-} ]]; then
+    if [[ "${BUILDTYPE}" == "RelWithDebInfo" ]]; then
         ./node_modules/.bin/node-pre-gyp package publish info
-    else
+    elif [[ "${BUILDTYPE}" == "Debug" ]]; then
         ./node_modules/.bin/node-pre-gyp package publish info --debug
+    else
+        echo "error: must provide either Debug or RelWithDebInfo for BUILDTYPE"
+        exit 1
     fi
 fi


### PR DESCRIPTION
Follow-up to #9154 - Make node release binaries debuggable - after switching to CircleCI.

From @bsudekum original notes:
> This change makes Node release binaries a little bit more debuggable. Now when there is a crash in production, we should get more information including line numbers. There is no speed implications here, the only downside is an increase in binary size (currently, release binaries are ~2mb).

/cc @springmeyer @tmpsantos 