### PR TITLE
Allow literal property arguments

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
@@ -3582,6 +3582,12 @@ public class Expression {
       return literal;
     }
 
+    @NonNull
+    @Override
+    public Object[] toArray() {
+      return new Object[] {"literal", literal};
+    }
+
     /**
      * Returns a string representation of the expression literal.
      *

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Layer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Layer.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.style.layers;
 
 import android.support.annotation.NonNull;
 
-import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.utils.ThreadUtils;
@@ -27,7 +26,7 @@ public abstract class Layer {
   /**
    * Validates if layer interaction is happening on the UI thread
    */
-  protected void checkThread(){
+  protected void checkThread() {
     ThreadUtils.checkThread("Layer");
   }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/ExpressionTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/ExpressionTest.java
@@ -177,6 +177,17 @@ public class ExpressionTest extends BaseActivityTest {
     });
   }
 
+  @Test
+  public void testLiteralProperty() {
+    validateTestSetup();
+    setupStyle();
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      layer.setProperties(
+        fillColor(literal("#4286f4"))
+      );
+    });
+  }
+
   private void setupStyle() {
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       // Add a source


### PR DESCRIPTION
This PR fixes an issue where literals passed as property arguments were generating nulls. For example, `PropertyFactory.iconImage(Expression.literal("image"))`.