### PR TITLE
Rename `HeatmapColorPropertyValue` to `ColorRampPropertyValue`

### DIFF
--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -359,10 +359,10 @@ set(MBGL_CORE_FILES
     src/mbgl/storage/response.cpp
 
     # style
+    include/mbgl/style/color_ramp_property_value.hpp
     include/mbgl/style/conversion.hpp
     include/mbgl/style/data_driven_property_value.hpp
     include/mbgl/style/filter.hpp
-    include/mbgl/style/heatmap_color_property_value.hpp
     include/mbgl/style/image.hpp
     include/mbgl/style/layer.hpp
     include/mbgl/style/layer_type.hpp
@@ -406,6 +406,7 @@ set(MBGL_CORE_FILES
     src/mbgl/style/types.cpp
 
     # style/conversion
+    include/mbgl/style/conversion/color_ramp_property_value.hpp
     include/mbgl/style/conversion/constant.hpp
     include/mbgl/style/conversion/coordinate.hpp
     include/mbgl/style/conversion/custom_geometry_source_options.hpp
@@ -415,7 +416,6 @@ set(MBGL_CORE_FILES
     include/mbgl/style/conversion/geojson.hpp
     include/mbgl/style/conversion/geojson_options.hpp
     include/mbgl/style/conversion/get_json_type.hpp
-    include/mbgl/style/conversion/heatmap_color_property_value.hpp
     include/mbgl/style/conversion/layer.hpp
     include/mbgl/style/conversion/light.hpp
     include/mbgl/style/conversion/position.hpp

--- a/include/mbgl/style/color_ramp_property_value.hpp
+++ b/include/mbgl/style/color_ramp_property_value.hpp
@@ -11,21 +11,21 @@ namespace style {
  * Special-case implementation of (a subset of) the PropertyValue<T> interface
  * used for building the HeatmapColor paint property traits class.
  */
-class HeatmapColorPropertyValue {
+class ColorRampPropertyValue {
 private:
     std::shared_ptr<expression::Expression> value;
 
-    friend bool operator==(const HeatmapColorPropertyValue& lhs, const HeatmapColorPropertyValue& rhs) {
+    friend bool operator==(const ColorRampPropertyValue& lhs, const ColorRampPropertyValue& rhs) {
         return (lhs.isUndefined() && rhs.isUndefined()) || (lhs.value && rhs.value && *(lhs.value) == *(rhs.value));
     }
 
-    friend bool operator!=(const HeatmapColorPropertyValue& lhs, const HeatmapColorPropertyValue& rhs) {
+    friend bool operator!=(const ColorRampPropertyValue& lhs, const ColorRampPropertyValue& rhs) {
         return !(lhs == rhs);
     }
 
 public:
-    HeatmapColorPropertyValue() : value(nullptr) {}
-    HeatmapColorPropertyValue(std::shared_ptr<expression::Expression> value_) : value(std::move(value_)) {}
+    ColorRampPropertyValue() : value(nullptr) {}
+    ColorRampPropertyValue(std::shared_ptr<expression::Expression> value_) : value(std::move(value_)) {}
 
     bool isUndefined() const { return value.get() == nullptr; }
 
@@ -33,14 +33,14 @@ public:
     template <typename Evaluator>
     Color evaluate(const Evaluator&, TimePoint = {}) const { return {}; }
 
-    Color evaluate(double heatmapDensity) const {
-        const auto result = value->evaluate(expression::EvaluationContext({}, nullptr, {heatmapDensity}));
+    Color evaluate(double rampEvaluationParameter) const {
+        const auto result = value->evaluate(expression::EvaluationContext({}, nullptr, {rampEvaluationParameter}));
         return *expression::fromExpressionValue<Color>(*result);
     }
 
-    bool isDataDriven()     const { return false; }
-    bool hasDataDrivenPropertyDifference(const HeatmapColorPropertyValue&) const { return false; }
-    
+    bool isDataDriven() const { return false; }
+    bool hasDataDrivenPropertyDifference(const ColorRampPropertyValue&) const { return false; }
+
     const expression::Expression& getExpression() const { return *value; }
 };
 

--- a/include/mbgl/style/conversion/color_ramp_property_value.hpp
+++ b/include/mbgl/style/conversion/color_ramp_property_value.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <mbgl/style/heatmap_color_property_value.hpp>
+#include <mbgl/style/color_ramp_property_value.hpp>
 #include <mbgl/style/conversion.hpp>
 #include <mbgl/style/conversion/constant.hpp>
 #include <mbgl/style/conversion/function.hpp>
@@ -15,11 +15,11 @@ namespace style {
 namespace conversion {
 
 template <>
-struct Converter<HeatmapColorPropertyValue> {
-    optional<HeatmapColorPropertyValue> operator()(const Convertible& value, Error& error) const {
+struct Converter<ColorRampPropertyValue> {
+    optional<ColorRampPropertyValue> operator()(const Convertible& value, Error& error) const {
         using namespace mbgl::style::expression;
         if (isUndefined(value)) {
-            return HeatmapColorPropertyValue();
+            return ColorRampPropertyValue();
         } else if (isExpression(value)) {
             ParsingContext ctx(type::Color);
             ParseResult expression = ctx.parseLayerPropertyExpression(value);
@@ -36,9 +36,9 @@ struct Converter<HeatmapColorPropertyValue> {
                 error = { "zoom expressions not supported" };
                 return {};
             }
-            return {HeatmapColorPropertyValue(std::move(*expression))};
+            return {ColorRampPropertyValue(std::move(*expression))};
         } else {
-            error = { "heatmap-color must be an expression" };
+            error = { "color ramp must be an expression" };
             return {};
         }
     }

--- a/include/mbgl/style/layers/heatmap_layer.hpp
+++ b/include/mbgl/style/layers/heatmap_layer.hpp
@@ -2,11 +2,11 @@
 
 #pragma once
 
+#include <mbgl/style/color_ramp_property_value.hpp>
 #include <mbgl/style/layer.hpp>
 #include <mbgl/style/filter.hpp>
 #include <mbgl/style/property_value.hpp>
 #include <mbgl/style/data_driven_property_value.hpp>
-#include <mbgl/style/heatmap_color_property_value.hpp>
 
 #include <mbgl/util/color.hpp>
 
@@ -55,9 +55,9 @@ public:
     void setHeatmapIntensityTransition(const TransitionOptions&);
     TransitionOptions getHeatmapIntensityTransition() const;
 
-    static HeatmapColorPropertyValue getDefaultHeatmapColor();
-    HeatmapColorPropertyValue getHeatmapColor() const;
-    void setHeatmapColor(HeatmapColorPropertyValue);
+    static ColorRampPropertyValue getDefaultHeatmapColor();
+    ColorRampPropertyValue getHeatmapColor() const;
+    void setHeatmapColor(ColorRampPropertyValue);
     void setHeatmapColorTransition(const TransitionOptions&);
     TransitionOptions getHeatmapColorTransition() const;
 

--- a/include/mbgl/style/layers/layer.hpp.ejs
+++ b/include/mbgl/style/layers/layer.hpp.ejs
@@ -7,13 +7,13 @@
 
 #pragma once
 
+<% if (type === 'heatmap') { -%>
+#include <mbgl/style/color_ramp_property_value.hpp>
+<% } -%>
 #include <mbgl/style/layer.hpp>
 #include <mbgl/style/filter.hpp>
 #include <mbgl/style/property_value.hpp>
 #include <mbgl/style/data_driven_property_value.hpp>
-<% if (type === 'heatmap') { -%>
-#include <mbgl/style/heatmap_color_property_value.hpp>
-<% } -%>
 
 #include <mbgl/util/color.hpp>
 

--- a/platform/android/src/style/conversion/property_value.hpp
+++ b/platform/android/src/style/conversion/property_value.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <mbgl/style/property_value.hpp>
+#include <mbgl/style/color_ramp_property_value.hpp>
 #include <mbgl/style/data_driven_property_value.hpp>
-#include <mbgl/style/heatmap_color_property_value.hpp>
+#include <mbgl/style/property_value.hpp>
 #include "../../conversion/conversion.hpp"
 #include "../../conversion/constant.hpp"
 #include "types.hpp"
@@ -75,10 +75,10 @@ struct Converter<jni::jobject*, mbgl::style::DataDrivenPropertyValue<T>> {
  * Convert core heat map color property value to java
  */
 template <>
-struct Converter<jni::jobject*, mbgl::style::HeatmapColorPropertyValue> {
+struct Converter<jni::jobject*, mbgl::style::ColorRampPropertyValue> {
 
-    Result<jni::jobject*> operator()(jni::JNIEnv& env, const mbgl::style::HeatmapColorPropertyValue value) const {
-        PropertyValueEvaluator<mbgl::style::HeatmapColorPropertyValue> evaluator(env);
+    Result<jni::jobject*> operator()(jni::JNIEnv& env, const mbgl::style::ColorRampPropertyValue value) const {
+        PropertyValueEvaluator<mbgl::style::ColorRampPropertyValue> evaluator(env);
         return *convert<jni::jobject*>(env, value.evaluate(evaluator));
     }
 };

--- a/platform/darwin/src/MGLHeatmapStyleLayer.mm
+++ b/platform/darwin/src/MGLHeatmapStyleLayer.mm
@@ -71,7 +71,7 @@
 - (void)setHeatmapColor:(NSExpression *)heatmapColor {
     MGLAssertStyleLayerIsValid();
 
-    auto mbglValue = MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toPropertyValue<mbgl::style::HeatmapColorPropertyValue>(heatmapColor);
+    auto mbglValue = MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toPropertyValue<mbgl::style::ColorRampPropertyValue>(heatmapColor);
     self.rawLayer->setHeatmapColor(mbglValue);
 }
 

--- a/platform/darwin/src/MGLStyleLayer.mm.ejs
+++ b/platform/darwin/src/MGLStyleLayer.mm.ejs
@@ -164,7 +164,7 @@ namespace mbgl {
 
 <% switch (property['property-type']) {
     case 'color-ramp': -%>
-    auto mbglValue = MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toPropertyValue<mbgl::style::HeatmapColorPropertyValue>(heatmapColor);
+    auto mbglValue = MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toPropertyValue<mbgl::style::ColorRampPropertyValue>(heatmapColor);
 <%     break
     case 'data-driven':
     case 'cross-faded-data-driven': -%>

--- a/platform/darwin/src/MGLStyleValue_Private.h
+++ b/platform/darwin/src/MGLStyleValue_Private.h
@@ -8,9 +8,9 @@
 #import "MGLTypes.h"
 
 #import "MGLConversion.h"
+#include <mbgl/style/conversion/color_ramp_property_value.hpp>
 #include <mbgl/style/conversion/property_value.hpp>
 #include <mbgl/style/conversion/data_driven_property_value.hpp>
-#include <mbgl/style/conversion/heatmap_color_property_value.hpp>
 #include <mbgl/style/conversion/position.hpp>
 #import <mbgl/style/types.hpp>
 
@@ -54,7 +54,7 @@ public:
     }
     
     // Convert an mbgl heatmap color property value into an mgl style value
-    NSExpression *toExpression(const mbgl::style::HeatmapColorPropertyValue &mbglValue) {
+    NSExpression *toExpression(const mbgl::style::ColorRampPropertyValue &mbglValue) {
         if (mbglValue.isUndefined()) {
             return nil;
         }
@@ -65,7 +65,7 @@ public:
      Converts an NSExpression to an mbgl property value.
      */
     template <typename MBGLValue>
-    typename std::enable_if_t<!std::is_same<MBGLValue, mbgl::style::HeatmapColorPropertyValue>::value,
+    typename std::enable_if_t<!std::is_same<MBGLValue, mbgl::style::ColorRampPropertyValue>::value,
     MBGLValue> toPropertyValue(NSExpression *expression) {
         if (!expression) {
             return {};
@@ -100,7 +100,7 @@ public:
      Converts an NSExpression to an mbgl property value.
      */
     template <typename MBGLValue>
-    typename std::enable_if_t<std::is_same<MBGLValue, mbgl::style::HeatmapColorPropertyValue>::value,
+    typename std::enable_if_t<std::is_same<MBGLValue, mbgl::style::ColorRampPropertyValue>::value,
     MBGLValue> toPropertyValue(NSExpression *expression) {
         if (!expression) {
             return {};
@@ -109,7 +109,7 @@ public:
         NSArray *jsonExpression = expression.mgl_jsonExpressionObject;
         
         mbgl::style::conversion::Error valueError;
-        auto value = mbgl::style::conversion::convert<mbgl::style::HeatmapColorPropertyValue>(
+        auto value = mbgl::style::conversion::convert<mbgl::style::ColorRampPropertyValue>(
             mbgl::style::conversion::makeConvertible(jsonExpression), valueError);
         if (!value) {
             [NSException raise:NSInvalidArgumentException

--- a/scripts/generate-style-code.js
+++ b/scripts/generate-style-code.js
@@ -100,7 +100,7 @@ global.propertyValueType = function (property) {
     case 'cross-faded-data-driven':
       return `DataDrivenPropertyValue<${evaluatedType(property)}>`;
     case 'color-ramp':
-      return `HeatmapColorPropertyValue`;
+      return `ColorRampPropertyValue`;
     default:
       return `PropertyValue<${evaluatedType(property)}>`;
   }

--- a/src/mbgl/style/conversion/make_property_setters.hpp
+++ b/src/mbgl/style/conversion/make_property_setters.hpp
@@ -174,7 +174,7 @@ inline auto makePaintPropertySetters() {
     result["heatmap-weight-transition"] = &setTransition<HeatmapLayer, &HeatmapLayer::setHeatmapWeightTransition>;
     result["heatmap-intensity"] = &setProperty<HeatmapLayer, PropertyValue<float>, &HeatmapLayer::setHeatmapIntensity>;
     result["heatmap-intensity-transition"] = &setTransition<HeatmapLayer, &HeatmapLayer::setHeatmapIntensityTransition>;
-    result["heatmap-color"] = &setProperty<HeatmapLayer, HeatmapColorPropertyValue, &HeatmapLayer::setHeatmapColor>;
+    result["heatmap-color"] = &setProperty<HeatmapLayer, ColorRampPropertyValue, &HeatmapLayer::setHeatmapColor>;
     result["heatmap-color-transition"] = &setTransition<HeatmapLayer, &HeatmapLayer::setHeatmapColorTransition>;
     result["heatmap-opacity"] = &setProperty<HeatmapLayer, PropertyValue<float>, &HeatmapLayer::setHeatmapOpacity>;
     result["heatmap-opacity-transition"] = &setTransition<HeatmapLayer, &HeatmapLayer::setHeatmapOpacityTransition>;

--- a/src/mbgl/style/conversion/property_setter.hpp
+++ b/src/mbgl/style/conversion/property_setter.hpp
@@ -2,10 +2,10 @@
 
 #include <mbgl/style/layer.hpp>
 #include <mbgl/style/conversion.hpp>
+#include <mbgl/style/conversion/color_ramp_property_value.hpp>
 #include <mbgl/style/conversion/constant.hpp>
 #include <mbgl/style/conversion/property_value.hpp>
 #include <mbgl/style/conversion/data_driven_property_value.hpp>
-#include <mbgl/style/conversion/heatmap_color_property_value.hpp>
 #include <mbgl/style/conversion/transition_options.hpp>
 
 #include <string>

--- a/src/mbgl/style/layers/heatmap_layer.cpp
+++ b/src/mbgl/style/layers/heatmap_layer.cpp
@@ -5,8 +5,8 @@
 #include <mbgl/style/layer_observer.hpp>
 // for constructing default heatmap-color ramp expression from style JSON
 #include <mbgl/style/conversion.hpp>
+#include <mbgl/style/conversion/color_ramp_property_value.hpp>
 #include <mbgl/style/conversion/json.hpp>
-#include <mbgl/style/conversion/heatmap_color_property_value.hpp>
 
 namespace mbgl {
 namespace style {
@@ -181,17 +181,17 @@ TransitionOptions HeatmapLayer::getHeatmapIntensityTransition() const {
     return impl().paint.template get<HeatmapIntensity>().options;
 }
 
-HeatmapColorPropertyValue HeatmapLayer::getDefaultHeatmapColor() {
+ColorRampPropertyValue HeatmapLayer::getDefaultHeatmapColor() {
     conversion::Error error;
     std::string rawValue = R"JSON(["interpolate",["linear"],["heatmap-density"],0,"rgba(0, 0, 255, 0)",0.1,"royalblue",0.3,"cyan",0.5,"lime",0.7,"yellow",1,"red"])JSON";
-    return *conversion::convertJSON<HeatmapColorPropertyValue>(rawValue, error);
+    return *conversion::convertJSON<ColorRampPropertyValue>(rawValue, error);
 }
 
-HeatmapColorPropertyValue HeatmapLayer::getHeatmapColor() const {
+ColorRampPropertyValue HeatmapLayer::getHeatmapColor() const {
     return impl().paint.template get<HeatmapColor>().value;
 }
 
-void HeatmapLayer::setHeatmapColor(HeatmapColorPropertyValue value) {
+void HeatmapLayer::setHeatmapColor(ColorRampPropertyValue value) {
     if (value == getHeatmapColor())
         return;
     auto impl_ = mutableImpl();

--- a/src/mbgl/style/layers/heatmap_layer_properties.hpp
+++ b/src/mbgl/style/layers/heatmap_layer_properties.hpp
@@ -24,6 +24,8 @@ struct HeatmapIntensity : PaintProperty<float> {
     static float defaultValue() { return 1; }
 };
 
+using HeatmapColor = ColorRampProperty;
+
 struct HeatmapOpacity : PaintProperty<float> {
     static float defaultValue() { return 1; }
 };

--- a/src/mbgl/style/layers/layer.cpp.ejs
+++ b/src/mbgl/style/layers/layer.cpp.ejs
@@ -11,8 +11,8 @@
 <% if (type === 'heatmap') { -%>
 // for constructing default heatmap-color ramp expression from style JSON
 #include <mbgl/style/conversion.hpp>
+#include <mbgl/style/conversion/color_ramp_property_value.hpp>
 #include <mbgl/style/conversion/json.hpp>
-#include <mbgl/style/conversion/heatmap_color_property_value.hpp>
 <% } -%>
 
 namespace mbgl {

--- a/src/mbgl/style/layers/layer_properties.hpp.ejs
+++ b/src/mbgl/style/layers/layer_properties.hpp.ejs
@@ -25,10 +25,13 @@ struct <%- camelize(property.name) %> : <%- layoutPropertyType(property, type) %
 
 <% } -%>
 <% for (const property of paintProperties) { -%>
-<%   if (property.name === 'heatmap-color') continue; -%>
+<%   if (property['property-type'] === 'color-ramp') { -%>
+using <%- camelize(property.name) %> = ColorRampProperty;
+<%   } else { -%>
 struct <%- camelize(property.name) %> : <%- paintPropertyType(property, type) %> {
     static <%- evaluatedType(property) %> defaultValue() { return <%- defaultValue(property) %>; }
 };
+<%   } -%>
 
 <% } -%>
 <% if (layoutProperties.length) { -%>

--- a/src/mbgl/style/paint_property.hpp
+++ b/src/mbgl/style/paint_property.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <mbgl/style/color_ramp_property_value.hpp>
 #include <mbgl/style/properties.hpp>
 #include <mbgl/style/property_value.hpp>
-#include <mbgl/style/heatmap_color_property_value.hpp>
 #include <mbgl/style/data_driven_property_value.hpp>
 #include <mbgl/renderer/property_evaluator.hpp>
 #include <mbgl/renderer/cross_faded_property_evaluator.hpp>
@@ -50,19 +50,19 @@ public:
 };
 
 /*
- * Special-case paint property traits for heatmap-color, needed because
- * heatmap-color values do not fit into the
+ * Special-case paint property traits for heatmap-color and line-gradient,
+ * needed because these values do not fit into the
  * Undefined | Value | {Camera,Source,Composite}Function taxonomy that applies
  * to all other paint properties.
  *
- * These traits are provided here--despite the fact that heatmap-color
+ * These traits are provided here--despite the fact that color ramps
  * is not used like other paint properties--to allow the parameter-pack-based
  * batch evaluation of paint properties to compile properly.
  */
-class HeatmapColor {
+class ColorRampProperty {
 public:
-    using TransitionableType = Transitionable<HeatmapColorPropertyValue>;
-    using UnevaluatedType = Transitioning<HeatmapColorPropertyValue>;
+    using TransitionableType = Transitionable<ColorRampPropertyValue>;
+    using UnevaluatedType = Transitioning<ColorRampPropertyValue>;
     using EvaluatorType = PropertyEvaluator<Color>;
     using PossiblyEvaluatedType = Color;
     using Type = Color;


### PR DESCRIPTION
Based on patch from @lbud (Lauren Budorick).

Give `HeatmapColorPropertyValue` a more generic name,
since the same value type will be used for both `heatmap-color`
and `line-gradient` properties.