### PR TITLE
[ios, macos] Edited MGLImageSource sample code

### DIFF
--- a/platform/darwin/src/MGLImageSource.h
+++ b/platform/darwin/src/MGLImageSource.h
@@ -38,8 +38,11 @@ MGL_EXPORT
    bottomLeft: CLLocationCoordinate2D(latitude: 37.936, longitude: -80.425),
    bottomRight: CLLocationCoordinate2D(latitude: 37.936, longitude: -71.516),
    topRight: CLLocationCoordinate2D(latitude: 46.437, longitude: -71.516))
- let source = MGLImageSource(identifier: "radar", coordinateQuad: coordinates, url: URL(string: "https://www.mapbox.com/mapbox-gl-js/assets/radar.gif")!)
+ let source = MGLImageSource(identifier: "radar-source", coordinateQuad: coordinates, url: URL(string: "https://www.mapbox.com/mapbox-gl-js/assets/radar.gif")!)
  mapView.style?.addSource(source)
+ 
+ let layer = MGLRasterStyleLayer(identifier: "radar-layer", source: source)
+ style.addLayer(layer)
  ```
  */
 MGL_EXPORT


### PR DESCRIPTION
I added a code snippet that shows to use the source to create a style layer. The nature of `MGLImageSource` seems to make the relationship between source and layer a little more confusing, so additional clarification may be necessary.

Addresses https://github.com/mapbox/mapbox-gl-native/issues/10148