### PR TITLE
Remove core animations, replace with Android SDK animators

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -133,6 +133,7 @@ public:
 
     // Projection
     ScreenCoordinate pixelForLatLng(const LatLng&) const;
+    ScreenCoordinate pixelForLatLng2(const LatLng&) const;
     LatLng latLngForPixel(const ScreenCoordinate&) const;
 
     // Annotations

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraPosition.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraPosition.java
@@ -52,7 +52,7 @@ public final class CameraPosition implements Parcelable {
    * Zoom level near the center of the screen. See zoom(float) for the definition of the camera's
    * zoom level.
    */
-  public final double zoom;
+  public double zoom;
 
   /**
    * Constructs a CameraPosition.

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -632,7 +632,7 @@ public final class MapboxMap {
     if (focalPoint == null) {
       focalPoint = new PointF(nativeMapView.getWidth() / 2, nativeMapView.getHeight() / 2);
     }
-    nativeMapView.setZoom(zoom, focalPoint, 0);
+    nativeMapView.setZoom(zoom, focalPoint);
   }
 
   /**
@@ -641,7 +641,7 @@ public final class MapboxMap {
    * @param tilt Tilt angle to change to
    */
   public void setTilt(@FloatRange(from = MapboxConstants.MINIMUM_TILT, to = MapboxConstants.MAXIMUM_TILT) double tilt) {
-    nativeMapView.setPitch(tilt, 0);
+    nativeMapView.setPitch(tilt);
   }
 
   /**
@@ -944,6 +944,7 @@ public final class MapboxMap {
    * @param duration The duration of the transformation
    */
   public void setFocalBearing(double bearing, float focalX, float focalY, long duration) {
+    // TODO remove obsolete public API
     transform.setBearing(bearing, focalX, focalY, duration);
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -194,28 +194,14 @@ final class NativeMapView {
     if (isDestroyedOn("moveBy")) {
       return;
     }
-    moveBy(dx, dy, 0);
-  }
-
-  public void moveBy(double dx, double dy, long duration) {
-    if (isDestroyedOn("moveBy")) {
-      return;
-    }
-    nativeMoveBy(dx / pixelRatio, dy / pixelRatio, duration);
+    nativeMoveBy(dx/pixelRatio, dy/pixelRatio);
   }
 
   public void setLatLng(LatLng latLng) {
     if (isDestroyedOn("setLatLng")) {
       return;
     }
-    setLatLng(latLng, 0);
-  }
-
-  public void setLatLng(LatLng latLng, long duration) {
-    if (isDestroyedOn("setLatLng")) {
-      return;
-    }
-    nativeSetLatLng(latLng.getLatitude(), latLng.getLongitude(), duration);
+    nativeSetLatLng(latLng.getLatitude(), latLng.getLongitude());
   }
 
   public LatLng getLatLng() {
@@ -254,18 +240,18 @@ final class NativeMapView {
     return nativeGetPitch();
   }
 
-  public void setPitch(double pitch, long duration) {
+  public void setPitch(double pitch) {
     if (isDestroyedOn("setPitch")) {
       return;
     }
-    nativeSetPitch(pitch, duration);
+    nativeSetPitch(pitch);
   }
 
-  public void setZoom(double zoom, PointF focalPoint, long duration) {
+  public void setZoom(double zoom, PointF focalPoint) {
     if (isDestroyedOn("setZoom")) {
       return;
     }
-    nativeSetZoom(zoom, focalPoint.x / pixelRatio, focalPoint.y / pixelRatio, duration);
+    nativeSetZoom(zoom, focalPoint.x / pixelRatio, focalPoint.y / pixelRatio);
   }
 
   public double getZoom() {
@@ -314,15 +300,7 @@ final class NativeMapView {
     if (isDestroyedOn("rotateBy")) {
       return;
     }
-    rotateBy(sx, sy, ex, ey, 0);
-  }
-
-  public void rotateBy(double sx, double sy, double ex, double ey,
-                       long duration) {
-    if (isDestroyedOn("rotateBy")) {
-      return;
-    }
-    nativeRotateBy(sx / pixelRatio, sy / pixelRatio, ex, ey, duration);
+    nativeRotateBy(sx / pixelRatio, sy / pixelRatio, ex, ey);
   }
 
   public void setContentPadding(int[] padding) {
@@ -340,28 +318,14 @@ final class NativeMapView {
     if (isDestroyedOn("setBearing")) {
       return;
     }
-    setBearing(degrees, 0);
-  }
-
-  public void setBearing(double degrees, long duration) {
-    if (isDestroyedOn("setBearing")) {
-      return;
-    }
-    nativeSetBearing(degrees, duration);
+    nativeSetBearing(degrees);
   }
 
   public void setBearing(double degrees, double cx, double cy) {
     if (isDestroyedOn("setBearing")) {
       return;
     }
-    setBearing(degrees, cx, cy, 0);
-  }
-
-  public void setBearing(double degrees, double fx, double fy, long duration) {
-    if (isDestroyedOn("setBearing")) {
-      return;
-    }
-    nativeSetBearingXY(degrees, fx / pixelRatio, fy / pixelRatio, duration);
+    nativeSetBearingXY(degrees, cx / pixelRatio, cy / pixelRatio);
   }
 
   public double getBearing() {
@@ -482,11 +446,11 @@ final class NativeMapView {
     nativeRemoveAnnotationIcon(symbol);
   }
 
-  public void setVisibleCoordinateBounds(LatLng[] coordinates, RectF padding, double direction, long duration) {
+  public void setVisibleCoordinateBounds(LatLng[] coordinates, RectF padding, double direction) {
     if (isDestroyedOn("setVisibleCoordinateBounds")) {
       return;
     }
-    nativeSetVisibleCoordinateBounds(coordinates, padding, direction, duration);
+    nativeSetVisibleCoordinateBounds(coordinates, padding, direction);
   }
 
   public void onLowMemory() {
@@ -873,9 +837,9 @@ final class NativeMapView {
 
   private native void nativeSetGestureInProgress(boolean inProgress);
 
-  private native void nativeMoveBy(double dx, double dy, long duration);
+  private native void nativeMoveBy(double dx, double dy);
 
-  private native void nativeSetLatLng(double latitude, double longitude, long duration);
+  private native void nativeSetLatLng(double latitude, double longitude);
 
   private native LatLng nativeGetLatLng();
 
@@ -887,9 +851,9 @@ final class NativeMapView {
 
   private native double nativeGetPitch();
 
-  private native void nativeSetPitch(double pitch, long duration);
+  private native void nativeSetPitch(double pitch);
 
-  private native void nativeSetZoom(double zoom, double cx, double cy, long duration);
+  private native void nativeSetZoom(double zoom, double cx, double cy);
 
   private native double nativeGetZoom();
 
@@ -903,13 +867,13 @@ final class NativeMapView {
 
   private native double nativeGetMaxZoom();
 
-  private native void nativeRotateBy(double sx, double sy, double ex, double ey, long duration);
+  private native void nativeRotateBy(double sx, double sy, double ex, double ey);
 
   private native void nativeSetContentPadding(double top, double left, double bottom, double right);
 
-  private native void nativeSetBearing(double degrees, long duration);
+  private native void nativeSetBearing(double degrees);
 
-  private native void nativeSetBearingXY(double degrees, double fx, double fy, long duration);
+  private native void nativeSetBearingXY(double degrees, double fx, double fy);
 
   private native double nativeGetBearing();
 
@@ -931,8 +895,7 @@ final class NativeMapView {
 
   private native void nativeRemoveAnnotationIcon(String symbol);
 
-  private native void nativeSetVisibleCoordinateBounds(LatLng[] coordinates, RectF padding,
-                                                       double direction, long duration);
+  private native void nativeSetVisibleCoordinateBounds(LatLng[] coordinates, RectF padding, double direction);
 
   private native void nativeOnLowMemory();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -533,6 +533,17 @@ final class NativeMapView {
     return nativeLatLngForPixel(pixel.x / pixelRatio, pixel.y / pixelRatio).wrap();
   }
 
+  public LatLng latLngForPixel(PointF pixel, double startScale) {
+    if (isDestroyedOn("latLngForPixel")) {
+      return new LatLng();
+    }
+    return nativeLatLngForPixel2(pixel.x , pixel.y, startScale);
+  }
+
+  public PointF pixelForLatLng2(LatLng latLng){
+    return nativePixelForLatLng2(latLng.getLatitude(), latLng.getLongitude());
+  }
+
   public double getTopOffsetPixelsForAnnotationSymbol(String symbolName) {
     if (isDestroyedOn("getTopOffsetPixelsForAnnotationSymbol")) {
       return 0;
@@ -877,6 +888,8 @@ final class NativeMapView {
 
   private native double nativeGetBearing();
 
+  private native double nativeGetScale();
+
   private native void nativeResetNorth();
 
   private native void nativeUpdateMarker(long markerId, double lat, double lon, String iconId);
@@ -916,8 +929,11 @@ final class NativeMapView {
   private native LatLng nativeLatLngForProjectedMeters(double northing, double easting);
 
   private native PointF nativePixelForLatLng(double lat, double lon);
+  private native PointF nativePixelForLatLng2(double lat, double lon);
 
   private native LatLng nativeLatLngForPixel(float x, float y);
+
+  private native LatLng nativeLatLngForPixel2(float x, float y, double startScale);
 
   private native double nativeGetTopOffsetPixelsForAnnotationSymbol(String symbolName);
 
@@ -1055,5 +1071,9 @@ final class NativeMapView {
       }
 
     });
+  }
+
+  public double getScale() {
+    return nativeGetScale();
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Projection.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Projection.java
@@ -86,6 +86,11 @@ public class Projection {
     return nativeMapView.latLngForPixel(point);
   }
 
+  public LatLng fromScreenLocation(PointF point, double startScale) {
+    return nativeMapView.latLngForPixel(point, startScale);
+  }
+
+
   /**
    * Gets a projection of the viewing frustum for converting between screen coordinates and
    * geo-latitude/longitude coordinates.

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
@@ -151,7 +151,7 @@ final class Transform implements MapView.OnMapChangedListener {
     CameraPosition camera = update.getCameraPosition(mapboxMap);
     final LatLng latLng = camera.target;
     final double zoom = camera.zoom;
-    final double angle = Math.toRadians(camera.bearing - 180);
+    final double angle = Math.toRadians(-camera.bearing);
     final double pitch = Math.toRadians(camera.tilt);
 
     if (Double.isNaN(zoom)) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
@@ -2,12 +2,16 @@ package com.mapbox.mapboxsdk.maps;
 
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
+import android.animation.ObjectAnimator;
+import android.animation.TimeAnimator;
 import android.animation.TypeEvaluator;
 import android.animation.ValueAnimator;
+import android.annotation.SuppressLint;
 import android.graphics.PointF;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
+import android.view.animation.LinearInterpolator;
 
 import com.mapbox.mapboxsdk.annotations.MarkerViewManager;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
@@ -17,6 +21,7 @@ import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.widgets.MyLocationView;
 import com.mapbox.mapboxsdk.utils.AnimatorUtils;
+import com.mapbox.services.android.telemetry.utils.MathUtils;
 
 import timber.log.Timber;
 
@@ -129,21 +134,142 @@ final class Transform implements MapView.OnMapChangedListener {
   }
 
   @UiThread
-  final void animateCamera(MapboxMap mapboxMap, CameraUpdate update, int durationMs,
+  @SuppressLint("NewApi")
+  final void animateCamera(MapboxMap mapboxMap, CameraUpdate update, final int durationMs,
                            final MapboxMap.CancelableCallback callback) {
-    CameraPosition cameraPosition = update.getCameraPosition(mapboxMap);
-    if (isValidCameraPosition(cameraPosition)) {
-      trackingSettings.resetTrackingModesIfRequired(this.cameraPosition, cameraPosition, false);
-      cancelTransitions();
-      cameraChangeDispatcher.onCameraMoveStarted(OnCameraMoveStartedListener.REASON_API_ANIMATION);
 
-      if (callback != null) {
-        cameraCancelableCallback = callback;
-      }
-      mapView.addOnMapChangedListener(this);
-      mapView.flyTo(cameraPosition.bearing, cameraPosition.target, durationMs, cameraPosition.tilt,
-        cameraPosition.zoom);
+    // TODO
+    // correct rotation value
+    // correct fixed 512 value for pixel points
+    // integrate callback & MapboxMap#cancelTransitions
+    // integrate padding (aka edge insets)
+    // integrate unwrap for shortest path
+    // handle edge cases for NaN and infinite values
+    // reimplement ValueAnimator with an actual value
+    // handle not provided values of CameraPosition, -1 = not provided
+
+    CameraPosition camera = update.getCameraPosition(mapboxMap);
+    final LatLng latLng = camera.target;
+    final double zoom = camera.zoom;
+    final double angle = Math.toRadians(camera.bearing - 180);
+    final double pitch = Math.toRadians(camera.tilt);
+
+    if (Double.isNaN(zoom)) {
+      return;
     }
+
+    // Determine endpoints.
+    //EdgeInsets padding = camera.padding;
+    LatLng startLatLng = getLatLng();//getLatLng(padding).wrapped();
+    //startLatLng.unwrapForShortestPath(latLng);
+
+    final PointF startPoint = mapView.pixelForLatLng2(startLatLng);
+    startPoint.y = 512 - startPoint.y;
+    final PointF endPoint = mapView.pixelForLatLng2(latLng);
+    endPoint.y = 512 - endPoint.y;
+
+    final double startZoom = mapView.getZoom();
+    final double startTilt = Math.toRadians(mapView.getPitch());
+    final double startBearing = Math.toRadians(getBearing());
+
+    // Minimize rotation by taking the shorter path around the circle.
+    final double angleNormal = normalizeAngle(angle, startBearing);
+
+    final double w0 = 512;
+    final double w1 = 256;
+    final double u1 = Math.hypot(endPoint.x - startPoint.x, endPoint.y - startPoint.y);
+    final double rho = 1.42;
+    final double rho2 = rho * rho;
+
+    final double r0 = calculateZoomFactor(0, w1, w0, rho2, u1);
+    final double r1 = calculateZoomFactor(1, w1, w0, rho2, u1);
+
+    final boolean isClose = false;
+
+    final double S = (isClose ? (Math.abs(Math.log(w1 / w0)) / rho) : ((r1 - r0) / rho));
+
+    final double startScale = Math.abs(mapView.getScale());
+
+    ValueAnimator valueAnimator = ValueAnimator.ofObject(new TypeEvaluator() {
+      @Override
+      public Object evaluate(float k, Object startValue, Object endValue) {
+        double s = k * S;
+        float us = k == 1.0 ? 1.0f : (float) u(s, isClose, w0, r0, rho, rho2, u1);
+
+        float framePointX = interpolate(startPoint.x, endPoint.x, us);
+        float framePointY = interpolate(startPoint.y, endPoint.y, us);
+        PointF framePoint = new PointF(framePointX, framePointY);
+        double frameZoom = startZoom + scaleZoom(1 / w(s, isClose, w1, w0, rho, r0));
+        double frameTilt = interpolate(startTilt, pitch, us);
+        double frameBearing = interpolate(startBearing, angleNormal, us);
+
+        // Zoom can be NaN if size is empty.
+        if (Double.isNaN(frameZoom)) {
+          frameZoom = zoom;
+        }
+
+        LatLng frameLatLng = mapView.latLngForPixel(framePoint, startScale);
+        mapView.setLatLng(frameLatLng);
+        mapView.setZoom(frameZoom, new PointF(mapView.getWidth() / 2, mapView.getHeight() / 2));
+        mapView.setBearing(Math.toDegrees(frameBearing));
+        mapView.setPitch(Math.toDegrees(frameTilt));
+        return new Object();
+      }
+    }, new Object(), new Object());
+    valueAnimator.setDuration(durationMs);
+    valueAnimator.start();
+  }
+
+  public static double normalizeAngle(double angle, double anchorAngle) {
+    if (Double.isNaN(angle) || Double.isNaN(anchorAngle)) {
+      return 0;
+    }
+
+    angle = MathUtils.wrap(angle, -Math.PI, Math.PI);
+    if (angle == -Math.PI) {
+      angle = Math.PI;
+    }
+    double diff = Math.abs(angle - anchorAngle);
+    if (Math.abs(angle - Math.PI * 2 - anchorAngle) < diff) {
+      angle -= Math.PI * 2;
+    }
+    if (Math.abs(angle + Math.PI * 2 - anchorAngle) < diff) {
+      angle += Math.PI * 2;
+    }
+
+    return angle;
+  }
+
+  private double scaleZoom(double scale) {
+    return log(scale, 2);
+  }
+
+  static double log(double x, int base) {
+    return (Math.log(x) / Math.log(base));
+  }
+
+  private float interpolate(float a, float b, float t) {
+    return a * (1.0f - t) + b * t;
+  }
+
+  private double interpolate(double a, double b, double t) {
+    return a * (1.0 - t) + b * t;
+  }
+
+
+  private double calculateZoomFactor(double i, double w1, double w0, double rho2, double u1) {
+    double b = (w1 * w1 - w0 * w0 + (i == 1 ? -1 : 1) * rho2 * rho2 * u1 * u1) / (2 * (i == 1 ? w1 : w0) * rho2 * u1);
+    return Math.log(Math.sqrt(b * b + 1) - b);
+  }
+
+  private double w(double s, boolean isClose, double w1, double w0, double rho, double r0) {
+    return (isClose ? Math.exp((w1 < w0 ? -1 : 1) * rho * s)
+      : (Math.cosh(r0) / Math.cosh(r0 + rho * s)));
+  }
+
+  private double u(double s, boolean isClose, double w0, double r0, double rho, double rho2, double u1) {
+    return (isClose ? 0.
+      : (w0 * (Math.cosh(r0) * Math.tanh(r0 + rho * s) - Math.sinh(r0)) / rho2 / u1));
   }
 
   private boolean isValidCameraPosition(@Nullable CameraPosition cameraPosition) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/AnimatorUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/AnimatorUtils.java
@@ -4,11 +4,16 @@ import android.animation.Animator;
 import android.animation.AnimatorInflater;
 import android.animation.AnimatorListenerAdapter;
 import android.animation.ObjectAnimator;
+import android.animation.PointFEvaluator;
+import android.animation.TypeEvaluator;
+import android.graphics.PointF;
 import android.support.annotation.AnimatorRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.view.animation.FastOutSlowInInterpolator;
 import android.view.View;
+
+import com.mapbox.mapboxsdk.geometry.LatLng;
 
 /**
  * Animator utility class.
@@ -165,4 +170,31 @@ public class AnimatorUtils {
   public interface OnAnimationEndListener {
     void onAnimationEnd();
   }
+
+  public static class PointFEvaluator implements TypeEvaluator<PointF> {
+
+    private final PointF pointF = new PointF();
+
+    @Override
+    public PointF evaluate(float fraction, PointF startValue, PointF endValue) {
+      pointF.x = startValue.x + ((endValue.x - startValue.x) * fraction);
+      pointF.y = startValue.y + ((endValue.y - startValue.y) * fraction);
+      return pointF;
+    }
+  }
+
+  public static class LatLngEvaluator implements TypeEvaluator<LatLng> {
+
+    private final LatLng latLng = new LatLng();
+
+    @Override
+    public LatLng evaluate(float fraction, LatLng startValue, LatLng endValue) {
+      latLng.setLatitude(startValue.getLatitude()
+        + ((endValue.getLatitude() - startValue.getLatitude()) * fraction));
+      latLng.setLongitude(startValue.getLongitude()
+        + ((endValue.getLongitude() - startValue.getLongitude()) * fraction));
+      return latLng;
+    }
+  }
 }
+

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/AnimatorUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/AnimatorUtils.java
@@ -3,6 +3,7 @@ package com.mapbox.mapboxsdk.utils;
 import android.animation.Animator;
 import android.animation.AnimatorInflater;
 import android.animation.AnimatorListenerAdapter;
+import android.animation.FloatEvaluator;
 import android.animation.ObjectAnimator;
 import android.animation.PointFEvaluator;
 import android.animation.TypeEvaluator;
@@ -13,6 +14,7 @@ import android.support.annotation.Nullable;
 import android.support.v4.view.animation.FastOutSlowInInterpolator;
 import android.view.View;
 
+import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
 /**
@@ -196,5 +198,21 @@ public class AnimatorUtils {
       return latLng;
     }
   }
+
+  public static class CameraPositionEvaluator implements TypeEvaluator<CameraPosition> {
+
+    private final LatLngEvaluator latLngEvaluator = new LatLngEvaluator();
+    private final FloatEvaluator floatEvaluator = new FloatEvaluator();
+
+    @Override
+    public CameraPosition evaluate(float fraction, CameraPosition startValue, CameraPosition endValue) {
+      LatLng latLng = latLngEvaluator.evaluate(fraction, startValue.target, endValue.target);
+      double zoom = floatEvaluator.evaluate(fraction, startValue.zoom, endValue.zoom);
+      double bearing = floatEvaluator.evaluate(fraction, startValue.bearing, endValue.bearing);
+      double tilt = floatEvaluator.evaluate(fraction, startValue.tilt, endValue.tilt);
+      return new CameraPosition.Builder().target(latLng).zoom(zoom).bearing(bearing).tilt(tilt).build();
+    }
+  }
+
 }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/AnimatedMarkerActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/AnimatedMarkerActivity.java
@@ -27,6 +27,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.testapp.R;
 import com.mapbox.mapboxsdk.testapp.utils.IconUtils;
+import com.mapbox.mapboxsdk.utils.AnimatorUtils;
 import com.mapbox.services.api.utils.turf.TurfMeasurement;
 import com.mapbox.services.commons.models.Position;
 
@@ -175,7 +176,7 @@ public class AnimatedMarkerActivity extends AppCompatActivity {
     marker.setRotation((float) getBearing(marker.getPosition(), to));
 
     final ValueAnimator markerAnimator = ObjectAnimator.ofObject(
-      marker, "position", new LatLngEvaluator(), marker.getPosition(), to);
+      marker, "position", new AnimatorUtils.LatLngEvaluator(), marker.getPosition(), to);
     markerAnimator.setDuration((long) (10 * marker.getPosition().distanceTo(to)));
     markerAnimator.setInterpolator(new AccelerateDecelerateInterpolator());
 
@@ -266,23 +267,6 @@ public class AnimatedMarkerActivity extends AppCompatActivity {
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
-  }
-
-  /**
-   * Evaluator for LatLng pairs
-   */
-  private static class LatLngEvaluator implements TypeEvaluator<LatLng> {
-
-    private LatLng latLng = new LatLng();
-
-    @Override
-    public LatLng evaluate(float fraction, LatLng startValue, LatLng endValue) {
-      latLng.setLatitude(startValue.getLatitude()
-        + ((endValue.getLatitude() - startValue.getLatitude()) * fraction));
-      latLng.setLongitude(startValue.getLongitude()
-        + ((endValue.getLongitude() - startValue.getLongitude()) * fraction));
-      return latLng;
-    }
   }
 
   private double getBearing(LatLng from, LatLng to) {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraAnimatorActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraAnimatorActivity.java
@@ -24,6 +24,7 @@ import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.utils.AnimatorUtils;
 
 /**
  * Test activity showcasing using Android SDK animators to animate camera position changes.
@@ -129,7 +130,7 @@ public class CameraAnimatorActivity extends AppCompatActivity implements OnMapRe
   }
 
   private Animator createLatLngAnimator(LatLng currentPosition, LatLng targetPosition) {
-    ValueAnimator latLngAnimator = ValueAnimator.ofObject(new LatLngEvaluator(), currentPosition, targetPosition);
+    ValueAnimator latLngAnimator = ValueAnimator.ofObject(new AnimatorUtils.LatLngEvaluator(), currentPosition, targetPosition);
     latLngAnimator.setDuration((long) (1000 * ANIMATION_DELAY_FACTOR));
     latLngAnimator.setInterpolator(new FastOutSlowInInterpolator());
     latLngAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
@@ -282,23 +283,6 @@ public class CameraAnimatorActivity extends AppCompatActivity implements OnMapRe
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
-  }
-
-  /**
-   * Helper class to evaluate LatLng objects with a ValueAnimator
-   */
-  private static class LatLngEvaluator implements TypeEvaluator<LatLng> {
-
-    private final LatLng latLng = new LatLng();
-
-    @Override
-    public LatLng evaluate(float fraction, LatLng startValue, LatLng endValue) {
-      latLng.setLatitude(startValue.getLatitude()
-        + ((endValue.getLatitude() - startValue.getLatitude()) * fraction));
-      latLng.setLongitude(startValue.getLongitude()
-        + ((endValue.getLongitude() - startValue.getLongitude()) * fraction));
-      return latLng;
-    }
   }
 
   interface AnimatorBuilder {

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -356,6 +356,10 @@ jni::jdouble NativeMapView::getBearing(jni::JNIEnv&) {
     return map->getBearing();
 }
 
+jni::jdouble NativeMapView::getScale(jni::JNIEnv&) {
+    return map->getBearing();
+}
+
 void NativeMapView::resetNorth(jni::JNIEnv&) {
     map->resetNorth();
 }
@@ -478,8 +482,17 @@ jni::Object<PointF> NativeMapView::pixelForLatLng(JNIEnv& env, jdouble latitude,
     return PointF::New(env, static_cast<float>(pixel.x), static_cast<float>(pixel.y));
 }
 
+jni::Object<PointF> NativeMapView::pixelForLatLng2(JNIEnv& env, jdouble latitude, jdouble longitude) {
+    mbgl::ScreenCoordinate pixel = map->pixelForLatLng2(mbgl::LatLng(latitude, longitude));
+    return PointF::New(env, static_cast<float>(pixel.x), static_cast<float>(pixel.y));
+}
+
 jni::Object<LatLng> NativeMapView::latLngForPixel(JNIEnv& env, jfloat x, jfloat y) {
     return LatLng::New(env, map->latLngForPixel(mbgl::ScreenCoordinate(x, y)));
+}
+
+jni::Object<LatLng> NativeMapView::latLngForPixel2(JNIEnv& env, jfloat x, jfloat y, jdouble startScale) {
+    return LatLng::New(env, Projection::unproject(mbgl::ScreenCoordinate(x, y), startScale));
 }
 
 jni::Array<jlong> NativeMapView::addPolylines(JNIEnv& env, jni::Array<jni::Object<Polyline>> polylines) {
@@ -958,6 +971,7 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
             METHOD(&NativeMapView::setBearing, "nativeSetBearing"),
             METHOD(&NativeMapView::setBearingXY, "nativeSetBearingXY"),
             METHOD(&NativeMapView::getBearing, "nativeGetBearing"),
+            METHOD(&NativeMapView::getScale, "nativeGetScale"),
             METHOD(&NativeMapView::resetNorth, "nativeResetNorth"),
             METHOD(&NativeMapView::setVisibleCoordinateBounds, "nativeSetVisibleCoordinateBounds"),
             METHOD(&NativeMapView::setContentPadding, "nativeSetContentPadding"),
@@ -973,8 +987,10 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
             METHOD(&NativeMapView::getMetersPerPixelAtLatitude, "nativeGetMetersPerPixelAtLatitude"),
             METHOD(&NativeMapView::projectedMetersForLatLng, "nativeProjectedMetersForLatLng"),
             METHOD(&NativeMapView::pixelForLatLng, "nativePixelForLatLng"),
+            METHOD(&NativeMapView::pixelForLatLng2, "nativePixelForLatLng2"),
             METHOD(&NativeMapView::latLngForProjectedMeters, "nativeLatLngForProjectedMeters"),
             METHOD(&NativeMapView::latLngForPixel, "nativeLatLngForPixel"),
+            METHOD(&NativeMapView::latLngForPixel2, "nativeLatLngForPixel2"),
             METHOD(&NativeMapView::addPolylines, "nativeAddPolylines"),
             METHOD(&NativeMapView::addPolygons, "nativeAddPolygons"),
             METHOD(&NativeMapView::updatePolyline, "nativeUpdatePolyline"),

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -210,13 +210,8 @@ void NativeMapView::setGestureInProgress(jni::JNIEnv&, jni::jboolean inProgress)
     map->setGestureInProgress(inProgress);
 }
 
-void NativeMapView::moveBy(jni::JNIEnv&, jni::jdouble dx, jni::jdouble dy, jni::jlong duration) {
-    mbgl::AnimationOptions animationOptions;
-    if (duration > 0) {
-       animationOptions.duration.emplace(mbgl::Milliseconds(duration));
-       animationOptions.easing.emplace(mbgl::util::UnitBezier {0.25, 0.46, 0.45, 0.94});
-    }
-    map->moveBy({dx, dy}, animationOptions);
+void NativeMapView::moveBy(jni::JNIEnv&, jni::jdouble dx, jni::jdouble dy) {
+    map->moveBy({dx, dy}, mbgl::AnimationOptions{});
 }
 
 void NativeMapView::jumpTo(jni::JNIEnv&, jni::jdouble angle, jni::jdouble latitude, jni::jdouble longitude, jni::jdouble pitch, jni::jdouble zoom) {
@@ -283,8 +278,8 @@ jni::Object<LatLng> NativeMapView::getLatLng(JNIEnv& env) {
     return LatLng::New(env, map->getLatLng(insets));
 }
 
-void NativeMapView::setLatLng(jni::JNIEnv&, jni::jdouble latitude, jni::jdouble longitude, jni::jlong duration) {
-    map->setLatLng(mbgl::LatLng(latitude, longitude), insets, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
+void NativeMapView::setLatLng(jni::JNIEnv&, jni::jdouble latitude, jni::jdouble longitude) {
+    map->setLatLng(mbgl::LatLng(latitude, longitude), insets, mbgl::AnimationOptions{});
 }
 
 jni::Object<CameraPosition> NativeMapView::getCameraForLatLngBounds(jni::JNIEnv& env, jni::Object<LatLngBounds> jBounds) {
@@ -310,12 +305,12 @@ jni::jdouble NativeMapView::getPitch(jni::JNIEnv&) {
     return map->getPitch();
 }
 
-void NativeMapView::setPitch(jni::JNIEnv&, jni::jdouble pitch, jni::jlong duration) {
-    map->setPitch(pitch, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
+void NativeMapView::setPitch(jni::JNIEnv&, jni::jdouble pitch) {
+    map->setPitch(pitch, mbgl::AnimationOptions{});
 }
 
-void NativeMapView::setZoom(jni::JNIEnv&, jni::jdouble zoom, jni::jdouble x, jni::jdouble y, jni::jlong duration) {
-    map->setZoom(zoom, mbgl::ScreenCoordinate{x,y}, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
+void NativeMapView::setZoom(jni::JNIEnv&, jni::jdouble zoom, jni::jdouble x, jni::jdouble y) {
+    map->setZoom(zoom, mbgl::ScreenCoordinate{x,y}, mbgl::AnimationOptions{});
 }
 
 jni::jdouble NativeMapView::getZoom(jni::JNIEnv&) {
@@ -342,19 +337,19 @@ jni::jdouble NativeMapView::getMaxZoom(jni::JNIEnv&) {
     return map->getMaxZoom();
 }
 
-void NativeMapView::rotateBy(jni::JNIEnv&, jni::jdouble sx, jni::jdouble sy, jni::jdouble ex, jni::jdouble ey, jni::jlong duration) {
+void NativeMapView::rotateBy(jni::JNIEnv&, jni::jdouble sx, jni::jdouble sy, jni::jdouble ex, jni::jdouble ey) {
     mbgl::ScreenCoordinate first(sx, sy);
     mbgl::ScreenCoordinate second(ex, ey);
-    map->rotateBy(first, second, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
+    map->rotateBy(first, second, mbgl::AnimationOptions{});
 }
 
-void NativeMapView::setBearing(jni::JNIEnv&, jni::jdouble degrees, jni::jlong duration) {
-    map->setBearing(degrees, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
+void NativeMapView::setBearing(jni::JNIEnv&, jni::jdouble degrees) {
+    map->setBearing(degrees, mbgl::AnimationOptions{});
 }
 
-void NativeMapView::setBearingXY(jni::JNIEnv&, jni::jdouble degrees, jni::jdouble cx, jni::jdouble cy, jni::jlong duration) {
+void NativeMapView::setBearingXY(jni::JNIEnv&, jni::jdouble degrees, jni::jdouble cx, jni::jdouble cy) {
     mbgl::ScreenCoordinate center(cx, cy);
-    map->setBearing(degrees, center, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
+    map->setBearing(degrees, center, mbgl::AnimationOptions{});
 }
 
 jni::jdouble NativeMapView::getBearing(jni::JNIEnv&) {
@@ -365,7 +360,7 @@ void NativeMapView::resetNorth(jni::JNIEnv&) {
     map->resetNorth();
 }
 
-void NativeMapView::setVisibleCoordinateBounds(JNIEnv& env, jni::Array<jni::Object<LatLng>> coordinates, jni::Object<RectF> padding, jdouble direction, jni::jlong duration) {
+void NativeMapView::setVisibleCoordinateBounds(JNIEnv& env, jni::Array<jni::Object<LatLng>> coordinates, jni::Object<RectF> padding, jdouble direction) {
     NullCheck(env, &coordinates);
     std::size_t count = coordinates.Length(env);
 
@@ -385,14 +380,7 @@ void NativeMapView::setVisibleCoordinateBounds(JNIEnv& env, jni::Array<jni::Obje
         cameraOptions.angle = (-direction * M_PI) / 180;
     }
 
-    mbgl::AnimationOptions animationOptions;
-    if (duration > 0) {
-        animationOptions.duration.emplace(mbgl::Milliseconds(duration));
-        // equivalent to kCAMediaTimingFunctionDefault in iOS
-        animationOptions.easing.emplace(mbgl::util::UnitBezier { 0.25, 0.1, 0.25, 0.1 });
-    }
-
-    map->easeTo(cameraOptions, animationOptions);
+    map->easeTo(cameraOptions, mbgl::AnimationOptions{});
 }
 
 void NativeMapView::setContentPadding(JNIEnv&, double top, double left, double bottom, double right) {

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -136,6 +136,7 @@ public:
     void setBearingXY(jni::JNIEnv&, jni::jdouble, jni::jdouble, jni::jdouble);
 
     jni::jdouble getBearing(jni::JNIEnv&);
+    jni::jdouble getScale(jni::JNIEnv&);
 
     void resetNorth(jni::JNIEnv&);
 
@@ -166,10 +167,13 @@ public:
     jni::Object<ProjectedMeters> projectedMetersForLatLng(JNIEnv&, jni::jdouble, jni::jdouble);
 
     jni::Object<PointF> pixelForLatLng(JNIEnv&, jdouble, jdouble);
+    jni::Object<PointF> pixelForLatLng2(JNIEnv&, jdouble, jdouble);
 
     jni::Object<LatLng> latLngForProjectedMeters(JNIEnv&, jdouble, jdouble);
 
     jni::Object<LatLng> latLngForPixel(JNIEnv&, jfloat, jfloat);
+
+    jni::Object<LatLng> latLngForPixel2(JNIEnv&, jfloat, jfloat, jdouble);
 
     jni::Array<jlong> addPolylines(JNIEnv&, jni::Array<jni::Object<Polyline>>);
 

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -91,7 +91,7 @@ public:
 
     void setGestureInProgress(jni::JNIEnv&, jni::jboolean);
 
-    void moveBy(jni::JNIEnv&, jni::jdouble, jni::jdouble, jni::jlong);
+    void moveBy(jni::JNIEnv&, jni::jdouble, jni::jdouble);
 
     void jumpTo(jni::JNIEnv&, jni::jdouble, jni::jdouble, jni::jdouble, jni::jdouble, jni::jdouble);
 
@@ -101,7 +101,7 @@ public:
 
     jni::Object<LatLng> getLatLng(JNIEnv&);
 
-    void setLatLng(jni::JNIEnv&, jni::jdouble, jni::jdouble, jni::jlong);
+    void setLatLng(jni::JNIEnv&, jni::jdouble, jni::jdouble);
 
     jni::Object<CameraPosition> getCameraForLatLngBounds(jni::JNIEnv&, jni::Object<mbgl::android::LatLngBounds>);
 
@@ -113,9 +113,9 @@ public:
 
     jni::jdouble getPitch(jni::JNIEnv&);
 
-    void setPitch(jni::JNIEnv&, jni::jdouble, jni::jlong);
+    void setPitch(jni::JNIEnv&, jni::jdouble);
 
-    void setZoom(jni::JNIEnv&, jni::jdouble, jni::jdouble, jni::jdouble, jni::jlong);
+    void setZoom(jni::JNIEnv&, jni::jdouble, jni::jdouble, jni::jdouble);
 
     jni::jdouble getZoom(jni::JNIEnv&);
 
@@ -129,17 +129,17 @@ public:
 
     jni::jdouble getMaxZoom(jni::JNIEnv&);
 
-    void rotateBy(jni::JNIEnv&, jni::jdouble, jni::jdouble, jni::jdouble, jni::jdouble, jni::jlong);
+    void rotateBy(jni::JNIEnv&, jni::jdouble, jni::jdouble, jni::jdouble, jni::jdouble);
 
-    void setBearing(jni::JNIEnv&, jni::jdouble, jni::jlong);
+    void setBearing(jni::JNIEnv&, jni::jdouble);
 
-    void setBearingXY(jni::JNIEnv&, jni::jdouble, jni::jdouble, jni::jdouble, jni::jlong);
+    void setBearingXY(jni::JNIEnv&, jni::jdouble, jni::jdouble, jni::jdouble);
 
     jni::jdouble getBearing(jni::JNIEnv&);
 
     void resetNorth(jni::JNIEnv&);
 
-    void setVisibleCoordinateBounds(JNIEnv&, jni::Array<jni::Object<LatLng>>, jni::Object<RectF>, jni::jdouble, jni::jlong);
+    void setVisibleCoordinateBounds(JNIEnv&, jni::Array<jni::Object<LatLng>>, jni::Object<RectF>, jni::jdouble);
 
     void setContentPadding(JNIEnv&, double, double, double, double);
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -558,7 +558,7 @@ void Map::setBearing(double degrees, const EdgeInsets& padding, const AnimationO
 }
 
 double Map::getBearing() const {
-    return -impl->transform.getAngle() * util::RAD2DEG;
+    return -impl->transform.getScale();
 }
 
 void Map::resetNorth(const AnimationOptions& animation) {
@@ -626,6 +626,15 @@ ScreenCoordinate Map::pixelForLatLng(const LatLng& latLng) const {
     LatLng unwrappedLatLng = latLng.wrapped();
     unwrappedLatLng.unwrapForShortestPath(getLatLng());
     return impl->transform.latLngToScreenCoordinate(unwrappedLatLng);
+}
+
+ScreenCoordinate Map::pixelForLatLng2(const LatLng& latLng) const {
+    // If the center and point longitudes are not in the same side of the
+    // antimeridian, we unwrap the point longitude so it would be seen if
+    // e.g. the next antimeridian side is visible.
+    LatLng unwrappedLatLng = latLng.wrapped();
+    unwrappedLatLng.unwrapForShortestPath(getLatLng());
+    return impl->transform.latLngToScreenCoordinate2(unwrappedLatLng);
 }
 
 LatLng Map::latLngForPixel(const ScreenCoordinate& pixel) const {

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -495,6 +495,10 @@ double Transform::getPitch() const {
     return state.pitch;
 }
 
+double Transform::getScale() const {
+    return state.scale;
+}
+
 #pragma mark - North Orientation
 
 void Transform::setNorthOrientation(NorthOrientation orientation) {
@@ -620,6 +624,12 @@ void Transform::setGestureInProgress(bool inProgress) {
 
 ScreenCoordinate Transform::latLngToScreenCoordinate(const LatLng& latLng) const {
     ScreenCoordinate point = state.latLngToScreenCoordinate(latLng);
+    point.y = state.size.height - point.y;
+    return point;
+}
+
+ScreenCoordinate Transform::latLngToScreenCoordinate2(const LatLng& latLng) const {\
+    ScreenCoordinate point = Projection::project(latLng,state.scale);
     point.y = state.size.height - point.y;
     return point;
 }

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -113,6 +113,8 @@ public:
     void setPitch(double pitch, optional<ScreenCoordinate> anchor, const AnimationOptions& = {});
     double getPitch() const;
 
+    double getScale() const;
+
     // North Orientation
     void setNorthOrientation(NorthOrientation);
     NorthOrientation getNorthOrientation() const;
@@ -144,6 +146,7 @@ public:
 
     // Conversion and projection
     ScreenCoordinate latLngToScreenCoordinate(const LatLng&) const;
+    ScreenCoordinate latLngToScreenCoordinate2(const LatLng&) const;
     LatLng screenCoordinateToLatLng(const ScreenCoordinate&) const;
 
 private:


### PR DESCRIPTION
WIP, this PR removes duration from the Android binding for animations. 
Internal animations are replaced with Android SDK animators.

Todo:
 - [ ]  add a setCameraPosition on MapboxMap
 - [ ] port CameraUpdateFactory animation flyTo:
   - [ ]  correct rotation value
   - [ ] correct fixed 512 value for pixel points
   - [ ] integrate callback & MapboxMap#cancelTransitions
   - [ ]  integrate padding (aka edge insets)
   - [ ]  integrate unwrap for shortest path
   - [ ] handle edge cases for NaN and infinite values
   - [ ] reimplement ValueAnimator with an actual value
   - [ ] handle not provided values of CameraPosition, -1 = not provided
 - [ ] port CameraUpdateFacttory animation easeTo
 - [ ] fix rotation gesture issue

Related to #8175 