### PR TITLE
Use a shared scheduler on threads without a default scheduler

### DIFF
--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -65,8 +65,10 @@ add_library(qmapboxgl SHARED
     platform/qt/src/qmapboxgl_map_observer.hpp
     platform/qt/src/qmapboxgl_map_renderer.cpp
     platform/qt/src/qmapboxgl_map_renderer.hpp
-    platform/qt/src/qmapboxgl_renderer_backend.hpp
     platform/qt/src/qmapboxgl_renderer_backend.cpp
+    platform/qt/src/qmapboxgl_renderer_backend.hpp
+    platform/qt/src/qmapboxgl_scheduler.cpp
+    platform/qt/src/qmapboxgl_scheduler.hpp
     platform/default/mbgl/util/default_styles.hpp
 )
 

--- a/platform/qt/src/qmapboxgl_map_renderer.hpp
+++ b/platform/qt/src/qmapboxgl_map_renderer.hpp
@@ -14,7 +14,6 @@
 
 #include <memory>
 #include <mutex>
-#include <queue>
 
 namespace mbgl {
 class Renderer;
@@ -23,7 +22,7 @@ class UpdateParameters;
 
 class QMapboxGLRendererBackend;
 
-class QMapboxGLMapRenderer : public QObject, public mbgl::Scheduler
+class QMapboxGLMapRenderer : public QObject
 {
     Q_OBJECT
 
@@ -31,9 +30,6 @@ public:
     QMapboxGLMapRenderer(qreal pixelRatio, mbgl::DefaultFileSource &,
             mbgl::ThreadPool &, QMapboxGLSettings::GLContextMode);
     virtual ~QMapboxGLMapRenderer();
-
-    // mbgl::Scheduler implementation.
-    void schedule(std::weak_ptr<mbgl::Mailbox> scheduled) final;
 
     void render();
     void updateFramebuffer(quint32 fbo, const mbgl::Size &size);
@@ -56,8 +52,5 @@ private:
     QMapboxGLRendererBackend m_backend;
     std::unique_ptr<mbgl::Renderer> m_renderer;
 
-    std::mutex m_taskQueueMutex;
-    std::queue<std::weak_ptr<mbgl::Mailbox>> m_taskQueue;
-
-    bool m_threadWithScheduler;
+    bool m_forceScheduler;
 };

--- a/platform/qt/src/qmapboxgl_scheduler.cpp
+++ b/platform/qt/src/qmapboxgl_scheduler.cpp
@@ -1,0 +1,38 @@
+#include "qmapboxgl_scheduler.hpp"
+
+#include <mbgl/util/util.hpp>
+
+#include <cassert>
+
+QMapboxGLScheduler::QMapboxGLScheduler()
+{
+}
+
+QMapboxGLScheduler::~QMapboxGLScheduler()
+{
+    MBGL_VERIFY_THREAD(tid);
+}
+
+void QMapboxGLScheduler::schedule(std::weak_ptr<mbgl::Mailbox> mailbox)
+{
+    std::lock_guard<std::mutex> lock(m_taskQueueMutex);
+    m_taskQueue.push(mailbox);
+
+    // Need to force the main thread to wake
+    // up this thread and process the events.
+    emit needsProcessing();
+}
+
+void QMapboxGLScheduler::processEvents()
+{
+    std::queue<std::weak_ptr<mbgl::Mailbox>> taskQueue;
+    {
+        std::unique_lock<std::mutex> lock(m_taskQueueMutex);
+        std::swap(taskQueue, m_taskQueue);
+    }
+
+    while (!taskQueue.empty()) {
+        mbgl::Mailbox::maybeReceive(taskQueue.front());
+        taskQueue.pop();
+    }
+}

--- a/platform/qt/src/qmapboxgl_scheduler.hpp
+++ b/platform/qt/src/qmapboxgl_scheduler.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <mbgl/actor/mailbox.hpp>
+#include <mbgl/actor/scheduler.hpp>
+#include <mbgl/util/util.hpp>
+
+#include <QObject>
+
+#include <memory>
+#include <mutex>
+#include <queue>
+
+class QMapboxGLScheduler : public QObject, public mbgl::Scheduler
+{
+    Q_OBJECT
+
+public:
+    QMapboxGLScheduler();
+    virtual ~QMapboxGLScheduler();
+
+    // mbgl::Scheduler implementation.
+    void schedule(std::weak_ptr<mbgl::Mailbox> scheduled) final;
+
+    void processEvents();
+
+signals:
+    void needsProcessing();
+
+private:
+    MBGL_STORE_THREAD(tid);
+
+    std::mutex m_taskQueueMutex;
+    std::queue<std::weak_ptr<mbgl::Mailbox>> m_taskQueue;
+};


### PR DESCRIPTION
Render threads won't have a scheduler, so we create one that is
shared by all the maps rendering at this thread. The bad side
effect of this is that we need to wake up the render thread
to process events.

Mapbox GL should get rid of processing events on the render
thread. This solution is a workaround.