### PR TITLE
[android] Fix compass direction

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
@@ -427,7 +427,8 @@ public final class UiSettings {
       return;
     }
 
-    compassView.update(cameraPosition.bearing);
+    double clockwiseBearing = -cameraPosition.bearing;
+    compassView.update(clockwiseBearing);
   }
 
   /**


### PR DESCRIPTION
- Fixes compass direction:
  - `Transform::getCameraOptions` returns a [counterclockwise angle](https://github.com/mapbox/mapbox-gl-native/blob/master/include/mbgl/map/camera.hpp#L30-L32) after [`transform.invalidateCameraPosition()`](https://github.com/mapbox/mapbox-gl-native/blob/master/include/mbgl/map/camera.hpp#L30-L32) which needs to be transformed to a clockwise bearing before [updating the compass](https://github.com/mapbox/mapbox-gl-native/blob/master/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java#L430)

Currently, the compass is pointing upside down:

![backward_compass](https://user-images.githubusercontent.com/1668582/28672211-5c8431ee-72df-11e7-9ab7-2c14678e1d48.png)

👀 @tobrun 