### PR TITLE
[ios] Update custom install docs for Xcode 9.1

### DIFF
--- a/platform/ios/DEVELOPING.md
+++ b/platform/ios/DEVELOPING.md
@@ -6,7 +6,7 @@ This document explains how to build the Mapbox Maps SDK for iOS from source. It 
 
 The Mapbox Maps SDK for iOS and iosapp demo application require iOS 8.0 or above.
 
-The Mapbox Maps SDK for iOS requires Xcode 8.0 or above.
+The Mapbox Maps SDK for iOS requires Xcode 9.1 or above to compile from source.
 
 ## Building the SDK
 
@@ -30,7 +30,7 @@ Before building, use the scheme picker button in the toolbar to change the schem
 * **static** builds the SDK as a static library and separate resource bundle.
 * **dynamic+static** is a combination of the **dynamic** and **static** schemes.
 
-If you don’t have an Apple Developer account, change the destination to a simulator such as “iPhone 6s” before you run and build the app.
+If you don’t have an Apple Developer account, change the destination to a simulator such as “iPhone 6s” before you build and run the app.
 
 ### Packaging builds
 
@@ -52,12 +52,12 @@ You can customize the build output by passing the following arguments into the `
 * `BUILDTYPE=Release` will optimize for distribution. Defaults to `Debug`.
 * `BUILD_DEVICE=false` builds only for the iOS Simulator.
 * `FORMAT=dynamic` builds only a dynamic framework. `FORMAT=static` builds only a static framework, for legacy compatibility.
-* `SYMBOLS=NO` strips the build output of any debug symbols, yielding much smaller binaries. Defaults to `YES`.
+* `SYMBOLS=NO` strips the build output of any debug symbols, yielding smaller binaries. Defaults to `YES`.
 
 An example command that creates a dynamic framework suitable for eventual App Store distribution:
 
 ```bash
-make iframework BUILDTYPE=Release SYMBOLS=NO
+make iframework BUILDTYPE=Release
 ```
 
 The products of these build commands can be found in the `build/ios/pkg` folder at the base of the repository.
@@ -168,5 +168,5 @@ The included applications use Mapbox vector tiles, which require a Mapbox accoun
 - Use two fingers to rotate
 - Double-tap to zoom in one level
 - Two-finger single-tap to zoom out one level
-- Double-tap, long-pressing the second, then pan up and down to "quick zoom" (iPhone only, meant for one-handed use)
+- Double-tap, long-pressing the second, then pan up and down to "quick zoom" (meant for one-handed use)
 - Use the debug menu to add test annotations, reset position, and cycle through the debug options.

--- a/platform/ios/INSTALL.md
+++ b/platform/ios/INSTALL.md
@@ -10,7 +10,10 @@ The Mapbox Maps SDK for iOS is intended to run on iOS 8.0 and above on the follo
 * iPad 2 and above (3, 4, Mini, Air, Mini 2, Air 2)
 * iPod touch 5th generation and above
 
-The Mapbox Maps SDK for iOS requires Xcode 8.0 or higher. To use this SDK with Xcode 7.3.1, download and use a symbols build from the [releases](https://github.com/mapbox/mapbox-gl-native/releases) page.
+The Mapbox Maps SDK for iOS requires:
+
+* Xcode 9.1 or higher to compile from source
+* Xcode 8.0 or higher to integrate the compiled framework into an application
 
 ### Building the SDK
 
@@ -22,9 +25,8 @@ The Mapbox Maps SDK for iOS requires Xcode 8.0 or higher. To use this SDK with X
    [sudo] gem install jazzy
    ```
 
-1. Run `make ipackage`. The packaging script will produce a `build/ios/pkg/` folder containing:
+1. Run `make iframework BUILDTYPE=Release`. The packaging script will produce a `build/ios/pkg/` folder containing:
   - a `dynamic` folder containing a dynamically-linked fat framework with debug symbols for devices and the iOS Simulator
-  - a `static` folder containing a statically-linked framework with debug symbols for devices and the iOS Simulator
   - a `documentation` folder with HTML API documentation
   - an example `Settings.bundle` containing an optional Mapbox Telemetry opt-out setting
 
@@ -58,7 +60,7 @@ A nightly build of the dynamic framework, based on the master branch, is availab
 
 You can alternatively install the SDK as a static framework:
 
-1. Build from source manually, per above.
+1. Build from source using the `make ipackage` command.
 
 1. Drag the Mapbox.bundle and Mapbox.framework from the `build/ios/pkg/static/` directory into the Project navigator. In the sheet that appears, make sure “Copy items if needed” is checked, then click Finish. Open the project editor and select your application target to verify that the following changes occurred automatically:
 


### PR DESCRIPTION
Update iOS custom build/install docs on GitHub to make clear the requirement for Xcode 9, which came about in #10452.

/cc @jmkiley @akitchen @1ec5 