### PR TITLE
Cherry pick CI fixes from boba to master

### DIFF
--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -1154,6 +1154,10 @@ NodeMap::~NodeMap() {
 
 std::unique_ptr<mbgl::AsyncRequest> NodeMap::request(const mbgl::Resource& resource, mbgl::FileSource::Callback callback_) {
     Nan::HandleScope scope;
+    // Because this method may be called while this NodeMap is already eligible for garbage collection,
+    // we need to explicitly hold onto our own handle here so that GC during a v8 call doesn't destroy
+    // *this while we're still executing code.
+    handle();
 
     v8::Local<v8::Value> argv[] = {
         Nan::New<v8::External>(this),

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -67,7 +67,7 @@ void RenderHeatmapLayer::render(PaintParameters& parameters, RenderSource*) {
                 }
             }
 
-            if (!renderTexture) {
+            if (!parameters.context.supportsHalfFloatTextures || !renderTexture) {
                 renderTexture = OffscreenTexture(parameters.context, size, gl::TextureType::UnsignedByte);
                 renderTexture->bind();
             }


### PR DESCRIPTION
Get fixes to #11281 and #11228 onto `master` early so we stop getting CI failures.

/cc @brunoabinader @jfirebaugh 