### PR TITLE
Ceil map dimensions

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -136,8 +136,8 @@ final class NativeMapView {
     if (checkState("resizeView")) {
       return;
     }
-    width = (int) (width / pixelRatio);
-    height = (int) (height / pixelRatio);
+    width = (int) Math.ceil(width / pixelRatio);
+    height = (int) Math.ceil(height / pixelRatio);
 
     if (width < 0) {
       throw new IllegalArgumentException("width cannot be negative.");


### PR DESCRIPTION
When computing map's dimensions passed to the core we are accounting for the pixel ratio. These calculations can result in non-integer values which we cast to `int` and effectively allow for minimum available zoom be low enough for the viewport to span beyond 360 degrees. This PR fixes the beforementioned issue by always rounding the map dimensions up.