### PR TITLE
[core] Fix build when building Qt Location plugin for Android

### DIFF
--- a/include/mbgl/math/log2.hpp
+++ b/include/mbgl/math/log2.hpp
@@ -2,6 +2,11 @@
 
 #include <cmath>
 #include <cstdint>
+#include <type_traits>
+
+#if defined(__ANDROID__)
+#include <android/api-level.h>
+#endif
 
 namespace mbgl {
 namespace util {
@@ -12,3 +17,14 @@ uint32_t ceil_log2(uint64_t x);
 
 } // namespace util
 } // namespace mbgl
+
+// log2 is not available on Android before API 18.
+#if defined(__ANDROID__) && defined(__GNUC__) && \
+    defined(__ANDROID_API__) && __ANDROID_API__ < 18
+
+template <typename T>
+typename std::enable_if_t<std::is_floating_point<T>::value, T> log2(T x) {
+    return ::log(x) / M_LN2;
+}
+
+#endif

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -193,8 +193,8 @@ void SymbolBucket::sortFeatures(const float angle) {
     std::sort(symbolInstanceIndexes.begin(), symbolInstanceIndexes.end(), [sin, cos, this](size_t &aIndex, size_t &bIndex) {
         const SymbolInstance& a = symbolInstances[aIndex];
         const SymbolInstance& b = symbolInstances[bIndex];
-        const int32_t aRotated = static_cast<int32_t>(std::lround(sin * a.anchor.point.x + cos * a.anchor.point.y));
-        const int32_t bRotated = static_cast<int32_t>(std::lround(sin * b.anchor.point.x + cos * b.anchor.point.y));
+        const int32_t aRotated = static_cast<int32_t>(::lround(sin * a.anchor.point.x + cos * a.anchor.point.y));
+        const int32_t bRotated = static_cast<int32_t>(::lround(sin * b.anchor.point.x + cos * b.anchor.point.y));
         return aRotated != bRotated ?
             aRotated < bRotated :
             a.dataFeatureIndex > b.dataFeatureIndex;

--- a/src/mbgl/util/tile_cover.cpp
+++ b/src/mbgl/util/tile_cover.cpp
@@ -4,6 +4,7 @@
 #include <mbgl/map/transform_state.hpp>
 #include <mbgl/util/tile_cover_impl.hpp>
 #include <mbgl/util/tile_coordinate.hpp>
+#include <mbgl/math/log2.hpp>
 
 #include <functional>
 #include <list>


### PR DESCRIPTION
- log2 is not available on Android before API 18.
- Android doesn't have 'round' on the std:: namespace when using g++.

Co-authored-by: Thiago Marcos P. Santos <thiago@mapbox.com>