### PR TITLE
Fix TileCover for LineStrings

### DIFF
--- a/src/mbgl/util/tile_cover_impl.cpp
+++ b/src/mbgl/util/tile_cover_impl.cpp
@@ -32,6 +32,8 @@ void start_list_on_local_minimum(PointList& points) {
         next_pt++;
         if (next_pt == points.end()) { next_pt = std::next(points.begin()); }
     }
+    if (pt == points.end())
+        return;
     //Re-close linear rings with first_pt = last_pt
     if (points.back() == points.front()) {
         points.pop_back();

--- a/src/mbgl/util/tile_cover_impl.hpp
+++ b/src/mbgl/util/tile_cover_impl.hpp
@@ -60,6 +60,22 @@ struct Bound {
     }
 };
 
+// Implements a modified scan-line algorithm to provide a streaming interface for
+// tile cover on arbitrary shapes.
+// A `BoundsMap` is genereted from the input geometry where each tuple indicates
+// the set of Bounds that start at a y tile coordinate. Each bound represents
+// a chain of edges from a local y-minima to a local y-maxima.
+// For each row, the activeBounds list aggregates all bounds that enter into or
+// begin in that row. This running list of bounds is scanned, capturing the
+// x-coordinates spanned by edges in a bound until the bound exits the row (or
+// ends). The result is a set of (possibly overlapping) min,max pairs of x coordinates
+// (spans). In the simplest case a span represents the x-coordinates at which a
+// single edge intersects the top and bottom of a tile row. Interior tiles of a
+// polygon are captured by merging spans using the non-zero rule.
+// The result of a scan using `nextRow()` is a list of spans (tileXSpans) of x-coordinates
+// that includes edges and interiors of polygons.
+// next() returns a tileID for each x-coordinate from (first, second] in each
+// span in tileXSpans.
 class TileCover::Impl {
 public:
     Impl(int32_t z, const Geometry<double>& geom, bool project = true);

--- a/test/util/tile_cover.test.cpp
+++ b/test/util/tile_cover.test.cpp
@@ -137,6 +137,17 @@ TEST(TileCover, GeomLineZ10) {
     
 }
 
+TEST(TileCover, GeomLineRegression11870) {
+    auto lineCover = util::tileCover(LineString<double>{
+        {-121.5063900000001,40.470099999999945},
+        {-121.5065300000001,40.470369999999946},
+        {-121.5065900000001,40.470519999999944},
+    }, 14);
+    EXPECT_EQ((std::vector<UnwrappedTileID>{ { 14, 2662, 6174 } }),
+          lineCover);
+
+}
+
 TEST(TileCover, WrappedGeomLineZ10) {
     auto lineCover = util::tileCover(LineString<double>{
         {-179.93342914581299,38.892101707724315},
@@ -262,6 +273,9 @@ TEST(TileCover, GeomSanFranciscoPoly) {
 TEST(TileCover, GeomInvalid) {
     auto point = Point<double>{ -122.5744, 97.6609 };
     EXPECT_THROW(util::tileCover(point, 2), std::domain_error);
+
+    auto badLine = LineString<double>{ {1.0,  35.0} };
+    EXPECT_EQ((std::vector<UnwrappedTileID>{ }), util::tileCover(badLine, 16));
 
     auto badPoly = Polygon<double> { { {1.0,  35.0} } };
     EXPECT_EQ((std::vector<UnwrappedTileID>{ }), util::tileCover(badPoly, 16));

--- a/test/util/tile_cover.test.cpp
+++ b/test/util/tile_cover.test.cpp
@@ -3,7 +3,8 @@
 #include <mbgl/map/transform.hpp>
 
 #include <algorithm>
-
+#include <stdlib.h>     /* srand, rand */
+#include <time.h>       /* time */
 #include <gtest/gtest.h>
 
 using namespace mbgl;
@@ -312,4 +313,60 @@ TEST(TileCount, BoundsCrossingAntimeridian) {
     EXPECT_EQ(1u, util::tileCount(crossingBounds, 0));
     EXPECT_EQ(4u, util::tileCount(crossingBounds, 3));
     EXPECT_EQ(8u, util::tileCount(crossingBounds, 4));
+}
+
+TEST(TileCover, DISABLED_FuzzPoly) {
+    while(1)
+    {
+        std::srand (time(NULL));
+        std::size_t len = std::rand() % 10000 + 3;
+        Polygon<double> polygon;
+
+        std::size_t num_rings = 1;
+        num_rings += std::rand() % 5;
+        while (num_rings > 0) {
+            LinearRing<double> ring;
+            for (std::size_t i = 0; i < len; ++i) {
+                double x = std::rand() % 180;
+                double y = std::rand() % 90;
+
+                ring.push_back({x,y});
+            }
+            polygon.emplace_back(ring);
+            --num_rings;
+        }
+        
+        std::clog << ".";
+        util::TileCover tc(polygon, 5);
+        while(tc.next()) {
+        };
+    }
+}
+
+TEST(TileCover, DISABLED_FuzzLine) {
+    while(1)
+    {
+        std::srand (time(NULL));
+        std::size_t len = std::rand() % 10000 + 3;
+        MultiLineString<double> mls;
+
+        std::size_t num_lines = 1;
+        num_lines += std::rand() % 5;
+        while (num_lines > 0) {
+            LineString<double> line;
+            for (std::size_t i = 0; i < len; ++i) {
+                double x = std::rand() % 180;
+                double y = std::rand() % 90;
+
+                line.push_back({x,y});
+            }
+            mls.emplace_back(line);
+            --num_lines;
+        }
+        
+        std::clog << ".";
+        util::TileCover tc(mls, 5);
+        while(tc.next()) {
+        };
+    }
 }


### PR DESCRIPTION
Fixes #11870.

The `create_bound_towards_maximum` and `create_bound_towards_minimum` methods responsible for creating a Bound from a local y-minima to a local y-maxima treated all input vectors of points as a ring. This was only valid for polygons(!!) but worked for lines if they met certain pre-conditions.

The example lines used in #11870 show that lines don't always start at a local y-minima. (i.e. a line can go from south to north)

From a given starting point, it is only necessary to iterate points until a point changes direction on the y-axis. This fix drastically simplifies the `create_bound_towards_`* methods. 

Also added comments describing the streaming tile cover algorithm.