### PR TITLE
[ios] Re-add i386 slice to framework; strip from dSYM

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,7 +4,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ## 3.7.2
 
-* Removed support for 32-bit simulators. ([#10772](https://github.com/mapbox/mapbox-gl-native/pull/10772))
+* Reduced the file size of the dSYM by removing the i386 architecture. Support for the i386 architecture (used by 32-bit simulators) will also be removed from the framework itself in a future release. ([#10781](https://github.com/mapbox/mapbox-gl-native/pull/10781))
 
 ## 3.7.1 - December 6, 2017
 

--- a/platform/ios/INSTALL.md
+++ b/platform/ios/INSTALL.md
@@ -10,7 +10,7 @@ The Mapbox Maps SDK for iOS is intended to run on iOS 8.0 and above on the follo
 * iPad 2 and above (3, 4, Mini, Air, Mini 2, Air 2, Pro)
 * iPod touch 5th generation and above
 
-Note that 32-bit simulators (such as the iPhone 5 or iPad 2) are not supported.
+Note that debugging in 32-bit simulators (such as the iPhone 5 or iPad 2) is only partially supported. Support for these simulators will be removed entirely in a future release of this SDK.
 
 The Mapbox Maps SDK for iOS requires Xcode 8.0 or higher. To use this SDK with Xcode 7.3.1, download and use a symbols build from the [releases](https://github.com/mapbox/mapbox-gl-native/releases) page.
 

--- a/platform/ios/scripts/package.sh
+++ b/platform/ios/scripts/package.sh
@@ -70,7 +70,7 @@ xcodebuild \
     CURRENT_SHORT_VERSION=${SHORT_VERSION} \
     CURRENT_SEMANTIC_VERSION=${SEM_VERSION} \
     CURRENT_COMMIT_HASH=${HASH} \
-    ARCHS="x86_64" \
+    ONLY_ACTIVE_ARCH=NO \
     -derivedDataPath ${DERIVED_DATA} \
     -workspace ./platform/ios/ios.xcworkspace \
     -scheme ${SCHEME} \
@@ -194,6 +194,11 @@ if [[ ${BUILD_DYNAMIC} == true && ${BUILDTYPE} == Release ]]; then
     validate_dsym \
         "${OUTPUT}/dynamic/${NAME}.framework.dSYM/Contents/Resources/DWARF/${NAME}" \
         "${OUTPUT}/dynamic/${NAME}.framework/${NAME}"
+
+        # To-do: remove this in 4.0.0, as we intend to remove support for i386 entirely.
+        step "Removing i386 slice from dSYM"
+        lipo -remove i386 "${OUTPUT}/dynamic/${NAME}.framework.dSYM/Contents/Resources/DWARF/${NAME}" -o "${OUTPUT}/dynamic/${NAME}.framework.dSYM/Contents/Resources/DWARF/${NAME}"
+        lipo -info "${OUTPUT}/dynamic/${NAME}.framework.dSYM/Contents/Resources/DWARF/${NAME}"
 fi
 
 function create_podspec {


### PR DESCRIPTION
Partially revert #10772, as removing i386 from the framework was deemed too breaking of a change for a semver minor release. This builds and adds i386 everywhere (as before), but later explicitly strips i386 from the dSYM to reduce its file size.

We’ll likely remove i386 entirely in the next semver major release of this SDK.

/cc @akitchen @fabian-guerra 