### PR TITLE
Bumped sdk to 5.1.3 in Fabric config file

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/resources/fabric/com.mapbox.mapboxsdk.mapbox-android-sdk.properties
+++ b/platform/android/MapboxGLAndroidSDK/src/main/resources/fabric/com.mapbox.mapboxsdk.mapbox-android-sdk.properties
@@ -1,3 +1,3 @@
 fabric-identifier=com.mapbox.mapboxsdk.mapbox-android-sdk
-fabric-version=5.1.0
+fabric-version=5.1.3
 fabric-build-type=binary


### PR DESCRIPTION
I kept looking for somewhere in the Fabric website, but it looks like updating the version # for Fabric is done in [this `gl-native` file](https://github.com/mapbox/mapbox-gl-native/blob/74bcca380dd7faa7a629d59e3346506e6a8cca34/platform/android/MapboxGLAndroidSDK/src/main/resources/fabric/com.mapbox.mapboxsdk.mapbox-android-sdk.properties).

_This pr updates this file to 5.1.3 as part of [the 5.1.3 SDK release](https://github.com/mapbox/mapbox-gl-native/issues/9800)_

Right now, it's still 5.1.0 as confirmed by the Android Studio Fabric plugin 👇 :

![screen shot 2017-08-22 at 1 23 54 pm](https://user-images.githubusercontent.com/4394910/29578405-2c226882-873d-11e7-8b63-35c1e4c5d353.png)


cc @tobrun 
