### PR TITLE
Converting GeoJsonSource features asynchronously

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/GeoJsonSource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/GeoJsonSource.java
@@ -188,7 +188,8 @@ public class GeoJsonSource extends Source {
   }
 
   /**
-   * Updates the GeoJson with a single feature
+   * Updates the GeoJson with a single feature. The update is performed asynchronously,
+   * so the data won't be immediately visible or available to query when this method returns.
    *
    * @param feature the GeoJSON {@link Feature} to set
    */
@@ -198,7 +199,8 @@ public class GeoJsonSource extends Source {
   }
 
   /**
-   * Updates the GeoJson with a single geometry
+   * Updates the GeoJson with a single geometry. The update is performed asynchronously,
+   * so the data won't be immediately visible or available to query when this method returns.
    *
    * @param geometry the GeoJSON {@link Geometry} to set
    */
@@ -208,7 +210,8 @@ public class GeoJsonSource extends Source {
   }
 
   /**
-   * Updates the GeoJson
+   * Updates the GeoJson. The update is performed asynchronously,
+   * so the data won't be immediately visible or available to query when this method returns.
    *
    * @param features the GeoJSON FeatureCollection
    */
@@ -218,7 +221,8 @@ public class GeoJsonSource extends Source {
   }
 
   /**
-   * Updates the GeoJson
+   * Updates the GeoJson. The update is performed asynchronously,
+   * so the data won't be immediately visible or available to query when this method returns.
    *
    * @param json the raw GeoJson FeatureCollection string
    */

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/SimpleMapActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/SimpleMapActivity.java
@@ -17,7 +17,6 @@ public class SimpleMapActivity extends AppCompatActivity {
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_map_simple);
-
     mapView = (MapView) findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
   }


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gl-native/issues/8484.

When updating the `GeoJsonSource`, one of the most resources consuming work is the conversion between Android features and `mbgl` ones.

To make the UX better when updating big data sets, this PR introduces `GeoJsonSource#setGeoJsonAsync` which performs the conversion on a worker thread and the returns back to the core flow and notifies the listener when that flow is finished with `OnGeoJsonSourceLoadedListener#onGeoJsonSourceLoaded` at the point where the synchronous method would return.

Examples of improvements:

|   | UI thread time | Overall time | Time saved |
| --- | --- | --- | --- |
| `LineString` geometry ~80k points | 1662ms | 2866ms | **~42%** |
| `FeatureCollection` ~50k features | 204ms | 1169ms | **~83%** |

The trend continues that for simple geometries time spent on the UI thread is about 50% shorter and for more complicated collections about 80% shorter.

This is still a work-in-progress:
- [x] resolve issues with setting raw json string that throws a JNI exception
- [x] add tests for the new methods
- [x] polish docs