### PR TITLE
[core] Only update collision debug data if debug mode is on

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone.  If you'd like to do so please see the [`Contributing Guide`](https://github.com/mapbox/mapbox-gl-native/blob/master/CONTRIBUTING.md) first to get started.
 
+## master
+
+* Remove unnecessary memory use when collision debug mode is not enabled ([#12294](https://github.com/mapbox/mapbox-gl-native/issues/12294))
+
 ## 6.3.0-alpha.2 - July 5, 2018
  - Add LatLngForScreenCoordinate to MapSnapshotter API, This allows to convert a LatLng value to the x,y position on the MapSnasphot image [#12221](https://github.com/mapbox/mapbox-gl-native/pull/12221)
  - Expose multiple getCameraFor equivalent methods to convert a geometry or a bounds to a camera position with taking in account padding, tilt and bearing [#12290](https://github.com/mapbox/mapbox-gl-native/pull/12290)
@@ -31,7 +35,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
  - Ensure that camera is invalidated before generating telemetry event [#12042](https://github.com/mapbox/mapbox-gl-native/pull/12042)
  - Offline download batches [#11284](https://github.com/mapbox/mapbox-gl-native/pull/11284)
  - Parse Fragment's xml attributes [#12078](https://github.com/mapbox/mapbox-gl-native/pull/12078)
- 
+
 ## 6.2.0-beta.1 - May 31, 2018
  - Bump mapbox-java to 3.2.0 [#12036](https://github.com/mapbox/mapbox-gl-native/pull/12036)
  - Optional camera position for map snapshotter [#12028](https://github.com/mapbox/mapbox-gl-native/pull/12029)
@@ -40,16 +44,16 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
  - Fix literal wrapping in comparison expressions [#12022](https://github.com/mapbox/mapbox-gl-native/pull/12022)
  - Null check access token in filesource initializer [#12023](https://github.com/mapbox/mapbox-gl-native/pull/12023)
  - Allow literal expression property arguments [#12018](https://github.com/mapbox/mapbox-gl-native/pull/12018)
- - Raw expression support [#12007](https://github.com/mapbox/mapbox-gl-native/pull/12007) 
+ - Raw expression support [#12007](https://github.com/mapbox/mapbox-gl-native/pull/12007)
 
-## 6.2.0-alpha.2 - May 25, 2018 
+## 6.2.0-alpha.2 - May 25, 2018
  - UI Thread checking [#12000](https://github.com/mapbox/mapbox-gl-native/pull/12000)
  - Don't force having an Mapbox access token [#12001](https://github.com/mapbox/mapbox-gl-native/pull/12001)
  - Unknown tokens in URLs are now preserved, rather than replaced with an empty string [#11787](https://github.com/mapbox/mapbox-gl-native/issues/11787)
  - Update onMapChange Listener javadoc [#11972](https://github.com/mapbox/mapbox-gl-native/pull/11972)
  - Set Tile loaded/rendered instead of marking tile as optional [#11985](https://github.com/mapbox/mapbox-gl-native/pull/11985)
  - Wrap glGetString in `MBGL_CHECK_ERROR` too [#11106](https://github.com/mapbox/mapbox-gl-native/pull/11106)
- - Accept constant expression in non-dds properties [#11960](https://github.com/mapbox/mapbox-gl-native/pull/11960) 
+ - Accept constant expression in non-dds properties [#11960](https://github.com/mapbox/mapbox-gl-native/pull/11960)
  - Style JSON configuration in Snapshotter [#11976](https://github.com/mapbox/mapbox-gl-native/pull/11976)
  - Remove mips and armeabi as supported ABI, update to NDK 17 [#11458](https://github.com/mapbox/mapbox-gl-native/pull/11458)
  - Re-assign ids when lng jumps to avoid flicker [#11938](https://github.com/mapbox/mapbox-gl-native/pull/11938)

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Added `-[MGLMapView camera:fittingShape:edgePadding:]` and `-[MGLMapView camera:fittingCoordinateBounds:edgePadding:]` allowing you specify the pitch and direction for the calculated camera. ([#12213](https://github.com/mapbox/mapbox-gl-native/pull/12213))
 * `-[MGLStyle localizeLabelsIntoLocale:]` and `-[NSExpression mgl_expressionLocalizedIntoLocale:]` can automatically localize labels into Japanese or Korean based on the system’s language settings. ([#12286](https://github.com/mapbox/mapbox-gl-native/pull/12286))
+* Remove unnecessary memory use when collision debug mode is not enabled ([#12294](https://github.com/mapbox/mapbox-gl-native/issues/12294))
 
 ## 4.2.0
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added `-[MGLMapView camera:fittingShape:edgePadding:]` and `-[MGLMapView camera:fittingCoordinateBounds:edgePadding:]` allowing you specify the pitch and direction for the calculated camera. ([#12213](https://github.com/mapbox/mapbox-gl-native/pull/12213))
 * `-[MGLStyle localizeLabelsIntoLocale:]` and `-[NSExpression mgl_expressionLocalizedIntoLocale:]` can automatically localize labels into Japanese or Korean based on the system’s language settings. ([#12286](https://github.com/mapbox/mapbox-gl-native/pull/12286))
 * Added `-[MGLMapSnapshot coordinateForPoint:]` that returns a map coordinate for a specified snapshot image point. Fixed a bug in `-[MGLMapShapshot pointForCoordinate:]` where incorrect points were returned. ([#12221](https://github.com/mapbox/mapbox-gl-native/pull/12221))
+* Remove unnecessary memory use when collision debug mode is not enabled ([#12294](https://github.com/mapbox/mapbox-gl-native/issues/12294))
 
 ## 0.7.2 - June 22, 2018
 

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,5 +1,6 @@
 # master
 - The `Map` constructor now accepts a `mode` option which can be either `"static"` (default) or `"tile"`. It must be set to `"tile"` when rendering individual tiles in order for the symbols to match across tiles.
+- Remove unnecessary memory use when collision debug mode is not enabled ([#12294](https://github.com/mapbox/mapbox-gl-native/issues/12294))
 
 # 3.5.8 - October 19, 2017
 - Fixes an issue that causes memory leaks when not deleting the frontend object

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -301,24 +301,36 @@ void Placement::updateBucketOpacities(SymbolBucket& bucket, std::set<uint32_t>& 
         }
         
         auto updateCollisionBox = [&](const auto& feature, const bool placed) {
-            for (const CollisionBox& box : feature.boxes) {
-                if (feature.alongLine) {
-                   auto dynamicVertex = CollisionBoxDynamicAttributes::vertex(placed, !box.used);
-                    bucket.collisionCircle.dynamicVertices.emplace_back(dynamicVertex);
-                    bucket.collisionCircle.dynamicVertices.emplace_back(dynamicVertex);
-                    bucket.collisionCircle.dynamicVertices.emplace_back(dynamicVertex);
-                    bucket.collisionCircle.dynamicVertices.emplace_back(dynamicVertex);
-                } else {
-                    auto dynamicVertex = CollisionBoxDynamicAttributes::vertex(placed, false);
-                    bucket.collisionBox.dynamicVertices.emplace_back(dynamicVertex);
-                    bucket.collisionBox.dynamicVertices.emplace_back(dynamicVertex);
-                    bucket.collisionBox.dynamicVertices.emplace_back(dynamicVertex);
-                    bucket.collisionBox.dynamicVertices.emplace_back(dynamicVertex);
-                }
+            if (feature.alongLine) {
+                return;
+            }
+            auto dynamicVertex = CollisionBoxDynamicAttributes::vertex(placed, false);
+            for (size_t i = 0; i < feature.boxes.size() * 4; i++) {
+                bucket.collisionBox.dynamicVertices.emplace_back(dynamicVertex);
             }
         };
-        updateCollisionBox(symbolInstance.textCollisionFeature, opacityState.text.placed);
-        updateCollisionBox(symbolInstance.iconCollisionFeature, opacityState.icon.placed);
+        
+        auto updateCollisionCircles = [&](const auto& feature, const bool placed) {
+            if (!feature.alongLine) {
+                return;
+            }
+            for (const CollisionBox& box : feature.boxes) {
+                auto dynamicVertex = CollisionBoxDynamicAttributes::vertex(placed, !box.used);
+                bucket.collisionCircle.dynamicVertices.emplace_back(dynamicVertex);
+                bucket.collisionCircle.dynamicVertices.emplace_back(dynamicVertex);
+                bucket.collisionCircle.dynamicVertices.emplace_back(dynamicVertex);
+                bucket.collisionCircle.dynamicVertices.emplace_back(dynamicVertex);
+            }
+        };
+        
+        if (bucket.hasCollisionBoxData()) {
+            updateCollisionBox(symbolInstance.textCollisionFeature, opacityState.text.placed);
+            updateCollisionBox(symbolInstance.iconCollisionFeature, opacityState.icon.placed);
+        }
+        if (bucket.hasCollisionCircleData()) {
+            updateCollisionCircles(symbolInstance.textCollisionFeature, opacityState.text.placed);
+            updateCollisionCircles(symbolInstance.iconCollisionFeature, opacityState.icon.placed);
+        }
     }
 
     bucket.updateOpacity();


### PR DESCRIPTION
Fixes issue #12294: unused debug vertices would pile up in buckets over course of tile's lifetime.

The `feature.alongLine` check should be superfluous, but I kept it in there as a way to validate assumptions.

I can't think of a great place to attach a test for this, since there's no change to behavior other than holding onto extra items in the `dynamicVertices` vector. I manually tested before the change to make sure I could reproduce the unbounded growth (although the growth was not dramatic enough to really be noticeable in the memory profiler: after spinning a tile around for a minute, I found I had a couple thousand unused collision vertices, maybe a couple tens of KB of memory?). After the change, I verified that the vertices weren't being created in non-debug mode, and that they still worked correctly in debug mode (the test suite also exercises the collision debug functionality).

Potential changelog entry:

```
Bug Fixes:

* Remove unnecessary memory use when collision debug mode is not enabled ([#12294](https://github.com/mapbox/mapbox-gl-native/issues/12294))
```

/cc @ansis @kkaefer 