### PR TITLE
Remove incorrect any_cast<>(unique_any) 

### DIFF
--- a/include/mbgl/util/unique_any.hpp
+++ b/include/mbgl/util/unique_any.hpp
@@ -222,33 +222,9 @@ template<typename ValueType>
 inline ValueType* any_cast(unique_any* any)
 {
     if(any == nullptr || any->type() != typeid(ValueType))
-        return nullptr;
+        throw bad_any_cast();
     else
         return any->cast<ValueType>();
-}
-
-template<typename ValueType, typename _Vt = std::decay_t<ValueType> >
-inline ValueType any_cast(const unique_any& any)
-{
-    static_assert(std::is_constructible<ValueType, const _Vt&>::value,
-        "any_cast type can't construct copy of contained object");
-    auto temp = any_cast<_Vt>(&any);
-    if (temp == nullptr) {
-        throw bad_any_cast();
-    }
-    return static_cast<ValueType>(*temp);
-}
-
-template<typename ValueType, typename _Vt = std::decay_t<ValueType> >
-inline ValueType any_cast(unique_any& any)
-{
-    static_assert(std::is_constructible<ValueType, const _Vt&>::value,
-        "any_cast type can't construct copy of contained object");
-    auto temp = any_cast<_Vt>(&any);
-    if (temp == nullptr) {
-        throw bad_any_cast();
-    }
-    return static_cast<ValueType>(*temp);
 }
 
 template<typename ValueType, typename _Vt = std::remove_cv_t<ValueType> >

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -177,7 +177,8 @@ static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
 }
 
 - (MGLSource *)sourceFromMBGLSource:(mbgl::style::Source *)rawSource {
-    if (MGLSource *source = rawSource->peer.has_value() ? mbgl::util::any_cast<SourceWrapper>(rawSource->peer).source : nil) {
+    if (rawSource->peer.has_value()) {
+        MGLSource* source = mbgl::util::any_cast<SourceWrapper>(&(rawSource->peer))->source;
         return source;
     }
 

--- a/test/util/unique_any.test.cpp
+++ b/test/util/unique_any.test.cpp
@@ -42,7 +42,7 @@ TEST(UniqueAny, BasicTypes) {
     EXPECT_TRUE(i.type() == typeid(int));
     EXPECT_TRUE(IsStackAllocated(i, any_cast<int>(&i)));
 
-    auto iValue = any_cast<int>(i);
+    auto iValue = *any_cast<int>(&i);
     EXPECT_TRUE(iValue == 3);
 
     EXPECT_TRUE(unique_any(4).has_value());
@@ -53,7 +53,7 @@ TEST(UniqueAny, BasicTypes) {
     EXPECT_TRUE(f.type() == typeid(float));
     EXPECT_TRUE(IsStackAllocated(f, any_cast<float>(&f)));
 
-    const float fValue = any_cast<const float>(f);
+    const float fValue = *any_cast<const float>(&f);
     EXPECT_TRUE(fValue == 6.2f);
 
     EXPECT_TRUE(unique_any(1.0f).has_value());
@@ -64,7 +64,7 @@ TEST(UniqueAny, BasicTypes) {
     EXPECT_TRUE(c.type() == typeid(char));
     EXPECT_TRUE(IsStackAllocated(c, any_cast<char>(&c)));
 
-    EXPECT_THROW(any_cast<float>(c), bad_any_cast);
+    EXPECT_THROW(any_cast<float>(&c), bad_any_cast);
 
     EXPECT_TRUE(unique_any('4').has_value());
     EXPECT_TRUE(unique_any('4').type() == typeid(char));
@@ -166,14 +166,13 @@ TEST(UniqueAny, SharedPtr) {
     std::weak_ptr<int> weak = shared;
     unique_any u1 = 0;
 
-    EXPECT_THROW(any_cast<float>(u1), bad_any_cast);
+    EXPECT_THROW(any_cast<float>(&u1), bad_any_cast);
 
     EXPECT_EQ(weak.use_count(), 1);
     unique_any u2 = shared;
     EXPECT_EQ(weak.use_count(), 2);
 
-    EXPECT_EQ(any_cast<std::unique_ptr<int>>(&u1), nullptr);
-    EXPECT_FALSE(IsStackAllocated(u1, any_cast<std::shared_ptr<TestType>>(&u1)));
+    EXPECT_THROW(any_cast<std::unique_ptr<int>>(&u1), bad_any_cast);
 
     u1 = std::move(u2);
     EXPECT_EQ(weak.use_count(), 2);


### PR DESCRIPTION
Closes #11631.

Remove `any_cast<>(unique_any...)` overloads that return copied values. This breaks the `unique_any` contract. 

cc @jfirebaugh @kkaefer 