### PR TITLE
Smallest LatLngBounds when visible region crosses dateline

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLngBounds.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLngBounds.java
@@ -222,6 +222,16 @@ public class LatLngBounds implements Parcelable {
   }
 
   /**
+   * Constructs a LatLngBounds from doubles representing a LatLng pair.
+   * <p>
+   * This method doesn't recalculate most east or most west boundaries.
+   * </p>
+   */
+  public static LatLngBounds from(double latNorth, double lonEast, double latSouth, double lonWest) {
+    return new LatLngBounds(latNorth, lonEast, latSouth, lonWest);
+  }
+
+  /**
    * Constructs a LatLngBounds from current bounds with an additional latitude-longitude pair.
    *
    * @param latLng the latitude lognitude pair to include in the bounds.

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Projection.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Projection.java
@@ -78,8 +78,6 @@ public class Projection {
    * @return The projection of the viewing frustum in its current state.
    */
   public VisibleRegion getVisibleRegion() {
-    LatLngBounds.Builder builder = new LatLngBounds.Builder();
-
     float left = 0;
     float right = nativeMapView.getWidth();
     float top = 0;
@@ -90,12 +88,13 @@ public class Projection {
     LatLng bottomRight = fromScreenLocation(new PointF(right, bottom));
     LatLng bottomLeft = fromScreenLocation(new PointF(left, bottom));
 
-    builder.include(topLeft)
-      .include(topRight)
-      .include(bottomRight)
-      .include(bottomLeft);
-
-    return new VisibleRegion(topLeft, topRight, bottomLeft, bottomRight, builder.build());
+    return new VisibleRegion(topLeft, topRight, bottomLeft, bottomRight,
+      LatLngBounds.from(
+        topRight.getLatitude(),
+        topRight.getLongitude(),
+        bottomLeft.getLatitude(),
+        bottomLeft.getLongitude())
+    );
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/SimpleMapActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/SimpleMapActivity.java
@@ -1,10 +1,17 @@
 package com.mapbox.mapboxsdk.testapp.activity.maplayout;
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 
+import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Projection;
 import com.mapbox.mapboxsdk.testapp.R;
+
+import timber.log.Timber;
 
 /**
  * Test activity showcasing a simple MapView without any MapboxMap interaction.
@@ -20,6 +27,19 @@ public class SimpleMapActivity extends AppCompatActivity {
 
     mapView = (MapView) findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+      public void onMapReady(MapboxMap mapboxMap) {
+        final Projection projection = mapboxMap.getProjection();
+
+        mapboxMap.setOnMapClickListener(new MapboxMap.OnMapClickListener() {
+          @Override
+          public void onMapClick(@NonNull LatLng point) {
+            Timber.e(projection.getVisibleRegion().toString());
+          }
+        });
+      }
+    });
   }
 
   @Override


### PR DESCRIPTION
closes #9687, this PR makes sure that the LatLngBounds returned by VisibleRegion complies to:

```
The smallest bounding box that includes the visible region defined in this class.
```

To make this possible I had to introduce `LatLngBounds.from`, this method was required to bypass bounds recalculation used in normal circumstances. This method also allows end developers to overwrite default LatLngBounds behaviour.

Adding this to the 5.1.3 milestone as implementation wasn't complying to the javadoc. 

cc @zugaldia 
