### PR TITLE
[ios] Document annotations-as-features limitations w/feature querying

### DIFF
--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -991,16 +991,6 @@ MGL_EXPORT IB_DESIGNABLE
 @property (nonatomic, readonly, nullable) NS_ARRAY_OF(id <MGLAnnotation>) *annotations;
 
 /**
- The complete list of annotations associated with the receiver that are
- currently visible.
-
- The objects in this array must adopt the `MGLAnnotation` protocol. If no
- annotations are associated with the map view or if no annotations associated
- with the map view are currently visible, the value of this property is `nil`.
- */
-@property (nonatomic, readonly, nullable) NS_ARRAY_OF(id <MGLAnnotation>) *visibleAnnotations;
-
-/**
  Adds an annotation to the map view.
 
  @note `MGLMultiPolyline`, `MGLMultiPolygon`, `MGLShapeCollection`, and
@@ -1093,6 +1083,16 @@ MGL_EXPORT IB_DESIGNABLE
     such object exists in the reuse queue.
  */
 - (nullable __kindof MGLAnnotationView *)dequeueReusableAnnotationViewWithIdentifier:(NSString *)identifier;
+
+/**
+ The complete list of annotations associated with the receiver that are
+ currently visible.
+
+ The objects in this array must adopt the `MGLAnnotation` protocol. If no
+ annotations are associated with the map view or if no annotations associated
+ with the map view are currently visible, the value of this property is `nil`.
+ */
+@property (nonatomic, readonly, nullable) NS_ARRAY_OF(id <MGLAnnotation>) *visibleAnnotations;
 
 /**
  Returns the list of annotations associated with the receiver that intersect with
@@ -1253,6 +1253,11 @@ MGL_EXPORT IB_DESIGNABLE
  visibility, use the
  `-[MGLVectorSource featuresInSourceLayersWithIdentifiers:predicate:]` and
  `-[MGLShapeSource featuresMatchingPredicate:]` methods on the relevant sources.
+
+ The returned features may also include features corresponding to annotations.
+ These features are not object-equal to the `MGLAnnotation` objects that were
+ originally added to the map. To query the map for annotations, use
+ `visibleAnnotations` or `-[MGLMapView visibleAnnotationsInRect:]`.
 
  @note Layer identifiers are not guaranteed to exist across styles or different
     versions of the same style. Applications that use this API must first set


### PR DESCRIPTION
Addresses this @1ec5 comment from https://github.com/mapbox/mapbox-gl-native/pull/9540#pullrequestreview-50879870:

> We should definitely warn in the feature querying documentation that those methods may return annotations as features – the other way around – but those annotations-as-features aren’t object-equal to the ones that were added to the map. So we should recommend against using feature querying to get annotations.

Also reorders `visibleAnnotations` to be immediately above `visibleAnnotationsInRect:`.