### PR TITLE
fix jni method lookup of GeometryCollection accessor

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/geometry/GeoJsonConversionTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/geometry/GeoJsonConversionTest.java
@@ -1,0 +1,49 @@
+package com.mapbox.mapboxsdk.testapp.geometry;
+
+import com.mapbox.geojson.Feature;
+import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.geojson.GeometryCollection;
+import com.mapbox.mapboxsdk.geometry.LatLngBounds;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
+import com.mapbox.mapboxsdk.style.sources.CustomGeometrySource;
+import com.mapbox.mapboxsdk.style.sources.GeometryTileProvider;
+import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
+import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static junit.framework.Assert.assertNotNull;
+
+/**
+ * Instrumentation test to validate java geojson conversion to c++
+ */
+public class GeoJsonConversionTest extends BaseActivityTest {
+
+  // Regression test for #12343
+  @Test
+  public void testGetCameraForLatLngBounds() {
+    validateTestSetup();
+    onMapView().perform(getMapboxMapAction((uiController, mapboxMap) -> {
+      mapboxMap.addSource(new CustomGeometrySource("test-id", new CustomProvider()));
+      mapboxMap.addLayer(new SymbolLayer("test-id", "test-id"));
+      assertNotNull(mapboxMap);
+    }));
+  }
+
+  @Override
+  protected Class getActivityClass() {
+    return EspressoTestActivity.class;
+  }
+
+  class CustomProvider implements GeometryTileProvider {
+    @Override
+    public FeatureCollection getFeaturesForBounds(LatLngBounds bounds, int zoom) {
+      return FeatureCollection.fromFeatures(
+        Collections.singletonList(
+          Feature.fromGeometry(
+            GeometryCollection.fromGeometries(
+              Collections.emptyList()))));
+    }
+  }
+}

--- a/platform/android/src/geojson/geometry_collection.cpp
+++ b/platform/android/src/geojson/geometry_collection.cpp
@@ -30,7 +30,7 @@ jni::Object<GeometryCollection> GeometryCollection::New(jni::JNIEnv& env, const 
 
 mapbox::geometry::geometry_collection<double> GeometryCollection::convert(jni::JNIEnv &env, jni::Object<GeometryCollection> jCollection) {
     // Get geometries
-    static auto getGeometries = javaClass.GetMethod<jni::Object<java::util::List> ()>(env, "getGeometries");
+    static auto getGeometries = javaClass.GetMethod<jni::Object<java::util::List> ()>(env, "geometries");
     auto jList = jCollection.Call(env, getGeometries);
 
     // Turn into array


### PR DESCRIPTION
closes #12343 
fix jni method lookup of GeometryCollection accessor geometries, add regression test.

cc @osana 