### PR TITLE
[ios] Remove Xcode 7 compatibility typedefs

### DIFF
--- a/platform/darwin/src/MGLTypes.h
+++ b/platform/darwin/src/MGLTypes.h
@@ -23,13 +23,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-#ifndef NS_STRING_ENUM
-    #define NS_STRING_ENUM
-    #define NS_EXTENSIBLE_STRING_ENUM
-    typedef NSString *NSErrorDomain;
-    typedef NSString *NSNotificationName;
-#endif
-
 typedef NSString *MGLExceptionName NS_TYPED_EXTENSIBLE_ENUM;
 
 /**


### PR DESCRIPTION
Removes `typedef`s added in #6923 for Xcode 7 compatibility — we currently require Xcode 8 (for app integration) or Xcode 9 (to build the SDK), so this can be removed.

~_(Also temporarily includes #12569, so tests run/pass.)_~

/cc @1ec5 @julianrex @fabian-guerra 