### PR TITLE
[core] Add layer before notifying observer

### DIFF
--- a/src/mbgl/style/style_impl.cpp
+++ b/src/mbgl/style/style_impl.cpp
@@ -204,9 +204,10 @@ Layer* Style::Impl::addLayer(std::unique_ptr<Layer> layer, optional<std::string>
     }
 
     layer->setObserver(this);
+    Layer* result = layers.add(std::move(layer), before);
     observer->onUpdate();
 
-    return layers.add(std::move(layer), before);
+    return result;
 }
 
 std::unique_ptr<Layer> Style::Impl::removeLayer(const std::string& id) {


### PR DESCRIPTION
Fixes #10160.

I was unable to write a regression test that would have caught this bug -- the render test harness does a number of actions that trigger `onUpdate` and therefore hide the effect of a missed update.