### PR TITLE
Build nightly builds from release-agua

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -294,7 +294,7 @@ jobs:
       - deploy:
           name: Publish to Maven
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then make run-android-upload-archives ; fi
+            if [ "${CIRCLE_BRANCH}" == "release-agua" ]; then make run-android-upload-archives ; fi
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Now that we have a `release-agua` branch for the upcoming mobile SDK releases, we should start building the Android snapshots from this branch (when a PR is merged to the branch).  