### PR TITLE
Initial implementation of debug collision circles

### DIFF
--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -255,6 +255,8 @@ set(MBGL_CORE_FILES
     src/mbgl/shaders/circle.hpp
     src/mbgl/shaders/collision_box.cpp
     src/mbgl/shaders/collision_box.hpp
+    src/mbgl/shaders/collision_circle.cpp
+    src/mbgl/shaders/collision_circle.hpp
     src/mbgl/shaders/debug.cpp
     src/mbgl/shaders/debug.hpp
     src/mbgl/shaders/extrusion_texture.cpp

--- a/src/mbgl/layout/symbol_instance.cpp
+++ b/src/mbgl/layout/symbol_instance.cpp
@@ -19,7 +19,7 @@ SymbolInstance::SymbolInstance(Anchor& anchor_,
                                const std::array<float, 2> textOffset_,
                                const float iconBoxScale,
                                const float iconPadding,
-                               const SymbolPlacementType iconPlacement,
+                               const SymbolPlacementType, // TODO: vestigial?
                                const std::array<float, 2> iconOffset_,
                                const GlyphPositionMap& positions,
                                const IndexedSubfeature& indexedFeature,
@@ -33,7 +33,7 @@ SymbolInstance::SymbolInstance(Anchor& anchor_,
 
     // Create the collision features that will be used to check whether this symbol instance can be placed
     textCollisionFeature(line_, anchor, shapedTextOrientations.second ?: shapedTextOrientations.first, textBoxScale, textPadding, textPlacement, indexedFeature),
-    iconCollisionFeature(line_, anchor, shapedIcon, iconBoxScale, iconPadding, iconPlacement, indexedFeature),
+    iconCollisionFeature(line_, anchor, shapedIcon, iconBoxScale, iconPadding, SymbolPlacementType::Point, indexedFeature),
     featureIndex(featureIndex_),
     textOffset(textOffset_),
     iconOffset(iconOffset_),

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -597,7 +597,8 @@ void SymbolLayout::addToDebugBuffers(CollisionTile& collisionTile, SymbolBucket&
                 const std::size_t indexLength = feature.alongLine ? 4 : 8;
 
                 if (collisionBuffer.segments.empty() || collisionBuffer.segments.back().vertexLength + vertexLength > std::numeric_limits<uint16_t>::max()) {
-                    collisionBuffer.segments.emplace_back(collisionBuffer.vertices.vertexSize(), bucket.collisionBox.lines.indexSize());
+                    collisionBuffer.segments.emplace_back(collisionBuffer.vertices.vertexSize(),
+                      feature.alongLine? bucket.collisionCircle.triangles.indexSize() : bucket.collisionBox.lines.indexSize());
                 }
 
                 auto& segment = collisionBuffer.segments.back();

--- a/src/mbgl/programs/programs.hpp
+++ b/src/mbgl/programs/programs.hpp
@@ -32,7 +32,8 @@ public:
           symbolIconSDF(context, programParameters),
           symbolGlyph(context, programParameters),
           debug(context, programParameters),
-          collisionBox(context, programParameters) {
+          collisionBox(context, programParameters),
+          collisionCircle(context, programParameters) {
     }
 
     ProgramMap<CircleProgram> circle;
@@ -53,6 +54,7 @@ public:
 
     DebugProgram debug;
     CollisionBoxProgram collisionBox;
+    CollisionCircleProgram collisionCircle;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -51,10 +51,16 @@ void SymbolBucket::upload(gl::Context& context) {
         icon.indexBuffer = context.createIndexBuffer(std::move(icon.triangles));
     }
 
-    if (!collisionBox.vertices.empty()) {
+    if (hasCollisionBoxData()) {
         collisionBox.vertexBuffer = context.createVertexBuffer(std::move(collisionBox.vertices));
         collisionBox.opacityVertexBuffer = context.createVertexBuffer(std::move(collisionBox.opacityVertices), gl::BufferUsage::StreamDraw);
         collisionBox.indexBuffer = context.createIndexBuffer(std::move(collisionBox.lines));
+    }
+    
+    if (hasCollisionCircleData()) {
+        collisionCircle.vertexBuffer = context.createVertexBuffer(std::move(collisionCircle.vertices));
+        collisionCircle.opacityVertexBuffer = context.createVertexBuffer(std::move(collisionCircle.opacityVertices), gl::BufferUsage::StreamDraw);
+        collisionCircle.indexBuffer = context.createIndexBuffer(std::move(collisionCircle.triangles));
     }
 
     for (auto& pair : paintPropertyBinders) {
@@ -79,6 +85,10 @@ bool SymbolBucket::hasIconData() const {
 
 bool SymbolBucket::hasCollisionBoxData() const {
     return !collisionBox.segments.empty();
+}
+
+bool SymbolBucket::hasCollisionCircleData() const {
+    return !collisionCircle.segments.empty();
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -58,6 +58,7 @@ public:
     bool hasTextData() const;
     bool hasIconData() const;
     bool hasCollisionBoxData() const;
+    bool hasCollisionCircleData() const;
 
     const style::SymbolLayoutProperties::PossiblyEvaluated layout;
     const bool sdfIcons;
@@ -102,16 +103,24 @@ public:
         optional<gl::IndexBuffer<gl::Triangles>> indexBuffer;
     } icon;
 
-    struct CollisionBoxBuffer {
+    struct CollisionBuffer {
         gl::VertexVector<CollisionBoxLayoutAttributes::Vertex> vertices;
         gl::VertexVector<CollisionBoxOpacityAttributes::Vertex> opacityVertices;
-        gl::IndexVector<gl::Lines> lines;
         SegmentVector<CollisionBoxProgram::Attributes> segments;
 
         optional<gl::VertexBuffer<CollisionBoxLayoutAttributes::Vertex>> vertexBuffer;
         optional<gl::VertexBuffer<CollisionBoxOpacityAttributes::Vertex>> opacityVertexBuffer;
+    };
+
+    struct CollisionBoxBuffer : public CollisionBuffer {
+        gl::IndexVector<gl::Lines> lines;
         optional<gl::IndexBuffer<gl::Lines>> indexBuffer;
     } collisionBox;
+    
+    struct CollisionCircleBuffer : public CollisionBuffer {
+        gl::IndexVector<gl::Triangles> triangles;
+        optional<gl::IndexBuffer<gl::Triangles>> indexBuffer;
+    } collisionCircle;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -233,7 +233,6 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
                     parameters.pixelsToGLUnits[1] / (pixelRatio * scale)
                     
                 }};
-            
             parameters.programs.collisionBox.draw(
                 parameters.context,
                 gl::Lines { 1.0f },
@@ -254,6 +253,41 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
                 parameters.state.getZoom(),
                 getID()
             );
+        }
+        if (bucket.hasCollisionCircleData()) {
+            static const style::Properties<>::PossiblyEvaluated properties {};
+            static const CollisionBoxProgram::PaintPropertyBinders paintAttributeData(properties, 0);
+
+            auto pixelRatio = tile.id.pixelsToTileUnits(1, parameters.state.getZoom());
+            auto scale = std::pow(2.0f, float(parameters.state.getZoom() - tile.tile.id.overscaledZ));
+            std::array<float,2> extrudeScale =
+                {{
+                    parameters.pixelsToGLUnits[0] / (pixelRatio * scale),
+                    parameters.pixelsToGLUnits[1] / (pixelRatio * scale)
+                    
+                }};
+
+            parameters.programs.collisionCircle.draw(
+                parameters.context,
+                gl::Triangles(),
+                gl::DepthMode::disabled(),
+                parameters.stencilModeForClipping(tile.clip),
+                parameters.colorModeForRenderPass(),
+                CollisionBoxProgram::UniformValues {
+                    uniforms::u_matrix::Value{ tile.matrix },
+                    uniforms::u_extrude_scale::Value{ extrudeScale },
+                    uniforms::u_camera_to_center_distance::Value{ parameters.state.getCameraToCenterDistance() }
+                },
+                *bucket.collisionCircle.vertexBuffer,
+                *bucket.collisionCircle.opacityVertexBuffer,
+                *bucket.collisionCircle.indexBuffer,
+                bucket.collisionCircle.segments,
+                paintAttributeData,
+                properties,
+                parameters.state.getZoom(),
+                getID()
+            );
+
         }
     }
 }

--- a/src/mbgl/text/collision_feature.cpp
+++ b/src/mbgl/text/collision_feature.cpp
@@ -124,7 +124,7 @@ void CollisionFeature::bboxifyLabel(const GeometryCoordinates& line, GeometryCoo
             0 :
             (boxDistanceToAnchor - firstBoxOffset) * 0.8;
 
-        boxes.emplace_back(boxAnchor, boxAnchor - convertPoint<float>(anchorPoint), -boxSize / 2, -boxSize / 2, boxSize / 2, boxSize / 2, paddedAnchorDistance);
+        boxes.emplace_back(boxAnchor, boxAnchor - convertPoint<float>(anchorPoint), -boxSize / 2, -boxSize / 2, boxSize / 2, boxSize / 2, paddedAnchorDistance, boxSize / 2);
     }
 }
 

--- a/src/mbgl/text/collision_feature.hpp
+++ b/src/mbgl/text/collision_feature.hpp
@@ -11,8 +11,8 @@ namespace mbgl {
 
 class CollisionBox {
 public:
-    CollisionBox(Point<float> _anchor, Point<float> _offset, float _x1, float _y1, float _x2, float _y2, float _tileUnitDistanceToAnchor = 0) :
-        anchor(std::move(_anchor)), offset(_offset), x1(_x1), y1(_y1), x2(_x2), y2(_y2), used(true), tileUnitDistanceToAnchor(_tileUnitDistanceToAnchor) {}
+    CollisionBox(Point<float> _anchor, Point<float> _offset, float _x1, float _y1, float _x2, float _y2, float _tileUnitDistanceToAnchor = 0, float _radius = 0) :
+        anchor(std::move(_anchor)), offset(_offset), x1(_x1), y1(_y1), x2(_x2), y2(_y2), used(true), tileUnitDistanceToAnchor(_tileUnitDistanceToAnchor), radius(_radius) {}
 
     // the box is centered around the anchor point
     Point<float> anchor;
@@ -34,11 +34,10 @@ public:
     // Placeholder for center of circles (can be derived from bounding box)
     float px;
     float py;
-    float radius;
     bool used;
 
     float tileUnitDistanceToAnchor;
-
+    float radius;
     
     // TODO Placeholders for old collision tiles
     float maxScale;


### PR DESCRIPTION
 - Naive copy-pasting of collision box code: should factor out more of the commonalities
 - "Used circle" logic seems to be working correctly
 - Rendering seems to break if there are too many circles (probably something to do with segment logic?)
[skip ci]

/cc @ansis