### PR TITLE
Clear RenderGeoJSONSource tilePyramid if no data is available

### DIFF
--- a/src/mbgl/renderer/sources/render_geojson_source.cpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.cpp
@@ -34,17 +34,22 @@ void RenderGeoJSONSource::update(Immutable<style::Source::Impl> baseImpl_,
 
     GeoJSONData* data_ = impl().getData();
 
-    if (!data_) {
-        return;
-    }
-
     if (data_ != data) {
         data = data_;
         tilePyramid.cache.clear();
 
-        for (auto const& item : tilePyramid.tiles) {
-            static_cast<GeoJSONTile*>(item.second.get())->updateData(data->getTile(item.first.canonical));
+        if (data) {
+            for (auto const& item : tilePyramid.tiles) {
+                static_cast<GeoJSONTile*>(item.second.get())->updateData(data->getTile(item.first.canonical));
+            }
+        } else {
+            tilePyramid.tiles.clear();
+            tilePyramid.renderTiles.clear();
         }
+    }
+
+    if (!data) {
+        return;
     }
 
     tilePyramid.update(layers,


### PR DESCRIPTION
In some circumstances, two different objects might get the same memory address if the former has been deleted before the latter gets constructed. Thus, we cannot rely solely on pointer comparsion when checking whether to update the tile data in `RenderGeoJSONSource::tylePiramid`.

Fixes #9868.