### PR TITLE
Invalidate camera position before delivering onMapReady

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -155,6 +155,7 @@ public final class MapboxMap {
    * Called before the OnMapReadyCallback is invoked.
    */
   void onPreMapReady() {
+    invalidateCameraPosition();
     annotationManager.reloadMarkers();
     annotationManager.adjustTopOffsetPixels(this);
   }
@@ -815,7 +816,7 @@ public final class MapboxMap {
   /**
    * Invalidates the current camera position by reconstructing it from mbgl
    */
-  void invalidateCameraPosition() {
+  private void invalidateCameraPosition() {
     CameraPosition cameraPosition = transform.invalidateCameraPosition();
     if (cameraPosition != null) {
       transform.updateCameraPosition(cameraPosition);


### PR DESCRIPTION
Refs. https://github.com/mapbox/mapbox-gl-native/issues/11577.
Even though the bug is already fixed on `release-boba` thanks to the removal of the `TrackingSettings` we can future-proof by invalidating the camera position before delivering the `onMapReady` callback. 