### PR TITLE
[iOS] Add tests for map region change events

### DIFF
--- a/platform/ios/Integration Test Harness/AppDelegate.m
+++ b/platform/ios/Integration Test Harness/AppDelegate.m
@@ -1,4 +1,8 @@
+#import "Mapbox.h"
+
 #import "AppDelegate.h"
+
+NSString * const MBXMapboxAccessTokenDefaultsKey = @"MBXMapboxAccessToken";
 
 @interface AppDelegate ()
 
@@ -8,6 +12,20 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 
+    // Set access token, unless MGLAccountManager already read it in from Info.plist.
+    if ( ! [MGLAccountManager accessToken]) {
+        NSString *accessToken = [[NSProcessInfo processInfo] environment][@"MAPBOX_ACCESS_TOKEN"];
+        if (accessToken) {
+            // Store to preferences so that we can launch the app later on without having to specify
+            // token.
+            [[NSUserDefaults standardUserDefaults] setObject:accessToken forKey:MBXMapboxAccessTokenDefaultsKey];
+        } else {
+            // Try to retrieve from preferences, maybe we've stored them there previously and can reuse
+            // the token.
+            accessToken = [[NSUserDefaults standardUserDefaults] objectForKey:MBXMapboxAccessTokenDefaultsKey];
+        }
+        [MGLAccountManager setAccessToken:accessToken];
+    }
     return YES;
 }
 

--- a/platform/ios/Integration Test Harness/Info.plist
+++ b/platform/ios/Integration Test Harness/Info.plist
@@ -22,6 +22,8 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/platform/ios/Integration Test Harness/MGLTestHarnessViewController.h
+++ b/platform/ios/Integration Test Harness/MGLTestHarnessViewController.h
@@ -1,0 +1,5 @@
+#import <UIKit/UIKit.h>
+
+@interface MGLTestHarnessViewController : UIViewController
+
+@end

