### PR TITLE
[ios] Improve geometry method definitions

### DIFF
--- a/platform/darwin/src/MGLComputedShapeSource.h
+++ b/platform/darwin/src/MGLComputedShapeSource.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
  This option is used with the `MGLComputedShapeSource` class; it is ignored when
  creating an `MGLShapeSource` object.
  */
-extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionWrapsCoordinates;
+FOUNDATION_EXTERN MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionWrapsCoordinates;
 
 /**
  An `NSNumber` object containing a Boolean value; specifies whether the shape of
@@ -30,7 +30,7 @@ extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionWrapsCoordinate
  This option is used with the `MGLComputedShapeSource` class; it is ignored when
  creating an `MGLShapeSource` object.
  */
-extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionClipsCoordinates;
+FOUNDATION_EXTERN MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionClipsCoordinates;
 
 /**
  Data source for `MGLComputedShapeSource`. This protocol defines two optional methods for fetching

--- a/platform/darwin/src/MGLGeometry.h
+++ b/platform/darwin/src/MGLGeometry.h
@@ -64,7 +64,7 @@ NS_INLINE BOOL MGLCoordinateSpanEqualToCoordinateSpan(MGLCoordinateSpan span1, M
 }
 
 /** An area of zero width and zero height. */
-extern MGL_EXPORT const MGLCoordinateSpan MGLCoordinateSpanZero;
+FOUNDATION_EXTERN MGL_EXPORT const MGLCoordinateSpan MGLCoordinateSpanZero;
 
 /** A rectangular area as measured on a two-dimensional map projection. */
 typedef struct __attribute__((objc_boxable)) MGLCoordinateBounds {
@@ -211,6 +211,6 @@ NS_INLINE CLLocationDegrees MGLDegreesFromRadians(CGFloat radians) {
 }
 
 /** Returns Mercator projection of a WGS84 coordinate at the specified zoom level. */
-extern MGL_EXPORT MGLMapPoint MGLMapPointForCoordinate(CLLocationCoordinate2D coordinate, double zoomLevel);
+FOUNDATION_EXTERN MGL_EXPORT MGLMapPoint MGLMapPointForCoordinate(CLLocationCoordinate2D coordinate, double zoomLevel);
 
 NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLGeometry.mm
+++ b/platform/darwin/src/MGLGeometry.mm
@@ -45,7 +45,6 @@ mbgl::LatLng MGLLatLngFromLocationCoordinate2D(CLLocationCoordinate2D coordinate
     }
 }
 
