### PR TITLE
[ios, macos] Remove mgl_ prefix from built-in expressions variables.

### DIFF
--- a/platform/darwin/docs/guides/For Style Authors.md.ejs
+++ b/platform/darwin/docs/guides/For Style Authors.md.ejs
@@ -339,9 +339,9 @@ In style specification | Method, function, or predicate type | Format string syn
 `to-number`            | `mgl_numberWithFallbackValues:` | `CAST(zipCode, 'NSNumber')`
 `to-string`            | `stringValue` | `CAST(ele, 'NSString')`
 `typeof`               | |
-`geometry-type`        | |`$mgl_geometryType`
-`id`                   | |`$mgl_featureIdentifier`
-`properties`           | |`$mgl_featureProperties`
+`geometry-type`        | |`$geometryType`
+`id`                   | |`$featureIdentifier`
+`properties`           | |`$featureProperties`
 `at`                   | `objectFrom:withIndex:` | `array[n]`
 `get`                  | `+[NSExpression expressionForKeyPath:]` | Key path
 `has`                  | `mgl_does:have:` | `mgl_does:have:(self, 'key')`

--- a/platform/darwin/docs/guides/Predicates and Expressions.md
+++ b/platform/darwin/docs/guides/Predicates and Expressions.md
@@ -65,7 +65,7 @@ attribute or, alternatively, one of the following special attributes:
 </thead>
 <tbody>
 <tr>
-   <td><code>$id</code></td>
+   <td><code>$featureIdentifier</code></td>
    <td>
        A value that uniquely identifies the feature in the containing source.
        For details on the types of values that may be associated with this key,
@@ -74,7 +74,7 @@ attribute or, alternatively, one of the following special attributes:
    </td>
 </tr>
 <tr>
-   <td><code>$type</code></td>
+   <td><code>$geometryType</code></td>
    <td>
        The type of geometry represented by the feature. A feature’s type is
        guaranteed to be one of the following strings:

--- a/platform/darwin/src/NSExpression+MGLAdditions.mm
+++ b/platform/darwin/src/NSExpression+MGLAdditions.mm
@@ -664,11 +664,11 @@ NSArray *MGLSubexpressionsWithJSONObjects(NSArray *objects) {
         } else if ([op isEqualToString:@"heatmap-density"]) {
             return [NSExpression expressionForVariable:@"heatmapDensity"];
         } else if ([op isEqualToString:@"geometry-type"]) {
-            return [NSExpression expressionForVariable:@"mgl_geometryType"];
+            return [NSExpression expressionForVariable:@"geometryType"];
         } else if ([op isEqualToString:@"id"]) {
-            return [NSExpression expressionForVariable:@"mgl_featureIdentifier"];
+            return [NSExpression expressionForVariable:@"featureIdentifier"];
         }  else if ([op isEqualToString:@"properties"]) {
-            return [NSExpression expressionForVariable:@"mgl_featureProperties"];
+            return [NSExpression expressionForVariable:@"featureProperties"];
         } else if ([op isEqualToString:@"var"]) {
             return [NSExpression expressionForVariable:argumentObjects.firstObject];
         } else if ([op isEqualToString:@"case"]) {
@@ -754,13 +754,13 @@ NSArray *MGLSubexpressionsWithJSONObjects(NSArray *objects) {
             if ([self.variable isEqualToString:@"zoomLevel"]) {
                 return @[@"zoom"];
             }
-            if ([self.variable isEqualToString:@"mgl_geometryType"]) {
+            if ([self.variable isEqualToString:@"geometryType"]) {
                 return @[@"geometry-type"];
             }
-            if ([self.variable isEqualToString:@"mgl_featureIdentifier"]) {
+            if ([self.variable isEqualToString:@"featureIdentifier"]) {
                 return @[@"id"];
             }
-            if ([self.variable isEqualToString:@"mgl_featureProperties"]) {
+            if ([self.variable isEqualToString:@"featureProperties"]) {
                 return @[@"properties"];
             }
             return @[@"var", self.variable];

--- a/platform/darwin/test/MGLExpressionTests.mm
+++ b/platform/darwin/test/MGLExpressionTests.mm
@@ -171,21 +171,21 @@ using namespace std::string_literals;
         XCTAssertEqualObjects([expression expressionValueWithObject:nil context:context], @1);
     }
     {
-        NSExpression *expression = [NSExpression expressionForVariable:@"mgl_geometryType"];
+        NSExpression *expression = [NSExpression expressionForVariable:@"geometryType"];
         XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, @[@"geometry-type"]);
-        XCTAssertEqualObjects([NSExpression expressionWithFormat:@"$mgl_geometryType"].mgl_jsonExpressionObject, @[@"geometry-type"]);
+        XCTAssertEqualObjects([NSExpression expressionWithFormat:@"$geometryType"].mgl_jsonExpressionObject, @[@"geometry-type"]);
         XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:@[@"geometry-type"]], expression);
     }
     {
-        NSExpression *expression = [NSExpression expressionForVariable:@"mgl_featureIdentifier"];
+        NSExpression *expression = [NSExpression expressionForVariable:@"featureIdentifier"];
         XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, @[@"id"]);
-        XCTAssertEqualObjects([NSExpression expressionWithFormat:@"$mgl_featureIdentifier"].mgl_jsonExpressionObject, @[@"id"]);
+        XCTAssertEqualObjects([NSExpression expressionWithFormat:@"$featureIdentifier"].mgl_jsonExpressionObject, @[@"id"]);
         XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:@[@"id"]], expression);
     }
     {
-        NSExpression *expression = [NSExpression expressionForVariable:@"mgl_featureProperties"];
+        NSExpression *expression = [NSExpression expressionForVariable:@"featureProperties"];
         XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, @[@"properties"]);
