### PR TITLE
[ios, build] Expand iOS tests to more versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ xcuserdata
 test/fixtures/api/assets.zip
 test/fixtures/storage/assets.zip
 /.circle-week
+/gems
 
 # Generated list files from code generation
 /scripts/generate-cmake-files.list

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org' do
+  #gem 'jazzy', '~> 0.9'
+  gem 'xcpretty', :git => 'https://github.com/technology-ebay-de/xcpretty.git', :branch => 'feature/parallel-testing-support'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org' do
-  #gem 'jazzy', '~> 0.9'
+  gem 'jazzy', :git => 'https://github.com/realm/jazzy.git', :ref => '4157c7608610cddd43cfae08ee5606fde09a32a8'
   gem 'xcpretty', :git => 'https://github.com/technology-ebay-de/xcpretty.git', :branch => 'feature/parallel-testing-support'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org' do
-  gem 'jazzy', :git => 'https://github.com/realm/jazzy.git', :ref => '4157c7608610cddd43cfae08ee5606fde09a32a8'
+  #gem 'jazzy', :git => 'https://github.com/realm/jazzy.git', :ref => '4157c7608610cddd43cfae08ee5606fde09a32a8'
   gem 'xcpretty', :git => 'https://github.com/technology-ebay-de/xcpretty.git', :branch => 'feature/parallel-testing-support'
 end

--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,11 @@ IOS_XCODEBUILD_SIM = xcodebuild \
 	  ARCHS=x86_64 ONLY_ACTIVE_ARCH=YES \
 	  -derivedDataPath $(IOS_OUTPUT_PATH) \
 	  -configuration $(BUILDTYPE) -sdk iphonesimulator \
-	  -destination 'platform=iOS Simulator,name=iPhone 6,OS=latest' \
+	  -destination 'platform=iOS Simulator,name=iPhone 8,OS=latest' \
+	  -destination 'platform=iOS Simulator,name=iPad Pro (10.5-inch),OS=latest' \
+	  -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3.1' \
+	  -destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' \
+	  -destination 'platform=iOS Simulator,name=iPhone 6,OS=8.4' \
 	  -workspace $(IOS_WORK_PATH)
 
 $(IOS_PROJ_PATH): $(IOS_USER_DATA_PATH)/WorkspaceSettings.xcsettings $(BUILD_DEPS)

--- a/Makefile
+++ b/Makefile
@@ -197,15 +197,14 @@ IOS_WORK_PATH = platform/ios/ios.xcworkspace
 IOS_USER_DATA_PATH = $(IOS_WORK_PATH)/xcuserdata/$(USER).xcuserdatad
 
 IOS_XCODEBUILD_SIM = xcodebuild \
-	  ARCHS=x86_64 ONLY_ACTIVE_ARCH=YES \
-	  -derivedDataPath $(IOS_OUTPUT_PATH) \
-	  -configuration $(BUILDTYPE) -sdk iphonesimulator \
-	  -destination 'platform=iOS Simulator,name=iPhone 8,OS=latest' \
-	  -destination 'platform=iOS Simulator,name=iPad Pro (10.5-inch),OS=latest' \
-	  -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3.1' \
-	  -destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' \
-	  -destination 'platform=iOS Simulator,name=iPhone 6,OS=8.4' \
-	  -workspace $(IOS_WORK_PATH)
+	ARCHS=x86_64 ONLY_ACTIVE_ARCH=YES \
+	-derivedDataPath $(IOS_OUTPUT_PATH) \
+	-configuration $(BUILDTYPE) -sdk iphonesimulator \
+	-destination 'platform=iOS Simulator,name=iPhone 8,OS=latest' \
+	-destination 'platform=iOS Simulator,name=iPad Pro (10.5-inch),OS=latest' \
+	-destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3.1' \
+	-destination 'platform=iOS Simulator,name=iPad Air 2,OS=10.3.1' \
+	-workspace $(IOS_WORK_PATH)
 
 $(IOS_PROJ_PATH): $(IOS_USER_DATA_PATH)/WorkspaceSettings.xcsettings $(BUILD_DEPS)
 	mkdir -p $(IOS_OUTPUT_PATH)

