### PR TITLE
Switch to "one-phase" tile loading

### DIFF
--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -96,6 +96,8 @@ public:
 
     void onError(std::exception_ptr, uint64_t correlationID);
     
+    void resetCrossTileIDs() override;
+    
 protected:
     const GeometryTileData* getData() {
         return data.get();

--- a/src/mbgl/tile/tile.hpp
+++ b/src/mbgl/tile/tile.hpp
@@ -95,6 +95,8 @@ public:
     bool isComplete() const {
         return loaded && !pending;
     }
+    
+    virtual void resetCrossTileIDs() {};
 
     void dumpDebugLogs() const;
 


### PR DESCRIPTION
 - Don't render tiles that don't have a symbol layer
 - Remove unused tiles/bucket from the cross tile symbol index
 - Clear cached "crossTileIDs" from symbol buckets that are removed from the symbol index

Local test situation:
 - 6 render failures
 - 2 query failures
 - 2 unit test failures in Annotations -- these are recent and I'm going to look into them, but I don't think they're caused by this PR.

/cc @ansis @jfirebaugh 