### PR TITLE
Use the correct cancelable callback after posting cancel

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -6,7 +6,6 @@ import android.graphics.PointF;
 import android.graphics.RectF;
 import android.location.Location;
 import android.os.Bundle;
-import android.os.Handler;
 import android.support.annotation.FloatRange;
 import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
@@ -713,20 +712,6 @@ public final class MapboxMap {
    */
   public final void moveCamera(final CameraUpdate update, final MapboxMap.CancelableCallback callback) {
     transform.moveCamera(MapboxMap.this, update, callback);
-    // MapChange.REGION_DID_CHANGE_ANIMATED is not called for `jumpTo`
-    // invalidate camera position to provide OnCameraChange event.
-    invalidateCameraPosition();
-
-    if (callback != null) {
-      new Handler().post(new Runnable() {
-        @Override
-        public void run() {
-          if (callback != null) {
-            callback.onFinish();
-          }
-        }
-      });
-    }
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
@@ -32,6 +32,7 @@ final class Transform implements MapView.OnMapChangedListener {
   private final MarkerViewManager markerViewManager;
   private final TrackingSettings trackingSettings;
   private final MyLocationView myLocationView;
+  private final Handler handler = new Handler();
 
   private CameraPosition cameraPosition;
   private MapboxMap.CancelableCallback cameraCancelableCallback;
@@ -83,7 +84,7 @@ final class Transform implements MapView.OnMapChangedListener {
     if (change == REGION_DID_CHANGE_ANIMATED) {
       updateCameraPosition(invalidateCameraPosition());
       if (cameraCancelableCallback != null) {
-        new Handler().post(new Runnable() {
+        handler.post(new Runnable() {
           @Override
           public void run() {
             if (cameraCancelableCallback != null) {
@@ -99,7 +100,7 @@ final class Transform implements MapView.OnMapChangedListener {
   }
 
   @UiThread
-  final void moveCamera(MapboxMap mapboxMap, CameraUpdate update, MapboxMap.CancelableCallback callback) {
+  final void moveCamera(MapboxMap mapboxMap, CameraUpdate update, final MapboxMap.CancelableCallback callback) {
     CameraPosition cameraPosition = update.getCameraPosition(mapboxMap);
     if (isValidCameraPosition(cameraPosition)) {
       trackingSettings.resetTrackingModesIfRequired(this.cameraPosition, cameraPosition, false);
@@ -107,6 +108,15 @@ final class Transform implements MapView.OnMapChangedListener {
       cameraChangeDispatcher.onCameraMoveStarted(OnCameraMoveStartedListener.REASON_API_ANIMATION);
       mapView.jumpTo(cameraPosition.bearing, cameraPosition.target, cameraPosition.tilt, cameraPosition.zoom);
       cameraChangeDispatcher.onCameraIdle();
+      invalidateCameraPosition();
+      handler.post(new Runnable() {
+        @Override
+        public void run() {
+          if (callback != null) {
+            callback.onFinish();
+          }
+        }
+      });
     }
   }
 
@@ -182,16 +192,15 @@ final class Transform implements MapView.OnMapChangedListener {
 
     // notify animateCamera and easeCamera about cancelling
     if (cameraCancelableCallback != null) {
+      final MapboxMap.CancelableCallback callback = cameraCancelableCallback;
       cameraChangeDispatcher.onCameraIdle();
-      new Handler().post(new Runnable() {
+      handler.post(new Runnable() {
         @Override
         public void run() {
-          if (cameraCancelableCallback != null) {
-            cameraCancelableCallback.onCancel();
-            cameraCancelableCallback = null;
-          }
+          callback.onCancel();
         }
       });
+      cameraCancelableCallback = null;
     }
 
     // cancel ongoing transitions

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraPositionActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraPositionActivity.java
@@ -13,7 +13,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.SeekBar;
 import android.widget.TextView;
-
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -21,7 +20,6 @@ import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.testapp.R;
-
 import timber.log.Timber;
 
 /**


### PR DESCRIPTION
A user reached out about the change introduced in https://github.com/mapbox/mapbox-gl-native/pull/10664. When an animation is started while another is ongoing, the onCancel callback of the newer animation will be invoked instead of the callback of the old animation.