### PR TITLE
Calculating camera's LatLng for bounds without map padding

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1550,19 +1550,8 @@ public final class MapboxMap {
    * @return the camera position that fits the bounds and padding
    */
   public CameraPosition getCameraForLatLngBounds(@Nullable LatLngBounds latLngBounds, int[] padding) {
-    // calculate and set additional bounds padding
-    int[] mapPadding = getPadding();
-    for (int i = 0; i < padding.length; i++) {
-      padding[i] = mapPadding[i] + padding[i];
-    }
-    projection.setContentPadding(padding);
-
     // get padded camera position from LatLngBounds
-    CameraPosition cameraPosition = nativeMapView.getCameraForLatLngBounds(latLngBounds);
-
-    // reset map padding
-    setPadding(mapPadding);
-    return cameraPosition;
+    return nativeMapView.getCameraForLatLngBounds(latLngBounds, padding);
   }
 
   /**
@@ -1574,19 +1563,8 @@ public final class MapboxMap {
    * @return the camera position that fits the bounds and padding
    */
   public CameraPosition getCameraForGeometry(Geometry geometry, double bearing, int[] padding) {
-    // calculate and set additional bounds padding
-    int[] mapPadding = getPadding();
-    for (int i = 0; i < padding.length; i++) {
-      padding[i] = mapPadding[i] + padding[i];
-    }
-    projection.setContentPadding(padding);
-
-    // get padded camera position from LatLngBounds
-    CameraPosition cameraPosition = nativeMapView.getCameraForGeometry(geometry, bearing);
-
-    // reset map padding
-    setPadding(mapPadding);
-    return cameraPosition;
+    // get padded camera position from Geometry
+    return nativeMapView.getCameraForGeometry(geometry, bearing, padding);
   }
 
   //

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -229,18 +229,28 @@ final class NativeMapView {
     return nativeGetLatLng().wrap();
   }
 
-  public CameraPosition getCameraForLatLngBounds(LatLngBounds latLngBounds) {
+  public CameraPosition getCameraForLatLngBounds(LatLngBounds latLngBounds, int[] padding) {
     if (isDestroyedOn("getCameraForLatLngBounds")) {
       return null;
     }
-    return nativeGetCameraForLatLngBounds(latLngBounds);
+    return nativeGetCameraForLatLngBounds(
+      latLngBounds,
+      padding[1] / pixelRatio,
+      padding[0] / pixelRatio,
+      padding[3] / pixelRatio,
+      padding[2] / pixelRatio);
   }
 
-  public CameraPosition getCameraForGeometry(Geometry geometry, double bearing) {
+  public CameraPosition getCameraForGeometry(Geometry geometry, double bearing, int[] padding) {
     if (isDestroyedOn("getCameraForGeometry")) {
       return null;
     }
-    return nativeGetCameraForGeometry(geometry, bearing);
+    return nativeGetCameraForGeometry(
+      geometry, bearing,
+      padding[1] / pixelRatio,
+      padding[0] / pixelRatio,
+      padding[3] / pixelRatio,
+      padding[2] / pixelRatio);
   }
 
   public void resetPosition() {
@@ -896,9 +906,11 @@ final class NativeMapView {
 
   private native LatLng nativeGetLatLng();
 
-  private native CameraPosition nativeGetCameraForLatLngBounds(LatLngBounds latLngBounds);
+  private native CameraPosition nativeGetCameraForLatLngBounds(
+    LatLngBounds latLngBounds, double top, double left, double bottom, double right);
 
-  private native CameraPosition nativeGetCameraForGeometry(Geometry geometry, double bearing);
+  private native CameraPosition nativeGetCameraForGeometry(
+    Geometry geometry, double bearing, double top, double left, double bottom, double right);
 
   private native void nativeResetPosition();
 

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -288,13 +288,15 @@ void NativeMapView::setLatLng(jni::JNIEnv&, jni::jdouble latitude, jni::jdouble 
     map->setLatLng(mbgl::LatLng(latitude, longitude), insets, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
 }
 
-jni::Object<CameraPosition> NativeMapView::getCameraForLatLngBounds(jni::JNIEnv& env, jni::Object<LatLngBounds> jBounds) {
-    return CameraPosition::New(env, map->cameraForLatLngBounds(mbgl::android::LatLngBounds::getLatLngBounds(env, jBounds), insets));
+jni::Object<CameraPosition> NativeMapView::getCameraForLatLngBounds(jni::JNIEnv& env, jni::Object<LatLngBounds> jBounds, double top, double left, double bottom, double right) {
+    mbgl::EdgeInsets padding = {top, left, bottom, right};
+    return CameraPosition::New(env, map->cameraForLatLngBounds(mbgl::android::LatLngBounds::getLatLngBounds(env, jBounds), padding));
 }
 
-jni::Object<CameraPosition> NativeMapView::getCameraForGeometry(jni::JNIEnv& env, jni::Object<geojson::Geometry> jGeometry, double bearing) {
+jni::Object<CameraPosition> NativeMapView::getCameraForGeometry(jni::JNIEnv& env, jni::Object<geojson::Geometry> jGeometry, double bearing, double top, double left, double bottom, double right) {
     auto geometry = geojson::Geometry::convert(env, jGeometry);
-    return CameraPosition::New(env, map->cameraForGeometry(geometry, insets, bearing));
+    mbgl::EdgeInsets padding = {top, left, bottom, right};
+    return CameraPosition::New(env, map->cameraForGeometry(geometry, padding, bearing));
 }
 
 void NativeMapView::setReachability(jni::JNIEnv&, jni::jboolean reachable) {

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -104,9 +104,9 @@ public:
 
     void setLatLng(jni::JNIEnv&, jni::jdouble, jni::jdouble, jni::jlong);
 
-    jni::Object<CameraPosition> getCameraForLatLngBounds(jni::JNIEnv&, jni::Object<mbgl::android::LatLngBounds>);
+    jni::Object<CameraPosition> getCameraForLatLngBounds(jni::JNIEnv&, jni::Object<mbgl::android::LatLngBounds>, double top, double left, double bottom, double right);
 
-    jni::Object<CameraPosition> getCameraForGeometry(jni::JNIEnv&, jni::Object<geojson::Geometry>, double bearing);
+    jni::Object<CameraPosition> getCameraForGeometry(jni::JNIEnv&, jni::Object<geojson::Geometry>, double bearing, double top, double left, double bottom, double right);
 
     void setReachability(jni::JNIEnv&, jni::jboolean);
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -446,7 +446,6 @@ CameraOptions Map::cameraForGeometry(const Geometry<double>& geometry, const Edg
         latLngs.push_back({ pt.y, pt.x });
     });
     return cameraForLatLngs(latLngs, padding, bearing);
-
 }
 
 LatLngBounds Map::latLngBoundsForCamera(const CameraOptions& camera) const {


### PR DESCRIPTION
When calculating camera's `LatLng` for bounds we were taking into account both map padding and additional bounds padding. Afterward, when moving the camera with any of `#easeTo`, `#jumpTo`, `#flyTo` we were applying map's padding once again resulting in the incorrect camera position.

The solution is to calculate initial `LatLng` of the new camera position with only additional padding, the one passed with bounds.

/cc @asheemmamoowala 