### PR TITLE
[core] Add support for wrapped LatLngBounds

### DIFF
--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -154,25 +154,84 @@ public:
                sw.longitude() > ne.longitude();
     }
 
-    bool contains(const LatLng& point) const {
-        return (point.latitude()  >= sw.latitude()  &&
-                point.latitude()  <= ne.latitude()  &&
-                point.longitude() >= sw.longitude() &&
-                point.longitude() <= ne.longitude());
+    bool crossesAntimeridian() const {
+        return (sw.wrapped().longitude() > ne.wrapped().longitude());
     }
 
-    bool contains(const LatLngBounds& area) const {
-        return (area.ne.latitude()  <= ne.latitude()  &&
-                area.sw.latitude()  >= sw.latitude()  &&
-                area.ne.longitude() <= ne.longitude() &&
-                area.sw.longitude() >= sw.longitude());
+    bool contains(const LatLng& point, LatLng::WrapMode wrap = LatLng::Unwrapped) const {
+        bool containsLatitude = point.latitude() >= sw.latitude() &&
+                                point.latitude() <= ne.latitude();
+        if (!containsLatitude) {
+            return false;
+        }
+
+        bool containsUnwrappedLongitude = point.longitude() >= sw.longitude() &&
+                                          point.longitude() <= ne.longitude();
+        if (containsUnwrappedLongitude) {
+            return true;
+        } else if (wrap == LatLng::Wrapped) {
+            LatLngBounds wrapped(sw.wrapped(), ne.wrapped());
+            auto ptLon = point.wrapped().longitude();
+            if (crossesAntimeridian()) {
+                return (ptLon >= wrapped.sw.longitude() &&
+                        ptLon <= util::LONGITUDE_MAX) ||
+                       (ptLon <= wrapped.ne.longitude() &&
+                        ptLon >= -util::LONGITUDE_MAX);
+            } else {
+                return (ptLon >= wrapped.sw.longitude() &&
+                        ptLon <= wrapped.ne.longitude());
+            }
+        }
+        return false;
     }
 
-    bool intersects(const LatLngBounds area) const {
-        return (area.ne.latitude()  > sw.latitude()  &&
-                area.sw.latitude()  < ne.latitude()  &&
-                area.ne.longitude() > sw.longitude() &&
-                area.sw.longitude() < ne.longitude());
+    bool contains(const LatLngBounds& area, LatLng::WrapMode wrap = LatLng::Unwrapped) const {
+        bool containsLatitude = area.north() <= north() && area.south() >= south();
+        if (!containsLatitude) {
+            return false;
+        }
+
+        bool containsUnwrapped = area.east() <= east() && area.west() >= west();
+        if(containsUnwrapped) {
+            return true;
+        } else if (wrap == LatLng::Wrapped) {
+            LatLngBounds wrapped(sw.wrapped(), ne.wrapped());
+            LatLngBounds other(area.sw.wrapped(), area.ne.wrapped());
+            if (crossesAntimeridian() & !area.crossesAntimeridian()) {
+                return (other.east() <= util::LONGITUDE_MAX && other.west() >= wrapped.west()) ||
+                       (other.east() <= wrapped.east() && other.west() >= -util::LONGITUDE_MAX);
+            } else {
+                return other.east() <= wrapped.east() && other.west() >= wrapped.west();
+            }
+        }
+        return false;
+    }
+
+    bool intersects(const LatLngBounds area, LatLng::WrapMode wrap = LatLng::Unwrapped) const {
+        bool latitudeIntersects = area.north() > south() && area.south() < north();
+        if (!latitudeIntersects) {
+            return false;
+        }
+
+        bool longitudeIntersects = area.east() > west() && area.west() < east();
+        if (longitudeIntersects) {
+            return true;
+        } else if (wrap == LatLng::Wrapped) {
+            LatLngBounds wrapped(sw.wrapped(), ne.wrapped());
+            LatLngBounds other(area.sw.wrapped(), area.ne.wrapped());
+            if (crossesAntimeridian()) {
+                return area.crossesAntimeridian() ||
+                       other.east() > wrapped.west() ||
+                       other.west() < wrapped.east();
+            } else if (other.crossesAntimeridian()){
+                return other.east() > wrapped.west() ||
+                       other.west() < wrapped.east();
+            } else {
+                return other.east() > wrapped.west() &&
+                       other.west() < wrapped.east();
+            }
+        }
+        return false;
     }
 
 private:

--- a/src/mbgl/style/custom_tile_loader.cpp
+++ b/src/mbgl/style/custom_tile_loader.cpp
@@ -81,7 +81,7 @@ void CustomTileLoader::invalidateTile(const CanonicalTileID& tileID) {
 void CustomTileLoader::invalidateRegion(const LatLngBounds& bounds, Range<uint8_t> ) {
     for (auto idtuple= tileCallbackMap.begin(); idtuple != tileCallbackMap.end(); idtuple++) {
         const LatLngBounds tileBounds(idtuple->first);
-        if (tileBounds.intersects(bounds) || bounds.contains(tileBounds) || tileBounds.contains(bounds)) {
+        if (tileBounds.intersects(bounds, LatLng::Wrapped) || bounds.contains(tileBounds, LatLng::Wrapped) || tileBounds.contains(bounds, LatLng::Wrapped)) {
             for (auto iter = idtuple->second.begin(); iter != idtuple->second.end(); iter++) {
                 auto actor = std::get<2>(*iter);
                 actor.invoke(&CustomGeometryTile::invalidateTileData);


### PR DESCRIPTION
Fixes #10622.

For custom sources, the `CustomTileLoader::invalidateRegion()` method invalidates all tiles that contain or intersect the provided `LatLngBounds`, using `CanonicalTileID`s. 

The input `bounds` may be wrapped when crossing the antimeridian or when working with wrapped worlds. 

Add `LatLng::WrapMode` as a  parameter to `LatLngBounds::contains()` and `LatLngBounds::intersects()` for comparing bounds in a canonical space.