### PR TITLE
[core] Don't crash on line labels with 0 glyphs.

### DIFF
--- a/src/mbgl/layout/symbol_projection.cpp
+++ b/src/mbgl/layout/symbol_projection.cpp
@@ -318,7 +318,7 @@ namespace mbgl {
                 placedGlyphs.push_back(*placedGlyph);
             }
             placedGlyphs.push_back(firstAndLastGlyph->second);
-        } else {
+        } else if (symbol.glyphOffsets.size() == 1) {
             // Only a single glyph to place
             // So, determine whether to flip based on projected angle of the line segment it's on
             if (keepUpright && !flip) {
@@ -337,7 +337,6 @@ namespace mbgl {
                     return *orientationChange;
                 }
             }
-            assert(symbol.glyphOffsets.size() == 1); // We are relying on SymbolInstance.hasText filtering out symbols without any glyphs at all
             const float glyphOffsetX = symbol.glyphOffsets.front();
             optional<PlacedGlyph> singleGlyph = placeGlyphAlongLine(fontScale * glyphOffsetX, lineOffsetX, lineOffsetY, flip, projectedAnchorPoint, symbol.anchorPoint, symbol.segment,
                 symbol.line, symbol.tileDistances, labelPlaneMatrix, false);
@@ -347,6 +346,8 @@ namespace mbgl {
             placedGlyphs.push_back(*singleGlyph);
         }
 
+        // The number of placedGlyphs must equal the number of glyphOffsets, which must correspond to the number of glyph vertices
+        // There may be 0 glyphs here, if a label consists entirely of glyphs that have 0x0 dimensions
         for (auto& placedGlyph : placedGlyphs) {
             addDynamicAttributes(placedGlyph.point, placedGlyph.angle, dynamicVertexArray);
         }


### PR DESCRIPTION
Fixes issue #10956.

We could make a rather boring render regression test for this by creating a line label with one 0x0 glyph in it, but not sure it would be that valuable... Do we often make render tests that try to trigger crashes?

/cc @ansis @tobrun 