### PR TITLE
Cherry-pick: [build] Added CircleCI macos-debug-qt5 job

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -34,6 +34,7 @@ workflows:
       #- ios-sanitize-address
       - ios-sanitize-thread
       - macos-debug
+      - macos-debug-qt5
 
 step-library:
   - &generate-cache-key
@@ -119,11 +120,23 @@ step-library:
 
   - &install-macos-dependencies
       run:
-        name: Install dependencies
+        name: Install macOS dependencies
         command: |
           brew install cmake
           brew install ccache
 
+  - &install-macos-qt-dependencies
+      run:
+        name: Install macOS Qt dependencies
+        command: |
+          sudo chown -R $USER /usr/local
+          brew install qt
+          brew link qt --force
+          brew linkapps qt
+          export HOMEBREW_QT5_CELLAR=$(brew --cellar qt)
+          export HOMEBREW_QT5_VERSION=$(brew list --versions qt | rev | cut -d' ' -f1 | rev)
+          ln -s $HOMEBREW_QT5_CELLAR/$HOMEBREW_QT5_VERSION/mkspecs /usr/local/mkspecs
+          ln -s $HOMEBREW_QT5_CELLAR/$HOMEBREW_QT5_VERSION/plugins /usr/local/plugins
 
   - &run-node-tests
       run:
@@ -688,6 +701,31 @@ jobs:
       - *reset-ccache-stats
       - *build-macos-test
       - *check-public-symbols
+      - *show-ccache-stats
+      - *save-cache
+      - store_artifacts:
+          path: test/fixtures
+          destination: test/fixtures
+
+# ------------------------------------------------------------------------------
+  macos-debug-qt5:
+    macos:
+      xcode: "9.0"
+    environment:
+      BUILDTYPE: Debug
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - checkout
+      - *install-macos-dependencies
+      - *install-macos-qt-dependencies
+      - *generate-cache-key
+      - *restore-cache
+      - *reset-ccache-stats
+      - *build-qt-app
+      - *build-qt-test
+      - run:
+          name: Run qt-test
+          command: make run-qt-test
       - *show-ccache-stats
       - *save-cache
       - store_artifacts:

--- a/platform/qt/bitrise-qt4.yml
+++ b/platform/qt/bitrise-qt4.yml
@@ -1,41 +1,15 @@
----
-format_version: 1.0.0
+format_version: 1.1.0
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+
 trigger_map:
 - pattern: "*"
   is_pull_request_allowed: true
   workflow: primary
+
 workflows:
   primary:
     steps:
     - script:
-        title: Run build
+        title: Skip Workflow
         inputs:
-        - content: |-
-            #!/bin/bash
-            set -eu -o pipefail
-            brew install cmake
-            brew install qt
-            brew link qt
-            brew linkapps qt
-            export BUILDTYPE=Debug
-            make qt-app
-            make run-qt-test
-        - is_debug: 'yes'
-    - slack:
-        title: Post to Slack
-        inputs:
-        - webhook_url: "$SLACK_HOOK_URL"
-        - channel: "#gl-bots"
-        - from_username: 'Bitrise Qt4 macOS'
-        - from_username_on_error: 'Bitrise Qt4 macOS'
-        - message: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
-            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
-            by ${GIT_CLONE_COMMIT_COMMITER_NAME}
-            passed'
-        - message_on_error: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
-            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
-            by ${GIT_CLONE_COMMIT_COMMITER_NAME}
-            failed'
-        - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png
-        - icon_url_on_error: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-error-icon-128.png
+        - content: echo "This workflow is obsolete — see CircleCi."

--- a/platform/qt/bitrise-qt5.yml
+++ b/platform/qt/bitrise-qt5.yml
@@ -1,52 +1,15 @@
----
-format_version: 1.0.0
+format_version: 1.1.0
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+
 trigger_map:
 - pattern: "*"
   is_pull_request_allowed: true
   workflow: primary
+
 workflows:
   primary:
     steps:
     - script:
-        title: Run build
+        title: Skip Workflow
         inputs:
-        - content: |-
-            #!/bin/bash
-            set -eu -o pipefail
-            sudo chown -R $USER /usr/local
-            brew install cmake
-            brew install qt
-            brew link qt --force
-            brew linkapps qt
-            export HOMEBREW_QT5_CELLAR=$(brew --cellar qt)
-            export HOMEBREW_QT5_VERSION=$(brew list --versions qt | rev | cut -d' ' -f1 | rev)
-            ln -s $HOMEBREW_QT5_CELLAR/$HOMEBREW_QT5_VERSION/mkspecs /usr/local/mkspecs
-            ln -s $HOMEBREW_QT5_CELLAR/$HOMEBREW_QT5_VERSION/plugins /usr/local/plugins
-            export BUILDTYPE=Debug
-            make qt-app
-            make run-qt-test
-        - is_debug: 'yes'
-    - deploy-to-bitrise-io:
-        title: Deploy to Bitrise.io
-        inputs:
-        - deploy_path: "test/fixtures"
-        - notify_user_groups: none
-        - is_compress: 'true'
-    - slack:
-        title: Post to Slack
-        inputs:
-        - webhook_url: "$SLACK_HOOK_URL"
-        - channel: "#gl-bots"
-        - from_username: 'Bitrise Qt5 macOS'
-        - from_username_on_error: 'Bitrise Qt5 macOS'
-        - message: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
-            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
-            by ${GIT_CLONE_COMMIT_COMMITER_NAME}
-            passed'
-        - message_on_error: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
-            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
-            by ${GIT_CLONE_COMMIT_COMMITER_NAME}
-            failed'
-        - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png
-        - icon_url_on_error: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-error-icon-128.png
+        - content: echo "This workflow is obsolete — see CircleCi."


### PR DESCRIPTION
Brings #10505 to `release-agua`. Replaces the Bitrise macOS Qt builds with a faster one on CircleCI.

#### Once this is merged:
- [ ] Mark `macos-debug-qt5` as required, and unmark Bitrise ones on `release-agua` branch

/cc @brunoabinader @kkaefer 