### PR TITLE
[build] See what happened when `npm install` fails

### DIFF
--- a/cmake/mbgl.cmake
+++ b/cmake/mbgl.cmake
@@ -44,9 +44,13 @@ if(WITH_NODEJS)
             execute_process(
                 COMMAND "${NodeJS_EXECUTABLE}" "${npm_EXECUTABLE}" install --ignore-scripts
                 WORKING_DIRECTORY "${DIRECTORY}"
-                RESULT_VARIABLE NPM_INSTALL_FAILED)
+                RESULT_VARIABLE NPM_INSTALL_FAILED
+                OUTPUT_VARIABLE NPM_OUTPUT
+                ERROR_VARIABLE NPM_OUTPUT)
             if(NOT NPM_INSTALL_FAILED)
                 execute_process(COMMAND ${CMAKE_COMMAND} -E touch "${DIRECTORY}/node_modules/.${NAME}.stamp")
+            else()
+                message(FATAL_ERROR "NPM install failed:\n${NPM_OUTPUT}")
             endif()
         endif()
 


### PR DESCRIPTION
Add some diagnostics to get a better handle on #12250. (Of course, as soon as you add logging, the problem disappears. 🤷‍♂️ )