### PR TITLE
[android] temporarily disable CustomGeometrySource tests

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CustomGeometrySourceTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CustomGeometrySourceTest.kt
@@ -13,6 +13,7 @@ import com.mapbox.mapboxsdk.testapp.activity.style.GridSourceActivity
 import com.mapbox.mapboxsdk.testapp.activity.style.GridSourceActivity.ID_GRID_LAYER
 import com.mapbox.mapboxsdk.testapp.activity.style.GridSourceActivity.ID_GRID_SOURCE
 import org.junit.Assert
+import org.junit.Ignore
 import org.junit.Test
 
 class CustomGeometrySourceTest : BaseActivityTest() {
@@ -34,6 +35,7 @@ class CustomGeometrySourceTest : BaseActivityTest() {
   }
 
   @Test
+  @Ignore
   fun threadsShutdownWhenSourceRemovedTest() {
     validateTestSetup()
     invoke(mapboxMap) { uiController, mapboxMap ->
@@ -49,6 +51,7 @@ class CustomGeometrySourceTest : BaseActivityTest() {
   }
 
   @Test
+  @Ignore
   fun threadsRestartedWhenSourceReAddedTest() {
     validateTestSetup()
     invoke(mapboxMap) { uiController, mapboxMap ->


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/12618.

This PR temporarily disables a couple of `CustomGeometrySource` tests until https://github.com/mapbox/mapbox-gl-native/issues/12551 is resolved.