### PR TITLE
Remove obsolete terminate context/display calls

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -261,9 +261,6 @@ public class MapView extends FrameLayout {
   @UiThread
   public void onDestroy() {
     destroyed = true;
-    nativeMapView.terminateContext();
-    nativeMapView.terminateDisplay();
-    nativeMapView.destroySurface();
     mapCallback.clearOnMapReadyCallbacks();
     nativeMapView.destroy();
     nativeMapView = null;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -130,25 +130,11 @@ final class NativeMapView {
     nativeInitializeDisplay();
   }
 
-  public void terminateDisplay() {
-    if (isDestroyedOn("terminateDisplay")) {
-      return;
-    }
-    nativeTerminateDisplay();
-  }
-
   public void initializeContext() {
     if (isDestroyedOn("initializeContext")) {
       return;
     }
     nativeInitializeContext();
-  }
-
-  public void terminateContext() {
-    if (isDestroyedOn("terminateContext")) {
-      return;
-    }
-    nativeTerminateContext();
   }
 
   public void createSurface(Surface surface) {
@@ -952,11 +938,7 @@ final class NativeMapView {
 
   private native void nativeInitializeDisplay();
 
-  private native void nativeTerminateDisplay();
-
   private native void nativeInitializeContext();
-
-  private native void nativeTerminateContext();
 
   private native void nativeCreateSurface(Object surface);
 

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -261,16 +261,8 @@ void NativeMapView::initializeDisplay(jni::JNIEnv&) {
     _initializeDisplay();
 }
 
-void NativeMapView::terminateDisplay(jni::JNIEnv&) {
-    _terminateDisplay();
-}
-
 void NativeMapView::initializeContext(jni::JNIEnv&) {
     _initializeContext();
-}
-
-void NativeMapView::terminateContext(jni::JNIEnv&) {
-    _terminateContext();
 }
 
 void NativeMapView::createSurface(jni::JNIEnv& env, jni::Object<> _surface) {
@@ -1471,9 +1463,7 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
             METHOD(&NativeMapView::resizeView, "nativeResizeView"),
             METHOD(&NativeMapView::resizeFramebuffer, "nativeResizeFramebuffer"),
             METHOD(&NativeMapView::initializeDisplay, "nativeInitializeDisplay"),
-            METHOD(&NativeMapView::terminateDisplay, "nativeTerminateDisplay"),
             METHOD(&NativeMapView::initializeContext, "nativeInitializeContext"),
-            METHOD(&NativeMapView::terminateContext, "nativeTerminateContext"),
             METHOD(&NativeMapView::createSurface, "nativeCreateSurface"),
             METHOD(&NativeMapView::destroySurface, "nativeDestroySurface"),
             METHOD(&NativeMapView::getStyleUrl, "nativeGetStyleUrl"),

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -95,11 +95,7 @@ public:
 
     void initializeDisplay(jni::JNIEnv&);
 
-    void terminateDisplay(jni::JNIEnv&);
-
     void initializeContext(jni::JNIEnv&);
-
-    void terminateContext(jni::JNIEnv&);
 
     void createSurface(jni::JNIEnv&, jni::Object<>);
 


### PR DESCRIPTION
This PR removes redundant calls to `terminateContext` and `terminateDisplay`. These methods are already called as part of the destructor of map object, we don't need to call them as part of `MapView#onDestroy`. I'm patching this up on the `release-ios-v3.6.0-android-v5.1.0` branch so we can  ship this in a patch release.

cc @brunoabinader 