### PR TITLE
[ios] POC: implementation of a CoreText-based LocalGlyphRasterizer

### DIFF
--- a/include/mbgl/renderer/renderer.hpp
+++ b/include/mbgl/renderer/renderer.hpp
@@ -25,7 +25,8 @@ class Renderer {
 public:
     Renderer(RendererBackend&, float pixelRatio_, FileSource&, Scheduler&,
              GLContextMode = GLContextMode::Unique,
-             const optional<std::string> programCacheDir = {});
+             const optional<std::string> programCacheDir = {},
+             const optional<std::string> localFontFamily = {});
     ~Renderer();
 
     void markContextLost();

--- a/platform/darwin/src/CFHandle.hpp
+++ b/platform/darwin/src/CFHandle.hpp
@@ -1,0 +1,27 @@
+
+namespace {
+
+template <typename T, typename S, void (*Releaser)(S)>
+struct CFHandle {
+    CFHandle(T t_): t(t_) {}
+    ~CFHandle() { Releaser(t); }
+    T operator*() { return t; }
+    operator bool() { return t; }
+private:
+    T t;
+};
+
+using CGImageHandle = CFHandle<CGImageRef, CGImageRef, CGImageRelease>;
+using CFDataHandle = CFHandle<CFDataRef, CFTypeRef, CFRelease>;
+using CGImageSourceHandle = CFHandle<CGImageSourceRef, CFTypeRef, CFRelease>;
+using CGDataProviderHandle = CFHandle<CGDataProviderRef, CGDataProviderRef, CGDataProviderRelease>;
+using CGColorSpaceHandle = CFHandle<CGColorSpaceRef, CGColorSpaceRef, CGColorSpaceRelease>;
+using CGContextHandle = CFHandle<CGContextRef, CGContextRef, CGContextRelease>;
+
+using CFStringRefHandle = CFHandle<CFStringRef, CFTypeRef, CFRelease>;
+using CFAttributedStringRefHandle = CFHandle<CFAttributedStringRef, CFTypeRef, CFRelease>;
+using CFDictionaryRefHandle = CFHandle<CFDictionaryRef, CFTypeRef, CFRelease>;
+
+
+} // namespace
+

--- a/platform/darwin/src/CFHandle.hpp
+++ b/platform/darwin/src/CFHandle.hpp
@@ -1,27 +1,31 @@
+#pragma once
+
+/*
+  CFHandle is a minimal wrapper designed to hold and release CoreFoundation-style handles
+  It is non-transferrable: wrap it in something like a unique_ptr if you need to pass it around,
+  or just use unique_ptr with a custom deleter.
+  CFHandle has no special treatment for null handles -- be careful not to let it hold a null
+  handle if the behavior of the Releaser isn't defined for null.
+ 
+  ex:
+   using CFDataHandle = CFHandle<CFDataRef, CFTypeRef, CFRelease>;
+ 
+   CFDataHandle data(CFDataCreateWithBytesNoCopy(
+        kCFAllocatorDefault, reinterpret_cast<const unsigned char*>(source.data()), source.size(),
+        kCFAllocatorNull));
+*/
 
 namespace {
 
-template <typename T, typename S, void (*Releaser)(S)>
+template <typename HandleType, typename ReleaserArgumentType, void (*Releaser)(ReleaserArgumentType)>
 struct CFHandle {
-    CFHandle(T t_): t(t_) {}
-    ~CFHandle() { Releaser(t); }
-    T operator*() { return t; }
-    operator bool() { return t; }
+    CFHandle(HandleType handle_): handle(handle_) {}
+    ~CFHandle() { Releaser(handle); }
+    HandleType operator*() { return handle; }
+    operator bool() { return handle; }
 private:
-    T t;
+    HandleType handle;
 };
-
-using CGImageHandle = CFHandle<CGImageRef, CGImageRef, CGImageRelease>;
-using CFDataHandle = CFHandle<CFDataRef, CFTypeRef, CFRelease>;
-using CGImageSourceHandle = CFHandle<CGImageSourceRef, CFTypeRef, CFRelease>;
-using CGDataProviderHandle = CFHandle<CGDataProviderRef, CGDataProviderRef, CGDataProviderRelease>;
-using CGColorSpaceHandle = CFHandle<CGColorSpaceRef, CGColorSpaceRef, CGColorSpaceRelease>;
-using CGContextHandle = CFHandle<CGContextRef, CGContextRef, CGContextRelease>;
-
-using CFStringRefHandle = CFHandle<CFStringRef, CFTypeRef, CFRelease>;
-using CFAttributedStringRefHandle = CFHandle<CFAttributedStringRef, CFTypeRef, CFRelease>;
-using CFDictionaryRefHandle = CFHandle<CFDictionaryRef, CFTypeRef, CFRelease>;
-
 
 } // namespace
 

--- a/platform/darwin/src/image.mm
+++ b/platform/darwin/src/image.mm
@@ -2,26 +2,7 @@
 
 #import <ImageIO/ImageIO.h>
 
