### PR TITLE
Remove fragment flash

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapFragment.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapFragment.java
@@ -11,6 +11,9 @@ import android.view.ViewGroup;
 
 import com.mapbox.mapboxsdk.utils.MapFragmentUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Fragment wrapper around a map view.
  * <p>
@@ -25,10 +28,11 @@ import com.mapbox.mapboxsdk.utils.MapFragmentUtils;
  *
  * @see #getMapAsync(OnMapReadyCallback)
  */
-public final class MapFragment extends Fragment {
+public final class MapFragment extends Fragment implements OnMapReadyCallback {
 
+  private final List<OnMapReadyCallback> mapReadyCallbackList = new ArrayList<>();
+  private MapboxMap mapboxMap;
   private MapView map;
-  private OnMapReadyCallback onMapReadyCallback;
 
   /**
    * Creates a default MapFragment instance
@@ -63,7 +67,9 @@ public final class MapFragment extends Fragment {
   public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     super.onCreateView(inflater, container, savedInstanceState);
     Context context = inflater.getContext();
-    return map = new MapView(context, MapFragmentUtils.resolveArgs(context, getArguments()));
+    map = new MapView(context, MapFragmentUtils.resolveArgs(context, getArguments()));
+    map.setVisibility(View.INVISIBLE);
+    return map;
   }
 
   /**
@@ -76,9 +82,16 @@ public final class MapFragment extends Fragment {
   public void onViewCreated(View view, Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
     map.onCreate(savedInstanceState);
-    if (onMapReadyCallback != null) {
-      map.getMapAsync(onMapReadyCallback);
+    map.getMapAsync(this);
+  }
+
+  @Override
+  public void onMapReady(MapboxMap mapboxMap) {
+    this.mapboxMap = mapboxMap;
+    for (OnMapReadyCallback onMapReadyCallback : mapReadyCallbackList) {
+      onMapReadyCallback.onMapReady(mapboxMap);
     }
+    map.setVisibility(View.VISIBLE);
   }
 
   /**
@@ -144,6 +157,7 @@ public final class MapFragment extends Fragment {
   public void onDestroyView() {
     super.onDestroyView();
     map.onDestroy();
+    mapReadyCallbackList.clear();
   }
 
   /**
@@ -152,10 +166,10 @@ public final class MapFragment extends Fragment {
    * @param onMapReadyCallback The callback to be invoked.
    */
   public void getMapAsync(@NonNull final OnMapReadyCallback onMapReadyCallback) {
-    if (map == null) {
-      this.onMapReadyCallback = onMapReadyCallback;
+    if (mapboxMap == null) {
+      mapReadyCallbackList.add(onMapReadyCallback);
     } else {
-      map.getMapAsync(onMapReadyCallback);
+      onMapReadyCallback.onMapReady(mapboxMap);
     }
   }
 }


### PR DESCRIPTION
This PR optimises showing a Map inside a fragment by hiding the surface on startup and only making it visible when the map is ready. Additionally this PR also allows to use multiple subscribers for OnMapReady events.

#### before
![ezgif com-video-to-gif 16](https://user-images.githubusercontent.com/2151639/34072588-37457c88-e28a-11e7-90c3-e7e7de8ffdcf.gif)

#### after
![ezgif com-video-to-gif 17](https://user-images.githubusercontent.com/2151639/34072591-3c014950-e28a-11e7-8541-af2a7589deca.gif)



