### PR TITLE
Fix build with Xcode 10

### DIFF
--- a/scripts/launch-c-xcode.in
+++ b/scripts/launch-c-xcode.in
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 export CCACHE_CPP2=true
-exec "@C_LAUNCHER@" "${DEVELOPER_DIR}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" "$@"
+exec "@C_LAUNCHER@" "${PATH%%/Contents/Developer/*}/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" "$@"

--- a/scripts/launch-cxx-xcode.in
+++ b/scripts/launch-cxx-xcode.in
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 export CCACHE_CPP2=true
-exec "@CXX_LAUNCHER@" "${DEVELOPER_DIR}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++" "$@"
+exec "@CXX_LAUNCHER@" "${PATH%%/Contents/Developer/*}/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++" "$@"


### PR DESCRIPTION
Xcode 10 no longer exposes `DEVELOPER_DIR` to the compiler launcher. We'll have to extract the location of Xcode's developer dir from `$PATH` :(

Fixes  https://github.com/mapbox/mapbox-gl-native/issues/12084

We should backport this to all release branches.