### PR TITLE
[core] update mapbox-gl-js submodule pin

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/HillshadeLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/HillshadeLayer.java
@@ -83,24 +83,6 @@ public class HillshadeLayer extends Layer {
   }
 
   /**
-   * Get the HillshadeIlluminationDirection property transition options
-   *
-   * @return transition options for Float
-   */
-  public TransitionOptions getHillshadeIlluminationDirectionTransition() {
-    return nativeGetHillshadeIlluminationDirectionTransition();
-  }
-
-  /**
-   * Set the HillshadeIlluminationDirection property transition options
-   *
-   * @param options transition options for Float
-   */
-  public void setHillshadeIlluminationDirectionTransition(TransitionOptions options) {
-    nativeSetHillshadeIlluminationDirectionTransition(options.getDuration(), options.getDelay());
-  }
-
-  /**
    * Get the HillshadeIlluminationAnchor property
    *
    * @return property wrapper value around String
@@ -271,10 +253,6 @@ public class HillshadeLayer extends Layer {
   }
 
   private native Object nativeGetHillshadeIlluminationDirection();
-
-  private native TransitionOptions nativeGetHillshadeIlluminationDirectionTransition();
-
-  private native void nativeSetHillshadeIlluminationDirectionTransition(long duration, long delay);
 
   private native Object nativeGetHillshadeIlluminationAnchor();
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HillshadeLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HillshadeLayerTest.java
@@ -87,24 +87,6 @@ public class HillshadeLayerTest extends BaseActivityTest {
   }
 
   @Test
-  public void testHillshadeIlluminationDirectionTransition() {
-    validateTestSetup();
-    setupLayer();
-    Timber.i("hillshade-illumination-directionTransitionOptions");
-    invoke(mapboxMap, new MapboxMapAction.OnInvokeActionListener() {
-      @Override
-      public void onInvokeAction(UiController uiController, MapboxMap mapboxMap) {
-        assertNotNull(layer);
-
-        // Set and Get
-        TransitionOptions options = new TransitionOptions(300, 100);
-        layer.setHillshadeIlluminationDirectionTransition(options);
-        assertEquals(layer.getHillshadeIlluminationDirectionTransition(), options);
-      }
-    });
-  }
-
-  @Test
   public void testHillshadeIlluminationDirectionAsConstant() {
     validateTestSetup();
     setupLayer();

--- a/platform/android/src/style/layers/hillshade_layer.cpp
+++ b/platform/android/src/style/layers/hillshade_layer.cpp
@@ -41,19 +41,6 @@ namespace android {
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
-    jni::Object<TransitionOptions> HillshadeLayer::getHillshadeIlluminationDirectionTransition(jni::JNIEnv& env) {
-        using namespace mbgl::android::conversion;
-        mbgl::style::TransitionOptions options = layer.as<mbgl::style::HillshadeLayer>()->HillshadeLayer::getHillshadeIlluminationDirectionTransition();
-        return *convert<jni::Object<TransitionOptions>>(env, options);
-    }
-
-    void HillshadeLayer::setHillshadeIlluminationDirectionTransition(jni::JNIEnv&, jlong duration, jlong delay) {
-        mbgl::style::TransitionOptions options;
-        options.duration.emplace(mbgl::Milliseconds(duration));
-        options.delay.emplace(mbgl::Milliseconds(delay));
-        layer.as<mbgl::style::HillshadeLayer>()->HillshadeLayer::setHillshadeIlluminationDirectionTransition(options);
-    }
-
     jni::Object<jni::ObjectTag> HillshadeLayer::getHillshadeIlluminationAnchor(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::HillshadeLayer>()->HillshadeLayer::getHillshadeIlluminationAnchor());
@@ -156,8 +143,6 @@ namespace android {
             std::make_unique<HillshadeLayer, JNIEnv&, jni::String, jni::String>,
             "initialize",
             "finalize",
-            METHOD(&HillshadeLayer::getHillshadeIlluminationDirectionTransition, "nativeGetHillshadeIlluminationDirectionTransition"),
-            METHOD(&HillshadeLayer::setHillshadeIlluminationDirectionTransition, "nativeSetHillshadeIlluminationDirectionTransition"),
             METHOD(&HillshadeLayer::getHillshadeIlluminationDirection, "nativeGetHillshadeIlluminationDirection"),
             METHOD(&HillshadeLayer::getHillshadeIlluminationAnchor, "nativeGetHillshadeIlluminationAnchor"),
             METHOD(&HillshadeLayer::getHillshadeExaggerationTransition, "nativeGetHillshadeExaggerationTransition"),

--- a/platform/android/src/style/layers/hillshade_layer.hpp
+++ b/platform/android/src/style/layers/hillshade_layer.hpp
@@ -30,8 +30,6 @@ public:
     // Properties
 
     jni::Object<jni::ObjectTag> getHillshadeIlluminationDirection(jni::JNIEnv&);
-    void setHillshadeIlluminationDirectionTransition(jni::JNIEnv&, jlong duration, jlong delay);
-    jni::Object<TransitionOptions> getHillshadeIlluminationDirectionTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getHillshadeIlluminationAnchor(jni::JNIEnv&);
 

--- a/platform/darwin/src/MGLHillshadeStyleLayer.h
+++ b/platform/darwin/src/MGLHillshadeStyleLayer.h
@@ -186,13 +186,6 @@ MGL_EXPORT
 @property (nonatomic, null_resettable) NSExpression *hillshadeIlluminationDirection;
 
 /**
- The transition affecting any changes to this layer’s `hillshadeIlluminationDirection` property.
-
- This property corresponds to the `hillshade-illumination-direction-transition` property in the style JSON file format.
-*/
-@property (nonatomic) MGLTransition hillshadeIlluminationDirectionTransition;
-
-/**
  The shading color of areas that face away from the light source.
  
  The default value of this property is an expression that evaluates to

--- a/platform/darwin/src/MGLHillshadeStyleLayer.mm
+++ b/platform/darwin/src/MGLHillshadeStyleLayer.mm
@@ -216,24 +216,6 @@ namespace mbgl {
     return MGLStyleValueTransformer<float, NSNumber *>().toExpression(propertyValue);
 }
 
-- (void)setHillshadeIlluminationDirectionTransition:(MGLTransition )transition {
-    MGLAssertStyleLayerIsValid();
-
-    mbgl::style::TransitionOptions options { { MGLDurationFromTimeInterval(transition.duration) }, { MGLDurationFromTimeInterval(transition.delay) } };
-    self.rawLayer->setHillshadeIlluminationDirectionTransition(options);
-}
-
-- (MGLTransition)hillshadeIlluminationDirectionTransition {
-    MGLAssertStyleLayerIsValid();
-
-    mbgl::style::TransitionOptions transitionOptions = self.rawLayer->getHillshadeIlluminationDirectionTransition();
-    MGLTransition transition;
-    transition.duration = MGLTimeIntervalFromDuration(transitionOptions.duration.value_or(mbgl::Duration::zero()));
-    transition.delay = MGLTimeIntervalFromDuration(transitionOptions.delay.value_or(mbgl::Duration::zero()));
-
-    return transition;
-}
-
 - (void)setHillshadeShadowColor:(NSExpression *)hillshadeShadowColor {
     MGLAssertStyleLayerIsValid();
 

--- a/platform/darwin/test/MGLHillshadeStyleLayerTests.mm
+++ b/platform/darwin/test/MGLHillshadeStyleLayerTests.mm
@@ -293,15 +293,6 @@
         functionExpression = [NSExpression expressionWithFormat:@"FUNCTION(bogus, 'mgl_stepWithMinimum:stops:', %@, %@)", constantExpression, @{@18: constantExpression}];
         functionExpression = [NSExpression expressionWithFormat:@"FUNCTION($zoomLevel, 'mgl_interpolateWithCurveType:parameters:stops:', 'linear', nil, %@)", @{@10: functionExpression}];
         XCTAssertThrowsSpecificNamed(layer.hillshadeIlluminationDirection = functionExpression, NSException, NSInvalidArgumentException, @"MGLHillshadeLayer should raise an exception if a camera-data expression is applied to a property that does not support key paths to feature attributes.");
-        // Transition property test
-        layer.hillshadeIlluminationDirectionTransition = transitionTest;
-        auto toptions = rawLayer->getHillshadeIlluminationDirectionTransition();
-        XCTAssert(toptions.delay && MGLTimeIntervalFromDuration(*toptions.delay) == transitionTest.delay);
-        XCTAssert(toptions.duration && MGLTimeIntervalFromDuration(*toptions.duration) == transitionTest.duration);
-
-        MGLTransition hillshadeIlluminationDirectionTransition = layer.hillshadeIlluminationDirectionTransition;
-        XCTAssertEqual(hillshadeIlluminationDirectionTransition.delay, transitionTest.delay);
-        XCTAssertEqual(hillshadeIlluminationDirectionTransition.duration, transitionTest.duration);
     }
 
     // hillshade-shadow-color

--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -50,6 +50,7 @@
   "render-tests/regressions/mapbox-gl-js#5370": "skip - https://github.com/mapbox/mapbox-gl-native/pull/9439",
   "render-tests/regressions/mapbox-gl-js#5599": "https://github.com/mapbox/mapbox-gl-native/issues/10399",
   "render-tests/regressions/mapbox-gl-js#5740": "https://github.com/mapbox/mapbox-gl-native/issues/10619",
+  "render-tests/regressions/mapbox-gl-js#5982": "https://github.com/mapbox/mapbox-gl-native/issues/10619",
   "render-tests/regressions/mapbox-gl-native#7357": "https://github.com/mapbox/mapbox-gl-native/issues/7357",
   "render-tests/runtime-styling/image-add-sdf": "https://github.com/mapbox/mapbox-gl-native/issues/9847",
   "render-tests/runtime-styling/paint-property-fill-flat-to-extrude": "https://github.com/mapbox/mapbox-gl-native/issues/6745",

--- a/scripts/generate-shaders.js
+++ b/scripts/generate-shaders.js
@@ -7,8 +7,6 @@ const outputPath = 'src/mbgl/shaders';
 
 var shaders = require('../mapbox-gl-js/src/shaders');
 
-delete shaders.hillshade;
-delete shaders.hillshadePrepare;
 delete shaders.heatmap;
 delete shaders.heatmapTexture;
 


### PR DESCRIPTION
* disables transition render test (transitions are not supported with Still image rendering in Node.js) (https://github.com/mapbox/mapbox-gl-native/issues/10619)
* removes support for hillshade-illumniation-direction-transition (https://github.com/mapbox/mapbox-gl-js/issues/5934)

