### PR TITLE
[ios, macos, build] Add CircleCI iOS & macOS builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,14 @@ iproj: $(IOS_PROJ_PATH)
 ios-test: $(IOS_PROJ_PATH)
 	set -o pipefail && $(IOS_XCODEBUILD_SIM) -scheme 'CI' test $(XCPRETTY)
 
+.PHONY: ios-sanitize-address
+ios-sanitize-address: $(IOS_PROJ_PATH)
+	set -o pipefail && $(IOS_XCODEBUILD_SIM) -scheme 'CI' -enableAddressSanitizer YES test $(XCPRETTY)
+
+.PHONY: ios-sanitize-thread
+ios-sanitize-thread: $(IOS_PROJ_PATH)
+	set -o pipefail && $(IOS_XCODEBUILD_SIM) -scheme 'CI' -enableThreadSanitizer YES test $(XCPRETTY)
+
 .PHONY: ipackage
 ipackage: $(IOS_PROJ_PATH)
 	FORMAT=$(FORMAT) BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=$(SYMBOLS) \

--- a/circle.yml
+++ b/circle.yml
@@ -30,6 +30,9 @@ workflows:
       - linux-gcc5-debug-coverage
       - linux-gcc5-release-qt4
       - linux-gcc5-release-qt5
+      - ios-debug
+      #- ios-sanitize-address
+      - ios-sanitize-thread
 
 step-library:
   - &generate-cache-key
@@ -47,7 +50,7 @@ step-library:
   - &save-cache
       save_cache:
         key: 'v3/{{ .Environment.CIRCLE_JOB }}/{{ arch }}/{{ .Branch }}/{{ checksum ".circle-week" }}'
-        paths: [ "node_modules", "/root/.ccache", "mason_packages/.binaries" ]
+        paths: [ "node_modules", "/root/.ccache", "~/.ccache", "mason_packages/.binaries" ]
 
 
   - &reset-ccache-stats
@@ -97,6 +100,24 @@ step-library:
       run:
         name: Build qt-test
         command: make qt-test
+  - &build-ios-test
+      run:
+        name: Build ios-test
+        command: make ios-test
+
+
+  - &check-public-symbols
+      run:
+        name: Check public symbols
+        command: make check-public-symbols
+
+
+  - &install-ios-dependencies
+      run:
+        name: Install dependencies
+        command: |
+          brew install cmake
+          brew install ccache
 
 
   - &run-node-tests
@@ -589,3 +610,59 @@ jobs:
           command: |
             xvfb-run --server-args="-screen 0 1024x768x24" \
               scripts/valgrind.sh build/qt-linux-x86_64/Release/mbgl-test --gtest_filter=-*.Load --gtest_filter=-Memory.Vector
+
+# ------------------------------------------------------------------------------
+  ios-debug:
+    macos:
+      xcode: "9.0"
+    environment:
+      BUILDTYPE: Debug
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - checkout
+      - *install-ios-dependencies
+      - *generate-cache-key
+      - *restore-cache
+      - *reset-ccache-stats
+      - *build-ios-test
+      - *check-public-symbols
+      - *show-ccache-stats
+      - *save-cache
+
+# ------------------------------------------------------------------------------
+  ios-sanitize-address:
+    macos:
+      xcode: "9.0"
+    environment:
+      BUILDTYPE: Debug
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - checkout
+      - *install-ios-dependencies
+      - *generate-cache-key
+      - *restore-cache
+      - *reset-ccache-stats
+      - run:
+          name: Build and run SDK unit tests with address sanitizer
+          command: make ios-sanitize-address
+      - *show-ccache-stats
+      - *save-cache
+
+# ------------------------------------------------------------------------------
+  ios-sanitize-thread:
+    macos:
+      xcode: "9.0"
+    environment:
+      BUILDTYPE: Debug
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - checkout
+      - *install-ios-dependencies
+      - *generate-cache-key
+      - *restore-cache
+      - *reset-ccache-stats
+      - run:
+          name: Build and run SDK unit tests with thread sanitizer
+          command: make ios-sanitize-thread
+      - *show-ccache-stats
+      - *save-cache

