### PR TITLE
[core] Implement TileCover for polygonal regions

### DIFF
--- a/benchmark/util/tilecover.benchmark.cpp
+++ b/benchmark/util/tilecover.benchmark.cpp
@@ -1,0 +1,96 @@
+#include <benchmark/benchmark.h>
+#include <mbgl/util/geo.hpp>
+#include <mbgl/util/geometry.hpp>
+#include <mbgl/util/tile_coordinate.hpp>
+#include <mbgl/util/tile_cover.hpp>
+#include <mbgl/map/transform.hpp>
+
+using namespace mbgl;
+
+static const LatLngBounds sanFrancisco =
+    LatLngBounds::hull({ 37.6609, -122.5744 }, { 37.8271, -122.3204 });
+
+static void TileCountBounds(benchmark::State& state) {
+    std::size_t length = 0;
+    while (state.KeepRunning()) {
+        auto count = util::tileCount(sanFrancisco, 10);
+        length += count;
+    }
+}
+
+static void TileCoverPitchedViewport(benchmark::State& state) {
+    Transform transform;
+    transform.resize({ 512, 512 });
+    // slightly offset center so that tile order is better defined
+    transform.setLatLng({ 0.1, -0.1 });
+    transform.setZoom(8);
+    transform.setAngle(5.0);
+    transform.setPitch(40.0 * M_PI / 180.0);
+    
+    std::size_t length = 0;
+    while (state.KeepRunning()) {
+        auto tiles = util::tileCover(transform.getState(), 8);
+        length += tiles.size();
+    }
+}
+
+static void TileCoverBounds(benchmark::State& state) {
+    std::size_t length = 0;
+    while (state.KeepRunning()) {
+        auto tiles = util::tileCover(sanFrancisco, 8);
+        length += tiles.size();
+    }
+}
+
+static const auto geomPolygon = Polygon<double>{
+    {
+        {-122.5143814086914,37.779127216982424},
+        {-122.50811576843262,37.72721239056709},
+        {-122.50313758850099,37.70820178063929},
+        {-122.3938751220703,37.707454835665274},
+        {-122.37567901611328,37.70663997801684},
+        {-122.36297607421874,37.71343018466285},
+        {-122.354736328125,37.727280276860036},
+        {-122.36469268798828,37.73868429065797},
+        {-122.38014221191408,37.75442980295571},
+        {-122.38391876220702,37.78753873820529},
+        {-122.35919952392578,37.8065289741725},
+        {-122.35679626464844,37.820632846207864},
+        {-122.3712158203125,37.835276322922695},
+        {-122.3818588256836,37.82958198283902},
+        {-122.37190246582031,37.80788523279169},
+        {-122.38735198974608,37.791337175930686},
+        {-122.40966796874999,37.812767557570204},
+        {-122.46425628662108,37.807071480609274},
+        {-122.46803283691405,37.810326435534755},
+        {-122.47901916503906,37.81168262440736},
+        {-122.48966217041016,37.78916666399649},
+        {-122.50579833984375,37.78781006166096},
+        {-122.5143814086914,37.779127216982424}
+    }
+};
+
+static void TileCoverPolygon(benchmark::State& state) {
+    std::size_t length = 0;
+
+    while (state.KeepRunning()) {
+        auto tiles = util::tileCover(geomPolygon, 8);
+        length += tiles.size();
+    }
+}
+
+static void TileCountPolygon(benchmark::State& state) {
+    std::size_t length = 0;
+
+    while (state.KeepRunning()) {
+        auto tiles = util::tileCount(geomPolygon, 16);
+        length += tiles;
+    }
+}
+
+BENCHMARK(TileCountBounds);
+BENCHMARK(TileCountPolygon);
+BENCHMARK(TileCoverPitchedViewport);
+BENCHMARK(TileCoverBounds);
+BENCHMARK(TileCoverPolygon);
+

--- a/cmake/benchmark-files.cmake
+++ b/cmake/benchmark-files.cmake
@@ -23,5 +23,6 @@ set(MBGL_BENCHMARK_FILES
 
     # util
     benchmark/util/dtoa.benchmark.cpp
+    benchmark/util/tilecover.benchmark.cpp
 
 )

--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -752,6 +752,8 @@ set(MBGL_CORE_FILES
     src/mbgl/util/tile_coordinate.hpp
     src/mbgl/util/tile_cover.cpp
     src/mbgl/util/tile_cover.hpp
+    src/mbgl/util/tile_cover_impl.cpp
+    src/mbgl/util/tile_cover_impl.hpp
     src/mbgl/util/tile_range.hpp
     src/mbgl/util/tiny_sdf.cpp
     src/mbgl/util/tiny_sdf.hpp

--- a/include/mbgl/util/projection.hpp
+++ b/include/mbgl/util/projection.hpp
@@ -78,8 +78,9 @@ public:
         return project_(latLng, worldSize(scale));
     }
 
-    static Point<double> project(const LatLng& latLng, uint8_t zoom) {
-        return project_(latLng, std::pow(2.0, zoom));
+    //Returns point on tile
+    static Point<double> project(const LatLng& latLng, int32_t zoom) {
+        return project_(latLng, 1 << zoom);
     }
 
     static LatLng unproject(const Point<double>& p, double scale, LatLng::WrapMode wrapMode = LatLng::Unwrapped) {
@@ -90,16 +91,7 @@ public:
             wrapMode
         };
     }
