### PR TITLE
[core] add support for mapzen terrarium

### DIFF
--- a/include/mbgl/util/tileset.hpp
+++ b/include/mbgl/util/tileset.hpp
@@ -14,13 +14,14 @@ namespace mbgl {
 class Tileset {
 public:
     enum class Scheme : bool { XYZ, TMS };
-    enum class Encoding : bool { Mapbox, Terrarium };
+    enum class DEMEncoding : bool { Mapbox, Terrarium };
 
     std::vector<std::string> tiles;
     Range<uint8_t> zoomRange;
     std::string attribution;
     Scheme scheme;
-    Encoding encoding;
+    // DEMEncoding is not supported by the TileJSON spec
+    DEMEncoding encoding;
     optional<LatLngBounds> bounds;
 
 
@@ -28,7 +29,7 @@ public:
             Range<uint8_t> zoomRange_ = { 0, util::DEFAULT_MAX_ZOOM },
             std::string attribution_ = {},
             Scheme scheme_ = Scheme::XYZ,
-            Encoding encoding_ = Encoding::Mapbox)
+            DEMEncoding encoding_ = DEMEncoding::Mapbox)
         : tiles(std::move(tiles_)),
           zoomRange(std::move(zoomRange_)),
           attribution(std::move(attribution_)),

