### PR TITLE
Update & simplify INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,8 +18,8 @@ operating system and what platform you want to develop for.
  1. Install [Xcode](https://developer.apple.com/xcode/)
  2. Launch Xcode and install any updates
  3. Install [Homebrew](http://brew.sh)
- 4. Install [Node.js](https://nodejs.org/), [ruby](https://www.ruby-lang.org/), [CMake](https://cmake.org/), and [ccache](https://ccache.samba.org) (`brew install nodejs ruby cmake ccache`)
- 5. Install [xcpretty](https://github.com/supermarin/xcpretty) (`gem install xcpretty`)
+ 4. Install [Node.js](https://nodejs.org/), [CMake](https://cmake.org/), and [ccache](https://ccache.samba.org) with `brew install nodejs cmake ccache`
+ 5. Install [xcpretty](https://github.com/supermarin/xcpretty) with `[sudo] gem install xcpretty` (optional, used for prettifying command line builds)
 
 ### Linux
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,9 +16,10 @@ operating system and what platform you want to develop for.
 ### macOS
 
  1. Install [Xcode](https://developer.apple.com/xcode/)
- 2. Install [Homebrew](http://brew.sh)
- 3. Install [Node.js](https://nodejs.org/), [ruby](https://www.ruby-lang.org/), [CMake](https://cmake.org/), and [ccache](https://ccache.samba.org) (`brew install nodejs ruby cmake ccache`)
- 4. Install [xcpretty](https://github.com/supermarin/xcpretty) (`gem install xcpretty`)
+ 2. Launch Xcode and install any updates
+ 3. Install [Homebrew](http://brew.sh)
+ 4. Install [Node.js](https://nodejs.org/), [ruby](https://www.ruby-lang.org/), [CMake](https://cmake.org/), and [ccache](https://ccache.samba.org) (`brew install nodejs ruby cmake ccache`)
+ 5. Install [xcpretty](https://github.com/supermarin/xcpretty) (`gem install xcpretty`)
 
 ### Linux
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,50 +7,37 @@ that you can download instantly and get started with fast](https://www.mapbox.co
 Still with us? These are the instructions you'll need to build Mapbox GL Native
 from source on a variety of platforms and set up a development environment.
 
-Your journey will start with getting the source code, then installing the
-dependencies, and then setting up a development environment, which varies
-depending on your operating system and what platform you want to develop for.
+Your journey will start with installing dependencies, then getting the source code, and
+then setting up a development environment, which varies depending on your
+operating system and what platform you want to develop for.
 
-## 1: Getting the source
+## 1: Installing dependencies
 
-Clone the git repository:
+### macOS
 
-    git clone https://github.com/mapbox/mapbox-gl-native.git
-    cd mapbox-gl-native
+ 1. Install [Xcode](https://developer.apple.com/xcode/)
+ 2. Install [Homebrew](http://brew.sh)
+ 3. Install [Node.js](https://nodejs.org/), [ruby](https://www.ruby-lang.org/), [CMake](https://cmake.org/), and [ccache](https://ccache.samba.org) (`brew install nodejs ruby cmake ccache`)
+ 4. Install [xcpretty](https://github.com/supermarin/xcpretty) (`gem install xcpretty`)
 
-## 2: Installing dependencies
+### Linux
 
-These dependencies are required for all operating systems and all platform
-targets.
+Install the following:
 
- - Modern C++ compiler that supports `-std=c++14`\*
-   - clang++ 3.5 or later _or_
-   - g++-4.9 or later
- - [CMake](https://cmake.org/) 3.1 or later (for build only)
- - [cURL](https://curl.haxx.se) (for build only)
- - [Node.js](https://nodejs.org/) 4.2.1 or later (for build only)
- - [`pkg-config`](https://wiki.freedesktop.org/www/Software/pkg-config/) (for build only)
-
-**Note**: We partially support C++14 because GCC 4.9 does not fully implement the
-final draft of the C++14 standard. More information in [DEVELOPING.md](DEVELOPING.md).
-
-Depending on your operating system and target, you'll need additional
-dependencies:
-
-### Additional dependencies for Linux
-
+ - `clang++` 3.5 or later or `g++` 4.9 or later
+ - [git](https://git-scm.com/)
+ - [CMake](https://cmake.org/) 3.1 or later
+ - [cURL](https://curl.haxx.se)
+ - [Node.js](https://nodejs.org/) 4.2.1 or later
  - [`libcurl`](http://curl.haxx.se/libcurl/) (depends on OpenSSL)
+ - [ccache](https://ccache.samba.org) (optional, improves recompilation performance)
 
-### Additional dependencies for macOS
+## 2: Getting the source
 
- - Apple Command Line Tools (available at [Apple Developer](https://developer.apple.com/download/more/))
- - [Homebrew](http://brew.sh)
- - [Cask](http://caskroom.io/) (if building for Android)
- - [xcpretty](https://github.com/supermarin/xcpretty) (`gem install xcpretty`)
+ Clone the git repository:
 
-### Optional dependencies
-
-- [ccache](https://ccache.samba.org) (for build only; improves recompilation performance)
+     git clone https://github.com/mapbox/mapbox-gl-native.git
+     cd mapbox-gl-native
 
 ## 3: Setting up a development environment & building
 
@@ -58,7 +45,7 @@ See the relevant SDK documentation for next steps:
 
 * [Maps SDK for Android](platform/android/)
 * [Maps SDK for iOS](platform/ios/)
-* [Maps SDK for iOS](platform/macos/)
+* [Maps SDK for macOS](platform/macos/)
 * [Mapbox Qt SDK](platform/qt/)
 * [Mapbox GL Native on Linux](platform/linux/)
 * [node-mapbox-gl-native](platform/node/)


### PR DESCRIPTION
While setting up `mapbox-gl-native` locally, I made some updates and simplifications to `INSTALL.md`

 - I moved "Getting the source" after "Installing dependencies" because some users may not have `git` installed initially
 - I split the "Installing dependencies" section into two, with simple platform-specific instructions in each.
 - I removed some useful but extraneous information from this file. (I may not be the best judge of what's extraneous, please share your thoughts)
 - I fixed some link text in the "Setting up a development environment & building" section (iOS -> macOS)