### PR TITLE
Blacklist adreno 2xx for VAO support

### DIFF
--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -258,9 +258,10 @@ UniqueTexture Context::createTexture() {
 
 bool Context::supportsVertexArrays() const {
     static bool blacklisted = []() {
-        // Blacklist Adreno 3xx as it crashes on glBuffer(Sub)Data
+        // Blacklist Adreno 2xx, 3xx as it crashes on glBuffer(Sub)Data
         const std::string renderer = reinterpret_cast<const char*>(glGetString(GL_RENDERER));
-        return renderer.find("Adreno (TM) 3") != std::string::npos;
+        return renderer.find("Adreno (TM) 2") != std::string::npos
+         || renderer.find("Adreno (TM) 3") != std::string::npos;
     }();
 
     return !blacklisted &&


### PR DESCRIPTION
Capturing from @kkaefer in https://github.com/mapbox/mapbox-navigation-android/issues/534#issuecomment-360329978 that we should try blacklisting Adreno 2xx GPU for VAO support to potentially resolve the crash mentioned in the upstream ticket. 