### PR TITLE
[build] standardize on -fvisibility=hidden for all targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,8 @@ endif(WITH_COVERAGE)
 
 set(CMAKE_CONFIGURATION_TYPES Debug Release RelWithDebugInfo Sanitize)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -ftemplate-depth=1024 -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Werror -Wno-variadic-macros -Wno-unknown-pragmas")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -ftemplate-depth=1024 -fPIC -fvisibility=hidden -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Werror -Wno-variadic-macros -Wno-unknown-pragmas")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -fvisibility=hidden -Wall -Wextra -Wshadow -Werror -Wno-variadic-macros -Wno-unknown-pragmas")
 if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
     # -Wno-error=unused-command-line-argument is required due to https://llvm.org/bugs/show_bug.cgi?id=7798
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=unused-command-line-argument")

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ workflows:
           filters:
             tags:
               only: /node-.*/
-      - node6-clang39-debug:
+      - node6-gcc6-debug:
           filters:
             tags:
               only: /node-.*/
@@ -425,16 +425,16 @@ jobs:
       - *upload-render-tests
 
 # ------------------------------------------------------------------------------
-  node6-clang39-debug:
+  node6-gcc6-debug:
     docker:
-      - image: mbgl/de3c86c2ff:linux-clang-3.9
+      - image: mbgl/de3c86c2ff:linux-gcc-6
+    resource_class: large
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 4
       JOBS: 4
       BUILDTYPE: Debug
       WITH_EGL: 1
-      WITH_CXX11ABI: 0
     steps:
       - checkout
       - *generate-cache-key
@@ -567,7 +567,7 @@ jobs:
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 4
-      JOBS: 2
+      JOBS: 4
       BUILDTYPE: Debug
       WITH_EGL: 1
       WITH_CXX11ABI: 0
@@ -592,7 +592,7 @@ jobs:
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 4
-      JOBS: 2
+      JOBS: 4
       BUILDTYPE: Debug
       WITH_EGL: 1
       WITH_COVERAGE: 1
@@ -620,7 +620,7 @@ jobs:
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 4
-      JOBS: 2 # OOM, causing the compiler to crash.
+      JOBS: 4
       BUILDTYPE: Release
       GTEST_OUTPUT: xml
       LD_PRELOAD: /usr/lib/x86_64-linux-gnu/libjemalloc.so
@@ -648,7 +648,7 @@ jobs:
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 4
-      JOBS: 2 # OOM, causing the compiler to crash.
+      JOBS: 4
       BUILDTYPE: Release
       WITH_QT_I18N: 1
     steps:

--- a/cmake/benchmark.cmake
+++ b/cmake/benchmark.cmake
@@ -2,10 +2,6 @@ add_executable(mbgl-benchmark
     ${MBGL_BENCHMARK_FILES}
 )
 
