### PR TITLE
[ios, macos] Fix overlay bounds that span the antimeridian.

### DIFF
--- a/platform/darwin/src/MGLGeometry.h
+++ b/platform/darwin/src/MGLGeometry.h
@@ -174,6 +174,17 @@ NS_INLINE MGLCoordinateBounds MGLCoordinateBoundsOffset(MGLCoordinateBounds boun
 }
 
 /**
+ YES if the coordinate is valid or NO if it is not.
+ Considers extended coordinates.
+ */
+NS_INLINE BOOL MGLLocationCoordinate2DIsValid(CLLocationCoordinate2D coordinate) {
+    return (coordinate.latitude  <= 90.0  &&
+            coordinate.latitude  >= -90.0  &&
+            coordinate.longitude <= 360.0 &&
+            coordinate.longitude >= -360.0);
+}
+
+/**
  Returns `YES` if the coordinate bounds covers no area.
 
  @note A bounds may be empty but have a non-zero coordinate span (e.g., when its

--- a/platform/darwin/src/MGLGeometry.h
+++ b/platform/darwin/src/MGLGeometry.h
@@ -174,17 +174,6 @@ NS_INLINE MGLCoordinateBounds MGLCoordinateBoundsOffset(MGLCoordinateBounds boun
 }
 
 /**
- YES if the coordinate is valid or NO if it is not.
- Considers extended coordinates.
- */
-NS_INLINE BOOL MGLLocationCoordinate2DIsValid(CLLocationCoordinate2D coordinate) {
-    return (coordinate.latitude  <= 90.0  &&
-            coordinate.latitude  >= -90.0  &&
-            coordinate.longitude <= 360.0 &&
-            coordinate.longitude >= -360.0);
-}
-
-/**
  Returns `YES` if the coordinate bounds covers no area.
 
  @note A bounds may be empty but have a non-zero coordinate span (e.g., when its

--- a/platform/darwin/src/MGLGeometry_Private.h
+++ b/platform/darwin/src/MGLGeometry_Private.h
@@ -71,6 +71,17 @@ NS_INLINE MGLCoordinateQuad MGLCoordinateQuadFromLatLngArray(std::array<mbgl::La
     MGLLocationCoordinate2DFromLatLng(quad[1]) };
 }
 
+/**
+ YES if the coordinate is valid or NO if it is not.
+ Considers extended coordinates.
+ */
+NS_INLINE BOOL MGLLocationCoordinate2DIsValid(CLLocationCoordinate2D coordinate) {
+    return (coordinate.latitude  <= 90.0  &&
+            coordinate.latitude  >= -90.0  &&
+            coordinate.longitude <= 360.0 &&
+            coordinate.longitude >= -360.0);
+}
+
 #if TARGET_OS_IPHONE
 NS_INLINE mbgl::EdgeInsets MGLEdgeInsetsFromNSEdgeInsets(UIEdgeInsets insets) {
     return { insets.top, insets.left, insets.bottom, insets.right };

--- a/platform/darwin/src/MGLMultiPoint.mm
+++ b/platform/darwin/src/MGLMultiPoint.mm
@@ -163,7 +163,7 @@
     if (!_bounds) {
         mbgl::LatLngBounds bounds = mbgl::LatLngBounds::empty();
         for (auto coordinate : _coordinates) {
-            if (!CLLocationCoordinate2DIsValid(coordinate)) {
+            if (!MGLLocationCoordinate2DIsValid(coordinate)) {
                 bounds = mbgl::LatLngBounds::empty();
                 break;
             }

--- a/platform/darwin/src/MGLOverlay.h
+++ b/platform/darwin/src/MGLOverlay.h
@@ -31,10 +31,10 @@ NS_ASSUME_NONNULL_BEGIN
  overlay. Implementers of this protocol must set this area when implementing
  their overlay class, and after setting it, you must not change it.
  
- To bring both sides of the antimeridian or international date line into view,
- specify some longitudes less than −180 degrees or greater than 180 degrees. For
- example, to show both Tokyo and San Francisco simultaneously, you could set the
- visible bounds to extend from (35.68476, −220.24257) to (37.78428, −122.41310).
+ If this overlay spans the antimeridian, its bounds may extend west of −180 degrees
+ longitude or east of 180 degrees longitude. For example, an overlay covering the
+ Pacific Ocean from Tokyo to San Francisco might have a bounds extending
+ from (35.68476, −220.24257) to (37.78428, −122.41310).
  */
 @property (nonatomic, readonly) MGLCoordinateBounds overlayBounds;
 

--- a/platform/darwin/src/MGLOverlay.h
+++ b/platform/darwin/src/MGLOverlay.h
@@ -30,6 +30,11 @@ NS_ASSUME_NONNULL_BEGIN
  This property contains the smallest rectangle that completely encompasses the
  overlay. Implementers of this protocol must set this area when implementing
  their overlay class, and after setting it, you must not change it.
+ 
+ To bring both sides of the antimeridian or international date line into view,
+ specify some longitudes less than −180 degrees or greater than 180 degrees. For
+ example, to show both Tokyo and San Francisco simultaneously, you could set the
+ visible bounds to extend from (35.68476, −220.24257) to (37.78428, −122.41310).
  */
 @property (nonatomic, readonly) MGLCoordinateBounds overlayBounds;
 

--- a/platform/darwin/src/MGLPointCollection.mm
+++ b/platform/darwin/src/MGLPointCollection.mm
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (!_bounds) {
         mbgl::LatLngBounds bounds = mbgl::LatLngBounds::empty();
         for (auto coordinate : _coordinates) {
-            if (!CLLocationCoordinate2DIsValid(coordinate)) {
+            if (!MGLLocationCoordinate2DIsValid(coordinate)) {
                 bounds = mbgl::LatLngBounds::empty();
                 break;
             }

--- a/platform/darwin/test/MGLGeometryTests.mm
+++ b/platform/darwin/test/MGLGeometryTests.mm
@@ -172,4 +172,40 @@
     XCTAssertEqual(point.y, roundTrippedPoint.y);
     XCTAssertEqual(point.zoomLevel, roundTrippedPoint.zoomLevel);
 }
+
+- (void)testMGLLocationCoordinate2DIsValid {
+    {
+        CLLocationCoordinate2D coordinate = CLLocationCoordinate2DMake(37.936, -71.516);
+        XCTAssertTrue(MGLLocationCoordinate2DIsValid(coordinate));
+    }
+    {
+        CLLocationCoordinate2D coordinate = CLLocationCoordinate2DMake(46.816368, 5.844469);
+        XCTAssertTrue(MGLLocationCoordinate2DIsValid(coordinate));
+    }
+    {
+        CLLocationCoordinate2D coordinate = CLLocationCoordinate2DMake(-21.512680, 23.334703);
+        XCTAssertTrue(MGLLocationCoordinate2DIsValid(coordinate));
+    }
+    {
+        CLLocationCoordinate2D coordinate = CLLocationCoordinate2DMake(-44.947936, -73.081313);
+        XCTAssertTrue(MGLLocationCoordinate2DIsValid(coordinate));
+    }
+    {
+        CLLocationCoordinate2D coordinate = CLLocationCoordinate2DMake(19.333630, 203.555405);
+        XCTAssertTrue(MGLLocationCoordinate2DIsValid(coordinate));
+    }
+    {
+        CLLocationCoordinate2D coordinate = CLLocationCoordinate2DMake(23.254696, -240.795323);
+        XCTAssertTrue(MGLLocationCoordinate2DIsValid(coordinate));
+    }
+    {
+        CLLocationCoordinate2D coordinate = CLLocationCoordinate2DMake(91, 361);
+        XCTAssertFalse(MGLLocationCoordinate2DIsValid(coordinate));
+    }
+    {
+        CLLocationCoordinate2D coordinate = CLLocationCoordinate2DMake(-91, -361);
+        XCTAssertFalse(MGLLocationCoordinate2DIsValid(coordinate));
+    }
+}
+
 @end

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -15,6 +15,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed an issue where selecting an onscreen annotation could move the map unintentionally. ([#11731](https://github.com/mapbox/mapbox-gl-native/pull/11731))
 * Reduce per-frame render CPU time ([#11811](https://github.com/mapbox/mapbox-gl-native/issues/11811))
 * Fixed a crash when removing an `MGLOfflinePack`. ([#6092](https://github.com/mapbox/mapbox-gl-native/issues/6092))
+* Fixed an issue preventing `[MGLOverlay overlayBounds]` return an empty box for coordinates that straddle the antimeridian. ([#11783](https://github.com/mapbox/mapbox-gl-native/pull/11783))
 
 ## 4.0.0 - April 19, 2018
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -15,7 +15,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed an issue where selecting an onscreen annotation could move the map unintentionally. ([#11731](https://github.com/mapbox/mapbox-gl-native/pull/11731))
 * Reduce per-frame render CPU time ([#11811](https://github.com/mapbox/mapbox-gl-native/issues/11811))
 * Fixed a crash when removing an `MGLOfflinePack`. ([#6092](https://github.com/mapbox/mapbox-gl-native/issues/6092))
-* Fixed an issue preventing `[MGLOverlay overlayBounds]` return an empty box for coordinates that straddle the antimeridian. ([#11783](https://github.com/mapbox/mapbox-gl-native/pull/11783))
+* Fixed an issue where an `MGLOverlay` object straddling the antimeridian had an empty `MGLOverlay.overlayBounds` value. ([#11783](https://github.com/mapbox/mapbox-gl-native/pull/11783))
 
 ## 4.0.0 - April 19, 2018
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Fixed an issue where selecting an onscreen annotation could move the map unintentionally. ([#11731](https://github.com/mapbox/mapbox-gl-native/pull/11731))
 * Fixed a crash when removing an `MGLOfflinePack`. ([#6092](https://github.com/mapbox/mapbox-gl-native/issues/6092))
+* Fixed an issue preventing `[MGLOverlay overlayBounds]` return an empty box for coordinates that straddle the antimeridian. ([#11783](https://github.com/mapbox/mapbox-gl-native/pull/11783))
 
 ## 0.7.0 - April 19, 2018
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * Fixed an issue where selecting an onscreen annotation could move the map unintentionally. ([#11731](https://github.com/mapbox/mapbox-gl-native/pull/11731))
 * Fixed a crash when removing an `MGLOfflinePack`. ([#6092](https://github.com/mapbox/mapbox-gl-native/issues/6092))
-* Fixed an issue preventing `[MGLOverlay overlayBounds]` return an empty box for coordinates that straddle the antimeridian. ([#11783](https://github.com/mapbox/mapbox-gl-native/pull/11783))
+* Fixed an issue where an `MGLOverlay` object straddling the antimeridian had an empty `MGLOverlay.overlayBounds` value. ([#11783](https://github.com/mapbox/mapbox-gl-native/pull/11783))
 
 ## 0.7.0 - April 19, 2018
 


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/11377