### PR TITLE
[ios, macos] Add predicate like expressions to NSExpression

### DIFF
--- a/platform/darwin/src/NSComparisonPredicate+MGLAdditions.mm
+++ b/platform/darwin/src/NSComparisonPredicate+MGLAdditions.mm
@@ -333,16 +333,17 @@
                                                                                          options:0];
             return @[op, leftHandPredicate.mgl_jsonExpressionObject, rightHandPredicate.mgl_jsonExpressionObject];
         }
-        case NSInPredicateOperatorType: {
+        case NSInPredicateOperatorType:
             op = @"match";
             break;
-        }
+        case NSContainsPredicateOperatorType:
+            op = @"has";
+            break;
         case NSMatchesPredicateOperatorType:
         case NSLikePredicateOperatorType:
         case NSBeginsWithPredicateOperatorType:
         case NSEndsWithPredicateOperatorType:
         case NSCustomSelectorPredicateOperatorType:
-        case NSContainsPredicateOperatorType:
             [NSException raise:NSInvalidArgumentException
                         format:@"NSPredicateOperatorType:%lu is not supported.", (unsigned long)self.predicateOperatorType];
     }

--- a/platform/darwin/src/NSComparisonPredicate+MGLAdditions.mm
+++ b/platform/darwin/src/NSComparisonPredicate+MGLAdditions.mm
@@ -318,6 +318,21 @@
         case NSNotEqualToPredicateOperatorType:
             op = @"!=";
             break;
+        case NSBetweenPredicateOperatorType: {
+            op = @"all";
+            NSArray *arguments = self.rightExpression.constantValue;
+            NSPredicate *leftHandPredicate = [NSComparisonPredicate predicateWithLeftExpression:arguments[0]
+                                                                                rightExpression:self.leftExpression
+                                                                                       modifier:NSAllPredicateModifier
+                                                                                           type:NSLessThanOrEqualToPredicateOperatorType
+                                                                                        options:0];
+            NSPredicate *rightHandPredicate = [NSComparisonPredicate predicateWithLeftExpression:self.leftExpression
+                                                                                 rightExpression:arguments[1]
+                                                                                        modifier:NSAllPredicateModifier
+                                                                                            type:NSLessThanOrEqualToPredicateOperatorType
+                                                                                         options:0];
+            return @[op, leftHandPredicate.mgl_jsonExpressionObject, rightHandPredicate.mgl_jsonExpressionObject];
+        }
         case NSMatchesPredicateOperatorType:
         case NSLikePredicateOperatorType:
         case NSBeginsWithPredicateOperatorType:
@@ -325,7 +340,6 @@
         case NSInPredicateOperatorType:
         case NSCustomSelectorPredicateOperatorType:
         case NSContainsPredicateOperatorType:
-        case NSBetweenPredicateOperatorType:
             [NSException raise:NSInvalidArgumentException
                         format:@"NSPredicateOperatorType:%lu is not supported.", (unsigned long)self.predicateOperatorType];
     }

