### PR TITLE
Harden offline region deletion

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegion.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegion.java
@@ -358,10 +358,10 @@ public class OfflineRegion {
    */
   public void delete(@NonNull final OfflineRegionDeleteCallback callback) {
     if (!isDeleted) {
+      isDeleted = true;
       deleteOfflineRegion(new OfflineRegionDeleteCallback() {
         @Override
         public void onDelete() {
-          isDeleted = true;
           getHandler().post(new Runnable() {
             @Override
             public void run() {
@@ -376,6 +376,7 @@ public class OfflineRegion {
           getHandler().post(new Runnable() {
             @Override
             public void run() {
+              isDeleted = false;
               callback.onError(error);
             }
           });


### PR DESCRIPTION
Closes #9858, this PR hardens disallowing calling delete twice. 
Note that this is a workaround untill https://github.com/mapbox/mapbox-gl-native/issues/8917 is resolved. 