### PR TITLE
Asynchronous TextureView

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -2,8 +2,8 @@ package com.mapbox.mapboxsdk.maps;
 
 import android.content.Context;
 import android.graphics.PointF;
-import android.os.Build;
 import android.opengl.GLSurfaceView;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.CallSuper;
 import android.support.annotation.IntDef;
@@ -27,7 +27,7 @@ import com.mapbox.mapboxsdk.annotations.Annotation;
 import com.mapbox.mapboxsdk.annotations.MarkerViewManager;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.constants.Style;
-import com.mapbox.mapboxsdk.egl.EGLConfigChooser;
+import com.mapbox.mapboxsdk.maps.renderer.GLSurfaceViewMapRenderer;
 import com.mapbox.mapboxsdk.maps.renderer.MapRenderer;
 import com.mapbox.mapboxsdk.maps.widgets.CompassView;
 import com.mapbox.mapboxsdk.maps.widgets.MyLocationView;
@@ -49,7 +49,6 @@ import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.maps.widgets.CompassView.TIME_MAP_NORTH_ANIMATION;
 import static com.mapbox.mapboxsdk.maps.widgets.CompassView.TIME_WAIT_IDLE;
-import static android.opengl.GLSurfaceView.RENDERMODE_WHEN_DIRTY;
 
 /**
  * <p>
@@ -86,7 +85,7 @@ public class MapView extends FrameLayout {
   private Bundle savedInstanceState;
   private final CopyOnWriteArrayList<OnMapChangedListener> onMapChangedListeners = new CopyOnWriteArrayList<>();
 
-  private GLSurfaceView glSurfaceView;
+  private MapRenderer mapRenderer;
 
   @UiThread
   public MapView(@NonNull Context context) {
@@ -286,12 +285,10 @@ public class MapView extends FrameLayout {
   }
 
   private void initialiseDrawingSurface() {
-    glSurfaceView = (GLSurfaceView) findViewById(R.id.surfaceView);
+    GLSurfaceView glSurfaceView = (GLSurfaceView) findViewById(R.id.surfaceView);
     glSurfaceView.setZOrderMediaOverlay(mapboxMapOptions.getRenderSurfaceOnTop());
-    glSurfaceView.setEGLContextClientVersion(2);
-    glSurfaceView.setEGLConfigChooser(new EGLConfigChooser());
 
-    MapRenderer mapRenderer = new MapRenderer(getContext(), glSurfaceView) {
+    GLSurfaceViewMapRenderer mapRenderer = new GLSurfaceViewMapRenderer(getContext(), glSurfaceView) {
       @Override
       public void onSurfaceCreated(GL10 gl, EGLConfig config) {
         MapView.this.post(new Runnable() {
@@ -309,10 +306,9 @@ public class MapView extends FrameLayout {
       }
     };
 
-    glSurfaceView.setRenderer(mapRenderer);
-    glSurfaceView.setRenderMode(RENDERMODE_WHEN_DIRTY);
     glSurfaceView.setVisibility(View.VISIBLE);
 
+    this.mapRenderer = mapRenderer;
     nativeMapView = new NativeMapView(this, mapRenderer);
     nativeMapView.resizeView(getMeasuredWidth(), getMeasuredHeight());
   }
@@ -345,8 +341,8 @@ public class MapView extends FrameLayout {
    */
   @UiThread
   public void onResume() {
-    if (glSurfaceView != null) {
-      glSurfaceView.onResume();
+    if (mapRenderer != null) {
+      mapRenderer.onResume();
     }
   }
 
@@ -355,8 +351,8 @@ public class MapView extends FrameLayout {
    */
   @UiThread
   public void onPause() {
-    if (glSurfaceView != null) {
-      glSurfaceView.onPause();
+    if (mapRenderer != null) {
+      mapRenderer.onPause();
     }
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -27,7 +27,7 @@ import com.mapbox.mapboxsdk.annotations.Annotation;
 import com.mapbox.mapboxsdk.annotations.MarkerViewManager;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.constants.Style;
-import com.mapbox.mapboxsdk.maps.renderer.GLSurfaceViewMapRenderer;
+import com.mapbox.mapboxsdk.maps.renderer.glsurfaceview.GLSurfaceViewMapRenderer;
 import com.mapbox.mapboxsdk.maps.renderer.MapRenderer;
 import com.mapbox.mapboxsdk.maps.widgets.CompassView;
 import com.mapbox.mapboxsdk.maps.widgets.MyLocationView;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -374,6 +374,10 @@ public class MapView extends FrameLayout {
     mapCallback.clearOnMapReadyCallbacks();
     nativeMapView.destroy();
     nativeMapView = null;
+
+    if (mapRenderer != null) {
+      mapRenderer.onDestroy();
+    }
   }
 
   @Override

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
@@ -85,6 +85,8 @@ public class MapboxMapOptions implements Parcelable {
 
   private String apiBaseUrl;
 
+  private boolean textureMode;
+
   private String style;
 
   /**
@@ -152,7 +154,7 @@ public class MapboxMapOptions implements Parcelable {
 
     style = in.readString();
     apiBaseUrl = in.readString();
-
+    textureMode = in.readByte() != 0;
     prefetchesTiles = in.readByte() != 0;
     zMediaOverlay = in.readByte() != 0;
   }
@@ -296,6 +298,8 @@ public class MapboxMapOptions implements Parcelable {
           ColorUtils.getPrimaryColor(context)));
       mapboxMapOptions.myLocationAccuracyThreshold(
         typedArray.getFloat(R.styleable.mapbox_MapView_mapbox_myLocationAccuracyThreshold, 0));
+      mapboxMapOptions.textureMode(
+        typedArray.getBoolean(R.styleable.mapbox_MapView_mapbox_renderTextureMode, false));
       mapboxMapOptions.setPrefetchesTiles(
         typedArray.getBoolean(R.styleable.mapbox_MapView_mapbox_enableTilePrefetch, true));
       mapboxMapOptions.renderSurfaceOnTop(
@@ -699,12 +703,29 @@ public class MapboxMapOptions implements Parcelable {
   }
 
   /**
+   * Enable {@link android.view.TextureView} as rendered surface.
+   * <p>
+   * Since the 5.2.0 release we replaced our TextureView with an {@link android.opengl.GLSurfaceView}
+   * implementation. Enabling this option will use the {@link android.view.TextureView} instead.
+   * {@link android.view.TextureView} can be useful in situations where you need to animate, scale
+   * or transform the view. This comes at a siginficant performance penalty and should not be considered
+   * unless absolutely needed.
+   * </p>
+   *
+   * @param textureMode True to enable texture mode
+   * @return This
+   */
+  public MapboxMapOptions textureMode(boolean textureMode) {
+    this.textureMode = textureMode;
+    return this;
+  }
+
+  /**
    * Enable tile pre-fetching. Loads tiles at a lower zoom-level to pre-render
    * a low resolution preview while more detailed tiles are loaded.
    * Enabled by default
    *
    * @param enable true to enable
-   *
    * @return This
    */
   public MapboxMapOptions setPrefetchesTiles(boolean enable) {
@@ -1049,6 +1070,15 @@ public class MapboxMapOptions implements Parcelable {
     return debugActive;
   }
 
+  /**
+   * Returns true if TextureView is being used the render view.
+   *
+   * @return True if TextureView is used.
+   */
+  public boolean getTextureMode() {
+    return textureMode;
+  }
+
   public static final Parcelable.Creator<MapboxMapOptions> CREATOR = new Parcelable.Creator<MapboxMapOptions>() {
     public MapboxMapOptions createFromParcel(Parcel in) {
       return new MapboxMapOptions(in);
@@ -1112,7 +1142,7 @@ public class MapboxMapOptions implements Parcelable {
 
     dest.writeString(style);
     dest.writeString(apiBaseUrl);
-
+    dest.writeByte((byte) (textureMode ? 1 : 0));
     dest.writeByte((byte) (prefetchesTiles ? 1 : 0));
     dest.writeByte((byte) (zMediaOverlay ? 1 : 0));
   }
@@ -1289,6 +1319,7 @@ public class MapboxMapOptions implements Parcelable {
     result = 31 * result + (myLocationAccuracyThreshold != +0.0f
       ? Float.floatToIntBits(myLocationAccuracyThreshold) : 0);
     result = 31 * result + (apiBaseUrl != null ? apiBaseUrl.hashCode() : 0);
+    result = 31 * result + (textureMode ? 1 : 0);
     result = 31 * result + (style != null ? style.hashCode() : 0);
     result = 31 * result + (prefetchesTiles ? 1 : 0);
     result = 31 * result + (zMediaOverlay ? 1 : 0);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/GLSurfaceViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/GLSurfaceViewMapRenderer.java
@@ -1,0 +1,84 @@
+package com.mapbox.mapboxsdk.maps.renderer;
+
+import android.content.Context;
+import android.opengl.GLSurfaceView;
+
+import com.mapbox.mapboxsdk.egl.EGLConfigChooser;
+
+import javax.microedition.khronos.egl.EGLConfig;
+import javax.microedition.khronos.opengles.GL10;
+
+import static android.opengl.GLSurfaceView.RENDERMODE_WHEN_DIRTY;
+
+/**
+ * The {@link GLSurfaceViewMapRenderer} encapsulates the GL thread and
+ * {@link GLSurfaceView} specifics to render the map.
+ *
+ * @see MapRenderer
+ */
+public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceView.Renderer {
+
+  private final GLSurfaceView glSurfaceView;
+
+  public GLSurfaceViewMapRenderer(Context context, GLSurfaceView glSurfaceView) {
+    super(context);
+    this.glSurfaceView = glSurfaceView;
+    glSurfaceView.setEGLContextClientVersion(2);
+    glSurfaceView.setEGLConfigChooser(new EGLConfigChooser());
+    glSurfaceView.setRenderer(this);
+    glSurfaceView.setRenderMode(RENDERMODE_WHEN_DIRTY);
+  }
+
+  @Override
+  public void onPause() {
+    if (glSurfaceView != null) {
+      glSurfaceView.onPause();
+    }
+  }
+
+  @Override
+  public void onResume() {
+    if (glSurfaceView != null) {
+      glSurfaceView.onResume();
+    }
+  }
+
+  @Override
+  public void onSurfaceCreated(GL10 gl, EGLConfig config) {
+    super.onSurfaceCreated(gl, config);
+  }
+
+  @Override
+  public void onSurfaceChanged(GL10 gl, int width, int height) {
+    super.onSurfaceChanged(gl, width, height);
+  }
+
+  @Override
+  public void onDrawFrame(GL10 gl) {
+    super.onDrawFrame(gl);
+  }
+
+  /**
+   * May be called from any thread.
+   * <p>
+   * Called from the renderer frontend to schedule a render.
+   */
+  @Override
+  public void requestRender() {
+    glSurfaceView.requestRender();
+  }
+
+  /**
+   * May be called from any thread.
+   * <p>
+   * Schedules work to be performed on the MapRenderer thread.
+   *
+   * @param runnable the runnable to execute
+   */
+  @Override
+  public void queueEvent(Runnable runnable) {
+    glSurfaceView.queueEvent(runnable);
+  }
+
+
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
@@ -41,6 +41,9 @@ public abstract class MapRenderer implements MapRendererScheduler {
     // Implement if needed
   }
 
+  public void onDestroy() {
+    // Implement if needed
+  }
 
   public void setOnFpsChangedListener(MapboxMap.OnFpsChangedListener listener) {
     onFpsChangedListener = listener;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
@@ -1,7 +1,7 @@
 package com.mapbox.mapboxsdk.maps.renderer;
 
 import android.content.Context;
-import android.opengl.GLSurfaceView;
+import android.support.annotation.CallSuper;
 
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.storage.FileSource;
@@ -16,17 +16,14 @@ import javax.microedition.khronos.opengles.GL10;
  * render on the one end and acts as a scheduler to request work to
  * be performed on the GL thread on the other.
  */
-public class MapRenderer implements GLSurfaceView.Renderer, MapRendererScheduler {
+public abstract class MapRenderer implements MapRendererScheduler {
 
   // Holds the pointer to the native peer after initialisation
   private long nativePtr = 0;
 
-  private final GLSurfaceView glSurfaceView;
-
   private MapboxMap.OnFpsChangedListener onFpsChangedListener;
 
-  public MapRenderer(Context context, GLSurfaceView glSurfaceView) {
-    this.glSurfaceView = glSurfaceView;
+  public MapRenderer(Context context) {
 
     FileSource fileSource = FileSource.getInstance(context);
     float pixelRatio = context.getResources().getDisplayMetrics().density;
@@ -36,17 +33,26 @@ public class MapRenderer implements GLSurfaceView.Renderer, MapRendererScheduler
     nativeInitialize(this, fileSource, pixelRatio, programCacheDir);
   }
 
+  public void onPause() {
+    // Implement if needed
+  }
+
+  public void onResume() {
+    // Implement if needed
+  }
+
+
   public void setOnFpsChangedListener(MapboxMap.OnFpsChangedListener listener) {
     onFpsChangedListener = listener;
   }
 
-  @Override
-  public void onSurfaceCreated(GL10 gl, EGLConfig config) {
+  @CallSuper
+  protected void onSurfaceCreated(GL10 gl, EGLConfig config) {
     nativeOnSurfaceCreated();
   }
 
-  @Override
-  public void onSurfaceChanged(GL10 gl, int width, int height) {
+  @CallSuper
+  protected void onSurfaceChanged(GL10 gl, int width, int height) {
     if (width < 0) {
       throw new IllegalArgumentException("fbWidth cannot be negative.");
     }
@@ -69,35 +75,13 @@ public class MapRenderer implements GLSurfaceView.Renderer, MapRendererScheduler
     nativeOnSurfaceChanged(width, height);
   }
 
-  @Override
-  public void onDrawFrame(GL10 gl) {
+  @CallSuper
+  protected void onDrawFrame(GL10 gl) {
     nativeRender();
 
     if (onFpsChangedListener != null) {
       updateFps();
     }
-  }
-
-  /**
-   * May be called from any thread.
-   * <p>
-   * Called from the renderer frontend to schedule a render.
-   */
-  @Override
-  public void requestRender() {
-    glSurfaceView.requestRender();
-  }
-
-  /**
-   * May be called from any thread.
-   * <p>
-   * Schedules work to be performed on the MapRenderer thread.
-   *
-   * @param runnable the runnable to execute
-   */
-  @Override
-  public void queueEvent(Runnable runnable) {
-    glSurfaceView.queueEvent(runnable);
   }
 
   /**
@@ -109,6 +93,7 @@ public class MapRenderer implements GLSurfaceView.Renderer, MapRendererScheduler
    * @param runnable the runnable to execute
    * @see MapRendererRunnable
    */
+  @CallSuper
   void queueEvent(MapRendererRunnable runnable) {
     this.queueEvent((Runnable) runnable);
   }
@@ -118,6 +103,7 @@ public class MapRenderer implements GLSurfaceView.Renderer, MapRendererScheduler
                                        float pixelRatio,
                                        String programCacheDir);
 
+  @CallSuper
   @Override
   protected native void finalize() throws Throwable;
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/egl/EGLConfigChooser.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/egl/EGLConfigChooser.java
@@ -1,4 +1,4 @@
-package com.mapbox.mapboxsdk.egl;
+package com.mapbox.mapboxsdk.maps.renderer.egl;
 
 import android.opengl.GLSurfaceView;
 import android.support.annotation.NonNull;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/egl/EGLConfigException.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/egl/EGLConfigException.java
@@ -1,4 +1,4 @@
-package com.mapbox.mapboxsdk.egl;
+package com.mapbox.mapboxsdk.maps.renderer.egl;
 
 /**
  * Used for EGL configuration exceptions

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
@@ -1,9 +1,10 @@
-package com.mapbox.mapboxsdk.maps.renderer;
+package com.mapbox.mapboxsdk.maps.renderer.glsurfaceview;
 
 import android.content.Context;
 import android.opengl.GLSurfaceView;
 
-import com.mapbox.mapboxsdk.egl.EGLConfigChooser;
+import com.mapbox.mapboxsdk.maps.renderer.MapRenderer;
+import com.mapbox.mapboxsdk.maps.renderer.egl.EGLConfigChooser;
 
 import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.opengles.GL10;
@@ -31,16 +32,12 @@ public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceVi
 
   @Override
   public void onPause() {
-    if (glSurfaceView != null) {
-      glSurfaceView.onPause();
-    }
+    glSurfaceView.onPause();
   }
 
   @Override
   public void onResume() {
-    if (glSurfaceView != null) {
-      glSurfaceView.onResume();
-    }
+    glSurfaceView.onResume();
   }
 
   @Override

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewMapRenderer.java
@@ -1,0 +1,96 @@
+package com.mapbox.mapboxsdk.maps.renderer.textureview;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.view.TextureView;
+
+import com.mapbox.mapboxsdk.maps.renderer.MapRenderer;
+
+import javax.microedition.khronos.egl.EGLConfig;
+import javax.microedition.khronos.opengles.GL10;
+
+/**
+ * The {@link TextureViewMapRenderer} encapsulates the GL thread and
+ * {@link TextureView} specifics to render the map.
+ *
+ * @see MapRenderer
+ */
+public class TextureViewMapRenderer extends MapRenderer {
+  private TextureViewRenderThread renderThread;
+
+  /**
+   * Create a {@link MapRenderer} for the given {@link TextureView}
+   *
+   * @param context     the current Context
+   * @param textureView the TextureView
+   */
+  public TextureViewMapRenderer(@NonNull Context context, @NonNull TextureView textureView) {
+    super(context);
+    renderThread = new TextureViewRenderThread(textureView, this);
+    renderThread.start();
+  }
+
+  /**
+   * Overridden to provide package access
+   */
+  @Override
+  protected void onSurfaceCreated(GL10 gl, EGLConfig config) {
+    super.onSurfaceCreated(gl, config);
+  }
+
+  /**
+   * Overridden to provide package access
+   */
+  @Override
+  protected void onSurfaceChanged(GL10 gl, int width, int height) {
+    super.onSurfaceChanged(gl, width, height);
+  }
+
+  /**
+   * Overridden to provide package access
+   */
+  @Override
+  protected void onDrawFrame(GL10 gl) {
+    super.onDrawFrame(gl);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void requestRender() {
+    renderThread.requestRender();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void queueEvent(Runnable runnable) {
+    renderThread.queueEvent(runnable);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void onPause() {
+    renderThread.onPause();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void onResume() {
+    renderThread.onResume();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void onDestroy() {
+    renderThread.onDestroy();
+  }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewRenderThread.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewRenderThread.java
@@ -1,0 +1,442 @@
+package com.mapbox.mapboxsdk.maps.renderer.textureview;
+
+import android.graphics.SurfaceTexture;
+import android.support.annotation.NonNull;
+import android.support.annotation.UiThread;
+import android.view.TextureView;
+
+import com.mapbox.mapboxsdk.maps.renderer.egl.EGLConfigChooser;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+
+import javax.microedition.khronos.egl.EGL10;
+import javax.microedition.khronos.egl.EGL11;
+import javax.microedition.khronos.egl.EGLConfig;
+import javax.microedition.khronos.egl.EGLContext;
+import javax.microedition.khronos.egl.EGLDisplay;
+import javax.microedition.khronos.egl.EGLSurface;
+import javax.microedition.khronos.opengles.GL10;
+
+import timber.log.Timber;
+
+/**
+ * The render thread is responsible for managing the communication between the
+ * ui thread and the render thread it creates. Also, the EGL and GL contexts
+ * are managed from here.
+ */
+class TextureViewRenderThread extends Thread implements TextureView.SurfaceTextureListener {
+
+  private final TextureViewMapRenderer mapRenderer;
+  private final EGLHolder eglHolder;
+
+  // Lock used for synchronization
+  private final Object lock = new Object();
+
+  // Guarded by lock
+  private final ArrayList<Runnable> eventQueue = new ArrayList<>();
+  private SurfaceTexture surface;
+  private int width;
+  private int height;
+  private boolean requestRender;
+  private boolean sizeChanged;
+  private boolean paused;
+  private boolean destroyContext;
+  private boolean destroySurface;
+  private boolean shouldExit;
+  private boolean exited;
+
+  /**
+   * Create a render thread for the given TextureView / Maprenderer combination.
+   *
+   * @param textureView the TextureView
+   * @param mapRenderer the MapRenderer
+   */
+  @UiThread
+  TextureViewRenderThread(@NonNull TextureView textureView, @NonNull TextureViewMapRenderer mapRenderer) {
+    textureView.setSurfaceTextureListener(this);
+    this.mapRenderer = mapRenderer;
+    this.eglHolder = new EGLHolder(new WeakReference<>(textureView));
+  }
+
+  // SurfaceTextureListener methods
+
+  @UiThread
+  @Override
+  public void onSurfaceTextureAvailable(final SurfaceTexture surface, final int width, final int height) {
+    synchronized (lock) {
+      this.surface = surface;
+      this.width = width;
+      this.height = height;
+      this.requestRender = true;
+      lock.notifyAll();
+    }
+  }
+
+  @Override
+  @UiThread
+  public void onSurfaceTextureSizeChanged(SurfaceTexture surface, final int width, final int height) {
+    synchronized (lock) {
+      this.width = width;
+      this.height = height;
+      this.sizeChanged = true;
+      this.requestRender = true;
+      lock.notifyAll();
+    }
+  }
+
+  @Override
+  @UiThread
+  public boolean onSurfaceTextureDestroyed(SurfaceTexture surface) {
+    synchronized (lock) {
+      this.surface = null;
+      this.destroySurface = true;
+      this.requestRender = false;
+      lock.notifyAll();
+    }
+    return true;
+  }
+
+  @Override
+  @UiThread
+  public void onSurfaceTextureUpdated(SurfaceTexture surface) {
+    // Ignored
+  }
+
+  // MapRenderer delegate methods
+
+  /**
+   * May be called from any thread
+   */
+  void requestRender() {
+    synchronized (lock) {
+      requestRender = true;
+      lock.notifyAll();
+    }
+  }
+
+  /**
+   * May be called from any thread
+   */
+  void queueEvent(Runnable runnable) {
+    if (runnable == null) {
+      throw new IllegalArgumentException("runnable must not be null");
+    }
+    synchronized (lock) {
+      eventQueue.add(runnable);
+      lock.notifyAll();
+    }
+  }
+
+
+  @UiThread
+  void onPause() {
+    synchronized (lock) {
+      this.paused = true;
+      lock.notifyAll();
+    }
+  }
+
+  @UiThread
+  void onResume() {
+    synchronized (lock) {
+      this.paused = false;
+      lock.notifyAll();
+    }
+  }
+
+
+  @UiThread
+  void onDestroy() {
+    synchronized (lock) {
+      this.shouldExit = true;
+      lock.notifyAll();
+
+      // Wait for the thread to exit
+      while (!this.exited) {
+        try {
+          lock.wait();
+        } catch (InterruptedException ex) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    }
+  }
+
+  // Thread implementation
+
+  @Override
+  public void run() {
+    try {
+
+      while (true) {
+        Runnable event = null;
+        boolean initializeEGL = false;
+        boolean recreateSurface = false;
+        int w = -1;
+        int h = -1;
+
+        // Guarded block
+        synchronized (lock) {
+          while (true) {
+
+            if (shouldExit) {
+              return;
+            }
+
+            // If any events are scheduled, pop one for processing
+            if (!eventQueue.isEmpty()) {
+              event = eventQueue.remove(0);
+              break;
+            }
+
+            if (destroySurface) {
+              eglHolder.destroySurface();
+              destroySurface = false;
+              break;
+            }
+
+            if (destroyContext) {
+              eglHolder.destroyContext();
+              destroyContext = false;
+              break;
+            }
+
+            if (surface != null && !paused && requestRender) {
+
+              w = width;
+              h = height;
+
+              // Initialize EGL if needed
+              if (eglHolder.eglContext == EGL10.EGL_NO_CONTEXT) {
+                initializeEGL = true;
+                break;
+              }
+
+              // Check if the size has changed
+              if (sizeChanged) {
+                recreateSurface = true;
+                sizeChanged = false;
+                break;
+              }
+
+              // Reset the request render flag now, so we can catch new requests
+              // while rendering
+              requestRender = false;
+
+              // Break the guarded loop and continue to process
+              break;
+            }
+
+
+            // Wait until needed
+            lock.wait();
+
+          } // end guarded while loop
+
+        } // end guarded block
+
+        // Run event, if any
+        if (event != null) {
+          event.run();
+          continue;
+        }
+
+        GL10 gl = eglHolder.createGL();
+
+        // Initialize EGL
+        if (initializeEGL) {
+          eglHolder.prepare();
+          eglHolder.createSurface();
+          mapRenderer.onSurfaceCreated(gl, eglHolder.eglConfig);
+          mapRenderer.onSurfaceChanged(gl, w, h);
+          continue;
+        }
+
+        // If the surface size has changed inform the map renderer.
+        if (recreateSurface) {
+          eglHolder.createSurface();
+          mapRenderer.onSurfaceChanged(gl, w, h);
+          continue;
+        }
+
+        // Don't continue without a surface
+        if (eglHolder.eglSurface == EGL10.EGL_NO_SURFACE) {
+          continue;
+        }
+
+        // Time to render a frame
+        mapRenderer.onDrawFrame(gl);
+
+        // Swap and check the result
+        int swapError = eglHolder.swap();
+        switch (swapError) {
+          case EGL10.EGL_SUCCESS:
+            break;
+          case EGL11.EGL_CONTEXT_LOST:
+            Timber.w("Context lost. Waiting for re-aquire");
+            synchronized (lock) {
+              surface = null;
+              destroySurface = true;
+              destroyContext = true;
+            }
+            break;
+          default:
+            Timber.w("eglSwapBuffer error: %s. Waiting or new surface", swapError);
+            // Probably lost the surface. Clear the current one and
+            // wait for a new one to be set
+            synchronized (lock) {
+              surface = null;
+              destroySurface = true;
+            }
+        }
+
+      }
+
+    } catch (InterruptedException err) {
+      // To be expected
+    } finally {
+      // Cleanup
+      eglHolder.cleanup();
+
+      // Signal we're done
+      synchronized (lock) {
+        this.exited = true;
+        lock.notifyAll();
+      }
+    }
+  }
+
+  /**
+   * Holds the EGL state and offers methods to mutate it.
+   */
+  private static class EGLHolder {
+    private static final int EGL_CONTEXT_CLIENT_VERSION = 0x3098;
+    private final WeakReference<TextureView> textureViewWeakRef;
+
+    private EGL10 egl;
+    private EGLConfig eglConfig;
+    private EGLDisplay eglDisplay = EGL10.EGL_NO_DISPLAY;
+    private EGLContext eglContext = EGL10.EGL_NO_CONTEXT;
+    private EGLSurface eglSurface = EGL10.EGL_NO_SURFACE;
+
+    EGLHolder(WeakReference<TextureView> textureViewWeakRef) {
+      this.textureViewWeakRef = textureViewWeakRef;
+    }
+
+    void prepare() {
+      this.egl = (EGL10) EGLContext.getEGL();
+
+      // Only re-initialize display when needed
+      if (eglDisplay == EGL10.EGL_NO_DISPLAY) {
+        this.eglDisplay = egl.eglGetDisplay(EGL10.EGL_DEFAULT_DISPLAY);
+
+        if (eglDisplay == EGL10.EGL_NO_DISPLAY) {
+          throw new RuntimeException("eglGetDisplay failed");
+        }
+
+        int[] version = new int[2];
+        if (!egl.eglInitialize(eglDisplay, version)) {
+          throw new RuntimeException("eglInitialize failed");
+        }
+      }
+
+      if (textureViewWeakRef == null) {
+        // No texture view present
+        eglConfig = null;
+        eglContext = EGL10.EGL_NO_CONTEXT;
+      } else /*if (eglContext == EGL10.EGL_NO_CONTEXT)*/ {
+        eglConfig = new EGLConfigChooser().chooseConfig(egl, eglDisplay);
+        int[] attrib_list = {EGL_CONTEXT_CLIENT_VERSION, 2, EGL10.EGL_NONE};
+        eglContext = egl.eglCreateContext(eglDisplay, eglConfig, EGL10.EGL_NO_CONTEXT, attrib_list);
+      }
+
+      if (eglContext == EGL10.EGL_NO_CONTEXT) {
+        throw new RuntimeException("createContext");
+      }
+    }
+
+    GL10 createGL() {
+      return (GL10) eglContext.getGL();
+    }
+
+    boolean createSurface() {
+      // The window size has changed, so we need to create a new surface.
+      destroySurface();
+
+      // Create an EGL surface we can render into.
+      TextureView view = textureViewWeakRef.get();
+      if (view != null) {
+        int[] surfaceAttribs = {EGL10.EGL_NONE};
+        eglSurface = egl.eglCreateWindowSurface(eglDisplay, eglConfig, view.getSurfaceTexture(), surfaceAttribs);
+      } else {
+        eglSurface = EGL10.EGL_NO_SURFACE;
+      }
+
+      if (eglSurface == null || eglSurface == EGL10.EGL_NO_SURFACE) {
+        int error = egl.eglGetError();
+        if (error == EGL10.EGL_BAD_NATIVE_WINDOW) {
+          Timber.e("createWindowSurface returned EGL_BAD_NATIVE_WINDOW.");
+        }
+        return false;
+      }
+
+      return makeCurrent();
+    }
+
+    boolean makeCurrent() {
+      if (!egl.eglMakeCurrent(eglDisplay, eglSurface, eglSurface, eglContext)) {
+        // Could not make the context current, probably because the underlying
+        // SurfaceView surface has been destroyed.
+        Timber.w("eglMakeCurrent: %s", egl.eglGetError());
+        return false;
+      }
+
+      return true;
+    }
+
+    int swap() {
+      if (!egl.eglSwapBuffers(eglDisplay, eglSurface)) {
+        return egl.eglGetError();
+      }
+      return EGL10.EGL_SUCCESS;
+    }
+
+    private void destroySurface() {
+      if (eglSurface == EGL10.EGL_NO_SURFACE) {
+        return;
+      }
+
+      if (!egl.eglDestroySurface(eglDisplay, eglSurface)) {
+        Timber.e("Could not destroy egl surface. Display %s, Surface %s", eglDisplay, eglSurface);
+        throw new RuntimeException("eglDestroyContext: " + egl.eglGetError());
+      }
+    }
+
+    private void destroyContext() {
+      if (eglSurface == null || eglSurface == EGL10.EGL_NO_SURFACE) {
+        return;
+      }
+
+      if (!egl.eglDestroyContext(eglDisplay, eglContext)) {
+        Timber.e("Could not destroy egl context. Display %s, Context %s", eglDisplay, eglContext);
+        throw new RuntimeException("eglDestroyContext: " + egl.eglGetError());
+      }
+    }
+
+    private void terminate() {
+      if (eglDisplay != EGL10.EGL_NO_DISPLAY) {
+        if (!egl.eglTerminate(eglDisplay)) {
+          Timber.w("Could not terminate egl. Display %s", eglDisplay);
+        }
+        eglDisplay = EGL10.EGL_NO_DISPLAY;
+      }
+    }
+
+    void cleanup() {
+      destroySurface();
+      destroyContext();
+      terminate();
+    }
+  }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
@@ -72,6 +72,9 @@
     <public name="mapbox_uiAttributionMarginRight" type="attr" />
     <public name="mapbox_uiAttributionMarginBottom" type="attr" />
 
+    <!-- Use TextureView-->
+    <public name="mapbox_renderTextureMode" type="attr" />
+
     <public name="mapbox_enableTilePrefetch" type="attr" />
     <public name="mapbox_enableZMediaOverlay" type="attr" />
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/attrs.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/attrs.xml
@@ -114,6 +114,9 @@
         <attr name="mapbox_uiAttributionMarginBottom" format="dimension"/>
         <attr name="mapbox_uiAttributionTintColor" format="color"/>
 
+        <!-- Use TextureView-->
+        <attr name="mapbox_renderTextureMode" format="boolean"/>
+
         <attr name="mapbox_enableTilePrefetch" format="boolean"/>
         <attr name="mapbox_enableZMediaOverlay" format="boolean"/>
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -728,6 +728,29 @@
                 android:value="@string/category_maplayout"/>
         </activity>
 
+        <!-- TextureView -->
+        <activity android:name=".activity.textureview.TextureViewDebugModeActivity"
+                  android:description="@string/description_textureview_debug"
+                  android:label="@string/activity_textureview_debug">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_textureview"/>
+        </activity>
+        <activity android:name=".activity.textureview.TextureViewResizeActivity"
+                  android:description="@string/description_textureview_resize"
+                  android:label="@string/activity_textureview_resize">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_textureview"/>
+        </activity>
+        <activity android:name=".activity.textureview.TextureViewAnimationActivity"
+                  android:description="@string/description_textureview_animate"
+                  android:label="@string/activity_textureview_animate">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_textureview"/>
+        </activity>
+
         <!-- For Instrumentation tests -->
         <activity
             android:name=".activity.style.RuntimeStyleTestActivity"

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/textureview/TextureViewAnimationActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/textureview/TextureViewAnimationActivity.java
@@ -1,0 +1,157 @@
+package com.mapbox.mapboxsdk.testapp.activity.textureview;
+
+import android.animation.ObjectAnimator;
+import android.os.Bundle;
+import android.os.Handler;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
+import android.widget.TextView;
+
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.testapp.R;
+
+import java.util.Locale;
+
+/**
+ * Test animating a {@link android.view.TextureView} backed map.
+ */
+public class TextureViewAnimationActivity extends AppCompatActivity {
+
+  private MapView mapView;
+  private MapboxMap mapboxMap;
+  private Handler handler;
+  private Runnable delayed;
+
+  private static LatLng[] PLACES = {
+    new LatLng(37.7749, -122.4194), // SF
+    new LatLng(38.9072, -77.0369), // DC
+    new LatLng(52.3702, 4.8952), // AMS
+    new LatLng(60.1699, 24.9384), // HEL
+    new LatLng(-13.1639, -74.2236), // AYA
+    new LatLng(52.5200, 13.4050), // BER
+    new LatLng(12.9716, 77.5946), // BAN
+    new LatLng(31.2304, 121.4737) // SHA
+  };
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_textureview_animate);
+    handler = new Handler(getMainLooper());
+    setupToolbar();
+    setupMapView(savedInstanceState);
+  }
+
+  private void setupToolbar() {
+    ActionBar actionBar = getSupportActionBar();
+    if (actionBar != null) {
+      getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+      getSupportActionBar().setHomeButtonEnabled(true);
+    }
+  }
+
+  private void setupMapView(Bundle savedInstanceState) {
+    mapView = (MapView) findViewById(R.id.mapView);
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+      public void onMapReady(MapboxMap mapboxMap) {
+        TextureViewAnimationActivity.this.mapboxMap = mapboxMap;
+
+        setFpsView(mapboxMap);
+
+        // Animate the map view
+        ObjectAnimator animation = ObjectAnimator.ofFloat(mapView, "rotationY", 0.0f, 360f);
+        animation.setDuration(3600);
+        animation.setRepeatCount(ObjectAnimator.INFINITE);
+        animation.start();
+
+        // Start an animation on the map as well
+        flyTo(mapboxMap, 0, 14);
+      }
+    });
+  }
+
+  private void flyTo(final MapboxMap mapboxMap, final int place, final double zoom) {
+    mapboxMap.animateCamera(
+      CameraUpdateFactory.newLatLngZoom(PLACES[place], zoom),
+      10000,
+      new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          delayed = new Runnable() {
+            @Override
+            public void run() {
+              delayed = null;
+              flyTo(mapboxMap, place, zoom);
+            }
+          };
+          handler.postDelayed(delayed, 2000);
+        }
+
+        @Override
+        public void onFinish() {
+          flyTo(mapboxMap, place == (PLACES.length - 1) ? 0 : place + 1, zoom);
+        }
+      });
+  }
+
+  private void setFpsView(MapboxMap mapboxMap) {
+    final TextView fpsView = (TextView) findViewById(R.id.fpsView);
+    mapboxMap.setOnFpsChangedListener(new MapboxMap.OnFpsChangedListener() {
+      @Override
+      public void onFpsChanged(double fps) {
+        fpsView.setText(String.format(Locale.US, "FPS: %4.2f", fps));
+      }
+    });
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+    if (handler != null && delayed != null) {
+      handler.removeCallbacks(delayed);
+    }
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/textureview/TextureViewDebugModeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/textureview/TextureViewDebugModeActivity.java
@@ -1,0 +1,293 @@
+package com.mapbox.mapboxsdk.testapp.activity.textureview;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.support.design.widget.FloatingActionButton;
+import android.support.v4.widget.DrawerLayout;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.ActionBarDrawerToggle;
+import android.support.v7.app.AppCompatActivity;
+import android.view.LayoutInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.BaseAdapter;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.constants.Style;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.style.layers.Layer;
+import com.mapbox.mapboxsdk.style.layers.Property;
+import com.mapbox.mapboxsdk.testapp.R;
+
+import java.util.List;
+import java.util.Locale;
+
+import timber.log.Timber;
+
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility;
+
+/**
+ * Test activity showcasing the different debug modes and allows to cycle between the default map styles.
+ */
+public class TextureViewDebugModeActivity extends AppCompatActivity implements OnMapReadyCallback {
+
+  private MapView mapView;
+  private MapboxMap mapboxMap;
+  private ActionBarDrawerToggle actionBarDrawerToggle;
+  private int currentStyleIndex = 0;
+
+  private static final String[] STYLES = new String[] {
+    Style.MAPBOX_STREETS,
+    Style.OUTDOORS,
+    Style.LIGHT,
+    Style.DARK,
+    Style.SATELLITE,
+    Style.SATELLITE_STREETS,
+    Style.TRAFFIC_DAY,
+    Style.TRAFFIC_NIGHT
+  };
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_textureview_debug_mode);
+    setupToolbar();
+    setupMapView(savedInstanceState);
+    setupDebugChangeView();
+    setupStyleChangeView();
+  }
+
+  private void setupToolbar() {
+    ActionBar actionBar = getSupportActionBar();
+    if (actionBar != null) {
+      getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+      getSupportActionBar().setHomeButtonEnabled(true);
+
+      DrawerLayout drawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
+      actionBarDrawerToggle = new ActionBarDrawerToggle(this,
+        drawerLayout,
+        R.string.navigation_drawer_open,
+        R.string.navigation_drawer_close
+      );
+      actionBarDrawerToggle.setDrawerIndicatorEnabled(true);
+      actionBarDrawerToggle.syncState();
+    }
+  }
+
+  private void setupMapView(Bundle savedInstanceState) {
+    mapView = (MapView) findViewById(R.id.mapView);
+    mapView.addOnMapChangedListener(new MapView.OnMapChangedListener() {
+      @Override
+      public void onMapChanged(int change) {
+        if (change == MapView.DID_FINISH_LOADING_STYLE && mapboxMap != null) {
+          Timber.v("New style loaded with JSON: %s", mapboxMap.getStyleJson());
+          setupNavigationView(mapboxMap.getLayers());
+        }
+      }
+    });
+
+    mapView.setTag(true);
+    mapView.setStyleUrl(STYLES[currentStyleIndex]);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(this);
+  }
+
+  @Override
+  public void onMapReady(MapboxMap map) {
+    mapboxMap = map;
+    mapboxMap.getUiSettings().setZoomControlsEnabled(true);
+
+    setupNavigationView(mapboxMap.getLayers());
+    setupZoomView();
+    setFpsView();
+  }
+
+  private void setFpsView() {
+    final TextView fpsView = (TextView) findViewById(R.id.fpsView);
+    mapboxMap.setOnFpsChangedListener(new MapboxMap.OnFpsChangedListener() {
+      @Override
+      public void onFpsChanged(double fps) {
+        fpsView.setText(String.format(Locale.US,"FPS: %4.2f", fps));
+      }
+    });
+  }
+
+  private void setupNavigationView(List<Layer> layerList) {
+    final LayerListAdapter adapter = new LayerListAdapter(this, layerList);
+    ListView listView = (ListView) findViewById(R.id.listView);
+    listView.setAdapter(adapter);
+    listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+      @Override
+      public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+        Layer clickedLayer = adapter.getItem(position);
+        toggleLayerVisibility(clickedLayer);
+        closeNavigationView();
+      }
+    });
+  }
+
+  private void toggleLayerVisibility(Layer layer) {
+    boolean isVisible = layer.getVisibility().getValue().equals(Property.VISIBLE);
+    layer.setProperties(
+      visibility(
+        isVisible ? Property.NONE : Property.VISIBLE
+      )
+    );
+  }
+
+  private void closeNavigationView() {
+    DrawerLayout drawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
+    drawerLayout.closeDrawers();
+  }
+
+  private void setupZoomView() {
+    final TextView textView = (TextView) findViewById(R.id.textZoom);
+    mapboxMap.setOnCameraChangeListener(new MapboxMap.OnCameraChangeListener() {
+      @Override
+      public void onCameraChange(CameraPosition position) {
+        textView.setText(String.format(getString(R.string.debug_zoom), position.zoom));
+      }
+    });
+  }
+
+  private void setupDebugChangeView() {
+    FloatingActionButton fabDebug = (FloatingActionButton) findViewById(R.id.fabDebug);
+    fabDebug.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View view) {
+        if (mapboxMap != null) {
+          Timber.d("Debug FAB: isDebug Active? %s", mapboxMap.isDebugActive());
+          mapboxMap.cycleDebugOptions();
+        }
+      }
+    });
+  }
+
+  private void setupStyleChangeView() {
+    FloatingActionButton fabStyles = (FloatingActionButton) findViewById(R.id.fabStyles);
+    fabStyles.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View view) {
+        if (mapboxMap != null) {
+          currentStyleIndex++;
+          if (currentStyleIndex == STYLES.length) {
+            currentStyleIndex = 0;
+          }
+          mapboxMap.setStyleUrl(STYLES[currentStyleIndex], new MapboxMap.OnStyleLoadedListener() {
+            @Override
+            public void onStyleLoaded(String style) {
+              Timber.d("Style loaded %s", style);
+            }
+          });
+        }
+      }
+    });
+  }
+
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    return actionBarDrawerToggle.onOptionsItemSelected(item) || super.onOptionsItemSelected(item);
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  private static class LayerListAdapter extends BaseAdapter {
+
+    private LayoutInflater layoutInflater;
+    private List<Layer> layers;
+
+    LayerListAdapter(Context context, List<Layer> layers) {
+      this.layoutInflater = LayoutInflater.from(context);
+      this.layers = layers;
+    }
+
+    @Override
+    public int getCount() {
+      return layers.size();
+    }
+
+    @Override
+    public Layer getItem(int position) {
+      return layers.get(position);
+    }
+
+    @Override
+    public long getItemId(int position) {
+      return position;
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+      Layer layer = layers.get(position);
+      View view = convertView;
+      if (view == null) {
+        view = layoutInflater.inflate(android.R.layout.simple_list_item_2, parent, false);
+        ViewHolder holder = new ViewHolder(
+          (TextView) view.findViewById(android.R.id.text1),
+          (TextView) view.findViewById(android.R.id.text2)
+        );
+        view.setTag(holder);
+      }
+      ViewHolder holder = (ViewHolder) view.getTag();
+      holder.text.setText(layer.getClass().getSimpleName());
+      holder.subText.setText(layer.getId());
+      return view;
+    }
+
+    private static class ViewHolder {
+      final TextView text;
+      final TextView subText;
+
+      ViewHolder(TextView text, TextView subText) {
+        this.text = text;
+        this.subText = subText;
+      }
+    }
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/textureview/TextureViewResizeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/textureview/TextureViewResizeActivity.java
@@ -1,0 +1,107 @@
+package com.mapbox.mapboxsdk.testapp.activity.textureview;
+
+import android.os.Bundle;
+import android.support.design.widget.CoordinatorLayout;
+import android.support.design.widget.FloatingActionButton;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.testapp.R;
+
+/**
+ * Test resizing a {@link android.view.TextureView} backed map on the fly.
+ */
+public class TextureViewResizeActivity extends AppCompatActivity {
+
+  private MapView mapView;
+  private MapboxMap mapboxMap;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_textureview_resize);
+    setupToolbar();
+    setupMapView(savedInstanceState);
+    setupFab();
+  }
+
+  private void setupToolbar() {
+    ActionBar actionBar = getSupportActionBar();
+    if (actionBar != null) {
+      getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+      getSupportActionBar().setHomeButtonEnabled(true);
+    }
+  }
+
+  private void setupMapView(Bundle savedInstanceState) {
+    mapView = (MapView) findViewById(R.id.mapView);
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+      public void onMapReady(MapboxMap mapboxMap) {
+        TextureViewResizeActivity.this.mapboxMap = mapboxMap;
+      }
+    });
+  }
+
+  private void setupFab() {
+    FloatingActionButton fabDebug = (FloatingActionButton) findViewById(R.id.fabResize);
+    fabDebug.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View view) {
+        if (mapView != null) {
+          View parent = findViewById(R.id.coordinator_layout);
+          int width = parent.getWidth() == mapView.getWidth() ? parent.getWidth() / 2 : parent.getWidth();
+          int height = parent.getHeight() == mapView.getHeight() ? parent.getHeight() / 2 : parent.getHeight();
+          mapView.setLayoutParams(new CoordinatorLayout.LayoutParams(width, height));
+        }
+      }
+    });
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_textureview_animate.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_textureview_animate.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinator_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/mapbox_blue"
+    android:orientation="vertical">
+
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_margin="50dp"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:mapbox_renderTextureMode="true"/>
+
+    <TextView
+        android:id="@+id/fpsView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|right"
+        android:layout_margin="16dp"
+        android:textIsSelectable="true"
+        android:textSize="14sp"/>
+
+</android.support.design.widget.CoordinatorLayout>
+

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_textureview_debug_mode.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_textureview_debug_mode.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v4.widget.DrawerLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/drawer_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:clickable="true"
+    android:focusable="true"
+    android:focusableInTouchMode="true">
+
+    <android.support.design.widget.CoordinatorLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/coordinator_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <com.mapbox.mapboxsdk.maps.MapView
+            android:id="@+id/mapView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:mapbox_renderTextureMode="true"
+            app:mapbox_uiAttribution="false"
+            app:mapbox_uiCompass="false"
+            app:mapbox_uiLogo="false"/>
+
+        <TextView
+            android:id="@+id/textZoom"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|start"
+            android:layout_margin="8dp"
+            android:textIsSelectable="true"
+            android:textSize="14sp"
+            app:layout_anchor="@id/bottom_sheet"
+            app:layout_anchorGravity="bottom|start"/>
+
+        <TextView
+            android:id="@+id/fpsView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="top|end"
+            android:layout_margin="8dp"
+            android:textIsSelectable="true"
+            android:textSize="14sp"
+            app:layout_anchor="@id/textZoom"
+            app:layout_anchorGravity="top"/>
+
+        <android.support.v4.widget.NestedScrollView
+            android:id="@+id/bottom_sheet"
+            android:layout_width="match_parent"
+            android:layout_height="250dp"
+            android:background="@color/white"
+            android:visibility="invisible"
+            app:behavior_hideable="true"
+            app:layout_behavior="android.support.design.widget.BottomSheetBehavior"/>
+
+        <android.support.design.widget.FloatingActionButton
+            android:id="@+id/fabDebug"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="top|end"
+            android:layout_marginBottom="82dp"
+            android:layout_marginEnd="@dimen/fab_margin"
+            android:layout_marginRight="@dimen/fab_margin"
+            android:src="@drawable/ic_refresh"
+            app:backgroundTint="@color/accent"
+            app:layout_anchor="@+id/fabStyles"
+            app:layout_anchorGravity="top"/>
+
+        <android.support.design.widget.FloatingActionButton
+            android:id="@id/fabStyles"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end|bottom"
+            android:layout_margin="@dimen/fab_margin"
+            android:src="@drawable/ic_layers"
+            app:backgroundTint="@color/primary"
+            app:layout_anchor="@id/bottom_sheet"
+            app:layout_anchorGravity="bottom|end"/>
+
+    </android.support.design.widget.CoordinatorLayout>
+
+    <android.support.design.widget.NavigationView
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        android:background="@android:color/white">
+
+        <ListView
+            android:id="@+id/listView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
+
+    </android.support.design.widget.NavigationView>
+
+</android.support.v4.widget.DrawerLayout>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_textureview_resize.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_textureview_resize.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinator_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:mapbox_renderTextureMode="true"/>
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/fabResize"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|right"
+        android:layout_marginBottom="@dimen/fab_margin"
+        android:layout_marginRight="@dimen/fab_margin"
+        android:src="@drawable/ic_refresh"
+        app:backgroundTint="@color/accent"
+        app:layout_anchorGravity="bottom"/>
+
+</android.support.design.widget.CoordinatorLayout>
+

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/categories.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/categories.xml
@@ -14,4 +14,5 @@
     <string name="category_style">Styling</string>
     <string name="category_features">Features</string>
     <string name="category_storage">Storage</string>
+    <string name="category_textureview">Texture View</string>
 </resources>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
@@ -64,4 +64,7 @@
     <string name="description_map_snapshotter_marker">Show how to add a marker to a Snapshot</string>
     <string name="description_camera_animator">Use Android SDK Animators to animate camera position changes</string>
     <string name="description_symbol_generator">Use Android SDK Views as symbols</string>
+    <string name="description_textureview_debug">Use TextureView to render the map</string>
+    <string name="description_textureview_resize">Resize a map rendered on a TextureView</string>
+    <string name="description_textureview_animate">Animate a map rendered on a TextureView</string>
 </resources>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
@@ -64,4 +64,7 @@
     <string name="activity_map_snapshotter_marker">Map Snapshot with marker</string>
     <string name="activity_camera_animator">Animator animation</string>
     <string name="activity_symbol_generator">SymbolGenerator</string>
+    <string name="activity_textureview_debug">TextureView debug</string>
+    <string name="activity_textureview_resize">TextureView resize</string>
+    <string name="activity_textureview_animate">TextureView animation</string>
 </resources>


### PR DESCRIPTION
Brings back the (deprecated) `TextureView` option, removed in #9576. Built on top of the a-synchronous rendering with a dedicated render thread to unblock the main thread as much as possible.

TODO:
- [x] Cleanup code
- [x] Cleanup on exit
- [x] Handle lost context
- [x] Handle bad surface
- [x] Life-cycle handling:
    - [x] pause/resume
    - [x] destroy
    - [x] multi-window
    - [x] rotate
- [x] Test activities
    - [x] Debug
    - [x] Transform
    - [x] Resize
- [x] un-deprecate