--- a/circle.yml
+++ b/circle.yml
@@ -33,6 +33,7 @@ workflows:
       - ios-debug
       #- ios-sanitize-address
       - ios-sanitize-thread
+      - macos-debug
 
 step-library:
   - &generate-cache-key
@@ -104,6 +105,10 @@ step-library:
       run:
         name: Build ios-test
         command: make ios-test
+  - &build-macos-test
+      run:
+        name: Build and run macOS tests
+        command: make run-test
 
 
   - &check-public-symbols
@@ -112,7 +117,7 @@ step-library:
         command: make check-public-symbols
 
 
-  - &install-ios-dependencies
+  - &install-macos-dependencies
       run:
         name: Install dependencies
         command: |
@@ -620,7 +625,7 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - checkout
-      - *install-ios-dependencies
+      - *install-macos-dependencies
       - *generate-cache-key
       - *restore-cache
       - *reset-ccache-stats
@@ -638,7 +643,7 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - checkout
-      - *install-ios-dependencies
+      - *install-macos-dependencies
       - *generate-cache-key
       - *restore-cache
       - *reset-ccache-stats
@@ -657,7 +662,7 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - checkout
-      - *install-ios-dependencies
+      - *install-macos-dependencies
       - *generate-cache-key
       - *restore-cache
       - *reset-ccache-stats
@@ -666,3 +671,24 @@ jobs:
           command: make ios-sanitize-thread
       - *show-ccache-stats
       - *save-cache
+
+# ------------------------------------------------------------------------------
+  macos-debug:
+    macos:
+      xcode: "9.0"
+    environment:
+      BUILDTYPE: Debug
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - checkout
+      - *install-macos-dependencies
+      - *generate-cache-key
+      - *restore-cache
+      - *reset-ccache-stats
+      - *build-macos-test
+      - *check-public-symbols
+      - *show-ccache-stats
+      - *save-cache
+      - store_artifacts:
+          path: test/fixtures
+          destination: test/fixtures

--- a/platform/ios/bitrise.yml
+++ b/platform/ios/bitrise.yml
@@ -13,48 +13,9 @@ workflows:
   primary:
     steps:
     - script:
-        title: Install Dependencies
+        title: Skip Workflow
         inputs:
-        - content: |-
-            #!/bin/bash
-            set -eu -o pipefail
-            brew install cmake
-        - is_debug: 'yes'
-    - script:
-        title: Generate Workspace
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -eu -o pipefail
-            export BUILDTYPE=Debug
-            make iproj
-        - is_debug: 'yes'
-    - xcode-test:
-        title: Run SDK Unit Tests
-        inputs:
-        - project_path: platform/ios/ios.xcworkspace
-        - scheme: CI
-    - deploy-to-bitrise-io:
-        title: Deploy to Bitrise.io
-        inputs:
-        - notify_user_groups: none
-    - slack:
-        title: Post to Slack
-        inputs:
-        - webhook_url: "$SLACK_HOOK_URL"
-        - channel: "#gl-bots"
-        - from_username: 'Bitrise iOS'
-        - from_username_on_error: 'Bitrise iOS'
-        - message: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
-            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
-            by ${GIT_CLONE_COMMIT_COMMITER_NAME}
-            passed'
-        - message_on_error: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
-            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
-            by ${GIT_CLONE_COMMIT_COMMITER_NAME}
-            failed'
-        - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png
-        - icon_url_on_error: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-error-icon-128.png
+        - content: echo "This workflow is obsolete — see CircleCi."
   nightly-release:
     steps:
     - script:

--- a/platform/macos/bitrise.yml
+++ b/platform/macos/bitrise.yml
@@ -12,39 +12,9 @@ workflows:
   primary:
     steps:
     - script:
