### PR TITLE
Disable rotation gesture when pinch zooming

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/almeros/android/multitouch/gesturedetectors/TwoFingerGestureDetector.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/almeros/android/multitouch/gesturedetectors/TwoFingerGestureDetector.java
@@ -54,8 +54,7 @@ public abstract class TwoFingerGestureDetector extends BaseGestureDetector {
 
     ViewConfiguration config = ViewConfiguration.get(context);
 
-    // We divide edge slop by 2 to make rotation gesture happen more easily #6870
-    edgeSlop = config.getScaledEdgeSlop() / 2;
+    edgeSlop = config.getScaledEdgeSlop();
   }
 
   @Override


### PR DESCRIPTION
This PR reworks our rotation gesture handling to not execute when pinch zooming is occurring. 
This UX matches what other map applications are doing atm. 

![ezgif com-video-to-gif 78](https://user-images.githubusercontent.com/2151639/30593743-ec0a57ee-9d4b-11e7-9e81-7fc1deb2254c.gif)


