### PR TITLE
Preserve depth buffer between 3D layers + optimize render order

### DIFF
--- a/include/mbgl/renderer/renderer_backend.hpp
+++ b/include/mbgl/renderer/renderer_backend.hpp
@@ -35,6 +35,8 @@ public:
     // set to the current state.
     virtual void bind() = 0;
 
+    virtual Size getFramebufferSize() const = 0;
+
 protected:
     // Called with the name of an OpenGL extension that should be loaded. RendererBackend implementations
     // must call the API-specific version that obtains the function pointer for this function,

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -115,6 +115,10 @@ void NativeMapView::bind() {
     setViewport(0, 0, getFramebufferSize());
 }
 
+mbgl::Size NativeMapView::getFramebufferSize() const {
+    return { static_cast<uint32_t>(fbWidth), static_cast<uint32_t>(fbHeight) };
+}
+
 /**
  * From mbgl::RendererBackend.
  */
@@ -1426,10 +1430,6 @@ void NativeMapView::_destroySurface() {
         ANativeWindow_release(window);
         window = nullptr;
     }
-}
-
-mbgl::Size NativeMapView::getFramebufferSize() const {
-    return { static_cast<uint32_t>(fbWidth), static_cast<uint32_t>(fbHeight) };
 }
 
 void NativeMapView::updateAssumedState() {

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -58,6 +58,9 @@ public:
     // mbgl::RendererBackend //
 
     void bind() override;
+
+    mbgl::Size getFramebufferSize() const override;
+
     void updateAssumedState() override;
 
     // Deprecated //
@@ -281,8 +284,6 @@ private:
     void _destroySurface();
 
     EGLConfig chooseConfig(const EGLConfig configs[], EGLint numConfigs);
-
-    mbgl::Size getFramebufferSize() const;
 
     void updateFps();
 

--- a/platform/default/mbgl/gl/headless_backend.cpp
+++ b/platform/default/mbgl/gl/headless_backend.cpp
@@ -64,6 +64,10 @@ void HeadlessBackend::bind() {
     context_.viewport = { 0, 0, size };
 }
 
+Size HeadlessBackend::getFramebufferSize() const {
+    return size;
+}
+
 void HeadlessBackend::updateAssumedState() {
     // no-op
 }

--- a/platform/default/mbgl/gl/headless_backend.hpp
+++ b/platform/default/mbgl/gl/headless_backend.hpp
@@ -15,6 +15,7 @@ public:
     ~HeadlessBackend() override;
 
     void bind() override;
+    Size getFramebufferSize() const override;
     void updateAssumedState() override;
 
     void setSize(Size);

--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -37,7 +37,7 @@ public:
     void invalidate();
 
     mbgl::Size getSize() const;
-    mbgl::Size getFramebufferSize() const;
+    mbgl::Size getFramebufferSize() const override;
 
     // mbgl::RendererBackend implementation
     void bind() override;

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -5464,6 +5464,10 @@ public:
         }
     }
 
+    mbgl::Size getFramebufferSize() const override {
+        return nativeView.framebufferSize;
+    }
+
     void onCameraWillChange(mbgl::MapObserver::CameraChangeMode mode) override {
         bool animated = mode == mbgl::MapObserver::CameraChangeMode::Animated;
         [nativeView cameraWillChangeAnimated:animated];

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2883,6 +2883,10 @@ public:
         setViewport(0, 0, nativeView.framebufferSize);
     }
 
+    mbgl::Size getFramebufferSize() const override {
+        return nativeView.framebufferSize;
+    }
+
     mbgl::PremultipliedImage readStillImage() {
         return readFramebuffer(nativeView.framebufferSize);
     }

--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -17,7 +17,6 @@
   "render-tests/debug/tile": "https://github.com/mapbox/mapbox-gl-native/issues/3841",
   "render-tests/extent/1024-circle": "needs investigation",
   "render-tests/extent/1024-symbol": "needs investigation",
-  "render-tests/fill-extrusion-multiple/multiple": "https://github.com/mapbox/mapbox-gl-native/issues/9894",
   "render-tests/fill-extrusion-pattern/@2x": "https://github.com/mapbox/mapbox-gl-js/issues/3327",
   "render-tests/fill-extrusion-pattern/function-2": "https://github.com/mapbox/mapbox-gl-js/issues/3327",
   "render-tests/fill-extrusion-pattern/function": "https://github.com/mapbox/mapbox-gl-js/issues/3327",

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1505,7 +1505,7 @@ QMapboxGLPrivate::QMapboxGLPrivate(QMapboxGL *q, const QMapboxGLSettings &settin
                                              static_cast<mbgl::GLContextMode>(settings.contextMode())),
             *this);
     connect(frontend.get(), SIGNAL(updated()), this, SLOT(invalidate()));
