### PR TITLE
[android] Fixes #10563 NPE addAnnotationIcon

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -321,6 +321,10 @@ public class MapView extends FrameLayout {
           MapView.this.post(new Runnable() {
             @Override
             public void run() {
+              // There is no guarantee that onDestroy will not be called before the surface is created
+              if (destroyed) {
+                return;
+              }
               // Initialise only once
               if (mapboxMap == null) {
                 initialiseMap();


### PR DESCRIPTION
Full trace is below. This was captured with 5.2.1 release. It would be good to pull this in any upcoming releases as this is a high rate crash amongst our users.  

Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.mapbox.mapboxsdk.maps.NativeMapView.addAnnotationIcon(java.lang.String, int, int, float, byte[])' on a null object reference
       at com.mapbox.mapboxsdk.maps.IconManager.loadIcon(SourceFile:115)
       at com.mapbox.mapboxsdk.maps.IconManager.(SourceFile)
       at com.mapbox.mapboxsdk.maps.MapView.initialiseMap(SourceFile:174)
       at com.mapbox.mapboxsdk.maps.MapView.access$800(SourceFile:70)
       at com.mapbox.mapboxsdk.maps.MapView$6$1.run(SourceFile:326)
       at android.os.Handler.handleCallback(Handler.java:739)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at android.os.Looper.loop(Looper.java:135)
       at android.app.ActivityThread.main(ActivityThread.java:5491)
       at java.lang.reflect.Method.invoke(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:372)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:984)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:779)