### PR TITLE
Gestures library v0.2.0

### DIFF
--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -10,7 +10,7 @@ ext {
     versions = [
             mapboxServices : '3.0.0-beta.4',
             mapboxTelemetry: '3.0.0-beta.3',
-            mapboxGestures : '0.1.0',
+            mapboxGestures : '0.2.0',
             supportLib     : '25.4.0',
             espresso       : '3.0.1',
             testRunner     : '1.0.1',


### PR DESCRIPTION
Bumping gestures library to `v0.2.0`.
This change includes a fix for the minimum required span to register a scale gesture. See https://github.com/mapbox/mapbox-gestures-android/pull/30.