### PR TITLE
[ios] Change MGLAnnotationView.scalesWithViewingDistance default value to NO

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -39,6 +39,7 @@ The 4.0._x_ series of releases will be the last to support iOS 8. The minimum iO
 
 ### Annotations
 
+* Changed the default value of `MGLAnnotationView.scalesWithViewingDistance` to `NO`, to improve performance. If your use case involves many annotation views, consider keeping this property disabled. ([#11636](https://github.com/mapbox/mapbox-gl-native/pull/11636))
 * Fixed an issue preventing `MGLAnnotationImage.image` from being updated. ([#10372](https://github.com/mapbox/mapbox-gl-native/pull/10372))
 * Improved performance of `MGLAnnotationView`-backed annotations that have `scalesWithViewingDistance` enabled. ([#10951](https://github.com/mapbox/mapbox-gl-native/pull/10951))
 * Fixed an issue where tapping a group of annotations may not have selected the nearest annotation. ([#11438](https://github.com/mapbox/mapbox-gl-native/pull/11438))

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -1810,12 +1810,6 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
         // Comment out the pin dropping functionality in the handleLongPress:
         // method in this class to make draggable annotation views play nice.
         annotationView.draggable = YES;
-
-        // Uncomment to force annotation view to maintain a constant size when
-        // the map is tilted. By default, annotation views will shrink and grow
-        // as they move towards and away from the horizon. Relatedly, annotations
-        // backed by GL sprites currently ONLY scale with viewing distance.
-        // annotationView.scalesWithViewingDistance = NO;
     } else {
         // orange indicates that the annotation view was reused
         annotationView.backgroundColor = [UIColor orangeColor];

--- a/platform/ios/src/MGLAnnotationView.h
+++ b/platform/ios/src/MGLAnnotationView.h
@@ -169,12 +169,12 @@ MGL_EXPORT
  value of this property is `NO` or the map’s pitch is zero, the annotation view
  remains the same size regardless of its position on-screen.
 
- The default value of this property is `YES`. Set this property to `NO` if the
- view’s legibility is important.
+ The default value of this property is `NO`. Keep this property set to `NO` if
+ the view’s legibility is important.
 
  @note Scaling many on-screen annotation views can contribute to poor map
-    performance. Consider disabling this property if your use case involves
-    hundreds or thousands of annotation views.
+    performance. Consider keeping this property disabled if your use case
+    involves hundreds or thousands of annotation views.
  */
 @property (nonatomic, assign) BOOL scalesWithViewingDistance;
 

--- a/platform/ios/src/MGLAnnotationView.mm
+++ b/platform/ios/src/MGLAnnotationView.mm
@@ -45,7 +45,7 @@
     _lastAppliedScaleTransform = CATransform3DIdentity;
     _annotation = annotation;
     _reuseIdentifier = [reuseIdentifier copy];
-    _scalesWithViewingDistance = YES;
+    _scalesWithViewingDistance = NO;
     _enabled = YES;
 }
 


### PR DESCRIPTION
Changes the default value of `MGLAnnotationView.scalesWithViewingDistance` to `NO`, which removes various inescapable overhead and improves out-of-box performance (FPS) by:

- 7% when `pitch = 0`
- 18% when `pitch = 30`

I measured this on iPhone X, 6s, and iPad Pro 10.5 running iOS 11.3/11.4b1 using a cobbled together ~3000 annotation, blank map style, camera movement benchmark — see the [`fb-bench-view-annotations`](https://github.com/mapbox/mapbox-gl-native/compare/release-boba...fb-bench-view-annotations) branch for details.

This change is prompted by the fact that annotation views do not generally perform well (even on top-of-the-line devices) and we need all the help we can get to maintain a smooth frame rate, otherwise the sync between annotation views and the map can become distractingly juddery.

See #5040 for past discussion of this default behavior (which was implemented in #5085). This PR follows up on #10951, also in `ios-v4.0.0`.

/cc @mapbox/maps-ios 