### PR TITLE
[ios] update constraints when updating content inset

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1049,7 +1049,7 @@ public:
     }
 
     // Compass, logo and attribution button constraints needs to be updated.
-    [self setNeedsLayout];
+    [self setNeedsUpdateConstraints];
 }
 
 /// Returns the frame of inset content within the map view.


### PR DESCRIPTION
Cherry picks #10485 into `release-agua`.

-- Edited to correct the PR number. 