### PR TITLE
[core] Dirty the correct state when a texture is deleted

### DIFF
--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -709,8 +709,10 @@ void Context::performCleanup() {
 
     if (!abandonedTextures.empty()) {
         for (const auto id : abandonedTextures) {
-            if (activeTexture == id) {
-                activeTexture.setDirty();
+            for (auto& binding : texture) {
+                if (binding == id) {
+                    binding.setDirty();
+                }
             }
         }
         MBGL_CHECK_ERROR(glDeleteTextures(int(abandonedTextures.size()), abandonedTextures.data()));

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -481,7 +481,7 @@ Context::createTexture(const Size size, const void* data, TextureFormat format, 
 
 void Context::updateTexture(
     TextureID id, const Size size, const void* data, TextureFormat format, TextureUnit unit) {
-    activeTexture = unit;
+    activeTextureUnit = unit;
     texture[unit] = id;
     MBGL_CHECK_ERROR(glTexImage2D(GL_TEXTURE_2D, 0, static_cast<GLenum>(format), size.width,
                                   size.height, 0, static_cast<GLenum>(format), GL_UNSIGNED_BYTE,
@@ -495,7 +495,7 @@ void Context::bindTexture(Texture& obj,
                           TextureWrap wrapX,
                           TextureWrap wrapY) {
     if (filter != obj.filter || mipmap != obj.mipmap || wrapX != obj.wrapX || wrapY != obj.wrapY) {
-        activeTexture = unit;
+        activeTextureUnit = unit;
         texture[unit] = obj.texture;
 
         if (filter != obj.filter || mipmap != obj.mipmap) {
@@ -526,7 +526,7 @@ void Context::bindTexture(Texture& obj,
     } else if (texture[unit] != obj.texture) {
         // We are checking first to avoid setting the active texture without a subsequent
         // texture bind.
-        activeTexture = unit;
+        activeTextureUnit = unit;
         texture[unit] = obj.texture;
     }
 }
@@ -558,7 +558,7 @@ void Context::setDirtyState() {
     clearStencil.setDirty();
     program.setDirty();
     lineWidth.setDirty();
-    activeTexture.setDirty();
+    activeTextureUnit.setDirty();
     pixelStorePack.setDirty();
     pixelStoreUnpack.setDirty();
 #if not MBGL_USE_GLES2

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -198,7 +198,7 @@ private:
 #endif
 
 public:
-    State<value::ActiveTexture> activeTexture;
+    State<value::ActiveTextureUnit> activeTextureUnit;
     State<value::BindFramebuffer> bindFramebuffer;
     State<value::Viewport> viewport;
     State<value::ScissorTest> scissorTest;

--- a/src/mbgl/gl/value.cpp
+++ b/src/mbgl/gl/value.cpp
@@ -242,13 +242,13 @@ LineWidth::Type LineWidth::Get() {
     return lineWidth;
 }
 
-const constexpr ActiveTexture::Type ActiveTexture::Default;
+const constexpr ActiveTextureUnit::Type ActiveTextureUnit::Default;
 
-void ActiveTexture::Set(const Type& value) {
+void ActiveTextureUnit::Set(const Type& value) {
     MBGL_CHECK_ERROR(glActiveTexture(GL_TEXTURE0 + value));
 }
 
-ActiveTexture::Type ActiveTexture::Get() {
+ActiveTextureUnit::Type ActiveTextureUnit::Get() {
     GLint activeTexture;
     MBGL_CHECK_ERROR(glGetIntegerv(GL_ACTIVE_TEXTURE, &activeTexture));
     return static_cast<Type>(activeTexture - GL_TEXTURE0);

--- a/src/mbgl/gl/value.hpp
+++ b/src/mbgl/gl/value.hpp
@@ -165,7 +165,7 @@ struct LineWidth {
     static Type Get();
 };
 
-struct ActiveTexture {
+struct ActiveTextureUnit {
     using Type = TextureUnit;
     static const constexpr Type Default = 0;
     static void Set(const Type&);

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -539,9 +539,9 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
     {
         MBGL_DEBUG_GROUP(parameters.context, "cleanup");
 
-        parameters.context.activeTexture = 1;
+        parameters.context.activeTextureUnit = 1;
         parameters.context.texture[1] = 0;
-        parameters.context.activeTexture = 0;
+        parameters.context.activeTextureUnit = 0;
         parameters.context.texture[0] = 0;
 
         parameters.context.bindVertexArray = 0;

--- a/src/mbgl/util/offscreen_texture.cpp
+++ b/src/mbgl/util/offscreen_texture.cpp
@@ -32,7 +32,7 @@ public:
             context.bindFramebuffer = framebuffer->framebuffer;
         }
 
-        context.activeTexture = 0;
+        context.activeTextureUnit = 0;
         context.scissorTest = false;
         context.viewport = { 0, 0, size };
     }


### PR DESCRIPTION
When a texture is deleted, it is as if all texture units to which that texture object is bound are rebound to texture object zero. Therefore it's the _bindings_ that need to be dirtied, not the active texture unit.

To reduce the chances of this sort of mistake happening again, rename ActiveTexture → ActiveTextureUnit for clarity.