### PR TITLE
Save snapshots in correct format

### DIFF
--- a/platform/macos/app/Base.lproj/MainMenu.xib
+++ b/platform/macos/app/Base.lproj/MainMenu.xib
@@ -128,7 +128,7 @@
                                     <action selector="revertDocumentToSaved:" target="-1" id="iJ3-Pv-kwq"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Save snapshot" id="vjX-0E-kLO">
+                            <menuItem title="Export Image…" id="vjX-0E-kLO">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="takeSnapshot:" target="-1" id="H06-sU-n4U"/>

--- a/platform/macos/app/MapDocument.m
+++ b/platform/macos/app/MapDocument.m
@@ -162,58 +162,48 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
 - (IBAction)takeSnapshot:(id)sender {
     MGLMapCamera *camera = self.mapView.camera;
     
-    MGLMapSnapshotOptions* options = [[MGLMapSnapshotOptions alloc] initWithStyleURL:self.mapView.styleURL camera:camera size:self.mapView.bounds.size];
+    MGLMapSnapshotOptions *options = [[MGLMapSnapshotOptions alloc] initWithStyleURL:self.mapView.styleURL camera:camera size:self.mapView.bounds.size];
     options.zoomLevel = self.mapView.zoomLevel;
     
     // Create and start the snapshotter
     snapshotter = [[MGLMapSnapshotter alloc] initWithOptions:options];
-    [snapshotter startWithCompletionHandler: ^(NSImage *image, NSError *error) {
+    [snapshotter startWithCompletionHandler:^(NSImage *image, NSError *error) {
         if (error) {
-            NSLog(@"Could not load snapshot: %@", [error localizedDescription]);
+            NSLog(@"Could not load snapshot: %@", error.localizedDescription);
         } else {
-            NSWindow* window = [[[self windowControllers] objectAtIndex:0] window];
-    
-            NSString* newName = [[@"snapshot" stringByDeletingPathExtension] stringByAppendingPathExtension:@"png"];
-            
             // Set the default name for the file and show the panel.
-            NSSavePanel* panel = [NSSavePanel savePanel];
+            NSSavePanel *panel = [NSSavePanel savePanel];
+            panel.nameFieldStringValue = [self.mapView.styleURL.lastPathComponent.stringByDeletingPathExtension stringByAppendingPathExtension:@"png"];
+            panel.allowedFileTypes = [@[(NSString *)kUTTypePNG] arrayByAddingObjectsFromArray:[NSBitmapImageRep imageUnfilteredTypes]];
             
-            [panel setNameFieldStringValue:newName];
-            [panel beginSheetModalForWindow:window completionHandler:^(NSInteger result){
+            [panel beginSheetModalForWindow:self.window completionHandler:^(NSInteger result) {
                 if (result == NSFileHandlingPanelOKButton) {
                     // Write the contents in the new format.
-                    NSURL*  fileURL = [panel URL];
+                    NSURL *fileURL = panel.URL;
                     
-                    NSBitmapImageRep *bitmapRep = nil;
-                    for (NSImageRep *imageRep in [image representations]) {
-                        if ([imageRep isKindOfClass:[NSBitmapImageRep class]]){
+                    NSBitmapImageRep *bitmapRep;
+                    for (NSImageRep *imageRep in image.representations) {
+                        if ([imageRep isKindOfClass:[NSBitmapImageRep class]]) {
                             bitmapRep = (NSBitmapImageRep *)imageRep;
                             break; // stop on first bitmap rep we find
                         }
                     }
                     
                     if (!bitmapRep) {
-                        bitmapRep = [NSBitmapImageRep imageRepWithData:[image TIFFRepresentation]];
-                        
+                        bitmapRep = [NSBitmapImageRep imageRepWithData:image.TIFFRepresentation];
                     }
                     
-                    NSString *uti;
-                    [fileURL getResourceValue:&uti forKey:NSURLTypeIdentifierKey error:nil];
+                    CFStringRef uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)fileURL.pathExtension, NULL /* inConformingToUTI */);
                     NSBitmapImageFileType fileType = NSTIFFFileType;
-                    
-                    if (UTTypeConformsTo((__bridge CFStringRef)uti, kUTTypePNG)) {
+                    if (UTTypeConformsTo(uti, kUTTypePNG)) {
                         fileType = NSPNGFileType;
-                    }
-                    if (UTTypeConformsTo((__bridge CFStringRef)uti, kUTTypeGIF)) {
+                    } else if (UTTypeConformsTo(uti, kUTTypeGIF)) {
                         fileType = NSGIFFileType;
-                    }
-                    if (UTTypeConformsTo((__bridge CFStringRef)uti, kUTTypeJPEG)) {
+                    } else if (UTTypeConformsTo(uti, kUTTypeJPEG2000)) {
+                        fileType = NSJPEG2000FileType;
+                    } else if (UTTypeConformsTo(uti, kUTTypeJPEG)) {
                         fileType = NSJPEGFileType;
-                    }
-                    if (UTTypeConformsTo((__bridge CFStringRef)uti, kUTTypeJPEG2000)) {
-                        fileType = NSJPEGFileType;
-                    }
-                    if (UTTypeConformsTo((__bridge CFStringRef)uti, kUTTypeBMP)) {
+                    } else if (UTTypeConformsTo(uti, kUTTypeBMP)) {
                         fileType = NSBitmapImageFileTypeBMP;
                     }
                     


### PR DESCRIPTION
I finally found a reliable way to convert from file extensions to UTIs to `NSBitmapImageFileType`s. This change allows files to be saved in any of the supported bitmap image formats, not only TIFF.

The save panel starts out with the name of the style as the file name. It restricts the allowed file types, so that if you enter an extension of .pdf, you’re prompted to add .png to the file name. Finally, the menu item has been renamed to Export Image, which is more consistent with other Mac applications.

/cc @fabian-guerra @ivovandongen