### PR TITLE
Fix scale gesture

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -491,7 +491,7 @@ final class MapGestureDetector {
         return super.onScale(detector);
       }
 
-      wasZoomingIn = (Math.log(detector.getScaleFactor()) / Math.log(Math.PI / 2)) >= 0;
+      wasZoomingIn = (Math.log(detector.getScaleFactor()) / Math.log(Math.PI / 2)) > 0;
       if (tiltGestureOccurred) {
         return false;
       }


### PR DESCRIPTION
We have heard about reports that users where able to perform a zoom in gesture while they were pinching out. Some debugging has shown that we weren't correctly creating the wasZoomingIn flag. Instead of checking against `>=` we should have checked against `>` instead.