### PR TITLE
[core,node] Pin 'nan' to ~2.8 to avoid Callback::Call deprecation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "nan": "^2.6.2",
+    "nan": "~2.8",
     "node-pre-gyp": "^0.6.37",
     "npm-run-all": "^4.0.2"
   },


### PR DESCRIPTION
CP master->boba

Alternative fix to #11288, until we figure out a proper async_hooks implementation.

/cc @brunoabinader @jfirebaugh 