### PR TITLE
add tileset encoding option to darwin sources

### DIFF
--- a/platform/darwin/docs/guides/For Style Authors.md.ejs
+++ b/platform/darwin/docs/guides/For Style Authors.md.ejs
@@ -205,6 +205,7 @@ In style JSON | In TileJSON   | In the SDK
 `tileSize`    | —             | `MGLTileSourceOptionTileSize`
 `attribution` | `attribution` | `MGLTileSourceOptionAttributionHTMLString` (but consider specifying `MGLTileSourceOptionAttributionInfos` instead for improved security)
 `scheme`      | `scheme`      | `MGLTileSourceOptionTileCoordinateSystem`
+`encoding`    | `encoding`    | `MGLTileSourceOptionDEMEncoding`
 
 ### Shape sources
 

--- a/platform/darwin/docs/guides/For Style Authors.md.ejs
+++ b/platform/darwin/docs/guides/For Style Authors.md.ejs
@@ -205,7 +205,7 @@ In style JSON | In TileJSON   | In the SDK
 `tileSize`    | —             | `MGLTileSourceOptionTileSize`
 `attribution` | `attribution` | `MGLTileSourceOptionAttributionHTMLString` (but consider specifying `MGLTileSourceOptionAttributionInfos` instead for improved security)
 `scheme`      | `scheme`      | `MGLTileSourceOptionTileCoordinateSystem`
-`encoding`    | `encoding`    | `MGLTileSourceOptionDEMEncoding`
+`encoding`    | –             | `MGLTileSourceOptionDEMEncoding`
 
 ### Shape sources
 

--- a/platform/darwin/src/MGLTileSource.h
+++ b/platform/darwin/src/MGLTileSource.h
@@ -117,6 +117,7 @@ extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionAttributionInfos;
  */
 extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionTileCoordinateSystem;
 
+
 /**
  Tile coordinate systems that determine how tile coordinates in tile URLs are
  interpreted.
@@ -139,6 +140,37 @@ typedef NS_ENUM(NSUInteger, MGLTileCoordinateSystem) {
      <a href="http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification">Tile Map Service Specification</a>.
      */
     MGLTileCoordinateSystemTMS
+};
+
+
+/**
+ An `NSNumber` object containing an unsigned integer that specifies the encoding
+ formula for raster-dem tilesets. The integer corresponds to one of
+ the constants described in `MGLDEMEncoding`.
+
+ The default value for this option is `MGLDEMEncodingMapbox`.
+
+ This option is not supported by the TileJSON spec.
+ */
+extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionDEMEncoding;
+
+/**
+ The encoding formula used to generate the raster-dem tileset
+*/
+
+typedef NS_ENUM(NSUInteger, MGLDEMEncoding) {
+
+    /**
+     Raster tiles generated with the Mapbox encoding formula where
+     elevaion = -10000 + ((R * 256 * 256 + G * 256 + B) * 0.1)
+    */
+    MGLDEMEncodingMapbox = 0,
+
+    /**
+     Raster tiles generated with the Mapzen Terrarium encoding formula where
+     elevaion = (R * 256 + G + B / 256) - 32768
+    */
+    MGLDEMEncodingTerrarium
 };
 
 /**

--- a/platform/darwin/src/MGLTileSource.h
+++ b/platform/darwin/src/MGLTileSource.h
@@ -161,14 +161,14 @@ extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionDEMEncoding;
 typedef NS_ENUM(NSUInteger, MGLDEMEncoding) {
 
     /**
-     Raster tiles generated with the Mapbox encoding formula where
-     elevaion = -10000 + ((R * 256 * 256 + G * 256 + B) * 0.1)
+     Raster tiles generated with the Mapbox encoding formula. 
+     See more details here: https://www.mapbox.com/help/access-elevation-data/#mapbox-terrain-rgb 
     */
     MGLDEMEncodingMapbox = 0,
 
     /**
-     Raster tiles generated with the Mapzen Terrarium encoding formula where
-     elevaion = (R * 256 + G + B / 256) - 32768
+     Raster tiles generated with the Mapzen Terrarium encoding formula.
+     See more details here: https://aws.amazon.com/public-datasets/terrain/
     */
     MGLDEMEncodingTerrarium
 };

