### PR TITLE
[core] Fix GCC8's new -Wcatch-value warnings

### DIFF
--- a/bin/offline.cpp
+++ b/bin/offline.cpp
@@ -33,14 +33,14 @@ int main(int argc, char *argv[]) {
 
     try {
         argumentParser.ParseCLI(argc, argv);
-    } catch (args::Help) {
+    } catch (const args::Help&) {
         std::cout << argumentParser;
         exit(0);
-    } catch (args::ParseError e) {
+    } catch (const args::ParseError& e) {
         std::cerr << e.what() << std::endl;
         std::cerr << argumentParser;
         exit(1);
-    } catch (args::ValidationError e) {
+    } catch (const args::ValidationError& e) {
         std::cerr << e.what() << std::endl;
         std::cerr << argumentParser;
         exit(2);

--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -39,14 +39,14 @@ int main(int argc, char *argv[]) {
 
     try {
         argumentParser.ParseCLI(argc, argv);
-    } catch (args::Help) {
+    } catch (const args::Help&) {
         std::cout << argumentParser;
         exit(0);
-    } catch (args::ParseError e) {
+    } catch (const args::ParseError& e) {
         std::cerr << e.what() << std::endl;
         std::cerr << argumentParser;
         exit(1);
-    } catch (args::ValidationError e) {
+    } catch (const args::ValidationError& e) {
         std::cerr << e.what() << std::endl;
         std::cerr << argumentParser;
         exit(2);

--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -658,7 +658,7 @@ void OfflineDatabase::putRegionResources(int64_t regionID, const std::list<std::
                 status.completedTileCount += 1;
                 status.completedTileSize += resourceSize;
             }
-        } catch (MapboxTileLimitExceededException) {
+        } catch (const MapboxTileLimitExceededException&) {
             // Commit the rest of the batch and retrow
             transaction.commit();
             throw;

--- a/platform/default/mbgl/storage/offline_download.cpp
+++ b/platform/default/mbgl/storage/offline_download.cpp
@@ -355,7 +355,7 @@ void OfflineDownload::ensureResource(const Resource& resource,
             if (buffer.size() == 64 || resourcesRemaining.size() == 0) {
                 try {
                     offlineDatabase.putRegionResources(id, buffer, status);
-                } catch (MapboxTileLimitExceededException) {
+                } catch (const MapboxTileLimitExceededException&) {
                     onMapboxTileCountLimitExceeded();
                     return;
                 }

--- a/platform/glfw/main.cpp
+++ b/platform/glfw/main.cpp
@@ -51,14 +51,14 @@ int main(int argc, char *argv[]) {
 
     try {
         argumentParser.ParseCLI(argc, argv);
-    } catch (args::Help) {
+    } catch (const args::Help&) {
         std::cout << argumentParser;
         exit(0);
-    } catch (args::ParseError e) {
+    } catch (const args::ParseError& e) {
         std::cerr << e.what() << std::endl;
         std::cerr << argumentParser;
         exit(1);
-    } catch (args::ValidationError e) {
+    } catch (const args::ValidationError& e) {
         std::cerr << e.what() << std::endl;
         std::cerr << argumentParser;
         exit(2);

--- a/src/mbgl/style/expression/coercion.cpp
+++ b/src/mbgl/style/expression/coercion.cpp
@@ -13,7 +13,7 @@ EvaluationResult toNumber(const Value& v) {
         [](const std::string& s) -> optional<double> {
             try {
                 return util::stof(s);
-            } catch(std::exception) {
+            } catch (const std::exception&) {
                 return optional<double>();
             }
         },

--- a/test/storage/offline_database.test.cpp
+++ b/test/storage/offline_database.test.cpp
@@ -631,7 +631,7 @@ TEST(OfflineDatabase, BatchInsertionMapboxTileCountExceeded) {
     try {
         db.putRegionResources(region.getID(), resources, status);
         EXPECT_FALSE(true);
-    } catch (MapboxTileLimitExceededException) {
+    } catch (const MapboxTileLimitExceededException&) {
         // Expected
     }
     

--- a/test/style/style.test.cpp
+++ b/test/style/style.test.cpp
@@ -65,7 +65,7 @@ TEST(Style, DuplicateSource) {
     try {
         style.addSource(std::make_unique<VectorSource>("sourceId", "mapbox://mapbox.mapbox-terrain-v2"));
         FAIL() << "Should not have been allowed to add a duplicate source id";
-    } catch (std::runtime_error) {
+    } catch (const std::runtime_error&) {
         // Expected
     }
 }

--- a/test/style/style_layer.test.cpp
+++ b/test/style/style_layer.test.cpp
@@ -285,7 +285,7 @@ TEST(Layer, DuplicateLayer) {
     try {
         style.addLayer(std::make_unique<LineLayer>("line", "unusedsource"));
         FAIL() << "Should not have been allowed to add a duplicate layer id";
-    } catch (const std::runtime_error e) {
+    } catch (const std::runtime_error& e) {
         // Expected
         ASSERT_STREQ("Layer line already exists", e.what());
     }


### PR DESCRIPTION
Polymorphic types shouldn't be caught by value, as the warning message says. Catch them by constant reference instead.