### PR TITLE
[build] Ask ninja to limit concurrency if load avg is above 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,10 @@ endif
 
 ifeq ($(V), 1)
   export XCPRETTY
-  NINJA_ARGS ?= -v
+  NINJA_ARGS ?= -v -l 2
 else
   export XCPRETTY ?= | tee '$(shell pwd)/build/xcodebuild-$(shell date +"%Y-%m-%d_%H%M%S").log' | xcpretty
-  NINJA_ARGS ?=
+  NINJA_ARGS ?= -l 2
 endif
 
 .PHONY: default


### PR DESCRIPTION
It is possible to overwhelm a machine's memory during compile due to the `Makefile` default of setting JOBS = number of cores. This uses `ninja`s ability to limit itself based on system load - maybe this will help reduce the possibility of a machine swapping or hanging by limiting concurrency before memory is exhausted?

>   -l N   do not start new jobs if the load average is greater than N

from http://manpages.ubuntu.com/manpages/bionic/man1/ninja.1.html

I think as long as this does not slow down compiles significantly on CI systems, its a good idea to merge for improving the experience of local developers with limited RAM.