### PR TITLE
[build] Run more sanitizers/analyzers on iOS/macOS CI; save Xcode logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,10 @@ ios-sanitize: $(IOS_PROJ_PATH)
 ios-sanitize-address: $(IOS_PROJ_PATH)
 	set -o pipefail && $(IOS_XCODEBUILD_SIM) -scheme 'CI' -enableAddressSanitizer YES test $(XCPRETTY)
 
+.PHONY: ios-static-analyzer
+ios-static-analyzer: $(IOS_PROJ_PATH)
+	set -o pipefail && $(IOS_XCODEBUILD_SIM) analyze -scheme 'CI' test $(XCPRETTY)
+
 .PHONY: ipackage
 ipackage: $(IOS_PROJ_PATH)
 	FORMAT=$(FORMAT) BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=$(SYMBOLS) \

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ifeq ($(V), 1)
   export XCPRETTY
   NINJA_ARGS ?= -v
 else
-  export XCPRETTY ?= | xcpretty
+  export XCPRETTY ?= | tee '$(shell pwd)/build/xcodebuild-$(shell date +"%Y-%m-%d_%H%M%S").log' | xcpretty
   NINJA_ARGS ?=
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -235,13 +235,13 @@ ios-test: $(IOS_PROJ_PATH)
 ios-integration-test: $(IOS_PROJ_PATH)
 	set -o pipefail && $(IOS_XCODEBUILD_SIM) -scheme 'Integration Test Harness' test $(XCPRETTY)
 
+.PHONY: ios-sanitize
+ios-sanitize: $(IOS_PROJ_PATH)
+	set -o pipefail && $(IOS_XCODEBUILD_SIM) -scheme 'CI' -enableThreadSanitizer YES -enableUndefinedBehaviorSanitizer YES test $(XCPRETTY)
+
 .PHONY: ios-sanitize-address
 ios-sanitize-address: $(IOS_PROJ_PATH)
 	set -o pipefail && $(IOS_XCODEBUILD_SIM) -scheme 'CI' -enableAddressSanitizer YES test $(XCPRETTY)
-
-.PHONY: ios-sanitize-thread
-ios-sanitize-thread: $(IOS_PROJ_PATH)
-	set -o pipefail && $(IOS_XCODEBUILD_SIM) -scheme 'CI' -enableThreadSanitizer YES test $(XCPRETTY)
 
 .PHONY: ipackage
 ipackage: $(IOS_PROJ_PATH)

--- a/circle.yml
+++ b/circle.yml
@@ -34,6 +34,7 @@ workflows:
       - ios-debug
       - ios-sanitize
       #- ios-sanitize-address
+      - ios-static-analyzer
       - ios-release:
           filters:
             tags:
@@ -766,6 +767,25 @@ jobs:
       - run:
           name: Build and run SDK unit tests with address sanitizer
           command: make ios-sanitize-address
+      - *show-ccache-stats
+      - *save-cache
+
+# ------------------------------------------------------------------------------
+  ios-static-analyzer:
+    macos:
+      xcode: "9.2.0"
+    environment:
+      BUILDTYPE: Debug
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - checkout
+      - *install-macos-dependencies
+      - *generate-cache-key
+      - *restore-cache
+      - *reset-ccache-stats
+      - run:
+          name: Build and run SDK unit tests with the static analyzer
+          command: make ios-static-analyzer
       - *show-ccache-stats
       - *save-cache
 

--- a/circle.yml
+++ b/circle.yml
@@ -32,8 +32,8 @@ workflows:
       - linux-gcc5-release-qt4
       - linux-gcc5-release-qt5
       - ios-debug
+      - ios-sanitize
       #- ios-sanitize-address
-      - ios-sanitize-thread
       - ios-release:
           filters:
             tags:
@@ -732,6 +732,25 @@ jobs:
       - *save-cache
 
 # ------------------------------------------------------------------------------
+  ios-sanitize:
+    macos:
+      xcode: "9.2.0"
+    environment:
+      BUILDTYPE: Debug
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - checkout
+      - *install-macos-dependencies
+      - *generate-cache-key
+      - *restore-cache
+      - *reset-ccache-stats
+      - run:
+          name: Build and run SDK unit tests with thread and undefined behavior sanitizers
+          command: make ios-sanitize
+      - *show-ccache-stats
+      - *save-cache
+
+# ------------------------------------------------------------------------------
   ios-sanitize-address:
     macos:
       xcode: "9.2.0"
