### PR TITLE
post updating InfoWindow update for InfoWindowAdapter

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/infowindow/DynamicInfoWindowAdapterActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/infowindow/DynamicInfoWindowAdapterActivity.java
@@ -3,7 +3,6 @@ package com.mapbox.mapboxsdk.testapp.activity.infowindow;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.support.v4.content.res.ResourcesCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
@@ -28,10 +27,10 @@ import java.util.Locale;
  */
 public class DynamicInfoWindowAdapterActivity extends AppCompatActivity implements OnMapReadyCallback {
 
+  private static final LatLng PARIS = new LatLng(48.864716, 2.349014);
+
   private MapboxMap mapboxMap;
   private MapView mapView;
-
-  private LatLng paris = new LatLng(48.864716, 2.349014);
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -45,7 +44,6 @@ public class DynamicInfoWindowAdapterActivity extends AppCompatActivity implemen
 
   @Override
   public void onMapReady(MapboxMap map) {
-
     mapboxMap = map;
 
     // Add info window adapter
@@ -66,27 +64,32 @@ public class DynamicInfoWindowAdapterActivity extends AppCompatActivity implemen
         double distanceKm = marker.getPosition().distanceTo(point) / 1000;
 
         // Get the info window
-        InfoWindow infoWindow = marker.getInfoWindow();
+        final InfoWindow infoWindow = marker.getInfoWindow();
 
         // Get the view from the info window
         if (infoWindow != null && infoWindow.getView() != null) {
           // Set the new text on the text view in the info window
-          ((TextView) infoWindow.getView()).setText(String.format(Locale.getDefault(), "%.2fkm", distanceKm));
-
-          // Update the info window position (as the text length changes)
-          infoWindow.update();
+          TextView textView  = (TextView) infoWindow.getView();
+          textView.setText(String.format(Locale.getDefault(), "%.2fkm", distanceKm));
+          textView.post(new Runnable() {
+            @Override
+            public void run() {
+              // Update the info window position (as the text length changes)
+              infoWindow.update();
+            }
+          });
         }
       }
     });
 
     // Focus on Paris
-    mapboxMap.animateCamera(CameraUpdateFactory.newLatLng(paris));
+    mapboxMap.animateCamera(CameraUpdateFactory.newLatLng(PARIS));
   }
 
   private MarkerView addMarker(MapboxMap mapboxMap) {
     return mapboxMap.addMarker(
       new MarkerViewOptions()
-        .position(paris)
+        .position(PARIS)
         .icon(IconUtils.drawableToIcon(this, R.drawable.ic_location_city,
           ResourcesCompat.getColor(getResources(), R.color.mapbox_blue, getTheme()))
         ));
@@ -96,7 +99,6 @@ public class DynamicInfoWindowAdapterActivity extends AppCompatActivity implemen
     final int padding = (int) getResources().getDimension(R.dimen.attr_margin);
     mapboxMap.setInfoWindowAdapter(new MapboxMap.InfoWindowAdapter() {
 
-      @Nullable
       @Override
       public View getInfoWindow(@NonNull Marker marker) {
         TextView textView = new TextView(DynamicInfoWindowAdapterActivity.this);


### PR DESCRIPTION
This PR fixes the example of a InfoWindowAdapter by posting the update of InfoWindow. 
Don't feel that this fix should be added to the SDK since this is a custom InfoWindowAdapter implementation (this issue doesn't happen with default implementation). 