### PR TITLE
Deprecate Mapbox locationengine

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
@@ -139,8 +139,10 @@ public final class Mapbox {
    * Returns the location engine used by the SDK.
    *
    * @return the location engine configured
+   * @deprecated use location layer plugin from
+   * https://github.com/mapbox/mapbox-plugins-android/tree/master/plugins/locationlayer instead.
    */
-  // TODO Do we need to expose this?
+  @Deprecated
   public static LocationEngine getLocationEngine() {
     return INSTANCE.locationEngine;
   }


### PR DESCRIPTION
With https://github.com/mapbox/mapbox-gl-native/pull/9771 we deprecated MyLocationView and other location related APIs. We seem to have forgotten to deprecate the `LocationSource` found in `Mapbox.java`