### PR TITLE
Allow unwrapped arguments in match expressions

### DIFF
--- a/platform/darwin/src/NSExpression+MGLAdditions.mm
+++ b/platform/darwin/src/NSExpression+MGLAdditions.mm
@@ -1358,11 +1358,15 @@ NSArray *MGLSubexpressionsWithJSONObjects(NSArray *objects) {
     for (NSUInteger index = minimumIndex; index < arguments.count; index++) {
         NSArray *argumentObject = arguments[index].mgl_jsonExpressionObject;
         // match operators with arrays as matching values should not parse arrays using the literal operator.
-        if (index > 0 && index < arguments.count - 1 && !(index % 2 == 0)
-            && (arguments[index].expressionType == NSAggregateExpressionType ||
-                (arguments[index].expressionType == NSConstantValueExpressionType && [arguments[index].constantValue isKindOfClass:[NSArray class]]))) {
-            
-            argumentObject = argumentObject.count == 2 ? argumentObject[1] : argumentObject;
+        if (index > 0 && index < arguments.count - 1 && !(index % 2 == 0)) {
+            NSExpression *expression = arguments[index];
+            if (![expression isKindOfClass:[NSExpression class]]) {
+                expression = [NSExpression expressionForConstantValue:expression];
+            }
+            if (expression.expressionType == NSAggregateExpressionType ||
+                (expression.expressionType == NSConstantValueExpressionType && [expression.constantValue isKindOfClass:[NSArray class]])) {
+                argumentObject = argumentObject.count == 2 ? argumentObject[1] : argumentObject;
+            }
         }
         [expressionObject addObject:argumentObject];
     }

--- a/platform/darwin/test/MGLExpressionTests.mm
+++ b/platform/darwin/test/MGLExpressionTests.mm
@@ -795,6 +795,13 @@ using namespace std::string_literals;
         XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
         XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression], expression);
     }
+    {
+        NSExpression *expression = [NSExpression expressionWithFormat:@"MGL_MATCH(x, %@, 'Apple', %@, 'Banana', 'Kumquat')",
+                                    @[@"a", @"A"], @"Bb"];
+        NSArray *jsonExpression =  @[@"match", @[@"get", @"x"], @[@"a", @"A"], @"Apple", @"Bb", @"Banana", @"Kumquat"];
+        XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
+        XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression].description, expression.description);
+    }
 }
 
 - (void)testCoalesceExpressionObject {

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -13,6 +13,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Added an `MGLRasterStyleLayer.rasterResamplingMode` property for configuring how raster style layers are overscaled. ([#12176](https://github.com/mapbox/mapbox-gl-native/pull/12176))
 * `-[MGLStyle localizeLabelsIntoLocale:]` and `-[NSExpression mgl_expressionLocalizedIntoLocale:]` can automatically localize labels into Japanese or Korean based on the system’s language settings. ([#12286](https://github.com/mapbox/mapbox-gl-native/pull/12286))
 * Fixed a crash when trying to parse expressions containing legacy filters. ([#12263](https://github.com/mapbox/mapbox-gl-native/pull/12263))
+* Fixed a crash that occurred when creating an `MGL_MATCH` expression using non-expressions as arguments. ([#12332](https://github.com/mapbox/mapbox-gl-native/pull/12332))
 
 ### Networking and storage
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added an `MGLRasterStyleLayer.rasterResamplingMode` property for configuring how raster style layers are overscaled. ([#12176](https://github.com/mapbox/mapbox-gl-native/pull/12176))
 * `-[MGLStyle localizeLabelsIntoLocale:]` and `-[NSExpression mgl_expressionLocalizedIntoLocale:]` can automatically localize labels into Japanese or Korean based on the system’s language settings. ([#12286](https://github.com/mapbox/mapbox-gl-native/pull/12286))
 * Fixed a crash in `-[MGLStyle localizeLabelsIntoLocale:]` on macOS 10.11. ([#12123](https://github.com/mapbox/mapbox-gl-native/pull/12123))
+* Fixed a crash that occurred when creating an `MGL_MATCH` expression using non-expressions as arguments. ([#12332](https://github.com/mapbox/mapbox-gl-native/pull/12332))
 * Fixed a crash when trying to parse expressions containing legacy filters. ([#12263](https://github.com/mapbox/mapbox-gl-native/pull/12263))
 
 ## Other changes


### PR DESCRIPTION
#11866 assumes the arguments to an `MGL_MATCH` expression are all expressions. But for use cases like https://github.com/mapbox/mapbox-gl-native/issues/11830#issuecomment-401914223, it feels natural to insert a raw object instead of a constant-value expression containing that object. This change allows either an expression or a non-expression as an argument to a match expression. There probably are other places where we’re assuming that arguments are wrapped in expressions, but this is the most likely one to trip up a developer.

/cc @fabian-guerra