### PR TITLE
[core] fix hang when parsing very large angles for hue in hsl colors

### DIFF
--- a/src/csscolorparser/csscolorparser.cpp
+++ b/src/csscolorparser/csscolorparser.cpp
@@ -185,7 +185,6 @@ optional<Color> parse(const std::string& css_str) {
     // Convert to lowercase.
     std::transform(str.begin(), str.end(), str.begin(), ::tolower);
 
-
     for (const auto& namedColor : namedColors) {
         if (str == namedColor.name) {
             return { namedColor.color };
@@ -262,8 +261,9 @@ optional<Color> parse(const std::string& css_str) {
             }
 
             float h = parseFloat(params[0]) / 360.0f;
-            while (h < 0.0f) h++;
-            while (h > 1.0f) h--;
+            float i;
+            // Normalize the hue to [0..1[
+            h = std::modf(h, &i);
 
             // NOTE(deanm): According to the CSS spec s/l should only be
             // percentages, but we don't bother and let float or percentage.


### PR DESCRIPTION
Brings in https://github.com/mapbox/css-color-parser-cpp/commit/325ad381167163a14c1480b3fe3b4384e9f08b01