### PR TITLE
Can spam coming from Transifex

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -12,7 +12,7 @@ type = STRINGS
 [mapbox-gl-native.foundationstringsdict-darwin]
 file_filter = platform/darwin/resources/<lang>.lproj/Foundation.stringsdict
 lang_map = pt_BR: pt-BR, pt_PT: pt-PT, zh_CN: zh-Hans, zh_TW: zh-Hant
-source_file = platform/darwin/resources/Base.lproj/Foundation.strings
+source_file = platform/darwin/resources/en.lproj/Foundation.stringsdict
 source_lang = en
 type = STRINGSDICT
 


### PR DESCRIPTION
A bogus source file path added in #9945 was causing contention between two resources. As a consequence, Transifex spammed the project’s watchers daily about changes that didn’t occur.

/cc @friedbunny