### PR TITLE
[ios] Fix location manager null reset.

### DIFF
--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -303,9 +303,8 @@ MGL_EXPORT IB_DESIGNABLE
  To receive the current user location, implement the `-[MGLMapViewDelegate mapView:didUpdateUserLocation:]`
  and `-[MGLMapViewDelegate mapView:didFailToLocateUserWithError:]` methods.
  
- If setting this property to `nil` and setting `showsUserLocation` to `YES`, or
- if no custom manager is provided this property is set to the default
- location manager.
+ If setting this property to `nil` or if no custom manager is provided this property
+ is set to the default location manager.
  
  `MGLMapView` uses a default location manager. If you want to substitute your own
  location manager, you should do so by setting this property before setting

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -436,6 +436,9 @@ public:
         _isWaitingForRedundantReachableNotification = YES;
     }
     [_reachability startNotifier];
+    
+    // setup default location manager
+    self.locationManager = nil;
 
     // Set up annotation management and selection state.
     _annotationImagesByIdentifier = [NSMutableDictionary dictionary];
@@ -695,8 +698,10 @@ public:
     [self.attributionButtonConstraints removeAllObjects];
     self.attributionButtonConstraints = nil;
     
+    [self.locationManager stopUpdatingLocation];
+    [self.locationManager stopUpdatingHeading];
     self.locationManager.delegate = nil;
-    self.locationManager = nil;
+
 }
 
 - (void)setDelegate:(nullable id<MGLMapViewDelegate>)delegate
@@ -4690,13 +4695,15 @@ public:
 
 #pragma mark - User Location -
 
-- (void)setLocationManager:(id<MGLLocationManager>)locationManager
+- (void)setLocationManager:(nullable id<MGLLocationManager>)locationManager
 {
     if (!locationManager) {
-        [self.locationManager stopUpdatingLocation];
-        [self.locationManager stopUpdatingHeading];
+        locationManager = [[MGLCLLocationManager alloc] init];
     }
-    self.locationManager.delegate = nil;
+    [_locationManager stopUpdatingLocation];
+    [_locationManager stopUpdatingHeading];
+    _locationManager.delegate = nil;
+    
     _locationManager = locationManager;
     _locationManager.delegate = self;
 }
@@ -4707,11 +4714,6 @@ public:
 
     if (shouldEnableLocationServices)
     {
-        // If no custom location manager is provided will use the internal implementation.
-        if (!self.locationManager) {
-            self.locationManager = [[MGLCLLocationManager alloc] init];
-        }
-
         if (self.locationManager.authorizationStatus == kCLAuthorizationStatusNotDetermined)
         {
             BOOL requiresWhenInUseUsageDescription = [NSProcessInfo.processInfo isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){11,0,0}];
@@ -4743,7 +4745,6 @@ public:
             }
         }
 
-        self.locationManager.delegate = self;
         [self.locationManager startUpdatingLocation];
 
         [self validateUserHeadingUpdating];


### PR DESCRIPTION
Reseting the location manager property from `MGLMapView` should not be tied to enabling the user location. If a user nils the property it should reset to the default implementation like setting a style.