### PR TITLE
Cherry picks client-side rendering of CJK glyphs into release-agua

### DIFF
--- a/platform/darwin/src/CFHandle.hpp
+++ b/platform/darwin/src/CFHandle.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+/*
+  CFHandle is a minimal wrapper designed to hold and release CoreFoundation-style handles
+  It is non-transferrable: wrap it in something like a unique_ptr if you need to pass it around,
+  or just use unique_ptr with a custom deleter.
+  CFHandle has no special treatment for null handles -- be careful not to let it hold a null
+  handle if the behavior of the Releaser isn't defined for null.
+ 
+  ex:
+   using CFDataHandle = CFHandle<CFDataRef, CFTypeRef, CFRelease>;
+ 
+   CFDataHandle data(CFDataCreateWithBytesNoCopy(
+        kCFAllocatorDefault, reinterpret_cast<const unsigned char*>(source.data()), source.size(),
+        kCFAllocatorNull));
+*/
+
+namespace {
+
+template <typename HandleType, typename ReleaserArgumentType, void (*Releaser)(ReleaserArgumentType)>
+struct CFHandle {
+    CFHandle(HandleType handle_): handle(handle_) {}
+    ~CFHandle() { Releaser(handle); }
+    HandleType operator*() { return handle; }
+    operator bool() { return handle; }
+private:
+    HandleType handle;
+};
+
+} // namespace
+

--- a/platform/darwin/src/MGLRendererConfiguration.h
+++ b/platform/darwin/src/MGLRendererConfiguration.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  Currently only used for CJK glyphs. Changing this at run time is not currently
  supported. Enable client-side rendering of CJK glyphs by setting
  `MGLIdeographFontFamilyName` in your containing app's Info.plist to a value
- which will be available at run time, i.e. "Arial Unicode MS". */
+ which will be available at run time, e.g. "PingFang". */
 @property (nonatomic, readonly) mbgl::optional<std::string> localFontFamilyName;
 
 @end

--- a/platform/darwin/src/MGLRendererConfiguration.h
+++ b/platform/darwin/src/MGLRendererConfiguration.h
@@ -1,0 +1,40 @@
+#import <Foundation/Foundation.h>
+#import <mbgl/storage/default_file_source.hpp>
+#import <mbgl/renderer/mode.hpp>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ The MGLRendererConfiguration object represents configuration values for the
+ renderer.
+ */
+@interface MGLRendererConfiguration : NSObject
+
+/** Returns an instance of the current renderer configuration. */
++ (instancetype)currentConfiguration;
+
+/** The file source to use. Defaults to `mbgl::DefaultFileSource` */
+@property (nonatomic, readonly) mbgl::DefaultFileSource *fileSource;
+
+/** The GL context mode to use. Defaults to `mbgl::GLContextMode::Unique` */
+@property (nonatomic, readonly) mbgl::GLContextMode contextMode;
+
+/** The scale factor to use.
+
+ Based on the native scale where available, otherwise the standard screen scale. */
+@property (nonatomic, readonly) const float scaleFactor;
+
+/** The cache dir to use. */
+@property (nonatomic, readonly) mbgl::optional<std::string> cacheDir;
+
+/** The name of the font family to use for client-side text rendering.
+
+ Currently only used for CJK glyphs. Changing this at run time is not currently
+ supported. Enable client-side rendering of CJK glyphs by setting
+ `MGLIdeographicFontFamilyName` in your containing app's Info.plist to a value
+ which will be available at runtime, i.e. "Arial Unicode MS". */
+@property (nonatomic, readonly) mbgl::optional<std::string> localFontFamilyName;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLRendererConfiguration.h
+++ b/platform/darwin/src/MGLRendererConfiguration.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <mbgl/storage/default_file_source.hpp>
-#import <mbgl/renderer/mode.hpp>
+#import <mbgl/map/mode.hpp>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/platform/darwin/src/MGLRendererConfiguration.h
+++ b/platform/darwin/src/MGLRendererConfiguration.h
@@ -31,8 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
 
  Currently only used for CJK glyphs. Changing this at run time is not currently
  supported. Enable client-side rendering of CJK glyphs by setting
- `MGLIdeographicFontFamilyName` in your containing app's Info.plist to a value
- which will be available at runtime, i.e. "Arial Unicode MS". */
+ `MGLIdeographFontFamilyName` in your containing app's Info.plist to a value
+ which will be available at run time, i.e. "Arial Unicode MS". */
 @property (nonatomic, readonly) mbgl::optional<std::string> localFontFamilyName;
 
 @end

--- a/platform/darwin/src/MGLRendererConfiguration.h
+++ b/platform/darwin/src/MGLRendererConfiguration.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  Currently only used for CJK glyphs. Changing this at run time is not currently
  supported. Enable client-side rendering of CJK glyphs by setting
- `MGLIdeographFontFamilyName` in your containing app's Info.plist to a value
+ `MGLIdeographicFontFamilyName` in your containing app's Info.plist to a value
  which will be available at run time, e.g. "PingFang". */
 @property (nonatomic, readonly) mbgl::optional<std::string> localFontFamilyName;
 

--- a/platform/darwin/src/MGLRendererConfiguration.mm
+++ b/platform/darwin/src/MGLRendererConfiguration.mm
@@ -1,0 +1,43 @@
+#import "MGLRendererConfiguration.h"
+#import "MGLOfflineStorage_Private.h"
+
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#else
+#import <AppKit/AppKit.h>
+#endif
+
+
+@implementation MGLRendererConfiguration
+
++ (instancetype)currentConfiguration {
+    return [[self alloc] init];
+}
+
+- (mbgl::DefaultFileSource *)fileSource {
+    return [MGLOfflineStorage sharedOfflineStorage].mbglFileSource;
+}
+
+- (mbgl::GLContextMode)contextMode {
+    return mbgl::GLContextMode::Unique;
+}
+
+- (const float)scaleFactor {
+#if TARGET_OS_IPHONE
+    return [UIScreen instancesRespondToSelector:@selector(nativeScale)] ? [[UIScreen mainScreen] nativeScale] : [[UIScreen mainScreen] scale];
+#else
+    return [NSScreen mainScreen].backingScaleFactor;
+#endif
+}
+
+- (mbgl::optional<std::string>)cacheDir {
+    return mbgl::optional<std::string>();
+}
+
+- (mbgl::optional<std::string>)localFontFamilyName {
+    NSString *fontFamilyName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"MGLIdeographicFontFamilyName"];
+
+    return fontFamilyName ? std::string([fontFamilyName UTF8String]) : mbgl::optional<std::string>();
+}
+
+@end

