### PR TITLE
Fix undefined behavior for division through 0

### DIFF
--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -168,7 +168,7 @@ void Transform::flyTo(const CameraOptions &camera, const AnimationOptions &anima
     double angle = camera.angle.value_or(getAngle());
     double pitch = camera.pitch.value_or(getPitch());
 
-    if (std::isnan(zoom)) {
+    if (std::isnan(zoom) || state.size.isEmpty()) {
         return;
     }
 

--- a/src/mbgl/text/collision_feature.cpp
+++ b/src/mbgl/text/collision_feature.cpp
@@ -135,7 +135,7 @@ void CollisionFeature::bboxifyLabel(const GeometryCoordinates& line, GeometryCoo
         // This makes our calculation spot-on at scale=2, and on the conservative side for
         // lower scales
         const float distanceToInnerEdge = std::max(std::fabs(boxDistanceToAnchor - firstBoxOffset) - step / 2, 0.0f);
-        float maxScale = labelLength / 2 / distanceToInnerEdge;
+        float maxScale = util::division(labelLength / 2, distanceToInnerEdge, std::numeric_limits<float>::infinity());
 
         // The box maxScale calculations are designed to be conservative on collisions in the scale range
         // [1,2]. At scale=1, each box has 50% overlap, and at scale=2, the boxes are lined up edge

--- a/src/mbgl/util/math.hpp
+++ b/src/mbgl/util/math.hpp
@@ -106,5 +106,18 @@ T smoothstep(T edge0, T edge1, T x) {
     return t * t * (T(3) - T(2) * t);
 }
 
+template <typename T>
+inline T division(const T dividend, const T divisor, const T nan) {
+    if (divisor == 0) {
+        if (dividend == 0) {
+            return nan;
+        } else {
+            return std::copysign(std::numeric_limits<T>::infinity(), dividend);
+        }
+    } else {
+        return dividend / divisor;
+    }
+}
+
 } // namespace util
 } // namespace mbgl


### PR DESCRIPTION
Introduces a `util::division` function that allows specifying a value for the `0/0` (NaN) case.