### PR TITLE
[ios, build] Strip symbols before recording size metrics

### DIFF
--- a/platform/ios/scripts/metrics.sh
+++ b/platform/ios/scripts/metrics.sh
@@ -4,7 +4,8 @@ set -e
 set -o pipefail
 
 # Generate stripped versions for every architecture
-xcrun bitcode_strip build/ios/pkg/dynamic/Mapbox.framework/Mapbox -r -o  build/ios/pkg/dynamic/Mapbox-stripped
+xcrun bitcode_strip build/ios/pkg/dynamic/Mapbox.framework/Mapbox -r -o build/ios/pkg/dynamic/Mapbox-stripped
+strip -Sx build/ios/pkg/dynamic/Mapbox-stripped
 lipo build/ios/pkg/dynamic/Mapbox-stripped -extract armv7 -output build/ios/pkg/dynamic/Mapbox-stripped-armv7
 lipo build/ios/pkg/dynamic/Mapbox-stripped -extract arm64 -output build/ios/pkg/dynamic/Mapbox-stripped-arm64
 lipo build/ios/pkg/dynamic/Mapbox-stripped -extract x86_64 -output build/ios/pkg/dynamic/Mapbox-stripped-x86_64


### PR DESCRIPTION
Use the `strip` command before recording binary size metrics for the iOS framework — this is the same command [we use when packaging stripped release builds](https://github.com/mapbox/mapbox-gl-native/blob/3710ef8810bdab2d2e7f261c3b5c5e4053a279c9/platform/ios/scripts/package.sh#L169-L177) and results in a closer approximation of actual in-app size.

Follows up on #12282.

### Before
```
 37M	build/ios/pkg/dynamic/Mapbox-stripped
9.4M	build/ios/pkg/dynamic/Mapbox-stripped-arm64
8.7M	build/ios/pkg/dynamic/Mapbox-stripped-armv7
9.4M	build/ios/pkg/dynamic/Mapbox-stripped-x86_64
```

### After
```
 19M	build/ios/pkg/dynamic/Mapbox-stripped
4.9M	build/ios/pkg/dynamic/Mapbox-stripped-arm64
4.5M	build/ios/pkg/dynamic/Mapbox-stripped-armv7
5.1M	build/ios/pkg/dynamic/Mapbox-stripped-x86_64
```

/cc @jfirebaugh 