### PR TITLE
[ios, build] Re-add support for 32-bit simulators (i386)

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,10 +4,14 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ## 4.0.1
 
+### Packaging
+
+* Re-added support for 32-bit simulators (i386) to work around an issue in CocoaPods. ([#11891](https://github.com/mapbox/mapbox-gl-native/pull/11891))
+
 ### Style layers
 
 * Deprecated `+[NSExpression featurePropertiesVariableExpression]` use `+[NSExpression featureAttributesVariableExpression]` instead. ([#11748](https://github.com/mapbox/mapbox-gl-native/pull/11748))
-* Added `FISRT`, `LAST`, and `SIZE` symbolic array subscripting support to expressions. ([#11770](https://github.com/mapbox/mapbox-gl-native/pull/11770))
+* Added `FIRST`, `LAST`, and `SIZE` symbolic array subscripting support to expressions. ([#11770](https://github.com/mapbox/mapbox-gl-native/pull/11770))
 
 
 ### Annotations

--- a/platform/ios/INSTALL.md
+++ b/platform/ios/INSTALL.md
@@ -12,7 +12,7 @@ The Mapbox Maps SDK for iOS is intended to run on iOS 8.0 and above on the follo
 
 _Note: Support for iOS 8 will be removed in a future release and the minimum iOS deployment version will increase to iOS 9.0._
 
-Note that 32-bit simulators (such as the iPhone 5 or iPad 2) are not supported.
+Note that debugging in 32-bit simulators (such as the iPhone 5 or iPad 2) is only partially supported.
 
 The Mapbox Maps SDK for iOS requires:
 

--- a/platform/ios/scripts/package.sh
+++ b/platform/ios/scripts/package.sh
@@ -70,7 +70,7 @@ xcodebuild \
     CURRENT_SHORT_VERSION=${SHORT_VERSION} \
     CURRENT_SEMANTIC_VERSION=${SEM_VERSION} \
     CURRENT_COMMIT_HASH=${HASH} \
-    ARCHS="x86_64" \
+    ONLY_ACTIVE_ARCH=NO \
     -derivedDataPath ${DERIVED_DATA} \
     -workspace ./platform/ios/ios.xcworkspace \
     -scheme ${SCHEME} \
@@ -194,6 +194,10 @@ if [[ ${BUILD_DYNAMIC} == true && ${BUILDTYPE} == Release ]]; then
     validate_dsym \
         "${OUTPUT}/dynamic/${NAME}.framework.dSYM/Contents/Resources/DWARF/${NAME}" \
         "${OUTPUT}/dynamic/${NAME}.framework/${NAME}"
+
+        step "Removing i386 slice from dSYM"
+        lipo -remove i386 "${OUTPUT}/dynamic/${NAME}.framework.dSYM/Contents/Resources/DWARF/${NAME}" -o "${OUTPUT}/dynamic/${NAME}.framework.dSYM/Contents/Resources/DWARF/${NAME}"
+        lipo -info "${OUTPUT}/dynamic/${NAME}.framework.dSYM/Contents/Resources/DWARF/${NAME}"
 fi
 
 function create_podspec {


### PR DESCRIPTION
Reverts the removal of `i386` slices from our framework in #10962/`ios-v4.0.0`. This is because CocoaPods effectively forces pods to package `i386` in all of their dependencies (e.g., https://github.com/mapbox/mapbox-navigation-ios/pull/1394).

This puts us back at the `ios-v3.7.x` state, where we strip `i386` from dSYMs only (#10781).

/cc @bsudekum @1ec5 @akitchen @fabian-guerra 