### PR TITLE
Workaround okhttp bug on Android Oreo

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HTTPRequest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HTTPRequest.java
@@ -85,7 +85,14 @@ class HTTPRequest implements Callback {
       }
       mRequest = builder.build();
       mCall = mClient.newCall(mRequest);
-      mCall.enqueue(this);
+
+      // TODO remove code block for workaround in #10303
+      if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.N_MR1) {
+        mCall.enqueue(this);
+      } else {
+        // Calling execute instead of enqueue is a workaround for #10303
+        onResponse(mCall, mCall.execute());
+      }
     } catch (Exception exception) {
       onFailure(exception);
     }


### PR DESCRIPTION
closes #10303.This PR works around an Android O bug related to okhttp. Once this is merged a follow up ticket should be created removing the workaround when a new version of okhttp has landed (atm no eta).