### PR TITLE
Attribution anchor point calculation fix

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/attribution/AttributionMeasure.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/attribution/AttributionMeasure.java
@@ -62,7 +62,7 @@ public class AttributionMeasure {
       float width = measure.getLogoContainerWidth() + measure.getTextViewShortContainerWidth();
       boolean fitBounds = width <= measure.getMaxSizeShort();
       if (fitBounds) {
-        PointF anchor = calculateAnchor(measure.snapshot, measure.textView, measure.margin);
+        PointF anchor = calculateAnchor(measure.snapshot, measure.textViewShort, measure.margin);
         return new AttributionLayout(measure.logo, anchor, true);
       }
       return null;


### PR DESCRIPTION
Attribution anchor point calculation fix for short text with full logo on a MapSnapshot.