### PR TITLE
Fix undefined behavior warning in quads.cpp

### DIFF
--- a/test/text/quads.test.cpp
+++ b/test/text/quads.test.cpp
@@ -13,7 +13,7 @@ TEST(getIconQuads, normal) {
     SymbolLayoutProperties::Evaluated layout;
     Anchor anchor(2.0, 3.0, 0.0, 0.5f, 0);
     ImagePosition image = {
-        mapbox::Bin(-1, 15, 11, 0, 0),
+        mapbox::Bin(-1, 15, 11, 0, 0, 0, 0),
         style::Image::Impl("test", PremultipliedImage({1,1}), 1.0)
     };
 
@@ -38,7 +38,7 @@ TEST(getIconQuads, normal) {
 TEST(getIconQuads, style) {
     Anchor anchor(0.0, 0.0, 0.0, 0.5f, 0);
     ImagePosition image = {
-        mapbox::Bin(-1, 20, 20, 0, 0),
+        mapbox::Bin(-1, 20, 20, 0, 0, 0, 0),
         style::Image::Impl("test", PremultipliedImage({1,1}), 1.0)
     };
 


### PR DESCRIPTION
quads.test.cpp used a bin with unsupported x/y coordinates, which caused an undefined behavior warning tracked in issue #9499.

/cc @kkaefer 