### PR TITLE
[ios] Remove more deprecated bits for release-boba

### DIFF
--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -416,25 +416,14 @@ MGL_EXPORT
 
 #pragma mark Managing Style Classes
 
-/**
- Support for style classes has been removed. This property always returns an empty array.
- */
-@property (nonatomic) NS_ARRAY_OF(NSString *) *styleClasses __attribute__((unavailable("This property is non-functional.")));
 
-/**
- Support for style classes has been removed. This method always returns NO.
- */
-- (BOOL)hasStyleClass:(NSString *)styleClass __attribute__((unavailable("This method is non-functional.")));
+@property (nonatomic) NS_ARRAY_OF(NSString *) *styleClasses __attribute__((unavailable("Support for style classes has been removed.")));
 
-/**
- Support for style classes has been removed. This method is a no-op.
- */
-- (void)addStyleClass:(NSString *)styleClass __attribute__((unavailable("This method is non-functional.")));
+- (BOOL)hasStyleClass:(NSString *)styleClass __attribute__((unavailable("Support for style classes has been removed.")));
 
-/**
- Support for style classes has been removed. This method is a no-op.
- */
-- (void)removeStyleClass:(NSString *)styleClass __attribute__((unavailable("This method is non-functional.")));
+- (void)addStyleClass:(NSString *)styleClass __attribute__((unavailable("Support for style classes has been removed.")));
+
+- (void)removeStyleClass:(NSString *)styleClass __attribute__((unavailable("Support for style classes has been removed.")));
 
 #pragma mark Managing a Style’s Images
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -10,7 +10,7 @@ The 4.0._x_ series of releases will be the last to support iOS 8. The minimum iO
 
 * Removed support for 32-bit simulators. ([#10962](https://github.com/mapbox/mapbox-gl-native/pull/10962))
 * Added Danish and Hebrew localizations. ([#10967](https://github.com/mapbox/mapbox-gl-native/pull/10967), [#11136](https://github.com/mapbox/mapbox-gl-native/pull/11134))
-* Removed methods, properties, and constants that had been deprecated as of v3.7.4. ([#11205](https://github.com/mapbox/mapbox-gl-native/pull/11205))
+* Removed methods, properties, and constants that had been deprecated as of v3.7.6. ([#11205](https://github.com/mapbox/mapbox-gl-native/pull/11205), [#11681](https://github.com/mapbox/mapbox-gl-native/pull/11681))
 
 ### Styles and rendering
 

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -286,13 +286,13 @@ MGL_EXPORT IB_DESIGNABLE
  */
 - (IBAction)showAttribution:(id)sender;
 
-@property (nonatomic) NS_ARRAY_OF(NSString *) *styleClasses __attribute__((unavailable("This property is non-functional.")));
+@property (nonatomic) NS_ARRAY_OF(NSString *) *styleClasses __attribute__((unavailable("Support for style classes has been removed.")));
 
-- (BOOL)hasStyleClass:(NSString *)styleClass __attribute__((unavailable("This method is non-functional.")));
+- (BOOL)hasStyleClass:(NSString *)styleClass __attribute__((unavailable("Support for style classes has been removed.")));
 
-- (void)addStyleClass:(NSString *)styleClass __attribute__((unavailable("This method is non-functional.")));
+- (void)addStyleClass:(NSString *)styleClass __attribute__((unavailable("Support for style classes has been removed.")));
 
-- (void)removeStyleClass:(NSString *)styleClass __attribute__((unavailable("This method is non-functional.")));
+- (void)removeStyleClass:(NSString *)styleClass __attribute__((unavailable("Support for style classes has been removed.")));
 
 #pragma mark Displaying the User’s Location
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -249,8 +249,6 @@ public:
 
     BOOL _opaque;
 
-    NS_MUTABLE_ARRAY_OF(NSURL *) *_bundledStyleURLs;
-
     MGLAnnotationTagContextMap _annotationContextsByAnnotationTag;
     MGLAnnotationObjectTagMap _annotationTagsByAnnotation;
 
@@ -3489,50 +3487,11 @@ public:
     return mbgl::Projection::getMetersPerPixelAtLatitude(latitude, self.zoomLevel);
 }
 
-- (CLLocationDistance)metersPerPixelAtLatitude:(CLLocationDegrees)latitude
-{
-    return [self metersPerPointAtLatitude:latitude];
-}
-
 #pragma mark - Camera Change Reason -
 
 - (void)resetCameraChangeReason
 {
     self.cameraChangeReasonBitmask = MGLCameraChangeReasonNone;
-}
-
-#pragma mark - Styling -
-
-- (NS_ARRAY_OF(NSURL *) *)bundledStyleURLs
-{
-    if ( ! _bundledStyleURLs)
-    {
-        _bundledStyleURLs = [NSMutableArray array];
-        for (NSUInteger i = 0; i < mbgl::util::default_styles::numOrderedStyles; i++)
-        {
-            NSURL *styleURL = [NSURL URLWithString:@(mbgl::util::default_styles::orderedStyles[i].url)];
-            [_bundledStyleURLs addObject:styleURL];
-        }
-    }
-
-    return [NSArray arrayWithArray:_bundledStyleURLs];
-}
-
-- (nullable NSString *)styleID
-{
-    [NSException raise:@"Method unavailable" format:
-     @"%s has been replaced by -[MGLMapView styleURL].",
-     __PRETTY_FUNCTION__];
-    return nil;
-}
-
-- (void)setStyleID:(nullable NSString *)styleID
-{
-    [NSException raise:@"Method unavailable" format:
-     @"%s has been replaced by -[MGLMapView setStyleURL:].\n\n"
-     @"If you previously set this style ID in a storyboard inspectable, select the MGLMapView in Interface Builder and delete the “styleID” entry from the User Defined Runtime Attributes section of the Identity inspector. "
-     @"Then go to the Attributes inspector and enter “mapbox://styles/%@” into the “Style URL” field.",
-     __PRETTY_FUNCTION__, styleID];
 }
 
 #pragma mark - Annotations -
@@ -4779,12 +4738,8 @@ public:
             userLocationAnnotationView = (MGLUserLocationAnnotationView *)[self.delegate mapView:self viewForAnnotation:self.userLocation];
             if (userLocationAnnotationView && ! [userLocationAnnotationView isKindOfClass:MGLUserLocationAnnotationView.class])
             {
-                static dispatch_once_t onceToken;
-                dispatch_once(&onceToken, ^{
-                    NSLog(@"Ignoring user location annotation view with type %@. User location annotation view must be a kind of MGLUserLocationAnnotationView. This warning is only shown once and will become an error in a future version.", NSStringFromClass(userLocationAnnotationView.class));
-                });
-
-                userLocationAnnotationView = nil;
+                [NSException raise:@"MGLUserLocationAnnotationTypeException"
+                            format:@"User location annotation view must be a kind of MGLUserLocationAnnotationView. %@", userLocationAnnotationView.debugDescription];
             }
         }
 


### PR DESCRIPTION
Follows up on #11205 and removes a couple stragglers that are deprecated as of v3.7.6.

- Converts a warning to an exception (`MGLUserLocationAnnotationTypeException`), as promised.
- Rewords the style class unavailability message.
- Removes the `styleID`, `bundledStyleURLs`, and `metersPerPixelAtLatitude:` implementations.

/cc @1ec5 @jmkiley 