### PR TITLE
Make places and roads accessible to VoiceOver

### DIFF
--- a/platform/darwin/src/MGLGeometry.mm
+++ b/platform/darwin/src/MGLGeometry.mm
@@ -62,6 +62,42 @@ double MGLZoomLevelForAltitude(CLLocationDistance altitude, CGFloat pitch, CLLoc
     return ::log2(mapPixelWidthAtZoom / mbgl::util::tileSize);
 }
 
+MGLRadianDistance MGLDistanceBetweenRadianCoordinates(MGLRadianCoordinate2D from, MGLRadianCoordinate2D to) {
+    double a = pow(sin((to.latitude - from.latitude) / 2), 2)
+        + pow(sin((to.longitude - from.longitude) / 2), 2) * cos(from.latitude) * cos(to.latitude);
+    
+    return 2 * atan2(sqrt(a), sqrt(1 - a));
+}
+
+MGLRadianDirection MGLRadianCoordinatesDirection(MGLRadianCoordinate2D from, MGLRadianCoordinate2D to) {
+    double a = sin(to.longitude - from.longitude) * cos(to.latitude);
+    double b = cos(from.latitude) * sin(to.latitude)
+    - sin(from.latitude) * cos(to.latitude) * cos(to.longitude - from.longitude);
+    return atan2(a, b);
+}
+
+MGLRadianCoordinate2D MGLRadianCoordinateAtDistanceFacingDirection(MGLRadianCoordinate2D coordinate,
+                                                                   MGLRadianDistance distance,
+                                                                   MGLRadianDirection direction) {
+    double otherLatitude = asin(sin(coordinate.latitude) * cos(distance)
+                                + cos(coordinate.latitude) * sin(distance) * cos(direction));
+    double otherLongitude = coordinate.longitude + atan2(sin(direction) * sin(distance) * cos(coordinate.latitude),
+                                                         cos(distance) - sin(coordinate.latitude) * sin(otherLatitude));
+    return MGLRadianCoordinate2DMake(otherLatitude, otherLongitude);
+}
+
+CLLocationDirection MGLDirectionBetweenCoordinates(CLLocationCoordinate2D firstCoordinate, CLLocationCoordinate2D secondCoordinate) {
+    // Ported from https://github.com/mapbox/turf-swift/blob/857e2e8060678ef4a7a9169d4971b0788fdffc37/Turf/Turf.swift#L23-L31
+    MGLRadianCoordinate2D firstRadianCoordinate = MGLRadianCoordinateFromLocationCoordinate(firstCoordinate);
+    MGLRadianCoordinate2D secondRadianCoordinate = MGLRadianCoordinateFromLocationCoordinate(secondCoordinate);
+    
+    CGFloat a = sin(secondRadianCoordinate.longitude - firstRadianCoordinate.longitude) * cos(secondRadianCoordinate.latitude);
+    CGFloat b = (cos(firstRadianCoordinate.latitude) * sin(secondRadianCoordinate.latitude)
+                 - sin(firstRadianCoordinate.latitude) * cos(secondRadianCoordinate.latitude) * cos(secondRadianCoordinate.longitude - firstRadianCoordinate.longitude));
+    MGLRadianDirection radianDirection = atan2(a, b);
+    return radianDirection * 180 / M_PI;
+}
+
 CGPoint MGLPointRounded(CGPoint point) {
 #if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
     CGFloat scaleFactor = [UIScreen instancesRespondToSelector:@selector(nativeScale)] ? [UIScreen mainScreen].nativeScale : [UIScreen mainScreen].scale;

--- a/platform/darwin/src/MGLGeometry_Private.h
+++ b/platform/darwin/src/MGLGeometry_Private.h
@@ -105,38 +105,26 @@ NS_INLINE MGLRadianCoordinate2D MGLRadianCoordinateFromLocationCoordinate(CLLoca
                                      MGLRadiansFromDegrees(locationCoordinate.longitude));
 }
 
-/*
+/**
  Returns the distance in radians given two coordinates.
  */
-NS_INLINE MGLRadianDistance MGLDistanceBetweenRadianCoordinates(MGLRadianCoordinate2D from, MGLRadianCoordinate2D to)
-{
-    double a = pow(sin((to.latitude - from.latitude) / 2), 2)
-                + pow(sin((to.longitude - from.longitude) / 2), 2) * cos(from.latitude) * cos(to.latitude);
-    
-    return 2 * atan2(sqrt(a), sqrt(1 - a));
-}
+MGLRadianDistance MGLDistanceBetweenRadianCoordinates(MGLRadianCoordinate2D from, MGLRadianCoordinate2D to);
 
-/*
+/**
  Returns direction in radians given two coordinates.
  */
-NS_INLINE MGLRadianDirection MGLRadianCoordinatesDirection(MGLRadianCoordinate2D from, MGLRadianCoordinate2D to) {
-    double a = sin(to.longitude - from.longitude) * cos(to.latitude);
-    double b = cos(from.latitude) * sin(to.latitude)
-                - sin(from.latitude) * cos(to.latitude) * cos(to.longitude - from.longitude);
-    return atan2(a, b);
-}
+MGLRadianDirection MGLRadianCoordinatesDirection(MGLRadianCoordinate2D from, MGLRadianCoordinate2D to);
 
-/*
- Returns coordinate at a given distance and direction away from coordinate.
+/**
+ Returns a coordinate at a given distance and direction away from coordinate.
  */
-NS_INLINE MGLRadianCoordinate2D MGLRadianCoordinateAtDistanceFacingDirection(MGLRadianCoordinate2D coordinate,
-                                                                             MGLRadianDistance distance,
-                                                                             MGLRadianDirection direction) {
-    double otherLatitude = asin(sin(coordinate.latitude) * cos(distance)
-                                + cos(coordinate.latitude) * sin(distance) * cos(direction));
-    double otherLongitude = coordinate.longitude + atan2(sin(direction) * sin(distance) * cos(coordinate.latitude),
-                                                         cos(distance) - sin(coordinate.latitude) * sin(otherLatitude));
-    return MGLRadianCoordinate2DMake(otherLatitude, otherLongitude);
-}
+MGLRadianCoordinate2D MGLRadianCoordinateAtDistanceFacingDirection(MGLRadianCoordinate2D coordinate,
+                                                                   MGLRadianDistance distance,
+                                                                   MGLRadianDirection direction);
+
+/**
+ Returns the direction from one coordinate to another.
+ */
+CLLocationDirection MGLDirectionBetweenCoordinates(CLLocationCoordinate2D firstCoordinate, CLLocationCoordinate2D secondCoordinate);
 
 CGPoint MGLPointRounded(CGPoint point);

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -638,7 +638,7 @@ static NSURL *MGLStyleURL_trafficNight;
             self.URL ? [NSString stringWithFormat:@"\"%@\"", self.URL] : self.URL];
 }
 
-#pragma mark Style language preferences
+#pragma mark Mapbox Streets source introspection
 
 - (void)setLocalizesLabels:(BOOL)localizesLabels
 {
@@ -747,6 +747,31 @@ static NSURL *MGLStyleURL_trafficNight;
 
         self.localizedLayersByIdentifier = [NSMutableDictionary dictionary];
     }
+}
+
+- (NS_SET_OF(MGLVectorSource *) *)mapboxStreetsSources {
+    return [self.sources objectsPassingTest:^BOOL (__kindof MGLVectorSource * _Nonnull source, BOOL * _Nonnull stop) {
+        return [source isKindOfClass:[MGLVectorSource class]] && source.mapboxStreets;
+    }];
+}
+
+- (NS_ARRAY_OF(MGLStyleLayer *) *)placeStyleLayers {
+    NSSet *streetsSourceIdentifiers = [self.mapboxStreetsSources valueForKey:@"identifier"];
+    
+    NSSet *placeSourceLayerIdentifiers = [NSSet setWithObjects:@"marine_label", @"country_label", @"state_label", @"place_label", @"water_label", @"poi_label", @"rail_station_label", @"mountain_peak_label", nil];
+    NSPredicate *isPlacePredicate = [NSPredicate predicateWithBlock:^BOOL (MGLVectorStyleLayer * _Nullable layer, NSDictionary<NSString *, id> * _Nullable bindings) {
+        return [layer isKindOfClass:[MGLVectorStyleLayer class]] && [streetsSourceIdentifiers containsObject:layer.sourceIdentifier] && [placeSourceLayerIdentifiers containsObject:layer.sourceLayerIdentifier];
+    }];
+    return [self.layers filteredArrayUsingPredicate:isPlacePredicate];
+}
+
+- (NS_ARRAY_OF(MGLStyleLayer *) *)roadStyleLayers {
+    NSSet *streetsSourceIdentifiers = [self.mapboxStreetsSources valueForKey:@"identifier"];
+    
+    NSPredicate *isPlacePredicate = [NSPredicate predicateWithBlock:^BOOL (MGLVectorStyleLayer * _Nullable layer, NSDictionary<NSString *, id> * _Nullable bindings) {
+        return [layer isKindOfClass:[MGLVectorStyleLayer class]] && [streetsSourceIdentifiers containsObject:layer.sourceIdentifier] && [layer.sourceLayerIdentifier isEqualToString:@"road_label"];
+    }];
+    return [self.layers filteredArrayUsingPredicate:isPlacePredicate];
 }
 
 @end

