### PR TITLE
Harden projection

### DIFF
--- a/include/mbgl/util/projection.hpp
+++ b/include/mbgl/util/projection.hpp
@@ -94,9 +94,10 @@ public:
 
 private:
     static Point<double> project_(const LatLng& latLng, double worldSize) {
+        const double latitude = util::clamp(latLng.latitude(), -util::LATITUDE_MAX, util::LATITUDE_MAX);
         return Point<double> {
             util::LONGITUDE_MAX + latLng.longitude(),
-            util::LONGITUDE_MAX - util::RAD2DEG * std::log(std::tan(M_PI / 4 + latLng.latitude() * M_PI / util::DEGREES_MAX))
+            util::LONGITUDE_MAX - util::RAD2DEG * std::log(std::tan(M_PI / 4 + latitude * M_PI / util::DEGREES_MAX))
         } * worldSize / util::DEGREES_MAX;
     }
 };

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -497,12 +497,10 @@ void GLFWView::onMouseClick(GLFWwindow *window, int button, int action, int modi
 void GLFWView::onMouseMove(GLFWwindow *window, double x, double y) {
     auto *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
     if (view->tracking) {
-        double dx = x - view->lastX;
-        double dy = y - view->lastY;
+        const double dx = x - view->lastX;
+        const double dy = y - view->lastY;
         if (dx || dy) {
-            view->map->setLatLng(
-                    view->map->latLngForPixel(mbgl::ScreenCoordinate(x - dx, y - dy)),
-                    mbgl::ScreenCoordinate(x, y));
+            view->map->moveBy(mbgl::ScreenCoordinate { dx, dy });
         }
     } else if (view->rotating) {
         view->map->rotateBy({ view->lastX, view->lastY }, { x, y });

--- a/test/util/projection.test.cpp
+++ b/test/util/projection.test.cpp
@@ -7,6 +7,49 @@
 
 using namespace mbgl;
 
+TEST(Projection, Boundaries) {
+    LatLng sw { -90.0, -180.0 };
+    LatLng ne { 90.0, 180.0 };
+
+    const double minScale = std::pow(2, 0);
+    const double maxScale = std::pow(2, util::DEFAULT_MAX_ZOOM);
+
+    Point<double> projected {};
+    LatLng unprojected {};
+
+    projected = Projection::project(sw, minScale);
+    EXPECT_DOUBLE_EQ(projected.x, 0.0);
+    EXPECT_DOUBLE_EQ(projected.y, util::tileSize);
+
+    unprojected = Projection::unproject(projected, minScale);
+    EXPECT_DOUBLE_EQ(unprojected.latitude(), -util::LATITUDE_MAX);
+    EXPECT_DOUBLE_EQ(unprojected.longitude(), sw.longitude());
+
+    projected = Projection::project(sw, maxScale);
+    EXPECT_DOUBLE_EQ(projected.x, 0.0);
+    EXPECT_DOUBLE_EQ(projected.y, util::tileSize * maxScale);
+
+    unprojected = Projection::unproject(projected, maxScale);
+    EXPECT_DOUBLE_EQ(unprojected.latitude(), -util::LATITUDE_MAX);
+    EXPECT_DOUBLE_EQ(unprojected.longitude(), sw.longitude());
+
+    projected = Projection::project(ne, minScale);
+    EXPECT_DOUBLE_EQ(projected.x, util::tileSize);
+    ASSERT_NEAR(projected.y, 0.0, 1e-10);
+
+    unprojected = Projection::unproject(projected, minScale);
+    EXPECT_DOUBLE_EQ(unprojected.latitude(), util::LATITUDE_MAX);
+    EXPECT_DOUBLE_EQ(unprojected.longitude(), ne.longitude());
+
+    projected = Projection::project(ne, maxScale);
+    EXPECT_DOUBLE_EQ(projected.x, util::tileSize * maxScale);
+    ASSERT_NEAR(projected.y, 0.0, 1e-6);
+
+    unprojected = Projection::unproject(projected, maxScale);
+    EXPECT_DOUBLE_EQ(unprojected.latitude(), util::LATITUDE_MAX);
+    EXPECT_DOUBLE_EQ(unprojected.longitude(), ne.longitude());
+}
+
 TEST(Projection, MetersPerPixelAtLatitude) {
     double zoom = 0;
     EXPECT_DOUBLE_EQ(Projection::getMetersPerPixelAtLatitude(0, zoom), 78271.516964020484);


### PR DESCRIPTION
Captured while testing https://github.com/mapbox/mapbox-gl-native/pull/12310 - but also reproducible in upstream master in some circumstances (e.g. when the width is much higher than height).

Projecting round -90.0 degrees using the [WebMercator projection algorithm](https://en.wikipedia.org/wiki/Web_Mercator#Formulas) produces undefined behavior because `log(0)` is undefined - in [C++ documentation for log](https://en.cppreference.com/w/cpp/numeric/math/log):
> If the argument is ±0, -∞ is returned and FE_DIVBYZERO is raised.

Thus, we need to constrain the latitude to be clamped between the WebMercator minimum and maximum latitude values.