### PR TITLE
[ios, build] Stop packaging i386 simulator arch

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## 3.7.2
+
+* Removed support for 32-bit simulators. ([#10772](https://github.com/mapbox/mapbox-gl-native/pull/10772))
+
 ## 3.7.1 - December 6, 2017
 
 ### Annotations
+
 * Fixed an issue that could cause `-[MGLMapViewDelegate mapView:didSelectAnnotation:]` to be triggered when tapping next to an `MGLAnnotationImage` annotation. ([#10538](https://github.com/mapbox/mapbox-gl-native/pull/10538))
 
 ### Packaging

--- a/platform/ios/INSTALL.md
+++ b/platform/ios/INSTALL.md
@@ -4,11 +4,13 @@ This document explains how to build a development version of Mapbox Maps SDK for
 
 ### Requirements
 
-The Mapbox Maps SDK for iOS is intended to run on iOS 8.0 and above on the following devices and their simulators:
+The Mapbox Maps SDK for iOS is intended to run on iOS 8.0 and above on the following devices:
 
-* iPhone 4S and above (5, 5c, 5s, 6, 6 Plus)
-* iPad 2 and above (3, 4, Mini, Air, Mini 2, Air 2)
+* iPhone 4s and above (5, 5c, 5s, 6, 6 Plus, 7, 7 Plus, 8, 8 Plus, X)
+* iPad 2 and above (3, 4, Mini, Air, Mini 2, Air 2, Pro)
 * iPod touch 5th generation and above
+
+Note that 32-bit simulators (such as the iPhone 5 or iPad 2) are not supported.
 
 The Mapbox Maps SDK for iOS requires Xcode 8.0 or higher. To use this SDK with Xcode 7.3.1, download and use a symbols build from the [releases](https://github.com/mapbox/mapbox-gl-native/releases) page.
 

--- a/platform/ios/scripts/metrics.sh
+++ b/platform/ios/scripts/metrics.sh
@@ -7,13 +7,11 @@ set -o pipefail
 xcrun bitcode_strip build/ios/pkg/dynamic/Mapbox.framework/Mapbox -r -o  build/ios/pkg/dynamic/Mapbox-stripped
 lipo build/ios/pkg/dynamic/Mapbox-stripped -extract armv7 -output build/ios/pkg/dynamic/Mapbox-stripped-armv7
 lipo build/ios/pkg/dynamic/Mapbox-stripped -extract arm64 -output build/ios/pkg/dynamic/Mapbox-stripped-arm64
-lipo build/ios/pkg/dynamic/Mapbox-stripped -extract i386 -output build/ios/pkg/dynamic/Mapbox-stripped-i386
 lipo build/ios/pkg/dynamic/Mapbox-stripped -extract x86_64 -output build/ios/pkg/dynamic/Mapbox-stripped-x86_64
 
 # Track individual architectures
 scripts/log_binary_size.sh "build/ios/pkg/dynamic/Mapbox-stripped-armv7"   "Platform=iOS,Arch=armv7"
 scripts/log_binary_size.sh "build/ios/pkg/dynamic/Mapbox-stripped-arm64"   "Platform=iOS,Arch=arm64"
-scripts/log_binary_size.sh "build/ios/pkg/dynamic/Mapbox-stripped-i386"    "Platform=iOS,Arch=i386"
 scripts/log_binary_size.sh "build/ios/pkg/dynamic/Mapbox-stripped-x86_64"  "Platform=iOS,Arch=x86_64"
 
 # Track overall library size

--- a/platform/ios/scripts/package.sh
+++ b/platform/ios/scripts/package.sh
@@ -70,7 +70,7 @@ xcodebuild \
     CURRENT_SHORT_VERSION=${SHORT_VERSION} \
     CURRENT_SEMANTIC_VERSION=${SEM_VERSION} \
     CURRENT_COMMIT_HASH=${HASH} \
-    ONLY_ACTIVE_ARCH=NO \
+    ARCHS="x86_64" \
     -derivedDataPath ${DERIVED_DATA} \
     -workspace ./platform/ios/ios.xcworkspace \
     -scheme ${SCHEME} \

--- a/platform/ios/scripts/validate-framework-zip.sh
+++ b/platform/ios/scripts/validate-framework-zip.sh
@@ -54,7 +54,7 @@ function verifyFramework() {
 
 	# Verify the static lib at least has simulator and the two common ARM architectures
 	local PRESENT_ARCHITECTURES=$( xcrun lipo -info "${BINARY_PATH}" )
-	for arch in "armv7" "arm64" "i386" "x86_64"; do
+	for arch in "armv7" "arm64" "x86_64"; do
 		if [[ ! $PRESENT_ARCHITECTURES == *$arch* ]]; then
 			printf "ERROR: Architecture ${arch} not found in ${FRAMEWORK_NAME}\n";
 			exit 6;

--- a/scripts/publish_binary_size.sh
+++ b/scripts/publish_binary_size.sh
@@ -56,7 +56,6 @@ else
     # Upload all dimensions that we are tracking
     publish_binary_size "Platform=iOS,Arch=armv7"
     publish_binary_size "Platform=iOS,Arch=arm64"
-    publish_binary_size "Platform=iOS,Arch=i386"
     publish_binary_size "Platform=iOS,Arch=x86_64"
     publish_binary_size "Platform=iOS,Arch=Dynamic"
 


### PR DESCRIPTION
Removes support for 32-bit simulators (`i386`), such as the iPhone 5 and iPad 2. This does not affect device support — 32-bit devices are still supported via the `armv7` architecture.

This reduces the packaged size of our framework and dSYM by ~25%. This change does not affect the size of apps that integrate our SDK, as simulator architectures aren’t included in shipping apps.

For now, this does not change any Xcode project or mason settings, which allows iosapp to still run in 32-bit simulators. If you need to test using an older form factor using the packaged framework, try using the iPhone 5s, iPad Air, or iPad Mini 2 simulators.

/cc @1ec5 @akitchen @fabian-guerra 