### PR TITLE
Bump proguard config for OkHttp 3.8.0

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/proguard-rules.pro
+++ b/platform/android/MapboxGLAndroidSDK/proguard-rules.pro
@@ -8,3 +8,8 @@
 -keep class com.mapbox.services.android.telemetry.** { *; }
 -keep class com.mapbox.services.commons.** { *;}
 -keep class com.google.gson.** { *; }
+
+# config for okhttp 3.8.0, https://github.com/square/okhttp/pull/3354
+-dontwarn okio.**
+-dontwarn javax.annotation.Nullable
+-dontwarn javax.annotation.ParametersAreNonnullByDefault


### PR DESCRIPTION
This PR solves the issue locally by applying the fixes from https://github.com/square/okhttp/pull/3354. I'm targetting the release branch directly as master will be upgraded to OkHttp 3.9.0 (which includes upstream PR mentioned above). 