### PR TITLE
[core] Fix querying for annotations near tile boundaries at high zoom.

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 
 ## master
 - Don't default-show text/icons that depend on the placement of a paired icon/text [#12483](https://github.com/mapbox/mapbox-gl-native/issues/12483)
+- Fix symbol querying for markers near tile boundaries at high zoom. ([#12472](https://github.com/mapbox/mapbox-gl-native/issues/12472))
 
 ## 6.4.0-beta.1 - August 9, 2018
  - Don't prefetch tiles for geojson sources [#12529](https://github.com/mapbox/mapbox-gl-native/pull/12529)

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Improved the Swift interface for `MGLMapView.decelerationRate`. ([#12584](https://github.com/mapbox/mapbox-gl-native/issues/12584))
 * Fixed inconsistencies in exception naming. ([#12583](https://github.com/mapbox/mapbox-gl-native/issues/12583))
 * Don't default-show text/icons that depend on the placement of a paired icon/text [#12483](https://github.com/mapbox/mapbox-gl-native/issues/12483)
+* Fix the behavior of `-[MGLMapView visibleFeaturesAtPoint:]` near tile boundaries at high zoom. ([#12472](https://github.com/mapbox/mapbox-gl-native/issues/12472))
 
 ## 4.3.0
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -3,6 +3,7 @@
 # master
 
 - Don't default-show text/icons that depend on the placement of a paired icon/text [#12483](https://github.com/mapbox/mapbox-gl-native/issues/12483)
+- Fix the `-[MGLMapView annotationAtPoint:]` method near tile boundaries at high zoom. ([#12472](https://github.com/mapbox/mapbox-gl-native/issues/12472))
 
 ## Styles and rendering
 

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,5 +1,6 @@
 # master
 - Don't default-show text/icons that depend on the placement of a paired icon/text [#12483](https://github.com/mapbox/mapbox-gl-native/issues/12483)
+- Fix symbol querying for annotations near tile boundaries at high zoom. ([#12472](https://github.com/mapbox/mapbox-gl-native/issues/12472))
 - The `Map` constructor now accepts a `mode` option which can be either `"static"` (default) or `"tile"`. It must be set to `"tile"` when rendering individual tiles in order for the symbols to match across tiles.
 - Remove unnecessary memory use when collision debug mode is not enabled ([#12294](https://github.com/mapbox/mapbox-gl-native/issues/12294))
 - Added support for rendering `symbol-placement: line-center` ([#12337](https://github.com/mapbox/mapbox-gl-native/pull/12337))

--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -140,7 +140,13 @@ std::unique_ptr<AnnotationTileData> AnnotationManager::getTileData(const Canonic
     auto pointLayer = tileData->addLayer(PointLayerID);
 
     LatLngBounds tileBounds(tileID);
-
+    // Hack for https://github.com/mapbox/mapbox-gl-native/issues/12472
+    // To handle precision issues, query a slightly larger area than the tile bounds
+    // Symbols at a border can be included in vector data for both tiles
+    // The rendering/querying logic will make sure the symbols show up in only one of the tiles
+    tileBounds.extend(LatLng(tileBounds.south() - 0.000000001, tileBounds.west() - 0.000000001));
+    tileBounds.extend(LatLng(tileBounds.north() + 0.000000001, tileBounds.east() + 0.000000001));
+    
     symbolTree.query(boost::geometry::index::intersects(tileBounds),
         boost::make_function_output_iterator([&](const auto& val){
             val->updateLayer(tileID, *pointLayer);

--- a/test/api/annotations.test.cpp
+++ b/test/api/annotations.test.cpp
@@ -59,6 +59,18 @@ TEST(Annotations, SymbolAnnotation) {
 //    }
 }
 
+TEST(Annotations, SymbolAnnotationTileBoundary) {
+    // Almost exactly the same as SymbolAnnotation test above, but offset my fractions of a degree
+    // tests precision issue from https://github.com/mapbox/mapbox-gl-native/issues/12472
+    AnnotationTest test;
+    
+    test.map.getStyle().loadJSON(util::read_file("test/fixtures/api/empty.json"));
+    test.map.addAnnotationImage(namedMarker("default_marker"));
+    test.map.addAnnotation(SymbolAnnotation { Point<double>(0.000000000000001, 0.00000000000001), "default_marker" });
+    test.map.setZoom(10);
+    test.checkRendering("point_annotation");
+}
+
 TEST(Annotations, LineAnnotation) {
     AnnotationTest test;
 
@@ -475,3 +487,4 @@ TEST(Annotations, ChangeMaxZoom) {
     test.map.setZoom(test.map.getMaxZoom());
     test.checkRendering("line_annotation_max_zoom");
 }
+


### PR DESCRIPTION
Fixes issue #12472.

This commit doesn't address the underlying issues that come from symbolAnnotationTree using a slightly lower precision coordinate system than the annotations themselves. Instead, it just puts a small padding around each tile when it queries for tile data, so that symbols right at the tile boundary will be included in both tiles. The rendering/querying code will take care of only displaying one instance.
The padding is in global coordinates, so at higher zoom the padding will be larger in tile units -- this is consistent with precision loss also being greater at higher zoom.

I initially wanted to address this issue by converting the `symbolAnnotationTree` to use a global integer coordinate system that would be consistent with tile unit coordinates up to our max supported zoom. But when I started down that path I came to the conclusion that adding _yet another_ coordinate system to GL would cause more confusion than it would be worth -- especially since I think long term we'd like to move `AnnotationManager` away from doing its own tiling and towards relying on something like `geojson-vt`. Also the "hack" of adding padding to the tile bounds turns out to be easy to implement, relatively easy to understand, and shouldn't really have any noticeable performance impact.

Before this change, the added `SymbolAnnotationTileBoundary` test would fail to draw the marker.

cc @mourner @1ec5 @ivovandongen @jadar