### PR TITLE
Update MapView OfflineRegionDefintion initialize

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -37,11 +37,13 @@ import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.constants.Style;
+import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.renderer.MapRenderer;
 import com.mapbox.mapboxsdk.maps.renderer.glsurfaceview.GLSurfaceViewMapRenderer;
 import com.mapbox.mapboxsdk.maps.renderer.textureview.TextureViewMapRenderer;
 import com.mapbox.mapboxsdk.maps.widgets.CompassView;
 import com.mapbox.mapboxsdk.net.ConnectivityReceiver;
+import com.mapbox.mapboxsdk.offline.OfflineGeometryRegionDefinition;
 import com.mapbox.mapboxsdk.offline.OfflineRegionDefinition;
 import com.mapbox.mapboxsdk.offline.OfflineTilePyramidRegionDefinition;
 import com.mapbox.mapboxsdk.storage.FileSource;
@@ -567,22 +569,46 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
       return;
     }
 
-    OfflineTilePyramidRegionDefinition regionDefinition = (OfflineTilePyramidRegionDefinition) definition;
-    setStyleUrl(regionDefinition.getStyleURL());
-    CameraPosition cameraPosition = new CameraPosition.Builder()
-      .target(regionDefinition.getBounds().getCenter())
-      .zoom(regionDefinition.getMinZoom())
-      .build();
+    if (definition instanceof OfflineTilePyramidRegionDefinition) {
+      setOfflineTilePyramidRegionDefinition((OfflineTilePyramidRegionDefinition) definition);
+    } else if (definition instanceof OfflineGeometryRegionDefinition) {
+      setOfflineGeometryRegionDefinition((OfflineGeometryRegionDefinition) definition);
+    } else {
+      throw new UnsupportedOperationException("OfflineRegionDefintion instance not supported");
+    }
+  }
 
+  private void setOfflineRegionDefinition(String styleUrl, LatLng cameraTarget, double minZoom, double maxZoom) {
+    CameraPosition cameraPosition = new CameraPosition.Builder()
+      .target(cameraTarget)
+      .zoom(minZoom)
+      .build();
+    setStyleUrl(styleUrl);
     if (!isMapInitialized()) {
       mapboxMapOptions.camera(cameraPosition);
-      mapboxMapOptions.minZoomPreference(regionDefinition.getMinZoom());
-      mapboxMapOptions.maxZoomPreference(regionDefinition.getMaxZoom());
+      mapboxMapOptions.minZoomPreference(minZoom);
+      mapboxMapOptions.maxZoomPreference(maxZoom);
       return;
     }
     mapboxMap.moveCamera(CameraUpdateFactory.newCameraPosition(cameraPosition));
-    mapboxMap.setMinZoomPreference(regionDefinition.getMinZoom());
-    mapboxMap.setMaxZoomPreference(regionDefinition.getMaxZoom());
+    mapboxMap.setMinZoomPreference(minZoom);
+    mapboxMap.setMaxZoomPreference(maxZoom);
+  }
+
+  private void setOfflineTilePyramidRegionDefinition(OfflineTilePyramidRegionDefinition regionDefinition) {
+    setOfflineRegionDefinition(regionDefinition.getStyleURL(),
+      regionDefinition.getBounds().getCenter(),
+      regionDefinition.getMinZoom(),
+      regionDefinition.getMaxZoom()
+    );
+  }
+
+  private void setOfflineGeometryRegionDefinition(OfflineGeometryRegionDefinition regionDefinition) {
+    setOfflineRegionDefinition(regionDefinition.getStyleURL(),
+      regionDefinition.getBounds().getCenter(),
+      regionDefinition.getMinZoom(),
+      regionDefinition.getMaxZoom()
+    );
   }
 
   //


### PR DESCRIPTION
Follow up from https://github.com/mapbox/mapbox-gl-native/pull/11447, where a new offline region definition was introduced. This PR updates the `MapView#setOfflineRegionDefinition(OfflineRegionDefinition definition)` to take this new type into account. 