### PR TITLE
[WIP] [ios, macos] Calculate number of tiles for an offline region

### DIFF
--- a/platform/darwin/src/MGLOfflineRegion.h
+++ b/platform/darwin/src/MGLOfflineRegion.h
@@ -11,8 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol MGLOfflineRegion <NSObject>
 
 /**
- The number of tiles that the object conforming to the `MGLOfflineRegion`
- protocol contains.
+ The number of tiles needed to load one of the style’s sources within the region.
  */
 @property (nonatomic, readonly) uint64_t tileCount;
 

--- a/platform/darwin/src/MGLOfflineRegion.h
+++ b/platform/darwin/src/MGLOfflineRegion.h
@@ -10,6 +10,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @protocol MGLOfflineRegion <NSObject>
 
+/**
+ The number of tiles that the object conforming to the `MGLOfflineRegion`
+ protocol contains.
+ */
+@property (nonatomic, readonly) uint64_t tileCount;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLOfflineRegion.h
+++ b/platform/darwin/src/MGLOfflineRegion.h
@@ -2,6 +2,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class MGLTileSource;
+
 /**
  An object conforming to the `MGLOfflineRegion` protocol determines which
  resources are required by an `MGLOfflinePack` object. At present, only
@@ -13,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The number of tiles needed to load one of the style’s sources within the region.
  */
-@property (nonatomic, readonly) uint64_t tileCount;
+-(uint64_t)countTilesForTileSource:(MGLTileSource *)tileSource;
 
 @end
 

--- a/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
+++ b/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
@@ -7,6 +7,7 @@
 #import "MGLOfflineRegion_Private.h"
 #import "MGLGeometry_Private.h"
 #import "MGLStyle.h"
+#import "MGLTileSource.h"
 
 @interface MGLTilePyramidOfflineRegion () <MGLOfflineRegion_Private>
 
@@ -53,8 +54,10 @@
     return self;
 }
 
--(uint64_t)tileCount {
+-(uint64_t)tileCount:(MGLTileSource *)tileSource {
     auto tilePyramidOfflineRegion = [self offlineRegionDefinition];
+    // TODO: Figure out how to work with the MGLTileSource here
+    // TODO: Pass tile type and size into the below method
     return tilePyramidOfflineRegion.tileCount(mbgl::style::SourceType::Vector, 512, {static_cast<unsigned char>(tilePyramidOfflineRegion.minZoom), static_cast<unsigned char>(tilePyramidOfflineRegion.maxZoom)});
 }
 

--- a/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
+++ b/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
@@ -8,6 +8,7 @@
 #import "MGLGeometry_Private.h"
 #import "MGLStyle.h"
 #import "MGLTileSource.h"
+#import "MGLVectorTileSource.h"
 
 @interface MGLTilePyramidOfflineRegion () <MGLOfflineRegion_Private>
 
@@ -54,11 +55,18 @@
     return self;
 }
 
--(uint64_t)tileCount:(MGLTileSource *)tileSource {
+-(uint64_t)countTilesForTileSource:(MGLTileSource *)tileSource {
     auto tilePyramidOfflineRegion = [self offlineRegionDefinition];
-    // TODO: Figure out how to work with the MGLTileSource here
-    // TODO: Pass tile type and size into the below method
-    return tilePyramidOfflineRegion.tileCount(mbgl::style::SourceType::Vector, 512, {static_cast<unsigned char>(tilePyramidOfflineRegion.minZoom), static_cast<unsigned char>(tilePyramidOfflineRegion.maxZoom)});
+    
+    mbgl::style::SourceType sourceType;
+
+    if ([tileSource isKindOfClass:[MGLVectorTileSource class]]) {
+        sourceType = mbgl::style::SourceType::Vector;
+    } else  {
+        sourceType = mbgl::style::SourceType::Raster;
+    }
+    
+    return tilePyramidOfflineRegion.tileCount(sourceType, 512, {static_cast<unsigned char>(tilePyramidOfflineRegion.minZoom), static_cast<unsigned char>(tilePyramidOfflineRegion.maxZoom)});
 }
 
 - (instancetype)initWithOfflineRegionDefinition:(const mbgl::OfflineRegionDefinition &)definition {

--- a/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
+++ b/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
@@ -53,6 +53,11 @@
     return self;
 }
 
+-(uint64_t)tileCount {
+    auto tilePyramidOfflineRegion = [self offlineRegionDefinition];
+    return tilePyramidOfflineRegion.tileCount(mbgl::style::SourceType::Vector, 512, {static_cast<unsigned char>(tilePyramidOfflineRegion.minZoom), static_cast<unsigned char>(tilePyramidOfflineRegion.maxZoom)});
+}
+
 - (instancetype)initWithOfflineRegionDefinition:(const mbgl::OfflineRegionDefinition &)definition {
     NSURL *styleURL = [NSURL URLWithString:@(definition.styleURL.c_str())];
     MGLCoordinateBounds bounds = MGLCoordinateBoundsFromLatLngBounds(definition.bounds);

--- a/platform/darwin/test/MGLOfflineRegionTests.m
+++ b/platform/darwin/test/MGLOfflineRegionTests.m
@@ -29,4 +29,6 @@
     XCTAssertEqual(original.maximumZoomLevel, original.maximumZoomLevel, @"Maximum zoom level has changed.");
 }
 
+// TODO: Add tileCount test(s)
+
 @end


### PR DESCRIPTION
Draft implementation for https://github.com/mapbox/mapbox-gl-native/issues/11504

Adds a new method which calculates the number of tiles within an `MGLTilePyramidOfflineRegion`.

This is implemented within the `MGLOfflineRegion` protocol in hopes of this one day applying to offline regions with arbitrary shapes, as mentioned in https://github.com/mapbox/mapbox-gl-native/pull/11447. This is very much a work in progress.