### PR TITLE
Don't crash on placing symbols with 0 renderable glyphs

### DIFF
--- a/src/mbgl/layout/symbol_instance.cpp
+++ b/src/mbgl/layout/symbol_instance.cpp
@@ -27,7 +27,7 @@ SymbolInstance::SymbolInstance(Anchor& anchor_,
     anchor(anchor_),
     line(line_),
     index(index_),
-    hasText(shapedTextOrientations.first || shapedTextOrientations.second),
+    hasText(false),
     hasIcon(shapedIcon),
 
     // Create the collision features that will be used to check whether this symbol instance can be placed
@@ -48,6 +48,8 @@ SymbolInstance::SymbolInstance(Anchor& anchor_,
     if (shapedTextOrientations.second) {
         verticalGlyphQuads = getGlyphQuads(shapedTextOrientations.second, layout, textPlacement, positions);
     }
+    // 'hasText' depends on finding at least one glyph in the shaping that's also in the GlyphPositionMap
+    hasText = horizontalGlyphQuads.size() > 0 || verticalGlyphQuads.size() > 0;
 
     if (shapedTextOrientations.first && shapedTextOrientations.second) {
         writingModes = WritingModeType::Horizontal | WritingModeType::Vertical;

--- a/src/mbgl/layout/symbol_projection.cpp
+++ b/src/mbgl/layout/symbol_projection.cpp
@@ -240,7 +240,11 @@ namespace mbgl {
                                                             const PlacedSymbol& symbol,
                                                             const mat4& labelPlaneMatrix,
                                                             const bool returnTileDistance) {
-
+        if (symbol.glyphOffsets.empty()) {
+            assert(false);
+            return optional<std::pair<PlacedGlyph, PlacedGlyph>>();
+        }
+        
         const float firstGlyphOffset = symbol.glyphOffsets.front();
         const float lastGlyphOffset = symbol.glyphOffsets.back();;
 


### PR DESCRIPTION
Fixes issue #11729. Close relative of issue #10956 -- in fact, I suspect fixing #10956 just shifted more people to encountering #11729 which for some reason we haven't figured out yet didn't generate intelligible stack traces. 😞 

It is possible for us to receive Glyphs from the server that are valid, but have an invalid bitmap. In that case, the glyphs will be present in the `GlyphMap` used for shaping, but not present in the `GlyphPositions` used in `getGlyphQuads`. `SymbolInstance::hasText` looked at the shaping instead of the actual quads.
`symbol_projection.cpp` should never try to project a label without any quads, but we'll also try to make it so that it doesn't crash if it does.

/cc @friedbunny @ksummerill @ansis @cmxyzx