### PR TITLE
Add style inspection to debug activity

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -305,14 +305,12 @@
         </activity>
         <activity
             android:name=".activity.maplayout.DebugModeActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize"
             android:description="@string/description_debug_mode"
             android:label="@string/activity_debug_mode">
             <meta-data
                 android:name="@string/category"
-                android:value="@string/category_maplayout"/>
-            <meta-data
-                android:name="android.support.PARENT_ACTIVITY"
-                android:value=".activity.FeatureOverviewActivity"/>
+                android:value="@string/category_basic"/>
         </activity>
         <activity
             android:name=".activity.offline.OfflineActivity"

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
@@ -1,10 +1,19 @@
 package com.mapbox.mapboxsdk.testapp.activity.maplayout;
 
+import android.content.Context;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
+import android.support.v4.widget.DrawerLayout;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.ActionBarDrawerToggle;
 import android.support.v7.app.AppCompatActivity;
+import android.view.LayoutInflater;
+import android.view.MenuItem;
 import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.BaseAdapter;
+import android.widget.ListView;
 import android.widget.TextView;
 
 import com.mapbox.mapboxsdk.camera.CameraPosition;
@@ -12,18 +21,24 @@ import com.mapbox.mapboxsdk.constants.Style;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.style.layers.Layer;
+import com.mapbox.mapboxsdk.style.layers.Property;
 import com.mapbox.mapboxsdk.testapp.R;
 
+import java.util.List;
+
 import timber.log.Timber;
+
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility;
 
 /**
  * Test Activity showcasing the different debug modes and allows to cycle between the default map styles.
  */
