### PR TITLE
Retain configuration 

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
@@ -146,4 +146,7 @@ public class MapboxConstants {
   public static final String STATE_LOCATION_VIEW_ACCURACY_TINT_COLOR = "mapbox_locViewAccuracyTintColor";
   public static final String STATE_LOCATION_VIEW_ACCURACY_THRESHOLD = "mapbox_locViewAccuracyThreshold";
   public static final String STATE_LOCATION_VIEW_PADDING = "mapbox_locViewPadding";
+  public static final String STATE_DESELECT_MARKER_ON_TAP = "mapbox_deselectMarkerOnTap";
+  public static final String STATE_USER_FOCAL_POINT = "mapbox_userFocalPoint";
+
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
@@ -91,6 +91,8 @@ public final class UiSettings {
     saveLogo(outState);
     saveAttribution(outState);
     saveZoomControl(outState);
+    saveDeselectMarkersOnTap(outState);
+    saveFocalPoint(outState);
   }
 
   void onRestoreInstanceState(@NonNull Bundle savedInstanceState) {
@@ -99,6 +101,8 @@ public final class UiSettings {
     restoreLogo(savedInstanceState);
     restoreAttribution(savedInstanceState);
     restoreZoomControl(savedInstanceState);
+    restoreDeselectMarkersOnTap(savedInstanceState);
+    restoreFocalPoint(savedInstanceState);
   }
 
   private void initialiseGestures(MapboxMapOptions options) {
@@ -783,6 +787,14 @@ public final class UiSettings {
     return doubleTapGestureChangeAllowed;
   }
 
+  private void restoreDeselectMarkersOnTap(Bundle savedInstanceState) {
+    setDeselectMarkersOnTap(savedInstanceState.getBoolean(MapboxConstants.STATE_DESELECT_MARKER_ON_TAP));
+  }
+
+  private void saveDeselectMarkersOnTap(Bundle outState) {
+    outState.putBoolean(MapboxConstants.STATE_DESELECT_MARKER_ON_TAP, isDeselectMarkersOnTap());
+  }
+
   /**
    * Gets whether the markers are automatically deselected (and therefore, their infowindows
    * closed) when a map tap is detected.
@@ -860,6 +872,17 @@ public final class UiSettings {
     setTiltGesturesEnabled(enabled);
     setZoomGesturesEnabled(enabled);
     setDoubleTapGesturesEnabled(enabled);
+  }
+
+  private void saveFocalPoint(Bundle outState) {
+    outState.putParcelable(MapboxConstants.STATE_USER_FOCAL_POINT, getFocalPoint());
+  }
+
+  private void restoreFocalPoint(Bundle savedInstanceState) {
+    PointF pointF = savedInstanceState.getParcelable(MapboxConstants.STATE_USER_FOCAL_POINT);
+    if (pointF != null) {
+      setFocalPoint(pointF);
+    }
   }
 
   /**


### PR DESCRIPTION
This PR retains the configuration for user provided focal point and deselect markers on tap.
Closes https://github.com/mapbox/mapbox-gl-native/issues/10907.