### PR TITLE
Insert tiles and resources (using batches)

### DIFF
--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -124,7 +124,7 @@ public:
      */
     void setOfflineMapboxTileCountLimit(uint64_t) const;
     
-    void startPutRegionResources(OfflineRegion& region, const std::list<std::tuple<Resource, Response, bool>>&, std::function<void (std::exception_ptr)> callback);
+    void startPutRegionResources(const int64_t regionID, const std::list<std::tuple<Resource, Response, bool>>&, std::function<void (std::exception_ptr)> callback);
 
     /*
      * Pause file request activity.

--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -8,6 +8,7 @@
 
 #include <vector>
 #include <mutex>
+#include <list>
 
 namespace mbgl {
 
@@ -122,6 +123,8 @@ public:
      * by the Mapbox Terms of Service.
      */
     void setOfflineMapboxTileCountLimit(uint64_t) const;
+    
+    void startPutRegionResources(OfflineRegion& region, const std::list<std::tuple<Resource, Response, bool>>&, std::function<void (std::exception_ptr)> callback);
 
     /*
      * Pause file request activity.

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
@@ -87,6 +87,13 @@ public class OfflineManager {
     void onError(String error);
   }
 
+  public interface PutOfflineCallback {
+
+      void onPut();
+
+      void onError(String error);
+  }
+
   /*
    * Constructor
    */
@@ -260,5 +267,43 @@ public class OfflineManager {
 
   private native void createOfflineRegion(FileSource fileSource, OfflineRegionDefinition definition,
                                           byte[] metadata, CreateOfflineRegionCallback callback);
+
+  /**
+   * Add a resource to be inserted into the cache. Call commitResourcesForPack for every batch.
+   *
+   * @param url url to resource.
+   * @param data a byte array with the content of the resource.
+   * @param compressed boolean true if the data content is compressed.
+   * @param modified a long with the number of *seconds* since epoc. or 0 if not set.
+   * @param expires a long with the number of *seconds* since epoc. or 0 if not set.
+   * @param eTag
+   * @param regionId
+   */
+  public native void putResourceWithUrl(String url, byte[] data, boolean compressed, long modified,
+                                        long expires, String eTag, long regionId);
+
+  /**
+   * Add a tile to be inserted into the cache. Call commitResourcesForPack for every batch.
+   *
+   * @param url a String with url template of the tile.
+   * @param pixelRatio
+   * @param x
+   * @param y
+   * @param z
+   * @param data a byte array with the content of the resource.
+   * @param compressed boolean true if the data content is compressed.
+   * @param modified a long with the number of *seconds* since epoc. or 0 if not set.
+   * @param expires a long with the number of *seconds* since epoc. or 0 if not set.
+   * @param eTag
+   * @param regionId
+   */
+  public native void putTileWithUrlTemplate(String url, float pixelRatio,
+                                            int x, int y, int z, byte[] data, boolean compressed,
+                                            long modified, long expires, String eTag, long regionId);
+
+  /**
+   * Insert a batch of tiles and resources into the cache. Call after some putTileWithUrlTemplate/putResourceWithUrl.
+   */
+  public native void commitResourcesForPack(long regionId, PutOfflineCallback callback);
 
 }

--- a/platform/android/src/offline/offline_manager.cpp
+++ b/platform/android/src/offline/offline_manager.cpp
@@ -195,7 +195,10 @@ void OfflineManager::registerNative(jni::JNIEnv& env) {
         "finalize",
         METHOD(&OfflineManager::setOfflineMapboxTileCountLimit, "setOfflineMapboxTileCountLimit"),
         METHOD(&OfflineManager::listOfflineRegions, "listOfflineRegions"),
-        METHOD(&OfflineManager::createOfflineRegion, "createOfflineRegion"));
+        METHOD(&OfflineManager::createOfflineRegion, "createOfflineRegion"),
+        METHOD(&OfflineManager::putResourceWithUrl, "putResourceWithUrl"),
+        METHOD(&OfflineManager::putTileWithUrlTemplate, "putTileWithUrlTemplate"),
+        METHOD(&OfflineManager::commitResourcesForPack, "commitResourcesForPack"));
 }
 
 // OfflineManager::ListOfflineRegionsCallback //

--- a/platform/android/src/offline/offline_manager.hpp
+++ b/platform/android/src/offline/offline_manager.hpp
@@ -9,7 +9,6 @@
 #include "offline_region.hpp"
 #include "offline_region_definition.hpp"
 
