### PR TITLE
[android] Support custom LibraryLoader

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/LibraryLoader.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/LibraryLoader.java
@@ -5,16 +5,32 @@ import timber.log.Timber;
 /**
  * Centralises the knowledge about "mapbox-gl" library loading.
  */
-public class LibraryLoader {
+public abstract class LibraryLoader {
+
+  private static final LibraryLoader DEFAULT = new LibraryLoader() {
+    @Override
+    public void load(String name) {
+      try {
+        System.loadLibrary(name);
+      } catch (UnsatisfiedLinkError error) {
+        Timber.e(error, "Failed to load native shared library.");
+      }
+    }
+  };
+
+  private static volatile LibraryLoader loader = DEFAULT;
+
+  public static void setLibraryLoader(LibraryLoader libraryLoader) {
+    loader = libraryLoader;
+  }
 
   /**
    * Loads "libmapbox-gl.so" native shared library.
    */
   public static void load() {
-    try {
-      System.loadLibrary("mapbox-gl");
-    } catch (UnsatisfiedLinkError error) {
-      Timber.e(error, "Failed to load native shared library.");
-    }
+    loader.load("mapbox-gl");
   }
+
+  public abstract void load(String name);
 }
+


### PR DESCRIPTION
Allows API callers to set their own native library loader.
For example, can use https://github.com/facebook/SoLoader