### PR TITLE
Automate tag release

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,20 @@ workflows:
             branches:
               ignore: master
       - android-debug-arm-v7
-      - android-release-all
+      - android-build-release:
+          filters:
+            branches:
+              ignore: /(master|release-boba|release-chai)/
+      - android-release-snapshot:
+          filters:
+            branches:
+              only: /(master|release-boba|release-chai)/
+      - android-release-tag:
+          filters:
+            tags:
+              only: /android-v.*/
+            branches:
+              ignore: /.*/
       - node4-clang39-release:
           filters:
             tags:
@@ -376,7 +389,48 @@ jobs:
           path: platform/android/MapboxGLAndroidSDKTestApp/lint-baseline.xml
 
 # ------------------------------------------------------------------------------
-  android-release-all:
+  android-build-release:
+    docker:
+      - image: mbgl/feb0443038:android-ndk-r17
+    resource_class: large
+    working_directory: /src
+    environment:
+      LIBSYSCONFCPUS: 4
+      JOBS: 4
+      BUILDTYPE: Release
+      IS_LOCAL_DEVELOPMENT: false
+    steps:
+      - checkout
+      - *generate-cache-key
+      - *restore-cache
+      - *restore-gradle-cache
+      - *reset-ccache-stats
+      - run:
+          name: Generate Maven credentials
+          shell: /bin/bash -euo pipefail
+          command: |
+            aws s3 cp s3://mapbox/android/signing-credentials/secring.gpg platform/android/MapboxGLAndroidSDK/secring.gpg
+            echo "NEXUS_USERNAME=$PUBLISH_NEXUS_USERNAME
+            NEXUS_PASSWORD=$PUBLISH_NEXUS_PASSWORD
+            signing.keyId=$SIGNING_KEYID
+            signing.password=$SIGNING_PASSWORD
+            signing.secretKeyRingFile=secring.gpg" >> platform/android/MapboxGLAndroidSDK/gradle.properties
+      - run:
+          name: Build package
+          command: make apackage
+      - run:
+          name: Build release Test App
+          command: make android
+      - *show-ccache-stats
+      - *save-cache
+      - *save-gradle-cache
+      - store_artifacts:
+          path: platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/release
+          destination: .
+
+
+# ------------------------------------------------------------------------------
+  android-release-snapshot:
     docker:
       - image: mbgl/feb0443038:android-ndk-r17
     resource_class: large
@@ -417,12 +471,63 @@ jobs:
       - deploy:
           name: Show statistics
           command: |
-            [ "${CIRCLE_BRANCH}" == "master" ] && export CLOUDWATCH=true
+            export CLOUDWATCH=true
             platform/android/scripts/metrics.sh
       - deploy:
           name: Publish to Maven
+          command: make run-android-upload-archives
+
+
+# ------------------------------------------------------------------------------
+  android-release-tag:
+    docker:
+      - image: mbgl/feb0443038:android-ndk-r17
+    resource_class: large
+    working_directory: /src
+    environment:
+      LIBSYSCONFCPUS: 4
+      JOBS: 4
+      BUILDTYPE: Release
+      IS_LOCAL_DEVELOPMENT: false
+    steps:
+      - checkout
+      - *generate-cache-key
+      - *restore-cache
+      - *restore-gradle-cache
+      - *reset-ccache-stats
+      - run:
+          name: Generate Maven credentials
+          shell: /bin/bash -euo pipefail
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then make run-android-upload-archives ; fi
+            aws s3 cp s3://mapbox/android/signing-credentials/secring.gpg platform/android/MapboxGLAndroidSDK/secring.gpg
+            echo "NEXUS_USERNAME=$PUBLISH_NEXUS_USERNAME
+            NEXUS_PASSWORD=$PUBLISH_NEXUS_PASSWORD
+            signing.keyId=$SIGNING_KEYID
+            signing.password=$SIGNING_PASSWORD
+            signing.secretKeyRingFile=secring.gpg" >> platform/android/MapboxGLAndroidSDK/gradle.properties
+      - run:
+          name: Update version name
+          command: sed -i -e "s/^VERSION_NAME=.*/VERSION_NAME=${CIRCLE_TAG:9}/" platform/android/MapboxGLAndroidSDK/gradle.properties
+      - run:
+          name: Build package
+          command: make apackage
+      - run:
+          name: Build release Test App
+          command: make android
+      - *show-ccache-stats
+      - *save-cache
+      - *save-gradle-cache
+      - store_artifacts:
+          path: platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/release
+          destination: .
+      - deploy:
+          name: Show statistics
+          command: |
+            export CLOUDWATCH=true
+            platform/android/scripts/metrics.sh
+      - deploy:
+          name: Publish to Maven
+          command: make run-android-upload-archives
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This PR splits Android release builds into 3 jobs:
 - `android-build-release`, builds a release version of each ABI and a release flavor of the TestApp with each push to the repo (unless below are run).
 - `android-release-snapshot`, runs only on `master` and `release-` branches publishing the snapshot. We could make the regex `release-.*` instead of declaring the branches explicitly, but I feel like it's a bit unsafe and someone could accidentally pollute the snapshot repo.
 - `android-release-tag`, runs only for `android-v.*` tags and publishes the release artifact to maven staging repo. This job also inserts the right version name into `MapboxGLAndroidSDK/gradle.properties` file based on the tag. Following current practice, all Android release tags need to start with `android-v` where anything that goes after this string will be used as a version name.