### PR TITLE
[node] Added Nan::AsyncResource in NodeMap::renderFinished

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "nan": "~2.8",
+    "nan": "^2.9.2",
     "node-pre-gyp": "^0.6.37",
     "npm-run-all": "^4.0.2"
   },

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -464,6 +464,8 @@ void NodeMap::renderFinished() {
     assert(!callback);
     assert(!image.data);
 
+    Nan::AsyncResource resource("mbgl:NodeMap.renderFinished", handle());
+
     if (error) {
         std::string errorMessage;
 
@@ -481,7 +483,7 @@ void NodeMap::renderFinished() {
         error = nullptr;
         assert(!error);
 
-        cb->Call(1, argv);
+        cb->Call(1, argv, &resource);
     } else if (img.data) {
         v8::Local<v8::Object> pixels = Nan::NewBuffer(
             reinterpret_cast<char *>(img.data.get()), img.bytes(),
@@ -497,12 +499,12 @@ void NodeMap::renderFinished() {
             Nan::Null(),
             pixels
         };
-        cb->Call(2, argv);
+        cb->Call(2, argv, &resource);
     } else {
         v8::Local<v8::Value> argv[] = {
             Nan::Error("Didn't get an image")
         };
-        cb->Call(1, argv);
+        cb->Call(1, argv, &resource);
     }
 }
 
@@ -1152,7 +1154,7 @@ NodeMap::~NodeMap() {
     if (map) release();
 }
 
-std::unique_ptr<mbgl::AsyncRequest> NodeMap::request(const mbgl::Resource& resource, mbgl::FileSource::Callback callback_) {
+std::unique_ptr<mbgl::AsyncRequest> NodeMap::request(const mbgl::Resource& resource, mbgl::FileSource::Callback fileSourceCallback) {
     Nan::HandleScope scope;
     // Because this method may be called while this NodeMap is already eligible for garbage collection,
     // we need to explicitly hold onto our own handle here so that GC during a v8 call doesn't destroy
@@ -1161,7 +1163,7 @@ std::unique_ptr<mbgl::AsyncRequest> NodeMap::request(const mbgl::Resource& resou
 
     v8::Local<v8::Value> argv[] = {
         Nan::New<v8::External>(this),
-        Nan::New<v8::External>(&callback_)
+        Nan::New<v8::External>(&fileSourceCallback)
     };
 
     auto instance = Nan::New(NodeRequest::constructor)->NewInstance(2, argv);


### PR DESCRIPTION
Nan [recently deprecated](https://github.com/nodejs/nan/commit/6dd5fa690af61ca3523004b433304c581b3ea309) `Callback::Call` without a given asynchronous resource. All our node CI jobs are now failing with the given output:

```
.../node_map.cpp:484:13: error: 'Call' is deprecated [-Werror,-Wdeprecated-declarations]
        cb->Call(1, argv);
            ^
```

Fixes https://github.com/mapbox/mapbox-gl-native/issues/11288.