### PR TITLE
Bumped telemetry library version to 3.0.0-beta.4

### DIFF
--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
     versions = [
             mapboxServices : '3.0.0-beta.4',
-            mapboxTelemetry: '3.0.0-beta.3',
+            mapboxTelemetry: '3.0.0-beta.4',
             mapboxGestures : '0.2.0',
             supportLib     : '25.4.0',
             espresso       : '3.0.1',


### PR DESCRIPTION
Closes #11554.
/cc @electrostat 