### PR TITLE
[ios] Update playground for Swift 3.2+

### DIFF
--- a/platform/ios/Mapbox.playground/Contents.swift
+++ b/platform/ios/Mapbox.playground/Contents.swift
@@ -1,9 +1,5 @@
 import UIKit
-#if swift(>=3)
-    import PlaygroundSupport
-#else
-    import XCPlayground
-#endif
+import PlaygroundSupport
 import Mapbox
 
 let width: CGFloat = 700
@@ -11,13 +7,9 @@ let height: CGFloat = 800
 
 class Responder: NSObject {
     var mapView: MGLMapView?
-    func togglePitch(sender: UISwitch)  {
+    @objc func togglePitch(sender: UISwitch)  {
         let camera = mapView!.camera
-        #if swift(>=3)
-            camera.pitch = sender.isOn ? 60 : 0
-        #else
-            camera.pitch = sender.on ? 60 : 0
-        #endif
+        camera.pitch = sender.isOn ? 60 : 0
         mapView!.setCamera(camera, animated: false)
     }
 }
@@ -26,11 +18,7 @@ class Responder: NSObject {
 let panelWidth: CGFloat = 200
 let panel = UIView(frame: CGRect(x: width - panelWidth, y: 0, width: 200, height: 100))
 panel.alpha = 0.8
-#if swift(>=3)
-    panel.backgroundColor = .white
-#else
-    panel.backgroundColor = UIColor.whiteColor()
-#endif
+panel.backgroundColor = .white
 
 // Delete markers
 let deleteSwitchLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 30))
@@ -53,11 +41,7 @@ let pitchLabel = UILabel(frame: CGRect(x: 0, y: 60, width: 100, height: 30))
 pitchLabel.text = "Pitch"
 let pitchSwitch = UISwitch(frame: CGRect(x: panelWidth-panelWidth / 2.0, y: 60, width: 100, height: 50))
 let responder = Responder()
