### PR TITLE
Change error message with invalid render usage

### DIFF
--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -398,7 +398,7 @@ void NodeMap::Render(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     }
 
     if (nodeMap->req) {
-        return Nan::ThrowError("Map is currently rendering an image");
+        return Nan::ThrowError("Map is currently processing a RenderRequest");
     }
 
     try {

--- a/platform/node/test/js/map.test.js
+++ b/platform/node/test/js/map.test.js
@@ -532,7 +532,7 @@ test('Map', function(t) {
             t.throws(function() {
                 map.render({}, function() {});
                 map.render({}, function() {});
-            }, /Map is currently rendering an image/);
+            }, /Map is currently processing a RenderRequest/);
 
             map.release();
             t.end();


### PR DESCRIPTION
This change disambiguates this error condition with a different error with the same error message at https://github.com/mapbox/mapbox-gl-native/blob/789baf4c1f252071bf58e689e050b34eb2656363/src/mbgl/map/map.cpp#L157-L160