### PR TITLE
[glfw] Getopt: Don't handle 0 value

### DIFF
--- a/platform/glfw/main.cpp
+++ b/platform/glfw/main.cpp
@@ -59,9 +59,6 @@ int main(int argc, char *argv[]) {
         if (opt == -1) break;
         switch (opt)
         {
-        case 0:
-            if (long_options[option_index].flag != nullptr)
-                break;
         case 'f':
             fullscreen = true;
             break;


### PR DESCRIPTION
Since we don't have any options with non-null flags we don't need to
handle the case where getopt_long returns 0.

The case that handled 0 was susceptible to switch fall-through and made
the code not compile with -Werror=implicit-fallthrough=.