### PR TITLE
Add benchmarks for parsing and evaluating style functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ run-test-%: test
 run-benchmark: run-benchmark-.
 
 run-benchmark-%: benchmark
-	$(MACOS_OUTPUT_PATH)/$(BUILDTYPE)/mbgl-benchmark --benchmark_filter=$*
+	$(MACOS_OUTPUT_PATH)/$(BUILDTYPE)/mbgl-benchmark --benchmark_filter=$* ${BENCHMARK_ARGS}
 
 .PHONY: node-benchmark
 node-benchmark: $(MACOS_PROJ_PATH)

--- a/benchmark/function/camera_function.benchmark.cpp
+++ b/benchmark/function/camera_function.benchmark.cpp
@@ -1,0 +1,69 @@
+#include <benchmark/benchmark.h>
+
+#include <mbgl/style/function/source_function.hpp>
+
+#include <mbgl/style/rapidjson_conversion.hpp>
+#include <mbgl/style/conversion.hpp>
+#include <mbgl/style/conversion/function.hpp>
+
+#include <rapidjson/document.h>
+
+
+using namespace mbgl;
+using namespace mbgl::style;
+
+static rapidjson::GenericDocument<rapidjson::UTF8<>, rapidjson::CrtAllocator> createFunctionJSON(size_t stopCount) {
+    rapidjson::GenericDocument<rapidjson::UTF8<>, rapidjson::CrtAllocator> doc;
+
+    std::string stops = "[";
+    for (size_t i = 0; i < stopCount; i++) {
+        std::string value = std::to_string(24.0f / stopCount * i);
+        if (stops.size() > 1) stops += ",";
+        stops += "[" + value + ", " + value + "]";
+    }
+    stops += "]";
+    
+    doc.Parse<0>(R"({"type": "exponential", "base": 2,  "stops": )" + stops + "}");
+    return doc;
+}
+
+static void Parse_CameraFunction(benchmark::State& state) {
+    size_t stopCount = state.range(0);
+    
+    while (state.KeepRunning()) {
+        conversion::Error error;
+        state.PauseTiming();
+        auto doc = createFunctionJSON(stopCount);
+        state.ResumeTiming();
+        optional<CameraFunction<float>> result = conversion::convert<CameraFunction<float>, JSValue>(doc, error);
+        if (!result) {
+            state.SkipWithError(error.message.c_str());
+        }
+    }
+    state.SetLabel(std::to_string(stopCount).c_str());
+}
+
+static void Evaluate_CameraFunction(benchmark::State& state) {
+    size_t stopCount = state.range(0);
+    auto doc = createFunctionJSON(stopCount);
+    conversion::Error error;
+    optional<CameraFunction<float>> function = conversion::convert<CameraFunction<float>, JSValue>(doc, error);
+    if (!function) {
+        state.SkipWithError(error.message.c_str());
+    }
+    
+    while(state.KeepRunning()) {
+        float z = 24.0f * static_cast<float>(rand() % 100) / 100;
+        function->evaluate(z);
+    }
+    
+    state.SetLabel(std::to_string(stopCount).c_str());
+}
+
+BENCHMARK(Parse_CameraFunction)
+    ->Arg(1)->Arg(2)->Arg(4)->Arg(6)->Arg(8)->Arg(10)->Arg(12);
+
+BENCHMARK(Evaluate_CameraFunction)
+    ->Arg(1)->Arg(2)->Arg(4)->Arg(6)->Arg(8)->Arg(10)->Arg(12);
+
+

