### PR TITLE
[android] Reuse Bitmap, Paint & Canvas instances in LocalGlyphRasterizer

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/text/LocalGlyphRasterizer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/text/LocalGlyphRasterizer.java
@@ -1,8 +1,10 @@
 package com.mapbox.mapboxsdk.text;
 
 import android.graphics.Canvas;
+import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Bitmap;
+import android.graphics.PorterDuff;
 import android.graphics.Typeface;
 import android.support.annotation.WorkerThread;
 
@@ -11,6 +13,25 @@ import android.support.annotation.WorkerThread;
  * by the portable local_glyph_rasterizer.hpp
  */
 public class LocalGlyphRasterizer {
+  private final Bitmap bitmap;
+  private final Paint paint;
+  private final Canvas canvas;
+
+  LocalGlyphRasterizer() {
+    /*
+      35x35px dimensions are hardwired to match local_glyph_rasterizer.cpp
+      These dimensions are large enough to draw a 24 point character in the middle
+      of the bitmap (y: 20) with some buffer around the edge
+    */
+    bitmap = Bitmap.createBitmap(35, 35, Bitmap.Config.ARGB_8888);
+
+    paint = new Paint();
+    paint.setAntiAlias(true);
+    paint.setTextSize(24);
+
+    canvas = new Canvas();
+    canvas.setBitmap(bitmap);
+  }
 
   /***
    * Uses Android-native drawing code to rasterize a single glyph
@@ -24,23 +45,10 @@ public class LocalGlyphRasterizer {
    * @return Return a {@link Bitmap} to be displayed in the requested tile.
    */
   @WorkerThread
-  protected static Bitmap drawGlyphBitmap(String fontFamily, boolean bold, char glyphID) {
-    /*
-      35x35px dimensions are hardwired to match local_glyph_rasterizer.cpp
-      These dimensions are large enough to draw a 24 point character in the middle
-      of the bitmap (y: 20) with some buffer around the edge
-    */
-    Bitmap bitmap = Bitmap.createBitmap(35, 35, Bitmap.Config.ARGB_8888);
-
-    Paint paint = new Paint();
-    paint.setAntiAlias(true);
-    paint.setTextSize(24);
+  protected Bitmap drawGlyphBitmap(String fontFamily, boolean bold, char glyphID) {
     paint.setTypeface(Typeface.create(fontFamily, bold ? Typeface.BOLD : Typeface.NORMAL));
-
-    Canvas canvas = new Canvas();
-    canvas.setBitmap(bitmap);
+    canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
     canvas.drawText(String.valueOf(glyphID), 0, 20, paint);
-
     return bitmap;
   }
 }

--- a/platform/android/src/text/local_glyph_rasterizer_jni.hpp
+++ b/platform/android/src/text/local_glyph_rasterizer_jni.hpp
@@ -17,14 +17,18 @@ namespace android {
 
 class LocalGlyphRasterizer {
 public:
-    static PremultipliedImage drawGlyphBitmap(const std::string& fontFamily, const bool bold, const char16_t glyphID);
-
     static constexpr auto Name() { return "com/mapbox/mapboxsdk/text/LocalGlyphRasterizer"; };
 
     static jni::Class<LocalGlyphRasterizer> javaClass;
 
     static void registerNative(jni::JNIEnv&);
 
+    LocalGlyphRasterizer();
+
+    PremultipliedImage drawGlyphBitmap(const std::string& fontFamily, const bool bold, const char16_t glyphID);
+
+private:
+    jni::UniqueObject<LocalGlyphRasterizer> javaObject;
 };
 
 } // namespace android


### PR DESCRIPTION
Closes #12421 

- Make `LocalGlyphRasterizer.drawGlyphBitmap()` non-static
- Store and reuse Bitmap, Paint & Canvas instances