### PR TITLE
add style json setter/getter to map snapshotter

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
@@ -278,6 +278,12 @@ public class MapSnapshotter {
    */
   public native void setStyleUrl(String styleUrl);
 
+  /**
+   * Updates the snapshotter with a new style json
+   *
+   * @param styleJson the style json
+   */
+  public native void setStyleJson(String styleJson);
 
   /**
    * Must be called in on the thread

--- a/platform/android/src/snapshotter/map_snapshotter.cpp
+++ b/platform/android/src/snapshotter/map_snapshotter.cpp
@@ -107,6 +107,10 @@ void MapSnapshotter::setStyleUrl(JNIEnv& env, jni::String styleURL) {
     snapshotter->setStyleURL(jni::Make<std::string>(env, styleURL));
 }
 
+void MapSnapshotter::setStyleJson(JNIEnv& env, jni::String styleJSON) {
+    snapshotter->setStyleJSON(jni::Make<std::string>(env, styleJSON));
+}
+
 void MapSnapshotter::setSize(JNIEnv&, jni::jint width, jni::jint height) {
     auto size = mbgl::Size { static_cast<uint32_t>(width), static_cast<uint32_t>(height) };
     snapshotter->setSize(size);
@@ -120,6 +124,7 @@ void MapSnapshotter::setCameraPosition(JNIEnv& env, jni::Object<CameraPosition> 
 void MapSnapshotter::setRegion(JNIEnv& env, jni::Object<LatLngBounds> region) {
     snapshotter->setRegion(LatLngBounds::getLatLngBounds(env, region));
 }
+
 
 // Private methods //
 
@@ -153,6 +158,7 @@ void MapSnapshotter::registerNative(jni::JNIEnv& env) {
                                            "nativeInitialize",
                                            "finalize",
                                             METHOD(&MapSnapshotter::setStyleUrl, "setStyleUrl"),
+                                            METHOD(&MapSnapshotter::setStyleJson, "setStyleJson"),
                                             METHOD(&MapSnapshotter::setSize, "setSize"),
                                             METHOD(&MapSnapshotter::setCameraPosition, "setCameraPosition"),
                                             METHOD(&MapSnapshotter::setRegion, "setRegion"),

--- a/platform/android/src/snapshotter/map_snapshotter.hpp
+++ b/platform/android/src/snapshotter/map_snapshotter.hpp
@@ -44,6 +44,8 @@ public:
 
     void setStyleUrl(JNIEnv&, jni::String styleURL);
 
+    void setStyleJson(JNIEnv&, jni::String styleJSON);
+
     void setSize(JNIEnv&, jni::jint width, jni::jint height);
 
     void setCameraPosition(JNIEnv&, jni::Object<CameraPosition> position);

--- a/platform/default/mbgl/map/map_snapshotter.cpp
+++ b/platform/default/mbgl/map/map_snapshotter.cpp
@@ -25,6 +25,9 @@ public:
     void setStyleURL(std::string styleURL);
     std::string getStyleURL() const;
 
+    void setStyleJSON(std::string styleJSON);
+    std::string getStyleJSON() const;
+
     void setSize(Size);
     Size getSize() const;
 
@@ -107,6 +110,14 @@ std::string MapSnapshotter::Impl::getStyleURL() const {
     return map.getStyle().getURL();
 }
 
+void MapSnapshotter::Impl::setStyleJSON(std::string styleJSON) {
+    map.getStyle().loadJSON(styleJSON);
+}
+
+std::string MapSnapshotter::Impl::getStyleJSON() const {
+   return map.getStyle().getJSON();
+}
+
 void MapSnapshotter::Impl::setSize(Size size) {
     map.setSize(size);
     frontend.setSize(size);
@@ -158,6 +169,14 @@ void MapSnapshotter::setStyleURL(const std::string& styleURL) {
 
 std::string MapSnapshotter::getStyleURL() const {
     return impl->actor().ask(&Impl::getStyleURL).get();
+}
+
+void MapSnapshotter::setStyleJSON(const std::string& styleJSON) {
+    impl->actor().invoke(&Impl::setStyleJSON, styleJSON);
+}
+
+std::string MapSnapshotter::getStyleJSON() const {
+    return impl->actor().ask(&Impl::getStyleJSON).get();
 }
 
 void MapSnapshotter::setSize(const Size& size) {

--- a/platform/default/mbgl/map/map_snapshotter.hpp
+++ b/platform/default/mbgl/map/map_snapshotter.hpp
@@ -39,6 +39,9 @@ public:
     void setStyleURL(const std::string& styleURL);
     std::string getStyleURL() const;
 
+    void setStyleJSON(const std::string& styleJSON);
+    std::string getStyleJSON() const;
+
     void setSize(const Size&);
     Size getSize() const;
 


### PR DESCRIPTION
We added styleJson support to map snapshotter in #11976 but we didn't create any setters/getters for setting a new style json when reusing the same snapshotter object.