### PR TITLE
[ios,macos] Fixed crash in `-[MGLStyle localizeLabelsIntoLocale:]` 

### DIFF
--- a/platform/darwin/src/MGLVectorTileSource.mm
+++ b/platform/darwin/src/MGLVectorTileSource.mm
@@ -109,7 +109,16 @@ static NSArray * const MGLMapboxStreetsAlternativeLanguages = @[
 + (NSString *)preferredMapboxStreetsLanguageForPreferences:(NSArray<NSString *> *)preferencesArray {
     BOOL acceptsEnglish = [preferencesArray filteredArrayUsingPredicate:
                            [NSPredicate predicateWithBlock:^BOOL(NSString * _Nullable language, NSDictionary<NSString *,id> * _Nullable bindings) {
-        return [[NSLocale localeWithLocaleIdentifier:language].languageCode isEqualToString:@"en"];
+        NSString *languageCode;
+
+        if (@available(iOS 10.0, macOS 10.12.0, *)) {
+            languageCode = [NSLocale localeWithLocaleIdentifier:language].languageCode;
+        }
+        else {
+            languageCode = [[NSLocale localeWithLocaleIdentifier:language] objectForKey:NSLocaleLanguageCode];
+        }
+
+        return [languageCode isEqualToString:@"en"];
     }]].count;
     
     NSArray<NSString *> *availableLanguages = acceptsEnglish ? MGLMapboxStreetsLanguages : MGLMapboxStreetsAlternativeLanguages;

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+* Fixed crash in `-[MGLStyle localizeLabelsIntoLocale:]` on iOS 9.3 (attempting to access a property that was introduced in iOS 10.0) ([#12123](https://github.com/mapbox/mapbox-gl-native/pull/12123))
+
 ## 4.0.2 - May 29, 2018
 
 * Fixed a crash when constant expressions were used for style properties that didn't support data-driven styling. ([#11960](https://github.com/mapbox/mapbox-gl-native/issues/11960))

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog for Mapbox Maps SDK for macOS
 
+* Fixed crash in `-[MGLStyle localizeLabelsIntoLocale:]` on iOS 9.3 (attempting to access a property that was introduced in iOS 10.0) ([#12123](https://github.com/mapbox/mapbox-gl-native/pull/12123))
+
 ## 0.7.1
 
 ### Style layers


### PR DESCRIPTION
[ios,macos] Fixed crash in `-[MGLStyle localizeLabelsIntoLocale:]` on iOS 9.3 (#12123)

# Conflicts:
#	platform/ios/CHANGELOG.md
#	platform/macos/CHANGELOG.md