### PR TITLE
backport to chai: Telemetry bump to v3.1.3

### DIFF
--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
     versions = [
             mapboxServices : '3.2.0',
-            mapboxTelemetry: '3.1.2',
+            mapboxTelemetry: '3.1.3',
             mapboxGestures : '0.2.0',
             supportLib     : '27.1.1',
             espresso       : '3.0.2',


### PR DESCRIPTION
CP https://github.com/mapbox/mapbox-gl-native/pull/12156 to `release-chai`.