### PR TITLE
Remove reflection lookup for MarkerViewAdapter initialization

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
@@ -637,7 +637,7 @@ public class MarkerViewManager implements MapView.OnMapChangedListener {
     private LayoutInflater inflater;
 
     ImageMarkerViewAdapter(Context context) {
-      super(context);
+      super(context, MarkerView.class);
       inflater = LayoutInflater.from(context);
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -45,7 +45,6 @@ import com.mapbox.mapboxsdk.style.layers.Layer;
 import com.mapbox.mapboxsdk.style.light.Light;
 import com.mapbox.mapboxsdk.style.sources.Source;
 
-import java.lang.reflect.ParameterizedType;
 import java.util.HashMap;
 import java.util.List;
 
@@ -2525,10 +2524,9 @@ public final class MapboxMap {
      *
      * @param context the context associated to a MapView
      */
-    @SuppressWarnings("unchecked")
-    public MarkerViewAdapter(Context context) {
+    public MarkerViewAdapter(Context context, Class<U> persistentClass) {
       this.context = context;
-      persistentClass = (Class<U>) ((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments()[0];
+      this.persistentClass = persistentClass;
       viewReusePool = new Pools.SimplePool<>(10000);
     }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/MarkerViewActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/MarkerViewActivity.java
@@ -260,7 +260,7 @@ public class MarkerViewActivity extends AppCompatActivity {
     private MapboxMap mapboxMap;
 
     CountryAdapter(@NonNull Context context, @NonNull MapboxMap mapboxMap) {
-      super(context);
+      super(context, CountryMarkerView.class);
       this.inflater = LayoutInflater.from(context);
       this.mapboxMap = mapboxMap;
     }
@@ -333,7 +333,7 @@ public class MarkerViewActivity extends AppCompatActivity {
     private MapboxMap mapboxMap;
 
     public TextAdapter(@NonNull Context context, @NonNull MapboxMap mapboxMap) {
-      super(context);
+      super(context, TextMarkerView.class);
       this.inflater = LayoutInflater.from(context);
       this.mapboxMap = mapboxMap;
     }


### PR DESCRIPTION
This PR fixes the need of using reflection to lookup the class by passing it as an argument instead. Some bytecode optimizers had trouble interpreting these lines. While it breaks semver, I think the severity justifies the cause.  