### PR TITLE
Prune unused layers from CrossTileSymbolIndex

### DIFF
--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -382,8 +382,10 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
     bool placementChanged = false;
     if (!placement->stillRecent(parameters.timePoint)) {
         auto newPlacement = std::make_unique<Placement>(parameters.state, parameters.mapMode);
+        std::set<std::string> usedSymbolLayers;
         for (auto it = order.rbegin(); it != order.rend(); ++it) {
             if (it->layer.is<RenderSymbolLayer>()) {
+                usedSymbolLayers.insert(it->layer.getID());
                 newPlacement->placeLayer(*it->layer.as<RenderSymbolLayer>(), parameters.projMatrix, parameters.debugOptions & MapDebugOptions::Collision);
             }
         }
@@ -393,6 +395,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         // started. If we violate this assumption, then we need to either make CollisionIndex completely independendent of
         // FeatureIndex, or find a way for its entries to point to multiple FeatureIndexes.
         commitFeatureIndexes();
+        crossTileSymbolIndex.pruneUnusedLayers(usedSymbolLayers);
         if (placementChanged || symbolBucketsChanged) {
             placement = std::move(newPlacement);
         }

--- a/src/mbgl/text/cross_tile_symbol_index.cpp
+++ b/src/mbgl/text/cross_tile_symbol_index.cpp
@@ -169,6 +169,18 @@ bool CrossTileSymbolIndex::addLayer(RenderSymbolLayer& symbolLayer) {
     return symbolBucketsChanged;
 }
 
+void CrossTileSymbolIndex::pruneUnusedLayers(const std::set<std::string>& usedLayers) {
+    std::vector<std::string> unusedLayers;
+    for (auto layerIndex : layerIndexes) {
+        if (usedLayers.find(layerIndex.first) == usedLayers.end()) {
+            unusedLayers.push_back(layerIndex.first);
+        }
+    }
+    for (auto unusedLayer : unusedLayers) {
+        layerIndexes.erase(unusedLayer);
+    }
+}
+
 void CrossTileSymbolIndex::reset() {
     layerIndexes.clear();
 }

--- a/src/mbgl/text/cross_tile_symbol_index.hpp
+++ b/src/mbgl/text/cross_tile_symbol_index.hpp
@@ -57,6 +57,7 @@ public:
     CrossTileSymbolIndex();
 
     bool addLayer(RenderSymbolLayer&);
+    void pruneUnusedLayers(const std::set<std::string>&);
 
     void reset();
 private:


### PR DESCRIPTION
Fixes issue #10939 -- removed layers would leak entries in the CrossTileSymbolIndex.

Native analog of https://github.com/mapbox/mapbox-gl-js/pull/6016. The behavior ends up being a little bit different on native because layers get removed from the `order` whenever they're not being rendered (even though they're still part of the style). That means that if you, say, cross to a zoom level where a layer isn't visible, `addLayer` won't get called for that layer, and thus `removeStaleBuckets` won't get called either, and you'll leave behind stale entries. I don't think those stale entries will cause a problem because you're guaranteed that none of the `crossTileIDs` will be in use (and thus it's OK to re-use the IDs when that layer becomes visible again). However, I think the new behavior of just removing entries for unused layers is cleaner, and solves the leaking problem when layers are actually fully removed from the style.

I didn't do an analogous unit test because setting up mocks for `CrossTileSymbolIndex` turned out to be a lot trickier than setting up just mocks for `CrossTillSymbolLayerIndex`, and it wasn't complicated logic to test. The render tests at least implicitly use the new code. 🤷‍♂️ 😬 

/cc @ansis 