### PR TITLE
Update Spanish, Vietnamese translations

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values-es/strings.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values-es/strings.xml
@@ -4,12 +4,13 @@
     <string name="mapbox_attributionsIconContentDescription">Ícono de atribución. Actívalo para mostrar el diálogo de atribución.</string>
     <string name="mapbox_myLocationViewContentDescription">Vista de ubicación. Muestra tu ubicación en el mapa.</string>
     <string name="mapbox_mapActionDescription">Se está mostrando un mapa creado con Mapbox. Arrastra dos dedos para desplazarte o pellizca para acercar.</string>
-    <string name="mapbox_attributionsDialogTitle">Mapbox Android SDK</string>
+    <string name="mapbox_attributionsDialogTitle">Mapbox Maps SDK para Android</string>
     <string name="mapbox_attributionTelemetryTitle">Ayúdanos a mejorar los mapas de Mapbox</string>
     <string name="mapbox_attributionTelemetryMessage">Gracias a tu contribución de datos anónimos de uso, ayudas a mejorar OpenStreetMap y Mapbox.</string>
     <string name="mapbox_attributionTelemetryPositive">Aceptar</string>
     <string name="mapbox_attributionTelemetryNegative">Rechazar</string>
     <string name="mapbox_attributionTelemetryNeutral">Más información</string>
+    <string name="mapbox_attributionErrorNoBrowser">No puede abrir la página Web porque no hay un navegador Web en el dispositivo.</string>
     <string name="mapbox_offline_error_region_definition_invalid">El parámetro OfflineRegionDefinition que se ingresó no coincide con los límites mundiales: %s</string>
-
+    <string name="mapbox_telemetrySettings">Ajustes de telemetría</string>
     </resources>

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values-vi/strings.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values-vi/strings.xml
@@ -4,12 +4,13 @@
     <string name="mapbox_attributionsIconContentDescription">Biểu tượng ghi công. Kích hoạt để xem hộp thoại ghi công.</string>
     <string name="mapbox_myLocationViewContentDescription">Cái chỉ vị trí. Cái này chỉ vị trí của bạn trên bản đồ.</string>
     <string name="mapbox_mapActionDescription">Đang xem bản đồ được xây dựng dùng Mapbox. Kéo hai ngón tay để cuộn. Chụm các ngón tay lại để phóng to. Tách các ngón tay ra để thu nhỏ.</string>
-    <string name="mapbox_attributionsDialogTitle">Mapbox Android SDK</string>
+    <string name="mapbox_attributionsDialogTitle">Mapbox Maps SDK cho Android</string>
     <string name="mapbox_attributionTelemetryTitle">Cải tiến các Bản đồ Mapbox</string>
     <string name="mapbox_attributionTelemetryMessage">Bạn đang giúp cải tiến các bản đồ OpenStreetMap và Mapbox bằng cách đóng góp dữ liệu vô danh hóa về cách sử dụng.</string>
     <string name="mapbox_attributionTelemetryPositive">Đồng ý</string>
     <string name="mapbox_attributionTelemetryNegative">Phản đối</string>
     <string name="mapbox_attributionTelemetryNeutral">Thông tin thêm</string>
+    <string name="mapbox_attributionErrorNoBrowser">Không thể mở trang Web vì thiết bị thiếu trình duyệt.</string>
     <string name="mapbox_offline_error_region_definition_invalid">OfflineRegionDefinition được cung cấp không vừa thế giới: %s</string>
-
+    <string name="mapbox_telemetrySettings">Thiết lập Trình viễn trắc</string>
     </resources>


### PR DESCRIPTION
Updated the Android map SDK’s Spanish and Vietnamese translations, including translations of “Mapbox Maps SDK for Android”.

/cc @langsmith