### PR TITLE
Add heatmap color property

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/HeatmapLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/HeatmapLayer.java
@@ -168,6 +168,32 @@ public class HeatmapLayer extends Layer {
   }
 
   /**
+   * Get the HeatmapColor property
+   *
+   * @return property wrapper value around String
+   */
+  @SuppressWarnings("unchecked")
+  public PropertyValue<String> getHeatmapColor() {
+    return (PropertyValue<String>) new PropertyValue("heatmap-color", nativeGetHeatmapColor());
+  }
+
+  /**
+   * Defines the color of each pixel based on its density value in a heatmap.  Should be an expression that uses `["heatmap-density"]` as input.
+   *
+   * @return int representation of a rgba string color
+   * @throws RuntimeException thrown if property isn't a value
+   */
+  @ColorInt
+  public int getHeatmapColorAsInt() {
+    PropertyValue<String> value = getHeatmapColor();
+    if (value.isValue()) {
+      return rgbaToColor(value.getValue());
+    } else {
+      throw new RuntimeException("heatmap-color was set as a Function");
+    }
+  }
+
+  /**
    * Get the HeatmapOpacity property
    *
    * @return property wrapper value around Float
@@ -208,6 +234,8 @@ public class HeatmapLayer extends Layer {
   private native TransitionOptions nativeGetHeatmapIntensityTransition();
 
   private native void nativeSetHeatmapIntensityTransition(long duration, long delay);
+
+  private native Object nativeGetHeatmapColor();
 
   private native Object nativeGetHeatmapOpacity();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyFactory.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyFactory.java
@@ -1615,6 +1615,36 @@ public class PropertyFactory {
   }
 
   /**
+   * Defines the color of each pixel based on its density value in a heatmap.  Should be an expression that uses `["heatmap-density"]` as input.
+   *
+   * @param value a int color value
+   * @return property wrapper around String color
+   */
+  public static PropertyValue<String> heatmapColor(@ColorInt int value) {
+    return new PaintPropertyValue<>("heatmap-color", colorToRgbaString(value));
+  }
+
+  /**
+   * Defines the color of each pixel based on its density value in a heatmap.  Should be an expression that uses `["heatmap-density"]` as input.
+   *
+   * @param value a String value
+   * @return property wrapper around String
+   */
+  public static PropertyValue<String> heatmapColor(String value) {
+    return new PaintPropertyValue<>("heatmap-color", value);
+  }
+
+  /**
+   * Defines the color of each pixel based on its density value in a heatmap.  Should be an expression that uses `["heatmap-density"]` as input.
+   *
+   * @param expression an expression statement
+   * @return property wrapper around an expression statement
+   */
+  public static PropertyValue<Expression> heatmapColor(Expression expression) {
+    return new PaintPropertyValue<>("heatmap-color", expression);
+  }
+
+  /**
    * The global opacity at which the heatmap layer will be drawn.
    *
    * @param value a Float value

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
@@ -123,6 +123,7 @@ public class <%- camelize(type) %>LayerTest extends BaseActivityTest {
   }
 <% } -%>
 <% for (const property of properties) { -%>
+<% if (property.name != 'heatmap-color') { -%>
 <% if (property.transition) { -%>
 
   @Test
@@ -454,6 +455,7 @@ public class <%- camelize(type) %>LayerTest extends BaseActivityTest {
       }
     });
   }
+<% } -%>
 <% } -%>
 <% } -%>
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/HeatmapLayerActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/HeatmapLayerActivity.java
@@ -16,6 +16,7 @@ import java.net.URL;
 import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.heatmapDensity;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.interpolate;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.linear;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.literal;
@@ -28,6 +29,7 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleOpacity;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleRadius;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleStrokeColor;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleStrokeWidth;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.heatmapColor;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.heatmapIntensity;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.heatmapOpacity;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.heatmapRadius;
@@ -51,7 +53,6 @@ public class HeatmapLayerActivity extends AppCompatActivity {
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_heatmaplayer);
-
     mapView = (MapView) findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(map -> {
@@ -76,11 +77,20 @@ public class HeatmapLayerActivity extends AppCompatActivity {
     layer.setSourceLayer(HEATMAP_LAYER_SOURCE);
     layer.setProperties(
 
-      // TODO add heatmap color https://github.com/mapbox/mapbox-gl-native/issues/11172
       // Color ramp for heatmap.  Domain is 0 (low) to 1 (high).
       // Begin color ramp at 0-stop with a 0-transparancy color
       // to create a blur-like effect.
-      //heatmapColor(),
+      heatmapColor(
+        interpolate(
+          linear(), heatmapDensity(),
+          literal(0), rgba(33, 102, 172, 0),
+          literal(0.2), rgb(103, 169, 207),
+          literal(0.4), rgb(209, 229, 240),
+          literal(0.6), rgb(253, 219, 199),
+          literal(0.8), rgb(239, 138, 98),
+          literal(1), rgb(178, 24, 43)
+        )
+      ),
 
       // Increase the heatmap weight based on frequency and property magnitude
       heatmapWeight(

--- a/platform/android/scripts/generate-style-code.js
+++ b/platform/android/scripts/generate-style-code.js
@@ -29,9 +29,6 @@ var layers = Object.keys(spec.layer.type.values).map((type) => {
   }, []);
 
   const paintProperties = Object.keys(spec[`paint_${type}`]).reduce((memo, name) => {
-    // disabled for now, see https://github.com/mapbox/mapbox-gl-native/issues/11172
-    if (name === 'heatmap-color') return memo;
-
     spec[`paint_${type}`][name].name = name;
     memo.push(spec[`paint_${type}`][name]);
     return memo;

--- a/platform/android/src/style/conversion/property_value.hpp
+++ b/platform/android/src/style/conversion/property_value.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/style/property_value.hpp>
 #include <mbgl/style/data_driven_property_value.hpp>
+#include <mbgl/style/heatmap_color_property_value.hpp>
 #include "../../conversion/conversion.hpp"
 #include "../../conversion/constant.hpp"
 #include "types.hpp"
@@ -67,6 +68,18 @@ struct Converter<jni::jobject*, mbgl::style::DataDrivenPropertyValue<T>> {
     Result<jni::jobject*> operator()(jni::JNIEnv& env, const mbgl::style::DataDrivenPropertyValue<T>& value) const {
         PropertyValueEvaluator<T> evaluator(env);
         return value.evaluate(evaluator);
+    }
+};
+
+/**
+ * Convert core heat map color property value to java
+ */
+template <>
+struct Converter<jni::jobject*, mbgl::style::HeatmapColorPropertyValue> {
+
+    Result<jni::jobject*> operator()(jni::JNIEnv& env, const mbgl::style::HeatmapColorPropertyValue value) const {
+        PropertyValueEvaluator<mbgl::style::HeatmapColorPropertyValue> evaluator(env);
+        return *convert<jni::jobject*>(env, value.evaluate(evaluator));
     }
 };
 

