### PR TITLE
[ios, macos] Warn if MGLShapeSource is initialized with MGLShapeCollection

### DIFF
--- a/platform/darwin/src/MGLComputedShapeSource.mm
+++ b/platform/darwin/src/MGLComputedShapeSource.mm
@@ -4,6 +4,7 @@
 #import "MGLSource_Private.h"
 #import "MGLShape_Private.h"
 #import "MGLGeometry_Private.h"
+#import "MGLShapeCollection.h"
 
 #include <mbgl/map/map.hpp>
 #include <mbgl/style/sources/custom_geometry_source.hpp>
@@ -131,6 +132,14 @@ mbgl::style::CustomGeometrySource::Options MBGLCustomGeometrySourceOptionsFromDi
         mbgl::FeatureCollection featureCollection;
         featureCollection.reserve(data.count);
         for (MGLShape <MGLFeature> * feature in data) {
+            if ([feature isMemberOfClass:[MGLShapeCollection class]]) {
+                static dispatch_once_t onceToken;
+                dispatch_once(&onceToken, ^{
+                    NSLog(@"MGLShapeCollection initialized with MGLFeatures will not retain attributes."
+                          @"Use MGLShapeCollectionFeature to retain attributes instead."
+                          @"This will be logged only once.");
+                });
+            }
             mbgl::Feature geoJsonObject = [feature geoJSONObject].get<mbgl::Feature>();
             featureCollection.push_back(geoJsonObject);
         }
@@ -196,6 +205,14 @@ mbgl::style::CustomGeometrySource::Options MBGLCustomGeometrySourceOptionsFromDi
     for (MGLShape <MGLFeature> * feature in features) {
         mbgl::Feature geoJsonObject = [feature geoJSONObject].get<mbgl::Feature>();
         featureCollection.push_back(geoJsonObject);
+        if ([feature isMemberOfClass:[MGLShapeCollection class]]) {
+            static dispatch_once_t onceToken;
+            dispatch_once(&onceToken, ^{
+                NSLog(@"MGLShapeCollection initialized with MGLFeatures will not retain attributes."
+                      @"Use MGLShapeCollectionFeature to retain attributes instead."
+                      @"This will be logged only once.");
+            });
+        }
     }
     const auto geojson = mbgl::GeoJSON{featureCollection};
     static_cast<mbgl::style::CustomGeometrySource *>(self.rawSource)->setTileData(tileID, geojson);

--- a/platform/darwin/src/MGLShapeCollection.mm
+++ b/platform/darwin/src/MGLShapeCollection.mm
@@ -1,6 +1,7 @@
 #import "MGLShapeCollection.h"
 
 #import "MGLShape_Private.h"
+#import "MGLFeature.h"
 
 #import <mbgl/style/conversion/geojson.hpp>
 

--- a/platform/darwin/src/MGLShapeSource.mm
+++ b/platform/darwin/src/MGLShapeSource.mm
@@ -105,6 +105,14 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
     auto geoJSONOptions = MGLGeoJSONOptionsFromDictionary(options);
     auto source = std::make_unique<mbgl::style::GeoJSONSource>(identifier.UTF8String, geoJSONOptions);
     if (self = [super initWithPendingSource:std::move(source)]) {
+        if ([shape isMemberOfClass:[MGLShapeCollection class]]) {
+            static dispatch_once_t onceToken;
+            dispatch_once(&onceToken, ^{
+                NSLog(@"MGLShapeCollection initialized with MGLFeatures will not retain attributes."
+                        @"Use MGLShapeCollectionFeature to retain attributes instead."
+                        @"This will be logged only once.");
+            });
+        }
         self.shape = shape;
     }
     return self;

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * The `-[MGLMapView visibleFeaturesAtPoint:]` method can now return features near tile boundaries at high zoom levels. ([#12570](https://github.com/mapbox/mapbox-gl-native/pull/12570))
 * Fixed inconsistencies in exception naming. ([#12583](https://github.com/mapbox/mapbox-gl-native/issues/12583))
 * Added `MGLShapeOfflineRegion` for defining arbitrarily shaped offline regions [#11447](https://github.com/mapbox/mapbox-gl-native/pull/11447)
+* Added a one-time warning about possible attribute loss when initializing an `MGLShapeSource` with an `MGLShapeCollection` [#12625](https://github.com/mapbox/mapbox-gl-native/pull/12625)
 
 ## 4.3.0 - August 15, 2018
 


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/11287 by throwing a single warning if any `MGLShapeCollection` contains a shape conforming to `MGLFeature` protocol, as attributes are not copied over into `MGLShapeCollection`s. 