### PR TITLE
Revert "[core] Replace Boost.Spirit with std::regex in CacheControl::parse

### DIFF
--- a/src/mbgl/util/http_header.cpp
+++ b/src/mbgl/util/http_header.cpp
@@ -2,20 +2,34 @@
 
 #include <mbgl/util/string.hpp>
 
-#include <regex>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wshadow"
+#pragma clang diagnostic push
+
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wtautological-constant-compare"
+#include <boost/spirit/include/qi.hpp>
+#include <boost/spirit/include/phoenix_core.hpp>
+#include <boost/spirit/include/phoenix_operator.hpp>
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 
 namespace mbgl {
 namespace http {
 
 CacheControl CacheControl::parse(const std::string& value) {
-    std::regex maxAgeRegex(R"((?:[^"]*"[^"]*[^\\]")*[^"]*max-age[\s]*=[\s]*([\d]+).*)");
-    std::smatch maxAgeMatch;
+    namespace qi = boost::spirit::qi;
+    namespace phoenix = boost::phoenix;
 
     CacheControl result;
-    result.mustRevalidate = value.find("must-revalidate") != std::string::npos;
-    if (std::regex_match(value, maxAgeMatch, maxAgeRegex) && maxAgeMatch.size() == 2) {
-        result.maxAge = ::atoll(maxAgeMatch[1].str().c_str());
-    }
+    qi::phrase_parse(value.begin(), value.end(), (
+        (qi::lit("must-revalidate") [ phoenix::ref(result.mustRevalidate) = true ]) |
+        (qi::lit("max-age") >> '=' >> qi::ulong_long [ phoenix::ref(result.maxAge) = qi::_1 ]) |
+        (*(('"' >> *(('\\' >> qi::char_) | (qi::char_ - '"')) >> '"') | (qi::char_ - '"' - ',')))
+    ) % ',', qi::ascii::space);
     return result;
 }
 

--- a/test/storage/headers.test.cpp
+++ b/test/storage/headers.test.cpp
@@ -10,10 +10,6 @@ TEST(HTTPHeader, Parsing) {
     ASSERT_FALSE(bool(cc.maxAge));
     EXPECT_FALSE(cc.mustRevalidate);
 
-    cc = http::CacheControl::parse(R"#("max-age=34)#");
-    ASSERT_FALSE(bool(cc.maxAge));
-    EXPECT_FALSE(cc.mustRevalidate);
-
     cc = http::CacheControl::parse(R"#(max-age =34)#");
     ASSERT_TRUE(bool(cc.maxAge));
     EXPECT_EQ(34u, *cc.maxAge);
@@ -38,11 +34,6 @@ TEST(HTTPHeader, Parsing) {
     EXPECT_FALSE(cc.mustRevalidate);
 
     cc = http::CacheControl::parse(R"#(max-age=3,max-age="34)#");
-    ASSERT_TRUE(bool(cc.maxAge));
-    EXPECT_EQ(3u, *cc.maxAge);
-    EXPECT_FALSE(cc.mustRevalidate);
-
-    cc = http::CacheControl::parse(R"#(max-age=3,max-age=""34)#");
     ASSERT_TRUE(bool(cc.maxAge));
     EXPECT_EQ(3u, *cc.maxAge);
     EXPECT_FALSE(cc.mustRevalidate);


### PR DESCRIPTION
This reverts commit 990b3b11b9427ffd86f693d3f4c3dd351891e5d0 as it seems that `std::regex` usage has increased binary size, per comments [here](https://github.com/mapbox/mapbox-gl-native/pull/12475#issuecomment-411446157).

/cc @jfirebaugh 