### PR TITLE
expose enableOnUserRequest and disableOnUserRequest 

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
@@ -11,8 +11,6 @@ import android.support.annotation.NonNull;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.Toast;
-
-import com.mapbox.android.telemetry.TelemetryEnabler;
 import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.attribution.Attribution;
 import com.mapbox.mapboxsdk.attribution.AttributionParser;
@@ -99,8 +97,7 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
     builder.setPositiveButton(R.string.mapbox_attributionTelemetryPositive, new DialogInterface.OnClickListener() {
       @Override
       public void onClick(DialogInterface dialog, int which) {
-        TelemetryEnabler.updateTelemetryState(TelemetryEnabler.State.ENABLED);
-        Telemetry.obtainTelemetry().enable();
+        Telemetry.enableOnUserRequest();
         dialog.cancel();
       }
     });
@@ -114,8 +111,7 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
     builder.setNegativeButton(R.string.mapbox_attributionTelemetryNegative, new DialogInterface.OnClickListener() {
       @Override
       public void onClick(DialogInterface dialog, int which) {
-        Telemetry.obtainTelemetry().disable();
-        TelemetryEnabler.updateTelemetryState(TelemetryEnabler.State.DISABLED);
+        Telemetry.disableOnUserRequest();
         dialog.cancel();
       }
     });

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Telemetry.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Telemetry.java
@@ -30,12 +30,39 @@ public class Telemetry {
     obtainTelemetry();
   }
 
+  /**
+   * Set the debug logging state of telemetry.
+   *
+   * @param debugLoggingEnabled true to enable logging
+   */
   public static void updateDebugLoggingEnabled(boolean debugLoggingEnabled) {
     TelemetryHolder.INSTANCE.telemetry.updateDebugLoggingEnabled(debugLoggingEnabled);
   }
 
+  /**
+   * Update the telemetry rotation session id interval
+   *
+   * @param interval the selected session interval
+   * @return true if rotation session id was updated
+   */
   public static boolean updateSessionIdRotationInterval(SessionInterval interval) {
     return TelemetryHolder.INSTANCE.telemetry.updateSessionIdRotationInterval(interval);
+  }
+
+  /**
+   * Method to be called when an end-user has selected to participate in telemetry collection.
+   */
+  public static void enableOnUserRequest() {
+    TelemetryEnabler.updateTelemetryState(TelemetryEnabler.State.ENABLED);
+    TelemetryHolder.INSTANCE.telemetry.enable();
+  }
+
+  /**
+   * Method to be called when an end-user has selected to opt-out of telemetry collection.
+   */
+  public static void disableOnUserRequest() {
+    Telemetry.obtainTelemetry().disable();
+    TelemetryEnabler.updateTelemetryState(TelemetryEnabler.State.DISABLED);
   }
 
   private static class TelemetryHolder {


### PR DESCRIPTION
closes https://github.com/mapbox/mapbox-gl-native/issues/12012, this PR exposes the required configurations on Telemetry that are needed for end-developers rolling their own attribution screen. They need to allow end users to opt-in/opt-out of telemetry collection.