### PR TITLE
Skip expression-based runtime styling test

### DIFF
--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -38,7 +38,7 @@
   "render-tests/line-opacity/step-curve": "https://github.com/mapbox/mapbox-gl-native/pull/9439",
   "render-tests/regressions/mapbox-gl-js#2305": "https://github.com/mapbox/mapbox-gl-native/issues/6927",
   "render-tests/regressions/mapbox-gl-js#3682": "https://github.com/mapbox/mapbox-gl-js/issues/3682",
-  "render-tests/regressions/mapbox-gl-js#5370": "https://github.com/mapbox/mapbox-gl-native/pull/9439",
+  "render-tests/regressions/mapbox-gl-js#5370": "skip - https://github.com/mapbox/mapbox-gl-native/pull/9439",
   "render-tests/regressions/mapbox-gl-native#7357": "https://github.com/mapbox/mapbox-gl-native/issues/7357",
   "render-tests/runtime-styling/image-add-sdf": "https://github.com/mapbox/mapbox-gl-native/issues/9847",
   "render-tests/runtime-styling/paint-property-fill-flat-to-extrude": "https://github.com/mapbox/mapbox-gl-native/issues/6745",


### PR DESCRIPTION
My bad for not catching this in https://github.com/mapbox/mapbox-gl-native/commit/057cc80fc45758e89bfa08eb1ce0df487dc002a6 🤕 — other ignored render tests with expressions are static styles, so their validation errors are caught in Warning events. This particular regression test uses runtime styling, [so its validation error throws](https://github.com/mapbox/mapbox-gl-native/blob/8bccf657e9cecb58d5b349dac48c0a50db813e91/platform/node/src/node_map.cpp#L746), and the test run quits.