### PR TITLE
release-espresso backport: Use unconverted bearing value for latlngbounds calculation

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1601,7 +1601,7 @@ public final class MapboxMap {
   public CameraPosition getCameraForLatLngBounds(@NonNull LatLngBounds latLngBounds,
                                                  @NonNull @Size(value = 4) int[] padding) {
     // we use current camera tilt/bearing value to provide expected transformations as #11993
-    return getCameraForLatLngBounds(latLngBounds, padding, transform.getBearing(), transform.getTilt());
+    return getCameraForLatLngBounds(latLngBounds, padding, transform.getRawBearing(), transform.getTilt());
   }
 
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/geometry/LatLngBoundsTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/geometry/LatLngBoundsTest.java
@@ -7,12 +7,17 @@ import com.mapbox.mapboxsdk.testapp.action.MapboxMapAction;
 import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 import com.mapbox.mapboxsdk.testapp.activity.feature.QueryRenderedFeaturesBoxHighlightActivity;
 
+import com.mapbox.mapboxsdk.testapp.utils.TestConstants;
 import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
 
 /**
  * Instrumentation test to validate integration of LatLngBounds
  */
 public class LatLngBoundsTest extends BaseActivityTest {
+
+  private static final double MAP_BEARING = 50;
 
   @Override
   protected Class getActivityClass() {
@@ -31,4 +36,31 @@ public class LatLngBoundsTest extends BaseActivityTest {
       mapboxMap.moveCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0));
     });
   }
+
+  @Test
+  public void testLatLngBoundsBearing() {
+    // regression test for #12549
+    validateTestSetup();
+    MapboxMapAction.invoke(mapboxMap, (uiController, mapboxMap) -> {
+      LatLngBounds bounds = new LatLngBounds.Builder()
+        .include(new LatLng(48.8589506, 2.2773457))
+        .include(new LatLng(47.2383171, -1.6309316))
+        .build();
+      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0));
+      mapboxMap.moveCamera(CameraUpdateFactory.bearingTo(MAP_BEARING));
+      assertEquals(
+        "Initial bearing should match for latlngbounds",
+        mapboxMap.getCameraPosition().bearing,
+        MAP_BEARING,
+        TestConstants.BEARING_DELTA
+      );
+
+      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0));
+      assertEquals("Bearing should match after resetting latlngbounds",
+        mapboxMap.getCameraPosition().bearing,
+        MAP_BEARING,
+        TestConstants.BEARING_DELTA);
+    });
+  }
+
 }


### PR DESCRIPTION
Backports #12616 to release-espresso
----
Closes https://github.com/mapbox/mapbox-gl-native/issues/12549, 
This PR uses unconverted bearing values from core when calculating bounds. 
Requires cherry pick to release-espresso branch.