### PR TITLE
[ios] Standardize exception definitions

### DIFF
--- a/platform/darwin/src/MGLComputedShapeSource.h
+++ b/platform/darwin/src/MGLComputedShapeSource.h
@@ -32,6 +32,8 @@ FOUNDATION_EXTERN MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionWrap
  */
 FOUNDATION_EXTERN MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionClipsCoordinates;
 
+FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLInvalidDatasourceException;
+
 /**
  Data source for `MGLComputedShapeSource`. This protocol defines two optional methods for fetching
  data, one based on tile coordinates, and one based on a bounding box. Classes that implement this

--- a/platform/darwin/src/MGLComputedShapeSource.mm
+++ b/platform/darwin/src/MGLComputedShapeSource.mm
@@ -10,6 +10,8 @@
 #include <mbgl/tile/tile_id.hpp>
 #include <mbgl/util/geojson.hpp>
 
+const MGLExceptionName MGLInvalidDatasourceException = @"MGLInvalidDatasourceException";
+
 const MGLShapeSourceOption MGLShapeSourceOptionWrapsCoordinates = @"MGLShapeSourceOptionWrapsCoordinates";
 const MGLShapeSourceOption MGLShapeSourceOptionClipsCoordinates = @"MGLShapeSourceOptionClipsCoordinates";
 
@@ -205,10 +207,12 @@ mbgl::style::CustomGeometrySource::Options MBGLCustomGeometrySourceOptionsFromDi
     self.dataSourceImplementsFeaturesForTile = [dataSource respondsToSelector:@selector(featuresInTileAtX:y:zoomLevel:)];
     self.dataSourceImplementsFeaturesForBounds = [dataSource respondsToSelector:@selector(featuresInCoordinateBounds:zoomLevel:)];
 
-    if(!self.dataSourceImplementsFeaturesForBounds && !self.dataSourceImplementsFeaturesForTile) {
-        [NSException raise:@"Invalid Datasource" format:@"Datasource does not implement any MGLComputedShapeSourceDataSource methods"];
-    } else if(self.dataSourceImplementsFeaturesForBounds && self.dataSourceImplementsFeaturesForTile) {
-        [NSException raise:@"Invalid Datasource" format:@"Datasource implements multiple MGLComputedShapeSourceDataSource methods"];
+    if (!self.dataSourceImplementsFeaturesForBounds && !self.dataSourceImplementsFeaturesForTile) {
+        [NSException raise:MGLInvalidDatasourceException
+                    format:@"Datasource does not implement any MGLComputedShapeSourceDataSource methods"];
+    } else if (self.dataSourceImplementsFeaturesForBounds && self.dataSourceImplementsFeaturesForTile) {
+        [NSException raise:MGLInvalidDatasourceException
+                    format:@"Datasource implements multiple MGLComputedShapeSourceDataSource methods"];
     }
 
     _dataSource = dataSource;

--- a/platform/darwin/src/MGLForegroundStyleLayer.mm
+++ b/platform/darwin/src/MGLForegroundStyleLayer.mm
@@ -3,7 +3,7 @@
 @implementation MGLForegroundStyleLayer
 
 - (NSString *)sourceIdentifier {
-    [NSException raise:@"MGLAbstractClassException"
+    [NSException raise:MGLAbstractClassException
                 format:@"MGLForegroundStyleLayer is an abstract class"];
     return nil;
 }

--- a/platform/darwin/src/MGLOfflinePack.h
+++ b/platform/darwin/src/MGLOfflinePack.h
@@ -1,9 +1,12 @@
 #import <Foundation/Foundation.h>
 
 #import "MGLFoundation.h"
+#import "MGLTypes.h"
 #import "MGLOfflineRegion.h"
 
 NS_ASSUME_NONNULL_BEGIN
+
+FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLInvalidOfflinePackException;
 
 /**
  The state an offline pack is currently in.

--- a/platform/darwin/src/MGLOfflinePack.mm
+++ b/platform/darwin/src/MGLOfflinePack.mm
@@ -8,6 +8,8 @@
 
 #include <mbgl/storage/default_file_source.hpp>
 
+const MGLExceptionName MGLInvalidOfflinePackException = @"MGLInvalidOfflinePackException";
+
 /**
  Assert that the current offline pack is valid.
 
@@ -17,7 +19,7 @@
 #define MGLAssertOfflinePackIsValid() \
     do { \
         if (_state == MGLOfflinePackStateInvalid) { \
-            [NSException raise:@"Invalid offline pack" \
+            [NSException raise:MGLInvalidOfflinePackException \
                         format: \
              @"-[MGLOfflineStorage removePack:withCompletionHandler:] has been called " \
              @"on this instance of MGLOfflinePack, rendering it invalid. It is an " \

--- a/platform/darwin/src/MGLOfflineStorage.h
+++ b/platform/darwin/src/MGLOfflineStorage.h
@@ -105,6 +105,8 @@ FOUNDATION_EXTERN MGL_EXPORT const MGLOfflinePackUserInfoKey MGLOfflinePackUserI
 
 FOUNDATION_EXTERN MGL_EXPORT NSString * const MGLOfflinePackMaximumCountUserInfoKey __attribute__((unavailable("Use MGLOfflinePackUserInfoKeyMaximumCount")));
 
+FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLUnsupportedRegionTypeException;
+
 /**
  A block to be called once an offline pack has been completely created and
  added.

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -30,6 +30,8 @@ const MGLOfflinePackUserInfoKey MGLOfflinePackUserInfoKeyProgress = @"Progress";
 const MGLOfflinePackUserInfoKey MGLOfflinePackUserInfoKeyError = @"Error";
 const MGLOfflinePackUserInfoKey MGLOfflinePackUserInfoKeyMaximumCount = @"MaximumCount";
 
+const MGLExceptionName MGLUnsupportedRegionTypeException = @"MGLUnsupportedRegionTypeException";
+
 @interface MGLOfflineStorage ()
 
 @property (nonatomic, strong, readwrite) NSMutableArray<MGLOfflinePack *> *packs;
@@ -278,8 +280,8 @@ const MGLOfflinePackUserInfoKey MGLOfflinePackUserInfoKeyMaximumCount = @"Maximu
 
 - (void)_addPackForRegion:(id <MGLOfflineRegion>)region withContext:(NSData *)context completionHandler:(MGLOfflinePackAdditionCompletionHandler)completion {
     if (![region conformsToProtocol:@protocol(MGLOfflineRegion_Private)]) {
-        [NSException raise:@"Unsupported region type" format:
-         @"Regions of type %@ are unsupported.", NSStringFromClass([region class])];
+        [NSException raise:MGLUnsupportedRegionTypeException
+                    format:@"Regions of type %@ are unsupported.", NSStringFromClass([region class])];
         return;
     }
 

--- a/platform/darwin/src/MGLShape.mm
+++ b/platform/darwin/src/MGLShape.mm
@@ -40,7 +40,7 @@ bool operator==(const CLLocationCoordinate2D lhs, const CLLocationCoordinate2D r
 }
 
 - (mbgl::Geometry<double>)geometryObject {
-    [NSException raise:@"MGLAbstractClassException"
+    [NSException raise:MGLAbstractClassException
                 format:@"MGLShape is an abstract class"];
     return mbgl::Point<double>();
 }
@@ -103,9 +103,8 @@ bool operator==(const CLLocationCoordinate2D lhs, const CLLocationCoordinate2D r
 
 - (CLLocationCoordinate2D)coordinate
 {
-    [[NSException exceptionWithName:@"MGLAbstractClassException"
-                             reason:@"MGLShape is an abstract class"
-                           userInfo:nil] raise];
+    [NSException raise:MGLAbstractClassException
+                format:@"MGLShape is an abstract class"];
     return kCLLocationCoordinate2DInvalid;
 }
 

--- a/platform/darwin/src/MGLSource.mm
+++ b/platform/darwin/src/MGLSource.mm
@@ -48,7 +48,7 @@
 
 - (void)addToMapView:(MGLMapView *)mapView {
     if (_pendingSource == nullptr) {
-        [NSException raise:@"MGLRedundantSourceException"
+        [NSException raise:MGLRedundantSourceException
                     format:@"This instance %@ was already added to %@. Adding the same source instance " \
          "to the style more than once is invalid.", self, mapView.style];
     }

--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -31,6 +31,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 static MGL_EXPORT const NSInteger MGLStyleDefaultVersion = 10;
 
+FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLInvalidStyleURLException;
+FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLRedundantLayerException;
+FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLRedundantLayerIdentifierException;
+FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLRedundantSourceException;
+FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLRedundantSourceIdentifierException;
+
 /**
  The proxy object for the current map style.
 

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -55,6 +55,12 @@
     #import "NSImage+MGLAdditions.h"
 #endif
 
+const MGLExceptionName MGLInvalidStyleURLException = @"MGLInvalidStyleURLException";
+const MGLExceptionName MGLRedundantLayerException = @"MGLRedundantLayerException";
+const MGLExceptionName MGLRedundantLayerIdentifierException = @"MGLRedundantLayerIdentifierException";
+const MGLExceptionName MGLRedundantSourceException = @"MGLRedundantSourceException";
+const MGLExceptionName MGLRedundantSourceIdentifierException = @"MGLRedundantSourceIdentifierException";
+
 /**
  Model class for localization changes.
  */
