### PR TITLE
Optional map snapshotter camera position

### DIFF
--- a/platform/android/src/snapshotter/map_snapshotter.cpp
+++ b/platform/android/src/snapshotter/map_snapshotter.cpp
@@ -38,7 +38,12 @@ MapSnapshotter::MapSnapshotter(jni::JNIEnv& _env,
     jFileSource = FileSource::getNativePeer(_env, _jFileSource);
     auto& fileSource = mbgl::android::FileSource::getDefaultFileSource(_env, _jFileSource);
     auto size = mbgl::Size { static_cast<uint32_t>(width), static_cast<uint32_t>(height) };
-    auto cameraOptions = position ? CameraPosition::getCameraOptions(_env, position) : CameraOptions();
+
+    optional<mbgl::CameraOptions> cameraOptions;
+    if (position) {
+        cameraOptions = CameraPosition::getCameraOptions(_env, position);
+    }
+
     optional<mbgl::LatLngBounds> bounds;
     if (region) {
         bounds = LatLngBounds::getLatLngBounds(_env, region);

--- a/platform/default/mbgl/map/map_snapshotter.cpp
+++ b/platform/default/mbgl/map/map_snapshotter.cpp
@@ -18,7 +18,7 @@ public:
          const std::pair<bool, std::string> style,
          const Size&,
          const float pixelRatio,
-         const CameraOptions&,
+         const optional<CameraOptions> cameraOptions,
          const optional<LatLngBounds> region,
          const optional<std::string> programCacheDir);
 
@@ -46,7 +46,7 @@ MapSnapshotter::Impl::Impl(FileSource& fileSource,
            const std::pair<bool, std::string> style,
            const Size& size,
            const float pixelRatio,
-           const CameraOptions& cameraOptions,
+           const optional<CameraOptions> cameraOptions,
            const optional<LatLngBounds> region,
            const optional<std::string> programCacheDir)
     : frontend(size, pixelRatio, fileSource, scheduler, programCacheDir)
@@ -57,7 +57,10 @@ MapSnapshotter::Impl::Impl(FileSource& fileSource,
     } else{
         map.getStyle().loadURL(style.second);
     }
-    map.jumpTo(cameraOptions);
+
+    if (cameraOptions) {
+        map.jumpTo(*cameraOptions);
+    }
 
     // Set region, if specified
     if (region) {
@@ -140,7 +143,7 @@ MapSnapshotter::MapSnapshotter(FileSource& fileSource,
                                const std::pair<bool, std::string> style,
                                const Size& size,
                                const float pixelRatio,
-                               const CameraOptions& cameraOptions,
+                               const optional<CameraOptions> cameraOptions,
                                const optional<LatLngBounds> region,
                                const optional<std::string> programCacheDir)
    : impl(std::make_unique<util::Thread<MapSnapshotter::Impl>>("Map Snapshotter", fileSource, scheduler, style, size, pixelRatio, cameraOptions, region, programCacheDir)) {

--- a/platform/default/mbgl/map/map_snapshotter.hpp
+++ b/platform/default/mbgl/map/map_snapshotter.hpp
@@ -30,7 +30,7 @@ public:
                    const std::pair<bool, std::string> style,
                    const Size&,
                    const float pixelRatio,
-                   const CameraOptions&,
+                   const optional<CameraOptions> cameraOptions,
                    const optional<LatLngBounds> region,
                    const optional<std::string> cacheDir = {});
 


### PR DESCRIPTION
When looking into render differences from android render tests, I was noticing the following behavior:

| expected        | actual           | output  |
| ------------- |:-------------:| -----:|
| ![expected](https://user-images.githubusercontent.com/2151639/40714674-990b0a32-6403-11e8-9735-ff425dabe442.png)      | ![actual](https://user-images.githubusercontent.com/2151639/40714677-9b38d622-6403-11e8-9a44-8f6d29dec717.png) | ![output](https://user-images.githubusercontent.com/2151639/40714682-9df165a0-6403-11e8-8b43-44b43bf65156.png) |

With using the following style.json:

```json
{
  "version": 8,
  "metadata": {
    "test": {
      "width": 64,
      "height": 64
    }
  },
  "bearing": 45,
  "sources": {},
  "sprite": "local://sprites/emerald",
  "layers": [
    {
      "id": "background",
      "type": "background",
      "paint": {
        "background-pattern": "cemetery_icon"
      }
    }
  ]
}
```
Was able to track down that our camera definition in the style.json was overwritten by the default camera:
```cpp
     if (style.first) {	  
         map.getStyle().loadJSON(style.second);	         
     } else{	  
         map.getStyle().loadURL(style.second);	         
     }	    
     map.jumpTo(cameraOptions);
```

 This PR fixes that behavior by using `optional<mbgl::CameraOptions>`  instead of `CameraOptions&`.



