### PR TITLE
[qt] add ResourceTransform API

### DIFF
--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -62,7 +62,7 @@ public:
     void setApiBaseUrl(const QString &);
 
     std::function<std::string(const std::string &&)> resourceTransform() const;
-    void setResourceTransform(std::function<std::string(const std::string &&)> &);
+    void setResourceTransform(const std::function<std::string(const std::string &&)> &);
 
 private:
     GLContextMode m_contextMode;

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -10,6 +10,8 @@
 #include <QString>
 #include <QStringList>
 
+#include <functional>
+
 class QMapboxGLPrivate;
 
 // This header follows the Qt coding style: https://wiki.qt.io/Qt_Coding_Style
@@ -59,6 +61,9 @@ public:
     QString apiBaseUrl() const;
     void setApiBaseUrl(const QString &);
 
+    std::function<std::string(const std::string &&)> resourceTransform() const;
+    void setResourceTransform(std::function<std::string(const std::string &&)> &);
+
 private:
     GLContextMode m_contextMode;
     ConstrainMode m_constrainMode;
@@ -69,6 +74,7 @@ private:
     QString m_assetPath;
     QString m_accessToken;
     QString m_apiBaseUrl;
+    std::function<std::string(const std::string &&)> m_resourceTransform;
 };
 
 struct Q_DECL_EXPORT QMapboxGLCameraOptions {

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -29,6 +29,7 @@
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/util/shared_thread_pool.hpp>
 #include <mbgl/util/traits.hpp>
+#include <mbgl/actor/scheduler.hpp>
 
 #if QT_VERSION >= 0x050000
 #include <QGuiApplication>
@@ -359,6 +360,27 @@ QString QMapboxGLSettings::apiBaseUrl() const
 void QMapboxGLSettings::setApiBaseUrl(const QString& url)
 {
     m_apiBaseUrl = url;
+}
+
+/*!
+    Returns resource transformation callback used to transform requested URLs.
+*/
+std::function<std::string(const std::string &&)> QMapboxGLSettings::resourceTransform() const
+{
+    return m_resourceTransform;
+}
+
+/*!
+    Sets the resource transformation callback.
+
+    When given, resource transformation callback will be used to transform the
+    requested resource URLs before they are requested from internet. This can be
+    used add or remove custom parameters, or reroute certain requests to other
+    servers or endpoints.
+*/
+void QMapboxGLSettings::setResourceTransform(std::function<std::string(const std::string &&)> &transform)
+{
+    m_resourceTransform = transform;
 }
 
 /*!
@@ -1499,6 +1521,18 @@ QMapboxGLPrivate::QMapboxGLPrivate(QMapboxGL *q, const QMapboxGLSettings &settin
         settings.cacheDatabaseMaximumSize()))
     , threadPool(mbgl::sharedThreadPool())
 {
+    // Setup resource transform if needed
+    if (settings.resourceTransform()) {
+      m_resourceTransform =
+        std::make_unique< mbgl::Actor<mbgl::ResourceTransform> >( *mbgl::Scheduler::GetCurrent(),
+                                                                  [callback = settings.resourceTransform()]
+                                                                  (mbgl::Resource::Kind , const std::string&& url_)  -> std::string {
+                                                                    return callback(std::move(url_));
+                                                                  }
+                                                                  );
+      fileSourceObj->setResourceTransform(m_resourceTransform->self());
+    }
+
     // Setup and connect the renderer frontend
     frontend = std::make_unique<QMapboxGLRendererFrontend>(
             std::make_unique<mbgl::Renderer>(*this, pixelRatio, *fileSourceObj, *threadPool,

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -378,7 +378,7 @@ std::function<std::string(const std::string &&)> QMapboxGLSettings::resourceTran
     used add or remove custom parameters, or reroute certain requests to other
     servers or endpoints.
 */
-void QMapboxGLSettings::setResourceTransform(std::function<std::string(const std::string &&)> &transform)
+void QMapboxGLSettings::setResourceTransform(const std::function<std::string(const std::string &&)> &transform)
 {
     m_resourceTransform = transform;
 }

--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -3,14 +3,18 @@
 #include "qmapboxgl.hpp"
 #include "qmapboxgl_renderer_frontend_p.hpp"
 
+#include <mbgl/actor/actor.hpp>
 #include <mbgl/map/map.hpp>
 #include <mbgl/renderer/renderer_backend.hpp>
 #include <mbgl/util/default_thread_pool.hpp>
 #include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/util/geo.hpp>
+#include <mbgl/storage/resource_transform.hpp>
 
 #include <QObject>
 #include <QSize>
+
+#include <memory>
 
 class QMapboxGLPrivate : public QObject, public mbgl::RendererBackend, public mbgl::MapObserver
 {
@@ -68,4 +72,7 @@ signals:
     void needsRendering();
     void mapChanged(QMapboxGL::MapChange);
     void copyrightsChanged(const QString &copyrightsHtml);
+
+private:
+    std::unique_ptr< mbgl::Actor<mbgl::ResourceTransform> > m_resourceTransform;
 };


### PR DESCRIPTION
Adds resource transform API to Qt platform. This PR adds functionality missing on Qt. By providing callback function, user can transform requested URL on Qt platform as well.

This PR fixes https://github.com/mapbox/mapbox-gl-native/issues/10130