### PR TITLE
Release Android v5.3.0-cn.1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -355,7 +355,7 @@ jobs:
       - deploy:
           name: Publish to Maven
           command: |
-            if [ "${CIRCLE_BRANCH}" == "release-agua" ]; then make run-android-upload-archives ; fi
+            if [ "${CIRCLE_BRANCH}" == "release-android-v5.3.0-cn.1" ]; then make run-android-upload-archives ; fi
 
 
 # ------------------------------------------------------------------------------

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Mapbox welcomes participation and contributions from everyone.  If you'd like to do so please see the [`Contributing Guide`](https://github.com/mapbox/mapbox-gl-native/blob/master/CONTRIBUTING.md) first to get started.
 
+## 5.3.0-cn.1 - December 20, 2017
+ - Enable CN endpoint [#10758](https://github.com/mapbox/mapbox-gl-native/pull/10758)
+
 ## 5.3.0 - December 20, 2017
  - Add support for TinySDF [#10706](https://github.com/mapbox/mapbox-gl-native/pull/10706)
  - Save restore MyLocationViewSettings [#10746](https://github.com/mapbox/mapbox-gl-native/pull/10746) 

--- a/platform/android/MapboxGLAndroidSDK/gradle.properties
+++ b/platform/android/MapboxGLAndroidSDK/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.mapbox.mapboxsdk
-VERSION_NAME=5.3.0-SNAPSHOT
+VERSION_NAME=5.3.0-cn.1
 
 POM_DESCRIPTION=Mapbox GL Android SDK
 POM_URL=https://github.com/mapbox/mapbox-gl-native

--- a/platform/android/MapboxGLAndroidSDK/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/AndroidManifest.xml
@@ -17,4 +17,9 @@
         <service android:name="com.mapbox.services.android.telemetry.service.TelemetryService"/>
     </application>
 
+    <!-- Enable the CN endpoint -->
+    <meta-data
+        android:name="com.mapbox.CnEventsServer"
+        android:value="true"/>
+
 </manifest>


### PR DESCRIPTION
Follow up from https://github.com/mapbox/mapbox-gl-native/pull/10758, contains same changes as with cn release in https://github.com/mapbox/mapbox-gl-native/pull/10520.