### PR TITLE
Update docs replacing Bitrise mentions with CircleCI

### DIFF
--- a/platform/android/README.md
+++ b/platform/android/README.md
@@ -1,6 +1,6 @@
 # [Mapbox Android SDK](https://www.mapbox.com/android-sdk/)
 
-[![Bitrise](https://www.bitrise.io/app/79cdcbdc42de4303.svg?token=_InPF8bII6W7J6kFr-L8QQ&branch=master)](https://www.bitrise.io/app/79cdcbdc42de4303)
+[![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native/tree/master)
 
 A library based on [Mapbox GL Native](../../README.md) for embedding interactive map views with scalable, customizable vector maps into Java applications on Android devices.
 

--- a/platform/android/tests/docs/UI_TESTS.md
+++ b/platform/android/tests/docs/UI_TESTS.md
@@ -61,7 +61,7 @@ You can generate JaCoCo reports from espresso tests by
 ## Running Espresso test automatically on AWS Device Farm
 To run tests on AWS device farm you need to execute `./gradlew -Pmapbox.abis=none devicefarmUpload`.
 You can configure the different steps in the testapp `build.gradle`.
-AWS credentials are found in bitrise.
+AWS credentials are found in CircleCI.
 
 
 

--- a/platform/android/tests/docs/UNIT_TESTS.md
+++ b/platform/android/tests/docs/UNIT_TESTS.md
@@ -77,7 +77,7 @@ The Unit tests are executed as part of the build process on our CI and are
 automatically run for each new commit pushed to this repo. If a Unit tests
 fails, this will fail and stop the build.
 
-You can find this gradle command in our [buildscript](https://github.com/mapbox/mapbox-gl-native/blob/master/platform/android/bitrise.yml#L48):
+You can find this gradle command in our [buildscript](https://github.com/mapbox/mapbox-gl-native/blob/master/circle.yml#L146-L215):
 
 ```
 $ ./gradlew -Pmapbox.abis=none testReleaseUnitTest


### PR DESCRIPTION
I noticed that the build badge on the Android README file was outdated. I took the opportunity to update a couple more things.
