### PR TITLE
Improve typing of expressions

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
@@ -758,7 +758,7 @@ public class Expression<T> {
    * @param input expression input
    * @return expression
    */
-  public static Expression get(@NonNull Expression<String> input) {
+  public static Expression<?> get(@NonNull Expression<String> input) {
     return new Expression<>("get", input);
   }
 
@@ -770,7 +770,7 @@ public class Expression<T> {
    * @param input string input
    * @return expression
    */
-  public static Expression get(@NonNull String input) {
+  public static Expression<?> get(@NonNull String input) {
     return get(literal(input));
   }
 
@@ -782,7 +782,7 @@ public class Expression<T> {
    * @param object an expression object
    * @return expression
    */
-  public static Expression get(@NonNull Expression<String> key, @NonNull Expression<Object> object) {
+  public static Expression<?> get(@NonNull Expression<String> key, @NonNull Expression<Object> object) {
     return new Expression<>("get", key, object);
   }
 
@@ -794,7 +794,7 @@ public class Expression<T> {
    * @param object an expression object
    * @return expression
    */
-  public static Expression get(@NonNull String key, @NonNull Expression<Object> object) {
+  public static Expression<?> get(@NonNull String key, @NonNull Expression<Object> object) {
     return get(literal(key), object);
   }
 
@@ -1758,4 +1758,37 @@ public class Expression<T> {
     return output;
   }
 
+  //
+  // asType
+  //
+
+  @SuppressWarnings("unchecked")
+  public Expression<Number> asNumber(){
+    return (Expression<Number>) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public Expression<String> asString(){
+    return (Expression<String>) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public Expression<Color> asColor(){
+    return (Expression<Color>) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public Expression<Boolean> asBoolean(){
+    return (Expression<Boolean>) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public Expression<Object> asObject(){
+    return (Expression<Object>) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public Expression<Array> asArray(){
+    return (Expression<Array>) this;
+  }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.java
@@ -408,14 +408,14 @@ public class ExpressionTest {
   @Test
   public void testHasExpression() throws Exception {
     Object[] expected = new Object[] {"has", new Object[] {"get", "key"}, new Object[] {"properties"}};
-    Object[] actual = has(get(literal("key")), properties()).toArray();
+    Object[] actual = has(get(literal("key")).asString(), properties()).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
 
   @Test
   public void testHasExpressionLiteral() throws Exception {
     Object[] expected = new Object[] {"has", new Object[] {"get", "key"}, new Object[] {"properties"}};
-    Object[] actual = has(get("key"), properties()).toArray();
+    Object[] actual = has(get("key").asString(), properties()).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
 
@@ -521,7 +521,7 @@ public class ExpressionTest {
   public void testDivisionWithNestedGet() throws Exception {
     Object nestedGet = new Object[] {"get", "key"};
     Object[] expected = new Object[] {"/", 2, nestedGet};
-    Object[] actual = division(literal(2), get(literal("key"))).toArray();
+    Object[] actual = division(literal(2), get(literal("key")).asNumber()).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
 
@@ -895,7 +895,7 @@ public class ExpressionTest {
   @Test
   public void testStepBasicLiteral() throws Exception {
     Object[] expected = new Object[] {"step", new Object[] {"get", "line-width"}, 11, 0, 111, 1, 1111};
-    Object[] actual = step(get("line-width"), literal(11), stop(0, 111), stop(1, 1111)).toArray();
+    Object[] actual = step(get("line-width").asNumber(), literal(11), stop(0, 111), stop(1, 1111)).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
 
@@ -942,7 +942,7 @@ public class ExpressionTest {
     Object[] get = new Object[] {"get", "x"};
     Object[] expected = new Object[] {"interpolate", exponential, get, 0, 100, 200};
     Object[] actual = interpolate(exponential(literal(12)),
-      get(literal("x")), literal(0), literal(100), literal(200)).toArray();
+      get(literal("x")).asNumber(), literal(0), literal(100), literal(200)).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
 
@@ -951,7 +951,7 @@ public class ExpressionTest {
     Object[] exponential = new Object[] {"exponential", 12};
     Object[] get = new Object[] {"get", "x"};
     Object[] expected = new Object[] {"interpolate", exponential, get, 0, 100, 100, 200};
-    Object[] actual = interpolate(exponential(12), get("x"), stop(0, 100), stop(100, 200)).toArray();
+    Object[] actual = interpolate(exponential(12), get("x").asNumber(), stop(0, 100), stop(100, 200)).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
 
@@ -961,7 +961,8 @@ public class ExpressionTest {
     Object[] exponential = new Object[] {"exponential", getX};
     Object[] getY = new Object[] {"get", "y"};
     Object[] expected = new Object[] {"interpolate", exponential, getY, 0, 100, 100, 200};
-    Object[] actual = interpolate(exponential(get("x")), get("y"), stop(0, 100), stop(100, 200)).toArray();
+    Object[] actual = interpolate(exponential(get("x").asNumber()), get("y").asNumber(),
+      stop(0, 100), stop(100, 200)).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
 
@@ -971,7 +972,7 @@ public class ExpressionTest {
     Object[] get = new Object[] {"get", "x"};
     Object[] expected = new Object[] {"interpolate", cubicBezier, get, 0, 100, 100, 200};
     Object[] actual = interpolate(cubicBezier(literal(1), literal(1), literal(1), literal(1)),
-      get(literal("x")), literal(0), literal(100), literal(100), literal(200)).toArray();
+      get(literal("x")).asNumber(), literal(0), literal(100), literal(100), literal(200)).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
 
@@ -980,7 +981,8 @@ public class ExpressionTest {
     Object[] cubicBezier = new Object[] {"cubic-bezier", 1, 1, 1, 1};
     Object[] get = new Object[] {"get", "x"};
     Object[] expected = new Object[] {"interpolate", cubicBezier, get, 0, 100, 100, 200};
-    Object[] actual = interpolate(cubicBezier(1, 1, 1, 1), get("x"), stop(0, 100), stop(100, 200)).toArray();
+    Object[] actual = interpolate(cubicBezier(1, 1, 1, 1), get("x").asNumber(),
+      stop(0, 100), stop(100, 200)).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
 
@@ -991,8 +993,9 @@ public class ExpressionTest {
     Object[] getZ = new Object[] {"get", "z"};
     Object[] cubicBezier = new Object[] {"cubic-bezier", getZ, 1, getY, 1};
     Object[] expected = new Object[] {"interpolate", cubicBezier, getX, 0, 100, 200};
-    Object[] actual = interpolate(cubicBezier(get(literal("z")), literal(1),
-      get(literal("y")), literal(1)), get(literal("x")), literal(0), literal(100), literal(200)).toArray();
+    Object[] actual = interpolate(cubicBezier(get(literal("z")).asNumber(), literal(1),
+      get(literal("y")).asNumber(), literal(1)), get(literal("x")).asNumber(), literal(0),
+      literal(100), literal(200)).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
 
@@ -1003,8 +1006,8 @@ public class ExpressionTest {
     Object[] getZ = new Object[] {"get", "z"};
     Object[] cubicBezier = new Object[] {"cubic-bezier", getZ, 1, getY, 1};
     Object[] expected = new Object[] {"interpolate", cubicBezier, getX, 0, 100, 100, 200};
-    Object[] actual = interpolate(cubicBezier(get("z"), literal(1), get("y"),
-      literal(1)), get("x"), stop(0, 100), stop(100, 200)).toArray();
+    Object[] actual = interpolate(cubicBezier(get("z").asNumber(), literal(1), get("y").asNumber(),
+      literal(1)), get("x").asNumber(), stop(0, 100), stop(100, 200)).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/DataDrivenStyleActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/DataDrivenStyleActivity.java
@@ -210,7 +210,7 @@ public class DataDrivenStyleActivity extends AppCompatActivity {
       fillColor(
         interpolate(
           exponential(0.5f),
-          get("stroke-width"),
+          get("stroke-width").asNumber(),
           stop(1f, color(Color.RED)),
           stop(5f, color(Color.BLUE)),
           stop(10f, color(Color.GREEN))
@@ -260,7 +260,7 @@ public class DataDrivenStyleActivity extends AppCompatActivity {
     layer.setProperties(
       fillColor(
         step(
-          get("stroke-width"),
+          get("stroke-width").asNumber(),
           color(Color.CYAN),
           stop(1f, color(Color.RED)),
           stop(2f, color(Color.BLUE)),
@@ -282,21 +282,21 @@ public class DataDrivenStyleActivity extends AppCompatActivity {
           exponential(1f),
           zoom(),
           stop(12, step(
-            get("stroke-width"),
+            get("stroke-width").asNumber(),
             color(Color.BLACK),
             stop(1f, color(Color.RED)),
             stop(2f, color(Color.WHITE)),
             stop(3f, color(Color.BLUE))
           )),
           stop(15, step(
-            get("stroke-width"),
+            get("stroke-width").asNumber(),
             color(Color.BLACK),
             stop(1f, color(Color.YELLOW)),
             stop(2f, color(Color.LTGRAY)),
             stop(3f, color(Color.CYAN))
           )),
           stop(18, step(
-            get("stroke-width"),
+            get("stroke-width").asNumber(),
             color(Color.BLACK),
             stop(1f, color(Color.WHITE)),
             stop(2f, color(Color.GRAY)),
@@ -319,21 +319,21 @@ public class DataDrivenStyleActivity extends AppCompatActivity {
           linear(),
           zoom(),
           stop(12, step(
-            get("stroke-width"),
+            get("stroke-width").asNumber(),
             color(Color.BLACK),
             stop(1f, color(Color.RED)),
             stop(2f, color(Color.WHITE)),
             stop(3f, color(Color.BLUE))
           )),
           stop(15, step(
-            get("stroke-width"),
+            get("stroke-width").asNumber(),
             color(Color.BLACK),
             stop(1f, color(Color.YELLOW)),
             stop(2f, color(Color.LTGRAY)),
             stop(3f, color(Color.CYAN))
           )),
           stop(18, step(
-            get("stroke-width"),
+            get("stroke-width").asNumber(),
             color(Color.BLACK),
             stop(1f, color(Color.WHITE)),
             stop(2f, color(Color.GRAY)),

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/SymbolGeneratorActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/SymbolGeneratorActivity.java
@@ -248,7 +248,7 @@ public class SymbolGeneratorActivity extends AppCompatActivity implements OnMapR
         iconImage(get(literal(FEATURE_ID))),
         iconAllowOverlap(false),
         iconSize(
-          division(get(literal(FEATURE_RANK)), literal(2))
+          division(get(literal(FEATURE_RANK)).asNumber(), literal(2))
         ),
         iconAnchor(ICON_ANCHOR_BOTTOM),
         iconOffset(new Float[] {0.0f, -5.0f}),
@@ -257,13 +257,13 @@ public class SymbolGeneratorActivity extends AppCompatActivity implements OnMapR
         textField(
           concat(
             upcase(literal("a ")),
-            get(literal(FEATURE_TYPE)),
+            get(FEATURE_TYPE).asString(),
             downcase(literal(" IN ")),
-            get(literal(FEATURE_REGION))
+            get(FEATURE_REGION).asString()
           )
         ),
         textSize(
-          product(get(literal(FEATURE_RANK)), pi())
+          product(get(FEATURE_RANK).asNumber(), pi())
         ),
         textAnchor(TEXT_ANCHOR_TOP)
       )


### PR DESCRIPTION
Atm when a expression has multiple return types we return a raw Expression, eg. with get():

```java
public static Expression get(@NonNull Expression<String> input)
```

The compiler warns for an unchecked assignment as the wrapping expression requires `Expression<Number>`:

<img width="1124" alt="screen shot 2018-01-24 at 14 27 15" src="https://user-images.githubusercontent.com/2151639/35336058-7ca34c96-0117-11e8-92c8-9b2024a75e21.png">

To fix this we can change the signature of such methods to:

```java
public static Expression<?> get(@NonNull Expression<String> input) 
```

Though this requires us to expose conversion methods as:

```java
public Expression<Number> asNumber(){
    return (Expression<Number>) this;
}
```

### Result

##### Before 

```java
// shows unchecked assignment compiler warning
division(literal(2), get("key"));
```

##### After

```java
// requires you to add asNumber else it won't compile
division(literal(2), get("key").asNumber());
```

@ivovandongen @LukasPaczos: do you feel this is an improvement on the API or do you have any ideas how we can handle this differently?



