### PR TITLE
Don't recreate TextureView surface as part of view resize

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewRenderThread.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewRenderThread.java
@@ -4,7 +4,6 @@ import android.graphics.SurfaceTexture;
 import android.support.annotation.NonNull;
 import android.support.annotation.UiThread;
 import android.view.TextureView;
-
 import com.mapbox.mapboxsdk.maps.renderer.egl.EGLConfigChooser;
 
 import java.lang.ref.WeakReference;
@@ -219,13 +218,6 @@ class TextureViewRenderThread extends Thread implements TextureView.SurfaceTextu
                 break;
               }
 
-              // Check if the size has changed
-              if (sizeChanged) {
-                recreateSurface = true;
-                sizeChanged = false;
-                break;
-              }
-
               // Reset the request render flag now, so we can catch new requests
               // while rendering
               requestRender = false;
@@ -270,6 +262,12 @@ class TextureViewRenderThread extends Thread implements TextureView.SurfaceTextu
         if (recreateSurface) {
           eglHolder.createSurface();
           mapRenderer.onSurfaceChanged(gl, w, h);
+          continue;
+        }
+
+        if (sizeChanged) {
+          mapRenderer.onSurfaceChanged(gl, w, h);
+          sizeChanged = false;
           continue;
         }
 


### PR DESCRIPTION
This PR decouples surface recreation from View resizing. This resolves the crash shown in #10983 and doesn't impact surface destruction that occurs as part of background/foregrounding the application. This branch was tested on a Samsung S8, J3  and a Google Pixel but considering we might include this in a patch release, we need thorough testing with AWS device farm. 

Closes #10983 
