### PR TITLE
Expose setStyleJson and getStyleJson

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -581,7 +581,7 @@ public class MapView extends FrameLayout {
       try {
         onMapChangedListener.onMapChanged(rawChange);
       } catch (RuntimeException err) {
-        Timber.e("Exception (%s) in MapView.OnMapChangedListener: %s", err.getClass(), err.getMessage());
+        Timber.e(err, "Exception in MapView.OnMapChangedListener");
       }
     }
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1088,13 +1088,34 @@ public final class MapboxMap {
   }
 
   /**
-   * Returns the map style currently displayed in the map view.
+   * Returns the map style url currently displayed in the map view.
    *
    * @return The URL of the map style
    */
   @Nullable
   public String getStyleUrl() {
     return nativeMapView.getStyleUrl();
+  }
+
+  /**
+   * Loads a new map style from a json string.
+   * <p>
+   * If the style fails to load or an invalid style URL is set, the map view will become blank.
+   * An error message will be logged in the Android logcat and {@link MapView#DID_FAIL_LOADING_MAP} event will be
+   * sent.
+   * </p>
+   */
+  public void setStyleJson(@NonNull String styleJson) {
+    nativeMapView.setStyleJson(styleJson);
+  }
+
+  /**
+   * Returns the map style json currently displayed in the map view.
+   *
+   * @return The json of the map style
+   */
+  public String getStyleJson() {
+    return nativeMapView.getStyleJson();
   }
 
   //

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -687,7 +687,7 @@
                   android:label="@string/activity_bottom_sheet">
             <meta-data
                 android:name="@string/category"
-                android:value="@string/category_basic"/>
+                android:value="@string/category_maplayout"/>
         </activity>
 
         <!-- For Instrumentation tests -->

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesBoxSymbolCountActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesBoxSymbolCountActivity.java
@@ -3,7 +3,6 @@ package com.mapbox.mapboxsdk.testapp.activity.feature;
 import android.graphics.BitmapFactory;
 import android.graphics.RectF;
 import android.os.Bundle;
-import android.support.annotation.RawRes;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.Toast;
@@ -14,15 +13,10 @@ import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.testapp.utils.ResourceUtils;
 import com.mapbox.services.commons.geojson.Feature;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.StringWriter;
-import java.io.Writer;
 import java.util.List;
 
 import timber.log.Timber;
@@ -57,9 +51,10 @@ public class QueryRenderedFeaturesBoxSymbolCountActivity extends AppCompatActivi
 
         // Add a symbol layer (also works with annotations)
         try {
-          mapboxMap.addSource(new GeoJsonSource("symbols-source", readRawResource(R.raw.test_points_utrecht)));
+          mapboxMap.addSource(new GeoJsonSource("symbols-source", ResourceUtils.readRawResource(
+            QueryRenderedFeaturesBoxSymbolCountActivity.this, R.raw.test_points_utrecht)));
         } catch (IOException ioException) {
-          Timber.e(ioException,"Could not load geojson");
+          Timber.e(ioException, "Could not load geojson");
           return;
         }
         mapboxMap.addImage(
@@ -92,23 +87,6 @@ public class QueryRenderedFeaturesBoxSymbolCountActivity extends AppCompatActivi
         });
       }
     });
