### PR TITLE
[build] Fix CI failure when master and release branch are identical (release-espresso)

### DIFF
--- a/scripts/environment.js
+++ b/scripts/environment.js
@@ -24,7 +24,7 @@ if (pr) {
 } else {
     const head = process.env['CIRCLE_SHA1'];
     for (const sha of execSync(`git rev-list --max-count=10 ${head}`).toString().trim().split('\n')) {
-        const base = execSync(`git branch -r --contains ${sha} origin/master origin/release-*`).toString().trim().replace(/^origin\//, '');
+        const base = execSync(`git branch -r --contains ${sha} origin/master origin/release-*`).toString().split('\n')[0].trim().replace(/^origin\//, '');
         if (base) {
             const mergeBase = execSync(`git merge-base origin/${base} ${head}`).toString().trim();
             console.log(`export CIRCLE_TARGET_BRANCH=${base}`);


### PR DESCRIPTION
Cherry-picks #12569 to `release-espresso` to fix the build.

/cc @julianrex @fabian-guerra @jfirebaugh 