### PR TITLE
[darwin, ios] Renames CGImage creation function to imply +1 retain count

### DIFF
--- a/platform/darwin/mbgl/util/image+MGLAdditions.hpp
+++ b/platform/darwin/mbgl/util/image+MGLAdditions.hpp
@@ -5,7 +5,7 @@
 #include <CoreGraphics/CGImage.h>
 
 // Creates a CGImage from a PremultipliedImage, taking over the memory ownership.
-CGImageRef CGImageFromMGLPremultipliedImage(mbgl::PremultipliedImage&&);
+CGImageRef CGImageCreateWithMGLPremultipliedImage(mbgl::PremultipliedImage&&);
 
 // Creates a PremultipliedImage by copying the pixels of the CGImage.
 // Does not alter the retain count of the supplied CGImage.

--- a/platform/darwin/src/image.mm
+++ b/platform/darwin/src/image.mm
@@ -23,7 +23,7 @@ using CGDataProviderHandle = CFHandle<CGDataProviderRef, CGDataProviderRef, CGDa
 using CGColorSpaceHandle = CFHandle<CGColorSpaceRef, CGColorSpaceRef, CGColorSpaceRelease>;
 using CGContextHandle = CFHandle<CGContextRef, CGContextRef, CGContextRelease>;
 
-CGImageRef CGImageFromMGLPremultipliedImage(mbgl::PremultipliedImage&& src) {
+CGImageRef CGImageCreateWithMGLPremultipliedImage(mbgl::PremultipliedImage&& src) {
     // We're converting the PremultipliedImage's backing store to a CGDataProvider, and are taking
     // over ownership of the memory.
     CGDataProviderHandle provider(CGDataProviderCreateWithData(

--- a/platform/ios/src/UIImage+MGLAdditions.mm
+++ b/platform/ios/src/UIImage+MGLAdditions.mm
@@ -6,7 +6,7 @@
 
 - (nullable instancetype)initWithMGLStyleImage:(const mbgl::style::Image *)styleImage
 {
-    CGImageRef image = CGImageFromMGLPremultipliedImage(styleImage->getImage().clone());
+    CGImageRef image = CGImageCreateWithMGLPremultipliedImage(styleImage->getImage().clone());
     if (!image) {
         return nil;
     }
@@ -24,7 +24,7 @@
 
 - (nullable instancetype)initWithMGLPremultipliedImage:(const mbgl::PremultipliedImage&&)mbglImage scale:(CGFloat)scale
 {
-    CGImageRef image = CGImageFromMGLPremultipliedImage(mbglImage.clone());
+    CGImageRef image = CGImageCreateWithMGLPremultipliedImage(mbglImage.clone());
     if (!image) {
         return nil;
     }

--- a/platform/macos/src/NSImage+MGLAdditions.mm
+++ b/platform/macos/src/NSImage+MGLAdditions.mm
@@ -5,7 +5,7 @@
 @implementation NSImage (MGLAdditions)
 
 - (nullable instancetype)initWithMGLPremultipliedImage:(mbgl::PremultipliedImage&&)src {
-    CGImageRef image = CGImageFromMGLPremultipliedImage(std::move(src));
+    CGImageRef image = CGImageCreateWithMGLPremultipliedImage(std::move(src));
     if (!image) {
         return nil;
     }
@@ -16,7 +16,7 @@
 }
 
 - (nullable instancetype)initWithMGLStyleImage:(const mbgl::style::Image *)styleImage {
-    CGImageRef image = CGImageFromMGLPremultipliedImage(styleImage->getImage().clone());
+    CGImageRef image = CGImageCreateWithMGLPremultipliedImage(styleImage->getImage().clone());
     if (!image) {
         return nil;
     }


### PR DESCRIPTION
Renaming `CGImageFromMGLPremultipliedImage()` to `CGImageCreateWithMGLPremultipliedImage()` follows [Cocoa naming conventions](https://developer.apple.com/library/content/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/Ownership.html#//apple_ref/doc/uid/20001148-SW3), allowing the static analyzer to infer the correct memory management and removing a few warnings.