### PR TITLE
[build] Replace boost_libprogram_options with args

### DIFF
--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -1,80 +1,81 @@
 #include <mbgl/map/map.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/run_loop.hpp>
+#include <mbgl/util/default_styles.hpp>
 
 #include <mbgl/gl/headless_frontend.hpp>
 #include <mbgl/util/default_thread_pool.hpp>
 #include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/style/style.hpp>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas"
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#pragma GCC diagnostic ignored "-Wshadow"
-#include <boost/program_options.hpp>
-#pragma GCC diagnostic pop
-
-namespace po = boost::program_options;
+#include <args/args.hxx>
 
 #include <cstdlib>
 #include <iostream>
 #include <fstream>
 
 int main(int argc, char *argv[]) {
-    std::string style_path;
-    double lat = 0, lon = 0;
-    double zoom = 0;
-    double bearing = 0;
-    double pitch = 0;
-    double pixelRatio = 1;
+    args::ArgumentParser argumentParser("Mapbox GL render tool");
+    args::HelpFlag helpFlag(argumentParser, "help", "Display this help menu", {"help"});
 
-    uint32_t width = 512;
-    uint32_t height = 512;
-    static std::string output = "out.png";
-    std::string cache_file = "cache.sqlite";
-    std::string asset_root = ".";
-    std::string token;
-    bool debug = false;
+    args::ValueFlag<std::string> tokenValue(argumentParser, "key", "Mapbox access token", {'t', "token"});
+    args::ValueFlag<std::string> styleValue(argumentParser, "URL", "Map stylesheet", {'s', "style"});
+    args::ValueFlag<std::string> outputValue(argumentParser, "file", "Output file name", {'o', "output"});
+    args::ValueFlag<std::string> cacheValue(argumentParser, "file", "Cache database file name", {'c', "cache"});
+    args::ValueFlag<std::string> assetsValue(argumentParser, "file", "Directory to which asset:// URLs will resolve", {'a', "assets"});
 
-    po::options_description desc("Allowed options");
-    desc.add_options()
-        ("style,s", po::value(&style_path)->required()->value_name("json"), "Map stylesheet")
-        ("lon,x", po::value(&lon)->value_name("degrees")->default_value(lon), "Longitude")
-        ("lat,y", po::value(&lat)->value_name("degrees")->default_value(lat), "Latitude in degrees")
-        ("zoom,z", po::value(&zoom)->value_name("number")->default_value(zoom), "Zoom level")
-        ("bearing,b", po::value(&bearing)->value_name("degrees")->default_value(bearing), "Bearing")
-        ("pitch,p", po::value(&pitch)->value_name("degrees")->default_value(pitch), "Pitch")
-        ("width,w", po::value(&width)->value_name("pixels")->default_value(width), "Image width")
-        ("height,h", po::value(&height)->value_name("pixels")->default_value(height), "Image height")
-        ("ratio,r", po::value(&pixelRatio)->value_name("number")->default_value(pixelRatio), "Image scale factor")
-        ("token,t", po::value(&token)->value_name("key")->default_value(token), "Mapbox access token")
-        ("debug", po::bool_switch(&debug)->default_value(debug), "Debug mode")
-        ("output,o", po::value(&output)->value_name("file")->default_value(output), "Output file name")
-        ("cache,d", po::value(&cache_file)->value_name("file")->default_value(cache_file), "Cache database file name")
-        ("assets,d", po::value(&asset_root)->value_name("file")->default_value(asset_root), "Directory to which asset:// URLs will resolve")
-    ;
+    args::Flag debugFlag(argumentParser, "debug", "Debug mode", {"debug"});
+
+    args::ValueFlag<double> pixelRatioValue(argumentParser, "number", "Image scale factor", {'r', "ratio"});
+
+    args::ValueFlag<double> zoomValue(argumentParser, "number", "Zoom level", {'z', "zoom"});
+
+    args::ValueFlag<double> lonValue(argumentParser, "degrees", "Longitude", {'x', "lon"});
+    args::ValueFlag<double> latValue(argumentParser, "degrees", "Latitude", {'y', "lat"});
+    args::ValueFlag<double> bearingValue(argumentParser, "degrees", "Bearing", {'b', "bearing"});
+    args::ValueFlag<double> pitchValue(argumentParser, "degrees", "Pitch", {'p', "pitch"});
+    args::ValueFlag<uint32_t> widthValue(argumentParser, "pixels", "Image width", {'w', "width"});
+    args::ValueFlag<uint32_t> heightValue(argumentParser, "pixels", "Image height", {'h', "height"});
 
     try {
-        po::variables_map vm;
-        po::store(po::parse_command_line(argc, argv, desc), vm);
-        po::notify(vm);
-    } catch(std::exception& e) {
-        std::cout << "Error: " << e.what() << std::endl << desc;
+        argumentParser.ParseCLI(argc, argv);
+    } catch (args::Help) {
+        std::cout << argumentParser;
+        exit(0);
+    } catch (args::ParseError e) {
+        std::cerr << e.what() << std::endl;
+        std::cerr << argumentParser;
         exit(1);
+    } catch (args::ValidationError e) {
+        std::cerr << e.what() << std::endl;
+        std::cerr << argumentParser;
+        exit(2);
     }
+
+    std::string style = styleValue ? args::get(styleValue) : mbgl::util::default_styles::streets.url;
+    const double lat = latValue ? args::get(latValue) : 0;
+    const double lon = lonValue ? args::get(lonValue) : 0;
+    const double zoom = zoomValue ? args::get(zoomValue) : 0;
+    const double bearing = bearingValue ? args::get(bearingValue) : 0;
+    const double pitch = pitchValue ? args::get(pitchValue) : 0;
+    const double pixelRatio = pixelRatioValue ? args::get(pixelRatioValue) : 1;
+
+    const uint32_t width = widthValue ? args::get(widthValue) : 512;
+    const uint32_t height = heightValue ? args::get(heightValue) : 512;
+    const std::string output = outputValue ? args::get(outputValue) : "out.png";
+    const std::string cache_file = cacheValue ? args::get(cacheValue) : "cache.sqlite";
+    const std::string asset_root = assetsValue ? args::get(assetsValue) : ".";
+
+    // Try to load the token from the environment.
+    const char* tokenEnv = getenv("MAPBOX_ACCESS_TOKEN");
+    const std::string token = tokenValue ? args::get(tokenValue) : (tokenEnv ? tokenEnv : std::string());
+
+    const bool debug = debugFlag ? args::get(debugFlag) : false;
 
     using namespace mbgl;
 
     util::RunLoop loop;
     DefaultFileSource fileSource(cache_file, asset_root);
-
-    // Try to load the token from the environment.
-    if (!token.size()) {
-        const char *token_ptr = getenv("MAPBOX_ACCESS_TOKEN");
-        if (token_ptr) {
-            token = token_ptr;
-        }
-    }
 
     // Set access token if present
     if (token.size()) {
@@ -85,11 +86,11 @@ int main(int argc, char *argv[]) {
     HeadlessFrontend frontend({ width, height }, pixelRatio, fileSource, threadPool);
     Map map(frontend, MapObserver::nullObserver(), frontend.getSize(), pixelRatio, fileSource, threadPool, MapMode::Static);
 
-    if (style_path.find("://") == std::string::npos) {
-        style_path = std::string("file://") + style_path;
+    if (style.find("://") == std::string::npos) {
+        style = std::string("file://") + style;
     }
 
-    map.getStyle().loadURL(style_path);
+    map.getStyle().loadURL(style);
     map.setLatLngZoom({ lat, lon }, zoom);
     map.setBearing(bearing);
     map.setPitch(pitch);

--- a/cmake/glfw.cmake
+++ b/cmake/glfw.cmake
@@ -25,6 +25,7 @@ target_add_mason_package(mbgl-glfw PRIVATE geojson)
 target_add_mason_package(mbgl-glfw PRIVATE geometry)
 target_add_mason_package(mbgl-glfw PRIVATE glfw)
 target_add_mason_package(mbgl-glfw PRIVATE variant)
+target_add_mason_package(mbgl-glfw PRIVATE args)
 
 mbgl_platform_glfw()
 

--- a/cmake/offline.cmake
+++ b/cmake/offline.cmake
@@ -15,7 +15,7 @@ target_link_libraries(mbgl-offline
 )
 
 target_add_mason_package(mbgl-offline PRIVATE boost)
-target_add_mason_package(mbgl-offline PRIVATE boost_libprogram_options)
+target_add_mason_package(mbgl-offline PRIVATE args)
 
 mbgl_platform_offline()
 

--- a/cmake/render.cmake
+++ b/cmake/render.cmake
@@ -11,8 +11,8 @@ target_link_libraries(mbgl-render
 )
 
 target_add_mason_package(mbgl-render PRIVATE boost)
-target_add_mason_package(mbgl-render PRIVATE boost_libprogram_options)
 target_add_mason_package(mbgl-render PRIVATE geojson)
+target_add_mason_package(mbgl-render PRIVATE args)
 
 mbgl_platform_render()
 

--- a/platform/linux/config.cmake
+++ b/platform/linux/config.cmake
@@ -1,6 +1,5 @@
 mason_use(glfw VERSION 2017-07-13-67c9155)
 mason_use(mesa VERSION 13.0.4)
-mason_use(boost_libprogram_options VERSION 1.62.0${MASON_CXXABI_SUFFIX})
 mason_use(sqlite VERSION 3.14.2)
 mason_use(libuv VERSION 1.9.1)
 mason_use(nunicode VERSION 1.7.1)
@@ -10,6 +9,7 @@ mason_use(webp VERSION 0.5.1)
 mason_use(gtest VERSION 1.8.0${MASON_CXXABI_SUFFIX})
 mason_use(benchmark VERSION 1.2.0)
 mason_use(icu VERSION 58.1-min-size)
+mason_use(args VERSION 6.2.0 HEADER_ONLY)
 
 include(cmake/loop-uv.cmake)
 

--- a/platform/macos/config.cmake
+++ b/platform/macos/config.cmake
@@ -1,10 +1,10 @@
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.10)
 
 mason_use(glfw VERSION 2017-07-13-67c9155)
-mason_use(boost_libprogram_options VERSION 1.62.0)
 mason_use(gtest VERSION 1.8.0)
 mason_use(benchmark VERSION 1.2.0)
 mason_use(icu VERSION 58.1-min-size)
+mason_use(args VERSION 6.2.0 HEADER_ONLY)
 
 include(cmake/loop-uv.cmake)
 include(cmake/loop-darwin.cmake)


### PR DESCRIPTION
Replaces boost's libprogram_options with Args header-only library for parsing CLI arguments. This simplifies the introduction of clang-3.8 + libc++ in our CI infrastructure and replaces a somewhat heavyweight dependency with a lighter one.

Ref: #10653