### PR TITLE
Fix compilation errors on QNX 7

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -121,3 +121,48 @@ used/needed but we had one incident fixed by #9665.
 ### Workarounds
 
 - Copy & Paste™ the code.
+
+
+## [Inheriting Constructors](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2540.htm)
+
+Compilers with only partial C++11 support causes compilation errors when using-declaration is used in derived class to inherit its base class's constructors `(e.g. using Base::Base;)`.
+
+```C++
+#include <vector>
+
+template <typename T>
+struct Varargs : std::vector<T>
+{
+    using std::vector<T>::vector;
+};
+
+// error: conflicts with version inherited from 'std::__1::vector<int, std::__1::allocator<int> >'
+int main()
+{
+    Varargs<int> v;
+    return 0;
+}
+```
+
+### Workarounds
+
+- Replace using-declaration (e.g. using Base::Base;) in derived class with `universal forwarding constructor`.
+
+```C++
+#include <vector>
+
+template <typename T>
+struct Varargs : std::vector<T>
+{
+    template <class... Args>
+    Varargs(Args&&... args) : std::vector<T>(std::forward<Args>(args)...) {}
+};
+
+int main()
+{
+    Varargs<int> v;
+    return 0;
+}
+```
+
+Note: Using `universal forwarding constructor` may not be appropriate when derived class has additional members that are not in base class. Write constructors for the derived class explicitly instead of using `universal forwarding constructor` when the derived class has additional members.

--- a/cmake/mason-dependencies.cmake
+++ b/cmake/mason-dependencies.cmake
@@ -1,11 +1,11 @@
 # All dependencies in a single separate file so its checksum can be used in a CI cache key name
 
-mason_use(geometry VERSION 0.9.2 HEADER_ONLY)
+mason_use(geometry VERSION 0.9.3 HEADER_ONLY)
 mason_use(variant VERSION 1.1.4 HEADER_ONLY)
 mason_use(unique_resource VERSION cba309e HEADER_ONLY)
 mason_use(rapidjson VERSION 1.1.0 HEADER_ONLY)
 mason_use(boost VERSION 1.65.1 HEADER_ONLY)
-mason_use(geojsonvt VERSION 6.3.0 HEADER_ONLY)
+mason_use(geojsonvt VERSION 6.5.1 HEADER_ONLY)
 mason_use(supercluster VERSION 0.2.2 HEADER_ONLY)
 mason_use(kdbush VERSION 0.1.1-1 HEADER_ONLY)
 mason_use(earcut VERSION 0.12.4 HEADER_ONLY)
@@ -16,7 +16,7 @@ mason_use(polylabel VERSION 1.0.3 HEADER_ONLY)
 mason_use(wagyu VERSION 0.4.3 HEADER_ONLY)
 mason_use(shelf-pack VERSION 2.1.1 HEADER_ONLY)
 mason_use(cheap-ruler VERSION 2.5.3 HEADER_ONLY)
-mason_use(vector-tile VERSION 1.0.1 HEADER_ONLY)
+mason_use(vector-tile VERSION 1.0.2 HEADER_ONLY)
 
 if(MBGL_PLATFORM STREQUAL "android")
     mason_use(jni.hpp VERSION 3.0.0 HEADER_ONLY)

