### PR TITLE
Fix-up: [ios, macos] Snapshot classes added to jazzy

### DIFF
--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -32,6 +32,9 @@ custom_categories:
       - MGLMapCamera
       - MGLMapView
       - MGLMapViewDelegate
+      - MGLMapSnapshot
+      - MGLMapSnapshotOptions
+      - MGLMapSnapshotter
       - MGLUserTrackingMode
   - name: Primitive Shapes
     children:

--- a/platform/macos/jazzy.yml
+++ b/platform/macos/jazzy.yml
@@ -28,6 +28,9 @@ custom_categories:
       - MGLMapCamera
       - MGLMapView
       - MGLMapViewDelegate
+      - MGLMapSnapshot
+      - MGLMapSnapshotOptions
+      - MGLMapSnapshotter
   - name: Shapes and Annotations
     children:
       - MGLAnnotation


### PR DESCRIPTION
Finishes #10212, closes #10121.

Rather than fiddle with the external branch from #10212, I’ve created a new branch/PR with a squashed and updated commit. Apologies for spreading this into a third issue.

<img width="250" alt="screen shot 2017-12-05 at 2 29 25 pm" src="https://user-images.githubusercontent.com/1198851/33626676-491af6b4-d9c9-11e7-8575-0fa4f0f9cc5b.png">

/cc @jmkiley @1ec5 @jcfausto 