--- a/benchmark/function/composite_function.benchmark.cpp
+++ b/benchmark/function/composite_function.benchmark.cpp
@@ -1,0 +1,76 @@
+#include <benchmark/benchmark.h>
+
+#include <mbgl/benchmark/stub_geometry_tile_feature.hpp>
+
+#include <mbgl/style/function/composite_exponential_stops.hpp>
+#include <mbgl/style/function/composite_function.hpp>
+
+#include <mbgl/style/rapidjson_conversion.hpp>
+#include <mbgl/style/conversion.hpp>
+#include <mbgl/style/conversion/function.hpp>
+
+#include <rapidjson/document.h>
+
+
+using namespace mbgl;
+using namespace mbgl::style;
+
+static rapidjson::GenericDocument<rapidjson::UTF8<>, rapidjson::CrtAllocator> createFunctionJSON(size_t stopCount) {
+    rapidjson::GenericDocument<rapidjson::UTF8<>, rapidjson::CrtAllocator> doc;
+
+    std::string stops = "[";
+    for (size_t outerStop = 0; outerStop < stopCount; outerStop++) {
+        for (size_t innerStop = 0; innerStop < stopCount; innerStop++) {
+            std::string zoom = std::to_string(24.0f / stopCount * outerStop);
+            std::string value = std::to_string(100.0f / stopCount * innerStop);
+
+            if (stops.size() > 1) stops += ",";
+            stops += R"([{"zoom":)" + zoom +  R"(,"value":)" + value + "}, " + value + "]";
+        }
+    }
+    stops += "]";
+    
+    doc.Parse<0>(R"({"type": "exponential", "base": 2,  "stops": )" + stops + R"(, "property": "x"})");
+    return doc;
+}
+
+static void Parse_CompositeFunction(benchmark::State& state) {
+    size_t stopCount = state.range(0);
+    
+    while (state.KeepRunning()) {
+        conversion::Error error;
+        state.PauseTiming();
+        auto doc = createFunctionJSON(stopCount);
+        state.ResumeTiming();
+        optional<CompositeFunction<float>> result = conversion::convert<style::CompositeFunction<float>, JSValue>(doc, error);
+        if (!result) {
+            state.SkipWithError(error.message.c_str());
+        }
+    }
+    state.SetLabel(std::to_string(stopCount).c_str());
+}
+
+static void Evaluate_CompositeFunction(benchmark::State& state) {
+    size_t stopCount = state.range(0);
+    auto doc = createFunctionJSON(stopCount);
+    conversion::Error error;
+    optional<CompositeFunction<float>> function = conversion::convert<CompositeFunction<float>, JSValue>(doc, error);
+    if (!function) {
+        state.SkipWithError(error.message.c_str());
+    }
+    
+    while(state.KeepRunning()) {
+        float z = 24.0f * static_cast<float>(rand() % 100) / 100;
+        function->evaluate(z, StubGeometryTileFeature(PropertyMap { { "x", static_cast<int64_t>(rand() % 100) } }), -1.0f);
+    }
+    
+    state.SetLabel(std::to_string(stopCount).c_str());
+}
+
+BENCHMARK(Parse_CompositeFunction)
+    ->Arg(1)->Arg(2)->Arg(4)->Arg(6)->Arg(8)->Arg(10)->Arg(12);
+
+BENCHMARK(Evaluate_CompositeFunction)
+    ->Arg(1)->Arg(2)->Arg(4)->Arg(6)->Arg(8)->Arg(10)->Arg(12);
+
+

--- a/benchmark/function/source_function.benchmark.cpp
+++ b/benchmark/function/source_function.benchmark.cpp
@@ -1,0 +1,70 @@
+#include <benchmark/benchmark.h>
+
+#include <mbgl/benchmark/stub_geometry_tile_feature.hpp>
+
+#include <mbgl/style/function/source_function.hpp>
+
+#include <mbgl/style/rapidjson_conversion.hpp>
+#include <mbgl/style/conversion.hpp>
+#include <mbgl/style/conversion/function.hpp>
+
+#include <rapidjson/document.h>
+
+
+using namespace mbgl;
+using namespace mbgl::style;
+
+static rapidjson::GenericDocument<rapidjson::UTF8<>, rapidjson::CrtAllocator> createFunctionJSON(size_t stopCount) {
+    rapidjson::GenericDocument<rapidjson::UTF8<>, rapidjson::CrtAllocator> doc;
+
+    std::string stops = "[";
+    for (size_t i = 0; i < stopCount; i++) {
+        std::string value = std::to_string(100.0f / stopCount * i);
+        if (stops.size() > 1) stops += ",";
+        stops += "[" + value + ", " + value + "]";
+    }
+    stops += "]";
+    
+    doc.Parse<0>(R"({"type": "exponential", "base": 2,  "stops": )" + stops + R"(, "property": "x"})");
+    return doc;
+}
+
+static void Parse_SourceFunction(benchmark::State& state) {
+    size_t stopCount = state.range(0);
+    
+    while (state.KeepRunning()) {
+        conversion::Error error;
+        state.PauseTiming();
+        auto doc = createFunctionJSON(stopCount);
+        state.ResumeTiming();
+        optional<SourceFunction<float>> result = conversion::convert<SourceFunction<float>, JSValue>(doc, error);
+        if (!result) {
+            state.SkipWithError(error.message.c_str());
+        }
+    }
+    state.SetLabel(std::to_string(stopCount).c_str());
+}
+
+static void Evaluate_SourceFunction(benchmark::State& state) {
+    size_t stopCount = state.range(0);
+    auto doc = createFunctionJSON(stopCount);
+    conversion::Error error;
+    optional<SourceFunction<float>> function = conversion::convert<SourceFunction<float>, JSValue>(doc, error);
+    if (!function) {
+        state.SkipWithError(error.message.c_str());
+    }
+    
+    while(state.KeepRunning()) {
+        function->evaluate(StubGeometryTileFeature(PropertyMap { { "x", static_cast<int64_t>(rand() % 100) } }), -1.0f);
+    }
+    
+    state.SetLabel(std::to_string(stopCount).c_str());
+}
+
+BENCHMARK(Parse_SourceFunction)
+    ->Arg(1)->Arg(2)->Arg(4)->Arg(6)->Arg(8)->Arg(10)->Arg(12);
+
+BENCHMARK(Evaluate_SourceFunction)
+    ->Arg(1)->Arg(2)->Arg(4)->Arg(6)->Arg(8)->Arg(10)->Arg(12);
+
+