--- a/platform/darwin/src/MGLRendererConfiguration.mm
+++ b/platform/darwin/src/MGLRendererConfiguration.mm
@@ -35,7 +35,7 @@
 }
 
 - (mbgl::optional<std::string>)localFontFamilyName {
-    NSString *fontFamilyName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"MGLIdeographFontFamilyName"];
+    NSString *fontFamilyName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"MGLIdeographicFontFamilyName"];
 
     return fontFamilyName ? std::string([fontFamilyName UTF8String]) : mbgl::optional<std::string>();
 }

--- a/platform/darwin/src/MGLRendererConfiguration.mm
+++ b/platform/darwin/src/MGLRendererConfiguration.mm
@@ -35,7 +35,7 @@
 }
 
 - (mbgl::optional<std::string>)localFontFamilyName {
-    NSString *fontFamilyName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"MGLIdeographicFontFamilyName"];
+    NSString *fontFamilyName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"MGLIdeographFontFamilyName"];
 
     return fontFamilyName ? std::string([fontFamilyName UTF8String]) : mbgl::optional<std::string>();
 }

--- a/platform/darwin/src/image.mm
+++ b/platform/darwin/src/image.mm
@@ -2,19 +2,7 @@
 
 #import <ImageIO/ImageIO.h>
 
-namespace {
-
-template <typename T, typename S, void (*Releaser)(S)>
-struct CFHandle {
-    CFHandle(T t_): t(t_) {}
-    ~CFHandle() { Releaser(t); }
-    T operator*() { return t; }
-    operator bool() { return t; }
-private:
-    T t;
-};
-
-} // namespace
+#import "CFHandle.hpp"
 
 using CGImageHandle = CFHandle<CGImageRef, CGImageRef, CGImageRelease>;
 using CFDataHandle = CFHandle<CFDataRef, CFTypeRef, CFRelease>;

