### PR TITLE
[ios] Install node modules in document.sh

### DIFF
--- a/platform/ios/scripts/document.sh
+++ b/platform/ios/scripts/document.sh
@@ -35,6 +35,7 @@ mkdir -p /tmp/mbgl/
 
 step "Generating readme and release notes"
 README=/tmp/mbgl/README.md
+npm install --ignore-scripts
 node platform/ios/scripts/release-notes.js jazzy >> "${README}"
 
 rm -rf ${OUTPUT}


### PR DESCRIPTION
Alters the `document.sh` script to require the installation of node modules before generating release notes.