### PR TITLE
[ios, build] Fix heap buffer overflow and enable asan build on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,7 +33,7 @@ workflows:
       - linux-gcc5-release-qt5
       - ios-debug
       - ios-sanitize
-      #- ios-sanitize-address
+      - ios-sanitize-address
       - ios-static-analyzer
       - ios-release:
           filters:

--- a/platform/darwin/src/MGLPolyline.mm
+++ b/platform/darwin/src/MGLPolyline.mm
@@ -72,9 +72,12 @@
     
     if (count > 1 || middle > traveled) {
         for (NSUInteger i = 0; i < count; i++) {
-            
+
+            // Avoid a heap buffer overflow when there are only two coordinates.
+            NSUInteger nextIndex = (i + 1 == count) ? 0 : 1;
+
             MGLRadianCoordinate2D from = MGLRadianCoordinateFromLocationCoordinate(coordinates[i]);
-            MGLRadianCoordinate2D to = MGLRadianCoordinateFromLocationCoordinate(coordinates[i + 1]);
+            MGLRadianCoordinate2D to = MGLRadianCoordinateFromLocationCoordinate(coordinates[i + nextIndex]);
             
             if (traveled >= middle) {
                 double overshoot = middle - traveled;
@@ -91,7 +94,6 @@
             }
             
             traveled += (MGLDistanceBetweenRadianCoordinates(from, to) * mbgl::util::EARTH_RADIUS_M);
-            
         }
     }
 


### PR DESCRIPTION
Fixes #10741, which allows us to enable the dormant `ios-sanitize-address` build on CircleCI.

/cc @1ec5 @akitchen @fabian-guerra @julianrex 