### PR TITLE
CompassView decode crash

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
@@ -191,6 +191,12 @@ public final class UiSettings {
   }
 
   private Drawable decode(byte[] bitmap) {
+    if (bitmap == null) {
+      // return default icon
+      return compassView.getResources().getDrawable(R.drawable.mapbox_compass_icon);
+    }
+
+    // try decoding saved bitmap
     Bitmap compass = BitmapFactory.decodeByteArray(bitmap, 0, bitmap.length);
     return new BitmapDrawable(compassView.getResources(), compass);
   }


### PR DESCRIPTION
This catches the occurrence mentioned in #10636 and returns the default icon instead.
closes #10636  