### PR TITLE
TileJSON Bounds allows values inclusive of world extents

### DIFF
--- a/src/mbgl/style/conversion/tileset.cpp
+++ b/src/mbgl/style/conversion/tileset.cpp
@@ -6,7 +6,7 @@ namespace style {
 namespace conversion {
 
 bool validateLatitude(const double lat) {
-    return lat < 90 && lat > -90;
+    return lat <= 90 && lat >= -90;
 }
 
 optional<Tileset> Converter<Tileset>::operator()(const Convertible& value, Error& error) const {

--- a/test/style/conversion/tileset.test.cpp
+++ b/test/style/conversion/tileset.test.cpp
@@ -52,6 +52,16 @@ TEST(Tileset, InvalidBounds) {
     }
 }
 
+TEST(Tileset, ValidWorldBounds) {
+    Error error;
+    mbgl::optional<Tileset> converted = convertJSON<Tileset>(R"JSON({
+        "tiles": ["http://mytiles"],
+        "bounds": [-180, -90, 180, 90]
+    })JSON", error);
+    EXPECT_TRUE((bool) converted);
+    EXPECT_EQ(converted->bounds, LatLngBounds::hull({90, -180}, {-90, 180}));
+}
+
 TEST(Tileset, FullConversion) {
     Error error;
     Tileset converted = *convertJSON<Tileset>(R"JSON({


### PR DESCRIPTION
TileJSON spec allows Bounds to be inclusive of world extents [-180 -90, 18, 90]
