### PR TITLE
[macos] Rename Guides to Appendices

### DIFF
--- a/platform/macos/jazzy.yml
+++ b/platform/macos/jazzy.yml
@@ -15,7 +15,7 @@ umbrella_header: src/Mapbox.h
 framework_root: ../darwin/src
 
 custom_categories:
-  - name: Guides
+  - name: Appendices
     children:
       - Working with GeoJSON Data
       - Predicates and Expressions


### PR DESCRIPTION
Cherry picks https://github.com/mapbox/mapbox-gl-native/pull/12634 into `release-espresso`