### PR TITLE
Delete local ref pixel buffers when converting Image.java

### DIFF
--- a/platform/android/src/map/image.cpp
+++ b/platform/android/src/map/image.cpp
@@ -29,7 +29,7 @@ mbgl::style::Image Image::getImage(jni::JNIEnv& env, jni::Object<Image> image) {
     }
 
     jni::GetArrayRegion(env, *pixels, 0, size, reinterpret_cast<jbyte*>(premultipliedImage.data.get()));
-
+    jni::DeleteLocalRef(env, pixels);
     return mbgl::style::Image {name, std::move(premultipliedImage), pixelRatio};
 }
 


### PR DESCRIPTION
Capturing from @kkaefer that we were missing a DeleteLocalRef in our image conversion code.