### PR TITLE
Null check NativeMapView UniqueWeakObject

### DIFF
--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -315,6 +315,7 @@ private:
     bool snapshot = false;
     bool firstRender = true;
     double fps = 0.0;
+    std::atomic<bool> destroyed = {false};
 
     // Minimum texture size according to OpenGL ES 2.0 specification.
     int width = 64;


### PR DESCRIPTION
Speculative fix that checks the javaPeer being non-null, closes #9981.