### PR TITLE
[ios] Fix MGLAnnotationView.rotatesToMatchCamera clobbering other transforms

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -14,6 +14,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Fixed an issue where selecting an onscreen annotation could move the map unintentionally. ([#11731](https://github.com/mapbox/mapbox-gl-native/pull/11731))
 * Fixed an issue where annotation views could become distorted if `rotatesToMatchCamera` is `YES`. ([#11817](https://github.com/mapbox/mapbox-gl-native/pull/11817))
+* Fixed `MGLAnnotationView.rotatesToMatchCamera` overriding other transforms that might be applied to annotation views that had this property enabled. ([#11842](https://github.com/mapbox/mapbox-gl-native/pull/11842))
 
 ### Other changes
 


### PR DESCRIPTION
Fixes an issue where `MGLAnnotationView.rotatesToMatchCamera = YES` would wipe out any other transforms that were being applied to that annotation view’s layer, such as via `.scalesWithViewingDistance`.

This bug was hinted at [in a comment during the original PR](https://github.com/mapbox/mapbox-gl-native/pull/9147/files#r123204521), but ultimately lost in the shuffle. Prompted by, but unrelated to, https://github.com/mapbox/mapbox-gl-native/issues/11756.

<img src=https://user-images.githubusercontent.com/1198851/39647176-dfd45372-4fab-11e8-8ea8-a845aa021106.jpeg width=250>

/cc @julianrex @1ec5 