### PR TITLE
Copyedit computed source wrapping options

### DIFF
--- a/platform/darwin/src/MGLAbstractShapeSource.h
+++ b/platform/darwin/src/MGLAbstractShapeSource.h
@@ -82,22 +82,29 @@ extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionBuffer;
 extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance;
 
 /**
- An `NSNumber` object containing a boolean; specifies whether the geometry for a
- `MGLComputedShapeSource` needs to be wrapped to accomodate coordinates with longitudes outside the [-180,180] extents. The default is `false.`
+ An `NSNumber` object containing a Boolean value; specifies whether the shape of
+ an `MGLComputedShapeSource` should be wrapped to accomodate coordinates with
+ longitudes beyond −180 and 180. The default value is `NO`.
  
- Setting this option to `true` affects performance.
-  */
-extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionWrapCoordinates;
+ Setting this option to `YES` affects rendering performance.
+ 
+ This option is ignored when creating an instance of a class besides
+ `MGLComputedShapeSource`.
+ */
+extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionWrapsCoordinates;
 
 /**
- An `NSNumber` object containing a boolean; specifies whether the geometry for a
- `MGLComputedShapeSource` needs to be clipped at the tile boundaries.
- The default is `false.`
-
- Setting this options to `true` affects performance. Use this option to clip
- polygons and lines at tile boundaries without artefacts.
+ An `NSNumber` object containing a Boolean value; specifies whether the shape of
+ an `MGLComputedShapeSource` should be clipped at the edge of each tile. The
+ default value is `NO`.
+ 
+ Setting this option to `YES` affects rendering performance. Use this option to
+ clip `MGLPolyline`s and `MGLPolygon`s at tile boundaries without artifacts.
+ 
+ This option is ignored when creating an instance of a class besides
+ `MGLComputedShapeSource`.
  */
-extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionClipCoordinates;
+extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionClipsCoordinates;
 
 /**
  `MGLAbstractShapeSource` is an abstract base class for map content sources that

--- a/platform/darwin/src/MGLAbstractShapeSource.mm
+++ b/platform/darwin/src/MGLAbstractShapeSource.mm
@@ -8,8 +8,8 @@ const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevel = @"MGLShapeSour
 const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevelForClustering = @"MGLShapeSourceOptionMaximumZoomLevelForClustering";
 const MGLShapeSourceOption MGLShapeSourceOptionMinimumZoomLevel = @"MGLShapeSourceOptionMinimumZoomLevel";
 const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance = @"MGLShapeSourceOptionSimplificationTolerance";
-const MGLShapeSourceOption MGLShapeSourceOptionWrapCoordinates = @"MGLShapeSourceOptionWrapCoordinates";
-const MGLShapeSourceOption MGLShapeSourceOptionClipCoordinates = @"MGLShapeSourceOptionClipCoordinates";
+const MGLShapeSourceOption MGLShapeSourceOptionWrapsCoordinates = @"MGLShapeSourceOptionWrapsCoordinates";
+const MGLShapeSourceOption MGLShapeSourceOptionClipsCoordinates = @"MGLShapeSourceOptionClipsCoordinates";
 
 @interface MGLAbstractShapeSource ()
 
@@ -116,18 +116,18 @@ mbgl::style::CustomGeometrySource::Options MBGLCustomGeometrySourceOptionsFromDi
         sourceOptions.tileOptions.tolerance = value.doubleValue;
     }
 
-    if (NSNumber *value = options[MGLShapeSourceOptionWrapCoordinates]) {
+    if (NSNumber *value = options[MGLShapeSourceOptionWrapsCoordinates]) {
         if (![value isKindOfClass:[NSNumber class]]) {
             [NSException raise:NSInvalidArgumentException
-                        format:@"MGLShapeSourceOptionWrapCoordinates must be an NSNumber."];
+                        format:@"MGLShapeSourceOptionWrapsCoordinates must be an NSNumber."];
         }
         sourceOptions.tileOptions.wrap = value.boolValue;
     }
 
-    if (NSNumber *value = options[MGLShapeSourceOptionClipCoordinates]) {
+    if (NSNumber *value = options[MGLShapeSourceOptionClipsCoordinates]) {
         if (![value isKindOfClass:[NSNumber class]]) {
             [NSException raise:NSInvalidArgumentException
-                        format:@"MGLShapeSourceOptionClipCoordinates must be an NSNumber."];
+                        format:@"MGLShapeSourceOptionClipsCoordinates must be an NSNumber."];
         }
         sourceOptions.tileOptions.clip = value.boolValue;
     }

--- a/platform/macos/app/MapDocument.m
+++ b/platform/macos/app/MapDocument.m
@@ -726,11 +726,13 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
         [self.undoManager setActionName:@"Add Graticule"];
     }
 
+    NSDictionary *sourceOptions = @{
+        MGLShapeSourceOptionMaximumZoomLevel:@14,
+        MGLShapeSourceOptionWrapsCoordinates: @YES,
+        MGLShapeSourceOptionClipsCoordinates: @YES,
+    };
     MGLComputedShapeSource *source = [[MGLComputedShapeSource alloc] initWithIdentifier:@"graticule"
-     options:@{MGLShapeSourceOptionMaximumZoomLevel:@14
-            , MGLShapeSourceOptionWrapCoordinates: @YES
-            , MGLShapeSourceOptionClipCoordinates: @YES
-            }];
+                                                                                options:sourceOptions];
 
     source.dataSource = self;
     [self.mapView.style addSource:source];


### PR DESCRIPTION
This is a followup to #11041 that renames `MGLShapeSourceOptionWrapCoordinates` to `MGLShapeSourceOptionWrapsCoordinates` and `MGLShapeSourceOptionClipCoordinates` to `MGLShapeSourceOptionClipsCoordinates`, since options are typically named declaratively rather than imperatively. The documentation comments for these options have also been copyedited, in part to use the Objective-C Boolean values.

/cc @asheemmamoowala @julianrex