### PR TITLE
Set Default MaxZoom to 22

### DIFF
--- a/include/mbgl/util/constants.hpp
+++ b/include/mbgl/util/constants.hpp
@@ -38,6 +38,7 @@ constexpr double MIN_ZOOM = 0.0;
 constexpr double MAX_ZOOM = 25.5;
 constexpr float  MIN_ZOOM_F = MIN_ZOOM;
 constexpr float  MAX_ZOOM_F = MAX_ZOOM;
+constexpr uint8_t DEFAULT_MAX_ZOOM = 22;
 
 constexpr uint8_t DEFAULT_PREFETCH_ZOOM_DELTA = 4;
 

--- a/include/mbgl/util/tileset.hpp
+++ b/include/mbgl/util/tileset.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/util/range.hpp>
+#include <mbgl/util/constants.hpp>
 
 #include <vector>
 #include <string>
@@ -18,7 +19,7 @@ public:
     Scheme scheme;
 
     Tileset(std::vector<std::string> tiles_ = std::vector<std::string>(),
-            Range<uint8_t> zoomRange_ = { 0, 22 },
+            Range<uint8_t> zoomRange_ = { 0, util::DEFAULT_MAX_ZOOM },
             std::string attribution_ = {},
             Scheme scheme_ = Scheme::XYZ)
         : tiles(std::move(tiles_)),

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -491,7 +491,7 @@ public final class MapboxMap {
 
   /**
    * <p>
-   * Gets the maximum zoom level the map can be displayed at.
+   * Gets the minimum zoom level the map can be displayed at.
    * </p>
    *
    * @return The minimum zoom level.
@@ -508,7 +508,9 @@ public final class MapboxMap {
    * <p>
    * Sets the maximum zoom level the map can be displayed at.
    * </p>
-   *
+   * <p>
+   *   The default maximum zoomn level is 22. The upper bound for this value is 25.5.
+   * </p>
    * @param maxZoom The new maximum zoom level.
    */
   public void setMaxZoomPreference(@FloatRange(from = MapboxConstants.MINIMUM_ZOOM,

--- a/platform/macos/src/MGLMapView.h
+++ b/platform/macos/src/MGLMapView.h
@@ -247,7 +247,8 @@ MGL_EXPORT IB_DESIGNABLE
  If the value of this property is smaller than that of the `minimumZoomLevel`
  property, the behavior is undefined.
 
- The default value of this property is 20.
+ The default value of this property is 22. The upper bound for this property
+ is 25.5.
  */
 @property (nonatomic) double maximumZoomLevel;
 

--- a/src/mbgl/annotation/render_annotation_source.cpp
+++ b/src/mbgl/annotation/render_annotation_source.cpp
@@ -38,7 +38,7 @@ void RenderAnnotationSource::update(Immutable<style::Source::Impl> baseImpl_,
                        parameters,
                        SourceType::Annotations,
                        util::tileSize,
-                       { 0, 22 },
+                       { 0, util::DEFAULT_MAX_ZOOM },
                        [&] (const OverscaledTileID& tileID) {
                            return std::make_unique<AnnotationTile>(tileID, parameters);
                        });

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -96,7 +96,7 @@ private:
 
     // Limit the amount of zooming possible on the map.
     double min_scale = std::pow(2, 0);
-    double max_scale = std::pow(2, 20);
+    double max_scale = std::pow(2, util::DEFAULT_MAX_ZOOM);
     double min_pitch = 0.0;
     double max_pitch = util::PITCH_MAX;
 


### PR DESCRIPTION
Closes #8318.

Now that #7155 has been addressed, this change can go in with the caveat that we still have a related open issue: #9820
