### PR TITLE
[ios, macos] Fix MGLMapSnapshotter pointForCoordinate returns a scaled point.

### DIFF
--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -76,7 +76,7 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
 - (CGPoint)pointForCoordinate:(CLLocationCoordinate2D)coordinate
 {
     mbgl::ScreenCoordinate sc = _pointForFn(MGLLatLngFromLocationCoordinate2D(coordinate));
-    return CGPointMake(sc.x * self.scale, sc.y * self.scale);
+    return CGPointMake(sc.x, sc.y);
 }
 @end
 


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/11003.
