### PR TITLE
Xcode uses wrong compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,21 +92,27 @@ find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
     set(C_LAUNCHER   "${CCACHE_PROGRAM}")
     set(CXX_LAUNCHER "${CCACHE_PROGRAM}")
-    configure_file(scripts/launch-c.in   launch-c)
-    configure_file(scripts/launch-cxx.in launch-cxx)
-    execute_process(COMMAND chmod a+rx "${CMAKE_BINARY_DIR}/launch-c" "${CMAKE_BINARY_DIR}/launch-cxx")
 
     if(CMAKE_GENERATOR STREQUAL "Xcode")
         # Set Xcode project attributes to route compilation and linking through our scripts
+        # Xcode doesn't include the path to the compiler/linker by default, so we'll have to add it.
+        configure_file(scripts/launch-c-xcode.in   launch-c   @ONLY)
+        configure_file(scripts/launch-cxx-xcode.in launch-cxx @ONLY)
+
         set(CMAKE_XCODE_ATTRIBUTE_CC         "${CMAKE_BINARY_DIR}/launch-c")
         set(CMAKE_XCODE_ATTRIBUTE_CXX        "${CMAKE_BINARY_DIR}/launch-cxx")
         set(CMAKE_XCODE_ATTRIBUTE_LD         "${CMAKE_BINARY_DIR}/launch-c")
         set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${CMAKE_BINARY_DIR}/launch-cxx")
     else()
         # Support Unix Makefiles and Ninja
+        configure_file(scripts/launch-c.in   launch-c   @ONLY)
+        configure_file(scripts/launch-cxx.in launch-cxx @ONLY)
+
         set(CMAKE_C_COMPILER_LAUNCHER        "${CMAKE_BINARY_DIR}/launch-c")
         set(CMAKE_CXX_COMPILER_LAUNCHER      "${CMAKE_BINARY_DIR}/launch-cxx")
     endif()
+
+    execute_process(COMMAND chmod a+rx "${CMAKE_BINARY_DIR}/launch-c" "${CMAKE_BINARY_DIR}/launch-cxx")
 
     if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
         # ccache splits up the compile steps, so we end up with unused arguments in some steps.

--- a/scripts/launch-c-xcode.in
+++ b/scripts/launch-c-xcode.in
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+export CCACHE_CPP2=true
+exec "@C_LAUNCHER@" "${DEVELOPER_DIR}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" "$@"

--- a/scripts/launch-c.in
+++ b/scripts/launch-c.in
@@ -1,10 +1,4 @@
 #!/bin/sh
 
-# Xcode generator doesn't include the compiler as the
-# first argument, Ninja and Makefiles do. Handle both cases.
-if [ "$1" = "${CMAKE_C_COMPILER}" ] ; then
-    shift
-fi
-
 export CCACHE_CPP2=true
-exec "${C_LAUNCHER}" "${CMAKE_C_COMPILER}" "$@"
+exec "@C_LAUNCHER@" "$@"

--- a/scripts/launch-cxx-xcode.in
+++ b/scripts/launch-cxx-xcode.in
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+export CCACHE_CPP2=true
+exec "@CXX_LAUNCHER@" "${DEVELOPER_DIR}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++" "$@"

--- a/scripts/launch-cxx.in
+++ b/scripts/launch-cxx.in
@@ -1,10 +1,4 @@
 #!/bin/sh
 
-# Xcode generator doesn't include the compiler as the
-# first argument, Ninja and Makefiles do. Handle both cases.
-if [ "$1" = "${CMAKE_CXX_COMPILER}" ] ; then
-    shift
-fi
-
 export CCACHE_CPP2=true
-exec "${CXX_LAUNCHER}" "${CMAKE_CXX_COMPILER}" "$@"
+exec "@CXX_LAUNCHER@" "$@"

--- a/test/algorithm/update_renderables.test.cpp
+++ b/test/algorithm/update_renderables.test.cpp
@@ -100,8 +100,6 @@ auto createTileDataFn(ActionLog& log, T& dataTiles) {
     };
 }
 
-// Unused template argument to fix Clang crash
-// See https://github.com/mapbox/mapbox-gl-native/pull/9501
 template <typename = int>
 auto retainTileDataFn(ActionLog& log) {
     return [&](auto& tileData, Resource::Necessity necessity) {
@@ -109,8 +107,6 @@ auto retainTileDataFn(ActionLog& log) {
     };
 }
 
-// Unused template argument to fix Clang crash
-// See https://github.com/mapbox/mapbox-gl-native/pull/9501
 template <typename = int>
 auto renderTileFn(ActionLog& log) {
     return [&](const auto& id, auto& tileData) {


### PR DESCRIPTION
When using Xcode installed in a non-standard location, CMake will use the wrong compiler when building the ccache launch script introduced in https://github.com/mapbox/mapbox-gl-native/pull/9399.

* Instead of picking the one for the currently enabled Xcode (activated with `xcode-select`), it'll always use `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang`
* Even when opening the generated project with another Xcode.app (e.g. with a beta version) it *still* uses the default compiler, rather than the compiler that ships with the Xcode.app that executes the build.

/cc @mapbox/ios 