### PR TITLE
Fix broken android unit tests, update test make target to SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -595,9 +595,9 @@ run-android-ui-test-%: run-android-ui-test-arm-v7-%
 # Run Java Unit tests on the JVM of the development machine executing this
 .PHONY: run-android-unit-test
 run-android-unit-test: platform/android/configuration.gradle
-	cd platform/android && $(MBGL_ANDROID_GRADLE) -Pmapbox.abis=none :MapboxGLAndroidSDKTestApp:testDebugUnitTest
+	cd platform/android && $(MBGL_ANDROID_GRADLE) -Pmapbox.abis=none :MapboxGLAndroidSDK:testDebugUnitTest
 run-android-unit-test-%: platform/android/configuration.gradle
-	cd platform/android && $(MBGL_ANDROID_GRADLE) -Pmapbox.abis=none :MapboxGLAndroidSDKTestApp:testDebugUnitTest --tests "$*"
+	cd platform/android && $(MBGL_ANDROID_GRADLE) -Pmapbox.abis=none :MapboxGLAndroidSDK:testDebugUnitTest --tests "$*"
 
 # Run Instrumentation tests on AWS device farm, requires additional authentication through gradle.properties
 .PHONY: run-android-ui-test-aws
@@ -654,7 +654,7 @@ android-lint-test-app: platform/android/configuration.gradle
 android-javadoc: platform/android/configuration.gradle
 	cd platform/android && $(MBGL_ANDROID_GRADLE) -Pmapbox.abis=none :MapboxGLAndroidSDK:javadocrelease
 
-# Symbolicate ndk stack traces for the arm-v7 abi	
+# Symbolicate ndk stack traces for the arm-v7 abi
 .PHONY: android-ndk-stack
 android-ndk-stack: android-ndk-stack-arm-v7
 

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/geometry/LatLngBoundsTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/geometry/LatLngBoundsTest.java
@@ -74,15 +74,6 @@ public class LatLngBoundsTest {
   }
 
   @Test
-  public void emptySpan() {
-    latLngBounds = new LatLngBounds.Builder()
-      .include(LAT_LNG_NOT_NULL_ISLAND)
-      .include(LAT_LNG_NOT_NULL_ISLAND)
-      .build();
-    assertTrue("Should be empty", latLngBounds.isEmptySpan());
-  }
-
-  @Test
   public void notEmptySpan() {
     latLngBounds = new LatLngBounds.Builder()
       .include(LAT_LNG_NOT_NULL_ISLAND)

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/AnnotationManagerTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/AnnotationManagerTest.java
@@ -10,6 +10,7 @@ import com.mapbox.mapboxsdk.annotations.MarkerViewManager;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,8 +33,9 @@ public class AnnotationManagerTest {
     Markers markers = new MarkerContainer(aNativeMapView, aMapView, annotationsArray, aIconManager, aMarkerViewManager);
     Polygons polygons = new PolygonContainer(aNativeMapView, annotationsArray);
     Polylines polylines = new PolylineContainer(aNativeMapView, annotationsArray);
+    ShapeAnnotations shapeAnnotations = new ShapeAnnotationContainer(aNativeMapView, annotationsArray);
     AnnotationManager annotationManager = new AnnotationManager(aNativeMapView, aMapView, annotationsArray,
-      aMarkerViewManager, aIconManager, annotations, markers, polygons, polylines);
+      aMarkerViewManager, aIconManager, annotations, markers, polygons, polylines, shapeAnnotations);
     Marker aMarker = mock(Marker.class);
     long aId = 5L;
     when(aNativeMapView.addMarker(aMarker)).thenReturn(aId);
@@ -58,17 +60,22 @@ public class AnnotationManagerTest {
     Markers markers = new MarkerContainer(aNativeMapView, aMapView, annotationsArray, aIconManager, aMarkerViewManager);
     Polygons polygons = new PolygonContainer(aNativeMapView, annotationsArray);
     Polylines polylines = new PolylineContainer(aNativeMapView, annotationsArray);
+    ShapeAnnotations shapeAnnotations = new ShapeAnnotationContainer(aNativeMapView, annotationsArray);
     AnnotationManager annotationManager = new AnnotationManager(aNativeMapView, aMapView, annotationsArray,
-      aMarkerViewManager, aIconManager, annotations, markers, polygons, polylines);
+      aMarkerViewManager, aIconManager, annotations, markers, polygons, polylines, shapeAnnotations);
     long firstId = 1L;
     long secondId = 2L;
     List<BaseMarkerOptions> markerList = new ArrayList<>();
     MarkerOptions firstMarkerOption = new MarkerOptions().position(new LatLng()).title("first");
     MarkerOptions secondMarkerOption = new MarkerOptions().position(new LatLng()).title("second");
+
     markerList.add(firstMarkerOption);
     markerList.add(secondMarkerOption);
     MapboxMap aMapboxMap = mock(MapboxMap.class);
     when(aNativeMapView.addMarker(any(Marker.class))).thenReturn(firstId, secondId);
+
+    when(aNativeMapView.addMarkers(ArgumentMatchers.<Marker>anyList()))
+            .thenReturn(new long[]{firstId, secondId});
 
     annotationManager.addMarkers(markerList, aMapboxMap);
 


### PR DESCRIPTION
The java unit tests were broken, CI didn't notice as we were trying to build the unit tests from the testapp while they are now found in the SDK. This PR updates the make target and fixes the broken tests.