### PR TITLE
[ios, macos] Add NSExpression convenience constructors and helper methods.

### DIFF
--- a/platform/darwin/docs/guides/For Style Authors.md.ejs
+++ b/platform/darwin/docs/guides/For Style Authors.md.ejs
@@ -339,9 +339,9 @@ In style specification | Method, function, or predicate type | Format string syn
 `to-number`            | `mgl_numberWithFallbackValues:` | `CAST(zipCode, 'NSNumber')`
 `to-string`            | `stringValue` | `CAST(ele, 'NSString')`
 `typeof`               | |
-`geometry-type`        | |`$geometryType`
-`id`                   | |`$featureIdentifier`
-`properties`           | |`$featureProperties`
+`geometry-type`        | `NSExpression.geometryTypeVariableExpression` | `$geometryType`
+`id`                   | `NSExpression.featureIdentifierVariableExpression` | `$featureIdentifier`
+`properties`           | `NSExpression.featurePropertiesVariableExpression` | `$featureProperties`
 `at`                   | `objectFrom:withIndex:` | `array[n]`
 `get`                  | `+[NSExpression expressionForKeyPath:]` | Key path
 `has`                  | `mgl_does:have:` | `mgl_does:have:(self, 'key')`
@@ -355,14 +355,14 @@ In style specification | Method, function, or predicate type | Format string syn
 `>=`                   | `NSGreaterThanOrEqualToPredicateOperatorType` | `key >= value`
 `all`                  | `NSAndPredicateType` | `p0 AND … AND pn`
 `any`                  | `NSOrPredicateType` | `p0 OR … OR pn`
-`case`                 | `+[NSExpression expressionForConditional:trueExpression:falseExpression:]` or `MGL_IF` | `TERNARY(1 = 2, YES, NO)` or `MGL_IF(1 = 2, YES, 2 = 2, YES, NO)`
+`case`                 | `+[NSExpression expressionForConditional:trueExpression:falseExpression:]` or `MGL_IF` or `+[NSExpression mgl_expressionForConditional:trueExpression:falseExpresssion:]` | `TERNARY(1 = 2, YES, NO)` or `MGL_IF(1 = 2, YES, 2 = 2, YES, NO)`
 `coalesce`             | `mgl_coalesce:` | `mgl_coalesce({x, y, z})`
-`match`                | `MGL_MATCH` | `MGL_MATCH(x, 0, 'zero match', 1, 'one match', 'two match', 'default')`
-`interpolate`          | `mgl_interpolate:withCurveType:parameters:stops:` |
-`step`                 | `mgl_step:withMinimum:stops:` |
+`match`                | `MGL_MATCH` or `+[NSExpression mgl_expressionForMatchingExpression:inDictionary:defaultExpression:]` | `MGL_MATCH(x, 0, 'zero match', 1, 'one match', 'two match', 'default')`
+`interpolate`          | `mgl_interpolate:withCurveType:parameters:stops:` or `+[NSExpression mgl_expressionForInterpolatingExpression:withCurveType:parameters:stops:]` |
+`step`                 | `mgl_step:withMinimum:stops:` or `+[NSExpression mgl_expressionForSteppingExpression:fromExpression:stops:]` |
 `let`                  | `mgl_expressionWithContext:` | `MGL_LET('ios', 11, 'macos', 10.13, $ios + $macos)`
 `var`                  | `+[NSExpression expressionForVariable:]` | `$variable`