--- a/platform/android/src/style/layers/heatmap_layer.cpp
+++ b/platform/android/src/style/layers/heatmap_layer.cpp
@@ -81,7 +81,11 @@ namespace android {
 
     jni::Object<jni::ObjectTag> HeatmapLayer::getHeatmapColor(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
-        Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::HeatmapLayer>()->HeatmapLayer::getHeatmapColor());
+        auto propertyValue = layer.as<mbgl::style::HeatmapLayer>()->HeatmapLayer::getHeatmapColor();
+        if (propertyValue.isUndefined()) {
+            propertyValue = layer.as<mbgl::style::HeatmapLayer>()->HeatmapLayer::getDefaultHeatmapColor();
+        }
+        Result<jni::jobject*> converted = convert<jni::jobject*>(env, propertyValue);
         return jni::Object<jni::ObjectTag>(*converted);
     }
 

--- a/platform/android/src/style/layers/heatmap_layer.cpp
+++ b/platform/android/src/style/layers/heatmap_layer.cpp
@@ -79,6 +79,12 @@ namespace android {
         layer.as<mbgl::style::HeatmapLayer>()->HeatmapLayer::setHeatmapIntensityTransition(options);
     }
 
+    jni::Object<jni::ObjectTag> HeatmapLayer::getHeatmapColor(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::HeatmapLayer>()->HeatmapLayer::getHeatmapColor());
+        return jni::Object<jni::ObjectTag>(*converted);
+    }
+
     jni::Object<jni::ObjectTag> HeatmapLayer::getHeatmapOpacity(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::HeatmapLayer>()->HeatmapLayer::getHeatmapOpacity());
