### PR TITLE
Enable native test for text-keep-upright with text-offset.

### DIFF
--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -57,7 +57,6 @@
   "render-tests/symbol-placement/line": "needs issue",
   "render-tests/text-anchor/property-function": "https://github.com/mapbox/mapbox-gl-native/issues/9555",
   "render-tests/text-justify/property-function": "https://github.com/mapbox/mapbox-gl-native/issues/9559",
-  "render-tests/text-keep-upright/line-placement-true-offset": "https://github.com/mapbox/mapbox-gl-native/issues/9271",
   "render-tests/text-size/composite-function-high-base": "https://github.com/mapbox/mapbox-gl-native/issues/8654",
   "render-tests/video/default": "skip - needs issue"
 }


### PR DESCRIPTION
Issue #9271 was fixed as part of PR #9009.

/cc @anandthakker @jfirebaugh 