### PR TITLE
[core] Don't reuse heatmap render texture on viewport resize.

### DIFF
--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -67,7 +67,7 @@ void RenderHeatmapLayer::render(PaintParameters& parameters, RenderSource*) {
                 }
             }
 
-            if (!renderTexture) {
+            if (!parameters.context.supportsHalfFloatTextures || !renderTexture) {
                 renderTexture = OffscreenTexture(parameters.context, size, gl::TextureType::UnsignedByte);
                 renderTexture->bind();
             }


### PR DESCRIPTION
Fixes issue #11228.

I couldn't think of any good way to exercise this functionality within our current test-harness, but I did test it manually using the "run these two tests one after the other using a sanitizer build" approach that I used to reproduce the bug in the first place.

@fabian-guerra We probably want to CP this into boba as well. It's probably not the worst bug (should only affect heatmap rendering on resizing viewports on devices that don't support half-float textures), but better never to release it in the first place.

/cc @mourner @brunoabinader 