### PR TITLE
[Qt] Fix database busy timeout not being set correctly

### DIFF
--- a/platform/qt/src/sqlite3.cpp
+++ b/platform/qt/src/sqlite3.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <cstdio>
 #include <chrono>
+#include <limits>
 
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/logging.hpp>
@@ -141,7 +142,11 @@ Database::~Database() {
 
 void Database::setBusyTimeout(std::chrono::milliseconds timeout) {
     assert(impl);
-    std::string timeoutStr = mbgl::util::toString(timeout.count());
+
+    // std::chrono::milliseconds.count() is a long and Qt will cast
+    // internally to int, so we need to make sure the limits apply.
+    std::string timeoutStr = mbgl::util::toString(timeout.count() & INT_MAX);
+
     QString connectOptions = impl->db->connectOptions();
     if (connectOptions.isEmpty()) {
         if (!connectOptions.isEmpty()) connectOptions.append(';');


### PR DESCRIPTION
It was overflowing due to long to int conversion inside Qt and
never being effectively set because Qt was silently ignoring
the conversion error and discarding the new value.

Fixes #9108.