### PR TITLE
Implement vertical text and queryRenderedSymbols

### DIFF
--- a/src/mbgl/annotation/render_annotation_source.cpp
+++ b/src/mbgl/annotation/render_annotation_source.cpp
@@ -61,8 +61,9 @@ std::unordered_map<std::string, std::vector<Feature>>
 RenderAnnotationSource::queryRenderedFeatures(const ScreenLineString& geometry,
                                               const TransformState& transformState,
                                               const std::vector<const RenderLayer*>& layers,
-                                              const RenderedQueryOptions& options) const {
-    return tilePyramid.queryRenderedFeatures(geometry, transformState, layers, options);
+                                              const RenderedQueryOptions& options,
+                                              const CollisionIndex& collisionIndex) const {
+    return tilePyramid.queryRenderedFeatures(geometry, transformState, layers, options, collisionIndex);
 }
 
 std::vector<Feature> RenderAnnotationSource::querySourceFeatures(const SourceQueryOptions&) const {

--- a/src/mbgl/annotation/render_annotation_source.hpp
+++ b/src/mbgl/annotation/render_annotation_source.hpp
@@ -27,7 +27,8 @@ public:
     queryRenderedFeatures(const ScreenLineString& geometry,
                           const TransformState& transformState,
                           const std::vector<const RenderLayer*>& layers,
-                          const RenderedQueryOptions& options) const final;
+                          const RenderedQueryOptions& options,
+                          const CollisionIndex& collisionIndex) const final;
 
     std::vector<Feature>
     querySourceFeatures(const SourceQueryOptions&) const final;