--- a/platform/ios/Integration Test Harness/MGLTestHarnessViewController.m
+++ b/platform/ios/Integration Test Harness/MGLTestHarnessViewController.m
@@ -1,0 +1,51 @@
+#import "Mapbox.h"
+#import "MGLMapViewDelegate.h"
+
+#import "MGLTestHarnessViewController.h"
+#import "MGLTestingSupport.h"
+
+@interface MGLTestHarnessViewController ()<MGLMapViewDelegate>
+
+@property (nonatomic) MGLMapView *mapView;
+
+@end
+
+@implementation MGLTestHarnessViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
+    
+    self.mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.mapView.accessibilityIdentifier = MGLTestingSupportMapViewID;
+    [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(31, -100) zoomLevel:3 animated:NO];
+    self.mapView.delegate = self;
+    
+    [self.view addSubview:self.mapView];
+}
+
+
+#pragma mark - mapview delgate handles
+
+- (void)mapViewDidFinishRenderingMap:(MGLMapView *)mapView fullyRendered:(BOOL)fullyRendered {
+    testingSupportPostNotification(MGLTestingSupportNotificationMapViewRendered);
+}
+
+- (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {
+    testingSupportPostNotification(MGLTestingSupportNotificationMapViewStyleLoaded);
+}
+
+- (void)mapView:(MGLMapView *)mapView regionWillChangeAnimated:(BOOL)animated {
+    testingSupportPostNotification(MGLTestingSupportNotificationMapViewRegionWillChange);
+}
+
+- (void)mapView:(MGLMapView *)mapView regionIsChangingWithReason:(MGLCameraChangeReason)reason {
+    testingSupportPostNotification(MGLTestingSupportNotificationMapViewRegionIsChanging);
+}
+
+- (void)mapView:(MGLMapView *)mapView regionDidChangeAnimated:(BOOL)animated {
+    testingSupportPostNotification(MGLTestingSupportNotificationMapViewRegionDidChanged);
+}
+
+
+@end

--- a/platform/ios/Integration Test Harness/MGLTestingSupport.h
+++ b/platform/ios/Integration Test Harness/MGLTestingSupport.h
@@ -1,0 +1,14 @@
+@import Foundation;
+
+typedef NSString *MGLTestingSupportNotification NS_TYPED_ENUM;
+
+extern NSString * const MGLTestingSupportMapViewID;
+
+extern const MGLTestingSupportNotification MGLTestingSupportNotificationMapViewStyleLoaded;
+extern const MGLTestingSupportNotification MGLTestingSupportNotificationMapViewRendered;
+extern const MGLTestingSupportNotification MGLTestingSupportNotificationMapViewRegionWillChange;
+extern const MGLTestingSupportNotification MGLTestingSupportNotificationMapViewRegionIsChanging;
+extern const MGLTestingSupportNotification MGLTestingSupportNotificationMapViewRegionDidChanged;
+
+
+FOUNDATION_EXTERN void testingSupportPostNotification(MGLTestingSupportNotification name);

--- a/platform/ios/Integration Test Harness/MGLTestingSupport.m
+++ b/platform/ios/Integration Test Harness/MGLTestingSupport.m
@@ -1,0 +1,14 @@
+#import "MGLTestingSupport.h"
+
+NSString * const MGLTestingSupportMapViewID = @"MGLTestingMapViewID";
+
+const MGLTestingSupportNotification MGLTestingSupportNotificationMapViewStyleLoaded = @"com.mapbox.examples.mapview-style-loaded";
+const MGLTestingSupportNotification MGLTestingSupportNotificationMapViewRendered = @"com.mapbox.examples.mapview-rendered";
+const MGLTestingSupportNotification MGLTestingSupportNotificationMapViewRegionWillChange = @"com.mapbox.examples.mapview-region-will-change";
+const MGLTestingSupportNotification MGLTestingSupportNotificationMapViewRegionIsChanging = @"com.mapbox.examples.mapview-region-is-changing";
+const MGLTestingSupportNotification MGLTestingSupportNotificationMapViewRegionDidChanged = @"com.mapbox.examples.mapview-region-did-changed";
+
+void testingSupportPostNotification(MGLTestingSupportNotification name) {
+    CFNotificationCenterRef center = CFNotificationCenterGetDarwinNotifyCenter();
+    CFNotificationCenterPostNotification(center, (CFNotificationName)name, NULL, NULL, true);
+}

--- a/platform/ios/Integration Test Harness/Main.storyboard
+++ b/platform/ios/Integration Test Harness/Main.storyboard
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Z5O-3Y-HMj">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Test Harness View Controller-->
+        <scene sceneID="MLC-BH-puJ">
+            <objects>
+                <viewController id="Z5O-3Y-HMj" customClass="MGLTestHarnessViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="wvk-8K-lWX">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <viewLayoutGuide key="safeArea" id="wI7-27-1Sj"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="eOM-FM-Yuu" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-98.400000000000006" y="201.94902548725639"/>
+        </scene>
+    </scenes>
+</document>

--- a/platform/ios/Integration UI Tests/Info.plist
+++ b/platform/ios/Integration UI Tests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/platform/ios/Integration UI Tests/MGLMapRegionChangeEventsTests.m
+++ b/platform/ios/Integration UI Tests/MGLMapRegionChangeEventsTests.m
@@ -1,0 +1,122 @@
+#import <XCTest/XCTest.h>
+
+#import "MGLTestingSupport.h"
+
+@interface MGLMapRegionChangeEventsTests : XCTestCase
+
+@property (nonatomic) XCUIApplication *app;
+
+@end
+
+@implementation MGLMapRegionChangeEventsTests
+
+- (void)setUp {
+    [super setUp];
+
+    // In UI tests it is usually best to stop immediately when a failure occurs.
+    self.continueAfterFailure = NO;
+    // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
+    self.app = [[XCUIApplication alloc] init];
+    self.app.launchArguments = [self.app.launchArguments arrayByAddingObject:@"useFastAnimations"];
+    [self.app launch];
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testMapViewRegionChangeEvents {
+
+    __block XCUIElement *mapViewElement;
+    __block NSMutableArray *regionEvents = [NSMutableArray array];
+    
+    [XCTContext runActivityNamed:@"Wait for initial render" block:^(id<XCTActivity>  _Nonnull activity) {
+        XCUIElementQuery *allQuery = [self.app descendantsMatchingType:XCUIElementTypeAny];
+        mapViewElement = [allQuery elementMatchingType:XCUIElementTypeAny identifier:MGLTestingSupportMapViewID];
+        XCTDarwinNotificationExpectation *expectation = [[XCTDarwinNotificationExpectation alloc] initWithNotificationName:MGLTestingSupportNotificationMapViewRendered];
+        [self waitForExpectations:@[expectation] timeout:15.0];
+    }];
+
+    [XCTContext runActivityNamed:@"Perform guestures" block:^(id<XCTActivity>  _Nonnull activity) {
+        XCTDarwinNotificationExpectation *willChangeExpectation = [[XCTDarwinNotificationExpectation alloc] initWithNotificationName:MGLTestingSupportNotificationMapViewRegionWillChange];
+        willChangeExpectation.handler = ^BOOL{
+            // Expect the RegionWillChange event occoured 2 times
+            [regionEvents addObject:MGLTestingSupportNotificationMapViewRegionWillChange];
+            NSArray *events = [regionEvents filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"SELF = %@",
+                                                                         MGLTestingSupportNotificationMapViewRegionWillChange]];
+            return events.count == 2;
+        };
+        
+        XCTDarwinNotificationExpectation *isChangingExpectation = [[XCTDarwinNotificationExpectation alloc] initWithNotificationName:MGLTestingSupportNotificationMapViewRegionIsChanging];
+        isChangingExpectation.handler = ^BOOL{
+            [regionEvents addObject:MGLTestingSupportNotificationMapViewRegionIsChanging];
+            NSArray *events = [regionEvents filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"SELF = %@",
+                                                                         MGLTestingSupportNotificationMapViewRegionIsChanging]];
+            // Expect the RegionIsChanging event occoured > 2 times
+            return events.count >= 2;
+        };
+        
+        XCTDarwinNotificationExpectation *didChangeExpectation = [[XCTDarwinNotificationExpectation alloc] initWithNotificationName:MGLTestingSupportNotificationMapViewRegionDidChanged];
+        didChangeExpectation.handler = ^BOOL{
+            [regionEvents addObject:MGLTestingSupportNotificationMapViewRegionDidChanged];
+            NSArray *events = [regionEvents filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"SELF = %@",
+                                                                         MGLTestingSupportNotificationMapViewRegionDidChanged]];
+            // Expect the RegionDidChanged event occoured 2 times
+            return events.count == 2;
+        };
+        
+        [mapViewElement swipeUp];
+        // TODO: Seems the swipe down guesture performed after previous guesture finished,
+        // Tried to find a method which could interrupt previous guesture and start an new guesture
+        [mapViewElement swipeDown];
+        [self waitForExpectations:@[willChangeExpectation,
+                                    isChangingExpectation,
+                                    didChangeExpectation]
+                          timeout:10];
+    }];
+    
+    /*
+     Verify the events occured as the following order.
+     
+     -mapView:regionWillChangeAnimated:
+     -mapViewIsChangingAnimated: many times
+     -mapView:regionDidChangeAnimated:
+     -mapView:regionWillChangeAnimated:
+     -mapViewIsChangingAnimated: many times
+     -mapView:regionDidChangeAnimated:
+     */
+    
+    NSIndexSet *willChangePoints = [regionEvents indexesOfObjectsPassingTest:^BOOL(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        return [obj isEqualToString:MGLTestingSupportNotificationMapViewRegionWillChange];
+    }];
+    
+    NSIndexSet *didChangedPoints = [regionEvents indexesOfObjectsPassingTest:^BOOL(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        return [obj isEqualToString:MGLTestingSupportNotificationMapViewRegionDidChanged];
+    }];
+    
+    [XCTContext runActivityNamed:@"Verify events triggered by swipe up" block:^(id<XCTActivity>  _Nonnull activity) {
+        [self verifyOrderWithEvents:[regionEvents subarrayWithRange:NSMakeRange(willChangePoints.firstIndex,
+                                                                                didChangedPoints.firstIndex - willChangePoints.firstIndex + 1)]];
+    }];
+    
+    [XCTContext runActivityNamed:@"Verify events triggered by swipe down" block:^(id<XCTActivity>  _Nonnull activity) {
+        [self verifyOrderWithEvents:[regionEvents subarrayWithRange:NSMakeRange(willChangePoints.lastIndex,
+                                                                                didChangedPoints.lastIndex - willChangePoints.lastIndex + 1)]];
+    }];
+}
+
+- (void)verifyOrderWithEvents:(NSArray *)events {
+    // All the evets's count should >= 3
+    XCTAssertGreaterThanOrEqual(events.count, 3);
+    // The RegionWillChange event should occoured at first
+    XCTAssertEqual(events.firstObject, MGLTestingSupportNotificationMapViewRegionWillChange);
+    // All the RegionIsChanging event occoured in the process
+    for (NSInteger i = 1; i < events.count - 2; i ++) {
+        XCTAssertEqual(events[i], MGLTestingSupportNotificationMapViewRegionIsChanging);
+    }
+    // The RegionDidChanged event should occoured at end
+    XCTAssertEqual(events.lastObject, MGLTestingSupportNotificationMapViewRegionDidChanged);
+}
+
+@end

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -285,6 +285,11 @@
 		55E2AD131E5B125400E8C587 /* MGLOfflineStorageTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 55E2AD121E5B125400E8C587 /* MGLOfflineStorageTests.mm */; };
 		632281DF1E6F855900D75A5D /* MBXEmbeddedMapViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 632281DE1E6F855900D75A5D /* MBXEmbeddedMapViewController.m */; };
 		6407D6701E0085FD00F6A9C3 /* MGLDocumentationExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6407D66F1E0085FD00F6A9C3 /* MGLDocumentationExampleTests.swift */; };
