### PR TITLE
[core, android] added tileCount to OfflineRegion.

### DIFF
--- a/include/mbgl/storage/offline.hpp
+++ b/include/mbgl/storage/offline.hpp
@@ -13,6 +13,7 @@
 namespace mbgl {
 
 class TileID;
+class LatLngBounds;
 
 /*
  * An offline region defined by a style URL, geographic bounding box, zoom range, and
@@ -197,6 +198,9 @@ public:
     int64_t getID() const;
     const OfflineRegionDefinition& getDefinition() const;
     const OfflineRegionMetadata& getMetadata() const;
+
+    // Compute only the count of tiles needed for tileCover
+    uint64_t getTileCount(const LatLngBounds&, uint8_t zoom, uint16_t tileSize) const;
 
 private:
     friend class OfflineDatabase;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegion.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegion.java
@@ -8,6 +8,7 @@ import android.support.annotation.Nullable;
 
 import com.mapbox.mapboxsdk.LibraryLoader;
 import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.geometry.LatLngBounds;
 import com.mapbox.mapboxsdk.storage.FileSource;
 
 import java.lang.annotation.Retention;
@@ -399,6 +400,20 @@ public class OfflineRegion {
     });
   }
 
+  /**
+   * Gets the tile count.
+   *
+   * @param zoomLevel zoom level of the map (?)
+   * @param tileSize size of tiles (?)
+   * @return the tile count
+   */
+  public long getTileCount(byte zoomLevel, int tileSize) {
+    if (getDefinition() == null) {
+      throw new RuntimeException("OfflineRegion is not loaded yet.");
+    }
+    return tileCount(getDefinition().getBounds(), zoomLevel, tileSize);
+  }
+
   private native void initialize(long offlineRegionPtr, FileSource fileSource);
 
   @Override
@@ -414,4 +429,5 @@ public class OfflineRegion {
 
   private native void updateOfflineRegionMetadata(byte[] metadata, OfflineRegionUpdateMetadataCallback callback);
 
+  private native long tileCount(LatLngBounds bounds, byte zoomLevel, int tileSize);
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/offline/OfflineActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/offline/OfflineActivity.java
@@ -175,7 +175,8 @@ public class OfflineActivity extends AppCompatActivity
         // Get regions info
         ArrayList<String> offlineRegionsNames = new ArrayList<>();
         for (OfflineRegion offlineRegion : offlineRegions) {
-          offlineRegionsNames.add(OfflineUtils.convertRegionName(offlineRegion.getMetadata()));
+          long tileCount = offlineRegion.getTileCount((byte) mapboxMap.getMinZoomLevel(), 256 );
+          offlineRegionsNames.add(OfflineUtils.convertRegionName(offlineRegion.getMetadata()) + " TileCount: " + tileCount);
         }
 
         // Create args

--- a/platform/android/src/offline/offline_region.cpp
+++ b/platform/android/src/offline/offline_region.cpp
@@ -8,6 +8,7 @@
 #include "offline_region_status.hpp"
 #include "../attach_env.hpp"
 #include "../jni/generic_global_ref_deleter.hpp"
+#include "../geometry/lat_lng_bounds.hpp"
 
 namespace mbgl {
 namespace android {
@@ -214,7 +215,8 @@ void OfflineRegion::registerNative(jni::JNIEnv& env) {
         METHOD(&OfflineRegion::setOfflineRegionDownloadState, "setOfflineRegionDownloadState"),
         METHOD(&OfflineRegion::getOfflineRegionStatus, "getOfflineRegionStatus"),
         METHOD(&OfflineRegion::deleteOfflineRegion, "deleteOfflineRegion"),
-        METHOD(&OfflineRegion::updateOfflineRegionMetadata, "updateOfflineRegionMetadata")
+        METHOD(&OfflineRegion::updateOfflineRegionMetadata, "updateOfflineRegionMetadata"),
+        METHOD(&OfflineRegion::tileCount, "tileCount")
     );
 }
 
@@ -303,6 +305,13 @@ void OfflineRegion::OfflineRegionUpdateMetadataCallback::onUpdate(jni::JNIEnv& e
     callback.Call(env, method, jMetadata);
     jni::DeleteLocalRef(env, jMetadata);
 }
+
+jni::jlong OfflineRegion::tileCount(jni::JNIEnv& env, jni::Object<mbgl::android::LatLngBounds> jBounds, jni::jbyte zoom, jni::jint tileSize) {
+    auto bounds = LatLngBounds::getLatLngBounds(env, jBounds);
+    auto tileCount = region->getTileCount(bounds, zoom, tileSize);
+    return tileCount;
+}
+
 
 } // namespace android
 } // namespace mbgl

--- a/platform/android/src/offline/offline_region.hpp
+++ b/platform/android/src/offline/offline_region.hpp
@@ -4,6 +4,7 @@
 #include <jni/jni.hpp>
 
 #include "../file_source.hpp"
+#include "../geometry/lat_lng_bounds.hpp"
 
 #include <memory>
 
@@ -79,6 +80,8 @@ public:
     void deleteOfflineRegion(jni::JNIEnv&, jni::Object<OfflineRegionDeleteCallback>);
 
     void updateOfflineRegionMetadata(jni::JNIEnv&, jni::Array<jni::jbyte>, jni::Object<OfflineRegionUpdateMetadataCallback>);
+
+    jni::jlong tileCount(jni::JNIEnv&, jni::Object<mbgl::android::LatLngBounds> bounds, jni::jbyte zoom, jni::jint tileSize);
 
     static jni::Object<OfflineRegion> New(jni::JNIEnv&, jni::Object<FileSource>, mbgl::OfflineRegion);
 

--- a/platform/default/mbgl/storage/offline.cpp
+++ b/platform/default/mbgl/storage/offline.cpp
@@ -136,4 +136,26 @@ int64_t OfflineRegion::getID() const {
     return id;
 }
 
+// Taken from https://github.com/mapbox/sphericalmercator#xyzbbox-zoom-tms_style-srs
+// Computes the projected tiles for the lower left and upper right points of the bounds
+// and uses that to compute the tile cover count
+//
+uint64_t OfflineRegion::getTileCount(const LatLngBounds& bounds, uint8_t zoom, uint16_t tileSize_) const {
+
+        auto sw = Projection::project(bounds.southwest().wrapped(), zoom, tileSize_);
+        auto ne = Projection::project(bounds.northeast().wrapped(), zoom, tileSize_);
+
+        auto x1 = floor(sw.x/ tileSize_);
+        auto x2 = floor((ne.x - 1) / tileSize_);
+        auto y1 = floor(sw.y/ tileSize_);
+        auto y2 = floor((ne.y - 1) / tileSize_);
+
+        auto minX = ::fmax(std::min(x1, x2), 0);
+        auto maxX = std::max(x1, x2);
+        auto minY = (std::pow(2, zoom) - 1) - std::max(y1, y2);
+        auto maxY = (std::pow(2, zoom) - 1) - ::fmax(std::min(y1, y2), 0);
+
+        return (maxX - minX + 1) * (maxY - minY + 1);
+    }
+
 } // namespace mbgl


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gl-native/issues/11108

* Added `public long getTileCount(byte zoomLevel, int tileSize)` method to `OfflineRegion`
    * The core implementation of `util::tileCount` is not accessible from Android because it is in `src` and not exposed
    * So as a workaround, the core implementation was copied over to Android platform's C++ code
    * Added Java-C++ binding code.
* Updated test app for `OfflineActivity` to test the new method. Ran the test app on Android Nougat.
* Verified by calling the method with same test data as in https://github.com/mapbox/mapbox-gl-native/blob/50fd9175109e01c5286d3363df21aeba6e89087b/test/util/tile_cover.test.cpp#L88
* The `getTileCount` can be enhanced to take in a range for the zoom levels.