### PR TITLE
Remove 'preinstall'

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "node": ">=6"
   },
   "scripts": {
-    "preinstall": "npm install node-pre-gyp",
     "install": "node-pre-gyp install --fallback-to-build=false || make node",
     "test": "tape platform/node/test/js/**/*.test.js",
     "test-memory": "node --expose-gc platform/node/test/memory.test.js",


### PR DESCRIPTION
This removes the `"preinstall": "npm install node-pre-gyp",`. This is not needed and also might cause problems with some `npm` versions. So it should be removed.

I was originally added as part of moving away from putting `node-pre-gyp` in the `bundledDependencies`. But neither of these workarounds are needed with recent node > 4.

Refs https://github.com/mapbox/node-pre-gyp/issues/260#issuecomment-407222286
