### PR TITLE
[core] Use correct Log::record overload.

### DIFF
--- a/src/mbgl/util/logging.cpp
+++ b/src/mbgl/util/logging.cpp
@@ -35,7 +35,7 @@ void Log::record(EventSeverity severity, Event event, const char* format, ...) {
     vsnprintf(msg, sizeof(msg), format, args);
     va_end(args);
 
-    record(severity, event, -1, msg);
+    record(severity, event, -1, std::string{ msg });
 }
 
 void Log::record(EventSeverity severity, Event event, int64_t code, const char* format, ...) {


### PR DESCRIPTION
Use an explicit std::string to distinguish from unnecessary use of const char* overload.

cc @jfirebaugh @kkaefer 