### PR TITLE
Cherry-pick TileJSON bounds support for agua patch 

### DIFF
--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -614,6 +614,7 @@ set(MBGL_CORE_FILES
     src/mbgl/util/tile_coordinate.hpp
     src/mbgl/util/tile_cover.cpp
     src/mbgl/util/tile_cover.hpp
+    src/mbgl/util/tile_range.hpp
     src/mbgl/util/tiny_sdf.cpp
     src/mbgl/util/tiny_sdf.hpp
     src/mbgl/util/token.hpp

--- a/cmake/test-files.cmake
+++ b/cmake/test-files.cmake
@@ -87,6 +87,7 @@ set(MBGL_TEST_FILES
     test/style/conversion/layer.test.cpp
     test/style/conversion/light.test.cpp
     test/style/conversion/stringify.test.cpp
+    test/style/conversion/tileset.test.cpp
 
     # style
     test/style/filter.test.cpp
@@ -138,6 +139,7 @@ set(MBGL_TEST_FILES
     test/util/thread.test.cpp
     test/util/thread_local.test.cpp
     test/util/tile_cover.test.cpp
+    test/util/tile_range.test.cpp
     test/util/timer.test.cpp
     test/util/token.test.cpp
     test/util/url.test.cpp

--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -154,19 +154,15 @@ public:
                sw.longitude() > ne.longitude();
     }
 
-    bool contains(const LatLng& point) const {
-        return (point.latitude()  >= sw.latitude()  &&
-                point.latitude()  <= ne.latitude()  &&
-                point.longitude() >= sw.longitude() &&
-                point.longitude() <= ne.longitude());
+    bool crossesAntimeridian() const {
+        return (sw.wrapped().longitude() > ne.wrapped().longitude());
     }
 
-    bool intersects(const LatLngBounds area) const {
-        return (area.ne.latitude()  > sw.latitude()  &&
-                area.sw.latitude()  < ne.latitude()  &&
-                area.ne.longitude() > sw.longitude() &&
-                area.sw.longitude() < ne.longitude());
-    }
+    bool contains(const CanonicalTileID& tileID) const;
+    bool contains(const LatLng& point, LatLng::WrapMode wrap = LatLng::Unwrapped) const;
+    bool contains(const LatLngBounds& area, LatLng::WrapMode wrap = LatLng::Unwrapped) const;
+
+    bool intersects(const LatLngBounds area, LatLng::WrapMode wrap = LatLng::Unwrapped) const;
 
 private:
     LatLng sw;

--- a/include/mbgl/util/projection.hpp
+++ b/include/mbgl/util/projection.hpp
@@ -78,6 +78,10 @@ public:
         return project_(latLng, worldSize(scale));
     }
 
+    static Point<double> project(const LatLng& latLng, uint8_t zoom) {
+        return project_(latLng, std::pow(2.0, zoom));
+    }
+
     static LatLng unproject(const Point<double>& p, double scale, LatLng::WrapMode wrapMode = LatLng::Unwrapped) {
         auto p2 = p * util::DEGREES_MAX / worldSize(scale);
         return LatLng {

--- a/include/mbgl/util/tileset.hpp
+++ b/include/mbgl/util/tileset.hpp
@@ -2,7 +2,9 @@
 
 #include <mbgl/util/range.hpp>
 #include <mbgl/util/constants.hpp>
-
+#include <mbgl/util/optional.hpp>
+#include <mbgl/util/geo.hpp>
+#include <tuple>
 #include <vector>
 #include <string>
 #include <cstdint>
@@ -17,6 +19,7 @@ public:
     Range<uint8_t> zoomRange;
     std::string attribution;
     Scheme scheme;
+    optional<LatLngBounds> bounds;
 
     Tileset(std::vector<std::string> tiles_ = std::vector<std::string>(),
             Range<uint8_t> zoomRange_ = { 0, util::DEFAULT_MAX_ZOOM },
@@ -25,13 +28,14 @@ public:
         : tiles(std::move(tiles_)),
           zoomRange(std::move(zoomRange_)),
           attribution(std::move(attribution_)),
-          scheme(scheme_) {}
+          scheme(scheme_),
+          bounds() {}
 
-    // TileJSON also includes center, zoom, and bounds, but they are not used by mbgl.
+    // TileJSON also includes center and zoom but they are not used by mbgl.
 
     friend bool operator==(const Tileset& lhs, const Tileset& rhs) {
-        return std::tie(lhs.tiles, lhs.zoomRange, lhs.attribution, lhs.scheme)
-            == std::tie(rhs.tiles, rhs.zoomRange, rhs.attribution, rhs.scheme);
+        return std::tie(lhs.tiles, lhs.zoomRange, lhs.attribution, lhs.scheme, lhs.bounds)
+            == std::tie(rhs.tiles, rhs.zoomRange, rhs.attribution, rhs.scheme, rhs.bounds);
     }
 };
 

--- a/platform/darwin/docs/guides/For Style Authors.md.ejs
+++ b/platform/darwin/docs/guides/For Style Authors.md.ejs
@@ -160,6 +160,7 @@ the following terms for concepts defined in the style specification:
 
 In the style specification | In the SDK
 ---------------------------|---------
+bounds                     | coordinate bounds
 filter                     | predicate
 function type              | interpolation mode
 id                         | identifier
@@ -200,6 +201,7 @@ In style JSON | In TileJSON   | In the SDK
 `tiles`       | `tiles`       | `tileURLTemplates` parameter in `-[MGLTileSource initWithIdentifier:tileURLTemplates:options:]`
 `minzoom`     | `minzoom`     | `MGLTileSourceOptionMinimumZoomLevel`
 `maxzoom`     | `maxzoom`     | `MGLTileSourceOptionMaximumZoomLevel`
+`bounds`      | `bounds`      | `MGLTileSourceOptionCoordinateBounds`
 `tileSize`    | —             | `MGLTileSourceOptionTileSize`
 `attribution` | `attribution` | `MGLTileSourceOptionAttributionHTMLString` (but consider specifying `MGLTileSourceOptionAttributionInfos` instead for improved security)
 `scheme`      | `scheme`      | `MGLTileSourceOptionTileCoordinateSystem`

--- a/platform/darwin/src/MGLTileSource.h
+++ b/platform/darwin/src/MGLTileSource.h
@@ -41,6 +41,20 @@ extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionMinimumZoomLevel;
  */
 extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionMaximumZoomLevel;
 
+/**
+ An `NSValue` object containing an `MGLCoordinateBounds` struct that specifies
+ the geographic extent of the source.
+ 
+ If this option is specified, the SDK avoids requesting any tile that falls
+ outside of the coordinate bounds. Otherwise, the SDK requests any tile needed
+ to cover the viewport, as it does by default.
+
+ This option corresponds to the `bounds` key in the
+ <a href="https://github.com/mapbox/tilejson-spec/tree/master/2.1.0">TileJSON</a>
+ specification.
+ */
+extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionCoordinateBounds;
+
 #if TARGET_OS_IPHONE
 /**
  An HTML string defining the buttons to be displayed in an action sheet when the

--- a/platform/darwin/src/MGLTileSource.mm
+++ b/platform/darwin/src/MGLTileSource.mm
@@ -1,7 +1,9 @@
 #import "MGLTileSource_Private.h"
 
 #import "MGLAttributionInfo_Private.h"
+#import "MGLGeometry_Private.h"
 #import "NSString+MGLAdditions.h"
+#import "NSValue+MGLAdditions.h"
 
 #if TARGET_OS_IPHONE
     #import <UIKit/UIKit.h>
@@ -13,6 +15,7 @@
 
 const MGLTileSourceOption MGLTileSourceOptionMinimumZoomLevel = @"MGLTileSourceOptionMinimumZoomLevel";
 const MGLTileSourceOption MGLTileSourceOptionMaximumZoomLevel = @"MGLTileSourceOptionMaximumZoomLevel";
+const MGLTileSourceOption MGLTileSourceOptionCoordinateBounds = @"MGLTileSourceOptionCoordinateBounds";
 const MGLTileSourceOption MGLTileSourceOptionAttributionHTMLString = @"MGLTileSourceOptionAttributionHTMLString";
 const MGLTileSourceOption MGLTileSourceOptionAttributionInfos = @"MGLTileSourceOptionAttributionInfos";
 const MGLTileSourceOption MGLTileSourceOptionTileCoordinateSystem = @"MGLTileSourceOptionTileCoordinateSystem";
@@ -69,6 +72,15 @@ mbgl::Tileset MGLTileSetFromTileURLTemplates(NS_ARRAY_OF(NSString *) *tileURLTem
     if (tileSet.zoomRange.min > tileSet.zoomRange.max) {
         [NSException raise:NSInvalidArgumentException
                     format:@"MGLTileSourceOptionMinimumZoomLevel must be less than MGLTileSourceOptionMaximumZoomLevel."];
+    }
+    
+    if (NSValue *coordinateBounds = options[MGLTileSourceOptionCoordinateBounds]) {
+        if (![coordinateBounds isKindOfClass:[NSValue class]]
+            && strcmp(coordinateBounds.objCType, @encode(MGLCoordinateBounds)) == 0) {
+            [NSException raise:NSInvalidArgumentException
+                        format:@"MGLTileSourceOptionCoordinateBounds must be set to an NSValue containing an MGLCoordinateBounds."];
+        }
+        tileSet.bounds = MGLLatLngBoundsFromCoordinateBounds(coordinateBounds.MGLCoordinateBoundsValue);
     }
 
     if (NSString *attribution = options[MGLTileSourceOptionAttributionHTMLString]) {

--- a/platform/darwin/test/MGLTileSetTests.mm
+++ b/platform/darwin/test/MGLTileSetTests.mm
@@ -2,6 +2,7 @@
 
 #import <Mapbox/Mapbox.h>
 #import "MGLTileSource_Private.h"
+#import "MGLGeometry_Private.h"
 
 #include <mbgl/util/tileset.hpp>
 
@@ -39,6 +40,19 @@
     // the mbgl object reflects the set values for min and max zoom level
     XCTAssertEqual(tileSet.zoomRange.min, 1);
     XCTAssertEqual(tileSet.zoomRange.max, 2);
+
+    // when the tile set has a bounds set
+    MGLCoordinateBounds bounds = MGLCoordinateBoundsMake(CLLocationCoordinate2DMake(12, 34), CLLocationCoordinate2DMake(56, 78));
+    tileSet = MGLTileSetFromTileURLTemplates(@[@"tile.1"], @{
+        MGLTileSourceOptionCoordinateBounds: @(bounds),
+    });
+
+    // the mbgl object reflects the set values for the bounds
+    XCTAssert(!!tileSet.bounds, @"The bounds are set after setting the bounds");
+    if (tileSet.bounds) {
+        MGLCoordinateBounds actual = MGLCoordinateBoundsFromLatLngBounds(*tileSet.bounds);
+        XCTAssert(MGLCoordinateBoundsEqualToCoordinateBounds(bounds, actual), @"The bounds round-trip");
+    }
 
     // when the tile set has an attribution
     NSString *attribution = @"my tileset © ©️🎈";

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
-## 3.7.3
+## 3.7.4
+
+* Added the `MGLTileSourceOptionTileCoordinateBounds` option to create an `MGLTileSource` that only supplies tiles within a specific geographic bounding box. ([#11141](https://github.com/mapbox/mapbox-gl-native/pull/11141))
+
+## 3.7.3 - January 10, 2018
 
 * Fixed a crash while zooming while annotations are present on the map. ([#10791](https://github.com/mapbox/mapbox-gl-native/pull/10791))
 * CJK characters can be displayed in a locally installed font or a custom font bundled with the application, reducing map download times. Specify the font name using the `MGLIdeographicFontFamilyName` key in the application’s Info.plist file. ([#10522](https://github.com/mapbox/mapbox-gl-native/pull/10522))

--- a/platform/ios/docs/guides/For Style Authors.md
+++ b/platform/ios/docs/guides/For Style Authors.md
@@ -109,6 +109,7 @@ the following terms for concepts defined in the style specification:
 
 In the style specification | In the SDK
 ---------------------------|---------
+bounds                     | coordinate bounds
 filter                     | predicate
 function type              | interpolation mode
 id                         | identifier
@@ -149,6 +150,7 @@ In style JSON | In TileJSON   | In the SDK
 `tiles`       | `tiles`       | `tileURLTemplates` parameter in `-[MGLTileSource initWithIdentifier:tileURLTemplates:options:]`
 `minzoom`     | `minzoom`     | `MGLTileSourceOptionMinimumZoomLevel`
 `maxzoom`     | `maxzoom`     | `MGLTileSourceOptionMaximumZoomLevel`
+`bounds`      | `bounds`      | `MGLTileSourceOptionCoordinateBounds`
 `tileSize`    | —             | `MGLTileSourceOptionTileSize`
 `attribution` | `attribution` | `MGLTileSourceOptionAttributionHTMLString` (but consider specifying `MGLTileSourceOptionAttributionInfos` instead for improved security)
 `scheme`      | `scheme`      | `MGLTileSourceOptionTileCoordinateSystem`

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for Mapbox Maps SDK for macOS
 
+## v0.6.2
+
+* Added the `MGLTileSourceOptionTileCoordinateBounds` option to create an `MGLTileSource` that only supplies tiles within a specific geographic bounding box. ([#11141](https://github.com/mapbox/mapbox-gl-native/pull/11141))
+
 ## v0.6.1 - January 16, 2018
 
 This version of the Mapbox macOS SDK corresponds to version 3.7.3 of the Mapbox Maps SDK for iOS.

--- a/platform/macos/docs/guides/For Style Authors.md
+++ b/platform/macos/docs/guides/For Style Authors.md
@@ -96,6 +96,7 @@ the following terms for concepts defined in the style specification:
 
 In the style specification | In the SDK
 ---------------------------|---------
+bounds                     | coordinate bounds
 filter                     | predicate
 function type              | interpolation mode
 id                         | identifier
@@ -136,6 +137,7 @@ In style JSON | In TileJSON   | In the SDK
 `tiles`       | `tiles`       | `tileURLTemplates` parameter in `-[MGLTileSource initWithIdentifier:tileURLTemplates:options:]`
 `minzoom`     | `minzoom`     | `MGLTileSourceOptionMinimumZoomLevel`
 `maxzoom`     | `maxzoom`     | `MGLTileSourceOptionMaximumZoomLevel`
+`bounds`      | `bounds`      | `MGLTileSourceOptionCoordinateBounds`
 `tileSize`    | —             | `MGLTileSourceOptionTileSize`
 `attribution` | `attribution` | `MGLTileSourceOptionAttributionHTMLString` (but consider specifying `MGLTileSourceOptionAttributionInfos` instead for improved security)
 `scheme`      | `scheme`      | `MGLTileSourceOptionTileCoordinateSystem`

--- a/src/mbgl/algorithm/update_renderables.hpp
+++ b/src/mbgl/algorithm/update_renderables.hpp
@@ -35,7 +35,11 @@ void updateRenderables(GetTileFn getTile,
         auto tile = getTile(idealDataTileID);
         if (!tile) {
             tile = createTile(idealDataTileID);
-            assert(tile);
+            // For source types where TileJSON.bounds is set, tiles outside the
+            // bounds are not created
+            if(tile == nullptr) {
+                continue;
+            }
         }
 
         // if (source has the tile and bucket is loaded) {

--- a/src/mbgl/annotation/render_annotation_source.cpp
+++ b/src/mbgl/annotation/render_annotation_source.cpp
@@ -41,6 +41,7 @@ void RenderAnnotationSource::update(Immutable<style::Source::Impl> baseImpl_,
                        // Zoom level 16 is typically sufficient for annotations.
                        // See https://github.com/mapbox/mapbox-gl-native/issues/10197
                        { 0, 16 },
+                       optional<LatLngBounds> {},
                        [&] (const OverscaledTileID& tileID) {
                            return std::make_unique<AnnotationTile>(tileID, parameters);
                        });

--- a/src/mbgl/renderer/sources/render_geojson_source.cpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.cpp
@@ -62,6 +62,7 @@ void RenderGeoJSONSource::update(Immutable<style::Source::Impl> baseImpl_,
                        SourceType::GeoJSON,
                        util::tileSize,
                        impl().getZoomRange(),
+                       optional<LatLngBounds>{},
                        [&] (const OverscaledTileID& tileID) {
                            return std::make_unique<GeoJSONTile>(tileID, impl().id, parameters, data->getTile(tileID.canonical));
                        });

--- a/src/mbgl/renderer/sources/render_raster_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_source.cpp
@@ -52,6 +52,7 @@ void RenderRasterSource::update(Immutable<style::Source::Impl> baseImpl_,
                        SourceType::Raster,
                        impl().getTileSize(),
                        tileset->zoomRange,
+                       tileset->bounds,
                        [&] (const OverscaledTileID& tileID) {
                            return std::make_unique<RasterTile>(tileID, parameters, *tileset);
                        });

--- a/src/mbgl/renderer/sources/render_raster_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_source.cpp
@@ -29,20 +29,21 @@ void RenderRasterSource::update(Immutable<style::Source::Impl> baseImpl_,
 
     enabled = needsRendering;
 
-    optional<Tileset> tileset = impl().getTileset();
+    optional<Tileset> _tileset = impl().getTileset();
 
-    if (!tileset) {
-        return;
-    }
-
-    if (tileURLTemplates != tileset->tiles) {
-        tileURLTemplates = tileset->tiles;
+    if (tileset != _tileset) {
+        tileset = _tileset;
 
         // TODO: this removes existing buckets, and will cause flickering.
         // Should instead refresh tile data in place.
         tilePyramid.tiles.clear();
         tilePyramid.renderTiles.clear();
         tilePyramid.cache.clear();
+    }
+    // Allow clearing the tile pyramid first, before the early return in case
+    //  the new tileset is not yet available or has an error in loading
+    if (!_tileset) {
+        return;
     }
 
     tilePyramid.update(layers,

--- a/src/mbgl/renderer/sources/render_raster_source.hpp
+++ b/src/mbgl/renderer/sources/render_raster_source.hpp
@@ -39,7 +39,7 @@ private:
     const style::RasterSource::Impl& impl() const;
 
     TilePyramid tilePyramid;
-    optional<std::vector<std::string>> tileURLTemplates;
+    optional<Tileset> tileset;
 };
 
 template <>

--- a/src/mbgl/renderer/sources/render_vector_source.cpp
+++ b/src/mbgl/renderer/sources/render_vector_source.cpp
@@ -55,6 +55,7 @@ void RenderVectorSource::update(Immutable<style::Source::Impl> baseImpl_,
                        SourceType::Vector,
                        util::tileSize,
                        tileset->zoomRange,
+                       tileset->bounds,
                        [&] (const OverscaledTileID& tileID) {
                            return std::make_unique<VectorTile>(tileID, impl().id, parameters, *tileset);
                        });

--- a/src/mbgl/renderer/sources/render_vector_source.cpp
+++ b/src/mbgl/renderer/sources/render_vector_source.cpp
@@ -32,20 +32,21 @@ void RenderVectorSource::update(Immutable<style::Source::Impl> baseImpl_,
 
     enabled = needsRendering;
 
-    optional<Tileset> tileset = impl().getTileset();
+    optional<Tileset> _tileset = impl().getTileset();
 
-    if (!tileset) {
-        return;
-    }
-
-    if (tileURLTemplates != tileset->tiles) {
-        tileURLTemplates = tileset->tiles;
+    if (tileset != _tileset) {
+        tileset = _tileset;
 
         // TODO: this removes existing buckets, and will cause flickering.
         // Should instead refresh tile data in place.
         tilePyramid.tiles.clear();
         tilePyramid.renderTiles.clear();
         tilePyramid.cache.clear();
+    }
+    // Allow clearing the tile pyramid first, before the early return in case
+    //  the new tileset is not yet available or has an error in loading
+    if (!_tileset) {
+        return;
     }
 
     tilePyramid.update(layers,

--- a/src/mbgl/renderer/sources/render_vector_source.hpp
+++ b/src/mbgl/renderer/sources/render_vector_source.hpp
@@ -39,7 +39,7 @@ private:
     const style::VectorSource::Impl& impl() const;
 
     TilePyramid tilePyramid;
-    optional<std::vector<std::string>> tileURLTemplates;
+    optional<Tileset> tileset;
 };
 
 template <>

--- a/src/mbgl/renderer/tile_pyramid.hpp
+++ b/src/mbgl/renderer/tile_pyramid.hpp
@@ -40,6 +40,7 @@ public:
                 SourceType type,
                 uint16_t tileSize,
                 Range<uint8_t> zoomRange,
+                optional<LatLngBounds> bounds,
                 std::function<std::unique_ptr<Tile> (const OverscaledTileID&)> createTile);
 
     void startRender(PaintParameters&);

--- a/src/mbgl/style/conversion/tileset.cpp
+++ b/src/mbgl/style/conversion/tileset.cpp
@@ -1,0 +1,104 @@
+#include <mbgl/style/conversion/tileset.hpp>
+#include <mbgl/util/geo.hpp>
+
+namespace mbgl {
+namespace style {
+namespace conversion {
+
+bool validateLatitude(const double lat) {
+    return lat < 90 && lat > -90;
+}
+
+optional<Tileset> Converter<Tileset>::operator()(const Convertible& value, Error& error) const {
+    Tileset result;
+
+    auto tiles = objectMember(value, "tiles");
+    if (!tiles) {
+        error = { "source must have tiles" };
+        return {};
+    }
+
+    if (!isArray(*tiles)) {
+        error = { "source tiles must be an array" };
+        return {};
+    }
+
+    for (std::size_t i = 0; i < arrayLength(*tiles); i++) {
+        optional<std::string> urlTemplate = toString(arrayMember(*tiles, i));
+        if (!urlTemplate) {
+            error = { "source tiles member must be a string" };
+            return {};
+        }
+        result.tiles.push_back(std::move(*urlTemplate));
+    }
+
+    auto schemeValue = objectMember(value, "scheme");
+    if (schemeValue) {
+        optional<std::string> scheme = toString(*schemeValue);
+        if (scheme && *scheme == "tms") {
+            result.scheme = Tileset::Scheme::TMS;
+        }
+    }
+
+    auto minzoomValue = objectMember(value, "minzoom");
+    if (minzoomValue) {
+        optional<float> minzoom = toNumber(*minzoomValue);
+        if (!minzoom || *minzoom < 0 || *minzoom > std::numeric_limits<uint8_t>::max()) {
+            error = { "invalid minzoom" };
+            return {};
+        }
+        result.zoomRange.min = *minzoom;
+    }
+
+    auto maxzoomValue = objectMember(value, "maxzoom");
+    if (maxzoomValue) {
+        optional<float> maxzoom = toNumber(*maxzoomValue);
+        if (!maxzoom || *maxzoom < 0 || *maxzoom > std::numeric_limits<uint8_t>::max()) {
+            error = { "invalid maxzoom" };
+            return {};
+        }
+        result.zoomRange.max = *maxzoom;
+    }
+
+    auto attributionValue = objectMember(value, "attribution");
+    if (attributionValue) {
+        optional<std::string> attribution = toString(*attributionValue);
+        if (!attribution) {
+            error = { "source attribution must be a string" };
+            return {};
+        }
+        result.attribution = std::move(*attribution);
+    }
+
+    auto boundsValue = objectMember(value, "bounds");
+    if (boundsValue) {
+        if (!isArray(*boundsValue) || arrayLength(*boundsValue) != 4) {
+            error = { "bounds must be an array with left, bottom, top, and right values" };
+            return {};
+        }
+        optional<double> left = toDouble(arrayMember(*boundsValue, 0));
+        optional<double> bottom = toDouble(arrayMember(*boundsValue, 1));
+        optional<double> right = toDouble(arrayMember(*boundsValue, 2));
+        optional<double> top = toDouble(arrayMember(*boundsValue, 3));
+
+        if (!left || !right || !bottom || !top) {
+            error = { "bounds array must contain numeric longitude and latitude values" };
+            return {};
+        }
+        if (!validateLatitude(*bottom) || !validateLatitude(*top) || top <= bottom){
+            error = { "bounds latitude values must be between -90 and 90 with bottom less than top" };
+            return {};
+        }
+        if(*left >= *right) {
+            error = { "bounds left longitude should be less than right longitude" };
+            return {};
+        }
+        result.bounds = LatLngBounds::hull({ *bottom, *left }, { *top, *right });
+    }
+
+    return result;
+}
+
+} // namespace conversion
+} // namespace style
+} // namespace mbgl

--- a/src/mbgl/util/geo.cpp
+++ b/src/mbgl/util/geo.cpp
@@ -1,6 +1,8 @@
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/constants.hpp>
 #include <mbgl/tile/tile_id.hpp>
+#include <mbgl/math/clamp.hpp>
+#include <mbgl/util/tile_range.hpp>
 
 #include <cmath>
 
@@ -30,6 +32,86 @@ LatLng::LatLng(const UnwrappedTileID& id)
 LatLngBounds::LatLngBounds(const CanonicalTileID& id)
     : sw({ lat_(id.z, id.y + 1), lon_(id.z, id.x) }),
       ne({ lat_(id.z, id.y), lon_(id.z, id.x + 1) }) {
+}
+
+bool LatLngBounds::contains(const CanonicalTileID& tileID) const {
+    return util::TileRange::fromLatLngBounds(*this, tileID.z).contains(tileID);
+}
+
+bool LatLngBounds::contains(const LatLng& point, LatLng::WrapMode wrap /*= LatLng::Unwrapped*/) const {
+    bool containsLatitude = point.latitude() >= sw.latitude() &&
+                            point.latitude() <= ne.latitude();
+    if (!containsLatitude) {
+        return false;
+    }
+
+    bool containsUnwrappedLongitude = point.longitude() >= sw.longitude() &&
+                                      point.longitude() <= ne.longitude();
+    if (containsUnwrappedLongitude) {
+        return true;
+    } else if (wrap == LatLng::Wrapped) {
+        LatLngBounds wrapped(sw.wrapped(), ne.wrapped());
+        auto ptLon = point.wrapped().longitude();
+        if (crossesAntimeridian()) {
+            return (ptLon >= wrapped.sw.longitude() &&
+                    ptLon <= util::LONGITUDE_MAX) ||
+                   (ptLon <= wrapped.ne.longitude() &&
+                    ptLon >= -util::LONGITUDE_MAX);
+        } else {
+            return (ptLon >= wrapped.sw.longitude() &&
+                    ptLon <= wrapped.ne.longitude());
+        }
+    }
+    return false;
+}
+
+bool LatLngBounds::contains(const LatLngBounds& area, LatLng::WrapMode wrap /*= LatLng::Unwrapped*/) const {
+    bool containsLatitude = area.north() <= north() && area.south() >= south();
+    if (!containsLatitude) {
+        return false;
+    }
+
+    bool containsUnwrapped = area.east() <= east() && area.west() >= west();
+    if(containsUnwrapped) {
+        return true;
+    } else if (wrap == LatLng::Wrapped) {
+        LatLngBounds wrapped(sw.wrapped(), ne.wrapped());
+        LatLngBounds other(area.sw.wrapped(), area.ne.wrapped());
+        if (crossesAntimeridian() & !area.crossesAntimeridian()) {
+            return (other.east() <= util::LONGITUDE_MAX && other.west() >= wrapped.west()) ||
+                   (other.east() <= wrapped.east() && other.west() >= -util::LONGITUDE_MAX);
+        } else {
+            return other.east() <= wrapped.east() && other.west() >= wrapped.west();
+        }
+    }
+    return false;
+}
+
+bool LatLngBounds::intersects(const LatLngBounds area, LatLng::WrapMode wrap /*= LatLng::Unwrapped*/) const {
+    bool latitudeIntersects = area.north() > south() && area.south() < north();
+    if (!latitudeIntersects) {
+        return false;
+    }
+
+    bool longitudeIntersects = area.east() > west() && area.west() < east();
+    if (longitudeIntersects) {
+        return true;
+    } else if (wrap == LatLng::Wrapped) {
+        LatLngBounds wrapped(sw.wrapped(), ne.wrapped());
+        LatLngBounds other(area.sw.wrapped(), area.ne.wrapped());
+        if (crossesAntimeridian()) {
+            return area.crossesAntimeridian() ||
+                   other.east() > wrapped.west() ||
+                   other.west() < wrapped.east();
+        } else if (other.crossesAntimeridian()){
+            return other.east() > wrapped.west() ||
+                   other.west() < wrapped.east();
+        } else {
+            return other.east() > wrapped.west() &&
+                   other.west() < wrapped.east();
+        }
+    }
+    return false;
 }
 
 ScreenCoordinate EdgeInsets::getCenter(uint16_t width, uint16_t height) const {

--- a/src/mbgl/util/tile_range.hpp
+++ b/src/mbgl/util/tile_range.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <mbgl/tile/tile_id.hpp>
+#include <mbgl/util/range.hpp>
+#include <mbgl/util/geo.hpp>
+#include <mbgl/util/projection.hpp>
+
+namespace mbgl {
+
+namespace util {
+
+class TileRange {
+public:
+    Range<Point<double>> range;
+    uint8_t z;
+
+    // Compute the range of tiles covered by the bounds.
+    static TileRange fromLatLngBounds(const LatLngBounds& bounds, uint8_t z) {
+        auto swProj = Projection::project(bounds.southwest().wrapped(), z);
+        auto ne = bounds.northeast();
+        auto neProj = Projection::project(ne.longitude() > util::LONGITUDE_MAX ? ne.wrapped() : ne , z);
+        const auto minX = std::floor(swProj.x);
+        const auto maxX = std::ceil(neProj.x);
+        const auto minY = std::floor(neProj.y);
+        const auto maxY = std::ceil(swProj.y);
+        return TileRange({ {minX, minY}, {maxX, maxY} }, z);
+    }
+
+    bool contains(const CanonicalTileID& tileID) {
+        return z == tileID.z &&
+        (range.min.x >= range.max.x ? //For wrapped bounds
+            tileID.x >= range.min.x || tileID.x < range.max.x :
+            tileID.x < range.max.x && tileID.x >= range.min.x) &&
+        tileID.y < range.max.y &&
+        tileID.y >= range.min.y;
+    }
+
+private:
+    TileRange(Range<Point<double>> range_, uint8_t z_)
+     : range(range_),
+     z(z_) {
+    }
+    
+};
+
+} // namespace util
+} // namespace mbgl

--- a/test/style/conversion/tileset.test.cpp
+++ b/test/style/conversion/tileset.test.cpp
@@ -1,0 +1,72 @@
+#include <mbgl/test/util.hpp>
+
+#include <mbgl/style/conversion/json.hpp>
+#include <mbgl/style/conversion/tileset.hpp>
+
+#include <mbgl/util/logging.hpp>
+
+using namespace mbgl;
+using namespace mbgl::style::conversion;
+
+TEST(Tileset, Empty) {
+    Error error;
+    mbgl::optional<Tileset> converted = convertJSON<Tileset>("{}", error);
+    EXPECT_FALSE((bool) converted);
+}
+
+TEST(Tileset, ErrorHandling) {
+    Error error;
+    mbgl::optional<Tileset> converted = convertJSON<Tileset>(R"JSON({
+        "tiles": "should not be a string"
+    })JSON", error);
+    EXPECT_FALSE((bool) converted);
+}
+
+TEST(Tileset, InvalidBounds) {
+    {
+        Error error;
+        mbgl::optional<Tileset> converted = convertJSON<Tileset>(R"JSON({
+            "tiles": ["http://mytiles"],
+            "bounds": [73, -180, -73, -120]
+        })JSON", error);
+
+        EXPECT_FALSE((bool) converted);
+    }
+    {
+        Error error;
+        mbgl::optional<Tileset> converted = convertJSON<Tileset>(R"JSON({
+            "tiles": ["http://mytiles"],
+            "bounds": [-120]
+        })JSON", error);
+
+        EXPECT_FALSE((bool) converted);
+    }
+    {
+        Error error;
+        mbgl::optional<Tileset> converted = convertJSON<Tileset>(R"JSON({
+            "tiles": ["http://mytiles"],
+            "bounds": "should not be a string"
+        })JSON", error);
+
+        EXPECT_FALSE((bool) converted);
+    }
+}
+
+TEST(Tileset, FullConversion) {
+    Error error;
+    Tileset converted = *convertJSON<Tileset>(R"JSON({
+        "tiles": ["http://mytiles"],
+        "scheme": "xyz",
+        "minzoom": 1,
+        "maxzoom": 2,
+        "attribution": "mapbox",
+        "bounds": [-180, -73, -120, 73]
+    })JSON", error);
+
+    EXPECT_EQ(converted.tiles[0], "http://mytiles");
+    EXPECT_EQ(converted.scheme, Tileset::Scheme::XYZ);
+    EXPECT_EQ(converted.zoomRange.min, 1);
+    EXPECT_EQ(converted.zoomRange.max, 2);
+    EXPECT_EQ(converted.attribution, "mapbox");
+    EXPECT_EQ(converted.bounds, LatLngBounds::hull({73, -180}, {-73, -120}));
+}

