### PR TITLE
[core] Don't resolve tokens after evaluating a text-field or icon-image expression

### DIFF
--- a/include/mbgl/style/data_driven_property_value.hpp
+++ b/include/mbgl/style/data_driven_property_value.hpp
@@ -50,6 +50,13 @@ public:
         return !value.template is<CameraFunction<T>>() && !value.template is<CompositeFunction<T>>();
     }
 
+    bool isExpression() const {
+        return value.match(
+            [] (const Undefined&) { return false; },
+            [] (const T&)         { return false; },
+            [] (const auto& fn)   { return fn.isExpression; });
+    }
+
     template <class... Ts>
     auto match(Ts&&... ts) const {
         return value.match(std::forward<Ts>(ts)...);

--- a/include/mbgl/style/data_driven_property_value.hpp
+++ b/include/mbgl/style/data_driven_property_value.hpp
@@ -54,7 +54,9 @@ public:
         return value.match(
             [] (const Undefined&) { return false; },
             [] (const T&)         { return false; },
-            [] (const auto& fn)   { return fn.isExpression; });
+            [] (const    CameraFunction<T>& fn)   { return fn.isExpression; },
+            [] (const    SourceFunction<T>& fn)   { return fn.isExpression; },
+            [] (const CompositeFunction<T>& fn)   { return fn.isExpression; });
     }
 
     template <class... Ts>

--- a/include/mbgl/style/function/camera_function.hpp
+++ b/include/mbgl/style/function/camera_function.hpp
@@ -27,15 +27,16 @@ public:
             IntervalStops<T>>>;
     
     CameraFunction(std::unique_ptr<expression::Expression> expression_)
-         : expression(std::move(expression_)),
+         : isExpression(true),
+           expression(std::move(expression_)),
            zoomCurve(expression::findZoomCurveChecked(expression.get()))
     {
         assert(!expression::isZoomConstant(*expression));
         assert(expression::isFeatureConstant(*expression));
     }
 
-    CameraFunction(Stops stops_)
-        : stops(std::move(stops_)),
+    CameraFunction(const Stops& stops)
+        : isExpression(false),
           expression(stops.match([&] (const auto& s) {
             return expression::Convert::toExpression(s);
           })),
@@ -76,11 +77,9 @@ public:
     }
 
     bool useIntegerZoom = false;
+    bool isExpression;
 
     const expression::Expression& getExpression() const { return *expression; }
-
-    // retained for compatibility with pre-expression function API
-    Stops stops;
 
 private:
     std::shared_ptr<expression::Expression> expression;

--- a/include/mbgl/style/function/composite_function.hpp
+++ b/include/mbgl/style/function/composite_function.hpp
@@ -51,16 +51,16 @@ public:
             CompositeCategoricalStops<T>>>;
 
     CompositeFunction(std::unique_ptr<expression::Expression> expression_)
-    :   expression(std::move(expression_)),
+    :   isExpression(true),
+        expression(std::move(expression_)),
         zoomCurve(expression::findZoomCurveChecked(expression.get()))
     {
         assert(!expression::isZoomConstant(*expression));
         assert(!expression::isFeatureConstant(*expression));
     }
 
