### PR TITLE
[Qt] Accept JSON as property value

### DIFF
--- a/platform/qt/app/mapwindow.cpp
+++ b/platform/qt/app/mapwindow.cpp
@@ -229,7 +229,21 @@ void MapWindow::keyPressEvent(QKeyEvent *ev)
 
             m_map->setFilter("3d-buildings", buildingsFilterExpression);
 
-            m_map->setPaintProperty("3d-buildings", "fill-extrusion-color", "#aaa");
+            QString fillExtrusionColorJSON = R"JSON(
+              [
+                "interpolate",
+                ["linear"],
+                ["get", "height"],
+                  0.0, "blue",
+                 20.0, "royalblue",
+                 40.0, "cyan",
+                 60.0, "lime",
+                 80.0, "yellow",
+                100.0, "red"
+              ]
+            )JSON";
+
+            m_map->setPaintProperty("3d-buildings", "fill-extrusion-color", fillExtrusionColorJSON);
             m_map->setPaintProperty("3d-buildings", "fill-extrusion-opacity", .6);
 
             QVariantMap extrusionHeight;

--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -79,6 +79,7 @@ add_library(qmapboxgl SHARED
 
 target_include_directories(qmapboxgl
     PUBLIC platform/qt/include
+    PRIVATE src
 )
 
 target_compile_definitions(qmapboxgl

--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -37,6 +37,9 @@ public:
     void render();
     void setFramebufferObject(quint32 fbo, const QSize& size);
 
+    using PropertySetter = std::function<mbgl::optional<mbgl::style::conversion::Error>(mbgl::style::Layer&, const std::string&, const mbgl::style::conversion::Convertible&)>;
+    bool setProperty(const PropertySetter& setter, const QString& layer, const QString& name, const QVariant& value);
+
     mbgl::EdgeInsets margins;
     std::unique_ptr<mbgl::Map> mapObj;
 


### PR DESCRIPTION
Enables (optionally) passing a style property value as a JSON string in QMapboxGL's `setPaintProperty` and `setLayoutProperty`. Added example usage in the Qt demo app.