### PR TITLE
Don't crash when attribute count is exceeded

### DIFF
--- a/src/mbgl/gl/attribute.cpp
+++ b/src/mbgl/gl/attribute.cpp
@@ -1,14 +1,20 @@
 #include <mbgl/gl/attribute.hpp>
+#include <mbgl/gl/context.hpp>
 #include <mbgl/gl/gl.hpp>
 
 namespace mbgl {
 namespace gl {
 
-void bindAttributeLocation(ProgramID id, AttributeLocation location, const char* name) {
-    if (location >= MAX_ATTRIBUTES) {
-        throw gl::Error("too many vertex attributes");
+void bindAttributeLocation(Context& context, ProgramID id, AttributeLocation location, const char* name) {
+    // We're using sequentially numberered attribute locations starting with 0. Therefore we can use
+    // the location as a proxy for the number of attributes.
+    if (location >= context.maximumVertexBindingCount) {
+        // Don't bind the location on this hardware since it exceeds the limit (otherwise we'd get
+        // an OpenGL error). This means we'll see rendering errors, and possibly slow rendering due
+        // to unbound attributes.
+    } else {
+        MBGL_CHECK_ERROR(glBindAttribLocation(id, location, name));
     }
-    MBGL_CHECK_ERROR(glBindAttribLocation(id, location, name));
 }
 
 std::set<std::string> getActiveAttributes(ProgramID id) {

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -226,7 +226,7 @@ public:
     State<value::BindVertexBuffer> vertexBuffer;
 
     State<value::BindVertexArray, const Context&> bindVertexArray { *this };
-    VertexArrayState globalVertexArrayState { UniqueVertexArray(0, { this }), *this };
+    VertexArrayState globalVertexArrayState { UniqueVertexArray(0, { this }) };
 
     State<value::PixelStorePack> pixelStorePack;
     State<value::PixelStoreUnpack> pixelStoreUnpack;
@@ -239,6 +239,8 @@ public:
 #endif // MBGL_USE_GLES2
 
     bool supportsHalfFloatTextures = false;
+    const uint32_t maximumVertexBindingCount;
+    static constexpr const uint32_t minimumRequiredVertexBindingCount = 8;
     
 private:
     State<value::StencilFunc> stencilFunc;

--- a/src/mbgl/gl/program.hpp
+++ b/src/mbgl/gl/program.hpp
@@ -35,7 +35,7 @@ public:
               context.createProgram(context.createShader(ShaderType::Vertex, vertexSource),
                                     context.createShader(ShaderType::Fragment, fragmentSource))),
           uniformsState((context.linkProgram(program), Uniforms::bindLocations(program))),
-          attributeLocations(Attributes::bindLocations(program)) {
+          attributeLocations(Attributes::bindLocations(context, program)) {
 
         // Re-link program after manually binding only active attributes in Attributes::bindLocations
         context.linkProgram(program);

--- a/src/mbgl/gl/vertex_array.cpp
+++ b/src/mbgl/gl/vertex_array.cpp
@@ -9,7 +9,11 @@ void VertexArray::bind(Context& context, BufferID indexBuffer, const AttributeBi
     context.bindVertexArray = state->vertexArray;
     state->indexBuffer = indexBuffer;
 
-    for (AttributeLocation location = 0; location < MAX_ATTRIBUTES; ++location) {
+    state->bindings.reserve(bindings.size());
+    for (AttributeLocation location = 0; location < bindings.size(); ++location) {
+        if (state->bindings.size() <= location) {
+            state->bindings.emplace_back(context, AttributeLocation(location));
+        }
         state->bindings[location] = bindings[location];
     }
 }

--- a/src/mbgl/gl/vertex_array.hpp
+++ b/src/mbgl/gl/vertex_array.hpp
@@ -15,9 +15,8 @@ class Context;
 
 class VertexArrayState {
 public:
-    VertexArrayState(UniqueVertexArray vertexArray_, Context& context)
-        : vertexArray(std::move(vertexArray_)),
-          bindings(makeBindings(context, std::make_index_sequence<MAX_ATTRIBUTES>())) {
+    VertexArrayState(UniqueVertexArray vertexArray_)
+        : vertexArray(std::move(vertexArray_)) {
     }
 
     void setDirty() {
@@ -31,13 +30,7 @@ public:
     State<value::BindElementBuffer> indexBuffer;
 
     using AttributeState = State<value::VertexAttribute, Context&, AttributeLocation>;
-    std::array<AttributeState, MAX_ATTRIBUTES> bindings;
-
-private:
-    template <std::size_t... I>
-    std::array<AttributeState, MAX_ATTRIBUTES> makeBindings(Context& context, std::index_sequence<I...>) {
-        return {{ AttributeState { context, I }... }};
-    }
+    std::vector<AttributeState> bindings;
 };
 
 class VertexArrayStateDeleter {

--- a/src/mbgl/programs/program.hpp
+++ b/src/mbgl/programs/program.hpp
@@ -46,7 +46,7 @@ public:
             Shaders::fragmentSource)) {
     }
 
-    static typename AllUniforms::Values allUniformValues(
+    static typename AllUniforms::Values computeAllUniformValues(
         const UniformValues& uniformValues,
         const PaintPropertyBinders& paintPropertyBinders,
         const typename PaintProperties::PossiblyEvaluated& currentProperties,
@@ -55,7 +55,7 @@ public:
             .concat(paintPropertyBinders.uniformValues(currentZoom, currentProperties));
     }
 
-    static typename Attributes::Bindings allAttributeBindings(
+    static typename Attributes::Bindings computeAllAttributeBindings(
         const gl::VertexBuffer<LayoutVertex>& layoutVertexBuffer,
         const PaintPropertyBinders& paintPropertyBinders,
         const typename PaintProperties::PossiblyEvaluated& currentProperties) {

--- a/src/mbgl/programs/program.hpp
+++ b/src/mbgl/programs/program.hpp
@@ -46,26 +46,34 @@ public:
             Shaders::fragmentSource)) {
     }
 
+    static typename AllUniforms::Values allUniformValues(
+        const UniformValues& uniformValues,
+        const PaintPropertyBinders& paintPropertyBinders,
+        const typename PaintProperties::PossiblyEvaluated& currentProperties,
+        float currentZoom) {
+        return uniformValues
+            .concat(paintPropertyBinders.uniformValues(currentZoom, currentProperties));
+    }
+
+    static typename Attributes::Bindings allAttributeBindings(
+        const gl::VertexBuffer<LayoutVertex>& layoutVertexBuffer,
+        const PaintPropertyBinders& paintPropertyBinders,
+        const typename PaintProperties::PossiblyEvaluated& currentProperties) {
+        return LayoutAttributes::bindings(layoutVertexBuffer)
+            .concat(paintPropertyBinders.attributeBindings(currentProperties));
+    }
+
     template <class DrawMode>
     void draw(gl::Context& context,
               DrawMode drawMode,
               gl::DepthMode depthMode,
               gl::StencilMode stencilMode,
               gl::ColorMode colorMode,
-              const UniformValues& uniformValues,
-              const gl::VertexBuffer<LayoutVertex>& layoutVertexBuffer,
               const gl::IndexBuffer<DrawMode>& indexBuffer,
               const SegmentVector<Attributes>& segments,
-              const PaintPropertyBinders& paintPropertyBinders,
-              const typename PaintProperties::PossiblyEvaluated& currentProperties,
-              float currentZoom,
+              const typename AllUniforms::Values& allUniformValues,
+              const typename Attributes::Bindings& allAttributeBindings,
               const std::string& layerID) {
-        typename AllUniforms::Values allUniformValues = uniformValues
-            .concat(paintPropertyBinders.uniformValues(currentZoom, currentProperties));
-
-        typename Attributes::Bindings allAttributeBindings = LayoutAttributes::bindings(layoutVertexBuffer)
-            .concat(paintPropertyBinders.attributeBindings(currentProperties));
-
         for (auto& segment : segments) {
             auto vertexArrayIt = segment.vertexArrays.find(layerID);
 

--- a/src/mbgl/programs/program.hpp
+++ b/src/mbgl/programs/program.hpp
@@ -63,6 +63,10 @@ public:
             .concat(paintPropertyBinders.attributeBindings(currentProperties));
     }
 
+    static uint32_t activeBindingCount(const typename Attributes::Bindings& allAttributeBindings) {
+        return Attributes::activeBindingCount(allAttributeBindings);
+    }
+
     template <class DrawMode>
     void draw(gl::Context& context,
               DrawMode drawMode,

--- a/src/mbgl/programs/symbol_program.hpp
+++ b/src/mbgl/programs/symbol_program.hpp
@@ -278,35 +278,41 @@ public:
             Shaders::fragmentSource)) {
     }
 
+    static typename AllUniforms::Values allUniformValues(
+        const UniformValues& uniformValues,
+        const SymbolSizeBinder& symbolSizeBinder,
+        const PaintPropertyBinders& paintPropertyBinders,
+        const typename PaintProperties::PossiblyEvaluated& currentProperties,
+        float currentZoom) {
+        return uniformValues.concat(symbolSizeBinder.uniformValues(currentZoom))
+            .concat(paintPropertyBinders.uniformValues(currentZoom, currentProperties));
+    }
+
+    static typename Attributes::Bindings allAttributeBindings(
+        const gl::VertexBuffer<LayoutVertex>& layoutVertexBuffer,
+        const gl::VertexBuffer<SymbolDynamicLayoutAttributes::Vertex>& dynamicLayoutVertexBuffer,
+        const gl::VertexBuffer<SymbolOpacityAttributes::Vertex>& opacityVertexBuffer,
+        const PaintPropertyBinders& paintPropertyBinders,
+        const typename PaintProperties::PossiblyEvaluated& currentProperties) {
+        assert(layoutVertexBuffer.vertexCount == dynamicLayoutVertexBuffer.vertexCount &&
+               layoutVertexBuffer.vertexCount == opacityVertexBuffer.vertexCount);
+        return LayoutAttributes::bindings(layoutVertexBuffer)
+            .concat(SymbolDynamicLayoutAttributes::bindings(dynamicLayoutVertexBuffer))
+            .concat(SymbolOpacityAttributes::bindings(opacityVertexBuffer))
+            .concat(paintPropertyBinders.attributeBindings(currentProperties));
+    }
+
     template <class DrawMode>
     void draw(gl::Context& context,
               DrawMode drawMode,
               gl::DepthMode depthMode,
               gl::StencilMode stencilMode,
               gl::ColorMode colorMode,
-              const UniformValues& uniformValues,
-              const gl::VertexBuffer<LayoutVertex>& layoutVertexBuffer,
-              const gl::VertexBuffer<SymbolDynamicLayoutAttributes::Vertex>& dynamicLayoutVertexBuffer,
-              const gl::VertexBuffer<SymbolOpacityAttributes::Vertex>& opacityVertexBuffer,
-              const SymbolSizeBinder& symbolSizeBinder,
               const gl::IndexBuffer<DrawMode>& indexBuffer,
               const SegmentVector<Attributes>& segments,
-              const PaintPropertyBinders& paintPropertyBinders,
-              const typename PaintProperties::PossiblyEvaluated& currentProperties,
-              float currentZoom,
+              const typename AllUniforms::Values& allUniformValues,
+              const typename Attributes::Bindings& allAttributeBindings,
               const std::string& layerID) {
-        typename AllUniforms::Values allUniformValues = uniformValues
-            .concat(symbolSizeBinder.uniformValues(currentZoom))
-            .concat(paintPropertyBinders.uniformValues(currentZoom, currentProperties));
-
-        typename Attributes::Bindings allAttributeBindings = LayoutAttributes::bindings(layoutVertexBuffer)
-            .concat(SymbolDynamicLayoutAttributes::bindings(dynamicLayoutVertexBuffer))
-            .concat(SymbolOpacityAttributes::bindings(opacityVertexBuffer))
-            .concat(paintPropertyBinders.attributeBindings(currentProperties));
-
-        assert(layoutVertexBuffer.vertexCount == dynamicLayoutVertexBuffer.vertexCount &&
-                layoutVertexBuffer.vertexCount == opacityVertexBuffer.vertexCount);
-
         for (auto& segment : segments) {
             auto vertexArrayIt = segment.vertexArrays.find(layerID);
 

--- a/src/mbgl/programs/symbol_program.hpp
+++ b/src/mbgl/programs/symbol_program.hpp
@@ -278,7 +278,7 @@ public:
             Shaders::fragmentSource)) {
     }
 
-    static typename AllUniforms::Values allUniformValues(
+    static typename AllUniforms::Values computeAllUniformValues(
         const UniformValues& uniformValues,
         const SymbolSizeBinder& symbolSizeBinder,
         const PaintPropertyBinders& paintPropertyBinders,
@@ -288,7 +288,7 @@ public:
             .concat(paintPropertyBinders.uniformValues(currentZoom, currentProperties));
     }
 
-    static typename Attributes::Bindings allAttributeBindings(
+    static typename Attributes::Bindings computeAllAttributeBindings(
         const gl::VertexBuffer<LayoutVertex>& layoutVertexBuffer,
         const gl::VertexBuffer<SymbolDynamicLayoutAttributes::Vertex>& dynamicLayoutVertexBuffer,
         const gl::VertexBuffer<SymbolOpacityAttributes::Vertex>& opacityVertexBuffer,

--- a/src/mbgl/programs/symbol_program.hpp
+++ b/src/mbgl/programs/symbol_program.hpp
@@ -302,6 +302,10 @@ public:
             .concat(paintPropertyBinders.attributeBindings(currentProperties));
     }
 
+    static uint32_t activeBindingCount(const typename Attributes::Bindings& allAttributeBindings) {
+        return Attributes::activeBindingCount(allAttributeBindings);
+    }
+
     template <class DrawMode>
     void draw(gl::Context& context,
               DrawMode drawMode,

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -62,6 +62,8 @@ void RenderBackgroundLayer::render(PaintParameters& parameters, RenderSource*) {
             properties
         );
 
+        checkRenderability(parameters, program.activeBindingCount(allAttributeBindings));
+
         program.draw(
             parameters.context,
             gl::Triangles(),

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -49,6 +49,33 @@ void RenderBackgroundLayer::render(PaintParameters& parameters, RenderSource*) {
     const Properties<>::PossiblyEvaluated properties;
     const BackgroundProgram::PaintPropertyBinders paintAttributeData(properties, 0);
 
+    auto draw = [&](auto& program, auto&& uniformValues) {
+        const auto allUniformValues = program.allUniformValues(
+            std::move(uniformValues),
+            paintAttributeData,
+            properties,
+            parameters.state.getZoom()
+        );
+        const auto allAttributeBindings = program.allAttributeBindings(
+            parameters.staticData.tileVertexBuffer,
+            paintAttributeData,
+            properties
+        );
+
+        program.draw(
+            parameters.context,
+            gl::Triangles(),
+            parameters.depthModeForSublayer(0, gl::DepthMode::ReadOnly),
+            gl::StencilMode::disabled(),
+            parameters.colorModeForRenderPass(),
+            parameters.staticData.quadTriangleIndexBuffer,
+            parameters.staticData.tileTriangleSegments,
+            allUniformValues,
+            allAttributeBindings,
+            getID()
+        );
+    };
+
     if (!evaluated.get<BackgroundPattern>().to.empty()) {
         optional<ImagePosition> imagePosA = parameters.imageManager.getPattern(evaluated.get<BackgroundPattern>().from);
         optional<ImagePosition> imagePosB = parameters.imageManager.getPattern(evaluated.get<BackgroundPattern>().to);
@@ -59,12 +86,8 @@ void RenderBackgroundLayer::render(PaintParameters& parameters, RenderSource*) {
         parameters.imageManager.bind(parameters.context, 0);
 
         for (const auto& tileID : util::tileCover(parameters.state, parameters.state.getIntegerZoom())) {
-            parameters.programs.backgroundPattern.draw(
-                parameters.context,
-                gl::Triangles(),
-                parameters.depthModeForSublayer(0, gl::DepthMode::ReadOnly),
-                gl::StencilMode::disabled(),
-                parameters.colorModeForRenderPass(),
+            draw(
+                parameters.programs.backgroundPattern,
                 BackgroundPatternUniforms::values(
                     parameters.matrixForTile(tileID),
                     evaluated.get<BackgroundOpacity>(),
@@ -74,36 +97,18 @@ void RenderBackgroundLayer::render(PaintParameters& parameters, RenderSource*) {
                     evaluated.get<BackgroundPattern>(),
                     tileID,
                     parameters.state
-                ),
-                parameters.staticData.tileVertexBuffer,
-                parameters.staticData.quadTriangleIndexBuffer,
-                parameters.staticData.tileTriangleSegments,
-                paintAttributeData,
-                properties,
-                parameters.state.getZoom(),
-                getID()
+                )
             );
         }
     } else {
         for (const auto& tileID : util::tileCover(parameters.state, parameters.state.getIntegerZoom())) {
-            parameters.programs.background.draw(
-                parameters.context,
-                gl::Triangles(),
-                parameters.depthModeForSublayer(0, gl::DepthMode::ReadOnly),
-                gl::StencilMode::disabled(),
-                parameters.colorModeForRenderPass(),
+            draw(
+                parameters.programs.background,
                 BackgroundProgram::UniformValues {
                     uniforms::u_matrix::Value{ parameters.matrixForTile(tileID) },
                     uniforms::u_color::Value{ evaluated.get<BackgroundColor>() },
                     uniforms::u_opacity::Value{ evaluated.get<BackgroundOpacity>() },
-                },
-                parameters.staticData.tileVertexBuffer,
-                parameters.staticData.quadTriangleIndexBuffer,
-                parameters.staticData.tileTriangleSegments,
-                paintAttributeData,
-                properties,
-                parameters.state.getZoom(),
-                getID()
+                }
             );
         }
     }

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -50,13 +50,13 @@ void RenderBackgroundLayer::render(PaintParameters& parameters, RenderSource*) {
     const BackgroundProgram::PaintPropertyBinders paintAttributeData(properties, 0);
 
     auto draw = [&](auto& program, auto&& uniformValues) {
-        const auto allUniformValues = program.allUniformValues(
+        const auto allUniformValues = program.computeAllUniformValues(
             std::move(uniformValues),
             paintAttributeData,
             properties,
             parameters.state.getZoom()
         );
-        const auto allAttributeBindings = program.allAttributeBindings(
+        const auto allAttributeBindings = program.computeAllAttributeBindings(
             parameters.staticData.tileVertexBuffer,
             paintAttributeData,
             properties

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -63,7 +63,7 @@ void RenderCircleLayer::render(PaintParameters& parameters, RenderSource*) {
 
         auto& programInstance = parameters.programs.circle.get(evaluated);
    
-        const auto allUniformValues = programInstance.allUniformValues(
+        const auto allUniformValues = programInstance.computeAllUniformValues(
             CircleProgram::UniformValues {
                 uniforms::u_matrix::Value{
                     tile.translatedMatrix(evaluated.get<CircleTranslate>(),
@@ -83,7 +83,7 @@ void RenderCircleLayer::render(PaintParameters& parameters, RenderSource*) {
             evaluated,
             parameters.state.getZoom()
         );
-        const auto allAttributeBindings = programInstance.allAttributeBindings(
+        const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
             *bucket.vertexBuffer,
             paintPropertyBinders,
             evaluated

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -89,6 +89,8 @@ void RenderCircleLayer::render(PaintParameters& parameters, RenderSource*) {
             evaluated
         );
 
+        checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
+
         programInstance.draw(
             parameters.context,
             gl::Triangles(),

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -83,6 +83,8 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters, RenderSource*
                 evaluated
             );
 
+            checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
+
             programInstance.draw(
                 parameters.context,
                 gl::Triangles(),
@@ -175,6 +177,8 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters, RenderSource*
             paintAttributeData,
             properties
         );
+
+        checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
 
         programInstance.draw(
             parameters.context,

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -68,17 +68,17 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters, RenderSource*
         parameters.context.setStencilMode(gl::StencilMode::disabled());
         parameters.context.clear(Color{ 0.0f, 0.0f, 0.0f, 0.0f }, depthClearValue, {});
 
-        auto draw = [&](auto& programInstance, const auto& bucket, auto&& uniformValues) {
-            const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
+        auto draw = [&](auto& programInstance, const auto& tileBucket, auto&& uniformValues) {
+            const auto& paintPropertyBinders = tileBucket.paintPropertyBinders.at(getID());
 
-            const auto allUniformValues = programInstance.allUniformValues(
+            const auto allUniformValues = programInstance.computeAllUniformValues(
                 std::move(uniformValues),
                 paintPropertyBinders,
                 evaluated,
                 parameters.state.getZoom()
             );
-            const auto allAttributeBindings = programInstance.allAttributeBindings(
-                *bucket.vertexBuffer,
+            const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
+                *tileBucket.vertexBuffer,
                 paintPropertyBinders,
                 evaluated
             );
@@ -91,8 +91,8 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters, RenderSource*
                 parameters.depthModeFor3D(gl::DepthMode::ReadWrite),
                 gl::StencilMode::disabled(),
                 parameters.colorModeForRenderPass(),
-                *bucket.indexBuffer,
-                bucket.triangleSegments,
+                *tileBucket.indexBuffer,
+                tileBucket.triangleSegments,
                 allUniformValues,
                 allAttributeBindings,
                 getID());
@@ -162,7 +162,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters, RenderSource*
         
         auto& programInstance = parameters.programs.extrusionTexture;
 
-        const auto allUniformValues = programInstance.allUniformValues(
+        const auto allUniformValues = programInstance.computeAllUniformValues(
             ExtrusionTextureProgram::UniformValues{
                 uniforms::u_matrix::Value{ viewportMat }, uniforms::u_world::Value{ size },
                 uniforms::u_image::Value{ 0 },
@@ -172,7 +172,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters, RenderSource*
             properties,
             parameters.state.getZoom()
         );
-        const auto allAttributeBindings = programInstance.allAttributeBindings(
+        const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
             parameters.staticData.extrusionTextureVertexBuffer,
             paintAttributeData,
             properties

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -92,6 +92,8 @@ void RenderFillLayer::render(PaintParameters& parameters, RenderSource*) {
                     evaluated
                 );
 
+                checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
+
                 programInstance.draw(
                     parameters.context,
                     drawMode,
@@ -178,6 +180,8 @@ void RenderFillLayer::render(PaintParameters& parameters, RenderSource*) {
                     paintPropertyBinders,
                     evaluated
                 );
+
+                checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
 
                 programInstance.draw(
                     parameters.context,

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -73,7 +73,7 @@ void RenderFillLayer::render(PaintParameters& parameters, RenderSource*) {
 
                 const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
 
-                const auto allUniformValues = programInstance.allUniformValues(
+                const auto allUniformValues = programInstance.computeAllUniformValues(
                     FillProgram::UniformValues {
                         uniforms::u_matrix::Value{
                             tile.translatedMatrix(evaluated.get<FillTranslate>(),
@@ -86,7 +86,7 @@ void RenderFillLayer::render(PaintParameters& parameters, RenderSource*) {
                     evaluated,
                     parameters.state.getZoom()
                 );
-                const auto allAttributeBindings = programInstance.allAttributeBindings(
+                const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
                     *bucket.vertexBuffer,
                     paintPropertyBinders,
                     evaluated
@@ -158,7 +158,7 @@ void RenderFillLayer::render(PaintParameters& parameters, RenderSource*) {
 
                 const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
 
-                const auto allUniformValues = programInstance.allUniformValues(
+                const auto allUniformValues = programInstance.computeAllUniformValues(
                     FillPatternUniforms::values(
                         tile.translatedMatrix(evaluated.get<FillTranslate>(),
                                               evaluated.get<FillTranslateAnchor>(),
@@ -175,7 +175,7 @@ void RenderFillLayer::render(PaintParameters& parameters, RenderSource*) {
                     evaluated,
                     parameters.state.getZoom()
                 );
-                const auto allAttributeBindings = programInstance.allAttributeBindings(
+                const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
                     *bucket.vertexBuffer,
                     paintPropertyBinders,
                     evaluated

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -69,12 +69,11 @@ void RenderFillLayer::render(PaintParameters& parameters, RenderSource*) {
                              const auto& depthMode,
                              const auto& indexBuffer,
                              const auto& segments) {
-                program.get(evaluated).draw(
-                    parameters.context,
-                    drawMode,
-                    depthMode,
-                    parameters.stencilModeForClipping(tile.clip),
-                    parameters.colorModeForRenderPass(),
+                auto& programInstance = program.get(evaluated);
+
+                const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
+
+                const auto allUniformValues = programInstance.allUniformValues(
                     FillProgram::UniformValues {
                         uniforms::u_matrix::Value{
                             tile.translatedMatrix(evaluated.get<FillTranslate>(),
@@ -83,12 +82,26 @@ void RenderFillLayer::render(PaintParameters& parameters, RenderSource*) {
                         },
                         uniforms::u_world::Value{ parameters.context.viewport.getCurrentValue().size },
                     },
+                    paintPropertyBinders,
+                    evaluated,
+                    parameters.state.getZoom()
+                );
+                const auto allAttributeBindings = programInstance.allAttributeBindings(
                     *bucket.vertexBuffer,
+                    paintPropertyBinders,
+                    evaluated
+                );
+
+                programInstance.draw(
+                    parameters.context,
+                    drawMode,
+                    depthMode,
+                    parameters.stencilModeForClipping(tile.clip),
+                    parameters.colorModeForRenderPass(),
                     indexBuffer,
                     segments,
-                    bucket.paintPropertyBinders.at(getID()),
-                    evaluated,
-                    parameters.state.getZoom(),
+                    allUniformValues,
+                    allAttributeBindings,
                     getID()
                 );
             };
@@ -139,12 +152,11 @@ void RenderFillLayer::render(PaintParameters& parameters, RenderSource*) {
                              const auto& depthMode,
                              const auto& indexBuffer,
                              const auto& segments) {
-                program.get(evaluated).draw(
-                    parameters.context,
-                    drawMode,
-                    depthMode,
-                    parameters.stencilModeForClipping(tile.clip),
-                    parameters.colorModeForRenderPass(),
+                auto& programInstance = program.get(evaluated);
+
+                const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
+
+                const auto allUniformValues = programInstance.allUniformValues(
                     FillPatternUniforms::values(
                         tile.translatedMatrix(evaluated.get<FillTranslate>(),
                                               evaluated.get<FillTranslateAnchor>(),
@@ -157,12 +169,26 @@ void RenderFillLayer::render(PaintParameters& parameters, RenderSource*) {
                         tile.id,
                         parameters.state
                     ),
+                    paintPropertyBinders,
+                    evaluated,
+                    parameters.state.getZoom()
+                );
+                const auto allAttributeBindings = programInstance.allAttributeBindings(
                     *bucket.vertexBuffer,
+                    paintPropertyBinders,
+                    evaluated
+                );
+
+                programInstance.draw(
+                    parameters.context,
+                    drawMode,
+                    depthMode,
+                    parameters.stencilModeForClipping(tile.clip),
+                    parameters.colorModeForRenderPass(),
                     indexBuffer,
                     segments,
-                    bucket.paintPropertyBinders.at(getID()),
-                    evaluated,
-                    parameters.state.getZoom(),
+                    allUniformValues,
+                    allAttributeBindings,
                     getID()
                 );
             };

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -112,6 +112,8 @@ void RenderHeatmapLayer::render(PaintParameters& parameters, RenderSource*) {
                 evaluated
             );
 
+            checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
+
             programInstance.draw(
                 parameters.context,
                 gl::Triangles(),
@@ -156,6 +158,8 @@ void RenderHeatmapLayer::render(PaintParameters& parameters, RenderSource*) {
             paintAttributeData,
             properties
         );
+
+        checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
 
         programInstance.draw(
             parameters.context,

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -92,23 +92,36 @@ void RenderHeatmapLayer::render(PaintParameters& parameters, RenderSource*) {
                 ? parameters.stencilModeForClipping(tile.clip)
                 : gl::StencilMode::disabled();
 
-            parameters.programs.heatmap.get(evaluated).draw(
+            const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
+
+            auto& programInstance = parameters.programs.heatmap.get(evaluated);
+       
+            const auto allUniformValues = programInstance.allUniformValues(
+                HeatmapProgram::UniformValues {
+                    uniforms::u_intensity::Value{ evaluated.get<style::HeatmapIntensity>() },
+                    uniforms::u_matrix::Value{ tile.matrix },
+                    uniforms::heatmap::u_extrude_scale::Value{ extrudeScale }
+                },
+                paintPropertyBinders,
+                evaluated,
+                parameters.state.getZoom()
+            );
+            const auto allAttributeBindings = programInstance.allAttributeBindings(
+                *bucket.vertexBuffer,
+                paintPropertyBinders,
+                evaluated
+            );
+
+            programInstance.draw(
                 parameters.context,
                 gl::Triangles(),
                 parameters.depthModeForSublayer(0, gl::DepthMode::ReadOnly),
                 stencilMode,
                 gl::ColorMode::additive(),
-                HeatmapProgram::UniformValues {
-                    uniforms::u_intensity::Value{evaluated.get<style::HeatmapIntensity>()},
-                    uniforms::u_matrix::Value{tile.matrix},
-                    uniforms::heatmap::u_extrude_scale::Value{extrudeScale}
-                },
-                *bucket.vertexBuffer,
                 *bucket.indexBuffer,
                 bucket.segments,
-                bucket.paintPropertyBinders.at(getID()),
-                evaluated,
-                parameters.state.getZoom(),
+                allUniformValues,
+                allAttributeBindings,
                 getID()
             );
         }
@@ -123,20 +136,39 @@ void RenderHeatmapLayer::render(PaintParameters& parameters, RenderSource*) {
         matrix::ortho(viewportMat, 0, size.width, size.height, 0, 0, 1);
 
         const Properties<>::PossiblyEvaluated properties;
+        const HeatmapTextureProgram::PaintPropertyBinders paintAttributeData{ properties, 0 };
 
-        parameters.programs.heatmapTexture.draw(
-            parameters.context, gl::Triangles(), gl::DepthMode::disabled(),
-            gl::StencilMode::disabled(), parameters.colorModeForRenderPass(),
+        auto& programInstance = parameters.programs.heatmapTexture;
+
+        const auto allUniformValues = programInstance.allUniformValues(
             HeatmapTextureProgram::UniformValues{
                 uniforms::u_matrix::Value{ viewportMat }, uniforms::u_world::Value{ size },
                 uniforms::u_image::Value{ 0 },
                 uniforms::u_color_ramp::Value{ 1 },
-                uniforms::u_opacity::Value{ evaluated.get<HeatmapOpacity>() } },
+                uniforms::u_opacity::Value{ evaluated.get<HeatmapOpacity>() }
+            },
+            paintAttributeData,
+            properties,
+            parameters.state.getZoom()
+        );
+        const auto allAttributeBindings = programInstance.allAttributeBindings(
             parameters.staticData.extrusionTextureVertexBuffer,
+            paintAttributeData,
+            properties
+        );
+
+        programInstance.draw(
+            parameters.context,
+            gl::Triangles(),
+            gl::DepthMode::disabled(),
+            gl::StencilMode::disabled(),
+            parameters.colorModeForRenderPass(),
             parameters.staticData.quadTriangleIndexBuffer,
             parameters.staticData.extrusionTextureSegments,
-            HeatmapTextureProgram::PaintPropertyBinders{ properties, 0 }, properties,
-            parameters.state.getZoom(), getID());
+            allUniformValues,
+            allAttributeBindings,
+            getID()
+        );
     }
 }
 

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -96,7 +96,7 @@ void RenderHeatmapLayer::render(PaintParameters& parameters, RenderSource*) {
 
             auto& programInstance = parameters.programs.heatmap.get(evaluated);
        
-            const auto allUniformValues = programInstance.allUniformValues(
+            const auto allUniformValues = programInstance.computeAllUniformValues(
                 HeatmapProgram::UniformValues {
                     uniforms::u_intensity::Value{ evaluated.get<style::HeatmapIntensity>() },
                     uniforms::u_matrix::Value{ tile.matrix },
@@ -106,7 +106,7 @@ void RenderHeatmapLayer::render(PaintParameters& parameters, RenderSource*) {
                 evaluated,
                 parameters.state.getZoom()
             );
-            const auto allAttributeBindings = programInstance.allAttributeBindings(
+            const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
                 *bucket.vertexBuffer,
                 paintPropertyBinders,
                 evaluated
@@ -142,7 +142,7 @@ void RenderHeatmapLayer::render(PaintParameters& parameters, RenderSource*) {
 
         auto& programInstance = parameters.programs.heatmapTexture;
 
-        const auto allUniformValues = programInstance.allUniformValues(
+        const auto allUniformValues = programInstance.computeAllUniformValues(
             HeatmapTextureProgram::UniformValues{
                 uniforms::u_matrix::Value{ viewportMat }, uniforms::u_world::Value{ size },
                 uniforms::u_image::Value{ 0 },
@@ -153,7 +153,7 @@ void RenderHeatmapLayer::render(PaintParameters& parameters, RenderSource*) {
             properties,
             parameters.state.getZoom()
         );
-        const auto allAttributeBindings = programInstance.allAttributeBindings(
+        const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
             parameters.staticData.extrusionTextureVertexBuffer,
             paintAttributeData,
             properties

--- a/src/mbgl/renderer/layers/render_hillshade_layer.cpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.cpp
@@ -93,6 +93,8 @@ void RenderHillshadeLayer::render(PaintParameters& parameters, RenderSource* src
             evaluated
         );
 
+        checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
+
         programInstance.draw(
             parameters.context,
             gl::Triangles(),
@@ -146,6 +148,8 @@ void RenderHillshadeLayer::render(PaintParameters& parameters, RenderSource* src
                 paintAttributeData,
                 properties
             );
+
+            checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
 
             programInstance.draw(
                 parameters.context,

--- a/src/mbgl/renderer/layers/render_hillshade_layer.cpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.cpp
@@ -73,7 +73,7 @@ void RenderHillshadeLayer::render(PaintParameters& parameters, RenderSource* src
 
         const HillshadeProgram::PaintPropertyBinders paintAttributeData{ evaluated, 0 };
 
-        const auto allUniformValues = programInstance.allUniformValues(
+        const auto allUniformValues = programInstance.computeAllUniformValues(
             HillshadeProgram::UniformValues {
                 uniforms::u_matrix::Value{ matrix },
                 uniforms::u_image::Value{ 0 },
@@ -87,7 +87,7 @@ void RenderHillshadeLayer::render(PaintParameters& parameters, RenderSource* src
             evaluated,
             parameters.state.getZoom()
         );
-        const auto allAttributeBindings = programInstance.allAttributeBindings(
+        const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
             vertexBuffer,
             paintAttributeData,
             evaluated
@@ -131,7 +131,7 @@ void RenderHillshadeLayer::render(PaintParameters& parameters, RenderSource* src
             
             auto& programInstance = parameters.programs.hillshadePrepare;
 
-            const auto allUniformValues = programInstance.allUniformValues(
+            const auto allUniformValues = programInstance.computeAllUniformValues(
                 HillshadePrepareProgram::UniformValues {
                     uniforms::u_matrix::Value { mat },
                     uniforms::u_dimension::Value { {{uint16_t(tilesize * 2), uint16_t(tilesize * 2) }} },
@@ -143,7 +143,7 @@ void RenderHillshadeLayer::render(PaintParameters& parameters, RenderSource* src
                 properties,
                 parameters.state.getZoom()
             );
-            const auto allAttributeBindings = programInstance.allAttributeBindings(
+            const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
                 parameters.staticData.rasterVertexBuffer,
                 paintAttributeData,
                 properties

--- a/src/mbgl/renderer/layers/render_hillshade_layer.cpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.cpp
@@ -69,12 +69,11 @@ void RenderHillshadeLayer::render(PaintParameters& parameters, RenderSource* src
                      const auto& indexBuffer,
                      const auto& segments,
                      const UnwrappedTileID& id) {
-        parameters.programs.hillshade.draw(
-            parameters.context,
-            gl::Triangles(),
-            parameters.depthModeForSublayer(0, gl::DepthMode::ReadOnly),
-            gl::StencilMode::disabled(),
-            parameters.colorModeForRenderPass(),
+        auto& programInstance = parameters.programs.hillshade;
+
+        const HillshadeProgram::PaintPropertyBinders paintAttributeData{ evaluated, 0 };
+
+        const auto allUniformValues = programInstance.allUniformValues(
             HillshadeProgram::UniformValues {
                 uniforms::u_matrix::Value{ matrix },
                 uniforms::u_image::Value{ 0 },
@@ -84,12 +83,26 @@ void RenderHillshadeLayer::render(PaintParameters& parameters, RenderSource* src
                 uniforms::u_light::Value{ getLight(parameters) },
                 uniforms::u_latrange::Value{ getLatRange(id) },
             },
+            paintAttributeData,
+            evaluated,
+            parameters.state.getZoom()
+        );
+        const auto allAttributeBindings = programInstance.allAttributeBindings(
             vertexBuffer,
+            paintAttributeData,
+            evaluated
+        );
+
+        programInstance.draw(
+            parameters.context,
+            gl::Triangles(),
+            parameters.depthModeForSublayer(0, gl::DepthMode::ReadOnly),
+            gl::StencilMode::disabled(),
+            parameters.colorModeForRenderPass(),
             indexBuffer,
             segments,
-            HillshadeProgram::PaintPropertyBinders { evaluated, 0 },
-            evaluated,
-            parameters.state.getZoom(),
+            allUniformValues,
+            allAttributeBindings,
             getID()
         );
     };
@@ -112,13 +125,11 @@ void RenderHillshadeLayer::render(PaintParameters& parameters, RenderSource* src
             
             parameters.context.bindTexture(*bucket.dem, 0, gl::TextureFilter::Nearest, gl::TextureMipMap::No, gl::TextureWrap::Clamp, gl::TextureWrap::Clamp);
             const Properties<>::PossiblyEvaluated properties;
+            const HillshadePrepareProgram::PaintPropertyBinders paintAttributeData{ properties, 0 };
             
-            parameters.programs.hillshadePrepare.draw(
-                parameters.context,
-                gl::Triangles(),
-                parameters.depthModeForSublayer(0, gl::DepthMode::ReadOnly),
-                gl::StencilMode::disabled(),
-                parameters.colorModeForRenderPass(),
+            auto& programInstance = parameters.programs.hillshadePrepare;
+
+            const auto allUniformValues = programInstance.allUniformValues(
                 HillshadePrepareProgram::UniformValues {
                     uniforms::u_matrix::Value { mat },
                     uniforms::u_dimension::Value { {{uint16_t(tilesize * 2), uint16_t(tilesize * 2) }} },
@@ -126,12 +137,26 @@ void RenderHillshadeLayer::render(PaintParameters& parameters, RenderSource* src
                     uniforms::u_maxzoom::Value{ float(maxzoom) },
                     uniforms::u_image::Value{ 0 }
                 },
+                paintAttributeData,
+                properties,
+                parameters.state.getZoom()
+            );
+            const auto allAttributeBindings = programInstance.allAttributeBindings(
                 parameters.staticData.rasterVertexBuffer,
+                paintAttributeData,
+                properties
+            );
+
+            programInstance.draw(
+                parameters.context,
+                gl::Triangles(),
+                parameters.depthModeForSublayer(0, gl::DepthMode::ReadOnly),
+                gl::StencilMode::disabled(),
+                parameters.colorModeForRenderPass(),
                 parameters.staticData.quadTriangleIndexBuffer,
                 parameters.staticData.rasterSegments,
-                HillshadePrepareProgram::PaintPropertyBinders { properties, 0 },
-                properties,
-                parameters.state.getZoom(),
+                allUniformValues,
+                allAttributeBindings,
                 getID()
             );
             bucket.texture = std::move(view.getTexture());

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -66,13 +66,13 @@ void RenderLineLayer::render(PaintParameters& parameters, RenderSource*) {
 
             const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
 
-            const auto allUniformValues = programInstance.allUniformValues(
+            const auto allUniformValues = programInstance.computeAllUniformValues(
                 std::move(uniformValues),
                 paintPropertyBinders,
                 evaluated,
                 parameters.state.getZoom()
             );
-            const auto allAttributeBindings = programInstance.allAttributeBindings(
+            const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
                 *bucket.vertexBuffer,
                 paintPropertyBinders,
                 evaluated

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -78,6 +78,8 @@ void RenderLineLayer::render(PaintParameters& parameters, RenderSource*) {
                 evaluated
             );
 
+            checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
+
             programInstance.draw(
                 parameters.context,
                 gl::Triangles(),

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -81,7 +81,7 @@ void RenderRasterLayer::render(PaintParameters& parameters, RenderSource* source
                      const auto& segments) {
         auto& programInstance = parameters.programs.raster;
 
-        const auto allUniformValues = programInstance.allUniformValues(
+        const auto allUniformValues = programInstance.computeAllUniformValues(
             RasterProgram::UniformValues {
                 uniforms::u_matrix::Value{ matrix },
                 uniforms::u_image0::Value{ 0 },
@@ -101,7 +101,7 @@ void RenderRasterLayer::render(PaintParameters& parameters, RenderSource* source
             evaluated,
             parameters.state.getZoom()
         );
-        const auto allAttributeBindings = programInstance.allAttributeBindings(
+        const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
             vertexBuffer,
             paintAttributeData,
             evaluated

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -107,6 +107,8 @@ void RenderRasterLayer::render(PaintParameters& parameters, RenderSource* source
             evaluated
         );
 
+        checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
+
         programInstance.draw(
             parameters.context,
             gl::Triangles(),

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -105,6 +105,8 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
                 paintProperties
             );
 
+            checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
+
             programInstance.draw(
                 parameters.context,
                 gl::Triangles(),

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -90,14 +90,14 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
         {
             auto& programInstance = program.get(paintProperties);
 
-            const auto allUniformValues = programInstance.allUniformValues(
+            const auto allUniformValues = programInstance.computeAllUniformValues(
                 std::move(uniformValues),
                 *symbolSizeBinder,
                 binders,
                 paintProperties,
                 parameters.state.getZoom()
             );
-            const auto allAttributeBindings = programInstance.allAttributeBindings(
+            const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
                 *buffers.vertexBuffer,
                 *buffers.dynamicVertexBuffer,
                 *buffers.opacityVertexBuffer,

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -88,7 +88,24 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
                          const auto& binders,
                          const auto& paintProperties)
         {
-            program.get(paintProperties).draw(
+            auto& programInstance = program.get(paintProperties);
+
+            const auto allUniformValues = programInstance.allUniformValues(
+                std::move(uniformValues),
+                *symbolSizeBinder,
+                binders,
+                paintProperties,
+                parameters.state.getZoom()
+            );
+            const auto allAttributeBindings = programInstance.allAttributeBindings(
+                *buffers.vertexBuffer,
+                *buffers.dynamicVertexBuffer,
+                *buffers.opacityVertexBuffer,
+                binders,
+                paintProperties
+            );
+
+            programInstance.draw(
                 parameters.context,
                 gl::Triangles(),
                 values_.pitchAlignment == AlignmentType::Map
@@ -96,16 +113,10 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
                     : gl::DepthMode::disabled(),
                 gl::StencilMode::disabled(),
                 parameters.colorModeForRenderPass(),
-                std::move(uniformValues),
-                *buffers.vertexBuffer,
-                *buffers.dynamicVertexBuffer,
-                *buffers.opacityVertexBuffer,
-                *symbolSizeBinder,
                 *buffers.indexBuffer,
                 buffers.segments,
-                binders,
-                paintProperties,
-                parameters.state.getZoom(),
+                allUniformValues,
+                allAttributeBindings,
                 getID()
             );
         };

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -82,6 +82,11 @@ public:
     friend std::string layoutKey(const RenderLayer&);
 
 protected:
+    // Checks whether the current hardware can render this layer. If it can't, we'll show a warning
+    // in the console to inform the developer.
+    void checkRenderability(const PaintParameters&, uint32_t activeBindingCount);
+
+protected:
     // renderTiles are exposed directly to CrossTileSymbolIndex and Placement so they
     // can update opacities in the symbol buckets immediately before rendering
     friend class CrossTileSymbolIndex;
@@ -92,6 +97,12 @@ protected:
     // Stores what render passes this layer is currently enabled for. This depends on the
     // evaluated StyleProperties object and is updated accordingly.
     RenderPass passes = RenderPass::None;
+
+private:
+    // Some layers may not render correctly on some hardware when the vertex attribute limit of
+    // that GPU is exceeded. More attributes are used when adding many data driven paint properties
+    // to a layer.
+    bool hasRenderFailures = false;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/render_tile.cpp
+++ b/src/mbgl/renderer/render_tile.cpp
@@ -87,7 +87,7 @@ void RenderTile::finishRender(PaintParameters& parameters) {
                 tile.expires, parameters.debugOptions, parameters.context);
         }
 
-        const auto allAttributeBindings = program.allAttributeBindings(
+        const auto allAttributeBindings = program.computeAllAttributeBindings(
             *tile.debugBucket->vertexBuffer,
             paintAttributeData,
             properties
@@ -101,7 +101,7 @@ void RenderTile::finishRender(PaintParameters& parameters) {
             gl::ColorMode::unblended(),
             *tile.debugBucket->indexBuffer,
             tile.debugBucket->segments,
-            program.allUniformValues(
+            program.computeAllUniformValues(
                 DebugProgram::UniformValues {
                     uniforms::u_matrix::Value{ matrix },
                     uniforms::u_color::Value{ Color::white() }
@@ -122,7 +122,7 @@ void RenderTile::finishRender(PaintParameters& parameters) {
             gl::ColorMode::unblended(),
             *tile.debugBucket->indexBuffer,
             tile.debugBucket->segments,
-            program.allUniformValues(
+            program.computeAllUniformValues(
                 DebugProgram::UniformValues {
                     uniforms::u_matrix::Value{ matrix },
                     uniforms::u_color::Value{ Color::black() }
@@ -145,7 +145,7 @@ void RenderTile::finishRender(PaintParameters& parameters) {
             gl::ColorMode::unblended(),
             parameters.staticData.tileBorderIndexBuffer,
             parameters.staticData.tileBorderSegments,
-            program.allUniformValues(
+            program.computeAllUniformValues(
                 DebugProgram::UniformValues {
                     uniforms::u_matrix::Value{ matrix },
                     uniforms::u_color::Value{ Color::red() }
@@ -154,7 +154,7 @@ void RenderTile::finishRender(PaintParameters& parameters) {
                 properties,
                 parameters.state.getZoom()
             ),
-            program.allAttributeBindings(
+            program.computeAllAttributeBindings(
                 parameters.staticData.tileVertexBuffer,
                 paintAttributeData,
                 properties

--- a/src/mbgl/renderer/render_tile.cpp
+++ b/src/mbgl/renderer/render_tile.cpp
@@ -74,6 +74,8 @@ void RenderTile::finishRender(PaintParameters& parameters) {
     static const style::Properties<>::PossiblyEvaluated properties {};
     static const DebugProgram::PaintPropertyBinders paintAttributeData(properties, 0);
 
+    auto& program = parameters.programs.debug;
+
     if (parameters.debugOptions & (MapDebugOptions::Timestamps | MapDebugOptions::ParseStatus)) {
         if (!tile.debugBucket || tile.debugBucket->renderable != tile.isRenderable() ||
             tile.debugBucket->complete != tile.isComplete() ||
@@ -85,41 +87,51 @@ void RenderTile::finishRender(PaintParameters& parameters) {
                 tile.expires, parameters.debugOptions, parameters.context);
         }
 
-        parameters.programs.debug.draw(
+        const auto allAttributeBindings = program.allAttributeBindings(
+            *tile.debugBucket->vertexBuffer,
+            paintAttributeData,
+            properties
+        );
+
+        program.draw(
             parameters.context,
             gl::Lines { 4.0f * parameters.pixelRatio },
             gl::DepthMode::disabled(),
             parameters.stencilModeForClipping(clip),
             gl::ColorMode::unblended(),
-            DebugProgram::UniformValues {
-                uniforms::u_matrix::Value{ matrix },
-                uniforms::u_color::Value{ Color::white() }
-            },
-            *tile.debugBucket->vertexBuffer,
             *tile.debugBucket->indexBuffer,
             tile.debugBucket->segments,
-            paintAttributeData,
-            properties,
-            parameters.state.getZoom(),
+            program.allUniformValues(
+                DebugProgram::UniformValues {
+                    uniforms::u_matrix::Value{ matrix },
+                    uniforms::u_color::Value{ Color::white() }
+                },
+                paintAttributeData,
+                properties,
+                parameters.state.getZoom()
+            ),
+            allAttributeBindings,
             "debug"
         );
 
-        parameters.programs.debug.draw(
+        program.draw(
             parameters.context,
             gl::Lines { 2.0f * parameters.pixelRatio },
             gl::DepthMode::disabled(),
             parameters.stencilModeForClipping(clip),
             gl::ColorMode::unblended(),
-            DebugProgram::UniformValues {
-                uniforms::u_matrix::Value{ matrix },
-                uniforms::u_color::Value{ Color::black() }
-            },
-            *tile.debugBucket->vertexBuffer,
             *tile.debugBucket->indexBuffer,
             tile.debugBucket->segments,
-            paintAttributeData,
-            properties,
-            parameters.state.getZoom(),
+            program.allUniformValues(
+                DebugProgram::UniformValues {
+                    uniforms::u_matrix::Value{ matrix },
+                    uniforms::u_color::Value{ Color::black() }
+                },
+                paintAttributeData,
+                properties,
+                parameters.state.getZoom()
+            ),
+            allAttributeBindings,
             "debug"
         );
     }
@@ -131,16 +143,22 @@ void RenderTile::finishRender(PaintParameters& parameters) {
             gl::DepthMode::disabled(),
             parameters.stencilModeForClipping(clip),
             gl::ColorMode::unblended(),
-            DebugProgram::UniformValues {
-                uniforms::u_matrix::Value{ matrix },
-                uniforms::u_color::Value{ Color::red() }
-            },
-            parameters.staticData.tileVertexBuffer,
             parameters.staticData.tileBorderIndexBuffer,
             parameters.staticData.tileBorderSegments,
-            paintAttributeData,
-            properties,
-            parameters.state.getZoom(),
+            program.allUniformValues(
+                DebugProgram::UniformValues {
+                    uniforms::u_matrix::Value{ matrix },
+                    uniforms::u_color::Value{ Color::red() }
+                },
+                paintAttributeData,
+                properties,
+                parameters.state.getZoom()
+            ),
+            program.allAttributeBindings(
+                parameters.staticData.tileVertexBuffer,
+                paintAttributeData,
+                properties
+            ),
             "debug"
         );
     }

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -495,7 +495,9 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         static const ClippingMaskProgram::PaintPropertyBinders paintAttributeData(properties, 0);
 
         for (const auto& clipID : parameters.clipIDGenerator.getClipIDs()) {
-            parameters.staticData.programs.clippingMask.draw(
+            auto& program = parameters.staticData.programs.clippingMask;
+
+            program.draw(
                 parameters.context,
                 gl::Triangles(),
                 gl::DepthMode::disabled(),
@@ -508,15 +510,21 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
                     gl::StencilMode::Replace
                 },
                 gl::ColorMode::disabled(),
-                ClippingMaskProgram::UniformValues {
-                    uniforms::u_matrix::Value{ parameters.matrixForTile(clipID.first) },
-                },
-                parameters.staticData.tileVertexBuffer,
                 parameters.staticData.quadTriangleIndexBuffer,
                 parameters.staticData.tileTriangleSegments,
-                paintAttributeData,
-                properties,
-                parameters.state.getZoom(),
+                program.allUniformValues(
+                    ClippingMaskProgram::UniformValues {
+                        uniforms::u_matrix::Value{ parameters.matrixForTile(clipID.first) },
+                    },
+                    paintAttributeData,
+                    properties,
+                    parameters.state.getZoom()
+                ),
+                program.allAttributeBindings(
+                    parameters.staticData.tileVertexBuffer,
+                    paintAttributeData,
+                    properties
+                ),
                 "clipping"
             );
         }

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -512,7 +512,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
                 gl::ColorMode::disabled(),
                 parameters.staticData.quadTriangleIndexBuffer,
                 parameters.staticData.tileTriangleSegments,
-                program.allUniformValues(
+                program.computeAllUniformValues(
                     ClippingMaskProgram::UniformValues {
                         uniforms::u_matrix::Value{ parameters.matrixForTile(clipID.first) },
                     },
@@ -520,7 +520,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
                     properties,
                     parameters.state.getZoom()
                 ),
-                program.allAttributeBindings(
+                program.computeAllAttributeBindings(
                     parameters.staticData.tileVertexBuffer,
                     paintAttributeData,
                     properties

--- a/src/mbgl/renderer/sources/render_image_source.cpp
+++ b/src/mbgl/renderer/sources/render_image_source.cpp
@@ -69,7 +69,7 @@ void RenderImageSource::finishRender(PaintParameters& parameters) {
             gl::ColorMode::unblended(),
             parameters.staticData.tileBorderIndexBuffer,
             parameters.staticData.tileBorderSegments,
-            programInstance.allUniformValues(
+            programInstance.computeAllUniformValues(
                 DebugProgram::UniformValues {
                     uniforms::u_matrix::Value{ matrix },
                     uniforms::u_color::Value{ Color::red() }
@@ -78,7 +78,7 @@ void RenderImageSource::finishRender(PaintParameters& parameters) {
                 properties,
                 parameters.state.getZoom()
             ),
-            programInstance.allAttributeBindings(
+            programInstance.computeAllAttributeBindings(
                 parameters.staticData.tileVertexBuffer,
                 paintAttributeData,
                 properties

--- a/src/mbgl/renderer/sources/render_image_source.cpp
+++ b/src/mbgl/renderer/sources/render_image_source.cpp
@@ -58,24 +58,32 @@ void RenderImageSource::finishRender(PaintParameters& parameters) {
     static const style::Properties<>::PossiblyEvaluated properties {};
     static const DebugProgram::PaintPropertyBinders paintAttributeData(properties, 0);
 
+    auto& programInstance = parameters.programs.debug;
+
     for (auto matrix : matrices) {
-        parameters.programs.debug.draw(
+        programInstance.draw(
             parameters.context,
             gl::LineStrip { 4.0f * parameters.pixelRatio },
             gl::DepthMode::disabled(),
             gl::StencilMode::disabled(),
             gl::ColorMode::unblended(),
-            DebugProgram::UniformValues {
-             uniforms::u_matrix::Value{ matrix },
-             uniforms::u_color::Value{ Color::red() }
-            },
-            parameters.staticData.tileVertexBuffer,
             parameters.staticData.tileBorderIndexBuffer,
             parameters.staticData.tileBorderSegments,
-            paintAttributeData,
-            properties,
-            parameters.state.getZoom(),
-            "debug"
+            programInstance.allUniformValues(
+                DebugProgram::UniformValues {
+                    uniforms::u_matrix::Value{ matrix },
+                    uniforms::u_color::Value{ Color::red() }
+                },
+                paintAttributeData,
+                properties,
+                parameters.state.getZoom()
+            ),
+            programInstance.allAttributeBindings(
+                parameters.staticData.tileVertexBuffer,
+                paintAttributeData,
+                properties
+            ),
+            "image"
         );
     }
 }


### PR DESCRIPTION
With data driven styling, we are dynamically computing shaders with a varying number of vertex attributes. One caveat of that is that the minimum mandated number for vertex attributes in the OpenGL ES 2.0 spec is only 8, [as we discovered](https://github.com/mapbox/mapbox-gl-native/issues/8183). Most modern GPUs have a higher limit than that, but there are some older mobile GPUs that only supply the bare minimum (see https://github.com/mapbox/mapbox-gl-native/issues/9331). @jfirebaugh reworked this in https://github.com/mapbox/mapbox-gl-native/pull/9433 to limit the number of vertex attributes we're using.

We're [throwing](https://github.com/mapbox/mapbox-gl-native/blob/ee3073e2416c2e3405ab3b6ed51f48514c95d363/src/mbgl/gl/attribute.cpp#L9) with a "too many vertex attributes" error in this case. This PR changes that so instead, we're printing a warning message when the user creates a style that has more attributes than the minimum limit, but we'll still bind them if the hardware supports it. If it doesn't, we won't bind the attributes beyond the hardware limit and instead accept the rendering errors. While this is unfortunate, it's still better than crashing.