### PR TITLE
[ios] Fix annotation view not fully cleanup before enqueue

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -105,6 +105,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Added support selection of shape and polyline annotations.([#9984](https://github.com/mapbox/mapbox-gl-native/pull/9984))
 * Fixed an issue where view annotations could be slightly misaligned. View annotation placement is now rounded to the nearest pixel. ([#10219](https://github.com/mapbox/mapbox-gl-native/pull/10219))
 * Fixed an issue where a shape annotation callout was not displayed if the centroid was not visible. ([#10255](https://github.com/mapbox/mapbox-gl-native/pull/10255))
+* Fixed an issue may potentially caused `NSInvalidArgumentException`. ([#11366](https://github.com/mapbox/mapbox-gl-native/pull/11366))
 
 ### User interaction
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -5770,6 +5770,8 @@ public:
     if (annotationContext.viewReuseIdentifier)
     {
         annotationView.annotation = nil;
+        [annotationView removeFromSuperview];
+        [self.annotationContainerView.annotationViews removeObject:annotationView];
         NSMutableArray *annotationViewReuseQueue = [self annotationViewReuseQueueForIdentifier:annotationContext.viewReuseIdentifier];
         if (![annotationViewReuseQueue containsObject:annotationView])
         {


### PR DESCRIPTION
This method recycled the annotation view but don't remove it from superview and the array `annotationContainerView.annotationViews`. 
https://github.com/mapbox/mapbox-gl-native/blob/374bad18c04ae8fea574f85d2149af8aeffb8dcc/platform/ios/src/MGLMapView.mm#L5764-L5780
Following code may throw an `NSInvalidArgumentException ` exception. if the loop retrieved a annotation view which has been recycled.

https://github.com/mapbox/mapbox-gl-native/blob/374bad18c04ae8fea574f85d2149af8aeffb8dcc/platform/ios/src/MGLMapView.mm#L1649-L1662

