### PR TITLE
[android] Update lifecycle documentation for Fragments

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -273,7 +273,7 @@ public class MapView extends FrameLayout {
   /**
    * <p>
    * You must call this method from the parent's Activity#onCreate(Bundle)} or
-   * Fragment#onCreate(Bundle).
+   * Fragment#onViewCreated(View, Bundle).
    * </p>
    * You must set a valid access token with {@link com.mapbox.mapboxsdk.Mapbox#getInstance(Context, String)}
    * before you call this method or an exception will be thrown.
@@ -410,7 +410,7 @@ public class MapView extends FrameLayout {
   }
 
   /**
-   * You must call this method from the parent's Activity#onDestroy() or Fragment#onDestroy().
+   * You must call this method from the parent's Activity#onDestroy() or Fragment#onDestroyView().
    */
   @UiThread
   public void onDestroy() {


### PR DESCRIPTION
Update the Javadoc to reflect the current implementation on [`DoubleMapActivity`](https://github.com/mapbox/mapbox-gl-native/blob/master/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DoubleMapActivity.java).
