### PR TITLE
[qt] Fix wrong signal being emitted

### DIFF
--- a/platform/qt/src/qmapboxgl_map_observer.cpp
+++ b/platform/qt/src/qmapboxgl_map_observer.cpp
@@ -65,7 +65,7 @@ void QMapboxGLMapObserver::onDidFinishRenderingFrame(mbgl::MapObserver::RenderMo
 
 void QMapboxGLMapObserver::onWillStartRenderingMap()
 {
-    emit mapChanged(QMapboxGL::MapChangeWillStartLoadingMap);
+    emit mapChanged(QMapboxGL::MapChangeWillStartRenderingMap);
 }
 
 void QMapboxGLMapObserver::onDidFinishRenderingMap(mbgl::MapObserver::RenderMode mode)


### PR DESCRIPTION
Probably caused by a typo when refactoring the asynchronous rendering.