### PR TITLE
Release Android v6.1.2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ before_build:
 
 build_script:
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
-  - cmake -G "Ninja" -DMBGL_PLATFORM=qt -DWITH_QT_DECODERS=ON -DWITH_QT_I18N=ON -DWITH_NODEJS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=C:\Qt\5.7\msvc2015_64\lib\cmake -DCMAKE_MAKE_PROGRAM="%APPVEYOR_BUILD_FOLDER%\platform\qt\ninja.exe" ..
+  - cmake -G "Ninja" -DMBGL_PLATFORM=qt -DWITH_QT_DECODERS=ON -DWITH_QT_I18N=ON -DWITH_NODEJS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=C:\Qt\5.6.3\msvc2015_64\lib\cmake -DCMAKE_MAKE_PROGRAM="%APPVEYOR_BUILD_FOLDER%\platform\qt\ninja.exe" ..
   - cmake --build . -- -j %NUMBER_OF_PROCESSORS%
 
 after_build:

--- a/circle.yml
+++ b/circle.yml
@@ -422,7 +422,7 @@ jobs:
       - deploy:
           name: Publish to Maven
           command: |
-            if [ "${CIRCLE_BRANCH}" == "release-boba" ]; then make run-android-upload-archives ; fi
+            if [ "${CIRCLE_BRANCH}" == "release-android-v6.1.2" ]; then make run-android-upload-archives ; fi
 
 
 # ------------------------------------------------------------------------------

--- a/circle.yml
+++ b/circle.yml
@@ -422,7 +422,7 @@ jobs:
       - deploy:
           name: Publish to Maven
           command: |
-            if [ "${CIRCLE_BRANCH}" == "release-android-v6.1.2" ]; then make run-android-upload-archives ; fi
+            if [ "${CIRCLE_BRANCH}" == "release-boba" ]; then make run-android-upload-archives ; fi
 
 
 # ------------------------------------------------------------------------------

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 Mapbox welcomes participation and contributions from everyone.  If you'd like to do so please see the [`Contributing Guide`](https://github.com/mapbox/mapbox-gl-native/blob/master/CONTRIBUTING.md) first to get started.
 
