### PR TITLE
[Qt] Add CMake toolchain for QNX platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -439,6 +439,35 @@ qtproj: $(MACOS_QT_PROJ_PATH)
 
 endif
 
+ifdef QNX_HOST
+export WITH_QT_DECODERS ?= ON
+export QCC_COMPILER_TARGET ?= gcc_ntox86_64
+export QCC_NTOARCH ?= x86_64
+
+export QNX_OUTPUT_PATH = build/qt-qnx-$(QCC_NTOARCH)/$(BUILDTYPE)
+QNX_QT_BUILD = $(QNX_OUTPUT_PATH)/build.ninja
+$(QNX_QT_BUILD): $(BUILD_DEPS)
+	@scripts/check-qt.sh
+	mkdir -p $(QNX_OUTPUT_PATH)
+	(cd $(QNX_OUTPUT_PATH) && cmake -G Ninja ../../.. \
+		-DCMAKE_BUILD_TYPE=$(BUILDTYPE) \
+		-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+		-DQCC_COMPILER_TARGET=${QCC_COMPILER_TARGET} \
+		-DQCC_NTOARCH=${QCC_NTOARCH} \
+		-DCMAKE_TOOLCHAIN_FILE=platform/qt/qnx.cmake \
+		-DMBGL_PLATFORM=qt \
+		-DWITH_QT_DECODERS=${WITH_QT_DECODERS} \
+		-DWITH_QT_I18N=${WITH_QT_I18N} \
+		-DWITH_QT_4=${WITH_QT_4} \
+		-DWITH_CXX11ABI=${WITH_CXX11ABI} \
+		-DWITH_COVERAGE=${WITH_COVERAGE})
+
+.PHONY: qnx-qt-lib
+qnx-qt-lib: $(QNX_QT_BUILD)
+	$(NINJA) $(NINJA_ARGS) -j$(JOBS) -C $(QNX_OUTPUT_PATH) qmapboxgl
+
+endif
+
 .PHONY: qt-lib
 qt-lib: $(QT_BUILD)
 	$(NINJA) $(NINJA_ARGS) -j$(JOBS) -C $(QT_OUTPUT_PATH) qmapboxgl

