### PR TITLE
[ios, build] Postpone jazzy install for ios-release build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -892,10 +892,6 @@ jobs:
     steps:
       - checkout
       - *install-macos-dependencies
-      - run:
-          name: Install jazzy
-          command: sudo gem install jazzy --no-document
-          background: true
       - *generate-cache-key
       - *restore-cache
       - *reset-ccache-stats

--- a/platform/ios/scripts/document.sh
+++ b/platform/ios/scripts/document.sh
@@ -6,7 +6,14 @@ set -u
 
 if [ -z `which jazzy` ]; then
     echo "Installing jazzy…"
-    gem install jazzy --no-document
+
+    CIRCLECI=${CIRCLECI:-false}
+    if [[ "${CIRCLECI}" == true ]]; then
+        sudo gem install jazzy --no-document
+    else
+        gem install jazzy --no-document
+    fi
+
     if [ -z `which jazzy` ]; then
         echo "Unable to install jazzy. See https://github.com/mapbox/mapbox-gl-native/blob/master/platform/ios/INSTALL.md"
         exit 1


### PR DESCRIPTION
Fixes the `ios-release` build (🤞), which was failing after #12292 with ccache permissions issues:

```
ccache: error: Failed to create temporary file for /Users/distiller/.ccache/tmp/async_task.stdout: Permission denied
Command /Users/distiller/project/build/ios/launch-c failed with exit code 1
```

/cc @jfirebaugh @asheemmamoowala @ChrisLoer 