-MGL_EXPORT
 CLLocationDistance MGLAltitudeForZoomLevel(double zoomLevel, CGFloat pitch, CLLocationDegrees latitude, CGSize size) {
     CLLocationDistance metersPerPixel = mbgl::Projection::getMetersPerPixelAtLatitude(latitude, zoomLevel);
     CLLocationDistance metersTall = metersPerPixel * size.height;
@@ -53,7 +52,6 @@ CLLocationDistance MGLAltitudeForZoomLevel(double zoomLevel, CGFloat pitch, CLLo
     return altitude * std::sin(M_PI_2 - MGLRadiansFromDegrees(pitch)) / std::sin(M_PI_2);
 }
 
-MGL_EXPORT
 double MGLZoomLevelForAltitude(CLLocationDistance altitude, CGFloat pitch, CLLocationDegrees latitude, CGSize size) {
     CLLocationDistance eyeAltitude = altitude / std::sin(M_PI_2 - MGLRadiansFromDegrees(pitch)) * std::sin(M_PI_2);
     CLLocationDistance metersTall = eyeAltitude * 2 * std::tan(MGLRadiansFromDegrees(MGLAngularFieldOfView) / 2.);

--- a/platform/darwin/src/MGLGeometry.mm
+++ b/platform/darwin/src/MGLGeometry.mm
@@ -98,7 +98,7 @@ CLLocationDirection MGLDirectionBetweenCoordinates(CLLocationCoordinate2D firstC
 
 CGPoint MGLPointRounded(CGPoint point) {
 #if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
-    CGFloat scaleFactor = [UIScreen instancesRespondToSelector:@selector(nativeScale)] ? [UIScreen mainScreen].nativeScale : [UIScreen mainScreen].scale;
+    CGFloat scaleFactor = [UIScreen mainScreen].nativeScale;
 #elif TARGET_OS_MAC
     CGFloat scaleFactor = [NSScreen mainScreen].backingScaleFactor;
 #endif

--- a/platform/darwin/src/MGLGeometry_Private.h
+++ b/platform/darwin/src/MGLGeometry_Private.h
@@ -99,7 +99,7 @@ NS_INLINE mbgl::EdgeInsets MGLEdgeInsetsFromNSEdgeInsets(NSEdgeInsets insets) {
     @param latitude The latitude of the point at the center of the viewport.
     @param size The size of the viewport.
     @return An altitude measured in meters. */
-CLLocationDistance MGLAltitudeForZoomLevel(double zoomLevel, CGFloat pitch, CLLocationDegrees latitude, CGSize size);
+MGL_EXPORT CLLocationDistance MGLAltitudeForZoomLevel(double zoomLevel, CGFloat pitch, CLLocationDegrees latitude, CGSize size);
 
 /** Converts a camera altitude to a map zoom level.
 
@@ -108,7 +108,7 @@ CLLocationDistance MGLAltitudeForZoomLevel(double zoomLevel, CGFloat pitch, CLLo
     @param latitude The latitude of the point at the center of the viewport.
     @param size The size of the viewport.
     @return A zero-based zoom level. */
-double MGLZoomLevelForAltitude(CLLocationDistance altitude, CGFloat pitch, CLLocationDegrees latitude, CGSize size);
+MGL_EXPORT double MGLZoomLevelForAltitude(CLLocationDistance altitude, CGFloat pitch, CLLocationDegrees latitude, CGSize size);
 
 /** Returns MGLRadianCoordinate2D, converted from CLLocationCoordinate2D. */
 NS_INLINE MGLRadianCoordinate2D MGLRadianCoordinateFromLocationCoordinate(CLLocationCoordinate2D locationCoordinate) {

--- a/platform/darwin/src/MGLGeometry_Private.h
+++ b/platform/darwin/src/MGLGeometry_Private.h
@@ -138,6 +138,9 @@ MGLRadianCoordinate2D MGLRadianCoordinateAtDistanceFacingDirection(MGLRadianCoor
  */
 CLLocationDirection MGLDirectionBetweenCoordinates(CLLocationCoordinate2D firstCoordinate, CLLocationCoordinate2D secondCoordinate);
 
+/**
+ Returns a point with coordinates rounded to the nearest logical pixel.
+ */
 CGPoint MGLPointRounded(CGPoint point);
 
 MGLMatrix4 MGLMatrix4Make(std::array<double, 16> mat);

--- a/platform/darwin/src/MGLOfflineStorage.h
+++ b/platform/darwin/src/MGLOfflineStorage.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
  alternatively observe KVO change notifications to the pack’s `progress` key
  path.
  */
-extern MGL_EXPORT const NSNotificationName MGLOfflinePackProgressChangedNotification;
+FOUNDATION_EXTERN MGL_EXPORT const NSNotificationName MGLOfflinePackProgressChangedNotification;
 
 /**
  Posted by the shared `MGLOfflineStorage` object whenever an `MGLOfflinePack`
@@ -40,7 +40,7 @@ extern MGL_EXPORT const NSNotificationName MGLOfflinePackProgressChangedNotifica
  `userInfo` dictionary contains the error object in the
  `MGLOfflinePackErrorUserInfoKey` key.
  */
-extern MGL_EXPORT const NSNotificationName MGLOfflinePackErrorNotification;
+FOUNDATION_EXTERN MGL_EXPORT const NSNotificationName MGLOfflinePackErrorNotification;
 
 /**
  Posted by the shared `MGLOfflineStorage` object when the maximum number of
@@ -55,7 +55,7 @@ extern MGL_EXPORT const NSNotificationName MGLOfflinePackErrorNotification;
  calling the `-[MGLOfflineStorage removePack:withCompletionHandler:]` method.
  Contact your Mapbox sales representative to have the limit raised.
  */
-extern MGL_EXPORT const NSNotificationName MGLOfflinePackMaximumMapboxTilesReachedNotification;
+FOUNDATION_EXTERN MGL_EXPORT const NSNotificationName MGLOfflinePackMaximumMapboxTilesReachedNotification;
 
 /**
  A key in the `userInfo` property of a notification posted by `MGLOfflinePack`.
@@ -68,9 +68,9 @@ typedef NSString *MGLOfflinePackUserInfoKey NS_EXTENSIBLE_STRING_ENUM;
  `MGLOfflinePackProgressChangedNotification` notification. Call `-integerValue`
  on the object to receive the `MGLOfflinePackState`-typed state.
  */
-extern MGL_EXPORT const MGLOfflinePackUserInfoKey MGLOfflinePackUserInfoKeyState;
+FOUNDATION_EXTERN MGL_EXPORT const MGLOfflinePackUserInfoKey MGLOfflinePackUserInfoKeyState;
 
-extern MGL_EXPORT NSString * const MGLOfflinePackStateUserInfoKey __attribute__((unavailable("Use MGLOfflinePackUserInfoKeyState")));
+FOUNDATION_EXTERN MGL_EXPORT NSString * const MGLOfflinePackStateUserInfoKey __attribute__((unavailable("Use MGLOfflinePackUserInfoKeyState")));
 
 /**
  The key for an `NSValue` object that indicates an offline pack’s current
@@ -79,9 +79,9 @@ extern MGL_EXPORT NSString * const MGLOfflinePackStateUserInfoKey __attribute__(
  `-MGLOfflinePackProgressValue` on the object to receive the
  `MGLOfflinePackProgress`-typed progress.
  */
-extern MGL_EXPORT const MGLOfflinePackUserInfoKey MGLOfflinePackUserInfoKeyProgress;
+FOUNDATION_EXTERN MGL_EXPORT const MGLOfflinePackUserInfoKey MGLOfflinePackUserInfoKeyProgress;
 
-extern MGL_EXPORT NSString * const MGLOfflinePackProgressUserInfoKey __attribute__((unavailable("Use MGLOfflinePackUserInfoKeyProgress")));
+FOUNDATION_EXTERN MGL_EXPORT NSString * const MGLOfflinePackProgressUserInfoKey __attribute__((unavailable("Use MGLOfflinePackUserInfoKeyProgress")));
 
 /**
  The key for an `NSError` object that is encountered in the course of
@@ -89,9 +89,9 @@ extern MGL_EXPORT NSString * const MGLOfflinePackProgressUserInfoKey __attribute
  an `MGLOfflinePackErrorNotification` notification. The error’s domain is
  `MGLErrorDomain`. See `MGLErrorCode` for possible error codes.
  */
-extern MGL_EXPORT const MGLOfflinePackUserInfoKey MGLOfflinePackUserInfoKeyError;
+FOUNDATION_EXTERN MGL_EXPORT const MGLOfflinePackUserInfoKey MGLOfflinePackUserInfoKeyError;
 
-extern MGL_EXPORT NSString * const MGLOfflinePackErrorUserInfoKey __attribute__((unavailable("Use MGLOfflinePackUserInfoKeyError")));
+FOUNDATION_EXTERN MGL_EXPORT NSString * const MGLOfflinePackErrorUserInfoKey __attribute__((unavailable("Use MGLOfflinePackUserInfoKeyError")));
 
 /**
  The key for an `NSNumber` object that indicates the maximum number of
@@ -101,9 +101,9 @@ extern MGL_EXPORT NSString * const MGLOfflinePackErrorUserInfoKey __attribute__(
  `-unsignedLongLongValue` on the object to receive the `uint64_t`-typed tile
  limit.
  */
-extern MGL_EXPORT const MGLOfflinePackUserInfoKey MGLOfflinePackUserInfoKeyMaximumCount;
+FOUNDATION_EXTERN MGL_EXPORT const MGLOfflinePackUserInfoKey MGLOfflinePackUserInfoKeyMaximumCount;
 
-extern MGL_EXPORT NSString * const MGLOfflinePackMaximumCountUserInfoKey __attribute__((unavailable("Use MGLOfflinePackUserInfoKeyMaximumCount")));
+FOUNDATION_EXTERN MGL_EXPORT NSString * const MGLOfflinePackMaximumCountUserInfoKey __attribute__((unavailable("Use MGLOfflinePackUserInfoKeyMaximumCount")));
 
 /**
  A block to be called once an offline pack has been completely created and

--- a/platform/darwin/src/MGLRasterDEMSource.h
+++ b/platform/darwin/src/MGLRasterDEMSource.h
@@ -13,7 +13,7 @@
  with the `MGLRasterDEMSource` class and is ignored when creating an
  `MGLRasterTileSource` or `MGLVectorTileSource` object.
  */
-extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionDEMEncoding;
+FOUNDATION_EXTERN MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionDEMEncoding;
 
 /**
  `MGLRasterDEMSource` is a map content source that supplies rasterized

--- a/platform/darwin/src/MGLRasterTileSource.h
+++ b/platform/darwin/src/MGLRasterTileSource.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
  This option is only applicable to `MGLRasterTileSource` objects; it is ignored
  when initializing `MGLVectorTileSource` objects.
  */
-extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionTileSize;
+FOUNDATION_EXTERN MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionTileSize;
 
 /**
  `MGLRasterTileSource` is a map content source that supplies raster image tiles

--- a/platform/darwin/src/MGLShapeSource.h
+++ b/platform/darwin/src/MGLShapeSource.h
@@ -24,7 +24,7 @@ typedef NSString *MGLShapeSourceOption NS_STRING_ENUM;
  This option only affects point features within an `MGLShapeSource` object; it
  is ignored when creating an `MGLComputedShapeSource` object.
  */
-extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionClustered;
+FOUNDATION_EXTERN MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionClustered;
 
 /**
  An `NSNumber` object containing an integer; specifies the radius of each
@@ -34,7 +34,7 @@ extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionClustered;
  This option only affects point features within an `MGLShapeSource` object; it
  is ignored when creating an `MGLComputedShapeSource` object.
  */
-extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionClusterRadius;
+FOUNDATION_EXTERN MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionClusterRadius;
 
 /**
  An `NSNumber` object containing an integer; specifies the maximum zoom level at
@@ -49,7 +49,7 @@ extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionClusterRadius;
  This option only affects point features within an `MGLShapeSource` object; it
  is ignored when creating an `MGLComputedShapeSource` object.
  */
-extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevelForClustering;
+FOUNDATION_EXTERN MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevelForClustering;
 
 /**
  An `NSNumber` object containing an integer; specifies the minimum zoom level at
@@ -59,7 +59,7 @@ extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLeve
  <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson-minzoom"><code>minzoom</code></a>
  source property in the Mapbox Style Specification.
  */
-extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionMinimumZoomLevel;
+FOUNDATION_EXTERN MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionMinimumZoomLevel;
 
 /**
  An `NSNumber` object containing an integer; specifies the maximum zoom level at
@@ -70,7 +70,7 @@ extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionMinimumZoomLeve
  <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson-maxzoom"><code>maxzoom</code></a>
  source property in the Mapbox Style Specification.
  */
-extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevel;
+FOUNDATION_EXTERN MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevel;
 
 /**
  An `NSNumber` object containing an integer; specifies the size of the tile
@@ -82,7 +82,7 @@ extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLeve
  <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson-buffer"><code>buffer</code></a>
  source property in the Mapbox Style Specification.
  */
-extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionBuffer;
+FOUNDATION_EXTERN MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionBuffer;
 
 /**
  An `NSNumber` object containing a double; specifies the Douglas-Peucker
@@ -93,7 +93,7 @@ extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionBuffer;
  <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson-tolerance"><code>tolerance</code></a>
  source property in the Mapbox Style Specification.
  */
-extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance;
+FOUNDATION_EXTERN MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance;
 
 /**
  `MGLShapeSource` is a map content source that supplies vector shapes to be

--- a/platform/darwin/src/MGLStyleValue.h
+++ b/platform/darwin/src/MGLStyleValue.h
@@ -8,9 +8,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef NSString *MGLStyleFunctionOption NS_STRING_ENUM NS_UNAVAILABLE;
 
-extern MGL_EXPORT const MGLStyleFunctionOption MGLStyleFunctionOptionInterpolationBase __attribute__((unavailable("Use NSExpression instead, applying the mgl_interpolate:withCurveType:parameters:stops: function with a curve type of “exponential” and a non-nil parameter.")));
+FOUNDATION_EXTERN MGL_EXPORT const MGLStyleFunctionOption MGLStyleFunctionOptionInterpolationBase __attribute__((unavailable("Use NSExpression instead, applying the mgl_interpolate:withCurveType:parameters:stops: function with a curve type of “exponential” and a non-nil parameter.")));
 
-extern MGL_EXPORT const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue __attribute__((unavailable("Use +[NSExpression expressionForConditional:trueExpression:falseExpression:] instead.")));
+FOUNDATION_EXTERN MGL_EXPORT const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue __attribute__((unavailable("Use +[NSExpression expressionForConditional:trueExpression:falseExpression:] instead.")));
 
 typedef NS_ENUM(NSUInteger, MGLInterpolationMode) {
     MGLInterpolationModeExponential __attribute__((unavailable("Use NSExpression instead, applying the mgl_interpolate:withCurveType:parameters:stops: function with a curve type of “exponential”."))) = 0,

--- a/platform/darwin/src/MGLTileSource.h
+++ b/platform/darwin/src/MGLTileSource.h
@@ -25,7 +25,7 @@ typedef NSString *MGLTileSourceOption NS_STRING_ENUM;
  <a href="https://github.com/mapbox/tilejson-spec/tree/master/2.1.0">TileJSON</a>
  specification.
  */
-extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionMinimumZoomLevel;
+FOUNDATION_EXTERN MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionMinimumZoomLevel;
 
 /**
  An `NSNumber` object containing an unsigned integer that specifies the maximum
@@ -39,7 +39,7 @@ extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionMinimumZoomLevel;
  <a href="https://github.com/mapbox/tilejson-spec/tree/master/2.1.0">TileJSON</a>
  specification.
  */
-extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionMaximumZoomLevel;
+FOUNDATION_EXTERN MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionMaximumZoomLevel;
 
 /**
  An `NSValue` object containing an `MGLCoordinateBounds` struct that specifies
@@ -53,7 +53,7 @@ extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionMaximumZoomLevel;
  <a href="https://github.com/mapbox/tilejson-spec/tree/master/2.1.0">TileJSON</a>
  specification.
  */
-extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionCoordinateBounds;
+FOUNDATION_EXTERN MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionCoordinateBounds;
 
 #if TARGET_OS_IPHONE
 /**
@@ -69,7 +69,7 @@ extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionCoordinateBounds;
  <a href="https://github.com/mapbox/tilejson-spec/tree/master/2.1.0">TileJSON</a>
  specification.
  */
-extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionAttributionHTMLString;
+FOUNDATION_EXTERN MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionAttributionHTMLString;
 
 /**
  An array of `MGLAttributionInfo` objects defining the buttons to be displayed
@@ -78,7 +78,7 @@ extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionAttributionHTMLSt
 
  By default, no attribution statements are displayed.
  */
-extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionAttributionInfos;
+FOUNDATION_EXTERN MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionAttributionInfos;
 #else
 /**
  An HTML string defining the buttons to be displayed in the map view’s
@@ -92,7 +92,7 @@ extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionAttributionInfos;
  <a href="https://github.com/mapbox/tilejson-spec/tree/master/2.1.0">TileJSON</a>
  specification.
  */
-extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionAttributionHTMLString;
+FOUNDATION_EXTERN MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionAttributionHTMLString;
 
 /**
  An array of `MGLAttributionInfo` objects defining the buttons to be displayed
@@ -101,7 +101,7 @@ extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionAttributionHTMLSt
 
  By default, no attribution statements are displayed.
  */
-extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionAttributionInfos;
+FOUNDATION_EXTERN MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionAttributionInfos;
 #endif
 
 /**
@@ -115,7 +115,7 @@ extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionAttributionInfos;
  <a href="https://github.com/mapbox/tilejson-spec/tree/master/2.1.0">TileJSON</a>
  specification.
  */
-extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionTileCoordinateSystem;
+FOUNDATION_EXTERN MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionTileCoordinateSystem;
 
 /**
  Tile coordinate systems that determine how tile coordinates in tile URLs are

--- a/platform/darwin/src/MGLTypes.h
+++ b/platform/darwin/src/MGLTypes.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 #endif
 
 /** Indicates an error occurred in the Mapbox SDK. */
-extern MGL_EXPORT NSErrorDomain const MGLErrorDomain;
+FOUNDATION_EXTERN MGL_EXPORT NSErrorDomain const MGLErrorDomain;
 
 /** Error constants for the Mapbox SDK. */
 typedef NS_ENUM(NSInteger, MGLErrorCode) {

--- a/platform/darwin/src/NSExpression+MGLAdditions.h
+++ b/platform/darwin/src/NSExpression+MGLAdditions.h
@@ -18,7 +18,7 @@ typedef NSString *MGLExpressionInterpolationMode NS_TYPED_ENUM;
  <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-interpolate"><code>interpolate</code></a>
  expression operator in the Mapbox Style Specification.
  */
-extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolationModeLinear;
+FOUNDATION_EXTERN MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolationModeLinear;
 
 /**
  An `NSString` identifying the `expotential` interpolation type in an `NSExpression`.
@@ -27,7 +27,7 @@ extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolatio
  <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-interpolate"><code>interpolate</code></a>
  expression operator in the Mapbox Style Specification.
  */
-extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolationModeExponential;
+FOUNDATION_EXTERN MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolationModeExponential;
 
 /**
  An `NSString` identifying the `cubic-bezier` interpolation type in an `NSExpression`.
@@ -36,7 +36,7 @@ extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolatio
  <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-interpolate"><code>interpolate</code></a>
  expression operator in the Mapbox Style Specification.
  */
-extern MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolationModeCubicBezier;
+FOUNDATION_EXTERN MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionInterpolationModeCubicBezier;
 
 /**
  Methods for creating expressions that use Mapbox-specific functionality and for

--- a/platform/darwin/src/NSExpression+MGLPrivateAdditions.h
+++ b/platform/darwin/src/NSExpression+MGLPrivateAdditions.h
@@ -79,6 +79,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-extern NSArray *MGLSubexpressionsWithJSONObjects(NSArray *objects);
+FOUNDATION_EXTERN NSArray *MGLSubexpressionsWithJSONObjects(NSArray *objects);
 
 NS_ASSUME_NONNULL_END

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -10,7 +10,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Token string syntax (`"{token}"`) in `MGLSymbolStyleLayer` `text` and `iconImageName` properties is now correctly converted to the appropriate `NSExpression` equivalent. ([#11659](https://github.com/mapbox/mapbox-gl-native/issues/11659))
 * Added an `MGLMapView.locationManager` property and `MGLLocationManager` protocol for tracking user location using a custom alternative to `CLLocationManager`. ([#12013](https://github.com/mapbox/mapbox-gl-native/pull/12013))
 * Fixed a crash when switching between two styles having layers with the same identifier but different layer types. ([#12432](https://github.com/mapbox/mapbox-gl-native/issues/12432))
-
+* Fixed an issue where the symbols for `MGLMapPointForCoordinate` could not be found. ([#12445](https://github.com/mapbox/mapbox-gl-native/issues/12445))
 
 ## 4.2.0 - July 18, 2018
 

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -24,13 +24,13 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol MGLLocationManager;
 
 /** The default deceleration rate for a map view. */
-extern MGL_EXPORT const CGFloat MGLMapViewDecelerationRateNormal;
+FOUNDATION_EXTERN MGL_EXPORT const CGFloat MGLMapViewDecelerationRateNormal;
 
 /** A fast deceleration rate for a map view. */
-extern MGL_EXPORT const CGFloat MGLMapViewDecelerationRateFast;
+FOUNDATION_EXTERN MGL_EXPORT const CGFloat MGLMapViewDecelerationRateFast;
 
 /** Disables deceleration in a map view. */
-extern MGL_EXPORT const CGFloat MGLMapViewDecelerationRateImmediate;
+FOUNDATION_EXTERN MGL_EXPORT const CGFloat MGLMapViewDecelerationRateImmediate;
 
 /**
  The vertical alignment of an annotation within a map view. Used with

--- a/platform/ios/src/MGLMapView_Private.h
+++ b/platform/ios/src/MGLMapView_Private.h
@@ -6,7 +6,7 @@ namespace mbgl {
 }
 
 /// Minimum size of an annotation’s accessibility element.
-extern const CGSize MGLAnnotationAccessibilityElementMinimumSize;
+FOUNDATION_EXTERN const CGSize MGLAnnotationAccessibilityElementMinimumSize;
 
 @interface MGLMapView (Private)
 


### PR DESCRIPTION
Fixes #12079.

Here’s my (potentially incorrect) understanding of this fix: `MGLMapPointForCoordinate()` was `extern`-defined in a C header, but implemented in an Obj-C++ source file and mangled as a C++ symbol. `FOUNDATION_EXTERN` is C++-aware and will force C-style symbol mangling, which fixes the undefined symbol issue in consumer Obj-C projects (#12079).

You can verify the change in symbol mangling using `nm`:

_Before:_
```
00000000000d3b21 T __Z24MGLMapPointForCoordinate22CLLocationCoordinate2Dd
```
_After:_
```
00000000000a0c01 T _MGLMapPointForCoordinate
```

This PR also:
- Moves `MGL_EXPORT` for two private methods to `MGLGeometry_Private.h`, rather than defining them with the implementation.
- Adds internal docs for `MGLPointRounded()` and removes obsolete iOS 7 compatibility.

/cc @1ec5 @julianrex @kkaefer @asheemmamoowala 