### PR TITLE
Use a host interface for CustomLayer instead of function pointers

### DIFF
--- a/include/mbgl/renderer/renderer_backend.hpp
+++ b/include/mbgl/renderer/renderer_backend.hpp
@@ -47,10 +47,10 @@ protected:
     // as a matched pair, exclusively through BackendScope, in two situations:
     //
     //   1. When releasing GL resources during Renderer destruction
-    //      (Including calling CustomLayerDeinitializeFunction during RenderCustomLayer destruction)
+    //      (Including calling CustomLayerHost::deinitialize during RenderCustomLayer destruction)
     //   2. When renderering through Renderer::render()
-    //      (Including calling CustomLayerDeinitializeFunction for newly added custom layers and
-    //       CustomLayerDeinitializeFunction on layer removal)
+    //      (Including calling CustomLayerHost::initialize for newly added custom layers and
+    //       CustomLayerHost::deinitialize on layer removal)
     virtual void activate() = 0;
     virtual void deactivate() = 0;
 

--- a/include/mbgl/style/layers/custom_layer.hpp
+++ b/include/mbgl/style/layers/custom_layer.hpp
@@ -2,13 +2,11 @@
 
 #include <mbgl/style/layer.hpp>
 
-#include <functional>
-
 namespace mbgl {
 namespace style {
 
 /**
- * Parameters that define the current camera position for a CustomLayerRenderFunction.
+ * Parameters that define the current camera position for a `CustomLayerHost::render()` function.
  */
 struct CustomLayerRenderParameters {
     double width;
@@ -23,41 +21,41 @@ struct CustomLayerRenderParameters {
 
 class CustomLayerHost {
 public:
-virtual ~CustomLayerHost() = default;
-/**
- * Initialize any GL state needed by the custom layer. This method is called once, from the
- * main thread, at a point when the GL context is active but before rendering for the first
- * time.
- *
- * Resources that are acquired in this method must be released in the UninitializeFunction.
- */
-virtual void initialize() = 0;
+    virtual ~CustomLayerHost() = default;
+    /**
+     * Initialize any GL state needed by the custom layer. This method is called once, from the
+     * main thread, at a point when the GL context is active but before rendering for the first
+     * time.
+     *
+     * Resources that are acquired in this method must be released in the `deinitialize` function.
+     */
+    virtual void initialize() = 0;
 
-/**
- * Render the layer. This method is called once per frame. The implementation should not make
- * any assumptions about the GL state (other than that the correct context is active). It may
- * make changes to the state, and is not required to reset values such as the depth mask, stencil
- * mask, and corresponding test flags to their original values.
- * Make sure that you are drawing your fragments with a z value of 1 to take advantage of the
- * opaque fragment culling in case there are opaque layers above your custom layer.
- */
-virtual void render(const CustomLayerRenderParameters&) = 0;
+    /**
+     * Render the layer. This method is called once per frame. The implementation should not make
+     * any assumptions about the GL state (other than that the correct context is active). It may
+     * make changes to the state, and is not required to reset values such as the depth mask, stencil
+     * mask, and corresponding test flags to their original values.
+     * Make sure that you are drawing your fragments with a z value of 1 to take advantage of the
+     * opaque fragment culling in case there are opaque layers above your custom layer.
+     */
+    virtual void render(const CustomLayerRenderParameters&) = 0;
 
-/**
- * Called when the system has destroyed the underlying GL context. The
- * `CustomLayerDeinitializeFunction` will not be called in this case, however
- * `CustomLayerInitializeFunction` will be called instead to prepare for a new render.
- *
- */
-virtual void contextLost() = 0;
+    /**
+     * Called when the system has destroyed the underlying GL context. The
+     * `deinitialize` function will not be called in this case, however
+     * `initialize` will be called instead to prepare for a new render.
+     *
+     */
+    virtual void contextLost() = 0;
 
-/**
- * Destroy any GL state needed by the custom layer, and deallocate context, if necessary. This
- * method is called once, from the main thread, at a point when the GL context is active.
- *
- * Note that it may be called even when the InitializeFunction has not been called.
- */
-virtual void deinitialize() = 0;
+    /**
+     * Destroy any GL state needed by the custom layer, and deallocate context, if necessary. This
+     * method is called once, from the main thread, at a point when the GL context is active.
+     *
+     * Note that it may be called even when the `initialize` function has not been called.
+     */
+    virtual void deinitialize() = 0;
 };
 
 class CustomLayer : public Layer {

--- a/include/mbgl/style/layers/custom_layer.hpp
+++ b/include/mbgl/style/layers/custom_layer.hpp
@@ -6,15 +6,6 @@ namespace mbgl {
 namespace style {
 
 /**
- * Initialize any GL state needed by the custom layer. This method is called once, from the
- * main thread, at a point when the GL context is active but before rendering for the first
- * time.
- *
- * Resources that are acquired in this method must be released in the UninitializeFunction.
- */
-using CustomLayerInitializeFunction = void (*)(void* context);
-
-/**
  * Parameters that define the current camera position for a CustomLayerRenderFunction.
  */
 struct CustomLayerRenderParameters {
@@ -28,6 +19,18 @@ struct CustomLayerRenderParameters {
     double fieldOfView;
 };
 
+class CustomLayerHost {
+public:
+virtual ~CustomLayerHost() = default;
+/**
+ * Initialize any GL state needed by the custom layer. This method is called once, from the
+ * main thread, at a point when the GL context is active but before rendering for the first
+ * time.
+ *
+ * Resources that are acquired in this method must be released in the UninitializeFunction.
+ */
+virtual void initialize() = 0;
+
 /**
  * Render the layer. This method is called once per frame. The implementation should not make
  * any assumptions about the GL state (other than that the correct context is active). It may
@@ -36,7 +39,7 @@ struct CustomLayerRenderParameters {
  * Make sure that you are drawing your fragments with a z value of 1 to take advantage of the
  * opaque fragment culling in case there are opaque layers above your custom layer.
  */
-using CustomLayerRenderFunction = void (*)(void* context, const CustomLayerRenderParameters&);
+virtual void render(const CustomLayerRenderParameters&) = 0;
 
 /**
  * Called when the system has destroyed the underlying GL context. The
@@ -44,7 +47,7 @@ using CustomLayerRenderFunction = void (*)(void* context, const CustomLayerRende
  * `CustomLayerInitializeFunction` will be called instead to prepare for a new render.
  *
  */
-using CustomLayerContextLostFunction = void (*)(void* context);
+virtual void contextLost() = 0;
 
 /**
  * Destroy any GL state needed by the custom layer, and deallocate context, if necessary. This
@@ -52,22 +55,13 @@ using CustomLayerContextLostFunction = void (*)(void* context);
  *
  * Note that it may be called even when the InitializeFunction has not been called.
  */
-using CustomLayerDeinitializeFunction = void (*)(void* context);
+virtual void deinitialize() = 0;
+};
 
 class CustomLayer : public Layer {
 public:
     CustomLayer(const std::string& id,
-                CustomLayerInitializeFunction,
-                CustomLayerRenderFunction,
-                CustomLayerContextLostFunction,
-                CustomLayerDeinitializeFunction,
-                void* context);
-
-    CustomLayer(const std::string& id,
-                CustomLayerInitializeFunction,
-                CustomLayerRenderFunction,
-                CustomLayerDeinitializeFunction,
-                void* context);
+                std::unique_ptr<CustomLayerHost> host);
 
     ~CustomLayer() final;
 

--- a/include/mbgl/style/layers/custom_layer.hpp
+++ b/include/mbgl/style/layers/custom_layer.hpp
@@ -2,6 +2,8 @@
 
 #include <mbgl/style/layer.hpp>
 
+#include <functional>
+
 namespace mbgl {
 namespace style {
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/CustomLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/CustomLayer.java
@@ -9,20 +9,8 @@ package com.mapbox.mapboxsdk.style.layers;
 public class CustomLayer extends Layer {
 
   public CustomLayer(String id,
-                     long context,
-                     long initializeFunction,
-                     long renderFunction,
-                     long deinitializeFunction) {
-    this(id, context, initializeFunction, renderFunction, 0L, deinitializeFunction);
-  }
-
-  public CustomLayer(String id,
-                     long context,
-                     long initializeFunction,
-                     long renderFunction,
-                     long contextLostFunction,
-                     long deinitializeFunction) {
-    initialize(id, initializeFunction, renderFunction, contextLostFunction, deinitializeFunction, context);
+                     long host) {
+    initialize(id, host);
   }
 
   public CustomLayer(long nativePtr) {
@@ -33,9 +21,7 @@ public class CustomLayer extends Layer {
     nativeUpdate();
   }
 
-  protected native void initialize(String id, long initializeFunction, long renderFunction,
-                                   long contextLostFunction, long deinitializeFunction,
-                                   long context);
+  protected native void initialize(String id, long host);
 
   protected native void nativeUpdate();
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/customlayer/CustomLayerActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/customlayer/CustomLayerActivity.java
@@ -58,11 +58,7 @@ public class CustomLayerActivity extends AppCompatActivity {
       fab.setImageResource(R.drawable.ic_layers);
     } else {
       customLayer = new CustomLayer("custom",
-        ExampleCustomLayer.createContext(),
-        ExampleCustomLayer.InitializeFunction,
-        ExampleCustomLayer.RenderFunction,
-        ExampleCustomLayer.ContextLostFunction, // Optional
-        ExampleCustomLayer.DeinitializeFunction);
+        ExampleCustomLayer.createContext());
       mapboxMap.addLayerBelow(customLayer, "building");
       fab.setImageResource(R.drawable.ic_layers_clear);
     }

--- a/platform/android/src/example_custom_layer.cpp
+++ b/platform/android/src/example_custom_layer.cpp
@@ -115,15 +115,6 @@ static const GLchar * fragmentShaderSource = "uniform highp vec4 fill_color; voi
 class ExampleCustomLayer: mbgl::style::CustomLayerHost {
 public:
     ~ExampleCustomLayer() {
-        __android_log_write(ANDROID_LOG_INFO, LOG_TAG, "~ExampleCustomLayer");
-        if (program) {
-            glDeleteBuffers(1, &buffer);
-            glDetachShader(program, vertexShader);
-            glDetachShader(program, fragmentShader);
-            glDeleteShader(vertexShader);
-            glDeleteShader(fragmentShader);
-            glDeleteProgram(program);
-        }
     }
 
     void initialize() {
@@ -159,7 +150,7 @@ public:
     }
 
     void render(const mbgl::style::CustomLayerRenderParameters&) {
-        mbgl::Log::Info(mbgl::Event::General, "Render");
+        __android_log_write(ANDROID_LOG_INFO, LOG_TAG, "Render");
         glUseProgram(program);
         glBindBuffer(GL_ARRAY_BUFFER, buffer);
         glEnableVertexAttribArray(a_pos);
@@ -180,10 +171,20 @@ public:
     }
 
     void contextLost() {
+        __android_log_write(ANDROID_LOG_INFO, LOG_TAG, "ContextLost");
+        program = 0;
     }
 
     void deinitialize() {
-
+        __android_log_write(ANDROID_LOG_INFO, LOG_TAG, "DeInitialize");
+        if (program) {
+            glDeleteBuffers(1, &buffer);
+            glDetachShader(program, vertexShader);
+            glDetachShader(program, fragmentShader);
+            glDeleteShader(vertexShader);
+            glDeleteShader(fragmentShader);
+            glDeleteProgram(program);
+        }
     }
 
     GLuint program = 0;

--- a/platform/android/src/style/layers/custom_layer.cpp
+++ b/platform/android/src/style/layers/custom_layer.cpp
@@ -7,14 +7,10 @@
 namespace mbgl {
 namespace android {
 
-    CustomLayer::CustomLayer(jni::JNIEnv& env, jni::String layerId, jni::jlong initializeFunction, jni::jlong renderFunction, jni::jlong contextLostFunction, jni::jlong deinitializeFunction, jni::jlong context)
+    CustomLayer::CustomLayer(jni::JNIEnv& env, jni::String layerId, jni::jlong host)
         : Layer(env, std::make_unique<mbgl::style::CustomLayer>(
                 jni::Make<std::string>(env, layerId),
-                reinterpret_cast<mbgl::style::CustomLayerInitializeFunction>(initializeFunction),
-                reinterpret_cast<mbgl::style::CustomLayerRenderFunction>(renderFunction),
-                reinterpret_cast<mbgl::style::CustomLayerContextLostFunction>(contextLostFunction),
-                reinterpret_cast<mbgl::style::CustomLayerDeinitializeFunction>(deinitializeFunction),
-                reinterpret_cast<void*>(context))
+                std::unique_ptr<mbgl::style::CustomLayerHost>(reinterpret_cast<mbgl::style::CustomLayerHost*>(host)))
                 ) {
     }
 
@@ -53,7 +49,7 @@ namespace android {
         // Register the peer
         jni::RegisterNativePeer<CustomLayer>(
             env, CustomLayer::javaClass, "nativePtr",
-            std::make_unique<CustomLayer, JNIEnv&, jni::String, jni::jlong, jni::jlong, jni::jlong, jni::jlong, jni::jlong>,
+            std::make_unique<CustomLayer, JNIEnv&, jni::String, jni::jlong>,
             "initialize",
             "finalize",
             METHOD(&CustomLayer::update, "nativeUpdate"));

--- a/platform/android/src/style/layers/custom_layer.hpp
+++ b/platform/android/src/style/layers/custom_layer.hpp
@@ -16,7 +16,7 @@ public:
 
     static void registerNative(jni::JNIEnv&);
 
-    CustomLayer(jni::JNIEnv&, jni::String, jni::jlong, jni::jlong, jni::jlong, jni::jlong, jni::jlong);
+    CustomLayer(jni::JNIEnv&, jni::String, jni::jlong);
 
     CustomLayer(mbgl::Map&, mbgl::style::CustomLayer&);
 

--- a/platform/darwin/src/MGLOpenGLStyleLayer.mm
+++ b/platform/darwin/src/MGLOpenGLStyleLayer.mm
@@ -1,4 +1,4 @@
-#import "MGLOpenGLStyleLayer.h"
+ #import "MGLOpenGLStyleLayer.h"
 
 #import "MGLMapView_Private.h"
 #import "MGLStyle_Private.h"
@@ -7,49 +7,50 @@
 #include <mbgl/style/layers/custom_layer.hpp>
 #include <mbgl/math/wrap.hpp>
 
-/**
- Runs the preparation handler block contained in the given context, which is
- implicitly an instance of `MGLOpenGLStyleLayer`.
+class MGLOpenGLLayerHost : public mbgl::style::CustomLayerHost {
+public:
+    MGLOpenGLLayerHost(MGLOpenGLStyleLayer *styleLayer) {
+        layerRef = styleLayer;
+        layer = nil;
+    }
+    ~MGLOpenGLLayerHost () {
+        layer = nil;
+    }
 
- @param context An `MGLOpenGLStyleLayer` instance that was provided as context
-    when creating an OpenGL style layer.
- */
-void MGLPrepareCustomStyleLayer(void *context) {
-    MGLOpenGLStyleLayer *layer = (__bridge MGLOpenGLStyleLayer *)context;
-    [layer didMoveToMapView:layer.style.mapView];
-}
+    void initialize() {
+        if (layerRef == nil) return;
+        else if (layer == nil) layer = layerRef;
 
-/**
- Runs the drawing handler block contained in the given context, which is
- implicitly an instance of `MGLOpenGLStyleLayer`.
+        [layer didMoveToMapView:layer.style.mapView];
+    }
 
- @param context An `MGLOpenGLStyleLayer` instance that was provided as context
-    when creating an OpenGL style layer.
- */
-void MGLDrawCustomStyleLayer(void *context, const mbgl::style::CustomLayerRenderParameters &params) {
-    MGLOpenGLStyleLayer *layer = (__bridge MGLOpenGLStyleLayer *)context;
-    MGLStyleLayerDrawingContext drawingContext = {
-        .size = CGSizeMake(params.width, params.height),
-        .centerCoordinate = CLLocationCoordinate2DMake(params.latitude, params.longitude),
-        .zoomLevel = params.zoom,
-        .direction = mbgl::util::wrap(params.bearing, 0., 360.),
-        .pitch = static_cast<CGFloat>(params.pitch),
-        .fieldOfView = static_cast<CGFloat>(params.fieldOfView),
-    };
-    [layer drawInMapView:layer.style.mapView withContext:drawingContext];
-}
+    void render(const mbgl::style::CustomLayerRenderParameters &params) {
+        assert(layerRef);
 
-/**
- Runs the completion handler block contained in the given context, which is
- implicitly an instance of `MGLOpenGLStyleLayer`.
+        MGLStyleLayerDrawingContext drawingContext = {
+            .size = CGSizeMake(params.width, params.height),
+            .centerCoordinate = CLLocationCoordinate2DMake(params.latitude, params.longitude),
+            .zoomLevel = params.zoom,
+            .direction = mbgl::util::wrap(params.bearing, 0., 360.),
+            .pitch = static_cast<CGFloat>(params.pitch),
+            .fieldOfView = static_cast<CGFloat>(params.fieldOfView),
+        };
+        [layer drawInMapView:layer.style.mapView withContext:drawingContext];
+    }
 
- @param context An `MGLOpenGLStyleLayer` instance that was provided as context
-    when creating an OpenGL style layer.
- */
-void MGLFinishCustomStyleLayer(void *context) {
-    MGLOpenGLStyleLayer *layer = (__bridge_transfer MGLOpenGLStyleLayer *)context;
-    [layer willMoveFromMapView:layer.style.mapView];
-}
+    void contextLost() {}
+
+    void deinitialize() {
+        if (layer == nil) return;
+
+        [layer willMoveFromMapView:layer.style.mapView];
+        layerRef = layer;
+        layer = nil;
+    }
+private:
+    __weak MGLOpenGLStyleLayer * layerRef;
+    MGLOpenGLStyleLayer * layer = nil;
+};
 
 /**
  An `MGLOpenGLStyleLayer` is a style layer that is rendered by OpenGL code that
@@ -98,10 +99,7 @@ void MGLFinishCustomStyleLayer(void *context) {
  */
 - (instancetype)initWithIdentifier:(NSString *)identifier {
     auto layer = std::make_unique<mbgl::style::CustomLayer>(identifier.UTF8String,
-                                                            MGLPrepareCustomStyleLayer,
-                                                            MGLDrawCustomStyleLayer,
-                                                            MGLFinishCustomStyleLayer,
-                                                            (__bridge_retained void *)self);
+                                                            std::make_unique<MGLOpenGLLayerHost>(self));
     return self = [super initWithPendingLayer:std::move(layer)];
 }
 
@@ -116,7 +114,9 @@ void MGLFinishCustomStyleLayer(void *context) {
         [NSException raise:@"MGLLayerReuseException"
                     format:@"%@ cannot be added to more than one MGLStyle at a time.", self];
     }
+    _style.openGLLayers[self.identifier] = nil;
     _style = style;
+    _style.openGLLayers[self.identifier] = self;
 }
 
 - (void)addToStyle:(MGLStyle *)style belowLayer:(MGLStyleLayer *)otherLayer {

--- a/platform/darwin/src/MGLOpenGLStyleLayer.mm
+++ b/platform/darwin/src/MGLOpenGLStyleLayer.mm
@@ -1,4 +1,4 @@
- #import "MGLOpenGLStyleLayer.h"
+#import "MGLOpenGLStyleLayer.h"
 
 #import "MGLMapView_Private.h"
 #import "MGLStyle_Private.h"
@@ -13,9 +13,6 @@ public:
         layerRef = styleLayer;
         layer = nil;
     }
-    ~MGLOpenGLLayerHost () {
-        layer = nil;
-    }
 
     void initialize() {
         if (layerRef == nil) return;
@@ -25,7 +22,7 @@ public:
     }
 
     void render(const mbgl::style::CustomLayerRenderParameters &params) {
-        assert(layerRef);
+        if(!layer) return;
 
         MGLStyleLayerDrawingContext drawingContext = {
             .size = CGSizeMake(params.width, params.height),
@@ -108,24 +105,15 @@ private:
 }
 
 #pragma mark - Adding to and removing from a map view
-
-- (void)setStyle:(MGLStyle *)style {
-    if (_style && style) {
-        [NSException raise:@"MGLLayerReuseException"
-                    format:@"%@ cannot be added to more than one MGLStyle at a time.", self];
-    }
-    _style.openGLLayers[self.identifier] = nil;
-    _style = style;
-    _style.openGLLayers[self.identifier] = self;
-}
-
 - (void)addToStyle:(MGLStyle *)style belowLayer:(MGLStyleLayer *)otherLayer {
     self.style = style;
+    self.style.openGLLayers[self.identifier] = self;
     [super addToStyle:style belowLayer:otherLayer];
 }
 
 - (void)removeFromStyle:(MGLStyle *)style {
     [super removeFromStyle:style];
+    self.style.openGLLayers[self.identifier] = nil;
     self.style = nil;
 }
 

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -83,6 +83,7 @@
 @property (nonatomic, readonly, weak) MGLMapView *mapView;
 @property (nonatomic, readonly) mbgl::style::Style *rawStyle;
 @property (readonly, copy, nullable) NSURL *URL;
+@property (nonatomic, readwrite, strong) NS_MUTABLE_DICTIONARY_OF(NSString *, MGLOpenGLStyleLayer *) *openGLLayers;
 @property (nonatomic) NS_MUTABLE_DICTIONARY_OF(NSString *, NS_DICTIONARY_OF(NSObject *, MGLTextLanguage *) *) *localizedLayersByIdentifier;
 
 @end
@@ -125,6 +126,7 @@ static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
     if (self = [super init]) {
         _mapView = mapView;
         _rawStyle = rawStyle;
+        _openGLLayers = [NSMutableDictionary dictionary];
         _localizedLayersByIdentifier = [NSMutableDictionary dictionary];
     }
     return self;

--- a/platform/darwin/src/MGLStyle_Private.h
+++ b/platform/darwin/src/MGLStyle_Private.h
@@ -25,7 +25,7 @@ namespace mbgl {
 @property (nonatomic, readonly) mbgl::style::Style *rawStyle;
 
 - (nullable NS_ARRAY_OF(MGLAttributionInfo *) *)attributionInfosWithFontSize:(CGFloat)fontSize linkColor:(nullable MGLColor *)linkColor;
-
+@property (nonatomic, readonly, strong) NS_MUTABLE_DICTIONARY_OF(NSString *, MGLOpenGLStyleLayer *) *openGLLayers;
 - (void)setStyleClasses:(NS_ARRAY_OF(NSString *) *)appliedClasses transitionDuration:(NSTimeInterval)transitionDuration;
 
 @end

--- a/platform/ios/Integration Tests/MBGLIntegrationTests.m
+++ b/platform/ios/Integration Tests/MBGLIntegrationTests.m
@@ -70,8 +70,34 @@
     addRemoveGLLayer();
 }
 
-//- (void)testOpenGLLayerDoesNotLeakWhenCreatedAndDestroyedWithoutAddingToStyle {
-//    XCTFail(@"Not yet implemented");
-//}
+- (void)testReusingOpenGLLayer {
+    NSTimeInterval waitInterval = 0.01;
+
+    MGLOpenGLStyleLayer *layer = [[MGLOpenGLStyleLayer alloc] initWithIdentifier:@"gl-layer"];
+    [self.style insertLayer:layer atIndex:0];
+
+    [[NSRunLoop currentRunLoop] runUntilDate:[[NSDate date] dateByAddingTimeInterval:waitInterval]];
+
+    [self.style removeLayer:layer];
+
+    [[NSRunLoop currentRunLoop] runUntilDate:[[NSDate date] dateByAddingTimeInterval:waitInterval]];
+
+    [self.style insertLayer:layer atIndex:0];
+
+    [[NSRunLoop currentRunLoop] runUntilDate:[[NSDate date] dateByAddingTimeInterval:waitInterval]];
+
+    [self.style removeLayer:layer];
+
+    [[NSRunLoop currentRunLoop] runUntilDate:[[NSDate date] dateByAddingTimeInterval:waitInterval]];
+}
+
+// This test does not strictly need to be in this test file/target. Including here for convenience.
+- (void)testOpenGLLayerDoesNotLeakWhenCreatedAndDestroyedWithoutAddingToStyle {
+    MGLOpenGLStyleLayer *layer = [[MGLOpenGLStyleLayer alloc] initWithIdentifier:@"gl-layer"];
+    __weak id weakLayer = layer;
+    layer = nil;
+    
+    XCTAssertNil(weakLayer);
+}
 
 @end

--- a/platform/ios/Integration Tests/MBGLIntegrationTests.m
+++ b/platform/ios/Integration Tests/MBGLIntegrationTests.m
@@ -1,6 +1,6 @@
 #import <XCTest/XCTest.h>
-
-@import Mapbox;
+#import <objc/message.h>
+#import <Mapbox/Mapbox.h>
 
 @interface MBGLIntegrationTests : XCTestCase <MGLMapViewDelegate>
 
@@ -11,7 +11,10 @@
 
 @implementation MBGLIntegrationTests {
     XCTestExpectation *_styleLoadingExpectation;
+    XCTestExpectation *_renderFinishedExpectation;
 }
+
+#pragma mark - Setup/Teardown
 
 - (void)setUp {
     [super setUp];
@@ -32,6 +35,16 @@
     [window makeKeyAndVisible];
 }
 
+- (void)tearDown {
+    _styleLoadingExpectation = nil;
+    self.mapView = nil;
+    self.style = nil;
+
+    [super tearDown];
+}
+
+#pragma mark - MGLMapViewDelegate
+
 - (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {
     XCTAssertNotNil(mapView.style);
     XCTAssertEqual(mapView.style, style);
@@ -39,30 +52,112 @@
     [_styleLoadingExpectation fulfill];
 }
 
-- (void)tearDown {
-    _styleLoadingExpectation = nil;
-    self.mapView = nil;
+- (void)mapViewDidFinishRenderingFrame:(MGLMapView *)mapView fullyRendered:(__unused BOOL)fullyRendered {
+    [_renderFinishedExpectation fulfill];
+    _renderFinishedExpectation = nil;
+}
 
-    [super tearDown];
+#pragma mark - Utilities
+
+- (void)waitForMapViewToBeRendered {
+    [self.mapView setNeedsDisplay];
+    _renderFinishedExpectation = [self expectationWithDescription:@"Map view should be rendered"];
+    [self waitForExpectations:@[_renderFinishedExpectation] timeout:1];
 }
 
 - (MGLStyle *)style {
     return self.mapView.style;
 }
 
+#pragma mark - Tests
+
+// This test does not strictly need to be in this test file/target. Including here for convenience.
+- (void)testOpenGLLayerDoesNotLeakWhenCreatedAndDestroyedWithoutAddingToStyle {
+    MGLOpenGLStyleLayer *layer = [[MGLOpenGLStyleLayer alloc] initWithIdentifier:@"gl-layer"];
+    __weak id weakLayer = layer;
+    layer = nil;
+
+    XCTAssertNil(weakLayer);
+}
+
+- (void)testAddingRemovingOpenGLLayerWithoutRendering {
+    XCTAssertNotNil(self.style);
+
+    void(^addRemoveGLLayer)(void) = ^{
+        __weak id weakLayer = nil;
+
+        @autoreleasepool {
+            MGLOpenGLStyleLayer *layer = [[MGLOpenGLStyleLayer alloc] initWithIdentifier:@"gl-layer"];
+            [self.style insertLayer:layer atIndex:0];
+            weakLayer = layer;
+
+            // Nil the layer prior to remove to ensure it's being retained
+            layer = nil;
+            [self.style removeLayer:weakLayer];
+        }
+
+        XCTAssertNil(weakLayer);
+    };
+
+    addRemoveGLLayer();
+    addRemoveGLLayer();
+    addRemoveGLLayer();
+}
+
+- (void)testReusingOpenGLLayerIdentifier {
+    __weak MGLOpenGLStyleLayer *weakLayer2;
+
+    @autoreleasepool {
+        MGLOpenGLStyleLayer *layer1 = [[MGLOpenGLStyleLayer alloc] initWithIdentifier:@"gl-layer"];
+        [self.style insertLayer:layer1 atIndex:0];
+        [self waitForMapViewToBeRendered];
+        [self.style removeLayer:layer1];
+
+        MGLOpenGLStyleLayer *layer2 = [[MGLOpenGLStyleLayer alloc] initWithIdentifier:@"gl-layer"];
+        weakLayer2 = layer2;
+
+        XCTAssertNotNil(layer2);
+        XCTAssert(layer1 != layer2);
+
+        [self.style insertLayer:layer2 atIndex:0];
+        [self waitForMapViewToBeRendered];
+        [self.style removeLayer:layer2];
+
+        XCTAssertNil([layer1 style]);
+        XCTAssertNil([layer2 style]);
+    }
+
+    // At this point, layer2 (and layer1) should still be around,
+    // since the render process needs to keep a reference to them.
+    XCTAssertNotNil(weakLayer2);
+
+    // Let render loop run enough to release the layers
+    [self waitForMapViewToBeRendered];
+    XCTAssertNil(weakLayer2);
+}
+
 - (void)testAddingRemovingOpenGLLayer {
     XCTAssertNotNil(self.style);
 
     void(^addRemoveGLLayer)(void) = ^{
-        MGLOpenGLStyleLayer *layer = [[MGLOpenGLStyleLayer alloc] initWithIdentifier:@"gl-layer"];
-        [self.style insertLayer:layer atIndex:0];
-        layer = nil;
 
-        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate date]];
+        __weak id retrievedLayer = nil;
+        
+        @autoreleasepool {
+            MGLOpenGLStyleLayer *layer = [[MGLOpenGLStyleLayer alloc] initWithIdentifier:@"gl-layer"];
+            [self.style insertLayer:layer atIndex:0];
+            layer = nil;
+            
+            [self waitForMapViewToBeRendered];
 
-        id retrievedLayer = [self.style layerWithIdentifier:@"gl-layer"];
-        XCTAssertNotNil(retrievedLayer);
-        [self.style removeLayer:retrievedLayer];
+            retrievedLayer = [self.style layerWithIdentifier:@"gl-layer"];
+            XCTAssertNotNil(retrievedLayer);
+
+            [self.style removeLayer:retrievedLayer];
+            [self waitForMapViewToBeRendered];
+        }
+
+        XCTAssertNil(retrievedLayer);
     };
 
     addRemoveGLLayer();
@@ -71,33 +166,97 @@
 }
 
 - (void)testReusingOpenGLLayer {
-    NSTimeInterval waitInterval = 0.01;
-
     MGLOpenGLStyleLayer *layer = [[MGLOpenGLStyleLayer alloc] initWithIdentifier:@"gl-layer"];
     [self.style insertLayer:layer atIndex:0];
-
-    [[NSRunLoop currentRunLoop] runUntilDate:[[NSDate date] dateByAddingTimeInterval:waitInterval]];
-
+    [self waitForMapViewToBeRendered];
+    
     [self.style removeLayer:layer];
-
-    [[NSRunLoop currentRunLoop] runUntilDate:[[NSDate date] dateByAddingTimeInterval:waitInterval]];
-
+    [self waitForMapViewToBeRendered];
+    
     [self.style insertLayer:layer atIndex:0];
-
-    [[NSRunLoop currentRunLoop] runUntilDate:[[NSDate date] dateByAddingTimeInterval:waitInterval]];
+    [self waitForMapViewToBeRendered];
 
     [self.style removeLayer:layer];
-
-    [[NSRunLoop currentRunLoop] runUntilDate:[[NSDate date] dateByAddingTimeInterval:waitInterval]];
+    [self waitForMapViewToBeRendered];
 }
 
-// This test does not strictly need to be in this test file/target. Including here for convenience.
-- (void)testOpenGLLayerDoesNotLeakWhenCreatedAndDestroyedWithoutAddingToStyle {
-    MGLOpenGLStyleLayer *layer = [[MGLOpenGLStyleLayer alloc] initWithIdentifier:@"gl-layer"];
-    __weak id weakLayer = layer;
-    layer = nil;
-    
+- (void)testOpenGLLayerDoesNotLeakWhenRemovedFromStyle {
+    __weak id weakLayer;
+    @autoreleasepool {
+        MGLOpenGLStyleLayer *layer = [[MGLOpenGLStyleLayer alloc] initWithIdentifier:@"gl-layer"];
+        weakLayer = layer;
+        [self.style insertLayer:layer atIndex:0];
+        layer = nil;
+
+        [self waitForMapViewToBeRendered];
+        [self.style removeLayer:[self.style layerWithIdentifier:@"gl-layer"]];
+    }
+
+    MGLStyleLayer *layer2 = weakLayer;
+
+    XCTAssertNotNil(weakLayer);
+    [self waitForMapViewToBeRendered];
+
+    layer2 = nil;
+    XCTAssertNil(weakLayer);
+}
+
+- (void)testOpenGLLayerDoesNotLeakWhenStyleChanged {
+    __weak MGLOpenGLStyleLayer *weakLayer;
+
+    @autoreleasepool {
+        {
+            MGLOpenGLStyleLayer *layer = [[MGLOpenGLStyleLayer alloc] initWithIdentifier:@"gl-layer"];
+            weakLayer = layer;
+            [self.style insertLayer:layer atIndex:0];
+            layer = nil;
+        }
+    }
+
+    XCTAssertNotNil(weakLayer);
+
+    [self waitForMapViewToBeRendered];
+
+    MGLStyleLayer *layer2 = [self.mapView.style layerWithIdentifier:@"gl-layer"];
+
+    NSURL *styleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"one-liner" withExtension:@"json"];
+    _styleLoadingExpectation = [self expectationWithDescription:@"Map view should finish loading style."];
+    [self.mapView setStyleURL:styleURL];
+    [self waitForExpectations:@[_styleLoadingExpectation] timeout:10];
+
+    // At this point the C++ CustomLayer will have been destroyed, and the rawLayer pointer has been NULLed
+    XCTAssert(weakLayer == layer2);
+    XCTAssertNotNil(weakLayer);
+
+    // Asking the style for the layer should return nil
+    MGLStyleLayer *layer3 = [self.mapView.style layerWithIdentifier:@"gl-layer"];
+    XCTAssertNil(layer3);
+}
+
+
+- (void)testOpenGLLayerDoesNotLeakWhenMapViewDeallocs {
+    __weak id weakLayer;
+ 
+    @autoreleasepool {
+
+        NSURL *styleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"one-liner" withExtension:@"json"];
+        MGLMapView *mapView2 = [[MGLMapView alloc] initWithFrame:UIScreen.mainScreen.bounds styleURL:styleURL];
+        mapView2.delegate = self;
+
+        XCTAssertNil(mapView2.style);
+
+        _styleLoadingExpectation = [self expectationWithDescription:@"Map view should finish loading style."];
+        [self waitForExpectationsWithTimeout:1 handler:nil];
+
+        MGLOpenGLStyleLayer *layer = [[MGLOpenGLStyleLayer alloc] initWithIdentifier:@"gl-layer"];
+        weakLayer = layer;
+        [mapView2.style insertLayer:layer atIndex:0];
+        layer = nil;
+
+        [self waitForMapViewToBeRendered];
+    }
     XCTAssertNil(weakLayer);
 }
 
 @end
+

--- a/platform/qt/include/qmapbox.hpp
+++ b/platform/qt/include/qmapbox.hpp
@@ -112,12 +112,16 @@ struct Q_MAPBOXGL_EXPORT CustomLayerRenderParameters {
     double zoom;
     double bearing;
     double pitch;
-    double altitude;
+    double fieldOfView;
 };
 
-typedef void (*CustomLayerInitializeFunction)(void* context) ;
-typedef void (*CustomLayerRenderFunction)(void* context, const CustomLayerRenderParameters&);
-typedef void (*CustomLayerDeinitializeFunction)(void* context);
+class Q_MAPBOXGL_EXPORT CustomLayerHostInterface {
+public:
+    virtual ~CustomLayerHostInterface() = default;
+    virtual void initialize() = 0;
+    virtual void render(const CustomLayerRenderParameters&) = 0;
+    virtual void deinitialize() = 0;
+};
 
 } // namespace QMapbox
 

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -223,10 +223,7 @@ public:
     void removeImage(const QString &name);
 
     void addCustomLayer(const QString &id,
-        QMapbox::CustomLayerInitializeFunction,
-        QMapbox::CustomLayerRenderFunction,
-        QMapbox::CustomLayerDeinitializeFunction,
-        void* context,
+        QScopedPointer<QMapbox::CustomLayerHostInterface>& host,
         const QString& before = QString());
     void addLayer(const QVariantMap &params, const QString& before = QString());
     bool layerExists(const QString &id);

--- a/platform/qt/src/qmapbox.cpp
+++ b/platform/qt/src/qmapbox.cpp
@@ -158,27 +158,9 @@ namespace QMapbox {
 */
 
 /*!
-    \typedef QMapbox::CustomLayerDeinitializeFunction
+    \class QMapbox::CustomLayerHostInterface
 
-    Represents a callback to be called when destroying a custom layer.
-
-    \warning This is used for delegating the rendering of a layer to the user of
-    this API and is not officially supported. Use at your own risk.
-*/
-
-/*!
-    \typedef QMapbox::CustomLayerInitializeFunction
-
-    Represents a callback to be called when initializing a custom layer.
-
-    \warning This is used for delegating the rendering of a layer to the user of
-    this API and is not officially supported. Use at your own risk.
-*/
-
-/*!
-    \typedef QMapbox::CustomLayerRenderFunction
-
-    Represents a callback to be called on each render pass for a custom layer.
+    Represents a host interface to be implemented for rendering custom layers.
 
     \warning This is used for delegating the rendering of a layer to the user of
     this API and is not officially supported. Use at your own risk.

--- a/src/mbgl/renderer/layers/render_custom_layer.cpp
+++ b/src/mbgl/renderer/layers/render_custom_layer.cpp
@@ -12,17 +12,16 @@ namespace mbgl {
 using namespace style;
 
 RenderCustomLayer::RenderCustomLayer(Immutable<style::CustomLayer::Impl> _impl)
-    : RenderLayer(LayerType::Custom, _impl) {
+    : RenderLayer(LayerType::Custom, _impl), host(_impl->host) {
+    host->initialize();
 }
 
 RenderCustomLayer::~RenderCustomLayer() {
     assert(BackendScope::exists());
-    if (initialized) {
-        if (contextDestroyed && impl().contextLostFn ) {
-            impl().contextLostFn(impl().context);
-        } else if (!contextDestroyed && impl().deinitializeFn) {
-            impl().deinitializeFn(impl().context);
-        }
+    if (contextDestroyed) {
+        host->contextLost();
+    } else if (!contextDestroyed) {
+        host->deinitialize();
     }
 }
 
@@ -44,15 +43,13 @@ std::unique_ptr<Bucket> RenderCustomLayer::createBucket(const BucketParameters&,
 }
 
 void RenderCustomLayer::render(PaintParameters& paintParameters, RenderSource*) {
-    if (context != impl().context || !initialized) {
+    if (host != impl().host) {
         //If the context changed, deinitialize the previous one before initializing the new one.
-        if (context && !contextDestroyed && impl().deinitializeFn) {
-            MBGL_CHECK_ERROR(impl().deinitializeFn(context));
+        if (host && !contextDestroyed) {
+            MBGL_CHECK_ERROR(host->deinitialize());
         }
-        context = impl().context;
-        assert(impl().initializeFn);
-        MBGL_CHECK_ERROR(impl().initializeFn(impl().context));
-        initialized = true;
+        host = impl().host;
+        MBGL_CHECK_ERROR(host->initialize());
     }
 
     gl::Context& glContext = paintParameters.context;
@@ -75,8 +72,7 @@ void RenderCustomLayer::render(PaintParameters& paintParameters, RenderSource*) 
     parameters.pitch = state.getPitch();
     parameters.fieldOfView = state.getFieldOfView();
 
-    assert(impl().renderFn);
-    MBGL_CHECK_ERROR(impl().renderFn(context, parameters));
+    MBGL_CHECK_ERROR(host->render(parameters));
 
     // Reset the view back to our original one, just in case the CustomLayer changed
     // the viewport or Framebuffer.

--- a/src/mbgl/renderer/layers/render_custom_layer.cpp
+++ b/src/mbgl/renderer/layers/render_custom_layer.cpp
@@ -13,6 +13,7 @@ using namespace style;
 
 RenderCustomLayer::RenderCustomLayer(Immutable<style::CustomLayer::Impl> _impl)
     : RenderLayer(LayerType::Custom, _impl), host(_impl->host) {
+    assert(BackendScope::exists());
     host->initialize();
 }
 
@@ -20,7 +21,7 @@ RenderCustomLayer::~RenderCustomLayer() {
     assert(BackendScope::exists());
     if (contextDestroyed) {
         host->contextLost();
-    } else if (!contextDestroyed) {
+    } else {
         host->deinitialize();
     }
 }

--- a/src/mbgl/renderer/layers/render_custom_layer.hpp
+++ b/src/mbgl/renderer/layers/render_custom_layer.hpp
@@ -24,9 +24,8 @@ public:
     };
 
 private:
-    bool initialized = false;
     bool contextDestroyed = false;
-    void * context = nullptr;
+    std::shared_ptr<style::CustomLayerHost> host;
 };
 
 template <>

--- a/src/mbgl/style/layers/custom_layer.cpp
+++ b/src/mbgl/style/layers/custom_layer.cpp
@@ -6,20 +6,8 @@ namespace mbgl {
 namespace style {
 
 CustomLayer::CustomLayer(const std::string& layerID,
-                         CustomLayerInitializeFunction init,
-                         CustomLayerRenderFunction render,
-                         CustomLayerContextLostFunction contextLost,
-                         CustomLayerDeinitializeFunction deinit,
-                         void* context)
-        : Layer(makeMutable<Impl>(layerID, init, render, contextLost, deinit, context)) {
-}
-
-CustomLayer::CustomLayer(const std::string& layerID,
-                         CustomLayerInitializeFunction init,
-                         CustomLayerRenderFunction render,
-                         CustomLayerDeinitializeFunction deinit,
-                         void* context)
-    : Layer(makeMutable<Impl>(layerID, init, render, nullptr, deinit, context)) {
+                         std::unique_ptr<CustomLayerHost> host)
+    : Layer(makeMutable<Impl>(layerID, std::move(host))) {
 }
 
 CustomLayer::~CustomLayer() = default;

--- a/src/mbgl/style/layers/custom_layer.cpp
+++ b/src/mbgl/style/layers/custom_layer.cpp
@@ -26,6 +26,7 @@ std::unique_ptr<Layer> CustomLayer::cloneRef(const std::string&) const {
 }
 
 // Visibility
+
 void CustomLayer::setVisibility(VisibilityType value) {
     if (value == getVisibility())
         return;

--- a/src/mbgl/style/layers/custom_layer.cpp
+++ b/src/mbgl/style/layers/custom_layer.cpp
@@ -26,7 +26,6 @@ std::unique_ptr<Layer> CustomLayer::cloneRef(const std::string&) const {
 }
 
 // Visibility
-
 void CustomLayer::setVisibility(VisibilityType value) {
     if (value == getVisibility())
         return;

--- a/src/mbgl/style/layers/custom_layer_impl.cpp
+++ b/src/mbgl/style/layers/custom_layer_impl.cpp
@@ -4,17 +4,9 @@ namespace mbgl {
 namespace style {
 
 CustomLayer::Impl::Impl(const std::string& id_,
-                         CustomLayerInitializeFunction initializeFn_,
-                         CustomLayerRenderFunction renderFn_,
-                         CustomLayerContextLostFunction contextLostFn_,
-                         CustomLayerDeinitializeFunction deinitializeFn_,
-                         void* context_)
+                        std::unique_ptr<CustomLayerHost> host_)
     : Layer::Impl(LayerType::Custom, id_, std::string()) {
-    initializeFn = initializeFn_;
-    renderFn = renderFn_;
-    deinitializeFn = deinitializeFn_;
-    contextLostFn = contextLostFn_;
-    context = context_;
+    host = std::move(host_);
 }
 
 bool CustomLayer::Impl::hasLayoutDifference(const Layer::Impl&) const {

--- a/src/mbgl/style/layers/custom_layer_impl.hpp
+++ b/src/mbgl/style/layers/custom_layer_impl.hpp
@@ -3,6 +3,8 @@
 #include <mbgl/style/layer_impl.hpp>
 #include <mbgl/style/layers/custom_layer.hpp>
 
+#include <memory>
+
 namespace mbgl {
 
 class TransformState;
@@ -12,20 +14,12 @@ namespace style {
 class CustomLayer::Impl : public Layer::Impl {
 public:
     Impl(const std::string& id,
-         CustomLayerInitializeFunction,
-         CustomLayerRenderFunction,
-         CustomLayerContextLostFunction,
-         CustomLayerDeinitializeFunction,
-         void* context);
+         std::unique_ptr<CustomLayerHost> host);
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
 
-    CustomLayerInitializeFunction initializeFn = nullptr;
-    CustomLayerRenderFunction renderFn = nullptr;
-    CustomLayerContextLostFunction contextLostFn = nullptr;
-    CustomLayerDeinitializeFunction deinitializeFn = nullptr;
-    void* context = nullptr;
+    std::shared_ptr<CustomLayerHost> host;
 };
 
 } // namespace style

--- a/test/api/custom_layer.test.cpp
+++ b/test/api/custom_layer.test.cpp
@@ -34,7 +34,7 @@ void main() {
 // layer implementation because it is intended to reflect how someone using custom layers
 // might actually write their own implementation.
 
-class TestLayer {
+class TestLayer : public mbgl::style::CustomLayerHost {
 public:
     ~TestLayer() {
         if (program) {
@@ -67,13 +67,17 @@ public:
         MBGL_CHECK_ERROR(glBufferData(GL_ARRAY_BUFFER, 6 * sizeof(GLfloat), triangle, GL_STATIC_DRAW));
     }
 
-    void render() {
+    void render(const mbgl::style::CustomLayerRenderParameters&) {
         MBGL_CHECK_ERROR(glUseProgram(program));
         MBGL_CHECK_ERROR(glBindBuffer(GL_ARRAY_BUFFER, buffer));
         MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
         MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_FLOAT, GL_FALSE, 0, nullptr));
         MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLE_STRIP, 0, 3));
     }
+
+    void contextLost() {}
+
+    void deinitialize() {}
 
     GLuint program = 0;
     GLuint vertexShader = 0;
@@ -95,15 +99,7 @@ TEST(CustomLayer, Basic) {
     map.setLatLngZoom({ 37.8, -122.5 }, 10);
     map.getStyle().addLayer(std::make_unique<CustomLayer>(
         "custom",
-        [] (void* context) {
-            reinterpret_cast<TestLayer*>(context)->initialize();
-        },
-        [] (void* context, const CustomLayerRenderParameters&) {
-            reinterpret_cast<TestLayer*>(context)->render();
-        },
-        [] (void* context) {
-            delete reinterpret_cast<TestLayer*>(context);
-        }, new TestLayer()));
+        std::make_unique<TestLayer>()));
 
     auto layer = std::make_unique<FillLayer>("landcover", "mapbox");
     layer->setSourceLayer("landcover");

--- a/test/api/custom_layer.test.cpp
+++ b/test/api/custom_layer.test.cpp
@@ -36,17 +36,6 @@ void main() {
 
 class TestLayer : public mbgl::style::CustomLayerHost {
 public:
-    ~TestLayer() {
-        if (program) {
-            MBGL_CHECK_ERROR(glDeleteBuffers(1, &buffer));
-            MBGL_CHECK_ERROR(glDetachShader(program, vertexShader));
-            MBGL_CHECK_ERROR(glDetachShader(program, fragmentShader));
-            MBGL_CHECK_ERROR(glDeleteShader(vertexShader));
-            MBGL_CHECK_ERROR(glDeleteShader(fragmentShader));
-            MBGL_CHECK_ERROR(glDeleteProgram(program));
-        }
-    }
-
     void initialize() {
         program = MBGL_CHECK_ERROR(glCreateProgram());
         vertexShader = MBGL_CHECK_ERROR(glCreateShader(GL_VERTEX_SHADER));
@@ -77,7 +66,16 @@ public:
 
     void contextLost() {}
 
-    void deinitialize() {}
+    void deinitialize() {
+         if (program) {
+                MBGL_CHECK_ERROR(glDeleteBuffers(1, &buffer));
+                MBGL_CHECK_ERROR(glDetachShader(program, vertexShader));
+                MBGL_CHECK_ERROR(glDetachShader(program, fragmentShader));
+                MBGL_CHECK_ERROR(glDeleteShader(vertexShader));
+                MBGL_CHECK_ERROR(glDeleteShader(fragmentShader));
+                MBGL_CHECK_ERROR(glDeleteProgram(program));
+            }
+    }
 
     GLuint program = 0;
     GLuint vertexShader = 0;


### PR DESCRIPTION
Fixes #11143.
Fixes #10771.

`CustomLayer`s are a special class of style layer where the core API delegates rendering of the layer to external code. 

With the change to asynchronous rendering, the `RenderCustomLayer` may call out to the external code to initialize, render, or clean-up outside of the `CustomLayer`'s lifecycle. For example, a custom layer added to the current map style, followed by a different style being set on the map.

In addition to #11143, a number of other issues related to custom layers have been opened/addressed recently: #10771, #10755, #10765, #11343. 

The existing API using a`void *` context object and function pointers, doesn't provide any lifecycle information. The context object needs to exist for the lifetime of the `CustomLayer` (`CustomLayer::Impl` to be more specific), and the `RenderCustomLayer`. This PR proposes using a `shared_ptr<>` to ensure that the context object has the required lifetime.

Since a `shared_ptr<>` cannot be used with `void *`, a host interface `CustomLayerHost` with the former function pointers converted to equivalent events.

On iOS/macOS, the SDK uses the peer style layer `MGLOpenGLStyleLayer` as the context object, creating a tenuous chain of ownership. The implementation of `CustomLayerHost` addresses  the retain/release issue described in [this comment](https://github.com/mapbox/mapbox-gl-native/issues/11143#issuecomment-368653965).

`RenderCustomLayer` calls `CustomLayerHost::initialize()`  in its constructor to ensure that the peer style layer is retained, even if the style (and `CustomLayer::Impl`) are changed prematurely.

### TODO
- [x] Pull in integration tests spread across a couple other branches
- [ ] Document and communicate API changes

cc @julianrex @lilykaiser @jfirebaugh @akitchen @1ec5 