### PR TITLE
[core] Stringify expression syntax, not function syntax

### DIFF
--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -1,4 +1,6 @@
 {
+  "query-tests/circle-pitch-scale/viewport-inside-align-map": "https://github.com/mapbox/mapbox-gl-native/issues/10615",
+  "query-tests/circle-pitch-scale/viewport-inside-align-viewport": "https://github.com/mapbox/mapbox-gl-native/issues/10615",
   "query-tests/geometry/multilinestring": "needs investigation",
   "query-tests/geometry/multipolygon": "needs investigation",
   "query-tests/geometry/polygon": "needs investigation",

--- a/src/mbgl/shaders/line_pattern.cpp
+++ b/src/mbgl/shaders/line_pattern.cpp
@@ -215,8 +215,14 @@ void main() {
 
     float x_a = mod(v_linesofar / u_pattern_size_a.x, 1.0);
     float x_b = mod(v_linesofar / u_pattern_size_b.x, 1.0);
-    float y_a = 0.5 + (v_normal.y * v_width2.s / u_pattern_size_a.y);
-    float y_b = 0.5 + (v_normal.y * v_width2.s / u_pattern_size_b.y);
+
+    // v_normal.y is 0 at the midpoint of the line, -1 at the lower edge, 1 at the upper edge
+    // we clamp the line width outset to be between 0 and half the pattern height plus padding (2.0)
+    // to ensure we don't sample outside the designated symbol on the sprite sheet.
+    // 0.5 is added to shift the component to be bounded between 0 and 1 for interpolation of
+    // the texture coordinate
+    float y_a = 0.5 + (v_normal.y * clamp(v_width2.s, 0.0, (u_pattern_size_a.y + 2.0) / 2.0) / u_pattern_size_a.y);
+    float y_b = 0.5 + (v_normal.y * clamp(v_width2.s, 0.0, (u_pattern_size_b.y + 2.0) / 2.0) / u_pattern_size_b.y);
     vec2 pos_a = mix(u_pattern_tl_a / u_texsize, u_pattern_br_a / u_texsize, vec2(x_a, y_a));
     vec2 pos_b = mix(u_pattern_tl_b / u_texsize, u_pattern_br_b / u_texsize, vec2(x_b, y_b));
 

--- a/src/mbgl/style/conversion/stringify.hpp
+++ b/src/mbgl/style/conversion/stringify.hpp
@@ -290,138 +290,19 @@ void stringify(Writer& writer, const Undefined&) {
     writer.Null();
 }
 
-template <class Writer>
-void stringify(Writer& writer, const CategoricalValue& v) {
-    CategoricalValue::visit(v, [&] (const auto& v_) { stringify(writer, v_); });
-}
-
-template <class Writer>
-class StringifyStops {
-public:
-    Writer& writer;
-
-    template <class T>
-    void operator()(const ExponentialStops<T>& f) {
-        writer.Key("type");
-        writer.String("exponential");
-        writer.Key("base");
-        writer.Double(f.base);
-        writer.Key("stops");
-        stringifyStops(f.stops);
-    }
-
-    template <class T>
-    void operator()(const IntervalStops<T>& f) {
-        writer.Key("type");
-        writer.String("interval");
-        writer.Key("stops");
-        stringifyStops(f.stops);
-    }
-
-    template <class T>
-    void operator()(const CategoricalStops<T>& f) {
-        writer.Key("type");
-        writer.String("categorical");
-        writer.Key("stops");
-        stringifyStops(f.stops);
-    }
-
-    template <class T>
-    void operator()(const IdentityStops<T>&) {
-        writer.Key("type");
-        writer.String("identity");
-    }
-
-    template <class T>
-    void operator()(const CompositeExponentialStops<T>& f) {
-        writer.Key("type");
-        writer.String("exponential");
-        writer.Key("base");
-        writer.Double(f.base);
-        writer.Key("stops");
-        stringifyCompositeStops(f.stops);
-    }
-
-    template <class T>
-    void operator()(const CompositeIntervalStops<T>& f) {
-        writer.Key("type");
-        writer.String("interval");
-        writer.Key("stops");
-        stringifyCompositeStops(f.stops);
-    }
-
-    template <class T>
-    void operator()(const CompositeCategoricalStops<T>& f) {
-        writer.Key("type");
-        writer.String("categorical");
-        writer.Key("stops");
-        stringifyCompositeStops(f.stops);
-    }
-
-private:
-    template <class K, class V>
-    void stringifyStops(const std::map<K, V>& stops) {
-        writer.StartArray();
-        for (const auto& stop : stops) {
-            writer.StartArray();
-            stringify(writer, stop.first);
-            stringify(writer, stop.second);
-            writer.EndArray();
-        }
-        writer.EndArray();
-    }
-
-    template <class InnerStops>
-    void stringifyCompositeStops(const std::map<float, InnerStops>& stops) {
-        writer.StartArray();
-        for (const auto& outer : stops) {
-            for (const auto& inner : outer.second) {
-                writer.StartArray();
-                writer.StartObject();
-                writer.Key("zoom");
-                writer.Double(outer.first);
-                writer.Key("value");
-                stringify(writer, inner.first);
-                writer.EndObject();
-                stringify(writer, inner.second);
-                writer.EndArray();
-            }
-        }
-        writer.EndArray();
-    }
-};
-
 template <class Writer, class T>
-void stringify(Writer& writer, const CameraFunction<T>& f) {
-    writer.StartObject();
-    CameraFunction<T>::Stops::visit(f.stops, StringifyStops<Writer> { writer });
-    writer.EndObject();
+void stringify(Writer& writer, const CameraFunction<T>& fn) {
+    stringify(writer, fn.getExpression().serialize());
 }
 
 template <class Writer, class T>
-void stringify(Writer& writer, const SourceFunction<T>& f) {
-    writer.StartObject();
-    writer.Key("property");
-    writer.String(f.property);
-    SourceFunction<T>::Stops::visit(f.stops, StringifyStops<Writer> { writer });
-    if (f.defaultValue) {
-        writer.Key("default");
-        stringify(writer, *f.defaultValue);
-    }
-    writer.EndObject();
+void stringify(Writer& writer, const SourceFunction<T>& fn) {
+    stringify(writer, fn.getExpression().serialize());
 }
 
 template <class Writer, class T>
-void stringify(Writer& writer, const CompositeFunction<T>& f) {
-    writer.StartObject();
-    writer.Key("property");
-    writer.String(f.property);
-    CompositeFunction<T>::Stops::visit(f.stops, StringifyStops<Writer> { writer });
-    if (f.defaultValue) {
-        writer.Key("default");
-        stringify(writer, *f.defaultValue);
-    }
-    writer.EndObject();
+void stringify(Writer& writer, const CompositeFunction<T>& fn) {
+    stringify(writer, fn.getExpression().serialize());
 }
 
 template <class Writer, class T>

--- a/test/style/conversion/stringify.test.cpp
+++ b/test/style/conversion/stringify.test.cpp
@@ -81,22 +81,22 @@ TEST(Stringify, Filter) {
 
 TEST(Stringify, CameraFunction) {
     ASSERT_EQ(stringify(CameraFunction<float>(ExponentialStops<float> { {{0, 1}}, 2 })),
-        "{\"type\":\"exponential\",\"base\":2.0,\"stops\":[[0.0,1.0]]}");
+        "[\"interpolate\",[\"exponential\",2.0],[\"zoom\"],0.0,1.0]");
     ASSERT_EQ(stringify(CameraFunction<float>(IntervalStops<float> { {{0, 1}} })),
-        "{\"type\":\"interval\",\"stops\":[[0.0,1.0]]}");
+        "[\"step\",[\"zoom\"],0.0,1.0]");
 }
 
 TEST(Stringify, SourceFunction) {
     ASSERT_EQ(stringify(SourceFunction<float>("property", ExponentialStops<float> { {{0, 1}}, 2 })),
-        "{\"property\":\"property\",\"type\":\"exponential\",\"base\":2.0,\"stops\":[[0.0,1.0]]}");
+        "[\"interpolate\",[\"exponential\",2.0],[\"number\",[\"get\",\"property\"]],0.0,1.0]");
     ASSERT_EQ(stringify(SourceFunction<float>("property", IntervalStops<float> { {{0, 1}} })),
-        "{\"property\":\"property\",\"type\":\"interval\",\"stops\":[[0.0,1.0]]}");
+        "[\"step\",[\"number\",[\"get\",\"property\"]],0.0,1.0]");
     ASSERT_EQ(stringify(SourceFunction<float>("property", CategoricalStops<float> { {{CategoricalValue(true), 1}} })),
-        "{\"property\":\"property\",\"type\":\"categorical\",\"stops\":[[true,1.0]]}");
+        "[\"case\",[\"boolean\",[\"get\",\"property\"]],1.0,[\"error\"]]");
     ASSERT_EQ(stringify(SourceFunction<float>("property", IdentityStops<float> {})),
-        "{\"property\":\"property\",\"type\":\"identity\"}");
+        "[\"number\",[\"get\",\"property\"]]");
     ASSERT_EQ(stringify(SourceFunction<float>("property", IdentityStops<float> {}, 0.0f)),
-        "{\"property\":\"property\",\"type\":\"identity\",\"default\":0.0}");
+        "[\"number\",[\"get\",\"property\"]]");
 }
 
 TEST(Stringify, CompositeFunction) {
@@ -108,16 +108,17 @@ TEST(Stringify, CompositeFunction) {
             },
             2
         }, 0.0f)),
