### PR TITLE
[ios, build] Force Bitrise to install pip for tag-based deployment

### DIFF
--- a/platform/ios/bitrise.yml
+++ b/platform/ios/bitrise.yml
@@ -108,13 +108,9 @@ workflows:
             #!/bin/bash
             set -eu -o pipefail
             brew install cmake
+            sudo easy_install pip
+            sudo pip install awscli
         - is_debug: 'yes'
-    - script:
-        title: Configure AWS-CLI
-        inputs:
-        - content: |-
-            #!/bin/bash
-            pip install awscli
     - script:
         title: Build package
         inputs:


### PR DESCRIPTION
For whatever reason, Bitrise no longer has pip installed automatically on their macOS stacks, so it has become necessary to do it ourselves. This fixes the tag deployment — I’ll do another PR to fix the nightly on the master branch → https://github.com/mapbox/mapbox-gl-native/pull/10232.

/cc @kkaefer @fabian-guerra