@@ -125,6 +131,7 @@ namespace android {
             METHOD(&HeatmapLayer::getHeatmapIntensityTransition, "nativeGetHeatmapIntensityTransition"),
             METHOD(&HeatmapLayer::setHeatmapIntensityTransition, "nativeSetHeatmapIntensityTransition"),
             METHOD(&HeatmapLayer::getHeatmapIntensity, "nativeGetHeatmapIntensity"),
+            METHOD(&HeatmapLayer::getHeatmapColor, "nativeGetHeatmapColor"),
             METHOD(&HeatmapLayer::getHeatmapOpacityTransition, "nativeGetHeatmapOpacityTransition"),
             METHOD(&HeatmapLayer::setHeatmapOpacityTransition, "nativeSetHeatmapOpacityTransition"),
             METHOD(&HeatmapLayer::getHeatmapOpacity, "nativeGetHeatmapOpacity"));

--- a/platform/android/src/style/layers/heatmap_layer.hpp
+++ b/platform/android/src/style/layers/heatmap_layer.hpp
@@ -39,6 +39,8 @@ public:
     void setHeatmapIntensityTransition(jni::JNIEnv&, jlong duration, jlong delay);
     jni::Object<TransitionOptions> getHeatmapIntensityTransition(jni::JNIEnv&);
 
+    jni::Object<jni::ObjectTag> getHeatmapColor(jni::JNIEnv&);
+
     jni::Object<jni::ObjectTag> getHeatmapOpacity(jni::JNIEnv&);
     void setHeatmapOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay);
     jni::Object<TransitionOptions> getHeatmapOpacityTransition(jni::JNIEnv&);

--- a/platform/android/src/style/layers/layer.cpp.ejs
+++ b/platform/android/src/style/layers/layer.cpp.ejs
@@ -48,12 +48,25 @@ namespace android {
     // Property getters
 
 <% for (const property of properties) { -%>
+<% if (property.name != 'heatmap-color') { -%>
     jni::Object<jni::ObjectTag> <%- camelize(type) %>Layer::get<%- camelize(property.name) %>(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::<%- camelize(type) %>Layer>()-><%- camelize(type) %>Layer::get<%- camelize(property.name) %>());
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+<% } else { -%>
+    jni::Object<jni::ObjectTag> HeatmapLayer::getHeatmapColor(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        auto propertyValue = layer.as<mbgl::style::HeatmapLayer>()->HeatmapLayer::getHeatmapColor();
+        if (propertyValue.isUndefined()) {
+            propertyValue = layer.as<mbgl::style::HeatmapLayer>()->HeatmapLayer::getDefaultHeatmapColor();
+        }
+        Result<jni::jobject*> converted = convert<jni::jobject*>(env, propertyValue);
+        return jni::Object<jni::ObjectTag>(*converted);
+    }
+
+<% } -%>
 <% if (property.transition) { -%>
     jni::Object<TransitionOptions> <%- camelize(type) %>Layer::get<%- camelize(property.name) %>Transition(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;


### PR DESCRIPTION
This PR adds heatmap color support to the android binding:

<img width="276" alt="screen shot 2018-02-16 at 10 48 27" src="https://user-images.githubusercontent.com/2151639/36301999-1971d9ce-1307-11e8-9839-8f6f34eebf05.png">

@ivovandongen to make this conversion possible I had to add support for the custom `mbgl::style::HeatmapColorPropertyValue`. Is `property_value.hpp` the correct place to do this? 

Closes #11172 



cc @mourner @anandthakker 