### PR TITLE
[core] Removed unused constructor

### DIFF
--- a/include/mbgl/actor/actor.hpp
+++ b/include/mbgl/actor/actor.hpp
@@ -57,14 +57,6 @@ public:
               object(self(), std::forward<Args>(args_)...) {
     }
 
-    // Enabled for plain Objects
-    template <typename U = Object, class... Args,
-            typename std::enable_if<!std::is_constructible<U, ActorRef<Object>, Args...>::value>::type...>
-    Actor(Scheduler& scheduler, Args&&... args_)
-            : mailbox(std::make_shared<Mailbox>(scheduler)),
-              object(std::forward<Args>(args_)...) {
-    }
-
     ~Actor() {
         mailbox->close();
     }

--- a/test/actor/actor.test.cpp
+++ b/test/actor/actor.test.cpp
@@ -305,34 +305,3 @@ TEST(Actor, Ask) {
     ASSERT_EQ(std::future_status::ready, status);
     ASSERT_EQ(2, result.get());
 }
-
-TEST(Actor, NoSelfActorRef) {
-    // Not all actors need a reference to self
-
-    // Trivially constructable
-    struct Trivial {};
-
-    ThreadPool pool { 2 };
-    Actor<Trivial> trivial(pool);
-
-
-    // With arguments
-    struct WithArguments {
-        std::promise<void> promise;
-
-        WithArguments(std::promise<void> promise_)
-                : promise(std::move(promise_)) {
-        }
-
-        void receive() {
-            promise.set_value();
-        }
-    };
-
-    std::promise<void> promise;
-    auto future = promise.get_future();
-    Actor<WithArguments> withArguments(pool, std::move(promise));
-
-    withArguments.invoke(&WithArguments::receive);
-    future.wait();
-}


### PR DESCRIPTION
Not in use at the moment, was causing a compiler error on
Apple LLVM version 8.0.0 (clang-800.0.42.1).

```
src/mbgl/sprite/sprite_loader.cpp:25:11: error: call to constructor of
'Actor<mbgl::SpriteLoaderWorker>' is ambiguous
```