### PR TITLE
Use separate shaders for background and clipping

### DIFF
--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -128,10 +128,13 @@ set(MBGL_CORE_FILES
 
     # programs
     src/mbgl/programs/attributes.hpp
+    src/mbgl/programs/background_program.cpp
+    src/mbgl/programs/background_program.hpp
     src/mbgl/programs/binary_program.cpp
     src/mbgl/programs/binary_program.hpp
     src/mbgl/programs/circle_program.cpp
     src/mbgl/programs/circle_program.hpp
+    src/mbgl/programs/clipping_mask_program.hpp
     src/mbgl/programs/collision_box_program.cpp
     src/mbgl/programs/collision_box_program.hpp
     src/mbgl/programs/debug_program.hpp
@@ -254,8 +257,14 @@ set(MBGL_CORE_FILES
     src/mbgl/renderer/sources/render_vector_source.hpp
 
     # shaders
+    src/mbgl/shaders/background.cpp
+    src/mbgl/shaders/background.hpp
+    src/mbgl/shaders/background_pattern.cpp
+    src/mbgl/shaders/background_pattern.hpp
     src/mbgl/shaders/circle.cpp
     src/mbgl/shaders/circle.hpp
+    src/mbgl/shaders/clipping_mask.cpp
+    src/mbgl/shaders/clipping_mask.hpp
     src/mbgl/shaders/collision_box.cpp
     src/mbgl/shaders/collision_box.hpp
     src/mbgl/shaders/collision_circle.cpp
@@ -630,6 +639,7 @@ set(MBGL_CORE_FILES
     include/mbgl/util/tileset.hpp
     include/mbgl/util/timer.hpp
     include/mbgl/util/traits.hpp
+    include/mbgl/util/tuple.hpp
     include/mbgl/util/type_list.hpp
     include/mbgl/util/unique_any.hpp
     include/mbgl/util/unitbezier.hpp

--- a/src/mbgl/programs/attributes.hpp
+++ b/src/mbgl/programs/attributes.hpp
@@ -143,4 +143,9 @@ struct a_halo_blur {
 };
 
 } // namespace attributes
+
+struct PositionOnlyLayoutAttributes : gl::Attributes<
+    attributes::a_pos>
+{};
+
 } // namespace mbgl

--- a/src/mbgl/programs/background_program.cpp
+++ b/src/mbgl/programs/background_program.cpp
@@ -1,0 +1,47 @@
+#include <mbgl/programs/background_program.hpp>
+#include <mbgl/renderer/image_atlas.hpp>
+#include <mbgl/renderer/cross_faded_property_evaluator.hpp>
+#include <mbgl/tile/tile_id.hpp>
+#include <mbgl/map/transform_state.hpp>
+
+namespace mbgl {
+
+using namespace style;
+
+static_assert(sizeof(BackgroundLayoutVertex) == 4, "expected BackgroundLayoutVertex size");
+
+BackgroundPatternUniforms::Values
+BackgroundPatternUniforms::values(mat4 matrix,
+                                  float opacity,
+                                  Size atlasSize,
+                                  const ImagePosition& a,
+                                  const ImagePosition& b,
+                                  const Faded<std::string>& fading,
+                                  const UnwrappedTileID& tileID,
+                                  const TransformState& state)
+{
+    int32_t tileSizeAtNearestZoom = util::tileSize * state.zoomScale(state.getIntegerZoom() - tileID.canonical.z);
+    int32_t pixelX = tileSizeAtNearestZoom * (tileID.canonical.x + tileID.wrap * state.zoomScale(tileID.canonical.z));
+    int32_t pixelY = tileSizeAtNearestZoom * tileID.canonical.y;
+
+    return BackgroundPatternUniforms::Values {
+        uniforms::u_matrix::Value{ matrix },
+        uniforms::u_opacity::Value{ opacity },
+        uniforms::u_texsize::Value{ atlasSize },
+        uniforms::u_pattern_tl_a::Value{ a.tl() },
+        uniforms::u_pattern_br_a::Value{ a.br() },
+        uniforms::u_pattern_tl_b::Value{ b.tl() },
+        uniforms::u_pattern_br_b::Value{ b.br() },
+        uniforms::u_pattern_size_a::Value{ a.displaySize() },
+        uniforms::u_pattern_size_b::Value{ b.displaySize() },
+        uniforms::u_scale_a::Value{ fading.fromScale },
+        uniforms::u_scale_b::Value{ fading.toScale },
+        uniforms::u_mix::Value{ fading.t },
+        uniforms::u_image::Value{ 0 },
+        uniforms::u_pixel_coord_upper::Value{ std::array<float, 2> {{ float(pixelX >> 16), float(pixelY >> 16) }} },
+        uniforms::u_pixel_coord_lower::Value{ std::array<float, 2> {{ float(pixelX & 0xFFFF), float(pixelY & 0xFFFF) }} },
+        uniforms::u_tile_units_to_pixels::Value{ 1.0f / tileID.pixelsToTileUnits(1.0f, state.getIntegerZoom()) },
+    };
+}
+
+} // namespace mbgl

--- a/src/mbgl/programs/background_program.hpp
+++ b/src/mbgl/programs/background_program.hpp
@@ -64,15 +64,6 @@ class BackgroundProgram : public Program<
 {
 public:
     using Program::Program;
-
-    static LayoutVertex layoutVertex(Point<int16_t> p) {
-        return LayoutVertex {
-            {{
-                p.x,
-                p.y
-            }}
-        };
-    }
 };
 
 class BackgroundPatternProgram : public Program<

--- a/src/mbgl/programs/background_program.hpp
+++ b/src/mbgl/programs/background_program.hpp
@@ -3,14 +3,12 @@
 #include <mbgl/programs/program.hpp>
 #include <mbgl/programs/attributes.hpp>
 #include <mbgl/programs/uniforms.hpp>
-#include <mbgl/shaders/fill.hpp>
-#include <mbgl/shaders/fill_pattern.hpp>
-#include <mbgl/shaders/fill_outline.hpp>
-#include <mbgl/shaders/fill_outline_pattern.hpp>
+#include <mbgl/shaders/background.hpp>
+#include <mbgl/shaders/background_pattern.hpp>
 #include <mbgl/util/geometry.hpp>
 #include <mbgl/util/mat4.hpp>
 #include <mbgl/util/size.hpp>
-#include <mbgl/style/layers/fill_layer_properties.hpp>
+#include <mbgl/style/layers/background_layer_properties.hpp>
 
 #include <string>
 
@@ -21,16 +19,17 @@ class UnwrappedTileID;
 class TransformState;
 template <class> class Faded;
 
-using FillLayoutAttributes = PositionOnlyLayoutAttributes;
+using BackgroundLayoutAttributes = PositionOnlyLayoutAttributes;
 
-struct FillUniforms : gl::Uniforms<
+struct BackgroundUniforms : gl::Uniforms<
     uniforms::u_matrix,
-    uniforms::u_world>
+    uniforms::u_color,
+    uniforms::u_opacity>
 {};
 
-struct FillPatternUniforms : gl::Uniforms<
+struct BackgroundPatternUniforms : gl::Uniforms<
     uniforms::u_matrix,
-    uniforms::u_world,
+    uniforms::u_opacity,
     uniforms::u_texsize,
     uniforms::u_pattern_tl_a,
     uniforms::u_pattern_br_a,
@@ -47,7 +46,7 @@ struct FillPatternUniforms : gl::Uniforms<
     uniforms::u_tile_units_to_pixels>
 {
     static Values values(mat4 matrix,
-                         Size framebufferSize,
+                         float opacity,
                          Size atlasSize,
                          const ImagePosition&,
                          const ImagePosition&,
@@ -56,12 +55,12 @@ struct FillPatternUniforms : gl::Uniforms<
                          const TransformState&);
 };
 
-class FillProgram : public Program<
-    shaders::fill,
+class BackgroundProgram : public Program<
+    shaders::background,
     gl::Triangle,
-    FillLayoutAttributes,
-    FillUniforms,
-    style::FillPaintProperties>
+    BackgroundLayoutAttributes,
+    BackgroundUniforms,
+    style::Properties<>>
 {
 public:
     using Program::Program;
@@ -76,40 +75,18 @@ public:
     }
 };
 
