### PR TITLE
Remove unused generated OpenGL programs

### DIFF
--- a/src/mbgl/programs/program.hpp
+++ b/src/mbgl/programs/program.hpp
@@ -113,22 +113,37 @@ public:
           parameters(std::move(parameters_)) {
     }
 
-    Program& get(const typename PaintProperties::PossiblyEvaluated& currentProperties) {
+    Program& get(size_t frameID, const typename PaintProperties::PossiblyEvaluated& currentProperties) {
         Bitset bits = PaintPropertyBinders::constants(currentProperties);
         auto it = programs.find(bits);
         if (it != programs.end()) {
-            return it->second;
+            std::get<size_t>(it->second) = frameID;
+            return std::get<Program>(it->second);
         }
-        return programs.emplace(std::piecewise_construct,
-                                std::forward_as_tuple(bits),
-                                std::forward_as_tuple(context,
-                                    parameters.withAdditionalDefines(PaintPropertyBinders::defines(currentProperties)))).first->second;
+        return std::get<Program>(
+            programs.emplace(std::piecewise_construct,
+                std::forward_as_tuple(bits),
+                std::forward_as_tuple<Program, size_t>(
+                    { context, parameters.withAdditionalDefines(PaintPropertyBinders::defines(currentProperties)) },
+                    std::move(frameID)
+                )).first->second);
+    }
+
+    // We are periodically removing old Program objects from our cache to prevent them from piling up.
+    void evictNotUsedSince(const size_t frameID) {
+        for (auto it = programs.begin(); it != programs.end();) {
+            if (std::get<size_t>(it->second) < frameID) {
+                programs.erase(it++);
+            } else {
+                ++it;
+            }
+        }
     }
 
 private:
     gl::Context& context;
     ProgramParameters parameters;
-    std::unordered_map<Bitset, Program> programs;
+    std::unordered_map<Bitset, std::tuple<Program, size_t>> programs;
 };
 
 } // namespace mbgl

--- a/src/mbgl/programs/programs.hpp
+++ b/src/mbgl/programs/programs.hpp
@@ -49,6 +49,24 @@ public:
           clippingMask(context, programParameters) {
     }
 
