### PR TITLE
[ios, macos] Convert various class methods to class properties

### DIFF
--- a/platform/darwin/src/MGLAccountManager.h
+++ b/platform/darwin/src/MGLAccountManager.h
@@ -5,7 +5,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- The MGLAccountManager object provides a global way to set a Mapbox API access
+ The `MGLAccountManager` object provides a global way to set a Mapbox API access
  token.
  */
 MGL_EXPORT
@@ -14,9 +14,9 @@ MGL_EXPORT
 #pragma mark Authorizing Access
 
 /**
- Set the
+ The
  <a href="https://www.mapbox.com/help/define-access-token/">Mapbox access token</a>
- to be used by all instances of MGLMapView in the current application.
+ used by all instances of `MGLMapView` in the current application.
 
  Mapbox-hosted vector tiles and styles require an API access token, which you
  can obtain from the
@@ -25,24 +25,16 @@ MGL_EXPORT
  your Mapbox account. They also deter other developers from using your styles
  without your permission.
 
- @param accessToken A Mapbox access token. Calling this method with a value of
-    `nil` has no effect.
+ Setting this property to a value of `nil` has no effect.
 
  @note You must set the access token before attempting to load any Mapbox-hosted
     style. Therefore, you should generally set it before creating an instance of
-    MGLMapView. The recommended way to set an access token is to add an entry to
-    your application’s Info.plist file with the key `MGLMapboxAccessToken` and
-    the type String. Alternatively, you may call this method from your
+    `MGLMapView`. The recommended way to set an access token is to add an entry
+    to your application’s Info.plist file with the key `MGLMapboxAccessToken`
+    and the type `String`. Alternatively, you may call this method from your
     application delegate’s `-applicationDidFinishLaunching:` method.
  */
-+ (void)setAccessToken:(nullable NSString *)accessToken;
-
-/**
- Returns the
- <a href="https://www.mapbox.com/help/define-access-token/">Mapbox access token</a>
- in use by instances of MGLMapView in the current application.
- */
-+ (nullable NSString *)accessToken;
+@property (class, nullable) NSString *accessToken;
 
 + (BOOL)mapboxMetricsEnabledSettingShownInApp __attribute__((unavailable("Telemetry settings are now always shown in the ℹ️ menu.")));
 

--- a/platform/darwin/src/MGLAccountManager_Private.h
+++ b/platform/darwin/src/MGLAccountManager_Private.h
@@ -3,7 +3,7 @@
 @interface MGLAccountManager (Private)
 
 /// Returns the shared instance of the `MGLAccountManager` class.
-+ (instancetype)sharedManager;
+@property (class, nonatomic, readonly) MGLAccountManager *sharedManager;
 
 /// The current global access token.
 @property (atomic) NSString *accessToken;

