### PR TITLE
Options to wrap/clip CustomGeometrySource data

### DIFF
--- a/include/mbgl/style/conversion/custom_geometry_source_options.hpp
+++ b/include/mbgl/style/conversion/custom_geometry_source_options.hpp
@@ -54,6 +54,26 @@ struct Converter<CustomGeometrySource::Options> {
             }
         }
 
+        const auto wrapValue = objectMember(value, "wrap");
+        if (wrapValue) {
+            if (toBool(*wrapValue)) {
+                options.tileOptions.wrap = static_cast<bool>(*toBool(*wrapValue));
+            } else {
+                error = { "CustomGeometrySource TileOptions wrap value must be a boolean" };
+                return {};
+            }
+        }
+
+        const auto clipValue = objectMember(value, "clip");
+        if (clipValue) {
+            if (toBool(*clipValue)) {
+                options.tileOptions.clip = static_cast<double>(*toBool(*clipValue));
+            } else {
+                error = { "CustomGeometrySource TileOptiosn clip value must be a boolean" };
+                return {};
+            }
+        }
+
         return { options };
     }
 

--- a/include/mbgl/style/sources/custom_geometry_source.hpp
+++ b/include/mbgl/style/sources/custom_geometry_source.hpp
@@ -25,6 +25,8 @@ public:
         double tolerance = 0.375;
         uint16_t tileSize = util::tileSize;
         uint16_t buffer = 128;
