### PR TITLE
Check if renderer is not destroyed before delivering snapshot

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
@@ -37,11 +37,11 @@ public abstract class MapRenderer implements MapRendererScheduler {
   }
 
   public void onPause() {
-    nativeOnPause();
+    // Implement if needed
   }
 
   public void onResume() {
-    nativeOnResume();
+    // Implement if needed
   }
 
   public void onStop() {
@@ -123,10 +123,6 @@ public abstract class MapRenderer implements MapRendererScheduler {
   private native void nativeOnSurfaceChanged(int width, int height);
 
   private native void nativeRender();
-
-  private native void nativeOnResume();
-
-  private native void nativeOnPause();
 
   private long frames;
   private long timeElapsed;

--- a/platform/android/src/map_renderer.hpp
+++ b/platform/android/src/map_renderer.hpp
@@ -98,10 +98,6 @@ private:
 
     void onSurfaceChanged(JNIEnv&, jint width, jint height);
 
-    void onResume(JNIEnv&);
-
-    void onPause(JNIEnv&);
-
 private:
     GenericUniqueWeakObject<MapRenderer> javaPeer;
 
@@ -124,7 +120,7 @@ private:
     std::mutex updateMutex;
 
     bool framebufferSizeChanged = false;
-    std::atomic<bool> paused {false};
+    std::atomic<bool> destroyed {false};
 
     std::unique_ptr<SnapshotCallback> snapshotCallback;
 };


### PR DESCRIPTION
When we are posting the snapshot callback back to the main thread, from the render thread, the Activity can be already destroyed and therefore the peer is destroyed as well. This PR adds a check if the renderer (therefore the `NativeMapView` peer) is not destroyed before delivering the callback.

Also, I removed changes from https://github.com/mapbox/mapbox-gl-native/pull/11358 as they seem obsolete now, not 100% sure as I wasn't able to reproduce the issue presented in the https://github.com/mapbox/mapbox-gl-native/pull/11358 after removing that workaround anyway. @tobrun would you mind rechecking that? Happy to bring them back if it's still an issue.