### PR TITLE
[android] Fix command line ./gradlew execution

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -46,7 +46,7 @@ android {
     // When building from Android Studio, gradle.properties sets `android.buildOnlyTargetAbi=true` so that
     // only the architecture for the device you're running on gets built.
     def abi = 'all'
-    if (!project.hasProperty('android.injected.invoked.from.ide') || project.hasProperty("mapbox.abis")) {
+    if (project.hasProperty("mapbox.abis")) {
         // Errors when the user invokes Gradle from the command line and didn't set mapbox.abis
         abi = project.getProperty("mapbox.abis")
     }


### PR DESCRIPTION
Prevents the following error when running `./gradlew` without arguments:

> Could not get unknown property 'mapbox.abis' for project ':MapboxGLAndroidSDK' of type org.gradle.api.Project.

Judging by cf0dc1c, I think we can remove the first conditional.