### PR TITLE
[linux] Documentation update to reflect Ubuntu 18.04 packages

### DIFF
--- a/platform/linux/README.md
+++ b/platform/linux/README.md
@@ -20,7 +20,7 @@ Ensure you have git and other build essentials:
     sudo apt-get install curl git build-essential zlib1g-dev automake \
                          libtool xutils-dev make cmake pkg-config python-pip \
                          libcurl4-openssl-dev libpng-dev libsqlite3-dev \
-                         libllvm3.4
+                         libllvm3.9
 
 Ensure you have cmake 3.x:
 

--- a/platform/linux/README.md
+++ b/platform/linux/README.md
@@ -24,8 +24,6 @@ Ensure you have git and other build essentials:
 
 Ensure you have cmake 3.x:
 
-    sudo add-apt-repository --yes ppa:george-edison55/cmake-3.x
-    sudo apt-get update
     sudo apt-get install cmake cmake-data
 
 Install glfw3 dependencies:


### PR DESCRIPTION
This PR updates the Linux docs section to reflect Ubuntu 18.04 packages availability:
- increases the version number for `libllvm`
- removes the need to add an external ppa repo for `cmake`, which is now part of the distro.