### PR TITLE
Use China telemetry endpoint with China API endpoint

### DIFF
--- a/platform/darwin/src/MGLNetworkConfiguration.h
+++ b/platform/darwin/src/MGLNetworkConfiguration.h
@@ -2,6 +2,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// The default base URL for Mapbox APIs other than the telemetry API.
+extern NSString * const MGLDefaultMapboxAPIBaseURL;
+
+/// The PRC base URL for Mapbox APIs other than the telemetry API.
+extern NSString * const MGLChinaMapboxAPIBaseURL;
+
 /**
  The MGLNetworkConfiguration object provides a global way to set a base API URL for
  retrieval of map data, styles, and other resources.

--- a/platform/darwin/src/MGLNetworkConfiguration.m
+++ b/platform/darwin/src/MGLNetworkConfiguration.m
@@ -1,5 +1,8 @@
 #import "MGLNetworkConfiguration.h"
 
+NSString * const MGLDefaultMapboxAPIBaseURL = @"https://api.mapbox.com";
+NSString * const MGLChinaMapboxAPIBaseURL = @"https://api.mapbox.cn";
+
 @implementation MGLNetworkConfiguration
 
 + (void)load {

--- a/platform/ios/src/MGLAPIClient.m
+++ b/platform/ios/src/MGLAPIClient.m
@@ -2,9 +2,11 @@
 #import "NSBundle+MGLAdditions.h"
 #import "NSData+MGLAdditions.h"
 #import "MGLAccountManager.h"
+#import "MGLNetworkConfiguration.h"
 
 static NSString * const MGLAPIClientUserAgentBase = @"MapboxEventsiOS";
-static NSString * const MGLAPIClientBaseURL = @"https://events.mapbox.cn";
+static NSString * const MGLAPIClientBaseURL = @"https://events.mapbox.com";
+static NSString * const MGLAPIClientChinaBaseURL = @"https://events.mapbox.cn";
 static NSString * const MGLAPIClientEventsPath = @"events/v2";
 
 static NSString * const MGLAPIClientHeaderFieldUserAgentKey = @"User-Agent";
@@ -104,6 +106,8 @@ static NSString * const MGLAPIClientHTTPMethodPost = @"POST";
     if (testServerURL && [testServerURL.scheme isEqualToString:@"https"]) {
         self.baseURL = testServerURL;
         self.usesTestServer = YES;
+    } else if ([[[NSBundle mainBundle] objectForInfoDictionaryKey:@"MGLMapboxAPIBaseURL"] isEqualToString:MGLChinaMapboxAPIBaseURL]) {
+        self.baseURL = [NSURL URLWithString:MGLAPIClientChinaBaseURL];
     } else {
         self.baseURL = [NSURL URLWithString:MGLAPIClientBaseURL];
     }


### PR DESCRIPTION
This PR generalizes #11845 so that it only takes effect if the application has opted into api.mapbox.cn for the Maps API via the `MGLMapboxAPIBaseURL` Info.plist key. For all other applications, the behavior is the same as in v3.7.7.

/cc @rclee @friedbunny