### PR TITLE
Add Projection matrix to the CustomLayer render parameters

### DIFF
--- a/include/mbgl/style/layers/custom_layer.hpp
+++ b/include/mbgl/style/layers/custom_layer.hpp
@@ -2,6 +2,8 @@
 
 #include <mbgl/style/layer.hpp>
 
+#include <array>
+
 namespace mbgl {
 namespace style {
 
@@ -17,6 +19,7 @@ struct CustomLayerRenderParameters {
     double bearing;
     double pitch;
     double fieldOfView;
+    std::array<double, 16> projectionMatrix;
 };
 
 class CustomLayerHost {

--- a/platform/darwin/src/MGLGeometry.h
+++ b/platform/darwin/src/MGLGeometry.h
@@ -14,6 +14,16 @@ typedef struct __attribute__((objc_boxable)) MGLCoordinateSpan {
     CLLocationDegrees longitudeDelta;
 } MGLCoordinateSpan;
 
+/* Defines a point on the map in Mercator projection for a specific zoom level. */
+typedef struct __attribute__((objc_boxable)) MGLMapPoint {
+    /** X coordinate representing a longitude in Mercator projection. */
+    CGFloat x;
+    /** Y coordinate representing  a latitide in Mercator projection. */
+    CGFloat y;
+    /** Zoom level at which the X and Y coordinates are valid. */
+    CGFloat zoomLevel;
+} MGLMapPoint;
+
 /**
  Creates a new `MGLCoordinateSpan` from the given latitudinal and longitudinal
  deltas.
@@ -180,5 +190,8 @@ NS_INLINE CGFloat MGLRadiansFromDegrees(CLLocationDegrees degrees) {
 NS_INLINE CLLocationDegrees MGLDegreesFromRadians(CGFloat radians) {
     return radians * 180 / M_PI;
 }
+
+/** Returns Mercator projection of a WGS84 coordinate at the specified zoom level. */
+extern MGL_EXPORT MGLMapPoint MGLMapPointMake(CLLocationCoordinate2D coordinate, double zoomLevel);
 
 NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLGeometry.mm
+++ b/platform/darwin/src/MGLGeometry.mm
@@ -106,3 +106,12 @@ CGPoint MGLPointRounded(CGPoint point) {
 #endif
     return CGPointMake(round(point.x * scaleFactor) / scaleFactor, round(point.y * scaleFactor) / scaleFactor);
 }
+
+MGLMapPoint MGLMapPointMake(CLLocationCoordinate2D coordinate, double zoomLevel) {
+    mbgl::Point<double> projectedCoordinate = mbgl::Projection::project(MGLLatLngFromLocationCoordinate2D(coordinate), std::pow(2.0, zoomLevel));
+    MGLMapPoint point;
+    point.x = projectedCoordinate.x;
+    point.y = projectedCoordinate.y;
+    point.zoomLevel = zoomLevel;
+    return point;
+}

--- a/platform/darwin/src/MGLOpenGLStyleLayer.h
+++ b/platform/darwin/src/MGLOpenGLStyleLayer.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <CoreLocation/CoreLocation.h>
+#import <QuartzCore/QuartzCore.h>
 
 #import "MGLFoundation.h"
 #import "MGLStyleValue.h"
@@ -17,6 +18,7 @@ typedef struct MGLStyleLayerDrawingContext {
     CLLocationDirection direction;
     CGFloat pitch;
     CGFloat fieldOfView;
+    CATransform3D projectionMatrix;
 } MGLStyleLayerDrawingContext;
 
 MGL_EXPORT

--- a/platform/darwin/src/MGLOpenGLStyleLayer.mm
+++ b/platform/darwin/src/MGLOpenGLStyleLayer.mm
@@ -7,6 +7,17 @@
 #include <mbgl/style/layers/custom_layer.hpp>
 #include <mbgl/math/wrap.hpp>
 
+
+CATransform3D CATransform3DMake(std::array<double, 16> array) {
+    CATransform3D t = {
+        .m11 = array[0], .m12 = array[1], .m13 = array[2], .m14 = array[3],
+        .m21 = array[4], .m22 = array[5], .m23 = array[6], .m24 = array[7],
+        .m31 = array[8], .m32 = array[9], .m33 = array[10], .m34 = array[11],
+        .m41 = array[12], .m42 = array[13], .m43 = array[14], .m44 = array[15]
+    };
+    return t;
+}
+
 class MGLOpenGLLayerHost : public mbgl::style::CustomLayerHost {
 public:
     MGLOpenGLLayerHost(MGLOpenGLStyleLayer *styleLayer) {
@@ -31,6 +42,7 @@ public:
             .direction = mbgl::util::wrap(params.bearing, 0., 360.),
             .pitch = static_cast<CGFloat>(params.pitch),
             .fieldOfView = static_cast<CGFloat>(params.fieldOfView),
+            .projectionMatrix = CATransform3DMake(params.projectionMatrix)
         };
         [layer drawInMapView:layer.style.mapView withContext:drawingContext];
     }

--- a/platform/darwin/src/NSValue+MGLAdditions.h
+++ b/platform/darwin/src/NSValue+MGLAdditions.h
@@ -29,6 +29,19 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly) CLLocationCoordinate2D MGLCoordinateValue;
 
 /**
+ Creates a new value object containing the specified Mapbox map point structure.
+
+ @param point The value for the new object.
+ @return A new value object that contains the coordinate and zoom level information.
+ */
++ (instancetype)valueWithMGLMapPoint:(MGLMapPoint)point;
+
+/**
+ The Mapbox map point structure representation of the value.
+ */
+@property (readonly) MGLMapPoint MGLMapPointValue;
+
+/**
  Creates a new value object containing the specified Mapbox coordinate span
  structure.
 

--- a/platform/darwin/src/NSValue+MGLAdditions.m
+++ b/platform/darwin/src/NSValue+MGLAdditions.m
@@ -14,6 +14,16 @@
     return coordinate;
 }
 
++ (instancetype)valueWithMGLMapPoint:(MGLMapPoint)point {
+    return [self valueWithBytes:&point objCType:@encode(MGLMapPoint)];
+}
+
+-(MGLMapPoint) MGLMapPointValue {
+    MGLMapPoint point;
+    [self getValue:&point];
+    return point;
+}
+
 + (instancetype)valueWithMGLCoordinateSpan:(MGLCoordinateSpan)span {
     return [self valueWithBytes:&span objCType:@encode(MGLCoordinateSpan)];
 }

--- a/platform/darwin/test/MGLGeometryTests.mm
+++ b/platform/darwin/test/MGLGeometryTests.mm
@@ -163,4 +163,13 @@
                           [NSValue valueWithMGLCoordinate:quad.bottomRight],
                           @"Quad bottom right should be computed correctly.");
 }
+
+- (void)testMGLMapPoint {
+    MGLMapPoint point = MGLMapPointMake(CLLocationCoordinate2DMake(37.936, -80.425), 0.0);
+    
+    MGLMapPoint roundTrippedPoint = [NSValue valueWithMGLMapPoint:point].MGLMapPointValue;
+    XCTAssertEqual(point.x, roundTrippedPoint.x);
+    XCTAssertEqual(point.y, roundTrippedPoint.y);
+    XCTAssertEqual(point.zoomLevel, roundTrippedPoint.zoomLevel);
+}
 @end

--- a/src/mbgl/renderer/layers/render_custom_layer.cpp
+++ b/src/mbgl/renderer/layers/render_custom_layer.cpp
@@ -6,6 +6,7 @@
 #include <mbgl/style/layers/custom_layer_impl.hpp>
 #include <mbgl/map/transform_state.hpp>
 #include <mbgl/gl/gl.hpp>
+#include <mbgl/util/mat4.hpp>
 
 namespace mbgl {
 
@@ -72,6 +73,9 @@ void RenderCustomLayer::render(PaintParameters& paintParameters, RenderSource*) 
     parameters.bearing = -state.getAngle() * util::RAD2DEG;
     parameters.pitch = state.getPitch();
     parameters.fieldOfView = state.getFieldOfView();
+    mat4 projMatrix;
+    state.getProjMatrix(projMatrix);
+    parameters.projectionMatrix = projMatrix;
 
     MBGL_CHECK_ERROR(host->render(parameters));
 


### PR DESCRIPTION
When working with `CustomLayer` or `MGLOpenGLStyleLayer` the render parameters do not include a projection matrix. While each point could be converted from `LatLng` to screen coordinates using `pixelForLatLng()`, this is inefficient for a large number of points and for points that are outside the screen bounds in pitched views. 

