### PR TITLE
[ios, build] Bump CircleCI to Xcode 9.4

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -718,7 +718,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-debug:
     macos:
-      xcode: "9.3.0"
+      xcode: "9.4.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -745,7 +745,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-sanitize:
     macos:
-      xcode: "9.3.0"
+      xcode: "9.4.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -766,7 +766,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-sanitize-address:
     macos:
-      xcode: "9.3.0"
+      xcode: "9.4.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -787,7 +787,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-static-analyzer:
     macos:
-      xcode: "9.3.0"
+      xcode: "9.4.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -808,7 +808,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-release:
     macos:
-      xcode: "9.3.0"
+      xcode: "9.4.0"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     shell: /bin/bash --login -eo pipefail
@@ -836,7 +836,7 @@ jobs:
 # ------------------------------------------------------------------------------
   macos-debug:
     macos:
-      xcode: "9.3.0"
+      xcode: "9.4.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -890,7 +890,7 @@ jobs:
 # ------------------------------------------------------------------------------
   macos-release-node4:
     macos:
-      xcode: "9.3.0"
+      xcode: "9.4.0"
     environment:
       BUILDTYPE: RelWithDebInfo
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -913,7 +913,7 @@ jobs:
 # ------------------------------------------------------------------------------
   macos-release-node6:
     macos:
-      xcode: "9.3.0"
+      xcode: "9.4.0"
     environment:
       BUILDTYPE: RelWithDebInfo
       HOMEBREW_NO_AUTO_UPDATE: 1


### PR DESCRIPTION
Keep macos-debug-qt5 on Xcode 9.3 for now.