### PR TITLE
add geojson regression tests for java method look up from JNI

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/geometry/GeoJsonConversionTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/geometry/GeoJsonConversionTest.java
@@ -1,8 +1,8 @@
 package com.mapbox.mapboxsdk.testapp.geometry;
 
-import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
-import com.mapbox.geojson.GeometryCollection;
+import com.mapbox.geojson.Point;
+import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.mapboxsdk.style.sources.CustomGeometrySource;
@@ -11,9 +11,14 @@ import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
 import org.junit.Test;
 
-import java.util.Collections;
-
-import static junit.framework.Assert.assertNotNull;
+import static com.mapbox.geojson.Feature.fromGeometry;
+import static com.mapbox.geojson.FeatureCollection.fromFeatures;
+import static com.mapbox.geojson.GeometryCollection.fromGeometries;
+import static com.mapbox.geojson.LineString.fromLngLats;
+import static com.mapbox.geojson.MultiLineString.fromLineString;
+import static com.mapbox.geojson.MultiPolygon.fromPolygon;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 
 /**
  * Instrumentation test to validate java geojson conversion to c++
@@ -22,12 +27,94 @@ public class GeoJsonConversionTest extends BaseActivityTest {
 
   // Regression test for #12343
   @Test
-  public void testGetCameraForLatLngBounds() {
+  public void testEmptyFeatureCollection() {
     validateTestSetup();
     onMapView().perform(getMapboxMapAction((uiController, mapboxMap) -> {
-      mapboxMap.addSource(new CustomGeometrySource("test-id", new CustomProvider()));
+      mapboxMap.addSource(
+        new CustomGeometrySource("test-id",
+          new CustomProvider(fromFeatures(singletonList(fromGeometry(fromGeometries(emptyList())))))
+        )
+      );
       mapboxMap.addLayer(new SymbolLayer("test-id", "test-id"));
-      assertNotNull(mapboxMap);
+    }));
+  }
+
+  @Test
+  public void testPointFeatureCollection() {
+    validateTestSetup();
+    onMapView().perform(getMapboxMapAction((uiController, mapboxMap) -> {
+      mapboxMap.addSource(
+        new CustomGeometrySource("test-id",
+          new CustomProvider(fromFeatures(singletonList(fromGeometry(Point.fromLngLat(0.0,0.0)))))
+        )
+      );
+      mapboxMap.addLayer(new SymbolLayer("test-id", "test-id"));
+    }));
+  }
+
+  @Test
+  public void testMultiPointFeatureCollection() {
+    validateTestSetup();
+    onMapView().perform(getMapboxMapAction((uiController, mapboxMap) -> {
+      mapboxMap.addSource(
+        new CustomGeometrySource("test-id",
+          new CustomProvider(fromFeatures(singletonList(fromGeometry(fromLngLats(emptyList())))))
+        )
+      );
+      mapboxMap.addLayer(new SymbolLayer("test-id", "test-id"));
+    }));
+  }
+
+
+  @Test
+  public void testPolygonFeatureCollection() {
+    validateTestSetup();
+    onMapView().perform(getMapboxMapAction((uiController, mapboxMap) -> {
+      mapboxMap.addSource(
+        new CustomGeometrySource("test-id",
+          new CustomProvider(fromFeatures(singletonList(fromGeometry(Polygon.fromLngLats(emptyList())))))
+        )
+      );
+      mapboxMap.addLayer(new SymbolLayer("test-id", "test-id"));
+    }));
+  }
+
+  @Test
+  public void testMultiPolygonFeatureCollection() {
+    validateTestSetup();
+    onMapView().perform(getMapboxMapAction((uiController, mapboxMap) -> {
+      mapboxMap.addSource(
+        new CustomGeometrySource("test-id",
+          new CustomProvider(fromFeatures(singletonList(fromGeometry(fromPolygon(Polygon.fromLngLats(emptyList()))))))
+        )
+      );
+      mapboxMap.addLayer(new SymbolLayer("test-id", "test-id"));
+    }));
+  }
+
+  @Test
+  public void testLineStringFeatureCollection() {
+    validateTestSetup();
+    onMapView().perform(getMapboxMapAction((uiController, mapboxMap) -> {
+      mapboxMap.addSource(
+        new CustomGeometrySource("test-id",
+          new CustomProvider(fromFeatures(singletonList(fromGeometry(fromLngLats(emptyList())))))
+        )
+      );
+      mapboxMap.addLayer(new SymbolLayer("test-id", "test-id"));
+    }));
+  }
+
+  @Test
+  public void testMultiLineStringFeatureCollection() {
+    validateTestSetup();
+    onMapView().perform(getMapboxMapAction((uiController, mapboxMap) -> {
+      mapboxMap.addSource(
+        new CustomGeometrySource("test-id",
+          new CustomProvider(fromFeatures(singletonList(fromGeometry(fromLineString(fromLngLats(emptyList()))))))
+        )
+      );
+      mapboxMap.addLayer(new SymbolLayer("test-id", "test-id"));
     }));
   }
 
@@ -37,13 +124,16 @@ public class GeoJsonConversionTest extends BaseActivityTest {
   }
 
   class CustomProvider implements GeometryTileProvider {
+
+    private FeatureCollection featureCollection;
+
+    CustomProvider(FeatureCollection featureCollection) {
+      this.featureCollection = featureCollection;
+    }
+
     @Override
     public FeatureCollection getFeaturesForBounds(LatLngBounds bounds, int zoom) {
-      return FeatureCollection.fromFeatures(
-        Collections.singletonList(
-          Feature.fromGeometry(
-            GeometryCollection.fromGeometries(
-              Collections.emptyList()))));
+      return featureCollection;
     }
   }
 }


### PR DESCRIPTION
Closes #12345 , this PR ensures the convert method is called on the related c++ files and as result makes sure that the java related method is executed from JNI. 