### PR TITLE
[core] Don't copy TileLayerIndexes on every frame.

### DIFF
--- a/src/mbgl/text/cross_tile_symbol_index.cpp
+++ b/src/mbgl/text/cross_tile_symbol_index.cpp
@@ -62,7 +62,7 @@ CrossTileSymbolLayerIndex::CrossTileSymbolLayerIndex() {
 }
 
 bool CrossTileSymbolLayerIndex::addBucket(const OverscaledTileID& tileID, SymbolBucket& bucket, uint32_t& maxCrossTileID) {
-    auto thisZoomIndexes = indexes[tileID.overscaledZ];
+    const auto& thisZoomIndexes = indexes[tileID.overscaledZ];
     auto previousIndex = thisZoomIndexes.find(tileID);
     if (previousIndex != thisZoomIndexes.end()) {
         if (previousIndex->second.bucketInstanceId == bucket.bucketInstanceId) {


### PR DESCRIPTION
Fixes issue #11811 (too much CPU time spent in CrossTileSymbolIndex).

I saw some discussion of discouraging `auto` if the type isn't present on the same line, so in this case the line would be: `const std::map<OverscaledTileID,TileLayerIndex>&`. I could go either way on that idea, but a quick sampling of the 1397 occurrences of `auto (.*) =` in the ios project show that we'd have to add a lot of type info to start following that guideline.

I think the best opportunity for catching something like this is whole SDK automated performance testing (@tobrun has an Android-specific proposal at https://github.com/mapbox/mapbox-gl-native/issues/10917)

/cc @ansis @jfirebaugh @anandthakker 

