### PR TITLE
Ensure GeometryTile::pending state is only false in the last placement attempt

### DIFF
--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -48,7 +48,6 @@
   "render-tests/regressions/mapbox-gl-js#4551": "skip - https://github.com/mapbox/mapbox-gl-native/issues/1350",
   "render-tests/regressions/mapbox-gl-js#4573": "skip - https://github.com/mapbox/mapbox-gl-native/issues/1350",
   "render-tests/regressions/mapbox-gl-native#7357": "https://github.com/mapbox/mapbox-gl-native/issues/7357",
-  "render-tests/regressions/mapbox-gl-native#9792": "skip - https://github.com/mapbox/mapbox-gl-native/issues/9792",
   "render-tests/runtime-styling/image-add-sdf": "skip - https://github.com/mapbox/mapbox-gl-native/issues/9847",
   "render-tests/runtime-styling/paint-property-fill-flat-to-extrude": "skip - https://github.com/mapbox/mapbox-gl-native/issues/6745",
   "render-tests/runtime-styling/set-style-paint-property-fill-flat-to-extrude": "skip - needs issue",

--- a/src/mbgl/renderer/image_manager.cpp
+++ b/src/mbgl/renderer/image_manager.cpp
@@ -52,23 +52,23 @@ const style::Image::Impl* ImageManager::getImage(const std::string& id) const {
     return nullptr;
 }
 