+		6FC77FCE20EB7B31009BB375 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6FC77FCD20EB7B31009BB375 /* Main.storyboard */; };
+		6FC77FD120EB7CA4009BB375 /* MGLTestHarnessViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6FC77FD020EB7CA4009BB375 /* MGLTestHarnessViewController.m */; };
+		6FC77FF120ECB0F4009BB375 /* MGLMapRegionChangeEventsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6FC77FF020ECB0F4009BB375 /* MGLMapRegionChangeEventsTests.m */; };
+		6FC77FFA20ECC043009BB375 /* MGLTestingSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 6FC77FF920ECC043009BB375 /* MGLTestingSupport.m */; };
+		6FC77FFB20ECC13E009BB375 /* MGLTestingSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 6FC77FF920ECC043009BB375 /* MGLTestingSupport.m */; };
 		8989B17C201A48EB0081CF59 /* MGLHeatmapStyleLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8989B17A201A48EA0081CF59 /* MGLHeatmapStyleLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8989B17D201A48EB0081CF59 /* MGLHeatmapStyleLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8989B17A201A48EA0081CF59 /* MGLHeatmapStyleLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8989B17E201A48EB0081CF59 /* MGLHeatmapStyleLayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8989B17B201A48EA0081CF59 /* MGLHeatmapStyleLayer.mm */; };
