### PR TITLE
Camera callbacks for velocity animated movements

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
@@ -34,6 +34,11 @@ class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, M
   private final Runnable onCameraMoveStartedRunnable = new Runnable() {
     @Override
     public void run() {
+      if (!idle) {
+        return;
+      }
+      idle = false;
+
       // deprecated API
       if (onCameraMoveStartedListener != null) {
         onCameraMoveStartedListener.onCameraMoveStarted(moveStartedReason);
@@ -85,6 +90,11 @@ class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, M
   private final Runnable onCameraIdleRunnable = new Runnable() {
     @Override
     public void run() {
+      if (idle) {
+        return;
+      }
+      idle = true;
+
       // deprecated API
       if (onCameraIdleListener != null) {
         onCameraIdleListener.onCameraIdle();
@@ -121,67 +131,23 @@ class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, M
 
   @Override
   public void onCameraMoveStarted(final int reason) {
-    if (!idle) {
-      return;
-    }
-    idle = false;
     moveStartedReason = reason;
     handler.post(onCameraMoveStartedRunnable);
-
-    // new API
-    if (!onCameraMoveStarted.isEmpty()) {
-      for (OnCameraMoveStartedListener cameraMoveStartedListener : onCameraMoveStarted) {
-        cameraMoveStartedListener.onCameraMoveStarted(reason);
-      }
-    }
   }
 
   @Override
   public void onCameraMove() {
     handler.post(onCameraMoveRunnable);
-    if (onCameraMoveListener != null && !idle) {
-      onCameraMoveListener.onCameraMove();
-    }
-
-    // new API
-    if (!onCameraMove.isEmpty() && !idle) {
-      for (OnCameraMoveListener cameraMoveListener : onCameraMove) {
-        cameraMoveListener.onCameraMove();
-      }
-    }
   }
 
   @Override
   public void onCameraMoveCanceled() {
     handler.post(onCameraMoveCancelRunnable);
-    if (onCameraMoveCanceledListener != null && !idle) {
-      onCameraMoveCanceledListener.onCameraMoveCanceled();
-    }
-
-    // new API
-    if (!onCameraMoveCanceled.isEmpty() && !idle) {
-      for (OnCameraMoveCanceledListener cameraMoveCanceledListener : onCameraMoveCanceled) {
-        cameraMoveCanceledListener.onCameraMoveCanceled();
-      }
-    }
   }
 
   @Override
   public void onCameraIdle() {
-    if (!idle) {
-      idle = true;
-      handler.post(onCameraIdleRunnable);
-      if (onCameraIdleListener != null) {
-        onCameraIdleListener.onCameraIdle();
-      }
-
-      // new API
-      if (!onCameraIdle.isEmpty()) {
-        for (OnCameraIdleListener cameraIdleListener : onCameraIdle) {
-          cameraIdleListener.onCameraIdle();
-        }
-      }
-    }
+    handler.post(onCameraIdleRunnable);
   }
 
   void addOnCameraIdleListener(@NonNull OnCameraIdleListener listener) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
@@ -239,7 +239,7 @@ final class Transform implements MapView.OnMapChangedListener {
     CameraPosition cameraPosition = invalidateCameraPosition();
     if (cameraPosition != null) {
       int newZoom = (int) Math.round(cameraPosition.zoom + (zoomIn ? 1 : -1));
-      setZoom(newZoom, focalPoint, MapboxConstants.ANIMATION_DURATION);
+      setZoom(newZoom, focalPoint, MapboxConstants.ANIMATION_DURATION, false);
     } else {
       // we are not transforming, notify about being idle
       cameraChangeDispatcher.onCameraIdle();
@@ -250,7 +250,7 @@ final class Transform implements MapView.OnMapChangedListener {
     CameraPosition cameraPosition = invalidateCameraPosition();
     if (cameraPosition != null) {
       int newZoom = (int) Math.round(cameraPosition.zoom + zoomAddition);
-      setZoom(newZoom, focalPoint, duration);
+      setZoom(newZoom, focalPoint, duration, false);
     } else {
       // we are not transforming, notify about being idle
       cameraChangeDispatcher.onCameraIdle();
@@ -258,16 +258,18 @@ final class Transform implements MapView.OnMapChangedListener {
   }
 
   void setZoom(double zoom, @NonNull PointF focalPoint) {
-    setZoom(zoom, focalPoint, 0);
+    setZoom(zoom, focalPoint, 0, false);
   }
 
-  void setZoom(double zoom, @NonNull PointF focalPoint, long duration) {
+  void setZoom(double zoom, @NonNull PointF focalPoint, long duration, boolean isAnimator) {
     if (mapView != null) {
       mapView.addOnMapChangedListener(new MapView.OnMapChangedListener() {
         @Override
         public void onMapChanged(int change) {
           if (change == MapView.REGION_DID_CHANGE_ANIMATED) {
-            cameraChangeDispatcher.onCameraIdle();
+            if (!isAnimator) {
+              cameraChangeDispatcher.onCameraIdle();
+            }
             mapView.removeOnMapChangedListener(this);
           }
         }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/10923. This PR cleans up overwritten changes from https://github.com/mapbox/mapbox-gl-native/pull/10690 and adds a right invocation of camera callbacks for velocity initiated movements (rotate and scale).

Changes in this PR are temporary workarounds for our gestures handling implementation until https://github.com/mapbox/mapbox-gl-native/issues/10016 lands.