### PR TITLE
[ios] Expose -showAttribution publicly as an IBAction

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -34,6 +34,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Fixed an issue that could cause line label rendering glitches when the line geometry is projected to a point behind the plane of the camera. ([#9865](https://github.com/mapbox/mapbox-gl-native/pull/9865))
 * Fixed an issue that could cause a crash when using `-[MGLMapView flyToCamera:completionHandler:]` and related methods with zoom levels at or near the maximum value. ([#9381](https://github.com/mapbox/mapbox-gl-native/pull/9381))
+* Added `-[MGLMapView showAttribution:]` to allow custom attribution buttons to show the default attribution interface. ([#10085](https://github.com/mapbox/mapbox-gl-native/pull/10085))
 
 ## 3.6.4 - September 25, 2017
 

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -283,24 +283,16 @@ MGL_EXPORT IB_DESIGNABLE
  */
 - (IBAction)showAttribution:(id)sender;
 
-/**
- Support for style classes has been removed. This property always returns an empty array.
- */
+/// :nodoc: Support for style classes has been removed. This property always returns an empty array.
 @property (nonatomic) NS_ARRAY_OF(NSString *) *styleClasses __attribute__((deprecated("This property is non-functional.")));
 
-/**
- Support for style classes has been removed. This property always returns NO.
- */
+/// :nodoc: Support for style classes has been removed. This property always returns NO.
 - (BOOL)hasStyleClass:(NSString *)styleClass __attribute__((deprecated("This method is non-functional.")));
 
-/**
- Support for style classes has been removed. This property is a no-op.
- */
+/// :nodoc: Support for style classes has been removed. This property is a no-op.
 - (void)addStyleClass:(NSString *)styleClass __attribute__((deprecated("This method is non-functional.")));
 
-/**
- Support for style classes has been removed. This property is a no-op.
- */
+/// :nodoc: Support for style classes has been removed. This property is a no-op.
 - (void)removeStyleClass:(NSString *)styleClass __attribute__((deprecated("This method is non-functional.")));
 
 #pragma mark Displaying the User’s Location

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -253,6 +253,9 @@ MGL_EXPORT IB_DESIGNABLE
  A view showing legally required copyright notices and telemetry settings,
  positioned at the bottom-right of the map view.
 
+ If you choose to reimplement this view, assign the `-showAttribution:` method
+ as the action for your view to present the default notices and settings.
+
  @note The Mapbox terms of service, which governs the use of Mapbox-hosted
     vector tiles and styles,
     <a href="https://www.mapbox.com/help/attribution/">requires</a> these
@@ -270,6 +273,15 @@ MGL_EXPORT IB_DESIGNABLE
     implementation help.
  */
 @property (nonatomic, readonly) UIButton *attributionButton;
+
+/**
+ Show the attribution and telemetry action sheet.
+
+ This action is performed when the user taps on the attribution button provided
+ by default via the `attributionButton` property. If you implement a custom
+ attribution button, you should add this action to the button.
+ */
+- (IBAction)showAttribution:(id)sender;
 
 /**
  Support for style classes has been removed. This property always returns an empty array.

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -503,7 +503,7 @@ public:
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
     if ([_attributionButton respondsToSelector:@selector(accessibilityIgnoresInvertColors)])  { _attributionButton.accessibilityIgnoresInvertColors = YES; }
 #endif
-    [_attributionButton addTarget:self action:@selector(showAttribution) forControlEvents:UIControlEventTouchUpInside];
+    [_attributionButton addTarget:self action:@selector(showAttribution:) forControlEvents:UIControlEventTouchUpInside];
     _attributionButton.translatesAutoresizingMaskIntoConstraints = NO;
     [self addSubview:_attributionButton];
     _attributionButtonConstraints = [NSMutableArray array];
@@ -2025,7 +2025,7 @@ public:
 
 #pragma mark - Attribution -
 
-- (void)showAttribution
+- (void)showAttribution:(__unused id)sender
 {
     NSString *title = NSLocalizedStringWithDefaultValue(@"SDK_NAME", nil, nil, @"Mapbox iOS SDK", @"Action sheet title");
     UIAlertController *attributionController = [UIAlertController alertControllerWithTitle:title


### PR DESCRIPTION
Fixes #9024 by exposing `-[MGLMapView showAttribution]` as an `IBAction`.

Also removes the deprecated/non-functional style class methods (#8953) from jazzy docs.

### Questions
- Maybe `-showAttribution` should be split out of the “Configuring the Map’s Appearance” category.
- Is this enough detail or should it explain more what attribution/telemetry is?

/cc @1ec5 @fabian-guerra