@@ -631,7 +636,21 @@
 			remoteGlobalIDString = DA8847D11CBAF91600AB86E3;
 			remoteInfo = dynamic;
 		};
-		CABE5DAB2072FA660003AF3C /* PBXContainerItemProxy */ = {
+		6FC77FD220EB9D8B009BB375 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DA1DC9421CB6C1C2006E619F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 16376B2E1FFDB4B40000563E;
+			remoteInfo = "Integration Test Harness";
+		};
+		6FC77FD620EBA802009BB375 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DA1DC9421CB6C1C2006E619F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DA1DC9491CB6C1C2006E619F;
+			remoteInfo = iosapp;
+		};
+		6FC77FF320ECB0F4009BB375 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = DA1DC9421CB6C1C2006E619F /* Project object */;
 			proxyType = 1;
@@ -956,6 +975,14 @@
 		632281DD1E6F855900D75A5D /* MBXEmbeddedMapViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBXEmbeddedMapViewController.h; sourceTree = "<group>"; };
 		632281DE1E6F855900D75A5D /* MBXEmbeddedMapViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MBXEmbeddedMapViewController.m; sourceTree = "<group>"; };
 		6407D66F1E0085FD00F6A9C3 /* MGLDocumentationExampleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MGLDocumentationExampleTests.swift; path = ../../darwin/test/MGLDocumentationExampleTests.swift; sourceTree = "<group>"; };
+		6FC77FCD20EB7B31009BB375 /* Main.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
+		6FC77FCF20EB7CA4009BB375 /* MGLTestHarnessViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLTestHarnessViewController.h; sourceTree = "<group>"; };
+		6FC77FD020EB7CA4009BB375 /* MGLTestHarnessViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLTestHarnessViewController.m; sourceTree = "<group>"; };
+		6FC77FEE20ECB0F4009BB375 /* Integration UI Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Integration UI Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6FC77FF020ECB0F4009BB375 /* MGLMapRegionChangeEventsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLMapRegionChangeEventsTests.m; sourceTree = "<group>"; };
+		6FC77FF220ECB0F4009BB375 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6FC77FF820ECC043009BB375 /* MGLTestingSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLTestingSupport.h; sourceTree = "<group>"; };
+		6FC77FF920ECC043009BB375 /* MGLTestingSupport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLTestingSupport.m; sourceTree = "<group>"; };
 		8989B17A201A48EA0081CF59 /* MGLHeatmapStyleLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLHeatmapStyleLayer.h; sourceTree = "<group>"; };
 		8989B17B201A48EA0081CF59 /* MGLHeatmapStyleLayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLHeatmapStyleLayer.mm; sourceTree = "<group>"; };
 		920A3E5C1E6F995200C16EFC /* MGLSourceQueryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MGLSourceQueryTests.m; path = ../../darwin/test/MGLSourceQueryTests.m; sourceTree = "<group>"; };
@@ -1299,6 +1326,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		6FC77FEB20ECB0F4009BB375 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DA1DC9471CB6C1C2006E619F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1373,6 +1407,11 @@
 				16376B3C1FFDB4B40000563E /* LaunchScreen.storyboard */,
 				16376B3F1FFDB4B40000563E /* Info.plist */,
 				16376B401FFDB4B40000563E /* main.m */,
