### PR TITLE
Don't tie Annotation geometries to Map maxzoom

### DIFF
--- a/src/mbgl/annotation/annotation_manager.hpp
+++ b/src/mbgl/annotation/annotation_manager.hpp
@@ -28,8 +28,8 @@ public:
     AnnotationManager(style::Style&);
     ~AnnotationManager();
 
-    AnnotationID addAnnotation(const Annotation&, const uint8_t maxZoom);
-    bool updateAnnotation(const AnnotationID&, const Annotation&, const uint8_t maxZoom);
+    AnnotationID addAnnotation(const Annotation&);
+    bool updateAnnotation(const AnnotationID&, const Annotation&);
     void removeAnnotation(const AnnotationID&);
 
     void addImage(std::unique_ptr<style::Image>);
@@ -49,13 +49,13 @@ public:
     static const std::string ShapeLayerID;
 
 private:
-    void add(const AnnotationID&, const SymbolAnnotation&, const uint8_t);
-    void add(const AnnotationID&, const LineAnnotation&, const uint8_t);
-    void add(const AnnotationID&, const FillAnnotation&, const uint8_t);
+    void add(const AnnotationID&, const SymbolAnnotation&);
+    void add(const AnnotationID&, const LineAnnotation&);
+    void add(const AnnotationID&, const FillAnnotation&);
 
-    void update(const AnnotationID&, const SymbolAnnotation&, const uint8_t);
-    void update(const AnnotationID&, const LineAnnotation&, const uint8_t);
-    void update(const AnnotationID&, const FillAnnotation&, const uint8_t);
+    void update(const AnnotationID&, const SymbolAnnotation&);
+    void update(const AnnotationID&, const LineAnnotation&);
+    void update(const AnnotationID&, const FillAnnotation&);
 
     void remove(const AnnotationID&);
 