--- a/src/mbgl/geometry/feature_index.cpp
+++ b/src/mbgl/geometry/feature_index.cpp
@@ -28,7 +28,7 @@ void FeatureIndex::insert(const GeometryCollection& geometries,
     for (const auto& ring : geometries) {
         // TODO: Templatize grid units so feature index can stick with integers?
         auto envelope = mapbox::geometry::envelope(ring);
-        grid.insert(IndexedSubfeature { index, sourceLayerName, bucketName, sortIndex++, 0, 0, 0, 0, 0 }, // TODO: FeatureIndex doesn't need to care about tileIDs, make this cleaner
+        grid.insert(IndexedSubfeature { index, "", sourceLayerName, bucketName, sortIndex++, 0, 0, 0, 0, 0 }, // TODO: FeatureIndex doesn't need to care about tileIDs or source IDS, make this cleaner
                     {convertPoint<float>(envelope.min), convertPoint<float>(envelope.max)});
     }
 }
@@ -50,6 +50,7 @@ void FeatureIndex::query(
         const RenderedQueryOptions& queryOptions,
         const GeometryTileData& geometryTileData,
         const CanonicalTileID& tileID,
+        const std::string& sourceID,
         const std::vector<const RenderLayer*>& layers,
         const CollisionIndex& collisionIndex,
         const float additionalQueryRadius) const {
@@ -81,7 +82,7 @@ void FeatureIndex::query(
         addFeature(result, indexedFeature, queryGeometry, queryOptions, geometryTileData, tileID, layers, bearing, pixelsToTileUnits);
     }
 
-    std::vector<IndexedSubfeature> symbolFeatures = collisionIndex.queryRenderedSymbols(queryGeometry, UnwrappedTileID(0, tileID)); // TODO: hook up
+    std::vector<IndexedSubfeature> symbolFeatures = collisionIndex.queryRenderedSymbols(queryGeometry, UnwrappedTileID(0, tileID), sourceID); // TODO: hook up
     std::sort(symbolFeatures.begin(), symbolFeatures.end(), topDownSymbols);
     for (const auto& symbolFeature : symbolFeatures) {
         addFeature(result, symbolFeature, queryGeometry, queryOptions, geometryTileData, tileID, layers, bearing, pixelsToTileUnits);

--- a/src/mbgl/geometry/feature_index.cpp
+++ b/src/mbgl/geometry/feature_index.cpp
@@ -28,7 +28,7 @@ void FeatureIndex::insert(const GeometryCollection& geometries,
     for (const auto& ring : geometries) {
         // TODO: Templatize grid units so feature index can stick with integers?
         auto envelope = mapbox::geometry::envelope(ring);
-        grid.insert(IndexedSubfeature { index, "", sourceLayerName, bucketName, sortIndex++, 0, 0, 0, 0, 0 }, // TODO: FeatureIndex doesn't need to care about tileIDs or source IDS, make this cleaner
+        grid.insert(IndexedSubfeature { index, "", sourceLayerName, bucketName, sortIndex++, 0, 0, 0 }, // TODO: FeatureIndex doesn't need to care about tileIDs or source IDS, make this cleaner
                     {convertPoint<float>(envelope.min), convertPoint<float>(envelope.max)});
     }
 }
@@ -82,7 +82,7 @@ void FeatureIndex::query(
         addFeature(result, indexedFeature, queryGeometry, queryOptions, geometryTileData, tileID, layers, bearing, pixelsToTileUnits);
     }
 
-    std::vector<IndexedSubfeature> symbolFeatures = collisionIndex.queryRenderedSymbols(queryGeometry, UnwrappedTileID(0, tileID), sourceID); // TODO: hook up
+    std::vector<IndexedSubfeature> symbolFeatures = collisionIndex.queryRenderedSymbols(queryGeometry, tileID, sourceID);
     std::sort(symbolFeatures.begin(), symbolFeatures.end(), topDownSymbols);
     for (const auto& symbolFeature : symbolFeatures) {
         addFeature(result, symbolFeature, queryGeometry, queryOptions, geometryTileData, tileID, layers, bearing, pixelsToTileUnits);

--- a/src/mbgl/geometry/feature_index.cpp
+++ b/src/mbgl/geometry/feature_index.cpp
@@ -28,7 +28,7 @@ void FeatureIndex::insert(const GeometryCollection& geometries,
     for (const auto& ring : geometries) {
         // TODO: Templatize grid units so feature index can stick with integers?
         auto envelope = mapbox::geometry::envelope(ring);
-        grid.insert(IndexedSubfeature { index, sourceLayerName, bucketName, sortIndex++ },
+        grid.insert(IndexedSubfeature { index, sourceLayerName, bucketName, sortIndex++, 0, 0, 0, 0, 0 }, // TODO: FeatureIndex doesn't need to care about tileIDs, make this cleaner
                     {convertPoint<float>(envelope.min), convertPoint<float>(envelope.max)});
     }
 }

--- a/src/mbgl/geometry/feature_index.hpp
+++ b/src/mbgl/geometry/feature_index.hpp
@@ -28,8 +28,6 @@ public:
     uint8_t z;
     uint32_t x;
     uint32_t y;
-    uint8_t overscaledZ;
-    int16_t wrap;
 };
 
 class FeatureIndex {

--- a/src/mbgl/geometry/feature_index.hpp
+++ b/src/mbgl/geometry/feature_index.hpp
@@ -21,6 +21,7 @@ class IndexedSubfeature {
 public:
     IndexedSubfeature() = delete;
     std::size_t index;
+    std::string sourceID;
     std::string sourceLayerName;
     std::string bucketName;
     size_t sortIndex;
@@ -46,6 +47,7 @@ public:
             const RenderedQueryOptions& options,
             const GeometryTileData&,
             const CanonicalTileID&,
+            const std::string&,
             const std::vector<const RenderLayer*>&,
             const CollisionIndex&,
             const float additionalQueryRadius) const;

--- a/src/mbgl/geometry/feature_index.hpp
+++ b/src/mbgl/geometry/feature_index.hpp
@@ -47,7 +47,7 @@ public:
             const GeometryTileData&,
             const CanonicalTileID&,
             const std::vector<const RenderLayer*>&,
-            const CollisionIndex*,
+            const CollisionIndex&,
             const float additionalQueryRadius) const;
 
     static optional<GeometryCoordinates> translateQueryGeometry(

--- a/src/mbgl/geometry/feature_index.hpp
+++ b/src/mbgl/geometry/feature_index.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/style/types.hpp>
 #include <mbgl/tile/geometry_tile_data.hpp>
+#include <mbgl/tile/tile_id.hpp>
 #include <mbgl/util/grid_index.hpp>
 #include <mbgl/util/feature.hpp>
 
@@ -15,7 +16,6 @@ class RenderedQueryOptions;
 class RenderLayer;
 
 class CollisionIndex;
-class CanonicalTileID;
 
 class IndexedSubfeature {
 public:
@@ -24,6 +24,11 @@ public:
     std::string sourceLayerName;
     std::string bucketName;
     size_t sortIndex;
+    uint8_t z;
+    uint32_t x;
+    uint32_t y;
+    uint8_t overscaledZ;
+    int16_t wrap;
 };
 
 class FeatureIndex {

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -226,15 +226,21 @@ void Context::updateVertexBuffer(UniqueBuffer& buffer, const void* data, std::si
     MBGL_CHECK_ERROR(glBufferSubData(GL_ARRAY_BUFFER, 0, size, data));
 }
 
-UniqueBuffer Context::createIndexBuffer(const void* data, std::size_t size) {
+UniqueBuffer Context::createIndexBuffer(const void* data, std::size_t size, const BufferUsage usage) {
     BufferID id = 0;
     MBGL_CHECK_ERROR(glGenBuffers(1, &id));
     UniqueBuffer result { std::move(id), { this } };
     bindVertexArray = 0;
     globalVertexArrayState.indexBuffer = result;
-    MBGL_CHECK_ERROR(glBufferData(GL_ELEMENT_ARRAY_BUFFER, size, data, GL_STATIC_DRAW));
+    MBGL_CHECK_ERROR(glBufferData(GL_ELEMENT_ARRAY_BUFFER, size, data, static_cast<GLenum>(usage)));
     return result;
 }
+
+void Context::updateIndexBuffer(UniqueBuffer& buffer, const void* data, std::size_t size) {
+    globalVertexArrayState.indexBuffer = buffer;
+    MBGL_CHECK_ERROR(glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, 0, size, data));
+}
+
 
 UniqueTexture Context::createTexture() {
     if (pooledTextures.empty()) {

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -75,10 +75,17 @@ public:
     }
 
     template <class DrawMode>
-    IndexBuffer<DrawMode> createIndexBuffer(IndexVector<DrawMode>&& v) {
+    IndexBuffer<DrawMode> createIndexBuffer(IndexVector<DrawMode>&& v, const BufferUsage usage=BufferUsage::StaticDraw) {
         return IndexBuffer<DrawMode> {
-            createIndexBuffer(v.data(), v.byteSize())
+            v.indexSize(),
+            createIndexBuffer(v.data(), v.byteSize(), usage)
         };
+    }
+    
+    template <class DrawMode>
+    void updateIndexBuffer(IndexBuffer<DrawMode>& buffer, IndexVector<DrawMode>&& v) {
+        assert(v.indexSize() == buffer.indexCount);
+        updateIndexBuffer(buffer.buffer, v.data(), v.byteSize());
     }
 
     template <RenderbufferType type>
@@ -250,7 +257,8 @@ private:
 
     UniqueBuffer createVertexBuffer(const void* data, std::size_t size, const BufferUsage usage);
     void updateVertexBuffer(UniqueBuffer& buffer, const void* data, std::size_t size);
-    UniqueBuffer createIndexBuffer(const void* data, std::size_t size);
+    UniqueBuffer createIndexBuffer(const void* data, std::size_t size, const BufferUsage usage);
+    void updateIndexBuffer(UniqueBuffer& buffer, const void* data, std::size_t size);
     UniqueTexture createTexture(Size size, const void* data, TextureFormat, TextureUnit);
     void updateTexture(TextureID, Size size, const void* data, TextureFormat, TextureUnit);
     UniqueFramebuffer createFramebuffer();

--- a/src/mbgl/gl/index_buffer.hpp
+++ b/src/mbgl/gl/index_buffer.hpp
@@ -35,6 +35,7 @@ private:
 template <class DrawMode>
 class IndexBuffer {
 public:
+    std::size_t indexCount;
     UniqueBuffer buffer;
 };
 

--- a/src/mbgl/layout/symbol_instance.cpp
+++ b/src/mbgl/layout/symbol_instance.cpp
@@ -32,7 +32,7 @@ SymbolInstance::SymbolInstance(Anchor& anchor_,
     hasIcon(shapedIcon),
 
     // Create the collision features that will be used to check whether this symbol instance can be placed
-    textCollisionFeature(line_, anchor, shapedTextOrientations.second ?: shapedTextOrientations.first, textBoxScale, textPadding, textPlacement, indexedFeature),
+    textCollisionFeature(line_, anchor, shapedTextOrientations.first, textBoxScale, textPadding, textPlacement, indexedFeature),
     iconCollisionFeature(line_, anchor, shapedIcon, iconBoxScale, iconPadding, SymbolPlacementType::Point, indexedFeature),
     featureIndex(featureIndex_),
     textOffset(textOffset_),
@@ -45,12 +45,10 @@ SymbolInstance::SymbolInstance(Anchor& anchor_,
             iconQuad = getIconQuad(*shapedIcon, layout, layoutTextSize, shapedTextOrientations.first);
         }
         if (shapedTextOrientations.first) {
-            auto quads = getGlyphQuads(shapedTextOrientations.first, layout, textPlacement, positions);
-            glyphQuads.insert(glyphQuads.end(), quads.begin(), quads.end());
+            horizontalGlyphQuads = getGlyphQuads(shapedTextOrientations.first, layout, textPlacement, positions);
         }
         if (shapedTextOrientations.second) {
-            auto quads = getGlyphQuads(shapedTextOrientations.second, layout, textPlacement, positions);
-            glyphQuads.insert(glyphQuads.end(), quads.begin(), quads.end());
+            verticalGlyphQuads = getGlyphQuads(shapedTextOrientations.second, layout, textPlacement, positions);
         }
     }
 

--- a/src/mbgl/layout/symbol_instance.hpp
+++ b/src/mbgl/layout/symbol_instance.hpp
@@ -39,7 +39,8 @@ public:
     uint32_t index;
     bool hasText;
     bool hasIcon;
-    SymbolQuads glyphQuads;
+    SymbolQuads horizontalGlyphQuads;
+    SymbolQuads verticalGlyphQuads;
     optional<SymbolQuad> iconQuad;
     CollisionFeature textCollisionFeature;
     CollisionFeature iconCollisionFeature;

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -178,7 +178,8 @@ bool SymbolLayout::hasSymbolInstances() const {
 }
 
 void SymbolLayout::prepare(const GlyphMap& glyphMap, const GlyphPositions& glyphPositions,
-                           const ImageMap& imageMap, const ImagePositions& imagePositions) {
+                           const ImageMap& imageMap, const ImagePositions& imagePositions,
+                           const OverscaledTileID& tileID) {
     const bool textAlongLine = layout.get<TextRotationAlignment>() == AlignmentType::Map &&
         layout.get<SymbolPlacement>() == SymbolPlacementType::Line;
 
@@ -247,7 +248,7 @@ void SymbolLayout::prepare(const GlyphMap& glyphMap, const GlyphPositions& glyph
 
         // if either shapedText or icon position is present, add the feature
         if (shapedTextOrientations.first || shapedIcon) {
-            addFeature(std::distance(features.begin(), it), feature, shapedTextOrientations, shapedIcon, glyphPositionMap);
+            addFeature(std::distance(features.begin(), it), feature, shapedTextOrientations, shapedIcon, glyphPositionMap, tileID);
         }
         
         feature.geometry.clear();
@@ -260,7 +261,8 @@ void SymbolLayout::addFeature(const std::size_t index,
                               const SymbolFeature& feature,
                               const std::pair<Shaping, Shaping>& shapedTextOrientations,
                               optional<PositionedIcon> shapedIcon,
-                              const GlyphPositionMap& glyphPositionMap) {
+                              const GlyphPositionMap& glyphPositionMap,
+                              const OverscaledTileID& tileID) {
     const float minScale = 0.5f;
     const float glyphSize = 24.0f;
     
@@ -292,7 +294,7 @@ void SymbolLayout::addFeature(const std::size_t index,
                                                   : layout.get<SymbolPlacement>();
     const float textRepeatDistance = symbolSpacing / 2;
     IndexedSubfeature indexedFeature = { feature.index, sourceLayer->getName(), bucketName,
-                                         symbolInstances.size() };
+                                         symbolInstances.size(), tileID.canonical.z, tileID.canonical.x, tileID.canonical.y, tileID.overscaledZ, tileID.wrap };
 
     auto addSymbolInstance = [&] (const GeometryCoordinates& line, Anchor& anchor) {
         // https://github.com/mapbox/vector-tile-spec/tree/master/2.1#41-layers

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -417,7 +417,10 @@ std::vector<float> CalculateTileDistances(const GeometryCoordinates& line, const
 }
 
 std::unique_ptr<SymbolBucket> SymbolLayout::place(const bool showCollisionBoxes) {
-    auto bucket = std::make_unique<SymbolBucket>(layout, layerPaintProperties, textSize, iconSize, zoom, sdfIcons, iconsNeedLinear, symbolInstances);
+    const bool mayOverlap = layout.get<TextAllowOverlap>() || layout.get<IconAllowOverlap>() ||
+        layout.get<TextIgnorePlacement>() || layout.get<IconIgnorePlacement>();
+    
+    auto bucket = std::make_unique<SymbolBucket>(layout, layerPaintProperties, textSize, iconSize, zoom, sdfIcons, iconsNeedLinear, mayOverlap, symbolInstances);
 
     // this iterates over the *bucket's* symbol instances so that it can set the placedsymbol index. TODO cleanup
     for (SymbolInstance &symbolInstance : bucket->symbolInstances) {
@@ -502,6 +505,7 @@ void SymbolLayout::addSymbol(Buffer& buffer,
     auto& segment = buffer.segments.back();
     assert(segment.vertexLength <= std::numeric_limits<uint16_t>::max());
     uint16_t index = segment.vertexLength;
+    placedSymbol.vertexStartIndex = index;
 
     // coordinates (2 triangles)
     buffer.vertices.emplace_back(SymbolLayoutAttributes::vertex(labelAnchor.point, tl, symbol.glyphOffset.y, tex.x, tex.y, sizeData));

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -295,7 +295,7 @@ void SymbolLayout::addFeature(const std::size_t index,
                                                   : layout.get<SymbolPlacement>();
     const float textRepeatDistance = symbolSpacing / 2;
     IndexedSubfeature indexedFeature = { feature.index, sourceID, sourceLayer->getName(), bucketName,
-                                         symbolInstances.size(), tileID.canonical.z, tileID.canonical.x, tileID.canonical.y, tileID.overscaledZ, tileID.wrap };
+                                         symbolInstances.size(), tileID.canonical.z, tileID.canonical.x, tileID.canonical.y };
 
     auto addSymbolInstance = [&] (const GeometryCoordinates& line, Anchor& anchor) {
         // https://github.com/mapbox/vector-tile-spec/tree/master/2.1#41-layers

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -179,7 +179,7 @@ bool SymbolLayout::hasSymbolInstances() const {
 
 void SymbolLayout::prepare(const GlyphMap& glyphMap, const GlyphPositions& glyphPositions,
                            const ImageMap& imageMap, const ImagePositions& imagePositions,
-                           const OverscaledTileID& tileID) {
+                           const OverscaledTileID& tileID, const std::string& sourceID) {
     const bool textAlongLine = layout.get<TextRotationAlignment>() == AlignmentType::Map &&
         layout.get<SymbolPlacement>() == SymbolPlacementType::Line;
 
@@ -248,7 +248,7 @@ void SymbolLayout::prepare(const GlyphMap& glyphMap, const GlyphPositions& glyph
 
         // if either shapedText or icon position is present, add the feature
         if (shapedTextOrientations.first || shapedIcon) {
-            addFeature(std::distance(features.begin(), it), feature, shapedTextOrientations, shapedIcon, glyphPositionMap, tileID);
+            addFeature(std::distance(features.begin(), it), feature, shapedTextOrientations, shapedIcon, glyphPositionMap, tileID, sourceID);
         }
         
         feature.geometry.clear();
@@ -262,7 +262,8 @@ void SymbolLayout::addFeature(const std::size_t index,
                               const std::pair<Shaping, Shaping>& shapedTextOrientations,
                               optional<PositionedIcon> shapedIcon,
                               const GlyphPositionMap& glyphPositionMap,
-                              const OverscaledTileID& tileID) {
+                              const OverscaledTileID& tileID,
+                              const std::string& sourceID) {
     const float minScale = 0.5f;
     const float glyphSize = 24.0f;
     
@@ -293,7 +294,7 @@ void SymbolLayout::addFeature(const std::size_t index,
                                                   ? SymbolPlacementType::Point
                                                   : layout.get<SymbolPlacement>();
     const float textRepeatDistance = symbolSpacing / 2;
-    IndexedSubfeature indexedFeature = { feature.index, sourceLayer->getName(), bucketName,
+    IndexedSubfeature indexedFeature = { feature.index, sourceID, sourceLayer->getName(), bucketName,
                                          symbolInstances.size(), tileID.canonical.z, tileID.canonical.x, tileID.canonical.y, tileID.overscaledZ, tileID.wrap };
 
     auto addSymbolInstance = [&] (const GeometryCoordinates& line, Anchor& anchor) {

--- a/src/mbgl/layout/symbol_layout.hpp
+++ b/src/mbgl/layout/symbol_layout.hpp
@@ -63,8 +63,6 @@ private:
     void addSymbol(Buffer&,
                    const Range<float> sizeData,
                    const SymbolQuad&,
-                   const bool keepUpright,
-                   const style::SymbolPlacementType,
                    const Anchor& labelAnchor,
                    PlacedSymbol& placedSymbol);
 

--- a/src/mbgl/layout/symbol_layout.hpp
+++ b/src/mbgl/layout/symbol_layout.hpp
@@ -34,7 +34,8 @@ public:
                  GlyphDependencies&);
 
     void prepare(const GlyphMap&, const GlyphPositions&,
-                                          const ImageMap&, const ImagePositions&, const OverscaledTileID&);
+                 const ImageMap&, const ImagePositions&,
+                 const OverscaledTileID&, const std::string&);
 
     std::unique_ptr<SymbolBucket> place(const bool showCollisionBoxes);
 
@@ -52,7 +53,8 @@ private:
                     const std::pair<Shaping, Shaping>& shapedTextOrientations,
                     optional<PositionedIcon> shapedIcon,
                     const GlyphPositionMap&,
-                    const OverscaledTileID&);
+                    const OverscaledTileID&,
+                    const std::string&);
 
     bool anchorIsTooClose(const std::u16string& text, const float repeatDistance, const Anchor&);
     std::map<std::u16string, std::vector<Anchor>> compareText;

--- a/src/mbgl/layout/symbol_layout.hpp
+++ b/src/mbgl/layout/symbol_layout.hpp
@@ -34,7 +34,7 @@ public:
                  GlyphDependencies&);
 
     void prepare(const GlyphMap&, const GlyphPositions&,
-                                          const ImageMap&, const ImagePositions&);
+                                          const ImageMap&, const ImagePositions&, const OverscaledTileID&);
 
     std::unique_ptr<SymbolBucket> place(const bool showCollisionBoxes);
 
@@ -51,7 +51,8 @@ private:
                     const SymbolFeature&,
                     const std::pair<Shaping, Shaping>& shapedTextOrientations,
                     optional<PositionedIcon> shapedIcon,
-                    const GlyphPositionMap&);
+                    const GlyphPositionMap&,
+                    const OverscaledTileID&);
 
     bool anchorIsTooClose(const std::u16string& text, const float repeatDistance, const Anchor&);
     std::map<std::u16string, std::vector<Anchor>> compareText;

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -21,7 +21,7 @@ public:
     PlacedSymbol(Point<float> anchorPoint_, uint16_t segment_, float lowerSize_, float upperSize_,
             std::array<float, 2> lineOffset_, WritingModeType writingModes_, const GeometryCoordinates& line_, const std::vector<float>& tileDistances_) :
         anchorPoint(anchorPoint_), segment(segment_), lowerSize(lowerSize_), upperSize(upperSize_),
-        lineOffset(lineOffset_), writingModes(writingModes_), line(line_), tileDistances(tileDistances_), hidden(false)
+        lineOffset(lineOffset_), writingModes(writingModes_), line(line_), tileDistances(tileDistances_), hidden(false), vertexStartIndex(0)
     {
     }
     Point<float> anchorPoint;
@@ -34,6 +34,7 @@ public:
     std::vector<float> tileDistances;
     std::vector<float> glyphOffsets;
     bool hidden;
+    size_t vertexStartIndex;
 };
 
 class SymbolBucket : public Bucket {
@@ -45,6 +46,7 @@ public:
                  float zoom,
                  bool sdfIcons,
                  bool iconsNeedLinear,
+                 bool sortFeaturesByY,
                  const std::vector<SymbolInstance>&);
 
     void upload(gl::Context&) override;
@@ -53,15 +55,21 @@ public:
     bool hasIconData() const;
     bool hasCollisionBoxData() const;
     bool hasCollisionCircleData() const;
+    
     void updateOpacity();
+    void sortFeatures(const float angle);
 
     const style::SymbolLayoutProperties::PossiblyEvaluated layout;
     const bool sdfIcons;
     const bool iconsNeedLinear;
+    const bool sortFeaturesByY;
+    
+    float sortedAngle = 0;
 
     bool staticUploaded = false;
     bool opacityUploaded = false;
     bool dynamicUploaded = false;
+    bool sortUploaded = false;
 
     std::vector<SymbolInstance> symbolInstances;
 

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -19,24 +19,20 @@ namespace mbgl {
 class PlacedSymbol {
 public:
     PlacedSymbol(Point<float> anchorPoint_, uint16_t segment_, float lowerSize_, float upperSize_,
-            std::array<float, 2> lineOffset_, bool useVerticalMode_, const GeometryCoordinates& line_, const std::vector<float>& tileDistances_) :
+            std::array<float, 2> lineOffset_, WritingModeType writingModes_, const GeometryCoordinates& line_, const std::vector<float>& tileDistances_) :
         anchorPoint(anchorPoint_), segment(segment_), lowerSize(lowerSize_), upperSize(upperSize_),
-        lineOffset(lineOffset_), useVerticalMode(useVerticalMode_), line(line_), tileDistances(tileDistances_)
+        lineOffset(lineOffset_), writingModes(writingModes_), line(line_), tileDistances(tileDistances_), hidden(false)
     {
-        // TODO WIP hook these up
-        writingMode = WritingModeType::None;
-        hidden = false;
     }
     Point<float> anchorPoint;
     uint16_t segment;
     float lowerSize;
     float upperSize;
     std::array<float, 2> lineOffset;
-    bool useVerticalMode;
+    WritingModeType writingModes;
     GeometryCoordinates line;
     std::vector<float> tileDistances;
     std::vector<float> glyphOffsets;
-    WritingModeType writingMode;
     bool hidden;
 };
 

--- a/src/mbgl/renderer/render_source.hpp
+++ b/src/mbgl/renderer/render_source.hpp
@@ -24,6 +24,7 @@ class SourceQueryOptions;
 class Tile;
 class RenderSourceObserver;
 class TileParameters;
+class CollisionIndex;
 
 class RenderSource : protected TileObserver {
 public:
@@ -63,7 +64,8 @@ public:
     queryRenderedFeatures(const ScreenLineString& geometry,
                           const TransformState& transformState,
                           const std::vector<const RenderLayer*>& layers,
-                          const RenderedQueryOptions& options) const = 0;
+                          const RenderedQueryOptions& options,
+                          const CollisionIndex& collisionIndex) const = 0;
 
     virtual std::vector<Feature>
     querySourceFeatures(const SourceQueryOptions&) const = 0;

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -631,7 +631,7 @@ std::vector<Feature> Renderer::Impl::queryRenderedFeatures(const ScreenLineStrin
     std::unordered_map<std::string, std::vector<Feature>> resultsByLayer;
     for (const auto& sourceID : sourceIDs) {
         if (RenderSource* renderSource = getRenderSource(sourceID)) {
-            auto sourceResults = renderSource->queryRenderedFeatures(geometry, transformState, layers, options);
+            auto sourceResults = renderSource->queryRenderedFeatures(geometry, transformState, layers, options, placement->collisionIndex);
             std::move(sourceResults.begin(), sourceResults.end(), std::inserter(resultsByLayer, resultsByLayer.begin()));
         }
     }

--- a/src/mbgl/renderer/sources/render_geojson_source.cpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.cpp
@@ -84,8 +84,9 @@ std::unordered_map<std::string, std::vector<Feature>>
 RenderGeoJSONSource::queryRenderedFeatures(const ScreenLineString& geometry,
                                            const TransformState& transformState,
                                            const std::vector<const RenderLayer*>& layers,
-                                           const RenderedQueryOptions& options) const {
-    return tilePyramid.queryRenderedFeatures(geometry, transformState, layers, options);
+                                           const RenderedQueryOptions& options,
+                                           const CollisionIndex& collisionIndex) const {
+    return tilePyramid.queryRenderedFeatures(geometry, transformState, layers, options, collisionIndex);
 }
 
 std::vector<Feature> RenderGeoJSONSource::querySourceFeatures(const SourceQueryOptions& options) const {

--- a/src/mbgl/renderer/sources/render_geojson_source.hpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.hpp
@@ -31,7 +31,8 @@ public:
     queryRenderedFeatures(const ScreenLineString& geometry,
                           const TransformState& transformState,
                           const std::vector<const RenderLayer*>& layers,
-                          const RenderedQueryOptions& options) const final;
+                          const RenderedQueryOptions& options,
+                          const CollisionIndex&) const final;
 
     std::vector<Feature>
     querySourceFeatures(const SourceQueryOptions&) const final;

--- a/src/mbgl/renderer/sources/render_image_source.cpp
+++ b/src/mbgl/renderer/sources/render_image_source.cpp
@@ -84,7 +84,8 @@ std::unordered_map<std::string, std::vector<Feature>>
 RenderImageSource::queryRenderedFeatures(const ScreenLineString&,
                                          const TransformState&,
                                          const std::vector<const RenderLayer*>&,
-                                         const RenderedQueryOptions&) const {
+                                         const RenderedQueryOptions&,
+                                         const CollisionIndex&) const {
     return std::unordered_map<std::string, std::vector<Feature>> {};
 }
 

--- a/src/mbgl/renderer/sources/render_image_source.hpp
+++ b/src/mbgl/renderer/sources/render_image_source.hpp
@@ -32,7 +32,8 @@ public:
     queryRenderedFeatures(const ScreenLineString& geometry,
                           const TransformState& transformState,
                           const std::vector<const RenderLayer*>& layers,
-                          const RenderedQueryOptions& options) const final;
+                          const RenderedQueryOptions& options,
+                          const CollisionIndex& collisionIndex) const final;
 
     std::vector<Feature> querySourceFeatures(const SourceQueryOptions&) const final;
 

--- a/src/mbgl/renderer/sources/render_raster_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_source.cpp
@@ -74,7 +74,8 @@ std::unordered_map<std::string, std::vector<Feature>>
 RenderRasterSource::queryRenderedFeatures(const ScreenLineString&,
                                           const TransformState&,
                                           const std::vector<const RenderLayer*>&,
-                                          const RenderedQueryOptions&) const {
+                                          const RenderedQueryOptions&,
+                                          const CollisionIndex& ) const {
     return std::unordered_map<std::string, std::vector<Feature>> {};
 }
 

--- a/src/mbgl/renderer/sources/render_raster_source.hpp
+++ b/src/mbgl/renderer/sources/render_raster_source.hpp
@@ -27,7 +27,8 @@ public:
     queryRenderedFeatures(const ScreenLineString& geometry,
                           const TransformState& transformState,
                           const std::vector<const RenderLayer*>& layers,
-                          const RenderedQueryOptions& options) const final;
+                          const RenderedQueryOptions& options,
+                          const CollisionIndex& collisionIndex) const final;
 
     std::vector<Feature>
     querySourceFeatures(const SourceQueryOptions&) const final;

--- a/src/mbgl/renderer/sources/render_vector_source.cpp
+++ b/src/mbgl/renderer/sources/render_vector_source.cpp
@@ -77,8 +77,9 @@ std::unordered_map<std::string, std::vector<Feature>>
 RenderVectorSource::queryRenderedFeatures(const ScreenLineString& geometry,
                                           const TransformState& transformState,
                                           const std::vector<const RenderLayer*>& layers,
-                                          const RenderedQueryOptions& options) const {
-    return tilePyramid.queryRenderedFeatures(geometry, transformState, layers, options);
+                                          const RenderedQueryOptions& options,
+                                          const CollisionIndex& collisionIndex) const {
+    return tilePyramid.queryRenderedFeatures(geometry, transformState, layers, options, collisionIndex);
 }
 
 std::vector<Feature> RenderVectorSource::querySourceFeatures(const SourceQueryOptions& options) const {

--- a/src/mbgl/renderer/sources/render_vector_source.hpp
+++ b/src/mbgl/renderer/sources/render_vector_source.hpp
@@ -27,7 +27,8 @@ public:
     queryRenderedFeatures(const ScreenLineString& geometry,
                           const TransformState& transformState,
                           const std::vector<const RenderLayer*>& layers,
-                          const RenderedQueryOptions& options) const final;
+                          const RenderedQueryOptions& options,
+                          const CollisionIndex& collisionIndex) const final;
 
     std::vector<Feature>
     querySourceFeatures(const SourceQueryOptions&) const final;

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -199,7 +199,8 @@ void TilePyramid::update(const std::vector<Immutable<style::Layer::Impl>>& layer
 std::unordered_map<std::string, std::vector<Feature>> TilePyramid::queryRenderedFeatures(const ScreenLineString& geometry,
                                            const TransformState& transformState,
                                            const std::vector<const RenderLayer*>& layers,
-                                           const RenderedQueryOptions& options) const {
+                                           const RenderedQueryOptions& options,
+                                           const CollisionIndex& collisionIndex) const {
     std::unordered_map<std::string, std::vector<Feature>> result;
     if (renderTiles.empty() || geometry.empty()) {
         return result;
@@ -242,7 +243,8 @@ std::unordered_map<std::string, std::vector<Feature>> TilePyramid::queryRendered
                                               tileSpaceQueryGeometry,
                                               transformState,
                                               layers,
-                                              options);
+                                              options,
+                                              collisionIndex);
     }
 
     return result;

--- a/src/mbgl/renderer/tile_pyramid.hpp
+++ b/src/mbgl/renderer/tile_pyramid.hpp
@@ -51,7 +51,8 @@ public:
     queryRenderedFeatures(const ScreenLineString& geometry,
                           const TransformState& transformState,
                           const std::vector<const RenderLayer*>&,
-                          const RenderedQueryOptions& options) const;
+                          const RenderedQueryOptions& options,
+                          const CollisionIndex& collisionIndex) const;
 
     std::vector<Feature> querySourceFeatures(const SourceQueryOptions&) const;
 

--- a/src/mbgl/text/collision_index.cpp
+++ b/src/mbgl/text/collision_index.cpp
@@ -235,7 +235,7 @@ void CollisionIndex::insertFeature(CollisionFeature& feature, bool ignorePlaceme
     }
 }
 
-std::vector<IndexedSubfeature> CollisionIndex::queryRenderedSymbols(const GeometryCoordinates& queryGeometry, const UnwrappedTileID& tileID) const {
+std::vector<IndexedSubfeature> CollisionIndex::queryRenderedSymbols(const GeometryCoordinates& queryGeometry, const UnwrappedTileID& tileID, const std::string& sourceID) const {
     std::vector<IndexedSubfeature> result;
     if (queryGeometry.empty() || (collisionGrid.empty() && ignoredGrid.empty())) {
         return result;
@@ -271,9 +271,9 @@ std::vector<IndexedSubfeature> CollisionIndex::queryRenderedSymbols(const Geomet
     std::vector<QueryResult> features = collisionGrid.query({{minX, minY}, {maxX, maxY}});
 
     for (auto& queryResult : features) {
-    auto& feature = queryResult.first;
+        auto& feature = queryResult.first;
         UnwrappedTileID featureTileID(feature.z, feature.x, feature.y); // TODO: Think about overscaling/wrapping
-        if (featureTileID == tileID) {
+        if (feature.sourceID == sourceID && featureTileID == tileID) {
             thisTileFeatures.push_back(queryResult);
         }
     }
@@ -282,7 +282,7 @@ std::vector<IndexedSubfeature> CollisionIndex::queryRenderedSymbols(const Geomet
     for (auto& queryResult : ignoredFeatures) {
         auto& feature = queryResult.first;
         UnwrappedTileID featureTileID(feature.z, feature.x, feature.y); // TODO: Think about overscaling/wrapping
-        if (featureTileID == tileID) {
+        if (feature.sourceID == sourceID && featureTileID == tileID) {
             thisTileFeatures.push_back(queryResult);
         }
     }

--- a/src/mbgl/text/collision_index.cpp
+++ b/src/mbgl/text/collision_index.cpp
@@ -300,9 +300,9 @@ std::vector<IndexedSubfeature> CollisionIndex::queryRenderedSymbols(const Geomet
         seenFeatures.insert(feature.index);
 
         int16_t minX1 = bbox.min.x;
-        int16_t maxX1 = bbox.max.y;
-        int16_t minY1 = bbox.min.y;
         int16_t maxY1 = bbox.max.y;
+        int16_t minY1 = bbox.min.y;
+        int16_t maxX1 = bbox.max.x;
 
         auto bboxPoints = GeometryCoordinates {
             { minX1, minY1 }, { maxX1, minY1 }, { maxX1, maxY1 }, { minX1, maxY1 }

--- a/src/mbgl/text/collision_index.cpp
+++ b/src/mbgl/text/collision_index.cpp
@@ -235,7 +235,7 @@ void CollisionIndex::insertFeature(CollisionFeature& feature, bool ignorePlaceme
     }
 }
 
-std::vector<IndexedSubfeature> CollisionIndex::queryRenderedSymbols(const GeometryCoordinates& queryGeometry, const UnwrappedTileID& tileID, const std::string& sourceID) const {
+std::vector<IndexedSubfeature> CollisionIndex::queryRenderedSymbols(const GeometryCoordinates& queryGeometry, const CanonicalTileID& tileID, const std::string& sourceID) const {
     std::vector<IndexedSubfeature> result;
     if (queryGeometry.empty() || (collisionGrid.empty() && ignoredGrid.empty())) {
         return result;
@@ -244,7 +244,7 @@ std::vector<IndexedSubfeature> CollisionIndex::queryRenderedSymbols(const Geomet
     mat4 posMatrix;
     mat4 projMatrix;
     transformState.getProjMatrix(projMatrix);
-    transformState.matrixFor(posMatrix, tileID);
+    transformState.matrixFor(posMatrix, UnwrappedTileID(0, tileID)); // TODO: This probably isn't right, I think it's working right now because both the wrapped and unwrapped version are getting queried, but I haven't thought through why it should work.
     matrix::multiply(posMatrix, projMatrix, posMatrix);
 
     GeometryCoordinates polygon;
@@ -272,7 +272,7 @@ std::vector<IndexedSubfeature> CollisionIndex::queryRenderedSymbols(const Geomet
 
     for (auto& queryResult : features) {
         auto& feature = queryResult.first;
-        UnwrappedTileID featureTileID(feature.z, feature.x, feature.y); // TODO: Think about overscaling/wrapping
+        CanonicalTileID featureTileID(feature.z, feature.x, feature.y);
         if (feature.sourceID == sourceID && featureTileID == tileID) {
             thisTileFeatures.push_back(queryResult);
         }
@@ -281,7 +281,7 @@ std::vector<IndexedSubfeature> CollisionIndex::queryRenderedSymbols(const Geomet
     std::vector<QueryResult> ignoredFeatures = ignoredGrid.query({{minX, minY}, {maxX, maxY}});
     for (auto& queryResult : ignoredFeatures) {
         auto& feature = queryResult.first;
-        UnwrappedTileID featureTileID(feature.z, feature.x, feature.y); // TODO: Think about overscaling/wrapping
+        CanonicalTileID featureTileID(feature.z, feature.x, feature.y);
         if (feature.sourceID == sourceID && featureTileID == tileID) {
             thisTileFeatures.push_back(queryResult);
         }

--- a/src/mbgl/text/collision_index.hpp
+++ b/src/mbgl/text/collision_index.hpp
@@ -31,7 +31,7 @@ public:
 
     void insertFeature(CollisionFeature& feature, bool ignorePlacement);
 
-    std::vector<IndexedSubfeature> queryRenderedSymbols(const GeometryCoordinates&, const UnwrappedTileID& tileID) const;
+    std::vector<IndexedSubfeature> queryRenderedSymbols(const GeometryCoordinates&, const UnwrappedTileID& tileID, const std::string& sourceID) const;
 
     
 private:

--- a/src/mbgl/text/collision_index.hpp
+++ b/src/mbgl/text/collision_index.hpp
@@ -31,7 +31,7 @@ public:
 
     void insertFeature(CollisionFeature& feature, bool ignorePlacement);
 
-    std::vector<IndexedSubfeature> queryRenderedSymbols(const GeometryCoordinates&, const UnwrappedTileID& tileID, const std::string& sourceID) const;
+    std::vector<IndexedSubfeature> queryRenderedSymbols(const GeometryCoordinates&, const CanonicalTileID& tileID, const std::string& sourceID) const;
 
     
 private:

--- a/src/mbgl/text/collision_index.hpp
+++ b/src/mbgl/text/collision_index.hpp
@@ -31,7 +31,7 @@ public:
 
     void insertFeature(CollisionFeature& feature, bool ignorePlacement);
 
-    std::vector<IndexedSubfeature> queryRenderedSymbols(const GeometryCoordinates&, const UnwrappedTileID& tileID, const float textPixelRatio) const;
+    std::vector<IndexedSubfeature> queryRenderedSymbols(const GeometryCoordinates&, const UnwrappedTileID& tileID) const;
 
     
 private:

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -265,6 +265,7 @@ void Placement::updateBucketOpacities(SymbolBucket& bucket) {
     }
 
     bucket.updateOpacity();
+    bucket.sortFeatures(state.getAngle());
 }
 
 JointOpacityState Placement::getOpacity(uint32_t crossTileSymbolID) const {

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -218,7 +218,10 @@ void Placement::updateBucketOpacities(SymbolBucket& bucket) {
         // TODO check if hasText is the right thing here, or if there are cases where hasText is true but it's not added to the buffers
         if (symbolInstance.hasText) {
             auto opacityVertex = SymbolOpacityAttributes::vertex(opacityState.text.placed, opacityState.text.opacity);
-            for (size_t i = 0; i < symbolInstance.glyphQuads.size() * 4; i++) {
+            for (size_t i = 0; i < symbolInstance.horizontalGlyphQuads.size() * 4; i++) {
+                bucket.text.opacityVertices.emplace_back(opacityVertex);
+            }
+            for (size_t i = 0; i < symbolInstance.verticalGlyphQuads.size() * 4; i++) {
                 bucket.text.opacityVertices.emplace_back(opacityVertex);
             }
             // TODO On JS we avoid setting this if it hasn't chnaged, but it may be cheap enough here we don't care

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -46,6 +46,9 @@ namespace mbgl {
             float symbolFadeChange(TimePoint now) const;
             bool hasTransitions(TimePoint now) const;
 
+            // TODO: public for queryRenderedFeatures
+            CollisionIndex collisionIndex;
+
         private:
 
             void placeLayerBucket(
@@ -59,7 +62,6 @@ namespace mbgl {
 
             void updateBucketOpacities(SymbolBucket&);
 
-            CollisionIndex collisionIndex;
             TransformState state;
             TimePoint commitTime;
 

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -51,6 +51,7 @@ GeometryTile::GeometryTile(const OverscaledTileID& id_,
       worker(parameters.workerScheduler,
              ActorRef<GeometryTile>(*this, mailbox),
              id_,
+             sourceID,
              obsolete,
              parameters.mode,
              parameters.pixelRatio,
@@ -238,6 +239,7 @@ void GeometryTile::queryRenderedFeatures(
                         options,
                         *data,
                         id.canonical,
+                        sourceID,
                         layers,
                         collisionIndex, // TODO: hook up to global CollisionIndex
                         additionalRadius);

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -216,7 +216,8 @@ void GeometryTile::queryRenderedFeatures(
     const GeometryCoordinates& queryGeometry,
     const TransformState& transformState,
     const std::vector<const RenderLayer*>& layers,
-    const RenderedQueryOptions& options) {
+    const RenderedQueryOptions& options,
+    const CollisionIndex& collisionIndex) {
 
     if (!featureIndex || !data) return;
 
@@ -238,7 +239,7 @@ void GeometryTile::queryRenderedFeatures(
                         *data,
                         id.canonical,
                         layers,
-                        0, // TODO: hook up to global CollisionIndex
+                        collisionIndex, // TODO: hook up to global CollisionIndex
                         additionalRadius);
 }
 

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -55,7 +55,8 @@ public:
             const GeometryCoordinates& queryGeometry,
             const TransformState&,
             const std::vector<const RenderLayer*>& layers,
-            const RenderedQueryOptions& options) override;
+            const RenderedQueryOptions& options,
+            const CollisionIndex& collisionIndex) override;
 
     void querySourceFeatures(
         std::vector<Feature>& result,

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -393,7 +393,7 @@ void GeometryTileWorker::attemptPlacement() {
             }
 
             symbolLayout->prepare(glyphMap, glyphAtlas.positions,
-                                  imageMap, imageAtlas.positions);
+                                  imageMap, imageAtlas.positions, id);
         }
 
         symbolLayoutsNeedPreparation = false;

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -23,6 +23,7 @@ using namespace style;
 GeometryTileWorker::GeometryTileWorker(ActorRef<GeometryTileWorker> self_,
                                        ActorRef<GeometryTile> parent_,
                                        OverscaledTileID id_,
+                                       const std::string& sourceID_,
                                        const std::atomic<bool>& obsolete_,
                                        const MapMode mode_,
                                        const float pixelRatio_,
@@ -30,6 +31,7 @@ GeometryTileWorker::GeometryTileWorker(ActorRef<GeometryTileWorker> self_,
     : self(std::move(self_)),
       parent(std::move(parent_)),
       id(std::move(id_)),
+      sourceID(sourceID_),
       obsolete(obsolete_),
       mode(mode_),
       pixelRatio(pixelRatio_),
@@ -393,7 +395,8 @@ void GeometryTileWorker::attemptPlacement() {
             }
 
             symbolLayout->prepare(glyphMap, glyphAtlas.positions,
-                                  imageMap, imageAtlas.positions, id);
+                                  imageMap, imageAtlas.positions,
+                                  id, sourceID);
         }
 
         symbolLayoutsNeedPreparation = false;

--- a/src/mbgl/tile/geometry_tile_worker.hpp
+++ b/src/mbgl/tile/geometry_tile_worker.hpp
@@ -27,6 +27,7 @@ public:
     GeometryTileWorker(ActorRef<GeometryTileWorker> self,
                        ActorRef<GeometryTile> parent,
                        OverscaledTileID,
+                       const std::string&,
                        const std::atomic<bool>&,
                        const MapMode,
                        const float pixelRatio,
@@ -57,6 +58,7 @@ private:
     ActorRef<GeometryTile> parent;
 
     const OverscaledTileID id;
+    const std::string sourceID;
     const std::atomic<bool>& obsolete;
     const MapMode mode;
     const float pixelRatio;

--- a/src/mbgl/tile/tile.cpp
+++ b/src/mbgl/tile/tile.cpp
@@ -34,7 +34,8 @@ void Tile::queryRenderedFeatures(
         const GeometryCoordinates&,
         const TransformState&,
         const std::vector<const RenderLayer*>&,
-        const RenderedQueryOptions&) {}
+        const RenderedQueryOptions&,
+        const CollisionIndex&) {}
 
 void Tile::querySourceFeatures(
         std::vector<Feature>&,

--- a/src/mbgl/tile/tile.hpp
+++ b/src/mbgl/tile/tile.hpp
@@ -62,7 +62,8 @@ public:
             const GeometryCoordinates& queryGeometry,
             const TransformState&,
             const std::vector<const RenderLayer*>&,
-            const RenderedQueryOptions& options);
+            const RenderedQueryOptions& options,
+            const CollisionIndex&);
 
     virtual void querySourceFeatures(
             std::vector<Feature>& result,

--- a/src/mbgl/util/grid_index.hpp
+++ b/src/mbgl/util/grid_index.hpp
@@ -65,8 +65,7 @@ public:
     void insert(T&& t, const BBox&);
     void insert(T&& t, const BCircle&);
     
-    std::vector<T> query(const BBox&) const;
-    std::vector<T> query(const BCircle&) const;
+    std::vector<std::pair<T,BBox>> query(const BBox&) const;
     
     bool hitTest(const BBox&) const;
     bool hitTest(const BCircle&) const;
@@ -78,8 +77,8 @@ private:
     bool completeIntersection(const BBox& query) const;
     BBox convertToBox(const BCircle& circle) const;
 
-    void query(const BBox&, std::function<bool (const T&)>) const;
-    void query(const BCircle&, std::function<bool (const T&)>) const;
+    void query(const BBox&, std::function<bool (const T&, const BBox&)>) const;
+    void query(const BCircle&, std::function<bool (const T&, const BBox&)>) const;
 
     int16_t convertToXCellCoord(const float x) const;
     int16_t convertToYCellCoord(const float y) const;


### PR DESCRIPTION
I rebased this branch on the vertical text changes because I happened to be debugging on Chinese maps that needed the vertical text changes.

Basic hook up of queryRenderedSymbols. The approach is to store CanonicalTileIDs and sourceIDs in the collision grid, and then use those to filter results to the appropriate tile/source in `queryRenderedSymbols`.

@ansis 