### PR TITLE
[android] Remove unnecessary jar generation from gradle-publish.gradle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -613,7 +613,12 @@ apackage: platform/android/configuration.gradle
 # Uploads the compiled Android SDK to Maven
 .PHONY: run-android-upload-archives
 run-android-upload-archives: platform/android/configuration.gradle
-	cd platform/android && $(MBGL_ANDROID_GRADLE) -Pmapbox.abis=all :MapboxGLAndroidSDK:uploadArchives
+	cd platform/android && export IS_LOCAL_DEVELOPMENT=false && $(MBGL_ANDROID_GRADLE) -Pmapbox.abis=all :MapboxGLAndroidSDK:uploadArchives
+
+# Uploads the compiled Android SDK to ~/.m2/repository/com/mapbox/mapboxsdk
+.PHONY: run-android-upload-archives-local
+run-android-upload-archives-local: platform/android/configuration.gradle
+	cd platform/android && export IS_LOCAL_DEVELOPMENT=true && $(MBGL_ANDROID_GRADLE) -Pmapbox.abis=all :MapboxGLAndroidSDK:uploadArchives
 
 # Dump system graphics information for the test app
 .PHONY: android-gfxinfo

--- a/platform/android/MapboxGLAndroidSDK/gradle-publish.gradle
+++ b/platform/android/MapboxGLAndroidSDK/gradle-publish.gradle
@@ -14,20 +14,15 @@ repositories {
     mavenCentral()
 }
 
-// From https://raw.github.com/mcxiaoke/gradle-mvn-push/master/jar.gradle
-android.libraryVariants.all { variant ->
-    def jarTask = project.tasks.create(name: "jar${variant.name.capitalize()}", type: Jar) {
-        from variant.javaCompile.destinationDir
-        exclude "**/R.class"
-        exclude "**/BuildConfig.class"
-    }
-    jarTask.dependsOn variant.javaCompile
-    artifacts.add('archives', jarTask);
-}
-
-// From https://raw.github.com/mcxiaoke/gradle-mvn-push/master/gradle-mvn-push.gradle
 def isReleaseBuild() {
     return VERSION_NAME.contains("SNAPSHOT") == false
+}
+
+def isLocalBuild() {
+    if (System.getenv('IS_LOCAL_DEVELOPMENT') != null) {
+        return System.getenv('IS_LOCAL_DEVELOPMENT').toBoolean()
+    }
+    return true
 }
 
 def getReleaseRepositoryUrl() {
@@ -40,6 +35,10 @@ def getSnapshotRepositoryUrl() {
             "https://oss.sonatype.org/content/repositories/snapshots/"
 }
 
+def obtainMavenLocalUrl() {
+    return getRepositories().mavenLocal().getUrl()
+}
+
 def getRepositoryUsername() {
     return hasProperty('USERNAME') ? USERNAME :
             (hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : "")
@@ -48,22 +47,6 @@ def getRepositoryUsername() {
 def getRepositoryPassword() {
     return hasProperty('PASSWORD') ? PASSWORD :
             (hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : "")
-}
-
-task apklib(type: Zip) {
-    appendix = extension = 'apklib'
-
-    from 'AndroidManifest.xml'
-    into('res') {
-        from 'res'
-    }
-    into('src') {
-        from 'src'
-    }
-}
-
-artifacts {
-    archives apklib
 }
 
 afterEvaluate { project ->
@@ -76,24 +59,16 @@ afterEvaluate { project ->
                 pom.artifactId = POM_ARTIFACT_ID
                 pom.version = VERSION_NAME
 
-                repository(url: getReleaseRepositoryUrl()) {
-                    authentication(userName: getRepositoryUsername(),
-                            password: getRepositoryPassword())
+                if (isLocalBuild()) {
+                    repository(url: obtainMavenLocalUrl())
+                } else {
+                    repository(url: getReleaseRepositoryUrl()) {
+                        authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+                    }
+                    snapshotRepository(url: getSnapshotRepositoryUrl()) {
+                        authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+                    }
                 }
-                snapshotRepository(url: getSnapshotRepositoryUrl()) {
-                    authentication(userName: getRepositoryUsername(),
-                            password: getRepositoryPassword())
-                }
-
-/*
-                // Leaving out as artifact was incorrectly named when found
-                addFilter('aar') { artifact, file ->
-                    artifact.name == archivesBaseName
-                }
-                addFilter('apklib') { artifact, file ->
-                    artifact.name == archivesBaseName + '-apklib'
-                }
-*/
 
                 pom.project {
                     name POM_NAME
@@ -149,5 +124,14 @@ afterEvaluate { project ->
     artifacts {
         archives androidSourcesJar
         archives androidJavadocsJar
+    }
+}
+
+// See: https://github.com/chrisbanes/gradle-mvn-push/issues/43#issuecomment-84140513
+afterEvaluate { project ->
+    android.libraryVariants.all { variant ->
+        tasks.androidJavadocs.doFirst {
+            classpath += files(variant.javaCompile.classpath.files)
+        }
     }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/Compare.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/Compare.java
@@ -1,7 +1,7 @@
 package com.mapbox.mapboxsdk.utils;
 
 /**
- * Comparisons from std sdk, which aren't available in API level <= 15
+ * Comparisons from std sdk, which aren't available in API level 15 and below
  */
 public class Compare {
 


### PR DESCRIPTION
- Removes unnecessary `jar` generation from `gradle-publish.gradle`
- Adds `run-android-upload-archives-local` to `Makefile`
- Fixes Javadoc `error: malformed HTML` in `Compare.java`

In the next release, developers will be able to include the SDK as follows:

```groovy
dependencies {
    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:{{ VERSION_ANDROID_SDK }}'
}
```

No need to include `@aar` and `transitive = true` anymore 🎉

👀 @tobrun @langsmith 
