### PR TITLE
[qt] Only share a FileSource if it points to the same path

### DIFF
--- a/platform/qt/app/mapwindow.cpp
+++ b/platform/qt/app/mapwindow.cpp
@@ -22,6 +22,13 @@ MapWindow::MapWindow(const QMapboxGLSettings &settings)
     setWindowIcon(QIcon(":icon.png"));
 }
 
+MapWindow::~MapWindow()
+{
+    // Make sure we have a valid context so we
+    // can delete the QMapboxGL.
+    makeCurrent();
+}
+
 void MapWindow::selfTest()
 {
     if (m_bearingAnimation) {

--- a/platform/qt/app/mapwindow.hpp
+++ b/platform/qt/app/mapwindow.hpp
@@ -29,6 +29,7 @@ class MapWindow : public QGLWidget
 
 public:
     MapWindow(const QMapboxGLSettings &);
+    ~MapWindow();
 
     void selfTest();
 


### PR DESCRIPTION
Previously all QMapboxGL objects were sharing the same cache created by the
first instantiated object. Now it will share the cache only if it points to
the same path.

Fixes #11766