### PR TITLE
[core] Initialize Xcode project build settings

### DIFF
--- a/cmake/benchmark.cmake
+++ b/cmake/benchmark.cmake
@@ -27,6 +27,8 @@ mbgl_platform_benchmark()
 
 create_source_groups(mbgl-benchmark)
 
+initialize_xcode_cxx_build_settings(mbgl-benchmark)
+
 xcode_create_scheme(
     TARGET mbgl-benchmark
     OPTIONAL_ARGS

--- a/cmake/core.cmake
+++ b/cmake/core.cmake
@@ -34,3 +34,5 @@ mbgl_platform_core()
 create_source_groups(mbgl-core)
 
 xcode_create_scheme(TARGET mbgl-core)
+
+initialize_xcode_cxx_build_settings(mbgl-core)

--- a/cmake/glfw.cmake
+++ b/cmake/glfw.cmake
@@ -34,6 +34,8 @@ mbgl_platform_glfw()
 
 create_source_groups(mbgl-glfw)
 
+initialize_xcode_cxx_build_settings(mbgl-glfw)
+
 xcode_create_scheme(
     TARGET mbgl-glfw
     OPTIONAL_ARGS

--- a/cmake/mbgl.cmake
+++ b/cmake/mbgl.cmake
@@ -114,6 +114,32 @@ function(write_xcconfig_target_properties)
     )
 endfunction()
 
+# Set Xcode project build settings to be consistent with the CXX flags we're
+# using. (Otherwise, Xcode's defaults may override some of these.)
+macro(initialize_xcode_cxx_build_settings target)
+    # -Wall
+    set_xcode_property(${target} GCC_WARN_SIGN_COMPARE YES)
+    set_xcode_property(${target} GCC_WARN_UNINITIALIZED_AUTOS YES)
+    set_xcode_property(${target} GCC_WARN_UNKNOWN_PRAGMAS YES)
+    set_xcode_property(${target} GCC_WARN_UNUSED_FUNCTION YES)
+    set_xcode_property(${target} GCC_WARN_UNUSED_LABEL YES)
+    set_xcode_property(${target} GCC_WARN_UNUSED_PARAMETER YES)
+    set_xcode_property(${target} GCC_WARN_UNUSED_VARIABLE YES)
+
+    # -Wextra
+    set_xcode_property(${target} CLANG_WARN_EMPTY_BODY YES)
+    set_xcode_property(${target} GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS YES)
+
+    # -Wshadow
+    set_xcode_property(${target} GCC_WARN_SHADOW YES)
+
+    # -Wno-unknown-pragmas
+    set_xcode_property(${target} GCC_WARN_UNKNOWN_PRAGMAS YES)
+
+    # -Wnon-virtual-dtor
+    set_xcode_property(${target} GCC_WARN_NON_VIRTUAL_DESTRUCTOR YES)
+endmacro(initialize_xcode_cxx_build_settings)
+
 # CMake 3.1 does not have this yet.
 set(CMAKE_CXX14_STANDARD_COMPILE_OPTION "-std=c++14")
 set(CMAKE_CXX14_EXTENSION_COMPILE_OPTION "-std=gnu++14")

--- a/cmake/node.cmake
+++ b/cmake/node.cmake
@@ -54,6 +54,8 @@ mbgl_platform_node()
 
 create_source_groups(mbgl-node)
 
+initialize_xcode_cxx_build_settings(mbgl-node)
+
 xcode_create_scheme(
     TARGET mbgl-node
 )

--- a/cmake/render.cmake
+++ b/cmake/render.cmake
@@ -21,6 +21,8 @@ mbgl_platform_render()
 
 create_source_groups(mbgl-render)
 
+initialize_xcode_cxx_build_settings(mbgl-render)
+
 xcode_create_scheme(
     TARGET mbgl-render
     OPTIONAL_ARGS

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -41,6 +41,8 @@ mbgl_platform_test()
 
 create_source_groups(mbgl-test)
 
+initialize_xcode_cxx_build_settings(mbgl-test)
+
 xcode_create_scheme(
     TARGET mbgl-test
     OPTIONAL_ARGS


### PR DESCRIPTION
Some of Xcode's project defaults cause some of our CXX flags to be overridden (e.g. `-Wno-unused-variable`, which unsets `-Wunused-variable` that should be included in `-Wall`).  The result is that building locally, it's easy to miss errors that then cause CI failures.

This change initializes those Xcode settings to be consistent with the CXX flags we're using.