### PR TITLE
Building release version of Test App in CI workflow

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -389,6 +389,9 @@ jobs:
       - run:
           name: Build package
           command: make apackage
+      - run:
+          name: Build release Test App
+          command: make android
       - *show-ccache-stats
       - *save-cache
       - *save-gradle-cache

--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -39,7 +39,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }


### PR DESCRIPTION
We are constantly encountering issues with dependencies and some of them come in form of `proguard` throwing missing packages warnings when different versions of the same library, containing major differences which we depend on transitively, clash (ex. https://github.com/mapbox/mapbox-gl-native/issues/11417), resulting in users not being able to release their apps with `proguard` enabled.

To quickly catch those types of regressions we can schedule Test App's release build within CircleCI `android-release-all` job. Time-cost of this additional step is barely a couple of seconds.

If this PR is accepted we should hold off on merging until fix for https://github.com/mapbox/mapbox-gl-native/issues/11417 lands, otherwise, all builds will start to fail.

/cc @kkaefer