### PR TITLE
Deploy macosapp as part of releases

### DIFF
--- a/platform/macos/ExportOptions.plist
+++ b/platform/macos/ExportOptions.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>developer-id</string>
+	<key>teamID</key>
+	<string>GJZR2MEM28</string>
+</dict>
+</plist>

--- a/platform/macos/scripts/deploy-packages.sh
+++ b/platform/macos/scripts/deploy-packages.sh
@@ -46,6 +46,19 @@ buildPackageStyle() {
             --name ${file_name} \
             --file "${BINARY_DIRECTORY}/${file_name}" > /dev/null
     fi
+    if [[ $2 == true ]]; then
+        cd build/macos/app
+        rm -f 'Mapbox GL.app.zip'
+        zip -yr '../deploy/Mapbox GL.app.zip' 'Mapbox GL.app'
+        cd -
+        if [[ "${GITHUB_RELEASE}" == true ]]; then
+            echo "Uploading ${file_name} to GitHub"
+            github-release upload \
+                --tag "macos-v${PUBLISH_VERSION}" \
+                --name ${file_name} \
+                --file "${BINARY_DIRECTORY}/${file_name}" > /dev/null
+        fi
+    fi
 }
 
 export TRAVIS_REPO_SLUG=mapbox-gl-native
@@ -114,6 +127,6 @@ if [[ "${GITHUB_RELEASE}" == true ]]; then
 fi
 
 buildPackageStyle "xpackage" "symbols"
-buildPackageStyle "xpackage SYMBOLS=NO"
+buildPackageStyle "xpackage SYMBOLS=NO" true
 
 step "Finished deploying ${PUBLISH_VERSION} in $(($SECONDS / 60)) minutes and $(($SECONDS % 60)) seconds"

--- a/platform/macos/scripts/deploy-packages.sh
+++ b/platform/macos/scripts/deploy-packages.sh
@@ -46,7 +46,7 @@ buildPackageStyle() {
             --name ${file_name} \
             --file "${BINARY_DIRECTORY}/${file_name}" > /dev/null
     fi
-    if [[ $2 == true ]]; then
+    if [[ ${DEPLOY_APP} == true ]]; then
         cd build/macos/app
         rm -f 'Mapbox GL.app.zip'
         zip -yr '../deploy/Mapbox GL.app.zip' 'Mapbox GL.app'
@@ -127,6 +127,6 @@ if [[ "${GITHUB_RELEASE}" == true ]]; then
 fi
 
 buildPackageStyle "xpackage" "symbols"
-buildPackageStyle "xpackage SYMBOLS=NO" true
+DEPLOY_APP=true buildPackageStyle "xpackage SYMBOLS=NO"
 
 step "Finished deploying ${PUBLISH_VERSION} in $(($SECONDS / 60)) minutes and $(($SECONDS % 60)) seconds"


### PR DESCRIPTION
This PR automates the following steps in [the macOS SDK release process](https://github.com/mapbox/mapbox-gl-native/wiki/Releasing-the-Mapbox-macOS-SDK):

> 6. Optionally, build Mapbox GL.app:
>    1. Run make xproj and switch to the macosapp scheme.
>    1. Go to Product ‣ Archive.
>    1. After macosapp finishes archiving, go to the Archives tab of the Organizer window. Select the macosapp archive, then click Export in the right sidebar.
>    1. In the sheet that appears, select “Export a Developer ID–signed Application”.
>    1. Zip up the exported .app and attach it to the release draft.

All in all:

* [x] Add steps to the packaging script to archive and export macosapp
* [x] Upload the exported, compressed application bundle to the GitHub release when deploying a release
* [x] Merge the new and existing `xcodebuild` invocations to avoid [recompiling the world](http://catb.org/jargon/html/R/recompile-the-world.html)

/cc @friedbunny