### PR TITLE
Asynchronously dispatch scale bar updates on camera updates

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -5071,7 +5071,9 @@ public:
     [self updateCompass];
     
     if (!self.scaleBar.hidden) {
-        [(MGLScaleBar *)self.scaleBar setMetersPerPoint:[self metersPerPointAtLatitude:self.centerCoordinate.latitude]];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [(MGLScaleBar *)self.scaleBar setMetersPerPoint:[self metersPerPointAtLatitude:self.centerCoordinate.latitude]];
+        });
     }
     
     if ([self.delegate respondsToSelector:@selector(mapViewRegionIsChanging:)])


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/10266

`-[MGLMapView cameraIsChanging]` is called in `MBGLView: 
 MapObserver::onCameraIsChanging()` and, after https://github.com/mapbox/mapbox-gl-native/commit/b6d56ad634e2b3048e97bedd9f674aa4ec975453, the frequency is too much for the associated view resizing and constraint updates required. This change dispatches all of that work to keep map rendering unblocked. Technically, there should now be a small delay between what the scale bar is representing and the visible map on screen. In practice, when testing, I'm unable to notice any difference and flyTo / panning / gestures in general work as expected again.