### PR TITLE
Fix/bounds validation message

### DIFF
--- a/src/mbgl/style/conversion/tileset.cpp
+++ b/src/mbgl/style/conversion/tileset.cpp
@@ -97,12 +97,12 @@ optional<Tileset> Converter<Tileset>::operator()(const Convertible& value, Error
         bottom = util::clamp(*bottom, -90.0, 90.0);
         top = util::clamp(*top, -90.0, 90.0);
         if (*top < *bottom){
-            error.message = "bounds bottom latitude must be smaller than top latitude";
+            error.message = "bounds bottom latitude must be less than or equal to top latitude";
             return nullopt;
         }
 
         if(*left > *right) {
-            error.message = "bounds left longitude should be less than right longitude";
+            error.message = "bounds left longitude must be less than or equal to right longitude";
             return nullopt;
         }
         left = util::max(-180.0, *left);


### PR DESCRIPTION
Noticed that https://github.com/mapbox/mapbox-gl-native/pull/12539/files changed the condition for valid bounds but didn't update the error message.

this pr:
* updates the message to reflect the current validation condition
* makes the message consistent for top-bottom and left-right bounds

@asheemmamoowala 