### PR TITLE
[android] Enable map rendering when app is paused

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -365,6 +365,10 @@ public class MapView extends FrameLayout {
     if (mapboxMap != null) {
       mapboxMap.onStart();
     }
+
+    if (mapRenderer != null) {
+      mapRenderer.onStart();
+    }
   }
 
   /**
@@ -396,6 +400,11 @@ public class MapView extends FrameLayout {
       // map was destroyed before it was started
       mapboxMap.onStop();
     }
+
+    if (mapRenderer != null) {
+      mapRenderer.onStop();
+    }
+
     ConnectivityReceiver.instance(getContext()).deactivate();
     FileSource.getInstance(getContext()).deactivate();
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
@@ -33,11 +33,19 @@ public abstract class MapRenderer implements MapRendererScheduler {
     nativeInitialize(this, fileSource, pixelRatio, programCacheDir);
   }
 
+  public void onStart() {
+    // Implement if needed
+  }
+
   public void onPause() {
     // Implement if needed
   }
 
   public void onResume() {
+    // Implement if needed
+  }
+
+  public void onStop() {
     // Implement if needed
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
@@ -31,12 +31,12 @@ public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceVi
   }
 
   @Override
-  public void onPause() {
+  public void onStop() {
     glSurfaceView.onPause();
   }
 
   @Override
-  public void onResume() {
+  public void onStart() {
     glSurfaceView.onResume();
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewMapRenderer.java
@@ -74,7 +74,7 @@ public class TextureViewMapRenderer extends MapRenderer {
    * {@inheritDoc}
    */
   @Override
-  public void onPause() {
+  public void onStop() {
     renderThread.onPause();
   }
 
@@ -82,7 +82,7 @@ public class TextureViewMapRenderer extends MapRenderer {
    * {@inheritDoc}
    */
   @Override
-  public void onResume() {
+  public void onStart() {
     renderThread.onResume();
   }
 


### PR DESCRIPTION
Enables rendering when the app is paused. This ensures that the app continues to render in split-mode.