### PR TITLE
Fix out of range exception for string compare

### DIFF
--- a/platform/default/asset_file_source.cpp
+++ b/platform/default/asset_file_source.cpp
@@ -75,7 +75,7 @@ std::unique_ptr<AsyncRequest> AssetFileSource::request(const Resource& resource,
 }
 
 bool AssetFileSource::acceptsURL(const std::string& url) {
-    return std::equal(assetProtocol.begin(), assetProtocol.end(), url.begin());
+    return 0 == url.find(assetProtocol);
 }
 
 } // namespace mbgl

--- a/platform/default/asset_file_source.cpp
+++ b/platform/default/asset_file_source.cpp
@@ -75,7 +75,7 @@ std::unique_ptr<AsyncRequest> AssetFileSource::request(const Resource& resource,
 }
 
 bool AssetFileSource::acceptsURL(const std::string& url) {
-    return 0 == url.find(assetProtocol);
+    return 0 == url.rfind(assetProtocol, 0);
 }
 
 } // namespace mbgl

--- a/platform/default/local_file_source.cpp
+++ b/platform/default/local_file_source.cpp
@@ -75,7 +75,7 @@ std::unique_ptr<AsyncRequest> LocalFileSource::request(const Resource& resource,
 }
 
 bool LocalFileSource::acceptsURL(const std::string& url) {
-    return 0 == url.find(fileProtocol);
+    return 0 == url.rfind(fileProtocol, 0);
 }
 
 } // namespace mbgl

--- a/platform/default/local_file_source.cpp
+++ b/platform/default/local_file_source.cpp
@@ -75,7 +75,7 @@ std::unique_ptr<AsyncRequest> LocalFileSource::request(const Resource& resource,
 }
 
 bool LocalFileSource::acceptsURL(const std::string& url) {
-    return std::equal(fileProtocol.begin(), fileProtocol.end(), url.begin());
+    return 0 == url.find(fileProtocol);
 }
 
 } // namespace mbgl

--- a/src/mbgl/style/expression/is_constant.cpp
+++ b/src/mbgl/style/expression/is_constant.cpp
@@ -17,7 +17,7 @@ bool isFeatureConstant(const Expression& expression) {
             return false;
         } else if (name == "has" && parameterCount && *parameterCount == 1) {
             return false;
-        } else if (0 == name.find(filter)) {
+        } else if (0 == name.rfind(filter, 0)) {
             // Legacy filters begin with "filter-" and are never constant.
             return false;
         } else if (

--- a/src/mbgl/style/expression/is_constant.cpp
+++ b/src/mbgl/style/expression/is_constant.cpp
@@ -17,7 +17,7 @@ bool isFeatureConstant(const Expression& expression) {
             return false;
         } else if (name == "has" && parameterCount && *parameterCount == 1) {
             return false;
-        } else if (std::equal(std::begin(filter), std::end(filter) - 1, name.begin())) {
+        } else if (0 == name.find(filter)) {
             // Legacy filters begin with "filter-" and are never constant.
             return false;
         } else if (
@@ -28,7 +28,7 @@ bool isFeatureConstant(const Expression& expression) {
             return false;
         }
     }
-    
+
     if (expression.getKind() == Kind::CollatorExpression) {
         // Although the results of a Collator expression with fixed arguments
         // generally shouldn't change between executions, we can't serialize them


### PR DESCRIPTION
There's out of range exception in debug build, if the last argument of *std::equal* is shorter than the first.

Original exception was fired from is_constant.cpp . Text search for 'std::equal(' revealed couple other places.