### PR TITLE
[gcc4.9] Keep compatibility with GCC + Android

### DIFF
--- a/include/mbgl/util/projection.hpp
+++ b/include/mbgl/util/projection.hpp
@@ -92,8 +92,8 @@ public:
         const double t2z = tileSize * std::pow(2, zoom);
         Point<double> pt = project_(point, t2z);
         // Flip y coordinate
-        auto x = std::round(std::min(pt.x, t2z));
-        auto y = std::round(std::min(t2z - pt.y, t2z));
+        auto x = ::round(std::min(pt.x, t2z));
+        auto y = ::round(std::min(t2z - pt.y, t2z));
         return { x, y };
     }
 private:

--- a/src/mbgl/util/tile_cover.cpp
+++ b/src/mbgl/util/tile_cover.cpp
@@ -182,10 +182,10 @@ uint64_t tileCount(const LatLngBounds& bounds, uint8_t zoom, uint16_t tileSize_)
     auto y1 = floor(sw.y/ tileSize_);
     auto y2 = floor((ne.y - 1) / tileSize_);
 
-    auto minX = std::fmax(std::min(x1, x2), 0);
+    auto minX = ::fmax(std::min(x1, x2), 0);
     auto maxX = std::max(x1, x2);
     auto minY = (std::pow(2, zoom) - 1) - std::max(y1, y2);
-    auto maxY = (std::pow(2, zoom) - 1) - std::fmax(std::min(y1, y2), 0);
+    auto maxY = (std::pow(2, zoom) - 1) - ::fmax(std::min(y1, y2), 0);
     
     return (maxX - minX + 1) * (maxY - minY + 1);
 }


### PR DESCRIPTION
Needed by Qt builds on Android. These functions are not on the `std::` namespace there.