### PR TITLE
Bump gl-js pin, update for line-gradient + new expression spec taxonomy

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyFactory.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyFactory.java
@@ -258,7 +258,7 @@ public class PropertyFactory {
   }
 
   /**
-   * Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512).
+   * Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
    *
    * @param value a String value
    * @return property wrapper around String
@@ -268,7 +268,7 @@ public class PropertyFactory {
   }
 
   /**
-   * Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512).
+   * Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
    *
    * @param expression an expression statement
    * @return property wrapper around an expression statement
@@ -279,7 +279,7 @@ public class PropertyFactory {
 
 
   /**
-   * Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512).
+   * Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
    *
    * @param <Z> the zoom parameter type
    * @param function a wrapper {@link CameraFunction} for String
@@ -565,7 +565,7 @@ public class PropertyFactory {
   }
 
   /**
-   * Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to density-independent pixels, multiply the length by the current line width.
+   * Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to density-independent pixels, multiply the length by the current line width. Note that GeoJSON sources with `lineMetrics: true` specified won't render dashed lines to the expected scale. Also note that zoom-dependent expressions will be evaluated only at integer zoom levels.
    *
    * @param value a Float[] value
    * @return property wrapper around Float[]
@@ -575,7 +575,7 @@ public class PropertyFactory {
   }
 
   /**
-   * Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to density-independent pixels, multiply the length by the current line width.
+   * Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to density-independent pixels, multiply the length by the current line width. Note that GeoJSON sources with `lineMetrics: true` specified won't render dashed lines to the expected scale. Also note that zoom-dependent expressions will be evaluated only at integer zoom levels.
    *
    * @param expression an expression statement
    * @return property wrapper around an expression statement
@@ -586,7 +586,7 @@ public class PropertyFactory {
 
 
   /**
-   * Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to density-independent pixels, multiply the length by the current line width.
+   * Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to density-independent pixels, multiply the length by the current line width. Note that GeoJSON sources with `lineMetrics: true` specified won't render dashed lines to the expected scale. Also note that zoom-dependent expressions will be evaluated only at integer zoom levels.
    *
    * @param <Z> the zoom parameter type
    * @param function a wrapper {@link CameraFunction} for Float[]
@@ -598,7 +598,7 @@ public class PropertyFactory {
   }
 
   /**
-   * Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512).
+   * Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
    *
    * @param value a String value
    * @return property wrapper around String
@@ -608,7 +608,7 @@ public class PropertyFactory {
   }
 
   /**
-   * Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512).
+   * Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
    *
    * @param expression an expression statement
    * @return property wrapper around an expression statement
@@ -619,7 +619,7 @@ public class PropertyFactory {
 
 
   /**
-   * Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512).
+   * Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
    *
    * @param <Z> the zoom parameter type
    * @param function a wrapper {@link CameraFunction} for String
@@ -1790,7 +1790,7 @@ public class PropertyFactory {
   }
 
   /**
-   * Name of image in sprite to use for drawing images on extruded fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512).
+   * Name of image in sprite to use for drawing images on extruded fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
    *
    * @param value a String value
    * @return property wrapper around String
@@ -1800,7 +1800,7 @@ public class PropertyFactory {
   }
 
   /**
-   * Name of image in sprite to use for drawing images on extruded fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512).
+   * Name of image in sprite to use for drawing images on extruded fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
    *
    * @param expression an expression statement
    * @return property wrapper around an expression statement
@@ -1811,7 +1811,7 @@ public class PropertyFactory {
 
 
   /**
-   * Name of image in sprite to use for drawing images on extruded fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512).
+   * Name of image in sprite to use for drawing images on extruded fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
    *
    * @param <Z> the zoom parameter type
    * @param function a wrapper {@link CameraFunction} for String
@@ -2391,7 +2391,7 @@ public class PropertyFactory {
   }
 
   /**
-   * Name of image in sprite to use for drawing an image background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512).
+   * Name of image in sprite to use for drawing an image background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
    *
    * @param value a String value
    * @return property wrapper around String
@@ -2401,7 +2401,7 @@ public class PropertyFactory {
   }
 
   /**
-   * Name of image in sprite to use for drawing an image background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512).
+   * Name of image in sprite to use for drawing an image background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
    *
    * @param expression an expression statement
    * @return property wrapper around an expression statement
@@ -2412,7 +2412,7 @@ public class PropertyFactory {
 
 
   /**
-   * Name of image in sprite to use for drawing an image background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512).
+   * Name of image in sprite to use for drawing an image background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
    *
    * @param <Z> the zoom parameter type
    * @param function a wrapper {@link CameraFunction} for String
@@ -2905,7 +2905,7 @@ public class PropertyFactory {
   }
 
   /**
-   * Name of image in sprite to use for drawing an image background. Within literal values and zoom functions, property names enclosed in curly brackets (e.g. `{token}`) are replaced with the value of the named property. Expressions and property functions do not support this syntax; for equivalent functionality in expressions, use the [`concat`](#expressions-concat) and [`get`](#expressions-get) operators.
+   * Name of image in sprite to use for drawing an image background.
    *
    * @param value a String value
    * @return property wrapper around String
@@ -2915,7 +2915,7 @@ public class PropertyFactory {
   }
 
   /**
-   * Name of image in sprite to use for drawing an image background. Within literal values and zoom functions, property names enclosed in curly brackets (e.g. `{token}`) are replaced with the value of the named property. Expressions and property functions do not support this syntax; for equivalent functionality in expressions, use the [`concat`](#expressions-concat) and [`get`](#expressions-get) operators.
+   * Name of image in sprite to use for drawing an image background.
    *
    * @param value a String value
    * @return property wrapper around String
@@ -2926,7 +2926,7 @@ public class PropertyFactory {
 
 
   /**
-   * Name of image in sprite to use for drawing an image background. Within literal values and zoom functions, property names enclosed in curly brackets (e.g. `{token}`) are replaced with the value of the named property. Expressions and property functions do not support this syntax; for equivalent functionality in expressions, use the [`concat`](#expressions-concat) and [`get`](#expressions-get) operators.
+   * Name of image in sprite to use for drawing an image background.
    *
    * @param <T> the function input type
    * @param function a wrapper function for String
@@ -3193,7 +3193,7 @@ public class PropertyFactory {
   }
 
   /**
-   * Value to use for a text label. Within literal values and zoom functions, property names enclosed in curly brackets (e.g. `{token}`) are replaced with the value of the named property. Expressions and property functions do not support this syntax; for equivalent functionality in expressions, use the [`concat`](#expressions-concat) and [`get`](#expressions-get) operators.
+   * Value to use for a text label.
    *
    * @param value a String value
    * @return property wrapper around String
@@ -3203,7 +3203,7 @@ public class PropertyFactory {
   }
 
   /**
-   * Value to use for a text label. Within literal values and zoom functions, property names enclosed in curly brackets (e.g. `{token}`) are replaced with the value of the named property. Expressions and property functions do not support this syntax; for equivalent functionality in expressions, use the [`concat`](#expressions-concat) and [`get`](#expressions-get) operators.
+   * Value to use for a text label.
    *
    * @param value a String value
    * @return property wrapper around String
@@ -3214,7 +3214,7 @@ public class PropertyFactory {
 
 
   /**
-   * Value to use for a text label. Within literal values and zoom functions, property names enclosed in curly brackets (e.g. `{token}`) are replaced with the value of the named property. Expressions and property functions do not support this syntax; for equivalent functionality in expressions, use the [`concat`](#expressions-concat) and [`get`](#expressions-get) operators.
+   * Value to use for a text label.
    *
    * @param <T> the function input type
    * @param function a wrapper function for String

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
@@ -176,7 +176,7 @@ public class <%- camelize(type) %>LayerTest extends BaseActivityTest {
         layer.setProperties(
           <%- camelizeWithLeadingLowercase(property.name) %>(
             zoom(
-<% if (property.function == 'piecewise-constant') { -%>
+<% if (!isInterpolable(property)) { -%>
               interval(
                 stop(2, <%- camelizeWithLeadingLowercase(property.name) %>(<%- defaultValueJava(property) %>))
               )
@@ -193,7 +193,7 @@ public class <%- camelize(type) %>LayerTest extends BaseActivityTest {
         assertNotNull(layer.get<%- camelize(property.name) %>());
         assertNotNull(layer.get<%- camelize(property.name) %>().getFunction());
         assertEquals(CameraFunction.class, layer.get<%- camelize(property.name) %>().getFunction().getClass());
-<% if (property.function == 'piecewise-constant') { -%>
+<% if (!isInterpolable(property)) { -%>
         assertEquals(IntervalStops.class, layer.get<%- camelize(property.name) %>().getFunction().getStops().getClass());
         assertEquals(1, ((IntervalStops) layer.get<%- camelize(property.name) %>().getFunction().getStops()).size());
 <% } else { -%>
@@ -231,7 +231,7 @@ public class <%- camelize(type) %>LayerTest extends BaseActivityTest {
       }
     });
   }
-<% if (property.function == 'piecewise-constant') { -%>
+<% if (!isInterpolable(property)) { -%>
 
   @Test
   public void test<%- camelize(property.name) %>AsIntervalSourceFunction() {

--- a/platform/android/scripts/generate-style-code.js
+++ b/platform/android/scripts/generate-style-code.js
@@ -30,6 +30,8 @@ var layers = Object.keys(spec.layer.type.values).map((type) => {
   const paintProperties = Object.keys(spec[`paint_${type}`]).reduce((memo, name) => {
     // disabled for now, see https://github.com/mapbox/mapbox-gl-native/issues/11172
     if (name === 'heatmap-color') return memo;
+    // not yet implemented
+    if (name === 'line-gradient') return memo;
 
     spec[`paint_${type}`][name].name = name;
     memo.push(spec[`paint_${type}`][name]);
@@ -252,8 +254,12 @@ global.propertyValueDoc = function (property, value) {
 };
 
 global.isDataDriven = function (property) {
-  return property['property-function'] === true;
+  return property['property-type'] === 'data-driven' || property['property-type'] === 'cross-faded-data-driven';
 };
+
+global.isInterpolable = function(property) {
+  return property.expression && property.expression.interpolated;
+}
 
 global.isLightProperty = function (property) {
   return property['light-property'] === true;
@@ -302,11 +308,11 @@ global.evaluatedType = function (property) {
 };
 
 global.supportsZoomFunction = function (property) {
-  return property['zoom-function'] === true;
+  return property.expression && property.expression.parameters.indexOf('zoom') > -1;
 };
 
 global.supportsPropertyFunction = function (property) {
-  return property['property-function'] === true;
+  return property['property-type'] === 'data-driven' || property['property-type'] === 'cross-faded-data-driven';
 };
 
 // Template processing //

--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -309,9 +309,9 @@ global.propertyDoc = function (propertyName, property, layerType, kind) {
             '* Conditional expressions\n' +
             '* Variable assignments and references to assigned variables\n';
         const inputVariable = property.name === 'heatmap-color' ? '$heatmapDensity' : '$zoomLevel';
-        if (property["property-function"]) {
+        if (isDataDriven(property)) {
             doc += `* Interpolation and step functions applied to the \`${inputVariable}\` variable and/or feature attributes\n`;
-        } else if (property.function === "interpolated") {
+        } else if (property.expression && property.expression.interpolated) {
             doc += `* Interpolation and step functions applied to the \`${inputVariable}\` variable\n\n` +
                 'This property does not support applying interpolation or step functions to feature attributes.';
         } else {
@@ -320,6 +320,10 @@ global.propertyDoc = function (propertyName, property, layerType, kind) {
         }
     }
     return doc;
+};
+
+global.isDataDriven = function (property) {
+  return property['property-type'] === 'data-driven' || property['property-type'] === 'cross-faded-data-driven';
 };
 
 global.propertyReqs = function (property, propertiesByName, type) {
@@ -633,6 +637,9 @@ const layers = _(spec.layer.type.values).map((value, layerType) => {
     }, []);
 
     const paintProperties = Object.keys(spec[`paint_${layerType}`]).reduce((memo, name) => {
+        // not yet implemented
+        if (name === 'line-gradient') return memo;
+
         spec[`paint_${layerType}`][name].name = name;
         memo.push(spec[`paint_${layerType}`][name]);
         return memo;

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -174,7 +174,8 @@ MGL_EXPORT
 
 /**
  Name of image in sprite to use for drawing image fills. For seamless patterns,
- image width and height must be a factor of two (2, 4, 8, ..., 512).
+ image width and height must be a factor of two (2, 4, 8, ..., 512). Note that
+ zoom-dependent expressions will be evaluated only at integer zoom levels.
  
  You can set this property to an expression containing any of the following:
  

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -278,7 +278,10 @@ MGL_EXPORT
 /**
  Specifies the lengths of the alternating dashes and gaps that form the dash
  pattern. The lengths are later scaled by the line width. To convert a dash
- length to points, multiply the length by the current line width.
+ length to points, multiply the length by the current line width. Note that
+ GeoJSON sources with `lineMetrics: true` specified won't render dashed lines to
+ the expected scale. Also note that zoom-dependent expressions will be evaluated
+ only at integer zoom levels.
  
  This property is measured in line widths.
  

--- a/platform/darwin/src/MGLStyleLayer.mm.ejs
+++ b/platform/darwin/src/MGLStyleLayer.mm.ejs
@@ -121,7 +121,7 @@ namespace mbgl {
 - (void)set<%- camelize(property.name) %>:(NSExpression *)<%- objCName(property) %> {
     MGLAssertStyleLayerIsValid();
 
-<% if (property["property-function"]) { -%>
+<% if (isDataDriven(property)) { -%>
     auto mbglValue = MGLStyleValueTransformer<<%- valueTransformerArguments(property).join(', ') %>>().toPropertyValue<mbgl::style::DataDrivenPropertyValue<<%- valueTransformerArguments(property)[0] %>>>(<%- objCName(property) %>);
 <% } else { -%>
     auto mbglValue = MGLStyleValueTransformer<<%- valueTransformerArguments(property).join(', ') %>>().toPropertyValue<mbgl::style::PropertyValue<<%- valueTransformerArguments(property)[0] %>>>(<%- objCName(property) %>);
@@ -159,7 +159,7 @@ namespace mbgl {
 
 <% if (property.name === 'heatmap-color') { -%>
     auto mbglValue = MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toPropertyValue<mbgl::style::HeatmapColorPropertyValue>(heatmapColor);
-<% } else if (property["property-function"]) { -%>
+<% } else if (isDataDriven(property)) { -%>
     auto mbglValue = MGLStyleValueTransformer<<%- valueTransformerArguments(property).join(', ') %>>().toPropertyValue<mbgl::style::DataDrivenPropertyValue<<%- valueTransformerArguments(property)[0] %>>>(<%- objCName(property) %>);
 <% } else { -%>
     auto mbglValue = MGLStyleValueTransformer<<%- valueTransformerArguments(property).join(', ') %>>().toPropertyValue<mbgl::style::PropertyValue<<%- valueTransformerArguments(property)[0] %>>>(<%- objCName(property) %>);

--- a/platform/darwin/test/MGLStyleLayerTests.mm.ejs
+++ b/platform/darwin/test/MGLStyleLayerTests.mm.ejs
@@ -69,7 +69,7 @@
 
         NSExpression *constantExpression = [NSExpression expressionWithFormat:<%- objCTestValue(property, type, true, 3) %>];
         layer.<%- objCName(property) %> = constantExpression;
-<% if (property["property-function"]) { -%>
+<% if (isDataDriven(property)) { -%>
         mbgl::style::DataDrivenPropertyValue<<%- mbglType(property) %>> propertyValue = { <%- mbglTestValue(property, type) %> };
 <% } else { -%>
         mbgl::style::PropertyValue<<%- mbglType(property) %>> propertyValue = { <%- mbglTestValue(property, type) %> };
@@ -88,13 +88,13 @@
             { 18, <%- mbglTestValue(property, type) %> },
         }};
         propertyValue = mbgl::style::CameraFunction<<%- mbglType(property) %>> { intervalStops };
-        
+
         XCTAssertEqual(rawLayer->get<%- camelize(originalPropertyName(property)) %>(), propertyValue,
                        @"Setting <%- objCName(property) %> to a camera expression should update <%- originalPropertyName(property) %>.");
         XCTAssertEqualObjects(layer.<%- objCName(property) %>, functionExpression,
                               @"<%- objCName(property) %> should round-trip camera expressions.");
 
-<% if (property["property-function"] && isInterpolatable(property)) { -%>
+<% if (isDataDriven(property) && isInterpolatable(property)) { -%>
         functionExpression = [NSExpression expressionWithFormat:@"FUNCTION(keyName, 'mgl_interpolateWithCurveType:parameters:stops:', 'linear', nil, %@)", @{@18: constantExpression}];
         layer.<%- objCName(property) %> = functionExpression;
 
@@ -118,7 +118,7 @@
                        @"Setting <%- objCName(property) %> to a camera-data expression should update <%- originalPropertyName(property) %>.");
         XCTAssertEqualObjects(layer.<%- objCName(property) %>, functionExpression,
                               @"<%- objCName(property) %> should round-trip camera-data expressions.");
-<% } -%>                              
+<% } -%>
 <% if (!property.required) { -%>
 
         layer.<%- objCName(property) %> = nil;
@@ -127,7 +127,7 @@
         XCTAssertEqualObjects(layer.<%- objCName(property) %>, defaultExpression,
                               @"<%- objCName(property) %> should return the default value after being unset.");
 <% } -%>
-<% if (!property["property-function"]) { -%>
+<% if (!isDataDriven(property)) { -%>
 
         functionExpression = [NSExpression expressionForKeyPath:@"bogus"];
         XCTAssertThrowsSpecificNamed(layer.<%- objCName(property) %> = functionExpression, NSException, NSInvalidArgumentException, @"MGL<%- camelize(type) %>Layer should raise an exception if a camera-data expression is applied to a property that does not support key paths to feature attributes.");

--- a/scripts/generate-shaders.js
+++ b/scripts/generate-shaders.js
@@ -42,7 +42,7 @@ ${shaders.prelude.fragmentSource}
 `);
 
 for (const key in shaders) {
-    if (key === 'prelude')
+    if (key === 'prelude' || key === 'lineGradient')
         continue;
 
     const shaderName = key.replace(/[A-Z]+/g, (match) => `_${match.toLowerCase()}`);

--- a/scripts/generate-style-code.js
+++ b/scripts/generate-style-code.js
@@ -16,7 +16,7 @@ function parseCSSColor(str) {
 }
 
 global.isDataDriven = function (property) {
-  return property['property-function'] === true;
+  return property['property-type'] === 'data-driven' || property['property-type'] === 'cross-faded-data-driven';
 };
 
 global.isLightProperty = function (property) {
@@ -168,6 +168,9 @@ const layers = Object.keys(spec.layer.type.values).map((type) => {
   }, []);
 
   const paintProperties = Object.keys(spec[`paint_${type}`]).reduce((memo, name) => {
+    // not yet implemented
+    if (name === 'line-gradient') return memo;
+
     spec[`paint_${type}`][name].name = name;
     memo.push(spec[`paint_${type}`][name]);
     return memo;

--- a/src/mbgl/shaders/line.cpp
+++ b/src/mbgl/shaders/line.cpp
@@ -31,6 +31,7 @@ uniform vec2 u_gl_units_to_pixels;
 varying vec2 v_normal;
 varying vec2 v_width2;
 varying float v_gamma_scale;
+varying highp float v_linesofar;
 
 
 #ifndef HAS_UNIFORM_u_color
@@ -130,6 +131,8 @@ void main() {
 
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;
+
+    v_linesofar = (floor(a_data.z / 4.0) + a_data.w * 64.0) * 2.0;
 
     vec2 pos = a_pos_normal.xy;
 


### PR DESCRIPTION
Port of https://github.com/mapbox/mapbox-gl-js/pull/6521:

* Updates code gen to ignore line-gradient properties + shaders
* Updates code gen to use style spec with new expression taxonomy (described in detail in https://github.com/mapbox/mapbox-gl-js/pull/6521) (this is a spec change only and causes no functional/library code changes)