### PR TITLE
[core] Fix issue #11538 (race condition crash for heavily modified annotations)

### DIFF
--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -130,8 +130,8 @@ void GeometryTile::onLayout(LayoutResult result, const uint64_t resultCorrelatio
     //  replacing a tile at a different zoom that _did_ have symbols.
     (void)resultCorrelationID;
     nonSymbolBuckets = std::move(result.nonSymbolBuckets);
-    pendingFeatureIndex = std::move(result.featureIndex);
-    pendingData = std::move(result.tileData);
+    pendingFeatureIndex = { std::move(result.featureIndex) };
+    pendingData = { std::move(result.tileData) };
     observer->onTileChanged(*this);
 }
 
@@ -215,10 +215,12 @@ Bucket* GeometryTile::getBucket(const Layer::Impl& layer) const {
 
 void GeometryTile::commitFeatureIndex() {
     if (pendingFeatureIndex) {
-        featureIndex = std::move(pendingFeatureIndex);
+        featureIndex = std::move(*pendingFeatureIndex);
+        pendingFeatureIndex = nullopt;
     }
     if (pendingData) {
-        data = std::move(pendingData);
+        data = std::move(*pendingData);
+        pendingData = nullopt;
     }
 }
 

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -125,9 +125,9 @@ private:
 
     std::unordered_map<std::string, std::shared_ptr<Bucket>> nonSymbolBuckets;
     std::unique_ptr<FeatureIndex> featureIndex;
-    optional<std::unique_ptr<FeatureIndex>> pendingFeatureIndex;
+    optional<std::pair<bool,std::unique_ptr<FeatureIndex>>> pendingFeatureIndex;
     std::unique_ptr<const GeometryTileData> data;
-    optional<std::unique_ptr<const GeometryTileData>> pendingData;
+    optional<std::pair<bool, std::unique_ptr<const GeometryTileData>>> pendingData;
 
     optional<AlphaImage> glyphAtlasImage;
     optional<PremultipliedImage> iconAtlasImage;

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -125,9 +125,9 @@ private:
 
     std::unordered_map<std::string, std::shared_ptr<Bucket>> nonSymbolBuckets;
     std::unique_ptr<FeatureIndex> featureIndex;
-    std::unique_ptr<FeatureIndex> pendingFeatureIndex;
+    optional<std::unique_ptr<FeatureIndex>> pendingFeatureIndex;
     std::unique_ptr<const GeometryTileData> data;
-    std::unique_ptr<const GeometryTileData> pendingData;
+    optional<std::unique_ptr<const GeometryTileData>> pendingData;
 
     optional<AlphaImage> glyphAtlasImage;
     optional<PremultipliedImage> iconAtlasImage;


### PR DESCRIPTION
This PR contains two fixes for issue #11538.

The first fix closes a logic error that would prevent the `GeometryTile` "data" member from updating if the data went from non-null to null. This could allow the tile to have an empty `FeatureIndex` with non-empty data (since it would keep the previous non-null data). This could lead to an out of bounds exception being thrown here:

https://github.com/mapbox/mapbox-gl-native/blob/553efa38e3591ce62863d4d74222710f8e3c2337/src/mbgl/geometry/feature_index.cpp#L109

The crash that would be generated doesn't match the stack trace reported in #11538, but it would be likely to happen in the same sort of stress case (quickly adding and removing annotations).

The second fix closes a race condition in which the `FeatureIndex`/`GeometryTileData` received in `GeometryTile::onLayout` could be committed before the corresponding updated `symbolBuckets` arrived in `GeometryTile::onPlacement`. Because the contents of the global `CollisionIndex` are based on the `symbolBuckets`, this would allow the `CollisionIndex` to end up "behind" the corresponding `FeatureIndex`/`GeometryTileData`, and if an item in the `CollisionIndex` had been removed from the new data, it would be possible to get an out-of-bounds exception at:

https://github.com/mapbox/mapbox-gl-native/blob/553efa38e3591ce62863d4d74222710f8e3c2337/src/mbgl/geometry/feature_index.cpp#L119

... which matches the stack trace in #11538.

A more satisfying fix for these issues would be to do the "one-phase" refactoring suggested in #10457 -- the split between "layout" and "placement" that allowed the race condition is _mostly_ vestigial after that global collision detection changes.

@julianrex Since you were able to reproduce the original crash much more reliably than me, can you try to reproduce the crash off of this branch?

/cc @friedbunny @tobrun @jfirebaugh @lilykaiser 