--- a/platform/qt/README.md
+++ b/platform/qt/README.md
@@ -51,6 +51,28 @@ At runtime, you will also need installed:
 - [OpenSSL 1.0.2+](https://slproweb.com/products/Win32OpenSSL.html)
 - DirectX
 
+#### QNX 7.0
+
+To build for QNX 7.0, you need to install the QNX Software Development Platform (SDP) on a Linux host.
+
+http://www.qnx.com/developers/docs/7.0.0/#com.qnx.doc.qnxsdp.nav/topic/bookset.html
+
+After installing the SDP, you need to source the QNX environment script:
+
+```
+source <SDP_DIRECTORY>/qnxsdp-env.sh
+```
+
+You also need to Build Qt for QNX.
+
+http://wiki.qt.io/Building_Qt_for_QNX_Neutrino_OS
+
+After building Qt for QNX, you need to add Qt installation's bin directory to the path.
+
+```
+export PATH=<INSTALLFOLDER>/bin:$PATH
+```
+
 ### Build instructions
 
 Public API headers can be found in the [platform/qt/include](include) directory.
@@ -78,4 +100,12 @@ $ mkdir build
 $ cd build
 $ cmake -G "Visual Studio 14 2015 Win64" -T LLVM-vs2014 -DMBGL_PLATFORM=qt -DWITH_QT_DECODERS=ON -DWITH_QT_I18N=ON -DWITH_NODEJS=OFF ..
 $ cmake --build . --config Release --target qmapboxgl -- /m
+```
+
+#### QNX 7.0
+
+Building the repository for QNX 7.0 is very similar to other platforms (e.g. Linux and macOS).
+
+```
+$ make qnx-qt-lib      # Will build libqmapboxgl.so
 ```

--- a/platform/qt/qnx.cmake
+++ b/platform/qt/qnx.cmake
@@ -1,0 +1,77 @@
+# CMake toolchain file for QNX Environment.
+#
+# Usage:
+#
+# To use this file, you need to set the 'CMAKE_TOOLCHAIN_FILE' to point to
+# 'qnx.cmake' on the command line:
+#
+#   cmake -DDCMAKE_TOOLCHAIN_FILE=platform/qt/qnx.cmake
+#
+# You will also need to provide the locations of the QNX HOST and TARGET locations.
+# This can be done by setting the environment variables(QNX_HOST and QNX_TARGET) from
+# the command line or running the environment setup script provided by the QNX Software
+# Development Platform:
+#
+#   source <SDP_DIRECTORY>/qnxsdp-env.sh
+#
+# Options:
+#
+# QCC_COMPILER_TARGET:
+#   The compiler name. Default: gcc_ntox86_64.
+# QCC_NTOARCH:
+#   The architecture to compile for. Default: x86_64.
+# QNX_HOST:
+#   Environment variable to QNX host build tools location.
+# QNX_TARGET:
+#   Environment variable to QNX target location.
+
+set(CMAKE_SYSTEM_NAME QNX)
+set(CMAKE_HOST_SYSTEM_NAME QNX)
+SET(CMAKE_SYSTEM_VERSION 7.0.0)
+set(QCC_COMPILER_TARGET "$ENV{QCC_COMPILER_TARGET}")
+set(QCC_NTOARCH "$ENV{QCC_NTOARCH}")
+
+#Check environment variables
+if ("$ENV{QNX_HOST}" STREQUAL "")
+    message(FATAL_ERROR "QNX_HOST environment variable not set")
+endif()
+
+if ("$ENV{QNX_TARGET}" STREQUAL "")
+    message(FATAL_ERROR "QNX_TARGET environment variable not set")
+endif()
+
+set(QNX_HOST "$ENV{QNX_HOST}")
+set(QNX_TARGET "$ENV{QNX_TARGET}")
+
+# Use 'qcc' instead of nto${QCC_NTOARCH}-gcc and nto${QCC_NTOARCH}-gcc++ once
+# the issue https://gitlab.kitware.com/cmake/cmake/issues/17126 is resolved.
+#set(CMAKE_C_COMPILER qcc)
+#set(CMAKE_C_COMPILER_TARGET ${QCC_COMPILER_TARGET})
+#set(CMAKE_CXX_COMPILER QCC)
+#set(CMAKE_CXX_COMPILER_TARGET ${QCC_COMPILER_TARGET})
+
+set(CMAKE_C_COMPILER ${QNX_HOST}/usr/bin/nto${QCC_NTOARCH}-gcc)
+set(CMAKE_CXX_COMPILER "${QNX_HOST}/usr/bin/nto${QCC_NTOARCH}-g++")
+
+set(CMAKE_LINKER       "${QNX_HOST}/usr/bin/nto${QCC_NTOARCH}-ld"     CACHE PATH "QNX linker program" FORCE)
+set(CMAKE_AR           "${QNX_HOST}/usr/bin/nto${QCC_NTOARCH}-ar"      CACHE PATH "QNX ar program" FORCE)
+set(CMAKE_NM           "${QNX_HOST}/usr/bin/nto${QCC_NTOARCH}-nm"      CACHE PATH "QNX nm program" FORCE)
+set(CMAKE_OBJCOPY      "${QNX_HOST}/usr/bin/nto${QCC_NTOARCH}-objcopy" CACHE PATH "QNX objcopy program" FORCE)
+set(CMAKE_OBJDUMP      "${QNX_HOST}/usr/bin/nto${QCC_NTOARCH}-objdump" CACHE PATH "QNX objdump program" FORCE)
+set(CMAKE_RANLIB       "${QNX_HOST}/usr/bin/nto${QCC_NTOARCH}-ranlib"  CACHE PATH "QNX ranlib program" FORCE)
+set(CMAKE_STRIP        "${QNX_HOST}/usr/bin/nto${QCC_NTOARCH}-strip"   CACHE PATH "QNX strip program" FORCE)
+set (CMAKE_SH           "${QNX_HOST}/usr/bin/sh"   CACHE PATH "QNX shell program" FORCE)
+
+set(CMAKE_C_FLAGS_DEBUG "-g")
+set(CMAKE_C_FLAGS_MINSIZEREL "-Os -DNDEBUG")
+set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -D_DEBUG")
+set(CMAKE_CXX_FLAGS_MINSIZEREL "-Os -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
+
+set(CMAKE_FIND_ROOT_PATH "${QNX_TARGET}")
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -160,6 +160,11 @@ elseif (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
 
     target_add_mason_package(qmapboxgl PRIVATE optional)
     target_add_mason_package(qmapboxgl PRIVATE tao_tuple)
+elseif (CMAKE_HOST_SYSTEM_NAME STREQUAL "QNX")
+    list(APPEND MBGL_QT_CORE_FILES
+        PRIVATE platform/qt/src/thread.cpp
+    )
+    add_definitions("-Wno-narrowing")
 endif()
 
 add_custom_command(


### PR DESCRIPTION
This adds CMake toolchain for QNX platform. By using this toolchain, we can compile Mapbox GL Plugin for Qt on QNX platform.