### PR TITLE
[ios, build] Bump CircleCI to Xcode 9.4

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -824,7 +824,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-debug:
     macos:
-      xcode: "9.3.0"
+      xcode: "9.4.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -851,7 +851,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-sanitize:
     macos:
-      xcode: "9.3.0"
+      xcode: "9.4.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -872,7 +872,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-sanitize-address:
     macos:
-      xcode: "9.3.0"
+      xcode: "9.4.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -893,7 +893,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-static-analyzer:
     macos:
-      xcode: "9.3.0"
+      xcode: "9.4.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -914,7 +914,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-release:
     macos:
-      xcode: "9.3.0"
+      xcode: "9.4.0"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     shell: /bin/bash --login -eo pipefail
@@ -942,7 +942,7 @@ jobs:
 # ------------------------------------------------------------------------------
   macos-debug:
     macos:
-      xcode: "9.3.0"
+      xcode: "9.4.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -971,7 +971,7 @@ jobs:
 # ------------------------------------------------------------------------------
   macos-debug-qt5:
     macos:
-      xcode: "9.3.0"
+      xcode: "9.4.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -996,7 +996,7 @@ jobs:
 # ------------------------------------------------------------------------------
   macos-release-node4:
     macos:
-      xcode: "9.3.0"
+      xcode: "9.4.0"
     environment:
       BUILDTYPE: RelWithDebInfo
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -1019,7 +1019,7 @@ jobs:
 # ------------------------------------------------------------------------------
   macos-release-node6:
     macos:
-      xcode: "9.3.0"
+      xcode: "9.4.0"
     environment:
       BUILDTYPE: RelWithDebInfo
       HOMEBREW_NO_AUTO_UPDATE: 1

--- a/circle.yml
+++ b/circle.yml
@@ -971,7 +971,7 @@ jobs:
 # ------------------------------------------------------------------------------
   macos-debug-qt5:
     macos:
-      xcode: "9.4.0"
+      xcode: "9.3.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1


### PR DESCRIPTION
[Container details.](https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-422/index.html)

/cc @fabian-guerra @julianrex 