### PR TITLE
[core] Bypass GeoJSON tile data update if tileID zoom is above source's maxZoom

### DIFF
--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -53,6 +53,7 @@ void NodeMap::Init(v8::Local<v8::Object> target) {
     Nan::SetPrototypeMethod(tpl, "cancel", Cancel);
 
     Nan::SetPrototypeMethod(tpl, "addSource", AddSource);
+    Nan::SetPrototypeMethod(tpl, "removeSource", RemoveSource);
     Nan::SetPrototypeMethod(tpl, "addLayer", AddLayer);
     Nan::SetPrototypeMethod(tpl, "removeLayer", RemoveLayer);
     Nan::SetPrototypeMethod(tpl, "addImage", AddImage);
@@ -545,6 +546,24 @@ void NodeMap::AddSource(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     }
 
     nodeMap->map->getStyle().addSource(std::move(*source));
+}
+
+void NodeMap::RemoveSource(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+    using namespace mbgl::style;
+    using namespace mbgl::style::conversion;
+
+    auto nodeMap = Nan::ObjectWrap::Unwrap<NodeMap>(info.Holder());
+    if (!nodeMap->map) return Nan::ThrowError(releasedMessage());
+
+    if (info.Length() != 1) {
+        return Nan::ThrowTypeError("One argument required");
+    }
+
+    if (!info[0]->IsString()) {
+        return Nan::ThrowTypeError("First argument must be a string");
+    }
+
+    nodeMap->map->getStyle().removeSource(*Nan::Utf8String(info[0]));
 }
 
 void NodeMap::AddLayer(const Nan::FunctionCallbackInfo<v8::Value>& info) {

--- a/platform/node/src/node_map.hpp
+++ b/platform/node/src/node_map.hpp
@@ -45,6 +45,7 @@ public:
     static void Release(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void Cancel(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void AddSource(const Nan::FunctionCallbackInfo<v8::Value>&);
+    static void RemoveSource(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void AddLayer(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void RemoveLayer(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void AddImage(const Nan::FunctionCallbackInfo<v8::Value>&);

--- a/platform/node/test/js/map.test.js
+++ b/platform/node/test/js/map.test.js
@@ -109,6 +109,7 @@ test('Map', function(t) {
             'release',
             'cancel',
             'addSource',
+            'removeSource',
             'addLayer',
             'removeLayer',
             'addImage',

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -132,7 +132,7 @@ double TransformState::getZoom() const {
     return scaleZoom(scale);
 }
 
-int32_t TransformState::getIntegerZoom() const {
+uint8_t TransformState::getIntegerZoom() const {
     return getZoom();
 }
 

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -47,7 +47,7 @@ public:
 
     // Zoom
     double getZoom() const;
-    int32_t getIntegerZoom() const;
+    uint8_t getIntegerZoom() const;
     double getZoomFraction() const;
 
     // Bounds

--- a/src/mbgl/renderer/sources/render_geojson_source.cpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.cpp
@@ -2,6 +2,7 @@
 #include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/renderer/paint_parameters.hpp>
 #include <mbgl/tile/geojson_tile.hpp>
+#include <mbgl/renderer/tile_parameters.hpp>
 
 #include <mbgl/algorithm/generate_clip_ids.hpp>
 #include <mbgl/algorithm/generate_clip_ids_impl.hpp>
@@ -39,16 +40,18 @@ void RenderGeoJSONSource::update(Immutable<style::Source::Impl> baseImpl_,
         tilePyramid.cache.clear();
 
         if (data) {
-            for (auto const& item : tilePyramid.tiles) {
-                static_cast<GeoJSONTile*>(item.second.get())->updateData(data->getTile(item.first.canonical));
+            const uint8_t maxZ = impl().getZoomRange().max;
+            for (const auto& pair : tilePyramid.tiles) {
+                if (pair.first.canonical.z <= maxZ) {
+                    static_cast<GeoJSONTile*>(pair.second.get())->updateData(data->getTile(pair.first.canonical));
+                }
             }
-        } else {
-            tilePyramid.tiles.clear();
-            tilePyramid.renderTiles.clear();
         }
     }
 
     if (!data) {
+        tilePyramid.tiles.clear();
+        tilePyramid.renderTiles.clear();
         return;
     }
 


### PR DESCRIPTION
Scale retained tile IDs to either the transform zoom or maximum zoom allowed by GeoJSON-VT if the current tile ID zoom is higher than the maximum zoom allowed by GeoJSON-VT when updating GeoJSON render sources.

This avoids situations where e.g. an updated GeoJSON source, which now has a maxZoom set to 16, calls for obtaining tiles from its GeoJSON-VT counterpart using the previous zoom level 18: it causes GeoJSON-VT to [throw](https://github.com/mapbox/geojson-vt-cpp/blob/master/include/mapbox/geojsonvt.hpp#L89).

Also adds `removeSource` as part of our Node bindings - used by the added integration test ```regressions/mapbox-gl-native#9979``` to verify.

Depends on https://github.com/mapbox/mapbox-gl-js/pull/5291.

Fixes #9979.