### PR TITLE
Clamp TileJSON.bounds latitudes to [-90, 90]

### DIFF
--- a/test/style/conversion/tileset.test.cpp
+++ b/test/style/conversion/tileset.test.cpp
@@ -66,7 +66,7 @@ TEST(Tileset, BoundsAreClamped) {
     Error error;
     mbgl::optional<Tileset> converted = convertJSON<Tileset>(R"JSON({
         "tiles": ["http://mytiles"],
-        "bounds": [-181.0000005,-90,180.00000000000006,90]
+        "bounds": [-181.0000005,-90.000000006,180.00000000000006,91]
     })JSON", error);
     EXPECT_TRUE((bool) converted);
     EXPECT_EQ(converted->bounds, LatLngBounds::hull({90, -180}, {-90, 180}));


### PR DESCRIPTION
Fixes #11963.

cc @ian29 @kkaefer 