### PR TITLE
Update build status buttons

### DIFF
--- a/platform/ios/README.md
+++ b/platform/ios/README.md
@@ -1,6 +1,6 @@
 # [Mapbox Maps SDK for iOS](https://www.mapbox.com/ios-sdk/)
 
-[![Bitrise](https://www.bitrise.io/app/7514e4cf3da2cc57.svg?token=OwqZE5rSBR9MVWNr_lf4sA&branch=master)](https://www.bitrise.io/app/7514e4cf3da2cc57)
+[![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native/tree/master)
 
 A library based on [Mapbox GL Native](../../README.md) for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS using Objective-C, Swift, or Interface Builder.
 

--- a/platform/macos/README.md
+++ b/platform/macos/README.md
@@ -1,6 +1,6 @@
 # [Mapbox Maps SDK for macOS](https://mapbox.github.io/mapbox-gl-native/macos/)
 
-[![Bitrise](https://www.bitrise.io/app/155ef7da24b38dcd.svg?token=4KSOw_gd6WxTnvGE2rMttg&branch=master)](https://www.bitrise.io/app/155ef7da24b38dcd)
+[![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native/tree/master)
 
 Put interactive, scalable world maps into your native Cocoa application with the Mapbox Maps SDK for macOS.
 


### PR DESCRIPTION
#11437 replaced Bitrise with CircleCI for iOS and macOS continuous integration. This PR updates the readmes for both platforms to match the repository’s main readme.

/cc @friedbunny