### PR TITLE
[node] Release v3.5.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-native",
-  "version": "3.5.7",
+  "version": "3.5.8",
   "description": "Renders map tiles with Mapbox GL",
   "keywords": [
     "mapbox",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.5.8 - October 19, 2017
+- Fixes an issue that causes memory leaks when not deleting the frontend object
+  in NodeMap::release()
+- Fixes a crash in Earcut: [#10245](https://github.com/mapbox/mapbox-gl-native/pull/10245)
+
 # 3.5.7 - October 9, 2017
 - Fixed an issue causing synchronous resource requests to stall [#10153](https://github.com/mapbox/mapbox-gl-native/pull/10153)
 

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -508,6 +508,7 @@ void NodeMap::release() {
     });
     
     map.reset();
+    frontend.reset();
 }
 
 /**


### PR DESCRIPTION
Ref: https://github.com/mapbox/mapbox-gl-native/issues/10243

- Fixes an issue that causes memory leaks when not deleting the frontend object in `NodeMap::release()`
- Fixes a crash in Earcut: `mapbox/earcut.hpp#54`