### PR TITLE
Use float for pixelratio when creating a snapshotter

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
@@ -82,7 +82,7 @@ public class MapSnapshotter {
    * MapSnapshotter options
    */
   public static class Options {
-    private int pixelRatio = 1;
+    private float pixelRatio = 1;
     private int width;
     private int height;
     private String styleUrl = Style.MAPBOX_STREETS;
@@ -122,7 +122,7 @@ public class MapSnapshotter {
      * @param pixelRatio the pixel ratio to use (default: 1)
      * @return the mutated {@link Options}
      */
-    public Options withPixelRatio(int pixelRatio) {
+    public Options withPixelRatio(float pixelRatio) {
       this.pixelRatio = pixelRatio;
       return this;
     }
@@ -164,7 +164,7 @@ public class MapSnapshotter {
     /**
      * @return the pixel ratio
      */
-    public int getPixelRatio() {
+    public float getPixelRatio() {
       return pixelRatio;
     }
 


### PR DESCRIPTION
When creating a Snapshotter through the options class, we were forcing the usage of int while the device destiny can be exposed as a decimal. This PR changes the pixelRatio to float in the options class (no other changes required as float was already used for the actual initialisation).

cc @ivovandongen 