### PR TITLE
Bumping new gestures library snaphost version

### DIFF
--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -10,7 +10,7 @@ ext {
     versions = [
             mapboxServices : '3.0.0-beta.2',
             mapboxTelemetry: '3.0.0-beta.1',
-            mapboxGestures : '0.1.0-20180227.133736-12',
+            mapboxGestures : '0.1.0-20180228.152340-13',
             supportLib     : '25.4.0',
             espresso       : '3.0.1',
             testRunner     : '1.0.1',


### PR DESCRIPTION
Bumping version to eliminate bug from https://github.com/mapbox/mapbox-gestures-android/issues/17.