### PR TITLE
[ios] Proper limiting behavior when trying to zoom out fully

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1269,9 +1269,8 @@ public:
     else if (pinch.state == UIGestureRecognizerStateChanged)
     {
         CGFloat newScale = self.scale * pinch.scale;
-        double zoom = log2(newScale);
-        if (zoom < _mbglMap->getMinZoom()) return;
-        
+        double zoom = MAX(log2(newScale), _mbglMap->getMinZoom());
+
         // Calculates the final camera zoom, has no effect within current map camera.
         MGLMapCamera *toCamera = [self cameraByZoomingToZoomLevel:zoom aroundAnchorPoint:centerPoint];
         
@@ -1626,9 +1625,7 @@ public:
     {
         CGFloat distance = [quickZoom locationInView:quickZoom.view].y - self.quickZoomStart;
 
-        CGFloat newZoom = log2f(self.scale) + (distance / 75);
-
-        if (newZoom < _mbglMap->getMinZoom()) return;
+        CGFloat newZoom = MAX(log2f(self.scale) + (distance / 75), _mbglMap->getMinZoom());
 
         CGPoint centerPoint = [self anchorPointForGesture:quickZoom];
         


### PR DESCRIPTION
If you try to zoom out in `MGLMapView` using either the pinch gesture or the double tap zoom gesture, you will not be able to get to the full maximum zoom level. As a result, there will always be some literal remaining "wiggle room" when fully zoomed out:

![ezgif com-video-to-gif 4](https://user-images.githubusercontent.com/647626/28541452-0f568ae8-7087-11e7-9db6-22d1922d08fc.gif)

Easy to verify and reproduce, appears to be in every release for the past two years.

The reason this occurs is because there is limiting code in the gesture handling that checks if the `newZoom` is less than the `minZoom`, and returns in that scenario. This is incorrect because you might not have fully reached the `minZoom` yet, and instead of capping the `newZoom` to `minZoom`, it is no-op'ing. Thus, you cannot fully zoom out.

This PR converts the `return` statement into a `newScale = MAX(newScale, minScale)`