### PR TITLE
[qt] Rename Qt SDK to 'Mapbox Maps SDK for Qt'

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,7 +47,7 @@ See the relevant SDK documentation for next steps:
 * [Maps SDK for Android](platform/android/)
 * [Maps SDK for iOS](platform/ios/)
 * [Maps SDK for macOS](platform/macos/)
-* [Mapbox Qt SDK](platform/qt/)
+* [Maps SDK for Qt](platform/qt/)
 * [Mapbox GL Native on Linux](platform/linux/)
 * [node-mapbox-gl-native](platform/node/)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository hosts the cross-platform Mapbox GL Native library, plus convenie
 | [Mapbox Maps SDK for iOS](platform/ios/)         | Objective-C or Swift               | [![Bitrise](https://www.bitrise.io/app/7514e4cf3da2cc57.svg?token=OwqZE5rSBR9MVWNr_lf4sA&branch=master)](https://www.bitrise.io/app/7514e4cf3da2cc57) |
 | [Mapbox Maps SDK for macOS](platform/macos/)     | Objective-C, Swift, or AppleScript | [![Bitrise](https://www.bitrise.io/app/155ef7da24b38dcd.svg?token=4KSOw_gd6WxTnvGE2rMttg&branch=master)](https://www.bitrise.io/app/155ef7da24b38dcd) |
 | [node-mapbox-gl-native](platform/node/) | Node.js                            | [![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native/tree/master) |
-| [Mapbox Qt SDK](platform/qt)            | C++03                              | [![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native/tree/master) [![AppVeyor CI build status](https://ci.appveyor.com/api/projects/status/3q12kbcooc6df8uc?svg=true)](https://ci.appveyor.com/project/Mapbox/mapbox-gl-native) |
+| [Mapbox Maps SDK for Qt](platform/qt)            | C++03                              | [![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native/tree/master) [![AppVeyor CI build status](https://ci.appveyor.com/api/projects/status/3q12kbcooc6df8uc?svg=true)](https://ci.appveyor.com/project/Mapbox/mapbox-gl-native) |
 
 Additional Mapbox GL Native–based libraries for **hybrid applications** are developed outside of this repository:
 

--- a/platform/qt/README.md
+++ b/platform/qt/README.md
@@ -1,4 +1,4 @@
-# Mapbox Qt SDK
+# Mapbox Maps SDK for Qt
 
 [![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native/tree/master) [![AppVeyor CI build status](https://ci.appveyor.com/api/projects/status/3q12kbcooc6df8uc?svg=true)](https://ci.appveyor.com/project/Mapbox/mapbox-gl-native)
 
@@ -9,7 +9,7 @@ available in the Qt SDK since Qt 5.9. Use the [Qt bugtracker](https://bugreports
 to the plugin and this GitHub repository for bugs related to Mapbox GL Native and the Qt bindings.
 
 You should build this repository if you want to develop/contribute using the low level Qt C++ bindings or
-want to contribute to the Mapbox GL Native projectusing the Qt port for debugging.
+want to contribute to the Mapbox GL Native project using the Qt port for debugging.
 
 See the Mapbox Qt landing page for more details: https://www.mapbox.com/qt/
 

--- a/platform/qt/config.qdocconf
+++ b/platform/qt/config.qdocconf
@@ -7,7 +7,7 @@ include($QT_INSTALL_DOCS/global/qt-html-templates-online.qdocconf)
 Cpp.ignoretokens = Q_MAPBOXGL_EXPORT
 
 project     = QMapboxGL
-description = Mapbox Qt SDK
+description = Mapbox Maps SDK for Qt
 language    = Cpp
 
 outputdir   = docs

--- a/platform/qt/src/qmapbox.cpp
+++ b/platform/qt/src/qmapbox.cpp
@@ -24,7 +24,7 @@ namespace QMapbox {
 
 /*!
     \namespace QMapbox
-    \inmodule Mapbox Qt SDK
+    \inmodule Mapbox Maps SDK for Qt
 
     Contains miscellaneous Mapbox bindings used throughout QMapboxGL.
 */
@@ -74,7 +74,7 @@ namespace QMapbox {
 /*!
     \class QMapbox::Feature
 
-    \inmodule Mapbox Qt SDK
+    \inmodule Mapbox Maps SDK for Qt
 
     Represents \l {https://www.mapbox.com/help/define-features/}{map features}
     via its \a type (PointType, LineStringType or PolygonType), \a geometry, \a
@@ -94,7 +94,7 @@ namespace QMapbox {
 /*!
     \class QMapbox::ShapeAnnotationGeometry
 
-    \inmodule Mapbox Qt SDK
+    \inmodule Mapbox Maps SDK for Qt
 
     Represents a shape annotation geometry.
 */
@@ -113,7 +113,7 @@ namespace QMapbox {
 /*!
     \class QMapbox::SymbolAnnotation
 
-    \inmodule Mapbox Qt SDK
+    \inmodule Mapbox Maps SDK for Qt
 
     A symbol annotation comprises of its geometry and an icon identifier.
 */
@@ -121,7 +121,7 @@ namespace QMapbox {
 /*!
     \class QMapbox::LineAnnotation
 
-    \inmodule Mapbox Qt SDK
+    \inmodule Mapbox Maps SDK for Qt
 
     Represents a line annotation object, along with its properties.
 
@@ -131,7 +131,7 @@ namespace QMapbox {
 /*!
     \class QMapbox::FillAnnotation
 
-    \inmodule Mapbox Qt SDK
+    \inmodule Mapbox Maps SDK for Qt
 
     Represents a fill annotation object, along with its properties.
 
@@ -195,7 +195,7 @@ namespace QMapbox {
 
 /*!
     \class QMapbox::CustomLayerRenderParameters
-    \inmodule Mapbox Qt SDK
+    \inmodule Mapbox Maps SDK for Qt
 
     QMapbox::CustomLayerRenderParameters provides the data passed on each render
     pass for a custom layer.

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -136,7 +136,7 @@ std::unique_ptr<mbgl::style::Image> toStyleImage(const QString &id, const QImage
     \class QMapboxGLSettings
     \brief The QMapboxGLSettings class stores the initial configuration for QMapboxGL.
 
-    \inmodule Mapbox Qt SDK
+    \inmodule Mapbox Maps SDK for Qt
 
     QMapboxGLSettings is used to configure QMapboxGL at the moment of its creation.
     Once created, the QMapboxGLSettings of a QMapboxGL can no longer be changed.
@@ -454,7 +454,7 @@ void QMapboxGLSettings::setResourceTransform(const std::function<std::string(con
     \class QMapboxGL
     \brief The QMapboxGL class is a Qt wrapper for the Mapbox GL Native engine.
 
-    \inmodule Mapbox Qt SDK
+    \inmodule Mapbox Maps SDK for Qt
 
     QMapboxGL is a Qt friendly version the Mapbox GL Native engine using Qt types
     and deep integration with Qt event loop. QMapboxGL relies as much as possible


### PR DESCRIPTION
Rename Mapbox Qt SDK to **Mapbox Maps SDK for Qt**.