### PR TITLE
Offline downloads - longer running transactions

### DIFF
--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -23,8 +23,8 @@ namespace mbgl {
 
 class Response;
 class TileID;
-class TransactionToken;
-class RegionTransaction;
+class BatchTransaction;
+class TransactionManager;
 
 class OfflineDatabase : private util::noncopyable {
 public:
@@ -38,7 +38,7 @@ public:
     // Return value is (inserted, stored size)
     std::pair<bool, uint64_t> put(const Resource&, const Response&);
 
-    std::shared_ptr<TransactionToken> beginRegionDownload();
+    std::shared_ptr<BatchTransaction> beginRegionDownload();
 
     std::vector<OfflineRegion> listRegions();
 
@@ -110,7 +110,7 @@ private:
     std::unique_ptr<::mapbox::sqlite::Database> db;
     std::unordered_map<const char *, std::unique_ptr<::mapbox::sqlite::Statement>> statements;
     
-    std::unique_ptr<RegionTransaction> regionTransaction;
+    std::unique_ptr<TransactionManager> transactionManager;
 
     template <class T>
     T getPragma(const char *);

--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -23,6 +23,8 @@ namespace mbgl {
 
 class Response;
 class TileID;
+class TransactionToken;
+class RegionTransaction;
 
 class OfflineDatabase : private util::noncopyable {
 public:
@@ -36,8 +38,7 @@ public:
     // Return value is (inserted, stored size)
     std::pair<bool, uint64_t> put(const Resource&, const Response&);
 
-    void beginRegionDownload();
-    void endRegionDownload();
+    std::shared_ptr<TransactionToken> beginRegionDownload();
 
     std::vector<OfflineRegion> listRegions();
 
@@ -108,8 +109,8 @@ private:
     const std::string path;
     std::unique_ptr<::mapbox::sqlite::Database> db;
     std::unordered_map<const char *, std::unique_ptr<::mapbox::sqlite::Statement>> statements;
-    std::unique_ptr<::mapbox::sqlite::Transaction> regionTransaction;
-    int64_t pendingRegionResources = 0;
+    
+    std::unique_ptr<RegionTransaction> regionTransaction;
 
     template <class T>
     T getPragma(const char *);

--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -15,6 +15,7 @@ namespace mapbox {
 namespace sqlite {
 class Database;
 class Statement;
+class Transaction;
 } // namespace sqlite
 } // namespace mapbox
 
@@ -34,6 +35,9 @@ public:
 
     // Return value is (inserted, stored size)
     std::pair<bool, uint64_t> put(const Resource&, const Response&);
+
+    void beginRegionDownload();
+    void endRegionDownload();
 
     std::vector<OfflineRegion> listRegions();
 
@@ -104,6 +108,8 @@ private:
     const std::string path;
     std::unique_ptr<::mapbox::sqlite::Database> db;
     std::unordered_map<const char *, std::unique_ptr<::mapbox::sqlite::Statement>> statements;
+    std::unique_ptr<::mapbox::sqlite::Transaction> regionTransaction;
+    int64_t pendingRegionResources = 0;
 
     template <class T>
     T getPragma(const char *);

--- a/platform/default/mbgl/storage/offline_download.cpp
+++ b/platform/default/mbgl/storage/offline_download.cpp
@@ -156,6 +156,7 @@ void OfflineDownload::activateDownload() {
     status = OfflineRegionStatus();
     status.downloadState = OfflineRegionDownloadState::Active;
     status.requiredResourceCount++;
+    offlineDatabase.beginRegionDownload();
     ensureResource(Resource::style(definition.styleURL), [&](Response styleResponse) {
         status.requiredResourceCountIsPrecise = true;
 
@@ -269,6 +270,7 @@ void OfflineDownload::activateDownload() {
 */
 void OfflineDownload::continueDownload() {
     if (resourcesRemaining.empty() && status.complete()) {
+        offlineDatabase.endRegionDownload();
         setState(OfflineRegionDownloadState::Inactive);
         return;
     }
@@ -283,6 +285,7 @@ void OfflineDownload::deactivateDownload() {
     requiredSourceURLs.clear();
     resourcesRemaining.clear();
     requests.clear();
+    offlineDatabase.endRegionDownload();
 }
 
 void OfflineDownload::queueResource(Resource resource) {

--- a/platform/default/mbgl/storage/offline_download.cpp
+++ b/platform/default/mbgl/storage/offline_download.cpp
@@ -156,7 +156,7 @@ void OfflineDownload::activateDownload() {
     status = OfflineRegionStatus();
     status.downloadState = OfflineRegionDownloadState::Active;
     status.requiredResourceCount++;
-    offlineDatabase.beginRegionDownload();
+    regionTransaction = offlineDatabase.beginRegionDownload();
     ensureResource(Resource::style(definition.styleURL), [&](Response styleResponse) {
         status.requiredResourceCountIsPrecise = true;
 
@@ -270,7 +270,7 @@ void OfflineDownload::activateDownload() {
 */
 void OfflineDownload::continueDownload() {
     if (resourcesRemaining.empty() && status.complete()) {
-        offlineDatabase.endRegionDownload();
+        regionTransaction.reset();
         setState(OfflineRegionDownloadState::Inactive);
         return;
     }
@@ -285,7 +285,7 @@ void OfflineDownload::deactivateDownload() {
     requiredSourceURLs.clear();
     resourcesRemaining.clear();
     requests.clear();
-    offlineDatabase.endRegionDownload();
+    regionTransaction.reset();
 }
 
 void OfflineDownload::queueResource(Resource resource) {

--- a/platform/default/mbgl/storage/offline_download.hpp
+++ b/platform/default/mbgl/storage/offline_download.hpp
@@ -62,7 +62,7 @@ private:
     void queueResource(Resource);
     void queueTiles(style::SourceType, uint16_t tileSize, const Tileset&);
     
-    std::shared_ptr<TransactionToken> regionTransaction;
+    std::shared_ptr<BatchTransaction> regionTransaction;
 };
 
 } // namespace mbgl

--- a/platform/default/mbgl/storage/offline_download.hpp
+++ b/platform/default/mbgl/storage/offline_download.hpp
@@ -61,6 +61,8 @@ private:
 
     void queueResource(Resource);
     void queueTiles(style::SourceType, uint16_t tileSize, const Tileset&);
+    
+    std::shared_ptr<TransactionToken> regionTransaction;
 };
 
 } // namespace mbgl

--- a/test/storage/offline_download.test.cpp
+++ b/test/storage/offline_download.test.cpp
@@ -295,6 +295,7 @@ TEST(OfflineDownload, GetStatusStyleComplete) {
         OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0),
         test.db, test.fileSource);
 
+    auto transaction = test.db.beginRegionDownload();
     test.db.putRegionResource(1,
         Resource::style("http://127.0.0.1:3000/style.json"),
         test.response("style.json"));
@@ -317,6 +318,8 @@ TEST(OfflineDownload, GetStatusStyleAndSourceComplete) {
         OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0),
         test.db, test.fileSource);
 
+    auto transaction = test.db.beginRegionDownload();
+    
     test.db.putRegionResource(1,
         Resource::style("http://127.0.0.1:3000/style.json"),
         test.response("style.json"));


### PR DESCRIPTION
Fixes #11217 
Closes #10252

Adds long(er) running transactions to offline downloads to avoid too much i/o overhead. Currently commits every 128 resources (very randomly picked, but performs well). Add-hoc cached resources and region (meta-data) are committed immediately and commit any region resources as well.

Tested with 
- Berlin region: 5195 tiles, north:52.6780473464 east:13.7603759766 south:52.3305137868 west:13.0627441406 max-zoom:15 
- Warmed up cache on the edge location
- Current hardware: Pixel 2 XL
- Old hardware: Galaxy Nexus 

Before:
- Current hardware: ~90 seconds 
- Old hardware: 15 minutes+

  After
- Current hardware: ~20 seconds
- Old hardware: ~130 seconds