### PR TITLE
[android] LatLngBounds were not build correctly when lon was the same

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLngBounds.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLngBounds.java
@@ -394,7 +394,7 @@ public class LatLngBounds implements Parcelable {
   }
 
   static boolean containsLongitude(final double eastLon, final double westLon, final double longitude) {
-    if (eastLon > westLon) {
+    if (eastLon >= westLon) {
       return (longitude <= eastLon)
         && (longitude >= westLon);
     }

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/geometry/LatLngBoundsTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/geometry/LatLngBoundsTest.java
@@ -197,6 +197,27 @@ public class LatLngBoundsTest {
   }
 
   @Test
+  public void includesOrderDoesNotMatter() {
+    LatLngBounds sameLongitudeFirst = new LatLngBounds.Builder()
+      .include(new LatLng(50, 10))  // southWest
+      .include(new LatLng(60, 10))
+      .include(new LatLng(60, 20))  // northEast
+      .include(new LatLng(50, 20))
+      .include(new LatLng(50, 10))  // southWest again
+      .build();
+
+    LatLngBounds sameLatitudeFirst = new LatLngBounds.Builder()
+      .include(new LatLng(50, 20))
+      .include(new LatLng(50, 10))  // southWest
+      .include(new LatLng(60, 10))
+      .include(new LatLng(60, 20))  // northEast
+      .include(new LatLng(50, 20))
+      .build();
+
+    assertEquals(sameLatitudeFirst, sameLongitudeFirst);
+  }
+
+  @Test
   public void includesOverDateline1() {
 
     LatLngBounds latLngBounds = new LatLngBounds.Builder()


### PR DESCRIPTION
LatLngBounds were not build correctly when points with
same longitudes were added first.

closes #11629 