### PR TITLE
[ios] Add additional documentation when working with antimeridian crossings

### DIFF
--- a/platform/darwin/src/MGLPolyline.h
+++ b/platform/darwin/src/MGLPolyline.h
@@ -33,8 +33,19 @@ NS_ASSUME_NONNULL_BEGIN
  `MGLPolygon` object. To group multiple polylines together in one shape, use an
  `MGLMultiPolyline` or `MGLShapeCollection` object.
 
- To make the polyline straddle the antimeridian, specify some longitudes less
- than −180 degrees or greater than 180 degrees.
+ To make the polyline go across the antimeridian or international date line, 
+ specify some longitudes less than −180 degrees or greater than 180 degrees.
+ For example, a polyline that stretches from Tokyo to San Francisco would have
+ coordinates of (35.68476, -220.24257) and (37.78428, -122.41310).
+ 
+ ```swift
+ let coordinates = [
+     CLLocationCoordinate2D(latitude: 35.68476, longitude: -220.24257),
+     CLLocationCoordinate2D(latitude: 37.78428, longitude: -122.41310)
+ ]
+ 
+ let polyline = MGLPolyline(coordinates: &coordinates, count: UInt(coordinates.count))
+```
 
  A polyline is known as a
  <a href="https://tools.ietf.org/html/rfc7946#section-3.1.4">LineString</a>

--- a/platform/darwin/src/MGLPolyline.h
+++ b/platform/darwin/src/MGLPolyline.h
@@ -43,9 +43,8 @@ NS_ASSUME_NONNULL_BEGIN
      CLLocationCoordinate2D(latitude: 35.68476, longitude: -220.24257),
      CLLocationCoordinate2D(latitude: 37.78428, longitude: -122.41310)
  ]
- 
- let polyline = MGLPolyline(coordinates: &coordinates, count: UInt(coordinates.count))
-```
+ let polyline = MGLPolyline(coordinates: coordinates, count: UInt(coordinates.count))
+ ```
 
  A polyline is known as a
  <a href="https://tools.ietf.org/html/rfc7946#section-3.1.4">LineString</a>

--- a/platform/darwin/test/MGLDocumentationExampleTests.swift
+++ b/platform/darwin/test/MGLDocumentationExampleTests.swift
@@ -103,6 +103,18 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
 
         XCTAssertNotNil(mapView.style?.source(withIdentifier: "pois"))
     }
+    
+    func testMGLPolyline() {
+        //#-example-code
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 35.68476, longitude: -220.24257),
+            CLLocationCoordinate2D(latitude: 37.78428, longitude: -122.41310)
+        ]
+        let polyline = MGLPolyline(coordinates: coordinates, count: UInt(coordinates.count))
+        //#-end-example-code
+        
+        XCTAssertNotNil(polyline)
+    }
 
     func testMGLCircleStyleLayer() {
         let population = MGLVectorSource(identifier: "population", configurationURL: URL(string: "https://example.com/style.json")!)


### PR DESCRIPTION
Adds additional context and a small example demonstrating how to create a line that crosses the antimeridian / international date line:

![jazzy](https://user-images.githubusercontent.com/10850812/29042603-985ffd84-7b85-11e7-9155-1e9c5ec57c83.jpg)