--- a/src/mbgl/annotation/fill_annotation_impl.cpp
+++ b/src/mbgl/annotation/fill_annotation_impl.cpp
@@ -7,8 +7,8 @@ namespace mbgl {
 
 using namespace style;
 
-FillAnnotationImpl::FillAnnotationImpl(AnnotationID id_, FillAnnotation annotation_, uint8_t maxZoom_)
-    : ShapeAnnotationImpl(id_, maxZoom_),
+FillAnnotationImpl::FillAnnotationImpl(AnnotationID id_, FillAnnotation annotation_)
+    : ShapeAnnotationImpl(id_),
       annotation(ShapeAnnotationGeometry::visit(annotation_.geometry, CloseShapeAnnotation{}), annotation_.opacity, annotation_.color, annotation_.outlineColor) {
 }
 

--- a/src/mbgl/annotation/fill_annotation_impl.hpp
+++ b/src/mbgl/annotation/fill_annotation_impl.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class FillAnnotationImpl : public ShapeAnnotationImpl {
 public:
-    FillAnnotationImpl(AnnotationID, FillAnnotation, uint8_t maxZoom);
+    FillAnnotationImpl(AnnotationID, FillAnnotation);
 
     void updateStyle(style::Style::Impl&) const final;
     const ShapeAnnotationGeometry& geometry() const final;

--- a/src/mbgl/annotation/line_annotation_impl.cpp
+++ b/src/mbgl/annotation/line_annotation_impl.cpp
@@ -7,8 +7,8 @@ namespace mbgl {
 
 using namespace style;
 
-LineAnnotationImpl::LineAnnotationImpl(AnnotationID id_, LineAnnotation annotation_, uint8_t maxZoom_)
-    : ShapeAnnotationImpl(id_, maxZoom_),
+LineAnnotationImpl::LineAnnotationImpl(AnnotationID id_, LineAnnotation annotation_)
+    : ShapeAnnotationImpl(id_),
       annotation(ShapeAnnotationGeometry::visit(annotation_.geometry, CloseShapeAnnotation{}), annotation_.opacity, annotation_.width, annotation_.color) {
 }
 

--- a/src/mbgl/annotation/line_annotation_impl.hpp
+++ b/src/mbgl/annotation/line_annotation_impl.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class LineAnnotationImpl : public ShapeAnnotationImpl {
 public:
-    LineAnnotationImpl(AnnotationID, LineAnnotation, uint8_t maxZoom);
+    LineAnnotationImpl(AnnotationID, LineAnnotation);
 
     void updateStyle(style::Style::Impl&) const final;
     const ShapeAnnotationGeometry& geometry() const final;

--- a/src/mbgl/annotation/shape_annotation_impl.cpp
+++ b/src/mbgl/annotation/shape_annotation_impl.cpp
@@ -13,9 +13,8 @@ namespace mbgl {
 using namespace style;
 namespace geojsonvt = mapbox::geojsonvt;
 
-ShapeAnnotationImpl::ShapeAnnotationImpl(const AnnotationID id_, const uint8_t maxZoom_)
+ShapeAnnotationImpl::ShapeAnnotationImpl(const AnnotationID id_)
     : id(id_),
-      maxZoom(maxZoom_),
       layerID(AnnotationManager::ShapeLayerID + util::toString(id)) {
 }
 
@@ -28,7 +27,9 @@ void ShapeAnnotationImpl::updateTileData(const CanonicalTileID& tileID, Annotati
             return Feature { std::move(geom) };
         }));
         mapbox::geojsonvt::Options options;
-        options.maxZoom = maxZoom;
+        // The annotation source is currently hard coded to maxzoom 16, so we're topping out at z16
+        // here as well.
+        options.maxZoom = 16;
         options.buffer = 255u;
         options.extent = util::EXTENT;
         options.tolerance = baseTolerance;

--- a/src/mbgl/annotation/shape_annotation_impl.hpp
+++ b/src/mbgl/annotation/shape_annotation_impl.hpp
@@ -17,7 +17,7 @@ class CanonicalTileID;
 
 class ShapeAnnotationImpl {
 public:
-    ShapeAnnotationImpl(const AnnotationID, const uint8_t maxZoom);
+    ShapeAnnotationImpl(const AnnotationID);
     virtual ~ShapeAnnotationImpl() = default;
 
     virtual void updateStyle(style::Style::Impl&) const = 0;
@@ -26,7 +26,6 @@ public:
     void updateTileData(const CanonicalTileID&, AnnotationTileData&);
 
     const AnnotationID id;
-    const uint8_t maxZoom;
     const std::string layerID;
     std::unique_ptr<mapbox::geojsonvt::GeoJSONVT> shapeTiler;
 };

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -676,13 +676,13 @@ double Map::getTopOffsetPixelsForAnnotationImage(const std::string& id) {
 }
 
 AnnotationID Map::addAnnotation(const Annotation& annotation) {
-    auto result = impl->annotationManager.addAnnotation(annotation, getMaxZoom());
+    auto result = impl->annotationManager.addAnnotation(annotation);
     impl->onUpdate();
     return result;
 }
 
 void Map::updateAnnotation(AnnotationID id, const Annotation& annotation) {
-    if (impl->annotationManager.updateAnnotation(id, annotation, getMaxZoom())) {
+    if (impl->annotationManager.updateAnnotation(id, annotation)) {
         impl->onUpdate();
     }
 }

--- a/test/api/annotations.test.cpp
+++ b/test/api/annotations.test.cpp
@@ -459,3 +459,19 @@ TEST(Annotations, DebugSparse) {
 
     test.checkRendering("debug_sparse");
 }
+
+TEST(Annotations, ChangeMaxZoom) {
+    AnnotationTest test;
+
+    LineString<double> line = {{ { 0, 0 }, { 45, 45 }, { 30, 0 } }};
+    LineAnnotation annotation { line };
+    annotation.color = Color::red();
+    annotation.width = { 5 };
+
+    test.map.setMaxZoom(6);
+    test.map.getStyle().loadJSON(util::read_file("test/fixtures/api/empty.json"));
+    test.map.addAnnotation(annotation);
+    test.map.setMaxZoom(14);
+    test.map.setZoom(test.map.getMaxZoom());
+    test.checkRendering("line_annotation_max_zoom");
+}


### PR DESCRIPTION
Instead, geometry generation via GeoJSONVT is now bound to the hardcoded limit of the annotation tile source https://github.com/mapbox/mapbox-gl-native/blob/28a21f3b0bb118224dcbe87b017ce74b7a7fab11/src/mbgl/annotation/render_annotation_source.cpp#L41-L43

Fixes https://github.com/mapbox/mapbox-gl-native/issues/10177