### PR TITLE
[core] Attempt placement if at least one image is ready

### DIFF
--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -48,7 +48,6 @@
   "render-tests/regressions/mapbox-gl-js#4551": "skip - https://github.com/mapbox/mapbox-gl-native/issues/1350",
   "render-tests/regressions/mapbox-gl-js#4573": "skip - https://github.com/mapbox/mapbox-gl-native/issues/1350",
   "render-tests/regressions/mapbox-gl-native#7357": "https://github.com/mapbox/mapbox-gl-native/issues/7357",
-  "render-tests/regressions/mapbox-gl-native#9792": "skip - https://github.com/mapbox/mapbox-gl-native/issues/9792",
   "render-tests/runtime-styling/paint-property-fill-flat-to-extrude": "skip - https://github.com/mapbox/mapbox-gl-native/issues/6745",
   "render-tests/runtime-styling/set-style-paint-property-fill-flat-to-extrude": "skip - needs issue",
   "render-tests/runtime-styling/source-add-geojson-inline": "skip - needs issue",

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -371,7 +371,9 @@ bool GeometryTileWorker::hasPendingSymbolDependencies() const {
             return true;
         }
     }
-    return !pendingImageDependencies.empty();
+
+    // Attempt placement if at least one image is ready.
+    return imageMap.empty() && !pendingImageDependencies.empty();
 }
 
 void GeometryTileWorker::attemptPlacement() {
@@ -398,6 +400,7 @@ void GeometryTileWorker::attemptPlacement() {
                                   imageMap, imageAtlas.positions);
         }
 
+        imageMap.clear();
         symbolLayoutsNeedPreparation = false;
     }
 

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -224,6 +224,7 @@ void GeometryTileWorker::onImagesAvailable(ImageMap newImageMap) {
             pendingImageDependencies.erase(it);
         }
     }
+    symbolLayoutsNeedPreparation = true;
     symbolDependenciesChanged();
 }
 


### PR DESCRIPTION
This patch fixes an edge case when two or more images are referred on a style, but only one of them gets actually fetched.

There are times (like in the test case from #9792) where two or more images are needed, but only one (or more up to _n - 1_) gets successfully fetched. In those cases, we still want to attempt placement, so `hasPendingSymbolDependencies` should return false. We force this behavior by checking whether `imageMap` is empty before actually checking for any pending image dependencies.

This works as long as `imageMap` state is always up-to-date. This isn't true in cases e.g. when we had at least one placement attempt already. To fix that, we clear up `imageMap` after using it, as it gets updated in `GeometryTileWorker::onImagesAvailable` anyway.

Fixes #9792.