### PR TITLE
Make geometry conversion optional for QueryRenderedFeatures

### DIFF
--- a/include/mbgl/renderer/query.hpp
+++ b/include/mbgl/renderer/query.hpp
@@ -14,14 +14,18 @@ namespace mbgl {
 class RenderedQueryOptions {
 public:
     RenderedQueryOptions(optional<std::vector<std::string>> layerIDs_ = {},
-                         optional<style::Filter> filter_ = {})
+                         optional<style::Filter> filter_ = {},
+                         optional<bool> geometryConversion_ = true)
         : layerIDs(std::move(layerIDs_)),
-          filter(std::move(filter_)) {}
+          filter(std::move(filter_)),
+          geometryConversion(geometryConversion_) {}
 
     /** layerIDs to include in the query */
     optional<std::vector<std::string>> layerIDs;
 
     optional<style::Filter> filter;
+
+    optional<bool> geometryConversion;
 };
 
 /**

--- a/include/mbgl/renderer/query.hpp
+++ b/include/mbgl/renderer/query.hpp
@@ -18,7 +18,7 @@ public:
                          optional<bool> geometryConversion_ = true)
         : layerIDs(std::move(layerIDs_)),
           filter(std::move(filter_)),
-          geometryConversion(geometryConversion_) {}
+          geometryConversion(std::move(geometryConversion_)) {}
 
     /** layerIDs to include in the query */
     optional<std::vector<std::string>> layerIDs;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1936,9 +1936,22 @@ public final class MapboxMap {
    * @return the list of feature
    */
   @NonNull
+  public List<Feature> queryRenderedFeatures(@NonNull PointF coordinates, boolean withGeometry, @Nullable String...
+    layerIds) {
+    return nativeMapView.queryRenderedFeatures(coordinates, layerIds, null, withGeometry);
+  }
+
+  /**
+   * Queries the map for rendered features
+   *
+   * @param coordinates the point to query
+   * @param layerIds    optionally - only query these layers
+   * @return the list of feature
+   */
+  @NonNull
   public List<Feature> queryRenderedFeatures(@NonNull PointF coordinates, @Nullable String...
     layerIds) {
-    return nativeMapView.queryRenderedFeatures(coordinates, layerIds, null);
+    return nativeMapView.queryRenderedFeatures(coordinates, layerIds, null, true);
   }
 
   /**
@@ -1953,7 +1966,7 @@ public final class MapboxMap {
   public List<Feature> queryRenderedFeatures(@NonNull PointF coordinates,
                                              @Nullable Filter.Statement filter,
                                              @Nullable String... layerIds) {
-    return nativeMapView.queryRenderedFeatures(coordinates, layerIds, filter);
+    return nativeMapView.queryRenderedFeatures(coordinates, layerIds, filter, true);
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -820,12 +820,13 @@ final class NativeMapView {
   @NonNull
   public List<Feature> queryRenderedFeatures(@NonNull PointF coordinates,
                                              @Nullable String[] layerIds,
-                                             @Nullable Filter.Statement filter) {
+                                             @Nullable Filter.Statement filter,
+                                             boolean withGeometry) {
     if (isDestroyedOn("queryRenderedFeatures")) {
       return new ArrayList<>();
     }
     Feature[] features = nativeQueryRenderedFeaturesForPoint(coordinates.x / pixelRatio,
-      coordinates.y / pixelRatio, layerIds, filter != null ? filter.toArray() : null);
+      coordinates.y / pixelRatio, layerIds, filter != null ? filter.toArray() : null, withGeometry);
     return features != null ? Arrays.asList(features) : new ArrayList<Feature>();
   }
 
@@ -1095,7 +1096,8 @@ final class NativeMapView {
 
   private native Feature[] nativeQueryRenderedFeaturesForPoint(float x, float y,
                                                                String[] layerIds,
-                                                               Object[] filter);
+                                                               Object[] filter,
+                                                               boolean withGeometry);
 
   private native Feature[] nativeQueryRenderedFeaturesForBox(float left, float top,
                                                              float right, float bottom,

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/feature/QueryRenderedFeaturesExecutionTimeTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/feature/QueryRenderedFeaturesExecutionTimeTest.java
@@ -1,0 +1,44 @@
+package com.mapbox.mapboxsdk.testapp.feature;
+
+import android.graphics.PointF;
+import android.support.test.espresso.UiController;
+
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.testapp.action.MapboxMapAction;
+import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
+import com.mapbox.mapboxsdk.testapp.activity.style.CircleLayerActivity;
+
+import org.junit.Test;
+
+import timber.log.Timber;
+
+public class QueryRenderedFeaturesExecutionTimeTest extends BaseActivityTest {
+
+  @Override
+  protected Class getActivityClass() {
+    return CircleLayerActivity.class;
+  }
+
+  @Test
+  public void testQueryRenderedFeaturesExecutionTime() {
+    validateTestSetup();
+    MapboxMapAction.invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
+      @Override
+      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
+        PointF point = new PointF(519.4336f, 1086.6211f);
+
+        long startTime = System.currentTimeMillis();
+        mapboxMap.queryRenderedFeatures(point, true);
+        long stopTime = System.currentTimeMillis();
+        long elapsedTime = stopTime - startTime;
+        Timber.e("Execution time with testQueryRenderedFeaturesExecutionTime: %s", elapsedTime);
+
+        startTime = System.currentTimeMillis();
+        mapboxMap.queryRenderedFeatures(point, false);
+        stopTime = System.currentTimeMillis();
+        elapsedTime = stopTime - startTime;
+        Timber.e("Execution time with testQueryRenderedFeaturesWithoutGeometryExecutionTime: %s", elapsedTime);
+      }
+    });
+  }
+}

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -771,7 +771,8 @@ jni::Array<jlong> NativeMapView::queryPointAnnotations(JNIEnv& env, jni::Object<
 
 jni::Array<jni::Object<geojson::Feature>> NativeMapView::queryRenderedFeaturesForPoint(JNIEnv& env, jni::jfloat x, jni::jfloat y,
                                                                               jni::Array<jni::String> layerIds,
-                                                                              jni::Array<jni::Object<>> jfilter) {
+                                                                              jni::Array<jni::Object<>> jfilter,
+                                                                              jni::jboolean jwithGeometry) {
     using namespace mbgl::android::conversion;
     using namespace mbgl::android::geojson;
 
@@ -781,9 +782,11 @@ jni::Array<jni::Object<geojson::Feature>> NativeMapView::queryRenderedFeaturesFo
     }
     mapbox::geometry::point<double> point = {x, y};
 
+    bool withGeometry = jwithGeometry;
+
     return *convert<jni::Array<jni::Object<Feature>>, std::vector<mbgl::Feature>>(
             env,
-            rendererFrontend->queryRenderedFeatures(point, { layers, toFilter(env, jfilter) }));
+            rendererFrontend->queryRenderedFeatures(point, { layers, toFilter(env, jfilter), withGeometry}));
 }
 
 jni::Array<jni::Object<geojson::Feature>> NativeMapView::queryRenderedFeaturesForBox(JNIEnv& env, jni::jfloat left, jni::jfloat top,

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -216,7 +216,8 @@ public:
 
     jni::Array<jni::Object<geojson::Feature>> queryRenderedFeaturesForPoint(JNIEnv&, jni::jfloat, jni::jfloat,
                                                                    jni::Array<jni::String>,
-                                                                   jni::Array<jni::Object<>> jfilter);
+                                                                   jni::Array<jni::Object<>> jfilter,
+                                                                   jni::jboolean jwithGeometry);
 
     jni::Array<jni::Object<geojson::Feature>> queryRenderedFeaturesForBox(JNIEnv&, jni::jfloat, jni::jfloat, jni::jfloat,
                                                                  jni::jfloat, jni::Array<jni::String>,

--- a/src/mbgl/geometry/feature_index.cpp
+++ b/src/mbgl/geometry/feature_index.cpp
@@ -131,7 +131,11 @@ void FeatureIndex::addFeature(
             continue;
         }
 
-        result[layerID].push_back(convertFeature(*geometryTileFeature, tileID));
+        if (!options.geometryConversion || options.geometryConversion.value()){
+            result[layerID].push_back(convertFeature(*geometryTileFeature, tileID));
+        } else {
+            result[layerID].push_back(convertFeatureProperties(*geometryTileFeature));
+        }
     }
 }
 

--- a/src/mbgl/geometry/feature_index.cpp
+++ b/src/mbgl/geometry/feature_index.cpp
@@ -131,11 +131,8 @@ void FeatureIndex::addFeature(
             continue;
         }
 
-        if (!options.geometryConversion || options.geometryConversion.value()){
-            result[layerID].push_back(convertFeature(*geometryTileFeature, tileID));
-        } else {
-            result[layerID].push_back(convertFeatureProperties(*geometryTileFeature));
-        }
+        bool isConvertGeometry = options.geometryConversion.value_or(true);
+        result[layerID].push_back(convertFeature(*geometryTileFeature, tileID, isConvertGeometry));
     }
 }
 

--- a/src/mbgl/tile/geometry_tile_data.cpp
+++ b/src/mbgl/tile/geometry_tile_data.cpp
@@ -180,4 +180,11 @@ Feature convertFeature(const GeometryTileFeature& geometryTileFeature, const Can
     return feature;
 }
 
+Feature convertFeatureProperties(const GeometryTileFeature& geometryTileFeature) {
+    Feature feature { Point<double>() };
+    feature.properties = geometryTileFeature.getProperties();
+    feature.id = geometryTileFeature.getID();
+    return feature;
+}
+
 } // namespace mbgl

--- a/src/mbgl/tile/geometry_tile_data.cpp
+++ b/src/mbgl/tile/geometry_tile_data.cpp
@@ -173,15 +173,47 @@ static Feature::geometry_type convertGeometry(const GeometryTileFeature& geometr
     return Point<double>();
 }
 
-Feature convertFeature(const GeometryTileFeature& geometryTileFeature, const CanonicalTileID& tileID) {
-    Feature feature { convertGeometry(geometryTileFeature, tileID) };
-    feature.properties = geometryTileFeature.getProperties();
-    feature.id = geometryTileFeature.getID();
-    return feature;
+static Feature::geometry_type convertGeometryType(const GeometryTileFeature& geometryTileFeature) {
+    GeometryCollection geometries = geometryTileFeature.getGeometries();
+
+    switch (geometryTileFeature.getType()) {
+        case FeatureType::Unknown: {
+            assert(false);
+            return Point<double>(NAN, NAN);
+        }
+
+        case FeatureType::Point: {
+            if(geometries.at(0).size() == 1){
+                return Point<double>();
+            } else {
+                return MultiPoint<double>();
+            }
+        }
+
+        case FeatureType::LineString: {
+            if(geometries.size() == 1){
+                return LineString<double>();
+            } else {
+                return MultiLineString<double>();
+            }
+        }
+
+        case FeatureType::Polygon: {
+            if (geometries.size() == 1) {
+                return Polygon<double>();
+            } else {
+                return MultiPolygon<double>();
+            }
+        }
+    }
+
+    // Unreachable, but placate GCC.
+    return Point<double>();
 }
 
-Feature convertFeatureProperties(const GeometryTileFeature& geometryTileFeature) {
-    Feature feature { Point<double>() };
+
+Feature convertFeature(const GeometryTileFeature& geometryTileFeature, const CanonicalTileID& tileID, bool isConvertGeometry) {
+    Feature feature { isConvertGeometry ? convertGeometry(geometryTileFeature, tileID) : convertGeometryType(geometryTileFeature)};
     feature.properties = geometryTileFeature.getProperties();
     feature.id = geometryTileFeature.getID();
     return feature;

--- a/src/mbgl/tile/geometry_tile_data.hpp
+++ b/src/mbgl/tile/geometry_tile_data.hpp
@@ -78,6 +78,9 @@ void limitHoles(GeometryCollection&, uint32_t maxHoles);
 // convert from GeometryTileFeature to Feature (eventually we should eliminate GeometryTileFeature)
 Feature convertFeature(const GeometryTileFeature&, const CanonicalTileID&);
 
+// convert from GeometryTileFeature to Feature without geometry (eventually we should eliminate GeometryTileFeature)
+Feature convertFeatureProperties(const GeometryTileFeature&);
+
 // Fix up possibly-non-V2-compliant polygon geometry using angus clipper.
 // The result is guaranteed to have correctly wound, strictly simple rings.
 GeometryCollection fixupPolygons(const GeometryCollection&);

--- a/src/mbgl/tile/geometry_tile_data.hpp
+++ b/src/mbgl/tile/geometry_tile_data.hpp
@@ -75,11 +75,9 @@ std::vector<GeometryCollection> classifyRings(const GeometryCollection&);
 // Truncate polygon to the largest `maxHoles` inner rings by area.
 void limitHoles(GeometryCollection&, uint32_t maxHoles);
 
-// convert from GeometryTileFeature to Feature (eventually we should eliminate GeometryTileFeature)
-Feature convertFeature(const GeometryTileFeature&, const CanonicalTileID&);
-
-// convert from GeometryTileFeature to Feature without geometry (eventually we should eliminate GeometryTileFeature)
-Feature convertFeatureProperties(const GeometryTileFeature&);
+// convert from GeometryTileFeature to Feature with optional geometry conversion
+// (eventually we should eliminate GeometryTileFeature)
+Feature convertFeature(const GeometryTileFeature&, const CanonicalTileID&, const bool = true);
 
 // Fix up possibly-non-V2-compliant polygon geometry using angus clipper.
 // The result is guaranteed to have correctly wound, strictly simple rings.


### PR DESCRIPTION
WIP, Closes #9605, 

This PR adds the option to not convert geometry when querying for rendered features. There are use-cases where you are only interested in feature properties and not the geometry. 

Some temp results in ms querying for 18 features using the android binding:
```
Execution time with testQueryRenderedFeaturesExecutionTime: 126
Execution time with testQueryRenderedFeaturesWithoutGeometryExecutionTime: 56

Execution time with testQueryRenderedFeaturesExecutionTime: 136
Execution time with testQueryRenderedFeaturesWithoutGeometryExecutionTime: 49

Execution time with testQueryRenderedFeaturesExecutionTime: 118
Execution time with testQueryRenderedFeaturesWithoutGeometryExecutionTime: 50
```

Todo:
 - [ ] implement for ScreenBox query
 - [ ] optimize android occurrences of QueryRenderedFeatures