### PR TITLE
Add orientation change regression test

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/OrientationTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/OrientationTest.java
@@ -1,0 +1,41 @@
+package com.mapbox.mapboxsdk.maps;
+
+import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
+import com.mapbox.mapboxsdk.testapp.activity.camera.CameraAnimationTypeActivity;
+import org.junit.Test;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
+import static com.mapbox.mapboxsdk.testapp.action.OrientationChangeAction.orientationLandscape;
+import static com.mapbox.mapboxsdk.testapp.action.OrientationChangeAction.orientationLandscapeReverse;
+import static com.mapbox.mapboxsdk.testapp.action.OrientationChangeAction.orientationPortrait;
+import static com.mapbox.mapboxsdk.testapp.action.OrientationChangeAction.orientationPortraitReverse;
+
+public class OrientationTest extends BaseActivityTest {
+
+  @Test
+  public void testChangeDeviceOrientation() {
+    onView(isRoot()).perform(orientationLandscape());
+    waitLoop(2200);
+    onView(isRoot()).perform(orientationPortrait());
+    waitLoop(2500);
+    onView(isRoot()).perform(orientationLandscapeReverse());
+    waitLoop(500);
+    onView(isRoot()).perform(orientationPortraitReverse());
+    waitLoop(1250);
+    onView(isRoot()).perform(orientationLandscape());
+    waitLoop(750);
+    onView(isRoot()).perform(orientationPortrait());
+    waitLoop(950);
+    onView(isRoot()).perform(orientationLandscapeReverse());
+    onView(isRoot()).perform(orientationPortraitReverse());
+    onView(isRoot()).perform(orientationLandscape());
+    onView(isRoot()).perform(orientationPortrait());
+  }
+
+  @Override
+  protected Class getActivityClass() {
+    return CameraAnimationTypeActivity.class;
+  }
+
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/action/OrientationChangeAction.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/action/OrientationChangeAction.java
@@ -1,0 +1,74 @@
+package com.mapbox.mapboxsdk.testapp.action;
+
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.pm.ActivityInfo;
+import android.support.test.espresso.UiController;
+import android.support.test.espresso.ViewAction;
+import android.view.View;
+import android.view.ViewGroup;
+import org.hamcrest.Matcher;
+
+import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
+
+public class OrientationChangeAction implements ViewAction {
+
+  private final int orientation;
+
+  private OrientationChangeAction(int orientation) {
+    this.orientation = orientation;
+  }
+
+  public static ViewAction orientationLandscape() {
+    return new OrientationChangeAction(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+  }
+
+  public static ViewAction orientationPortrait() {
+    return new OrientationChangeAction(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+  }
+
+  public static ViewAction orientationLandscapeReverse() {
+    return new OrientationChangeAction(ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE);
+  }
+
+  public static ViewAction orientationPortraitReverse() {
+    return new OrientationChangeAction(ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT);
+  }
+
+  @Override
+  public Matcher<View> getConstraints() {
+    return isRoot();
+  }
+
+  @Override
+  public String getDescription() {
+    return "change orientation to " + orientation;
+  }
+
+  @Override
+  public void perform(UiController uiController, View view) {
+    uiController.loopMainThreadUntilIdle();
+    Activity activity = getActivity(view.getContext());
+    if (activity == null && view instanceof ViewGroup) {
+      ViewGroup v = (ViewGroup) view;
+      int c = v.getChildCount();
+      for (int i = 0; i < c && activity == null; ++i) {
+        activity = getActivity(v.getChildAt(i).getContext());
+      }
+    }
+    activity.setRequestedOrientation(orientation);
+  }
+
+  private Activity getActivity(Context context) {
+    while (context instanceof ContextWrapper) {
+      if (context instanceof Activity) {
+        return (Activity) context;
+      }
+      context = ((ContextWrapper) context).getBaseContext();
+    }
+    return null;
+  }
+
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/activity/BaseActivityTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/activity/BaseActivityTest.java
@@ -10,18 +10,14 @@ import android.support.test.espresso.UiController;
 import android.support.test.espresso.ViewAction;
 import android.support.test.rule.ActivityTestRule;
 import android.view.View;
-
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.testapp.R;
 import com.mapbox.mapboxsdk.testapp.utils.OnMapReadyIdlingResource;
-
 import junit.framework.Assert;
-
 import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
-
 import timber.log.Timber;
 
 import static android.support.test.espresso.Espresso.onView;
@@ -72,7 +68,11 @@ public abstract class BaseActivityTest {
   }
 
   protected void waitLoop() {
-    onView(withId(R.id.mapView)).perform(new LoopAction(500));
+    waitLoop(500);
+  }
+
+  protected void waitLoop(long waitTime) {
+    onView(withId(R.id.mapView)).perform(new LoopAction(waitTime));
   }
 
   static boolean isConnected(Context context) {


### PR DESCRIPTION
This PR adds a integration test that validates possible regressions related to orientation changes. Haven't been able to reproduce the crashes for which this test was created though I feel this would be a great addition to our test suite. 

cc @LukasPaczos  