-    CompositeFunction(std::string property_, Stops stops_, optional<T> defaultValue_ = {})
-    :   property(std::move(property_)),
-        stops(std::move(stops_)),
+    CompositeFunction(const std::string& property, const Stops& stops, optional<T> defaultValue_ = {})
+    :   isExpression(false),
         defaultValue(std::move(defaultValue_)),
         expression(stops.match([&] (const auto& s) {
             return expression::Convert::toExpression(property, s);
@@ -113,12 +113,11 @@ public:
 
     const expression::Expression& getExpression() const { return *expression; }
 
-    std::string property;
-    Stops stops;
-    optional<T> defaultValue;
     bool useIntegerZoom = false;
+    bool isExpression;
     
 private:
+    optional<T> defaultValue;
     std::shared_ptr<expression::Expression> expression;
     const variant<const expression::InterpolateBase*, const expression::Step*> zoomCurve;
 };

--- a/include/mbgl/style/function/source_function.hpp
+++ b/include/mbgl/style/function/source_function.hpp
@@ -30,15 +30,15 @@ public:
             IdentityStops<T>>>;
 
     SourceFunction(std::unique_ptr<expression::Expression> expression_)
-        : expression(std::move(expression_))
+        : isExpression(true),
+          expression(std::move(expression_))
     {
         assert(expression::isZoomConstant(*expression));
         assert(!expression::isFeatureConstant(*expression));
     }
     
-    SourceFunction(std::string property_, Stops stops_, optional<T> defaultValue_ = {})
-        : property(std::move(property_)),
-          stops(std::move(stops_)),
+    SourceFunction(const std::string& property, const Stops& stops, optional<T> defaultValue_ = {})
+        : isExpression(false),
           defaultValue(std::move(defaultValue_)),
           expression(stops.match([&] (const IdentityStops<T>&) {
               return expression::Convert::fromIdentityFunction(expression::valueTypeToExpressionType<T>(), property);
@@ -67,15 +67,12 @@ public:
     }
 
     bool useIntegerZoom = false;
+    bool isExpression;
 
     const expression::Expression& getExpression() const { return *expression; }
 
-    // retained for compatibility with pre-expression function API
-    std::string property;
-    Stops stops;
-    optional<T> defaultValue;
-
 private:
+    optional<T> defaultValue;
     std::shared_ptr<expression::Expression> expression;
 };
 

--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -36,7 +36,6 @@
   "render-tests/regressions/mapbox-gl-js#2769": "https://github.com/mapbox/mapbox-gl-native/issues/10619",
   "render-tests/regressions/mapbox-gl-js#3682": "https://github.com/mapbox/mapbox-gl-js/issues/3682",
   "render-tests/regressions/mapbox-gl-js#5370": "skip - https://github.com/mapbox/mapbox-gl-native/pull/9439",
-  "render-tests/regressions/mapbox-gl-js#5599": "https://github.com/mapbox/mapbox-gl-native/issues/10399",
   "render-tests/regressions/mapbox-gl-js#5740": "https://github.com/mapbox/mapbox-gl-native/issues/10619",
   "render-tests/regressions/mapbox-gl-js#5982": "https://github.com/mapbox/mapbox-gl-native/issues/10619",
   "render-tests/regressions/mapbox-gl-native#7357": "https://github.com/mapbox/mapbox-gl-native/issues/7357",

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -126,7 +126,7 @@ SymbolLayout::SymbolLayout(const BucketParameters& parameters,
         
         if (hasText) {
             std::string u8string = layout.evaluate<TextField>(zoom, ft);
-            if (layout.get<TextField>().isConstant()) {
+            if (layout.get<TextField>().isConstant() && !leader.layout.get<TextField>().isExpression()) {
                 u8string = util::replaceTokens(u8string, getValue);
             }
             
@@ -159,7 +159,7 @@ SymbolLayout::SymbolLayout(const BucketParameters& parameters,
 
         if (hasIcon) {
             std::string icon = layout.evaluate<IconImage>(zoom, ft);
-            if (layout.get<IconImage>().isConstant()) {
+            if (layout.get<IconImage>().isConstant() && !leader.layout.get<IconImage>().isExpression()) {
                 icon = util::replaceTokens(icon, getValue);
             }
             ft.icon = icon;


### PR DESCRIPTION
Fixes #10399.

I opted for a fix equivalent to the current approach in gl-js, rather than the approach outlined in https://github.com/mapbox/mapbox-gl-native/issues/10399#issuecomment-342369415. We should refactor to the latter on `master`, but after getting started on it I think it's more involved than we want for boba.