### PR TITLE
fade symbols across tiles

### DIFF
--- a/src/mbgl/layout/symbol_instance.cpp
+++ b/src/mbgl/layout/symbol_instance.cpp
@@ -26,6 +26,7 @@ SymbolInstance::SymbolInstance(Anchor& anchor_,
                                const std::size_t featureIndex_,
                                const std::u16string& key_) :
     anchor(anchor_),
+    insideTileBoundaries(0 <= anchor.point.x && 0 <= anchor.point.y && anchor.point.x < util::EXTENT && anchor.point.y < util::EXTENT),
     line(line_),
     index(index_),
     hasText(shapedTextOrientations.first || shapedTextOrientations.second),

--- a/src/mbgl/layout/symbol_instance.hpp
+++ b/src/mbgl/layout/symbol_instance.hpp
@@ -35,6 +35,7 @@ public:
                    const std::u16string& key);
 
     Anchor anchor;
+    bool insideTileBoundaries;
     GeometryCoordinates line;
     uint32_t index;
     bool hasText;

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -128,6 +128,8 @@ public:
         gl::IndexVector<gl::Triangles> triangles;
         optional<gl::IndexBuffer<gl::Triangles>> indexBuffer;
     } collisionCircle;
+
+    uint32_t bucketInstanceId = 0;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -366,9 +366,10 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         order.emplace_back(RenderItem { *layer, source });
     }
 
+    bool symbolBucketsChanged = false;
     for (auto it = order.rbegin(); it != order.rend(); ++it) {
         if (it->layer.is<RenderSymbolLayer>()) {
-            crossTileSymbolIndex->addLayer(*it->layer.as<RenderSymbolLayer>());
+            if (crossTileSymbolIndex->addLayer(*it->layer.as<RenderSymbolLayer>())) symbolBucketsChanged = true;
         }
     }
 
@@ -383,10 +384,11 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
     if (placementChanged) placement = std::move(newPlacement);
     parameters.symbolFadeChange = placement->symbolFadeChange(parameters.timePoint);
 
