### PR TITLE
Change device under test to Pixel

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -296,7 +296,7 @@ jobs:
             (gcloud firebase test android run --type instrumentation \
               --app platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/debug/MapboxGLAndroidSDKTestApp-debug.apk \
               --test platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/androidTest/debug/MapboxGLAndroidSDKTestApp-debug-androidTest.apk \
-              --device-ids shamu --os-version-ids 22 --locales en --orientations portrait --timeout 20m \
+              --device-ids sailfish --os-version-ids 26 --locales en --orientations portrait --timeout 20m \
               2>&1 | tee firebase.log) || EXIT_CODE=$?
 
             FIREBASE_TEST_BUCKET=$(sed -n 's|^.*\[https://console.developers.google.com/storage/browser/\([^]]*\).*|gs://\1|p' firebase.log)


### PR DESCRIPTION
Capturing from #10883 that the Firebase step is increasing our CI execution time when it's not being able to assign us a device. The device under test atm is a Motorola Nexus 6 from 2014, to increase reliability I'm suggesting to change it to a Google Pixel running Android 8.0.