### PR TITLE
[core] Fast tileCount with help from @mapbox/sphericalmercator module

### DIFF
--- a/include/mbgl/storage/offline.hpp
+++ b/include/mbgl/storage/offline.hpp
@@ -31,12 +31,14 @@ public:
 
     /* Private */
     std::vector<CanonicalTileID> tileCover(SourceType, uint16_t tileSize, const Range<uint8_t>& zoomRange) const;
-
+    unsigned long tileCount(SourceType, uint16_t tileSize, const Range<uint8_t>& zoomRange) const;
     const std::string styleURL;
     const LatLngBounds bounds;
     const double minZoom;
     const double maxZoom;
     const float pixelRatio;
+private:
+    Range<uint8_t> coveringZoomRange(SourceType, uint16_t tileSize, const Range<uint8_t>& zoomRange) const;
 };
 
 /*

--- a/platform/default/mbgl/storage/offline.cpp
+++ b/platform/default/mbgl/storage/offline.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/storage/offline.hpp>
 #include <mbgl/util/tile_cover.hpp>
 #include <mbgl/util/tileset.hpp>
+#include <mbgl/util/projection.hpp>
 
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
@@ -24,6 +25,31 @@ OfflineTilePyramidRegionDefinition::OfflineTilePyramidRegionDefinition(
 }
 
 std::vector<CanonicalTileID> OfflineTilePyramidRegionDefinition::tileCover(SourceType type, uint16_t tileSize, const Range<uint8_t>& zoomRange) const {
+    const Range<uint8_t> clampedZoomRange = coveringZoomRange(type, tileSize, zoomRange);
+
+    std::vector<CanonicalTileID> result;
+
+    for (uint8_t z = clampedZoomRange.min; z <= clampedZoomRange.max; z++) {
+        for (const auto& tile : util::tileCover(bounds, z)) {
+            result.emplace_back(tile.canonical);
+        }
+    }
+
+    return result;
+}
+
+unsigned long OfflineTilePyramidRegionDefinition::tileCount(SourceType type, uint16_t tileSize, const Range<uint8_t>& zoomRange) const {
+    
+    const Range<uint8_t> clampedZoomRange = coveringZoomRange(type, tileSize, zoomRange);
+    unsigned long result = 0;;
+    for (uint8_t z = clampedZoomRange.min; z <= clampedZoomRange.max; z++) {
+        result +=  util::tileCount(bounds, z, tileSize);
+    }
+
+    return result;
+}
+
+Range<uint8_t> OfflineTilePyramidRegionDefinition::coveringZoomRange(SourceType type, uint16_t tileSize, const Range<uint8_t>& zoomRange) const {
     double minZ = std::max<double>(util::coveringZoomLevel(minZoom, type, tileSize), zoomRange.min);
     double maxZ = std::min<double>(util::coveringZoomLevel(maxZoom, type, tileSize), zoomRange.max);
 
@@ -31,16 +57,7 @@ std::vector<CanonicalTileID> OfflineTilePyramidRegionDefinition::tileCover(Sourc
     assert(maxZ >= 0);
     assert(minZ < std::numeric_limits<uint8_t>::max());
     assert(maxZ < std::numeric_limits<uint8_t>::max());
-
-    std::vector<CanonicalTileID> result;
-
-    for (uint8_t z = minZ; z <= maxZ; z++) {
-        for (const auto& tile : util::tileCover(bounds, z)) {
-            result.emplace_back(tile.canonical);
-        }
-    }
-
-    return result;
+    return { static_cast<uint8_t>(minZ), static_cast<uint8_t>(maxZ) };
 }
 
 OfflineRegionDefinition decodeOfflineRegionDefinition(const std::string& region) {

--- a/platform/default/mbgl/storage/offline_download.cpp
+++ b/platform/default/mbgl/storage/offline_download.cpp
@@ -80,7 +80,7 @@ OfflineRegionStatus OfflineDownload::getStatus() const {
         auto handleTiledSource = [&] (const variant<std::string, Tileset>& urlOrTileset, const uint16_t tileSize) {
             if (urlOrTileset.is<Tileset>()) {
                 result.requiredResourceCount +=
-                    definition.tileCover(type, tileSize, urlOrTileset.get<Tileset>().zoomRange).size();
+                    definition.tileCount(type, tileSize, urlOrTileset.get<Tileset>().zoomRange);
             } else {
                 result.requiredResourceCount += 1;
                 const auto& url = urlOrTileset.get<std::string>();
@@ -90,7 +90,7 @@ OfflineRegionStatus OfflineDownload::getStatus() const {
                     optional<Tileset> tileset = style::conversion::convertJSON<Tileset>(*sourceResponse->data, error);
                     if (tileset) {
                         result.requiredResourceCount +=
-                            definition.tileCover(type, tileSize, (*tileset).zoomRange).size();
+                            definition.tileCount(type, tileSize, (*tileset).zoomRange);
                     }
                 } else {
                     result.requiredResourceCountIsPrecise = false;

--- a/src/mbgl/util/tile_cover.cpp
+++ b/src/mbgl/util/tile_cover.cpp
@@ -169,5 +169,26 @@ std::vector<UnwrappedTileID> tileCover(const TransformState& state, int32_t z) {
         z);
 }
 
+// Taken from https://github.com/mapbox/sphericalmercator#xyzbbox-zoom-tms_style-srs
+// Computes the projected tiles for the lower left and uppoer right points of the bounds
+// and uses that to compute the tile cover count
+unsigned long tileCount(const LatLngBounds& bounds, uint8_t zoom, uint16_t tileSize_){
+
+    auto sw = Projection::project(bounds.southwest().wrapped(), zoom, tileSize_);
+    auto ne = Projection::project(bounds.northeast().wrapped(), zoom, tileSize_);
+
+    auto x1 = floor(sw.x/ tileSize_);
+    auto x2 = floor((ne.x - 1) / tileSize_);
+    auto y1 = floor(sw.y/ tileSize_);
+    auto y2 = floor((ne.y - 1) / tileSize_);
+
+    auto minX = std::fmax(std::min(x1, x2), 0);
+    auto maxX = std::max(x1, x2);
+    auto minY = (std::pow(2, zoom) - 1) - std::max(y1, y2);
+    auto maxY = (std::pow(2, zoom) - 1) - std::fmax(std::min(y1, y2), 0);
+    
+    return (maxX - minX + 1) * (maxY - minY + 1);
+}
+
 } // namespace util
 } // namespace mbgl

--- a/src/mbgl/util/tile_cover.hpp
+++ b/src/mbgl/util/tile_cover.hpp
@@ -18,5 +18,8 @@ int32_t coveringZoomLevel(double z, SourceType type, uint16_t tileSize);
 std::vector<UnwrappedTileID> tileCover(const TransformState&, int32_t z);
 std::vector<UnwrappedTileID> tileCover(const LatLngBounds&, int32_t z);
 
+// Compute only the count of tiles needed for tileCover
+unsigned long tileCount(const LatLngBounds&, uint8_t z, uint16_t tileSize);
+
 } // namespace util
 } // namespace mbgl

--- a/test/storage/offline.test.cpp
+++ b/test/storage/offline.test.cpp
@@ -52,3 +52,11 @@ TEST(OfflineTilePyramidRegionDefinition, TileCoverWrapped) {
     EXPECT_EQ((std::vector<CanonicalTileID>{ { 0, 0, 0 } }),
               region.tileCover(SourceType::Vector, 512, { 0, 22 }));
 }
+
+TEST(OfflineTilePyramidRegionDefinition, TileCount) {
+    OfflineTilePyramidRegionDefinition region("", sanFranciscoWrapped, 0, 22, 1.0);
+
+    //These numbers match the count from tileCover().size().
+    EXPECT_EQ(38424u, region.tileCount(SourceType::Vector, 512, { 10, 18 }));
+    EXPECT_EQ(9675240u, region.tileCount(SourceType::Vector, 512, { 3, 22 }));
+}

--- a/test/util/tile_cover.test.cpp
+++ b/test/util/tile_cover.test.cpp
@@ -84,3 +84,12 @@ TEST(TileCover, SanFranciscoZ0Wrapped) {
     EXPECT_EQ((std::vector<UnwrappedTileID>{ { 0, 1, 0 } }),
               util::tileCover(sanFranciscoWrapped, 0));
 }
+
+TEST(TileCount, SanFranciscoZ10) {
+    EXPECT_EQ(4u, util::tileCount(sanFrancisco, 10, util::tileSize));
+}
+
+TEST(TileCount, SanFranciscoZ22) {
+    EXPECT_EQ(7254450u, util::tileCount(sanFrancisco, 22, util::tileSize));
+}
+


### PR DESCRIPTION
Closes #9675 

Implement a separate `util::tileCount()` method for computing the number of tiles that need to be downloaded for offline packs.

The time for computing tile count for a bounding box around SF went from *12070 ms* to *1 ms*. 

The failed attempts include: 
* Running `tileCover` on the max zoom, and getting parents of those tiles up to min zoom. I was surprised by the cost of `boost::hash_combine` which made this more expensive than running `tileCover` for every zoom level.
* Computing the number of tiles needed at each zoom level based on `LatLng` extents of the bounding box vs `LatLng` extents of a tile. This approached had way better performance but suffered from floating point errors due to the precision of `LatLng` for high zoom levels. 

Thanks to @jfirebaugh for pointing me to [@mapbox/sphericalmercator](https://github.com/mapbox/sphericalmercator#xyzbbox-zoom-tms_style-srs)