### PR TITLE
[ios] Provide MGLStyle.localizesLabels unavailability notice

### DIFF
--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -497,6 +497,8 @@ MGL_EXPORT
  */
 - (void)localizeLabelsIntoLocale:(nullable NSLocale *)locale;
 
+@property (nonatomic) BOOL localizesLabels __attribute__((unavailable("Use -localizeLabelsIntoLocale: instead.")));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -218,7 +218,7 @@ MGL_EXPORT IB_DESIGNABLE
  the server, calling this method does not necessarily ensure that the map view
  reflects those changes.
  */
-- (IBAction)reloadStyle:(id)sender;
+- (IBAction)reloadStyle:(nullable id)sender;
 
 /**
  A Boolean value indicating whether the map may display scale information.


### PR DESCRIPTION
Follows up on #11651. Re-adds `MGLStyle.localizesLabels`, makes it unavailable, and includes a message pointing developers at its replacement.

![screen shot 2018-04-17 at 4 45 01 pm](https://user-images.githubusercontent.com/1198851/38896045-a8784b58-425f-11e8-9b9b-662ba6c0a268.png)

/cc @1ec5 