### PR TITLE
[iOS] Update Events submodule with crash fix

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -16,6 +16,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed a crash when switching between two styles having layers with the same identifier but different layer types. ([#12432](https://github.com/mapbox/mapbox-gl-native/issues/12432))
 * Fixed an issue where the symbols for `MGLMapPointForCoordinate` could not be found. ([#12445](https://github.com/mapbox/mapbox-gl-native/issues/12445))
 * Fixed an issue causing country and ocean labels to disappear after calling `-[MGLStyle localizeLabelsIntoLocale:]` when the system language is set to Simplified Chinese. ([#12164](https://github.com/mapbox/mapbox-gl-native/issues/12164))
+* Fixed a `CLLocationManager` crash when `MGLMapView` is deallocated. ([#55](https://github.com/mapbox/mapbox-events-ios/pull/55))
 
 ## 4.2.0 - July 18, 2018
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -16,7 +16,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed a crash when switching between two styles having layers with the same identifier but different layer types. ([#12432](https://github.com/mapbox/mapbox-gl-native/issues/12432))
 * Fixed an issue where the symbols for `MGLMapPointForCoordinate` could not be found. ([#12445](https://github.com/mapbox/mapbox-gl-native/issues/12445))
 * Fixed an issue causing country and ocean labels to disappear after calling `-[MGLStyle localizeLabelsIntoLocale:]` when the system language is set to Simplified Chinese. ([#12164](https://github.com/mapbox/mapbox-gl-native/issues/12164))
-* Fixed a `CLLocationManager` crash when `MGLMapView` is deallocated. ([#55](https://github.com/mapbox/mapbox-events-ios/pull/55))
+* Fixed a `CLLocationManager` crash when `MGLMapView` is deallocated. ([#12542](https://github.com/mapbox/mapbox-gl-native/pull/12542))
 
 ## 4.2.0 - July 18, 2018
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -16,7 +16,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed a crash when switching between two styles having layers with the same identifier but different layer types. ([#12432](https://github.com/mapbox/mapbox-gl-native/issues/12432))
 * Fixed an issue where the symbols for `MGLMapPointForCoordinate` could not be found. ([#12445](https://github.com/mapbox/mapbox-gl-native/issues/12445))
 * Fixed an issue causing country and ocean labels to disappear after calling `-[MGLStyle localizeLabelsIntoLocale:]` when the system language is set to Simplified Chinese. ([#12164](https://github.com/mapbox/mapbox-gl-native/issues/12164))
-* Fixed a `CLLocationManager` crash when `MGLMapView` is deallocated. ([#12542](https://github.com/mapbox/mapbox-gl-native/pull/12542))
+* Fixed a crash that occurred when `MMELocationManager` was deallocated and the delegate was reporting updates. ([#12542](https://github.com/mapbox/mapbox-gl-native/pull/12542))
 
 ## 4.2.0 - July 18, 2018
 


### PR DESCRIPTION
Updates Events submodule to include a CLLocationManager crash fix.

ref: https://github.com/mapbox/mapbox-events-ios/pull/55