### PR TITLE
Throw exception when converting PropertyValue with an expression 

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
@@ -9,6 +9,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
+import com.mapbox.mapboxsdk.style.layers.PropertyValue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1735,7 +1736,9 @@ public class Expression {
    */
   private Object toValue(ExpressionLiteral expressionValue) {
     Object value = expressionValue.toValue();
-    if (value instanceof Expression.ExpressionLiteral) {
+    if (value instanceof PropertyValue) {
+      throw new IllegalArgumentException("PropertyValue are not allowed as an expression literal, use value instead.");
+    } else if (value instanceof Expression.ExpressionLiteral) {
       return toValue((ExpressionLiteral) value);
     } else if (value instanceof Expression) {
       return ((Expression) value).toArray();

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.java
@@ -73,6 +73,7 @@ import static com.mapbox.mapboxsdk.style.expressions.Expression.typeOf;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.upcase;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.var;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.zoom;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineOpacity;
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
@@ -1095,4 +1096,13 @@ public class ExpressionTest {
     assertTrue("expression should match", Arrays.deepEquals(expected, greenColor.toArray()));
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testThrowIllegalArgumentExceptionForPropertyValueLiteral() {
+    Expression expression = interpolate(exponential(1f), zoom(),
+      stop(17f, lineOpacity(1f)),
+      stop(16.5f, lineOpacity(0.5f)),
+      stop(16f, lineOpacity(0f))
+    );
+    expression.toArray();
+  }
 }


### PR DESCRIPTION
This PR catches the common pitfall of using a PropertyValue inside an expression. This typically occurs  when  a user migrates from the old dds approach to the new expression syntax. 
 - [ ] look into alternative approach of getting the value from the PropertyValue instead?
  
closes #11572 
