### PR TITLE
Prioritize style loading 

### DIFF
--- a/platform/default/online_file_source.cpp
+++ b/platform/default/online_file_source.cpp
@@ -111,7 +111,10 @@ public:
     }
 
     void queueRequest(OnlineFileRequest* request) {
-        auto it = pendingRequestsList.insert(pendingRequestsList.end(), request);
+        auto it = pendingRequestsList.insert(
+            // prioritise style loading so an ongoing offline download doesn't block showing a new map
+            request->resource.kind == Resource::Style ? pendingRequestsList.begin() : pendingRequestsList.end(), request
+        );
         pendingRequestsMap.emplace(request, std::move(it));
         assert(pendingRequestsMap.size() == pendingRequestsList.size());
     }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/11461 
Closes https://github.com/mapbox/mapbox-gl-native/issues/12610

This PR is a potential easy fix for above issues. When an offline download is ongoing and the user tries to show a new map. The map won't show and the OnMapReady isn't invoked. This stems from the style resource being placed at the at the end of the online filesource queue. This PR prioritizes downloading style resources by placing it and the start of the queue. 

Note that I'm unfamiliar with the internal working of the online filesource and c++ components used.