--- a/platform/darwin/src/NSComparisonPredicate+MGLAdditions.mm
+++ b/platform/darwin/src/NSComparisonPredicate+MGLAdditions.mm
@@ -336,8 +336,7 @@
         case NSInPredicateOperatorType: {
             NSMutableArray *elements = [NSMutableArray arrayWithObjects:@"match", self.leftExpression.mgl_jsonExpressionObject, nil];
             NSArray *optionsExpressions = self.rightExpression.constantValue;
-            NSEnumerator *optionsEnumerator = optionsExpressions.objectEnumerator;
-            while (id object = optionsEnumerator.nextObject) {
+            for (id object in optionsExpressions) {
                 id option = ((NSExpression *)object).mgl_jsonExpressionObject;
                 [elements addObject:option];
                 [elements addObject:@YES];

--- a/platform/darwin/src/NSComparisonPredicate+MGLAdditions.mm
+++ b/platform/darwin/src/NSComparisonPredicate+MGLAdditions.mm
@@ -333,11 +333,14 @@
                                                                                          options:0];
             return @[op, leftHandPredicate.mgl_jsonExpressionObject, rightHandPredicate.mgl_jsonExpressionObject];
         }
+        case NSInPredicateOperatorType: {
+            op = @"match";
+            break;
+        }
         case NSMatchesPredicateOperatorType:
         case NSLikePredicateOperatorType:
         case NSBeginsWithPredicateOperatorType:
         case NSEndsWithPredicateOperatorType:
-        case NSInPredicateOperatorType:
         case NSCustomSelectorPredicateOperatorType:
         case NSContainsPredicateOperatorType:
             [NSException raise:NSInvalidArgumentException

--- a/platform/darwin/src/NSPredicate+MGLAdditions.mm
+++ b/platform/darwin/src/NSPredicate+MGLAdditions.mm
@@ -319,6 +319,10 @@ NSArray *MGLSubpredicatesWithJSONObjects(NSArray *objects) {
         NSArray *subpredicates = MGLSubpredicatesWithJSONObjects([objects subarrayWithRange:NSMakeRange(1, objects.count - 1)]);
         return [NSCompoundPredicate orPredicateWithSubpredicates:subpredicates];
     }
+    if ([op isEqualToString:@"match"]) {
+        NSArray *subpredicates = MGLSubexpressionsWithJSONObjects([objects subarrayWithRange:NSMakeRange(1, objects.count - 1)]);
+        return [NSPredicate predicateWithFormat:@"%@ IN %@" argumentArray:subpredicates];
+    }
     
     NSAssert(NO, @"Unrecognized expression conditional operator %@.", op);
     return nil;

--- a/platform/darwin/src/NSPredicate+MGLAdditions.mm
+++ b/platform/darwin/src/NSPredicate+MGLAdditions.mm
@@ -323,6 +323,10 @@ NSArray *MGLSubpredicatesWithJSONObjects(NSArray *objects) {
         NSArray *subpredicates = MGLSubexpressionsWithJSONObjects([objects subarrayWithRange:NSMakeRange(1, objects.count - 1)]);
         return [NSPredicate predicateWithFormat:@"%@ IN %@" argumentArray:subpredicates];
     }
+    if ([op isEqualToString:@"has"]) {
+        NSArray *subpredicates = MGLSubexpressionsWithJSONObjects([objects subarrayWithRange:NSMakeRange(1, objects.count - 1)]);
+        return [NSPredicate predicateWithFormat:@"%@ CONTAINS %@" argumentArray:subpredicates];
+    }
     
     NSAssert(NO, @"Unrecognized expression conditional operator %@.", op);
     return nil;

--- a/platform/darwin/src/NSPredicate+MGLAdditions.mm
+++ b/platform/darwin/src/NSPredicate+MGLAdditions.mm
@@ -295,7 +295,7 @@ NSArray *MGLSubpredicatesWithJSONObjects(NSArray *objects) {
     }
     if ([op isEqualToString:@"all"]) {
         NSArray *jsonObjects = [objects subarrayWithRange:NSMakeRange(1, objects.count - 1)];
-        NSArray *subpredicates = MGLSubpredicatesWithJSONObjects(jsonObjects);
+        NSArray<NSPredicate *> *subpredicates = MGLSubpredicatesWithJSONObjects(jsonObjects);
         if (jsonObjects.count == 2) {
             // Determine if the expression is of BETWEEN type
             if ([jsonObjects[0] isKindOfClass:[NSArray class]] &&
@@ -304,26 +304,28 @@ NSArray *MGLSubpredicatesWithJSONObjects(NSArray *objects) {
                 NSArray *rightCondition = jsonObjects[1];
                 NSString *leftOperator = leftCondition.firstObject;
                 NSString *rightOperator = rightCondition.firstObject;
+                
                 NSArray *limits;
                 NSExpression *leftConditionExpression;
+                
                 if([leftOperator isEqualToString:@">="] && [rightOperator isEqualToString:@"<="]) {
-                    limits = @[[NSExpression mgl_expressionWithJSONObject:leftCondition[2]], [NSExpression mgl_expressionWithJSONObject:rightCondition[2]]];
-                    leftConditionExpression = [NSExpression mgl_expressionWithJSONObject:leftCondition[1]];
+                    limits = @[((NSComparisonPredicate *)subpredicates[0]).rightExpression, ((NSComparisonPredicate *)subpredicates[1]).rightExpression];
+                    leftConditionExpression = ((NSComparisonPredicate *)subpredicates[0]).leftExpression;
                 
                 } else if ([leftOperator isEqualToString:@"<="] && [rightOperator isEqualToString:@"<="]) {
-                    limits = @[[NSExpression mgl_expressionWithJSONObject:leftCondition[1]], [NSExpression mgl_expressionWithJSONObject:rightCondition[2]]];
-                    leftConditionExpression = [NSExpression mgl_expressionWithJSONObject:leftCondition[2]];
+                    limits = @[((NSComparisonPredicate *)subpredicates[0]).leftExpression, ((NSComparisonPredicate *)subpredicates[1]).rightExpression];
+                    leftConditionExpression = ((NSComparisonPredicate *)subpredicates[0]).rightExpression;
                 
                 } else if([leftOperator isEqualToString:@"<="] && [rightOperator isEqualToString:@">="]) {
-                    limits = @[[NSExpression mgl_expressionWithJSONObject:leftCondition[1]], [NSExpression mgl_expressionWithJSONObject:rightCondition[1]]];
-                    leftConditionExpression = [NSExpression mgl_expressionWithJSONObject:leftCondition[2]];
+                    limits = @[((NSComparisonPredicate *)subpredicates[0]).leftExpression, ((NSComparisonPredicate *)subpredicates[1]).leftExpression];
+                    leftConditionExpression = ((NSComparisonPredicate *)subpredicates[0]).rightExpression;
                 
                 } else if([leftOperator isEqualToString:@">="] && [rightOperator isEqualToString:@">="]) {
-                    limits = @[[NSExpression mgl_expressionWithJSONObject:leftCondition[2]], [NSExpression mgl_expressionWithJSONObject:rightCondition[1]]];
-                    leftConditionExpression = [NSExpression mgl_expressionWithJSONObject:leftCondition[1]];
+                    limits = @[((NSComparisonPredicate *)subpredicates[0]).rightExpression, ((NSComparisonPredicate *)subpredicates[1]).leftExpression];
+                    leftConditionExpression = ((NSComparisonPredicate *)subpredicates[0]).leftExpression;
                 }
                 
-                if (limits && limits) {
+                if (limits && leftConditionExpression) {
                      return [NSPredicate predicateWithFormat:@"%@ BETWEEN %@", leftConditionExpression, [NSExpression expressionForAggregate:limits]];
                 }
             }

--- a/platform/darwin/test/MGLPredicateTests.mm
+++ b/platform/darwin/test/MGLPredicateTests.mm
@@ -576,6 +576,28 @@ namespace mbgl {
         NSArray *expected = @[@"==", @1, @2];
         XCTAssertEqualObjects([NSPredicate predicateWithFormat:@"1 = 2"].mgl_jsonExpressionObject, expected);
     }
+    {
+        NSArray *expected = @[@"all", @[@"<=", @10, @[@"get", @"x"]], @[@"<=", @[@"get", @"x"], @100]];
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"x BETWEEN %@", @[[NSExpression expressionForConstantValue:@10], [NSExpression expressionForConstantValue:@100]]];
+        XCTAssertEqualObjects(predicate.mgl_jsonExpressionObject, expected);
+        XCTAssertEqualObjects([NSPredicate mgl_predicateWithJSONObject:expected], predicate);
+    }
+    {
+        NSArray *expected = @[@"all", @[@">=",  @[@"get", @"x"], @10], @[@"<=", @[@"get", @"x"], @100]];
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"x BETWEEN %@", @[[NSExpression expressionForConstantValue:@10], [NSExpression expressionForConstantValue:@100]]];
+        XCTAssertEqualObjects([NSPredicate mgl_predicateWithJSONObject:expected], predicate);
+    }
+    {
+        NSArray *expected = @[@"all", @[@">=",  @[@"get", @"x"], @10], @[@">=", @100, @[@"get", @"x"]]];
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"x BETWEEN %@", @[[NSExpression expressionForConstantValue:@10], [NSExpression expressionForConstantValue:@100]]];
+        XCTAssertEqualObjects([NSPredicate mgl_predicateWithJSONObject:expected], predicate);
+    }
+    {
+        NSArray *expected = @[@"all", @[@"==", @10, @[@"get", @"x"]], @[@"<=", @[@"get", @"x"], @100]];
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%@ == x && x <= %@", [NSExpression expressionForConstantValue:@10], [NSExpression expressionForConstantValue:@100]];
+        XCTAssertEqualObjects(predicate.mgl_jsonExpressionObject, expected);
+        XCTAssertEqualObjects([NSPredicate mgl_predicateWithJSONObject:expected], predicate);
+    }
 }
 
 @end

--- a/platform/darwin/test/MGLPredicateTests.mm
+++ b/platform/darwin/test/MGLPredicateTests.mm
@@ -598,6 +598,18 @@ namespace mbgl {
         XCTAssertEqualObjects(predicate.mgl_jsonExpressionObject, expected);
         XCTAssertEqualObjects([NSPredicate mgl_predicateWithJSONObject:expected], predicate);
     }
+    {
+        NSArray *expected = @[@"match", @[@"id"], @[@"literal", @[@6, @5, @4, @3]]];
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"$mgl_featureIdentifier IN { 6, 5, 4, 3}"];
+        XCTAssertEqualObjects(predicate.mgl_jsonExpressionObject, expected);
+        XCTAssertEqualObjects([NSPredicate mgl_predicateWithJSONObject:expected], predicate);
+    }
+    {
+        NSArray *expected = @[@"!", @[@"match", @[@"get", @"x"], @[@"literal", @[@6, @5, @4, @3]]]];
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"NOT x IN { 6, 5, 4, 3}"];
+        XCTAssertEqualObjects(predicate.mgl_jsonExpressionObject, expected);
+        XCTAssertEqualObjects([NSPredicate mgl_predicateWithJSONObject:expected], predicate);
+    }
 }
 
 @end

