### PR TITLE
[core] Make sure ThreadLocal will not own the pointer it is managing

### DIFF
--- a/platform/default/thread_local.cpp
+++ b/platform/default/thread_local.cpp
@@ -29,7 +29,11 @@ ThreadLocal<T>::ThreadLocal() : impl(std::make_unique<Impl>()) {
 
 template <class T>
 ThreadLocal<T>::~ThreadLocal() {
-    delete get();
+    // ThreadLocal will not take ownership
+    // of the pointer it is managing. The pointer
+    // needs to be explicitly cleared before we
+    // destroy this object.
+    assert(!get());
 
     if (pthread_key_delete(impl->key)) {
         Log::Error(Event::General, "Failed to delete local storage key.");

--- a/platform/qt/src/thread_local.cpp
+++ b/platform/qt/src/thread_local.cpp
@@ -4,6 +4,7 @@
 #include <mbgl/map/backend_scope.hpp>
 
 #include <array>
+#include <cassert>
 
 #include <QThreadStorage>
 
@@ -23,7 +24,11 @@ ThreadLocal<T>::ThreadLocal() : impl(std::make_unique<Impl>()) {
 
 template <class T>
 ThreadLocal<T>::~ThreadLocal() {
-    delete get();
+    // ThreadLocal will not take ownership
+    // of the pointer it is managing. The pointer
+    // needs to be explicitly cleared before we
+    // destroy this object.
+    assert(!get());
 }
 
 template <class T>

--- a/scripts/valgrind.sup
+++ b/scripts/valgrind.sup
@@ -76,11 +76,3 @@
    fun:_ZN4mbgl4util10write_fileERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES8_
    ...
 }
-{
-   Qt5 ThreadStorage
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:_Znwm
-   fun:_Z24qThreadStorage_localDataISt5arrayIPiLm1EEERT_R18QThreadStorageDataPS3_.isra.5
-   ...
-}


### PR DESCRIPTION
ThreadLocal should not own the pointer it is managing because the use case
in Mapbox GL is to keep a pointer to a stack allocated object, like:

``` 
MyObject foo;
threadLocal.set(&foo);
```

To keep consistency, it is required that we clear the managed object before
ThreadLocal gets destroyed by setting it to `nullptr`.