### PR TITLE
make android-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -610,6 +610,10 @@ run-android-ui-test-spoon: platform/android/configuration.gradle
 test-code-android:
 	node platform/android/scripts/generate-test-code.js
 
+# Runs checkstyle and lint on the Android code
+.PHONY: android-check
+android-check : android-checkstyle android-lint-sdk android-lint-test-app
+
 # Runs checkstyle on the Android code
 .PHONY: android-checkstyle
 android-checkstyle: platform/android/configuration.gradle


### PR DESCRIPTION
This PR introduces a new make target that wraps checkstyle and lint. This allows to execute one make target instead of 3 before pushing a PR to this repo. I verified that if one target fails, it stops execution of the other targets.

cc @ivovandongen 