### PR TITLE
Ensure that camera is invalidated before generating telemetry event

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -23,6 +23,7 @@ import com.mapbox.android.telemetry.Event;
 import com.mapbox.android.telemetry.MapEventFactory;
 import com.mapbox.android.telemetry.MapState;
 import com.mapbox.mapboxsdk.R;
+import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.utils.MathUtils;
@@ -885,20 +886,20 @@ final class MapGestureDetector {
   }
 
   private void sendTelemetryEvent(String eventType, PointF focalPoint) {
-    if (isZoomValid(transform)) {
-      MapEventFactory mapEventFactory = new MapEventFactory();
-      LatLng latLng = projection.fromScreenLocation(focalPoint);
-      MapState state = new MapState(latLng.getLatitude(), latLng.getLongitude(), transform.getZoom());
-      state.setGesture(eventType);
-      Telemetry.obtainTelemetry().push(mapEventFactory.createMapGestureEvent(Event.Type.MAP_CLICK, state));
+    CameraPosition cameraPosition = transform.getCameraPosition();
+    if (cameraPosition != null) {
+      double zoom = cameraPosition.zoom;
+      if (isZoomValid(zoom)) {
+        MapEventFactory mapEventFactory = new MapEventFactory();
+        LatLng latLng = projection.fromScreenLocation(focalPoint);
+        MapState state = new MapState(latLng.getLatitude(), latLng.getLongitude(), zoom);
+        state.setGesture(eventType);
+        Telemetry.obtainTelemetry().push(mapEventFactory.createMapGestureEvent(Event.Type.MAP_CLICK, state));
+      }
     }
   }
 
-  private boolean isZoomValid(Transform transform) {
-    if (transform == null) {
-      return false;
-    }
-    double mapZoom = transform.getZoom();
+  private boolean isZoomValid(double mapZoom) {
     return mapZoom >= MapboxConstants.MINIMUM_ZOOM && mapZoom <= MapboxConstants.MAXIMUM_ZOOM;
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
@@ -218,10 +218,6 @@ final class Transform implements MapView.OnMapChangedListener {
 
   // Zoom in or out
 
-  double getZoom() {
-    return cameraPosition.zoom;
-  }
-
   double getRawZoom() {
     return mapView.getZoom();
   }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/11908.
Said NPE could've only happened if a user interacted with the Activity containing the map before the first frame is rendered.