### PR TITLE
Remove transition option tests

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/BackgroundLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/BackgroundLayerTest.java
@@ -33,7 +33,6 @@ import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
-import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
 
 /**
@@ -75,24 +74,6 @@ public class BackgroundLayerTest extends BaseActivityTest {
         // Set
         layer.setProperties(visibility(NONE));
         assertEquals(layer.getVisibility().getValue(), NONE);
-      }
-    });
-  }
-
-  @Test
-  public void testBackgroundColorTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("background-colorTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setBackgroundColorTransition(options);
-        assertEquals(layer.getBackgroundColorTransition(), options);
       }
     });
   }
@@ -164,24 +145,6 @@ public class BackgroundLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testBackgroundPatternTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("background-patternTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setBackgroundPatternTransition(options);
-        assertEquals(layer.getBackgroundPatternTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testBackgroundPatternAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -225,24 +188,6 @@ public class BackgroundLayerTest extends BaseActivityTest {
         assertEquals(CameraFunction.class, layer.getBackgroundPattern().getFunction().getClass());
         assertEquals(IntervalStops.class, layer.getBackgroundPattern().getFunction().getStops().getClass());
         assertEquals(1, ((IntervalStops) layer.getBackgroundPattern().getFunction().getStops()).size());
-      }
-    });
-  }
-
-  @Test
-  public void testBackgroundOpacityTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("background-opacityTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setBackgroundOpacityTransition(options);
-        assertEquals(layer.getBackgroundOpacityTransition(), options);
       }
     });
   }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CircleLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CircleLayerTest.java
@@ -33,7 +33,6 @@ import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
-import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
 
 /**
@@ -103,24 +102,6 @@ public class CircleLayerTest extends BaseActivityTest {
         final String sourceLayer = "test";
         layer.setSourceLayer(sourceLayer);
         assertEquals(layer.getSourceLayer(), sourceLayer);
-      }
-    });
-  }
-
-  @Test
-  public void testCircleRadiusTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("circle-radiusTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setCircleRadiusTransition(options);
-        assertEquals(layer.getCircleRadiusTransition(), options);
       }
     });
   }
@@ -308,24 +289,6 @@ public class CircleLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testCircleColorTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("circle-colorTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setCircleColorTransition(options);
-        assertEquals(layer.getCircleColorTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testCircleColorAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -480,24 +443,6 @@ public class CircleLayerTest extends BaseActivityTest {
         // Set and Get
         layer.setProperties(circleColor(Color.RED));
         assertEquals(layer.getCircleColorAsInt(), Color.RED);
-      }
-    });
-  }
-
-  @Test
-  public void testCircleBlurTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("circle-blurTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setCircleBlurTransition(options);
-        assertEquals(layer.getCircleBlurTransition(), options);
       }
     });
   }
@@ -685,24 +630,6 @@ public class CircleLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testCircleOpacityTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("circle-opacityTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setCircleOpacityTransition(options);
-        assertEquals(layer.getCircleOpacityTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testCircleOpacityAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -880,24 +807,6 @@ public class CircleLayerTest extends BaseActivityTest {
         assertEquals(0f, stop.in.zoom, 0.001);
         assertEquals(0.3f, stop.in.value, 0.001f);
         assertEquals(0.9f, stop.out, 0.001f);
-      }
-    });
-  }
-
-  @Test
-  public void testCircleTranslateTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("circle-translateTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setCircleTranslateTransition(options);
-        assertEquals(layer.getCircleTranslateTransition(), options);
       }
     });
   }
@@ -1096,24 +1005,6 @@ public class CircleLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testCircleStrokeWidthTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("circle-stroke-widthTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setCircleStrokeWidthTransition(options);
-        assertEquals(layer.getCircleStrokeWidthTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testCircleStrokeWidthAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -1296,24 +1187,6 @@ public class CircleLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testCircleStrokeColorTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("circle-stroke-colorTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setCircleStrokeColorTransition(options);
-        assertEquals(layer.getCircleStrokeColorTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testCircleStrokeColorAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -1468,24 +1341,6 @@ public class CircleLayerTest extends BaseActivityTest {
         // Set and Get
         layer.setProperties(circleStrokeColor(Color.RED));
         assertEquals(layer.getCircleStrokeColorAsInt(), Color.RED);
-      }
-    });
-  }
-
-  @Test
-  public void testCircleStrokeOpacityTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("circle-stroke-opacityTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setCircleStrokeOpacityTransition(options);
-        assertEquals(layer.getCircleStrokeOpacityTransition(), options);
       }
     });
   }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillExtrusionLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillExtrusionLayerTest.java
@@ -33,7 +33,6 @@ import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
-import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
 
 /**
@@ -108,24 +107,6 @@ public class FillExtrusionLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testFillExtrusionOpacityTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("fill-extrusion-opacityTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setFillExtrusionOpacityTransition(options);
-        assertEquals(layer.getFillExtrusionOpacityTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testFillExtrusionOpacityAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -170,24 +151,6 @@ public class FillExtrusionLayerTest extends BaseActivityTest {
         assertEquals(ExponentialStops.class, layer.getFillExtrusionOpacity().getFunction().getStops().getClass());
         assertEquals(0.5f, ((ExponentialStops) layer.getFillExtrusionOpacity().getFunction().getStops()).getBase(), 0.001);
         assertEquals(1, ((ExponentialStops) layer.getFillExtrusionOpacity().getFunction().getStops()).size());
-      }
-    });
-  }
-
-  @Test
-  public void testFillExtrusionColorTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("fill-extrusion-colorTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setFillExtrusionColorTransition(options);
-        assertEquals(layer.getFillExtrusionColorTransition(), options);
       }
     });
   }
@@ -352,24 +315,6 @@ public class FillExtrusionLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testFillExtrusionTranslateTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("fill-extrusion-translateTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setFillExtrusionTranslateTransition(options);
-        assertEquals(layer.getFillExtrusionTranslateTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testFillExtrusionTranslateAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -467,24 +412,6 @@ public class FillExtrusionLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testFillExtrusionPatternTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("fill-extrusion-patternTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setFillExtrusionPatternTransition(options);
-        assertEquals(layer.getFillExtrusionPatternTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testFillExtrusionPatternAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -528,24 +455,6 @@ public class FillExtrusionLayerTest extends BaseActivityTest {
         assertEquals(CameraFunction.class, layer.getFillExtrusionPattern().getFunction().getClass());
         assertEquals(IntervalStops.class, layer.getFillExtrusionPattern().getFunction().getStops().getClass());
         assertEquals(1, ((IntervalStops) layer.getFillExtrusionPattern().getFunction().getStops()).size());
-      }
-    });
-  }
-
-  @Test
-  public void testFillExtrusionHeightTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("fill-extrusion-heightTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setFillExtrusionHeightTransition(options);
-        assertEquals(layer.getFillExtrusionHeightTransition(), options);
       }
     });
   }
@@ -728,24 +637,6 @@ public class FillExtrusionLayerTest extends BaseActivityTest {
         assertEquals(0f, stop.in.zoom, 0.001);
         assertEquals(0.3f, stop.in.value, 0.001f);
         assertEquals(0.9f, stop.out, 0.001f);
-      }
-    });
-  }
-
-  @Test
-  public void testFillExtrusionBaseTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("fill-extrusion-baseTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setFillExtrusionBaseTransition(options);
-        assertEquals(layer.getFillExtrusionBaseTransition(), options);
       }
     });
   }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillLayerTest.java
@@ -33,7 +33,6 @@ import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
-import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
 
 /**
@@ -151,24 +150,6 @@ public class FillLayerTest extends BaseActivityTest {
         assertEquals(CameraFunction.class, layer.getFillAntialias().getFunction().getClass());
         assertEquals(IntervalStops.class, layer.getFillAntialias().getFunction().getStops().getClass());
         assertEquals(1, ((IntervalStops) layer.getFillAntialias().getFunction().getStops()).size());
-      }
-    });
-  }
-
-  @Test
-  public void testFillOpacityTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("fill-opacityTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setFillOpacityTransition(options);
-        assertEquals(layer.getFillOpacityTransition(), options);
       }
     });
   }
@@ -356,24 +337,6 @@ public class FillLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testFillColorTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("fill-colorTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setFillColorTransition(options);
-        assertEquals(layer.getFillColorTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testFillColorAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -528,24 +491,6 @@ public class FillLayerTest extends BaseActivityTest {
         // Set and Get
         layer.setProperties(fillColor(Color.RED));
         assertEquals(layer.getFillColorAsInt(), Color.RED);
-      }
-    });
-  }
-
-  @Test
-  public void testFillOutlineColorTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("fill-outline-colorTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setFillOutlineColorTransition(options);
-        assertEquals(layer.getFillOutlineColorTransition(), options);
       }
     });
   }
@@ -710,24 +655,6 @@ public class FillLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testFillTranslateTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("fill-translateTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setFillTranslateTransition(options);
-        assertEquals(layer.getFillTranslateTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testFillTranslateAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -820,24 +747,6 @@ public class FillLayerTest extends BaseActivityTest {
         assertEquals(CameraFunction.class, layer.getFillTranslateAnchor().getFunction().getClass());
         assertEquals(IntervalStops.class, layer.getFillTranslateAnchor().getFunction().getStops().getClass());
         assertEquals(1, ((IntervalStops) layer.getFillTranslateAnchor().getFunction().getStops()).size());
-      }
-    });
-  }
-
-  @Test
-  public void testFillPatternTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("fill-patternTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setFillPatternTransition(options);
-        assertEquals(layer.getFillPatternTransition(), options);
       }
     });
   }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
@@ -33,7 +33,6 @@ import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
-import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
 
 /**
@@ -359,24 +358,6 @@ public class LineLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testLineOpacityTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("line-opacityTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setLineOpacityTransition(options);
-        assertEquals(layer.getLineOpacityTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testLineOpacityAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -559,24 +540,6 @@ public class LineLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testLineColorTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("line-colorTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setLineColorTransition(options);
-        assertEquals(layer.getLineColorTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testLineColorAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -736,24 +699,6 @@ public class LineLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testLineTranslateTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("line-translateTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setLineTranslateTransition(options);
-        assertEquals(layer.getLineTranslateTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testLineTranslateAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -846,24 +791,6 @@ public class LineLayerTest extends BaseActivityTest {
         assertEquals(CameraFunction.class, layer.getLineTranslateAnchor().getFunction().getClass());
         assertEquals(IntervalStops.class, layer.getLineTranslateAnchor().getFunction().getStops().getClass());
         assertEquals(1, ((IntervalStops) layer.getLineTranslateAnchor().getFunction().getStops()).size());
-      }
-    });
-  }
-
-  @Test
-  public void testLineWidthTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("line-widthTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setLineWidthTransition(options);
-        assertEquals(layer.getLineWidthTransition(), options);
       }
     });
   }
@@ -1051,24 +978,6 @@ public class LineLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testLineGapWidthTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("line-gap-widthTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setLineGapWidthTransition(options);
-        assertEquals(layer.getLineGapWidthTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testLineGapWidthAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -1246,24 +1155,6 @@ public class LineLayerTest extends BaseActivityTest {
         assertEquals(0f, stop.in.zoom, 0.001);
         assertEquals(0.3f, stop.in.value, 0.001f);
         assertEquals(0.9f, stop.out, 0.001f);
-      }
-    });
-  }
-
-  @Test
-  public void testLineOffsetTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("line-offsetTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setLineOffsetTransition(options);
-        assertEquals(layer.getLineOffsetTransition(), options);
       }
     });
   }
@@ -1451,24 +1342,6 @@ public class LineLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testLineBlurTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("line-blurTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setLineBlurTransition(options);
-        assertEquals(layer.getLineBlurTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testLineBlurAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -1651,24 +1524,6 @@ public class LineLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testLineDasharrayTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("line-dasharrayTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setLineDasharrayTransition(options);
-        assertEquals(layer.getLineDasharrayTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testLineDasharrayAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -1712,24 +1567,6 @@ public class LineLayerTest extends BaseActivityTest {
         assertEquals(CameraFunction.class, layer.getLineDasharray().getFunction().getClass());
         assertEquals(IntervalStops.class, layer.getLineDasharray().getFunction().getStops().getClass());
         assertEquals(1, ((IntervalStops) layer.getLineDasharray().getFunction().getStops()).size());
-      }
-    });
-  }
-
-  @Test
-  public void testLinePatternTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("line-patternTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setLinePatternTransition(options);
-        assertEquals(layer.getLinePatternTransition(), options);
       }
     });
   }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RasterLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RasterLayerTest.java
@@ -33,7 +33,6 @@ import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
-import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
 
 /**
@@ -82,24 +81,6 @@ public class RasterLayerTest extends BaseActivityTest {
         // Set
         layer.setProperties(visibility(NONE));
         assertEquals(layer.getVisibility().getValue(), NONE);
-      }
-    });
-  }
-
-  @Test
-  public void testRasterOpacityTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("raster-opacityTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setRasterOpacityTransition(options);
-        assertEquals(layer.getRasterOpacityTransition(), options);
       }
     });
   }
@@ -154,24 +135,6 @@ public class RasterLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testRasterHueRotateTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("raster-hue-rotateTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setRasterHueRotateTransition(options);
-        assertEquals(layer.getRasterHueRotateTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testRasterHueRotateAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -216,24 +179,6 @@ public class RasterLayerTest extends BaseActivityTest {
         assertEquals(ExponentialStops.class, layer.getRasterHueRotate().getFunction().getStops().getClass());
         assertEquals(0.5f, ((ExponentialStops) layer.getRasterHueRotate().getFunction().getStops()).getBase(), 0.001);
         assertEquals(1, ((ExponentialStops) layer.getRasterHueRotate().getFunction().getStops()).size());
-      }
-    });
-  }
-
-  @Test
-  public void testRasterBrightnessMinTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("raster-brightness-minTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setRasterBrightnessMinTransition(options);
-        assertEquals(layer.getRasterBrightnessMinTransition(), options);
       }
     });
   }
@@ -288,24 +233,6 @@ public class RasterLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testRasterBrightnessMaxTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("raster-brightness-maxTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setRasterBrightnessMaxTransition(options);
-        assertEquals(layer.getRasterBrightnessMaxTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testRasterBrightnessMaxAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -350,24 +277,6 @@ public class RasterLayerTest extends BaseActivityTest {
         assertEquals(ExponentialStops.class, layer.getRasterBrightnessMax().getFunction().getStops().getClass());
         assertEquals(0.5f, ((ExponentialStops) layer.getRasterBrightnessMax().getFunction().getStops()).getBase(), 0.001);
         assertEquals(1, ((ExponentialStops) layer.getRasterBrightnessMax().getFunction().getStops()).size());
-      }
-    });
-  }
-
-  @Test
-  public void testRasterSaturationTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("raster-saturationTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setRasterSaturationTransition(options);
-        assertEquals(layer.getRasterSaturationTransition(), options);
       }
     });
   }
@@ -422,24 +331,6 @@ public class RasterLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testRasterContrastTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("raster-contrastTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setRasterContrastTransition(options);
-        assertEquals(layer.getRasterContrastTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testRasterContrastAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -484,24 +375,6 @@ public class RasterLayerTest extends BaseActivityTest {
         assertEquals(ExponentialStops.class, layer.getRasterContrast().getFunction().getStops().getClass());
         assertEquals(0.5f, ((ExponentialStops) layer.getRasterContrast().getFunction().getStops()).getBase(), 0.001);
         assertEquals(1, ((ExponentialStops) layer.getRasterContrast().getFunction().getStops()).size());
-      }
-    });
-  }
-
-  @Test
-  public void testRasterFadeDurationTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("raster-fade-durationTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setRasterFadeDurationTransition(options);
-        assertEquals(layer.getRasterFadeDurationTransition(), options);
       }
     });
   }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
@@ -33,7 +33,6 @@ import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
-import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
 
 /**
@@ -2733,24 +2732,6 @@ public class SymbolLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testIconOpacityTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("icon-opacityTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setIconOpacityTransition(options);
-        assertEquals(layer.getIconOpacityTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testIconOpacityAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -2933,24 +2914,6 @@ public class SymbolLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testIconColorTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("icon-colorTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setIconColorTransition(options);
-        assertEquals(layer.getIconColorTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testIconColorAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -3110,24 +3073,6 @@ public class SymbolLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testIconHaloColorTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("icon-halo-colorTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setIconHaloColorTransition(options);
-        assertEquals(layer.getIconHaloColorTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testIconHaloColorAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -3282,24 +3227,6 @@ public class SymbolLayerTest extends BaseActivityTest {
         // Set and Get
         layer.setProperties(iconHaloColor(Color.RED));
         assertEquals(layer.getIconHaloColorAsInt(), Color.RED);
-      }
-    });
-  }
-
-  @Test
-  public void testIconHaloWidthTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("icon-halo-widthTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setIconHaloWidthTransition(options);
-        assertEquals(layer.getIconHaloWidthTransition(), options);
       }
     });
   }
@@ -3487,24 +3414,6 @@ public class SymbolLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testIconHaloBlurTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("icon-halo-blurTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setIconHaloBlurTransition(options);
-        assertEquals(layer.getIconHaloBlurTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testIconHaloBlurAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -3687,24 +3596,6 @@ public class SymbolLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testIconTranslateTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("icon-translateTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setIconTranslateTransition(options);
-        assertEquals(layer.getIconTranslateTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testIconTranslateAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -3797,24 +3688,6 @@ public class SymbolLayerTest extends BaseActivityTest {
         assertEquals(CameraFunction.class, layer.getIconTranslateAnchor().getFunction().getClass());
         assertEquals(IntervalStops.class, layer.getIconTranslateAnchor().getFunction().getStops().getClass());
         assertEquals(1, ((IntervalStops) layer.getIconTranslateAnchor().getFunction().getStops()).size());
-      }
-    });
-  }
-
-  @Test
-  public void testTextOpacityTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("text-opacityTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setTextOpacityTransition(options);
-        assertEquals(layer.getTextOpacityTransition(), options);
       }
     });
   }
@@ -4002,24 +3875,6 @@ public class SymbolLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testTextColorTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("text-colorTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setTextColorTransition(options);
-        assertEquals(layer.getTextColorTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testTextColorAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -4179,24 +4034,6 @@ public class SymbolLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testTextHaloColorTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("text-halo-colorTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setTextHaloColorTransition(options);
-        assertEquals(layer.getTextHaloColorTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testTextHaloColorAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -4351,24 +4188,6 @@ public class SymbolLayerTest extends BaseActivityTest {
         // Set and Get
         layer.setProperties(textHaloColor(Color.RED));
         assertEquals(layer.getTextHaloColorAsInt(), Color.RED);
-      }
-    });
-  }
-
-  @Test
-  public void testTextHaloWidthTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("text-halo-widthTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setTextHaloWidthTransition(options);
-        assertEquals(layer.getTextHaloWidthTransition(), options);
       }
     });
   }
@@ -4556,24 +4375,6 @@ public class SymbolLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testTextHaloBlurTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("text-halo-blurTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setTextHaloBlurTransition(options);
-        assertEquals(layer.getTextHaloBlurTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testTextHaloBlurAsConstant() {
     validateTestSetup();
     setupLayer();
@@ -4751,24 +4552,6 @@ public class SymbolLayerTest extends BaseActivityTest {
         assertEquals(0f, stop.in.zoom, 0.001);
         assertEquals(0.3f, stop.in.value, 0.001f);
         assertEquals(0.9f, stop.out, 0.001f);
-      }
-    });
-  }
-
-  @Test
-  public void testTextTranslateTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("text-translateTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setTextTranslateTransition(options);
-        assertEquals(layer.getTextTranslateTransition(), options);
       }
     });
   }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
@@ -37,7 +37,6 @@ import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
-import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
 
 /**
@@ -123,26 +122,6 @@ public class <%- camelize(type) %>LayerTest extends BaseActivityTest {
   }
 <% } -%>
 <% for (const property of properties) { -%>
-<% if (property.transition) { -%>
-
-  @Test
-  public void test<%- camelize(property.name) %>Transition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("<%- property.name %>TransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.set<%- camelize(property.name) %>Transition(options);
-        assertEquals(layer.get<%- camelize(property.name) %>Transition(), options);
-      }
-    });
-  }
-<% } -%>
 
   @Test
   public void test<%- camelize(property.name) %>AsConstant() {


### PR DESCRIPTION
This PR removes tests for transition options to limit the amount of tests executed on CI. (currently we are running all tests found in the style package). For each property that supported transition options, we were generating a test for it. 

Note: `make android-style-code` is generating changes that should not be included in this PR ([here](https://github.com/mapbox/mapbox-gl-native/compare/tvn-limit-ci-tests?expand=1#diff-ffc041b38fb81bccaa2c261dbc6b938e) & [here](https://github.com/mapbox/mapbox-gl-native/compare/tvn-limit-ci-tests?expand=1#diff-d92d4de750896b2b661429f96c3ba54c))
 