--- a/Makefile
+++ b/Makefile
@@ -200,9 +200,13 @@ IOS_XCODEBUILD_SIM = xcodebuild \
 	ARCHS=x86_64 ONLY_ACTIVE_ARCH=YES \
 	-derivedDataPath $(IOS_OUTPUT_PATH) \
 	-configuration $(BUILDTYPE) -sdk iphonesimulator \
+	-destination 'platform=iOS Simulator,name=iPhone X,OS=latest' \
 	-destination 'platform=iOS Simulator,name=iPhone 8,OS=latest' \
+	-destination 'platform=iOS Simulator,name=iPhone SE,OS=latest' \
 	-destination 'platform=iOS Simulator,name=iPad Pro (10.5-inch),OS=latest' \
+	-destination 'platform=iOS Simulator,name=iPhone 7 Plus,OS=10.3.1' \
 	-destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3.1' \
+	-destination 'platform=iOS Simulator,name=iPhone 5s,OS=10.3.1' \
 	-destination 'platform=iOS Simulator,name=iPad Air 2,OS=10.3.1' \
 	-workspace $(IOS_WORK_PATH)
 

--- a/Makefile
+++ b/Makefile
@@ -198,15 +198,15 @@ IOS_USER_DATA_PATH = $(IOS_WORK_PATH)/xcuserdata/$(USER).xcuserdatad
 
 IOS_SIMULATORS = -destination 'platform=iOS Simulator,name=iPhone X,OS=latest' \
 	-destination 'platform=iOS Simulator,name=iPhone 8,OS=latest' \
-	-destination 'platform=iOS Simulator,name=iPad Pro (10.5-inch),OS=latest' \
 	-destination 'platform=iOS Simulator,name=iPhone 7 Plus,OS=10.3.1' \
-	-destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3.1' \
-	-destination 'platform=iOS Simulator,name=iPad (5th generation),OS=10.3.1'
+	-destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3.1'
 
 # Run full compatibility suite locally
 ifeq ($(CI),)
   IOS_SIMULATORS += \
+	-destination 'platform=iOS Simulator,name=iPad Pro (10.5-inch),OS=latest' \
 	-destination 'platform=iOS Simulator,name=iPhone SE,OS=latest' \
+	-destination 'platform=iOS Simulator,name=iPad (5th generation),OS=10.3.1' \
 	-destination 'platform=iOS Simulator,name=iPhone 5s,OS=10.3.1' \
 	-destination 'platform=iOS Simulator,name=iPhone 6s Plus,OS=9.3' \
 	-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' \
@@ -223,7 +223,7 @@ IOS_XCODEBUILD_SIM = xcodebuild \
 	$(IOS_SIMULATORS) \
 	-parallelizeTargets \
 	-jobs $(JOBS) \
-	-maximum-concurrent-test-simulator-destinations 3 \
+	-maximum-concurrent-test-simulator-destinations 4 \
 	-workspace $(IOS_WORK_PATH)
 
 $(IOS_PROJ_PATH): $(IOS_USER_DATA_PATH)/WorkspaceSettings.xcsettings $(BUILD_DEPS)

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,8 @@ IOS_XCODEBUILD_SIM = xcodebuild \
 	-destination 'platform=iOS Simulator,name=iPhone 7 Plus,OS=10.3.1' \
 	-destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3.1' \
 	-destination 'platform=iOS Simulator,name=iPad Air 2,OS=10.3.1' \
+	-parallelizeTargets \
+	-jobs $(JOBS) \
 	-workspace $(IOS_WORK_PATH)
 
 $(IOS_PROJ_PATH): $(IOS_USER_DATA_PATH)/WorkspaceSettings.xcsettings $(BUILD_DEPS)

