### PR TITLE
Prioritize thread pause()/resume() calls (Take #2)

### DIFF
--- a/include/mbgl/util/run_loop.hpp
+++ b/include/mbgl/util/run_loop.hpp
@@ -88,12 +88,13 @@ private:
 
     void process() {
         std::unique_lock<std::mutex> lock(mutex);
-        Queue queue_;
-        lock.unlock();
-
-        while (!queue_.empty()) {
-            (*(queue_.front()))();
-            queue_.pop();
+        std::shared_ptr<WorkTask> task;
+        while (!queue.empty()) {
+            task = std::move(queue.front());
+            queue.pop();
+            lock.unlock();
+            (*task)();
+            lock.lock();
         }
     }
 

--- a/include/mbgl/util/thread.hpp
+++ b/include/mbgl/util/thread.hpp
@@ -128,26 +128,9 @@ private:
     MBGL_STORE_THREAD(tid);
 
     void schedule(std::weak_ptr<Mailbox> mailbox) override {
-        {
-            std::lock_guard<std::mutex> lock(mutex);
-            queue.push(mailbox);
-        }
-
-        loop->invoke([this] { receive(); });
+        loop->schedule(mailbox);
     }
 
-    void receive() {
-        std::unique_lock<std::mutex> lock(mutex);
-
-        auto mailbox = queue.front();
-        queue.pop();
-        lock.unlock();
-
-        Mailbox::maybeReceive(mailbox);
-    }
-
-    std::mutex mutex;
-    std::queue<std::weak_ptr<Mailbox>> queue;
     std::thread thread;
     std::unique_ptr<Actor<Object>> object;
 

--- a/include/mbgl/util/thread.hpp
+++ b/include/mbgl/util/thread.hpp
@@ -103,7 +103,7 @@ public:
 
         auto pausing = paused->get_future();
 
-        loop->invoke([this] {
+        loop->invoke(RunLoop::Priority::High, [this] {
             auto resuming = resumed->get_future();
             paused->set_value();
             resuming.get();

--- a/platform/android/src/run_loop.cpp
+++ b/platform/android/src/run_loop.cpp
@@ -216,11 +216,8 @@ LOOP_HANDLE RunLoop::getLoopHandle() {
     return Get()->impl.get();
 }
 
-void RunLoop::push(std::shared_ptr<WorkTask> task) {
-    withMutex([&] {
-        queue.push(std::move(task));
-        impl->wake();
-    });
+void RunLoop::wake() {
+    impl->wake();
 }
 
 void RunLoop::run() {

--- a/platform/darwin/src/run_loop.cpp
+++ b/platform/darwin/src/run_loop.cpp
@@ -29,11 +29,8 @@ RunLoop::~RunLoop() {
     Scheduler::SetCurrent(nullptr);
 }
 
-void RunLoop::push(std::shared_ptr<WorkTask> task) {
-    withMutex([&] {
-        queue.push(std::move(task));
-        impl->async->send();
-    });
+void RunLoop::wake() {
+    impl->async->send();
 }
 
 void RunLoop::run() {

--- a/platform/default/run_loop.cpp
+++ b/platform/default/run_loop.cpp
@@ -129,11 +129,8 @@ LOOP_HANDLE RunLoop::getLoopHandle() {
     return Get()->impl->loop;
 }
 
-void RunLoop::push(std::shared_ptr<WorkTask> task) {
-    withMutex([&] {
-        queue.push(std::move(task));
-        impl->async->send();
-    });
+void RunLoop::wake() {
+    impl->async->send();
 }
 
 void RunLoop::run() {

--- a/platform/qt/src/run_loop.cpp
+++ b/platform/qt/src/run_loop.cpp
@@ -52,11 +52,8 @@ LOOP_HANDLE RunLoop::getLoopHandle() {
     return nullptr;
 }
 
-void RunLoop::push(std::shared_ptr<WorkTask> task) {
-    withMutex([&] {
-        queue.push(std::move(task));
-        impl->async->send();
-    });
+void RunLoop::wake() {
+    impl->async->send();
 }
 
 void RunLoop::run() {

--- a/test/util/run_loop.test.cpp
+++ b/test/util/run_loop.test.cpp
@@ -50,3 +50,17 @@ TEST(RunLoop, MultipleRun) {
 
     EXPECT_TRUE(secondTimeout);
 }
+
+TEST(RunLoop, Priorities) {
+    std::vector<int> order;
+
+    RunLoop loop(RunLoop::Type::New);
+    loop.invoke([&] { order.push_back(1); });
+    loop.invoke(RunLoop::Priority::High, [&] { order.push_back(2); });
+    loop.invoke([&] { order.push_back(3); });
+    loop.invoke(RunLoop::Priority::High, [&] { order.push_back(4); });
+    loop.invoke(RunLoop::Priority::Default, [&] { loop.stop(); });
+    loop.run();
+
+    EXPECT_EQ((std::vector<int>{ 2, 4, 1, 3 }), order);
+}


### PR DESCRIPTION
Alternative implementation of https://github.com/mapbox/mapbox-gl-native/pull/10174 that continues to use the existing model, and just prioritizes `pause()` calls by adding them to the front of the queue to address @jfirebaugh's concerns in https://github.com/mapbox/mapbox-gl-native/pull/10174#pullrequestreview-68377496

Implements part 1 of https://github.com/mapbox/mapbox-gl-native/issues/10031