### PR TITLE
[core] Simplify Value conversions

### DIFF
--- a/include/mbgl/style/expression/value.hpp
+++ b/include/mbgl/style/expression/value.hpp
@@ -60,64 +60,39 @@ type::Type valueTypeToExpressionType();
   Conversions between style value types and expression::Value
 */
 
-// no-op overloads
-Value toExpressionValue(const Value&);
-
-// T = Value (just wrap in optional)
-template <typename T>
-std::enable_if_t<std::is_same<T, Value>::value,
-optional<T>> fromExpressionValue(const Value& v)
-{
-    return optional<T>(v);
-}
-
-// T = member type of Value
-template <typename T>
-std::enable_if_t< std::is_convertible<T, Value>::value && !std::is_same<T, Value>::value,
-optional<T>> fromExpressionValue(const Value& v)
-{
-    return v.template is<T>() ? v.template get<T>() : optional<T>();
-}
-
-// real conversions
-template <typename T, typename Enable = std::enable_if_t< !std::is_convertible<T, Value>::value >>
-Value toExpressionValue(const T& value);
-
-template <typename T>
-std::enable_if_t< !std::is_convertible<T, Value>::value,
-optional<T>> fromExpressionValue(const Value& v);
-
-
-
 template <class T, class Enable = void>
 struct ValueConverter {
-    using ExpressionType = T;
-    
     static Value toExpressionValue(const T& value) {
         return Value(value);
     }
+
     static optional<T> fromExpressionValue(const Value& value) {
         return value.template is<T>() ? value.template get<T>() : optional<T>();
     }
 };
 
 template <>
