### PR TITLE
[core] Use std::ios::binary format in std::ifstream

### DIFF
--- a/src/mbgl/util/io.cpp
+++ b/src/mbgl/util/io.cpp
@@ -20,7 +20,7 @@ void write_file(const std::string &filename, const std::string &data) {
 }
 
 std::string read_file(const std::string &filename) {
-    std::ifstream file(filename);
+    std::ifstream file(filename, std::ios::binary);
     if (file.good()) {
         std::stringstream data;
         data << file.rdbuf();
@@ -31,7 +31,7 @@ std::string read_file(const std::string &filename) {
 }
 
 optional<std::string> readFile(const std::string &filename) {
-    std::ifstream file(filename);
+    std::ifstream file(filename, std::ios::binary);
     if (file.good()) {
         std::stringstream data;
         data << file.rdbuf();


### PR DESCRIPTION
Apparently, MSVC2015+ has issues with `std::ifstream` when the default type `std::ios::in` is used for blob data. Enforcing `std::ios::binary` should fix that.

Fixes https://github.com/mapbox/mapbox-gl-native/issues/11971.