### PR TITLE
[core] Prevent symbols at the same zoom from sharing a crossTileID.

### DIFF
--- a/src/mbgl/text/cross_tile_symbol_index.hpp
+++ b/src/mbgl/text/cross_tile_symbol_index.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/util/optional.hpp>
 
 #include <map>
+#include <set>
 #include <vector>
 #include <string>
 #include <memory>
@@ -32,7 +33,7 @@ public:
     TileLayerIndex(OverscaledTileID coord, std::vector<SymbolInstance>&, uint32_t bucketInstanceId);
 
     Point<int64_t> getScaledCoordinates(SymbolInstance&, const OverscaledTileID&);
-    void findMatches(std::vector<SymbolInstance>&, const OverscaledTileID&);
+    void findMatches(std::vector<SymbolInstance>&, const OverscaledTileID&, std::set<uint32_t>&);
     
     OverscaledTileID coord;
     uint32_t bucketInstanceId;
@@ -45,7 +46,10 @@ public:
     bool addBucket(const OverscaledTileID&, SymbolBucket&, uint32_t& maxCrossTileID);
     bool removeStaleBuckets(const std::unordered_set<uint32_t>& currentIDs);
 private:
-    std::map<uint8_t,std::map<OverscaledTileID,TileLayerIndex>> indexes;
+    void removeBucketCrossTileIDs(uint8_t zoom, const TileLayerIndex& removedBucket);
+
+    std::map<uint8_t, std::map<OverscaledTileID,TileLayerIndex>> indexes;
+    std::map<uint8_t, std::set<uint32_t>> usedCrossTileIDs;
 };
 
 class CrossTileSymbolIndex {


### PR DESCRIPTION
Port of GL JS PR https://github.com/mapbox/mapbox-gl-js/pull/5994.

Fixes issue #10844, which would allow multiple symbols in a tile to share the same crossTileID as one of their duplicate parent-tile symbols. Once the symbols shared a crossTileID, they would permanently remain "duplicates" of each other, even after increasing zoom level allowed the CrossTileSymbolIndex to distinguish between them.

I've manually tested this with the reuse queue heads-up display. The behavior with "Add 100 views" is that when you first add them, the "queue" count goes to 100, and then next time the map renders the "visible" count updates to 100. Is that the expected behavior? With "Add 10000 views", it shows 9089, visible -- so definitely progress from the earlier behavior, but I take it we're expecting that to be exactly 10,000?

Also an issue has already been filed against the GL JS version of this PR https://github.com/mapbox/mapbox-gl-js/issues/6002.

/cc @ansis @friedbunny 