### PR TITLE
Round-trip linear interpolators

### DIFF
--- a/src/mbgl/style/conversion/stringify.hpp
+++ b/src/mbgl/style/conversion/stringify.hpp
@@ -303,9 +303,13 @@ public:
     template <class T>
     void operator()(const ExponentialStops<T>& f) {
         writer.Key("type");
-        writer.String("exponential");
-        writer.Key("base");
-        writer.Double(f.base);
+        if (f.base == 1) {
+            writer.String("linear");
+        } else {
+            writer.String("exponential");
+            writer.Key("base");
+            writer.Double(f.base);
+        }
         writer.Key("stops");
         stringifyStops(f.stops);
     }
@@ -335,9 +339,13 @@ public:
     template <class T>
     void operator()(const CompositeExponentialStops<T>& f) {
         writer.Key("type");
-        writer.String("exponential");
-        writer.Key("base");
-        writer.Double(f.base);
+        if (f.base == 1) {
+            writer.String("linear");
+        } else {
+            writer.String("exponential");
+            writer.Key("base");
+            writer.Double(f.base);
+        }
         writer.Key("stops");
         stringifyCompositeStops(f.stops);
     }

--- a/src/mbgl/style/expression/interpolate.cpp
+++ b/src/mbgl/style/expression/interpolate.cpp
@@ -223,7 +223,11 @@ mbgl::Value Interpolate<T>::serialize() const {
     
     interpolator.match(
         [&](const ExponentialInterpolator& exponential) {
-            serialized.emplace_back(std::vector<mbgl::Value>{{ std::string("exponential"), exponential.base }});
+            if (exponential.base == 1) {
+                serialized.emplace_back(std::vector<mbgl::Value>{{ std::string("linear") }});
+            } else {
+                serialized.emplace_back(std::vector<mbgl::Value>{{ std::string("exponential"), exponential.base }});
+            }
         },
         [&](const CubicBezierInterpolator& cubicBezier) {
             static const std::string cubicBezierTag("cubic-bezier");

--- a/test/style/conversion/stringify.test.cpp
+++ b/test/style/conversion/stringify.test.cpp
@@ -80,6 +80,8 @@ TEST(Stringify, Filter) {
 }
 
 TEST(Stringify, CameraFunction) {
+    ASSERT_EQ(stringify(CameraFunction<float>(ExponentialStops<float> { {{0, 1}}, 1 })),
+        "{\"type\":\"linear\",\"stops\":[[0.0,1.0]]}");
     ASSERT_EQ(stringify(CameraFunction<float>(ExponentialStops<float> { {{0, 1}}, 2 })),
         "{\"type\":\"exponential\",\"base\":2.0,\"stops\":[[0.0,1.0]]}");
     ASSERT_EQ(stringify(CameraFunction<float>(IntervalStops<float> { {{0, 1}} })),


### PR DESCRIPTION
Serialize linear interpolators as such rather than as exponential interpolators with a base of 1.0.

Fixes #11562. Depends on mapbox/mapbox-gl-js#6425.

/cc @ChrisLoer @anandthakker