--- a/test/util/tile_range.test.cpp
+++ b/test/util/tile_range.test.cpp
@@ -1,0 +1,56 @@
+
+#include <mbgl/util/tile_range.hpp>
+#include <mbgl/util/geo.hpp>
+#include <mbgl/map/transform.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace mbgl;
+
+TEST(TileRange, ContainsWorld) {
+    auto range = util::TileRange::fromLatLngBounds(LatLngBounds::world(), 0);
+    EXPECT_TRUE(range.contains(CanonicalTileID(0, 0, 0)));
+    EXPECT_FALSE(range.contains(CanonicalTileID(10, 0, 0)));
+}
+
+TEST(TileRange, ContainsBoundsFromTile) {
+    {
+        const LatLngBounds bounds{ CanonicalTileID(3, 7, 0) };
+        auto range = util::TileRange::fromLatLngBounds(bounds, 3);
+        EXPECT_TRUE(range.contains(CanonicalTileID(3, 7, 0)));
+    }
+    {
+        const LatLngBounds bounds{ CanonicalTileID(10, 162, 395) };
+        auto range = util::TileRange::fromLatLngBounds(bounds, 10);
+        EXPECT_TRUE(range.contains(CanonicalTileID(10, 162, 395)));
+    }
+}
+TEST(TileRange, ContainsIntersectingTiles) {
+    auto bounds = LatLngBounds::hull({ 37.6609, -122.5744 }, { 37.8271, -122.3204 });
+    auto range = util::TileRange::fromLatLngBounds(bounds, 13);
+    EXPECT_FALSE(range.contains(CanonicalTileID(13, 1316, 3100)));
+    EXPECT_TRUE(range.contains(CanonicalTileID(13, 1310, 3166)));
+}
+
+TEST(TileRange, ContainsWrappedBounds) {
+    auto wrappedBounds = LatLngBounds::hull({ 37.6609, 237.6796 }, { 37.8271, 237.4256 });
+    auto range = util::TileRange::fromLatLngBounds(wrappedBounds, 13);
+    EXPECT_FALSE(range.contains(CanonicalTileID(13, 1316, 3100)));
+    EXPECT_TRUE(range.contains(CanonicalTileID(13, 1310, 3166)));
+}
+
+TEST(TileRange, ContainsBoundsCrossingAntimeridian) {
+    {
+        auto cossingBounds = LatLngBounds::hull({-20.9615, -214.309}, {19.477, -155.830});
+        auto range = util::TileRange::fromLatLngBounds(cossingBounds, 1);
+        EXPECT_TRUE(range.contains(CanonicalTileID(1, 1, 1)));
+        EXPECT_TRUE(range.contains(CanonicalTileID(1, 0, 0)));
+    }
+    {
+        auto cossingBounds = LatLngBounds::hull({-20.9615, -214.309}, {19.477, -155.830});
+        auto range = util::TileRange::fromLatLngBounds(cossingBounds, 6);
+        EXPECT_FALSE(range.contains(CanonicalTileID(6, 55, 34)));
+        EXPECT_FALSE(range.contains(CanonicalTileID(6, 5, 28)));
+        EXPECT_TRUE(range.contains(CanonicalTileID(6, 63, 28)));
+    }
+}


### PR DESCRIPTION
Cherry-pick TileJSON bounds support to the release-agua branch.

* [x] Cherry-pick #10701
* [x] Cherry-pick #11042
* [x] Cherry-pick #11141