### PR TITLE
[ios, build] Fix nightly build on bitrise by installing pip

### DIFF
--- a/platform/ios/bitrise.yml
+++ b/platform/ios/bitrise.yml
@@ -62,14 +62,9 @@ workflows:
             #!/bin/bash
             set -eu -o pipefail
             brew install cmake
+            sudo easy_install pip
+            sudo pip install awscli
         - is_debug: 'yes'
-    - script:
-        title: Configure AWS-CLI
-        inputs:
-        - content: |-
-            #!/bin/bash
-            apt-get install -y python-pip python-dev build-essential
-            pip install awscli
     - script:
         title: Build package
         inputs:


### PR DESCRIPTION
Fixes the [broken iOS nightly build on Bitrise](https://www.bitrise.io/build/ef5156406583d122). Companion to #10231 on `release-agua`.

```
/var/folders/90/5stft2v13fb_m_gv3c8x9nwc0000gn/T/bitrise565838807/step_src/._script_cont: line 2: apt-get: command not found
/var/folders/90/5stft2v13fb_m_gv3c8x9nwc0000gn/T/bitrise565838807/step_src/._script_cont: line 3: pip: command not found
|                                                                              |
+---+---------------------------------------------------------------+----------+
| x | Configure AWS-CLI (exit code: 127)
```

/cc @kkaefer