### PR TITLE
Update gl-js SHA + ignore fill-extrusion-multiple test

### DIFF
--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -21,6 +21,7 @@
   "render-tests/debug/tile": "https://github.com/mapbox/mapbox-gl-native/issues/3841",
   "render-tests/extent/1024-circle": "needs investigation",
   "render-tests/extent/1024-symbol": "needs investigation",
+  "render-tests/fill-extrusion-multiple/multiple": "https://github.com/mapbox/mapbox-gl-native/issues/9894",
   "render-tests/fill-extrusion-pattern/@2x": "https://github.com/mapbox/mapbox-gl-js/issues/3327",
   "render-tests/fill-extrusion-pattern/function-2": "https://github.com/mapbox/mapbox-gl-js/issues/3327",
   "render-tests/fill-extrusion-pattern/function": "https://github.com/mapbox/mapbox-gl-js/issues/3327",


### PR DESCRIPTION
Updates gl-js to https://github.com/mapbox/mapbox-gl-js/pull/5101 and ignores that test, pending https://github.com/mapbox/mapbox-gl-native/issues/9894.