### PR TITLE
fix three render tests

### DIFF
--- a/src/mbgl/text/glyph.hpp
+++ b/src/mbgl/text/glyph.hpp
@@ -75,10 +75,10 @@ class Shaping {
     explicit Shaping(float x, float y, WritingModeType writingMode_)
         : top(y), bottom(y), left(x), right(x), writingMode(writingMode_) {}
     std::vector<PositionedGlyph> positionedGlyphs;
-    int32_t top = 0;
-    int32_t bottom = 0;
-    int32_t left = 0;
-    int32_t right = 0;
+    float top = 0;
+    float bottom = 0;
+    float left = 0;
+    float right = 0;
     WritingModeType writingMode;
 
     explicit operator bool() const { return !positionedGlyphs.empty(); }

--- a/src/mbgl/text/shaping.cpp
+++ b/src/mbgl/text/shaping.cpp
@@ -313,7 +313,7 @@ void shapeLines(Shaping& shaping,
 
     align(shaping, justify, anchorAlign.horizontalAlign, anchorAlign.verticalAlign, maxLineLength,
           lineHeight, lines.size());
-    const uint32_t height = lines.size() * lineHeight;
+    const float height = lines.size() * lineHeight;
 
     // Calculate the bounding box
     shaping.top += -anchorAlign.verticalAlign * height;


### PR DESCRIPTION
Three render tests were failing because `Shaping` in -js uses floats while `Shaping` in -native uses integers. This fixes the tests by switching to floats in -native. Should we just round in -js instead?

@ChrisLoer 

The tests that were failing because of this difference:
- runtime-styling/set-style-glyphs
- text-font/chinese
- text-visibility/visible