### PR TITLE
Harden deselection mechanism for markers

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AnnotationManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AnnotationManager.java
@@ -302,12 +302,14 @@ class AnnotationManager {
     }
 
     for (Marker marker : selectedMarkers) {
-      if (marker.isInfoWindowShown()) {
-        marker.hideInfoWindow();
-      }
+      if (marker != null) {
+        if (marker.isInfoWindowShown()) {
+          marker.hideInfoWindow();
+        }
 
-      if (marker instanceof MarkerView) {
-        markerViewManager.deselect((MarkerView) marker, false);
+        if (marker instanceof MarkerView) {
+          markerViewManager.deselect((MarkerView) marker, false);
+        }
       }
     }
 


### PR DESCRIPTION
closes #10390, while the exception in related issue shouldn't happen with normal usage, it can occur with rolling your own selection mechanism. This PR hardens those executions.