### PR TITLE
[core] Move *TileID hashing to separate header

### DIFF
--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -490,6 +490,7 @@ set(MBGL_CORE_FILES
     src/mbgl/text/shaping.hpp
 
     # tile
+    include/mbgl/tile/tile_id.hpp
     src/mbgl/tile/geojson_tile.cpp
     src/mbgl/tile/geojson_tile.hpp
     src/mbgl/tile/geometry_tile.cpp
@@ -506,7 +507,7 @@ set(MBGL_CORE_FILES
     src/mbgl/tile/tile.hpp
     src/mbgl/tile/tile_cache.cpp
     src/mbgl/tile/tile_cache.hpp
-    src/mbgl/tile/tile_id.hpp
+    src/mbgl/tile/tile_id_hash.cpp
     src/mbgl/tile/tile_id_io.cpp
     src/mbgl/tile/tile_loader.hpp
     src/mbgl/tile/tile_loader_impl.hpp

--- a/include/mbgl/tile/tile_id.hpp
+++ b/include/mbgl/tile/tile_id.hpp
@@ -4,11 +4,11 @@
 
 #include <cstdint>
 #include <array>
+#include <tuple>
 #include <forward_list>
 #include <algorithm>
 #include <iosfwd>
 #include <cassert>
-#include <boost/functional/hash.hpp>
 
 namespace mbgl {
 
@@ -244,32 +244,19 @@ inline float UnwrappedTileID::pixelsToTileUnits(const float pixelValue, const fl
 
 namespace std {
 
-template <> struct hash<mbgl::CanonicalTileID> {
-    size_t operator()(const mbgl::CanonicalTileID &id) const {
-        std::size_t seed = 0;
-        boost::hash_combine(seed, id.x);
-        boost::hash_combine(seed, id.y);
-        boost::hash_combine(seed, id.z);
-        return seed;
-    }
+template <>
+struct hash<mbgl::CanonicalTileID> {
+    size_t operator()(const mbgl::CanonicalTileID& id) const;
 };
 
-template <> struct hash<mbgl::UnwrappedTileID> {
-    size_t operator()(const mbgl::UnwrappedTileID &id) const {
-        std::size_t seed = 0;
-        boost::hash_combine(seed, std::hash<mbgl::CanonicalTileID>{}(id.canonical));
-        boost::hash_combine(seed, id.wrap);
-        return seed;
-    }
+template <>
+struct hash<mbgl::UnwrappedTileID> {
+    size_t operator()(const mbgl::UnwrappedTileID& id) const;
 };
 
-template <> struct hash<mbgl::OverscaledTileID> {
-    size_t operator()(const mbgl::OverscaledTileID &id) const {
-        std::size_t seed = 0;
-        boost::hash_combine(seed, std::hash<mbgl::CanonicalTileID>{}(id.canonical));
-        boost::hash_combine(seed, id.overscaledZ);
-        return seed;
-    }
+template <>
+struct hash<mbgl::OverscaledTileID> {
+    size_t operator()(const mbgl::OverscaledTileID& id) const;
 };
 
 } // namespace std

--- a/src/mbgl/tile/tile_id_hash.cpp
+++ b/src/mbgl/tile/tile_id_hash.cpp
@@ -1,0 +1,29 @@
+#include <mbgl/tile/tile_id.hpp>
+
+#include <boost/functional/hash.hpp>
+
+namespace std {
+
+size_t hash<mbgl::CanonicalTileID>::operator()(const mbgl::CanonicalTileID& id) const {
+    std::size_t seed = 0;
+    boost::hash_combine(seed, id.x);
+    boost::hash_combine(seed, id.y);
+    boost::hash_combine(seed, id.z);
+    return seed;
+}
+
+size_t hash<mbgl::UnwrappedTileID>::operator()(const mbgl::UnwrappedTileID& id) const {
+    std::size_t seed = 0;
+    boost::hash_combine(seed, std::hash<mbgl::CanonicalTileID>{}(id.canonical));
+    boost::hash_combine(seed, id.wrap);
+    return seed;
+}
+
+size_t hash<mbgl::OverscaledTileID>::operator()(const mbgl::OverscaledTileID& id) const {
+    std::size_t seed = 0;
+    boost::hash_combine(seed, std::hash<mbgl::CanonicalTileID>{}(id.canonical));
+    boost::hash_combine(seed, id.overscaledZ);
+    return seed;
+}
+
+} // namespace std


### PR DESCRIPTION
Promoting the *`TileID` classes to a public header in core, and moving the hashing functions to a separate private header.