### PR TITLE
Start collision fading

### DIFF
--- a/src/mbgl/programs/collision_box_program.hpp
+++ b/src/mbgl/programs/collision_box_program.hpp
@@ -77,6 +77,8 @@ public:
                 .concat(CollisionBoxOpacityAttributes::bindings(opacityVertexBuffer))
 				.concat(paintPropertyBinders.attributeBindings(currentProperties));
 
+            assert(layoutVertexBuffer.vertexCount == opacityVertexBuffer.vertexCount);
+
 			for (auto& segment : segments) {
 				auto vertexArrayIt = segment.vertexArrays.find(layerID);
 

--- a/src/mbgl/programs/symbol_program.cpp
+++ b/src/mbgl/programs/symbol_program.cpp
@@ -37,6 +37,7 @@ Values makeValues(const bool isText,
                   const bool alongLine,
                   const RenderTile& tile,
                   const TransformState& state,
+                  const float symbolFadeChange,
                   Args&&... args) {
     std::array<float, 2> extrudeScale;
     
@@ -82,7 +83,7 @@ Values makeValues(const bool isText,
         uniforms::u_extrude_scale::Value{ extrudeScale },
         uniforms::u_texsize::Value{ texsize },
         uniforms::u_texture::Value{ 0 },
-        uniforms::u_fade_change::Value{ 1 },
+        uniforms::u_fade_change::Value{ symbolFadeChange },
         uniforms::u_is_text::Value{ isText },
         uniforms::u_camera_to_center_distance::Value{ state.getCameraToCenterDistance() },
         uniforms::u_pitch::Value{ state.getPitch() },
@@ -101,7 +102,8 @@ SymbolIconProgram::uniformValues(const bool isText,
                                  const std::array<float, 2>& pixelsToGLUnits,
                                  const bool alongLine,
                                  const RenderTile& tile,
-                                 const TransformState& state)
+                                 const TransformState& state,
+                                 const float symbolFadeChange)
 {
     return makeValues<SymbolIconProgram::UniformValues>(
         isText,
@@ -110,7 +112,8 @@ SymbolIconProgram::uniformValues(const bool isText,
         pixelsToGLUnits,
         alongLine,
         tile,
-        state
+        state,
+        symbolFadeChange
     );
 }
 
@@ -123,6 +126,7 @@ typename SymbolSDFProgram<PaintProperties>::UniformValues SymbolSDFProgram<Paint
       const bool alongLine,
       const RenderTile& tile,
       const TransformState& state,
+      const float symbolFadeChange,
       const SymbolSDFPart part)
 {
     const float gammaScale = (values.pitchAlignment == AlignmentType::Map
@@ -137,6 +141,7 @@ typename SymbolSDFProgram<PaintProperties>::UniformValues SymbolSDFProgram<Paint
         alongLine,
         tile,
         state,
+        symbolFadeChange,
         uniforms::u_gamma_scale::Value{ gammaScale },
         uniforms::u_is_halo::Value{ part == SymbolSDFPart::Halo }
     );

--- a/src/mbgl/programs/symbol_program.hpp
+++ b/src/mbgl/programs/symbol_program.hpp
@@ -333,6 +333,9 @@ public:
             .concat(SymbolOpacityAttributes::bindings(opacityVertexBuffer))
             .concat(paintPropertyBinders.attributeBindings(currentProperties));
 
+        assert(layoutVertexBuffer.vertexCount == dynamicLayoutVertexBuffer.vertexCount &&
+                layoutVertexBuffer.vertexCount == opacityVertexBuffer.vertexCount);
+
         for (auto& segment : segments) {
             auto vertexArrayIt = segment.vertexArrays.find(layerID);
 

--- a/src/mbgl/programs/symbol_program.hpp
+++ b/src/mbgl/programs/symbol_program.hpp
@@ -386,7 +386,8 @@ public:
                                        const std::array<float, 2>& pixelsToGLUnits,
                                        const bool alongLine,
                                        const RenderTile&,
-                                       const TransformState&);
+                                       const TransformState&,
+                                       const float symbolFadeChange);
 };
 
 enum class SymbolSDFPart {
@@ -454,6 +455,7 @@ public:
                                        const bool alongLine,
                                        const RenderTile&,
                                        const TransformState&,
+                                       const float SymbolFadeChange,
                                        const SymbolSDFPart);
 };
 

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -149,7 +149,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
             if (bucket.sdfIcons) {
                 if (values.hasHalo) {
                     draw(parameters.programs.symbolIconSDF,
-                         SymbolSDFIconProgram::uniformValues(false, values, texsize, parameters.pixelsToGLUnits, alongLine, tile, parameters.state, SymbolSDFPart::Halo),
+                         SymbolSDFIconProgram::uniformValues(false, values, texsize, parameters.pixelsToGLUnits, alongLine, tile, parameters.state, parameters.symbolFadeChange, SymbolSDFPart::Halo),
                          bucket.icon,
                          bucket.iconSizeBinder,
                          values,
@@ -159,7 +159,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
 
                 if (values.hasFill) {
                     draw(parameters.programs.symbolIconSDF,
-                         SymbolSDFIconProgram::uniformValues(false, values, texsize, parameters.pixelsToGLUnits, alongLine, tile, parameters.state, SymbolSDFPart::Fill),
+                         SymbolSDFIconProgram::uniformValues(false, values, texsize, parameters.pixelsToGLUnits, alongLine, tile, parameters.state, parameters.symbolFadeChange, SymbolSDFPart::Fill),
                          bucket.icon,
                          bucket.iconSizeBinder,
                          values,
@@ -168,7 +168,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
                 }
             } else {
                 draw(parameters.programs.symbolIcon,
-                     SymbolIconProgram::uniformValues(false, values, texsize, parameters.pixelsToGLUnits, alongLine, tile, parameters.state),
+                     SymbolIconProgram::uniformValues(false, values, texsize, parameters.pixelsToGLUnits, alongLine, tile, parameters.state, parameters.symbolFadeChange),
                      bucket.icon,
                      bucket.iconSizeBinder,
                      values,
@@ -202,7 +202,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
 
             if (values.hasHalo) {
                 draw(parameters.programs.symbolGlyph,
-                     SymbolSDFTextProgram::uniformValues(true, values, texsize, parameters.pixelsToGLUnits, alongLine, tile, parameters.state, SymbolSDFPart::Halo),
+                     SymbolSDFTextProgram::uniformValues(true, values, texsize, parameters.pixelsToGLUnits, alongLine, tile, parameters.state, parameters.symbolFadeChange, SymbolSDFPart::Halo),
                      bucket.text,
                      bucket.textSizeBinder,
                      values,
@@ -212,7 +212,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
 
             if (values.hasFill) {
                 draw(parameters.programs.symbolGlyph,
-                     SymbolSDFTextProgram::uniformValues(true, values, texsize, parameters.pixelsToGLUnits, alongLine, tile, parameters.state, SymbolSDFPart::Fill),
+                     SymbolSDFTextProgram::uniformValues(true, values, texsize, parameters.pixelsToGLUnits, alongLine, tile, parameters.state, parameters.symbolFadeChange, SymbolSDFPart::Fill),
                      bucket.text,
                      bucket.textSizeBinder,
                      values,

--- a/src/mbgl/renderer/paint_parameters.cpp
+++ b/src/mbgl/renderer/paint_parameters.cpp
@@ -13,7 +13,8 @@ PaintParameters::PaintParameters(gl::Context& context_,
                     const EvaluatedLight& evaluatedLight_,
                     RenderStaticData& staticData_,
                     ImageManager& imageManager_,
-                    LineAtlas& lineAtlas_)
+                    LineAtlas& lineAtlas_,
+                    TimePoint placementCommitTime)
     : context(context_),
     backend(backend_),
     state(updateParameters.transformState),
@@ -25,6 +26,7 @@ PaintParameters::PaintParameters(gl::Context& context_,
     debugOptions(updateParameters.debugOptions),
     contextMode(contextMode_),
     timePoint(updateParameters.timePoint),
+    symbolFadeChange(std::chrono::duration<float>(placementCommitTime - updateParameters.timePoint) / Duration(std::chrono::milliseconds(300))), // TODO don't hardcode
     pixelRatio(pixelRatio_),
 #ifndef NDEBUG
     programs((debugOptions & MapDebugOptions::Overdraw) ? staticData_.overdrawPrograms : staticData_.programs)

--- a/src/mbgl/renderer/paint_parameters.hpp
+++ b/src/mbgl/renderer/paint_parameters.hpp
@@ -32,7 +32,8 @@ public:
                     const EvaluatedLight&,
                     RenderStaticData&,
                     ImageManager&,
-                    LineAtlas&);
+                    LineAtlas&,
+                    TimePoint placementCommitTime);
 
     gl::Context& context;
     RendererBackend& backend;
@@ -49,6 +50,8 @@ public:
     MapDebugOptions debugOptions;
     GLContextMode contextMode;
     TimePoint timePoint;
+
+    float symbolFadeChange;
 
     float pixelRatio;
     std::array<float, 2> pixelsToGLUnits;

--- a/src/mbgl/renderer/renderer_impl.hpp
+++ b/src/mbgl/renderer/renderer_impl.hpp
@@ -10,6 +10,7 @@
 #include <mbgl/map/zoom_history.hpp>
 #include <mbgl/map/mode.hpp>
 #include <mbgl/text/glyph_manager_observer.hpp>
+#include <mbgl/text/placement.hpp>
 
 #include <memory>
 #include <string>
@@ -102,6 +103,8 @@ private:
     std::unordered_map<std::string, std::unique_ptr<RenderSource>> renderSources;
     std::unordered_map<std::string, std::unique_ptr<RenderLayer>> renderLayers;
     RenderLight renderLight;
+
+    std::unique_ptr<Placement> placement;
 
     bool contextLost = false;
 };

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -239,8 +239,8 @@ void Placement::updateBucketOpacities(SymbolBucket& bucket, gl::Context& context
                 }
             }
         };
-        updateCollisionBox(symbolInstance.textCollisionFeature, symbolInstance.placedText);
-        updateCollisionBox(symbolInstance.iconCollisionFeature, symbolInstance.placedIcon);
+        updateCollisionBox(symbolInstance.textCollisionFeature, opacityState.text.targetOpacity == 1.0);
+        updateCollisionBox(symbolInstance.iconCollisionFeature, opacityState.icon.targetOpacity == 1.0);
     }
 
     if (bucket.hasTextData()) context.updateVertexBuffer(*bucket.text.opacityVertexBuffer, std::move(bucket.text.opacityVertices));

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -11,7 +11,7 @@ namespace mbgl {
 OpacityState::OpacityState(float targetOpacity_) : opacity(0), targetOpacity(targetOpacity_) {}
 
 OpacityState::OpacityState(OpacityState& prevState, float increment, float targetOpacity) :
-    opacity(std::fmax(0, std::fmin(1, prevState.opacity + prevState.targetOpacity == 1.0 ? increment : -increment))),
+    opacity(std::fmax(0, std::fmin(1, prevState.opacity + (prevState.targetOpacity == 1.0 ? increment : -increment)))),
     targetOpacity(targetOpacity) {}
 
 bool OpacityState::isHidden() const {
@@ -155,8 +155,7 @@ void Placement::commit(std::unique_ptr<Placement> prevPlacement, TimePoint now) 
         }
 
     } else {
-        const Duration symbolFadeDuration(300);
-        float increment = (commitTime - prevPlacement->commitTime) / symbolFadeDuration;
+        float increment = std::chrono::duration<float>(commitTime - prevPlacement->commitTime) / Duration(std::chrono::milliseconds(300));
 
         // add the opacities from the current placement, and copy their current values from the previous placement
         for (auto& placementPair : placements) {

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -27,10 +27,13 @@ JointOpacityState::JointOpacityState(JointOpacityState& prevOpacityState, float 
     text(OpacityState(prevOpacityState.text, increment, textOpacity)) {}
 
 
+uint32_t Placement::maxCrossTileID = 0;
+
 Placement::Placement(const TransformState& state_) : collisionIndex(state_), state(state_) {}
 
 void Placement::placeLayer(RenderSymbolLayer& symbolLayer, bool showCollisionBoxes) {
     for (RenderTile& renderTile : symbolLayer.renderTiles) {
+
         if (!renderTile.tile.isRenderable()) {
             continue;
         }
@@ -83,11 +86,15 @@ void Placement::placeLayerBucket(
 
     for (auto& symbolInstance : bucket.symbolInstances) {
 
+        // TODO symbollayout handles a couple special cases related to this. copy those over if needed.
+        auto anchor = symbolInstance.anchor;
+        const bool withinPlus0 = anchor.point.x >= 0 && anchor.point.x < util::EXTENT && anchor.point.y >= 0 && anchor.point.y < util::EXTENT;
+        if (!withinPlus0) continue;
 
         bool placeText = false;
         bool placeIcon = false;
 
-        if (!symbolInstance.isDuplicate) {
+        if (true || !symbolInstance.isDuplicate) {
 
             if (symbolInstance.placedTextIndices.size()) {
                 assert(symbolInstance.placedTextIndices.size() != 0);
@@ -157,6 +164,7 @@ void Placement::commit(std::unique_ptr<Placement> prevPlacement, TimePoint now) 
     } else {
         float increment = std::chrono::duration<float>(commitTime - prevPlacement->commitTime) / Duration(std::chrono::milliseconds(300));
 
+        if (increment) {}
         // add the opacities from the current placement, and copy their current values from the previous placement
         for (auto& placementPair : placements) {
             auto prevOpacity = prevPlacement->opacities.find(placementPair.first);

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -61,8 +61,9 @@ namespace mbgl {
             TransformState state;
             TimePoint commitTime;
 
-            uint32_t maxCrossTileID = 0;
+            static uint32_t maxCrossTileID; // TODO remove
             std::unordered_map<uint32_t,PlacementPair> placements;
             std::unordered_map<uint32_t,JointOpacityState> opacities;
     };
+
 } // namespace mbgl


### PR DESCRIPTION
Box collisions are starting to look pretty good.

Circle collisions still look messed up:
 - Some line labels don't seem to have matching collision circles
 - Doesn't look like the right labels are getting marked as collided

On the plus side:
 - Collision circle colors match whether the label shows
 - Collision circle fading based on projected label size seems to be working as expected

Fade animations are working as long as you keep the map rendering.

/cc @ansis 