### PR TITLE
[Qt] Expose mapLoadingFailed signal

### DIFF
--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -251,6 +251,7 @@ public slots:
 signals:
     void needsRendering();
     void mapChanged(QMapboxGL::MapChange);
+    void mapLoadingFailed(const QString &reason);
     void copyrightsChanged(const QString &copyrightsHtml);
 
     void staticRenderFinished(const QString &error);

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -128,6 +128,13 @@ public:
         MapChangeSourceDidChange
     };
 
+    enum MapLoadingFailure {
+        StyleParseFailure,
+        StyleLoadFailure,
+        NotFoundFailure,
+        UnknownFailure
+    };
+
     // Determines the orientation of the map.
     enum NorthOrientation {
         NorthUpwards, // Default
@@ -251,7 +258,7 @@ public slots:
 signals:
     void needsRendering();
     void mapChanged(QMapboxGL::MapChange);
-    void mapLoadingFailed(const QString &reason);
+    void mapLoadingFailed(QMapboxGL::MapLoadingFailure, const QString &reason);
     void copyrightsChanged(const QString &copyrightsHtml);
 
     void staticRenderFinished(const QString &error);
@@ -263,5 +270,6 @@ private:
 };
 
 Q_DECLARE_METATYPE(QMapboxGL::MapChange);
+Q_DECLARE_METATYPE(QMapboxGL::MapLoadingFailure);
 
 #endif // QMAPBOXGL_H

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1649,6 +1649,7 @@ QMapboxGLPrivate::QMapboxGLPrivate(QMapboxGL *q, const QMapboxGLSettings &settin
     qRegisterMetaType<QMapboxGL::MapChange>("QMapboxGL::MapChange");
 
     connect(m_mapObserver.get(), SIGNAL(mapChanged(QMapboxGL::MapChange)), q, SIGNAL(mapChanged(QMapboxGL::MapChange)));
+    connect(m_mapObserver.get(), SIGNAL(mapLoadingFailed(QString)), q, SIGNAL(mapLoadingFailed(QString)));
     connect(m_mapObserver.get(), SIGNAL(copyrightsChanged(QString)), q, SIGNAL(copyrightsChanged(QString)));
 
     // Setup the Map object

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -518,6 +518,19 @@ void QMapboxGLSettings::setResourceTransform(const std::function<std::string(con
 */
 
 /*!
+    \enum QMapboxGL::MapLoadingFailure
+
+    This enum represents map loading failure type.
+
+    \value StyleParseFailure                             Failure to parse the style.
+    \value StyleLoadFailure                              Failure to load the style data.
+    \value NotFoundFailure                               Failure to obtain style resource file.
+    \value UnknownFailure                                Unknown map loading failure.
+
+    \sa mapLoadingFailed()
+*/
+
+/*!
     \enum QMapboxGL::NorthOrientation
 
     This enum sets the orientation of the north bearing. It will directly affect bearing when
@@ -1613,6 +1626,13 @@ void QMapboxGL::connectionEstablished()
 */
 
 /*!
+    \fn void QMapboxGL::mapLoadingFailed(QMapboxGL::MapLoadingFailure type, const QString &description)
+
+    This signal is emitted when a map loading failure happens. Details of the
+    failures are provided, including its \a type and textual \a description.
+*/
+
+/*!
     \fn void QMapboxGL::copyrightsChanged(const QString &copyrightsHtml);
 
     This signal is emitted when the copyrights of the current content of the map
@@ -1649,7 +1669,7 @@ QMapboxGLPrivate::QMapboxGLPrivate(QMapboxGL *q, const QMapboxGLSettings &settin
     qRegisterMetaType<QMapboxGL::MapChange>("QMapboxGL::MapChange");
 
     connect(m_mapObserver.get(), SIGNAL(mapChanged(QMapboxGL::MapChange)), q, SIGNAL(mapChanged(QMapboxGL::MapChange)));
-    connect(m_mapObserver.get(), SIGNAL(mapLoadingFailed(QString)), q, SIGNAL(mapLoadingFailed(QString)));
+    connect(m_mapObserver.get(), SIGNAL(mapLoadingFailed(QMapboxGL::MapLoadingFailure,QString)), q, SIGNAL(mapLoadingFailed(QMapboxGL::MapLoadingFailure,QString)));
     connect(m_mapObserver.get(), SIGNAL(copyrightsChanged(QString)), q, SIGNAL(copyrightsChanged(QString)));
 
     // Setup the Map object

--- a/platform/qt/src/qmapboxgl_map_observer.cpp
+++ b/platform/qt/src/qmapboxgl_map_observer.cpp
@@ -2,6 +2,10 @@
 
 #include "qmapboxgl_p.hpp"
 
+#include <mbgl/util/string.hpp>
+
+#include <exception>
+
 QMapboxGLMapObserver::QMapboxGLMapObserver(QMapboxGLPrivate *d)
     : d_ptr(d)
 {
@@ -44,9 +48,10 @@ void QMapboxGLMapObserver::onDidFinishLoadingMap()
     emit mapChanged(QMapboxGL::MapChangeDidFinishLoadingMap);
 }
 
-void QMapboxGLMapObserver::onDidFailLoadingMap(std::exception_ptr)
+void QMapboxGLMapObserver::onDidFailLoadingMap(std::exception_ptr exception)
 {
     emit mapChanged(QMapboxGL::MapChangeDidFailLoadingMap);
+    emit mapLoadingFailed(QString::fromStdString(mbgl::util::toString(exception)));
 }
 
 void QMapboxGLMapObserver::onWillStartRenderingFrame()

--- a/platform/qt/src/qmapboxgl_map_observer.hpp
+++ b/platform/qt/src/qmapboxgl_map_observer.hpp
@@ -36,6 +36,7 @@ public:
 
 signals:
     void mapChanged(QMapboxGL::MapChange);
+    void mapLoadingFailed(const QString &reason);
     void copyrightsChanged(const QString &copyrightsHtml);
 
 private:

--- a/platform/qt/src/qmapboxgl_map_observer.hpp
+++ b/platform/qt/src/qmapboxgl_map_observer.hpp
@@ -36,7 +36,7 @@ public:
 
 signals:
     void mapChanged(QMapboxGL::MapChange);
-    void mapLoadingFailed(const QString &reason);
+    void mapLoadingFailed(QMapboxGL::MapLoadingFailure, const QString &reason);
     void copyrightsChanged(const QString &copyrightsHtml);
 
 private:


### PR DESCRIPTION
Expose `mapLoadingFailed` signal, forwarding the error reason from within the `std::exception_ptr` from MapObserver's `onDidFailLoadingMap`.