### PR TITLE
[android] NativeMapView.addImage without copying bitmap into Java

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -758,20 +758,11 @@ final class NativeMapView {
       return;
     }
 
-    // Check/correct config
-    if (image.getConfig() != Bitmap.Config.ARGB_8888) {
-      image = image.copy(Bitmap.Config.ARGB_8888, false);
-    }
-
-    // Get pixels
-    ByteBuffer buffer = ByteBuffer.allocate(image.getByteCount());
-    image.copyPixelsToBuffer(buffer);
-
     // Determine pixel ratio
     float density = image.getDensity() == Bitmap.DENSITY_NONE ? Bitmap.DENSITY_NONE : image.getDensity();
     float pixelRatio = density / DisplayMetrics.DENSITY_DEFAULT;
 
-    nativeAddImage(name, image.getWidth(), image.getHeight(), pixelRatio, buffer.array());
+    nativeAddImage(name, image, pixelRatio);
   }
 
   public void addImages(@NonNull HashMap<String, Bitmap> bitmapHashMap) {
@@ -1032,8 +1023,7 @@ final class NativeMapView {
 
   private native void nativeRemoveSource(Source source, long sourcePtr);
 
-  private native void nativeAddImage(String name, int width, int height, float pixelRatio,
-                                     byte[] array);
+  private native void nativeAddImage(String name, Bitmap bitmap, float pixelRatio);
 
   private native void nativeAddImages(Image[] images);
 

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -893,16 +893,9 @@ void NativeMapView::removeSource(JNIEnv& env, jni::Object<Source> obj, jlong sou
     source->removeFromMap(env, obj, *map);
 }
 
-void NativeMapView::addImage(JNIEnv& env, jni::String name, jni::jint w, jni::jint h, jni::jfloat scale, jni::Array<jbyte> pixels) {
-    jni::NullCheck(env, &pixels);
-    std::size_t size = pixels.Length(env);
-
-    mbgl::PremultipliedImage premultipliedImage({ static_cast<uint32_t>(w), static_cast<uint32_t>(h) });
-    if (premultipliedImage.bytes() != uint32_t(size)) {
-        throw mbgl::util::SpriteImageException("Sprite image pixel count mismatch");
-    }
-
-    jni::GetArrayRegion(env, *pixels, 0, size, reinterpret_cast<jbyte*>(premultipliedImage.data.get()));
+void NativeMapView::addImage(JNIEnv& env, jni::String name, jni::Object<Bitmap> bitmap, jni::jfloat scale) {
+    jni::NullCheck(env, &bitmap);
+    mbgl::PremultipliedImage premultipliedImage = Bitmap::GetImage(env, bitmap);
 
     map->getStyle().addImage(std::make_unique<mbgl::style::Image>(
         jni::Make<std::string>(env, name),

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -236,7 +236,7 @@ public:
 
     void removeSource(JNIEnv&, jni::Object<Source>, jlong nativePtr);
 
-    void addImage(JNIEnv&, jni::String, jni::jint, jni::jint, jni::jfloat, jni::Array<jbyte>);
+    void addImage(JNIEnv&, jni::String, jni::Object<Bitmap> bitmap, jni::jfloat);
 
     void addImages(JNIEnv&, jni::Array<jni::Object<mbgl::android::Image>>);
 


### PR DESCRIPTION
Bitmaps bytes are stored in native memory. NativeMapView.addImage was copying the bitmap from native to Java and then back to native. Using Bitmap::GetImage keeps the bitmap in native only.

I tested some small bitmaps on a pixel and it saved .3ms each.

@kkaefer @tobrun 