### PR TITLE
[ios] Fix type narrowing issue with MGLOpenGLStyleLayer projection matrix

### DIFF
--- a/platform/darwin/src/MGLGeometry.h
+++ b/platform/darwin/src/MGLGeometry.h
@@ -24,17 +24,13 @@ typedef struct __attribute__((objc_boxable)) MGLMapPoint {
     CGFloat zoomLevel;
 } MGLMapPoint;
 
-union __attribute__((aligned(16))) _MGLMatrix4 {
-    struct
-    {
-        double m00, m01, m02, m03;
-        double m10, m11, m12, m13;
-        double m20, m21, m22, m23;
-        double m30, m31, m32, m33;
-    };
-    double m[16];
-};
-typedef union _MGLMatrix4 MGLMatrix4;
+/* Defines a 4x4 matrix. */
+typedef struct MGLMatrix4 {
+    double m00, m01, m02, m03;
+    double m10, m11, m12, m13;
+    double m20, m21, m22, m23;
+    double m30, m31, m32, m33;
+} MGLMatrix4;
 
 /**
  Creates a new `MGLCoordinateSpan` from the given latitudinal and longitudinal

--- a/platform/darwin/src/MGLGeometry.h
+++ b/platform/darwin/src/MGLGeometry.h
@@ -24,6 +24,18 @@ typedef struct __attribute__((objc_boxable)) MGLMapPoint {
     CGFloat zoomLevel;
 } MGLMapPoint;
 
+union __attribute__((aligned(16))) _MGLMatrix4 {
+    struct
+    {
+        double m00, m01, m02, m03;
+        double m10, m11, m12, m13;
+        double m20, m21, m22, m23;
+        double m30, m31, m32, m33;
+    };
+    double m[16];
+};
+typedef union _MGLMatrix4 MGLMatrix4;
+
 /**
  Creates a new `MGLCoordinateSpan` from the given latitudinal and longitudinal
  deltas.

--- a/platform/darwin/src/MGLGeometry.mm
+++ b/platform/darwin/src/MGLGeometry.mm
@@ -111,3 +111,11 @@ MGLMapPoint MGLMapPointForCoordinate(CLLocationCoordinate2D coordinate, double z
     mbgl::Point<double> projectedCoordinate = mbgl::Projection::project(MGLLatLngFromLocationCoordinate2D(coordinate), std::pow(2.0, zoomLevel));
     return MGLMapPointMake(projectedCoordinate.x, projectedCoordinate.y, zoomLevel);
 }
+
+MGLMatrix4 MGLMatrix4Make(std::array<double, 16>  array) {
+    MGLMatrix4 mat4;
+    for(uint8_t i = 0; i< 16; i++) {
+        mat4.m[i] = array[i];
+    }
+    return mat4;
+}

--- a/platform/darwin/src/MGLGeometry.mm
+++ b/platform/darwin/src/MGLGeometry.mm
@@ -113,9 +113,12 @@ MGLMapPoint MGLMapPointForCoordinate(CLLocationCoordinate2D coordinate, double z
 }
 
 MGLMatrix4 MGLMatrix4Make(std::array<double, 16>  array) {
-    MGLMatrix4 mat4;
-    for(uint8_t i = 0; i< 16; i++) {
-        mat4.m[i] = array[i];
-    }
+    MGLMatrix4 mat4 = {
+        .m00 = array[0], .m01 = array[1], .m02 = array[2], .m03 = array[3],
+        .m10 = array[4], .m11 = array[5], .m12 = array[6], .m13 = array[7],
+        .m20 = array[8], .m21 = array[9], .m22 = array[10], .m23 = array[11],
+        .m30 = array[12], .m31 = array[13], .m32 = array[14], .m33 = array[15]
+    };
     return mat4;
 }
+

--- a/platform/darwin/src/MGLGeometry_Private.h
+++ b/platform/darwin/src/MGLGeometry_Private.h
@@ -128,3 +128,5 @@ MGLRadianCoordinate2D MGLRadianCoordinateAtDistanceFacingDirection(MGLRadianCoor
 CLLocationDirection MGLDirectionBetweenCoordinates(CLLocationCoordinate2D firstCoordinate, CLLocationCoordinate2D secondCoordinate);
 
 CGPoint MGLPointRounded(CGPoint point);
+
+MGLMatrix4 MGLMatrix4Make(std::array<double, 16> mat);

--- a/platform/darwin/src/MGLOpenGLStyleLayer.h
+++ b/platform/darwin/src/MGLOpenGLStyleLayer.h
@@ -5,6 +5,7 @@
 #import "MGLFoundation.h"
 #import "MGLStyleValue.h"
 #import "MGLStyleLayer.h"
+#import "MGLGeometry.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -18,7 +19,7 @@ typedef struct MGLStyleLayerDrawingContext {
     CLLocationDirection direction;
     CGFloat pitch;
     CGFloat fieldOfView;
-    CATransform3D projectionMatrix;
+    MGLMatrix4 projectionMatrix;
 } MGLStyleLayerDrawingContext;
 
 MGL_EXPORT

--- a/platform/darwin/src/MGLOpenGLStyleLayer.mm
+++ b/platform/darwin/src/MGLOpenGLStyleLayer.mm
@@ -3,20 +3,10 @@
 #import "MGLMapView_Private.h"
 #import "MGLStyle_Private.h"
 #import "MGLStyleLayer_Private.h"
+#import "MGLGeometry_Private.h"
 
 #include <mbgl/style/layers/custom_layer.hpp>
 #include <mbgl/math/wrap.hpp>
-
-
-CATransform3D CATransform3DMake(std::array<double, 16> array) {
-    CATransform3D t = {
-        .m11 = static_cast<CGFloat>(array[0]), .m12 = static_cast<CGFloat>(array[1]), .m13 = static_cast<CGFloat>(array[2]), .m14 = static_cast<CGFloat>(array[3]),
-        .m21 = static_cast<CGFloat>(array[4]), .m22 = static_cast<CGFloat>(array[5]), .m23 = static_cast<CGFloat>(array[6]), .m24 = static_cast<CGFloat>(array[7]),
-        .m31 = static_cast<CGFloat>(array[8]), .m32 = static_cast<CGFloat>(array[9]), .m33 = static_cast<CGFloat>(array[10]), .m34 = static_cast<CGFloat>(array[11]),
-        .m41 = static_cast<CGFloat>(array[12]), .m42 = static_cast<CGFloat>(array[13]), .m43 = static_cast<CGFloat>(array[14]), .m44 = static_cast<CGFloat>(array[15])
-    };
-    return t;
-}
 
 class MGLOpenGLLayerHost : public mbgl::style::CustomLayerHost {
 public:
@@ -42,7 +32,7 @@ public:
             .direction = mbgl::util::wrap(params.bearing, 0., 360.),
             .pitch = static_cast<CGFloat>(params.pitch),
             .fieldOfView = static_cast<CGFloat>(params.fieldOfView),
-            .projectionMatrix = CATransform3DMake(params.projectionMatrix)
+            .projectionMatrix = MGLMatrix4Make(params.projectionMatrix)
         };
         [layer drawInMapView:layer.style.mapView withContext:drawingContext];
     }

--- a/platform/darwin/src/MGLOpenGLStyleLayer.mm
+++ b/platform/darwin/src/MGLOpenGLStyleLayer.mm
@@ -10,10 +10,10 @@
 
 CATransform3D CATransform3DMake(std::array<double, 16> array) {
     CATransform3D t = {
-        .m11 = array[0], .m12 = array[1], .m13 = array[2], .m14 = array[3],
-        .m21 = array[4], .m22 = array[5], .m23 = array[6], .m24 = array[7],
-        .m31 = array[8], .m32 = array[9], .m33 = array[10], .m34 = array[11],
-        .m41 = array[12], .m42 = array[13], .m43 = array[14], .m44 = array[15]
+        .m11 = static_cast<CGFloat>(array[0]), .m12 = static_cast<CGFloat>(array[1]), .m13 = static_cast<CGFloat>(array[2]), .m14 = static_cast<CGFloat>(array[3]),
+        .m21 = static_cast<CGFloat>(array[4]), .m22 = static_cast<CGFloat>(array[5]), .m23 = static_cast<CGFloat>(array[6]), .m24 = static_cast<CGFloat>(array[7]),
+        .m31 = static_cast<CGFloat>(array[8]), .m32 = static_cast<CGFloat>(array[9]), .m33 = static_cast<CGFloat>(array[10]), .m34 = static_cast<CGFloat>(array[11]),
+        .m41 = static_cast<CGFloat>(array[12]), .m42 = static_cast<CGFloat>(array[13]), .m43 = static_cast<CGFloat>(array[14]), .m44 = static_cast<CGFloat>(array[15])
     };
     return t;
 }


### PR DESCRIPTION
`CATransform3D`'s matrix is internally typed as `CGFloat`, which we were implicitly casting to from `double`. The `-Wc++11-narrowing` flag disallows implicit narrowing casts, so this PR makes it explicit.

Text of the errors:

> non-constant-expression cannot be narrowed from type 'std::__1::array<double, 16>::value_type' (aka 'double') to 'CGFloat' (aka 'float') in initializer list [-Wc++11-narrowing]

This manifested only in `Release` builds, so it wasn’t caught initially by CI or manual testing in `Debug`. The cast-everything fix is what Xcode suggested and seems like the least invasive approach, but perhaps @asheemmamoowala has suggestions about a better path.

In any case, this needs to be addressed before we put out any release, as it fails the build.

/cc @1ec5 @fabian-guerra @julianrex @lilykaiser 