### PR TITLE
Obtain paths to file directories on a worker thread

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
@@ -11,6 +11,9 @@ import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.exceptions.MapboxConfigurationException;
 import com.mapbox.mapboxsdk.maps.Telemetry;
 import com.mapbox.mapboxsdk.net.ConnectivityReceiver;
+import com.mapbox.mapboxsdk.storage.FileSource;
+import com.mapbox.mapboxsdk.utils.ThreadUtils;
+
 import timber.log.Timber;
 
 /**
@@ -42,8 +45,10 @@ public final class Mapbox {
    */
   @UiThread
   public static synchronized Mapbox getInstance(@NonNull Context context, @Nullable String accessToken) {
+    ThreadUtils.checkThread("Mapbox");
     if (INSTANCE == null) {
       Context appContext = context.getApplicationContext();
+      FileSource.initializeFileDirsPaths(appContext);
       INSTANCE = new Mapbox(appContext, accessToken);
       if (isAccessTokenValid(accessToken)) {
         initializeTelemetry();

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
@@ -28,7 +28,7 @@ public abstract class MapRenderer implements MapRendererScheduler {
   public MapRenderer(Context context, String localIdeographFontFamily) {
     FileSource fileSource = FileSource.getInstance(context);
     float pixelRatio = context.getResources().getDisplayMetrics().density;
-    String programCacheDir = context.getCacheDir().getAbsolutePath();
+    String programCacheDir = FileSource.getInternalCachePath(context);
 
     // Initialise native peer
     nativeInitialize(this, fileSource, pixelRatio, programCacheDir, localIdeographFontFamily);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
@@ -109,7 +109,7 @@ public class OfflineManager {
       @Override
       public void run() {
         try {
-          String path = context.getCacheDir().getAbsolutePath() + File.separator + "mbgl-cache.db";
+          String path = FileSource.getInternalCachePath(context) + File.separator + "mbgl-cache.db";
           File file = new File(path);
           if (file.exists()) {
             file.delete();

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
@@ -217,7 +217,7 @@ public class MapSnapshotter {
     checkThread();
     this.context = context.getApplicationContext();
     FileSource fileSource = FileSource.getInstance(context);
-    String programCacheDir = context.getCacheDir().getAbsolutePath();
+    String programCacheDir = FileSource.getInternalCachePath(context);
 
     nativeInitialize(this, fileSource, options.pixelRatio, options.width,
       options.height, options.styleUrl, options.styleJson, options.region, options.cameraPosition,


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/12049 by obtaining file directories paths on a worker thread as early as possible and caching them.

We are still hitting violations inside the `LibraryLoader` but I'm not sure we'll be able to handle those.