### PR TITLE
Don't force downloading of Open Sans fonts

### DIFF
--- a/src/mbgl/style/parser.cpp
+++ b/src/mbgl/style/parser.cpp
@@ -277,7 +277,7 @@ std::vector<FontStack> Parser::fontStacks() const {
     std::set<FontStack> result;
 
     for (const auto& layer : layers) {
-        if (layer->is<SymbolLayer>()) {
+        if (layer->is<SymbolLayer>() && !layer->as<SymbolLayer>()->getTextField().isUndefined()) {
             layer->as<SymbolLayer>()->getTextFont().match(
                 [&] (Undefined) {
                     result.insert({"Open Sans Regular", "Arial Unicode MS Regular"});

--- a/test/fixtures/style_parser/font_stacks.json
+++ b/test/fixtures/style_parser/font_stacks.json
@@ -12,6 +12,7 @@
     "source": "source",
     "source-layer": "source-layer",
     "layout": {
+      "text-field": "a",
       "text-font": ["a"]
     }
   }, {
@@ -20,6 +21,7 @@
     "source": "source",
     "source-layer": "source-layer",
     "layout": {
+      "text-field": "a",
       "text-font": {
         "stops": [[0, ["a", "b"]]]
       }
@@ -30,6 +32,7 @@
     "source": "source",
     "source-layer": "source-layer",
     "layout": {
+      "text-field": "a",
       "text-font": {
         "stops": [[0, ["a", "b"]], [1, ["a", "b", "c"]]]
       }

--- a/test/style/style_parser.test.cpp
+++ b/test/style/style_parser.test.cpp
@@ -103,6 +103,23 @@ TEST(StyleParser, FontStacks) {
     ASSERT_EQ(FontStack({"a", "b", "c"}), result[2]);
 }
 
+TEST(StyleParser, FontStacksNoTextField) {
+    style::Parser parser;
+    parser.parse(R"({
+        "version": 8,
+        "layers": [{
+            "id": "symbol",
+            "type": "symbol",
+            "source": "vector",
+            "layout": {
+                "text-font": ["a"]
+            }
+        }]
+    })");
+    auto result = parser.fontStacks();
+    ASSERT_EQ(0u, result.size());
+}
+
 TEST(StyleParser, FontStacksCaseExpression) {
     style::Parser parser;
     parser.parse(R"({
@@ -112,6 +129,7 @@ TEST(StyleParser, FontStacksCaseExpression) {
             "type": "symbol",
             "source": "vector",
             "layout": {
+                "text-field": "a",
                 "text-font": ["case", ["==", "a", ["string", ["get", "text-font"]]], ["literal", ["Arial"]], ["literal", ["Helvetica"]]]
             }
         }]
@@ -131,6 +149,7 @@ TEST(StyleParser, FontStacksMatchExpression) {
             "type": "symbol",
             "source": "vector",
             "layout": {
+                "text-field": "a",
                 "text-font": ["match", ["get", "text-font"], "a", ["literal", ["Arial"]], ["literal", ["Helvetica"]]]
             }
         }]
@@ -150,6 +169,7 @@ TEST(StyleParser, FontStacksStepExpression) {
             "type": "symbol",
             "source": "vector",
             "layout": {
+                "text-field": "a",
                 "text-font": ["array", "string", ["step", ["get", "text-font"], ["literal", ["Arial"]], 0, ["literal", ["Helvetica"]]]]
             }
         }]
@@ -170,6 +190,7 @@ TEST(StyleParser, FontStacksGetExpression) {
             "type": "symbol",
             "source": "vector",
             "layout": {
+                "text-field": "a",
                 "text-font": ["array", "string", ["get", "text-font"]]
             }
         }]


### PR DESCRIPTION
When a `SymbolLayer` doesn't have a `text-font` defined, we automatically add Open Sans/Arial Unicode MS. However, when the `SymbolLayer` is only used for rendering icons, it doesn't have `text-field` defined either. In those cases, we still force downloading Open Sans/Arial Unicode MS during offline pack creation. If the user doesn't use this font, this change should save ~15MB and a few seconds in download time.