### PR TITLE
viewport-collision: symbol cross-fading

### DIFF
--- a/src/mbgl/renderer/renderer_impl.hpp
+++ b/src/mbgl/renderer/renderer_impl.hpp
@@ -71,6 +71,8 @@ private:
     void onTileChanged(RenderSource&, const OverscaledTileID&) override;
     void onTileError(RenderSource&, const OverscaledTileID&, std::exception_ptr) override;
 
+    void updateFadingTiles();
+
     friend class Renderer;
 
     RendererBackend& backend;
@@ -110,6 +112,7 @@ private:
     std::unique_ptr<Placement> placement;
 
     bool contextLost = false;
+    bool fadingTiles = false;
 };
 
 } // namespace mbgl

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -46,7 +46,6 @@ void Placement::placeLayer(RenderSymbolLayer& symbolLayer, const mat4& projMatri
     std::unordered_set<uint32_t> seenCrossTileIDs;
 
     for (RenderTile& renderTile : symbolLayer.renderTiles) {
-
         if (!renderTile.tile.isRenderable()) {
             continue;
         }
@@ -78,7 +77,7 @@ void Placement::placeLayer(RenderSymbolLayer& symbolLayer, const mat4& projMatri
                 state,
                 pixelsToTileUnits);
 
-        placeLayerBucket(symbolBucket, posMatrix, textLabelPlaneMatrix, iconLabelPlaneMatrix, scale, textPixelRatio, showCollisionBoxes, seenCrossTileIDs);
+        placeLayerBucket(symbolBucket, posMatrix, textLabelPlaneMatrix, iconLabelPlaneMatrix, scale, textPixelRatio, showCollisionBoxes, seenCrossTileIDs, renderTile.tile.holdForFade());
     }
 }
 
@@ -90,7 +89,8 @@ void Placement::placeLayerBucket(
         const float scale,
         const float textPixelRatio,
         const bool showCollisionBoxes,
-        std::unordered_set<uint32_t>& seenCrossTileIDs) {
+        std::unordered_set<uint32_t>& seenCrossTileIDs,
+        const bool holdingForFade) {
 
     auto partiallyEvaluatedTextSize = bucket.textSizeBinder->evaluateForZoom(state.getZoom());
     auto partiallyEvaluatedIconSize = bucket.iconSizeBinder->evaluateForZoom(state.getZoom());
@@ -101,6 +101,13 @@ void Placement::placeLayerBucket(
     for (auto& symbolInstance : bucket.symbolInstances) {
 
         if (seenCrossTileIDs.count(symbolInstance.crossTileID) == 0) {
+            if (holdingForFade) {
+                // Mark all symbols from this tile as "not placed", but don't add to seenCrossTileIDs, because we don't
+                // know yet if we have a duplicate in a parent tile that _should_ be placed.
+                placements.emplace(symbolInstance.crossTileID, JointPlacement(false, false, false));
+                continue;
+            }
+
             bool placeText = false;
             bool placeIcon = false;
             bool offscreen = true;
@@ -152,6 +159,12 @@ void Placement::placeLayerBucket(
 
             assert(symbolInstance.crossTileID != 0);
 
+            if (placements.find(symbolInstance.crossTileID) != placements.end()) {
+                // If there's a previous placement with this ID, it comes from a tile that's fading out
+                // Erase it so that the placement result from the non-fading tile supersedes it
+                placements.erase(symbolInstance.crossTileID);
+            }
+            
             placements.emplace(symbolInstance.crossTileID, JointPlacement(placeText, placeIcon, offscreen));
             seenCrossTileIDs.insert(symbolInstance.crossTileID);
         }

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -70,7 +70,8 @@ private:
             const float scale,
             const float pixelRatio,
             const bool showCollisionBoxes,
-            std::unordered_set<uint32_t>& seenCrossTileIDs);
+            std::unordered_set<uint32_t>& seenCrossTileIDs,
+            const bool holdingForFade);
 
     void updateBucketOpacities(SymbolBucket&, std::set<uint32_t>&);
 

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -294,4 +294,25 @@ void GeometryTile::resetCrossTileIDs() {
     }
 }
 
+bool GeometryTile::holdForFade() const {
+    return mode == MapMode::Continuous &&
+           (fadeState == FadeState::NeedsFirstPlacement || fadeState == FadeState::NeedsSecondPlacement);
+}
+
+void GeometryTile::markRenderedIdeal() {
+    fadeState = FadeState::Loaded;
+}
+void GeometryTile::markRenderedPreviously() {
+    if (fadeState == FadeState::Loaded) {
+        fadeState = FadeState::NeedsFirstPlacement;
+    }
+}
+void GeometryTile::performedFadePlacement() {
+    if (fadeState == FadeState::NeedsFirstPlacement) {
+        fadeState = FadeState::NeedsSecondPlacement;
+    } else if (fadeState == FadeState::NeedsSecondPlacement) {
+        fadeState = FadeState::CanRemove;
+    }
+}
+
 } // namespace mbgl

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -97,6 +97,11 @@ public:
     
     void resetCrossTileIDs() override;
     
+    bool holdForFade() const override;
+    void markRenderedIdeal() override;
+    void markRenderedPreviously() override;
+    void performedFadePlacement() override;
+    
 protected:
     const GeometryTileData* getData() {
         return data.get();
@@ -130,7 +135,15 @@ private:
     const MapMode mode;
     
     bool showCollisionBoxes;
+    
+    enum class FadeState {
+        Loaded,
+        NeedsFirstPlacement,
+        NeedsSecondPlacement,
+        CanRemove
+    };
 
+    FadeState fadeState = FadeState::Loaded;
 public:
     optional<gl::Texture> glyphAtlasTexture;
     optional<gl::Texture> iconAtlasTexture;

--- a/src/mbgl/tile/tile.hpp
+++ b/src/mbgl/tile/tile.hpp
@@ -95,6 +95,20 @@ public:
         return loaded && !pending;
     }
     
+    // "holdForFade" is used to keep tiles in the render tree after they're no longer
+    // ideal tiles in order to allow symbols to fade out
+    virtual bool holdForFade() const {
+        return false;
+    }
+    // Set whenever this tile is used as an ideal tile
+    virtual void markRenderedIdeal() {}
+    // Set when the tile is removed from the ideal render set but may still be held for fading
+    virtual void markRenderedPreviously() {}
+    // Placement operation performed while this tile is fading
+    // We hold onto a tile for two placements: fading starts with the first placement
+    // and will have time to finish by the second placement.
+    virtual void performedFadePlacement() {}
+    
     virtual void resetCrossTileIDs() {};
 
     void dumpDebugLogs() const;


### PR DESCRIPTION
This is a proof-of-concept of doing symbol cross fading by holding on to render tiles until after their symbols have had a chance to fade out. It doesn't take care of issues like avoiding over-draw of non-symbol layers, but it's enough to get a feel for how it might work.

I think it looks fairly promising, although it'll introduce enough complications (questions like: how many of these "hold for fading" tiles will you hold on to during rapid pan/fade operations?) that I'd prefer to push it to a follow-up PR after `viewport-collision` merges, if possible.

**This PR: cross fading**
![cross_fade](https://user-images.githubusercontent.com/375121/32810676-f074d896-c950-11e7-8e2c-8960150b727a.gif)

**Master: instant switch**
![master_instant_switch](https://user-images.githubusercontent.com/375121/32810688-f7b05932-c950-11e7-8fb2-51b832257026.gif)

/cc @ansis @jfirebaugh @kkaefer  @nickidlugash 
