### PR TITLE
Hide overlain views on initalisation

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_internal.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_internal.xml
@@ -28,6 +28,7 @@
         android:contentDescription="@string/mapbox_compassContentDescription"/>
 
     <ImageView
+        android:visibility="gone"
         android:id="@+id/logoView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -35,6 +36,7 @@
         android:src="@drawable/mapbox_logo_icon"/>
 
     <ImageView
+        android:visibility="gone"
         android:id="@+id/attributionView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
This PR fixes the issue that you can see the logo & attribution icon initialized in the top left corner and afterwards seeing it move to the expected location. Hiding these views on initialization solves the issue. 
See difference in gifs below:

After:

![ezgif com-video-to-gif 32](https://user-images.githubusercontent.com/2151639/30862210-8ce792ea-a2cd-11e7-84bb-11204db2ca19.gif)

Before:

![ezgif com-video-to-gif 30](https://user-images.githubusercontent.com/2151639/30861997-ca4f53e4-a2cc-11e7-8fd3-32f74c4d0e7e.gif)

