### PR TITLE
Bump used gradle tools version

### DIFF
--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath dependenciesList.licensesPlugin
         classpath dependenciesList.kotlinPlugin
     }


### PR DESCRIPTION
Bumps latest gradle tools version to match Android Studio 3.1.3 (potentially need to update ci-image)