### PR TITLE
[android] - manage InfoWindow selection in AnnotationManager

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
@@ -570,11 +570,6 @@ public class MarkerViewManager implements MapView.OnMapChangedListener {
       clickHandled = onMarkerViewClickListener.onMarkerClick(markerView, view, adapter);
     }
 
-    if (!clickHandled) {
-      ensureInfoWindowOffset(markerView);
-      select(markerView, view, adapter);
-    }
-
     return clickHandled;
   }
 


### PR DESCRIPTION
Follow up from #9424, there we consolidated select states of Marker and MarkerView. We didn't remove selecting state handling as part of the MarkerView click handler. This resulted in select and immediately deselecting the Marker and thus not showing the InfoWindow.

