### PR TITLE
Set GCC_GENERATE_DEBUGGING_SYMBOLS in Xcode

### DIFF
--- a/cmake/mbgl.cmake
+++ b/cmake/mbgl.cmake
@@ -191,6 +191,9 @@ function(initialize_xcode_cxx_build_settings target)
 
     # -flto
     set_xcode_property(${target} LLVM_LTO $<$<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebugInfo>>:YES>)
+
+    # Make releases debuggable.
+    set_xcode_property(${target} GCC_GENERATE_DEBUGGING_SYMBOLS YES)
 endfunction()
 
 # CMake 3.1 does not have this yet.


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/12668