### PR TITLE
Rename `EvaluationContext::heatmapDensity` to `colorRampParameter`

### DIFF
--- a/include/mbgl/style/expression/expression.hpp
+++ b/include/mbgl/style/expression/expression.hpp
@@ -30,13 +30,13 @@ public:
     EvaluationContext(float zoom_, GeometryTileFeature const * feature_) :
         zoom(zoom_), feature(feature_)
     {}
-    EvaluationContext(optional<float> zoom_, GeometryTileFeature const * feature_, optional<double> heatmapDensity_) :
-        zoom(std::move(zoom_)), feature(feature_), heatmapDensity(std::move(heatmapDensity_))
+    EvaluationContext(optional<float> zoom_, GeometryTileFeature const * feature_, optional<double> colorRampParameter_) :
+        zoom(std::move(zoom_)), feature(feature_), colorRampParameter(std::move(colorRampParameter_))
     {}
     
     optional<float> zoom;
     GeometryTileFeature const * feature;
-    optional<double> heatmapDensity;
+    optional<double> colorRampParameter;
 };
 
 template <typename T>
@@ -151,7 +151,7 @@ public:
     Kind getKind() const { return kind; };
     type::Type getType() const { return type; };
     
-    EvaluationResult evaluate(optional<float> zoom, const Feature& feature, optional<double> heatmapDensity) const;
+    EvaluationResult evaluate(optional<float> zoom, const Feature& feature, optional<double> colorRampParameter) const;
 
     /**
      * Statically analyze the expression, attempting to enumerate possible outputs. Returns

--- a/src/mbgl/style/expression/compound_expression.cpp
+++ b/src/mbgl/style/expression/compound_expression.cpp
@@ -343,12 +343,12 @@ std::unordered_map<std::string, CompoundExpressionRegistry::Definition> initiali
     });
 
     define("heatmap-density", [](const EvaluationContext& params) -> Result<double> {
-        if (!params.heatmapDensity) {
+        if (!params.colorRampParameter) {
             return EvaluationError {
                 "The 'heatmap-density' expression is unavailable in the current evaluation context."
             };
         }
-        return *(params.heatmapDensity);
+        return *(params.colorRampParameter);
     });
 
     define("has", [](const EvaluationContext& params, const std::string& key) -> Result<bool> {

--- a/src/mbgl/style/expression/expression.cpp
+++ b/src/mbgl/style/expression/expression.cpp
@@ -28,9 +28,9 @@ public:
 };
 
 
-EvaluationResult Expression::evaluate(optional<float> zoom, const Feature& feature, optional<double> heatmapDensity) const {
+EvaluationResult Expression::evaluate(optional<float> zoom, const Feature& feature, optional<double> colorRampParameter) const {
     GeoJSONFeature f(feature);
-    return this->evaluate(EvaluationContext(zoom, &f, heatmapDensity));
+    return this->evaluate(EvaluationContext(zoom, &f, colorRampParameter));
 }
 
 } // namespace expression


### PR DESCRIPTION
More generic name as the same class member is to be used by the
linear gradient properties.