### PR TITLE
Accept constant expressions in non-dds properties

### DIFF
--- a/cmake/test-files.cmake
+++ b/cmake/test-files.cmake
@@ -79,6 +79,7 @@ set(MBGL_TEST_FILES
     test/style/conversion/geojson_options.test.cpp
     test/style/conversion/layer.test.cpp
     test/style/conversion/light.test.cpp
+    test/style/conversion/property_value.test.cpp
     test/style/conversion/stringify.test.cpp
     test/style/conversion/tileset.test.cpp
 

--- a/include/mbgl/style/conversion/property_value.hpp
+++ b/include/mbgl/style/conversion/property_value.hpp
@@ -29,11 +29,19 @@ struct Converter<PropertyValue<T>> {
                 return {};
             }
 
-            if (isFeatureConstant(**expression)) {
-                return { CameraFunction<T>(std::move(*expression)) };
-            } else {
+            if (!isFeatureConstant(**expression)) {
                 error = { "property expressions not supported" };
                 return {};
+            } else if (!isZoomConstant(**expression)) {
+                return { CameraFunction<T>(std::move(*expression)) };
+            } else {
+                auto literal = dynamic_cast<Literal*>(expression->get());
+                assert(literal);
+                optional<T> constant = fromExpressionValue<T>(literal->getValue());
+                if (!constant) {
+                    return {};
+                }
+                return PropertyValue<T>(*constant);
             }
         } else if (isObject(value)) {
             optional<CameraFunction<T>> function = convert<CameraFunction<T>>(value, error);

--- a/test/style/conversion/property_value.test.cpp
+++ b/test/style/conversion/property_value.test.cpp
@@ -1,0 +1,21 @@
+#include <mbgl/test/util.hpp>
+
+#include <mbgl/style/conversion/json.hpp>
+#include <mbgl/style/conversion/property_value.hpp>
+#include <mbgl/util/rapidjson.hpp>
+
+using namespace mbgl;
+using namespace mbgl::style;
+using namespace mbgl::style::conversion;
+
+TEST(StyleConversion, PropertyValue) {
+    // PropertyValue<T> accepts a constant expression: https://github.com/mapbox/mapbox-gl-native/issues/11940
+    Error error;
+    JSDocument doc;
+    doc.Parse<0>(R"(["literal", [1, 2]])");
+    auto expected = std::array<float, 2>{{1, 2}};
+    auto result = convert<PropertyValue<std::array<float, 2>>>(doc, error);
+    ASSERT_TRUE(result);
+    ASSERT_TRUE(result->isConstant());
+    ASSERT_EQ(result->asConstant(), expected);
+}


### PR DESCRIPTION
Closes #11940

Needs backport to `release-boba`