--- a/platform/darwin/src/local_glyph_rasterizer.mm
+++ b/platform/darwin/src/local_glyph_rasterizer.mm
@@ -1,0 +1,233 @@
+#include <mbgl/text/local_glyph_rasterizer.hpp>
+#include <mbgl/util/i18n.hpp>
+#include <mbgl/util/platform.hpp>
+
+#include <unordered_map>
+
+#import <Foundation/Foundation.h>
+#import <CoreText/CoreText.h>
+#import <ImageIO/ImageIO.h>
+
+#import "CFHandle.hpp"
+
+namespace mbgl {
+
+/*
+    Darwin implementation of LocalGlyphRasterizer:
+     Draws CJK glyphs using locally available fonts.
+ 
+    Mirrors GL JS implementation in that:
+     - Only CJK glyphs are drawn locally (because we can guess their metrics effectively)
+        * Render size/metrics determined experimentally by rendering a few different fonts
+     - Configuration is done at map creation time by setting a "font family"
+        * JS uses a CSS font-family, this uses kCTFontFamilyNameAttribute which has
+          somewhat different behavior.
+     - We use heuristics to extract a font-weight based on the incoming font stack
+ 
+    Further improvements are possible:
+     - If we could reliably extract glyph metrics, we wouldn't be limited to CJK glyphs
+     - We could push the font configuration down to individual style layers, which would
+        allow any current style to be reproducible using local fonts.
+     - Instead of just exposing "font family" as a configuration, we could expose a richer
+        CTFontDescriptor configuration option (although we'd have to override font size to
+        make sure it stayed at 24pt).
+     - Because Apple exposes glyph paths via `CTFontCreatePathForGlyph` we could potentially
+        render directly to SDF instead of going through TinySDF -- although it's not clear
+        how much of an improvement it would be.
+*/
+
+using CGColorSpaceHandle = CFHandle<CGColorSpaceRef, CGColorSpaceRef, CGColorSpaceRelease>;
+using CGContextHandle = CFHandle<CGContextRef, CGContextRef, CGContextRelease>;
+using CFStringRefHandle = CFHandle<CFStringRef, CFTypeRef, CFRelease>;
+using CFAttributedStringRefHandle = CFHandle<CFAttributedStringRef, CFTypeRef, CFRelease>;
+using CFDictionaryRefHandle = CFHandle<CFDictionaryRef, CFTypeRef, CFRelease>;
+using CTFontDescriptorRefHandle = CFHandle<CTFontDescriptorRef, CFTypeRef, CFRelease>;
+using CTLineRefHandle = CFHandle<CTLineRef, CFTypeRef, CFRelease>;
+
+class LocalGlyphRasterizer::Impl {
+public:
+    Impl(const optional<std::string> fontFamily_)
+        : fontFamily(fontFamily_)
+    {}
+    
+    ~Impl() {
+        for (auto& pair : fontHandles) {
+            CFRelease(pair.second);
+        }
+    }
+
+    
+    CTFontRef getFont(const FontStack& fontStack) {
+        if (!fontFamily) {
+            return NULL;
+        }
+        
+        if (fontHandles.find(fontStack) == fontHandles.end()) {
+            
+            NSDictionary* fontTraits = @{ (NSString *)kCTFontWeightTrait: [NSNumber numberWithFloat:getFontWeight(fontStack)] };
+            
+            NSDictionary *fontAttributes = @{
+                (NSString *)kCTFontSizeAttribute: [NSNumber numberWithFloat:24.0],
+                (NSString *)kCTFontFamilyNameAttribute: [[NSString alloc] initWithCString:fontFamily->c_str() encoding:NSUTF8StringEncoding],
+                (NSString *)kCTFontTraitsAttribute: fontTraits
+                //(NSString *)kCTFontStyleNameAttribute: (getFontWeight(fontStack) > .3) ? @"Bold" : @"Regular"
+            };
+
+            CTFontDescriptorRefHandle descriptor(CTFontDescriptorCreateWithAttributes((CFDictionaryRef)fontAttributes));
+            CTFontRef font = CTFontCreateWithFontDescriptor(*descriptor, 0.0, NULL);
+            if (!font) {
+                throw std::runtime_error("CTFontCreateWithFontDescriptor failed");
+            }
+
+            fontHandles[fontStack] = font;
+        }
+        return fontHandles[fontStack];
+    }
+    
+private:
+    float getFontWeight(const FontStack& fontStack) {
+        // Analog to logic in glyph_manager.js
+        // From NSFontDescriptor.h (macOS 10.11+) NSFontWeight*:
+        constexpr float light = -.4;
+        constexpr float regular = 0.0;
+        constexpr float medium = .23;
+        constexpr float bold = .4;
+        
+        float fontWeight = regular;
+        for (auto font : fontStack) {
+            // Last font in the fontstack "wins"
+            std::string lowercaseFont = mbgl::platform::lowercase(font);
+            if (lowercaseFont.find("bold") != std::string::npos) {
+                fontWeight = bold;
+            } else if (lowercaseFont.find("medium") != std::string::npos) {
+                fontWeight = medium;
+            } else if (lowercaseFont.find("light") != std::string::npos) {
+                fontWeight = light;
+            }
+        }
+
+        return fontWeight;
+    }
+
+    std::unordered_map<FontStack, CTFontRef, FontStackHash> fontHandles;
+    optional<std::string> fontFamily;
+};
+
+LocalGlyphRasterizer::LocalGlyphRasterizer(const optional<std::string> fontFamily)
+    : impl(std::make_unique<Impl>(fontFamily))
+{}
+
+LocalGlyphRasterizer::~LocalGlyphRasterizer()
+{}
+
+bool LocalGlyphRasterizer::canRasterizeGlyph(const FontStack& fontStack, GlyphID glyphID) {
+    return util::i18n::allowsFixedWidthGlyphGeneration(glyphID) && impl->getFont(fontStack);
+}
+
+/*
+// TODO: In theory we should be able to transform user-coordinate bounding box and advance
+// values into pixel glyph metrics. This would remove the need to use fixed glyph metrics
+// (which will be slightly off depending on the font), and allow us to return non CJK glyphs
+// (which will have variable "advance" values).
+void extractGlyphMetrics(CTFontRef font, CTLineRef line) {
+    CFArrayRef glyphRuns = CTLineGetGlyphRuns(line);
+    CFIndex runCount = CFArrayGetCount(glyphRuns);
+    assert(runCount == 1);
+    CTRunRef run = (CTRunRef)CFArrayGetValueAtIndex(glyphRuns, 0);
+    CFIndex glyphCount = CTRunGetGlyphCount(run);
+    assert(glyphCount == 1);
+    const CGGlyph *glyphs = CTRunGetGlyphsPtr(run);
+
+    CGRect boundingRects[1];
+    boundingRects[0] = CGRectMake(0, 0, 0, 0);
+    CGSize advances[1];
+    advances[0] = CGSizeMake(0,0);
+    CGRect totalBoundingRect = CTFontGetBoundingRectsForGlyphs(font, kCTFontOrientationDefault, glyphs, boundingRects, 1);
+    double totalAdvance = CTFontGetAdvancesForGlyphs(font, kCTFontOrientationDefault, glyphs, advances, 1);
+    
+    // Break in the debugger to see these values: translating from "user coordinates" to bitmap pixel coordinates
+    // should be OK, but a lot of glyphs seem to have empty bounding boxes...?
+    (void)totalBoundingRect;
+    (void)totalAdvance;
+}
+*/
+
+PremultipliedImage drawGlyphBitmap(GlyphID glyphID, CTFontRef font, Size size) {
+    PremultipliedImage rgbaBitmap(size);
+    
+    CFStringRefHandle string(CFStringCreateWithCharacters(NULL, reinterpret_cast<UniChar*>(&glyphID), 1));
+
+    CGColorSpaceHandle colorSpace(CGColorSpaceCreateDeviceRGB());
+    // TODO: Is there a way to just draw a single alpha channel instead of copying it out of an RGB image? Doesn't seem like the grayscale colorspace is what I'm looking for...
+    if (!colorSpace) {
+        throw std::runtime_error("CGColorSpaceCreateDeviceRGB failed");
+    }
+    
+    constexpr const size_t bitsPerComponent = 8;
+    constexpr const size_t bytesPerPixel = 4;
+    const size_t bytesPerRow = bytesPerPixel * size.width;
+
+    CGContextHandle context(CGBitmapContextCreate(
+        rgbaBitmap.data.get(),
+        size.width,
+        size.height,
+        bitsPerComponent,
+        bytesPerRow,
+        *colorSpace,
+        kCGBitmapByteOrderDefault | kCGImageAlphaPremultipliedLast));
+    if (!context) {
+        throw std::runtime_error("CGBitmapContextCreate failed");
+    }
+
+    CFStringRef keys[] = { kCTFontAttributeName };
+    CFTypeRef values[] = { font };
+
+    CFDictionaryRefHandle attributes(
+        CFDictionaryCreate(kCFAllocatorDefault, (const void**)&keys,
+            (const void**)&values, sizeof(keys) / sizeof(keys[0]),
+            &kCFTypeDictionaryKeyCallBacks,
+            &kCFTypeDictionaryValueCallBacks));
+
+    CFAttributedStringRefHandle attrString(CFAttributedStringCreate(kCFAllocatorDefault, *string, *attributes));
+
+    CTLineRefHandle line(CTLineCreateWithAttributedString(*attrString));
+    
+    // For debugging only, doesn't get useful metrics yet
+    //extractGlyphMetrics(font, *line);
+    
+    // Start drawing a little bit below the top of the bitmap
+    CGContextSetTextPosition(*context, 0.0, 5.0);
+    CTLineDraw(*line, *context);
+    
+    return rgbaBitmap;
+}
+
+Glyph LocalGlyphRasterizer::rasterizeGlyph(const FontStack& fontStack, GlyphID glyphID) {
+    Glyph fixedMetrics;
+    CTFontRef font = impl->getFont(fontStack);
+    if (!font) {
+        return fixedMetrics;
+    }
+    
+    fixedMetrics.id = glyphID;
+
+    Size size(35, 35);
+    
+    fixedMetrics.metrics.width = size.width;
+    fixedMetrics.metrics.height = size.height;
+    fixedMetrics.metrics.left = 3;
+    fixedMetrics.metrics.top = -1;
+    fixedMetrics.metrics.advance = 24;
+
+    PremultipliedImage rgbaBitmap = drawGlyphBitmap(glyphID, font, size);
+   
+    // Copy alpha values from RGBA bitmap into the AlphaImage output
+    fixedMetrics.bitmap = AlphaImage(size);
+    for (uint32_t i = 0; i < size.width * size.height; i++) {
+        fixedMetrics.bitmap.data[i] = rgbaBitmap.data[4 * i + 3];
+    }
+
+    return fixedMetrics;
+}
+
+} // namespace mbgl

--- a/platform/ios/app/Info.plist
+++ b/platform/ios/app/Info.plist
@@ -24,7 +24,7 @@
 	<string>7877</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>MGLIdeographicFontFamilyName</key>