+        bool clip = false;
+        bool wrap = false;
     };
 
     struct Options {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/CustomGeometrySource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/CustomGeometrySource.java
@@ -37,18 +37,18 @@ public class CustomGeometrySource extends Source {
    * @param provider The tile provider that returns geometry data for this source.
    */
   public CustomGeometrySource(String id, GeometryTileProvider provider) {
-    this(id, provider, new GeoJsonOptions());
+    this(id, provider, new CustomGeometrySourceOptions());
   }
 
   /**
-   * Create a CustomGeometrySource with non-default GeoJsonOptions.
+   * Create a CustomGeometrySource with non-default CustomGeometrySourceOptions.
    * <p>Supported options are minZoom, maxZoom, buffer, and tolerance.</p>
    *
    * @param id      The source id.
    * @param provider The tile provider that returns geometry data for this source.
-   * @param options GeoJsonOptions.
+   * @param options CustomGeometrySourceOptions.
    */
-  public CustomGeometrySource(String id, GeometryTileProvider provider, GeoJsonOptions options) {
+  public CustomGeometrySource(String id, GeometryTileProvider provider, CustomGeometrySourceOptions options) {
     this.provider = provider;
     executor = Executors.newFixedThreadPool(4);
     initialize(id, options);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/CustomGeometrySourceOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/CustomGeometrySourceOptions.java
@@ -1,0 +1,31 @@
+package com.mapbox.mapboxsdk.style.sources;
+
+/**
+ * Builder class for composing CustomGeometrySource objects.
+ */
+public class CustomGeometrySourceOptions extends GeoJsonOptions {
+
+  /**
+   * If the data includes wrapped coordinates, setting this to true unwraps the coordinates.
+   *
+   * @param wrap defaults to false
+   * @return the current instance for chaining
+   */
+  public CustomGeometrySourceOptions withWrap(boolean wrap) {
+    this.put("wrap", wrap);
+    return this;
+  }
+
+  /**
+   * If the data includes geometry outside the tile boundaries, setting this to true clips the geometry
+   * to the tile boundaries.
+   *
+   * @param clip defaults to false
+   * @return the current instance for chaining
+   */
+  public CustomGeometrySourceOptions withClip(boolean clip) {
+    this.put("clip", clip);
+    return this;
+  }
+
+}

--- a/platform/android/src/style/sources/custom_geometry_source.cpp
+++ b/platform/android/src/style/sources/custom_geometry_source.cpp
@@ -18,7 +18,7 @@ namespace mbgl {
 namespace android {
 
     // This conversion is expected not to fail because it's used only in contexts where
-    // the value was originally a GeoJsonOptions object on the Java side. If it fails
+    // the value was originally a CustomGeometrySourceOptions object on the Java side. If it fails
     // to convert, it's a bug in our serialization or Java-side static typing.
     static style::CustomGeometrySource::Options convertCustomGeometrySourceOptions(jni::JNIEnv& env,
                                                                                    jni::Object<> options,

--- a/platform/darwin/src/MGLAbstractShapeSource.h
+++ b/platform/darwin/src/MGLAbstractShapeSource.h
@@ -82,6 +82,24 @@ extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionBuffer;
 extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance;
 
 /**
+ An `NSNumber` object containing a boolean; specifies whether the geometry for a
+ `MGLComputedShapeSource` needs to be wrapped to accomodate coordinates with longitudes outside the [-180,180] extents. The default is `false.`
+ 
+ Setting this option to `true` affects performance.
+  */
+extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionWrapCoordinates;
+
+/**
+ An `NSNumber` object containing a boolean; specifies whether the geometry for a
+ `MGLComputedShapeSource` needs to be clipped at the tile boundaries.
+ The default is `false.`
+
+ Setting this options to `true` affects performance. Use this option to clip
+ polygons and lines at tile boundaries without artefacts.
+ */
+extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionClipCoordinates;
+
+/**
  `MGLAbstractShapeSource` is an abstract base class for map content sources that
  supply vector shapes to be shown on the map. A shape source is added to an
  `MGLStyle` object along with an `MGLVectorStyleLayer` object. The vector style

--- a/platform/darwin/src/MGLAbstractShapeSource.mm
+++ b/platform/darwin/src/MGLAbstractShapeSource.mm
@@ -8,6 +8,8 @@ const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevel = @"MGLShapeSour
 const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevelForClustering = @"MGLShapeSourceOptionMaximumZoomLevelForClustering";
 const MGLShapeSourceOption MGLShapeSourceOptionMinimumZoomLevel = @"MGLShapeSourceOptionMinimumZoomLevel";
 const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance = @"MGLShapeSourceOptionSimplificationTolerance";
+const MGLShapeSourceOption MGLShapeSourceOptionWrapCoordinates = @"MGLShapeSourceOptionWrapCoordinates";
+const MGLShapeSourceOption MGLShapeSourceOptionClipCoordinates = @"MGLShapeSourceOptionClipCoordinates";
 
 @interface MGLAbstractShapeSource ()
 
@@ -113,5 +115,22 @@ mbgl::style::CustomGeometrySource::Options MBGLCustomGeometrySourceOptionsFromDi
         }
         sourceOptions.tileOptions.tolerance = value.doubleValue;
     }
+
+    if (NSNumber *value = options[MGLShapeSourceOptionWrapCoordinates]) {
+        if (![value isKindOfClass:[NSNumber class]]) {
+            [NSException raise:NSInvalidArgumentException
+                        format:@"MGLShapeSourceOptionWrapCoordinates must be an NSNumber."];
+        }
+        sourceOptions.tileOptions.wrap = value.boolValue;
+    }
+
+    if (NSNumber *value = options[MGLShapeSourceOptionClipCoordinates]) {
+        if (![value isKindOfClass:[NSNumber class]]) {
+            [NSException raise:NSInvalidArgumentException
+                        format:@"MGLShapeSourceOptionClipCoordinates must be an NSNumber."];
+        }
+        sourceOptions.tileOptions.clip = value.boolValue;
+    }
+
     return sourceOptions;
 }

--- a/platform/macos/app/MapDocument.m
+++ b/platform/macos/app/MapDocument.m
@@ -727,7 +727,11 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
     }
 
     MGLComputedShapeSource *source = [[MGLComputedShapeSource alloc] initWithIdentifier:@"graticule"
-                                                                                options:@{MGLShapeSourceOptionMaximumZoomLevel:@14}];
+     options:@{MGLShapeSourceOptionMaximumZoomLevel:@14
+            , MGLShapeSourceOptionWrapCoordinates: @YES
+            , MGLShapeSourceOptionClipCoordinates: @YES
+            }];
+
     source.dataSource = self;
     [self.mapView.style addSource:source];
     MGLLineStyleLayer *lineLayer = [[MGLLineStyleLayer alloc] initWithIdentifier:@"graticule.lines"

--- a/src/mbgl/tile/custom_geometry_tile.cpp
+++ b/src/mbgl/tile/custom_geometry_tile.cpp
@@ -39,7 +39,7 @@ void CustomGeometryTile::setTileData(const GeoJSON& geoJSON) {
         vtOptions.extent = util::EXTENT;
         vtOptions.buffer = ::round(scale * options.buffer);
         vtOptions.tolerance = scale * options.tolerance;
-        featureData = mapbox::geojsonvt::geoJSONToTile(geoJSON, id.canonical.z, id.canonical.x, id.canonical.y, vtOptions).features;
+        featureData = mapbox::geojsonvt::geoJSONToTile(geoJSON, id.canonical.z, id.canonical.x, id.canonical.y, vtOptions, options.wrap, options.clip).features;
     } else {
         setNecessity(TileNecessity::Optional);
     }


### PR DESCRIPTION
Closes #10965.

Allow `CustomGeometrySource` data providers to pass in geometry with wrapped coordinates and/or geometry that needs to be clipped to tile boundaries. These options disabled by default and should only be enabled when the source data requires it.