-        title: Build
+        title: Skip Workflow
         inputs:
-        - content: |-
-            #!/bin/bash
-            set -eu -o pipefail
-            brew install cmake
-            gem install xcpretty --no-rdoc --no-ri
-            export BUILDTYPE=Debug
-            export XCPRETTY="| tee ${BITRISE_DEPLOY_DIR}/raw-xcodebuild-output.txt | xcpretty --color --report html --output ${BITRISE_DEPLOY_DIR}/xcode-test-results.html"
-            make run-test
-    - deploy-to-bitrise-io:
-        title: Deploy to Bitrise.io
-        inputs:
-        - deploy_path: "test/fixtures"
-        - notify_user_groups: none
-        - is_compress: 'true'
-    - slack:
-        title: Post to Slack
-        inputs:
-        - webhook_url: "$SLACK_HOOK_URL"
-        - channel: "#gl-bots"
-        - from_username: 'Bitrise macOS'
-        - from_username_on_error: 'Bitrise macOS'
-        - message: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
-            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
-            by ${GIT_CLONE_COMMIT_COMMITER_NAME}
-            passed'
-        - message_on_error: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
-            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
-            by ${GIT_CLONE_COMMIT_COMMITER_NAME}
-            failed'
-        - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png
-        - icon_url_on_error: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-error-icon-128.png
+        - content: echo "This workflow is obsolete — see CircleCi."
   nightly-release:
     steps:
     - script:


### PR DESCRIPTION
Follows up on #8551 & #9051 and adds iOS & macOS tests to CircleCI. A new branch takes about 8-9 minutes to finish running these tests, while a cached build can take 4-5 minutes. ~This does not yet replace Bitrise and these builds will not be marked `required`~, but that’s the end goal after some period of validation.

Adds ~three~ four builds, currently all using Xcode 9.0.x and iOS 11.x/macOS 10.13.x:

- `ios-debug`: Debug build that runs unit tests on a single iPhone 7 simulator. Replaces the [Bitrise iOS build](https://www.bitrise.io/app/7514e4cf3da2cc57#/builds).
- `ios-sanitize-address`: Same, but with the [address sanitizer](https://developer.apple.com/documentation/code_diagnostics/address_sanitizer) enabled. Fairly slow and [currently times out a few tests](https://circleci.com/gh/mapbox/mapbox-gl-native/31728) — ~will probably disable this,~ disabled this until tests can be adjusted.
- `ios-sanitize-thread`: Same, but with the [thread sanitizer](https://developer.apple.com/documentation/code_diagnostics/thread_sanitizer) enabled. Seems about as fast/reliable as without.
- `macos-debug`: Debug build that runs core and macOS unit tests. Replaces the [Bitrise macOS build](https://www.bitrise.io/app/155ef7da24b38dcd#/builds).

You can see these builds for this branch here: https://circleci.com/gh/mapbox/mapbox-gl-native/tree/fb-circleci-agua

### Selected benefits
- Faster
- Auto-cancels obsolete builds(?)
- Can cancel groups of builds

### Notes
- CircleCI 2.0’s macOS support is early and I’m seeing containers fail to start (`Unexpected preparation error: Process exited with status 1`) and then automatically retry. This initially appears as a failure, but then later reports its actual status when the retry has completed.
- Xcode 9 adds the ability to run multiple concurrent simulators, but this seems very unreliable and tests randomly fail. Xcpretty/scan also don’t handle this well, failing to echo the test output from any of the simulators. Too bad, because multiple concurrent simulators would be awesome.
- After we’re in a good place, I’ll work on porting workflows that require auth or signing, such as the [deployment flow](https://github.com/mapbox/mapbox-gl-native/pull/10170) or the nightly builds.
- Qt and Node platform builds that we’re running on macOS will also come, eventually.

### Questions
- What types of builds should we have? Release? Older iOS simulators? Older Xcode? Linting?

/cc @mapbox/ios @kkaefer @brunoabinader