### PR TITLE
Do not overwrite user-set focal point when tracking location

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
@@ -372,9 +372,6 @@ public class MyLocationView extends View {
    */
   public void setTilt(@FloatRange(from = 0, to = 60.0f) double tilt) {
     this.tilt = tilt;
-    if (myLocationTrackingMode == MyLocationTracking.TRACKING_FOLLOW) {
-      mapboxMap.getUiSettings().setFocalPoint(getCenter());
-    }
     invalidate();
   }
 


### PR DESCRIPTION
Up until this point, we were overwriting user-set focal point when camera's tilt was changed and location tracking was enabled. Since I'm not seeing any `MyLocationView` regressions after introducing these changes, I'm just removing the responsible call.