### PR TITLE
[ios, macos] Updates documentation to describe font fallback on iOS 8

### DIFF
--- a/platform/ios/app/Info.plist
+++ b/platform/ios/app/Info.plist
@@ -25,7 +25,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MGLIdeographicFontFamilyName</key>
-	<string>PingFang</string>
+	<string>PingFang TC</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2014–2017 Mapbox</string>
 	<key>NSLocationAlwaysUsageDescription</key>

--- a/platform/ios/docs/guides/Info.plist Keys.md
+++ b/platform/ios/docs/guides/Info.plist Keys.md
@@ -22,4 +22,4 @@ If you have implemented custom opt-out of Mapbox Telemetry within the user inter
 
 ## MGLIdeographicFontFamilyName
 
-The name of the font family to use for client-side text rendering of CJK ideographs. Set this to the name of a font family which will be available at run time, e.g. `PingFang`.
+The name of the font family to use for client-side text rendering of CJK ideographs. Set this to the name of a font family which will be available at run time, e.g. `PingFang TC` (iOS 9+), `Heiti TC` (iOS 8+), another appropriate built-in font, or a font provided by your application. Note that if a non-existent font is specified, iOS will fall back to using Helvetica which is likely not to include support for the glyphs needed to render maps in your application.

--- a/platform/macos/app/Info.plist
+++ b/platform/macos/app/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>MGLIdeographicFontFamilyName</key>
+	<string>PingFang TC</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDocumentTypes</key>

--- a/platform/macos/docs/guides/Info.plist Keys.md
+++ b/platform/macos/docs/guides/Info.plist Keys.md
@@ -18,4 +18,4 @@ The default value is `https://api.mapbox.com`.
 
 ## MGLIdeographicFontFamilyName                                                                                                                                                          
 
-The name of the font family to use for client-side text rendering of CJK ideographs. Set this to the name of a font family which will be available at run time, e.g. `PingFang`.
+The name of the font family to use for client-side text rendering of CJK ideographs. Set this to the name of a font family which will be available at run time, e.g. `PingFang TC` (iOS 9+), `Heiti TC` (iOS 8+), another appropriate built-in font, or a font provided by your application. Note that if a non-existent font is specified, iOS will fall back to using Helvetica which is likely not to include support for the glyphs needed to render maps in your application.


### PR DESCRIPTION
Also updates the font to use for rendering CJK ideographs in our sample
apps to `PingFang TC`, as simply specifying `PingFang` was always
triggering iOS's font fallback behavior.

[Fixes #10675]