### PR TITLE
Fix crash when trying to parse legacy filters

### DIFF
--- a/src/mbgl/style/expression/is_constant.cpp
+++ b/src/mbgl/style/expression/is_constant.cpp
@@ -4,6 +4,8 @@ namespace mbgl {
 namespace style {
 namespace expression {
 
+constexpr static const char filter[] = "filter-";
+
 bool isFeatureConstant(const Expression& expression) {
     if (auto e = dynamic_cast<const CompoundExpressionBase*>(&expression)) {
         const std::string name = e->getName();
@@ -11,6 +13,9 @@ bool isFeatureConstant(const Expression& expression) {
         if (name == "get" && parameterCount && *parameterCount == 1) {
             return false;
         } else if (name == "has" && parameterCount && *parameterCount == 1) {
+            return false;
+        } else if (std::equal(std::begin(filter), std::end(filter) - 1, name.begin())) {
+            // Legacy filters begin with "filter-" and are never constant.
             return false;
         } else if (
             name == "properties" ||

--- a/test/style/filter.test.cpp
+++ b/test/style/filter.test.cpp
@@ -192,3 +192,7 @@ TEST(Filter, ZoomExpressionNested) {
     ASSERT_TRUE(filter(R"(["==", ["get", "two"], ["zoom"]])", {{"two", int64_t(2)}}, {}, FeatureType::Point, {}, 2.0f));
     ASSERT_FALSE(filter(R"(["==", ["get", "two"], ["+", ["zoom"], 1]])", {{"two", int64_t(2)}}, {}, FeatureType::Point, {}, 2.0f));
 }
+
+TEST(Filter, Internal) {
+    filter(R"(["filter-==","class","snow"])");
+}


### PR DESCRIPTION
Legacy filters aren't part of the style specification, but you can generate them by parsing a legacy filter in a stylesheet, and obtaining the parsed Filter and serializing it.