### PR TITLE
throttle symbol placement

### DIFF
--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -32,6 +32,7 @@ bool JointOpacityState::isHidden() const {
 
 Placement::Placement(const TransformState& state_, MapMode mapMode_)
     : collisionIndex(state_)
+    , recentUntil(TimePoint::min())
     , state(state_)
     , mapMode(mapMode_)
 {}
@@ -290,7 +291,7 @@ float Placement::symbolFadeChange(TimePoint now) const {
 }
 
 bool Placement::hasTransitions(TimePoint now) const {
-    return symbolFadeChange(now) < 1.0;
+    return symbolFadeChange(now) < 1.0 || stale;
 }
 
 } // namespace mbgl

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -50,6 +50,9 @@ namespace mbgl {
             // TODO: public for queryRenderedFeatures
             CollisionIndex collisionIndex;
 
+            TimePoint recentUntil;
+            bool stale = false;
+
         private:
 
             void placeLayerBucket(


### PR DESCRIPTION
This throttles symbol placement to once every 300ms.

Whenever a new tile is loaded it applies the previous slightly-stale Placement to the new buckets.

@ChrisLoer 