### PR TITLE
[node] add setLight support

### DIFF
--- a/platform/node/src/node_map.hpp
+++ b/platform/node/src/node_map.hpp
@@ -57,6 +57,7 @@ public:
     static void SetZoom(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void SetBearing(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void SetPitch(const Nan::FunctionCallbackInfo<v8::Value>&);
+    static void SetLight(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void SetAxonometric(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void SetXSkew(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void SetYSkew(const Nan::FunctionCallbackInfo<v8::Value>&);

--- a/platform/node/test/js/map.test.js
+++ b/platform/node/test/js/map.test.js
@@ -121,6 +121,7 @@ test('Map', function(t) {
             'setZoom',
             'setBearing',
             'setPitch',
+            'setLight',
             'setAxonometric',
             'setXSkew',
             'setYSkew',

--- a/platform/node/test/suite_implementation.js
+++ b/platform/node/test/suite_implementation.js
@@ -53,6 +53,7 @@ module.exports = function (style, options, callback) {
     options.zoom = style.zoom || 0;
     options.bearing = style.bearing || 0;
     options.pitch = style.pitch || 0;
+    options.light = style.light || {};
 
     map.load(style, { defaultStyleCamera: true });
 
@@ -129,6 +130,8 @@ module.exports = function (style, options, callback) {
                 options.bearing = operation[1];
             } else if (operation[0] === 'setPitch') {
                 options.pitch = operation[1];
+            } else if (operation[0] === 'setLight') {
+                options.light = operation[1];
             }
 
             map[operation[0]].apply(map, operation.slice(1));


### PR DESCRIPTION
I worked on fixing a failing regression test in gl-js master (`regressions/mapbox-gl-js#5982`), but eventually noticed that we need https://github.com/mapbox/mapbox-gl-native/issues/10619 in order to test transitions. Meanwhile, this is the `setLight` code that exposes light manipulation in Node.js and to the test harness.