### PR TITLE
[build] Use Qt 5.6.3 instead of 5.7 in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ before_build:
 
 build_script:
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
-  - cmake -G "Ninja" -DMBGL_PLATFORM=qt -DWITH_QT_DECODERS=ON -DWITH_QT_I18N=ON -DWITH_NODEJS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=C:\Qt\5.7\msvc2015_64\lib\cmake -DCMAKE_MAKE_PROGRAM="%APPVEYOR_BUILD_FOLDER%\platform\qt\ninja.exe" ..
+  - cmake -G "Ninja" -DMBGL_PLATFORM=qt -DWITH_QT_DECODERS=ON -DWITH_QT_I18N=ON -DWITH_NODEJS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=C:\Qt\5.6.3\msvc2015_64\lib\cmake -DCMAKE_MAKE_PROGRAM="%APPVEYOR_BUILD_FOLDER%\platform\qt\ninja.exe" ..
   - cmake --build . -- -j %NUMBER_OF_PROCESSORS%
 
 after_build:

--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -145,6 +145,7 @@ elseif (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
     add_definitions("-Wno-unused-command-line-argument")
     add_definitions("-Wno-unused-local-typedef")
     add_definitions("-Wno-unused-private-field")
+    add_definitions("-Wno-inconsistent-missing-override")
 
     list(APPEND MBGL_QT_CORE_FILES
         PRIVATE platform/qt/src/thread.cpp


### PR DESCRIPTION
AppVeyor started complaining about missing package configurations:
```
CMake Error at platform/qt/qt5.cmake:1 (find_package):
  By not providing "FindQt5Core.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Qt5Core", but
  CMake did not find one.
  Could not find a package configuration file provided by "Qt5Core" with any
  of the following names:
    Qt5CoreConfig.cmake
    qt5core-config.cmake
  Add the installation prefix of "Qt5Core" to CMAKE_PREFIX_PATH or set
  "Qt5Core_DIR" to a directory containing one of the above files.  If
  "Qt5Core" provides a separate development package or SDK, be sure it has been installed.
Call Stack (most recent call first):
  platform/qt/qt.cmake:107 (include)
  platform/qt/config.cmake:4 (include)
  CMakeLists.txt:138 (include)
```

This is probably due to recent changes in AppVeyor´s build environment: https://www.appveyor.com/docs/build-environment/#qt

From the link above, Qt 5.6.3 seems to still have the MSVC2015 configuration. Thus, I'm attempting to use it instead of Qt 5.7.