### PR TITLE
[core] Keep original input for legacy filters

### DIFF
--- a/include/mbgl/style/filter.hpp
+++ b/include/mbgl/style/filter.hpp
@@ -11,14 +11,18 @@
 
 namespace mbgl {
 namespace style {
-    
+
 class Filter {
 public:
     optional<std::shared_ptr<const expression::Expression>> expression;
-    
+private:
+    optional<mbgl::Value> legacyFilter;
+public:
     Filter() : expression() {}
     
-    Filter(expression::ParseResult _expression) : expression(std::move(*_expression)) {
+    Filter(expression::ParseResult _expression, optional<mbgl::Value> _filter = {})
+    : expression(std::move(*_expression)),
+     legacyFilter(std::move(_filter)){
         assert(!expression || *expression != nullptr);
     }
     
@@ -34,6 +38,16 @@ public:
     
     friend bool operator!=(const Filter& lhs, const Filter& rhs) {
         return !(lhs == rhs);
+    }
+    
+    mbgl::Value serialize() const {
+        if (legacyFilter) {
+            return *legacyFilter;
+        }
+        else if (expression) {
+            return (**expression).serialize();
+        }
+        return NullValue();
     }
 };
 

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1615,8 +1615,6 @@ QVariant QVariantFromValue(const mbgl::Value &value) {
     \layer, if any.
 
     Filter value types are described in the {https://www.mapbox.com/mapbox-gl-js/style-spec/#types}{Mapbox style specification}.
-
-    This function only supports expression-based filters.
 */
 QVariant QMapboxGL::getFilter(const QString &layer)  const {
     using namespace mbgl::style;
@@ -1645,12 +1643,7 @@ QVariant QMapboxGL::getFilter(const QString &layer)  const {
         return QVariant();
     }
 
-    if (!filter_.expression) {
-        qWarning() << "getFilter only supports expression-based filters";
-        return QVariant();
-    }
-
-    auto serialized = (**filter_.expression).serialize();
+    auto serialized = filter_.serialize();
     return QVariantFromValue(serialized);
 }
 

--- a/test/style/filter.test.cpp
+++ b/test/style/filter.test.cpp
@@ -11,6 +11,10 @@
 #include <mbgl/style/filter.hpp>
 #include <mbgl/style/conversion/json.hpp>
 #include <mbgl/style/conversion/filter.hpp>
+#include <mbgl/util/rapidjson.hpp>
+
+#include <rapidjson/writer.h>
+#include <rapidjson/stringbuffer.h>
 
 using namespace mbgl;
 using namespace mbgl::style;
@@ -37,6 +41,42 @@ void invalidFilter(const char * json) {
     optional<Filter> filter = conversion::convertJSON<Filter>(json, error);
     EXPECT_FALSE(bool(filter));
     EXPECT_NE(error.message, "");
+}
+
+void writeJSON(rapidjson::Writer<rapidjson::StringBuffer>& writer, const Value& value) {
+    value.match(
+        [&] (const NullValue&) { writer.Null(); },
+        [&] (bool b) { writer.Bool(b); },
+        [&] (uint64_t t) { writer.Uint64(t); },
+        [&] (int64_t t) { writer.Int64(t); },
+        [&] (double f) {
+            // make sure integer values are stringified without trailing ".0".
+            f == std::floor(f) ? writer.Int(f) : writer.Double(f);
+        },
+        [&] (const std::string& s) { writer.String(s); },
+        [&] (const std::vector<Value>& arr) {
+            writer.StartArray();
+            for(const auto& item : arr) {
+                writeJSON(writer, item);
+            }
+            writer.EndArray();
+        },
+        [](const auto&) {
+        });
+}
+
+std::string stringifyFilter(const char * json) {
+    conversion::Error error;
+    optional<Filter> filter = conversion::convertJSON<Filter>(json, error);
+    EXPECT_TRUE(bool(filter));
+    EXPECT_EQ(error.message, "");
+
+    auto value = filter->serialize();
+
+    rapidjson::StringBuffer s;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(s);
+    writeJSON(writer, value);
+    return s.GetString();
 }
 
 TEST(Filter, EqualsNull) {
@@ -179,6 +219,21 @@ TEST(Filter, LegacyProperty) {
     ASSERT_TRUE(filter("[\"<=\", \"two\", \"2\"]", {{"two", std::string("2")}}));
     ASSERT_FALSE(filter("[\"<\", \"two\", \"1\"]", {{"two", std::string("2")}}));
     ASSERT_FALSE(filter("[\"==\", \"two\", 4]", {{"two", std::string("2")}}));
+}
+
+TEST(Filter, Serialize) {
+    std::string json = R"(["any",["==","foo",0],["==","foo",1]])";
+    EXPECT_EQ(stringifyFilter(json.c_str()), std::string(json));
+    
+    json = R"(["<=","two",2])";
+    EXPECT_EQ(stringifyFilter(json.c_str()), std::string(json));
+
+    //Constant folding for Expression filters
+    json = R"(["==",["+",1,1],2])";
+    EXPECT_EQ(stringifyFilter(json.c_str()), std::string("true"));
+
+    json = R"(["all",["==",["get","foo"],0],["==",["get","foo"],1]])";
+    EXPECT_EQ(stringifyFilter(json.c_str()), std::string(json));
 }
 
 TEST(Filter, ExpressionLegacyMix) {


### PR DESCRIPTION
As a follow up to #12226 , hold on to the original input for legacy filters and pass it back in `Filter::serialize()`. This prevents internally converted filter expressions from being exposed via `QMapboxGL::getFilter()`

refs: #12264 

cc @anandthakker @kkaefer 