-#if swift(>=3)
-    pitchSwitch.addTarget(responder, action: #selector(responder.togglePitch(sender:)), for: .valueChanged)
-#else
-    pitchSwitch.addTarget(responder, action: #selector(responder.togglePitch(_:)), forControlEvents: .ValueChanged)
-#endif
+pitchSwitch.addTarget(responder, action: #selector(responder.togglePitch(sender:)), for: .valueChanged)
 panel.addSubview(pitchLabel)
 panel.addSubview(pitchSwitch)
 
@@ -72,11 +56,7 @@ MGLAccountManager.setAccessToken(accessToken)
 class PlaygroundAnnotationView: MGLAnnotationView {
     
     override func prepareForReuse() {
-        #if swift(>=3)
-            isHidden = hideMarkerSwitchView.isOn
-        #else
-            hidden = hideMarkerSwitchView.on
-        #endif
+        isHidden = hideMarkerSwitchView.isOn
     }
     
 }
@@ -86,8 +66,7 @@ class PlaygroundAnnotationView: MGLAnnotationView {
 class MapDelegate: NSObject, MGLMapViewDelegate {
     
     var annotationViewByAnnotation = [MGLPointAnnotation: PlaygroundAnnotationView]()
-    
-    #if swift(>=3)
+
     func mapView(_ mapView: MGLMapView, viewFor annotation: MGLAnnotation) -> MGLAnnotationView? {
         
         var annotationView = mapView.dequeueReusableAnnotationView(withIdentifier: "annotation") as? PlaygroundAnnotationView
@@ -109,31 +88,7 @@ class MapDelegate: NSObject, MGLMapViewDelegate {
         
         return annotationView
     }
-    #else
-    func mapView(mapView: MGLMapView, viewForAnnotation annotation: MGLAnnotation) -> MGLAnnotationView? {
-        
-        var annotationView = mapView.dequeueReusableAnnotationViewWithIdentifier("annotation") as? PlaygroundAnnotationView
-        
-        if (annotationView == nil) {
-            let av = PlaygroundAnnotationView(reuseIdentifier: "annotation")
-            av.frame = CGRect(x: 0, y: 0, width: 30, height: 30)
-            av.centerOffset = CGVector(dx: -15, dy: -15)
-            let centerView = UIView(frame: CGRectInset(av.bounds, 3, 3))
-            centerView.backgroundColor = UIColor.whiteColor()
-            av.addSubview(centerView)
-            av.backgroundColor = UIColor.purpleColor()
-            annotationView = av
-        } else {
-            annotationView!.subviews.first?.backgroundColor = UIColor.greenColor()
-        }
-    
-        annotationViewByAnnotation[annotation as! MGLPointAnnotation] = annotationView
-        
-        return annotationView
-    }
-    #endif
-    
-    #if swift(>=3)
+
     func mapView(_ mapView: MGLMapView, didSelect annotation: MGLAnnotation) {
         let pointAnnotation = annotation as! MGLPointAnnotation
         let annotationView: PlaygroundAnnotationView  = annotationViewByAnnotation[pointAnnotation]!
@@ -159,48 +114,14 @@ class MapDelegate: NSObject, MGLMapViewDelegate {
             }
         }
     }
-    #else
-    func mapView(mapView: MGLMapView, didSelectAnnotation annotation: MGLAnnotation) {
-        let pointAnnotation = annotation as! MGLPointAnnotation
-        let annotationView: PlaygroundAnnotationView  = annotationViewByAnnotation[pointAnnotation]!
-        
-        for view in annotationViewByAnnotation.values {
-            view.layer.zPosition = -1
-        }
-        
-        annotationView.layer.zPosition = 1
-        
-        UIView.animateWithDuration(1.25, delay: 0, usingSpringWithDamping: 0.4, initialSpringVelocity: 0.6, options: .CurveEaseOut, animations: {
-            annotationView.transform = CGAffineTransformMakeScale(1.8, 1.8)
-        }) { _ in
-            annotationView.transform = CGAffineTransformMakeScale(1, 1)
-            
-            if deleteMarkerSwitchView.on {
-                mapView.removeAnnotation(pointAnnotation)
-                return
-            }
-            
-            if hideMarkerSwitchView.on {
-                annotationView.hidden = true
-            }
-        }
-    }
-    #endif
     
-    func handleTap(press: UILongPressGestureRecognizer) {
+    @objc func handleTap(press: UILongPressGestureRecognizer) {
         let mapView: MGLMapView = press.view as! MGLMapView
         
-        #if swift(>=3)
-            let isRecognized = press.state == .recognized
-        #else
-            let isRecognized = press.state == .Recognized
-        #endif
+        let isRecognized = press.state == .recognized
+
         if (isRecognized) {
-            #if swift(>=3)
-                let coordinate: CLLocationCoordinate2D = mapView.convert(press.location(in: mapView), toCoordinateFrom: mapView)
-            #else
-                let coordinate: CLLocationCoordinate2D = mapView.convertPoint(press.locationInView(mapView), toCoordinateFromView: mapView)
-            #endif
+            let coordinate: CLLocationCoordinate2D = mapView.convert(press.location(in: mapView), toCoordinateFrom: mapView)
             let annotation = MGLPointAnnotation()
             annotation.title = "Dropped Marker"
             annotation.coordinate = coordinate
@@ -218,11 +139,7 @@ let centerCoordinate = CLLocationCoordinate2D(latitude: 37.174057, longitude: -1
 let mapView = MGLMapView(frame: CGRect(x: 0, y: 0, width: width, height: height))
 mapView.frame = CGRect(x: 0, y: 0, width: width, height: height)
 
-#if swift(>=3)
-    PlaygroundPage.current.liveView = mapView
-#else
-    XCPlaygroundPage.currentPage.liveView = mapView
-#endif
+PlaygroundPage.current.liveView = mapView
 
 let mapDelegate = MapDelegate()
 mapView.delegate = mapDelegate
@@ -233,11 +150,7 @@ mapView.addGestureRecognizer(tapGesture)
 
 //: Zoom in to a location
 
-#if swift(>=3)
-    mapView.setCenter(centerCoordinate, zoomLevel: 12, animated: false)
-#else
-    mapView.setCenterCoordinate(centerCoordinate, zoomLevel: 12, animated: false)
-#endif
+mapView.setCenter(centerCoordinate, zoomLevel: 12, animated: false)
 
 //: Add control panel
 

--- a/platform/ios/Mapbox.playground/timeline.xctimeline
+++ b/platform/ios/Mapbox.playground/timeline.xctimeline
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Timeline
-   version = "3.0">
-   <TimelineItems>
-   </TimelineItems>
-</Timeline>


### PR DESCRIPTION
- Removes support for Swift 2.x, which we no longer need (as we require Xcode 8.x).
- Updates for Swift 3.2 — namely, `@objc` in a couple places.

/cc @1ec5 @jmkiley @captainbarbosa 