### PR TITLE
Fix CustomLayer context retain count

### DIFF
--- a/platform/darwin/src/MGLOpenGLStyleLayer.mm
+++ b/platform/darwin/src/MGLOpenGLStyleLayer.mm
@@ -47,7 +47,7 @@ void MGLDrawCustomStyleLayer(void *context, const mbgl::style::CustomLayerRender
     when creating an OpenGL style layer.
  */
 void MGLFinishCustomStyleLayer(void *context) {
-    MGLOpenGLStyleLayer *layer = (__bridge MGLOpenGLStyleLayer *)context;
+    MGLOpenGLStyleLayer *layer = (__bridge_transfer MGLOpenGLStyleLayer *)context;
     [layer willMoveFromMapView:layer.style.mapView];
 }
 
@@ -101,7 +101,7 @@ void MGLFinishCustomStyleLayer(void *context) {
                                                             MGLPrepareCustomStyleLayer,
                                                             MGLDrawCustomStyleLayer,
                                                             MGLFinishCustomStyleLayer,
-                                                            (__bridge void *)self);
+                                                            (__bridge_retained void *)self);
     return self = [super initWithPendingLayer:std::move(layer)];
 }
 
@@ -116,9 +116,7 @@ void MGLFinishCustomStyleLayer(void *context) {
         [NSException raise:@"MGLLayerReuseException"
                     format:@"%@ cannot be added to more than one MGLStyle at a time.", self];
     }
-    _style.openGLLayers[self.identifier] = nil;
     _style = style;
-    _style.openGLLayers[self.identifier] = self;
 }
 
 - (void)addToStyle:(MGLStyle *)style belowLayer:(MGLStyleLayer *)otherLayer {

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -77,7 +77,6 @@
 @property (nonatomic, readonly, weak) MGLMapView *mapView;
 @property (nonatomic, readonly) mbgl::style::Style *rawStyle;
 @property (readonly, copy, nullable) NSURL *URL;
-@property (nonatomic, readwrite, strong) NS_MUTABLE_DICTIONARY_OF(NSString *, MGLOpenGLStyleLayer *) *openGLLayers;
 @property (nonatomic) NS_MUTABLE_DICTIONARY_OF(NSString *, NS_DICTIONARY_OF(NSObject *, MGLTextLanguage *) *) *localizedLayersByIdentifier;
 
 @end
@@ -169,7 +168,6 @@ static NSURL *MGLStyleURL_trafficNight;
     if (self = [super init]) {
         _mapView = mapView;
         _rawStyle = rawStyle;
-        _openGLLayers = [NSMutableDictionary dictionary];
         _localizedLayersByIdentifier = [NSMutableDictionary dictionary];
     }
     return self;

--- a/platform/darwin/src/MGLStyle_Private.h
+++ b/platform/darwin/src/MGLStyle_Private.h
@@ -26,8 +26,6 @@ namespace mbgl {
 
 - (nullable NS_ARRAY_OF(MGLAttributionInfo *) *)attributionInfosWithFontSize:(CGFloat)fontSize linkColor:(nullable MGLColor *)linkColor;
 
-@property (nonatomic, readonly, strong) NS_MUTABLE_DICTIONARY_OF(NSString *, MGLOpenGLStyleLayer *) *openGLLayers;
-
 - (void)setStyleClasses:(NS_ARRAY_OF(NSString *) *)appliedClasses transitionDuration:(NSTimeInterval)transitionDuration;
 
 @end

--- a/src/mbgl/renderer/layers/render_custom_layer.hpp
+++ b/src/mbgl/renderer/layers/render_custom_layer.hpp
@@ -26,6 +26,7 @@ public:
 private:
     bool initialized = false;
     bool contextDestroyed = false;
+    void * context = nullptr;
 };
 
 template <>


### PR DESCRIPTION
Fixes #10755 

In core, with style diffing a `RenderCustomLayer` instance is reused if the new style has a `CustomLayer` with the same identifier as the previous style. This was not handled correctly in `RenderCustomLayer`. When the `impl` or `context` for the layer is changed, it should invoke the `CustomLayerDeinitializeFunction` callback.

Changes to core GL for asynchronous rendering changed when the `mbgl::style::CustomLayer`'s `CustomLayerDeinitializeFunction` callback method is invoked. This resulted in the `MGLOpenGLStyleLayer` releasing itself early when removed from the owning style:

https://github.com/mapbox/mapbox-gl-native/blob/920057c9d6285fc30f4155a505e2bf15143e3842/platform/darwin/src/MGLOpenGLStyleLayer.mm#L114-L121

When `MGLFinishCustomStyleLayer` is called on a subsequent frame, it is left holding on to a dangling pointer to the layer.

To remedy this, the layer retention needs to match the lifecycle required by the async renderer. Using `__bridge_retain` implicitly retains the bridged pointer passed to core. This should be the correct behavior since we are not using a weak pointer. When `MGLFinishCustomStyleLayer` takes back ownership of the pointer from core and uses `__bridge_transfer`. 

Apple docs for [Toll-Free Bridged Types](https://developer.apple.com/library/content/documentation/CoreFoundation/Conceptual/CFDesignConcepts/Articles/tollFreeBridgedTypes.html) 

//cc @lilykaiser @jmkiley @jfirebaugh @1ec5 