### PR TITLE
avoid race condition when calling getMapAsync from OnMapReadyIdlingResource

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/utils/OnMapReadyIdlingResource.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/utils/OnMapReadyIdlingResource.java
@@ -1,6 +1,8 @@
 package com.mapbox.mapboxsdk.testapp.utils;
 
 import android.app.Activity;
+import android.os.Handler;
+import android.support.annotation.WorkerThread;
 import android.support.test.espresso.IdlingResource;
 
 import com.mapbox.mapboxsdk.maps.MapView;
@@ -14,14 +16,17 @@ public class OnMapReadyIdlingResource implements IdlingResource, OnMapReadyCallb
   private MapboxMap mapboxMap;
   private IdlingResource.ResourceCallback resourceCallback;
 
+  @WorkerThread
   public OnMapReadyIdlingResource(Activity activity) {
-    try {
-      Field field = activity.getClass().getDeclaredField("mapView");
-      field.setAccessible(true);
-      ((MapView) field.get(activity)).getMapAsync(this);
-    } catch (Exception err) {
-      throw new RuntimeException(err);
-    }
+    new Handler(activity.getMainLooper()).post(() -> {
+      try {
+        Field field = activity.getClass().getDeclaredField("mapView");
+        field.setAccessible(true);
+        ((MapView) field.get(activity)).getMapAsync(OnMapReadyIdlingResource.this);
+      } catch (Exception err) {
+        throw new RuntimeException(err);
+      }
+    });
   }
 
   @Override


### PR DESCRIPTION
Closes #10998 , this PR moves the invocation in of `getMapAsync` in `OnMapReadyIdlingResource` to the main thread. Our tests where suffering from an occasional race condition (1 out 7000 executions) where the style could have been loaded but due to thread switching this was missed when calling getMapSync from the other thread. Will need to do some additional tests run to confirm but I'm hoping proposed code will fix the root cause.

cc @mapbox/android as this file has been used in different projects
