### PR TITLE
Remove bogus library search path

### DIFF
--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -1967,10 +1967,6 @@
 				INFOPLIST_FILE = "$(SRCROOT)/sdk/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/cmake/Debug",
-				);
 				OTHER_CFLAGS = "-fvisibility=hidden";
 				OTHER_LDFLAGS = (
 					"$(mbgl_core_LINK_LIBRARIES)",


### PR DESCRIPTION
Fixed a build warning caused by a nonexistent library search path in the Debug configuration:

```
ld: warning: directory not found for option '-L/path/to/mapbox-gl-native/platform/macos/cmake/Debug'
```

This change just removes the setting. I don’t recall why it was necessary in the first place, but everything still seems to work, and the iOS targets don’t need this setting. 🤷‍♂️

/cc @GretaCB @kkaefer