### PR TITLE
Build release with debug signing

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -41,6 +41,7 @@ android {
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.debug
         }
     }
 


### PR DESCRIPTION
This PR allows to build the release apk with a debug configuration. This unblocks running commands as: `BUILDTYPE=Release make android` so we don't need to provide a real signing configuration.

cc @ChrisLoer 