### PR TITLE
Re-implement "avoid edges" for MapMode::Tile

### DIFF
--- a/src/mbgl/text/collision_index.hpp
+++ b/src/mbgl/text/collision_index.hpp
@@ -3,13 +3,18 @@
 #include <mbgl/geometry/feature_index.hpp>
 #include <mbgl/text/collision_feature.hpp>
 #include <mbgl/util/grid_index.hpp>
+#include <mbgl/util/optional.hpp>
 #include <mbgl/map/transform_state.hpp>
+
+#include <array>
 
 namespace mbgl {
 
 class PlacedSymbol;
 
 struct TileDistance;
+    
+using CollisionTileBoundaries = std::array<float,4>;
 
 class CollisionIndex {
 public:
@@ -26,15 +31,19 @@ public:
                                       const float fontSize,
                                       const bool allowOverlap,
                                       const bool pitchWithMap,
-                                      const bool collisionDebug);
+                                      const bool collisionDebug,
+                                      const optional<CollisionTileBoundaries>& avoidEdges);
 
     void insertFeature(CollisionFeature& feature, bool ignorePlacement, uint32_t bucketInstanceId);
 
     std::unordered_map<uint32_t, std::vector<IndexedSubfeature>> queryRenderedSymbols(const ScreenLineString&) const;
+    
+    CollisionTileBoundaries projectTileBoundaries(const mat4& posMatrix) const;
 
 private:
     bool isOffscreen(const CollisionBox&) const;
     bool isInsideGrid(const CollisionBox&) const;
+    bool isInsideTile(const CollisionBox&, const CollisionTileBoundaries& tileBoundaries) const;
 
     std::pair<bool,bool> placeLineFeature(CollisionFeature& feature,
                                   const mat4& posMatrix,
@@ -45,7 +54,8 @@ private:
                                   const float fontSize,
                                   const bool allowOverlap,
                                   const bool pitchWithMap,
-                                  const bool collisionDebug);
+                                  const bool collisionDebug,
+                                  const optional<CollisionTileBoundaries>& avoidEdges);
     
     float approximateTileDistance(const TileDistance& tileDistance, const float lastSegmentAngle, const float pixelsToTileUnits, const float cameraToAnchorDistance, const bool pitchWithMap);
     

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -110,6 +110,13 @@ void Placement::placeLayerBucket(
     auto partiallyEvaluatedTextSize = bucket.textSizeBinder->evaluateForZoom(state.getZoom());
     auto partiallyEvaluatedIconSize = bucket.iconSizeBinder->evaluateForZoom(state.getZoom());
 
+    optional<CollisionTileBoundaries> avoidEdges;
+    if (mapMode == MapMode::Tile &&
+        (bucket.layout.get<style::SymbolAvoidEdges>() ||
+         bucket.layout.get<style::SymbolPlacement>() == style::SymbolPlacementType::Line)) {
+        avoidEdges = collisionIndex.projectTileBoundaries(posMatrix);
+    }
+    
     for (auto& symbolInstance : bucket.symbolInstances) {
 
         if (seenCrossTileIDs.count(symbolInstance.crossTileID) == 0) {
@@ -133,7 +140,7 @@ void Placement::placeLayerBucket(
                         placedSymbol, scale, fontSize,
                         bucket.layout.get<style::TextAllowOverlap>(),
                         bucket.layout.get<style::TextPitchAlignment>() == style::AlignmentType::Map,
-                        showCollisionBoxes);
+                        showCollisionBoxes, avoidEdges);
                 placeText = placed.first;
                 offscreen &= placed.second;
             }
@@ -147,7 +154,7 @@ void Placement::placeLayerBucket(
                         placedSymbol, scale, fontSize,
                         bucket.layout.get<style::IconAllowOverlap>(),
                         bucket.layout.get<style::IconPitchAlignment>() == style::AlignmentType::Map,
-                        showCollisionBoxes);
+                        showCollisionBoxes, avoidEdges);
                 placeIcon = placed.first;
                 offscreen &= placed.second;
             }


### PR DESCRIPTION
 Fixes issue #12461.
 - Only implement "avoid edges" in MapMode::Tile since it's no longer relevant in Static or Continuous mode.
 - New: Force "avoid edges" to "true" for line labels, since in tile mode they'll always clip poorly at tile boundaries.
 - Remove unused "withinPlus0/inside" logic.

In terms of performance, for continuous-rendered maps that don't care, this is an extra boolean-ish check for each symbol at placement time -- should be pretty negligible. For tiled maps, there's an extra check against the tile boundaries but it doesn't involve much extra projection and it might even be a performance win in that it will allow more collision-detection to early-exit near tile boundaries.

Open questions:
- [x] Is it OK to force `avoidEdges: true` for line labels? I'm counting on `MapMode::Tile` being a special case (i.e. api-gl) where this makes sense.
- [x] What further testing do we need? The tile-mode render test is the only real testing I've done of this because I don't have an easy way to run an api-gl staging version.
- [x] Am I right that the "withinPlus0" logic still doesn't do anything even with this re-implemented?
- [x] Am I leaving a trap for future maintainers by implying that it's easy to check against tile boundaries without building in strong checking that limits the logic to tiled (i.e. 0-pitch/0-bearing) mode? Maybe just add an assert in `isInsideTile`?

cc @ansis @ian29 @lilykaiser 