### PR TITLE
Fix coloring for debug collision boxes

### DIFF
--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -533,7 +533,7 @@ size_t SymbolLayout::addSymbol(Buffer& buffer,
     buffer.dynamicVertices.emplace_back(dynamicVertex);
     buffer.dynamicVertices.emplace_back(dynamicVertex);
     
-    auto opacityVertex = SymbolOpacityAttributes::vertex(1.0, 1.0); // TODO
+    auto opacityVertex = SymbolOpacityAttributes::vertex(1.0, 1.0); // TODO: This data doesn't matter, it's just a kind-of-silly way to set the size of the opacity buffer
     buffer.opacityVertices.emplace_back(opacityVertex);
     buffer.opacityVertices.emplace_back(opacityVertex);
     buffer.opacityVertices.emplace_back(opacityVertex);
@@ -558,6 +558,9 @@ void SymbolLayout::addToDebugBuffers(SymbolBucket& bucket) {
     }
 
     for (const SymbolInstance &symbolInstance : symbolInstances) {
+        if (!symbolInstance.insideTileBoundaries) {
+            continue;
+        }
         auto populateCollisionBox = [&](const auto& feature) {
             SymbolBucket::CollisionBuffer& collisionBuffer = feature.alongLine ?
                 static_cast<SymbolBucket::CollisionBuffer&>(bucket.collisionCircle) :
@@ -586,7 +589,7 @@ void SymbolLayout::addToDebugBuffers(SymbolBucket& bucket) {
                 collisionBuffer.vertices.emplace_back(CollisionBoxProgram::vertex(anchor, symbolInstance.anchor.point, br));
                 collisionBuffer.vertices.emplace_back(CollisionBoxProgram::vertex(anchor, symbolInstance.anchor.point, bl));
 
-                auto opacityVertex = CollisionBoxOpacityAttributes::vertex(true, false); // TODO
+                auto opacityVertex = CollisionBoxOpacityAttributes::vertex(false, false); // TODO: This data doesn't matter, it's just a kind-of-silly way to set the size of the opacity buffer
                 collisionBuffer.opacityVertices.emplace_back(opacityVertex);
                 collisionBuffer.opacityVertices.emplace_back(opacityVertex);
                 collisionBuffer.opacityVertices.emplace_back(opacityVertex);

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -246,25 +246,27 @@ void Placement::updateBucketOpacities(SymbolBucket& bucket) {
             }
         }
         
-        auto updateCollisionBox = [&](const auto& feature, const bool placed) {
-            for (const CollisionBox& box : feature.boxes) {
-                if (feature.alongLine) {
-                   auto opacityVertex = CollisionBoxOpacityAttributes::vertex(placed, !box.used);
-                    bucket.collisionCircle.opacityVertices.emplace_back(opacityVertex);
-                    bucket.collisionCircle.opacityVertices.emplace_back(opacityVertex);
-                    bucket.collisionCircle.opacityVertices.emplace_back(opacityVertex);
-                    bucket.collisionCircle.opacityVertices.emplace_back(opacityVertex);
-                } else {
-                    auto opacityVertex = CollisionBoxOpacityAttributes::vertex(placed, false);
-                    bucket.collisionBox.opacityVertices.emplace_back(opacityVertex);
-                    bucket.collisionBox.opacityVertices.emplace_back(opacityVertex);
-                    bucket.collisionBox.opacityVertices.emplace_back(opacityVertex);
-                    bucket.collisionBox.opacityVertices.emplace_back(opacityVertex);
+        if (symbolInstance.insideTileBoundaries) {
+            auto updateCollisionBox = [&](const auto& feature, const bool placed) {
+                for (const CollisionBox& box : feature.boxes) {
+                    if (feature.alongLine) {
+                       auto opacityVertex = CollisionBoxOpacityAttributes::vertex(placed, !box.used);
+                        bucket.collisionCircle.opacityVertices.emplace_back(opacityVertex);
+                        bucket.collisionCircle.opacityVertices.emplace_back(opacityVertex);
+                        bucket.collisionCircle.opacityVertices.emplace_back(opacityVertex);
+                        bucket.collisionCircle.opacityVertices.emplace_back(opacityVertex);
+                    } else {
+                        auto opacityVertex = CollisionBoxOpacityAttributes::vertex(placed, false);
+                        bucket.collisionBox.opacityVertices.emplace_back(opacityVertex);
+                        bucket.collisionBox.opacityVertices.emplace_back(opacityVertex);
+                        bucket.collisionBox.opacityVertices.emplace_back(opacityVertex);
+                        bucket.collisionBox.opacityVertices.emplace_back(opacityVertex);
+                    }
                 }
-            }
-        };
-        updateCollisionBox(symbolInstance.textCollisionFeature, opacityState.text.placed);
-        updateCollisionBox(symbolInstance.iconCollisionFeature, opacityState.icon.placed);
+            };
+            updateCollisionBox(symbolInstance.textCollisionFeature, opacityState.text.placed);
+            updateCollisionBox(symbolInstance.iconCollisionFeature, opacityState.icon.placed);
+        }
     }
 
     bucket.updateOpacity();

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -241,7 +241,7 @@ void GeometryTile::queryRenderedFeatures(
                         id.canonical,
                         sourceID,
                         layers,
-                        collisionIndex, // TODO: hook up to global CollisionIndex
+                        collisionIndex,
                         additionalRadius);
 }
 

--- a/src/mbgl/tile/tile.hpp
+++ b/src/mbgl/tile/tile.hpp
@@ -53,10 +53,6 @@ public:
     virtual void setLayers(const std::vector<Immutable<style::Layer::Impl>>&) {}
     virtual void setMask(TileMask&&) {}
 
-    // TODO: Implement
-    virtual void placeLayer(const bool, CollisionIndex& , const style::Layer::Impl&) {};
-    virtual void commitPlacement(const CollisionIndex&, CollisionFadeTimes&) {};
-
     virtual void queryRenderedFeatures(
             std::unordered_map<std::string, std::vector<Feature>>& result,
             const GeometryCoordinates& queryGeometry,


### PR DESCRIPTION
The problem was that we were creating boxes in the symbol buffer areas and they weren't getting their colors updated. The fix is to avoid creating/updating boxes outside of the tile boundaries (this might need revisiting for api-gl if we need to support debug boxes there).

Also removed placeholder code in `Tile` that ended up not being used.

/cc @ansis @jfirebaugh 