### PR TITLE
Port `symbol-placement: line-center` to native

### DIFF
--- a/include/mbgl/style/types.hpp
+++ b/include/mbgl/style/types.hpp
@@ -63,9 +63,10 @@ enum class CirclePitchScaleType : bool {
     Viewport,
 };
 
-enum class SymbolPlacementType : bool {
+enum class SymbolPlacementType : uint8_t {
     Point,
     Line,
+    LineCenter
 };
 
 enum class AlignmentType : uint8_t {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Property.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Property.java
@@ -92,6 +92,10 @@ public final class Property {
    * The label is placed along the line of the geometry. Can only be used on LineString and Polygon geometries.
    */
   public static final String SYMBOL_PLACEMENT_LINE = "line";
+  /**
+   * The label is placed at the center of the line of the geometry. Can only be used on LineString and Polygon geometries. Note that a single feature in a vector tile may contain multiple line geometries.
+   */
+  public static final String SYMBOL_PLACEMENT_LINE_CENTER = "line-center";
 
   /**
    * Label placement relative to its geometry.
@@ -99,6 +103,7 @@ public final class Property {
   @StringDef({
       SYMBOL_PLACEMENT_POINT,
       SYMBOL_PLACEMENT_LINE,
+      SYMBOL_PLACEMENT_LINE_CENTER,
     })
   @Retention(RetentionPolicy.SOURCE)
   public @interface SYMBOL_PLACEMENT {}
@@ -106,7 +111,7 @@ public final class Property {
   // ICON_ROTATION_ALIGNMENT: In combination with `symbol-placement`, determines the rotation behavior of icons.
 
   /**
-   * When {@link SYMBOL_PLACEMENT} is set to {@link Property#SYMBOL_PLACEMENT_POINT}, aligns icons east-west. When {@link SYMBOL_PLACEMENT} is set to {@link Property#SYMBOL_PLACEMENT_LINE}, aligns icon x-axes with the line.
+   * When {@link SYMBOL_PLACEMENT} is set to {@link Property#SYMBOL_PLACEMENT_POINT}, aligns icons east-west. When {@link SYMBOL_PLACEMENT} is set to {@link Property#SYMBOL_PLACEMENT_LINE} or {@link Property#SYMBOL_PLACEMENT_LINE_CENTER}, aligns icon x-axes with the line.
    */
   public static final String ICON_ROTATION_ALIGNMENT_MAP = "map";
   /**
@@ -114,7 +119,7 @@ public final class Property {
    */
   public static final String ICON_ROTATION_ALIGNMENT_VIEWPORT = "viewport";
   /**
-   * When {@link SYMBOL_PLACEMENT} is set to {@link Property#SYMBOL_PLACEMENT_POINT}, this is equivalent to {@link Property#ICON_ROTATION_ALIGNMENT_VIEWPORT}. When {@link SYMBOL_PLACEMENT} is set to {@link Property#SYMBOL_PLACEMENT_LINE}, this is equivalent to {@link Property#ICON_ROTATION_ALIGNMENT_MAP}.
+   * When {@link SYMBOL_PLACEMENT} is set to {@link Property#SYMBOL_PLACEMENT_POINT}, this is equivalent to {@link Property#ICON_ROTATION_ALIGNMENT_VIEWPORT}. When {@link SYMBOL_PLACEMENT} is set to {@link Property#SYMBOL_PLACEMENT_LINE} or {@link Property#SYMBOL_PLACEMENT_LINE_CENTER}, this is equivalent to {@link Property#ICON_ROTATION_ALIGNMENT_MAP}.
    */
   public static final String ICON_ROTATION_ALIGNMENT_AUTO = "auto";
 
@@ -271,7 +276,7 @@ public final class Property {
   // TEXT_ROTATION_ALIGNMENT: In combination with `symbol-placement`, determines the rotation behavior of the individual glyphs forming the text.
 
   /**
-   * When {@link SYMBOL_PLACEMENT} is set to {@link Property#SYMBOL_PLACEMENT_POINT}, aligns text east-west. When {@link SYMBOL_PLACEMENT} is set to {@link Property#SYMBOL_PLACEMENT_LINE}, aligns text x-axes with the line.
+   * When {@link SYMBOL_PLACEMENT} is set to {@link Property#SYMBOL_PLACEMENT_POINT}, aligns text east-west. When {@link SYMBOL_PLACEMENT} is set to {@link Property#SYMBOL_PLACEMENT_LINE} or {@link Property#SYMBOL_PLACEMENT_LINE_CENTER}, aligns text x-axes with the line.
    */
   public static final String TEXT_ROTATION_ALIGNMENT_MAP = "map";
   /**
@@ -279,7 +284,7 @@ public final class Property {
    */
   public static final String TEXT_ROTATION_ALIGNMENT_VIEWPORT = "viewport";
   /**
-   * When {@link SYMBOL_PLACEMENT} is set to {@link Property#SYMBOL_PLACEMENT_POINT}, this is equivalent to {@link Property#TEXT_ROTATION_ALIGNMENT_VIEWPORT}. When {@link SYMBOL_PLACEMENT} is set to {@link Property#SYMBOL_PLACEMENT_LINE}, this is equivalent to {@link Property#TEXT_ROTATION_ALIGNMENT_MAP}.
+   * When {@link SYMBOL_PLACEMENT} is set to {@link Property#SYMBOL_PLACEMENT_POINT}, this is equivalent to {@link Property#TEXT_ROTATION_ALIGNMENT_VIEWPORT}. When {@link SYMBOL_PLACEMENT} is set to {@link Property#SYMBOL_PLACEMENT_LINE} or {@link Property#SYMBOL_PLACEMENT_LINE_CENTER}, this is equivalent to {@link Property#TEXT_ROTATION_ALIGNMENT_MAP}.
    */
   public static final String TEXT_ROTATION_ALIGNMENT_AUTO = "auto";
 

--- a/platform/android/scripts/generate-style-code.js
+++ b/platform/android/scripts/generate-style-code.js
@@ -235,10 +235,15 @@ global.propertyValueDoc = function (property, value) {
 
     // Match references to other property names & values.
     // Requires the format 'When `foo` is set to `bar`,'.
-    let doc = property.values[value].doc.replace(/When `(.+?)` is set to `(.+?)`,/g, function (m, peerPropertyName, propertyValue, offset, str) {
+    let doc = property.values[value].doc.replace(/When `(.+?)` is set to `(.+?)`(?: or `([^`]+?)`)?,/g, function (m, peerPropertyName, propertyValue, secondPropertyValue, offset, str) {
         let otherProperty = snakeCaseUpper(peerPropertyName);
         let otherValue = snakeCaseUpper(peerPropertyName) + '_' + snakeCaseUpper(propertyValue);
-        return 'When {@link ' + `${otherProperty}` + '} is set to {@link Property#' + `${otherValue}` + '},';
+        const firstPropertyValue = 'When {@link ' + `${otherProperty}` + '} is set to {@link Property#' + `${otherValue}` + '}';
+        if (secondPropertyValue) {
+            return firstPropertyValue + ` or {@link Property#${snakeCaseUpper(peerPropertyName) + '_' + snakeCaseUpper(secondPropertyValue)}},`;
+        } else {
+            return firstPropertyValue + ',';
+        }
     });
 
     // Match references to our own property values.

--- a/platform/android/src/style/conversion/types_string_values.hpp
+++ b/platform/android/src/style/conversion/types_string_values.hpp
@@ -67,6 +67,9 @@ namespace conversion {
           case mbgl::style::SymbolPlacementType::Line:
             return "line";
             break;
+          case mbgl::style::SymbolPlacementType::LineCenter:
+            return "line-center";
+            break;
           default:
             throw std::runtime_error("Not implemented");
         }

--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -248,13 +248,20 @@ global.testHelperMessage = function (property, layerType, isFunction) {
 global.propertyDoc = function (propertyName, property, layerType, kind) {
     // Match references to other property names & values.
     // Requires the format 'When `foo` is set to `bar`,'.
-    let doc = property.doc.replace(/`([^`]+?)` is set to `([^`]+?)`/g, function (m, peerPropertyName, propertyValue, offset, str) {
+    let doc = property.doc.replace(/`([^`]+?)` is set to `([^`]+?)`(?: or `([^`]+?)`)?/g, function (m, peerPropertyName, propertyValue, secondPropertyValue, offset, str) {
         let otherProperty = camelizeWithLeadingLowercase(peerPropertyName);
         let otherValue = objCType(layerType, peerPropertyName) + camelize(propertyValue);
         if (property.type == 'array' && kind == 'light') {
             otherValue = propertyValue;
         }
-        return '`' + `${otherProperty}` + '` is set to `' + `${otherValue}` + '`';
+        const firstPropertyValue = '`' + `${otherProperty}` + '` is set to `' + `${otherValue}` + '`';
+        if (secondPropertyValue) {
+            return firstPropertyValue + ' or `' +
+                objCType(layerType, peerPropertyName) + camelize(secondPropertyValue) +
+                '`';
+        } else {
+            return firstPropertyValue;
+        }
     });
     // Match references to our own property values.
     // Requires the format 'is equivalent to `bar`'.

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -83,8 +83,8 @@ typedef NS_ENUM(NSUInteger, MGLIconPitchAlignment) {
 typedef NS_ENUM(NSUInteger, MGLIconRotationAlignment) {
     /**
      When `symbolPlacement` is set to `MGLSymbolPlacementPoint`, aligns icons
-     east-west. When `symbolPlacement` is set to `MGLSymbolPlacementLine`,
-     aligns icon x-axes with the line.
+     east-west. When `symbolPlacement` is set to `MGLSymbolPlacementLine` or
+     `MGLSymbolPlacementLineCenter`, aligns icon x-axes with the line.
      */
     MGLIconRotationAlignmentMap,
     /**
@@ -95,8 +95,8 @@ typedef NS_ENUM(NSUInteger, MGLIconRotationAlignment) {
     /**
      When `symbolPlacement` is set to `MGLSymbolPlacementPoint`, this is
      equivalent to `MGLIconRotationAlignmentViewport`. When `symbolPlacement` is
-     set to `MGLSymbolPlacementLine`, this is equivalent to
-     `MGLIconRotationAlignmentMap`.
+     set to `MGLSymbolPlacementLine` or `MGLSymbolPlacementLineCenter`, this is
+     equivalent to `MGLIconRotationAlignmentMap`.
      */
     MGLIconRotationAlignmentAuto,
 };
@@ -142,6 +142,12 @@ typedef NS_ENUM(NSUInteger, MGLSymbolPlacement) {
      `LineString` and `Polygon` geometries.
      */
     MGLSymbolPlacementLine,
+    /**
+     The label is placed at the center of the line of the geometry. Can only be
+     used on `LineString` and `Polygon` geometries. Note that a single feature
+     in a vector tile may contain multiple line geometries.
+     */
+    MGLSymbolPlacementLineCenter,
 };
 
 /**
@@ -242,8 +248,8 @@ typedef NS_ENUM(NSUInteger, MGLTextPitchAlignment) {
 typedef NS_ENUM(NSUInteger, MGLTextRotationAlignment) {
     /**
      When `symbolPlacement` is set to `MGLSymbolPlacementPoint`, aligns text
-     east-west. When `symbolPlacement` is set to `MGLSymbolPlacementLine`,
-     aligns text x-axes with the line.
+     east-west. When `symbolPlacement` is set to `MGLSymbolPlacementLine` or
+     `MGLSymbolPlacementLineCenter`, aligns text x-axes with the line.
      */
     MGLTextRotationAlignmentMap,
     /**
@@ -254,8 +260,8 @@ typedef NS_ENUM(NSUInteger, MGLTextRotationAlignment) {
     /**
      When `symbolPlacement` is set to `MGLSymbolPlacementPoint`, this is
      equivalent to `MGLTextRotationAlignmentViewport`. When `symbolPlacement` is
-     set to `MGLSymbolPlacementLine`, this is equivalent to
-     `MGLTextRotationAlignmentMap`.
+     set to `MGLSymbolPlacementLine` or `MGLSymbolPlacementLineCenter`, this is
+     equivalent to `MGLTextRotationAlignmentMap`.
      */
     MGLTextRotationAlignmentAuto,
 };
@@ -653,12 +659,13 @@ MGL_EXPORT
  * Constant `MGLIconRotationAlignment` values
  * Any of the following constant string values:
    * `map`: When `symbol-placement` is set to `point`, aligns icons east-west.
- When `symbol-placement` is set to `line`, aligns icon x-axes with the line.
+ When `symbol-placement` is set to `line` or `line-center`, aligns icon x-axes
+ with the line.
    * `viewport`: Produces icons whose x-axes are aligned with the x-axis of the
  viewport, regardless of the value of `symbol-placement`.
    * `auto`: When `symbol-placement` is set to `point`, this is equivalent to
- `viewport`. When `symbol-placement` is set to `line`, this is equivalent to
- `map`.
+ `viewport`. When `symbol-placement` is set to `line` or `line-center`, this is
+ equivalent to `map`.
  * Predefined functions, including mathematical and string operators
  * Conditional expressions
  * Variable assignments and references to assigned variables
@@ -795,8 +802,9 @@ MGL_EXPORT
  
  This property is only applied to the style if `iconImageName` is non-`nil`, and
  `iconRotationAlignment` is set to an expression that evaluates to `map`, and
- `symbolPlacement` is set to an expression that evaluates to `line`. Otherwise,
- it is ignored.
+ `symbolPlacement` is set to an expression that evaluates to either
+ `MGLSymbolPlacementLine` or `MGLSymbolPlacementLineCenter`. Otherwise, it is
+ ignored.
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-icon-keep-upright"><code>icon-keep-upright</code></a>
@@ -828,8 +836,9 @@ MGL_EXPORT
  
  This property is only applied to the style if `text` is non-`nil`, and
  `textRotationAlignment` is set to an expression that evaluates to `map`, and
- `symbolPlacement` is set to an expression that evaluates to `line`. Otherwise,
- it is ignored.
+ `symbolPlacement` is set to an expression that evaluates to either
+ `MGLSymbolPlacementLine` or `MGLSymbolPlacementLineCenter`. Otherwise, it is
+ ignored.
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-keep-upright"><code>text-keep-upright</code></a>
@@ -861,8 +870,9 @@ MGL_EXPORT
  `45`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`, and
- `symbolPlacement` is set to an expression that evaluates to `line`. Otherwise,
- it is ignored.
+ `symbolPlacement` is set to an expression that evaluates to either
+ `MGLSymbolPlacementLine` or `MGLSymbolPlacementLineCenter`. Otherwise, it is
+ ignored.
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-max-angle"><code>text-max-angle</code></a>
@@ -956,6 +966,9 @@ MGL_EXPORT
    * `point`: The label is placed at the point where the geometry is located.
    * `line`: The label is placed along the line of the geometry. Can only be
  used on `LineString` and `Polygon` geometries.
+   * `line-center`: The label is placed at the center of the line of the
+ geometry. Can only be used on `LineString` and `Polygon` geometries. Note that
+ a single feature in a vector tile may contain multiple line geometries.
  * Predefined functions, including mathematical and string operators
  * Conditional expressions
  * Variable assignments and references to assigned variables
@@ -1427,12 +1440,13 @@ MGL_EXPORT
  * Constant `MGLTextRotationAlignment` values
  * Any of the following constant string values:
    * `map`: When `symbol-placement` is set to `point`, aligns text east-west.
- When `symbol-placement` is set to `line`, aligns text x-axes with the line.
+ When `symbol-placement` is set to `line` or `line-center`, aligns text x-axes
+ with the line.
    * `viewport`: Produces glyphs whose x-axes are aligned with the x-axis of the
  viewport, regardless of the value of `symbol-placement`.
    * `auto`: When `symbol-placement` is set to `point`, this is equivalent to
- `viewport`. When `symbol-placement` is set to `line`, this is equivalent to
- `map`.
+ `viewport`. When `symbol-placement` is set to `line` or `line-center`, this is
+ equivalent to `map`.
  * Predefined functions, including mathematical and string operators
  * Conditional expressions
  * Variable assignments and references to assigned variables

--- a/platform/darwin/src/MGLSymbolStyleLayer.mm
+++ b/platform/darwin/src/MGLSymbolStyleLayer.mm
@@ -47,6 +47,7 @@ namespace mbgl {
     MBGL_DEFINE_ENUM(MGLSymbolPlacement, {
         { MGLSymbolPlacementPoint, "point" },
         { MGLSymbolPlacementLine, "line" },
+        { MGLSymbolPlacementLineCenter, "line-center" },
     });
 
     MBGL_DEFINE_ENUM(MGLTextAnchor, {

--- a/platform/darwin/test/MGLSymbolStyleLayerTests.mm
+++ b/platform/darwin/test/MGLSymbolStyleLayerTests.mm
@@ -962,22 +962,22 @@
                       @"symbol-placement should be unset initially.");
         NSExpression *defaultExpression = layer.symbolPlacement;
 
-        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"'line'"];
+        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"'line-center'"];
         layer.symbolPlacement = constantExpression;
-        mbgl::style::PropertyValue<mbgl::style::SymbolPlacementType> propertyValue = { mbgl::style::SymbolPlacementType::Line };
+        mbgl::style::PropertyValue<mbgl::style::SymbolPlacementType> propertyValue = { mbgl::style::SymbolPlacementType::LineCenter };
         XCTAssertEqual(rawLayer->getSymbolPlacement(), propertyValue,
                        @"Setting symbolPlacement to a constant value expression should update symbol-placement.");
         XCTAssertEqualObjects(layer.symbolPlacement, constantExpression,
                               @"symbolPlacement should round-trip constant value expressions.");
 
-        constantExpression = [NSExpression expressionWithFormat:@"'line'"];
+        constantExpression = [NSExpression expressionWithFormat:@"'line-center'"];
         NSExpression *functionExpression = [NSExpression expressionWithFormat:@"mgl_step:from:stops:($zoomLevel, %@, %@)", constantExpression, @{@18: constantExpression}];
         layer.symbolPlacement = functionExpression;
 
         {
             using namespace mbgl::style::expression::dsl;
             propertyValue = mbgl::style::PropertyExpression<mbgl::style::SymbolPlacementType>(
-                step(zoom(), literal("line"), 18.0, literal("line"))
+                step(zoom(), literal("line-center"), 18.0, literal("line-center"))
             );
         }
 
@@ -2883,6 +2883,7 @@
     XCTAssertEqual([NSValue valueWithMGLIconTextFit:MGLIconTextFitBoth].MGLIconTextFitValue, MGLIconTextFitBoth);
     XCTAssertEqual([NSValue valueWithMGLSymbolPlacement:MGLSymbolPlacementPoint].MGLSymbolPlacementValue, MGLSymbolPlacementPoint);
     XCTAssertEqual([NSValue valueWithMGLSymbolPlacement:MGLSymbolPlacementLine].MGLSymbolPlacementValue, MGLSymbolPlacementLine);
+    XCTAssertEqual([NSValue valueWithMGLSymbolPlacement:MGLSymbolPlacementLineCenter].MGLSymbolPlacementValue, MGLSymbolPlacementLineCenter);
     XCTAssertEqual([NSValue valueWithMGLTextAnchor:MGLTextAnchorCenter].MGLTextAnchorValue, MGLTextAnchorCenter);
     XCTAssertEqual([NSValue valueWithMGLTextAnchor:MGLTextAnchorLeft].MGLTextAnchorValue, MGLTextAnchorLeft);
     XCTAssertEqual([NSValue valueWithMGLTextAnchor:MGLTextAnchorRight].MGLTextAnchorValue, MGLTextAnchorRight);

--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -56,6 +56,7 @@
   "render-tests/runtime-styling/image-add-sdf": "https://github.com/mapbox/mapbox-gl-native/issues/9847",
   "render-tests/runtime-styling/paint-property-fill-flat-to-extrude": "https://github.com/mapbox/mapbox-gl-native/issues/6745",
   "render-tests/runtime-styling/set-style-paint-property-fill-flat-to-extrude": "https://github.com/mapbox/mapbox-gl-native/issues/6745",
+  "render-tests/symbol-cross-fade/chinese": "https://github.com/mapbox/mapbox-gl-native/issues/10619",
   "render-tests/symbol-placement/line-overscaled": "https://github.com/mapbox/mapbox-gl-js/issues/5654",
   "render-tests/symbol-visibility/visible": "https://github.com/mapbox/mapbox-gl-native/issues/10409",
   "render-tests/text-no-cross-source-collision/default": "skip - gl-js only",

--- a/src/mbgl/programs/symbol_program.cpp
+++ b/src/mbgl/programs/symbol_program.cpp
@@ -94,7 +94,6 @@ Values makeValues(const bool isText,
         uniforms::u_camera_to_center_distance::Value{ state.getCameraToCenterDistance() },
         uniforms::u_pitch::Value{ state.getPitch() },
         uniforms::u_pitch_with_map::Value{ pitchWithMap },
-        uniforms::u_max_camera_distance::Value{ values.maxCameraDistance },
         uniforms::u_rotate_symbol::Value{ rotateInShader },
         uniforms::u_aspect_ratio::Value{ state.getSize().aspectRatio() },
         std::forward<Args>(args)...

--- a/src/mbgl/programs/symbol_program.hpp
+++ b/src/mbgl/programs/symbol_program.hpp
@@ -41,7 +41,6 @@ MBGL_DEFINE_UNIFORM_SCALAR(bool, u_is_size_zoom_constant);
 MBGL_DEFINE_UNIFORM_SCALAR(bool, u_is_size_feature_constant);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_size_t);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_size);
-MBGL_DEFINE_UNIFORM_SCALAR(float, u_max_camera_distance);
 MBGL_DEFINE_UNIFORM_SCALAR(bool, u_rotate_symbol);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_aspect_ratio);
 } // namespace uniforms
@@ -356,7 +355,6 @@ class SymbolIconProgram : public SymbolProgram<
         uniforms::u_camera_to_center_distance,
         uniforms::u_pitch,
         uniforms::u_pitch_with_map,
-        uniforms::u_max_camera_distance,
         uniforms::u_rotate_symbol,
         uniforms::u_aspect_ratio>,
     style::IconPaintProperties>
@@ -396,7 +394,6 @@ class SymbolSDFProgram : public SymbolProgram<
         uniforms::u_camera_to_center_distance,
         uniforms::u_pitch,
         uniforms::u_pitch_with_map,
-        uniforms::u_max_camera_distance,
         uniforms::u_rotate_symbol,
         uniforms::u_aspect_ratio,
         uniforms::u_gamma_scale,
@@ -418,8 +415,7 @@ public:
             uniforms::u_is_text,
             uniforms::u_camera_to_center_distance,
             uniforms::u_pitch,
-            uniforms::u_pitch_with_map,            
-            uniforms::u_max_camera_distance,
+            uniforms::u_pitch_with_map,
             uniforms::u_rotate_symbol,
             uniforms::u_aspect_ratio,
             uniforms::u_gamma_scale,

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -130,7 +130,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
             auto values = iconPropertyValues(layout);
             auto paintPropertyValues = iconPaintProperties();
 
-            const bool alongLine = layout.get<SymbolPlacement>() == SymbolPlacementType::Line &&
+            const bool alongLine = layout.get<SymbolPlacement>() != SymbolPlacementType::Point &&
                 layout.get<IconRotationAlignment>() == AlignmentType::Map;
 
             if (alongLine) {
@@ -191,7 +191,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
             auto values = textPropertyValues(layout);
             auto paintPropertyValues = textPaintProperties();
 
-            const bool alongLine = layout.get<SymbolPlacement>() == SymbolPlacementType::Line &&
+            const bool alongLine = layout.get<SymbolPlacement>() != SymbolPlacementType::Point &&
                 layout.get<TextRotationAlignment>() == AlignmentType::Map;
 
             if (alongLine) {
@@ -335,24 +335,11 @@ style::SymbolPropertyValues RenderSymbolLayer::iconPropertyValues(const style::S
             evaluated.get<style::IconTranslateAnchor>(),
             evaluated.get<style::IconHaloColor>().constantOr(Color::black()).a > 0 &&
             evaluated.get<style::IconHaloWidth>().constantOr(1),
-            evaluated.get<style::IconColor>().constantOr(Color::black()).a > 0,
-            10.0f
+            evaluated.get<style::IconColor>().constantOr(Color::black()).a > 0
     };
 }
 
 style::SymbolPropertyValues RenderSymbolLayer::textPropertyValues(const style::SymbolLayoutProperties::PossiblyEvaluated& layout_) const {
-    // We hide line labels with viewport alignment as they move into the distance
-    // because the approximations we use for drawing their glyphs get progressively worse
-    // The "1.5" here means we start hiding them when the distance from the label
-    // to the camera is 50% greater than the distance from the center of the map
-    // to the camera. Depending on viewport properties, you might expect this to filter
-    // the top third of the screen at pitch 60, and do almost nothing at pitch 45
-    // "10" is effectively infinite at any pitch we support
-    const bool limitMaxDistance =
-        layout_.get<style::SymbolPlacement>() == style::SymbolPlacementType::Line
-        && layout_.get<style::TextRotationAlignment>() == style::AlignmentType::Map
-        && layout_.get<style::TextPitchAlignment>() == style::AlignmentType::Viewport;
-
     return style::SymbolPropertyValues {
             layout_.get<style::TextPitchAlignment>(),
             layout_.get<style::TextRotationAlignment>(),
@@ -361,8 +348,7 @@ style::SymbolPropertyValues RenderSymbolLayer::textPropertyValues(const style::S
             evaluated.get<style::TextTranslateAnchor>(),
             evaluated.get<style::TextHaloColor>().constantOr(Color::black()).a > 0 &&
             evaluated.get<style::TextHaloWidth>().constantOr(1),
-            evaluated.get<style::TextColor>().constantOr(Color::black()).a > 0,
-            limitMaxDistance ? 1.5f : 10.0f
+            evaluated.get<style::TextColor>().constantOr(Color::black()).a > 0
     };
 }
 

--- a/src/mbgl/renderer/layers/render_symbol_layer.hpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.hpp
@@ -48,8 +48,6 @@ public:
 
     bool hasHalo;
     bool hasFill;
-    
-    float maxCameraDistance; // 1.5 for road labels, or 10 (essentially infinite) for everything else
 };
 
 } // namespace style

--- a/src/mbgl/style/types.cpp
+++ b/src/mbgl/style/types.cpp
@@ -62,6 +62,7 @@ MBGL_DEFINE_ENUM(LineJoinType, {
 MBGL_DEFINE_ENUM(SymbolPlacementType, {
     { SymbolPlacementType::Point, "point" },
     { SymbolPlacementType::Line, "line" },
+    { SymbolPlacementType::LineCenter, "line-center" },
 });
 
 MBGL_DEFINE_ENUM(SymbolAnchorType, {

--- a/src/mbgl/text/collision_feature.cpp
+++ b/src/mbgl/text/collision_feature.cpp
@@ -16,7 +16,7 @@ CollisionFeature::CollisionFeature(const GeometryCoordinates& line,
                                    IndexedSubfeature indexedFeature_,
                                    const float overscaling)
         : indexedFeature(std::move(indexedFeature_))
-        , alongLine(placement == style::SymbolPlacementType::Line) {
+        , alongLine(placement != style::SymbolPlacementType::Point) {
     if (top == 0 && bottom == 0 && left == 0 && right == 0) return;
 
     const float y1 = top * boxScale - padding;
@@ -42,7 +42,8 @@ CollisionFeature::CollisionFeature(const GeometryCoordinates& line,
 void CollisionFeature::bboxifyLabel(const GeometryCoordinates& line, GeometryCoordinate& anchorPoint,
                                     const int segment, const float labelLength, const float boxSize, const float overscaling) {
     const float step = boxSize / 2;
-    const int nBoxes = std::floor(labelLength / step);
+    const int nBoxes = std::max(static_cast<int>(std::floor(labelLength / step)), 1);
+
     // We calculate line collision circles out to 300% of what would normally be our
     // max size, to allow collision detection to work on labels that expand as
     // they move into the distance

--- a/src/mbgl/text/get_anchors.hpp
+++ b/src/mbgl/text/get_anchors.hpp
@@ -17,4 +17,14 @@ Anchors getAnchors(const GeometryCoordinates& line,
                    const float boxScale,
                    const float overscaling);
 
+optional<Anchor> getCenterAnchor(const GeometryCoordinates& line,
+                                 const float maxAngle,
+                                 const float textLeft,
+                                 const float textRight,
+                                 const float iconLeft,
+                                 const float iconRight,
+                                 const float glyphSize,
+                                 const float boxScale);
+    
+
 } // namespace mbgl

--- a/src/mbgl/text/quads.cpp
+++ b/src/mbgl/text/quads.cpp
@@ -117,7 +117,7 @@ SymbolQuads getGlyphQuads(const Shaping& shapedText,
         const float rectBuffer = 3.0f + glyphPadding;
 
         const float halfAdvance = glyph.metrics.advance / 2.0;
-        const bool alongLine = layout.get<TextRotationAlignment>() == AlignmentType::Map && placement == SymbolPlacementType::Line;
+        const bool alongLine = layout.get<TextRotationAlignment>() == AlignmentType::Map && placement != SymbolPlacementType::Point;
 
         const Point<float> glyphOffset = alongLine ?
             Point<float>{ positionedGlyph.x + halfAdvance, positionedGlyph.y } :


### PR DESCRIPTION
Fixes #12300.

Removes unused "maxCameraDistance" shader uniforms (these have been obsolete since the switch to viewport collision detection and render-time line-label layout).

Also changes collision detection behavior for line labels with width less than 1/2 of a collision circle (previously, such labels wouldn't show).

Using an unmerged pin of GL JS for tests.

`text-max-angle/line-center` is currently failing because one extra label is showing up -- I haven't dug into why yet.

/cc @ansis @nickidlugash 