### PR TITLE
Look more widely for IBDesignablesAgent

### DIFF
--- a/platform/darwin/src/NSProcessInfo+MGLAdditions.m
+++ b/platform/darwin/src/NSProcessInfo+MGLAdditions.m
@@ -1,15 +1,9 @@
 #import "NSProcessInfo+MGLAdditions.h"
 
-#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
-    static NSString * const MGLIBDesignablesAgentProcessName = @"IBDesignablesAgentCocoaTouch";
-#elif TARGET_OS_MAC
-    static NSString * const MGLIBDesignablesAgentProcessName = @"IBDesignablesAgent";
-#endif
-
 @implementation NSProcessInfo (MGLAdditions)
 
 - (BOOL)mgl_isInterfaceBuilderDesignablesAgent {
-    return [self.processName isEqualToString:MGLIBDesignablesAgentProcessName];
+    return [self.processName hasPrefix:@"IBDesignablesAgent"];
 }
 
 @end

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Packaging
 
 * The minimum deployment target for this SDK is now macOS 10.11.0. ([#11776](https://github.com/mapbox/mapbox-gl-native/pull/11776))
+* Fixed an issue where `MGLMapView` produced a designable error in Interface Builder storyboards. ([#12140](https://github.com/mapbox/mapbox-gl-native/pull/12140))
 
 ### Style layers
 


### PR DESCRIPTION
Cast a wider net when trying to detect the helper process that builds the Interface Builder designable when MGLMapView is displayed in a storyboard or XIB. Detecting the helper process is important because it keeps mbgl and the telemetry subsystem from initializing and causing the designable to time out or raise an exception. In Xcode 10, the helper process has been renamed on each platform:

Platform SDK | Xcode 9 | Xcode 10
----|----|----
iOS | IBDesignablesAgentCocoaTouch | IBDesignablesAgent-iOS
macOS | IBDesignablesAgent | IBDesignablesAgent-macOS
tvOS | IBDesignablesAgentAppleTV | IBDesignablesAgent-tvOS

(tvOS is mentioned here because of #9319.)

I left out the iOS changelog blurb because this fix by itself doesn’t address #10072 or #10573.

/cc @friedbunny @fabian-guerra