### PR TITLE
Revert "[core] Expose ColorMask in gl::Context::clear()"

### DIFF
--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -590,33 +590,28 @@ void Context::setDirtyState() {
 
 void Context::clear(optional<mbgl::Color> color,
                     optional<float> depth,
-                    optional<int32_t> stencil,
-                    optional<ColorMode::Mask> colorMask_) {
+                    optional<int32_t> stencil) {
     GLbitfield mask = 0;
 
     if (color) {
         mask |= GL_COLOR_BUFFER_BIT;
         clearColor = *color;
-        colorMask = colorMask_ ? *colorMask_ : value::ColorMask::Default;
+        colorMask = value::ColorMask::Default;
     }
 
     if (depth) {
         mask |= GL_DEPTH_BUFFER_BIT;
         clearDepth = *depth;
-        depthMask = true;
+        depthMask = value::DepthMask::Default;
     }
 
     if (stencil) {
         mask |= GL_STENCIL_BUFFER_BIT;
         clearStencil = *stencil;
-        stencilMask = 0xFF;
+        stencilMask = value::StencilMask::Default;
     }
 
     MBGL_CHECK_ERROR(glClear(mask));
-
-    if (colorMask_) {
-        colorMask = value::ColorMask::Default;
-    }
 }
 
 #if not MBGL_USE_GLES2

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -146,8 +146,7 @@ public:
 
     void clear(optional<mbgl::Color> color,
                optional<float> depth,
-               optional<int32_t> stencil,
-               optional<ColorMode::Mask> colorMask = value::ColorMask::Default);
+               optional<int32_t> stencil);
 
     void setDrawMode(const Points&);
     void setDrawMode(const Lines&);

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -443,9 +443,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         if (parameters.debugOptions & MapDebugOptions::Overdraw) {
             parameters.context.clear(Color::black(), ClearDepth::Default, ClearStencil::Default);
         } else if (parameters.contextMode == GLContextMode::Shared) {
-            // Preserve the shared context background colors, clearing only alpha.
-            optional<gl::ColorMode::Mask> mask = { { false, false, false, true } };
-            parameters.context.clear(backgroundColor, ClearDepth::Default, ClearStencil::Default, mask);
+            parameters.context.clear({}, ClearDepth::Default, ClearStencil::Default);
         } else {
             parameters.context.clear(backgroundColor, ClearDepth::Default, ClearStencil::Default);
         }


### PR DESCRIPTION
As mentioned by @paoletto in https://github.com/mapbox/mapbox-gl-native/pull/10329#issuecomment-341158497, it turns out we don't need to clear the color buffers _at all_ (including alpha channel) in shared context mode.

This partially reverts commit e350ef37fe68312c4b5fb03b289a90c0bdda4f03.

Ref: https://github.com/mapbox/mapbox-gl-native/pull/10329