### PR TITLE
[ios] Explicitly return a BOOL value for nullable dict keys

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -4312,15 +4312,15 @@ public:
         if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusNotDetermined)
         {
             BOOL requiresWhenInUseUsageDescription = [NSProcessInfo.processInfo isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){11,0,0}];
-            BOOL hasWhenInUseUsageDescription = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"];
+            BOOL hasWhenInUseUsageDescription = !![[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"];
             BOOL hasAlwaysUsageDescription;
             if (requiresWhenInUseUsageDescription)
             {
-                hasAlwaysUsageDescription = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysAndWhenInUseUsageDescription"] && hasWhenInUseUsageDescription;
+                hasAlwaysUsageDescription = !![[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysAndWhenInUseUsageDescription"] && hasWhenInUseUsageDescription;
             }
             else
             {
-                hasAlwaysUsageDescription = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"];
+                hasAlwaysUsageDescription = !![[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"];
             }
 
             if (hasAlwaysUsageDescription)


### PR DESCRIPTION
Otherwise it errors with, `cannot initialize a variable of type 'BOOL' (aka 'signed char') with an rvalue of type 'id _Nullable’`.

This change doesn't seem like it should be necessary and, indeed, this error is intermittent and only appears on Release builds. Potentially related to trying to use Xcode 8 after Xcode 9 has futzed with the system or project? 😬

This should have started happening immediately after #9869, but it only really reared its head today.

/cc @fabian-guerra @1ec5