### PR TITLE
[core] Evict unused font stacks from GlyphManager

### DIFF
--- a/include/mbgl/util/font_stack.hpp
+++ b/include/mbgl/util/font_stack.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
+#include <mbgl/util/immutable.hpp>
+#include <mbgl/style/layer.hpp>
+
 #include <string>
 #include <vector>
+#include <set>
 
 namespace mbgl {
 
@@ -13,5 +17,8 @@ std::string fontStackToString(const FontStack&);
 struct FontStackHash {
     std::size_t operator()(const FontStack&) const;
 };
+
+// Statically evaluate layer properties to determine what font stacks are used.
+std::set<FontStack> fontStacks(const std::vector<Immutable<style::Layer::Impl>>&);
 
 } // namespace mbgl

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -178,6 +178,10 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         renderLayers.at(entry.first)->setImpl(entry.second.after);
     }
 
+    if (!layerDiff.removed.empty() || !layerDiff.added.empty() || !layerDiff.changed.empty()) {
+        glyphManager->evict(fontStacks(*updateParameters.layers));
+    }
+
     // Update layers for class and zoom changes.
     for (const auto& entry : renderLayers) {
         RenderLayer& layer = *entry.second;

--- a/src/mbgl/text/glyph_manager.cpp
+++ b/src/mbgl/text/glyph_manager.cpp
@@ -5,6 +5,7 @@
 #include <mbgl/storage/resource.hpp>
 #include <mbgl/storage/response.hpp>
 #include <mbgl/util/tiny_sdf.hpp>
+#include <mbgl/util/std.hpp>
 
 namespace mbgl {
 
@@ -151,6 +152,12 @@ void GlyphManager::removeRequestor(GlyphRequestor& requestor) {
             range.second.requestors.erase(&requestor);
         }
     }
+}
+
+void GlyphManager::evict(const std::set<FontStack>& keep) {
+    util::erase_if(entries, [&] (const auto& entry) {
+        return keep.count(entry.first) == 0;
+    });
 }
 
 } // namespace mbgl

--- a/src/mbgl/text/glyph_manager.hpp
+++ b/src/mbgl/text/glyph_manager.hpp
@@ -42,6 +42,9 @@ public:
 
     void setObserver(GlyphManagerObserver*);
 
+    // Remove glyphs for all but the supplied font stacks.
+    void evict(const std::set<FontStack>&);
+
 private:
     Glyph generateLocalSDF(const FontStack& fontStack, GlyphID glyphID);
 

--- a/src/mbgl/util/font_stack.cpp
+++ b/src/mbgl/util/font_stack.cpp
@@ -1,9 +1,13 @@
 #include <mbgl/util/font_stack.hpp>
+#include <mbgl/util/logging.hpp>
+#include <mbgl/style/layers/symbol_layer_impl.hpp>
 
 #include <boost/functional/hash.hpp>
 #include <boost/algorithm/string/join.hpp>
 
 namespace mbgl {
+
+using namespace style;
 
 std::string fontStackToString(const FontStack& fontStack) {
     return boost::algorithm::join(fontStack, ",");
@@ -11,6 +15,42 @@ std::string fontStackToString(const FontStack& fontStack) {
 
 std::size_t FontStackHash::operator()(const FontStack& fontStack) const {
     return boost::hash_range(fontStack.begin(), fontStack.end());
+}
+
+std::set<FontStack> fontStacks(const std::vector<Immutable<style::Layer::Impl>>& layers) {
+    std::set<FontStack> result;
+
+    for (const auto& layer : layers) {
+        if (layer->type != LayerType::Symbol) {
+            continue;
+        }
+
+        const SymbolLayer::Impl& impl = dynamic_cast<const SymbolLayer::Impl&>(*layer);
+        if (impl.layout.get<TextField>().isUndefined()) {
+            continue;
+        }
+
+        impl.layout.get<TextFont>().match(
+            [&] (Undefined) {
+                result.insert({"Open Sans Regular", "Arial Unicode MS Regular"});
+            },
+            [&] (const FontStack& constant) {
+                result.insert(constant);
+            },
+            [&] (const auto& function) {
+                for (const auto& value : function.possibleOutputs()) {
+                    if (value) {
+                        result.insert(*value);
+                    } else {
+                        Log::Warning(Event::ParseStyle, "Layer '%s' has an invalid value for text-font and will not render text. Output values must be contained as literals within the expression.", impl.id.c_str());
+                        break;
+                    }
+                }
+            }
+        );
+    }
+
+    return result;
 }
 
 } // namespace mbgl


### PR DESCRIPTION
Cherry picks #12414 to the release-node-v4.0.0 branch.