### PR TITLE
Remove lost dependency from SDK

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -7,11 +7,6 @@ dependencies {
     implementation dependenciesList.supportFragmentV4
     implementation dependenciesList.timber
     implementation dependenciesList.okhttp3
-    compileOnly(dependenciesList.lost) {
-        exclude group: 'com.google.guava'
-        exclude group: 'com.android.support'
-    }
-    testImplementation dependenciesList.lost
     testImplementation dependenciesList.junit
     testImplementation dependenciesList.mockito
     testImplementation dependenciesList.robolectric

--- a/platform/android/MapboxGLAndroidSDK/proguard-rules.pro
+++ b/platform/android/MapboxGLAndroidSDK/proguard-rules.pro
@@ -13,6 +13,3 @@
 -dontwarn okio.**
 -dontwarn javax.annotation.Nullable
 -dontwarn javax.annotation.ParametersAreNonnullByDefault
-
-# config for optional location provider https://github.com/mapbox/mapbox-gl-native/issues/10960
--dontwarn com.mapzen.android.lost.api**


### PR DESCRIPTION
We were still using a compileOnly dependency on lost. This PR removes it from the SDK. 