-## 6.1.2
+## 6.1.2 - May 18, 2018
+ - Update telemetry to 3.1.1 [#11942](https://github.com/mapbox/mapbox-gl-native/pull/11942)
+
+## 6.2.0-alpha.1 - May 17, 2018
  - `"to-string"` expression operator converts `null` to empty string rather than to `"null"` [#11904](https://github.com/mapbox/mapbox-gl-native/pull/11904)
+ - Expose MapView#setOfflineRegion [#1922](https://github.com/mapbox/mapbox-gl-native/pull/11922)
+ - Add nullability annotations to public API for kotlin language integration [#11925](https://github.com/mapbox/mapbox-gl-native/pull/11925)
+ - Expose MapView created callbacks on MapFragment and SupportMapFragment [#11934](https://github.com/mapbox/mapbox-gl-native/pull/11934)
+ - Update mapbox-java to 3.1.0 [#11916](https://github.com/mapbox/mapbox-gl-native/pull/11916)
 
 ## 6.1.1 - May 7, 2018
  - Update telemetry to 3.1.0 [#11855](https://github.com/mapbox/mapbox-gl-native/pull/11855)
@@ -97,9 +104,9 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
  - Update javadoc configuration for Gradle 4.4 [#11384](https://github.com/mapbox/mapbox-gl-native/pull/11384)
  - Rework zoomIn and zoomOut to use ValueAnimators [#11382](https://github.com/mapbox/mapbox-gl-native/pull/11382)
  - Delete LocalRef when converting Image.java [#11350](https://github.com/mapbox/mapbox-gl-native/pull/11350)
- - Use float for pixelratio when creating a snapshotter [#11367](https://github.com/mapbox/mapbox-gl-native/pull/11367) 
+ - Use float for pixelratio when creating a snapshotter [#11367](https://github.com/mapbox/mapbox-gl-native/pull/11367)
  - Validate width/height when creating a snapshot [#11364](https://github.com/mapbox/mapbox-gl-native/pull/11364)
-  
+
 ## 6.0.0-beta.3 - March 2, 2018
  - Added missing local reference deletes [#11243](https://github.com/mapbox/mapbox-gl-native/pull/11243), [#11272](https://github.com/mapbox/mapbox-gl-native/pull/11272)
  - Remove obsolete camera api [#11201](https://github.com/mapbox/mapbox-gl-native/pull/11201)
@@ -122,7 +129,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
  - Add missing DeleteLocalRefs [#11272](https://github.com/mapbox/mapbox-gl-native/pull/11272)
  - Continue loading style even if we mutate it [#11294](https://github.com/mapbox/mapbox-gl-native/pull/11294)
  - Update telemetry version for OkHttp [#11338](https://github.com/mapbox/mapbox-gl-native/pull/11338)
- 
+
 ## 6.0.0-beta.2 - February 13, 2018
  - Deprecate LocationEngine [#11185](https://github.com/mapbox/mapbox-gl-native/pull/11185)
  - Remove LOST from SDK [11186](https://github.com/mapbox/mapbox-gl-native/pull/11186)
@@ -132,7 +139,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
  - AddImage performance improvement [#11111](https://github.com/mapbox/mapbox-gl-native/pull/11111)
  - Migrate MAS to 3.0.0, refactor GeoJson integration [#11149](https://github.com/mapbox/mapbox-gl-native/pull/11149)
  - Remove @jar and @aar dependency suffixes [#11161](https://github.com/mapbox/mapbox-gl-native/pull/11161)
- 
+
 ## 5.4.1 - February 9, 2018
  - Don't recreate TextureView surface as part of view resizing, solves OOM crashes [#11148](https://github.com/mapbox/mapbox-gl-native/pull/11148)
  - Don't invoke OnLowMemory before map is ready, solves startup crash on low memory devices [#11109](https://github.com/mapbox/mapbox-gl-native/pull/11109)
@@ -167,7 +174,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
  - Custom library loader [#10733](https://github.com/mapbox/mapbox-gl-native/pull/10733)
  - Inconsistent parameters for LatLngBounds.union [#10728](https://github.com/mapbox/mapbox-gl-native/pull/10728)
  - Gradle 4.1 / AS 3.0 [#10549](https://github.com/mapbox/mapbox-gl-native/pull/10549)
- 
+
 ## 5.3.2 - January 22, 2018
  - Validate surface creation before destroying [#10890](https://github.com/mapbox/mapbox-gl-native/pull/10890)
  - Add filesource activation ot OfflineRegion [#10904](https://github.com/mapbox/mapbox-gl-native/pull/10904)
@@ -177,7 +184,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
  - Allow changing the used OkHttpClient [#10948](https://github.com/mapbox/mapbox-gl-native/pull/10948)
  - Validate zoom level before creating telemetry event [#10959](https://github.com/mapbox/mapbox-gl-native/pull/10959)
  - Handle null call instances in HttpRequest [#10987](https://github.com/mapbox/mapbox-gl-native/pull/10987)
- 
+
 ## 5.3.1 - January 10, 2018
  - Blacklist binary program loading for Vivante GC4000 GPUs [#10862](https://github.com/mapbox/mapbox-gl-native/pull/10862)
  - Support Genymotion [#10841](https://github.com/mapbox/mapbox-gl-native/pull/10841)
@@ -188,11 +195,11 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
  - Allow configuring Http url logging when a request fails [#10830](https://github.com/mapbox/mapbox-gl-native/pull/10830)
  - Don't send double tap event multiple times for telemetry [#10854](https://github.com/mapbox/mapbox-gl-native/pull/10854)
  - Fix code generation [#10856](https://github.com/mapbox/mapbox-gl-native/pull/10856)
- - Use the correct cancelable callback after posting cancel [#10871](https://github.com/mapbox/mapbox-gl-native/pull/10871) 
-  
+ - Use the correct cancelable callback after posting cancel [#10871](https://github.com/mapbox/mapbox-gl-native/pull/10871)
+
 ## 5.3.0 - December 20, 2017
  - Add support for TinySDF [#10706](https://github.com/mapbox/mapbox-gl-native/pull/10706)
- - Save restore MyLocationViewSettings [#10746](https://github.com/mapbox/mapbox-gl-native/pull/10746) 
+ - Save restore MyLocationViewSettings [#10746](https://github.com/mapbox/mapbox-gl-native/pull/10746)
  - Post animation callback invocation [#10664](https://github.com/mapbox/mapbox-gl-native/pull/10664)
  - Allow configuring Http logging [#10681](https://github.com/mapbox/mapbox-gl-native/pull/10681)
  - Fix reverse scale gesture [#10688](https://github.com/mapbox/mapbox-gl-native/pull/10688)

--- a/platform/android/MapboxGLAndroidSDK/gradle.properties
+++ b/platform/android/MapboxGLAndroidSDK/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.mapbox.mapboxsdk
-VERSION_NAME=6.2.0-SNAPSHOT
+VERSION_NAME=6.1.2
 
 POM_DESCRIPTION=Mapbox GL Android SDK
 POM_URL=https://github.com/mapbox/mapbox-gl-native

--- a/platform/android/MapboxGLAndroidSDK/gradle.properties
+++ b/platform/android/MapboxGLAndroidSDK/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.mapbox.mapboxsdk
-VERSION_NAME=6.1.2
+VERSION_NAME=6.1.3-SNAPSHOT
 
 POM_DESCRIPTION=Mapbox GL Android SDK
 POM_URL=https://github.com/mapbox/mapbox-gl-native

--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
     versions = [
             mapboxServices : '3.0.1',
-            mapboxTelemetry: '3.1.0',
+            mapboxTelemetry: '3.1.1',
             mapboxGestures : '0.2.0',
             supportLib     : '25.4.0',
             espresso       : '3.0.1',

--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -145,6 +145,7 @@ elseif (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
     add_definitions("-Wno-unused-command-line-argument")
     add_definitions("-Wno-unused-local-typedef")
     add_definitions("-Wno-unused-private-field")
+    add_definitions("-Wno-inconsistent-missing-override")
 
     list(APPEND MBGL_QT_CORE_FILES
         PRIVATE platform/qt/src/thread.cpp


### PR DESCRIPTION
This PR cherry picks #11942 and releases a stable new version of the SDK on Maven.