### PR TITLE
[ios] Update puck arrow stroke color when tint changes

### DIFF
--- a/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
+++ b/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
@@ -63,6 +63,7 @@ const CGFloat MGLUserLocationHeadingUpdateThreshold = 0.01;
     if (_puckModeActivated)
     {
         _puckArrow.fillColor = newTintColor;
+        _puckArrow.strokeColor = newTintColor;
     }
     else
     {


### PR DESCRIPTION
Fixes #10471, where the user puck’s stroke’s color wasn’t updating when the tint color changed. Didn’t update the changelog, as this minor issue was introduced during the 3.7.0 pre-release cycle.

/cc @fabian-guerra @suryu