### PR TITLE
MapView#isDestroyed

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -425,6 +425,19 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     }
   }
 
+  /**
+   * Returns if the map has been destroyed.
+   * <p>
+   * This method can be used to determine if the result of an asynchronous operation should be set.
+   * </p>
+   *
+   * @return true, if the map has been destroyed
+   */
+  @UiThread
+  public boolean isDestroyed() {
+    return destroyed;
+  }
+
   @Override
   public boolean onTouchEvent(MotionEvent event) {
     if (!isMapInitialized() || !isZoomButtonControllerInitialized()) {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/BulkMarkerActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/BulkMarkerActivity.java
@@ -92,7 +92,7 @@ public class BulkMarkerActivity extends AppCompatActivity implements AdapterView
   }
 
   private void showMarkers(int amount) {
-    if (mapboxMap == null || locations == null) {
+    if (mapboxMap == null || locations == null || mapView.isDestroyed()) {
       return;
     }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/SymbolGeneratorActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/SymbolGeneratorActivity.java
@@ -14,7 +14,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
-
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
 import com.mapbox.mapboxsdk.maps.MapView;
@@ -26,13 +25,12 @@ import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.style.sources.Source;
 import com.mapbox.mapboxsdk.testapp.R;
 import com.mapbox.mapboxsdk.testapp.utils.ResourceUtils;
+import timber.log.Timber;
 
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.List;
-
-import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.concat;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.division;
@@ -240,6 +238,10 @@ public class SymbolGeneratorActivity extends AppCompatActivity implements OnMapR
   }
 
   public void onDataLoaded(@NonNull FeatureCollection featureCollection) {
+    if (mapView.isDestroyed()) {
+      return;
+    }
+
     // create expressions
     Expression iconImageExpression = string(get(literal(FEATURE_ID)));
     Expression iconSizeExpression = division(number(get(literal(FEATURE_RANK))), literal(2.0f));


### PR DESCRIPTION
add convenience method for destroyed state on MapView which can be used to determine if an asynchronous result should be set on map.