### PR TITLE
Revert to ImageView

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/CompassView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/CompassView.java
@@ -1,15 +1,16 @@
 package com.mapbox.mapboxsdk.maps.widgets;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
 import android.support.v4.view.ViewCompat;
 import android.support.v4.view.ViewPropertyAnimatorCompat;
 import android.support.v4.view.ViewPropertyAnimatorListenerAdapter;
-import android.support.v7.widget.AppCompatImageView;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 
@@ -22,7 +23,8 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
  * use {@link com.mapbox.mapboxsdk.maps.UiSettings}.
  * </p>
  */
-public final class CompassView extends AppCompatImageView implements Runnable {
+@SuppressLint("AppCompatCustomView")
+public final class CompassView extends ImageView implements Runnable {
 
   public static final long TIME_WAIT_IDLE = 500;
   public static final long TIME_MAP_NORTH_ANIMATION = 150;


### PR DESCRIPTION
This PR reverts using ImageView instead of AppCompatImageView. While it's best practice to use AppCompatImageViews for custom views (to enable automatic tinting). It also requires adding the design/appcompat library to the end user application. Often for customers in cn, this was perceived as an issue. To me the customer requests outways the functionality of automatic tinting (eg. attribution icon). In https://github.com/mapbox/mapbox-gl-native/pull/10268 we addressed his by moving to ImageView instead. 