-    // TODO only update when necessary
-    for (auto it = order.rbegin(); it != order.rend(); ++it) {
-        if (it->layer.is<RenderSymbolLayer>()) {
-            placement->updateLayerOpacities(*it->layer.as<RenderSymbolLayer>());
+    if (placementChanged || symbolBucketsChanged) {
+        for (auto it = order.rbegin(); it != order.rend(); ++it) {
+            if (it->layer.is<RenderSymbolLayer>()) {
+                placement->updateLayerOpacities(*it->layer.as<RenderSymbolLayer>());
+            }
         }
     }
 

--- a/src/mbgl/renderer/renderer_impl.hpp
+++ b/src/mbgl/renderer/renderer_impl.hpp
@@ -31,6 +31,7 @@ class Scheduler;
 class GlyphManager;
 class ImageManager;
 class LineAtlas;
+class CrossTileSymbolIndex;
 
 class Renderer::Impl : public GlyphManagerObserver,
                        public RenderSourceObserver{
@@ -104,6 +105,7 @@ private:
     std::unordered_map<std::string, std::unique_ptr<RenderLayer>> renderLayers;
     RenderLight renderLight;
 
+    std::unique_ptr<CrossTileSymbolIndex> crossTileSymbolIndex;
     std::unique_ptr<Placement> placement;
 
     bool contextLost = false;

--- a/src/mbgl/text/cross_tile_symbol_index.cpp
+++ b/src/mbgl/text/cross_tile_symbol_index.cpp
@@ -28,7 +28,6 @@ Point<double> TileLayerIndex::getScaledCoordinates(SymbolInstance& symbolInstanc
 
 void TileLayerIndex::findMatches(std::vector<SymbolInstance>& symbolInstances, const OverscaledTileID& newCoord) {
     float tolerance = coord.canonical.z < newCoord.canonical.z ? 1 : std::pow(2, coord.canonical.z - newCoord.canonical.z);
-    tolerance = 100;
 
     for (auto& symbolInstance : symbolInstances) {
         // already has a match, skip

--- a/src/mbgl/text/cross_tile_symbol_index.cpp
+++ b/src/mbgl/text/cross_tile_symbol_index.cpp
@@ -1,29 +1,22 @@
 #include <mbgl/text/cross_tile_symbol_index.hpp>
 #include <mbgl/layout/symbol_instance.hpp>
+#include <mbgl/renderer/buckets/symbol_bucket.hpp>
+#include <mbgl/renderer/render_tile.hpp>
+#include <mbgl/tile/tile.hpp>
 
 namespace mbgl {
 
 
-TileLayerIndex::TileLayerIndex(OverscaledTileID coord_, std::shared_ptr<std::vector<SymbolInstance>> symbolInstances_)
-    : coord(coord_), symbolInstances(symbolInstances_) {
-        for (SymbolInstance& symbolInstance : *symbolInstances) {
-            if (indexedSymbolInstances.find(symbolInstance.key) == indexedSymbolInstances.end()) {
-                indexedSymbolInstances.emplace(symbolInstance.key, std::vector<IndexedSymbolInstance>());
+TileLayerIndex::TileLayerIndex(OverscaledTileID coord_, std::vector<SymbolInstance>& symbolInstances) 
+    : coord(coord_) {
+        for (SymbolInstance& symbolInstance : symbolInstances) {
+            if (symbolInstance.insideTileBoundaries) {
+                indexedSymbolInstances[symbolInstance.key].emplace_back(symbolInstance.crossTileID, getScaledCoordinates(symbolInstance, coord));
             }
-
-            indexedSymbolInstances.at(symbolInstance.key).emplace_back(symbolInstance, getScaledCoordinates(symbolInstance, coord));
-
-            symbolInstance.isDuplicate = false;
-            // symbolInstance.isDuplicate = false;
-            // If we don't pick up an opacity from our parent or child tiles
-            // Reset so that symbols in cached tiles fade in the same
-            // way as freshly loaded tiles
-            //symbolInstance.textOpacityState = OpacityState();
-            //symbolInstance.iconOpacityState = OpacityState();
         }
     }
 
-Point<double> TileLayerIndex::getScaledCoordinates(SymbolInstance& symbolInstance, OverscaledTileID& childTileCoord) {
+Point<double> TileLayerIndex::getScaledCoordinates(SymbolInstance& symbolInstance, const OverscaledTileID& childTileCoord) {
     // Round anchor positions to roughly 4 pixel grid
     const double roundingFactor = 512.0 / util::EXTENT / 2.0;
     const double scale = roundingFactor / std::pow(2, childTileCoord.canonical.z - coord.canonical.z);
@@ -33,28 +26,41 @@ Point<double> TileLayerIndex::getScaledCoordinates(SymbolInstance& symbolInstanc
     };
 }
 
-optional<SymbolInstance> TileLayerIndex::getMatchingSymbol(SymbolInstance& childTileSymbol, OverscaledTileID& childTileCoord) {
-    auto it = indexedSymbolInstances.find(childTileSymbol.key);
-    if (it == indexedSymbolInstances.end()) return {};
+void TileLayerIndex::findMatches(std::vector<SymbolInstance>& symbolInstances, const OverscaledTileID& newCoord) {
+    float tolerance = coord.canonical.z < newCoord.canonical.z ? 1 : std::pow(2, coord.canonical.z - newCoord.canonical.z);
+    tolerance = 100;
 
-    Point<double> childTileSymbolCoord = getScaledCoordinates(childTileSymbol, childTileCoord);
+    for (auto& symbolInstance : symbolInstances) {
+        // already has a match, skip
+        if (symbolInstance.crossTileID) continue;
 
-    for (IndexedSymbolInstance& thisTileSymbol: it->second) {
-		// Return any symbol with the same keys whose coordinates are within 1
-        // grid unit. (with a 4px grid, this covers a 12px by 12px area)
-        if (std::fabs(thisTileSymbol.coord.x - childTileSymbolCoord.x) <= 1 &&
-            std::fabs(thisTileSymbol.coord.y - childTileSymbolCoord.y) <= 1) {
-            return { thisTileSymbol.instance };
+        auto it = indexedSymbolInstances.find(symbolInstance.key);
+        if (it == indexedSymbolInstances.end()) continue;
+
+        Point<double> scaledSymbolCoord = getScaledCoordinates(symbolInstance, newCoord);
+
+        for (IndexedSymbolInstance& thisTileSymbol: it->second) {
+            // Return any symbol with the same keys whose coordinates are within 1
+            // grid unit. (with a 4px grid, this covers a 12px by 12px area)
+            if (std::fabs(thisTileSymbol.coord.x - scaledSymbolCoord.x) <= tolerance &&
+                std::fabs(thisTileSymbol.coord.y - scaledSymbolCoord.y) <= tolerance) {
+
+                symbolInstance.crossTileID = thisTileSymbol.crossTileID;
+                break;
+            }
         }
     }
-
-    return {};
 }
 
 CrossTileSymbolLayerIndex::CrossTileSymbolLayerIndex() {
 }
 
-void CrossTileSymbolLayerIndex::addTile(const OverscaledTileID& coord, std::shared_ptr<std::vector<SymbolInstance>> symbolInstances) {
+uint32_t CrossTileSymbolLayerIndex::maxCrossTileID = 0;
+
+void CrossTileSymbolLayerIndex::addBucket(const OverscaledTileID& coord, SymbolBucket& bucket) {
+    if (bucket.bucketInstanceId) return;
+    bucket.bucketInstanceId = ++maxBucketInstanceId;
+
     uint8_t minZoom = 25;
     uint8_t maxZoom = 0;
     for (auto& it : indexes) {
@@ -63,42 +69,42 @@ void CrossTileSymbolLayerIndex::addTile(const OverscaledTileID& coord, std::shar
         maxZoom = std::max(maxZoom, z);
     }
 
-    TileLayerIndex tileIndex(coord, symbolInstances);
 
     // make all higher-res child tiles block duplicate labels in this tile
     for (auto z = maxZoom; z > coord.overscaledZ; z--) {
-        auto zoomIndexes = indexes.find(coord.overscaledZ);
+        auto zoomIndexes = indexes.find(z);
         if (zoomIndexes != indexes.end()) {
             for (auto& childIndex : zoomIndexes->second) {
                 if (!childIndex.second.coord.isChildOf(coord)) continue;
-                // Mark labels in this tile blocked, and don't copy opacity state
-                // into this tile
-                blockLabels(childIndex.second, tileIndex, false);
+                childIndex.second.findMatches(bucket.symbolInstances, coord);
             }
         }
     }
 
     // make this tile block duplicate labels in lower-res parent tiles
-    for (auto z = coord.overscaledZ - 1; z >= minZoom; z--) {
+    for (auto z = coord.overscaledZ; z >= minZoom; z--) {
         auto parentCoord = coord.scaledTo(z);
         auto zoomIndexes = indexes.find(z);
         if (zoomIndexes != indexes.end()) {
             auto parentIndex = zoomIndexes->second.find(parentCoord);
             if (parentIndex != zoomIndexes->second.end()) {
-                // Mark labels in the parent tile blocked, and copy opacity state
-                // into this tile
-                blockLabels(tileIndex, parentIndex->second, true);
+                parentIndex->second.findMatches(bucket.symbolInstances, coord);
             }
         }
     }
     
-    if (indexes.find(coord.overscaledZ) == indexes.end()) {
-        indexes.emplace(coord.overscaledZ, std::map<OverscaledTileID,TileLayerIndex>());
+    for (auto& symbolInstance : bucket.symbolInstances) {
+        if (!symbolInstance.crossTileID && symbolInstance.insideTileBoundaries) {
+            // symbol did not match any known symbol, assign a new id
+            symbolInstance.crossTileID = ++maxCrossTileID;
+        }
     }
 
-    indexes.at(coord.overscaledZ).emplace(coord, std::move(tileIndex));
+    TileLayerIndex tileIndex(coord, bucket.symbolInstances);
+    indexes[coord.overscaledZ].emplace(coord, std::move(tileIndex));
 }
 
+/*
 void CrossTileSymbolLayerIndex::removeTile(const OverscaledTileID& coord) {
 	
 	auto removedIndex = indexes.at(coord.overscaledZ).at(coord);
@@ -125,51 +131,30 @@ void CrossTileSymbolLayerIndex::removeTile(const OverscaledTileID& coord) {
         indexes.erase(coord.overscaledZ);
     }
 }
-
-void CrossTileSymbolLayerIndex::blockLabels(TileLayerIndex& childIndex, TileLayerIndex& parentIndex, bool copyParentOpacity) {
-    for (auto& symbolInstance : *childIndex.symbolInstances) {
-        // only non-duplicate labels can block other labels
-        if (!symbolInstance.isDuplicate) {
-            auto parentSymbolInstance = parentIndex.getMatchingSymbol(symbolInstance, childIndex.coord);
-            if (parentSymbolInstance) {
-                // if the parent label was previously non-duplicate, make it duplicate because it's now blocked
-                if (!parentSymbolInstance->isDuplicate) {
-                    parentSymbolInstance->isDuplicate = true;
-
-                    // If the child label is the one being added to the index,
-                    // copy the parent's opacity to the child
-                    if (copyParentOpacity) {
-                        //symbolInstance.textOpacityState = parentSymbolInstance->textOpacityState;
-                        //symbolInstance.iconOpacityState = parentSymbolInstance->iconOpacityState;
-                    }
-                }
-            }
-        }
-    }
-}
-
-void CrossTileSymbolLayerIndex::unblockLabels(TileLayerIndex& childIndex, TileLayerIndex& parentIndex) {
-    assert(childIndex.coord.overscaledZ > parentIndex.coord.overscaledZ);
-    for (auto& symbolInstance : *childIndex.symbolInstances) {
-        // only non-duplicate labels were blocking other labels
-        if (!symbolInstance.isDuplicate) {
-            auto parentSymbolInstance = parentIndex.getMatchingSymbol(symbolInstance, childIndex.coord);
-            if (parentSymbolInstance) {
-                // this label is now unblocked, copy its opacity state
-                parentSymbolInstance->isDuplicate = false;
-                //parentSymbolInstance->textOpacityState = symbolInstance.textOpacityState;
-                //parentSymbolInstance->iconOpacityState = symbolInstance.iconOpacityState;
-
-                // mark child as duplicate so that it doesn't unblock further tiles at lower res
-                // in the remaining calls to unblockLabels before it's fully removed
-                symbolInstance.isDuplicate = true;
-            }
-        }
-    }
-}
+*/
 
 CrossTileSymbolIndex::CrossTileSymbolIndex() {}
 
+void CrossTileSymbolIndex::addLayer(RenderSymbolLayer& symbolLayer) {
+
+    auto& layerIndex = layerIndexes[symbolLayer.getID()];
+
+     for (RenderTile& renderTile : symbolLayer.renderTiles) {
+         if (!renderTile.tile.isRenderable()) {
+             continue;
+         }
+
+
+
+         auto bucket = renderTile.tile.getBucket(*symbolLayer.baseImpl);
+         assert(dynamic_cast<SymbolBucket*>(bucket));
+         SymbolBucket& symbolBucket = *reinterpret_cast<SymbolBucket*>(bucket);
+
+         layerIndex.addBucket(renderTile.tile.id, symbolBucket);
+     }
+}
+
+/*
 void CrossTileSymbolIndex::addTileLayer(std::string& layerId, const OverscaledTileID& coord, std::shared_ptr<std::vector<SymbolInstance>> symbolInstances) {
     if (layerIndexes.find(layerId) == layerIndexes.end()) {
         layerIndexes.emplace(layerId, CrossTileSymbolLayerIndex());
@@ -185,4 +170,5 @@ void CrossTileSymbolIndex::removeTileLayer(std::string& layerId, const Overscale
         it->second.removeTile(coord);
     }
 }
+*/
 } // namespace mbgl

--- a/src/mbgl/text/cross_tile_symbol_index.cpp
+++ b/src/mbgl/text/cross_tile_symbol_index.cpp
@@ -16,13 +16,13 @@ TileLayerIndex::TileLayerIndex(OverscaledTileID coord_, std::vector<SymbolInstan
         }
     }
 
-Point<double> TileLayerIndex::getScaledCoordinates(SymbolInstance& symbolInstance, const OverscaledTileID& childTileCoord) {
+Point<int64_t> TileLayerIndex::getScaledCoordinates(SymbolInstance& symbolInstance, const OverscaledTileID& childTileCoord) {
     // Round anchor positions to roughly 4 pixel grid
     const double roundingFactor = 512.0 / util::EXTENT / 2.0;
     const double scale = roundingFactor / std::pow(2, childTileCoord.canonical.z - coord.canonical.z);
     return {
-        std::floor((childTileCoord.canonical.x * util::EXTENT + symbolInstance.anchor.point.x) * scale),
-        std::floor((childTileCoord.canonical.y * util::EXTENT + symbolInstance.anchor.point.y) * scale)
+        static_cast<int64_t>(std::floor((childTileCoord.canonical.x * util::EXTENT + symbolInstance.anchor.point.x) * scale)),
+        static_cast<int64_t>(std::floor((childTileCoord.canonical.y * util::EXTENT + symbolInstance.anchor.point.y) * scale))
     };
 }
 
@@ -36,13 +36,13 @@ void TileLayerIndex::findMatches(std::vector<SymbolInstance>& symbolInstances, c
         auto it = indexedSymbolInstances.find(symbolInstance.key);
         if (it == indexedSymbolInstances.end()) continue;
 
-        Point<double> scaledSymbolCoord = getScaledCoordinates(symbolInstance, newCoord);
+        auto scaledSymbolCoord = getScaledCoordinates(symbolInstance, newCoord);
 
         for (IndexedSymbolInstance& thisTileSymbol: it->second) {
             // Return any symbol with the same keys whose coordinates are within 1
             // grid unit. (with a 4px grid, this covers a 12px by 12px area)
-            if (std::fabs(thisTileSymbol.coord.x - scaledSymbolCoord.x) <= tolerance &&
-                std::fabs(thisTileSymbol.coord.y - scaledSymbolCoord.y) <= tolerance) {
+            if (std::abs(thisTileSymbol.coord.x - scaledSymbolCoord.x) <= tolerance &&
+                std::abs(thisTileSymbol.coord.y - scaledSymbolCoord.y) <= tolerance) {
 
                 symbolInstance.crossTileID = thisTileSymbol.crossTileID;
                 break;

--- a/src/mbgl/text/cross_tile_symbol_index.hpp
+++ b/src/mbgl/text/cross_tile_symbol_index.hpp
@@ -13,45 +13,48 @@
 namespace mbgl {
 
 class SymbolInstance;
+class RenderSymbolLayer;
+class SymbolBucket;
+
+class IndexEntry {
+    Point<float> anchorPoint;
+
+};
 
 class IndexedSymbolInstance {
     public:
-        IndexedSymbolInstance(SymbolInstance& symbolInstance, Point<double> coord_)
-            : instance(symbolInstance), coord(std::move(coord_)) {};
-        SymbolInstance& instance;
+        IndexedSymbolInstance(uint32_t crossTileID_, Point<double> coord_)
+            : crossTileID(crossTileID_), coord(coord_) {};
+        uint32_t crossTileID;
         Point<double> coord;
 };
 
 class TileLayerIndex {
     public:
-        TileLayerIndex(OverscaledTileID coord, std::shared_ptr<std::vector<SymbolInstance>>);
+        TileLayerIndex(OverscaledTileID coord, std::vector<SymbolInstance>&);
 
-        Point<double> getScaledCoordinates(SymbolInstance&, OverscaledTileID&);
-        optional<SymbolInstance> getMatchingSymbol(SymbolInstance& childTileSymbol, OverscaledTileID& childTileCoord);
+        Point<double> getScaledCoordinates(SymbolInstance&, const OverscaledTileID&);
+        void findMatches(std::vector<SymbolInstance>&, const OverscaledTileID&);
         
         OverscaledTileID coord;
         std::map<std::u16string,std::vector<IndexedSymbolInstance>> indexedSymbolInstances;
-        std::shared_ptr<std::vector<SymbolInstance>> symbolInstances;
 };
 
 class CrossTileSymbolLayerIndex {
     public:
         CrossTileSymbolLayerIndex();
-
-        void addTile(const OverscaledTileID&, std::shared_ptr<std::vector<SymbolInstance>>);
-        void removeTile(const OverscaledTileID&);
-        void blockLabels(TileLayerIndex& childIndex, TileLayerIndex& parentIndex, bool copyParentOpacity);
-        void unblockLabels(TileLayerIndex& childIndex, TileLayerIndex& parentIndex);
+        void addBucket(const OverscaledTileID&, SymbolBucket&);
     private:
         std::map<uint8_t,std::map<OverscaledTileID,TileLayerIndex>> indexes;
+        uint32_t maxBucketInstanceId = 0;
+        static uint32_t maxCrossTileID;
 };
 
 class CrossTileSymbolIndex {
     public:
         CrossTileSymbolIndex();
 
-        void addTileLayer(std::string& layerId, const OverscaledTileID&, std::shared_ptr<std::vector<SymbolInstance>>);
-        void removeTileLayer(std::string& layerId, const OverscaledTileID&);
+        void addLayer(RenderSymbolLayer&);
     private:
         std::map<std::string,CrossTileSymbolLayerIndex> layerIndexes;
 };

--- a/src/mbgl/text/cross_tile_symbol_index.hpp
+++ b/src/mbgl/text/cross_tile_symbol_index.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <string>
 #include <memory>
+#include <unordered_set>
 
 namespace mbgl {
 
@@ -31,12 +32,13 @@ class IndexedSymbolInstance {
 
 class TileLayerIndex {
     public:
-        TileLayerIndex(OverscaledTileID coord, std::vector<SymbolInstance>&);
+        TileLayerIndex(OverscaledTileID coord, std::vector<SymbolInstance>&, uint32_t bucketInstanceId);
 
         Point<double> getScaledCoordinates(SymbolInstance&, const OverscaledTileID&);
         void findMatches(std::vector<SymbolInstance>&, const OverscaledTileID&);
         
         OverscaledTileID coord;
+        uint32_t bucketInstanceId;
         std::map<std::u16string,std::vector<IndexedSymbolInstance>> indexedSymbolInstances;
 };
 
@@ -44,6 +46,7 @@ class CrossTileSymbolLayerIndex {
     public:
         CrossTileSymbolLayerIndex();
         void addBucket(const OverscaledTileID&, SymbolBucket&);
+        bool removeStaleBuckets(const std::unordered_set<uint32_t>& currentIDs);
     private:
         std::map<uint8_t,std::map<OverscaledTileID,TileLayerIndex>> indexes;
         uint32_t maxBucketInstanceId = 0;
@@ -54,7 +57,7 @@ class CrossTileSymbolIndex {
     public:
         CrossTileSymbolIndex();
 
-        void addLayer(RenderSymbolLayer&);
+        bool addLayer(RenderSymbolLayer&);
     private:
         std::map<std::string,CrossTileSymbolLayerIndex> layerIndexes;
 };

--- a/src/mbgl/text/cross_tile_symbol_index.hpp
+++ b/src/mbgl/text/cross_tile_symbol_index.hpp
@@ -24,17 +24,17 @@ class IndexEntry {
 
 class IndexedSymbolInstance {
     public:
-        IndexedSymbolInstance(uint32_t crossTileID_, Point<double> coord_)
+        IndexedSymbolInstance(uint32_t crossTileID_, Point<int64_t> coord_)
             : crossTileID(crossTileID_), coord(coord_) {};
         uint32_t crossTileID;
-        Point<double> coord;
+        Point<int64_t> coord;
 };
 
 class TileLayerIndex {
     public:
         TileLayerIndex(OverscaledTileID coord, std::vector<SymbolInstance>&, uint32_t bucketInstanceId);
 
-        Point<double> getScaledCoordinates(SymbolInstance&, const OverscaledTileID&);
+        Point<int64_t> getScaledCoordinates(SymbolInstance&, const OverscaledTileID&);
         void findMatches(std::vector<SymbolInstance>&, const OverscaledTileID&);
         
         OverscaledTileID coord;

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -30,8 +30,6 @@ bool JointOpacityState::isHidden() const {
     return icon.isHidden() && text.isHidden();
 }
 
-uint32_t Placement::maxCrossTileID = 0;
-
 Placement::Placement(const TransformState& state_, MapMode mapMode_)
     : collisionIndex(state_)
     , state(state_)
@@ -150,10 +148,7 @@ void Placement::placeLayerBucket(
                 collisionIndex.insertFeature(symbolInstance.iconCollisionFeature, bucket.layout.get<IconIgnorePlacement>());
             }
 
-            if (symbolInstance.crossTileID == 0) {
-                // TODO properly assign these
-                symbolInstance.crossTileID = ++maxCrossTileID;
-            }
+            assert(symbolInstance.crossTileID != 0);
 
             placements.emplace(symbolInstance.crossTileID, PlacementPair(placeText, placeIcon));
         }

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -66,7 +66,6 @@ namespace mbgl {
             MapMode mapMode;
             TimePoint commitTime;
 
-            static uint32_t maxCrossTileID; // TODO remove
             std::unordered_map<uint32_t,PlacementPair> placements;
             std::unordered_map<uint32_t,JointOpacityState> opacities;
     };

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -5,6 +5,7 @@
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/text/collision_index.hpp>
 #include <mbgl/layout/symbol_projection.hpp>
+#include <unordered_set>
 
 namespace mbgl {
 
@@ -58,7 +59,8 @@ namespace mbgl {
                     const mat4& iconLabelPlaneMatrix,
                     const float scale,
                     const float pixelRatio,
-                    const bool showCollisionBoxes);
+                    const bool showCollisionBoxes,
+                    std::unordered_set<uint32_t>& seenCrossTileIDs);
 
             void updateBucketOpacities(SymbolBucket&);
 


### PR DESCRIPTION
The `CrossTileSymbolIndex` assigns an id that is shared by similar symbols in different tiles. For example, a symbol for `Berlin` in two tiles would have the same ID. This lets us fade symbols across tile boundaries and will also let us apply old placements to newly loaded tiles.

---

@ChrisLoer 

This diffs each layer's current renderTiles internally and updates the index by adding/removing tiles. Removing is currently disabled because it makes the zoom flickering problem worse.