### PR TITLE
drop symbols outside of tile boundaries

### DIFF
--- a/src/mbgl/layout/symbol_instance.cpp
+++ b/src/mbgl/layout/symbol_instance.cpp
@@ -11,7 +11,6 @@ SymbolInstance::SymbolInstance(Anchor& anchor_,
                                optional<PositionedIcon> shapedIcon,
                                const SymbolLayoutProperties::Evaluated& layout,
                                const float layoutTextSize,
-                               const bool addToBuffers,
                                const uint32_t index_,
                                const float textBoxScale,
                                const float textPadding,
@@ -27,7 +26,6 @@ SymbolInstance::SymbolInstance(Anchor& anchor_,
                                const std::u16string& key_,
                                const float overscaling) :
     anchor(anchor_),
-    insideTileBoundaries(0 <= anchor.point.x && 0 <= anchor.point.y && anchor.point.x < util::EXTENT && anchor.point.y < util::EXTENT),
     line(line_),
     index(index_),
     hasText(shapedTextOrientations.first || shapedTextOrientations.second),
@@ -42,16 +40,14 @@ SymbolInstance::SymbolInstance(Anchor& anchor_,
     key(key_) {
 
     // Create the quads used for rendering the icon and glyphs.
-    if (addToBuffers) {
-        if (shapedIcon) {
-            iconQuad = getIconQuad(*shapedIcon, layout, layoutTextSize, shapedTextOrientations.first);
-        }
-        if (shapedTextOrientations.first) {
-            horizontalGlyphQuads = getGlyphQuads(shapedTextOrientations.first, layout, textPlacement, positions);
-        }
-        if (shapedTextOrientations.second) {
-            verticalGlyphQuads = getGlyphQuads(shapedTextOrientations.second, layout, textPlacement, positions);
-        }
+    if (shapedIcon) {
+        iconQuad = getIconQuad(*shapedIcon, layout, layoutTextSize, shapedTextOrientations.first);
+    }
+    if (shapedTextOrientations.first) {
+        horizontalGlyphQuads = getGlyphQuads(shapedTextOrientations.first, layout, textPlacement, positions);
+    }
+    if (shapedTextOrientations.second) {
+        verticalGlyphQuads = getGlyphQuads(shapedTextOrientations.second, layout, textPlacement, positions);
     }
 
     if (shapedTextOrientations.first && shapedTextOrientations.second) {

--- a/src/mbgl/layout/symbol_instance.hpp
+++ b/src/mbgl/layout/symbol_instance.hpp
@@ -19,7 +19,6 @@ public:
                    optional<PositionedIcon> shapedIcon,
                    const style::SymbolLayoutProperties::Evaluated&,
                    const float layoutTextSize,
-                   const bool inside,
                    const uint32_t index,
                    const float textBoxScale,
                    const float textPadding,
@@ -36,7 +35,6 @@ public:
                    const float overscaling);
 
     Anchor anchor;
-    bool insideTileBoundaries;
     GeometryCoordinates line;
     uint32_t index;
     bool hasText;

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -316,14 +316,16 @@ void SymbolLayout::addFeature(const std::size_t index,
 
         if (avoidEdges && !inside) return;
 
-        const bool addToBuffers = mode == MapMode::Still || withinPlus0;
-
-        symbolInstances.emplace_back(anchor, line, shapedTextOrientations, shapedIcon,
-                layout.evaluate(zoom, feature), layoutTextSize,
-                addToBuffers, symbolInstances.size(),
-                textBoxScale, textPadding, textPlacement, textOffset,
-                iconBoxScale, iconPadding, iconPlacement, iconOffset,
-                glyphPositionMap, indexedFeature, index, feature.text ? *feature.text : std::u16string{}, overscaling);
+        // TODO set this to make api-gl work
+        const bool singleTileMode = false && mode == MapMode::Still;
+        if (singleTileMode || withinPlus0) {
+            symbolInstances.emplace_back(anchor, line, shapedTextOrientations, shapedIcon,
+                    layout.evaluate(zoom, feature), layoutTextSize,
+                    symbolInstances.size(),
+                    textBoxScale, textPadding, textPlacement, textOffset,
+                    iconBoxScale, iconPadding, iconPlacement, iconOffset,
+                    glyphPositionMap, indexedFeature, index, feature.text ? *feature.text : std::u16string{}, overscaling);
+        }
     };
     
     const auto& type = feature.getType();
@@ -558,9 +560,6 @@ void SymbolLayout::addToDebugBuffers(SymbolBucket& bucket) {
     }
 
     for (const SymbolInstance &symbolInstance : symbolInstances) {
-        if (!symbolInstance.insideTileBoundaries) {
-            continue;
-        }
         auto populateCollisionBox = [&](const auto& feature) {
             SymbolBucket::CollisionBuffer& collisionBuffer = feature.alongLine ?
                 static_cast<SymbolBucket::CollisionBuffer&>(bucket.collisionCircle) :

--- a/src/mbgl/text/cross_tile_symbol_index.cpp
+++ b/src/mbgl/text/cross_tile_symbol_index.cpp
@@ -10,9 +10,7 @@ namespace mbgl {
 TileLayerIndex::TileLayerIndex(OverscaledTileID coord_, std::vector<SymbolInstance>& symbolInstances, uint32_t bucketInstanceId_) 
     : coord(coord_), bucketInstanceId(bucketInstanceId_) {
         for (SymbolInstance& symbolInstance : symbolInstances) {
-            if (symbolInstance.insideTileBoundaries) {
-                indexedSymbolInstances[symbolInstance.key].emplace_back(symbolInstance.crossTileID, getScaledCoordinates(symbolInstance, coord));
-            }
+            indexedSymbolInstances[symbolInstance.key].emplace_back(symbolInstance.crossTileID, getScaledCoordinates(symbolInstance, coord));
         }
     }
 
@@ -99,7 +97,7 @@ void CrossTileSymbolLayerIndex::addBucket(const OverscaledTileID& coord, SymbolB
     }
     
     for (auto& symbolInstance : bucket.symbolInstances) {
-        if (!symbolInstance.crossTileID && symbolInstance.insideTileBoundaries) {
+        if (!symbolInstance.crossTileID) {
             // symbol did not match any known symbol, assign a new id
             symbolInstance.crossTileID = ++maxCrossTileID;
         }

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -98,11 +98,6 @@ void Placement::placeLayerBucket(
 
     for (auto& symbolInstance : bucket.symbolInstances) {
 
-        // TODO symbollayout handles a couple special cases related to this. copy those over if needed.
-        auto anchor = symbolInstance.anchor;
-        const bool withinPlus0 = anchor.point.x >= 0 && anchor.point.x < util::EXTENT && anchor.point.y >= 0 && anchor.point.y < util::EXTENT;
-        if (!withinPlus0) continue;
-
         if (seenCrossTileIDs.count(symbolInstance.crossTileID) == 0) {
             bool placeText = false;
             bool placeIcon = false;
@@ -246,27 +241,25 @@ void Placement::updateBucketOpacities(SymbolBucket& bucket) {
             }
         }
         
-        if (symbolInstance.insideTileBoundaries) {
-            auto updateCollisionBox = [&](const auto& feature, const bool placed) {
-                for (const CollisionBox& box : feature.boxes) {
-                    if (feature.alongLine) {
-                       auto opacityVertex = CollisionBoxOpacityAttributes::vertex(placed, !box.used);
-                        bucket.collisionCircle.opacityVertices.emplace_back(opacityVertex);
-                        bucket.collisionCircle.opacityVertices.emplace_back(opacityVertex);
-                        bucket.collisionCircle.opacityVertices.emplace_back(opacityVertex);
-                        bucket.collisionCircle.opacityVertices.emplace_back(opacityVertex);
-                    } else {
-                        auto opacityVertex = CollisionBoxOpacityAttributes::vertex(placed, false);
-                        bucket.collisionBox.opacityVertices.emplace_back(opacityVertex);
-                        bucket.collisionBox.opacityVertices.emplace_back(opacityVertex);
-                        bucket.collisionBox.opacityVertices.emplace_back(opacityVertex);
-                        bucket.collisionBox.opacityVertices.emplace_back(opacityVertex);
-                    }
+        auto updateCollisionBox = [&](const auto& feature, const bool placed) {
+            for (const CollisionBox& box : feature.boxes) {
+                if (feature.alongLine) {
+                   auto opacityVertex = CollisionBoxOpacityAttributes::vertex(placed, !box.used);
+                    bucket.collisionCircle.opacityVertices.emplace_back(opacityVertex);
+                    bucket.collisionCircle.opacityVertices.emplace_back(opacityVertex);
+                    bucket.collisionCircle.opacityVertices.emplace_back(opacityVertex);
+                    bucket.collisionCircle.opacityVertices.emplace_back(opacityVertex);
+                } else {
+                    auto opacityVertex = CollisionBoxOpacityAttributes::vertex(placed, false);
+                    bucket.collisionBox.opacityVertices.emplace_back(opacityVertex);
+                    bucket.collisionBox.opacityVertices.emplace_back(opacityVertex);
+                    bucket.collisionBox.opacityVertices.emplace_back(opacityVertex);
+                    bucket.collisionBox.opacityVertices.emplace_back(opacityVertex);
                 }
-            };
-            updateCollisionBox(symbolInstance.textCollisionFeature, opacityState.text.placed);
-            updateCollisionBox(symbolInstance.iconCollisionFeature, opacityState.icon.placed);
-        }
+            }
+        };
+        updateCollisionBox(symbolInstance.textCollisionFeature, opacityState.text.placed);
+        updateCollisionBox(symbolInstance.iconCollisionFeature, opacityState.icon.placed);
     }
 
     bucket.updateOpacity();

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -65,7 +65,7 @@ namespace mbgl {
                     const bool showCollisionBoxes,
                     std::unordered_set<uint32_t>& seenCrossTileIDs);
 
-            void updateBucketOpacities(SymbolBucket&);
+            void updateBucketOpacities(SymbolBucket&, std::unordered_set<uint32_t>&);
 
             TransformState state;
             MapMode mapMode;


### PR DESCRIPTION
Only create `SymbolInstance`s for symbols within tile boundaries. This let's us drop all the boundary-checking logic from everywhere else. Later on we'll need to properly set `bool singleTileMode = true` for api-gl in single-tile mode.

@ChrisLoer 