--- a/benchmark/src/mbgl/benchmark/stub_geometry_tile_feature.hpp
+++ b/benchmark/src/mbgl/benchmark/stub_geometry_tile_feature.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <mbgl/tile/geometry_tile_data.hpp>
+#include <mbgl/util/feature.hpp>
+
+using namespace mbgl;
+
+class StubGeometryTileFeature : public GeometryTileFeature {
+public:
+    StubGeometryTileFeature(PropertyMap properties_)
+        : properties(std::move(properties_)) {
+    }
+
+    StubGeometryTileFeature(optional<FeatureIdentifier> id_, FeatureType type_, GeometryCollection geometry_, PropertyMap properties_)
+        : properties(std::move(properties_)),
+          id(std::move(id_)),
+          type(type_),
+          geometry(std::move(geometry_)) {
+    }
+
+    PropertyMap properties;
+    optional<FeatureIdentifier> id;
+    FeatureType type = FeatureType::Point;
+    GeometryCollection geometry;
+
+    FeatureType getType() const override {
+        return type;
+    }
+
+    optional<FeatureIdentifier> getID() const override {
+        return id;
+    }
+
+    optional<Value> getValue(const std::string& key) const override {
+        return properties.count(key) ? properties.at(key) : optional<Value>();
+    }
+
+    GeometryCollection getGeometries() const override {
+        return geometry;
+    }
+};

