### PR TITLE
[android] Update comment from onDestroy to onDestroyView

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -401,7 +401,7 @@ public class MapView extends FrameLayout {
   }
 
   /**
-   * You must call this method from the parent's Activity#onDestroy() or Fragment#onDestroy().
+   * You must call this method from the parent's Activity#onDestroy() or Fragment#onDestroyView().
    */
   @UiThread
   public void onDestroy() {


### PR DESCRIPTION
Updated comment to reflect that MapView's lifecycle callback in a fragment should be called from `onDestroyView` rather than on `onDestroy`. This is consistent with that `MapFragment` is doing.