+    // We are periodically removing old Program objects from our cache to prevent them from piling up.
+    void evictNotUsedSince(const size_t frameID) {
+        circle.evictNotUsedSince(frameID);
+        fill.evictNotUsedSince(frameID);
+        fillExtrusion.evictNotUsedSince(frameID);
+        fillExtrusionPattern.evictNotUsedSince(frameID);
+        fillPattern.evictNotUsedSince(frameID);
+        fillOutline.evictNotUsedSince(frameID);
+        fillOutlinePattern.evictNotUsedSince(frameID);
+        heatmap.evictNotUsedSince(frameID);
+        line.evictNotUsedSince(frameID);
+        lineSDF.evictNotUsedSince(frameID);
+        linePattern.evictNotUsedSince(frameID);
+        symbolIcon.evictNotUsedSince(frameID);
+        symbolIconSDF.evictNotUsedSince(frameID);
+        symbolGlyph.evictNotUsedSince(frameID);
+    }
+
     BackgroundProgram background;
     BackgroundPatternProgram backgroundPattern;
     ProgramMap<CircleProgram> circle;

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -61,7 +61,7 @@ void RenderCircleLayer::render(PaintParameters& parameters, RenderSource*) {
 
         const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
 
-        auto& programInstance = parameters.programs.circle.get(evaluated);
+        auto& programInstance = parameters.programs.circle.get(parameters.frameID, evaluated);
    
         const auto allUniformValues = programInstance.computeAllUniformValues(
             CircleProgram::UniformValues {

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -105,7 +105,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters, RenderSource*
                     *reinterpret_cast<FillExtrusionBucket*>(tile.tile.getBucket(*baseImpl));
 
                 draw(
-                    parameters.programs.fillExtrusion.get(evaluated),
+                    parameters.programs.fillExtrusion.get(parameters.frameID, evaluated),
                     bucket,
                     FillExtrusionUniforms::values(
                         tile.translatedClipMatrix(evaluated.get<FillExtrusionTranslate>(),
@@ -134,7 +134,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters, RenderSource*
                     *reinterpret_cast<FillExtrusionBucket*>(tile.tile.getBucket(*baseImpl));
 
                 draw(
-                    parameters.programs.fillExtrusionPattern.get(evaluated),
+                    parameters.programs.fillExtrusionPattern.get(parameters.frameID, evaluated),
                     bucket,
                     FillExtrusionPatternUniforms::values(
                         tile.translatedClipMatrix(evaluated.get<FillExtrusionTranslate>(),

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -69,7 +69,7 @@ void RenderFillLayer::render(PaintParameters& parameters, RenderSource*) {
                              const auto& depthMode,
                              const auto& indexBuffer,
                              const auto& segments) {
-                auto& programInstance = program.get(evaluated);
+                auto& programInstance = program.get(parameters.frameID, evaluated);
 
                 const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
 
@@ -154,7 +154,7 @@ void RenderFillLayer::render(PaintParameters& parameters, RenderSource*) {
                              const auto& depthMode,
                              const auto& indexBuffer,
                              const auto& segments) {
-                auto& programInstance = program.get(evaluated);
+                auto& programInstance = program.get(parameters.frameID, evaluated);
 
                 const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
 

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -94,7 +94,7 @@ void RenderHeatmapLayer::render(PaintParameters& parameters, RenderSource*) {
 
             const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
 
-            auto& programInstance = parameters.programs.heatmap.get(evaluated);
+            auto& programInstance = parameters.programs.heatmap.get(parameters.frameID, evaluated);
        
             const auto allUniformValues = programInstance.computeAllUniformValues(
                 HeatmapProgram::UniformValues {

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -62,7 +62,7 @@ void RenderLineLayer::render(PaintParameters& parameters, RenderSource*) {
         LineBucket& bucket = *reinterpret_cast<LineBucket*>(tile.tile.getBucket(*baseImpl));
 
         auto draw = [&] (auto& program, auto&& uniformValues) {
-            auto& programInstance = program.get(evaluated);
+            auto& programInstance = program.get(parameters.frameID, evaluated);
 
             const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
 

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -88,7 +88,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
                          const auto& binders,
                          const auto& paintProperties)
         {
-            auto& programInstance = program.get(paintProperties);
+            auto& programInstance = program.get(parameters.frameID, paintProperties);
 
             const auto allUniformValues = programInstance.computeAllUniformValues(
                 std::move(uniformValues),

--- a/src/mbgl/renderer/paint_parameters.cpp
+++ b/src/mbgl/renderer/paint_parameters.cpp
@@ -2,12 +2,14 @@
 #include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/renderer/render_static_data.hpp>
 #include <mbgl/map/transform_state.hpp>
+#include <mbgl/util/chrono.hpp>
 
 namespace mbgl {
 
 PaintParameters::PaintParameters(gl::Context& context_,
                     float pixelRatio_,
                     GLContextMode contextMode_,
+                    const size_t frameID_,
                     RendererBackend& backend_,
                     const UpdateParameters& updateParameters,
                     const EvaluatedLight& evaluatedLight_,
@@ -24,6 +26,7 @@ PaintParameters::PaintParameters(gl::Context& context_,
     mapMode(updateParameters.mode),
     debugOptions(updateParameters.debugOptions),
     contextMode(contextMode_),
+    frameID(frameID_),
     timePoint(updateParameters.timePoint),
     pixelRatio(pixelRatio_),
 #ifndef NDEBUG
@@ -48,6 +51,13 @@ PaintParameters::PaintParameters(gl::Context& context_,
 
     if (state.getViewportMode() == ViewportMode::FlippedY) {
         pixelsToGLUnits[1] *= -1;
+    }
+}
+
+PaintParameters::~PaintParameters() {
+    const size_t retention = mapMode == MapMode::Continuous ? 100 : 20;
+    if (frameID >= retention) {
+        programs.evictNotUsedSince(frameID - retention);
     }
 }
 

--- a/src/mbgl/renderer/paint_parameters.hpp
+++ b/src/mbgl/renderer/paint_parameters.hpp
@@ -28,12 +28,14 @@ public:
     PaintParameters(gl::Context&,
                     float pixelRatio,
                     GLContextMode,
+                    size_t frameID,
                     RendererBackend&,
                     const UpdateParameters&,
                     const EvaluatedLight&,
                     RenderStaticData&,
                     ImageManager&,
                     LineAtlas&);
+    ~PaintParameters();
 
     gl::Context& context;
     RendererBackend& backend;
@@ -49,6 +51,7 @@ public:
     MapMode mapMode;
     MapDebugOptions debugOptions;
     GLContextMode contextMode;
+    const size_t frameID;
     TimePoint timePoint;
 
     float pixelRatio;

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -256,6 +256,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         backend.getContext(),
         pixelRatio,
         contextMode,
+        frameCount++,
         backend,
         updateParameters,
         renderLight.getEvaluated(),

--- a/src/mbgl/renderer/renderer_impl.hpp
+++ b/src/mbgl/renderer/renderer_impl.hpp
@@ -98,6 +98,7 @@ private:
     RenderState renderState = RenderState::Never;
     ZoomHistory zoomHistory;
     TransformState transformState;
+    size_t frameCount = 0;
 
     std::unique_ptr<GlyphManager> glyphManager;
     std::unique_ptr<ImageManager> imageManager;


### PR DESCRIPTION
Since https://github.com/mapbox/mapbox-gl-native/pull/9185 we started generating DDS-specific program objects to work around some OpenGL implementations that were slow with constant vertex attributes. When reusing a map object with many different styles, this leads to the generation of many permutations of Program objects that are retained indefinitely. This patch adds a retention duration which is 100 frames in continuous mode, and 20 frames for static frames.