### PR TITLE
[android, docs] Clean up MapSnapshotter javadoc.

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -2047,7 +2047,10 @@ public final class MapboxMap {
   //
 
   /**
-   * Takes a snapshot of the map.
+   * Renders a snapshot of the current map state as a {@link Bitmap}.
+   * Rendering does not wait for tiles to load or for animations to finish.
+   * To render a single static map image in the background, consider using
+   * {@link com.mapbox.mapboxsdk.snapshotter.MapSnapshotter}
    *
    * @param callback Callback method invoked when the snapshot is taken.
    */

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -2047,7 +2047,7 @@ public final class MapboxMap {
   //
 
   /**
-   * Renders a snapshot of the current map state as a {@link Bitmap}.
+   * Renders a snapshot of the current map state as a Bitmap.
    * Rendering does not wait for tiles to load or for animations to finish.
    * To render a single static map image in the background, consider using
    * {@link com.mapbox.mapboxsdk.snapshotter.MapSnapshotter}

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
@@ -29,10 +29,8 @@ import com.mapbox.mapboxsdk.storage.FileSource;
 import timber.log.Timber;
 
 /**
- * Use MapSnapshotter to create static map images, rendered in the background.
- * <br>
- * MapSnapshotter itself must be used on the UI thread (for access to the main looper).
- * <br>
+ * <p>Use MapSnapshotter to create static map images, rendered in the background.</p>
+ * <p>MapSnapshotter itself must be used on the UI thread (for access to the main looper).</p>
  * For an example of using MapSnapshotter, see <a href="https://github.com/mapbox/mapbox-gl-native/blob/e423ef5609cd738c07180d11744d4a45ffb3f82f/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/snapshot/MapSnapshotterActivity.java" target="_blank">MapSnapshotterActivity.java</a>
  */
 @UiThread
@@ -79,11 +77,10 @@ public class MapSnapshotter {
   private ErrorHandler errorHandler;
 
   /**
-   * Specifies the parameters for drawing a static map image using MapSnapshotter.
-   * <br><br>
-   * The width and height of the image must be specified.<br>
-   * Set the Mapbox Style to use with the {@link Options#withStyle(String)} method.<br>
-   * Set the camera position for the snapshot with {@link Options#withCameraPosition(CameraPosition)}.
+   * <p>Specifies the parameters for drawing a static map image using MapSnapshotter.</p>
+   * <p>The width and height of the image must be specified.</p>
+   * <p>Set the Mapbox Style to use with the {@link Options#withStyle(String)} method.</p>
+   * <p>Set the camera position for the snapshot with {@link Options#withCameraPosition(CameraPosition)}.</p>
    */
   public static class Options {
     private float pixelRatio = 1;
@@ -118,7 +115,7 @@ public class MapSnapshotter {
     /**
      * @param region The region to show in the snapshot.
      *               If the {@link CameraPosition} is also set,
-     *               the camera position will be overridden to match the specified region.
+     *               the {@link CameraPosition#target} will be overridden to match the specified region.
      * @return The mutated {@link Options}
      */
     public Options withRegion(LatLngBounds region) {
@@ -137,7 +134,7 @@ public class MapSnapshotter {
 
     /**
      * @param cameraPosition The {@link CameraPosition} to use for the snapshot.
-     *                       Setting a {@link LatLngBounds} region will override the camera position.
+     *                       Setting a {@link LatLngBounds} region will override the {@link CameraPosition#target}.
      * @return The mutated {@link Options}
      */
     public Options withCameraPosition(CameraPosition cameraPosition) {
@@ -296,7 +293,7 @@ public class MapSnapshotter {
    *
    * @param mapSnapshot the map snapshot to draw the overlay on
    */
-  private void addOverlay(MapSnapshot mapSnapshot) {
+  protected void addOverlay(MapSnapshot mapSnapshot) {
     Bitmap snapshot = mapSnapshot.getBitmap();
     Canvas canvas = new Canvas(snapshot);
     int margin = (int) context.getResources().getDisplayMetrics().density * LOGO_MARGIN_DP;


### PR DESCRIPTION
- Make internal/native methods private
- Add descriptions, example.
- Push users towards expected configuration options of Size/Style/Camera
- Specify in docs "don't modify options while snapshot is in progress" (see issue #11825)
- Specify in docs that starting a snapshot while one is in progress is an error
- Emphasize that "region" for the most part clobbers "camera position" (it's not just the target that can change)
- Update `MapboxMap#snapshot` with a suggestion to use `MapSnapshotter` instead.

The motivation here is that I've been doing some `MapSnapshotter` concurrency debugging, and just from looking at the docs I had a hard time figuring out how the Android wrapper was meant to be used. This PR is mainly just a bunch of small tweaks related to things that confused me.

Their shouldn't be any change in behavior in this PR (although several methods do transition from protected->private, technically a change...). I think it's weird that we include `finalize` in the docs (because we have to make it protected to expose it for the native wrapper), but it looks like we follow that pattern for other wrapper classes.

Apologies that I'm a javadoc noob and I don't really know what conventions to follow.

/cc @tobrun @zugaldia @ivovandongen 