### PR TITLE
[build] Disable binary size checks for fork PRs

### DIFF
--- a/scripts/check_binary_size.js
+++ b/scripts/check_binary_size.js
@@ -18,7 +18,13 @@ process.on('unhandledRejection', error => {
     process.exit(1)
 });
 
-const key = Buffer.from(process.env['SIZE_CHECK_APP_PRIVATE_KEY'], 'base64').toString('binary');
+const pk = process.env['SIZE_CHECK_APP_PRIVATE_KEY'];
+if (!pk) {
+    console.log('Fork PR; not computing size.');
+    process.exit(0);
+}
+
+const key = Buffer.from(pk, 'base64').toString('binary');
 const payload = {
     exp: Math.floor(Date.now() / 1000) + 60,
     iat: Math.floor(Date.now() / 1000),


### PR DESCRIPTION
We can't run the checks without potentially exposing the Github App private key to malicious PRs.

https://github.com/mapbox/mapbox-gl-native/pull/12434#issuecomment-406714517