--- a/Makefile
+++ b/Makefile
@@ -202,11 +202,9 @@ IOS_XCODEBUILD_SIM = xcodebuild \
 	-configuration $(BUILDTYPE) -sdk iphonesimulator \
 	-destination 'platform=iOS Simulator,name=iPhone X,OS=latest' \
 	-destination 'platform=iOS Simulator,name=iPhone 8,OS=latest' \
-	-destination 'platform=iOS Simulator,name=iPhone SE,OS=latest' \
 	-destination 'platform=iOS Simulator,name=iPad Pro (10.5-inch),OS=latest' \
 	-destination 'platform=iOS Simulator,name=iPhone 7 Plus,OS=10.3.1' \
 	-destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3.1' \
-	-destination 'platform=iOS Simulator,name=iPhone 5s,OS=10.3.1' \
 	-destination 'platform=iOS Simulator,name=iPad Air 2,OS=10.3.1' \
 	-workspace $(IOS_WORK_PATH)
 

--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,7 @@ IOS_XCODEBUILD_SIM = xcodebuild \
 	$(IOS_SIMULATORS) \
 	-parallelizeTargets \
 	-jobs $(JOBS) \
+	-maximum-concurrent-test-simulator-destinations 3 \
 	-workspace $(IOS_WORK_PATH)
 
 $(IOS_PROJ_PATH): $(IOS_USER_DATA_PATH)/WorkspaceSettings.xcsettings $(BUILD_DEPS)

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ifeq ($(V), 1)
   export XCPRETTY
   NINJA_ARGS ?= -v
 else
-  export XCPRETTY ?= | tee '$(shell pwd)/build/xcodebuild-$(shell date +"%Y-%m-%d_%H%M%S").log' | xcpretty
+  export XCPRETTY ?= | tee '$(shell pwd)/build/xcodebuild-$(shell date +"%Y-%m-%d_%H%M%S").log' | bundle exec xcpretty
   NINJA_ARGS ?=
 endif
 
@@ -715,3 +715,4 @@ clean:
 distclean: clean
 	-rm -rf ./mason_packages
 	-rm -rf ./node_modules
+	-rm -rf ./gems

--- a/Makefile
+++ b/Makefile
@@ -196,16 +196,31 @@ IOS_PROJ_PATH = $(IOS_OUTPUT_PATH)/mbgl.xcodeproj
 IOS_WORK_PATH = platform/ios/ios.xcworkspace
 IOS_USER_DATA_PATH = $(IOS_WORK_PATH)/xcuserdata/$(USER).xcuserdatad
 
-IOS_XCODEBUILD_SIM = xcodebuild \
-	ARCHS=x86_64 ONLY_ACTIVE_ARCH=YES \
-	-derivedDataPath $(IOS_OUTPUT_PATH) \
-	-configuration $(BUILDTYPE) -sdk iphonesimulator \
-	-destination 'platform=iOS Simulator,name=iPhone X,OS=latest' \
+IOS_SIMULATORS = -destination 'platform=iOS Simulator,name=iPhone X,OS=latest' \
 	-destination 'platform=iOS Simulator,name=iPhone 8,OS=latest' \
 	-destination 'platform=iOS Simulator,name=iPad Pro (10.5-inch),OS=latest' \
 	-destination 'platform=iOS Simulator,name=iPhone 7 Plus,OS=10.3.1' \
 	-destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3.1' \
-	-destination 'platform=iOS Simulator,name=iPad Air 2,OS=10.3.1' \
+	-destination 'platform=iOS Simulator,name=iPad (5th generation),OS=10.3.1'
+
+# Run full compatibility suite locally
+ifeq ($(CI),)
+  IOS_SIMULATORS += \
+	-destination 'platform=iOS Simulator,name=iPhone SE,OS=latest' \
+	-destination 'platform=iOS Simulator,name=iPhone 5s,OS=10.3.1' \
+	-destination 'platform=iOS Simulator,name=iPhone 6s Plus,OS=9.3' \
+	-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' \
+	-destination 'platform=iOS Simulator,name=iPad Air 2,OS=9.3' \
+	-destination 'platform=iOS Simulator,name=iPhone 6 Plus,OS=8.4' \
+	-destination 'platform=iOS Simulator,name=iPhone 6,OS=8.4' \
+	-destination 'platform=iOS Simulator,name=iPad Air,OS=8.4'
+endif
+
+IOS_XCODEBUILD_SIM = xcodebuild \
+	ARCHS=x86_64 ONLY_ACTIVE_ARCH=YES \
+	-derivedDataPath $(IOS_OUTPUT_PATH) \
+	-configuration $(BUILDTYPE) -sdk iphonesimulator \
+	$(IOS_SIMULATORS) \
 	-parallelizeTargets \
 	-jobs $(JOBS) \
 	-workspace $(IOS_WORK_PATH)