-namespace {
-
-template <typename T, typename S, void (*Releaser)(S)>
-struct CFHandle {
-    CFHandle(T t_): t(t_) {}
-    ~CFHandle() { Releaser(t); }
-    T operator*() { return t; }
-    operator bool() { return t; }
-private:
-    T t;
-};
-
-} // namespace
-
-using CGImageHandle = CFHandle<CGImageRef, CGImageRef, CGImageRelease>;
-using CFDataHandle = CFHandle<CFDataRef, CFTypeRef, CFRelease>;
-using CGImageSourceHandle = CFHandle<CGImageSourceRef, CFTypeRef, CFRelease>;
-using CGDataProviderHandle = CFHandle<CGDataProviderRef, CGDataProviderRef, CGDataProviderRelease>;
-using CGColorSpaceHandle = CFHandle<CGColorSpaceRef, CGColorSpaceRef, CGColorSpaceRelease>;
-using CGContextHandle = CFHandle<CGContextRef, CGContextRef, CGContextRelease>;
+#import "CFHandle.hpp"
 
 CGImageRef CGImageFromMGLPremultipliedImage(mbgl::PremultipliedImage&& src) {
     // We're converting the PremultipliedImage's backing store to a CGDataProvider, and are taking

--- a/platform/darwin/src/image.mm
+++ b/platform/darwin/src/image.mm
@@ -4,6 +4,13 @@
 
 #import "CFHandle.hpp"
 
+using CGImageHandle = CFHandle<CGImageRef, CGImageRef, CGImageRelease>;
+using CFDataHandle = CFHandle<CFDataRef, CFTypeRef, CFRelease>;
+using CGImageSourceHandle = CFHandle<CGImageSourceRef, CFTypeRef, CFRelease>;
+using CGDataProviderHandle = CFHandle<CGDataProviderRef, CGDataProviderRef, CGDataProviderRelease>;
+using CGColorSpaceHandle = CFHandle<CGColorSpaceRef, CGColorSpaceRef, CGColorSpaceRelease>;
+using CGContextHandle = CFHandle<CGContextRef, CGContextRef, CGContextRelease>;
+
 CGImageRef CGImageFromMGLPremultipliedImage(mbgl::PremultipliedImage&& src) {
     // We're converting the PremultipliedImage's backing store to a CGDataProvider, and are taking
     // over ownership of the memory.

--- a/platform/darwin/src/local_glyph_rasterizer.mm
+++ b/platform/darwin/src/local_glyph_rasterizer.mm
@@ -21,6 +21,11 @@ namespace mbgl {
      - Extract glyph metrics so that this can be used with more than just fixed width glyphs
 */
 
+using CGColorSpaceHandle = CFHandle<CGColorSpaceRef, CGColorSpaceRef, CGColorSpaceRelease>;
+using CGContextHandle = CFHandle<CGContextRef, CGContextRef, CGContextRelease>;
+using CFStringRefHandle = CFHandle<CFStringRef, CFTypeRef, CFRelease>;
+using CFAttributedStringRefHandle = CFHandle<CFAttributedStringRef, CFTypeRef, CFRelease>;
+using CFDictionaryRefHandle = CFHandle<CFDictionaryRef, CFTypeRef, CFRelease>;
 using CTFontDescriptorRefHandle = CFHandle<CTFontDescriptorRef, CFTypeRef, CFRelease>;
 using CTLineRefHandle = CFHandle<CTLineRef, CFTypeRef, CFRelease>;
 

--- a/platform/darwin/src/local_glyph_rasterizer.mm
+++ b/platform/darwin/src/local_glyph_rasterizer.mm
@@ -22,6 +22,15 @@ private:
 
 namespace mbgl {
 
+using CGContextHandle = CFHandle<CGContextRef, CGContextRef, CGContextRelease>;
+using CGColorSpaceHandle = CFHandle<CGColorSpaceRef, CGColorSpaceRef, CGColorSpaceRelease>;
+using CTFontDescriptorRefHandle = CFHandle<CTFontDescriptorRef, CFTypeRef, CFRelease>;
+using CTFontRefHandle = CFHandle<CTFontRef, CFTypeRef, CFRelease>;
+using CFStringRefHandle = CFHandle<CFStringRef, CFTypeRef, CFRelease>;
+using CFAttributedStringRefHandle = CFHandle<CFAttributedStringRef, CFTypeRef, CFRelease>;
+using CTLineRefHandle = CFHandle<CTLineRef, CFTypeRef, CFRelease>;
+using CFDictionaryRefHandle = CFHandle<CFDictionaryRef, CFTypeRef, CFRelease>;
+
 /*
     Initial implementation of darwin TinySDF support:
     Draw any CJK glyphs using a default system font
@@ -34,87 +43,41 @@ namespace mbgl {
      - Extract glyph metrics so that this can be used with more than just fixed width glyphs
 */
 
+class LocalGlyphRasterizer::Impl {
+public:
+    Impl(CTFontRef fontHandle)
+        : font(fontHandle)
+    {}
+
+    CTFontRefHandle font;
+};
+
+LocalGlyphRasterizer::LocalGlyphRasterizer(void*)
+{
+    NSDictionary *fontAttributes =
+              [NSDictionary dictionaryWithObjectsAndKeys:
+                      [NSNumber numberWithFloat:24.0], (NSString *)kCTFontSizeAttribute,
+                      nil];
+
+    CTFontDescriptorRefHandle descriptor(CTFontDescriptorCreateWithAttributes((CFDictionaryRef)fontAttributes));
+
+    impl = std::make_unique<Impl>(CTFontCreateWithFontDescriptor(*descriptor, 0.0, NULL));
+}
+
+LocalGlyphRasterizer::~LocalGlyphRasterizer()
+{}
+
 bool LocalGlyphRasterizer::canRasterizeGlyph(const FontStack&, GlyphID glyphID) {
     // TODO: This is a rough approximation of the set of glyphs that will work with fixed glyph metrics
     // Either narrow this down to be conservative, or actually extract glyph metrics in rasterizeGlyph
     return util::i18n::allowsIdeographicBreaking(glyphID);
 }
 
-using CGContextHandle = CFHandle<CGContextRef, CGContextRef, CGContextRelease>;
-using CGColorSpaceHandle = CFHandle<CGColorSpaceRef, CGColorSpaceRef, CGColorSpaceRelease>;
-
-Glyph LocalGlyphRasterizer::rasterizeGlyph(const FontStack&, GlyphID glyphID) {
-    Glyph fixedMetrics;
-    fixedMetrics.id = glyphID;
-
-    uint32_t width = 35;
-    uint32_t height = 35;
-    
-    fixedMetrics.metrics.width = width;
-    fixedMetrics.metrics.height = height;
-    fixedMetrics.metrics.left = 3;
-    fixedMetrics.metrics.top = -1;
-    fixedMetrics.metrics.advance = 24;
-
-    Size size(width, height);
-
-    fixedMetrics.bitmap = AlphaImage(size);
-    
-    NSDictionary *fontAttributes =
-              [NSDictionary dictionaryWithObjectsAndKeys:
-                      [NSNumber numberWithFloat:24.0], (NSString *)kCTFontSizeAttribute,
-                      nil];
-    // Create a descriptor.
-    CTFontDescriptorRef descriptor =
-              CTFontDescriptorCreateWithAttributes((CFDictionaryRef)fontAttributes);
-
-    // Create a font using the descriptor.
-    CTFontRef font = CTFontCreateWithFontDescriptor(descriptor, 0.0, NULL);
-    CFRelease(descriptor);
-
-
-    CFStringRef string = CFStringCreateWithCharacters(NULL, (UniChar*)&glyphID, 1);
-
-    PremultipliedImage image(size);
-
-    CGColorSpaceHandle colorSpace(CGColorSpaceCreateDeviceRGB());
-    // TODO: Is there a way to just draw a single alpha channel instead of copying it out of an RGB image? Doesn't seem like the grayscale colorspace is what I'm looking for...
-    if (!colorSpace) {
-        throw std::runtime_error("CGColorSpaceCreateDeviceRGB failed");
-    }
-    
-    constexpr const size_t bitsPerComponent = 8;
-    constexpr const size_t bytesPerPixel = 4;
-    const size_t bytesPerRow = bytesPerPixel * width;
-
-    CGContextHandle context(CGBitmapContextCreate(
-        image.data.get(),
-        width,
-        height,
-        bitsPerComponent,
-        bytesPerRow,
-        *colorSpace,
-        kCGBitmapByteOrderDefault | kCGImageAlphaPremultipliedLast));
-    if (!context) {
-        throw std::runtime_error("CGBitmapContextCreate failed");
-    }
-
-    CFStringRef keys[] = { kCTFontAttributeName };
-    CFTypeRef values[] = { font };
-
-    CFDictionaryRef attributes =
-        CFDictionaryCreate(kCFAllocatorDefault, (const void**)&keys,
-            (const void**)&values, sizeof(keys) / sizeof(keys[0]),
-            &kCFTypeDictionaryKeyCallBacks,
-            &kCFTypeDictionaryValueCallBacks);
-
-    CFAttributedStringRef attrString =
-        CFAttributedStringCreate(kCFAllocatorDefault, string, attributes);
-    CFRelease(string);
-    CFRelease(attributes);
-
-    CTLineRef line = CTLineCreateWithAttributedString(attrString); // TODO: Get glyph runs (for metric extraction) and use showGlyphs API instead?
-
+// TODO: In theory we should be able to transform user-coordinate bounding box and advance
+// values into pixel glyph metrics. This would remove the need to use fixed glyph metrics
+// (which will be slightly off depending on the font), and allow us to return non CJK glyphs
+// (which will have variable "advance" values).
+void extractGlyphMetrics(CTFontRef font, CTLineRef line) {
     CFArrayRef glyphRuns = CTLineGetGlyphRuns(line);
     CFIndex runCount = CFArrayGetCount(glyphRuns);
     assert(runCount == 1);
@@ -134,16 +97,76 @@ Glyph LocalGlyphRasterizer::rasterizeGlyph(const FontStack&, GlyphID glyphID) {
     // should be OK, but a lot of glyphs seem to have empty bounding boxes...?
     (void)totalBoundingRect;
     (void)totalAdvance;
+}
+
+PremultipliedImage drawGlyphBitmap(GlyphID glyphID, CTFontRef font, Size size) {
+    PremultipliedImage rgbaBitmap(size);
+    
+    CFStringRefHandle string(CFStringCreateWithCharacters(NULL, reinterpret_cast<UniChar*>(&glyphID), 1));
+
+    CGColorSpaceHandle colorSpace(CGColorSpaceCreateDeviceRGB());
+    // TODO: Is there a way to just draw a single alpha channel instead of copying it out of an RGB image? Doesn't seem like the grayscale colorspace is what I'm looking for...
+    if (!colorSpace) {
+        throw std::runtime_error("CGColorSpaceCreateDeviceRGB failed");
+    }
+    
+    constexpr const size_t bitsPerComponent = 8;
+    constexpr const size_t bytesPerPixel = 4;
+    const size_t bytesPerRow = bytesPerPixel * size.width;
+
+    CGContextHandle context(CGBitmapContextCreate(
+        rgbaBitmap.data.get(),
+        size.width,
+        size.height,
+        bitsPerComponent,
+        bytesPerRow,
+        *colorSpace,
+        kCGBitmapByteOrderDefault | kCGImageAlphaPremultipliedLast));
+    if (!context) {
+        throw std::runtime_error("CGBitmapContextCreate failed");
+    }
+
+    CFStringRef keys[] = { kCTFontAttributeName };
+    CFTypeRef values[] = { font };
+
+    CFDictionaryRefHandle attributes(
+        CFDictionaryCreate(kCFAllocatorDefault, (const void**)&keys,
+            (const void**)&values, sizeof(keys) / sizeof(keys[0]),
+            &kCFTypeDictionaryKeyCallBacks,
+            &kCFTypeDictionaryValueCallBacks));
+
+    CFAttributedStringRefHandle attrString(CFAttributedStringCreate(kCFAllocatorDefault, *string, *attributes));
+
+    CTLineRefHandle line(CTLineCreateWithAttributedString(*attrString));
+    
+    // For debugging only, doesn't get useful metrics yet
+    extractGlyphMetrics(font, *line);
     
     // Set text position and draw the line into the graphics context
     CGContextSetTextPosition(*context, 0.0, 5.0);
-    CTLineDraw(line, *context);
+    CTLineDraw(*line, *context);
     
-    CFRelease(line);
-    CFRelease(font);
+    return rgbaBitmap;
+}
+
+Glyph LocalGlyphRasterizer::rasterizeGlyph(const FontStack&, GlyphID glyphID) {
+    Glyph fixedMetrics;
+    fixedMetrics.id = glyphID;
+
+    Size size(35, 35);
     
-    for (uint32_t i = 0; i < width * height; i++) {
-        fixedMetrics.bitmap.data[i] = image.data[4 * i + 3]; // alpha value
+    fixedMetrics.metrics.width = size.width;
+    fixedMetrics.metrics.height = size.height;
+    fixedMetrics.metrics.left = 3;
+    fixedMetrics.metrics.top = -1;
+    fixedMetrics.metrics.advance = 24;
+
+    PremultipliedImage rgbaBitmap = drawGlyphBitmap(glyphID, *(impl->font), size);
+   
+    // Copy alpha values from RGBA bitmap into the AlphaImage output
+    fixedMetrics.bitmap = AlphaImage(size);
+    for (uint32_t i = 0; i < size.width * size.height; i++) {
+        fixedMetrics.bitmap.data[i] = rgbaBitmap.data[4 * i + 3];
     }
 
     return fixedMetrics;

--- a/platform/darwin/src/local_glyph_rasterizer.mm
+++ b/platform/darwin/src/local_glyph_rasterizer.mm
@@ -1,0 +1,129 @@
+#include <mbgl/text/local_glyph_rasterizer.hpp>
+#include <mbgl/util/i18n.hpp>
+
+#import <Foundation/Foundation.h>
+
+namespace {
+
+template <typename T, typename S, void (*Releaser)(S)>
+struct CFHandle {
+    CFHandle(T t_): t(t_) {}
+    ~CFHandle() { Releaser(t); }
+    T operator*() { return t; }
+    operator bool() { return t; }
+private:
+    T t;
+};
+
+} // namespace
+
+
+namespace mbgl {
+
+/*
+    Initial implementation of darwin TinySDF support:
+    Draw any CJK glyphs using a default system font
+ 
+    Where to take this:
+     - Configure whether to use local fonts, and which fonts to use,
+       based on map or even style layer options
+     - Build heuristics for choosing fonts based on input FontStack
+       (maybe a globally configurable FontStack -> UIFontDescriptor map would make sense?
+     - Extract glyph metrics so that this can be used with more than just fixed width glyphs
+*/
+
+bool LocalGlyphRasterizer::canRasterizeGlyph(const FontStack&, GlyphID glyphID) {
+    // TODO: This is a rough approximation of the set of glyphs that will work with fixed glyph metrics
+    // Either narrow this down to be conservative, or actually extract glyph metrics in rasterizeGlyph
+    return util::i18n::allowsIdeographicBreaking(glyphID);
+}
+
+using CGContextHandle = CFHandle<CGContextRef, CGContextRef, CGContextRelease>;
+using CGColorSpaceHandle = CFHandle<CGColorSpaceRef, CGColorSpaceRef, CGColorSpaceRelease>;
+
+Glyph LocalGlyphRasterizer::rasterizeGlyph(const FontStack&, GlyphID glyphID) {
+    Glyph fixedMetrics;
+    fixedMetrics.id = glyphID;
+
+    fixedMetrics.metrics.width = 24;
+    fixedMetrics.metrics.height = 24;
+    fixedMetrics.metrics.left = 0;
+    fixedMetrics.metrics.top = -8;
+    fixedMetrics.metrics.advance = 24;
+
+    uint32_t width = 30;
+    uint32_t height = 30;
+    Size size(width, height);
+
+    fixedMetrics.bitmap = AlphaImage(size);
+    
+    NSDictionary *fontAttributes =
+              [NSDictionary dictionaryWithObjectsAndKeys:
+                      [NSNumber numberWithFloat:24.0], (NSString *)kCTFontSizeAttribute,
+                      nil];
+    // Create a descriptor.
+    CTFontDescriptorRef descriptor =
+              CTFontDescriptorCreateWithAttributes((CFDictionaryRef)fontAttributes);
+
+    // Create a font using the descriptor.
+    CTFontRef font = CTFontCreateWithFontDescriptor(descriptor, 0.0, NULL);
+    CFRelease(descriptor);
+
+
+    CFStringRef string = CFStringCreateWithCharacters(NULL, (UniChar*)&glyphID, 1);
+
+    PremultipliedImage image(size);
+
+    CGColorSpaceHandle colorSpace(CGColorSpaceCreateDeviceRGB());
+    // TODO: Is there a way to just draw a single alpha channel instead of copying it out of an RGB image? Doesn't seem like the grayscale colorspace is what I'm looking for...
+    if (!colorSpace) {
+        throw std::runtime_error("CGColorSpaceCreateDeviceRGB failed");
+    }
+    
+    constexpr const size_t bitsPerComponent = 8;
+    constexpr const size_t bytesPerPixel = 4;
+    const size_t bytesPerRow = bytesPerPixel * width;
+
+    CGContextHandle context(CGBitmapContextCreate(
+        image.data.get(),
+        width,
+        height,
+        bitsPerComponent,
+        bytesPerRow,
+        *colorSpace,
+        kCGBitmapByteOrderDefault | kCGImageAlphaPremultipliedLast));
+    if (!context) {
+        throw std::runtime_error("CGBitmapContextCreate failed");
+    }
+
+    CFStringRef keys[] = { kCTFontAttributeName };
+    CFTypeRef values[] = { font };
+
+    CFDictionaryRef attributes =
+        CFDictionaryCreate(kCFAllocatorDefault, (const void**)&keys,
+            (const void**)&values, sizeof(keys) / sizeof(keys[0]),
+            &kCFTypeDictionaryKeyCallBacks,
+            &kCFTypeDictionaryValueCallBacks);
+
+    CFAttributedStringRef attrString =
+        CFAttributedStringCreate(kCFAllocatorDefault, string, attributes);
+    CFRelease(string);
+    CFRelease(attributes);
+
+    CTLineRef line = CTLineCreateWithAttributedString(attrString); // TODO: Get glyph runs (for metric extraction) and use showGlyphs API instead?
+
+    // Set text position and draw the line into the graphics context
+    CGContextSetTextPosition(*context, 0.0, 0.0);
+    CTLineDraw(line, *context);
+    CFRelease(line);
+    CFRelease(font);
+    CFRelease(string); // TODO: Surely leaking something here, wrap these up!
+    
+    for (uint32_t i = 0; i < width * height; i++) {
+        fixedMetrics.bitmap.data[i] = image.data[4 * i + 3]; // alpha value
+    }
+
+    return fixedMetrics;
+}
+
+} // namespace mbgl

--- a/platform/darwin/src/local_glyph_rasterizer.mm
+++ b/platform/darwin/src/local_glyph_rasterizer.mm
@@ -34,11 +34,13 @@ public:
     CTFontRefHandle font;
 };
 
-LocalGlyphRasterizer::LocalGlyphRasterizer(void* configuration)
+LocalGlyphRasterizer::LocalGlyphRasterizer(const optional<std::string> fontFamily)
 {
-    if (configuration) {
-        NSMutableDictionary *fontAttributes = CFBridgingRelease((CFDictionaryRef)configuration);
-        fontAttributes[(NSString *)kCTFontSizeAttribute] = [NSNumber numberWithFloat:24.0];
+    if (fontFamily) {
+        NSDictionary *fontAttributes = @{
+            (NSString *)kCTFontSizeAttribute: [NSNumber numberWithFloat:24.0],
+            (NSString *)kCTFontFamilyNameAttribute: [[NSString alloc] initWithCString:fontFamily->c_str() encoding:NSUTF8StringEncoding]
+        };
 
         CTFontDescriptorRefHandle descriptor(CTFontDescriptorCreateWithAttributes((CFDictionaryRef)fontAttributes));
 

--- a/platform/darwin/src/local_glyph_rasterizer.mm
+++ b/platform/darwin/src/local_glyph_rasterizer.mm
@@ -2,6 +2,8 @@
 #include <mbgl/util/i18n.hpp>
 
 #import <Foundation/Foundation.h>
+#import <CoreText/CoreText.h>
+#import <ImageIO/ImageIO.h>
 
 namespace {
 

--- a/platform/darwin/src/local_glyph_rasterizer.mm
+++ b/platform/darwin/src/local_glyph_rasterizer.mm
@@ -47,8 +47,8 @@ Glyph LocalGlyphRasterizer::rasterizeGlyph(const FontStack&, GlyphID glyphID) {
     Glyph fixedMetrics;
     fixedMetrics.id = glyphID;
 
-    uint32_t width = 40;
-    uint32_t height = 40;
+    uint32_t width = 35;
+    uint32_t height = 35;
     
     fixedMetrics.metrics.width = width;
     fixedMetrics.metrics.height = height;
@@ -136,7 +136,7 @@ Glyph LocalGlyphRasterizer::rasterizeGlyph(const FontStack&, GlyphID glyphID) {
     (void)totalAdvance;
     
     // Set text position and draw the line into the graphics context
-    CGContextSetTextPosition(*context, 0.0, 10.0);
+    CGContextSetTextPosition(*context, 0.0, 5.0);
     CTLineDraw(line, *context);
     
     CFRelease(line);

--- a/platform/darwin/src/local_glyph_rasterizer.mm
+++ b/platform/darwin/src/local_glyph_rasterizer.mm
@@ -5,31 +5,9 @@
 #import <CoreText/CoreText.h>
 #import <ImageIO/ImageIO.h>
 
-namespace {
-
-template <typename T, typename S, void (*Releaser)(S)>
-struct CFHandle {
-    CFHandle(T t_): t(t_) {}
-    ~CFHandle() { Releaser(t); }
-    T operator*() { return t; }
-    operator bool() { return t; }
-private:
-    T t;
-};
-
-} // namespace
-
+#import "CFHandle.hpp"
 
 namespace mbgl {
-
-using CGContextHandle = CFHandle<CGContextRef, CGContextRef, CGContextRelease>;
-using CGColorSpaceHandle = CFHandle<CGColorSpaceRef, CGColorSpaceRef, CGColorSpaceRelease>;
-using CTFontDescriptorRefHandle = CFHandle<CTFontDescriptorRef, CFTypeRef, CFRelease>;
-using CTFontRefHandle = CFHandle<CTFontRef, CFTypeRef, CFRelease>;
-using CFStringRefHandle = CFHandle<CFStringRef, CFTypeRef, CFRelease>;
-using CFAttributedStringRefHandle = CFHandle<CFAttributedStringRef, CFTypeRef, CFRelease>;
-using CTLineRefHandle = CFHandle<CTLineRef, CFTypeRef, CFRelease>;
-using CFDictionaryRefHandle = CFHandle<CFDictionaryRef, CFTypeRef, CFRelease>;
 
 /*
     Initial implementation of darwin TinySDF support:
@@ -42,6 +20,10 @@ using CFDictionaryRefHandle = CFHandle<CFDictionaryRef, CFTypeRef, CFRelease>;
        (maybe a globally configurable FontStack -> UIFontDescriptor map would make sense?
      - Extract glyph metrics so that this can be used with more than just fixed width glyphs
 */
+
+using CTFontDescriptorRefHandle = CFHandle<CTFontDescriptorRef, CFTypeRef, CFRelease>;
+using CTFontRefHandle = CFHandle<CTFontRef, CFTypeRef, CFRelease>;
+using CTLineRefHandle = CFHandle<CTLineRef, CFTypeRef, CFRelease>;
 
 class LocalGlyphRasterizer::Impl {
 public:

--- a/platform/default/local_glyph_rasterizer.cpp
+++ b/platform/default/local_glyph_rasterizer.cpp
@@ -2,6 +2,15 @@
 
 namespace mbgl {
 
+class LocalGlyphRasterizer::Impl {
+};
+
+LocalGlyphRasterizer::LocalGlyphRasterizer(void*)
+{}
+
+LocalGlyphRasterizer::~LocalGlyphRasterizer()
+{}
+
 bool LocalGlyphRasterizer::canRasterizeGlyph(const FontStack&, GlyphID) {
     return false;
 }

--- a/platform/default/local_glyph_rasterizer.cpp
+++ b/platform/default/local_glyph_rasterizer.cpp
@@ -5,7 +5,7 @@ namespace mbgl {
 class LocalGlyphRasterizer::Impl {
 };
 
-LocalGlyphRasterizer::LocalGlyphRasterizer(void*)
+LocalGlyphRasterizer::LocalGlyphRasterizer(const optional<std::string>)
 {}
 
 LocalGlyphRasterizer::~LocalGlyphRasterizer()

--- a/platform/ios/config.cmake
+++ b/platform/ios/config.cmake
@@ -85,6 +85,7 @@ macro(mbgl_platform_core)
     target_link_libraries(mbgl-core
         PUBLIC "-lz"
         PUBLIC "-framework Foundation"
+        PUBLIC "-framework CoreText"
         PUBLIC "-framework CoreGraphics"
         PUBLIC "-framework OpenGLES"
         PUBLIC "-framework ImageIO"

--- a/platform/ios/config.cmake
+++ b/platform/ios/config.cmake
@@ -28,11 +28,11 @@ macro(mbgl_platform_core)
         # Misc
         PRIVATE platform/darwin/mbgl/storage/reachability.h
         PRIVATE platform/darwin/mbgl/storage/reachability.m
+        PRIVATE platform/darwin/src/local_glyph_rasterizer.mm
         PRIVATE platform/darwin/src/logging_nslog.mm
         PRIVATE platform/darwin/src/nsthread.mm
         PRIVATE platform/darwin/src/string_nsstring.mm
         PRIVATE platform/default/bidi.cpp
-        PRIVATE platform/default/local_glyph_rasterizer.cpp
         PRIVATE platform/default/thread_local.cpp
         PRIVATE platform/default/utf.cpp
 

--- a/platform/ios/config.cmake
+++ b/platform/ios/config.cmake
@@ -28,6 +28,7 @@ macro(mbgl_platform_core)
         # Misc
         PRIVATE platform/darwin/mbgl/storage/reachability.h
         PRIVATE platform/darwin/mbgl/storage/reachability.m
+        PRIVATE platform/darwin/src/CFHandle.hpp
         PRIVATE platform/darwin/src/local_glyph_rasterizer.mm
         PRIVATE platform/darwin/src/logging_nslog.mm
         PRIVATE platform/darwin/src/nsthread.mm

--- a/platform/macos/config.cmake
+++ b/platform/macos/config.cmake
@@ -14,6 +14,7 @@ macro(mbgl_platform_core)
         # Misc
         PRIVATE platform/darwin/mbgl/storage/reachability.h
         PRIVATE platform/darwin/mbgl/storage/reachability.m
+        PRIVATE platform/darwin/src/CFHandle.hpp
         PRIVATE platform/darwin/src/local_glyph_rasterizer.mm
         PRIVATE platform/darwin/src/logging_nslog.mm
         PRIVATE platform/darwin/src/nsthread.mm

--- a/platform/macos/config.cmake
+++ b/platform/macos/config.cmake
@@ -65,6 +65,7 @@ macro(mbgl_platform_core)
     target_link_libraries(mbgl-core
         PUBLIC "-lz"
         PUBLIC "-framework Foundation"
+        PUBLIC "-framework CoreText"
         PUBLIC "-framework CoreGraphics"
         PUBLIC "-framework OpenGL"
         PUBLIC "-framework ImageIO"

--- a/platform/macos/config.cmake
+++ b/platform/macos/config.cmake
@@ -14,11 +14,11 @@ macro(mbgl_platform_core)
         # Misc
         PRIVATE platform/darwin/mbgl/storage/reachability.h
         PRIVATE platform/darwin/mbgl/storage/reachability.m
+        PRIVATE platform/darwin/src/local_glyph_rasterizer.mm
         PRIVATE platform/darwin/src/logging_nslog.mm
         PRIVATE platform/darwin/src/nsthread.mm
         PRIVATE platform/darwin/src/string_nsstring.mm
         PRIVATE platform/default/bidi.cpp
-        PRIVATE platform/default/local_glyph_rasterizer.cpp
         PRIVATE platform/default/thread_local.cpp
         PRIVATE platform/default/utf.cpp
 

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -217,15 +217,15 @@ public:
 
 - (instancetype)initWithFrame:(NSRect)frameRect {
     if (self = [super initWithFrame:frameRect]) {
-        [self commonInit];
+        [self commonInit:nil];
         self.styleURL = nil;
     }
     return self;
 }
 
-- (instancetype)initWithFrame:(NSRect)frame styleURL:(nullable NSURL *)styleURL {
+- (instancetype)initWithFrame:(NSRect)frame styleURL:(nullable NSURL *)styleURL localIdeographFontFamily:(nullable NSString *)fontFamily {
     if (self = [super initWithFrame:frame]) {
-        [self commonInit];
+        [self commonInit:fontFamily];
         self.styleURL = styleURL;
     }
     return self;
@@ -233,7 +233,7 @@ public:
 
 - (instancetype)initWithCoder:(nonnull NSCoder *)decoder {
     if (self = [super initWithCoder:decoder]) {
-        [self commonInit];
+        [self commonInit:nil];
     }
     return self;
 }
@@ -252,7 +252,7 @@ public:
     return @[@"camera", @"debugMask"];
 }
 
-- (void)commonInit {
+- (void)commonInit:(nullable NSString*)fontFamily {
     _isTargetingInterfaceBuilder = NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent;
 
     // Set up cross-platform controllers and resources.
@@ -274,7 +274,7 @@ public:
 
     _mbglThreadPool = mbgl::sharedThreadPool();
 
-    auto renderer = std::make_unique<mbgl::Renderer>(*_mbglView, [NSScreen mainScreen].backingScaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::GLContextMode::Unique);
+    auto renderer = std::make_unique<mbgl::Renderer>(*_mbglView, [NSScreen mainScreen].backingScaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::GLContextMode::Unique, mbgl::optional<std::string>(), fontFamily ? std::string([fontFamily UTF8String]) : mbgl::optional<std::string>());
     _rendererFrontend = std::make_unique<MGLRenderFrontend>(std::move(renderer), self, *_mbglView, true);
     _mbglMap = new mbgl::Map(*_rendererFrontend, *_mbglView, self.size, [NSScreen mainScreen].backingScaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::MapMode::Continuous, mbgl::ConstrainMode::None, mbgl::ViewportMode::Default);
 

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -223,9 +223,9 @@ public:
     return self;
 }
 
-- (instancetype)initWithFrame:(NSRect)frame styleURL:(nullable NSURL *)styleURL localIdeographFontFamily:(nullable NSString *)fontFamily {
+- (instancetype)initWithFrame:(NSRect)frame styleURL:(nullable NSURL *)styleURL {
     if (self = [super initWithFrame:frame]) {
-        [self commonInit:fontFamily];
+        [self commonInit:nil];
         self.styleURL = styleURL;
     }
     return self;

--- a/src/mbgl/renderer/renderer.cpp
+++ b/src/mbgl/renderer/renderer.cpp
@@ -10,9 +10,10 @@ Renderer::Renderer(RendererBackend& backend,
                    FileSource& fileSource_,
                    Scheduler& scheduler_,
                    GLContextMode contextMode_,
-                   const optional<std::string> programCacheDir_)
+                   const optional<std::string> programCacheDir_,
+                   const optional<std::string> localFontFamily_)
         : impl(std::make_unique<Impl>(backend, pixelRatio_, fileSource_, scheduler_,
-                                      contextMode_, std::move(programCacheDir_))) {
+                                      contextMode_, std::move(programCacheDir_), std::move(localFontFamily_))) {
 }
 
 Renderer::~Renderer() {

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -42,7 +42,8 @@ Renderer::Impl::Impl(RendererBackend& backend_,
                      FileSource& fileSource_,
                      Scheduler& scheduler_,
                      GLContextMode contextMode_,
-                     const optional<std::string> programCacheDir_)
+                     const optional<std::string> programCacheDir_,
+                     const optional<std::string> localFontFamily_)
     : backend(backend_)
     , scheduler(scheduler_)
     , fileSource(fileSource_)
@@ -50,7 +51,7 @@ Renderer::Impl::Impl(RendererBackend& backend_,
     , contextMode(contextMode_)
     , pixelRatio(pixelRatio_)
     , programCacheDir(programCacheDir_)
-    , glyphManager(std::make_unique<GlyphManager>(fileSource))
+    , glyphManager(std::make_unique<GlyphManager>(fileSource, std::make_unique<LocalGlyphRasterizer>(localFontFamily_)))
     , imageManager(std::make_unique<ImageManager>())
     , lineAtlas(std::make_unique<LineAtlas>(Size{ 256, 512 }))
     , imageImpls(makeMutable<std::vector<Immutable<style::Image::Impl>>>())

--- a/src/mbgl/renderer/renderer_impl.hpp
+++ b/src/mbgl/renderer/renderer_impl.hpp
@@ -38,7 +38,7 @@ class Renderer::Impl : public GlyphManagerObserver,
                        public RenderSourceObserver{
 public:
     Impl(RendererBackend&, float pixelRatio_, FileSource&, Scheduler&, GLContextMode,
-         const optional<std::string> programCacheDir);
+         const optional<std::string> programCacheDir, const optional<std::string> localFontFamily);
     ~Impl() final;
 
     void markContextLost() {

--- a/src/mbgl/text/glyph_manager.hpp
+++ b/src/mbgl/text/glyph_manager.hpp
@@ -25,7 +25,7 @@ public:
 
 class GlyphManager : public util::noncopyable {
 public:
-    GlyphManager(FileSource&, std::unique_ptr<LocalGlyphRasterizer> = std::make_unique<LocalGlyphRasterizer>());
+    GlyphManager(FileSource&, std::unique_ptr<LocalGlyphRasterizer> = std::make_unique<LocalGlyphRasterizer>((void*)NULL));
     ~GlyphManager();
 
     // Workers send a `getGlyphs` message to the main thread once they have determined

--- a/src/mbgl/text/glyph_manager.hpp
+++ b/src/mbgl/text/glyph_manager.hpp
@@ -25,7 +25,7 @@ public:
 
 class GlyphManager : public util::noncopyable {
 public:
-    GlyphManager(FileSource&, std::unique_ptr<LocalGlyphRasterizer>);
+    GlyphManager(FileSource&, std::unique_ptr<LocalGlyphRasterizer> = std::make_unique<LocalGlyphRasterizer>(optional<std::string>()));
     ~GlyphManager();
 
     // Workers send a `getGlyphs` message to the main thread once they have determined

--- a/src/mbgl/text/glyph_manager.hpp
+++ b/src/mbgl/text/glyph_manager.hpp
@@ -25,7 +25,7 @@ public:
 
 class GlyphManager : public util::noncopyable {
 public:
-    GlyphManager(FileSource&, std::unique_ptr<LocalGlyphRasterizer> = std::make_unique<LocalGlyphRasterizer>((void*)NULL));
+    GlyphManager(FileSource&, std::unique_ptr<LocalGlyphRasterizer>);
     ~GlyphManager();
 
     // Workers send a `getGlyphs` message to the main thread once they have determined

--- a/src/mbgl/text/local_glyph_rasterizer.hpp
+++ b/src/mbgl/text/local_glyph_rasterizer.hpp
@@ -32,11 +32,15 @@ namespace mbgl {
 
 class LocalGlyphRasterizer {
 public:
-    virtual ~LocalGlyphRasterizer() = default;
+    virtual ~LocalGlyphRasterizer();
+    LocalGlyphRasterizer(void* configuration);
 
     // virtual so that test harness can override platform-specific behavior
     virtual bool canRasterizeGlyph(const FontStack&, GlyphID);
     virtual Glyph rasterizeGlyph(const FontStack&, GlyphID);
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl;
 };
 
 } // namespace mbgl

--- a/src/mbgl/text/local_glyph_rasterizer.hpp
+++ b/src/mbgl/text/local_glyph_rasterizer.hpp
@@ -33,7 +33,7 @@ namespace mbgl {
 class LocalGlyphRasterizer {
 public:
     virtual ~LocalGlyphRasterizer();
-    LocalGlyphRasterizer(void* configuration);
+    LocalGlyphRasterizer(void* configuration = nullptr);
 
     // virtual so that test harness can override platform-specific behavior
     virtual bool canRasterizeGlyph(const FontStack&, GlyphID);

--- a/src/mbgl/text/local_glyph_rasterizer.hpp
+++ b/src/mbgl/text/local_glyph_rasterizer.hpp
@@ -33,7 +33,7 @@ namespace mbgl {
 class LocalGlyphRasterizer {
 public:
     virtual ~LocalGlyphRasterizer();
-    LocalGlyphRasterizer(void* configuration = nullptr);
+    LocalGlyphRasterizer(const optional<std::string> fontFamily = optional<std::string>());
 
     // virtual so that test harness can override platform-specific behavior
     virtual bool canRasterizeGlyph(const FontStack&, GlyphID);

--- a/src/mbgl/util/i18n.cpp
+++ b/src/mbgl/util/i18n.cpp
@@ -392,6 +392,11 @@ bool allowsIdeographicBreaking(char16_t chr) {
     //        || isInCJKCompatibilityIdeographsSupplement(chr));
 }
 
+bool allowsFixedWidthGlyphGeneration(char16_t chr) {
+    // Mirrors conservative set of characters used in glyph_manager.js/_tinySDF
+    return isInCJKUnifiedIdeographs(chr) || isInHangulSyllables(chr);
+}
+
 bool allowsVerticalWritingMode(const std::u16string& string) {
     for (char32_t chr : string) {
         if (hasUprightVerticalOrientation(chr)) {

--- a/src/mbgl/util/i18n.hpp
+++ b/src/mbgl/util/i18n.hpp
@@ -23,6 +23,10 @@ bool allowsIdeographicBreaking(const std::u16string& string);
     by the given Unicode codepoint due to ideographic breaking. */
 bool allowsIdeographicBreaking(char16_t chr);
 
+/** Conservative set of characters expected to have relatively fixed sizes and
+    advances */
+bool allowsFixedWidthGlyphGeneration(char16_t chr);
+
 /** Returns whether any substring of the given string can be drawn as vertical
     text with upright glyphs. */
 bool allowsVerticalWritingMode(const std::u16string& string);

--- a/test/text/glyph_manager.test.cpp
+++ b/test/text/glyph_manager.test.cpp
@@ -19,10 +19,6 @@ static constexpr const size_t stubBitmapLength = 900;
 
 class StubLocalGlyphRasterizer : public LocalGlyphRasterizer {
 public:
-    StubLocalGlyphRasterizer()
-        : LocalGlyphRasterizer(0)
-    {}
-
     bool canRasterizeGlyph(const FontStack&, GlyphID glyphID) {
         return util::i18n::allowsIdeographicBreaking(glyphID);
     }

--- a/test/text/glyph_manager.test.cpp
+++ b/test/text/glyph_manager.test.cpp
@@ -19,6 +19,10 @@ static constexpr const size_t stubBitmapLength = 900;
 
 class StubLocalGlyphRasterizer : public LocalGlyphRasterizer {
 public:
+    StubLocalGlyphRasterizer()
+        : LocalGlyphRasterizer(0)
+    {}
+
     bool canRasterizeGlyph(const FontStack&, GlyphID glyphID) {
         return util::i18n::allowsIdeographicBreaking(glyphID);
     }


### PR DESCRIPTION
This is an experiment in rasterizing glyphs locally using `CTLineCreateWithAttributedString`, for use with TinySDF.

The basics seem to work. Look at render test failures on macos or ios to see the appearance of the locally rendered glyphs.

The guess-based glyph metrics I copied over from the JS implementation don't seem to be quite right. Instead of trying to work out a better guess, I'll look into just getting the metrics directly from CoreText.

There are several TODOs before this is ready for production:

- [ ] Provide a configuration interface that supports font descriptors
- [ ] C++ wrappers on C interfaces, share code with `image.mm`
- [ ] Extract glyph metrics
- [ ] Build in font stack awareness?

/cc @1ec5 @boundsj 