### PR TITLE
Style JSON configuration on map snapshotter

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
@@ -86,6 +86,7 @@ public class MapSnapshotter {
     private int width;
     private int height;
     private String styleUrl = Style.MAPBOX_STREETS;
+    private String styleJson;
     private LatLngBounds region;
     private CameraPosition cameraPosition;
     private boolean showLogo = true;
@@ -108,6 +109,15 @@ public class MapSnapshotter {
      */
     public Options withStyle(String url) {
       this.styleUrl = url;
+      return this;
+    }
+
+    /**
+     * @param styleJson The style json to use
+     * @return the mutated {@link Options}
+     */
+    public Options withStyleJson(String styleJson) {
+      this.styleJson = styleJson;
       return this;
     }
 
@@ -208,7 +218,7 @@ public class MapSnapshotter {
     String programCacheDir = context.getCacheDir().getAbsolutePath();
 
     nativeInitialize(this, fileSource, options.pixelRatio, options.width,
-      options.height, options.styleUrl, options.region, options.cameraPosition,
+      options.height, options.styleUrl, options.styleJson, options.region, options.cameraPosition,
       options.showLogo, programCacheDir);
   }
 
@@ -462,7 +472,7 @@ public class MapSnapshotter {
 
   protected native void nativeInitialize(MapSnapshotter mapSnapshotter,
                                          FileSource fileSource, float pixelRatio,
-                                         int width, int height, String styleUrl,
+                                         int width, int height, String styleUrl, String styleJson,
                                          LatLngBounds region, CameraPosition position,
                                          boolean showLogo, String programCacheDir);
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -345,6 +345,17 @@
                 android:value=".activity.FeatureOverviewActivity" />
         </activity>
         <activity
+                android:name=".activity.snapshot.MapSnapshotterLocalStyleActivity"
+                android:description="@string/description_map_snapshotter_local_style"
+                android:label="@string/activity_map_snapshotter_local_style">
+            <meta-data
+                    android:name="@string/category"
+                    android:value="@string/category_imagegenerator" />
+            <meta-data
+                    android:name="android.support.PARENT_ACTIVITY"
+                    android:value=".activity.FeatureOverviewActivity" />
+        </activity>
+        <activity
             android:name=".activity.maplayout.DoubleMapActivity"
             android:description="@string/description_doublemap"
             android:label="@string/activity_double_map">

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/snapshot/MapSnapshotterLocalStyleActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/snapshot/MapSnapshotterLocalStyleActivity.java
@@ -1,0 +1,71 @@
+package com.mapbox.mapboxsdk.testapp.activity.snapshot;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.view.ViewTreeObserver;
+import android.widget.ImageView;
+import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.snapshotter.MapSnapshot;
+import com.mapbox.mapboxsdk.snapshotter.MapSnapshotter;
+import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.testapp.utils.ResourceUtils;
+import timber.log.Timber;
+
+import java.io.IOException;
+
+/**
+ * Test activity showing how to use a the MapSnapshotter with a local style
+ */
+public class MapSnapshotterLocalStyleActivity extends AppCompatActivity
+  implements MapSnapshotter.SnapshotReadyCallback {
+
+  private MapSnapshotter mapSnapshotter;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_map_snapshotter_marker);
+
+    final View container = findViewById(R.id.container);
+    container.getViewTreeObserver()
+      .addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+        @Override
+        public void onGlobalLayout() {
+          //noinspection deprecation
+          container.getViewTreeObserver().removeGlobalOnLayoutListener(this);
+
+          String styleJson;
+          try {
+            styleJson = ResourceUtils.readRawResource(MapSnapshotterLocalStyleActivity.this, R.raw.sat_style);
+          } catch (IOException exception) {
+            throw new RuntimeException(exception);
+          }
+
+          Timber.i("Starting snapshot");
+          mapSnapshotter = new MapSnapshotter(
+            getApplicationContext(),
+            new MapSnapshotter
+              .Options(Math.min(container.getMeasuredWidth(), 1024), Math.min(container.getMeasuredHeight(), 1024))
+              .withStyleJson(styleJson)
+              .withCameraPosition(new CameraPosition.Builder().target(new LatLng(52.090737, 5.121420)).zoom(18).build())
+          );
+          mapSnapshotter.start(MapSnapshotterLocalStyleActivity.this, error -> Timber.e(error));
+        }
+      });
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapSnapshotter.cancel();
+  }
+
+  @Override
+  public void onSnapshotReady(MapSnapshot snapshot) {
+    Timber.i("Snapshot ready");
+    ImageView imageView = (ImageView) findViewById(R.id.snapshot_image);
+    imageView.setImageBitmap(snapshot.getBitmap());
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
@@ -57,6 +57,7 @@
     <string name="description_map_snapshotter">Show a static bitmap taken with the MapSnapshotter</string>
     <string name="description_map_snapshotter_reuse">Show how to reuse a MapSnapshotter instance</string>
     <string name="description_map_snapshotter_marker">Show how to add a marker to a Snapshot</string>
+    <string name="description_map_snapshotter_local_style">Show how to load a local style with a Snapshot</string>
     <string name="description_camera_animator">Use Android SDK Animators to animate camera position changes</string>
     <string name="description_symbol_generator">Use Android SDK Views as symbols</string>
     <string name="description_textureview_debug">Use TextureView to render the map</string>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
@@ -57,6 +57,7 @@
     <string name="activity_map_snapshotter">Map Snapshotter</string>
     <string name="activity_map_snapshotter_reuse">Map Snapshotter Reuse</string>
     <string name="activity_map_snapshotter_marker">Map Snapshot with marker</string>
+    <string name="activity_map_snapshotter_local_style">Map Snapshot with local style</string>
     <string name="activity_camera_animator">Animator animation</string>
     <string name="activity_symbol_generator">SymbolGenerator</string>
     <string name="activity_textureview_debug">TextureView debug</string>

--- a/platform/android/scripts/exclude-activity-gen.json
+++ b/platform/android/scripts/exclude-activity-gen.json
@@ -2,6 +2,7 @@
   "BaseLocationActivity",
   "MapSnapshotterMarkerActivity",
   "MapSnapshotterReuseActivity",
+  "MapSnapshotterLocalStyleActivity",
   "LatLngBoundsActivity",
   "BottomSheetActivity",
   "MapSnapshotterActivity",

--- a/platform/android/src/snapshotter/map_snapshotter.cpp
+++ b/platform/android/src/snapshotter/map_snapshotter.cpp
@@ -20,6 +20,7 @@ MapSnapshotter::MapSnapshotter(jni::JNIEnv& _env,
                                jni::jint width,
                                jni::jint height,
                                jni::String styleURL,
+                               jni::String styleJSON,
                                jni::Object<LatLngBounds> region,
                                jni::Object<CameraPosition> position,
                                jni::jboolean _showLogo,
@@ -42,12 +43,19 @@ MapSnapshotter::MapSnapshotter(jni::JNIEnv& _env,
     if (region) {
         bounds = LatLngBounds::getLatLngBounds(_env, region);
     }
+
+    std::pair<bool, std::string> style;
+    if (styleJSON) {
+        style = std::make_pair(true, jni::Make<std::string>(_env, styleJSON));
+    } else {
+        style = std::make_pair(false, jni::Make<std::string>(_env, styleURL));
+    }
     
     showLogo = _showLogo;
     // Create the core snapshotter
     snapshotter = std::make_unique<mbgl::MapSnapshotter>(fileSource,
                                                          *threadPool,
-                                                         jni::Make<std::string>(_env, styleURL),
+                                                         style,
                                                          size,
                                                          pixelRatio,
                                                          cameraOptions,
@@ -141,7 +149,7 @@ void MapSnapshotter::registerNative(jni::JNIEnv& env) {
 
     // Register the peer
     jni::RegisterNativePeer<MapSnapshotter>(env, MapSnapshotter::javaClass, "nativePtr",
-                                            std::make_unique<MapSnapshotter, JNIEnv&, jni::Object<MapSnapshotter>, jni::Object<FileSource>, jni::jfloat, jni::jint, jni::jint, jni::String, jni::Object<LatLngBounds>, jni::Object<CameraPosition>, jni::jboolean, jni::String>,
+                                            std::make_unique<MapSnapshotter, JNIEnv&, jni::Object<MapSnapshotter>, jni::Object<FileSource>, jni::jfloat, jni::jint, jni::jint, jni::String, jni::String, jni::Object<LatLngBounds>, jni::Object<CameraPosition>, jni::jboolean, jni::String>,
                                            "nativeInitialize",
                                            "finalize",
                                             METHOD(&MapSnapshotter::setStyleUrl, "setStyleUrl"),

--- a/platform/android/src/snapshotter/map_snapshotter.hpp
+++ b/platform/android/src/snapshotter/map_snapshotter.hpp
@@ -34,6 +34,7 @@ public:
                    jni::jint width,
                    jni::jint height,
                    jni::String styleURL,
+                   jni::String styleJSON,
                    jni::Object<LatLngBounds> region,
                    jni::Object<CameraPosition> position,
                    jni::jboolean showLogo,

--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -428,6 +428,7 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
     _mbglThreadPool = mbgl::sharedThreadPool();
     
     std::string styleURL = std::string([options.styleURL.absoluteString UTF8String]);
+    std::pair<bool, std::string> style = std::make_pair(false, styleURL);
     
     // Size; taking into account the minimum texture size for OpenGL ES
     // For non retina screens the ratio is 1:1 MGLSnapshotterMinimumPixelSize
@@ -454,7 +455,7 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
     }
     
     // Create the snapshotter
-    _mbglMapSnapshotter = std::make_unique<mbgl::MapSnapshotter>(*mbglFileSource, *_mbglThreadPool, styleURL, size, pixelRatio, cameraOptions, coordinateBounds);
+    _mbglMapSnapshotter = std::make_unique<mbgl::MapSnapshotter>(*mbglFileSource, *_mbglThreadPool, style, size, pixelRatio, cameraOptions, coordinateBounds);
 }
 
 @end

--- a/platform/default/mbgl/map/map_snapshotter.cpp
+++ b/platform/default/mbgl/map/map_snapshotter.cpp
@@ -15,7 +15,7 @@ class MapSnapshotter::Impl {
 public:
     Impl(FileSource&,
          Scheduler&,
-         const std::string& styleURL,
+         const std::pair<bool, std::string> style,
          const Size&,
          const float pixelRatio,
          const CameraOptions&,
@@ -43,7 +43,7 @@ private:
 
 MapSnapshotter::Impl::Impl(FileSource& fileSource,
            Scheduler& scheduler,
-           const std::string& styleURL,
+           const std::pair<bool, std::string> style,
            const Size& size,
            const float pixelRatio,
            const CameraOptions& cameraOptions,
@@ -52,8 +52,11 @@ MapSnapshotter::Impl::Impl(FileSource& fileSource,
     : frontend(size, pixelRatio, fileSource, scheduler, programCacheDir)
     , map(frontend, MapObserver::nullObserver(), size, pixelRatio, fileSource, scheduler, MapMode::Static) {
 
-    map.getStyle().loadURL(styleURL);
-
+    if (style.first) {
+        map.getStyle().loadJSON(style.second);
+    } else{
+        map.getStyle().loadURL(style.second);
+    }
     map.jumpTo(cameraOptions);
 
     // Set region, if specified
@@ -134,13 +137,13 @@ LatLngBounds MapSnapshotter::Impl::getRegion() const {
 
 MapSnapshotter::MapSnapshotter(FileSource& fileSource,
                                Scheduler& scheduler,
-                               const std::string& styleURL,
+                               const std::pair<bool, std::string> style,
                                const Size& size,
                                const float pixelRatio,
                                const CameraOptions& cameraOptions,
                                const optional<LatLngBounds> region,
                                const optional<std::string> programCacheDir)
-   : impl(std::make_unique<util::Thread<MapSnapshotter::Impl>>("Map Snapshotter", fileSource, scheduler, styleURL, size, pixelRatio, cameraOptions, region, programCacheDir)) {
+   : impl(std::make_unique<util::Thread<MapSnapshotter::Impl>>("Map Snapshotter", fileSource, scheduler, style, size, pixelRatio, cameraOptions, region, programCacheDir)) {
 }
 
 MapSnapshotter::~MapSnapshotter() = default;

--- a/platform/default/mbgl/map/map_snapshotter.hpp
+++ b/platform/default/mbgl/map/map_snapshotter.hpp
@@ -27,7 +27,7 @@ class MapSnapshotter {
 public:
     MapSnapshotter(FileSource& fileSource,
                    Scheduler& scheduler,
-                   const std::string& styleURL,
+                   const std::pair<bool, std::string> style,
                    const Size&,
                    const float pixelRatio,
                    const CameraOptions&,


### PR DESCRIPTION
Closes #11974 , this PR adds the ability to use a local style.json file as style for a map snapshotter. This option is needed to port our node render tests to Android in https://github.com/mapbox/mapbox-gl-native/issues/10047.

@LukasPaczos would you be able to review the java code?
@ChrisLoer would you be able to review the core code? (I'm not satisfied with current optional setup, is there a way to make this cleaner? variant or other c++ construct?)

