### PR TITLE
[ios] Add experimental frame rate measurements to MGLMapView

### DIFF
--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -1008,6 +1008,7 @@
 		96E0272C1E57C7E5004B8E66 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		96E0272D1E57C7E6004B8E66 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		96E0272E1E57C7E7004B8E66 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		96F017292118FBAE00892778 /* MGLMapView_Experimental.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLMapView_Experimental.h; sourceTree = "<group>"; };
 		96F3F73B1F5711F1003E2D2C /* MGLUserLocationHeadingIndicator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLUserLocationHeadingIndicator.h; sourceTree = "<group>"; };
 		AC518DFD201BB55A00EBC820 /* MGLTelemetryConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLTelemetryConfig.h; sourceTree = "<group>"; };
 		AC518DFE201BB55A00EBC820 /* MGLTelemetryConfig.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLTelemetryConfig.m; sourceTree = "<group>"; };
@@ -1955,6 +1956,7 @@
 				CA55CD3E202C16AA00CE7095 /* MGLCameraChangeReason.h */,
 				DA704CC01F65A475004B3F28 /* MGLMapAccessibilityElement.h */,
 				DA704CC11F65A475004B3F28 /* MGLMapAccessibilityElement.mm */,
+				96F017292118FBAE00892778 /* MGLMapView_Experimental.h */,
 				DA17BE2F1CC4BAC300402C41 /* MGLMapView_Private.h */,
 				DA8848361CBAFB8500AB86E3 /* MGLMapView.h */,
 				DA88484A1CBAFB9800AB86E3 /* MGLMapView.mm */,

--- a/platform/ios/src/MGLMapView_Experimental.h
+++ b/platform/ios/src/MGLMapView_Experimental.h
@@ -1,0 +1,32 @@
+#import <Mapbox/Mapbox.h>
+
+@interface MGLMapView (Experimental)
+
+#pragma mark Rendering Performance Measurement
+
+/** Enable rendering performance measurement. */
+@property (nonatomic) BOOL experimental_enableFrameRateMeasurement;
+
+/**
+ Average frames per second over the previous second, updated once per second.
+
+ Requires `experimental_enableFrameRateMeasurement`.
+ */
+@property (nonatomic, readonly) CGFloat averageFrameRate;
+
+/**
+  Frame render duration for the previous frame, updated instantaneously.
+
+  Requires `experimental_enableFrameRateMeasurement`.
+ */
+@property (nonatomic, readonly) CFTimeInterval frameTime;
+
+/**
+ Average frame render duration over the previous second, updated once per
+ second.
+
+ Requires `experimental_enableFrameRateMeasurement`.
+ */
+@property (nonatomic, readonly) CFTimeInterval averageFrameTime;
+
+@end


### PR DESCRIPTION
Adds new properties on `MGLMapView` for average frame rate, average frame render duration, and instantaneous frame render duration (useful for producing graphs and benchmarks).

### Feature flag strategy
These measurements happen once per frame and therefore shouldn’t be enabled by default. I went with a simple private `BOOL` that’s settable at run-time, but we should profile this to make sure it’s not impacting regular performance. If it is, I’d suppose a compile-time flag would be more appropriate (but less convenient, as external apps would need custom builds).

I also added `MGLMapView_Experimental.h`, which declares read-only properties for `iosapp` but isn’t included as a public header in the SDK.

This is the first time we’re added anything feature flag'y in the iOS SDK, so we should probably discuss guidelines around internal documentation, implementation, etc.

### How to use
In `iosapp`, you can enable these measurements via the “Show Map Info HUD” setting.

![img_a91c6db70cd6-1](https://user-images.githubusercontent.com/1198851/43744769-a5bcee04-99a9-11e8-9df1-b3f701eff126.jpeg)


### To-do
- [x] Profile.
- [x] Inline docs.

/cc @mapbox/maps-ios 