### PR TITLE
Expose attribution manager as public API

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
@@ -10,6 +10,7 @@ import android.support.annotation.NonNull;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.Toast;
+
 import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.attribution.Attribution;
 import com.mapbox.mapboxsdk.attribution.AttributionParser;
@@ -30,7 +31,7 @@ import java.util.Set;
  * Additionally an telemetry option item is shown to configure telemetry settings.
  * </p>
  */
-class AttributionDialogManager implements View.OnClickListener, DialogInterface.OnClickListener {
+public class AttributionDialogManager implements View.OnClickListener, DialogInterface.OnClickListener {
 
   private static final String MAP_FEEDBACK_URL = "https://www.mapbox.com/map-feedback";
   private static final String MAP_FEEDBACK_LOCATION_FORMAT = MAP_FEEDBACK_URL + "/#/%f/%f/%d";
@@ -40,7 +41,7 @@ class AttributionDialogManager implements View.OnClickListener, DialogInterface.
   private String[] attributionTitles;
   private Set<Attribution> attributionSet;
 
-  AttributionDialogManager(@NonNull Context context, @NonNull MapboxMap mapboxMap) {
+  public AttributionDialogManager(@NonNull Context context, @NonNull MapboxMap mapboxMap) {
     this.context = context;
     this.mapboxMap = mapboxMap;
   }
@@ -52,7 +53,7 @@ class AttributionDialogManager implements View.OnClickListener, DialogInterface.
     showAttributionDialog();
   }
 
-  private void showAttributionDialog() {
+  protected void showAttributionDialog() {
     attributionTitles = getAttributionTitles();
     AlertDialog.Builder builder = new AlertDialog.Builder(context);
     builder.setTitle(R.string.mapbox_attributionsDialogTitle);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
@@ -38,7 +38,6 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
 
   private final Context context;
   private final MapboxMap mapboxMap;
-  private String[] attributionTitles;
   private Set<Attribution> attributionSet;
 
   public AttributionDialogManager(@NonNull Context context, @NonNull MapboxMap mapboxMap) {
@@ -50,11 +49,10 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
   @Override
   public void onClick(View view) {
     attributionSet = new AttributionBuilder(mapboxMap).build();
-    showAttributionDialog();
+    showAttributionDialog(getAttributionTitles());
   }
 
-  protected void showAttributionDialog() {
-    attributionTitles = getAttributionTitles();
+  protected void showAttributionDialog(String[] attributionTitles) {
     AlertDialog.Builder builder = new AlertDialog.Builder(context);
     builder.setTitle(R.string.mapbox_attributionsDialogTitle);
     builder.setAdapter(new ArrayAdapter<>(context, R.layout.mapbox_attribution_list_item, attributionTitles), this);
@@ -80,7 +78,7 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
   }
 
   private boolean isLatestEntry(int attributionKeyIndex) {
-    return attributionKeyIndex == attributionTitles.length - 1;
+    return attributionKeyIndex == getAttributionTitles().length - 1;
   }
 
   private void showTelemetryDialog() {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -22,6 +22,7 @@ import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.ZoomButtonsController;
+
 import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.annotations.Annotation;
 import com.mapbox.mapboxsdk.annotations.MarkerViewManager;
@@ -36,16 +37,18 @@ import com.mapbox.mapboxsdk.maps.widgets.MyLocationViewSettings;
 import com.mapbox.mapboxsdk.net.ConnectivityReceiver;
 import com.mapbox.mapboxsdk.storage.FileSource;
 import com.mapbox.services.android.telemetry.MapboxTelemetry;
-import timber.log.Timber;
 
-import javax.microedition.khronos.egl.EGLConfig;
-import javax.microedition.khronos.opengles.GL10;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.microedition.khronos.egl.EGLConfig;
+import javax.microedition.khronos.opengles.GL10;
+
+import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.maps.widgets.CompassView.TIME_MAP_NORTH_ANIMATION;
 import static com.mapbox.mapboxsdk.maps.widgets.CompassView.TIME_WAIT_IDLE;
@@ -201,7 +204,7 @@ public class MapView extends FrameLayout {
     compassView.setOnClickListener(createCompassClickListener(cameraChangeDispatcher));
     // inject widgets with MapboxMap
     myLocationView.setMapboxMap(mapboxMap);
-    attrView.setOnClickListener(new AttributionDialogManager(context, mapboxMap));
+    attrView.setOnClickListener(new AttributionClickListener(context, mapboxMap));
 
     // Ensure this view is interactable
     setClickable(true);
@@ -1070,6 +1073,30 @@ public class MapView extends FrameLayout {
 
     void clearOnMapReadyCallbacks() {
       onMapReadyCallbackList.clear();
+    }
+  }
+
+  /**
+   * Click event hook for providing a custom attribution dialog manager.
+   */
+  private static class AttributionClickListener implements OnClickListener {
+
+    private final AttributionDialogManager defaultDialogManager;
+    private UiSettings uiSettings;
+
+    private AttributionClickListener(Context context, MapboxMap mapboxMap) {
+      this.defaultDialogManager = new AttributionDialogManager(context, mapboxMap);
+      this.uiSettings = mapboxMap.getUiSettings();
+    }
+
+    @Override
+    public void onClick(View v) {
+      AttributionDialogManager customDialogManager = uiSettings.getAttributionDialogManager();
+      if (customDialogManager != null) {
+        uiSettings.getAttributionDialogManager().onClick(v);
+      } else {
+        defaultDialogManager.onClick(v);
+      }
     }
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
@@ -37,6 +37,7 @@ public final class UiSettings {
 
   private final ImageView attributionsView;
   private final int[] attributionsMargins = new int[4];
+  private AttributionDialogManager attributionDialogManager;
 
   private final View logoView;
   private final int[] logoMargins = new int[4];
@@ -533,6 +534,28 @@ public final class UiSettings {
    */
   public boolean isAttributionEnabled() {
     return attributionsView.getVisibility() == View.VISIBLE;
+  }
+
+
+  /**
+   * Set a custom attribution dialog manager.
+   * <p>
+   * Set to null to reset to default behaviour.
+   * </p>
+   *
+   * @param attributionDialogManager the manager class used for showing attribution
+   */
+  public void setAttributionDialogManager(AttributionDialogManager attributionDialogManager) {
+    this.attributionDialogManager = attributionDialogManager;
+  }
+
+  /**
+   * Get the custom attribution dialog manager.
+   *
+   * @return the active manager class used for showing attribution
+   */
+  public AttributionDialogManager getAttributionDialogManager() {
+    return attributionDialogManager;
   }
 
   /**


### PR DESCRIPTION
Closes #10932, this PR allows the Android SDK to have parity with the iOS SDK in terms of showing the attribution dialog on demand. On top of this, custom instances of AttributionDialogManager can be created and hooked into the attribution click with: 

```java
findViewById(R.id.attributionView).setOnClickListener(yourAwesomeAttribtionManager);
```

This allows to override the protected `showAttributionDialog` and provide a custom implementation.