### PR TITLE
Bump snapshot version on master to 7.0.0-SNAPSHOT

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/gradle.properties
+++ b/platform/android/MapboxGLAndroidSDK/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.mapbox.mapboxsdk
-VERSION_NAME=6.0.0-SNAPSHOT
+VERSION_NAME=7.0.0-SNAPSHOT
 
 POM_DESCRIPTION=Mapbox GL Android SDK
 POM_URL=https://github.com/mapbox/mapbox-gl-native


### PR DESCRIPTION
Yesterday we created the `release-boba` branch from master, both that branch as master are configured to build a 6.0.0-SNAPSHOT when a merge occurs. This PR updates the master configuration to 7.0.0-SNAPSHOT to avoid having 2 branches building the same snapshot version.