### PR TITLE
add make target for ndk-stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -553,6 +553,11 @@ run-android-ui-test-$1-%: platform/android/configuration.gradle
 	-adb uninstall com.mapbox.mapboxsdk.testapp 2> /dev/null
 	cd platform/android && $(MBGL_ANDROID_GRADLE) -Pmapbox.abis=$2 :MapboxGLAndroidSDKTestApp:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.class="$$*"
 
+# Symbolicate native stack trace with the specified abi
+.PHONY: android-ndk-stack-$1
+android-ndk-stack-$1: platform/android/configuration.gradle
+	adb logcat | ndk-stack -sym platform/android/MapboxGLAndroidSDK/build/intermediates/cmake/debug/obj/$2/
+
 endef
 
 # Explodes the arguments into individual variables
@@ -640,6 +645,10 @@ android-lint-test-app: platform/android/configuration.gradle
 .PHONY: android-javadoc
 android-javadoc: platform/android/configuration.gradle
 	cd platform/android && $(MBGL_ANDROID_GRADLE) -Pmapbox.abis=none :MapboxGLAndroidSDK:javadocrelease
+
+# Symbolicate ndk stack traces for the arm-v7 abi	
+.PHONY: android-ndk-stack
+android-ndk-stack: android-ndk-stack-arm-v7
 
 # Open Android Studio if machine is macos
 ifeq ($(HOST_PLATFORM), macos)


### PR DESCRIPTION
This PR reintroduces the make target for ndk-stack. I was spending a lot of time looking up the specific command when running into a native crash. This was initially removed with integrating c++ build into android studio. Two targets were added, one abi specific, the other defaults to arm-v7.