### PR TITLE
[ios] Improved heading indicator arrow visibility

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## 3.7.6
+
+* Improved the visibility of the heading indicator arrow. ([#11337](https://github.com/mapbox/mapbox-gl-native/pull/11337))
+
 ## 3.7.5 - February 16, 2018
 
 * Fixed an issue where requesting location services permission would trigger an unrecoverable loop. ([#11229](https://github.com/mapbox/mapbox-gl-native/pull/11229))

--- a/platform/ios/src/MGLUserLocationHeadingArrowLayer.m
+++ b/platform/ios/src/MGLUserLocationHeadingArrowLayer.m
@@ -3,7 +3,7 @@
 #import "MGLFaux3DUserLocationAnnotationView.h"
 #import "MGLGeometry.h"
 
-const CGFloat MGLUserLocationHeadingArrowSize = 6;
+const CGFloat MGLUserLocationHeadingArrowSize = 8;
 
 @implementation MGLUserLocationHeadingArrowLayer
 


### PR DESCRIPTION
Fixes #10028. Made the heading indicator arrow 25% larger — this is a simple fix and is as large as the current implementation can go without obvious visual artifacts.

<img src=https://user-images.githubusercontent.com/1198851/36754682-bb127e9a-1bd7-11e8-91a5-c2d50ff804a3.png width=400>

/cc @fabian-guerra @julianrex 