### PR TITLE
GCC 4.9 developing notes

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of conduct
+
+Everyone is invited to participate in Mapbox’s open source projects and public discussions: we want to create a welcoming and friendly environment. Harassment of participants or other unethical and unprofessional behavior will not be tolerated in our spaces. The [Contributor Covenant](http://contributor-covenant.org) applies to all projects under the Mapbox organization and we ask that you please read [the full text](http://contributor-covenant.org/version/1/2/0/).
+
+You can learn more about our open source philosophy on [mapbox.com](https://www.mapbox.com/about/open/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,3 @@ We’ve color-coded our labels by facet to make them easier to use:
  * non-actionable status (grey)
  * importance / urgency (green)
  * topic / project / misc (yellow)
-
-# Code of conduct
-Everyone is invited to participate in Mapbox’s open source projects and public discussions: we want to create a welcoming and friendly environment. Harassment of participants or other unethical and unprofessional behavior will not be tolerated in our spaces. The [Contributor Covenant](http://contributor-covenant.org) applies to all projects under the Mapbox organization and we ask that you please read [the full text](http://contributor-covenant.org/version/1/2/0/).
-
-You can learn more about our open source philosophy on [mapbox.com](https://www.mapbox.com/about/open/).

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,112 @@
+# Modern C++ support
+
+Mapbox GL Native supports the C++14 standard, and encourages contributions to
+the source code using modern C++ idioms like return type deductions, generic
+lambdas, `std::optional` and alike. However, we do not support all the features
+from the final draft of the C++14 standard - we had to sacrifice support for
+these features in order to support GCC from version 4.9 onwards.
+
+The following C++14 features are **not supported** in Mapbox GL Native:
+
+## [C++14 variable templates](https://isocpp.org/wiki/faq/cpp14-language#variable-templates)
+
+Constructs like the example below are not supported:
+
+```C++
+template<typename T> constexpr T pi = T(3.14);
+```
+
+### Workarounds:
+
+- If the variable is an alias, use the call the alias points to: [example](https://github.com/mapbox/mapbox-gl-native/commit/f1ac757bd28351fd57113a1e16f6c2e00ab193c1#diff-711ce10b54a522c948efc9030ffab4fcL269)
+```C++
+// auto foo = pi<double>;
+auto foo = double(3.14);
+```
+
+- Replace variable templates with either functions or structs: [example 1](https://github.com/mapbox/mapbox-gl-native/commit/f1ac757bd28351fd57113a1e16f6c2e00ab193c1#diff-ffbe6cdfd30513aaa4749b4d959a5da6L58), [example 2](https://github.com/mapbox/mapbox-gl-native/commit/f1ac757bd28351fd57113a1e16f6c2e00ab193c1#diff-04af54dc8685cdc382ebe24466dc1d00L98)
+
+## [C++14 aggregates with non-static data member initializers](http://en.cppreference.com/w/cpp/language/aggregate_initialization)
+
+Constructs like the example below are not supported:
+
+```C++
+struct Foo {
+    int x = { 0 };
+};
+
+// error: no matching function for call to 'Foo::Foo(<brace-enclosed initializer list>)'
+int main() {
+    Foo foo { 0 };
+    return 0;
+}
+```
+
+### Workarounds
+- Replace data member initializers with default parameter values in default constructors:
+
+```C++
+struct Foo {
+    Foo(int x_ = 0) : x(x_) {}
+    int x;
+};
+
+int main() {
+    Foo foo { 0 }; // works with default constructor
+    return 0;
+}
+```
+
+- Replace bracket initialization with regular round brackets or none:
+
+```C++
+struct Foo {
+    Foo(int x_ = 0) : x(x_) {}
+    int x;
+};
+
+int main() {
+    Foo foo(); // works
+    Foo bar; // also works
+    return 0;
+}
+```
+
+## [Extended `constexpr` support](https://isocpp.org/wiki/faq/cpp14-language#extended-constexpr)
+
+GCC 4.9 strictly forbids `constexpr` usage in the following scenarios:
+- No local variable declarations (not `static` or `thread_local`, and no uninitialized variables)
+- Cannot mutate objects whose lifetime began with the constant expression evaluation
+- Disable usage of if, switch, for, while, do-while (not goto) inside constexpr expressions
+- Enforces that constexpr member functions are implicitly const
+
+```C++
+// sorry, unimplemented: use of the value of the object being constructed
+// in a constant expression
+struct Foo {
+    int x, y;
+    constexpr Foo(int i) : x(i), y(x) {}
+};
+
+// error: body of constexpr function 'constexpr int test1(int)' not a
+// return-statement
+constexpr int test1(int i) {
+    int j = i;
+    return j;
+}
+
+// error: body of constexpr function 'constexpr bool test2(int)' not a
+// return-statement
+constexpr bool test2(int i) {
+    if (i > 0) {
+        return true;
+    } else {
+        return false;
+    }
+}
+```
+
+### Workarounds
+
+- Either remove `constexpr` specifier or replace it with `inline` in case of
+  functions

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,13 +23,16 @@ Clone the git repository:
 These dependencies are required for all operating systems and all platform
 targets.
 
- - Modern C++ compiler that supports `-std=c++14`
+ - Modern C++ compiler that supports `-std=c++14`\*
    - clang++ 3.5 or later _or_
-   - g++-5 or later
+   - g++-4.9 or later
  - [CMake](https://cmake.org/) 3.1 or later (for build only)
  - [cURL](https://curl.haxx.se) (for build only)
  - [Node.js](https://nodejs.org/) 4.2.1 or later (for build only)
  - [`pkg-config`](https://wiki.freedesktop.org/www/Software/pkg-config/) (for build only)
+
+**Note**: We partially support C++14 because GCC 4.9 does not fully implement the
+final draft of the C++14 standard. More information in [DEVELOPING.md](DEVELOPING.md).
 
 Depending on your operating system and target, you'll need additional
 dependencies:

--- a/include/mbgl/renderer/query.hpp
+++ b/include/mbgl/renderer/query.hpp
@@ -13,8 +13,8 @@ namespace mbgl {
  */
 class RenderedQueryOptions {
 public:
-    RenderedQueryOptions(optional<std::vector<std::string>> layerIDs_ = optional<std::vector<std::string>>(),
-                         optional<style::Filter> filter_ = optional<style::Filter>())
+    RenderedQueryOptions(optional<std::vector<std::string>> layerIDs_ = {},
+                         optional<style::Filter> filter_ = {})
         : layerIDs(std::move(layerIDs_)),
           filter(std::move(filter_)) {}
 
@@ -29,8 +29,8 @@ public:
  */
 class SourceQueryOptions {
 public:
-    SourceQueryOptions(optional<std::vector<std::string>> sourceLayers_ = optional<std::vector<std::string>> (),
-                       optional<style::Filter> filter_ = optional<style::Filter>())
+    SourceQueryOptions(optional<std::vector<std::string>> sourceLayers_ = {},
+                       optional<style::Filter> filter_ = {})
         : sourceLayers(std::move(sourceLayers_)),
           filter(std::move(filter_)) {}
 

--- a/include/mbgl/renderer/renderer.hpp
+++ b/include/mbgl/renderer/renderer.hpp
@@ -19,7 +19,7 @@ class RendererObserver;
 class RenderedQueryOptions;
 class Scheduler;
 class SourceQueryOptions;
-class UpdateParameters;
+struct UpdateParameters;
 class View;
 
 class Renderer {

--- a/include/mbgl/renderer/renderer.hpp
+++ b/include/mbgl/renderer/renderer.hpp
@@ -26,7 +26,7 @@ class Renderer {
 public:
     Renderer(RendererBackend&, float pixelRatio_, FileSource&, Scheduler&,
              GLContextMode = GLContextMode::Unique,
-             const optional<std::string> programCacheDir = optional<std::string>());
+             const optional<std::string> programCacheDir = {});
     ~Renderer();
 
     void setObserver(RendererObserver*);

--- a/include/mbgl/renderer/renderer_frontend.hpp
+++ b/include/mbgl/renderer/renderer_frontend.hpp
@@ -5,7 +5,7 @@
 namespace mbgl {
 
 class RendererObserver;
-class UpdateParameters;
+struct UpdateParameters;
 
 // The RenderFrontend is the bridge between the Map and
 // platform used to update and observer the Renderer

--- a/include/mbgl/style/transition_options.hpp
+++ b/include/mbgl/style/transition_options.hpp
@@ -11,8 +11,8 @@ public:
     optional<Duration> duration;
     optional<Duration> delay;
 
-    TransitionOptions(optional<Duration> duration_ = optional<Duration>(),
-                      optional<Duration> delay_ = optional<Duration>())
+    TransitionOptions(optional<Duration> duration_ = {},
+                      optional<Duration> delay_ = {})
         : duration(std::move(duration_)),
           delay(std::move(delay_)) {}
 

--- a/platform/android/README.md
+++ b/platform/android/README.md
@@ -40,12 +40,15 @@ These dependencies are required for all operating systems and all platform targe
   - NDK
   - LLDB
 
-- Modern C++ compiler that supports -std=c++14
+- Modern C++ compiler that supports `-std=c++14`\*
   - clang++ 3.5 or later or
-  - g++-5 or later
+  - g++-4.9 or later
 - [cURL](https://curl.haxx.se) (for build only)
 - [Node.js](https://nodejs.org/) or later (for build only)
 - [pkg-config](https://wiki.freedesktop.org/www/Software/pkg-config/) (for build only)
+
+**Note**: We partially support C++14 because GCC 4.9 does not fully implement the
+final draft of the C++14 standard. More information in [DEVELOPING.md](DEVELOPING.md).
 
 ##### Additional Dependencies for Linux
 

--- a/platform/linux/README.md
+++ b/platform/linux/README.md
@@ -8,12 +8,15 @@ This process gives you a Linux desktop app built on a Linux host system.
 
 ### Build
 
-Install GCC 5+ if you are running Ubuntu 14.04 or older. Alternatively, you can also use [Clang 3.5+](http://llvm.org/apt/).
+Install GCC 4.9+ if you are running Ubuntu 14.04 or older. Alternatively, you can also use [Clang 3.5+](http://llvm.org/apt/).
 
     sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
     sudo apt-get update
-    sudo apt-get install gcc-5 g++-5
-    export CXX=g++-5
+    sudo apt-get install gcc-4.9 g++-4.9
+    export CXX=g++-4.9
+
+**Note**: We partially support C++14 because GCC 4.9 does not fully implement the
+final draft of the C++14 standard. More information in [DEVELOPING.md](DEVELOPING.md).
 
 Ensure you have git and other build essentials:
 

--- a/src/mbgl/annotation/annotation_tile.hpp
+++ b/src/mbgl/annotation/annotation_tile.hpp
@@ -7,7 +7,7 @@
 namespace mbgl {
 
 class AnnotationManager;
-class TileParameters;
+struct TileParameters;
 
 class AnnotationTile : public GeometryTile {
 public:

--- a/src/mbgl/renderer/render_source.hpp
+++ b/src/mbgl/renderer/render_source.hpp
@@ -24,7 +24,7 @@ class RenderedQueryOptions;
 class SourceQueryOptions;
 class Tile;
 class RenderSourceObserver;
-class TileParameters;
+struct TileParameters;
 
 class RenderSource : protected TileObserver {
 public:

--- a/src/mbgl/renderer/render_style.hpp
+++ b/src/mbgl/renderer/render_style.hpp
@@ -23,7 +23,7 @@ class RenderData;
 class TransformState;
 class RenderedQueryOptions;
 class Scheduler;
-class UpdateParameters;
+struct UpdateParameters;
 class RenderStyleObserver;
 
 namespace style {

--- a/src/mbgl/renderer/sources/render_image_source.cpp
+++ b/src/mbgl/renderer/sources/render_image_source.cpp
@@ -61,11 +61,11 @@ RenderImageSource::queryRenderedFeatures(const ScreenLineString&,
                                          const TransformState&,
                                          const RenderStyle&,
                                          const RenderedQueryOptions&) const {
-    return std::unordered_map<std::string, std::vector<Feature>>();
+    return std::unordered_map<std::string, std::vector<Feature>> {};
 }
 
 std::vector<Feature> RenderImageSource::querySourceFeatures(const SourceQueryOptions&) const {
-    return std::vector<Feature>();
+    return {};
 }
 
 void RenderImageSource::update(Immutable<style::Source::Impl> baseImpl_,

--- a/src/mbgl/renderer/sources/render_raster_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_source.cpp
@@ -73,11 +73,11 @@ RenderRasterSource::queryRenderedFeatures(const ScreenLineString&,
                                           const TransformState&,
                                           const RenderStyle&,
                                           const RenderedQueryOptions&) const {
-    return std::unordered_map<std::string, std::vector<Feature>>();
+    return std::unordered_map<std::string, std::vector<Feature>> {};
 }
 
 std::vector<Feature> RenderRasterSource::querySourceFeatures(const SourceQueryOptions&) const {
-    return std::vector<Feature>();
+    return {};
 }
 
 void RenderRasterSource::onLowMemory() {

--- a/src/mbgl/renderer/tile_parameters.hpp
+++ b/src/mbgl/renderer/tile_parameters.hpp
@@ -11,29 +11,7 @@ class AnnotationManager;
 class ImageManager;
 class GlyphManager;
 
-class TileParameters {
-public:
-    TileParameters(const float pixelRatio_,
-                   const MapDebugOptions debugOptions_,
-                   const TransformState& transformState_,
-                   Scheduler& workerScheduler_,
-                   FileSource& fileSource_,
-                   const MapMode mode_,
-                   AnnotationManager& annotationManager_,
-                   ImageManager& imageManager_,
-                   GlyphManager& glyphManager_,
-                   const uint8_t prefetchZoomDelta_)
-        : pixelRatio(pixelRatio_),
-          debugOptions(debugOptions_),
-          transformState(std::move(transformState_)),
-          workerScheduler(workerScheduler_),
-          fileSource(fileSource_),
-          mode(mode_),
-          annotationManager(annotationManager_),
-          imageManager(imageManager_),
-          glyphManager(glyphManager_),
-          prefetchZoomDelta(prefetchZoomDelta_) {}
-
+struct TileParameters {
     const float pixelRatio;
     const MapDebugOptions debugOptions;
     const TransformState& transformState;

--- a/src/mbgl/renderer/tile_pyramid.hpp
+++ b/src/mbgl/renderer/tile_pyramid.hpp
@@ -24,7 +24,7 @@ class RenderTile;
 class RenderStyle;
 class RenderedQueryOptions;
 class SourceQueryOptions;
-class TileParameters;
+struct TileParameters;
 
 class TilePyramid {
 public:

--- a/src/mbgl/renderer/update_parameters.hpp
+++ b/src/mbgl/renderer/update_parameters.hpp
@@ -17,45 +17,7 @@ class Scheduler;
 class FileSource;
 class AnnotationManager;
 
-class UpdateParameters {
-public:
-    UpdateParameters(const bool styleLoaded_,
-                     const MapMode mode_,
-                     const float pixelRatio_,
-                     const MapDebugOptions debugOptions_,
-                     const TimePoint timePoint_,
-                     const TransformState TransformState_,
-                     const std::string glyphURL_,
-                     const bool spriteLoaded_,
-                     const style::TransitionOptions transitionOptions_,
-                     const Immutable<style::Light::Impl> light_,
-                     const Immutable<std::vector<Immutable<style::Image::Impl>>> images_,
-                     const Immutable<std::vector<Immutable<style::Source::Impl>>> sources_,
-                     const Immutable<std::vector<Immutable<style::Layer::Impl>>> layers_,
-                     Scheduler& scheduler_,
-                     FileSource& fileSource_,
-                     AnnotationManager& annotationManager_,
-                     const uint8_t prefetchZoomDelta_,
-                     const bool stillImageRequest_)
-        : styleLoaded(styleLoaded_),
-          mode(mode_),
-          pixelRatio(pixelRatio_),
-          debugOptions(debugOptions_),
-          timePoint(std::move(timePoint_)),
-          transformState(std::move(TransformState_)),
-          glyphURL(std::move(glyphURL_)),
-          spriteLoaded(spriteLoaded_),
-          transitionOptions(std::move(transitionOptions_)),
-          light(std::move(light_)),
-          images(std::move(images_)),
-          sources(std::move(sources_)),
-          layers(std::move(layers_)),
-          scheduler(scheduler_),
-          fileSource(fileSource_),
-          annotationManager(annotationManager_),
-          prefetchZoomDelta(prefetchZoomDelta_),
-          stillImageRequest(stillImageRequest_) {}
-
+struct UpdateParameters {
     const bool styleLoaded;
     const MapMode mode;
     const float pixelRatio;

--- a/src/mbgl/tile/geojson_tile.hpp
+++ b/src/mbgl/tile/geojson_tile.hpp
@@ -5,7 +5,7 @@
 
 namespace mbgl {
 
-class TileParameters;
+struct TileParameters;
 
 class GeoJSONTile : public GeometryTile {
 public:

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -22,7 +22,7 @@ class GeometryTileData;
 class RenderStyle;
 class RenderLayer;
 class SourceQueryOptions;
-class TileParameters;
+struct TileParameters;
 class GlyphAtlas;
 class ImageAtlas;
 

--- a/src/mbgl/tile/raster_tile.hpp
+++ b/src/mbgl/tile/raster_tile.hpp
@@ -8,7 +8,7 @@
 namespace mbgl {
 
 class Tileset;
-class TileParameters;
+struct TileParameters;
 
 namespace style {
 class Layer;

--- a/src/mbgl/tile/tile_loader.hpp
+++ b/src/mbgl/tile/tile_loader.hpp
@@ -10,7 +10,7 @@ class FileSource;
 class AsyncRequest;
 class Response;
 class Tileset;
-class TileParameters;
+struct TileParameters;
 
 template <typename T>
 class TileLoader : private util::noncopyable {

--- a/src/mbgl/tile/vector_tile.hpp
+++ b/src/mbgl/tile/vector_tile.hpp
@@ -6,7 +6,7 @@
 namespace mbgl {
 
 class Tileset;
-class TileParameters;
+struct TileParameters;
 
 class VectorTile : public GeometryTile {
 public:


### PR DESCRIPTION
Added GCC 4.9 developing notes, including examples and workarounds of C++14 features not supported by that compiler version. A separate code of conduct makes all checks go green in https://github.com/mapbox/mapbox-gl-native/community page.