### PR TITLE
Re-bind uniform locations after re-linking program

### DIFF
--- a/src/mbgl/gl/program.hpp
+++ b/src/mbgl/gl/program.hpp
@@ -36,8 +36,13 @@ public:
                                     context.createShader(ShaderType::Fragment, fragmentSource))),
           uniformsState((context.linkProgram(program), Uniforms::bindLocations(program))),
           attributeLocations(Attributes::bindLocations(program)) {
+
         // Re-link program after manually binding only active attributes in Attributes::bindLocations
         context.linkProgram(program);
+
+        // We have to re-initialize the uniforms state from the bindings as the uniform locations
+        // get shifted on some implementations
+        uniformsState = Uniforms::bindLocations(program);
     }
 
     template <class BinaryProgram>


### PR DESCRIPTION
On some gl implementations the uniform locations are shifted after linking the program a second time, resulting in errors when using any uniform. (On some implementations they are actually doubled). Re-binding the uniforms after selectively binding the vertex attributes prevents this.

This currently prevents running on the Android emulator with hardware acceleration.

Fixes #11266