+				6FC77FCD20EB7B31009BB375 /* Main.storyboard */,
+				6FC77FCF20EB7CA4009BB375 /* MGLTestHarnessViewController.h */,
+				6FC77FD020EB7CA4009BB375 /* MGLTestHarnessViewController.m */,
+				6FC77FF820ECC043009BB375 /* MGLTestingSupport.h */,
+				6FC77FF920ECC043009BB375 /* MGLTestingSupport.m */,
 			);
 			path = "Integration Test Harness";
 			sourceTree = "<group>";
@@ -1693,6 +1732,15 @@
 			name = Sources;
 			sourceTree = "<group>";
 		};
+		6FC77FEF20ECB0F4009BB375 /* Integration UI Tests */ = {
+			isa = PBXGroup;
+			children = (
+				6FC77FF020ECB0F4009BB375 /* MGLMapRegionChangeEventsTests.m */,
+				6FC77FF220ECB0F4009BB375 /* Info.plist */,
+			);
+			path = "Integration UI Tests";
+			sourceTree = "<group>";
+		};
 		9604FC341F313A5E003EEA02 /* Fixtures */ = {
 			isa = PBXGroup;
 			children = (
@@ -1725,6 +1773,7 @@
 				DA2E88521CC036F400F24E7B /* SDK Tests */,
 				16376B301FFDB4B40000563E /* Integration Test Harness */,
 				16376B081FFD9DAF0000563E /* Integration Tests */,
+				6FC77FEF20ECB0F4009BB375 /* Integration UI Tests */,
 				DA1DC9921CB6DF24006E619F /* Frameworks */,
 				DAC07C951CBB2CAD000CB309 /* Configuration */,
 				DA1DC94B1CB6C1C2006E619F /* Products */,
@@ -1743,6 +1792,7 @@
 				DA25D5B91CCD9EDE00607828 /* Settings.bundle */,
 				16376B071FFD9DAF0000563E /* integration.xctest */,
 				16376B2F1FFDB4B40000563E /* Integration Test Harness.app */,
+				6FC77FEE20ECB0F4009BB375 /* Integration UI Tests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2459,7 +2509,8 @@
 			);
 			dependencies = (
 				165D0CE620005351009A3C66 /* PBXTargetDependency */,
-				CABE5DAC2072FA660003AF3C /* PBXTargetDependency */,
+				6FC77FD320EB9D8B009BB375 /* PBXTargetDependency */,
+				6FC77FD720EBA802009BB375 /* PBXTargetDependency */,
 			);
 			name = integration;
 			productName = "integration-tests";
@@ -2483,6 +2534,24 @@
 			productName = "Integration Test Harness";
 			productReference = 16376B2F1FFDB4B40000563E /* Integration Test Harness.app */;
 			productType = "com.apple.product-type.application";
+		};
+		6FC77FED20ECB0F4009BB375 /* Integration UI Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6FC77FF720ECB0F4009BB375 /* Build configuration list for PBXNativeTarget "Integration UI Tests" */;
+			buildPhases = (
+				6FC77FEA20ECB0F4009BB375 /* Sources */,
+				6FC77FEB20ECB0F4009BB375 /* Frameworks */,
+				6FC77FEC20ECB0F4009BB375 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6FC77FF420ECB0F4009BB375 /* PBXTargetDependency */,
+			);
+			name = "Integration UI Tests";
+			productName = "Integration UI Tests";
+			productReference = 6FC77FEE20ECB0F4009BB375 /* Integration UI Tests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
 		};
 		DA1DC9491CB6C1C2006E619F /* iosapp */ = {
 			isa = PBXNativeTarget;
@@ -2622,11 +2691,16 @@
 					16376B061FFD9DAF0000563E = {
 						CreatedOnToolsVersion = 9.2;
 						ProvisioningStyle = Automatic;
-						TestTargetID = DA1DC9491CB6C1C2006E619F;
+						TestTargetID = 16376B2E1FFDB4B40000563E;
 					};
 					16376B2E1FFDB4B40000563E = {
 						CreatedOnToolsVersion = 9.2;
 						ProvisioningStyle = Automatic;
+					};
+					6FC77FED20ECB0F4009BB375 = {
+						CreatedOnToolsVersion = 9.4;
+						ProvisioningStyle = Automatic;
+						TestTargetID = 16376B2E1FFDB4B40000563E;
 					};
 					DA1DC9491CB6C1C2006E619F = {
 						CreatedOnToolsVersion = 7.3;
@@ -2699,6 +2773,7 @@
 				DA2E88501CC036F400F24E7B /* test */,
 				16376B061FFD9DAF0000563E /* integration */,
 				16376B2E1FFDB4B40000563E /* Integration Test Harness */,
+				6FC77FED20ECB0F4009BB375 /* Integration UI Tests */,
 			);
 		};
 /* End PBXProject section */
