### PR TITLE
Don't invoke onLowMemory when map isn't ready

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -486,7 +486,9 @@ public class MapView extends FrameLayout {
    */
   @UiThread
   public void onLowMemory() {
-    nativeMapView.onLowMemory();
+    if (nativeMapView != null) {
+      nativeMapView.onLowMemory();
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #11103, This PR avoids calling into `NativeMapView#onLowMemory` when the map isn't fully created yet. This can occur on low memory devices (eg. Android Wearables) when the map is being underway of being created. 