### PR TITLE
sort child symbol tiles before parent symbol tiles

### DIFF
--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -336,7 +336,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
                 auto par = util::rotate(pa, parameters.state.getAngle());
                 auto pbr = util::rotate(pb, parameters.state.getAngle());
 
-                return std::tie(par.y, par.x) < std::tie(pbr.y, pbr.x);
+                return std::tie(b.id.canonical.z, par.y, par.x) < std::tie(a.id.canonical.z, pbr.y, pbr.x);
             });
         } else {
             std::sort(sortedTiles.begin(), sortedTiles.end(),


### PR DESCRIPTION
This fixes placement priority by putting child tiles ahead of parent tiles. -js already does this.

There is a second, slightly related problem that remains unfixed: for areas covered by both parent and child tiles it tries placing symbols from both tiles. This means the duplicate road labels in the parent tile still have priority over labels in some other layers in the child tiles.