### PR TITLE
Prevent render thread from waking up unneeded on still rendering

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -748,6 +748,11 @@ void Map::Impl::onInvalidate() {
 }
 
 void Map::Impl::onUpdate() {
+    // Don't load/render anything in still mode until explicitly requested.
+    if (mode != MapMode::Continuous && !stillImageRequest) {
+        return;
+    }
+    
     TimePoint timePoint = mode == MapMode::Continuous ? Clock::now() : Clock::time_point::max();
 
     transform.updateTransitions(timePoint);

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -85,11 +85,6 @@ void Renderer::Impl::setObserver(RendererObserver* observer_) {
 
 void Renderer::Impl::render(const UpdateParameters& updateParameters) {
     if (updateParameters.mode != MapMode::Continuous) {
-        // Don't load/render anyting in still mode until explicitly requested.
-        if (!updateParameters.stillImageRequest) {
-            return;
-        }
-
         // Reset zoom history state.
         zoomHistory.first = true;
     }


### PR DESCRIPTION
No longer sends a update message to the render frontend when rendering in still mode only to shortcut it in the renderer. This prevents unneeded render passes in qt.