### PR TITLE
Backport: limit annotation tile source to z16

### DIFF
--- a/src/mbgl/annotation/render_annotation_source.cpp
+++ b/src/mbgl/annotation/render_annotation_source.cpp
@@ -38,7 +38,9 @@ void RenderAnnotationSource::update(Immutable<style::Source::Impl> baseImpl_,
                        parameters,
                        SourceType::Annotations,
                        util::tileSize,
-                       { 0, util::DEFAULT_MAX_ZOOM },
+                       // Zoom level 16 is typically sufficient for annotations.
+                       // See https://github.com/mapbox/mapbox-gl-native/issues/10197
+                       { 0, 16 },
                        [&] (const OverscaledTileID& tileID) {
                            return std::make_unique<AnnotationTile>(tileID, parameters);
                        });


### PR DESCRIPTION
Backport https://github.com/mapbox/mapbox-gl-native/pull/10197 to Agua.