### PR TITLE
[android] Fix is download complete

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegionStatus.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegionStatus.java
@@ -80,7 +80,7 @@ public class OfflineRegionStatus {
    * @return true if download is complete, false if not
    */
   public boolean isComplete() {
-    return (completedResourceCount == requiredResourceCount);
+    return (completedResourceCount == requiredResourceCount) && downloadState == OfflineRegion.STATE_INACTIVE;
   }
 
   /**


### PR DESCRIPTION
Fixes #9908 

- ~~Prevents calling `observer->statusChanged(status);` when the download is deactivated which caused two calls to [`onStatusChanged`](https://github.com/mapbox/mapbox-gl-native/blob/master/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/offline/OfflineActivity.java#L258) making [`status.isComplete()`](https://github.com/mapbox/mapbox-gl-native/blob/master/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/offline/OfflineActivity.java#L264) `true` twice as well.~~
- Fixes `OfflineRegionStatus#isComplete`:
  - A download is complete when `completedResourceCount` and `requiredResourceCount` match and the `downloadState` is `OfflineRegion.STATE_INACTIVE` which prevents reporting _is completed_ twice.

👀 @fabian-guerra @zugaldia 