### PR TITLE
Blacklist VAO usage on adreno 3xx

### DIFF
--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -248,7 +248,14 @@ UniqueTexture Context::createTexture() {
 }
 
 bool Context::supportsVertexArrays() const {
-    return vertexArray &&
+    static bool blacklisted = []() {
+        // Blacklist Adreno 3xx as it crashes on glBuffer(Sub)Data
+        const std::string renderer = reinterpret_cast<const char*>(glGetString(GL_RENDERER));
+        return renderer.find("Adreno (TM) 3") != std::string::npos;
+    }();
+
+    return !blacklisted &&
+           vertexArray &&
            vertexArray->genVertexArrays &&
            vertexArray->bindVertexArray &&
            vertexArray->deleteVertexArrays;


### PR DESCRIPTION
Changes in the way we use vertex buffers introduced in #9009 causes crashes on usage of glBuffer(Sub)Data. This affects line placed text.

Relevant issues:
- Fixes #10152
- Fixes #10151
- Fixes #10150
- Fixes #9935

closes #10233