### PR TITLE
AppVeyor should build all branches

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,6 @@ environment:
 
 shallow_clone: true
 
-branches:
-  only:
-    - master
-
 cache:
   - '%APPVEYOR_BUILD_FOLDER%\mason_packages'
   - '%APPVEYOR_BUILD_FOLDER%\LLVM-5.0.1-win64.exe'


### PR DESCRIPTION
AppVeyor CI is only started atm when a PR is aimed at master. Now that we have a new release branch (release-boba) we are noticing that the CI bot is not running, removing the whitelist from the configuration should solve this. More info [here](https://www.appveyor.com/docs/branches/#white--and-blacklisting).