--- a/platform/darwin/src/MGLTileSource.h
+++ b/platform/darwin/src/MGLTileSource.h
@@ -161,14 +161,12 @@ extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionDEMEncoding;
 typedef NS_ENUM(NSUInteger, MGLDEMEncoding) {
 
     /**
-     Raster tiles generated with the Mapbox encoding formula. 
-     See more details here: https://www.mapbox.com/help/access-elevation-data/#mapbox-terrain-rgb 
+     Raster tiles generated with the [Mapbox encoding formula](https://www.mapbox.com/help/access-elevation-data/#mapbox-terrain-rgb).
     */
     MGLDEMEncodingMapbox = 0,
 
     /**
-     Raster tiles generated with the Mapzen Terrarium encoding formula.
-     See more details here: https://aws.amazon.com/public-datasets/terrain/
+     Raster tiles generated with the [Mapzen Terrarium encoding formula](https://aws.amazon.com/public-datasets/terrain/).
     */
     MGLDEMEncodingTerrarium
 };

--- a/platform/darwin/src/MGLTileSource.mm
+++ b/platform/darwin/src/MGLTileSource.mm
@@ -19,6 +19,7 @@ const MGLTileSourceOption MGLTileSourceOptionCoordinateBounds = @"MGLTileSourceO
 const MGLTileSourceOption MGLTileSourceOptionAttributionHTMLString = @"MGLTileSourceOptionAttributionHTMLString";
 const MGLTileSourceOption MGLTileSourceOptionAttributionInfos = @"MGLTileSourceOptionAttributionInfos";
 const MGLTileSourceOption MGLTileSourceOptionTileCoordinateSystem = @"MGLTileSourceOptionTileCoordinateSystem";
+const MGLTileSourceOption MGLTileSourceOptionDEMEncoding = @"MGLTileSourceOptionDEMEncoding";
 
 @implementation MGLTileSource
 
@@ -125,6 +126,23 @@ mbgl::Tileset MGLTileSetFromTileURLTemplates(NS_ARRAY_OF(NSString *) *tileURLTem
                 break;
             case MGLTileCoordinateSystemTMS:
                 tileSet.scheme = mbgl::Tileset::Scheme::TMS;
+                break;
+        }
+    }
+
+    if (NSNumber *demEncodingNumber = options[MGLTileSourceOptionDEMEncoding]) {
+        if (![demEncodingNumber isKindOfClass:[NSValue class]]) {
+            [NSException raise:NSInvalidArgumentException
+                        format:@"MGLTileSourceOptionDEMEncoding must be set to an NSValue or NSNumber."];
+        }
+        MGLDEMEncoding demEncoding;
+        [demEncodingNumber getValue:&demEncoding];
+        switch (demEncoding) {
+            case MGLDEMEncodingMapbox:
+                tileSet.encoding = mbgl::Tileset::DEMEncoding::Mapbox;
+                break;
+            case MGLDEMEncodingTerrarium:
+                tileSet.encoding = mbgl::Tileset::DEMEncoding::Terrarium;
                 break;
         }
     }

--- a/platform/darwin/test/MGLTileSetTests.mm
+++ b/platform/darwin/test/MGLTileSetTests.mm
@@ -102,6 +102,23 @@
 
     // the scheme is reflected by the mbgl tileset
     XCTAssertEqual(tileSet.scheme, mbgl::Tileset::Scheme::TMS);
