### PR TITLE
 [ios] Fix pinch drift ignoring delegate camera change response

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ## 3.7.6
 
+* Fixed an issue where the pinch gesture could drift beyond bounds imposed by `-[MGLMapViewDelegate mapView:shouldChangeFromCamera:toCamera:]`. ([#11423](https://github.com/mapbox/mapbox-gl-native/pull/11423))
 * Improved the visibility of the heading indicator arrow. ([#11337](https://github.com/mapbox/mapbox-gl-native/pull/11337))
 
 ## 3.7.5 - February 16, 2018

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1459,10 +1459,12 @@ public:
         double zoom = log2(newScale);
         MGLMapCamera *toCamera = [self cameraByZoomingToZoomLevel:zoom aroundAnchorPoint:centerPoint];
 
-        if ([self _shouldChangeFromCamera:oldCamera toCamera:toCamera])
+        if ( ! [self _shouldChangeFromCamera:oldCamera toCamera:toCamera])
         {
             drift = NO;
-        } else {
+        }
+        else
+        {
             if (drift)
             {
                 _mbglMap->setZoom(zoom, mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y }, MGLDurationFromTimeInterval(duration));
@@ -1695,7 +1697,9 @@ public:
              {
                  [weakSelf unrotateIfNeededForGesture];
              }];
-        } else {
+        }
+        else
+        {
             [self unrotateIfNeededForGesture];
         }
     }


### PR DESCRIPTION
Fixes #11422, where the pinch gesture could drift beyond the bounds imposed by `-[MGLMapViewDelegate mapView:shouldChangeFromCamera:toCamera:]`.

This doesn’t add a unit test, but does add a debug option to iosapp.

/cc @julianrex @fabian-guerra @lilykaiser 