### PR TITLE
Fix shadowing argument on apple clang 8.0

### DIFF
--- a/platform/default/mbgl/gl/headless_backend.cpp
+++ b/platform/default/mbgl/gl/headless_backend.cpp
@@ -11,9 +11,9 @@ namespace mbgl {
 
 class HeadlessBackend::View {
 public:
-    View(gl::Context& context, Size size)
-        : color(context.createRenderbuffer<gl::RenderbufferType::RGBA>(size)),
-          depthStencil(context.createRenderbuffer<gl::RenderbufferType::DepthStencil>(size)),
+    View(gl::Context& context, Size size_)
+        : color(context.createRenderbuffer<gl::RenderbufferType::RGBA>(size_)),
+          depthStencil(context.createRenderbuffer<gl::RenderbufferType::DepthStencil>(size_)),
           framebuffer(context.createFramebuffer(color, depthStencil)) {
     }
 


### PR DESCRIPTION
Fixes `headless_backend.cpp:14:37: Declaration shadows a field of 'mbgl::HeadlessBackend'` on `Apple LLVM version 8.0.0 (clang-800.0.42.1)`