### PR TITLE
Combine AWS keys

### DIFF
--- a/cloudformation/travis.template
+++ b/cloudformation/travis.template
@@ -130,22 +130,7 @@
                                 }
                             ]
                         }
-                    }
-                ]
-            }
-        },
-        "BuildUserKey": {
-            "Type": "AWS::IAM::AccessKey",
-            "Properties": {
-                "UserName": {
-                    "Ref": "BuildUser"
-                }
-            }
-        },
-        "BitriseUser": {
-            "Type": "AWS::IAM::User",
-            "Properties": {
-                "Policies": [
+                    },
                     {
                         "PolicyName": "get-signing-key",
                         "PolicyDocument": {
@@ -223,11 +208,11 @@
                 ]
             }
         },
-        "BitriseUserKey": {
+        "BuildUserKey": {
             "Type": "AWS::IAM::AccessKey",
             "Properties": {
                 "UserName": {
-                    "Ref": "BitriseUser"
+                    "Ref": "BuildUser"
                 }
             }
         },
@@ -308,19 +293,6 @@
             "Value": {
                 "Fn::GetAtt": [
                     "BuildUserKey",
-                    "SecretAccessKey"
-                ]
-            }
-        },
-        "BitriseAccessKeyId": {
-            "Value": {
-                "Ref": "BitriseUserKey"
-            }
-        },
-        "BitriseSecretAccessKey": {
-            "Value": {
-                "Fn::GetAtt": [
-                    "BitriseUserKey",
                     "SecretAccessKey"
                 ]
             }


### PR DESCRIPTION
This PR combines the AWS keys generated for policies under `BitriseAccessKeyId` and `AccessKeyId` into a single policy.

This will allow us to keep a single set of keys on Circle CI for publishing both Android and Node binaries.

/cc @jfirebaugh @zugaldia @friedbunny  