### PR TITLE
[core] Avoid flashing on pitched overzoomed tiles.

### DIFF
--- a/src/mbgl/shaders/collision_box.cpp
+++ b/src/mbgl/shaders/collision_box.cpp
@@ -22,7 +22,10 @@ varying float v_notUsed;
 void main() {
     vec4 projectedPoint = u_matrix * vec4(a_anchor_pos, 0, 1);
     highp float camera_to_anchor_distance = projectedPoint.w;
-    highp float collision_perspective_ratio = 0.5 + 0.5 * (u_camera_to_center_distance / camera_to_anchor_distance);
+    highp float collision_perspective_ratio = clamp(
+        0.5 + 0.5 * (u_camera_to_center_distance / camera_to_anchor_distance),
+        0.0, // Prevents oversized near-field boxes in pitched/overzoomed tiles
+        4.0);
 
     gl_Position = u_matrix * vec4(a_pos, 0.0, 1.0);
     gl_Position.xy += a_extrude * u_extrude_scale * gl_Position.w * collision_perspective_ratio;

--- a/src/mbgl/shaders/symbol_icon.cpp
+++ b/src/mbgl/shaders/symbol_icon.cpp
@@ -80,7 +80,10 @@ void main() {
     highp float distance_ratio = u_pitch_with_map ?
         camera_to_anchor_distance / u_camera_to_center_distance :
         u_camera_to_center_distance / camera_to_anchor_distance;
-    highp float perspective_ratio = 0.5 + 0.5 * distance_ratio;
+    highp float perspective_ratio = clamp(
+            0.5 + 0.5 * distance_ratio,
+            0.0, // Prevents oversized near-field symbols in pitched/overzoomed tiles
+            4.0);
 
     size *= perspective_ratio;
 

--- a/src/mbgl/shaders/symbol_sdf.cpp
+++ b/src/mbgl/shaders/symbol_sdf.cpp
@@ -156,7 +156,10 @@ void main() {
     highp float distance_ratio = u_pitch_with_map ?
         camera_to_anchor_distance / u_camera_to_center_distance :
         u_camera_to_center_distance / camera_to_anchor_distance;
-    highp float perspective_ratio = 0.5 + 0.5 * distance_ratio;
+    highp float perspective_ratio = clamp(
+        0.5 + 0.5 * distance_ratio,
+        0.0, // Prevents oversized near-field symbols in pitched/overzoomed tiles
+        4.0);
 
     size *= perspective_ratio;
 


### PR DESCRIPTION
Clamps perspective ratios in shaders.
Fixes issue #11487.
Port of GL JS PR #6365.

/cc @ansis @jfirebaugh @malwoodsantoro @friedbunny @tobrun 