### PR TITLE
Add special-case HeatmapColor paint property traits class

### DIFF
--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -334,6 +334,7 @@ set(MBGL_CORE_FILES
     include/mbgl/style/data_driven_property_value.hpp
     include/mbgl/style/filter.hpp
     include/mbgl/style/filter_evaluator.hpp
+    include/mbgl/style/heatmap_color_property_value.hpp
     include/mbgl/style/image.hpp
     include/mbgl/style/layer.hpp
     include/mbgl/style/layer_type.hpp
@@ -386,6 +387,7 @@ set(MBGL_CORE_FILES
     include/mbgl/style/conversion/geojson.hpp
     include/mbgl/style/conversion/geojson_options.hpp
     include/mbgl/style/conversion/get_json_type.hpp
+    include/mbgl/style/conversion/heatmap_color_property_value.hpp
     include/mbgl/style/conversion/layer.hpp
     include/mbgl/style/conversion/light.hpp
     include/mbgl/style/conversion/position.hpp

--- a/include/mbgl/style/conversion/heatmap_color_property_value.hpp
+++ b/include/mbgl/style/conversion/heatmap_color_property_value.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <mbgl/style/heatmap_color_property_value.hpp>
+#include <mbgl/style/conversion.hpp>
+#include <mbgl/style/conversion/constant.hpp>
+#include <mbgl/style/conversion/function.hpp>
+#include <mbgl/style/conversion/expression.hpp>
+#include <mbgl/style/expression/value.hpp>
+#include <mbgl/style/expression/is_constant.hpp>
+#include <mbgl/style/expression/is_expression.hpp>
+#include <mbgl/style/expression/find_zoom_curve.hpp>
+
+namespace mbgl {
+namespace style {
+namespace conversion {
+
+template <>
+struct Converter<HeatmapColorPropertyValue> {
+    optional<HeatmapColorPropertyValue> operator()(const Convertible& value, Error& error) const {
+        if (isUndefined(value)) {
+            return HeatmapColorPropertyValue();
+        } else if (isExpression(value)) {
+            optional<std::unique_ptr<Expression>> expression = convert<std::unique_ptr<Expression>>(value, error, expression::type::Color);
+            if (!expression) {
+                return {};
+            }
+            if (!isFeatureConstant(**expression)) {
+                error = { "property expressions not supported" };
+                return {};
+            }
+            if (!isZoomConstant(**expression)) {
+                error = { "zoom expressions not supported" };
+                return {};
+            }
+            return {HeatmapColorPropertyValue(std::move(*expression))};
+        } else {
+            error = { "heatmap-color must be an expression" };
+            return {};
+        }
+    }
+};
+
+} // namespace conversion
+} // namespace style
+} // namespace mbgl
+

--- a/include/mbgl/style/heatmap_color_property_value.hpp
+++ b/include/mbgl/style/heatmap_color_property_value.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <mbgl/util/variant.hpp>
+#include <mbgl/style/undefined.hpp>
+#include <mbgl/style/function/camera_function.hpp>
+#include <mbgl/renderer/property_evaluation_parameters.hpp>
+
+namespace mbgl {
+namespace style {
+
+class NoopPropertyEvaluator {
+public:
+    using ResultType = Color;
+    NoopPropertyEvaluator(const PropertyEvaluationParameters&, Color) {}
+};
+
+/*
+ * Special-case implementation of (a subset of) the PropertyValue<T> interface
+ * used for building the HeatmapColor paint property traits class.
+ */
+class HeatmapColorPropertyValue {
+private:
+    std::shared_ptr<expression::Expression> value;
+
+    friend bool operator==(const HeatmapColorPropertyValue& lhs, const HeatmapColorPropertyValue& rhs) {
+        return *(lhs.value) == *(rhs.value);
+    }
+
+    friend bool operator!=(const HeatmapColorPropertyValue& lhs, const HeatmapColorPropertyValue& rhs) {
+        return !(lhs == rhs);
+    }
+    
+public:
+    HeatmapColorPropertyValue() : value(nullptr) {}
+    HeatmapColorPropertyValue(std::shared_ptr<expression::Expression> value_) : value(std::move(value_)) {}
+    
+    bool isUndefined() const { return value.get() != nullptr; }
+
+    // noop, needed for batch evaluation of paint property values to compile
+    Color evaluate(const NoopPropertyEvaluator&, TimePoint = {}) const { return {}; }
+    bool isDataDriven()     const { return false; }
+    bool hasDataDrivenPropertyDifference(const HeatmapColorPropertyValue&) const { return false; }
+};
+
+
+} // namespace style
+} // namespace mbgl

--- a/include/mbgl/style/layers/heatmap_layer.hpp
+++ b/include/mbgl/style/layers/heatmap_layer.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/style/filter.hpp>
 #include <mbgl/style/property_value.hpp>
 #include <mbgl/style/data_driven_property_value.hpp>
+#include <mbgl/style/heatmap_color_property_value.hpp>
 
 #include <mbgl/util/color.hpp>
 
@@ -54,9 +55,9 @@ public:
     void setHeatmapIntensityTransition(const TransitionOptions&);
     TransitionOptions getHeatmapIntensityTransition() const;
 
-    static PropertyValue<Color> getDefaultHeatmapColor();
-    PropertyValue<Color> getHeatmapColor() const;
-    void setHeatmapColor(PropertyValue<Color>);
+    static HeatmapColorPropertyValue getDefaultHeatmapColor();
+    HeatmapColorPropertyValue getHeatmapColor() const;
+    void setHeatmapColor(HeatmapColorPropertyValue);
     void setHeatmapColorTransition(const TransitionOptions&);
     TransitionOptions getHeatmapColorTransition() const;
 

--- a/include/mbgl/style/layers/layer.hpp.ejs
+++ b/include/mbgl/style/layers/layer.hpp.ejs
@@ -11,6 +11,9 @@
 #include <mbgl/style/filter.hpp>
 #include <mbgl/style/property_value.hpp>
 #include <mbgl/style/data_driven_property_value.hpp>
+<% if (type === 'heatmap') { -%>
+#include <mbgl/style/heatmap_color_property_value.hpp>
+<% } -%>
 
 #include <mbgl/util/color.hpp>
 

--- a/scripts/generate-style-code.js
+++ b/scripts/generate-style-code.js
@@ -96,6 +96,8 @@ global.paintPropertyType = function (property, type) {
 global.propertyValueType = function (property) {
   if (isDataDriven(property)) {
     return `DataDrivenPropertyValue<${evaluatedType(property)}>`;
+  } else if (property.name === 'heatmap-color') {
+    return `HeatmapColorPropertyValue`;
   } else {
     return `PropertyValue<${evaluatedType(property)}>`;
   }
@@ -109,10 +111,6 @@ global.defaultValue = function (property) {
 
   if (property.name === 'fill-outline-color') {
     return '{}';
-  }
-
-  if (property.name === 'heatmap-color') {
-    return 'Color::red()';
   }
 
   switch (property.type) {

--- a/src/mbgl/style/conversion/make_property_setters.hpp
+++ b/src/mbgl/style/conversion/make_property_setters.hpp
@@ -172,7 +172,7 @@ inline auto makePaintPropertySetters() {
     result["heatmap-weight-transition"] = &setTransition<HeatmapLayer, &HeatmapLayer::setHeatmapWeightTransition>;
     result["heatmap-intensity"] = &setProperty<HeatmapLayer, PropertyValue<float>, &HeatmapLayer::setHeatmapIntensity>;
     result["heatmap-intensity-transition"] = &setTransition<HeatmapLayer, &HeatmapLayer::setHeatmapIntensityTransition>;
-    result["heatmap-color"] = &setProperty<HeatmapLayer, PropertyValue<Color>, &HeatmapLayer::setHeatmapColor>;
+    result["heatmap-color"] = &setProperty<HeatmapLayer, HeatmapColorPropertyValue, &HeatmapLayer::setHeatmapColor>;
     result["heatmap-color-transition"] = &setTransition<HeatmapLayer, &HeatmapLayer::setHeatmapColorTransition>;
     result["heatmap-opacity"] = &setProperty<HeatmapLayer, PropertyValue<float>, &HeatmapLayer::setHeatmapOpacity>;
     result["heatmap-opacity-transition"] = &setTransition<HeatmapLayer, &HeatmapLayer::setHeatmapOpacityTransition>;

--- a/src/mbgl/style/conversion/property_setter.hpp
+++ b/src/mbgl/style/conversion/property_setter.hpp
@@ -5,6 +5,7 @@
 #include <mbgl/style/conversion/constant.hpp>
 #include <mbgl/style/conversion/property_value.hpp>
 #include <mbgl/style/conversion/data_driven_property_value.hpp>
+#include <mbgl/style/conversion/heatmap_color_property_value.hpp>
 #include <mbgl/style/conversion/transition_options.hpp>
 
 #include <string>

--- a/src/mbgl/style/layers/heatmap_layer.cpp
+++ b/src/mbgl/style/layers/heatmap_layer.cpp
@@ -3,6 +3,10 @@
 #include <mbgl/style/layers/heatmap_layer.hpp>
 #include <mbgl/style/layers/heatmap_layer_impl.hpp>
 #include <mbgl/style/layer_observer.hpp>
+// for constructing default heatmap-color ramp expression from style JSON
+#include <mbgl/style/conversion.hpp>
+#include <mbgl/style/conversion/json.hpp>
+#include <mbgl/style/conversion/heatmap_color_property_value.hpp>
 
 namespace mbgl {
 namespace style {
@@ -175,15 +179,17 @@ TransitionOptions HeatmapLayer::getHeatmapIntensityTransition() const {
     return impl().paint.template get<HeatmapIntensity>().options;
 }
 
-PropertyValue<Color> HeatmapLayer::getDefaultHeatmapColor() {
-    return { Color::red() };
+HeatmapColorPropertyValue HeatmapLayer::getDefaultHeatmapColor() {
+    conversion::Error error;
+    std::string rawValue = R"JSON(["interpolate",["linear"],["heatmap-density"],0,"rgba(0, 0, 255, 0)",0.1,"royalblue",0.3,"cyan",0.5,"lime",0.7,"yellow",1,"red"])JSON";
+    return *conversion::convertJSON<HeatmapColorPropertyValue>(rawValue, error);
 }
 
-PropertyValue<Color> HeatmapLayer::getHeatmapColor() const {
+HeatmapColorPropertyValue HeatmapLayer::getHeatmapColor() const {
     return impl().paint.template get<HeatmapColor>().value;
 }
 
-void HeatmapLayer::setHeatmapColor(PropertyValue<Color> value) {
+void HeatmapLayer::setHeatmapColor(HeatmapColorPropertyValue value) {
     if (value == getHeatmapColor())
         return;
     auto impl_ = mutableImpl();

--- a/src/mbgl/style/layers/heatmap_layer_properties.hpp
+++ b/src/mbgl/style/layers/heatmap_layer_properties.hpp
@@ -24,10 +24,6 @@ struct HeatmapIntensity : PaintProperty<float> {
     static float defaultValue() { return 1; }
 };
 
-struct HeatmapColor : PaintProperty<Color> {
-    static Color defaultValue() { return Color::red(); }
-};
-
 struct HeatmapOpacity : PaintProperty<float> {
     static float defaultValue() { return 1; }
 };

--- a/src/mbgl/style/layers/layer.cpp.ejs
+++ b/src/mbgl/style/layers/layer.cpp.ejs
@@ -8,6 +8,12 @@
 #include <mbgl/style/layers/<%- type.replace('-', '_') %>_layer.hpp>
 #include <mbgl/style/layers/<%- type.replace('-', '_') %>_layer_impl.hpp>
 #include <mbgl/style/layer_observer.hpp>
+<% if (type === 'heatmap') { -%>
+// for constructing default heatmap-color ramp expression from style JSON
+#include <mbgl/style/conversion.hpp>
+#include <mbgl/style/conversion/json.hpp>
+#include <mbgl/style/conversion/heatmap_color_property_value.hpp>
+<% } -%>
 
 namespace mbgl {
 namespace style {
@@ -134,7 +140,13 @@ void <%- camelize(type) %>Layer::set<%- camelize(property.name) %>(<%- propertyV
 // Paint properties
 <% for (const property of paintProperties) { %>
 <%- propertyValueType(property) %> <%- camelize(type) %>Layer::getDefault<%- camelize(property.name) %>() {
+<% if (property.name === 'heatmap-color') { -%>
+    conversion::Error error;
+    std::string rawValue = R"JSON(<%- JSON.stringify(property.default) %>)JSON";
+    return *conversion::convertJSON<<%- propertyValueType(property)%>>(rawValue, error);
+<% } else { -%>
     return { <%- defaultValue(property) %> };
+<% } -%>
 }
 
 <%- propertyValueType(property) %> <%- camelize(type) %>Layer::get<%- camelize(property.name) %>() const {

--- a/src/mbgl/style/layers/layer_properties.hpp.ejs
+++ b/src/mbgl/style/layers/layer_properties.hpp.ejs
@@ -25,6 +25,7 @@ struct <%- camelize(property.name) %> : <%- layoutPropertyType(property, type) %
 
 <% } -%>
 <% for (const property of paintProperties) { -%>
+<%   if (property.name === 'heatmap-color') continue; -%>
 struct <%- camelize(property.name) %> : <%- paintPropertyType(property, type) %> {
     static <%- evaluatedType(property) %> defaultValue() { return <%- defaultValue(property) %>; }
 };

--- a/src/mbgl/style/paint_property.hpp
+++ b/src/mbgl/style/paint_property.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/style/properties.hpp>
 #include <mbgl/style/property_value.hpp>
+#include <mbgl/style/heatmap_color_property_value.hpp>
 #include <mbgl/style/data_driven_property_value.hpp>
 #include <mbgl/renderer/property_evaluator.hpp>
 #include <mbgl/renderer/cross_faded_property_evaluator.hpp>
@@ -46,6 +47,28 @@ public:
     using PossiblyEvaluatedType = Faded<T>;
     using Type = T;
     static constexpr bool IsDataDriven = false;
+};
+
+/*
+ * Special-case paint property traits for heatmap-color, needed because
+ * heatmap-color values do not fit into the
+ * Undefined | Value | {Camera,Source,Composite}Function taxonomy that applies
+ * to all other paint properties.
+ *
+ * These traits are provided here--despite the fact that heatmap-color
+ * is not used like other paint properties--to allow the parameter-pack-based
+ * batch evaluation of paint properties to compile properly.
+ */
+class HeatmapColor {
+public:
+    using TransitionableType = Transitionable<HeatmapColorPropertyValue>;
+    using UnevaluatedType = Transitioning<HeatmapColorPropertyValue>;
+    using EvaluatorType = NoopPropertyEvaluator;
+    using PossiblyEvaluatedType = Color;
+    using Type = Color;
+    static constexpr bool IsDataDriven = false;
+    
+    static Color defaultValue() { return {}; }
 };
 
 } // namespace style


### PR DESCRIPTION
@mourner @jfirebaugh -- i took a stab at adding a special-case `HeatmapColor` property to handle the differing evaluation semantics (and non-primitive default value)