### PR TITLE
[ios, macos] Added snapshot classes to jazzy

### DIFF
--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -32,6 +32,8 @@ custom_categories:
       - MGLMapCamera
       - MGLMapView
       - MGLMapViewDelegate
+      - MGLMapSnapshotOptions
+      - MGLMapSnapshotter
       - MGLUserTrackingMode
   - name: Primitive Shapes
     children:

--- a/platform/macos/jazzy.yml
+++ b/platform/macos/jazzy.yml
@@ -28,6 +28,8 @@ custom_categories:
       - MGLMapCamera
       - MGLMapView
       - MGLMapViewDelegate
+      - MGLMapSnapshotOptions
+      - MGLMapSnapshotter
   - name: Shapes and Annotations
     children:
       - MGLAnnotation


### PR DESCRIPTION
This pull request adds the classes MGLMapSnapshotter and MGLMapSnapshopOptions to the jazzy.yml file for iOS and MacOS platforms documentation under the maps section as requested.

Resolves #10121  

