### PR TITLE
[test/glfw] Add ability to take application offline

### DIFF
--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -140,6 +140,7 @@ public:
     void resume();
 
     // For testing only.
+    void setOnlineStatus(bool);
     void put(const Resource&, const Response&);
 
     class Impl;

--- a/include/mbgl/storage/online_file_source.hpp
+++ b/include/mbgl/storage/online_file_source.hpp
@@ -24,6 +24,9 @@ public:
 
     std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
 
+    // For testing only.
+    void setOnlineStatus(bool);
+
 private:
     friend class OnlineFileRequest;
 

--- a/platform/default/default_file_source.cpp
+++ b/platform/default/default_file_source.cpp
@@ -177,6 +177,10 @@ public:
         offlineDatabase->setOfflineMapboxTileCountLimit(limit);
     }
 
+    void setOnlineStatus(const bool status) {
+        onlineFileSource.setOnlineStatus(status);
+    }
+
     void put(const Resource& resource, const Response& response) {
         offlineDatabase->put(resource, response);
     }
@@ -302,6 +306,10 @@ void DefaultFileSource::resume() {
 }
 
 // For testing only:
+
+void DefaultFileSource::setOnlineStatus(const bool status) {
+    impl->actor().invoke(&Impl::setOnlineStatus, status);
+}
 
 void DefaultFileSource::put(const Resource& resource, const Response& response) {
     impl->actor().invoke(&Impl::put, resource, response);

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -110,6 +110,7 @@ GLFWView::GLFWView(bool fullscreen_, bool benchmark_)
     printf("- Press `N` to reset north\n");
     printf("- Press `R` to enable the route demo\n");
     printf("- Press `E` to insert an example building extrusion layer\n");
+    printf("- Press `O` to toggle online connectivity\n");
     printf("- Press `Z` to cycle through north orientations\n");
     printf("- Prezz `X` to cycle through the viewport modes\n");
     printf("- Press `A` to cycle through Mapbox offices in the world + dateline monument\n");
@@ -175,6 +176,9 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
         case GLFW_KEY_X:
             if (!mods)
                 view->map->resetPosition();
+            break;
+        case GLFW_KEY_O:
+            view->onlineStatusCallback();
             break;
         case GLFW_KEY_S:
             if (view->changeStyleCallback)

--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -28,6 +28,10 @@ public:
         pauseResumeCallback = callback;
     };
 
+    void setOnlineStatusCallback(std::function<void()> callback) {
+        onlineStatusCallback = callback;
+    }
+
     void setShouldClose();
 
     void setWindowTitle(const std::string&);
@@ -111,6 +115,7 @@ private:
 
     std::function<void()> changeStyleCallback;
     std::function<void()> pauseResumeCallback;
+    std::function<void()> onlineStatusCallback;
     std::function<void(mbgl::Map*)> animateRouteCallback;
 
     mbgl::util::RunLoop runLoop;

--- a/platform/glfw/settings_json.cpp
+++ b/platform/glfw/settings_json.cpp
@@ -14,6 +14,7 @@ void Settings_JSON::load() {
         file >> bearing;
         file >> pitch;
         file >> debug;
+        file >> online;
     }
 }
 
@@ -26,6 +27,7 @@ void Settings_JSON::save() {
         file << bearing << std::endl;
         file << pitch << std::endl;
         file << debug << std::endl;
+        file << online << std::endl;
     }
 }
 
@@ -36,6 +38,7 @@ void Settings_JSON::clear() {
     bearing = 0;
     pitch = 0;
     debug = 0;
+    online = true;
 }
 
 } // namespace mbgl

--- a/platform/glfw/settings_json.hpp
+++ b/platform/glfw/settings_json.hpp
@@ -19,6 +19,7 @@ public:
     double pitch = 0;
 
     EnumType debug = 0;
+    bool online = true;
 };
 
 } // namespace mbgl


### PR DESCRIPTION
During testing of https://github.com/mapbox/mapbox-gl-native/pull/10011, I heavily used this modification to the `OnlineFileSource` and GLFW, which made testing offline behavior much easier since I didn't have to toggle wifi, or use tools like Little Snitch to block application connectivity.