@@ -210,7 +216,7 @@ static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
     try {
         [source addToMapView:self.mapView];
     } catch (std::runtime_error & err) {
-        [NSException raise:@"MGLRedundantSourceIdentifierException" format:@"%s", err.what()];
+        [NSException raise:MGLRedundantSourceIdentifierException format:@"%s", err.what()];
     }
 }
 
@@ -313,14 +319,14 @@ static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
             MGLStyleLayer *sibling = layers.size() ? [self layerFromMBGLLayer:layers.at(0)] : nil;
             [styleLayer addToStyle:self belowLayer:sibling];
         } catch (const std::runtime_error & err) {
-            [NSException raise:@"MGLRedundantLayerIdentifierException" format:@"%s", err.what()];
+            [NSException raise:MGLRedundantLayerIdentifierException format:@"%s", err.what()];
         }
     } else {
         try {
             MGLStyleLayer *sibling = [self layerFromMBGLLayer:layers.at(index)];
             [styleLayer addToStyle:self belowLayer:sibling];
         } catch (std::runtime_error & err) {
-            [NSException raise:@"MGLRedundantLayerIdentifierException" format:@"%s", err.what()];
+            [NSException raise:MGLRedundantLayerIdentifierException format:@"%s", err.what()];
         }
     }
 }
