### PR TITLE
[android] - build SNAPSHOT from release branch

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -273,7 +273,7 @@ jobs:
       - deploy:
           name: Publish to Maven
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then make run-android-upload-archives ; fi
+            if [ "${CIRCLE_BRANCH}" == "release-ios-v3.6.0-android-v5.1.0" ]; then make run-android-upload-archives ; fi
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Refs #9852, it seems that sonatype can't handle multiple SNAPSHOT versions (context in #9852). 
For now we will continue to build SNAPSHOTS for patch releases from the release branch.

 