### PR TITLE
Android: make sure the object is still valid before calling nativeOnResponse()

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HTTPRequest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HTTPRequest.java
@@ -189,7 +189,11 @@ class HTTPRequest implements Callback {
       @Override
       public void onResponse(byte[] bytes) {
         if (bytes != null) {
-          nativeOnResponse(200, null, null, null, null, null, null, bytes);
+          lock.lock();
+          if (nativePtr != 0) {
+            nativeOnResponse(200, null, null, null, null, null, null, bytes);
+          }
+          lock.unlock();
         }
       }
     }).execute(resourceUrl);


### PR DESCRIPTION
When the DefaultFileSource goes away while a request is in progress that loads from the local file system with `local://`, we could be invoking `nativeOnResponse()` on an invalid object.