### PR TITLE
Allow changing the used OkHttpClient

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HTTPRequest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HTTPRequest.java
@@ -234,4 +234,8 @@ class HTTPRequest implements Callback {
   static void enablePrintRequestUrlOnFailure(boolean enabled) {
     logRequestUrl = enabled;
   }
+
+  static void setOKHttpClient(OkHttpClient client) {
+    mClient = client;
+  }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HttpRequestUtil.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HttpRequestUtil.java
@@ -1,5 +1,7 @@
 package com.mapbox.mapboxsdk.http;
 
+import okhttp3.OkHttpClient;
+
 /**
  * Utility class for setting HttpRequest configurations
  */
@@ -28,8 +30,17 @@ public class HttpRequestUtil {
    *
    * @param enabled True will print urls, false will disable
    */
-  public static void setPrintRequestUrlOnFaillure(boolean enabled) {
+  public static void setPrintRequestUrlOnFailure(boolean enabled) {
     HTTPRequest.enablePrintRequestUrlOnFailure(enabled);
+  }
+
+  /**
+   * Set the OkHttpClient used for requesting map resources.
+   *
+   * @param client the OkHttpClient
+   */
+  public static void setOkHttpClient(OkHttpClient client) {
+    HTTPRequest.setOKHttpClient(client);
   }
 
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
@@ -55,7 +55,7 @@ public class DebugModeActivity extends AppCompatActivity implements OnMapReadyCa
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    HttpRequestUtil.setPrintRequestUrlOnFaillure(true);
+    HttpRequestUtil.setPrintRequestUrlOnFailure(true);
     setContentView(R.layout.activity_debug_mode);
     setupToolbar();
     setupMapView(savedInstanceState);
@@ -206,7 +206,7 @@ public class DebugModeActivity extends AppCompatActivity implements OnMapReadyCa
   protected void onDestroy() {
     super.onDestroy();
     mapView.onDestroy();
-    HttpRequestUtil.setPrintRequestUrlOnFaillure(false);
+    HttpRequestUtil.setPrintRequestUrlOnFailure(false);
   }
 
   @Override


### PR DESCRIPTION
Capturing from an end user that they need to be able to add [Interceptors](https://github.com/square/okhttp/wiki/Interceptors) to requests made by the SDK. To also improve integration for issues as #9640 it makes more sense allow setting an external OkHttpClient instead of exposing the existing one (eg. SSLSocketFactory can only be added as part of the builder).