### PR TITLE
Fix map snapshotter marker example

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/snapshot/MapSnapshotterMarkerActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/snapshot/MapSnapshotterMarkerActivity.java
@@ -25,6 +25,8 @@ import timber.log.Timber;
  */
 public class MapSnapshotterMarkerActivity extends AppCompatActivity implements MapSnapshotter.SnapshotReadyCallback {
 
+  private MapSnapshotter mapSnapshotter;
+
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -40,7 +42,7 @@ public class MapSnapshotterMarkerActivity extends AppCompatActivity implements M
 
           Timber.i("Starting snapshot");
 
-          MapSnapshotter mapSnapshotter = new MapSnapshotter(
+          mapSnapshotter = new MapSnapshotter(
             getApplicationContext(),
             new MapSnapshotter
               .Options(Math.min(container.getMeasuredWidth(), 1024), Math.min(container.getMeasuredHeight(), 1024))


### PR DESCRIPTION
The reference to the MapSnapshotter needs to be held for the duration of the snapshot, otherwise it might be GC'd

Fixes #10351