### PR TITLE
Bump OkHttp - remove Android Oreo crash workaround

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HTTPRequest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HTTPRequest.java
@@ -86,14 +86,7 @@ class HTTPRequest implements Callback {
       }
       mRequest = builder.build();
       mCall = mClient.newCall(mRequest);
-
-      // TODO remove code block for workaround in #10303
-      if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.N_MR1) {
-        mCall.enqueue(this);
-      } else {
-        // Calling execute instead of enqueue is a workaround for #10303
-        onResponse(mCall, mCall.execute());
-      }
+      mCall.enqueue(this);
     } catch (Exception exception) {
       onFailure(exception);
     }

--- a/platform/android/dependencies.gradle
+++ b/platform/android/dependencies.gradle
@@ -42,7 +42,7 @@ ext {
 
             // square crew
             timber                 : 'com.jakewharton.timber:timber:4.5.1',
-            okhttp3                : 'com.squareup.okhttp3:okhttp:3.9.0',
+            okhttp3                : 'com.squareup.okhttp3:okhttp:3.9.1',
             leakCanaryDebug        : "com.squareup.leakcanary:leakcanary-android:${leakCanaryVersion}",
             leakCanaryRelease      : "com.squareup.leakcanary:leakcanary-android-no-op:${leakCanaryVersion}"
     ]


### PR DESCRIPTION
closes #10369, removing code block refs #10366.