+	<key>MGLIdeographFontFamilyName</key>
 	<string>PingFang</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2014–2017 Mapbox</string>

--- a/platform/ios/app/Info.plist
+++ b/platform/ios/app/Info.plist
@@ -24,6 +24,8 @@
 	<string>7877</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>MGLIdeographicFontFamilyName</key>
+	<string>PingFang</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2014–2017 Mapbox</string>
 	<key>NSLocationAlwaysUsageDescription</key>

--- a/platform/ios/app/Info.plist
+++ b/platform/ios/app/Info.plist
@@ -25,7 +25,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MGLIdeographicFontFamilyName</key>
-	<string>PingFang</string>
+	<string>PingFang TC</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2014–2017 Mapbox</string>
 	<key>NSLocationAlwaysUsageDescription</key>

--- a/platform/ios/app/Info.plist
+++ b/platform/ios/app/Info.plist
@@ -24,7 +24,7 @@
 	<string>7877</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>MGLIdeographFontFamilyName</key>
+	<key>MGLIdeographicFontFamilyName</key>
 	<string>PingFang</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2014–2017 Mapbox</string>

--- a/platform/ios/config.cmake
+++ b/platform/ios/config.cmake
@@ -28,11 +28,12 @@ macro(mbgl_platform_core)
         # Misc
         PRIVATE platform/darwin/mbgl/storage/reachability.h
         PRIVATE platform/darwin/mbgl/storage/reachability.m
+        PRIVATE platform/darwin/src/CFHandle.hpp
+        PRIVATE platform/darwin/src/local_glyph_rasterizer.mm
         PRIVATE platform/darwin/src/logging_nslog.mm
         PRIVATE platform/darwin/src/nsthread.mm
         PRIVATE platform/darwin/src/string_nsstring.mm
         PRIVATE platform/default/bidi.cpp
-        PRIVATE platform/default/local_glyph_rasterizer.cpp
         PRIVATE platform/default/thread_local.cpp
         PRIVATE platform/default/utf.cpp
 
@@ -84,6 +85,7 @@ macro(mbgl_platform_core)
     target_link_libraries(mbgl-core
         PUBLIC "-lz"
         PUBLIC "-framework Foundation"
+        PUBLIC "-framework CoreText"
         PUBLIC "-framework CoreGraphics"
         PUBLIC "-framework OpenGLES"
         PUBLIC "-framework ImageIO"

--- a/platform/ios/docs/guides/Info.plist Keys.md
+++ b/platform/ios/docs/guides/Info.plist Keys.md
@@ -20,6 +20,6 @@ The default value is `https://api.mapbox.com`.
 
 If you have implemented custom opt-out of Mapbox Telemetry within the user interface of your app, use this key to disable the built-in check for opt-out support. See [this guide](https://www.mapbox.com/ios-sdk/#telemetry_opt_out) for more details.
 
-## MGLIdeographFontFamilyName
+## MGLIdeographicFontFamilyName
 
 The name of the font family to use for client-side text rendering of CJK ideographs. Set this to the name of a font family which will be available at run time, e.g. `PingFang`.

--- a/platform/ios/docs/guides/Info.plist Keys.md
+++ b/platform/ios/docs/guides/Info.plist Keys.md
@@ -19,3 +19,7 @@ The default value is `https://api.mapbox.com`.
 ## MGLMapboxMetricsEnabledSettingShownInApp
 
 If you have implemented custom opt-out of Mapbox Telemetry within the user interface of your app, use this key to disable the built-in check for opt-out support. See [this guide](https://www.mapbox.com/ios-sdk/#telemetry_opt_out) for more details.
+
+## MGLIdeographFontFamilyName
+
+The name of the font family to use for client-side text rendering of CJK ideographs. Set this to the name of a font family which will be available at run time, i.e. `Arial Unicode MS`.

--- a/platform/ios/docs/guides/Info.plist Keys.md
+++ b/platform/ios/docs/guides/Info.plist Keys.md
@@ -22,4 +22,4 @@ If you have implemented custom opt-out of Mapbox Telemetry within the user inter
 
 ## MGLIdeographFontFamilyName
 
-The name of the font family to use for client-side text rendering of CJK ideographs. Set this to the name of a font family which will be available at run time, i.e. `Arial Unicode MS`.
+The name of the font family to use for client-side text rendering of CJK ideographs. Set this to the name of a font family which will be available at run time, e.g. `PingFang`.

--- a/platform/ios/docs/guides/Info.plist Keys.md
+++ b/platform/ios/docs/guides/Info.plist Keys.md
@@ -22,4 +22,4 @@ If you have implemented custom opt-out of Mapbox Telemetry within the user inter
 
 ## MGLIdeographicFontFamilyName
 
-The name of the font family to use for client-side text rendering of CJK ideographs. Set this to the name of a font family which will be available at run time, e.g. `PingFang`.
+The name of the font family to use for client-side text rendering of CJK ideographs. Set this to the name of a font family which will be available at run time, e.g. `PingFang TC` (iOS 9+), `Heiti TC` (iOS 8+), another appropriate built-in font, or a font provided by your application. Note that if a non-existent font is specified, iOS will fall back to using Helvetica which is likely not to include support for the glyphs needed to render maps in your application.

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -150,6 +150,10 @@
 		35E79F201D41266300957B9E /* MGLStyleLayer_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 35E79F1F1D41266300957B9E /* MGLStyleLayer_Private.h */; };
 		35E79F211D41266300957B9E /* MGLStyleLayer_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 35E79F1F1D41266300957B9E /* MGLStyleLayer_Private.h */; };
 		36F1153D1D46080700878E1A /* libmbgl-core.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 36F1153B1D46080700878E1A /* libmbgl-core.a */; };
+		3EA93369F61CF70AFA50465D /* MGLRendererConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3EA931BC4F087E166D538F21 /* MGLRendererConfiguration.mm */; };
+		3EA934623AD0000B7D99C3FB /* MGLRendererConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EA9337830C7738BF7F5493C /* MGLRendererConfiguration.h */; };
+		3EA9363147E77DD29FA06063 /* MGLRendererConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EA9337830C7738BF7F5493C /* MGLRendererConfiguration.h */; };
+		3EA9366247780E4F252652A8 /* MGLRendererConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3EA931BC4F087E166D538F21 /* MGLRendererConfiguration.mm */; };
 		400533011DB0862B0069F638 /* NSArray+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 400532FF1DB0862B0069F638 /* NSArray+MGLAdditions.h */; };
 		400533021DB0862B0069F638 /* NSArray+MGLAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 400533001DB0862B0069F638 /* NSArray+MGLAdditions.mm */; };
 		400533031DB086490069F638 /* NSArray+MGLAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 400533001DB0862B0069F638 /* NSArray+MGLAdditions.mm */; };
