### PR TITLE
Check if Activity isn't finishing before showing dialog

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
@@ -1,5 +1,6 @@
 package com.mapbox.mapboxsdk.maps;
 
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
@@ -48,7 +49,17 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
   @Override
   public void onClick(View view) {
     attributionSet = new AttributionBuilder(mapboxMap).build();
-    showAttributionDialog(getAttributionTitles());
+
+    boolean isActivityFinishing = false;
+    if (context instanceof Activity) {
+      isActivityFinishing = ((Activity) context).isFinishing();
+    }
+
+    // check is hosting activity isn't finishing
+    // https://github.com/mapbox/mapbox-gl-native/issues/11238
+    if (!isActivityFinishing) {
+      showAttributionDialog(getAttributionTitles());
+    }
   }
 
   protected void showAttributionDialog(String[] attributionTitles) {


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/11238, this PR hardens the integration by checking if the hosting activity isn't finishing following the advice from this [SO](https://stackoverflow.com/a/18665887)-post. 