--- a/circle.yml
+++ b/circle.yml
@@ -154,6 +154,14 @@ step-library:
           brew install cmake
           brew install ccache
 
+  - &install-xcpretty-workaround
+      run:
+        name: Install xcpretty fork
+        command: |
+          git clone https://github.com/technology-ebay-de/xcpretty --branch feature/parallel-testing-support
+          gem build xcpretty/xcpretty.gemspec
+          sudo gem install xcpretty*.gem
+
   - &install-macos-node4-dependencies
       run:
         name: Install macOS Node@4 dependencies
@@ -729,6 +737,7 @@ jobs:
     steps:
       - checkout
       - *install-macos-dependencies
+      - *install-xcpretty-workaround
       - *generate-cache-key
       - *restore-cache
       - *reset-ccache-stats
@@ -756,6 +765,7 @@ jobs:
     steps:
       - checkout
       - *install-macos-dependencies
+      - *install-xcpretty-workaround
       - *generate-cache-key
       - *restore-cache
       - *reset-ccache-stats
@@ -777,6 +787,7 @@ jobs:
     steps:
       - checkout
       - *install-macos-dependencies
+      - *install-xcpretty-workaround
       - *generate-cache-key
       - *restore-cache
       - *reset-ccache-stats

--- a/circle.yml
+++ b/circle.yml
@@ -756,7 +756,6 @@ jobs:
     steps:
       - checkout
       - *install-macos-dependencies
-      - *install-xcpretty-workaround
       - *generate-cache-key
       - *restore-cache
       - *reset-ccache-stats

--- a/circle.yml
+++ b/circle.yml
@@ -158,11 +158,7 @@ step-library:
       run:
         name: Install xcpretty fork
         command: |
-          brew install ruby
-          gem env
-          git clone https://github.com/technology-ebay-de/xcpretty --branch feature/parallel-testing-support
-          gem build xcpretty/xcpretty.gemspec
-          sudo gem install xcpretty*.gem
+          bundle install
 
   - &install-macos-node4-dependencies
       run:

--- a/circle.yml
+++ b/circle.yml
@@ -154,12 +154,6 @@ step-library:
           brew install cmake
           brew install ccache
 
-  - &install-xcpretty-workaround
-      run:
-        name: Install xcpretty fork
-        command: |
-          bundle install
-
   - &install-macos-node4-dependencies
       run:
         name: Install macOS Node@4 dependencies
@@ -735,7 +729,6 @@ jobs:
     steps:
       - checkout
       - *install-macos-dependencies
-      - *install-xcpretty-workaround
       - *generate-cache-key
       - *restore-cache
       - *reset-ccache-stats
@@ -785,7 +778,6 @@ jobs:
     steps:
       - checkout
       - *install-macos-dependencies
-      - *install-xcpretty-workaround
       - *generate-cache-key
       - *restore-cache
       - *reset-ccache-stats

--- a/circle.yml
+++ b/circle.yml
@@ -158,6 +158,8 @@ step-library:
       run:
         name: Install xcpretty fork
         command: |
+          brew install ruby
+          gem env
           git clone https://github.com/technology-ebay-de/xcpretty --branch feature/parallel-testing-support
           gem build xcpretty/xcpretty.gemspec
           sudo gem install xcpretty*.gem