@@ -402,7 +408,7 @@ static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
     try {
         [layer addToStyle:self belowLayer:nil];
     } catch (std::runtime_error & err) {
-        [NSException raise:@"MGLRedundantLayerIdentifierException" format:@"%s", err.what()];
+        [NSException raise:MGLRedundantLayerIdentifierException format:@"%s", err.what()];
     }
     [self didChangeValueForKey:@"layers"];
 }
@@ -431,7 +437,7 @@ static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
     try {
         [layer addToStyle:self belowLayer:sibling];
     } catch (std::runtime_error & err) {
-        [NSException raise:@"MGLRedundantLayerIdentifierException" format:@"%s", err.what()];
+        [NSException raise:MGLRedundantLayerIdentifierException format:@"%s", err.what()];
     }
     [self didChangeValueForKey:@"layers"];
 }
@@ -473,14 +479,14 @@ static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
         try {
             [layer addToStyle:self belowLayer:nil];
         } catch (std::runtime_error & err) {
-            [NSException raise:@"MGLRedundantLayerIdentifierException" format:@"%s", err.what()];
+            [NSException raise:MGLRedundantLayerIdentifierException format:@"%s", err.what()];
         }
     } else {
         MGLStyleLayer *sibling = [self layerFromMBGLLayer:layers.at(index + 1)];
         try {
             [layer addToStyle:self belowLayer:sibling];
         } catch (std::runtime_error & err) {
-            [NSException raise:@"MGLRedundantLayerIdentifierException" format:@"%s", err.what()];
+            [NSException raise:MGLRedundantLayerIdentifierException format:@"%s", err.what()];
         }
     }
     [self didChangeValueForKey:@"layers"];

