### PR TITLE
Qt QSQLite + HTTPRequest updates

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -38,6 +38,8 @@ import ycm_core
 
 compilation_database_folders = [
   'build/linux-x86_64/Debug',
+  'build/qt-linux-x86_64/Debug',
+  'build/qt4-linux-x86_64/Debug',
   'build/macos/compdb/Debug',
 ]
 

--- a/platform/qt/src/http_file_source.cpp
+++ b/platform/qt/src/http_file_source.cpp
@@ -80,9 +80,10 @@ void HTTPFileSource::Impl::onReplyFinished()
         return;
     }
 
+    QByteArray data = reply->readAll();
     QVector<HTTPRequest*>& requestsVector = it.value().second;
     for (auto req : requestsVector) {
-        req->handleNetworkReply(reply);
+        req->handleNetworkReply(reply, data);
     }
 
     m_pending.erase(it);

--- a/platform/qt/src/http_request.cpp
+++ b/platform/qt/src/http_request.cpp
@@ -52,7 +52,7 @@ QNetworkRequest HTTPRequest::networkRequest() const
     return req;
 }
 
-void HTTPRequest::handleNetworkReply(QNetworkReply *reply)
+void HTTPRequest::handleNetworkReply(QNetworkReply *reply, const QByteArray& data)
 {
     m_handled = true;
 
@@ -98,11 +98,10 @@ void HTTPRequest::handleNetworkReply(QNetworkReply *reply)
 
     switch(responseCode) {
     case 200: {
-        QByteArray bytes = reply->readAll();
-        if (bytes.isEmpty()) {
+        if (data.isEmpty()) {
             response.data = std::make_shared<std::string>();
         } else {
-            response.data = std::make_shared<std::string>(bytes.constData(), bytes.size());
+            response.data = std::make_shared<std::string>(data.constData(), data.size());
         }
         break;
     }

--- a/platform/qt/src/http_request.hpp
+++ b/platform/qt/src/http_request.hpp
@@ -20,7 +20,7 @@ public:
     QUrl requestUrl() const;
     QNetworkRequest networkRequest() const;
 
-    void handleNetworkReply(QNetworkReply *);
+    void handleNetworkReply(QNetworkReply *, const QByteArray& data);
 
 private:
     HTTPFileSource::Impl* m_context;

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1578,7 +1578,9 @@ mbgl::Size QMapboxGLPrivate::getFramebufferSize() const {
 
 void QMapboxGLPrivate::updateAssumedState() {
     assumeFramebufferBinding(fbObject);
+#if QT_VERSION >= 0x050600
     assumeViewport(0, 0, getFramebufferSize());
+#endif
 }
 
 void QMapboxGLPrivate::bind() {

--- a/platform/qt/src/sqlite3.cpp
+++ b/platform/qt/src/sqlite3.cpp
@@ -6,6 +6,7 @@
 #include <QStringList>
 #include <QThread>
 #include <QVariant>
+#include <QAtomicInt>
 
 #include <cassert>
 #include <cstring>
@@ -60,20 +61,26 @@ void checkDatabaseOpenError(const QSqlDatabase &db) {
     }
 }
 
+namespace {
+    QString incrementCounter() {
+        static QAtomicInt count = 0;
+        return QString::number(count.fetchAndAddAcquire(1));
+    }
+}
+
 class DatabaseImpl {
 public:
-    DatabaseImpl(const char* filename, int flags) {
-        static uint64_t count = 0;
-        const QString connectionName = QString::number(uint64_t(QThread::currentThread())) + QString::number(count++);
-
+    DatabaseImpl(const char* filename, int flags)
+        : connectionName(QString::number(uint64_t(QThread::currentThread())) + incrementCounter())
+    {
         if (!QSqlDatabase::drivers().contains("QSQLITE")) {
             throw Exception { Exception::Code::CANTOPEN, "SQLite driver not found." };
         }
 
         assert(!QSqlDatabase::contains(connectionName));
-        db.reset(new QSqlDatabase(QSqlDatabase::addDatabase("QSQLITE", connectionName)));
+        auto db = QSqlDatabase::addDatabase("QSQLITE", connectionName);
 
-        QString connectOptions = db->connectOptions();
+        QString connectOptions = db.connectOptions();
         if (flags & OpenFlag::ReadOnly) {
             if (!connectOptions.isEmpty()) connectOptions.append(';');
             connectOptions.append("QSQLITE_OPEN_READONLY");
@@ -83,20 +90,21 @@ public:
             connectOptions.append("QSQLITE_ENABLE_SHARED_CACHE");
         }
 
-        db->setConnectOptions(connectOptions);
-        db->setDatabaseName(QString(filename));
+        db.setConnectOptions(connectOptions);
+        db.setDatabaseName(QString(filename));
 
-        if (!db->open()) {
-            checkDatabaseOpenError(*db);
+        if (!db.open()) {
+            checkDatabaseOpenError(db);
         }
     }
 
     ~DatabaseImpl() {
-        db->close();
-        checkDatabaseError(*db);
+        auto db = QSqlDatabase::database(connectionName);
+        db.close();
+        checkDatabaseError(db);
     }
 
-    QScopedPointer<QSqlDatabase> db;
+    QString connectionName;
 };
 
 class StatementImpl {
@@ -146,17 +154,18 @@ void Database::setBusyTimeout(std::chrono::milliseconds timeout) {
     // internally to int, so we need to make sure the limits apply.
     std::string timeoutStr = mbgl::util::toString(timeout.count() & INT_MAX);
 
-    QString connectOptions = impl->db->connectOptions();
+    auto db = QSqlDatabase::database(impl->connectionName);
+    QString connectOptions = db.connectOptions();
     if (connectOptions.isEmpty()) {
         if (!connectOptions.isEmpty()) connectOptions.append(';');
         connectOptions.append("QSQLITE_BUSY_TIMEOUT=").append(QString::fromStdString(timeoutStr));
     }
-    if (impl->db->isOpen()) {
-        impl->db->close();
+    if (db.isOpen()) {
+        db.close();
     }
-    impl->db->setConnectOptions(connectOptions);
-    if (!impl->db->open()) {
-        checkDatabaseOpenError(*impl->db);
+    db.setConnectOptions(connectOptions);
+    if (!db.open()) {
+        checkDatabaseOpenError(db);
     }
 }
 
@@ -168,7 +177,7 @@ void Database::exec(const std::string &sql) {
         if (!statement.endsWith(';')) {
             statement.append(';');
         }
-        QSqlQuery query(*impl->db);
+        QSqlQuery query(QSqlDatabase::database(impl->connectionName));
         query.prepare(statement);
 
         if (!query.exec()) {
@@ -182,7 +191,7 @@ Statement Database::prepare(const char *query) {
 }
 
 Statement::Statement(Database *db, const char *sql)
-        : impl(std::make_unique<StatementImpl>(QString(sql), *db->impl->db)) {
+        : impl(std::make_unique<StatementImpl>(QString(sql), QSqlDatabase::database(db->impl->connectionName))) {
     assert(impl);
 }
 

--- a/platform/qt/src/sqlite3.cpp
+++ b/platform/qt/src/sqlite3.cpp
@@ -102,7 +102,6 @@ public:
 class StatementImpl {
 public:
     StatementImpl(const QString& sql, const QSqlDatabase& db) : query(db) {
-        query.setForwardOnly(true);
         if (!query.prepare(sql)) {
             checkQueryError(query);
         }
@@ -170,8 +169,8 @@ void Database::exec(const std::string &sql) {
             statement.append(';');
         }
         QSqlQuery query(*impl->db);
-        query.setForwardOnly(true);
         query.prepare(statement);
+
         if (!query.exec()) {
             checkQueryError(query);
         }
@@ -296,12 +295,11 @@ void Statement::bindBlob(int offset, const std::vector<uint8_t>& value, bool ret
 
 bool Statement::run() {
     assert(impl);
+
     if (impl->query.isValid()) {
         return impl->query.next();
     }
 
-    assert(!impl->query.isActive());
-    impl->query.setForwardOnly(true);
     if (!impl->query.exec()) {
         checkQueryError(impl->query);
     }


### PR DESCRIPTION
- Cleanup & refactor `QSqlDatabase` usage in the Qt SQLite implementation.
- Fixes an issue in Qt's `HTTPRequest` implementation that causes data corruption when two or more HTTPRequest are pending on the same network reply - the first one gets the data while the following ones gets empty data because `QNetworkReply::readAll()` erases the contents of the data reply.

Fixes #10413.