### PR TITLE
Set Tile loaded/rendered instead of marking tile as optional.

### DIFF
--- a/src/mbgl/tile/custom_geometry_tile.cpp
+++ b/src/mbgl/tile/custom_geometry_tile.cpp
@@ -38,9 +38,9 @@ void CustomGeometryTile::setTileData(const GeoJSON& geoJSON) {
         vtOptions.extent = util::EXTENT;
         vtOptions.buffer = ::round(scale * options.buffer);
         vtOptions.tolerance = scale * options.tolerance;
-        featureData = mapbox::geojsonvt::geoJSONToTile(geoJSON, id.canonical.z, id.canonical.x, id.canonical.y, vtOptions, options.wrap, options.clip).features;
-    } else {
-        setNecessity(TileNecessity::Optional);
+        featureData = mapbox::geojsonvt::geoJSONToTile(geoJSON,
+            id.canonical.z, id.canonical.x, id.canonical.y,
+            vtOptions, options.wrap, options.clip).features;
     }
     setData(std::make_unique<GeoJSONTileData>(std::move(featureData)));
 }


### PR DESCRIPTION
Fixes #11957.

When a tile has no features `CustomGeometryTile::setTileData` marks it as `TileNecessity::optional`, before calling `GeometryTile:setData`. This call to `setData` triggers parse and layout on the `GeometryTileWorker` and the worker will subsequently update the tile, which requests a new render frame. In the next frame, the tile is marked as `TileNecessity::Required` again, triggerring a reload of the tile data and subsequent repeat layout of the empty feature data - creating a never-ending loop.

The fix here is to mark the tile as `loaded` and `renderable` instead of `optional`. This way the tile skips layout (and placement) and does not incur future reloads until evicted fro the tile cache. 

Verified the fix on iOS, macOS, and Android. CPU consumption drops back to 0 and tiles behave correctly.

The one thing I am not sure of in this approach is using the `loaded` and `renderable` protected members from the `Tile` parent class. 

cc @ChrisLoer @fabian-guerra  