### PR TITLE
Account for circle-stroke-width in queryRenderedFeatures

### DIFF
--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -1,5 +1,4 @@
 {
-  "query-tests/circle-stroke-width/inside": "https://github.com/mapbox/mapbox-gl-native/issues/10307",
   "query-tests/geometry/multilinestring": "needs investigation",
   "query-tests/geometry/multipolygon": "needs investigation",
   "query-tests/geometry/polygon": "needs investigation",

--- a/src/mbgl/renderer/buckets/circle_bucket.cpp
+++ b/src/mbgl/renderer/buckets/circle_bucket.cpp
@@ -108,8 +108,9 @@ float CircleBucket::getQueryRadius(const RenderLayer& layer) const {
     auto circleLayer = layer.as<RenderCircleLayer>();
 
     float radius = get<CircleRadius>(*circleLayer, paintPropertyBinders);
+    float stroke = get<CircleStrokeWidth>(*circleLayer, paintPropertyBinders);
     auto translate = circleLayer->evaluated.get<CircleTranslate>();
-    return radius + util::length(translate[0], translate[1]);
+    return radius + stroke + util::length(translate[0], translate[1]);
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -108,13 +108,12 @@ bool RenderCircleLayer::queryIntersectsFeature(
             bearing,
             pixelsToTileUnits);
 
-    // Evaluate function
-    auto circleRadius = evaluated.get<style::CircleRadius>()
-                                .evaluate(feature, zoom, style::CircleRadius::defaultValue())
-                        * pixelsToTileUnits;
+    // Evaluate functions
+    auto radius = evaluated.evaluate<style::CircleRadius>(zoom, feature) * pixelsToTileUnits;
+    auto stroke = evaluated.evaluate<style::CircleStrokeWidth>(zoom, feature) * pixelsToTileUnits;
 
     // Test intersection
-    return util::polygonIntersectsBufferedMultiPoint(translatedQueryGeometry.value_or(queryGeometry), feature.getGeometries(), circleRadius);
+    return util::polygonIntersectsBufferedMultiPoint(translatedQueryGeometry.value_or(queryGeometry), feature.getGeometries(), radius + stroke);
 }
 
 } // namespace mbgl


### PR DESCRIPTION
Fixes #10307, porting https://github.com/mapbox/mapbox-gl-js/pull/5514.