### PR TITLE
[android] Clear out mapCallback's OnMapReadyCallbacks on onDestroy

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -296,6 +296,7 @@ public class MapView extends FrameLayout {
   @UiThread
   public void onDestroy() {
     destroyed = true;
+    mapCallback.clearOnMapReadyCallbacks();
     nativeMapView.destroy();
     nativeMapView = null;
   }
@@ -1013,6 +1014,10 @@ public class MapView extends FrameLayout {
 
     void addOnMapReadyCallback(OnMapReadyCallback callback) {
       onMapReadyCallbackList.add(callback);
+    }
+
+    void clearOnMapReadyCallbacks() {
+      onMapReadyCallbackList.clear();
     }
   }
 }


### PR DESCRIPTION
There is a state where MapView's `OnMapChangedListener.onMapReadyCallbackList.onMapReady()` callbacks are called, but member `destroyed` == true (i.e. `onDestroy()` has been called).

This can cause any callback provided to `getMapAsync` to be executed even though the MapView is in a destroyed state!

The following patch calls `clear()` on the list of callbacks, preventing code execution in `OnMapChangedListener.onMapReady() `.
