### PR TITLE
CP master->boba: [core] don't hide icons if text is an empty string

### DIFF
--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -39,7 +39,6 @@
   "render-tests/regressions/mapbox-gl-js#5599": "https://github.com/mapbox/mapbox-gl-native/issues/10399",
   "render-tests/regressions/mapbox-gl-js#5740": "https://github.com/mapbox/mapbox-gl-native/issues/10619",
   "render-tests/regressions/mapbox-gl-js#5982": "https://github.com/mapbox/mapbox-gl-native/issues/10619",
-  "render-tests/regressions/mapbox-gl-js#6160": "https://github.com/mapbox/mapbox-gl-native/pull/11206",
   "render-tests/regressions/mapbox-gl-native#7357": "https://github.com/mapbox/mapbox-gl-native/issues/7357",
   "render-tests/runtime-styling/image-add-sdf": "https://github.com/mapbox/mapbox-gl-native/issues/9847",
   "render-tests/runtime-styling/paint-property-fill-flat-to-extrude": "https://github.com/mapbox/mapbox-gl-native/issues/6745",

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -95,9 +95,6 @@ void Placement::placeLayerBucket(
     auto partiallyEvaluatedTextSize = bucket.textSizeBinder->evaluateForZoom(state.getZoom());
     auto partiallyEvaluatedIconSize = bucket.iconSizeBinder->evaluateForZoom(state.getZoom());
 
-    const bool iconWithoutText = !bucket.hasTextData() || bucket.layout.get<style::TextOptional>();
-    const bool textWithoutIcon = !bucket.hasIconData() || bucket.layout.get<style::IconOptional>();
-
     for (auto& symbolInstance : bucket.symbolInstances) {
 
         if (seenCrossTileIDs.count(symbolInstance.crossTileID) == 0) {
@@ -139,6 +136,9 @@ void Placement::placeLayerBucket(
                 placeIcon = placed.first;
                 offscreen &= placed.second;
             }
+
+            const bool iconWithoutText = !symbolInstance.hasText || bucket.layout.get<style::TextOptional>();
+            const bool textWithoutIcon = !symbolInstance.hasIcon || bucket.layout.get<style::IconOptional>();
 
             // combine placements for icon and text
             if (!iconWithoutText && !textWithoutIcon) {


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/11344. This has been lingering for a while and just (slightly) bit me when I was expecting it to be in boba.

This is the native equivalent of https://github.com/mapbox/mapbox-gl-js/issues/6160 -- not a major bug but something we want to get in nonetheless.

This isn't too late for the next beta of iOS and Android?

/cc @ansis @jfirebaugh @tobrun @friedbunny 