### PR TITLE
cmake fixes + tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ if(WITH_COVERAGE)
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
 endif(WITH_COVERAGE)
 
-set(CMAKE_CONFIGURATION_TYPES Debug Release RelWithDebugInfo Sanitize)
+set(CMAKE_CONFIGURATION_TYPES Debug Release RelWithDebInfo Sanitize)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -ftemplate-depth=1024 -fPIC -fvisibility=hidden -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Werror -Wno-variadic-macros -Wno-unknown-pragmas")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -fvisibility=hidden -Wall -Wextra -Wshadow -Werror -Wno-variadic-macros -Wno-unknown-pragmas")
@@ -84,13 +84,15 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Os -DNDEBUG")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O3 -DNDEBUG")
 set(CMAKE_CXX_FLAGS_SANITIZE "${CMAKE_CXX_FLAGS_SANITIZE} -O1 -g -fno-omit-frame-pointer -fno-optimize-sibling-calls")
 
-
 if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=unknown-warning-option")
 elseif(CMAKE_COMPILER_IS_GNUCXX)
     # https://svn.boost.org/trac/boost/ticket/9240
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fext-numeric-literals")
 endif()
+
+set(CMAKE_SHARED_LINKER_FLAGS_SANITIZE "${CMAKE_SHARED_LINKER_FLAGS}")
+set(CMAKE_EXE_LINKER_FLAGS_SANITIZE "${CMAKE_EXE_LINKER_FLAGS}")
 
 # Technique from https://crascit.com/2016/04/09/using-ccache-with-cmake/
 find_program(CCACHE_PROGRAM ccache)

--- a/cmake/mason.cmake
+++ b/cmake/mason.cmake
@@ -90,17 +90,15 @@ function(mason_use _PACKAGE)
                 set(_URL "${MASON_REPOSITORY}/${_SLUG}.tar.gz")
                 message("[Mason] Downloading package ${_URL}...")
 
-                set(_FAILED)
-                set(_ERROR)
-                # Note: some CMake versions are compiled without SSL support
+                set(_STATUS)
                 get_filename_component(_CACHE_DIR "${_CACHE_PATH}" DIRECTORY)
                 file(MAKE_DIRECTORY "${_CACHE_DIR}")
-                execute_process(
-                    COMMAND curl --retry 3 -s -f -S -L "${_URL}" -o "${_CACHE_PATH}.tmp"
-                    RESULT_VARIABLE _FAILED
-                    ERROR_VARIABLE _ERROR)
-                if(_FAILED)
-                    message(FATAL_ERROR "[Mason] Failed to download ${_URL}: ${_ERROR}")
+                file(DOWNLOAD "${_URL}" "${_CACHE_PATH}.tmp" STATUS _STATUS)
+                
+                list(GET _STATUS 0 _STATUS_CODE)
+                list(GET _STATUS 1 _STATUS_STRING)
+                if(NOT _STATUS_CODE EQUAL 0)
+                    message(FATAL_ERROR "[Mason] Failed to download ${_URL}: ${_STATUS_STRING}")
                 else()
                     # We downloaded to a temporary file to prevent half-finished downloads
                     file(RENAME "${_CACHE_PATH}.tmp" "${_CACHE_PATH}")


### PR DESCRIPTION
- fixed typo in list of configuration types; RelWithDebugInfo should be RelWithDebInfo
- added missing linker flags for Sanitize configuration type
- changed mason's download to use cmake's built-in support instead of directly calling curl; curl isn't available by default on Windows