### PR TITLE
Literal array conversion of primitive arrays

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
@@ -112,6 +112,9 @@ public class Expression {
    * @return the expression
    */
   public static Expression literal(@NonNull Object object) {
+    if (object.getClass().isArray()) {
+      return literal(ExpressionArray.toObjectArray(object));
+    }
     return new ExpressionLiteral(object);
   }
 
@@ -2033,6 +2036,11 @@ public class Expression {
       };
     }
 
+    /**
+     * Convert the expression array to a string representation.
+     *
+     * @return the string representation of the expression array
+     */
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder("[\"literal\"], [");
@@ -2052,5 +2060,21 @@ public class Expression {
       builder.append("]]");
       return builder.toString();
     }
+  }
+
+  /**
+   * Converts an object that is a primitive array to an Object[]
+   *
+   * @param object the object to convert to an object array
+   * @return the converted object array
+   */
+  static Object[] toObjectArray(Object object) {
+    // object is a primitive array
+    int len = java.lang.reflect.Array.getLength(object);
+    Object[] objects = new Object[len];
+    for (int i = 0; i < len; i++) {
+      objects[i] = java.lang.reflect.Array.get(object, i);
+    }
+    return objects;
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.java
@@ -1081,4 +1081,12 @@ public class ExpressionTest {
     String actual = literal(array).toString();
     assertEquals("literal array should match", expected, actual);
   }
+
+  @Test
+  public void testLiteralPrimitiveArrayConversion() throws Exception {
+    float[] array = new float[] {0.2f, 0.5f};
+    Object[] expected = new Object[] {"literal", new Object[] {0.2f, 0.5f}};
+    Object[] actual = literal(array).toArray();
+    assertEquals("primitive array should be convered", expected, actual);
+  }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/SymbolGeneratorActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/SymbolGeneratorActivity.java
@@ -269,8 +269,8 @@ public class SymbolGeneratorActivity extends AppCompatActivity implements OnMapR
         iconSize(iconSizeExpression),
         iconAnchor(ICON_ANCHOR_BOTTOM),
         iconOffset(step(zoom(), literal(new float[] {0f, 0f}),
-          literal(1), literal(new Float[] {0f, 0f}),
-          literal(10), literal(new Float[] {0f, -35f})
+          stop(1, new Float[] {0f, 0f}),
+          stop(10, new Float[] {0f, -35f})
         )),
 
         // text field configuration

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/SymbolGeneratorActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/SymbolGeneratorActivity.java
@@ -45,8 +45,11 @@ import static com.mapbox.mapboxsdk.style.expressions.Expression.number;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.pi;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.product;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.rgba;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.step;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.stop;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.string;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.upcase;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.zoom;
 import static com.mapbox.mapboxsdk.style.layers.Property.ICON_ANCHOR_BOTTOM;
 import static com.mapbox.mapboxsdk.style.layers.Property.TEXT_ANCHOR_TOP;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAllowOverlap;
@@ -265,7 +268,10 @@ public class SymbolGeneratorActivity extends AppCompatActivity implements OnMapR
         iconAllowOverlap(false),
         iconSize(iconSizeExpression),
         iconAnchor(ICON_ANCHOR_BOTTOM),
-        iconOffset(new Float[] {0.0f, -5.0f}),
+        iconOffset(step(zoom(), literal(new float[] {0f, 0f}),
+          literal(1), literal(new Float[] {0f, 0f}),
+          literal(10), literal(new Float[] {0f, -35f})
+        )),
 
         // text field configuration
         textField(textFieldExpression),


### PR DESCRIPTION
This PR boxes primitive arrays to Object[] to get a correct literal array expression conversion. 
Closes #11498 