### PR TITLE
[android] - bump OkHttp dependency 

### DIFF
--- a/platform/android/dependencies.gradle
+++ b/platform/android/dependencies.gradle
@@ -47,7 +47,7 @@ ext {
 
             // square crew
             timber                 : 'com.jakewharton.timber:timber:4.5.1',
-            okhttp3                : 'com.squareup.okhttp3:okhttp:3.7.0',
+            okhttp3                : 'com.squareup.okhttp3:okhttp:3.8.0',
             leakCanaryDebug        : "com.squareup.leakcanary:leakcanary-android:${leakCanaryVersion}",
             leakCanaryRelease      : "com.squareup.leakcanary:leakcanary-android-no-op:${leakCanaryVersion}",
             leakCanaryTest         : "com.squareup.leakcanary:leakcanary-android-no-op:${leakCanaryVersion}"


### PR DESCRIPTION
Bumping OkHttp dependency to avoid null pointers in Android 7.0
More information in https://github.com/square/okhttp/issues/3245.
Closes #9521 
