### PR TITLE
Don't query shape annotations if none were added

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AnnotationManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AnnotationManager.java
@@ -370,10 +370,12 @@ class AnnotationManager {
   //
 
   boolean onTap(PointF tapPoint) {
-    ShapeAnnotationHit shapeAnnotationHit = getShapeAnnotationHitFromTap(tapPoint);
-    long shapeAnnotationId = new ShapeAnnotationHitResolver(mapboxMap).execute(shapeAnnotationHit);
-    if (shapeAnnotationId != NO_ANNOTATION_ID) {
-      handleClickForShapeAnnotation(shapeAnnotationId);
+    if (!shapeAnnotationIds.isEmpty()) {
+      ShapeAnnotationHit shapeAnnotationHit = getShapeAnnotationHitFromTap(tapPoint);
+      long shapeAnnotationId = new ShapeAnnotationHitResolver(mapboxMap).execute(shapeAnnotationHit);
+      if (shapeAnnotationId != NO_ANNOTATION_ID) {
+        handleClickForShapeAnnotation(shapeAnnotationId);
+      }
     }
 
     MarkerHit markerHit = getMarkerHitFromTouchArea(tapPoint);


### PR DESCRIPTION
Definitive fix for https://github.com/mapbox/mapbox-gl-native/issues/9584. When clicking the map and no shape annotations are added. We were passing in an empty array for layer id. This resulted in querying all the layer maps while we only want to query the layers with shape annotations on them. 


