### PR TITLE
[build] Compile iOS static library as Relocatable Object File

### DIFF
--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -2840,7 +2840,9 @@
 			baseConfigurationReference = 55D8C9941D0F133500F42F10 /* config.xcconfig */;
 			buildSettings = {
 				BITCODE_GENERATION_MODE = bitcode;
+				DEAD_CODE_STRIPPING = NO;
 				HEADER_SEARCH_PATHS = "$(mbgl_core_INCLUDE_DIRECTORIES)";
+				MACH_O_TYPE = mh_object;
 				OTHER_CFLAGS = "-fvisibility=hidden";
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
@@ -2867,7 +2869,9 @@
 			baseConfigurationReference = 55D8C9941D0F133500F42F10 /* config.xcconfig */;
 			buildSettings = {
 				BITCODE_GENERATION_MODE = bitcode;
+				DEAD_CODE_STRIPPING = NO;
 				HEADER_SEARCH_PATHS = "$(mbgl_core_INCLUDE_DIRECTORIES)";
+				MACH_O_TYPE = mh_object;
 				OTHER_CFLAGS = "-fvisibility=hidden";
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",


### PR DESCRIPTION
This is an experimental change, PR’d for discussion.

### Changes
Sets the iOS static library’s Mach-O Type to Relocatable Object File (`mh_object`), where it was previously the default, Static Library (`staticlib`). Also disables dead code stripping on the static library, as this is not compatible with `mh_object`.

 ### Effect
This reduces the uncompressed size of a release-build, symbol-stripped static library from 280 MB to 110 MB. See the footnote in https://github.com/mapbox/mapbox-gl-native/pull/9022#issuecomment-315895565 for raw numbers. This has no effect on the ultimate size of an application.

### Mechanism
Per [this post](https://stackoverflow.com/a/6604697/2094275) about the `ld` docs, enabling relocation: “Merges object files to produce another mach-o object file with file type `MH_OBJECT`.” And [per this post](https://stackoverflow.com/a/16492468/2094275) this has the effect of “helping” mark symbols as private, which probably accounts for some of the size reduction.

### Questions
#### Does this still qualify as a sufficiently static library?
Is it compatible with our current static library? So far, the answer is yes: inserting this library into an existing app works as expected. Have tested with Swift, will need to test with Obj-C.

#### Does this affect debugging in client apps?
Have not tested yet.

#### Does this break anything? 😬
So far, no, but our static library testing infrastructure is weak. Our symbol visibility script does not indicate any missing symbols.

### Related issues
https://github.com/mapbox/mapbox-gl-native/issues/8089, https://github.com/mapbox/mapbox-gl-native/pull/9022

/cc @boundsj @kkaefer @1ec5