### PR TITLE
[ios] Add heading accuracy check and hide the header Indicator if need to.

### DIFF
--- a/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
+++ b/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
@@ -245,7 +245,9 @@ const CGFloat MGLUserLocationHeadingUpdateThreshold = 0.01;
             _oldHeadingAccuracy = -1;
         }
 
-        if ( ! _headingIndicatorLayer && headingAccuracy)
+        bool validHeadingAccuracy = headingAccuracy > 0 && headingAccuracy < kCLLocationAccuracyNearestTenMeters;
+        
+        if ( ! _headingIndicatorLayer && validHeadingAccuracy)
         {
             if (headingTrackingModeEnabled)
             {
@@ -258,6 +260,9 @@ const CGFloat MGLUserLocationHeadingUpdateThreshold = 0.01;
                 [self.layer addSublayer:_headingIndicatorLayer];
                 _headingIndicatorLayer.zPosition = 1;
             }
+        }
+        else {
+            _headingIndicatorLayer.hidden = YES;
         }
 
         if (_oldHeadingAccuracy != headingAccuracy)

--- a/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
+++ b/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
@@ -14,6 +14,8 @@ const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuck
 
 const CGFloat MGLUserLocationHeadingUpdateThreshold = 0.01;
 
+const CLLocationDirection MGLLUserLocationHeadingAccuracyThreshold = 30;
+
 @implementation MGLFaux3DUserLocationAnnotationView
 {
     BOOL _puckModeActivated;
@@ -245,7 +247,7 @@ const CGFloat MGLUserLocationHeadingUpdateThreshold = 0.01;
             _oldHeadingAccuracy = -1;
         }
 
-        bool validHeadingAccuracy = headingAccuracy > 0 && headingAccuracy < kCLLocationAccuracyNearestTenMeters;
+        bool validHeadingAccuracy = headingAccuracy > 0 && headingAccuracy <= MGLLUserLocationHeadingAccuracyThreshold;
         
         if ( ! _headingIndicatorLayer && validHeadingAccuracy)
         {


### PR DESCRIPTION
[ios] Add heading accuracy check and hide the header Indicator when the heading accuracy is outside the range. Use kCLLocationAccuracyNearestTenMeters as the threshold for now.