### PR TITLE
[core] Revert conditional attribute binding (on release branch)

### DIFF
--- a/src/mbgl/gl/attribute.cpp
+++ b/src/mbgl/gl/attribute.cpp
@@ -4,35 +4,9 @@
 namespace mbgl {
 namespace gl {
 
-void bindAttributeLocation(ProgramID id, AttributeLocation location, const char* name) {
-    if (location >= MAX_ATTRIBUTES) {
-        throw gl::Error("too many vertex attributes");
-    }
+AttributeLocation bindAttributeLocation(ProgramID id, AttributeLocation location, const char* name) {
     MBGL_CHECK_ERROR(glBindAttribLocation(id, location, name));
-}
-
-std::set<std::string> getActiveAttributes(ProgramID id) {
-    std::set<std::string> activeAttributes;
-
-    GLint attributeCount;
-    MBGL_CHECK_ERROR(glGetProgramiv(id, GL_ACTIVE_ATTRIBUTES, &attributeCount));
-
-    GLint maxAttributeLength;
-    MBGL_CHECK_ERROR(glGetProgramiv(id, GL_ACTIVE_ATTRIBUTE_MAX_LENGTH, &maxAttributeLength));
-
-    std::string attributeName;
-    attributeName.resize(maxAttributeLength);
-
-    GLsizei actualLength;
-    GLint size;
-    GLenum type;
-
-    for (int32_t i = 0; i < attributeCount; i++) {
-        MBGL_CHECK_ERROR(glGetActiveAttrib(id, i, maxAttributeLength, &actualLength, &size, &type, &attributeName[0]));
-        activeAttributes.emplace(std::string(attributeName, 0, actualLength));
-    }
-
-    return activeAttributes;
+    return location;
 }
 
 } // namespace gl

--- a/src/mbgl/gl/attribute.hpp
+++ b/src/mbgl/gl/attribute.hpp
@@ -8,7 +8,6 @@
 
 #include <cstddef>
 #include <vector>
-#include <set>
 #include <functional>
 #include <string>
 #include <array>
@@ -214,8 +213,7 @@ const std::size_t Vertex<A1, A2, A3, A4, A5>::attributeOffsets[5] = {
 
 } // namespace detail
 
-void bindAttributeLocation(ProgramID, AttributeLocation, const char * name);
-std::set<std::string> getActiveAttributes(ProgramID);
+AttributeLocation bindAttributeLocation(ProgramID, AttributeLocation, const char * name);
 
 template <class... As>
 class Attributes {
@@ -235,19 +233,7 @@ public:
     static constexpr std::size_t Index = TypeIndex<A, As...>::value;
 
     static Locations bindLocations(const ProgramID& id) {
-        std::set<std::string> activeAttributes = getActiveAttributes(id);
-
-        AttributeLocation location = 0;
-        auto maybeBindLocation = [&](const char* name) -> optional<AttributeLocation> {
-            if (activeAttributes.count(name)) {
-                bindAttributeLocation(id, location, name);
-                return location++;
-            } else {
-                return {};
-            }
-        };
-
-        return Locations { maybeBindLocation(As::name())... };
+        return Locations { bindAttributeLocation(id, Index<As>, As::name())... };
     }
 
     template <class Program>

--- a/src/mbgl/gl/program.hpp
+++ b/src/mbgl/gl/program.hpp
@@ -34,17 +34,15 @@ public:
         : program(
               context.createProgram(context.createShader(ShaderType::Vertex, vertexSource),
                                     context.createShader(ShaderType::Fragment, fragmentSource))),
-          uniformsState((context.linkProgram(program), Uniforms::bindLocations(program))),
-          attributeLocations(Attributes::bindLocations(program)) {
-        // Re-link program after manually binding only active attributes in Attributes::bindLocations
-        context.linkProgram(program);
+          attributeLocations(Attributes::bindLocations(program)),
+          uniformsState((context.linkProgram(program), Uniforms::bindLocations(program))) {
     }
 
     template <class BinaryProgram>
     Program(Context& context, const BinaryProgram& binaryProgram)
         : program(context.createProgram(binaryProgram.format(), binaryProgram.code())),
-          uniformsState(Uniforms::loadNamedLocations(binaryProgram)),
-          attributeLocations(Attributes::loadNamedLocations(binaryProgram)) {
+          attributeLocations(Attributes::loadNamedLocations(binaryProgram)),
+          uniformsState(Uniforms::loadNamedLocations(binaryProgram)) {
     }
     
     static Program createProgram(gl::Context& context,
@@ -142,8 +140,8 @@ public:
 private:
     UniqueProgram program;
 
-    typename Uniforms::State uniformsState;
     typename Attributes::Locations attributeLocations;
+    typename Uniforms::State uniformsState;
 };
 
 } // namespace gl


### PR DESCRIPTION
Reverts eed89fcf9d099266aa793375ad63493e880f8a80, which causes issues on certain Android devices (#9473). We don't actually need this change on this branch, I brought it over only to make the subsequent commits cleanly cherry-pickable.