-class FillPatternProgram : public Program<
-    shaders::fill_pattern,
+class BackgroundPatternProgram : public Program<
+    shaders::background_pattern,
     gl::Triangle,
-    FillLayoutAttributes,
-    FillPatternUniforms,
-    style::FillPaintProperties>
+    BackgroundLayoutAttributes,
+    BackgroundPatternUniforms,
+    style::Properties<>>
 {
 public:
     using Program::Program;
 };
 
-class FillOutlineProgram : public Program<
-    shaders::fill_outline,
-    gl::Line,
-    FillLayoutAttributes,
-    FillUniforms,
-    style::FillPaintProperties>
-{
-public:
-    using Program::Program;
-};
-
-class FillOutlinePatternProgram : public Program<
-    shaders::fill_outline_pattern,
-    gl::Line,
-    FillLayoutAttributes,
-    FillPatternUniforms,
-    style::FillPaintProperties>
-{
-public:
-    using Program::Program;
-};
-
-using FillLayoutVertex = FillProgram::LayoutVertex;
-using FillAttributes = FillProgram::Attributes;
+using BackgroundLayoutVertex = BackgroundProgram::LayoutVertex;
+using BackgroundAttributes = BackgroundProgram::Attributes;
 
 } // namespace mbgl

--- a/src/mbgl/programs/clipping_mask_program.hpp
+++ b/src/mbgl/programs/clipping_mask_program.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <mbgl/programs/program.hpp>
+#include <mbgl/programs/attributes.hpp>
+#include <mbgl/programs/uniforms.hpp>
+#include <mbgl/shaders/clipping_mask.hpp>
+#include <mbgl/style/properties.hpp>
+
+namespace mbgl {
+
+class ClippingMaskProgram : public Program<
+    shaders::clipping_mask,
+    gl::Triangle,
+    PositionOnlyLayoutAttributes,
+    gl::Uniforms<
+        uniforms::u_matrix>,
+    style::Properties<>>
+{
+public:
+    using Program::Program;
+};
+
+using ClippingMaskLayoutVertex = ClippingMaskProgram::LayoutVertex;
+using ClippingMaskAttributes = ClippingMaskProgram::Attributes;
+
+} // namespace mbgl

