### PR TITLE
Remove snapshot repository reference

### DIFF
--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -14,7 +14,8 @@ allprojects {
         mavenCentral()
         jcenter()
         google()
-        maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
+        // Snapshot repository
+        //maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
     }
 }
 


### PR DESCRIPTION
Refs. https://github.com/mapbox/mapbox-gl-native/issues/11708.
In order to prevent pushes to the repo that include snapshot artifact references, let's disable the snapshot repository handle in the test app which will cause builds that use snapshots to fail.