### PR TITLE
[core] Added Style::getDefaultCamera()

### DIFF
--- a/include/mbgl/style/style.hpp
+++ b/include/mbgl/style/style.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/style/transition_options.hpp>
+#include <mbgl/map/camera.hpp>
 #include <mbgl/util/geo.hpp>
 
 #include <string>
@@ -32,10 +33,7 @@ public:
 
     // Defaults
     std::string getName() const;
-    LatLng getDefaultLatLng() const;
-    double getDefaultZoom() const;
-    double getDefaultBearing() const;
-    double getDefaultPitch() const;
+    CameraOptions getDefaultCamera() const;
 
     // TransitionOptions
     TransitionOptions getTransitionOptions() const;

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2136,10 +2136,11 @@ public:
 
 - (void)resetPosition
 {
-    CGFloat pitch = _mbglMap->getStyle().getDefaultPitch();
-    CLLocationDirection heading = mbgl::util::wrap(_mbglMap->getStyle().getDefaultBearing(), 0., 360.);
-    CLLocationDistance distance = MGLAltitudeForZoomLevel(_mbglMap->getStyle().getDefaultZoom(), pitch, 0, self.frame.size);
-    self.camera = [MGLMapCamera cameraLookingAtCenterCoordinate:MGLLocationCoordinate2DFromLatLng(_mbglMap->getStyle().getDefaultLatLng())
+    auto camera = _mbglMap->getStyle().getDefaultCamera();
+    CGFloat pitch = *camera.pitch;
+    CLLocationDirection heading = mbgl::util::wrap(*camera.angle, 0., 360.);
+    CLLocationDistance distance = MGLAltitudeForZoomLevel(*camera.zoom, pitch, 0, self.frame.size);
+    self.camera = [MGLMapCamera cameraLookingAtCenterCoordinate:MGLLocationCoordinate2DFromLatLng(*camera.center)
                                                    fromDistance:distance
                                                           pitch:pitch
                                                         heading:heading];

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -727,11 +727,7 @@ void Map::Impl::onStyleLoading() {
 
 void Map::Impl::onStyleLoaded() {
     if (!cameraMutated) {
-        // Zoom first because it may constrain subsequent operations.
-        map.setZoom(style->getDefaultZoom());
-        map.setLatLng(style->getDefaultLatLng());
-        map.setBearing(style->getDefaultBearing());
-        map.setPitch(style->getDefaultPitch());
+        map.jumpTo(style->getDefaultCamera());
     }
 
     annotationManager.onStyleLoaded();

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -34,20 +34,8 @@ std::string Style::getName() const {
     return impl->getName();
 }
 
-LatLng Style::getDefaultLatLng() const {
-    return impl->getDefaultLatLng();
-}
-
-double Style::getDefaultZoom() const {
-    return impl->getDefaultZoom();
-}
-
-double Style::getDefaultBearing() const {
-    return impl->getDefaultBearing();
-}
-
-double Style::getDefaultPitch() const {
-    return impl->getDefaultPitch();
+CameraOptions Style::getDefaultCamera() const {
+    return impl->getDefaultCamera();
 }
 
 TransitionOptions Style::getTransitionOptions() const {

--- a/src/mbgl/style/style_impl.cpp
+++ b/src/mbgl/style/style_impl.cpp
@@ -107,10 +107,11 @@ void Style::Impl::parse(const std::string& json_) {
     }
 
     name = parser.name;
-    defaultLatLng = parser.latLng;
-    defaultZoom = parser.zoom;
-    defaultBearing = parser.bearing;
-    defaultPitch = parser.pitch;
+    defaultCamera.center = parser.latLng;
+    defaultCamera.zoom = parser.zoom;
+    defaultCamera.angle = parser.bearing;
+    defaultCamera.pitch = parser.pitch;
+
     setLight(std::make_unique<Light>(parser.light));
 
     spriteLoaded = false;
@@ -232,20 +233,8 @@ std::string Style::Impl::getName() const {
     return name;
 }
 
-LatLng Style::Impl::getDefaultLatLng() const {
-    return defaultLatLng;
-}
-
-double Style::Impl::getDefaultZoom() const {
-    return defaultZoom;
-}
-
-double Style::Impl::getDefaultBearing() const {
-    return defaultBearing;
-}
-
-double Style::Impl::getDefaultPitch() const {
-    return defaultPitch;
+CameraOptions Style::Impl::getDefaultCamera() const {
+    return defaultCamera;
 }
 
 std::vector<Source*> Style::Impl::getSources() {

--- a/src/mbgl/style/style_impl.hpp
+++ b/src/mbgl/style/style_impl.hpp
@@ -12,6 +12,8 @@
 #include <mbgl/style/layer.hpp>
 #include <mbgl/style/collection.hpp>
 
+#include <mbgl/map/camera.hpp>
+
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/optional.hpp>
 #include <mbgl/util/geo.hpp>
@@ -69,10 +71,7 @@ public:
     std::unique_ptr<Layer> removeLayer(const std::string& layerID);
 
     std::string getName() const;
-    LatLng getDefaultLatLng() const;
-    double getDefaultZoom() const;
-    double getDefaultBearing() const;
-    double getDefaultPitch() const;
+    CameraOptions getDefaultCamera() const;
 
     TransitionOptions getTransitionOptions() const;
     void setTransitionOptions(const TransitionOptions&);
@@ -117,10 +116,7 @@ private:
 
     // Defaults
     std::string name;
-    LatLng defaultLatLng;
-    double defaultZoom = 0;
-    double defaultBearing = 0;
-    double defaultPitch = 0;
+    CameraOptions defaultCamera;
 
     // SpriteLoaderObserver implementation.
     void onSpriteLoaded(std::vector<std::unique_ptr<Image>>&&) override;

--- a/test/fixtures/api/empty-zoomed.json
+++ b/test/fixtures/api/empty-zoomed.json
@@ -1,0 +1,6 @@
+{
+  "version": 8,
+  "zoom": 0.5,
+  "sources": {},
+  "layers": []
+}

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -160,6 +160,21 @@ TEST(Map, Offline) {
     NetworkStatus::Set(NetworkStatus::Status::Online);
 }
 
+TEST(Map, SetStyleDefaultCamera) {
+    MapTest<> test;
+    test.map.getStyle().loadJSON(util::read_file("test/fixtures/api/empty.json"));
+    EXPECT_DOUBLE_EQ(test.map.getZoom(), 0.0);
+    EXPECT_DOUBLE_EQ(test.map.getPitch(), 0.0);
+    EXPECT_DOUBLE_EQ(test.map.getBearing(), 0.0);
+    EXPECT_EQ(test.map.getLatLng(), LatLng {});
+
+    test.map.getStyle().loadJSON(util::read_file("test/fixtures/api/empty-zoomed.json"));
+    EXPECT_DOUBLE_EQ(test.map.getZoom(), 0.0);
+
+    test.map.jumpTo(test.map.getStyle().getDefaultCamera());
+    EXPECT_DOUBLE_EQ(test.map.getZoom(), 0.5);
+}
+
 TEST(Map, SetStyleInvalidJSON) {
     Log::setObserver(std::make_unique<FixtureLogObserver>());
 

--- a/test/style/style.test.cpp
+++ b/test/style/style.test.cpp
@@ -28,27 +28,27 @@ TEST(Style, Properties) {
 
     style.loadJSON(R"STYLE({"center": [10, 20]})STYLE");
     ASSERT_EQ("", style.getName());
-    ASSERT_EQ((LatLng{20, 10}), style.getDefaultLatLng());
+    ASSERT_EQ((LatLng{20, 10}), *style.getDefaultCamera().center);
 
     style.loadJSON(R"STYLE({"bearing": 24})STYLE");
     ASSERT_EQ("", style.getName());
-    ASSERT_EQ((LatLng{0, 0}), style.getDefaultLatLng());
-    ASSERT_EQ(24, style.getDefaultBearing());
+    ASSERT_EQ(LatLng {}, *style.getDefaultCamera().center);
+    ASSERT_EQ(24, *style.getDefaultCamera().angle);
 
     style.loadJSON(R"STYLE({"zoom": 13.3})STYLE");
     ASSERT_EQ("", style.getName());
-    ASSERT_EQ(13.3, style.getDefaultZoom());
+    ASSERT_EQ(13.3, *style.getDefaultCamera().zoom);
 
     style.loadJSON(R"STYLE({"pitch": 60})STYLE");
     ASSERT_EQ("", style.getName());
-    ASSERT_EQ(60, style.getDefaultPitch());
+    ASSERT_EQ(60, *style.getDefaultCamera().pitch);
 
     style.loadJSON(R"STYLE({"name": 23, "center": {}, "bearing": "north", "zoom": null, "pitch": "wide"})STYLE");
     ASSERT_EQ("", style.getName());
-    ASSERT_EQ((LatLng{0, 0}), style.getDefaultLatLng());
-    ASSERT_EQ(0, style.getDefaultBearing());
-    ASSERT_EQ(0, style.getDefaultZoom());
-    ASSERT_EQ(0, style.getDefaultPitch());
+    ASSERT_EQ(LatLng {}, *style.getDefaultCamera().center);
+    ASSERT_EQ(0, *style.getDefaultCamera().zoom);
+    ASSERT_EQ(0, *style.getDefaultCamera().angle);
+    ASSERT_EQ(0, *style.getDefaultCamera().pitch);
 }
 
 TEST(Style, DuplicateSource) {


### PR DESCRIPTION
Spin-off from https://github.com/mapbox/mapbox-gl-native/pull/9689. We were not resetting `cameraMutated` back to false, which was causing the consecutive loaded styles to not use their default camera (zoom, pitch, bearing, coordinates) values.