### PR TITLE
CustomGeometrySource shouldn't flash when invalidating region/tile

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/CustomGeometrySource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/CustomGeometrySource.java
@@ -191,7 +191,7 @@ public class CustomGeometrySource extends Source {
 
       FeatureCollection data = provider.getFeaturesForBounds(LatLngBounds.from(id.z, id.x, id.y), id.z);
       CustomGeometrySource source = sourceRef.get();
-      if (!isCancelled() && source != null && !data.getFeatures().isEmpty())  {
+      if (!isCancelled() && source != null && data != null)  {
         source.setTileData(id, data);
       }
     }

--- a/src/mbgl/style/custom_tile_loader.hpp
+++ b/src/mbgl/style/custom_tile_loader.hpp
@@ -2,25 +2,25 @@
 
 #include <mbgl/style/sources/custom_geometry_source.hpp>
 #include <mbgl/tile/tile_id.hpp>
-#include <mbgl/util/geo.hpp>
 #include <mbgl/util/geojson.hpp>
 #include <mbgl/actor/actor_ref.hpp>
 
 #include <map>
 
 namespace mbgl {
-namespace style {
 
-using SetTileDataFunction = std::function<void(const GeoJSON&)>;
+class CustomGeometryTile;
+
+namespace style {
 
 class CustomTileLoader : private util::noncopyable {
 public:
 
-    using OverscaledIDFunctionTuple = std::tuple<uint8_t, int16_t, ActorRef<SetTileDataFunction>>;
+    using OverscaledIDFunctionTuple = std::tuple<uint8_t, int16_t, ActorRef<CustomGeometryTile>>;
 
     CustomTileLoader(const TileFunction& fetchTileFn, const TileFunction& cancelTileFn);
 
-    void fetchTile(const OverscaledTileID& tileID, ActorRef<SetTileDataFunction> callbackRef);
+    void fetchTile(const OverscaledTileID& tileID, ActorRef<CustomGeometryTile> tileRef);
     void cancelTile(const OverscaledTileID& tileID);
 
     void removeTile(const OverscaledTileID& tileID);

--- a/src/mbgl/style/sources/custom_geometry_source.cpp
+++ b/src/mbgl/style/sources/custom_geometry_source.cpp
@@ -40,6 +40,6 @@ void CustomGeometrySource::invalidateTile(const CanonicalTileID& tileID) {
 void CustomGeometrySource::invalidateRegion(const LatLngBounds& bounds) {
     loader->invoke(&CustomTileLoader::invalidateRegion, bounds, impl().getZoomRange());
 }
-    
+
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/tile/custom_geometry_tile.hpp
+++ b/src/mbgl/tile/custom_geometry_tile.hpp
@@ -1,12 +1,18 @@
 #pragma once
 
 #include <mbgl/tile/geometry_tile.hpp>
+#include <mbgl/style/sources/custom_geometry_source.hpp>
 #include <mbgl/util/feature.hpp>
-#include <mbgl/style/custom_tile_loader.hpp>
+#include <mbgl/util/geojson.hpp>
+#include <mbgl/actor/mailbox.hpp>
 
 namespace mbgl {
 
 class TileParameters;
+
+namespace style {
+class CustomTileLoader;
+} // namespace style
 
 class CustomGeometryTile: public GeometryTile {
 public:
@@ -16,7 +22,9 @@ public:
                const style::CustomGeometrySource::TileOptions,
                ActorRef<style::CustomTileLoader> loader);
     ~CustomGeometryTile() override;
+
     void setTileData(const GeoJSON& data);
+    void invalidateTileData();
 
     void setNecessity(TileNecessity) final;
 
@@ -25,10 +33,12 @@ public:
         const SourceQueryOptions&) override;
 
 private:
+    bool stale = true;
     TileNecessity necessity;
     const style::CustomGeometrySource::TileOptions options;
     ActorRef<style::CustomTileLoader> loader;
-    Actor<style::SetTileDataFunction> actor;
+    std::shared_ptr<Mailbox> mailbox;
+    ActorRef<CustomGeometryTile> actorRef;
 };
 
 } // namespace mbgl


### PR DESCRIPTION
`CustomGeometrySource::invalidateRegion` and `CustomGeometrySource::invalidateTile` clear the existing tile contents as part of the invalidation, causing the tile to flash before the new content is laid out. The flash can be longer on slower devices.
 
https://github.com/mapbox/mapbox-gl-native/blob/8757164ac8f2b033b2b12d4baf075ed18cfeb2b4/src/mbgl/style/custom_tile_loader.cpp#L72

This PR introduces two changes to fix this:
- Hold an `ActorRef<CustomGeometryTile>` to allow calling multiple class methods.
- Marks the `CustomGeometryTile` as stale, requiring that it fetch new data the next time it is being used for rendering.

I'm using `Tile::setNecessity()` as a proxy for determiningg when a tile is being added to a pyramid's render tiles list. Ideally, there'd be a more explicit notification to tiles that they are included in the render tiles list, and as an ideal or fallback tile.
