### PR TITLE
Look more widely for IBDesignablesAgent (release-chai)

### DIFF
--- a/platform/darwin/src/NSProcessInfo+MGLAdditions.m
+++ b/platform/darwin/src/NSProcessInfo+MGLAdditions.m
@@ -1,15 +1,9 @@
 #import "NSProcessInfo+MGLAdditions.h"
 
-#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
-    static NSString * const MGLIBDesignablesAgentProcessName = @"IBDesignablesAgentCocoaTouch";
-#elif TARGET_OS_MAC
-    static NSString * const MGLIBDesignablesAgentProcessName = @"IBDesignablesAgent";
-#endif
-
 @implementation NSProcessInfo (MGLAdditions)
 
 - (BOOL)mgl_isInterfaceBuilderDesignablesAgent {
-    return [self.processName isEqualToString:MGLIBDesignablesAgentProcessName];
+    return [self.processName hasPrefix:@"IBDesignablesAgent"];
 }
 
 @end

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Packaging
 
 * The minimum deployment target for this SDK is now macOS 10.11.0. ([#11776](https://github.com/mapbox/mapbox-gl-native/pull/11776))
+* Fixed an issue where `MGLMapView` produced a designable error in Interface Builder storyboards. ([#12140](https://github.com/mapbox/mapbox-gl-native/pull/12140))
 
 ### Style layers
 


### PR DESCRIPTION
Cherry-pick of #12140 to the release-chai branch for iOS map SDK v4.1.0 and macOS map SDK v0.8.0.

/cc @julianrex