### PR TITLE
[core] Update glyph requestors _before_ requesting from file source

### DIFF
--- a/src/mbgl/text/glyph_manager.cpp
+++ b/src/mbgl/text/glyph_manager.cpp
@@ -36,8 +36,9 @@ void GlyphManager::getGlyphs(GlyphRequestor& requestor, GlyphDependencies glyphD
         for (const auto& range : ranges) {
             auto it = entry.ranges.find(range);
             if (it == entry.ranges.end() || !it->second.parsed) {
-                GlyphRequest& request = requestRange(entry, fontStack, range);
+                GlyphRequest& request = entry.ranges[range];
                 request.requestors[&requestor] = dependencies;
+                requestRange(request, fontStack, range);
             }
         }
     }
@@ -49,18 +50,14 @@ void GlyphManager::getGlyphs(GlyphRequestor& requestor, GlyphDependencies glyphD
     }
 }
 
-GlyphManager::GlyphRequest& GlyphManager::requestRange(Entry& entry, const FontStack& fontStack, const GlyphRange& range) {
-    GlyphRequest& request = entry.ranges[range];
-
+void GlyphManager::requestRange(GlyphRequest& request, const FontStack& fontStack, const GlyphRange& range) {
     if (request.req) {
-        return request;
+        return;
     }
 
     request.req = fileSource.request(Resource::glyphs(glyphURL, fontStack, range), [this, fontStack, range](Response res) {
         processResponse(res, fontStack, range);
     });
-
-    return request;
 }
 
 void GlyphManager::processResponse(const Response& res, const FontStack& fontStack, const GlyphRange& range) {

--- a/src/mbgl/text/glyph_manager.hpp
+++ b/src/mbgl/text/glyph_manager.hpp
@@ -58,7 +58,7 @@ private:
 
     std::unordered_map<FontStack, Entry, FontStackHash> entries;
 
-    GlyphRequest& requestRange(Entry&, const FontStack&, const GlyphRange&);
+    void requestRange(GlyphRequest&, const FontStack&, const GlyphRange&);
     void processResponse(const Response&, const FontStack&, const GlyphRange&);
     void notify(GlyphRequestor&, const GlyphDependencies&);
 

--- a/test/src/mbgl/test/stub_file_source.hpp
+++ b/test/src/mbgl/test/stub_file_source.hpp
@@ -9,7 +9,12 @@ namespace mbgl {
 
 class StubFileSource : public FileSource {
 public:
-    StubFileSource();
+    enum class ResponseType {
+        Asynchronous = 0,
+        Synchronous
+    };
+
+    StubFileSource(ResponseType = ResponseType::Asynchronous);
     ~StubFileSource() override;
 
     std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
@@ -36,6 +41,7 @@ private:
     optional<Response> defaultResponse(const Resource&);
 
     std::unordered_map<AsyncRequest*, std::tuple<Resource, ResponseFunction, Callback>> pending;
+    ResponseType type;
     util::Timer timer;
 };
 


### PR DESCRIPTION
If the file source request happens immediately (e.g. when obtaining from a memory cache), then the glyph manager response processing happens _before_ the glyph requestors map gets updated, causing the notification to never happen in such cases.