### PR TITLE
Add data-driven-styling support for `text-font`

### DIFF
--- a/include/mbgl/style/expression/array_assertion.hpp
+++ b/include/mbgl/style/expression/array_assertion.hpp
@@ -30,6 +30,10 @@ public:
         return false;
     }
 
+    std::vector<optional<Value>> possibleOutputs() const override {
+        return input->possibleOutputs();
+    }
+
 private:
     std::unique_ptr<Expression> input;
 };

--- a/include/mbgl/style/expression/assertion.hpp
+++ b/include/mbgl/style/expression/assertion.hpp
@@ -1,7 +1,9 @@
 #pragma once
+
 #include <mbgl/style/expression/expression.hpp>
 #include <mbgl/style/conversion.hpp>
 #include <mbgl/style/expression/parsing_context.hpp>
+
 #include <memory>
 #include <vector>
 
@@ -23,6 +25,8 @@ public:
     
     bool operator==(const Expression& e) const override;
 
+    std::vector<optional<Value>> possibleOutputs() const override;
+
 private:
     std::vector<std::unique_ptr<Expression>> inputs;
 };
@@ -30,4 +34,3 @@ private:
 } // namespace expression
 } // namespace style
 } // namespace mbgl
-

--- a/include/mbgl/style/expression/at.hpp
+++ b/include/mbgl/style/expression/at.hpp
@@ -28,6 +28,10 @@ public:
         return false;
     }
 
+    std::vector<optional<Value>> possibleOutputs() const override {
+        return { nullopt };
+    }
+
 private:
     std::unique_ptr<Expression> index;
     std::unique_ptr<Expression> input;

--- a/include/mbgl/style/expression/boolean_operator.hpp
+++ b/include/mbgl/style/expression/boolean_operator.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/style/expression/expression.hpp>
 #include <mbgl/style/conversion.hpp>
+
 #include <memory>
 
 namespace mbgl {
@@ -20,6 +21,7 @@ public:
     EvaluationResult evaluate(const EvaluationContext& params) const override;
     void eachChild(const std::function<void(const Expression&)>& visit) const override;
     bool operator==(const Expression& e) const override;
+    std::vector<optional<Value>> possibleOutputs() const override;
 
 private:
     std::vector<std::unique_ptr<Expression>> inputs;
@@ -36,8 +38,8 @@ public:
 
     EvaluationResult evaluate(const EvaluationContext& params) const override;
     void eachChild(const std::function<void(const Expression&)>& visit) const override;
-
     bool operator==(const Expression& e) const override;
+    std::vector<optional<Value>> possibleOutputs() const override;
 
 private:
     std::vector<std::unique_ptr<Expression>> inputs;
@@ -46,4 +48,3 @@ private:
 } // namespace expression
 } // namespace style
 } // namespace mbgl
-

--- a/include/mbgl/style/expression/case.hpp
+++ b/include/mbgl/style/expression/case.hpp
@@ -26,6 +26,8 @@ public:
     
     bool operator==(const Expression& e) const override;
 
+    std::vector<optional<Value>> possibleOutputs() const override;
+
 private:
     std::vector<Branch> branches;
     std::unique_ptr<Expression> otherwise;

--- a/include/mbgl/style/expression/coalesce.hpp
+++ b/include/mbgl/style/expression/coalesce.hpp
@@ -27,7 +27,9 @@ public:
     void eachChild(const std::function<void(const Expression&)>& visit) const override;
 
     bool operator==(const Expression& e) const override;
-    
+
+    std::vector<optional<Value>> possibleOutputs() const override;
+
     std::size_t getLength() const {
         return args.size();
     }

--- a/include/mbgl/style/expression/coercion.hpp
+++ b/include/mbgl/style/expression/coercion.hpp
@@ -1,6 +1,8 @@
 #pragma once
+
 #include <mbgl/style/expression/expression.hpp>
 #include <mbgl/style/conversion.hpp>
+
 #include <memory>
 #include <vector>
 
@@ -23,6 +25,9 @@ public:
     void eachChild(const std::function<void(const Expression&)>& visit) const override;
 
     bool operator==(const Expression& e) const override;
+
+    std::vector<optional<Value>> possibleOutputs() const override;
+
 private:
     EvaluationResult (*coerceSingleValue) (const Value& v);
     std::vector<std::unique_ptr<Expression>> inputs;

--- a/include/mbgl/style/expression/compound_expression.hpp
+++ b/include/mbgl/style/expression/compound_expression.hpp
@@ -72,7 +72,11 @@ public:
             [&](const std::vector<type::Type>& p) -> optional<std::size_t> { return p.size(); }
         );
     }
-    
+
+    std::vector<optional<Value>> possibleOutputs() const override {
+        return { nullopt };
+    }
+
 private:
     std::string name;
     variant<std::vector<type::Type>, VarargsType> params;
@@ -107,7 +111,7 @@ public:
         }
         return false;
     }
-    
+
 private:
     Signature signature;
     typename Signature::Args args;

