### PR TITLE
add binding integration for RasterDEMSource

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/RasterDemSource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/RasterDemSource.java
@@ -1,0 +1,93 @@
+package com.mapbox.mapboxsdk.style.sources;
+
+import android.support.annotation.Nullable;
+import android.support.annotation.UiThread;
+
+import java.net.URL;
+
+/**
+ * A raster DEM source. Currently only supports Mapbox Terrain RGB (mapbox://mapbox.terrain-rgb)
+ *
+ * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#sources-raster-dem">The style specification</a>
+ */
+@UiThread
+public class RasterDemSource extends Source {
+  public static final int DEFAULT_TILE_SIZE = 512;
+
+  /**
+   * Internal use
+   *
+   * @param nativePtr - pointer to native peer
+   */
+  private RasterDemSource(long nativePtr) {
+    super(nativePtr);
+  }
+
+  /**
+   * Create the raster dem source from an URL
+   *
+   * @param id  the source id
+   * @param url the source url
+   */
+  public RasterDemSource(String id, URL url) {
+    this(id, url.toExternalForm());
+  }
+
+  /**
+   * Create the raster dem source from an URL
+   *
+   * @param id  the source id
+   * @param url the source url
+   */
+  public RasterDemSource(String id, String url) {
+    initialize(id, url, DEFAULT_TILE_SIZE);
+  }
+
+  /**
+   * Create the raster source from an URL with a specific tile size
+   *
+   * @param id       the source id
+   * @param url      the source url
+   * @param tileSize the tile size
+   */
+  public RasterDemSource(String id, String url, int tileSize) {
+    initialize(id, url, tileSize);
+  }
+
+  /**
+   * Create the raster dem source from a {@link TileSet}
+   *
+   * @param id      the source id
+   * @param tileSet the {@link TileSet}
+   */
+  public RasterDemSource(String id, TileSet tileSet) {
+    initialize(id, tileSet.toValueObject(), DEFAULT_TILE_SIZE);
+  }
+
+  /**
+   * Create the raster source from a {@link TileSet} with a specific tile size
+   *
+   * @param id       the source id
+   * @param tileSet  the {@link TileSet}
+   * @param tileSize tje tile size
+   */
+  public RasterDemSource(String id, TileSet tileSet, int tileSize) {
+    initialize(id, tileSet.toValueObject(), tileSize);
+  }
+
+  /**
+   * @return The url or null
+   */
+  @Nullable
+  public String getUrl() {
+    return nativeGetUrl();
+  }
+
+  protected native void initialize(String layerId, Object payload, int tileSize);
+
+  @Override
+  protected native void finalize() throws Throwable;
+
+  protected native String nativeGetUrl();
+
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -778,6 +778,17 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activity.FeatureOverviewActivity"/>
         </activity>
+        <activity
+            android:name=".activity.style.HillshadeLayerActivity"
+            android:description="@string/description_hillshade"
+            android:label="@string/activity_hillshade">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_style"/>
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".activity.FeatureOverviewActivity"/>
+        </activity>
 
         <!-- For Instrumentation tests -->
         <activity

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/HillshadeLayerActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/HillshadeLayerActivity.java
@@ -1,0 +1,84 @@
+package com.mapbox.mapboxsdk.testapp.activity.style;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.style.layers.HillshadeLayer;
+import com.mapbox.mapboxsdk.style.sources.RasterDemSource;
+import com.mapbox.mapboxsdk.testapp.R;
+
+/**
+ * Test activity showcasing using HillshadeLayer.
+ */
+public class HillshadeLayerActivity extends AppCompatActivity {
+
+  private static final String LAYER_ID = "hillshade-layer";
+  private static final String LAYER_BELOW_ID = "waterway-river-canal";
+  private static final String SOURCE_ID = "hillshade-source";
+  private static final String SOURCE_URL = "mapbox://mapbox.terrain-rgb";
+
+  private MapView mapView;
+  private MapboxMap mapboxMap;
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_fill_extrusion_layer);
+
+    mapView = (MapView) findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(map -> {
+      mapboxMap = map;
+
+      RasterDemSource rasterDemSource = new RasterDemSource(SOURCE_ID, SOURCE_URL);
+      mapboxMap.addSource(rasterDemSource);
+
+      HillshadeLayer hillshadeLayer = new HillshadeLayer(LAYER_ID, SOURCE_ID);
+      mapboxMap.addLayerBelow(hillshadeLayer, LAYER_BELOW_ID);
+    });
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  public void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_hillshade_layer.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_hillshade_layer.xml
@@ -9,11 +9,9 @@
         android:id="@id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:mapbox_cameraTargetLat="46.343350"
-        app:mapbox_cameraTargetLng="7.497989"
-        app:mapbox_cameraZoom="9"
-        app:mapbox_cameraBearing="140"
-        app:mapbox_cameraTilt="60"
+        app:mapbox_cameraTargetLat="52.090710"
+        app:mapbox_cameraTargetLng="5.121125"
+        app:mapbox_cameraZoom="10"
         app:mapbox_styleUrl="@string/mapbox_style_mapbox_streets"/>
 
 </RelativeLayout>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
@@ -69,4 +69,5 @@
     <string name="description_textureview_animate">Animate a map rendered on a TextureView</string>
     <string name="description_grid_source">Example Custom Geometry Source</string>
     <string name="description_local_glyph">Suzhou using Droid Sans for Chinese glyphs</string>
+    <string name="description_hillshade">Example raster-dem source and hillshade layer</string>
 </resources>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
@@ -69,4 +69,5 @@
     <string name="activity_textureview_animate">TextureView animation</string>
     <string name="activity_grid_source">Grid Source</string>
     <string name="activity_local_glyph">Local CJK glyph generation</string>
+    <string name="activity_hillshade">Hillshade</string>
 </resources>

--- a/platform/android/config.cmake
+++ b/platform/android/config.cmake
@@ -186,6 +186,8 @@ add_library(mbgl-android STATIC
     platform/android/src/style/sources/vector_source.hpp
     platform/android/src/style/sources/image_source.hpp
     platform/android/src/style/sources/image_source.cpp
+    platform/android/src/style/sources/raster_dem_source.cpp
+    platform/android/src/style/sources/raster_dem_source.hpp
     platform/android/src/style/functions/stop.cpp
     platform/android/src/style/functions/stop.hpp
     platform/android/src/style/functions/categorical_stops.cpp

--- a/platform/android/src/style/sources/raster_dem_source.cpp
+++ b/platform/android/src/style/sources/raster_dem_source.cpp
@@ -1,0 +1,63 @@
+#include "raster_dem_source.hpp"
+
+#include "../android_conversion.hpp"
+#include "../value.hpp"
+#include "../conversion/url_or_tileset.hpp"
+#include "source.hpp"
+
+#include <mbgl/util/variant.hpp>
+
+#include <string>
+
+namespace mbgl {
+namespace android {
+
+    RasterDEMSource::RasterDEMSource(jni::JNIEnv& env, jni::String sourceId, jni::Object<> urlOrTileSet, jni::jint tileSize)
+        : Source(
+            env,
+            std::make_unique<mbgl::style::RasterDEMSource>(
+                jni::Make<std::string>(env, sourceId),
+                convertURLOrTileset(Value(env, urlOrTileSet)),
+                tileSize
+            )
+        ) {
+    }
+
+    RasterDEMSource::RasterDEMSource(jni::JNIEnv& env,
+                               mbgl::style::Source& coreSource,
+                               AndroidRendererFrontend& frontend)
+         : Source(env, coreSource, createJavaPeer(env), frontend) {
+    }
+
+    RasterDEMSource::~RasterDEMSource() = default;
+
+    jni::String RasterDEMSource::getURL(jni::JNIEnv& env) {
+        optional<std::string> url = source.as<mbgl::style::RasterDEMSource>()->RasterDEMSource::getURL();
+        return url ? jni::Make<jni::String>(env, *url) : jni::String();
+    }
+
+    jni::Class<RasterDEMSource> RasterDEMSource::javaClass;
+
+    jni::Object<Source> RasterDEMSource::createJavaPeer(jni::JNIEnv& env) {
+        static auto constructor = RasterDEMSource::javaClass.template GetConstructor<jni::jlong>(env);
+        return jni::Object<Source>(RasterDEMSource::javaClass.New(env, constructor, reinterpret_cast<jni::jlong>(this)).Get());
+    }
+
+    void RasterDEMSource::registerNative(jni::JNIEnv& env) {
+        // Lookup the class
+        RasterDEMSource::javaClass = *jni::Class<RasterDEMSource>::Find(env).NewGlobalRef(env).release();
+
+        #define METHOD(MethodPtr, name) jni::MakeNativePeerMethod<decltype(MethodPtr), (MethodPtr)>(name)
+
+        // Register the peer
+        jni::RegisterNativePeer<RasterDEMSource>(
+            env, RasterDEMSource::javaClass, "nativePtr",
+            std::make_unique<RasterDEMSource, JNIEnv&, jni::String, jni::Object<>, jni::jint>,
+            "initialize",
+            "finalize",
+            METHOD(&RasterDEMSource::getURL, "nativeGetUrl")
+        );
+    }
+
+} // namespace android
+} // namespace mbgl

--- a/platform/android/src/style/sources/raster_dem_source.hpp
+++ b/platform/android/src/style/sources/raster_dem_source.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "source.hpp"
+#include <mbgl/style/sources/raster_dem_source.hpp>
+#include <jni/jni.hpp>
+
+namespace mbgl {
+namespace android {
+
+class RasterDEMSource : public Source {
+public:
+
+    static constexpr auto Name() { return "com/mapbox/mapboxsdk/style/sources/RasterDemSource"; };
+
+    static jni::Class<RasterDEMSource> javaClass;
+
+    static void registerNative(jni::JNIEnv&);
+
+    RasterDEMSource(jni::JNIEnv&, jni::String, jni::Object<>, jni::jint);
+
+    RasterDEMSource(jni::JNIEnv&, mbgl::style::Source&, AndroidRendererFrontend&);
+
+    ~RasterDEMSource();
+
+    jni::String getURL(jni::JNIEnv&);
+
+private:
+    jni::Object<Source> createJavaPeer(jni::JNIEnv&);
+
+}; // class RasterDEMSource
+
+} // namespace android
+} // namespace mbgl

--- a/platform/android/src/style/sources/source.cpp
+++ b/platform/android/src/style/sources/source.cpp
@@ -28,6 +28,7 @@
 #include "unknown_source.hpp"
 #include "vector_source.hpp"
 #include "custom_geometry_source.hpp"
+#include "raster_dem_source.hpp"
 
 namespace mbgl {
 namespace android {
@@ -155,6 +156,7 @@ namespace android {
         UnknownSource::registerNative(env);
         VectorSource::registerNative(env);
         CustomGeometrySource::registerNative(env);
+        RasterDEMSource::registerNative(env);
     }
 
 } // namespace android


### PR DESCRIPTION
closes #11025, this PR adds binding integration for RasterDEMSource + example:


![image](https://user-images.githubusercontent.com/2151639/35351044-06a12f26-0140-11e8-8352-89f1d1617272.png)


Todo:
  - [x] add javadoc
  - [x] move camera position to a location with hills in example
  - [x] add HillshadeLayer below label layers in example



