### PR TITLE
[build] Print binary size stats to CI logs, too

### DIFF
--- a/scripts/check_binary_size.js
+++ b/scripts/check_binary_size.js
@@ -51,9 +51,7 @@ function getPriorSize() {
             console.log('No matching check found.');
             return Promise.resolve(null);
         }
-        const prior = +run.output.summary.match(/`.*` is (\d+) bytes/)[1];
-        console.log(`Prior size was ${prettyBytes(prior)}.`);
-        return prior;
+        return +run.output.summary.match(/`.*` is (\d+) bytes/)[1];
     });
 }
 
@@ -70,6 +68,8 @@ github.apps.createInstallationToken({installation_id: SIZE_CHECK_APP_INSTALLATIO
                     return prettyBytes(size);
                 }
             })();
+
+            console.log(`${label}: ${title} (${size} bytes)`);
 
             return github.checks.create({
                 owner: 'mapbox',


### PR DESCRIPTION
In addition to the GitHub “Checks” binary size stats, also print that information to the CI log, e.g.,

```
iOS armv7: +1.21 kB 0.032% (3.84 MB) (3839952 bytes)
iOS arm64: +1.3 kB 0.031% (4.15 MB) (4145944 bytes)
iOS x86_64: +1.31 kB 0.029% (4.45 MB) (4452864 bytes)
iOS Dynamic: +1.3 kB 0.008% (16.7 MB) (16728856 bytes)
```

~_(Also temporarily includes #12569, so tests run/pass.)_~

/cc @jfirebaugh 