--- a/include/mbgl/style/expression/compound_expression.hpp
+++ b/include/mbgl/style/expression/compound_expression.hpp
@@ -33,7 +33,10 @@ namespace expression {
 */
 struct VarargsType { type::Type type; };
 template <typename T>
-struct Varargs : std::vector<T> { using std::vector<T>::vector; };
+struct Varargs : std::vector<T> {
+    template <class... Args>
+    Varargs(Args&&... args) : std::vector<T>(std::forward<Args>(args)...) {}
+};
 
 namespace detail {
 // Base class for the Signature<Fn> structs that are used to determine

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -36,10 +36,12 @@ class Debugging;
 class ProgramBinary;
 } // namespace extension
 
-class Context : private util::noncopyable {
+class Context {
 public:
     Context();
     ~Context();
+    Context(const Context&) = delete;
+    Context& operator=(const Context& other) = delete;
 
     void initializeExtensions(const std::function<gl::ProcAddress(const char*)>&);
 

--- a/src/mbgl/style/expression/interpolate.cpp
+++ b/src/mbgl/style/expression/interpolate.cpp
@@ -170,23 +170,23 @@ ParseResult parseInterpolate(const Convertible& value, ParsingContext& ctx) {
             labelValue->match(
                 [&](uint64_t n) {
                     if (n > std::numeric_limits<double>::max()) {
-                        label = {std::numeric_limits<double>::infinity()};
+                        label = optional<double>{std::numeric_limits<double>::infinity()};
                     } else {
-                        label = {static_cast<double>(n)};
+                        label = optional<double>{static_cast<double>(n)};
                     }
                 },
                 [&](int64_t n) {
                     if (n > std::numeric_limits<double>::max()) {
-                        label = {std::numeric_limits<double>::infinity()};
+                        label = optional<double>{std::numeric_limits<double>::infinity()};
                     } else {
-                        label = {static_cast<double>(n)};
+                        label = optional<double>{static_cast<double>(n)};
                     }
                 },
                 [&](double n) {
                     if (n > std::numeric_limits<double>::max()) {
-                        label = {std::numeric_limits<double>::infinity()};
+                        label = optional<double>{std::numeric_limits<double>::infinity()};
                     } else {
-                        label = {static_cast<double>(n)};
+                        label = optional<double>{n};
                     }
                 },
                 [&](const auto&) {}

--- a/src/mbgl/style/expression/match.cpp
+++ b/src/mbgl/style/expression/match.cpp
@@ -138,7 +138,7 @@ optional<InputType> parseInputValue(const Convertible& input, ParsingContext& pa
                     parentContext.error("Branch labels must be integers no larger than " + util::toString(Value::maxSafeInteger()) + ".", index);
                 } else {
                     type = {type::Number};
-                    result = {static_cast<int64_t>(n)};
+                    result = optional<InputType>{static_cast<int64_t>(n)};
                 }
             },
             [&] (int64_t n) {
@@ -146,7 +146,7 @@ optional<InputType> parseInputValue(const Convertible& input, ParsingContext& pa
                     parentContext.error("Branch labels must be integers no larger than " + util::toString(Value::maxSafeInteger()) + ".", index);
                 } else {
                     type = {type::Number};
-                    result = {n};
+                    result = optional<InputType>{n};
                 }
             },
             [&] (double n) {
@@ -156,7 +156,7 @@ optional<InputType> parseInputValue(const Convertible& input, ParsingContext& pa
                     parentContext.error("Numeric branch labels must be integer values.", index);
                 } else {
                     type = {type::Number};
-                    result = {static_cast<int64_t>(n)};
+                    result = optional<InputType>{static_cast<int64_t>(n)};
                 }
             },
             [&] (const std::string& s) {

--- a/src/mbgl/style/expression/step.cpp
+++ b/src/mbgl/style/expression/step.cpp
@@ -127,23 +127,23 @@ ParseResult Step::parse(const mbgl::style::conversion::Convertible& value, Parsi
             labelValue->match(
                 [&](uint64_t n) {
                     if (n > std::numeric_limits<double>::max()) {
-                        label = {std::numeric_limits<double>::infinity()};
+                        label = optional<double>{std::numeric_limits<double>::infinity()};
                     } else {
-                        label = {static_cast<double>(n)};
+                        label = optional<double>{static_cast<double>(n)};
                     }
                 },
                 [&](int64_t n) {
                     if (n > std::numeric_limits<double>::max()) {
-                        label = {std::numeric_limits<double>::infinity()};
+                        label = optional<double>{std::numeric_limits<double>::infinity()};
                     } else {
-                        label = {static_cast<double>(n)};
+                        label = optional<double>{static_cast<double>(n)};
                     }
                 },
                 [&](double n) {
                     if (n > std::numeric_limits<double>::max()) {
-                        label = {std::numeric_limits<double>::infinity()};
+                        label = optional<double>{std::numeric_limits<double>::infinity()};
                     } else {
-                        label = {static_cast<double>(n)};
+                        label = optional<double>{n};
                     }
                 },
                 [&](const auto&) {}

--- a/src/mbgl/tile/geometry_tile_data.hpp
+++ b/src/mbgl/tile/geometry_tile_data.hpp
@@ -22,19 +22,19 @@ class GeometryCoordinates : public std::vector<GeometryCoordinate> {
 public:
     using coordinate_type = int16_t;
 
-    GeometryCoordinates() = default;
-    GeometryCoordinates(const std::vector<GeometryCoordinate>& v)
-        : std::vector<GeometryCoordinate>(v) {}
-    GeometryCoordinates(std::vector<GeometryCoordinate>&& v)
-        : std::vector<GeometryCoordinate>(std::move(v)) {}
-
-    using std::vector<GeometryCoordinate>::vector;
+    template <class... Args>
+    GeometryCoordinates(Args&&... args) : std::vector<GeometryCoordinate>(std::forward<Args>(args)...) {}
+    GeometryCoordinates(std::initializer_list<GeometryCoordinate> args)
+      : std::vector<GeometryCoordinate>(std::move(args)) {}
 };
 
 class GeometryCollection : public std::vector<GeometryCoordinates> {
 public:
     using coordinate_type = int16_t;
-    using std::vector<GeometryCoordinates>::vector;
+    template <class... Args>
+    GeometryCollection(Args&&... args) : std::vector<GeometryCoordinates>(std::forward<Args>(args)...) {}
+    GeometryCollection(std::initializer_list<GeometryCoordinates> args)
+      : std::vector<GeometryCoordinates>(std::move(args)) {}
 };
 
 class GeometryTileFeature {

--- a/test/api/recycle_map.cpp
+++ b/test/api/recycle_map.cpp
@@ -35,7 +35,7 @@ TEST(API, RecycleMapUpdateImages) {
 
     auto loadStyle = [&](auto markerName, auto markerPath) {
         auto source = std::make_unique<GeoJSONSource>("geometry");
-        source->setGeoJSON({ Point<double> { 0, 0 } });
+        source->setGeoJSON( Geometry<double>{ Point<double>{ 0, 0 } } );
 
         auto layer = std::make_unique<SymbolLayer>("geometry", "geometry");
         layer->setIconImage({ markerName });


### PR DESCRIPTION
This PR includes the changes that are needed for building mapbox-gl-native on Qt QNX 7( [Mapbox Qt bug](https://bugreports.qt.io/browse/QTBUG-59685) ). It also updates the mason modules geometry, geojsonvt and vector-tile to latest to get the fixes that are needed for QNX 7 compiler. 

Reason for the errors: QNX 7 compiler (i.e qcc based GCC 5.4.0 with libc++ from LLVM) has a limited c++11 feature support and causing the following compilation errors: 

```
1)
qt5/qtlocation/src/3rdparty/mapbox-gl-native/src/mbgl/tile/geometry_tile_data.hpp:37:45: error: 'template<class _InputIterator> mbgl::GeometryCollection::GeometryCollection(_InputIterator, _InputIterator, const allocator_type&)' inherited from 'std::__1::vector<mbgl::GeometryCoordinates>'
     using std::vector<GeometryCoordinates>::vector;
                                             ^
qt5/qtlocation/src/3rdparty/mapbox-gl-native/src/mbgl/tile/geometry_tile_data.hpp:37:45: error: conflicts with version inherited from 'std::__1::vector<mbgl::GeometryCoordinates>'

2)
qt5/qtlocation/src/3rdparty/mapbox-gl-native/src/mbgl/style/expression/interpolate.cpp: In lambda function:
qt5/qtlocation/src/3rdparty/mapbox-gl-native/src/mbgl/style/expression/interpolate.cpp:108:31: error: ambiguous overload for 'operator=' (operand types are 'mbgl::optional<double> {aka std::experimental::fundamentals_v1::optional<double>}' and '<brace-enclosed initializer list>')
                         label = {std::numeric_limits<double>::infinity()};
                               ^
3)
qt5/qtlocation/src/3rdparty/mapbox-gl-native/src/mbgl/gl/vertex_array.cpp:9:29:   required from here
qnx700/target/qnx7/usr/include/c++/v1/__tuple:351:8: error: invalid use of incomplete type 'struct std::__1::__tuple_assignable_imp<std::__1::__tuple_types<const mbgl::gl::Context&>, std::__1::__tuple_types<const mbgl::gl::Context&> >'
 struct __tuple_assignable_apply<true, _Tp, _Up>
        ^
qnx700/target/qnx7/usr/include/c++/v1/__tuple:338:8: note: declaration of 'struct std::__1::__tuple_assignable_imp<std::__1::__tuple_types<const mbgl::gl::Context&>, std::__1::__tuple_types<const mbgl::gl::Context&> >'
 struct __tuple_assignable_imp<__tuple_types<_Tp0, _Tp...>, __tuple_types<_Up0, _Up...> >
```