### PR TITLE
[ios, macos] Moved numbers away from start of lines in documentation

### DIFF
--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -403,7 +403,7 @@ global.describeValue = function (value, property, layerType) {
         case 'boolean':
             return value ? '`YES`' : '`NO`';
         case 'number':
-            return 'the float ' + formatNumber(value);
+            return 'the float ' + '`' + formatNumber(value) + '`';
         case 'string':
             if (value === '') {
                 return 'the empty string';

--- a/platform/darwin/src/MGLBackgroundStyleLayer.h
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.h
@@ -95,8 +95,8 @@ which it is added.
 /**
  The opacity at which the background will be drawn.
  
- The default value of this property is an expression that evaluates to the float
- 1. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 1.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  

--- a/platform/darwin/src/MGLBackgroundStyleLayer.h
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.h
@@ -95,8 +95,8 @@ which it is added.
 /**
  The opacity at which the background will be drawn.
  
- The default value of this property is an expression that evaluates to the float 1.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `1`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -116,8 +116,8 @@ MGL_EXPORT
  Amount to blur the circle. 1 blurs the circle such that only the centerpoint is
  full opacity.
  
- The default value of this property is an expression that evaluates to the float
- 0. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 0.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -185,8 +185,8 @@ MGL_EXPORT
 /**
  The opacity at which the circle will be drawn.
  
- The default value of this property is an expression that evaluates to the float
- 1. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 1.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -234,8 +234,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float
- 5. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 5.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -333,8 +333,8 @@ MGL_EXPORT
 /**
  The opacity of the circle's stroke.
  
- The default value of this property is an expression that evaluates to the float
- 1. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 1.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -360,8 +360,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float
- 0. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 0.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -116,8 +116,8 @@ MGL_EXPORT
  Amount to blur the circle. 1 blurs the circle such that only the centerpoint is
  full opacity.
  
- The default value of this property is an expression that evaluates to the float 0.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `0`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -185,8 +185,8 @@ MGL_EXPORT
 /**
  The opacity at which the circle will be drawn.
  
- The default value of this property is an expression that evaluates to the float 1.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `1`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -234,8 +234,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float 5.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `5`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -333,8 +333,8 @@ MGL_EXPORT
 /**
  The opacity of the circle's stroke.
  
- The default value of this property is an expression that evaluates to the float 1.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `1`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -360,8 +360,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float 0.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `0`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  

--- a/platform/darwin/src/MGLFillExtrusionStyleLayer.h
+++ b/platform/darwin/src/MGLFillExtrusionStyleLayer.h
@@ -77,8 +77,8 @@ MGL_EXPORT
  
  This property is measured in meters.
  
- The default value of this property is an expression that evaluates to the float 0.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `0`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `fillExtrusionHeight` is
  non-`nil`. Otherwise, it is ignored.
@@ -163,8 +163,8 @@ MGL_EXPORT
  
  This property is measured in meters.
  
- The default value of this property is an expression that evaluates to the float 0.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `0`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -188,8 +188,8 @@ MGL_EXPORT
  The opacity of the entire fill extrusion layer. This is rendered on a
  per-layer, not per-feature, basis, and data-driven styling is not available.
  
- The default value of this property is an expression that evaluates to the float 1.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `1`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  

--- a/platform/darwin/src/MGLFillExtrusionStyleLayer.h
+++ b/platform/darwin/src/MGLFillExtrusionStyleLayer.h
@@ -77,8 +77,8 @@ MGL_EXPORT
  
  This property is measured in meters.
  
- The default value of this property is an expression that evaluates to the float
- 0. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 0.
+ Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `fillExtrusionHeight` is
  non-`nil`. Otherwise, it is ignored.
@@ -163,8 +163,8 @@ MGL_EXPORT
  
  This property is measured in meters.
  
- The default value of this property is an expression that evaluates to the float
- 0. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 0.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -188,8 +188,8 @@ MGL_EXPORT
  The opacity of the entire fill extrusion layer. This is rendered on a
  per-layer, not per-feature, basis, and data-driven styling is not available.
  
- The default value of this property is an expression that evaluates to the float
- 1. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 1.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -150,8 +150,8 @@ MGL_EXPORT
  The opacity of the entire fill layer. In contrast to the `fillColor`, this
  value will also affect the 1pt stroke around the fill, if the stroke is used.
  
- The default value of this property is an expression that evaluates to the float 1.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `1`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -150,8 +150,8 @@ MGL_EXPORT
  The opacity of the entire fill layer. In contrast to the `fillColor`, this
  value will also affect the 1pt stroke around the fill, if the stroke is used.
  
- The default value of this property is an expression that evaluates to the float
- 1. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 1.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  

--- a/platform/darwin/src/MGLHeatmapStyleLayer.h
+++ b/platform/darwin/src/MGLHeatmapStyleLayer.h
@@ -115,8 +115,8 @@ MGL_EXPORT
  Similar to `heatmapWeight` but controls the intensity of the heatmap globally.
  Primarily used for adjusting the heatmap based on zoom level.
  
- The default value of this property is an expression that evaluates to the float
- 1. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 1.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -141,8 +141,8 @@ MGL_EXPORT
 /**
  The global opacity at which the heatmap layer will be drawn.
  
- The default value of this property is an expression that evaluates to the float
- 1. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 1.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -170,8 +170,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float
- 30. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 30.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -196,8 +196,8 @@ MGL_EXPORT
  of 10 would be equivalent to having 10 points of weight 1 in the same spot.
  Especially useful when combined with clustering.
  
- The default value of this property is an expression that evaluates to the float
- 1. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 1.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  

--- a/platform/darwin/src/MGLHeatmapStyleLayer.h
+++ b/platform/darwin/src/MGLHeatmapStyleLayer.h
@@ -115,8 +115,8 @@ MGL_EXPORT
  Similar to `heatmapWeight` but controls the intensity of the heatmap globally.
  Primarily used for adjusting the heatmap based on zoom level.
  
- The default value of this property is an expression that evaluates to the float 1.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `1`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -141,8 +141,8 @@ MGL_EXPORT
 /**
  The global opacity at which the heatmap layer will be drawn.
  
- The default value of this property is an expression that evaluates to the float 1.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `1`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -170,8 +170,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float 30.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `30`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -196,8 +196,8 @@ MGL_EXPORT
  of 10 would be equivalent to having 10 points of weight 1 in the same spot.
  Especially useful when combined with clustering.
  
- The default value of this property is an expression that evaluates to the float 1.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `1`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  

--- a/platform/darwin/src/MGLHillshadeStyleLayer.h
+++ b/platform/darwin/src/MGLHillshadeStyleLayer.h
@@ -129,8 +129,8 @@ MGL_EXPORT
 /**
  Intensity of the hillshade
  
- The default value of this property is an expression that evaluates to the float 0.5.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `0.5`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -231,8 +231,8 @@ MGL_EXPORT
  `MGLHillshadeIlluminationAnchorViewport` and due north if
  `hillshadeIlluminationAnchor` is set to `MGLHillshadeIlluminationAnchorMap`.
  
- The default value of this property is an expression that evaluates to the float 335.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `335`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  

--- a/platform/darwin/src/MGLHillshadeStyleLayer.h
+++ b/platform/darwin/src/MGLHillshadeStyleLayer.h
@@ -129,8 +129,8 @@ MGL_EXPORT
 /**
  Intensity of the hillshade
  
- The default value of this property is an expression that evaluates to the float
- 0.5. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 0.5.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -231,8 +231,8 @@ MGL_EXPORT
  `MGLHillshadeIlluminationAnchorViewport` and due north if
  `hillshadeIlluminationAnchor` is set to `MGLHillshadeIlluminationAnchorMap`.
  
- The default value of this property is an expression that evaluates to the float
- 335. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 335.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  

--- a/platform/darwin/src/MGLLight.h
+++ b/platform/darwin/src/MGLLight.h
@@ -187,8 +187,8 @@ MGL_EXPORT
  Intensity of lighting (on a scale from 0 to 1). Higher numbers will present as
  more extreme contrast.
  
- The default value of this property is an expression that evaluates to the float
- 0.5.
+ The default value of this property is an expression that evaluates to the
+ float 0.5.
  
  You can set this property to an expression containing any of the following:
  

--- a/platform/darwin/src/MGLLight.h
+++ b/platform/darwin/src/MGLLight.h
@@ -187,8 +187,8 @@ MGL_EXPORT
  Intensity of lighting (on a scale from 0 to 1). Higher numbers will present as
  more extreme contrast.
  
- The default value of this property is an expression that evaluates to the
- float 0.5.
+ The default value of this property is an expression that evaluates to the float
+ `0.5`.
  
  You can set this property to an expression containing any of the following:
  

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -179,8 +179,8 @@ MGL_EXPORT
 /**
  Used to automatically convert miter joins to bevel joins for sharp angles.
  
- The default value of this property is an expression that evaluates to the float 2.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `2`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `lineJoin` is set to an
  expression that evaluates to `miter`. Otherwise, it is ignored.
@@ -201,8 +201,8 @@ MGL_EXPORT
 /**
  Used to automatically convert round joins to miter joins for shallow angles.
  
- The default value of this property is an expression that evaluates to the
- float 1.05. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `1.05`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `lineJoin` is set to an
  expression that evaluates to `round`. Otherwise, it is ignored.
@@ -227,8 +227,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float 0.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `0`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -342,8 +342,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float 0.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `0`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -371,8 +371,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float 0.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `0`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -395,8 +395,8 @@ MGL_EXPORT
 /**
  The opacity at which the line will be drawn.
  
- The default value of this property is an expression that evaluates to the float 1.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `1`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -541,8 +541,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float 1.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `1`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -179,8 +179,8 @@ MGL_EXPORT
 /**
  Used to automatically convert miter joins to bevel joins for sharp angles.
  
- The default value of this property is an expression that evaluates to the float
- 2. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 2.
+ Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `lineJoin` is set to an
  expression that evaluates to `miter`. Otherwise, it is ignored.
@@ -201,8 +201,8 @@ MGL_EXPORT
 /**
  Used to automatically convert round joins to miter joins for shallow angles.
  
- The default value of this property is an expression that evaluates to the float
- 1.05. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the
+ float 1.05. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `lineJoin` is set to an
  expression that evaluates to `round`. Otherwise, it is ignored.
@@ -227,8 +227,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float
- 0. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 0.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -342,8 +342,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float
- 0. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 0.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -371,8 +371,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float
- 0. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 0.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -395,8 +395,8 @@ MGL_EXPORT
 /**
  The opacity at which the line will be drawn.
  
- The default value of this property is an expression that evaluates to the float
- 1. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 1.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -541,8 +541,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float
- 1. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 1.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  

--- a/platform/darwin/src/MGLRasterStyleLayer.h
+++ b/platform/darwin/src/MGLRasterStyleLayer.h
@@ -63,8 +63,8 @@ MGL_EXPORT
  Increase or reduce the brightness of the image. The value is the maximum
  brightness.
  
- The default value of this property is an expression that evaluates to the float
- 1. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 1.
+ Set this property to `nil` to reset it to the default value.
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-raster-brightness-max"><code>raster-brightness-max</code></a>
@@ -96,8 +96,8 @@ MGL_EXPORT
  Increase or reduce the brightness of the image. The value is the minimum
  brightness.
  
- The default value of this property is an expression that evaluates to the float
- 0. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 0.
+ Set this property to `nil` to reset it to the default value.
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-raster-brightness-min"><code>raster-brightness-min</code></a>
@@ -128,8 +128,8 @@ MGL_EXPORT
 /**
  Increase or reduce the contrast of the image.
  
- The default value of this property is an expression that evaluates to the float
- 0. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 0.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -156,8 +156,8 @@ MGL_EXPORT
  
  This property is measured in milliseconds.
  
- The default value of this property is an expression that evaluates to the float
- 300. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the
+ float 300. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -177,8 +177,8 @@ MGL_EXPORT
  
  This property is measured in degrees.
  
- The default value of this property is an expression that evaluates to the float
- 0. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 0.
+ Set this property to `nil` to reset it to the default value.
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-raster-hue-rotate"><code>raster-hue-rotate</code></a>
@@ -209,8 +209,8 @@ MGL_EXPORT
 /**
  The opacity at which the image will be drawn.
  
- The default value of this property is an expression that evaluates to the float
- 1. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 1.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -235,8 +235,8 @@ MGL_EXPORT
 /**
  Increase or reduce the saturation of the image.
  
- The default value of this property is an expression that evaluates to the float
- 0. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 0.
+ Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  

--- a/platform/darwin/src/MGLRasterStyleLayer.h
+++ b/platform/darwin/src/MGLRasterStyleLayer.h
@@ -63,8 +63,8 @@ MGL_EXPORT
  Increase or reduce the brightness of the image. The value is the maximum
  brightness.
  
- The default value of this property is an expression that evaluates to the float 1.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `1`. Set this property to `nil` to reset it to the default value.
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-raster-brightness-max"><code>raster-brightness-max</code></a>
@@ -96,8 +96,8 @@ MGL_EXPORT
  Increase or reduce the brightness of the image. The value is the minimum
  brightness.
  
- The default value of this property is an expression that evaluates to the float 0.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `0`. Set this property to `nil` to reset it to the default value.
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-raster-brightness-min"><code>raster-brightness-min</code></a>
@@ -128,8 +128,8 @@ MGL_EXPORT
 /**
  Increase or reduce the contrast of the image.
  
- The default value of this property is an expression that evaluates to the float 0.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `0`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -156,8 +156,8 @@ MGL_EXPORT
  
  This property is measured in milliseconds.
  
- The default value of this property is an expression that evaluates to the
- float 300. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `300`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -177,8 +177,8 @@ MGL_EXPORT
  
  This property is measured in degrees.
  
- The default value of this property is an expression that evaluates to the float 0.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `0`. Set this property to `nil` to reset it to the default value.
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-raster-hue-rotate"><code>raster-hue-rotate</code></a>
@@ -209,8 +209,8 @@ MGL_EXPORT
 /**
  The opacity at which the image will be drawn.
  
- The default value of this property is an expression that evaluates to the float 1.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `1`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  
@@ -235,8 +235,8 @@ MGL_EXPORT
 /**
  Increase or reduce the saturation of the image.
  
- The default value of this property is an expression that evaluates to the float 0.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `0`. Set this property to `nil` to reset it to the default value.
  
  You can set this property to an expression containing any of the following:
  

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -563,8 +563,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float 2.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `2`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
@@ -614,8 +614,8 @@ MGL_EXPORT
  
  This property is measured in degrees.
  
- The default value of this property is an expression that evaluates to the
- float 0. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `0`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
@@ -677,8 +677,8 @@ MGL_EXPORT
  
  This property is measured in factor of the original icon sizes.
  
- The default value of this property is an expression that evaluates to the
- float 1. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `1`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
@@ -857,8 +857,8 @@ MGL_EXPORT
  
  This property is measured in degrees.
  
- The default value of this property is an expression that evaluates to the
- float 45. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `45`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`, and
  `symbolPlacement` is set to an expression that evaluates to `line`. Otherwise,
@@ -889,8 +889,8 @@ MGL_EXPORT
  
  This property is measured in ems.
  
- The default value of this property is an expression that evaluates to the
- float 10. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `10`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
@@ -972,8 +972,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the
- float 250. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `250`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `symbolPlacement` is set to an
  expression that evaluates to `line`. Otherwise, it is ignored.
@@ -1128,8 +1128,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the
- float 16. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `16`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
@@ -1218,8 +1218,8 @@ MGL_EXPORT
  
  This property is measured in ems.
  
- The default value of this property is an expression that evaluates to the float 0.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `0`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
@@ -1240,8 +1240,8 @@ MGL_EXPORT
  
  This property is measured in ems.
  
- The default value of this property is an expression that evaluates to the
- float 1.2. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `1.2`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
@@ -1337,8 +1337,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float 2.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `2`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
@@ -1388,8 +1388,8 @@ MGL_EXPORT
  
  This property is measured in degrees.
  
- The default value of this property is an expression that evaluates to the float 0.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `0`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
@@ -1528,8 +1528,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float 0.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `0`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
@@ -1610,8 +1610,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float 0.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `0`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
@@ -1637,8 +1637,8 @@ MGL_EXPORT
 /**
  The opacity at which the icon will be drawn.
  
- The default value of this property is an expression that evaluates to the float 1.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `1`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
@@ -1818,8 +1818,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float 0.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `0`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
@@ -1899,8 +1899,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float 0.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `0`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
@@ -1926,8 +1926,8 @@ MGL_EXPORT
 /**
  The opacity at which the text will be drawn.
  
- The default value of this property is an expression that evaluates to the float 1.
- Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float
+ `1`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -563,8 +563,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float
- 2. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 2.
+ Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
@@ -614,8 +614,8 @@ MGL_EXPORT
  
  This property is measured in degrees.
  
- The default value of this property is an expression that evaluates to the float
- 0. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the
+ float 0. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
@@ -677,8 +677,8 @@ MGL_EXPORT
  
  This property is measured in factor of the original icon sizes.
  
- The default value of this property is an expression that evaluates to the float
- 1. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the
+ float 1. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
@@ -857,8 +857,8 @@ MGL_EXPORT
  
  This property is measured in degrees.
  
- The default value of this property is an expression that evaluates to the float
- 45. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the
+ float 45. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`, and
  `symbolPlacement` is set to an expression that evaluates to `line`. Otherwise,
@@ -889,8 +889,8 @@ MGL_EXPORT
  
  This property is measured in ems.
  
- The default value of this property is an expression that evaluates to the float
- 10. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the
+ float 10. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
@@ -972,8 +972,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float
- 250. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the
+ float 250. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `symbolPlacement` is set to an
  expression that evaluates to `line`. Otherwise, it is ignored.
@@ -1128,8 +1128,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float
- 16. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the
+ float 16. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
@@ -1218,8 +1218,8 @@ MGL_EXPORT
  
  This property is measured in ems.
  
- The default value of this property is an expression that evaluates to the float
- 0. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 0.
+ Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
@@ -1240,8 +1240,8 @@ MGL_EXPORT
  
  This property is measured in ems.
  
- The default value of this property is an expression that evaluates to the float
- 1.2. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the
+ float 1.2. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
@@ -1337,8 +1337,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float
- 2. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 2.
+ Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
@@ -1388,8 +1388,8 @@ MGL_EXPORT
  
  This property is measured in degrees.
  
- The default value of this property is an expression that evaluates to the float
- 0. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 0.
+ Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
@@ -1528,8 +1528,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float
- 0. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 0.
+ Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
@@ -1610,8 +1610,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float
- 0. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 0.
+ Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
@@ -1637,8 +1637,8 @@ MGL_EXPORT
 /**
  The opacity at which the icon will be drawn.
  
- The default value of this property is an expression that evaluates to the float
- 1. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 1.
+ Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
@@ -1818,8 +1818,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float
- 0. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 0.
+ Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
@@ -1899,8 +1899,8 @@ MGL_EXPORT
  
  This property is measured in points.
  
- The default value of this property is an expression that evaluates to the float
- 0. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 0.
+ Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
@@ -1926,8 +1926,8 @@ MGL_EXPORT
 /**
  The opacity at which the text will be drawn.
  
- The default value of this property is an expression that evaluates to the float
- 1. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an expression that evaluates to the float 1.
+ Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.


### PR DESCRIPTION
Jazzy formats numbers followed by periods at the start of a line as lists. This changed even non-1 numbers to 1.

<img width="453" alt="Before" src="https://user-images.githubusercontent.com/12474734/39901731-2bed3f26-547f-11e8-80a4-53cb6525d5ab.png">

<img width="450" alt="After" src="https://user-images.githubusercontent.com/12474734/39901733-2ffd5f06-547f-11e8-9b63-e9ccff3d2b94.png">