--- a/src/mbgl/programs/programs.hpp
+++ b/src/mbgl/programs/programs.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <mbgl/programs/background_program.hpp>
 #include <mbgl/programs/circle_program.hpp>
+#include <mbgl/programs/clipping_mask_program.hpp>
 #include <mbgl/programs/extrusion_texture_program.hpp>
 #include <mbgl/programs/fill_program.hpp>
 #include <mbgl/programs/fill_extrusion_program.hpp>
@@ -16,7 +18,9 @@ namespace mbgl {
 class Programs {
 public:
     Programs(gl::Context& context, const ProgramParameters& programParameters)
-        : circle(context, programParameters),
+        : background(context, programParameters),
+          backgroundPattern(context, programParameters),
+          circle(context, programParameters),
           extrusionTexture(context, programParameters),
           fill(context, programParameters),
           fillExtrusion(context, programParameters),
@@ -33,9 +37,12 @@ public:
           symbolGlyph(context, programParameters),
           debug(context, programParameters),
           collisionBox(context, programParameters),
-          collisionCircle(context, programParameters) {
+          collisionCircle(context, programParameters),
+          clippingMask(context, programParameters) {
     }
 
+    BackgroundProgram background;
+    BackgroundPatternProgram backgroundPattern;
     ProgramMap<CircleProgram> circle;
     ExtrusionTextureProgram extrusionTexture;
     ProgramMap<FillProgram> fill;
@@ -55,6 +62,7 @@ public:
     DebugProgram debug;
     CollisionBoxProgram collisionBox;
     CollisionCircleProgram collisionCircle;
+    ClippingMaskProgram clippingMask;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/render_static_data.cpp
+++ b/src/mbgl/renderer/render_static_data.cpp
@@ -3,12 +3,12 @@
 
 namespace mbgl {
 
-static gl::VertexVector<FillLayoutVertex> tileVertices() {
-    gl::VertexVector<FillLayoutVertex> result;
-    result.emplace_back(FillProgram::layoutVertex({ 0,            0 }));
-    result.emplace_back(FillProgram::layoutVertex({ util::EXTENT, 0 }));
-    result.emplace_back(FillProgram::layoutVertex({ 0, util::EXTENT }));
-    result.emplace_back(FillProgram::layoutVertex({ util::EXTENT, util::EXTENT }));
+static gl::VertexVector<PositionOnlyLayoutAttributes::Vertex> tileVertices() {
+    gl::VertexVector<PositionOnlyLayoutAttributes::Vertex> result;
+    result.emplace_back(PositionOnlyLayoutAttributes::Vertex({{{ 0,            0 }}}));
+    result.emplace_back(PositionOnlyLayoutAttributes::Vertex({{{ util::EXTENT, 0 }}}));
+    result.emplace_back(PositionOnlyLayoutAttributes::Vertex({{{ 0, util::EXTENT }}}));
+    result.emplace_back(PositionOnlyLayoutAttributes::Vertex({{{ util::EXTENT, util::EXTENT }}}));
     return result;
 }
 

--- a/src/mbgl/renderer/render_static_data.hpp
+++ b/src/mbgl/renderer/render_static_data.hpp
@@ -13,14 +13,14 @@ class RenderStaticData {
 public:
     RenderStaticData(gl::Context&, float pixelRatio, const optional<std::string>& programCacheDir);
 
-    gl::VertexBuffer<FillLayoutVertex> tileVertexBuffer;
+    gl::VertexBuffer<PositionOnlyLayoutAttributes::Vertex> tileVertexBuffer;
     gl::VertexBuffer<RasterLayoutVertex> rasterVertexBuffer;
     gl::VertexBuffer<ExtrusionTextureLayoutVertex> extrusionTextureVertexBuffer;
 
     gl::IndexBuffer<gl::Triangles> quadTriangleIndexBuffer;
     gl::IndexBuffer<gl::LineStrip> tileBorderIndexBuffer;
 
-    SegmentVector<FillAttributes> tileTriangleSegments;
+    SegmentVector<BackgroundAttributes> tileTriangleSegments;
     SegmentVector<DebugAttributes> tileBorderSegments;
     SegmentVector<RasterAttributes> rasterSegments;
     SegmentVector<ExtrusionTextureAttributes> extrusionTextureSegments;

--- a/src/mbgl/renderer/render_tile.cpp
+++ b/src/mbgl/renderer/render_tile.cpp
@@ -72,7 +72,7 @@ void RenderTile::finishRender(PaintParameters& parameters) {
         return;
 
     static const style::Properties<>::PossiblyEvaluated properties {};
-    static const DebugProgram::PaintPropertyBinders paintAttibuteData(properties, 0);
+    static const DebugProgram::PaintPropertyBinders paintAttributeData(properties, 0);
 
     if (parameters.debugOptions & (MapDebugOptions::Timestamps | MapDebugOptions::ParseStatus)) {
         if (!tile.debugBucket || tile.debugBucket->renderable != tile.isRenderable() ||
@@ -98,7 +98,7 @@ void RenderTile::finishRender(PaintParameters& parameters) {
             *tile.debugBucket->vertexBuffer,
             *tile.debugBucket->indexBuffer,
             tile.debugBucket->segments,
-            paintAttibuteData,
+            paintAttributeData,
             properties,
             parameters.state.getZoom(),
             "debug"
@@ -117,7 +117,7 @@ void RenderTile::finishRender(PaintParameters& parameters) {
             *tile.debugBucket->vertexBuffer,
             *tile.debugBucket->indexBuffer,
             tile.debugBucket->segments,
-            paintAttibuteData,
+            paintAttributeData,
             properties,
             parameters.state.getZoom(),
             "debug"
@@ -138,7 +138,7 @@ void RenderTile::finishRender(PaintParameters& parameters) {
             parameters.staticData.tileVertexBuffer,
             parameters.staticData.tileBorderIndexBuffer,
             parameters.staticData.tileBorderSegments,
-            paintAttibuteData,
+            paintAttributeData,
             properties,
             parameters.state.getZoom(),
             "debug"

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -474,11 +474,11 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
     {
         MBGL_DEBUG_GROUP(parameters.context, "clipping masks");
 
-        static const style::FillPaintProperties::PossiblyEvaluated properties {};
-        static const FillProgram::PaintPropertyBinders paintAttibuteData(properties, 0);
+        static const Properties<>::PossiblyEvaluated properties {};
+        static const ClippingMaskProgram::PaintPropertyBinders paintAttributeData(properties, 0);
 
         for (const auto& clipID : parameters.clipIDGenerator.getClipIDs()) {
-            parameters.staticData.programs.fill.get(properties).draw(
+            parameters.staticData.programs.clippingMask.draw(
                 parameters.context,
                 gl::Triangles(),
                 gl::DepthMode::disabled(),
@@ -491,14 +491,13 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
                     gl::StencilMode::Replace
                 },
                 gl::ColorMode::disabled(),
-                FillProgram::UniformValues {
+                ClippingMaskProgram::UniformValues {
                     uniforms::u_matrix::Value{ parameters.matrixForTile(clipID.first) },
-                    uniforms::u_world::Value{ parameters.context.viewport.getCurrentValue().size },
                 },
                 parameters.staticData.tileVertexBuffer,
                 parameters.staticData.quadTriangleIndexBuffer,
                 parameters.staticData.tileTriangleSegments,
-                paintAttibuteData,
+                paintAttributeData,
                 properties,
                 parameters.state.getZoom(),
                 "clipping"

--- a/src/mbgl/renderer/sources/render_image_source.cpp
+++ b/src/mbgl/renderer/sources/render_image_source.cpp
@@ -56,7 +56,7 @@ void RenderImageSource::finishRender(PaintParameters& parameters) {
     }
 
     static const style::Properties<>::PossiblyEvaluated properties {};
-    static const DebugProgram::PaintPropertyBinders paintAttibuteData(properties, 0);
+    static const DebugProgram::PaintPropertyBinders paintAttributeData(properties, 0);
 
     for (auto matrix : matrices) {
         parameters.programs.debug.draw(
@@ -72,7 +72,7 @@ void RenderImageSource::finishRender(PaintParameters& parameters) {
             parameters.staticData.tileVertexBuffer,
             parameters.staticData.tileBorderIndexBuffer,
             parameters.staticData.tileBorderSegments,
-            paintAttibuteData,
+            paintAttributeData,
             properties,
             parameters.state.getZoom(),
             "debug"

--- a/src/mbgl/shaders/background.cpp
+++ b/src/mbgl/shaders/background.cpp
@@ -1,0 +1,34 @@
+// NOTE: DO NOT CHANGE THIS FILE. IT IS AUTOMATICALLY GENERATED.
+
+#include <mbgl/shaders/background.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+const char* background::name = "background";
+const char* background::vertexSource = R"MBGL_SHADER(
+attribute vec2 a_pos;
+
+uniform mat4 u_matrix;
+
+void main() {
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+}
+
+)MBGL_SHADER";
+const char* background::fragmentSource = R"MBGL_SHADER(
+uniform vec4 u_color;
+uniform float u_opacity;
+
+void main() {
+    gl_FragColor = u_color * u_opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
+}
+
+)MBGL_SHADER";
+
+} // namespace shaders
+} // namespace mbgl

--- a/src/mbgl/shaders/background.hpp
+++ b/src/mbgl/shaders/background.hpp
@@ -1,0 +1,16 @@
+// NOTE: DO NOT CHANGE THIS FILE. IT IS AUTOMATICALLY GENERATED.
+
+#pragma once
+
+namespace mbgl {
+namespace shaders {
+
+class background {
+public:
+    static const char* name;
+    static const char* vertexSource;
+    static const char* fragmentSource;
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/src/mbgl/shaders/background_pattern.cpp
+++ b/src/mbgl/shaders/background_pattern.cpp
@@ -1,0 +1,65 @@
+// NOTE: DO NOT CHANGE THIS FILE. IT IS AUTOMATICALLY GENERATED.
+
+#include <mbgl/shaders/background_pattern.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+const char* background_pattern::name = "background_pattern";
+const char* background_pattern::vertexSource = R"MBGL_SHADER(
+uniform mat4 u_matrix;
+uniform vec2 u_pattern_size_a;
+uniform vec2 u_pattern_size_b;
+uniform vec2 u_pixel_coord_upper;
+uniform vec2 u_pixel_coord_lower;
+uniform float u_scale_a;
+uniform float u_scale_b;
+uniform float u_tile_units_to_pixels;
+
+attribute vec2 a_pos;
+
+varying vec2 v_pos_a;
+varying vec2 v_pos_b;
+
+void main() {
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+
+    v_pos_a = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, u_scale_a * u_pattern_size_a, u_tile_units_to_pixels, a_pos);
+    v_pos_b = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, u_scale_b * u_pattern_size_b, u_tile_units_to_pixels, a_pos);
+}
+
+)MBGL_SHADER";
+const char* background_pattern::fragmentSource = R"MBGL_SHADER(
+uniform vec2 u_pattern_tl_a;
+uniform vec2 u_pattern_br_a;
+uniform vec2 u_pattern_tl_b;
+uniform vec2 u_pattern_br_b;
+uniform vec2 u_texsize;
+uniform float u_mix;
+uniform float u_opacity;
+
+uniform sampler2D u_image;
+
+varying vec2 v_pos_a;
+varying vec2 v_pos_b;
+
+void main() {
+    vec2 imagecoord = mod(v_pos_a, 1.0);
+    vec2 pos = mix(u_pattern_tl_a / u_texsize, u_pattern_br_a / u_texsize, imagecoord);
+    vec4 color1 = texture2D(u_image, pos);
+
+    vec2 imagecoord_b = mod(v_pos_b, 1.0);
+    vec2 pos2 = mix(u_pattern_tl_b / u_texsize, u_pattern_br_b / u_texsize, imagecoord_b);
+    vec4 color2 = texture2D(u_image, pos2);
+
+    gl_FragColor = mix(color1, color2, u_mix) * u_opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
+}
+
+)MBGL_SHADER";
+
+} // namespace shaders
+} // namespace mbgl

--- a/src/mbgl/shaders/background_pattern.hpp
+++ b/src/mbgl/shaders/background_pattern.hpp
@@ -1,0 +1,16 @@
+// NOTE: DO NOT CHANGE THIS FILE. IT IS AUTOMATICALLY GENERATED.
+
+#pragma once
+
+namespace mbgl {
+namespace shaders {
+
+class background_pattern {
+public:
+    static const char* name;
+    static const char* vertexSource;
+    static const char* fragmentSource;
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/src/mbgl/shaders/clipping_mask.cpp
+++ b/src/mbgl/shaders/clipping_mask.cpp
@@ -1,0 +1,27 @@
+// NOTE: DO NOT CHANGE THIS FILE. IT IS AUTOMATICALLY GENERATED.
+
+#include <mbgl/shaders/clipping_mask.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+const char* clipping_mask::name = "clipping_mask";
+const char* clipping_mask::vertexSource = R"MBGL_SHADER(
+attribute vec2 a_pos;
+
+uniform mat4 u_matrix;
+
+void main() {
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+}
+
+)MBGL_SHADER";
+const char* clipping_mask::fragmentSource = R"MBGL_SHADER(
+void main() {
+    gl_FragColor = vec4(1.0);
+}
+
+)MBGL_SHADER";
+
+} // namespace shaders
+} // namespace mbgl

--- a/src/mbgl/shaders/clipping_mask.hpp
+++ b/src/mbgl/shaders/clipping_mask.hpp
@@ -1,0 +1,16 @@
+// NOTE: DO NOT CHANGE THIS FILE. IT IS AUTOMATICALLY GENERATED.
+
+#pragma once
+
+namespace mbgl {
+namespace shaders {
+
+class clipping_mask {
+public:
+    static const char* name;
+    static const char* vertexSource;
+    static const char* fragmentSource;
+};
+
+} // namespace shaders
+} // namespace mbgl


### PR DESCRIPTION
Uses separate background, background-pattern and clipping masks shaders.
Fixes https://github.com/mapbox/mapbox-gl-native/issues/10863.
Port of https://github.com/mapbox/mapbox-gl-js/pull/5965.