### PR TITLE
Validate width/height aren't 0 for snapshot

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
@@ -95,6 +95,9 @@ public class MapSnapshotter {
      * @param height the height of the image
      */
     public Options(int width, int height) {
+      if (width == 0 || height == 0) {
+        throw new IllegalArgumentException("Unable to create a snapshot with width or height set to 0");
+      }
       this.width = width;
       this.height = height;
     }


### PR DESCRIPTION
This PR replaces the native crash that occurs when creating a snapshot with width or height 0 with an IllegalArgumentException. 

cc @ivovandongen 