### PR TITLE
Backport: Fix style parsing crash when a layer's paint property is not an object

### DIFF
--- a/include/mbgl/style/conversion/layer.hpp
+++ b/include/mbgl/style/conversion/layer.hpp
@@ -43,6 +43,9 @@ optional<Error> setPaintProperties(Layer& layer, const V& value) {
     if (!paintValue) {
         return {};
     }
+    if (!isObject(*paintValue)) {
+        return { { "paint must be an object" } };
+    }
     return eachMember(*paintValue, [&] (const std::string& k, const V& v) {
         return setPaintProperty(layer, k, v);
     });

--- a/test/fixtures/style_parser/paint-nonobject.info.json
+++ b/test/fixtures/style_parser/paint-nonobject.info.json
@@ -1,0 +1,7 @@
+{
+    "default": {
+        "log": [
+            [1, "WARNING", "ParseStyle", "paint must be an object"]
+        ]
+    }
+}

--- a/test/fixtures/style_parser/paint-nonobject.style.json
+++ b/test/fixtures/style_parser/paint-nonobject.style.json
@@ -1,0 +1,8 @@
+{
+  "version": 8,
+  "layers": [{
+    "id": "background",
+    "type": "background",
+    "paint": true
+  }]
+}


### PR DESCRIPTION
Fixes crash reported in #10226. Backport of https://github.com/mapbox/mapbox-gl-native/pull/11001