### PR TITLE
Don't recycle bitmap for icon reuse.

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/IconManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/IconManager.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.maps;
 
 import android.graphics.Bitmap;
-import android.os.Build;
 
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.annotations.Icon;
@@ -143,7 +142,7 @@ class IconManager {
     }
   }
 
-  public void iconCleanup(Icon icon) {
+  void iconCleanup(Icon icon) {
     int refCounter = iconMap.get(icon) - 1;
     if (refCounter == 0) {
       remove(icon);
@@ -155,18 +154,10 @@ class IconManager {
   private void remove(Icon icon) {
     nativeMapView.removeAnnotationIcon(icon.getId());
     iconMap.remove(icon);
-    if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      recycleBitmap(icon.getBitmap());
-    }
   }
 
   private void updateIconRefCounter(Icon icon, int refCounter) {
     iconMap.put(icon, refCounter);
   }
 
-  private void recycleBitmap(Bitmap bitmap) {
-    if (!bitmap.isRecycled()) {
-      bitmap.recycle();
-    }
-  }
 }


### PR DESCRIPTION
Closes #9936, regression from https://github.com/mapbox/mapbox-gl-native/pull/9643. 

In the mentioned PR, I assumed it was save to recycle bitmaps when no longer in use but since the android resources system caches resources, we aren't allowed to make that assumption. From this PR forward it will be the end-users responsibility to recycle bitmaps if they want to free memory.
