### PR TITLE
[ios] Preserve bcsymbolmap files when using CocoaPods

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,6 +4,10 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ## 4.2.0
 
+### Packaging
+
+* When integrating this framework using CocoaPods, the included bcsymbolmap files are now preserved. If you have bitcode enabled and you are seeing incorrectly symbolicated crash logs, you should create a build phase in your Xcode project that copies these bcsymbolmap files to your app’s Products Directory when installing. ([#12257](https://github.com/mapbox/mapbox-gl-native/pull/12257))
+
 ### Styles and rendering
 
 * Added an `MGLRasterStyleLayer.rasterResamplingMode` property for configuring how raster style layers are overscaled. ([#12176](https://github.com/mapbox/mapbox-gl-native/pull/12176))

--- a/platform/ios/Mapbox-iOS-SDK-nightly-dynamic.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-nightly-dynamic.podspec
@@ -27,4 +27,6 @@ Pod::Spec.new do |m|
   m.vendored_frameworks = 'dynamic/Mapbox.framework'
   m.module_name = 'Mapbox'
 
+  m.preserve_path = '**/*.bcsymbolmap'
+
 end

--- a/platform/ios/Mapbox-iOS-SDK-symbols.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-symbols.podspec
@@ -27,4 +27,6 @@ Pod::Spec.new do |m|
   m.vendored_frameworks = 'dynamic/Mapbox.framework'
   m.module_name = 'Mapbox'
 
+  m.preserve_path = '**/*.bcsymbolmap'
+
 end

--- a/platform/ios/Mapbox-iOS-SDK.podspec
+++ b/platform/ios/Mapbox-iOS-SDK.podspec
@@ -27,4 +27,6 @@ Pod::Spec.new do |m|
   m.vendored_frameworks = 'dynamic/Mapbox.framework'
   m.module_name = 'Mapbox'
 
+  m.preserve_path = '**/*.bcsymbolmap'
+
 end


### PR DESCRIPTION
Bitcode symbol map files (`bcsymbolmap`) are used in conjunction with dSYMs to symbolicate crashes. CocoaPods doesn't yet automatically preserve `bcsymbolmap` files when it is installing vendored pods, so this PR stops CocoaPods from discarding these files.

CocoaPods also does not add `bcsymbolmap` files to an app's `xcarchive`, so the developer needs to do this themselves, typically as an install-only build script phase — see https://github.com/mapbox/mapbox-gl-native/issues/8463#issuecomment-400040165 for general instructions.

### Related issues
- This partially addresses https://github.com/mapbox/mapbox-gl-native/issues/8463, but a full solution will make the inclusion of dSYMs and `bcsymbolmaps` automatic for all integration methods (or obviate that need).
- https://github.com/CocoaPods/CocoaPods/issues/1698 is a related-ish upstream issue.
- #9613 is where we started packaging `bcsymbolmaps` with our framework downloads.

/cc @julianrex @1ec5 @akitchen 