### PR TITLE
Add per-platform issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/android.md
+++ b/.github/ISSUE_TEMPLATE/android.md
@@ -1,0 +1,33 @@
+---
+name: Android
+about: Mapbox Maps SDK for Android
+
+---
+<!--
+Hello and thanks for contributing to the Mapbox Maps SDK for Android! To help us diagnose your problem quickly, please:
+
+ - Include a minimal demonstration of the bug, including code, logs, and screenshots.
+ - Ensure you can reproduce the bug using the latest release.
+ - Only post to report a bug or request a feature; direct all other questions to: https://stackoverflow.com/questions/tagged/mapbox
+
+Start with a brief description below this line. -->
+
+### Steps to reproduce
+
+ 1.
+ 2.
+ 3.
+
+### Expected behavior
+
+
+
+### Actual behavior
+
+
+
+### Configuration
+
+**Android versions:** 
+**Device models:** 
+**Mapbox SDK versions:** 

--- a/.github/ISSUE_TEMPLATE/ios.md
+++ b/.github/ISSUE_TEMPLATE/ios.md
@@ -1,0 +1,33 @@
+---
+name: iOS
+about: Mapbox Maps SDK for iOS
+
+---
+<!--
+Hello and thanks for contributing to the Mapbox Maps SDK for iOS! To help us diagnose your problem quickly, please:
+
+ - Include a minimal demonstration of the bug, including code, logs, and screenshots.
+ - Ensure you can reproduce the bug using the latest release.
+ - Only post to report a bug or request a feature; direct all other questions to: https://stackoverflow.com/questions/tagged/mapbox
+
+Start with a brief description below this line. -->
+
+### Steps to reproduce
+
+ 1.
+ 2.
+ 3.
+
+### Expected behavior
+
+
+
+### Actual behavior
+
+
+
+### Configuration
+
+**iOS versions:** 
+**Device/simulator models:** 
+**Mapbox SDK versions:** 

--- a/.github/ISSUE_TEMPLATE/macos.md
+++ b/.github/ISSUE_TEMPLATE/macos.md
@@ -1,15 +1,18 @@
+---
+name: macOS
+about: Mapbox Maps SDK for macOS
+
+---
 <!--
-Hello and thanks for contributing! To help us diagnose your problem quickly, please:
+Hello and thanks for contributing to the Mapbox Maps SDK for macOS! To help us diagnose your problem quickly, please:
 
  - Include a minimal demonstration of the bug, including code, logs, and screenshots.
  - Ensure you can reproduce the bug using the latest release.
  - Only post to report a bug or request a feature; direct all other questions to: https://stackoverflow.com/questions/tagged/mapbox
--->
 
-**Platform:**
-**Mapbox SDK version:**
+Start with a brief description below this line. -->
 
-### Steps to trigger behavior
+### Steps to reproduce
 
  1.
  2.
@@ -17,4 +20,14 @@ Hello and thanks for contributing! To help us diagnose your problem quickly, ple
 
 ### Expected behavior
 
+
+
 ### Actual behavior
+
+
+
+### Configuration
+
+**macOS versions:** 
+**Mac models:** 
+**Mapbox SDK versions:** 

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,0 +1,25 @@
+---
+name: Other
+about: Another platform or a cross-platform issue
+
+---
+<!--
+Hello and thanks for contributing to the Mapbox Maps SDK! To help us diagnose your problem quickly, please:
+
+ - Include a minimal demonstration of the bug, including code, logs, and screenshots.
+ - Ensure you can reproduce the bug using the latest release.
+ - Only post to report a bug or request a feature; direct all other questions to: https://stackoverflow.com/questions/tagged/mapbox
+-->
+
+**Platform:**
+**Mapbox SDK version:**
+
+### Steps to trigger behavior
+
+ 1.
+ 2.
+ 3.
+
+### Expected behavior
+
+### Actual behavior


### PR DESCRIPTION
Following the lead of mapbox/mapbox-gl-js#6606, this PR divides the issue template up by platform, so contributors have to choose one of the following options before they can open an issue:

* **Android**
  Mapbox Maps SDK for Android
* **iOS**
  Mapbox Maps SDK for iOS
* **macOS**
  Mapbox Maps SDK for macOS
* **Other**
  Other platform or cross-platform issue

For the moment, I’ve added templates for just three of the platforms, the ones where the default template (now “Other”) doesn’t currently ask for enough detail. But we can add templates for more platforms as needed.

/cc @mapbox/android @mapbox/ios