### PR TITLE
[build] Package bcsymbolmap files; cleanup packaging script

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Reduced the size of the dynamic framework by optimizing symbol visibility. ([#7604](https://github.com/mapbox/mapbox-gl-native/pull/7604))
 * Fixed an issue where the attribution button would have its custom tint color reset when the map view received a tint color change notification, such as when an alert controller was presented. ([#9598](https://github.com/mapbox/mapbox-gl-native/pull/9598))
+* Bitcode symbol maps (.bcsymbolmap files) are now included with the dynamic framework. ([#9613](https://github.com/mapbox/mapbox-gl-native/pull/9613))
 
 ## 3.6.0 - June 29, 2017
 

--- a/platform/ios/scripts/package.sh
+++ b/platform/ios/scripts/package.sh
@@ -21,33 +21,17 @@ elif [[ ${FORMAT} == "dynamic" ]]; then
     BUILD_STATIC=false
 fi
 
-SELF_CONTAINED=${SELF_CONTAINED:-}
-STATIC_BUNDLE_DIR=
-if [[ ${SELF_CONTAINED} ]]; then
-    STATIC_BUNDLE_DIR="${OUTPUT}/static/${NAME}.framework"
-else
-    STATIC_BUNDLE_DIR="${OUTPUT}/static"
-fi
-
-STATIC_SETTINGS_DIR=
-if [[ ${SELF_CONTAINED} ]]; then
-    STATIC_SETTINGS_DIR="${OUTPUT}/static/${NAME}.framework"
-else
-    STATIC_SETTINGS_DIR="${OUTPUT}"
-fi
-
 SDK=iphonesimulator
 if [[ ${BUILD_FOR_DEVICE} == true ]]; then
     SDK=iphoneos
 fi
 IOS_SDK_VERSION=`xcrun --sdk ${SDK} --show-sdk-version`
 
-echo "Configuring ${FORMAT:-dynamic and static} ${BUILDTYPE} framework for ${SDK}; symbols: ${SYMBOLS}; self-contained static framework: ${SELF_CONTAINED:-NO}"
-
 function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
 function finish { >&2 echo -en "\033[0m"; }
 trap finish EXIT
 
+step "Configuring ${FORMAT:-dynamic and static} ${BUILDTYPE} framework for ${SDK}; symbols: ${SYMBOLS}"
 
 rm -rf ${OUTPUT}
 if [[ ${BUILD_STATIC} == true ]]; then
@@ -69,7 +53,7 @@ PROJ_VERSION=$(git rev-list --count HEAD)
 SEM_VERSION=$( git describe --tags --match=ios-v*.*.* --abbrev=0 | sed 's/^ios-v//' )
 SHORT_VERSION=${SEM_VERSION%-*}
 
-step "Building targets (build ${PROJ_VERSION}, version ${SEM_VERSION})…"
+step "Building targets (build ${PROJ_VERSION}, version ${SEM_VERSION})"
 
 SCHEME='dynamic'
 if [[ ${BUILD_DYNAMIC} == true && ${BUILD_STATIC} == true ]]; then
@@ -78,6 +62,7 @@ elif [[ ${BUILD_STATIC} == true ]]; then
     SCHEME='static'
 fi
 
+step "Building for iOS Simulator using scheme ${SCHEME}"
 xcodebuild \
     CURRENT_PROJECT_VERSION=${PROJ_VERSION} \
     CURRENT_SHORT_VERSION=${SHORT_VERSION} \
@@ -92,6 +77,7 @@ xcodebuild \
     -jobs ${JOBS} | xcpretty
 
 if [[ ${BUILD_FOR_DEVICE} == true ]]; then
+    step "Building for iOS devices using scheme ${SCHEME}"
     xcodebuild \
         CURRENT_PROJECT_VERSION=${PROJ_VERSION} \
         CURRENT_SHORT_VERSION=${SHORT_VERSION} \
@@ -119,7 +105,7 @@ if [[ ${BUILD_FOR_DEVICE} == true ]]; then
             ${LIBS[@]/#/${PRODUCTS}/${BUILDTYPE}-iphonesimulator/lib} \
             `cmake -LA -N ${DERIVED_DATA} | grep MASON_PACKAGE_icu_LIBRARIES | cut -d= -f2`
 
-        cp -rv ${PRODUCTS}/${BUILDTYPE}-iphoneos/${NAME}.bundle ${STATIC_BUNDLE_DIR}
+        cp -rv ${PRODUCTS}/${BUILDTYPE}-iphoneos/${NAME}.bundle ${OUTPUT}/static
     fi
 
     if [[ ${BUILD_DYNAMIC} == true ]]; then
@@ -149,7 +135,7 @@ if [[ ${BUILD_FOR_DEVICE} == true ]]; then
             -create -output ${OUTPUT}/dynamic/${NAME}.framework/${NAME} | echo
     fi
 
-    cp -rv ${PRODUCTS}/${BUILDTYPE}-iphoneos/Settings.bundle ${STATIC_SETTINGS_DIR}
+    cp -rv ${PRODUCTS}/${BUILDTYPE}-iphoneos/Settings.bundle ${OUTPUT}
 else
     if [[ ${BUILD_STATIC} == true ]]; then
         step "Assembling static library for iOS Simulator…"
@@ -159,7 +145,7 @@ else
             ${LIBS[@]/#/${PRODUCTS}/${BUILDTYPE}-iphonesimulator/lib} \
             `cmake -LA -N ${DERIVED_DATA} | grep MASON_PACKAGE_icu_LIBRARIES | cut -d= -f2`
 
-        cp -rv ${PRODUCTS}/${BUILDTYPE}-iphonesimulator/${NAME}.bundle ${STATIC_BUNDLE_DIR}
+        cp -rv ${PRODUCTS}/${BUILDTYPE}-iphonesimulator/${NAME}.bundle ${OUTPUT}/static
     fi
 
     if [[ ${BUILD_DYNAMIC} == true ]]; then
@@ -174,7 +160,7 @@ else
         fi
     fi
 
-    cp -rv ${PRODUCTS}/${BUILDTYPE}-iphonesimulator/Settings.bundle ${STATIC_SETTINGS_DIR}
+    cp -rv ${PRODUCTS}/${BUILDTYPE}-iphonesimulator/Settings.bundle ${OUTPUT}
 fi
 
 if [[ ${SYMBOLS} = NO ]]; then
@@ -244,9 +230,9 @@ if [[ ${BUILD_STATIC} == true ]]; then
 fi
 
 step "Copying library resources…"
-cp -pv LICENSE.md ${STATIC_SETTINGS_DIR}
+cp -pv LICENSE.md ${OUTPUT}
 if [[ ${BUILD_STATIC} == true ]]; then
-    cp -pv "${STATIC_BUNDLE_DIR}/${NAME}.bundle/Info.plist" "${OUTPUT}/static/${NAME}.framework/Info.plist"
+    cp -pv "${OUTPUT}/static/${NAME}.bundle/Info.plist" "${OUTPUT}/static/${NAME}.framework/Info.plist"
     plutil -replace CFBundlePackageType -string FMWK "${OUTPUT}/static/${NAME}.framework/Info.plist"
     mkdir "${OUTPUT}/static/${NAME}.framework/Modules"
     cp -pv platform/ios/framework/modulemap "${OUTPUT}/static/${NAME}.framework/Modules/module.modulemap"

--- a/platform/ios/scripts/package.sh
+++ b/platform/ios/scripts/package.sh
@@ -237,6 +237,10 @@ if [[ ${BUILD_STATIC} == true ]]; then
     mkdir "${OUTPUT}/static/${NAME}.framework/Modules"
     cp -pv platform/ios/framework/modulemap "${OUTPUT}/static/${NAME}.framework/Modules/module.modulemap"
 fi
+if [[ ${BUILD_DYNAMIC} == true && ${BUILD_FOR_DEVICE} == true ]]; then
+    step "Copying bitcode symbol maps…"
+    find "${PRODUCTS}/${BUILDTYPE}-iphoneos" -name '*.bcsymbolmap' -type f -exec cp -pv {} "${OUTPUT}/dynamic/" \;
+fi
 sed -n -e '/^## /,$p' platform/ios/CHANGELOG.md > "${OUTPUT}/CHANGELOG.md"
 
 rm -rf /tmp/mbgl


### PR DESCRIPTION
`.bcsymbolmap` files are text files with a list of symbols available in our framework, used to map recompiled bitcode to named symbols for crash reporting. These files are generated in the build process, one per device architecture, and share UUIDs with those slices/dSYMs.

These bcsymbolmap files can be included during the app archiving process and uploaded to Apple.

- Carthage ~does this automatically~. (https://github.com/Carthage/Carthage/pull/853)
- CocoaPods does not. (It’s only just now getting proper dSYM support. 😑)
- Our standalone-install [`strip-framework.sh`](https://github.com/mapbox/mapbox-gl-native/blob/ios-v3.6.0/platform/ios/framework/strip-frameworks.sh#L43) ~already supports this~. (https://github.com/realm/realm-cocoa/pull/2759)

08b963e packages these files alongside our dynamic framework. When uploaded with an app archive, this should theoretically help eliminate the pesky `__hidden` symbols issue (https://github.com/mapbox/mapbox-gl-native/issues/8463).

### Notes

- Documentation on bcsymbolmap is rare and mostly anecdotal, as one expects of an Apple build process detail.
- There are [rumors](https://twitter.com/steipete/status/877893721672433665) that Xcode 9 will stop producing them.
- bcsymbolmaps are only generated for dynamic frameworks, similar to dSYMs.
- Many framework vendors don’t bother bundling these, but [Realm](https://github.com/realm/realm-cocoa/blob/05d670995401d984346a2025c1aa975da0995c21/build.sh#L164-L165) and [PSPDFKit](https://pspdfkit.com/guides/ios/current/faq/framework-size/#toc_dsym-and-bcsymbolmaps) do.
- These files are large: 2.7 MB uncompressed, ~18K lines — [see this example](https://gist.github.com/friedbunny/606c4cfaf62c8e8ab3fde09812aff981).
- Like most debug ephemera, they aren’t shipped in the final end-user app.

## Also did some more Fabric cleanup

612a1e8 follows up on #9264 and removes the Fabric-specific static framework + bundle mode, first introduced in #4232, later updated in #4783.

/cc @1ec5 @boundsj @fabian-guerra