### PR TITLE
[ios] Fix an Interface Builder crash for IBInspectable properties.

### DIFF
--- a/platform/ios/src/MGLMapView+IBAdditions.h
+++ b/platform/ios/src/MGLMapView+IBAdditions.h
@@ -31,6 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) IBInspectable double latitude;
 @property (nonatomic) IBInspectable double longitude;
 @property (nonatomic) IBInspectable double zoomLevel;
+@property (nonatomic) IBInspectable double minimumZoomLevel;
+@property (nonatomic) IBInspectable double maximumZoomLevel;
 
 // Renamed properties. Interface Builder derives the display name of each
 // inspectable from the runtime name, but runtime names don’t always make sense

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -610,7 +610,7 @@ MGL_EXPORT IB_DESIGNABLE
  *
  * The default minimumZoomLevel is 0.
  */
-@property (nonatomic) IBInspectable double minimumZoomLevel;
+@property (nonatomic) double minimumZoomLevel;
 
 /**
  * The maximum zoom level the map can be shown at.
@@ -621,7 +621,7 @@ MGL_EXPORT IB_DESIGNABLE
  * The default maximumZoomLevel is 22. The upper bound for this property
  * is 25.5.
  */
-@property (nonatomic) IBInspectable double maximumZoomLevel;
+@property (nonatomic) double maximumZoomLevel;
 
 /**
  The heading of the map, measured in degrees clockwise from true north.


### PR DESCRIPTION
Fixes #10573 

Adding the IBInspectable to `minimumZoomLevel` and `maximumZoomLevel` in `MGLMapview` made IB crash.
