### PR TITLE
Start collision line labels

### DIFF
--- a/src/mbgl/text/collision_index.cpp
+++ b/src/mbgl/text/collision_index.cpp
@@ -198,7 +198,7 @@ bool CollisionIndex::placeLineFeature(CollisionFeature& feature,
         }
     }
 
-    return collisionDetected;
+    return !collisionDetected;
 }
 
 

--- a/src/mbgl/util/grid_index.hpp
+++ b/src/mbgl/util/grid_index.hpp
@@ -74,6 +74,9 @@ public:
     bool empty() const;
 
 private:
+    bool noIntersection(const BBox& query) const;
+    bool completeIntersection(const BBox& query) const;
+    BBox convertToBox(const BCircle& circle) const;
 
     void query(const BBox&, std::function<bool (const T&)>) const;
     void query(const BCircle&, std::function<bool (const T&)>) const;


### PR DESCRIPTION
Flip a boolean to make line label detection work.

Fix a smaller problem in grid index -- queries that are entirely outside the range of the grid should be ignored instead of running geometry tests for all the cells along the borders of the index.

/cc @ansis 