### PR TITLE
Shave some binary size in CompoundExpression implementation

### DIFF
--- a/include/mbgl/style/expression/compound_expression.hpp
+++ b/include/mbgl/style/expression/compound_expression.hpp
@@ -5,9 +5,7 @@
 #include <mbgl/style/expression/parsing_context.hpp>
 #include <mbgl/style/expression/type.hpp>
 #include <mbgl/style/expression/value.hpp>
-
 #include <mbgl/util/optional.hpp>
-#include <mbgl/util/variant.hpp>
 
 #include <memory>
 #include <vector>
@@ -16,115 +14,34 @@ namespace mbgl {
 namespace style {
 namespace expression {
 
+namespace detail {
+struct SignatureBase;
+} // namespace detail
+
 /*
     CompoundExpression provides a mechanism for implementing an expression
     simply by providing a list of pure functions of the form
     (const T0& arg0, const T1& arg1, ...) -> Result<U> where T0, T1, ..., U are
     member types of mbgl::style::expression::Value.
- 
+
     The majority of expressions specified in the style-spec are implemented in
     this fashion (see compound_expression.cpp).
 */
-
-
-/*
-    Represents the parameter list for an expression that takes an arbitrary
-    number of arguments (of a specific type).
-*/
-struct VarargsType { type::Type type; };
-template <typename T>
-struct Varargs : std::vector<T> {
-    template <class... Args>
-    Varargs(Args&&... args) : std::vector<T>(std::forward<Args>(args)...) {}
-};
-
-namespace detail {
-// Base class for the Signature<Fn> structs that are used to determine
-// each CompoundExpression definition's type::Type data from the type of its
-// "evaluate" function.
-struct SignatureBase {
-    SignatureBase(type::Type result_, variant<std::vector<type::Type>, VarargsType> params_, std::string name_) :
-        result(std::move(result_)),
-        params(std::move(params_)),
-        name(std::move(name_))
-    {}
-    virtual ~SignatureBase() = default;
-    virtual std::unique_ptr<Expression> makeExpression(std::vector<std::unique_ptr<Expression>>) const = 0;
-    type::Type result;
-    variant<std::vector<type::Type>, VarargsType> params;
-    std::string name;
-};
-} // namespace detail
-
-
-/*
-    Common base class for CompoundExpression<Signature> instances.  Used to
-    allow downcasting (and access to things like name & parameter list) during
-    an Expression tree traversal.
-*/
-class CompoundExpressionBase : public Expression {
+class CompoundExpression : public Expression {
 public:
-    CompoundExpressionBase(std::string name_, const detail::SignatureBase& signature) :
-        Expression(Kind::CompoundExpression, signature.result),
-        name(std::move(name_)),
-        params(signature.params)
-    {}
+    CompoundExpression(const detail::SignatureBase&, std::vector<std::unique_ptr<Expression>>);
 
-    std::string getName() const { return name; }
-    optional<std::size_t> getParameterCount() const {
-        return params.match(
-            [&](const VarargsType&) { return optional<std::size_t>(); },
-            [&](const std::vector<type::Type>& p) -> optional<std::size_t> { return p.size(); }
-        );
-    }
+    std::string getOperator() const override;
+    EvaluationResult evaluate(const EvaluationContext& evaluationParams) const override;
+    std::vector<optional<Value>> possibleOutputs() const override;
+    void eachChild(const std::function<void(const Expression&)>& visit) const override;
+    bool operator==(const Expression& e) const override;
 
-    std::vector<optional<Value>> possibleOutputs() const override {
-        return { nullopt };
-    }
+    optional<std::size_t> getParameterCount() const;
 
-private:
-    std::string name;
-    variant<std::vector<type::Type>, VarargsType> params;
-};
-
-template <typename Signature>
-class CompoundExpression : public CompoundExpressionBase {
-public:
-    using Args = typename Signature::Args;
-    
-    CompoundExpression(const std::string& name_,
-                       Signature signature_,
-                       typename Signature::Args args_) :
-        CompoundExpressionBase(name_, signature_),
-        signature(signature_),
-        args(std::move(args_))
-    {}
-    
-    EvaluationResult evaluate(const EvaluationContext& evaluationParams) const override {
-        return signature.apply(evaluationParams, args);
-    }
-    
-    void eachChild(const std::function<void(const Expression&)>& visit) const override {
-        for (const std::unique_ptr<Expression>& e : args) {
-            visit(*e);
-        }
-    }
-
-    bool operator==(const Expression& e) const override {
-        if (e.getKind() == Kind::CompoundExpression) {
-            auto rhs = static_cast<const CompoundExpression*>(&e);
-            return getName() == rhs->getName() && Expression::childrenEqual(args, rhs->args);
-        }
-        return false;
-    }
-    
-    std::string getOperator() const override {
-        return signature.name;
-    }
-
-private:
-    Signature signature;
-    typename Signature::Args args;
+protected:
+    const detail::SignatureBase& signature;
+    std::vector<std::unique_ptr<Expression>> args;
 };
 
 /*
@@ -136,7 +53,9 @@ struct CompoundExpressionRegistry {
     static std::unordered_map<std::string, Definition> definitions;
 };
 
-ParseResult parseCompoundExpression(const std::string name, const mbgl::style::conversion::Convertible& value, ParsingContext& ctx);
+ParseResult parseCompoundExpression(const std::string name,
+                                    const mbgl::style::conversion::Convertible& value,
+                                    ParsingContext& ctx);
 
 ParseResult createCompoundExpression(const std::string& name,
                                      std::vector<std::unique_ptr<Expression>> args,

--- a/include/mbgl/style/expression/is_constant.hpp
+++ b/include/mbgl/style/expression/is_constant.hpp
@@ -10,9 +10,9 @@ namespace expression {
 template <typename T>
 bool isGlobalPropertyConstant(const Expression& expression, const T& properties) {
     if (expression.getKind() == Kind::CompoundExpression) {
-        auto e = static_cast<const CompoundExpressionBase*>(&expression);
+        auto e = static_cast<const CompoundExpression*>(&expression);
         for (const std::string& property : properties) {
-            if (e->getName() == property) {
+            if (e->getOperator() == property) {
                 return false;
             }
         }

--- a/src/mbgl/style/expression/find_zoom_curve.cpp
+++ b/src/mbgl/style/expression/find_zoom_curve.cpp
@@ -34,8 +34,8 @@ optional<variant<const Interpolate*, const Step*, ParsingError>> findZoomCurve(c
     case Kind::Interpolate: {
         auto curve = static_cast<const Interpolate*>(e);
         if (curve->getInput()->getKind() == Kind::CompoundExpression) {
-            auto z = static_cast<CompoundExpressionBase*>(curve->getInput().get());
-            if (z && z->getName() == "zoom") {
+            auto z = static_cast<CompoundExpression*>(curve->getInput().get());
+            if (z && z->getOperator() == "zoom") {
                 result = {curve};
             }
         }
@@ -44,8 +44,8 @@ optional<variant<const Interpolate*, const Step*, ParsingError>> findZoomCurve(c
     case Kind::Step: {
         auto step = static_cast<const Step*>(e);
         if (step->getInput()->getKind() == Kind::CompoundExpression) {
-            auto z = static_cast<CompoundExpressionBase*>(step->getInput().get());
-            if (z && z->getName() == "zoom") {
+            auto z = static_cast<CompoundExpression*>(step->getInput().get());
+            if (z && z->getOperator() == "zoom") {
                 result = {step};
             }
         }

--- a/src/mbgl/style/expression/is_constant.cpp
+++ b/src/mbgl/style/expression/is_constant.cpp
@@ -10,8 +10,8 @@ constexpr static const char filter[] = "filter-";
 
 bool isFeatureConstant(const Expression& expression) {
     if (expression.getKind() == Kind::CompoundExpression) {
-        auto e = static_cast<const CompoundExpressionBase*>(&expression);
-        const std::string name = e->getName();
+        auto e = static_cast<const CompoundExpression*>(&expression);
+        const std::string name = e->getOperator();
         optional<std::size_t> parameterCount = e->getParameterCount();
         if (name == "get" && parameterCount && *parameterCount == 1) {
             return false;

--- a/src/mbgl/style/expression/parsing_context.cpp
+++ b/src/mbgl/style/expression/parsing_context.cpp
@@ -38,8 +38,8 @@ bool isConstant(const Expression& expression) {
     }
 
     if (expression.getKind() == Kind::CompoundExpression) {
-        auto compound = static_cast<const CompoundExpressionBase*>(&expression);
-        if (compound->getName() == "error") {
+        auto compound = static_cast<const CompoundExpression*>(&expression);
+        if (compound->getOperator() == "error") {
             return false;
         }
     }


### PR DESCRIPTION
I think it should be possible to eliminate `SignatureBase` and its virtual methods and just have:

```c++
struct Signature {
    std::string name;
    type::Type result;
    variant<std::vector<type::Type>, VarargsType> params;
    EvaluationResult (*evaluate)(const EvaluationContext&,
                                 const std::vector<std::unique_ptr<Expression>>&);
};
```

But it's a tricky problem that I didn't manage to crack yet.