### PR TITLE
Fix undefined access for HTTP responses that don't contain a body

### DIFF
--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -188,11 +188,11 @@ std::pair<bool, uint64_t> OfflineDatabase::putInternal(const Resource& resource,
     if (resource.kind == Resource::Kind::Tile) {
         assert(resource.tileData);
         inserted = putTile(*resource.tileData, response,
-                compressed ? compressedData : *response.data,
+                compressed ? compressedData : response.data ? *response.data : "",
                 compressed);
     } else {
         inserted = putResource(resource, response,
-                compressed ? compressedData : *response.data,
+                compressed ? compressedData : response.data ? *response.data : "",
                 compressed);
     }
 


### PR DESCRIPTION
Found via https://github.com/mapbox/mapbox-gl-native/issues/9499