### PR TITLE
Fix symbol export warning

### DIFF
--- a/platform/darwin/src/MGLMapSnapshotter.h
+++ b/platform/darwin/src/MGLMapSnapshotter.h
@@ -5,10 +5,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-MGL_EXPORT
 /**
- The options to use when creating images with the `MGLMapsnapshotter`.
+ The options to use when creating images with the `MGLMapSnapshotter`.
  */
+MGL_EXPORT
 @interface MGLMapSnapshotOptions : NSObject
 
 /**
@@ -63,7 +63,8 @@ MGL_EXPORT
 
 /**
  The scale of the output image. Defaults to the main screen scale.
- Minimum is 1.
+ 
+ The minimum scale is 1.
  */
 @property (nonatomic) CGFloat scale;
 


### PR DESCRIPTION
Fixed a warning issued by check-public-symbols.js in MGLMapSnapshotOptions due to the `MGL_EXPORT` keyword appearing before the documentation comment. This warning fails `make xdeploy` (but not `make ideploy` because that target doesn’t check for public symbols):

```
* Checking that all public symbols are exported…
- missing symbol export for class MGLMapSnapshotOptions in platform/darwin/src/MGLMapSnapshotter.h:12:12
make[1]: *** [xpackage] Error 1
make: *** [xdeploy] Error 2
```

Also copyedited a couple comments in the same header.

/cc @kkaefer @friedbunny