-`concat`               | `mgl_join:` | `mgl_join({'Old', ' ', 'MacDonald'})`
+`concat`               | `mgl_join:` or `-[NSExpression mgl_expressionByAppendingExpression:]` | `mgl_join({'Old', ' ', 'MacDonald'})`
 `downcase`             | `lowercase:` | `lowercase('DOWNTOWN')`
 `upcase`               | `uppercase:` | `uppercase('Elysian Fields')`
 <% if (macOS) { -%>
@@ -398,8 +398,8 @@ In style specification | Method, function, or predicate type | Format string syn
 `sin`                  | |
 `sqrt`                 | `sqrt:` | `sqrt(2)`
 `tan`                  | |
-`zoom`                 | | `$zoom`
-`heatmap-density`      | | `$heatmapDensity`
+`zoom`                 | `NSExpression.zoomLevelVariableExpression` | `$zoom`
+`heatmap-density`      | `NSExpression.heatmapDensityVariableExpression` | `$heatmapDensity`
 
 For operators that have no corresponding `NSExpression` symbol, use the
 `MGL_FUNCTION()` format string syntax.

--- a/platform/darwin/src/NSExpression+MGLAdditions.h
+++ b/platform/darwin/src/NSExpression+MGLAdditions.h
@@ -9,7 +9,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NSString *MGLExpressionInterpolationMode NS_TYPED_EXTENSIBLE_ENUM;
+typedef NSString *MGLExpressionInterpolationMode NS_TYPED_ENUM;
 
 /**
  An `NSString` identifying the `linear` interpolation type in an `NSExpression`.
@@ -94,34 +94,33 @@ extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolatio
  and stops.
  
  @param steppingExpression The stepping expression.
- @param fromExpression The expression which could be a constant or function expression.
+ @param minimumExpression The expression which could be a constant or function expression.
  @param stops The stops must be an `NSDictionary` constant `NSExpression`.
- The wrapped dictionary must be numeric expression literals in strictly ascending order.
  */
-+ (instancetype)mgl_expressionForSteppingExpression:(nonnull NSExpression*)steppingExpression fromExpression:(nonnull NSExpression *)fromExpression stops:(nonnull NSExpression*)stops NS_SWIFT_NAME(init(forMGLStepping:from:stops:));
++ (instancetype)mgl_expressionForSteppingExpression:(nonnull NSExpression*)steppingExpression fromExpression:(nonnull NSExpression *)minimumExpression stops:(nonnull NSExpression*)stops NS_SWIFT_NAME(init(forMGLStepping:from:stops:));
 
 /**
  Returns an interpolated function expression specifying the function operator, curve type,
  parameters and steps.
  
- @param interpolatingExpression The interpolating expression input.
+ @param inputExpression The interpolating expression input.
  @param curveType The curve type could be `MGLExpressionInterpolationModeLinear`,
  `MGLExpressionInterpolationModeExponential` and
  `MGLExpressionInterpolationModeCubicBezier`.
  @param parameters The parameters expression.
  @param stops The stops expression.
  */
-+ (instancetype)mgl_expressionForInterpolatingExpression:(nonnull NSExpression*)interpolatingExpression withCurveType:(nonnull MGLExpressionInterpolationMode)curveType parameters:(nullable NSExpression *)parameters stops:(nonnull NSExpression*)stops NS_SWIFT_NAME(init(forMGLInterpolating:curveType:parameters:stops:));
++ (instancetype)mgl_expressionForInterpolatingExpression:(nonnull NSExpression*)inputExpression withCurveType:(nonnull MGLExpressionInterpolationMode)curveType parameters:(nullable NSExpression *)parameters stops:(nonnull NSExpression*)stops NS_SWIFT_NAME(init(forMGLInterpolating:curveType:parameters:stops:));
 
 /**
  Returns a match function expression specifying the input, matching values,
  and default value.
  
- @param matchingExpression The matching expression.
+ @param inputExpression The matching expression.
  @param matchedExpressions The matched values expression dictionary must be condition : value.
  @param defaultExpression The defaultValue expression to be used in case there is no match.
  */
-+ (instancetype)mgl_expressionForMatchingExpression:(nonnull NSExpression *)matchingExpression inDictionary:(nonnull NSDictionary<NSExpression *, NSExpression *> *)matchedExpressions defaultExpression:(nonnull NSExpression *)defaultExpression NS_SWIFT_NAME(init(forMGLMatchingKey:matched:default:));
++ (instancetype)mgl_expressionForMatchingExpression:(nonnull NSExpression *)inputExpression inDictionary:(nonnull NSDictionary<NSExpression *, NSExpression *> *)matchedExpressions defaultExpression:(nonnull NSExpression *)defaultExpression NS_SWIFT_NAME(init(forMGLMatchingKey:in:default:));
 /**
  Returns a constant expression appending the passed expression.
  
@@ -129,8 +128,6 @@ extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolatio
  expression type; otherwise, an exception is rised.
  
  @param expression The expression to append to the receiver.
-    system’s preferred language, if supported, specify `nil`. To use the local
-    language, specify a locale with the identifier `mul`.
  */
 - (instancetype)mgl_expressionByAppendingExpression:(nonnull NSExpression *)expression NS_SWIFT_NAME(mgl_appending(_:));
 

--- a/platform/darwin/src/NSExpression+MGLAdditions.h
+++ b/platform/darwin/src/NSExpression+MGLAdditions.h
@@ -9,6 +9,74 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NSString *MGLExpressionInterpolationMode NS_TYPED_EXTENSIBLE_ENUM;
+
+/**
+ An `NSString` identifying the `linear` interpolation type in an `NSExpression`.
+ 
+ This attribute corresponds to the `linear` value in the
+ <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-interpolate"><code>interpolate</code></a>
+ expression reference in the Mapbox Style Specification.
+ */
+extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolationModeLinear;
+
+/**
+ An `NSString` identifying the `expotential` interpolation type in an `NSExpression`.
+ 
+ This attribute corresponds to the `exponential` value in the
+ <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-interpolate"><code>interpolate</code></a>
+ expression reference in the Mapbox Style Specification.
+ */
+extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolationModeExponential;
+
+/**
+ An `NSString` identifying the `cubic-bezier` interpolation type in an `NSExpression`.
+ 
+ This attribute corresponds to the `cubic-bezier` value in the
+ <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-interpolate"><code>interpolate</code></a>
+ expression reference in the Mapbox Style Specification.
+ */
+extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolationModeCubicBezier;
+
+@interface NSExpression (MGLVariableAdditions)
+
+/**
+ `NSExpression` attribute that corresponds to the
+ <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-zoom"><code>zoom</code></a>
+ expression reference in the Mapbox Style Specification.
+ */
++ (NSExpression *)mgl_zoomLevelVariableExpression;
+
+/**
+ `NSExpression` attribute that corresponds to the
+ <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-heatmap-density"><code>heatmap-density</code></a>
+ expression reference in the Mapbox Style Specification.
+ */
++ (NSExpression *)mgl_heatmapVariableExpression;
+
+/**
+ `NSExpression` attribute that corresponds to the
+ <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#eexpressions-geometry-type"><code>geometry-type</code></a>
+ expression reference in the Mapbox Style Specification.
+ */
++ (NSExpression *)mgl_geometryTypeVariableExpression;
+
+/**
+ `NSExpression` attribute that corresponds to the
+ <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-id"><code>id</code></a>
+ expression reference in the Mapbox Style Specification.
+ */
++ (NSExpression *)mgl_featureIdentifierVariableExpression;
+
+/**
+ `NSExpression` attribute that corresponds to the
+ <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-properties"><code>properties</code></a>
+ expression reference in the Mapbox Style Specification.
+ */
++ (NSExpression *)mgl_featurePropertiesVariableExpression;
+
+@end
+
 @interface NSExpression (MGLAdditions)
 
 /**
@@ -43,6 +111,49 @@ NS_ASSUME_NONNULL_BEGIN
  write to a file.
  */
 @property (nonatomic, readonly) id mgl_jsonExpressionObject;
+
+/**
+ Returns a conditional function expression specifying the string predicate, and
+ expressions for each condition.
+ 
+ @param conditionPredicate The predicate to get evaluated.
+ @param trueExpression The expression for conditions equal to true.
+ @param falseExpression The expression for conditions equal to false.
+ */
++ (instancetype)mgl_expressionForConditional:(nonnull NSPredicate *)conditionPredicate trueExpression:(nonnull NSExpression *)trueExpression falseExpresssion:(nonnull NSExpression *)falseExpression;
+
+/**
+ Returns a step function expression specifying the function operator, default expression
+ and stops.
+ 
+ @param operatorExpression The operator expression.
+ @param expression The expression which could be a constant or function expression.
+ @param stops The stops dictionay must be numeric literals in strictly ascending order.
+ */
++ (instancetype)mgl_expressionForStepFunction:(nonnull NSExpression*)operatorExpression defaultExpression:(nonnull NSExpression *)expression stops:(nonnull NSExpression*)stops;
+
+/**
+ Returns an interpolated function expression specifying the function operator, curve type,
+ parameters and steps.
+ 
+ @param expressionOperator The expression operator.
+ @param curveType The curve type could be `MGLExpressionInterpolationModeLinear`,
+ `MGLExpressionInterpolationModeExponential` and
+ `MGLExpressionInterpolationModeCubicBezier`.
+ @param parameters The parameters expression.
+ @param steps The steps expression.
+ */
++ (instancetype)mgl_expressionForInterpolateFunction:(nonnull NSExpression*)expressionOperator curveType:(nonnull MGLExpressionInterpolationMode)curveType parameters:(nullable NSExpression *)parameters steps:(nonnull NSExpression*)steps;
+
+
+/**
+ Returns a string constant expression appending the passed expression.
+ 
+ @param string The string to append.
+    system’s preferred language, if supported, specify `nil`. To use the local
+    language, specify a locale with the identifier `mul`.
+ */
+- (instancetype)mgl_expressionByAppendingExpression:(NSExpression *)string;
 
 /**
  Returns a copy of the receiver localized into the given locale.

--- a/platform/darwin/src/NSExpression+MGLAdditions.h
+++ b/platform/darwin/src/NSExpression+MGLAdditions.h
@@ -166,7 +166,6 @@ extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolatio
  guide for a correspondence of operators and types between the style
  specification and the `NSExpression` representation used by this SDK.
  
- @param locale The locale into which labels should be localized. To use the
  You can use `NSJSONSerialization` to serialize the Foundation object as data to
  write to a file.
  */

--- a/platform/darwin/src/NSExpression+MGLAdditions.h
+++ b/platform/darwin/src/NSExpression+MGLAdditions.h
@@ -52,7 +52,7 @@ extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolatio
  <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-heatmap-density"><code>heatmap-density</code></a>
  expression reference in the Mapbox Style Specification.
  */
-+ (NSExpression *)mgl_heatmapVariableExpression;
++ (NSExpression *)mgl_heatmapDensityVariableExpression;
 
 /**
  `NSExpression` attribute that corresponds to the
@@ -74,6 +74,54 @@ extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolatio
  expression reference in the Mapbox Style Specification.
  */
 + (NSExpression *)mgl_featurePropertiesVariableExpression;
+
+@end
+
+@interface NSExpression (MGLInitializerAdditions)
+
+/**
+ Returns a conditional function expression specifying the string predicate, and
+ expressions for each condition.
+ 
+ @param conditionPredicate The predicate to get evaluated.
+ @param trueExpression The expression for conditions equal to true.
+ @param falseExpression The expression for conditions equal to false.
+ */
++ (instancetype)mgl_expressionForConditional:(nonnull NSPredicate *)conditionPredicate trueExpression:(nonnull NSExpression *)trueExpression falseExpresssion:(nonnull NSExpression *)falseExpression;
+
+/**
+ Returns a step function expression specifying the function operator, default expression
+ and stops.
+ 
+ @param input The input expression.
+ @param from The expression which could be a constant or function expression.
+ @param stops The stops dictionay must be numeric literals in strictly ascending order.
+ */
++ (instancetype)mgl_expressionForStepFunction:(nonnull NSExpression*)input from:(nonnull NSExpression *)from stops:(nonnull NSExpression*)stops;
+
+/**
+ Returns an interpolated function expression specifying the function operator, curve type,
+ parameters and steps.
+ 
+ @param input The expression input.
+ @param curveType The curve type could be `MGLExpressionInterpolationModeLinear`,
+ `MGLExpressionInterpolationModeExponential` and
+ `MGLExpressionInterpolationModeCubicBezier`.
+ @param parameters The parameters expression.
+ @param steps The steps expression.
+ */
++ (instancetype)mgl_expressionForInterpolateFunction:(nonnull NSExpression*)input curveType:(nonnull MGLExpressionInterpolationMode)curveType parameters:(nullable NSExpression *)parameters steps:(nonnull NSExpression*)steps;
+
++ (instancetype)mgl_expressionForMatchFunction:(nonnull NSExpression*)condition values:(nonnull NSExpression *)values defaultValue:(nonnull NSExpression *)defaultValue;
+
+/**
+ Returns a string constant expression appending the passed expression.
+ 
+ @param string The string to append.
+    system’s preferred language, if supported, specify `nil`. To use the local
+    language, specify a locale with the identifier `mul`.
+ */
+- (instancetype)mgl_expressionByAppendingExpression:(NSExpression *)string;
 
 @end
 
@@ -107,53 +155,11 @@ extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolatio
  guide for a correspondence of operators and types between the style
  specification and the `NSExpression` representation used by this SDK.
  
+ @param locale The locale into which labels should be localized. To use the
  You can use `NSJSONSerialization` to serialize the Foundation object as data to
  write to a file.
  */
 @property (nonatomic, readonly) id mgl_jsonExpressionObject;
-
-/**
- Returns a conditional function expression specifying the string predicate, and
- expressions for each condition.
- 
- @param conditionPredicate The predicate to get evaluated.
- @param trueExpression The expression for conditions equal to true.
- @param falseExpression The expression for conditions equal to false.
- */
-+ (instancetype)mgl_expressionForConditional:(nonnull NSPredicate *)conditionPredicate trueExpression:(nonnull NSExpression *)trueExpression falseExpresssion:(nonnull NSExpression *)falseExpression;
-
-/**
- Returns a step function expression specifying the function operator, default expression
- and stops.
- 
- @param operatorExpression The operator expression.
- @param expression The expression which could be a constant or function expression.
- @param stops The stops dictionay must be numeric literals in strictly ascending order.
- */
-+ (instancetype)mgl_expressionForStepFunction:(nonnull NSExpression*)operatorExpression defaultExpression:(nonnull NSExpression *)expression stops:(nonnull NSExpression*)stops;
-
-/**
- Returns an interpolated function expression specifying the function operator, curve type,
- parameters and steps.
- 
- @param expressionOperator The expression operator.
- @param curveType The curve type could be `MGLExpressionInterpolationModeLinear`,
- `MGLExpressionInterpolationModeExponential` and
- `MGLExpressionInterpolationModeCubicBezier`.
- @param parameters The parameters expression.
- @param steps The steps expression.
- */
-+ (instancetype)mgl_expressionForInterpolateFunction:(nonnull NSExpression*)expressionOperator curveType:(nonnull MGLExpressionInterpolationMode)curveType parameters:(nullable NSExpression *)parameters steps:(nonnull NSExpression*)steps;
-
-
-/**
- Returns a string constant expression appending the passed expression.
- 
- @param string The string to append.
-    system’s preferred language, if supported, specify `nil`. To use the local
-    language, specify a locale with the identifier `mul`.
- */
-- (instancetype)mgl_expressionByAppendingExpression:(NSExpression *)string;
 
 /**
  Returns a copy of the receiver localized into the given locale.

--- a/platform/darwin/src/NSExpression+MGLAdditions.h
+++ b/platform/darwin/src/NSExpression+MGLAdditions.h
@@ -41,39 +41,39 @@ extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolatio
 @interface NSExpression (MGLVariableAdditions)
 
 /**
- `NSExpression` attribute that corresponds to the
+ `NSExpression` variable that corresponds to the
  <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-zoom"><code>zoom</code></a>
  expression reference in the Mapbox Style Specification.
  */
-+ (NSExpression *)mgl_zoomLevelVariableExpression;
+@property (class, nonatomic, readonly) NSExpression *zoomLevelVariableExpression;
 
 /**
- `NSExpression` attribute that corresponds to the
+ `NSExpression` variable that corresponds to the
  <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-heatmap-density"><code>heatmap-density</code></a>
  expression reference in the Mapbox Style Specification.
  */
-+ (NSExpression *)mgl_heatmapDensityVariableExpression;
+@property (class, nonatomic, readonly) NSExpression *heatmapDensityVariableExpression;
 
 /**
- `NSExpression` attribute that corresponds to the
+ `NSExpression` variable that corresponds to the
  <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#eexpressions-geometry-type"><code>geometry-type</code></a>
  expression reference in the Mapbox Style Specification.
  */
-+ (NSExpression *)mgl_geometryTypeVariableExpression;
+@property (class, nonatomic, readonly) NSExpression *geometryTypeVariableExpression;
 
 /**
- `NSExpression` attribute that corresponds to the
+ `NSExpression` variable that corresponds to the
  <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-id"><code>id</code></a>
  expression reference in the Mapbox Style Specification.
  */
-+ (NSExpression *)mgl_featureIdentifierVariableExpression;
+@property (class, nonatomic, readonly) NSExpression *featureIdentifierVariableExpression;
 
 /**
- `NSExpression` attribute that corresponds to the
+ `NSExpression` variable that corresponds to the
  <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-properties"><code>properties</code></a>
  expression reference in the Mapbox Style Specification.
  */
-+ (NSExpression *)mgl_featurePropertiesVariableExpression;
+@property (class, nonatomic, readonly) NSExpression *featurePropertiesVariableExpression;
 
 @end
 

--- a/platform/darwin/src/NSExpression+MGLAdditions.h
+++ b/platform/darwin/src/NSExpression+MGLAdditions.h
@@ -87,7 +87,7 @@ extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolatio
  @param trueExpression The expression for conditions equal to true.
  @param falseExpression The expression for conditions equal to false.
  */
-+ (instancetype)mgl_expressionForConditional:(nonnull NSPredicate *)conditionPredicate trueExpression:(nonnull NSExpression *)trueExpression falseExpresssion:(nonnull NSExpression *)falseExpression;
++ (instancetype)mgl_expressionForConditional:(nonnull NSPredicate *)conditionPredicate trueExpression:(nonnull NSExpression *)trueExpression falseExpresssion:(nonnull NSExpression *)falseExpression NS_SWIFT_NAME(mgl_conditional(_:trueExpression:falseExpression:));
 
 /**
  Returns a step function expression specifying the function operator, default expression
@@ -97,7 +97,7 @@ extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolatio
  @param from The expression which could be a constant or function expression.
  @param stops The stops dictionay must be numeric literals in strictly ascending order.
  */
-+ (instancetype)mgl_expressionForStepFunction:(nonnull NSExpression*)input from:(nonnull NSExpression *)from stops:(nonnull NSExpression*)stops;
++ (instancetype)mgl_expressionForStepFunction:(nonnull NSExpression*)input from:(nonnull NSExpression *)from stops:(nonnull NSExpression*)stops NS_SWIFT_NAME(mgl_stepFunction(input:from:stops:));
 
 /**
  Returns an interpolated function expression specifying the function operator, curve type,
@@ -110,18 +110,26 @@ extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolatio
  @param parameters The parameters expression.
  @param steps The steps expression.
  */
-+ (instancetype)mgl_expressionForInterpolateFunction:(nonnull NSExpression*)input curveType:(nonnull MGLExpressionInterpolationMode)curveType parameters:(nullable NSExpression *)parameters steps:(nonnull NSExpression*)steps;
-
-+ (instancetype)mgl_expressionForMatchFunction:(nonnull NSExpression*)condition values:(nonnull NSExpression *)values defaultValue:(nonnull NSExpression *)defaultValue;
++ (instancetype)mgl_expressionForInterpolateFunction:(nonnull NSExpression*)input curveType:(nonnull MGLExpressionInterpolationMode)curveType parameters:(nullable NSExpression *)parameters steps:(nonnull NSExpression*)steps NS_SWIFT_NAME(mgl_interpolateFunction(input:curveType:parameters:steps:));
 
 /**
- Returns a string constant expression appending the passed expression.
+ Returns a match function expression specifying the condition, lookup values,
+ and default value.
  
- @param string The string to append.
+ @param condition The expression condition.
+ @param values The lookup values expression.
+ @param defaultValue The defaultValue expression to be used in case there is no match.
+ */
++ (instancetype)mgl_expressionForMatchFunction:(nonnull NSExpression*)condition values:(nonnull NSExpression *)values defaultValue:(nonnull NSExpression *)defaultValue NS_SWIFT_NAME(mgl_matchFunction(condition:values:defaultValue:));
+
+/**
+ Returns a constant expression appending the passed expression.
+ 
+ @param expression The expression to append to the receiver.
     system’s preferred language, if supported, specify `nil`. To use the local
     language, specify a locale with the identifier `mul`.
  */
-- (instancetype)mgl_expressionByAppendingExpression:(NSExpression *)string;
+- (instancetype)mgl_expressionByAppendingExpression:(nonnull NSExpression *)expression NS_SWIFT_NAME(mgl_appending(_:));
 
 @end
 

--- a/platform/darwin/src/NSExpression+MGLAdditions.h
+++ b/platform/darwin/src/NSExpression+MGLAdditions.h
@@ -87,43 +87,46 @@ extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolatio
  @param trueExpression The expression for conditions equal to true.
  @param falseExpression The expression for conditions equal to false.
  */
-+ (instancetype)mgl_expressionForConditional:(nonnull NSPredicate *)conditionPredicate trueExpression:(nonnull NSExpression *)trueExpression falseExpresssion:(nonnull NSExpression *)falseExpression NS_SWIFT_NAME(mgl_conditional(_:trueExpression:falseExpression:));
++ (instancetype)mgl_expressionForConditional:(nonnull NSPredicate *)conditionPredicate trueExpression:(nonnull NSExpression *)trueExpression falseExpresssion:(nonnull NSExpression *)falseExpression NS_SWIFT_NAME(init(forMGLConditional:trueExpression:falseExpression:));
 
 /**
- Returns a step function expression specifying the function operator, default expression
+ Returns a step function expression specifying the stepping, from expression
  and stops.
  
- @param input The input expression.
- @param from The expression which could be a constant or function expression.
- @param stops The stops dictionay must be numeric literals in strictly ascending order.
+ @param steppingExpression The stepping expression.
+ @param fromExpression The expression which could be a constant or function expression.
+ @param stops The stops must be an `NSDictionary` constant `NSExpression`.
+ The wrapped dictionary must be numeric expression literals in strictly ascending order.
  */
-+ (instancetype)mgl_expressionForStepFunction:(nonnull NSExpression*)input from:(nonnull NSExpression *)from stops:(nonnull NSExpression*)stops NS_SWIFT_NAME(mgl_stepFunction(input:from:stops:));
++ (instancetype)mgl_expressionForSteppingExpression:(nonnull NSExpression*)steppingExpression fromExpression:(nonnull NSExpression *)fromExpression stops:(nonnull NSExpression*)stops NS_SWIFT_NAME(init(forMGLStepping:from:stops:));
 
 /**
  Returns an interpolated function expression specifying the function operator, curve type,
  parameters and steps.
  
- @param input The expression input.
+ @param interpolatingExpression The interpolating expression input.
  @param curveType The curve type could be `MGLExpressionInterpolationModeLinear`,
  `MGLExpressionInterpolationModeExponential` and
  `MGLExpressionInterpolationModeCubicBezier`.
  @param parameters The parameters expression.
- @param steps The steps expression.
+ @param stops The stops expression.
  */
-+ (instancetype)mgl_expressionForInterpolateFunction:(nonnull NSExpression*)input curveType:(nonnull MGLExpressionInterpolationMode)curveType parameters:(nullable NSExpression *)parameters steps:(nonnull NSExpression*)steps NS_SWIFT_NAME(mgl_interpolateFunction(input:curveType:parameters:steps:));
++ (instancetype)mgl_expressionForInterpolatingExpression:(nonnull NSExpression*)interpolatingExpression withCurveType:(nonnull MGLExpressionInterpolationMode)curveType parameters:(nullable NSExpression *)parameters stops:(nonnull NSExpression*)stops NS_SWIFT_NAME(init(forMGLInterpolating:curveType:parameters:stops:));
 
 /**
- Returns a match function expression specifying the condition, lookup values,
+ Returns a match function expression specifying the input, matching values,
  and default value.
  
- @param condition The expression condition.
- @param values The lookup values expression.
- @param defaultValue The defaultValue expression to be used in case there is no match.
+ @param matchingExpression The matching expression.
+ @param matchedExpressions The matched values expression dictionary must be condition : value.
+ @param defaultExpression The defaultValue expression to be used in case there is no match.
  */
-+ (instancetype)mgl_expressionForMatchFunction:(nonnull NSExpression*)condition values:(nonnull NSExpression *)values defaultValue:(nonnull NSExpression *)defaultValue NS_SWIFT_NAME(mgl_matchFunction(condition:values:defaultValue:));
-
++ (instancetype)mgl_expressionForMatchingExpression:(nonnull NSExpression *)matchingExpression inDictionary:(nonnull NSDictionary<NSExpression *, NSExpression *> *)matchedExpressions defaultExpression:(nonnull NSExpression *)defaultExpression NS_SWIFT_NAME(init(forMGLMatchingKey:matched:default:));
 /**
  Returns a constant expression appending the passed expression.
+ 
+ @note Both the receiver and the given expression must be an `NSString` constant
+ expression type; otherwise, an exception is rised.
  
  @param expression The expression to append to the receiver.
     system’s preferred language, if supported, specify `nil`. To use the local

--- a/platform/darwin/src/NSExpression+MGLAdditions.mm
+++ b/platform/darwin/src/NSExpression+MGLAdditions.mm
@@ -599,21 +599,27 @@ NS_DICTIONARY_OF(NSNumber *, NSExpression *) *MGLStopDictionaryByReplacingTokens
     }
 }
 
-+ (instancetype)mgl_expressionForStepFunction:(NSExpression *)input from:(NSExpression *)from stops:(nonnull NSExpression *)stops {
++ (instancetype)mgl_expressionForSteppingExpression:(nonnull NSExpression*)steppingExpression fromExpression:(nonnull NSExpression *)fromExpression stops:(nonnull NSExpression*)stops {
     return [NSExpression expressionForFunction:@"mgl_step:from:stops:"
-                                     arguments:@[input, from, stops]];
+                                     arguments:@[steppingExpression, fromExpression, stops]];
 }
 
-+ (instancetype)mgl_expressionForInterpolateFunction:(nonnull NSExpression*)input curveType:(nonnull MGLExpressionInterpolationMode)curveType parameters:(nullable NSExpression *)parameters steps:(nonnull NSExpression*)steps {
++ (instancetype)mgl_expressionForInterpolatingExpression:(nonnull NSExpression*)interpolatingExpression withCurveType:(nonnull MGLExpressionInterpolationMode)curveType parameters:(nullable NSExpression *)parameters stops:(nonnull NSExpression*)stops {
     NSExpression *sanitizeParams = parameters ? parameters : [NSExpression expressionForConstantValue:nil];
     return [NSExpression expressionForFunction:@"mgl_interpolate:withCurveType:parameters:stops:"
-                                     arguments:@[input, [NSExpression expressionForConstantValue:curveType], sanitizeParams, steps]];
+                                     arguments:@[interpolatingExpression, [NSExpression expressionForConstantValue:curveType], sanitizeParams, stops]];
 }
 
-+ (instancetype)mgl_expressionForMatchFunction:(nonnull NSExpression*)condition values:(nonnull NSExpression *)values defaultValue:(nonnull NSExpression *)defaultValue {
-    NSMutableArray *optionsArray = [NSMutableArray arrayWithArray:values.constantValue];
-    [optionsArray insertObject:condition atIndex:0];
-    [optionsArray addObject:defaultValue];
++ (instancetype)mgl_expressionForMatchingExpression:(nonnull NSExpression *)matchingExpression inDictionary:(nonnull NSDictionary<NSExpression *, NSExpression *> *)matchedExpressions defaultExpression:(nonnull NSExpression *)defaultExpression {
+    NSMutableArray *optionsArray = [NSMutableArray arrayWithObjects:matchingExpression, nil];
+    
+    NSEnumerator *matchEnumerator = matchedExpressions.keyEnumerator;
+    while (NSExpression *key = matchEnumerator.nextObject) {
+        [optionsArray addObject:key];
+        [optionsArray addObject:[matchedExpressions objectForKey:key]];
+    }
+    
+    [optionsArray addObject:defaultExpression];
     return [NSExpression expressionForFunction:@"MGL_MATCH"
                                      arguments:optionsArray];
 }

--- a/platform/darwin/src/NSExpression+MGLAdditions.mm
+++ b/platform/darwin/src/NSExpression+MGLAdditions.mm
@@ -567,24 +567,24 @@ NS_DICTIONARY_OF(NSNumber *, NSExpression *) *MGLStopDictionaryByReplacingTokens
 @end
 @implementation NSExpression (MGLVariableAdditions)
 
-+ (NSExpression *)mgl_zoomLevelVariableExpression {
++ (NSExpression *)zoomLevelVariableExpression {
     return [NSExpression expressionForVariable:@"zoomLevel"];
 }
 
-+ (NSExpression *)mgl_heatmapDensityVariableExpression {
++ (NSExpression *)heatmapDensityVariableExpression {
     return [NSExpression expressionForVariable:@"heatmapDensity"];
 }
 
-+ (NSExpression *)mgl_geometryTypeVariableExpression {
-    return [NSExpression expressionForVariable:@"mgl_geometryType"];
++ (NSExpression *)geometryTypeVariableExpression {
+    return [NSExpression expressionForVariable:@"geometryType"];
 }
 
-+ (NSExpression *)mgl_featureIdentifierVariableExpression {
-    return [NSExpression expressionForVariable:@"mgl_featureIdentifier"];
++ (NSExpression *)featureIdentifierVariableExpression {
+    return [NSExpression expressionForVariable:@"featureIdentifier"];
 }
 
-+ (NSExpression *)mgl_featurePropertiesVariableExpression {
-    return [NSExpression expressionForVariable:@"mgl_featureProperties"];
++ (NSExpression *)featurePropertiesVariableExpression {
+    return [NSExpression expressionForVariable:@"featureProperties"];
 }
 
 @end
@@ -831,15 +831,15 @@ NSArray *MGLSubexpressionsWithJSONObjects(NSArray *objects) {
             return [NSExpression expressionForFunction:@"mgl_step:from:stops:"
                                              arguments:@[inputExpression, minimum, stopExpression]];
         } else if ([op isEqualToString:@"zoom"]) {
-            return NSExpression.mgl_zoomLevelVariableExpression;
+            return NSExpression.zoomLevelVariableExpression;
         } else if ([op isEqualToString:@"heatmap-density"]) {
-            return NSExpression.mgl_heatmapDensityVariableExpression;
+            return NSExpression.heatmapDensityVariableExpression;
         } else if ([op isEqualToString:@"geometry-type"]) {
-            return NSExpression.mgl_geometryTypeVariableExpression;
+            return NSExpression.geometryTypeVariableExpression;
         } else if ([op isEqualToString:@"id"]) {
-            return NSExpression.mgl_featureIdentifierVariableExpression;
+            return NSExpression.featureIdentifierVariableExpression;
         }  else if ([op isEqualToString:@"properties"]) {
-            return NSExpression.mgl_featurePropertiesVariableExpression;
+            return NSExpression.featurePropertiesVariableExpression;
         } else if ([op isEqualToString:@"var"]) {
             return [NSExpression expressionForVariable:argumentObjects.firstObject];
         } else if ([op isEqualToString:@"case"]) {
@@ -889,9 +889,6 @@ NSArray *MGLSubexpressionsWithJSONObjects(NSArray *objects) {
                 format:@"Unable to convert JSON object %@ to an NSExpression.", object];
     
     return nil;
-}
-- (instancetype)mgl_expressionByAppendingExpression:(NSExpression *)expression {
-    return [NSExpression expressionForFunction:self selectorName:@"stringByAppendingString:" arguments:@[expression]];
 }
 
 - (id)mgl_jsonExpressionObject {

--- a/platform/darwin/src/NSExpression+MGLAdditions.mm
+++ b/platform/darwin/src/NSExpression+MGLAdditions.mm
@@ -599,19 +599,19 @@ NS_DICTIONARY_OF(NSNumber *, NSExpression *) *MGLStopDictionaryByReplacingTokens
     }
 }
 
-+ (instancetype)mgl_expressionForSteppingExpression:(nonnull NSExpression*)steppingExpression fromExpression:(nonnull NSExpression *)fromExpression stops:(nonnull NSExpression*)stops {
++ (instancetype)mgl_expressionForSteppingExpression:(nonnull NSExpression*)steppingExpression fromExpression:(nonnull NSExpression *)minimumExpression stops:(nonnull NSExpression*)stops {
     return [NSExpression expressionForFunction:@"mgl_step:from:stops:"
-                                     arguments:@[steppingExpression, fromExpression, stops]];
+                                     arguments:@[steppingExpression, minimumExpression, stops]];
 }
 
-+ (instancetype)mgl_expressionForInterpolatingExpression:(nonnull NSExpression*)interpolatingExpression withCurveType:(nonnull MGLExpressionInterpolationMode)curveType parameters:(nullable NSExpression *)parameters stops:(nonnull NSExpression*)stops {
++ (instancetype)mgl_expressionForInterpolatingExpression:(nonnull NSExpression*)inputExpression withCurveType:(nonnull MGLExpressionInterpolationMode)curveType parameters:(nullable NSExpression *)parameters stops:(nonnull NSExpression*)stops {
     NSExpression *sanitizeParams = parameters ? parameters : [NSExpression expressionForConstantValue:nil];
     return [NSExpression expressionForFunction:@"mgl_interpolate:withCurveType:parameters:stops:"
-                                     arguments:@[interpolatingExpression, [NSExpression expressionForConstantValue:curveType], sanitizeParams, stops]];
+                                     arguments:@[inputExpression, [NSExpression expressionForConstantValue:curveType], sanitizeParams, stops]];
 }
 
-+ (instancetype)mgl_expressionForMatchingExpression:(nonnull NSExpression *)matchingExpression inDictionary:(nonnull NSDictionary<NSExpression *, NSExpression *> *)matchedExpressions defaultExpression:(nonnull NSExpression *)defaultExpression {
-    NSMutableArray *optionsArray = [NSMutableArray arrayWithObjects:matchingExpression, nil];
++ (instancetype)mgl_expressionForMatchingExpression:(nonnull NSExpression *)inputExpression inDictionary:(nonnull NSDictionary<NSExpression *, NSExpression *> *)matchedExpressions defaultExpression:(nonnull NSExpression *)defaultExpression {
+    NSMutableArray *optionsArray = [NSMutableArray arrayWithObjects:inputExpression, nil];
     
     NSEnumerator *matchEnumerator = matchedExpressions.keyEnumerator;
     while (NSExpression *key = matchEnumerator.nextObject) {

--- a/platform/darwin/src/NSExpression+MGLAdditions.mm
+++ b/platform/darwin/src/NSExpression+MGLAdditions.mm
@@ -618,7 +618,7 @@ NS_DICTIONARY_OF(NSNumber *, NSExpression *) *MGLStopDictionaryByReplacingTokens
                                      arguments:optionsArray];
 }
 
-- (instancetype)mgl_expressionByAppendingExpression:(NSExpression *)expression {
+- (instancetype)mgl_expressionByAppendingExpression:(nonnull NSExpression *)expression {
     NSExpression *subexpression = [NSExpression expressionForAggregate:@[self, expression]];
     return [NSExpression expressionForFunction:@"mgl_join:" arguments:@[subexpression]];
 }

--- a/platform/darwin/test/MGLExpressionTests.mm
+++ b/platform/darwin/test/MGLExpressionTests.mm
@@ -1019,19 +1019,19 @@ using namespace std::string_literals;
     }
     {
         NSDictionary *stops = @{@0: MGLConstantExpression(@111), @1: MGLConstantExpression(@1111)};
-        NSExpression *expression = [NSExpression mgl_expressionForStepFunction:[NSExpression expressionForKeyPath:@"x"]
-                                                                          from:[NSExpression expressionForConstantValue:@11]
-                                                                         stops:[NSExpression expressionForConstantValue:stops]];
+        NSExpression *expression = [NSExpression mgl_expressionForSteppingExpression:[NSExpression expressionForKeyPath:@"x"]
+                                                                      fromExpression:[NSExpression expressionForConstantValue:@11]
+                                                                               stops:[NSExpression expressionForConstantValue:stops]];
         NSArray *jsonExpression = @[@"step", @[@"get", @"x"], @11, @0, @111, @1, @1111];
         XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
         XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression], expression);
     }
     {
         NSDictionary *stops = @{@0: MGLConstantExpression(@100), @10: MGLConstantExpression(@200)};
-        NSExpression *expression = [NSExpression mgl_expressionForInterpolateFunction:[NSExpression expressionForKeyPath:@"x"]
-                                                                            curveType:MGLExpressionInterpolationModeLinear
-                                                                           parameters:nil
-                                                                                steps:[NSExpression expressionForConstantValue:stops]];
+        NSExpression *expression = [NSExpression mgl_expressionForInterpolatingExpression:[NSExpression expressionForKeyPath:@"x"]
+                                                                            withCurveType:MGLExpressionInterpolationModeLinear
+                                                                               parameters:nil
+                                                                                    stops:[NSExpression expressionForConstantValue:stops]];
         NSArray *jsonExpression = @[@"interpolate", @[@"linear"], @[@"get", @"x"], @0, @100, @10, @200];
         XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
         XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression], expression);
@@ -1045,10 +1045,10 @@ using namespace std::string_literals;
         XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression], expression);
     }
     {
-        NSArray *values = @[MGLConstantExpression(@1), MGLConstantExpression(@"one")];
-        NSExpression *expression = [NSExpression mgl_expressionForMatchFunction:[NSExpression expressionWithFormat:@"2 * 1"]
-                                                                         values:[NSExpression expressionForConstantValue:values]
-                                                                   defaultValue:[NSExpression expressionForConstantValue:@"default"]];
+        NSDictionary *values = @{ MGLConstantExpression(@1): MGLConstantExpression(@"one") };
+        NSExpression *expression = [NSExpression mgl_expressionForMatchingExpression:[NSExpression expressionWithFormat:@"2 * 1"]
+                                                                        inDictionary:values
+                                                                   defaultExpression:[NSExpression expressionForConstantValue:@"default"]];
         NSArray *jsonExpression =  @[@"match", @[@"*", @2, @1], @1, @"one", @"default"];
         XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
         XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression], expression);

--- a/platform/darwin/test/MGLExpressionTests.mm
+++ b/platform/darwin/test/MGLExpressionTests.mm
@@ -1006,4 +1006,54 @@ using namespace std::string_literals;
     }
 }
 
+- (void)testConvenienceInitializers {
+    {
+        NSExpression *expression = [NSExpression mgl_expressionForConditional:[NSPredicate predicateWithFormat:@"1 = 2"]
+                                                               trueExpression:MGLConstantExpression(@YES)
+                                                             falseExpresssion:MGLConstantExpression(@NO)];
+        
+        NSArray *jsonExpression = @[@"case", @[@"==", @1, @2], @YES, @NO];
+        XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
+        XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression], expression);
+        XCTAssertEqualObjects([expression expressionValueWithObject:nil context:nil], @NO);
+    }
+    {
+        NSDictionary *stops = @{@0: MGLConstantExpression(@111), @1: MGLConstantExpression(@1111)};
+        NSExpression *expression = [NSExpression mgl_expressionForStepFunction:[NSExpression expressionForKeyPath:@"x"]
+                                                                          from:[NSExpression expressionForConstantValue:@11]
+                                                                         stops:[NSExpression expressionForConstantValue:stops]];
+        NSArray *jsonExpression = @[@"step", @[@"get", @"x"], @11, @0, @111, @1, @1111];
+        XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
+        XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression], expression);
+    }
+    {
+        NSDictionary *stops = @{@0: MGLConstantExpression(@100), @10: MGLConstantExpression(@200)};
+        NSExpression *expression = [NSExpression mgl_expressionForInterpolateFunction:[NSExpression expressionForKeyPath:@"x"]
+                                                                            curveType:MGLExpressionInterpolationModeLinear
+                                                                           parameters:nil
+                                                                                steps:[NSExpression expressionForConstantValue:stops]];
+        NSArray *jsonExpression = @[@"interpolate", @[@"linear"], @[@"get", @"x"], @0, @100, @10, @200];
+        XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
+        XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression], expression);
+    }
+    {
+        NSExpression *expression = [[NSExpression expressionForConstantValue:@"Old"] mgl_expressionByAppendingExpression:[NSExpression expressionForConstantValue:@"MacDonald"]];
+
+        NSArray *jsonExpression = @[@"concat", @"Old", @"MacDonald"];
+        XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
+        XCTAssertEqualObjects([expression expressionValueWithObject:nil context:nil], @"OldMacDonald");
+        XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression], expression);
+    }
+    {
+        NSArray *values = @[MGLConstantExpression(@1), MGLConstantExpression(@"one")];
+        NSExpression *expression = [NSExpression mgl_expressionForMatchFunction:[NSExpression expressionWithFormat:@"2 * 1"]
+                                                                         values:[NSExpression expressionForConstantValue:values]
+                                                                   defaultValue:[NSExpression expressionForConstantValue:@"default"]];
+        NSArray *jsonExpression =  @[@"match", @[@"*", @2, @1], @1, @"one", @"default"];
+        XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
+        XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression], expression);
+    }
+}
+
+
 @end

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -967,9 +967,14 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
                                       @10.0f: [UIColor redColor],
                                       @12.0f: [UIColor greenColor],
                                       @14.0f: [UIColor blueColor]};
+    NSExpression *fillColorExpression = [NSExpression mgl_expressionForInterpolateFunction:NSExpression.mgl_zoomLevelVariableExpression
+                                                                                 curveType:MGLExpressionInterpolationModeLinear
+                                                                                parameters:nil
+                                                                                     steps:[NSExpression expressionForConstantValue:waterColorStops]];
     waterLayer.fillColor = [NSExpression expressionWithFormat:
                             @"mgl_interpolate:withCurveType:parameters:stops:($zoomLevel, 'linear', nil, %@)",
                             waterColorStops];
+    waterLayer.fillColor = fillColorExpression;
 
     NSDictionary *fillAntialiasedStops = @{@11: @YES,
                                            @12: @NO,
@@ -1467,10 +1472,16 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
 
     // source, categorical function that sets any feature with a "fill" attribute value of true to red color and anything without to green
     MGLFillStyleLayer *fillStyleLayer = [[MGLFillStyleLayer alloc] initWithIdentifier:@"fill-layer" source:shapeSource];
-    fillStyleLayer.fillColor = [NSExpression expressionWithFormat:@"TERNARY(fill == YES, %@, %@)", [UIColor greenColor], [UIColor redColor]];
+    fillStyleLayer.fillColor = [NSExpression mgl_expressionForConditional:[NSPredicate predicateWithFormat:@"fill == YES"]
+                                                           trueExpression:[NSExpression expressionForConstantValue:[UIColor greenColor]]
+                                                         falseExpresssion:[NSExpression expressionForConstantValue:[UIColor redColor]]];
+                                                               
+    
 
     // source, identity function that sets any feature with an "opacity" attribute to use that value and anything without to 1.0
-    fillStyleLayer.fillOpacity = [NSExpression expressionWithFormat:@"TERNARY(opacity != nil, opacity, 1.0)"];
+    fillStyleLayer.fillOpacity = [NSExpression mgl_expressionForConditional:[NSPredicate predicateWithFormat:@"opacity != nil"]
+                                                             trueExpression:[NSExpression expressionForKeyPath:@"opacity"] 
+                                                           falseExpresssion:[NSExpression expressionForConstantValue:@1.0]];
     [self.mapView.style addLayer:fillStyleLayer];
 }
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -967,10 +967,10 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
                                       @10.0f: [UIColor redColor],
                                       @12.0f: [UIColor greenColor],
                                       @14.0f: [UIColor blueColor]};
-    NSExpression *fillColorExpression = [NSExpression mgl_expressionForInterpolateFunction:NSExpression.mgl_zoomLevelVariableExpression
-                                                                                 curveType:MGLExpressionInterpolationModeLinear
-                                                                                parameters:nil
-                                                                                     steps:[NSExpression expressionForConstantValue:waterColorStops]];
+    NSExpression *fillColorExpression = [NSExpression mgl_expressionForInterpolatingExpression:NSExpression.zoomLevelVariableExpression
+                                                                                 withCurveType:MGLExpressionInterpolationModeLinear
+                                                                                    parameters:nil
+                                                                                         stops:[NSExpression expressionForConstantValue:waterColorStops]];
     waterLayer.fillColor = fillColorExpression;
 
     NSDictionary *fillAntialiasedStops = @{@11: @YES,
@@ -978,9 +978,9 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
                                            @13: @YES,
                                            @14: @NO,
                                            @15: @YES};
-    waterLayer.fillAntialiased = [NSExpression mgl_expressionForStepFunction:NSExpression.mgl_zoomLevelVariableExpression
-                                                                        from:[NSExpression expressionForConstantValue:@NO]
-                                                                       stops:[NSExpression expressionForConstantValue:fillAntialiasedStops]];
+    waterLayer.fillAntialiased = [NSExpression mgl_expressionForSteppingExpression:NSExpression.zoomLevelVariableExpression
+                                                                    fromExpression:[NSExpression expressionForConstantValue:@NO]
+                                                                             stops:[NSExpression expressionForConstantValue:fillAntialiasedStops]];
 }
 
 - (void)styleRoadLayer

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -971,9 +971,6 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
                                                                                  curveType:MGLExpressionInterpolationModeLinear
                                                                                 parameters:nil
                                                                                      steps:[NSExpression expressionForConstantValue:waterColorStops]];
-    waterLayer.fillColor = [NSExpression expressionWithFormat:
-                            @"mgl_interpolate:withCurveType:parameters:stops:($zoomLevel, 'linear', nil, %@)",
-                            waterColorStops];
     waterLayer.fillColor = fillColorExpression;
 
     NSDictionary *fillAntialiasedStops = @{@11: @YES,
@@ -981,9 +978,9 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
                                            @13: @YES,
                                            @14: @NO,
                                            @15: @YES};
-    waterLayer.fillAntialiased = [NSExpression expressionWithFormat:
-                                  @"mgl_step:from:stops:($zoomLevel, false, %@)",
-                                  fillAntialiasedStops];
+    waterLayer.fillAntialiased = [NSExpression mgl_expressionForStepFunction:NSExpression.mgl_zoomLevelVariableExpression
+                                                                        from:[NSExpression expressionForConstantValue:@NO]
+                                                                       stops:[NSExpression expressionForConstantValue:fillAntialiasedStops]];
 }
 
 - (void)styleRoadLayer

--- a/platform/ios/docs/guides/For Style Authors.md
+++ b/platform/ios/docs/guides/For Style Authors.md
@@ -329,9 +329,9 @@ In style specification | Method, function, or predicate type | Format string syn
 `to-number`            | `mgl_numberWithFallbackValues:` | `CAST(zipCode, 'NSNumber')`
 `to-string`            | `stringValue` | `CAST(ele, 'NSString')`
 `typeof`               | |
-`geometry-type`        | |`$geometryType`
-`id`                   | |`$featureIdentifier`
-`properties`           | |`$featureProperties`
+`geometry-type`        | `NSExpression.geometryTypeVariableExpression` | `$geometryType`
+`id`                   | `NSExpression.featureIdentifierVariableExpression` | `$featureIdentifier`
+`properties`           | `NSExpression.featurePropertiesVariableExpression` | `$featureProperties`
 `at`                   | `objectFrom:withIndex:` | `array[n]`
 `get`                  | `+[NSExpression expressionForKeyPath:]` | Key path
 `has`                  | `mgl_does:have:` | `mgl_does:have:(self, 'key')`
@@ -345,14 +345,14 @@ In style specification | Method, function, or predicate type | Format string syn
 `>=`                   | `NSGreaterThanOrEqualToPredicateOperatorType` | `key >= value`
 `all`                  | `NSAndPredicateType` | `p0 AND … AND pn`
 `any`                  | `NSOrPredicateType` | `p0 OR … OR pn`
-`case`                 | `+[NSExpression expressionForConditional:trueExpression:falseExpression:]` or `MGL_IF` | `TERNARY(1 = 2, YES, NO)` or `MGL_IF(1 = 2, YES, 2 = 2, YES, NO)`
+`case`                 | `+[NSExpression expressionForConditional:trueExpression:falseExpression:]` or `MGL_IF` or `+[NSExpression mgl_expressionForConditional:trueExpression:falseExpresssion:]` | `TERNARY(1 = 2, YES, NO)` or `MGL_IF(1 = 2, YES, 2 = 2, YES, NO)`
 `coalesce`             | `mgl_coalesce:` | `mgl_coalesce({x, y, z})`
-`match`                | `MGL_MATCH` | `MGL_MATCH(x, 0, 'zero match', 1, 'one match', 'two match', 'default')`
-`interpolate`          | `mgl_interpolate:withCurveType:parameters:stops:` |
-`step`                 | `mgl_step:withMinimum:stops:` |
+`match`                | `MGL_MATCH` or `+[NSExpression mgl_expressionForMatchingExpression:inDictionary:defaultExpression:]` | `MGL_MATCH(x, 0, 'zero match', 1, 'one match', 'two match', 'default')`
+`interpolate`          | `mgl_interpolate:withCurveType:parameters:stops:` or `+[NSExpression mgl_expressionForInterpolatingExpression:withCurveType:parameters:stops:]` |
+`step`                 | `mgl_step:withMinimum:stops:` or `+[NSExpression mgl_expressionForSteppingExpression:fromExpression:stops:]` |
 `let`                  | `mgl_expressionWithContext:` | `MGL_LET('ios', 11, 'macos', 10.13, $ios + $macos)`
 `var`                  | `+[NSExpression expressionForVariable:]` | `$variable`
-`concat`               | `mgl_join:` | `mgl_join({'Old', ' ', 'MacDonald'})`
+`concat`               | `mgl_join:` or `-[NSExpression mgl_expressionByAppendingExpression:]` | `mgl_join({'Old', ' ', 'MacDonald'})`
 `downcase`             | `lowercase:` | `lowercase('DOWNTOWN')`
 `upcase`               | `uppercase:` | `uppercase('Elysian Fields')`
 `rgb`                  | `+[UIColor colorWithRed:green:blue:alpha:]` |
@@ -383,8 +383,8 @@ In style specification | Method, function, or predicate type | Format string syn
 `sin`                  | |
 `sqrt`                 | `sqrt:` | `sqrt(2)`
 `tan`                  | |
-`zoom`                 | | `$zoom`
-`heatmap-density`      | | `$heatmapDensity`
+`zoom`                 | `NSExpression.zoomLevelVariableExpression` | `$zoom`
+`heatmap-density`      | `NSExpression.heatmapDensityVariableExpression` | `$heatmapDensity`
 
 For operators that have no corresponding `NSExpression` symbol, use the
 `MGL_FUNCTION()` format string syntax.

--- a/platform/macos/docs/guides/For Style Authors.md
+++ b/platform/macos/docs/guides/For Style Authors.md
@@ -322,9 +322,9 @@ In style specification | Method, function, or predicate type | Format string syn
 `to-number`            | `mgl_numberWithFallbackValues:` | `CAST(zipCode, 'NSNumber')`
 `to-string`            | `stringValue` | `CAST(ele, 'NSString')`
 `typeof`               | |
-`geometry-type`        | |`$geometryType`
-`id`                   | |`$featureIdentifier`
-`properties`           | |`$featureProperties`
+`geometry-type`        | `NSExpression.geometryTypeVariableExpression` | `$geometryType`
+`id`                   | `NSExpression.featureIdentifierVariableExpression` | `$featureIdentifier`
+`properties`           | `NSExpression.featurePropertiesVariableExpression` | `$featureProperties`
 `at`                   | `objectFrom:withIndex:` | `array[n]`
 `get`                  | `+[NSExpression expressionForKeyPath:]` | Key path
 `has`                  | `mgl_does:have:` | `mgl_does:have:(self, 'key')`
@@ -338,14 +338,14 @@ In style specification | Method, function, or predicate type | Format string syn
 `>=`                   | `NSGreaterThanOrEqualToPredicateOperatorType` | `key >= value`
 `all`                  | `NSAndPredicateType` | `p0 AND … AND pn`
 `any`                  | `NSOrPredicateType` | `p0 OR … OR pn`
-`case`                 | `+[NSExpression expressionForConditional:trueExpression:falseExpression:]` or `MGL_IF` | `TERNARY(1 = 2, YES, NO)` or `MGL_IF(1 = 2, YES, 2 = 2, YES, NO)`
+`case`                 | `+[NSExpression expressionForConditional:trueExpression:falseExpression:]` or `MGL_IF` or `+[NSExpression mgl_expressionForConditional:trueExpression:falseExpresssion:]` | `TERNARY(1 = 2, YES, NO)` or `MGL_IF(1 = 2, YES, 2 = 2, YES, NO)`
 `coalesce`             | `mgl_coalesce:` | `mgl_coalesce({x, y, z})`
-`match`                | `MGL_MATCH` | `MGL_MATCH(x, 0, 'zero match', 1, 'one match', 'two match', 'default')`
-`interpolate`          | `mgl_interpolate:withCurveType:parameters:stops:` |
-`step`                 | `mgl_step:withMinimum:stops:` |
+`match`                | `MGL_MATCH` or `+[NSExpression mgl_expressionForMatchingExpression:inDictionary:defaultExpression:]` | `MGL_MATCH(x, 0, 'zero match', 1, 'one match', 'two match', 'default')`
+`interpolate`          | `mgl_interpolate:withCurveType:parameters:stops:` or `+[NSExpression mgl_expressionForInterpolatingExpression:withCurveType:parameters:stops:]` |
+`step`                 | `mgl_step:withMinimum:stops:` or `+[NSExpression mgl_expressionForSteppingExpression:fromExpression:stops:]` |
 `let`                  | `mgl_expressionWithContext:` | `MGL_LET('ios', 11, 'macos', 10.13, $ios + $macos)`
 `var`                  | `+[NSExpression expressionForVariable:]` | `$variable`
-`concat`               | `mgl_join:` | `mgl_join({'Old', ' ', 'MacDonald'})`
+`concat`               | `mgl_join:` or `-[NSExpression mgl_expressionByAppendingExpression:]` | `mgl_join({'Old', ' ', 'MacDonald'})`
 `downcase`             | `lowercase:` | `lowercase('DOWNTOWN')`
 `upcase`               | `uppercase:` | `uppercase('Elysian Fields')`
 `rgb`                  | `+[NSColor colorWithCalibratedRed:green:blue:alpha:]` |
@@ -376,8 +376,8 @@ In style specification | Method, function, or predicate type | Format string syn
 `sin`                  | |
 `sqrt`                 | `sqrt:` | `sqrt(2)`
 `tan`                  | |
-`zoom`                 | | `$zoom`
-`heatmap-density`      | | `$heatmapDensity`
+`zoom`                 | `NSExpression.zoomLevelVariableExpression` | `$zoom`
+`heatmap-density`      | `NSExpression.heatmapDensityVariableExpression` | `$heatmapDensity`
 
 For operators that have no corresponding `NSExpression` symbol, use the
 `MGL_FUNCTION()` format string syntax.


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/11016.

- [x] Add documentation.
- [x] Add convenience properties/initializers.
- [x] Modify expression tests.

This PR adds convenience initializers and properties that helps developers transition from the strongly typed `MGLStyleValue` class.

/cc @1ec5 