### PR TITLE
Build boba snapshots from master

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -375,7 +375,7 @@ jobs:
       - deploy:
           name: Publish to Maven
           command: |
-            if [ "${CIRCLE_BRANCH}" == "release-agua" ]; then make run-android-upload-archives ; fi
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then make run-android-upload-archives ; fi
 
 
 # ------------------------------------------------------------------------------

--- a/platform/android/MapboxGLAndroidSDK/gradle.properties
+++ b/platform/android/MapboxGLAndroidSDK/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.mapbox.mapboxsdk
-VERSION_NAME=5.2.0-SNAPSHOT
+VERSION_NAME=6.0.0-SNAPSHOT
 
 POM_DESCRIPTION=Mapbox GL Android SDK
 POM_URL=https://github.com/mapbox/mapbox-gl-native

--- a/platform/android/dependencies.gradle
+++ b/platform/android/dependencies.gradle
@@ -4,8 +4,8 @@ ext {
     compileSdkVersion = 25
     buildToolsVersion = "25.0.2"
 
-    versionCode = 11
-    versionName = "5.0.0"
+    versionCode = 12
+    versionName = "6.0.0"
 
     mapboxServicesVersion = "2.2.8"
     supportLibVersion = "25.4.0"


### PR DESCRIPTION
With this PR, we are starting to build snapshot builds for the Android SDK. This allows developers to test out custom sources and the upcoming font and expressions work.