### PR TITLE
[core] Don't redo placement for zoom changes at low pitch.

### DIFF
--- a/src/mbgl/text/placement_config.hpp
+++ b/src/mbgl/text/placement_config.hpp
@@ -13,9 +13,9 @@ public:
     bool operator==(const PlacementConfig& rhs) const {
         return angle == rhs.angle &&
             pitch == rhs.pitch &&
-            cameraToCenterDistance == rhs.cameraToCenterDistance &&
-            (pitch * util::RAD2DEG < 25 || cameraToTileDistance == rhs.cameraToTileDistance) &&
-            debug == rhs.debug;
+            debug == rhs.debug &&
+            ((pitch * util::RAD2DEG < 25) ||
+             (cameraToCenterDistance == rhs.cameraToCenterDistance && cameraToTileDistance == rhs.cameraToTileDistance));
     }
 
     bool operator!=(const PlacementConfig& rhs) const {


### PR DESCRIPTION
 Fixes issue #9996 
 Port of GL-JS https://github.com/mapbox/mapbox-gl-js/pull/5284

This PR changes the "redo placement" logic to avoid triggering placement when the zoom level changes but (1) the pitch is relatively low (under 25 degrees), and (2) other transform parameters are unchanged.

/cc @jfirebaugh @ansis 