### PR TITLE
Update Traditional Chinese localization

### DIFF
--- a/platform/ios/framework/Settings.bundle/zh-Hant.lproj/Root.strings
+++ b/platform/ios/framework/Settings.bundle/zh-Hant.lproj/Root.strings
@@ -1,3 +1,3 @@
 ﻿"TELEMETRY_GROUP_TITLE" = "隱私設置";
-"TELEMETRY_SWITCH_TITLE" = "Mapbox傳感數據";
-"TELEMETRY_GROUP_FOOTER" = "此設置允許應用將用戶位置和數據以匿名的方式分享給Mapbox。";
+"TELEMETRY_SWITCH_TITLE" = "Mapbox遙測";
+"TELEMETRY_GROUP_FOOTER" = "此設置允許應用程式將位置資訊及使用數據以匿名的方式分享給Mapbox。";


### PR DESCRIPTION
Updated the Traditional Chinese translation of Mapbox Telemetry strings in the iOS SDK’s provided Settings bundle based on Transifex.

/cc @lily-chai @friedbunny