### PR TITLE
[ios] Fix heading update loop

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
-## 3.6.2
+## 3.6.3
+
+* Fixed an issue where user heading tracking mode would update too frequently. ([#9845](https://github.com/mapbox/mapbox-gl-native/pull/9845))
+
+## 3.6.2 - August 18, 2017
 
 * Added an `MGLStyle.localizesLabels` property, off by default, that localizes any Mapbox Streets–sourced symbol layer into the user’s preferred language. ([#9582](https://github.com/mapbox/mapbox-gl-native/pull/9582))
 * Added an additional camera method to MGLMapView that accepts an edge padding parameter. ([#9651](https://github.com/mapbox/mapbox-gl-native/pull/9651))

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -4690,29 +4690,38 @@ public:
     {
         // note that right/left device and interface orientations are opposites (see UIApplication.h)
         //
+        CLDeviceOrientation orientation;
         switch ([[UIApplication sharedApplication] statusBarOrientation])
         {
             case (UIInterfaceOrientationLandscapeLeft):
             {
-                self.locationManager.headingOrientation = CLDeviceOrientationLandscapeRight;
+                orientation = CLDeviceOrientationLandscapeRight;
                 break;
             }
             case (UIInterfaceOrientationLandscapeRight):
             {
-                self.locationManager.headingOrientation = CLDeviceOrientationLandscapeLeft;
+                orientation = CLDeviceOrientationLandscapeLeft;
                 break;
             }
             case (UIInterfaceOrientationPortraitUpsideDown):
             {
-                self.locationManager.headingOrientation = CLDeviceOrientationPortraitUpsideDown;
+                orientation = CLDeviceOrientationPortraitUpsideDown;
                 break;
             }
             case (UIInterfaceOrientationPortrait):
             default:
             {
-                self.locationManager.headingOrientation = CLDeviceOrientationPortrait;
+                orientation = CLDeviceOrientationPortrait;
                 break;
             }
+        }
+
+        // Setting the location manager's heading orientation causes it to send
+        // a heading event, which in turn makes us redraw, which kicks off a
+        // loop... so don't do that. rdar://34059173
+        if (self.locationManager.headingOrientation != orientation)
+        {
+            self.locationManager.headingOrientation = orientation;
         }
     }
 }


### PR DESCRIPTION
Fixes #9822, significantly reducing CPU usage during user heading tracking mode.

In #7716, we started calling `layoutSubviews` more often. If the compass were visible, this would then call `updateHeadingForDeviceOrientation`, which would set `CLLocationManager.headingOrientation`.

Even if there is no actual change in its value, setting `CLLocationManager.headingOrientation` triggers a new heading update, which in turn caused us to update the user location annotation and `layoutSubviews` again. This effectively disabled the heading filter and would continue until heading tracking mode was disabled.

/cc @frederoni @fabian-guerra @1ec5