### PR TITLE
[core] Align URL token replacement behavior with GL JS

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Mapbox welcomes participation and contributions from everyone.  If you'd like to do so please see the [`Contributing Guide`](https://github.com/mapbox/mapbox-gl-native/blob/master/CONTRIBUTING.md) first to get started.
 
+## master
+- Unknown tokens in URLs are now preserved, rather than replaced with an empty string [#11787](https://github.com/mapbox/mapbox-gl-native/issues/11787)
+
 ## 6.1.2 - May 18, 2018
  - Update telemetry to 3.1.1 [#11942](https://github.com/mapbox/mapbox-gl-native/pull/11942)
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -12,6 +12,10 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Added support for aggregate expressions as input values to `MGL_MATCH` expressions. ([#11866](https://github.com/mapbox/mapbox-gl-native/pull/11866))
 
+### Other changes
+
+* Unknown tokens in URLs are now preserved, rather than replaced with an empty string. ([#11787](https://github.com/mapbox/mapbox-gl-native/issues/11787))
+
 ## 4.0.1 - May 14, 2018
 
 ### Packaging

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 * Added support for aggregate expressions as input values to `MGL_MATCH` expressions. ([#11866](https://github.com/mapbox/mapbox-gl-native/pull/11866))
 
+### Other changes
+
+* Unknown tokens in URLs are now preserved, rather than replaced with an empty string. ([#11787](https://github.com/mapbox/mapbox-gl-native/issues/11787))
+
 ## 0.7.1
 
 ### Style layers

--- a/src/mbgl/storage/resource.cpp
+++ b/src/mbgl/storage/resource.cpp
@@ -79,13 +79,13 @@ Resource Resource::spriteJSON(const std::string& base, float pixelRatio) {
 Resource Resource::glyphs(const std::string& urlTemplate, const FontStack& fontStack, const std::pair<uint16_t, uint16_t>& glyphRange) {
     return Resource {
         Resource::Kind::Glyphs,
-        util::replaceTokens(urlTemplate, [&](const std::string& token) {
+        util::replaceTokens(urlTemplate, [&](const std::string& token) -> optional<std::string> {
             if (token == "fontstack") {
                 return util::percentEncode(fontStackToString(fontStack));
             } else if (token == "range") {
                 return util::toString(glyphRange.first) + "-" + util::toString(glyphRange.second);
             } else {
-                return std::string();
+                return {};
             }
         })
     };
@@ -104,7 +104,7 @@ Resource Resource::tile(const std::string& urlTemplate,
     }
     return Resource {
         Resource::Kind::Tile,
-        util::replaceTokens(urlTemplate, [&](const std::string& token) {
+        util::replaceTokens(urlTemplate, [&](const std::string& token) -> optional<std::string> {
             if (token == "z") {
                 return util::toString(z);
             } else if (token == "x") {
@@ -123,7 +123,7 @@ Resource Resource::tile(const std::string& urlTemplate,
             } else if (token == "ratio") {
                 return std::string(pixelRatio > 1.0 ? "@2x" : "");
             } else {
-                return std::string();
+                return {};
             }
         }),
         Resource::TileData {

--- a/src/mbgl/util/token.hpp
+++ b/src/mbgl/util/token.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mbgl/util/optional.hpp>
+
 #include <map>
 #include <string>
 #include <algorithm>
@@ -25,7 +27,14 @@ std::string replaceTokens(const std::string &source, const Lookup &lookup) {
         if (pos != end) {
             for (brace++; brace != end && tokenReservedChars.find(*brace) == std::string::npos; brace++);
             if (brace != end && *brace == '}') {
-                result.append(lookup({ pos + 1, brace }));
+                std::string key { pos + 1, brace };
+                if (optional<std::string> replacement = lookup(key)) {
+                    result.append(*replacement);
+                } else {
+                    result.append("{");
+                    result.append(key);
+                    result.append("}");
+                }
                 pos = brace + 1;
             } else {
                 result.append(pos, brace);

--- a/src/mbgl/util/url.cpp
+++ b/src/mbgl/util/url.cpp
@@ -130,7 +130,7 @@ Path::Path(const std::string& str, const size_t pos, const size_t count)
 }
 
 std::string transformURL(const std::string& tpl, const std::string& str, const URL& url) {
-    auto result = util::replaceTokens(tpl, [&](const std::string& token) -> std::string {
+    auto result = util::replaceTokens(tpl, [&](const std::string& token) -> optional<std::string> {
         if (token == "path") {
             return str.substr(url.path.first, url.path.second);
         } else if (token == "domain") {
@@ -146,8 +146,9 @@ std::string transformURL(const std::string& tpl, const std::string& str, const U
         } else if (token == "extension") {
             const Path path(str, url.path.first, url.path.second);
             return str.substr(path.extension.first, path.extension.second);
+        } else {
+            return {};
         }
-        return "";
     });
 
     // Append the query string if it exists.

--- a/test/util/token.test.cpp
+++ b/test/util/token.test.cpp
@@ -47,4 +47,7 @@ TEST(Token, replaceTokens) {
         if (token == "HØYDE") return "150";
         return "";
     }));
+    EXPECT_EQ("{unknown}", mbgl::util::replaceTokens("{unknown}", [](const std::string&) -> optional<std::string> {
+        return {};
+    }));
 }


### PR DESCRIPTION
I.e. preserve unknown tokens in URLs rather than replacing them with an empty string.

Fixes #11787.