### PR TITLE
[ios] Support iOS 11 location usage descriptions

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 ## 3.6.3
 
 * Fixed an issue where user heading tracking mode would update too frequently. ([#9845](https://github.com/mapbox/mapbox-gl-native/pull/9845))
+* Added support for iOS 11 location usage descriptions. ([#9869](https://github.com/mapbox/mapbox-gl-native/pull/9869))
 
 ## 3.6.2 - August 18, 2017
 

--- a/platform/ios/app/Info.plist
+++ b/platform/ios/app/Info.plist
@@ -27,9 +27,11 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2014–2017 Mapbox</string>
 	<key>NSLocationAlwaysUsageDescription</key>
-	<string>The map will ALWAYS display the user’s location.</string>
+	<string>The map will display your location. The map may also use your location when it isn’t visible in order to improve OpenStreetMap and Mapbox products.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>The map will display the user’s location.</string>
+	<string>The map will display your location.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>The map will display your location. If you choose Always, the map may also use your location when it isn’t visible in order to improve OpenStreetMap and Mapbox products.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
Adds support for iOS 11’s `NSLocationAlwaysAndWhenInUseUsageDescription` key and new location permission behavior. Our SDK’s behavior remains unchanged in older iOS versions.

In apps compiled with the iOS 11 SDK:
- `NSLocationAlwaysUsageDescription` is ignored.
- `NSLocationWhenInUseUsageDescription` is required, even if `NSLocationAlwaysAndWhenInUseUsageDescription` is set.

If an app can ask for `always`, we do that. This may not be desirable for some use cases, in which case the developer should request location authorization themselves before enabling any Mapbox features that require it.

[Here’s a nice writeup of the iOS 11 changes generally.](https://mackuba.eu/2017/07/13/changes-to-location-tracking-in-ios-11/)

/cc @boundsj @1ec5 @fabian-guerra