--- a/platform/darwin/src/MGLMapSnapshotter.h
+++ b/platform/darwin/src/MGLMapSnapshotter.h
@@ -140,7 +140,7 @@ typedef void (^MGLMapSnapshotCompletionHandler)(MGLMapSnapshot* _Nullable snapsh
  ```swift
  let camera = MGLMapCamera(lookingAtCenter: CLLocationCoordinate2D(latitude: 37.7184, longitude: -122.4365), fromDistance: 100, pitch: 20, heading: 0)
  
- let options = MGLMapSnapshotOptions(styleURL: MGLStyle.satelliteStreetsStyleURL(), camera: camera, size: CGSize(width: 320, height: 480))
+ let options = MGLMapSnapshotOptions(styleURL: MGLStyle.satelliteStreetsStyleURL, camera: camera, size: CGSize(width: 320, height: 480))
  options.zoomLevel = 10
  
  let snapshotter = MGLMapSnapshotter(options: options)

--- a/platform/darwin/src/MGLNetworkConfiguration.h
+++ b/platform/darwin/src/MGLNetworkConfiguration.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MGLNetworkConfiguration : NSObject
 
 /// Returns the shared instance of the `MGLNetworkConfiguration` class.
-+ (instancetype)sharedManager;
+@property (class, nonatomic, readonly) MGLNetworkConfiguration *sharedManager;
 
 /// The current API base URL. If `nil`, the Mapbox default base API URL is in use.
 @property (atomic, nullable) NSURL *apiBaseURL;

--- a/platform/darwin/src/MGLOfflineStorage.h
+++ b/platform/darwin/src/MGLOfflineStorage.h
@@ -170,7 +170,7 @@ MGL_EXPORT
 /**
  Returns the shared offline storage object.
  */
-+ (instancetype)sharedOfflineStorage;
+@property (class, nonatomic, readonly) MGLOfflineStorage *sharedOfflineStorage;
 
 #pragma mark - Accessing the Delegate
 

--- a/platform/darwin/src/MGLRasterTileSource.h
+++ b/platform/darwin/src/MGLRasterTileSource.h
@@ -47,7 +47,7 @@ extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionTileSize;
      .maximumZoomLevel: 16,
      .tileSize: 512,
      .attributionInfos: [
-         MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
+         MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "https://mapbox.com"))
      ]
  ])
  mapView.style?.addSource(source)

--- a/platform/darwin/src/MGLRendererConfiguration.h
+++ b/platform/darwin/src/MGLRendererConfiguration.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MGLRendererConfiguration : NSObject
 
 /** Returns an instance of the current renderer configuration. */
-+ (instancetype)currentConfiguration;
+@property (class, nonatomic, readonly) MGLRendererConfiguration *currentConfiguration;
 
 /** The file source to use. Defaults to `mbgl::DefaultFileSource` */
 @property (nonatomic, readonly) mbgl::DefaultFileSource *fileSource;

--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -68,7 +68,7 @@ MGL_EXPORT
     `-streetsStyleURLWithVersion:` method instead. Such details may change
     significantly from version to version.
  */
-+ (NSURL *)streetsStyleURL;
+@property (class, nonatomic, readonly) NSURL *streetsStyleURL;
 
 /**
  Returns the URL to the given version of the
@@ -98,7 +98,7 @@ MGL_EXPORT
     `-outdoorsStyleURLWithVersion:` method instead. Such details may change
     significantly from version to version.
  */
-+ (NSURL *)outdoorsStyleURL;
+@property (class, nonatomic, readonly) NSURL *outdoorsStyleURL;
 
 /**
  Returns the URL to the given version of the
@@ -122,7 +122,7 @@ MGL_EXPORT
     `-lightStyleURLWithVersion:` method instead. Such details may change
     significantly from version to version.
  */
-+ (NSURL *)lightStyleURL;
+@property (class, nonatomic, readonly) NSURL *lightStyleURL;
 
 /**
  Returns the URL to the given version of the
@@ -147,7 +147,7 @@ MGL_EXPORT
     `-darkStyleURLWithVersion:` method instead. Such details may change
     significantly from version to version.
  */
-+ (NSURL *)darkStyleURL;
+@property (class, nonatomic, readonly) NSURL *darkStyleURL;
 
 /**
  Returns the URL to the given version of the
@@ -172,7 +172,7 @@ MGL_EXPORT
     `-satelliteStyleURLWithVersion:` method instead. Such details may change
     significantly from version to version.
  */
-+ (NSURL *)satelliteStyleURL;
+@property (class, nonatomic, readonly) NSURL *satelliteStyleURL;
 
 /**
  Returns the URL to the given version of the
@@ -203,7 +203,7 @@ MGL_EXPORT
     `-satelliteStreetsStyleURLWithVersion:` method instead. Such details may
     change significantly from version to version.
  */
-+ (NSURL *)satelliteStreetsStyleURL;
+@property (class, nonatomic, readonly) NSURL *satelliteStreetsStyleURL;
 
 /**
  Returns the URL to the given version of the

--- a/platform/darwin/src/MGLVectorTileSource.h
+++ b/platform/darwin/src/MGLVectorTileSource.h
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
      .minimumZoomLevel: 9,
      .maximumZoomLevel: 16,
      .attributionInfos: [
-         MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
+         MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "https://mapbox.com"))
      ]
  ])
  mapView.style?.addSource(source)

--- a/platform/darwin/test/MGLDocumentationExampleTests.swift
+++ b/platform/darwin/test/MGLDocumentationExampleTests.swift
@@ -80,7 +80,7 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
             .maximumZoomLevel: 16,
             .tileSize: 512,
             .attributionInfos: [
-                MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
+                MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "https://mapbox.com"))
             ]
         ])
         mapView.style?.addSource(source)
@@ -115,7 +115,7 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
             .minimumZoomLevel: 9,
             .maximumZoomLevel: 16,
             .attributionInfos: [
-                MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
+                MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "https://mapbox.com"))
             ]
         ])
         mapView.style?.addSource(source)
@@ -280,7 +280,7 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
             .maximumZoomLevel: 16,
             .tileSize: 512,
             .attributionInfos: [
-                MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
+                MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "https://mapbox.com"))
             ]
         ])
         mapView.style?.addSource(source)
@@ -300,7 +300,7 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
             .maximumZoomLevel: 16,
             .tileSize: 256,
             .attributionInfos: [
-                MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
+                MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "https://mapbox.com"))
             ]
         ])
         mapView.style?.addSource(source)
@@ -370,7 +370,7 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
         #endif
         
         class MGLStyle {
-            static func satelliteStreetsStyleURL() -> URL {
+            static var satelliteStreetsStyleURL: URL {
                 return MGLDocumentationExampleTests.styleURL
             }
         }
@@ -378,7 +378,7 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
         //#-example-code
         let camera = MGLMapCamera(lookingAtCenter: CLLocationCoordinate2D(latitude: 37.7184, longitude: -122.4365), fromDistance: 100, pitch: 20, heading: 0)
 
-        let options = MGLMapSnapshotOptions(styleURL: MGLStyle.satelliteStreetsStyleURL(), camera: camera, size: CGSize(width: 320, height: 480))
+        let options = MGLMapSnapshotOptions(styleURL: MGLStyle.satelliteStreetsStyleURL, camera: camera, size: CGSize(width: 320, height: 480))
         options.zoomLevel = 10
 
         let snapshotter = MGLMapSnapshotter(options: options)

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -11,6 +11,7 @@ The 4.0._x_ series of releases will be the last to support iOS 8. The minimum iO
 * Removed support for 32-bit simulators. ([#10962](https://github.com/mapbox/mapbox-gl-native/pull/10962))
 * Added Danish and Hebrew localizations. ([#10967](https://github.com/mapbox/mapbox-gl-native/pull/10967), [#11136](https://github.com/mapbox/mapbox-gl-native/pull/11134))
 * Removed methods, properties, and constants that had been deprecated as of v3.7.6. ([#11205](https://github.com/mapbox/mapbox-gl-native/pull/11205), [#11681](https://github.com/mapbox/mapbox-gl-native/pull/11681))
+* Refined certain Swift interfaces by converting them from class methods to class properties. ([#11674](https://github.com/mapbox/mapbox-gl-native/pull/11674))
 
 ### Styles
 

--- a/platform/ios/Mapbox.playground/Contents.swift
+++ b/platform/ios/Mapbox.playground/Contents.swift
@@ -51,7 +51,7 @@ panel.addSubview(pitchSwitch)
  Put your access token into a plain text file called `token`. Then select the “token” placeholder below, go to Editor ‣ Insert File Literal, and select the `token` file.
  */
 var accessToken = try String(contentsOfURL: <#token#>)
-MGLAccountManager.setAccessToken(accessToken)
+MGLAccountManager.accessToken = accessToken
 
 class PlaygroundAnnotationView: MGLAnnotationView {
     

--- a/platform/ios/docs/guides/Info.plist Keys.md
+++ b/platform/ios/docs/guides/Info.plist Keys.md
@@ -8,7 +8,7 @@ Set the [Mapbox access token](https://www.mapbox.com/help/define-access-token/) 
 
 Mapbox-hosted vector tiles and styles require an API access token, which you can obtain from the [Mapbox account page](https://www.mapbox.com/studio/account/tokens/). Access tokens associate requests to Mapbox’s vector tile and style APIs with your Mapbox account. They also deter other developers from using your styles without your permission.
 
-As an alternative, you can use `+[MGLAccountManager setAccessToken:]` to set a token in code. See [our guide](https://www.mapbox.com/help/ios-private-access-token/) for some tips on keeping access tokens in open source code private.
+As an alternative, you can use `MGLAccountManager.accessToken` to set a token in code. See [our guide](https://www.mapbox.com/help/ios-private-access-token/) for some tips on keeping access tokens in open source code private.
 
 ## MGLMapboxAPIBaseURL
 

--- a/platform/ios/scripts/script_resources/MapboxDemo/MapboxDemo/ViewController.swift
+++ b/platform/ios/scripts/script_resources/MapboxDemo/MapboxDemo/ViewController.swift
@@ -110,7 +110,7 @@ class ViewController: UIViewController {
         // You can obtain your own access token from the
         // [Mapbox account page](https://www.mapbox.com/studio/account/tokens/)
         // and add it to this application's Info.plist as the value for MGLMapboxAccessToken
-        if MGLAccountManager.accessToken() == "pk.eyJ1IjoibWFwYm94IiwiYSI6ImNqYThuNnZ3NTA5MGMyd3F1cmF1eW1xaGEifQ.TdBTSHHPeT1pfLZ_6x_1vA" {
+        if MGLAccountManager.accessToken == "pk.eyJ1IjoibWFwYm94IiwiYSI6ImNqYThuNnZ3NTA5MGMyd3F1cmF1eW1xaGEifQ.TdBTSHHPeT1pfLZ_6x_1vA" {
             accessTokenWarningView.isHidden = false
         }
         

--- a/platform/ios/src/MGLTelemetryConfig.h
+++ b/platform/ios/src/MGLTelemetryConfig.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern NSString *const MGLMapboxMetricsProfile;
 
-+ (nullable instancetype)sharedConfig;
+@property (class, nullable, nonatomic, readonly) MGLTelemetryConfig *sharedConfig;
 
 - (void)configurationFromKey:(NSString *)key;
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -47,6 +47,7 @@
 * The `-[MGLMapView convertRect:toCoordinateBoundsFromView:]` method and the `MGLMapView.visibleCoordinateBounds` property’s getter now indicate that the coordinate bounds straddles the antimeridian by extending one side beyond ±180 degrees longitude. ([#11265](https://github.com/mapbox/mapbox-gl-native/pull/11265))
 * Feature querying results now account for the `MGLSymbolStyleLayer.circleStrokeWidth` property. ([#10897](https://github.com/mapbox/mapbox-gl-native/pull/10897))
 * Removed methods, properties, and constants that had been deprecated as of v0.6.1. ([#11205](https://github.com/mapbox/mapbox-gl-native/pull/11205))
+* Refined certain Swift interfaces by converting them from class methods to class properties. ([#11674](https://github.com/mapbox/mapbox-gl-native/pull/11674))
 
 ## v0.6.1 - January 16, 2018
 

--- a/platform/macos/docs/guides/Info.plist Keys.md
+++ b/platform/macos/docs/guides/Info.plist Keys.md
@@ -8,7 +8,7 @@ Set the [Mapbox access token](https://www.mapbox.com/help/define-access-token/) 
 
 Mapbox-hosted vector tiles and styles require an API access token, which you can obtain from the [Mapbox account page](https://www.mapbox.com/studio/account/tokens/). Access tokens associate requests to Mapbox’s vector tile and style APIs with your Mapbox account. They also deter other developers from using your styles without your permission.
 
-As an alternative, you can use `+[MGLAccountManager setAccessToken:]` to set a token in code. See [our guide](https://www.mapbox.com/help/ios-private-access-token/) for some tips on keeping access tokens in open source code private.
+As an alternative, you can use `MGLAccountManager.accessToken` to set a token in code. See [our guide](https://www.mapbox.com/help/ios-private-access-token/) for some tips on keeping access tokens in open source code private.
 
 ## MGLMapboxAPIBaseURL
 


### PR DESCRIPTION
Fixes #6778. This improves our Swift interface _in an unavoidably breaking way_ while mostly having no effect on Obj-C usage.

For example, before → after:
- `MGLStyle.streetsStyleURL()` → `MGLStyle.streetsStyleURL`
- `MGLOfflineStorage.shared()` → `MGLOfflineStorage.shared`
- `MGLAccountManager.setAccessToken("foo")`  → `MGLAccountManager.accessToken = "foo”`

This also updates a variety of internal/undocumented classes in a similar way — this doesn’t really matter while we’re using Obj-C, but future-proofs potential Swiftification.

### To-do (suggestions welcome)
- [x] Update generated darwin examples.
- [ ] ~Improve changelog entry.~
- [x] Audit my choices in property values — e.g., `nonatomic`?
- [x] Double check SDK docs here for missed updates.

/cc @mapbox/maps-ios