-    
+
     mapObj = std::make_unique<mbgl::Map>(
             *frontend,
             *this, sanitizedSize(size),
@@ -1528,18 +1528,18 @@ QMapboxGLPrivate::~QMapboxGLPrivate()
 {
 }
 
-mbgl::Size QMapboxGLPrivate::framebufferSize() const {
+mbgl::Size QMapboxGLPrivate::getFramebufferSize() const {
     return sanitizedSize(fbSize);
 }
 
 void QMapboxGLPrivate::updateAssumedState() {
     assumeFramebufferBinding(fbObject);
-    assumeViewport(0, 0, framebufferSize());
+    assumeViewport(0, 0, getFramebufferSize());
 }
 
 void QMapboxGLPrivate::bind() {
     setFramebufferBinding(fbObject);
-    setViewport(0, 0, framebufferSize());
+    setViewport(0, 0, getFramebufferSize());
 }
 
 void QMapboxGLPrivate::invalidate()

--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -20,10 +20,10 @@ public:
     explicit QMapboxGLPrivate(QMapboxGL *, const QMapboxGLSettings &, const QSize &size, qreal pixelRatio);
     virtual ~QMapboxGLPrivate();
 
-    mbgl::Size framebufferSize() const;
 
     // mbgl::RendererBackend implementation.
     void bind() final;
+    mbgl::Size getFramebufferSize() const final;
     void updateAssumedState() final;
     void activate() final {}
     void deactivate() final {}

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -456,17 +456,16 @@ Framebuffer Context::createFramebuffer(const Texture& color) {
 
 Framebuffer
 Context::createFramebuffer(const Texture& color,
-                           const Renderbuffer<RenderbufferType::DepthComponent>& depth) {
-    if (color.size != depth.size) {
+                           const Renderbuffer<RenderbufferType::DepthComponent>& depthTarget) {
+    if (color.size != depthTarget.size) {
         throw std::runtime_error("Renderbuffer size mismatch");
     }
     auto fbo = createFramebuffer();
     bindFramebuffer = fbo;
-    MBGL_CHECK_ERROR(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
-                                            color.texture, 0));
-    MBGL_CHECK_ERROR(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depth.renderbuffer));
+    MBGL_CHECK_ERROR(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, color.texture, 0));
+    MBGL_CHECK_ERROR(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthTarget.renderbuffer));
     checkFramebuffer();
-    return { color.size, std::move(fbo) };
+    return { depthTarget.size, std::move(fbo) };
 }
 
 UniqueTexture

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -454,15 +454,10 @@ Framebuffer Context::createFramebuffer(const Texture& color) {
     return { color.size, std::move(fbo) };
 }
 
-Framebuffer
-Context::createFramebuffer(const Texture& color,
-                           const Renderbuffer<RenderbufferType::DepthComponent>& depthTarget) {
-    auto fbo = createFramebuffer();
-    bindFramebuffer = fbo;
-    MBGL_CHECK_ERROR(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, color.texture, 0));
+void
+Context::attachRenderbuffer(const Renderbuffer<RenderbufferType::DepthComponent>& depthTarget) {
     MBGL_CHECK_ERROR(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthTarget.renderbuffer));
     checkFramebuffer();
-    return { depthTarget.size, std::move(fbo) };
 }
 
 UniqueTexture

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -462,11 +462,8 @@ Context::createFramebuffer(const Texture& color,
     }
     auto fbo = createFramebuffer();
     bindFramebuffer = fbo;
-    // TODO: revert this; just for debugging on CI:
-    GLuint depthInt = depthTarget.renderbuffer;
-    Log::Info(Event::General, "bound framebuffer: %d; renderbuffer name: %d", bindFramebuffer, depthInt);
     MBGL_CHECK_ERROR(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, color.texture, 0));
-    MBGL_CHECK_ERROR(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthInt));
+    MBGL_CHECK_ERROR(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthTarget.renderbuffer));
     checkFramebuffer();
     return { depthTarget.size, std::move(fbo) };
 }

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -462,8 +462,11 @@ Context::createFramebuffer(const Texture& color,
     }
     auto fbo = createFramebuffer();
     bindFramebuffer = fbo;
+    // TODO: revert this; just for debugging on CI:
+    GLuint depthInt = depthTarget.renderbuffer;
+    Log::Info(Event::General, "bound framebuffer: %d; renderbuffer name: %d", bindFramebuffer, depthInt);
     MBGL_CHECK_ERROR(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, color.texture, 0));
-    MBGL_CHECK_ERROR(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthTarget.renderbuffer));
+    MBGL_CHECK_ERROR(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthInt));
     checkFramebuffer();
     return { depthTarget.size, std::move(fbo) };
 }

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -454,10 +454,19 @@ Framebuffer Context::createFramebuffer(const Texture& color) {
     return { color.size, std::move(fbo) };
 }
 
-void
-Context::attachRenderbuffer(const Renderbuffer<RenderbufferType::DepthComponent>& depthTarget) {
-    MBGL_CHECK_ERROR(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthTarget.renderbuffer));
+Framebuffer
+Context::createFramebuffer(const Texture& color,
+                           const Renderbuffer<RenderbufferType::DepthComponent>& depth) {
+    if (color.size != depth.size) {
+        throw std::runtime_error("Renderbuffer size mismatch");
+    }
+    auto fbo = createFramebuffer();
+    bindFramebuffer = fbo;
+    MBGL_CHECK_ERROR(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                                            color.texture, 0));
+    MBGL_CHECK_ERROR(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depth.renderbuffer));
     checkFramebuffer();
