### PR TITLE
Add support for API version 14

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/AndroidManifest.xml
@@ -1,12 +1,19 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.mapbox.mapboxsdk">
+          xmlns:tools="http://schemas.android.com/tools"
+          package="com.mapbox.mapboxsdk">
 
-    <uses-feature android:glEsVersion="0x00020000" android:required="true" />
-    <uses-feature android:name="android.hardware.wifi" android:required="false" /> <!-- Implied by ACCESS_WIFI_STATE. -->
+    <uses-feature
+        android:glEsVersion="0x00020000"
+        android:required="true"/>
+    <uses-feature
+        android:name="android.hardware.wifi"
+        android:required="false"/> <!-- Implied by ACCESS_WIFI_STATE. -->
 
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+
+    <uses-sdk tools:overrideLibrary="com.mapzen.lost"/>
 
     <application>
         <!-- Include the telemetry service to simplify set up (https://www.mapbox.com/telemetry) -->

--- a/platform/android/dependencies.gradle
+++ b/platform/android/dependencies.gradle
@@ -1,5 +1,5 @@
 ext {
-    minSdkVersion = 15
+    minSdkVersion = 14
     targetSdkVersion = 25
     compileSdkVersion = 25
     buildToolsVersion = "25.0.2"


### PR DESCRIPTION
Closes #10057, this PR verifies if we are able to support API 14. PR responsible for the initial change in https://github.com/mapbox/mapbox-gl-native/pull/2152/files. To allow us to compile I had to blacklist two dependencies that are requiring at least API 15: 
 - LOST v1.1.1
 - Telemetry

cc @zugaldia 
