### PR TITLE
Android - release local refs

### DIFF
--- a/platform/android/src/image.cpp
+++ b/platform/android/src/image.cpp
@@ -16,7 +16,12 @@ PremultipliedImage decodeImage(const std::string& string) {
                         reinterpret_cast<const signed char*>(string.data()));
 
     auto bitmap = android::BitmapFactory::DecodeByteArray(*env, array, 0, string.size());
-    return android::Bitmap::GetImage(*env, bitmap);
+    jni::DeleteLocalRef(*env, array);
+
+    auto image = android::Bitmap::GetImage(*env, bitmap);
+    jni::DeleteLocalRef(*env, bitmap);
+
+    return image;
 }
 
 } // namespace mbgl

--- a/platform/android/src/text/local_glyph_rasterizer.cpp
+++ b/platform/android/src/text/local_glyph_rasterizer.cpp
@@ -46,6 +46,7 @@ PremultipliedImage LocalGlyphRasterizer::drawGlyphBitmap(const std::string& font
                                      jniFontFamily,
                                      static_cast<jni::jboolean>(bold),
                                      static_cast<jni::jchar>(glyphID));
+    jni::DeleteLocalRef(*env, jniFontFamily);
 
     PremultipliedImage result = Bitmap::GetImage(*env, javaBitmap);
     jni::DeleteLocalRef(*env, javaBitmap);


### PR DESCRIPTION
A few more instances where JNI local references can be cleared earlier.