### PR TITLE
[core] Tweak conversions to reduce binary size

### DIFF
--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -426,8 +426,10 @@ set(MBGL_CORE_FILES
     include/mbgl/style/conversion/source.hpp
     include/mbgl/style/conversion/tileset.hpp
     include/mbgl/style/conversion/transition_options.hpp
+    src/mbgl/style/conversion/color_ramp_property_value.cpp
     src/mbgl/style/conversion/constant.cpp
     src/mbgl/style/conversion/coordinate.cpp
+    src/mbgl/style/conversion/custom_geometry_source_options.cpp
     src/mbgl/style/conversion/filter.cpp
     src/mbgl/style/conversion/function.cpp
     src/mbgl/style/conversion/geojson.cpp

--- a/include/mbgl/style/conversion/color_ramp_property_value.hpp
+++ b/include/mbgl/style/conversion/color_ramp_property_value.hpp
@@ -2,11 +2,6 @@
 
 #include <mbgl/style/color_ramp_property_value.hpp>
 #include <mbgl/style/conversion.hpp>
-#include <mbgl/style/conversion/constant.hpp>
-#include <mbgl/style/expression/value.hpp>
-#include <mbgl/style/expression/is_constant.hpp>
-#include <mbgl/style/expression/is_expression.hpp>
-#include <mbgl/style/expression/parsing_context.hpp>
 
 namespace mbgl {
 namespace style {
@@ -14,32 +9,7 @@ namespace conversion {
 
 template <>
 struct Converter<ColorRampPropertyValue> {
-    optional<ColorRampPropertyValue> operator()(const Convertible& value, Error& error, bool /* convertTokens */ = false) const {
-        using namespace mbgl::style::expression;
-        if (isUndefined(value)) {
-            return ColorRampPropertyValue();
-        } else if (isExpression(value)) {
-            ParsingContext ctx(type::Color);
-            ParseResult expression = ctx.parseLayerPropertyExpression(value);
-            if (!expression) {
-                error = { ctx.getCombinedErrors() };
-                return {};
-            }
-            assert(*expression);
-            if (!isFeatureConstant(**expression)) {
-                error = { "property expressions not supported" };
-                return {};
-            }
-            if (!isZoomConstant(**expression)) {
-                error = { "zoom expressions not supported" };
-                return {};
-            }
-            return {ColorRampPropertyValue(std::move(*expression))};
-        } else {
-            error = { "color ramp must be an expression" };
-            return {};
-        }
-    }
+    optional<ColorRampPropertyValue> operator()(const Convertible& value, Error& error, bool /* convertTokens */ = false) const;
 };
 
 } // namespace conversion

--- a/include/mbgl/style/conversion/constant.hpp
+++ b/include/mbgl/style/conversion/constant.hpp
@@ -33,14 +33,14 @@ struct Converter<T, typename std::enable_if_t<std::is_enum<T>::value>> {
     optional<T> operator()(const Convertible& value, Error& error) const {
         optional<std::string> string = toString(value);
         if (!string) {
-            error = { "value must be a string" };
-            return {};
+            error.message = "value must be a string";
+            return nullopt;
         }
 
         const auto result = Enum<T>::toEnum(*string);
         if (!result) {
-            error = { "value must be a valid enumeration value" };
-            return {};
+            error.message = "value must be a valid enumeration value";
+            return nullopt;
         }
 
         return *result;
@@ -56,16 +56,16 @@ template <size_t N>
 struct Converter<std::array<float, N>> {
     optional<std::array<float, N>> operator()(const Convertible& value, Error& error) const {
         if (!isArray(value) || arrayLength(value) != N) {
-            error = { "value must be an array of " + util::toString(N) + " numbers" };
-            return {};
+            error.message = "value must be an array of " + util::toString(N) + " numbers";
+            return nullopt;
         }
 
         std::array<float, N> result;
         for (size_t i = 0; i < N; i++) {
             optional<float> n = toNumber(arrayMember(value, i));
             if (!n) {
-                error = { "value must be an array of " + util::toString(N) + " numbers" };
-                return {};
+                error.message = "value must be an array of " + util::toString(N) + " numbers";
+                return nullopt;
             }
             result[i] = *n;
         }

--- a/include/mbgl/style/conversion/custom_geometry_source_options.hpp
+++ b/include/mbgl/style/conversion/custom_geometry_source_options.hpp
@@ -9,74 +9,7 @@ namespace conversion {
 
 template <>
 struct Converter<CustomGeometrySource::Options> {
-
-    template <class V>
-    optional<CustomGeometrySource::Options> operator()(const V& value, Error& error) const {
-        CustomGeometrySource::Options options;
-
-        const auto minzoomValue = objectMember(value, "minzoom");
-        if (minzoomValue) {
-            if (toNumber(*minzoomValue)) {
-                options.zoomRange.min = static_cast<uint8_t>(*toNumber(*minzoomValue));
-            } else {
-                error = { "GeoJSON source minzoom value must be a number" };
-                return {};
-            }
-        }
-
-        const auto maxzoomValue = objectMember(value, "maxzoom");
-        if (maxzoomValue) {
-            if (toNumber(*maxzoomValue)) {
-                options.zoomRange.max = static_cast<uint8_t>(*toNumber(*maxzoomValue));
-            } else {
-                error = { "GeoJSON source maxzoom value must be a number" };
-                return {};
-            }
-        }
-
-        const auto bufferValue = objectMember(value, "buffer");
-        if (bufferValue) {
-            if (toNumber(*bufferValue)) {
-                options.tileOptions.buffer = static_cast<uint16_t>(*toNumber(*bufferValue));
-            } else {
-                error = { "GeoJSON source buffer value must be a number" };
-                return {};
-            }
-        }
-
-        const auto toleranceValue = objectMember(value, "tolerance");
-        if (toleranceValue) {
-            if (toNumber(*toleranceValue)) {
-                options.tileOptions.tolerance = static_cast<double>(*toNumber(*toleranceValue));
-            } else {
-                error = { "GeoJSON source tolerance value must be a number" };
-                return {};
-            }
-        }
-
-        const auto wrapValue = objectMember(value, "wrap");
-        if (wrapValue) {
-            if (toBool(*wrapValue)) {
-                options.tileOptions.wrap = static_cast<bool>(*toBool(*wrapValue));
-            } else {
-                error = { "CustomGeometrySource TileOptions wrap value must be a boolean" };
-                return {};
-            }
-        }
-
-        const auto clipValue = objectMember(value, "clip");
-        if (clipValue) {
-            if (toBool(*clipValue)) {
-                options.tileOptions.clip = static_cast<double>(*toBool(*clipValue));
-            } else {
-                error = { "CustomGeometrySource TileOptiosn clip value must be a boolean" };
-                return {};
-            }
-        }
-
-        return { options };
-    }
-
+    optional<CustomGeometrySource::Options> operator()(const Convertible& value, Error& error) const;
 };
 
 } // namespace conversion

--- a/include/mbgl/style/conversion/data_driven_property_value.hpp
+++ b/include/mbgl/style/conversion/data_driven_property_value.hpp
@@ -29,8 +29,8 @@ struct Converter<DataDrivenPropertyValue<T>> {
             ParsingContext ctx(valueTypeToExpressionType<T>());
             ParseResult parsed = ctx.parseLayerPropertyExpression(value);
             if (!parsed) {
-                error = { ctx.getCombinedErrors() };
-                return {};
+                error.message = ctx.getCombinedErrors();
+                return nullopt;
             }
             expression = PropertyExpression<T>(std::move(*parsed));
         } else if (isObject(value)) {
@@ -38,26 +38,26 @@ struct Converter<DataDrivenPropertyValue<T>> {
         } else {
             optional<T> constant = convert<T>(value, error);
             if (!constant) {
-                return {};
+                return nullopt;
             }
             return convertTokens ? maybeConvertTokens(*constant) : DataDrivenPropertyValue<T>(*constant);
         }
 
         if (!expression) {
-            return {};
+            return nullopt;
         } else if (!(*expression).isFeatureConstant() || !(*expression).isZoomConstant()) {
             return { std::move(*expression) };
         } else if ((*expression).getExpression().getKind() == Kind::Literal) {
             optional<T> constant = fromExpressionValue<T>(
                 static_cast<const Literal&>((*expression).getExpression()).getValue());
             if (!constant) {
-                return {};
+                return nullopt;
             }
             return DataDrivenPropertyValue<T>(*constant);
         } else {
             assert(false);
-            error = { "expected a literal expression" };
-            return {};
+            error.message = "expected a literal expression";
+            return nullopt;
         }
     }
 

--- a/include/mbgl/style/conversion/function.hpp
+++ b/include/mbgl/style/conversion/function.hpp
@@ -19,7 +19,7 @@ template <class T>
 optional<PropertyExpression<T>> convertFunctionToExpression(const Convertible& value, Error& error, bool convertTokens) {
     auto expression = convertFunctionToExpression(expression::valueTypeToExpressionType<T>(), value, error, convertTokens);
     if (!expression) {
-        return {};
+        return nullopt;
     }
 
     optional<T> defaultValue;
@@ -28,8 +28,8 @@ optional<PropertyExpression<T>> convertFunctionToExpression(const Convertible& v
     if (defaultValueValue) {
         defaultValue = convert<T>(*defaultValueValue, error);
         if (!defaultValue) {
-            error = { R"(wrong type for "default": )" + error.message };
-            return {};
+            error.message = R"(wrong type for "default": )" + error.message;
+            return nullopt;
         }
     }
 

--- a/include/mbgl/style/conversion/property_value.hpp
+++ b/include/mbgl/style/conversion/property_value.hpp
@@ -33,8 +33,8 @@ struct Converter<PropertyValue<T>> {
             ParsingContext ctx(valueTypeToExpressionType<T>());
             ParseResult parsed = ctx.parseLayerPropertyExpression(value);
             if (!parsed) {
-                error = { ctx.getCombinedErrors() };
-                return {};
+                error.message = ctx.getCombinedErrors();
+                return nullopt;
             }
             expression = PropertyExpression<T>(std::move(*parsed));
         } else if (isObject(value)) {
@@ -42,29 +42,29 @@ struct Converter<PropertyValue<T>> {
         } else {
             optional<T> constant = convert<T>(value, error);
             if (!constant) {
-                return {};
+                return nullopt;
             }
             return { *constant };
         }
 
         if (!expression) {
-            return {};
+            return nullopt;
         } else if (!(*expression).isFeatureConstant()) {
-            error = { "data expressions not supported" };
-            return {};
+            error.message = "data expressions not supported";
+            return nullopt;
         } else if (!(*expression).isZoomConstant()) {
             return { std::move(*expression) };
         } else if ((*expression).getExpression().getKind() == Kind::Literal) {
             optional<T> constant = fromExpressionValue<T>(
                 static_cast<const Literal&>((*expression).getExpression()).getValue());
             if (!constant) {
-                return {};
+                return nullopt;
             }
             return PropertyValue<T>(*constant);
         } else {
             assert(false);
-            error = { "expected a literal expression" };
-            return {};
+            error.message = "expected a literal expression";
+            return nullopt;
         }
     }
 };

--- a/src/mbgl/style/conversion/color_ramp_property_value.cpp
+++ b/src/mbgl/style/conversion/color_ramp_property_value.cpp
@@ -1,0 +1,42 @@
+#include <mbgl/style/conversion/color_ramp_property_value.hpp>
+#include <mbgl/style/conversion.hpp>
+#include <mbgl/style/conversion/constant.hpp>
+#include <mbgl/style/expression/value.hpp>
+#include <mbgl/style/expression/is_constant.hpp>
+#include <mbgl/style/expression/is_expression.hpp>
+#include <mbgl/style/expression/parsing_context.hpp>
+
+namespace mbgl {
+namespace style {
+namespace conversion {
+
+optional<ColorRampPropertyValue> Converter<ColorRampPropertyValue>::operator()(const Convertible& value, Error& error, bool) const {
+    using namespace mbgl::style::expression;
+    if (isUndefined(value)) {
+        return ColorRampPropertyValue();
+    } else if (isExpression(value)) {
+        ParsingContext ctx(type::Color);
+        ParseResult expression = ctx.parseLayerPropertyExpression(value);
+        if (!expression) {
+            error.message = ctx.getCombinedErrors();
+            return nullopt;
+        }
+        assert(*expression);
+        if (!isFeatureConstant(**expression)) {
+            error.message = "data expressions not supported";
+            return nullopt;
+        }
+        if (!isZoomConstant(**expression)) {
+            error.message = "zoom expressions not supported";
+            return nullopt;
+        }
+        return ColorRampPropertyValue(std::move(*expression));
+    } else {
+        error.message = "color ramp must be an expression";
+        return nullopt;
+    }
+}
+
+} // namespace conversion
+} // namespace style
+} // namespace mbgl

--- a/src/mbgl/style/conversion/constant.cpp
+++ b/src/mbgl/style/conversion/constant.cpp
@@ -7,8 +7,8 @@ namespace conversion {
 optional<bool> Converter<bool>::operator()(const Convertible& value, Error& error) const {
     optional<bool> converted = toBool(value);
     if (!converted) {
-        error = { "value must be a boolean" };
-        return {};
+        error.message = "value must be a boolean";
+        return nullopt;
     }
     return *converted;
 }
@@ -16,8 +16,8 @@ optional<bool> Converter<bool>::operator()(const Convertible& value, Error& erro
 optional<float> Converter<float>::operator()(const Convertible& value, Error& error) const {
     optional<float> converted = toNumber(value);
     if (!converted) {
-        error = { "value must be a number" };
-        return {};
+        error.message = "value must be a number";
+        return nullopt;
     }
     return *converted;
 }
@@ -25,8 +25,8 @@ optional<float> Converter<float>::operator()(const Convertible& value, Error& er
 optional<std::string> Converter<std::string>::operator()(const Convertible& value, Error& error) const {
     optional<std::string> converted = toString(value);
     if (!converted) {
-        error = { "value must be a string" };
-        return {};
+        error.message = "value must be a string";
+        return nullopt;
     }
     return *converted;
 }
@@ -34,14 +34,14 @@ optional<std::string> Converter<std::string>::operator()(const Convertible& valu
 optional<Color> Converter<Color>::operator()(const Convertible& value, Error& error) const {
     optional<std::string> string = toString(value);
     if (!string) {
-        error = { "value must be a string" };
-        return {};
+        error.message = "value must be a string";
+        return nullopt;
     }
 
     optional<Color> color = Color::parse(*string);
     if (!color) {
-        error = { "value must be a valid color" };
-        return {};
+        error.message = "value must be a valid color";
+        return nullopt;
     }
 
     return *color;
@@ -49,8 +49,8 @@ optional<Color> Converter<Color>::operator()(const Convertible& value, Error& er
 
 optional<std::vector<float>> Converter<std::vector<float>>::operator()(const Convertible& value, Error& error) const {
     if (!isArray(value)) {
-        error = { "value must be an array" };
-        return {};
+        error.message = "value must be an array";
+        return nullopt;
     }
 
     std::vector<float> result;
@@ -59,8 +59,8 @@ optional<std::vector<float>> Converter<std::vector<float>>::operator()(const Con
     for (std::size_t i = 0; i < arrayLength(value); ++i) {
         optional<float> number = toNumber(arrayMember(value, i));
         if (!number) {
-            error = { "value must be an array of numbers" };
-            return {};
+            error.message = "value must be an array of numbers";
+            return nullopt;
         }
         result.push_back(*number);
     }
@@ -70,8 +70,8 @@ optional<std::vector<float>> Converter<std::vector<float>>::operator()(const Con
 
 optional<std::vector<std::string>> Converter<std::vector<std::string>>::operator()(const Convertible& value, Error& error) const {
     if (!isArray(value)) {
-        error = { "value must be an array" };
-        return {};
+        error.message = "value must be an array";
+        return nullopt;
     }
 
     std::vector<std::string> result;
@@ -80,8 +80,8 @@ optional<std::vector<std::string>> Converter<std::vector<std::string>>::operator
     for (std::size_t i = 0; i < arrayLength(value); ++i) {
         optional<std::string> string = toString(arrayMember(value, i));
         if (!string) {
-            error = { "value must be an array of strings" };
-            return {};
+            error.message = "value must be an array of strings";
+            return nullopt;
         }
         result.push_back(*string);
     }

--- a/src/mbgl/style/conversion/coordinate.cpp
+++ b/src/mbgl/style/conversion/coordinate.cpp
@@ -6,20 +6,20 @@ namespace conversion {
 
 optional<LatLng> Converter<LatLng>::operator() (const Convertible& value, Error& error) const {
     if (!isArray(value) || arrayLength(value) < 2 ) {
-        error = { "coordinate array must contain numeric longitude and latitude values" };
-        return {};
+        error.message = "coordinate array must contain numeric longitude and latitude values";
+        return nullopt;
     }
     //Style spec uses GeoJSON convention for specifying coordinates
     optional<double> latitude = toDouble(arrayMember(value, 1));
     optional<double> longitude = toDouble(arrayMember(value, 0));
 
     if (!latitude || !longitude) {
-        error = { "coordinate array must contain numeric longitude and latitude values" };
-        return {};
+        error.message = "coordinate array must contain numeric longitude and latitude values";
+        return nullopt;
     }
     if (*latitude < -90 || *latitude > 90 ){
-        error = { "coordinate latitude must be between -90 and 90" };
-        return {};
+        error.message = "coordinate latitude must be between -90 and 90";
+        return nullopt;
     }
     return LatLng(*latitude, *longitude);
 }

--- a/src/mbgl/style/conversion/custom_geometry_source_options.cpp
+++ b/src/mbgl/style/conversion/custom_geometry_source_options.cpp
@@ -1,0 +1,75 @@
+#include <mbgl/style/conversion/custom_geometry_source_options.hpp>
+
+namespace mbgl {
+namespace style {
+namespace conversion {
+
+optional<CustomGeometrySource::Options> Converter<CustomGeometrySource::Options>::operator()(const Convertible& value, Error& error) const {
+    CustomGeometrySource::Options options;
+
+    const auto minzoomValue = objectMember(value, "minzoom");
+    if (minzoomValue) {
+        if (toNumber(*minzoomValue)) {
+            options.zoomRange.min = static_cast<uint8_t>(*toNumber(*minzoomValue));
+        } else {
+            error.message = "GeoJSON source minzoom value must be a number";
+            return nullopt;
+        }
+    }
+
+    const auto maxzoomValue = objectMember(value, "maxzoom");
+    if (maxzoomValue) {
+        if (toNumber(*maxzoomValue)) {
+            options.zoomRange.max = static_cast<uint8_t>(*toNumber(*maxzoomValue));
+        } else {
+            error.message = "GeoJSON source maxzoom value must be a number";
+            return nullopt;
+        }
+    }
+
+    const auto bufferValue = objectMember(value, "buffer");
+    if (bufferValue) {
+        if (toNumber(*bufferValue)) {
+            options.tileOptions.buffer = static_cast<uint16_t>(*toNumber(*bufferValue));
+        } else {
+            error.message = "GeoJSON source buffer value must be a number";
+            return nullopt;
+        }
+    }
+
+    const auto toleranceValue = objectMember(value, "tolerance");
+    if (toleranceValue) {
+        if (toNumber(*toleranceValue)) {
+            options.tileOptions.tolerance = static_cast<double>(*toNumber(*toleranceValue));
+        } else {
+            error.message = "GeoJSON source tolerance value must be a number";
+            return nullopt;
+        }
+    }
+
+    const auto wrapValue = objectMember(value, "wrap");
+    if (wrapValue) {
+        if (toBool(*wrapValue)) {
+            options.tileOptions.wrap = static_cast<bool>(*toBool(*wrapValue));
+        } else {
+            error.message = "CustomGeometrySource TileOptions wrap value must be a boolean";
+            return nullopt;
+        }
+    }
+
+    const auto clipValue = objectMember(value, "clip");
+    if (clipValue) {
+        if (toBool(*clipValue)) {
+            options.tileOptions.clip = static_cast<double>(*toBool(*clipValue));
+        } else {
+            error.message = "CustomGeometrySource TileOptiosn clip value must be a boolean";
+            return nullopt;
+        }
+    }
+
+    return options;
+}
+
+} // namespace conversion
+} // namespace style
+} // namespace mbgl

--- a/src/mbgl/style/conversion/filter.cpp
+++ b/src/mbgl/style/conversion/filter.cpp
@@ -9,9 +9,9 @@
 namespace mbgl {
 namespace style {
 namespace conversion {
-    
+
 using namespace mbgl::style::expression;
-    
+
 static bool isExpression(const Convertible& filter);
 ParseResult convertLegacyFilter(const Convertible& values, Error& error);
 optional<mbgl::Value> serializeLegacyFilter(const Convertible& values);
@@ -21,8 +21,8 @@ optional<Filter> Converter<Filter>::operator()(const Convertible& value, Error& 
         ParsingContext parsingContext(type::Boolean);
         ParseResult parseResult = parsingContext.parseExpression(value);
         if (!parseResult) {
-            error = { parsingContext.getCombinedErrors() };
-            return {};
+            error.message = parsingContext.getCombinedErrors();
+            return nullopt;
         } else {
             return { Filter(std::move(parseResult)) };
         }
@@ -30,7 +30,7 @@ optional<Filter> Converter<Filter>::operator()(const Convertible& value, Error& 
         ParseResult expression = convertLegacyFilter(value, error);
         if (!expression) {
             assert(error.message.size() > 0);
-            return {};
+            return nullopt;
         }
         return Filter(optional<std::unique_ptr<Expression>>(std::move(*expression)), serializeLegacyFilter(value));
     }
@@ -41,23 +41,23 @@ bool isExpression(const Convertible& filter) {
     if (!isArray(filter) || arrayLength(filter) == 0) {
         return false;
     }
-    
+
     optional<std::string> op = toString(arrayMember(filter, 0));
-    
+
     if (!op) {
         return false;
-        
+
     } else if (*op == "has") {
         if (arrayLength(filter) < 2) return false;
         optional<std::string> operand = toString(arrayMember(filter, 1));
         return operand && *operand != "$id" && *operand != "$type";
-        
+
     } else if (*op == "in" || *op == "!in" || *op == "!has" || *op == "none") {
         return false;
-        
+
     } else if (*op == "==" || *op == "!=" || *op == ">" || *op == ">=" || *op == "<" || *op == "<=") {
         return arrayLength(filter) != 3 || isArray(arrayMember(filter, 1)) || isArray(arrayMember(filter, 2));
-        
+
     } else if (*op == "any" || *op == "all") {
         for (std::size_t i = 1; i < arrayLength(filter); i++) {
             Convertible f = arrayMember(filter, i);
@@ -66,18 +66,18 @@ bool isExpression(const Convertible& filter) {
             }
         }
         return true;
-        
+
     } else {
         return true;
     }
 }
-    
+
 ParseResult createExpression(std::string op, optional<std::vector<std::unique_ptr<Expression>>> args, Error& error) {
     if (!args) return {};
     assert(std::all_of(args->begin(), args->end(), [](const std::unique_ptr<Expression> &e) {
         return bool(e.get());
     }));
-    
+
     if (op == "any") {
         return {std::make_unique<Any>(std::move(*args))};
     } else if (op == "all") {
@@ -86,7 +86,7 @@ ParseResult createExpression(std::string op, optional<std::vector<std::unique_pt
         ParsingContext parsingContext(type::Boolean);
         ParseResult parseResult = createCompoundExpression(op, std::move(*args), parsingContext);
         if (!parseResult) {
-            error = { parsingContext.getCombinedErrors() };
+            error.message = parsingContext.getCombinedErrors();
             return {};
         } else {
             return parseResult;
@@ -98,7 +98,7 @@ ParseResult createExpression(std::string op, ParseResult arg, Error& error) {
     if (!arg) {
         return {};
     }
-    
+
     std::vector<std::unique_ptr<Expression>> args;
     args.push_back(std::move(*arg));
     return createExpression(op, std::move(args), error);
@@ -110,7 +110,7 @@ ParseResult convertLiteral(const Convertible& convertible, Error& error) {
     if (parseResult) {
         return parseResult;
     } else {
-        error = { parsingContext.getCombinedErrors() };
+        error.message = parsingContext.getCombinedErrors();
         return {};
     }
 }
@@ -120,7 +120,7 @@ optional<std::vector<std::unique_ptr<Expression>>> convertLiteralArray(const Con
     for (std::size_t i = startIndex; i < arrayLength(input); i++) {
         ParseResult literal = convertLiteral(arrayMember(input, i), error);
         if (!literal) {
-            return {};
+            return nullopt;
         }
         output.push_back(std::move(*literal));
     }
@@ -130,9 +130,9 @@ optional<std::vector<std::unique_ptr<Expression>>> convertLiteralArray(const Con
 ParseResult convertLegacyComparisonFilter(const Convertible& values, Error& error, optional<std::string> opOverride = {}) {
     optional<std::string> op = opOverride ? opOverride : toString(arrayMember(values, 0));
     optional<std::string> property = toString(arrayMember(values, 1));
-    
+
     if (!property) {
-        error = { "filter property must be a string" };
+        error.message = "filter property must be a string";
         return {};
     } else if (*property == "$type") {
         return createExpression("filter-type-" + *op, convertLiteralArray(values, error, 2), error);
@@ -142,12 +142,12 @@ ParseResult convertLegacyComparisonFilter(const Convertible& values, Error& erro
         return createExpression("filter-" + *op, convertLiteralArray(values, error, 1), error);
     }
 }
-    
+
 ParseResult convertLegacyHasFilter(const Convertible& values, Error& error) {
     optional<std::string> property = toString(arrayMember(values, 1));
-    
+
     if (!property) {
-        error = { "filter property must be a string" };
+        error.message = "filter property must be a string";
         return {};
     } else if (*property == "$type") {
         return {std::make_unique<Literal>(true)};
@@ -160,9 +160,9 @@ ParseResult convertLegacyHasFilter(const Convertible& values, Error& error) {
 
 ParseResult convertLegacyInFilter(const Convertible& values, Error& error) {
     optional<std::string> property = toString(arrayMember(values, 1));
-    
+
     if (!property) {
-        error = { "filter property must be a string" };
+        error.message = "filter property must be a string";
         return {};
     } else if (arrayLength(values) == 0) {
         return {std::make_unique<Literal>(false)};
@@ -180,22 +180,22 @@ optional<std::vector<std::unique_ptr<Expression>>> convertLegacyFilterArray(cons
     for (std::size_t i = startIndex; i < arrayLength(input); i++) {
         optional<std::unique_ptr<Expression>> child = convertLegacyFilter(arrayMember(input, i), error);
         if (!child) {
-            return {};
+            return nullopt;
         }
         output.push_back(std::move(*child));
     }
     return {std::move(output)};
 }
-    
+
 ParseResult convertLegacyFilter(const Convertible& values, Error& error) {
     if (isUndefined(values)) {
         return {std::make_unique<Literal>(true)};
     }
-    
+
     optional<std::string> op = toString(arrayMember(values, 0));
 
     if (!op) {
-        error = { "filter operator must be a string" };
+        error.message = "filter operator must be a string";
         return {};
     } else if (arrayLength(values) <= 1) {
         return {std::make_unique<Literal>(*op != "any")};
@@ -221,7 +221,7 @@ ParseResult convertLegacyFilter(const Convertible& values, Error& error) {
 
 optional<mbgl::Value> serializeLegacyFilter(const Convertible& values) {
     if (isUndefined(values)) {
-        return {};
+        return nullopt;
     } else if (isArray(values)) {
         std::vector<mbgl::Value> result;
         for (std::size_t i = 0; i < arrayLength(values); i++) {

--- a/src/mbgl/style/conversion/geojson_options.cpp
+++ b/src/mbgl/style/conversion/geojson_options.cpp
@@ -12,8 +12,8 @@ optional<GeoJSONOptions> Converter<GeoJSONOptions>::operator()(const Convertible
         if (toNumber(*minzoomValue)) {
             options.minzoom = static_cast<uint8_t>(*toNumber(*minzoomValue));
         } else {
-            error = { "GeoJSON source minzoom value must be a number" };
-            return {};
+            error.message = "GeoJSON source minzoom value must be a number";
+            return nullopt;
         }
     }
 
@@ -22,8 +22,8 @@ optional<GeoJSONOptions> Converter<GeoJSONOptions>::operator()(const Convertible
         if (toNumber(*maxzoomValue)) {
             options.maxzoom = static_cast<uint8_t>(*toNumber(*maxzoomValue));
         } else {
-            error = { "GeoJSON source maxzoom value must be a number" };
-            return {};
+            error.message = "GeoJSON source maxzoom value must be a number";
+            return nullopt;
         }
     }
 
@@ -32,8 +32,8 @@ optional<GeoJSONOptions> Converter<GeoJSONOptions>::operator()(const Convertible
         if (toNumber(*bufferValue)) {
             options.buffer = static_cast<uint16_t>(*toNumber(*bufferValue));
         } else {
-            error = { "GeoJSON source buffer value must be a number" };
-            return {};
+            error.message = "GeoJSON source buffer value must be a number";
+            return nullopt;
         }
     }
 
@@ -42,8 +42,8 @@ optional<GeoJSONOptions> Converter<GeoJSONOptions>::operator()(const Convertible
         if (toNumber(*toleranceValue)) {
             options.tolerance = static_cast<double>(*toNumber(*toleranceValue));
         } else {
-            error = { "GeoJSON source tolerance value must be a number" };
-            return {};
+            error.message = "GeoJSON source tolerance value must be a number";
+            return nullopt;
         }
     }
 
@@ -52,8 +52,8 @@ optional<GeoJSONOptions> Converter<GeoJSONOptions>::operator()(const Convertible
         if (toBool(*clusterValue)) {
             options.cluster = *toBool(*clusterValue);
         } else {
-            error = { "GeoJSON source cluster value must be a boolean" };
-            return {};
+            error.message = "GeoJSON source cluster value must be a boolean";
+            return nullopt;
         }
     }
 
@@ -62,8 +62,8 @@ optional<GeoJSONOptions> Converter<GeoJSONOptions>::operator()(const Convertible
         if (toNumber(*clusterMaxZoomValue)) {
             options.clusterMaxZoom = static_cast<uint8_t>(*toNumber(*clusterMaxZoomValue));
         } else {
-            error = { "GeoJSON source clusterMaxZoom value must be a number" };
-            return {};
+            error.message = "GeoJSON source clusterMaxZoom value must be a number";
+            return nullopt;
         }
     }
 
@@ -72,8 +72,8 @@ optional<GeoJSONOptions> Converter<GeoJSONOptions>::operator()(const Convertible
         if (toNumber(*clusterRadiusValue)) {
             options.clusterRadius = static_cast<double>(*toNumber(*clusterRadiusValue));
         } else {
-            error = { "GeoJSON source clusterRadius value must be a number" };
-            return {};
+            error.message = "GeoJSON source clusterRadius value must be a number";
+            return nullopt;
         }
     }
 

--- a/src/mbgl/style/conversion/layer.cpp
+++ b/src/mbgl/style/conversion/layer.cpp
@@ -37,7 +37,7 @@ optional<Error> setPaintProperty(Layer& layer, const std::string& name, const Co
 optional<Error> setPaintProperties(Layer& layer, const Convertible& value) {
     auto paintValue = objectMember(value, "paint");
     if (!paintValue) {
-        return {};
+        return nullopt;
     }
     if (!isObject(*paintValue)) {
         return { { "paint must be an object" } };
@@ -51,14 +51,14 @@ template <class LayerType>
 optional<std::unique_ptr<Layer>> convertVectorLayer(const std::string& id, const Convertible& value, Error& error) {
     auto sourceValue = objectMember(value, "source");
     if (!sourceValue) {
-        error = { "layer must have a source" };
-        return {};
+        error.message = "layer must have a source";
+        return nullopt;
     }
 
     optional<std::string> source = toString(*sourceValue);
     if (!source) {
-        error = { "layer source must be a string" };
-        return {};
+        error.message = "layer source must be a string";
+        return nullopt;
     }
 
     std::unique_ptr<LayerType> layer = std::make_unique<LayerType>(id, *source);
@@ -67,8 +67,8 @@ optional<std::unique_ptr<Layer>> convertVectorLayer(const std::string& id, const
     if (sourceLayerValue) {
         optional<std::string> sourceLayer = toString(*sourceLayerValue);
         if (!sourceLayer) {
-            error = { "layer source-layer must be a string" };
-            return {};
+            error.message = "layer source-layer must be a string";
+            return nullopt;
         }
         layer->setSourceLayer(*sourceLayer);
     }
@@ -77,7 +77,7 @@ optional<std::unique_ptr<Layer>> convertVectorLayer(const std::string& id, const
     if (filterValue) {
         optional<Filter> filter = convert<Filter>(*filterValue, error);
         if (!filter) {
-            return {};
+            return nullopt;
         }
         layer->setFilter(*filter);
     }
@@ -88,14 +88,14 @@ optional<std::unique_ptr<Layer>> convertVectorLayer(const std::string& id, const
 static optional<std::unique_ptr<Layer>> convertRasterLayer(const std::string& id, const Convertible& value, Error& error) {
     auto sourceValue = objectMember(value, "source");
     if (!sourceValue) {
-        error = { "layer must have a source" };
-        return {};
+        error.message = "layer must have a source";
+        return nullopt;
     }
 
     optional<std::string> source = toString(*sourceValue);
     if (!source) {
-        error = { "layer source must be a string" };
-        return {};
+        error.message = "layer source must be a string";
+        return nullopt;
     }
 
     return { std::make_unique<RasterLayer>(id, *source) };
@@ -104,14 +104,14 @@ static optional<std::unique_ptr<Layer>> convertRasterLayer(const std::string& id
 static optional<std::unique_ptr<Layer>> convertHillshadeLayer(const std::string& id, const Convertible& value, Error& error) {
     auto sourceValue = objectMember(value, "source");
     if (!sourceValue) {
-        error = { "layer must have a source" };
-        return {};
+        error.message = "layer must have a source";
+        return nullopt;
     }
 
     optional<std::string> source = toString(*sourceValue);
     if (!source) {
-        error = { "layer source must be a string" };
-        return {};
+        error.message = "layer source must be a string";
+        return nullopt;
     }
 
     return { std::make_unique<HillshadeLayer>(id, *source) };
@@ -124,32 +124,32 @@ static optional<std::unique_ptr<Layer>> convertBackgroundLayer(const std::string
 
 optional<std::unique_ptr<Layer>> Converter<std::unique_ptr<Layer>>::operator()(const Convertible& value, Error& error) const {
     if (!isObject(value)) {
-        error = { "layer must be an object" };
-        return {};
+        error.message = "layer must be an object";
+        return nullopt;
     }
 
     auto idValue = objectMember(value, "id");
     if (!idValue) {
-        error = { "layer must have an id" };
-        return {};
+        error.message = "layer must have an id";
+        return nullopt;
     }
 
     optional<std::string> id = toString(*idValue);
     if (!id) {
-        error = { "layer id must be a string" };
-        return {};
+        error.message = "layer id must be a string";
+        return nullopt;
     }
 
     auto typeValue = objectMember(value, "type");
     if (!typeValue) {
-        error = { "layer must have a type" };
-        return {};
+        error.message = "layer must have a type";
+        return nullopt;
     }
 
     optional<std::string> type = toString(*typeValue);
     if (!type) {
-        error = { "layer type must be a string" };
-        return {};
+        error.message = "layer type must be a string";
+        return nullopt;
     }
 
     optional<std::unique_ptr<Layer>> converted;
@@ -173,8 +173,8 @@ optional<std::unique_ptr<Layer>> Converter<std::unique_ptr<Layer>>::operator()(c
     } else if (*type == "background") {
         converted = convertBackgroundLayer(*id, value, error);
     } else {
-        error = { "invalid layer type" };
-        return {};
+        error.message = "invalid layer type";
+        return nullopt;
     }
 
     if (!converted) {
@@ -187,8 +187,8 @@ optional<std::unique_ptr<Layer>> Converter<std::unique_ptr<Layer>>::operator()(c
     if (minzoomValue) {
         optional<float> minzoom = toNumber(*minzoomValue);
         if (!minzoom) {
-            error = { "minzoom must be numeric" };
-            return {};
+            error.message = "minzoom must be numeric";
+            return nullopt;
         }
         layer->setMinZoom(*minzoom);
     }
@@ -197,8 +197,8 @@ optional<std::unique_ptr<Layer>> Converter<std::unique_ptr<Layer>>::operator()(c
     if (maxzoomValue) {
         optional<float> maxzoom = toNumber(*maxzoomValue);
         if (!maxzoom) {
-            error = { "maxzoom must be numeric" };
-            return {};
+            error.message = "maxzoom must be numeric";
+            return nullopt;
         }
         layer->setMaxZoom(*maxzoom);
     }
@@ -206,22 +206,22 @@ optional<std::unique_ptr<Layer>> Converter<std::unique_ptr<Layer>>::operator()(c
     auto layoutValue = objectMember(value, "layout");
     if (layoutValue) {
         if (!isObject(*layoutValue)) {
-            error = { "layout must be an object" };
-            return {};
+            error.message = "layout must be an object";
+            return nullopt;
         }
         optional<Error> error_ = eachMember(*layoutValue, [&] (const std::string& k, const Convertible& v) {
             return setLayoutProperty(*layer, k, v);
         });
         if (error_) {
             error = *error_;
-            return {};
+            return nullopt;
         }
     }
 
     optional<Error> error_ = setPaintProperties(*layer, value);
     if (error_) {
         error = *error_;
-        return {};
+        return nullopt;
     }
 
     return std::move(layer);

--- a/src/mbgl/style/conversion/light.cpp
+++ b/src/mbgl/style/conversion/light.cpp
@@ -9,8 +9,8 @@ namespace conversion {
 
 optional<Light> Converter<Light>::operator()(const Convertible& value, Error& error) const {
     if (!isObject(value)) {
-        error = { "light must be an object" };
-        return {};
+        error.message = "light must be an object";
+        return nullopt;
     }
 
     Light light;
@@ -23,7 +23,7 @@ optional<Light> Converter<Light>::operator()(const Convertible& value, Error& er
         if (convertedAnchor) {
             light.setAnchor(*convertedAnchor);
         } else {
-            return {};
+            return nullopt;
         }
     }
 
@@ -34,7 +34,7 @@ optional<Light> Converter<Light>::operator()(const Convertible& value, Error& er
         if (transition) {
             light.setAnchorTransition(*transition);
         } else {
-            return {};
+            return nullopt;
         }
     }
 
@@ -46,7 +46,7 @@ optional<Light> Converter<Light>::operator()(const Convertible& value, Error& er
         if (convertedColor) {
             light.setColor(*convertedColor);
         } else {
-            return {};
+            return nullopt;
         }
     }
 
@@ -57,7 +57,7 @@ optional<Light> Converter<Light>::operator()(const Convertible& value, Error& er
         if (transition) {
             light.setColorTransition(*transition);
         } else {
-            return {};
+            return nullopt;
         }
     }
 
@@ -69,7 +69,7 @@ optional<Light> Converter<Light>::operator()(const Convertible& value, Error& er
         if (convertedPosition) {
             light.setPosition(*convertedPosition);
         } else {
-            return {};
+            return nullopt;
         }
     }
 
@@ -80,7 +80,7 @@ optional<Light> Converter<Light>::operator()(const Convertible& value, Error& er
         if (transition) {
             light.setPositionTransition(*transition);
         } else {
-            return {};
+            return nullopt;
         }
     }
 
@@ -92,7 +92,7 @@ optional<Light> Converter<Light>::operator()(const Convertible& value, Error& er
         if (convertedIntensity) {
             light.setIntensity(*convertedIntensity);
         } else {
-            return {};
+            return nullopt;
         }
     }
 
@@ -103,7 +103,7 @@ optional<Light> Converter<Light>::operator()(const Convertible& value, Error& er
         if (transition) {
             light.setIntensityTransition(*transition);
         } else {
-            return {};
+            return nullopt;
         }
     }
 

--- a/src/mbgl/style/conversion/position.cpp
+++ b/src/mbgl/style/conversion/position.cpp
@@ -11,7 +11,7 @@ optional<Position> Converter<Position>::operator()(const Convertible& value, Err
     optional<std::array<float, 3>> spherical = convert<std::array<float, 3>>(value, error);
 
     if (!spherical) {
-        return {};
+        return nullopt;
     }
 
     return Position(*spherical);

--- a/src/mbgl/style/conversion/property_setter.hpp
+++ b/src/mbgl/style/conversion/property_setter.hpp
@@ -31,7 +31,7 @@ optional<Error> setProperty(Layer& layer, const Convertible& value) {
     }
 
     (typedLayer->*setter)(*typedValue);
-    return {};
+    return nullopt;
 }
 
 template <class L, void (L::*setter)(const TransitionOptions&)>
@@ -48,13 +48,13 @@ optional<Error> setTransition(Layer& layer, const Convertible& value) {
     }
 
     (typedLayer->*setter)(*transition);
-    return {};
+    return nullopt;
 }
 
 inline optional<Error> setVisibility(Layer& layer, const Convertible& value) {
     if (isUndefined(value)) {
         layer.setVisibility(VisibilityType::Visible);
-        return {};
+        return nullopt;
     }
 
     Error error;
@@ -64,7 +64,7 @@ inline optional<Error> setVisibility(Layer& layer, const Convertible& value) {
     }
 
     layer.setVisibility(*visibility);
-    return {};
+    return nullopt;
 }
 
 } // namespace conversion

--- a/src/mbgl/style/conversion/source.cpp
+++ b/src/mbgl/style/conversion/source.cpp
@@ -20,15 +20,15 @@ static optional<variant<std::string, Tileset>> convertURLOrTileset(const Convert
     if (!urlVal) {
         optional<Tileset> tileset = convert<Tileset>(value, error);
         if (!tileset) {
-            return {};
+            return nullopt;
         }
         return { *tileset };
     }
 
     optional<std::string> url = toString(*urlVal);
     if (!url) {
-        error = { "source url must be a string" };
-        return {};
+        error.message = "source url must be a string";
+        return nullopt;
     }
 
     return { *url };
@@ -39,7 +39,7 @@ static optional<std::unique_ptr<Source>> convertRasterSource(const std::string& 
                                                              Error& error) {
     optional<variant<std::string, Tileset>> urlOrTileset = convertURLOrTileset(value, error);
     if (!urlOrTileset) {
-        return {};
+        return nullopt;
     }
 
     uint16_t tileSize = util::tileSize;
@@ -47,8 +47,8 @@ static optional<std::unique_ptr<Source>> convertRasterSource(const std::string& 
     if (tileSizeValue) {
         optional<float> size = toNumber(*tileSizeValue);
         if (!size || *size < 0 || *size > std::numeric_limits<uint16_t>::max()) {
-            error = { "invalid tileSize" };
-            return {};
+            error.message = "invalid tileSize";
+            return nullopt;
         }
         tileSize = *size;
     }
@@ -61,7 +61,7 @@ static optional<std::unique_ptr<Source>> convertRasterDEMSource(const std::strin
                                                              Error& error) {
     optional<variant<std::string, Tileset>> urlOrTileset = convertURLOrTileset(value, error);
     if (!urlOrTileset) {
-        return {};
+        return nullopt;
     }
 
     uint16_t tileSize = util::tileSize;
@@ -69,8 +69,8 @@ static optional<std::unique_ptr<Source>> convertRasterDEMSource(const std::strin
     if (tileSizeValue) {
         optional<float> size = toNumber(*tileSizeValue);
         if (!size || *size < 0 || *size > std::numeric_limits<uint16_t>::max()) {
-            error = { "invalid tileSize" };
-            return {};
+            error.message = "invalid tileSize";
+            return nullopt;
         }
         tileSize = *size;
     }
@@ -83,7 +83,7 @@ static optional<std::unique_ptr<Source>> convertVectorSource(const std::string& 
                                                              Error& error) {
     optional<variant<std::string, Tileset>> urlOrTileset = convertURLOrTileset(value, error);
     if (!urlOrTileset) {
-        return {};
+        return nullopt;
     }
 
     return { std::make_unique<VectorSource>(id, std::move(*urlOrTileset)) };
@@ -94,13 +94,13 @@ static optional<std::unique_ptr<Source>> convertGeoJSONSource(const std::string&
                                                               Error& error) {
     auto dataValue = objectMember(value, "data");
     if (!dataValue) {
-        error = { "GeoJSON source must have a data value" };
-        return {};
+        error.message = "GeoJSON source must have a data value";
+        return nullopt;
     }
 
     optional<GeoJSONOptions> options = convert<GeoJSONOptions>(value, error);
     if (!options) {
-        return {};
+        return nullopt;
     }
 
     auto result = std::make_unique<GeoJSONSource>(id, *options);
@@ -108,14 +108,14 @@ static optional<std::unique_ptr<Source>> convertGeoJSONSource(const std::string&
     if (isObject(*dataValue)) {
         optional<GeoJSON> geoJSON = convert<GeoJSON>(*dataValue, error);
         if (!geoJSON) {
-            return {};
+            return nullopt;
         }
         result->setGeoJSON(std::move(*geoJSON));
     } else if (toString(*dataValue)) {
         result->setURL(*toString(*dataValue));
     } else {
-        error = { "GeoJSON data must be a URL or an object" };
-        return {};
+        error.message = "GeoJSON data must be a URL or an object";
+        return nullopt;
     }
 
     return { std::move(result) };
@@ -126,32 +126,32 @@ static optional<std::unique_ptr<Source>> convertImageSource(const std::string& i
                                                             Error& error) {
     auto urlValue = objectMember(value, "url");
     if (!urlValue) {
-        error = { "Image source must have a url value" };
-        return {};
+        error.message = "Image source must have a url value";
+        return nullopt;
     }
-    
+
     auto urlString = toString(*urlValue);
     if (!urlString) {
-        error = { "Image url must be a URL string" };
-        return {};
+        error.message = "Image url must be a URL string";
+        return nullopt;
     }
-    
+
     auto coordinatesValue = objectMember(value, "coordinates");
     if (!coordinatesValue) {
-        error = { "Image source must have a coordinates values" };
-        return {};
+        error.message = "Image source must have a coordinates values";
+        return nullopt;
     }
-    
+
     if (!isArray(*coordinatesValue) || arrayLength(*coordinatesValue) != 4) {
-        error = { "Image coordinates must be an array of four longitude latitude pairs" };
-        return {};
+        error.message = "Image coordinates must be an array of four longitude latitude pairs";
+        return nullopt;
     }
-    
+
     std::array<LatLng, 4> coordinates;
     for (std::size_t i=0; i < 4; i++) {
         auto latLng = conversion::convert<LatLng>(arrayMember(*coordinatesValue,i), error);
         if (!latLng) {
-            return {};
+            return nullopt;
         }
         coordinates[i] = *latLng;
     }
@@ -163,20 +163,20 @@ static optional<std::unique_ptr<Source>> convertImageSource(const std::string& i
 
 optional<std::unique_ptr<Source>> Converter<std::unique_ptr<Source>>::operator()(const Convertible& value, Error& error, const std::string& id) const {
     if (!isObject(value)) {
-        error = { "source must be an object" };
-        return {};
+        error.message = "source must be an object";
+        return nullopt;
     }
 
     auto typeValue = objectMember(value, "type");
     if (!typeValue) {
-        error = { "source must have a type" };
-        return {};
+        error.message = "source must have a type";
+        return nullopt;
     }
 
     optional<std::string> type = toString(*typeValue);
     if (!type) {
-        error = { "source type must be a string" };
-        return {};
+        error.message = "source type must be a string";
+        return nullopt;
     }
     const std::string tname = *type;
     if (*type == "raster") {
@@ -190,8 +190,8 @@ optional<std::unique_ptr<Source>> Converter<std::unique_ptr<Source>>::operator()
     } else if (*type == "image") {
         return convertImageSource(id, value, error);
     } else {
-        error = { "invalid source type" };
-        return {};
+        error.message = "invalid source type";
+        return nullopt;
     }
 }
 

--- a/src/mbgl/style/conversion/tileset.cpp
+++ b/src/mbgl/style/conversion/tileset.cpp
@@ -11,20 +11,20 @@ optional<Tileset> Converter<Tileset>::operator()(const Convertible& value, Error
 
     auto tiles = objectMember(value, "tiles");
     if (!tiles) {
-        error = { "source must have tiles" };
-        return {};
+        error.message = "source must have tiles";
+        return nullopt;
     }
 
     if (!isArray(*tiles)) {
-        error = { "source tiles must be an array" };
-        return {};
+        error.message = "source tiles must be an array";
+        return nullopt;
     }
 
     for (std::size_t i = 0; i < arrayLength(*tiles); i++) {
         optional<std::string> urlTemplate = toString(arrayMember(*tiles, i));
         if (!urlTemplate) {
-            error = { "source tiles member must be a string" };
-            return {};
+            error.message = "source tiles member must be a string";
+            return nullopt;
         }
         result.tiles.push_back(std::move(*urlTemplate));
     }
@@ -43,7 +43,7 @@ optional<Tileset> Converter<Tileset>::operator()(const Convertible& value, Error
         if (encoding && *encoding == "terrarium") {
             result.encoding = Tileset::DEMEncoding::Terrarium;
         } else if (encoding && *encoding != "mapbox") {
-            error = { "invalid raster-dem encoding type - valid types are 'mapbox' and 'terrarium' " };
+            error.message = "invalid raster-dem encoding type - valid types are 'mapbox' and 'terrarium' ";
         }
     }
 
@@ -51,8 +51,8 @@ optional<Tileset> Converter<Tileset>::operator()(const Convertible& value, Error
     if (minzoomValue) {
         optional<float> minzoom = toNumber(*minzoomValue);
         if (!minzoom || *minzoom < 0 || *minzoom > std::numeric_limits<uint8_t>::max()) {
-            error = { "invalid minzoom" };
-            return {};
+            error.message = "invalid minzoom";
+            return nullopt;
         }
         result.zoomRange.min = *minzoom;
     }
@@ -61,8 +61,8 @@ optional<Tileset> Converter<Tileset>::operator()(const Convertible& value, Error
     if (maxzoomValue) {
         optional<float> maxzoom = toNumber(*maxzoomValue);
         if (!maxzoom || *maxzoom < 0 || *maxzoom > std::numeric_limits<uint8_t>::max()) {
-            error = { "invalid maxzoom" };
-            return {};
+            error.message = "invalid maxzoom";
+            return nullopt;
         }
         result.zoomRange.max = *maxzoom;
     }
@@ -71,8 +71,8 @@ optional<Tileset> Converter<Tileset>::operator()(const Convertible& value, Error
     if (attributionValue) {
         optional<std::string> attribution = toString(*attributionValue);
         if (!attribution) {
-            error = { "source attribution must be a string" };
-            return {};
+            error.message = "source attribution must be a string";
+            return nullopt;
         }
         result.attribution = std::move(*attribution);
     }
@@ -80,8 +80,8 @@ optional<Tileset> Converter<Tileset>::operator()(const Convertible& value, Error
     auto boundsValue = objectMember(value, "bounds");
     if (boundsValue) {
         if (!isArray(*boundsValue) || arrayLength(*boundsValue) != 4) {
-            error = { "bounds must be an array with left, bottom, top, and right values" };
-            return {};
+            error.message = "bounds must be an array with left, bottom, top, and right values";
+            return nullopt;
         }
         optional<double> left = toDouble(arrayMember(*boundsValue, 0));
         optional<double> bottom = toDouble(arrayMember(*boundsValue, 1));
@@ -89,20 +89,20 @@ optional<Tileset> Converter<Tileset>::operator()(const Convertible& value, Error
         optional<double> top = toDouble(arrayMember(*boundsValue, 3));
 
         if (!left || !right || !bottom || !top) {
-            error = { "bounds array must contain numeric longitude and latitude values" };
-            return {};
+            error.message = "bounds array must contain numeric longitude and latitude values";
+            return nullopt;
         }
 
         bottom = util::clamp(*bottom, -90.0, 90.0);
         top = util::clamp(*top, -90.0, 90.0);
         if (top <= bottom){
-            error = { "bounds bottom latitude must be smaller than top latitude" };
-            return {};
+            error.message = "bounds bottom latitude must be smaller than top latitude";
+            return nullopt;
         }
 
         if(*left >= *right) {
-            error = { "bounds left longitude should be less than right longitude" };
-            return {};
+            error.message = "bounds left longitude should be less than right longitude";
+            return nullopt;
         }
         left = util::max(-180.0, *left);
         right = util::min(180.0, *right);

--- a/src/mbgl/style/conversion/transition_options.cpp
+++ b/src/mbgl/style/conversion/transition_options.cpp
@@ -6,8 +6,8 @@ namespace conversion {
 
 optional<TransitionOptions> Converter<TransitionOptions>::operator()(const Convertible& value, Error& error) const {
     if (!isObject(value)) {
-        error = { "transition must be an object" };
-        return {};
+        error.message = "transition must be an object";
+        return nullopt;
     }
 
     optional<TransitionOptions> result = TransitionOptions{};
@@ -16,8 +16,8 @@ optional<TransitionOptions> Converter<TransitionOptions>::operator()(const Conve
     if (duration) {
         auto number = toNumber(*duration);
         if (!number) {
-            error = { "duration must be a number" };
-            return {};
+            error.message = "duration must be a number";
+            return nullopt;
         }
         result->duration = { std::chrono::milliseconds(int64_t(*number)) };
     }
@@ -26,8 +26,8 @@ optional<TransitionOptions> Converter<TransitionOptions>::operator()(const Conve
     if (delay) {
         auto number = toNumber(*delay);
         if (!number) {
-            error = { "delay must be a number" };
-            return {};
+            error.message = "delay must be a number";
+            return nullopt;
         }
         result->delay = { std::chrono::milliseconds(int64_t(*number)) };
     }


### PR DESCRIPTION
* `return {}` → `return nullopt`
* `error = { "..." }` → `error.message = "..."`