--- a/cmake/benchmark-files.cmake
+++ b/cmake/benchmark-files.cmake
@@ -5,6 +5,11 @@ set(MBGL_BENCHMARK_FILES
     benchmark/api/query.benchmark.cpp
     benchmark/api/render.benchmark.cpp
 
+    # function
+    benchmark/function/camera_function.benchmark.cpp
+    benchmark/function/composite_function.benchmark.cpp
+    benchmark/function/source_function.benchmark.cpp
+
     # include/mbgl
     benchmark/include/mbgl/benchmark.hpp
 
@@ -18,6 +23,7 @@ set(MBGL_BENCHMARK_FILES
 
     # src/mbgl/benchmark
     benchmark/src/mbgl/benchmark/benchmark.cpp
+    benchmark/src/mbgl/benchmark/stub_geometry_tile_feature.hpp
 
     # util
     benchmark/util/dtoa.benchmark.cpp

--- a/platform/linux/config.cmake
+++ b/platform/linux/config.cmake
@@ -8,7 +8,7 @@ mason_use(libpng VERSION 1.6.25)
 mason_use(libjpeg-turbo VERSION 1.5.0)
 mason_use(webp VERSION 0.5.1)
 mason_use(gtest VERSION 1.8.0${MASON_CXXABI_SUFFIX})
-mason_use(benchmark VERSION 1.0.0-1)
+mason_use(benchmark VERSION 1.2.0)
 mason_use(icu VERSION 58.1-min-size)
 
 # Link with libuv. This is not part of loop-uv.cmake because loop-uv.cmake is also

--- a/platform/macos/config.cmake
+++ b/platform/macos/config.cmake
@@ -3,7 +3,7 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET 10.10)
 mason_use(glfw VERSION 2017-07-13-67c9155)
 mason_use(boost_libprogram_options VERSION 1.62.0)
 mason_use(gtest VERSION 1.8.0)
-mason_use(benchmark VERSION 1.0.0-1)
+mason_use(benchmark VERSION 1.2.0)
 mason_use(icu VERSION 58.1-min-size)
 
 include(cmake/loop-darwin.cmake)


### PR DESCRIPTION
Benchmarks for "parsing" (converting from JSON) and evaluating each type of DDS function.  

Example results:

```
---------------------------------------------------------------------
Benchmark                              Time           CPU Iterations
---------------------------------------------------------------------
Parse_CameraFunction/1              5912 ns       5884 ns     118763 1
Parse_CameraFunction/2              7563 ns       7526 ns     100021 2
Parse_CameraFunction/4             10579 ns      10568 ns      65460 4
Parse_CameraFunction/6             14101 ns      14078 ns      46792 6
Parse_CameraFunction/8             18148 ns      18129 ns      38659 8
Parse_CameraFunction/10            21299 ns      21260 ns      32044 10
Parse_CameraFunction/12            25631 ns      25598 ns      27472 12
Evaluate_CameraFunction/1            105 ns        104 ns    6943067 1
Evaluate_CameraFunction/2            165 ns        165 ns    4281738 2
Evaluate_CameraFunction/4            185 ns        184 ns    3794532 4
Evaluate_CameraFunction/6            193 ns        193 ns    3544914 6
Evaluate_CameraFunction/8            198 ns        198 ns    3524282 8
Evaluate_CameraFunction/10           211 ns        211 ns    3243789 10
Evaluate_CameraFunction/12           212 ns        211 ns    3273705 12
Parse_CompositeFunction/1           9481 ns       9456 ns      73828 1
Parse_CompositeFunction/2          19743 ns      19648 ns      36176 2
Parse_CompositeFunction/4          58765 ns      58655 ns      11013 4
Parse_CompositeFunction/6         124609 ns     124454 ns       5480 6
Parse_CompositeFunction/8         219764 ns     219296 ns       3238 8
Parse_CompositeFunction/10        335272 ns     334335 ns       2009 10
Parse_CompositeFunction/12        503914 ns     503198 ns       1456 12
Evaluate_CompositeFunction/1        2727 ns       2723 ns     251411 1
Evaluate_CompositeFunction/2        3255 ns       3252 ns     209955 2
Evaluate_CompositeFunction/4        4555 ns       4552 ns     153638 4
Evaluate_CompositeFunction/6        5690 ns       5685 ns     114965 6
Evaluate_CompositeFunction/8        6955 ns       6935 ns      97806 8
Evaluate_CompositeFunction/10       8320 ns       8311 ns      75999 10
Evaluate_CompositeFunction/12       9433 ns       9423 ns      61013 12
Parse_SourceFunction/1              6724 ns       6716 ns     100830 1
Parse_SourceFunction/2              8174 ns       8161 ns      84843 2
Parse_SourceFunction/4             11436 ns      11412 ns      61432 4
Parse_SourceFunction/6             15073 ns      15045 ns      46060 6
Parse_SourceFunction/8             18658 ns      18635 ns      35066 8
Parse_SourceFunction/10            22813 ns      22715 ns      30112 10
Parse_SourceFunction/12            27464 ns      27412 ns      26248 12
Evaluate_SourceFunction/1           1094 ns       1093 ns     604569 1
Evaluate_SourceFunction/2           1199 ns       1199 ns     560852 2
Evaluate_SourceFunction/4           1212 ns       1209 ns     516251 4
Evaluate_SourceFunction/6           1258 ns       1256 ns     549274 6
Evaluate_SourceFunction/8           1224 ns       1223 ns     559186 8
Evaluate_SourceFunction/10          1247 ns       1245 ns     558592 10
Evaluate_SourceFunction/12          1275 ns       1272 ns     540119 12
```