### PR TITLE
[ios, macos] Introduce `MGLShapeSourceOptionLineDistanceMetrics`

### DIFF
--- a/platform/darwin/docs/guides/For Style Authors.md.ejs
+++ b/platform/darwin/docs/guides/For Style Authors.md.ejs
@@ -222,6 +222,7 @@ In style JSON    | In the SDK
 `cluster`        | `MGLShapeSourceOptionClustered`
 `clusterRadius`  | `MGLShapeSourceOptionClusterRadius`
 `clusterMaxZoom` | `MGLShapeSourceOptionMaximumZoomLevelForClustering`
+`lineMetrics`    | `MGLShapeSourceOptionLineDistanceMetrics`
 
 To create a shape source from local GeoJSON data, first
 [convert the GeoJSON data into a shape](working-with-geojson-data.html#converting-geojson-data-into-shape-objects),

--- a/platform/darwin/src/MGLShapeSource.h
+++ b/platform/darwin/src/MGLShapeSource.h
@@ -96,6 +96,18 @@ FOUNDATION_EXTERN MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionBuff
 FOUNDATION_EXTERN MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance;
 
 /**
+ An `NSNumber` object containing a Boolean enabling or disabling calculating line distance metrics. 
+ 
+ Set this property to `YES` in order for the `MGLLineStyleLayer.lineGradient` property to have its intended effect.
+ The default value is `NO`.
+ 
+ This option corresponds to the
+ <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#sources-geojson-lineMetrics"><code>lineMetrics</code></a>
+ source property in the Mapbox Style Specification.
+ */
+FOUNDATION_EXTERN MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionLineDistanceMetrics;
+
+/**
  `MGLShapeSource` is a map content source that supplies vector shapes to be
  shown on the map. The shapes may be instances of `MGLShape` or `MGLFeature`,
  or they may be defined by local or external

--- a/platform/darwin/src/MGLShapeSource.mm
+++ b/platform/darwin/src/MGLShapeSource.mm
@@ -20,6 +20,7 @@ const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevel = @"MGLShapeSour
 const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevelForClustering = @"MGLShapeSourceOptionMaximumZoomLevelForClustering";
 const MGLShapeSourceOption MGLShapeSourceOptionMinimumZoomLevel = @"MGLShapeSourceOptionMinimumZoomLevel";
 const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance = @"MGLShapeSourceOptionSimplificationTolerance";
+const MGLShapeSourceOption MGLShapeSourceOptionLineDistanceMetrics = @"MGLShapeSourceOptionLineDistanceMetrics";
 
 mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShapeSourceOption, id> *options) {
     auto geoJSONOptions = mbgl::style::GeoJSONOptions();
@@ -78,6 +79,14 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
                         format:@"MGLShapeSourceOptionClustered must be an NSNumber."];
         }
         geoJSONOptions.cluster = value.boolValue;
+    }
+
+    if (NSNumber *value = options[MGLShapeSourceOptionLineDistanceMetrics]) {
+        if (![value isKindOfClass:[NSNumber class]]) {
+            [NSException raise:NSInvalidArgumentException
+                        format:@"MGLShapeSourceOptionLineDistanceMetrics must be an NSNumber."];
+        }
+        geoJSONOptions.lineMetrics = value.boolValue;
     }
 
     return geoJSONOptions;

--- a/platform/darwin/test/MGLShapeSourceTests.mm
+++ b/platform/darwin/test/MGLShapeSourceTests.mm
@@ -18,7 +18,8 @@
                               MGLShapeSourceOptionMaximumZoomLevelForClustering: @98,
                               MGLShapeSourceOptionMaximumZoomLevel: @99,
                               MGLShapeSourceOptionBuffer: @1976,
-                              MGLShapeSourceOptionSimplificationTolerance: @0.42};
+                              MGLShapeSourceOptionSimplificationTolerance: @0.42,
+                              MGLShapeSourceOptionLineDistanceMetrics: @YES};
 
     auto mbglOptions = MGLGeoJSONOptionsFromDictionary(options);
     XCTAssertTrue(mbglOptions.cluster);
@@ -27,6 +28,7 @@
     XCTAssertEqual(mbglOptions.maxzoom, 99);
     XCTAssertEqual(mbglOptions.buffer, 1976);
     XCTAssertEqual(mbglOptions.tolerance, 0.42);
+    XCTAssertTrue(mbglOptions.lineMetrics);
 
     options = @{MGLShapeSourceOptionClustered: @"number 1"};
     XCTAssertThrows(MGLGeoJSONOptionsFromDictionary(options));

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -17,6 +17,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Token string syntax (`"{token}"`) in `MGLSymbolStyleLayer` `text` and `iconImageName` properties is now correctly converted to the appropriate `NSExpression` equivalent. ([#11659](https://github.com/mapbox/mapbox-gl-native/issues/11659))
 * Fixed a crash when switching between two styles having layers with the same identifier but different layer types. ([#12432](https://github.com/mapbox/mapbox-gl-native/issues/12432))
 * Added a new option to `MGLSymbolPlacement`, `MGLSymbolPlacementLineCenter`, that places the label relative to the center of the geometry. ([#12337](https://github.com/mapbox/mapbox-gl-native/pull/12337))
+* Added a `MGLShapeSourceOptionLineDistanceMetrics` property that enables or disables calculating line distance metrics.
 
 ## User location
 

--- a/platform/ios/docs/guides/For Style Authors.md
+++ b/platform/ios/docs/guides/For Style Authors.md
@@ -171,6 +171,7 @@ In style JSON    | In the SDK
 `cluster`        | `MGLShapeSourceOptionClustered`
 `clusterRadius`  | `MGLShapeSourceOptionClusterRadius`
 `clusterMaxZoom` | `MGLShapeSourceOptionMaximumZoomLevelForClustering`
+`lineMetrics`    | `MGLShapeSourceOptionLineDistanceMetrics`
 
 To create a shape source from local GeoJSON data, first
 [convert the GeoJSON data into a shape](working-with-geojson-data.html#converting-geojson-data-into-shape-objects),

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Token string syntax (`"{token}"`) in `MGLSymbolStyleLayer` `text` and `iconImageName` properties is now correctly converted to the appropriate `NSExpression` equivalent. ([#11659](https://github.com/mapbox/mapbox-gl-native/issues/11659))
 * Fixed a crash when switching between two styles having layers with the same identifier but different layer types. ([#12432](https://github.com/mapbox/mapbox-gl-native/issues/12432))
 * Added a new option to `MGLSymbolPlacement`, `MGLSymbolPlacementLineCenter`, that places the label relative to the center of the geometry. ([#12337](https://github.com/mapbox/mapbox-gl-native/pull/12337))
+* Added a `MGLShapeSourceOptionLineDistanceMetrics` property that enables or disables calculating line distance metrics.
 
 ## Other changes
 

--- a/platform/macos/docs/guides/For Style Authors.md
+++ b/platform/macos/docs/guides/For Style Authors.md
@@ -158,6 +158,7 @@ In style JSON    | In the SDK
 `cluster`        | `MGLShapeSourceOptionClustered`
 `clusterRadius`  | `MGLShapeSourceOptionClusterRadius`
 `clusterMaxZoom` | `MGLShapeSourceOptionMaximumZoomLevelForClustering`
+`lineMetrics`    | `MGLShapeSourceOptionLineDistanceMetrics`
 
 To create a shape source from local GeoJSON data, first
 [convert the GeoJSON data into a shape](working-with-geojson-data.html#converting-geojson-data-into-shape-objects),


### PR DESCRIPTION
Exposes access to
https://www.mapbox.com/mapbox-gl-js/style-spec/#sources-geojson-lineMetrics