### PR TITLE
Do not try to load glyphs if glyphUrl is not set

### DIFF
--- a/src/mbgl/text/glyph_manager.cpp
+++ b/src/mbgl/text/glyph_manager.cpp
@@ -5,6 +5,7 @@
 #include <mbgl/storage/resource.hpp>
 #include <mbgl/storage/response.hpp>
 #include <mbgl/util/tiny_sdf.hpp>
+#include <mbgl/util/logging.hpp>
 
 namespace mbgl {
 
@@ -19,6 +20,10 @@ GlyphManager::GlyphManager(FileSource& fileSource_, std::unique_ptr<LocalGlyphRa
 GlyphManager::~GlyphManager() = default;
 
 void GlyphManager::getGlyphs(GlyphRequestor& requestor, GlyphDependencies glyphDependencies) {
+    if(glyphURL.empty()) {
+        Log::Error(Event::Style, "getGlyph : no glyphURL available, returning");
+        return;
+    }
     auto dependencies = std::make_shared<GlyphDependencies>(std::move(glyphDependencies));
 
     // Figure out which glyph ranges need to be fetched. For each range that does need to


### PR DESCRIPTION
Hello,

Using our app on Android devices, sometimes there are no labels on the map and we see the error 
`[Style]: Failed to load glyph range 0-255 for font stack DejaVu Sans Condensed: Attempt to invoke virtual method 'java.lang.String okhttp3.HttpUrl.host()' on a null object reference  `
There seems to be a racing condition where there are layout requests resulting in glyphs loading requests, while the glyph url is not yet set. Afterwards the glyphs are marked as loaded, so any subsequent layout request will not load them (even if the glyph url is now available).
On our app it was easily reproductible (80%) by starting a new instance of the app (with a deeplink) from another one already running.

My solution for our app was to check if glyphs url is set before attempting to load them. It works, however I am not sure if this is ok for all use cases and platforms, maybe there is a more elegant solution ?

Regards,
Philémon