--- a/include/mbgl/style/expression/equals.hpp
+++ b/include/mbgl/style/expression/equals.hpp
@@ -19,6 +19,7 @@ public:
     void eachChild(const std::function<void(const Expression&)>& visit) const override;
     bool operator==(const Expression&) const override;
     EvaluationResult evaluate(const EvaluationContext&) const override;
+    std::vector<optional<Value>> possibleOutputs() const override;
 
 private:
     std::unique_ptr<Expression> lhs;

--- a/include/mbgl/style/expression/expression.hpp
+++ b/include/mbgl/style/expression/expression.hpp
@@ -1,14 +1,15 @@
 #pragma once
 
-#include <array>
-#include <vector>
-#include <memory>
 #include <mbgl/util/optional.hpp>
 #include <mbgl/util/variant.hpp>
 #include <mbgl/util/color.hpp>
 #include <mbgl/style/expression/type.hpp>
 #include <mbgl/style/expression/value.hpp>
 #include <mbgl/style/expression/parsing_context.hpp>
+
+#include <array>
+#include <vector>
+#include <memory>
 
 namespace mbgl {
 
@@ -38,7 +39,7 @@ public:
     optional<double> heatmapDensity;
 };
 
-template<typename T>
+template <typename T>
 class Result : private variant<EvaluationError, T> {
 public:
     using variant<EvaluationError, T>::variant;
@@ -128,6 +129,13 @@ public:
     
     EvaluationResult evaluate(optional<float> zoom, const Feature& feature, optional<double> heatmapDensity) const;
 
+    /**
+     * Statically analyze the expression, attempting to enumerate possible outputs. Returns
+     * an array of values plus the sentinel null optional value, used to indicate that the
+     * complete set of outputs is statically undecidable.
+     */
+    virtual std::vector<optional<Value>> possibleOutputs() const = 0;
+
 protected:
     template <typename T>
     static bool childrenEqual(const T& lhs, const T& rhs) {
@@ -161,8 +169,6 @@ protected:
                            const std::pair<std::unique_ptr<Expression>, std::unique_ptr<Expression>>& rhs) {
         return *(lhs.first) == *(rhs.first) && *(lhs.second) == *(rhs.second);
     }
-    
-    
 
 private:
     type::Type type;

--- a/include/mbgl/style/expression/interpolate.hpp
+++ b/include/mbgl/style/expression/interpolate.hpp
@@ -89,6 +89,8 @@ public:
         );
     }
 
+    std::vector<optional<Value>> possibleOutputs() const override;
+
 protected:
     const Interpolator interpolator;
     const std::unique_ptr<Expression> input;

--- a/include/mbgl/style/expression/let.hpp
+++ b/include/mbgl/style/expression/let.hpp
@@ -33,6 +33,8 @@ public:
         return false;
     }
 
+    std::vector<optional<Value>> possibleOutputs() const override;
+
     Expression* getResult() const {
         return result.get();
     }
@@ -61,7 +63,9 @@ public:
         }
         return false;
     }
-    
+
+    std::vector<optional<Value>> possibleOutputs() const override;
+
 private:
     std::string name;
     std::shared_ptr<Expression> value;

--- a/include/mbgl/style/expression/literal.hpp
+++ b/include/mbgl/style/expression/literal.hpp
@@ -28,7 +28,11 @@ public:
         }
         return false;
     }
-    
+
+    std::vector<optional<Value>> possibleOutputs() const override {
+        return {{ value }};
+    }
+
 private:
     Value value;
 };

--- a/include/mbgl/style/expression/match.hpp
+++ b/include/mbgl/style/expression/match.hpp
@@ -25,14 +25,15 @@ public:
         otherwise(std::move(otherwise_))
     {}
 
+    EvaluationResult evaluate(const EvaluationContext& params) const override;
+
     void eachChild(const std::function<void(const Expression&)>& visit) const override;
 
     bool operator==(const Expression& e) const override;
 
-    EvaluationResult evaluate(const EvaluationContext& params) const override;
-    
+    std::vector<optional<Value>> possibleOutputs() const override;
+
 private:
-    
     std::unique_ptr<Expression> input;
     Branches branches;
     std::unique_ptr<Expression> otherwise;

--- a/include/mbgl/style/expression/step.hpp
+++ b/include/mbgl/style/expression/step.hpp
@@ -33,6 +33,8 @@ public:
 
     bool operator==(const Expression& e) const override;
 
+    std::vector<optional<Value>> possibleOutputs() const override;
+
     static ParseResult parse(const mbgl::style::conversion::Convertible& value, ParsingContext& ctx);
 
 private:

--- a/include/mbgl/style/expression/value.hpp
+++ b/include/mbgl/style/expression/value.hpp
@@ -148,6 +148,15 @@ struct ValueConverter<T, std::enable_if_t< std::is_enum<T>::value >> {
     static optional<T> fromExpressionValue(const Value& value);
 };
 
+template <typename T>
+std::vector<optional<T>> fromExpressionValues(const std::vector<optional<Value>>& values) {
+    std::vector<optional<T>> result;
+    for (const auto& value : values) {
+        result.push_back(value ? fromExpressionValue<T>(*value) : nullopt);
+    }
+    return result;
+}
+
 } // namespace expression
 } // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/function/camera_function.hpp
