### PR TITLE
MAS 2.2.3

### DIFF
--- a/platform/android/dependencies.gradle
+++ b/platform/android/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
     versionCode = 11
     versionName = "5.0.0"
 
-    mapboxServicesVersion = "2.2.2"
+    mapboxServicesVersion = "2.2.3"
     supportLibVersion = "25.3.1"
     espressoVersion = '2.2.2'
     testRunnerVersion = '0.5'


### PR DESCRIPTION
- Bumps MAS version number to `2.2.3`

👀 @cammace  