### PR TITLE
Backport: Correctly alter sprite URLs

### DIFF
--- a/src/mbgl/storage/resource.cpp
+++ b/src/mbgl/storage/resource.cpp
@@ -54,17 +54,19 @@ Resource Resource::source(const std::string& url) {
 }
 
 Resource Resource::spriteImage(const std::string& base, float pixelRatio) {
-    return Resource {
-        Resource::Kind::SpriteImage,
-        base + (pixelRatio > 1 ? "@2x" : "") + ".png"
-    };
+    util::URL url(base);
+    return Resource{ Resource::Kind::SpriteImage,
+                     base.substr(0, url.path.first + url.path.second) +
+                         (pixelRatio > 1 ? "@2x" : "") + ".png" +
+                         base.substr(url.query.first, url.query.second) };
 }
 
 Resource Resource::spriteJSON(const std::string& base, float pixelRatio) {
-    return Resource {
-        Resource::Kind::SpriteJSON,
-        base + (pixelRatio > 1 ? "@2x" : "") + ".json"
-    };
+    util::URL url(base);
+    return Resource{ Resource::Kind::SpriteJSON,
+                     base.substr(0, url.path.first + url.path.second) +
+                         (pixelRatio > 1 ? "@2x" : "") + ".json" +
+                         base.substr(url.query.first, url.query.second) };
 }
 
 Resource Resource::glyphs(const std::string& urlTemplate, const FontStack& fontStack, const std::pair<uint16_t, uint16_t>& glyphRange) {

--- a/test/storage/resource.test.cpp
+++ b/test/storage/resource.test.cpp
@@ -115,6 +115,10 @@ TEST(Resource, SpriteImage) {
     Resource resource = Resource::spriteImage("http://example.com/sprite", 2.0);
     EXPECT_EQ(Resource::Kind::SpriteImage, resource.kind);
     EXPECT_EQ("http://example.com/sprite@2x.png", resource.url);
+
+    Resource paramResource = Resource::spriteImage("http://example.com/sprite?query=true", 2.0);
+    EXPECT_EQ(Resource::Kind::SpriteImage, paramResource.kind);
+    EXPECT_EQ("http://example.com/sprite@2x.png?query=true", paramResource.url);
 }
 
 TEST(Resource, SpriteJSON) {
@@ -122,4 +126,8 @@ TEST(Resource, SpriteJSON) {
     Resource resource = Resource::spriteJSON("http://example.com/sprite", 2.0);
     EXPECT_EQ(Resource::Kind::SpriteJSON, resource.kind);
     EXPECT_EQ("http://example.com/sprite@2x.json", resource.url);
+
+    Resource paramResource = Resource::spriteJSON("http://example.com/sprite?query=true", 2.0);
+    EXPECT_EQ(Resource::Kind::SpriteJSON, paramResource.kind);
+    EXPECT_EQ("http://example.com/sprite@2x.json?query=true", paramResource.url);
 }


### PR DESCRIPTION
Backport https://github.com/mapbox/mapbox-gl-native/pull/10213 to iOS 3.6/Android 5.1.