### PR TITLE
Make actor self reference optional - again

### DIFF
--- a/include/mbgl/actor/actor.hpp
+++ b/include/mbgl/actor/actor.hpp
@@ -50,11 +50,16 @@ class Actor : public util::noncopyable {
 public:
 
     // Enabled for Objects with a constructor taking ActorRef<Object> as the first parameter
-    template <typename U = Object, class... Args,
-            typename std::enable_if<std::is_constructible<U, ActorRef<Object>, Args...>::value>::type...>
+    template <typename U = Object, class... Args, typename std::enable_if<std::is_constructible<U, ActorRef<U>, Args...>::value>::type * = nullptr>
     Actor(Scheduler& scheduler, Args&&... args_)
             : mailbox(std::make_shared<Mailbox>(scheduler)),
               object(self(), std::forward<Args>(args_)...) {
+    }
+
+    // Enabled for plain Objects
+    template<typename U = Object, class... Args, typename std::enable_if<!std::is_constructible<U, ActorRef<U>, Args...>::value>::type * = nullptr>
+    Actor(Scheduler& scheduler, Args&& ... args_)
+            : mailbox(std::make_shared<Mailbox>(scheduler)), object(std::forward<Args>(args_)...) {
     }
 
     ~Actor() {

--- a/test/actor/actor.test.cpp
+++ b/test/actor/actor.test.cpp
@@ -305,3 +305,34 @@ TEST(Actor, Ask) {
     ASSERT_EQ(std::future_status::ready, status);
     ASSERT_EQ(2, result.get());
 }
+
+TEST(Actor, NoSelfActorRef) {
+    // Not all actors need a reference to self
+    
+    // Trivially constructable
+    struct Trivial {};
+    
+    ThreadPool pool { 2 };
+    Actor<Trivial> trivial(pool);
+    
+    
+    // With arguments
+    struct WithArguments {
+        std::promise<void> promise;
+        
+        WithArguments(std::promise<void> promise_)
+        : promise(std::move(promise_)) {
+        }
+        
+        void receive() {
+            promise.set_value();
+        }
+    };
+    
+    std::promise<void> promise;
+    auto future = promise.get_future();
+    Actor<WithArguments> withArguments(pool, std::move(promise));
+    
+    withArguments.invoke(&WithArguments::receive);
+    future.wait();
+}


### PR DESCRIPTION
In #9591 we added a way to construct Actors from arbitrary objects (without requiring modifying the constructor(s)). This broke on Apple clang < 8.2 which is needed for Qt and got reversed in #9720.

This PR re-introduces the same construct with a slightly different syntax on the templates which works with older apple clang versions as well.