@@ -662,6 +666,8 @@
 		35E79F1F1D41266300957B9E /* MGLStyleLayer_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLStyleLayer_Private.h; sourceTree = "<group>"; };
 		36F1153B1D46080700878E1A /* libmbgl-core.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libmbgl-core.a"; path = "build/Debug-iphoneos/libmbgl-core.a"; sourceTree = "<group>"; };
 		36F1153C1D46080700878E1A /* libmbgl-platform-ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libmbgl-platform-ios.a"; path = "build/Debug-iphoneos/libmbgl-platform-ios.a"; sourceTree = "<group>"; };
+		3EA931BC4F087E166D538F21 /* MGLRendererConfiguration.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLRendererConfiguration.mm; sourceTree = "<group>"; };
+		3EA9337830C7738BF7F5493C /* MGLRendererConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLRendererConfiguration.h; sourceTree = "<group>"; };
 		400532FF1DB0862B0069F638 /* NSArray+MGLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+MGLAdditions.h"; sourceTree = "<group>"; };
 		400533001DB0862B0069F638 /* NSArray+MGLAdditions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "NSArray+MGLAdditions.mm"; sourceTree = "<group>"; };
 		4018B1C31CDC277F00F666AF /* MGLAnnotationView_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLAnnotationView_Private.h; sourceTree = "<group>"; };
@@ -1401,6 +1407,7 @@
 				DAD165801CF4CF9A001FF4B9 /* Formatters */,
 				DAD165811CF4CFC4001FF4B9 /* Geometry */,
 				DAD165821CF4CFE3001FF4B9 /* Offline Maps */,
+				DA8848911CBB049300AB86E3 /* reachability */,
 				DA8847DF1CBAFA5100AB86E3 /* MGLAccountManager.h */,
 				DA8847FF1CBAFA6200AB86E3 /* MGLAccountManager_Private.h */,
 				DA8848001CBAFA6200AB86E3 /* MGLAccountManager.m */,
@@ -1416,13 +1423,14 @@
 				927FBCFE1F4DB05500F8BF1F /* MGLMapSnapshotter.mm */,
 				DD0902A41DB18F1B00C5BDCE /* MGLNetworkConfiguration.h */,
 				DD0902A21DB18DE700C5BDCE /* MGLNetworkConfiguration.m */,
+				3EA9337830C7738BF7F5493C /* MGLRendererConfiguration.h */,
+				3EA931BC4F087E166D538F21 /* MGLRendererConfiguration.mm */,
 				92F2C3EC1F0E3C3A00268EC0 /* MGLRendererFrontend.h */,
 				DA8847EC1CBAFA5100AB86E3 /* MGLStyle.h */,
 				35E0CFE51D3E501500188327 /* MGLStyle_Private.h */,
 				DA88480F1CBAFA6200AB86E3 /* MGLStyle.mm */,
 				DA8847EE1CBAFA5100AB86E3 /* MGLTypes.h */,
 				DA8848111CBAFA6200AB86E3 /* MGLTypes.m */,
-				DA8848911CBB049300AB86E3 /* reachability */,
 				35E1A4D71D74336F007AA97F /* MGLValueEvaluator.h */,
 			);
 			name = Foundation;
@@ -1848,6 +1856,7 @@
 				DA8847F61CBAFA5100AB86E3 /* MGLOfflineStorage.h in Headers */,
 				DAD1656E1CF41981001FF4B9 /* MGLFeature_Private.h in Headers */,
 				DA88483C1CBAFB8500AB86E3 /* MGLMapView.h in Headers */,
+				3EA9363147E77DD29FA06063 /* MGLRendererConfiguration.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1941,6 +1950,7 @@
 				DAF0D8191DFE6B2800B28378 /* MGLAttributionInfo_Private.h in Headers */,
 				DABFB86A1CBE99E500D62B32 /* MGLStyle.h in Headers */,
 				DA00FC8F1D5EEB0D009AABC8 /* MGLAttributionInfo.h in Headers */,
+				3EA934623AD0000B7D99C3FB /* MGLRendererConfiguration.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2389,6 +2399,7 @@
 				DA8848581CBAFB9800AB86E3 /* MGLMapboxEvents.m in Sources */,
 				35CE61841D4165D9004F2359 /* UIColor+MGLAdditions.mm in Sources */,
 				DA8848561CBAFB9800AB86E3 /* MGLLocationManager.m in Sources */,
+				3EA93369F61CF70AFA50465D /* MGLRendererConfiguration.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2477,6 +2488,7 @@
 				DAA4E41C1CBB730400178DFB /* MGLAccountManager.m in Sources */,
 				35CE61851D4165D9004F2359 /* UIColor+MGLAdditions.mm in Sources */,
 				DAA4E4241CBB730400178DFB /* MGLPolyline.mm in Sources */,
