### PR TITLE
[iOS] Add fallbacks for name fields

### DIFF
--- a/platform/darwin/src/NSExpression+MGLAdditions.mm
+++ b/platform/darwin/src/NSExpression+MGLAdditions.mm
@@ -1401,23 +1401,25 @@ NSDictionary<NSNumber *, NSExpression *> *MGLLocalizedStopDictionary(NSDictionar
                         localizedKeyPath = [NSString stringWithFormat:@"name_%@", preferredLanguage];
                     }
                 }
-                // If the keypath is `name` or `name_en`, no need to fallback
-                if ([localizedKeyPath isEqualToString:@"name"] || [localizedKeyPath isEqualToString:@"name_en"]) {
+                // If the keypath is `name`, no need to fallback
+                if ([localizedKeyPath isEqualToString:@"name"]) {
                     return [NSExpression expressionForKeyPath:localizedKeyPath];
                 }
-                // If the keypath is `name_zh-Hans`, fallback to `name_zh`. If `name_zh` is empty, fallback to `name`
+                // If the keypath is `name_zh-Hans`, fallback to `name_zh` to `name`
                 // The `name_zh-Hans` field was added since Mapbox Streets v7
                 // See the documentation of name fields for detail https://www.mapbox.com/vector-tiles/mapbox-streets-v7/#overview
+                // CN tiles might using `name_zh-CN` for Simplified Chinese
                 if ([localizedKeyPath isEqualToString:@"name_zh-Hans"]) {
-                    return [NSExpression expressionWithFormat:@"mgl_coalesce(%@)",
-                            @[[NSExpression expressionForKeyPath:localizedKeyPath],
-                              [NSExpression expressionForKeyPath:@"name_zh"],
-                              [NSExpression expressionForKeyPath:@"name"],]];
+                    return [NSExpression expressionWithFormat:@"mgl_coalesce({%K, %K, %K, %K})",
+                            localizedKeyPath, @"name_zh-CN", @"name_zh", @"name"];
+                }
+                // Mapbox Streets v8 has `name_zh-Hant`, we should fallback to Simplified Chinese if the filed has no value
+                if ([localizedKeyPath isEqualToString:@"name_zh-Hant"]) {
+                    return [NSExpression expressionWithFormat:@"mgl_coalesce({%K, %K, %K, %K, %K})",
+                            localizedKeyPath, @"name_zh-Hans", @"name_zh-CN", @"name_zh", @"name"];
                 }
                 // Other keypath fallback to `name`
-                return [NSExpression expressionWithFormat:@"mgl_coalesce(%@)",
-                        @[[NSExpression expressionForKeyPath:localizedKeyPath],
-                          [NSExpression expressionForKeyPath:@"name"],]];
+                return [NSExpression expressionWithFormat:@"mgl_coalesce({%K, %K})", localizedKeyPath, @"name"];
             }
             return self;
         }

--- a/platform/darwin/test/MGLExpressionTests.mm
+++ b/platform/darwin/test/MGLExpressionTests.mm
@@ -1023,12 +1023,17 @@ using namespace std::string_literals;
     }
     {
         NSExpression *original = [NSExpression expressionForKeyPath:@"name_en"];
-        NSExpression *expected = [NSExpression expressionForKeyPath:@"name_fr"];
+        NSExpression *expected = [NSExpression expressionWithFormat:@"mgl_coalesce(%@)",
+                                  @[[NSExpression expressionForKeyPath:@"name_fr"],
+                                    [NSExpression expressionForKeyPath:@"name"]]];
         XCTAssertEqualObjects([original mgl_expressionLocalizedIntoLocale:[NSLocale localeWithLocaleIdentifier:@"fr-CA"]], expected);
     }
     {
         NSExpression *original = [NSExpression expressionForKeyPath:@"name_en"];
-        NSExpression *expected = [NSExpression expressionForKeyPath:@"name_zh-Hans"];
+        NSExpression *expected = [NSExpression expressionWithFormat:@"mgl_coalesce(%@)",
+                                  @[[NSExpression expressionForKeyPath:@"name_zh-Hans"],
+                                    [NSExpression expressionForKeyPath:@"name_zh"],
+                                    [NSExpression expressionForKeyPath:@"name"]]];
         XCTAssertEqualObjects([original mgl_expressionLocalizedIntoLocale:[NSLocale localeWithLocaleIdentifier:@"zh-Hans"]], expected);
     }
     {
@@ -1045,7 +1050,9 @@ using namespace std::string_literals;
         NSExpression *expected = [NSExpression expressionWithFormat:@"mgl_step:from:stops:($zoomLevel, short, %@)", @{
             @1: [NSExpression expressionForKeyPath:@"abbr"],
             @2: @"…",
-            @3: [NSExpression expressionForKeyPath:@"name_es"],
+            @3: [NSExpression expressionWithFormat:@"mgl_coalesce(%@)",
+                 @[[NSExpression expressionForKeyPath:@"name_es"],
+                   [NSExpression expressionForKeyPath:@"name"]]]
         }];
         XCTAssertEqualObjects([original mgl_expressionLocalizedIntoLocale:[NSLocale localeWithLocaleIdentifier:@"es-PR"]], expected);
     }

