### PR TITLE
Move CollisionIndex to use GridIndex instead of boost::rtree.

### DIFF
--- a/src/mbgl/text/collision_feature.hpp
+++ b/src/mbgl/text/collision_feature.hpp
@@ -34,6 +34,7 @@ public:
     // Placeholder for center of circles (can be derived from bounding box)
     float px;
     float py;
+    float radius;
     bool used;
 
     float tileUnitDistanceToAnchor;

--- a/src/mbgl/text/collision_index.hpp
+++ b/src/mbgl/text/collision_index.hpp
@@ -1,50 +1,23 @@
 #pragma once
 
+#include <mbgl/geometry/feature_index.hpp>
 #include <mbgl/text/collision_feature.hpp>
 #include <mbgl/text/placement_config.hpp>
 #include <mbgl/tile/geometry_tile_data.hpp>
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-function"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wshadow"
-#ifdef __clang__
-#pragma GCC diagnostic ignored "-Wunknown-pragmas"
-#endif
-#pragma GCC diagnostic ignored "-Wpragmas"
-#pragma GCC diagnostic ignored "-Wdeprecated-register"
-#pragma GCC diagnostic ignored "-Wshorten-64-to-32"
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#ifndef __clang__
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#pragma GCC diagnostic ignored "-Wmisleading-indentation"
-#endif
-#include <boost/geometry.hpp>
-#include <boost/geometry/geometries/point.hpp>
-#include <boost/geometry/geometries/box.hpp>
-#include <boost/geometry/index/rtree.hpp>
-#pragma GCC diagnostic pop
-
+#include <mbgl/util/grid_index.hpp>
 #include <mbgl/map/transform_state.hpp>
 
 namespace mbgl {
 
-namespace bg = boost::geometry;
-namespace bgm = bg::model;
-namespace bgi = bg::index;
-using CollisionPoint = bgm::point<float, 2, bg::cs::cartesian>;
-using Box = bgm::box<CollisionPoint>;
-using CollisionTreeBox = std::tuple<Box, CollisionBox, IndexedSubfeature>;
-using Tree = bgi::rtree<CollisionTreeBox, bgi::linear<16, 4>>;
-
-class IndexedSubfeature;
 class PlacedSymbol;
 
 struct TileDistance;
 
 class CollisionIndex {
 public:
+    using CollisionGrid = GridIndex<IndexedSubfeature>;
+    using GridUnit = int16_t;
+
     explicit CollisionIndex(const TransformState&);
 
     bool placeFeature(CollisionFeature& feature,
@@ -74,8 +47,6 @@ private:
                                   const bool allowOverlap,
                                   const bool pitchWithMap,
                                   const bool collisionDebug);
-
-    Box getTreeBox(const CollisionBox& box) const;
     
     float approximateTileDistance(const TileDistance& tileDistance, const float lastSegmentAngle, const float pixelsToTileUnits, const float cameraToAnchorDistance, const bool pitchWithMap);
     
@@ -86,8 +57,8 @@ private:
     TransformState transformState;
     float pitchFactor;
 
-    Tree tree;
-    Tree ignoredTree;
+    CollisionGrid collisionGrid;
+    CollisionGrid ignoredGrid;
 };
 
 } // namespace mbgl

--- a/src/mbgl/util/grid_index.cpp
+++ b/src/mbgl/util/grid_index.cpp
@@ -246,6 +246,12 @@ bool GridIndex<T>::circleAndBoxCollide(const BCircle& circle, const BBox& box) c
     return (dx * dx + dy * dy) <= (circle.radius * circle.radius);
 }
 
+template <class T>
+bool GridIndex<T>::empty() const {
+    return boxElements.empty() && circleElements.empty();
+}
+
+
 template class GridIndex<IndexedSubfeature>;
 
 } // namespace mbgl

--- a/src/mbgl/util/grid_index.hpp
+++ b/src/mbgl/util/grid_index.hpp
@@ -70,6 +70,8 @@ public:
     
     bool hitTest(const BBox&) const;
     bool hitTest(const BCircle&) const;
+    
+    bool empty() const;
 
 private:
 


### PR DESCRIPTION
- Stops crash on inserting line labels
- Breaks queryRenderedSymbols for now.
[skip ci]

/cc @ansis 