### PR TITLE
[build] Attempt to determine a likely base branch without a PR

### DIFF
--- a/scripts/environment.js
+++ b/scripts/environment.js
@@ -21,4 +21,15 @@ if (pr) {
         console.log(`export CIRCLE_TARGET_BRANCH=${base}`);
         console.log(`export CIRCLE_MERGE_BASE=${mergeBase}`);
     });
+} else {
+    const head = process.env['CIRCLE_SHA1'];
+    for (const sha of execSync(`git rev-list --max-count=10 ${head}`).toString().trim().split('\n')) {
+        const base = execSync(`git branch -r --contains ${sha} origin/master origin/release-*`).toString().trim().replace(/^origin\//, '');
+        if (base) {
+            const mergeBase = execSync(`git merge-base origin/${base} ${head}`).toString().trim();
+            console.log(`export CIRCLE_TARGET_BRANCH=${base}`);
+            console.log(`export CIRCLE_MERGE_BASE=${mergeBase}`);
+            break;
+        }
+    }
 }


### PR DESCRIPTION
Walk backward through the history (maximum of 10 commits) until finding a commit on either `master` or `release-*`; assume that's the base branch.

This ensures that the size checks report the difference to the base even if you haven't opened a PR yet (as they did here).