### PR TITLE
Insert tiles and resources from iOS

### DIFF
--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -122,6 +122,8 @@ public:
      * by the Mapbox Terms of Service.
      */
     void setOfflineMapboxTileCountLimit(uint64_t) const;
+    
+    void startPutRegionResource(OfflineRegion& region, const Resource& resource, const Response& response, const bool compressed, std::function<void (std::exception_ptr)> callback);
 
     /*
      * Pause file request activity.

--- a/platform/darwin/src/MGLOfflineStorage.h
+++ b/platform/darwin/src/MGLOfflineStorage.h
@@ -284,12 +284,12 @@ MGL_EXPORT
 /**
  Insert a tile into the cache.
  */
--(void)putTileWithUrlTemplate:(NSString *)urlTemplate pixelRatio:(float)pixelRatio x:(int32_t)x y:(int32_t)y z:(int8_t)z data:(NSData *)data compressed:(BOOL)compressed expires:(NSDate *)expires pack:(MGLOfflinePack *)pack completionHandler:(void (^)(NSError * _Nullable error))completion;
+-(void)putTileWithUrlTemplate:(NSString *)urlTemplate pixelRatio:(float)pixelRatio x:(int32_t)x y:(int32_t)y z:(int8_t)z data:(NSData *)data compressed:(BOOL)compressed modified:(NSDate *)modified expires:(NSDate *)expires etag:(NSString *)etag pack:(MGLOfflinePack *)pack completionHandler:(void (^)(NSError * _Nullable error))completion;
 
 /**
  Insert a resource into the cache.
  */
--(void)putResourceWithUrl:(NSString *)url data:(NSData *)data compressed:(BOOL)compressed expires:(NSDate *)expires pack:(MGLOfflinePack *)pack completionHandler:(void (^)(NSError * _Nullable error))completion;
+-(void)putResourceWithUrl:(NSString *)url data:(NSData *)data compressed:(BOOL)compressed modified:(NSDate *)modified expires:(NSDate *)expires etag:(NSString *)etag pack:(MGLOfflinePack *)pack completionHandler:(void (^)(NSError * _Nullable error))completion;
 
 /**
  The cumulative size, measured in bytes, of all downloaded resources on disk.

--- a/platform/darwin/src/MGLOfflineStorage.h
+++ b/platform/darwin/src/MGLOfflineStorage.h
@@ -282,6 +282,16 @@ MGL_EXPORT
 - (void)setMaximumAllowedMapboxTiles:(uint64_t)maximumCount;
 
 /**
+ Insert a tile into the cache.
+ */
+-(void)putTileWithUrlTemplate:(NSString *)urlTemplate pixelRatio:(float)pixelRatio x:(int32_t)x y:(int32_t)y z:(int8_t)z data:(NSData *)data compressed:(BOOL)compressed expires:(NSDate *)expires pack:(MGLOfflinePack *)pack completionHandler:(void (^)(NSError * _Nullable error))completion;
+
+/**
+ Insert a resource into the cache.
+ */
+-(void)putResourceWithUrl:(NSString *)url data:(NSData *)data compressed:(BOOL)compressed expires:(NSDate *)expires pack:(MGLOfflinePack *)pack completionHandler:(void (^)(NSError * _Nullable error))completion;
+
+/**
  The cumulative size, measured in bytes, of all downloaded resources on disk.
 
  The returned value includes all resources, including tiles, whether downloaded

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -382,10 +382,18 @@ NSString * const MGLOfflinePackMaximumCountUserInfoKey = MGLOfflinePackUserInfoK
 /**
  Insert a tile into the offline storage coupled with a offline pack. The compressed flag tells wether the data is (zlib) compressed or not.
  */