-  }
-
-  private String readRawResource(@RawRes int rawResource) throws IOException {
-    InputStream is = getResources().openRawResource(rawResource);
-    Writer writer = new StringWriter();
-    char[] buffer = new char[1024];
-    try {
-      Reader reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
-      int numRead;
-      while ((numRead = reader.read(buffer)) != -1) {
-        writer.write(buffer, 0, numRead);
-      }
-    } finally {
-      is.close();
-    }
-
-    return writer.toString();
   }
 
   public MapboxMap getMapboxMap() {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
@@ -41,10 +41,18 @@ public class DebugModeActivity extends AppCompatActivity {
     setContentView(R.layout.activity_debug_mode);
 
     mapView = (MapView) findViewById(R.id.mapView);
+    mapView.addOnMapChangedListener(new MapView.OnMapChangedListener() {
+      @Override
+      public void onMapChanged(int change) {
+        if (change == MapView.DID_FINISH_LOADING_STYLE && mapboxMap != null) {
+          Timber.e("New loaded style = %s", mapboxMap.getStyleJson());
+        }
+      }
+    });
+
     mapView.setTag(true);
     mapView.setStyleUrl(STYLES[currentStyleIndex]);
     mapView.onCreate(savedInstanceState);
-
     mapView.getMapAsync(new OnMapReadyCallback() {
       @Override
       public void onMapReady(@NonNull MapboxMap map) {
@@ -63,13 +71,12 @@ public class DebugModeActivity extends AppCompatActivity {
       }
     });
 
-
     FloatingActionButton fabDebug = (FloatingActionButton) findViewById(R.id.fabDebug);
     fabDebug.setOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View view) {
         if (mapboxMap != null) {
-          Timber.d("Debug FAB: isDebug Active? %s" , mapboxMap.isDebugActive());
+          Timber.d("Debug FAB: isDebug Active? %s", mapboxMap.isDebugActive());
           mapboxMap.cycleDebugOptions();
         }
       }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/DataDrivenStyleActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/DataDrivenStyleActivity.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.testapp.activity.style;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import android.support.annotation.RawRes;
 import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -18,14 +17,9 @@ import com.mapbox.mapboxsdk.style.layers.FillLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.style.sources.Source;
 import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.testapp.utils.ResourceUtils;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.StringWriter;
-import java.io.Writer;
 
 import timber.log.Timber;
 
@@ -355,7 +349,7 @@ public class DataDrivenStyleActivity extends AppCompatActivity {
     // Add a source
     Source source;
     try {
-      source = new GeoJsonSource("amsterdam-parks-source", readRawResource(R.raw.amsterdam));
+      source = new GeoJsonSource("amsterdam-parks-source", ResourceUtils.readRawResource(this, R.raw.amsterdam));
       mapboxMap.addSource(source);
     } catch (IOException ioException) {
       Toast.makeText(
@@ -374,22 +368,5 @@ public class DataDrivenStyleActivity extends AppCompatActivity {
         fillAntialias(true)
       )
     );
-  }
-
-  private String readRawResource(@RawRes int rawResource) throws IOException {
-    InputStream is = getResources().openRawResource(rawResource);
-    Writer writer = new StringWriter();
-    char[] buffer = new char[1024];
-    try {
-      Reader reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
-      int numRead;
-      while ((numRead = reader.read(buffer)) != -1) {
-        writer.write(buffer, 0, numRead);
-      }
-    } finally {
-      is.close();
-    }
-
-    return writer.toString();
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
@@ -3,7 +3,6 @@ package com.mapbox.mapboxsdk.testapp.activity.style;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.os.Handler;
-import android.support.annotation.RawRes;
 import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -32,16 +31,11 @@ import com.mapbox.mapboxsdk.style.sources.Source;
 import com.mapbox.mapboxsdk.style.sources.TileSet;
 import com.mapbox.mapboxsdk.style.sources.VectorSource;
 import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.testapp.utils.ResourceUtils;
 import com.mapbox.services.commons.geojson.Feature;
 import com.mapbox.services.commons.geojson.FeatureCollection;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.StringWriter;
-import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -285,7 +279,7 @@ public class RuntimeStyleActivity extends AppCompatActivity {
     // Add a source
     Source source;
     try {
-      source = new GeoJsonSource("amsterdam-spots", readRawResource(R.raw.amsterdam));
+      source = new GeoJsonSource("amsterdam-spots", ResourceUtils.readRawResource(this, R.raw.amsterdam));
     } catch (IOException ioException) {
       Toast.makeText(
         RuntimeStyleActivity.this,
@@ -332,7 +326,7 @@ public class RuntimeStyleActivity extends AppCompatActivity {
     // Load some data
     FeatureCollection parks;
     try {
-      String json = readRawResource(R.raw.amsterdam);
+      String json = ResourceUtils.readRawResource(this, R.raw.amsterdam);
       parks = FeatureCollection.fromJson(json);
     } catch (IOException ioException) {
       Toast.makeText(
@@ -485,23 +479,6 @@ public class RuntimeStyleActivity extends AppCompatActivity {
         }
       }
     }
-  }
-
-  private String readRawResource(@RawRes int rawResource) throws IOException {
-    InputStream is = getResources().openRawResource(rawResource);
-    Writer writer = new StringWriter();
-    char[] buffer = new char[1024];
-    try {
-      Reader reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
-      int numRead;
-      while ((numRead = reader.read(buffer)) != -1) {
-        writer.write(buffer, 0, numRead);
-      }
-    } finally {
-      is.close();
-    }
-
-    return writer.toString();
   }
 
   private void addCustomTileSource() {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/StyleFileActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/StyleFileActivity.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.annotation.RawRes;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
@@ -15,17 +14,12 @@ import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.testapp.utils.ResourceUtils;
 
-import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.StringWriter;
-import java.io.Writer;
 import java.lang.ref.WeakReference;
 
 import timber.log.Timber;
@@ -87,7 +81,7 @@ public class StyleFileActivity extends AppCompatActivity {
     protected String doInBackground(Void... voids) {
       String styleJson = "";
       try {
-        styleJson = RawResourceReaderWriter.readRawResource(context.get(), R.raw.sat_style);
+        styleJson = ResourceUtils.readRawResource(context.get(), R.raw.sat_style);
       } catch (Exception exception) {
         Timber.e(exception, "Can't load local file style");
       }
@@ -126,7 +120,7 @@ public class StyleFileActivity extends AppCompatActivity {
         Timber.i("Writing style file to: %s", cacheStyleFile.getAbsolutePath());
         Context context = this.context.get();
         if (context != null) {
-          writeToFile(cacheStyleFile, RawResourceReaderWriter.readRawResource(context, R.raw.local_style));
+          writeToFile(cacheStyleFile, ResourceUtils.readRawResource(context, R.raw.local_style));
         }
       } catch (Exception exception) {
         Toast.makeText(context.get(), "Could not create style file in cache dir", Toast.LENGTH_SHORT).show();
@@ -152,28 +146,6 @@ public class StyleFileActivity extends AppCompatActivity {
           writer.close();
         }
       }
-    }
-  }
-
-  static class RawResourceReaderWriter {
-    static String readRawResource(Context context, @RawRes int rawResource) throws IOException {
-      String json = "";
-      if (context != null) {
-        InputStream is = context.getResources().openRawResource(rawResource);
-        Writer writer = new StringWriter();
-        char[] buffer = new char[1024];
-        try {
-          Reader reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
-          int numRead;
-          while ((numRead = reader.read(buffer)) != -1) {
-            writer.write(buffer, 0, numRead);
-          }
-        } finally {
-          is.close();
-        }
-        json = writer.toString();
-      }
-      return json;
     }
   }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/utils/ResourceUtils.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/utils/ResourceUtils.java
@@ -1,0 +1,36 @@
+package com.mapbox.mapboxsdk.testapp.utils;
+
+import android.content.Context;
+import android.support.annotation.RawRes;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.io.Writer;
+
+public class ResourceUtils {
+
+  public static String readRawResource(Context context, @RawRes int rawResource) throws IOException {
+    String json = "";
+    if (context != null) {
+      InputStream is = context.getResources().openRawResource(rawResource);
+      Writer writer = new StringWriter();
+      char[] buffer = new char[1024];
+      try {
+        Reader reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+        int numRead;
+        while ((numRead = reader.read(buffer)) != -1) {
+          writer.write(buffer, 0, numRead);
+        }
+      } finally {
+        is.close();
+      }
+      json = writer.toString();
+    }
+    return json;
+  }
+}
+

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_style_file.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_style_file.xml
@@ -15,7 +15,18 @@
         app:mapbox_styleUrl="@string/mapbox_style_mapbox_streets"/>
 
     <android.support.design.widget.FloatingActionButton
-        android:id="@id/fab"
+        android:id="@+id/fab_style_json"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
+        android:layout_above="@+id/fab_file"
+        android:layout_margin="@dimen/fab_margin"
+        android:src="@drawable/ic_add"
+        app:backgroundTint="@android:color/white"/>
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@id/fab_file"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/raw/sat_style.json
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/raw/sat_style.json
@@ -1,0 +1,31 @@
+{
+  "version": 8,
+  "name": "Satellite",
+  "metadata": {
+    "mapbox:autocomposite": true
+  },
+  "sources": {
+    "mapbox": {
+      "type": "raster",
+      "url": "mapbox://mapbox.satellite",
+      "tileSize": 256
+    }
+  },
+  "sprite": "mapbox://sprites/mapbox/satellite-v8",
+  "glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {
+        "background-color": "rgb(4,7,14)"
+      }
+    },
+    {
+      "id": "satellite",
+      "type": "raster",
+      "source": "mapbox",
+      "source-layer": "mapbox_satellite_full"
+    }
+  ]
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
@@ -187,8 +187,8 @@
     <string name="dynamic_marker_chelsea_snippet">Stamford Bridge</string>
     <string name="dynamic_marker_arsenal_title">Arsenal</string>
     <string name="dynamic_marker_arsenal_snippet">Emirates Stadium</string>
-    <string name="debug_zoom">Zoom: %f</string>
-    <string name="viewcache_size">"ViewCache size %d"</string>
+    <string name="debug_zoom">Zoom: %.2f</string>
+    <string name="viewcache_size">ViewCache size %.2f</string>
     <string name="latitude">Latitude</string>
     <string name="min_value">-180</string>
     <string name="longitude">Longitude</string>


### PR DESCRIPTION
closes #8347, additionally this PR fixes: 
 - add example for setStyleJson to local file style example
 - add example for getStyleJson in debug mode activity
 - correct exception forwarding for timber
 - formatting issue with doubles
 - corrected placement of bottomsheet activity category