### PR TITLE
[Qt] Destroy the map object before the renderer frontend

### DIFF
--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -58,8 +58,8 @@ public:
 
     std::shared_ptr<mbgl::DefaultFileSource> fileSourceObj;
     std::shared_ptr<mbgl::ThreadPool> threadPool;
-    std::unique_ptr<mbgl::Map> mapObj;
     std::unique_ptr<QMapboxGLRendererFrontend> frontend;
+    std::unique_ptr<mbgl::Map> mapObj;
 
     bool dirty { false };
 


### PR DESCRIPTION
The Map object will call the renderer frontend on its destructor.

Fixes #9535.