### PR TITLE
Still mode optimizations

### DIFF
--- a/src/mbgl/style/style_impl.cpp
+++ b/src/mbgl/style/style_impl.cpp
@@ -88,7 +88,7 @@ void Style::Impl::parse(const std::string& json_) {
     }
 
     mutated = false;
-    loaded = true;
+    loaded = false;
     json = json_;
 
     sources.clear();
@@ -118,6 +118,7 @@ void Style::Impl::parse(const std::string& json_) {
     spriteLoader->load(parser.spriteURL, scheduler, fileSource);
     glyphURL = parser.glyphURL;
 
+    loaded = true;
     observer->onStyleLoaded();
 }
 


### PR DESCRIPTION
Move last bits of core changes from https://github.com/mapbox/mapbox-gl-native/pull/9689 into a separate PR.

Two important changes included:

1) When parsing a style, there are lots of intermediary `onUpdate` calls triggered e.g. when adding a source and/or layer that could be safely avoided.

2) In still mode, we don't need to run intermediary render calls while the style is incomplete (loading). This also saves a lot of time, reducing the amount of render calls to ~1 in most cases.