### PR TITLE
[core] Fix crash due to mixing legacy filters and expressions (#12065)

### DIFF
--- a/test/style/filter.test.cpp
+++ b/test/style/filter.test.cpp
@@ -3,6 +3,11 @@
 #include <mbgl/util/geometry.hpp>
 #include <mbgl/test/stub_geometry_tile_feature.hpp>
 
+#include <mbgl/util/rapidjson.hpp>
+#include <rapidjson/writer.h>
+#include <rapidjson/stringbuffer.h>
+#include <mbgl/style/conversion/stringify.hpp>
+
 #include <mbgl/style/filter.hpp>
 #include <mbgl/style/conversion/json.hpp>
 #include <mbgl/style/conversion/filter.hpp>
@@ -174,6 +179,13 @@ TEST(Filter, LegacyProperty) {
     ASSERT_TRUE(filter("[\"<=\", \"two\", \"2\"]", {{"two", std::string("2")}}));
     ASSERT_FALSE(filter("[\"<\", \"two\", \"1\"]", {{"two", std::string("2")}}));
     ASSERT_FALSE(filter("[\"==\", \"two\", 4]", {{"two", std::string("2")}}));
+}
+
+TEST(Filter, ExpressionLegacyMix) {
+    conversion::Error error;
+    optional<Filter> filter = conversion::convertJSON<Filter>(R"(["any", ["all", ["==", ["geometry-type"], "LineString"]], ["==", "x", 1]])", error);
+    EXPECT_FALSE(bool(filter));
+    EXPECT_TRUE(error.message.size() > 0);
 }
 
 TEST(Filter, ZoomExpressionNested) {


### PR DESCRIPTION
* Fix crash due to mixing legacy filters and expressions

In some cases, (invalid) nested filters that used a mix of legacy filter
syntax and expression syntax caused a crash due to a failure to
propagate parsing errors from deeper within the filter expression.

These errors went undetected in part because these conversion functions
returned unique_ptr<Expression> values (or vectors thereof), using
{nullptr} to represent a parsing error, but the core expression classes
expect unique_ptr<Expression> that are never null.

This changes over to using expression::ParseResult (aka
optional<unique_ptr<Expression>>), to represent conversion failure
the same way we do in the rest of the expression system.

* Fix clang 3.8 / gcc 4.9 issue