### PR TITLE
Determine need for clip ID based on actual layers/tiles

### DIFF
--- a/src/mbgl/algorithm/generate_clip_ids_impl.hpp
+++ b/src/mbgl/algorithm/generate_clip_ids_impl.hpp
@@ -17,7 +17,7 @@ void ClipIDGenerator::update(std::vector<std::reference_wrapper<Renderable>> ren
     const auto end = renderables.end();
     for (auto it = renderables.begin(); it != end; it++) {
         auto& renderable = it->get();
-        if (!renderable.used) {
+        if (!renderable.used || !renderable.needsClipping) {
             continue;
         }
 

--- a/src/mbgl/renderer/render_tile.hpp
+++ b/src/mbgl/renderer/render_tile.hpp
@@ -28,6 +28,7 @@ public:
     mat4 matrix;
     mat4 nearClippedMatrix;
     bool used = false;
+    bool needsClipping = false;
 
     mat4 translatedMatrix(const std::array<float, 2>& translate,
                           style::TranslateAnchorType anchor,

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -370,6 +370,13 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
             if (bucket) {
                 sortedTilesForInsertion.emplace_back(tile);
                 tile.used = true;
+
+                // We only need clipping when we're _not_ drawing a symbol layer. The only exception
+                // for symbol layers is when we're rendering still images. See render_symbol_layer.cpp
+                // for the exception we make there.
+                if (!symbolLayer || parameters.mapMode == MapMode::Still) {
+                    tile.needsClipping = true;
+                }
             }
         }
         layer->setRenderTiles(std::move(sortedTilesForInsertion));

--- a/test/algorithm/generate_clip_ids.test.cpp
+++ b/test/algorithm/generate_clip_ids.test.cpp
@@ -8,13 +8,16 @@ struct Renderable {
     UnwrappedTileID id;
     ClipID clip;
     bool used;
+    bool needsClipping;
 
     Renderable(UnwrappedTileID id_,
                ClipID clip_,
-               bool used_ = true)
+               bool used_ = true,
+               bool needsClipping_ = true)
         : id(std::move(id_)),
           clip(std::move(clip_)),
-          used(used_) {}
+          used(used_),
+          needsClipping(needsClipping_) {}
 
     bool operator==(const Renderable& rhs) const {
         return id == rhs.id && clip == rhs.clip;


### PR DESCRIPTION
When generating clip IDs for our stencil buffer based clipping approach, we are currently looking at the *tiles* of a particular source. Instead, we should only consider layers that actually need clipping (lines, fills, extrusions) rather than blindly generating clip IDs for every tile.

An example: A vector tile source is only used in symbol layers (which don't require clipping). Since we're currently generating clip IDs for all tiles in a *geometry source* (but not a raster source), we'd still generate clip IDs for these tiles even though they're never used.