### PR TITLE
Revamp predicate and expression guide

### DIFF
--- a/platform/darwin/docs/guides/Predicates and Expressions.md
+++ b/platform/darwin/docs/guides/Predicates and Expressions.md
@@ -145,7 +145,9 @@ NSExpression(forFunction: "lowercase:",
 ### Functions
 
 Of the
-[functions predefined by the `+[NSExpression expressionForFunction:arguments:]` method](https://developer.apple.com/documentation/foundation/nsexpression/1413747-init#discussion),
+[functions predefined](https://developer.apple.com/documentation/foundation/nsexpression/1413747-init#discussion)
+by the
+[`+[NSExpression expressionForFunction:arguments:]` method](https://developer.apple.com/documentation/foundation/nsexpression/1413747-init),
 the following subset is supported in layer attribute values:
 
 Initializer parameter | Format string syntax
@@ -175,7 +177,7 @@ Initializer parameter | Format string syntax
 `length:`             | `length('Wapakoneta')`
 `castObject:toType:`  | `CAST(ele, 'NSString')`<br>`CAST(ele, 'NSNumber')`
 
-A number of [Mapbox-specific functions](#mapbox-specific-funcions) are also
+A number of [Mapbox-specific functions](#mapbox-specific-functions) are also
 available.
 
 The following predefined functions are **not** supported:

--- a/platform/darwin/docs/guides/Predicates and Expressions.md
+++ b/platform/darwin/docs/guides/Predicates and Expressions.md
@@ -356,6 +356,61 @@ order. Compared to the
 function, this function takes only one argument, which is an aggregate
 expression containing the strings to concatenate.
 
+### `mgl_acos:`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>mgl_acos:</code></dd>
+<dt>Format string syntax:</dt>
+<dd><code>mgl_acos(1)</code></dd>
+</dl>
+
+Returns the arccosine of the number.
+
+### `mgl_asin:`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>mgl_asin:</code></dd>
+<dt>Format string syntax:</dt>
+<dd><code>mgl_asin(0)</code></dd>
+</dl>
+
+Returns the arcsine of the number.
+
+### `mgl_atan:`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>mgl_atan:</code></dd>
+<dt>Format string syntax:</dt>
+<dd><code>mgl_atan(20)</code></dd>
+</dl>
+
+Returns the arctangent of the number.
+
+### `mgl_cos:`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>mgl_cos:</code></dd>
+<dt>Format string syntax:</dt>
+<dd><code>mgl_cos(0)</code></dd>
+</dl>
+
+Returns the cosine of the number.
+
+### `mgl_log2:`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>mgl_log2:</code></dd>
+<dt>Format string syntax:</dt>
+<dd><code>mgl_log2(1024)</code></dd>
+</dl>
+
+Returns the base-2 logarithm of the number.
+
 ### `mgl_round:`
 
 <dl>
@@ -367,6 +422,28 @@ expression containing the strings to concatenate.
 
 Returns the number rounded to the nearest integer. If the number is halfway
 between two integers, this function rounds it away from zero.
+
+### `mgl_sin:`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>mgl_sin:</code></dd>
+<dt>Format string syntax:</dt>
+<dd><code>mgl_sin(0)</code></dd>
+</dl>
+
+Returns the sine of the number.
+
+### `mgl_tan:`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>mgl_tan:</code></dd>
+<dt>Format string syntax:</dt>
+<dd><code>mgl_tan(0)</code></dd>
+</dl>
+
+Returns the tangent of the number.
 
 ### `mgl_coalesce:`
 

--- a/platform/darwin/docs/guides/Predicates and Expressions.md
+++ b/platform/darwin/docs/guides/Predicates and Expressions.md
@@ -541,7 +541,7 @@ Returns the result of matching the input expression against the given constant
 values.
 
 This function corresponds to the
-`+[NSExpression(MGLInitializerAdditions) mgl_expressionForMatchingExpression:inDictionary:defaultExpression:]`
+`+[NSExpression(MGLAdditions) mgl_expressionForMatchingExpression:inDictionary:defaultExpression:]`
 method and the
 [`match`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-match)
 operator in the Mapbox Style Specification.
@@ -568,7 +568,7 @@ and is supported on iOS 8._x_ and macOS 10.10._x_; however, each conditional
 passed into this function must be wrapped in a constant expression.
 
 This function corresponds to the
-`+[NSExpression(MGLInitializerAdditions) mgl_expressionForConditional:trueExpression:falseExpresssion:]`
+`+[NSExpression(MGLAdditions) mgl_expressionForConditional:trueExpression:falseExpresssion:]`
 method and the
 [`case`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-case)
 operator in the Mapbox Style Specification.
@@ -740,7 +740,7 @@ use a stop dictionary with the zoom levels 0, 10, and 20 as keys and the colors
 yellow, orange, and red as the values.
 
 This function corresponds to the
-`+[NSExpression(MGLInitializerAdditions) mgl_expressionForInterpolatingExpression:withCurveType:parameters:stops:]`
+`+[NSExpression(MGLAdditions) mgl_expressionForInterpolatingExpression:withCurveType:parameters:stops:]`
 method and the
 [`interpolate`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-interpolate)
 operator in the Mapbox Style Specification. See also the
@@ -824,7 +824,7 @@ use a stop dictionary with the zoom levels 0, 10, and 20 as keys and the colors
 yellow, orange, and red as the values.
 
 This function corresponds to the
-`+[NSExpression(MGLInitializerAdditions) mgl_expressionForSteppingExpression:fromExpression:stops:]`
+`+[NSExpression(MGLAdditions) mgl_expressionForSteppingExpression:fromExpression:stops:]`
 method and the
 [`step`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-step)
 operator in the Mapbox Style Specification.
@@ -845,7 +845,7 @@ operator in the Mapbox Style Specification.
 The target string with each of the argument strings appended in order.
 
 This function corresponds to the
-`-[NSExpression(MGLInitializerAdditions) mgl_expressionByAppendingExpression:]`
+`-[NSExpression(MGLAdditions) mgl_expressionByAppendingExpression:]`
 method and is similar to the
 [`concat`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-concat)
 operator in the Mapbox Style Specification. See also the

--- a/platform/darwin/docs/guides/Predicates and Expressions.md
+++ b/platform/darwin/docs/guides/Predicates and Expressions.md
@@ -622,7 +622,7 @@ defined in the context dictionary.
 <dt>Format string syntax:</dt>
 <dd>
    <code>FUNCTION($zoomLevel, 'mgl_interpolateWithCurveType:parameters:stops:', 'linear', NIL, %@)</code>
-   with a dictionary containing zoom levels as keys
+   with a dictionary containing zoom levels or other constant values as keys
 </dd>
 <dt>Target:</dt>
 <dd>
@@ -659,6 +659,12 @@ defined in the context dictionary.
 
 A value interpolated along the continuous mathematical function defined by the
 arguments, with the target as the input to the function.
+
+The input expression is matched against the keys in the stop dictionary. The
+keys may be feature attribute values, zoom levels, or heatmap densities. The
+values may be constant values or `NSExpression` objects. For example, you can
+use a stop dictionary with the zoom levels 0, 10, and 20 as keys and the colors
+yellow, orange, and red as the values.
 
 ### `mgl_numberWithFallbackValues:`
 
@@ -702,7 +708,7 @@ A numeric representation of the target:
 <dt>Format string syntax:</dt>
 <dd>
    <code>FUNCTION($zoomLevel, 'mgl_stepWithMinimum:stops:', 0, %@)</code> with
-   a dictionary with zoom levels as keys
+   a dictionary with zoom levels or other constant values as keys
 </dd>
 <dt>Target:</dt>
 <dd>
@@ -723,6 +729,12 @@ A numeric representation of the target:
 
 The output value of the stop whose key is just less than the evaluated target,
 or the minimum value if the target is less than the least of the stops’ keys.
+
+The input expression is matched against the keys in the stop dictionary. The
+keys may be feature attribute values, zoom levels, or heatmap densities. The
+values may be constant values or `NSExpression` objects. For example, you can
+use a stop dictionary with the zoom levels 0, 10, and 20 as keys and the colors
+yellow, orange, and red as the values.
 
 ### `stringByAppendingString:`
 

--- a/platform/darwin/docs/guides/Predicates and Expressions.md
+++ b/platform/darwin/docs/guides/Predicates and Expressions.md
@@ -299,7 +299,7 @@ string syntax:
 
 <dl>
 <dt>Selector:</dt>
-<dd>`mgl_does:have:`</dd>
+<dd><code>mgl_does:have:</code></dd>
 <dt>Format string syntax:</dt>
 <dd><code>mgl_does:have:(SELF, 'key')</code> or <code>mgl_does:have:(%@, 'key')</code></dd>
 </dl>
@@ -483,7 +483,7 @@ expression that contains references to those variables.
 <dt>Selector:</dt>
 <dd><code>MGL_MATCH:</code></dd>
 <dt>Format string syntax:</dt>
-<dd><code>`MGL_MATCH(x, 0, 'zero match', 1, 'one match', 'two match', 'default')`</code></dd>
+<dd><code>MGL_MATCH(x, 0, 'zero match', 1, 'one match', 'two match', 'default')</code></dd>
 <dt>Arguments:</dt>
 <dd>
    An input expression, then any number of argument pairs, followed by a default
@@ -501,7 +501,7 @@ values.
 <dt>Selector:</dt>
 <dd><code>MGL_IF:</code></dd>
 <dt>Format string syntax:</dt>
-<dd><code>`MGL_IF(1 = 2, YES, 2 = 2, YES, NO)`</code></dd>
+<dd><code>MGL_IF(1 = 2, YES, 2 = 2, YES, NO)</code></dd>
 <dt>Arguments:</dt>
 <dd>
    Alternating <code>NSPredicate</code> conditionals and resulting expressions,
@@ -522,7 +522,7 @@ passed into this function must be wrapped in a constant expression.
 <dt>Selector:</dt>
 <dd><code>MGL_FUNCTION:</code></dd>
 <dt>Format string syntax:</dt>
-<dd><code>`MGL_FUNCTION('typeof', mystery)`</code></dd>
+<dd><code>MGL_FUNCTION('typeof', mystery)</code></dd>
 <dt>Arguments:</dt>
 <dd>
    Any arguments required by the expression operator, as defined in the
@@ -552,7 +552,7 @@ that the operator expects.
 <dt>Selector:</dt>
 <dd><code>boolValue</code></dd>
 <dt>Format string syntax:</dt>
-<dd><code>`FUNCTION(1, 'boolValue')`</code></dd>
+<dd><code>FUNCTION(1, 'boolValue')</code></dd>
 <dt>Target:</dt>
 <dd>
    An <code>NSExpression</code> that evaluates to a number or string.
@@ -571,7 +571,7 @@ otherwise <code>TRUE</code>.
 <dt>Selector:</dt>
 <dd><code>mgl_has:</code></dd>
 <dt>Format string syntax:</dt>
-<dd><code>`FUNCTION($featureProperties, 'mgl_has:', '🧀🍔')`</code></dd>
+<dd><code>FUNCTION($featureProperties, 'mgl_has:', '🧀🍔')</code></dd>
 <dt>Target:</dt>
 <dd>
    An <code>NSExpression</code> that evaluates to an <code>NSDictionary</code>
@@ -595,8 +595,8 @@ object has a value for the feature attribute.
 <dd><code>mgl_expressionWithContext:</code></dd>
 <dt>Format string syntax:</dt>
 <dd>
-   <code>`FUNCTION($ios + $macos, 'mgl_expressionWithContext:', %@)`</code> with
-   a dictionary containing `ios` and `macos` keys
+   <code>FUNCTION($ios + $macos, 'mgl_expressionWithContext:', %@)</code> with
+   a dictionary containing <code>ios</code> and <code>macos</code> keys
 </dd>
 <dt>Target:</dt>
 <dd>
@@ -621,7 +621,7 @@ defined in the context dictionary.
 <dd><code>mgl_interpolateWithCurveType:parameters:stops:</code></dd>
 <dt>Format string syntax:</dt>
 <dd>
-   <code>`FUNCTION($zoomLevel, 'mgl_interpolateWithCurveType:parameters:stops:', 'linear', NIL, %@)`</code>
+   <code>FUNCTION($zoomLevel, 'mgl_interpolateWithCurveType:parameters:stops:', 'linear', NIL, %@)</code>
    with a dictionary containing zoom levels as keys
 </dd>
 <dt>Target:</dt>
@@ -671,7 +671,7 @@ arguments, with the target as the input to the function.
    <code>decimalValue</code>
 </dd>
 <dt>Format string syntax:</dt>
-<dd><code>`FUNCTION(ele, 'mgl_numberWithFallbackValues:', 0)`</code></dd>
+<dd><code>FUNCTION(ele, 'mgl_numberWithFallbackValues:', 0)</code></dd>
 <dt>Target:</dt>
 <dd>
    An <code>NSExpression</code> that evaluates to a Boolean value, number, or
@@ -701,7 +701,7 @@ A numeric representation of the target:
 <dd><code>mgl_stepWithMinimum:stops:</code></dd>
 <dt>Format string syntax:</dt>
 <dd>
-   <code>`FUNCTION($zoomLevel, 'mgl_stepWithMinimum:stops:', 0, %@)`</code> with
+   <code>FUNCTION($zoomLevel, 'mgl_stepWithMinimum:stops:', 0, %@)</code> with
    a dictionary with zoom levels as keys
 </dd>
 <dt>Target:</dt>
@@ -730,7 +730,7 @@ or the minimum value if the target is less than the least of the stops’ keys.
 <dt>Selector:</dt>
 <dd><code>stringByAppendingString:</code></dd>
 <dt>Format string syntax:</dt>
-<dd><code>`FUNCTION('Old', 'stringByAppendingString:', 'MacDonald')`</code></dd>
+<dd><code>FUNCTION('Old', 'stringByAppendingString:', 'MacDonald')</code></dd>
 <dt>Target:</dt>
 <dd>An <code>NSExpression</code> that evaluates to a string.</dd>
 <dt>Arguments:</dt>
@@ -745,7 +745,7 @@ The target string with each of the argument strings appended in order.
 <dt>Selector:</dt>
 <dd><code>stringValue</code></dd>
 <dt>Format string syntax:</dt>
-<dd><code>`FUNCTION(ele, 'stringValue')`</code></dd>
+<dd><code>FUNCTION(ele, 'stringValue')</code></dd>
 <dt>Target:</dt>
 <dd>
    An <code>NSExpression</code> that evaluates to a Boolean value, number, or

--- a/platform/darwin/docs/guides/Predicates and Expressions.md
+++ b/platform/darwin/docs/guides/Predicates and Expressions.md
@@ -526,7 +526,7 @@ passed into this function must be wrapped in a constant expression.
 <dt>Arguments:</dt>
 <dd>
    Any arguments required by the expression operator, as defined in the
-   [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions).
+   <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions">Mapbox Style Specification</a>.
 </dd>
 </dl>
 

--- a/platform/darwin/docs/guides/Predicates and Expressions.md
+++ b/platform/darwin/docs/guides/Predicates and Expressions.md
@@ -227,6 +227,8 @@ The following variables are defined by this SDK for use with style layers:
    </td>
    <td>
       A value that uniquely identifies the feature in the containing source.
+      This variable corresponds to the
+      <code>NSExpression.featureIdentifierVariableExpression</code> property.
    </td>
 </tr>
 <tr>
@@ -249,6 +251,8 @@ The following variables are defined by this SDK for use with style layers:
                <code>MGLPolygon</code> class
            </li>
        </ul>
+       This variable corresponds to the
+       <code>NSExpression.geometryTypeVariableExpression</code> property.
    </td>
 </tr>
 <tr>
@@ -260,6 +264,8 @@ The following variables are defined by this SDK for use with style layers:
       of a screen point in a heatmap layer; in other words, a relative measure
       of how many data points are crowded around a particular pixel. This
       variable can only be used with the <code>heatmapColor</code> property.
+      This variable corresponds to the
+      <code>NSExpression.heatmapDensityVariableExpression</code> property.
    </td>
 </tr>
 <tr>
@@ -268,7 +274,8 @@ The following variables are defined by this SDK for use with style layers:
    <td>
       The current zoom level. In style layout and paint properties, this
       variable may only appear as the target of a top-level interpolation or
-      step expression.
+      step expression. This variable corresponds to the
+      <code>NSExpression.zoomLevelVariableExpression</code> property.
    </td>
 </tr>
 </tbody>
@@ -301,7 +308,7 @@ string syntax:
 <dt>Selector:</dt>
 <dd><code>mgl_does:have:</code></dd>
 <dt>Format string syntax:</dt>
-<dd><code>mgl_does:have:(SELF, 'key')</code> or <code>mgl_does:have:(%@, 'key')</code></dd>
+<dd><code>mgl_does:have:(SELF, '🧀🍔')</code> or <code>mgl_does:have:(%@, '🧀🍔')</code></dd>
 </dl>
 
 Returns a Boolean value indicating whether the dictionary has a value for the
@@ -367,6 +374,10 @@ expression containing the strings to concatenate.
 
 Returns the arccosine of the number.
 
+This function corresponds to the
+[`acos`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-acos)
+operator in the Mapbox Style Specification.
+
 ### `mgl_asin:`
 
 <dl>
@@ -377,6 +388,10 @@ Returns the arccosine of the number.
 </dl>
 
 Returns the arcsine of the number.
+
+This function corresponds to the
+[`asin`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-asin)
+operator in the Mapbox Style Specification.
 
 ### `mgl_atan:`
 
@@ -389,6 +404,10 @@ Returns the arcsine of the number.
 
 Returns the arctangent of the number.
 
+This function corresponds to the
+[`atan`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-atan)
+operator in the Mapbox Style Specification.
+
 ### `mgl_cos:`
 
 <dl>
@@ -400,6 +419,10 @@ Returns the arctangent of the number.
 
 Returns the cosine of the number.
 
+This function corresponds to the
+[`cos`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-cos)
+operator in the Mapbox Style Specification.
+
 ### `mgl_log2:`
 
 <dl>
@@ -410,6 +433,10 @@ Returns the cosine of the number.
 </dl>
 
 Returns the base-2 logarithm of the number.
+
+This function corresponds to the
+[`log2`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-log2)
+operator in the Mapbox Style Specification.
 
 ### `mgl_round:`
 
@@ -423,6 +450,10 @@ Returns the base-2 logarithm of the number.
 Returns the number rounded to the nearest integer. If the number is halfway
 between two integers, this function rounds it away from zero.
 
+This function corresponds to the
+[`round`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-round)
+operator in the Mapbox Style Specification.
+
 ### `mgl_sin:`
 
 <dl>
@@ -433,6 +464,10 @@ between two integers, this function rounds it away from zero.
 </dl>
 
 Returns the sine of the number.
+
+This function corresponds to the
+[`sin`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-sin)
+operator in the Mapbox Style Specification.
 
 ### `mgl_tan:`
 
@@ -445,6 +480,10 @@ Returns the sine of the number.
 
 Returns the tangent of the number.
 
+This function corresponds to the
+[`tan`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-tan)
+operator in the Mapbox Style Specification.
+
 ### `mgl_coalesce:`
 
 <dl>
@@ -455,6 +494,10 @@ Returns the tangent of the number.
 </dl>
 
 Returns the first non-`nil` value from an array of expressions.
+
+This function corresponds to the
+[`coalesce`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-coalesce)
+operator in the Mapbox Style Specification.
 
 ### `MGL_LET`
 
@@ -495,6 +538,12 @@ expression that contains references to those variables.
 Returns the result of matching the input expression against the given constant
 values.
 
+This function corresponds to the
+`+[NSExpression(MGLInitializerAdditions) mgl_expressionForMatchingExpression:inDictionary:defaultExpression:]`
+method and the
+[`match`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-match)
+operator in the Mapbox Style Specification.
+
 ### `MGL_IF`
 
 <dl>
@@ -516,6 +565,12 @@ the `TERNARY()` syntax, this function can accept multiple “if else” conditio
 and is supported on iOS 8._x_ and macOS 10.10._x_; however, each conditional
 passed into this function must be wrapped in a constant expression.
 
+This function corresponds to the
+`+[NSExpression(MGLInitializerAdditions) mgl_expressionForConditional:trueExpression:falseExpresssion:]`
+method and the
+[`case`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-case)
+operator in the Mapbox Style Specification.
+
 ### `MGL_FUNCTION`
 
 <dl>
@@ -525,10 +580,12 @@ passed into this function must be wrapped in a constant expression.
 <dd><code>MGL_FUNCTION('typeof', mystery)</code></dd>
 <dt>Arguments:</dt>
 <dd>
-   Any arguments required by the expression operator, as defined in the
-   <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions">Mapbox Style Specification</a>.
+   Any arguments required by the expression operator.
 </dd>
 </dl>
+
+An expression exactly as defined by the
+[Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions).
 
 ## Custom functions
 
@@ -588,6 +645,14 @@ otherwise <code>TRUE</code>.
 <code>true</code> if the dictionary has a value for the key or if the evaluated
 object has a value for the feature attribute.
 
+This function corresponds to the
+[`has`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-has)
+operator in the Mapbox Style Specification. See also the
+[`mgl_does:have:`](#code-mgl_does-have-code) function, which is used on its own
+without the `FUNCTION()` operator. You can also check whether an object has an
+attribute by comparing the key path to `NIL`, for example `cheeseburger != NIL`
+or `burger.cheese != NIL`
+
 ### `mgl_expressionWithContext:`
 
 <dl>
@@ -613,6 +678,12 @@ object has a value for the feature attribute.
 
 The target expression with variable subexpressions replaced with the values
 defined in the context dictionary.
+
+This function corresponds to the
+[`let`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-let)
+operator in the Mapbox Style Specification. See also the
+[`MGL_LET`](#code-mgl_let-code) function, which is used on its own without the
+`FUNCTION()` operator.
 
 ### `mgl_interpolateWithCurveType:parameters:stops:`
 
@@ -666,6 +737,14 @@ values may be constant values or `NSExpression` objects. For example, you can
 use a stop dictionary with the zoom levels 0, 10, and 20 as keys and the colors
 yellow, orange, and red as the values.
 
+This function corresponds to the
+`+[NSExpression(MGLInitializerAdditions) mgl_expressionForInterpolatingExpression:withCurveType:parameters:stops:]`
+method and the
+[`interpolate`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-interpolate)
+operator in the Mapbox Style Specification. See also the
+[`mgl_interpolate:withCurveType:parameters:stops:`](#code-mgl_interpolate-withcurvetype-parameters-stops-code)
+function, which is used on its own without the `FUNCTION()` operator.
+
 ### `mgl_numberWithFallbackValues:`
 
 <dl>
@@ -699,6 +778,12 @@ A numeric representation of the target:
     algorithm of the ECMAScript Language Specification.
   * If multiple values are provided, each one is evaluated in order until the
     first successful conversion is obtained.
+
+This function corresponds to the
+[`to-number`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-types-to-number)
+operator in the Mapbox Style Specification. You can also cast a value to a
+number by passing the value and the string `NSNumber` into the `CAST()`
+operator.
 
 ### `mgl_stepWithMinimum:stops:`
 
@@ -736,6 +821,12 @@ values may be constant values or `NSExpression` objects. For example, you can
 use a stop dictionary with the zoom levels 0, 10, and 20 as keys and the colors
 yellow, orange, and red as the values.
 
+This function corresponds to the
+`+[NSExpression(MGLInitializerAdditions) mgl_expressionForSteppingExpression:fromExpression:stops:]`
+method and the
+[`step`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-step)
+operator in the Mapbox Style Specification.
+
 ### `stringByAppendingString:`
 
 <dl>
@@ -750,6 +841,14 @@ yellow, orange, and red as the values.
 </dl>
 
 The target string with each of the argument strings appended in order.
+
+This function corresponds to the
+`-[NSExpression(MGLInitializerAdditions) mgl_expressionByAppendingExpression:]`
+method and is similar to the
+[`concat`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-concat)
+operator in the Mapbox Style Specification. See also the
+[`mgl_join:`](#code-mgl_join-code) function, which concatenates multiple
+expressions and is used on its own without the `FUNCTION()` operator.
 
 ### `stringValue`
 
@@ -780,3 +879,9 @@ A string representation of the target:
 * Otherwise, the target is converted to a string in the format specified by the
   [`JSON.stringify()`](https://tc39.github.io/ecma262/#sec-json.stringify)
   function of the ECMAScript Language Specification.
+
+This function corresponds to the
+[`to-string`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-types-to-string)
+operator in the Mapbox Style Specification. You can also cast a value to a
+string by passing the value and the string `NSString` into the `CAST()`
+operator.

--- a/platform/darwin/docs/guides/Predicates and Expressions.md
+++ b/platform/darwin/docs/guides/Predicates and Expressions.md
@@ -136,7 +136,7 @@ NSExpression(forFunction: "lowercase:",
              arguments: [NSExpression(forKeyPath: "ISO 3166-1:2006")])
 ```
 
-### Predefined functions
+### Functions
 
 Of the
 [functions predefined by the `+[NSExpression expressionForFunction:arguments:]` method](https://developer.apple.com/documentation/foundation/nsexpression/1413747-init#discussion),
@@ -169,7 +169,10 @@ Initializer parameter | Format string syntax
 `length:`             | `length('Wapakoneta')`
 `castObject:toType:`  | `CAST(ele, 'NSString')`<br>`CAST(ele, 'NSNumber')`
 
-The following predefined functions are not supported:
+A number of [Mapbox-specific functions](#mapbox-specific-funcions) are also
+available.
+
+The following predefined functions are **not** supported:
 
 Initializer parameter | Format string syntax
 ----------------------|---------------------
@@ -187,228 +190,13 @@ Initializer parameter | Format string syntax
 `onesComplement:`     | `onesComplement(255)`
 `distanceToLocation:fromLocation:` | `distanceToLocation:fromLocation:(there, here)`
 
-### Mapbox-specific functions
-
-For compatibility with the Mapbox Style Specification, the following functions
-are defined by this SDK. When setting a style layer property, you can call these
-functions just like the predefined functions above, using either the
-`+[NSExpression expressionForFunction:arguments:]` method or a convenient format
-string syntax:
-
-Initializer parameter | Format string syntax | Description
-----------------------|----------------------|------------
-`mgl_does:have:` | `mgl_does:have:(SELF, 'key')` or `mgl_does:have:(%@, 'key')` | Returns a Boolean value indicating whether the dictionary has a value for the key or whether the evaluated object (`SELF`) has a value for the feature attribute. Compared to the `mgl_has:` custom function, that function’s target is instead passed in as the first argument to this function. Both functions are equivalent to the syntax `key != NIL` or `%@[key] != NIL` but can be used outside of a predicate.
-`mgl_interpolate:withCurveType:parameters:stops:` | `mgl_interpolate:withCurveType:parameters:stops:(x, 'linear', nil, %@)` | Produces continuous, smooth results by interpolating between pairs of input and output values (“stops”). Compared to the `mgl_interpolateWithCurveType:parameters:stops:` custom function, the input expression (that function’s target) is instead passed in as the first argument to this function.
-`mgl_step:from:stops:` | `mgl_step:from:stops:(x, 11, %@)` | Produces discrete, stepped results by evaluating a piecewise-constant function defined by pairs of input and output values ("stops"). Compared to the `mgl_stepWithMinimum:stops:` custom function, the input expression (that function’s target) is instead passed in as the first argument to this function.
-`mgl_join:` | `mgl_join({'Old', 'MacDonald'})` | Returns the result of concatenating together all the elements of an array in order. Compared to the `stringByAppendingString:` custom function, this function takes only one argument, which is an aggregate expression containing the strings to concatenate.
-`mgl_round:` | `mgl_round(1.5)` | Returns the number rounded to the nearest integer. If the number is halfway between two integers, this function rounds it away from zero.
-`mgl_coalesce:` | `mgl_coalesce({x, y, z})` | Returns the first non-`nil` value from an array of expressions.
-`MGL_LET` | `MGL_LET('age', uppercase('old'), 'name', uppercase('MacDonald'), mgl_join({$age, $name}))` | Any number of variable names interspersed with their assigned `NSExpression` values, followed by an `NSExpression` that may contain references to those variables. Compared to the `mgl_expressionWithContext:` custom function, this function takes the variable names and values inline before the expression that contains references to those variables.
-`MGL_MATCH` | `MGL_MATCH(x, 0, 'zero match', 1, 'one match', 'two match', 'default')` | Evaluates the first expression and returns the value that matches the initial condition. After the first expression condition a pair of matching/return value should be added and a default value.
-`MGL_IF` | `MGL_IF(1 = 2, YES, 2 = 2, YES, NO)` | Returns the first value that meets the condition otherwise a default value. The expression conditions should be added in pairs of conditional/return value. Unlike `+[NSExpression expressionForConditional:trueExpression:falseExpression:]` or the `TERNARY()` syntax, this function can accept multiple “if else” conditions and is supported on iOS 8._x_ and macOS 10.10._x_; however, each conditional passed into this function must be wrapped in a constant expression.
-
-The following custom functions are also available with the
-`+[NSExpression expressionForFunction:selectorName:arguments:]` method or the
-`FUNCTION()` format string syntax:
-
-<table>
-<thead>
-<tr><th>Selector name</th><th>Target</th><th>Arguments</th><th>Returns</th></tr>
-</thead>
-<tbody>
-<tr>
-   <td><code>boolValue</code></td>
-   <td>
-      An <code>NSExpression</code> that evaluates to a number or string.
-   </td>
-   <td></td>
-   <td>
-      A Boolean representation of the target: <code>FALSE</code> when then input is an
-      empty string, 0, <code>FALSE</code>, <code>NIL</code>, or <code>NaN</code>, otherwise <code>TRUE</code>.
-   </td>
-</tr>
-<tr>
-   <td><code>mgl_has:</code></td>
-   <td>
-      An <code>NSExpression</code> that evaluates to an <code>NSDictionary</code> or the evaluated object (<code>SELF</code>).
-   </td>
-   <td>
-      An <code>NSExpression</code> that evaluates to an <code>NSString</code> representing the key to look up in the dictionary or the feature attribute to look up in the evaluated object (see <code>MGLFeature.attributes</code>).
-   </td>
-   <td>
-      <code>true</code> if the dictionary has a value for the key or if the evaluated object has a value for the feature attribute.
-   </td>
-<tr>
-   <td><code>mgl_expressionWithContext:</code></td>
-   <td>
-      An <code>NSExpression</code> that may contain references to the variables defined in
-      the context dictionary.
-   </td>
-   <td>
-      An <code>NSDictionary</code> with <code>NSString</code>s as keys and <code>NSExpression</code>s as values.
-      Each key is a variable name and each value is the variable’s value within
-      the target expression.
-   </td>
-   <td>
-      The target expression with variable subexpressions replaced with the
-      values defined in the context dictionary.
-   </td>
-</tr>
-<tr>
-   <td><code>mgl_interpolateWithCurveType:parameters:stops:</code></td>
-   <td>
-      An <code>NSExpression</code> that evaluates to a number and contains a variable or
-      key path expression.
-   </td>
-   <td>
-      The first argument is one of the following strings denoting curve types:
-      <code>linear</code>, <code>exponential</code>, or <code>cubic-bezier</code>.
-      
-      The second argument is an expression providing parameters for the curve:
-      
-      <ul>
-         <li>If the curve type is <code>linear</code>, the argument is <code>NIL</code>.</li>
-         <li>
-            If the curve type is <code>exponential</code>, the argument is an expression
-            that evaluates to a number, specifying the base of the exponential
-            interpolation.
-         </li>
-         <li>
-            If the curve type is <code>cubic-bezier</code>, the argument is an array or
-            aggregate expression containing four expressions, each evaluating to
-            a number. The four numbers are control points for the cubic Bézier
-            curve.
-         </li>
-      </ul>
-      
-      The third argument is an <code>NSDictionary</code> object representing the
-      interpolation’s stops, with numeric zoom levels as keys and expressions as
-      values.
-   </td>
-   <td>
-      A value interpolated along the continuous mathematical function defined by
-      the arguments, with the target as the input to the function.
-   </td>
-</tr>
-<tr>
-   <td>
-      <code>mgl_numberWithFallbackValues:</code>,
-      <code>doubleValue</code>,
-      <code>floatValue</code>,
-      <code>decimalValue</code>
-   </td>
-   <td>
-      An <code>NSExpression</code> that evaluates to a Boolean value, number, or string.
-   </td>
-   <td>
-      Zero or more <code>NSExpression</code>s, each evaluating to a Boolean value or
-      string.
-   </td>
-   <td>
-      A numeric representation of the target:
-      <ul>
-         <li>If the target is <code>NIL</code> or <code>FALSE</code>, the result is 0.</li>
-         <li>If the target is true, the result is 1.</li>
-         <li>
-            If the target is a string, it is converted to a number as specified
-            by the
-            “<a href="https://tc39.github.io/ecma262/#sec-tonumber-applied-to-the-string-type">ToNumber Applied to the String Type</a>”
-            algorithm of the ECMAScript Language Specification.
-         </li>
-         <li>
-            If multiple values are provided, each one is evaluated in order
-            until the first successful conversion is obtained.
-         </li>
-      </ul>
-   </td>
-</tr>
-<tr>
-   <td><code>mgl_stepWithMinimum:stops:</code></td>
-   <td>
-      An <code>NSExpression</code> that evaluates to a number and contains a variable or
-      key path expression.
-   </td>
-   <td>
-      The first argument is an expression that evaluates to a number, specifying
-      the minimum value in case the target is less than any of the stops in the
-      second argument.
-      
-      The second argument is an <code>NSDictionary</code> object representing the
-      interpolation’s stops, with numeric zoom levels as keys and expressions as
-      values.
-   </td>
-   <td>
-      The output value of the stop whose key is just less than the evaluated
-      target, or the minimum value if the target is less than the least of the
-      stops’ keys.
-   </td>
-</tr>
-<tr>
-   <td><code>stringByAppendingString:</code></td>
-   <td>
-      An <code>NSExpression</code> that evaluates to a string.
-   </td>
-   <td>
-      One or more <code>NSExpression</code>s, each evaluating to a string.
-   </td>
-   <td>
-      The target string with each of the argument strings appended in order.
-   </td>
-</tr>
-<tr>
-   <td><code>stringValue</code></td>
-   <td>
-      An <code>NSExpression</code> that evaluates to a Boolean value, number, or string.
-   </td>
-   <td></td>
-   <td>
-      A string representation of the target:
-      <ul>
-         <li>If the target is <code>NIL</code>, the result is the string <code>null</code>.</li>
-         <li>
-            If the target is a Boolean value, the result is the string <code>true</code> or
-            <code>false</code>.
-         </li>
-         <li>
-            If the target is a number, it is converted to a string as specified
-            by the
-            “<a href="https://tc39.github.io/ecma262/#sec-tostring-applied-to-the-number-type">NumberToString</a>”
-            algorithm of the ECMAScript Language Specification.
-         </li>
-         <li>
-            If the target is a color, it is converted to a string of the form
-            <code>rgba(r,g,b,a)</code>, where <var>r</var>, <var>g</var>, and <var>b</var>
-            are numerals ranging from 0 to 255 and <var>a</var> ranges from 0 to
-            1.
-         </li>
-         <li>
-            Otherwise, the target is converted to a string in the format
-            specified by the
-            <a href="https://tc39.github.io/ecma262/#sec-json.stringify"><code>JSON.stringify()</code></a>
-            function of the ECMAScript Language Specification.
-         </li>
-      </ul>
-   </td>
-</tr>
-</tbody>
-</table>
-
-Some of these functions are defined as methods on their respective target
-classes, but you should not call them directly outside the context of an
-expression, because the result may differ from the evaluated expression’s result
-or may result in undefined behavior.
-
-The Mapbox Style Specification defines some operators for which no custom
-function is available. To use these operators in an `NSExpression`, call the
-`MGL_FUNCTION()` function with the same arguments that the operator expects.
-
 ### Conditionals
 
 Conditionals are supported via the built-in
 `+[NSExpression expressionForConditional:trueExpression:falseExpression:]`
 method and `TERNARY()` operator. If you need to express multiple cases
 (“else-if”), you can either nest a conditional within a conditional or use the
-`MGL_IF()` or `MGL_MATCH()` function.
+[`MGL_IF()`](#code-mgl_if-code) or [`MGL_MATCH()`](#code-mgl_match-code) function.
 
 ### Aggregates
 
@@ -492,3 +280,408 @@ of a [Mapbox-specific function](#mapbox-specific-functions) that takes an
 ```swift
 NSExpression(format: "MGL_LET(floorCount, 2, $floorCount + 1)")
 ```
+
+## Mapbox-specific functions
+
+For compatibility with the Mapbox Style Specification, the following functions
+are defined by this SDK. When setting a style layer property, you can call these
+functions just like the predefined functions above, using either the
+`+[NSExpression expressionForFunction:arguments:]` method or a convenient format
+string syntax:
+
+### `mgl_does:have:`
+
+<dl>
+<dt>Selector:</dt>
+<dd>`mgl_does:have:`</dd>
+<dt>Format string syntax:</dt>
+<dd><code>mgl_does:have:(SELF, 'key')</code> or <code>mgl_does:have:(%@, 'key')</code></dd>
+</dl>
+
+Returns a Boolean value indicating whether the dictionary has a value for the
+key or whether the evaluated object (`SELF`) has a value for the feature
+attribute. Compared to the [`mgl_has:`](#code-mgl_has-code) custom function,
+that function’s target is instead passed in as the first argument to this
+function. Both functions are equivalent to the syntax `key != NIL` or
+`%@[key] != NIL` but can be used outside of a predicate.
+
+### `mgl_interpolate:withCurveType:parameters:stops:`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>mgl_interpolate:withCurveType:parameters:stops:</code></dd>
+<dt>Format string syntax:</dt>
+<dd><code>mgl_interpolate:withCurveType:parameters:stops:(x, 'linear', nil, %@)</code></dd>
+</dl>
+
+Produces continuous, smooth results by interpolating between pairs of input and
+output values (“stops”). Compared to the
+[`mgl_interpolateWithCurveType:parameters:stops:`](#code-mgl_interpolatewithcurvetype-parameters-stops-code)
+custom function, the input expression (that function’s target) is instead passed
+in as the first argument to this function.
+
+### `mgl_step:from:stops:`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>mgl_step:from:stops:</code></dd>
+<dt>Format string syntax:</dt>
+<dd><code>mgl_step:from:stops:(x, 11, %@)</code></dd>
+</dl>
+
+Produces discrete, stepped results by evaluating a piecewise-constant function
+defined by pairs of input and output values ("stops"). Compared to the
+[`mgl_stepWithMinimum:stops:`](#code-mgl_stepwithminimum-stops-code) custom
+function, the input expression (that function’s target) is instead passed in as
+the first argument to this function.
+
+### `mgl_join:`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>mgl_join:</code></dd>
+<dt>Format string syntax:</dt>
+<dd><code>mgl_join({'Old', 'MacDonald'})</code></dd>
+</dl>
+
+Returns the result of concatenating together all the elements of an array in
+order. Compared to the
+[`stringByAppendingString:`](#code-stringbyappendingstring-code) custom
+function, this function takes only one argument, which is an aggregate
+expression containing the strings to concatenate.
+
+### `mgl_round:`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>mgl_round:</code></dd>
+<dt>Format string syntax:</dt>
+<dd><code>mgl_round(1.5)</code></dd>
+</dl>
+
+Returns the number rounded to the nearest integer. If the number is halfway
+between two integers, this function rounds it away from zero.
+
+### `mgl_coalesce:`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>mgl_coalesce:</code></dd>
+<dt>Format string syntax:</dt>
+<dd><code>mgl_coalesce({x, y, z})</code></dd>
+</dl>
+
+Returns the first non-`nil` value from an array of expressions.
+
+### `MGL_LET`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>MGL_LET:</code></dd>
+<dt>Format string syntax:</dt>
+<dd><code>MGL_LET('age', uppercase('old'), 'name', uppercase('MacDonald'), mgl_join({$age, $name}))</code></dd>
+<dt>Arguments:</dt>
+<dd>
+   Any number of variable names interspersed with their assigned
+   <code>NSExpression</code> values, followed by an <code>NSExpression</code>
+   that may contain references to those variables.
+</dd>
+</dl>
+
+Returns the result of evaluating an expression with the given variable values.
+Compared to the
+[`mgl_expressionWithContext:`](#code-mgl_expressionwithcontext-code) custom
+function, this function takes the variable names and values inline before the
+expression that contains references to those variables.
+
+### `MGL_MATCH`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>MGL_MATCH:</code></dd>
+<dt>Format string syntax:</dt>
+<dd><code>`MGL_MATCH(x, 0, 'zero match', 1, 'one match', 'two match', 'default')`</code></dd>
+<dt>Arguments:</dt>
+<dd>
+   An input expression, then any number of argument pairs, followed by a default
+   expression. Each argument pair consists of a constant value followed by an
+   expression to produce as a result of matching that constant value.
+</dd>
+</dl>
+
+Returns the result of matching the input expression against the given constant
+values.
+
+### `MGL_IF`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>MGL_IF:</code></dd>
+<dt>Format string syntax:</dt>
+<dd><code>`MGL_IF(1 = 2, YES, 2 = 2, YES, NO)`</code></dd>
+<dt>Arguments:</dt>
+<dd>
+   Alternating <code>NSPredicate</code> conditionals and resulting expressions,
+   followed by a default expression.
+</dd>
+</dl>
+
+Returns the first expression that meets the condition; otherwise, the default
+value. Unlike
+`+[NSExpression expressionForConditional:trueExpression:falseExpression:]` or
+the `TERNARY()` syntax, this function can accept multiple “if else” conditions
+and is supported on iOS 8._x_ and macOS 10.10._x_; however, each conditional
+passed into this function must be wrapped in a constant expression.
+
+### `MGL_FUNCTION`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>MGL_FUNCTION:</code></dd>
+<dt>Format string syntax:</dt>
+<dd><code>`MGL_FUNCTION('typeof', mystery)`</code></dd>
+<dt>Arguments:</dt>
+<dd>
+   Any arguments required by the expression operator, as defined in the
+   [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions).
+</dd>
+</dl>
+
+## Custom functions
+
+The following custom functions are also available with the
+`+[NSExpression expressionForFunction:selectorName:arguments:]` method or the
+`FUNCTION()` format string syntax.
+
+Some of these functions are defined as methods on their respective target
+classes, but you should not call them directly outside the context of an
+expression, because the result may differ from the evaluated expression’s result
+or may result in undefined behavior.
+
+The Mapbox Style Specification defines some operators for which no custom
+function is available. To use these operators in an `NSExpression`, call the
+[`MGL_FUNCTION()`](#code-mgl_function-code) function with the same arguments
+that the operator expects.
+
+### `boolValue`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>boolValue</code></dd>
+<dt>Format string syntax:</dt>
+<dd><code>`FUNCTION(1, 'boolValue')`</code></dd>
+<dt>Target:</dt>
+<dd>
+   An <code>NSExpression</code> that evaluates to a number or string.
+</dd>
+<dt>Arguments:</dt>
+<dd>None.</dd>
+</dl>
+
+A Boolean representation of the target: <code>FALSE</code> when then input is an
+empty string, 0, <code>FALSE</code>, <code>NIL</code>, or <code>NaN</code>,
+otherwise <code>TRUE</code>.
+
+### `mgl_has:`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>mgl_has:</code></dd>
+<dt>Format string syntax:</dt>
+<dd><code>`FUNCTION($featureProperties, 'mgl_has:', '🧀🍔')`</code></dd>
+<dt>Target:</dt>
+<dd>
+   An <code>NSExpression</code> that evaluates to an <code>NSDictionary</code>
+   or the evaluated object (<code>SELF</code>).
+</dd>
+<dt>Arguments:</dt>
+<dd>
+   An <code>NSExpression</code> that evaluates to an <code>NSString</code>
+   representing the key to look up in the dictionary or the feature attribute to
+   look up in the evaluated object (see <code>MGLFeature.attributes</code>).
+</dd>
+</dl>
+
+<code>true</code> if the dictionary has a value for the key or if the evaluated
+object has a value for the feature attribute.
+
+### `mgl_expressionWithContext:`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>mgl_expressionWithContext:</code></dd>
+<dt>Format string syntax:</dt>
+<dd>
+   <code>`FUNCTION($ios + $macos, 'mgl_expressionWithContext:', %@)`</code> with
+   a dictionary containing `ios` and `macos` keys
+</dd>
+<dt>Target:</dt>
+<dd>
+   An <code>NSExpression</code> that may contain references to the variables
+   defined in the context dictionary.
+</dd>
+<dt>Arguments:</dt>
+<dd>
+   An <code>NSDictionary</code> with <code>NSString</code>s as keys and
+   <code>NSExpression</code>s as values. Each key is a variable name and each
+   value is the variable’s value within the target expression.
+</dd>
+</dl>
+
+The target expression with variable subexpressions replaced with the values
+defined in the context dictionary.
+
+### `mgl_interpolateWithCurveType:parameters:stops:`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>mgl_interpolateWithCurveType:parameters:stops:</code></dd>
+<dt>Format string syntax:</dt>
+<dd>
+   <code>`FUNCTION($zoomLevel, 'mgl_interpolateWithCurveType:parameters:stops:', 'linear', NIL, %@)`</code>
+   with a dictionary containing zoom levels as keys
+</dd>
+<dt>Target:</dt>
+<dd>
+   An <code>NSExpression</code> that evaluates to a number and contains a
+   variable or key path expression.
+</dd>
+<dt>Arguments:</dt>
+<dd>
+   The first argument is one of the following strings denoting curve types:
+   <code>linear</code>, <code>exponential</code>, or <code>cubic-bezier</code>.
+   
+   The second argument is an expression providing parameters for the curve:
+   
+   <ul>
+      <li>If the curve type is <code>linear</code>, the argument is <code>NIL</code>.</li>
+      <li>
+         If the curve type is <code>exponential</code>, the argument is an
+         expression that evaluates to a number, specifying the base of the
+         exponential interpolation.
+      </li>
+      <li>
+         If the curve type is <code>cubic-bezier</code>, the argument is an
+         array or aggregate expression containing four expressions, each
+         evaluating to a number. The four numbers are control points for the
+         cubic Bézier curve.
+      </li>
+   </ul>
+   
+   The third argument is an <code>NSDictionary</code> object representing the
+   interpolation’s stops, with numeric zoom levels as keys and expressions as
+   values.
+</dd>
+</dl>
+
+A value interpolated along the continuous mathematical function defined by the
+arguments, with the target as the input to the function.
+
+### `mgl_numberWithFallbackValues:`
+
+<dl>
+<dt>Selector:</dt>
+<dd>
+   <code>mgl_numberWithFallbackValues:</code>,
+   <code>doubleValue</code>,
+   <code>floatValue</code>, or
+   <code>decimalValue</code>
+</dd>
+<dt>Format string syntax:</dt>
+<dd><code>`FUNCTION(ele, 'mgl_numberWithFallbackValues:', 0)`</code></dd>
+<dt>Target:</dt>
+<dd>
+   An <code>NSExpression</code> that evaluates to a Boolean value, number, or
+   string.
+</dd>
+<dt>Arguments:</dt>
+<dd>
+   Zero or more <code>NSExpression</code>s, each evaluating to a Boolean value
+   or string.
+</dd>
+</dl>
+
+A numeric representation of the target:
+
+* If the target is <code>NIL</code> or <code>FALSE</code>, the result is 0.
+* If the target is true, the result is 1.
+  * If the target is a string, it is converted to a number as specified by the
+    “[ToNumber Applied to the String Type](https://tc39.github.io/ecma262/#sec-tonumber-applied-to-the-string-type)”
+    algorithm of the ECMAScript Language Specification.
+  * If multiple values are provided, each one is evaluated in order until the
+    first successful conversion is obtained.
+
+### `mgl_stepWithMinimum:stops:`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>mgl_stepWithMinimum:stops:</code></dd>
+<dt>Format string syntax:</dt>
+<dd>
+   <code>`FUNCTION($zoomLevel, 'mgl_stepWithMinimum:stops:', 0, %@)`</code> with
+   a dictionary with zoom levels as keys
+</dd>
+<dt>Target:</dt>
+<dd>
+   An <code>NSExpression</code> that evaluates to a number and contains a
+   variable or key path expression.
+</dd>
+<dt>Arguments:</dt>
+<dd>
+   The first argument is an expression that evaluates to a number, specifying
+   the minimum value in case the target is less than any of the stops in the
+   second argument.
+   
+   The second argument is an <code>NSDictionary</code> object representing the
+   interpolation’s stops, with numeric zoom levels as keys and expressions as
+   values.
+</dd>
+</dl>
+
+The output value of the stop whose key is just less than the evaluated target,
+or the minimum value if the target is less than the least of the stops’ keys.
+
+### `stringByAppendingString:`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>stringByAppendingString:</code></dd>
+<dt>Format string syntax:</dt>
+<dd><code>`FUNCTION('Old', 'stringByAppendingString:', 'MacDonald')`</code></dd>
+<dt>Target:</dt>
+<dd>An <code>NSExpression</code> that evaluates to a string.</dd>
+<dt>Arguments:</dt>
+<dd>One or more <code>NSExpression</code>s, each evaluating to a string.</dd>
+</dl>
+
+The target string with each of the argument strings appended in order.
+
+### `stringValue`
+
+<dl>
+<dt>Selector:</dt>
+<dd><code>stringValue</code></dd>
+<dt>Format string syntax:</dt>
+<dd><code>`FUNCTION(ele, 'stringValue')`</code></dd>
+<dt>Target:</dt>
+<dd>
+   An <code>NSExpression</code> that evaluates to a Boolean value, number, or
+   string.
+</dd>
+<dt>Arguments:</dt>
+<dd>None.</dd>
+</dl>
+
+A string representation of the target:
+
+* If the target is <code>NIL</code>, the result is the empty string.
+* If the target is a Boolean value, the result is the string `true` or `false`.
+* If the target is a number, it is converted to a string as specified by the
+  “[NumberToString](https://tc39.github.io/ecma262/#sec-tostring-applied-to-the-number-type)”
+  algorithm of the ECMAScript Language Specification.
+* If the target is a color, it is converted to a string of the form
+  `rgba(r,g,b,a)`, where <var>r</var>, <var>g</var>, and <var>b</var> are
+  numerals ranging from 0 to 255 and <var>a</var> ranges from 0 to 1.
+* Otherwise, the target is converted to a string in the format specified by the
+  [`JSON.stringify()`](https://tc39.github.io/ecma262/#sec-json.stringify)
+  function of the ECMAScript Language Specification.

--- a/platform/darwin/docs/guides/Predicates and Expressions.md
+++ b/platform/darwin/docs/guides/Predicates and Expressions.md
@@ -130,6 +130,12 @@ expression format string of `lowercase(ISO 3166-1:2006)` or a predicate format
 string of `ISO 3166-1:2006 == 'US-OH'` would raise an exception. Instead, use a
 `%K` placeholder or the `+[NSExpression expressionForKeyPath:]` initializer:
 
+```objc
+[NSPredicate predicateWithFormat:@"%K == 'US-OH'", @"ISO 3166-1:2006"];
+[NSExpression expressionForFunction:@"lowercase:"
+                          arguments:@[[NSExpression expressionForKeyPath:@"ISO 3166-1:2006"]]]
+```
+
 ```swift
 NSPredicate(format: "%K == 'US-OH'", "ISO 3166-1:2006")
 NSExpression(forFunction: "lowercase:",

--- a/platform/darwin/docs/theme/assets/css/jazzy.css.scss
+++ b/platform/darwin/docs/theme/assets/css/jazzy.css.scss
@@ -118,6 +118,7 @@ h3 {
 
 h3 > code {
   font-weight: bold;
+  font-size: 1.2rem;
 }
 
 h4 {

--- a/platform/darwin/docs/theme/assets/css/jazzy.css.scss
+++ b/platform/darwin/docs/theme/assets/css/jazzy.css.scss
@@ -113,7 +113,11 @@ h2 {
 }
 
 h3 {
-  @include heading(14px, 1em 0 0.3em);
+  @include heading(1.2rem, 1em 0 0.3em);
+}
+
+h3 > code {
+  font-weight: bold;
 }
 
 h4 {

--- a/platform/darwin/src/NSExpression+MGLAdditions.h
+++ b/platform/darwin/src/NSExpression+MGLAdditions.h
@@ -16,7 +16,7 @@ typedef NSString *MGLExpressionInterpolationMode NS_TYPED_ENUM;
  
  This attribute corresponds to the `linear` value in the
  <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-interpolate"><code>interpolate</code></a>
- expression reference in the Mapbox Style Specification.
+ expression operator in the Mapbox Style Specification.
  */
 extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolationModeLinear;
 
@@ -25,7 +25,7 @@ extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolatio
  
  This attribute corresponds to the `exponential` value in the
  <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-interpolate"><code>interpolate</code></a>
- expression reference in the Mapbox Style Specification.
+ expression operator in the Mapbox Style Specification.
  */
 extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolationModeExponential;
 
@@ -34,50 +34,55 @@ extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolatio
  
  This attribute corresponds to the `cubic-bezier` value in the
  <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-interpolate"><code>interpolate</code></a>
- expression reference in the Mapbox Style Specification.
+ expression operator in the Mapbox Style Specification.
  */
 extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolationModeCubicBezier;
 
-@interface NSExpression (MGLVariableAdditions)
+/**
+ Methods for creating expressions that use Mapbox-specific functionality and for
+ converting to and from the JSON format defined in the
+ <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions">Mapbox Style Specification</a>.
+ */
+@interface NSExpression (MGLAdditions)
+
+#pragma mark Creating Variable Expressions
 
 /**
  `NSExpression` variable that corresponds to the
  <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-zoom"><code>zoom</code></a>
- expression reference in the Mapbox Style Specification.
+ expression operator in the Mapbox Style Specification.
  */
 @property (class, nonatomic, readonly) NSExpression *zoomLevelVariableExpression;
 
 /**
  `NSExpression` variable that corresponds to the
  <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-heatmap-density"><code>heatmap-density</code></a>
- expression reference in the Mapbox Style Specification.
+ expression operator in the Mapbox Style Specification.
  */
 @property (class, nonatomic, readonly) NSExpression *heatmapDensityVariableExpression;
 
 /**
  `NSExpression` variable that corresponds to the
  <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#eexpressions-geometry-type"><code>geometry-type</code></a>
- expression reference in the Mapbox Style Specification.
+ expression operator in the Mapbox Style Specification.
  */
 @property (class, nonatomic, readonly) NSExpression *geometryTypeVariableExpression;
 
 /**
  `NSExpression` variable that corresponds to the
  <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-id"><code>id</code></a>
- expression reference in the Mapbox Style Specification.
+ expression operator in the Mapbox Style Specification.
  */
 @property (class, nonatomic, readonly) NSExpression *featureIdentifierVariableExpression;
 
 /**
  `NSExpression` variable that corresponds to the
  <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-properties"><code>properties</code></a>
- expression reference in the Mapbox Style Specification.
+ expression operator in the Mapbox Style Specification.
  */
 @property (class, nonatomic, readonly) NSExpression *featurePropertiesVariableExpression;
 
-@end
-
-@interface NSExpression (MGLInitializerAdditions)
+#pragma mark Creating Conditional Expressions
 
 /**
  Returns a conditional function expression specifying the string predicate, and
@@ -88,6 +93,8 @@ extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolatio
  @param falseExpression The expression for conditions equal to false.
  */
 + (instancetype)mgl_expressionForConditional:(nonnull NSPredicate *)conditionPredicate trueExpression:(nonnull NSExpression *)trueExpression falseExpresssion:(nonnull NSExpression *)falseExpression NS_SWIFT_NAME(init(forMGLConditional:trueExpression:falseExpression:));
+
+#pragma mark Creating Ramp, Scale, and Curve Expressions
 
 /**
  Returns a step function expression specifying the stepping, from expression
@@ -121,6 +128,9 @@ extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolatio
  @param defaultExpression The defaultValue expression to be used in case there is no match.
  */
 + (instancetype)mgl_expressionForMatchingExpression:(nonnull NSExpression *)inputExpression inDictionary:(nonnull NSDictionary<NSExpression *, NSExpression *> *)matchedExpressions defaultExpression:(nonnull NSExpression *)defaultExpression NS_SWIFT_NAME(init(forMGLMatchingKey:in:default:));
+
+#pragma mark Concatenating String Expressions
+
 /**
  Returns a constant expression appending the passed expression.
  
@@ -131,9 +141,7 @@ extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolatio
  */
 - (instancetype)mgl_expressionByAppendingExpression:(nonnull NSExpression *)expression NS_SWIFT_NAME(mgl_appending(_:));
 
-@end
-
-@interface NSExpression (MGLAdditions)
+#pragma mark Converting JSON Expressions
 
 /**
  Returns an expression equivalent to the given Foundation object deserialized
@@ -167,6 +175,8 @@ extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolatio
  write to a file.
  */
 @property (nonatomic, readonly) id mgl_jsonExpressionObject;
+
+#pragma mark Localizing the Expression
 
 /**
  Returns a copy of the receiver localized into the given locale.

--- a/platform/darwin/src/NSExpression+MGLAdditions.mm
+++ b/platform/darwin/src/NSExpression+MGLAdditions.mm
@@ -621,7 +621,8 @@ NS_DICTIONARY_OF(NSNumber *, NSExpression *) *MGLStopDictionaryByReplacingTokens
 }
 
 @end
-@implementation NSExpression (MGLVariableAdditions)
+
+@implementation NSExpression (MGLAdditions)
 
 + (NSExpression *)zoomLevelVariableExpression {
     return [NSExpression expressionForVariable:@"zoomLevel"];
@@ -643,9 +644,21 @@ NS_DICTIONARY_OF(NSNumber *, NSExpression *) *MGLStopDictionaryByReplacingTokens
     return [NSExpression expressionForVariable:@"featureProperties"];
 }
 
+- (NSExpression *)mgl_expressionWithContext:(NSDictionary<NSString *, NSExpression *> *)context {
+    [NSException raise:NSInternalInconsistencyException
+                format:@"Assignment expressions lack underlying Objective-C implementations."];
+    return self;
+}
+
+- (id)mgl_has:(id)element {
+    [NSException raise:NSInvalidArgumentException
+                format:@"Has expressions lack underlying Objective-C implementations."];
+    return nil;
+}
+
 @end
 
-@implementation NSExpression (MGLInitializerAdditions)
+@implementation NSExpression (MGLAdditions)
 
 + (instancetype)mgl_expressionForConditional:(nonnull NSPredicate *)conditionPredicate trueExpression:(nonnull NSExpression *)trueExpression falseExpresssion:(nonnull NSExpression *)falseExpression {
     if (@available(iOS 9.0, *)) {
@@ -655,12 +668,12 @@ NS_DICTIONARY_OF(NSNumber *, NSExpression *) *MGLStopDictionaryByReplacingTokens
     }
 }
 
-+ (instancetype)mgl_expressionForSteppingExpression:(nonnull NSExpression*)steppingExpression fromExpression:(nonnull NSExpression *)minimumExpression stops:(nonnull NSExpression*)stops {
++ (instancetype)mgl_expressionForSteppingExpression:(nonnull NSExpression *)steppingExpression fromExpression:(nonnull NSExpression *)minimumExpression stops:(nonnull NSExpression *)stops {
     return [NSExpression expressionForFunction:@"mgl_step:from:stops:"
                                      arguments:@[steppingExpression, minimumExpression, stops]];
 }
 
-+ (instancetype)mgl_expressionForInterpolatingExpression:(nonnull NSExpression*)inputExpression withCurveType:(nonnull MGLExpressionInterpolationMode)curveType parameters:(nullable NSExpression *)parameters stops:(nonnull NSExpression*)stops {
++ (instancetype)mgl_expressionForInterpolatingExpression:(nonnull NSExpression *)inputExpression withCurveType:(nonnull MGLExpressionInterpolationMode)curveType parameters:(nullable NSExpression *)parameters stops:(nonnull NSExpression *)stops {
     NSExpression *sanitizeParams = parameters ? parameters : [NSExpression expressionForConstantValue:nil];
     return [NSExpression expressionForFunction:@"mgl_interpolate:withCurveType:parameters:stops:"
                                      arguments:@[inputExpression, [NSExpression expressionForConstantValue:curveType], sanitizeParams, stops]];
@@ -684,26 +697,6 @@ NS_DICTIONARY_OF(NSNumber *, NSExpression *) *MGLStopDictionaryByReplacingTokens
     NSExpression *subexpression = [NSExpression expressionForAggregate:@[self, expression]];
     return [NSExpression expressionForFunction:@"mgl_join:" arguments:@[subexpression]];
 }
-
-@end
-
-@implementation NSExpression (MGLExpressionAdditions)
-
-- (NSExpression *)mgl_expressionWithContext:(NSDictionary<NSString *, NSExpression *> *)context {
-    [NSException raise:NSInternalInconsistencyException
-                format:@"Assignment expressions lack underlying Objective-C implementations."];
-    return self;
-}
-
-- (id)mgl_has:(id)element {
-    [NSException raise:NSInvalidArgumentException
-                format:@"Has expressions lack underlying Objective-C implementations."];
-    return nil;
-}
-
-@end
-
-@implementation NSExpression (MGLAdditions)
 
 static NSDictionary<NSString *, NSString *> *MGLFunctionNamesByExpressionOperator;
 static NSDictionary<NSString *, NSString *> *MGLExpressionOperatorsByFunctionNames;

--- a/platform/darwin/src/NSExpression+MGLAdditions.mm
+++ b/platform/darwin/src/NSExpression+MGLAdditions.mm
@@ -622,6 +622,22 @@ NS_DICTIONARY_OF(NSNumber *, NSExpression *) *MGLStopDictionaryByReplacingTokens
 
 @end
 
+@implementation NSExpression (MGLExpressionAdditions)
+
+- (NSExpression *)mgl_expressionWithContext:(NSDictionary<NSString *, NSExpression *> *)context {
+    [NSException raise:NSInternalInconsistencyException
+                format:@"Assignment expressions lack underlying Objective-C implementations."];
+    return self;
+}
+
+- (id)mgl_has:(id)element {
+    [NSException raise:NSInvalidArgumentException
+                format:@"Has expressions lack underlying Objective-C implementations."];
+    return nil;
+}
+
+@end
+
 @implementation NSExpression (MGLAdditions)
 
 + (NSExpression *)zoomLevelVariableExpression {
@@ -643,22 +659,6 @@ NS_DICTIONARY_OF(NSNumber *, NSExpression *) *MGLStopDictionaryByReplacingTokens
 + (NSExpression *)featurePropertiesVariableExpression {
     return [NSExpression expressionForVariable:@"featureProperties"];
 }
-
-- (NSExpression *)mgl_expressionWithContext:(NSDictionary<NSString *, NSExpression *> *)context {
-    [NSException raise:NSInternalInconsistencyException
-                format:@"Assignment expressions lack underlying Objective-C implementations."];
-    return self;
-}
-
-- (id)mgl_has:(id)element {
-    [NSException raise:NSInvalidArgumentException
-                format:@"Has expressions lack underlying Objective-C implementations."];
-    return nil;
-}
-
-@end
-
-@implementation NSExpression (MGLAdditions)
 
 + (instancetype)mgl_expressionForConditional:(nonnull NSPredicate *)conditionPredicate trueExpression:(nonnull NSExpression *)trueExpression falseExpresssion:(nonnull NSExpression *)falseExpression {
     if (@available(iOS 9.0, *)) {


### PR DESCRIPTION
This is a smorgasbord of improvements related to predicate and expression documentation.

Consolidated the NSExpression categories into a single category, with marks to separate different tasks. Documented the `NSExpression(MGLAdditions)` category so that it shows up in the jazzy documentation.

Corrected various factual inaccuracies in the “Predicates and Expressions” guide. Moved some explanation from the predicates section to the expressions section. Added sections for all the other expression types we support.

Reorganized the custom function documentation as a series of sections with headers and definition lists instead of a monolithic table. Linked references to custom functions. Added format string examples for all custom functions. Each custom function definition cross-references the corresponding aftermarket function (or vice versa), the corresponding style specification expression operator, and any related NSExpression syntax.

Documented the trigonometric functions added in #11716.

Made `<h3>` tags more visible throughout jazzy documentation. (This is the only page that includes `<h3>` tags, and the heading for each function needs to be at least as prominent as the surrounding text.

Fixes #11740 and fixes #11745.

/cc @fabian-guerra @jmkiley @friedbunny