+
+    // when the dem enciding is changed using an NSNumber
+    tileSet = MGLTileSetFromTileURLTemplates(tileURLTemplates, @{
+        MGLTileSourceOptionDEMEncoding: @(MGLDEMEncodingTerrarium),
+    });
+
+    // the encoding is reflected by the mbgl tileset
+    XCTAssertEqual(tileSet.encoding, mbgl::Tileset::DEMEncoding::Terrarium);
+
+    // when the dem enciding is changed using an NSValue
+    MGLDEMEncoding terrarium = MGLDEMEncodingTerrarium;
+    tileSet = MGLTileSetFromTileURLTemplates(tileURLTemplates, @{
+        MGLTileSourceOptionDEMEncoding: [NSValue value:&terrarium withObjCType:@encode(MGLDEMEncoding)],
+    });
+
+    // the encoding is reflected by the mbgl tileset
+    XCTAssertEqual(tileSet.encoding, mbgl::Tileset::DEMEncoding::Terrarium);
 }
 
 - (void)testInvalidTileSet {

--- a/platform/ios/docs/guides/For Style Authors.md
+++ b/platform/ios/docs/guides/For Style Authors.md
@@ -154,6 +154,7 @@ In style JSON | In TileJSON   | In the SDK
 `tileSize`    | —             | `MGLTileSourceOptionTileSize`
 `attribution` | `attribution` | `MGLTileSourceOptionAttributionHTMLString` (but consider specifying `MGLTileSourceOptionAttributionInfos` instead for improved security)
 `scheme`      | `scheme`      | `MGLTileSourceOptionTileCoordinateSystem`
+`encoding`    | `encoding`    | `MGLTileSourceOptionDEMEncoding`
 
 ### Shape sources
 

--- a/platform/ios/docs/guides/For Style Authors.md
+++ b/platform/ios/docs/guides/For Style Authors.md
@@ -154,7 +154,7 @@ In style JSON | In TileJSON   | In the SDK
 `tileSize`    | —             | `MGLTileSourceOptionTileSize`
 `attribution` | `attribution` | `MGLTileSourceOptionAttributionHTMLString` (but consider specifying `MGLTileSourceOptionAttributionInfos` instead for improved security)
 `scheme`      | `scheme`      | `MGLTileSourceOptionTileCoordinateSystem`
-`encoding`    | `encoding`    | `MGLTileSourceOptionDEMEncoding`
+`encoding`    | –             | `MGLTileSourceOptionDEMEncoding`
 
 ### Shape sources
 

--- a/platform/macos/docs/guides/For Style Authors.md
+++ b/platform/macos/docs/guides/For Style Authors.md
@@ -141,6 +141,7 @@ In style JSON | In TileJSON   | In the SDK
 `tileSize`    | —             | `MGLTileSourceOptionTileSize`
 `attribution` | `attribution` | `MGLTileSourceOptionAttributionHTMLString` (but consider specifying `MGLTileSourceOptionAttributionInfos` instead for improved security)
 `scheme`      | `scheme`      | `MGLTileSourceOptionTileCoordinateSystem`
+`encoding`    | `encoding`    | `MGLTileSourceOptionDEMEncoding`
 
 ### Shape sources
 

--- a/platform/macos/docs/guides/For Style Authors.md
+++ b/platform/macos/docs/guides/For Style Authors.md
@@ -141,7 +141,7 @@ In style JSON | In TileJSON   | In the SDK
 `tileSize`    | —             | `MGLTileSourceOptionTileSize`
 `attribution` | `attribution` | `MGLTileSourceOptionAttributionHTMLString` (but consider specifying `MGLTileSourceOptionAttributionInfos` instead for improved security)
 `scheme`      | `scheme`      | `MGLTileSourceOptionTileCoordinateSystem`
-`encoding`    | `encoding`    | `MGLTileSourceOptionDEMEncoding`
+`encoding`    | –             | `MGLTileSourceOptionDEMEncoding`
 
 ### Shape sources
 


### PR DESCRIPTION
part of #11224 

@1ec5 I didn't end up following your instructions exactly because `encoding` is not a constructor option for RasterDEMTileset but rather an option on the base `Tileset` class so I didn't understand how to add the option handling further down in the source inheritance – but maybe I'm doing something wrong 😅 