@@ -747,25 +766,6 @@ jobs:
       - run:
           name: Build and run SDK unit tests with address sanitizer
           command: make ios-sanitize-address
-      - *show-ccache-stats
-      - *save-cache
-
-# ------------------------------------------------------------------------------
-  ios-sanitize-thread:
-    macos:
-      xcode: "9.2.0"
-    environment:
-      BUILDTYPE: Debug
-      HOMEBREW_NO_AUTO_UPDATE: 1
-    steps:
-      - checkout
-      - *install-macos-dependencies
-      - *generate-cache-key
-      - *restore-cache
-      - *reset-ccache-stats
-      - run:
-          name: Build and run SDK unit tests with thread sanitizer
-          command: make ios-sanitize-thread
       - *show-ccache-stats
       - *save-cache
 

--- a/circle.yml
+++ b/circle.yml
@@ -224,6 +224,18 @@ step-library:
         path: mapbox-gl-js/test/integration/render-tests/index-recycle-map.html
         destination: render-tests
 
+  - &collect-xcode-build-logs
+      run:
+        name: Collect Xcode build logs
+        when: always
+        command: |
+          export XCODE_LOG_DIR=build/logs
+          mkdir -p $XCODE_LOG_DIR
+          cp build/*.log $XCODE_LOG_DIR
+  - &upload-xcode-build-logs
+      store_artifacts:
+        path: build/logs
+
 jobs:
   nitpick:
     docker:
@@ -731,6 +743,8 @@ jobs:
           command: scripts/nitpick/generated-code.js darwin
       - *show-ccache-stats
       - *save-cache
+      - *collect-xcode-build-logs
+      - *upload-xcode-build-logs
 
 # ------------------------------------------------------------------------------
   ios-sanitize:
@@ -750,6 +764,8 @@ jobs:
           command: make ios-sanitize
       - *show-ccache-stats
       - *save-cache
+      - *collect-xcode-build-logs
+      - *upload-xcode-build-logs
 
 # ------------------------------------------------------------------------------
   ios-sanitize-address:
@@ -769,6 +785,8 @@ jobs:
           command: make ios-sanitize-address
       - *show-ccache-stats
       - *save-cache
+      - *collect-xcode-build-logs
+      - *upload-xcode-build-logs
 
 # ------------------------------------------------------------------------------
   ios-static-analyzer:
@@ -788,6 +806,8 @@ jobs:
           command: make ios-static-analyzer
       - *show-ccache-stats
       - *save-cache
+      - *collect-xcode-build-logs
+      - *upload-xcode-build-logs
 
 # ------------------------------------------------------------------------------
   ios-release:
@@ -843,6 +863,8 @@ jobs:
       - store_artifacts:
           path: test/fixtures
           destination: test/fixtures
+      - *collect-xcode-build-logs
+      - *upload-xcode-build-logs
 
 # ------------------------------------------------------------------------------
   macos-debug-qt5:
@@ -889,6 +911,8 @@ jobs:
       - *run-node-macos-tests
       - *publish-node-package
       - *upload-render-tests
+      - *collect-xcode-build-logs
+      - *upload-xcode-build-logs
 
 # ------------------------------------------------------------------------------
   macos-release-node6:
@@ -910,3 +934,5 @@ jobs:
       - *run-node-macos-tests
       - *publish-node-package
       - *upload-render-tests
+      - *collect-xcode-build-logs
+      - *upload-xcode-build-logs


### PR DESCRIPTION
Pulls out the immediately viable parts of #10742.

- Adds `ios-sanitize`, which runs both the thread and [undefined behavior sanitizers](https://developer.apple.com/documentation/code_diagnostics/undefined_behavior_sanitizer). Replaces the current `ios-sanitize-thread` build.
- Adds `ios-static-analyzer` — fixes #1549.
- Saves raw Xcode build logs to `build/xcodebuild-YYYY-MM-DD-HMS.log`, which CircleCI then keeps around as build artifacts. Useful for times when xcpretty might obscure a failure.

/cc @mapbox/maps-ios 