### PR TITLE
[android] Fix formatting zoom position DebugModeActivity crash

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
@@ -187,7 +187,7 @@
     <string name="dynamic_marker_chelsea_snippet">Stamford Bridge</string>
     <string name="dynamic_marker_arsenal_title">Arsenal</string>
     <string name="dynamic_marker_arsenal_snippet">Emirates Stadium</string>
-    <string name="debug_zoom">Zoom: %d</string>
+    <string name="debug_zoom">Zoom: %f</string>
     <string name="viewcache_size">"ViewCache size %d"</string>
     <string name="latitude">Latitude</string>
     <string name="min_value">-180</string>


### PR DESCRIPTION
- Fix formatting zoom position `DebugModeActivity` crash:

`java.util.IllegalFormatConversionException: %d can't format java.lang.Double arguments`

👀 @tobrun 