### PR TITLE
Add enabled property to MGLShape

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -10,7 +10,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed inconsistencies in exception naming. ([#12583](https://github.com/mapbox/mapbox-gl-native/issues/12583))
 * Added `MGLShapeOfflineRegion` for defining arbitrarily shaped offline regions [#11447](https://github.com/mapbox/mapbox-gl-native/pull/11447)
 * Added a one-time warning about possible attribute loss when initializing an `MGLShapeSource` with an `MGLShapeCollection` [#12625](https://github.com/mapbox/mapbox-gl-native/pull/12625)
-* Added an -[MGLMapViewDelegate mapView:shapeAnnotationIsEnabled:] method to specify whether an annotation is selectable. ([#12352](https://github.com/mapbox/mapbox-gl-native/pull/12352))
+* Added an `-[MGLMapViewDelegate mapView:shapeAnnotationIsEnabled:]` method to specify whether an annotation is selectable. ([#12352](https://github.com/mapbox/mapbox-gl-native/pull/12352))
 
 ## 4.3.0 - August 15, 2018
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed inconsistencies in exception naming. ([#12583](https://github.com/mapbox/mapbox-gl-native/issues/12583))
 * Added `MGLShapeOfflineRegion` for defining arbitrarily shaped offline regions [#11447](https://github.com/mapbox/mapbox-gl-native/pull/11447)
 * Added a one-time warning about possible attribute loss when initializing an `MGLShapeSource` with an `MGLShapeCollection` [#12625](https://github.com/mapbox/mapbox-gl-native/pull/12625)
+* `-[MGLMapViewDelegate mapView:canSelectAnnotation:]` can now specify if an annotation is selectable. ([#12352](https://github.com/mapbox/mapbox-gl-native/pull/12352))
 
 ## 4.3.0 - August 15, 2018
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -10,7 +10,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed inconsistencies in exception naming. ([#12583](https://github.com/mapbox/mapbox-gl-native/issues/12583))
 * Added `MGLShapeOfflineRegion` for defining arbitrarily shaped offline regions [#11447](https://github.com/mapbox/mapbox-gl-native/pull/11447)
 * Added a one-time warning about possible attribute loss when initializing an `MGLShapeSource` with an `MGLShapeCollection` [#12625](https://github.com/mapbox/mapbox-gl-native/pull/12625)
-* `-[MGLMapViewDelegate mapView:canSelectAnnotation:]` can now specify if an annotation is selectable. ([#12352](https://github.com/mapbox/mapbox-gl-native/pull/12352))
+* Added an -[MGLMapViewDelegate mapView:shapeAnnotationIsEnabled:] method to specify whether an annotation is selectable. ([#12352](https://github.com/mapbox/mapbox-gl-native/pull/12352))
 
 ## 4.3.0 - August 15, 2018
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -4183,9 +4183,8 @@ public:
             {
                 if ([annotation isKindOfClass:[MGLMultiPoint class]])
                 {
-                    if ([self.delegate respondsToSelector:@selector(mapView:shapeAnnotationIsEnabled:)] &&
-                        ![self.delegate mapView:self shapeAnnotationIsEnabled:(MGLMultiPoint *)annotation]) {
-                        return true;
+                    if ([self.delegate respondsToSelector:@selector(mapView:shapeAnnotationIsEnabled:)]) {
+                        return !!(![self.delegate mapView:self shapeAnnotationIsEnabled:(MGLMultiPoint *)annotation]);
                     } else {
                         return false;
                     }

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -4157,6 +4157,11 @@ public:
                 return true;
             }
             
+            if ([self.delegate respondsToSelector:@selector(mapView:canSelectAnnotation:)] &&
+                ![self.delegate mapView:self canSelectAnnotation:annotation]) {
+                return true;
+            }
+            
             MGLAnnotationContext annotationContext = _annotationContextsByAnnotationTag.at(annotationTag);
             CGRect annotationRect;
             

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -4157,11 +4157,6 @@ public:
                 return true;
             }
             
-            if ([self.delegate respondsToSelector:@selector(mapView:canSelectAnnotation:)] &&
-                ![self.delegate mapView:self canSelectAnnotation:annotation]) {
-                return true;
-            }
-            
             MGLAnnotationContext annotationContext = _annotationContextsByAnnotationTag.at(annotationTag);
             CGRect annotationRect;
             
@@ -4188,7 +4183,12 @@ public:
             {
                 if ([annotation isKindOfClass:[MGLMultiPoint class]])
                 {
-                    return false;
+                    if ([self.delegate respondsToSelector:@selector(mapView:shapeAnnotationIsEnabled:)] &&
+                        ![self.delegate mapView:self shapeAnnotationIsEnabled:(MGLMultiPoint *)annotation]) {
+                        return true;
+                    } else {
+                        return false;
+                    }
                 }
                 
                 MGLAnnotationImage *annotationImage = [self imageOfAnnotationWithTag:annotationTag];

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -435,8 +435,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Returns a Boolean value indicating whether the shape annotation can be selected.
  
- If the return value is YES, the user can select the annotation by tapping [clicking]
- on it. If the delegate does not implement this method, the default value is YES.
+ If the return value is `YES`, the user can select the annotation by tapping
+ on it. If the delegate does not implement this method, the default value is `YES`.
  
  @param mapView The map view that has selected the annotation.
  @param annotation The object representing the shape annotation.

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -433,16 +433,16 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Selecting Annotations
 
 /**
- Returns a Boolean value indicating whether the annotation can be selected.
+ Returns a Boolean value indicating whether the shape annotation can be selected.
  
- If the return value is `YES`, or if this method is absent from the delegate,
- the annotation will be selected.
+ If the return value is YES, the user can select the annotation by tapping [clicking]
+ on it. If the delegate does not implement this method, the default value is YES.
  
  @param mapView The map view that has selected the annotation.
- @param annotation The object representing the annotation.
+ @param annotation The object representing the shape annotation.
  @return A Boolean value indicating whether the annotation can be selected.
  */
-- (BOOL)mapView:(MGLMapView *)mapView canSelectAnnotation:(id <MGLAnnotation>)annotation;
+- (BOOL)mapView:(MGLMapView *)mapView shapeAnnotationIsEnabled:(MGLShape *)annotation;
 
 /**
  Tells the delegate that one of its annotations was selected.

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -433,6 +433,18 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Selecting Annotations
 
 /**
+ Returns a Boolean value indicating whether the annotation can be selected.
+ 
+ If the return value is `YES`, or if this method is absent from the delegate,
+ the annotation will be selected.
+ 
+ @param mapView The map view that has selected the annotation.
+ @param annotation The object representing the annotation.
+ @return A Boolean value indicating whether the annotation can be selected.
+ */
+- (BOOL)mapView:(MGLMapView *)mapView canSelectAnnotation:(id <MGLAnnotation>)annotation;
+
+/**
  Tells the delegate that one of its annotations was selected.
 
  You can use this method to track changes in the selection state of annotations.

--- a/platform/ios/test/MGLMapViewDelegateIntegrationTests.swift
+++ b/platform/ios/test/MGLMapViewDelegateIntegrationTests.swift
@@ -59,7 +59,7 @@ extension MGLMapViewDelegateIntegrationTests: MGLMapViewDelegate {
 
     func mapViewDidFinishRenderingFrame(_ mapView: MGLMapView, fullyRendered: Bool) {}
     
-    func mapView(_ mapView: MGLMapView, canSelect annotation: MGLAnnotation) -> Bool { return false }
+    func mapView(_ mapView: MGLMapView, shapeAnnotationIsEnabled annotation: MGLShape) -> Bool { return false }
 
     func mapView(_ mapView: MGLMapView, didAdd annotationViews: [MGLAnnotationView]) {}
 

--- a/platform/ios/test/MGLMapViewDelegateIntegrationTests.swift
+++ b/platform/ios/test/MGLMapViewDelegateIntegrationTests.swift
@@ -58,6 +58,8 @@ extension MGLMapViewDelegateIntegrationTests: MGLMapViewDelegate {
     func mapView(_ mapView: MGLMapView, tapOnCalloutFor annotation: MGLAnnotation) {}
 
     func mapViewDidFinishRenderingFrame(_ mapView: MGLMapView, fullyRendered: Bool) {}
+    
+    func mapView(_ mapView: MGLMapView, canSelect annotation: MGLAnnotation) -> Bool { return false }
 
     func mapView(_ mapView: MGLMapView, didAdd annotationViews: [MGLAnnotationView]) {}
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -6,7 +6,7 @@
 * The `-[MGLMapView annotationAtPoint:]` method can now return annotations near tile boundaries at high zoom levels. ([#12570](https://github.com/mapbox/mapbox-gl-native/pull/12570))
 * Fixed inconsistencies in exception naming. ([#12583](https://github.com/mapbox/mapbox-gl-native/issues/12583))
 * Added `MGLShapeOfflineRegion` for defining arbitrarily shaped offline regions [#11447](https://github.com/mapbox/mapbox-gl-native/pull/11447)
-* `-[MGLMapViewDelegate mapView:canSelectAnnotation:]` can now specify if an annotation is selectable. ([#12352](https://github.com/mapbox/mapbox-gl-native/pull/12352))
+* Added an -[MGLMapViewDelegate mapView:shapeAnnotationIsEnabled:] method to specify whether an annotation is selectable. ([#12352](https://github.com/mapbox/mapbox-gl-native/pull/12352))
 
 # 0.10.0 - August 15, 2018
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -6,6 +6,7 @@
 * The `-[MGLMapView annotationAtPoint:]` method can now return annotations near tile boundaries at high zoom levels. ([#12570](https://github.com/mapbox/mapbox-gl-native/pull/12570))
 * Fixed inconsistencies in exception naming. ([#12583](https://github.com/mapbox/mapbox-gl-native/issues/12583))
 * Added `MGLShapeOfflineRegion` for defining arbitrarily shaped offline regions [#11447](https://github.com/mapbox/mapbox-gl-native/pull/11447)
+* `-[MGLMapViewDelegate mapView:canSelectAnnotation:]` can now specify if an annotation is selectable. ([#12352](https://github.com/mapbox/mapbox-gl-native/pull/12352))
 
 # 0.10.0 - August 15, 2018
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -6,7 +6,7 @@
 * The `-[MGLMapView annotationAtPoint:]` method can now return annotations near tile boundaries at high zoom levels. ([#12570](https://github.com/mapbox/mapbox-gl-native/pull/12570))
 * Fixed inconsistencies in exception naming. ([#12583](https://github.com/mapbox/mapbox-gl-native/issues/12583))
 * Added `MGLShapeOfflineRegion` for defining arbitrarily shaped offline regions [#11447](https://github.com/mapbox/mapbox-gl-native/pull/11447)
-* Added an -[MGLMapViewDelegate mapView:shapeAnnotationIsEnabled:] method to specify whether an annotation is selectable. ([#12352](https://github.com/mapbox/mapbox-gl-native/pull/12352))
+* Added an `-[MGLMapViewDelegate mapView:shapeAnnotationIsEnabled:]` method to specify whether an annotation is selectable. ([#12352](https://github.com/mapbox/mapbox-gl-native/pull/12352))
 
 # 0.10.0 - August 15, 2018
 

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2108,9 +2108,8 @@ public:
             
             if ([annotation isKindOfClass:[MGLMultiPoint class]])
             {
-                if ([self.delegate respondsToSelector:@selector(mapView:shapeAnnotationIsEnabled:)] &&
-                    ![self.delegate mapView:self shapeAnnotationIsEnabled:(MGLMultiPoint *)annotation]) {
-                    return true;
+                if ([self.delegate respondsToSelector:@selector(mapView:shapeAnnotationIsEnabled:)]) {
+                    return !!(![self.delegate mapView:self shapeAnnotationIsEnabled:(MGLMultiPoint *)annotation]);
                 } else {
                     return false;
                 }

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2106,14 +2106,14 @@ public:
                 return true;
             }
             
-            if ([self.delegate respondsToSelector:@selector(mapView:canSelectAnnotation:)] &&
-                ![self.delegate mapView:self canSelectAnnotation:annotation]) {
-                return true;
-            }
-            
             if ([annotation isKindOfClass:[MGLMultiPoint class]])
             {
-                return false;
+                if ([self.delegate respondsToSelector:@selector(mapView:shapeAnnotationIsEnabled:)] &&
+                    ![self.delegate mapView:self shapeAnnotationIsEnabled:(MGLMultiPoint *)annotation]) {
+                    return true;
+                } else {
+                    return false;
+                }
             }
             
             MGLAnnotationImage *annotationImage = [self imageOfAnnotationWithTag:annotationTag];

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2106,6 +2106,11 @@ public:
                 return true;
             }
             
+            if ([self.delegate respondsToSelector:@selector(mapView:canSelectAnnotation:)] &&
+                ![self.delegate mapView:self canSelectAnnotation:annotation]) {
+                return true;
+            }
+            
             if ([annotation isKindOfClass:[MGLMultiPoint class]])
             {
                 return false;

--- a/platform/macos/src/MGLMapViewDelegate.h
+++ b/platform/macos/src/MGLMapViewDelegate.h
@@ -244,6 +244,18 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Selecting Annotations
 
 /**
+ Returns a Boolean value indicating whether the annotation can be selected.
+ 
+ If the return value is `YES`, or if this method is absent from the delegate,
+ the annotation will be selected.
+ 
+ @param mapView The map view that has selected the annotation.
+ @param annotation The object representing the annotation.
+ @return A Boolean value indicating whether the annotation can be selected.
+ */
+- (BOOL)mapView:(MGLMapView *)mapView canSelectAnnotation:(id <MGLAnnotation>)annotation;
+
+/**
  Tells the delegate that one of its annotations has been selected.
 
  You can use this method to track changes to the selection state of annotations.

--- a/platform/macos/src/MGLMapViewDelegate.h
+++ b/platform/macos/src/MGLMapViewDelegate.h
@@ -244,16 +244,16 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Selecting Annotations
 
 /**
- Returns a Boolean value indicating whether the annotation can be selected.
+ Returns a Boolean value indicating whether the shape annotation can be selected.
  
- If the return value is `YES`, or if this method is absent from the delegate,
- the annotation will be selected.
+ If the return value is YES, the user can select the annotation by tapping [clicking]
+ on it. If the delegate does not implement this method, the default value is YES.
  
  @param mapView The map view that has selected the annotation.
- @param annotation The object representing the annotation.
+ @param annotation The object representing the shape annotation.
  @return A Boolean value indicating whether the annotation can be selected.
  */
-- (BOOL)mapView:(MGLMapView *)mapView canSelectAnnotation:(id <MGLAnnotation>)annotation;
+- (BOOL)mapView:(MGLMapView *)mapView shapeAnnotationIsEnabled:(MGLShape *)annotation;
 
 /**
  Tells the delegate that one of its annotations has been selected.

--- a/platform/macos/src/MGLMapViewDelegate.h
+++ b/platform/macos/src/MGLMapViewDelegate.h
@@ -246,8 +246,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Returns a Boolean value indicating whether the shape annotation can be selected.
  
- If the return value is YES, the user can select the annotation by tapping [clicking]
- on it. If the delegate does not implement this method, the default value is YES.
+ If the return value is `YES`, the user can select the annotation by clicking
+ on it. If the delegate does not implement this method, the default value is `YES`.
  
  @param mapView The map view that has selected the annotation.
  @param annotation The object representing the shape annotation.

--- a/platform/macos/test/MGLMapViewDelegateIntegrationTests.swift
+++ b/platform/macos/test/MGLMapViewDelegateIntegrationTests.swift
@@ -27,7 +27,7 @@ extension MGLMapViewDelegateIntegrationTests: MGLMapViewDelegate {
 
     func mapViewDidFailLoadingMap(_ mapView: MGLMapView, withError error: Error) {}
     
-    func mapView(_ mapView: MGLMapView, canSelect annotation: MGLAnnotation) -> Bool { return false }
+    func mapView(_ mapView: MGLMapView, shapeAnnotationIsEnabled annotation: MGLShape) -> Bool { return false }
 
     func mapView(_ mapView: MGLMapView, didDeselect annotation: MGLAnnotation) {}
 

--- a/platform/macos/test/MGLMapViewDelegateIntegrationTests.swift
+++ b/platform/macos/test/MGLMapViewDelegateIntegrationTests.swift
@@ -26,6 +26,8 @@ extension MGLMapViewDelegateIntegrationTests: MGLMapViewDelegate {
     func mapViewDidFinishRenderingMap(_ mapView: MGLMapView, fullyRendered: Bool) {}
 
     func mapViewDidFailLoadingMap(_ mapView: MGLMapView, withError error: Error) {}
+    
+    func mapView(_ mapView: MGLMapView, canSelect annotation: MGLAnnotation) -> Bool { return false }
 
     func mapView(_ mapView: MGLMapView, didDeselect annotation: MGLAnnotation) {}
 


### PR DESCRIPTION
To Do: 

- [X] Add `enabled` property to `MGLShape`. 
~- [x] Account for MGLShapeCollection, which does not inherit from `MGLMultiPoint`.~ This is not necessary. 
- [X] Document that the `enabled` property only applies to annotations, and not style layers.
- [ ] Add tests. 

Fixes #10539