### PR TITLE
[iOS] Fix unbalanced change delimiter

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -16,7 +16,6 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Added the `collator` and `resolved-locale` expression operators to more precisely compare strings in style JSON. A subset of this functionality is available through predicate options when creating an `NSPredicate`. ([#11869](https://github.com/mapbox/mapbox-gl-native/pull/11869))
 * Fixed a crash when trying to parse expressions containing legacy filters. ([#12263](https://github.com/mapbox/mapbox-gl-native/pull/12263))
 * Fixed a crash that occurred when creating an `MGL_MATCH` expression using non-expressions as arguments. ([#12332](https://github.com/mapbox/mapbox-gl-native/pull/12332))
-* Fixed an issue that assertions will trip up when a gesture not ended and another gesture triggered. ([#12148](https://github.com/mapbox/mapbox-gl-native/pull/12148), [#12160](https://github.com/mapbox/mapbox-gl-native/issues/12160))
 
 ### Networking and storage
 
@@ -28,6 +27,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Added `-[MGLMapSnapshot coordinateForPoint:]` that returns a map coordinate for a specified snapshot image point. ([#12221](https://github.com/mapbox/mapbox-gl-native/pull/12221))
 * Reduced memory usage when collision debug mode is disabled. ([#12294](https://github.com/mapbox/mapbox-gl-native/issues/12294))
 * Fixed a bug with annotation view touch handling when a non-zero `centerOffset` is specified. ([#12234](https://github.com/mapbox/mapbox-gl-native/pull/12234))
+* Fixed an issue that assertions will trip up when a gesture not ended and another gesture triggered. ([#12148](https://github.com/mapbox/mapbox-gl-native/pull/12148), [#12160](https://github.com/mapbox/mapbox-gl-native/issues/12160))
 
 ## 4.0.3 - June 22, 2018
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -16,6 +16,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Added the `collator` and `resolved-locale` expression operators to more precisely compare strings in style JSON. A subset of this functionality is available through predicate options when creating an `NSPredicate`. ([#11869](https://github.com/mapbox/mapbox-gl-native/pull/11869))
 * Fixed a crash when trying to parse expressions containing legacy filters. ([#12263](https://github.com/mapbox/mapbox-gl-native/pull/12263))
 * Fixed a crash that occurred when creating an `MGL_MATCH` expression using non-expressions as arguments. ([#12332](https://github.com/mapbox/mapbox-gl-native/pull/12332))
+* Fixed an issue that assertions will trip up when a gesture not ended and another gesture triggered. ([#12148](https://github.com/mapbox/mapbox-gl-native/pull/12148), [#12160](https://github.com/mapbox/mapbox-gl-native/issues/12160))
 
 ### Networking and storage
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -27,7 +27,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Added `-[MGLMapSnapshot coordinateForPoint:]` that returns a map coordinate for a specified snapshot image point. ([#12221](https://github.com/mapbox/mapbox-gl-native/pull/12221))
 * Reduced memory usage when collision debug mode is disabled. ([#12294](https://github.com/mapbox/mapbox-gl-native/issues/12294))
 * Fixed a bug with annotation view touch handling when a non-zero `centerOffset` is specified. ([#12234](https://github.com/mapbox/mapbox-gl-native/pull/12234))
-* Fixed an issue that assertions will trip up when a gesture not ended and another gesture triggered. ([#12148](https://github.com/mapbox/mapbox-gl-native/pull/12148), [#12160](https://github.com/mapbox/mapbox-gl-native/issues/12160))
+* Fixed a crash that occurred when the user started a gesture before the drift animation for a previous gesture was complete. ([#12148](https://github.com/mapbox/mapbox-gl-native/pull/12148), [#12160](https://github.com/mapbox/mapbox-gl-native/issues/12160))
 
 ## 4.0.3 - June 22, 2018
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -386,7 +386,6 @@ public:
 {
     _isTargetingInterfaceBuilder = NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent;
     _opaque = NO;
-    _changeDelimiterSuppressionDepth = 0;
 
     BOOL background = [UIApplication sharedApplication].applicationState == UIApplicationStateBackground;
     if (!background)

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -386,6 +386,7 @@ public:
 {
     _isTargetingInterfaceBuilder = NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent;
     _opaque = NO;
+    _changeDelimiterSuppressionDepth = 0;
 
     BOOL background = [UIApplication sharedApplication].applicationState == UIApplicationStateBackground;
     if (!background)
@@ -1264,7 +1265,6 @@ public:
 
 - (void)touchesBegan:(__unused NSSet<UITouch *> *)touches withEvent:(__unused UIEvent *)event
 {
-    _changeDelimiterSuppressionDepth = 0;
     _mbglMap->setGestureInProgress(false);
     if (self.userTrackingState == MGLUserTrackingStateBegan)
     {


### PR DESCRIPTION
Always reset `_changeDelimiterSuppressionDepth` will lead to "Unbalanced change delimiter suppression/unsuppression".
The issue will happen when a gesture not ended and another gesture triggered.
I've encountered this issue while debuging, here is the log:
```
2018-06-14 14:39:25.633152+0800 MapboxLab[27249:10009823] From: handlePinchGesture:, _changeDelimiterSuppressionDepth++, value=1
2018-06-14 14:39:25.664658+0800 MapboxLab[27249:10009823] From: touchesBegan, _changeDelimiterSuppressionDepth=0, value=0
2018-06-14 14:39:26.066514+0800 MapboxLab[27249:10009823] From: handlePinchGesture:, _changeDelimiterSuppressionDepth--, value=-1
```

/cc @chriswu42 