### PR TITLE
Distinguish between conditionals and expressions in case expressions

### DIFF
--- a/platform/darwin/src/NSExpression+MGLAdditions.mm
+++ b/platform/darwin/src/NSExpression+MGLAdditions.mm
@@ -662,9 +662,9 @@ NSArray *MGLSubexpressionsWithJSONObjects(NSArray *objects) {
             NSMutableArray *arguments = [NSMutableArray array];
             
             for (NSUInteger index = 0; index < argumentObjects.count; index++) {
-                if ([argumentObjects[index] isKindOfClass:[NSArray class]]) {
-                    NSPredicate *conditional = [NSPredicate mgl_predicateWithJSONObject:argumentObjects[index]];
-                    NSExpression *argument = [NSExpression expressionWithFormat:@"%@", conditional];
+                if (index % 2 == 0 && index != argumentObjects.count - 1) {
+                    NSPredicate *predicate = [NSPredicate mgl_predicateWithJSONObject:argumentObjects[index]];
+                    NSExpression *argument = [NSExpression expressionForConstantValue:predicate];
                     [arguments addObject:argument];
                 } else {
                     [arguments addObject:[NSExpression mgl_expressionWithJSONObject:argumentObjects[index]]];
@@ -673,7 +673,7 @@ NSArray *MGLSubexpressionsWithJSONObjects(NSArray *objects) {
             
             if (@available(iOS 9.0, *)) {
                 if (arguments.count == 3) {
-                    NSPredicate *conditional = [NSPredicate mgl_predicateWithJSONObject:argumentObjects.firstObject];
+                    NSPredicate *conditional = [arguments.firstObject constantValue];
                     return [NSExpression expressionForConditional:conditional trueExpression:arguments[1] falseExpression:arguments[2]];
                 }
             }

--- a/platform/darwin/src/NSExpression+MGLAdditions.mm
+++ b/platform/darwin/src/NSExpression+MGLAdditions.mm
@@ -806,7 +806,7 @@ NSArray *MGLSubexpressionsWithJSONObjects(NSArray *objects) {
             if (op) {
                 NSArray *arguments = self.arguments.mgl_jsonExpressionObject;
                 return [@[op] arrayByAddingObjectsFromArray:arguments];
-            } else if ([function isEqualToString:@"valueForKeyPath:"]) {
+            } else if ([function isEqualToString:@"valueForKey:"] || [function isEqualToString:@"valueForKeyPath:"]) {
                 return @[@"get", self.arguments.firstObject.mgl_jsonExpressionObject, self.operand.mgl_jsonExpressionObject];
             } else if ([function isEqualToString:@"average:"]) {
                 NSExpression *sum = [NSExpression expressionForFunction:@"sum:" arguments:self.arguments];

--- a/platform/darwin/test/MGLExpressionTests.mm
+++ b/platform/darwin/test/MGLExpressionTests.mm
@@ -743,7 +743,21 @@ using namespace std::string_literals;
         XCTAssertEqualObjects([NSExpression mgl_expressionWithJSONObject:jsonExpression], expression);
         XCTAssertEqualObjects([expression expressionValueWithObject:nil context:nil], @YES);
     }
-    
+    {
+        NSArray *jsonExpression = @[
+            @"case",
+            @[
+                @"<",
+                @[@"get", @"area"],
+                @80000
+            ],
+            @[@"get", @"abbr"],
+            @[@"get", @"name_en"]
+        ];
+        NSExpression *expression = [NSExpression expressionWithFormat:@"TERNARY(area < 80000, abbr, name_en)"];
+        XCTAssertEqualObjects([NSExpression mgl_expressionWithJSONObject:jsonExpression], expression);
+        XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
+    }
 }
 
 - (void)testLookupExpressionObject {


### PR DESCRIPTION
An argument to a `case` expression is a conditional or value depending on its index, not its data type. Also added support for `valueForKey:`, which is a common alternative to `valueForKeyPath:`, inside function expressions.

Fixes #11613.

/cc @fabian-guerra