### PR TITLE
Allow multiple listeners for camera events, deprecate old API

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
@@ -1,5 +1,10 @@
 package com.mapbox.mapboxsdk.maps;
 
+import android.support.annotation.NonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import static com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraIdleListener;
 import static com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraMoveCanceledListener;
 import static com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraMoveListener;
@@ -9,6 +14,11 @@ class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, M
   MapboxMap.OnCameraMoveCanceledListener, OnCameraIdleListener {
 
   private boolean idle = true;
+
+  private final List<OnCameraMoveStartedListener> onCameraMoveStartedListenerList = new ArrayList<>();
+  private final List<OnCameraMoveCanceledListener> onCameraMoveCanceledListenerList = new ArrayList<>();
+  private final List<OnCameraMoveListener> onCameraMoveListenerList = new ArrayList<>();
+  private final List<OnCameraIdleListener> onCameraIdleListenerList = new ArrayList<>();
 
   private OnCameraMoveStartedListener onCameraMoveStartedListener;
   private OnCameraMoveCanceledListener onCameraMoveCanceledListener;
@@ -41,6 +51,12 @@ class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, M
     if (onCameraMoveStartedListener != null) {
       onCameraMoveStartedListener.onCameraMoveStarted(reason);
     }
+
+    if (!onCameraMoveStartedListenerList.isEmpty()) {
+      for (OnCameraMoveStartedListener cameraMoveStartedListener : onCameraMoveStartedListenerList) {
+        cameraMoveStartedListener.onCameraMoveStarted(reason);
+      }
+    }
   }
 
   @Override
@@ -48,12 +64,24 @@ class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, M
     if (onCameraMoveListener != null && !idle) {
       onCameraMoveListener.onCameraMove();
     }
+
+    if (!onCameraMoveListenerList.isEmpty()) {
+      for (OnCameraMoveListener cameraMoveListener : onCameraMoveListenerList) {
+        cameraMoveListener.onCameraMove();
+      }
+    }
   }
 
   @Override
   public void onCameraMoveCanceled() {
     if (onCameraMoveCanceledListener != null && !idle) {
       onCameraMoveCanceledListener.onCameraMoveCanceled();
+    }
+
+    if (!onCameraMoveCanceledListenerList.isEmpty()) {
+      for (OnCameraMoveCanceledListener cameraMoveCanceledListener : onCameraMoveCanceledListenerList) {
+        cameraMoveCanceledListener.onCameraMoveCanceled();
+      }
     }
   }
 
@@ -64,6 +92,52 @@ class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, M
       if (onCameraIdleListener != null) {
         onCameraIdleListener.onCameraIdle();
       }
