### PR TITLE
[android] Agua cherry-pick of TinySDF functionality

### DIFF
--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -481,6 +481,7 @@ set(MBGL_CORE_FILES
     src/mbgl/text/glyph_pbf.cpp
     src/mbgl/text/glyph_pbf.hpp
     src/mbgl/text/glyph_range.hpp
+    src/mbgl/text/local_glyph_rasterizer.hpp
     src/mbgl/text/placement_config.hpp
     src/mbgl/text/quads.cpp
     src/mbgl/text/quads.hpp

--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -613,6 +613,8 @@ set(MBGL_CORE_FILES
     src/mbgl/util/tile_coordinate.hpp
     src/mbgl/util/tile_cover.cpp
     src/mbgl/util/tile_cover.hpp
+    src/mbgl/util/tiny_sdf.cpp
+    src/mbgl/util/tiny_sdf.hpp
     src/mbgl/util/token.hpp
     src/mbgl/util/url.cpp
     src/mbgl/util/url.hpp

--- a/include/mbgl/renderer/renderer.hpp
+++ b/include/mbgl/renderer/renderer.hpp
@@ -25,7 +25,8 @@ class Renderer {
 public:
     Renderer(RendererBackend&, float pixelRatio_, FileSource&, Scheduler&,
              GLContextMode = GLContextMode::Unique,
-             const optional<std::string> programCacheDir = {});
+             const optional<std::string> programCacheDir = {},
+             const optional<std::string> localFontFamily = {});
     ~Renderer();
 
     void markContextLost();

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -293,7 +293,7 @@ public class MapView extends FrameLayout {
   private void initialiseDrawingSurface(MapboxMapOptions options) {
     if (options.getTextureMode()) {
       TextureView textureView = new TextureView(getContext());
-      mapRenderer = new TextureViewMapRenderer(getContext(), textureView) {
+      mapRenderer = new TextureViewMapRenderer(getContext(), textureView, options.getLocalIdeographFontFamily()) {
         @Override
         protected void onSurfaceCreated(GL10 gl, EGLConfig config) {
           MapView.this.post(new Runnable() {
@@ -315,7 +315,7 @@ public class MapView extends FrameLayout {
       GLSurfaceView glSurfaceView = (GLSurfaceView) findViewById(R.id.surfaceView);
       glSurfaceView.setZOrderMediaOverlay(mapboxMapOptions.getRenderSurfaceOnTop());
 
-      mapRenderer = new GLSurfaceViewMapRenderer(getContext(), glSurfaceView) {
+      mapRenderer = new GLSurfaceViewMapRenderer(getContext(), glSurfaceView, options.getLocalIdeographFontFamily()) {
         @Override
         public void onSurfaceCreated(GL10 gl, EGLConfig config) {
           MapView.this.post(new Runnable() {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
@@ -82,6 +82,7 @@ public class MapboxMapOptions implements Parcelable {
   private float myLocationAccuracyThreshold;
   private boolean prefetchesTiles = true;
   private boolean zMediaOverlay = false;
+  private String localIdeographFontFamily;
 
   private String apiBaseUrl;
 
@@ -157,6 +158,7 @@ public class MapboxMapOptions implements Parcelable {
     textureMode = in.readByte() != 0;
     prefetchesTiles = in.readByte() != 0;
     zMediaOverlay = in.readByte() != 0;
+    localIdeographFontFamily = in.readString();
   }
 
   static Bitmap getBitmapFromDrawable(Drawable drawable) {
@@ -304,6 +306,8 @@ public class MapboxMapOptions implements Parcelable {
         typedArray.getBoolean(R.styleable.mapbox_MapView_mapbox_enableTilePrefetch, true));
       mapboxMapOptions.renderSurfaceOnTop(
         typedArray.getBoolean(R.styleable.mapbox_MapView_mapbox_enableZMediaOverlay, false));
+      mapboxMapOptions.localIdeographFontFamily(
+        typedArray.getString(R.styleable.mapbox_MapView_mapbox_localIdeographFontFamily));
     } finally {
       typedArray.recycle();
     }
@@ -734,6 +738,18 @@ public class MapboxMapOptions implements Parcelable {
   }
 
   /**
+   * Set the font-family for generating glyphs locally for ideographs in the ‘CJK Unified Ideographs’
+   * and ‘Hangul Syllables’ ranges.
+   *
+   * @param fontFamily font family for local ideograph generation.
+   * @return This
+   */
+  public MapboxMapOptions localIdeographFontFamily(String fontFamily) {
+    this.localIdeographFontFamily = fontFamily;
+    return this;
+  }
+
+  /**
    * Check whether tile pre-fetching is enabled.
    *
    * @return true if enabled
@@ -1079,6 +1095,16 @@ public class MapboxMapOptions implements Parcelable {
     return textureMode;
   }
 
+  /**
+   * Returns the font-family for locally overriding generation of glyphs in the
+   * ‘CJK Unified Ideographs’ and ‘Hangul Syllables’ ranges.
+   *
+   * @return Local ideograph font family name.
+   */
+  public String getLocalIdeographFontFamily() {
+    return localIdeographFontFamily;
+  }
+
   public static final Parcelable.Creator<MapboxMapOptions> CREATOR = new Parcelable.Creator<MapboxMapOptions>() {
     public MapboxMapOptions createFromParcel(Parcel in) {
       return new MapboxMapOptions(in);
@@ -1145,6 +1171,7 @@ public class MapboxMapOptions implements Parcelable {
     dest.writeByte((byte) (textureMode ? 1 : 0));
     dest.writeByte((byte) (prefetchesTiles ? 1 : 0));
     dest.writeByte((byte) (zMediaOverlay ? 1 : 0));
+    dest.writeString(localIdeographFontFamily);
   }
 
   @Override
@@ -1274,6 +1301,9 @@ public class MapboxMapOptions implements Parcelable {
     if (zMediaOverlay != options.zMediaOverlay) {
       return false;
     }
+    if (localIdeographFontFamily != options.localIdeographFontFamily) {
+      return false;
+    }
 
     return false;
   }
@@ -1323,6 +1353,7 @@ public class MapboxMapOptions implements Parcelable {
     result = 31 * result + (style != null ? style.hashCode() : 0);
     result = 31 * result + (prefetchesTiles ? 1 : 0);
     result = 31 * result + (zMediaOverlay ? 1 : 0);
+    result = 31 * result + (localIdeographFontFamily != null ? localIdeographFontFamily.hashCode() : 0);
     return result;
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
@@ -23,14 +23,13 @@ public abstract class MapRenderer implements MapRendererScheduler {
 
   private MapboxMap.OnFpsChangedListener onFpsChangedListener;
 
-  public MapRenderer(Context context) {
+  public MapRenderer(Context context, String localIdeographFontFamily) {
 
     FileSource fileSource = FileSource.getInstance(context);
     float pixelRatio = context.getResources().getDisplayMetrics().density;
     String programCacheDir = context.getCacheDir().getAbsolutePath();
-
     // Initialise native peer
-    nativeInitialize(this, fileSource, pixelRatio, programCacheDir);
+    nativeInitialize(this, fileSource, pixelRatio, programCacheDir, localIdeographFontFamily);
   }
 
   public void onStart() {
@@ -112,7 +111,8 @@ public abstract class MapRenderer implements MapRendererScheduler {
   private native void nativeInitialize(MapRenderer self,
                                        FileSource fileSource,
                                        float pixelRatio,
-                                       String programCacheDir);
+                                       String programCacheDir,
+                                       String localIdeographFontFamily);
 
   @CallSuper
   @Override

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
@@ -21,8 +21,8 @@ public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceVi
 
   private final GLSurfaceView glSurfaceView;
 
-  public GLSurfaceViewMapRenderer(Context context, GLSurfaceView glSurfaceView) {
-    super(context);
+  public GLSurfaceViewMapRenderer(Context context, GLSurfaceView glSurfaceView, String localIdeographFontFamily) {
+    super(context, localIdeographFontFamily);
     this.glSurfaceView = glSurfaceView;
     glSurfaceView.setEGLContextClientVersion(2);
     glSurfaceView.setEGLConfigChooser(new EGLConfigChooser());

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewMapRenderer.java
@@ -24,8 +24,10 @@ public class TextureViewMapRenderer extends MapRenderer {
    * @param context     the current Context
    * @param textureView the TextureView
    */
-  public TextureViewMapRenderer(@NonNull Context context, @NonNull TextureView textureView) {
-    super(context);
+  public TextureViewMapRenderer(@NonNull Context context,
+                                @NonNull TextureView textureView,
+                                String localIdeographFontFamily) {
+    super(context, localIdeographFontFamily);
     renderThread = new TextureViewRenderThread(textureView, this);
     renderThread.start();
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/text/LocalGlyphRasterizer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/text/LocalGlyphRasterizer.java
@@ -1,0 +1,46 @@
+package com.mapbox.mapboxsdk.text;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Bitmap;
+import android.graphics.Typeface;
+import android.support.annotation.WorkerThread;
+
+/**
+ * LocalGlyphRasterizer is the Android-specific platform implementation used
+ * by the portable local_glyph_rasterizer.hpp
+ */
+public class LocalGlyphRasterizer {
+
+  /***
+   * Uses Android-native drawing code to rasterize a single glyph
+   * to a square @{link Bitmap} which can be returned to portable
+   * code for transformation into a Signed Distance Field glyph.
+   *
+   * @param fontFamily Font family string to pass to Typeface.create
+   * @param bold If true, use Typeface.BOLD option
+   * @param glyphID 16-bit Unicode BMP codepoint to draw
+   *
+   * @return Return a @{link Bitmap} to be displayed in the requested tile.
+   */
+  @WorkerThread
+  protected static Bitmap drawGlyphBitmap(String fontFamily, boolean bold, char glyphID) {
+    /*
+      35x35px dimensions are hardwired to match local_glyph_rasterizer.cpp
+      These dimensions are large enough to draw a 24 point character in the middle
+      of the bitmap (y: 20) with some buffer around the edge
+    */
+    Bitmap bitmap = Bitmap.createBitmap(35, 35, Bitmap.Config.ARGB_8888);
+
+    Paint paint = new Paint();
+    paint.setAntiAlias(true);
+    paint.setTextSize(24);
+    paint.setTypeface(Typeface.create(fontFamily, bold ? Typeface.BOLD : Typeface.NORMAL));
+
+    Canvas canvas = new Canvas();
+    canvas.setBitmap(bitmap);
+    canvas.drawText(String.valueOf(glyphID), 0, 20, paint);
+
+    return bitmap;
+  }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
@@ -11,6 +11,7 @@
     <!--Configuration-->
     <public name="mapbox_styleUrl" type="attr" />
     <public name="mapbox_apiBaseUrl" type="attr" />
+    <public name="mapbox_localIdeographFontFamily" type="attr" />
 
     <!--Camera-->
     <public name="mapbox_cameraTargetLng" type="attr" />

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/attrs.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/attrs.xml
@@ -5,6 +5,7 @@
         <!--Configuration-->
         <attr name="mapbox_styleUrl" format="string"/>
         <attr name="mapbox_apiBaseUrl" format="string"/>
+        <attr name="mapbox_localIdeographFontFamily" format="string"/>
 
         <!--Camera-->
         <attr name="mapbox_cameraTargetLat" format="float"/>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -367,9 +367,10 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activity.FeatureOverviewActivity"/>
         </activity>
-        <activity android:name=".activity.snapshot.MapSnapshotterActivity"
-                  android:description="@string/description_map_snapshotter"
-                  android:label="@string/activity_map_snapshotter">
+        <activity
+            android:name=".activity.snapshot.MapSnapshotterActivity"
+            android:description="@string/description_map_snapshotter"
+            android:label="@string/activity_map_snapshotter">
             <meta-data
                 android:name="@string/category"
                 android:value="@string/category_imagegenerator"/>
@@ -377,9 +378,10 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activity.FeatureOverviewActivity"/>
         </activity>
-        <activity android:name=".activity.snapshot.MapSnapshotterReuseActivity"
-                  android:description="@string/description_map_snapshotter_reuse"
-                  android:label="@string/activity_map_snapshotter_reuse">
+        <activity
+            android:name=".activity.snapshot.MapSnapshotterReuseActivity"
+            android:description="@string/description_map_snapshotter_reuse"
+            android:label="@string/activity_map_snapshotter_reuse">
             <meta-data
                 android:name="@string/category"
                 android:value="@string/category_imagegenerator"/>
@@ -387,9 +389,10 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activity.FeatureOverviewActivity"/>
         </activity>
-        <activity android:name=".activity.snapshot.MapSnapshotterMarkerActivity"
-                  android:description="@string/description_map_snapshotter_marker"
-                  android:label="@string/activity_map_snapshotter_marker">
+        <activity
+            android:name=".activity.snapshot.MapSnapshotterMarkerActivity"
+            android:description="@string/description_map_snapshotter_marker"
+            android:label="@string/activity_map_snapshotter_marker">
             <meta-data
                 android:name="@string/category"
                 android:value="@string/category_imagegenerator"/>
@@ -586,8 +589,8 @@
         </activity>
         <activity
             android:name=".activity.style.AnimatedImageSourceActivity"
-            android:label="@string/activity_animated_image_source"
-            android:description="@string/description_animated_image_source">
+            android:description="@string/description_animated_image_source"
+            android:label="@string/activity_animated_image_source">
             <meta-data
                 android:name="@string/category"
                 android:value="@string/category_style"/>
@@ -720,35 +723,50 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activity.FeatureOverviewActivity"/>
         </activity>
-        <activity android:name=".activity.maplayout.BottomSheetActivity"
-                  android:description="@string/description_bottom_sheet"
-                  android:label="@string/activity_bottom_sheet">
+        <activity
+            android:name=".activity.maplayout.BottomSheetActivity"
+            android:description="@string/description_bottom_sheet"
+            android:label="@string/activity_bottom_sheet">
             <meta-data
                 android:name="@string/category"
                 android:value="@string/category_maplayout"/>
         </activity>
 
         <!-- TextureView -->
-        <activity android:name=".activity.textureview.TextureViewDebugModeActivity"
-                  android:description="@string/description_textureview_debug"
-                  android:label="@string/activity_textureview_debug">
+        <activity
+            android:name=".activity.textureview.TextureViewDebugModeActivity"
+            android:description="@string/description_textureview_debug"
+            android:label="@string/activity_textureview_debug">
             <meta-data
                 android:name="@string/category"
                 android:value="@string/category_textureview"/>
         </activity>
-        <activity android:name=".activity.textureview.TextureViewResizeActivity"
-                  android:description="@string/description_textureview_resize"
-                  android:label="@string/activity_textureview_resize">
+        <activity
+            android:name=".activity.textureview.TextureViewResizeActivity"
+            android:description="@string/description_textureview_resize"
+            android:label="@string/activity_textureview_resize">
             <meta-data
                 android:name="@string/category"
                 android:value="@string/category_textureview"/>
         </activity>
-        <activity android:name=".activity.textureview.TextureViewAnimationActivity"
-                  android:description="@string/description_textureview_animate"
-                  android:label="@string/activity_textureview_animate">
+        <activity
+            android:name=".activity.textureview.TextureViewAnimationActivity"
+            android:description="@string/description_textureview_animate"
+            android:label="@string/activity_textureview_animate">
             <meta-data
                 android:name="@string/category"
                 android:value="@string/category_textureview"/>
+        </activity>
+        <activity
+            android:name=".activity.maplayout.LocalGlyphActivity"
+            android:description="@string/description_local_glyph"
+            android:label="@string/activity_local_glyph">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_maplayout"/>
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".activity.FeatureOverviewActivity"/>
         </activity>
 
         <!-- For Instrumentation tests -->

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/LocalGlyphActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/LocalGlyphActivity.java
@@ -1,0 +1,81 @@
+package com.mapbox.mapboxsdk.testapp.activity.maplayout;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+
+import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.testapp.R;
+
+public class LocalGlyphActivity extends AppCompatActivity {
+  private MapView mapView;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_local_glyph);
+
+    mapView = (MapView) findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+      public void onMapReady(@NonNull MapboxMap mapboxMap) {
+        // Set initial position to Suzhou
+        mapboxMap.moveCamera(CameraUpdateFactory.newCameraPosition(
+          new CameraPosition.Builder()
+            .target(new LatLng(31.3003, 120.7457))
+            .zoom(11)
+            .bearing(0)
+            .tilt(0)
+            .build()));
+      }
+    });
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_local_glyph.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_local_glyph.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".activity.maplayout.LocalGlyphActivity">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:mapbox_localIdeographFontFamily="Droid Sans" />
+
+</LinearLayout>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
@@ -67,4 +67,5 @@
     <string name="description_textureview_debug">Use TextureView to render the map</string>
     <string name="description_textureview_resize">Resize a map rendered on a TextureView</string>
     <string name="description_textureview_animate">Animate a map rendered on a TextureView</string>
+    <string name="description_local_glyph">Suzhou using Droid Sans for Chinese glyphs</string>
 </resources>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
@@ -67,4 +67,6 @@
     <string name="activity_textureview_debug">TextureView debug</string>
     <string name="activity_textureview_resize">TextureView resize</string>
     <string name="activity_textureview_animate">TextureView animation</string>
+    <string name="activity_grid_source">Grid Source</string>
+    <string name="activity_local_glyph">Local CJK glyph generation</string>
 </resources>

--- a/platform/android/config.cmake
+++ b/platform/android/config.cmake
@@ -36,6 +36,7 @@ macro(mbgl_platform_core)
         PRIVATE platform/android/src/thread.cpp
         PRIVATE platform/default/string_stdlib.cpp
         PRIVATE platform/default/bidi.cpp
+        PRIVATE platform/default/local_glyph_rasterizer.cpp
         PRIVATE platform/default/thread_local.cpp
         PRIVATE platform/default/utf.cpp
 

--- a/platform/android/config.cmake
+++ b/platform/android/config.cmake
@@ -32,11 +32,12 @@ macro(mbgl_platform_core)
         PRIVATE platform/android/src/timer.cpp
 
         # Misc
+        PRIVATE platform/android/src/text/local_glyph_rasterizer_jni.hpp
+        PRIVATE platform/android/src/text/local_glyph_rasterizer.cpp
         PRIVATE platform/android/src/logging_android.cpp
         PRIVATE platform/android/src/thread.cpp
         PRIVATE platform/default/string_stdlib.cpp
         PRIVATE platform/default/bidi.cpp
-        PRIVATE platform/default/local_glyph_rasterizer.cpp
         PRIVATE platform/default/thread_local.cpp
         PRIVATE platform/default/utf.cpp
 

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -51,6 +51,7 @@
 #include "style/light.hpp"
 #include "snapshotter/map_snapshotter.hpp"
 #include "snapshotter/map_snapshot.hpp"
+#include "text/local_glyph_rasterizer_jni.hpp"
 
 namespace mbgl {
 namespace android {
@@ -188,6 +189,9 @@ void registerNatives(JavaVM *vm) {
     // Snapshotter
     MapSnapshotter::registerNative(env);
     MapSnapshot::registerNative(env);
+
+    // text
+    LocalGlyphRasterizer::registerNative(env);
 }
 
 } // namespace android

--- a/platform/android/src/map_renderer.hpp
+++ b/platform/android/src/map_renderer.hpp
@@ -48,7 +48,8 @@ public:
                 jni::Object<MapRenderer>,
                 jni::Object<FileSource>,
                 jni::jfloat pixelRatio,
-                jni::String programCacheDir);
+                jni::String programCacheDir,
+                jni::String localIdeographFontFamily);
 
     ~MapRenderer() override;
 
@@ -103,6 +104,7 @@ private:
     float pixelRatio;
     DefaultFileSource& fileSource;
     std::string programCacheDir;
+    optional<std::string> localIdeographFontFamily;
 
     std::shared_ptr<ThreadPool> threadPool;
     std::shared_ptr<Mailbox> mailbox;

--- a/platform/android/src/text/local_glyph_rasterizer.cpp
+++ b/platform/android/src/text/local_glyph_rasterizer.cpp
@@ -1,0 +1,126 @@
+#include <mbgl/text/local_glyph_rasterizer.hpp>
+#include <mbgl/util/i18n.hpp>
+#include <mbgl/util/platform.hpp>
+
+#include <jni/jni.hpp>
+
+#include "../attach_env.hpp"
+#include "../bitmap.hpp"
+
+#include "local_glyph_rasterizer_jni.hpp"
+
+/*
+    Android implementation of LocalGlyphRasterizer:
+     Draws CJK glyphs using locally available fonts.
+
+    Follows pattern of GL JS implementation in that:
+     - Only CJK glyphs are drawn locally (because we can guess their metrics effectively)
+        * Render size/metrics determined experimentally using Noto Sans
+     - Configuration is done at map creation time by setting a "font family"
+        * JS uses a CSS font-family, this uses android.graphics.Typeface
+          https://developer.android.com/reference/android/graphics/Typeface.html
+     - We use heuristics to extract a font-weight based on the incoming font stack
+        * JS tries to extract multiple weights, this implementation only looks for
+          "bold"
+
+     mbgl::LocalGlyphRasterizer is the portable interface
+     mbgl::LocalGlyphRasterizer::Impl stores platform-specific configuration data
+     mbgl::android::LocalGlyphRasterizer is the JNI wrapper
+     com.mapbox.mapboxsdk.text.LocalGlyphRasterizer is the Java implementation that
+      actually does the drawing
+ */
+
+namespace mbgl {
+namespace android {
+
+PremultipliedImage LocalGlyphRasterizer::drawGlyphBitmap(const std::string& fontFamily, const bool bold, const GlyphID glyphID) {
+    UniqueEnv env { AttachEnv() };
+
+    using Signature = jni::Object<Bitmap>(jni::String, jni::jboolean, jni::jchar);
+    auto method = javaClass.GetStaticMethod<Signature>(*env, "drawGlyphBitmap");
+
+    jni::String jniFontFamily = jni::Make<jni::String>(*env, fontFamily);
+
+    auto javaBitmap = javaClass.Call(*env,
+                                     method,
+                                     jniFontFamily,
+                                     static_cast<jni::jboolean>(bold),
+                                     static_cast<jni::jchar>(glyphID));
+
+    PremultipliedImage result = Bitmap::GetImage(*env, javaBitmap);
+    jni::DeleteLocalRef(*env, javaBitmap);
+    return result;
+}
+
+void LocalGlyphRasterizer::registerNative(jni::JNIEnv& env) {
+    javaClass = *jni::Class<LocalGlyphRasterizer>::Find(env).NewGlobalRef(env).release();
+}
+
+jni::Class<LocalGlyphRasterizer> LocalGlyphRasterizer::javaClass;
+
+} // namespace android
+
+class LocalGlyphRasterizer::Impl {
+public:
+    Impl(const optional<std::string> fontFamily_)
+        : fontFamily(fontFamily_)
+    {}
+
+    bool isConfigured() const {
+        return bool(fontFamily);
+    }
+
+    PremultipliedImage drawGlyphBitmap(const FontStack& fontStack, GlyphID glyphID) {
+        bool bold = false;
+        for (auto font : fontStack) {
+            std::string lowercaseFont = platform::lowercase(font);
+            if (lowercaseFont.find("bold") != std::string::npos) {
+                bold = true;
+            }
+        }
+        return android::LocalGlyphRasterizer::drawGlyphBitmap(*fontFamily, bold, glyphID);
+    }
+
+private:
+    optional<std::string> fontFamily;
+};
+
+LocalGlyphRasterizer::LocalGlyphRasterizer(const optional<std::string> fontFamily)
+    : impl(std::make_unique<Impl>(fontFamily))
+{}
+
+LocalGlyphRasterizer::~LocalGlyphRasterizer()
+{}
+
+bool LocalGlyphRasterizer::canRasterizeGlyph(const FontStack&, GlyphID glyphID) {
+     return util::i18n::allowsFixedWidthGlyphGeneration(glyphID) && impl->isConfigured();
+}
+
+Glyph LocalGlyphRasterizer::rasterizeGlyph(const FontStack& fontStack, GlyphID glyphID) {
+    Glyph fixedMetrics;
+    if (!impl->isConfigured()) {
+        return fixedMetrics;
+    }
+
+    fixedMetrics.id = glyphID;
+
+    Size size(35, 35);
+
+    fixedMetrics.metrics.width = size.width;
+    fixedMetrics.metrics.height = size.height;
+    fixedMetrics.metrics.left = 3;
+    fixedMetrics.metrics.top = -10;
+    fixedMetrics.metrics.advance = 24;
+
+    PremultipliedImage rgbaBitmap = impl->drawGlyphBitmap(fontStack, glyphID);
+
+    // Copy alpha values from RGBA bitmap into the AlphaImage output
+    fixedMetrics.bitmap = AlphaImage(size);
+    for (uint32_t i = 0; i < size.width * size.height; i++) {
+        fixedMetrics.bitmap.data[i] = rgbaBitmap.data[4 * i + 3];
+    }
+
+    return fixedMetrics;
+}
+
+} // namespace mbgl

--- a/platform/android/src/text/local_glyph_rasterizer_jni.hpp
+++ b/platform/android/src/text/local_glyph_rasterizer_jni.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <mbgl/util/image.hpp>
+
+#include <jni/jni.hpp>
+
+/*
+    android::LocalGlyphRasterizer is the JNI wrapper of
+    com/mapbox/mapboxsdk/text/LocalGlyphRasterizer
+
+    mbgl::LocalGlyphRasterizer is the portable interface
+    Both implementations are in local_glyph_rasterizer.cpp
+ */
+
+namespace mbgl {
+namespace android {
+
+class LocalGlyphRasterizer {
+public:
+    static PremultipliedImage drawGlyphBitmap(const std::string& fontFamily, const bool bold, const char16_t glyphID);
+
+    static constexpr auto Name() { return "com/mapbox/mapboxsdk/text/LocalGlyphRasterizer"; };
+
+    static jni::Class<LocalGlyphRasterizer> javaClass;
+
+    static void registerNative(jni::JNIEnv&);
+
+};
+
+} // namespace android
+} // namespace mbgl

--- a/platform/default/local_glyph_rasterizer.cpp
+++ b/platform/default/local_glyph_rasterizer.cpp
@@ -1,0 +1,13 @@
+#include <mbgl/text/local_glyph_rasterizer.hpp>
+
+namespace mbgl {
+
+bool LocalGlyphRasterizer::canRasterizeGlyph(const FontStack&, GlyphID) {
+    return false;
+}
+
+Glyph LocalGlyphRasterizer::rasterizeGlyph(const FontStack&, GlyphID) {
+    return Glyph();
+}
+
+} // namespace mbgl

--- a/platform/default/local_glyph_rasterizer.cpp
+++ b/platform/default/local_glyph_rasterizer.cpp
@@ -2,6 +2,15 @@
 
 namespace mbgl {
 
+class LocalGlyphRasterizer::Impl {
+};
+
+LocalGlyphRasterizer::LocalGlyphRasterizer(const optional<std::string>)
+{}
+
+LocalGlyphRasterizer::~LocalGlyphRasterizer()
+{}
+
 bool LocalGlyphRasterizer::canRasterizeGlyph(const FontStack&, GlyphID) {
     return false;
 }

--- a/platform/ios/config.cmake
+++ b/platform/ios/config.cmake
@@ -32,6 +32,7 @@ macro(mbgl_platform_core)
         PRIVATE platform/darwin/src/nsthread.mm
         PRIVATE platform/darwin/src/string_nsstring.mm
         PRIVATE platform/default/bidi.cpp
+        PRIVATE platform/default/local_glyph_rasterizer.cpp
         PRIVATE platform/default/thread_local.cpp
         PRIVATE platform/default/utf.cpp
 

--- a/platform/linux/config.cmake
+++ b/platform/linux/config.cmake
@@ -51,6 +51,7 @@ macro(mbgl_platform_core)
         PRIVATE platform/default/string_stdlib.cpp
         PRIVATE platform/default/thread.cpp
         PRIVATE platform/default/bidi.cpp
+        PRIVATE platform/default/local_glyph_rasterizer.cpp
         PRIVATE platform/default/thread_local.cpp
         PRIVATE platform/default/utf.cpp
 

--- a/platform/macos/config.cmake
+++ b/platform/macos/config.cmake
@@ -18,6 +18,7 @@ macro(mbgl_platform_core)
         PRIVATE platform/darwin/src/nsthread.mm
         PRIVATE platform/darwin/src/string_nsstring.mm
         PRIVATE platform/default/bidi.cpp
+        PRIVATE platform/default/local_glyph_rasterizer.cpp
         PRIVATE platform/default/thread_local.cpp
         PRIVATE platform/default/utf.cpp
 

--- a/platform/qt/config.cmake
+++ b/platform/qt/config.cmake
@@ -48,6 +48,8 @@ macro(mbgl_platform_core)
         target_sources(mbgl-core PRIVATE platform/qt/src/bidi.cpp)
     endif()
 
+    target_sources(mbgl-core PRIVATE platform/default/local_glyph_rasterizer.cpp)
+
 endmacro()
 
 

--- a/src/mbgl/renderer/renderer.cpp
+++ b/src/mbgl/renderer/renderer.cpp
@@ -10,9 +10,10 @@ Renderer::Renderer(RendererBackend& backend,
                    FileSource& fileSource_,
                    Scheduler& scheduler_,
                    GLContextMode contextMode_,
-                   const optional<std::string> programCacheDir_)
+                   const optional<std::string> programCacheDir_,
+                   const optional<std::string> localFontFamily_)
         : impl(std::make_unique<Impl>(backend, pixelRatio_, fileSource_, scheduler_,
-                                      contextMode_, std::move(programCacheDir_))) {
+                                      contextMode_, std::move(programCacheDir_), std::move(localFontFamily_))) {
 }
 
 Renderer::~Renderer() {

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -42,7 +42,8 @@ Renderer::Impl::Impl(RendererBackend& backend_,
                      FileSource& fileSource_,
                      Scheduler& scheduler_,
                      GLContextMode contextMode_,
-                     const optional<std::string> programCacheDir_)
+                     const optional<std::string> programCacheDir_,
+                     const optional<std::string> localFontFamily_)
     : backend(backend_)
     , scheduler(scheduler_)
     , fileSource(fileSource_)
@@ -50,7 +51,7 @@ Renderer::Impl::Impl(RendererBackend& backend_,
     , contextMode(contextMode_)
     , pixelRatio(pixelRatio_)
     , programCacheDir(programCacheDir_)
-    , glyphManager(std::make_unique<GlyphManager>(fileSource))
+    , glyphManager(std::make_unique<GlyphManager>(fileSource, std::make_unique<LocalGlyphRasterizer>(localFontFamily_)))
     , imageManager(std::make_unique<ImageManager>())
     , lineAtlas(std::make_unique<LineAtlas>(Size{ 256, 512 }))
     , imageImpls(makeMutable<std::vector<Immutable<style::Image::Impl>>>())

--- a/src/mbgl/renderer/renderer_impl.hpp
+++ b/src/mbgl/renderer/renderer_impl.hpp
@@ -36,7 +36,7 @@ class Renderer::Impl : public GlyphManagerObserver,
                        public RenderSourceObserver{
 public:
     Impl(RendererBackend&, float pixelRatio_, FileSource&, Scheduler&, GLContextMode,
-         const optional<std::string> programCacheDir);
+         const optional<std::string> programCacheDir, const optional<std::string> localFontFamily);
     ~Impl() final;
 
     void markContextLost() {

--- a/src/mbgl/text/glyph_manager.hpp
+++ b/src/mbgl/text/glyph_manager.hpp
@@ -3,6 +3,7 @@
 #include <mbgl/text/glyph.hpp>
 #include <mbgl/text/glyph_manager_observer.hpp>
 #include <mbgl/text/glyph_range.hpp>
+#include <mbgl/text/local_glyph_rasterizer.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/font_stack.hpp>
 #include <mbgl/util/immutable.hpp>
@@ -24,7 +25,7 @@ public:
 
 class GlyphManager : public util::noncopyable {
 public:
-    GlyphManager(FileSource&);
+    GlyphManager(FileSource&, std::unique_ptr<LocalGlyphRasterizer> = std::make_unique<LocalGlyphRasterizer>());
     ~GlyphManager();
 
     // Workers send a `getGlyphs` message to the main thread once they have determined
@@ -42,6 +43,8 @@ public:
     void setObserver(GlyphManagerObserver*);
 
 private:
+    Glyph generateLocalSDF(const FontStack& fontStack, GlyphID glyphID);
+
     FileSource& fileSource;
     std::string glyphURL;
 
@@ -61,8 +64,10 @@ private:
     GlyphRequest& requestRange(Entry&, const FontStack&, const GlyphRange&);
     void processResponse(const Response&, const FontStack&, const GlyphRange&);
     void notify(GlyphRequestor&, const GlyphDependencies&);
-
+    
     GlyphManagerObserver* observer = nullptr;
+    
+    std::unique_ptr<LocalGlyphRasterizer> localGlyphRasterizer;
 };
 
 } // namespace mbgl

--- a/src/mbgl/text/glyph_manager.hpp
+++ b/src/mbgl/text/glyph_manager.hpp
@@ -25,7 +25,7 @@ public:
 
 class GlyphManager : public util::noncopyable {
 public:
-    GlyphManager(FileSource&, std::unique_ptr<LocalGlyphRasterizer> = std::make_unique<LocalGlyphRasterizer>());
+    GlyphManager(FileSource&, std::unique_ptr<LocalGlyphRasterizer> = std::make_unique<LocalGlyphRasterizer>(optional<std::string>()));
     ~GlyphManager();
 
     // Workers send a `getGlyphs` message to the main thread once they have determined

--- a/src/mbgl/text/local_glyph_rasterizer.hpp
+++ b/src/mbgl/text/local_glyph_rasterizer.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <mbgl/text/glyph.hpp>
+
+namespace mbgl {
+
+/*
+    Given a font stack and a glyph ID, platform-specific implementations of
+    LocalGlyphRasterizer will decide which, if any, local fonts to use and
+    then generate a matching glyph object with a greyscale rasterization of
+    the glyph and appropriate metrics. GlyphManager will then use TinySDF to
+    transform the rasterized bitmap into an SDF.
+ 
+    The JS equivalent of this functionality will only generate glyphs in the
+    'CJK Unified Ideographs' and 'Hangul Syllables' ranges, for which it can
+    get away with rendering a fixed 30px square image and GlyphMetrics of:
+
+        width: 24,
+        height: 24,
+        left: 0,
+        top: -8,
+        advance: 24
+
+    The JS equivalent also uses heuristic evaluation of the font stack name
+    to control the font-weight it uses during rasterization.
+ 
+    It is left to platform-specific implementation to decide how best to
+    map a FontStack to a particular rasterization.
+ 
+    The default implementation simply refuses to rasterize any glyphs.
+*/
+
+class LocalGlyphRasterizer {
+public:
+    virtual ~LocalGlyphRasterizer() = default;
+
+    // virtual so that test harness can override platform-specific behavior
+    virtual bool canRasterizeGlyph(const FontStack&, GlyphID);
+    virtual Glyph rasterizeGlyph(const FontStack&, GlyphID);
+};
+
+} // namespace mbgl

--- a/src/mbgl/text/local_glyph_rasterizer.hpp
+++ b/src/mbgl/text/local_glyph_rasterizer.hpp
@@ -32,11 +32,15 @@ namespace mbgl {
 
 class LocalGlyphRasterizer {
 public:
-    virtual ~LocalGlyphRasterizer() = default;
+    virtual ~LocalGlyphRasterizer();
+    LocalGlyphRasterizer(const optional<std::string> fontFamily = optional<std::string>());
 
     // virtual so that test harness can override platform-specific behavior
     virtual bool canRasterizeGlyph(const FontStack&, GlyphID);
     virtual Glyph rasterizeGlyph(const FontStack&, GlyphID);
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl;
 };
 
 } // namespace mbgl

--- a/src/mbgl/util/i18n.cpp
+++ b/src/mbgl/util/i18n.cpp
@@ -392,6 +392,11 @@ bool allowsIdeographicBreaking(char16_t chr) {
     //        || isInCJKCompatibilityIdeographsSupplement(chr));
 }
 
+bool allowsFixedWidthGlyphGeneration(char16_t chr) {
+    // Mirrors conservative set of characters used in glyph_manager.js/_tinySDF
+    return isInCJKUnifiedIdeographs(chr) || isInHangulSyllables(chr);
+}
+
 bool allowsVerticalWritingMode(const std::u16string& string) {
     for (char32_t chr : string) {
         if (hasUprightVerticalOrientation(chr)) {

--- a/src/mbgl/util/i18n.hpp
+++ b/src/mbgl/util/i18n.hpp
@@ -23,6 +23,10 @@ bool allowsIdeographicBreaking(const std::u16string& string);
     by the given Unicode codepoint due to ideographic breaking. */
 bool allowsIdeographicBreaking(char16_t chr);
 
+/** Conservative set of characters expected to have relatively fixed sizes and
+    advances */
+bool allowsFixedWidthGlyphGeneration(char16_t chr);
+
 /** Returns whether any substring of the given string can be drawn as vertical
     text with upright glyphs. */
 bool allowsVerticalWritingMode(const std::u16string& string);

--- a/src/mbgl/util/tiny_sdf.cpp
+++ b/src/mbgl/util/tiny_sdf.cpp
@@ -1,0 +1,105 @@
+#include <mbgl/util/tiny_sdf.hpp>
+
+#include <mbgl/util/math.hpp>
+
+#include <algorithm>
+
+namespace mbgl {
+namespace util {
+
+namespace tinysdf {
+
+static const double INF = 1e20;
+
+// 1D squared distance transform
+void edt1d(std::vector<double>& f,
+           std::vector<double>& d,
+           std::vector<int16_t>& v,
+           std::vector<double>& z,
+           uint32_t n) {
+    v[0] = 0;
+    z[0] = -INF;
+    z[1] = +INF;
+
+    for (uint32_t q = 1, k = 0; q < n; q++) {
+        double s = ((f[q] + q * q) - (f[v[k]] + v[k] * v[k])) / (2 * q - 2 * v[k]);
+        while (s <= z[k]) {
+            k--;
+            s = ((f[q] + q * q) - (f[v[k]] + v[k] * v[k])) / (2 * q - 2 * v[k]);
+        }
+        k++;
+        v[k] = q;
+        z[k] = s;
+        z[k + 1] = +INF;
+    }
+
+    for (uint32_t q = 0, k = 0; q < n; q++) {
+        while (z[k + 1] < q) k++;
+        d[q] = (q - v[k]) * (q - v[k]) + f[v[k]];
+    }
+}
+
+
+// 2D Euclidean distance transform by Felzenszwalb & Huttenlocher https://cs.brown.edu/~pff/dt/
+void edt(std::vector<double>& data,
+         uint32_t width,
+         uint32_t height,
+         std::vector<double>& f,
+         std::vector<double>& d,
+         std::vector<int16_t>& v,
+         std::vector<double>& z) {
+    for (uint32_t x = 0; x < width; x++) {
+        for (uint32_t y = 0; y < height; y++) {
+            f[y] = data[y * width + x];
+        }
+        edt1d(f, d, v, z, height);
+        for (uint32_t y = 0; y < height; y++) {
+            data[y * width + x] = d[y];
+        }
+    }
+    for (uint32_t y = 0; y < height; y++) {
+        for (uint32_t x = 0; x < width; x++) {
+            f[x] = data[y * width + x];
+        }
+        edt1d(f, d, v, z, width);
+        for (uint32_t x = 0; x < width; x++) {
+            data[y * width + x] = std::sqrt(d[x]);
+        }
+    }
+}
+
+} // namespace tinysdf
+
+AlphaImage transformRasterToSDF(const AlphaImage& rasterInput, double radius, double cutoff) {
+    uint32_t size = rasterInput.size.width * rasterInput.size.height;
+    uint32_t maxDimension = std::max(rasterInput.size.width, rasterInput.size.height);
+    
+    AlphaImage sdf(rasterInput.size);
+    
+    // temporary arrays for the distance transform
+    std::vector<double> gridOuter(size);
+    std::vector<double> gridInner(size);
+    std::vector<double> f(maxDimension);
+    std::vector<double> d(maxDimension);
+    std::vector<double> z(maxDimension + 1);
+    std::vector<int16_t> v(maxDimension);
+    
+    for (uint32_t i = 0; i < size; i++) {
+        double a = double(rasterInput.data[i]) / 255; // alpha value
+        gridOuter[i] = a == 1.0 ? 0.0 : a == 0.0 ? tinysdf::INF : std::pow(std::max(0.0, 0.5 - a), 2.0);
+        gridInner[i] = a == 1.0 ? tinysdf::INF : a == 0.0 ? 0.0 : std::pow(std::max(0.0, a - 0.5), 2.0);
+    }
+
+    tinysdf::edt(gridOuter, rasterInput.size.width, rasterInput.size.height, f, d, v, z);
+    tinysdf::edt(gridInner, rasterInput.size.width, rasterInput.size.height, f, d, v, z);
+
+    for (uint32_t i = 0; i < size; i++) {
+        double distance = gridOuter[i] - gridInner[i];
+        sdf.data[i] = std::max(0l, std::min(255l, std::lround(255.0 - 255.0 * (distance / radius + cutoff))));
+    }
+
+    return sdf;
+}
+
+} // namespace util
+} // namespace mbgl

--- a/src/mbgl/util/tiny_sdf.hpp
+++ b/src/mbgl/util/tiny_sdf.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <mbgl/util/image.hpp>
+
+namespace mbgl {
+namespace util {
+
+/*
+    C++ port of https://github.com/mapbox/tiny-sdf, which is in turn based on the
+    Felzenszwalb/Huttenlocher distance transform paper (https://cs.brown.edu/~pff/papers/dt-final.pdf).
+    Note there exists an alternative C++ implementation from the paper’s authors at
+    https://cs.brown.edu/~pff/dt/, which this implementation is not based on.
+ 
+    Takes an alpha channel raster input and transforms it into an alpha channel
+    Signed Distance Field (SDF) output of the same dimensions.
+*/
+AlphaImage transformRasterToSDF(const AlphaImage& rasterInput, double radius, double cutoff);
+
+} // namespace util
+} // namespace mbgl


### PR DESCRIPTION
This PR cherry picks core/android TinySDF functionality from `master`. It also contains the initial ios/macos implementation because that commit made significant changes to core, but does not include all the follow-up commits that actually enable the functionality on ios/macos. It includes the core test for TinySDF, but does not include the unit tests that actually do local glyph generation (they only ran on macOS).

I tested by building the test app and running the "Local CJK glyphs" test activity in a Pixel emulator.

In general I tried to keep the commits as minimally modified as possible, hoping that will reduce pain during the eventual merge back to master. If it helps, I can re-write the ios/macos commit to strip out the darwin-specific parts of the code.

/cc @zugaldia @chriswu42 @lilykaiser @Guardiola31337 @ivovandongen 