### PR TITLE
Bringing back missing two-tap telemetry event

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -796,6 +796,8 @@ final class MapGestureDetector {
       transform.cancelTransitions();
       cameraChangeDispatcher.onCameraMoveStarted(REASON_API_GESTURE);
 
+      sendTelemetryEvent(Events.TWO_FINGER_TAP, detector.getFocalPoint());
+
       PointF zoomFocalPoint;
       // Single finger double tap
       if (focalPoint != null) {


### PR DESCRIPTION
This PR fixes `TWO_FINGER_TAP` event from [here](https://github.com/mapbox/mapbox-gl-native/pull/11221/files#diff-dc8b8b458b4be05d4cfad1bbafea82aeL195) that wasn't properly ported to the new gestures handling implementation.