### PR TITLE
[core] fix loading of stale must-revalidate resources

### DIFF
--- a/src/mbgl/tile/tile_loader_impl.hpp
+++ b/src/mbgl/tile/tile_loader_impl.hpp
@@ -61,7 +61,10 @@ void TileLoader<T>::loadOptional() {
             // When the optional request could not be satisfied, don't treat it as an error.
             // Instead, we make sure that the next request knows that there has been an optional
             // request before by setting one of the prior* fields.
+            resource.priorModified = res.modified;
             resource.priorExpires = Timestamp{ Seconds::zero() };
+            resource.priorEtag = res.etag;
+            resource.priorData = res.data;
         } else {
             loadedData(res);
         }


### PR DESCRIPTION
In https://github.com/mapbox/mapbox-gl-native/pull/9670, we implemented support for the `Cache-Control: must-revalidate` header. While we now respect this header and don't show resources that are stale and have this header set, the **optional** cache request never completes. This means we're also never going to try to actually get a fresh tile and just never show this tile anymore.

This commit fixes this by responding with a Not Found error when the resource is unusable (= stale and has must-revalidate set). Since we actually still have the data (but can't use it due to caching rules), we're responding with the data as well. To avoid a second cache hit, `tile_loader_impl.hpp` now passes on the data from the Optional to the Required request so that it can be reused when we get a 304 Not Modified response from the server.

This bug wasn't caught be existing tests, since we're not doing `Necessity::Optional` requests with the `DefaultFileSource`.