### PR TITLE
[ios] Don't force the attribution button tint color to update

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 ## 3.6.1
 
 * Reduced the size of the dynamic framework by optimizing symbol visibility. ([#7604](https://github.com/mapbox/mapbox-gl-native/pull/7604))
+* Fixed an issue where the attribution button would have its custom tint color reset when the map view received a tint color change notification, such as when an alert controller was presented. ([#9598](https://github.com/mapbox/mapbox-gl-native/pull/9598))
 
 ## 3.6.0 - June 29, 2017
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1144,8 +1144,10 @@ public:
 
 - (void)updateTintColorForView:(UIView *)view
 {
-    // stop at recursing container & annotation views (#8522)
-    if ([view isEqual:self.annotationContainerView]) return;
+    // Don't update:
+    //   - annotation views
+    //   - attribution button (handled automatically)
+    if ([view isEqual:self.annotationContainerView] || [view isEqual:self.attributionButton]) return;
 
     if ([view respondsToSelector:@selector(setTintColor:)]) view.tintColor = self.tintColor;
 


### PR DESCRIPTION
Partially addresses https://github.com/mapbox/mapbox-gl-native/issues/9597, where subviews of MGLMapView have their custom tint colors unnecessarily overridden. A full fix for that issue would be a breaking change, so this only attempts to fix the attribution button.

UIButton can be relied on to automatically update its tint to match its parent view, if it still inherits a tint from that parent.

This issue was brought to the fore because of the switch to UIAlertController in v3.6.0 (https://github.com/mapbox/mapbox-gl-native/pull/8373), which triggers `-tintColorDidChange` calls on presentation and dismissal.

/cc @fabian-guerra @1ec5 @boundsj @jmkiley 