-        XCTAssertEqualObjects([NSExpression expressionWithFormat:@"$mgl_featureProperties"].mgl_jsonExpressionObject, @[@"properties"]);
+        XCTAssertEqualObjects([NSExpression expressionWithFormat:@"$featureProperties"].mgl_jsonExpressionObject, @[@"properties"]);
         XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:@[@"properties"]], expression);
     }
     {
@@ -817,7 +817,7 @@ using namespace std::string_literals;
     }
     {
         NSExpression *expression = [NSExpression expressionForFunction:@"mgl_does:have:"
-                                                             arguments:@[[NSExpression expressionForVariable:@"mgl_featureProperties"],
+                                                             arguments:@[[NSExpression expressionForVariable:@"featureProperties"],
                                                                          [NSExpression expressionForConstantValue:@"x"]]];
         NSArray *jsonExpression = @[@"has", @"x", @[@"properties"]];
         XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);

--- a/platform/darwin/test/MGLPredicateTests.mm
+++ b/platform/darwin/test/MGLPredicateTests.mm
@@ -615,9 +615,9 @@ namespace mbgl {
     }
     {
         NSArray *expected = @[@"match", @[@"id"], @6, @YES, @5, @YES, @4, @YES, @3, @YES, @NO];
-        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"$mgl_featureIdentifier IN { 6, 5, 4, 3}"];
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"$featureIdentifier IN { 6, 5, 4, 3}"];
         XCTAssertEqualObjects(predicate.mgl_jsonExpressionObject, expected);
-        NSPredicate *predicateAfter = [NSPredicate predicateWithFormat:@"MGL_MATCH($mgl_featureIdentifier, 6, YES, 5, YES, 4, YES, 3, YES, NO) == YES"];
+        NSPredicate *predicateAfter = [NSPredicate predicateWithFormat:@"MGL_MATCH($featureIdentifier, 6, YES, 5, YES, 4, YES, 3, YES, NO) == YES"];
         XCTAssertEqualObjects([NSPredicate mgl_predicateWithJSONObject:expected], predicateAfter);
     }
     {
@@ -636,9 +636,9 @@ namespace mbgl {
     }
     {
         NSArray *expected = @[@"match", @[@"id"], @6, @YES, @5, @YES, @4, @YES, @3, @YES, @NO];
-        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"{ 6, 5, 4, 3} CONTAINS $mgl_featureIdentifier"];
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"{ 6, 5, 4, 3} CONTAINS $featureIdentifier"];
         XCTAssertEqualObjects(predicate.mgl_jsonExpressionObject, expected);
-        NSPredicate *predicateAfter = [NSPredicate predicateWithFormat:@"MGL_MATCH($mgl_featureIdentifier, 6, YES, 5, YES, 4, YES, 3, YES, NO) == YES"];
+        NSPredicate *predicateAfter = [NSPredicate predicateWithFormat:@"MGL_MATCH($featureIdentifier, 6, YES, 5, YES, 4, YES, 3, YES, NO) == YES"];
         XCTAssertEqualObjects([NSPredicate mgl_predicateWithJSONObject:expected], predicateAfter);
     }
 }

--- a/platform/ios/docs/guides/For Style Authors.md
+++ b/platform/ios/docs/guides/For Style Authors.md
@@ -329,9 +329,9 @@ In style specification | Method, function, or predicate type | Format string syn
 `to-number`            | `mgl_numberWithFallbackValues:` | `CAST(zipCode, 'NSNumber')`
 `to-string`            | `stringValue` | `CAST(ele, 'NSString')`
 `typeof`               | |
-`geometry-type`        | |`$mgl_geometryType`
-`id`                   | |`$mgl_featureIdentifier`
-`properties`           | |`$mgl_featureProperties`
+`geometry-type`        | |`$geometryType`
+`id`                   | |`$featureIdentifier`
+`properties`           | |`$featureProperties`
 `at`                   | `objectFrom:withIndex:` | `array[n]`
 `get`                  | `+[NSExpression expressionForKeyPath:]` | Key path
 `has`                  | `mgl_does:have:` | `mgl_does:have:(self, 'key')`

--- a/platform/macos/docs/guides/For Style Authors.md
+++ b/platform/macos/docs/guides/For Style Authors.md
@@ -322,9 +322,9 @@ In style specification | Method, function, or predicate type | Format string syn
 `to-number`            | `mgl_numberWithFallbackValues:` | `CAST(zipCode, 'NSNumber')`
 `to-string`            | `stringValue` | `CAST(ele, 'NSString')`
 `typeof`               | |
-`geometry-type`        | |`$mgl_geometryType`
-`id`                   | |`$mgl_featureIdentifier`
-`properties`           | |`$mgl_featureProperties`
+`geometry-type`        | |`$geometryType`
+`id`                   | |`$featureIdentifier`
+`properties`           | |`$featureProperties`
 `at`                   | `objectFrom:withIndex:` | `array[n]`
 `get`                  | `+[NSExpression expressionForKeyPath:]` | Key path
 `has`                  | `mgl_does:have:` | `mgl_does:have:(self, 'key')`


### PR DESCRIPTION
Fixes #11683 