+				3EA9366247780E4F252652A8 /* MGLRendererConfiguration.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -187,6 +187,7 @@ public:
 @property (nonatomic) EAGLContext *context;
 @property (nonatomic) GLKView *glView;
 @property (nonatomic) UIImageView *glSnapshotView;
+
 @property (nonatomic) NS_MUTABLE_ARRAY_OF(NSLayoutConstraint *) *scaleBarConstraints;
 @property (nonatomic, readwrite) MGLScaleBar *scaleBar;
 @property (nonatomic, readwrite) UIImageView *compassView;
@@ -195,7 +196,10 @@ public:
 @property (nonatomic) NS_MUTABLE_ARRAY_OF(NSLayoutConstraint *) *logoViewConstraints;
 @property (nonatomic, readwrite) UIButton *attributionButton;
 @property (nonatomic) NS_MUTABLE_ARRAY_OF(NSLayoutConstraint *) *attributionButtonConstraints;
+
 @property (nonatomic, readwrite) MGLStyle *style;
+@property (nonatomic, readonly) NSString *ideographicFontFamilyName;
+
 @property (nonatomic) UITapGestureRecognizer *singleTapGestureRecognizer;
 @property (nonatomic) UITapGestureRecognizer *doubleTap;
 @property (nonatomic) UITapGestureRecognizer *twoFingerTap;
@@ -204,11 +208,14 @@ public:
 @property (nonatomic) UIRotationGestureRecognizer *rotate;
 @property (nonatomic) UILongPressGestureRecognizer *quickZoom;
 @property (nonatomic) UIPanGestureRecognizer *twoFingerDrag;
+
 /// Mapping from reusable identifiers to annotation images.
 @property (nonatomic) NS_MUTABLE_DICTIONARY_OF(NSString *, MGLAnnotationImage *) *annotationImagesByIdentifier;
+
 /// Currently shown popover representing the selected annotation.
 @property (nonatomic) UIView<MGLCalloutView> *calloutViewForSelectedAnnotation;
 @property (nonatomic) MGLUserLocationAnnotationView *userLocationAnnotationView;
+
 /// Indicates how thoroughly the map view is tracking the user location.
 @property (nonatomic) MGLUserTrackingState userTrackingState;
 @property (nonatomic) CLLocationManager *locationManager;
@@ -402,8 +409,9 @@ public:
     mbgl::DefaultFileSource *mbglFileSource = [MGLOfflineStorage sharedOfflineStorage].mbglFileSource;
     const float scaleFactor = [UIScreen instancesRespondToSelector:@selector(nativeScale)] ? [[UIScreen mainScreen] nativeScale] : [[UIScreen mainScreen] scale];
     _mbglThreadPool = mbgl::sharedThreadPool();
-    
-    auto renderer = std::make_unique<mbgl::Renderer>(*_mbglView, scaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::GLContextMode::Unique);
+    NSString *fontFamilyName = self.ideographicFontFamilyName;
+
+    auto renderer = std::make_unique<mbgl::Renderer>(*_mbglView, scaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::GLContextMode::Unique, mbgl::optional<std::string>(), fontFamilyName ? std::string([fontFamilyName UTF8String]) : mbgl::optional<std::string>());
     _rendererFrontend = std::make_unique<MGLRenderFrontend>(std::move(renderer), self, *_mbglView);
     _mbglMap = new mbgl::Map(*_rendererFrontend, *_mbglView, self.size, scaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::MapMode::Continuous, mbgl::ConstrainMode::None, mbgl::ViewportMode::Default);
 
@@ -3458,6 +3466,12 @@ public:
 - (void)removeStyleClass:(NSString *)styleClass
 {
     [self.style removeStyleClass:styleClass];
+}
+
+#pragma mark Ideographic Font Info
+
+- (NSString *)ideographicFontFamilyName {
+    return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"MGLIdeographicFontFamilyName"];
 }
 
 #pragma mark - Annotations -

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -42,6 +42,7 @@
 #import "MGLOfflineStorage_Private.h"
 #import "MGLFoundation_Private.h"
 #import "MGLRendererFrontend.h"
+#import "MGLRendererConfiguration.h"
 
 #import "MGLVectorSource+MGLAdditions.h"
 #import "NSBundle+MGLAdditions.h"
@@ -198,7 +199,6 @@ public:
 @property (nonatomic) NS_MUTABLE_ARRAY_OF(NSLayoutConstraint *) *attributionButtonConstraints;
 
 @property (nonatomic, readwrite) MGLStyle *style;
-@property (nonatomic, readonly) NSString *ideographicFontFamilyName;
 
 @property (nonatomic) UITapGestureRecognizer *singleTapGestureRecognizer;
 @property (nonatomic) UITapGestureRecognizer *doubleTap;
@@ -323,7 +323,7 @@ public:
 
 + (void)initialize
 {
-    if (self == [MGLMapView self])
+    if (self == [MGLMapView class])
     {
         [MGLSDKUpdateChecker checkForUpdates];
     }
@@ -406,14 +406,12 @@ public:
     [[NSFileManager defaultManager] removeItemAtPath:fileCachePath error:NULL];
 
     // setup mbgl map
-    mbgl::DefaultFileSource *mbglFileSource = [MGLOfflineStorage sharedOfflineStorage].mbglFileSource;
-    const float scaleFactor = [UIScreen instancesRespondToSelector:@selector(nativeScale)] ? [[UIScreen mainScreen] nativeScale] : [[UIScreen mainScreen] scale];
+    MGLRendererConfiguration *config = [MGLRendererConfiguration currentConfiguration];
     _mbglThreadPool = mbgl::sharedThreadPool();
-    NSString *fontFamilyName = self.ideographicFontFamilyName;
 
-    auto renderer = std::make_unique<mbgl::Renderer>(*_mbglView, scaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::GLContextMode::Unique, mbgl::optional<std::string>(), fontFamilyName ? std::string([fontFamilyName UTF8String]) : mbgl::optional<std::string>());
+    auto renderer = std::make_unique<mbgl::Renderer>(*_mbglView, config.scaleFactor, *config.fileSource, *_mbglThreadPool, config.contextMode, config.cacheDir, config.localFontFamilyName);
     _rendererFrontend = std::make_unique<MGLRenderFrontend>(std::move(renderer), self, *_mbglView);
-    _mbglMap = new mbgl::Map(*_rendererFrontend, *_mbglView, self.size, scaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::MapMode::Continuous, mbgl::ConstrainMode::None, mbgl::ViewportMode::Default);
+    _mbglMap = new mbgl::Map(*_rendererFrontend, *_mbglView, self.size, config.scaleFactor, *[config fileSource], *_mbglThreadPool, mbgl::MapMode::Continuous, mbgl::ConstrainMode::None, mbgl::ViewportMode::Default);
 
     // start paused if in IB
     if (_isTargetingInterfaceBuilder || background) {
@@ -3466,12 +3464,6 @@ public:
 - (void)removeStyleClass:(NSString *)styleClass
 {
     [self.style removeStyleClass:styleClass];
-}
-
-#pragma mark Ideographic Font Info
-
-- (NSString *)ideographicFontFamilyName {
-    return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"MGLIdeographicFontFamilyName"];
 }
 
 #pragma mark - Annotations -

--- a/platform/macos/app/Info.plist
+++ b/platform/macos/app/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>MGLIdeographicFontFamilyName</key>
+	<string>PingFang TC</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDocumentTypes</key>

--- a/platform/macos/config.cmake
+++ b/platform/macos/config.cmake
@@ -14,11 +14,12 @@ macro(mbgl_platform_core)
         # Misc
         PRIVATE platform/darwin/mbgl/storage/reachability.h
         PRIVATE platform/darwin/mbgl/storage/reachability.m
+        PRIVATE platform/darwin/src/CFHandle.hpp
+        PRIVATE platform/darwin/src/local_glyph_rasterizer.mm
         PRIVATE platform/darwin/src/logging_nslog.mm
         PRIVATE platform/darwin/src/nsthread.mm
         PRIVATE platform/darwin/src/string_nsstring.mm
         PRIVATE platform/default/bidi.cpp
-        PRIVATE platform/default/local_glyph_rasterizer.cpp
         PRIVATE platform/default/thread_local.cpp
         PRIVATE platform/default/utf.cpp
 
@@ -64,6 +65,7 @@ macro(mbgl_platform_core)
     target_link_libraries(mbgl-core
         PUBLIC "-lz"
         PUBLIC "-framework Foundation"
+        PUBLIC "-framework CoreText"
         PUBLIC "-framework CoreGraphics"
         PUBLIC "-framework OpenGL"
         PUBLIC "-framework ImageIO"

--- a/platform/macos/docs/guides/Info.plist Keys.md
+++ b/platform/macos/docs/guides/Info.plist Keys.md
@@ -18,4 +18,4 @@ The default value is `https://api.mapbox.com`.
 
 ## MGLIdeographicFontFamilyName                                                                                                                                                          
 
-The name of the font family to use for client-side text rendering of CJK ideographs. Set this to the name of a font family which will be available at run time, e.g. `PingFang`.
+The name of the font family to use for client-side text rendering of CJK ideographs. Set this to the name of a font family which will be available at run time, e.g. `PingFang TC` (iOS 9+), `Heiti TC` (iOS 8+), another appropriate built-in font, or a font provided by your application. Note that if a non-existent font is specified, iOS will fall back to using Helvetica which is likely not to include support for the glyphs needed to render maps in your application.

--- a/platform/macos/docs/guides/Info.plist Keys.md
+++ b/platform/macos/docs/guides/Info.plist Keys.md
@@ -18,4 +18,4 @@ The default value is `https://api.mapbox.com`.
 
 ## MGLIdeographFontFamilyName                                                                                                                                                          
                                                                                                                                                                                        
-The name of the font family to use for client-side text rendering of CJK ideographs. Set this to the name of a font family which will be available at run time, i.e. `Arial Unicode MS`.
+The name of the font family to use for client-side text rendering of CJK ideographs. Set this to the name of a font family which will be available at run time, e.g. `PingFang`.

--- a/platform/macos/docs/guides/Info.plist Keys.md
+++ b/platform/macos/docs/guides/Info.plist Keys.md
@@ -15,3 +15,7 @@ As an alternative, you can use `+[MGLAccountManager setAccessToken:]` to set a t
 Use this key if you need to customize the API base URL used throughout the SDK. If unset, the default Mapbox API is used.
 
 The default value is `https://api.mapbox.com`.
+
+## MGLIdeographFontFamilyName                                                                                                                                                          
+                                                                                                                                                                                       
+The name of the font family to use for client-side text rendering of CJK ideographs. Set this to the name of a font family which will be available at run time, i.e. `Arial Unicode MS`.

--- a/platform/macos/docs/guides/Info.plist Keys.md
+++ b/platform/macos/docs/guides/Info.plist Keys.md
@@ -16,6 +16,6 @@ Use this key if you need to customize the API base URL used throughout the SDK. 
 
 The default value is `https://api.mapbox.com`.
 
-## MGLIdeographFontFamilyName                                                                                                                                                          
-                                                                                                                                                                                       
+## MGLIdeographicFontFamilyName                                                                                                                                                          
+
 The name of the font family to use for client-side text rendering of CJK ideographs. Set this to the name of a font family which will be available at run time, e.g. `PingFang`.

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -59,6 +59,8 @@
 		35C6DF871E214C1800ACA483 /* MGLDistanceFormatterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 35C6DF861E214C1800ACA483 /* MGLDistanceFormatterTests.m */; };
 		35D65C5A1D65AD5500722C23 /* NSDate+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D65C581D65AD5500722C23 /* NSDate+MGLAdditions.h */; };
 		35D65C5B1D65AD5500722C23 /* NSDate+MGLAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 35D65C591D65AD5500722C23 /* NSDate+MGLAdditions.mm */; };
