### PR TITLE
Harden map events creation

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -22,6 +22,7 @@ import com.mapbox.android.gestures.StandardScaleGestureDetector;
 import com.mapbox.android.telemetry.Event;
 import com.mapbox.android.telemetry.MapEventFactory;
 import com.mapbox.android.telemetry.MapState;
+import com.mapbox.android.telemetry.MapboxTelemetry;
 import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
@@ -886,11 +887,12 @@ final class MapGestureDetector {
     if (cameraPosition != null) {
       double zoom = cameraPosition.zoom;
       if (isZoomValid(zoom)) {
+        MapboxTelemetry telemetry = Telemetry.obtainTelemetry();
         MapEventFactory mapEventFactory = new MapEventFactory();
         LatLng latLng = projection.fromScreenLocation(focalPoint);
         MapState state = new MapState(latLng.getLatitude(), latLng.getLongitude(), zoom);
         state.setGesture(eventType);
-        Telemetry.obtainTelemetry().push(mapEventFactory.createMapGestureEvent(Event.Type.MAP_CLICK, state));
+        telemetry.push(mapEventFactory.createMapGestureEvent(Event.Type.MAP_CLICK, state));
       }
     }
   }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/12404.

`MapEventFactory`'s constructor requires a `Context` provided by the `MapboxTelemetry`. Below change ensures that the telemetry is initialized before creating the event.

This might not resolve the crash from #12404 itself if the `Mapbox#getInstance` wasn't called beforehand, but at least it will throw the right exception.

/cc @electrostat 