### PR TITLE
Android licenses formatting

### DIFF
--- a/platform/android/LICENSE.md
+++ b/platform/android/LICENSE.md
@@ -1,118 +1,118 @@
-<!-- This file was generated. Use `make android-license` to update. -->
-## Additional Mapbox GL licenses
-Mapbox GL uses portions of the Android Arch-Common.
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
+<!-- This file was generated. Use `make android-license` to update. -->  
+## Additional Mapbox GL licenses  
+Mapbox GL uses portions of the Android Arch-Common.  
+URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Arch-Runtime.
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
+Mapbox GL uses portions of the Android Arch-Runtime.  
+URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Lifecycle LiveData Core.
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
+Mapbox GL uses portions of the Android Lifecycle LiveData Core.  
+URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Lifecycle Runtime.
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
+Mapbox GL uses portions of the Android Lifecycle Runtime.  
+URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Lifecycle ViewModel.
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
+Mapbox GL uses portions of the Android Lifecycle ViewModel.  
+URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Lifecycle-Common.
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
+Mapbox GL uses portions of the Android Lifecycle-Common.  
+URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library Annotations.
-URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)
+Mapbox GL uses portions of the Android Support Library Annotations.  
+URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library compat.
-URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)
+Mapbox GL uses portions of the Android Support Library compat.  
+URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library core UI.
-URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)
+Mapbox GL uses portions of the Android Support Library core UI.  
+URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library core utils.
-URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)
+Mapbox GL uses portions of the Android Support Library core utils.  
+URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library fragment.
-URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)
+Mapbox GL uses portions of the Android Support Library fragment.  
+URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Gson.
+Mapbox GL uses portions of the Gson.  
 License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Mapbox Android Core Library.
-URL: [https://github.com/mapbox/mapbox-events-android](https://github.com/mapbox/mapbox-events-android)
+Mapbox GL uses portions of the Mapbox Android Core Library.  
+URL: [https://github.com/mapbox/mapbox-events-android](https://github.com/mapbox/mapbox-events-android)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Mapbox Android Gestures Library.
-URL: [https://github.com/mapbox/mapbox-gestures-android](https://github.com/mapbox/mapbox-gestures-android)
+Mapbox GL uses portions of the Mapbox Android Gestures Library.  
+URL: [https://github.com/mapbox/mapbox-gestures-android](https://github.com/mapbox/mapbox-gestures-android)  
 License: [BSD 2-Clause "Simplified" License](https://raw.githubusercontent.com/mapbox/mapbox-gestures-android/master/LICENSE.md)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Mapbox Android Telemetry Library.
-URL: [https://github.com/mapbox/mapbox-events-android](https://github.com/mapbox/mapbox-events-android)
+Mapbox GL uses portions of the Mapbox Android Telemetry Library.  
+URL: [https://github.com/mapbox/mapbox-events-android](https://github.com/mapbox/mapbox-events-android)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Mapbox Services SDK.
-URL: [https://github.com/mapbox/mapbox-java](https://github.com/mapbox/mapbox-java)
+Mapbox GL uses portions of the Mapbox Services SDK.  
+URL: [https://github.com/mapbox/mapbox-java](https://github.com/mapbox/mapbox-java)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the OkHttp.
+Mapbox GL uses portions of the OkHttp.  
 License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Okio.
+Mapbox GL uses portions of the Okio.  
 License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Timber.
-URL: [https://github.com/JakeWharton/timber](https://github.com/JakeWharton/timber)
+Mapbox GL uses portions of the Timber.  
+URL: [https://github.com/JakeWharton/timber](https://github.com/JakeWharton/timber)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Gradle License Plugin.
-URL: [https://github.com/jaredsburrows/gradle-license-plugin](https://github.com/jaredsburrows/gradle-license-plugin)
+Mapbox GL uses portions of the Gradle License Plugin.  
+URL: [https://github.com/jaredsburrows/gradle-license-plugin](https://github.com/jaredsburrows/gradle-license-plugin)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================

--- a/platform/android/scripts/generate-license.py
+++ b/platform/android/scripts/generate-license.py
@@ -5,8 +5,8 @@ import json
 
 path = os.getcwd() + "/platform/android/"
 with open(path + "LICENSE.md", 'w') as licenseFile:
-    licenseFile.write("<!-- This file was generated. Use `make android-license` to update. -->\n")
-    licenseFile.write("## Additional Mapbox GL licenses\n")
+    licenseFile.write("<!-- This file was generated. Use `make android-license` to update. -->  \n")
+    licenseFile.write("## Additional Mapbox GL licenses  \n")
     with open(path + "MapboxGLAndroidSDK/build/reports/licenses/licenseReleaseReport.json", 'r') as dataFile:
         data = json.load(dataFile)
 
@@ -33,7 +33,7 @@ with open(path + "LICENSE.md", 'w') as licenseFile:
                 licenseName = license["license"]
                 licenseUrl = license["license_url"]
 
-            licenseFile.write("Mapbox GL uses portions of the %s.\n" % projectName +
-                              ("URL: [%s](%s)\n" % (projectUrl, projectUrl) if projectUrl is not None else "") +
+            licenseFile.write("Mapbox GL uses portions of the %s.  \n" % projectName +
+                              ("URL: [%s](%s)  \n" % (projectUrl, projectUrl) if projectUrl is not None else "") +
                               "License: [%s](%s)" % (licenseName, licenseUrl) +
                               "\n\n===========================================================================\n\n")


### PR DESCRIPTION
Refs. https://github.com/mapbox/mapbox-gl-native/pull/12139. Fixes [`platform/android/LICENSE.md`](https://github.com/mapbox/mapbox-gl-native/blob/master/platform/android/LICENSE.md) formatting.