### PR TITLE
[core] Synchronize state of CollisionIndex and FeatureIndexes.

### DIFF
--- a/src/mbgl/renderer/renderer_impl.hpp
+++ b/src/mbgl/renderer/renderer_impl.hpp
@@ -74,6 +74,7 @@ private:
     void onTileChanged(RenderSource&, const OverscaledTileID&) override;
     void onTileError(RenderSource&, const OverscaledTileID&, std::exception_ptr) override;
 
+    void commitFeatureIndexes();
     void updateFadingTiles();
 
     friend class Renderer;

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -130,7 +130,7 @@ void GeometryTile::onLayout(LayoutResult result, const uint64_t resultCorrelatio
     //  replacing a tile at a different zoom that _did_ have symbols.
     (void)resultCorrelationID;
     nonSymbolBuckets = std::move(result.nonSymbolBuckets);
-    featureIndex = std::move(result.featureIndex);
+    pendingFeatureIndex = std::move(result.featureIndex);
     data = std::move(result.tileData);
     observer->onTileChanged(*this);
 }
@@ -211,6 +211,12 @@ Bucket* GeometryTile::getBucket(const Layer::Impl& layer) const {
 
     assert(it->second);
     return it->second.get();
+}
+
+void GeometryTile::commitFeatureIndex() {
+    if (pendingFeatureIndex) {
+        featureIndex = std::move(pendingFeatureIndex);
+    }
 }
 
 void GeometryTile::queryRenderedFeatures(

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -131,7 +131,7 @@ void GeometryTile::onLayout(LayoutResult result, const uint64_t resultCorrelatio
     (void)resultCorrelationID;
     nonSymbolBuckets = std::move(result.nonSymbolBuckets);
     pendingFeatureIndex = std::move(result.featureIndex);
-    data = std::move(result.tileData);
+    pendingData = std::move(result.tileData);
     observer->onTileChanged(*this);
 }
 
@@ -216,6 +216,9 @@ Bucket* GeometryTile::getBucket(const Layer::Impl& layer) const {
 void GeometryTile::commitFeatureIndex() {
     if (pendingFeatureIndex) {
         featureIndex = std::move(pendingFeatureIndex);
+    }
+    if (pendingData) {
+        data = std::move(pendingData);
     }
 }
 

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -127,6 +127,7 @@ private:
     std::unique_ptr<FeatureIndex> featureIndex;
     std::unique_ptr<FeatureIndex> pendingFeatureIndex;
     std::unique_ptr<const GeometryTileData> data;
+    std::unique_ptr<const GeometryTileData> pendingData;
 
     optional<AlphaImage> glyphAtlasImage;
     optional<PremultipliedImage> iconAtlasImage;

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -100,6 +100,8 @@ public:
     void markRenderedPreviously() override;
     void performedFadePlacement() override;
     
+    void commitFeatureIndex() override;
+    
 protected:
     const GeometryTileData* getData() {
         return data.get();
@@ -123,6 +125,7 @@ private:
 
     std::unordered_map<std::string, std::shared_ptr<Bucket>> nonSymbolBuckets;
     std::unique_ptr<FeatureIndex> featureIndex;
+    std::unique_ptr<FeatureIndex> pendingFeatureIndex;
     std::unique_ptr<const GeometryTileData> data;
 
     optional<AlphaImage> glyphAtlasImage;

--- a/src/mbgl/tile/tile.hpp
+++ b/src/mbgl/tile/tile.hpp
@@ -109,6 +109,11 @@ public:
     // and will have time to finish by the second placement.
     virtual void performedFadePlacement() {}
     
+    // FeatureIndexes are loaded asynchronously, but must be used with a CollisionIndex
+    // generated from the same data. Calling commitFeatureIndex signals the current
+    // CollisionIndex is up-to-date and allows us to start using the last loaded FeatureIndex
+    virtual void commitFeatureIndex() {}
+    
     void dumpDebugLogs() const;
 
     const OverscaledTileID id;


### PR DESCRIPTION
Fixes issue #10778, in which mismatch between FeatureIndex and CollisionIndex could lead to inconsistent results or even invalid array access.

The expected behavior after this change is that the FeatureIndexes used by `queryRenderedFeatures` will only update at the same time placement finishes and the CollisionIndex is updated. This means the results will always be valid, and there shouldn't be any "flickering" in which a symbol disappears from query results in between the time a tile updates and the time the next placement happens. For non-symbol features, this change _opens_ a gap between when they start being rendered (as soon as the tile loads) and when they show up in query results (when placement happens).

This approach relies on placement happening all at once, so we can't port it directly to GL JS (and if we implement partial placement on gl-native we'll have to adjust this). I think a fuller solution would have the CollisionIndex either outright own the data it needs to return (too bulky?) or maybe have some form of shared ownership.

I don't have a good strategy for measuring the performance impact, but I think it should be pretty minimal -- it's basically just a delete gets deferred by up to 300ms when a tile updates.

I also don't know a great way to test this, since the flaw depends on precise timing and the logic isn't contained to a single unit. 😕 

/cc @ansis