### PR TITLE
[build] Bump macos-debug-qt5 xcode to 9.3.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -866,7 +866,7 @@ jobs:
 # ------------------------------------------------------------------------------
   macos-debug-qt5:
     macos:
-      xcode: "9.2.0"
+      xcode: "9.3.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1


### PR DESCRIPTION
Use XCode 9.3.0 in `macos-debug-qt5` CI build.

Fixes #11661.