### PR TITLE
Expose MapView created callbacks on MapFragment 

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapFragment.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapFragment.java
@@ -8,7 +8,6 @@ import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-
 import com.mapbox.mapboxsdk.utils.MapFragmentUtils;
 
 import java.util.ArrayList;
@@ -31,6 +30,7 @@ import java.util.List;
 public final class MapFragment extends Fragment implements OnMapReadyCallback {
 
   private final List<OnMapReadyCallback> mapReadyCallbackList = new ArrayList<>();
+  private OnMapViewReadyCallback mapViewReadyCallback;
   private MapboxMap mapboxMap;
   private MapView map;
 
@@ -56,6 +56,19 @@ public final class MapFragment extends Fragment implements OnMapReadyCallback {
   }
 
   /**
+   * Called when the context attaches to this fragment.
+   *
+   * @param context the context attaching
+   */
+  @Override
+  public void onAttach(Context context) {
+    super.onAttach(context);
+    if (context instanceof OnMapViewReadyCallback) {
+      mapViewReadyCallback = (OnMapViewReadyCallback) context;
+    }
+  }
+
+  /**
    * Creates the fragment view hierarchy.
    *
    * @param inflater           Inflater used to inflate content.
@@ -75,15 +88,25 @@ public final class MapFragment extends Fragment implements OnMapReadyCallback {
    * Called when the fragment view hierarchy is created.
    *
    * @param view               The content view of the fragment
-   * @param savedInstanceState THe saved instance state of the framgnt
+   * @param savedInstanceState The saved instance state of the fragment
    */
   @Override
   public void onViewCreated(View view, Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
     map.onCreate(savedInstanceState);
     map.getMapAsync(this);
+
+    // notify listeners about mapview creation
+    if (mapViewReadyCallback != null) {
+      mapViewReadyCallback.onMapViewReady(map);
+    }
   }
 
+  /**
+   * Called when the style of the map has successfully loaded.
+   *
+   * @param mapboxMap The public api controller of the map
+   */
   @Override
   public void onMapReady(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
@@ -169,5 +192,22 @@ public final class MapFragment extends Fragment implements OnMapReadyCallback {
     } else {
       onMapReadyCallback.onMapReady(mapboxMap);
     }
+  }
+
+  /**
+   * Callback to be invoked when the map fragment has inflated its MapView.
+   * <p>
+   * To use this interface the context hosting the fragment must implement this interface.
+   * That instance will be set as part of Fragment#onAttach(Context context).
+   * </p>
+   */
+  public interface OnMapViewReadyCallback {
+
+    /**
+     * Called when the map has been created.
+     *
+     * @param mapView The created mapview
+     */
+    void onMapViewReady(MapView mapView);
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
@@ -31,6 +31,7 @@ import java.util.List;
 public class SupportMapFragment extends Fragment implements OnMapReadyCallback {
 
   private final List<OnMapReadyCallback> mapReadyCallbackList = new ArrayList<>();
+  private MapFragment.OnMapViewReadyCallback mapViewReadyCallback;
   private MapboxMap mapboxMap;
   private MapView map;
 
@@ -53,6 +54,19 @@ public class SupportMapFragment extends Fragment implements OnMapReadyCallback {
     SupportMapFragment mapFragment = new SupportMapFragment();
     mapFragment.setArguments(MapFragmentUtils.createFragmentArgs(mapboxMapOptions));
     return mapFragment;
+  }
+
+  /**
+   * Called when the context attaches to this fragment.
+   *
+   * @param context the context attaching
+   */
+  @Override
+  public void onAttach(Context context) {
+    super.onAttach(context);
+    if (context instanceof MapFragment.OnMapViewReadyCallback) {
+      mapViewReadyCallback = (MapFragment.OnMapViewReadyCallback) context;
+    }
   }
 
   /**
@@ -82,6 +96,11 @@ public class SupportMapFragment extends Fragment implements OnMapReadyCallback {
     super.onViewCreated(view, savedInstanceState);
     map.onCreate(savedInstanceState);
     map.getMapAsync(this);
+
+    // notify listeners about MapView creation
+    if (mapViewReadyCallback != null) {
+      mapViewReadyCallback.onMapViewReady(map);
+    }
   }
 
   @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/MapFragmentActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/MapFragmentActivity.java
@@ -1,14 +1,13 @@
 package com.mapbox.mapboxsdk.testapp.activity.fragment;
 
-import android.app.FragmentTransaction;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
-
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.constants.Style;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapFragment;
+import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
@@ -20,53 +19,71 @@ import com.mapbox.mapboxsdk.testapp.R;
  * Uses MapboxMapOptions to initialise the Fragment.
  * </p>
  */
-public class MapFragmentActivity extends AppCompatActivity implements OnMapReadyCallback {
+public class MapFragmentActivity extends AppCompatActivity implements MapFragment.OnMapViewReadyCallback,
+  OnMapReadyCallback, MapView.OnMapChangedListener {
 
   private MapboxMap mapboxMap;
+  private MapView mapView;
+  private boolean initialCameraAnimation = true;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_map_fragment);
-
-    MapFragment mapFragment;
     if (savedInstanceState == null) {
-      final FragmentTransaction transaction = getFragmentManager().beginTransaction();
-
-      MapboxMapOptions options = new MapboxMapOptions();
-      options.styleUrl(Style.OUTDOORS);
-
-      options.scrollGesturesEnabled(false);
-      options.zoomGesturesEnabled(false);
-      options.tiltGesturesEnabled(false);
-      options.rotateGesturesEnabled(false);
-
-      options.debugActive(false);
-
-      LatLng dc = new LatLng(38.90252, -77.02291);
-
-      options.minZoomPreference(9);
-      options.maxZoomPreference(11);
-      options.camera(new CameraPosition.Builder()
-        .target(dc)
-        .zoom(11)
-        .build());
-
-      mapFragment = MapFragment.newInstance(options);
-
-      transaction.add(R.id.fragment_container, mapFragment, "com.mapbox.map");
-      transaction.commit();
-    } else {
-      mapFragment = (MapFragment) getFragmentManager().findFragmentByTag("com.mapbox.map");
+      MapFragment mapFragment =  MapFragment.newInstance(createFragmentOptions());
+      getFragmentManager()
+        .beginTransaction()
+        .add(R.id.fragment_container,mapFragment, "com.mapbox.map")
+        .commit();
+      mapFragment.getMapAsync(this);
     }
+  }
 
-    mapFragment.getMapAsync(this);
+  private MapboxMapOptions createFragmentOptions() {
+    MapboxMapOptions options = new MapboxMapOptions();
+    options.styleUrl(Style.OUTDOORS);
+
+    options.scrollGesturesEnabled(false);
+    options.zoomGesturesEnabled(false);
+    options.tiltGesturesEnabled(false);
+    options.rotateGesturesEnabled(false);
+    options.debugActive(false);
+
+    LatLng dc = new LatLng(38.90252, -77.02291);
+
+    options.minZoomPreference(9);
+    options.maxZoomPreference(11);
+    options.camera(new CameraPosition.Builder()
+      .target(dc)
+      .zoom(11)
+      .build());
+    return options;
+  }
+
+  @Override
+  public void onMapViewReady(MapView map) {
+    mapView = map;
+    mapView.addOnMapChangedListener(this);
   }
 
   @Override
   public void onMapReady(MapboxMap map) {
     mapboxMap = map;
-    mapboxMap.animateCamera(
-      CameraUpdateFactory.newCameraPosition(new CameraPosition.Builder().tilt(45.0).build()), 10000);
+  }
+
+  @Override
+  public void onMapChanged(int change) {
+    if (initialCameraAnimation && change == MapView.DID_FINISH_RENDERING_MAP_FULLY_RENDERED) {
+      mapboxMap.animateCamera(
+        CameraUpdateFactory.newCameraPosition(new CameraPosition.Builder().tilt(45.0).build()), 5000);
+      initialCameraAnimation = false;
+    }
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.removeOnMapChangedListener(this);
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/SupportMapFragmentActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/SupportMapFragmentActivity.java
@@ -1,13 +1,13 @@
 package com.mapbox.mapboxsdk.testapp.activity.fragment;
 
 import android.os.Bundle;
-import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.AppCompatActivity;
-
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.constants.Style;
 import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapFragment;
+import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
@@ -20,51 +20,71 @@ import com.mapbox.mapboxsdk.testapp.R;
  * Uses MapboxMapOptions to initialise the Fragment.
  * </p>
  */
-public class SupportMapFragmentActivity extends AppCompatActivity implements OnMapReadyCallback {
+public class SupportMapFragmentActivity extends AppCompatActivity implements MapFragment.OnMapViewReadyCallback,
+  OnMapReadyCallback, MapView.OnMapChangedListener {
 
   private MapboxMap mapboxMap;
+  private MapView mapView;
+  private boolean initialCameraAnimation = true;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_map_fragment);
-
-    SupportMapFragment mapFragment;
     if (savedInstanceState == null) {
-      final FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
-
-      MapboxMapOptions options = new MapboxMapOptions();
-      options.styleUrl(Style.SATELLITE_STREETS);
-
-      options.debugActive(false);
-      options.compassEnabled(false);
-      options.attributionEnabled(false);
-      options.logoEnabled(false);
-
-      LatLng dc = new LatLng(38.90252, -77.02291);
-
-      options.minZoomPreference(9);
-      options.maxZoomPreference(11);
-      options.camera(new CameraPosition.Builder()
-        .target(dc)
-        .zoom(11)
-        .build());
-
-      mapFragment = SupportMapFragment.newInstance(options);
-
-      transaction.add(R.id.fragment_container, mapFragment, "com.mapbox.map");
-      transaction.commit();
-    } else {
-      mapFragment = (SupportMapFragment) getSupportFragmentManager().findFragmentByTag("com.mapbox.map");
+      SupportMapFragment mapFragment = SupportMapFragment.newInstance(createFragmentOptions());
+      getSupportFragmentManager()
+        .beginTransaction()
+        .add(R.id.fragment_container, mapFragment, "com.mapbox.map")
+        .commit();
+      mapFragment.getMapAsync(this);
     }
+  }
 
-    mapFragment.getMapAsync(this);
+  private MapboxMapOptions createFragmentOptions() {
+    MapboxMapOptions options = new MapboxMapOptions();
+    options.styleUrl(Style.MAPBOX_STREETS);
+
+    options.scrollGesturesEnabled(false);
+    options.zoomGesturesEnabled(false);
+    options.tiltGesturesEnabled(false);
+    options.rotateGesturesEnabled(false);
+    options.debugActive(false);
+
+    LatLng dc = new LatLng(38.90252, -77.02291);
+
+    options.minZoomPreference(9);
+    options.maxZoomPreference(11);
+    options.camera(new CameraPosition.Builder()
+      .target(dc)
+      .zoom(11)
+      .build());
+    return options;
+  }
+
+  @Override
+  public void onMapViewReady(MapView map) {
+    mapView = map;
+    mapView.addOnMapChangedListener(this);
   }
 
   @Override
   public void onMapReady(MapboxMap map) {
     mapboxMap = map;
-    mapboxMap.animateCamera(
-      CameraUpdateFactory.newCameraPosition(new CameraPosition.Builder().tilt(45.0).build()), 10000);
+  }
+
+  @Override
+  public void onMapChanged(int change) {
+    if (initialCameraAnimation && change == MapView.DID_FINISH_RENDERING_MAP_FULLY_RENDERED) {
+      mapboxMap.animateCamera(
+        CameraUpdateFactory.newCameraPosition(new CameraPosition.Builder().tilt(45.0).build()), 5000);
+      initialCameraAnimation = false;
+    }
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.removeOnMapChangedListener(this);
   }
 }


### PR DESCRIPTION
Google made a u-turn at i/o this year when it comes to advising to use fragments to build an UI. Since they are now considered first class citizens this PR adds the ability to get a callback when the MapView has been created. Users have reached out in the past to get a reference to the underlying mapview when using our fragments, the callback in this PR makes it easier for them. 