### PR TITLE
Make target for dumping system gfx information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -603,6 +603,11 @@ apackage: platform/android/configuration.gradle
 run-android-upload-archives: platform/android/configuration.gradle
 	cd platform/android && $(MBGL_ANDROID_GRADLE) -Pmapbox.abis=all :MapboxGLAndroidSDK:uploadArchives
 
+# Dump system graphics information for the test app
+.PHONY: android-gfxinfo
+android-gfxinfo:
+	adb shell dumpsys gfxinfo com.mapbox.mapboxsdk.testapp reset
+
 # Runs Android UI tests on all connected devices using Spoon
 .PHONY: run-android-ui-test-spoon
 run-android-ui-test-spoon: platform/android/configuration.gradle


### PR DESCRIPTION
This PR adds a make target for dumping system gfx system information related to the test app. This is allows to profile GPU rendering and quantify the amount of dropped frames. 

Example output:

```
Stats since: 752958278148ns
Total frames rendered: 82189
Janky frames: 35335 (42.99%)
90th percentile: 34ms
95th percentile: 42ms
99th percentile: 69ms
Number Missed Vsync: 4706
Number High input latency: 142
Number Slow UI thread: 17270
Number Slow bitmap uploads: 1542
Number Slow draw: 23342
```