### PR TITLE
[core, node] Support axonometric rendering

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -127,6 +127,14 @@ public:
     void setViewportMode(ViewportMode);
     ViewportMode getViewportMode() const;
 
+    // Projection mode
+    void setAxonometric(bool);
+    bool getAxonometric() const;
+    void setXSkew(double ySkew);
+    double getXSkew() const;
+    void setYSkew(double ySkew);
+    double getYSkew() const;
+
     // Size
     void setSize(Size);
     Size getSize() const;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "nan": "^2.4.0",
-    "node-pre-gyp": "^0.6.36",
+    "node-pre-gyp": "^0.6.37",
     "npm-run-all": "^4.0.2"
   },
   "devDependencies": {

--- a/platform/glfw/settings_json.hpp
+++ b/platform/glfw/settings_json.hpp
@@ -17,6 +17,9 @@ public:
     double zoom = 0;
     double bearing = 0;
     double pitch = 0;
+    bool axonometric = false;
+    double xSkew = 0.0;
+    double ySkew = 1.0;
 
     EnumType debug = 0;
     bool online = true;

--- a/platform/node/src/node_map.hpp
+++ b/platform/node/src/node_map.hpp
@@ -57,6 +57,9 @@ public:
     static void SetZoom(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void SetBearing(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void SetPitch(const Nan::FunctionCallbackInfo<v8::Value>&);
+    static void SetAxonometric(const Nan::FunctionCallbackInfo<v8::Value>&);
+    static void SetXSkew(const Nan::FunctionCallbackInfo<v8::Value>&);
+    static void SetYSkew(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void DumpDebugLogs(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void QueryRenderedFeatures(const Nan::FunctionCallbackInfo<v8::Value>&);
 

--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -36,6 +36,7 @@
   "render-tests/line-join/property-function": "https://github.com/mapbox/mapbox-gl-js/pull/5020",
   "render-tests/line-join/property-function-dasharray": "https://github.com/mapbox/mapbox-gl-js/pull/5020",
   "render-tests/line-opacity/step-curve": "https://github.com/mapbox/mapbox-gl-native/pull/9439",
+  "render-tests/raster-masking/overlapping-zoom": "https://github.com/mapbox/mapbox-gl-native/issues/10195",
   "render-tests/regressions/mapbox-gl-js#2305": "https://github.com/mapbox/mapbox-gl-native/issues/6927",
   "render-tests/regressions/mapbox-gl-js#3682": "https://github.com/mapbox/mapbox-gl-js/issues/3682",
   "render-tests/regressions/mapbox-gl-js#5370": "skip - https://github.com/mapbox/mapbox-gl-native/pull/9439",

--- a/platform/node/test/js/map.test.js
+++ b/platform/node/test/js/map.test.js
@@ -121,6 +121,9 @@ test('Map', function(t) {
             'setZoom',
             'setBearing',
             'setPitch',
+            'setAxonometric',
+            'setXSkew',
+            'setYSkew',
             'dumpDebugLogs',
             'queryRenderedFeatures'
         ]);

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -617,6 +617,35 @@ ViewportMode Map::getViewportMode() const {
     return impl->transform.getViewportMode();
 }
 
+#pragma mark - Projection mode
+
+void Map::setAxonometric(bool axonometric) {
+    impl->transform.setAxonometric(axonometric);
+    impl->onUpdate();
+}
+
+bool Map::getAxonometric() const {
+    return impl->transform.getAxonometric();
+}
+
+void Map::setXSkew(double xSkew) {
+    impl->transform.setXSkew(xSkew);
+    impl->onUpdate();
+}
+
+double Map::getXSkew() const {
+    return impl->transform.getXSkew();
+}
+
+void Map::setYSkew(double ySkew) {
+    impl->transform.setYSkew(ySkew);
+    impl->onUpdate();
+}
+
+double Map::getYSkew() const {
+    return impl->transform.getYSkew();
+}
+
 #pragma mark - Projection
 
 ScreenCoordinate Map::pixelForLatLng(const LatLng& latLng) const {

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -527,6 +527,32 @@ ViewportMode Transform::getViewportMode() const {
     return state.getViewportMode();
 }
 
+#pragma mark - Projection mode
+
+void Transform::setAxonometric(bool axonometric) {
+    state.axonometric = axonometric;
+}
+
+bool Transform::getAxonometric() const {
+    return state.axonometric;
+}
+
+void Transform::setXSkew(double xSkew) {
+    state.xSkew = xSkew;
+}
+
+double Transform::getXSkew() const {
+    return state.xSkew;
+}
+
+void Transform::setYSkew(double ySkew) {
+    state.ySkew = ySkew;
+}
+
+double Transform::getYSkew() const {
+    return state.ySkew;
+}
+
 #pragma mark - Transition
 
 void Transform::startTransition(const CameraOptions& camera,

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -125,6 +125,14 @@ public:
     void setViewportMode(ViewportMode);
     ViewportMode getViewportMode() const;
 
+    // Projection mode
+    void setAxonometric(bool);
+    bool getAxonometric() const;
+    void setXSkew(double xSkew);
+    double getXSkew() const;
+    void setYSkew(double ySkew);
+    double getYSkew() const;
+
     // Transitions
     bool inTransition() const;
     void updateTransitions(const TimePoint& now);

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -66,6 +66,15 @@ void TransformState::getProjMatrix(mat4& projMatrix, uint16_t nearZ) const {
     matrix::translate(projMatrix, projMatrix, pixel_x() - size.width / 2.0f,
                       pixel_y() - size.height / 2.0f, 0);
 
+    if (axonometric) {
+        // mat[11] controls perspective
+        projMatrix[11] = 0;
+
+        // mat[8], mat[9] control x-skew, y-skew
+        projMatrix[8] = xSkew;
+        projMatrix[9] = ySkew;
+    }
+
     matrix::scale(projMatrix, projMatrix, 1, 1,
                   1.0 / Projection::getMetersPerPixelAtLatitude(getLatLng(LatLng::Unwrapped).latitude(), getZoom()));
 }

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -134,6 +134,9 @@ private:
     // `fov = 2 * arctan((height / 2) / (height * 1.5))`
     double fov = 0.6435011087932844;
     double pitch = 0.0;
+    double xSkew = 0.0;
+    double ySkew = 1.0;
+    bool axonometric = false;
 
     // cache values for spherical mercator math
     double Bc = Projection::worldSize(scale) / util::DEGREES_MAX;


### PR DESCRIPTION
* Adds support in core for axonometric rendering for 3D layers. New API surface:
    * `void Map::setAxonometric(bool)`
    * `bool Map::getAxonometric() const`
    * `void Map::setXSkew(double)`
    * `double Map::getXSkew() const`
    * `void Map::setYSkew(double)`
    * `double Map::getYSkew() const`
* Adds platform support for axonometric _only for node_ for the time being: this clears the way to use fill-extrusion layers in fallback maps. We may add bindings for other platforms + gl-js later. New node map arguments are
    * `axonometric: boolean`
    * `skew: [number, number]`

Presently the default for `skew` if `axonometric = true` and `skew` is unspecified is [0, 1]. This is what lower Manhattan looks like with [0, 1]:
![image](https://user-images.githubusercontent.com/3170312/30834870-0023138e-a20a-11e7-9dd5-683c23a6aa24.png)
[Here](https://www.mapbox.com/bites/00358/#15.95/40.7074/-74.0108) is a quick demo where you can tweak the skew. @nickidlugash — do you have any thoughts on what a reasonable default should be? [0, 0] feels like the type of neutral we usually use, but may lead people to think it's broken. Regardless, this default doesn't have to be what we use in api-gl for fallback maps.

Locally I ran a render-test run applying `axonometric: true` to all tests to verify that there are no unintended consequences/layer types using the perspective projection matrix in unexpected ways. I suppose theoretically we could add a new CI run to verify that, but it doesn't seem necessary and our CI infrastructure is heavy enough as it is…