### PR TITLE
[Qt] Align database creation behavior with the default implementation

### DIFF
--- a/platform/qt/src/sqlite3.cpp
+++ b/platform/qt/src/sqlite3.cpp
@@ -50,6 +50,15 @@ void checkDatabaseError(const QSqlDatabase &db) {
     }
 }
 
+void checkDatabaseOpenError(const QSqlDatabase &db) {
+    // Assume every error when opening the data as CANTOPEN. Qt
+    // always returns -1 for `nativeErrorCode()` on database errors.
+    QSqlError lastError = db.lastError();
+    if (lastError.type() != QSqlError::NoError) {
+        throw Exception { Exception::Code::CANTOPEN, "Error opening the database." };
+    }
+}
+
 class DatabaseImpl {
 public:
     DatabaseImpl(const char* filename, int flags) {
@@ -77,7 +86,7 @@ public:
         db->setDatabaseName(QString(filename));
 
         if (!db->open()) {
-            checkDatabaseError(*db);
+            checkDatabaseOpenError(*db);
         }
     }
 
@@ -143,7 +152,7 @@ void Database::setBusyTimeout(std::chrono::milliseconds timeout) {
     }
     impl->db->setConnectOptions(connectOptions);
     if (!impl->db->open()) {
-        checkDatabaseError(*impl->db);
+        checkDatabaseOpenError(*impl->db);
     }
 }
 

--- a/test/storage/sqlite.test.cpp
+++ b/test/storage/sqlite.test.cpp
@@ -25,3 +25,14 @@ TEST(SQLite, Statement) {
     ASSERT_EQ(stmt2.lastInsertRowId(), 2);
     ASSERT_EQ(stmt2.changes(), 1u);
 }
+
+TEST(SQLite, TEST_REQUIRES_WRITE(CantOpenException)) {
+    try {
+        // Should throw a CANTOPEN when the database doesn't exist,
+        // make sure all the backends behave the same way.
+        mapbox::sqlite::Database("test/fixtures/offline_database/foobar123.db", mapbox::sqlite::ReadOnly);
+        FAIL();
+    } catch (mapbox::sqlite::Exception& ex) {
+        ASSERT_EQ(ex.code, mapbox::sqlite::Exception::Code::CANTOPEN);
+    }
+}


### PR DESCRIPTION
Qt doesn't throw a Exception::Code::CANTOPEN when trying to open a database
that doesn't exist without the Create flag.

Another attempt to fix #9108