### PR TITLE
[build] Shuffle render tests in 'test-node-recycle-map' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -443,7 +443,7 @@ test-node: node
 .PHONY: test-node-recycle-map
 test-node-recycle-map: node
 	npm test
-	npm run test-render -- --recycle-map
+	npm run test-render -- --recycle-map --shuffle
 	npm run test-query
 
 #### Android targets ###########################################################


### PR DESCRIPTION
Enables shuffling render tests when recycling the map object.

I've let it running continuously throughout the last weekend using the following command without any additional issues found:

```
$ true; while [ $? -eq 0 ]; do node platform/node/test/render.test.js --recycle-map --shuffle; done
```

So far we've solved all of the bugs (and bugfixes) found while running this technique. https://github.com/mapbox/mapbox-gl-native/issues/9978 is the last one open, which is fixed in https://github.com/mapbox/mapbox-gl-native/pull/9931.

Depends on: https://github.com/mapbox/mapbox-gl-native/pull/9931.