### PR TITLE
[ios] Various Xcode 9 fixes

### DIFF
--- a/platform/darwin/src/NSString+MGLAdditions.m
+++ b/platform/darwin/src/NSString+MGLAdditions.m
@@ -12,7 +12,14 @@
 
 - (NSString *)mgl_titleCasedStringWithLocale:(NSLocale *)locale {
     NSMutableString *string = self.mutableCopy;
-    [string enumerateLinguisticTagsInRange:string.mgl_wholeRange scheme:NSLinguisticTagSchemeLexicalClass options:0 orthography:nil usingBlock:^(NSString * _Nonnull tag, NSRange tokenRange, NSRange sentenceRange, BOOL * _Nonnull stop) {
+    NSOrthography *orthography;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+    if ([NSOrthography respondsToSelector:@selector(defaultOrthographyForLanguage:)]) {
+        orthography = [NSOrthography defaultOrthographyForLanguage:locale.localeIdentifier];
+    }
+#pragma clang diagnostic pop
+    [string enumerateLinguisticTagsInRange:string.mgl_wholeRange scheme:NSLinguisticTagSchemeLexicalClass options:0 orthography:orthography usingBlock:^(NSString * _Nonnull tag, NSRange tokenRange, NSRange sentenceRange, BOOL * _Nonnull stop) {
         NSString *word = [string substringWithRange:tokenRange];
         if (word.length > 3
             || !([tag isEqualToString:NSLinguisticTagConjunction]

--- a/platform/darwin/src/NSString+MGLAdditions.m
+++ b/platform/darwin/src/NSString+MGLAdditions.m
@@ -13,12 +13,14 @@
 - (NSString *)mgl_titleCasedStringWithLocale:(NSLocale *)locale {
     NSMutableString *string = self.mutableCopy;
     NSOrthography *orthography;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability-new"
     if ([NSOrthography respondsToSelector:@selector(defaultOrthographyForLanguage:)]) {
         orthography = [NSOrthography defaultOrthographyForLanguage:locale.localeIdentifier];
     }
 #pragma clang diagnostic pop
+#endif
     [string enumerateLinguisticTagsInRange:string.mgl_wholeRange scheme:NSLinguisticTagSchemeLexicalClass options:0 orthography:orthography usingBlock:^(NSString * _Nonnull tag, NSRange tokenRange, NSRange sentenceRange, BOOL * _Nonnull stop) {
         NSString *word = [string substringWithRange:tokenRange];
         if (word.length > 3

--- a/platform/darwin/test/MGLNSStringAdditionsTests.m
+++ b/platform/darwin/test/MGLNSStringAdditionsTests.m
@@ -19,7 +19,7 @@
 
     XCTAssertEqualObjects([@"Improve the map" mgl_titleCasedStringWithLocale:locale], @"Improve the Map");
     XCTAssertEqualObjects([@"Improve The Map" mgl_titleCasedStringWithLocale:locale], @"Improve The Map");
-
+    
     XCTAssertEqualObjects([@"Improve a map" mgl_titleCasedStringWithLocale:locale], @"Improve a Map");
     XCTAssertEqualObjects([@"Improve A Map" mgl_titleCasedStringWithLocale:locale], @"Improve A Map");
 

--- a/platform/darwin/test/MGLSDKTestHelpers.swift
+++ b/platform/darwin/test/MGLSDKTestHelpers.swift
@@ -25,7 +25,8 @@ extension MGLSDKTestHelpers {
         let methodDescriptionList: UnsafeMutablePointer<objc_method_description>! = protocol_copyMethodDescriptionList(p, false, true, &methodCount)
         for i in 0..<Int(methodCount) {
             let description: objc_method_description = methodDescriptionList[i]
-            methods.insert(description.name.description)
+            XCTAssertNotNil(description.name?.description)
+            methods.insert(description.name!.description)
         }
         free(methodDescriptionList)
         return methods

--- a/platform/darwin/test/MGLStyleValueTests.swift
+++ b/platform/darwin/test/MGLStyleValueTests.swift
@@ -267,22 +267,50 @@ extension MGLStyleValueTests {
             options: [.defaultValue: defaultRadius]
         )
         circleStyleLayer.circleRadius = expectedCompositeCategoricalValue
-        XCTAssertEqual(circleStyleLayer.circleRadius, expectedCompositeCategoricalValue)
+        
+        var compositeValue = circleStyleLayer.circleRadius as! MGLCompositeStyleFunction
+        var expectedCompositeValue = expectedCompositeCategoricalValue as! MGLCompositeStyleFunction
+        XCTAssertEqual(compositeValue.attributeName, expectedCompositeValue.attributeName)
+        XCTAssertEqual(compositeValue.stops as NSDictionary, radiusCompositeCategoricalStops as NSDictionary)
+        XCTAssertEqual(compositeValue.interpolationMode, expectedCompositeValue.interpolationMode)
+        XCTAssertEqual(compositeValue.defaultValue, expectedCompositeValue.defaultValue)
 
         // data-driven, composite function with inner exponential color stop values nested in outer camera stops
         let radiusCompositeExponentialOrIntervalStops: [Float: [Float: MGLStyleValue<NSNumber>]] = [
-            0: [0: smallRadius],
-            10: [200: smallRadius],
-            20: [200: largeRadius]
+            0: [0: MGLStyleValue<NSNumber>(rawValue: 5)],
+            10: [200: MGLStyleValue<NSNumber>(rawValue: 5)],
+            20: [200: MGLStyleValue<NSNumber>(rawValue: 20)]
         ]
+
+        let expectedStops = [
+            0: [0: MGLStyleValue<NSNumber>(rawValue: 5)],
+            10: [200: MGLStyleValue<NSNumber>(rawValue: 5)],
+            20: [200: MGLStyleValue<NSNumber>(rawValue: 20)]
+        ]
+        circleStyleLayer.circleRadius = MGLStyleValue<NSNumber>(
+            interpolationMode: .exponential,
+            compositeStops: [
+                0: [0: MGLStyleValue<NSNumber>(rawValue: 5)],
+                10: [200: MGLStyleValue<NSNumber>(rawValue: 5)],
+                20: [200: MGLStyleValue<NSNumber>(rawValue: 20)]
+            ],
+            attributeName: "temp",
+            options: [.defaultValue: mediumRadius]
+        )
+        
         let expectedCompositeExponentialValue = MGLStyleValue<NSNumber>(
             interpolationMode: .exponential,
             compositeStops: radiusCompositeExponentialOrIntervalStops,
             attributeName: "temp",
             options: [.defaultValue: mediumRadius]
         )
-        circleStyleLayer.circleRadius = expectedCompositeExponentialValue
-        XCTAssertEqual(circleStyleLayer.circleRadius, expectedCompositeExponentialValue)
+
+        compositeValue = circleStyleLayer.circleRadius as! MGLCompositeStyleFunction
+        expectedCompositeValue = expectedCompositeExponentialValue as! MGLCompositeStyleFunction
+        XCTAssertEqual(compositeValue.attributeName, expectedCompositeValue.attributeName)
+        XCTAssertEqual(compositeValue.stops as NSDictionary, expectedStops as NSDictionary)
+        XCTAssertEqual(compositeValue.interpolationMode, expectedCompositeValue.interpolationMode)
+        XCTAssertEqual(compositeValue.defaultValue, expectedCompositeValue.defaultValue)
 
         // get a value back
         if let returnedCircleRadius = circleStyleLayer.circleRadius as? MGLCompositeStyleFunction<NSNumber> {
@@ -305,11 +333,30 @@ extension MGLStyleValueTests {
         // data-driven, composite function with inner interval color stop values nested in outer camera stops
         let expectedCompositeIntervalValue = MGLStyleValue<NSNumber>(
             interpolationMode: .interval,
-            compositeStops: radiusCompositeExponentialOrIntervalStops,
+            compositeStops: [
+                
+                10: [200: MGLStyleValue<NSNumber>(rawValue: 5)],
+                20: [200: MGLStyleValue<NSNumber>(rawValue: 20)]
+            ],
             attributeName: "temp",
             options: nil
         )
-        circleStyleLayer.circleRadius = expectedCompositeIntervalValue
-        XCTAssertEqual(circleStyleLayer.circleRadius, expectedCompositeIntervalValue)
+        circleStyleLayer.circleRadius = MGLStyleValue<NSNumber>(
+            interpolationMode: .interval,
+            compositeStops: [
+                0: [0: MGLStyleValue<NSNumber>(rawValue: 5)],
+                10: [200: MGLStyleValue<NSNumber>(rawValue: 5)],
+                20: [200: MGLStyleValue<NSNumber>(rawValue: 20)]
+            ],
+            attributeName: "temp",
+            options: nil
+        )
+        
+        compositeValue = circleStyleLayer.circleRadius as! MGLCompositeStyleFunction
+        expectedCompositeValue = expectedCompositeIntervalValue as! MGLCompositeStyleFunction
+        XCTAssertEqual(compositeValue.attributeName, expectedCompositeValue.attributeName)
+        XCTAssertEqual(compositeValue.stops as NSDictionary, expectedStops as NSDictionary)
+        XCTAssertEqual(compositeValue.interpolationMode, expectedCompositeValue.interpolationMode)
+        XCTAssertEqual(compositeValue.defaultValue, expectedCompositeValue.defaultValue)
     }
 }

--- a/platform/darwin/test/MGLStyleValueTests.swift
+++ b/platform/darwin/test/MGLStyleValueTests.swift
@@ -6,16 +6,34 @@ typealias MGLColor = UIColor
 #elseif os(macOS)
 typealias MGLColor = NSColor
 #endif
+
+#if swift(>=3.2)
+#else
+func XCTAssertEqual<T: FloatingPoint>(_ lhs: @autoclosure () throws -> T, _ rhs: @autoclosure () throws -> T, accuracy: T) {
+    XCTAssertEqualWithAccuracy(lhs, rhs, accuracy: accuracy)
+}
+#endif
     
 extension MGLStyleValueTests {
+    
+    struct Color {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+    }
+    
     func assertColorsEqualWithAccuracy(_ actual: MGLColor, _ expected: MGLColor, accuracy: Float = 1/255) {
-        var actualComponents : [CGFloat] = [0, 0, 0, 0]
-        var expectedComponents : [CGFloat] = [0, 0, 0, 0]
-        actual.getRed(&(actualComponents[0]), green: &(actualComponents[1]), blue: &(actualComponents[2]), alpha: &(actualComponents[3]))
-        expected.getRed(&(expectedComponents[0]), green: &(expectedComponents[1]), blue: &(expectedComponents[2]), alpha: &(expectedComponents[3]))
-        for (ac, ec) in zip(actualComponents, expectedComponents) {
-            XCTAssertEqualWithAccuracy(Float(ac), Float(ec), accuracy: accuracy)
-        }
+        var actualColor = Color()
+        var expectedColor = Color()
+        
+        actual.getRed(&actualColor.red, green: &actualColor.green, blue: &actualColor.blue, alpha: &actualColor.alpha)
+        expected.getRed(&expectedColor.red, green: &expectedColor.green, blue: &expectedColor.blue, alpha: &expectedColor.alpha)
+
+        XCTAssertEqual(Float(actualColor.red), Float(expectedColor.red), accuracy: accuracy)
+        XCTAssertEqual(Float(actualColor.green), Float(expectedColor.green), accuracy: accuracy)
+        XCTAssertEqual(Float(actualColor.blue), Float(expectedColor.blue), accuracy: accuracy)
+        XCTAssertEqual(Float(actualColor.alpha), Float(expectedColor.alpha), accuracy: accuracy)
     }
     
     func assertColorValuesEqual(_ actual: MGLStyleValue<MGLColor>, _ expected: MGLStyleValue<MGLColor>) {

--- a/platform/ios/DEVELOPING.md
+++ b/platform/ios/DEVELOPING.md
@@ -151,13 +151,6 @@ make darwin-update-examples
 
 `make ios-test` builds and runs unit tests of cross-platform code as well as the SDK.
 
-Before you can run unit tests of the cross-platform code on the command line, install ios-sim version 3.2.0 (not any other version):
-
-```bash
-brew tap mapbox/homebrew-ios-sim-3
-brew install mapbox/homebrew-ios-sim-3/ios-sim
-```
-
 To instead run the cross-platform tests in Xcode instead of on the command line:
 
 1. Run `make iproj` to set up the workspace.

--- a/platform/ios/bitrise.yml
+++ b/platform/ios/bitrise.yml
@@ -17,8 +17,6 @@ workflows:
             #!/bin/bash
             set -eu -o pipefail
             brew install cmake
-            brew tap mapbox/homebrew-ios-sim-3
-            brew install mapbox/homebrew-ios-sim-3/ios-sim
         - is_debug: 'yes'
     - script:
         title: Generate Workspace


### PR DESCRIPTION
Fixes compilation for Xcode 9

- Replaced deprecated method
- Obj-C method description name is optional in Swift as of Xcode 9.
- Stricter indirect values (Color.getRed:green:blue)
 - [x] Fix backwards compatibility

@kkaefer @boundsj 👀 