### PR TITLE
Move shape annotation click handling to core

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -175,8 +175,9 @@ public class MapView extends FrameLayout {
     Markers markers = new MarkerContainer(nativeMapView, this, annotationsArray, iconManager, markerViewManager);
     Polygons polygons = new PolygonContainer(nativeMapView, annotationsArray);
     Polylines polylines = new PolylineContainer(nativeMapView, annotationsArray);
+    ShapeAnnotations shapeAnnotations = new ShapeAnnotationContainer(nativeMapView, annotationsArray);
     AnnotationManager annotationManager = new AnnotationManager(nativeMapView, this, annotationsArray,
-      markerViewManager, iconManager, annotations, markers, polygons, polylines);
+      markerViewManager, iconManager, annotations, markers, polygons, polylines, shapeAnnotations);
     Transform transform = new Transform(nativeMapView, annotationManager.getMarkerViewManager(), trackingSettings,
       cameraChangeDispatcher);
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MarkerContainer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MarkerContainer.java
@@ -98,15 +98,8 @@ class MarkerContainer implements Markers {
   @NonNull
   @Override
   public List<Marker> obtainAllIn(@NonNull RectF rectangle) {
-    // convert Rectangle to be density depedent
-    float pixelRatio = nativeMapView.getPixelRatio();
-    RectF rect = new RectF(rectangle.left / pixelRatio,
-      rectangle.top / pixelRatio,
-      rectangle.right / pixelRatio,
-      rectangle.bottom / pixelRatio);
-
+    RectF rect = nativeMapView.getDensityDependantRectangle(rectangle);
     long[] ids = nativeMapView.queryPointAnnotations(rect);
-
     List<Long> idsList = new ArrayList<>(ids.length);
     for (long id : ids) {
       idsList.add(id);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -468,6 +468,13 @@ final class NativeMapView {
     return nativeQueryPointAnnotations(rect);
   }
 
+  public long[] queryShapeAnnotations(RectF rectF) {
+    if (isDestroyedOn("queryShapeAnnotations")) {
+      return new long[] {};
+    }
+    return nativeQueryShapeAnnotations(rectF);
+  }
+
   public void addAnnotationIcon(String symbol, int width, int height, float scale, byte[] pixels) {
     if (isDestroyedOn("addAnnotationIcon")) {
       return;
@@ -825,6 +832,15 @@ final class NativeMapView {
     return pixelRatio;
   }
 
+  RectF getDensityDependantRectangle(final RectF rectangle) {
+    return new RectF(
+      rectangle.left / pixelRatio,
+      rectangle.top / pixelRatio,
+      rectangle.right / pixelRatio,
+      rectangle.bottom / pixelRatio
+    );
+  }
+
   //
   // Callbacks
   //
@@ -926,6 +942,8 @@ final class NativeMapView {
   private native void nativeRemoveAnnotations(long[] id);
 
   private native long[] nativeQueryPointAnnotations(RectF rect);
+
+  private native long[] nativeQueryShapeAnnotations(RectF rect);
 
   private native void nativeAddAnnotationIcon(String symbol, int width, int height, float scale, byte[] pixels);
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/ShapeAnnotationContainer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/ShapeAnnotationContainer.java
@@ -1,0 +1,38 @@
+package com.mapbox.mapboxsdk.maps;
+
+import android.graphics.RectF;
+import android.support.v4.util.LongSparseArray;
+
+import com.mapbox.mapboxsdk.annotations.Annotation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class ShapeAnnotationContainer implements ShapeAnnotations {
+
+  private final NativeMapView nativeMapView;
+  private final LongSparseArray<Annotation> annotations;
+
+  ShapeAnnotationContainer(NativeMapView nativeMapView, LongSparseArray<Annotation> annotations) {
+    this.nativeMapView = nativeMapView;
+    this.annotations = annotations;
+  }
+
+  @Override
+  public List<Annotation> obtainAllIn(RectF rectangle) {
+    RectF rect = nativeMapView.getDensityDependantRectangle(rectangle);
+    long[] annotationIds = nativeMapView.queryShapeAnnotations(rect);
+    return getAnnotationsFromIds(annotationIds);
+  }
+
+  private List<Annotation> getAnnotationsFromIds(long[] annotationIds) {
+    List<Annotation> shapeAnnotations = new ArrayList<>();
+    for (long annotationId : annotationIds) {
+      Annotation annotation = annotations.get(annotationId);
+      if (annotation != null) {
+        shapeAnnotations.add(annotation);
+      }
+    }
+    return shapeAnnotations;
+  }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/ShapeAnnotations.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/ShapeAnnotations.java
@@ -1,0 +1,13 @@
+package com.mapbox.mapboxsdk.maps;
+
+import android.graphics.RectF;
+
+import com.mapbox.mapboxsdk.annotations.Annotation;
+
+import java.util.List;
+
+interface ShapeAnnotations {
+
+  List<Annotation> obtainAllIn(RectF rectF);
+
+}

--- a/platform/android/src/android_renderer_frontend.cpp
+++ b/platform/android/src/android_renderer_frontend.cpp
@@ -112,6 +112,11 @@ AnnotationIDs AndroidRendererFrontend::queryPointAnnotations(const ScreenBox& bo
     return mapRenderer.actor().ask(&Renderer::queryPointAnnotations, box).get();
 }
 
+AnnotationIDs AndroidRendererFrontend::queryShapeAnnotations(const ScreenBox& box) const {
+    // Waits for the result from the orchestration thread and returns
+    return mapRenderer.actor().ask(&Renderer::queryShapeAnnotations, box).get();
+}
+
 } // namespace android
 } // namespace mbgl
 

--- a/platform/android/src/android_renderer_frontend.hpp
+++ b/platform/android/src/android_renderer_frontend.hpp
@@ -36,6 +36,7 @@ public:
     std::vector<Feature> queryRenderedFeatures(const ScreenBox&, const RenderedQueryOptions&) const;
     std::vector<Feature> querySourceFeatures(const std::string& sourceID, const SourceQueryOptions&) const;
     AnnotationIDs queryPointAnnotations(const ScreenBox& box) const;
+    AnnotationIDs queryShapeAnnotations(const ScreenBox& box) const;
 
     // Memory
     void onLowMemory();

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -633,6 +633,26 @@ jni::Array<jlong> NativeMapView::queryPointAnnotations(JNIEnv& env, jni::Object<
     return result;
 }
 
+jni::Array<jlong> NativeMapView::queryShapeAnnotations(JNIEnv &env, jni::Object<RectF> rect) {
+    using namespace mbgl::style;
+    using namespace mbgl::style::conversion;
+
+    // Convert input
+    mbgl::ScreenBox box = {
+         {RectF::getLeft(env, rect),  RectF::getTop(env, rect)},
+         {RectF::getRight(env, rect), RectF::getBottom(env, rect)},
+    };
+
+    mbgl::AnnotationIDs ids = rendererFrontend->queryShapeAnnotations(box);
+
+    // Convert result
+    std::vector<jlong> longIds(ids.begin(), ids.end());
+    auto result = jni::Array<jni::jlong>::New(env, ids.size());
+    result.SetRegion<std::vector<jni::jlong>>(env, 0, longIds);
+
+    return result;
+}
+
 jni::Array<jni::Object<geojson::Feature>> NativeMapView::queryRenderedFeaturesForPoint(JNIEnv& env, jni::jfloat x, jni::jfloat y,
                                                                               jni::Array<jni::String> layerIds,
                                                                               jni::Array<jni::Object<>> jfilter) {
@@ -1000,6 +1020,7 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
             METHOD(&NativeMapView::getTransitionDelay, "nativeGetTransitionDelay"),
             METHOD(&NativeMapView::setTransitionDelay, "nativeSetTransitionDelay"),
             METHOD(&NativeMapView::queryPointAnnotations, "nativeQueryPointAnnotations"),
+            METHOD(&NativeMapView::queryShapeAnnotations, "nativeQueryShapeAnnotations"),
             METHOD(&NativeMapView::queryRenderedFeaturesForPoint, "nativeQueryRenderedFeaturesForPoint"),
             METHOD(&NativeMapView::queryRenderedFeaturesForBox, "nativeQueryRenderedFeaturesForBox"),
             METHOD(&NativeMapView::getLight, "nativeGetLight"),

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -197,6 +197,8 @@ public:
 
     jni::Array<jlong> queryPointAnnotations(JNIEnv&, jni::Object<RectF>);
 
+    jni::Array<jlong> queryShapeAnnotations(JNIEnv&, jni::Object<RectF>);
+
     jni::Array<jni::Object<geojson::Feature>> queryRenderedFeaturesForPoint(JNIEnv&, jni::jfloat, jni::jfloat,
                                                                    jni::Array<jni::String>,
                                                                    jni::Array<jni::Object<>> jfilter);


### PR DESCRIPTION
Closes #10234, refs https://github.com/mapbox/mapbox-gl-native/pull/9984 and https://github.com/mapbox/mapbox-gl-native/pull/9443.

This moves the logic as shown in #9984 to core. 