### PR TITLE
Reinstall constraints only when needed

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -22,6 +22,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Improved performance and memory impact of `MGLScaleBar`. ([#11921](https://github.com/mapbox/mapbox-gl-native/pull/11921))
 * Fixed race conditions that could cause crashes when re-using `MGLMapSnapshotter` or using multiple snapshotters at the same time. ([#11831](https://github.com/mapbox/mapbox-gl-native/pull/11831))
 * Fixed crash in `-[MGLStyle localizeLabelsIntoLocale:]` on iOS 9.3 (attempting to access a property that was introduced in iOS 10.0) ([#12123](https://github.com/mapbox/mapbox-gl-native/pull/12123))
+* Improved performance in view controllers that contain `MGLMapView`s. ([#12144](https://github.com/mapbox/mapbox-gl-native/pull/12144))
 
 ## 4.0.2 - May 29, 2018
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -489,6 +489,8 @@ public:
     [self addSubview:_scaleBar];
     _scaleBarConstraints = [NSMutableArray array];
     
+    [self installConstraints];
+    
     // setup interaction
     //
     _pan = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePanGesture:)];
@@ -740,7 +742,7 @@ public:
     return nil;
 }
 
-- (void)updateConstraintsPreiOS11 {
+- (void)installConstraintsPreiOS11 {
     // If we have a view controller reference and its automaticallyAdjustsScrollViewInsets
     // is set to YES, use its view as the parent for constraints. -[MGLMapView adjustContentInset]
     // already take top and bottom layout guides into account. If we don't have a reference, apply
@@ -887,7 +889,7 @@ public:
     [containerView addConstraints:self.attributionButtonConstraints];
 }
 
-- (void)updateConstraints
+- (void)installConstraints
 {
     // If safeAreaLayoutGuide API exists
     if (@available(iOS 11.0, *)) {
@@ -925,10 +927,8 @@ public:
                                                                                                constant:8.0 + self.contentInset.right]];
         [self addConstraints:self.attributionButtonConstraints];
     } else {
-        [self updateConstraintsPreiOS11];
+        [self installConstraintsPreiOS11];
     }
-    
-    [super updateConstraints];
 }
 
 - (NSLayoutConstraint *)constraintForYAxisAnchor:(NSLayoutYAxisAnchor *)yAxisAnchor belowAnchor:(NSLayoutYAxisAnchor *)anchor
@@ -1062,7 +1062,7 @@ public:
     }
 
     // Compass, logo and attribution button constraints needs to be updated.
-    [self setNeedsUpdateConstraints];
+    [self installConstraints];
 }
 
 /// Returns the frame of inset content within the map view.
@@ -1143,6 +1143,7 @@ public:
 - (void)didMoveToSuperview
 {
     [self validateDisplayLink];
+    [self installConstraints];
     [super didMoveToSuperview];
 }
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -18,7 +18,7 @@
 * Fixed an issue preventing nested key path expressions get parsed accordingly to the spec. ([#11959](https://github.com/mapbox/mapbox-gl-native/pull/11959))
 * Fixed race conditions that could cause crashes when re-using `MGLMapSnapshotter` or using multiple snapshotters at the same time. ([#11831](https://github.com/mapbox/mapbox-gl-native/pull/11831))
 * Fixed crash in `-[MGLStyle localizeLabelsIntoLocale:]` on iOS 9.3 (attempting to access a property that was introduced in iOS 10.0 and used in Darwin code) ([#12123](https://github.com/mapbox/mapbox-gl-native/pull/12123))
-
+* Improved performance in view controllers that contain `MGLMapView`s. ([#12144](https://github.com/mapbox/mapbox-gl-native/pull/12144))
 
 ## 0.7.1
 

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -298,6 +298,7 @@ public:
     [self installLogoView];
     [self installAttributionView];
     [self installGestureRecognizers];
+    [self installConstraints];
 
     // Set up annotation management and selection state.
     _annotationImagesByIdentifier = [NSMutableDictionary dictionary];
@@ -510,6 +511,23 @@ public:
                                      multiplier:1
                                        constant:8]];
     }
+    
+    // Place the attribution view to the right of the logo view and size it to
+    // fit the buttons inside.
+    [self addConstraint:[NSLayoutConstraint constraintWithItem:_logoView
+                                                     attribute:NSLayoutAttributeBaseline
+                                                     relatedBy:NSLayoutRelationEqual
+                                                        toItem:_attributionView
+                                                     attribute:NSLayoutAttributeBaseline
+                                                    multiplier:1
+                                                      constant:_logoView.image.alignmentRect.origin.y]];
+    [self addConstraint:[NSLayoutConstraint constraintWithItem:_attributionView
+                                                     attribute:NSLayoutAttributeLeading
+                                                     relatedBy:NSLayoutRelationEqual
+                                                        toItem:_logoView
+                                                     attribute:NSLayoutAttributeTrailing
+                                                    multiplier:1
+                                                      constant:8]];
 }
 
 - (void)dealloc {
@@ -704,7 +722,7 @@ public:
     }
 }
 
-- (void)updateConstraints {
+- (void)installConstraints {
     // Place the zoom controls at the lower-right corner of the view.
     [self addConstraint:
      [NSLayoutConstraint constraintWithItem:self
@@ -760,25 +778,6 @@ public:
                                   attribute:NSLayoutAttributeLeading
                                  multiplier:1
                                    constant:MGLOrnamentPadding - _logoView.image.alignmentRect.origin.x]];
-
-    // Place the attribution view to the right of the logo view and size it to
-    // fit the buttons inside.
-    [self addConstraint:[NSLayoutConstraint constraintWithItem:_logoView
-                                                     attribute:NSLayoutAttributeBaseline
-                                                     relatedBy:NSLayoutRelationEqual
-                                                        toItem:_attributionView
-                                                     attribute:NSLayoutAttributeBaseline
-                                                    multiplier:1
-                                                      constant:_logoView.image.alignmentRect.origin.y]];
-    [self addConstraint:[NSLayoutConstraint constraintWithItem:_attributionView
-                                                     attribute:NSLayoutAttributeLeading
-                                                     relatedBy:NSLayoutRelationEqual
-                                                        toItem:_logoView
-                                                     attribute:NSLayoutAttributeTrailing
-                                                    multiplier:1
-                                                      constant:8]];
-
-    [super updateConstraints];
 }
 
 - (void)renderSync {
@@ -944,7 +943,6 @@ public:
     if ([source isKindOfClass:[MGLTileSource class]]) {
         [self installAttributionView];
     }
-    self.needsUpdateConstraints = YES;
     self.needsDisplay = YES;
 }
 


### PR DESCRIPTION
Remove and re-add MGLMapView’s constraints for ornaments only upon external changes, such as when the view moves to a different view controller with a different value for `automaticallyAdjustsScrollViewInsets`.

Updating constraints is still an all-or-nothing affair; a future change could more more granularly change only the constraints affected by the inset setting or layout guides.

This PR probably regresses the case where a view controller’s `automaticallyAdjustsScrollViewInsets` is changed while MGLMapView is a subview of that view controller’s view. To avoid that regression, we’d have to key-value observe a property on the view controller – which we only know about by crawling up the responder chain. This seems like a greater evil than the regression, which would be better addressed by replacing `automaticallyAdjustsScrollViewInsets` with a property on MGLMapView itself: #12143.

I haven’t checked, but I suspect #4352 still reproduces despite this change, since it doesn’t affect mbgl’s knowledge of the map’s size in any way.

/cc @julianrex @friedbunny