### PR TITLE
[ios, build] Install npm packages before deploying

### DIFF
--- a/platform/ios/scripts/deploy-packages.sh
+++ b/platform/ios/scripts/deploy-packages.sh
@@ -95,6 +95,7 @@ git checkout ${VERSION_TAG}
 step "Deploying version ${PUBLISH_VERSION}…"
 
 make clean && make distclean
+npm install --ignore-scripts
 mkdir -p ${BINARY_DIRECTORY}
 
 if [[ "${GITHUB_RELEASE}" == true ]]; then


### PR DESCRIPTION
Follow-up to #11997. The release notes templating script uses npm packages, but the deployment script does `make distclean` and wipes out installed/cached packages. So, manually install these packages ourselves (instead of relying on them being implicitly installed by one of our `make` commands).

/cc @fabian-guerra 