### PR TITLE
[ios] Fix ornament constrains on iOS 10

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -747,7 +747,7 @@ public:
                                          toItem:viewController.topLayoutGuide
                                       attribute:NSLayoutAttributeBottom
                                      multiplier:1.0
-                                       constant:5.0 + self.contentInset.top]];
+                                       constant:5.0]];
     }
     [self.compassViewConstraints addObject:
      [NSLayoutConstraint constraintWithItem:self.compassView
@@ -757,6 +757,7 @@ public:
                                   attribute:NSLayoutAttributeTop
                                  multiplier:1.0
                                    constant:5.0 + self.contentInset.top]];
+    
     [self.compassViewConstraints addObject:
      [NSLayoutConstraint constraintWithItem:self
                                   attribute:NSLayoutAttributeTrailing
@@ -781,7 +782,7 @@ public:
                                          toItem:viewController.topLayoutGuide
                                       attribute:NSLayoutAttributeBottom
                                      multiplier:1.0
-                                       constant:5.0 + self.contentInset.top]];
+                                       constant:5.0]];
     }
     [self.scaleBarConstraints addObject:
      [NSLayoutConstraint constraintWithItem:self.scaleBar


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/10773

https://github.com/mapbox/mapbox-gl-native/blob/8e69a35d758d4fa632ed153590ae56c976269b76/platform/ios/src/MGLMapView.mm#L743-L750

`constant:5.0 + self.contentInset.top` caused add twice the navigation bar height. 