### PR TITLE
[android] Make AndroidRendererFrontend to request render once per event loop (#12586)

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
@@ -197,6 +197,9 @@ public class RuntimeStyleActivity extends AppCompatActivity {
       case R.id.action_numeric_filter:
         styleNumericFillLayer();
         return true;
+      case R.id.action_bring_water_to_front:
+        bringWaterToFront();
+        return true;
       default:
         return super.onOptionsItemSelected(item);
     }
@@ -570,6 +573,16 @@ public class RuntimeStyleActivity extends AppCompatActivity {
         Toast.makeText(RuntimeStyleActivity.this, "No regions layer in this style", Toast.LENGTH_SHORT).show();
       }
     }, 2000);
+  }
+
+  private void bringWaterToFront() {
+    Layer water = mapboxMap.getLayer("water");
+    if (water != null) {
+      mapboxMap.removeLayer(water);
+      mapboxMap.addLayerAt(water, mapboxMap.getLayers().size() - 1);
+    } else {
+      Toast.makeText(this, "No water layer in this style", Toast.LENGTH_SHORT).show();
+    }
   }
 
   private static class DefaultCallback implements MapboxMap.CancelableCallback {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/menu/menu_runtime_style.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/menu/menu_runtime_style.xml
@@ -66,4 +66,8 @@
         android:id="@+id/action_numeric_filter"
         android:title="@string/apply_numeric_fill_filter"
         mapbox:showAsAction="never" />
+    <item
+        android:id="@+id/action_bring_water_to_front"
+        android:title="@string/bring_water_to_front"
+        mapbox:showAsAction="never" />
 </menu>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/actions.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/actions.xml
@@ -79,6 +79,7 @@
     <string name="apply_filtered_fill">Apply filtered fill</string>
     <string name="apply_filtered_line">Apply filtered line</string>
     <string name="apply_numeric_fill_filter">Apply numeric fill filter</string>
+    <string name="bring_water_to_front">Bring water to front</string>
     <string name="toggle_text_size">Toggle text size</string>
     <string name="toggle_text_field_contents">Toggle text field contents</string>
     <string name="toggle_text_font">Toggle text font</string>

--- a/platform/android/src/android_renderer_frontend.hpp
+++ b/platform/android/src/android_renderer_frontend.hpp
@@ -18,6 +18,12 @@ namespace mbgl {
 class RenderedQueryOptions;
 class SourceQueryOptions;
 
+namespace util {
+
+class AsyncTask;
+
+} // namespace util
+
 namespace android {
 
 class AndroidRendererFrontend : public RendererFrontend {
@@ -44,6 +50,8 @@ public:
 private:
     MapRenderer& mapRenderer;
     util::RunLoop* mapRunLoop;
+    std::unique_ptr<util::AsyncTask> updateAsyncTask;
+    std::shared_ptr<UpdateParameters> updateParams;
 };
 
 } // namespace android


### PR DESCRIPTION
Closes #12586

- When `AndroidRendererFrontend::update()` called multiple times in a single loop, `updateAsyncTask->send()` will perform nothing, thus `MapRenderer::update()`/`requestRender()` will be coalesced.
- I also added a simple test case to Runtime Style demo. With this change, "Bring water to front" action no more causes flickering.