### PR TITLE
[macos] Fix pod name within docs

### DIFF
--- a/platform/macos/docs/pod-README.md
+++ b/platform/macos/docs/pod-README.md
@@ -40,7 +40,7 @@ Create a [Podfile](https://guides.cocoapods.org/syntax/podfile.html) with the fo
 platform :osx, '10.11'
 
 target 'TargetNameForYourApp' do
-  pod 'Mapbox-iOS-SDK', '~> x.y'
+  pod 'Mapbox-macOS-SDK', '~> x.y'
 end
 ```
 


### PR DESCRIPTION
Fixes a typo with the macOS documentation which suggested the pod required was `Mapbox-iOS-SDK` instead of the correct `Mapbox-macOS-SDK`.