### PR TITLE
[core] Add space in OfflineDatabase::updateMetadata SQL query

### DIFF
--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -593,7 +593,7 @@ OfflineRegion OfflineDatabase::createRegion(const OfflineRegionDefinition& defin
 OfflineRegionMetadata OfflineDatabase::updateMetadata(const int64_t regionID, const OfflineRegionMetadata& metadata) {
     // clang-format off
     Statement stmt = getStatement(
-                                  "UPDATE regions SET description = ?1"
+                                  "UPDATE regions SET description = ?1 "
                                   "WHERE id = ?2");
     // clang-format on
     stmt->bindBlob(1, metadata);


### PR DESCRIPTION
Adds a space between `?1` and `WHERE` in the SQL query from `OfflineDatabase::updateMetadata`. Qt's SQLite driver is unable to parse it properly, bailing out instead:
> near "id": syntax error Unable to execute statement

Fixes #11295.