### PR TITLE
Fixed NSLocale.languageCode crash in iOS 9.3

### DIFF
--- a/platform/darwin/src/MGLVectorTileSource.mm
+++ b/platform/darwin/src/MGLVectorTileSource.mm
@@ -109,8 +109,15 @@ static NSArray * const MGLMapboxStreetsAlternativeLanguages = @[
 + (NSString *)preferredMapboxStreetsLanguageForPreferences:(NSArray<NSString *> *)preferencesArray {
     BOOL acceptsEnglish = [preferencesArray filteredArrayUsingPredicate:
                            [NSPredicate predicateWithBlock:^BOOL(NSString * _Nullable language, NSDictionary<NSString *,id> * _Nullable bindings) {
+        NSString *languageCode;
 
-        NSString *languageCode = [[NSLocale localeWithLocaleIdentifier:language] objectForKey:NSLocaleLanguageCode];
+        if (@available(iOS 10.0, macOS 10.12.0, *)) {
+            languageCode = [NSLocale localeWithLocaleIdentifier:language].languageCode;
+        }
+        else {
+            languageCode = [[NSLocale localeWithLocaleIdentifier:language] objectForKey:NSLocaleLanguageCode];
+        }
+
         return [languageCode isEqualToString:@"en"];
     }]].count;
     

--- a/platform/darwin/src/MGLVectorTileSource.mm
+++ b/platform/darwin/src/MGLVectorTileSource.mm
@@ -109,7 +109,9 @@ static NSArray * const MGLMapboxStreetsAlternativeLanguages = @[
 + (NSString *)preferredMapboxStreetsLanguageForPreferences:(NSArray<NSString *> *)preferencesArray {
     BOOL acceptsEnglish = [preferencesArray filteredArrayUsingPredicate:
                            [NSPredicate predicateWithBlock:^BOOL(NSString * _Nullable language, NSDictionary<NSString *,id> * _Nullable bindings) {
-        return [[NSLocale localeWithLocaleIdentifier:language].languageCode isEqualToString:@"en"];
+
+        NSString *languageCode = [[NSLocale localeWithLocaleIdentifier:language] objectForKey:NSLocaleLanguageCode];
+        return [languageCode isEqualToString:@"en"];
     }]].count;
     
     NSArray<NSString *> *availableLanguages = acceptsEnglish ? MGLMapboxStreetsLanguages : MGLMapboxStreetsAlternativeLanguages;

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -21,6 +21,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Added custom `-hitTest:withEvent:` to `MGLSMCalloutView` to avoid registering taps in transparent areas of the standard annotation callout. ([#11939](https://github.com/mapbox/mapbox-gl-native/pull/11939))
 * Improved performance and memory impact of `MGLScaleBar`. ([#11921](https://github.com/mapbox/mapbox-gl-native/pull/11921))
 * Fixed race conditions that could cause crashes when re-using `MGLMapSnapshotter` or using multiple snapshotters at the same time. ([#11831](https://github.com/mapbox/mapbox-gl-native/pull/11831))
+* Fixed crash on iOS 9.3 (`NSLocale.languageCode` introduced in iOS 10.0)
 
 ## 4.0.2 - May 29, 2018
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -21,7 +21,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Added custom `-hitTest:withEvent:` to `MGLSMCalloutView` to avoid registering taps in transparent areas of the standard annotation callout. ([#11939](https://github.com/mapbox/mapbox-gl-native/pull/11939))
 * Improved performance and memory impact of `MGLScaleBar`. ([#11921](https://github.com/mapbox/mapbox-gl-native/pull/11921))
 * Fixed race conditions that could cause crashes when re-using `MGLMapSnapshotter` or using multiple snapshotters at the same time. ([#11831](https://github.com/mapbox/mapbox-gl-native/pull/11831))
-* Fixed crash on iOS 9.3 (`NSLocale.languageCode` introduced in iOS 10.0)
+* Fixed crash on iOS 9.3 (`NSLocale.languageCode` introduced in iOS 10.0) ([#12123](https://github.com/mapbox/mapbox-gl-native/pull/12123))
 
 ## 4.0.2 - May 29, 2018
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -21,7 +21,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Added custom `-hitTest:withEvent:` to `MGLSMCalloutView` to avoid registering taps in transparent areas of the standard annotation callout. ([#11939](https://github.com/mapbox/mapbox-gl-native/pull/11939))
 * Improved performance and memory impact of `MGLScaleBar`. ([#11921](https://github.com/mapbox/mapbox-gl-native/pull/11921))
 * Fixed race conditions that could cause crashes when re-using `MGLMapSnapshotter` or using multiple snapshotters at the same time. ([#11831](https://github.com/mapbox/mapbox-gl-native/pull/11831))
-* Fixed crash on iOS 9.3 (`NSLocale.languageCode` introduced in iOS 10.0) ([#12123](https://github.com/mapbox/mapbox-gl-native/pull/12123))
+* Fixed crash in `-[MGLStyle localizeLabelsIntoLocale:]` on iOS 9.3 (attempting to access a property that was introduced in iOS 10.0) ([#12123](https://github.com/mapbox/mapbox-gl-native/pull/12123))
 
 ## 4.0.2 - May 29, 2018
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Adjusted when and how the camera transition update and finish callbacks are called, fixing recursion bugs. ([#11614](https://github.com/mapbox/mapbox-gl-native/pull/11614))
 * Fixed an issue preventing nested key path expressions get parsed accordingly to the spec. ([#11959](https://github.com/mapbox/mapbox-gl-native/pull/11959))
 * Fixed race conditions that could cause crashes when re-using `MGLMapSnapshotter` or using multiple snapshotters at the same time. ([#11831](https://github.com/mapbox/mapbox-gl-native/pull/11831))
-* Fixed crash on iOS 9.3 (`NSLocale.languageCode` introduced in iOS 10.0)
+* Fixed crash on iOS 9.3 (`NSLocale.languageCode` introduced in iOS 10.0, and used in Darwin code) ([#12123](https://github.com/mapbox/mapbox-gl-native/pull/12123))
 
 ## 0.7.1
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -16,7 +16,8 @@
 * Adjusted when and how the camera transition update and finish callbacks are called, fixing recursion bugs. ([#11614](https://github.com/mapbox/mapbox-gl-native/pull/11614))
 * Fixed an issue preventing nested key path expressions get parsed accordingly to the spec. ([#11959](https://github.com/mapbox/mapbox-gl-native/pull/11959))
 * Fixed race conditions that could cause crashes when re-using `MGLMapSnapshotter` or using multiple snapshotters at the same time. ([#11831](https://github.com/mapbox/mapbox-gl-native/pull/11831))
-* Fixed crash on iOS 9.3 (`NSLocale.languageCode` introduced in iOS 10.0, and used in Darwin code) ([#12123](https://github.com/mapbox/mapbox-gl-native/pull/12123))
+* Fixed crash in `-[MGLStyle localizeLabelsIntoLocale:]` on iOS 9.3 (attempting to access a property that was introduced in iOS 10.0 and used in Darwin code) ([#12123](https://github.com/mapbox/mapbox-gl-native/pull/12123))
+
 
 ## 0.7.1
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Adjusted when and how the camera transition update and finish callbacks are called, fixing recursion bugs. ([#11614](https://github.com/mapbox/mapbox-gl-native/pull/11614))
 * Fixed an issue preventing nested key path expressions get parsed accordingly to the spec. ([#11959](https://github.com/mapbox/mapbox-gl-native/pull/11959))
 * Fixed race conditions that could cause crashes when re-using `MGLMapSnapshotter` or using multiple snapshotters at the same time. ([#11831](https://github.com/mapbox/mapbox-gl-native/pull/11831))
+* Fixed crash on iOS 9.3 (`NSLocale.languageCode` introduced in iOS 10.0)
 
 ## 0.7.1
 


### PR DESCRIPTION
Fixes #12063 (same bug as #7399)