### PR TITLE
Add Node as executable for profiling action

### DIFF
--- a/cmake/node.xcscheme
+++ b/cmake/node.xcscheme
@@ -65,16 +65,23 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      savedToolIdentifier = ""
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
       useCustomWorkingDirectory = "YES"
       customWorkingDirectory = "${XCSCHEME_WORKING_DIRECTORY}"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
       debugDocumentVersioning = "YES">
+      <PathRunnable
+         runnableDebuggingMode = "0"
+         FilePath = "${XCSCHEME_NODE_EXECUTABLE}">
+      </PathRunnable>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"


### PR DESCRIPTION
This is now the same as the Run action. Previously, you had to manually select the Node executable when launching in Profiling mode.