### PR TITLE
Increase firebase timeout for CI testing

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -204,7 +204,7 @@ jobs:
             (gcloud firebase test android run --type instrumentation \
               --app platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/MapboxGLAndroidSDKTestApp-debug.apk \
               --test platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/MapboxGLAndroidSDKTestApp-debug-androidTest.apk \
-              --device-ids shamu --os-version-ids 22 --locales en --orientations portrait --timeout 15m \
+              --device-ids shamu --os-version-ids 22 --locales en --orientations portrait --timeout 20m \
               --test-targets "package com.mapbox.mapboxsdk.testapp.style" 2>&1 | tee firebase.log) || EXIT_CODE=$?
 
             FIREBASE_TEST_BUCKET=$(sed -n 's|^.*\[https://console.developers.google.com/storage/browser/\([^]]*\).*|gs://\1|p' firebase.log)


### PR DESCRIPTION
Been hitting firebase timeouts on an average of 1 out of 5 CI builds yesterday. I initially punted this on some infrastructure issue on Firebase but since I'm hitting this again today I'm increasing the timeout from 15 to 20 minutes (afaik we aren't the slowest build on this repo, this makes the increase is justifiable).  



