### PR TITLE
Start collision overscaling

### DIFF
--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -51,7 +51,6 @@
   "render-tests/text-pitch-alignment/map-text-rotation-alignment-map": "https://github.com/mapbox/mapbox-gl-native/issues/9732",
   "render-tests/text-pitch-alignment/map-text-rotation-alignment-viewport": "https://github.com/mapbox/mapbox-gl-native/issues/9732",
   "render-tests/text-pitch-alignment/viewport-overzoomed": "https://github.com/mapbox/mapbox-gl-js/issues/5095",
-  "render-tests/text-pitch-alignment/viewport-overzoomed-single-glyph": "https://github.com/mapbox/mapbox-gl-js/issues/5095",
   "render-tests/text-pitch-alignment/viewport-text-rotation-alignment-map": "https://github.com/mapbox/mapbox-gl-native/issues/9732",
   "render-tests/text-pitch-alignment/viewport-text-rotation-alignment-viewport": "https://github.com/mapbox/mapbox-gl-native/issues/9732",
   "render-tests/text-pitch-scaling/line-half": "https://github.com/mapbox/mapbox-gl-native/issues/9732",

--- a/src/mbgl/layout/symbol_instance.cpp
+++ b/src/mbgl/layout/symbol_instance.cpp
@@ -24,7 +24,8 @@ SymbolInstance::SymbolInstance(Anchor& anchor_,
                                const GlyphPositionMap& positions,
                                const IndexedSubfeature& indexedFeature,
                                const std::size_t featureIndex_,
-                               const std::u16string& key_) :
+                               const std::u16string& key_,
+                               const float overscaling) :
     anchor(anchor_),
     insideTileBoundaries(0 <= anchor.point.x && 0 <= anchor.point.y && anchor.point.x < util::EXTENT && anchor.point.y < util::EXTENT),
     line(line_),
@@ -33,7 +34,7 @@ SymbolInstance::SymbolInstance(Anchor& anchor_,
     hasIcon(shapedIcon),
 
     // Create the collision features that will be used to check whether this symbol instance can be placed
-    textCollisionFeature(line_, anchor, shapedTextOrientations.first, textBoxScale, textPadding, textPlacement, indexedFeature),
+    textCollisionFeature(line_, anchor, shapedTextOrientations.first, textBoxScale, textPadding, textPlacement, indexedFeature, overscaling),
     iconCollisionFeature(line_, anchor, shapedIcon, iconBoxScale, iconPadding, SymbolPlacementType::Point, indexedFeature),
     featureIndex(featureIndex_),
     textOffset(textOffset_),

--- a/src/mbgl/layout/symbol_instance.hpp
+++ b/src/mbgl/layout/symbol_instance.hpp
@@ -32,7 +32,8 @@ public:
                    const GlyphPositionMap&,
                    const IndexedSubfeature&,
                    const std::size_t featureIndex,
-                   const std::u16string& key);
+                   const std::u16string& key,
+                   const float overscaling);
 
     Anchor anchor;
     bool insideTileBoundaries;

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -323,7 +323,7 @@ void SymbolLayout::addFeature(const std::size_t index,
                 addToBuffers, symbolInstances.size(),
                 textBoxScale, textPadding, textPlacement, textOffset,
                 iconBoxScale, iconPadding, iconPlacement, iconOffset,
-                glyphPositionMap, indexedFeature, index, feature.text ? *feature.text : std::u16string{});
+                glyphPositionMap, indexedFeature, index, feature.text ? *feature.text : std::u16string{}, overscaling);
     };
     
     const auto& type = feature.getType();

--- a/src/mbgl/text/collision_feature.hpp
+++ b/src/mbgl/text/collision_feature.hpp
@@ -50,8 +50,9 @@ public:
                      const float boxScale,
                      const float padding,
                      const style::SymbolPlacementType placement,
-                     const IndexedSubfeature& indexedFeature_)
-        : CollisionFeature(line, anchor, shapedText.top, shapedText.bottom, shapedText.left, shapedText.right, boxScale, padding, placement, indexedFeature_) {}
+                     const IndexedSubfeature& indexedFeature_,
+                     const float overscaling)
+        : CollisionFeature(line, anchor, shapedText.top, shapedText.bottom, shapedText.left, shapedText.right, boxScale, padding, placement, indexedFeature_, overscaling) {}
 
     // for icons
     CollisionFeature(const GeometryCoordinates& line,
@@ -66,7 +67,7 @@ public:
                            (shapedIcon ? shapedIcon->bottom() : 0),
                            (shapedIcon ? shapedIcon->left() : 0),
                            (shapedIcon ? shapedIcon->right() : 0),
-                           boxScale, padding, placement, indexedFeature_) {}
+                           boxScale, padding, placement, indexedFeature_, 1) {}
 
     CollisionFeature(const GeometryCoordinates& line,
                      const Anchor&,
@@ -77,7 +78,8 @@ public:
                      const float boxScale,
                      const float padding,
                      const style::SymbolPlacementType,
-                     IndexedSubfeature);
+                     IndexedSubfeature,
+                     const float overscaling);
 
     std::vector<CollisionBox> boxes;
     IndexedSubfeature indexedFeature;
