### PR TITLE
MapRendererRunnable - avoid weak reference table overflow

### DIFF
--- a/platform/android/src/map_renderer_runnable.hpp
+++ b/platform/android/src/map_renderer_runnable.hpp
@@ -8,8 +8,6 @@
 
 #include <jni/jni.hpp>
 
-#include "jni/generic_global_ref_deleter.hpp"
-
 namespace mbgl {
 namespace android {
 
@@ -39,10 +37,11 @@ public:
 
     void run(jni::JNIEnv&);
 
-    jni::Object<MapRendererRunnable> getPeer();
+    // Transfers ownership of the Peer object to the caller
+    jni::UniqueObject<MapRendererRunnable> peer();
 
 private:
-    GenericUniqueWeakObject<MapRendererRunnable> javaPeer;
+    jni::UniqueObject<MapRendererRunnable> javaPeer;
     std::weak_ptr<Mailbox> mailbox;
 };
 


### PR DESCRIPTION
Apparently on some devices the weak reference table is limited (numbers around 52000). Even though we don't use that many weak references, when GC is not called for a while they can stack up and a crash will occur before the GC has had the time to clear the references. 

The C++ peer now holds on to a global ref (strong) which can be obtained to queue the java peer and then release automatically so that the GC can take over after the runnable has been executed.

Fixes #10301