### PR TITLE
Correct marker location when using Snapshot#pixelForLatLng

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/snapshot/MapSnapshotterMarkerActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/snapshot/MapSnapshotterMarkerActivity.java
@@ -9,12 +9,14 @@ import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.view.ViewTreeObserver;
 import android.widget.ImageView;
+
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.constants.Style;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.snapshotter.MapSnapshot;
 import com.mapbox.mapboxsdk.snapshotter.MapSnapshotter;
 import com.mapbox.mapboxsdk.testapp.R;
+
 import timber.log.Timber;
 
 /**
@@ -72,9 +74,10 @@ public class MapSnapshotterMarkerActivity extends AppCompatActivity implements M
     // Dom toren
     PointF markerLocation = snapshot.pixelForLatLng(new LatLng(52.090649433011315, 5.121310651302338));
     canvas.drawBitmap(marker,
-      markerLocation.x,
-      /* Subtract height (in dp) so the bottom of the marker aligns correctly */
-      markerLocation.y - (marker.getHeight() / getResources().getDisplayMetrics().density),
+      /* Subtract half of the width so we center the bitmap correctly */
+      markerLocation.x - marker.getWidth() / 2,
+      /* Subtract half of the height so we align the bitmap bottom correctly */
+      markerLocation.y - marker.getHeight() / 2,
       null
     );
     return snapshot.getBitmap();


### PR DESCRIPTION
When validating if https://github.com/mapbox/mapbox-gl-native/issues/11003 is applicable for Android. I noticed that the marker wasn't really centring when I was expecting it to. To test I used the following [location](https://www.openstreetmap.org/query?lat=52.51450&lon=13.35012#map=19/52.51450/13.35012) from Openstreetmap.

##### Before

<img width="262" alt="screen shot 2018-01-24 at 15 53 51" src="https://user-images.githubusercontent.com/2151639/35339311-9417e4aa-0120-11e8-9b0f-16a98636496e.png">

##### After

<img width="262" alt="screen shot 2018-01-24 at 15 52 01" src="https://user-images.githubusercontent.com/2151639/35339329-9b7bc734-0120-11e8-93a5-0fcf894b8dd2.png">


