### PR TITLE
[build] Fix node package publish logic

### DIFF
--- a/platform/node/scripts/after_success.sh
+++ b/platform/node/scripts/after_success.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-if [[ -n ${PUBLISH:-} ]]; then
+if [[ "${PUBLISH:-}" == true ]]; then
     if [[ "${BUILDTYPE}" == "RelWithDebInfo" ]]; then
         ./node_modules/.bin/node-pre-gyp package publish info
     elif [[ "${BUILDTYPE}" == "Debug" ]]; then


### PR DESCRIPTION
CircleCI always sets `PUBLISH`, so we need an extra check if it is set to `true`.