### PR TITLE
[build] Clang-3.8: Explicit mbgl::PlacedGlyph default+copy+move ctor

### DIFF
--- a/src/mbgl/layout/symbol_projection.hpp
+++ b/src/mbgl/layout/symbol_projection.hpp
@@ -23,8 +23,16 @@ namespace mbgl {
     };
     
     struct PlacedGlyph {
+        PlacedGlyph() = default;
+
         PlacedGlyph(Point<float> point_, float angle_, optional<TileDistance> tileDistance_)
             : point(point_), angle(angle_), tileDistance(std::move(tileDistance_))
+        {}
+        PlacedGlyph(PlacedGlyph&& other) noexcept
+            : point(std::move(other.point)), angle(other.angle), tileDistance(std::move(other.tileDistance))
+        {}
+        PlacedGlyph(const PlacedGlyph& other)
+            : point(std::move(other.point)), angle(other.angle), tileDistance(std::move(other.tileDistance))
         {}
         Point<float> point;
         float angle;


### PR DESCRIPTION
Fails on Qt CI:

https://codereview.qt-project.org/#/c/211971/

```
In file included from src/mbgl/layout/symbol_projection.cpp:1:
 In file included from src/mbgl/layout/symbol_projection.hpp:3:
 In file included from src/mbgl/util/mat4.hpp:25:
 In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/array:106:
 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/utility:264:58: error: no matching constructor for initialization of 'mbgl::PlacedGlyph'
 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/type_traits:2348:38: note: in instantiation of member function 'std::__1::pair<mbgl::PlacedGlyph, mbgl::PlacedGlyph>::pair' requested here
 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/experimental/optional:327:28: note: in instantiation of template class 'std::__1::is_constructible<std::__1::pair<mbgl::PlacedGlyph, mbgl::PlacedGlyph>>' requested here
 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/experimental/optional:332:14: note: in instantiation of default argument for 'optional<>' required here
 src/mbgl/layout/symbol_projection.cpp:255:9: note: while substituting deduced template arguments into function template 'optional' [with _Args = <>, $1 = (no value)]
 src/mbgl/layout/symbol_projection.hpp:25:12: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 0 were provided
 src/mbgl/layout/symbol_projection.hpp:25:12: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 0 were provided
 src/mbgl/layout/symbol_projection.hpp:26:9: note: candidate constructor not viable: requires 3 arguments, but 0 were provided
 In file included from src/mbgl/layout/symbol_projection.cpp:1:
 In file included from src/mbgl/layout/symbol_projection.hpp:3:
 In file included from src/mbgl/util/mat4.hpp:25:
 In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/array:106:
 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/utility:264:67: error: no matching constructor for initialization of 'mbgl::PlacedGlyph'
 make[4]: *** [.obj/src/mbgl/layout/symbol_projection.o] Error 1
 make[3]: *** [sub-------3rdparty-mapbox-gl-native-make_first] Error 2
 make[2]: *** [sub-geoservices-make_first] Error 2
 make[1]: *** [sub-plugins-make_first] Error 2
 make: *** [sub-src-make_first] Error 2```