### PR TITLE
[android] incorrect latlngBounds in the VisibleRegion when map is rotated

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Projection.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Projection.java
@@ -104,11 +104,12 @@ public class Projection {
     LatLng bottomLeft = fromScreenLocation(new PointF(left, bottom));
 
     return new VisibleRegion(topLeft, topRight, bottomLeft, bottomRight,
-      LatLngBounds.from(
-        topRight.getLatitude(),
-        topRight.getLongitude(),
-        bottomLeft.getLatitude(),
-        bottomLeft.getLongitude())
+      new LatLngBounds.Builder()
+        .include(topRight)
+        .include(bottomLeft)
+        .include(bottomRight)
+        .include(topLeft)
+        .build()
     );
   }
 


### PR DESCRIPTION
fixed visibleRegion.latlngBounds for rotated map

closes #11137 