-        "{\"property\":\"property\",\"type\":\"exponential\",\"base\":2.0,"
-        "\"stops\":["
-            "[{\"zoom\":0.0,\"value\":0.0},1.0],"
-            "[{\"zoom\":1.0,\"value\":0.0},1.0]],\"default\":0.0}");
+        "[\"interpolate\","
+            "[\"exponential\",1.0],"
+            "[\"zoom\"],"
+            "0.0,[\"interpolate\",[\"exponential\",2.0],[\"number\",[\"get\",\"property\"]],0.0,1.0],"
+            "1.0,[\"interpolate\",[\"exponential\",2.0],[\"number\",[\"get\",\"property\"]],0.0,1.0]]");
 }
 
 TEST(Stringify, PropertyValue) {
     ASSERT_EQ(stringify(PropertyValue<float>(1)), "1.0");
     ASSERT_EQ(stringify(PropertyValue<float>(CameraFunction<float>(ExponentialStops<float> { {{0, 1}}, 2 }))),
-        "{\"type\":\"exponential\",\"base\":2.0,\"stops\":[[0.0,1.0]]}");
+        "[\"interpolate\",[\"exponential\",2.0],[\"zoom\"],0.0,1.0]");
 }
 
 TEST(Stringify, Layout) {


### PR DESCRIPTION
Fixes #11451, while not attempting to handle the corner case where two layers are alike in all ref properties except for function `default`s.