-public class DebugModeActivity extends AppCompatActivity {
+public class DebugModeActivity extends AppCompatActivity implements OnMapReadyCallback {
 
   private MapView mapView;
   private MapboxMap mapboxMap;
-
+  private ActionBarDrawerToggle actionBarDrawerToggle;
   private int currentStyleIndex = 0;
 
   private static final String[] STYLES = new String[] {
@@ -32,20 +47,46 @@ public class DebugModeActivity extends AppCompatActivity {
     Style.LIGHT,
     Style.DARK,
     Style.SATELLITE,
-    Style.SATELLITE_STREETS
+    Style.SATELLITE_STREETS,
+    Style.TRAFFIC_DAY,
+    Style.TRAFFIC_NIGHT
   };
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_debug_mode);
+    setupToolbar();
+    setupMapView(savedInstanceState);
+    setupDebugChangeView();
+    setupStyleChangeView();
+  }
 
+  private void setupToolbar() {
+    ActionBar actionBar = getSupportActionBar();
+    if (actionBar != null) {
+      getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+      getSupportActionBar().setHomeButtonEnabled(true);
+
+      DrawerLayout drawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
+      actionBarDrawerToggle = new ActionBarDrawerToggle(this,
+        drawerLayout,
+        R.string.navigation_drawer_open,
+        R.string.navigation_drawer_close
+      );
+      actionBarDrawerToggle.setDrawerIndicatorEnabled(true);
+      actionBarDrawerToggle.syncState();
+    }
+  }
+
+  private void setupMapView(Bundle savedInstanceState) {
     mapView = (MapView) findViewById(R.id.mapView);
     mapView.addOnMapChangedListener(new MapView.OnMapChangedListener() {
       @Override
       public void onMapChanged(int change) {
         if (change == MapView.DID_FINISH_LOADING_STYLE && mapboxMap != null) {
-          Timber.e("New loaded style = %s", mapboxMap.getStyleJson());
+          Timber.v("New style loaded with JSON: %s", mapboxMap.getStyleJson());
+          setupNavigationView(mapboxMap.getLayers());
         }
       }
     });
@@ -53,24 +94,57 @@ public class DebugModeActivity extends AppCompatActivity {
     mapView.setTag(true);
     mapView.setStyleUrl(STYLES[currentStyleIndex]);
     mapView.onCreate(savedInstanceState);
-    mapView.getMapAsync(new OnMapReadyCallback() {
+    mapView.getMapAsync(this);
+  }
+
+  @Override
+  public void onMapReady(MapboxMap map) {
+    mapboxMap = map;
+    mapboxMap.getUiSettings().setZoomControlsEnabled(true);
+
+    setupNavigationView(mapboxMap.getLayers());
+    setupZoomView();
+  }
+
+  private void setupNavigationView(List<Layer> layerList) {
+    final LayerListAdapter adapter = new LayerListAdapter(this, layerList);
+    ListView listView = (ListView) findViewById(R.id.listView);
+    listView.setAdapter(adapter);
+    listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
       @Override
-      public void onMapReady(@NonNull MapboxMap map) {
-        mapboxMap = map;
-
-        mapboxMap.getUiSettings().setZoomControlsEnabled(true);
-
-        // show current zoom level on screen
-        final TextView textView = (TextView) findViewById(R.id.textZoom);
-        mapboxMap.setOnCameraChangeListener(new MapboxMap.OnCameraChangeListener() {
-          @Override
-          public void onCameraChange(CameraPosition position) {
-            textView.setText(String.format(getString(R.string.debug_zoom), position.zoom));
-          }
-        });
+      public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+        Layer clickedLayer = adapter.getItem(position);
+        toggleLayerVisibility(clickedLayer);
+        closeNavigationView();
       }
     });
+  }
 
+  private void toggleLayerVisibility(Layer layer) {
+    boolean isVisible = layer.getVisibility().getValue().equals(Property.VISIBLE);
+    layer.setProperties(
+      visibility(
+        isVisible ? Property.NONE : Property.VISIBLE
+      )
+    );
+  }
+
+  private void closeNavigationView() {
+    DrawerLayout drawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
+    drawerLayout.closeDrawers();
+  }
+
+  private void setupZoomView() {
+    final TextView textView = (TextView) findViewById(R.id.textZoom);
+    mapboxMap.setOnCameraChangeListener(new MapboxMap.OnCameraChangeListener() {
+      @Override
+      public void onCameraChange(CameraPosition position) {
+        textView.setText(String.format(getString(R.string.debug_zoom), position.zoom));
+      }
+    });
+  }
+
+  private void setupDebugChangeView() {
     FloatingActionButton fabDebug = (FloatingActionButton) findViewById(R.id.fabDebug);
     fabDebug.setOnClickListener(new View.OnClickListener() {
       @Override
@@ -81,7 +155,9 @@ public class DebugModeActivity extends AppCompatActivity {
         }
       }
     });
+  }
 
+  private void setupStyleChangeView() {
     FloatingActionButton fabStyles = (FloatingActionButton) findViewById(R.id.fabStyles);
     fabStyles.setOnClickListener(new View.OnClickListener() {
       @Override
@@ -100,6 +176,11 @@ public class DebugModeActivity extends AppCompatActivity {
         }
       }
     });
+  }
+
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    return actionBarDrawerToggle.onOptionsItemSelected(item) || super.onOptionsItemSelected(item);
   }
 
   @Override
