### PR TITLE
[core] Relayout tiles cherry-picked from the cache

### DIFF
--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -40,7 +40,6 @@
   "render-tests/regressions/mapbox-gl-js#2305": "https://github.com/mapbox/mapbox-gl-native/issues/6927",
   "render-tests/regressions/mapbox-gl-js#3682": "https://github.com/mapbox/mapbox-gl-js/issues/3682",
   "render-tests/regressions/mapbox-gl-native#7357": "https://github.com/mapbox/mapbox-gl-native/issues/7357",
-  "render-tests/regressions/mapbox-gl-native#9900": "skip - https://github.com/mapbox/mapbox-gl-native/pull/9905",
   "render-tests/runtime-styling/image-add-sdf": "https://github.com/mapbox/mapbox-gl-native/issues/9847",
   "render-tests/runtime-styling/paint-property-fill-flat-to-extrude": "https://github.com/mapbox/mapbox-gl-native/issues/6745",
   "render-tests/runtime-styling/set-style-paint-property-fill-flat-to-extrude": "https://github.com/mapbox/mapbox-gl-native/issues/6745",

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -186,6 +186,8 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         renderSources.emplace(entry.first, std::move(renderSource));
     }
 
+    const bool hasImageDiff = !(imageDiff.added.empty() && imageDiff.removed.empty() && imageDiff.changed.empty());
+
     // Update all sources.
     for (const auto& source : *sourceImpls) {
         std::vector<Immutable<Layer::Impl>> filteredLayers;
@@ -203,11 +205,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
                 needsRendering = true;
             }
 
-            if (!needsRelayout && (
-                hasLayoutDifference(layerDiff, layer->id) ||
-                !imageDiff.added.empty() ||
-                !imageDiff.removed.empty() ||
-                !imageDiff.changed.empty())) {
+            if (!needsRelayout && (hasImageDiff || hasLayoutDifference(layerDiff, layer->id))) {
                 needsRelayout = true;
             }
 

--- a/src/mbgl/renderer/tile_pyramid.hpp
+++ b/src/mbgl/renderer/tile_pyramid.hpp
@@ -63,8 +63,6 @@ public:
 
     bool enabled = false;
 
-    void removeStaleTiles(const std::set<OverscaledTileID>&);
-
     std::map<OverscaledTileID, std::unique_ptr<Tile>> tiles;
     TileCache cache;
 


### PR DESCRIPTION
Imagine the following scenario:

1. A map is created with a given vector source `source`, layer `foo` and LatLngZoom position **1**.
Render occurs: A render tile for the tile coordinate corresponding to position 1 is created, passing layer `foo` via [tile.setLayers](https://github.com/mapbox/mapbox-gl-native/blob/master/src/mbgl/renderer/tile_pyramid.cpp#L143).

2. The map now goes to position **2**, far enough to be outside of the render source's tile pyramid. Also, a new layer `bar` is added to the style.
Render occurs: A render tile for the tile coordinate corresponding to position **2** is created.

3. The map now goes back to position **1**.
Render occurs: The previously cached/retained render tile generated for position **1** is reused, and no relayout is made because there were neither [layout differences](https://github.com/mapbox/mapbox-gl-native/blob/master/src/mbgl/renderer/renderer_impl.cpp#L207) nor [image diffs](https://github.com/mapbox/mapbox-gl-native/blob/master/src/mbgl/renderer/renderer_impl.cpp#L208-L210). Because `setLayout` never occurs, the tile renders without the layout from layer `bar` :boom:

This PR enforces relayout for _all_ retained tiles if `needsRelayout` is true - which includes not only those retained tiles that are actually rendered. Relayout is also needed when a previous layer associated with a given source has been removed.

Added `API.RecycleMapRefreshRenderTileLayers` utest to verify.

Fixes #9900.
