### PR TITLE
Check if the custom geometry request has been canceled while converting features

### DIFF
--- a/platform/android/src/style/sources/custom_geometry_source.cpp
+++ b/platform/android/src/style/sources/custom_geometry_source.cpp
@@ -102,6 +102,19 @@ namespace android {
         peer.Call(*_env, releaseThreads);
     };
 
+    bool CustomGeometrySource::isCancelled(jni::jint z,
+                                                jni::jint x,
+                                                jni::jint y) {
+        android::UniqueEnv _env = android::AttachEnv();
+
+        static auto isCancelled = javaClass.GetMethod<jboolean (jni::jint, jni::jint, jni::jint)>(*_env, "isCancelled");
+
+        assert(javaPeer);
+
+        auto peer = jni::Cast(*_env, *javaPeer, javaClass);
+        return peer.Call(*_env, isCancelled, z, x, y);
+    };
+
     void CustomGeometrySource::setTileData(jni::JNIEnv& env,
                                            jni::jint z,
                                            jni::jint x,
@@ -112,8 +125,10 @@ namespace android {
         // Convert the jni object
         auto geometry = geojson::FeatureCollection::convert(env, jFeatures);
 
-        // Update the core source
-        source.as<mbgl::style::CustomGeometrySource>()->CustomGeometrySource::setTileData(CanonicalTileID(z, x, y), GeoJSON(geometry));
+        // Update the core source if not cancelled
+        if (!isCancelled(z, x ,y)) {
+            source.as<mbgl::style::CustomGeometrySource>()->CustomGeometrySource::setTileData(CanonicalTileID(z, x, y), GeoJSON(geometry));
+        }
     }
 
     void CustomGeometrySource::invalidateTile(jni::JNIEnv&, jni::jint z, jni::jint x, jni::jint y) {

--- a/platform/android/src/style/sources/custom_geometry_source.hpp
+++ b/platform/android/src/style/sources/custom_geometry_source.hpp
@@ -33,6 +33,7 @@ public:
 
     void fetchTile(const mbgl::CanonicalTileID& tileID);
     void cancelTile(const mbgl::CanonicalTileID& tileID);
+    bool isCancelled(jni::jint z, jni::jint x, jni::jint y);
     void startThreads();
     void releaseThreads();
     void setTileData(jni::JNIEnv& env, jni::jint z, jni::jint x, jni::jint y, jni::Object<geojson::FeatureCollection> jf);


### PR DESCRIPTION
Fixes #12508.

Unfortunately, I wasn't able to manufacture any examples that would visualise race conditions, but while testing, I noticed that [converting features](https://github.com/mapbox/mapbox-gl-native/compare/12508-custom-geomerty-source-race?expand=1#diff-4daf8924d97ae9614980001e12d9e450R115) is the operation that takes the longest when setting new tile data. Adding the check if the request has been canceled meanwhile might resolve most race cases.