### PR TITLE
[ios, macos] Fix keypath expressions, json object is parsed incorrectly for nested keypaths.

### DIFF
--- a/platform/darwin/src/NSExpression+MGLAdditions.mm
+++ b/platform/darwin/src/NSExpression+MGLAdditions.mm
@@ -1070,7 +1070,8 @@ NSArray *MGLSubexpressionsWithJSONObjects(NSArray *objects) {
             
         case NSKeyPathExpressionType: {
             NSArray *expressionObject;
-            for (NSString *pathComponent in self.keyPath.pathComponents.reverseObjectEnumerator) {
+            NSArray *keyPath = [self.keyPath componentsSeparatedByString:@"."];
+            for (NSString *pathComponent in keyPath) {
                 if (expressionObject) {
                     expressionObject = @[@"get", pathComponent, expressionObject];
                 } else {

--- a/platform/darwin/test/MGLExpressionTests.mm
+++ b/platform/darwin/test/MGLExpressionTests.mm
@@ -306,6 +306,18 @@ using namespace std::string_literals;
         XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
         XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression], expression);
     }
+    {
+        NSExpression *expression = [NSExpression expressionForKeyPath:@"lineStyle.color"];
+        NSArray *jsonExpression = @[@"get", @"color", @[@"get", @"lineStyle"]];
+        XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
+        XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression], expression);
+    }
+    {
+        NSExpression *expression = [NSExpression expressionForKeyPath:@"map.box.gl"];
+        NSArray *jsonExpression = @[@"get", @"gl", @[@"get", @"box", @[@"get", @"map"]]];
+        XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
+        XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression], expression);
+    }
 }
 
 - (void)testStatisticalExpressionObject {

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -17,6 +17,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Unknown tokens in URLs are now preserved, rather than replaced with an empty string. ([#11787](https://github.com/mapbox/mapbox-gl-native/issues/11787))
 * Adjusted when and how the camera transition update and finish callbacks are called, fixing recursion bugs. ([#11614](https://github.com/mapbox/mapbox-gl-native/pull/11614))
 * Improved application launch performance.
+* Fixed an issue preventing nested key path expressions get parsed accordingly to the spec. ([#11959](https://github.com/mapbox/mapbox-gl-native/pull/11959))
 
 ## 4.0.1 - May 14, 2018
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * Unknown tokens in URLs are now preserved, rather than replaced with an empty string. ([#11787](https://github.com/mapbox/mapbox-gl-native/issues/11787))
 * Adjusted when and how the camera transition update and finish callbacks are called, fixing recursion bugs. ([#11614](https://github.com/mapbox/mapbox-gl-native/pull/11614))
+* Fixed an issue preventing nested key path expressions get parsed accordingly to the spec. ([#11959](https://github.com/mapbox/mapbox-gl-native/pull/11959))
 
 ## 0.7.1
 


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/11874