### PR TITLE
 [ios] Fix iOS 8 incompatibility in scale bar RTL check

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -39,6 +39,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed an issue that could cause a crash when using `-[MGLMapView flyToCamera:completionHandler:]` and related methods with zoom levels at or near the maximum value. ([#9381](https://github.com/mapbox/mapbox-gl-native/pull/9381))
 * Added `-[MGLMapView showAttribution:]` to allow custom attribution buttons to show the default attribution interface. ([#10085](https://github.com/mapbox/mapbox-gl-native/pull/10085))
 * Fixed a conflict between multiple copies of SMCalloutView in a project. ([#10183](https://github.com/mapbox/mapbox-gl-native/pull/10183))
+* Fixed a crash when enabling the scale bar in iOS 8. ([#10241](https://github.com/mapbox/mapbox-gl-native/pull/10241))
 
 ## 3.6.4 - September 25, 2017
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -165,7 +165,9 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
     self.mapView.scaleBar.hidden = NO;
     self.mapView.showsUserHeadingIndicator = YES;
     self.hudLabel.hidden = YES;
-    self.hudLabel.titleLabel.font = [UIFont monospacedDigitSystemFontOfSize:10 weight:UIFontWeightRegular];
+    if ([UIFont respondsToSelector:@selector(monospacedDigitSystemFontOfSize:weight:)]) {
+        self.hudLabel.titleLabel.font = [UIFont monospacedDigitSystemFontOfSize:10 weight:UIFontWeightRegular];
+    }
 
     if ([MGLAccountManager accessToken].length)
     {

--- a/platform/ios/src/MGLScaleBar.mm
+++ b/platform/ios/src/MGLScaleBar.mm
@@ -175,10 +175,15 @@ static const CGFloat MGLFeetPerMeter = 3.28084;
     return [self usesMetricSystem] ? self.metersPerPoint : self.metersPerPoint * MGLFeetPerMeter;
 }
 
-#pragma mark - Convenient methods
+#pragma mark - Convenience methods
 
 - (BOOL)usesRightToLeftLayout {
-    return [UIView userInterfaceLayoutDirectionForSemanticContentAttribute:self.superview.semanticContentAttribute] == UIUserInterfaceLayoutDirectionRightToLeft;
+    // semanticContentAttribute is iOS 9+
+    if ([self.superview respondsToSelector:@selector(semanticContentAttribute)]) {
+        return [UIView userInterfaceLayoutDirectionForSemanticContentAttribute:self.superview.semanticContentAttribute] == UIUserInterfaceLayoutDirectionRightToLeft;
+    } else {
+        return UIApplication.sharedApplication.userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft;
+    }
 }
 
 - (BOOL)usesMetricSystem {
@@ -244,7 +249,7 @@ static const CGFloat MGLFeetPerMeter = 3.28084;
     
     CGFloat alpha = maximumDistance > allowedDistance ? .0f : 1.0f;
     
-    if(self.alpha != alpha) {
+    if (self.alpha != alpha) {
         [UIView animateWithDuration:.2f delay:0 options:UIViewAnimationOptionBeginFromCurrentState animations:^{
             self.alpha = alpha;
         } completion:nil];


### PR DESCRIPTION
Fixes #10225 by checking to see if [`UIView.semanticContentAttribute`](https://developer.apple.com/documentation/uikit/uiview/1622461-semanticcontentattribute) is available before using it in `-[MGLScaleBar usesRightToLeftLayout]`. This now falls back to [`UIApplication.userInterfaceLayoutDirection`](https://developer.apple.com/documentation/uikit/uiapplication/1623025-userinterfacelayoutdirection) in iOS 8.

Also fixes an issue in iosapp where `-[UIFont monospacedDigitSystemFontOfSize:weight:]` wasn’t available in iOS 8.

![simulator screen shot - iphone 6 - 2017-10-19 at 11 39 30](https://user-images.githubusercontent.com/1198851/31780851-eaeb243e-b4c4-11e7-8a20-3bb7c6d7acbc.png)

/cc @frederoni @fabian-guerra