### PR TITLE
Fix to textureview transparent background testapp activity

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_textureview_transparent.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_textureview_transparent.xml
@@ -21,8 +21,7 @@
         app:mapbox_cameraTargetLng="8.363795"
         app:mapbox_cameraZoom="2"
         app:mapbox_renderTextureMode="true"
-        app:mapbox_renderTextureTranslucentSurface="true"
-        app:mapbox_styleUrl="mapbox://styles/agerace-globant/cja02de7193b02suvy4gpbt2c"/>
+        app:mapbox_renderTextureTranslucentSurface="true"/>
 
 </android.support.design.widget.CoordinatorLayout>
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/raw/no_bg_style.json
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/raw/no_bg_style.json
@@ -2,7 +2,7 @@
   "version": 8,
   "name": "Land",
   "metadata": {
-    "mapbox:autocomposite": true,
+    "mapbox:autocomposite": true
   },
   "sources": {
     "composite": {


### PR DESCRIPTION
Map style wasn't loading because the style JSON had an erroneous comma in it.  Was exploring this because of https://github.com/mapbox/mapbox-android-demo/pull/820

**Before:**
![43932549-9f0d993a-9bf9-11e8-9b02-e9216b6440c1](https://user-images.githubusercontent.com/4394910/43973142-7ebaa4c4-9c8b-11e8-9fc2-ebee1caf7411.png)


**After:**

![ezgif com-resize 1](https://user-images.githubusercontent.com/4394910/43973206-b2177aae-9c8b-11e8-8cef-a65f14799494.gif)
