### PR TITLE
[ios, macos] Add shapes annotations select/deselect delegates.

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -197,6 +197,7 @@ public:
     std::vector<Feature> querySourceFeatures(const std::string& sourceID, const SourceQueryOptions& options = {});
 
     AnnotationIDs queryPointAnnotations(const ScreenBox&);
+    AnnotationIDs queryShapeAnnotations(const ScreenBox&, const RenderedQueryOptions& options = {});
 
     // Memory
     void setSourceTileCacheSize(size_t);
@@ -213,6 +214,7 @@ public:
 private:
     class Impl;
     const std::unique_ptr<Impl> impl;
+    AnnotationIDs queryAnnotations(const ScreenBox&,  const RenderedQueryOptions& options = {});
 };
 
 } // namespace mbgl

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Added support for iOS 11 location usage descriptions. ([#9869](https://github.com/mapbox/mapbox-gl-native/pull/9869))
 * Fixed an issue where `MGLUserLocation.location` did not follow its documented initialization behavior. This property will now properly return `nil` until the user’s location has been determined. ([#9639](https://github.com/mapbox/mapbox-gl-native/pull/9639))
 * `MGLMapView`’s `minimumZoomLevel` and `maximumZoomLevel` properties are now available in Interface Builder’s Attributes inspector. ([#9729](https://github.com/mapbox/mapbox-gl-native/pull/9729))
+* Added support for selection of shape and polyline annotations. ([#9755](https://github.com/mapbox/mapbox-gl-native/pull/9755))
 
 ## 3.6.2 - August 18, 2017
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -1809,4 +1809,14 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
     }
 }
 
+- (void)mapView:(MGLMapView *)mapView didSelectShapeAnnotation:(nonnull MGLShape *)shapeAnnotation
+{
+    NSLog(@"Did Select: %f, %f", shapeAnnotation.coordinate.latitude, shapeAnnotation.coordinate.longitude);
+}
+
+- (void)mapView:(MGLMapView *)mapView didDeselectShapeAnnotation:(nonnull MGLShape *)shapeAnnotation
+{
+    NSLog(@"Did deselect: %f, %f", shapeAnnotation.coordinate.latitude, shapeAnnotation.coordinate.longitude);
+}
+
 @end

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -152,6 +152,11 @@ typedef std::unordered_map<MGLAnnotationTag, MGLAnnotationContext> MGLAnnotation
 /// Mapping from an annotation object to an annotation tag.
 typedef std::map<id<MGLAnnotation>, MGLAnnotationTag> MGLAnnotationObjectTagMap;
 
+/// Mapping from a shape annotation object to shape layer id.
+typedef std::map<id<MGLAnnotation>, std::string> MGLShapeAnnotationObjectLayerIDMap;
+
+static NSString *const  MGLLayerIDShapeAnnotation = @"com.mapbox.annotations.shape.";
+
 mbgl::util::UnitBezier MGLUnitBezierForMediaTimingFunction(CAMediaTimingFunction *function)
 {
     if ( ! function)
@@ -285,9 +290,11 @@ public:
 
     MGLAnnotationTagContextMap _annotationContextsByAnnotationTag;
     MGLAnnotationObjectTagMap _annotationTagsByAnnotation;
-
+    MGLShapeAnnotationObjectLayerIDMap _shapeAnnotationLayerIDsByAnnotation;
+    
     /// Tag of the selected annotation. If the user location annotation is selected, this ivar is set to `MGLAnnotationTagNotFound`.
     MGLAnnotationTag _selectedAnnotationTag;
+    MGLShape *_selectedShapeAnnotation;
 
     BOOL _userLocationAnnotationIsSelected;
     /// Size of the rectangle formed by unioning the maximum slop area around every annotation image and annotation image view.
@@ -468,6 +475,7 @@ public:
     _annotationImagesByIdentifier = [NSMutableDictionary dictionary];
     _annotationContextsByAnnotationTag = {};
     _annotationTagsByAnnotation = {};
+    _shapeAnnotationLayerIDsByAnnotation = {};
     _annotationViewReuseQueueByIdentifier = [NSMutableDictionary dictionary];
     _selectedAnnotationTag = MGLAnnotationTagNotFound;
     _annotationsNearbyLastTap = {};
@@ -1483,12 +1491,20 @@ public:
     id<MGLAnnotation>annotation = [self annotationForGestureRecognizer:singleTap persistingResults:YES];
     if(annotation)
     {
+        [self deselectShapeAnnotation:_selectedShapeAnnotation];
         [self selectAnnotation:annotation animated:YES];
     }
     else
     {
         [self deselectAnnotation:self.selectedAnnotation animated:YES];
+        MGLShape *shapeAnnotation = [self shapeAnnotationForGestureRecognizer:singleTap];
+        if (shapeAnnotation) {
+            [self selectShapeAnnotation:shapeAnnotation];
+        } else {
+            [self deselectShapeAnnotation:_selectedShapeAnnotation];
+        }
     }
+    
 }
 
 /**
@@ -1861,8 +1877,12 @@ public:
         if(!self.selectedAnnotation)
         {
             id<MGLAnnotation>annotation = [self annotationForGestureRecognizer:(UITapGestureRecognizer*)gestureRecognizer persistingResults:NO];
-            if(!annotation) {
-                return NO;
+            if(!annotation && !_selectedShapeAnnotation) {
+                MGLShape *shapeAnnotation = [self shapeAnnotationForGestureRecognizer:(UITapGestureRecognizer*)gestureRecognizer];
+                if (!shapeAnnotation) {
+                    return NO;
+                }
+                
             }
         }
     }
@@ -3226,6 +3246,8 @@ public:
             context.annotation = annotation;
             _annotationContextsByAnnotationTag[annotationTag] = context;
             _annotationTagsByAnnotation[annotation] = annotationTag;
+            NSString *layerID = [NSString stringWithFormat:@"%@%u", MGLLayerIDShapeAnnotation, annotationTag];
+            _shapeAnnotationLayerIDsByAnnotation[annotation] = layerID.UTF8String;
 
             [(NSObject *)annotation addObserver:self forKeyPath:@"coordinates" options:0 context:(void *)(NSUInteger)annotationTag];
         }
@@ -3524,6 +3546,7 @@ public:
 
         _annotationContextsByAnnotationTag.erase(annotationTag);
         _annotationTagsByAnnotation.erase(annotation);
+        _shapeAnnotationLayerIDsByAnnotation.erase(annotation);
 
         if ([annotation isKindOfClass:[NSObject class]] && ![annotation isKindOfClass:[MGLMultiPoint class]])
         {
@@ -4148,6 +4171,99 @@ public:
             _mbglMap->updateAnnotation(pair.first, mbgl::SymbolAnnotation { point, iconIdentifier.UTF8String ?: "" });
         }
     }
+}
+
+#pragma mark - Shape Annotation
+
+- (void)selectShapeAnnotation:(MGLShape *)shapeAnnotation
+{
+    if (!shapeAnnotation) return;
+    
+    if (shapeAnnotation == _selectedShapeAnnotation) return;
+    
+    [self deselectShapeAnnotation:_selectedShapeAnnotation];
+    
+    _selectedShapeAnnotation = shapeAnnotation;
+    
+    if ([self.delegate respondsToSelector:@selector(mapView:didSelectShapeAnnotation:)])
+    {
+        [self.delegate mapView:self didSelectShapeAnnotation:shapeAnnotation];
+    }
+}
+
+- (void)deselectShapeAnnotation:(MGLShape *)shapeAnnotation
+{
+    if (!shapeAnnotation) return;
+    
+    if (_selectedShapeAnnotation == shapeAnnotation)
+    {
+        if ([self.delegate respondsToSelector:@selector(mapView:didDeselectShapeAnnotation:)])
+        {
+            [self.delegate mapView:self didDeselectShapeAnnotation:shapeAnnotation];
+        }
+        _selectedShapeAnnotation = nil;
+    }
+   
+}
+
+- (MGLShape*)shapeAnnotationForGestureRecognizer:(UITapGestureRecognizer*)singleTap
+{
+    CGPoint tapPoint = [singleTap locationInView:self];
+  
+    MGLAnnotationTag hitAnnotationTag = [self shapeAnnotationTagAtPoint:tapPoint];
+    
+    if (hitAnnotationTag != MGLAnnotationTagNotFound) {
+        id <MGLAnnotation> annotation = [self annotationWithTag:hitAnnotationTag];
+        NSAssert(annotation, @"Cannot select nonexistent annotation with tag %u", hitAnnotationTag);
+        if ([annotation isKindOfClass:[MGLShape class]]) {
+            return (MGLShape *)annotation;
+        }
+    }
+    
+    return nil;
+}
+
+- (MGLAnnotationTag)shapeAnnotationTagAtPoint:(CGPoint)point
+{
+    CGRect queryRect = CGRectInset({ point, CGSizeZero },
+                                   -_unionedAnnotationRepresentationSize.width,
+                                   -_unionedAnnotationRepresentationSize.height);
+    queryRect = CGRectInset(queryRect, -MGLAnnotationImagePaddingForHitTest,
+                            -MGLAnnotationImagePaddingForHitTest);
+    
+    std::vector<MGLAnnotationTag> nearbyAnnotations = [self shapeAnnotationTagsInRect:queryRect];
+    
+    MGLAnnotationTag hitAnnotationTag = MGLAnnotationTagNotFound;
+    
+    // Choose the first nearby annotation.
+    if (nearbyAnnotations.size())
+    {
+        hitAnnotationTag = nearbyAnnotations.front();
+    }
+    return hitAnnotationTag;
+}
+
+- (std::vector<MGLAnnotationTag>)shapeAnnotationTagsInRect:(CGRect)rect
+{
+    mbgl::ScreenBox screenBox = {
+        { CGRectGetMinX(rect), CGRectGetMinY(rect) },
+        { CGRectGetMaxX(rect), CGRectGetMaxY(rect) },
+    };
+    
+    std::vector<MGLAnnotationTag> nearbyAnnotations;
+    
+    mbgl::optional<std::vector<std::string>> optionalLayerIDs;
+    if (_shapeAnnotationLayerIDsByAnnotation.size()) {
+        __block std::vector<std::string> layerIDs;
+        layerIDs.reserve(_shapeAnnotationLayerIDsByAnnotation.size());
+        for (const auto &annotation : _shapeAnnotationLayerIDsByAnnotation) {
+            layerIDs.push_back(annotation.second);
+        }
+        optionalLayerIDs = layerIDs;
+        nearbyAnnotations = _mbglMap->queryShapeAnnotations(screenBox, { optionalLayerIDs });
+    }
+
+    return nearbyAnnotations;
 }
 
 #pragma mark - User Location -

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -382,6 +382,27 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)mapView:(MGLMapView *)mapView didDeselectAnnotation:(id <MGLAnnotation>)annotation;
 
 /**
+ Tells the delegate that one of its shape annotations was selected.
+ 
+ You can use this method to track changes in the selection state of annotations.
+ 
+ @param mapView The map view containing the annotation.
+ @param shapeAnnotation The shape annotation that was selected.
+ */
+- (void)mapView:(MGLMapView *)mapView didSelectShapeAnnotation:(MGLShape *)shapeAnnotation;
+
+/**
+ Tells the delegate that one of its shape annotations was deselected.
+ 
+ You can use this method to track changes in the selection state of annotations.
+ 
+ 
+ @param mapView The map view containing the annotation.
+ @param shapeAnnotation The shape annotation that was deselected.
+ */
+- (void)mapView:(MGLMapView *)mapView didDeselectShapeAnnotation:(MGLShape *)shapeAnnotation;
+
+/**
  Tells the delegate that one of its annotation views was selected.
 
  You can use this method to track changes in the selection state of annotation

--- a/platform/ios/test/MGLMapViewDelegateIntegrationTests.swift
+++ b/platform/ios/test/MGLMapViewDelegateIntegrationTests.swift
@@ -78,5 +78,9 @@ extension MGLMapViewDelegateIntegrationTests: MGLMapViewDelegate {
     func mapView(_ mapView: MGLMapView, annotation: MGLAnnotation, calloutAccessoryControlTapped control: UIControl) {}
 
     func mapView(_ mapView: MGLMapView, shouldChangeFrom oldCamera: MGLMapCamera, to newCamera: MGLMapCamera) -> Bool { return false }
+    
+    func mapView(_ mapView: MGLMapView, didSelectShapeAnnotation shapeAnnotation: MGLShape) {}
+    
+    func mapView(_ mapView: MGLMapView, didDeselectShapeAnnotation shapeAnnotation: MGLShape) {}
 
 }

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for Mapbox macOS SDK
 
+## 0.5.2
+
+This version of the Mapbox macOS SDK corresponds to version 3.6.3 of the Mapbox iOS SDK.
+
+* Added support for selection of shape and polyline annotations. ([#9755](https://github.com/mapbox/mapbox-gl-native/pull/9755))
+
 ## 0.5.1
 
 This version of the Mapbox macOS SDK corresponds to version 3.6.2 of the Mapbox iOS SDK.

--- a/platform/macos/src/MGLMapViewDelegate.h
+++ b/platform/macos/src/MGLMapViewDelegate.h
@@ -263,6 +263,27 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)mapView:(MGLMapView *)mapView didDeselectAnnotation:(id <MGLAnnotation>)annotation;
 
+/**
+ Tells the delegate that one of its shape annotations was selected.
+ 
+ You can use this method to track changes in the selection state of annotations.
+ 
+ @param mapView The map view containing the annotation.
+ @param shapeAnnotation The shape annotation that was selected.
+ */
+- (void)mapView:(MGLMapView *)mapView didSelectShapeAnnotation:(MGLShape *)shapeAnnotation;
+
+/**
+ Tells the delegate that one of its shape annotations was deselected.
+ 
+ You can use this method to track changes in the selection state of annotations.
+ 
+ 
+ @param mapView The map view containing the annotation.
+ @param shapeAnnotation The shape annotation that was deselected.
+ */
+- (void)mapView:(MGLMapView *)mapView didDeselectShapeAnnotation:(MGLShape *)shapeAnnotation;
+
 #pragma mark Managing Callout Popovers
 
 /**

--- a/platform/macos/test/MGLMapViewDelegateIntegrationTests.swift
+++ b/platform/macos/test/MGLMapViewDelegateIntegrationTests.swift
@@ -52,5 +52,9 @@ extension MGLMapViewDelegateIntegrationTests: MGLMapViewDelegate {
     func mapView(_ mapView: MGLMapView, fillColorForPolygonAnnotation annotation: MGLPolygon) -> NSColor { return .black }
 
     func mapView(_ mapView: MGLMapView, calloutViewControllerFor annotation: MGLAnnotation) -> NSViewController? { return nil }
+    
+    func mapView(_ mapView: MGLMapView, didSelectShapeAnnotation shapeAnnotation: MGLShape) {}
+    
+    func mapView(_ mapView: MGLMapView, didDeselectShapeAnnotation shapeAnnotation: MGLShape) {}
 
 }

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -854,6 +854,15 @@ std::vector<Feature> Map::querySourceFeatures(const std::string& sourceID, const
 AnnotationIDs Map::queryPointAnnotations(const ScreenBox& box) {
     RenderedQueryOptions options;
     options.layerIDs = {{ AnnotationManager::PointLayerID }};
+    return queryAnnotations(box, options);
+}
+    
+AnnotationIDs Map::queryShapeAnnotations(const ScreenBox& box, const RenderedQueryOptions& options) {
+
+    return queryAnnotations(box, options);
+}
+    
+AnnotationIDs Map::queryAnnotations(const ScreenBox& box,  const RenderedQueryOptions& options) {
     auto features = queryRenderedFeatures(box, options);
     std::set<AnnotationID> set;
     for (auto &feature : features) {


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/2082

The new delegates return a MGLShape annotation. The consideration is for polyllines you get the centroid (coordinate) for the whole line. The initial implementation I made returned a feature and the feature's centroid. I'm thinking add a delegate only for polylines. Thoughts?