### PR TITLE
Avoid rounding pixelratio of addImage

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -772,8 +772,9 @@ final class NativeMapView {
       return;
     }
 
-    // Determine pixel ratio
-    nativeAddImage(name, image, image.getDensity() / DisplayMetrics.DENSITY_DEFAULT);
+    // Determine pixel ratio, cast to float to avoid rounding, see mapbox-gl-native/issues/11809
+    float pixelRatio = (float) image.getDensity() / DisplayMetrics.DENSITY_DEFAULT;
+    nativeAddImage(name, image, pixelRatio);
   }
 
   public void addImages(@NonNull HashMap<String, Bitmap> bitmapHashMap) {


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/11809. When dividing two integers and assigning it to a float, you are still rounding the output of division. This is expected for our SDK, to workaround this, you can cast one argument to a float so the other is casted automatically.

Context: [4.2.4](http://docs.oracle.com/javase/specs/jls/se7/html/jls-4.html#jls-4.2.4) and [15.17](http://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.17)