### PR TITLE
Rework logical condition convenience expressions 

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
@@ -236,36 +236,36 @@ public class Expression {
   /**
    * Returns true if the input values are equal, false otherwise.
    *
-   * @param compareOne the first boolean
+   * @param compareOne the first expression
    * @param compareTwo the second boolean
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-==">Style specification</a>
    */
-  public static Expression eq(boolean compareOne, boolean compareTwo) {
+  public static Expression eq(Expression compareOne, boolean compareTwo) {
+    return eq(compareOne, literal(compareTwo));
+  }
+
+  /**
+   * Returns true if the input values are equal, false otherwise.
+   *
+   * @param compareOne the first expression
+   * @param compareTwo the second number
+   * @return expression
+   * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-==">Style specification</a>
+   */
+  public static Expression eq(@NonNull Expression compareOne, @NonNull String compareTwo) {
     return eq(literal(compareOne), literal(compareTwo));
   }
 
   /**
    * Returns true if the input values are equal, false otherwise.
    *
-   * @param compareOne the first number
+   * @param compareOne the first expression
    * @param compareTwo the second number
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-==">Style specification</a>
    */
-  public static Expression eq(@NonNull String compareOne, @NonNull String compareTwo) {
-    return eq(literal(compareOne), literal(compareTwo));
-  }
-
-  /**
-   * Returns true if the input values are equal, false otherwise.
-   *
-   * @param compareOne the first number
-   * @param compareTwo the second number
-   * @return expression
-   * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-==">Style specification</a>
-   */
-  public static Expression eq(@NonNull Number compareOne, @NonNull Number compareTwo) {
+  public static Expression eq(@NonNull Expression compareOne, @NonNull Number compareTwo) {
     return eq(literal(compareOne), literal(compareTwo));
   }
 
@@ -285,36 +285,36 @@ public class Expression {
   /**
    * Returns true if the input values are equal, false otherwise.
    *
-   * @param compareOne the first boolean
+   * @param compareOne the first expression
    * @param compareTwo the second boolean
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-!=">Style specification</a>
    */
-  public static Expression neq(boolean compareOne, boolean compareTwo) {
+  public static Expression neq(Expression compareOne, boolean compareTwo) {
     return new Expression("!=", literal(compareOne), literal(compareTwo));
   }
-
+//fixme
   /**
    * Returns `true` if the input values are not equal, `false` otherwise.
    *
-   * @param compareOne the first string
+   * @param compareOne the first expression
    * @param compareTwo the second string
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-!=">Style specification</a>
    */
-  public static Expression neq(@NonNull String compareOne, @NonNull String compareTwo) {
+  public static Expression neq(@NonNull Expression compareOne, @NonNull String compareTwo) {
     return new Expression("!=", literal(compareOne), literal(compareTwo));
   }
 
   /**
    * Returns `true` if the input values are not equal, `false` otherwise.
    *
-   * @param compareOne the first number
+   * @param compareOne the first expression
    * @param compareTwo the second number
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-!=">Style specification</a>
    */
-  public static Expression neq(@NonNull Number compareOne, @NonNull Number compareTwo) {
+  public static Expression neq(@NonNull Expression compareOne, @NonNull Number compareTwo) {
     return new Expression("!=", literal(compareOne), literal(compareTwo));
   }
 
@@ -334,24 +334,24 @@ public class Expression {
   /**
    * Returns true if the first input is strictly greater than the second, false otherwise.
    *
-   * @param compareOne the first number
+   * @param compareOne the first expression
    * @param compareTwo the second number
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions->">Style specification</a>
    */
-  public static Expression gt(@NonNull Number compareOne, @NonNull Number compareTwo) {
+  public static Expression gt(@NonNull Expression compareOne, @NonNull Number compareTwo) {
     return new Expression(">", literal(compareOne), literal(compareTwo));
   }
 
   /**
    * Returns true if the first input is strictly greater than the second, false otherwise.
    *
-   * @param compareOne the first string
+   * @param compareOne the first expression
    * @param compareTwo the second string
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions->">Style specification</a>
    */
-  public static Expression gt(@NonNull String compareOne, @NonNull String compareTwo) {
+  public static Expression gt(@NonNull Expression compareOne, @NonNull String compareTwo) {
     return new Expression(">", literal(compareOne), literal(compareTwo));
   }
 
@@ -359,7 +359,7 @@ public class Expression {
    * Returns true if the first input is strictly less than the second, false otherwise.
    * The inputs must be numbers or strings, and both of the same type.
    *
-   * @param compareOne the first number
+   * @param compareOne the first expression
    * @param compareTwo the second number
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-<">Style specification</a>
@@ -371,24 +371,24 @@ public class Expression {
   /**
    * Returns true if the first input is strictly less than the second, false otherwise.
    *
-   * @param compareOne the first number
+   * @param compareOne the first expression
    * @param compareTwo the second number
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-<">Style specification</a>
    */
-  public static Expression lt(@NonNull Number compareOne, @NonNull Number compareTwo) {
+  public static Expression lt(@NonNull Expression compareOne, @NonNull Number compareTwo) {
     return new Expression("<", literal(compareOne), literal(compareTwo));
   }
 
   /**
    * Returns true if the first input is strictly less than the second, false otherwise.
    *
-   * @param compareOne the first string
+   * @param compareOne the first expression
    * @param compareTwo the second string
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-<">Style specification</a>
    */
-  public static Expression lt(@NonNull String compareOne, @NonNull String compareTwo) {
+  public static Expression lt(@NonNull Expression compareOne, @NonNull String compareTwo) {
     return new Expression("<", literal(compareOne), literal(compareTwo));
   }
 
@@ -408,24 +408,24 @@ public class Expression {
   /**
    * Returns true if the first input is greater than or equal to the second, false otherwise.
    *
-   * @param compareOne the first number
+   * @param compareOne the first expression
    * @param compareTwo the second number
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions->=">Style specification</a>
    */
-  public static Expression gte(@NonNull Number compareOne, @NonNull Number compareTwo) {
+  public static Expression gte(@NonNull Expression compareOne, @NonNull Number compareTwo) {
     return new Expression(">=", literal(compareOne), literal(compareTwo));
   }
 
   /**
    * Returns true if the first input is greater than or equal to the second, false otherwise.
    *
-   * @param compareOne the first string
+   * @param compareOne the first expression
    * @param compareTwo the second string
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions->=">Style specification</a>
    */
-  public static Expression gte(@NonNull String compareOne, @NonNull String compareTwo) {
+  public static Expression gte(@NonNull Expression compareOne, @NonNull String compareTwo) {
     return new Expression(">=", literal(compareOne), literal(compareTwo));
   }
 
@@ -445,24 +445,24 @@ public class Expression {
   /**
    * Returns true if the first input is less than or equal to the second, false otherwise.
    *
-   * @param compareOne the first number
+   * @param compareOne the first expression
    * @param compareTwo the second number
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-<=">Style specification</a>
    */
-  public static Expression lte(@NonNull Number compareOne, @NonNull Number compareTwo) {
+  public static Expression lte(@NonNull Expression compareOne, @NonNull Number compareTwo) {
     return new Expression("<=", literal(compareOne), literal(compareTwo));
   }
 
   /**
    * Returns true if the first input is less than or equal to the second, false otherwise.
    *
-   * @param compareOne the first string
+   * @param compareOne the first expression
    * @param compareTwo the second string
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-<=">Style specification</a>
    */
-  public static Expression lte(@NonNull String compareOne, @NonNull String compareTwo) {
+  public static Expression lte(@NonNull Expression compareOne, @NonNull String compareTwo) {
     return new Expression("<=", literal(compareOne), literal(compareTwo));
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.java
@@ -126,7 +126,7 @@ public class ExpressionTest {
   @Test
   public void testEqLiteral() throws Exception {
     Object[] expected = new Object[] {"==", 1, 1};
-    Object[] actual = eq(1, 1).toArray();
+    Object[] actual = eq(literal(1), 1).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
 
@@ -140,7 +140,7 @@ public class ExpressionTest {
   @Test
   public void testNeqLiteral() throws Exception {
     Object[] expected = new Object[] {"!=", 0, 1};
-    Object[] actual = neq(0, 1).toArray();
+    Object[] actual = neq(literal(0), 1).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
 
@@ -154,7 +154,7 @@ public class ExpressionTest {
   @Test
   public void testGtLiteral() throws Exception {
     Object[] expected = new Object[] {">", 0, 1};
-    Object[] actual = gt(0, 1).toArray();
+    Object[] actual = gt(literal(0), 1).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
 
@@ -168,7 +168,7 @@ public class ExpressionTest {
   @Test
   public void testLtLiteral() throws Exception {
     Object[] expected = new Object[] {"<", 1, 0};
-    Object[] actual = lt(1, 0).toArray();
+    Object[] actual = lt(literal(1), 0).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
 
@@ -182,7 +182,7 @@ public class ExpressionTest {
   @Test
   public void testGteLiteral() throws Exception {
     Object[] expected = new Object[] {">=", 1, 1};
-    Object[] actual = gte(1, 1).toArray();
+    Object[] actual = gte(literal(1), 1).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
 
@@ -196,7 +196,7 @@ public class ExpressionTest {
   @Test
   public void testLteLiteral() throws Exception {
     Object[] expected = new Object[] {"<=", 1, 1};
-    Object[] actual = lte(1, 1).toArray();
+    Object[] actual = lte(literal(1), 1).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LightTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LightTest.java
@@ -152,7 +152,7 @@ public class LightTest extends BaseActivityTest {
         light = mapboxMap.getLight();
         FillExtrusionLayer fillExtrusionLayer = new FillExtrusionLayer("3d-buildings", "composite");
         fillExtrusionLayer.setSourceLayer("building");
-        fillExtrusionLayer.setFilter(eq("extrude", "true"));
+        fillExtrusionLayer.setFilter(eq(Expression.get("extrude"), "true"));
         fillExtrusionLayer.setMinZoom(15);
         fillExtrusionLayer.setProperties(
           fillExtrusionColor(Color.LTGRAY),

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/light.junit.ejs
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/light.junit.ejs
@@ -112,7 +112,7 @@ public class LightTest extends BaseActivityTest {
         light = mapboxMap.getLight();
         FillExtrusionLayer fillExtrusionLayer = new FillExtrusionLayer("3d-buildings", "composite");
         fillExtrusionLayer.setSourceLayer("building");
-        fillExtrusionLayer.setFilter(eq("extrude", "true"));
+        fillExtrusionLayer.setFilter(eq(Expression.get("extrude"), "true"));
         fillExtrusionLayer.setMinZoom(15);
         fillExtrusionLayer.setProperties(
           fillExtrusionColor(Color.LTGRAY),

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
@@ -529,7 +529,7 @@ public class RuntimeStyleActivity extends AppCompatActivity {
       LineLayer counties = (LineLayer) mapboxMap.getLayer("counties");
 
       if (counties != null) {
-        counties.setFilter(eq("NAME10", "Washington"));
+        counties.setFilter(eq(get("NAME10"), "Washington"));
 
         counties.setProperties(
           lineColor(Color.RED),


### PR DESCRIPTION
When reworking our DDS examples to the new API, we noticed that the current convenience methods of logical conditions of something as `eq(String, String)` didn't make much sense. This is because IRL you will use at least one expression in there. This PR addresses this by change the syntax to use one epxresssion and one literal value. 