--- a/platform/darwin/test/MGLExpressionTests.mm
+++ b/platform/darwin/test/MGLExpressionTests.mm
@@ -1013,7 +1013,7 @@ using namespace std::string_literals;
     }
     {
         NSExpression *original = [NSExpression expressionForKeyPath:@"name_en"];
-        NSExpression *expected = original;
+        NSExpression *expected = [NSExpression expressionWithFormat:@"mgl_coalesce({%K, %K})", @"name_en", @"name"];
         XCTAssertEqualObjects([original mgl_expressionLocalizedIntoLocale:nil], expected);
     }
     {
@@ -1023,17 +1023,13 @@ using namespace std::string_literals;
     }
     {
         NSExpression *original = [NSExpression expressionForKeyPath:@"name_en"];
-        NSExpression *expected = [NSExpression expressionWithFormat:@"mgl_coalesce(%@)",
-                                  @[[NSExpression expressionForKeyPath:@"name_fr"],
-                                    [NSExpression expressionForKeyPath:@"name"]]];
+        NSExpression *expected = [NSExpression expressionWithFormat:@"mgl_coalesce({%K, %K})", @"name_fr", @"name"];
         XCTAssertEqualObjects([original mgl_expressionLocalizedIntoLocale:[NSLocale localeWithLocaleIdentifier:@"fr-CA"]], expected);
     }
     {
         NSExpression *original = [NSExpression expressionForKeyPath:@"name_en"];
-        NSExpression *expected = [NSExpression expressionWithFormat:@"mgl_coalesce(%@)",
-                                  @[[NSExpression expressionForKeyPath:@"name_zh-Hans"],
-                                    [NSExpression expressionForKeyPath:@"name_zh"],
-                                    [NSExpression expressionForKeyPath:@"name"]]];
+        NSExpression *expected = [NSExpression expressionWithFormat:@"mgl_coalesce({%K, %K, %K, %K})",
+                                  @"name_zh-Hans", @"name_zh-CN", @"name_zh", @"name"];
         XCTAssertEqualObjects([original mgl_expressionLocalizedIntoLocale:[NSLocale localeWithLocaleIdentifier:@"zh-Hans"]], expected);
     }
     {
@@ -1050,9 +1046,7 @@ using namespace std::string_literals;
         NSExpression *expected = [NSExpression expressionWithFormat:@"mgl_step:from:stops:($zoomLevel, short, %@)", @{
             @1: [NSExpression expressionForKeyPath:@"abbr"],
             @2: @"…",
-            @3: [NSExpression expressionWithFormat:@"mgl_coalesce(%@)",
-                 @[[NSExpression expressionForKeyPath:@"name_es"],
-                   [NSExpression expressionForKeyPath:@"name"]]]
+            @3: [NSExpression expressionWithFormat:@"mgl_coalesce({%K, %K})", @"name_es", @"name"]
         }];
         XCTAssertEqualObjects([original mgl_expressionLocalizedIntoLocale:[NSLocale localeWithLocaleIdentifier:@"es-PR"]], expected);
     }

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -26,6 +26,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Added the `collator` and `resolved-locale` expression operators to more precisely compare strings in style JSON. A subset of this functionality is available through predicate options when creating an `NSPredicate`. ([#11869](https://github.com/mapbox/mapbox-gl-native/pull/11869))
 * Fixed a crash when trying to parse expressions containing legacy filters. ([#12263](https://github.com/mapbox/mapbox-gl-native/pull/12263))
 * Fixed a crash that occurred when creating an `MGL_MATCH` expression using non-expressions as arguments. ([#12332](https://github.com/mapbox/mapbox-gl-native/pull/12332))
+* Fixed an issue that no localized low-zoom labels when system language is Simplified Chinese ([#12164](https://github.com/mapbox/mapbox-gl-native/issues/12164))
 
 ### Networking and storage
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -26,7 +26,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Added the `collator` and `resolved-locale` expression operators to more precisely compare strings in style JSON. A subset of this functionality is available through predicate options when creating an `NSPredicate`. ([#11869](https://github.com/mapbox/mapbox-gl-native/pull/11869))
 * Fixed a crash when trying to parse expressions containing legacy filters. ([#12263](https://github.com/mapbox/mapbox-gl-native/pull/12263))
 * Fixed a crash that occurred when creating an `MGL_MATCH` expression using non-expressions as arguments. ([#12332](https://github.com/mapbox/mapbox-gl-native/pull/12332))
-* Fixed an issue that no localized low-zoom labels when system language is Simplified Chinese ([#12164](https://github.com/mapbox/mapbox-gl-native/issues/12164))
+* Fixed an issue causing country and ocean labels to disappear after calling -[MGLStyle localizeLabelsIntoLocale:] when the system language is set to Simplified Chinese. ([#12164](https://github.com/mapbox/mapbox-gl-native/issues/12164))
 
 ### Networking and storage
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -11,6 +11,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Added an `MGLMapView.locationManager` property and `MGLLocationManager` protocol for tracking user location using a custom alternative to `CLLocationManager`. ([#12013](https://github.com/mapbox/mapbox-gl-native/pull/12013))
 * Fixed a crash when switching between two styles having layers with the same identifier but different layer types. ([#12432](https://github.com/mapbox/mapbox-gl-native/issues/12432))
 * Fixed an issue where the symbols for `MGLMapPointForCoordinate` could not be found. ([#12445](https://github.com/mapbox/mapbox-gl-native/issues/12445))
+* Fixed an issue causing country and ocean labels to disappear after calling `-[MGLStyle localizeLabelsIntoLocale:]` when the system language is set to Simplified Chinese. ([#12164](https://github.com/mapbox/mapbox-gl-native/issues/12164))
 
 ## 4.2.0 - July 18, 2018
 
@@ -26,7 +27,6 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Added the `collator` and `resolved-locale` expression operators to more precisely compare strings in style JSON. A subset of this functionality is available through predicate options when creating an `NSPredicate`. ([#11869](https://github.com/mapbox/mapbox-gl-native/pull/11869))
 * Fixed a crash when trying to parse expressions containing legacy filters. ([#12263](https://github.com/mapbox/mapbox-gl-native/pull/12263))
 * Fixed a crash that occurred when creating an `MGL_MATCH` expression using non-expressions as arguments. ([#12332](https://github.com/mapbox/mapbox-gl-native/pull/12332))
-* Fixed an issue causing country and ocean labels to disappear after calling -[MGLStyle localizeLabelsIntoLocale:] when the system language is set to Simplified Chinese. ([#12164](https://github.com/mapbox/mapbox-gl-native/issues/12164))
 
 ### Networking and storage
 


### PR DESCRIPTION
Aiming to fix this issue https://github.com/mapbox/mapbox-gl-native/issues/12164 and compatible with [name fields of Mapbox Streets v8](https://www.mapbox.com/vector-tiles/mapbox-streets-v8/#common-fields).