### PR TITLE
Support Genymotion

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/egl/EGLConfigChooser.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/egl/EGLConfigChooser.java
@@ -1,6 +1,7 @@
 package com.mapbox.mapboxsdk.maps.renderer.egl;
 
 import android.opengl.GLSurfaceView;
+import android.os.Build;
 import android.support.annotation.NonNull;
 
 import java.util.ArrayList;
@@ -261,9 +262,8 @@ public class EGLConfigChooser implements GLSurfaceView.EGLConfigChooser {
     return attributevalue[0];
   }
 
-
   private int[] getConfigAttributes() {
-    boolean emulator = inEmulator();
+    boolean emulator = inEmulator() || inGenymotion();
     Timber.i("In emulator: %s", emulator);
 
     // Get all configs at least RGB 565 with 16 depth and 8 stencil
@@ -290,4 +290,12 @@ public class EGLConfigChooser implements GLSurfaceView.EGLConfigChooser {
   private boolean inEmulator() {
     return System.getProperty("ro.kernel.qemu") != null;
   }
+
+  /**
+   * Detect if we are in genymotion
+   */
+  private boolean inGenymotion() {
+    return Build.MANUFACTURER.contains("Genymotion");
+  }
+
 }


### PR DESCRIPTION
Closes #10685. When we migrated to GlSurfaceView, the EglConfig configuration did not take in account Genymotion virtual machines. 

<img width="643" alt="screen shot 2018-01-05 at 13 42 52" src="https://user-images.githubusercontent.com/2151639/34609995-62775d64-f21f-11e7-9897-de31dbb3a276.png">


cc @ivovandongen 