### PR TITLE
Initialize RunLoop::Impl::nextRunnable iterator

### DIFF
--- a/platform/android/src/run_loop_impl.hpp
+++ b/platform/android/src/run_loop_impl.hpp
@@ -57,7 +57,7 @@ private:
 
     std::recursive_mutex mtx;
     std::list<Runnable*> runnables;
-    std::list<Runnable*>::iterator nextRunnable;
+    std::list<Runnable*>::iterator nextRunnable = runnables.end();
 };
 
 } // namespace util


### PR DESCRIPTION
The `nextRunnable` member is not initialized. While we explicitly set it in most cases before using it, we could trigger undefined memory access in this scenario:

* `addRunnable(x)`
* no call to `processRunnables()` meanwhile
* `removeRunnable(x)`

If the uninitialized `nextRunnable` happens to point to the same memory as `runnable->iter`, we're calling `++nextRunnable` on undefined memory.