### PR TITLE
Canonicalize another exception name

### DIFF
--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Don't default-show text/icons that depend on the placement of a paired icon/text [#12483](https://github.com/mapbox/mapbox-gl-native/issues/12483)
 - Fix the `-[MGLMapView annotationAtPoint:]` method near tile boundaries at high zoom. ([#12472](https://github.com/mapbox/mapbox-gl-native/issues/12472))
+* Fixed inconsistencies in exception naming. ([#12583](https://github.com/mapbox/mapbox-gl-native/issues/12583))
 
 ## Styles and rendering
 

--- a/platform/macos/src/MGLMapView+IBAdditions.mm
+++ b/platform/macos/src/MGLMapView+IBAdditions.mm
@@ -1,5 +1,7 @@
 #import "MGLMapView+IBAdditions.h"
 
+#import "MGLStyle.h"
+
 #import "MGLMapView_Private.h"
 
 @implementation MGLMapView (IBAdditions)
@@ -17,7 +19,7 @@
                  [NSCharacterSet whitespaceAndNewlineCharacterSet]];
     NSURL *url = URLString.length ? [NSURL URLWithString:URLString] : nil;
     if (URLString.length && !url) {
-        [NSException raise:@"Invalid style URL"
+        [NSException raise:MGLInvalidStyleURLException
                     format:@"“%@” is not a valid style URL.", URLString];
     }
     self.styleURL = url;


### PR DESCRIPTION
Replaced one more exception name string with a formal symbol as a followup to #12583.

/cc @friedbunny