### PR TITLE
Don't save state if map hasn't been initialised

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -329,8 +329,10 @@ public class MapView extends FrameLayout {
    */
   @UiThread
   public void onSaveInstanceState(@NonNull Bundle outState) {
-    outState.putBoolean(MapboxConstants.STATE_HAS_SAVED_STATE, true);
-    mapboxMap.onSaveInstanceState(outState);
+    if (mapboxMap != null) {
+      outState.putBoolean(MapboxConstants.STATE_HAS_SAVED_STATE, true);
+      mapboxMap.onSaveInstanceState(outState);
+    }
   }
 
   /**


### PR DESCRIPTION
With migration to GLSurfaceView we are also waiting for the view to be measured before creating the map object. It's possible that the user destroys the map before the map was fully created. With current codebase this can result in a crash. 

cc @danesfeder 