### PR TITLE
Define user dot constants in implementation file

### DIFF
--- a/platform/ios/src/MGLFaux3DUserLocationAnnotationView.h
+++ b/platform/ios/src/MGLFaux3DUserLocationAnnotationView.h
@@ -1,14 +1,14 @@
 #import <UIKit/UIKit.h>
 #import "MGLUserLocationAnnotationView.h"
 
-const CGFloat MGLUserLocationAnnotationDotSize = 22.0;
-const CGFloat MGLUserLocationAnnotationHaloSize = 115.0;
+extern const CGFloat MGLUserLocationAnnotationDotSize;
+extern const CGFloat MGLUserLocationAnnotationHaloSize;
 
-const CGFloat MGLUserLocationAnnotationPuckSize = 45.0;
-const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuckSize * 0.6;
+extern const CGFloat MGLUserLocationAnnotationPuckSize;
+extern const CGFloat MGLUserLocationAnnotationArrowSize;
 
 // Threshold in radians between heading indicator rotation updates.
-const CGFloat MGLUserLocationHeadingUpdateThreshold = 0.01;
+extern const CGFloat MGLUserLocationHeadingUpdateThreshold;
 
 @interface MGLFaux3DUserLocationAnnotationView : MGLUserLocationAnnotationView
 

--- a/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
+++ b/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
@@ -6,6 +6,14 @@
 #import "MGLUserLocationHeadingArrowLayer.h"
 #import "MGLUserLocationHeadingBeamLayer.h"
 
+const CGFloat MGLUserLocationAnnotationDotSize = 22.0;
+const CGFloat MGLUserLocationAnnotationHaloSize = 115.0;
+
+const CGFloat MGLUserLocationAnnotationPuckSize = 45.0;
+const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuckSize * 0.6;
+
+const CGFloat MGLUserLocationHeadingUpdateThreshold = 0.01;
+
 @implementation MGLFaux3DUserLocationAnnotationView
 {
     BOOL _puckModeActivated;


### PR DESCRIPTION
#9886 moved these constant declarations to a header file, but they should’ve been `extern`ed and defined in the original implementation file. Otherwise, the linker could end up seeing duplicate symbols. I’m not sure why this hasn’t been failing the iOS builds, but it ended up failing tvOS builds in #9319 when I tried to include this header in the tvOS SDK.

/cc @friedbunny