### PR TITLE
avoid adding duplicate points to bounds

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLngBounds.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLngBounds.java
@@ -450,7 +450,7 @@ public class LatLngBounds implements Parcelable {
      */
     public Builder includes(List<LatLng> latLngs) {
       for (LatLng point : latLngs) {
-        latLngList.add(point);
+        include(point);
       }
       return this;
     }
@@ -462,7 +462,9 @@ public class LatLngBounds implements Parcelable {
      * @return this
      */
     public Builder include(@NonNull LatLng latLng) {
-      latLngList.add(latLng);
+      if (!latLngList.contains(latLng)) {
+        latLngList.add(latLng);
+      }
       return this;
     }
   }


### PR DESCRIPTION
closes #9953, this PR validates if a point added to the LatLngBounds builder hasn't been added before. Atm a developer can create a bounds from one point by passing in the same point twice. 