### PR TITLE
[android] Tweak TinySDF docs to better describe font-family behavior.

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
@@ -725,8 +725,11 @@ public class MapboxMapOptions implements Parcelable {
   }
 
   /**
-   * Set the font-family for generating glyphs locally for ideographs in the ‘CJK Unified Ideographs’
+   * Set the font family for generating glyphs locally for ideographs in the ‘CJK Unified Ideographs’
    * and ‘Hangul Syllables’ ranges.
+   *
+   * The font family argument is passed to {@link android.graphics.Typeface#create(String, int)}.
+   * Default system fonts are defined in '/system/etc/fonts.xml'
    *
    * @param fontFamily font family for local ideograph generation.
    * @return This

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/text/LocalGlyphRasterizer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/text/LocalGlyphRasterizer.java
@@ -14,14 +14,14 @@ public class LocalGlyphRasterizer {
 
   /***
    * Uses Android-native drawing code to rasterize a single glyph
-   * to a square @{link Bitmap} which can be returned to portable
+   * to a square {@link Bitmap} which can be returned to portable
    * code for transformation into a Signed Distance Field glyph.
    *
    * @param fontFamily Font family string to pass to Typeface.create
    * @param bold If true, use Typeface.BOLD option
    * @param glyphID 16-bit Unicode BMP codepoint to draw
    *
-   * @return Return a @{link Bitmap} to be displayed in the requested tile.
+   * @return Return a {@link Bitmap} to be displayed in the requested tile.
    */
   @WorkerThread
   protected static Bitmap drawGlyphBitmap(String fontFamily, boolean bold, char glyphID) {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_local_glyph.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_local_glyph.xml
@@ -12,6 +12,6 @@
         android:id="@id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:mapbox_localIdeographFontFamily="Droid Sans" />
+        app:mapbox_localIdeographFontFamily="sans-serif" />
 
 </LinearLayout>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
@@ -67,5 +67,5 @@
     <string name="description_textureview_debug">Use TextureView to render the map</string>
     <string name="description_textureview_resize">Resize a map rendered on a TextureView</string>
     <string name="description_textureview_animate">Animate a map rendered on a TextureView</string>
-    <string name="description_local_glyph">Suzhou using Droid Sans for Chinese glyphs</string>
+    <string name="description_local_glyph">Suzhou using local sans-serif for Chinese glyphs</string>
 </resources>


### PR DESCRIPTION
Added reference to `/system/etc/fonts.xml` to javadoc, to better explain what the font-family parameter actually does. Stop using "Droid Sans" in the test example because it was misleading -- it wasn't actually in the default font list for any of the devices we had, so instead it was loading the default font. Instead, we use "sans-serif", which will probably load the same font, but using the right nomenclature.

Also fix to broken javadoc links to Bitmap.

/cc @lilykaiser @zugaldia @ivovandongen @Guardiola31337 