### PR TITLE
Remove nunicode from android binding

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/StringUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/StringUtils.java
@@ -1,0 +1,27 @@
+package com.mapbox.mapboxsdk.utils;
+
+import android.support.annotation.Keep;
+import android.support.annotation.NonNull;
+
+import java.text.Normalizer;
+
+/**
+ * String utility class used by core from jni.
+ */
+@Keep
+class StringUtils {
+
+  /**
+   * Normalises String input and strip diacritics from it.
+   *
+   * @return normalised String with stripped diacritics.
+   */
+  @Keep
+  @NonNull
+  static String unaccent(@NonNull String value) {
+    return Normalizer.normalize(value, Normalizer.Form.NFD)
+      .replaceAll("(\\p{InCombiningDiacriticalMarks}"
+        + "|\\p{InCombiningDiacriticalMarksForSymbols}"
+        + "|\\p{InCombiningDiacriticalMarksSupplement})+", "");
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/string/UppperLowerCaseTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/string/UppperLowerCaseTest.java
@@ -1,0 +1,50 @@
+package com.mapbox.mapboxsdk.testapp.string;
+
+import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
+import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+
+/**
+ * Test verifying if String#toUpperCase and String#toLowerCase produces desired results
+ * <p>
+ * See core test in https://github.com/mapbox/mapbox-gl-native/blob/master/test/util/text_conversions.test.cpp
+ * </p>
+ */
+public class UppperLowerCaseTest extends BaseActivityTest {
+
+  @Override
+  protected Class getActivityClass() {
+    return EspressoTestActivity.class;
+  }
+
+  @Test
+  public void testToUpperCase() {
+    assertEquals("STREET", "strEEt".toUpperCase());  // EN
+    assertEquals("ROAD", "rOAd".toUpperCase());      // EN
+
+    assertEquals("STRASSE", "straße".toUpperCase()); // DE
+    assertEquals("MASSE", "maße".toUpperCase());     // DE
+    assertEquals("WEISSKOPFSEEADLER", "weißkopfseeadler".toUpperCase()); // DE
+
+    assertEquals("BÊNÇÃO", "bênção".toUpperCase()); // PT
+    assertEquals("AZƏRBAYCAN", "Azərbaycan".toUpperCase()); // AZ
+    assertEquals("ὈΔΥΣΣΕΎΣ", "Ὀδυσσεύς".toUpperCase()); // GR
+  }
+
+  @Test
+  public void testToLowerCase() {
+    assertEquals("street", "strEEt".toLowerCase());  // EN
+    assertEquals("road", "rOAd".toLowerCase());      // EN
+
+    assertEquals("straße", "Straße".toLowerCase());   // DE
+    assertEquals("strasse", "STRASSE".toLowerCase()); // DE
+    assertEquals("masse", "MASSE".toLowerCase());     // DE
+    assertEquals("weisskopfseeadler", "weiSSkopfseeadler".toLowerCase()); // DE
+
+    assertEquals("bênção", "BÊNÇÃO".toLowerCase()); // PT
+    assertEquals("azərbaycan", "AZƏRBAYCAN".toLowerCase()); //
+  }
+
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/render/RenderTestActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/render/RenderTestActivity.java
@@ -56,6 +56,7 @@ public class RenderTestActivity extends AppCompatActivity {
       add("overlapping,raster-masking");
       add("missing,raster-loading");
       add("pitchAndBearing,line-pitch");
+      add("overdraw,sparse-tileset");
     }
   };
 
@@ -292,7 +293,7 @@ public class RenderTestActivity extends AppCompatActivity {
   }
 
   public void onLoadIgnoreList(List<String> ignoreList) {
-    Timber.e("We loaded %s amount of tests to be ignored", ignoreList.size());
+    Timber.e("We loaded %s of tests to be ignored", ignoreList.size());
     EXCLUDED_TESTS.addAll(ignoreList);
     new LoadRenderDefinitionTask(this).execute();
   }

--- a/platform/android/config.cmake
+++ b/platform/android/config.cmake
@@ -1,6 +1,5 @@
 set(USE_GLES2 ON)
 
-include(cmake/nunicode.cmake)
 include(cmake/sqlite.cmake)
 include(cmake/icu.cmake)
 
@@ -49,7 +48,6 @@ macro(mbgl_platform_core)
     target_add_mason_package(mbgl-core PUBLIC rapidjson)
 
     target_link_libraries(mbgl-core
-        PRIVATE nunicode
         PRIVATE icu
         PUBLIC expected
         PUBLIC -llog

--- a/platform/android/core-files.txt
+++ b/platform/android/core-files.txt
@@ -11,10 +11,10 @@ platform/android/src/text/local_glyph_rasterizer.cpp
 platform/android/src/text/local_glyph_rasterizer_jni.hpp
 platform/android/src/logging_android.cpp
 platform/android/src/thread.cpp
-platform/default/string_stdlib.cpp
+platform/android/src/string_util.cpp
 platform/default/bidi.cpp
 platform/default/thread_local.cpp
-platform/default/unaccent.cpp
+platform/android/src/unaccent.cpp
 platform/default/unaccent.hpp
 platform/default/utf.cpp
 

--- a/platform/android/scripts/run-render-test.py
+++ b/platform/android/scripts/run-render-test.py
@@ -3,7 +3,7 @@
 import os
 import shutil
 
-catPath = os.getcwd() + "/platform/android/build/render-test/render/"
+catPath = os.getcwd() + "/platform/android/build/render-test/"
 failCounter = 0
 testCounter = 0
 for cat in os.listdir(catPath):

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -187,6 +187,7 @@ void registerNatives(JavaVM *vm) {
     LocalGlyphRasterizer::registerNative(env);
     Locale::registerNative(env);
     Collator::registerNative(env);
+    StringUtils::registerNative(env);
 
     // Logger
     Logger::registerNative(env);

--- a/platform/android/src/string_util.cpp
+++ b/platform/android/src/string_util.cpp
@@ -1,0 +1,25 @@
+#include <mbgl/util/platform.hpp>
+#include "attach_env.hpp"
+#include <jni/jni.hpp>
+
+namespace mbgl {
+namespace platform {
+
+std::string uppercase(const std::string& str) {
+    auto env{ android::AttachEnv() };
+    jni::Local<jni::String> value = jni::Make<jni::String>(*env, str.c_str());
+    static auto toUpperCase = jni::Class<jni::StringTag>::Singleton(*env).GetMethod<jni::String()>(*env, "toUpperCase");
+    auto result = value.Call(*env, toUpperCase);
+    return jni::Make<std::string>(*env, result);
+}
+
+std::string lowercase(const std::string& str) {
+    auto env{ android::AttachEnv() };
+    jni::Local<jni::String> value = jni::Make<jni::String>(*env, str.c_str());
+    static auto toLowerCase = jni::Class<jni::StringTag>::Singleton(*env).GetMethod<jni::String()>(*env, "toLowerCase");
+    auto result = value.Call(*env, toLowerCase);
+    return jni::Make<std::string>(*env, result);
+}
+
+} // namespace platform
+} // namespace mbgl

--- a/platform/android/src/text/collator.cpp
+++ b/platform/android/src/text/collator.cpp
@@ -30,8 +30,18 @@ void Collator::setStrength(jni::JNIEnv& env, const jni::Object<Collator>& collat
 
 jni::jint Collator::compare(jni::JNIEnv& env, const jni::Object<Collator>& collator, const jni::String& lhs, const jni::String& rhs) {
     static auto& javaClass = jni::Class<Collator>::Singleton(env);
-    auto static method = javaClass.GetMethod<jni::jint (jni::String, jni::String)>(env, "compare");
+    static auto method = javaClass.GetMethod<jni::jint (jni::String, jni::String)>(env, "compare");
     return collator.Call(env, method, lhs, rhs);
+}
+
+void StringUtils::registerNative(jni::JNIEnv& env) {
+    jni::Class<StringUtils>::Singleton(env);
+}
+
+jni::Local<jni::String> StringUtils::unaccent(jni::JNIEnv& env, const jni::String& value) {
+    static auto& javaClass = jni::Class<StringUtils>::Singleton(env);
+    static auto method = javaClass.GetStaticMethod<jni::String (jni::String)>(env, "unaccent");
+    return javaClass.Call(env, method, value);
 }
 
 void Locale::registerNative(jni::JNIEnv& env) {

--- a/platform/android/src/text/collator_jni.hpp
+++ b/platform/android/src/text/collator_jni.hpp
@@ -49,5 +49,16 @@ public:
     static void registerNative(jni::JNIEnv&);
 };
 
+
+class StringUtils {
+public:
+    static constexpr auto Name() { return "com/mapbox/mapboxsdk/utils/StringUtils"; };
+
+    static jni::Local<jni::String> unaccent(jni::JNIEnv&, const jni::String&);
+
+
+    static void registerNative(jni::JNIEnv&);
+};
+
 } // namespace android
 } // namespace mbgl

--- a/platform/android/src/unaccent.cpp
+++ b/platform/android/src/unaccent.cpp
@@ -1,0 +1,18 @@
+#include <unaccent.hpp>
+#include <string>
+#include "attach_env.hpp"
+#include "text/collator_jni.hpp"
+#include <jni/jni.hpp>
+
+namespace mbgl {
+namespace platform {
+
+std::string unaccent(const std::string& str) {
+    android::UniqueEnv env = android::AttachEnv();
+    jni::Local<jni::String> input = jni::Make<jni::String>(*env, str);
+    jni::Local<jni::String> unaccented = android::StringUtils::unaccent(*env, input);
+    return jni::Make<std::string>(*env, unaccented);
+}
+
+} // namespace platform
+} // namespace mbgl


### PR DESCRIPTION
This PR is the first step to remove nunicode from the Mapbox Maps SDK for Android. Removing this c++ library would result in decreasing the overal binary size of the SDK. 

In this PR, we are replacing the nunicode uppercase and lowercase invocations by wiring through jni to leverage the android platform specific `java/lang/String#toUpperCase()` and `jave/lang/String#toLowerCase()` instead.

Note though, we can't remove nunicode yet as it's used for collator expressions (https://github.com/mapbox/mapbox-gl-native/issues/12268). 
@ChrisLoer would it be possible to move that implementaton to [Collator.java](https://developer.android.com/reference/java/text/Collator) in the same way as this PR does for upperCasing/lowerCasing?