### PR TITLE
Adding Traditional Chinese character strings.xml files for HK & Taiwan support

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -46,7 +46,7 @@ type = STRINGS
 
 [mapbox-gl-native.stringsxml-android]
 file_filter = platform/android/MapboxGLAndroidSDK/src/main/res/values-<lang>/strings.xml
-lang_map = pt_PT: pt-rPT, zh_CN: zh-rCN
+lang_map = pt_PT: pt-rPT, zh_CN: zh-rCN, zh_TW: zh-rTW, zh_HK: zh-rHK
 source_file = platform/android/MapboxGLAndroidSDK/src/main/res/values/strings.xml
 source_lang = en
 type = ANDROID

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values-es/strings.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values-es/strings.xml
@@ -12,5 +12,6 @@
     <string name="mapbox_attributionTelemetryNeutral">Más información</string>
     <string name="mapbox_attributionErrorNoBrowser">No puede abrir la página Web porque no hay un navegador Web en el dispositivo.</string>
     <string name="mapbox_offline_error_region_definition_invalid">El parámetro OfflineRegionDefinition que se ingresó no coincide con los límites mundiales: %s</string>
+    <string name="mapbox_telemetryImproveMap">Mejorar este mapa</string>
     <string name="mapbox_telemetrySettings">Ajustes de telemetría</string>
     </resources>

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values-vi/strings.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values-vi/strings.xml
@@ -12,5 +12,6 @@
     <string name="mapbox_attributionTelemetryNeutral">Thông tin thêm</string>
     <string name="mapbox_attributionErrorNoBrowser">Không thể mở trang Web vì thiết bị thiếu trình duyệt.</string>
     <string name="mapbox_offline_error_region_definition_invalid">OfflineRegionDefinition được cung cấp không vừa thế giới: %s</string>
+    <string name="mapbox_telemetryImproveMap">Cải thiện Bản đồ này</string>
     <string name="mapbox_telemetrySettings">Thiết lập Trình viễn trắc</string>
     </resources>

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values-zh-rCN/strings.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values-zh-rCN/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="mapbox_compassContentDescription">指南针，点击使地图旋转重置到正北方向。</string>
     <string name="mapbox_attributionsIconContentDescription">Attribution图标，点击以显示attribution对话框。</string>
     <string name="mapbox_myLocationViewContentDescription">定位视图，在地图上显示当前位置。</string>
     <string name="mapbox_mapActionDescription">显示由Mapbox创建的地图，通过拖动两个手指来滚动，捏两个手指来放大。</string>
@@ -11,5 +12,6 @@
     <string name="mapbox_attributionTelemetryNeutral">更多信息</string>
     <string name="mapbox_attributionErrorNoBrowser">设备中未安装任何浏览器，不能打开该网页</string>
     <string name="mapbox_offline_error_region_definition_invalid">提供的OfflineRegionDefinition不符合标准地理范围：%s</string>
+    <string name="mapbox_telemetryImproveMap">完善地图</string>
     <string name="mapbox_telemetrySettings">Telemetry设置</string>
 </resources>

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values-zh-rHK/strings.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values-zh-rHK/strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_compassContentDescription">指南針，点击使地图旋转重置到正北方向。</string>
+    <string name="mapbox_attributionsIconContentDescription">Attribution圖標，點擊以顯示attribution對話框。</string>
+    <string name="mapbox_myLocationViewContentDescription">定位視圖，在地圖上顯示當前位置。</string>
+    <string name="mapbox_mapActionDescription">顯示由Mapbox創建的地圖，通過拖動兩個手指來滾動，捏兩個手指來放大。</string>
+    <string name="mapbox_attributionsDialogTitle">Mapbox Maps SDK for Android</string>
+    <string name="mapbox_attributionTelemetryTitle">讓Mapbox地圖變得更好</string>
+    <string name="mapbox_attributionTelemetryMessage">您的匿名數據幫助OpenStreetMap和Mapbox的地圖變得更好。</string>
+    <string name="mapbox_attributionTelemetryPositive">繼續參與</string>
+    <string name="mapbox_attributionTelemetryNegative">不再參與</string>
+    <string name="mapbox_attributionTelemetryNeutral">更多信息</string>
+    <string name="mapbox_attributionErrorNoBrowser">設備中未安裝任何瀏覽器，不能打開該網頁</string>
+    <string name="mapbox_offline_error_region_definition_invalid">提供的OfflineRegionDefinition不符合標準地理範圍：%s</string>
+    <string name="mapbox_telemetryImproveMap">完善地圖</string>
+    <string name="mapbox_telemetrySettings">Telemetry設置</string>
+    </resources>

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values-zh-rTW/strings.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_compassContentDescription">指南針，点击使地图旋转重置到正北方向。</string>
+    <string name="mapbox_attributionsIconContentDescription">Attribution圖標，點擊以顯示attribution對話框。</string>
+    <string name="mapbox_myLocationViewContentDescription">定位視圖，在地圖上顯示當前位置。</string>
+    <string name="mapbox_mapActionDescription">顯示由Mapbox創建的地圖，通過拖動兩個手指來滾動，捏兩個手指來放大。</string>
+    <string name="mapbox_attributionsDialogTitle">Mapbox Maps SDK for Android</string>
+    <string name="mapbox_attributionTelemetryTitle">讓Mapbox地圖變得更好</string>
+    <string name="mapbox_attributionTelemetryMessage">您的匿名數據幫助OpenStreetMap和Mapbox的地圖變得更好。</string>
+    <string name="mapbox_attributionTelemetryPositive">繼續參與</string>
+    <string name="mapbox_attributionTelemetryNegative">不再參與</string>
+    <string name="mapbox_attributionTelemetryNeutral">更多信息</string>
+    <string name="mapbox_attributionErrorNoBrowser">設備中未安裝任何瀏覽器，不能打開該網頁</string>
+    <string name="mapbox_offline_error_region_definition_invalid">提供的OfflineRegionDefinition不符合標準地理範圍：%s</string>
+    <string name="mapbox_telemetryImproveMap">完善地圖</string>
+    <string name="mapbox_telemetrySettings">Telemetry設置</string>
+    </resources>

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/strings.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="mapbox_attributionTelemetryNeutral">More info</string>
     <string name="mapbox_attributionErrorNoBrowser">No web browser installed on device, can\'t open web page.</string>
     <string name="mapbox_offline_error_region_definition_invalid">Provided OfflineRegionDefinition doesn\'t fit the world bounds: %s</string>
+    <string name="mapbox_telemetryImproveMap">Improve This Map</string>
     <string name="mapbox_telemetrySettings">Telemetry Settings</string>
     <string name="mapbox_telemetryLink" translatable="false">https://www.mapbox.com/telemetry/</string>
 


### PR DESCRIPTION
This pr adds telem window language support for traditional Chinese characters if an Android device is set to the Hong Kong or Taiwan region

![device-2018-08-22-113830](https://user-images.githubusercontent.com/4394910/44483474-0e9a3c80-a600-11e8-966d-1e55353472a2.png)


![device-2018-08-22-113840](https://user-images.githubusercontent.com/4394910/44483475-0f32d300-a600-11e8-8fed-0cbe84fc19f0.png)


Related

- https://github.com/mapbox/mapbox-gl-native/pull/12696
- https://github.com/mapbox/mapbox-gl-native/issues/12708
- https://github.com/mapbox/mapbox-gl-native/pull/12707


cc @macro-shen @chriswu42 @suntony @springmeyer @jmkiley @lloydsheng @1ec5 @jcsg 
