### PR TITLE
Added check for `-Wtautological-constant-compare` prior to ignore.

### DIFF
--- a/src/mbgl/util/http_header.cpp
+++ b/src/mbgl/util/http_header.cpp
@@ -8,7 +8,9 @@
 #pragma GCC diagnostic ignored "-Wshadow"
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wshorten-64-to-32"
-#pragma clang diagnostic ignored "-Wtautological-constant-compare"
+//#if __has_warning("-Wtautological-constant-compare")
+    #pragma clang diagnostic ignored "-Wtautological-constant-compare"
+//#endif
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/phoenix_core.hpp>
 #include <boost/spirit/include/phoenix_operator.hpp>

--- a/src/mbgl/util/http_header.cpp
+++ b/src/mbgl/util/http_header.cpp
@@ -8,9 +8,9 @@
 #pragma GCC diagnostic ignored "-Wshadow"
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wshorten-64-to-32"
-//#if __has_warning("-Wtautological-constant-compare")
+#if __has_warning("-Wtautological-constant-compare")
     #pragma clang diagnostic ignored "-Wtautological-constant-compare"
-//#endif
+#endif
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/phoenix_core.hpp>
 #include <boost/spirit/include/phoenix_operator.hpp>

--- a/src/mbgl/util/http_header.cpp
+++ b/src/mbgl/util/http_header.cpp
@@ -7,10 +7,10 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
 #pragma clang diagnostic push
+
 #pragma clang diagnostic ignored "-Wshorten-64-to-32"
-#if __has_warning("-Wtautological-constant-compare")
-    #pragma clang diagnostic ignored "-Wtautological-constant-compare"
-#endif
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wtautological-constant-compare"
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/phoenix_core.hpp>
 #include <boost/spirit/include/phoenix_operator.hpp>


### PR DESCRIPTION
This removes a build warning on iOS: `Unknown warning group '-Wtautological-constant-compare', ignored`

/cc @tobrun 