@@ -142,5 +223,59 @@ public class DebugModeActivity extends AppCompatActivity {
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
+  }
+
+  private static class LayerListAdapter extends BaseAdapter {
+
+    private LayoutInflater layoutInflater;
+    private List<Layer> layers;
+
+    LayerListAdapter(Context context, List<Layer> layers) {
+      this.layoutInflater = LayoutInflater.from(context);
+      this.layers = layers;
+    }
+
+    @Override
+    public int getCount() {
+      return layers.size();
+    }
+
+    @Override
+    public Layer getItem(int position) {
+      return layers.get(position);
+    }
+
+    @Override
+    public long getItemId(int position) {
+      return position;
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+      Layer layer = layers.get(position);
+      View view = convertView;
+      if (view == null) {
+        view = layoutInflater.inflate(android.R.layout.simple_list_item_2, parent, false);
+        ViewHolder holder = new ViewHolder(
+          (TextView) view.findViewById(android.R.id.text1),
+          (TextView) view.findViewById(android.R.id.text2)
+        );
+        view.setTag(holder);
+      }
+      ViewHolder holder = (ViewHolder) view.getTag();
+      holder.text.setText(layer.getClass().getSimpleName());
+      holder.subText.setText(layer.getId());
+      return view;
+    }
+
+    private static class ViewHolder {
+      final TextView text;
+      final TextView subText;
+
+      ViewHolder(TextView text, TextView subText) {
+        this.text = text;
+        this.subText = subText;
+      }
+    }
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_debug_mode.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_debug_mode.xml
@@ -1,48 +1,86 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<android.support.v4.widget.DrawerLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/coordinator_layout"
+    android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:clickable="true"
+    android:focusable="true"
+    android:focusableInTouchMode="true">
 
-    <com.mapbox.mapboxsdk.maps.MapView
-        android:id="@+id/mapView"
+    <android.support.design.widget.CoordinatorLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/coordinator_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:mapbox_uiAttribution="false"
-        app:mapbox_uiCompass="false"
-        app:mapbox_uiLogo="false"/>
+        android:orientation="vertical">
 
-    <TextView
-        android:id="@+id/textZoom"
+        <com.mapbox.mapboxsdk.maps.MapView
+            android:id="@+id/mapView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:mapbox_uiAttribution="false"
+            app:mapbox_uiCompass="false"
+            app:mapbox_uiLogo="false"/>
+
+        <TextView
+            android:id="@+id/textZoom"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|start"
+            android:layout_margin="8dp"
+            android:textIsSelectable="true"
+            android:textSize="14sp"
+            app:layout_anchor="@id/bottom_sheet"
+            app:layout_anchorGravity="bottom|start"/>
+
+        <android.support.v4.widget.NestedScrollView
+            android:id="@+id/bottom_sheet"
+            android:layout_width="match_parent"
+            android:layout_height="250dp"
+            android:background="@color/white"
+            android:visibility="invisible"
+            app:behavior_hideable="true"
+            app:layout_behavior="android.support.design.widget.BottomSheetBehavior"/>
+
+        <android.support.design.widget.FloatingActionButton
+            android:id="@+id/fabDebug"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="top|end"
+            android:layout_marginBottom="82dp"
+            android:layout_marginEnd="@dimen/fab_margin"
+            android:layout_marginRight="@dimen/fab_margin"
+            android:src="@drawable/ic_refresh"
+            app:backgroundTint="@color/accent"
+            app:layout_anchor="@+id/fabStyles"
+            app:layout_anchorGravity="top"/>
+
+        <android.support.design.widget.FloatingActionButton
+            android:id="@id/fabStyles"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end|bottom"
+            android:layout_margin="@dimen/fab_margin"
+            android:src="@drawable/ic_layers"
+            app:backgroundTint="@color/primary"
+            app:layout_anchor="@id/bottom_sheet"
+            app:layout_anchorGravity="bottom|end"/>
+
+    </android.support.design.widget.CoordinatorLayout>
+
+    <android.support.design.widget.NavigationView
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom|start"
-        android:layout_margin="8dp"
-        android:textIsSelectable="false"
-        android:textSize="14sp"/>
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        android:background="@android:color/white">
 
-    <android.support.design.widget.FloatingActionButton
-        android:id="@+id/fabDebug"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="end|bottom"
-        android:layout_marginBottom="82dp"
-        android:layout_marginEnd="@dimen/fab_margin"
-        android:layout_marginRight="@dimen/fab_margin"
-        android:src="@drawable/ic_refresh"
-        app:backgroundTint="@color/accent"
-        app:layout_anchorGravity="top"/>
+        <ListView
+            android:id="@+id/listView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
 
-    <android.support.design.widget.FloatingActionButton
-        android:id="@+id/fabStyles"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="end|bottom"
-        android:layout_margin="@dimen/fab_margin"
-        android:src="@drawable/ic_layers"
-        app:backgroundTint="@color/primary"/>
+    </android.support.design.widget.NavigationView>
 
-</android.support.design.widget.CoordinatorLayout>
+</android.support.v4.widget.DrawerLayout>


### PR DESCRIPTION
Inspired by the side view in the macOS test app, this PR adds showing a list of loaded layers to the debug activity. This allows to "debug" a style by toggling the visibility of them. 

![ezgif com-crop 1](https://user-images.githubusercontent.com/2151639/29310594-96ef3ff8-81ae-11e7-91ec-d776c85f5899.gif)
