### PR TITLE
[build] Set clang-tidy timeout to 20 minutes

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -187,6 +187,7 @@ jobs:
       - run:
           name: Run Clang checks
           command: make check
+          no_output_timeout: 20m
 
 # ------------------------------------------------------------------------------
   android-debug-arm-v7:


### PR DESCRIPTION
Default timeout is 10 minutes, [but suddenly we're exceeding that](https://circleci.com/gh/mapbox/mapbox-gl-native/40615) on `release-agua`:

```
Running Clang checks... (this might take a while)
Makefile:360: recipe for target 'check' failed
make: *** [check] Terminated
Too long with no output (exceeded 10m0s)
```

This takes about 8 minutes to run (and succeed) locally on my machine.

/cc @brunoabinader @kkaefer @fabian-guerra 