### PR TITLE
Current Scheduler

### DIFF
--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -8,6 +8,7 @@ set(MBGL_CORE_FILES
     include/mbgl/actor/message.hpp
     include/mbgl/actor/scheduler.hpp
     src/mbgl/actor/mailbox.cpp
+    src/mbgl/actor/scheduler.cpp
 
     # algorithm
     src/mbgl/algorithm/covered_by_children.hpp

--- a/include/mbgl/actor/scheduler.hpp
+++ b/include/mbgl/actor/scheduler.hpp
@@ -21,18 +21,21 @@ class Mailbox;
       Subject to these constraints, processing can happen on whatever thread in the
       pool is available.
 
-    * `RunLoop` is a `Scheduler` that is typically used to create a mailbox and
-      `ActorRef` for an object that lives on the main thread and is not itself wrapped
-      as an `Actor`:
-
-        auto mailbox = std::make_shared<Mailbox>(*util::RunLoop::Get());
+    * `Scheduler::GetCurrent()` is typically used to create a mailbox and `ActorRef`
+      for an object that lives on the main thread and is not itself wrapped an
+      `Actor`. The underlying implementation of this Scheduler should usually be
+      a `RunLoop`
+        auto mailbox = std::make_shared<Mailbox>(*Scheduler::Get());
         Actor<Worker> worker(threadPool, ActorRef<Foo>(*this, mailbox));
 */
-
 class Scheduler {
 public:
     virtual ~Scheduler() = default;
     virtual void schedule(std::weak_ptr<Mailbox>) = 0;
+
+    // Set/Get the current Scheduler for this thread
+    static Scheduler* GetCurrent();
+    static void SetCurrent(Scheduler*);
 };
 
 } // namespace mbgl

--- a/include/mbgl/util/run_loop.hpp
+++ b/include/mbgl/util/run_loop.hpp
@@ -62,6 +62,12 @@ public:
         push(task);
         return std::make_unique<WorkRequest>(task);
     }
+                    
+    void schedule(std::weak_ptr<Mailbox> mailbox) override {
+        invoke([mailbox] () {
+            Mailbox::maybeReceive(mailbox);
+        });
+    }
 
     class Impl;
 
@@ -71,12 +77,6 @@ private:
     using Queue = std::queue<std::shared_ptr<WorkTask>>;
 
     void push(std::shared_ptr<WorkTask>);
