### PR TITLE
Move ZoomButtonController creation to view initalisation

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -118,6 +118,7 @@ public class MapView extends FrameLayout {
     myLocationView = (MyLocationView) view.findViewById(R.id.userLocationView);
     attrView = (ImageView) view.findViewById(R.id.attributionView);
     logoView = (ImageView) view.findViewById(R.id.logoView);
+    mapZoomButtonController = new MapZoomButtonController(new ZoomButtonsController(this));
 
     // add accessibility support
     setContentDescription(context.getString(R.string.mapbox_mapActionDescription));
@@ -166,7 +167,7 @@ public class MapView extends FrameLayout {
     mapKeyListener = new MapKeyListener(transform, trackingSettings, uiSettings);
 
     MapZoomControllerListener zoomListener = new MapZoomControllerListener(mapGestureDetector, uiSettings, transform);
-    mapZoomButtonController = new MapZoomButtonController(this, uiSettings, zoomListener);
+    mapZoomButtonController.bind(uiSettings, zoomListener);
 
     // inject widgets with MapboxMap
     compassView.setMapboxMap(mapboxMap);
@@ -542,9 +543,7 @@ public class MapView extends FrameLayout {
   @CallSuper
   protected void onDetachedFromWindow() {
     super.onDetachedFromWindow();
-    if (mapZoomButtonController != null) {
-      mapZoomButtonController.setVisible(false);
-    }
+    mapZoomButtonController.setVisible(false);
   }
 
   // Called when view is hidden and shown
@@ -553,11 +552,12 @@ public class MapView extends FrameLayout {
     if (isInEditMode()) {
       return;
     }
+
     if (visibility == View.VISIBLE && nativeMapView == null) {
       initialiseDrawingSurface(mapboxMapOptions.getTextureMode());
     }
 
-    if (mapZoomButtonController != null && nativeMapView != null) {
+    if (nativeMapView != null) {
       mapZoomButtonController.setVisible(visibility == View.VISIBLE);
     }
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapZoomButtonController.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapZoomButtonController.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.maps;
 
 import android.support.annotation.NonNull;
-import android.view.View;
 import android.widget.ZoomButtonsController;
 
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
@@ -12,21 +11,25 @@ import com.mapbox.mapboxsdk.constants.MapboxConstants;
  * Allows single touch only devices to zoom in and out.
  * </p>
  */
-final class MapZoomButtonController extends ZoomButtonsController {
+final class MapZoomButtonController {
 
   private UiSettings uiSettings;
+  private ZoomButtonsController zoomButtonsController;
 
-  MapZoomButtonController(@NonNull View ownerView, @NonNull UiSettings uiSettings, @NonNull OnZoomListener listener) {
-    super(ownerView);
-    this.uiSettings = uiSettings;
-    setZoomSpeed(MapboxConstants.ANIMATION_DURATION);
-    setOnZoomListener(listener);
+  MapZoomButtonController(@NonNull ZoomButtonsController zoomButtonsController) {
+    this.zoomButtonsController = zoomButtonsController;
+    this.zoomButtonsController.setZoomSpeed(MapboxConstants.ANIMATION_DURATION);
   }
 
-  @Override
-  public void setVisible(boolean visible) {
-    if (uiSettings.isZoomControlsEnabled()) {
-      super.setVisible(visible);
+  void bind(UiSettings uiSettings, ZoomButtonsController.OnZoomListener onZoomListener) {
+    this.uiSettings = uiSettings;
+    zoomButtonsController.setOnZoomListener(onZoomListener);
+  }
+
+  void setVisible(boolean visible) {
+    if (uiSettings != null && !uiSettings.isZoomControlsEnabled()) {
+      return;
     }
+    zoomButtonsController.setVisible(visible);
   }
 }


### PR DESCRIPTION
in #9462 we started to make a distinction between view versus map initialization. `MapZoomButtonController` was created as part of the map initialization while it's actually a view itself. This PR also changes from inheritance to composition.