### PR TITLE
[android] fixed LatLngBounds returned by VisibleRegion when map is rotated

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Projection.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Projection.java
@@ -104,11 +104,12 @@ public class Projection {
     LatLng bottomLeft = fromScreenLocation(new PointF(left, bottom));
 
     return new VisibleRegion(topLeft, topRight, bottomLeft, bottomRight,
-      LatLngBounds.from(
-        topRight.getLatitude(),
-        topRight.getLongitude(),
-        bottomLeft.getLatitude(),
-        bottomLeft.getLongitude())
+      new LatLngBounds.Builder()
+        .include(topRight)
+        .include(bottomLeft)
+        .include(bottomRight)
+        .include(topLeft)
+        .build()
     );
   }
 


### PR DESCRIPTION
smallest bounding box for 4 points cannot
be created using LatLngBounds.fromLatLngs()
as the order matters in that method and that does not work for rotated map