### PR TITLE
add FileSource pause/resume 

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -36,6 +36,7 @@ import com.mapbox.mapboxsdk.maps.widgets.CompassView;
 import com.mapbox.mapboxsdk.maps.widgets.MyLocationView;
 import com.mapbox.mapboxsdk.maps.widgets.MyLocationViewSettings;
 import com.mapbox.mapboxsdk.net.ConnectivityReceiver;
+import com.mapbox.mapboxsdk.storage.FileSource;
 import com.mapbox.services.android.telemetry.MapboxTelemetry;
 
 import java.lang.annotation.Retention;
@@ -260,6 +261,7 @@ public class MapView extends FrameLayout {
   @UiThread
   public void onStart() {
     ConnectivityReceiver.instance(getContext()).activate();
+    FileSource.getInstance(getContext()).activate();
     if (mapboxMap != null) {
       mapboxMap.onStart();
     }
@@ -288,6 +290,7 @@ public class MapView extends FrameLayout {
   public void onStop() {
     mapboxMap.onStop();
     ConnectivityReceiver.instance(getContext()).deactivate();
+    FileSource.getInstance(getContext()).deactivate();
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegion.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegion.java
@@ -300,10 +300,19 @@ public class OfflineRegion {
 
   /**
    * Pause or resume downloading of regional resources.
+   * <p>
+   * After a download has been completed, you are required to reset the state of the region to STATE_INACTIVE.
+   * </p>
    *
    * @param state the download state
    */
   public void setDownloadState(@DownloadState int state) {
+    if (state == STATE_ACTIVE) {
+      fileSource.activate();
+    } else {
+      fileSource.deactivate();
+    }
+
     this.state = state;
     setOfflineRegionDownloadState(state);
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
@@ -72,7 +72,7 @@ public class FileSource {
         MapboxConstants.KEY_META_DATA_SET_STORAGE_EXTERNAL,
         MapboxConstants.DEFAULT_SET_STORAGE_EXTERNAL);
     } catch (PackageManager.NameNotFoundException exception) {
-      Timber.e(exception,"Failed to read the package metadata: ");
+      Timber.e(exception, "Failed to read the package metadata: ");
     } catch (Exception exception) {
       Timber.e(exception, "Failed to read the storage key: ");
     }
@@ -119,9 +119,27 @@ public class FileSource {
   }
 
   private long nativePtr;
+  private long activeCounter;
+  private boolean wasPaused;
 
   private FileSource(String cachePath, AssetManager assetManager) {
     initialize(Mapbox.getAccessToken(), cachePath, assetManager);
+  }
+
+  public void activate() {
+    activeCounter++;
+    if (activeCounter == 1 && wasPaused) {
+      wasPaused = false;
+      resume();
+    }
+  }
+
+  public void deactivate() {
+    activeCounter--;
+    if (activeCounter == 0) {
+      wasPaused = true;
+      pause();
+    }
   }
 
   public native void setAccessToken(@NonNull String accessToken);
@@ -129,6 +147,10 @@ public class FileSource {
   public native String getAccessToken();
 
   public native void setApiBaseUrl(String baseUrl);
+
+  private native void resume();
+
+  private native void pause();
 
   /**
    * Sets a callback for transforming URLs requested from the internet

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/offline/OfflineActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/offline/OfflineActivity.java
@@ -264,6 +264,7 @@ public class OfflineActivity extends AppCompatActivity
         if (status.isComplete()) {
           // Download complete
           endProgress("Region downloaded successfully.");
+          offlineRegion.setDownloadState(OfflineRegion.STATE_INACTIVE);
           offlineRegion.setObserver(null);
           return;
         } else if (status.isRequiredResourceCountPrecise()) {
@@ -281,11 +282,13 @@ public class OfflineActivity extends AppCompatActivity
       @Override
       public void onError(OfflineRegionError error) {
         Timber.e("onError: %s, %s", error.getReason(), error.getMessage());
+        offlineRegion.setDownloadState(OfflineRegion.STATE_INACTIVE);
       }
 
       @Override
       public void mapboxTileCountLimitExceeded(long limit) {
         Timber.e("Mapbox tile count limit exceeded: %s", limit);
+        offlineRegion.setDownloadState(OfflineRegion.STATE_INACTIVE);
       }
     });
 

--- a/platform/android/src/file_source.cpp
+++ b/platform/android/src/file_source.cpp
@@ -8,8 +8,6 @@
 #include "asset_manager_file_source.hpp"
 #include "jni/generic_global_ref_deleter.hpp"
 
-#include <string>
-
 namespace mbgl {
 namespace android {
 
@@ -64,6 +62,14 @@ void FileSource::setResourceTransform(jni::JNIEnv& env, jni::Object<FileSource::
     }
 }
 
+void FileSource::resume(jni::JNIEnv&) {
+    fileSource->resume();
+}
+
+void FileSource::pause(jni::JNIEnv&) {
+    fileSource->pause();
+}
+
 jni::Class<FileSource> FileSource::javaClass;
 
 FileSource* FileSource::getNativePeer(jni::JNIEnv& env, jni::Object<FileSource> jFileSource) {
@@ -93,7 +99,9 @@ void FileSource::registerNative(jni::JNIEnv& env) {
         METHOD(&FileSource::getAccessToken, "getAccessToken"),
         METHOD(&FileSource::setAccessToken, "setAccessToken"),
         METHOD(&FileSource::setAPIBaseUrl, "setApiBaseUrl"),
-        METHOD(&FileSource::setResourceTransform, "setResourceTransform")
+        METHOD(&FileSource::setResourceTransform, "setResourceTransform"),
+        METHOD(&FileSource::resume, "resume"),
+        METHOD(&FileSource::pause, "pause")
     );
 }
 

--- a/platform/android/src/file_source.hpp
+++ b/platform/android/src/file_source.hpp
@@ -41,6 +41,10 @@ public:
 
     void setResourceTransform(jni::JNIEnv&, jni::Object<FileSource::ResourceTransformCallback>);
 
+    void resume(jni::JNIEnv&);
+
+    void pause(jni::JNIEnv&);
+
     static jni::Class<FileSource> javaClass;
 
     static FileSource* getNativePeer(jni::JNIEnv&, jni::Object<FileSource>);


### PR DESCRIPTION
closes #9965,

This PR integrates with FileSource pause/resume when the app state changes (foreground vs background). I'm currently looking into counting ongoing filesource interactions for two reasons:
 - we need to be able to do offline downloads in the background and don't stop them when the app is backgrounded.
 - we need to support showing multiple maps in one Activity/Fragment, we aren't allows to call pause redundantly. 