--- a/platform/darwin/src/MGLStyleLayer.h
+++ b/platform/darwin/src/MGLStyleLayer.h
@@ -5,6 +5,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLInvalidStyleLayerException;
+
 /**
  `MGLStyleLayer` is an abstract base class for style layers. A style layer
  manages the layout and appearance of content at a specific z-index in a style.

--- a/platform/darwin/src/MGLStyleLayer.mm
+++ b/platform/darwin/src/MGLStyleLayer.mm
@@ -4,6 +4,8 @@
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/layer.hpp>
 
+const MGLExceptionName MGLInvalidStyleLayerException = @"MGLInvalidStyleLayerException";
+
 @interface MGLStyleLayer ()
 
 @property (nonatomic, readonly) mbgl::style::Layer *rawLayer;
@@ -33,7 +35,7 @@
 - (void)addToStyle:(MGLStyle *)style belowLayer:(MGLStyleLayer *)otherLayer
 {
     if (_pendingLayer == nullptr) {
-        [NSException raise:@"MGLRedundantLayerException"
+        [NSException raise:MGLRedundantLayerException
             format:@"This instance %@ was already added to %@. Adding the same layer instance " \
                     "to the style more than once is invalid.", self, style];
     }

--- a/platform/darwin/src/MGLStyleLayer_Private.h
+++ b/platform/darwin/src/MGLStyleLayer_Private.h
@@ -24,7 +24,7 @@ struct LayerWrapper {
 #define MGLAssertStyleLayerIsValid() \
     do { \
         if (!self.rawLayer) { \
-            [NSException raise:@"Invalid style layer" \
+            [NSException raise:MGLInvalidStyleLayerException \
                         format: \
             @"-[MGLStyle removeLayer:] has been called " \
             @"with this instance but another style layer instance was added with the same identifer. It is an " \

--- a/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
+++ b/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
@@ -23,7 +23,7 @@
 }
 
 - (instancetype)init {
-    [NSException raise:@"Method unavailable"
+    [NSException raise:MGLUnavailableMethodException
                 format:
      @"-[MGLTilePyramidOfflineRegion init] is unavailable. "
      @"Use -initWithStyleURL:bounds:fromZoomLevel:toZoomLevel: instead."];
@@ -37,7 +37,7 @@
         }
 
         if (!styleURL.scheme) {
-            [NSException raise:@"Invalid style URL" format:
+            [NSException raise:MGLInvalidStyleURLException format:
              @"%@ does not support setting a relative file URL as the style URL. "
              @"To download the online resources required by this style, "
              @"specify a URL to an online copy of this style. "

--- a/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
+++ b/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
@@ -23,8 +23,7 @@
 }
 
 - (instancetype)init {
-    [NSException raise:MGLUnavailableMethodException
-                format:
+    [NSException raise:NSGenericException format:
      @"-[MGLTilePyramidOfflineRegion init] is unavailable. "
      @"Use -initWithStyleURL:bounds:fromZoomLevel:toZoomLevel: instead."];
     return nil;

--- a/platform/darwin/src/MGLTileSource.mm
+++ b/platform/darwin/src/MGLTileSource.mm
@@ -25,7 +25,7 @@ const MGLTileSourceOption MGLTileSourceOptionDEMEncoding = @"MGLTileSourceOption
 @implementation MGLTileSource
 
 - (NSURL *)configurationURL {
-    [NSException raise:@"MGLAbstractClassException"
+    [NSException raise:MGLAbstractClassException
                 format:@"MGLTileSource is an abstract class"];
     return nil;
 }
@@ -41,7 +41,7 @@ const MGLTileSourceOption MGLTileSourceOptionDEMEncoding = @"MGLTileSourceOption
 }
 
 - (NSString *)attributionHTMLString {
-    [NSException raise:@"MGLAbstractClassException"
+    [NSException raise:MGLAbstractClassException
                 format:@"MGLTileSource is an abstract class"];
     return nil;
 }

--- a/platform/darwin/src/MGLTypes.h
+++ b/platform/darwin/src/MGLTypes.h
@@ -32,6 +32,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef NSString *MGLExceptionName NS_TYPED_EXTENSIBLE_ENUM;
 
+/**
+ :nodoc: Generic exceptions used across multiple disparate classes. Exceptions
+ that are unique to a class or class-cluster should be defined in those headers.
+ */
 FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLAbstractClassException;
 FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLUnavailableMethodException;
 

--- a/platform/darwin/src/MGLTypes.h
+++ b/platform/darwin/src/MGLTypes.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
     typedef NSString *NSNotificationName;
 #endif
 
-typedef NSString *MGLExceptionName NS_EXTENSIBLE_STRING_ENUM;
+typedef NSString *MGLExceptionName NS_TYPED_EXTENSIBLE_ENUM;
 
 FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLAbstractClassException;
 FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLUnavailableMethodException;

