### PR TITLE
Update javadoc configuration

### DIFF
--- a/platform/android/gradle/gradle-javadoc.gradle
+++ b/platform/android/gradle/gradle-javadoc.gradle
@@ -1,21 +1,18 @@
 android.libraryVariants.all { variant ->
     def name = variant.name
-    // noinspection GroovyAssignabilityCheck
     task "javadoc$name"(type: Javadoc) {
         description = "Generates javadoc for build $name"
         failOnError = false
         destinationDir = new File(destinationDir, variant.baseName)
-        source = files(variant.javaCompile.source)
-        classpath = files(variant.javaCompile.classpath.files) + files(android.bootClasspath)
-        options.windowTitle("Mapbox Android SDK $VERSION_NAME Reference")
-        options.docTitle("Mapbox Android SDK $VERSION_NAME")
-        options.header("Mapbox Android SDK $VERSION_NAME Reference")
+        source = variant.javaCompile.source
+        options.windowTitle("Mapbox Maps SDK for Android $VERSION_NAME Reference")
+        options.docTitle("Mapbox Maps SDK for Android $VERSION_NAME")
+        options.header("Mapbox Maps SDK for Android $VERSION_NAME Reference")
         options.bottom("&copy; 2015&ndash;2018 Mapbox. All rights reserved.")
         options.links("http://docs.oracle.com/javase/7/docs/api/")
         options.linksOffline("http://d.android.com/reference/", "$System.env.ANDROID_HOME/docs/reference")
         options.overview("src/main/java/overview.html")
         options.group("Mapbox Android SDK", "com.mapbox.*")
-        options.group("Third Party Libraries", "com.almeros.*")
-        exclude '**/R.java', '**/BuildConfig.java', 'com/almeros/**'
+        exclude '**/R.java', '**/BuildConfig.java'
     }
 }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/11311

This PR updates our javadoc configuration to be compatible with newer gradle/AS versions. The reason why this broke was the usage of `files()` in our custom gradle javadoc task (see more information about this issue [here](https://issuetracker.google.com/issues/67482030)). Replacing our old config with `variant.javaCompile.source` resolves the issue:

<img width="299" alt="screen shot 2018-03-05 at 14 04 06" src="https://user-images.githubusercontent.com/2151639/36976777-16ba3e9e-207f-11e8-93e2-10f065cd09ec.png">


While at it, I also updated the title of the docs to reflect the `Mapbox Maps SDK for Android` naming convention + removed references to the almeros library. 

