### PR TITLE
[android] - unbound variable with external PR

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -409,7 +409,6 @@ jobs:
       - *save-gradle-cache
       - run:
           name: Log in to Google Cloud Platform
-          shell: /bin/bash -euo pipefail
           command: |
             if [ -n "${GCLOUD_SERVICE_ACCOUNT_JSON}" ]; then
               echo "${GCLOUD_SERVICE_ACCOUNT_JSON}" > secret.json
@@ -419,7 +418,6 @@ jobs:
       - run:
           name: Run instrumentation tests on Firebase
           no_output_timeout: 1200
-          shell: /bin/bash -euo pipefail
           command: |
             if [ -n "${GCLOUD_SERVICE_ACCOUNT_JSON}" ]; then
               gcloud firebase test android models list
@@ -467,7 +465,6 @@ jobs:
       - *reset-ccache-stats
       - run:
           name: Generate Maven credentials
-          shell: /bin/bash -euo pipefail
           command: |
             if [ -n "${PUBLISH_NEXUS_USERNAME}" ]; then
               aws s3 cp s3://mapbox/android/signing-credentials/secring.gpg platform/android/MapboxGLAndroidSDK/secring.gpg


### PR DESCRIPTION
Third time the charm, we are running into some CI issues for PRs coming from forks. While solution in https://github.com/mapbox/mapbox-gl-native/pull/12489 worked for [this](https://github.com/mapbox/mapbox-gl-native/blob/master/circle.yml#L401) step, it failed for the [next](https://github.com/mapbox/mapbox-gl-native/blob/master/circle.yml#L414) step in this [build](https://circleci.com/gh/mapbox/mapbox-gl-native/134890?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link). Seeing that the only difference is the usage of `shell: /bin/bash -euo pipefail` I opted to remove it from the configuration. 