-
-    void schedule(std::weak_ptr<Mailbox> mailbox) override {
-        invoke([mailbox] () {
-            Mailbox::maybeReceive(mailbox);
-        });
-    }
 
     void withMutex(std::function<void()>&& fn) {
         std::lock_guard<std::mutex> lock(mutex);

--- a/platform/android/src/file_source.cpp
+++ b/platform/android/src/file_source.cpp
@@ -1,9 +1,9 @@
 #include "file_source.hpp"
 
 #include <mbgl/actor/actor.hpp>
+#include <mbgl/actor/scheduler.hpp>
 #include <mbgl/storage/resource_transform.hpp>
 #include <mbgl/util/logging.hpp>
-#include <mbgl/util/run_loop.hpp>
 
 #include "asset_manager_file_source.hpp"
 #include "jni/generic_global_ref_deleter.hpp"
@@ -45,7 +45,7 @@ void FileSource::setAPIBaseUrl(jni::JNIEnv& env, jni::String url) {
 
 void FileSource::setResourceTransform(jni::JNIEnv& env, jni::Object<FileSource::ResourceTransformCallback> transformCallback) {
     if (transformCallback) {
-        resourceTransform = std::make_unique<Actor<ResourceTransform>>(*util::RunLoop::Get(),
+        resourceTransform = std::make_unique<Actor<ResourceTransform>>(*Scheduler::GetCurrent(),
             // Capture the ResourceTransformCallback object as a managed global into
             // the lambda. It is released automatically when we're setting a new ResourceTransform in
             // a subsequent call.

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -11,6 +11,7 @@
 #import "NSValue+MGLAdditions.h"
 
 #include <mbgl/actor/actor.hpp>
+#include <mbgl/actor/scheduler.hpp>
 #include <mbgl/storage/resource_transform.hpp>
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/util/string.hpp>
@@ -81,7 +82,7 @@ NSString * const MGLOfflinePackMaximumCountUserInfoKey = MGLOfflinePackUserInfoK
 - (void)setDelegate:(id<MGLOfflineStorageDelegate>)newValue {
     _delegate = newValue;
     if ([self.delegate respondsToSelector:@selector(offlineStorage:URLForResourceOfKind:withURL:)]) {
-        _mbglResourceTransform = std::make_unique<mbgl::Actor<mbgl::ResourceTransform>>(*mbgl::util::RunLoop::Get(), [offlineStorage = self](auto kind_, const std::string&& url_) -> std::string {
+        _mbglResourceTransform = std::make_unique<mbgl::Actor<mbgl::ResourceTransform>>(*mbgl::Scheduler::GetCurrent(), [offlineStorage = self](auto kind_, const std::string&& url_) -> std::string {
             NSURL* url =
             [NSURL URLWithString:[[NSString alloc] initWithBytes:url_.data()
                                                           length:url_.length()

--- a/platform/default/online_file_source.cpp
+++ b/platform/default/online_file_source.cpp
@@ -383,7 +383,7 @@ ActorRef<OnlineFileRequest> OnlineFileRequest::actor() {
     if (!mailbox) {
         // Lazy constructed because this can be costly and
         // the ResourceTransform is not used by many apps.
-        mailbox = std::make_shared<Mailbox>(*util::RunLoop::Get());
+        mailbox = std::make_shared<Mailbox>(*Scheduler::GetCurrent());
     }
 
     return ActorRef<OnlineFileRequest>(*this, mailbox);

--- a/platform/default/thread_local.cpp
+++ b/platform/default/thread_local.cpp
@@ -58,8 +58,8 @@ void ThreadLocal<T>::set(T* ptr) {
     }
 }
 
-template class ThreadLocal<RunLoop>;
 template class ThreadLocal<BackendScope>;
+template class ThreadLocal<Scheduler>;
 template class ThreadLocal<int>; // For unit tests
 
 } // namespace util

--- a/platform/qt/src/thread_local.cpp
+++ b/platform/qt/src/thread_local.cpp
@@ -1,6 +1,6 @@
 #include <mbgl/util/thread_local.hpp>
 
-#include <mbgl/util/run_loop.hpp>
+#include <mbgl/actor/scheduler.hpp>
 #include <mbgl/renderer/backend_scope.hpp>
 
 #include <array>
@@ -41,7 +41,7 @@ void ThreadLocal<T>::set(T* ptr) {
    impl->local.localData()[0] = ptr;
 }
 
-template class ThreadLocal<RunLoop>;
+template class ThreadLocal<Scheduler>;
 template class ThreadLocal<BackendScope>;
 template class ThreadLocal<int>; // For unit tests
 

--- a/src/mbgl/actor/scheduler.cpp
+++ b/src/mbgl/actor/scheduler.cpp
@@ -1,0 +1,19 @@
+#include <mbgl/actor/scheduler.hpp>
+#include <mbgl/util/thread_local.hpp>
+
+namespace mbgl {
+    
+static auto& current() {
+    static util::ThreadLocal<Scheduler> scheduler;
+    return scheduler;
+};
+
+void Scheduler::SetCurrent(Scheduler* scheduler) {
+    current().set(scheduler);
+}
+
+Scheduler* Scheduler::GetCurrent() {
+    return current().get();
+}
+
+} //namespace mbgl

--- a/src/mbgl/sprite/sprite_loader.cpp
+++ b/src/mbgl/sprite/sprite_loader.cpp
@@ -10,8 +10,8 @@
 #include <mbgl/storage/file_source.hpp>
 #include <mbgl/storage/resource.hpp>
 #include <mbgl/storage/response.hpp>
-#include <mbgl/util/run_loop.hpp>
 #include <mbgl/actor/actor.hpp>
+#include <mbgl/actor/scheduler.hpp>
 
 #include <cassert>
 
@@ -21,7 +21,7 @@ static SpriteLoaderObserver nullObserver;
 
 struct SpriteLoader::Loader {
     Loader(Scheduler& scheduler, SpriteLoader& imageManager)
-        : mailbox(std::make_shared<Mailbox>(*util::RunLoop::Get())),
+        : mailbox(std::make_shared<Mailbox>(*Scheduler::GetCurrent())),
           worker(scheduler, ActorRef<SpriteLoader>(imageManager, mailbox)) {
     }
 

--- a/src/mbgl/storage/file_source_request.cpp
+++ b/src/mbgl/storage/file_source_request.cpp
@@ -1,13 +1,13 @@
 #include <mbgl/storage/file_source_request.hpp>
 
 #include <mbgl/actor/mailbox.hpp>
-#include <mbgl/util/run_loop.hpp>
+#include <mbgl/actor/scheduler.hpp>
 
 namespace mbgl {
 
 FileSourceRequest::FileSourceRequest(FileSource::Callback&& callback)
     : responseCallback(callback)
-    , mailbox(std::make_shared<Mailbox>(*util::RunLoop::Get())) {
+    , mailbox(std::make_shared<Mailbox>(*Scheduler::GetCurrent())) {
 }
 
 FileSourceRequest::~FileSourceRequest() {

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -17,10 +17,10 @@
 #include <mbgl/geometry/feature_index.hpp>
 #include <mbgl/text/collision_tile.hpp>
 #include <mbgl/map/transform_state.hpp>
-#include <mbgl/util/run_loop.hpp>
 #include <mbgl/style/filter_evaluator.hpp>
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/logging.hpp>
+#include <mbgl/actor/scheduler.hpp>
 
 #include <iostream>
 
@@ -33,7 +33,7 @@ GeometryTile::GeometryTile(const OverscaledTileID& id_,
                            const TileParameters& parameters)
     : Tile(id_),
       sourceID(std::move(sourceID_)),
-      mailbox(std::make_shared<Mailbox>(*util::RunLoop::Get())),
+      mailbox(std::make_shared<Mailbox>(*Scheduler::GetCurrent())),
       worker(parameters.workerScheduler,
              ActorRef<GeometryTile>(*this, mailbox),
              id_,

--- a/src/mbgl/tile/raster_tile.cpp
+++ b/src/mbgl/tile/raster_tile.cpp
@@ -8,7 +8,7 @@
 #include <mbgl/storage/file_source.hpp>
 #include <mbgl/renderer/tile_parameters.hpp>
 #include <mbgl/renderer/buckets/raster_bucket.hpp>
-#include <mbgl/util/run_loop.hpp>
+#include <mbgl/actor/scheduler.hpp>
 
 namespace mbgl {
 
@@ -17,7 +17,7 @@ RasterTile::RasterTile(const OverscaledTileID& id_,
                        const Tileset& tileset)
     : Tile(id_),
       loader(*this, id_, parameters, tileset),
-      mailbox(std::make_shared<Mailbox>(*util::RunLoop::Get())),
+      mailbox(std::make_shared<Mailbox>(*Scheduler::GetCurrent())),
       worker(parameters.workerScheduler,
              ActorRef<RasterTile>(*this, mailbox)) {
 }


### PR DESCRIPTION
Extracted the current `Scheduler` part of #9611 as requested:

This PR adds an abstraction on top of the RunLoop so that we can Schedule work on arbitrary schedulers. This is important for asynchronous rendering where we are dealing with threads without a runloop that need to defer scheduling of additional work to another thread scheduler and/or use another form of scheduling than a RunLoop (see #9576).

In certain places we will still work with the `RunLoop` directly where it's needed (`OnlineFileSource`, `AsyncTask`)