### PR TITLE
[core] Fix issues with the std:: namespace and old compilers

### DIFF
--- a/include/mbgl/util/string.hpp
+++ b/include/mbgl/util/string.hpp
@@ -1,8 +1,33 @@
 #pragma once
 
+#include <sstream>
 #include <string>
 #include <cassert>
+#include <cstdlib>
 #include <exception>
+
+// Polyfill needed by Qt when building for Android with GCC
+#if defined(__ANDROID__) && defined(__GLIBCXX__)
+
+namespace std {
+
+template <typename T>
+std::string to_string(T value)
+{
+    std::ostringstream oss;
+    oss << value;
+
+    return oss.str();
+}
+
+inline int stoi(const std::string &str)
+{
+    return atoi(str.c_str());
+}
+
+} // namespace std
+
+#endif
 
 namespace mbgl {
 namespace util {

--- a/scripts/clang-tools.sh
+++ b/scripts/clang-tools.sh
@@ -3,11 +3,11 @@
 set -e
 set -o pipefail
 
-CLANG_TIDY_PREFIX=${CLANG_TIDY_PREFIX:-$(scripts/mason.sh PREFIX clang-tidy VERSION 4.0.0)}
+CLANG_TIDY_PREFIX=${CLANG_TIDY_PREFIX:-$(scripts/mason.sh PREFIX clang-tidy VERSION 4.0.1)}
 CLANG_TIDY=${CLANG_TIDY:-${CLANG_TIDY_PREFIX}/bin/clang-tidy}
 CLANG_APPLY=${CLANG_APPLY:-${CLANG_TIDY_PREFIX}/bin/clang-apply-replacements}
 
-CLANG_FORMAT=${CLANG_FORMAT:-$(scripts/mason.sh PREFIX clang-format VERSION 4.0.0)/bin/clang-format}
+CLANG_FORMAT=${CLANG_FORMAT:-$(scripts/mason.sh PREFIX clang-format VERSION 4.0.1)/bin/clang-format}
 
 for CLANG_FILE in "${CLANG_TIDY} ${CLANG_APPLY} ${CLANG_FORMAT}"; do
     command -v ${CLANG_TIDY} > /dev/null 2>&1 || {

--- a/src/mbgl/annotation/shape_annotation_impl.hpp
+++ b/src/mbgl/annotation/shape_annotation_impl.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mbgl/util/string.hpp>
 #include <mapbox/geojsonvt.hpp>
 
 #include <mbgl/annotation/annotation.hpp>

--- a/src/mbgl/style/parser.cpp
+++ b/src/mbgl/style/parser.cpp
@@ -8,6 +8,7 @@
 #include <mbgl/style/conversion/light.hpp>
 
 #include <mbgl/util/logging.hpp>
+#include <mbgl/util/string.hpp>
 
 #include <mapbox/geojsonvt.hpp>
 

--- a/src/mbgl/style/sources/geojson_source_impl.cpp
+++ b/src/mbgl/style/sources/geojson_source_impl.cpp
@@ -1,9 +1,12 @@
 #include <mbgl/style/sources/geojson_source_impl.hpp>
 #include <mbgl/util/constants.hpp>
 #include <mbgl/tile/tile_id.hpp>
+#include <mbgl/util/string.hpp>
 
 #include <mapbox/geojsonvt.hpp>
 #include <supercluster.hpp>
+
+#include <cmath>
 
 namespace mbgl {
 namespace style {
@@ -52,14 +55,14 @@ GeoJSONSource::Impl::Impl(const Impl& other, const GeoJSON& geoJSON)
         mapbox::supercluster::Options clusterOptions;
         clusterOptions.maxZoom = options.clusterMaxZoom;
         clusterOptions.extent = util::EXTENT;
-        clusterOptions.radius = std::round(scale * options.clusterRadius);
+        clusterOptions.radius = ::round(scale * options.clusterRadius);
         data = std::make_unique<SuperclusterData>(
             geoJSON.get<mapbox::geometry::feature_collection<double>>(), clusterOptions);
     } else {
         mapbox::geojsonvt::Options vtOptions;
         vtOptions.maxZoom = options.maxzoom;
         vtOptions.extent = util::EXTENT;
-        vtOptions.buffer = std::round(scale * options.buffer);
+        vtOptions.buffer = ::round(scale * options.buffer);
         vtOptions.tolerance = scale * options.tolerance;
         data = std::make_unique<GeoJSONVTData>(geoJSON, vtOptions);
     }

--- a/src/mbgl/text/shaping.cpp
+++ b/src/mbgl/text/shaping.cpp
@@ -7,6 +7,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include <algorithm>
+#include <cmath>
 
 namespace mbgl {
 
@@ -72,7 +73,7 @@ float determineAverageLineWidth(const std::u16string& logicalInput,
         }
     }
     
-    int32_t targetLineCount = std::fmax(1, std::ceil(totalWidth / maxWidth));
+    int32_t targetLineCount = ::fmax(1, std::ceil(totalWidth / maxWidth));
     return totalWidth / targetLineCount;
 }
 

--- a/src/mbgl/tile/geojson_tile.cpp
+++ b/src/mbgl/tile/geojson_tile.cpp
@@ -2,6 +2,7 @@
 #include <mbgl/tile/geometry_tile_data.hpp>
 #include <mbgl/renderer/query.hpp>
 #include <mbgl/renderer/tile_parameters.hpp>
+#include <mbgl/util/string.hpp>
 
 #include <mapbox/geojsonvt.hpp>
 #include <supercluster.hpp>

--- a/src/mbgl/util/dtoa.cpp
+++ b/src/mbgl/util/dtoa.cpp
@@ -6,6 +6,8 @@
 #include <rapidjson/internal/dtoa.h>
 #endif
 
+#include <mbgl/util/string.hpp>
+
 namespace mbgl {
 namespace util {
 

--- a/src/mbgl/util/http_header.cpp
+++ b/src/mbgl/util/http_header.cpp
@@ -1,5 +1,7 @@
 #include <mbgl/util/http_header.hpp>
 
+#include <mbgl/util/string.hpp>
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wunused-parameter"


### PR DESCRIPTION
Specifically when building Android with GCC 4.9 (which Qt still does :-/)