### PR TITLE
[ios] Add MGLMapViewDecelerationRate typed enum

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## master
+
+* Improved the Swift interface for `MGLMapView.decelerationRate`. ([#12584](https://github.com/mapbox/mapbox-gl-native/issues/12584))
+
 ## 4.3.0
 
 ### Styles and rendering

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -23,14 +23,17 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol MGLFeature;
 @protocol MGLLocationManager;
 
+/** Options for `MGLMapView.decelerationRate`. */
+typedef CGFloat MGLMapViewDecelerationRate NS_TYPED_EXTENSIBLE_ENUM;
+
 /** The default deceleration rate for a map view. */
-FOUNDATION_EXTERN MGL_EXPORT const CGFloat MGLMapViewDecelerationRateNormal;
+FOUNDATION_EXTERN MGL_EXPORT const MGLMapViewDecelerationRate MGLMapViewDecelerationRateNormal;
 
 /** A fast deceleration rate for a map view. */
-FOUNDATION_EXTERN MGL_EXPORT const CGFloat MGLMapViewDecelerationRateFast;
+FOUNDATION_EXTERN MGL_EXPORT const MGLMapViewDecelerationRate MGLMapViewDecelerationRateFast;
 
 /** Disables deceleration in a map view. */
-FOUNDATION_EXTERN MGL_EXPORT const CGFloat MGLMapViewDecelerationRateImmediate;
+FOUNDATION_EXTERN MGL_EXPORT const MGLMapViewDecelerationRate MGLMapViewDecelerationRateImmediate;
 
 /**
  The vertical alignment of an annotation within a map view. Used with

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -84,9 +84,9 @@
 class MBGLView;
 class MGLAnnotationContext;
 
-const CGFloat MGLMapViewDecelerationRateNormal = UIScrollViewDecelerationRateNormal;
-const CGFloat MGLMapViewDecelerationRateFast = UIScrollViewDecelerationRateFast;
-const CGFloat MGLMapViewDecelerationRateImmediate = 0.0;
+const MGLMapViewDecelerationRate MGLMapViewDecelerationRateNormal = UIScrollViewDecelerationRateNormal;
+const MGLMapViewDecelerationRate MGLMapViewDecelerationRateFast = UIScrollViewDecelerationRateFast;
+const MGLMapViewDecelerationRate MGLMapViewDecelerationRateImmediate = 0.0;
 
 const MGLMapViewPreferredFramesPerSecond MGLMapViewPreferredFramesPerSecondDefault = -1;
 const MGLMapViewPreferredFramesPerSecond MGLMapViewPreferredFramesPerSecondLowPower = 30;


### PR DESCRIPTION
Improves Swiftiness of `MGLMapView.decelerationRate` by allowing type-omission, à la `mapView.decelerationRate = .fast`.

In the past we’ve decided that Swift-only interface changes do not warrant semver major bumps. Swift users that have this property set will see a fix-it with something like:

> error: 'MGLMapViewDecelerationRateNormal' has been renamed to ‘MGLMapViewDecelerationRate.normal'

/cc @julianrex @fabian-guerra @captainbarbosa @1ec5 