### PR TITLE
Programmatically create GlSurfaceView

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -304,7 +304,7 @@ public class MapView extends FrameLayout {
 
       addView(textureView, 0);
     } else {
-      GLSurfaceView glSurfaceView = (GLSurfaceView) findViewById(R.id.surfaceView);
+      GLSurfaceView glSurfaceView = new GLSurfaceView(getContext());
       glSurfaceView.setZOrderMediaOverlay(mapboxMapOptions.getRenderSurfaceOnTop());
       mapRenderer = new GLSurfaceViewMapRenderer(getContext(), glSurfaceView, options.getLocalIdeographFontFamily()) {
         @Override
@@ -314,7 +314,7 @@ public class MapView extends FrameLayout {
         }
       };
 
-      glSurfaceView.setVisibility(View.VISIBLE);
+      addView(glSurfaceView, 0);
     }
 
     nativeMapView = new NativeMapView(this, mapRenderer);

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_internal.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_internal.xml
@@ -1,13 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <android.opengl.GLSurfaceView
-        android:id="@+id/surfaceView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:contentDescription="@null"
-        android:visibility="gone"/>
-
     <FrameLayout
         android:id="@+id/markerViewContainer"
         android:layout_width="match_parent"


### PR DESCRIPTION
This PR solves a very strange bug with activity recreation and fragments:

> Debugging shows when you recreate the activity, I'm seeing 2 fragments being recreated and both share the same SurfaceView which results in the `setRenderer has already been called for this instance` exception. This should not happen as they both do layout inflation on their own. Creating the SurfaceView programmatically resolves the issue though can't really explain why both fragments share the same SurfaceView. 

Closes #11121 