-void ImageManager::getImages(ImageRequestor& requestor, ImageDependencies dependencies) {
+void ImageManager::getImages(ImageRequestor& requestor, ImageRequestPair&& pair) {
     // If the sprite has been loaded, or if all the icon dependencies are already present
     // (i.e. if they've been addeded via runtime styling), then notify the requestor immediately.
     // Otherwise, delay notification until the sprite is loaded. At that point, if any of the
     // dependencies are still unavailable, we'll just assume they are permanently missing.
     bool hasAllDependencies = true;
     if (!isLoaded()) {
-        for (const auto& dependency : dependencies) {
+        for (const auto& dependency : pair.first) {
             if (images.find(dependency) == images.end()) {
                 hasAllDependencies = false;
             }
         }
     }
     if (isLoaded() || hasAllDependencies) {
-        notify(requestor, dependencies);
+        notify(requestor, std::move(pair));
     } else {
-        requestors.emplace(&requestor, std::move(dependencies));
+        requestors.emplace(&requestor, std::move(pair));
     }
 }
 
@@ -76,17 +76,17 @@ void ImageManager::removeRequestor(ImageRequestor& requestor) {
     requestors.erase(&requestor);
 }
 
-void ImageManager::notify(ImageRequestor& requestor, const ImageDependencies& dependencies) const {
+void ImageManager::notify(ImageRequestor& requestor, const ImageRequestPair& pair) const {
     ImageMap response;
 
-    for (const auto& dependency : dependencies) {
+    for (const auto& dependency : pair.first) {
         auto it = images.find(dependency);
         if (it != images.end()) {
             response.emplace(*it);
         }
     }
 
-    requestor.onImagesAvailable(response);
+    requestor.onImagesAvailable(response, pair.second);
 }
 
 void ImageManager::dumpDebugLogs() const {

--- a/src/mbgl/renderer/image_manager.hpp
+++ b/src/mbgl/renderer/image_manager.hpp
@@ -21,7 +21,7 @@ class Context;
 class ImageRequestor {
 public:
     virtual ~ImageRequestor() = default;
-    virtual void onImagesAvailable(ImageMap) = 0;
+    virtual void onImagesAvailable(ImageMap, uint64_t imageCorrelationID) = 0;
 };
 
 /*
@@ -50,15 +50,15 @@ public:
     void updateImage(Immutable<style::Image::Impl>);
     void removeImage(const std::string&);
 
-    void getImages(ImageRequestor&, ImageDependencies);
+    void getImages(ImageRequestor&, ImageRequestPair&&);
     void removeRequestor(ImageRequestor&);
 
 private:
-    void notify(ImageRequestor&, const ImageDependencies&) const;
+    void notify(ImageRequestor&, const ImageRequestPair&) const;
 
     bool loaded = false;
 
-    std::unordered_map<ImageRequestor*, ImageDependencies> requestors;
+    std::unordered_map<ImageRequestor*, ImageRequestPair> requestors;
     ImageMap images;
 
 // Pattern stuff

--- a/src/mbgl/style/image_impl.hpp
+++ b/src/mbgl/style/image_impl.hpp
@@ -28,5 +28,6 @@ public:
 
 using ImageMap = std::unordered_map<std::string, Immutable<style::Image::Impl>>;
 using ImageDependencies = std::set<std::string>;
+using ImageRequestPair = std::pair<ImageDependencies, uint64_t>;
 
 } // namespace mbgl

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -43,7 +43,8 @@ GeometryTile::GeometryTile(const OverscaledTileID& id_,
       glyphManager(parameters.glyphManager),
       imageManager(parameters.imageManager),
       placementThrottler(Milliseconds(300), [this] { invokePlacement(); }),
-      lastYStretch(1.0f) {
+      lastYStretch(1.0f),
+      mode(parameters.mode) {
 }
 
 GeometryTile::~GeometryTile() {
@@ -86,7 +87,11 @@ void GeometryTile::setPlacementConfig(const PlacementConfig& desiredConfig) {
 
     ++correlationID;
     requestedConfig = desiredConfig;
-    placementThrottler.invoke();
+    if (mode == MapMode::Continuous) {
+        placementThrottler.invoke();
+    } else {
+        invokePlacement();
+    }
 }
 
 void GeometryTile::invokePlacement() {

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -142,6 +142,7 @@ private:
     
     util::Throttler placementThrottler;
     float lastYStretch;
+    const MapMode mode;
 
 public:
     optional<gl::Texture> glyphAtlasTexture;

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -40,10 +40,10 @@ public:
     void setLayers(const std::vector<Immutable<style::Layer::Impl>>&) override;
     
     void onGlyphsAvailable(GlyphMap) override;
-    void onImagesAvailable(ImageMap) override;
+    void onImagesAvailable(ImageMap, uint64_t imageCorrelationID) override;
     
     void getGlyphs(GlyphDependencies);
-    void getImages(ImageDependencies);
+    void getImages(ImageRequestPair);
 
     void upload(gl::Context&) override;
     Bucket* getBucket(const style::Layer::Impl&) const override;

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -216,7 +216,10 @@ void GeometryTileWorker::onGlyphsAvailable(GlyphMap newGlyphMap) {
     symbolDependenciesChanged();
 }
 
-void GeometryTileWorker::onImagesAvailable(ImageMap newImageMap) {
+void GeometryTileWorker::onImagesAvailable(ImageMap newImageMap, uint64_t imageCorrelationID_) {
+    if (imageCorrelationID != imageCorrelationID_) {
+        return; // Ignore outdated image request replies.
+    }
     imageMap = std::move(newImageMap);
     pendingImageDependencies.clear();
     symbolDependenciesChanged();
@@ -239,7 +242,7 @@ void GeometryTileWorker::requestNewGlyphs(const GlyphDependencies& glyphDependen
 void GeometryTileWorker::requestNewImages(const ImageDependencies& imageDependencies) {
     pendingImageDependencies = imageDependencies;
     if (!pendingImageDependencies.empty()) {
-        parent.invoke(&GeometryTile::getImages, pendingImageDependencies);
+        parent.invoke(&GeometryTile::getImages, std::make_pair(pendingImageDependencies, ++imageCorrelationID));
     }
 }
 

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -218,12 +218,7 @@ void GeometryTileWorker::onGlyphsAvailable(GlyphMap newGlyphMap) {
 
 void GeometryTileWorker::onImagesAvailable(ImageMap newImageMap) {
     imageMap = std::move(newImageMap);
-    for (const auto& pair : imageMap) {
-        auto it = pendingImageDependencies.find(pair.first);
-        if (it != pendingImageDependencies.end()) {
-            pendingImageDependencies.erase(it);
-        }
-    }
+    pendingImageDependencies.clear();
     symbolDependenciesChanged();
 }
 

--- a/src/mbgl/tile/geometry_tile_worker.hpp
+++ b/src/mbgl/tile/geometry_tile_worker.hpp
@@ -38,7 +38,7 @@ public:
     void setPlacementConfig(PlacementConfig, uint64_t correlationID);
     
     void onGlyphsAvailable(GlyphMap glyphs);
-    void onImagesAvailable(ImageMap images);
+    void onImagesAvailable(ImageMap images, uint64_t imageCorrelationID);
 
 private:
     void coalesced();
@@ -70,6 +70,7 @@ private:
 
     State state = Idle;
     uint64_t correlationID = 0;
+    uint64_t imageCorrelationID = 0;
 
     // Outer optional indicates whether we've received it or not.
     optional<std::vector<Immutable<style::Layer::Impl>>> layers;

--- a/test/renderer/image_manager.test.cpp
+++ b/test/renderer/image_manager.test.cpp
@@ -108,11 +108,12 @@ TEST(ImageManager, RemoveReleasesBinPackRect) {
 
 class StubImageRequestor : public ImageRequestor {
 public:
-    void onImagesAvailable(ImageMap images) final {
-        if (imagesAvailable) imagesAvailable(images);
+    void onImagesAvailable(ImageMap images, uint64_t imageCorrelationID_) final {
+        if (imagesAvailable && imageCorrelationID == imageCorrelationID_) imagesAvailable(images);
     }
 
     std::function<void (ImageMap)> imagesAvailable;
+    uint64_t imageCorrelationID = 0;
 };
 
 TEST(ImageManager, NotifiesRequestorWhenSpriteIsLoaded) {
@@ -124,7 +125,8 @@ TEST(ImageManager, NotifiesRequestorWhenSpriteIsLoaded) {
         notified = true;
     };
 
-    imageManager.getImages(requestor, {"one"});
+    uint64_t imageCorrelationID = 0;
+    imageManager.getImages(requestor, std::make_pair(std::set<std::string> {"one"}, imageCorrelationID));
     ASSERT_FALSE(notified);
 
     imageManager.setLoaded(true);
@@ -140,8 +142,9 @@ TEST(ImageManager, NotifiesRequestorImmediatelyIfDependenciesAreSatisfied) {
         notified = true;
     };
 
+    uint64_t imageCorrelationID = 0;
     imageManager.addImage(makeMutable<style::Image::Impl>("one", PremultipliedImage({ 16, 16 }), 2));
-    imageManager.getImages(requestor, {"one"});
+    imageManager.getImages(requestor, std::make_pair(std::set<std::string> {"one"}, imageCorrelationID));
 
     ASSERT_TRUE(notified);
 }


### PR DESCRIPTION
This PR:
 - reverts the `GeometryTilerWorker` change from #9739, and:
 - Modifies the logic from `ImageManager` to notify its requestors only when all image dependencies are met.

This causes `API.RecycleMapUpdateImages` to pass without cd8eb13ba2d8b65f6cac12a36e0586abc56fcb9f.