-struct ValueConverter<float> {
-    using ExpressionType = double;
-    static type::Type expressionType() { return type::Number; }
-    static Value toExpressionValue(const float value);
-    static optional<float> fromExpressionValue(const Value& value);
+struct ValueConverter<Value> {
+    static type::Type expressionType() { return type::Value; }
+    static Value toExpressionValue(const Value& value) { return value; }
+    static optional<Value> fromExpressionValue(const Value& value) { return value; }
 };
 
-template<>
+template <>
 struct ValueConverter<mbgl::Value> {
     static Value toExpressionValue(const mbgl::Value& value);
     static mbgl::Value fromExpressionValue(const Value& value);
 };
 
+template <>
+struct ValueConverter<float> {
+    static type::Type expressionType() { return type::Number; }
+    static Value toExpressionValue(const float value);
+    static optional<float> fromExpressionValue(const Value& value);
+};
+
 template <typename T, std::size_t N>
 struct ValueConverter<std::array<T, N>> {
-    using ExpressionType = std::vector<Value>;
     static type::Type expressionType() {
         return type::Array(valueTypeToExpressionType<T>(), N);
     }
@@ -127,7 +102,6 @@ struct ValueConverter<std::array<T, N>> {
 
 template <typename T>
 struct ValueConverter<std::vector<T>> {
-    using ExpressionType = std::vector<Value>;
     static type::Type expressionType() {
         return type::Array(valueTypeToExpressionType<T>());
     }
@@ -137,7 +111,6 @@ struct ValueConverter<std::vector<T>> {
 
 template <>
 struct ValueConverter<Position> {
-    using ExpressionType = std::vector<Value>;
     static type::Type expressionType() { return type::Array(type::Number, 3); }
     static Value toExpressionValue(const mbgl::style::Position& value);
     static optional<Position> fromExpressionValue(const Value& v);
@@ -145,11 +118,20 @@ struct ValueConverter<Position> {
 
 template <typename T>
 struct ValueConverter<T, std::enable_if_t< std::is_enum<T>::value >> {
-    using ExpressionType = std::string;
     static type::Type expressionType() { return type::String; }
     static Value toExpressionValue(const T& value);
     static optional<T> fromExpressionValue(const Value& value);
 };
+
+template <typename T>
+Value toExpressionValue(const T& value) {
+    return ValueConverter<T>::toExpressionValue(value);
+}
+
+template <typename T>
+optional<T> fromExpressionValue(const Value& value) {
+    return ValueConverter<T>::fromExpressionValue(value);
+}
 
 template <typename T>
 std::vector<optional<T>> fromExpressionValues(const std::vector<optional<Value>>& values) {

--- a/src/mbgl/style/expression/value.cpp
+++ b/src/mbgl/style/expression/value.cpp
@@ -241,27 +241,6 @@ optional<T> ValueConverter<T, std::enable_if_t< std::is_enum<T>::value >>::fromE
     );
 }
 
-
-Value toExpressionValue(const Value& v) {
-    return v;
-}
-
-template <typename T, typename Enable>
-Value toExpressionValue(const T& value) {
-    return ValueConverter<T>::toExpressionValue(value);
-}
-
-optional<Value> fromExpressionValue(const Value& v) {
-    return optional<Value>(v);
-}
-
-template <typename T>
-std::enable_if_t< !std::is_convertible<T, Value>::value,
-optional<T>> fromExpressionValue(const Value& v)
-{
-    return ValueConverter<T>::fromExpressionValue(v);
-}
-
 template <typename T>
 type::Type valueTypeToExpressionType() {
     return ValueConverter<T>::expressionType();
@@ -281,90 +260,64 @@ template <> type::Type valueTypeToExpressionType<std::vector<Value>>() { return 
 template <> type::Type valueTypeToExpressionType<type::ErrorType>() { return type::Error; }
 
 
-template Value toExpressionValue(const mbgl::Value&);
-template optional<mbgl::Value> fromExpressionValue<mbgl::Value>(const Value&);
-
 // for to_rgba expression
 template type::Type valueTypeToExpressionType<std::array<double, 4>>();
-template optional<std::array<double, 4>> fromExpressionValue<std::array<double, 4>>(const Value&);
-template Value toExpressionValue(const std::array<double, 4>&);
+template struct ValueConverter<std::array<double, 4>>;
 
 // layout/paint property types
 template type::Type valueTypeToExpressionType<float>();
-template optional<float> fromExpressionValue<float>(const Value&);
-template Value toExpressionValue(const float&);
+template type::Type valueTypeToExpressionType<Position>();
 
 template type::Type valueTypeToExpressionType<std::array<float, 2>>();
-template optional<std::array<float, 2>> fromExpressionValue<std::array<float, 2>>(const Value&);
-template Value toExpressionValue(const std::array<float, 2>&);
+template struct ValueConverter<std::array<float, 2>>;
 
 template type::Type valueTypeToExpressionType<std::array<float, 4>>();
-template optional<std::array<float, 4>> fromExpressionValue<std::array<float, 4>>(const Value&);
-template Value toExpressionValue(const std::array<float, 4>&);
+template struct ValueConverter<std::array<float, 4>>;
 
 template type::Type valueTypeToExpressionType<std::vector<float>>();
-template optional<std::vector<float>> fromExpressionValue<std::vector<float>>(const Value&);
-template Value toExpressionValue(const std::vector<float>&);
+template struct ValueConverter<std::vector<float>>;
 
 template type::Type valueTypeToExpressionType<std::vector<std::string>>();
-template optional<std::vector<std::string>> fromExpressionValue<std::vector<std::string>>(const Value&);
-template Value toExpressionValue(const std::vector<std::string>&);
+template struct ValueConverter<std::vector<std::string>>;
 
 template type::Type valueTypeToExpressionType<AlignmentType>();
-template optional<AlignmentType> fromExpressionValue<AlignmentType>(const Value&);
-template Value toExpressionValue(const AlignmentType&);
+template struct ValueConverter<AlignmentType>;
 
 template type::Type valueTypeToExpressionType<CirclePitchScaleType>();
-template optional<CirclePitchScaleType> fromExpressionValue<CirclePitchScaleType>(const Value&);
-template Value toExpressionValue(const CirclePitchScaleType&);
+template struct ValueConverter<CirclePitchScaleType>;
 
 template type::Type valueTypeToExpressionType<IconTextFitType>();
-template optional<IconTextFitType> fromExpressionValue<IconTextFitType>(const Value&);
-template Value toExpressionValue(const IconTextFitType&);
+template struct ValueConverter<IconTextFitType>;
 
 template type::Type valueTypeToExpressionType<LineCapType>();
-template optional<LineCapType> fromExpressionValue<LineCapType>(const Value&);
-template Value toExpressionValue(const LineCapType&);
+template struct ValueConverter<LineCapType>;
 
 template type::Type valueTypeToExpressionType<LineJoinType>();
-template optional<LineJoinType> fromExpressionValue<LineJoinType>(const Value&);
-template Value toExpressionValue(const LineJoinType&);
+template struct ValueConverter<LineJoinType>;
 
 template type::Type valueTypeToExpressionType<SymbolPlacementType>();
-template optional<SymbolPlacementType> fromExpressionValue<SymbolPlacementType>(const Value&);
-template Value toExpressionValue(const SymbolPlacementType&);
+template struct ValueConverter<SymbolPlacementType>;
 
 template type::Type valueTypeToExpressionType<SymbolAnchorType>();
-template optional<SymbolAnchorType> fromExpressionValue<SymbolAnchorType>(const Value&);
-template Value toExpressionValue(const SymbolAnchorType&);
+template struct ValueConverter<SymbolAnchorType>;
 
 template type::Type valueTypeToExpressionType<TextJustifyType>();
-template optional<TextJustifyType> fromExpressionValue<TextJustifyType>(const Value&);
-template Value toExpressionValue(const TextJustifyType&);
+template struct ValueConverter<TextJustifyType>;
 
 template type::Type valueTypeToExpressionType<TextTransformType>();
-template optional<TextTransformType> fromExpressionValue<TextTransformType>(const Value&);
-template Value toExpressionValue(const TextTransformType&);
+template struct ValueConverter<TextTransformType>;
 
 template type::Type valueTypeToExpressionType<TranslateAnchorType>();
-template optional<TranslateAnchorType> fromExpressionValue<TranslateAnchorType>(const Value&);
-template Value toExpressionValue(const TranslateAnchorType&);
+template struct ValueConverter<TranslateAnchorType>;
 
 template type::Type valueTypeToExpressionType<RasterResamplingType>();
-template optional<RasterResamplingType> fromExpressionValue<RasterResamplingType>(const Value&);
-template Value toExpressionValue(const RasterResamplingType&);
+template struct ValueConverter<RasterResamplingType>;
 
 template type::Type valueTypeToExpressionType<HillshadeIlluminationAnchorType>();
-template optional<HillshadeIlluminationAnchorType> fromExpressionValue<HillshadeIlluminationAnchorType>(const Value&);
-template Value toExpressionValue(const HillshadeIlluminationAnchorType&);
+template struct ValueConverter<HillshadeIlluminationAnchorType>;
 
 template type::Type valueTypeToExpressionType<LightAnchorType>();
-template optional<LightAnchorType> fromExpressionValue<LightAnchorType>(const Value&);
-template Value toExpressionValue(const LightAnchorType&);
-
-template type::Type valueTypeToExpressionType<Position>();
-template optional<Position> fromExpressionValue<Position>(const Value&);
-template Value toExpressionValue(const Position&);
+template struct ValueConverter<LightAnchorType>;
 
 } // namespace expression
 } // namespace style


### PR DESCRIPTION
Use a single template function for each of {to,from}ExpressionValue, always dispatching to ValueConverter.

Remove unused ValueConverter::ExpressionType typedefs.