### PR TITLE
[ios, build] Add tag-based Bitrise iOS deployment workflow

### DIFF
--- a/platform/ios/bitrise.yml
+++ b/platform/ios/bitrise.yml
@@ -4,6 +4,8 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 trigger_map:
 - pattern: nightly-release
   workflow: nightly-release
+- pattern: release-from-tag
+  workflow: release-from-tag
 - pattern: "*"
   is_pull_request_allowed: true
   workflow: primary
@@ -88,13 +90,54 @@ workflows:
         inputs:
         - webhook_url: "$SLACK_HOOK_URL"
         - channel: "#gl-bots"
-        - from_username: 'Bitrise iOS Nightly \U0001F31D'
-        - from_username_on_error: 'Bitrise iOS Nightly \U0001F31D'
+        - from_username: 'Bitrise iOS Nightly 💤'
+        - from_username_on_error: 'Bitrise iOS Nightly 💤'
         - message: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
             for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}@%7B1day%7D...${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
             completed successfully.'
         - message_on_error: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
             for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}@%7B1day%7D...${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
+            failed.'
+        - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png
+        - icon_url_on_error: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-error-icon-128.png
+  release-from-tag:
+    steps:
+    - script:
+        title: Install Dependencies
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -eu -o pipefail
+            brew install cmake
+        - is_debug: 'yes'
+    - script:
+        title: Configure AWS-CLI
+        inputs:
+        - content: |-
+            #!/bin/bash
+            apt-get install -y python-pip python-dev build-essential
+            pip install awscli
+    - script:
+        title: Build package
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -eu -o pipefail
+            export VERSION_TAG=${BITRISE_GIT_TAG}
+            platform/ios/scripts/deploy-packages.sh
+        - is_debug: 'yes'
+    - slack:
+        title: Post to Slack
+        inputs:
+        - webhook_url: "$SLACK_HOOK_URL"
+        - channel: "#gl-bots"
+        - from_username: 'Bitrise iOS Deploy'
+        - from_username_on_error: 'Bitrise iOS Deploy'
+        - message: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
+            for <https://github.com/mapbox/mapbox-gl-native/releases/tag/${BITRISE_GIT_TAG}|`${BITRISE_GIT_TAG}`>
+            completed successfully.'
+        - message_on_error: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
+            for <https://github.com/mapbox/mapbox-gl-native/releases/tag/${BITRISE_GIT_TAG}|`${BITRISE_GIT_TAG}`>
             failed.'
         - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png
         - icon_url_on_error: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-error-icon-128.png

--- a/platform/ios/bitrise.yml
+++ b/platform/ios/bitrise.yml
@@ -70,7 +70,6 @@ workflows:
         inputs:
         - content: |-
             #!/bin/bash
-            apt-get install -y python-pip python-dev build-essential
             pip install awscli
     - script:
         title: Build package
@@ -115,7 +114,6 @@ workflows:
         inputs:
         - content: |-
             #!/bin/bash
-            apt-get install -y python-pip python-dev build-essential
             pip install awscli
     - script:
         title: Build package

--- a/platform/ios/scripts/deploy-packages.sh
+++ b/platform/ios/scripts/deploy-packages.sh
@@ -58,17 +58,17 @@ BINARY_DIRECTORY=${BINARY_DIRECTORY:-build/ios/deploy}
 GITHUB_RELEASE=${GITHUB_RELEASE:-true}
 PUBLISH_PRE_FLAG=''
 
+if [[ -z `which github-release` ]]; then
+    step "Installing github-release…"
+    brew install github-release
+    if [ -z `which github-release` ]; then
+        echo "Unable to install github-release. See: https://github.com/aktau/github-release"
+        exit 1
+    fi
+fi
+
 if [[ ${GITHUB_RELEASE} = "true" ]]; then
     GITHUB_RELEASE=true # Assign bool, not just a string
-
-    if [[ -z `which github-release` ]]; then
-        step "Installing github-release…"
-        brew install github-release
-        if [ -z `which github-release` ]; then
-            echo "Unable to install github-release. See: https://github.com/aktau/github-release"
-            exit 1
-        fi
-    fi
 fi
 
 if [[ -z ${VERSION_TAG} ]]; then
@@ -83,7 +83,7 @@ if [[ $( echo ${VERSION_TAG} | grep --invert-match ios-v ) ]]; then
     exit 1
 fi
 
-if [[ $( curl --head https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/tags/${VERSION_TAG} | head -n 1 | grep -c "404 Not Found") == 0 ]]; then
+if github-release info --tag ${VERSION_TAG} | grep --quiet "draft: ✗"; then
     echo "Error: ${VERSION_TAG} has already been published on GitHub"
     echo "See: https://github.com/${GITHUB_USER}/${GITHUB_REPO}/releases/tag/${VERSION_TAG}"
     exit 1


### PR DESCRIPTION
Closes #2844 by using Bitrise to build and deploy iOS releases.

The release process will be as described in https://github.com/mapbox/mapbox-gl-native/issues/2844#issuecomment-335248007 — the new step is `3.`:

> 1. Release manager bumps versions and updates release notes; gets that merged.
> 2. Release manager tags the release.
> 3. Bitrise receives the tag hook and starts the release build using the deployment script.
> 4. Release manager updates the Github release with notes, checks that binaries are 👍, then pushes publish.
> 5. Release manager handles the various other docs updates elsewhere.

### Notes
- It takes about 50 minutes for Bitrise to setup, build, and deploy — versus 30-40 minutes locally.
- Using `make ideploy` locally will still work, provided you do all of the usual auth’ing.