### PR TITLE
[core] Modify TransitionOptions conversion code to appease GCC6 sanitization

### DIFF
--- a/src/mbgl/style/conversion/transition_options.cpp
+++ b/src/mbgl/style/conversion/transition_options.cpp
@@ -10,29 +10,29 @@ optional<TransitionOptions> Converter<TransitionOptions>::operator()(const Conve
         return {};
     }
 
-    TransitionOptions result;
-
-    auto duration = objectMember(value, "duration");
-    if (duration) {
-        auto number = toNumber(*duration);
+    auto objectDuration = objectMember(value, "duration");
+    optional<Duration> duration;
+    if (objectDuration) {
+        auto number = toNumber(*objectDuration);
         if (!number) {
             error = { "duration must be a number" };
             return {};
         }
-        result.duration = { std::chrono::milliseconds(int64_t(*number)) };
+        duration = Duration(std::chrono::milliseconds(int64_t(*number)));
     }
 
-    auto delay = objectMember(value, "delay");
-    if (delay) {
-        auto number = toNumber(*delay);
+    auto objectDelay = objectMember(value, "delay");
+    optional<Duration> delay;
+    if (objectDelay) {
+        auto number = toNumber(*objectDelay);
         if (!number) {
             error = { "delay must be a number" };
             return {};
         }
-        result.delay = { std::chrono::milliseconds(int64_t(*number)) };
+        delay = Duration(std::chrono::milliseconds(int64_t(*number)));
     }
 
-    return result;
+    return TransitionOptions{duration, delay};
 }
 
 } // namespace conversion


### PR DESCRIPTION
Without this change, GCC 6 generates the the following compiler error while building with `BUILDTYPE=Sanitize`:

```
../../../src/mbgl/style/conversion/transition_options.cpp: In member function ‘mbgl::optional<mbgl::style::TransitionOptions> mbgl::style::conversion::Converter<mbgl::style::TransitionOptions>::operator()(const mbgl::style::conversion::Convertible&, mbgl::style::conversion::Error&) const’:
../../../src/mbgl/style/conversion/transition_options.cpp:13:23: error: ‘result.mbgl::style::TransitionOptions::delay.std::experimental::fundamentals_v1::optional<std::chrono::duration<long int, std::ratio<1l, 1000000000l> > >::<anonymous>.std::experimental::fundamentals_v1::_Optional_base<std::chrono::duration<long int, std::ratio<1l, 1000000000l> >, false>::<anonymous>.std::experimental::fundamentals_v1::_Optional_base<std::chrono::duration<long int, std::ratio<1l, 1000000000l> >, false>::<anonymous union>::_M_payload.std::chrono::duration<long int, std::ratio<1l, 1000000000l> >::__r’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     TransitionOptions result;
                       ^~~~~~
../../../src/mbgl/style/conversion/transition_options.cpp:13:23: error: ‘result.mbgl::style::TransitionOptions::duration.std::experimental::fundamentals_v1::optional<std::chrono::duration<long int, std::ratio<1l, 1000000000l> > >::<anonymous>.std::experimental::fundamentals_v1::_Optional_base<std::chrono::duration<long int, std::ratio<1l, 1000000000l> >, false>::<anonymous>.std::experimental::fundamentals_v1::_Optional_base<std::chrono::duration<long int, std::ratio<1l, 1000000000l> >, false>::<anonymous union>::_M_payload.std::chrono::duration<long int, std::ratio<1l, 1000000000l> >::__r’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
cc1plus: all warnings being treated as errors
```

This change suggested by @joto just constructs the `TransitionOptions` at the time it's returned instead of constructing an empty `TransitionOptions` and modifying it. Getting rid of the temporary variable is nice, but on the other hand relying on the reader knowing the order of the "duration"/"delay" constructor arguments is not as nice...

I'd insert a comment explaining why it has to be the way it is, but I don't really have a good explanation.

We don't currently have a CI target that makes a sanitize build on GCC6, but maybe we should, because it's useful for debugging issues that show up in the recycle-map test?

/cc @jfirebaugh 