### PR TITLE
Revisit proguard configuration for release-boba

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/proguard-rules.pro
+++ b/platform/android/MapboxGLAndroidSDK/proguard-rules.pro
@@ -2,17 +2,38 @@
 # in ../sdk/tools/proguard/proguard-android.txt,
 # contents of this file will be appended into proguard-android.txt
 -keepattributes Signature, *Annotation*, EnclosingMethod
--keep class almeros.android.multitouch.gesturedetectors.** { *; }
+
+# config for the SDK
 -keep class com.mapbox.mapboxsdk.** { *; }
 -keep interface com.mapbox.mapboxsdk.** { *; }
--keep class com.mapbox.services.android.telemetry.** { *; }
--keep class com.mapbox.services.commons.** { *;}
--keep class com.google.gson.** { *; }
 
 # config for okhttp 3.8.0, https://github.com/square/okhttp/pull/3354
 -dontwarn okio.**
--dontwarn javax.annotation.Nullable
--dontwarn javax.annotation.ParametersAreNonnullByDefault
+-dontwarn javax.annotation.**
+-dontnote okhttp3.**
 
-# config for optional location provider https://github.com/mapbox/mapbox-gl-native/issues/10960
+# config for mapbox-android-telemetry:3.0.0-beta.1
+-dontwarn com.mapbox.android.core.location.MockLocationEngine
+-dontwarn com.mapbox.android.core.location.MockLocationEngine$LocationUpdateRunnable
+-dontwarn java.awt.Color
 -dontwarn com.mapzen.android.lost.api**
+
+# config for mapbox-sdk-geojson:3.0.0-beta.3
+-keep class com.mapbox.geojson.** { *; }
+-keep class com.google.gson.** { *; }
+-dontnote com.google.gson.internal.UnsafeAllocator
+
+# config for mapbox-android-gestures:0.0.1-20180228.152340-13
+-dontnote com.mapbox.android.gestures.*
+
+# config for additional warnings
+-keep class com.google.android.gms.dynamite.descriptors.com.google.android.gms.flags.ModuleDescriptor { java.lang.String MODULE_ID; }
+-keep class com.google.android.gms.dynamite.descriptors.com.google.android.gms.flags.ModuleDescriptor { int MODULE_VERSION; }
+-keep class com.google.android.gms.dynamite.DynamiteModule$DynamiteLoaderClassLoader { java.lang.ClassLoader sClassLoader; }
+-dontnote com.google.devtools.build.android.desugar.runtime.ThrowableExtension
+-dontnote org.robolectric.Robolectric
+-dontnote libcore.io.Memory
+-dontnote com.google.protobuf.ExtensionRegistry
+-dontnote com.google.protobuf.Extension
+-dontnote android.net.**
+-dontnote org.apache.http.**

--- a/platform/android/MapboxGLAndroidSDK/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/AndroidManifest.xml
@@ -1,20 +1,15 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          xmlns:tools="http://schemas.android.com/tools"
           package="com.mapbox.mapboxsdk">
 
-    <uses-feature android:glEsVersion="0x00020000" android:required="true" />
-    <uses-feature android:name="android.hardware.wifi" android:required="false" /> <!-- Implied by ACCESS_WIFI_STATE. -->
-    <uses-feature android:name="android.hardware.location.gps" android:required="false"/>
+    <uses-feature
+        android:glEsVersion="0x00020000"
+        android:required="true"/>
+    <uses-feature
+        android:name="android.hardware.wifi"
+        android:required="false"/> <!-- Implied by ACCESS_WIFI_STATE. -->
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
-
-    <uses-sdk tools:overrideLibrary="com.mapzen.lost"/>
-
-    <application>
-        <!-- Include the telemetry service to simplify set up (https://www.mapbox.com/telemetry) -->
-        <service android:name="com.mapbox.services.android.telemetry.service.TelemetryService"/>
-    </application>
 
 </manifest>


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/11417, we can revisit the config once telemetry has configured proguard on their end.  

cc @electrostat 