@@ -85,7 +87,7 @@ public:
 
 private:
     void bboxifyLabel(const GeometryCoordinates& line, GeometryCoordinate& anchorPoint,
-                      const int segment, const float length, const float height);
+                      const int segment, const float length, const float height, const float overscaling);
 };
 
 } // namespace mbgl

--- a/src/mbgl/text/cross_tile_symbol_index.cpp
+++ b/src/mbgl/text/cross_tile_symbol_index.cpp
@@ -78,6 +78,9 @@ void CrossTileSymbolLayerIndex::addBucket(const OverscaledTileID& coord, SymbolB
                 childIndex.second.findMatches(bucket.symbolInstances, coord);
             }
         }
+        if (z == 0) {
+            break;
+        }
     }
 
     // make this tile block duplicate labels in lower-res parent tiles
@@ -89,6 +92,9 @@ void CrossTileSymbolLayerIndex::addBucket(const OverscaledTileID& coord, SymbolB
             if (parentIndex != zoomIndexes->second.end()) {
                 parentIndex->second.findMatches(bucket.symbolInstances, coord);
             }
+        }
+        if (z == 0) {
+            break;
         }
     }
     

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -56,7 +56,7 @@ void Placement::placeLayer(RenderSymbolLayer& symbolLayer, const mat4& projMatri
 
         const float scale = std::pow(2, state.getZoom() - renderTile.id.canonical.z);
 
-        const float pixelRatio = util::EXTENT / (util::tileSize * renderTile.tile.id.overscaleFactor());
+        const float textPixelRatio = util::EXTENT / util::tileSize;
 
         mat4 posMatrix;
         state.matrixFor(posMatrix, renderTile.id);
@@ -74,7 +74,7 @@ void Placement::placeLayer(RenderSymbolLayer& symbolLayer, const mat4& projMatri
                 state,
                 pixelsToTileUnits);
 
-        placeLayerBucket(symbolBucket, posMatrix, textLabelPlaneMatrix, iconLabelPlaneMatrix, scale, pixelRatio, showCollisionBoxes, seenCrossTileIDs);
+        placeLayerBucket(symbolBucket, posMatrix, textLabelPlaneMatrix, iconLabelPlaneMatrix, scale, textPixelRatio, showCollisionBoxes, seenCrossTileIDs);
     }
 }
 
@@ -84,7 +84,7 @@ void Placement::placeLayerBucket(
         const mat4& textLabelPlaneMatrix,
         const mat4& iconLabelPlaneMatrix,
         const float scale,
-        const float pixelRatio,
+        const float textPixelRatio,
         const bool showCollisionBoxes,
         std::unordered_set<uint32_t>& seenCrossTileIDs) {
 
@@ -114,7 +114,7 @@ void Placement::placeLayerBucket(
                 const float fontSize = evaluateSizeForFeature(partiallyEvaluatedTextSize, placedSymbol);
 
                 placeText = collisionIndex.placeFeature(symbolInstance.textCollisionFeature,
-                        posMatrix, textLabelPlaneMatrix, pixelRatio,
+                        posMatrix, textLabelPlaneMatrix, textPixelRatio,
                         placedSymbol, scale, fontSize,
                         bucket.layout.get<TextAllowOverlap>(),
                         bucket.layout.get<TextPitchAlignment>() == style::AlignmentType::Map,
@@ -127,7 +127,7 @@ void Placement::placeLayerBucket(
                 const float fontSize = evaluateSizeForFeature(partiallyEvaluatedIconSize, placedSymbol);
 
                 placeIcon = collisionIndex.placeFeature(symbolInstance.iconCollisionFeature,
-                        posMatrix, iconLabelPlaneMatrix, pixelRatio,
+                        posMatrix, iconLabelPlaneMatrix, textPixelRatio,
                         placedSymbol, scale, fontSize,
                         bucket.layout.get<IconAllowOverlap>(),
                         bucket.layout.get<IconPitchAlignment>() == style::AlignmentType::Map,


### PR DESCRIPTION
On top of adding the overscaling logic to `CollisionFeature`, I had to correct `textPixelRatio` not to include the (superfluous) overscaling factor.

@ansis 