### PR TITLE
[core] Align line vertex to 4-byte boundary

### DIFF
--- a/src/mbgl/programs/attributes.hpp
+++ b/src/mbgl/programs/attributes.hpp
@@ -23,7 +23,7 @@ inline uint16_t packUint8Pair(T a, T b) {
 MBGL_DEFINE_ATTRIBUTE(int16_t, 2, a_pos);
 MBGL_DEFINE_ATTRIBUTE(int16_t, 2, a_extrude);
 MBGL_DEFINE_ATTRIBUTE(int16_t, 4, a_pos_offset);
-MBGL_DEFINE_ATTRIBUTE(int16_t, 3, a_pos_normal);
+MBGL_DEFINE_ATTRIBUTE(int16_t, 4, a_pos_normal);
 MBGL_DEFINE_ATTRIBUTE(uint16_t, 2, a_texture_pos);
 MBGL_DEFINE_ATTRIBUTE(int16_t,  3, a_normal);
 MBGL_DEFINE_ATTRIBUTE(uint16_t, 1, a_edgedistance);

--- a/src/mbgl/programs/line_program.cpp
+++ b/src/mbgl/programs/line_program.cpp
@@ -10,7 +10,7 @@ namespace mbgl {
 
 using namespace style;
 
-static_assert(sizeof(LineLayoutVertex) == 10, "expected LineLayoutVertex size");
+static_assert(sizeof(LineLayoutVertex) == 12, "expected LineLayoutVertex size");
 
 template <class Values, class...Args>
 Values makeValues(const LinePaintProperties::Evaluated& properties,

--- a/src/mbgl/programs/line_program.hpp
+++ b/src/mbgl/programs/line_program.hpp
@@ -61,7 +61,8 @@ public:
             {{
                 p.x,
                 p.y,
-                static_cast<int16_t>(attributes::packUint8Pair(round ? 1 : 0, up ? 1 : 0))
+                static_cast<int16_t>(round ? 1 : 0),
+                static_cast<int16_t>(up ? 1 : -1)
             }},
             {{
                 // add 128 to store a byte in an unsigned byte

--- a/src/mbgl/shaders/line.cpp
+++ b/src/mbgl/shaders/line.cpp
@@ -21,7 +21,7 @@ const char* line::vertexSource = R"MBGL_SHADER(
 // #define scale 63.0
 #define scale 0.015873016
 
-attribute vec3 a_pos_normal;
+attribute vec4 a_pos_normal;
 attribute vec4 a_data;
 
 uniform mat4 u_matrix;
@@ -109,12 +109,9 @@ void main() {
 
     vec2 pos = a_pos_normal.xy;
 
-    // transform y normal so that 0 => -1 and 1 => 1
-    // In the texture normal, x is 0 if the normal points straight up/down and 1 if it's a round cap
+    // x is 1 if it's a round cap, 0 otherwise
     // y is 1 if the normal points up, and -1 if it points down
-    mediump vec2 normal = unpack_float(a_pos_normal.z);
-    normal.y = sign(normal.y - 0.5);
-
+    mediump vec2 normal = a_pos_normal.zw;
     v_normal = normal;
 
     // these transformations used to be applied in the JS and native code bases.

--- a/src/mbgl/shaders/line_pattern.cpp
+++ b/src/mbgl/shaders/line_pattern.cpp
@@ -23,7 +23,7 @@ const char* line_pattern::vertexSource = R"MBGL_SHADER(
 // Retina devices need a smaller distance to avoid aliasing.
 #define ANTIALIASING 1.0 / DEVICE_PIXEL_RATIO / 2.0
 
-attribute vec3 a_pos_normal;
+attribute vec4 a_pos_normal;
 attribute vec4 a_data;
 
 uniform mat4 u_matrix;
@@ -99,12 +99,9 @@ void main() {
 
     vec2 pos = a_pos_normal.xy;
 
-    // transform y normal so that 0 => -1 and 1 => 1
-    // In the texture normal, x is 0 if the normal points straight up/down and 1 if it's a round cap
+    // x is 1 if it's a round cap, 0 otherwise
     // y is 1 if the normal points up, and -1 if it points down
-    mediump vec2 normal = unpack_float(a_pos_normal.z);
-    normal.y = sign(normal.y - 0.5);
-
+    mediump vec2 normal = a_pos_normal.zw;
     v_normal = normal;
 
     // these transformations used to be applied in the JS and native code bases.

--- a/src/mbgl/shaders/line_sdf.cpp
+++ b/src/mbgl/shaders/line_sdf.cpp
@@ -23,7 +23,7 @@ const char* line_sdf::vertexSource = R"MBGL_SHADER(
 // Retina devices need a smaller distance to avoid aliasing.
 #define ANTIALIASING 1.0 / DEVICE_PIXEL_RATIO / 2.0
 
-attribute vec3 a_pos_normal;
+attribute vec4 a_pos_normal;
 attribute vec4 a_data;
 
 uniform mat4 u_matrix;
@@ -118,12 +118,9 @@ void main() {
 
     vec2 pos = a_pos_normal.xy;
 
-    // transform y normal so that 0 => -1 and 1 => 1
-    // In the texture normal, x is 0 if the normal points straight up/down and 1 if it's a round cap
+    // x is 1 if it's a round cap, 0 otherwise
     // y is 1 if the normal points up, and -1 if it points down
-    mediump vec2 normal = unpack_float(a_pos_normal.z);
-    normal.y = sign(normal.y - 0.5);
-
+    mediump vec2 normal = a_pos_normal.zw;
     v_normal = normal;
 
     // these transformations used to be applied in the JS and native code bases.


### PR DESCRIPTION
10 byte vertices are heavily penalized by common GL implementations.

Cherry-picks aa4dff1095e8f5e8ad584f5f7dcab3e61d8cf8ee