### PR TITLE
Move scale bar size invalidation

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1015,6 +1015,14 @@ public:
 // This gets called when the view dimension changes, e.g. because the device is being rotated.
 - (void)layoutSubviews
 {
+    // Calling this here instead of in the scale bar itself because if this is done in the
+    // scale bar instance, it triggers a call to this this `layoutSubviews` method that
+    // calls `_mbglMap->setSize()` just below that triggers rendering update which triggers
+    // another scale bar update which causes a rendering update loop and a major performace
+    // degradation. The only time the scale bar's intrinsic content size _must_ invalidated
+    // is here as a reaction to this object's view dimension changes.
+    [self.scaleBar invalidateIntrinsicContentSize];
+    
     [super layoutSubviews];
 
     [self adjustContentInset];

--- a/platform/ios/src/MGLScaleBar.mm
+++ b/platform/ios/src/MGLScaleBar.mm
@@ -225,9 +225,6 @@ static const CGFloat MGLFeetPerMeter = 3.28084;
                             CGRectGetMinY(self.frame),
                             size.width,
                             size.height);
-    
-    [self invalidateIntrinsicContentSize];
-    [self setNeedsLayout];
 }
 
 - (void)updateVisibility {


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/10266

Invalidating the intrinsic content size was causing MGLMapView's `layoutSubviews` method to be called which called into `_mbglMap->setSize()` that called `mbgl::map::onUpdate()` that triggered (with the new-ish [async rendering updates](https://github.com/mapbox/mapbox-gl-native/commit/b6d56ad634e2b3048e97bedd9f674aa4ec975453)) a call to `rendererFrontend.update()` that caused a camera update that then kicked off the whole process again. 

From what I can tell, this means that in addition to the normal rendering updates, this loop created many many more additional updates and appears to slow the entire animation / gesture down (I think mostly due to transition cancellations).

The change in https://github.com/mapbox/mapbox-gl-native/pull/10273 works around this issue by apparently short circuiting the intrinsic content size + layout subviews loop but does not actually solve for that underlying issue. 

The change proposed here stops the layout loop by removing the call to `invalidateIntrinsicContentSize` in the scale bar class that was triggering the loop. I also removed the call to `setNeedsLayout` because UIKit appears to already intelligently call `layoutSubviews` when the scale bar's bounds changes as a result of changing the frame size. The intrinsic content size invalidation is now done in the map view's layout subviews method so that it is done only when it really needs to be done and not every time the scale bar frame size gets updated.

Taken together, these changes don't seem to cause any functionality regressions and also fix the performance issue described in https://github.com/mapbox/mapbox-gl-native/issues/10266
