### PR TITLE
Set error handler when starting snapshotter

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
@@ -29,7 +29,7 @@ public class MapSnapshotter {
    *
    * @see MapSnapshotter#start(MapboxMap.SnapshotReadyCallback, ErrorHandler)
    */
-  public static interface ErrorHandler {
+  public interface ErrorHandler {
 
     /**
      * Called on error. Snapshotting will not
@@ -193,6 +193,7 @@ public class MapSnapshotter {
     }
 
     this.callback = callback;
+    this.errorHandler = errorHandler;
     nativeStart();
   }
 


### PR DESCRIPTION
Follow up from #9748, noticed that we weren't setting ErrorHandler as part of `MapSnapshotter#start`. Which resulted in not invoking the error handler when an error occurred.  Additionally removed the obsolete static keyword on the interface definition of ErrorHandler. 