### PR TITLE
[core, ios, qt, android] Close race condition in RunLoop (issue #9620)

### DIFF
--- a/platform/android/src/run_loop.cpp
+++ b/platform/android/src/run_loop.cpp
@@ -217,8 +217,10 @@ LOOP_HANDLE RunLoop::getLoopHandle() {
 }
 
 void RunLoop::push(std::shared_ptr<WorkTask> task) {
-    withMutex([&] { queue.push(std::move(task)); });
-    impl->wake();
+    withMutex([&] {
+        queue.push(std::move(task));
+        impl->wake();
+    });
 }
 
 void RunLoop::run() {

--- a/platform/darwin/src/run_loop.cpp
+++ b/platform/darwin/src/run_loop.cpp
@@ -30,8 +30,10 @@ RunLoop::~RunLoop() {
 }
 
 void RunLoop::push(std::shared_ptr<WorkTask> task) {
-    withMutex([&] { queue.push(std::move(task)); });
-    impl->async->send();
+    withMutex([&] {
+        queue.push(std::move(task));
+        impl->async->send();
+    });
 }
 
 void RunLoop::run() {

--- a/platform/default/run_loop.cpp
+++ b/platform/default/run_loop.cpp
@@ -130,8 +130,10 @@ LOOP_HANDLE RunLoop::getLoopHandle() {
 }
 
 void RunLoop::push(std::shared_ptr<WorkTask> task) {
-    withMutex([&] { queue.push(std::move(task)); });
-    impl->async->send();
+    withMutex([&] {
+        queue.push(std::move(task));
+        impl->async->send();
+    });
 }
 
 void RunLoop::run() {

--- a/platform/qt/src/run_loop.cpp
+++ b/platform/qt/src/run_loop.cpp
@@ -53,8 +53,10 @@ LOOP_HANDLE RunLoop::getLoopHandle() {
 }
 
 void RunLoop::push(std::shared_ptr<WorkTask> task) {
-    withMutex([&] { queue.push(task); });
-    impl->async->send();
+    withMutex([&] {
+        queue.push(std::move(task));
+        impl->async->send();
+    });
 }
 
 void RunLoop::run() {


### PR DESCRIPTION
See https://github.com/mapbox/mapbox-gl-native/issues/9620#issuecomment-346469961

Because a message we queue from the foreground may cause the background to complete, exit, and tear down the AsyncTask, we have to block queue processing until we've finished our call to AsyncTask::send().

Broadening the scope of a mutex is scary, but I audited the code of our four implementations of AsyncTask and I don't see any way this could cause a deadlock.

If we wanted to keep the scope of the mutex as limited as possible, we could move the mutex scope-broadening to `RunLoop::stop()`, with a custom implementation that bypasses `invoke`/`push`, but I'm not sure it would be worth the extra complexity. I suppose the scenario to worry about is that since we're holding the mutex while we call `async->send` we could cause the background to wake up and immediately be blocked on the mutex... but it doesn't seem like it would be that common or that costly when it did happen?

/cc @tmpsantos @jfirebaugh @kkaefer @ivovandongen 