### PR TITLE
Mapbox develops React Native Mapbox GL

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Additional Mapbox GL Native–based libraries for **hybrid applications** are de
 
 | Toolkit                                  | Android | iOS | Developer   |
 | ---------------------------------------- | --------|-----|------------ |
-| [React Native](https://github.com/mapbox/react-native-mapbox-gl/) ([npm](https://www.npmjs.com/package/react-native-mapbox-gl)) | :white_check_mark: | :white_check_mark: |  |
+| [React Native](https://github.com/mapbox/react-native-mapbox-gl/) ([npm](https://www.npmjs.com/package/react-native-mapbox-gl)) | :white_check_mark: | :white_check_mark: | Mapbox |
 | [Apache Cordova](http://plugins.telerik.com/cordova/plugin/mapbox/) ([npm](https://www.npmjs.com/package/cordova-plugin-mapbox)) | :white_check_mark: | :white_check_mark: | Telerik |
 | [NativeScript](http://plugins.telerik.com/nativescript/plugin/mapbox/) ([npm](https://www.npmjs.com/package/nativescript-mapbox/)) | :white_check_mark: | :white_check_mark: | Telerik |
 | [Xamarin](https://components.xamarin.com/view/mapboxsdk/) | :white_check_mark: | :white_check_mark: | Xamarin |


### PR DESCRIPTION
Updated the readme to acknowledge Mapbox’s official support for React Native. For context, we originally held off from making this claim in #6696 because RNMBGL wasn’t officially supported. However, as of mapbox/react-native-mapbox-gl#618, we’re going to develop the project as an official Mapbox product.

/cc @nitaliano @bsudekum