### PR TITLE
[ios] Set location to nil until the user's location is determined

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Fixed an issue where user heading tracking mode would update too frequently. ([#9845](https://github.com/mapbox/mapbox-gl-native/pull/9845))
 * Added support for iOS 11 location usage descriptions. ([#9869](https://github.com/mapbox/mapbox-gl-native/pull/9869))
+* Fixed an issue where `MGLUserLocation.location` did not follow its documented initialization behavior. This property will now properly return `nil` until the user’s location has been determined. ([#9639](https://github.com/mapbox/mapbox-gl-native/pull/9639))
 
 ## 3.6.2 - August 18, 2017
 

--- a/platform/ios/src/MGLUserLocation.h
+++ b/platform/ios/src/MGLUserLocation.h
@@ -20,8 +20,7 @@ MGL_EXPORT
 /**
  The current location of the device. (read-only)
 
- This property contains `nil` if the map view is not currently showing the user
- location or if the user’s location has not yet been determined.
+ This property returns `nil` if the user’s location has not yet been determined.
  */
 @property (nonatomic, readonly, nullable) CLLocation *location;
 

--- a/platform/ios/src/MGLUserLocation.m
+++ b/platform/ios/src/MGLUserLocation.m
@@ -19,7 +19,6 @@ NS_ASSUME_NONNULL_END
 {
     if (self = [super init])
     {
-        _location = [[CLLocation alloc] initWithLatitude:MAXFLOAT longitude:MAXFLOAT];
         _mapView = mapView;
     }
 
@@ -102,7 +101,7 @@ NS_ASSUME_NONNULL_END
 
 - (CLLocationCoordinate2D)coordinate
 {
-    return self.location.coordinate;
+    return _location ? _location.coordinate : kCLLocationCoordinate2DInvalid;
 }
 
 - (NSString *)title


### PR DESCRIPTION
The documentation for the `location` property states that "This property contains `nil` if the map view is not currently showing the user location or if the user’s location has not yet been determined." The iOS SDK presently returns a garbage value, which has some rather annoying consequences when the value should logically be nullable. This change should rectify the issue.