### PR TITLE
Update CI images

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -216,7 +216,7 @@ jobs:
 # ------------------------------------------------------------------------------
   clang-tidy:
     docker:
-      - image: mbgl/de3c86c2ff:linux-clang-3.9
+      - image: mbgl/7d2403f42e:linux-clang-3.9
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 4
@@ -242,7 +242,7 @@ jobs:
 # ------------------------------------------------------------------------------
   android-debug-arm-v7:
     docker:
-      - image: mbgl/de3c86c2ff:android-ndk-r16
+      - image: mbgl/7d2403f42e:android-ndk-r16b
     resource_class: large
     working_directory: /src
     environment:
@@ -334,7 +334,7 @@ jobs:
 # ------------------------------------------------------------------------------
   android-release-all:
     docker:
-      - image: mbgl/ci@sha256:c34e221294d81da80918d3e9a9df5de795b067e88f86d7c9a5e262763332536e
+      - image: mbgl/7d2403f42e:android-ndk-r16b
     resource_class: large
     working_directory: /src
     environment:
@@ -381,7 +381,7 @@ jobs:
 # ------------------------------------------------------------------------------
   node4-clang39-release:
     docker:
-      - image: mbgl/de3c86c2ff:linux-clang-3.9-node-4
+      - image: mbgl/7d2403f42e:linux-clang-3.9-node-4
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 4
@@ -404,7 +404,7 @@ jobs:
 # ------------------------------------------------------------------------------
   node6-clang39-release:
     docker:
-      - image: mbgl/de3c86c2ff:linux-clang-3.9
+      - image: mbgl/7d2403f42e:linux-clang-3.9
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 4
@@ -427,7 +427,7 @@ jobs:
 # ------------------------------------------------------------------------------
   node6-gcc6-debug:
     docker:
-      - image: mbgl/de3c86c2ff:linux-gcc-6
+      - image: mbgl/7d2403f42e:linux-gcc-6
     resource_class: large
     working_directory: /src
     environment:
@@ -450,7 +450,7 @@ jobs:
 # ------------------------------------------------------------------------------
   linux-clang39-debug:
     docker:
-      - image: mbgl/de3c86c2ff:linux-clang-3.9
+      - image: mbgl/7d2403f42e:linux-clang-3.9
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 4
@@ -472,7 +472,7 @@ jobs:
 # ------------------------------------------------------------------------------
   linux-clang4-sanitize-address:
     docker:
-      - image: mbgl/de3c86c2ff:linux-clang-4
+      - image: mbgl/7d2403f42e:linux-clang-4
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 4
@@ -502,7 +502,7 @@ jobs:
 # ------------------------------------------------------------------------------
   linux-clang4-sanitize-undefined:
     docker:
-      - image: mbgl/de3c86c2ff:linux-clang-4
+      - image: mbgl/7d2403f42e:linux-clang-4
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 4
@@ -532,7 +532,7 @@ jobs:
 # ------------------------------------------------------------------------------
   linux-clang4-sanitize-thread:
     docker:
-      - image: mbgl/de3c86c2ff:linux-clang-4
+      - image: mbgl/7d2403f42e:linux-clang-4
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 4
@@ -562,7 +562,7 @@ jobs:
 # ------------------------------------------------------------------------------
   linux-gcc4.9-debug:
     docker:
-      - image: mbgl/de3c86c2ff:linux-gcc-4.9
+      - image: mbgl/7d2403f42e:linux-gcc-4.9
     resource_class: large
     working_directory: /src
     environment:
@@ -587,7 +587,7 @@ jobs:
 # ------------------------------------------------------------------------------
   linux-gcc5-debug-coverage:
     docker:
-      - image: mbgl/de3c86c2ff:linux-gcc-5
+      - image: mbgl/7d2403f42e:linux-gcc-5
     resource_class: large
     working_directory: /src
     environment:
@@ -615,7 +615,7 @@ jobs:
 # ------------------------------------------------------------------------------
   linux-gcc5-release-qt4:
     docker:
-      - image: mbgl/de3c86c2ff:linux-gcc-5-qt-4
+      - image: mbgl/7d2403f42e:linux-gcc-5-qt-4
     resource_class: large
     working_directory: /src
     environment:
@@ -643,7 +643,7 @@ jobs:
 # ------------------------------------------------------------------------------
   linux-gcc5-release-qt5:
     docker:
-      - image: mbgl/de3c86c2ff:linux-gcc-5-qt-5.9
+      - image: mbgl/7d2403f42e:linux-gcc-5-qt-5.9
     resource_class: large
     working_directory: /src
     environment:

--- a/platform/android/dependencies.gradle
+++ b/platform/android/dependencies.gradle
@@ -2,7 +2,7 @@ ext {
     minSdkVersion = 15
     targetSdkVersion = 25
     compileSdkVersion = 25
-    buildToolsVersion = "25.0.2"
+    buildToolsVersion = "25.0.3"
 
     versionCode = 12
     versionName = "6.0.0"


### PR DESCRIPTION
This PR updates the CI images to the latest image from https://github.com/mapbox/mbgl-ci-images/pull/14:
  - update ndk16 to ndk16b
  - update 27.0.1 android build tools to 27.0.2
  - update build tools 25.0.2 to 25.0.3

cc @Guardiola31337 