### PR TITLE
Organize CMake targets in folders for IDEs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ if($ENV{CI})
     add_compile_options(-DCI_BUILD=1)
 endif()
 
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
 if(EXISTS ${CMAKE_SOURCE_DIR}/.git/HEAD)
     exec_program(
         "git"

--- a/cmake/benchmark.cmake
+++ b/cmake/benchmark.cmake
@@ -24,6 +24,8 @@ mbgl_platform_benchmark()
 
 create_source_groups(mbgl-benchmark)
 
+set_target_properties(mbgl-benchmark PROPERTIES FOLDER "Executables")
+
 initialize_xcode_cxx_build_settings(mbgl-benchmark)
 
 xcode_create_scheme(

--- a/cmake/core.cmake
+++ b/cmake/core.cmake
@@ -27,6 +27,8 @@ mbgl_platform_core()
 
 create_source_groups(mbgl-core)
 
+set_target_properties(mbgl-core PROPERTIES FOLDER "Core")
+
 xcode_create_scheme(TARGET mbgl-core)
 
 initialize_xcode_cxx_build_settings(mbgl-core)

--- a/cmake/filesource.cmake
+++ b/cmake/filesource.cmake
@@ -45,6 +45,8 @@ mbgl_filesource()
 
 create_source_groups(mbgl-filesource)
 
+set_target_properties(mbgl-filesource PROPERTIES FOLDER "Core")
+
 xcode_create_scheme(TARGET mbgl-filesource)
 
 initialize_xcode_cxx_build_settings(mbgl-filesource)

--- a/cmake/glfw.cmake
+++ b/cmake/glfw.cmake
@@ -31,6 +31,8 @@ mbgl_platform_glfw()
 
 create_source_groups(mbgl-glfw)
 
+set_target_properties(mbgl-glfw PROPERTIES FOLDER "Executables")
+
 initialize_xcode_cxx_build_settings(mbgl-glfw)
 
 xcode_create_scheme(

--- a/cmake/loop-darwin.cmake
+++ b/cmake/loop-darwin.cmake
@@ -11,4 +11,6 @@ target_include_directories(mbgl-loop-darwin
 
 create_source_groups(mbgl-loop-darwin)
 
+set_target_properties(mbgl-loop-darwin PROPERTIES FOLDER "Core")
+
 xcode_create_scheme(TARGET mbgl-loop-darwin)

--- a/cmake/mbgl.cmake
+++ b/cmake/mbgl.cmake
@@ -80,6 +80,7 @@ if(WITH_NODEJS)
         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
         COMMENT "Updating submodules..."
     )
+    set_target_properties(update-submodules PROPERTIES FOLDER "Misc")
 
     # Run npm install for both directories, and add custom commands, and a target that depends on them.
     _npm_install("${CMAKE_SOURCE_DIR}" mapbox-gl-native update-submodules)
@@ -88,6 +89,7 @@ if(WITH_NODEJS)
         npm-install ALL
         DEPENDS "${CMAKE_SOURCE_DIR}/node_modules/.mapbox-gl-js.stamp"
     )
+    set_target_properties(npm-install PROPERTIES FOLDER "Misc")
 endif()
 
 # Generate source groups so the files are properly sorted in IDEs like Xcode.

--- a/cmake/node.cmake
+++ b/cmake/node.cmake
@@ -58,8 +58,10 @@ target_link_libraries(mbgl-node INTERFACE
 )
 
 target_add_mason_package(mbgl-node INTERFACE geojson)
+set_target_properties(mbgl-node.all PROPERTIES FOLDER "Node.js")
 
 add_custom_target(mbgl-node.active DEPENDS mbgl-node.abi-${NodeJS_ABI})
+set_target_properties(mbgl-node.active PROPERTIES FOLDER "Node.js")
 
 mbgl_platform_node()
 
@@ -67,6 +69,7 @@ create_source_groups(mbgl-node)
 
 foreach(ABI IN LISTS mbgl-node::abis)
     initialize_xcode_cxx_build_settings(mbgl-node.abi-${ABI})
+    set_target_properties(mbgl-node.abi-${ABI} PROPERTIES FOLDER "Node.js")
     xcode_create_scheme(
         TARGET mbgl-node.abi-${ABI}
         NAME "mbgl-node (ABI ${ABI})"

--- a/cmake/offline.cmake
+++ b/cmake/offline.cmake
@@ -21,6 +21,8 @@ mbgl_platform_offline()
 
 create_source_groups(mbgl-offline)
 
+set_target_properties(mbgl-offline PROPERTIES FOLDER "Executables")
+
 xcode_create_scheme(
     TARGET mbgl-offline
     OPTIONAL_ARGS

--- a/cmake/render.cmake
+++ b/cmake/render.cmake
@@ -20,6 +20,8 @@ create_source_groups(mbgl-render)
 
 initialize_xcode_cxx_build_settings(mbgl-render)
 
+set_target_properties(mbgl-render PROPERTIES FOLDER "Executables")
+
 xcode_create_scheme(
     TARGET mbgl-render
     OPTIONAL_ARGS

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -43,6 +43,8 @@ create_source_groups(mbgl-test)
 
 initialize_xcode_cxx_build_settings(mbgl-test)
 
+set_target_properties(mbgl-test PROPERTIES FOLDER "Executables")
+
 xcode_create_scheme(
     TARGET mbgl-test
     OPTIONAL_ARGS


### PR DESCRIPTION
(Factored this out from a larger refactor)

This is only visible in IDEs like Xcode:

![image](https://user-images.githubusercontent.com/52399/42821127-24667126-89d8-11e8-95f0-07ed02daa3ec.png)
