### PR TITLE
[node, build] Don't fail on non-node tags

### DIFF
--- a/platform/node/bitrise.yml
+++ b/platform/node/bitrise.yml
@@ -4,6 +4,8 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 trigger_map:
 - tag: "node-v*"
   workflow: publish
+- tag: "*"
+  workflow: primary
 - push_branch: "*"
   workflow: primary
 - pull_request_target_branch: "*"


### PR DESCRIPTION
Fixes Node Bitrise failures [like this one](https://www.bitrise.io/build/02707f9c31deb838) when a tag is pushed but doesn’t conform to `node-v*`.

/cc @Guardiola31337 @fabian-guerra 