### PR TITLE
Reset tileset-based render sources when any tileset properties changed.

### DIFF
--- a/src/mbgl/renderer/sources/render_raster_dem_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.cpp
@@ -32,14 +32,14 @@ void RenderRasterDEMSource::update(Immutable<style::Source::Impl> baseImpl_,
 
     enabled = needsRendering;
 
-    optional<Tileset> tileset = impl().getTileset();
+    optional<Tileset> _tileset = impl().getTileset();
 
-    if (!tileset) {
+    if (!_tileset) {
         return;
     }
 
-    if (tileURLTemplates != tileset->tiles) {
-        tileURLTemplates = tileset->tiles;
+    if (tileset != _tileset) {
+        tileset = _tileset;
 
         // TODO: this removes existing buckets, and will cause flickering.
         // Should instead refresh tile data in place.

--- a/src/mbgl/renderer/sources/render_raster_dem_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.cpp
@@ -34,10 +34,6 @@ void RenderRasterDEMSource::update(Immutable<style::Source::Impl> baseImpl_,
 
     optional<Tileset> _tileset = impl().getTileset();
 
-    if (!_tileset) {
-        return;
-    }
-
     if (tileset != _tileset) {
         tileset = _tileset;
 
@@ -46,6 +42,11 @@ void RenderRasterDEMSource::update(Immutable<style::Source::Impl> baseImpl_,
         tilePyramid.tiles.clear();
         tilePyramid.renderTiles.clear();
         tilePyramid.cache.clear();
+    }
+    // Allow clearing the tile pyramid first, before the early return in case
+    //  the new tileset is not yet available or has an error in loading
+    if (!_tileset) {
+        return;
     }
 
     tilePyramid.update(layers,

--- a/src/mbgl/renderer/sources/render_raster_dem_source.hpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.hpp
@@ -40,7 +40,7 @@ private:
     const style::RasterSource::Impl& impl() const;
 
     TilePyramid tilePyramid;
-    optional<std::vector<std::string>> tileURLTemplates;
+    optional<Tileset> tileset;
 
 protected:
     void onTileChanged(Tile&) final;

--- a/src/mbgl/renderer/sources/render_raster_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_source.cpp
@@ -29,14 +29,14 @@ void RenderRasterSource::update(Immutable<style::Source::Impl> baseImpl_,
 
     enabled = needsRendering;
 
-    optional<Tileset> tileset = impl().getTileset();
+    optional<Tileset> _tileset = impl().getTileset();
 
-    if (!tileset) {
+    if (!_tileset) {
         return;
     }
 
-    if (tileURLTemplates != tileset->tiles) {
-        tileURLTemplates = tileset->tiles;
+    if (tileset != _tileset) {
+        tileset = _tileset;
 
         // TODO: this removes existing buckets, and will cause flickering.
         // Should instead refresh tile data in place.

--- a/src/mbgl/renderer/sources/render_raster_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_source.cpp
@@ -31,10 +31,6 @@ void RenderRasterSource::update(Immutable<style::Source::Impl> baseImpl_,
 
     optional<Tileset> _tileset = impl().getTileset();
 
-    if (!_tileset) {
-        return;
-    }
-
     if (tileset != _tileset) {
         tileset = _tileset;
 
@@ -43,6 +39,11 @@ void RenderRasterSource::update(Immutable<style::Source::Impl> baseImpl_,
         tilePyramid.tiles.clear();
         tilePyramid.renderTiles.clear();
         tilePyramid.cache.clear();
+    }
+    // Allow clearing the tile pyramid first, before the early return in case
+    //  the new tileset is not yet available or has an error in loading
+    if (!_tileset) {
+        return;
     }
 
     tilePyramid.update(layers,

--- a/src/mbgl/renderer/sources/render_raster_source.hpp
+++ b/src/mbgl/renderer/sources/render_raster_source.hpp
@@ -40,7 +40,7 @@ private:
     const style::RasterSource::Impl& impl() const;
 
     TilePyramid tilePyramid;
-    optional<std::vector<std::string>> tileURLTemplates;
+    optional<Tileset> tileset;
 };
 
 template <>

--- a/src/mbgl/renderer/sources/render_vector_source.cpp
+++ b/src/mbgl/renderer/sources/render_vector_source.cpp
@@ -34,10 +34,6 @@ void RenderVectorSource::update(Immutable<style::Source::Impl> baseImpl_,
 
     optional<Tileset> _tileset = impl().getTileset();
 
-    if (!_tileset) {
-        return;
-    }
-
     if (tileset != _tileset) {
         tileset = _tileset;
 
@@ -46,6 +42,11 @@ void RenderVectorSource::update(Immutable<style::Source::Impl> baseImpl_,
         tilePyramid.tiles.clear();
         tilePyramid.renderTiles.clear();
         tilePyramid.cache.clear();
+    }
+    // Allow clearing the tile pyramid first, before the early return in case
+    //  the new tileset is not yet available or has an error in loading
+    if (!_tileset) {
+        return;
     }
 
     tilePyramid.update(layers,

--- a/src/mbgl/renderer/sources/render_vector_source.cpp
+++ b/src/mbgl/renderer/sources/render_vector_source.cpp
@@ -32,14 +32,14 @@ void RenderVectorSource::update(Immutable<style::Source::Impl> baseImpl_,
 
     enabled = needsRendering;
 
-    optional<Tileset> tileset = impl().getTileset();
+    optional<Tileset> _tileset = impl().getTileset();
 
-    if (!tileset) {
+    if (!_tileset) {
         return;
     }
 
-    if (tileURLTemplates != tileset->tiles) {
-        tileURLTemplates = tileset->tiles;
+    if (tileset != _tileset) {
+        tileset = _tileset;
 
         // TODO: this removes existing buckets, and will cause flickering.
         // Should instead refresh tile data in place.

--- a/src/mbgl/renderer/sources/render_vector_source.hpp
+++ b/src/mbgl/renderer/sources/render_vector_source.hpp
@@ -40,7 +40,7 @@ private:
     const style::VectorSource::Impl& impl() const;
 
     TilePyramid tilePyramid;
-    optional<std::vector<std::string>> tileURLTemplates;
+    optional<Tileset> tileset;
 };
 
 template <>


### PR DESCRIPTION
Closes #10880.

Render sources were resetting the tile pyramid only if the tileset URL templates changed. When recycling maps, a change to `Tileset::bounds` is ignored and previously cached tiles outside the bounds are reused.

Tested with multiple (previously failing) seeds: `v0ZfOIRpA4`, `wTv2gAE0hK` and `tRIdKgDdQD`