### PR TITLE
Provide custom hit test for callout views

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -18,6 +18,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Adjusted when and how the camera transition update and finish callbacks are called, fixing recursion bugs. ([#11614](https://github.com/mapbox/mapbox-gl-native/pull/11614))
 * Improved application launch performance.
 * Fixed an issue preventing nested key path expressions get parsed accordingly to the spec. ([#11959](https://github.com/mapbox/mapbox-gl-native/pull/11959))
+* Added custom `-hitTest:withEvent:` to `MGLSMCalloutView` to avoid registering taps in transparent areas of the standard annotation callout. ([#11939](https://github.com/mapbox/mapbox-gl-native/pull/11939))
 
 ## 4.0.1 - May 14, 2018
 

--- a/platform/ios/vendor/SMCalloutView/SMCalloutView.m
+++ b/platform/ios/vendor/SMCalloutView/SMCalloutView.m
@@ -28,8 +28,6 @@
 #define TOP_ANCHOR_MARGIN 13 // all the above measurements assume a bottom anchor! if we're pointing "up" we'll need to add this top margin to everything.
 #define COMFORTABLE_MARGIN 10 // when we try to reposition content to be visible, we'll consider this margin around your target rect
 
-#define CHECK_CALLOUT_SHAPE_FOR_HIT_TEST
-
 NSTimeInterval const kMGLSMCalloutViewRepositionDelayForUIScrollView = 1.0/3.0;
 
 @interface MGLSMCalloutView ()
@@ -64,9 +62,8 @@ NSTimeInterval const kMGLSMCalloutViewRepositionDelayForUIScrollView = 1.0/3.0;
     return self;
 }
 
-#ifdef CHECK_CALLOUT_SHAPE_FOR_HIT_TEST
-- (UIView*)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
-    UIView* hitView = [super hitTest:point withEvent:event];
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+    UIView *hitView = [super hitTest:point withEvent:event];
 
     // If we tapped on our container (i.e. the UIButton), then ask the background
     // view if the point is "inside". MGLSMCalloutMaskedBackgroundView provides a
@@ -84,7 +81,6 @@ NSTimeInterval const kMGLSMCalloutViewRepositionDelayForUIScrollView = 1.0/3.0;
 
     return hitView;
 }
-#endif
 
 - (BOOL)supportsHighlighting {
     if (![self.delegate respondsToSelector:@selector(calloutViewClicked:)])
@@ -762,7 +758,6 @@ static UIImage *blackArrowImage = nil, *whiteArrowImage = nil, *grayArrowImage =
     return layer;
 }
 
-#ifdef CHECK_CALLOUT_SHAPE_FOR_HIT_TEST
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
 
     // Only interested in providing a custom pointInside for touches.
@@ -780,7 +775,6 @@ static UIImage *blackArrowImage = nil, *whiteArrowImage = nil, *grayArrowImage =
 
     return NO;
 }
-#endif
 
 @end
 


### PR DESCRIPTION
Avoid selecting callout when tapping in blank space. Refs #11875

~This is currently enabled via a define `CHECK_CALLOUT_SHAPE_FOR_HIT_TEST`. We need to consider whether we use a runtime flag instead, or we remove the define/ifdef completely.~