--- a/circle.yml
+++ b/circle.yml
@@ -4,53 +4,53 @@ workflows:
   version: 2
   default:
     jobs:
-      - nitpick
-      - clang-tidy:
-          filters:
-            branches:
-              ignore: master
-      - android-debug-arm-v7
-      - android-release-all
-      - node4-clang39-release:
-          filters:
-            tags:
-              only: /node-.*/
-      - node6-clang39-release:
-          filters:
-            tags:
-              only: /node-.*/
-      - node6-gcc6-debug:
-          filters:
-            tags:
-              only: /node-.*/
-      - linux-clang-3.8-libcxx-debug
-      - linux-clang4-sanitize-address
-      - linux-clang4-sanitize-undefined
-      - linux-clang4-sanitize-thread
-      - linux-gcc4.9-debug
-      - linux-gcc5-debug-coverage
-      - linux-gcc5-release-qt4
-      - linux-gcc5-release-qt5
+      # - nitpick
+      # - clang-tidy:
+      #     filters:
+      #       branches:
+      #         ignore: master
+      # - android-debug-arm-v7
+      # - android-release-all
+      # - node4-clang39-release:
+      #     filters:
+      #       tags:
+      #         only: /node-.*/
+      # - node6-clang39-release:
+      #     filters:
+      #       tags:
+      #         only: /node-.*/
+      # - node6-gcc6-debug:
+      #     filters:
+      #       tags:
+      #         only: /node-.*/
+      # - linux-clang-3.8-libcxx-debug
+      # - linux-clang4-sanitize-address
+      # - linux-clang4-sanitize-undefined
+      # - linux-clang4-sanitize-thread
+      # - linux-gcc4.9-debug
+      # - linux-gcc5-debug-coverage
+      # - linux-gcc5-release-qt4
+      # - linux-gcc5-release-qt5
       - ios-debug
-      - ios-sanitize
+      # - ios-sanitize
       #- ios-sanitize-address
-      - ios-static-analyzer
-      - ios-release:
-          filters:
-            tags:
-              only: /ios-.*/
-            branches:
-              ignore: /.*/
-      - macos-debug
-      - macos-debug-qt5
-      - macos-release-node4:
-          filters:
-            tags:
-              only: /node-.*/
-      - macos-release-node6:
-          filters:
-            tags:
-              only: /node-.*/
+      # - ios-static-analyzer
+      # - ios-release:
+      #     filters:
+      #       tags:
+      #         only: /ios-.*/
+      #       branches:
+      #         ignore: /.*/
+      # - macos-debug
+      # - macos-debug-qt5
+      # - macos-release-node4:
+      #     filters:
+      #       tags:
+      #         only: /node-.*/
+      # - macos-release-node6:
+      #     filters:
+      #       tags:
+      #         only: /node-.*/
 
 step-library:
   - &generate-cache-key

--- a/cmake/mbgl.cmake
+++ b/cmake/mbgl.cmake
@@ -70,6 +70,24 @@ if(WITH_NODEJS)
     )
 endif()
 
