### PR TITLE
Happy new year!

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-mapbox-gl-native copyright (c) 2014-2017 Mapbox.
+mapbox-gl-native copyright (c) 2014-2018 Mapbox.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/platform/android/MapboxGLAndroidSDK/gradle-javadoc.gradle
+++ b/platform/android/MapboxGLAndroidSDK/gradle-javadoc.gradle
@@ -10,7 +10,7 @@ android.libraryVariants.all { variant ->
         options.windowTitle("Mapbox Android SDK $VERSION_NAME Reference")
         options.docTitle("Mapbox Android SDK $VERSION_NAME")
         options.header("Mapbox Android SDK $VERSION_NAME Reference")
-        options.bottom("&copy; 2015&ndash;2017 Mapbox. All rights reserved.")
+        options.bottom("&copy; 2015&ndash;2018 Mapbox. All rights reserved.")
         options.links("http://docs.oracle.com/javase/7/docs/api/")
         options.linksOffline("http://d.android.com/reference/", "$System.env.ANDROID_HOME/docs/reference")
         options.overview("src/main/java/overview.html")

--- a/platform/ios/app/Info.plist
+++ b/platform/ios/app/Info.plist
@@ -27,7 +27,7 @@
 	<key>MGLIdeographicFontFamilyName</key>
 	<string>PingFang TC</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>© 2014–2017 Mapbox</string>
+	<string>© 2014–2018 Mapbox</string>
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string>The map will display your location. The map may also use your location when it isn’t visible in order to improve OpenStreetMap and Mapbox products.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>

--- a/platform/ios/benchmark/Info.plist
+++ b/platform/ios/benchmark/Info.plist
@@ -25,7 +25,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string>© 2015–2017 Mapbox</string>
+	<string>© 2015–2018 Mapbox</string>
 	<key>UIApplicationExitsOnSuspend</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -3,7 +3,7 @@ author: Mapbox
 author_url: https://www.mapbox.com/
 github_url: https://github.com/mapbox/mapbox-gl-native
 dash_url: https://www.mapbox.com/ios-sdk/docsets/Mapbox.xml
-copyright: '© 2014–2017 [Mapbox](https://www.mapbox.com/). See [license](https://github.com/mapbox/mapbox-gl-native/blob/master/LICENSE.md) for more details.'
+copyright: '© 2014–2018 [Mapbox](https://www.mapbox.com/). See [license](https://github.com/mapbox/mapbox-gl-native/blob/master/LICENSE.md) for more details.'
 
 head: |
   <link rel='shortcut icon' href='https://www.mapbox.com/img/favicon.ico' type='image/x-icon' />

--- a/platform/ios/uitest/LaunchScreen.xib
+++ b/platform/ios/uitest/LaunchScreen.xib
@@ -12,7 +12,7 @@
             <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="© 2015–2017 Mapbox. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="© 2015–2018 Mapbox. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
                     <rect key="frame" x="20" y="439" width="441" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>

--- a/platform/macos/jazzy.yml
+++ b/platform/macos/jazzy.yml
@@ -3,7 +3,7 @@ author: Mapbox
 author_url: https://www.mapbox.com/
 github_url: https://github.com/mapbox/mapbox-gl-native
 dash_url: https://mapbox.github.io/mapbox-gl-native/macos/docsets/Mapbox.xml
-copyright: '© 2014–2017 [Mapbox](https://www.mapbox.com/). See [license](https://github.com/mapbox/mapbox-gl-native/blob/master/LICENSE.md) for more details.'
+copyright: '© 2014–2018 [Mapbox](https://www.mapbox.com/). See [license](https://github.com/mapbox/mapbox-gl-native/blob/master/LICENSE.md) for more details.'
 
 head: |
   <link rel='shortcut icon' href='https://www.mapbox.com/img/favicon.ico' type='image/x-icon' />

--- a/test/src/app-info.plist
+++ b/test/src/app-info.plist
@@ -25,7 +25,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string>© 2014–2017 Mapbox</string>
+	<string>© 2014–2018 Mapbox</string>
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string>The map will ALWAYS display the user's location.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>


### PR DESCRIPTION
2018 equivalent PR of https://github.com/mapbox/mapbox-gl-native/pull/7595 and https://github.com/mapbox/mapbox-gl-native/pull/3439. This PR updates our licenses to reflect the new year. 

@brunoabinader @tmpsantos do we need to update anything on the qt side?