### PR TITLE
[core] Clear atlasImage rect for a removed pattern

### DIFF
--- a/include/mbgl/util/image.hpp
+++ b/include/mbgl/util/image.hpp
@@ -5,6 +5,7 @@
 #include <mbgl/util/size.hpp>
 
 #include <string>
+#include <cstring>
 #include <memory>
 #include <algorithm>
 
@@ -89,6 +90,31 @@ public:
             std::min(size.height, size_.height)
         });
         operator=(std::move(newImage));
+    }
+
+    // Clears the rect area specified by `pt` and `size` from `dstImage`.
+    static void clear(Image& dstImg, const Point<uint32_t>& pt, const Size& size) {
+        if (size.isEmpty()) {
+            return;
+        }
+
+        if (!dstImg.valid()) {
+            throw std::invalid_argument("invalid destination for image clear");
+        }
+
+        if (size.width > dstImg.size.width ||
+            size.height > dstImg.size.height ||
+            pt.x > dstImg.size.width - size.width ||
+            pt.y > dstImg.size.height - size.height) {
+            throw std::out_of_range("out of range destination coordinates for image clear");
+        }
+
+        uint8_t* dstData = dstImg.data.get();
+
+        for (uint32_t y = 0; y < size.height; y++) {
+            const std::size_t dstOffset = (pt.y + y) * dstImg.stride() + pt.x * channels;
+            std::memset(dstData + dstOffset, 0, size.width * channels);
+        }
     }
 
     // Copy image data within `rect` from `src` to the rectangle of the same size at `pt`

--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -41,6 +41,7 @@
   "render-tests/regressions/mapbox-gl-js#3548": "skip - needs issue",
   "render-tests/regressions/mapbox-gl-js#3682": "https://github.com/mapbox/mapbox-gl-js/issues/3682",
   "render-tests/regressions/mapbox-gl-native#7357": "https://github.com/mapbox/mapbox-gl-native/issues/7357",
+  "render-tests/regressions/mapbox-gl-native#9900": "skip - https://github.com/mapbox/mapbox-gl-native/pull/9905",
   "render-tests/runtime-styling/image-add-sdf": "skip - https://github.com/mapbox/mapbox-gl-native/issues/9847",
   "render-tests/runtime-styling/paint-property-fill-flat-to-extrude": "skip - https://github.com/mapbox/mapbox-gl-native/issues/6745",
   "render-tests/runtime-styling/set-style-paint-property-fill-flat-to-extrude": "skip - needs issue",

--- a/src/mbgl/renderer/image_manager.cpp
+++ b/src/mbgl/renderer/image_manager.cpp
@@ -39,6 +39,13 @@ void ImageManager::removeImage(const std::string& id) {
 
     auto it = patterns.find(id);
     if (it != patterns.end()) {
+        // Clear pattern from the atlas image.
+        const uint32_t x = it->second.bin->x;
+        const uint32_t y = it->second.bin->y;
+        const uint32_t w = it->second.bin->w;
+        const uint32_t h = it->second.bin->h;
+        PremultipliedImage::clear(atlasImage, { x, y }, { w, h });
+
         shelfPack.unref(*it->second.bin);
         patterns.erase(it);
     }


### PR DESCRIPTION
Recreating the `atlasImage` object ensures no pattern leftovers are redrawn.

Fixes #9976.

Depends on https://github.com/mapbox/mapbox-gl-js/pull/5281.

(If #9905 is merged first, then the entry in ```ignores.json``` can be removed).