### PR TITLE
Ensure the right context is active on map cleanup

### DIFF
--- a/benchmark/api/query.benchmark.cpp
+++ b/benchmark/api/query.benchmark.cpp
@@ -40,7 +40,7 @@ public:
     OffscreenView view{ backend.getContext(), { 1000, 1000 } };
     DefaultFileSource fileSource{ "benchmark/fixtures/api/cache.db", "." };
     ThreadPool threadPool{ 4 };
-    AsyncRendererFrontend rendererFrontend { std::make_unique<Renderer>(backend, 1, fileSource, threadPool), view };
+    AsyncRendererFrontend rendererFrontend { std::make_unique<Renderer>(backend, 1, fileSource, threadPool), backend, view };
     Map map { rendererFrontend, MapObserver::nullObserver(), view.getSize(), 1, fileSource, threadPool, MapMode::Still };
     ScreenBox box{{ 0, 0 }, { 1000, 1000 }};
 };

--- a/benchmark/api/render.benchmark.cpp
+++ b/benchmark/api/render.benchmark.cpp
@@ -47,7 +47,7 @@ static void prepare(Map& map, optional<std::string> json = {}) {
 
 static void API_renderStill_reuse_map(::benchmark::State& state) {
     RenderBenchmark bench;
-    AsyncRendererFrontend frontend { std::make_unique<Renderer>(bench.backend, 1, bench.fileSource, bench.threadPool), bench.view };
+    AsyncRendererFrontend frontend { std::make_unique<Renderer>(bench.backend, 1, bench.fileSource, bench.threadPool), bench.backend, bench.view };
     Map map { frontend, MapObserver::nullObserver(), bench.view.getSize(), 1, bench.fileSource, bench.threadPool, MapMode::Still };
     prepare(map);
 
@@ -58,7 +58,7 @@ static void API_renderStill_reuse_map(::benchmark::State& state) {
 
 static void API_renderStill_reuse_map_switch_styles(::benchmark::State& state) {
     RenderBenchmark bench;
-    AsyncRendererFrontend frontend { std::make_unique<Renderer>(bench.backend, 1, bench.fileSource, bench.threadPool), bench.view };
+    AsyncRendererFrontend frontend { std::make_unique<Renderer>(bench.backend, 1, bench.fileSource, bench.threadPool), bench.backend, bench.view };
     Map map { frontend, MapObserver::nullObserver(), bench.view.getSize(), 1, bench.fileSource, bench.threadPool, MapMode::Still };
     
     while (state.KeepRunning()) {
@@ -73,7 +73,7 @@ static void API_renderStill_recreate_map(::benchmark::State& state) {
     RenderBenchmark bench;
     
     while (state.KeepRunning()) {
-        AsyncRendererFrontend frontend { std::make_unique<Renderer>(bench.backend, 1, bench.fileSource, bench.threadPool), bench.view };
+        AsyncRendererFrontend frontend { std::make_unique<Renderer>(bench.backend, 1, bench.fileSource, bench.threadPool), bench.backend, bench.view };
         Map map { frontend, MapObserver::nullObserver(), bench.view.getSize(), 1, bench.fileSource, bench.threadPool, MapMode::Still };
         prepare(map);
         mbgl::benchmark::render(map, bench.view);

--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -90,7 +90,7 @@ int main(int argc, char *argv[]) {
     OffscreenView view(backend.getContext(), { static_cast<uint32_t>(width * pixelRatio),
                                                static_cast<uint32_t>(height * pixelRatio) });
     ThreadPool threadPool(4);
-    AsyncRendererFrontend rendererFrontend(std::make_unique<Renderer>(backend, pixelRatio, fileSource, threadPool), view);
+    AsyncRendererFrontend rendererFrontend(std::make_unique<Renderer>(backend, pixelRatio, fileSource, threadPool), backend, view);
     Map map(rendererFrontend, MapObserver::nullObserver(), mbgl::Size { width, height }, pixelRatio, fileSource, threadPool, MapMode::Still);
 
     if (style_path.find("://") == std::string::npos) {

--- a/include/mbgl/renderer/renderer_backend.hpp
+++ b/include/mbgl/renderer/renderer_backend.hpp
@@ -30,10 +30,6 @@ public:
     // Called prior to rendering to update the internally assumed OpenGL state.
     virtual void updateAssumedState() = 0;
 
-    virtual BackendScope::ScopeType getScopeType() const {
-        return BackendScope::ScopeType::Explicit;
-    }
-
 protected:
     // Called with the name of an OpenGL extension that should be loaded. RendererBackend implementations
     // must call the API-specific version that obtains the function pointer for this function,

--- a/platform/android/src/android_renderer_frontend.cpp
+++ b/platform/android/src/android_renderer_frontend.cpp
@@ -1,6 +1,7 @@
 #include "android_renderer_frontend.hpp"
 
 #include <mbgl/map/view.hpp>
+#include <mbgl/renderer/backend_scope.hpp>
 #include <mbgl/renderer/renderer.hpp>
 
 namespace mbgl {
@@ -8,8 +9,10 @@ namespace android {
 
 AndroidRendererFrontend::AndroidRendererFrontend(
         std::unique_ptr<Renderer> renderer_,
+        RendererBackend& backend_,
         InvalidateCallback invalidate)
         : renderer(std::move(renderer_))
+        , backend(backend_)
         , asyncInvalidate([=, invalidate=std::move(invalidate)]() {
             invalidate();
         }) {
@@ -37,6 +40,8 @@ void AndroidRendererFrontend::update(std::shared_ptr<UpdateParameters> params) {
 void AndroidRendererFrontend::render(View& view) {
     assert (renderer);
     if (!updateParameters) return;
+
+    BackendScope guard { backend };
 
     renderer->render(view, *updateParameters);
 }

--- a/platform/android/src/android_renderer_frontend.hpp
+++ b/platform/android/src/android_renderer_frontend.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <mbgl/annotation/annotation.hpp>
+#include <mbgl/renderer/renderer_backend.hpp>
 #include <mbgl/renderer/renderer_frontend.hpp>
 #include <mbgl/util/async_task.hpp>
 #include <mbgl/util/geo.hpp>
@@ -23,7 +24,7 @@ namespace android {
 class AndroidRendererFrontend : public RendererFrontend {
 public:
     using InvalidateCallback = std::function<void ()>;
-    AndroidRendererFrontend(std::unique_ptr<Renderer>, InvalidateCallback);
+    AndroidRendererFrontend(std::unique_ptr<Renderer>, RendererBackend&, InvalidateCallback);
     ~AndroidRendererFrontend() override;
 
     void reset() override;
@@ -43,6 +44,7 @@ public:
 
 private:
     std::unique_ptr<Renderer> renderer;
+    RendererBackend& backend;
     std::shared_ptr<UpdateParameters> updateParameters;
     util::AsyncTask asyncInvalidate;
 };

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -78,6 +78,7 @@ NativeMapView::NativeMapView(jni::JNIEnv& _env,
 
     // Create a renderer frontend
     rendererFrontend = std::make_unique<AndroidRendererFrontend>(std::move(renderer),
+                                                                 *this,
                                                                  [this] { this->invalidate(); });
 
     // Create the core map

--- a/platform/default/mbgl/gl/headless_backend.cpp
+++ b/platform/default/mbgl/gl/headless_backend.cpp
@@ -12,7 +12,7 @@ namespace mbgl {
 HeadlessBackend::HeadlessBackend() = default;
 
 HeadlessBackend::~HeadlessBackend() {
-    BackendScope guard { *this, getScopeType() };
+    BackendScope guard { *this };
     context.reset();
 }
 

--- a/platform/default/mbgl/renderer/async_renderer_frontend.cpp
+++ b/platform/default/mbgl/renderer/async_renderer_frontend.cpp
@@ -1,13 +1,16 @@
 #include "async_renderer_frontend.hpp"
+
+#include <mbgl/renderer/backend_scope.hpp>
 #include <mbgl/renderer/renderer.hpp>
 
 namespace mbgl {
 
-AsyncRendererFrontend::AsyncRendererFrontend(std::unique_ptr<Renderer> renderer_, View& view_)
+AsyncRendererFrontend::AsyncRendererFrontend(std::unique_ptr<Renderer> renderer_, RendererBackend& backend, View& view_)
     : renderer(std::move(renderer_))
     , view(view_)
-    , asyncInvalidate([this] {
+    , asyncInvalidate([&] {
         if (renderer && updateParameters) {
+            BackendScope guard { backend };
             renderer->render(view, *updateParameters);
         }
     }) {

--- a/platform/default/mbgl/renderer/async_renderer_frontend.hpp
+++ b/platform/default/mbgl/renderer/async_renderer_frontend.hpp
@@ -10,11 +10,12 @@
 namespace mbgl {
     
 class Renderer;
+class RendererBackend;
 
 // Default implementation for RendererFrontend
 class AsyncRendererFrontend : public mbgl::RendererFrontend {
 public:
-    AsyncRendererFrontend(std::unique_ptr<Renderer>, View&);
+    AsyncRendererFrontend(std::unique_ptr<Renderer>, RendererBackend&, View&);
     ~AsyncRendererFrontend() override;
 
     void reset() override;

--- a/platform/glfw/glfw_renderer_frontend.cpp
+++ b/platform/glfw/glfw_renderer_frontend.cpp
@@ -29,6 +29,8 @@ void GLFWRendererFrontend::render() {
     assert(renderer);
     
     if (!updateParameters) return;
+    
+    mbgl::BackendScope guard { glfwView, mbgl::BackendScope::ScopeType::Implicit };
 
     renderer->render(glfwView, *updateParameters);
 }

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -503,7 +503,6 @@ void GLFWView::run() {
                 animateRouteCallback(map);
 
             activate();
-            mbgl::BackendScope guard { *this, getScopeType() };
 
             rendererFrontend->render();
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -455,7 +455,7 @@ public:
     _mbglThreadPool = mbgl::sharedThreadPool();
     
     auto renderer = std::make_unique<mbgl::Renderer>(*_mbglView, scaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::GLContextMode::Unique);
-    _rendererFrontend = std::make_unique<MGLRenderFrontend>(std::move(renderer), self, _mbglView);
+    _rendererFrontend = std::make_unique<MGLRenderFrontend>(std::move(renderer), self, *_mbglView, *_mbglView);
     _mbglMap = new mbgl::Map(*_rendererFrontend, *_mbglView, self.size, scaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::MapMode::Continuous, mbgl::ConstrainMode::None, mbgl::ViewportMode::Default);
 
     // start paused if in IB
@@ -5527,10 +5527,6 @@ public:
         CFRelease(str);
 
         return reinterpret_cast<mbgl::gl::ProcAddress>(symbol);
-    }
-    
-    mbgl::BackendScope::ScopeType getScopeType() const override {
-        return mbgl::BackendScope::ScopeType::Implicit;
     }
 
     void activate() override

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -275,7 +275,7 @@ public:
     _mbglThreadPool = mbgl::sharedThreadPool();
 
     auto renderer = std::make_unique<mbgl::Renderer>(*_mbglView, [NSScreen mainScreen].backingScaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::GLContextMode::Unique);
-    _rendererFrontend = std::make_unique<MGLRenderFrontend>(std::move(renderer), self, _mbglView, true);
+    _rendererFrontend = std::make_unique<MGLRenderFrontend>(std::move(renderer), self, *_mbglView, *_mbglView, true);
     _mbglMap = new mbgl::Map(*_rendererFrontend, *_mbglView, self.size, [NSScreen mainScreen].backingScaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::MapMode::Continuous, mbgl::ConstrainMode::None, mbgl::ViewportMode::Default);
 
     // Install the OpenGL layer. Interface Builder’s synchronous drawing means
@@ -2877,10 +2877,6 @@ public:
         glGetIntegerv(GL_FRAMEBUFFER_BINDING, &fbo);
         assumeFramebufferBinding(fbo);
         assumeViewport(0, 0, nativeView.framebufferSize);
-    }
-    
-    mbgl::BackendScope::ScopeType getScopeType() const override {
-        return mbgl::BackendScope::ScopeType::Implicit;
     }
 
     void bind() override {

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -526,7 +526,7 @@ void NodeMap::cancel() {
     map.reset();
 
     auto renderer = std::make_unique<mbgl::Renderer>(backend, pixelRatio, *this, threadpool);
-    rendererFrontend = std::make_unique<NodeRendererFrontend>(std::move(renderer), [this] { return view.get(); });
+    rendererFrontend = std::make_unique<NodeRendererFrontend>(std::move(renderer), backend, [this] { return view.get(); });
     map = std::make_unique<mbgl::Map>(*rendererFrontend, mapObserver, mbgl::Size{ 256, 256 }, pixelRatio,
                                       *this, threadpool, mbgl::MapMode::Still);
 
@@ -985,7 +985,7 @@ NodeMap::NodeMap(v8::Local<v8::Object> options)
                      : 1.0;
       }())
     , mapObserver(NodeMapObserver())
-    , rendererFrontend(std::make_unique<NodeRendererFrontend>(std::make_unique<mbgl::Renderer>(backend, pixelRatio, *this, threadpool), [this] { return view.get(); }))
+    , rendererFrontend(std::make_unique<NodeRendererFrontend>(std::make_unique<mbgl::Renderer>(backend, pixelRatio, *this, threadpool), backend, [this] { return view.get(); }))
     , map(std::make_unique<mbgl::Map>(*rendererFrontend,
                                       mapObserver,
                                       mbgl::Size { 256, 256 },

--- a/platform/node/src/node_renderer_frontend.cpp
+++ b/platform/node/src/node_renderer_frontend.cpp
@@ -1,13 +1,16 @@
 #include "node_renderer_frontend.hpp"
+
 #include <mbgl/renderer/renderer.hpp>
+#include <mbgl/renderer/renderer_backend.hpp>
 #include <mbgl/renderer/backend_scope.hpp>
 
 namespace node_mbgl {
 
-NodeRendererFrontend::NodeRendererFrontend(std::unique_ptr<mbgl::Renderer> renderer_, ViewAccessorFunction getView)
+NodeRendererFrontend::NodeRendererFrontend(std::unique_ptr<mbgl::Renderer> renderer_, mbgl::RendererBackend& backend_, ViewAccessorFunction getView)
     : renderer(std::move(renderer_))
-    , asyncInvalidate([&, this, getView] {
+    , asyncInvalidate([&, getView] {
         if (renderer && updateParameters) {
+            mbgl::BackendScope guard { backend_ };
             renderer->render(*getView(), *updateParameters);
         }
     }) {

--- a/platform/node/src/node_renderer_frontend.hpp
+++ b/platform/node/src/node_renderer_frontend.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <mbgl/renderer/renderer_backend.hpp>
 #include <mbgl/renderer/renderer_frontend.hpp>
 #include <mbgl/renderer/query.hpp>
 #include <mbgl/util/async_task.hpp>
@@ -12,6 +11,8 @@
 
 namespace mbgl {
     class Renderer;
+    class RendererBackend;
+    class View;
 } //  namespace mbgl
 
 namespace node_mbgl {
@@ -19,7 +20,7 @@ namespace node_mbgl {
 class NodeRendererFrontend : public mbgl::RendererFrontend {
 public:
     using ViewAccessorFunction = std::function<mbgl::View* ()>;
-    NodeRendererFrontend(std::unique_ptr<mbgl::Renderer>, ViewAccessorFunction);
+    NodeRendererFrontend(std::unique_ptr<mbgl::Renderer>, mbgl::RendererBackend&, ViewAccessorFunction);
 
     ~NodeRendererFrontend();
     

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1446,9 +1446,6 @@ void QMapboxGL::render()
     }
 #endif
 
-    // The OpenGL implementation automatically enables the OpenGL context for us.
-    mbgl::BackendScope scope { *d_ptr, mbgl::BackendScope::ScopeType::Implicit };
-
     d_ptr->dirty = false;
     d_ptr->render();
 }
@@ -1505,6 +1502,7 @@ QMapboxGLPrivate::QMapboxGLPrivate(QMapboxGL *q, const QMapboxGLSettings &settin
     frontend = std::make_unique<QMapboxGLRendererFrontend>(
             std::make_unique<mbgl::Renderer>(*this, pixelRatio, *fileSourceObj, *threadPool,
                                              static_cast<mbgl::GLContextMode>(settings.contextMode())),
+            *this,
             *this);
     connect(frontend.get(), SIGNAL(updated()), this, SLOT(invalidate()));
     

--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -31,9 +31,6 @@ public:
     void updateAssumedState() final;
     void activate() final {}
     void deactivate() final {}
-    mbgl::BackendScope::ScopeType getScopeType() const final {
-        return mbgl::BackendScope::ScopeType::Implicit;
-    }
 
     // mbgl::MapObserver implementation.
     void onCameraWillChange(mbgl::MapObserver::CameraChangeMode) final;

--- a/platform/qt/src/qmapboxgl_renderer_frontend_p.cpp
+++ b/platform/qt/src/qmapboxgl_renderer_frontend_p.cpp
@@ -3,8 +3,9 @@
 #include <mbgl/renderer/backend_scope.hpp>
 #include <mbgl/renderer/renderer.hpp>
 
-QMapboxGLRendererFrontend::QMapboxGLRendererFrontend(std::unique_ptr<mbgl::Renderer> renderer_, mbgl::View& view_)
+QMapboxGLRendererFrontend::QMapboxGLRendererFrontend(std::unique_ptr<mbgl::Renderer> renderer_, mbgl::RendererBackend& backend_, mbgl::View& view_)
     : renderer(std::move(renderer_))
+    , backend(backend_)
     , view(view_) {
 }
 
@@ -23,10 +24,15 @@ void QMapboxGLRendererFrontend::update(std::shared_ptr<mbgl::UpdateParameters> u
 
 void QMapboxGLRendererFrontend::setObserver(mbgl::RendererObserver& observer_) {
     if (!renderer) return;
+    
     renderer->setObserver(&observer_);
 }
 
 void QMapboxGLRendererFrontend::render() {
     if (!renderer || !updateParameters) return;
+    
+    // The OpenGL implementation automatically enables the OpenGL context for us.
+    mbgl::BackendScope scope { backend, mbgl::BackendScope::ScopeType::Implicit };
+    
     renderer->render(view, *updateParameters);
 }

--- a/platform/qt/src/qmapboxgl_renderer_frontend_p.hpp
+++ b/platform/qt/src/qmapboxgl_renderer_frontend_p.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mbgl/renderer/renderer_backend.hpp>
 #include <mbgl/renderer/renderer_frontend.hpp>
 
 #include <QObject>
@@ -14,7 +15,7 @@ class QMapboxGLRendererFrontend : public QObject, public mbgl::RendererFrontend
     Q_OBJECT
 
 public:
-    explicit QMapboxGLRendererFrontend(std::unique_ptr<mbgl::Renderer>, mbgl::View&);
+    explicit QMapboxGLRendererFrontend(std::unique_ptr<mbgl::Renderer>, mbgl::RendererBackend&, mbgl::View&);
     ~QMapboxGLRendererFrontend() override;
     
     void reset() override;
@@ -30,6 +31,7 @@ signals:
     
 private:
     std::unique_ptr<mbgl::Renderer> renderer;
+    mbgl::RendererBackend& backend;
     mbgl::View& view;
     std::shared_ptr<mbgl::UpdateParameters> updateParameters;
 };

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -35,7 +35,7 @@ Renderer::Impl::Impl(RendererBackend& backend_,
 }
 
 Renderer::Impl::~Impl() {
-    BackendScope guard { backend, backend.getScopeType()};
+    BackendScope guard { backend };
     renderStyle.reset();
     staticData.reset();
 };
@@ -47,8 +47,8 @@ void Renderer::Impl::setObserver(RendererObserver* observer_) {
 void Renderer::Impl::render(View& view, const UpdateParameters& updateParameters) {
     // Don't load/render anyting in still mode until explicitly requested.
     if (updateParameters.mode == MapMode::Still && !updateParameters.stillImageRequest) return;
-
-    BackendScope guard { backend, backend.getScopeType() };
+    
+    assert(BackendScope::exists());
 
     renderStyle->update(updateParameters);
     transformState = updateParameters.transformState;
@@ -348,7 +348,7 @@ void Renderer::Impl::onResourceError(std::exception_ptr ptr) {
 }
 
 void Renderer::Impl::onLowMemory() {
-    BackendScope guard { backend, backend.getScopeType() };
+    BackendScope guard { backend };
     backend.getContext().performCleanup();
     renderStyle->onLowMemory();
     observer->onInvalidate();


### PR DESCRIPTION
Fixes #9572

Could alternatively be done in the renderer frontend, but that would require passing the backend to it just for cleanup.