--- a/platform/darwin/src/MGLTypes.h
+++ b/platform/darwin/src/MGLTypes.h
@@ -37,7 +37,6 @@ typedef NSString *MGLExceptionName NS_TYPED_EXTENSIBLE_ENUM;
  that are unique to a class or class-cluster should be defined in those headers.
  */
 FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLAbstractClassException;
-FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLUnavailableMethodException;
 
 /** Indicates an error occurred in the Mapbox SDK. */
 FOUNDATION_EXTERN MGL_EXPORT NSErrorDomain const MGLErrorDomain;

--- a/platform/darwin/src/MGLTypes.h
+++ b/platform/darwin/src/MGLTypes.h
@@ -30,6 +30,11 @@ NS_ASSUME_NONNULL_BEGIN
     typedef NSString *NSNotificationName;
 #endif
 
+typedef NSString *MGLExceptionName NS_EXTENSIBLE_STRING_ENUM;
+
+FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLAbstractClassException;
+FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLUnavailableMethodException;
+
 /** Indicates an error occurred in the Mapbox SDK. */
 FOUNDATION_EXTERN MGL_EXPORT NSErrorDomain const MGLErrorDomain;
 

--- a/platform/darwin/src/MGLTypes.m
+++ b/platform/darwin/src/MGLTypes.m
@@ -1,6 +1,5 @@
 #import "MGLTypes.h"
 
 const MGLExceptionName MGLAbstractClassException = @"MGLAbstractClassException";
-const MGLExceptionName MGLUnavailableMethodException = @"MGLUnavailableMethodException";
 
 NSString * const MGLErrorDomain = @"MGLErrorDomain";

--- a/platform/darwin/src/MGLTypes.m
+++ b/platform/darwin/src/MGLTypes.m
@@ -1,3 +1,6 @@
 #import "MGLTypes.h"
 
+const MGLExceptionName MGLAbstractClassException = @"MGLAbstractClassException";
+const MGLExceptionName MGLUnavailableMethodException = @"MGLUnavailableMethodException";
+
 NSString * const MGLErrorDomain = @"MGLErrorDomain";

