### PR TITLE
Limit annotation tiles to z16

### DIFF
--- a/src/mbgl/annotation/render_annotation_source.cpp
+++ b/src/mbgl/annotation/render_annotation_source.cpp
@@ -38,7 +38,9 @@ void RenderAnnotationSource::update(Immutable<style::Source::Impl> baseImpl_,
                        parameters,
                        SourceType::Annotations,
                        util::tileSize,
-                       { 0, util::DEFAULT_MAX_ZOOM },
+                       // Zoom level 16 is typically sufficient for annotations.
+                       // See https://github.com/mapbox/mapbox-gl-native/issues/10197
+                       { 0, 16 },
                        [&] (const OverscaledTileID& tileID) {
                            return std::make_unique<AnnotationTile>(tileID, parameters);
                        });


### PR DESCRIPTION
We're currently generating annotation tiles all the way up to z22: https://github.com/mapbox/mapbox-gl-native/blob/2166b8577b4bd2812d504ceb31b6c2af243de8f5/src/mbgl/annotation/render_annotation_source.cpp#L41

In most cases, however, it's unnecessary to regenerate the tiles for higher zoom levels. We should limit the tiles to z16 to match the tile level most vector tilesets use as well.