### PR TITLE
Wrap glGetString in `MBGL_CHECK_ERROR` too

### DIFF
--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -287,7 +287,7 @@ UniqueTexture Context::createTexture() {
 
 bool Context::supportsVertexArrays() const {
     static bool blacklisted = []() {
-        const std::string renderer = reinterpret_cast<const char*>(glGetString(GL_RENDERER));
+        const std::string renderer = reinterpret_cast<const char*>(MBGL_CHECK_ERROR(glGetString(GL_RENDERER)));
 
         Log::Info(Event::General, "GPU Identifier: %s", renderer.c_str());
 
@@ -318,7 +318,7 @@ bool Context::supportsProgramBinaries() const {
     // https://chromium.googlesource.com/chromium/src/gpu/+/master/config/gpu_driver_bug_list.json#2316
     // Blacklist Vivante GC4000 due to bugs when linking loaded programs:
     // https://github.com/mapbox/mapbox-gl-native/issues/10704
-    const std::string renderer = reinterpret_cast<const char*>(glGetString(GL_RENDERER));
+    const std::string renderer = reinterpret_cast<const char*>(MBGL_CHECK_ERROR(glGetString(GL_RENDERER)));
     if (renderer.find("Adreno (TM) 3") != std::string::npos
      || renderer.find("Adreno (TM) 4") != std::string::npos
      || renderer.find("Adreno (TM) 5") != std::string::npos

--- a/test/api/custom_layer.test.cpp
+++ b/test/api/custom_layer.test.cpp
@@ -48,7 +48,7 @@ public:
         MBGL_CHECK_ERROR(glCompileShader(fragmentShader));
         MBGL_CHECK_ERROR(glAttachShader(program, fragmentShader));
         MBGL_CHECK_ERROR(glLinkProgram(program));
-        a_pos = glGetAttribLocation(program, "a_pos");
+        a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
 
         GLfloat triangle[] = { 0, 0.5, 0.5, -0.5, -0.5, -0.5 };
         MBGL_CHECK_ERROR(glGenBuffers(1, &buffer));


### PR DESCRIPTION
For Qt, we're using `MBGL_CHECK_ERROR` as a way to link all OpenGL functions against the `QOpenGLFunctions` object instead of the plain library functions. This adds this wrapper to two missing functions.
