### PR TITLE
Document to use subclasses of MGLFeature to access attributes

### DIFF
--- a/platform/darwin/src/MGLPointAnnotation.h
+++ b/platform/darwin/src/MGLPointAnnotation.h
@@ -28,7 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
  default content of the annotation’s callout (on iOS) or popover (on macOS).
 
  To group multiple related points together in one shape, use an
- `MGLPointCollection` or `MGLShapeCollection` object.
+ `MGLPointCollection` or `MGLShapeCollection` object. To access
+ a point’s attributes, use an `MGLPointFeature` object.
 
  A point shape is known as a
  <a href="https://tools.ietf.org/html/rfc7946#section-3.1.2">Point</a> geometry

--- a/platform/darwin/src/MGLPointCollection.h
+++ b/platform/darwin/src/MGLPointCollection.h
@@ -15,7 +15,8 @@
  You can add point collections to the map by adding them to an `MGLShapeSource`
  object. Configure the appearance of an `MGLShapeSource`’s or
  `MGLVectorSource`’s point collections collectively using an
- `MGLCircleStyleLayer` or `MGLSymbolStyleLayer` object.
+ `MGLCircleStyleLayer` or `MGLSymbolStyleLayer` object. To access a point
+ collection’s attributes, use an `MGLPointCollectionFeature` object.
 
  You cannot add an `MGLPointCollection` object directly to a map view as an
  annotation. However, you can create individual `MGLPointAnnotation` objects

--- a/platform/darwin/src/MGLPolygon.h
+++ b/platform/darwin/src/MGLPolygon.h
@@ -18,7 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
  You can add polygon shapes to the map by adding them to an `MGLShapeSource`
  object. Configure the appearance of an `MGLShapeSource`’s or
  `MGLVectorSource`’s polygons collectively using an `MGLFillStyleLayer` or
- `MGLSymbolStyleLayer` object.
+ `MGLSymbolStyleLayer` object. To access a polygon’s attributes, use an
+ `MGLPolygonFeature` object.
 
  Alternatively, you can add a polygon overlay directly to a map view using the
  `-[MGLMapView addAnnotation:]` or `-[MGLMapView addOverlay:]` method. Configure

--- a/platform/darwin/src/MGLPolyline.h
+++ b/platform/darwin/src/MGLPolyline.h
@@ -18,7 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
  You can add polyline shapes to the map by adding them to an `MGLShapeSource`
  object. Configure the appearance of an `MGLShapeSource`’s or
  `MGLVectorSource`’s polylines collectively using an `MGLLineStyleLayer` or
- `MGLSymbolStyleLayer` object.
+ `MGLSymbolStyleLayer` object. To access a polyline’s attributes, use an
+ `MGLPolylineFeature` object.
 
  Alternatively, you can add a polyline overlay directly to a map view using the
  `-[MGLMapView addAnnotation:]` or `-[MGLMapView addOverlay:]` method. Configure

--- a/platform/darwin/src/MGLShape.h
+++ b/platform/darwin/src/MGLShape.h
@@ -20,7 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 
  Although you do not create instances of this class directly, you can use its
  `+[MGLShape shapeWithData:encoding:error:]` factory method to create one of the
- concrete subclasses of `MGLShape` noted above from GeoJSON data.
+ concrete subclasses of `MGLShape` noted above from GeoJSON data. To access a
+ shape’s attributes, use the corresponding `MGLFeature` class instead.
 
  You can add shapes to the map by adding them to an `MGLShapeSource` object.
  Configure the appearance of an `MGLShapeSource`’s or `MGLVectorSource`’s shapes

--- a/platform/darwin/src/MGLShapeCollection.h
+++ b/platform/darwin/src/MGLShapeCollection.h
@@ -27,7 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 
  To represent a collection of point, polyline, or polygon shapes, it may be more
  convenient to use an `MGLPointCollection`, `MGLMultiPolyline`, or
- `MGLMultiPolygon` object, respectively.
+ `MGLMultiPolygon` object, respectively. To access a shape collection’s attributes,
+ use the corresponding `MGLFeature` object.
 
  A shape collection is known as a
  <a href="https://tools.ietf.org/html/rfc7946#section-3.1.8">GeometryCollection</a>


### PR DESCRIPTION
Documents to use a `MGLFeature` in order to access the attributes of a shape.

Partially addresses #11287 