### PR TITLE
[core] coveredByChildren is false if at least one child is uncovered

### DIFF
--- a/src/mbgl/algorithm/covered_by_children.hpp
+++ b/src/mbgl/algorithm/covered_by_children.hpp
@@ -8,15 +8,23 @@ namespace algorithm {
 template <typename Iterator>
 bool coveredByChildren(const UnwrappedTileID& id, Iterator it, const Iterator& end) {
     for (const auto& child : id.children()) {
-        it = std::lower_bound(it, end, child, [](auto& a, auto& b) { return std::get<0>(a) < b; });
+        it = std::lower_bound(it, end, child, [](const auto& a, const auto& b) { return std::get<0>(a) < b; });
+
+        // Child is not present, neither its grandchildren.
         if (it == end) {
             return false;
-        } else if (std::get<0>(*it) != child) {
-            return coveredByChildren(child, it, end);
+        }
+
+        // Child is not present, but its grandchildren are.
+        if (std::get<0>(*it) != child) {
+            // This child is not covered by its grandchildren.
+            if (!coveredByChildren(child, it, end)) {
+                return false;
+            }
         }
     }
 
-    // We looked at all four immediate children and verified that they're covered.
+    // We looked at all four children (recursively) and verified that they're covered.
     return true;
 }
 

--- a/test/algorithm/covered_by_children.test.cpp
+++ b/test/algorithm/covered_by_children.test.cpp
@@ -8,6 +8,48 @@ using namespace mbgl;
 
 using List = std::map<UnwrappedTileID, bool>;
 
+TEST(CoveredByChildren, GrandChildren) {
+    const List list {
+        { UnwrappedTileID{ 0, 0, 0 }, true },
+        // These grandchildren covers 1/0/0, but 1/0/0 only covers a quarter of
+        // 0/0/0.
+        { UnwrappedTileID{ 2, 0, 0 }, true },
+        { UnwrappedTileID{ 2, 0, 1 }, true },
+        { UnwrappedTileID{ 2, 1, 0 }, true },
+        { UnwrappedTileID{ 2, 1, 1 }, true },
+    };
+    EXPECT_FALSE(algorithm::coveredByChildren(UnwrappedTileID{ 0, 0, 0 }, list));
+
+    const List list2 {
+        { UnwrappedTileID{ 0, 0, 0 }, true },
+
+        // Children of 1/0/0
+        { UnwrappedTileID{ 2, 0, 0 }, true },
+        { UnwrappedTileID{ 2, 0, 1 }, true },
+        { UnwrappedTileID{ 2, 1, 0 }, true },
+        { UnwrappedTileID{ 2, 1, 1 }, true },
+
+        // Children of 1/0/1
+        { UnwrappedTileID{ 2, 0, 2 }, true },
+        { UnwrappedTileID{ 2, 0, 3 }, true },
+        { UnwrappedTileID{ 2, 1, 2 }, true },
+        { UnwrappedTileID{ 2, 1, 3 }, true },
+
+        // Children of 1/1/0
+        { UnwrappedTileID{ 2, 2, 0 }, true },
+        { UnwrappedTileID{ 2, 2, 1 }, true },
+        { UnwrappedTileID{ 2, 3, 0 }, true },
+        { UnwrappedTileID{ 2, 3, 1 }, true },
+
+        // Children of 1/0/1
+        { UnwrappedTileID{ 2, 2, 2 }, true },
+        { UnwrappedTileID{ 2, 2, 3 }, true },
+        { UnwrappedTileID{ 2, 3, 2 }, true },
+        { UnwrappedTileID{ 2, 3, 3 }, true },
+    };
+    EXPECT_TRUE(algorithm::coveredByChildren(UnwrappedTileID{ 0, 0, 0 }, list2));
+}
+
 TEST(CoveredByChildren, NotCovered) {
     const List list1;
     EXPECT_FALSE(algorithm::coveredByChildren(UnwrappedTileID{ 0, 0, 0 }, list1));
@@ -24,7 +66,7 @@ TEST(CoveredByChildren, NotCovered) {
 
     const List list3{
         { UnwrappedTileID{ 0, 0, 0 }, true },
-        // all four child tiles, with with a different wrap index
+        // all four child tiles, with a different wrap index
         { UnwrappedTileID{ 1, { 1, 0, 0 } }, true },
         { UnwrappedTileID{ 1, { 1, 0, 1 } }, true },
         { UnwrappedTileID{ 1, { 1, 1, 0 } }, true },


### PR DESCRIPTION
Another spin-off from https://github.com/mapbox/mapbox-gl-native/pull/12310 - I discovered that the `coveredByChildren` algorithm returns `true` if at least one child is entirely covered by its grandchildren. 

Because we are limiting the number of tiles in #12310, some edge cases were causing the lower zoom tiles to disappear - notice that symbols still appear because their rendering is unaffected by clip IDs.

On the screenshots below, notice how the uppermost tile is not rendered (only its symbols), and its absence of depth buffer color:

| original | depth buffer |
| --- | --- |
| ![screenshot from 2018-07-11 22-28-52](https://user-images.githubusercontent.com/76133/42595776-f8ce87d6-855b-11e8-8088-d1d1808a20f2.png) | ![screenshot from 2018-07-11 22-29-23](https://user-images.githubusercontent.com/76133/42595788-fee810c4-855b-11e8-89f7-774e09e9ae17.png) |

With the changes applied, the uppermost tile reappears, along with its depth buffer (dark grey):

| fixed | depth buffer |
| --- | --- |
| ![screenshot from 2018-07-11 22-30-23](https://user-images.githubusercontent.com/76133/42595831-24ca3cd6-855c-11e8-9acf-d0a29c96aab4.png) | ![screenshot from 2018-07-11 22-30-44](https://user-images.githubusercontent.com/76133/42595838-299b858a-855c-11e8-804e-76cf9e733407.png) |

/cc @kkaefer @asheemmamoowala 



