### PR TITLE
[core,ios] Release more memory on entering background

### DIFF
--- a/include/mbgl/renderer/renderer.hpp
+++ b/include/mbgl/renderer/renderer.hpp
@@ -48,7 +48,7 @@ public:
     void dumpDebugLogs();
 
     // Memory
-    void onLowMemory();
+    void reduceMemoryUse();
 
 private:
     class Impl;

--- a/platform/android/src/android_renderer_frontend.cpp
+++ b/platform/android/src/android_renderer_frontend.cpp
@@ -77,8 +77,8 @@ void AndroidRendererFrontend::update(std::shared_ptr<UpdateParameters> params) {
     mapRenderer.requestRender();
 }
 
-void AndroidRendererFrontend::onLowMemory() {
-    mapRenderer.actor().invoke(&Renderer::onLowMemory);
+void AndroidRendererFrontend::reduceMemoryUse() {
+    mapRenderer.actor().invoke(&Renderer::reduceMemoryUse);
 }
 
 std::vector<Feature> AndroidRendererFrontend::querySourceFeatures(const std::string& sourceID,

--- a/platform/android/src/android_renderer_frontend.hpp
+++ b/platform/android/src/android_renderer_frontend.hpp
@@ -39,7 +39,7 @@ public:
     AnnotationIDs queryShapeAnnotations(const ScreenBox& box) const;
 
     // Memory
-    void onLowMemory();
+    void reduceMemoryUse();
 
 private:
     MapRenderer& mapRenderer;

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -450,7 +450,7 @@ jni::Array<jni::jlong> NativeMapView::addMarkers(jni::JNIEnv& env, jni::Array<jn
 }
 
 void NativeMapView::onLowMemory(JNIEnv&) {
-    rendererFrontend->onLowMemory();
+    rendererFrontend->reduceMemoryUse();
 }
 
 using DebugOptions = mbgl::MapDebugOptions;

--- a/platform/darwin/src/MGLRendererFrontend.h
+++ b/platform/darwin/src/MGLRendererFrontend.h
@@ -56,9 +56,9 @@ public:
         return renderer.get();
     }
     
-    void onLowMemory() {
+    void reduceMemoryUse() {
         if (!renderer)  return;
-        renderer->onLowMemory();
+        renderer->reduceMemoryUse();
     }
     
 private:

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -706,7 +706,7 @@ public:
 {
     MGLAssertIsMainThread();
 
-    _rendererFrontend->onLowMemory();
+    _rendererFrontend->reduceMemoryUse();
 }
 
 #pragma mark - Layout -
@@ -2278,7 +2278,7 @@ public:
 
 - (void)emptyMemoryCache
 {
-    _rendererFrontend->onLowMemory();
+    _rendererFrontend->reduceMemoryUse();
 }
 
 - (void)setZoomEnabled:(BOOL)zoomEnabled

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1148,6 +1148,13 @@ public:
 - (void)sleepGL:(__unused NSNotification *)notification
 {
     MGLAssertIsMainThread();
+    
+    // Ideally we would wait until we actually received a memory warning but the bulk of the memory
+    // we have to release is tied up in GL buffers that we can't touch once we're in the background.
+    // Compromise position: release everything but currently rendering tiles
+    // A possible improvement would be to store a copy of the GL buffers that we could use to rapidly
+    // restart, but that we could also discard in response to a memory warning.
+    _rendererFrontend->reduceMemoryUse();
 
     if ( ! self.dormant)
     {

--- a/src/mbgl/annotation/render_annotation_source.cpp
+++ b/src/mbgl/annotation/render_annotation_source.cpp
@@ -73,8 +73,8 @@ std::vector<Feature> RenderAnnotationSource::querySourceFeatures(const SourceQue
     return {};
 }
 
-void RenderAnnotationSource::onLowMemory() {
-    tilePyramid.onLowMemory();
+void RenderAnnotationSource::reduceMemoryUse() {
+    tilePyramid.reduceMemoryUse();
 }
 
 void RenderAnnotationSource::dumpDebugLogs() const {

--- a/src/mbgl/annotation/render_annotation_source.hpp
+++ b/src/mbgl/annotation/render_annotation_source.hpp
@@ -33,7 +33,7 @@ public:
     std::vector<Feature>
     querySourceFeatures(const SourceQueryOptions&) const final;
 
-    void onLowMemory() final;
+    void reduceMemoryUse() final;
     void dumpDebugLogs() const final;
 
 private:

--- a/src/mbgl/renderer/render_source.hpp
+++ b/src/mbgl/renderer/render_source.hpp
@@ -70,7 +70,7 @@ public:
     virtual std::vector<Feature>
     querySourceFeatures(const SourceQueryOptions&) const = 0;
 
-    virtual void onLowMemory() = 0;
+    virtual void reduceMemoryUse() = 0;
 
     virtual void dumpDebugLogs() const = 0;
 

--- a/src/mbgl/renderer/renderer.cpp
+++ b/src/mbgl/renderer/renderer.cpp
@@ -94,9 +94,9 @@ void Renderer::dumpDebugLogs() {
     impl->dumDebugLogs();
 }
 
-void Renderer::onLowMemory() {
+void Renderer::reduceMemoryUse() {
     BackendScope guard { impl->backend };
-    impl->onLowMemory();
+    impl->reduceMemoryUse();
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -722,10 +722,10 @@ std::vector<Feature> Renderer::Impl::querySourceFeatures(const std::string& sour
     return source->querySourceFeatures(options);
 }
 
-void Renderer::Impl::onLowMemory() {
+void Renderer::Impl::reduceMemoryUse() {
     assert(BackendScope::exists());
     for (const auto& entry : renderSources) {
-        entry.second->onLowMemory();
+        entry.second->reduceMemoryUse();
     }
     backend.getContext().performCleanup();
     observer->onInvalidate();

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -724,10 +724,10 @@ std::vector<Feature> Renderer::Impl::querySourceFeatures(const std::string& sour
 
 void Renderer::Impl::onLowMemory() {
     assert(BackendScope::exists());
-    backend.getContext().performCleanup();
     for (const auto& entry : renderSources) {
         entry.second->onLowMemory();
     }
+    backend.getContext().performCleanup();
     observer->onInvalidate();
 }
 

--- a/src/mbgl/renderer/renderer_impl.hpp
+++ b/src/mbgl/renderer/renderer_impl.hpp
@@ -53,7 +53,7 @@ public:
     std::vector<Feature> querySourceFeatures(const std::string& sourceID, const SourceQueryOptions&) const;
     std::vector<Feature> queryShapeAnnotations(const ScreenLineString&) const;
 
-    void onLowMemory();
+    void reduceMemoryUse();
     void dumDebugLogs();
 
 private:

--- a/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
+++ b/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
@@ -76,8 +76,8 @@ std::vector<Feature> RenderCustomGeometrySource::querySourceFeatures(const Sourc
     return tilePyramid.querySourceFeatures(options);
 }
 
-void RenderCustomGeometrySource::onLowMemory() {
-    tilePyramid.onLowMemory();
+void RenderCustomGeometrySource::reduceMemoryUse() {
+    tilePyramid.reduceMemoryUse();
 }
 
 void RenderCustomGeometrySource::dumpDebugLogs() const {

--- a/src/mbgl/renderer/sources/render_custom_geometry_source.hpp
+++ b/src/mbgl/renderer/sources/render_custom_geometry_source.hpp
@@ -33,7 +33,7 @@ public:
     std::vector<Feature>
     querySourceFeatures(const SourceQueryOptions&) const final;
 
-    void onLowMemory() final;
+    void reduceMemoryUse() final;
     void dumpDebugLogs() const final;
     
 private:

--- a/src/mbgl/renderer/sources/render_geojson_source.cpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.cpp
@@ -94,8 +94,8 @@ std::vector<Feature> RenderGeoJSONSource::querySourceFeatures(const SourceQueryO
     return tilePyramid.querySourceFeatures(options);
 }
 
-void RenderGeoJSONSource::onLowMemory() {
-    tilePyramid.onLowMemory();
+void RenderGeoJSONSource::reduceMemoryUse() {
+    tilePyramid.reduceMemoryUse();
 }
 
 void RenderGeoJSONSource::dumpDebugLogs() const {

--- a/src/mbgl/renderer/sources/render_geojson_source.hpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.hpp
@@ -37,7 +37,7 @@ public:
     std::vector<Feature>
     querySourceFeatures(const SourceQueryOptions&) const final;
 
-    void onLowMemory() final;
+    void reduceMemoryUse() final;
     void dumpDebugLogs() const final;
 
 private:

--- a/src/mbgl/renderer/sources/render_image_source.hpp
+++ b/src/mbgl/renderer/sources/render_image_source.hpp
@@ -37,7 +37,7 @@ public:
 
     std::vector<Feature> querySourceFeatures(const SourceQueryOptions&) const final;
 
-    void onLowMemory() final {
+    void reduceMemoryUse() final {
     }
     void dumpDebugLogs() const final;
 

--- a/src/mbgl/renderer/sources/render_raster_dem_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.cpp
@@ -155,8 +155,8 @@ std::vector<Feature> RenderRasterDEMSource::querySourceFeatures(const SourceQuer
     return {};
 }
 
-void RenderRasterDEMSource::onLowMemory() {
-    tilePyramid.onLowMemory();
+void RenderRasterDEMSource::reduceMemoryUse() {
+    tilePyramid.reduceMemoryUse();
 }
 
 void RenderRasterDEMSource::dumpDebugLogs() const {

--- a/src/mbgl/renderer/sources/render_raster_dem_source.hpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.hpp
@@ -33,7 +33,7 @@ public:
     std::vector<Feature>
     querySourceFeatures(const SourceQueryOptions&) const final;
 
-    void onLowMemory() final;
+    void reduceMemoryUse() final;
     void dumpDebugLogs() const final;
 
 private:

--- a/src/mbgl/renderer/sources/render_raster_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_source.cpp
@@ -85,8 +85,8 @@ std::vector<Feature> RenderRasterSource::querySourceFeatures(const SourceQueryOp
     return {};
 }
 
-void RenderRasterSource::onLowMemory() {
-    tilePyramid.onLowMemory();
+void RenderRasterSource::reduceMemoryUse() {
+    tilePyramid.reduceMemoryUse();
 }
 
 void RenderRasterSource::dumpDebugLogs() const {

--- a/src/mbgl/renderer/sources/render_raster_source.hpp
+++ b/src/mbgl/renderer/sources/render_raster_source.hpp
@@ -33,7 +33,7 @@ public:
     std::vector<Feature>
     querySourceFeatures(const SourceQueryOptions&) const final;
 
-    void onLowMemory() final;
+    void reduceMemoryUse() final;
     void dumpDebugLogs() const final;
 
 private:

--- a/src/mbgl/renderer/sources/render_vector_source.cpp
+++ b/src/mbgl/renderer/sources/render_vector_source.cpp
@@ -88,8 +88,8 @@ std::vector<Feature> RenderVectorSource::querySourceFeatures(const SourceQueryOp
     return tilePyramid.querySourceFeatures(options);
 }
 
-void RenderVectorSource::onLowMemory() {
-    tilePyramid.onLowMemory();
+void RenderVectorSource::reduceMemoryUse() {
+    tilePyramid.reduceMemoryUse();
 }
 
 void RenderVectorSource::dumpDebugLogs() const {

--- a/src/mbgl/renderer/sources/render_vector_source.hpp
+++ b/src/mbgl/renderer/sources/render_vector_source.hpp
@@ -33,7 +33,7 @@ public:
     std::vector<Feature>
     querySourceFeatures(const SourceQueryOptions&) const final;
 
-    void onLowMemory() final;
+    void reduceMemoryUse() final;
     void dumpDebugLogs() const final;
 
 private:

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -303,7 +303,7 @@ void TilePyramid::setCacheSize(size_t size) {
     cache.setSize(size);
 }
 
-void TilePyramid::onLowMemory() {
+void TilePyramid::reduceMemoryUse() {
     cache.clear();
 }
 

--- a/src/mbgl/renderer/tile_pyramid.hpp
+++ b/src/mbgl/renderer/tile_pyramid.hpp
@@ -59,7 +59,7 @@ public:
     std::vector<Feature> querySourceFeatures(const SourceQueryOptions&) const;
 
     void setCacheSize(size_t);
-    void onLowMemory();
+    void reduceMemoryUse();
 
     void setObserver(TileObserver*);
     void dumpDebugLogs() const;


### PR DESCRIPTION
The iOS SDK (https://github.com/mapbox/mapbox-gl-native/issues/9203) and the Nav SDK (https://github.com/mapbox/mapbox-navigation-ios/issues/963) both have issues tied to mbgl holding onto too much memory while in the background, causing iOS to kill the app. This PR tries to make some simple changes to ameliorate the situation:

- https://github.com/mapbox/mapbox-gl-native/commit/b4fb4f6cc4e5edeaa6538250f3b81f92f53bf529 fixes a simple bug in our `onLowMemory` implementation that would prevent us from releasing abandoned buffers after clearing the in memory tile cache.
- https://github.com/mapbox/mapbox-gl-native/commit/52957fd8c47c4016231839631b4b8a76a76b73f9 modifies the iOS SDK to always clear the tile cache on entering the background state. We need to clear the cache when we enter the background because once we're actually in the background, we can't make any GL calls, and the bulk of the data we need to release is tied up in GL buffers.

Together these changes make it so that the memory used by the tile cache is effectively released when the app goes into the background. Tiles that are currently being rendered are still kept in memory, allowing a fast restart. If a low memory warning is received while in the background, we will try to clear the cache again, but it will effectively be a no-op.

How much memory will be released depends on the total size of tiles in the cache, but from playing around with the iosapp, it seems like navigating through city streets will tend to load up at least 50MB in the cache.

**Before:**
![screenshot 2018-02-13 14 27 31](https://user-images.githubusercontent.com/375121/36181093-18edc5ca-10d8-11e8-9582-b95442c4fb07.png)

**After:**
(sharp drops represent switching to another app)
![screenshot 2018-02-13 14 23 01](https://user-images.githubusercontent.com/375121/36181094-19122f00-10d8-11e8-800d-89ae15b632ca.png)

The cost of this change is that, after reloading, if you pan to a tile that would have been cached in memory, it will now require reloading/reparsing from disk. Just playing around on my phone I can't really tell the difference.

## Further improvements?
### Evacuate the GPU
A significant chunk of memory is still used by the tiles that are still being rendered at the time we enter the background. We don't want to throw away their data if we can avoid it because we want to be able to start rendering immediately on re-entering the foreground. It's _possible_ we could implement a solution where:
- On entering the background, we'd "slumber" buffers by using something like `glGetBufferSubData` to copy the data out into memory we manage.
- If we received a low memory warning while in the background, we'd release our locally stored buffers -- making re-start time a little slower, but still better than having the app killed (?).
- On re-entering the foreground, as long as the buffers were still intact, we'd re-upload them to the GPU

I don't know how significant the overhead of that copying would be, but I think it would add a fair amount of complexity.

### Release other GL resources
I spent a little bit of time poking into releasing textures and framebuffers before we go into the background, since in most cases we can re-create them pretty quickly. I feel like I'm missing something, but even aggressively releasing all textures (without corresponding code to re-create/re-upload them) didn't seem to make a noticeable dent in memory usage. We could also try abandoning/re-creating programs and shaders -- I haven't looked into that at all.

/cc @bsudekum @friedbunny @kkaefer @jfirebaugh @lbud 