### PR TITLE
fix collisions for overscaled tiles, and flickering

### DIFF
--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -367,7 +367,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
     auto newPlacement = std::make_unique<Placement>(parameters.state);
     for (auto it = order.rbegin(); it != order.rend(); ++it) {
         if (it->layer.is<RenderSymbolLayer>()) {
-            newPlacement->placeLayer(*it->layer.as<RenderSymbolLayer>(), parameters.debugOptions & MapDebugOptions::Collision);
+            newPlacement->placeLayer(*it->layer.as<RenderSymbolLayer>(), parameters.projMatrix, parameters.debugOptions & MapDebugOptions::Collision);
         }
     }
 

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -51,6 +51,8 @@ void Placement::placeLayer(RenderSymbolLayer& symbolLayer, const mat4& projMatri
 
         const float scale = std::pow(2, state.getZoom() - renderTile.id.canonical.z);
 
+        const float pixelRatio = util::EXTENT / (util::tileSize * renderTile.tile.id.overscaleFactor());
+
         mat4 posMatrix;
         state.matrixFor(posMatrix, renderTile.id);
         matrix::multiply(posMatrix, projMatrix, posMatrix);
@@ -67,7 +69,7 @@ void Placement::placeLayer(RenderSymbolLayer& symbolLayer, const mat4& projMatri
                 state,
                 pixelsToTileUnits);
 
-        placeLayerBucket(symbolBucket, posMatrix, textLabelPlaneMatrix, iconLabelPlaneMatrix, scale, showCollisionBoxes);
+        placeLayerBucket(symbolBucket, posMatrix, textLabelPlaneMatrix, iconLabelPlaneMatrix, scale, pixelRatio, showCollisionBoxes);
     }
 }
 
@@ -77,6 +79,7 @@ void Placement::placeLayerBucket(
         const mat4& textLabelPlaneMatrix,
         const mat4& iconLabelPlaneMatrix,
         const float scale,
+        const float pixelRatio,
         const bool showCollisionBoxes) {
 
     // TODO collision debug array clearing
@@ -86,7 +89,6 @@ void Placement::placeLayerBucket(
 
     const bool iconWithoutText = !bucket.hasTextData() || bucket.layout.get<TextOptional>();
     const bool textWithoutIcon = !bucket.hasIconData() || bucket.layout.get<IconOptional>();
-    float pixelRatio = util::EXTENT / util::tileSize;
 
     for (auto& symbolInstance : bucket.symbolInstances) {
 
@@ -108,7 +110,7 @@ void Placement::placeLayerBucket(
 
                 placeText = collisionIndex.placeFeature(symbolInstance.textCollisionFeature,
                         posMatrix, textLabelPlaneMatrix, pixelRatio,
-                        placedSymbol,scale, fontSize,
+                        placedSymbol, scale, fontSize,
                         bucket.layout.get<TextAllowOverlap>(),
                         bucket.layout.get<TextPitchAlignment>() == style::AlignmentType::Map,
                         showCollisionBoxes);

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -34,7 +34,7 @@ uint32_t Placement::maxCrossTileID = 0;
 
 Placement::Placement(const TransformState& state_) : collisionIndex(state_), state(state_) {}
 
-void Placement::placeLayer(RenderSymbolLayer& symbolLayer, bool showCollisionBoxes) {
+void Placement::placeLayer(RenderSymbolLayer& symbolLayer, const mat4& projMatrix, bool showCollisionBoxes) {
     for (RenderTile& renderTile : symbolLayer.renderTiles) {
 
         if (!renderTile.tile.isRenderable()) {
@@ -51,6 +51,10 @@ void Placement::placeLayer(RenderSymbolLayer& symbolLayer, bool showCollisionBox
 
         const float scale = std::pow(2, state.getZoom() - renderTile.id.canonical.z);
 
+        mat4 posMatrix;
+        state.matrixFor(posMatrix, renderTile.id);
+        matrix::multiply(posMatrix, projMatrix, posMatrix);
+
         mat4 textLabelPlaneMatrix = getLabelPlaneMatrix(renderTile.matrix,
                 layout.get<TextPitchAlignment>() == style::AlignmentType::Map,
                 layout.get<TextRotationAlignment>() == style::AlignmentType::Map,
@@ -63,7 +67,7 @@ void Placement::placeLayer(RenderSymbolLayer& symbolLayer, bool showCollisionBox
                 state,
                 pixelsToTileUnits);
 
-        placeLayerBucket(symbolBucket, renderTile.matrix, textLabelPlaneMatrix, iconLabelPlaneMatrix, scale, showCollisionBoxes);
+        placeLayerBucket(symbolBucket, posMatrix, textLabelPlaneMatrix, iconLabelPlaneMatrix, scale, showCollisionBoxes);
     }
 }
 

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -54,6 +54,7 @@ namespace mbgl {
                     const mat4& textLabelPlaneMatrix,
                     const mat4& iconLabelPlaneMatrix,
                     const float scale,
+                    const float pixelRatio,
                     const bool showCollisionBoxes);
 
             void updateBucketOpacities(SymbolBucket&);

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -39,7 +39,7 @@ namespace mbgl {
     class Placement {
         public:
             Placement(const TransformState&);
-            void placeLayer(RenderSymbolLayer&, bool showCollisionBoxes);
+            void placeLayer(RenderSymbolLayer&, const mat4&, bool showCollisionBoxes);
             bool commit(const Placement& prevPlacement, TimePoint);
             void updateLayerOpacities(RenderSymbolLayer&);
             JointOpacityState getOpacity(uint32_t crossTileSymbolID) const;


### PR DESCRIPTION
The first commit fixes the occasional flickering of hidden labels.
The second commit fixes collisions in overscaled tiles.

@ChrisLoer 