### PR TITLE
Telemetry library 3.0.0-beta.3

### DIFF
--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
     versions = [
             mapboxServices : '3.0.0-beta.4',
-            mapboxTelemetry: '3.0.0-beta.2',
+            mapboxTelemetry: '3.0.0-beta.3',
             mapboxGestures : '0.1.0',
             supportLib     : '25.4.0',
             espresso       : '3.0.1',


### PR DESCRIPTION
Bumping telemetry library to `3.0.0-beta.3`.