### PR TITLE
Resize logo based on snapshot size

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnaphotUtil.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnaphotUtil.java
@@ -1,0 +1,29 @@
+package com.mapbox.mapboxsdk.snapshotter;
+
+import android.graphics.BitmapFactory;
+
+class MapSnaphotUtil {
+
+  static int calculateInSampleSize(BitmapFactory.Options options, int reqWidth, int reqHeight) {
+    // Raw height and width of image
+    final int height = options.outHeight;
+    final int width = options.outWidth;
+    int inSampleSize = 1;
+
+    if (height > reqHeight || width > reqWidth) {
+
+      final int halfHeight = height / 2;
+      final int halfWidth = width / 2;
+
+      // Calculate the largest inSampleSize value that is a power of 2 and keeps both
+      // height and width larger than the requested height and width.
+      while ((halfHeight / inSampleSize) >= reqHeight
+        && (halfWidth / inSampleSize) >= reqWidth) {
+        inSampleSize *= 2;
+      }
+    }
+    return inSampleSize;
+  }
+
+
+}


### PR DESCRIPTION
closes #10036, currently targets #10163 but can be retargeted. 