+		3EA9317388DC9A0BF46B7674 /* MGLRendererConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EA9369A4C46957566058822 /* MGLRendererConfiguration.h */; };
+		3EA93BA38DBB4B814B6C1FCC /* MGLRendererConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3EA93B1B0864609938506E12 /* MGLRendererConfiguration.mm */; };
 		4031ACFC1E9EB3C100A3EA26 /* MGLMapViewDelegateIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4031ACFB1E9EB3C100A3EA26 /* MGLMapViewDelegateIntegrationTests.swift */; };
 		4031AD031E9FD6AA00A3EA26 /* MGLSDKTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4031AD011E9FD6A300A3EA26 /* MGLSDKTestHelpers.swift */; };
 		4049C2A51DB6CE7F00B3F799 /* MGLPointCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 4049C2A11DB6CE7800B3F799 /* MGLPointCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -334,6 +336,8 @@
 		35C6DF861E214C1800ACA483 /* MGLDistanceFormatterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MGLDistanceFormatterTests.m; path = ../../darwin/test/MGLDistanceFormatterTests.m; sourceTree = "<group>"; };
 		35D65C581D65AD5500722C23 /* NSDate+MGLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDate+MGLAdditions.h"; sourceTree = "<group>"; };
 		35D65C591D65AD5500722C23 /* NSDate+MGLAdditions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "NSDate+MGLAdditions.mm"; sourceTree = "<group>"; };
+		3EA9369A4C46957566058822 /* MGLRendererConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLRendererConfiguration.h; sourceTree = "<group>"; };
+		3EA93B1B0864609938506E12 /* MGLRendererConfiguration.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLRendererConfiguration.mm; sourceTree = "<group>"; };
 		4031ACFB1E9EB3C100A3EA26 /* MGLMapViewDelegateIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MGLMapViewDelegateIntegrationTests.swift; sourceTree = "<group>"; };
 		4031AD011E9FD6A300A3EA26 /* MGLSDKTestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MGLSDKTestHelpers.swift; path = ../../darwin/test/MGLSDKTestHelpers.swift; sourceTree = "<group>"; };
 		4049C2A11DB6CE7800B3F799 /* MGLPointCollection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLPointCollection.h; sourceTree = "<group>"; };
@@ -1087,6 +1091,8 @@
 				92092EEF1F5EB10E00AF5130 /* MGLMapSnapshotter.mm */,
 				DD0902B01DB1AC6400C5BDCE /* MGLNetworkConfiguration.h */,
 				DD0902AF1DB1AC6400C5BDCE /* MGLNetworkConfiguration.m */,
