### PR TITLE
Use center property (instead of frame) when repositioning annotation views

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -8,11 +8,16 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Deprecated `+[NSExpression featurePropertiesVariableExpression]` use `+[NSExpression featureAttributesVariableExpression]` instead. ([#11748](https://github.com/mapbox/mapbox-gl-native/pull/11748))
 
+
+### Annotations
+
+* Fixed an issue where selecting an onscreen annotation could move the map unintentionally. ([#11731](https://github.com/mapbox/mapbox-gl-native/pull/11731))
+* Fixed an issue where annotation views could become distorted if `rotatesToMatchCamera` is `YES`. ([#11817](https://github.com/mapbox/mapbox-gl-native/pull/11817))
+
 ### Other changes
 
 * Added a Korean localization. ([#11792](https://github.com/mapbox/mapbox-gl-native/pull/11792))
 * Fixed an issue where `-[MGLMapView metersPerPixelAtLatitude:]` was removed, but not marked as unavailable. ([#11765](https://github.com/mapbox/mapbox-gl-native/pull/11765))
-* Fixed an issue where selecting an onscreen annotation could move the map unintentionally. ([#11731](https://github.com/mapbox/mapbox-gl-native/pull/11731))
 * Reduce per-frame render CPU time ([#11811](https://github.com/mapbox/mapbox-gl-native/issues/11811))
 * Fixed a crash when removing an `MGLOfflinePack`. ([#6092](https://github.com/mapbox/mapbox-gl-native/issues/6092))
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -5725,10 +5725,12 @@ public:
                 if (annotationView.layer.animationKeys.count > 0) {
                     continue;
                 }
+
                 // Move the annotation view far out of view to the left
-                CGRect adjustedFrame = annotationView.frame;
-                adjustedFrame.origin.x = -CGRectGetWidth(self.frame) * 10.0;
-                annotationView.frame = adjustedFrame;
+                CGPoint adjustedCenter = annotationView.center;
+                adjustedCenter.x = -CGRectGetWidth(self.frame) * 10.0;
+                annotationView.center = adjustedCenter;
+
                 [self enqueueAnnotationViewForAnnotationContext:annotationContext];
             }
         }


### PR DESCRIPTION
This addresses https://github.com/mapbox/mapbox-gl-native/issues/11756.
