### PR TITLE
[boba] Clamp TileJSON bounds

### DIFF
--- a/src/mbgl/style/conversion/tileset.cpp
+++ b/src/mbgl/style/conversion/tileset.cpp
@@ -103,6 +103,8 @@ optional<Tileset> Converter<Tileset>::operator()(const Convertible& value, Error
             error = { "bounds left longitude should be less than right longitude" };
             return {};
         }
+	*left = util::max(-180.0, *left);
+	*right = util::min(180.0, *right);
         result.bounds = LatLngBounds::hull({ *bottom, *left }, { *top, *right });
     }
 

--- a/test/style/conversion/tileset.test.cpp
+++ b/test/style/conversion/tileset.test.cpp
@@ -62,6 +62,16 @@ TEST(Tileset, ValidWorldBounds) {
     EXPECT_EQ(converted->bounds, LatLngBounds::hull({90, -180}, {-90, 180}));
 }
 
+TEST(Tileset, BoundsAreClamped) {
+    Error error;
+    mbgl::optional<Tileset> converted = convertJSON<Tileset>(R"JSON({
+        "tiles": ["http://mytiles"],
+        "bounds": [-181.0000005,-90,180.00000000000006,90]
+    })JSON", error);
+    EXPECT_TRUE((bool) converted);
+    EXPECT_EQ(converted->bounds, LatLngBounds::hull({90, -180}, {-90, 180}));
+}
+
 TEST(Tileset, FullConversion) {
     Error error;
     Tileset converted = *convertJSON<Tileset>(R"JSON({


### PR DESCRIPTION
Fixes #11411.

In mapbox-gl-js, TileJSON bounds longitudes are clamped to `[-180,180]`. Existing styles benefitted from this clamping when their bounds were outside this range.
(For example `[-179.9999893871037, -89.99993255000595, 180.00000000000006, 90]`)

In mapbox-gl-native, these longitude values are wrapped to:`[179.9999893871037, -179.99999999999994]`, resulting in bounds with a skinny horizontal extent.

Changed the TileJSON conversion to clamp the bounds, to provide results consistent with mapbox-gl-js.