@@ -2716,8 +2791,16 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6FC77FCE20EB7B31009BB375 /* Main.storyboard in Resources */,
 				16376B3E1FFDB4B40000563E /* LaunchScreen.storyboard in Resources */,
 				16376B3B1FFDB4B40000563E /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6FC77FEC20ECB0F4009BB375 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2818,7 +2901,18 @@
 			buildActionMask = 2147483647;
 			files = (
 				16376B411FFDB4B40000563E /* main.m in Sources */,
+				6FC77FD120EB7CA4009BB375 /* MGLTestHarnessViewController.m in Sources */,
 				16376B331FFDB4B40000563E /* AppDelegate.m in Sources */,
+				6FC77FFA20ECC043009BB375 /* MGLTestingSupport.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6FC77FEA20ECB0F4009BB375 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6FC77FF120ECB0F4009BB375 /* MGLMapRegionChangeEventsTests.m in Sources */,
+				6FC77FFB20ECC13E009BB375 /* MGLTestingSupport.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3162,10 +3256,20 @@
 			target = DA8847D11CBAF91600AB86E3 /* dynamic */;
 			targetProxy = 165D0CE520005351009A3C66 /* PBXContainerItemProxy */;
 		};
-		CABE5DAC2072FA660003AF3C /* PBXTargetDependency */ = {
+		6FC77FD320EB9D8B009BB375 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 16376B2E1FFDB4B40000563E /* Integration Test Harness */;
-			targetProxy = CABE5DAB2072FA660003AF3C /* PBXContainerItemProxy */;
+			targetProxy = 6FC77FD220EB9D8B009BB375 /* PBXContainerItemProxy */;
+		};
+		6FC77FD720EBA802009BB375 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DA1DC9491CB6C1C2006E619F /* iosapp */;
+			targetProxy = 6FC77FD620EBA802009BB375 /* PBXContainerItemProxy */;
+		};
+		6FC77FF420ECB0F4009BB375 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 16376B2E1FFDB4B40000563E /* Integration Test Harness */;
+			targetProxy = 6FC77FF320ECB0F4009BB375 /* PBXContainerItemProxy */;
 		};
 		DA25D5C81CCDA0C100607828 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3477,6 +3581,46 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mapbox.Integration-Test-Harness";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		6FC77FF520ECB0F4009BB375 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "Integration UI Tests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mapbox.Integration-UI-Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "Integration Test Harness";
+			};
+			name = Debug;
+		};
+		6FC77FF620ECB0F4009BB375 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "Integration UI Tests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mapbox.Integration-UI-Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "Integration Test Harness";
 			};
 			name = Release;
 		};
@@ -3897,6 +4041,15 @@
 			buildConfigurations = (
 				16376B431FFDB4B40000563E /* Debug */,
 				16376B441FFDB4B40000563E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6FC77FF720ECB0F4009BB375 /* Build configuration list for PBXNativeTarget "Integration UI Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6FC77FF520ECB0F4009BB375 /* Debug */,
+				6FC77FF620ECB0F4009BB375 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
The PR contains following main changes:
1.  Added a UI testing bundle `Integration UI Tests`
2. Added a simple map view page in the bundle for testing 
3. Added a test for verifying map region events triggered as expected