### PR TITLE
Fix MGLMapSnapshotter concurrency bugs (issue #11827).

### DIFF
--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -126,7 +126,7 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
     _snapshotCallback = std::make_unique<mbgl::Actor<mbgl::MapSnapshotter::Callback>>(*mbgl::Scheduler::GetCurrent(), [=](std::exception_ptr mbglError, mbgl::PremultipliedImage image, mbgl::MapSnapshotter::Attributions attributions, mbgl::MapSnapshotter::PointForFn pointForFn) {
         __typeof__(self) strongSelf = weakSelf;
         // If self had died, _snapshotCallback would have been destroyed and this block would not be executed
-        assert(strongSelf);
+        NSCAssert(strongSelf, @"Snapshot callback executed after being destroyed.");
 
         strongSelf.loading = false;
 

--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -108,6 +108,11 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
 
 - (void)startWithQueue:(dispatch_queue_t)queue completionHandler:(MGLMapSnapshotCompletionHandler)completion
 {
+    if (!mbgl::Scheduler::GetCurrent()) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"startWithQueue:completionHandler: must be called from a thread with an active run loop."];
+    }
+
     if ([self isLoading]) {
         [NSException raise:NSInternalInconsistencyException
                     format:@"Already started this snapshotter."];

--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -85,12 +85,9 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
 @end
 
 @implementation MGLMapSnapshotter {
-    
     std::shared_ptr<mbgl::ThreadPool> _mbglThreadPool;
     std::unique_ptr<mbgl::MapSnapshotter> _mbglMapSnapshotter;
     std::unique_ptr<mbgl::Actor<mbgl::MapSnapshotter::Callback>> _snapshotCallback;
-    NSArray<MGLAttributionInfo *> *_attributionInfo;
-    
 }
 
 - (instancetype)initWithOptions:(MGLMapSnapshotOptions *)options
@@ -119,8 +116,13 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
     self.loading = true;
     
     __weak __typeof__(self) weakSelf = self;
+    // mbgl::Scheduler::GetCurrent() scheduler means "run callback on current (ie UI/main) thread"
+    // capture weakSelf to avoid retain cycle if callback is never called (ie snapshot cancelled)
     _snapshotCallback = std::make_unique<mbgl::Actor<mbgl::MapSnapshotter::Callback>>(*mbgl::Scheduler::GetCurrent(), [=](std::exception_ptr mbglError, mbgl::PremultipliedImage image, mbgl::MapSnapshotter::Attributions attributions, mbgl::MapSnapshotter::PointForFn pointForFn) {
         __typeof__(self) strongSelf = weakSelf;
+        // If self had died, _snapshotCallback would have been destroyed and this block would not be executed
+        assert(strongSelf);
+
         strongSelf.loading = false;
 
         if (mbglError) {
@@ -142,20 +144,159 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
 #endif
             [strongSelf drawAttributedSnapshot:attributions snapshotImage:mglImage pointForFn:pointForFn queue:queue completionHandler:completion];
         }
-        _snapshotCallback = NULL;
+        strongSelf->_snapshotCallback = NULL;
     });
 
-    dispatch_async(queue, ^{
-        __typeof__(self) strongSelf = weakSelf;
-        if (!strongSelf) {
-            return;
+    // Launches snapshot on background Thread owned by mbglMapSnapshotter
+    // _snapshotCallback->self() is an ActorRef: if the callback is destroyed, further messages
+    // to the callback are just no-ops
+    _mbglMapSnapshotter->snapshot(_snapshotCallback->self());
+}
+
++ (void)drawAttributedSnapshotWorker:(mbgl::MapSnapshotter::Attributions)attributions snapshotImage:(MGLImage *)mglImage pointForFn:(mbgl::MapSnapshotter::PointForFn)pointForFn queue:(dispatch_queue_t)queue scale:(CGFloat)scale size:(CGSize)size completionHandler:(MGLMapSnapshotCompletionHandler)completion {
+    
+    NSArray<MGLAttributionInfo *>* attributionInfo = [MGLMapSnapshotter generateAttributionInfos:attributions];
+    
+#if TARGET_OS_IPHONE
+    MGLAttributionInfoStyle attributionInfoStyle = MGLAttributionInfoStyleLong;
+    for (NSUInteger styleValue = MGLAttributionInfoStyleLong; styleValue >= MGLAttributionInfoStyleShort; styleValue--) {
+        attributionInfoStyle = (MGLAttributionInfoStyle)styleValue;
+        CGSize attributionSize = [MGLMapSnapshotter attributionSizeWithLogoStyle:attributionInfoStyle sourceAttributionStyle:attributionInfoStyle attributionInfo:attributionInfo];
+        if (attributionSize.width <= mglImage.size.width) {
+            break;
         }
-        strongSelf->_mbglMapSnapshotter->snapshot(strongSelf->_snapshotCallback->self());
+    }
+    
+    UIImage *logoImage = [MGLMapSnapshotter logoImageWithStyle:attributionInfoStyle];
+    CGSize attributionBackgroundSize = [MGLMapSnapshotter attributionTextSizeWithStyle:attributionInfoStyle attributionInfo:attributionInfo];
+    
+    CGRect logoImageRect = CGRectMake(MGLLogoImagePosition.x, mglImage.size.height - (MGLLogoImagePosition.y + logoImage.size.height), logoImage.size.width, logoImage.size.height);
+    CGPoint attributionOrigin = CGPointMake(mglImage.size.width - 10 - attributionBackgroundSize.width,
+                                            logoImageRect.origin.y + (logoImageRect.size.height / 2) - (attributionBackgroundSize.height / 2) + 1);
+    if (!logoImage) {
+        CGSize defaultLogoSize = [MGLMapSnapshotter mapboxLongStyleLogo].size;
+        logoImageRect = CGRectMake(0, mglImage.size.height - (MGLLogoImagePosition.y + defaultLogoSize.height), 0, defaultLogoSize.height);
+        attributionOrigin = CGPointMake(10, logoImageRect.origin.y + (logoImageRect.size.height / 2) - (attributionBackgroundSize.height / 2) + 1);
+    }
+    
+    CGRect attributionBackgroundFrame = CGRectMake(attributionOrigin.x,
+                                                   attributionOrigin.y,
+                                                   attributionBackgroundSize.width,
+                                                   attributionBackgroundSize.height);
+    CGPoint attributionTextPosition = CGPointMake(attributionBackgroundFrame.origin.x + 10,
+                                                  attributionBackgroundFrame.origin.y - 1);
+    
+    CGRect cropRect = CGRectMake(attributionBackgroundFrame.origin.x * mglImage.scale,
+                                 attributionBackgroundFrame.origin.y * mglImage.scale,
+                                 attributionBackgroundSize.width * mglImage.scale,
+                                 attributionBackgroundSize.height * mglImage.scale);
+    
+    
+    UIGraphicsBeginImageContextWithOptions(mglImage.size, NO, scale);
+    
+    [mglImage drawInRect:CGRectMake(0, 0, mglImage.size.width, mglImage.size.height)];
+    
+    [logoImage drawInRect:logoImageRect];
+    
+    UIImage *currentImage = UIGraphicsGetImageFromCurrentImageContext();
+    CGImageRef attributionImageRef = CGImageCreateWithImageInRect([currentImage CGImage], cropRect);
+    UIImage *attributionImage = [UIImage imageWithCGImage:attributionImageRef];
+    CGImageRelease(attributionImageRef);
+    
+    CIImage *ciAttributionImage = [[CIImage alloc] initWithCGImage:attributionImage.CGImage];
+    
+    UIImage *blurredAttributionBackground = [MGLMapSnapshotter blurredAttributionBackground:ciAttributionImage];
+    
+    [blurredAttributionBackground drawInRect:attributionBackgroundFrame];
+    
+    [MGLMapSnapshotter drawAttributionTextWithStyle:attributionInfoStyle origin:attributionTextPosition attributionInfo:attributionInfo];
+    
+    UIImage *compositedImage = UIGraphicsGetImageFromCurrentImageContext();
+    
+    UIGraphicsEndImageContext();
+#else
+    NSSize targetSize = NSMakeSize(size.width, size.height);
+    NSRect targetFrame = NSMakeRect(0, 0, targetSize.width, targetSize.height);
+    
+    MGLAttributionInfoStyle attributionInfoStyle = MGLAttributionInfoStyleLong;
+    for (NSUInteger styleValue = MGLAttributionInfoStyleLong; styleValue >= MGLAttributionInfoStyleShort; styleValue--) {
+        attributionInfoStyle = (MGLAttributionInfoStyle)styleValue;
+        CGSize attributionSize = [MGLMapSnapshotter attributionSizeWithLogoStyle:attributionInfoStyle sourceAttributionStyle:attributionInfoStyle attributionInfo:attributionInfo];
+        if (attributionSize.width <= mglImage.size.width) {
+            break;
+        }
+    }
+    
+    NSImage *logoImage = [MGLMapSnapshotter logoImageWithStyle:attributionInfoStyle];
+    CGSize attributionBackgroundSize = [MGLMapSnapshotter attributionTextSizeWithStyle:attributionInfoStyle attributionInfo:attributionInfo];
+    NSImage *sourceImage = mglImage;
+    
+    CGRect logoImageRect = CGRectMake(MGLLogoImagePosition.x, MGLLogoImagePosition.y, logoImage.size.width, logoImage.size.height);
+    CGPoint attributionOrigin = CGPointMake(targetFrame.size.width - 10 - attributionBackgroundSize.width,
+                                            MGLLogoImagePosition.y + 1);
+    if (!logoImage) {
+        CGSize defaultLogoSize = [MGLMapSnapshotter mapboxLongStyleLogo].size;
+        logoImageRect = CGRectMake(0, MGLLogoImagePosition.y, 0, defaultLogoSize.height);
+        attributionOrigin = CGPointMake(10, attributionOrigin.y);
+    }
+    
+    CGRect attributionBackgroundFrame = CGRectMake(attributionOrigin.x,
+                                                   attributionOrigin.y,
+                                                   attributionBackgroundSize.width,
+                                                   attributionBackgroundSize.height);
+    CGPoint attributionTextPosition = CGPointMake(attributionBackgroundFrame.origin.x + 10,
+                                                  logoImageRect.origin.y + (logoImageRect.size.height / 2) - (attributionBackgroundSize.height / 2));
+    
+    
+    NSImage *compositedImage = nil;
+    NSImageRep *sourceImageRep = [sourceImage bestRepresentationForRect:targetFrame
+                                                                context:nil
+                                                                  hints:nil];
+    compositedImage = [[NSImage alloc] initWithSize:targetSize];
+    
+    [compositedImage lockFocus];
+    
+    [sourceImageRep drawInRect: targetFrame];
+    
+    if (logoImage) {
+        [logoImage drawInRect:logoImageRect];
+    }
+    
+    NSBitmapImageRep *attributionBackground = [[NSBitmapImageRep alloc] initWithFocusedViewRect:attributionBackgroundFrame];
+    
+    CIImage *attributionBackgroundImage = [[CIImage alloc] initWithCGImage:[attributionBackground CGImage]];
+    
+    NSImage *blurredAttributionBackground = [MGLMapSnapshotter blurredAttributionBackground:attributionBackgroundImage];
+    
+    [blurredAttributionBackground drawInRect:attributionBackgroundFrame];
+    
+    [MGLMapSnapshotter drawAttributionTextWithStyle:attributionInfoStyle origin:attributionTextPosition attributionInfo:attributionInfo];
+    
+    [compositedImage unlockFocus];
+    
+#endif
+    // Dispatch result to origin queue
+    dispatch_async(queue, ^{
+        MGLMapSnapshot* snapshot = [[MGLMapSnapshot alloc] initWithImage:compositedImage scale:scale pointForFn:pointForFn];
+        completion(snapshot, nil);
     });
 }
 
-- (MGLImage *)drawAttributedSnapshot:(mbgl::MapSnapshotter::Attributions)attributions snapshotImage:(MGLImage *)mglImage pointForFn:(mbgl::MapSnapshotter::PointForFn)pointForFn queue:(dispatch_queue_t)queue completionHandler:(MGLMapSnapshotCompletionHandler)completion {
+- (void)drawAttributedSnapshot:(mbgl::MapSnapshotter::Attributions)attributions snapshotImage:(MGLImage *)mglImage pointForFn:(mbgl::MapSnapshotter::PointForFn)pointForFn queue:(dispatch_queue_t)queue completionHandler:(MGLMapSnapshotCompletionHandler)completion {
     
+    // Process image watermark in a work queue
+    dispatch_queue_t workQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+    // Capture scale and size by value to avoid accessing self from another thread
+    CGFloat scale = self.options.scale;
+    CGSize size = self.options.size;
+    // pointForFn is a copyable std::function that captures state by value: see MapSnapshotter::Impl::snapshot
+    dispatch_async(workQueue, ^{
+        // Call a class method to ensure we're not accidentally capturing self
+        [MGLMapSnapshotter drawAttributedSnapshotWorker:attributions snapshotImage:mglImage pointForFn:pointForFn queue:queue scale:scale size:size completionHandler:completion];
+    });
+}
+
++ (NSArray<MGLAttributionInfo *>*) generateAttributionInfos:(mbgl::MapSnapshotter::Attributions)attributions {
     NSMutableArray *infos = [NSMutableArray array];
     
 #if TARGET_OS_IPHONE
@@ -172,144 +313,12 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
                                                                          linkColor:attributeFontColor];
         [infos growArrayByAddingAttributionInfosFromArray:tileSetInfos];
     }
-    
-    _attributionInfo = infos;
-    
-    // Process image watermark in a work queue
-    dispatch_queue_t workQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-    dispatch_async(workQueue, ^{
-#if TARGET_OS_IPHONE
-        MGLAttributionInfoStyle attributionInfoStyle = MGLAttributionInfoStyleLong;
-        for (NSUInteger styleValue = MGLAttributionInfoStyleLong; styleValue >= MGLAttributionInfoStyleShort; styleValue--) {
-            attributionInfoStyle = (MGLAttributionInfoStyle)styleValue;
-            CGSize attributionSize = [self attributionSizeWithLogoStyle:attributionInfoStyle sourceAttributionStyle:attributionInfoStyle];
-            if (attributionSize.width <= mglImage.size.width) {
-                break;
-            }
-        }
-        
-        UIImage *logoImage = [self logoImageWithStyle:attributionInfoStyle];
-        CGSize attributionBackgroundSize = [self attributionTextSizeWithStyle:attributionInfoStyle];
-        
-        CGRect logoImageRect = CGRectMake(MGLLogoImagePosition.x, mglImage.size.height - (MGLLogoImagePosition.y + logoImage.size.height), logoImage.size.width, logoImage.size.height);
-        CGPoint attributionOrigin = CGPointMake(mglImage.size.width - 10 - attributionBackgroundSize.width,
-                                                logoImageRect.origin.y + (logoImageRect.size.height / 2) - (attributionBackgroundSize.height / 2) + 1);
-        if (!logoImage) {
-            CGSize defaultLogoSize = [self mapboxLongStyleLogo].size;
-            logoImageRect = CGRectMake(0, mglImage.size.height - (MGLLogoImagePosition.y + defaultLogoSize.height), 0, defaultLogoSize.height);
-            attributionOrigin = CGPointMake(10, logoImageRect.origin.y + (logoImageRect.size.height / 2) - (attributionBackgroundSize.height / 2) + 1);
-        }
-        
-        CGRect attributionBackgroundFrame = CGRectMake(attributionOrigin.x,
-                                                       attributionOrigin.y,
-                                                       attributionBackgroundSize.width,
-                                                       attributionBackgroundSize.height);
-        CGPoint attributionTextPosition = CGPointMake(attributionBackgroundFrame.origin.x + 10,
-                                                      attributionBackgroundFrame.origin.y - 1);
-        
-        CGRect cropRect = CGRectMake(attributionBackgroundFrame.origin.x * mglImage.scale,
-                                     attributionBackgroundFrame.origin.y * mglImage.scale,
-                                     attributionBackgroundSize.width * mglImage.scale,
-                                     attributionBackgroundSize.height * mglImage.scale);
-        
-        
-        UIGraphicsBeginImageContextWithOptions(mglImage.size, NO, self.options.scale);
-        
-        [mglImage drawInRect:CGRectMake(0, 0, mglImage.size.width, mglImage.size.height)];
-        
-        [logoImage drawInRect:logoImageRect];
-
-        UIImage *currentImage = UIGraphicsGetImageFromCurrentImageContext();
-        CGImageRef attributionImageRef = CGImageCreateWithImageInRect([currentImage CGImage], cropRect);
-        UIImage *attributionImage = [UIImage imageWithCGImage:attributionImageRef];
-        CGImageRelease(attributionImageRef);
-
-        CIImage *ciAttributionImage = [[CIImage alloc] initWithCGImage:attributionImage.CGImage];
-
-        UIImage *blurredAttributionBackground = [self blurredAttributionBackground:ciAttributionImage];
-
-        [blurredAttributionBackground drawInRect:attributionBackgroundFrame];
-
-        [self drawAttributionTextWithStyle:attributionInfoStyle origin:attributionTextPosition];
-        
-        UIImage *compositedImage = UIGraphicsGetImageFromCurrentImageContext();
-        
-        UIGraphicsEndImageContext();
-#else
-        NSSize targetSize = NSMakeSize(self.options.size.width, self.options.size.height);
-        NSRect targetFrame = NSMakeRect(0, 0, targetSize.width, targetSize.height);
-        
-        MGLAttributionInfoStyle attributionInfoStyle = MGLAttributionInfoStyleLong;
-        for (NSUInteger styleValue = MGLAttributionInfoStyleLong; styleValue >= MGLAttributionInfoStyleShort; styleValue--) {
-            attributionInfoStyle = (MGLAttributionInfoStyle)styleValue;
-            CGSize attributionSize = [self attributionSizeWithLogoStyle:attributionInfoStyle sourceAttributionStyle:attributionInfoStyle];
-            if (attributionSize.width <= mglImage.size.width) {
-                break;
-            }
-        }
-        
-        NSImage *logoImage = [self logoImageWithStyle:attributionInfoStyle];
-        CGSize attributionBackgroundSize = [self attributionTextSizeWithStyle:attributionInfoStyle];
-        NSImage *sourceImage = mglImage;
-        
-        CGRect logoImageRect = CGRectMake(MGLLogoImagePosition.x, MGLLogoImagePosition.y, logoImage.size.width, logoImage.size.height);
-        CGPoint attributionOrigin = CGPointMake(targetFrame.size.width - 10 - attributionBackgroundSize.width,
-                                                MGLLogoImagePosition.y + 1);
-        if (!logoImage) {
-            CGSize defaultLogoSize = [self mapboxLongStyleLogo].size;
-            logoImageRect = CGRectMake(0, MGLLogoImagePosition.y, 0, defaultLogoSize.height);
-            attributionOrigin = CGPointMake(10, attributionOrigin.y);
-        }
-        
-        CGRect attributionBackgroundFrame = CGRectMake(attributionOrigin.x,
-                                                       attributionOrigin.y,
-                                                       attributionBackgroundSize.width,
-                                                       attributionBackgroundSize.height);
-        CGPoint attributionTextPosition = CGPointMake(attributionBackgroundFrame.origin.x + 10,
-                                                      logoImageRect.origin.y + (logoImageRect.size.height / 2) - (attributionBackgroundSize.height / 2));
-        
-        
-        NSImage *compositedImage = nil;
-        NSImageRep *sourceImageRep = [sourceImage bestRepresentationForRect:targetFrame
-                                                                    context:nil
-                                                                      hints:nil];
-        compositedImage = [[NSImage alloc] initWithSize:targetSize];
-        
-        [compositedImage lockFocus];
-        
-        [sourceImageRep drawInRect: targetFrame];
-        
-        if (logoImage) {
-            [logoImage drawInRect:logoImageRect];
-        }
-        
-        NSBitmapImageRep *attributionBackground = [[NSBitmapImageRep alloc] initWithFocusedViewRect:attributionBackgroundFrame];
-        
-        CIImage *attributionBackgroundImage = [[CIImage alloc] initWithCGImage:[attributionBackground CGImage]];
-        
-        NSImage *blurredAttributionBackground = [self blurredAttributionBackground:attributionBackgroundImage];
-        
-        [blurredAttributionBackground drawInRect:attributionBackgroundFrame];
-        
-        [self drawAttributionTextWithStyle:attributionInfoStyle origin:attributionTextPosition];
-        
-        [compositedImage unlockFocus];
-        
-        
-#endif
-        
-        // Dispatch result to origin queue
-        dispatch_async(queue, ^{
-            MGLMapSnapshot* snapshot = [[MGLMapSnapshot alloc] initWithImage:compositedImage scale:self.options.scale pointForFn:pointForFn];
-            completion(snapshot, nil);
-        });
-    });
-    return nil;
+    return infos;
 }
 
-- (void)drawAttributionTextWithStyle:(MGLAttributionInfoStyle)attributionInfoStyle origin:(CGPoint)origin
++ (void)drawAttributionTextWithStyle:(MGLAttributionInfoStyle)attributionInfoStyle origin:(CGPoint)origin attributionInfo:(NSArray<MGLAttributionInfo *>*)attributionInfo
 {
-    for (MGLAttributionInfo *info in _attributionInfo) {
+    for (MGLAttributionInfo *info in attributionInfo) {
         if (info.isFeedbackLink) {
             continue;
         }
@@ -320,7 +329,7 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
     }
 }
 
-- (MGLImage *)blurredAttributionBackground:(CIImage *)backgroundImage
++ (MGLImage *)blurredAttributionBackground:(CIImage *)backgroundImage
 {
     CGAffineTransform transform = CGAffineTransformIdentity;
     CIFilter *clamp = [CIFilter filterWithName:@"CIAffineClamp"];
@@ -351,12 +360,12 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
     return image;
 }
 
-- (MGLImage *)logoImageWithStyle:(MGLAttributionInfoStyle)style
++ (MGLImage *)logoImageWithStyle:(MGLAttributionInfoStyle)style
 {
     MGLImage *logoImage;
     switch (style) {
         case MGLAttributionInfoStyleLong:
-            logoImage = [self mapboxLongStyleLogo];
+            logoImage = [MGLMapSnapshotter mapboxLongStyleLogo];
             break;
         case MGLAttributionInfoStyleMedium:
 #if TARGET_OS_IPHONE
@@ -372,7 +381,7 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
     return logoImage;
 }
 
-- (MGLImage *)mapboxLongStyleLogo
++ (MGLImage *)mapboxLongStyleLogo
 {
     MGLImage *logoImage;
 #if TARGET_OS_IPHONE
@@ -383,11 +392,11 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
     return logoImage;
 }
 
-- (CGSize)attributionSizeWithLogoStyle:(MGLAttributionInfoStyle)logoStyle sourceAttributionStyle:(MGLAttributionInfoStyle)attributionStyle
++ (CGSize)attributionSizeWithLogoStyle:(MGLAttributionInfoStyle)logoStyle sourceAttributionStyle:(MGLAttributionInfoStyle)attributionStyle attributionInfo:(NSArray<MGLAttributionInfo *>*)attributionInfo
 {
     MGLImage *logoImage = [self logoImageWithStyle:logoStyle];
     
-    CGSize attributionBackgroundSize = [self attributionTextSizeWithStyle:attributionStyle];
+    CGSize attributionBackgroundSize = [MGLMapSnapshotter attributionTextSizeWithStyle:attributionStyle attributionInfo:attributionInfo];
     
     CGSize attributionSize = CGSizeZero;
     
@@ -400,10 +409,10 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
     return attributionSize;
 }
 
-- (CGSize)attributionTextSizeWithStyle:(MGLAttributionInfoStyle)attributionStyle
++ (CGSize)attributionTextSizeWithStyle:(MGLAttributionInfoStyle)attributionStyle attributionInfo:(NSArray<MGLAttributionInfo *>*)attributionInfo
 {
     CGSize attributionBackgroundSize = CGSizeMake(10, 0);
-    for (MGLAttributionInfo *info in _attributionInfo) {
+    for (MGLAttributionInfo *info in attributionInfo) {
         if (info.isFeedbackLink) {
             continue;
         }

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -20,6 +20,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed an issue preventing nested key path expressions get parsed accordingly to the spec. ([#11959](https://github.com/mapbox/mapbox-gl-native/pull/11959))
 * Added custom `-hitTest:withEvent:` to `MGLSMCalloutView` to avoid registering taps in transparent areas of the standard annotation callout. ([#11939](https://github.com/mapbox/mapbox-gl-native/pull/11939))
 * Improved performance and memory impact of `MGLScaleBar`. ([#11921](https://github.com/mapbox/mapbox-gl-native/pull/11921))
+* Fixed race conditions that could cause crashes when re-using `MGLMapSnapshotter` or using multiple snapshotters at the same time. ([#11831](https://github.com/mapbox/mapbox-gl-native/pull/11831))
 
 ## 4.0.2 - May 29, 2018
 

--- a/platform/ios/Integration Tests/MGLMapViewIntegrationTest.h
+++ b/platform/ios/Integration Tests/MGLMapViewIntegrationTest.h
@@ -10,6 +10,12 @@
 
 #define MGLTestAssertEqualWithAccuracy(myself, expression1, expression2, accuracy, ...) \
     _XCTPrimitiveAssertEqualWithAccuracy(myself, expression1, @#expression1, expression2, @#expression2, accuracy, @#accuracy, __VA_ARGS__)
+#define MGLTestAssertNil(myself, expression, ...) \
+    _XCTPrimitiveAssertNil(myself, expression, @#expression, __VA_ARGS__)
+
+#define MGLTestAssertNotNil(myself, expression, ...) \
+    _XCTPrimitiveAssertNotNil(myself, expression, @#expression, __VA_ARGS__)
+
 
 @interface MGLMapViewIntegrationTest : XCTestCase <MGLMapViewDelegate>
 @property (nonatomic) MGLMapView *mapView;

--- a/platform/ios/Integration Tests/Snapshotter Tests/MGLMapSnapshotterTest.m
+++ b/platform/ios/Integration Tests/Snapshotter Tests/MGLMapSnapshotterTest.m
@@ -1,0 +1,239 @@
+#import "MGLMapViewIntegrationTest.h"
+
+@interface MGLMapSnapshotterTest : MGLMapViewIntegrationTest
+@end
+
+// Convenience func to create snapshotter
+MGLMapSnapshotter* snapshotterWithCoordinates(CLLocationCoordinate2D coordinates, CGSize size) {
+    // Create snapshot options
+    MGLMapCamera* mapCamera    = [[MGLMapCamera alloc] init];
+    mapCamera.pitch            = 20;
+    mapCamera.centerCoordinate = coordinates;
+    MGLMapSnapshotOptions* options = [[MGLMapSnapshotOptions alloc] initWithStyleURL:[MGLStyle satelliteStreetsStyleURL]
+                                                                              camera:mapCamera
+                                                                                size:size];
+    options.zoomLevel = 10;
+
+    // Create and start the snapshotter
+    MGLMapSnapshotter* snapshotter = [[MGLMapSnapshotter alloc] initWithOptions:options];
+    return snapshotter;
+}
+
+NSString* validAccessToken() {
+    NSString *accessToken = [[NSProcessInfo processInfo] environment][@"MAPBOX_ACCESS_TOKEN"];
+    if (!accessToken) {
+        printf("warning: MAPBOX_ACCESS_TOKEN env var is required for this test - skipping.\n");
+        return nil;
+    }
+
+    [MGLAccountManager setAccessToken:accessToken];
+    return accessToken;
+}
+
+@implementation MGLMapSnapshotterTest
+
+- (void)testMultipleSnapshotsWithASingleSnapshotter {
+    if (!validAccessToken()) {
+        return;
+    }
+
+    CGSize size = self.mapView.bounds.size;
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"snapshots"];
+    expectation.expectedFulfillmentCount = 2;
+    expectation.assertForOverFulfill = YES;
+
+    CLLocationCoordinate2D coord = CLLocationCoordinate2DMake(30.0, 30.0);
+
+    MGLMapSnapshotter *snapshotter = snapshotterWithCoordinates(coord, size);
+    XCTAssertNotNil(snapshotter);
+
+    [snapshotter startWithCompletionHandler:^(MGLMapSnapshot * _Nullable snapshot, NSError * _Nullable error) {
+        [expectation fulfill];
+    }];
+
+    @try {
+        [snapshotter startWithCompletionHandler:^(MGLMapSnapshot * _Nullable snapshot, NSError * _Nullable error) {
+            XCTFail(@"Should not be called - but should it?");
+        }];
+        XCTFail(@"Should not be called");
+    }
+    @catch (NSException *exception) {
+        XCTAssert(exception.name == NSInternalInconsistencyException);
+        [expectation fulfill];
+    }
+
+    [self waitForExpectations:@[expectation] timeout:10.0];
+}
+
+- (void)testAllocatingSnapshotOnBackgroundQueue {
+    if (!validAccessToken()) {
+        return;
+    }
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"snapshots"];
+
+    CGSize size                  = self.mapView.bounds.size;
+    CLLocationCoordinate2D coord = CLLocationCoordinate2DMake(30.0, 30.0);
+
+    dispatch_queue_attr_t attr = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INITIATED, QOS_MIN_RELATIVE_PRIORITY);
+    dispatch_queue_t backgroundQueue = dispatch_queue_create(__PRETTY_FUNCTION__, attr);
+
+    // This crashes maybe 1 in 10 times.
+    dispatch_async(backgroundQueue, ^{
+
+        // Create the snapshotter - DO NOT START.
+        MGLMapSnapshotter* snapshotter = snapshotterWithCoordinates(coord, size);
+
+        dispatch_group_t group = dispatch_group_create();
+        dispatch_group_enter(group);
+
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            dispatch_group_leave(group);
+        });
+
+        dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+
+        snapshotter = nil;
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [expectation fulfill];
+        });
+    });
+
+    [self waitForExpectations:@[expectation] timeout:2.0];
+}
+
+- (void)testMultipleSnapshottersFromBackgroundQueue {
+    if (!validAccessToken()) {
+        return;
+    }
+
+    // Crashes with only 1 snapshot
+    CGSize size = self.mapView.bounds.size;
+    CLLocationCoordinate2D coord = CLLocationCoordinate2DMake(30.0, 30.0);
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"snapshots"];
+    expectation.expectedFulfillmentCount = 1;
+    expectation.assertForOverFulfill = YES;
+
+    __weak __typeof__(self) weakself = self;
+
+    dispatch_queue_attr_t attr = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INITIATED, QOS_MIN_RELATIVE_PRIORITY); // also for concurrent
+    dispatch_queue_t backgroundQueue = dispatch_queue_create(__PRETTY_FUNCTION__, attr);
+
+
+    // Use dispatch_group to keep the backgroundQueue block around (and
+    // so also the MGLMapSnapshotter
+    dispatch_group_t group = dispatch_group_create();
+    dispatch_group_enter(group);
+
+
+    dispatch_async(backgroundQueue, ^{
+
+        MGLMapSnapshotter *snapshotter = snapshotterWithCoordinates(coord, size);
+        XCTAssertNotNil(snapshotter);
+
+        MGLMapSnapshotCompletionHandler completion = ^(MGLMapSnapshot * _Nullable snapshot, NSError * _Nullable error) {
+
+            // This should be the main queue
+            __typeof__(self) strongself = weakself;
+
+            MGLTestAssertNotNil(strongself, strongself);
+
+            MGLTestAssertNotNil(strongself, snapshot);
+            MGLTestAssertNotNil(strongself, snapshot.image);
+            MGLTestAssertNil(strongself, error, @"Snapshot should not error with: %@", error);
+
+            // Change this back to XCTAttachmentLifetimeDeleteOnSuccess when we're sure this
+            // test is passing.
+            XCTAttachment *attachment = [XCTAttachment attachmentWithImage:snapshot.image];
+            attachment.lifetime = XCTAttachmentLifetimeKeepAlways;
+            [strongself addAttachment:attachment];
+
+            dispatch_group_leave(group);
+        };
+
+        // untested
+        @try {
+            [snapshotter startWithCompletionHandler:completion];
+            MGLTestFail(weakself);
+        }
+        @catch (NSException *exception) {
+            MGLTestAssert(weakself, exception.name == NSInvalidArgumentException);
+            dispatch_group_leave(group);
+        }
+
+        // Wait for the snapshot to complete
+        dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+
+        snapshotter = nil;
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [expectation fulfill];
+        });
+    });
+
+    [self waitForExpectations:@[expectation] timeout:10.0];
+}
+
+- (void)testMultipleSnapshotters {
+    if (!validAccessToken()) {
+        return;
+    }
+
+    NSUInteger numSnapshots = 8;
+    CGSize size = self.mapView.bounds.size;
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"snapshots"];
+    expectation.expectedFulfillmentCount = numSnapshots;
+    expectation.assertForOverFulfill = YES;
+
+    __weak __typeof__(self) weakself = self;
+
+    for (size_t run = 0; run < numSnapshots; run++) {
+
+        float ratio = (float)run/(float)numSnapshots;
+        float lon = (ratio*120.0) + ((1.0-ratio)*54.0);
+        CLLocationCoordinate2D coord = CLLocationCoordinate2DMake(57.0, lon);
+
+        __block MGLMapSnapshotter *snapshotter;
+
+        // Allocate from an autorelease pool here, to avoid having
+        // snapshotter retained for longer than we'd like to test.
+        @autoreleasepool {
+            snapshotter = snapshotterWithCoordinates(coord, size);
+            XCTAssertNotNil(snapshotter);
+        }
+
+        [snapshotter startWithCompletionHandler:^(MGLMapSnapshot * _Nullable snapshot, NSError * _Nullable error) {
+
+            // This should be the main queue
+            __typeof__(self) strongself = weakself;
+
+            MGLTestAssertNotNil(strongself, strongself);
+
+            MGLTestAssertNotNil(strongself, snapshot);
+            MGLTestAssertNotNil(strongself, snapshot.image);
+            MGLTestAssertNil(strongself, error, @"Snapshot should not error with: %@", error);
+
+            // Change this back to XCTAttachmentLifetimeDeleteOnSuccess when we're sure this
+            // test is passing.
+            XCTAttachment *attachment = [XCTAttachment attachmentWithImage:snapshot.image];
+            attachment.lifetime = XCTAttachmentLifetimeKeepAlways;
+            [strongself addAttachment:attachment];
+
+            // Dealloc the snapshotter (by having this line in the block, we
+            // also retained the snapshotter. Setting to nil should release, as
+            // this block should be the only thing retaining it (since it was
+            // allocated from the above autorelease pool)
+            snapshotter = nil;
+
+            [expectation fulfill];
+        }];
+    } // end for loop
+
+    [self waitForExpectations:@[expectation] timeout:20.0];
+}
+
+@end

--- a/platform/ios/Integration Tests/Snapshotter Tests/MGLMapSnapshotterTest.m
+++ b/platform/ios/Integration Tests/Snapshotter Tests/MGLMapSnapshotterTest.m
@@ -104,12 +104,11 @@ NSString* validAccessToken() {
     [self waitForExpectations:@[expectation] timeout:2.0];
 }
 
-- (void)testMultipleSnapshottersFromBackgroundQueue {
+- (void)testSnapshotterFromBackgroundQueue {
     if (!validAccessToken()) {
         return;
     }
 
-    // Crashes with only 1 snapshot
     CGSize size = self.mapView.bounds.size;
     CLLocationCoordinate2D coord = CLLocationCoordinate2DMake(30.0, 30.0);
 
@@ -145,10 +144,9 @@ NSString* validAccessToken() {
             MGLTestAssertNotNil(strongself, snapshot.image);
             MGLTestAssertNil(strongself, error, @"Snapshot should not error with: %@", error);
 
-            // Change this back to XCTAttachmentLifetimeDeleteOnSuccess when we're sure this
-            // test is passing.
+            // Change this to XCTAttachmentLifetimeKeepAlways to be able to look at the snapshots after running
             XCTAttachment *attachment = [XCTAttachment attachmentWithImage:snapshot.image];
-            attachment.lifetime = XCTAttachmentLifetimeKeepAlways;
+            attachment.lifetime = XCTAttachmentLifetimeDeleteOnSuccess;
             [strongself addAttachment:attachment];
 
             dispatch_group_leave(group);
@@ -174,10 +172,11 @@ NSString* validAccessToken() {
         });
     });
 
-    [self waitForExpectations:@[expectation] timeout:10.0];
+    [self waitForExpectations:@[expectation] timeout:60.0];
 }
 
-- (void)testMultipleSnapshotters {
+- (void)testMultipleSnapshottersPENDING {
+    MGL_CHECK_IF_PENDING_TEST_SHOULD_RUN();
     if (!validAccessToken()) {
         return;
     }
@@ -217,10 +216,9 @@ NSString* validAccessToken() {
             MGLTestAssertNotNil(strongself, snapshot.image);
             MGLTestAssertNil(strongself, error, @"Snapshot should not error with: %@", error);
 
-            // Change this back to XCTAttachmentLifetimeDeleteOnSuccess when we're sure this
-            // test is passing.
+            // Change this to XCTAttachmentLifetimeKeepAlways to be able to look at the snapshots after running
             XCTAttachment *attachment = [XCTAttachment attachmentWithImage:snapshot.image];
-            attachment.lifetime = XCTAttachmentLifetimeKeepAlways;
+            attachment.lifetime = XCTAttachmentLifetimeDeleteOnSuccess;
             [strongself addAttachment:attachment];
 
             // Dealloc the snapshotter (by having this line in the block, we
@@ -233,7 +231,7 @@ NSString* validAccessToken() {
         }];
     } // end for loop
 
-    [self waitForExpectations:@[expectation] timeout:20.0];
+    [self waitForExpectations:@[expectation] timeout:60.0];
 }
 
 @end

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -365,6 +365,7 @@
 		AC518E04201BB56100EBC820 /* MGLTelemetryConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = AC518DFE201BB55A00EBC820 /* MGLTelemetryConfig.m */; };
 		CA0C27922076C804001CE5B7 /* MGLShapeSourceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA0C27912076C804001CE5B7 /* MGLShapeSourceTests.m */; };
 		CA0C27942076CA19001CE5B7 /* MGLMapViewIntegrationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CA0C27932076CA19001CE5B7 /* MGLMapViewIntegrationTest.m */; };
+		CA1B4A512099FB2200EDD491 /* MGLMapSnapshotterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CA1B4A502099FB2200EDD491 /* MGLMapSnapshotterTest.m */; };
 		CA4EB8C720863487006AB465 /* MGLStyleLayerIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA4EB8C620863487006AB465 /* MGLStyleLayerIntegrationTests.m */; };
 		CA34C9C3207FD272005C1A06 /* MGLCameraTransitionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CA34C9C2207FD272005C1A06 /* MGLCameraTransitionTests.mm */; };
 		CA55CD41202C16AA00CE7095 /* MGLCameraChangeReason.h in Headers */ = {isa = PBXBuildFile; fileRef = CA55CD3E202C16AA00CE7095 /* MGLCameraChangeReason.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1001,6 +1002,7 @@
 		CA0C27912076C804001CE5B7 /* MGLShapeSourceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLShapeSourceTests.m; sourceTree = "<group>"; };
 		CA0C27932076CA19001CE5B7 /* MGLMapViewIntegrationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLMapViewIntegrationTest.m; sourceTree = "<group>"; };
 		CA0C27952076CA50001CE5B7 /* MGLMapViewIntegrationTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLMapViewIntegrationTest.h; sourceTree = "<group>"; };
+		CA1B4A502099FB2200EDD491 /* MGLMapSnapshotterTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLMapSnapshotterTest.m; sourceTree = "<group>"; };
 		CA4EB8C620863487006AB465 /* MGLStyleLayerIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLStyleLayerIntegrationTests.m; sourceTree = "<group>"; };
 		CA34C9C2207FD272005C1A06 /* MGLCameraTransitionTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLCameraTransitionTests.mm; sourceTree = "<group>"; };
 		CA55CD3E202C16AA00CE7095 /* MGLCameraChangeReason.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLCameraChangeReason.h; sourceTree = "<group>"; };
@@ -1356,6 +1358,7 @@
 		16376B081FFD9DAF0000563E /* Integration Tests */ = {
 			isa = PBXGroup;
 			children = (
+				CA1B4A4F2099FA2800EDD491 /* Snapshotter Tests */,
 				16376B091FFD9DAF0000563E /* MBGLIntegrationTests.m */,
 				16376B0B1FFD9DAF0000563E /* Info.plist */,
 				CA34C9C2207FD272005C1A06 /* MGLCameraTransitionTests.mm */,
@@ -1706,6 +1709,14 @@
 				DD4823741D94AE6C00EB71B7 /* numeric_filter_style.json */,
 			);
 			name = Fixtures;
+			sourceTree = "<group>";
+		};
+		CA1B4A4F2099FA2800EDD491 /* Snapshotter Tests */ = {
+			isa = PBXGroup;
+			children = (
+				CA1B4A502099FB2200EDD491 /* MGLMapSnapshotterTest.m */,
+			);
+			path = "Snapshotter Tests";
 			sourceTree = "<group>";
 		};
 		DA1DC9411CB6C1C2006E619F = {
@@ -2821,6 +2832,7 @@
 				16376B0A1FFD9DAF0000563E /* MBGLIntegrationTests.m in Sources */,
 				CA0C27942076CA19001CE5B7 /* MGLMapViewIntegrationTest.m in Sources */,
 				CA0C27922076C804001CE5B7 /* MGLShapeSourceTests.m in Sources */,
+				CA1B4A512099FB2200EDD491 /* MGLMapSnapshotterTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Unknown tokens in URLs are now preserved, rather than replaced with an empty string. ([#11787](https://github.com/mapbox/mapbox-gl-native/issues/11787))
 * Adjusted when and how the camera transition update and finish callbacks are called, fixing recursion bugs. ([#11614](https://github.com/mapbox/mapbox-gl-native/pull/11614))
 * Fixed an issue preventing nested key path expressions get parsed accordingly to the spec. ([#11959](https://github.com/mapbox/mapbox-gl-native/pull/11959))
+* Fixed race conditions that could cause crashes when re-using `MGLMapSnapshotter` or using multiple snapshotters at the same time. ([#11831](https://github.com/mapbox/mapbox-gl-native/pull/11831))
 
 ## 0.7.1
 


### PR DESCRIPTION
I took a stab at making the changes @julianrex and I have been discussing for fixing issue #11827.

- Biggest change: when we apply the watermark on a background thread, don't capture self (turn most of the related instance methods into class methods)
- Don't call mbglMapSnapshotter->snapshot from a user-provided queue, since it's an asynchronous call anyway and starting it on the user's queue requires capturing self.

The design goal here is that we should not be passing shared pointers/references across thread boundaries. Because `startWithQueue` allows users to provide their own queue for handling the completion, we have to assume that anything on that queue can run on another thread (even though the more common `startWithCompletion` will run on the main/UI thread). When we capture a block for execution on a (potentially) different thread, we need to copy everything it needs by value. Any further changes to `MGLMapSnapshotter` should only affect the result of future `start` calls.

It's now possible to remove the "can't restart after cancel" constraint we had (just need to use the last-set "options" to re-initialize the `mbglMapSnapshotter`), but I haven't done that yet. I'm still getting up to speed on all the context for how this interface is/should be used (see issue #11825).

I'm a bit out of my element in Objective-C so careful review from someone on the iOS team is definitely a must. I'm also not sure of the best way to test beyond what CI gives us -- I've done just the basic loading of snapshots in the macos and ios test apps.

/cc @julianrex @friedbunny @1ec5 