### PR TITLE
Fix distant collision perspective ratios (#10794).

### DIFF
--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -85,6 +85,7 @@
   "render-tests/text-pitch-alignment/map-text-rotation-alignment-map": "https://github.com/mapbox/mapbox-gl-native/issues/9732",
   "render-tests/text-pitch-alignment/viewport-text-rotation-alignment-map": "https://github.com/mapbox/mapbox-gl-native/issues/9732",
   "render-tests/text-pitch-scaling/line-half": "https://github.com/mapbox/mapbox-gl-native/issues/9732",
+  "render-tests/tilejson-bounds/default": "https://github.com/mapbox/mapbox-gl-native/pull/10701",
   "render-tests/video/default": "skip - https://github.com/mapbox/mapbox-gl-native/issues/601",
   "render-tests/background-color/colorSpace-hcl": "needs issue",
   "render-tests/hillshade-accent-color/default": "skip - https://github.com/mapbox/mapbox-gl-native/pull/10642",

--- a/src/mbgl/shaders/collision_circle.cpp
+++ b/src/mbgl/shaders/collision_circle.cpp
@@ -26,19 +26,19 @@ varying vec2 v_extrude_scale;
 void main() {
     vec4 projectedPoint = u_matrix * vec4(a_anchor_pos, 0, 1);
     highp float camera_to_anchor_distance = projectedPoint.w;
-    highp float collision_perspective_ratio = 0.5 + 0.5 * (camera_to_anchor_distance / u_camera_to_center_distance);
+    highp float collision_perspective_ratio = 0.5 + 0.5 * (u_camera_to_center_distance / camera_to_anchor_distance);
 
     gl_Position = u_matrix * vec4(a_pos, 0.0, 1.0);
 
     highp float padding_factor = 1.2; // Pad the vertices slightly to make room for anti-alias blur
-    gl_Position.xy += a_extrude * u_extrude_scale * padding_factor * gl_Position.w / collision_perspective_ratio;
+    gl_Position.xy += a_extrude * u_extrude_scale * padding_factor * gl_Position.w * collision_perspective_ratio;
 
     v_placed = a_placed.x;
     v_notUsed = a_placed.y;
     v_radius = abs(a_extrude.y); // We don't pitch the circles, so both units of the extrusion vector are equal in magnitude to the radius
 
     v_extrude = a_extrude * padding_factor;
-    v_extrude_scale = u_extrude_scale * u_camera_to_center_distance / collision_perspective_ratio;
+    v_extrude_scale = u_extrude_scale * u_camera_to_center_distance * collision_perspective_ratio;
 }
 
 )MBGL_SHADER";

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -59,7 +59,7 @@ void Placement::placeLayer(RenderSymbolLayer& symbolLayer, const mat4& projMatri
         const float pixelsToTileUnits = renderTile.id.pixelsToTileUnits(1, state.getZoom());
 
         const float scale = std::pow(2, state.getZoom() - renderTile.tile.id.overscaledZ);
-        const float textPixelRatio = util::EXTENT / (util::tileSize * renderTile.tile.id.overscaleFactor());
+        const float textPixelRatio = (util::tileSize * renderTile.tile.id.overscaleFactor()) / util::EXTENT;
 
         mat4 posMatrix;
         state.matrixFor(posMatrix, renderTile.id);


### PR DESCRIPTION
Fixes issue #10794.

Port of fix to https://github.com/mapbox/mapbox-gl-js/issues/5911.
Add native ignore for tilejson-bounds.

I'm mainly relying on the two new regression tests for GL JS issue #5911, but I also did some quick manual testing using the macosapp, looking at the scene in the original issue, as well as overscaled tiles.

/cc @ansis @asheemmamoowala 