### PR TITLE
Unwrap LatLngBounds during JNI conversion

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLngBounds.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLngBounds.java
@@ -28,7 +28,7 @@ public class LatLngBounds implements Parcelable {
   /**
    * Construct a new LatLngBounds based on its corners, given in NESW
    * order.
-   *
+   * <p>
    * If eastern longitude is smaller than the western one, bounds will include antimeridian.
    * For example, if the NE point is (10, -170) and the SW point is (-10, 170), then bounds will span over 20 degrees
    * and cross the antimeridian.
@@ -75,7 +75,6 @@ public class LatLngBounds implements Parcelable {
       if (longCenter >= GeometryConstants.MAX_LONGITUDE) {
         longCenter = this.longitudeEast - halfSpan;
       }
-      return new LatLng(latCenter, longCenter);
     }
 
     return new LatLng(latCenter, longCenter);
@@ -188,7 +187,6 @@ public class LatLngBounds implements Parcelable {
     return GeometryConstants.LONGITUDE_SPAN - longSpan;
   }
 
-
   static double getLongitudeSpan(final double longEast, final double longWest) {
     double longSpan = Math.abs(longEast - longWest);
     if (longEast >= longWest) {
@@ -279,12 +277,11 @@ public class LatLngBounds implements Parcelable {
 
   /**
    * Constructs a LatLngBounds from doubles representing a LatLng pair.
-   *
+   * <p>
    * This values of latNorth and latSouth should be in the range of [-90, 90],
    * see {@link GeometryConstants#MIN_LATITUDE} and {@link GeometryConstants#MAX_LATITUDE},
    * otherwise IllegalArgumentException will be thrown.
    * latNorth should be greater or equal latSouth, otherwise  IllegalArgumentException will be thrown.
-   *
    * <p>
    * This method doesn't recalculate most east or most west boundaries.
    * Note that lonEast and lonWest will be wrapped to be in the range of [-180, 180],
@@ -335,14 +332,14 @@ public class LatLngBounds implements Parcelable {
 
   /**
    * Constructs a LatLngBounds from a Tile identifier.
-   *
+   * <p>
    * Returned bounds will have latitude in the range of Mercator projection.
-   * @see GeometryConstants#MIN_MERCATOR_LATITUDE
-   * @see GeometryConstants#MAX_MERCATOR_LATITUDE
    *
    * @param z Tile zoom level.
    * @param x Tile X coordinate.
    * @param y Tile Y coordinate.
+   * @see GeometryConstants#MIN_MERCATOR_LATITUDE
+   * @see GeometryConstants#MAX_MERCATOR_LATITUDE
    */
   public static LatLngBounds from(int z, int x, int y) {
     return new LatLngBounds(lat_(z, y), lon_(z, x + 1), lat_(z, y + 1), lon_(z, x));

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1550,7 +1550,7 @@ public final class MapboxMap {
    * @param padding      the padding to apply to the bounds
    * @return the camera position that fits the bounds and padding
    */
-  public CameraPosition getCameraForLatLngBounds(@Nullable LatLngBounds latLngBounds, int[] padding) {
+  public CameraPosition getCameraForLatLngBounds(@NonNull LatLngBounds latLngBounds, int[] padding) {
     // get padded camera position from LatLngBounds
     return nativeMapView.getCameraForLatLngBounds(latLngBounds, padding);
   }

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/geometry/LatLngBoundsTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/geometry/LatLngBoundsTest.java
@@ -524,7 +524,6 @@ public class LatLngBoundsTest {
     LatLngBounds.from(0, Double.POSITIVE_INFINITY, -20, -20);
   }
 
-
   @Test
   public void testConstructorChecksSouthLatitudeNaN() {
     exception.expect(IllegalArgumentException.class);
@@ -543,7 +542,7 @@ public class LatLngBoundsTest {
   public void testConstructorChecksSouthLatitudeGreaterThan90() {
     exception.expect(IllegalArgumentException.class);
     exception.expectMessage("latitude must be between -90 and 90");
-    LatLngBounds.from(20, 20,95, 0);
+    LatLngBounds.from(20, 20, 95, 0);
   }
 
   @Test

--- a/platform/android/src/geometry/lat_lng_bounds.cpp
+++ b/platform/android/src/geometry/lat_lng_bounds.cpp
@@ -9,14 +9,17 @@ jni::Object<LatLngBounds> LatLngBounds::New(jni::JNIEnv& env, mbgl::LatLngBounds
 }
 
 mbgl::LatLngBounds LatLngBounds::getLatLngBounds(jni::JNIEnv& env, jni::Object<LatLngBounds> bounds) {
-    static auto swLat = LatLngBounds::javaClass.GetField<jni::jdouble>(env, "latitudeSouth");
-    static auto swLon = LatLngBounds::javaClass.GetField<jni::jdouble>(env, "longitudeWest");
-    static auto neLat = LatLngBounds::javaClass.GetField<jni::jdouble>(env, "latitudeNorth");
-    static auto neLon = LatLngBounds::javaClass.GetField<jni::jdouble>(env, "longitudeEast");
-    return mbgl::LatLngBounds::hull(
-        { bounds.Get(env, swLat), bounds.Get(env, swLon) },
-        { bounds.Get(env, neLat), bounds.Get(env, neLon) }
-    );
+    static auto swLatField = LatLngBounds::javaClass.GetField<jni::jdouble>(env, "latitudeSouth");
+    static auto swLonField = LatLngBounds::javaClass.GetField<jni::jdouble>(env, "longitudeWest");
+    static auto neLatField = LatLngBounds::javaClass.GetField<jni::jdouble>(env, "latitudeNorth");
+    static auto neLonField = LatLngBounds::javaClass.GetField<jni::jdouble>(env, "longitudeEast");
+
+    mbgl::LatLng sw = { bounds.Get(env, swLatField), bounds.Get(env, swLonField) };
+    mbgl::LatLng ne = { bounds.Get(env, neLatField), bounds.Get(env, neLonField) };
+
+    sw.unwrapForShortestPath(ne);
+
+    return mbgl::LatLngBounds::hull(sw, ne);
 }
 
 void LatLngBounds::registerNative(jni::JNIEnv& env) {


### PR DESCRIPTION
This PR reverts changes from https://github.com/mapbox/mapbox-gl-native/pull/11759 and unwraps the bounds during the JNI conversion instead.