### PR TITLE
Allow overriding abi from IDE

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -41,11 +41,14 @@ android {
     // to invoke the Java tests. When we explicitly specify an ABI of 'none', no native dependencies are
     // added. When another ABI is specified explicitly, we're just going to build that ABI. In all other
     // cases, all ABIs are built.
-    // When invoking from the command line, set `-Pmapbox.abis=...` to only build the desired architectures.
+    //
+    // When invoking from the command line or to override the device default, set `-Pmapbox.abis=...` to
+    // only build the desired architectures.
+    //
     // When building from Android Studio, gradle.properties sets `android.buildOnlyTargetAbi=true` so that
     // only the architecture for the device you're running on gets built.
     def abi = 'all'
-    if (!project.hasProperty('android.injected.invoked.from.ide')) {
+    if (!project.hasProperty('android.injected.invoked.from.ide') || project.hasProperty("mapbox.abis")) {
         // Errors when the user invokes Gradle from the command line and didn't set mapbox.abis
         abi = project.getProperty("mapbox.abis")
     }


### PR DESCRIPTION
This allows to build a different architecture then the default for a device, for example armeabi-v7a instead of arm64-v8a (which allows for better stack traces.

Set in compiler > command-line options: -Pmapbox.abis=...