### PR TITLE
Test app - fix highlight buildings example

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesBoxHighlightActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesBoxHighlightActivity.java
@@ -46,6 +46,15 @@ public class QueryRenderedFeaturesBoxHighlightActivity extends AppCompatActivity
       @Override
       public void onMapReady(final MapboxMap mapboxMap) {
         QueryRenderedFeaturesBoxHighlightActivity.this.mapboxMap = mapboxMap;
+
+        // Add layer / source
+        final GeoJsonSource source = new GeoJsonSource("highlighted-shapes-source");
+        mapboxMap.addSource(source);
+        mapboxMap.addLayer(
+          new FillLayer("highlighted-shapes-layer", "highlighted-shapes-source")
+            .withProperties(fillColor(Color.RED))
+        );
+
         selectionBox.setOnClickListener(new View.OnClickListener() {
           @Override
           public void onClick(View view) {
@@ -62,17 +71,8 @@ public class QueryRenderedFeaturesBoxHighlightActivity extends AppCompatActivity
               String.format("%s features in box", features.size()),
               Toast.LENGTH_SHORT).show();
 
-            // remove layer / source if already added
-            mapboxMap.removeSource("highlighted-shapes-source");
-            mapboxMap.removeLayer("highlighted-shapes-layer");
-
-            // Add layer / source
-            mapboxMap.addSource(
-              new GeoJsonSource("highlighted-shapes-source",
-                FeatureCollection.fromFeatures(features))
-            );
-            mapboxMap.addLayer(new FillLayer("highlighted-shapes-layer", "highlighted-shapes-source")
-              .withProperties(fillColor(Color.RED)));
+            // Update source data
+            source.setGeoJson(FeatureCollection.fromFeatures(features));
           }
         });
       }


### PR DESCRIPTION
Fixes a crash due to the fact that sources can no longer be removed when in use and this example tries to add a duplicate source right after.