### PR TITLE
Support custom library loader

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/LibraryLoader.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/LibraryLoader.java
@@ -3,18 +3,46 @@ package com.mapbox.mapboxsdk;
 import timber.log.Timber;
 
 /**
- * Centralises the knowledge about "mapbox-gl" library loading.
+ * Loads the mapbox-gl shared library
+ * <p>
+ * By default uses the {@link System#loadLibrary(String)},
+ * use {@link #setLibraryLoader(LibraryLoader)} to provide an alternative library loading hook.
+ * </p>
  */
-public class LibraryLoader {
+public abstract class LibraryLoader {
+
+  private static final LibraryLoader DEFAULT = new LibraryLoader() {
+    @Override
+    public void load(String name) {
+      System.loadLibrary(name);
+    }
+  };
+
+  private static volatile LibraryLoader loader = DEFAULT;
+
+  /**
+   * Set the library loader that loads the shared library.
+   *
+   * @param libraryLoader the library loader
+   */
+  public static void setLibraryLoader(LibraryLoader libraryLoader) {
+    loader = libraryLoader;
+  }
 
   /**
    * Loads "libmapbox-gl.so" native shared library.
+   * <p>
+   * Catches UnsatisfiedLinkErrors and prints a warning to logcat.
+   * </p>
    */
   public static void load() {
     try {
-      System.loadLibrary("mapbox-gl");
+      loader.load("mapbox-gl");
     } catch (UnsatisfiedLinkError error) {
       Timber.e(error, "Failed to load native shared library.");
     }
   }
+
+  public abstract void load(String name);
 }
+


### PR DESCRIPTION
Follow up from https://github.com/mapbox/mapbox-gl-native/pull/10732: 

>Allows API callers to set their own native library loader.
For example, can use https://github.com/facebook/SoLoader

cc @jaegs  