-
 namespace mbgl {
 namespace android {
 
@@ -48,6 +47,19 @@ public:
         static void registerNative(jni::JNIEnv&);
     };
 
+    class PutOfflineCallback {
+    public:
+        static constexpr auto Name() { return "com/mapbox/mapboxsdk/offline/OfflineManager$PutOfflineCallback";}
+
+        static void onError(jni::JNIEnv&, jni::Object<OfflineManager::PutOfflineCallback>, std::exception_ptr);
+
+        static void onPut(jni::JNIEnv&, jni::Object<OfflineManager::PutOfflineCallback>);
+
+        static jni::Class<OfflineManager::PutOfflineCallback> javaClass;
+
+        static void registerNative(jni::JNIEnv&);
+    };
+
     static constexpr auto Name() { return "com/mapbox/mapboxsdk/offline/OfflineManager"; };
 
     static jni::Class<OfflineManager> javaClass;
@@ -66,6 +78,30 @@ public:
                              jni::Object<OfflineRegionDefinition> definition,
                              jni::Array<jni::jbyte> metadata,
                              jni::Object<OfflineManager::CreateOfflineRegionCallback> callback);
+
+    void putResourceWithUrl(jni::JNIEnv&,
+                            jni::String url_,
+                            jni::Array<jni::jbyte> arr,
+                            jboolean compressed,
+                            jlong modified,
+                            jlong expires,
+                            jni::String eTag_,
+                            jlong regionId);
+
+    void putTileWithUrlTemplate(jni::JNIEnv&,
+                                jni::String urlTemplate_,
+                                jfloat pixelRatio,
+                                jint x,
+                                jint y,
+                                jint z,
+                                jni::Array<jni::jbyte> arr,
+                                jboolean compressed,
+                                jlong modified,
+                                jlong expires,
+                                jni::String eTag_,
+                                jlong regionId);
+
+    void commitResourcesForPack(jni::JNIEnv&, jlong regionId, jni::Object<OfflineManager::PutOfflineCallback> callback_);
 
 private:
     mbgl::DefaultFileSource& fileSource;

--- a/platform/darwin/src/MGLOfflineStorage.h
+++ b/platform/darwin/src/MGLOfflineStorage.h
@@ -294,7 +294,7 @@ MGL_EXPORT
 /**
  Insert a batch of tiles and resources into the cache. Call after some putTileWithUrlTemplate/putResourceWithUrl.
  */
