### PR TITLE
Validate Marker before opening InfoWindow

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/InfoWindowManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/InfoWindowManager.java
@@ -1,6 +1,5 @@
 package com.mapbox.mapboxsdk.maps;
 
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
@@ -55,8 +54,8 @@ class InfoWindowManager {
     return allowConcurrentMultipleInfoWindows;
   }
 
-  boolean isInfoWindowValidForMarker(@NonNull Marker marker) {
-    return !TextUtils.isEmpty(marker.getTitle()) || !TextUtils.isEmpty(marker.getSnippet());
+  boolean isInfoWindowValidForMarker(Marker marker) {
+    return marker != null && (!TextUtils.isEmpty(marker.getTitle()) || !TextUtils.isEmpty(marker.getSnippet()));
   }
 
   void setOnInfoWindowClickListener(@Nullable MapboxMap.OnInfoWindowClickListener listener) {


### PR DESCRIPTION
Was able to hit a crash when clicking a marker and closing the Activity hosting the MapView quickly after. This PR adds a check to validate if Marker is still valid to show an InfoWindow when we get the results back from queryPointAnnotations.