### PR TITLE
Round-trip linear interpolators (release-boba)

### DIFF
--- a/include/mbgl/util/color.hpp
+++ b/include/mbgl/util/color.hpp
@@ -4,6 +4,7 @@
 
 #include <cassert>
 #include <string>
+#include <array>
 
 namespace mbgl {
 
@@ -37,6 +38,7 @@ public:
 
     static optional<Color> parse(const std::string&);
     std::string stringify() const;
+    std::array<double, 4> toArray() const;
 };
 
 inline bool operator==(const Color& colorA, const Color& colorB) {

--- a/src/mbgl/style/expression/compound_expression.cpp
+++ b/src/mbgl/style/expression/compound_expression.cpp
@@ -209,12 +209,7 @@ std::unordered_map<std::string, CompoundExpressionRegistry::Definition> initiali
         );
     });
     define("to-rgba", [](const Color& color) -> Result<std::array<double, 4>> {
-        return std::array<double, 4> {{ 
-            255 * color.r / color.a, 
-            255 * color.g / color.a,
-            255 * color.b / color.a, 
-            color.a 
-        }};
+        return color.toArray();
     });
     
     define("rgba", rgba);

--- a/src/mbgl/style/expression/interpolate.cpp
+++ b/src/mbgl/style/expression/interpolate.cpp
@@ -223,7 +223,11 @@ mbgl::Value Interpolate<T>::serialize() const {
     
     interpolator.match(
         [&](const ExponentialInterpolator& exponential) {
-            serialized.emplace_back(std::vector<mbgl::Value>{{ std::string("exponential"), exponential.base }});
+            if (exponential.base == 1) {
+                serialized.emplace_back(std::vector<mbgl::Value>{{ std::string("linear") }});
+            } else {
+                serialized.emplace_back(std::vector<mbgl::Value>{{ std::string("exponential"), exponential.base }});
+            }
         },
         [&](const CubicBezierInterpolator& cubicBezier) {
             static const std::string cubicBezierTag("cubic-bezier");

--- a/src/mbgl/style/expression/value.cpp
+++ b/src/mbgl/style/expression/value.cpp
@@ -106,12 +106,13 @@ Value ValueConverter<mbgl::Value>::toExpressionValue(const mbgl::Value& value) {
 mbgl::Value ValueConverter<mbgl::Value>::fromExpressionValue(const Value& value) {
     return value.match(
         [&](const Color& color)->mbgl::Value {
+            std::array<double, 4> array = color.toArray();
             return std::vector<mbgl::Value>{
                 std::string("rgba"),
-                double(255 * color.r / color.a),
-                double(255 * color.g / color.a),
-                double(255 * color.b / color.a),
-                double(color.a)
+                array[0],
+                array[1],
+                array[2],
+                array[3],
             };
         },
         [&](const std::vector<Value>& values)->mbgl::Value {

--- a/src/mbgl/util/color.cpp
+++ b/src/mbgl/util/color.cpp
@@ -23,11 +23,25 @@ optional<Color> Color::parse(const std::string& s) {
 }
 
 std::string Color::stringify() const {
+    std::array<double, 4> array = toArray();
     return "rgba(" +
-        util::toString(r * 255 / a) + "," +
-        util::toString(g * 255 / a) + "," +
-        util::toString(b * 255 / a) + "," +
-        util::toString(a) + ")";
+        util::toString(array[0]) + "," +
+        util::toString(array[1]) + "," +
+        util::toString(array[2]) + "," +
+        util::toString(array[3]) + ")";
+}
+
+std::array<double, 4> Color::toArray() const {
+    if (a == 0) {
+        return {{ 0, 0, 0, 0 }};
+    } else {
+        return {{
+            r * 255 / a,
+            g * 255 / a,
+            b * 255 / a,
+            a,
+        }};
+    }
 }
 
 } // namespace mbgl

--- a/test/style/conversion/stringify.test.cpp
+++ b/test/style/conversion/stringify.test.cpp
@@ -80,6 +80,8 @@ TEST(Stringify, Filter) {
 }
 
 TEST(Stringify, CameraFunction) {
+    ASSERT_EQ(stringify(CameraFunction<float>(ExponentialStops<float> { {{0, 1}}, 1 })),
+        "[\"interpolate\",[\"linear\"],[\"zoom\"],0.0,1.0]");
     ASSERT_EQ(stringify(CameraFunction<float>(ExponentialStops<float> { {{0, 1}}, 2 })),
         "[\"interpolate\",[\"exponential\",2.0],[\"zoom\"],0.0,1.0]");
     ASSERT_EQ(stringify(CameraFunction<float>(IntervalStops<float> { {{0, 1}} })),
@@ -109,7 +111,7 @@ TEST(Stringify, CompositeFunction) {
             2
         }, 0.0f)),
         "[\"interpolate\","
-            "[\"exponential\",1.0],"
+            "[\"linear\"],"
             "[\"zoom\"],"
             "0.0,[\"interpolate\",[\"exponential\",2.0],[\"number\",[\"get\",\"property\"]],0.0,1.0],"
             "1.0,[\"interpolate\",[\"exponential\",2.0],[\"number\",[\"get\",\"property\"]],0.0,1.0]]");


### PR DESCRIPTION
Backport of #11564 and mapbox/mapbox-gl-js#6388 to the release-boba branch.

Unblocks #11389. Depends on mapbox/mapbox-gl-js#6427.

/cc @ChrisLoer @anandthakker