### PR TITLE
Avoid exceptions for flow control during database creation

### DIFF
--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -59,7 +59,6 @@ public:
     uint64_t getOfflineMapboxTileCount();
 
 private:
-    void connect(int flags);
     int userVersion();
     void ensureSchema();
     void removeExisting();

--- a/platform/default/sqlite3.cpp
+++ b/platform/default/sqlite3.cpp
@@ -14,27 +14,20 @@ namespace sqlite {
 
 class DatabaseImpl {
 public:
-    DatabaseImpl(const char* filename, int flags)
+    DatabaseImpl(sqlite3* db_)
+        : db(db_)
     {
-        const int error = sqlite3_open_v2(filename, &db, flags, nullptr);
-        if (error != SQLITE_OK) {
-            const auto message = sqlite3_errmsg(db);
-            db = nullptr;
-            throw Exception { error, message };
-        }
     }
 
     ~DatabaseImpl()
     {
-        if (!db) return;
-
         const int error = sqlite3_close(db);
         if (error != SQLITE_OK) {
             mbgl::Log::Error(mbgl::Event::Database, "%s (Code %i)", sqlite3_errmsg(db), error);
         }
     }
 
-    sqlite3* db = nullptr;
+    sqlite3* db;
 };
 
 class StatementImpl {
@@ -164,10 +157,28 @@ const static bool sqliteVersionCheck __attribute__((unused)) = []() {
     return true;
 }();
 
-Database::Database(const std::string &filename, int flags)
-    : impl(std::make_unique<DatabaseImpl>(filename.c_str(), flags))
-{
+mapbox::util::variant<Database, Exception> Database::tryOpen(const std::string &filename, int flags) {
+    sqlite3* db = nullptr;
+    const int error = sqlite3_open_v2(filename.c_str(), &db, flags, nullptr);
+    if (error != SQLITE_OK) {
+        const auto message = sqlite3_errmsg(db);
+        return Exception { error, message };
+    }
+    return Database(std::make_unique<DatabaseImpl>(db));
 }
+
+Database Database::open(const std::string &filename, int flags) {
+    auto result = tryOpen(filename, flags);
+    if (result.is<Exception>()) {
+        throw result.get<Exception>();
+    } else {
+        return std::move(result.get<Database>());
+    }
+}
+
+Database::Database(std::unique_ptr<DatabaseImpl> impl_)
+    : impl(std::move(impl_))
+{}
 
 Database::Database(Database &&other)
     : impl(std::move(other.impl)) {}

--- a/platform/default/sqlite3.hpp
+++ b/platform/default/sqlite3.hpp
@@ -5,6 +5,7 @@
 #include <stdexcept>
 #include <chrono>
 #include <memory>
+#include <mapbox/variant.hpp>
 
 namespace mapbox {
 namespace sqlite {
@@ -71,11 +72,14 @@ class Query;
 
 class Database {
 private:
+    Database(std::unique_ptr<DatabaseImpl>);
     Database(const Database &) = delete;
     Database &operator=(const Database &) = delete;
 
 public:
-    Database(const std::string &filename, int flags = 0);
+    static mapbox::util::variant<Database, Exception> tryOpen(const std::string &filename, int flags = 0);
+    static Database open(const std::string &filename, int flags = 0);
+
     Database(Database &&);
     ~Database();
     Database &operator=(Database &&);

--- a/test/storage/offline_database.test.cpp
+++ b/test/storage/offline_database.test.cpp
@@ -66,7 +66,7 @@ TEST(OfflineDatabase, TEST_REQUIRES_WRITE(SchemaVersion)) {
     std::string path("test/fixtures/offline_database/offline.db");
 
     {
-        mapbox::sqlite::Database db{ path, mapbox::sqlite::Create | mapbox::sqlite::ReadWrite };
+        mapbox::sqlite::Database db = mapbox::sqlite::Database::open(path, mapbox::sqlite::Create | mapbox::sqlite::ReadWrite);
         db.exec("PRAGMA user_version = 1");
     }
 
@@ -599,7 +599,7 @@ TEST(OfflineDatabase, OfflineMapboxTileCount) {
 }
 
 static int databasePageCount(const std::string& path) {
-    mapbox::sqlite::Database db{ path, mapbox::sqlite::ReadOnly };
+    mapbox::sqlite::Database db = mapbox::sqlite::Database::open(path, mapbox::sqlite::ReadOnly);
     mapbox::sqlite::Statement stmt{ db, "pragma page_count" };
     mapbox::sqlite::Query query{ stmt };
     query.run();
@@ -607,7 +607,7 @@ static int databasePageCount(const std::string& path) {
 }
 
 static int databaseUserVersion(const std::string& path) {
-    mapbox::sqlite::Database db{ path, mapbox::sqlite::ReadOnly };
+    mapbox::sqlite::Database db = mapbox::sqlite::Database::open(path, mapbox::sqlite::ReadOnly);
     mapbox::sqlite::Statement stmt{ db, "pragma user_version" };
     mapbox::sqlite::Query query{ stmt };
     query.run();
@@ -615,7 +615,7 @@ static int databaseUserVersion(const std::string& path) {
 }
 
 static std::string databaseJournalMode(const std::string& path) {
-    mapbox::sqlite::Database db{ path, mapbox::sqlite::ReadOnly };
+    mapbox::sqlite::Database db = mapbox::sqlite::Database::open(path, mapbox::sqlite::ReadOnly);
     mapbox::sqlite::Statement stmt{ db, "pragma journal_mode" };
     mapbox::sqlite::Query query{ stmt };
     query.run();
@@ -623,7 +623,7 @@ static std::string databaseJournalMode(const std::string& path) {
 }
 
 static int databaseSyncMode(const std::string& path) {
-    mapbox::sqlite::Database db{ path, mapbox::sqlite::ReadOnly };
+    mapbox::sqlite::Database db = mapbox::sqlite::Database::open(path, mapbox::sqlite::ReadOnly);
     mapbox::sqlite::Statement stmt{ db, "pragma synchronous" };
     mapbox::sqlite::Query query{ stmt };
     query.run();
@@ -631,7 +631,7 @@ static int databaseSyncMode(const std::string& path) {
 }
 
 static std::vector<std::string> databaseTableColumns(const std::string& path, const std::string& name) {
-    mapbox::sqlite::Database db{ path, mapbox::sqlite::ReadOnly };
+    mapbox::sqlite::Database db = mapbox::sqlite::Database::open(path, mapbox::sqlite::ReadOnly);
     const auto sql = std::string("pragma table_info(") + name + ")";
     mapbox::sqlite::Statement stmt{ db, sql.c_str() };
     mapbox::sqlite::Query query{ stmt };

--- a/test/storage/sqlite.test.cpp
+++ b/test/storage/sqlite.test.cpp
@@ -6,7 +6,7 @@
 TEST(SQLite, Statement) {
     using namespace mbgl;
 
-    mapbox::sqlite::Database db(":memory:", mapbox::sqlite::Create | mapbox::sqlite::ReadWrite);
+    mapbox::sqlite::Database db = mapbox::sqlite::Database::open(":memory:", mapbox::sqlite::Create | mapbox::sqlite::ReadWrite);
     db.exec("CREATE TABLE test (id INTEGER);");
 
     mapbox::sqlite::Statement stmt1{ db, "INSERT INTO test (id) VALUES (?1);" };
@@ -28,13 +28,10 @@ TEST(SQLite, Statement) {
     ASSERT_EQ(query2.changes(), 1u);
 }
 
-TEST(SQLite, TEST_REQUIRES_WRITE(CantOpenException)) {
-    try {
-        // Should throw a CANTOPEN when the database doesn't exist,
-        // make sure all the backends behave the same way.
-        mapbox::sqlite::Database("test/fixtures/offline_database/foobar123.db", mapbox::sqlite::ReadOnly);
-        FAIL();
-    } catch (mapbox::sqlite::Exception& ex) {
-        ASSERT_EQ(ex.code, mapbox::sqlite::ResultCode::CantOpen);
-    }
+TEST(SQLite, TEST_REQUIRES_WRITE(TryOpen)) {
+    // Should return a CANTOPEN exception when the database doesn't exist,
+    // make sure all the backends behave the same way.
+    auto result = mapbox::sqlite::Database::tryOpen("test/fixtures/offline_database/foobar123.db", mapbox::sqlite::ReadOnly);
+    ASSERT_TRUE(result.is<mapbox::sqlite::Exception>());
+    ASSERT_EQ(result.get<mapbox::sqlite::Exception>().code, mapbox::sqlite::ResultCode::CantOpen);
 }


### PR DESCRIPTION
Fixes #10796.

Unfortuntely, it's difficult to avoid all exceptions, because `sqlite3_open_v2` does not reliably return `SQLITE_NOTADB` if the file is not a database. However, this should avoid cases where developers misinterpret the `SQLITE_CANTOPEN` exception as a crash, which is the common case.