### PR TITLE
[Qt] Add QMapboxGL::layerIds()

### DIFF
--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -236,6 +236,8 @@ public:
     bool layerExists(const QString &id);
     void removeLayer(const QString &id);
 
+    QList<QString> layerIds() const;
+
     void setFilter(const QString &layer, const QVariant &filter);
 
     // When rendering on a different thread,

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1466,6 +1466,23 @@ void QMapboxGL::removeLayer(const QString& id)
 }
 
 /*!
+    List of all existing layer ids from the current style.
+*/
+QList<QString> QMapboxGL::layerIds() const
+{
+    const auto &layers = d_ptr->mapObj->getStyle().getLayers();
+
+    QList<QString> layerIds;
+    layerIds.reserve(layers.size());
+
+    for (const mbgl::style::Layer *layer : layers) {
+        layerIds.append(QString::fromStdString(layer->getID()));
+    }
+
+    return layerIds;
+}
+
+/*!
     Adds the \a image with the identifier \a id that can be used
     later by a symbol layer.
 


### PR DESCRIPTION
Exposes a function that reads all entries from `mbgl::style::getLayers()` and returns a list containing their respective IDs.