### PR TITLE
[node] prevent race condition for renderFinished

### DIFF
--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -447,6 +447,12 @@ void NodeMap::startRender(NodeMap::RenderOptions options) {
 }
 
 void NodeMap::renderFinished() {
+    if (!callback) {
+        // In some situations, the render finishes at the same time as we call cancel. Make sure
+        // we are only finishing a render once.
+        return;
+    }
+
     Nan::HandleScope scope;
 
     // We're done with this render call, so we're unrefing so that the loop could close.


### PR DESCRIPTION
This happens when the render finished on the thread, and the user cancels a request in the same event loop iteration. There's an assert in Nan that catches this for Debug builds, but won't prevent it for release builds.

In addition to possibly invoking undefined behavior when we try to call an empty callback, or try to access empty image data, there's a heinous memory leak. Here's what happens when we call `Unref()` twice as part of `renderFinished`:

refcount changes during a render with the above mentioned race condition that leads to `renderFinished` being called twice:
```
    initial: 0
    Ref() -> 1, calls ClearWeak()
    Unref() -> 0, calls MakeWeak()
    Unref() -> -1
```

next render:
```
    initial: -1 (!)
    Ref() -> 0, calls ClearWeak()
    Unref() -> -1   ==> MakeWeak() is not called!
```

From now on, this Map object can _never_ be garbage collected, since the refcount is negative, which means that `MakeWeak()` will never be called as part of `Unref()`.


