### PR TITLE
[ios] Warn about using MGLFeature-conforming annotations

### DIFF
--- a/platform/darwin/src/MGLFeature.h
+++ b/platform/darwin/src/MGLFeature.h
@@ -18,15 +18,19 @@ NS_ASSUME_NONNULL_BEGIN
  You can add custom data to display on the map by creating feature objects and
  adding them to an `MGLShapeSource` using the
  `-[MGLShapeSource initWithIdentifier:shape:options:]` method or
- `MGLShapeSource.shape` property. Similarly, you can add `MGLPointFeature`,
- `MGLPolylineFeature`, and `MGLPolygonFeature` objects to the map as annotations
- using `-[MGLMapView addAnnotations:]` and related methods.
+ `MGLShapeSource.shape` property.
 
  In addition to adding data to the map, you can also extract data from the map:
  `-[MGLMapView visibleFeaturesAtPoint:]` and related methods return feature
  objects that correspond to features in the source. This enables you to inspect
  the properties of features in vector tiles loaded by `MGLVectorSource` objects.
  You also reuse these feature objects as overlay annotations.
+
+ While it is possible to add `MGLFeature`-conforming objects to the map as
+ annotations using `-[MGLMapView addAnnotations:]` and related methods, doing so
+ will convert feature objects into plain annotations. Features added as
+ annotations will not have `identifier` or `attributes` properties set and
+ should not be used be with feature querying.
  */
 @protocol MGLFeature <MGLAnnotation>
 

--- a/platform/darwin/src/MGLFeature.mm
+++ b/platform/darwin/src/MGLFeature.mm
@@ -42,6 +42,15 @@ MGL_DEFINE_FEATURE_IS_EQUAL();
     return mbglFeature({[self geometryObject]}, identifier, self.attributes);
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: %p; identifier = %@, coordinate = %f, %f, attributes = %@>",
+            NSStringFromClass([self class]), (void *)self,
+            self.identifier ? [NSString stringWithFormat:@"\"%@\"", self.identifier] : self.identifier,
+            self.coordinate.latitude, self.coordinate.longitude,
+            self.attributes.count ? self.attributes : @"none"];
+}
+
 @end
 
 @interface MGLPolylineFeature ()
@@ -68,6 +77,16 @@ MGL_DEFINE_FEATURE_IS_EQUAL();
     return mbglFeature({[self geometryObject]}, identifier, self.attributes);
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: %p; identifier = %@, count = %lu, bounds = %@, attributes = %@>",
+            NSStringFromClass([self class]), (void *)self,
+            self.identifier ? [NSString stringWithFormat:@"\"%@\"", self.identifier] : self.identifier,
+            (unsigned long)[self pointCount],
+            MGLStringFromCoordinateBounds(self.overlayBounds),
+            self.attributes.count ? self.attributes : @"none"];
+}
+
 @end
 
 @interface MGLPolygonFeature ()
@@ -92,6 +111,16 @@ MGL_DEFINE_FEATURE_IS_EQUAL();
 
 - (mbgl::GeoJSON)geoJSONObject {
     return mbglFeature({[self geometryObject]}, identifier, self.attributes);
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: %p; identifier = %@, count = %lu, bounds = %@, attributes = %@>",
+            NSStringFromClass([self class]), (void *)self,
+            self.identifier ? [NSString stringWithFormat:@"\"%@\"", self.identifier] : self.identifier,
+            (unsigned long)[self pointCount],
+            MGLStringFromCoordinateBounds(self.overlayBounds),
+            self.attributes.count ? self.attributes : @"none"];
 }
 
 @end
@@ -146,6 +175,16 @@ MGL_DEFINE_FEATURE_IS_EQUAL();
     return mbglFeature({[self geometryObject]}, identifier, self.attributes);
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: %p; identifier = %@, count = %lu, bounds = %@, attributes = %@>",
+            NSStringFromClass([self class]), (void *)self,
+            self.identifier ? [NSString stringWithFormat:@"\"%@\"", self.identifier] : self.identifier,
+            (unsigned long)self.polylines.count,
+            MGLStringFromCoordinateBounds(self.overlayBounds),
+            self.attributes.count ? self.attributes : @"none"];
+}
+
 @end
 
 @interface MGLMultiPolygonFeature ()
@@ -170,6 +209,16 @@ MGL_DEFINE_FEATURE_IS_EQUAL();
 
 - (mbgl::GeoJSON)geoJSONObject {
     return mbglFeature({[self geometryObject]}, identifier, self.attributes);
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: %p; identifier = %@, count = %lu, bounds = %@, attributes = %@>",
+            NSStringFromClass([self class]), (void *)self,
+            self.identifier ? [NSString stringWithFormat:@"\"%@\"", self.identifier] : self.identifier,
+            (unsigned long)self.polygons.count,
+            MGLStringFromCoordinateBounds(self.overlayBounds),
+            self.attributes.count ? self.attributes : @"none"];
 }
 
 @end

--- a/platform/darwin/src/MGLPolygon.mm
+++ b/platform/darwin/src/MGLPolygon.mm
@@ -200,4 +200,14 @@
              @"coordinates": coordinates};
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: %p; title = %@, subtitle: = %@, count = %lu; bounds = %@>",
+            NSStringFromClass([self class]), (void *)self,
+            self.title ? [NSString stringWithFormat:@"\"%@\"", self.title] : self.title,
+            self.subtitle ? [NSString stringWithFormat:@"\"%@\"", self.subtitle] : self.subtitle,
+            (unsigned long)self.polygons.count,
+            MGLStringFromCoordinateBounds(self.overlayBounds)];
+}
+
 @end

--- a/platform/darwin/src/MGLPolyline.mm
+++ b/platform/darwin/src/MGLPolyline.mm
@@ -201,4 +201,14 @@
              @"coordinates": coordinates};
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: %p; title = %@, subtitle: = %@, count = %lu; bounds = %@>",
+            NSStringFromClass([self class]), (void *)self,
+            self.title ? [NSString stringWithFormat:@"\"%@\"", self.title] : self.title,
+            self.subtitle ? [NSString stringWithFormat:@"\"%@\"", self.subtitle] : self.subtitle,
+            (unsigned long)self.polylines.count,
+            MGLStringFromCoordinateBounds(self.overlayBounds)];
+}
+
 @end

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3187,6 +3187,11 @@ public:
     {
         NSAssert([annotation conformsToProtocol:@protocol(MGLAnnotation)], @"annotation should conform to MGLAnnotation");
 
+        if ([annotation conformsToProtocol:@protocol(MGLFeature)])
+        {
+            NSLog(@"Warning: Annotations that conform to the MGLFeature protocol do not keep their `identifier` or `attributes` properties when added to the map as annotations. Add this feature using runtime styling if you intend to later query the map for it. %@", annotation.description);
+        }
+
         // adding the same annotation object twice is a no-op
         if (_annotationTagsByAnnotation.count(annotation) != 0)
         {


### PR DESCRIPTION
Until https://github.com/mapbox/mapbox-gl-native/issues/6178 is addressed, this adds two warnings about using `MGLFeature`-conforming objects as annotations:

- Prints a warning to console when a developer does so.
- Changes `MGLFeature`’s documentation to discourage developers from doing so.

This also adds friendlier debug descriptions for various feature/shape types.

/cc @1ec5 @captainbarbosa @boundsj @fabian-guerra