### PR TITLE
[ios] Note plans to drop iOS 8

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,6 +4,8 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ## 4.0.0
 
+The 4.0._x_ series of releases will be the last to support iOS 8. The minimum iOS deployment version will increase to iOS 9.0 in a future release.
+
 ### Packaging
 
 * Removed support for 32-bit simulators. ([#10962](https://github.com/mapbox/mapbox-gl-native/pull/10962))

--- a/platform/ios/DEVELOPING.md
+++ b/platform/ios/DEVELOPING.md
@@ -4,7 +4,7 @@ This document explains how to build the Mapbox Maps SDK for iOS from source. It 
 
 ## Requirements
 
-The Mapbox Maps SDK for iOS and iosapp demo application require iOS 8.0 or above.
+The Mapbox Maps SDK for iOS and iosapp demo application require iOS 8.0 or above. _Note: Support for iOS 8 will be removed in a future release and the minimum iOS deployment version will increase to iOS 9.0._
 
 The Mapbox Maps SDK for iOS requires Xcode 9.1 or above to compile from source.
 

--- a/platform/ios/INSTALL.md
+++ b/platform/ios/INSTALL.md
@@ -10,6 +10,8 @@ The Mapbox Maps SDK for iOS is intended to run on iOS 8.0 and above on the follo
 * iPad 2 and above (3, 4, Mini, Air, Mini 2, Air 2, Pro)
 * iPod touch 5th generation and above
 
+_Note: Support for iOS 8 will be removed in a future release and the minimum iOS deployment version will increase to iOS 9.0._
+
 Note that 32-bit simulators (such as the iPhone 5 or iPad 2) are not supported.
 
 The Mapbox Maps SDK for iOS requires:

--- a/platform/ios/README.md
+++ b/platform/ios/README.md
@@ -2,7 +2,7 @@
 
 [![Bitrise](https://www.bitrise.io/app/7514e4cf3da2cc57.svg?token=OwqZE5rSBR9MVWNr_lf4sA&branch=master)](https://www.bitrise.io/app/7514e4cf3da2cc57)
 
-A library based on [Mapbox GL Native](../../README.md) for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS 8.0 and above using Objective-C, Swift, or Interface Builder.
+A library based on [Mapbox GL Native](../../README.md) for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS using Objective-C, Swift, or Interface Builder.
 
 This repository is for day-to-day development of the SDK. Building the SDK yourself requires [a number of dependencies and steps](../../INSTALL.md) that are unnecessary for developing production applications. For production applications, please consider installing an official, prebuilt release instead; see the [Mapbox iOS SDK website](https://www.mapbox.com/ios-sdk/) for installation instructions.
 


### PR DESCRIPTION
Support for iOS 8 is being deprecated in `ios-v4.0.0` and will be removed in a future version — so let’s warn folks.

/cc @mapbox/maps-ios 