### PR TITLE
[build] Fix CI failure when master and release branch are identical

### DIFF
--- a/scripts/environment.js
+++ b/scripts/environment.js
@@ -24,7 +24,7 @@ if (pr) {
 } else {
     const head = process.env['CIRCLE_SHA1'];
     for (const sha of execSync(`git rev-list --max-count=10 ${head}`).toString().trim().split('\n')) {
-        const base = execSync(`git branch -r --contains ${sha} origin/master origin/release-*`).toString().trim().replace(/^origin\//, '');
+        const base = execSync(`git branch -r --contains ${sha} origin/master origin/release-*`).toString().replace(/$\n.*/m, '').trim().replace(/^origin\//, '');
         if (base) {
             const mergeBase = execSync(`git merge-base origin/${base} ${head}`).toString().trim();
             console.log(`export CIRCLE_TARGET_BRANCH=${base}`);

--- a/scripts/environment.js
+++ b/scripts/environment.js
@@ -24,7 +24,7 @@ if (pr) {
 } else {
     const head = process.env['CIRCLE_SHA1'];
     for (const sha of execSync(`git rev-list --max-count=10 ${head}`).toString().trim().split('\n')) {
-        const base = execSync(`git branch -r --contains ${sha} origin/master origin/release-*`).toString().replace(/$\n.*/m, '').trim().replace(/^origin\//, '');
+        const base = execSync(`git branch -r --contains ${sha} origin/master origin/release-*`).toString().split('\n')[0].trim().replace(/^origin\//, '');
         if (base) {
             const mergeBase = execSync(`git merge-base origin/${base} ${head}`).toString().trim();
             console.log(`export CIRCLE_TARGET_BRANCH=${base}`);


### PR DESCRIPTION
Follows-up on #12446. The search for a branch containing the previous hash could return multiple matches on separate lines if, for instance, a newly-cut release branch were identical to master. Since the branches are effectively the same, it should be safe to only return the first match.

See [this failure on the `release-espresso` cut](https://circleci.com/gh/mapbox/mapbox-gl-native/139158) and [this failure on a separate `master`-based branch after the cut](https://circleci.com/gh/mapbox/mapbox-gl-native/139188).

/cc @jfirebaugh @julianrex @LukasPaczos 