### PR TITLE
[build] Forgot to update CI image to linux-clang-3.8-libcxx

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -450,7 +450,7 @@ jobs:
 # ------------------------------------------------------------------------------
   linux-clang-3.8-libcxx-debug:
     docker:
-      - image: mbgl/7d2403f42e:linux-clang-3.9
+      - image: mbgl/7d2403f42e:linux-clang-3.8-libcxx
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 4
@@ -464,11 +464,8 @@ jobs:
       - *restore-cache
       - *reset-ccache-stats
       - *build-linux
-      - *build-benchmark
-      - *build-test
       - *show-ccache-stats
       - *save-cache
-      - *run-unit-tests
 
 # ------------------------------------------------------------------------------
   linux-clang4-sanitize-address:


### PR DESCRIPTION
When rebasing patches in https://github.com/mapbox/mapbox-gl-native/pull/10653, the `linux-clang-3.8-libcxx-debug` CI job docker image ended up unchanged. Clang 3.8 does not properly link with GCC-originated `benchmark` and `gtest`, giving errors like:
```
undefined reference to `std::ios_base::Init::Init()'
```

I've tried compiling `benchmark` using C++11 ABI w/o success (same goes for gtest). This is the reason why I ended up removing these steps from the build - as the most important aspect of this CI job, is to have the core source built anyways.