### PR TITLE
Remove heatmap layer suppression from Darwin code generator

### DIFF
--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -14,9 +14,6 @@ const suffix = 'StyleLayer';
 
 let spec = _.merge(require('../../../scripts/style-spec'), require('./style-spec-overrides-v8.json'));
 
-// Temporarily ignore layer types defined in the style specification but not yet supported in mbgl.
-delete spec.layer.type.values.heatmap;
-
 // Rename properties and keep `original` for use with setters and getters
 _.forOwn(cocoaConventions, function (properties, kind) {
     _.forOwn(properties, function (newName, oldName) {


### PR DESCRIPTION
This Darwin-specific override, which suppresses heatmap layer code from being generated, was added in #10726 but has been superseded by #10937.

/cc @kkaefer