### PR TITLE
Release android v5.4.1

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Mapbox welcomes participation and contributions from everyone.  If you'd like to do so please see the [`Contributing Guide`](https://github.com/mapbox/mapbox-gl-native/blob/master/CONTRIBUTING.md) first to get started.
 
+## 5.4.1 - February 9, 2018
+ - Don't recreate TextureView surface as part of view resizing, solves OOM crashes [#11148](https://github.com/mapbox/mapbox-gl-native/pull/11148)
+ - Don't invoke OnLowMemory before map is ready, solves startup crash on low memory devices [#11109](https://github.com/mapbox/mapbox-gl-native/pull/11109)
+ - Programmatically create GLSurfaceView, solves fragment bug [#11124](https://github.com/mapbox/mapbox-gl-native/pull/11124)
+ - Proguard config for optional location provider, solves obfuscation warnings [#11127](https://github.com/mapbox/mapbox-gl-native/pull/11127)
+ - MapView weak reference in global layout listener, solves memory leak [#11128](https://github.com/mapbox/mapbox-gl-native/pull/11128)
+
 ## 5.4.0 - January 30, 2018
  - Blacklist Adreno 2xx GPU for VAO support [#11047](https://github.com/mapbox/mapbox-gl-native/pull/11047)
  - Bearing tracking mode GPS_NORTH_FACING [#11095](https://github.com/mapbox/mapbox-gl-native/pull/11095)

--- a/platform/android/MapboxGLAndroidSDK/gradle.properties
+++ b/platform/android/MapboxGLAndroidSDK/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.mapbox.mapboxsdk
-VERSION_NAME=5.4.1-SNAPSHOT
+VERSION_NAME=5.4.2-SNAPSHOT
 
 POM_DESCRIPTION=Mapbox GL Android SDK
 POM_URL=https://github.com/mapbox/mapbox-gl-native

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -477,7 +477,9 @@ public class MapView extends FrameLayout {
    */
   @UiThread
   public void onLowMemory() {
-    nativeMapView.onLowMemory();
+    if (nativeMapView != null) {
+      nativeMapView.onLowMemory();
+    }
   }
 
   /**


### PR DESCRIPTION
Refs #11162, this PR releases the v5.4.1 of the SDK, additionally it cherry-picks https://github.com/mapbox/mapbox-gl-native/pull/11163/commits/18eebcc47752d02f72b131682a08cc3cebd8fb08 and https://github.com/mapbox/mapbox-gl-native/pull/11109/commits/013965890b82cf67fb4a10ebbeb0eae8d84006b4. Other changes for this release were already on `release-agua`, note that these need to be cherry-picked to release-boba. 

 - [x] update release configuration & release to maven
 - [x] update to cn config & release
 - [x] reset configuration to default