+++ b/include/mbgl/style/function/camera_function.hpp
@@ -12,7 +12,6 @@
 #include <mbgl/util/interpolate.hpp>
 #include <mbgl/util/variant.hpp>
 
-
 namespace mbgl {
 namespace style {
 
@@ -66,7 +65,11 @@ public:
             [&](auto z) { return z->getCoveringStops(lower, upper); }
         );
     }
-    
+
+    std::vector<optional<T>> possibleOutputs() const {
+        return expression::fromExpressionValues<T>(expression->possibleOutputs());
+    }
+
     friend bool operator==(const CameraFunction& lhs,
                            const CameraFunction& rhs) {
         return *lhs.expression == *rhs.expression;

--- a/include/mbgl/style/function/composite_function.hpp
+++ b/include/mbgl/style/function/composite_function.hpp
@@ -102,6 +102,10 @@ public:
         );
     }
 
+    std::vector<optional<T>> possibleOutputs() const {
+        return expression::fromExpressionValues<T>(expression->possibleOutputs());
+    }
+
     friend bool operator==(const CompositeFunction& lhs,
                            const CompositeFunction& rhs) {
         return *lhs.expression == *rhs.expression;

--- a/include/mbgl/style/function/convert.hpp
+++ b/include/mbgl/style/function/convert.hpp
@@ -45,6 +45,10 @@ public:
         return EvaluationError{message};
     }
 
+    std::vector<optional<Value>> possibleOutputs() const override {
+        return {};
+    }
+
 private:
     std::string message;
 };

--- a/include/mbgl/style/function/source_function.hpp
+++ b/include/mbgl/style/function/source_function.hpp
@@ -57,6 +57,10 @@ public:
         return defaultValue ? *defaultValue : finalDefaultValue;
     }
 