--(void)putTileWithUrlTemplate:(NSString *)urlTemplate pixelRatio:(float)pixelRatio x:(int32_t)x y:(int32_t)y z:(int8_t)z data:(NSData *)data compressed:(BOOL)compressed expires:(NSDate *)expires pack:(MGLOfflinePack *)pack completionHandler:(void (^)(NSError * _Nullable error))completion {
+-(void)putTileWithUrlTemplate:(NSString *)urlTemplate pixelRatio:(float)pixelRatio x:(int32_t)x y:(int32_t)y z:(int8_t)z data:(NSData *)data compressed:(BOOL)compressed modified:(NSDate *)modified expires:(NSDate *)expires etag:(NSString *)etag pack:(MGLOfflinePack *)pack completionHandler:(void (^)(NSError * _Nullable error))completion {
     mbgl::Resource resource = mbgl::Resource::tile([urlTemplate UTF8String], pixelRatio, x, y, z, mbgl::Tileset::Scheme::XYZ);
     mbgl::Response response = mbgl::Response();
     response.data = std::make_shared<std::string>(static_cast<const char*>(data.bytes), data.length);
+    
+    if (etag) {
+        response.etag = std::string([etag UTF8String]);
+    }
+    
+    if (modified) {
+        response.modified = mbgl::util::now() + mbgl::Seconds(static_cast<long long>(modified.timeIntervalSinceNow));
+    }
     
     if (expires) {
         response.expires = mbgl::util::now() + mbgl::Seconds(static_cast<long long>(expires.timeIntervalSinceNow));
@@ -397,10 +405,18 @@ NSString * const MGLOfflinePackMaximumCountUserInfoKey = MGLOfflinePackUserInfoK
 /**
  Insert a resource into the offline storage coupled with a offline pack. The compressed flag tells wether the data is (zlib) compressed or not.
  */
--(void)putResourceWithUrl:(NSString *)url data:(NSData *)data compressed:(BOOL)compressed expires:(NSDate *)expires pack:(MGLOfflinePack *)pack completionHandler:(void (^)(NSError * _Nullable error))completion {
+-(void)putResourceWithUrl:(NSString *)url data:(NSData *)data compressed:(BOOL)compressed modified:(NSDate *)modified expires:(NSDate *)expires etag:(NSString *)etag pack:(MGLOfflinePack *)pack completionHandler:(void (^)(NSError * _Nullable error))completion {
     mbgl::Resource resource = mbgl::Resource(mbgl::Resource::Kind::Unknown, [url UTF8String]);
     mbgl::Response response = mbgl::Response();
     response.data = std::make_shared<std::string>(static_cast<const char*>(data.bytes), data.length);
+    
+    if (etag) {
+        response.etag = std::string([etag UTF8String]);
+    }
+    
+    if (modified) {
+        response.modified = mbgl::util::now() + mbgl::Seconds(static_cast<long long>(modified.timeIntervalSinceNow));
+    }
     
     if (expires) {
         response.expires = mbgl::util::now() + mbgl::Seconds(static_cast<long long>(expires.timeIntervalSinceNow));

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -15,6 +15,9 @@
 #include <mbgl/storage/resource_transform.hpp>
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/util/string.hpp>
+#include <mbgl/storage/resource.hpp>
+#include <mbgl/storage/response.hpp>
+#include <mbgl/util/chrono.hpp>
 
 #include <memory>
 
@@ -374,6 +377,56 @@ NSString * const MGLOfflinePackMaximumCountUserInfoKey = MGLOfflinePackUserInfoK
 
 - (void)setMaximumAllowedMapboxTiles:(uint64_t)maximumCount {
     _mbglFileSource->setOfflineMapboxTileCountLimit(maximumCount);
+}
+
+/**
+ Insert a tile into the offline storage coupled with a offline pack. The compressed flag tells wether the data is (zlib) compressed or not.
+ */
+-(void)putTileWithUrlTemplate:(NSString *)urlTemplate pixelRatio:(float)pixelRatio x:(int32_t)x y:(int32_t)y z:(int8_t)z data:(NSData *)data compressed:(BOOL)compressed expires:(NSDate *)expires pack:(MGLOfflinePack *)pack completionHandler:(void (^)(NSError * _Nullable error))completion {
+    mbgl::Resource resource = mbgl::Resource::tile([urlTemplate UTF8String], pixelRatio, x, y, z, mbgl::Tileset::Scheme::XYZ);
+    mbgl::Response response = mbgl::Response();
+    response.data = std::make_shared<std::string>(static_cast<const char*>(data.bytes), data.length);
+    
+    if (expires) {
+        response.expires = mbgl::util::now() + mbgl::Seconds(static_cast<long long>(expires.timeIntervalSinceNow));
+    }
+    
+    [self _putResource:resource response:response compressed:compressed pack:pack completionHandler:completion];
+}
+
+/**
+ Insert a resource into the offline storage coupled with a offline pack. The compressed flag tells wether the data is (zlib) compressed or not.
+ */
+-(void)putResourceWithUrl:(NSString *)url data:(NSData *)data compressed:(BOOL)compressed expires:(NSDate *)expires pack:(MGLOfflinePack *)pack completionHandler:(void (^)(NSError * _Nullable error))completion {
+    mbgl::Resource resource = mbgl::Resource(mbgl::Resource::Kind::Unknown, [url UTF8String]);
+    mbgl::Response response = mbgl::Response();
+    response.data = std::make_shared<std::string>(static_cast<const char*>(data.bytes), data.length);
+    
+    if (expires) {
+        response.expires = mbgl::util::now() + mbgl::Seconds(static_cast<long long>(expires.timeIntervalSinceNow));
+    }
+
+    [self _putResource:resource response:response compressed:compressed pack:pack completionHandler:completion];
+}
+
+-(void)_putResource:(mbgl::Resource)resource
+          response:(mbgl::Response)response
+        compressed:(BOOL)compressed
+              pack:(MGLOfflinePack *)pack
+ completionHandler:(void (^)(NSError * _Nullable error))completion {
+    _mbglFileSource->startPutRegionResource(*pack.mbglOfflineRegion, resource, response, compressed, [&, completion](std::exception_ptr exception) {
+        NSError *error;
+        if (exception) {
+            error = [NSError errorWithDomain:MGLErrorDomain code:-1 userInfo:@{
+                                                                               NSLocalizedDescriptionKey: @(mbgl::util::toString(exception).c_str()),
+                                                                               }];
+        }
+        if (completion) {
+            dispatch_async(dispatch_get_main_queue(), [&, completion, error](void) {
+                completion(error);
+            });
+        }
+    });
 }
 
 #pragma mark -

--- a/platform/default/default_file_source.cpp
+++ b/platform/default/default_file_source.cpp
@@ -184,6 +184,15 @@ public:
     void put(const Resource& resource, const Response& response) {
         offlineDatabase->put(resource, response);
     }
+    
+    void startPutRegionResource(const int64_t regionID, const Resource& resource, const Response&  response, const bool compressed, std::function<void (std::exception_ptr)> callback) {
+        try {
+            offlineDatabase->putRegionResource(regionID, resource, response, compressed);
+            callback({});
+        } catch (...) {
+            callback(std::current_exception());
+        }
+    }
 
 private:
     OfflineDownload& getDownload(int64_t regionID) {
@@ -296,6 +305,10 @@ void DefaultFileSource::getOfflineRegionStatus(OfflineRegion& region, std::funct
 void DefaultFileSource::setOfflineMapboxTileCountLimit(uint64_t limit) const {
     impl->actor().invoke(&Impl::setOfflineMapboxTileCountLimit, limit);
 }
+    
+void DefaultFileSource::startPutRegionResource(OfflineRegion& region, const Resource& resource, const Response& response, const bool compressed, std::function<void (std::exception_ptr)> callback) {
+    impl->actor().invoke(&Impl::startPutRegionResource, region.getID(), resource, response, compressed, callback);
+}
 
 void DefaultFileSource::pause() {
     impl->pause();
@@ -304,7 +317,7 @@ void DefaultFileSource::pause() {
 void DefaultFileSource::resume() {
     impl->resume();
 }
-
+    
 // For testing only:
 
 void DefaultFileSource::setOnlineStatus(const bool status) {

--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -207,6 +207,34 @@ std::pair<bool, uint64_t> OfflineDatabase::putInternal(const Resource& resource,
 
     return { inserted, size };
 }
+    
+std::pair<bool, uint64_t> OfflineDatabase::putInternal(const Resource& resource, const Response& response, bool evict_, bool compressed) {
+    if (response.error) {
+        return { false, 0 };
+    }
+    
+    uint64_t size = response.data->size();
+    
+    if (evict_ && !evict(size)) {
+        Log::Debug(Event::Database, "Unable to make space for entry");
+        return { false, 0 };
+    }
+    
+    bool inserted;
+    
+    if (resource.kind == Resource::Kind::Tile) {
+        assert(resource.tileData);
+        inserted = putTile(*resource.tileData, response,
+                           *response.data,
+                           compressed);
+    } else {
+        inserted = putResource(resource, response,
+                               *response.data,
+                               compressed);
+    }
+    
+    return { inserted, size };
+}
 
 optional<std::pair<Response, uint64_t>> OfflineDatabase::getResource(const Resource& resource) {
     // clang-format off
@@ -641,6 +669,20 @@ optional<int64_t> OfflineDatabase::hasRegionResource(int64_t regionID, const Res
 
 uint64_t OfflineDatabase::putRegionResource(int64_t regionID, const Resource& resource, const Response& response) {
     uint64_t size = putInternal(resource, response, false).second;
+    bool previouslyUnused = markUsed(regionID, resource);
+    
+    if (offlineMapboxTileCount
+        && resource.kind == Resource::Kind::Tile
+        && util::mapbox::isMapboxURL(resource.url)
+        && previouslyUnused) {
+        *offlineMapboxTileCount += 1;
+    }
+    
+    return size;
+}
+
+uint64_t OfflineDatabase::putRegionResource(int64_t regionID, const Resource& resource, const Response& response, const bool compressed) {
+    uint64_t size = putInternal(resource, response, false, compressed).second;
     bool previouslyUnused = markUsed(regionID, resource);
 
     if (offlineMapboxTileCount

--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -48,6 +48,7 @@ public:
     optional<std::pair<Response, uint64_t>> getRegionResource(int64_t regionID, const Resource&);
     optional<int64_t> hasRegionResource(int64_t regionID, const Resource&);
     uint64_t putRegionResource(int64_t regionID, const Resource&, const Response&);
+    uint64_t putRegionResource(int64_t regionID, const Resource&, const Response&, const bool compressed);
 
     OfflineRegionDefinition getRegionDefinition(int64_t regionID);
     OfflineRegionStatus getRegionCompletedStatus(int64_t regionID);
@@ -94,6 +95,7 @@ private:
     optional<std::pair<Response, uint64_t>> getInternal(const Resource&);
     optional<int64_t> hasInternal(const Resource&);
     std::pair<bool, uint64_t> putInternal(const Resource&, const Response&, bool evict);
+    std::pair<bool, uint64_t> putInternal(const Resource&, const Response&, bool evict, bool compressed);
 
     // Return value is true iff the resource was previously unused by any other regions.
     bool markUsed(int64_t regionID, const Resource&);


### PR DESCRIPTION
Allow apps to insert tiles and resources into the offline storage. I use this to download server-generated offline archives and then inserting all of the tiles and resources into the offline storage.

See #9947