### PR TITLE
[ios] Update MGLUserLocation.heading for showsUserHeadingIndicator

### DIFF
--- a/platform/ios/src/MGLUserLocation.h
+++ b/platform/ios/src/MGLUserLocation.h
@@ -34,7 +34,8 @@ MGL_EXPORT
  The heading of the user location. (read-only)
 
  This property is `nil` if the user location tracking mode is not
- `MGLUserTrackingModeFollowWithHeading`.
+ `MGLUserTrackingModeFollowWithHeading` or if
+ `MGLMapView.showsUserHeadingIndicator` is disabled.
  */
 @property (nonatomic, readonly, nullable) CLHeading *heading;
 


### PR DESCRIPTION
Update the docs to indicate that heading is also provided if `MGLMapView.showsUserHeadingIndicator` is enabled. Prompted by #10181.

/cc @jmkiley @1ec5 