### PR TITLE
[build] Add ccache install reminder and docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,8 @@ if(CCACHE_PROGRAM)
         # Clang also thinks that ccache isn't interactive, so we explicitly need to enable color.
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments -fcolor-diagnostics")
     endif()
+else()
+    message(STATUS "Can't find ccache — consider installing ccache to improve recompilation performance")
 endif()
 
 if(NOT EXISTS ${CMAKE_SOURCE_DIR}/platform/${MBGL_PLATFORM}/config.cmake)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,14 +11,14 @@ Your journey will start with getting the source code, then installing the
 dependencies, and then setting up a development environment, which varies
 depending on your operating system and what platform you want to develop for.
 
-## 1: Getting the Source
+## 1: Getting the source
 
 Clone the git repository:
 
     git clone https://github.com/mapbox/mapbox-gl-native.git
     cd mapbox-gl-native
 
-## 2: Installing Dependencies
+## 2: Installing dependencies
 
 These dependencies are required for all operating systems and all platform
 targets.
@@ -34,16 +34,20 @@ targets.
 Depending on your operating system and target, you'll need additional
 dependencies:
 
-### Additional Dependencies for Linux
+### Additional dependencies for Linux
 
  - [`libcurl`](http://curl.haxx.se/libcurl/) (depends on OpenSSL)
 
-### Additional Dependencies for macOS
+### Additional dependencies for macOS
 
  - Apple Command Line Tools (available at [Apple Developer](https://developer.apple.com/download/more/))
  - [Homebrew](http://brew.sh)
  - [Cask](http://caskroom.io/) (if building for Android)
  - [xcpretty](https://github.com/supermarin/xcpretty) (`gem install xcpretty`)
+
+### Optional dependencies
+
+- [ccache](https://ccache.samba.org) (for build only; improves recompilation performance)
 
 ## 3: Setting up a development environment & building
 


### PR DESCRIPTION
ccache support was added in https://github.com/mapbox/mapbox-gl-native/pull/9399 — this PR follows up with some helpful docs/notes:

- Prints a reminder to install ccache if it’s not found while cmake is setting up.
- Adds ccache to the core install doc as an optional dependency.

/cc @kkaefer