### PR TITLE
Align implementations of LocalFileSource and AssetFileSource

### DIFF
--- a/platform/default/default_file_source.cpp
+++ b/platform/default/default_file_source.cpp
@@ -14,16 +14,6 @@
 
 #include <cassert>
 
-namespace {
-
-const std::string assetProtocol = "asset://";
-
-bool isAssetURL(const std::string& url) {
-    return std::equal(assetProtocol.begin(), assetProtocol.end(), url.begin());
-}
-
-} // namespace
-
 namespace mbgl {
 
 class DefaultFileSource::Impl {
@@ -118,7 +108,7 @@ public:
             ref.invoke(&FileSourceRequest::setResponse, res);
         };
 
-        if (isAssetURL(resource.url)) {
+        if (AssetFileSource::acceptsURL(resource.url)) {
             //Asset request
             tasks[req] = assetFileSource->request(resource, callback);
         } else if (LocalFileSource::acceptsURL(resource.url)) {

--- a/src/mbgl/storage/asset_file_source.hpp
+++ b/src/mbgl/storage/asset_file_source.hpp
@@ -15,6 +15,8 @@ public:
 
     std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
 
+    static bool acceptsURL(const std::string& url);
+
 private:
     class Impl;
 


### PR DESCRIPTION
This is more of a cleanup commit that unifies the implementations and hardens the functionality (by returning an error when attempting to make a request with a URL that doesn't start with the correct scheme rather than failing later down the road).