-target_compile_options(mbgl-benchmark
-    PRIVATE -fvisibility-inlines-hidden
-)
-
 target_include_directories(mbgl-benchmark
     PRIVATE src
     PRIVATE benchmark/include

--- a/cmake/core.cmake
+++ b/cmake/core.cmake
@@ -2,11 +2,6 @@ add_library(mbgl-core STATIC
     ${MBGL_CORE_FILES}
 )
 
-target_compile_options(mbgl-core
-    PRIVATE -fPIC
-    PRIVATE -fvisibility-inlines-hidden
-)
-
 target_include_directories(mbgl-core
     PUBLIC include
     PRIVATE src

--- a/cmake/filesource.cmake
+++ b/cmake/filesource.cmake
@@ -30,13 +30,6 @@ target_add_mason_package(mbgl-filesource PRIVATE rapidjson)
 target_add_mason_package(mbgl-filesource PRIVATE boost)
 target_add_mason_package(mbgl-filesource PRIVATE geojson)
 
-set_xcode_property(mbgl-filesource GCC_SYMBOLS_PRIVATE_EXTERN YES)
-
-target_compile_options(mbgl-filesource
-    PRIVATE -fPIC
-    PRIVATE -fvisibility-inlines-hidden
-)
-
 target_include_directories(mbgl-filesource
     PRIVATE include
     PRIVATE src

--- a/cmake/glfw.cmake
+++ b/cmake/glfw.cmake
@@ -12,10 +12,6 @@ target_sources(mbgl-glfw
     PRIVATE platform/default/mbgl/util/default_styles.hpp
 )
 
-target_compile_options(mbgl-glfw
-    PRIVATE -fvisibility-inlines-hidden
-)
-
 target_include_directories(mbgl-glfw
     PRIVATE platform/default
 )

--- a/cmake/loop-darwin.cmake
+++ b/cmake/loop-darwin.cmake
@@ -4,13 +4,6 @@ add_library(mbgl-loop-darwin STATIC
     platform/darwin/src/timer.cpp
 )
 
-set_xcode_property(mbgl-loop-darwin GCC_SYMBOLS_PRIVATE_EXTERN YES)
-
-target_compile_options(mbgl-loop-darwin
-    PRIVATE -fPIC
-    PRIVATE -fvisibility-inlines-hidden
-)
-
 target_include_directories(mbgl-loop-darwin
     PRIVATE include
     PRIVATE src

--- a/cmake/loop-uv.cmake
+++ b/cmake/loop-uv.cmake
@@ -4,11 +4,6 @@ add_library(mbgl-loop-uv STATIC
     platform/default/timer.cpp
 )
 
-target_compile_options(mbgl-loop-uv
-    PRIVATE -fPIC
-    PRIVATE -fvisibility-inlines-hidden
-)
-
 target_include_directories(mbgl-loop-uv
     PRIVATE include
     PRIVATE src

--- a/cmake/node.cmake
+++ b/cmake/node.cmake
@@ -27,11 +27,6 @@ target_sources(mbgl-node
     PRIVATE platform/node/src/util/async_queue.hpp
 )
 
-target_compile_options(mbgl-node
-    PRIVATE -fPIC
-    PRIVATE -fvisibility-inlines-hidden
-)
-
 target_include_directories(mbgl-node
     PRIVATE platform/default
 )

--- a/cmake/offline.cmake
+++ b/cmake/offline.cmake
@@ -6,10 +6,6 @@ target_sources(mbgl-offline
     PRIVATE platform/default/mbgl/util/default_styles.hpp
 )
 
-target_compile_options(mbgl-offline
-    PRIVATE -fvisibility-inlines-hidden
-)
-
 target_include_directories(mbgl-offline
     PRIVATE platform/default
 )

--- a/cmake/render.cmake
+++ b/cmake/render.cmake
@@ -2,10 +2,6 @@ add_executable(mbgl-render
     bin/render.cpp
 )
 
-target_compile_options(mbgl-render
-    PRIVATE -fvisibility-inlines-hidden
-)
-
 target_include_directories(mbgl-render
     PRIVATE platform/default
 )

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -8,10 +8,6 @@ else()
     )
 endif()
 
-target_compile_options(mbgl-test
-    PRIVATE -fvisibility-inlines-hidden
-)
-
 set_source_files_properties(test/src/mbgl/test/util.cpp PROPERTIES COMPILE_FLAGS -DNODE_EXECUTABLE="${NodeJS_EXECUTABLE}")
 
 target_include_directories(mbgl-test

--- a/platform/android/config.cmake
+++ b/platform/android/config.cmake
@@ -7,12 +7,18 @@ set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> cruT <TARGET> <LINK_FLAGS> <OBJECTS>")
 set(CMAKE_CXX_ARCHIVE_APPEND "<CMAKE_AR> ruT <TARGET> <LINK_FLAGS> <OBJECTS>")
 set(CMAKE_C_ARCHIVE_APPEND "<CMAKE_AR> ruT <TARGET> <LINK_FLAGS> <OBJECTS>")
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffunction-sections -fdata-sections")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections")
+
 if ((ANDROID_ABI STREQUAL "armeabi") OR (ANDROID_ABI STREQUAL "armeabi-v7a") OR (ANDROID_ABI STREQUAL "arm64-v8a") OR
     (ANDROID_ABI STREQUAL "x86") OR (ANDROID_ABI STREQUAL "x86_64"))
     # Use Identical Code Folding on platforms that support the gold linker.
     set(CMAKE_EXE_LINKER_FLAGS "-fuse-ld=gold -Wl,--icf=safe ${CMAKE_EXE_LINKER_FLAGS}")
     set(CMAKE_SHARED_LINKER_FLAGS "-fuse-ld=gold -Wl,--icf=safe ${CMAKE_SHARED_LINKER_FLAGS}")
 endif()
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections -Wl,--version-script=${CMAKE_SOURCE_DIR}/platform/android/version-script")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--gc-sections -Wl,--version-script=${CMAKE_SOURCE_DIR}/platform/android/version-script")
 
 mason_use(jni.hpp VERSION 3.0.0 HEADER_ONLY)
 mason_use(nunicode VERSION 1.7.1)
@@ -79,12 +85,6 @@ macro(mbgl_platform_core)
     target_add_mason_package(mbgl-core PUBLIC rapidjson)
     target_add_mason_package(mbgl-core PRIVATE icu)
 
-    target_compile_options(mbgl-core
-        PRIVATE -fvisibility=hidden
-        PRIVATE -ffunction-sections
-        PRIVATE -fdata-sections
-    )
-
     target_link_libraries(mbgl-core
         PUBLIC -llog
         PUBLIC -landroid
@@ -112,12 +112,6 @@ macro(mbgl_filesource)
 
     target_add_mason_package(mbgl-filesource PUBLIC sqlite)
     target_add_mason_package(mbgl-filesource PUBLIC jni.hpp)
-
-    target_compile_options(mbgl-filesource
-        PRIVATE -fvisibility=hidden
-        PRIVATE -ffunction-sections
-        PRIVATE -fdata-sections
-    )
 
     target_link_libraries(mbgl-filesource
         PUBLIC -llog
@@ -308,12 +302,6 @@ add_library(mbgl-android STATIC
     platform/android/src/jni.cpp
 )
 
-target_compile_options(mbgl-android
-    PRIVATE -fvisibility=hidden
-    PRIVATE -ffunction-sections
-    PRIVATE -fdata-sections
-)
-
 target_link_libraries(mbgl-android
     PUBLIC mbgl-filesource
     PUBLIC mbgl-core
@@ -327,8 +315,6 @@ add_library(mapbox-gl SHARED
 
 target_link_libraries(mapbox-gl
     PRIVATE mbgl-android
-    PRIVATE -Wl,--gc-sections
-    PRIVATE -Wl,--version-script=${CMAKE_SOURCE_DIR}/platform/android/version-script
 )
 
 ## Test library ##
@@ -346,14 +332,8 @@ macro(mbgl_platform_test)
         PRIVATE platform/android
     )
 
-    target_compile_options(mbgl-test
-        PRIVATE -fvisibility=hidden
-    )
-
     target_link_libraries(mbgl-test
         PRIVATE mbgl-android
-        PRIVATE -Wl,--gc-sections
-        PRIVATE -Wl,--version-script=${CMAKE_SOURCE_DIR}/platform/android/version-script
     )
 endmacro()
 
@@ -363,14 +343,6 @@ add_library(example-custom-layer SHARED
     platform/android/src/example_custom_layer.cpp
 )
 
-target_compile_options(example-custom-layer
-    PRIVATE -fvisibility=hidden
-    PRIVATE -ffunction-sections
-    PRIVATE -fdata-sections
-)
-
 target_link_libraries(example-custom-layer
     PRIVATE mbgl-core
-    PRIVATE -Wl,--gc-sections
-    PRIVATE -Wl,--version-script=${CMAKE_SOURCE_DIR}/platform/android/version-script
 )

--- a/platform/ios/config.cmake
+++ b/platform/ios/config.cmake
@@ -62,10 +62,6 @@ macro(mbgl_platform_core)
     target_add_mason_package(mbgl-core PUBLIC polylabel)
     target_add_mason_package(mbgl-core PRIVATE icu)
 
-    target_compile_options(mbgl-core
-        PRIVATE -fvisibility=hidden
-    )
-
     target_include_directories(mbgl-core
         PUBLIC platform/darwin
         PUBLIC platform/default
@@ -92,10 +88,6 @@ macro(mbgl_filesource)
 
         # Database
         PRIVATE platform/default/sqlite3.cpp
-    )
-
-    target_compile_options(mbgl-filesource
-        PRIVATE -fvisibility=hidden
     )
 
     target_link_libraries(mbgl-filesource

--- a/platform/linux/config.cmake
+++ b/platform/linux/config.cmake
@@ -30,7 +30,6 @@ macro(mbgl_platform_core)
         target_link_libraries(mbgl-core
             PUBLIC -lGLESv2
             PUBLIC -lEGL
-            PUBLIC -lgbm
         )
     else()
         target_sources(mbgl-core

--- a/platform/macos/config.cmake
+++ b/platform/macos/config.cmake
@@ -50,7 +50,6 @@ macro(mbgl_platform_core)
 
     target_compile_options(mbgl-core
         PRIVATE -fobjc-arc
-        PRIVATE -fvisibility=hidden
     )
 
     target_include_directories(mbgl-core
@@ -81,7 +80,6 @@ macro(mbgl_filesource)
 
     target_compile_options(mbgl-filesource
         PRIVATE -fobjc-arc
-        PRIVATE -fvisibility=hidden
     )
 
     target_link_libraries(mbgl-filesource
@@ -96,11 +94,6 @@ macro(mbgl_platform_glfw)
         PRIVATE mbgl-filesource
         PRIVATE mbgl-loop-darwin
     )
-
-    target_compile_options(mbgl-glfw
-        PRIVATE -fvisibility=hidden
-    )
-
 endmacro()
 
 
@@ -109,9 +102,6 @@ macro(mbgl_platform_render)
         PRIVATE mbgl-filesource
         PRIVATE mbgl-loop-darwin
     )
-    target_compile_options(mbgl-render
-        PRIVATE -fvisibility=hidden
-    )
 endmacro()
 
 
@@ -119,9 +109,6 @@ macro(mbgl_platform_offline)
     target_link_libraries(mbgl-offline
         PRIVATE mbgl-filesource
         PRIVATE mbgl-loop-darwin
-    )
-    target_compile_options(mbgl-offline
-        PRIVATE -fvisibility=hidden
     )
 endmacro()
 
@@ -141,10 +128,6 @@ macro(mbgl_platform_test)
         COMPILE_FLAGS -DWORK_DIRECTORY="${CMAKE_SOURCE_DIR}"
     )
 
-    target_compile_options(mbgl-test
-        PRIVATE -fvisibility=hidden
-    )
-
     target_link_libraries(mbgl-test
         PRIVATE mbgl-filesource
         PRIVATE mbgl-loop-darwin
@@ -152,10 +135,6 @@ macro(mbgl_platform_test)
 endmacro()
 
 macro(mbgl_platform_benchmark)
-    target_compile_options(mbgl-benchmark
-        PRIVATE -fvisibility=hidden
-    )
-
     target_sources(mbgl-benchmark
         PRIVATE benchmark/src/main.cpp
     )
@@ -173,10 +152,6 @@ macro(mbgl_platform_benchmark)
 endmacro()
 
 macro(mbgl_platform_node)
-    target_compile_options(mbgl-node
-        PRIVATE -fvisibility=hidden
-    )
-
     target_link_libraries(mbgl-node
         PRIVATE "-Wl,-bind_at_load"
     )

--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -5,8 +5,7 @@ option(WITH_QT_DECODERS "Use builtin Qt image decoders" OFF)
 option(WITH_QT_I18N     "Use builtin Qt i18n support"   OFF)
 option(WITH_QT_4        "Use Qt4 instead of Qt5"        OFF)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -D__QT__")
-set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -fvisibility=hidden -D__QT__")
+add_definitions("-D__QT__")
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)

--- a/src/parsedate/parsedate.c
+++ b/src/parsedate/parsedate.c
@@ -418,7 +418,7 @@ static time_t my_timegm(struct my_tm *tm)
 {
   static const int month_days_cumulative [12] =
     { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 };
-  int month, year, leap_days;
+  int month_, year, leap_days;
 
   if(tm->tm_year < 70)
     /* we don't support years before 1970 as they will cause this function
@@ -426,14 +426,14 @@ static time_t my_timegm(struct my_tm *tm)
     return -1;
 
   year = tm->tm_year + 1900;
-  month = tm->tm_mon;
-  if(month < 0) {
-    year += (11 - month) / 12;
-    month = 11 - (11 - month) % 12;
+  month_ = tm->tm_mon;
+  if(month_ < 0) {
+    year += (11 - month_) / 12;
+    month_ = 11 - (11 - month_) % 12;
   }
-  else if(month >= 12) {
-    year -= month / 12;
-    month = month % 12;
+  else if(month_ >= 12) {
+    year -= month_ / 12;
+    month_ = month_ % 12;
   }
 
   leap_days = year - (tm->tm_mon <= 1);
@@ -441,7 +441,7 @@ static time_t my_timegm(struct my_tm *tm)
                - (1969 / 4) + (1969 / 100) - (1969 / 400));
 
   return ((((time_t) (year - 1970) * 365
-            + leap_days + month_days_cumulative [month] + tm->tm_mday - 1) * 24
+            + leap_days + month_days_cumulative [month_] + tm->tm_mday - 1) * 24
            + tm->tm_hour) * 60 + tm->tm_min) * 60 + tm->tm_sec;
 }
 


### PR DESCRIPTION
Enables `-fvisibility=hidden` for iOS and Linux, and adds [a workaround for GCC 6.3-7.1](https://github.com/mapbox/mapbox-gl-native/pull/10499). Also changes a Clang 3.9 build to a GCC 6 build.