--(void)commitResourcesWithCompletionHandler:(void (^)(NSError * _Nullable error))completion;
+-(void)commitResourcesForPack:(MGLOfflinePack *)pack withCompletionHandler:(void (^)(NSError * _Nullable error))completion;
 
 /**
  The cumulative size, measured in bytes, of all downloaded resources on disk.

--- a/platform/darwin/src/MGLOfflineStorage.h
+++ b/platform/darwin/src/MGLOfflineStorage.h
@@ -282,6 +282,21 @@ MGL_EXPORT
 - (void)setMaximumAllowedMapboxTiles:(uint64_t)maximumCount;
 
 /**
+ Add a tile to be inserted into the cache. Call commitResourcesWithCompletionHandler for every batch.
+ */
+-(void)putTileWithUrlTemplate:(NSString *)urlTemplate pixelRatio:(float)pixelRatio x:(int32_t)x y:(int32_t)y z:(int8_t)z data:(NSData *)data compressed:(BOOL)compressed modified:(NSDate *)modified expires:(NSDate *)expires etag:(NSString *)etag pack:(MGLOfflinePack *)pack;
+
+/**
+ Add a resource to be inserted into the cache. Call commitResourcesWithCompletionHandler for every batch.
+ */
+-(void)putResourceWithUrl:(NSString *)url data:(NSData *)data compressed:(BOOL)compressed modified:(NSDate *)modified expires:(NSDate *)expires etag:(NSString *)etag pack:(MGLOfflinePack *)pack;
+
+/**
+ Insert a batch of tiles and resources into the cache. Call after some putTileWithUrlTemplate/putResourceWithUrl.
+ */
+-(void)commitResourcesWithCompletionHandler:(void (^)(NSError * _Nullable error))completion;
+
+/**
  The cumulative size, measured in bytes, of all downloaded resources on disk.
 
  The returned value includes all resources, including tiles, whether downloaded

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -435,7 +435,7 @@ const MGLOfflinePackUserInfoKey MGLOfflinePackUserInfoKeyMaximumCount = @"Maximu
         _resourcesToInsertByRegionID.erase(it++);
     }
     
-    _mbglFileSource->startPutRegionResources(*pack.mbglOfflineRegion, resources, [&, completion](std::exception_ptr exception) {
+    _mbglFileSource->startPutRegionResources(*pack.mbglOfflineRegion->getID(), resources, [&, completion](std::exception_ptr exception) {
         NSError *error;
         if (exception) {
             error = [NSError errorWithDomain:MGLErrorDomain code:-1 userInfo:@{

--- a/platform/default/default_file_source.cpp
+++ b/platform/default/default_file_source.cpp
@@ -174,6 +174,16 @@ public:
     void put(const Resource& resource, const Response& response) {
         offlineDatabase->put(resource, response);
     }
+    
+    void startPutRegionResources(const int64_t regionID, const std::list<std::tuple<Resource, Response, bool>>& resources, std::function<void (std::exception_ptr)> callback) {
+        try {
+            OfflineRegionStatus status;
+            offlineDatabase->putRegionResources(regionID, resources, status);
+            callback({});
+        } catch (...) {
+            callback(std::current_exception());
+        }
+    }
 
 private:
     OfflineDownload& getDownload(int64_t regionID) {
@@ -285,6 +295,10 @@ void DefaultFileSource::getOfflineRegionStatus(OfflineRegion& region, std::funct
 
 void DefaultFileSource::setOfflineMapboxTileCountLimit(uint64_t limit) const {
     impl->actor().invoke(&Impl::setOfflineMapboxTileCountLimit, limit);
+}
+    
+void DefaultFileSource::startPutRegionResources(OfflineRegion& region, const std::list<std::tuple<Resource, Response, bool>>& resources, std::function<void (std::exception_ptr)> callback) {
+    impl->actor().invoke(&Impl::startPutRegionResources, region.getID(), resources, callback);
 }
 
 void DefaultFileSource::pause() {

--- a/platform/default/default_file_source.cpp
+++ b/platform/default/default_file_source.cpp
@@ -297,8 +297,8 @@ void DefaultFileSource::setOfflineMapboxTileCountLimit(uint64_t limit) const {
     impl->actor().invoke(&Impl::setOfflineMapboxTileCountLimit, limit);
 }
     
-void DefaultFileSource::startPutRegionResources(OfflineRegion& region, const std::list<std::tuple<Resource, Response, bool>>& resources, std::function<void (std::exception_ptr)> callback) {
-    impl->actor().invoke(&Impl::startPutRegionResources, region.getID(), resources, callback);
+void DefaultFileSource::startPutRegionResources(const int64_t regionID, const std::list<std::tuple<Resource, Response, bool>>& resources, std::function<void (std::exception_ptr)> callback) {
+    impl->actor().invoke(&Impl::startPutRegionResources, regionID, resources, callback);
 }
 
 void DefaultFileSource::pause() {

--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -56,6 +56,7 @@ public:
     optional<int64_t> hasRegionResource(int64_t regionID, const Resource&);
     uint64_t putRegionResource(int64_t regionID, const Resource&, const Response&);
     void putRegionResources(int64_t regionID, const std::list<std::tuple<Resource, Response>>&, OfflineRegionStatus&);
+    void putRegionResources(int64_t regionID, const std::list<std::tuple<Resource, Response, bool>>&, OfflineRegionStatus&);
 
     OfflineRegionDefinition getRegionDefinition(int64_t regionID);
     OfflineRegionStatus getRegionCompletedStatus(int64_t regionID);
@@ -88,10 +89,12 @@ private:
                      const std::string&, bool compressed);
 
     uint64_t putRegionResourceInternal(int64_t regionID, const Resource&, const Response&);
+    uint64_t putRegionResourceInternal(int64_t regionID, const Resource&, const Response&, bool compressed);
 
     optional<std::pair<Response, uint64_t>> getInternal(const Resource&);
     optional<int64_t> hasInternal(const Resource&);
     std::pair<bool, uint64_t> putInternal(const Resource&, const Response&, bool evict);
+    std::pair<bool, uint64_t> putInternal(const Resource&, const Response&, bool evict, bool compressed);
 
     // Return value is true iff the resource was previously unused by any other regions.
     bool markUsed(int64_t regionID, const Resource&);


### PR DESCRIPTION
Some new methods on `MGLOfflineStorage` to insert tiles and resources from iOS in batches. 

Out app lets the user download SQL tile archives with the same schema as `.mapbox/cache.db`. Our app then does a select * from those tables and use this API to insert the tiles and the resources into the mapbox cache. This works very well and with the new batch API, it is pretty fast.

Our server decide on compress or no-compress when creating the archives. The methods on `MGLOfflineStorage` therefore take a compressed flag. This makes import a lot faster since extra compression is not needed, but it makes this patch less clean.

This is a new version of #10051 that we have used in production for a long time.
The original issue is #9947.