### PR TITLE
Hook up tile distance calculation.

### DIFF
--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -19,13 +19,12 @@ namespace mbgl {
 class PlacedSymbol {
 public:
     PlacedSymbol(Point<float> anchorPoint_, uint16_t segment_, float lowerSize_, float upperSize_,
-            std::array<float, 2> lineOffset_, bool useVerticalMode_, GeometryCoordinates line_) :
+            std::array<float, 2> lineOffset_, bool useVerticalMode_, const GeometryCoordinates& line_, const std::vector<float>& tileDistances_) :
         anchorPoint(anchorPoint_), segment(segment_), lowerSize(lowerSize_), upperSize(upperSize_),
-        lineOffset(lineOffset_), useVerticalMode(useVerticalMode_), line(std::move(line_))
+        lineOffset(lineOffset_), useVerticalMode(useVerticalMode_), line(line_), tileDistances(tileDistances_)
     {
         // TODO WIP hook these up
         writingMode = WritingModeType::None;
-        tileDistances = std::vector<float>(line.size());
         hidden = false;
     }
     Point<float> anchorPoint;

--- a/src/mbgl/text/collision_feature.hpp
+++ b/src/mbgl/text/collision_feature.hpp
@@ -11,8 +11,8 @@ namespace mbgl {
 
 class CollisionBox {
 public:
-    CollisionBox(Point<float> _anchor, Point<float> _offset, float _x1, float _y1, float _x2, float _y2, float _tileUnitDistanceToAnchor = 0, float _radius = 0) :
-        anchor(std::move(_anchor)), offset(_offset), x1(_x1), y1(_y1), x2(_x2), y2(_y2), used(true), tileUnitDistanceToAnchor(_tileUnitDistanceToAnchor), radius(_radius) {}
+    CollisionBox(Point<float> _anchor, Point<float> _offset, float _x1, float _y1, float _x2, float _y2, float _signedDistanceFromAnchor = 0, float _radius = 0) :
+        anchor(std::move(_anchor)), offset(_offset), x1(_x1), y1(_y1), x2(_x2), y2(_y2), used(true), signedDistanceFromAnchor(_signedDistanceFromAnchor), radius(_radius) {}
 
     // the box is centered around the anchor point
     Point<float> anchor;
@@ -36,7 +36,7 @@ public:
     float py;
     bool used;
 
-    float tileUnitDistanceToAnchor;
+    float signedDistanceFromAnchor;
     float radius;
 };
 

--- a/src/mbgl/text/collision_index.cpp
+++ b/src/mbgl/text/collision_index.cpp
@@ -130,10 +130,10 @@ bool CollisionIndex::placeLineFeature(CollisionFeature& feature,
     bool atLeastOneCirclePlaced = false;
     for (size_t i = 0; i < feature.boxes.size(); i++) {
         CollisionBox& circle = feature.boxes[i];
-        const float boxDistanceToAnchor = circle.tileUnitDistanceToAnchor;
+        const float boxSignedDistanceFromAnchor = circle.signedDistanceFromAnchor;
         if (!firstAndLastGlyph ||
-            (boxDistanceToAnchor < -firstTileDistance) ||
-            (boxDistanceToAnchor > lastTileDistance)) {
+            (boxSignedDistanceFromAnchor < -firstTileDistance) ||
+            (boxSignedDistanceFromAnchor > lastTileDistance)) {
             // The label either doesn't fit on its line or we
             // don't need to use this circle because the label
             // doesn't extend this far. Either way, mark the circle unused.
@@ -160,9 +160,9 @@ bool CollisionIndex::placeLineFeature(CollisionFeature& feature,
                 const bool atLeastOneMoreCircle = (i + 1) < feature.boxes.size();
                 if (atLeastOneMoreCircle) {
                     const CollisionBox& nextCircle = feature.boxes[i + 1];
-                    const float nextBoxDistanceToAnchor = nextCircle.tileUnitDistanceToAnchor;
-                    if ((nextBoxDistanceToAnchor > -firstTileDistance) &&
-                    (nextBoxDistanceToAnchor < lastTileDistance)) {
+                    const float nextBoxDistanceFromAnchor = nextCircle.signedDistanceFromAnchor;
+                    if ((nextBoxDistanceFromAnchor > -firstTileDistance) &&
+                    (nextBoxDistanceFromAnchor < lastTileDistance)) {
                         // Hide significantly overlapping circles, unless this is the last one we can
                         // use, in which case we want to keep it in place even if it's tightly packed
                         // with the one before it.


### PR DESCRIPTION
Collision circles should now agree with labels pretty well even in pitched views. @ansis 