### PR TITLE
[android] Revert native loading behavior

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/LibraryLoader.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/LibraryLoader.java
@@ -1,17 +1,11 @@
 package com.mapbox.mapboxsdk;
 
-import android.content.Context;
-
-import java.io.File;
-
 import timber.log.Timber;
 
 /**
  * Centralises the knowledge about "mapbox-gl" library loading.
  */
 public class LibraryLoader {
-
-  private static final String LIBRARY_NAME = "libmapbox-gl.so";
 
   /**
    * Loads "libmapbox-gl.so" native shared library.
@@ -20,22 +14,7 @@ public class LibraryLoader {
     try {
       System.loadLibrary("mapbox-gl");
     } catch (UnsatisfiedLinkError error) {
-      Context context = Mapbox.getApplicationContext();
-      if (context != null) {
-        Timber.d("Loading %s from internal storage.", LIBRARY_NAME);
-        System.load(getLibraryLocation(context).getAbsolutePath());
-      }
+      Timber.e(error, "Failed to load native shared library.");
     }
-  }
-
-  /**
-   * Returns a file in the app internal storage that may contain a locally cached copy
-   * of the Mapbox native library.
-   *
-   * @param context The application context
-   * @return a file object
-   */
-  public static File getLibraryLocation(Context context) {
-    return new File(context.getFilesDir(), LIBRARY_NAME);
   }
 }


### PR DESCRIPTION
This PR reverts the changes from https://github.com/mapbox/mapbox-gl-native/pull/10154 while adding an `UnsatisfiedLinkError` safeguard.