--- a/platform/darwin/src/MGLStyle_Private.h
+++ b/platform/darwin/src/MGLStyle_Private.h
@@ -14,6 +14,8 @@ namespace mbgl {
 @class MGLAttributionInfo;
 @class MGLMapView;
 @class MGLOpenGLStyleLayer;
+@class MGLVectorSource;
+@class MGLVectorStyleLayer;
 
 @interface MGLStyle (Private)
 
@@ -27,6 +29,13 @@ namespace mbgl {
 @property (nonatomic, readonly, strong) NS_MUTABLE_DICTIONARY_OF(NSString *, MGLOpenGLStyleLayer *) *openGLLayers;
 
 - (void)setStyleClasses:(NS_ARRAY_OF(NSString *) *)appliedClasses transitionDuration:(NSTimeInterval)transitionDuration;
+
+@end
+
+@interface MGLStyle (MGLStreetsAdditions)
+
+@property (nonatomic, readonly, copy) NS_ARRAY_OF(MGLVectorStyleLayer *) *placeStyleLayers;
+@property (nonatomic, readonly, copy) NS_ARRAY_OF(MGLVectorStyleLayer *) *roadStyleLayers;
 
 @end
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -23,16 +23,20 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed an issue that could cause antialiasing between polygons on the same layer to fail if the fill layers used data-driven styling for the fill color. ([#9699](https://github.com/mapbox/mapbox-gl-native/pull/9699))
 * The previously deprecated support for style classes has been removed. For interface compatibility, the API methods remain, but they are now non-functional.
 
-### Annotations and user interaction
+### Annotations
 
 * Fixed several bugs and performance issues related to the use of annotations backed by `MGLAnnotationImage`. The limits on the number and size of images and glyphs has been effectively eliminated and should now depend on hardware constraints. These fixes also apply to images used to represent icons in `MGLSymbolStyleLayer`. ([#9213](https://github.com/mapbox/mapbox-gl-native/pull/9213))
-* Increased the default maximum zoom level from 20 to 22. ([#9835](https://github.com/mapbox/mapbox-gl-native/pull/9835))
 * Added an `overlays` property to `MGLMapView`. ([#8617](https://github.com/mapbox/mapbox-gl-native/pull/8617))
 * Selecting an annotation no longer sets the user tracking mode to `MGLUserTrackingModeNone`. ([#10094](https://github.com/mapbox/mapbox-gl-native/pull/10094))
 * Added `-[MGLMapView cameraThatFitsShape:direction:edgePadding:]` to get a camera with zoom level and center coordinate computed to fit a shape. ([#10107](https://github.com/mapbox/mapbox-gl-native/pull/10107))
 * Added support selection of shape and polyline annotations.([#9984](https://github.com/mapbox/mapbox-gl-native/pull/9984))
 * Fixed an issue where view annotations could be slightly misaligned. View annotation placement is now rounded to the nearest pixel. ([#10219](https://github.com/mapbox/mapbox-gl-native/pull/10219))
 * Fixed an issue where a shape annotation callout was not displayed if the centroid was not visible. ([#10255](https://github.com/mapbox/mapbox-gl-native/pull/10255))
+
+### User interaction
+
+* Users of VoiceOver can now swipe left and right to navigate among visible places, points of interest, and roads. ([#9950](https://github.com/mapbox/mapbox-gl-native/pull/9950))
+* Increased the default maximum zoom level from 20 to 22. ([#9835](https://github.com/mapbox/mapbox-gl-native/pull/9835))
 
 ### Other changes
 

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -296,6 +296,10 @@
 		DA6408DC1DA4E7D300908C90 /* MGLVectorStyleLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = DA6408D91DA4E7D300908C90 /* MGLVectorStyleLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA6408DD1DA4E7D300908C90 /* MGLVectorStyleLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = DA6408DA1DA4E7D300908C90 /* MGLVectorStyleLayer.m */; };
 		DA6408DE1DA4E7D300908C90 /* MGLVectorStyleLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = DA6408DA1DA4E7D300908C90 /* MGLVectorStyleLayer.m */; };
+		DA704CC21F65A475004B3F28 /* MGLMapAccessibilityElement.h in Headers */ = {isa = PBXBuildFile; fileRef = DA704CC01F65A475004B3F28 /* MGLMapAccessibilityElement.h */; };
+		DA704CC31F65A475004B3F28 /* MGLMapAccessibilityElement.h in Headers */ = {isa = PBXBuildFile; fileRef = DA704CC01F65A475004B3F28 /* MGLMapAccessibilityElement.h */; };
+		DA704CC41F65A475004B3F28 /* MGLMapAccessibilityElement.m in Sources */ = {isa = PBXBuildFile; fileRef = DA704CC11F65A475004B3F28 /* MGLMapAccessibilityElement.m */; };
+		DA704CC51F65A475004B3F28 /* MGLMapAccessibilityElement.m in Sources */ = {isa = PBXBuildFile; fileRef = DA704CC11F65A475004B3F28 /* MGLMapAccessibilityElement.m */; };
 		DA72620B1DEEE3480043BB89 /* MGLOpenGLStyleLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = DA7262091DEEE3480043BB89 /* MGLOpenGLStyleLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA72620C1DEEE3480043BB89 /* MGLOpenGLStyleLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = DA7262091DEEE3480043BB89 /* MGLOpenGLStyleLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA72620D1DEEE3480043BB89 /* MGLOpenGLStyleLayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA72620A1DEEE3480043BB89 /* MGLOpenGLStyleLayer.mm */; };
@@ -821,6 +825,8 @@
 		DA704CBC1F637405004B3F28 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = uk; path = uk.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		DA704CBD1F63746E004B3F28 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
 		DA704CC71F6663A3004B3F28 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Foundation.strings; sourceTree = "<group>"; };
+		DA704CC01F65A475004B3F28 /* MGLMapAccessibilityElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLMapAccessibilityElement.h; sourceTree = "<group>"; };
+		DA704CC11F65A475004B3F28 /* MGLMapAccessibilityElement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLMapAccessibilityElement.m; sourceTree = "<group>"; };
 		DA7262091DEEE3480043BB89 /* MGLOpenGLStyleLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLOpenGLStyleLayer.h; sourceTree = "<group>"; };
 		DA72620A1DEEE3480043BB89 /* MGLOpenGLStyleLayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLOpenGLStyleLayer.mm; sourceTree = "<group>"; };
 		DA737ADA1E59139D00AD2CDE /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = es; path = es.lproj/Foundation.stringsdict; sourceTree = "<group>"; };
@@ -1423,6 +1429,8 @@
 				35CE617F1D4165C2004F2359 /* Categories */,
 				DAD165841CF4D06B001FF4B9 /* Annotations */,
 				DAD165851CF4D08B001FF4B9 /* Telemetry */,
+				DA704CC01F65A475004B3F28 /* MGLMapAccessibilityElement.h */,
+				DA704CC11F65A475004B3F28 /* MGLMapAccessibilityElement.m */,
 				DA8848361CBAFB8500AB86E3 /* MGLMapView.h */,
 				DA17BE2F1CC4BAC300402C41 /* MGLMapView_Private.h */,
 				DA8848371CBAFB8500AB86E3 /* MGLMapView+IBAdditions.h */,
@@ -1762,6 +1770,7 @@
 				DA35A2C91CCAAAD200E826B2 /* NSValue+MGLAdditions.h in Headers */,
 				3510FFEA1D6D9C7A00F413B2 /* NSComparisonPredicate+MGLAdditions.h in Headers */,
 				DA6408DB1DA4E7D300908C90 /* MGLVectorStyleLayer.h in Headers */,
+				DA704CC21F65A475004B3F28 /* MGLMapAccessibilityElement.h in Headers */,
 				DD0902AB1DB192A800C5BDCE /* MGLNetworkConfiguration.h in Headers */,
 				DA8848571CBAFB9800AB86E3 /* MGLMapboxEvents.h in Headers */,
 				35D3A1E61E9BE7EB002B38EE /* MGLScaleBar.h in Headers */,
@@ -1897,6 +1906,7 @@
 				558DE7A11E5615E400C7916D /* MGLFoundation_Private.h in Headers */,
 				3538AA1E1D542239008EC33D /* MGLForegroundStyleLayer.h in Headers */,
 				30E578181DAA85520050F07E /* UIImage+MGLAdditions.h in Headers */,
+				DA704CC31F65A475004B3F28 /* MGLMapAccessibilityElement.h in Headers */,
 				40F887711D7A1E59008ECB67 /* MGLShapeSource_Private.h in Headers */,
 				DABFB8631CBE99E500D62B32 /* MGLOfflineRegion.h in Headers */,
 				DA35A2B21CCA141D00E826B2 /* MGLCompassDirectionFormatter.h in Headers */,
@@ -2364,6 +2374,7 @@
 				DA88482A1CBAFA6200AB86E3 /* MGLTilePyramidOfflineRegion.mm in Sources */,
 				4049C29F1DB6CD6C00B3F799 /* MGLPointCollection.mm in Sources */,
 				35136D3F1D42273000C20EFD /* MGLLineStyleLayer.mm in Sources */,
+				DA704CC41F65A475004B3F28 /* MGLMapAccessibilityElement.m in Sources */,
 				DA72620D1DEEE3480043BB89 /* MGLOpenGLStyleLayer.mm in Sources */,
 				DA88481A1CBAFA6200AB86E3 /* MGLAccountManager.m in Sources */,
 				3510FFFB1D6DCC4700F413B2 /* NSCompoundPredicate+MGLAdditions.mm in Sources */,
@@ -2451,6 +2462,7 @@
 				DAA4E4211CBB730400178DFB /* MGLOfflineStorage.mm in Sources */,
 				4049C2A01DB6CD6C00B3F799 /* MGLPointCollection.mm in Sources */,
 				35136D401D42273000C20EFD /* MGLLineStyleLayer.mm in Sources */,
+				DA704CC51F65A475004B3F28 /* MGLMapAccessibilityElement.m in Sources */,
 				DA72620E1DEEE3480043BB89 /* MGLOpenGLStyleLayer.mm in Sources */,
 				DAA4E42F1CBB730400178DFB /* MGLCompactCalloutView.m in Sources */,
 				3510FFFC1D6DCC4700F413B2 /* NSCompoundPredicate+MGLAdditions.mm in Sources */,

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -298,8 +298,8 @@
 		DA6408DE1DA4E7D300908C90 /* MGLVectorStyleLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = DA6408DA1DA4E7D300908C90 /* MGLVectorStyleLayer.m */; };
 		DA704CC21F65A475004B3F28 /* MGLMapAccessibilityElement.h in Headers */ = {isa = PBXBuildFile; fileRef = DA704CC01F65A475004B3F28 /* MGLMapAccessibilityElement.h */; };
 		DA704CC31F65A475004B3F28 /* MGLMapAccessibilityElement.h in Headers */ = {isa = PBXBuildFile; fileRef = DA704CC01F65A475004B3F28 /* MGLMapAccessibilityElement.h */; };
-		DA704CC41F65A475004B3F28 /* MGLMapAccessibilityElement.m in Sources */ = {isa = PBXBuildFile; fileRef = DA704CC11F65A475004B3F28 /* MGLMapAccessibilityElement.m */; };
-		DA704CC51F65A475004B3F28 /* MGLMapAccessibilityElement.m in Sources */ = {isa = PBXBuildFile; fileRef = DA704CC11F65A475004B3F28 /* MGLMapAccessibilityElement.m */; };
+		DA704CC41F65A475004B3F28 /* MGLMapAccessibilityElement.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA704CC11F65A475004B3F28 /* MGLMapAccessibilityElement.mm */; };
+		DA704CC51F65A475004B3F28 /* MGLMapAccessibilityElement.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA704CC11F65A475004B3F28 /* MGLMapAccessibilityElement.mm */; };
 		DA72620B1DEEE3480043BB89 /* MGLOpenGLStyleLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = DA7262091DEEE3480043BB89 /* MGLOpenGLStyleLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA72620C1DEEE3480043BB89 /* MGLOpenGLStyleLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = DA7262091DEEE3480043BB89 /* MGLOpenGLStyleLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA72620D1DEEE3480043BB89 /* MGLOpenGLStyleLayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA72620A1DEEE3480043BB89 /* MGLOpenGLStyleLayer.mm */; };
@@ -824,9 +824,9 @@
 		DA704CBB1F637311004B3F28 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Foundation.strings; sourceTree = "<group>"; };
 		DA704CBC1F637405004B3F28 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = uk; path = uk.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		DA704CBD1F63746E004B3F28 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
-		DA704CC71F6663A3004B3F28 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Foundation.strings; sourceTree = "<group>"; };
 		DA704CC01F65A475004B3F28 /* MGLMapAccessibilityElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLMapAccessibilityElement.h; sourceTree = "<group>"; };
-		DA704CC11F65A475004B3F28 /* MGLMapAccessibilityElement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLMapAccessibilityElement.m; sourceTree = "<group>"; };
+		DA704CC11F65A475004B3F28 /* MGLMapAccessibilityElement.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLMapAccessibilityElement.mm; sourceTree = "<group>"; };
+		DA704CC71F6663A3004B3F28 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Foundation.strings; sourceTree = "<group>"; };
 		DA7262091DEEE3480043BB89 /* MGLOpenGLStyleLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLOpenGLStyleLayer.h; sourceTree = "<group>"; };
 		DA72620A1DEEE3480043BB89 /* MGLOpenGLStyleLayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLOpenGLStyleLayer.mm; sourceTree = "<group>"; };
 		DA737ADA1E59139D00AD2CDE /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = es; path = es.lproj/Foundation.stringsdict; sourceTree = "<group>"; };
@@ -1432,7 +1432,7 @@
 				DAD165841CF4D06B001FF4B9 /* Annotations */,
 				DAD165851CF4D08B001FF4B9 /* Telemetry */,
 				DA704CC01F65A475004B3F28 /* MGLMapAccessibilityElement.h */,
-				DA704CC11F65A475004B3F28 /* MGLMapAccessibilityElement.m */,
+				DA704CC11F65A475004B3F28 /* MGLMapAccessibilityElement.mm */,
 				DA8848361CBAFB8500AB86E3 /* MGLMapView.h */,
 				DA17BE2F1CC4BAC300402C41 /* MGLMapView_Private.h */,
 				DA8848371CBAFB8500AB86E3 /* MGLMapView+IBAdditions.h */,
@@ -2374,7 +2374,7 @@
 				DA88482A1CBAFA6200AB86E3 /* MGLTilePyramidOfflineRegion.mm in Sources */,
 				4049C29F1DB6CD6C00B3F799 /* MGLPointCollection.mm in Sources */,
 				35136D3F1D42273000C20EFD /* MGLLineStyleLayer.mm in Sources */,
-				DA704CC41F65A475004B3F28 /* MGLMapAccessibilityElement.m in Sources */,
+				DA704CC41F65A475004B3F28 /* MGLMapAccessibilityElement.mm in Sources */,
 				DA72620D1DEEE3480043BB89 /* MGLOpenGLStyleLayer.mm in Sources */,
 				DA88481A1CBAFA6200AB86E3 /* MGLAccountManager.m in Sources */,
 				3510FFFB1D6DCC4700F413B2 /* NSCompoundPredicate+MGLAdditions.mm in Sources */,
@@ -2462,7 +2462,7 @@
 				DAA4E4211CBB730400178DFB /* MGLOfflineStorage.mm in Sources */,
 				4049C2A01DB6CD6C00B3F799 /* MGLPointCollection.mm in Sources */,
 				35136D401D42273000C20EFD /* MGLLineStyleLayer.mm in Sources */,
-				DA704CC51F65A475004B3F28 /* MGLMapAccessibilityElement.m in Sources */,
+				DA704CC51F65A475004B3F28 /* MGLMapAccessibilityElement.mm in Sources */,
 				DA72620E1DEEE3480043BB89 /* MGLOpenGLStyleLayer.mm in Sources */,
 				DAA4E42F1CBB730400178DFB /* MGLCompactCalloutView.m in Sources */,
 				3510FFFC1D6DCC4700F413B2 /* NSCompoundPredicate+MGLAdditions.mm in Sources */,
@@ -2771,7 +2771,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = "";
+                DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/app/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -2785,7 +2785,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = "";
+                DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/app/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -292,6 +292,7 @@
 		DA35A2CB1CCAAAD200E826B2 /* NSValue+MGLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DA35A2C81CCAAAD200E826B2 /* NSValue+MGLAdditions.m */; };
 		DA35A2CC1CCAAAD200E826B2 /* NSValue+MGLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DA35A2C81CCAAAD200E826B2 /* NSValue+MGLAdditions.m */; };
 		DA35D0881E1A6309007DED41 /* one-liner.json in Resources */ = {isa = PBXBuildFile; fileRef = DA35D0871E1A6309007DED41 /* one-liner.json */; };
+		DA5DB12A1FABF1EE001C2326 /* MGLMapAccessibilityElementTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA5DB1291FABF1EE001C2326 /* MGLMapAccessibilityElementTests.m */; };
 		DA6408DB1DA4E7D300908C90 /* MGLVectorStyleLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = DA6408D91DA4E7D300908C90 /* MGLVectorStyleLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA6408DC1DA4E7D300908C90 /* MGLVectorStyleLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = DA6408D91DA4E7D300908C90 /* MGLVectorStyleLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA6408DD1DA4E7D300908C90 /* MGLVectorStyleLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = DA6408DA1DA4E7D300908C90 /* MGLVectorStyleLayer.m */; };
@@ -806,6 +807,7 @@
 		DA57D4AC1EBA922A00793288 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = vi; path = vi.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		DA5C09BA1EFC48550056B178 /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA5C09BB1EFC486C0056B178 /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DA5DB1291FABF1EE001C2326 /* MGLMapAccessibilityElementTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLMapAccessibilityElementTests.m; sourceTree = "<group>"; };
 		DA6023F11E4CE94300DBFF23 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Foundation.strings; sourceTree = "<group>"; };
 		DA6023F21E4CE94800DBFF23 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = sv; path = sv.lproj/Foundation.stringsdict; sourceTree = "<group>"; };
 		DA618B111E68823600CB7F44 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ru; path = ru.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -1354,6 +1356,7 @@
 				3598544C1E1D38AA00B29F84 /* MGLDistanceFormatterTests.m */,
 				DA0CD58F1CF56F6A00A5F5A5 /* MGLFeatureTests.mm */,
 				DA2E885C1CC0382C00F24E7B /* MGLGeometryTests.mm */,
+				DA5DB1291FABF1EE001C2326 /* MGLMapAccessibilityElementTests.m */,
 				35E208A61D24210F00EC9A46 /* MGLNSDataAdditionsTests.m */,
 				1F95931C1E6DE2E900D5B294 /* MGLNSDateAdditionsTests.mm */,
 				DAE7DEC11E245455007505A6 /* MGLNSStringAdditionsTests.m */,
@@ -2286,6 +2289,7 @@
 				DA2E88621CC0382C00F24E7B /* MGLOfflinePackTests.m in Sources */,
 				55E2AD131E5B125400E8C587 /* MGLOfflineStorageTests.mm in Sources */,
 				920A3E5D1E6F995200C16EFC /* MGLSourceQueryTests.m in Sources */,
+				DA5DB12A1FABF1EE001C2326 /* MGLMapAccessibilityElementTests.m in Sources */,
 				FAE1CDCB1E9D79CB00C40B5B /* MGLFillExtrusionStyleLayerTests.mm in Sources */,
 				DA35A2AA1CCA058D00E826B2 /* MGLCoordinateFormatterTests.m in Sources */,
 				357579831D502AE6000B822E /* MGLRasterStyleLayerTests.mm in Sources */,
@@ -2771,7 +2775,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-                DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/app/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -2785,7 +2789,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-                DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/app/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -1125,6 +1125,8 @@
 		35599DB81D46AD7F0048254D /* Categories */ = {
 			isa = PBXGroup;
 			children = (
+				1FDD9D6D1F26936400252B09 /* MGLVectorSource+MGLAdditions.h */,
+				1FDD9D6E1F26936400252B09 /* MGLVectorSource+MGLAdditions.m */,
 				350098DA1D484E60004B2AF0 /* NSValue+MGLStyleAttributeAdditions.h */,
 				350098DB1D484E60004B2AF0 /* NSValue+MGLStyleAttributeAdditions.mm */,
 			);
@@ -1628,8 +1630,6 @@
 		DAD165831CF4CFED001FF4B9 /* Categories */ = {
 			isa = PBXGroup;
 			children = (
-				1FDD9D6D1F26936400252B09 /* MGLVectorSource+MGLAdditions.h */,
-				1FDD9D6E1F26936400252B09 /* MGLVectorSource+MGLAdditions.m */,
 				7E016D821D9E890300A29A21 /* MGLPolygon+MGLAdditions.h */,
 				7E016D831D9E890300A29A21 /* MGLPolygon+MGLAdditions.m */,
 				7E016D7C1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.h */,

--- a/platform/ios/resources/Base.lproj/Localizable.strings
+++ b/platform/ios/resources/Base.lproj/Localizable.strings
@@ -64,6 +64,12 @@
 /* User-friendly error description */
 "PARSE_STYLE_FAILED_DESC" = "The map failed to load because the style is corrupted.";
 
+/* Accessibility value indicating that a road is a divided road (dual carriageway) */
+"ROAD_DIVIDED_A11Y_VALUE" = "Divided road";
+
+/* String format for accessibility value for road feature; {route number} */
+"ROAD_REF_A11Y_FMT" = "Route %@";
+
 /* Action sheet title */
 "SDK_NAME" = "Mapbox iOS SDK";
 

--- a/platform/ios/resources/Base.lproj/Localizable.strings
+++ b/platform/ios/resources/Base.lproj/Localizable.strings
@@ -34,6 +34,9 @@
 /* Accessibility label */
 "INFO_A11Y_LABEL" = "About this map";
 
+/* List separator */
+"LIST_SEPARATOR" = ", ";
+
 /* User-friendly error description */
 "LOAD_MAP_FAILED_DESC" = "The map failed to load because an unknown error occurred.";
 
@@ -46,8 +49,17 @@
 /* Accessibility label */
 "MAP_A11Y_LABEL" = "Map";
 
-/* Map accessibility value */
-"MAP_A11Y_VALUE" = "Zoom %1$dx\n%2$ld annotation(s) visible";
+/* Map accessibility value; {number of visible annotations} */
+"MAP_A11Y_VALUE_ANNOTATIONS" = "%ld annotation(s) visible.";
+
+/* Map accessibility value; {list of visible places} */
+"MAP_A11Y_VALUE_PLACES" = "Places visible: %@.";
+
+/* Map accessibility value; {number of visible roads} */
+"MAP_A11Y_VALUE_ROADS" = "%ld road(s) visible.";
+
+/* Map accessibility value; {zoom level} */
+"MAP_A11Y_VALUE_ZOOM" = "Zoom %dx.";
 
 /* User-friendly error description */
 "PARSE_STYLE_FAILED_DESC" = "The map failed to load because the style is corrupted.";

--- a/platform/ios/resources/Base.lproj/Localizable.strings
+++ b/platform/ios/resources/Base.lproj/Localizable.strings
@@ -67,6 +67,9 @@
 /* Accessibility value indicating that a road is a divided road (dual carriageway) */
 "ROAD_DIVIDED_A11Y_VALUE" = "Divided road";
 
+/* Accessibility value indicating that a road is a one-way road */
+"ROAD_ONEWAY_A11Y_VALUE" = "One way";
+
 /* String format for accessibility value for road feature; {route number} */
 "ROAD_REF_A11Y_FMT" = "Route %@";
 

--- a/platform/ios/resources/en.lproj/Localizable.stringsdict
+++ b/platform/ios/resources/en.lproj/Localizable.stringsdict
@@ -2,22 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>MAP_A11Y_VALUE</key>
+	<key>MAP_A11Y_VALUE_ANNOTATIONS</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@level@
-%#@count@</string>
-		<key>level</key>
-		<dict>
-			<key>NSStringFormatSpecTypeKey</key>
-			<string>NSStringPluralRuleType</string>
-			<key>NSStringFormatValueTypeKey</key>
-			<string>d</string>
-			<key>one</key>
-			<string>Zoom %dx</string>
-			<key>other</key>
-			<string>Zoom %dx</string>
-		</dict>
+		<string>%#@count@</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -28,6 +16,38 @@
 			<string>%d annotation visible</string>
 			<key>other</key>
 			<string>%d annotations visible</string>
+		</dict>
+	</dict>
+	<key>MAP_A11Y_VALUE_ROADS</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>ld</string>
+			<key>one</key>
+			<string>%d road visible</string>
+			<key>other</key>
+			<string>%d roads visible</string>
+		</dict>
+	</dict>
+	<key>MAP_A11Y_VALUE_ZOOM</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@level@</string>
+		<key>level</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Zoom %dx</string>
+			<key>other</key>
+			<string>Zoom %dx</string>
 		</dict>
 	</dict>
 </dict>

--- a/platform/ios/src/MGLMapAccessibilityElement.h
+++ b/platform/ios/src/MGLMapAccessibilityElement.h
@@ -1,0 +1,40 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol MGLFeature;
+
+/// Unique identifier representing a single annotation in mbgl.
+typedef uint32_t MGLAnnotationTag;
+
+/** An accessibility element representing something that appears on the map. */
+@interface MGLMapAccessibilityElement : UIAccessibilityElement
+
+@end
+
+/** An accessibility element representing a map annotation. */
+@interface MGLAnnotationAccessibilityElement : MGLMapAccessibilityElement
+
+/** The tag of the annotation represented by this element. */
+@property (nonatomic) MGLAnnotationTag tag;
+
+- (instancetype)initWithAccessibilityContainer:(id)container tag:(MGLAnnotationTag)identifier NS_DESIGNATED_INITIALIZER;
+
+@end
+
+/** An accessibility element representing a map feature. */
+@interface MGLFeatureAccessibilityElement : MGLMapAccessibilityElement
+
+/** The feature represented by this element. */
+@property (nonatomic, strong) id <MGLFeature> feature;
+
+- (instancetype)initWithAccessibilityContainer:(id)container feature:(id <MGLFeature>)feature NS_DESIGNATED_INITIALIZER;
+
+@end
+
+/** An accessibility element representing the MGLMapView at large. */
+@interface MGLMapViewProxyAccessibilityElement : UIAccessibilityElement
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/platform/ios/src/MGLMapAccessibilityElement.h
+++ b/platform/ios/src/MGLMapAccessibilityElement.h
@@ -32,6 +32,10 @@ typedef uint32_t MGLAnnotationTag;
 
 @end
 
+/** An accessibility element representing a place feature. */
+@interface MGLPlaceFeatureAccessibilityElement : MGLFeatureAccessibilityElement
+@end
+
 /** An accessibility element representing the MGLMapView at large. */
 @interface MGLMapViewProxyAccessibilityElement : UIAccessibilityElement
 

--- a/platform/ios/src/MGLMapAccessibilityElement.h
+++ b/platform/ios/src/MGLMapAccessibilityElement.h
@@ -36,6 +36,10 @@ typedef uint32_t MGLAnnotationTag;
 @interface MGLPlaceFeatureAccessibilityElement : MGLFeatureAccessibilityElement
 @end
 
+/** An accessibility element representing a road feature. */
+@interface MGLRoadFeatureAccessibilityElement : MGLFeatureAccessibilityElement
+@end
+
 /** An accessibility element representing the MGLMapView at large. */
 @interface MGLMapViewProxyAccessibilityElement : UIAccessibilityElement
 

--- a/platform/ios/src/MGLMapAccessibilityElement.h
+++ b/platform/ios/src/MGLMapAccessibilityElement.h
@@ -1,5 +1,7 @@
 #import <UIKit/UIKit.h>
 
+#import "MGLFoundation.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol MGLFeature;
@@ -8,6 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 typedef uint32_t MGLAnnotationTag;
 
 /** An accessibility element representing something that appears on the map. */
+MGL_EXPORT
 @interface MGLMapAccessibilityElement : UIAccessibilityElement
 
 @end
@@ -23,6 +26,7 @@ typedef uint32_t MGLAnnotationTag;
 @end
 
 /** An accessibility element representing a map feature. */
+MGL_EXPORT
 @interface MGLFeatureAccessibilityElement : MGLMapAccessibilityElement
 
 /** The feature represented by this element. */
@@ -33,16 +37,18 @@ typedef uint32_t MGLAnnotationTag;
 @end
 
 /** An accessibility element representing a place feature. */
+MGL_EXPORT
 @interface MGLPlaceFeatureAccessibilityElement : MGLFeatureAccessibilityElement
 @end
 
 /** An accessibility element representing a road feature. */
+MGL_EXPORT
 @interface MGLRoadFeatureAccessibilityElement : MGLFeatureAccessibilityElement
 @end
 
 /** An accessibility element representing the MGLMapView at large. */
+MGL_EXPORT
 @interface MGLMapViewProxyAccessibilityElement : UIAccessibilityElement
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/platform/ios/src/MGLMapAccessibilityElement.m
+++ b/platform/ios/src/MGLMapAccessibilityElement.m
@@ -143,16 +143,20 @@ CLLocationDirection MGLDirectionBetweenCoordinates(CLLocationCoordinate2D firstC
         }
         
         // Announce whether the road is a divided road.
-        if ([feature isKindOfClass:[MGLShapeCollectionFeature class]]) {
+        MGLPolyline *polyline;
+        if ([feature isKindOfClass:[MGLMultiPolylineFeature class]]) {
             [facts addObject:NSLocalizedStringWithDefaultValue(@"ROAD_DIVIDED_A11Y_VALUE", nil, nil, @"Divided road", @"Accessibility value indicating that a road is a divided road (dual carriageway)")];
-            feature = [(MGLShapeCollectionFeature *)feature shapes].firstObject;
+            polyline = [(MGLMultiPolylineFeature *)feature polylines].firstObject;
         }
         
         // Announce the road’s general direction.
         if ([feature isKindOfClass:[MGLPolylineFeature class]]) {
-            NSUInteger pointCount = [(MGLPolylineFeature *)feature pointCount];
+            polyline = (MGLPolylineFeature *)feature;
+        }
+        if (polyline) {
+            NSUInteger pointCount = polyline.pointCount;
             if (pointCount) {
-                CLLocationCoordinate2D *coordinates = [(MGLPolyline *)feature coordinates];
+                CLLocationCoordinate2D *coordinates = polyline.coordinates;
                 CLLocationDirection startDirection = MGLDirectionBetweenCoordinates(coordinates[pointCount - 1], coordinates[0]);
                 CLLocationDirection endDirection = MGLDirectionBetweenCoordinates(coordinates[0], coordinates[pointCount - 1]);
                 

--- a/platform/ios/src/MGLMapAccessibilityElement.m
+++ b/platform/ios/src/MGLMapAccessibilityElement.m
@@ -111,11 +111,23 @@ CLLocationDirection MGLDirectionBetweenCoordinates(CLLocationCoordinate2D firstC
             [facts addObject:attributes[@"maki"]];
         }
         
-        NSNumber *elevation = attributes[@"elevation_m"];
-        if (elevation) {
-            MGLDistanceFormatter *formatter = [[MGLDistanceFormatter alloc] init];
+        // Announce the peak’s elevation in the preferred units.
+        if (attributes[@"elevation_m"] ?: attributes[@"elevation_ft"]) {
+            NSLengthFormatter *formatter = [[NSLengthFormatter alloc] init];
             formatter.unitStyle = NSFormattingUnitStyleLong;
-            [facts addObject:[formatter stringFromDistance:elevation.doubleValue]];
+            
+            NSNumber *elevationValue;
+            NSLengthFormatterUnit unit;
+            BOOL usesMetricSystem = ![[formatter.numberFormatter.locale objectForKey:NSLocaleMeasurementSystem]
+                                      isEqualToString:@"U.S."];
+            if (usesMetricSystem) {
+                elevationValue = attributes[@"elevation_m"];
+                unit = NSLengthFormatterUnitMeter;
+            } else {
+                elevationValue = attributes[@"elevation_ft"];
+                unit = NSLengthFormatterUnitFoot;
+            }
+            [facts addObject:[formatter stringFromValue:elevationValue.doubleValue unit:unit]];
         }
         
         if (facts.count) {

--- a/platform/ios/src/MGLMapAccessibilityElement.m
+++ b/platform/ios/src/MGLMapAccessibilityElement.m
@@ -7,11 +7,8 @@
 
 @implementation MGLMapAccessibilityElement
 
-- (instancetype)initWithAccessibilityContainer:(id)container {
-    if (self = [super initWithAccessibilityContainer:container]) {
-        self.accessibilityTraits = UIAccessibilityTraitButton | UIAccessibilityTraitAdjustable;
-    }
-    return self;
+- (UIAccessibilityTraits)accessibilityTraits {
+    return super.accessibilityTraits | UIAccessibilityTraitAdjustable;
 }
 
 - (void)accessibilityIncrement {
@@ -34,6 +31,10 @@
     return self;
 }
 
+- (UIAccessibilityTraits)accessibilityTraits {
+    return super.accessibilityTraits | UIAccessibilityTraitButton;
+}
+
 @end
 
 @implementation MGLFeatureAccessibilityElement
@@ -42,11 +43,24 @@
     if (self = [super initWithAccessibilityContainer:container]) {
         _feature = feature;
         
-        NSDictionary *attributes = feature.attributes;
         NSString *nameAttribute = [NSString stringWithFormat:@"name_%@",
                                    [MGLVectorSource preferredMapboxStreetsLanguage]];
-        self.accessibilityLabel = attributes[nameAttribute];
-        
+        self.accessibilityLabel = [feature attributeForKey:nameAttribute];
+    }
+    return self;
+}
+
+- (UIAccessibilityTraits)accessibilityTraits {
+    return super.accessibilityTraits | UIAccessibilityTraitStaticText;
+}
+
+@end
+
+@implementation MGLPlaceFeatureAccessibilityElement
+
+- (instancetype)initWithAccessibilityContainer:(id)container feature:(id<MGLFeature>)feature {
+    if (self = [super initWithAccessibilityContainer:container feature:feature]) {
+        NSDictionary *attributes = feature.attributes;
         NSMutableArray *facts = [NSMutableArray array];
         
         // Announce the kind of place or POI.

--- a/platform/ios/src/MGLMapAccessibilityElement.m
+++ b/platform/ios/src/MGLMapAccessibilityElement.m
@@ -1,0 +1,90 @@
+#import "MGLMapAccessibilityElement.h"
+#import "MGLDistanceFormatter.h"
+#import "MGLFeature.h"
+
+#import "NSBundle+MGLAdditions.h"
+
+@implementation MGLMapAccessibilityElement
+
+- (instancetype)initWithAccessibilityContainer:(id)container {
+    if (self = [super initWithAccessibilityContainer:container]) {
+        self.accessibilityTraits = UIAccessibilityTraitButton | UIAccessibilityTraitAdjustable;
+    }
+    return self;
+}
+
+- (void)accessibilityIncrement {
+    [self.accessibilityContainer accessibilityIncrement];
+}
+
+- (void)accessibilityDecrement {
+    [self.accessibilityContainer accessibilityDecrement];
+}
+
+@end
+
+@implementation MGLAnnotationAccessibilityElement
+
+- (instancetype)initWithAccessibilityContainer:(id)container tag:(MGLAnnotationTag)tag {
+    if (self = [super initWithAccessibilityContainer:container]) {
+        _tag = tag;
+        self.accessibilityHint = NSLocalizedStringWithDefaultValue(@"ANNOTATION_A11Y_HINT", nil, nil, @"Shows more info", @"Accessibility hint");
+    }
+    return self;
+}
+
+@end
+
+@implementation MGLFeatureAccessibilityElement
+
+- (instancetype)initWithAccessibilityContainer:(id)container feature:(id<MGLFeature>)feature {
+    if (self = [super initWithAccessibilityContainer:container]) {
+        _feature = feature;
+        
+        NSDictionary *attributes = feature.attributes;
+        // TODO: Localize the name.
+        self.accessibilityLabel = attributes[@"name"];
+        
+        NSMutableArray *facts = [NSMutableArray array];
+        
+        // Announce the kind of place or POI.
+        if (attributes[@"type"]) {
+            // FIXME: Unfortunately, these types aren’t a closed set that can be
+            // localized, since they’re based on OpenStreetMap tags.
+            [facts addObject:[attributes[@"type"] stringByReplacingOccurrencesOfString:@"_" withString:@" "]];
+        }
+        // Announce the kind of airport, rail station, or mountain based on its
+        // Maki image name.
+        else if (attributes[@"maki"]) {
+            // TODO: Localize Maki image names.
+            [facts addObject:attributes[@"maki"]];
+        }
+        
+        NSNumber *elevation = attributes[@"elevation_m"];
+        if (elevation) {
+            MGLDistanceFormatter *formatter = [[MGLDistanceFormatter alloc] init];
+            formatter.unitStyle = NSFormattingUnitStyleLong;
+            [facts addObject:[formatter stringFromDistance:elevation.doubleValue]];
+        }
+        
+        if (facts.count) {
+            self.accessibilityValue = [facts componentsJoinedByString:NSLocalizedStringWithDefaultValue(@"LIST_SEPARATOR", nil, nil, @", ", @"List separator")];
+        }
+    }
+    return self;
+}
+
+@end
+
+@implementation MGLMapViewProxyAccessibilityElement
+
+- (instancetype)initWithAccessibilityContainer:(id)container {
+    if (self = [super initWithAccessibilityContainer:container]) {
+        self.accessibilityTraits = UIAccessibilityTraitButton;
+        self.accessibilityLabel = [self.accessibilityContainer accessibilityLabel];
+        self.accessibilityHint = NSLocalizedStringWithDefaultValue(@"CLOSE_CALLOUT_A11Y_HINT", nil, nil, @"Returns to the map", @"Accessibility hint for closing the selected annotation’s callout view and returning to the map");
+    }
+    return self;
+}
+
+@end

--- a/platform/ios/src/MGLMapAccessibilityElement.m
+++ b/platform/ios/src/MGLMapAccessibilityElement.m
@@ -13,16 +13,23 @@ typedef struct {
     MGLLocationRadians longitude;
 } MGLRadianCoordinate2D;
 
+MGLRadianCoordinate2D MGLRadianCoordinate2DMake(MGLLocationRadians latitude, MGLLocationRadians longitude) {
+    MGLRadianCoordinate2D radianCoordinate = {
+        .latitude = latitude,
+        .longitude = longitude,
+    };
+    return radianCoordinate;
+}
+
+MGLRadianCoordinate2D MGLRadianCoordinate2DFromLocationCoordinate2D(CLLocationCoordinate2D degreeCoordinate) {
+    return MGLRadianCoordinate2DMake(degreeCoordinate.latitude * M_PI / 180, degreeCoordinate.longitude * M_PI / 180);
+}
+
 /** Returns the direction from one coordinate to another. */
 CLLocationDirection MGLDirectionBetweenCoordinates(CLLocationCoordinate2D firstCoordinate, CLLocationCoordinate2D secondCoordinate) {
-    MGLRadianCoordinate2D firstRadianCoordinate = {
-        firstCoordinate.latitude * M_PI / 180,
-        firstCoordinate.longitude * M_PI / 180,
-    };
-    MGLRadianCoordinate2D secondRadianCoordinate = {
-        secondCoordinate.latitude * M_PI / 180,
-        secondCoordinate.longitude * M_PI / 180,
-    };
+    // Ported from https://github.com/mapbox/turf-swift/blob/857e2e8060678ef4a7a9169d4971b0788fdffc37/Turf/Turf.swift#L23-L31
+    MGLRadianCoordinate2D firstRadianCoordinate = MGLRadianCoordinate2DFromLocationCoordinate2D(firstCoordinate);
+    MGLRadianCoordinate2D secondRadianCoordinate = MGLRadianCoordinate2DFromLocationCoordinate2D(secondCoordinate);
     
     CGFloat a = sin(secondRadianCoordinate.longitude - firstRadianCoordinate.longitude) * cos(secondRadianCoordinate.latitude);
     CGFloat b = (cos(firstRadianCoordinate.latitude) * sin(secondRadianCoordinate.latitude)

--- a/platform/ios/src/MGLMapAccessibilityElement.m
+++ b/platform/ios/src/MGLMapAccessibilityElement.m
@@ -1,9 +1,35 @@
 #import "MGLMapAccessibilityElement.h"
 #import "MGLDistanceFormatter.h"
+#import "MGLCompassDirectionFormatter.h"
 #import "MGLFeature.h"
 #import "MGLVectorSource+MGLAdditions.h"
 
 #import "NSBundle+MGLAdditions.h"
+
+typedef CLLocationDegrees MGLLocationRadians;
+typedef CLLocationDirection MGLRadianDirection;
+typedef struct {
+    MGLLocationRadians latitude;
+    MGLLocationRadians longitude;
+} MGLRadianCoordinate2D;
+
+/** Returns the direction from one coordinate to another. */
+CLLocationDirection MGLDirectionBetweenCoordinates(CLLocationCoordinate2D firstCoordinate, CLLocationCoordinate2D secondCoordinate) {
+    MGLRadianCoordinate2D firstRadianCoordinate = {
+        firstCoordinate.latitude * M_PI / 180,
+        firstCoordinate.longitude * M_PI / 180,
+    };
+    MGLRadianCoordinate2D secondRadianCoordinate = {
+        secondCoordinate.latitude * M_PI / 180,
+        secondCoordinate.longitude * M_PI / 180,
+    };
+    
+    CGFloat a = sin(secondRadianCoordinate.longitude - firstRadianCoordinate.longitude) * cos(secondRadianCoordinate.latitude);
+    CGFloat b = (cos(firstRadianCoordinate.latitude) * sin(secondRadianCoordinate.latitude)
+                 - sin(firstRadianCoordinate.latitude) * cos(secondRadianCoordinate.latitude) * cos(secondRadianCoordinate.longitude - firstRadianCoordinate.longitude));
+    MGLRadianDirection radianDirection = atan2(a, b);
+    return radianDirection * 180 / M_PI;
+}
 
 @implementation MGLMapAccessibilityElement
 
@@ -83,6 +109,54 @@
             MGLDistanceFormatter *formatter = [[MGLDistanceFormatter alloc] init];
             formatter.unitStyle = NSFormattingUnitStyleLong;
             [facts addObject:[formatter stringFromDistance:elevation.doubleValue]];
+        }
+        
+        if (facts.count) {
+            NSString *separator = NSLocalizedStringWithDefaultValue(@"LIST_SEPARATOR", nil, nil, @", ", @"List separator");
+            self.accessibilityValue = [facts componentsJoinedByString:separator];
+        }
+    }
+    return self;
+}
+
+@end
+
+@implementation MGLRoadFeatureAccessibilityElement
+
+- (instancetype)initWithAccessibilityContainer:(id)container feature:(id<MGLFeature>)feature {
+    if (self = [super initWithAccessibilityContainer:container feature:feature]) {
+        NSDictionary *attributes = feature.attributes;
+        NSMutableArray *facts = [NSMutableArray array];
+        
+        // Announce the route number.
+        if (attributes[@"ref"]) {
+            // TODO: Decorate the route number with the network name based on the shield attribute.
+            NSString *ref = [NSString stringWithFormat:NSLocalizedStringWithDefaultValue(@"ROAD_REF_A11Y_FMT", nil, nil, @"Route %@", @"String format for accessibility value for road feature; {route number}"), attributes[@"ref"]];
+            [facts addObject:ref];
+        }
+        
+        // Announce whether the road is a divided road.
+        if ([feature isKindOfClass:[MGLShapeCollectionFeature class]]) {
+            [facts addObject:NSLocalizedStringWithDefaultValue(@"ROAD_DIVIDED_A11Y_VALUE", nil, nil, @"Divided road", @"Accessibility value indicating that a road is a divided road (dual carriageway)")];
+            feature = [(MGLShapeCollectionFeature *)feature shapes].firstObject;
+        }
+        
+        // Announce the road’s general direction.
+        if ([feature isKindOfClass:[MGLPolylineFeature class]]) {
+            NSUInteger pointCount = [(MGLPolylineFeature *)feature pointCount];
+            if (pointCount) {
+                CLLocationCoordinate2D *coordinates = [(MGLPolyline *)feature coordinates];
+                CLLocationDirection startDirection = MGLDirectionBetweenCoordinates(coordinates[pointCount - 1], coordinates[0]);
+                CLLocationDirection endDirection = MGLDirectionBetweenCoordinates(coordinates[0], coordinates[pointCount - 1]);
+                
+                MGLCompassDirectionFormatter *formatter = [[MGLCompassDirectionFormatter alloc] init];
+                formatter.unitStyle = NSFormattingUnitStyleLong;
+                
+                NSString *startDirectionString = [formatter stringFromDirection:startDirection];
+                NSString *endDirectionString = [formatter stringFromDirection:endDirection];
+                NSString *directionString = [NSString stringWithFormat:NSLocalizedStringWithDefaultValue(@"ROAD_DIRECTION_A11Y_FMT", nil, nil, @"%@ to %@", @"String format for accessibility value for road feature; {starting compass direction}, {ending compass direction}"), startDirectionString, endDirectionString];
+                [facts addObject:directionString];
+            }
         }
         
         if (facts.count) {

--- a/platform/ios/src/MGLMapAccessibilityElement.m
+++ b/platform/ios/src/MGLMapAccessibilityElement.m
@@ -1,6 +1,7 @@
 #import "MGLMapAccessibilityElement.h"
 #import "MGLDistanceFormatter.h"
 #import "MGLFeature.h"
+#import "MGLVectorSource+MGLAdditions.h"
 
 #import "NSBundle+MGLAdditions.h"
 
@@ -42,8 +43,9 @@
         _feature = feature;
         
         NSDictionary *attributes = feature.attributes;
-        // TODO: Localize the name.
-        self.accessibilityLabel = attributes[@"name"];
+        NSString *nameAttribute = [NSString stringWithFormat:@"name_%@",
+                                   [MGLVectorSource preferredMapboxStreetsLanguage]];
+        self.accessibilityLabel = attributes[nameAttribute];
         
         NSMutableArray *facts = [NSMutableArray array];
         
@@ -51,7 +53,9 @@
         if (attributes[@"type"]) {
             // FIXME: Unfortunately, these types aren’t a closed set that can be
             // localized, since they’re based on OpenStreetMap tags.
-            [facts addObject:[attributes[@"type"] stringByReplacingOccurrencesOfString:@"_" withString:@" "]];
+            NSString *type = [attributes[@"type"] stringByReplacingOccurrencesOfString:@"_"
+                                                                            withString:@" "];
+            [facts addObject:type];
         }
         // Announce the kind of airport, rail station, or mountain based on its
         // Maki image name.
@@ -68,7 +72,8 @@
         }
         
         if (facts.count) {
-            self.accessibilityValue = [facts componentsJoinedByString:NSLocalizedStringWithDefaultValue(@"LIST_SEPARATOR", nil, nil, @", ", @"List separator")];
+            NSString *separator = NSLocalizedStringWithDefaultValue(@"LIST_SEPARATOR", nil, nil, @", ", @"List separator");
+            self.accessibilityValue = [facts componentsJoinedByString:separator];
         }
     }
     return self;

--- a/platform/ios/src/MGLMapAccessibilityElement.m
+++ b/platform/ios/src/MGLMapAccessibilityElement.m
@@ -76,9 +76,20 @@ CLLocationDirection MGLDirectionBetweenCoordinates(CLLocationCoordinate2D firstC
     if (self = [super initWithAccessibilityContainer:container]) {
         _feature = feature;
         
-        NSString *nameAttribute = [NSString stringWithFormat:@"name_%@",
-                                   [MGLVectorSource preferredMapboxStreetsLanguage]];
-        self.accessibilityLabel = [feature attributeForKey:nameAttribute];
+        NSString *languageCode = [MGLVectorSource preferredMapboxStreetsLanguage];
+        NSString *nameAttribute = [NSString stringWithFormat:@"name_%@", languageCode];
+        NSString *name = [feature attributeForKey:nameAttribute];
+        
+        // If a feature hasn’t been translated into the preferred language, it
+        // may be in the local language, which may be written in another script.
+        // Romanize it.
+        NSLocale *locale = [NSLocale localeWithLocaleIdentifier:languageCode];
+        NSString *scriptCode = [locale objectForKey:NSLocaleScriptCode];
+        if ([scriptCode isEqualToString:@"Latn"]) {
+            name = [name stringByApplyingTransform:NSStringTransformToLatin reverse:NO];
+        }
+        
+        self.accessibilityLabel = name;
     }
     return self;
 }

--- a/platform/ios/src/MGLMapAccessibilityElement.mm
+++ b/platform/ios/src/MGLMapAccessibilityElement.mm
@@ -5,38 +5,7 @@
 #import "MGLVectorSource+MGLAdditions.h"
 
 #import "NSBundle+MGLAdditions.h"
-
-typedef CLLocationDegrees MGLLocationRadians;
-typedef CLLocationDirection MGLRadianDirection;
-typedef struct {
-    MGLLocationRadians latitude;
-    MGLLocationRadians longitude;
-} MGLRadianCoordinate2D;
-
-MGLRadianCoordinate2D MGLRadianCoordinate2DMake(MGLLocationRadians latitude, MGLLocationRadians longitude) {
-    MGLRadianCoordinate2D radianCoordinate = {
-        .latitude = latitude,
-        .longitude = longitude,
-    };
-    return radianCoordinate;
-}
-
-MGLRadianCoordinate2D MGLRadianCoordinate2DFromLocationCoordinate2D(CLLocationCoordinate2D degreeCoordinate) {
-    return MGLRadianCoordinate2DMake(degreeCoordinate.latitude * M_PI / 180, degreeCoordinate.longitude * M_PI / 180);
-}
-
-/** Returns the direction from one coordinate to another. */
-CLLocationDirection MGLDirectionBetweenCoordinates(CLLocationCoordinate2D firstCoordinate, CLLocationCoordinate2D secondCoordinate) {
-    // Ported from https://github.com/mapbox/turf-swift/blob/857e2e8060678ef4a7a9169d4971b0788fdffc37/Turf/Turf.swift#L23-L31
-    MGLRadianCoordinate2D firstRadianCoordinate = MGLRadianCoordinate2DFromLocationCoordinate2D(firstCoordinate);
-    MGLRadianCoordinate2D secondRadianCoordinate = MGLRadianCoordinate2DFromLocationCoordinate2D(secondCoordinate);
-    
-    CGFloat a = sin(secondRadianCoordinate.longitude - firstRadianCoordinate.longitude) * cos(secondRadianCoordinate.latitude);
-    CGFloat b = (cos(firstRadianCoordinate.latitude) * sin(secondRadianCoordinate.latitude)
-                 - sin(firstRadianCoordinate.latitude) * cos(secondRadianCoordinate.latitude) * cos(secondRadianCoordinate.longitude - firstRadianCoordinate.longitude));
-    MGLRadianDirection radianDirection = atan2(a, b);
-    return radianDirection * 180 / M_PI;
-}
+#import "MGLGeometry_Private.h"
 
 @implementation MGLMapAccessibilityElement
 

--- a/platform/ios/src/MGLMapAccessibilityElement.mm
+++ b/platform/ios/src/MGLMapAccessibilityElement.mm
@@ -53,8 +53,16 @@
         // may be in the local language, which may be written in another script.
         // Romanize it.
         NSLocale *locale = [NSLocale localeWithLocaleIdentifier:languageCode];
-        NSString *scriptCode = [locale objectForKey:NSLocaleScriptCode];
-        if ([scriptCode isEqualToString:@"Latn"]) {
+        NSOrthography *orthography;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+        if ([NSOrthography respondsToSelector:@selector(defaultOrthographyForLanguage:)]) {
+            orthography = [NSOrthography defaultOrthographyForLanguage:locale.localeIdentifier];
+        }
+#pragma clang diagnostic pop
+#endif
+        if ([orthography.dominantScript isEqualToString:@"Latn"]) {
             name = [name stringByApplyingTransform:NSStringTransformToLatin reverse:NO];
         }
         

--- a/platform/ios/src/MGLMapAccessibilityElement.mm
+++ b/platform/ios/src/MGLMapAccessibilityElement.mm
@@ -142,6 +142,11 @@
             [facts addObject:ref];
         }
         
+        // Announce whether the road is a one-way road.
+        if ([attributes[@"oneway"] isEqualToString:@"true"]) {
+            [facts addObject:NSLocalizedStringWithDefaultValue(@"ROAD_ONEWAY_A11Y_VALUE", nil, nil, @"One way", @"Accessibility value indicating that a road is a one-way road")];
+        }
+        
         // Announce whether the road is a divided road.
         MGLPolyline *polyline;
         if ([feature isKindOfClass:[MGLMultiPolylineFeature class]]) {

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2637,7 +2637,10 @@ public:
                 [path moveToPoint:point];
             }
         }
-        UIBezierPath *screenPath = UIAccessibilityConvertPathToScreenCoordinates(path, self);
+        CGPathRef strokedCGPath = CGPathCreateCopyByStrokingPath(path.CGPath, NULL, MGLAnnotationAccessibilityElementMinimumSize.width, kCGLineCapButt, kCGLineJoinMiter, 0);
+        UIBezierPath *strokedPath = [UIBezierPath bezierPathWithCGPath:strokedCGPath];
+        CGPathRelease(strokedCGPath);
+        UIBezierPath *screenPath = UIAccessibilityConvertPathToScreenCoordinates(strokedPath, self);
         element.accessibilityPath = screenPath;
     }
     

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -5325,6 +5325,8 @@ public:
     if (!_mbglMap) {
         return;
     }
+    
+    UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil);
 
     if ([self.delegate respondsToSelector:@selector(mapViewDidFinishRenderingMap:fullyRendered:)])
     {

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2573,7 +2573,7 @@ public:
     }
     
     MGLFeatureAccessibilityElement *element = [_featureAccessibilityElements objectsPassingTest:^BOOL(MGLFeatureAccessibilityElement * _Nonnull element, BOOL * _Nonnull stop) {
-        return (element.feature.identifier && [element.feature.identifier isEqual:feature.identifier]) || [element.feature isEqual:feature];
+        return element.feature.identifier && ![element.feature.identifier isEqual:@0] && [element.feature.identifier isEqual:feature.identifier];
     }].anyObject;
     if (!element)
     {
@@ -2602,7 +2602,7 @@ public:
     }
     
     MGLFeatureAccessibilityElement *element = [_featureAccessibilityElements objectsPassingTest:^BOOL(MGLFeatureAccessibilityElement * _Nonnull element, BOOL * _Nonnull stop) {
-        return (element.feature.identifier && [element.feature.identifier isEqual:feature.identifier]) || [element.feature isEqual:feature];
+        return element.feature.identifier && ![element.feature.identifier isEqual:@0] && [element.feature.identifier isEqual:feature.identifier];
     }].anyObject;
     if (!element)
     {
@@ -2709,6 +2709,16 @@ public:
     if (tag != MGLAnnotationTagNotFound)
     {
         std::sort(visibleAnnotations.begin(), visibleAnnotations.end());
+        std::sort(visibleAnnotations.begin(), visibleAnnotations.end(), [&](const MGLAnnotationTag tagA, const MGLAnnotationTag tagB) {
+            CLLocationCoordinate2D coordinateA = [[self annotationWithTag:tagA] coordinate];
+            CLLocationCoordinate2D coordinateB = [[self annotationWithTag:tagB] coordinate];
+            CGPoint pointA = [self convertCoordinate:coordinateA toPointToView:self];
+            CGPoint pointB = [self convertCoordinate:coordinateB toPointToView:self];
+            CGFloat deltaA = hypot(pointA.x - centerPoint.x, pointA.y - centerPoint.y);
+            CGFloat deltaB = hypot(pointB.x - centerPoint.x, pointB.y - centerPoint.y);
+            return deltaA < deltaB;
+        });
+        
         auto foundElement = std::find(visibleAnnotations.begin(), visibleAnnotations.end(), tag);
         if (foundElement == visibleAnnotations.end())
         {
@@ -2720,14 +2730,22 @@ public:
     // Visible place features
     NSArray *visiblePlaceFeatures = self.visiblePlaceFeatures;
     NSRange visiblePlaceFeatureRange = NSMakeRange(NSMaxRange(visibleAnnotationRange), visiblePlaceFeatures.count);
-    if ([element isKindOfClass:[MGLFeatureAccessibilityElement class]])
+    if ([element isKindOfClass:[MGLPlaceFeatureAccessibilityElement class]])
     {
-        id <MGLFeature> feature = [(MGLFeatureAccessibilityElement *)element feature];
+        visiblePlaceFeatures = [visiblePlaceFeatures sortedArrayUsingComparator:^NSComparisonResult(id <MGLFeature> _Nonnull featureA, id <MGLFeature> _Nonnull featureB) {
+            CGPoint pointA = [self convertCoordinate:featureA.coordinate toPointToView:self];
+            CGPoint pointB = [self convertCoordinate:featureB.coordinate toPointToView:self];
+            CGFloat deltaA = hypot(pointA.x - centerPoint.x, pointA.y - centerPoint.y);
+            CGFloat deltaB = hypot(pointB.x - centerPoint.x, pointB.y - centerPoint.y);
+            return [@(deltaA) compare:@(deltaB)];
+        }];
+        
+        id <MGLFeature> feature = [(MGLPlaceFeatureAccessibilityElement *)element feature];
         NSUInteger featureIndex = [visiblePlaceFeatures indexOfObject:feature];
         if (featureIndex == NSNotFound)
         {
             featureIndex = [visiblePlaceFeatures indexOfObjectPassingTest:^BOOL (id <MGLFeature> _Nonnull visibleFeature, NSUInteger idx, BOOL * _Nonnull stop) {
-                return visibleFeature.identifier && [visibleFeature.identifier isEqual:feature.identifier];
+                return visibleFeature.identifier && ![visibleFeature.identifier isEqual:@0] && [visibleFeature.identifier isEqual:feature.identifier];
             }];
         }
         if (featureIndex == NSNotFound)
@@ -2740,14 +2758,22 @@ public:
     // Visible road features
     NSArray *visibleRoadFeatures = self.visibleRoadFeatures;
     NSRange visibleRoadFeatureRange = NSMakeRange(NSMaxRange(visiblePlaceFeatureRange), visibleRoadFeatures.count);
-    if ([element isKindOfClass:[MGLFeatureAccessibilityElement class]])
+    if ([element isKindOfClass:[MGLRoadFeatureAccessibilityElement class]])
     {
-        id <MGLFeature> feature = [(MGLFeatureAccessibilityElement *)element feature];
+        visibleRoadFeatures = [visibleRoadFeatures sortedArrayUsingComparator:^NSComparisonResult(id <MGLFeature> _Nonnull featureA, id <MGLFeature> _Nonnull featureB) {
+            CGPoint pointA = [self convertCoordinate:featureA.coordinate toPointToView:self];
+            CGPoint pointB = [self convertCoordinate:featureB.coordinate toPointToView:self];
+            CGFloat deltaA = hypot(pointA.x - centerPoint.x, pointA.y - centerPoint.y);
+            CGFloat deltaB = hypot(pointB.x - centerPoint.x, pointB.y - centerPoint.y);
+            return [@(deltaA) compare:@(deltaB)];
+        }];
+        
+        id <MGLFeature> feature = [(MGLRoadFeatureAccessibilityElement *)element feature];
         NSUInteger featureIndex = [visibleRoadFeatures indexOfObject:feature];
         if (featureIndex == NSNotFound)
         {
             featureIndex = [visibleRoadFeatures indexOfObjectPassingTest:^BOOL (id <MGLFeature> _Nonnull visibleFeature, NSUInteger idx, BOOL * _Nonnull stop) {
-                return visibleFeature.identifier && [visibleFeature.identifier isEqual:feature.identifier];
+                return visibleFeature.identifier && ![visibleFeature.identifier isEqual:@0] && [visibleFeature.identifier isEqual:feature.identifier];
             }];
         }
         if (featureIndex == NSNotFound)

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2633,6 +2633,16 @@ public:
     {
         id <MGLFeature> feature = [(MGLFeatureAccessibilityElement *)element feature];
         NSUInteger featureIndex = [visiblePlaceFeatures indexOfObject:feature];
+        if (featureIndex == NSNotFound)
+        {
+            featureIndex = [visiblePlaceFeatures indexOfObjectPassingTest:^BOOL (id <MGLFeature> _Nonnull visibleFeature, NSUInteger idx, BOOL * _Nonnull stop) {
+                return [visibleFeature.identifier isEqual:feature.identifier];
+            }];
+        }
+        if (featureIndex == NSNotFound)
+        {
+            return NSNotFound;
+        }
         return visiblePlaceFeatureRange.location + featureIndex;
     }
     

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2411,9 +2411,6 @@ public:
         return nil;
     }
     
-    std::vector<MGLAnnotationTag> visibleAnnotations = [self annotationTagsInRect:self.bounds];
-    NSArray *visiblePlaceFeatures = self.visiblePlaceFeatures;
-    
     // Compass
     NSUInteger compassIndex = 0;
     if (index == compassIndex)
@@ -2435,6 +2432,7 @@ public:
     }
     
     // Visible annotations
+    std::vector<MGLAnnotationTag> visibleAnnotations = [self annotationTagsInRect:self.bounds];
     NSRange visibleAnnotationRange = NSMakeRange(NSMaxRange(userLocationAnnotationRange), visibleAnnotations.size());
     if (NSLocationInRange(index, visibleAnnotationRange))
     {
@@ -2456,6 +2454,7 @@ public:
     }
     
     // Visible place features
+    NSArray *visiblePlaceFeatures = self.visiblePlaceFeatures;
     NSRange visiblePlaceFeatureRange = NSMakeRange(NSMaxRange(visibleAnnotationRange), visiblePlaceFeatures.count);
     if (NSLocationInRange(index, visiblePlaceFeatureRange))
     {
@@ -2566,7 +2565,7 @@ public:
     }
     if (!element)
     {
-        element = [[MGLFeatureAccessibilityElement alloc] initWithAccessibilityContainer:self feature:feature];
+        element = [[MGLPlaceFeatureAccessibilityElement alloc] initWithAccessibilityContainer:self feature:feature];
     }
     if (!feature)
     {

--- a/platform/ios/test/MGLMapAccessibilityElementTests.m
+++ b/platform/ios/test/MGLMapAccessibilityElementTests.m
@@ -62,15 +62,20 @@
     MGLPolylineFeature *roadFeature = [MGLPolylineFeature polylineWithCoordinates:coordinates count:sizeof(coordinates) / sizeof(coordinates[0])];
     roadFeature.attributes = @{
         @"ref": @"42",
+        @"oneway": @"true",
     };
     MGLRoadFeatureAccessibilityElement *element = [[MGLRoadFeatureAccessibilityElement alloc] initWithAccessibilityContainer:self feature:roadFeature];
-    XCTAssertEqualObjects(element.accessibilityValue, @"Route 42, southwest to northeast");
+    XCTAssertEqualObjects(element.accessibilityValue, @"Route 42, One way, southwest to northeast");
     
     CLLocationCoordinate2D opposingCoordinates[] = {
-        CLLocationCoordinate2DMake(1, 0),
         CLLocationCoordinate2DMake(2, 1),
+        CLLocationCoordinate2DMake(1, 0),
     };
     MGLPolylineFeature *opposingRoadFeature = [MGLPolylineFeature polylineWithCoordinates:opposingCoordinates count:sizeof(opposingCoordinates) / sizeof(opposingCoordinates[0])];
+    opposingRoadFeature.attributes = @{
+        @"ref": @"42",
+        @"oneway": @"true",
+    };
     MGLMultiPolylineFeature *dividedRoadFeature = [MGLMultiPolylineFeature multiPolylineWithPolylines:@[roadFeature, opposingRoadFeature]];
     dividedRoadFeature.attributes = @{
         @"ref": @"42",

--- a/platform/ios/test/MGLMapAccessibilityElementTests.m
+++ b/platform/ios/test/MGLMapAccessibilityElementTests.m
@@ -1,0 +1,31 @@
+#import <Mapbox/Mapbox.h>
+#import <XCTest/XCTest.h>
+
+#import "../../ios/src/MGLMapAccessibilityElement.h"
+
+@interface MGLMapAccessibilityElementTests : XCTestCase
+@end
+
+@implementation MGLMapAccessibilityElementTests
+
+- (void)testFeatureLabels {
+    MGLPointFeature *feature = [[MGLPointFeature alloc] init];
+    feature.attributes = @{
+        @"name": @"Local",
+        @"name_en": @"English",
+        @"name_es": @"Spanish",
+        @"name_fr": @"French",
+        @"name_tlh": @"Klingon",
+    };
+    MGLFeatureAccessibilityElement *element = [[MGLFeatureAccessibilityElement alloc] initWithAccessibilityContainer:self feature:feature];
+    XCTAssertEqualObjects(element.accessibilityLabel, @"English", @"Accessibility label should be localized.");
+    
+    feature.attributes = @{
+        @"name": @"Цинциннати",
+        @"name_en": @"Цинциннати",
+    };
+    element = [[MGLFeatureAccessibilityElement alloc] initWithAccessibilityContainer:self feature:feature];
+    XCTAssertEqualObjects(element.accessibilityLabel, @"Cincinnati", @"Accessibility label should be romanized.");
+}
+
+@end

--- a/platform/ios/test/MGLMapAccessibilityElementTests.m
+++ b/platform/ios/test/MGLMapAccessibilityElementTests.m
@@ -28,4 +28,55 @@
     XCTAssertEqualObjects(element.accessibilityLabel, @"Cincinnati", @"Accessibility label should be romanized.");
 }
 
+- (void)testPlaceFeatureValues {
+    MGLPointFeature *feature = [[MGLPointFeature alloc] init];
+    feature.attributes = @{
+        @"type": @"village_green",
+    };
+    MGLPlaceFeatureAccessibilityElement *element = [[MGLPlaceFeatureAccessibilityElement alloc] initWithAccessibilityContainer:self feature:feature];
+    XCTAssertEqualObjects(element.accessibilityValue, @"village green");
+    
+    feature = [[MGLPointFeature alloc] init];
+    feature.attributes = @{
+        @"maki": @"cat",
+    };
+    element = [[MGLPlaceFeatureAccessibilityElement alloc] initWithAccessibilityContainer:self feature:feature];
+    XCTAssertEqualObjects(element.accessibilityValue, @"cat");
+    
+    feature = [[MGLPointFeature alloc] init];
+    feature.attributes = @{
+        @"elevation_ft": @31337,
+        @"elevation_m": @1337,
+    };
+    element = [[MGLPlaceFeatureAccessibilityElement alloc] initWithAccessibilityContainer:self feature:feature];
+    XCTAssertEqualObjects(element.accessibilityValue, @"31,337 feet");
+}
+
+- (void)testRoadFeatureValues {
+    CLLocationCoordinate2D coordinates[] = {
+        CLLocationCoordinate2DMake(0, 0),
+        CLLocationCoordinate2DMake(0, 1),
+        CLLocationCoordinate2DMake(1, 2),
+        CLLocationCoordinate2DMake(2, 2),
+    };
+    MGLPolylineFeature *roadFeature = [MGLPolylineFeature polylineWithCoordinates:coordinates count:sizeof(coordinates) / sizeof(coordinates[0])];
+    roadFeature.attributes = @{
+        @"ref": @"42",
+    };
+    MGLRoadFeatureAccessibilityElement *element = [[MGLRoadFeatureAccessibilityElement alloc] initWithAccessibilityContainer:self feature:roadFeature];
+    XCTAssertEqualObjects(element.accessibilityValue, @"Route 42, southwest to northeast");
+    
+    CLLocationCoordinate2D opposingCoordinates[] = {
+        CLLocationCoordinate2DMake(1, 0),
+        CLLocationCoordinate2DMake(2, 1),
+    };
+    MGLPolylineFeature *opposingRoadFeature = [MGLPolylineFeature polylineWithCoordinates:opposingCoordinates count:sizeof(opposingCoordinates) / sizeof(opposingCoordinates[0])];
+    MGLMultiPolylineFeature *dividedRoadFeature = [MGLMultiPolylineFeature multiPolylineWithPolylines:@[roadFeature, opposingRoadFeature]];
+    dividedRoadFeature.attributes = @{
+        @"ref": @"42",
+    };
+    element = [[MGLRoadFeatureAccessibilityElement alloc] initWithAccessibilityContainer:self feature:dividedRoadFeature];
+    XCTAssertEqualObjects(element.accessibilityValue, @"Route 42, Divided road, southwest to northeast");
+}
+
 @end

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -670,6 +670,8 @@
 		352742791D4C235C00A1ECE6 /* Categories */ = {
 			isa = PBXGroup;
 			children = (
+				1FCDF1401F2A4F3600A46694 /* MGLVectorSource+MGLAdditions.h */,
+				1FCDF1411F2A4F3600A46694 /* MGLVectorSource+MGLAdditions.m */,
 				DA8F25A61D51CB270010E6B5 /* NSValue+MGLStyleAttributeAdditions.h */,
 				DA8F25A71D51CB270010E6B5 /* NSValue+MGLStyleAttributeAdditions.mm */,
 			);
@@ -959,8 +961,6 @@
 		DAD1657F1CF4CF50001FF4B9 /* Categories */ = {
 			isa = PBXGroup;
 			children = (
-				1FCDF1401F2A4F3600A46694 /* MGLVectorSource+MGLAdditions.h */,
-				1FCDF1411F2A4F3600A46694 /* MGLVectorSource+MGLAdditions.m */,
 				408AA8601DAEED3300022900 /* MGLPolygon+MGLAdditions.h */,
 				408AA85C1DAEED3300022900 /* MGLPolygon+MGLAdditions.m */,
 				408AA8611DAEED3300022900 /* MGLPolyline+MGLAdditions.h */,


### PR DESCRIPTION
After zooming in or out using VoiceOver’s one-finger upward or downward swipe gestures, MGLMapView now summarize the visible places and roads in addition to announcing the new zoom level. The places and roads are all part of the list of accessibility elements within the map view’s container, so the user can now navigate among these features to get a better sense of the map’s contents.

![streets](https://user-images.githubusercontent.com/1231218/30254828-a8ed24be-9652-11e7-84e2-5bbaa4ac9692.PNG)
_“Café du Monde: cafe”_

![traffic night](https://user-images.githubusercontent.com/1231218/30265379-d8a653b8-9690-11e7-8cc3-1fb87d7598af.PNG)
_“Orleans Ave: divided road, northwest to southeast”_

![outdoors](https://user-images.githubusercontent.com/1231218/30267409-524fe548-9697-11e7-97d5-4e5ea41e7d15.PNG)
_“Denali: mountain, 20,313 feet”_

These features work in any style that uses the Mapbox Streets source in at least one layer, and it’s mostly localizable (although some parts of the readout are dependent on open-ended OpenStreetMap tags, which are in English). For screen recordings of these features, see [this blog post](https://blog.mapbox.com/accessible-maps-for-blindness-or-visual-impairment-on-ios-5c7911c349c4).

Along the way, the annotation accessibility element code has been refactored for better reliability, and the annotations are now sorted by proper geographic distance.

~~There remain a few problems with this feature, primarily that some of the roads seem to go in and out of the container chain:~~

```
[Accessibility] Went all the way up the container chain from @, but could not find any container that was one of the ordered children of @.  This may be acceptable if it happened right around a layout change, but it would be best to double check by swiping left/right to see if you can get to all elements.
```

More to come:

* [x] Add convenience methods for querying places and roads in Mapbox Streets–sourced styles
* [x] Summarize places after zooming
* [x] Count roads after zooming
* [x] Refactor accessibility code to work with ranges instead of arithmetic on indices
* [x] Sort annotation accessibility elements by geographic distance
* [x] Make places navigable in VoiceOver
* [x] Make roads navigable in VoiceOver
* [ ] Make compass directions less granular (#6872, can be tail work)
* [x] Fix accessibility warnings
* [x] Remove custom direction-to implementation in favor of #9110
* [ ] Include route network in readout for roads with refs (can be tail work)
* [ ] Localize common POI type descriptions (can be tail work)
* [ ] Implement custom rotor for zoom levels on iOS 10 and above (can be tail work)
* [ ] Profile for performance bottlenecks
* [x] Unit test accessibility values

Fixes #4821.

/cc @fabian-guerra @friedbunny