### PR TITLE
[ios, build] Support pre-releases in templated release notes

### DIFF
--- a/platform/ios/scripts/release-notes.js
+++ b/platform/ios/scripts/release-notes.js
@@ -1,37 +1,65 @@
 #!/usr/bin/env node
 
 const fs = require('fs');
+const child_process = require('child_process');
 const ejs = require('ejs');
 const _ = require('lodash');
 const semver = require('semver');
 
 const changelog = fs.readFileSync('platform/ios/CHANGELOG.md', 'utf8');
 
-// This regular expression parses the changelog for individual releases:
-//  - Matches lines starting with "## ".
-//  - Groups the version number.
-//  - Skips the (optional) release date.
-//  - Groups the changelog content.
-//  - Ends when another "## " is found.
+/*
+  Find current and immediately previous releases by parsing git tags.
+*/
+let currentVersion = child_process.execSync('git describe --tags --match=ios-v*.*.* --abbrev=0')
+    .toString()
+    .trim()
+    .replace('ios-v', '');
+
+let gitTags = child_process.execSync('git tag --list ios-v*.*.*')
+    .toString()
+    .split('\n')
+    .map(function (tag) {
+        tag = tag.replace('ios-v', '').trim();
+        return semver.clean(tag);
+    });
+let previousVersion = semver.maxSatisfying(gitTags, "<" + currentVersion);
+
+/*
+  Parse the raw changelog text and split it into individual releases.
+
+  This regular expression:
+    - Matches lines starting with "## ".
+    - Groups the version number.
+    - Skips the (optional) release date.
+    - Groups the changelog content.
+    - Ends when another "## " is found.
+*/
 const regex = /^## (\d+\.\d+\.\d+).*?\n(.+?)(?=\n^## )/gms;
 
-let releases = [];
+let releaseNotes = [];
 while (match = regex.exec(changelog)) {
-    releases.push({
+    releaseNotes.push({
         'version': match[1],
         'changelog': match[2].trim(),
     });
 }
 
-const currentRelease = releases[0];
+/*
+  Match the current tag with the most appropriate release notes.
+*/
+const versionsInReleaseNotes = _.map(releaseNotes, 'version');
+const bestReleaseNotesForCurrentVersion = semver.minSatisfying(versionsInReleaseNotes, ">=" + currentVersion);
+const currentReleaseNotes = _.find(releaseNotes, { version: bestReleaseNotesForCurrentVersion });
 
-const versions = _.map(releases, 'version');
-const previousVersion = semver.maxSatisfying(versions, "<" + currentRelease.version);
-
-const releaseNotes = ejs.render(fs.readFileSync('platform/ios/scripts/release-notes.md.ejs', 'utf8'), {
-    'currentVersion': currentRelease.version,
-    'previousVersion': previousVersion,
-    'changelog': currentRelease.changelog,
+/*
+  Fill and print the release notes template.
+*/
+const templatedReleaseNotes = ejs.render(fs.readFileSync('platform/ios/scripts/release-notes.md.ejs', 'utf8'), {
+    'CURRENTVERSION': currentVersion,
+    'PREVIOUSVERSION': previousVersion,
+    'CHANGELOG': currentReleaseNotes.changelog,
+    'isPrerelease': semver.prerelease(currentVersion)
 });
 
-process.stdout.write(releaseNotes);
+process.stdout.write(templatedReleaseNotes);

--- a/platform/ios/scripts/release-notes.md.ejs
+++ b/platform/ios/scripts/release-notes.md.ejs
@@ -1,10 +1,12 @@
-<%
-  const CURRENTVERSION = locals.currentVersion;
-  const PREVIOUSVERSION = locals.previousVersion;
-  const CHANGELOG = locals.changelog;
--%>
 [Changes](https://github.com/mapbox/mapbox-gl-native/compare/ios-v<%-PREVIOUSVERSION%>...ios-v<%-CURRENTVERSION%>) since [Mapbox Maps SDK for iOS v<%-PREVIOUSVERSION%>](https://github.com/mapbox/mapbox-gl-native/releases/tag/ios-v<%-PREVIOUSVERSION%>):
 
-<%-CHANGELOG%>
+<%-CHANGELOG-%>
+
+<% if (isPrerelease) { %>
+To install this prerelease via CocoaPods, point your Podfile to either of these URLs:
+
+* https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v<%-CURRENTVERSION%>/platform/ios/Mapbox-iOS-SDK.podspec
+* https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v<%-CURRENTVERSION%>/platform/ios/Mapbox-iOS-SDK-symbols.podspec
+<% } -%>
 
 Documentation is [available online](https://www.mapbox.com/ios-sdk/api/<%-CURRENTVERSION%>/) or as part of the download.


### PR DESCRIPTION
Follows up on #11997 to add support for pre-releases in our generated GitHub release notes.

This eliminates the manual updating of URLs in release notes for pre-releases, but not the manual curation of pre-release-to-pre-release notes to remove irrelevant changelog entries.

If you want to test this out, run `./platform/ios/scripts/release-notes.js` and it will print the current release notes for `ios-v4.3.0-alpha.2`.

/cc @fabian-guerra @julianrex @captainbarbosa 