+    std::vector<optional<T>> possibleOutputs() const {
+        return expression::fromExpressionValues<T>(expression->possibleOutputs());
+    }
+
     friend bool operator==(const SourceFunction& lhs,
                            const SourceFunction& rhs) {
         return *lhs.expression == *rhs.expression;

--- a/include/mbgl/style/layers/symbol_layer.hpp
+++ b/include/mbgl/style/layers/symbol_layer.hpp
@@ -118,9 +118,9 @@ public:
     DataDrivenPropertyValue<std::string> getTextField() const;
     void setTextField(DataDrivenPropertyValue<std::string>);
 
-    static PropertyValue<std::vector<std::string>> getDefaultTextFont();
-    PropertyValue<std::vector<std::string>> getTextFont() const;
-    void setTextFont(PropertyValue<std::vector<std::string>>);
+    static DataDrivenPropertyValue<std::vector<std::string>> getDefaultTextFont();
+    DataDrivenPropertyValue<std::vector<std::string>> getTextFont() const;
+    void setTextFont(DataDrivenPropertyValue<std::vector<std::string>>);
 
     static DataDrivenPropertyValue<float> getDefaultTextSize();
     DataDrivenPropertyValue<float> getTextSize() const;

--- a/include/mbgl/util/optional.hpp
+++ b/include/mbgl/util/optional.hpp
@@ -7,4 +7,7 @@ namespace mbgl {
 template <typename T>
 using optional = std::experimental::optional<T>;
 
+using nullopt_t = std::experimental::nullopt_t;
+constexpr nullopt_t nullopt = std::experimental::nullopt;
+
 } // namespace mbgl

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyFactory.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyFactory.java
@@ -2888,11 +2888,11 @@ public class PropertyFactory {
   /**
    * Font stack to use for displaying text.
    *
-   * @param <Z> the zoom parameter type
-   * @param function a wrapper {@link CameraFunction} for String[]
+   * @param <T> the function input type
+   * @param function a wrapper function for String[]
    * @return property wrapper around a String[] function
    */
-  public static <Z extends Number> PropertyValue<CameraFunction<Z, String[]>> textFont(CameraFunction<Z, String[]> function) {
+  public static <T> PropertyValue<Function<T, String[]>> textFont(Function<T, String[]> function) {
     return new LayoutPropertyValue<>("text-font", function);
   }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
@@ -1616,6 +1616,63 @@ public class SymbolLayerTest extends BaseActivityTest {
   }
 
   @Test
+  public void testTextFontAsIdentitySourceFunction() {
+    validateTestSetup();
+    setupLayer();
+    Timber.i("text-font");
+    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
+      @Override
+      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
+        assertNotNull(layer);
+
+        // Set
+        layer.setProperties(
+          textFont(property("FeaturePropertyA", Stops.<String[]>identity()))
+        );
+
+        // Verify
+        assertNotNull(layer.getTextFont());
+        assertNotNull(layer.getTextFont().getFunction());
+        assertEquals(SourceFunction.class, layer.getTextFont().getFunction().getClass());
+        assertEquals("FeaturePropertyA", ((SourceFunction) layer.getTextFont().getFunction()).getProperty());
+        assertEquals(IdentityStops.class, layer.getTextFont().getFunction().getStops().getClass());
+      }
+    });
+  }
+
+  @Test
+  public void testTextFontAsIntervalSourceFunction() {
+    validateTestSetup();
+    setupLayer();
+    Timber.i("text-font");
+    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
+      @Override
+      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
+        assertNotNull(layer);
+
+        // Set
+        layer.setProperties(
+          textFont(
+            property(
+              "FeaturePropertyA",
+              interval(
+                stop(1, textFont(new String[]{"Open Sans Regular", "Arial Unicode MS Regular"}))
+              )
+            )
+          )
+        );
+
+        // Verify
+        assertNotNull(layer.getTextFont());
+        assertNotNull(layer.getTextFont().getFunction());
+        assertEquals(SourceFunction.class, layer.getTextFont().getFunction().getClass());
+        assertEquals("FeaturePropertyA", ((SourceFunction) layer.getTextFont().getFunction()).getProperty());
+        assertEquals(IntervalStops.class, layer.getTextFont().getFunction().getStops().getClass());
+      }
+    });
+  }
+
+  @Test
   public void testTextSizeAsConstant() {
     validateTestSetup();
     setupLayer();

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -1054,8 +1054,18 @@ MGL_EXPORT
  You can set this property to an instance of:
  
  * `MGLConstantStyleValue`
- * `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeInterval`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSArray<NSString *> *> *textFontNames;
 

--- a/platform/darwin/src/MGLSymbolStyleLayer.mm
+++ b/platform/darwin/src/MGLSymbolStyleLayer.mm
@@ -632,7 +632,7 @@ namespace mbgl {
 - (void)setTextFontNames:(MGLStyleValue<NSArray<NSString *> *> *)textFontNames {
     MGLAssertStyleLayerIsValid();
 
-    auto mbglValue = MGLStyleValueTransformer<std::vector<std::string>, NSArray<NSString *> *, std::string>().toPropertyValue(textFontNames);
+    auto mbglValue = MGLStyleValueTransformer<std::vector<std::string>, NSArray<NSString *> *, std::string>().toDataDrivenPropertyValue(textFontNames);
     self.rawLayer->setTextFont(mbglValue);
 }
 
@@ -641,9 +641,9 @@ namespace mbgl {
 
     auto propertyValue = self.rawLayer->getTextFont();
     if (propertyValue.isUndefined()) {
-        return MGLStyleValueTransformer<std::vector<std::string>, NSArray<NSString *> *, std::string>().toStyleValue(self.rawLayer->getDefaultTextFont());
+        return MGLStyleValueTransformer<std::vector<std::string>, NSArray<NSString *> *, std::string>().toDataDrivenStyleValue(self.rawLayer->getDefaultTextFont());
     }
-    return MGLStyleValueTransformer<std::vector<std::string>, NSArray<NSString *> *, std::string>().toStyleValue(propertyValue);
+    return MGLStyleValueTransformer<std::vector<std::string>, NSArray<NSString *> *, std::string>().toDataDrivenStyleValue(propertyValue);
 }
 
 - (void)setTextFont:(MGLStyleValue<NSArray<NSString *> *> *)textFont {

--- a/platform/darwin/test/MGLSymbolStyleLayerTests.mm
+++ b/platform/darwin/test/MGLSymbolStyleLayerTests.mm
@@ -1017,7 +1017,7 @@
 
         MGLStyleValue<NSArray<NSString *> *> *constantStyleValue = [MGLStyleValue<NSArray<NSString *> *> valueWithRawValue:@[@"Text Font", @"Tnof Txet"]];
         layer.textFontNames = constantStyleValue;
-        mbgl::style::PropertyValue<std::vector<std::string>> propertyValue = { { "Text Font", "Tnof Txet" } };
+        mbgl::style::DataDrivenPropertyValue<std::vector<std::string>> propertyValue = { { "Text Font", "Tnof Txet" } };
         XCTAssertEqual(rawLayer->getTextFont(), propertyValue,
                        @"Setting textFontNames to a constant value should update text-font.");
         XCTAssertEqualObjects(layer.textFontNames, constantStyleValue,
@@ -1041,11 +1041,6 @@
                       @"Unsetting textFontNames should return text-font to the default value.");
         XCTAssertEqualObjects(layer.textFontNames, defaultStyleValue,
                               @"textFontNames should return the default value after being unset.");
-
-        functionStyleValue = [MGLStyleValue<NSArray<NSString *> *> valueWithInterpolationMode:MGLInterpolationModeIdentity sourceStops:nil attributeName:@"" options:nil];
-        XCTAssertThrowsSpecificNamed(layer.textFontNames = functionStyleValue, NSException, NSInvalidArgumentException, @"MGLStyleValue should raise an exception if it is applied to a property that cannot support it");
-        functionStyleValue = [MGLStyleValue<NSArray<NSString *> *> valueWithInterpolationMode:MGLInterpolationModeInterval compositeStops:@{@18: constantStyleValue} attributeName:@"" options:nil];
-        XCTAssertThrowsSpecificNamed(layer.textFontNames = functionStyleValue, NSException, NSInvalidArgumentException, @"MGLStyleValue should raise an exception if it is applied to a property that cannot support it");
     }
 
     // text-size

--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -60,7 +60,6 @@
   "render-tests/runtime-styling/set-style-paint-property-fill-flat-to-extrude": "https://github.com/mapbox/mapbox-gl-native/issues/6745",
   "render-tests/symbol-placement/line-overscaled": "https://github.com/mapbox/mapbox-gl-js/issues/5654",
   "render-tests/symbol-visibility/visible": "https://github.com/mapbox/mapbox-gl-native/issues/10409",
-  "render-tests/text-font/data-expression": "https://github.com/mapbox/mapbox-gl-native/issues/10535",
   "render-tests/text-pitch-alignment/auto-text-rotation-alignment-map": "https://github.com/mapbox/mapbox-gl-native/issues/9732",
   "render-tests/text-pitch-alignment/map-text-rotation-alignment-map": "https://github.com/mapbox/mapbox-gl-native/issues/9732",
   "render-tests/text-pitch-alignment/viewport-text-rotation-alignment-map": "https://github.com/mapbox/mapbox-gl-native/issues/9732",

--- a/src/mbgl/style/conversion/make_property_setters.hpp
+++ b/src/mbgl/style/conversion/make_property_setters.hpp
@@ -49,7 +49,7 @@ inline auto makeLayoutPropertySetters() {
     result["text-pitch-alignment"] = &setProperty<SymbolLayer, PropertyValue<AlignmentType>, &SymbolLayer::setTextPitchAlignment>;
     result["text-rotation-alignment"] = &setProperty<SymbolLayer, PropertyValue<AlignmentType>, &SymbolLayer::setTextRotationAlignment>;
     result["text-field"] = &setProperty<SymbolLayer, DataDrivenPropertyValue<std::string>, &SymbolLayer::setTextField>;
-    result["text-font"] = &setProperty<SymbolLayer, PropertyValue<std::vector<std::string>>, &SymbolLayer::setTextFont>;
+    result["text-font"] = &setProperty<SymbolLayer, DataDrivenPropertyValue<std::vector<std::string>>, &SymbolLayer::setTextFont>;
     result["text-size"] = &setProperty<SymbolLayer, DataDrivenPropertyValue<float>, &SymbolLayer::setTextSize>;
     result["text-max-width"] = &setProperty<SymbolLayer, DataDrivenPropertyValue<float>, &SymbolLayer::setTextMaxWidth>;
     result["text-line-height"] = &setProperty<SymbolLayer, PropertyValue<float>, &SymbolLayer::setTextLineHeight>;

--- a/src/mbgl/style/expression/assertion.cpp
+++ b/src/mbgl/style/expression/assertion.cpp
@@ -66,6 +66,16 @@ bool Assertion::operator==(const Expression& e) const {
     return false;
 }
 
+std::vector<optional<Value>> Assertion::possibleOutputs() const {
+    std::vector<optional<Value>> result;
+    for (const auto& input : inputs) {
+        for (auto& output : input->possibleOutputs()) {
+            result.push_back(std::move(output));
+        }
+    }
+    return result;
+}
+
 } // namespace expression
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/expression/boolean_operator.cpp
+++ b/src/mbgl/style/expression/boolean_operator.cpp
@@ -26,6 +26,10 @@ bool Any::operator==(const Expression& e) const {
     return false;
 }
 
+std::vector<optional<Value>> Any::possibleOutputs() const {
+    return {{ true }, { false }};
+}
+
 
 EvaluationResult All::evaluate(const EvaluationContext& params) const {
     for (auto it = inputs.begin(); it != inputs.end(); it++) {
@@ -47,6 +51,10 @@ bool All::operator==(const Expression& e) const {
         return Expression::childrenEqual(inputs, rhs->inputs);
     }
     return false;
+}
+
+std::vector<optional<Value>> All::possibleOutputs() const {
+    return {{ true }, { false }};
 }
 
 using namespace mbgl::style::conversion;

--- a/src/mbgl/style/expression/case.cpp
+++ b/src/mbgl/style/expression/case.cpp
@@ -34,6 +34,19 @@ bool Case::operator==(const Expression& e) const {
     return false;
 }
 
+std::vector<optional<Value>> Case::possibleOutputs() const {
+    std::vector<optional<Value>> result;
+    for (const auto& branch : branches) {
+        for (auto& output : branch.second->possibleOutputs()) {
+            result.push_back(std::move(output));
+        }
+    }
+    for (auto& output : otherwise->possibleOutputs()) {
+        result.push_back(std::move(output));
+    }
+    return result;
+}
+
 using namespace mbgl::style::conversion;
 ParseResult Case::parse(const Convertible& value, ParsingContext& ctx) {
     assert(isArray(value));

--- a/src/mbgl/style/expression/coalesce.cpp
+++ b/src/mbgl/style/expression/coalesce.cpp
@@ -27,6 +27,16 @@ bool Coalesce::operator==(const Expression& e) const {
     return false;
 }
 
+std::vector<optional<Value>> Coalesce::possibleOutputs() const {
+    std::vector<optional<Value>> result;
+    for (const auto& arg : args) {
+        for (auto& output : arg->possibleOutputs()) {
+            result.push_back(std::move(output));
+        }
+    }
+    return result;
+}
+
 using namespace mbgl::style::conversion;
 ParseResult Coalesce::parse(const Convertible& value, ParsingContext& ctx) {
     assert(isArray(value));

--- a/src/mbgl/style/expression/coercion.cpp
+++ b/src/mbgl/style/expression/coercion.cpp
@@ -136,6 +136,16 @@ bool Coercion::operator==(const Expression& e) const {
     return false;
 }
 
+std::vector<optional<Value>> Coercion::possibleOutputs() const {
+    std::vector<optional<Value>> result;
+    for (const auto& input : inputs) {
+        for (auto& output : input->possibleOutputs()) {
+            result.push_back(std::move(output));
+        }
+    }
+    return result;
+}
+
 } // namespace expression
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/expression/equals.cpp
+++ b/src/mbgl/style/expression/equals.cpp
@@ -37,6 +37,10 @@ bool Equals::operator==(const Expression& e) const {
     return false;
 }
 
+std::vector<optional<Value>> Equals::possibleOutputs() const {
+    return {{ true }, { false }};
+}
+
 static bool isComparableType(const type::Type& type) {
     return type == type::String ||
         type == type::Number ||

--- a/src/mbgl/style/expression/interpolate.cpp
+++ b/src/mbgl/style/expression/interpolate.cpp
@@ -206,6 +206,16 @@ ParseResult parseInterpolate(const Convertible& value, ParsingContext& ctx) {
     );
 }
 
+std::vector<optional<Value>> InterpolateBase::possibleOutputs() const {
+    std::vector<optional<Value>> result;
+    for (const auto& stop : stops) {
+        for (auto& output : stop.second->possibleOutputs()) {
+            result.push_back(std::move(output));
+        }
+    }
+    return result;
+}
+
 } // namespace expression
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/expression/let.cpp
+++ b/src/mbgl/style/expression/let.cpp
@@ -17,6 +17,10 @@ void Let::eachChild(const std::function<void(const Expression&)>& visit) const {
     visit(*result);
 }
 
+std::vector<optional<Value>> Let::possibleOutputs() const {
+    return result->possibleOutputs();
+}
+
 using namespace mbgl::style::conversion;
 
 ParseResult Let::parse(const Convertible& value, ParsingContext& ctx) {
@@ -66,6 +70,10 @@ EvaluationResult Var::evaluate(const EvaluationContext& params) const {
 }
 
 void Var::eachChild(const std::function<void(const Expression&)>&) const {}
+
+std::vector<optional<Value>> Var::possibleOutputs() const {
+    return { nullopt };
+}
 
 ParseResult Var::parse(const Convertible& value_, ParsingContext& ctx) {
     assert(isArray(value_));

--- a/src/mbgl/style/expression/match.cpp
+++ b/src/mbgl/style/expression/match.cpp
@@ -26,6 +26,20 @@ bool Match<T>::operator==(const Expression& e) const {
     return false;
 }
 
+template <typename T>
+std::vector<optional<Value>> Match<T>::possibleOutputs() const {
+    std::vector<optional<Value>> result;
+    for (const auto& branch : branches) {
+        for (auto& output : branch.second->possibleOutputs()) {
+            result.push_back(std::move(output));
+        }
+    }
+    for (auto& output : otherwise->possibleOutputs()) {
+        result.push_back(std::move(output));
+    }
+    return result;
+}
+
 
 template<> EvaluationResult Match<std::string>::evaluate(const EvaluationContext& params) const {
     const EvaluationResult inputValue = input->evaluate(params);

--- a/src/mbgl/style/expression/step.cpp
+++ b/src/mbgl/style/expression/step.cpp
@@ -40,6 +40,16 @@ bool Step::operator==(const Expression& e) const {
     return false;
 }
 
+std::vector<optional<Value>> Step::possibleOutputs() const {
+    std::vector<optional<Value>> result;
+    for (const auto& stop : stops) {
+        for (auto& output : stop.second->possibleOutputs()) {
+            result.push_back(std::move(output));
+        }
+    }
+    return result;
+}
+
 Range<float> Step::getCoveringStops(const double lower, const double upper) const {
     return ::mbgl::style::expression::getCoveringStops(stops, lower, upper);
 }

--- a/src/mbgl/style/layers/symbol_layer.cpp
+++ b/src/mbgl/style/layers/symbol_layer.cpp
@@ -412,15 +412,15 @@ void SymbolLayer::setTextField(DataDrivenPropertyValue<std::string> value) {
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
-PropertyValue<std::vector<std::string>> SymbolLayer::getDefaultTextFont() {
+DataDrivenPropertyValue<std::vector<std::string>> SymbolLayer::getDefaultTextFont() {
     return TextFont::defaultValue();
 }
 
-PropertyValue<std::vector<std::string>> SymbolLayer::getTextFont() const {
+DataDrivenPropertyValue<std::vector<std::string>> SymbolLayer::getTextFont() const {
     return impl().layout.get<TextFont>();
 }
 
-void SymbolLayer::setTextFont(PropertyValue<std::vector<std::string>> value) {
+void SymbolLayer::setTextFont(DataDrivenPropertyValue<std::vector<std::string>> value) {
     if (value == getTextFont())
         return;
     auto impl_ = mutableImpl();

--- a/src/mbgl/style/layers/symbol_layer_properties.hpp
+++ b/src/mbgl/style/layers/symbol_layer_properties.hpp
@@ -112,7 +112,7 @@ struct TextField : DataDrivenLayoutProperty<std::string> {
     static std::string defaultValue() { return ""; }
 };
 
-struct TextFont : LayoutProperty<std::vector<std::string>> {
+struct TextFont : DataDrivenLayoutProperty<std::vector<std::string>> {
     static constexpr const char * key = "text-font";
     static std::vector<std::string> defaultValue() { return { "Open Sans Regular", "Arial Unicode MS Regular" }; }
 };

--- a/src/mbgl/style/parser.cpp
+++ b/src/mbgl/style/parser.cpp
@@ -119,6 +119,9 @@ StyleParseResult Parser::parse(const std::string& json) {
         }
     }
 
+    // Call for side effect of logging warnings for invalid values.
+    fontStacks();
+
     return nullptr;
 }
 
@@ -286,6 +289,9 @@ std::vector<FontStack> Parser::fontStacks() const {
                     for (const auto& value : function.possibleOutputs()) {
                         if (value) {
                             result.insert(*value);
+                        } else {
+                            Log::Warning(Event::ParseStyle, "Layer '%s' has an invalid value for text-font and will not work offline. Output values must be contained as literals within the expression.", layer->getID().c_str());
+                            break;
                         }
                     }
                 }

--- a/test/fixtures/style_parser/text-font.info.json
+++ b/test/fixtures/style_parser/text-font.info.json
@@ -1,0 +1,14 @@
+{
+  "default": {
+    "log": [
+      [1, "WARNING", "ParseStyle", "Layer 'invalid expression - get' has an invalid value for text-font and will not work offline. Output values must be contained as literals within the expression."],
+      [1, "WARNING", "ParseStyle", "Layer 'invalid expression - case' has an invalid value for text-font and will not work offline. Output values must be contained as literals within the expression."],
+      [1, "WARNING", "ParseStyle", "Layer 'invalid expression - match' has an invalid value for text-font and will not work offline. Output values must be contained as literals within the expression."],
+      [1, "WARNING", "ParseStyle", "Layer 'invalid expression - at' has an invalid value for text-font and will not work offline. Output values must be contained as literals within the expression."],
+      [1, "WARNING", "ParseStyle", "Layer 'invalid expression - coalesce' has an invalid value for text-font and will not work offline. Output values must be contained as literals within the expression."],
+      [1, "WARNING", "ParseStyle", "Layer 'invalid expression - step' has an invalid value for text-font and will not work offline. Output values must be contained as literals within the expression."],
+      [1, "WARNING", "ParseStyle", "Layer 'invalid expression - let/var' has an invalid value for text-font and will not work offline. Output values must be contained as literals within the expression."],
+      [1, "WARNING", "ParseStyle", "Layer 'invalid expression - identity function' has an invalid value for text-font and will not work offline. Output values must be contained as literals within the expression."]
+    ]
+  }
+}

--- a/test/fixtures/style_parser/text-font.style.json
+++ b/test/fixtures/style_parser/text-font.style.json
@@ -1,0 +1,135 @@
+{
+  "version": 8,
+  "glyphs": "https://example.com/{fontstack}/{range}",
+  "sources": {
+    "vector": {
+      "type": "vector",
+      "url": "mapbox://mapbox.mapbox-streets-v5"
+    }
+  },
+  "layers": [
+    {
+      "id": "minimum",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "layer",
+      "layout": {
+        "text-font": ["Helvetica"],
+        "text-field": "{foo}"
+      }
+    },
+    {
+      "id": "valid expression - case",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "layer",
+      "layout": {
+        "text-font": ["case", ["==", "a", ["string", ["get", "text-font"]]], ["literal", ["Arial"]], ["literal", ["Helvetica"]]],
+        "text-field": "{foo}"
+      }
+    },
+    {
+      "id": "valid expression - match",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "layer",
+      "layout": {
+        "text-font": ["match", ["get", "text-font"], "a", ["literal", ["Arial"]], ["literal", ["Helvetica"]]],
+        "text-field": "{foo}"
+      }
+    },
+    {
+      "id": "valid expression - step",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "layer",
+      "layout": {
+        "text-font": ["array", "string", ["step", ["get", "text-font"], ["literal", ["Arial"]], 0, ["literal", ["Helvetica"]]]],
+        "text-field": "{foo}"
+      }
+    },
+    {
+      "id": "invalid expression - get",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "layer",
+      "layout": {
+        "text-font": ["array", "string", ["get", "text-font"]],
+        "text-field": "{foo}"
+      }
+    },
+    {
+      "id": "invalid expression - case",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "layer",
+      "layout": {
+        "text-font": ["case", ["==", "a", ["string", ["get", "text-font"]]], ["array", "string", ["get", "text-font-a"]], ["literal", ["Helvetica"]]],
+        "text-field": "{foo}"
+      }
+    },
+    {
+      "id": "invalid expression - match",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "layer",
+      "layout": {
+        "text-font": ["match", ["get", "text-font"], "a", ["array", "string", ["get", "text-font-a"]], ["literal", ["Helvetica"]]],
+        "text-field": "{foo}"
+      }
+    },
+    {
+      "id": "invalid expression - at",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "layer",
+      "layout": {
+        "text-font": ["array", "string", ["at", 0, ["array", ["get", "text-font"]]]],
+        "text-field": "{foo}"
+      }
+    },
+    {
+      "id": "invalid expression - coalesce",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "layer",
+      "layout": {
+        "text-font": ["array", "string", ["coalesce", ["get", "text-font"]]],
+        "text-field": "{foo}"
+      }
+    },
+    {
+      "id": "invalid expression - step",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "layer",
+      "layout": {
+        "text-font": ["step", ["zoom"], ["array", "string", ["get", "text-font-0"]], 0, ["array", "string", ["get", "text-font-1"]]],
+        "text-field": "{foo}"
+      }
+    },
+    {
+      "id": "invalid expression - let/var",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "layer",
+      "layout": {
+        "text-font": ["let", "p", ["array", "string", ["get", "text-font"]], ["var", "p"]],
+        "text-field": "{foo}"
+      }
+    },
+    {
+      "id": "invalid expression - identity function",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "layer",
+      "layout": {
+        "text-font": {
+          "type": "identity",
+          "property": "text-font"
+        },
+        "text-field": "{foo}"
+      }
+    }
+  ]
+}

--- a/test/style/style_parser.test.cpp
+++ b/test/style/style_parser.test.cpp
@@ -102,3 +102,78 @@ TEST(StyleParser, FontStacks) {
     ASSERT_EQ(FontStack({"a", "b"}), result[1]);
     ASSERT_EQ(FontStack({"a", "b", "c"}), result[2]);
 }
+
+TEST(StyleParser, FontStacksCaseExpression) {
+    style::Parser parser;
+    parser.parse(R"({
+        "version": 8,
+        "layers": [{
+            "id": "symbol",
+            "type": "symbol",
+            "source": "vector",
+            "layout": {
+                "text-font": ["case", ["==", "a", ["string", ["get", "text-font"]]], ["literal", ["Arial"]], ["literal", ["Helvetica"]]]
+            }
+        }]
+    })");
+    auto result = parser.fontStacks();
+    ASSERT_EQ(2u, result.size());
+    ASSERT_EQ(FontStack({"Arial"}), result[0]);
+    ASSERT_EQ(FontStack({"Helvetica"}), result[1]);
+}
+
+TEST(StyleParser, FontStacksMatchExpression) {
+    style::Parser parser;
+    parser.parse(R"({
+        "version": 8,
+        "layers": [{
+            "id": "symbol",
+            "type": "symbol",
+            "source": "vector",
+            "layout": {
+                "text-font": ["match", ["get", "text-font"], "a", ["literal", ["Arial"]], ["literal", ["Helvetica"]]]
+            }
+        }]
+    })");
+    auto result = parser.fontStacks();
+    ASSERT_EQ(2u, result.size());
+    ASSERT_EQ(FontStack({"Arial"}), result[0]);
+    ASSERT_EQ(FontStack({"Helvetica"}), result[1]);
+}
+
+TEST(StyleParser, FontStacksStepExpression) {
+    style::Parser parser;
+    parser.parse(R"({
+        "version": 8,
+        "layers": [{
+            "id": "symbol",
+            "type": "symbol",
+            "source": "vector",
+            "layout": {
+                "text-font": ["array", "string", ["step", ["get", "text-font"], ["literal", ["Arial"]], 0, ["literal", ["Helvetica"]]]]
+            }
+        }]
+    })");
+    auto result = parser.fontStacks();
+    ASSERT_EQ(2u, result.size());
+    ASSERT_EQ(FontStack({"Arial"}), result[0]);
+    ASSERT_EQ(FontStack({"Helvetica"}), result[1]);
+}
+
+TEST(StyleParser, FontStacksGetExpression) {
+    // Invalid style, but not currently validated.
+    style::Parser parser;
+    parser.parse(R"({
+        "version": 8,
+        "layers": [{
+            "id": "symbol",
+            "type": "symbol",
+            "source": "vector",
+            "layout": {
+                "text-font": ["array", "string", ["get", "text-font"]]
+            }
+        }]
+    })");
+    auto result = parser.fontStacks();
+    ASSERT_EQ(0u, result.size());
+}


### PR DESCRIPTION
Fixes #10535. Fixes #9939.

Before getting to the meat of the changes in the last commit, I needed to pay back some technical debt on our generated style code:

* Special case heatmap-color so it doesn't crash `make style-code` (even though I'm then ignoring 
 -- manually reverting -- all hillshade and heatmap related changes it generates)
* Commit accumulated `make style-code` updates. Some of these changes undo previous changes to generated files that didn't come with accompanying changes to the source templates (#10846) -- they'll need to be reverted once that bug is fixed. cc @tobrun and @1ec5 for reviews of Android and Darwin changes respectively.
* Deal with https://github.com/mapbox/mapbox-gl-js/commit/fa472086d4c3027a9a717f7793265272b259a875.