### PR TITLE
Actor enhancements

### DIFF
--- a/include/mbgl/actor/actor.hpp
+++ b/include/mbgl/actor/actor.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/util/noncopyable.hpp>
 
 #include <memory>
+#include <future>
 
 namespace mbgl {
 
@@ -59,6 +60,17 @@ public:
     template <typename Fn, class... Args>
     void invoke(Fn fn, Args&&... args) {
         mailbox->push(actor::makeMessage(object, fn, std::forward<Args>(args)...));
+    }
+
+    template <typename Fn, class... Args>
+    auto ask(Fn fn, Args&&... args) {
+        // Result type is deduced from the function's return type
+        using ResultType = typename std::result_of<decltype(fn)(Object, Args...)>::type;
+
+        std::promise<ResultType> promise;
+        auto future = promise.get_future();
+        mailbox->push(actor::makeMessage(std::move(promise), object, fn, std::forward<Args>(args)...));
+        return future;
     }
 
     ActorRef<std::decay_t<Object>> self() {

--- a/include/mbgl/actor/message.hpp
+++ b/include/mbgl/actor/message.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <mbgl/util/optional.hpp>
+
+#include <future>
 #include <utility>
 
 namespace mbgl {
@@ -36,12 +39,43 @@ public:
     ArgsTuple argsTuple;
 };
 
+template <class ResultType, class Object, class MemberFn, class ArgsTuple>
+class AskMessageImpl : public Message {
+public:
+    AskMessageImpl(std::promise<ResultType> promise_, Object& object_, MemberFn memberFn_, ArgsTuple argsTuple_)
+        : object(object_),
+          memberFn(memberFn_),
+          argsTuple(std::move(argsTuple_)),
+          promise(std::move(promise_)) {
+    }
+
+    void operator()() override {
+        promise.set_value(ask(std::make_index_sequence<std::tuple_size<ArgsTuple>::value>()));
+    }
+
+    template <std::size_t... I>
+    ResultType ask(std::index_sequence<I...>) {
+        return (object.*memberFn)(std::move(std::get<I>(argsTuple))...);
+    }
+
+    Object& object;
+    MemberFn memberFn;
+    ArgsTuple argsTuple;
+    std::promise<ResultType> promise;
+};
+
 namespace actor {
 
 template <class Object, class MemberFn, class... Args>
 std::unique_ptr<Message> makeMessage(Object& object, MemberFn memberFn, Args&&... args) {
     auto tuple = std::make_tuple(std::forward<Args>(args)...);
     return std::make_unique<MessageImpl<Object, MemberFn, decltype(tuple)>>(object, memberFn, std::move(tuple));
+}
+
+template <class ResultType, class Object, class MemberFn, class... Args>
+std::unique_ptr<Message> makeMessage(std::promise<ResultType>&& promise, Object& object, MemberFn memberFn, Args&&... args) {
+    auto tuple = std::make_tuple(std::forward<Args>(args)...);
+    return std::make_unique<AskMessageImpl<ResultType, Object, MemberFn, decltype(tuple)>>(std::move(promise), object, memberFn, std::move(tuple));
 }
 
 } // namespace actor

--- a/test/actor/actor.test.cpp
+++ b/test/actor/actor.test.cpp
@@ -281,3 +281,27 @@ TEST(Actor, NonConcurrentMailbox) {
     test.invoke(&Test::end);
     endedFuture.wait();
 }
+
+TEST(Actor, Ask) {
+    // Asking for a result
+
+    struct Test {
+
+        Test(ActorRef<Test>) {}
+
+        int doubleIt(int i) {
+            return i * 2;
+        }
+    };
+
+    ThreadPool pool { 2 };
+    Actor<Test> test(pool);
+
+    auto result = test.ask(&Test::doubleIt, 1);
+
+    ASSERT_TRUE(result.valid());
+    
+    auto status = result.wait_for(std::chrono::seconds(1));
+    ASSERT_EQ(std::future_status::ready, status);
+    ASSERT_EQ(2, result.get());
+}

--- a/test/actor/actor_ref.test.cpp
+++ b/test/actor/actor_ref.test.cpp
@@ -3,12 +3,9 @@
 
 #include <mbgl/test/util.hpp>
 
-#include <chrono>
-#include <functional>
 #include <future>
 
 using namespace mbgl;
-using namespace std::chrono_literals;
 
 TEST(ActorRef, CanOutliveActor) {
     // An ActorRef can outlive its actor. Doing does not extend the actor's lifetime.
@@ -39,4 +36,59 @@ TEST(ActorRef, CanOutliveActor) {
 
     EXPECT_TRUE(died);
     test.invoke(&Test::receive);
+}
+
+TEST(ActorRef, Ask) {
+    // Ask returns a Future eventually returning the result
+
+    struct Test {
+
+        Test(ActorRef<Test>) {}
+
+        int gimme() {
+            return 20;
+        }
+
+        int echo(int i) {
+            return i;
+        }
+    };
+
+    ThreadPool pool { 1 };
+    Actor<Test> actor(pool);
+    ActorRef<Test> ref = actor.self();
+
+    EXPECT_EQ(20, ref.ask(&Test::gimme).get());
+    EXPECT_EQ(30, ref.ask(&Test::echo, 30).get());
+}
+
+
+TEST(ActorRef, AskOnDestroyedActor) {
+    // Tests behavior when calling ask() after the
+    // Actor has gone away. Should set a exception_ptr.
+
+    struct Test {
+        bool& died;
+
+        Test(ActorRef<Test>, bool& died_) : died(died_) {}
+
+        ~Test() {
+            died = true;
+        }
+
+        int receive() {
+            return 1;
+        }
+    };
+    bool died = false;
+
+    ThreadPool pool { 1 };
+    auto actor = std::make_unique<Actor<Test>>(pool, died);
+    ActorRef<Test> ref = actor->self();
+
+    actor.reset();
+    EXPECT_TRUE(died);
+
+    auto result = ref.ask(&Test::receive);
+    EXPECT_ANY_THROW(result.get());
 }


### PR DESCRIPTION
Split off two additions to the Actor system from work on async rendering (#9576):

-  Add ask pattern to Actor/ActorRef to make blocking calls from one thread to the other (Similar to Akka)
- Make self reference on Actors optional so we can make arbitrary objects Actors without modifying the constructor