+				3EA9369A4C46957566058822 /* MGLRendererConfiguration.h */,
+				3EA93B1B0864609938506E12 /* MGLRendererConfiguration.mm */,
 				92F2C3EA1F0E3A1900268EC0 /* MGLRendererFrontend.h */,
 				DAE6C3571CC31E0400DB3429 /* MGLStyle.h */,
 				3537CA731D3F93A600380318 /* MGLStyle_Private.h */,
@@ -1237,6 +1243,7 @@
 				1F7454A41ECFB00300021D39 /* MGLLight.h in Headers */,
 				408AA8671DAEEE3900022900 /* NSDictionary+MGLAdditions.h in Headers */,
 				DAE6C3671CC31E0400DB3429 /* MGLStyle.h in Headers */,
+				3EA9317388DC9A0BF46B7674 /* MGLRendererConfiguration.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1512,6 +1519,7 @@
 				3529039C1D6C63B80002C7DF /* NSPredicate+MGLAdditions.mm in Sources */,
 				DA8F25981D51CAC70010E6B5 /* MGLVectorSource.mm in Sources */,
 				352742A11D4C25BD00A1ECE6 /* MGLStyleValue.mm in Sources */,
+				3EA93BA38DBB4B814B6C1FCC /* MGLRendererConfiguration.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -217,7 +217,7 @@ public:
 
 - (instancetype)initWithFrame:(NSRect)frameRect {
     if (self = [super initWithFrame:frameRect]) {
-        [self commonInit];
+        [self commonInit:nil];
         self.styleURL = nil;
     }
     return self;
@@ -225,7 +225,7 @@ public:
 
 - (instancetype)initWithFrame:(NSRect)frame styleURL:(nullable NSURL *)styleURL {
     if (self = [super initWithFrame:frame]) {
-        [self commonInit];
+        [self commonInit:nil];
         self.styleURL = styleURL;
     }
     return self;
@@ -233,7 +233,7 @@ public:
 
 - (instancetype)initWithCoder:(nonnull NSCoder *)decoder {
     if (self = [super initWithCoder:decoder]) {
-        [self commonInit];
+        [self commonInit:nil];
     }
     return self;
 }
@@ -252,7 +252,7 @@ public:
     return @[@"camera", @"debugMask"];
 }
 
-- (void)commonInit {
+- (void)commonInit:(nullable NSString*)fontFamily {
     _isTargetingInterfaceBuilder = NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent;
 
     // Set up cross-platform controllers and resources.
@@ -274,7 +274,7 @@ public:
 
     _mbglThreadPool = mbgl::sharedThreadPool();
 
-    auto renderer = std::make_unique<mbgl::Renderer>(*_mbglView, [NSScreen mainScreen].backingScaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::GLContextMode::Unique);
+    auto renderer = std::make_unique<mbgl::Renderer>(*_mbglView, [NSScreen mainScreen].backingScaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::GLContextMode::Unique, mbgl::optional<std::string>(), fontFamily ? std::string([fontFamily UTF8String]) : mbgl::optional<std::string>());
     _rendererFrontend = std::make_unique<MGLRenderFrontend>(std::move(renderer), self, *_mbglView, true);
     _mbglMap = new mbgl::Map(*_rendererFrontend, *_mbglView, self.size, [NSScreen mainScreen].backingScaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::MapMode::Continuous, mbgl::ConstrainMode::None, mbgl::ViewportMode::Default);
 

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -5,6 +5,7 @@
 #import "MGLOpenGLLayer.h"
 #import "MGLStyle.h"
 #import "MGLRendererFrontend.h"
+#import "MGLRendererConfiguration.h"
 
 #import "MGLAnnotationImage_Private.h"
 #import "MGLAttributionInfo_Private.h"
@@ -272,13 +273,12 @@ public:
     NSURL *legacyCacheURL = [cachesDirectoryURL URLByAppendingPathComponent:@"cache.db"];
     [[NSFileManager defaultManager] removeItemAtURL:legacyCacheURL error:NULL];
 
-    mbgl::DefaultFileSource* mbglFileSource = [MGLOfflineStorage sharedOfflineStorage].mbglFileSource;
     _mbglThreadPool = mbgl::sharedThreadPool();
-    NSString *fontFamilyName = self.ideographicFontFamilyName;
+    MGLRendererConfiguration *config = [MGLRendererConfiguration currentConfiguration];
 
-    auto renderer = std::make_unique<mbgl::Renderer>(*_mbglView, [NSScreen mainScreen].backingScaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::GLContextMode::Unique, mbgl::optional<std::string>(), fontFamilyName ? std::string([fontFamilyName UTF8String]) : mbgl::optional<std::string>());
+    auto renderer = std::make_unique<mbgl::Renderer>(*_mbglView, config.scaleFactor, *config.fileSource, *_mbglThreadPool, config.contextMode, config.cacheDir, config.localFontFamilyName);
     _rendererFrontend = std::make_unique<MGLRenderFrontend>(std::move(renderer), self, *_mbglView, true);
-    _mbglMap = new mbgl::Map(*_rendererFrontend, *_mbglView, self.size, [NSScreen mainScreen].backingScaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::MapMode::Continuous, mbgl::ConstrainMode::None, mbgl::ViewportMode::Default);
+    _mbglMap = new mbgl::Map(*_rendererFrontend, *_mbglView, self.size, config.scaleFactor, *config.fileSource, *_mbglThreadPool, mbgl::MapMode::Continuous, mbgl::ConstrainMode::None, mbgl::ViewportMode::Default);
 
     // Install the OpenGL layer. Interface Builder’s synchronous drawing means
     // we can’t display a map, so don’t even bother to have a map layer.

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -144,8 +144,6 @@ public:
 @property (nonatomic, readwrite) NSView *attributionView;
 
 @property (nonatomic, readwrite) MGLStyle *style;
-@property (nonatomic, readonly) NSString *ideographicFontFamilyName;
-
 
 /// Mapping from reusable identifiers to annotation images.
 @property (nonatomic) NS_MUTABLE_DICTIONARY_OF(NSString *, MGLAnnotationImage *) *annotationImagesByIdentifier;
@@ -652,12 +650,6 @@ public:
 
 - (mbgl::Renderer *)renderer {
     return _rendererFrontend->getRenderer();
-}
-
-#pragma mark Ideographic Font Info
-
-- (NSString *)ideographicFontFamilyName {
-    return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"MGLIdeographicFontFamilyName"];
 }
 
 #pragma mark View hierarchy and drawing


### PR DESCRIPTION
Cherry picks the iOS/macOS code from https://github.com/mapbox/mapbox-gl-native/pull/10522 into `release-agua`