### PR TITLE
[ios] Optimize MGLAnnotationView scale transform when not pitched

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -17,6 +17,10 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Fixed a memory leak that occurred when creating a map snapshot. ([#10585](https://github.com/mapbox/mapbox-gl-native/pull/10585))
 
+### Annotations
+
+* Improved performance of `MGLAnnotationView`-backed annotations that have `scalesWithViewingDistance` enabled. ([#10951](https://github.com/mapbox/mapbox-gl-native/pull/10951))
+
 ### Other changes
 
 * Long-pressing the attribution button causes the SDK’s version number to be displayed in the action sheet that appears. ([#10650](https://github.com/mapbox/mapbox-gl-native/pull/10650))

--- a/platform/ios/src/MGLAnnotationView.h
+++ b/platform/ios/src/MGLAnnotationView.h
@@ -171,6 +171,10 @@ MGL_EXPORT
 
  The default value of this property is `YES`. Set this property to `NO` if the
  view’s legibility is important.
+
+ @note Scaling many on-screen annotation views can contribute to poor map
+    performance. Consider disabling this property if your use case involves
+    hundreds or thousands of annotation views.
  */
 @property (nonatomic, assign) BOOL scalesWithViewingDistance;
 


### PR DESCRIPTION
Skips 3D transform (pitch scaling) logic if an `MGLAnnotationView` with `scalesWithViewingDistance = YES` is being shown on an unpitched map.

This change yields a modest 5-10% reduction in the amount of time spent updating view annotation positions in such cases. Since `scalesWithViewingDistance` is enabled by default, this seems worthwhile.

![screen shot 2018-01-17 at 8 16 32 pm](https://user-images.githubusercontent.com/1198851/35075861-7d93e8a8-fbc3-11e7-889f-4bf8587c1785.png)
_Moving around an unpitched map, post-optimization._

/cc @boundsj @1ec5 