### PR TITLE
[core] fix loading overscaled tiles

### DIFF
--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -93,17 +93,21 @@ void TilePyramid::update(const std::vector<Immutable<style::Layer::Impl>>& layer
     if (overscaledZoom >= zoomRange.min) {
         int32_t idealZoom = std::min<int32_t>(zoomRange.max, overscaledZoom);
 
+
+        // Make sure we're not reparsing overzoomed raster tiles.
+        if (type == SourceType::Raster) {
+            tileZoom = idealZoom;
+        }
+
         // Only attempt prefetching in continuous mode.
         if (parameters.mode == MapMode::Continuous) {
-            tileZoom = idealZoom;
-
             // Request lower zoom level tiles (if configured to do so) in an attempt
             // to show something on the screen faster at the cost of a little of bandwidth.
             if (parameters.prefetchZoomDelta) {
                 panZoom = std::max<int32_t>(tileZoom - parameters.prefetchZoomDelta, zoomRange.min);
             }
 
-            if (panZoom < tileZoom) {
+            if (panZoom < idealZoom) {
                 panTiles = util::tileCover(parameters.transformState, panZoom);
             }
         }


### PR DESCRIPTION
fix #10833

This reverts a regression in ed5438fc21672e838947c06669dd44051ce24c81 which set `tileZoom = idealZoom` for all types of tiles.

The second change makes it so that panTiles get loaded only if they have a lower *data zoom* (only if they cover a larger area). This avoids reloading the same data tile as a `panTile` for an overscaled tile.

@brunoabinader does the `if (panZoom < idealZoom) {` make sense here?

cc @ChrisLoer 