### PR TITLE
WIP Lifecycle arch components

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -7,6 +7,8 @@ dependencies {
     implementation rootProject.ext.dep.supportFragmentV4
     implementation rootProject.ext.dep.timber
     implementation rootProject.ext.dep.okhttp3
+    implementation rootProject.ext.dep.lifecycleRuntime
+    annotationProcessor rootProject.ext.dep.lifecycleProcessor
     compileOnly(rootProject.ext.dep.lost) {
         exclude group: 'com.google.guava'
         exclude group: 'com.android.support'
@@ -108,8 +110,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     lintOptions {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapState.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapState.java
@@ -1,0 +1,324 @@
+package com.mapbox.mapboxsdk.maps;
+
+import android.arch.lifecycle.ViewModel;
+import android.graphics.drawable.Drawable;
+import android.view.Gravity;
+
+import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
+
+import static com.mapbox.mapboxsdk.maps.MapboxMapOptions.UNDEFINED_COLOR;
+
+public class MapState extends ViewModel {
+
+  private String styleUrl;
+  private CameraPosition cameraPosition;
+  private boolean nativeDebug;
+
+  // Gestures
+  private boolean zoomGesturesEnabled = true;
+  private boolean zoomGesturesChangeAllowed = true;
+  private boolean scrollGesturesEnabled = true;
+  private boolean scrollGesturesChangeAllowed = true;
+  private boolean rotateGesturesEnabled = true;
+  private boolean rotateGesturesChangeAllowed = true;
+  private boolean tiltGesturesEnabled = true;
+  private boolean tiltGesturesChangeAllowed = true;
+  private boolean doubleTapGesturesEnabled = true;
+  private boolean doubleTapGesturesChangeAllowed = true;
+
+  // Compass
+  private boolean compassEnabled = true;
+  private boolean compassFadingNorth = true;
+  private int compassGravity = Gravity.TOP | Gravity.END;
+  private int[] compassMargins;
+  private Drawable compassImage;
+
+  // Logo
+  private boolean logoEnabled = true;
+  private int logoGravity = Gravity.BOTTOM | Gravity.START;
+  private int[] logoMargins;
+
+  // Attribution
+  private boolean attributionEnabled = true
+  private int attributionGravity = Gravity.BOTTOM | Gravity.START;
+  private int[] attributionMargins;
+  private int attributionTintColor = UNDEFINED_COLOR;
+
+  // Zoom control
+  private boolean zoomControlsEnabled;
+
+  public void update(MapboxMap mapboxMap) {
+    UiSettings uiSettings = mapboxMap.getUiSettings();
+
+    restoreCameraPosition(mapboxMap);
+    restoreGestureSettings(uiSettings);
+    restoreCompass(uiSettings);
+    restoreLogo(uiSettings);
+    restoreAttribution(uiSettings);
+    restoreZoomControl(uiSettings);
+    restoreStyle(mapboxMap);
+  }
+
+  private void restoreCameraPosition(MapboxMap mapboxMap) {
+    if (cameraPosition != null) {
+      mapboxMap.moveCamera(CameraUpdateFactory.newCameraPosition(
+        new CameraPosition.Builder(cameraPosition).build())
+      );
+    }
+  }
+
+  private void restoreGestureSettings(UiSettings uiSettings) {
+    uiSettings.setZoomGesturesEnabled(zoomGesturesEnabled);
+    uiSettings.setZoomGestureChangeAllowed(zoomGesturesChangeAllowed);
+    uiSettings.setScrollGesturesEnabled(scrollGesturesEnabled);
+    uiSettings.setScrollGestureChangeAllowed(scrollGesturesChangeAllowed);
+    uiSettings.setRotateGesturesEnabled(rotateGesturesEnabled);
+    uiSettings.setRotateGestureChangeAllowed(rotateGesturesChangeAllowed);
+    uiSettings.setTiltGesturesEnabled(tiltGesturesEnabled);
+    uiSettings.setTiltGestureChangeAllowed(tiltGesturesChangeAllowed);
+    uiSettings.setDoubleTapGesturesEnabled(doubleTapGesturesEnabled);
+    uiSettings.setDoubleTapGestureChangeAllowed(doubleTapGesturesChangeAllowed);
+  }
+
+  private void restoreCompass(UiSettings uiSettings) {
+    uiSettings.setCompassEnabled(compassEnabled);
+    uiSettings.setCompassGravity(compassGravity);
+    uiSettings.setCompassMargins(compassMargins[0], compassMargins[1], compassMargins[2], compassMargins[3]);
+    uiSettings.setCompassFadeFacingNorth(compassFadingNorth);
+    uiSettings.setCompassImage(compassImage);
+  }
+
+  private void restoreLogo(UiSettings uiSettings) {
+    uiSettings.setLogoEnabled(logoEnabled);
+    uiSettings.setLogoGravity(logoGravity);
+    uiSettings.setLogoMargins(logoMargins[0], logoMargins[1], logoMargins[2], logoMargins[3]);
+  }
+
+  private void restoreAttribution(UiSettings uiSettings) {
+    uiSettings.setAttributionEnabled(attributionEnabled);
+    uiSettings.setAttributionGravity(attributionGravity);
+    uiSettings.setAttributionMargins(attributionMargins[0], attributionMargins[1], attributionMargins[2], attributionMargins[3]);
+    uiSettings.setAttributionTintColor(attributionTintColor);
+  }
+
+  private void restoreZoomControl(UiSettings uiSettings) {
+    uiSettings.setZoomControlsEnabled(zoomControlsEnabled);
+  }
+
+  private void restoreStyle(MapboxMap mapboxMap) {
+    if (styleUrl != null && !mapboxMap.getStyleUrl().equals(styleUrl)) {
+      mapboxMap.setStyle(styleUrl);
+    }
+  }
+
+  // Getters Setters
+
+  public String getStyleUrl() {
+    return styleUrl;
+  }
+
+  public void setStyleUrl(String styleUrl) {
+    this.styleUrl = styleUrl;
+  }
+
+  public CameraPosition getCameraPosition() {
+    return cameraPosition;
+  }
+
+  public void setCameraPosition(CameraPosition cameraPosition) {
+    this.cameraPosition = cameraPosition;
+  }
+
+  public boolean isNativeDebug() {
+    return nativeDebug;
+  }
+
+  public void setNativeDebug(boolean nativeDebug) {
+    this.nativeDebug = nativeDebug;
+  }
+
+  public boolean isZoomGesturesEnabled() {
+    return zoomGesturesEnabled;
+  }
+
+  public void setZoomGesturesEnabled(boolean zoomGesturesEnabled) {
+    this.zoomGesturesEnabled = zoomGesturesEnabled;
+  }
+
+  public boolean isZoomGesturesChangeAllowed() {
+    return zoomGesturesChangeAllowed;
+  }
+
+  public void setZoomGesturesChangeAllowed(boolean zoomGesturesChangeAllowed) {
+    this.zoomGesturesChangeAllowed = zoomGesturesChangeAllowed;
+  }
+
+  public boolean isScrollGesturesEnabled() {
+    return scrollGesturesEnabled;
+  }
+
+  public void setScrollGesturesEnabled(boolean scrollGesturesEnabled) {
+    this.scrollGesturesEnabled = scrollGesturesEnabled;
+  }
+
+  public boolean isScrollGesturesChangeAllowed() {
+    return scrollGesturesChangeAllowed;
+  }
+
+  public void setScrollGesturesChangeAllowed(boolean scrollGesturesChangeAllowed) {
+    this.scrollGesturesChangeAllowed = scrollGesturesChangeAllowed;
+  }
+
+  public boolean isRotateGesturesEnabled() {
+    return rotateGesturesEnabled;
+  }
+
+  public void setRotateGesturesEnabled(boolean rotateGesturesEnabled) {
+    this.rotateGesturesEnabled = rotateGesturesEnabled;
+  }
+
+  public boolean isRotateGesturesChangeAllowed() {
+    return rotateGesturesChangeAllowed;
+  }
+
+  public void setRotateGesturesChangeAllowed(boolean rotateGesturesChangeAllowed) {
+    this.rotateGesturesChangeAllowed = rotateGesturesChangeAllowed;
+  }
+
+  public boolean isTiltGesturesEnabled() {
+    return tiltGesturesEnabled;
+  }
+
+  public void setTiltGesturesEnabled(boolean tiltGesturesEnabled) {
+    this.tiltGesturesEnabled = tiltGesturesEnabled;
+  }
+
+  public boolean isTiltGesturesChangeAllowed() {
+    return tiltGesturesChangeAllowed;
+  }
+
+  public void setTiltGesturesChangeAllowed(boolean tiltGesturesChangeAllowed) {
+    this.tiltGesturesChangeAllowed = tiltGesturesChangeAllowed;
+  }
+
+  public boolean isDoubleTapGesturesEnabled() {
+    return doubleTapGesturesEnabled;
+  }
+
+  public void setDoubleTapGesturesEnabled(boolean doubleTapGesturesEnabled) {
+    this.doubleTapGesturesEnabled = doubleTapGesturesEnabled;
+  }
+
+  public boolean isDoubleTapGesturesChangeAllowed() {
+    return doubleTapGesturesChangeAllowed;
+  }
+
+  public void setDoubleTapGesturesChangeAllowed(boolean doubleTapGesturesChangeAllowed) {
+    this.doubleTapGesturesChangeAllowed = doubleTapGesturesChangeAllowed;
+  }
+
+  public boolean isCompassEnabled() {
+    return compassEnabled;
+  }
+
+  public void setCompassEnabled(boolean compassEnabled) {
+    this.compassEnabled = compassEnabled;
+  }
+
+  public boolean isCompassFadingNorth() {
+    return compassFadingNorth;
+  }
+
+  public void setCompassFadingNorth(boolean compassFadingNorth) {
+    this.compassFadingNorth = compassFadingNorth;
+  }
+
+  public int getCompassGravity() {
+    return compassGravity;
+  }
+
+  public void setCompassGravity(int compassGravity) {
+    this.compassGravity = compassGravity;
+  }
+
+  public int[] getCompassMargins() {
+    return compassMargins;
+  }
+
+  public void setCompassMargins(int[] compassMargins) {
+    this.compassMargins = compassMargins;
+  }
+
+  public Drawable getCompassImage() {
+    return compassImage;
+  }
+
+  public void setCompassImage(Drawable compassImage) {
+    this.compassImage = compassImage;
+  }
+
+  public boolean isLogoEnabled() {
+    return logoEnabled;
+  }
+
+  public void setLogoEnabled(boolean logoEnabled) {
+    this.logoEnabled = logoEnabled;
+  }
+
+  public int getLogoGravity() {
+    return logoGravity;
+  }
+
+  public void setLogoGravity(int logoGravity) {
+    this.logoGravity = logoGravity;
+  }
+
+  public int[] getLogoMargins() {
+    return logoMargins;
+  }
+
+  public void setLogoMargins(int[] logoMargins) {
+    this.logoMargins = logoMargins;
+  }
+
+  public boolean isAttributionEnabled() {
+    return attributionEnabled;
+  }
+
+  public void setAttributionEnabled(boolean attributionEnabled) {
+    this.attributionEnabled = attributionEnabled;
+  }
+
+  public int getAttributionGravity() {
+    return attributionGravity;
+  }
+
+  public void setAttributionGravity(int attributionGravity) {
+    this.attributionGravity = attributionGravity;
+  }
+
+  public int[] getAttributionMargins() {
+    return attributionMargins;
+  }
+
+  public void setAttributionMargins(int[] attributionMargins) {
+    this.attributionMargins = attributionMargins;
+  }
+
+  public int getAttributionTintColor() {
+    return attributionTintColor;
+  }
+
+  public void setAttributionTintColor(int attributionTintColor) {
+    this.attributionTintColor = attributionTintColor;
+  }
+
+  public boolean isZoomControlsEnabled() {
+    return zoomControlsEnabled;
+  }
+
+  public void setZoomControlsEnabled(boolean zoomControlsEnabled) {
+    this.zoomControlsEnabled = zoomControlsEnabled;
+  }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
@@ -1,5 +1,6 @@
 package com.mapbox.mapboxsdk.maps;
 
+import android.arch.lifecycle.ViewModel;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Bitmap;
@@ -32,11 +33,11 @@ import java.util.Arrays;
  * MapView(Context, MapboxMapOptions). If you add a map using XML, then you can apply these options
  * using custom XML tags.
  */
-public class MapboxMapOptions implements Parcelable {
+public class MapboxMapOptions implements Parcelable{
 
   private static final float FOUR_DP = 4f;
   private static final float NINETY_TWO_DP = 92f;
-  private static final int UNDEFINED_COLOR = -1;
+  public static final int UNDEFINED_COLOR = -1;
 
   private CameraPosition cameraPosition;
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
@@ -33,36 +33,18 @@ public final class UiSettings {
   private final FocalPointChangeListener focalPointChangeListener;
   private final Projection projection;
   private final CompassView compassView;
-  private final int[] compassMargins = new int[4];
 
   private final ImageView attributionsView;
-  private final int[] attributionsMargins = new int[4];
 
   private final View logoView;
-  private final int[] logoMargins = new int[4];
 
   private float pixelRatio;
 
-  private boolean rotateGesturesEnabled = true;
-  private boolean rotateGestureChangeAllowed = true;
-
-  private boolean tiltGesturesEnabled = true;
-  private boolean tiltGestureChangeAllowed = true;
-
-  private boolean zoomGesturesEnabled = true;
-  private boolean zoomGestureChangeAllowed = true;
-
-  private boolean scrollGesturesEnabled = true;
-  private boolean scrollGestureChangeAllowed = true;
-
-  private boolean zoomControlsEnabled;
-
-  private boolean doubleTapGesturesEnabled = true;
-  private boolean doubleTapGestureChangeAllowed = true;
-
-  private boolean deselectMarkersOnTap = true;
-
   private PointF userProvidedFocalPoint;
+
+  private boolean deselectMarkersOnTap;
+
+  private MapState mapState;
 
   UiSettings(@NonNull Projection projection, @NonNull FocalPointChangeListener listener,
              @NonNull CompassView compassView, @NonNull ImageView attributionsView, @NonNull View logoView) {
@@ -189,6 +171,7 @@ public final class UiSettings {
   }
 
   private void setLogoMargins(Resources resources, int[] logoMargins) {
+    mapState.setLogoMargins(logoMargins);
     if (logoMargins != null) {
       setLogoMargins(logoMargins[0], logoMargins[1], logoMargins[2], logoMargins[3]);
     } else {
@@ -282,6 +265,7 @@ public final class UiSettings {
    * @param compassEnabled True to enable the compass; false to disable the compass.
    */
   public void setCompassEnabled(boolean compassEnabled) {
+    mapState.setCompassEnabled(compassEnabled);
     compassView.setEnabled(compassEnabled);
   }
 
@@ -291,7 +275,7 @@ public final class UiSettings {
    * @return True if the compass is enabled; false if the compass is disabled.
    */
   public boolean isCompassEnabled() {
-    return compassView.isEnabled();
+    return mapState.isCompassEnabled();
   }
 
   /**
@@ -305,6 +289,7 @@ public final class UiSettings {
    */
   @UiThread
   public void setCompassGravity(int gravity) {
+    mapState.setCompassGravity(gravity);
     setWidgetGravity(compassView, gravity);
   }
 
@@ -317,6 +302,7 @@ public final class UiSettings {
    * @param compassFadeFacingNorth True to enable the fading animation; false to disable it
    */
   public void setCompassFadeFacingNorth(boolean compassFadeFacingNorth) {
+    mapState.setCompassFadingNorth(compassFadeFacingNorth);
     compassView.fadeCompassViewFacingNorth(compassFadeFacingNorth);
   }
 
@@ -329,6 +315,7 @@ public final class UiSettings {
    * @param compass the drawable to show as image compass
    */
   public void setCompassImage(Drawable compass) {
+    mapState.setCompassImage(compass);
     compassView.setCompassImage(compass);
   }
 
@@ -338,7 +325,7 @@ public final class UiSettings {
    * @return True if the compass will fade, false if it remains visible
    */
   public boolean isCompassFadeWhenFacingNorth() {
-    return compassView.isFadeCompassViewFacingNorth();
+    return mapState.isCompassFadingNorth();
   }
 
   /**
@@ -347,7 +334,7 @@ public final class UiSettings {
    * @return The gravity
    */
   public int getCompassGravity() {
-    return ((FrameLayout.LayoutParams) compassView.getLayoutParams()).gravity;
+    return mapState.getCompassGravity();
   }
 
   /**
@@ -361,7 +348,8 @@ public final class UiSettings {
    */
   @UiThread
   public void setCompassMargins(int left, int top, int right, int bottom) {
-    setWidgetMargins(compassView, compassMargins, left, top, right, bottom);
+    mapState.setCompassMargins(new int[] {left, top, right, bottom});
+    setWidgetMargins(compassView, mapState.getCompassMargins(), left, top, right, bottom);
   }
 
   /**
@@ -370,7 +358,7 @@ public final class UiSettings {
    * @return The left margin in pixels
    */
   public int getCompassMarginLeft() {
-    return compassMargins[0];
+    return mapState.getCompassMargins()[0];
   }
 
   /**
@@ -379,7 +367,7 @@ public final class UiSettings {
    * @return The top margin in pixels
    */
   public int getCompassMarginTop() {
-    return compassMargins[1];
+    return mapState.getCompassMargins()[1];
   }
 
   /**
@@ -388,7 +376,7 @@ public final class UiSettings {
    * @return The right margin in pixels
    */
   public int getCompassMarginRight() {
-    return compassMargins[2];
+    return mapState.getCompassMargins()[2];
   }
 
   /**
@@ -397,7 +385,7 @@ public final class UiSettings {
    * @return The bottom margin in pixels
    */
   public int getCompassMarginBottom() {
-    return compassMargins[3];
+    return mapState.getCompassMargins()[3];
   }
 
   /**
@@ -427,6 +415,7 @@ public final class UiSettings {
    * @param enabled True to enable the logo; false to disable the logo.
    */
   public void setLogoEnabled(boolean enabled) {
+    mapState.setLogoEnabled(enabled);
     logoView.setVisibility(enabled ? View.VISIBLE : View.GONE);
   }
 
@@ -436,7 +425,8 @@ public final class UiSettings {
    * @return True if the logo is enabled; false if the logo is disabled.
    */
   public boolean isLogoEnabled() {
-    return logoView.getVisibility() == View.VISIBLE;
+    return mapState.isLogoEnabled();
+//    return logoView.getVisibility() == View.VISIBLE;
   }
 
   /**
@@ -449,6 +439,7 @@ public final class UiSettings {
    * @param gravity Android SDK Gravity.
    */
   public void setLogoGravity(int gravity) {
+    mapState.setLogoGravity(gravity);
     setWidgetGravity(logoView, gravity);
   }
 
@@ -458,7 +449,7 @@ public final class UiSettings {
    * @return The gravity
    */
   public int getLogoGravity() {
-    return ((FrameLayout.LayoutParams) logoView.getLayoutParams()).gravity;
+    return mapState.getLogoGravity();
   }
 
   /**
@@ -471,7 +462,8 @@ public final class UiSettings {
    * @param bottom The bottom margin in pixels.
    */
   public void setLogoMargins(int left, int top, int right, int bottom) {
-    setWidgetMargins(logoView, logoMargins, left, top, right, bottom);
+    mapState.setLogoMargins(new int[] {left, top, right, bottom});
+    setWidgetMargins(logoView, mapState.getLogoMargins(), left, top, right, bottom);
   }
 
   /**
@@ -480,7 +472,7 @@ public final class UiSettings {
    * @return The left margin in pixels
    */
   public int getLogoMarginLeft() {
-    return logoMargins[0];
+    return mapState.getLogoMargins()[0];
   }
 
   /**
@@ -489,7 +481,7 @@ public final class UiSettings {
    * @return The top margin in pixels
    */
   public int getLogoMarginTop() {
-    return logoMargins[1];
+    return mapState.getLogoMargins()[1];
   }
 
   /**
@@ -498,7 +490,7 @@ public final class UiSettings {
    * @return The right margin in pixels
    */
   public int getLogoMarginRight() {
-    return logoMargins[2];
+    return mapState.getLogoMargins()[2];
   }
 
   /**
@@ -507,7 +499,7 @@ public final class UiSettings {
    * @return The bottom margin in pixels
    */
   public int getLogoMarginBottom() {
-    return logoMargins[3];
+    return mapState.getLogoMargins()[3];
   }
 
   /**
@@ -519,6 +511,7 @@ public final class UiSettings {
    * @param enabled True to enable the attribution; false to disable the attribution.
    */
   public void setAttributionEnabled(boolean enabled) {
+    mapState.setAttributionEnabled(enabled);
     attributionsView.setVisibility(enabled ? View.VISIBLE : View.GONE);
   }
 
@@ -528,7 +521,7 @@ public final class UiSettings {
    * @return True if the attribution is enabled; false if the attribution is disabled.
    */
   public boolean isAttributionEnabled() {
-    return attributionsView.getVisibility() == View.VISIBLE;
+    return mapState.isAttributionEnabled();
   }
 
   /**
@@ -540,6 +533,7 @@ public final class UiSettings {
    * @param gravity Android SDK Gravity.
    */
   public void setAttributionGravity(int gravity) {
+    mapState.setAttributionGravity(gravity);
     setWidgetGravity(attributionsView, gravity);
   }
 
@@ -549,7 +543,7 @@ public final class UiSettings {
    * @return The gravity
    */
   public int getAttributionGravity() {
-    return ((FrameLayout.LayoutParams) attributionsView.getLayoutParams()).gravity;
+    return mapState.getAttributionGravity();
   }
 
   /**
@@ -561,7 +555,8 @@ public final class UiSettings {
    * @param bottom The bottom margin in pixels.
    */
   public void setAttributionMargins(int left, int top, int right, int bottom) {
-    setWidgetMargins(attributionsView, attributionsMargins, left, top, right, bottom);
+    mapState.setAttributionMargins(new int[] {left, top, right, bottom});
+    setWidgetMargins(attributionsView, mapState.getAttributionMargins(), left, top, right, bottom);
   }
 
   /**
@@ -588,7 +583,7 @@ public final class UiSettings {
    * @return The left margin in pixels
    */
   public int getAttributionMarginLeft() {
-    return attributionsMargins[0];
+    return mapState.getAttributionMargins()[0];
   }
 
   /**
@@ -597,7 +592,7 @@ public final class UiSettings {
    * @return The top margin in pixels
    */
   public int getAttributionMarginTop() {
-    return attributionsMargins[1];
+    return mapState.getAttributionMargins()[1];
   }
 
   /**
@@ -606,7 +601,7 @@ public final class UiSettings {
    * @return The right margin in pixels
    */
   public int getAttributionMarginRight() {
-    return attributionsMargins[2];
+    return mapState.getAttributionMargins()[2];
   }
 
   /**
@@ -615,7 +610,7 @@ public final class UiSettings {
    * @return The bottom margin in pixels
    */
   public int getAttributionMarginBottom() {
-    return attributionsMargins[3];
+    return mapState.getAttributionMargins()[3];
   }
 
   /**
@@ -631,8 +626,8 @@ public final class UiSettings {
    * @param rotateGesturesEnabled If true, rotating is enabled.
    */
   public void setRotateGesturesEnabled(boolean rotateGesturesEnabled) {
-    if (rotateGestureChangeAllowed) {
-      this.rotateGesturesEnabled = rotateGesturesEnabled;
+    if (mapState.isRotateGesturesChangeAllowed()) {
+      mapState.setRotateGesturesEnabled(rotateGesturesEnabled);
     }
   }
 
@@ -642,15 +637,15 @@ public final class UiSettings {
    * @return If true, rotating is enabled.
    */
   public boolean isRotateGesturesEnabled() {
-    return rotateGesturesEnabled;
+    return mapState.isRotateGesturesEnabled();
   }
 
   void setRotateGestureChangeAllowed(boolean rotateGestureChangeAllowed) {
-    this.rotateGestureChangeAllowed = rotateGestureChangeAllowed;
+    mapState.setRotateGesturesChangeAllowed(rotateGestureChangeAllowed);
   }
 
   boolean isRotateGestureChangeAllowed() {
-    return rotateGestureChangeAllowed;
+    return mapState.isRotateGesturesChangeAllowed();
   }
 
   /**
@@ -666,8 +661,8 @@ public final class UiSettings {
    * @param tiltGesturesEnabled If true, tilting is enabled.
    */
   public void setTiltGesturesEnabled(boolean tiltGesturesEnabled) {
-    if (tiltGestureChangeAllowed) {
-      this.tiltGesturesEnabled = tiltGesturesEnabled;
+    if (mapState.isTiltGesturesChangeAllowed()) {
+      mapState.setTiltGesturesEnabled(tiltGesturesEnabled);
     }
   }
 
@@ -677,15 +672,15 @@ public final class UiSettings {
    * @return If true, tilting is enabled.
    */
   public boolean isTiltGesturesEnabled() {
-    return tiltGesturesEnabled;
+    return mapState.isTiltGesturesEnabled();
   }
 
   void setTiltGestureChangeAllowed(boolean tiltGestureChangeAllowed) {
-    this.tiltGestureChangeAllowed = tiltGestureChangeAllowed;
+    mapState.setTiltGesturesChangeAllowed(tiltGestureChangeAllowed);
   }
 
   boolean isTiltGestureChangeAllowed() {
-    return tiltGestureChangeAllowed;
+    return mapState.isTiltGesturesChangeAllowed();
   }
 
   /**
@@ -701,8 +696,8 @@ public final class UiSettings {
    * @param zoomGesturesEnabled If true, zooming is enabled.
    */
   public void setZoomGesturesEnabled(boolean zoomGesturesEnabled) {
-    if (zoomGestureChangeAllowed) {
-      this.zoomGesturesEnabled = zoomGesturesEnabled;
+    if (mapState.isZoomGesturesChangeAllowed()) {
+      mapState.setZoomGesturesEnabled(zoomGesturesEnabled);
     }
   }
 
@@ -712,15 +707,15 @@ public final class UiSettings {
    * @return If true, zooming is enabled.
    */
   public boolean isZoomGesturesEnabled() {
-    return zoomGesturesEnabled;
+    return mapState.isZoomGesturesEnabled();
   }
 
   void setZoomGestureChangeAllowed(boolean zoomGestureChangeAllowed) {
-    this.zoomGestureChangeAllowed = zoomGestureChangeAllowed;
+    mapState.setZoomGesturesChangeAllowed(zoomGestureChangeAllowed);
   }
 
   boolean isZoomGestureChangeAllowed() {
-    return zoomGestureChangeAllowed;
+    return mapState.isZoomGesturesChangeAllowed();
   }
 
   /**
@@ -736,7 +731,7 @@ public final class UiSettings {
    * @param zoomControlsEnabled If true, the zoom controls are enabled.
    */
   public void setZoomControlsEnabled(boolean zoomControlsEnabled) {
-    this.zoomControlsEnabled = zoomControlsEnabled;
+    mapState.setZoomControlsEnabled(zoomControlsEnabled);
   }
 
   /**
@@ -745,7 +740,7 @@ public final class UiSettings {
    * @return If true, the zoom controls are enabled.
    */
   public boolean isZoomControlsEnabled() {
-    return zoomControlsEnabled;
+    return mapState.isZoomControlsEnabled();
   }
 
   /**
@@ -761,8 +756,8 @@ public final class UiSettings {
    * @param doubleTapGesturesEnabled If true, zooming with a double tap is enabled.
    */
   public void setDoubleTapGesturesEnabled(boolean doubleTapGesturesEnabled) {
-    if (doubleTapGestureChangeAllowed) {
-      this.doubleTapGesturesEnabled = doubleTapGesturesEnabled;
+    if (mapState.isDoubleTapGesturesChangeAllowed()) {
+      mapState.setDoubleTapGesturesEnabled(doubleTapGesturesEnabled);
     }
   }
 
@@ -772,15 +767,15 @@ public final class UiSettings {
    * @return If true, zooming with a double tap is enabled.
    */
   public boolean isDoubleTapGesturesEnabled() {
-    return doubleTapGesturesEnabled;
+    return mapState.isDoubleTapGesturesEnabled();
   }
 
   void setDoubleTapGestureChangeAllowed(boolean doubleTapGestureChangeAllowed) {
-    this.doubleTapGestureChangeAllowed = doubleTapGestureChangeAllowed;
+    mapState.setDoubleTapGesturesChangeAllowed(doubleTapGestureChangeAllowed);
   }
 
   boolean isDoubleTapGestureChangeAllowed() {
-    return doubleTapGestureChangeAllowed;
+    return mapState.isDoubleTapGesturesChangeAllowed();
   }
 
   /**
@@ -816,8 +811,8 @@ public final class UiSettings {
    * @param scrollGesturesEnabled If true, scrolling is enabled.
    */
   public void setScrollGesturesEnabled(boolean scrollGesturesEnabled) {
-    if (scrollGestureChangeAllowed) {
-      this.scrollGesturesEnabled = scrollGesturesEnabled;
+    if (mapState.isScrollGesturesChangeAllowed()) {
+      mapState.setScrollGesturesEnabled(scrollGesturesEnabled);
     }
   }
 
@@ -827,15 +822,15 @@ public final class UiSettings {
    * @return If true, scrolling is enabled.
    */
   public boolean isScrollGesturesEnabled() {
-    return scrollGesturesEnabled;
+    return mapState.isScrollGesturesEnabled();
   }
 
   void setScrollGestureChangeAllowed(boolean scrollGestureChangeAllowed) {
-    this.scrollGestureChangeAllowed = scrollGestureChangeAllowed;
+    mapState.setScrollGesturesChangeAllowed(scrollGestureChangeAllowed);
   }
 
   boolean isScrollGestureChangeAllowed() {
-    return scrollGestureChangeAllowed;
+    return mapState.isScrollGesturesChangeAllowed();
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -78,6 +78,9 @@ dependencies {
     androidTestImplementation rootProject.ext.dep.testRules
     androidTestImplementation rootProject.ext.dep.testEspressoCore
     androidTestImplementation rootProject.ext.dep.testEspressoIntents
+
+    implementation rootProject.ext.dep.lifecycleRuntime
+    annotationProcessor rootProject.ext.dep.lifecycleProcessor
 }
 
 apply from: 'gradle-make.gradle'

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/SimpleMapActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/SimpleMapActivity.java
@@ -3,7 +3,6 @@ package com.mapbox.mapboxsdk.testapp.activity.maplayout;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
-import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.testapp.R;
 
 /**
@@ -11,56 +10,9 @@ import com.mapbox.mapboxsdk.testapp.R;
  */
 public class SimpleMapActivity extends AppCompatActivity {
 
-  private MapView mapView;
-
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_map_simple);
-
-    mapView = (MapView) findViewById(R.id.mapView);
-    mapView.onCreate(savedInstanceState);
-  }
-
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
-  public void onLowMemory() {
-    super.onLowMemory();
-    mapView.onLowMemory();
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
-  }
-
-  @Override
-  protected void onSaveInstanceState(Bundle outState) {
-    super.onSaveInstanceState(outState);
-    mapView.onSaveInstanceState(outState);
   }
 }

--- a/platform/android/dependencies.gradle
+++ b/platform/android/dependencies.gradle
@@ -1,14 +1,14 @@
 ext {
     minSdkVersion = 14
-    targetSdkVersion = 25
-    compileSdkVersion = 25
-    buildToolsVersion = "26.0.3"
+    targetSdkVersion = 27
+    compileSdkVersion = 27
+    buildToolsVersion = "27.0.3"
 
     versionCode = 12
     versionName = "6.0.0"
 
     mapboxServicesVersion = "2.2.9"
-    supportLibVersion = "25.4.0"
+    supportLibVersion = "27.0.2"
     espressoVersion = '3.0.1'
     testRunnerVersion = '1.0.1'
     leakCanaryVersion = '1.5.1'
@@ -39,6 +39,10 @@ ext {
             supportFragmentV4      : "com.android.support:support-fragment:${supportLibVersion}",
             supportDesign          : "com.android.support:design:${supportLibVersion}",
             supportRecyclerView    : "com.android.support:recyclerview-v7:${supportLibVersion}",
+
+            // arch components
+            lifecycleRuntime       : "android.arch.lifecycle:extensions:1.0.0",
+            lifecycleProcessor     : "android.arch.lifecycle:common-java8:1.0.0",
 
             // square crew
             timber                 : 'com.jakewharton.timber:timber:4.5.1',


### PR DESCRIPTION
This WIP PR adds integration for [Android Architecture Components](https://developer.android.com/topic/libraries/architecture/index.html). This change allows us to remove the required lifecyle methods on MapView. Below you can see the SimpleMapActivity that used to look like [this](https://github.com/mapbox/mapbox-gl-native/blob/master/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/SimpleMapActivity.java).

![screenshot from 2018-01-09 14-40-23](https://user-images.githubusercontent.com/2151639/34726096-511abb60-f553-11e7-9425-a77d2de68e56.png)

To do:
 - [ ] determine binary size impact 
 - [ ] determine minimal dependency configuration
 - [ ] saving state using a ViewModel (using the lifecycle arch components results in not being able to rely on saved instance state anymore, to support restoring state we will have to integrate a ViewModel.) 
 - [ ] allow/test backwards compatibility with Activity instances not integrating lifecycle components.