### PR TITLE
[android] Fix possibly race on undefined behavior

### DIFF
--- a/platform/android/src/run_loop.cpp
+++ b/platform/android/src/run_loop.cpp
@@ -167,6 +167,7 @@ void RunLoop::Impl::removeRunnable(Runnable* runnable) {
 }
 
 void RunLoop::Impl::initRunnable(Runnable* runnable) {
+    std::lock_guard<std::recursive_mutex> lock(mtx);
     runnable->iter = runnables.end();
 }
 


### PR DESCRIPTION
`runnable->iter = runnables.end()` assumes that `::end()` is a `static` or `constxpr` and thread-safe. This is likely to be true for most of the implementations. That said we cannot rely on undefined behavior and we should assume the worse case scenario.