### PR TITLE
[core] Reset zoom history state in still mode

### DIFF
--- a/src/mbgl/map/zoom_history.hpp
+++ b/src/mbgl/map/zoom_history.hpp
@@ -29,7 +29,7 @@ struct ZoomHistory {
         if (lastFloorZoom > floorZ) {
             lastIntegerZoom = floorZ + 1;
             lastIntegerZoomTime = now == Clock::time_point::max() ? zero : now;
-        } else if (lastFloorZoom < floorZ || lastIntegerZoom != floorZ) {
+        } else if (lastFloorZoom < floorZ) {
             lastIntegerZoom = floorZ;
             lastIntegerZoomTime = now == Clock::time_point::max() ? zero : now;
         }

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -68,8 +68,15 @@ void Renderer::Impl::setObserver(RendererObserver* observer_) {
 }
 
 void Renderer::Impl::render(const UpdateParameters& updateParameters) {
-    // Don't load/render anyting in still mode until explicitly requested.
-    if (updateParameters.mode == MapMode::Still && !updateParameters.stillImageRequest) return;
+    if (updateParameters.mode == MapMode::Still) {
+        // Don't load/render anyting in still mode until explicitly requested.
+        if (!updateParameters.stillImageRequest) {
+            return;
+        }
+
+        // Reset zoom history state.
+        zoomHistory.first = true;
+    }
     
     assert(BackendScope::exists());
     

--- a/test/api/zoom_history.cpp
+++ b/test/api/zoom_history.cpp
@@ -62,4 +62,10 @@ TEST(API, ZoomHistory) {
     // ZoomHistory.lastIntegerZoom should be 0.
     map->setZoom(0.5);
     test::checkImage("test/fixtures/zoom_history", frontend.render(*map), 0.0002);
+
+    map->setZoom(1.0);
+    frontend.render(*map);
+
+    map->setZoom(0.5);
+    test::checkImage("test/fixtures/zoom_history", frontend.render(*map), 0.0002);
 }


### PR DESCRIPTION
```
$ node platform/node/test/render.test.js --recycle-map \
    "line-dasharray/slant" \
    "line-dasharray/literal--line-width-composite-function"
* passed line-dasharray slant
* failed line-dasharray literal--line-width-composite-function
1 passed (50.0%)
1 failed (50.0%)
```

| expected | actual | diff |
| -- | -- | -- |
| ![expected](https://user-images.githubusercontent.com/76133/29885386-441976aa-8dbf-11e7-96cf-3fb2bb6b6999.png) | ![actual](https://user-images.githubusercontent.com/76133/29885388-491ed74e-8dbf-11e7-8533-f469bcd97fa8.png) | ![diff](https://user-images.githubusercontent.com/76133/29885396-500b38fe-8dbf-11e7-911a-fe9b160a92a4.png) |

This is an edge case from the issue reported in https://github.com/mapbox/mapbox-gl-native/pull/9760. When switching from a higher zoom level to a lower one, we might end up evaluating render layers for _zoom + 1_ which causes the blurred lines.