### PR TITLE
[build] disable parts of the build that require node when WITH_NODEJS=OFF is set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,7 @@ if(COMMAND mbgl_platform_offline)
     include(cmake/offline.cmake)
 endif()
 
-if(COMMAND mbgl_platform_node)
+if(WITH_NODEJS AND COMMAND mbgl_platform_node)
     include(cmake/node.cmake)
 endif()
 

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -8,6 +8,11 @@ else()
     )
 endif()
 
+
+if(NOT WITH_NODEJS)
+    target_compile_definitions(mbgl-test PRIVATE "-DTEST_HAS_SERVER=0")
+endif()
+
 set_source_files_properties(test/src/mbgl/test/util.cpp PROPERTIES COMPILE_FLAGS -DNODE_EXECUTABLE="${NodeJS_EXECUTABLE}")
 
 target_include_directories(mbgl-test

--- a/test/src/mbgl/test/util.cpp
+++ b/test/src/mbgl/test/util.cpp
@@ -11,10 +11,6 @@
 
 #include <unistd.h>
 
-#ifndef NODE_EXECUTABLE
-#define NODE_EXECUTABLE node
-#endif
-
 #define xstr(s) str(s)
 #define str(s) #s
 
@@ -53,8 +49,6 @@ Server::Server(const char* script) {
         close(output[0]);
 
         const char* executable = xstr(NODE_EXECUTABLE);
-
-        fprintf(stderr, "executable: %s\n", executable);
 
         // Launch the actual server process.
         int ret = execl(executable, executable, script, nullptr);

--- a/test/src/mbgl/test/util.hpp
+++ b/test/src/mbgl/test/util.hpp
@@ -5,20 +5,24 @@
 #endif
 
 #if ANDROID
-#define TEST_READ_ONLY 0
-#define TEST_HAS_SERVER 0
+    #define TEST_READ_ONLY 0
+    #undef TEST_HAS_SERVER
+    #define TEST_HAS_SERVER 0
 #elif TARGET_OS_IOS
-#define TEST_READ_ONLY 1
-#define TEST_HAS_SERVER 0
+    #define TEST_READ_ONLY 1
+    #undef TEST_HAS_SERVER
+    #define TEST_HAS_SERVER 0
 #else
-#define TEST_READ_ONLY 0
-#define TEST_HAS_SERVER 1
+    #define TEST_READ_ONLY 0
+    #ifndef TEST_HAS_SERVER
+        #define TEST_HAS_SERVER 1
+    #endif
 #endif
 
 #if TARGET_OS_SIMULATOR
-#define TEST_IS_SIMULATOR 1
+    #define TEST_IS_SIMULATOR 1
 #else
-#define TEST_IS_SIMULATOR 0
+    #define TEST_IS_SIMULATOR 0
 #endif
 
 #if !TEST_IS_SIMULATOR && !CI_BUILD


### PR DESCRIPTION
When `WITH_NODEJS=OFF` is set, we are refraining from trying to run `npm install`, but we were still trying to build the node module and run unit tests that require the Node.js server