+    return { color.size, std::move(fbo) };
 }
 
 UniqueTexture

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -96,8 +96,8 @@ public:
     Framebuffer createFramebuffer(const Texture&,
                                   const Renderbuffer<RenderbufferType::DepthStencil>&);
     Framebuffer createFramebuffer(const Texture&);
-    Framebuffer createFramebuffer(const Texture&,
-                                  const Renderbuffer<RenderbufferType::DepthComponent>&);
+
+    void attachRenderbuffer(const Renderbuffer<RenderbufferType::DepthComponent>&);
 
     template <typename Image,
               TextureFormat format = Image::channels == 4 ? TextureFormat::RGBA

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -96,8 +96,8 @@ public:
     Framebuffer createFramebuffer(const Texture&,
                                   const Renderbuffer<RenderbufferType::DepthStencil>&);
     Framebuffer createFramebuffer(const Texture&);
-
-    void attachRenderbuffer(const Renderbuffer<RenderbufferType::DepthComponent>&);
+    Framebuffer createFramebuffer(const Texture&,
+                                  const Renderbuffer<RenderbufferType::DepthComponent>&);
 
     template <typename Image,
               TextureFormat format = Image::channels == 4 ? TextureFormat::RGBA

--- a/src/mbgl/gl/renderbuffer.hpp
+++ b/src/mbgl/gl/renderbuffer.hpp
@@ -16,6 +16,15 @@ public:
     using type = std::integral_constant<RenderbufferType, renderbufferType>;
     Size size;
     UniqueRenderbuffer renderbuffer;
+
+    void shouldClear(bool clear) {
+        dirty = clear;
+    }
+    bool needsClearing() {
+        return dirty;
+    }
+
+private:
     bool dirty;
 };
 

--- a/src/mbgl/gl/renderbuffer.hpp
+++ b/src/mbgl/gl/renderbuffer.hpp
@@ -12,6 +12,7 @@ public:
     using type = std::integral_constant<RenderbufferType, renderbufferType>;
     Size size;
     gl::UniqueRenderbuffer renderbuffer;
+    bool dirty = false;
 };
 
 } // namespace gl

