### PR TITLE
[ios] Update constraints when updating content inset

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1050,7 +1050,7 @@ public:
     }
 
     // Compass, logo and attribution button constraints needs to be updated.
-    [self setNeedsLayout];
+    [self setNeedsUpdateConstraints];
 }
 
 /// Returns the frame of inset content within the map view.


### PR DESCRIPTION
Now that the layout of ornaments is based on constraints (as of #9995), updating the content inset should flag that the constraints need updating.

@boundsj @fabian-guerra @1ec5 👀 