### PR TITLE
Fix MGLMapSnapshotter test crash

### DIFF
--- a/platform/darwin/src/MGLImageSource.h
+++ b/platform/darwin/src/MGLImageSource.h
@@ -38,11 +38,8 @@ MGL_EXPORT
    bottomLeft: CLLocationCoordinate2D(latitude: 37.936, longitude: -80.425),
    bottomRight: CLLocationCoordinate2D(latitude: 37.936, longitude: -71.516),
    topRight: CLLocationCoordinate2D(latitude: 46.437, longitude: -71.516))
- let source = MGLImageSource(identifier: "radar-source", coordinateQuad: coordinates, url: URL(string: "https://www.mapbox.com/mapbox-gl-js/assets/radar.gif")!)
+ let source = MGLImageSource(identifier: "radar", coordinateQuad: coordinates, url: URL(string: "https://www.mapbox.com/mapbox-gl-js/assets/radar.gif")!)
  mapView.style?.addSource(source)
- 
- let layer = MGLRasterStyleLayer(identifier: "radar-layer", source: source)
- style.addLayer(layer)
  ```
  */
 MGL_EXPORT

--- a/platform/darwin/src/MGLMapSnapshotter.h
+++ b/platform/darwin/src/MGLMapSnapshotter.h
@@ -145,11 +145,11 @@ typedef void (^MGLMapSnapshotCompletionHandler)(MGLMapSnapshot* _Nullable snapsh
  
  let snapshotter = MGLMapSnapshotter(options: options)
  snapshotter.start { (snapshot, error) in
-     if error != nil {
-         // error handler
-     } else {
-         // image handler
+     if let error = error {
+         fatalError(error.localizedDescription)
      }
+     
+     image = snapshot?.image
  }
  ```
  */


### PR DESCRIPTION
Fixed a crash in MGLDocumentationExampleTests caused by an asynchronous snapshot call that the test wasn’t waiting on, compounded by the use of a style that requires an access token (as opposed to the `one-liner` style that uses no remote resources). Employed some weird-looking Swiftisms to fulfill expectations without making the example code look weird.

Running `make darwin-update-examples` also caught a change to the MGLImageSource example that wasn’t reflected in MGLImageSource.h.

Fixes #10641.

/cc @akitchen @friedbunny