### PR TITLE
Make the offline DB schema a regular include file

### DIFF
--- a/cmake/filesource.cmake
+++ b/cmake/filesource.cmake
@@ -19,6 +19,7 @@ add_library(mbgl-filesource STATIC
     platform/default/mbgl/storage/offline_database.cpp
     platform/default/mbgl/storage/offline_download.hpp
     platform/default/mbgl/storage/offline_download.cpp
+    platform/default/mbgl/storage/offline_schema.hpp
 
     # Database
     platform/default/sqlite3.hpp

--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -6,6 +6,8 @@
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/logging.hpp>
 
+#include "offline_schema.hpp"
+
 #include "sqlite3.hpp"
 
 namespace mbgl {
@@ -82,8 +84,6 @@ void OfflineDatabase::ensureSchema() {
     }
 
     try {
-        #include "offline_schema.cpp.include"
-
         // When downgrading the database, or when the database is corrupt, we've deleted the old database handle,
         // so we need to reopen it.
         if (!db) {
@@ -95,7 +95,7 @@ void OfflineDatabase::ensureSchema() {
         db->exec("PRAGMA auto_vacuum = INCREMENTAL");
         db->exec("PRAGMA journal_mode = DELETE");
         db->exec("PRAGMA synchronous = FULL");
-        db->exec(schema);
+        db->exec(offlineDatabaseSchema);
         db->exec("PRAGMA user_version = 6");
     } catch (...) {
         Log::Error(Event::Database, "Unexpected error creating database schema: %s", util::toString(std::current_exception()).c_str());

--- a/platform/default/mbgl/storage/offline_schema.hpp
+++ b/platform/default/mbgl/storage/offline_schema.hpp
@@ -1,5 +1,11 @@
-/* THIS IS A GENERATED FILE; EDIT offline_schema.sql INSTEAD */
-static const char * schema = 
+#pragma once
+
+// THIS IS A GENERATED FILE; EDIT offline_schema.sql INSTEAD
+// To regenerate, run `node platform/default/mbgl/storage/offline_schema.js`
+
+namespace mbgl {
+
+static constexpr const char* offlineDatabaseSchema =
 "CREATE TABLE resources (\n"
 "  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,\n"
 "  url TEXT NOT NULL,\n"
@@ -53,3 +59,5 @@ static const char * schema =
 "CREATE INDEX region_tiles_tile_id\n"
 "ON region_tiles (tile_id);\n"
 ;
+
+} // namespace mbgl

--- a/platform/default/mbgl/storage/offline_schema.js
+++ b/platform/default/mbgl/storage/offline_schema.js
@@ -1,24 +1,21 @@
-// To regenerate:
-// (cd platform/default/mbgl/storage && node offline_schema.js)
-
 var fs = require('fs');
-var readline = require('readline');
+fs.writeFileSync('platform/default/mbgl/storage/offline_schema.hpp', `#pragma once
 
-var lineReader = readline.createInterface({
-    input: fs.createReadStream('offline_schema.sql')
-});
+// THIS IS A GENERATED FILE; EDIT offline_schema.sql INSTEAD
+// To regenerate, run \`node platform/default/mbgl/storage/offline_schema.js\`
 
-var lines = [
-    "/* THIS IS A GENERATED FILE; EDIT offline_schema.sql INSTEAD */",
-    "static const char * schema = ",
-];
+namespace mbgl {
 
-lineReader
-    .on('line', function (line) {
-        line = line.replace(/ *--.*/, '');
-        if (line) lines.push('"' + line + '\\n"');
-    })
-    .on('close', function () {
-        lines.push(';\n');
-        fs.writeFileSync('offline_schema.cpp.include', lines.join('\n'));
-    });
+static constexpr const char* offlineDatabaseSchema =
+${fs.readFileSync('platform/default/mbgl/storage/offline_schema.sql', 'utf8')
+    .replace(/ *--.*/g, '')
+    .split('\n')
+    .filter(a => a)
+    .map(line => '"' + line + '\\n"')
+    .join('\n')
+}
+;
+
+} // namespace mbgl
+`);
+


### PR DESCRIPTION
Removes special casing in some situation, and use template syntax in the generation script.