### PR TITLE
[qt] Fix Qt build on MinGW

### DIFF
--- a/src/mbgl/util/compression.cpp
+++ b/src/mbgl/util/compression.cpp
@@ -1,6 +1,6 @@
 #include <mbgl/util/compression.hpp>
 
-#if defined(__QT__) && defined(_WINDOWS)
+#if defined(__QT__) && defined(_WINDOWS) && !defined(__GNUC__)
 #include <QtZlib/zlib.h>
 #else
 #include <zlib.h>


### PR DESCRIPTION
MinGW ships with zlib headers. No need to use the Qt built-in zlib.