### PR TITLE
always commit placement to fix #11795

### DIFF
--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -387,6 +387,8 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
 
     bool placementChanged = false;
     if (!placement->stillRecent(parameters.timePoint)) {
+        placementChanged = true;
+
         auto newPlacement = std::make_unique<Placement>(parameters.state, parameters.mapMode);
         std::set<std::string> usedSymbolLayers;
         for (auto it = order.rbegin(); it != order.rend(); ++it) {
@@ -396,13 +398,9 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
             }
         }
 
-        placementChanged = newPlacement->commit(*placement, parameters.timePoint);
+        newPlacement->commit(*placement, parameters.timePoint);
         crossTileSymbolIndex.pruneUnusedLayers(usedSymbolLayers);
-        if (placementChanged || symbolBucketsChanged) {
-            placement = std::move(newPlacement);
-        }
-
-        placement->setRecent(parameters.timePoint);
+        placement = std::move(newPlacement);
         
         updateFadingTiles();
     } else {

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -63,7 +63,7 @@ class Placement {
 public:
     Placement(const TransformState&, MapMode mapMode);
     void placeLayer(RenderSymbolLayer&, const mat4&, bool showCollisionBoxes);
-    bool commit(const Placement& prevPlacement, TimePoint);
+    void commit(const Placement& prevPlacement, TimePoint);
     void updateLayerOpacities(RenderSymbolLayer&);
     float symbolFadeChange(TimePoint now) const;
     bool hasTransitions(TimePoint now) const;
@@ -94,12 +94,12 @@ private:
 
     TransformState state;
     MapMode mapMode;
+    TimePoint fadeStartTime;
     TimePoint commitTime;
 
     std::unordered_map<uint32_t, JointPlacement> placements;
     std::unordered_map<uint32_t, JointOpacityState> opacities;
 
-    TimePoint recentUntil;
     bool stale = false;
     
     std::unordered_map<uint32_t, RetainedQueryData> retainedQueryData;


### PR DESCRIPTION
fix #11795 

Since placements will be committed even if they do not need the full fade duration to fade features in, we need the new `fadeStartTime` to keep track of how long we still need to fade. This is important because if we fade too long we will trigger another placement and never stop
rendering.

I think the important thing that needs to be reviewed is that the logic that prevents infinite rendering is sound.