### PR TITLE
API for platform side animations

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -148,7 +148,8 @@ public class MapView extends FrameLayout {
     addOnMapChangedListener(mapCallback);
 
     // callback for focal point invalidation
-    final FocalPointInvalidator focalPointInvalidator = new FocalPointInvalidator(createFocalPointChangeListener());
+    final FocalPointInvalidator focalPointInvalidator = new FocalPointInvalidator();
+    focalPointInvalidator.addListener(createFocalPointChangeListener());
 
     // callback for registering touch listeners
     RegisterTouchListener registerTouchListener = new RegisterTouchListener();
@@ -177,8 +178,11 @@ public class MapView extends FrameLayout {
       markerViewManager, iconManager, annotations, markers, polygons, polylines);
     Transform transform = new Transform(nativeMapView, annotationManager.getMarkerViewManager(), trackingSettings,
       cameraChangeDispatcher);
+
     mapboxMap = new MapboxMap(nativeMapView, transform, uiSettings, trackingSettings, myLocationViewSettings, proj,
       registerTouchListener, annotationManager, cameraChangeDispatcher);
+    focalPointInvalidator.addListener(mapboxMap.createFocalPointChangeListener());
+
     mapCallback.attachMapboxMap(mapboxMap);
 
     // user input
@@ -817,10 +821,10 @@ public class MapView extends FrameLayout {
 
   private class FocalPointInvalidator implements FocalPointChangeListener {
 
-    private final FocalPointChangeListener[] focalPointChangeListeners;
+    private final List<FocalPointChangeListener> focalPointChangeListeners = new ArrayList<>();
 
-    FocalPointInvalidator(FocalPointChangeListener... listeners) {
-      focalPointChangeListeners = listeners;
+    void addListener(FocalPointChangeListener focalPointChangeListener) {
+      focalPointChangeListeners.add(focalPointChangeListener);
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -75,6 +75,7 @@ public final class MapboxMap {
   private final OnRegisterTouchListener onRegisterTouchListener;
 
   private MapboxMap.OnFpsChangedListener onFpsChangedListener;
+  private PointF focalPoint;
 
   MapboxMap(NativeMapView map, Transform transform, UiSettings ui, TrackingSettings tracking,
             MyLocationViewSettings myLocationView, Projection projection, OnRegisterTouchListener listener,
@@ -610,6 +611,47 @@ public final class MapboxMap {
   //
   // Camera API
   //
+
+  /**
+   * Moves the center of the screen to a latitude and longitude specified by a LatLng object. This centers the
+   * camera on the LatLng object.
+   *
+   * @param latLng Target location to change to
+   */
+  public void setLatLng(@NonNull LatLng latLng) {
+    nativeMapView.setLatLng(latLng);
+  }
+
+  /**
+   * Moves the camera viewpoint to a particular zoom level.
+   *
+   * @param zoom Zoom level to change to
+   */
+  public void setZoom(@FloatRange(from = MapboxConstants.MINIMUM_ZOOM, to = MapboxConstants.MAXIMUM_ZOOM) double zoom) {
+    if (focalPoint == null) {
+      focalPoint = new PointF(nativeMapView.getWidth() / 2, nativeMapView.getHeight() / 2);
+    }
+    nativeMapView.setZoom(zoom, focalPoint, 0);
+  }
+
+  /**
+   * Moves the camera viewpoint angle to a particular angle in degrees.
+   *
+   * @param tilt Tilt angle to change to
+   */
+  public void setTilt(@FloatRange(from = MapboxConstants.MINIMUM_TILT, to = MapboxConstants.MAXIMUM_TILT) double tilt) {
+    nativeMapView.setPitch(tilt, 0);
+  }
+
+  /**
+   * Moves the camera viewpoint direction to a particular angle in degrees.
+   *
+   * @param bearing Direction angle to change to
+   */
+  public void setBearing(@FloatRange(from = MapboxConstants.MINIMUM_DIRECTION, to = MapboxConstants.MAXIMUM_DIRECTION)
+                           double bearing) {
+    nativeMapView.setBearing(bearing);
+  }
 
   /**
    * Cancels ongoing animations.
@@ -1984,6 +2026,15 @@ public final class MapboxMap {
                                              @Nullable Filter.Statement filter,
                                              @Nullable String... layerIds) {
     return nativeMapView.queryRenderedFeatures(coordinates, layerIds, filter);
+  }
+
+  FocalPointChangeListener createFocalPointChangeListener() {
+    return new FocalPointChangeListener() {
+      @Override
+      public void onFocalPointChanged(PointF pointF) {
+        focalPoint = pointF;
+      }
+    };
   }
 
   //

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -113,6 +113,17 @@
                 android:value=".activity.FeatureOverviewActivity"/>
         </activity>
         <activity
+            android:name=".activity.camera.CameraAnimatorActivity"
+            android:description="@string/description_camera_animator"
+            android:label="@string/activity_camera_animator">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_camera"/>
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".activity.FeatureOverviewActivity"/>
+        </activity>
+        <activity
             android:name=".activity.camera.CameraPositionActivity"
             android:description="@string/description_cameraposition"
             android:label="@string/activity_camera_position">

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraAnimatorActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraAnimatorActivity.java
@@ -1,0 +1,174 @@
+package com.mapbox.mapboxsdk.testapp.activity.camera;
+
+import android.animation.Animator;
+import android.animation.AnimatorSet;
+import android.animation.TypeEvaluator;
+import android.animation.ValueAnimator;
+import android.os.Bundle;
+import android.support.v4.view.animation.FastOutLinearInInterpolator;
+import android.support.v4.view.animation.FastOutSlowInInterpolator;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.view.animation.AnticipateOvershootInterpolator;
+
+import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.testapp.R;
+
+/**
+ * Test activity showcasing using Android SDK animators to animate camera position changes.
+ */
+public class CameraAnimatorActivity extends AppCompatActivity implements OnMapReadyCallback {
+
+  private static final double ANIMATION_DELAY_FACTOR = 1.5;
+
+  private MapView mapView;
+  private MapboxMap mapboxMap;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_camera_animator);
+
+    mapView = (MapView) findViewById(R.id.mapView);
+    if (mapView != null) {
+      mapView.onCreate(savedInstanceState);
+      mapView.getMapAsync(this);
+    }
+  }
+
+  @Override
+  public void onMapReady(final MapboxMap map) {
+    mapboxMap = map;
+    findViewById(R.id.fab).setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View view) {
+        view.setVisibility(View.GONE);
+        createAnimator(mapboxMap.getCameraPosition()).start();
+      }
+    });
+  }
+
+  private Animator createAnimator(CameraPosition currentPosition) {
+    AnimatorSet animatorSet = new AnimatorSet();
+    animatorSet.play(createLatLngAnimator(currentPosition.target));
+    animatorSet.play(createZoomAnimator(currentPosition.zoom));
+    animatorSet.play(createBearingAnimator(currentPosition.bearing));
+    animatorSet.play(createTiltAnimator(currentPosition.tilt));
+    return animatorSet;
+  }
+
+  private Animator createLatLngAnimator(LatLng currentPosition) {
+    LatLng target = new LatLng(37.789992, -122.402214);
+    ValueAnimator latLngAnimator = ValueAnimator.ofObject(new LatLngEvaluator(), currentPosition, target);
+    latLngAnimator.setDuration((long) (1000 * ANIMATION_DELAY_FACTOR));
+    latLngAnimator.setInterpolator(new FastOutSlowInInterpolator());
+    latLngAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
+      @Override
+      public void onAnimationUpdate(ValueAnimator animation) {
+        mapboxMap.setLatLng((LatLng) animation.getAnimatedValue());
+      }
+    });
+    return latLngAnimator;
+  }
+
+  private Animator createZoomAnimator(double currentZoom) {
+    ValueAnimator zoomAnimator = ValueAnimator.ofFloat((float) currentZoom, 14.5f);
+    zoomAnimator.setDuration((long) (2200 * ANIMATION_DELAY_FACTOR));
+    zoomAnimator.setStartDelay((long) (600 * ANIMATION_DELAY_FACTOR));
+    zoomAnimator.setInterpolator(new AnticipateOvershootInterpolator());
+    zoomAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
+      @Override
+      public void onAnimationUpdate(ValueAnimator animation) {
+        mapboxMap.setZoom((Float) animation.getAnimatedValue());
+      }
+    });
+    return zoomAnimator;
+  }
+
+  private Animator createBearingAnimator(double currentBearing) {
+    ValueAnimator bearingAnimator = ValueAnimator.ofFloat((float) currentBearing, 135);
+    bearingAnimator.setDuration((long) (1000 * ANIMATION_DELAY_FACTOR));
+    bearingAnimator.setStartDelay((long) (1000 * ANIMATION_DELAY_FACTOR));
+    bearingAnimator.setInterpolator(new FastOutLinearInInterpolator());
+    bearingAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
+      @Override
+      public void onAnimationUpdate(ValueAnimator animation) {
+        mapboxMap.setBearing((Float) animation.getAnimatedValue());
+      }
+    });
+    return bearingAnimator;
+  }
+
+  private Animator createTiltAnimator(double currentTilt) {
+    ValueAnimator tiltAnimator = ValueAnimator.ofFloat((float) currentTilt, 60);
+    tiltAnimator.setDuration((long) (1000 * ANIMATION_DELAY_FACTOR));
+    tiltAnimator.setStartDelay((long) (1500 * ANIMATION_DELAY_FACTOR));
+    tiltAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
+      @Override
+      public void onAnimationUpdate(ValueAnimator animation) {
+        mapboxMap.setTilt((Float) animation.getAnimatedValue());
+      }
+    });
+    return tiltAnimator;
+  }
+
+  private static class LatLngEvaluator implements TypeEvaluator<LatLng> {
+
+    private final LatLng latLng = new LatLng();
+
+    @Override
+    public LatLng evaluate(float fraction, LatLng startValue, LatLng endValue) {
+      latLng.setLatitude(startValue.getLatitude()
+        + ((endValue.getLatitude() - startValue.getLatitude()) * fraction));
+      latLng.setLongitude(startValue.getLongitude()
+        + ((endValue.getLongitude() - startValue.getLongitude()) * fraction));
+      return latLng;
+    }
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/drawable/ic_play_arrow_black_24dp.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/drawable/ic_play_arrow_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M8,5v14l11,-7z"/>
+</vector>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_camera_animator.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_camera_animator.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinator_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:mapbox_cameraTargetLat="37.774913"
+        app:mapbox_cameraTargetLng="-122.419368"
+        app:mapbox_cameraZoom="11"
+        app:mapbox_styleUrl="@string/mapbox_style_mapbox_streets"/>
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end|bottom"
+        android:layout_margin="@dimen/fab_margin"
+        android:src="@drawable/ic_play_arrow_black_24dp"
+        app:backgroundTint="@android:color/white"/>
+
+</android.support.design.widget.CoordinatorLayout>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
@@ -60,4 +60,5 @@
     <string name="description_animated_image_source">Shows how to animate georeferenced images</string>
     <string name="description_bottom_sheet">Show 2 MapView on screen with a bottom sheet</string>
     <string name="description_map_snapshotter">Show a static bitmap taken with the MapSnapshotter</string>
+    <string name="description_camera_animator">Use Android SDK Animators to animate camera position changes</string>
 </resources>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
@@ -60,4 +60,5 @@
     <string name="activity_animated_image_source">Animated Image Source</string>
     <string name="activity_bottom_sheet">Bottom sheet</string>
     <string name="activity_map_snapshotter">Map Snapshotter</string>
+    <string name="activity_camera_animator">Animator animation</string>
 </resources>


### PR DESCRIPTION
Closes #8175, Refs #9808, this PR adds a simple camera API on MapboxMap that can be used in combination with Android SDK animators to perform animations as shown in https://github.com/mapbox/mapbox-gl-native/issues/9808#issuecomment-324274671.

![ezgif com-video-to-gif 26](https://user-images.githubusercontent.com/2151639/30490690-0ce00270-9a3b-11e7-89fa-5bcb0f0210b4.gif)
