### PR TITLE
[core, node] Hold on to map handle during NodeMap::request

### DIFF
--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -1154,6 +1154,10 @@ NodeMap::~NodeMap() {
 
 std::unique_ptr<mbgl::AsyncRequest> NodeMap::request(const mbgl::Resource& resource, mbgl::FileSource::Callback callback_) {
     Nan::HandleScope scope;
+    // Because this method may be called while this NodeMap is already eligible for garbage collection,
+    // we need to explicitly hold onto our own handle here so that GC during a v8 call doesn't destroy
+    // *this while we're still executing code.
+    handle();
 
     v8::Local<v8::Value> argv[] = {
         Nan::New<v8::External>(this),


### PR DESCRIPTION
Avoids a potential crash if garbage collection happens in the middle of a call to NodeMap::request from a map that's eligible for GC.
Fixes issue #11281

I tried to do a scan of other `NodeMap` methods to find others susceptible to the same problem, and I also tried to audit the returned `NodeAsyncRequest` to make sure it never executed invalid code -- but it would be nice to have other eyes on that.

I tested the change with my local reproduction case which depended on inserting a delay into the response to the `render reports an error when the request function responds with an error` test and then doing 5000 v8 heap allocations at the beginning of `NodeMap::request`. I was also using node 4 since that's what failed on the server originally. One concern is that the repro case was not 100% effective (although it reproduced most of the time), and also it was very sensitive to small changes (e.g. _increasing_ the number of heap allocations to 10k made it stop reproducing).

/cc @jfirebaugh @kkaefer @springmeyer 