--- a/include/mbgl/util/tileset.hpp
+++ b/include/mbgl/util/tileset.hpp
@@ -14,22 +14,27 @@ namespace mbgl {
 class Tileset {
 public:
     enum class Scheme : bool { XYZ, TMS };
+    enum class Encoding : bool { Mapbox, Terrarium };
 
     std::vector<std::string> tiles;
     Range<uint8_t> zoomRange;
     std::string attribution;
     Scheme scheme;
+    Encoding encoding;
     optional<LatLngBounds> bounds;
+
 
     Tileset(std::vector<std::string> tiles_ = std::vector<std::string>(),
             Range<uint8_t> zoomRange_ = { 0, util::DEFAULT_MAX_ZOOM },
             std::string attribution_ = {},
-            Scheme scheme_ = Scheme::XYZ)
+            Scheme scheme_ = Scheme::XYZ,
+            Encoding encoding_ = Encoding::Mapbox)
         : tiles(std::move(tiles_)),
           zoomRange(std::move(zoomRange_)),
           attribution(std::move(attribution_)),
           scheme(scheme_),
-          bounds() {}
+          encoding(encoding_),
+          bounds() {};
 
     // TileJSON also includes center and zoom but they are not used by mbgl.
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/HillshadeLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/HillshadeLayer.java
@@ -11,7 +11,7 @@ import static com.mapbox.mapboxsdk.utils.ColorUtils.rgbaToColor;
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 
 /**
- * Client-side hillshading visualization based on DEM data. Currently, the implementation only supports Mapbox Terrain RGB tiles
+ * Client-side hillshading visualization based on DEM data. Currently, the implementation only supports Mapbox Terrain RGB and Mapzen Terrarium tiles.
  *
  * @see <a href="https://www.mapbox.com/mapbox-gl-style-spec/#layers-hillshade">The online documentation</a>
  */

--- a/src/mbgl/geometry/dem_data.cpp
+++ b/src/mbgl/geometry/dem_data.cpp
@@ -3,7 +3,7 @@
 
 namespace mbgl {
 
-DEMData::DEMData(const PremultipliedImage& _image):
+DEMData::DEMData(const PremultipliedImage& _image, Tileset::Encoding encoding):
     dim(_image.size.height),
     border(std::max<int32_t>(std::ceil(_image.size.height / 2), 1)),
     stride(dim + 2 * border),
@@ -13,13 +13,22 @@ DEMData::DEMData(const PremultipliedImage& _image):
         throw std::runtime_error("raster-dem tiles must be square.");
     }
 
+    auto decodeRGB = [&] (const uint8_t r, const uint8_t g, const uint8_t b) {
+        if (encoding == Tileset::Encoding::Mapbox) {
+            return (r * 256 * 256 + g * 256 + b)/10 - 10000;
+        } else {
+            // encoding == Tileset::Encoding::Terrarium;
+            return ((r * 256 + g + b / 256) - 32768);
+        }
+    };
+
     std::memset(image.data.get(), 0, image.bytes());
 
     for (int32_t y = 0; y < dim; y++) {
         for (int32_t x = 0; x < dim; x++) {
             const int32_t i = y * dim + x;
             const int32_t j = i * 4;
-            set(x, y, (_image.data[j] * 256 * 256 + _image.data[j+1] * 256 + _image.data[j+2])/10 - 10000);
+            set(x, y, decodeRGB(_image.data[j], _image.data[j+1], _image.data[j+2]));
         }
     }
     

--- a/src/mbgl/geometry/dem_data.cpp
+++ b/src/mbgl/geometry/dem_data.cpp
@@ -3,7 +3,7 @@
 
 namespace mbgl {
 
-DEMData::DEMData(const PremultipliedImage& _image, Tileset::Encoding encoding):
+DEMData::DEMData(const PremultipliedImage& _image, Tileset::DEMEncoding encoding):
     dim(_image.size.height),
     border(std::max<int32_t>(std::ceil(_image.size.height / 2), 1)),
     stride(dim + 2 * border),
@@ -13,14 +13,17 @@ DEMData::DEMData(const PremultipliedImage& _image, Tileset::Encoding encoding):
         throw std::runtime_error("raster-dem tiles must be square.");
     }
 
-    auto decodeRGB = [&] (const uint8_t r, const uint8_t g, const uint8_t b) {
-        if (encoding == Tileset::Encoding::Mapbox) {
-            return (r * 256 * 256 + g * 256 + b)/10 - 10000;
-        } else {
-            // encoding == Tileset::Encoding::Terrarium;
-            return ((r * 256 + g + b / 256) - 32768);
-        }
+    auto decodeMapbox = [] (const uint8_t r, const uint8_t g, const uint8_t b){
+        // https://www.mapbox.com/help/access-elevation-data/#mapbox-terrain-rgb
+        return (r * 256 * 256 + g * 256 + b)/10 - 10000;
     };
+
+    auto decodeTerrarium = [] (const uint8_t r, const uint8_t g, const uint8_t b){
+        // https://aws.amazon.com/public-datasets/terrain/
+        return ((r * 256 + g + b / 256) - 32768);
+    };
+
+    auto decodeRGB = encoding == Tileset::DEMEncoding::Terrarium ? decodeTerrarium : decodeMapbox;
 
     std::memset(image.data.get(), 0, image.bytes());
 

--- a/src/mbgl/geometry/dem_data.hpp
+++ b/src/mbgl/geometry/dem_data.hpp
@@ -13,7 +13,7 @@ namespace mbgl {
 
 class DEMData {
 public:
-    DEMData(const PremultipliedImage& image, Tileset::Encoding encoding);
+    DEMData(const PremultipliedImage& image, Tileset::DEMEncoding encoding);
     void backfillBorder(const DEMData& borderTileData, int8_t dx, int8_t dy);
 
     void set(const int32_t x, const int32_t y, const int32_t value) {

--- a/src/mbgl/geometry/dem_data.hpp
+++ b/src/mbgl/geometry/dem_data.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/math/clamp.hpp>
 #include <mbgl/util/image.hpp>
+#include <mbgl/util/tileset.hpp>
 
 #include <memory>
 #include <array>
@@ -12,7 +13,7 @@ namespace mbgl {
 
 class DEMData {
 public:
-    DEMData(const PremultipliedImage& image);
+    DEMData(const PremultipliedImage& image, Tileset::Encoding encoding);
     void backfillBorder(const DEMData& borderTileData, int8_t dx, int8_t dy);
 
     void set(const int32_t x, const int32_t y, const int32_t value) {

--- a/src/mbgl/renderer/buckets/hillshade_bucket.cpp
+++ b/src/mbgl/renderer/buckets/hillshade_bucket.cpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 using namespace style;
 
-HillshadeBucket::HillshadeBucket(PremultipliedImage&& image_, Tileset::Encoding encoding): demdata(image_, encoding) {
+HillshadeBucket::HillshadeBucket(PremultipliedImage&& image_, Tileset::DEMEncoding encoding): demdata(image_, encoding) {
 }
 
 HillshadeBucket::HillshadeBucket(DEMData&& demdata_) : demdata(std::move(demdata_)) {

--- a/src/mbgl/renderer/buckets/hillshade_bucket.cpp
+++ b/src/mbgl/renderer/buckets/hillshade_bucket.cpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 using namespace style;
 
-HillshadeBucket::HillshadeBucket(PremultipliedImage&& image_): demdata(image_) {
+HillshadeBucket::HillshadeBucket(PremultipliedImage&& image_, Tileset::Encoding encoding): demdata(image_, encoding) {
 }
 
 HillshadeBucket::HillshadeBucket(DEMData&& demdata_) : demdata(std::move(demdata_)) {

--- a/src/mbgl/renderer/buckets/hillshade_bucket.hpp
+++ b/src/mbgl/renderer/buckets/hillshade_bucket.hpp
@@ -8,6 +8,7 @@
 #include <mbgl/renderer/bucket.hpp>
 #include <mbgl/renderer/tile_mask.hpp>
 #include <mbgl/geometry/dem_data.hpp>
+#include <mbgl/util/tileset.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/mat4.hpp>
 #include <mbgl/util/optional.hpp>
@@ -16,8 +17,8 @@ namespace mbgl {
 
 class HillshadeBucket : public Bucket {
 public:
-    HillshadeBucket(PremultipliedImage&&);
-    HillshadeBucket(std::shared_ptr<PremultipliedImage>);
+    HillshadeBucket(PremultipliedImage&&, Tileset::Encoding encoding);
+    HillshadeBucket(std::shared_ptr<PremultipliedImage>, Tileset::Encoding encoding);
     HillshadeBucket(DEMData&&);
 
 

--- a/src/mbgl/renderer/buckets/hillshade_bucket.hpp
+++ b/src/mbgl/renderer/buckets/hillshade_bucket.hpp
@@ -17,8 +17,8 @@ namespace mbgl {
 
 class HillshadeBucket : public Bucket {
 public:
-    HillshadeBucket(PremultipliedImage&&, Tileset::Encoding encoding);
-    HillshadeBucket(std::shared_ptr<PremultipliedImage>, Tileset::Encoding encoding);
+    HillshadeBucket(PremultipliedImage&&, Tileset::DEMEncoding encoding);
+    HillshadeBucket(std::shared_ptr<PremultipliedImage>, Tileset::DEMEncoding encoding);
     HillshadeBucket(DEMData&&);
 
 

--- a/src/mbgl/style/conversion/tileset.cpp
+++ b/src/mbgl/style/conversion/tileset.cpp
@@ -44,7 +44,9 @@ optional<Tileset> Converter<Tileset>::operator()(const Convertible& value, Error
     if (encodingValue) {
         optional<std::string> encoding = toString(*encodingValue);
         if (encoding && *encoding == "terrarium") {
-            result.encoding = Tileset::Encoding::Terrarium;
+            result.encoding = Tileset::DEMEncoding::Terrarium;
+        } else if (encoding && *encoding != "mapbox") {
+            error = { "invalid raster-dem encoding type - valid types are 'mapbox' and 'terrarium' " };
         }
     }
 

--- a/src/mbgl/style/conversion/tileset.cpp
+++ b/src/mbgl/style/conversion/tileset.cpp
@@ -40,6 +40,14 @@ optional<Tileset> Converter<Tileset>::operator()(const Convertible& value, Error
         }
     }
 
+    auto encodingValue = objectMember(value, "encoding");
+    if (encodingValue) {
+        optional<std::string> encoding = toString(*encodingValue);
+        if (encoding && *encoding == "terrarium") {
+            result.encoding = Tileset::Encoding::Terrarium;
+        }
+    }
+
     auto minzoomValue = objectMember(value, "minzoom");
     if (minzoomValue) {
         optional<float> minzoom = toNumber(*minzoomValue);

--- a/src/mbgl/tile/raster_dem_tile.cpp
+++ b/src/mbgl/tile/raster_dem_tile.cpp
@@ -21,6 +21,7 @@ RasterDEMTile::RasterDEMTile(const OverscaledTileID& id_,
       worker(parameters.workerScheduler,
              ActorRef<RasterDEMTile>(*this, mailbox)) {
 
+    encoding = tileset.encoding;
     if ( id.canonical.y == 0 ){
         // this tile doesn't have upper neighboring tiles so marked those as backfilled
         neighboringTiles = neighboringTiles | DEMTileNeighbors::NoUpper;
@@ -47,7 +48,7 @@ void RasterDEMTile::setMetadata(optional<Timestamp> modified_, optional<Timestam
 void RasterDEMTile::setData(std::shared_ptr<const std::string> data) {
     pending = true;
     ++correlationID;
-    worker.invoke(&RasterDEMTileWorker::parse, data, correlationID);
+    worker.invoke(&RasterDEMTileWorker::parse, data, correlationID, encoding);
 }
 
 void RasterDEMTile::onParsed(std::unique_ptr<HillshadeBucket> result, const uint64_t resultCorrelationID) {

--- a/src/mbgl/tile/raster_dem_tile.hpp
+++ b/src/mbgl/tile/raster_dem_tile.hpp
@@ -94,7 +94,7 @@ private:
     Actor<RasterDEMTileWorker> worker;
     
     uint64_t correlationID = 0;
-    Tileset::Encoding encoding;
+    Tileset::DEMEncoding encoding;
 
     // Contains the Bucket object for the tile. Buckets are render
     // objects and they get added by tile parsing operations.

--- a/src/mbgl/tile/raster_dem_tile.hpp
+++ b/src/mbgl/tile/raster_dem_tile.hpp
@@ -94,6 +94,7 @@ private:
     Actor<RasterDEMTileWorker> worker;
     
     uint64_t correlationID = 0;
+    Tileset::Encoding encoding;
 
     // Contains the Bucket object for the tile. Buckets are render
     // objects and they get added by tile parsing operations.

--- a/src/mbgl/tile/raster_dem_tile_worker.cpp
+++ b/src/mbgl/tile/raster_dem_tile_worker.cpp
@@ -10,14 +10,14 @@ RasterDEMTileWorker::RasterDEMTileWorker(ActorRef<RasterDEMTileWorker>, ActorRef
     : parent(std::move(parent_)) {
 }
 
-void RasterDEMTileWorker::parse(std::shared_ptr<const std::string> data, uint64_t correlationID) {
+void RasterDEMTileWorker::parse(std::shared_ptr<const std::string> data, uint64_t correlationID, Tileset::Encoding encoding) {
     if (!data) {
         parent.invoke(&RasterDEMTile::onParsed, nullptr, correlationID); // No data; empty tile.
         return;
     }
 
     try {
-        auto bucket = std::make_unique<HillshadeBucket>(decodeImage(*data));
+        auto bucket = std::make_unique<HillshadeBucket>(decodeImage(*data), encoding);
         parent.invoke(&RasterDEMTile::onParsed, std::move(bucket), correlationID);
     } catch (...) {
         parent.invoke(&RasterDEMTile::onError, std::current_exception(), correlationID);

--- a/src/mbgl/tile/raster_dem_tile_worker.cpp
+++ b/src/mbgl/tile/raster_dem_tile_worker.cpp
@@ -10,7 +10,7 @@ RasterDEMTileWorker::RasterDEMTileWorker(ActorRef<RasterDEMTileWorker>, ActorRef
     : parent(std::move(parent_)) {
 }
 
-void RasterDEMTileWorker::parse(std::shared_ptr<const std::string> data, uint64_t correlationID, Tileset::Encoding encoding) {
+void RasterDEMTileWorker::parse(std::shared_ptr<const std::string> data, uint64_t correlationID, Tileset::DEMEncoding encoding) {
     if (!data) {
         parent.invoke(&RasterDEMTile::onParsed, nullptr, correlationID); // No data; empty tile.
         return;

--- a/src/mbgl/tile/raster_dem_tile_worker.hpp
+++ b/src/mbgl/tile/raster_dem_tile_worker.hpp
@@ -14,7 +14,7 @@ class RasterDEMTileWorker {
 public:
     RasterDEMTileWorker(ActorRef<RasterDEMTileWorker>, ActorRef<RasterDEMTile>);
 
-    void parse(std::shared_ptr<const std::string> data, uint64_t correlationID, Tileset::Encoding encoding);
+    void parse(std::shared_ptr<const std::string> data, uint64_t correlationID, Tileset::DEMEncoding encoding);
 
 private:
     ActorRef<RasterDEMTile> parent;

--- a/src/mbgl/tile/raster_dem_tile_worker.hpp
+++ b/src/mbgl/tile/raster_dem_tile_worker.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/actor/actor_ref.hpp>
+#include <mbgl/util/tileset.hpp>
 
 #include <memory>
 #include <string>
@@ -13,7 +14,7 @@ class RasterDEMTileWorker {
 public:
     RasterDEMTileWorker(ActorRef<RasterDEMTileWorker>, ActorRef<RasterDEMTile>);
 
-    void parse(std::shared_ptr<const std::string> data, uint64_t correlationID);
+    void parse(std::shared_ptr<const std::string> data, uint64_t correlationID, Tileset::Encoding encoding);
 
 private:
     ActorRef<RasterDEMTile> parent;

--- a/test/geometry/dem_data.test.cpp
+++ b/test/geometry/dem_data.test.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/test/util.hpp>
 
 #include <mbgl/util/image.hpp>
+#include <mbgl/util/tileset.hpp>
 #include <mbgl/geometry/dem_data.hpp>
 
 using namespace mbgl;
@@ -16,28 +17,28 @@ auto fakeImage = [](Size s) {
 
 TEST(DEMData, Constructor) {
     PremultipliedImage image = fakeImage({16, 16});
-    DEMData pyramid(image);
+    DEMData demdata(image, Tileset::Encoding::Mapbox);
 
-    EXPECT_EQ(pyramid.dim, 16);
-    EXPECT_EQ(pyramid.border, 8);
-    EXPECT_EQ(pyramid.stride, 32);
-    EXPECT_EQ(pyramid.getImage()->bytes(), size_t(32*32*4));
-    EXPECT_EQ(pyramid.dim, 16);
-    EXPECT_EQ(pyramid.border, 8);
+    EXPECT_EQ(demdata.dim, 16);
+    EXPECT_EQ(demdata.border, 8);
+    EXPECT_EQ(demdata.stride, 32);
+    EXPECT_EQ(demdata.getImage()->bytes(), size_t(32*32*4));
+    EXPECT_EQ(demdata.dim, 16);
+    EXPECT_EQ(demdata.border, 8);
 };
 
 TEST(DEMData, RoundTrip) {
     PremultipliedImage image = fakeImage({16, 16});
-    DEMData pyramid(image);
+    DEMData demdata(image, Tileset::Encoding::Mapbox);
 
-    pyramid.set(4, 6, 255);
-    EXPECT_EQ(pyramid.get(4, 6), 255);
+    demdata.set(4, 6, 255);
+    EXPECT_EQ(demdata.get(4, 6), 255);
 }
 
 TEST(DEMData, InitialBackfill) {
 
     PremultipliedImage image1 = fakeImage({4, 4});
-    DEMData dem1(image1);
+    DEMData dem1(image1, Tileset::Encoding::Mapbox);
 
     bool nonempty = true;
     // checking that a 1 px border around the fake image has been populated
@@ -91,10 +92,10 @@ TEST(DEMData, InitialBackfill) {
 
 TEST(DEMData, BackfillNeighbor) {
     PremultipliedImage image1 = fakeImage({4, 4});
-    DEMData dem0(image1);
+    DEMData dem0(image1, Tileset::Encoding::Mapbox);
 
     PremultipliedImage image2 = fakeImage({4, 4});
-    DEMData dem1(image2);
+    DEMData dem1(image2, Tileset::Encoding::Mapbox);
 
     dem0.backfillBorder(dem1, -1, 0);
     for (int y = 0; y < 4; y++) {

--- a/test/geometry/dem_data.test.cpp
+++ b/test/geometry/dem_data.test.cpp
@@ -23,8 +23,6 @@ TEST(DEMData, ConstructorMapbox) {
     EXPECT_EQ(demdata.border, 8);
     EXPECT_EQ(demdata.stride, 32);
     EXPECT_EQ(demdata.getImage()->bytes(), size_t(32*32*4));
-    EXPECT_EQ(demdata.dim, 16);
-    EXPECT_EQ(demdata.border, 8);
 };
 
 TEST(DEMData, ConstructorTerrarium) {
@@ -35,8 +33,6 @@ TEST(DEMData, ConstructorTerrarium) {
     EXPECT_EQ(demdata.border, 8);
     EXPECT_EQ(demdata.stride, 32);
     EXPECT_EQ(demdata.getImage()->bytes(), size_t(32*32*4));
-    EXPECT_EQ(demdata.dim, 16);
-    EXPECT_EQ(demdata.border, 8);
 };
 
 TEST(DEMData, RoundTrip) {

--- a/test/geometry/dem_data.test.cpp
+++ b/test/geometry/dem_data.test.cpp
@@ -17,7 +17,7 @@ auto fakeImage = [](Size s) {
 
 TEST(DEMData, Constructor) {
     PremultipliedImage image = fakeImage({16, 16});
-    DEMData demdata(image, Tileset::Encoding::Mapbox);
+    DEMData demdata(image, Tileset::DEMEncoding::Mapbox);
 
     EXPECT_EQ(demdata.dim, 16);
     EXPECT_EQ(demdata.border, 8);
@@ -29,7 +29,7 @@ TEST(DEMData, Constructor) {
 
 TEST(DEMData, RoundTrip) {
     PremultipliedImage image = fakeImage({16, 16});
-    DEMData demdata(image, Tileset::Encoding::Mapbox);
+    DEMData demdata(image, Tileset::DEMEncoding::Mapbox);
 
     demdata.set(4, 6, 255);
     EXPECT_EQ(demdata.get(4, 6), 255);
@@ -38,7 +38,7 @@ TEST(DEMData, RoundTrip) {
 TEST(DEMData, InitialBackfill) {
 
     PremultipliedImage image1 = fakeImage({4, 4});
-    DEMData dem1(image1, Tileset::Encoding::Mapbox);
+    DEMData dem1(image1, Tileset::DEMEncoding::Mapbox);
 
     bool nonempty = true;
     // checking that a 1 px border around the fake image has been populated
@@ -92,10 +92,10 @@ TEST(DEMData, InitialBackfill) {
 
 TEST(DEMData, BackfillNeighbor) {
     PremultipliedImage image1 = fakeImage({4, 4});
-    DEMData dem0(image1, Tileset::Encoding::Mapbox);
+    DEMData dem0(image1, Tileset::DEMEncoding::Mapbox);
 
     PremultipliedImage image2 = fakeImage({4, 4});
-    DEMData dem1(image2, Tileset::Encoding::Mapbox);
+    DEMData dem1(image2, Tileset::DEMEncoding::Mapbox);
 
     dem0.backfillBorder(dem1, -1, 0);
     for (int y = 0; y < 4; y++) {

--- a/test/geometry/dem_data.test.cpp
+++ b/test/geometry/dem_data.test.cpp
@@ -15,9 +15,21 @@ auto fakeImage = [](Size s) {
     return img;
 };
 
-TEST(DEMData, Constructor) {
+TEST(DEMData, ConstructorMapbox) {
     PremultipliedImage image = fakeImage({16, 16});
     DEMData demdata(image, Tileset::DEMEncoding::Mapbox);
+
+    EXPECT_EQ(demdata.dim, 16);
+    EXPECT_EQ(demdata.border, 8);
+    EXPECT_EQ(demdata.stride, 32);
+    EXPECT_EQ(demdata.getImage()->bytes(), size_t(32*32*4));
+    EXPECT_EQ(demdata.dim, 16);
+    EXPECT_EQ(demdata.border, 8);
+};
+
+TEST(DEMData, ConstructorTerrarium) {
+    PremultipliedImage image = fakeImage({16, 16});
+    DEMData demdata(image, Tileset::DEMEncoding::Terrarium);
 
     EXPECT_EQ(demdata.dim, 16);
     EXPECT_EQ(demdata.border, 8);

--- a/test/tile/raster_dem_tile.test.cpp
+++ b/test/tile/raster_dem_tile.test.cpp
@@ -62,7 +62,7 @@ TEST(RasterDEMTile, onError) {
 TEST(RasterDEMTile, onParsed) {
     RasterDEMTileTest test;
     RasterDEMTile tile(OverscaledTileID(0, 0, 0), test.tileParameters, test.tileset);
-    tile.onParsed(std::make_unique<HillshadeBucket>(PremultipliedImage({16, 16}), Tileset::Encoding::Mapbox), 0);
+    tile.onParsed(std::make_unique<HillshadeBucket>(PremultipliedImage({16, 16}), Tileset::DEMEncoding::Mapbox), 0);
     EXPECT_TRUE(tile.isRenderable());
     EXPECT_TRUE(tile.isLoaded());
     EXPECT_TRUE(tile.isComplete());

--- a/test/tile/raster_dem_tile.test.cpp
+++ b/test/tile/raster_dem_tile.test.cpp
@@ -62,7 +62,7 @@ TEST(RasterDEMTile, onError) {
 TEST(RasterDEMTile, onParsed) {
     RasterDEMTileTest test;
     RasterDEMTile tile(OverscaledTileID(0, 0, 0), test.tileParameters, test.tileset);
-    tile.onParsed(std::make_unique<HillshadeBucket>(PremultipliedImage({16, 16})), 0);
+    tile.onParsed(std::make_unique<HillshadeBucket>(PremultipliedImage({16, 16}), Tileset::Encoding::Mapbox), 0);
     EXPECT_TRUE(tile.isRenderable());
     EXPECT_TRUE(tile.isLoaded());
     EXPECT_TRUE(tile.isComplete());


### PR DESCRIPTION
port of https://github.com/mapbox/mapbox-gl-js/pull/6110 adding support for mapzen terrarium encoded dem RGB tiles.

ended up `#include`ing `Tileset` all over the place because it seemed like the place we store top-level source keys like `encoding`, but not sure this is the best approach – happy to hear suggestions of alternatives.

closes #11204 