### PR TITLE
Android events initialization method name typo fix

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
@@ -53,7 +53,7 @@ public final class Mapbox {
       INSTANCE = new Mapbox(appContext, accessToken, locationEngine);
       locationEngine.setPriority(LocationEnginePriority.NO_POWER);
 
-      Events.initiliaze();
+      Events.initialize();
       ConnectivityReceiver.instance(appContext);
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Events.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Events.java
@@ -26,7 +26,7 @@ public class Events {
     }
   }
 
-  public static void initiliaze() {
+  public static void initialize() {
     obtainTelemetry();
   }
 


### PR DESCRIPTION
This pr fixes a misspelling that I saw the other day and merges changes into the boba release branch.

cc @Guardiola31337 