### PR TITLE
[core] LatLngBounds::contains(const LatLngBounds&)

### DIFF
--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -161,6 +161,13 @@ public:
                 point.longitude() <= ne.longitude());
     }
 
+    bool contains(const LatLngBounds& area) const {
+        return (area.ne.latitude()  <= ne.latitude()  &&
+                area.sw.latitude()  >= sw.latitude()  &&
+                area.ne.longitude() <= ne.longitude() &&
+                area.sw.longitude() >= sw.longitude());
+    }
+
     bool intersects(const LatLngBounds area) const {
         return (area.ne.latitude()  > sw.latitude()  &&
                 area.sw.latitude()  < ne.latitude()  &&

--- a/test/util/geo.test.cpp
+++ b/test/util/geo.test.cpp
@@ -220,3 +220,9 @@ TEST(LatLngBounds, FromTileID) {
         ASSERT_DOUBLE_EQ(util::LATITUDE_MAX, bounds.north());
     }
 }
+
+TEST(LatLngBounds, Contains) {
+    const LatLngBounds bounds( CanonicalTileID(4,2,6));
+    const LatLngBounds innerBounds( CanonicalTileID(9,82,197));
+    EXPECT_TRUE(bounds.contains(innerBounds));
+}


### PR DESCRIPTION
Implement a `LatLngBounds` containment comparison.