### PR TITLE
Bump kotlin, timber and okhttp dependencies

### DIFF
--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -18,9 +18,9 @@ ext {
             junit          : '4.12',
             mockito        : '2.18.3',
             robolectric    : '3.8',
-            timber         : '4.7.0',
-            okhttp         : '3.10.0',
-            kotlin         : '1.2.50',
+            timber         : '4.7.1',
+            okhttp         : '3.11.0',
+            kotlin         : '1.2.51',
             licenses       : '0.8.41'
     ]
 


### PR DESCRIPTION
Was hitting IDE compilation issues on both macOS as Linux:

> Please select an Android SDK

Capturing form the comments in [this](https://stackoverflow.com/a/50119113/1281750) SO post that we need to bump our kotlin dependency to `1.2.51` instead of `1.2.50`. While I was at it validated if other dependencies could be bumped (okhttp and Timber). 