### PR TITLE
[core] fix deduping rings in querying, #11357

### DIFF
--- a/src/mbgl/geometry/feature_index.cpp
+++ b/src/mbgl/geometry/feature_index.cpp
@@ -25,13 +25,14 @@ void FeatureIndex::insert(const GeometryCollection& geometries,
                           std::size_t index,
                           const std::string& sourceLayerName,
                           const std::string& bucketLeaderID) {
+    auto featureSortIndex = sortIndex++;
     for (const auto& ring : geometries) {
         auto envelope = mapbox::geometry::envelope(ring);
         if (envelope.min.x < util::EXTENT &&
             envelope.min.y < util::EXTENT &&
             envelope.max.x >= 0 &&
             envelope.max.y >= 0) {
-            grid.insert(IndexedSubfeature(index, sourceLayerName, bucketLeaderID, sortIndex++),
+            grid.insert(IndexedSubfeature(index, sourceLayerName, bucketLeaderID, featureSortIndex++),
                         {convertPoint<float>(envelope.min), convertPoint<float>(envelope.max)});
         }
     }


### PR DESCRIPTION
fix #11357

Different rings for the same feature were being assigned different indices. This assigns the same index to all features. -js already has the correct behaviour.

cc @mb12 @ChrisLoer 