### PR TITLE
Getting bitmap from drawable fix

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/BitmapUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/BitmapUtils.java
@@ -54,13 +54,25 @@ public class BitmapUtils {
 
   /**
    * Extract an underlying bitmap from a drawable
-   * @param drawable The source drawable
+   *
+   * @param sourceDrawable The source drawable
    * @return The underlying bitmap
    */
-  public static Bitmap getBitmapFromDrawable(Drawable drawable) {
-    if (drawable instanceof BitmapDrawable) {
-      return ((BitmapDrawable) drawable).getBitmap();
+  public static Bitmap getBitmapFromDrawable(Drawable sourceDrawable) {
+    if (sourceDrawable == null) {
+      return null;
+    }
+
+    if (sourceDrawable instanceof BitmapDrawable) {
+      return ((BitmapDrawable) sourceDrawable).getBitmap();
     } else {
+      //copying drawable object to not manipulate on the same reference
+      Drawable.ConstantState constantState = sourceDrawable.getConstantState();
+      if (constantState == null) {
+        return null;
+      }
+      Drawable drawable = constantState.newDrawable().mutate();
+
       Bitmap bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(),
         Bitmap.Config.ARGB_8888);
       Canvas canvas = new Canvas(bitmap);
@@ -72,6 +84,7 @@ public class BitmapUtils {
 
   /**
    * Create a byte array out of drawable
+   *
    * @param drawable The source drawable
    * @return The byte array of source drawable
    */
@@ -79,7 +92,11 @@ public class BitmapUtils {
     if (drawable == null) {
       return null;
     }
+
     Bitmap bitmap = getBitmapFromDrawable(drawable);
+    if (bitmap == null) {
+      return null;
+    }
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
     bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
     return stream.toByteArray();
@@ -87,8 +104,9 @@ public class BitmapUtils {
 
   /**
    * Decode byte array to drawable object
+   *
    * @param context Context to obtain {@link android.content.res.Resources}
-   * @param array The source byte array
+   * @param array   The source byte array
    * @return The drawable created from source byte array
    */
   public static Drawable getDrawableFromByteArray(Context context, byte[] array) {


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/10761.

When getting `Bitmap` from `Drawable`, that's not `BitmapDrawable`, we were manipulating this `Drawable` object's bounds [here](https://github.com/mapbox/mapbox-gl-native/blob/de5357c95f1158d610a958bb0d40029fc73629d7/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/BitmapUtils.java#L67). This occurred when `onSaveInstanceState` was called and was overwritten again in favor of right values in `OnRestoreInstanceState`. However, above issue was present because when we minimize the app activity's `onSaveInstanceState` is called, but `OnCreate` is not, which results in SDK's `OnRestoreInstanceState` not being called.

Anyway, using copied `Drawable` to draw on canvas resolves the issue. 