### PR TITLE
Convert colors to sRGB for mbgl; fix title case unit tests

### DIFF
--- a/platform/darwin/src/MGLAttributionInfo.mm
+++ b/platform/darwin/src/MGLAttributionInfo.mm
@@ -49,7 +49,8 @@
         CGFloat blue;
         CGFloat alpha;
 #if !TARGET_OS_IPHONE
-        linkColor = [linkColor colorUsingColorSpaceName:NSCalibratedRGBColorSpace];
+        // CSS uses the sRGB color space.
+        linkColor = [linkColor colorUsingColorSpace:[NSColorSpace sRGBColorSpace]];
 #endif
         [linkColor getRed:&red green:&green blue:&blue alpha:&alpha];
         [css appendFormat:

--- a/platform/darwin/src/NSString+MGLAdditions.m
+++ b/platform/darwin/src/NSString+MGLAdditions.m
@@ -1,5 +1,9 @@
 #import "NSString+MGLAdditions.h"
 
+#if TARGET_OS_OSX
+    #import <Availability.h>
+#endif
+
 @implementation NSString (MGLAdditions)
 
 - (NSRange)mgl_wholeRange {
@@ -13,7 +17,7 @@
 - (NSString *)mgl_titleCasedStringWithLocale:(NSLocale *)locale {
     NSMutableString *string = self.mutableCopy;
     NSOrthography *orthography;
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 || __MAC_OS_X_VERSION_MAX_ALLOWED >= 101300
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability-new"
     if ([NSOrthography respondsToSelector:@selector(defaultOrthographyForLanguage:)]) {

--- a/platform/darwin/test/MGLSDKTestHelpers.swift
+++ b/platform/darwin/test/MGLSDKTestHelpers.swift
@@ -23,9 +23,9 @@ extension MGLSDKTestHelpers {
     class func protocolMethodDescriptions(_ p: Protocol) -> Set<String> {
         var methods = Set<String>()
         var methodCount = UInt32()
-        let methodDescriptionList: UnsafeMutablePointer<objc_method_description>! = protocol_copyMethodDescriptionList(p, false, true, &methodCount)
+        let methodDescriptionList = protocol_copyMethodDescriptionList(p, false, true, &methodCount)
         for i in 0..<Int(methodCount) {
-            let description: objc_method_description = methodDescriptionList[i]
+            let description = methodDescriptionList![i]
             XCTAssertNotNil(description.name?.description)
             methods.insert(description.name!.description)
         }
@@ -36,11 +36,16 @@ extension MGLSDKTestHelpers {
     class func classMethodDescriptions(_ cls: Swift.AnyClass) -> Set<String> {
         var methods = Set<String>()
         var methodCount = UInt32()
-        let methodList: UnsafeMutablePointer<Method?>! = class_copyMethodList(cls, &methodCount)
+        let methodList = class_copyMethodList(cls, &methodCount)
         for i in 0..<Int(methodCount) {
-            let method = methodList[i]
-            let selector : Selector = method_getName(method)
-            methods.insert(selector.description)
+            let method = methodList![i]
+            let selector = method_getName(method)
+            #if os(macOS)
+                methods.insert(selector.description)
+            #else
+                XCTAssertNotNil(selector)
+                methods.insert(selector!.description)
+            #endif
         }
         free(methodList)
         return methods

--- a/platform/darwin/test/MGLTileSetTests.mm
+++ b/platform/darwin/test/MGLTileSetTests.mm
@@ -82,7 +82,7 @@
 #else
     NSString *html = (@"<font face=\"Helvetica\" size=\"3\" style=\"font: 12.0px Helvetica\">"
                       @"<a href=\"https://www.mapbox.com/\">Mapbox</a> </font>"
-                      @"<font face=\"Helvetica\" size=\"3\" style=\"font: 12.0px Helvetica; background-color: #ff2600\">GL</font>\n");
+                      @"<font face=\"Helvetica\" size=\"3\" style=\"font: 12.0px Helvetica; background-color: #ff0000\">GL</font>\n");
 #endif
     XCTAssertEqualObjects(@(tileSet.attribution.c_str()), html);
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -8,7 +8,7 @@
 * The layout and paint properties on subclasses of `MGLStyleLayer` are now of type `NSExpression` instead of `MGLStyleValue`. A new “Predicates and Expressions” guide provides an overview of the supported operators. ([#10726](https://github.com/mapbox/mapbox-gl-native/pull/10726))
 * Added an `MGLComputedShapeSource` class that allows applications to supply vector data to a style layer on a per-tile basis. ([#9983](https://github.com/mapbox/mapbox-gl-native/pull/9983))
 * A style can now display smooth hillshading and customize its appearance at runtime using the `MGLHillshadeStyleLayer` class. Hillshading is based on a rasterized digital elevation model supplied by the `MGLRasterDEMSource` class. ([#10642](https://github.com/mapbox/mapbox-gl-native/pull/10642))
-* Fixed incorrect color calibration when using color-related methods of `MGLStyleLayer` subclasses. It is no longer necessary to explicitly convert an `NSColor` to the sRGB color space before using these classes. ([#11391](https://github.com/mapbox/mapbox-gl-native/pull/11391))
+* Fixed incorrect color calibration when using color-related methods of `MGLStyleLayer` subclasses, as well as when displaying an `MGLAttributionInfo`. It is no longer necessary to explicitly convert an `NSColor` to the sRGB color space before using these classes. ([#11391](https://github.com/mapbox/mapbox-gl-native/pull/11391))
 * The `MGLSymbolStyleLayer.textFontNames` property can now depend on a feature’s attributes. ([#10850](https://github.com/mapbox/mapbox-gl-native/pull/10850))
 * Properties such as `MGLSymbolStyleLayer.iconAllowsOverlap` and `MGLSymbolStyleLayer.iconIgnoresPlacement` now account for symbols in other sources. ([#10436](https://github.com/mapbox/mapbox-gl-native/pull/10436))
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## 0.7.0
 
-### Styles and rendering
+### Styles
 
 * Added support for a new layer type: `MGLHeatmapStyleLayer`, a powerful way to visualize point data distributions using heatmaps, fully customizable through runtime styling. [#11046](https://github.com/mapbox/mapbox-gl-native/pull/11046)
 * The layout and paint properties on subclasses of `MGLStyleLayer` are now of type `NSExpression` instead of `MGLStyleValue`. A new “Predicates and Expressions” guide provides an overview of the supported operators. ([#10726](https://github.com/mapbox/mapbox-gl-native/pull/10726))
 * Added an `MGLComputedShapeSource` class that allows applications to supply vector data to a style layer on a per-tile basis. ([#9983](https://github.com/mapbox/mapbox-gl-native/pull/9983))
 * A style can now display smooth hillshading and customize its appearance at runtime using the `MGLHillshadeStyleLayer` class. Hillshading is based on a rasterized digital elevation model supplied by the `MGLRasterDEMSource` class. ([#10642](https://github.com/mapbox/mapbox-gl-native/pull/10642))
+* Fixed incorrect color calibration when using color-related methods of `MGLStyleLayer` subclasses. It is no longer necessary to explicitly convert an `NSColor` to the sRGB color space before using these classes. ([#11391](https://github.com/mapbox/mapbox-gl-native/pull/11391))
 * The `MGLSymbolStyleLayer.textFontNames` property can now depend on a feature’s attributes. ([#10850](https://github.com/mapbox/mapbox-gl-native/pull/10850))
 * Properties such as `MGLSymbolStyleLayer.iconAllowsOverlap` and `MGLSymbolStyleLayer.iconIgnoresPlacement` now account for symbols in other sources. ([#10436](https://github.com/mapbox/mapbox-gl-native/pull/10436))
 

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -1378,7 +1378,7 @@
 				TargetAttributes = {
 					DA839E911CC2E3400062CAFB = {
 						CreatedOnToolsVersion = 7.3;
-						LastSwiftMigration = 0830;
+						LastSwiftMigration = 0920;
 					};
 					DAAA17961CE13BAE00731EFE = {
 						CreatedOnToolsVersion = 7.3.1;
@@ -1388,7 +1388,7 @@
 					};
 					DAE6C3301CC30DB200DB3429 = {
 						CreatedOnToolsVersion = 7.3;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0920;
 					};
 				};
 			};
@@ -1885,7 +1885,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGL;
 				PRODUCT_NAME = "Mapbox GL";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -1900,7 +1900,7 @@
 				OTHER_CFLAGS = "-fvisibility=hidden";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGL;
 				PRODUCT_NAME = "Mapbox GL";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -2026,7 +2026,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "../darwin/test/test-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -2053,7 +2053,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.test;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "../darwin/test/test-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/platform/macos/src/NSColor+MGLAdditions.mm
+++ b/platform/macos/src/NSColor+MGLAdditions.mm
@@ -6,14 +6,16 @@
 {
     CGFloat r, g, b, a;
 
-    [[self colorUsingColorSpaceName:NSCalibratedRGBColorSpace] getRed:&r green:&g blue:&b alpha:&a];
+    // The Mapbox Style Specification does not specify a color space, but it is
+    // assumed to be sRGB for consistency with CSS.
+    [[self colorUsingColorSpace:[NSColorSpace sRGBColorSpace]] getRed:&r green:&g blue:&b alpha:&a];
 
     return { (float)r, (float)g, (float)b, (float)a };
 }
 
 + (NSColor *)mgl_colorWithColor:(mbgl::Color)color
 {
-    return [NSColor colorWithCalibratedRed:color.r green:color.g blue:color.b alpha:color.a];
+    return [NSColor colorWithRed:color.r green:color.g blue:color.b alpha:color.a];
 }
 
 - (mbgl::style::PropertyValue<mbgl::Color>)mgl_colorPropertyValue


### PR DESCRIPTION
When converting an NSColor to `mbgl::Color`, automatically convert to the sRGB color space instead of the calibrated RGB color space. Colors set via the runtime styling API, as well as any colors displayed in the attribution buttons, should be more accurate now.

This PR fixes the macOS SDK’s unit tests so that they pass on macOS 10.13 High Sierra. The calibrated RGB color space differs between Sierra and High Sierra. In addition, a compile-time conditional compilation check added in #10224 has been refined to work on macOS, and the macOS targets have been upgraded to Swift 4 (a pro forma procedure).

Fixes #11289.

/cc @frederoni @friedbunny