### PR TITLE
[ios] Various test and warning fixes for backwards compatibility

### DIFF
--- a/platform/darwin/test/MGLCoordinateFormatterTests.m
+++ b/platform/darwin/test/MGLCoordinateFormatterTests.m
@@ -24,7 +24,12 @@
     coordinate = CLLocationCoordinate2DMake(38.9131982, -77.0325453144239);
     XCTAssertEqualObjects([shortFormatter stringFromCoordinate:coordinate], @"38°54′48″N, 77°1′57″W");
     XCTAssertEqualObjects([mediumFormatter stringFromCoordinate:coordinate], @"38°54′48″ north, 77°1′57″ west");
-    XCTAssertEqualObjects([longFormatter stringFromCoordinate:coordinate], @"38 degrees, 54 minutes, and 48 seconds north by 77 degrees, 1 minute, and 57 seconds west");
+    if (@available(iOS 9.0, *)) {
+        XCTAssertEqualObjects([longFormatter stringFromCoordinate:coordinate], @"38 degrees, 54 minutes, and 48 seconds north by 77 degrees, 1 minute, and 57 seconds west");
+    } else {
+        // Foundation in iOS 8 does not know how to pluralize coordinates.
+        XCTAssertEqualObjects([longFormatter stringFromCoordinate:coordinate], @"38 degree(s), 54 minute(s), and 48 second(s) north by 77 degree(s), 1 minute(s), and 57 second(s) west");
+    }
 
     shortFormatter.allowsSeconds = NO;
     mediumFormatter.allowsSeconds = NO;
@@ -33,7 +38,12 @@
     coordinate = CLLocationCoordinate2DMake(38.9131982, -77.0325453144239);
     XCTAssertEqualObjects([shortFormatter stringFromCoordinate:coordinate], @"38°55′N, 77°2′W");
     XCTAssertEqualObjects([mediumFormatter stringFromCoordinate:coordinate], @"38°55′ north, 77°2′ west");
-    XCTAssertEqualObjects([longFormatter stringFromCoordinate:coordinate], @"38 degrees and 55 minutes north by 77 degrees and 2 minutes west");
+    if (@available(iOS 9.0, *)) {
+        XCTAssertEqualObjects([longFormatter stringFromCoordinate:coordinate], @"38 degrees and 55 minutes north by 77 degrees and 2 minutes west");
+    } else {
+        // Foundation in iOS 8 does not know how to pluralize coordinates.
+        XCTAssertEqualObjects([longFormatter stringFromCoordinate:coordinate], @"38 degree(s) and 55 minute(s) north by 77 degree(s) and 2 minute(s) west");
+    }
 
     shortFormatter.allowsMinutes = NO;
     mediumFormatter.allowsMinutes = NO;
@@ -42,7 +52,12 @@
     coordinate = CLLocationCoordinate2DMake(38.9131982, -77.0325453144239);
     XCTAssertEqualObjects([shortFormatter stringFromCoordinate:coordinate], @"39°N, 77°W");
     XCTAssertEqualObjects([mediumFormatter stringFromCoordinate:coordinate], @"39° north, 77° west");
-    XCTAssertEqualObjects([longFormatter stringFromCoordinate:coordinate], @"39 degrees north by 77 degrees west");
+    if (@available(iOS 9.0, *)) {
+        XCTAssertEqualObjects([longFormatter stringFromCoordinate:coordinate], @"39 degrees north by 77 degrees west");
+    } else {
+        // Foundation in iOS 8 does not know how to pluralize coordinates.
+        XCTAssertEqualObjects([longFormatter stringFromCoordinate:coordinate], @"39 degree(s) north by 77 degree(s) west");
+    }
 }
 
 @end

--- a/platform/darwin/test/MGLDocumentationExampleTests.swift
+++ b/platform/darwin/test/MGLDocumentationExampleTests.swift
@@ -391,7 +391,7 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
         }
         //#-end-example-code
         
