### PR TITLE
Array expression literal

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
@@ -116,6 +116,16 @@ public class Expression {
   }
 
   /**
+   * Create a literal array expression
+   *
+   * @param array the array
+   * @return the expression
+   */
+  public static Expression literal(@NonNull Object[] array) {
+    return new ExpressionArray(array);
+  }
+
+  /**
    * Expression literal utility method to convert a color int to an color expression
    *
    * @param color the int color
@@ -1600,7 +1610,7 @@ public class Expression {
                                        @NonNull Expression number, Stop... stops) {
     return interpolate(interpolation, number, Stop.toExpressionArray(stops));
   }
-  
+
   /**
    * interpolates linearly between the pair of stops just less than and just greater than the input.
    *
@@ -2004,6 +2014,43 @@ public class Expression {
       } else {
         throw new RuntimeException("Unsupported literal expression conversion for " + jsonPrimitive.getClass());
       }
+    }
+  }
+
+  private static class ExpressionArray extends Expression {
+
+    private Object[] array;
+
+    ExpressionArray(Object[] array) {
+      this.array = array;
+    }
+
+    @NonNull
+    @Override
+    public Object[] toArray() {
+      return new Object[] {
+        "literal", array
+      };
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder builder = new StringBuilder("[\"literal\"], [");
+      Object argument;
+      for (int i = 0; i < array.length; i++) {
+        argument = array[i];
+        if (argument instanceof String) {
+          builder.append("\"").append(argument).append("\"");
+        } else {
+          builder.append(argument);
+        }
+
+        if (i != array.length - 1) {
+          builder.append(", ");
+        }
+      }
+      builder.append("]]");
+      return builder.toString();
     }
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.java
@@ -365,14 +365,14 @@ public class ExpressionTest {
 
   @Test
   public void testAt() throws Exception {
-    Object[] expected = new Object[] {"at", 3, new Object[] {"one", "two"}};
+    Object[] expected = new Object[] {"at", 3, new Object[] {"literal", new Object[] {"one", "two"}}};
     Object[] actual = at(literal(3), literal(new Object[] {"one", "two"})).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
 
   @Test
   public void testAtLiteral() throws Exception {
-    Object[] expected = new Object[] {"at", 3, new Object[] {"one", "two"}};
+    Object[] expected = new Object[] {"at", 3, new Object[] {"literal", new Object[] {"one", "two"}}};
     Object[] actual = at(3, literal(new Object[] {"one", "two"})).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
@@ -955,12 +955,13 @@ public class ExpressionTest {
 
   @Test
   public void testLinear() throws Exception {
-    Object[] stopZero = new Object[] {0, 1};
-    Object[] stopOne = new Object[] {1, 2};
-    Object[] stopTwo = new Object[] {2, 3};
-    Object[] expected = new Object[] {"interpolate", new Object[] {"linear"}, 12, stopZero, stopOne, stopTwo};
-    Object[] actual = interpolate(linear(), literal(12),
-      literal(stopZero), literal(stopOne), literal(stopTwo)).toArray();
+    Object[] expected = new Object[] {"interpolate", new Object[] {"linear"}, 12, 0, 1, 1, 2, 2, 3};
+    Object[] actual = interpolate(
+      linear(), literal(12),
+      literal(0), literal(1),
+      literal(1), literal(2),
+      literal(2), literal(3))
+      .toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
 
@@ -1063,5 +1064,21 @@ public class ExpressionTest {
     String actual = interpolate(cubicBezier(literal(1), literal(1), literal(1), literal(1)),
       get(literal("x")), literal(0), literal(100), literal(100), literal(200)).toString();
     assertEquals("toString should match", expected, actual);
+  }
+
+  @Test
+  public void testLiteralArray() throws Exception {
+    Object[] array = new Object[] {1, "text"};
+    Object[] expected = new Object[] {"literal", array};
+    Object[] actual = literal(array).toArray();
+    assertTrue("expression should match", Arrays.deepEquals(expected, actual));
+  }
+
+  @Test
+  public void testLiteralArrayString() throws Exception {
+    Object[] array = new Object[] {1, "text"};
+    String expected = "[\"literal\"], [1, \"text\"]]";
+    String actual = literal(array).toString();
+    assertEquals("literal array should match", expected, actual);
   }
 }


### PR DESCRIPTION
Closes #11421, this PR adds correct integration for `literal(Object[])`:

Not commited but a small end-to-end test with:

```
  Object[] objectArray = new Object[]{1, "hello"};
  Expression textFieldExpression =  Expression.toString(length(literal(objectArray)));
```

Results in showing 2 as symbol text in:

<img width="312" alt="screen shot 2018-03-15 at 11 10 22" src="https://user-images.githubusercontent.com/2151639/37457357-123018e2-2842-11e8-9015-4d622d552e5a.png">



