### PR TITLE
[ios, macos] Avoid implicit capture of MBGLOfflineRegionObserver this pointer

### DIFF
--- a/platform/darwin/src/MGLOfflinePack.mm
+++ b/platform/darwin/src/MGLOfflinePack.mm
@@ -227,19 +227,22 @@ NSError *MGLErrorFromResponseError(mbgl::Response::Error error) {
 @end
 
 void MBGLOfflineRegionObserver::statusChanged(mbgl::OfflineRegionStatus status) {
+    __weak MBGLOfflinePack *_pack = pack;
     dispatch_async(dispatch_get_main_queue(), ^{
-        [pack offlineRegionStatusDidChange:status];
+        [_pack offlineRegionStatusDidChange:status];
     });
 }
 
 void MBGLOfflineRegionObserver::responseError(mbgl::Response::Error error) {
+    __weak MBGLOfflinePack *_pack = pack;
     dispatch_async(dispatch_get_main_queue(), ^{
-        [pack didReceiveError:MGLErrorFromResponseError(error)];
+        [_pack didReceiveError:MGLErrorFromResponseError(error)];
     });
 }
 
 void MBGLOfflineRegionObserver::mapboxTileCountLimitExceeded(uint64_t limit) {
+    __weak MBGLOfflinePack *_pack = pack;
     dispatch_async(dispatch_get_main_queue(), ^{
-        [pack didReceiveMaximumAllowedMapboxTiles:limit];
+        [_pack didReceiveMaximumAllowedMapboxTiles:limit];
     });
 }

--- a/platform/darwin/src/MGLOfflinePack.mm
+++ b/platform/darwin/src/MGLOfflinePack.mm
@@ -227,22 +227,22 @@ NSError *MGLErrorFromResponseError(mbgl::Response::Error error) {
 @end
 
 void MBGLOfflineRegionObserver::statusChanged(mbgl::OfflineRegionStatus status) {
-    __weak MBGLOfflinePack *_pack = pack;
+    __weak MGLOfflinePack *weakPack = pack;
     dispatch_async(dispatch_get_main_queue(), ^{
-        [_pack offlineRegionStatusDidChange:status];
+        [weakPack offlineRegionStatusDidChange:status];
     });
 }
 
 void MBGLOfflineRegionObserver::responseError(mbgl::Response::Error error) {
-    __weak MBGLOfflinePack *_pack = pack;
+    __weak MGLOfflinePack *weakPack = pack;
     dispatch_async(dispatch_get_main_queue(), ^{
-        [_pack didReceiveError:MGLErrorFromResponseError(error)];
+        [weakPack didReceiveError:MGLErrorFromResponseError(error)];
     });
 }
 
 void MBGLOfflineRegionObserver::mapboxTileCountLimitExceeded(uint64_t limit) {
-    __weak MBGLOfflinePack *_pack = pack;
+    __weak MGLOfflinePack *weakPack = pack;
     dispatch_async(dispatch_get_main_queue(), ^{
-        [_pack didReceiveMaximumAllowedMapboxTiles:limit];
+        [weakPack didReceiveMaximumAllowedMapboxTiles:limit];
     });
 }


### PR DESCRIPTION
`MBGLOfflineRegionObserver` is owned by the offline database thread, and might be destroyed by the time the `dispatch_async` completes. Instead of implicitly capturing `this`, capture a copy of the `MBGLOfflinePack` weak pointer.

Speculatively fixes #6092.