### PR TITLE
Restore max zoom to 25.5

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
@@ -55,7 +55,7 @@ public class MapboxConstants {
   /**
    * The currently supported maximum zoom level.
    */
-  public static final float MAXIMUM_ZOOM = 20.0f;
+  public static final float MAXIMUM_ZOOM = 25.5f;
 
   /**
    * The currently supported maximum tilt value.


### PR DESCRIPTION
closes #7155, validated that linked issues in #7155 didn't show. 
@zugaldia do we want to include this in the next patch release?