### PR TITLE
[qt] Fix build when building the Qt Location plugin

### DIFF
--- a/platform/qt/include/qmapbox.hpp
+++ b/platform/qt/include/qmapbox.hpp
@@ -9,10 +9,14 @@
 
 // This header follows the Qt coding style: https://wiki.qt.io/Qt_Coding_Style
 
-#if defined(QT_BUILD_MAPBOXGL_LIB)
-    #define Q_MAPBOXGL_EXPORT Q_DECL_EXPORT
+#if !defined(QT_MAPBOXGL_STATIC)
+#  if defined(QT_BUILD_MAPBOXGL_LIB)
+#    define Q_MAPBOXGL_EXPORT Q_DECL_EXPORT
+#  else
+#    define Q_MAPBOXGL_EXPORT Q_DECL_IMPORT
+#  endif
 #else
-    #define Q_MAPBOXGL_EXPORT Q_DECL_IMPORT
+#  define Q_MAPBOXGL_EXPORT
 #endif
 
 namespace QMapbox {

--- a/src/mbgl/style/expression/compound_expression.cpp
+++ b/src/mbgl/style/expression/compound_expression.cpp
@@ -364,7 +364,7 @@ std::unordered_map<std::string, CompoundExpressionRegistry::Definition> initiali
         return result;
     });
     
-    define("round", [](double x) -> Result<double> { return std::round(x); });
+    define("round", [](double x) -> Result<double> { return ::round(x); });
     define("floor", [](double x) -> Result<double> { return std::floor(x); });
     define("ceil", [](double x) -> Result<double> { return std::ceil(x); });
     define("abs", [](double x) -> Result<double> { return std::abs(x); });


### PR DESCRIPTION
- MinGW has to explicitly know that is building a static library.
- Android doesn't have 'round' on the std:: namespace when using g++.