### PR TITLE
release-espresso backport: Fix out of range exception for string compare

### DIFF
--- a/platform/default/asset_file_source.cpp
+++ b/platform/default/asset_file_source.cpp
@@ -75,7 +75,7 @@ std::unique_ptr<AsyncRequest> AssetFileSource::request(const Resource& resource,
 }
 
 bool AssetFileSource::acceptsURL(const std::string& url) {
-    return std::equal(assetProtocol.begin(), assetProtocol.end(), url.begin());
+    return 0 == url.rfind(assetProtocol, 0);
 }
 
 } // namespace mbgl

--- a/platform/default/local_file_source.cpp
+++ b/platform/default/local_file_source.cpp
@@ -75,7 +75,7 @@ std::unique_ptr<AsyncRequest> LocalFileSource::request(const Resource& resource,
 }
 
 bool LocalFileSource::acceptsURL(const std::string& url) {
-    return std::equal(fileProtocol.begin(), fileProtocol.end(), url.begin());
+    return 0 == url.rfind(fileProtocol, 0);
 }
 
 } // namespace mbgl

--- a/src/mbgl/style/expression/is_constant.cpp
+++ b/src/mbgl/style/expression/is_constant.cpp
@@ -17,7 +17,7 @@ bool isFeatureConstant(const Expression& expression) {
             return false;
         } else if (name == "has" && parameterCount && *parameterCount == 1) {
             return false;
-        } else if (std::equal(std::begin(filter), std::end(filter) - 1, name.begin())) {
+        } else if (0 == name.rfind(filter, 0)) {
             // Legacy filters begin with "filter-" and are never constant.
             return false;
         } else if (
@@ -28,7 +28,7 @@ bool isFeatureConstant(const Expression& expression) {
             return false;
         }
     }
-    
+
     if (expression.getKind() == Kind::CollatorExpression) {
         // Although the results of a Collator expression with fixed arguments
         // generally shouldn't change between executions, we can't serialize them

--- a/test/style/filter.test.cpp
+++ b/test/style/filter.test.cpp
@@ -251,3 +251,7 @@ TEST(Filter, ZoomExpressionNested) {
 TEST(Filter, Internal) {
     filter(R"(["filter-==","class","snow"])");
 }
+
+TEST(Filter, Short) {
+    filter(R"(["==", ["id"], "foo"])");
+}


### PR DESCRIPTION
Backports #12630 to release-espresso
----
Recut of https://github.com/mapbox/mapbox-gl-native/pull/12621 so that we can run all of the tests with credentials.