-    
-    // Project lat, lon to point in a zoom-dependent world size
-    static Point<double> project(const LatLng& point, uint8_t zoom, uint16_t tileSize) {
-        const double t2z = tileSize * std::pow(2, zoom);
-        Point<double> pt = project_(point, t2z);
-        // Flip y coordinate
-        auto x = ::round(std::min(pt.x, t2z));
-        auto y = ::round(std::min(t2z - pt.y, t2z));
-        return { x, y };
-    }
+
 private:
     static Point<double> project_(const LatLng& latLng, double worldSize) {
         return Point<double> {

--- a/platform/default/mbgl/storage/offline.cpp
+++ b/platform/default/mbgl/storage/offline.cpp
@@ -43,7 +43,7 @@ uint64_t OfflineTilePyramidRegionDefinition::tileCount(style::SourceType type, u
     const Range<uint8_t> clampedZoomRange = coveringZoomRange(type, tileSize, zoomRange);
     unsigned long result = 0;;
     for (uint8_t z = clampedZoomRange.min; z <= clampedZoomRange.max; z++) {
-        result +=  util::tileCount(bounds, z, tileSize);
+        result +=  util::tileCount(bounds, z);
     }
 
     return result;

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -7,6 +7,7 @@
 #include <mbgl/programs/programs.hpp>
 #include <mbgl/programs/background_program.hpp>
 #include <mbgl/util/tile_cover.hpp>
+#include <mbgl/map/transform_state.hpp>
 
 namespace mbgl {
 

--- a/src/mbgl/util/tile_cover.cpp
+++ b/src/mbgl/util/tile_cover.cpp
@@ -186,12 +186,10 @@ std::vector<UnwrappedTileID> tileCover(const Geometry<double>& geometry, int32_t
         tc.getTiles(scanCover);
     };
 
-    // Sort by y/x.
     t.sort([](const ID& a, const ID& b) {
         return std::tie(a.y, a.x) < std::tie(b.y, b.x);
     });
 
-    // Erase duplicate tile IDs.
     t.erase(std::unique(t.begin(), t.end(), [](const ID& a, const ID& b) {
         return a.x == b.x && a.y == b.y;
     }), t.end());

--- a/src/mbgl/util/tile_cover.cpp
+++ b/src/mbgl/util/tile_cover.cpp
@@ -186,14 +186,6 @@ std::vector<UnwrappedTileID> tileCover(const Geometry<double>& geometry, int32_t
         tc.getTiles(scanCover);
     };
 
-    t.sort([](const ID& a, const ID& b) {
-        return std::tie(a.y, a.x) < std::tie(b.y, b.x);
-    });
-
-    t.erase(std::unique(t.begin(), t.end(), [](const ID& a, const ID& b) {
-        return a.x == b.x && a.y == b.y;
-    }), t.end());
-
     std::vector<UnwrappedTileID> result;
     result.reserve(t.size());
     for (const auto& id : t) {

--- a/src/mbgl/util/tile_cover.cpp
+++ b/src/mbgl/util/tile_cover.cpp
@@ -30,7 +30,7 @@ struct edge {
 };
 
 // scan-line conversion
-static void scanSpans(edge e0, edge e1, int32_t ymin, int32_t ymax, ScanLine scanLine) {
+static void scanSpans(edge e0, edge e1, int32_t ymin, int32_t ymax, util::ScanLine scanLine) {
     double y0 = ::fmax(ymin, std::floor(e1.y0));
     double y1 = ::fmin(ymax, std::ceil(e1.y1));
 
@@ -54,7 +54,7 @@ static void scanSpans(edge e0, edge e1, int32_t ymin, int32_t ymax, ScanLine sca
 }
 
 // scan-line conversion
-static void scanTriangle(const Point<double>& a, const Point<double>& b, const Point<double>& c, int32_t ymin, int32_t ymax, ScanLine& scanLine) {
+static void scanTriangle(const Point<double>& a, const Point<double>& b, const Point<double>& c, int32_t ymin, int32_t ymax, util::ScanLine& scanLine) {
     edge ab = edge(a, b);
     edge bc = edge(b, c);
     edge ca = edge(c, a);

--- a/src/mbgl/util/tile_cover.cpp
+++ b/src/mbgl/util/tile_cover.cpp
@@ -3,6 +3,7 @@
 #include <mbgl/util/interpolate.hpp>
 #include <mbgl/map/transform_state.hpp>
 #include <mbgl/util/tile_cover_impl.hpp>
+#include <mbgl/util/tile_coordinate.hpp>
 
 #include <functional>
 #include <list>
@@ -246,15 +247,15 @@ TileCover::TileCover(const LatLngBounds&bounds_, int32_t z) {
     auto nw = Projection::project(bounds.northwest(), z);
 
     Polygon<double> p({ {sw, nw, ne, se, sw} });
-    impl = new TileCoverImpl(z, p, false);
+    impl = std::make_unique<TileCover::Impl>(z, p, false);
 }
 
-TileCover::TileCover(const Geometry<double>& geom, int32_t z, bool project/* = true*/) {
-    impl = new TileCoverImpl(z, geom, project);
+TileCover::TileCover(const Geometry<double>& geom, int32_t z, bool project/* = true*/)
+ : impl( std::make_unique<TileCover::Impl>(z, geom, project)) {
 }
 
 TileCover::~TileCover() {
-    delete impl;
+
 }
 
 bool TileCover::next() {

--- a/src/mbgl/util/tile_cover.hpp
+++ b/src/mbgl/util/tile_cover.hpp
@@ -2,10 +2,10 @@
 
 #include <mbgl/tile/tile_id.hpp>
 #include <mbgl/style/types.hpp>
-#include <mbgl/util/tile_coordinate.hpp>
 #include <mbgl/util/geometry.hpp>
 
 #include <vector>
+#include <memory>
 
 namespace mbgl {
 
@@ -14,7 +14,6 @@ class LatLngBounds;
 
 namespace util {
 
-class TileCoverImpl;
 using ScanLine = const std::function<void(int32_t x0, int32_t x1, int32_t y)>;
 
 // Helper class to stream tile-cover results per row
@@ -32,7 +31,8 @@ public:
     bool getTiles(ScanLine&);
 
 private:
-    TileCoverImpl* impl;
+    class Impl;
+    std::unique_ptr<Impl> impl;
 };
 
 int32_t coveringZoomLevel(double z, style::SourceType type, uint16_t tileSize);

--- a/src/mbgl/util/tile_cover.hpp
+++ b/src/mbgl/util/tile_cover.hpp
@@ -3,6 +3,7 @@
 #include <mbgl/tile/tile_id.hpp>
 #include <mbgl/style/types.hpp>
 #include <mbgl/util/geometry.hpp>
+#include <mbgl/util/optional.hpp>
 
 #include <vector>
 #include <memory>
@@ -14,8 +15,6 @@ class LatLngBounds;
 
 namespace util {
 
-using ScanLine = const std::function<void(int32_t x0, int32_t x1, int32_t y)>;
-
 // Helper class to stream tile-cover results per row
 class TileCover {
 public:
@@ -24,11 +23,8 @@ public:
     TileCover(const Geometry<double>&, int32_t z, bool project = true);
     ~TileCover();
 
-    //Returns false when there are no more rows to cover
-    bool next();
-    //Invokes the ScanLine callback to indicate tiles coverd for the row from [x0,x1)
-    // ScanLine may be invoked with duplcaite or overlapping ranges.
-    bool getTiles(ScanLine&);
+    optional<UnwrappedTileID> next();
+    bool hasNext();
 
 private:
     class Impl;

--- a/src/mbgl/util/tile_cover.hpp
+++ b/src/mbgl/util/tile_cover.hpp
@@ -3,7 +3,7 @@
 #include <mbgl/tile/tile_id.hpp>
 #include <mbgl/style/types.hpp>
 #include <mbgl/util/tile_coordinate.hpp>
-
+#include <mbgl/util/geometry.hpp>
 #include <vector>
 
 namespace mbgl {
@@ -13,13 +13,35 @@ class LatLngBounds;
 
 namespace util {
 
+class TileCoverImpl;
+using ScanLine = const std::function<void(int32_t x0, int32_t x1, int32_t y)>;
+
+// Helper class to stream tile-cover results per row
+class TileCover {
+public:
+    TileCover(const LatLngBounds&, int32_t z);
+    // When project == true, use projection the geometry points to tile coordinates
+    TileCover(const Geometry<double>&, int32_t z, bool project = true);
+    ~TileCover();
+
+    //Returns false when there are no more rows to cover
+    bool next();
+    //Invokes the ScanLine callback to indicate tiles coverd for the row from [x0,x1)
+    bool getTiles(ScanLine&);
+
+private:
+    TileCoverImpl* impl;
+};
+
 int32_t coveringZoomLevel(double z, style::SourceType type, uint16_t tileSize);
 
 std::vector<UnwrappedTileID> tileCover(const TransformState&, int32_t z);
 std::vector<UnwrappedTileID> tileCover(const LatLngBounds&, int32_t z);
+std::vector<UnwrappedTileID> tileCover(const Geometry<double>&, int32_t z);
 
 // Compute only the count of tiles needed for tileCover
 uint64_t tileCount(const LatLngBounds&, uint8_t z);
+uint64_t tileCount(const Geometry<double>&, uint8_t z);
 
 } // namespace util
 } // namespace mbgl

--- a/src/mbgl/util/tile_cover.hpp
+++ b/src/mbgl/util/tile_cover.hpp
@@ -19,7 +19,7 @@ std::vector<UnwrappedTileID> tileCover(const TransformState&, int32_t z);
 std::vector<UnwrappedTileID> tileCover(const LatLngBounds&, int32_t z);
 
 // Compute only the count of tiles needed for tileCover
-uint64_t tileCount(const LatLngBounds&, uint8_t z, uint16_t tileSize);
+uint64_t tileCount(const LatLngBounds&, uint8_t z);
 
 } // namespace util
 } // namespace mbgl

--- a/src/mbgl/util/tile_cover.hpp
+++ b/src/mbgl/util/tile_cover.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/style/types.hpp>
 #include <mbgl/util/tile_coordinate.hpp>
 #include <mbgl/util/geometry.hpp>
+
 #include <vector>
 
 namespace mbgl {
@@ -20,13 +21,14 @@ using ScanLine = const std::function<void(int32_t x0, int32_t x1, int32_t y)>;
 class TileCover {
 public:
     TileCover(const LatLngBounds&, int32_t z);
-    // When project == true, use projection the geometry points to tile coordinates
+    // When project == true, projects the geometry points to tile coordinates
     TileCover(const Geometry<double>&, int32_t z, bool project = true);
     ~TileCover();
 
     //Returns false when there are no more rows to cover
     bool next();
     //Invokes the ScanLine callback to indicate tiles coverd for the row from [x0,x1)
+    // ScanLine may be invoked with duplcaite or overlapping ranges.
     bool getTiles(ScanLine&);
 
 private:

--- a/src/mbgl/util/tile_cover_impl.cpp
+++ b/src/mbgl/util/tile_cover_impl.cpp
@@ -1,4 +1,5 @@
 #include <mbgl/util/tile_cover_impl.hpp>
+#include <mbgl/util/tile_coordinate.hpp>
 
 #include <functional>
 #include <cmath>
@@ -9,9 +10,16 @@
 namespace mbgl {
 namespace util {
 
+using PointList = std::vector<Point<double>>;
+
+struct TileSpan {
+    int32_t xmin, xmax;
+    bool winding;
+};
+
+
+// Find the first local minimum going forward in the list.
 void start_list_on_local_minimum(PointList& points) {
-    assert(points.size() > 2);
-    // Find the first local minimum going forward in the list
     auto prev_pt = std::prev(points.end(), 2);
     auto pt = points.begin();
     auto next_pt = std::next(pt);
@@ -25,18 +33,27 @@ void start_list_on_local_minimum(PointList& points) {
         next_pt++;
         if (next_pt == points.end()) { next_pt = std::next(points.begin()); }
     }
-    //Re-close the linear ring
-    points.pop_back();
+    //Re-close linear rings with first_pt = last_pt
+    if (points.back() == points.front()) {
+        points.pop_back();
+    }
     std::rotate(points.begin(), pt, points.end());
     points.push_back(*points.begin());
 }
 
+//Create a bound towards a local maximum point, starting from pt.
 Bound create_bound_towards_maximum(PointList& points, PointList::iterator& pt) {
     if (std::distance(pt, points.end()) < 2) { return {}; }
     if (std::distance(pt, points.end()) == 2) {
         Bound bnd;
-        if (points[0].y < points[1].y) std::copy(pt, points.end(), std::back_inserter(bnd.points));
-        else std::reverse_copy(pt, points.end(), std::back_inserter(bnd.points));
+        if (pt->y < std::next(pt)->y) {
+            std::copy(pt, points.end(), std::back_inserter(bnd.points));
+            bnd.winding = true;
+        }
+        else {
+            std::reverse_copy(pt, points.end(), std::back_inserter(bnd.points));
+            bnd.winding = false;
+        }
         pt = points.end();
         return bnd;
     }
@@ -62,12 +79,19 @@ Bound create_bound_towards_maximum(PointList& points, PointList::iterator& pt) {
     return bnd;
 }
 
+//Create a bound towards a local minimum point, starting from pt.
 Bound create_bound_towards_minimum(PointList& points, PointList::iterator& pt) {
     if (std::distance(pt, points.end()) < 2) { return {}; }
     if (std::distance(pt, points.end()) == 2) {
         Bound bnd;
-        if (pt->y < std::next(pt)->y) std::copy(pt, points.end(), std::back_inserter(bnd.points));
-        else std::reverse_copy(pt, points.end(), std::back_inserter(bnd.points));
+        if (pt->y < std::next(pt)->y) {
+            std::copy(pt, points.end(), std::back_inserter(bnd.points));
+            bnd.winding = true;
+        }
+        else {
+            std::reverse_copy(pt, points.end(), std::back_inserter(bnd.points));
+            bnd.winding = false;
+        }
         pt = points.end();
         return bnd;
     }
@@ -88,89 +112,98 @@ Bound create_bound_towards_minimum(PointList& points, PointList::iterator& pt) {
     Bound bnd;
     if (std::next(pt) == points.end()) { next_pt = points.end(); pt++; };
     bnd.points.reserve(static_cast<std::size_t>(std::distance(begin, next_pt)));
+    //For bounds that start at a max, reverse copy so that all bounds start at a min
     std::reverse_copy(begin, next_pt, std::back_inserter(bnd.points));
     bnd.winding = false;
     return bnd;
 }
 
-void build_edge_table(PointList& points, uint32_t maxTile, EdgeTable& et, bool closed = false) {
+//Build a map of bounds and their starting Y tile coordinate.
+void build_bounds_map(PointList& points, uint32_t maxTile, BoundsMap& et, bool closed = false) {
+    if (points.size() < 2) return;
+    //While traversing closed rings, start the bounds at a local minimum
     if (closed) {
         start_list_on_local_minimum(points);
     }
+
     auto pointsIter = points.begin();
     while (pointsIter != points.end()) {
         Bound to_max = create_bound_towards_maximum(points, pointsIter);
         Bound to_min = create_bound_towards_minimum(points, pointsIter);
 
         if (to_max.points.size() > 0) {
-            // Projections may result in values beyond the bounds due to double precision
+            // Projections may result in values beyond the bounds, clamp to max tile coordinates
             const auto y = static_cast<uint32_t>(std::floor(clamp(to_max.points.front().y, 0.0, (double)maxTile)));
-            et[y].push_back(std::move(to_max));
+            et[y].push_back(to_max);
         }
         if (to_min.points.size() > 0) {
             const auto y = static_cast<uint32_t>(std::floor(clamp(to_min.points.front().y, 0.0, (double)maxTile)));
-            et[y].push_back(std::move(to_min));
+            et[y].push_back(to_min);
         }
     }
     assert(pointsIter == points.end());
 }
 
-std::vector<TileCoverRange> scan_row(uint32_t y, BoundList& aet) {
-    std::vector<TileCoverRange> tile_range;
+void update_span(TileSpan& xp, double x) {
+    xp.xmin = std::min(xp.xmin, static_cast<int32_t>(std::floor(x)));
+    xp.xmax = std::max(xp.xmax, static_cast<int32_t>(std::ceil(x)));
+}
+
+//Build a vector of X tile-coordinates spanned by each bound.
+std::vector<TileSpan> scan_row(uint32_t y, Bounds& aet) {
+    std::vector<TileSpan> tile_range;
     tile_range.reserve(aet.size());
 
     for(Bound& b: aet) {
-        TileCoverRange xp = { INT_MAX, 0 , b.winding };
+        TileSpan xp = { INT_MAX, 0, b.winding };
         double x;
         const auto numEdges = b.points.size() - 1;
         assert(numEdges >= 1);
-        while (b.currentPointIndex < numEdges) {
+        while (b.currentPoint < numEdges) {
             x = b.interpolate(y);
-            xp.x0 = std::min(xp.x0, static_cast<int32_t>(std::floor(x)));
-            xp.x1 = std::max(xp.x1, static_cast<int32_t>(std::ceil(x)));
+            update_span(xp, x);
 
-            // If this edge ends beyond the current row, find the x-value at the exit,
-            //  and be done with this bound
-            auto& p1 = b.points[b.currentPointIndex + 1];
+            // If this edge ends beyond the current row, find the x-intercept where
+            // it exits the row
+            auto& p1 = b.points[b.currentPoint + 1];
             if (p1.y > y+1) {
                 x = b.interpolate(y+1);
-                xp.x0 = std::min(xp.x0, static_cast<int32_t>(std::floor(x)));
-                xp.x1 = std::max(xp.x1, static_cast<int32_t>(std::ceil(x)));
+                update_span(xp, x);
                 break;
-            } else if(b.currentPointIndex == numEdges - 1) {
-                // For last edge, consider x at edge end;
+            } else if(b.currentPoint == numEdges - 1) {
+                // For last edge, consider x-intercept at the end of the edge.
                 x = p1.x;
-                xp.x0 = std::min(xp.x0, static_cast<int32_t>(std::floor(x)));
-                xp.x1 = std::max(xp.x1, static_cast<int32_t>(std::ceil(x)));
+                update_span(xp, x);
             }
-            b.currentPointIndex++;
+            b.currentPoint++;
         }
         tile_range.push_back(xp);
     }
-    // Erase bounds in aet whose current edge ends inside this row, or there are no more edges
+    // Erase bounds in the active table whose current edge ends inside this row,
+    // or there are no more edges
     auto bound = aet.begin();
     while (bound != aet.end()) {
-        if ( bound->currentPointIndex == bound->points.size() - 1 &&
-            bound->points[bound->currentPointIndex].y <= y+1) {
+        if ( bound->currentPoint == bound->points.size() - 1 &&
+            bound->points[bound->currentPoint].y <= y+1) {
             bound = aet.erase(bound);
         } else {
             bound++;
         }
     }
     // Sort the X-extents of each crossing bound by x_min, x_max
-    std::sort(tile_range.begin(), tile_range.end(), [] (TileCoverRange& a, TileCoverRange& b) {
-        return std::tie(a.x0, a.x1) < std::tie(b.x0, b.x1);
+    std::sort(tile_range.begin(), tile_range.end(), [] (TileSpan& a, TileSpan& b) {
+        return std::tie(a.xmin, a.xmax) < std::tie(b.xmin, b.xmax);
     });
 
     return tile_range;
 }
 
-struct ToEdgeTable {
+struct BuildBoundsMap {
     int32_t zoom;
     bool project = false;
-    ToEdgeTable(int32_t z, bool p): zoom(z), project(p) {}
+    BuildBoundsMap(int32_t z, bool p): zoom(z), project(p) {}
 
-    void buildTable(const std::vector<Point<double>>& points, EdgeTable& et, bool closed = false) const {
+    void buildTable(const std::vector<Point<double>>& points, BoundsMap& et, bool closed = false) const {
         PointList projectedPoints;
         if (project) {
             projectedPoints.reserve(points.size());
@@ -181,15 +214,15 @@ struct ToEdgeTable {
         } else {
             projectedPoints.insert(projectedPoints.end(), points.begin(), points.end());
         }
-        build_edge_table(projectedPoints, 1 << zoom, et, closed);
+        build_bounds_map(projectedPoints, 1 << zoom, et, closed);
     }
 
-    void buildPolygonTable(const Polygon<double>& polygon, EdgeTable& et) const {
+    void buildPolygonTable(const Polygon<double>& polygon, BoundsMap& et) const {
         for(const auto&ring : polygon) {
             buildTable(ring, et, true);
         }
     }
-    EdgeTable operator()(const Point<double>&p) const {
+    BoundsMap operator()(const Point<double>&p) const {
         Bound bnd;
         auto point = p;
         if(project) {
@@ -197,14 +230,14 @@ struct ToEdgeTable {
         }
         bnd.points.insert(bnd.points.end(), 2, point);
         bnd.winding = false;
-        EdgeTable et;
+        BoundsMap et;
         const auto y = static_cast<uint32_t>(std::floor(clamp(point.y, 0.0, (double)(1 << zoom))));
         et[y].push_back(bnd);
         return et;
     }
 
-    EdgeTable operator()(const MultiPoint<double>& points) const {
-        EdgeTable et;
+    BoundsMap operator()(const MultiPoint<double>& points) const {
+        BoundsMap et;
         for (const Point<double>& p: points) {
             Bound bnd;
             auto point = p;
@@ -219,97 +252,113 @@ struct ToEdgeTable {
         return et;
     }
 
-    EdgeTable operator()(const LineString<double>& lines) const {
-        EdgeTable et;
+    BoundsMap operator()(const LineString<double>& lines) const {
+        BoundsMap et;
         buildTable(lines, et);
         return et;
     }
 
-    EdgeTable operator()(const MultiLineString<double>& lines) const {
-        EdgeTable et;
+    BoundsMap operator()(const MultiLineString<double>& lines) const {
+        BoundsMap et;
         for(const auto&line : lines) {
             buildTable(line, et);
         }
         return et;
     }
 
-    EdgeTable operator()(const Polygon<double>& polygon) const {
-        EdgeTable et;
+    BoundsMap operator()(const Polygon<double>& polygon) const {
+        BoundsMap et;
         buildPolygonTable(polygon, et);
         return et;
     }
 
-    EdgeTable operator()(const MultiPolygon<double>& polygons) const {
-        EdgeTable et;
+    BoundsMap operator()(const MultiPolygon<double>& polygons) const {
+        BoundsMap et;
         for(const auto& polygon: polygons) {
             buildPolygonTable(polygon, et);
         }
         return et;
     }
 
-    EdgeTable operator()(const mapbox::geometry::geometry_collection<double>&) const {
+    BoundsMap operator()(const mapbox::geometry::geometry_collection<double>&) const {
         return {};
     }
 };
 
-TileCover::Impl::Impl(int32_t z, const Geometry<double>& geom, bool project): maxY(1 << z) {
+TileCover::Impl::Impl(int32_t z, const Geometry<double>& geom, bool project)
+ : zoom(z) {
     ToFeatureType toFeatureType;
     isClosed = apply_visitor(toFeatureType, geom) == FeatureType::Polygon;
 
-    ToEdgeTable toEdgeTable(z, project);
-    edgeTable = apply_visitor(toEdgeTable, geom);
-    reset();
+    BuildBoundsMap toBoundsMap(z, project);
+    boundsMap = apply_visitor(toBoundsMap, geom);
+    if (boundsMap.size() == 0) return;
+
+    //Iniitalize the active edge table, and current row span
+    currentBounds = boundsMap.begin();
+    tileY = 0;
+    nextRow();
+    if (tileXSpans.empty()) return;
+    tileX = tileXSpans.front().first;
 }
 
-void TileCover::Impl::reset() {
-    if (edgeTable.size() == 0) return;
-    currentEdgeTable = edgeTable.begin();
-    activeEdgeTable = currentEdgeTable->second;
-    currentRow = currentEdgeTable->first;
-}
+void TileCover::Impl::nextRow() {
+    // Update AET for next row
+    if (currentBounds != boundsMap.end()) {
+        if (activeBounds.size() == 0 && currentBounds->first > tileY) {
+            //For multi-geoms: use the next row with an edge table starting point
+            tileY = currentBounds->first;
+        }
+        if (tileY == currentBounds->first) {
+            
+            std::move(currentBounds->second.begin(), currentBounds->second.end(), std::back_inserter(activeBounds));
+            currentBounds++;
+        }
+    }
+    //Scan aet and update currenRange with x_min, x_max pairs
+    auto xps = util::scan_row(tileY, activeBounds);
+    if (xps.size() == 0) {
+        return;
+    }
 
-bool TileCover::Impl::next() {
-    return activeEdgeTable.size() != 0 && currentRow < maxY;
-}
-
-bool TileCover::Impl::scanRow(ScanLine& scanCover) {
-    if (!next()) { return false; }
-
-    auto xps = util::scan_row(currentRow, activeEdgeTable);
-    assert(isClosed ? xps.size() % 2 == 0 : true);
-
-    auto x_min = xps[0].x0;
-    auto x_max = xps[0].x1;
+    auto x_min = xps[0].xmin;
+    auto x_max = xps[0].xmax;
     int32_t nzRule = xps[0].winding ? 1 : -1;
     for (size_t i = 1; i < xps.size(); i++) {
         auto xp = xps[i];
         if (!(isClosed && nzRule != 0)) {
-            if (xp.x0 >= x_max) {
-                scanCover(x_min, x_max, currentRow);
-                x_min = xp.x0;
+            if (xp.xmin > x_max && xp.xmax >= x_max) {
+                tileXSpans.emplace(x_min, x_max);
+                x_min = xp.xmin;
             }
         }
         nzRule += xp.winding ? 1 : -1;
-        x_max = std::max(x_min, xp.x1);
+        x_max = std::max(x_min, xp.xmax);
     }
-    scanCover(x_min, x_max, currentRow);
-    assert(isClosed ? nzRule == 0 : true);
+    tileXSpans.emplace(x_min, x_max);
+}
 
-    // Update AET for next row
-    currentRow++;
-    auto nextRow = std::next(currentEdgeTable);
-    if (nextRow != edgeTable.end()) {
-        if (activeEdgeTable.size() == 0 && nextRow->first > currentRow) {
-            //For multi-geoms: Use the next row with an edge table starting point
-            currentRow = nextRow->first;
+bool TileCover::Impl::hasNext() const {
+    return (!tileXSpans.empty() && tileX < tileXSpans.front().second && tileY < (1 << zoom));
+}
+
+optional<UnwrappedTileID> TileCover::Impl::next() {
+    if (!hasNext()) return {};
+
+    const auto x = tileX;
+    const auto y = tileY;
+    tileX++;
+    if (tileX >= tileXSpans.front().second) {
+        tileXSpans.pop();
+        if(tileXSpans.empty()) {
+            tileY++;
+            nextRow();
         }
-        if (currentRow == nextRow->first) {
-            activeEdgeTable.insert(activeEdgeTable.end(), nextRow->second.begin(), nextRow->second.end());
-            currentEdgeTable++;
+        if (!tileXSpans.empty()) {
+            tileX = tileXSpans.front().first;
         }
     }
-    return next();
-
+    return UnwrappedTileID(zoom, x, y);
 }
 
 } // namespace util

--- a/src/mbgl/util/tile_cover_impl.cpp
+++ b/src/mbgl/util/tile_cover_impl.cpp
@@ -147,7 +147,7 @@ std::vector<x_range> scan_row(uint32_t y, bound_list& aet) {
         }
         tile_range.push_back(xp);
     }
-    // Erase bounds in the aet whose current edge ends inside this row, or there are no more edges
+    // Erase bounds in aet whose current edge ends inside this row, or there are no more edges
     auto bound = aet.begin();
     while (bound != aet.end()) {
         if ( bound->currentPointIndex == bound->points.size() - 1 &&
@@ -157,7 +157,7 @@ std::vector<x_range> scan_row(uint32_t y, bound_list& aet) {
             bound++;
         }
     }
-    // Sort the X-extents of each lml by x_min, x_max
+    // Sort the X-extents of each crossing bound by x_min, x_max
     std::sort(tile_range.begin(), tile_range.end(), [] (x_range& a, x_range& b) {
         return std::tie(a.first, a.second) < std::tie(b.first, b.second);
     });
@@ -264,7 +264,6 @@ bool TileCoverImpl::scanRow(ScanLine& scanCover) {
         auto x_max = p++->second;
         scanCover(x_min, x_max, currentY);
     }
-    // Move to the next row
     currentY++;
 
     // Update AET for next row

--- a/src/mbgl/util/tile_cover_impl.cpp
+++ b/src/mbgl/util/tile_cover_impl.cpp
@@ -1,6 +1,5 @@
 #include <mbgl/util/tile_cover_impl.hpp>
 
-#include <iostream>
 #include <functional>
 #include <cmath>
 #include <assert.h>
@@ -10,102 +9,111 @@
 namespace mbgl {
 namespace util {
 
-//namespace {
-void start_list_on_local_minimum(edge_list& edges) {
-    if (edges.size() <= 2) {
-        return;
-    }
+void start_list_on_local_minimum(point_list& points) {
+    assert(points.size() > 2);
     // Find the first local minimum going forward in the list
-    auto prev_edge = edges.end();
-    --prev_edge;
-    auto edge = edges.begin();
-
-    while (edge != edges.end()) {
-        if (edge->p0 == prev_edge->p0) {
+    auto prev_pt = std::prev(points.end(), 2);
+    auto pt = points.begin();
+    auto next_pt = std::next(pt);
+    while (pt != points.end()) {
+        if ((pt->y <= prev_pt->y) &&
+            (pt->y < next_pt->y)) {
             break;
         }
-        prev_edge = edge;
-        ++edge;
+        prev_pt = pt;
+        pt++;
+        next_pt++;
+        if (next_pt == points.end()) { next_pt = std::next(points.begin()); }
     }
-    std::rotate(edges.begin(), edge, edges.end());
+    //Re-close the linear ring
+    points.erase(std::prev(points.end()));
+    std::rotate(points.begin(), pt, points.end());
+    points.push_back(*points.begin());
 }
 
-bound create_bound_towards_maximum(edge_list& edges) {
-    if (edges.size() == 0) return {};
-    if (edges.size() == 1) {
+bound create_bound_towards_maximum(point_list& points, point_list::iterator& pt) {
+    if (std::distance(pt, points.end()) < 2) { return {}; };
+    if (std::distance(pt, points.end()) == 2) {
         bound bnd;
-        std::swap(bnd.edges, edges);
+        if (points[0].y < points[1].y) std::copy(pt, points.end(), std::back_inserter(bnd.points));
+        else std::reverse_copy(pt, points.end(), std::back_inserter(bnd.points));
+        pt = points.end();
         return bnd;
     }
-    auto next_edge = edges.begin();
-    auto edge = next_edge;
-    ++next_edge;
-
-    while (next_edge != edges.end()) {
-        if (edge->p1 == next_edge->p1) {
+    const auto begin = pt;
+    auto prev_pt = pt == points.begin() ? std::prev(points.end(), 2) : std::prev(pt);
+    auto next_pt = std::next(pt) == points.end() ? std::next(points.begin()) : std::next(pt);
+    while (pt != points.end()) {
+        if ((pt->y >= prev_pt->y) &&
+            (pt->y > next_pt->y )) {
             break;
         }
-        edge = next_edge;
-        ++next_edge;
+        prev_pt = pt;
+        pt++;
+        next_pt++;
+        if (next_pt == points.end()) { next_pt = std::next(points.begin()); }
     }
 
     bound bnd;
-    bnd.edges.reserve(static_cast<std::size_t>(std::distance(edges.begin(), next_edge)));
-    std::move(edges.begin(), next_edge, std::back_inserter(bnd.edges));
-    edges.erase(edges.begin(), next_edge);
+    if (std::next(pt) == points.end()) { next_pt = points.end(); pt++; };
+    bnd.points.reserve(static_cast<std::size_t>(std::distance(begin, next_pt)));
+    std::copy(begin, next_pt, std::back_inserter(bnd.points));
 
     return bnd;
 }
 
-bound create_bound_towards_minimum(edge_list& edges) {
-    if (edges.size() == 0) return {};
-    if (edges.size() == 1) {
+bound create_bound_towards_minimum(point_list& points, point_list::iterator& pt) {
+    if (std::distance(pt, points.end()) < 2) { return {}; };
+    if (std::distance(pt, points.end()) == 2) {
         bound bnd;
-        std::swap(bnd.edges, edges);
+        if (pt->y < std::next(pt)->y) std::copy(pt, points.end(), std::back_inserter(bnd.points));
+        else std::reverse_copy(pt, points.end(), std::back_inserter(bnd.points));
+        pt = points.end();
         return bnd;
     }
-    auto next_edge = edges.begin();
-    auto edge = next_edge;
-    ++next_edge;
-
-    while (next_edge != edges.end()) {
-        if (edge->p0 == next_edge->p0) {
+    auto begin = pt;
+    auto prev_pt = pt == points.begin() ? std::prev(points.end(), 2) : std::prev(pt);
+    auto next_pt = std::next(pt) == points.end() ? std::next(points.begin()) : std::next(pt);
+    while (pt != points.end()) {
+        if ((pt->y <= prev_pt->y) &&
+            (pt->y < next_pt->y)) {
             break;
         }
-        edge = next_edge;
-        ++next_edge;
+        prev_pt = pt;
+        pt++;
+        next_pt++;
+        if (next_pt == points.end()) { next_pt = std::next(points.begin()); }
     }
 
     bound bnd;
-
-    bnd.edges.reserve(static_cast<std::size_t>(std::distance(edges.begin(), next_edge)));
-    std::move(edges.begin(), next_edge, std::back_inserter(bnd.edges));
-    edges.erase(edges.begin(), next_edge);
-    std::reverse(bnd.edges.begin(), bnd.edges.end());
-
+    if (std::next(pt) == points.end()) { next_pt = points.end(); pt++; };
+    bnd.points.reserve(static_cast<std::size_t>(std::distance(begin, next_pt)));
+    std::reverse_copy(begin, next_pt, std::back_inserter(bnd.points));
     return bnd;
 }
 
-void build_edge_table(edge_list& edges, uint32_t maxTile, edge_table& et, bool closed = false) {
+void build_edge_table(point_list& points, uint32_t maxTile, edge_table& et, bool closed = false) {
     if (closed) {
-        start_list_on_local_minimum(edges);
+        start_list_on_local_minimum(points);
     }
-    bound to_max, to_min;
-    while (!edges.empty()) {
-        to_max = create_bound_towards_maximum(edges);
-        to_min = create_bound_towards_minimum(edges);
+    auto pointsIter = points.begin();
+    while (pointsIter != points.end()) {
+        bound to_max = create_bound_towards_maximum(points, pointsIter);
+        bound to_min = create_bound_towards_minimum(points, pointsIter);
 
-        if (to_max.edges.size() > 0) {
+        if (to_max.points.size() > 0) {
             // Projections may result in values beyond the bounds due to double precision
-            const auto y = static_cast<uint32_t>(std::floor(util::clamp(to_max.edges.front().p0.y, 0.0, (double)maxTile)));
+            const auto y = static_cast<uint32_t>(std::floor(clamp(to_max.points.front().y, 0.0, (double)maxTile)));
+            to_max.interpolate(y);
             et[y].push_back(std::move(to_max));
         }
-        if (to_min.edges.size() > 0) {
-            const auto y = static_cast<uint32_t>(std::floor(util::clamp(to_min.edges.front().p0.y, 0.0, (double)maxTile)));
+        if (to_min.points.size() > 0) {
+            const auto y = static_cast<uint32_t>(std::floor(clamp(to_min.points.front().y, 0.0, (double)maxTile)));
+            to_min.interpolate(y);
             et[y].push_back(std::move(to_min));
         }
     }
-    assert(edges.size() == 0);
+    assert(pointsIter == points.end());
 }
 
 std::vector<x_range> scan_row(uint32_t y, bound_list& aet) {
@@ -115,38 +123,38 @@ std::vector<x_range> scan_row(uint32_t y, bound_list& aet) {
     for(bound& b: aet) {
         x_range xp = { INT_MAX, 0 };
         double x;
-        const auto numEdges = b.edges.size();
-        while (b.currentEdgeIndex < numEdges) {
-            auto& e = b.currentEdge();
-            x = e.x;
+        const auto numEdges = b.points.size() - 1;
+        while (b.currentPointIndex < numEdges) {
+            x = b.currentX;
             xp.first = std::min(xp.first, static_cast<int32_t>(std::floor(x)));
             xp.second = std::max(xp.second, static_cast<int32_t>(std::ceil(x)));
 
             // If this edge ends beyond the current row, find the x-value at the exit,
             //  and be done with this bound
-            if (e.p1.y > y+1) {
-                x = e.interpolate(y+1);
+            auto& p1 = b.points[b.currentPointIndex + 1];
+            if (p1.y > y+1) {
+                x = b.interpolate(y+1);
                 xp.first = std::min(xp.first, static_cast<int32_t>(std::floor(x)));
                 xp.second = std::max(xp.second, static_cast<int32_t>(std::ceil(x)));
                 break;
-            } else if(b.currentEdgeIndex == numEdges - 1) {
+            } else if(b.currentPointIndex == numEdges - 1) {
                 // For last edge, consider x at edge end;
-                x = e.p1.x;
+                x = p1.x;
                 xp.first = std::min(xp.first, static_cast<int32_t>(std::floor(x)));
                 xp.second = std::max(xp.second, static_cast<int32_t>(std::ceil(x)));
             }
-            b.currentEdgeIndex++;
+            b.currentPointIndex++;
         }
         tile_range.push_back(xp);
     }
     // Erase bounds in the aet whose current edge ends inside this row, or there are no more edges
-    auto b = aet.begin();
-    while (b != aet.end()) {
-        if ( b->currentEdgeIndex >= b->edges.size() ||
-            b->currentEdge().p1.y <= y+1) {
-            b = aet.erase(b);
+    auto bound = aet.begin();
+    while (bound != aet.end()) {
+        if ( bound->currentPointIndex == bound->points.size() - 1 &&
+            bound->points[bound->currentPointIndex].y <= y+1) {
+            bound = aet.erase(bound);
         } else {
-            b++;
+            bound++;
         }
     }
     // Sort the X-extents of each lml by x_min, x_max
@@ -157,137 +165,118 @@ std::vector<x_range> scan_row(uint32_t y, bound_list& aet) {
     return tile_range;
 }
 
-struct ToEdges {
+struct ToEdgeTables {
     int32_t zoom;
-    bool project;
-    ToEdges(int32_t z, bool p): zoom(z), project(p) {}
+    bool project = false;
+    ToEdgeTables(int32_t z, bool p): zoom(z), project(p) {}
 
-    void makeEdges(const std::vector<Point<double>>& points, edge_list& edges) const {
-        edges.reserve(edges.size() + points.size()-1);
-        auto p1 = !project ? points[0] : Projection::project({points[0].y, points[0].x}, zoom);
-        for (uint32_t j=1; j < points.size(); j++) {
-            auto p2 = !project ? points[j] : Projection::project({points[j].y, points[j].x}, zoom);
-            edges.emplace_back(p1, p2);
-            p1 = p2;
+    void buildTable(const std::vector<Point<double>>& points, edge_table& et, bool closed = false) const {
+        point_list projectedPoints;
+        if (project) {
+            projectedPoints.reserve(points.size());
+            for(const auto&p : points) {
+                projectedPoints.push_back(
+                    Projection::project(LatLng{ p.y, p.x }, zoom));
+            }
+        } else {
+            projectedPoints.insert(projectedPoints.end(), points.begin(), points.end());
         }
+        build_edge_table(projectedPoints, 1 << zoom, et, closed);
     }
-
-    edge_list polyEdges(const Polygon<double>& g) const {
-        edge_list edges;
-
-        for (uint32_t i = 0; i < g.size(); i++) {
-            const auto ring = g[i];
-            makeEdges(ring, edges);
+    
+    edge_table buildPolygonTable(const Polygon<double>& polygon) const {
+        edge_table et;
+        for(const auto&ring : polygon) {
+            buildTable(ring, et, true);
         }
-        return edges;
+        return et;
+    }
+    std::vector<edge_table> operator()(const Point<double>&) const {
+        return { };
     }
 
-    std::vector<edge_list> operator()(const Point<double>& p) const {
-        const auto pt = Projection::project({p.y, p.x}, zoom);
-        return { { {pt, pt} } };
+    std::vector<edge_table> operator()(const MultiPoint<double>&) const {
+        return { };
     }
 
-    std::vector<edge_list> operator()(const MultiPoint<double>&points) const {
-        std::vector<edge_list> edgeLists;
-        edgeLists.reserve(points.size());
-        for (const auto& p: points) {
-            const auto pt = Projection::project({p.y, p.x}, zoom);
-            edgeLists.push_back({ edge{pt, pt} });
+    std::vector<edge_table> operator()(const LineString<double>& lines) const {
+        edge_table et;
+        buildTable(lines, et);
+        return { et };
+    }
+
+    std::vector<edge_table> operator()(const MultiLineString<double>& lines) const {
+        edge_table et;
+        for(const auto&line : lines) {
+            buildTable(line, et);
         }
-        return edgeLists;
+        return { et };
     }
 
-    std::vector<edge_list> operator()(const LineString<double>& lines) const {
-        edge_list edges;
-        makeEdges(lines, edges);
-        return { edges };
+    std::vector<edge_table> operator()(const Polygon<double>& polygon) const {
+        return { buildPolygonTable(polygon) };
     }
 
-    std::vector<edge_list> operator()(const MultiLineString<double>& g) const {
-        std::vector<edge_list> edgeLists;
-        for(const auto& lines: g) {
-            edge_list edges;
-            makeEdges(lines, edges);
-            edgeLists.push_back(edges);
-            edges.clear();
+    std::vector<edge_table> operator()(const MultiPolygon<double>& polygons) const {
+        std::vector<edge_table> tables;
+        for(const auto& polygon: polygons) {
+            tables.push_back(buildPolygonTable(polygon));
         }
-        return edgeLists;
+        return tables;
     }
 
-    std::vector<edge_list> operator()(const Polygon<double>& g) const {
-        return { polyEdges(g) };
-    }
-
-    std::vector<edge_list> operator()(const MultiPolygon<double>& g) const {
-        std::vector<edge_list> edgeLists;
-        for(const auto& polygon: g) {
-            edgeLists.push_back(polyEdges(polygon));
-        }
-        return edgeLists;
-    }
-
-    std::vector<edge_list> operator()(const mapbox::geometry::geometry_collection<double>&) const {
+    std::vector<edge_table> operator()(const mapbox::geometry::geometry_collection<double>&) const {
         return {};
     }
 };
 
-//} //end namespace
-
-TileCoverImpl::TileCoverImpl(int32_t z, const Geometry<double>& geom, bool project): max_y(1 << z) {
+TileCoverImpl::TileCoverImpl(int32_t z, const Geometry<double>& geom, bool project): maxY(1 << z) {
     ToFeatureType toFeatureType;
-    closed_geom = apply_visitor(toFeatureType, geom) == FeatureType::Polygon;
+    isClosed = apply_visitor(toFeatureType, geom) == FeatureType::Polygon;
 
-    // Build edge table
-    ToEdges te(z, project);
-    std::vector<edge_list> edgeLists = apply_visitor(te, geom);
-    for(auto& edges: edgeLists) {
-        edge_table table;
-        build_edge_table(edges, max_y, table, closed_geom);
-        et.push_back(table);
-    }
+    ToEdgeTables toEdgeTables(z, project);
+    edgeTables = apply_visitor(toEdgeTables, geom);
     reset();
 }
 
 void TileCoverImpl::reset() {
-    current_edge_table = et.begin();
-    if (current_edge_table != et.end()) {
-        aet = current_edge_table->begin()->second;
-        current_y = current_edge_table->begin()->first;
+    currentEdgeTable = edgeTables.begin();
+    if (currentEdgeTable != edgeTables.end()) {
+        activeEdgeTable = currentEdgeTable->begin()->second;
+        currentY = currentEdgeTable->begin()->first;
     }
 }
 
 bool TileCoverImpl::next() {
-    return current_edge_table != et.end() && aet.size() != 0 && current_y < max_y;
+    return currentEdgeTable != edgeTables.end() && activeEdgeTable.size() != 0 && currentY < maxY;
 }
 
 bool TileCoverImpl::scanRow(ScanLine& scanCover) {
     if (!next()) { return false; }
 
-    auto xps = util::scan_row(current_y, aet);
+    auto xps = util::scan_row(currentY, activeEdgeTable);
     auto p = xps.begin();
-
+    assert(isClosed ? xps.size() % 2 == 0 : true);
     while (p != xps.end()) {
         auto x_min = p->first;
         // For closed geometries, consider odd even pairs of tile ranges
-        if (closed_geom) { p++; }
+        if (isClosed) { p++; }
         auto x_max = p++->second;
-        scanCover(x_min, x_max, current_y);
+        scanCover(x_min, x_max, currentY);
     }
-
     // Move to the next row
-    current_y++;
+    currentY++;
 
     // Update AET for next row
-    auto nextRow = current_edge_table->find(current_y);
-    if (nextRow != current_edge_table->end()) {
-        aet.insert(aet.end(), nextRow->second.begin(), nextRow->second.end());
-    } else if (aet.size() == 0){
-        current_edge_table++;
-        if (current_edge_table == et.end()) return false;
-        aet = current_edge_table->begin()->second;
-        current_y = current_edge_table->begin()->first;
+    auto nextRow = currentEdgeTable->find(currentY);
+    if (nextRow != currentEdgeTable->end()) {
+        activeEdgeTable.insert(activeEdgeTable.end(), nextRow->second.begin(), nextRow->second.end());
+    } else if (activeEdgeTable.size() == 0){
+        currentEdgeTable++;
+        if (currentEdgeTable == edgeTables.end()) return false;
+        activeEdgeTable = currentEdgeTable->begin()->second;
+        currentY = currentEdgeTable->begin()->first;
     }
-
     return next();
 }
 

--- a/src/mbgl/util/tile_cover_impl.cpp
+++ b/src/mbgl/util/tile_cover_impl.cpp
@@ -339,7 +339,7 @@ void TileCover::Impl::nextRow() {
 }
 
 bool TileCover::Impl::hasNext() const {
-    return (!tileXSpans.empty() && tileX < tileXSpans.front().second && tileY < (1 << zoom));
+    return (!tileXSpans.empty() && tileX < tileXSpans.front().second && tileY < (1u << zoom));
 }
 
 optional<UnwrappedTileID> TileCover::Impl::next() {

--- a/src/mbgl/util/tile_cover_impl.cpp
+++ b/src/mbgl/util/tile_cover_impl.cpp
@@ -1,0 +1,276 @@
+#include <mbgl/util/tile_cover_impl.hpp>
+
+#include <iostream>
+#include <functional>
+#include <cmath>
+#include <assert.h>
+#include <limits.h>
+#include <algorithm>
+
+namespace mbgl {
+namespace util {
+
+//namespace {
+void start_list_on_local_minimum(edge_list& edges) {
+    if (edges.size() <= 2) {
+        return;
+    }
+    // Find the first local minimum going forward in the list
+    auto prev_edge = edges.end();
+    --prev_edge;
+    auto edge = edges.begin();
+
+    while (edge != edges.end()) {
+        if (edge->p0 == prev_edge->p0) {
+            break;
+        }
+        prev_edge = edge;
+        ++edge;
+    }
+    std::rotate(edges.begin(), edge, edges.end());
+}
+
+bound create_bound_towards_maximum(edge_list& edges) {
+    if (edges.size() == 0) return {};
+    if (edges.size() == 1) {
+        bound bnd;
+        std::swap(bnd.edges, edges);
+        return bnd;
+    }
+    auto next_edge = edges.begin();
+    auto edge = next_edge;
+    ++next_edge;
+
+    while (next_edge != edges.end()) {
+        if (edge->p1 == next_edge->p1) {
+            break;
+        }
+        edge = next_edge;
+        ++next_edge;
+    }
+
+    bound bnd;
+    bnd.edges.reserve(static_cast<std::size_t>(std::distance(edges.begin(), next_edge)));
+    std::move(edges.begin(), next_edge, std::back_inserter(bnd.edges));
+    edges.erase(edges.begin(), next_edge);
+
+    return bnd;
+}
+
+bound create_bound_towards_minimum(edge_list& edges) {
+    if (edges.size() == 0) return {};
+    if (edges.size() == 1) {
+        bound bnd;
+        std::swap(bnd.edges, edges);
+        return bnd;
+    }
+    auto next_edge = edges.begin();
+    auto edge = next_edge;
+    ++next_edge;
+
+    while (next_edge != edges.end()) {
+        if (edge->p0 == next_edge->p0) {
+            break;
+        }
+        edge = next_edge;
+        ++next_edge;
+    }
+
+    bound bnd;
+
+    bnd.edges.reserve(static_cast<std::size_t>(std::distance(edges.begin(), next_edge)));
+    std::move(edges.begin(), next_edge, std::back_inserter(bnd.edges));
+    edges.erase(edges.begin(), next_edge);
+    std::reverse(bnd.edges.begin(), bnd.edges.end());
+
+    return bnd;
+}
+
+void build_edge_table(edge_list& edges, uint32_t maxTile, edge_table& et, bool closed = false) {
+    if (closed) {
+        start_list_on_local_minimum(edges);
+    }
+    bound to_max, to_min;
+    while (!edges.empty()) {
+        to_max = create_bound_towards_maximum(edges);
+        to_min = create_bound_towards_minimum(edges);
+
+        if (to_max.edges.size() > 0) {
+            // Projections may result in values beyond the bounds due to double precision
+            const auto y = static_cast<uint32_t>(std::floor(util::clamp(to_max.edges.front().p0.y, 0.0, (double)maxTile)));
+            et[y].push_back(std::move(to_max));
+        }
+        if (to_min.edges.size() > 0) {
+            const auto y = static_cast<uint32_t>(std::floor(util::clamp(to_min.edges.front().p0.y, 0.0, (double)maxTile)));
+            et[y].push_back(std::move(to_min));
+        }
+    }
+    assert(edges.size() == 0);
+}
+
+std::vector<x_range> scan_row(uint32_t y, bound_list& aet) {
+    std::vector<x_range> tile_range;
+    tile_range.reserve(aet.size());
+
+    for(bound& b: aet) {
+        x_range xp = { INT_MAX, 0 };
+        double x;
+        const auto numEdges = b.edges.size();
+        while (b.currentEdgeIndex < numEdges) {
+            auto& e = b.currentEdge();
+            x = e.x;
+            xp.first = std::min(xp.first, static_cast<int32_t>(std::floor(x)));
+            xp.second = std::max(xp.second, static_cast<int32_t>(std::ceil(x)));
+
+            // If this edge ends beyond the current row, find the x-value at the exit,
+            //  and be done with this bound
+            if (e.p1.y > y+1) {
+                x = e.interpolate(y+1);
+                xp.first = std::min(xp.first, static_cast<int32_t>(std::floor(x)));
+                xp.second = std::max(xp.second, static_cast<int32_t>(std::ceil(x)));
+                break;
+            } else if(b.currentEdgeIndex == numEdges - 1) {
+                // For last edge, consider x at edge end;
+                x = e.p1.x;
+                xp.first = std::min(xp.first, static_cast<int32_t>(std::floor(x)));
+                xp.second = std::max(xp.second, static_cast<int32_t>(std::ceil(x)));
+            }
+            b.currentEdgeIndex++;
+        }
+        tile_range.push_back(xp);
+    }
+    // Erase bounds in the aet whose current edge ends inside this row, or there are no more edges
+    auto b = aet.begin();
+    while (b != aet.end()) {
+        if ( b->currentEdgeIndex >= b->edges.size() ||
+            b->currentEdge().p1.y <= y+1) {
+            b = aet.erase(b);
+        } else {
+            b++;
+        }
+    }
+    // Sort the X-extents of each lml by x_min, x_max
+    std::sort(tile_range.begin(), tile_range.end(), [] (x_range& a, x_range& b) {
+        return std::tie(a.first, a.second) < std::tie(b.first, b.second);
+    });
+
+    return tile_range;
+}
+
+struct ToEdges {
+    int32_t zoom;
+    bool project;
+    ToEdges(int32_t z, bool p): zoom(z), project(p) {}
+
+    void makeEdges(const std::vector<Point<double>>& points, edge_list& edges) const {
+        edges.reserve(edges.size() + points.size()-1);
+        auto p1 = !project ? points[0] : Projection::project({points[0].y, points[0].x}, zoom);
+        for (uint32_t j=1; j < points.size(); j++) {
+            auto p2 = !project ? points[j] : Projection::project({points[j].y, points[j].x}, zoom);
+            edges.emplace_back(p1, p2);
+            p1 = p2;
+        }
+    }
+
+    edge_list polyEdges(const Polygon<double>& g) const {
+        edge_list edges;
+
+        for (uint32_t i = 0; i < g.size(); i++) {
+            const auto ring = g[i];
+            makeEdges(ring, edges);
+        }
+        return edges;
+    }
+
+    edge_list operator()(const Point<double>& p) const {
+        const auto pt = Projection::project({p.y, p.x}, zoom);
+        return { {pt, pt} };
+    }
+
+    edge_list operator()(const MultiPoint<double>&points) const {
+        edge_list edges;
+        edges.reserve(points.size());
+        for (const auto& p: points) {
+            const auto pt = Projection::project({p.y, p.x}, zoom);
+            edges.emplace_back(pt, pt);
+        }
+        return edges;
+    }
+
+    edge_list operator()(const LineString<double>& lines) const {
+        edge_list edges;
+        makeEdges(lines, edges);
+        return edges;
+    }
+
+    edge_list operator()(const MultiLineString<double>& g) const {
+        edge_list edges;
+        for(const auto& lines: g) {
+            makeEdges(lines, edges);
+        }
+        return edges;
+    }
+
+    edge_list operator()(const Polygon<double>& g) const {
+        return polyEdges(g);
+    }
+
+    edge_list operator()(const MultiPolygon<double>&) const {
+        return {};
+    }
+
+    std::vector<edge> operator()(const mapbox::geometry::geometry_collection<double>&) const {
+        return {};
+    }
+};
+
+//} //end namespace
+
+TileCoverImpl::TileCoverImpl(int32_t z, const Geometry<double>& geom, bool project): max_y(1 << z) {
+    ToFeatureType toFeatureType;
+    closed_geom = apply_visitor(toFeatureType, geom) == FeatureType::Polygon;
+
+    // Build edge table
+    ToEdges te(z, project);
+    edge_list edges = apply_visitor(te, geom);
+    build_edge_table(edges, max_y, et, closed_geom);
+    reset();
+}
+
+void TileCoverImpl::reset() {
+    aet = et.begin()->second;
+    current_y = et.begin()->first;
+}
+
+bool TileCoverImpl::next() {
+    return aet.size() != 0 && current_y < max_y;
+}
+
+bool TileCoverImpl::scanRow(ScanLine& scanCover) {
+    if (!next()) { return false; }
+
+    auto xps = util::scan_row(current_y, aet);
+    auto p = xps.begin();
+
+    while (p != xps.end()) {
+        auto x_min = p->first;
+        // For closed geometries, consider odd even pairs of tile ranges
+        if (closed_geom) { p++; }
+        auto x_max = p++->second;
+        scanCover(x_min, x_max, current_y);
+    }
+
+    // Move to the next row
+    current_y++;
+
+    // Update AET for next row
+    auto nextRow = et.find(current_y);
+    if (nextRow != et.end()) {
+        aet.insert(aet.end(), nextRow->second.begin(), nextRow->second.end());
+    }
+
+    return next();
+}
+
+} // namespace util
+} // namespace mbgl

--- a/src/mbgl/util/tile_cover_impl.hpp
+++ b/src/mbgl/util/tile_cover_impl.hpp
@@ -19,12 +19,17 @@ struct bound;
 using point_list = std::vector<Point<double>>;
 using bound_list = std::vector<bound>;
 using edge_table = std::map<uint32_t, bound_list>;
-using x_range = std::pair<int32_t, int32_t>;
-
+struct x_range {
+    int32_t x0;
+    int32_t x1;
+    bool winding;
+};
+    
 struct bound {
     point_list points;
     size_t currentPointIndex = 0;
     double currentX;
+    bool winding;
 
     double interpolate(uint32_t y) {
         const auto& p0 = points[currentPointIndex];
@@ -56,10 +61,9 @@ public:
     void reset();
 private:
     bool isClosed;
-    uint32_t currentY;
+    uint32_t currentRow;
     bound_list activeEdgeTable;
-    std::vector<edge_table> edgeTables;
-    std::vector<edge_table>::iterator currentEdgeTable;
+    edge_table edgeTable;
     uint32_t maxY;
 };
 

--- a/src/mbgl/util/tile_cover_impl.hpp
+++ b/src/mbgl/util/tile_cover_impl.hpp
@@ -85,7 +85,8 @@ private:
     bool closed_geom;
     uint32_t current_y; // current scanLine
     bound_list aet;
-    edge_table et;
+    std::vector<edge_table> et;
+    std::vector<edge_table>::iterator current_edge_table;
     uint32_t max_y;
 };
 

--- a/src/mbgl/util/tile_cover_impl.hpp
+++ b/src/mbgl/util/tile_cover_impl.hpp
@@ -1,10 +1,9 @@
 #pragma once
 
-#include <mbgl/tile/tile_id.hpp>
 #include <mbgl/style/types.hpp>
 #include <mbgl/util/tile_coordinate.hpp>
 #include <mbgl/util/geometry.hpp>
-#include <mbgl/math/clamp.hpp>
+
 #include <vector>
 #include <map>
 
@@ -15,60 +14,34 @@ class LatLngBounds;
 
 namespace util {
 
-struct edge;
 struct bound;
 
-using edge_list = std::vector<edge>;
+using point_list = std::vector<Point<double>>;
 using bound_list = std::vector<bound>;
 using edge_table = std::map<uint32_t, bound_list>;
 using x_range = std::pair<int32_t, int32_t>;
-static const double INF = 1e20;
 
-struct edge {
-    Point<double> p0, p1;
-    double x, m;
-    edge(Point<double> _a, Point<double> _b) {
-        if (_a.y > _b.y) {
-            std::swap(_a, _b);
-        }
-        p0 = _a;
-        p1 = _b;
+struct bound {
+    point_list points;
+    size_t currentPointIndex = 0;
+    double currentX;
+
+    double interpolate(uint32_t y) {
+        const auto& p0 = points[currentPointIndex];
+        const auto& p1 = points[currentPointIndex + 1];
 
         const auto dx = p1.x - p0.x;
         const auto dy = p1.y - p0.y;
-        x = p0.x;
-        if (dy == 0) {
-            m = INF;
+        currentX = p0.x;
+        if (dx == 0) {
+            return currentX;
+        } else if (dy == 0){
+            return y <= p0.y ? p0.x : p1.x;
         }
-        else {
-            m = dx / dy;
-        }
-    }
-
-    double interpolate(uint32_t y) {
-        if (m == 0) { return x; }
-
-        if ( y < p0.y || y > p1.y) {
-            util::clamp(y, static_cast<uint32_t>(p0.y), static_cast<uint32_t>(p1.y));
-        }
-
-        x = m * (y - p0.y) + p0.x;
-        return x;
-    }
-};
-
-struct bound {
-    edge_list edges;
-    size_t currentEdgeIndex = 0;
-
-    edge& currentEdge() {
-        if(currentEdgeIndex >= edges.size()) { return edges.back(); };
-        return edges[currentEdgeIndex];
-    }
-
-    const edge& current() const {
-        if(currentEdgeIndex >= edges.size()) { return edges.back(); };
-        return edges[currentEdgeIndex];
+        if (y < p0.y) return currentX;
+        if (y > p1.y) return p1.x;
+        currentX = (dx / dy) * (y - p0.y) + p0.x;
+        return currentX;
     }
 };
 
@@ -82,12 +55,12 @@ public:
     bool next();
     void reset();
 private:
-    bool closed_geom;
-    uint32_t current_y; // current scanLine
-    bound_list aet;
-    std::vector<edge_table> et;
-    std::vector<edge_table>::iterator current_edge_table;
-    uint32_t max_y;
+    bool isClosed;
+    uint32_t currentY;
+    bound_list activeEdgeTable;
+    std::vector<edge_table> edgeTables;
+    std::vector<edge_table>::iterator currentEdgeTable;
+    uint32_t maxY;
 };
 
 

--- a/src/mbgl/util/tile_cover_impl.hpp
+++ b/src/mbgl/util/tile_cover_impl.hpp
@@ -15,23 +15,23 @@ class LatLngBounds;
 
 namespace util {
 
-struct bound;
+struct Bound;
 
-using point_list = std::vector<Point<double>>;
-using bound_list = std::vector<bound>;
-using edge_table = std::map<uint32_t, bound_list>;
-struct x_range {
+using PointList = std::vector<Point<double>>;
+using BoundList = std::vector<Bound>;
+using EdgeTable = std::map<uint32_t, BoundList>;
+struct TileCoverRange {
     int32_t x0;
     int32_t x1;
     bool winding;
 };
     
-struct bound {
-    point_list points;
+struct Bound {
+    PointList points;
     size_t currentPointIndex = 0;
     bool winding = false;
-    bound() = default;
-    bound(const bound& rhs) {
+    Bound() = default;
+    Bound(const Bound& rhs) {
         points = rhs.points;
         currentPointIndex = rhs.currentPointIndex;
         winding = rhs.winding;
@@ -69,9 +69,10 @@ public:
 private:
     bool isClosed;
     uint32_t currentRow;
-    bound_list activeEdgeTable;
-    edge_table edgeTable;
-    uint32_t maxY;
+    BoundList activeEdgeTable;
+    EdgeTable edgeTable;
+    EdgeTable::iterator currentEdgeTable;
+    const uint32_t maxY;
 };
 
 

--- a/src/mbgl/util/tile_cover_impl.hpp
+++ b/src/mbgl/util/tile_cover_impl.hpp
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <mbgl/tile/tile_id.hpp>
+#include <mbgl/style/types.hpp>
+#include <mbgl/util/tile_coordinate.hpp>
+#include <mbgl/util/geometry.hpp>
+#include <mbgl/math/clamp.hpp>
+#include <vector>
+#include <map>
+
+namespace mbgl {
+
+class TransformState;
+class LatLngBounds;
+
+namespace util {
+
+struct edge;
+struct bound;
+
+using edge_list = std::vector<edge>;
+using bound_list = std::vector<bound>;
+using edge_table = std::map<uint32_t, bound_list>;
+using x_range = std::pair<int32_t, int32_t>;
+static const double INF = 1e20;
+
+struct edge {
+    Point<double> p0, p1;
+    double x, m;
+    edge(Point<double> _a, Point<double> _b) {
+        if (_a.y > _b.y) {
+            std::swap(_a, _b);
+        }
+        p0 = _a;
+        p1 = _b;
+
+        const auto dx = p1.x - p0.x;
+        const auto dy = p1.y - p0.y;
+        x = p0.x;
+        if (dy == 0) {
+            m = INF;
+        }
+        else {
+            m = dx / dy;
+        }
+    }
+
+    double interpolate(uint32_t y) {
+        if (m == 0) { return x; }
+
+        if ( y < p0.y || y > p1.y) {
+            util::clamp(y, static_cast<uint32_t>(p0.y), static_cast<uint32_t>(p1.y));
+        }
+
+        x = m * (y - p0.y) + p0.x;
+        return x;
+    }
+};
+
+struct bound {
+    edge_list edges;
+    size_t currentEdgeIndex = 0;
+
+    edge& currentEdge() {
+        if(currentEdgeIndex >= edges.size()) { return edges.back(); };
+        return edges[currentEdgeIndex];
+    }
+
+    const edge& current() const {
+        if(currentEdgeIndex >= edges.size()) { return edges.back(); };
+        return edges[currentEdgeIndex];
+    }
+};
+
+using ScanLine = const std::function<void(int32_t x0, int32_t x1, int32_t y)>;
+
+class TileCoverImpl {
+
+public:
+    TileCoverImpl(int32_t z, const Geometry<double>& geom, bool project = true);
+    bool scanRow(ScanLine& );
+    bool next();
+    void reset();
+private:
+    bool closed_geom;
+    uint32_t current_y; // current scanLine
+    bound_list aet;
+    edge_table et;
+    uint32_t max_y;
+};
+
+
+} // namespace util
+} // namespace mbgl

--- a/test/util/tile_cover.test.cpp
+++ b/test/util/tile_cover.test.cpp
@@ -2,6 +2,8 @@
 #include <mbgl/util/geo.hpp>
 #include <mbgl/map/transform.hpp>
 
+#include <algorithm>
+
 #include <gtest/gtest.h>
 
 using namespace mbgl;
@@ -22,8 +24,8 @@ TEST(TileCover, Antarctic) {
 
 TEST(TileCover, WorldZ0) {
     EXPECT_EQ((std::vector<UnwrappedTileID>{
-                  { 0, 0, 0 },
-              }),
+        { 0, 0, 0 },
+    }),
               util::tileCover(LatLngBounds::world(), 0));
 }
 
@@ -37,15 +39,15 @@ TEST(TileCover, Pitch) {
     transform.setPitch(40.0 * M_PI / 180.0);
 
     EXPECT_EQ((std::vector<UnwrappedTileID>{
-                  { 2, 1, 2 }, { 2, 1, 1 }, { 2, 2, 2 }, { 2, 2, 1 }, { 2, 3, 2 }
-              }),
+        { 2, 1, 2 }, { 2, 1, 1 }, { 2, 2, 2 }, { 2, 2, 1 }, { 2, 3, 2 }
+    }),
               util::tileCover(transform.getState(), 2));
 }
 
 TEST(TileCover, WorldZ1) {
     EXPECT_EQ((std::vector<UnwrappedTileID>{
-                  { 1, 0, 0 }, { 1, 0, 1 }, { 1, 1, 0 }, { 1, 1, 1 },
-              }),
+        { 1, 0, 0 }, { 1, 0, 1 }, { 1, 1, 0 }, { 1, 1, 1 },
+    }),
               util::tileCover(LatLngBounds::world(), 1));
 }
 
@@ -83,24 +85,24 @@ TEST(TileCoverStream, WorldZ1) {
         }
     })){};
     EXPECT_EQ((std::vector<UnwrappedTileID>{
-                { 1, 0, 0 }, { 1, 1, 0 }, { 1, 0, 1 }, { 1, 1, 1 },
-            }), t);
+        { 1, 0, 0 }, { 1, 1, 0 }, { 1, 0, 1 }, { 1, 1, 1 },
+    }), t);
 }
 
 static const LatLngBounds sanFrancisco =
-    LatLngBounds::hull({ 37.6609, -122.5744 }, { 37.8271, -122.3204 });
+LatLngBounds::hull({ 37.6609, -122.5744 }, { 37.8271, -122.3204 });
 
 TEST(TileCover, SanFranciscoZ0) {
     EXPECT_EQ((std::vector<UnwrappedTileID>{
-                  { 0, 0, 0 },
-              }),
+        { 0, 0, 0 },
+    }),
               util::tileCover(sanFrancisco, 0));
 }
 
 TEST(TileCover, SanFranciscoZ10) {
     EXPECT_EQ((std::vector<UnwrappedTileID>{
-                  { 10, 163, 395 }, { 10, 163, 396 }, { 10, 164, 395 }, { 10, 164, 396 },
-              }),
+        { 10, 163, 395 }, { 10, 163, 396 }, { 10, 164, 395 }, { 10, 164, 396 },
+    }),
               util::tileCover(sanFrancisco, 10));
 }
 
@@ -112,81 +114,100 @@ TEST(TileCover, SanFranciscoZ0Wrapped) {
               util::tileCover(sanFranciscoWrapped, 0));
 }
 
-TEST(TileCover, GeomPointZ13) {
-    EXPECT_EQ((std::vector<UnwrappedTileID>{ { 13, 2343, 3133 } }),
-            util::tileCover(Point<double> {-77.03355114851098,38.89224995264726 }, 13));
-}
-
-TEST(TileCover, GeomPointZ10) {
-    EXPECT_EQ((std::vector<UnwrappedTileID>{ { 10, 292, 391 } }),
-            util::tileCover(Point<double> {-77.03355114851098,38.89224995264726 }, 10));
-}
-
 TEST(TileCover, GeomLineZ10) {
-
     auto lineCover = util::tileCover(LineString<double>{
-            {-121.49368286132812,38.57903714667459},
-            {-122.4422836303711,37.773157169570695}
-        }, 10);
-    EXPECT_EQ((std::vector<UnwrappedTileID>{ { 10, 166, 392}, {10, 165, 393}, {10, 166, 393}, {10, 164, 394}, {10, 165, 394}, {10,163,395}, {10, 164, 395} }),
-        lineCover);
-
-}
-
-TEST(TileCover, GeomLineZ13) {
-    auto lineCover = util::tileCover(LineString<double>{
-            {-77.03342914581299,38.892101707724315},
-            {-77.02394485473633,38.89203490311832},
-            {-77.02390193939209,38.8824811975508},
-            {-77.0119285583496,38.8824811975508},
-            {-77.01218605041504,38.887391829071106},
-            {-77.01390266418456,38.88735842456116},
-            {-77.01622009277342,38.896510672795266},
-            {-77.01725006103516,38.914143795902376},
-            {-77.01879501342773,38.914143795902376},
-            {-77.0196533203125,38.91307524644972}
-        }, 13);
-    EXPECT_EQ((std::vector<UnwrappedTileID>{ { 13, 2343, 3133 }, { 13, 2343, 3134 } }),
-        lineCover);
+        {-121.49368286132812,38.57903714667459},
+        {-122.4422836303711,37.773157169570695}
+    }, 10);
+    EXPECT_EQ((std::vector<UnwrappedTileID>{
+        { 10, 166, 392}, {10, 165, 393}, {10, 166, 393},
+        {10, 164, 394}, {10, 165, 394}, {10,163,395}, {10, 164, 395}
+    }),lineCover);
+    
 }
 
 TEST(TileCover, WrappedGeomLineZ10) {
     auto lineCover = util::tileCover(LineString<double>{
-            {-179.93342914581299,38.892101707724315},
-            {-180.02394485473633,38.89203490311832}
-        }, 10);
+        {-179.93342914581299,38.892101707724315},
+        {-180.02394485473633,38.89203490311832}
+    }, 10);
     EXPECT_EQ((std::vector<UnwrappedTileID>{ { 10, -1, 391 }, { 10, 0, 391 } }),
-        lineCover);
-
+              lineCover);
+    
     lineCover = util::tileCover(LineString<double>{
-            {179.93342914581299,38.892101707724315},
-            {180.02394485473633,38.89203490311832}
-        }, 10);
+        {179.93342914581299,38.892101707724315},
+        {180.02394485473633,38.89203490311832}
+    }, 10);
     EXPECT_EQ((std::vector<UnwrappedTileID>{ { 10, 1023, 391 }, { 10, 1024, 391 } }),
-        lineCover);
+              lineCover);
 }
 
-TEST(TileCover, GeomLineZ15) {
-    auto lineCover = util::tileCover(LineString<double>{
-            {-77.03342914581299,38.892101707724315},
-            {-77.02394485473633,38.89203490311832},
-            {-77.02390193939209,38.8824811975508},
-            {-77.0119285583496,38.8824811975508},
-            {-77.01218605041504,38.887391829071106},
-            {-77.01390266418456,38.88735842456116},
-            {-77.01622009277342,38.896510672795266},
-            {-77.01725006103516,38.914143795902376},
-            {-77.01879501342773,38.914143795902376},
-            {-77.0196533203125,38.91307524644972}
-        }, 15);
-    EXPECT_EQ(lineCover, (std::vector<UnwrappedTileID>{
-        { 15,9373,12533 },
-        { 15,9373,12534 },
-        { 15,9372,12535 },
-        { 15,9373,12535 },
-        { 15,9373,12536 },
-        { 15,9374,12536 }
-        }));
+TEST(TileCover, GeomMultiLineString) {
+    auto geom = MultiLineString<double>{
+        { { -122.5, 37.76 }, { -122.4, 37.76} },
+        { { -122.5, 37.72 }, { -122.4, 37.72} } };
+
+    EXPECT_EQ((std::vector<UnwrappedTileID>{
+        {14, 2616, 6333}, {14, 2617, 6333}, {14, 2618, 6333},
+        {14, 2619, 6333}, {14, 2620, 6333}, {14, 2621, 6333} }),
+              util::tileCover(geom, 14));
+}
+
+TEST(TileCover, GeomPolygon) {
+    auto polygon = Polygon<double>{
+        {
+            {5.09765625,53.067626642387374},
+            {2.373046875,43.389081939117496},
+            {-4.74609375,48.45835188280866},
+            {-1.494140625,37.09023980307208},
+            {22.587890625,36.24427318493909},
+            {31.640625,46.13417004624326},
+            {17.841796875,54.7246201949245},
+            {5.09765625,53.067626642387374},
+        },{
+            {19.6875,49.66762782262194},
+            {8.701171874999998,50.233151832472245},
+            {5.185546875,41.244772343082076},
+            {16.34765625,39.095962936305476},
+            {13.623046875,45.089035564831036},
+            {22.8515625,43.51668853502906},
+            {19.6875,49.66762782262194}
+        }
+    };
+
+    auto results = util::tileCover(polygon, 8);
+
+    EXPECT_NE(std::find(results.begin(), results.end(), UnwrappedTileID{8, 134, 87}), results.end());
+    EXPECT_NE(std::find(results.begin(), results.end(), UnwrappedTileID{8, 139, 87}), results.end());
+    // Should have a hole
+    EXPECT_EQ(std::find(results.begin(), results.end(), UnwrappedTileID{8, 136, 87}), results.end());
+}
+
+TEST(TileCover, GeomMultiPolygon) {
+    auto multiPolygon = MultiPolygon<double>{
+        {{
+            {5.09765625,53.067626642387374},
+            {2.373046875,43.389081939117496},
+            {-4.74609375,48.45835188280866},
+            {-1.494140625,37.09023980307208},
+            {22.587890625,36.24427318493909},
+            {31.640625,46.13417004624326},
+            {17.841796875,54.7246201949245},
+            {5.09765625,53.067626642387374},
+        }},{{
+            {59.150390625,45.460130637921004},
+            {65.126953125,41.11246878918088},
+            {69.169921875,47.45780853075031},
+            {63.896484375,50.064191736659104},
+            {59.150390625,45.460130637921004}
+        }}
+    };
+    auto results = util::tileCover(multiPolygon, 8);
+
+    EXPECT_EQ(423u, results.size());
+    EXPECT_NE(std::find(results.begin(), results.end(), UnwrappedTileID{8, 139, 87}), results.end());
+    EXPECT_NE(std::find(results.begin(), results.end(), UnwrappedTileID{8, 136, 87}), results.end());
+    EXPECT_NE(std::find(results.begin(), results.end(), UnwrappedTileID{8, 174, 94}), results.end());
 }
 
 TEST(TileCover, GeomSanFranciscoPoly) {
@@ -218,55 +239,14 @@ TEST(TileCover, GeomSanFranciscoPoly) {
         }
     };
 
-    auto results = util::tileCover(sanFranciscoGeom, 10);
-    EXPECT_EQ((std::vector<UnwrappedTileID>{ { 10, 163, 395 }, { 10, 163, 396 } }),
-        results);
-
-    results = util::tileCover(sanFranciscoGeom, 12);
     EXPECT_EQ((std::vector<UnwrappedTileID>{
-            { 12, 654, 1582 }, { 12, 655, 1582 },
-            { 12, 654, 1583 },  { 12, 655, 1583 },
-            { 12, 654, 1584 }, { 12, 655, 1584 }
-        }), results);
-
+        { 12, 654, 1582 }, { 12, 655, 1582 },
+        { 12, 654, 1583 },  { 12, 655, 1583 },
+        { 12, 654, 1584 }, { 12, 655, 1584 }
+    }), util::tileCover(sanFranciscoGeom, 12));
 }
 
-TEST(TileCover, GeomPoint) {
-    auto geom = Point<double>(-122.5744, 37.6609);
 
-    EXPECT_EQ((std::vector<UnwrappedTileID>{ {2 ,0 ,1 } }),
-            util::tileCover(geom, 2));
-}
-
-TEST(TileCover, GeomMultiPoint) {
-    auto geom = MultiPoint<double>{ { -122.5, 37.76 }, { -122.4, 37.76} };
-
-    EXPECT_EQ((std::vector<UnwrappedTileID>{
-                {19, 83740, 202675}, {19, 83886, 202675} }),
-            util::tileCover(geom, 19));
-}
-
-TEST(TileCover, GeomLineString) {
-    auto geom = LineString<double>{{ -122.5, 37.76 }, { -122.4, 37.76} };
-
-    EXPECT_EQ((std::vector<UnwrappedTileID>{
-                {14, 2616, 6333}, {14, 2617, 6333}, {14, 2618, 6333},
-                {14, 2619, 6333}, {14, 2620, 6333}, {14, 2621, 6333} }),
-              util::tileCover(geom, 14));
-}
-
-TEST(TileCover, GeomMultiLineString) {
-    auto geom = MultiLineString<double>{
-            { { -122.5, 37.76 }, { -122.4, 37.76} },
-            { { -122.5, 37.72 }, { -122.4, 37.72} } };
-
-    EXPECT_EQ((std::vector<UnwrappedTileID>{
-                {14, 2616, 6333}, {14, 2617, 6333}, {14, 2618, 6333},
-                {14, 2619, 6333}, {14, 2620, 6333}, {14, 2621, 6333},
-                {14, 2616, 6335}, {14, 2617, 6335}, {14, 2618, 6335},
-                {14, 2619, 6335}, {14, 2620, 6335}, {14, 2621, 6335} }),
-            util::tileCover(geom, 14));
-}
 
 TEST(TileCount, World) {
     EXPECT_EQ(1u, util::tileCount(LatLngBounds::world(), 0));

--- a/test/util/tile_cover.test.cpp
+++ b/test/util/tile_cover.test.cpp
@@ -85,11 +85,28 @@ TEST(TileCover, SanFranciscoZ0Wrapped) {
               util::tileCover(sanFranciscoWrapped, 0));
 }
 
+TEST(TileCount, World) {
+    EXPECT_EQ(1u, util::tileCount(LatLngBounds::world(), 0));
+    EXPECT_EQ(4u, util::tileCount(LatLngBounds::world(), 1));
+}
+
 TEST(TileCount, SanFranciscoZ10) {
-    EXPECT_EQ(4u, util::tileCount(sanFrancisco, 10, util::tileSize));
+    EXPECT_EQ(4u, util::tileCount(sanFrancisco, 10));
+}
+
+TEST(TileCount, SanFranciscoWrappedZ10) {
+    EXPECT_EQ(4u, util::tileCount(sanFranciscoWrapped, 10));
 }
 
 TEST(TileCount, SanFranciscoZ22) {
-    EXPECT_EQ(7254450u, util::tileCount(sanFrancisco, 22, util::tileSize));
+    EXPECT_EQ(7254450u, util::tileCount(sanFrancisco, 22));
+}
+
+TEST(TileCount, BoundsCrossingAntimeridian) {
+    auto crossingBounds = LatLngBounds::hull({-20.9615, -214.309}, {19.477, -155.830});
+
+    EXPECT_EQ(1u, util::tileCount(crossingBounds, 0));
+    EXPECT_EQ(4u, util::tileCount(crossingBounds, 3));
+    EXPECT_EQ(8u, util::tileCount(crossingBounds, 4));
 }
 

--- a/test/util/tile_cover.test.cpp
+++ b/test/util/tile_cover.test.cpp
@@ -90,7 +90,7 @@ TEST(TileCoverStream, WorldZ1) {
 }
 
 static const LatLngBounds sanFrancisco =
-LatLngBounds::hull({ 37.6609, -122.5744 }, { 37.8271, -122.3204 });
+    LatLngBounds::hull({ 37.6609, -122.5744 }, { 37.8271, -122.3204 });
 
 TEST(TileCover, SanFranciscoZ0) {
     EXPECT_EQ((std::vector<UnwrappedTileID>{

--- a/test/util/tile_cover.test.cpp
+++ b/test/util/tile_cover.test.cpp
@@ -114,6 +114,21 @@ TEST(TileCover, SanFranciscoZ0Wrapped) {
               util::tileCover(sanFranciscoWrapped, 0));
 }
 
+TEST(TileCover, GeomPoint) {
+    auto point = Point<double>{ -122.5744, 37.6609 };
+
+    EXPECT_EQ((std::vector<UnwrappedTileID>{ {2 ,0 ,1 } }),
+              util::tileCover(point, 2));
+}
+
+TEST(TileCover, GeomMultiPoint) {
+    auto points = MultiPoint<double>{ { -122.5, 37.76 }, { -122.4, 37.76} };
+
+    EXPECT_EQ((std::vector<UnwrappedTileID>{
+        {20, 167480, 405351}, {20, 167772, 405351} }),
+              util::tileCover(points, 20));
+}
+
 TEST(TileCover, GeomLineZ10) {
     auto lineCover = util::tileCover(LineString<double>{
         {-121.49368286132812,38.57903714667459},
@@ -149,7 +164,9 @@ TEST(TileCover, GeomMultiLineString) {
 
     EXPECT_EQ((std::vector<UnwrappedTileID>{
         {14, 2616, 6333}, {14, 2617, 6333}, {14, 2618, 6333},
-        {14, 2619, 6333}, {14, 2620, 6333}, {14, 2621, 6333} }),
+        {14, 2619, 6333}, {14, 2620, 6333}, {14, 2621, 6333},
+        {14, 2616, 6335}, {14, 2617, 6335}, {14, 2618, 6335},
+        {14, 2619, 6335}, {14, 2620, 6335}, {14, 2621, 6335}}),
               util::tileCover(geom, 14));
 }
 

--- a/test/util/tile_cover.test.cpp
+++ b/test/util/tile_cover.test.cpp
@@ -231,6 +231,43 @@ TEST(TileCover, GeomSanFranciscoPoly) {
 
 }
 
+TEST(TileCover, GeomPoint) {
+    auto geom = Point<double>(-122.5744, 37.6609);
+
+    EXPECT_EQ((std::vector<UnwrappedTileID>{ {2 ,0 ,1 } }),
+            util::tileCover(geom, 2));
+}
+
+TEST(TileCover, GeomMultiPoint) {
+    auto geom = MultiPoint<double>{ { -122.5, 37.76 }, { -122.4, 37.76} };
+
+    EXPECT_EQ((std::vector<UnwrappedTileID>{
+                {19, 83740, 202675}, {19, 83886, 202675} }),
+            util::tileCover(geom, 19));
+}
+
+TEST(TileCover, GeomLineString) {
+    auto geom = LineString<double>{{ -122.5, 37.76 }, { -122.4, 37.76} };
+
+    EXPECT_EQ((std::vector<UnwrappedTileID>{
+                {14, 2616, 6333}, {14, 2617, 6333}, {14, 2618, 6333},
+                {14, 2619, 6333}, {14, 2620, 6333}, {14, 2621, 6333} }),
+              util::tileCover(geom, 14));
+}
+
+TEST(TileCover, GeomMultiLineString) {
+    auto geom = MultiLineString<double>{
+            { { -122.5, 37.76 }, { -122.4, 37.76} },
+            { { -122.5, 37.72 }, { -122.4, 37.72} } };
+
+    EXPECT_EQ((std::vector<UnwrappedTileID>{
+                {14, 2616, 6333}, {14, 2617, 6333}, {14, 2618, 6333},
+                {14, 2619, 6333}, {14, 2620, 6333}, {14, 2621, 6333},
+                {14, 2616, 6335}, {14, 2617, 6335}, {14, 2618, 6335},
+                {14, 2619, 6335}, {14, 2620, 6335}, {14, 2621, 6335} }),
+            util::tileCover(geom, 14));
+}
+
 TEST(TileCount, World) {
     EXPECT_EQ(1u, util::tileCount(LatLngBounds::world(), 0));
     EXPECT_EQ(4u, util::tileCount(LatLngBounds::world(), 1));

--- a/test/util/tile_cover.test.cpp
+++ b/test/util/tile_cover.test.cpp
@@ -59,6 +59,34 @@ TEST(TileCover, SingletonZ1) {
               util::tileCover(LatLngBounds::singleton({ 0, 0 }), 1));
 }
 
+TEST(TileCoverStream, Arctic) {
+    auto bounds = LatLngBounds::hull({ 84, -180 }, { 70, 180 });
+    auto zoom = 3;
+    util::TileCover tc(bounds, zoom);
+    auto results = util::tileCover(bounds, zoom);
+    std::vector<UnwrappedTileID> t;
+    while(tc.getTiles([&](int32_t x0, int32_t x1, int32_t y) {
+        for (auto x = x0; x < x1; x++) {
+            t.emplace_back(zoom, x, y);
+        }
+    })) {};
+    EXPECT_EQ(t.size(), results.size());
+}
+
+TEST(TileCoverStream, WorldZ1) {
+    auto zoom = 1;
+    util::TileCover tc(LatLngBounds::world(), zoom);
+    std::vector<UnwrappedTileID> t;
+    while(tc.getTiles([&](int32_t x0, int32_t x1, int32_t y) {
+        for (auto x = x0; x < x1; x++) {
+            t.emplace_back(zoom, x, y);
+        }
+    })){};
+    EXPECT_EQ((std::vector<UnwrappedTileID>{
+                { 1, 0, 0 }, { 1, 1, 0 }, { 1, 0, 1 }, { 1, 1, 1 },
+            }), t);
+}
+
 static const LatLngBounds sanFrancisco =
     LatLngBounds::hull({ 37.6609, -122.5744 }, { 37.8271, -122.3204 });
 
@@ -72,7 +100,6 @@ TEST(TileCover, SanFranciscoZ0) {
 TEST(TileCover, SanFranciscoZ10) {
     EXPECT_EQ((std::vector<UnwrappedTileID>{
                   { 10, 163, 395 }, { 10, 163, 396 }, { 10, 164, 395 }, { 10, 164, 396 },
-
               }),
               util::tileCover(sanFrancisco, 10));
 }
@@ -83,6 +110,125 @@ static const LatLngBounds sanFranciscoWrapped =
 TEST(TileCover, SanFranciscoZ0Wrapped) {
     EXPECT_EQ((std::vector<UnwrappedTileID>{ { 0, 1, 0 } }),
               util::tileCover(sanFranciscoWrapped, 0));
+}
+
+TEST(TileCover, GeomPointZ13) {
+    EXPECT_EQ((std::vector<UnwrappedTileID>{ { 13, 2343, 3133 } }),
+            util::tileCover(Point<double> {-77.03355114851098,38.89224995264726 }, 13));
+}
+
+TEST(TileCover, GeomPointZ10) {
+    EXPECT_EQ((std::vector<UnwrappedTileID>{ { 10, 292, 391 } }),
+            util::tileCover(Point<double> {-77.03355114851098,38.89224995264726 }, 10));
+}
+
+TEST(TileCover, GeomLineZ10) {
+
+    auto lineCover = util::tileCover(LineString<double>{
+            {-121.49368286132812,38.57903714667459},
+            {-122.4422836303711,37.773157169570695}
+        }, 10);
+    EXPECT_EQ((std::vector<UnwrappedTileID>{ { 10, 166, 392}, {10, 165, 393}, {10, 166, 393}, {10, 164, 394}, {10, 165, 394}, {10,163,395}, {10, 164, 395} }),
+        lineCover);
+
+}
+
+TEST(TileCover, GeomLineZ13) {
+    auto lineCover = util::tileCover(LineString<double>{
+            {-77.03342914581299,38.892101707724315},
+            {-77.02394485473633,38.89203490311832},
+            {-77.02390193939209,38.8824811975508},
+            {-77.0119285583496,38.8824811975508},
+            {-77.01218605041504,38.887391829071106},
+            {-77.01390266418456,38.88735842456116},
+            {-77.01622009277342,38.896510672795266},
+            {-77.01725006103516,38.914143795902376},
+            {-77.01879501342773,38.914143795902376},
+            {-77.0196533203125,38.91307524644972}
+        }, 13);
+    EXPECT_EQ((std::vector<UnwrappedTileID>{ { 13, 2343, 3133 }, { 13, 2343, 3134 } }),
+        lineCover);
+}
+
+TEST(TileCover, WrappedGeomLineZ10) {
+    auto lineCover = util::tileCover(LineString<double>{
+            {-179.93342914581299,38.892101707724315},
+            {-180.02394485473633,38.89203490311832}
+        }, 10);
+    EXPECT_EQ((std::vector<UnwrappedTileID>{ { 10, -1, 391 }, { 10, 0, 391 } }),
+        lineCover);
+
+    lineCover = util::tileCover(LineString<double>{
+            {179.93342914581299,38.892101707724315},
+            {180.02394485473633,38.89203490311832}
+        }, 10);
+    EXPECT_EQ((std::vector<UnwrappedTileID>{ { 10, 1023, 391 }, { 10, 1024, 391 } }),
+        lineCover);
+}
+
+TEST(TileCover, GeomLineZ15) {
+    auto lineCover = util::tileCover(LineString<double>{
+            {-77.03342914581299,38.892101707724315},
+            {-77.02394485473633,38.89203490311832},
+            {-77.02390193939209,38.8824811975508},
+            {-77.0119285583496,38.8824811975508},
+            {-77.01218605041504,38.887391829071106},
+            {-77.01390266418456,38.88735842456116},
+            {-77.01622009277342,38.896510672795266},
+            {-77.01725006103516,38.914143795902376},
+            {-77.01879501342773,38.914143795902376},
+            {-77.0196533203125,38.91307524644972}
+        }, 15);
+    EXPECT_EQ(lineCover, (std::vector<UnwrappedTileID>{
+        { 15,9373,12533 },
+        { 15,9373,12534 },
+        { 15,9372,12535 },
+        { 15,9373,12535 },
+        { 15,9373,12536 },
+        { 15,9374,12536 }
+        }));
+}
+
+TEST(TileCover, GeomSanFranciscoPoly) {
+    auto sanFranciscoGeom = Polygon<double>{
+        {
+            {-122.5143814086914,37.779127216982424},
+            {-122.50811576843262,37.72721239056709},
+            {-122.50313758850099,37.70820178063929},
+            {-122.3938751220703,37.707454835665274},
+            {-122.37567901611328,37.70663997801684},
+            {-122.36297607421874,37.71343018466285},
+            {-122.354736328125,37.727280276860036},
+            {-122.36469268798828,37.73868429065797},
+            {-122.38014221191408,37.75442980295571},
+            {-122.38391876220702,37.78753873820529},
+            {-122.35919952392578,37.8065289741725},
+            {-122.35679626464844,37.820632846207864},
+            {-122.3712158203125,37.835276322922695},
+            {-122.3818588256836,37.82958198283902},
+            {-122.37190246582031,37.80788523279169},
+            {-122.38735198974608,37.791337175930686},
+            {-122.40966796874999,37.812767557570204},
+            {-122.46425628662108,37.807071480609274},
+            {-122.46803283691405,37.810326435534755},
+            {-122.47901916503906,37.81168262440736},
+            {-122.48966217041016,37.78916666399649},
+            {-122.50579833984375,37.78781006166096},
+            {-122.5143814086914,37.779127216982424}
+        }
+    };
+
+    auto results = util::tileCover(sanFranciscoGeom, 10);
+    EXPECT_EQ((std::vector<UnwrappedTileID>{ { 10, 163, 395 }, { 10, 163, 396 } }),
+        results);
+
+    results = util::tileCover(sanFranciscoGeom, 12);
+    EXPECT_EQ((std::vector<UnwrappedTileID>{
+            { 12, 654, 1582 }, { 12, 655, 1582 },
+            { 12, 654, 1583 },  { 12, 655, 1583 },
+            { 12, 654, 1584 }, { 12, 655, 1584 }
+        }), results);
+
 }
 
 TEST(TileCount, World) {
@@ -109,4 +255,3 @@ TEST(TileCount, BoundsCrossingAntimeridian) {
     EXPECT_EQ(4u, util::tileCount(crossingBounds, 3));
     EXPECT_EQ(8u, util::tileCount(crossingBounds, 4));
 }
-

--- a/test/util/tile_cover.test.cpp
+++ b/test/util/tile_cover.test.cpp
@@ -166,11 +166,11 @@ TEST(TileCover, GeomPolygon) {
             {5.09765625,53.067626642387374},
         },{
             {19.6875,49.66762782262194},
-            {8.701171874999998,50.233151832472245},
-            {5.185546875,41.244772343082076},
-            {16.34765625,39.095962936305476},
-            {13.623046875,45.089035564831036},
             {22.8515625,43.51668853502906},
+            {13.623046875,45.089035564831036},
+            {16.34765625,39.095962936305476},
+            {5.185546875,41.244772343082076},
+            {8.701171874999998,50.233151832472245},
             {19.6875,49.66762782262194}
         }
     };
@@ -204,7 +204,7 @@ TEST(TileCover, GeomMultiPolygon) {
     };
     auto results = util::tileCover(multiPolygon, 8);
 
-    EXPECT_EQ(423u, results.size());
+    EXPECT_EQ(424u, results.size());
     EXPECT_NE(std::find(results.begin(), results.end(), UnwrappedTileID{8, 139, 87}), results.end());
     EXPECT_NE(std::find(results.begin(), results.end(), UnwrappedTileID{8, 136, 87}), results.end());
     EXPECT_NE(std::find(results.begin(), results.end(), UnwrappedTileID{8, 174, 94}), results.end());

--- a/test/util/tile_range.test.cpp
+++ b/test/util/tile_range.test.cpp
@@ -52,14 +52,14 @@ TEST(TileRange, ContainsWrappedBounds) {
 
 TEST(TileRange, ContainsBoundsCrossingAntimeridian) {
     {
-        auto cossingBounds = LatLngBounds::hull({-20.9615, -214.309}, {19.477, -155.830});
-        auto range = util::TileRange::fromLatLngBounds(cossingBounds, 1);
+        auto crossingBounds = LatLngBounds::hull({-20.9615, -214.309}, {19.477, -155.830});
+        auto range = util::TileRange::fromLatLngBounds(crossingBounds, 1);
         EXPECT_TRUE(range.contains(CanonicalTileID(1, 1, 1)));
         EXPECT_TRUE(range.contains(CanonicalTileID(1, 0, 0)));
     }
     {
-        auto cossingBounds = LatLngBounds::hull({-20.9615, -214.309}, {19.477, -155.830});
-        auto range = util::TileRange::fromLatLngBounds(cossingBounds, 6);
+        auto crossingBounds = LatLngBounds::hull({-20.9615, -214.309}, {19.477, -155.830});
+        auto range = util::TileRange::fromLatLngBounds(crossingBounds, 6);
         EXPECT_FALSE(range.contains(CanonicalTileID(6, 55, 34)));
         EXPECT_FALSE(range.contains(CanonicalTileID(6, 5, 28)));
         EXPECT_TRUE(range.contains(CanonicalTileID(6, 63, 28)));


### PR DESCRIPTION
The existing scanline-based tile cover implementation blocks when computing large rectangles. When extended to polygonal regions, this would further impact the performance and block interactivity in end-user applications.

This PR implements a streaming tile cover algorithm. An edge table-like data structure is created for all geometry, and then a modified scan-line is used for each tile row. Each row requires just one scan-line 
while accumulating the x-extents for each edge within that row. 

Usage:
```
    mbgl::util::TileCover tc(LatLngBounds::world(), zoom);
    while(tc.hasNext()) {
        UnwrappedtileID tile = *tc.next();
        ...
    };
```


- [x] Unit tests for polygons with holes and multi-polygons
- [x] A wrapper method `util::tileCover` that accepts arbitrary geometry and returns tiles.  
- [x] Benchmark tests for tile cover

cc @ivovandongen @mourner