### PR TITLE
[core] Allow prefetching tiles for all source types

### DIFF
--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -93,14 +93,11 @@ void TilePyramid::update(const std::vector<Immutable<style::Layer::Impl>>& layer
     if (overscaledZoom >= zoomRange.min) {
         int32_t idealZoom = std::min<int32_t>(zoomRange.max, overscaledZoom);
 
-        // Make sure we're not reparsing overzoomed raster tiles.
-        if (type == SourceType::Raster) {
+        // Only attempt prefetching in continuous mode.
+        if (parameters.mode == MapMode::Continuous) {
             tileZoom = idealZoom;
 
-            // FIXME: Prefetching is only enabled for raster
-            // tiles until we fix #7026.
-
-            // Request lower zoom level tiles (if configure to do so) in an attempt
+            // Request lower zoom level tiles (if configured to do so) in an attempt
             // to show something on the screen faster at the cost of a little of bandwidth.
             if (parameters.prefetchZoomDelta) {
                 panZoom = std::max<int32_t>(tileZoom - parameters.prefetchZoomDelta, zoomRange.min);


### PR DESCRIPTION
Follow up to #7741, we should revisit this feature proposed by @tmpsantos now that #7026 is fixed.