### PR TITLE
[core, node] Don't create an annotation source in static map modes.

### DIFF
--- a/src/mbgl/annotation/annotation_manager.hpp
+++ b/src/mbgl/annotation/annotation_manager.hpp
@@ -25,7 +25,7 @@ class Style;
 
 class AnnotationManager : private util::noncopyable {
 public:
-    AnnotationManager(style::Style&);
+    AnnotationManager(style::Style*);
     ~AnnotationManager();
 
     AnnotationID addAnnotation(const Annotation&);
@@ -36,7 +36,7 @@ public:
     void removeImage(const std::string&);
     double getTopOffsetPixelsForImage(const std::string&);
 
-    void setStyle(style::Style&);
+    void setStyle(style::Style*);
     void onStyleLoaded();
 
     void updateData();
@@ -63,7 +63,7 @@ private:
 
     std::unique_ptr<AnnotationTileData> getTileData(const CanonicalTileID&);
 
-    std::reference_wrapper<style::Style> style;
+    style::Style* style;
 
     std::mutex mutex;
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -129,7 +129,7 @@ Map::Impl::Impl(Map& map_,
       mode(mode_),
       pixelRatio(pixelRatio_),
       style(std::make_unique<Style>(scheduler, fileSource, pixelRatio)),
-      annotationManager(*style) {
+      annotationManager(mode == MapMode::Continuous ? style.get() : NULL) {
 
     style->impl->setObserver(this);
     rendererFrontend.setObserver(*this);
@@ -233,7 +233,7 @@ void Map::setStyle(std::unique_ptr<Style> style) {
     assert(style);
     impl->onStyleLoading();
     impl->style = std::move(style);
-    impl->annotationManager.setStyle(*impl->style);
+    impl->annotationManager.setStyle(impl->mode == MapMode::Continuous ? impl->style.get() : NULL);
 }
 
 #pragma mark - Transitions


### PR DESCRIPTION
Fixes issue #12545.

When I was trying to dig into the lifecycle of a node map request, I noticed that we were generating "annotation tiles" for every request, even though it's not possible to add annotations to node map requests. The tiles themselves are empty and cheap to generate, but using them incurs the overhead of sending tile parsing requests to the workers and waiting for responses.

This PR keeps the `AnnotationManager`, but prevents it from adding itself as a source to the style if `mapMode != Continuous` -- so the change affects `MapSnapshotter` (which also doesn't support annotations) as well.

I tried to evaluate the impact of the change by looking at the time to run the render test harness with the recycle-map option. The first three runs made it seem like this was about a 1% speed-up of the test harness, but then when I kept doing more runs the numbers got a lot more variable. In the end there was stil a ~.5 second speed up after the change, but there's enough variation I'm pretty uncertain that I'm measuring a real effect.

After | Before
-- | --
130.5 | 132.1
130.3 | 131.5
130.1 | 131.3
75.9 | 78.3
76 | 72.7
76.1 | 78
77.42 | 75.82
77.46 | 78.73

Conceptually: this is a pretty small amount of CPU time, and it's probably not going to have any impact at all on render time as long as the annotation work gets done while we'd be waiting on resource loads anyway. However, for fast server-side rendering we should (ideally) be set up to spend as little time as possible blocking on resources requests.

Performance aside, I'm attracted to the idea of removing `AnnotationManager` from this pathway just because I find it hard to reason about `AnnotationManager` -- it's one of the few remaining data structures we have that relies on a mutex to protect shared state.

cc @jfirebaugh 