### PR TITLE
Updated MGLScaleBar to use rendered UIImages instead of MGLScaleBarLabel

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -19,6 +19,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Improved application launch performance.
 * Fixed an issue preventing nested key path expressions get parsed accordingly to the spec. ([#11959](https://github.com/mapbox/mapbox-gl-native/pull/11959))
 * Added custom `-hitTest:withEvent:` to `MGLSMCalloutView` to avoid registering taps in transparent areas of the standard annotation callout. ([#11939](https://github.com/mapbox/mapbox-gl-native/pull/11939))
+* Improved performance and memory impact of `MGLScaleBar`. ([#11921](https://github.com/mapbox/mapbox-gl-native/pull/11921))
 
 ## 4.0.1 - May 14, 2018
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -152,8 +152,8 @@ CLLocationCoordinate2D randomWorldCoordinate() {
 
     // Now create a world coord
     CLLocationDegrees heading          = drand48()*360.0;
-    CLLocationDistance dist            = drand48()*radius;
-    CLLocationCoordinate2D newLocation = coordinateCentered(coordinate, heading, dist);
+    CLLocationDistance distance        = drand48()*radius;
+    CLLocationCoordinate2D newLocation = coordinateCentered(coordinate, heading, distance);
     return newLocation;
 }
 
@@ -1753,8 +1753,8 @@ CLLocationCoordinate2D randomWorldCoordinate() {
     for (NSInteger i = 0; i<numAnnotations; i++) {
 
         CLLocationDegrees heading          = drand48()*360.0;
-        CLLocationDistance dist            = drand48()*radius;
-        CLLocationCoordinate2D newLocation = coordinateCentered(coordinate, heading, dist);
+        CLLocationDistance distance        = drand48()*radius;
+        CLLocationCoordinate2D newLocation = coordinateCentered(coordinate, heading, distance);
 
         MBXDroppedPinAnnotation *annotation = [[MBXDroppedPinAnnotation alloc] init];
         annotation.coordinate = newLocation;
@@ -1769,10 +1769,10 @@ CLLocationCoordinate2D randomWorldCoordinate() {
     [self.mapView removeAnnotations:self.mapView.annotations];
     [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(31, -100) zoomLevel:3 animated:NO];
 
-    [self _randomWorldTourInternal];
+    [self randomWorldTourInternal];
 }
 
-- (void)_randomWorldTourInternal {
+- (void)randomWorldTourInternal {
 
     self.randomWalk = YES;
 
@@ -1809,7 +1809,7 @@ CLLocationCoordinate2D randomWorldCoordinate() {
                 dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
                     MBXViewController *strongSelf = weakSelf;
                     if (strongSelf.randomWalk) {
-                        [strongSelf _randomWorldTourInternal];
+                        [strongSelf randomWorldTourInternal];
                     }
                 });
             }];

--- a/platform/ios/src/MGLScaleBar.mm
+++ b/platform/ios/src/MGLScaleBar.mm
@@ -75,7 +75,7 @@ static const MGLRow MGLImperialTable[] ={
 @class MGLScaleBarLabel;
 
 @interface MGLScaleBar()
-@property (nonatomic) NSArray<MGLScaleBarLabel *> *labels;
+@property (nonatomic) NSArray<UIView *> *labelViews;
 @property (nonatomic) NSArray<UIView *> *bars;
 @property (nonatomic) UIView *containerView;
 @property (nonatomic) MGLDistanceFormatter *formatter;
@@ -84,6 +84,10 @@ static const MGLRow MGLImperialTable[] ={
 @property (nonatomic) UIColor *secondaryColor;
 @property (nonatomic) CALayer *borderLayer;
 @property (nonatomic, assign) CGFloat borderWidth;
+@property (nonatomic) NSCache* labelImageCache;
+@property (nonatomic) MGLScaleBarLabel* prototypeLabel;
+
+
 @end
 
 static const CGFloat MGLBarHeight = 4;
@@ -117,6 +121,10 @@ static const CGFloat MGLFeetPerMeter = 3.28084;
 @end
 
 @implementation MGLScaleBar
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:NSCurrentLocaleDidChangeNotification object:nil];
+}
 
 - (instancetype)initWithCoder:(NSCoder *)decoder {
     if (self = [super initWithCoder:decoder]) {
@@ -152,7 +160,41 @@ static const CGFloat MGLFeetPerMeter = 3.28084;
     [_containerView.layer addSublayer:_borderLayer];
     
     _formatter = [[MGLDistanceFormatter alloc] init];
+
+    // Image labels are now images
+    _labelImageCache              = [[NSCache alloc] init];
+    _prototypeLabel               = [[MGLScaleBarLabel alloc] init];
+    _prototypeLabel.font          = [UIFont systemFontOfSize:8 weight:UIFontWeightMedium];
+    _prototypeLabel.clipsToBounds = NO;
+
+    NSUInteger numberOfLabels = 4;
+    NSMutableArray *labelViews = [NSMutableArray arrayWithCapacity:numberOfLabels];
+
+    for (NSUInteger i = 0; i < numberOfLabels; i++) {
+        UIView *view = [[UIView alloc] init];
+        view.bounds        = CGRectZero;
+        view.clipsToBounds = NO;
+        view.contentMode   = UIViewContentModeCenter;
+        view.hidden        = YES;
+        [labelViews addObject:view];
+        [self addSubview:view];
+    }
+    _labelViews = [labelViews copy];
+
+    // Zero is a special case (no formatting)
+    [self addZeroLabel];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(currentLocaleDidChange:)
+                                                 name:NSCurrentLocaleDidChangeNotification
+                                               object:nil];
 }
+
+- (void)currentLocaleDidChange:(NSNotification*)notification {
+    // Clear the cache, so labels should be rebuilt.
+    [self.labelImageCache removeAllObjects];
+    [self addZeroLabel];
+};
 
 #pragma mark - Dimensions
 
@@ -190,21 +232,31 @@ static const CGFloat MGLFeetPerMeter = 3.28084;
     CLLocationDistance maximumDistance = [self maximumWidth] * [self unitsPerPoint];
     
     BOOL useMetric = [self usesMetricSystem];
-    MGLRow row = useMetric ? MGLMetricTable[0] : MGLImperialTable[0];
-    NSUInteger count = useMetric
-    ? sizeof(MGLMetricTable) / sizeof(MGLMetricTable[0])
-    : sizeof(MGLImperialTable) / sizeof(MGLImperialTable[0]);
-    
-    for (NSUInteger i = 0; i < count; i++) {
-        CLLocationDistance distance = useMetric ? MGLMetricTable[i].distance : MGLImperialTable[i].distance;
-        if (distance <= maximumDistance) {
-            row = useMetric ? MGLMetricTable[i] : MGLImperialTable[i];
-        } else {
-            break;
-        }
+
+    const MGLRow *row;
+    const MGLRow *table;
+    NSUInteger count;
+
+    if (useMetric) {
+        row = table = MGLMetricTable;
+        count = sizeof(MGLMetricTable) / sizeof(MGLMetricTable[0]);
     }
-    
-    return row;
+    else {
+        row = table = MGLImperialTable;
+        count = sizeof(MGLImperialTable) / sizeof(MGLImperialTable[0]);
+    }
+
+    while (row < table + count) {
+        if (row->distance > maximumDistance) {
+            // use the previous row
+            NSAssert(row != table, @"");
+            return *(row - 1);
+        }
+        ++row;
+    }
+
+    // Didn't find it, just return the first.
+    return *table;
 }
 
 #pragma mark - Setters
@@ -255,9 +307,9 @@ static const CGFloat MGLFeetPerMeter = 3.28084;
     
     _row = row;
     [_bars makeObjectsPerformSelector:@selector(removeFromSuperview)];
-    [_labels makeObjectsPerformSelector:@selector(removeFromSuperview)];
     _bars = nil;
-    _labels = nil;
+
+    [self updateLabels];
 }
 
 #pragma mark - Views
@@ -275,59 +327,89 @@ static const CGFloat MGLFeetPerMeter = 3.28084;
     return _bars;
 }
 
-- (NSArray<UILabel *> *)labels {
-    if (!_labels) {
-        NSDecimalNumber *zeroNumber = [NSDecimalNumber decimalNumberWithString:@"0"];
-        NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
-        NSMutableArray *labels = [NSMutableArray array];
-        
-        for (NSUInteger i = 0; i <= self.row.numberOfBars; i++) {
-            UILabel *label = [[MGLScaleBarLabel alloc] init];
-            label.font = [UIFont systemFontOfSize:8 weight:UIFontWeightMedium];
-            label.text = [formatter stringFromNumber:zeroNumber];
-            label.clipsToBounds = NO;
-            [label setNeedsDisplay];
-            [label sizeToFit];
-            [labels addObject:label];
-            [self addSubview:label];
-        }
-        _labels = labels;
+#pragma mark - Labels
+
+- (void)addZeroLabel {
+    NSDecimalNumber *zeroNumber = [NSDecimalNumber decimalNumberWithString:@"0"];
+    NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
+    NSString *text = [formatter stringFromNumber:zeroNumber];
+
+    UIImage* image = [self imageForLabelText:text];
+    [self.labelImageCache setObject:image forKey:@(0)];
+}
+
+- (UIImage*)imageForLabelText:(NSString*)text {
+    self.prototypeLabel.text = text;
+    [self.prototypeLabel setNeedsDisplay];
+    [self.prototypeLabel sizeToFit];
+
+    // Now render
+    UIGraphicsBeginImageContextWithOptions(self.prototypeLabel.bounds.size, NO, 0.0);
+    [self.prototypeLabel.layer renderInContext: UIGraphicsGetCurrentContext()];
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return image;
+}
+
+- (UIImage*)cachedLabelImageForDistance:(CLLocationDistance)barDistance {
+    // Make a slightly nicer key, rather than something that's a double.
+    NSUInteger floorDist = (NSUInteger)(barDistance*100);
+
+    NSNumber *key = @(floorDist);
+    UIImage *cachedImage = [self.labelImageCache objectForKey:key];
+
+    if (cachedImage) {
+        return cachedImage;
     }
-    return _labels;
+
+    // Calc it
+    NSString *text = [self.formatter stringFromDistance:barDistance];
+    UIImage *image = [self imageForLabelText:text];
+
+    [self.labelImageCache setObject:image forKey:key];
+
+    return image;
+}
+
+- (void)updateLabels {
+    NSEnumerator<UIView*> *viewEnumerator = [self.labelViews objectEnumerator];
+    NSInteger i = 0;
+    CLLocationDistance multiplier = (self.row.distance / self.row.numberOfBars);
+
+    if (![self usesMetricSystem]) {
+        multiplier /= MGLFeetPerMeter;
+    }
+
+    for (; i <= self.row.numberOfBars; i++) {
+        UIView *labelView = [viewEnumerator nextObject];
+        labelView.hidden = NO;
+
+        CLLocationDistance barDistance = multiplier * i;
+        UIImage *image = [self cachedLabelImageForDistance:barDistance];
+
+        labelView.layer.contents      = (id)image.CGImage;
+        labelView.layer.contentsScale = image.scale;
+    }
+
+    // Hide the rest.
+    for (; i < self.labelViews.count; i++) {
+        UIView *labelView = [viewEnumerator nextObject];
+        labelView.hidden = YES;
+    }
 }
 
 #pragma mark - Layout
 
 - (void)layoutSubviews {
     [super layoutSubviews];
-    
+
     if (!self.row.numberOfBars) {
         // Current distance is not within allowed range
         return;
     }
-    
-    [self updateLabels];
+
     [self layoutBars];
     [self layoutLabels];
-}
-
-- (void)updateLabels {
-    NSArray *labels = [self.labels subarrayWithRange:NSMakeRange(1, self.labels.count-1)];
-    BOOL useMetric = [self usesMetricSystem];
-    NSUInteger i = 0;
-    
-    for (MGLScaleBarLabel *label in labels) {
-        CLLocationDistance barDistance = (self.row.distance / self.row.numberOfBars) * (i + 1);
-        
-        if (!useMetric) {
-            barDistance /= MGLFeetPerMeter;
-        }
-        
-        label.text = [self.formatter stringFromDistance:barDistance];
-        [label setNeedsDisplay];
-        [label sizeToFit];
-        i++;
-    }
 }
 
 - (void)layoutBars {
@@ -357,11 +439,15 @@ static const CGFloat MGLFeetPerMeter = 3.28084;
     CGFloat barWidth = round(self.bounds.size.width / self.bars.count);
     BOOL RTL = [self usesRightToLeftLayout];
     NSUInteger i = RTL ? self.bars.count : 0;
-    for (MGLScaleBarLabel *label in self.labels) {
+    for (UIView *label in self.labelViews) {
         CGFloat xPosition = round(barWidth * i - CGRectGetMidX(label.bounds) + self.borderWidth);
-        label.frame = CGRectMake(xPosition, 0,
-                                 CGRectGetWidth(label.bounds),
-                                 CGRectGetHeight(label.bounds));
+        CGFloat yPosition = round(0.5 * (CGRectGetMaxY(self.bounds) - MGLBarHeight));
+
+        CGRect frame = label.frame;
+        frame.origin.x = xPosition;
+        frame.origin.y = yPosition;
+        label.frame = frame;
+
         i = RTL ? i-1 : i+1;
     }
 }

--- a/platform/ios/src/MGLScaleBar.mm
+++ b/platform/ios/src/MGLScaleBar.mm
@@ -122,10 +122,6 @@ static const CGFloat MGLFeetPerMeter = 3.28084;
 
 @implementation MGLScaleBar
 
-- (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:NSCurrentLocaleDidChangeNotification object:nil];
-}
-
 - (instancetype)initWithCoder:(NSCoder *)decoder {
     if (self = [super initWithCoder:decoder]) {
         [self commonInit];
@@ -183,18 +179,7 @@ static const CGFloat MGLFeetPerMeter = 3.28084;
 
     // Zero is a special case (no formatting)
     [self addZeroLabel];
-
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(currentLocaleDidChange:)
-                                                 name:NSCurrentLocaleDidChangeNotification
-                                               object:nil];
 }
-
-- (void)currentLocaleDidChange:(NSNotification*)notification {
-    // Clear the cache, so labels should be rebuilt.
-    [self.labelImageCache removeAllObjects];
-    [self addZeroLabel];
-};
 
 #pragma mark - Dimensions
 


### PR DESCRIPTION
- Added a new "random world tour" to iOS for testing/profiling purposes
- Render MGLScaleBarLabel on demand caching the resulting UIImages for use as scale bar labels

~Edit: No changelog entry yet~

Edit 2: Updated with screenshots of Instruments running the `randomWorldTour` example on an iPhone X, specifically looking at CPU and memory usage (not FPS).

## CPU / MGLScaleBarLabel

**Before**: In the following image, I'm filtering symbols for `drawTextInRect` which was only used by `MGLScaleBarLabel`. You can see, in this test, taking up a total of 14% of the CPU - significant for such a small on-screen item. You can also see that allocations take up a good chunk of this too (and if we filter on `malloc` - that actually goes up further).

![screen shot 2018-05-15 at 09 48 49](https://user-images.githubusercontent.com/3765757/40116806-d631015e-58e2-11e8-8a30-b5c89a28474e.png)

**After**: Filtering on `drawTextInRect` and then `MGLScaleBar`, the effect is essentially non-existent:

![screen shot 2018-05-15 at 11 45 51](https://user-images.githubusercontent.com/3765757/40121357-5f99fad4-58ef-11e8-8501-410038e8c70c.png)

![screen shot 2018-05-15 at 11 45 59](https://user-images.githubusercontent.com/3765757/40121444-953e6fbc-58ef-11e8-922f-22b4f3063803.png)


## Memory impact

**Before**: The following includes transient allocations i.e. allocations that have come and gone. The highlighted line, 33%, will include will include all allocations from `CA::Transaction::commit()`, but notice on the right that the "Heaviest Stack Trace" is our `MGLScaleBarLabel`.

![screen shot 2018-05-15 at 10 35 49](https://user-images.githubusercontent.com/3765757/40117000-9172cfe2-58e3-11e8-84bf-876cd27a0d81.png)

**After**: Hunting for the same `CA::Transaction::commit()` as above:
![screen shot 2018-05-15 at 11 50 19](https://user-images.githubusercontent.com/3765757/40121556-d93fefd8-58ef-11e8-8105-35454b074baa.png)


## Transient allocations

**Before**: Looking at all allocations, sorted by transient, we see:

![screen shot 2018-05-15 at 10 25 31](https://user-images.githubusercontent.com/3765757/40117154-15cb8c02-58e4-11e8-9b41-a29001a6ff09.png)

**After**: In these traces, the comparisons aren't exact, but it's worth noting how the top 3 small allocations compare with the next largest chunk, `mbgl::VectorTileFeature` - this reduced much more than I was expecting (and why I included these traces).

![screen shot 2018-05-15 at 11 54 25](https://user-images.githubusercontent.com/3765757/40121642-093ab1c8-58f0-11e8-954e-294de63e4541.png)








