### PR TITLE
Exception handler

### DIFF
--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -103,7 +103,11 @@ void NativeMapView::notifyMapChange(mbgl::MapChange change) {
 
     android::UniqueEnv _env = android::AttachEnv();
     static auto onMapChanged = javaClass.GetMethod<void (int)>(*_env, "onMapChanged");
-    javaPeer->Call(*_env, onMapChanged, (int) change);
+    try {
+        javaPeer->Call(*_env, onMapChanged, (int) change);
+    } catch (jni::PendingJavaException& exception) {
+        jni::ThrowJavaError(*_env, std::current_exception());
+    }
 }
 
 void NativeMapView::onCameraWillChange(MapObserver::CameraChangeMode mode) {


### PR DESCRIPTION
closes #10188,

This PR doesn't add the exception handler as outlined in #10188 but catches the pending java exception and rethrows it using `jni::ThrowJavaError. This solves the issue of not being able to see which java exception occurred while still crashing the app.

eg.

>JNI DETECTED ERROR IN APPLICATION: JNI CallVoidMethodV called with pending exception java.lang.RuntimeException: HELLO WORLD

instead of:

> void abort_message(const char *, ...): assertion "terminating with uncaught exception of type jni::PendingJavaException" failed

Full log of proposal [here](https://gist.github.com/tobrun/eb905e1a8750606a571b90e9dab803f9)