--- a/platform/darwin/test/MGLPredicateTests.mm
+++ b/platform/darwin/test/MGLPredicateTests.mm
@@ -610,6 +610,18 @@ namespace mbgl {
         XCTAssertEqualObjects(predicate.mgl_jsonExpressionObject, expected);
         XCTAssertEqualObjects([NSPredicate mgl_predicateWithJSONObject:expected], predicate);
     }
+    {
+        NSArray *expected = @[@"has", @[@"literal", @[@6, @5, @4, @3]], @[@"get", @"x"]];
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"{ 6, 5, 4, 3} CONTAINS x"];
+        XCTAssertEqualObjects(predicate.mgl_jsonExpressionObject, expected);
+        XCTAssertEqualObjects([NSPredicate mgl_predicateWithJSONObject:expected], predicate);
+    }
+    {
+        NSArray *expected = @[@"has", @[@"literal", @[@6, @5, @4, @3]], @[@"id"]];
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"{ 6, 5, 4, 3} CONTAINS $mgl_featureIdentifier"];
+        XCTAssertEqualObjects(predicate.mgl_jsonExpressionObject, expected);
+        XCTAssertEqualObjects([NSPredicate mgl_predicateWithJSONObject:expected], predicate);
+    }
 }
 
 @end

--- a/platform/darwin/test/MGLPredicateTests.mm
+++ b/platform/darwin/test/MGLPredicateTests.mm
@@ -617,40 +617,30 @@ namespace mbgl {
         NSArray *expected = @[@"match", @[@"id"], @6, @YES, @5, @YES, @4, @YES, @3, @YES, @NO];
         NSPredicate *predicate = [NSPredicate predicateWithFormat:@"$mgl_featureIdentifier IN { 6, 5, 4, 3}"];
         XCTAssertEqualObjects(predicate.mgl_jsonExpressionObject, expected);
-        NSString *mglMatch = @"MGL_MATCH($mgl_featureIdentifier, 6, YES, 5, YES, 4, YES, 3, YES, NO)";
-        NSPredicate *predicateAfter = [self matchPredicateWithFormat:mglMatch];
+        NSPredicate *predicateAfter = [NSPredicate predicateWithFormat:@"MGL_MATCH($mgl_featureIdentifier, 6, YES, 5, YES, 4, YES, 3, YES, NO) == YES"];
         XCTAssertEqualObjects([NSPredicate mgl_predicateWithJSONObject:expected], predicateAfter);
     }
     {
         NSArray *expected = @[@"!", @[@"match", @[@"get", @"x"], @6, @YES, @5, @YES, @4, @YES, @3, @YES, @NO]];
         NSPredicate *predicate = [NSPredicate predicateWithFormat:@"NOT x IN { 6, 5, 4, 3}"];
         XCTAssertEqualObjects(predicate.mgl_jsonExpressionObject, expected);
+        NSPredicate *predicateAfter = [NSPredicate predicateWithFormat:@"NOT MGL_MATCH(x, 6, YES, 5, YES, 4, YES, 3, YES, NO) == YES"];
+        XCTAssertEqualObjects([NSPredicate mgl_predicateWithJSONObject:expected], predicateAfter);
     }
     {
         NSArray *expected = @[@"match", @[@"get", @"x"], @6, @YES, @5, @YES, @4, @YES, @3, @YES, @NO];
         NSPredicate *predicate = [NSPredicate predicateWithFormat:@"{ 6, 5, 4, 3} CONTAINS x"];
         XCTAssertEqualObjects(predicate.mgl_jsonExpressionObject, expected);
-        NSString *mglMatch = @"MGL_MATCH(x, 6, YES, 5, YES, 4, YES, 3, YES, NO)";
-        NSPredicate *predicateAfter = [self matchPredicateWithFormat:mglMatch];
+        NSPredicate *predicateAfter = [NSPredicate predicateWithFormat:@"MGL_MATCH(x, 6, YES, 5, YES, 4, YES, 3, YES, NO) == YES"];
         XCTAssertEqualObjects([NSPredicate mgl_predicateWithJSONObject:expected], predicateAfter);
     }
     {
         NSArray *expected = @[@"match", @[@"id"], @6, @YES, @5, @YES, @4, @YES, @3, @YES, @NO];
         NSPredicate *predicate = [NSPredicate predicateWithFormat:@"{ 6, 5, 4, 3} CONTAINS $mgl_featureIdentifier"];
         XCTAssertEqualObjects(predicate.mgl_jsonExpressionObject, expected);
-        NSString *mglMatch = @"MGL_MATCH($mgl_featureIdentifier, 6, YES, 5, YES, 4, YES, 3, YES, NO)";
-        NSPredicate *predicateAfter = [self matchPredicateWithFormat:mglMatch];
+        NSPredicate *predicateAfter = [NSPredicate predicateWithFormat:@"MGL_MATCH($mgl_featureIdentifier, 6, YES, 5, YES, 4, YES, 3, YES, NO) == YES"];
         XCTAssertEqualObjects([NSPredicate mgl_predicateWithJSONObject:expected], predicateAfter);
     }
-}
-
-- (NSPredicate *)matchPredicateWithFormat:(NSString *)format {
-    NSPredicate *predicate = [NSComparisonPredicate predicateWithLeftExpression:[NSExpression expressionWithFormat:format]
-                                                                rightExpression:[NSExpression expressionForConstantValue:@YES]
-                                                                       modifier:NSDirectPredicateModifier
-                                                                           type:NSNotEqualToPredicateOperatorType
-                                                                        options:0];
-    return predicate;
 }
 
 @end


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/11013

Add the following operators to `NSExpression`.
- [x] `BETWEEN`
- [x] `IN`
- [x] `CONTAINS`