### PR TITLE
[build] Run lower-value iOS CircleCI builds as nightlies

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,9 +33,6 @@ workflows:
       - linux-gcc4.9-debug
       - linux-gcc5-debug-coverage
       - ios-debug
-      - ios-sanitize
-      - ios-sanitize-address
-      - ios-static-analyzer
       - ios-release
       - ios-release-tag:
           filters:
@@ -57,6 +54,9 @@ workflows:
                 - master
     jobs:
       - ios-release
+      - ios-sanitize
+      - ios-sanitize-address
+      - ios-static-analyzer
 
 step-library:
   - &npm-install


### PR DESCRIPTION
These jobs have a low incidence of unique meaningful failures and are mostly just informational, so running them less often frees up relatively scarce CircleCI macOS concurrency while preserving much of their value. This’ll also reduce the impact of occasionally flaky builds, such as #11038.

After merge, `ios-sanitize`, `ios-sanitize-address`, and `ios-static-analyzer` builds will be stop being “required” for GitHub PRs.

/cc @mapbox/maps-ios @kkaefer @jfirebaugh 