### PR TITLE
Correct ColorMode::Replace

### DIFF
--- a/src/mbgl/gl/color_mode.hpp
+++ b/src/mbgl/gl/color_mode.hpp
@@ -48,7 +48,7 @@ public:
 
     struct Replace {
         static constexpr BlendEquation equation = BlendEquation::Add;
-        static constexpr BlendFactor srcFactor = One;
+        static constexpr BlendFactor srcFactor = Zero;
         static constexpr BlendFactor dstFactor = One;
     };
 

--- a/src/mbgl/gl/color_mode.hpp
+++ b/src/mbgl/gl/color_mode.hpp
@@ -48,8 +48,8 @@ public:
 
     struct Replace {
         static constexpr BlendEquation equation = BlendEquation::Add;
-        static constexpr BlendFactor srcFactor = Zero;
-        static constexpr BlendFactor dstFactor = One;
+        static constexpr BlendFactor srcFactor = One;
+        static constexpr BlendFactor dstFactor = Zero;
     };
 
     using Add              = LinearBlend<BlendEquation::Add>;


### PR DESCRIPTION
`srcFactor` in a Replace operation should be `ZERO`, not `ONE` (would not affect present refactoring results, but this would have affected e.g. heatmap implementation cc @mourner — I noticed in gl-js heatmaps use `blendFunc(ONE, ONE)` + `blend(true)`)