### PR TITLE
handle null call instances in HttpRequest

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HTTPRequest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HTTPRequest.java
@@ -170,7 +170,7 @@ class HTTPRequest implements Callback {
     String errorMessage = e.getMessage() != null ? e.getMessage() : "Error processing the request";
     int type = getFailureType(e);
 
-    if (logEnabled) {
+    if (logEnabled && call != null && call.request() != null) {
       String requestUrl = call.request().url().toString();
       logFailure(type, errorMessage, requestUrl);
     }


### PR DESCRIPTION
A user reported that they were able to get a null Call object when there is no internet connection. Haven't been able to produce the crash though the fix in this PR hardens that part of the codebase.