### PR TITLE
Cherry pick v5.3.2 changes

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Mapbox welcomes participation and contributions from everyone.  If you'd like to do so please see the [`Contributing Guide`](https://github.com/mapbox/mapbox-gl-native/blob/master/CONTRIBUTING.md) first to get started.
 
+## master
+ - Add Hebrew localization [#10967](https://github.com/mapbox/mapbox-gl-native/pull/10967)
+
+## 5.3.2 - January 22, 2018
+ - Validate surface creation before destroying [#10890](https://github.com/mapbox/mapbox-gl-native/pull/10890)
+ - Add filesource activation ot OfflineRegion [#10904](https://github.com/mapbox/mapbox-gl-native/pull/10904)
+ - Save configuration of UiSettings [#10908](https://github.com/mapbox/mapbox-gl-native/pull/10908)
+ - Do not overwrite user-set focal point [#10910](https://github.com/mapbox/mapbox-gl-native/pull/10910)
+ - Camera callbacks for velocity animated movements [#10925](https://github.com/mapbox/mapbox-gl-native/pull/10925)
+ - Allow changing the used OkHttpClient [#10948](https://github.com/mapbox/mapbox-gl-native/pull/10948)
+ - Validate zoom level before creating telemetry event [#10959](https://github.com/mapbox/mapbox-gl-native/pull/10959)
+ - Handle null call instances in HttpRequest [#10987](https://github.com/mapbox/mapbox-gl-native/pull/10987)
+ 
 ## 5.3.1 - January 10, 2018
  - Blacklist binary program loading for Vivante GC4000 GPUs [#10862](https://github.com/mapbox/mapbox-gl-native/pull/10862)
  - Support Genymotion [#10841](https://github.com/mapbox/mapbox-gl-native/pull/10841)

--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -127,7 +127,7 @@ android {
     }
 
     testOptions {
-        unitTests{
+        unitTests {
             returnDefaultValues = true
         }
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
@@ -146,4 +146,7 @@ public class MapboxConstants {
   public static final String STATE_LOCATION_VIEW_ACCURACY_TINT_COLOR = "mapbox_locViewAccuracyTintColor";
   public static final String STATE_LOCATION_VIEW_ACCURACY_THRESHOLD = "mapbox_locViewAccuracyThreshold";
   public static final String STATE_LOCATION_VIEW_PADDING = "mapbox_locViewPadding";
+  public static final String STATE_DESELECT_MARKER_ON_TAP = "mapbox_deselectMarkerOnTap";
+  public static final String STATE_USER_FOCAL_POINT = "mapbox_userFocalPoint";
+
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HTTPRequest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HTTPRequest.java
@@ -234,4 +234,8 @@ class HTTPRequest implements Callback {
   static void enablePrintRequestUrlOnFailure(boolean enabled) {
     logRequestUrl = enabled;
   }
+
+  static void setOKHttpClient(OkHttpClient client) {
+    mClient = client;
+  }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HTTPRequest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HTTPRequest.java
@@ -170,7 +170,7 @@ class HTTPRequest implements Callback {
     String errorMessage = e.getMessage() != null ? e.getMessage() : "Error processing the request";
     int type = getFailureType(e);
 
-    if (logEnabled) {
+    if (logEnabled && call != null && call.request() != null) {
       String requestUrl = call.request().url().toString();
       logFailure(type, errorMessage, requestUrl);
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HttpRequestUtil.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HttpRequestUtil.java
@@ -1,5 +1,7 @@
 package com.mapbox.mapboxsdk.http;
 
+import okhttp3.OkHttpClient;
+
 /**
  * Utility class for setting HttpRequest configurations
  */
@@ -28,8 +30,17 @@ public class HttpRequestUtil {
    *
    * @param enabled True will print urls, false will disable
    */
-  public static void setPrintRequestUrlOnFaillure(boolean enabled) {
+  public static void setPrintRequestUrlOnFailure(boolean enabled) {
     HTTPRequest.enablePrintRequestUrlOnFailure(enabled);
+  }
+
+  /**
+   * Set the OkHttpClient used for requesting map resources.
+   *
+   * @param client the OkHttpClient
+   */
+  public static void setOkHttpClient(OkHttpClient client) {
+    HTTPRequest.setOKHttpClient(client);
   }
 
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
@@ -34,6 +34,11 @@ class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, M
   private final Runnable onCameraMoveStartedRunnable = new Runnable() {
     @Override
     public void run() {
+      if (!idle) {
+        return;
+      }
+      idle = false;
+
       // deprecated API
       if (onCameraMoveStartedListener != null) {
         onCameraMoveStartedListener.onCameraMoveStarted(moveStartedReason);
@@ -85,6 +90,11 @@ class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, M
   private final Runnable onCameraIdleRunnable = new Runnable() {
     @Override
     public void run() {
+      if (idle) {
+        return;
+      }
+      idle = true;
+
       // deprecated API
       if (onCameraIdleListener != null) {
         onCameraIdleListener.onCameraIdle();
@@ -121,10 +131,6 @@ class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, M
 
   @Override
   public void onCameraMoveStarted(final int reason) {
-    if (!idle) {
-      return;
-    }
-    idle = false;
     moveStartedReason = reason;
     handler.post(onCameraMoveStartedRunnable);
   }
@@ -141,10 +147,7 @@ class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, M
 
   @Override
   public void onCameraIdle() {
-    if (!idle) {
-      idle = true;
-      handler.post(onCameraIdleRunnable);
-    }
+    handler.post(onCameraIdleRunnable);
   }
 
   void addOnCameraIdleListener(@NonNull OnCameraIdleListener listener) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapFragment.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapFragment.java
@@ -68,7 +68,6 @@ public final class MapFragment extends Fragment implements OnMapReadyCallback {
     super.onCreateView(inflater, container, savedInstanceState);
     Context context = inflater.getContext();
     map = new MapView(context, MapFragmentUtils.resolveArgs(context, getArguments()));
-    map.setVisibility(View.INVISIBLE);
     return map;
   }
 
@@ -91,7 +90,6 @@ public final class MapFragment extends Fragment implements OnMapReadyCallback {
     for (OnMapReadyCallback onMapReadyCallback : mapReadyCallbackList) {
       onMapReadyCallback.onMapReady(mapboxMap);
     }
-    map.setVisibility(View.VISIBLE);
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -75,6 +75,7 @@ public class MapView extends FrameLayout {
   private NativeMapView nativeMapView;
   private MapboxMapOptions mapboxMapOptions;
   private boolean destroyed;
+  private boolean hasSurface;
 
   private MyLocationView myLocationView;
   private CompassView compassView;
@@ -321,6 +322,7 @@ public class MapView extends FrameLayout {
   }
 
   private void initRenderSurface() {
+    hasSurface = true;
     post(new Runnable() {
       @Override
       public void run() {
@@ -409,7 +411,7 @@ public class MapView extends FrameLayout {
     destroyed = true;
     mapCallback.clearOnMapReadyCallbacks();
 
-    if (nativeMapView != null) {
+    if (nativeMapView != null && hasSurface) {
       // null when destroying an activity programmatically mapbox-navigation-android/issues/503
       nativeMapView.destroy();
       nativeMapView = null;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxEventWrapper.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxEventWrapper.java
@@ -4,6 +4,7 @@ import android.location.Location;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.services.android.telemetry.MapboxEvent;
 
 import java.util.Hashtable;
@@ -21,24 +22,32 @@ class MapboxEventWrapper {
   static Hashtable<String, Object> buildMapClickEvent(
     @NonNull Location location, @NonNull String gestureId, Transform transform) {
     try {
-      return MapboxEvent.buildMapClickEvent(location, gestureId, transform.getZoom());
+      double mapZoom = transform.getZoom();
+      if (mapZoom >= MapboxConstants.MINIMUM_ZOOM && mapZoom <= MapboxConstants.MAXIMUM_ZOOM) {
+        // validate zoom #8057
+        return MapboxEvent.buildMapClickEvent(location, gestureId, transform.getZoom());
+      }
     } catch (NullPointerException exception) {
       // Map/Transform is not ready yet #8650
       // returning null is valid, event is ignored.
-      return null;
     }
+    return null;
   }
 
   @Nullable
   static Hashtable<String, Object> buildMapDragEndEvent(
     @NonNull Location location, Transform transform) {
     try {
-      return MapboxEvent.buildMapDragEndEvent(location, transform.getZoom());
+      double mapZoom = transform.getZoom();
+      if (mapZoom >= MapboxConstants.MINIMUM_ZOOM && mapZoom <= MapboxConstants.MAXIMUM_ZOOM) {
+        // validate zoom #8057
+        return MapboxEvent.buildMapDragEndEvent(location, transform.getZoom());
+      }
     } catch (NullPointerException exception) {
       // Map/Transform is not ready yet #8650
       // returning null is valid, event is ignored.
-      return null;
     }
+    return null;
   }
 
   @Nullable

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
@@ -68,7 +68,6 @@ public class SupportMapFragment extends Fragment implements OnMapReadyCallback {
     super.onCreateView(inflater, container, savedInstanceState);
     Context context = inflater.getContext();
     map = new MapView(context, MapFragmentUtils.resolveArgs(context, getArguments()));
-    map.setVisibility(View.INVISIBLE);
     return map;
   }
 
@@ -91,7 +90,6 @@ public class SupportMapFragment extends Fragment implements OnMapReadyCallback {
     for (OnMapReadyCallback onMapReadyCallback : mapReadyCallbackList) {
       onMapReadyCallback.onMapReady(mapboxMap);
     }
-    map.setVisibility(View.VISIBLE);
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
@@ -261,7 +261,7 @@ final class Transform implements MapView.OnMapChangedListener {
     setZoom(zoom, focalPoint, 0, false);
   }
 
-  void setZoom(double zoom, @NonNull PointF focalPoint, long duration, boolean isAnimator) {
+  void setZoom(double zoom, @NonNull PointF focalPoint, long duration, final boolean isAnimator) {
     if (mapView != null) {
       mapView.addOnMapChangedListener(new MapView.OnMapChangedListener() {
         @Override

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
@@ -239,7 +239,7 @@ final class Transform implements MapView.OnMapChangedListener {
     CameraPosition cameraPosition = invalidateCameraPosition();
     if (cameraPosition != null) {
       int newZoom = (int) Math.round(cameraPosition.zoom + (zoomIn ? 1 : -1));
-      setZoom(newZoom, focalPoint, MapboxConstants.ANIMATION_DURATION);
+      setZoom(newZoom, focalPoint, MapboxConstants.ANIMATION_DURATION, false);
     } else {
       // we are not transforming, notify about being idle
       cameraChangeDispatcher.onCameraIdle();
@@ -250,7 +250,7 @@ final class Transform implements MapView.OnMapChangedListener {
     CameraPosition cameraPosition = invalidateCameraPosition();
     if (cameraPosition != null) {
       int newZoom = (int) Math.round(cameraPosition.zoom + zoomAddition);
-      setZoom(newZoom, focalPoint, duration);
+      setZoom(newZoom, focalPoint, duration, false);
     } else {
       // we are not transforming, notify about being idle
       cameraChangeDispatcher.onCameraIdle();
@@ -258,16 +258,18 @@ final class Transform implements MapView.OnMapChangedListener {
   }
 
   void setZoom(double zoom, @NonNull PointF focalPoint) {
-    setZoom(zoom, focalPoint, 0);
+    setZoom(zoom, focalPoint, 0, false);
   }
 
-  void setZoom(double zoom, @NonNull PointF focalPoint, long duration) {
+  void setZoom(double zoom, @NonNull PointF focalPoint, long duration, boolean isAnimator) {
     if (mapView != null) {
       mapView.addOnMapChangedListener(new MapView.OnMapChangedListener() {
         @Override
         public void onMapChanged(int change) {
           if (change == MapView.REGION_DID_CHANGE_ANIMATED) {
-            cameraChangeDispatcher.onCameraIdle();
+            if (!isAnimator) {
+              cameraChangeDispatcher.onCameraIdle();
+            }
             mapView.removeOnMapChangedListener(this);
           }
         }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
@@ -91,6 +91,8 @@ public final class UiSettings {
     saveLogo(outState);
     saveAttribution(outState);
     saveZoomControl(outState);
+    saveDeselectMarkersOnTap(outState);
+    saveFocalPoint(outState);
   }
 
   void onRestoreInstanceState(@NonNull Bundle savedInstanceState) {
@@ -99,6 +101,8 @@ public final class UiSettings {
     restoreLogo(savedInstanceState);
     restoreAttribution(savedInstanceState);
     restoreZoomControl(savedInstanceState);
+    restoreDeselectMarkersOnTap(savedInstanceState);
+    restoreFocalPoint(savedInstanceState);
   }
 
   private void initialiseGestures(MapboxMapOptions options) {
@@ -783,6 +787,14 @@ public final class UiSettings {
     return doubleTapGestureChangeAllowed;
   }
 
+  private void restoreDeselectMarkersOnTap(Bundle savedInstanceState) {
+    setDeselectMarkersOnTap(savedInstanceState.getBoolean(MapboxConstants.STATE_DESELECT_MARKER_ON_TAP));
+  }
+
+  private void saveDeselectMarkersOnTap(Bundle outState) {
+    outState.putBoolean(MapboxConstants.STATE_DESELECT_MARKER_ON_TAP, isDeselectMarkersOnTap());
+  }
+
   /**
    * Gets whether the markers are automatically deselected (and therefore, their infowindows
    * closed) when a map tap is detected.
@@ -860,6 +872,17 @@ public final class UiSettings {
     setTiltGesturesEnabled(enabled);
     setZoomGesturesEnabled(enabled);
     setDoubleTapGesturesEnabled(enabled);
+  }
+
+  private void saveFocalPoint(Bundle outState) {
+    outState.putParcelable(MapboxConstants.STATE_USER_FOCAL_POINT, getFocalPoint());
+  }
+
+  private void restoreFocalPoint(Bundle savedInstanceState) {
+    PointF pointF = savedInstanceState.getParcelable(MapboxConstants.STATE_USER_FOCAL_POINT);
+    if (pointF != null) {
+      setFocalPoint(pointF);
+    }
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
@@ -372,9 +372,6 @@ public class MyLocationView extends View {
    */
   public void setTilt(@FloatRange(from = 0, to = 60.0f) double tilt) {
     this.tilt = tilt;
-    if (myLocationTrackingMode == MyLocationTracking.TRACKING_FOLLOW) {
-      mapboxMap.getUiSettings().setFocalPoint(getCenter());
-    }
     invalidate();
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegion.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegion.java
@@ -1,12 +1,12 @@
 package com.mapbox.mapboxsdk.offline;
 
 import android.os.Handler;
-import android.os.Looper;
 import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.mapbox.mapboxsdk.LibraryLoader;
+import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.storage.FileSource;
 
 import java.lang.annotation.Retention;
@@ -51,7 +51,7 @@ public class OfflineRegion {
   private byte[] metadata;
 
   // Makes sure callbacks come back to the main thread
-  private Handler handler;
+  private final Handler handler = new Handler();
 
   /**
    * A region can have a single observer, which gets notified whenever a change
@@ -239,14 +239,6 @@ public class OfflineRegion {
     return metadata;
   }
 
-  private Handler getHandler() {
-    if (handler == null) {
-      handler = new Handler(Looper.getMainLooper());
-    }
-
-    return handler;
-  }
-
   /**
    * Register an observer to be notified when the state of the region changes.
    *
@@ -257,7 +249,7 @@ public class OfflineRegion {
       @Override
       public void onStatusChanged(final OfflineRegionStatus status) {
         if (deliverMessages()) {
-          getHandler().post(new Runnable() {
+          handler.post(new Runnable() {
             @Override
             public void run() {
               if (observer != null) {
@@ -271,7 +263,7 @@ public class OfflineRegion {
       @Override
       public void onError(final OfflineRegionError error) {
         if (deliverMessages()) {
-          getHandler().post(new Runnable() {
+          handler.post(new Runnable() {
             @Override
             public void run() {
               if (observer != null) {
@@ -285,7 +277,7 @@ public class OfflineRegion {
       @Override
       public void mapboxTileCountLimitExceeded(final long limit) {
         if (deliverMessages()) {
-          getHandler().post(new Runnable() {
+          handler.post(new Runnable() {
             @Override
             public void run() {
               if (observer != null) {
@@ -325,23 +317,26 @@ public class OfflineRegion {
    * @param callback the callback to invoked.
    */
   public void getStatus(@NonNull final OfflineRegionStatusCallback callback) {
+    FileSource.getInstance(Mapbox.getApplicationContext()).activate();
     getOfflineRegionStatus(new OfflineRegionStatusCallback() {
       @Override
       public void onStatus(final OfflineRegionStatus status) {
-        getHandler().post(new Runnable() {
+        handler.post(new Runnable() {
           @Override
           public void run() {
             callback.onStatus(status);
+            FileSource.getInstance(Mapbox.getApplicationContext()).deactivate();
           }
         });
       }
 
       @Override
       public void onError(final String error) {
-        getHandler().post(new Runnable() {
+        handler.post(new Runnable() {
           @Override
           public void run() {
             callback.onError(error);
+            FileSource.getInstance(Mapbox.getApplicationContext()).deactivate();
           }
         });
       }
@@ -368,13 +363,15 @@ public class OfflineRegion {
   public void delete(@NonNull final OfflineRegionDeleteCallback callback) {
     if (!isDeleted) {
       isDeleted = true;
+      FileSource.getInstance(Mapbox.getApplicationContext()).activate();
       deleteOfflineRegion(new OfflineRegionDeleteCallback() {
         @Override
         public void onDelete() {
-          getHandler().post(new Runnable() {
+          handler.post(new Runnable() {
             @Override
             public void run() {
               callback.onDelete();
+              FileSource.getInstance(Mapbox.getApplicationContext()).deactivate();
               OfflineRegion.this.finalize();
             }
           });
@@ -382,10 +379,11 @@ public class OfflineRegion {
 
         @Override
         public void onError(final String error) {
-          getHandler().post(new Runnable() {
+          handler.post(new Runnable() {
             @Override
             public void run() {
               isDeleted = false;
+              FileSource.getInstance(Mapbox.getApplicationContext()).deactivate();
               callback.onError(error);
             }
           });
@@ -408,7 +406,7 @@ public class OfflineRegion {
     updateOfflineRegionMetadata(bytes, new OfflineRegionUpdateMetadataCallback() {
       @Override
       public void onUpdate(final byte[] metadata) {
-        getHandler().post(new Runnable() {
+        handler.post(new Runnable() {
           @Override
           public void run() {
             OfflineRegion.this.metadata = metadata;
@@ -419,7 +417,7 @@ public class OfflineRegion {
 
       @Override
       public void onError(final String error) {
-        getHandler().post(new Runnable() {
+        handler.post(new Runnable() {
           @Override
           public void run() {
             callback.onError(error);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
@@ -57,7 +57,7 @@ public class DebugModeActivity extends AppCompatActivity implements OnMapReadyCa
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    HttpRequestUtil.setPrintRequestUrlOnFaillure(true);
+    HttpRequestUtil.setPrintRequestUrlOnFailure(true);
     setContentView(R.layout.activity_debug_mode);
     setupToolbar();
     setupMapView(savedInstanceState);
@@ -231,7 +231,7 @@ public class DebugModeActivity extends AppCompatActivity implements OnMapReadyCa
   protected void onDestroy() {
     super.onDestroy();
     mapView.onDestroy();
-    HttpRequestUtil.setPrintRequestUrlOnFaillure(false);
+    HttpRequestUtil.setPrintRequestUrlOnFailure(false);
   }
 
   @Override


### PR DESCRIPTION
This PR cherry-picks all the 5.3.2 changes from master to the release branch:

##### TODO

 - [x] merge and cherry-pick https://github.com/mapbox/mapbox-gl-native/pull/10959
 - [x] create changelog and cherry-pick PR #10982
 - [x] merge and cherry-pick https://github.com/mapbox/mapbox-gl-native/pull/10987

##### Changelog proposal

```markdown
## 5.3.2 - January 22, 2018
 - Validate Surface creation before destroying [#10890](https://github.com/mapbox/mapbox-gl-native/pull/10890)
 - Add filesource activation ot OfflineRegion [#10904](https://github.com/mapbox/mapbox-gl-native/pull/10904)
 - Save configuration of UiSettings [#10908](https://github.com/mapbox/mapbox-gl-native/pull/10908)
 - Do not overwrite user-set focal point [#10910](https://github.com/mapbox/mapbox-gl-native/pull/10910)
 - Camera callbacks for velocity animated movements [#10925](https://github.com/mapbox/mapbox-gl-native/pull/10925)
 - Allow changing the used OkHttpClient [#10948](https://github.com/mapbox/mapbox-gl-native/pull/10948)
 - Validate zoom level before creating telemetry event [#10959](https://github.com/mapbox/mapbox-gl-native/pull/10959)
 ```
