### PR TITLE
Make default output from step more descriptive

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
@@ -1520,13 +1520,14 @@ public class Expression {
    * Returns the output value of the stop just less than the input,
    * or the first input if the input is less than the first stop.
    *
-   * @param input the input value
-   * @param stops pair of input and output values
+   * @param input         the input value
+   * @param defaultOutput the default output expression
+   * @param stops         pair of input and output values
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-step">Style specification</a>
    */
-  public static Expression step(@NonNull Number input, @NonNull Expression expression, Expression... stops) {
-    return step(literal(input), expression, stops);
+  public static Expression step(@NonNull Number input, @NonNull Expression defaultOutput, Expression... stops) {
+    return step(literal(input), defaultOutput, stops);
   }
 
   /**
@@ -1536,13 +1537,14 @@ public class Expression {
    * Returns the output value of the stop just less than the input,
    * or the first input if the input is less than the first stop.
    *
-   * @param expression the input expression
-   * @param stops      pair of input and output values
+   * @param input         the input expression
+   * @param defaultOutput the default output expression
+   * @param stops         pair of input and output values
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-step">Style specification</a>
    */
-  public static Expression step(@NonNull Expression input, @NonNull Expression expression, Expression... stops) {
-    return new Expression("step", join(new Expression[] {input, expression}, stops));
+  public static Expression step(@NonNull Expression input, @NonNull Expression defaultOutput, Expression... stops) {
+    return new Expression("step", join(new Expression[] {input, defaultOutput}, stops));
   }
 
   /**
@@ -1552,13 +1554,14 @@ public class Expression {
    * Returns the output value of the stop just less than the input,
    * or the first input if the input is less than the first stop.
    *
-   * @param input the input value
-   * @param stops pair of input and output values
+   * @param input         the input value
+   * @param defaultOutput the default output expression
+   * @param stops         pair of input and output values
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-step">Style specification</a>
    */
-  public static Expression step(@NonNull Number input, @NonNull Expression expression, Stop... stops) {
-    return step(literal(input), expression, Stop.toExpressionArray(stops));
+  public static Expression step(@NonNull Number input, @NonNull Expression defaultOutput, Stop... stops) {
+    return step(literal(input), defaultOutput, Stop.toExpressionArray(stops));
   }
 
   /**
@@ -1568,13 +1571,14 @@ public class Expression {
    * Returns the output value of the stop just less than the input,
    * or the first input if the input is less than the first stop.
    *
-   * @param input the input value
-   * @param stops pair of input and output values
+   * @param input         the input value
+   * @param defaultOutput the default output expression
+   * @param stops         pair of input and output values
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-step">Style specification</a>
    */
-  public static Expression step(@NonNull Expression input, @NonNull Expression expression, Stop... stops) {
-    return step(input, expression, Stop.toExpressionArray(stops));
+  public static Expression step(@NonNull Expression input, @NonNull Expression defaultOutput, Stop... stops) {
+    return step(input, defaultOutput, Stop.toExpressionArray(stops));
   }
 
   /**


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gl-native/issues/11498, in particular:

> Expression.step requires three parameters(input expression stops) but documentation doesn't provide description for second parameter

FWIW, we will be adding code examples later as part of https://github.com/mapbox/mapbox-gl-native/issues/11159

cc @sigis151