### PR TITLE
Fix English priority during label localization

### DIFF
--- a/platform/darwin/src/MGLVectorTileSource.mm
+++ b/platform/darwin/src/MGLVectorTileSource.mm
@@ -112,7 +112,8 @@ static NSArray * const MGLMapboxStreetsAlternativeLanguages = @[
         return [[NSLocale localeWithLocaleIdentifier:language].languageCode isEqualToString:@"en"];
     }]].count;
     
-    NSArray<NSString *> *preferredLanguages = [NSBundle preferredLocalizationsFromArray:MGLMapboxStreetsAlternativeLanguages
+    NSArray<NSString *> *availableLanguages = acceptsEnglish ? MGLMapboxStreetsLanguages : MGLMapboxStreetsAlternativeLanguages;
+    NSArray<NSString *> *preferredLanguages = [NSBundle preferredLocalizationsFromArray:availableLanguages
                                                                          forPreferences:preferencesArray];
     NSString *mostSpecificLanguage;
     for (NSString *language in preferredLanguages) {
@@ -120,10 +121,7 @@ static NSArray * const MGLMapboxStreetsAlternativeLanguages = @[
             mostSpecificLanguage = language;
         }
     }
-    if ([mostSpecificLanguage isEqualToString:@"mul"]) {
-        return acceptsEnglish ? @"en" : nil;
-    }
-    return mostSpecificLanguage;
+    return [mostSpecificLanguage isEqualToString:@"mul"] ? nil : mostSpecificLanguage;
 }
 
 - (BOOL)isMapboxStreets {
@@ -133,21 +131,6 @@ static NSArray * const MGLMapboxStreetsAlternativeLanguages = @[
     }
     NSArray *identifiers = [url.host componentsSeparatedByString:@","];
     return [identifiers containsObject:@"mapbox.mapbox-streets-v7"] || [identifiers containsObject:@"mapbox.mapbox-streets-v6"];
-}
-
-- (NS_DICTIONARY_OF(NSString *, NSString *) *)localizedKeysByKeyForPreferredLanguage:(nullable NSString *)preferredLanguage {
-    if (!self.mapboxStreets) {
-        return @{};
-    }
-
-    // Replace {name} and {name_*} with the matching localized name tag.
-    NSString *localizedKey = preferredLanguage ? [NSString stringWithFormat:@"name_%@", preferredLanguage] : @"name";
-    NSMutableDictionary *localizedKeysByKey = [NSMutableDictionary dictionaryWithObject:localizedKey forKey:@"name"];
-    for (NSString *languageCode in [MGLVectorTileSource mapboxStreetsLanguages]) {
-        NSString *key = [NSString stringWithFormat:@"name_%@", languageCode];
-        localizedKeysByKey[key] = localizedKey;
-    }
-    return localizedKeysByKey;
 }
 
 @end

--- a/platform/darwin/src/MGLVectorTileSource_Private.h
+++ b/platform/darwin/src/MGLVectorTileSource_Private.h
@@ -11,8 +11,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable NSString *)preferredMapboxStreetsLanguage;
 + (nullable NSString *)preferredMapboxStreetsLanguageForPreferences:(NSArray<NSString *> *)preferencesArray;
 
-- (NS_DICTIONARY_OF(NSString *, NSString *) *)localizedKeysByKeyForPreferredLanguage:(nullable NSString *)preferredLanguage;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/platform/darwin/test/MGLStyleTests.mm
+++ b/platform/darwin/test/MGLStyleTests.mm
@@ -448,6 +448,10 @@
         XCTAssertNil([MGLVectorTileSource preferredMapboxStreetsLanguageForPreferences:preferences]);
     }
     {
+        NSArray *preferences = @[@"en", @"fr", @"el"];
+        XCTAssertEqualObjects([MGLVectorTileSource preferredMapboxStreetsLanguageForPreferences:preferences], @"en");
+    }
+    {
         NSArray *preferences = @[@"tlh"];
         XCTAssertNil([MGLVectorTileSource preferredMapboxStreetsLanguageForPreferences:preferences]);
     }

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -23,6 +23,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 ### Other changes
 
 * Added a Korean localization. ([#11792](https://github.com/mapbox/mapbox-gl-native/pull/11792))
+* If English is the first language listed in the user’s Preferred Languages setting, `-[MGLStyle localizeLabelsIntoLocale:]` no longer prioritizes other languages over English. ([#11907](https://github.com/mapbox/mapbox-gl-native/pull/11907))
 * Fixed an issue where `-[MGLMapView metersPerPixelAtLatitude:]` was removed, but not marked as unavailable. ([#11765](https://github.com/mapbox/mapbox-gl-native/pull/11765))
 * Reduce per-frame render CPU time ([#11811](https://github.com/mapbox/mapbox-gl-native/issues/11811))
 * Fixed a crash when removing an `MGLOfflinePack`. ([#6092](https://github.com/mapbox/mapbox-gl-native/issues/6092))

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 * Fixed an issue where selecting an onscreen annotation could move the map unintentionally. ([#11731](https://github.com/mapbox/mapbox-gl-native/pull/11731))
 * Fixed a crash when removing an `MGLOfflinePack`. ([#6092](https://github.com/mapbox/mapbox-gl-native/issues/6092))
+* If English is the first language listed in the user’s Preferred Languages setting, `-[MGLStyle localizeLabelsIntoLocale:]` no longer prioritizes other languages over English. ([#11907](https://github.com/mapbox/mapbox-gl-native/pull/11907))
 * Fixed an issue where an `MGLOverlay` object straddling the antimeridian had an empty `MGLOverlay.overlayBounds` value. ([#11783](https://github.com/mapbox/mapbox-gl-native/pull/11783))
 * Fixed an issue where certain colors were being misrepresented in `NSExpression` obtained from `MGLStyleLayer` getters. ([#11725](https://github.com/mapbox/mapbox-gl-native/pull/11725))
 


### PR DESCRIPTION
Respect English in the Preferred Languages setting even if other Mapbox Streets source–supported languages are listed too. Also removed some dead code that is no longer called as of #11651.

Fixes #11906.

/cc @friedbunny @bsudekum