### PR TITLE
[ios, macos] Change the format for case expressions to a flat structure.

### DIFF
--- a/platform/darwin/src/NSExpression+MGLAdditions.mm
+++ b/platform/darwin/src/NSExpression+MGLAdditions.mm
@@ -690,7 +690,17 @@ NSArray *MGLSubexpressionsWithJSONObjects(NSArray *objects) {
         }
             
         case NSConditionalExpressionType: {
-            NSMutableArray *arguments = [NSMutableArray arrayWithObjects:self.predicate.mgl_jsonExpressionObject, self.trueExpression.mgl_jsonExpressionObject, nil];
+            NSMutableArray *arguments = [NSMutableArray arrayWithObjects:self.predicate.mgl_jsonExpressionObject, nil];
+            
+            if (self.trueExpression.expressionType == NSConditionalExpressionType) {
+                // Fold nested conditionals into a single case expression.
+                NSArray *trueArguments = self.trueExpression.mgl_jsonExpressionObject;
+                trueArguments = [trueArguments subarrayWithRange:NSMakeRange(1, trueArguments.count - 1)];
+                [arguments addObjectsFromArray:trueArguments];
+            } else {
+                [arguments addObject:self.trueExpression.mgl_jsonExpressionObject];
+            }
+            
             if (self.falseExpression.expressionType == NSConditionalExpressionType) {
                 // Fold nested conditionals into a single case expression.
                 NSArray *falseArguments = self.falseExpression.mgl_jsonExpressionObject;

--- a/platform/darwin/src/NSPredicate+MGLAdditions.h
+++ b/platform/darwin/src/NSPredicate+MGLAdditions.h
@@ -16,4 +16,6 @@
 
 @property (nonatomic, readonly) id mgl_jsonExpressionObject;
 
+- (id)mgl_case:(id)firstValue, ...;
+
 @end

--- a/platform/darwin/src/NSPredicate+MGLAdditions.mm
+++ b/platform/darwin/src/NSPredicate+MGLAdditions.mm
@@ -324,4 +324,29 @@ NSArray *MGLSubpredicatesWithJSONObjects(NSArray *objects) {
     return nil;
 }
 
+- (id)mgl_case:(id)firstValue, ... {
+
+    if ([self evaluateWithObject:nil]) {
+        return firstValue;
+    }
+    
+    id eachExpression;
+    va_list argumentList;
+    va_start(argumentList, firstValue);
+    
+    while ((eachExpression = va_arg(argumentList, id))) {
+        if ([eachExpression isKindOfClass:[NSComparisonPredicate class]]) {
+            id valueExpression = va_arg(argumentList, id);
+            if ([eachExpression evaluateWithObject:nil]) {
+                return valueExpression;
+            }
+        } else {
+            return eachExpression;
+        }
+    }
+    va_end(argumentList);
+    
+    return nil;
+}
+
 @end

--- a/platform/darwin/test/MGLExpressionTests.mm
+++ b/platform/darwin/test/MGLExpressionTests.mm
@@ -577,6 +577,10 @@ using namespace std::string_literals;
     // https://github.com/mapbox/mapbox-gl-native/issues/11007
     if (@available(iOS 9.0, *)) {
         {
+            
+            NSExpression *nested = [NSExpression expressionWithFormat:@"TERNARY( 1== 2, TERNARY(0==1, FALSE, TERNARY(4==5, FALSE, FALSE)), TERNARY(1==1, TRUE, FALSE))"];
+            NSLog(@"%@", nested.mgl_jsonExpressionObject);
+            
             NSPredicate *conditional = [NSPredicate predicateWithFormat:@"1 = 2"];
             NSExpression *trueExpression = [NSExpression expressionForConstantValue:@YES];
             NSExpression *falseExpression = [NSExpression expressionForConstantValue:@NO];

--- a/platform/darwin/test/MGLExpressionTests.mm
+++ b/platform/darwin/test/MGLExpressionTests.mm
@@ -577,10 +577,6 @@ using namespace std::string_literals;
     // https://github.com/mapbox/mapbox-gl-native/issues/11007
     if (@available(iOS 9.0, *)) {
         {
-            
-            NSExpression *nested = [NSExpression expressionWithFormat:@"TERNARY( 1== 2, TERNARY(0==1, FALSE, TERNARY(4==5, FALSE, FALSE)), TERNARY(1==1, TRUE, FALSE))"];
-            NSLog(@"%@", nested.mgl_jsonExpressionObject);
-            
             NSPredicate *conditional = [NSPredicate predicateWithFormat:@"1 = 2"];
             NSExpression *trueExpression = [NSExpression expressionForConstantValue:@YES];
             NSExpression *falseExpression = [NSExpression expressionForConstantValue:@NO];
@@ -597,6 +593,20 @@ using namespace std::string_literals;
             XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
             XCTAssertEqualObjects([expression expressionValueWithObject:nil context:nil], @NO);
             XCTAssertEqualObjects([NSExpression mgl_expressionWithJSONObject:jsonExpression], expression);
+        }
+        {
+            NSExpression *expression = [NSExpression expressionWithFormat:@"TERNARY(0 = 1, TERNARY(1 = 2, TRUE, FALSE), TRUE)"];
+            NSArray *jsonExpression = @[@"case", @[@"==", @0, @1], @[@"==", @1, @2], @YES, @NO, @YES];
+            XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
+            XCTAssertEqualObjects([expression expressionValueWithObject:nil context:nil], @YES);
+            XCTAssertEqualObjects([NSExpression mgl_expressionWithJSONObject:jsonExpression], expression);
+        }
+        {
+            NSExpression *nestedExpression = [NSExpression expressionWithFormat:@"TERNARY(1 == 2, TERNARY(0 == 1, FALSE, TERNARY(4 == 5, FALSE, FALSE)), TERNARY(1 == 1, TRUE, FALSE))"];
+            NSArray *nestedJSONExpression = @[@"case", @[@"==", @1, @2], @[@"==", @0, @1], @NO,  @[@"==", @4, @5], @NO, @NO,  @[@"==", @1, @1], @YES, @NO];
+            XCTAssertEqualObjects(nestedExpression.mgl_jsonExpressionObject, nestedJSONExpression);
+            XCTAssertEqualObjects([nestedExpression expressionValueWithObject:nil context:nil], @YES);
+            XCTAssertEqualObjects([NSExpression mgl_expressionWithJSONObject:nestedJSONExpression], nestedExpression);
         }
     }
 }

--- a/platform/darwin/test/MGLExpressionTests.mm
+++ b/platform/darwin/test/MGLExpressionTests.mm
@@ -573,42 +573,29 @@ using namespace std::string_literals;
 }
 
 - (void)testConditionalExpressionObject {
-    // FIXME: This test crashes because iOS 8 doesn't have `+[NSExpression expressionForConditional:trueExpression:falseExpression:]`.
-    // https://github.com/mapbox/mapbox-gl-native/issues/11007
-    if (@available(iOS 9.0, *)) {
-        {
-            NSPredicate *conditional = [NSPredicate predicateWithFormat:@"1 = 2"];
-            NSExpression *trueExpression = [NSExpression expressionForConstantValue:@YES];
-            NSExpression *falseExpression = [NSExpression expressionForConstantValue:@NO];
-            NSExpression *expression = [NSExpression expressionForConditional:conditional trueExpression:trueExpression falseExpression:falseExpression];
-            NSArray *jsonExpression = @[@"case", @[@"==", @1, @2], @YES, @NO];
-            XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
-            XCTAssertEqualObjects([NSExpression expressionWithFormat:@"TERNARY(1 = 2, TRUE, FALSE)"].mgl_jsonExpressionObject, jsonExpression);
-            XCTAssertEqualObjects([expression expressionValueWithObject:nil context:nil], @NO);
-            XCTAssertEqualObjects([NSExpression mgl_expressionWithJSONObject:jsonExpression], expression);
-        }
-        {
-            NSExpression *expression = [NSExpression expressionWithFormat:@"TERNARY(0 = 1, TRUE, TERNARY(1 = 2, TRUE, FALSE))"];
-            NSArray *jsonExpression = @[@"case", @[@"==", @0, @1], @YES, @[@"==", @1, @2], @YES, @NO];
-            XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
-            XCTAssertEqualObjects([expression expressionValueWithObject:nil context:nil], @NO);
-            XCTAssertEqualObjects([NSExpression mgl_expressionWithJSONObject:jsonExpression], expression);
-        }
-        {
-            NSExpression *expression = [NSExpression expressionWithFormat:@"TERNARY(0 = 1, TERNARY(1 = 2, TRUE, FALSE), TRUE)"];
-            NSArray *jsonExpression = @[@"case", @[@"==", @0, @1], @[@"==", @1, @2], @YES, @NO, @YES];
-            XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
-            XCTAssertEqualObjects([expression expressionValueWithObject:nil context:nil], @YES);
-            XCTAssertEqualObjects([NSExpression mgl_expressionWithJSONObject:jsonExpression], expression);
-        }
-        {
-            NSExpression *nestedExpression = [NSExpression expressionWithFormat:@"TERNARY(1 == 2, TERNARY(0 == 1, FALSE, TERNARY(4 == 5, FALSE, FALSE)), TERNARY(1 == 1, TRUE, FALSE))"];
-            NSArray *nestedJSONExpression = @[@"case", @[@"==", @1, @2], @[@"==", @0, @1], @NO,  @[@"==", @4, @5], @NO, @NO,  @[@"==", @1, @1], @YES, @NO];
-            XCTAssertEqualObjects(nestedExpression.mgl_jsonExpressionObject, nestedJSONExpression);
-            XCTAssertEqualObjects([nestedExpression expressionValueWithObject:nil context:nil], @YES);
-            XCTAssertEqualObjects([NSExpression mgl_expressionWithJSONObject:nestedJSONExpression], nestedExpression);
-        }
+    {
+        NSExpression *expression = [NSExpression expressionWithFormat:@"FUNCTION(%@, 'mgl_case:', %@, %@)",
+                                    [NSExpression expressionWithFormat:@"%@", [NSPredicate predicateWithFormat:@"1 = 2"]],
+                                                                                                 MGLConstantExpression(@YES),
+                                                                                                 MGLConstantExpression(@NO)];
+        NSArray *jsonExpression = @[@"case", @[@"==", @1, @2], @YES, @NO];
+        XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
+        XCTAssertEqualObjects([NSExpression mgl_expressionWithJSONObject:jsonExpression], expression);
+        XCTAssertEqualObjects([expression expressionValueWithObject:nil context:nil], @NO);
     }
+    {
+        NSExpression *expression = [NSExpression expressionWithFormat:@"FUNCTION(%@, 'mgl_case:', %@, %@, %@, %@)",
+                                    [NSExpression expressionWithFormat:@"%@", [NSPredicate predicateWithFormat:@"1 = 2"]],
+                                                                                                 MGLConstantExpression(@YES),
+                                                                                                 [NSExpression expressionWithFormat:@"%@", [NSPredicate predicateWithFormat:@"1 = 1"]],
+                                                                                                 MGLConstantExpression(@YES),
+                                                                                                 MGLConstantExpression(@NO)];
+        NSArray *jsonExpression = @[@"case", @[@"==", @1, @2], @YES, @[@"==", @1, @1], @YES, @NO];
+        XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
+        XCTAssertEqualObjects([NSExpression mgl_expressionWithJSONObject:jsonExpression], expression);
+        XCTAssertEqualObjects([expression expressionValueWithObject:nil context:nil], @YES);
+    }
+    
 }
 
 @end


### PR DESCRIPTION
Fixes #11007 

- [x] Add compact syntax.
- [x] Add multiple branch support.
- [x] Add tests.
- [x] Add iOS 8.x support.