+# Run gem bundle install
+if(MBGL_PLATFORM STREQUAL "ios" OR MBGL_PLATFORM STREQUAL "macos")
+    SET(BUNDLE_INSTALL_FAILED FALSE)
+    SET(BUNDLE_INSTALL_PATH "./gems")
+    if("Gemfile" IS_NEWER_THAN "${BUNDLE_INSTALL_PATH}/.stamp")
+        message(STATUS "Running 'bundle install'...")
+        execute_process(
+            COMMAND bundle install --path=${BUNDLE_INSTALL_PATH}
+            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+            RESULT_VARIABLE BUNDLE_INSTALL_FAILED)
+        if(NOT BUNDLE_INSTALL_FAILED)
+            execute_process(
+                COMMAND touch "${BUNDLE_INSTALL_PATH}/.stamp"
+                WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+        endif()
+    endif()
+endif()
+
 # Generate source groups so the files are properly sorted in IDEs like Xcode.
 function(create_source_groups target)
     get_target_property(sources ${target} SOURCES)

--- a/platform/ios/scripts/document.sh
+++ b/platform/ios/scripts/document.sh
@@ -6,7 +6,7 @@ set -u
 
 if [ -z `which jazzy` ]; then
     echo "Installing jazzy…"
-    gem install jazzy --no-rdoc --no-ri
+    gem install jazzy --no-document
     if [ -z `which jazzy` ]; then
         echo "Unable to install jazzy. See https://github.com/mapbox/mapbox-gl-native/blob/master/platform/ios/INSTALL.md"
         exit 1

--- a/platform/ios/scripts/document.sh
+++ b/platform/ios/scripts/document.sh
@@ -4,9 +4,13 @@ set -e
 set -o pipefail
 set -u
 
-# Install jazzy (and other dependencies), if not already installed.
-if [ ! -d "./gems" ]; then
-    bundle install --path=./gems
+if [ -z `which jazzy` ]; then
+    echo "Installing jazzy…"
+    gem install jazzy --no-rdoc --no-ri
+    if [ -z `which jazzy` ]; then
+        echo "Unable to install jazzy. See https://github.com/mapbox/mapbox-gl-native/blob/master/platform/ios/INSTALL.md"
+        exit 1
+    fi
 fi
 
 OUTPUT=${OUTPUT:-documentation}
@@ -32,7 +36,7 @@ cp -r platform/ios/docs/img "${OUTPUT}"
 DEFAULT_THEME="platform/darwin/docs/theme"
 THEME=${JAZZY_THEME:-$DEFAULT_THEME}
 
-bundle exec jazzy \
+jazzy \
     --config platform/ios/jazzy.yml \
     --sdk iphonesimulator \
     --github-file-prefix https://github.com/mapbox/mapbox-gl-native/tree/${BRANCH} \

--- a/platform/ios/scripts/document.sh
+++ b/platform/ios/scripts/document.sh
@@ -4,13 +4,9 @@ set -e
 set -o pipefail
 set -u
 
-if [ -z `which jazzy` ]; then
-    echo "Installing jazzy…"
-    gem install jazzy --no-document
-    if [ -z `which jazzy` ]; then
-        echo "Unable to install jazzy. See https://github.com/mapbox/mapbox-gl-native/blob/master/platform/ios/INSTALL.md"
-        exit 1
-    fi
+# Install jazzy (and other dependencies), if not already installed.
+if [ ! -d "./gems" ]; then
+    bundle install --path=./gems
 fi
 
 OUTPUT=${OUTPUT:-documentation}
@@ -36,7 +32,7 @@ cp -r platform/ios/docs/img "${OUTPUT}"
 DEFAULT_THEME="platform/darwin/docs/theme"
 THEME=${JAZZY_THEME:-$DEFAULT_THEME}
 
-jazzy \
+bundle exec jazzy \
     --config platform/ios/jazzy.yml \
     --sdk iphonesimulator \
     --github-file-prefix https://github.com/mapbox/mapbox-gl-native/tree/${BRANCH} \


### PR DESCRIPTION
- Runs tests with multiple concurrent simulators across all supported iOS versions. Fixes #10708.
  - Tests currently fail on iOS <11 — will address those here before merging.
  - Installs a forked xcpretty (https://github.com/technology-ebay-de/xcpretty/commit/2b681274dbdef611374d70118cdf4170fae3d55b) that partially fixes https://github.com/supermarin/xcpretty/issues/295, a bug preventing test results from appearing when multiple simulators are in use.
- ~Adds `make ios-static-analyzer` and runs it on CircleCI. Fixes #1549.~
- ~Adds `make ios-sanitize` with thread sanitizer and [undefined behavior sanitizer](https://developer.apple.com/documentation/code_diagnostics/undefined_behavior_sanitizer).~
  - ~Replaces `make ios-sanitize-thread`.~
- ~Address sanitizer tests (`make ios-sanitize-address`) are still disabled, waiting on a fix for #10741.~

/cc @akitchen @1ec5 @fabian-guerra 