### PR TITLE
[core] Wrapped LatLng should be inclusive of min and max longitude.

### DIFF
--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <mbgl/math/clamp.hpp>
-#include <mbgl/math/wrap.hpp>
 #include <mbgl/util/constants.hpp>
 
 #include <mapbox/geometry/point.hpp>
@@ -53,8 +52,15 @@ public:
 
     LatLng wrapped() const { return { lat, lon, Wrapped }; }
 
+    double wrap (double value, double min, double max) {
+        const double d = max - min;
+        const double f = std::fmod(value - min, d);
+        const double s = std::fmod(f + d, d);
+        return value >= max && s == 0 ? max : s + min;
+    }
+
     void wrap() {
-        lon = util::wrap(lon, -util::LONGITUDE_MAX, util::LONGITUDE_MAX);
+        lon = wrap(lon, -util::LONGITUDE_MAX, util::LONGITUDE_MAX);
     }
 
     // If the distance from start to end longitudes is between half and full

--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -9,6 +9,7 @@
 #import <mbgl/util/default_thread_pool.hpp>
 #import <mbgl/util/string.hpp>
 #import <mbgl/util/shared_thread_pool.hpp>
+#import <mbgl/math/wrap.hpp>
 
 #import "MGLOfflineStorage_Private.h"
 #import "MGLGeometry_Private.h"

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -8,6 +8,7 @@
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/projection.hpp>
 #include <mbgl/math/clamp.hpp>
+#include <mbgl/math/wrap.hpp>
 #include <mbgl/util/logging.hpp>
 #include <mbgl/util/platform.hpp>
 

--- a/test/util/geo.test.cpp
+++ b/test/util/geo.test.cpp
@@ -170,6 +170,10 @@ TEST(LatLng, Boundaries) {
     coordinate.wrap();
     ASSERT_DOUBLE_EQ(179.90000000000001, coordinate.longitude()); // 1E-14
 
+    coordinate = LatLng(0, 180);
+    coordinate.wrap();
+    ASSERT_DOUBLE_EQ(180.0, coordinate.longitude());
+
     coordinate = LatLng(0, 180.9);
     coordinate.wrap();
     ASSERT_DOUBLE_EQ(-179.09999999999999, coordinate.longitude());


### PR DESCRIPTION
Core equivalent of #10769.

`mbgl::util::wrap(value, min, max)` wraps `value`, inclusive of `min`, but exclusive of `max`. For `LatLng`,  latitudes that are positive multiples of `+180.0` should not be wrapped to `-180.0`. 

//cc @osana 