-        wait(for: [expectation], timeout: 1)
+        wait(for: [expectation], timeout: 5)
     }
     
     // For testMGLMapView().

--- a/platform/darwin/test/MGLExpressionTests.mm
+++ b/platform/darwin/test/MGLExpressionTests.mm
@@ -573,23 +573,27 @@ using namespace std::string_literals;
 }
 
 - (void)testConditionalExpressionObject {
-    {
-        NSPredicate *conditional = [NSPredicate predicateWithFormat:@"1 = 2"];
-        NSExpression *trueExpression = [NSExpression expressionForConstantValue:@YES];
-        NSExpression *falseExpression = [NSExpression expressionForConstantValue:@NO];
-        NSExpression *expression = [NSExpression expressionForConditional:conditional trueExpression:trueExpression falseExpression:falseExpression];
-        NSArray *jsonExpression = @[@"case", @[@"==", @1, @2], @YES, @NO];
-        XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
-        XCTAssertEqualObjects([NSExpression expressionWithFormat:@"TERNARY(1 = 2, TRUE, FALSE)"].mgl_jsonExpressionObject, jsonExpression);
-        XCTAssertEqualObjects([expression expressionValueWithObject:nil context:nil], @NO);
-        XCTAssertEqualObjects([NSExpression mgl_expressionWithJSONObject:jsonExpression], expression);
-    }
-    {
-        NSExpression *expression = [NSExpression expressionWithFormat:@"TERNARY(0 = 1, TRUE, TERNARY(1 = 2, TRUE, FALSE))"];
-        NSArray *jsonExpression = @[@"case", @[@"==", @0, @1], @YES, @[@"==", @1, @2], @YES, @NO];
-        XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
-        XCTAssertEqualObjects([expression expressionValueWithObject:nil context:nil], @NO);
-        XCTAssertEqualObjects([NSExpression mgl_expressionWithJSONObject:jsonExpression], expression);
+    // FIXME: This test crashes because iOS 8 doesn't have `+[NSExpression expressionForConditional:trueExpression:falseExpression:]`.
+    // https://github.com/mapbox/mapbox-gl-native/issues/11007
+    if (@available(iOS 9.0, *)) {
+        {
+            NSPredicate *conditional = [NSPredicate predicateWithFormat:@"1 = 2"];
+            NSExpression *trueExpression = [NSExpression expressionForConstantValue:@YES];
+            NSExpression *falseExpression = [NSExpression expressionForConstantValue:@NO];
+            NSExpression *expression = [NSExpression expressionForConditional:conditional trueExpression:trueExpression falseExpression:falseExpression];
+            NSArray *jsonExpression = @[@"case", @[@"==", @1, @2], @YES, @NO];
+            XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
+            XCTAssertEqualObjects([NSExpression expressionWithFormat:@"TERNARY(1 = 2, TRUE, FALSE)"].mgl_jsonExpressionObject, jsonExpression);
+            XCTAssertEqualObjects([expression expressionValueWithObject:nil context:nil], @NO);
+            XCTAssertEqualObjects([NSExpression mgl_expressionWithJSONObject:jsonExpression], expression);
+        }
+        {
+            NSExpression *expression = [NSExpression expressionWithFormat:@"TERNARY(0 = 1, TRUE, TERNARY(1 = 2, TRUE, FALSE))"];
+            NSArray *jsonExpression = @[@"case", @[@"==", @0, @1], @YES, @[@"==", @1, @2], @YES, @NO];
+            XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
+            XCTAssertEqualObjects([expression expressionValueWithObject:nil context:nil], @NO);
+            XCTAssertEqualObjects([NSExpression mgl_expressionWithJSONObject:jsonExpression], expression);
+        }
     }
 }
 

--- a/platform/darwin/test/MGLFeatureTests.mm
+++ b/platform/darwin/test/MGLFeatureTests.mm
@@ -298,29 +298,36 @@
 }
 
 - (void)testShapeCollectionFeatureGeoJSONDictionary {
-    MGLPointAnnotation *pointFeature = [[MGLPointAnnotation alloc] init];
+    MGLPointFeature *pointFeature = [[MGLPointFeature alloc] init];
     CLLocationCoordinate2D pointCoordinate = { 10, 10 };
     pointFeature.coordinate = pointCoordinate;
 
     CLLocationCoordinate2D coord1 = { 0, 0 };
     CLLocationCoordinate2D coord2 = { 10, 10 };
     CLLocationCoordinate2D coords[] = { coord1, coord2 };
-    MGLPolyline *polyline = [MGLPolyline polylineWithCoordinates:coords count:2];
+    MGLPolylineFeature *polylineFeature = [MGLPolylineFeature polylineWithCoordinates:coords count:2];
 
-    MGLShapeCollectionFeature *shapeCollectionFeature = [MGLShapeCollectionFeature shapeCollectionWithShapes:@[pointFeature,
-                                                                                                             polyline]];
+    MGLShapeCollectionFeature *shapeCollectionFeature = [MGLShapeCollectionFeature shapeCollectionWithShapes:@[pointFeature, polylineFeature]];
+
     // A GeoJSON feature
     NSDictionary *geoJSONFeature = [shapeCollectionFeature geoJSONDictionary];
 
     // it has the correct geometry
     NSDictionary *expectedGeometry = @{@"type": @"GeometryCollection",
                                        @"geometries": @[
-                                                         @{@"type": @"Point",
-                                                           @"coordinates": @[@(pointCoordinate.longitude), @(pointCoordinate.latitude)]},
-                                                         @{@"type": @"LineString",
-                                                           @"coordinates": @[@[@(coord1.longitude), @(coord1.latitude)],
-                                                                             @[@(coord2.longitude), @(coord2.latitude)]]}
-                                                       ]};
+                                           @{ @"geometry": @{@"type": @"Point",
+                                                             @"coordinates": @[@(pointCoordinate.longitude), @(pointCoordinate.latitude)]},
+                                              @"properties": [NSNull null],
+                                              @"type": @"Feature",
+                                             },
+                                            @{ @"geometry": @{@"type": @"LineString",
+                                                              @"coordinates": @[@[@(coord1.longitude), @(coord1.latitude)],
+                                                                                @[@(coord2.longitude), @(coord2.latitude)]]},
+                                               @"properties": [NSNull null],
+                                               @"type": @"Feature",
+                                            }
+                                        ]
+                                    };
     XCTAssertEqualObjects(geoJSONFeature[@"geometry"], expectedGeometry);
 
     // When the shape collection is created with an empty array of shapes

--- a/platform/ios/test/MGLMapViewLayoutTests.m
+++ b/platform/ios/test/MGLMapViewLayoutTests.m
@@ -67,7 +67,7 @@
     CGFloat bottomSafeAreaInset = 0.0;
     double accuracy = 0.01;
 
-    if ( [self.mapView respondsToSelector:@selector(safeAreaInsets)] ) {
+    if (@available(iOS 11.0, *)) {
         bottomSafeAreaInset = self.mapView.safeAreaInsets.bottom;
     }
     


### PR DESCRIPTION
Fixes a couple build warnings and compatibility issues — see commit messages for the text of the warnings. 

There’s still one broken test on iOS 8 in [`-[MGLExpressionTests testConditionalExpressionObject]`](https://github.com/mapbox/mapbox-gl-native/blob/44ca0a5ec4979138514e8dda10dd1b1173dd0db1/platform/darwin/test/MGLExpressionTests.mm#L575-L594), which will eventually be addressed by https://github.com/mapbox/mapbox-gl-native/issues/11007.

Unblocks https://github.com/mapbox/mapbox-gl-native/pull/10742.

/cc @1ec5 @fabian-guerra @akitchen 