### PR TITLE
[ios] Use 'Recognized' state for tap gesture handlers

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -511,7 +511,6 @@ public:
     _doubleTap.numberOfTapsRequired = 2;
     [self addGestureRecognizer:_doubleTap];
 
-
     _twoFingerDrag = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handleTwoFingerDragGesture:)];
     _twoFingerDrag.minimumNumberOfTouches = 2;
     _twoFingerDrag.maximumNumberOfTouches = 2;
@@ -1586,10 +1585,11 @@ public:
 
 - (void)handleSingleTapGesture:(UITapGestureRecognizer *)singleTap
 {
-    if (singleTap.state != UIGestureRecognizerStateEnded)
+    if (singleTap.state != UIGestureRecognizerStateRecognized)
     {
         return;
     }
+
     [self trackGestureEvent:MMEEventGestureSingleTap forRecognizer:singleTap];
 
     if (self.mapViewProxyAccessibilityElement.accessibilityElementIsFocused)
@@ -1611,8 +1611,8 @@ public:
         return;
     }
 
-    id<MGLAnnotation>annotation = [self annotationForGestureRecognizer:singleTap persistingResults:YES];
-    if(annotation)
+    id<MGLAnnotation> annotation = [self annotationForGestureRecognizer:singleTap persistingResults:YES];
+    if (annotation)
     {
         CGPoint calloutPoint = [singleTap locationInView:self];
         CGRect positionRect = [self positioningRectForAnnotation:annotation defaultCalloutPoint:calloutPoint];
@@ -1698,10 +1698,10 @@ public:
 
     [self cancelTransitions];
 
-    if (doubleTap.state == UIGestureRecognizerStateEnded)
-    {
-        self.cameraChangeReasonBitmask |= MGLCameraChangeReasonGestureZoomIn;
+    self.cameraChangeReasonBitmask |= MGLCameraChangeReasonGestureZoomIn;
 
+    if (doubleTap.state == UIGestureRecognizerStateRecognized)
+    {
         MGLMapCamera *oldCamera = self.camera;
 
         double newZoom = round(self.zoomLevel) + 1.0;
@@ -1741,13 +1741,7 @@ public:
 
     self.cameraChangeReasonBitmask |= MGLCameraChangeReasonGestureZoomOut;
 
-    if (twoFingerTap.state == UIGestureRecognizerStateBegan)
-    {
-        [self trackGestureEvent:MMEEventGestureTwoFingerSingleTap forRecognizer:twoFingerTap];
-
-        [self notifyGestureDidBegin];
-    }
-    else if (twoFingerTap.state == UIGestureRecognizerStateEnded)
+    if (twoFingerTap.state == UIGestureRecognizerStateRecognized)
     {
         MGLMapCamera *oldCamera = self.camera;
 
@@ -1759,6 +1753,8 @@ public:
 
         if ([self _shouldChangeFromCamera:oldCamera toCamera:toCamera])
         {
+            [self trackGestureEvent:MMEEventGestureTwoFingerSingleTap forRecognizer:twoFingerTap];
+
             mbgl::ScreenCoordinate center(gesturePoint.x, gesturePoint.y);
             _mbglMap->setZoom(newZoom, center, MGLDurationFromTimeInterval(MGLAnimationDuration));
             
@@ -1992,7 +1988,6 @@ public:
             if ([self angleBetweenPoints:west east:east] > horizontalToleranceDegrees) {
                 return NO;
             }
-            
         }
     }
     else if (gestureRecognizer == _singleTapGestureRecognizer)
@@ -2000,8 +1995,8 @@ public:
         // Gesture will be recognized if it could deselect an annotation
         if(!self.selectedAnnotation)
         {
-            id<MGLAnnotation>annotation = [self annotationForGestureRecognizer:(UITapGestureRecognizer*)gestureRecognizer persistingResults:NO];
-            if(!annotation) {
+            id<MGLAnnotation> annotation = [self annotationForGestureRecognizer:(UITapGestureRecognizer*)gestureRecognizer persistingResults:NO];
+            if (!annotation) {
                 return NO;
             }
         }


### PR DESCRIPTION
This switches our tap gesture recognizer handling methods to look for [`UIGestureRecognizerStateRecognized `](https://developer.apple.com/documentation/uikit/uigesturerecognizerstate/uigesturerecognizerstaterecognized?language=objc), rather than `.Ended`. `.Recognized` is defined to be the same as `.Ended`, but using the former is semantically nicer.

Besides some minor refactoring, this fixes a minor issue where the two-finger single tap (zoom out) gesture was checking for a nonexistent `.Began` state. Tap gestures have no `.Began`/`.Ended` states; they can only be `.Possible` or `.Recognized`. 

Note: the substantive changes are mainly in 5358c38, but I split this into two commits (that I’ll squash) so that those changes can be reviewed without the indentation changes of the second commit.

/cc @1ec5 @julianrex 