### PR TITLE
[core] Fix GeometryTile race condition

### DIFF
--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -404,6 +404,11 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         // commitFeatureIndexes depends on the assumption that no new FeatureIndex has been loaded since placement
         // started. If we violate this assumption, then we need to either make CollisionIndex completely independendent of
         // FeatureIndex, or find a way for its entries to point to multiple FeatureIndexes.
+        // We also depend on the assumption that anything that can change the results of CollisionIndex::queryRenderedSymbols
+        // will cause 'placementChanged' to be true (note that adding a non-placed item to the index will _not_ make
+        // placementChanged true).
+        // We should consider switching to the "always commit new placements" strategy used in
+        //   https://github.com/mapbox/mapbox-gl-js/pull/6104
         commitFeatureIndexes();
         crossTileSymbolIndex.pruneUnusedLayers(usedSymbolLayers);
         if (placementChanged || symbolBucketsChanged) {

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -124,11 +124,11 @@ private:
     uint64_t correlationID = 0;
 
     std::unordered_map<std::string, std::shared_ptr<Bucket>> nonSymbolBuckets;
+    optional<std::pair<std::unique_ptr<FeatureIndex>, std::unique_ptr<const GeometryTileData>>> dataPendingSymbolBuckets;
+    optional<std::pair<std::unique_ptr<FeatureIndex>, std::unique_ptr<const GeometryTileData>>> dataPendingCommit;
     std::unique_ptr<FeatureIndex> featureIndex;
-    optional<std::pair<bool,std::unique_ptr<FeatureIndex>>> pendingFeatureIndex;
     std::unique_ptr<const GeometryTileData> data;
-    optional<std::pair<bool, std::unique_ptr<const GeometryTileData>>> pendingData;
-
+    
     optional<AlphaImage> glyphAtlasImage;
     optional<PremultipliedImage> iconAtlasImage;
 


### PR DESCRIPTION
I was almost there with the first fix, but it still left a hole open. @ansis, would you have time to put some eyes on this? The timing is really tricky to think about.

The good news is that @friedbunny set me up with a branch where I could reproduce easily, log what was happening, and verify that this fix made the crash go away.

Follow up fix for issue #11538.
This closes a hole in the logic where:
- Layout result 1 arrived
- Symbols arrives for result 1, it was marked ready for commit
- Layout result 2 arrived, clearing "ready for commit" state
- Global placement ran on symbols for result 1, but layout result 1 data wasn't committed because it had been replaced with layout result 2.

/cc @jfirebaugh @ansis @friedbunny @julianrex @tobrun 