### PR TITLE
Null java peer callback

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
@@ -37,11 +37,11 @@ public abstract class MapRenderer implements MapRendererScheduler {
   }
 
   public void onPause() {
-    // Implement if needed
+    nativeOnPause();
   }
 
   public void onResume() {
-    // Implement if needed
+    nativeOnResume();
   }
 
   public void onStop() {
@@ -123,6 +123,10 @@ public abstract class MapRenderer implements MapRendererScheduler {
   private native void nativeOnSurfaceChanged(int width, int height);
 
   private native void nativeRender();
+
+  private native void nativeOnResume();
+
+  private native void nativeOnPause();
 
   private long frames;
   private long timeElapsed;

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/imagegenerator/SnapshotActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/imagegenerator/SnapshotActivity.java
@@ -1,5 +1,6 @@
 package com.mapbox.mapboxsdk.testapp.activity.imagegenerator;
 
+import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.content.ContextCompat;
@@ -15,6 +16,8 @@ import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.testapp.R;
 
 import java.util.Locale;
+
+import timber.log.Timber;
 
 /**
  * Test activity showcasing the Snapshot API to create and display a bitmap of the current shown Map.
@@ -75,6 +78,12 @@ public class SnapshotActivity extends AppCompatActivity implements OnMapReadyCal
   @Override
   protected void onPause() {
     super.onPause();
+    mapboxMap.snapshot(new MapboxMap.SnapshotReadyCallback() {
+      @Override
+      public void onSnapshotReady(Bitmap snapshot) {
+        Timber.e("Regression test for https://github.com/mapbox/mapbox-gl-native/pull/11358");
+      }
+    });
     mapView.onPause();
   }
 

--- a/platform/android/src/map_renderer.cpp
+++ b/platform/android/src/map_renderer.cpp
@@ -136,7 +136,7 @@ void MapRenderer::render(JNIEnv&) {
     renderer->render(*params);
 
     // Deliver the snapshot if requested
-    if (snapshotCallback) {
+    if (snapshotCallback && !paused) {
         snapshotCallback->operator()(backend->readFramebuffer());
         snapshotCallback.reset();
     }
@@ -174,6 +174,14 @@ void MapRenderer::onSurfaceChanged(JNIEnv&, jint width, jint height) {
     requestRender();
 }
 
+void MapRenderer::onResume(JNIEnv&) {
+    paused = false;
+}
+
+void MapRenderer::onPause(JNIEnv&) {
+    paused = true;
+}
+
 // Static methods //
 
 jni::Class<MapRenderer> MapRenderer::javaClass;
@@ -192,7 +200,11 @@ void MapRenderer::registerNative(jni::JNIEnv& env) {
                                          METHOD(&MapRenderer::onSurfaceCreated,
                                                 "nativeOnSurfaceCreated"),
                                          METHOD(&MapRenderer::onSurfaceChanged,
-                                                "nativeOnSurfaceChanged"));
+                                                "nativeOnSurfaceChanged"),
+                                         METHOD(&MapRenderer::onResume,
+                                                "nativeOnResume"),
+                                         METHOD(&MapRenderer::onPause,
+                                                "nativeOnPause"));
 }
 
 MapRenderer& MapRenderer::getNativePeer(JNIEnv& env, jni::Object<MapRenderer> jObject) {

--- a/platform/android/src/map_renderer.hpp
+++ b/platform/android/src/map_renderer.hpp
@@ -98,6 +98,10 @@ private:
 
     void onSurfaceChanged(JNIEnv&, jint width, jint height);
 
+    void onResume(JNIEnv&);
+
+    void onPause(JNIEnv&);
+
 private:
     GenericUniqueWeakObject<MapRenderer> javaPeer;
 
@@ -120,6 +124,7 @@ private:
     std::mutex updateMutex;
 
     bool framebufferSizeChanged = false;
+    std::atomic<bool> paused {false};
 
     std::unique_ptr<SnapshotCallback> snapshotCallback;
 };

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -257,7 +257,6 @@ private:
     MapRenderer& mapRenderer;
 
     std::string styleUrl;
-    std::string apiKey;
 
     float pixelRatio;
 


### PR DESCRIPTION
This PR adds null checking to the java peer before calling into a NativeMapView callback. 
With the `Mapbox#snapshot` api I was able to reproduce:

> JNI DETECTED ERROR IN APPLICATION: can't call void com.mapbox.mapboxsdk.maps.NativeMapView.onSnapshotReady(android.graphics.Bitmap) on null object

When requesting a snapshot as part of Activity#onPause:

```java
  @Override
  protected void onPause() {
    super.onPause();
    mapboxMap.snapshot(new MapboxMap.SnapshotReadyCallback() {
      @Override
      public void onSnapshotReady(Bitmap snapshot) {
        Timber.e("snapshot ready");
      }
    });
    mapView.onPause();
  }
```

This could potentially explain crashes as https://github.com/mapbox/mapbox-gl-native/issues/11268.
