### PR TITLE
[core] don't prefetch tiles for geojson sources

### DIFF
--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -110,7 +110,7 @@ void TilePyramid::update(const std::vector<Immutable<style::Layer::Impl>>& layer
         }
 
         // Only attempt prefetching in continuous mode.
-        if (parameters.mode == MapMode::Continuous) {
+        if (parameters.mode == MapMode::Continuous && type != style::SourceType::GeoJSON) {
             // Request lower zoom level tiles (if configured to do so) in an attempt
             // to show something on the screen faster at the cost of a little of bandwidth.
             if (parameters.prefetchZoomDelta) {


### PR DESCRIPTION
It doesn't make sense to prefetch GeoJSON tiles because there aren't any network calls associated with loading tiles from geojson-vt, and prefetching causes overdraw flickering to be much worse which is affecting users. 

Related to https://github.com/mapbox/mapbox-gl-native/issues/11877#issuecomment-402486813

@1ec5 @LukasPaczos I took a quick look and didn't see any, but are there docs/examples I need to update reflecting this change? 