--- a/platform/darwin/src/MGLVectorStyleLayer.m
+++ b/platform/darwin/src/MGLVectorStyleLayer.m
@@ -3,12 +3,12 @@
 @implementation MGLVectorStyleLayer
 
 - (void)setPredicate:(NSPredicate *)predicate {
-    [NSException raise:@"MGLAbstractClassException"
+    [NSException raise:MGLAbstractClassException
                 format:@"MGLVectorStyleLayer is an abstract class"];
 }
 
 - (NSPredicate *)predicate {
-    [NSException raise:@"MGLAbstractClassException"
+    [NSException raise:MGLAbstractClassException
                 format:@"MGLVectorStyleLayer is an abstract class"];
     return nil;
 }

--- a/platform/darwin/src/NSBundle+MGLAdditions.h
+++ b/platform/darwin/src/NSBundle+MGLAdditions.h
@@ -27,6 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 #define NSLocalizedStringWithDefaultValue(key, tbl, bundle, val, comment) \
     [[NSBundle mgl_frameworkBundle] localizedStringForKey:(key) value:(val) table:(tbl)]
 
+FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLBundleNotFoundException;
+
 @interface NSBundle (MGLAdditions)
 
 /// Returns the bundle containing the SDK’s classes and Info.plist file.

--- a/platform/darwin/src/NSBundle+MGLAdditions.m
+++ b/platform/darwin/src/NSBundle+MGLAdditions.m
@@ -2,6 +2,8 @@
 
 #import "MGLAccountManager.h"
 
+const MGLExceptionName MGLBundleNotFoundException = @"MGLBundleNotFoundException";
+
 @implementation NSBundle (MGLAdditions)
 
 + (instancetype)mgl_frameworkBundle {
@@ -14,8 +16,8 @@
         if (bundlePath) {
             bundle = [self bundleWithPath:bundlePath];
         } else {
-            [NSException raise:@"MGLBundleNotFoundException" format:
-             @"The Mapbox framework bundle could not be found. If using the Mapbox Maps SDK for iOS as a static framework, make sure that Mapbox.bundle is copied into the root of the app bundle."];
+            [NSException raise:MGLBundleNotFoundException
+                        format:@"The Mapbox framework bundle could not be found. If using the Mapbox Maps SDK for iOS as a static framework, make sure that Mapbox.bundle is copied into the root of the app bundle."];
         }
     }
 

--- a/platform/darwin/test/MGLOfflinePackTests.m
+++ b/platform/darwin/test/MGLOfflinePackTests.m
@@ -12,10 +12,10 @@
 
     XCTAssertEqual(invalidPack.state, MGLOfflinePackStateInvalid, @"Offline pack should be invalid when initialized independently of MGLOfflineStorage.");
 
-    XCTAssertThrowsSpecificNamed(invalidPack.region, NSException, @"Invalid offline pack", @"Invalid offline pack should raise an exception when accessing its region.");
-    XCTAssertThrowsSpecificNamed(invalidPack.context, NSException, @"Invalid offline pack", @"Invalid offline pack should raise an exception when accessing its context.");
-    XCTAssertThrowsSpecificNamed([invalidPack resume], NSException, @"Invalid offline pack", @"Invalid offline pack should raise an exception when being resumed.");
-    XCTAssertThrowsSpecificNamed([invalidPack suspend], NSException, @"Invalid offline pack", @"Invalid offline pack should raise an exception when being suspended.");
+    XCTAssertThrowsSpecificNamed(invalidPack.region, NSException, MGLInvalidOfflinePackException, @"Invalid offline pack should raise an exception when accessing its region.");
+    XCTAssertThrowsSpecificNamed(invalidPack.context, NSException, MGLInvalidOfflinePackException, @"Invalid offline pack should raise an exception when accessing its context.");
+    XCTAssertThrowsSpecificNamed([invalidPack resume], NSException, MGLInvalidOfflinePackException, @"Invalid offline pack should raise an exception when being resumed.");
+    XCTAssertThrowsSpecificNamed([invalidPack suspend], NSException, MGLInvalidOfflinePackException, @"Invalid offline pack should raise an exception when being suspended.");
 }
 
 - (void)testProgressBoxing {

--- a/platform/darwin/test/MGLOfflineRegionTests.m
+++ b/platform/darwin/test/MGLOfflineRegionTests.m
@@ -14,7 +14,7 @@
     XCTAssertEqualObjects(region.styleURL, [MGLStyle streetsStyleURLWithVersion:MGLStyleDefaultVersion], @"Streets isn’t the default style.");
 
     NSURL *localURL = [NSURL URLWithString:@"beautiful.style"];
-    XCTAssertThrowsSpecificNamed([[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:localURL bounds:bounds fromZoomLevel:0 toZoomLevel:DBL_MAX], NSException, @"Invalid style URL", @"No exception raised when initializing region with a local file URL as the style URL.");
+    XCTAssertThrowsSpecificNamed([[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:localURL bounds:bounds fromZoomLevel:0 toZoomLevel:DBL_MAX], NSException, MGLInvalidStyleURLException, @"No exception raised when initializing region with a local file URL as the style URL.");
 }
 
 - (void)testEquality {

--- a/platform/darwin/test/MGLStyleTests.mm
+++ b/platform/darwin/test/MGLStyleTests.mm
@@ -156,15 +156,15 @@
 - (void)testAddingSourcesTwice {
     MGLShapeSource *shapeSource = [[MGLShapeSource alloc] initWithIdentifier:@"shapeSource" shape:nil options:nil];
     [self.style addSource:shapeSource];
-    XCTAssertThrowsSpecificNamed([self.style addSource:shapeSource], NSException, @"MGLRedundantSourceException");
+    XCTAssertThrowsSpecificNamed([self.style addSource:shapeSource], NSException, MGLRedundantSourceException);
 
     MGLRasterTileSource *rasterTileSource = [[MGLRasterTileSource alloc] initWithIdentifier:@"rasterTileSource" configurationURL:[NSURL URLWithString:@".json"] tileSize:42];
     [self.style addSource:rasterTileSource];
-    XCTAssertThrowsSpecificNamed([self.style addSource:rasterTileSource], NSException, @"MGLRedundantSourceException");
+    XCTAssertThrowsSpecificNamed([self.style addSource:rasterTileSource], NSException, MGLRedundantSourceException);
 
     MGLVectorTileSource *vectorTileSource = [[MGLVectorTileSource alloc] initWithIdentifier:@"vectorTileSource" configurationURL:[NSURL URLWithString:@".json"]];
     [self.style addSource:vectorTileSource];
-    XCTAssertThrowsSpecificNamed([self.style addSource:vectorTileSource], NSException, @"MGLRedundantSourceException");
+    XCTAssertThrowsSpecificNamed([self.style addSource:vectorTileSource], NSException, MGLRedundantSourceException);
 }
 
 - (void)testAddingSourcesWithDuplicateIdentifiers {
@@ -172,7 +172,7 @@
     MGLVectorTileSource *source2 = [[MGLVectorTileSource alloc] initWithIdentifier:@"my-source" configurationURL:[NSURL URLWithString:@"mapbox://mapbox.mapbox-terrain-v2"]];
 
     [self.style addSource: source1];
-    XCTAssertThrowsSpecificNamed([self.style addSource: source2], NSException, @"MGLRedundantSourceIdentifierException");
+    XCTAssertThrowsSpecificNamed([self.style addSource: source2], NSException, MGLRedundantSourceIdentifierException);
 }
 
 - (void)testRemovingSourcesBeforeAddingThem {
@@ -265,27 +265,27 @@
 
     MGLBackgroundStyleLayer *backgroundLayer = [[MGLBackgroundStyleLayer alloc] initWithIdentifier:@"backgroundLayer"];
     [self.style addLayer:backgroundLayer];
-    XCTAssertThrowsSpecificNamed([self.style addLayer:backgroundLayer], NSException, @"MGLRedundantLayerException");
+    XCTAssertThrowsSpecificNamed([self.style addLayer:backgroundLayer], NSException, MGLRedundantLayerException);
 
     MGLCircleStyleLayer *circleLayer = [[MGLCircleStyleLayer alloc] initWithIdentifier:@"circleLayer" source:source];
     [self.style addLayer:circleLayer];
-    XCTAssertThrowsSpecificNamed([self.style addLayer:circleLayer], NSException, @"MGLRedundantLayerException");
+    XCTAssertThrowsSpecificNamed([self.style addLayer:circleLayer], NSException, MGLRedundantLayerException);
 
     MGLFillStyleLayer *fillLayer = [[MGLFillStyleLayer alloc] initWithIdentifier:@"fillLayer" source:source];
     [self.style addLayer:fillLayer];
-    XCTAssertThrowsSpecificNamed([self.style addLayer:fillLayer], NSException, @"MGLRedundantLayerException");
+    XCTAssertThrowsSpecificNamed([self.style addLayer:fillLayer], NSException, MGLRedundantLayerException);
 
     MGLLineStyleLayer *lineLayer = [[MGLLineStyleLayer alloc] initWithIdentifier:@"lineLayer" source:source];
     [self.style addLayer:lineLayer];
-    XCTAssertThrowsSpecificNamed([self.style addLayer:lineLayer], NSException, @"MGLRedundantLayerException");
+    XCTAssertThrowsSpecificNamed([self.style addLayer:lineLayer], NSException, MGLRedundantLayerException);
 
     MGLRasterStyleLayer *rasterLayer = [[MGLRasterStyleLayer alloc] initWithIdentifier:@"rasterLayer" source:source];
     [self.style addLayer:rasterLayer];
-    XCTAssertThrowsSpecificNamed([self.style addLayer:rasterLayer], NSException, @"MGLRedundantLayerException");
+    XCTAssertThrowsSpecificNamed([self.style addLayer:rasterLayer], NSException, MGLRedundantLayerException);
 
     MGLSymbolStyleLayer *symbolLayer = [[MGLSymbolStyleLayer alloc] initWithIdentifier:@"symbolLayer" source:source];
     [self.style addLayer:symbolLayer];
-    XCTAssertThrowsSpecificNamed([self.style addLayer:symbolLayer], NSException, @"MGLRedundantLayerException");
+    XCTAssertThrowsSpecificNamed([self.style addLayer:symbolLayer], NSException, MGLRedundantLayerException);
 }
 
 - (void)testAddingLayersWithDuplicateIdentifiers {

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 ## master
 
 * Improved the Swift interface for `MGLMapView.decelerationRate`. ([#12584](https://github.com/mapbox/mapbox-gl-native/issues/12584))
+* Fixed inconsistencies in exception naming. ([#12583](https://github.com/mapbox/mapbox-gl-native/issues/12583))
 
 ## 4.3.0
 

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -97,6 +97,10 @@ FOUNDATION_EXTERN MGL_EXPORT const MGLMapViewPreferredFramesPerSecond MGLMapView
 /** The maximum supported frame rate; typically 60 FPS. */
 FOUNDATION_EXTERN MGL_EXPORT const MGLMapViewPreferredFramesPerSecond MGLMapViewPreferredFramesPerSecondMaximum;
 
+FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLMissingLocationServicesUsageDescriptionException;
+FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLUserLocationAnnotationTypeException;
+FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLResourceNotFoundException;
+
 /**
  An interactive, customizable map view with an interface similar to the one
  provided by Apple’s MapKit.

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -92,6 +92,10 @@ const MGLMapViewPreferredFramesPerSecond MGLMapViewPreferredFramesPerSecondDefau
 const MGLMapViewPreferredFramesPerSecond MGLMapViewPreferredFramesPerSecondLowPower = 30;
 const MGLMapViewPreferredFramesPerSecond MGLMapViewPreferredFramesPerSecondMaximum = 60;
 
+const MGLExceptionName MGLMissingLocationServicesUsageDescriptionException = @"MGLMissingLocationServicesUsageDescriptionException";
+const MGLExceptionName MGLUserLocationAnnotationTypeException = @"MGLUserLocationAnnotationTypeException";
+const MGLExceptionName MGLResourceNotFoundException = @"MGLResourceNotFoundException";
+
 /// Indicates the manner in which the map view is tracking the user location.
 typedef NS_ENUM(NSUInteger, MGLUserTrackingState) {
     /// The map view is not yet tracking the user location.
@@ -138,7 +142,7 @@ static NSString * const MGLInvisibleStyleMarkerSymbolName = @"invisible_marker";
 
 /// Prefix that denotes a sprite installed by MGLMapView, to avoid collisions
 /// with style-defined sprites.
-NSString *const MGLAnnotationSpritePrefix = @"com.mapbox.sprites.";
+NSString * const MGLAnnotationSpritePrefix = @"com.mapbox.sprites.";
 
 /// Slop area around the hit testing point, allowing for imprecise annotation selection.
 const CGFloat MGLAnnotationImagePaddingForHitTest = 5;
@@ -4790,7 +4794,8 @@ public:
                 NSString *suggestedUsageKeys = requiresWhenInUseUsageDescription ?
                     @"NSLocationWhenInUseUsageDescription and (optionally) NSLocationAlwaysAndWhenInUseUsageDescription" :
                     @"NSLocationWhenInUseUsageDescription and/or NSLocationAlwaysUsageDescription";
-                [NSException raise:@"Missing Location Services usage description" format:@"This app must have a value for %@ in its Info.plist.", suggestedUsageKeys];
+                [NSException raise:MGLMissingLocationServicesUsageDescriptionException
+                            format:@"This app must have a value for %@ in its Info.plist.", suggestedUsageKeys];
             }
         }
 
@@ -4827,7 +4832,7 @@ public:
             userLocationAnnotationView = (MGLUserLocationAnnotationView *)[self.delegate mapView:self viewForAnnotation:self.userLocation];
             if (userLocationAnnotationView && ! [userLocationAnnotationView isKindOfClass:MGLUserLocationAnnotationView.class])
             {
-                [NSException raise:@"MGLUserLocationAnnotationTypeException"
+                [NSException raise:MGLUserLocationAnnotationTypeException
                             format:@"User location annotation view must be a kind of MGLUserLocationAnnotationView. %@", userLocationAnnotationView.debugDescription];
             }
         }
@@ -6007,7 +6012,7 @@ public:
 
     if ( ! image)
     {
-        [NSException raise:@"MGLResourceNotFoundException" format:
+        [NSException raise:MGLResourceNotFoundException format:
          @"The resource named “%@” could not be found in the Mapbox framework bundle.", imageName];
     }
 
@@ -6296,8 +6301,8 @@ private:
     NSURL *url = URLString.length ? [NSURL URLWithString:URLString] : nil;
     if (URLString.length && !url)
     {
-        [NSException raise:@"Invalid style URL" format:
-         @"“%@” is not a valid style URL.", URLString];
+        [NSException raise:MGLInvalidStyleURLException
+                    format:@"“%@” is not a valid style URL.", URLString];
     }
     self.styleURL = url;
 }


### PR DESCRIPTION
Fixes #7258 by converting stringly-typed exception names into `MGLExceptionName`-typed constants. This doesn’t attempt to document the exceptions, but that could happen in the future.

/cc @1ec5 @fabian-guerra @julianrex @captainbarbosa 