+
+      if (!onCameraIdleListenerList.isEmpty()) {
+        for (OnCameraIdleListener cameraIdleListener : onCameraIdleListenerList) {
+          cameraIdleListener.onCameraIdle();
+        }
+      }
+    }
+  }
+
+  void addOnCameraIdleListener(@NonNull OnCameraIdleListener listener) {
+    onCameraIdleListenerList.add(listener);
+  }
+
+  void removeOnCameraIdleListener(@NonNull OnCameraIdleListener listener) {
+    if (onCameraIdleListenerList.contains(listener)) {
+      onCameraIdleListenerList.remove(listener);
+    }
+  }
+
+  void addOnCameraMoveCancelListener(OnCameraMoveCanceledListener listener) {
+    onCameraMoveCanceledListenerList.add(listener);
+  }
+
+  void removeOnCameraMoveCancelListener(OnCameraMoveCanceledListener listener) {
+    if (onCameraMoveCanceledListenerList.contains(listener)) {
+      onCameraMoveCanceledListenerList.remove(listener);
+    }
+  }
+
+  void addOnCameraMoveStartedListener(OnCameraMoveStartedListener listener) {
+    onCameraMoveStartedListenerList.add(listener);
+  }
+
+  void removeOnCameraMoveStartedListener(OnCameraMoveStartedListener listener) {
+    if (onCameraMoveStartedListenerList.contains(listener)) {
+      onCameraMoveStartedListenerList.remove(listener);
+    }
+  }
+
+  void addOnCameraMoveListener(OnCameraMoveListener listener) {
+    onCameraMoveListenerList.add(listener);
+  }
+
+  void removeOnCameraMoveListener(OnCameraMoveListener listener) {
+    if (onCameraMoveListenerList.contains(listener)) {
+      onCameraMoveListenerList.remove(listener);
     }
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1725,36 +1725,120 @@ public final class MapboxMap {
    * Sets a callback that is invoked when camera movement has ended.
    *
    * @param listener the listener to notify
+   * @deprecated use {@link #addOnCameraIdleListener(OnCameraIdleListener)}
+   * and {@link #removeOnCameraIdleListener(OnCameraIdleListener)} instead
    */
+  @Deprecated
   public void setOnCameraIdleListener(@Nullable OnCameraIdleListener listener) {
     cameraChangeDispatcher.setOnCameraIdleListener(listener);
+  }
+
+  /**
+   * Adds a callback that is invoked when camera movement has ended.
+   *
+   * @param listener the listener to notify
+   */
+  public void addOnCameraIdleListener(@Nullable OnCameraIdleListener listener) {
+    cameraChangeDispatcher.addOnCameraIdleListener(listener);
+  }
+
+  /**
+   * Removes a callback that is invoked when camera movement has ended.
+   *
+   * @param listener the listener to remove
+   */
+  public void removeOnCameraIdleListener(@Nullable OnCameraIdleListener listener) {
+    cameraChangeDispatcher.removeOnCameraIdleListener(listener);
   }
 
   /**
    * Sets a callback that is invoked when camera movement was cancelled.
    *
    * @param listener the listener to notify
+   * @deprecated use {@link #addOnCameraMoveCancelListener(OnCameraMoveCanceledListener)} and
+   * {@link #removeOnCameraMoveCancelListener(OnCameraMoveCanceledListener)} instead
    */
+  @Deprecated
   public void setOnCameraMoveCancelListener(@Nullable OnCameraMoveCanceledListener listener) {
     cameraChangeDispatcher.setOnCameraMoveCanceledListener(listener);
+  }
+
+  /**
+   * Adds a callback that is invoked when camera movement was cancelled.
+   *
+   * @param listener the listener to notify
+   */
+  public void addOnCameraMoveCancelListener(@Nullable OnCameraMoveCanceledListener listener) {
+    cameraChangeDispatcher.addOnCameraMoveCancelListener(listener);
+  }
+
+  /**
+   * Removes a callback that is invoked when camera movement was cancelled.
+   *
+   * @param listener the listener to remove
+   */
+  public void removeOnCameraMoveCancelListener(@Nullable OnCameraMoveCanceledListener listener) {
+    cameraChangeDispatcher.removeOnCameraMoveCancelListener(listener);
   }
 
   /**
    * Sets a callback that is invoked when camera movement has started.
    *
    * @param listener the listener to notify
+   * @deprecated use {@link #addOnCameraMoveStartedListener(OnCameraMoveStartedListener)} and
+   * {@link #removeOnCameraMoveStartedListener(OnCameraMoveStartedListener)} instead
    */
+  @Deprecated
   public void setOnCameraMoveStartedListener(@Nullable OnCameraMoveStartedListener listener) {
     cameraChangeDispatcher.setOnCameraMoveStartedListener(listener);
+  }
+
+  /**
+   * Adds a callback that is invoked when camera movement has started.
+   *
+   * @param listener the listener to notify
+   */
+  public void addOnCameraMoveStartedListener(@Nullable OnCameraMoveStartedListener listener) {
+    cameraChangeDispatcher.addOnCameraMoveStartedListener(listener);
+  }
+
+  /**
+   * Removes a callback that is invoked when camera movement has started.
+   *
+   * @param listener the listener to remove
+   */
+  public void removeOnCameraMoveStartedListener(@Nullable OnCameraMoveStartedListener listener) {
+    cameraChangeDispatcher.removeOnCameraMoveStartedListener(listener);
   }
 
   /**
    * Sets a callback that is invoked when camera position changes.
    *
    * @param listener the listener to notify
+   * @deprecated use {@link #addOnCameraMoveListener(OnCameraMoveListener)} and
+   * {@link #removeOnCameraMoveListener(OnCameraMoveListener)}instead
    */
+  @Deprecated
   public void setOnCameraMoveListener(@Nullable OnCameraMoveListener listener) {
     cameraChangeDispatcher.setOnCameraMoveListener(listener);
+  }
+
+  /**
+   * Adds a callback that is invoked when camera position changes.
+   *
+   * @param listener the listener to notify
+   */
+  public void addOnCameraMoveListener(@Nullable OnCameraMoveListener listener) {
+    cameraChangeDispatcher.addOnCameraMoveListener(listener);
+  }
+
+  /**
+   * Removes a callback that is invoked when camera position changes.
+   *
+   * @param listener the listener to remove
+   */
+  public void removeOnCameraMoveListener(@Nullable OnCameraMoveListener listener) {
+    cameraChangeDispatcher.removeOnCameraMoveListener(listener);
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcherTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcherTest.java
@@ -1,0 +1,87 @@
+package com.mapbox.mapboxsdk.maps;
+
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class CameraChangeDispatcherTest {
+
+  @Test
+  public void testSetCameraIdleListener() {
+    CameraChangeDispatcher dispatcher = new CameraChangeDispatcher();
+    MapboxMap.OnCameraIdleListener listener = mock(MapboxMap.OnCameraIdleListener.class);
+    dispatcher.setOnCameraIdleListener(listener);
+    dispatcher.onCameraMoveStarted(MapboxMap.OnCameraMoveStartedListener.REASON_API_GESTURE);
+    dispatcher.onCameraIdle();
+    verify(listener).onCameraIdle();
+  }
+
+  @Test
+  public void testSetCameraMoveStartedListener() {
+    CameraChangeDispatcher dispatcher = new CameraChangeDispatcher();
+    MapboxMap.OnCameraMoveStartedListener listener = mock(MapboxMap.OnCameraMoveStartedListener.class);
+    dispatcher.setOnCameraMoveStartedListener(listener);
+    dispatcher.onCameraMoveStarted(MapboxMap.OnCameraMoveStartedListener.REASON_API_GESTURE);
+    verify(listener).onCameraMoveStarted(MapboxMap.OnCameraMoveStartedListener.REASON_API_GESTURE);
+  }
+
+  @Test
+  public void testSetCameraMoveCancelListener() {
+    CameraChangeDispatcher dispatcher = new CameraChangeDispatcher();
+    MapboxMap.OnCameraMoveCanceledListener listener = mock(MapboxMap.OnCameraMoveCanceledListener.class);
+    dispatcher.setOnCameraMoveCanceledListener(listener);
+    dispatcher.onCameraMoveStarted(MapboxMap.OnCameraMoveStartedListener.REASON_API_GESTURE);
+    dispatcher.onCameraMoveCanceled();
+    verify(listener).onCameraMoveCanceled();
+  }
+
+  @Test
+  public void testSetCameraMoveListener() {
+    CameraChangeDispatcher dispatcher = new CameraChangeDispatcher();
+    MapboxMap.OnCameraMoveListener listener = mock(MapboxMap.OnCameraMoveListener.class);
+    dispatcher.setOnCameraMoveListener(listener);
+    dispatcher.onCameraMoveStarted(MapboxMap.OnCameraMoveStartedListener.REASON_API_GESTURE);
+    dispatcher.onCameraMove();
+    verify(listener).onCameraMove();
+  }
+
+  @Test
+  public void testAddCameraIdleListener() {
+    CameraChangeDispatcher dispatcher = new CameraChangeDispatcher();
+    MapboxMap.OnCameraIdleListener listener = mock(MapboxMap.OnCameraIdleListener.class);
+    dispatcher.addOnCameraIdleListener(listener);
+    dispatcher.onCameraMoveStarted(MapboxMap.OnCameraMoveStartedListener.REASON_API_GESTURE);
+    dispatcher.onCameraIdle();
+    verify(listener).onCameraIdle();
+  }
+
+  @Test
+  public void testAddCameraMoveStartedListener() {
+    CameraChangeDispatcher dispatcher = new CameraChangeDispatcher();
+    MapboxMap.OnCameraMoveStartedListener listener = mock(MapboxMap.OnCameraMoveStartedListener.class);
+    dispatcher.addOnCameraMoveStartedListener(listener);
+    dispatcher.onCameraMoveStarted(MapboxMap.OnCameraMoveStartedListener.REASON_API_GESTURE);
+    verify(listener).onCameraMoveStarted(MapboxMap.OnCameraMoveStartedListener.REASON_API_GESTURE);
+  }
+
+  @Test
+  public void testAddCameraMoveCancelListener() {
+    CameraChangeDispatcher dispatcher = new CameraChangeDispatcher();
+    MapboxMap.OnCameraMoveCanceledListener listener = mock(MapboxMap.OnCameraMoveCanceledListener.class);
+    dispatcher.addOnCameraMoveCancelListener(listener);
+    dispatcher.onCameraMoveStarted(MapboxMap.OnCameraMoveStartedListener.REASON_API_GESTURE);
+    dispatcher.onCameraMoveCanceled();
+    verify(listener).onCameraMoveCanceled();
+  }
+
+  @Test
+  public void testAddCameraMoveListener() {
+    CameraChangeDispatcher dispatcher = new CameraChangeDispatcher();
+    MapboxMap.OnCameraMoveListener listener = mock(MapboxMap.OnCameraMoveListener.class);
+    dispatcher.addOnCameraMoveListener(listener);
+    dispatcher.onCameraMoveStarted(MapboxMap.OnCameraMoveStartedListener.REASON_API_GESTURE);
+    dispatcher.onCameraMove();
+    verify(listener).onCameraMove();
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraPositionActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraPositionActivity.java
@@ -1,6 +1,5 @@
 package com.mapbox.mapboxsdk.testapp.activity.camera;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -28,11 +27,13 @@ import timber.log.Timber;
 /**
  * Test activity showcasing how to listen to camera change events.
  */
-public class CameraPositionActivity extends AppCompatActivity implements OnMapReadyCallback {
+public class CameraPositionActivity extends AppCompatActivity implements OnMapReadyCallback, View.OnClickListener,
+  MapboxMap.OnMapLongClickListener {
 
   private MapView mapView;
   private MapboxMap mapboxMap;
   private FloatingActionButton fab;
+  private boolean logCameraChanges;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -47,96 +48,49 @@ public class CameraPositionActivity extends AppCompatActivity implements OnMapRe
   @Override
   public void onMapReady(@NonNull final MapboxMap map) {
     mapboxMap = map;
-
-    mapboxMap.setOnCameraIdleListener(new MapboxMap.OnCameraIdleListener() {
-      @Override
-      public void onCameraIdle() {
-        Timber.e("OnCameraIdle");
-        fab.setColorFilter(ContextCompat.getColor(CameraPositionActivity.this, android.R.color.holo_green_dark));
-      }
-    });
-
-    mapboxMap.setOnCameraMoveCancelListener(new MapboxMap.OnCameraMoveCanceledListener() {
-      @Override
-      public void onCameraMoveCanceled() {
-        Timber.e("OnCameraMoveCanceled");
-      }
-    });
-
-    mapboxMap.setOnCameraMoveListener(new MapboxMap.OnCameraMoveListener() {
-      @Override
-      public void onCameraMove() {
-        Timber.e("OnCameraMove");
-        fab.setColorFilter(ContextCompat.getColor(CameraPositionActivity.this, android.R.color.holo_orange_dark));
-      }
-    });
-
-    mapboxMap.setOnCameraMoveStartedListener(new MapboxMap.OnCameraMoveStartedListener() {
-
-      private final String[] REASONS = {"REASON_API_GESTURE", "REASON_DEVELOPER_ANIMATION", "REASON_API_ANIMATION"};
-
-      @Override
-      public void onCameraMoveStarted(int reason) {
-        // reason ranges from 1 <-> 3
-        fab.setColorFilter(ContextCompat.getColor(CameraPositionActivity.this, android.R.color.holo_red_dark));
-        Timber.e("OnCameraMoveStarted: %s", REASONS[reason - 1]);
-      }
-    });
+    toggleLogCameraChanges();
 
     // add a listener to FAB
     fab = (FloatingActionButton) findViewById(R.id.fab);
     fab.setColorFilter(ContextCompat.getColor(CameraPositionActivity.this, R.color.primary));
-    fab.setOnClickListener(new View.OnClickListener() {
-      @SuppressLint("InflateParams")
-      @Override
-      public void onClick(View view) {
-        Context context = view.getContext();
-        final View dialogContent = LayoutInflater.from(context).inflate(R.layout.dialog_camera_position, null);
-        AlertDialog.Builder builder = new AlertDialog.Builder(
-          context, com.mapbox.mapboxsdk.R.style.mapbox_AlertDialogStyle);
-        builder.setTitle(R.string.dialog_camera_position);
-        builder.setView(onInflateDialogContent(dialogContent));
-        builder.setPositiveButton("Animate", new DialogInterface.OnClickListener() {
-          @Override
-          public void onClick(DialogInterface dialog, int which) {
-            double latitude = Double.parseDouble(
-              ((TextView) dialogContent.findViewById(R.id.value_lat)).getText().toString());
-            double longitude = Double.parseDouble(
-              ((TextView) dialogContent.findViewById(R.id.value_lon)).getText().toString());
-            double zoom = Double.parseDouble(
-              ((TextView) dialogContent.findViewById(R.id.value_zoom)).getText().toString());
-            double bearing = Double.parseDouble(
-              ((TextView) dialogContent.findViewById(R.id.value_bearing)).getText().toString());
-            double tilt = Double.parseDouble(
-              ((TextView) dialogContent.findViewById(R.id.value_tilt)).getText().toString());
+    fab.setOnClickListener(this);
 
-            CameraPosition cameraPosition = new CameraPosition.Builder()
-              .target(new LatLng(latitude, longitude))
-              .zoom(zoom)
-              .bearing(bearing)
-              .tilt(tilt)
-              .build();
+    // listen to long click events to toggle logging camera changes
+    mapboxMap.setOnMapLongClickListener(this);
+  }
 
-            mapboxMap.animateCamera(CameraUpdateFactory.newCameraPosition(cameraPosition), 5000,
-              new MapboxMap.CancelableCallback() {
-                @Override
-                public void onCancel() {
-                  Timber.v("OnCancel called");
-                }
+  @Override
+  public void onMapLongClick(@NonNull LatLng point) {
+    toggleLogCameraChanges();
+  }
 
-                @Override
-                public void onFinish() {
-                  Timber.v("OnFinish called");
-                }
-              });
-            Timber.v(cameraPosition.toString());
-          }
-        });
-        builder.setNegativeButton("Cancel", null);
-        builder.setCancelable(false);
-        builder.show();
-      }
-    });
+  @Override
+  public void onClick(View view) {
+    Context context = view.getContext();
+    final View dialogContent = LayoutInflater.from(context).inflate(R.layout.dialog_camera_position, null);
+    AlertDialog.Builder builder = new AlertDialog.Builder(
+      context, com.mapbox.mapboxsdk.R.style.mapbox_AlertDialogStyle);
+    builder.setTitle(R.string.dialog_camera_position);
+    builder.setView(onInflateDialogContent(dialogContent));
+    builder.setPositiveButton("Animate", new DialogClickListener(mapboxMap, dialogContent));
+    builder.setNegativeButton("Cancel", null);
+    builder.setCancelable(false);
+    builder.show();
+  }
+
+  private void toggleLogCameraChanges() {
+    logCameraChanges = !logCameraChanges;
+    if (logCameraChanges) {
+      mapboxMap.addOnCameraIdleListener(idleListener);
+      mapboxMap.addOnCameraMoveCancelListener(moveCanceledListener);
+      mapboxMap.addOnCameraMoveListener(moveListener);
+      mapboxMap.addOnCameraMoveStartedListener(moveStartedListener);
+    } else {
+      mapboxMap.removeOnCameraIdleListener(idleListener);
+      mapboxMap.removeOnCameraMoveCancelListener(moveCanceledListener);
+      mapboxMap.removeOnCameraMoveListener(moveListener);
+      mapboxMap.removeOnCameraMoveStartedListener(moveStartedListener);
+    }
   }
 
   @Override
@@ -193,6 +147,42 @@ public class CameraPositionActivity extends AppCompatActivity implements OnMapRe
     seekBar.setProgress(defaultValue);
   }
 
+  private MapboxMap.OnCameraIdleListener idleListener = new MapboxMap.OnCameraIdleListener() {
+    @Override
+    public void onCameraIdle() {
+      Timber.e("OnCameraIdle");
+      fab.setColorFilter(ContextCompat.getColor(CameraPositionActivity.this, android.R.color.holo_green_dark));
+    }
+  };
+
+  private MapboxMap.OnCameraMoveListener moveListener = new MapboxMap.OnCameraMoveListener() {
+    @Override
+    public void onCameraMove() {
+      Timber.e("OnCameraMove");
+      fab.setColorFilter(ContextCompat.getColor(CameraPositionActivity.this, android.R.color.holo_orange_dark));
+    }
+  };
+
+  private MapboxMap.OnCameraMoveCanceledListener moveCanceledListener = new MapboxMap.OnCameraMoveCanceledListener() {
+    @Override
+    public void onCameraMoveCanceled() {
+      Timber.e("OnCameraMoveCanceled");
+
+    }
+  };
+
+  private MapboxMap.OnCameraMoveStartedListener moveStartedListener = new MapboxMap.OnCameraMoveStartedListener() {
+
+    private final String[] REASONS = {"REASON_API_GESTURE", "REASON_DEVELOPER_ANIMATION", "REASON_API_ANIMATION"};
+
+    @Override
+    public void onCameraMoveStarted(int reason) {
+      // reason ranges from 1 <-> 3
+      fab.setColorFilter(ContextCompat.getColor(CameraPositionActivity.this, android.R.color.holo_red_dark));
+      Timber.e("OnCameraMoveStarted: %s", REASONS[reason - 1]);
+    }
+  };
+
   private class ValueChangeListener implements SeekBar.OnSeekBarChangeListener {
 
     protected TextView textView;
@@ -222,6 +212,52 @@ public class CameraPositionActivity extends AppCompatActivity implements OnMapRe
     @Override
     public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
       super.onProgressChanged(seekBar, progress - 180, fromUser);
+    }
+  }
+
+  private static class DialogClickListener implements DialogInterface.OnClickListener {
+
+    private MapboxMap mapboxMap;
+    private View dialogContent;
+
+    public DialogClickListener(MapboxMap mapboxMap, View view) {
+      this.mapboxMap = mapboxMap;
+      this.dialogContent = view;
+    }
+
+    @Override
+    public void onClick(DialogInterface dialog, int which) {
+      double latitude = Double.parseDouble(
+        ((TextView) dialogContent.findViewById(R.id.value_lat)).getText().toString());
+      double longitude = Double.parseDouble(
+        ((TextView) dialogContent.findViewById(R.id.value_lon)).getText().toString());
+      double zoom = Double.parseDouble(
+        ((TextView) dialogContent.findViewById(R.id.value_zoom)).getText().toString());
+      double bearing = Double.parseDouble(
+        ((TextView) dialogContent.findViewById(R.id.value_bearing)).getText().toString());
+      double tilt = Double.parseDouble(
+        ((TextView) dialogContent.findViewById(R.id.value_tilt)).getText().toString());
+
+      CameraPosition cameraPosition = new CameraPosition.Builder()
+        .target(new LatLng(latitude, longitude))
+        .zoom(zoom)
+        .bearing(bearing)
+        .tilt(tilt)
+        .build();
+
+      mapboxMap.animateCamera(CameraUpdateFactory.newCameraPosition(cameraPosition), 5000,
+        new MapboxMap.CancelableCallback() {
+          @Override
+          public void onCancel() {
+            Timber.v("OnCancel called");
+          }
+
+          @Override
+          public void onFinish() {
+            Timber.v("OnFinish called");
+          }
+        });
+      Timber.v(cameraPosition.toString());
     }
   }
 }


### PR DESCRIPTION
Closes #9917. This PR solves the issue that multiple plugins could register for camera change events without blocking the end user to register for these events. 
