### PR TITLE
Harden MarkerView integration by checking for null bitmap

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/Icon.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/Icon.java
@@ -36,7 +36,7 @@ public class Icon {
    * @return The bitmap being used for the icon.
    */
   public Bitmap getBitmap() {
-    if (mBitmap.getConfig() != Bitmap.Config.ARGB_8888) {
+    if (mBitmap != null && mBitmap.getConfig() != Bitmap.Config.ARGB_8888) {
       mBitmap = mBitmap.copy(Bitmap.Config.ARGB_8888, false);
     }
     return mBitmap;


### PR DESCRIPTION
This PR patches up the getBitmap call on Icon to avoid throwing a nullpointer when using the deprecated MarkerView api. Closes https://github.com/mapbox/mapbox-gl-native/issues/10507. 