--- a/src/mbgl/gl/renderbuffer.hpp
+++ b/src/mbgl/gl/renderbuffer.hpp
@@ -9,10 +9,14 @@ namespace gl {
 template <RenderbufferType renderbufferType>
 class Renderbuffer {
 public:
+    Renderbuffer(Size size_, UniqueRenderbuffer renderbuffer_, bool dirty_ = false)
+        : size(std::move(size_)), renderbuffer(std::move(renderbuffer_)), dirty(dirty_) {
+    }
+
     using type = std::integral_constant<RenderbufferType, renderbufferType>;
     Size size;
-    gl::UniqueRenderbuffer renderbuffer;
-    bool dirty = false;
+    UniqueRenderbuffer renderbuffer;
+    bool dirty;
 };
 
 } // namespace gl

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -52,7 +52,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters, RenderSource*
     }
 
     if (parameters.pass == RenderPass::Pass3D) {
-        const auto size = parameters.context.viewport.getCurrentValue().size;
+        const auto& size = parameters.staticData.backendSize;
 
         if (!renderTexture || renderTexture->getSize() != size) {
             renderTexture = OffscreenTexture(parameters.context, size, *parameters.staticData.depthRenderbuffer);
@@ -125,7 +125,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters, RenderSource*
     } else if (parameters.pass == RenderPass::Translucent) {
         parameters.context.bindTexture(renderTexture->getTexture());
 
-        const auto size = parameters.context.viewport.getCurrentValue().size;
+        const auto& size = parameters.staticData.backendSize;
 
         mat4 viewportMat;
         matrix::ortho(viewportMat, 0, size.width, size.height, 0, 0, 1);

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -37,8 +37,9 @@ void RenderFillExtrusionLayer::transition(const TransitionParameters& parameters
 void RenderFillExtrusionLayer::evaluate(const PropertyEvaluationParameters& parameters) {
     evaluated = unevaluated.evaluate(parameters);
 
-    passes = (evaluated.get<style::FillExtrusionOpacity>() > 0) ? RenderPass::Translucent
-                                                         : RenderPass::None;
+    passes = (evaluated.get<style::FillExtrusionOpacity>() > 0)
+                 ? (RenderPass::Translucent | RenderPass::Pass3D)
+                 : RenderPass::None;
 }
 
 bool RenderFillExtrusionLayer::hasTransition() const {
@@ -50,113 +51,99 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters, RenderSource*
         return;
     }
 
-    const auto size = parameters.context.viewport.getCurrentValue().size;
+    if (parameters.pass == RenderPass::Pass3D) {
+        const auto size = parameters.context.viewport.getCurrentValue().size;
 
-    if (!parameters.staticData.extrusionTexture || parameters.staticData.extrusionTexture->getSize() != size) {
-        parameters.staticData.extrusionTexture = OffscreenTexture(parameters.context, size, OffscreenTextureAttachment::Depth);
+        if (!renderTexture || renderTexture->getSize() != size) {
+            renderTexture = OffscreenTexture(parameters.context, size);
+        }
+
+        renderTexture->bind();
+        renderTexture->attachRenderbuffer(*parameters.staticData.depthRenderbuffer);
+
+        parameters.context.setStencilMode(gl::StencilMode::disabled());
+        optional<float> depthClearValue = {};
+        if (parameters.staticData.depthRenderbuffer->dirty) depthClearValue = 1.0;
+        parameters.context.clear(Color{ 0.0f, 0.0f, 0.0f, 0.0f }, depthClearValue, {});
+        parameters.staticData.depthRenderbuffer->dirty = false;
+
+        if (evaluated.get<FillExtrusionPattern>().from.empty()) {
+            for (const RenderTile& tile : renderTiles) {
+                assert(dynamic_cast<FillExtrusionBucket*>(tile.tile.getBucket(*baseImpl)));
+                FillExtrusionBucket& bucket =
+                    *reinterpret_cast<FillExtrusionBucket*>(tile.tile.getBucket(*baseImpl));
+
+                parameters.programs.fillExtrusion.get(evaluated).draw(
+                    parameters.context, gl::Triangles(),
+                    parameters.depthModeFor3D(gl::DepthMode::ReadWrite),
+                    gl::StencilMode::disabled(), parameters.colorModeForRenderPass(),
+                    FillExtrusionUniforms::values(
+                        tile.translatedClipMatrix(evaluated.get<FillExtrusionTranslate>(),
+                                                  evaluated.get<FillExtrusionTranslateAnchor>(),
+                                                  parameters.state),
+                        parameters.state, parameters.evaluatedLight),
+                    *bucket.vertexBuffer, *bucket.indexBuffer, bucket.triangleSegments,
+                    bucket.paintPropertyBinders.at(getID()), evaluated, parameters.state.getZoom(),
+                    getID());
+            }
+        } else {
+            optional<ImagePosition> imagePosA =
+                parameters.imageManager.getPattern(evaluated.get<FillExtrusionPattern>().from);
+            optional<ImagePosition> imagePosB =
+                parameters.imageManager.getPattern(evaluated.get<FillExtrusionPattern>().to);
+
+            if (!imagePosA || !imagePosB) {
+                return;
+            }
+
+            parameters.imageManager.bind(parameters.context, 0);
+
+            for (const RenderTile& tile : renderTiles) {
+                assert(dynamic_cast<FillExtrusionBucket*>(tile.tile.getBucket(*baseImpl)));
+                FillExtrusionBucket& bucket =
+                    *reinterpret_cast<FillExtrusionBucket*>(tile.tile.getBucket(*baseImpl));
+
+                parameters.programs.fillExtrusionPattern.get(evaluated).draw(
+                    parameters.context, gl::Triangles(),
+                    parameters.depthModeFor3D(gl::DepthMode::ReadWrite),
+                    gl::StencilMode::disabled(), parameters.colorModeForRenderPass(),
+                    FillExtrusionPatternUniforms::values(
+                        tile.translatedClipMatrix(evaluated.get<FillExtrusionTranslate>(),
+                                                  evaluated.get<FillExtrusionTranslateAnchor>(),
+                                                  parameters.state),
+                        parameters.imageManager.getPixelSize(), *imagePosA, *imagePosB,
+                        evaluated.get<FillExtrusionPattern>(), tile.id, parameters.state,
+                        -std::pow(2, tile.id.canonical.z) / util::tileSize / 8.0f,
+                        parameters.evaluatedLight),
+                    *bucket.vertexBuffer, *bucket.indexBuffer, bucket.triangleSegments,
+                    bucket.paintPropertyBinders.at(getID()), evaluated, parameters.state.getZoom(),
+                    getID());
+            }
+        }
+
+    } else if (parameters.pass == RenderPass::Translucent) {
+        parameters.context.bindTexture(renderTexture->getTexture());
+
+        const auto size = parameters.context.viewport.getCurrentValue().size;
+
+        mat4 viewportMat;
+        matrix::ortho(viewportMat, 0, size.width, size.height, 0, 0, 1);
+
+        const Properties<>::PossiblyEvaluated properties;
+
+        parameters.programs.extrusionTexture.draw(
+            parameters.context, gl::Triangles(), gl::DepthMode::disabled(),
+            gl::StencilMode::disabled(), parameters.colorModeForRenderPass(),
+            ExtrusionTextureProgram::UniformValues{
+                uniforms::u_matrix::Value{ viewportMat }, uniforms::u_world::Value{ size },
+                uniforms::u_image::Value{ 0 },
+                uniforms::u_opacity::Value{ evaluated.get<FillExtrusionOpacity>() } },
+            parameters.staticData.extrusionTextureVertexBuffer,
+            parameters.staticData.quadTriangleIndexBuffer,
+            parameters.staticData.extrusionTextureSegments,
+            ExtrusionTextureProgram::PaintPropertyBinders{ properties, 0 }, properties,
+            parameters.state.getZoom(), getID());
     }
-
-    parameters.staticData.extrusionTexture->bind();
-
-    parameters.context.setStencilMode(gl::StencilMode::disabled());
-    parameters.context.setDepthMode(parameters.depthModeForSublayer(0, gl::DepthMode::ReadWrite));
-    parameters.context.clear(Color{ 0.0f, 0.0f, 0.0f, 0.0f }, 1.0f, {});
-
-    if (evaluated.get<FillExtrusionPattern>().from.empty()) {
-        for (const RenderTile& tile : renderTiles) {
-            assert(dynamic_cast<FillExtrusionBucket*>(tile.tile.getBucket(*baseImpl)));
-            FillExtrusionBucket& bucket = *reinterpret_cast<FillExtrusionBucket*>(tile.tile.getBucket(*baseImpl));
-
-            parameters.programs.fillExtrusion.get(evaluated).draw(
-                parameters.context,
-                gl::Triangles(),
-                parameters.depthModeForSublayer(0, gl::DepthMode::ReadWrite),
-                gl::StencilMode::disabled(),
-                parameters.colorModeForRenderPass(),
-                FillExtrusionUniforms::values(
-                    tile.translatedClipMatrix(evaluated.get<FillExtrusionTranslate>(),
-                                              evaluated.get<FillExtrusionTranslateAnchor>(),
-                                              parameters.state),
-                    parameters.state,
-                    parameters.evaluatedLight
-                ),
-                *bucket.vertexBuffer,
-                *bucket.indexBuffer,
-                bucket.triangleSegments,
-                bucket.paintPropertyBinders.at(getID()),
-                evaluated,
-                parameters.state.getZoom(),
-                getID());
-        }
-    } else {
-        optional<ImagePosition> imagePosA = parameters.imageManager.getPattern(evaluated.get<FillExtrusionPattern>().from);
-        optional<ImagePosition> imagePosB = parameters.imageManager.getPattern(evaluated.get<FillExtrusionPattern>().to);
-
-        if (!imagePosA || !imagePosB) {
-            return;
-        }
-
-        parameters.imageManager.bind(parameters.context, 0);
-
-        for (const RenderTile& tile : renderTiles) {
-            assert(dynamic_cast<FillExtrusionBucket*>(tile.tile.getBucket(*baseImpl)));
-            FillExtrusionBucket& bucket = *reinterpret_cast<FillExtrusionBucket*>(tile.tile.getBucket(*baseImpl));
-
-            parameters.programs.fillExtrusionPattern.get(evaluated).draw(
-                parameters.context,
-                gl::Triangles(),
-                parameters.depthModeForSublayer(0, gl::DepthMode::ReadWrite),
-                gl::StencilMode::disabled(),
-                parameters.colorModeForRenderPass(),
-                FillExtrusionPatternUniforms::values(
-                    tile.translatedClipMatrix(evaluated.get<FillExtrusionTranslate>(),
-                                              evaluated.get<FillExtrusionTranslateAnchor>(),
-                                              parameters.state),
-                    parameters.imageManager.getPixelSize(),
-                    *imagePosA,
-                    *imagePosB,
-                    evaluated.get<FillExtrusionPattern>(),
-                    tile.id,
-                    parameters.state,
-                    -std::pow(2, tile.id.canonical.z) / util::tileSize / 8.0f,
-                    parameters.evaluatedLight
-                ),
-                *bucket.vertexBuffer,
-                *bucket.indexBuffer,
-                bucket.triangleSegments,
-                bucket.paintPropertyBinders.at(getID()),
-                evaluated,
-                parameters.state.getZoom(),
-                getID());
-        }
-    }
-
-    parameters.backend.bind();
-    parameters.context.bindTexture(parameters.staticData.extrusionTexture->getTexture());
-
-    mat4 viewportMat;
-    matrix::ortho(viewportMat, 0, size.width, size.height, 0, 0, 1);
-
-    const Properties<>::PossiblyEvaluated properties;
-
-    parameters.programs.extrusionTexture.draw(
-        parameters.context,
-        gl::Triangles(),
-        gl::DepthMode::disabled(),
-        gl::StencilMode::disabled(),
-        parameters.colorModeForRenderPass(),
-        ExtrusionTextureProgram::UniformValues{
-            uniforms::u_matrix::Value{ viewportMat }, uniforms::u_world::Value{ size },
-            uniforms::u_image::Value{ 0 },
-            uniforms::u_opacity::Value{ evaluated.get<FillExtrusionOpacity>() }
-        },
-        parameters.staticData.extrusionTextureVertexBuffer,
-        parameters.staticData.quadTriangleIndexBuffer,
-        parameters.staticData.extrusionTextureSegments,
-        ExtrusionTextureProgram::PaintPropertyBinders{ properties, 0 },
-        properties,
-        parameters.state.getZoom(),
-        getID());
 }
 
 bool RenderFillExtrusionLayer::queryIntersectsFeature(

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.hpp
@@ -3,6 +3,8 @@
 #include <mbgl/renderer/render_layer.hpp>
 #include <mbgl/style/layers/fill_extrusion_layer_impl.hpp>
 #include <mbgl/style/layers/fill_extrusion_layer_properties.hpp>
+#include <mbgl/util/optional.hpp>
+#include <mbgl/util/offscreen_texture.hpp>
 
 namespace mbgl {
 
@@ -30,6 +32,8 @@ public:
     style::FillExtrusionPaintProperties::PossiblyEvaluated evaluated;
 
     const style::FillExtrusionLayer::Impl& impl() const;
+
+    optional<OffscreenTexture> renderTexture;
 };
 
 template <>

--- a/src/mbgl/renderer/paint_parameters.cpp
+++ b/src/mbgl/renderer/paint_parameters.cpp
@@ -62,6 +62,10 @@ gl::DepthMode PaintParameters::depthModeForSublayer(uint8_t n, gl::DepthMode::Ma
     return gl::DepthMode { gl::DepthMode::LessEqual, mask, { nearDepth, farDepth } };
 }
 
+gl::DepthMode PaintParameters::depthModeFor3D(gl::DepthMode::Mask mask) const {
+    return gl::DepthMode { gl::DepthMode::LessEqual, mask, { 0.0, 1.0 } };
+}
+
 gl::StencilMode PaintParameters::stencilModeForClipping(const ClipID& id) const {
     return gl::StencilMode {
         gl::StencilMode::Equal { static_cast<uint32_t>(id.mask.to_ulong()) },

--- a/src/mbgl/renderer/paint_parameters.hpp
+++ b/src/mbgl/renderer/paint_parameters.hpp
@@ -60,6 +60,7 @@ public:
     Programs& programs;
 
     gl::DepthMode depthModeForSublayer(uint8_t n, gl::DepthMode::Mask) const;
+    gl::DepthMode depthModeFor3D(gl::DepthMode::Mask) const;
     gl::StencilMode stencilModeForClipping(const ClipID&) const;
     gl::ColorMode colorModeForRenderPass() const;
 

--- a/src/mbgl/renderer/render_pass.hpp
+++ b/src/mbgl/renderer/render_pass.hpp
@@ -11,6 +11,7 @@ enum class RenderPass : uint8_t {
     None = 0,
     Opaque = 1 << 0,
     Translucent = 1 << 1,
+    Pass3D = 1 << 2,
 };
 
 MBGL_CONSTEXPR RenderPass operator|(RenderPass a, RenderPass b) {

--- a/src/mbgl/renderer/render_static_data.hpp
+++ b/src/mbgl/renderer/render_static_data.hpp
@@ -26,6 +26,7 @@ public:
     SegmentVector<ExtrusionTextureAttributes> extrusionTextureSegments;
 
     optional<gl::Renderbuffer<gl::RenderbufferType::DepthComponent>> depthRenderbuffer;
+    bool has3D = false;
 
     Programs programs;
 

--- a/src/mbgl/renderer/render_static_data.hpp
+++ b/src/mbgl/renderer/render_static_data.hpp
@@ -27,6 +27,7 @@ public:
 
     optional<gl::Renderbuffer<gl::RenderbufferType::DepthComponent>> depthRenderbuffer;
     bool has3D = false;
+    Size backendSize;
 
     Programs programs;
 

--- a/src/mbgl/renderer/render_static_data.hpp
+++ b/src/mbgl/renderer/render_static_data.hpp
@@ -4,7 +4,6 @@
 #include <mbgl/gl/index_buffer.hpp>
 #include <mbgl/programs/programs.hpp>
 #include <mbgl/util/optional.hpp>
-#include <mbgl/util/offscreen_texture.hpp>
 
 #include <string>
 
@@ -26,7 +25,7 @@ public:
     SegmentVector<RasterAttributes> rasterSegments;
     SegmentVector<ExtrusionTextureAttributes> extrusionTextureSegments;
 
-    optional<OffscreenTexture> extrusionTexture;
+    optional<gl::Renderbuffer<gl::RenderbufferType::DepthComponent>> depthRenderbuffer;
 
     Programs programs;
 

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -391,7 +391,6 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
     // depth rbo between them.
     if (parameters.staticData.has3D) {
         MBGL_DEBUG_GROUP(parameters.context, "3d");
-        parameters.backend.bind();
         parameters.pass = RenderPass::Pass3D;
 
         const auto size = parameters.context.viewport.getCurrentValue().size;

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -384,20 +384,9 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
     // - 3D PASS -------------------------------------------------------------------------------------
     // Renders any 3D layers bottom-to-top to unique FBOs with texture attachments, but share the same
     // depth rbo between them.
-    int indent = 0;
-
-    if (debug::renderTree) {
-        Log::Info(Event::Render, "{");
-        indent++;
-    }
-
     {
         parameters.pass = RenderPass::Pass3D;
         MBGL_DEBUG_GROUP(parameters.context, "3d");
-
-        if (debug::renderTree) {
-            Log::Info(Event::Render, "%*s%s {", indent++ * 4, "", "3D");
-        }
 
         const auto size = parameters.context.viewport.getCurrentValue().size;
 
@@ -418,13 +407,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         }
 
         parameters.backend.bind();
-
-        if (debug::renderTree) {
-            Log::Info(Event::Render, "%*s%s", --indent * 4, "", "}");
-        }
     }
-
-    if (debug::renderTree) { Log::Info(Event::Render, "}"); indent--; }
 
     // - CLEAR -------------------------------------------------------------------------------------
     // Renders the backdrop of the OpenGL view. This also paints in areas where we don't have any

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -385,8 +385,9 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
     // Renders any 3D layers bottom-to-top to unique FBOs with texture attachments, but share the same
     // depth rbo between them.
     {
-        parameters.pass = RenderPass::Pass3D;
         MBGL_DEBUG_GROUP(parameters.context, "3d");
+        parameters.backend.bind();
+        parameters.pass = RenderPass::Pass3D;
 
         const auto size = parameters.context.viewport.getCurrentValue().size;
 
@@ -406,7 +407,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
             }
         }
 
-        parameters.backend.bind();
+        // The main backend/framebuffer will be rebound in the clear step.
     }
 
     // - CLEAR -------------------------------------------------------------------------------------

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -390,6 +390,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
     // Renders any 3D layers bottom-to-top to unique FBOs with texture attachments, but share the same
     // depth rbo between them.
     if (parameters.staticData.has3D) {
+        parameters.backend.bind();
         MBGL_DEBUG_GROUP(parameters.context, "3d");
         parameters.pass = RenderPass::Pass3D;
 

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -13,6 +13,7 @@
 #include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/renderer/layers/render_background_layer.hpp>
 #include <mbgl/renderer/layers/render_custom_layer.hpp>
+#include <mbgl/renderer/layers/render_fill_extrusion_layer.hpp>
 #include <mbgl/renderer/style_diff.hpp>
 #include <mbgl/renderer/query.hpp>
 #include <mbgl/renderer/backend_scope.hpp>
@@ -271,6 +272,10 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         RenderLayer* layer = getRenderLayer(layerImpl->id);
         assert(layer);
 
+        if (!parameters.staticData.has3D && layer->is<RenderFillExtrusionLayer>()) {
+            parameters.staticData.has3D = true;
+        }
+
         if (!layer->needsRendering(zoomHistory.lastZoom)) {
             continue;
         }
@@ -384,7 +389,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
     // - 3D PASS -------------------------------------------------------------------------------------
     // Renders any 3D layers bottom-to-top to unique FBOs with texture attachments, but share the same
     // depth rbo between them.
-    {
+    if (parameters.staticData.has3D) {
         MBGL_DEBUG_GROUP(parameters.context, "3d");
         parameters.backend.bind();
         parameters.pass = RenderPass::Pass3D;

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -401,7 +401,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
             parameters.staticData.depthRenderbuffer =
                 parameters.context.createRenderbuffer<gl::RenderbufferType::DepthComponent>(size);
         }
-        parameters.staticData.depthRenderbuffer->dirty = true;
+        parameters.staticData.depthRenderbuffer->shouldClear(true);
 
         uint32_t i = static_cast<uint32_t>(order.size()) - 1;
         for (auto it = order.begin(); it != order.end(); ++it, --i) {

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -372,13 +372,8 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         parameters.imageManager.upload(parameters.context, 0);
         parameters.lineAtlas.upload(parameters.context, 0);
         parameters.frameHistory.upload(parameters.context, 0);
-    }
 
-    // - PREPARE + CLIP ------------------------------------------------------------------------------
-    {
-        MBGL_DEBUG_GROUP(parameters.context, "clip");
-
-        // Update all clipping IDs.
+        // Update all clipping IDs + upload buckets.
         for (const auto& entry : renderSources) {
             if (entry.second->isEnabled()) {
                 entry.second->startRender(parameters);

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -390,16 +390,15 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
     // Renders any 3D layers bottom-to-top to unique FBOs with texture attachments, but share the same
     // depth rbo between them.
     if (parameters.staticData.has3D) {
-        parameters.backend.bind();
+        parameters.staticData.backendSize = parameters.backend.getFramebufferSize();
+
         MBGL_DEBUG_GROUP(parameters.context, "3d");
         parameters.pass = RenderPass::Pass3D;
 
-        const auto size = parameters.context.viewport.getCurrentValue().size;
-
         if (!parameters.staticData.depthRenderbuffer ||
-            parameters.staticData.depthRenderbuffer->size != size) {
+            parameters.staticData.depthRenderbuffer->size != parameters.staticData.backendSize) {
             parameters.staticData.depthRenderbuffer =
-                parameters.context.createRenderbuffer<gl::RenderbufferType::DepthComponent>(size);
+                parameters.context.createRenderbuffer<gl::RenderbufferType::DepthComponent>(parameters.staticData.backendSize);
         }
         parameters.staticData.depthRenderbuffer->shouldClear(true);
 
@@ -411,8 +410,6 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
                 it->layer.render(parameters, it->source);
             }
         }
-
-        // The main backend/framebuffer will be rebound in the clear step.
     }
 
     // - CLEAR -------------------------------------------------------------------------------------

--- a/src/mbgl/util/offscreen_texture.cpp
+++ b/src/mbgl/util/offscreen_texture.cpp
@@ -18,7 +18,7 @@ public:
     Impl(gl::Context& context_,
          const Size size_,
          gl::Renderbuffer<gl::RenderbufferType::DepthComponent>& depth_)
-        : context(context_), size(std::move(size_)), depth(std::move(depth_)) {
+        : context(context_), size(std::move(size_)), depth(&depth_) {
         assert(!size.isEmpty());
     }
 
@@ -57,7 +57,7 @@ private:
     const Size size;
     optional<gl::Framebuffer> framebuffer;
     optional<gl::Texture> texture;
-    optional<gl::Renderbuffer<gl::RenderbufferType::DepthComponent>> depth;
+    gl::Renderbuffer<gl::RenderbufferType::DepthComponent>* depth = nullptr;
 };
 
 OffscreenTexture::OffscreenTexture(gl::Context& context,

--- a/src/mbgl/util/offscreen_texture.hpp
+++ b/src/mbgl/util/offscreen_texture.hpp
@@ -13,12 +13,14 @@ class OffscreenTexture {
 public:
     OffscreenTexture(gl::Context&,
                      Size size = { 256, 256 });
+    OffscreenTexture(gl::Context&,
+                     Size size,
+                     gl::Renderbuffer<gl::RenderbufferType::DepthComponent>&);
     ~OffscreenTexture();
     OffscreenTexture(OffscreenTexture&&);
     OffscreenTexture& operator=(OffscreenTexture&&);
 
     void bind();
-    void attachRenderbuffer(gl::Renderbuffer<gl::RenderbufferType::DepthComponent>&);
 
     PremultipliedImage readStillImage();
 

--- a/src/mbgl/util/offscreen_texture.hpp
+++ b/src/mbgl/util/offscreen_texture.hpp
@@ -9,21 +9,16 @@ class Context;
 class Texture;
 } // namespace gl
 
-enum class OffscreenTextureAttachment {
-    None,
-    Depth,
-};
-
 class OffscreenTexture {
 public:
     OffscreenTexture(gl::Context&,
-                     Size size = { 256, 256 },
-                     OffscreenTextureAttachment type = OffscreenTextureAttachment::None);
+                     Size size = { 256, 256 });
     ~OffscreenTexture();
     OffscreenTexture(OffscreenTexture&&);
     OffscreenTexture& operator=(OffscreenTexture&&);
 
     void bind();
+    void attachRenderbuffer(gl::Renderbuffer<gl::RenderbufferType::DepthComponent>&);
 
     PremultipliedImage readStillImage();
 

--- a/test/renderer/backend_scope.test.cpp
+++ b/test/renderer/backend_scope.test.cpp
@@ -12,6 +12,10 @@ public:
     void bind() override {
     }
 
+    mbgl::Size getFramebufferSize() const override {
+        return mbgl::Size{};
+    }
+
     void activate() override {
         if (activateFunction) activateFunction();
     }
@@ -87,15 +91,15 @@ TEST(BackendScope, NestedScopes) {
 TEST(BackendScope, ChainedScopes) {
     bool activatedA = false;
     bool activatedB = false;
-    
+
     StubRendererBackend backendA;
     backendA.activateFunction = [&] { activatedA = true; };
     backendA.deactivateFunction = [&] { activatedA = false; };
-    
+
     StubRendererBackend backendB;
     backendB.activateFunction = [&] { activatedB = true; };
     backendB.deactivateFunction = [&] { activatedB = false; };
-    
+
     {
         BackendScope scopeA { backendA };
         ASSERT_TRUE(activatedA);
@@ -107,7 +111,7 @@ TEST(BackendScope, ChainedScopes) {
         ASSERT_FALSE(activatedB);
         ASSERT_TRUE(activatedA);
     }
-    
+
     ASSERT_FALSE(activatedA);
     ASSERT_FALSE(activatedB);
 }


### PR DESCRIPTION
Port of https://github.com/mapbox/mapbox-gl-js/pull/5101: 

* Optimizes render order by rendering all fill-extrusion textures first, so that we don't have to restore any framebuffer contents (fixes #9286)
* Preserves depth buffer contents between different fill-extrusion layers in the same render pass so that multiple fill-extrusion layers can be rendered on the same map (ref https://github.com/mapbox/mapbox-gl-js/issues/4134)

Also fixes https://github.com/mapbox/mapbox-gl-native/issues/9978 (I think)…
