### PR TITLE
[ios, macos] Fix snapshot scale

### DIFF
--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -133,6 +133,8 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
                 MGLImage *mglImage = [[MGLImage alloc] initWithMGLPremultipliedImage:std::move(image) scale:self.options.scale];
 #else
                 MGLImage *mglImage = [[MGLImage alloc] initWithMGLPremultipliedImage:std::move(image)];
+                mglImage.size = NSMakeSize(mglImage.size.width / self.options.scale,
+                                           mglImage.size.height / self.options.scale);
 #endif
                 
                 // Process image watermark in a work queue


### PR DESCRIPTION
Fixes #10089
Fixes the scale of the snapshot on iOS by letting CGImage resize the output.
~~Snapshotting on macOS already works as intended.~~

@1ec5 👀 
@fabian-guerra feel free to cherry-pick this into https://github.com/mapbox/mapbox-gl-native/pull/10020
