### PR TITLE
port backendscope changes to release branch

### DIFF
--- a/cmake/test-files.cmake
+++ b/cmake/test-files.cmake
@@ -42,6 +42,7 @@ set(MBGL_TEST_FILES
     test/programs/binary_program.test.cpp
 
     # renderer
+    test/renderer/backend_scope.test.cpp
     test/renderer/group_by_layout.test.cpp
 
     # sprite

--- a/include/mbgl/map/backend.hpp
+++ b/include/mbgl/map/backend.hpp
@@ -3,6 +3,7 @@
 #include <mbgl/map/map_observer.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/size.hpp>
+#include <mbgl/util/util.hpp>
 
 #include <memory>
 #include <mutex>
@@ -79,5 +80,9 @@ private:
 
     friend class BackendScope;
 };
+
+constexpr bool operator==(const Backend& a, const Backend& b) {
+    return &a == &b;
+}
 
 } // namespace mbgl

--- a/include/mbgl/map/backend_scope.hpp
+++ b/include/mbgl/map/backend_scope.hpp
@@ -22,10 +22,14 @@ public:
     static bool exists();
 
 private:
+    void activate();
+    void deactivate();
+
     BackendScope* priorScope;
     BackendScope* nextScope;
     Backend& backend;
     const ScopeType scopeType;
+    bool activated = false;
 };
 
 } // namespace mbgl

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -120,9 +120,6 @@ gl::ProcAddress NativeMapView::initializeExtension(const char* name) {
 }
 
 void NativeMapView::activate() {
-    if (active++) {
-        return;
-    }
 
     oldDisplay = eglGetCurrentDisplay();
     oldReadSurface = eglGetCurrentSurface(EGL_READ);
@@ -151,10 +148,6 @@ void NativeMapView::activate() {
  * From mbgl::Backend.
  */
 void NativeMapView::deactivate() {
-    if (--active) {
-        return;
-    }
-
     assert(vm != nullptr);
 
     if (oldContext != context && oldContext != EGL_NO_CONTEXT) {

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -334,8 +334,6 @@ private:
     std::shared_ptr<mbgl::ThreadPool> threadPool;
     std::unique_ptr<mbgl::Map> map;
     mbgl::EdgeInsets insets;
-
-    unsigned active = 0;
 };
 
 } // namespace android

--- a/test/renderer/backend_scope.test.cpp
+++ b/test/renderer/backend_scope.test.cpp
@@ -1,0 +1,113 @@
+#include <mbgl/test/util.hpp>
+
+#include <mbgl/map/backend.hpp>
+#include <mbgl/map/backend_scope.hpp>
+
+#include <functional>
+
+using namespace mbgl;
+
+class StubBackend: public Backend {
+public:
+
+    void activate() override {
+        if (activateFunction) activateFunction();
+    }
+
+    void deactivate() override {
+        if (deactivateFunction) deactivateFunction();
+    }
+
+    void updateAssumedState() override {
+        if (updateAssumedStateFunction) updateAssumedStateFunction();
+    }
+
+    void invalidate() override {}
+
+    gl::ProcAddress initializeExtension(const char* ext) override {
+        if (initializeExtensionFunction) {
+            return initializeExtensionFunction(ext);
+        } else {
+            return {};
+        }
+    }
+
+    std::function<void ()> activateFunction;
+    std::function<void ()> deactivateFunction;
+    std::function<void ()> updateAssumedStateFunction;
+    std::function<gl::ProcAddress (const char*)> initializeExtensionFunction;
+};
+
+// A scope should activate on construction
+// and deactivate on descruction (going out
+// of scope)
+TEST(BackendScope, SingleScope) {
+    bool activated;
+    bool deactivated;
+
+    StubBackend backend;
+    backend.activateFunction = [&] { activated = true; };
+    backend.deactivateFunction = [&] { deactivated = true; };
+
+    {
+        BackendScope test { backend };
+    }
+
+    ASSERT_TRUE(activated);
+    ASSERT_TRUE(deactivated);
+}
+
+// With nested scopes, only the outer scope
+// should activate/deactivate
+TEST(BackendScope, NestedScopes) {
+    int activated = 0;
+    int deactivated = 0;
+
+    StubBackend backend;
+    backend.activateFunction = [&] { activated++; };
+    backend.deactivateFunction = [&] { deactivated++; };
+
+    {
+        BackendScope outer { backend };
+        ASSERT_EQ(1, activated);
+        {
+            BackendScope inner { backend };
+            ASSERT_EQ(1, activated);
+        }
+        ASSERT_EQ(0, deactivated);
+    }
+
+    ASSERT_EQ(1, deactivated);
+}
+
+// With chained scopes, where scopes have
+// different backends, the scopes should each
+// activate the scope on entering and de-activating
+// on leaving the scope
+TEST(BackendScope, ChainedScopes) {
+    bool activatedA = false;
+    bool activatedB = false;
+    
+    StubBackend backendA;
+    backendA.activateFunction = [&] { activatedA = true; };
+    backendA.deactivateFunction = [&] { activatedA = false; };
+    
+    StubBackend backendB;
+    backendB.activateFunction = [&] { activatedB = true; };
+    backendB.deactivateFunction = [&] { activatedB = false; };
+    
+    {
+        BackendScope scopeA { backendA };
+        ASSERT_TRUE(activatedA);
+        {
+            BackendScope scopeB { backendB };
+            ASSERT_FALSE(activatedA);
+            ASSERT_TRUE(activatedB);
+        }
+        ASSERT_FALSE(activatedB);
+        ASSERT_TRUE(activatedA);
+    }
+    
+    ASSERT_FALSE(activatedA);
+    ASSERT_FALSE(activatedB);
+}


### PR DESCRIPTION
Ports backend scope changes that make manual reference counting on android for backend activation/deactivation obsolete.

Fixes #9458

@zugaldia I tagged you for review as you reported #9458 and I'm not sure how to reproduce.