### PR TITLE
Mapbox maps SDK for iOS custom logging.

### DIFF
--- a/platform/darwin/src/MGLLoggingConfiguration.h
+++ b/platform/darwin/src/MGLLoggingConfiguration.h
@@ -1,0 +1,84 @@
+#import <Foundation/Foundation.h>
+
+#import "MGLFoundation.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Constants indicating the message's logging level.
+ */
+typedef NS_ENUM(NSInteger, MGLLoggingLevel) {
+    /**
+     None-level messages are ignored.
+     */
+    MGLLoggingLevelNone = 0,
+    /**
+     Info-level messages contain information that may be helpful for flow tracing
+     but is not essential.
+     */
+    MGLLoggingLevelInfo,
+    /**
+     Debug-level messages contain information that may be helpful for troubleshooting
+     specific problems.
+     */
+    MGLLoggingLevelDebug,
+    /**
+     Error-level messages contain information that is intended to aid in process-level
+     errors.
+     */
+    MGLLoggingLevelError,
+    /**
+     Fault-level messages contain system-level error information.
+     */
+    MGLLoggingLevelFault,
+    /**
+     :nodoc: Any new logging level should be included in the default logging implementation.
+     */
+};
+
+/**
+ A block to be called once `loggingLevel` is set to a higher value than `MGLLoggingLevelNone`.
+ 
+ @param loggingLevel The message logging level.
+ @param filePath The description of the file and method for the calling message.
+ @param line The line where the message is logged.
+ @param message The logging message.
+ */
+typedef void (^MGLLoggingBlockHandler)(MGLLoggingLevel loggingLevel, NSString *filePath, NSUInteger line, NSString *message);
+
+/**
+ The `MGLLoggingConfiguration` object provides a global way to set this SDK logging levels
+ and logging handler.
+ */
+MGL_EXPORT
+@interface MGLLoggingConfiguration : NSObject
+
+/**
+ The handler this SDK uses to log messages.
+ 
+ If this property is set to nil or if no custom handler is provided this property
+ is set to the default handler.
+ 
+ The default handler uses `os_log` and `NSLog` for iOS 10+ and iOS < 10 respectively.
+ */
+@property (nonatomic, copy, null_resettable) MGLLoggingBlockHandler handler;
+
+/**
+ The logging level.
+ 
+ The default value is `MGLLoggingLevelNone`.
+ 
+ Setting this property includes logging levels less than or equal to the setted value.
+ */
+@property (assign, nonatomic) MGLLoggingLevel loggingLevel;
+
+/**
+ Returns the shared logging object.
+ */
+@property (class, nonatomic, readonly) MGLLoggingConfiguration *sharedConfiguration;
+
+- (MGLLoggingBlockHandler)handler UNAVAILABLE_ATTRIBUTE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLLoggingConfiguration.m
+++ b/platform/darwin/src/MGLLoggingConfiguration.m
@@ -1,0 +1,66 @@
+#import "MGLLoggingConfiguration_Private.h"
+
+#if __has_builtin(__builtin_os_log_format)
+#import <os/log.h>
+#endif
+
+@implementation MGLLoggingConfiguration
+
++ (instancetype)sharedConfiguration
+{
+    static dispatch_once_t once;
+    static id sharedConfiguration;
+    dispatch_once(&once, ^{
+        sharedConfiguration = [[self alloc] init];
+        ((MGLLoggingConfiguration *)sharedConfiguration).handler = nil;
+    });
+    return sharedConfiguration;
+}
+
+- (void)setHandler:(void (^)(MGLLoggingLevel, NSString *, NSUInteger, NSString *))handler {
+    
+    if (!handler) {
+        _handler = [self defaultBlockHandler];
+    } else {
+        _handler = handler;
+    }
+}
+
+- (void)logCallingFunction:(const char *)callingFunction functionLine:(NSUInteger)functionLine messageType:(MGLLoggingLevel)type format:(id)messageFormat, ...
+{
+    va_list formatList;
+    va_start(formatList, messageFormat);
+    NSString *formattedMessage = [[NSString alloc] initWithFormat:messageFormat arguments:formatList];
+    va_end(formatList);
+    
+    _handler(type, @(callingFunction), functionLine, formattedMessage);
+    
+}
+
+- (MGLLoggingBlockHandler)defaultBlockHandler {
+    MGLLoggingBlockHandler mapboxHandler = ^(MGLLoggingLevel level, NSString *fileName, NSUInteger line, NSString *message) {
+        
+        if (@available(iOS 10.0, macOS 10.12.0, *)) {
+            static dispatch_once_t once;
+            static os_log_t mapbox_log;
+            static os_log_type_t log_types[] = { OS_LOG_TYPE_DEFAULT,
+                                                    OS_LOG_TYPE_INFO,
+                                                    OS_LOG_TYPE_DEBUG,
+                                                    OS_LOG_TYPE_ERROR,
+                                                    OS_LOG_TYPE_FAULT };
+            dispatch_once(&once, ^ {
+                mapbox_log = os_log_create("com.mapbox.maps-ios-sdk", "SDK");
+            });
+            NSUInteger logTypesCount = sizeof(log_types) / sizeof(os_log_type_t);
+            NSAssert(level <= logTypesCount, @"There is an attempt to log a non suported logging level.");
+            os_log_type_t logType = log_types[level];
+            os_log_with_type(mapbox_log, logType, "%@ - %d: %@", fileName, line, message);
+        } else {
+            NSLog(@"[SDK] %@ - %lu: %@", fileName, line, message);
+        }
+    };
+    
+    return mapboxHandler;
+}
+
+@end

--- a/platform/darwin/src/MGLLoggingConfiguration_Private.h
+++ b/platform/darwin/src/MGLLoggingConfiguration_Private.h
@@ -1,0 +1,19 @@
+#import "MGLLoggingConfiguration.h"
+
+#define MGLLogInfo(message, ...)  MGLLogWithType(MGLLoggingLevelInfo, __PRETTY_FUNCTION__, __LINE__, message, ##__VA_ARGS__)
+#define MGLLogDebug(message, ...) MGLLogWithType(MGLLoggingLevelDebug, __PRETTY_FUNCTION__, __LINE__, message, ##__VA_ARGS__)
+#define MGLLogError(message, ...) MGLLogWithType(MGLLoggingLevelError, __PRETTY_FUNCTION__, __LINE__, message, ##__VA_ARGS__)
+#define MGLLogFault(message, ...) MGLLogWithType(MGLLoggingLevelFault, __PRETTY_FUNCTION__, __LINE__, message, ##__VA_ARGS__)
+#define MGLLogWithType(type, function, line, message, ...) \
+{ \
+    if ([MGLLoggingConfiguration sharedConfiguration].loggingLevel != MGLLoggingLevelNone && type <= [MGLLoggingConfiguration sharedConfiguration].loggingLevel) \
+    { \
+        [[MGLLoggingConfiguration sharedConfiguration] logCallingFunction:function functionLine:line messageType:type format:(message), ##__VA_ARGS__]; \
+    } \
+}
+
+@interface MGLLoggingConfiguration (Private)
+
+- (void)logCallingFunction:(const char *)callingFunction functionLine:(NSUInteger)functionLine messageType:(MGLLoggingLevel)type format:(id)messageFormat, ...;
+
+@end

--- a/platform/ios/app/MBXAppDelegate.m
+++ b/platform/ios/app/MBXAppDelegate.m
@@ -21,6 +21,7 @@ NSString * const MBXMapboxAccessTokenDefaultsKey = @"MBXMapboxAccessToken";
             accessToken = [[NSUserDefaults standardUserDefaults] objectForKey:MBXMapboxAccessTokenDefaultsKey];
         }
         [MGLAccountManager setAccessToken:accessToken];
+        [MGLLoggingConfiguration sharedConfiguration].loggingLevel = MGLLoggingLevelDebug;
     }
 
     return YES;

--- a/platform/ios/core-files.txt
+++ b/platform/ios/core-files.txt
@@ -16,6 +16,9 @@ platform/darwin/src/MGLFoundation_Private.h
 platform/darwin/src/MGLLocationManager.h
 platform/darwin/src/MGLLocationManager.m
 platform/darwin/src/MGLLocationManager_Private.h
+platform/darwin/src/MGLLoggingConfiguration.h
+platform/darwin/src/MGLLoggingConfiguration.m
+platform/darwin/src/MGLLoggingConfiguration_Private.h
 platform/darwin/src/MGLMapCamera.h
 platform/darwin/src/MGLMapCamera.mm
 platform/darwin/src/MGLMapSnapshotter.h

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -35,6 +35,12 @@
 		1F06668D1EC64F8E001C16D7 /* MGLLight.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1F0666891EC64F8E001C16D7 /* MGLLight.mm */; };
 		1F26B6C120E189C9007BCC21 /* MBXCustomLocationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F26B6C020E189C9007BCC21 /* MBXCustomLocationViewController.m */; };
 		1F26B6C320E1A351007BCC21 /* simple_route.json in Resources */ = {isa = PBXBuildFile; fileRef = 1F26B6C220E1A351007BCC21 /* simple_route.json */; };
+		1F6A82A221360F9D00BA5B41 /* MGLLoggingConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F6A82A021360F9C00BA5B41 /* MGLLoggingConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F6A82A321360F9D00BA5B41 /* MGLLoggingConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F6A82A021360F9C00BA5B41 /* MGLLoggingConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F6A82A421360F9D00BA5B41 /* MGLLoggingConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F6A82A121360F9C00BA5B41 /* MGLLoggingConfiguration.m */; };
+		1F6A82A521360F9D00BA5B41 /* MGLLoggingConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F6A82A121360F9C00BA5B41 /* MGLLoggingConfiguration.m */; };
+		1F6A82A82138871900BA5B41 /* MGLLoggingConfiguration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F6A82A62138871900BA5B41 /* MGLLoggingConfiguration_Private.h */; };
+		1F6A82A92138871900BA5B41 /* MGLLoggingConfiguration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F6A82A62138871900BA5B41 /* MGLLoggingConfiguration_Private.h */; };
 		1F7454921ECBB42C00021D39 /* MGLLight.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1F0666891EC64F8E001C16D7 /* MGLLight.mm */; };
 		1F7454931ECBB43F00021D39 /* MGLLight.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F0666881EC64F8E001C16D7 /* MGLLight.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1F7454961ECD450D00021D39 /* MGLLight_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F7454941ECD450D00021D39 /* MGLLight_Private.h */; };
@@ -773,6 +779,9 @@
 		1F26B6BF20E189C9007BCC21 /* MBXCustomLocationViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MBXCustomLocationViewController.h; sourceTree = "<group>"; };
 		1F26B6C020E189C9007BCC21 /* MBXCustomLocationViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MBXCustomLocationViewController.m; sourceTree = "<group>"; };
 		1F26B6C220E1A351007BCC21 /* simple_route.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = simple_route.json; sourceTree = "<group>"; };
+		1F6A82A021360F9C00BA5B41 /* MGLLoggingConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLLoggingConfiguration.h; sourceTree = "<group>"; };
+		1F6A82A121360F9C00BA5B41 /* MGLLoggingConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLLoggingConfiguration.m; sourceTree = "<group>"; };
+		1F6A82A62138871900BA5B41 /* MGLLoggingConfiguration_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLLoggingConfiguration_Private.h; sourceTree = "<group>"; };
 		1F7454941ECD450D00021D39 /* MGLLight_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLLight_Private.h; sourceTree = "<group>"; };
 		1F7454A61ED08AB400021D39 /* MGLLightTest.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLLightTest.mm; path = ../../darwin/test/MGLLightTest.mm; sourceTree = "<group>"; };
 		1F8A59F62165326C004DFE75 /* sideload_sat.db */ = {isa = PBXFileReference; lastKnownFileType = file; name = sideload_sat.db; path = ../../../test/fixtures/offline_database/sideload_sat.db; sourceTree = "<group>"; };
@@ -1941,6 +1950,9 @@
 				1FCAE2A020B872A400C577DD /* MGLLocationManager.h */,
 				1FCAE2A620B88B3800C577DD /* MGLLocationManager_Private.h */,
 				1FCAE2A120B872A400C577DD /* MGLLocationManager.m */,
+				1F6A82A021360F9C00BA5B41 /* MGLLoggingConfiguration.h */,
+				1F6A82A121360F9C00BA5B41 /* MGLLoggingConfiguration.m */,
+				1F6A82A62138871900BA5B41 /* MGLLoggingConfiguration_Private.h */,
 			);
 			name = Foundation;
 			path = ../darwin/src;
@@ -2266,6 +2278,7 @@
 				1FCAE2A820B88B3800C577DD /* MGLLocationManager_Private.h in Headers */,
 				DA8847EF1CBAFA5100AB86E3 /* MGLAccountManager.h in Headers */,
 				DA35A2C91CCAAAD200E826B2 /* NSValue+MGLAdditions.h in Headers */,
+				1F6A82A82138871900BA5B41 /* MGLLoggingConfiguration_Private.h in Headers */,
 				3510FFEA1D6D9C7A00F413B2 /* NSComparisonPredicate+MGLAdditions.h in Headers */,
 				DA6408DB1DA4E7D300908C90 /* MGLVectorStyleLayer.h in Headers */,
 				DA704CC21F65A475004B3F28 /* MGLMapAccessibilityElement.h in Headers */,
@@ -2273,6 +2286,7 @@
 				DA8848571CBAFB9800AB86E3 /* MGLMapboxEvents.h in Headers */,
 				35D3A1E61E9BE7EB002B38EE /* MGLScaleBar.h in Headers */,
 				0778DD431F67556700A73B34 /* MGLComputedShapeSource.h in Headers */,
+				1F6A82A221360F9D00BA5B41 /* MGLLoggingConfiguration.h in Headers */,
 				DA8848311CBAFA6200AB86E3 /* NSString+MGLAdditions.h in Headers */,
 				967C864B210A9D3C004DF794 /* UIDevice+MGLAdditions.h in Headers */,
 				1FCAE2A220B872A400C577DD /* MGLLocationManager.h in Headers */,
@@ -2392,6 +2406,7 @@
 				3566C7721D4A9198008152BC /* MGLSource_Private.h in Headers */,
 				353933FF1D3FB7DD003F57D7 /* MGLSymbolStyleLayer.h in Headers */,
 				DAAF722E1DA903C700312FA4 /* MGLStyleValue_Private.h in Headers */,
+				1F6A82A92138871900BA5B41 /* MGLLoggingConfiguration_Private.h in Headers */,
 				DABFB8661CBE99E500D62B32 /* MGLPointAnnotation.h in Headers */,
 				96E516E42000560B00A02306 /* MGLComputedShapeSource_Private.h in Headers */,
 				96E516E92000560B00A02306 /* MGLAnnotationImage_Private.h in Headers */,
@@ -2456,6 +2471,7 @@
 				354B83971D2E873E005D9406 /* MGLUserLocationAnnotationView.h in Headers */,
 				DAF0D8111DFE0EA000B28378 /* MGLRasterTileSource_Private.h in Headers */,
 				96E516FF20005A4F00A02306 /* MGLMapboxEvents.h in Headers */,
+				1F6A82A321360F9D00BA5B41 /* MGLLoggingConfiguration.h in Headers */,
 				DABFB86B1CBE99E500D62B32 /* MGLTilePyramidOfflineRegion.h in Headers */,
 				968F36B51E4D128D003A5522 /* MGLDistanceFormatter.h in Headers */,
 				4018B1CB1CDC288E00F666AF /* MGLAnnotationView.h in Headers */,
@@ -3012,6 +3028,7 @@
 				DA88482B1CBAFA6200AB86E3 /* MGLTypes.m in Sources */,
 				FA68F14D1E9D656600F9F6C2 /* MGLFillExtrusionStyleLayer.mm in Sources */,
 				404C26E41D89B877000AA13D /* MGLTileSource.mm in Sources */,
+				1F6A82A421360F9D00BA5B41 /* MGLLoggingConfiguration.m in Sources */,
 				355AE0011E9281DA00F3939D /* MGLScaleBar.mm in Sources */,
 				40834C451FE05F7500C1BD0D /* TSKBackgroundReporter.m in Sources */,
 				DA88481D1CBAFA6200AB86E3 /* MGLMapCamera.mm in Sources */,
@@ -3143,6 +3160,7 @@
 				355AE0021E9281DA00F3939D /* MGLScaleBar.mm in Sources */,
 				4018B1C81CDC287F00F666AF /* MGLAnnotationView.mm in Sources */,
 				07D8C6FB1F67560100381808 /* MGLComputedShapeSource.mm in Sources */,
+				1F6A82A521360F9D00BA5B41 /* MGLLoggingConfiguration.m in Sources */,
 				40834C521FE05F7600C1BD0D /* TSKBackgroundReporter.m in Sources */,
 				DAA4E4341CBB730400178DFB /* MGLFaux3DUserLocationAnnotationView.m in Sources */,
 				DACA86292019218600E9693A /* MGLRasterDEMSource.mm in Sources */,

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1,7 +1,5 @@
 #import "MGLMapView_Private.h"
 
-#include <mbgl/util/logging.hpp>
-
 #import <GLKit/GLKit.h>
 #import <OpenGLES/EAGL.h>
 
@@ -75,6 +73,7 @@
 #import "MGLAttributionInfo_Private.h"
 #import "MGLMapAccessibilityElement.h"
 #import "MGLLocationManager_Private.h"
+#import "MGLLoggingConfiguration_Private.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -378,7 +377,7 @@ public:
     {
         styleURL = [MGLStyle streetsStyleURLWithVersion:MGLStyleDefaultVersion];
     }
-
+    MGLLogDebug(@"Setting styleURL: %@", styleURL);
     styleURL = styleURL.mgl_URLByStandardizingScheme;
     self.style = nil;
     _mbglMap->getStyle().loadURL([[styleURL absoluteString] UTF8String]);
@@ -402,6 +401,7 @@ public:
 
 - (void)commonInit
 {
+    MGLLogInfo(@"Initializing.");
     _isTargetingInterfaceBuilder = NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent;
     _opaque = NO;
 
@@ -600,6 +600,9 @@ public:
         [MGLMapboxEvents pushTurnstileEvent];
         [MGLMapboxEvents pushEvent:MMEEventTypeMapLoad withAttributes:@{}];
     }
+
+    MGLLogInfo(@"Initialization completed.");
+
 }
 
 - (mbgl::Size)size

--- a/platform/ios/src/Mapbox.h
+++ b/platform/ios/src/Mapbox.h
@@ -69,3 +69,4 @@ FOUNDATION_EXPORT MGL_EXPORT const unsigned char MapboxVersionString[];
 #import "NSExpression+MGLAdditions.h"
 #import "NSPredicate+MGLAdditions.h"
 #import "MGLLocationManager.h"
+#import "MGLLoggingConfiguration.h"

--- a/platform/macos/core-files.txt
+++ b/platform/macos/core-files.txt
@@ -13,6 +13,9 @@ platform/darwin/src/MGLAttributionInfo_Private.h
 platform/darwin/src/MGLFoundation.h
 platform/darwin/src/MGLFoundation.mm
 platform/darwin/src/MGLFoundation_Private.h
+platform/darwin/src/MGLLoggingConfiguration.h
+platform/darwin/src/MGLLoggingConfiguration.m
+platform/darwin/src/MGLLoggingConfiguration_Private.h
 platform/darwin/src/MGLMapCamera.h
 platform/darwin/src/MGLMapCamera.mm
 platform/darwin/src/MGLMapSnapshotter.h

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		1F7454A51ECFB00300021D39 /* MGLLight.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1F7454A21ECFB00300021D39 /* MGLLight.mm */; };
 		1F7454AB1ED1DDBD00021D39 /* MGLLightTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1F7454AA1ED1DDBD00021D39 /* MGLLightTest.mm */; };
 		1F8A59FA21653483004DFE75 /* sideload_sat.db in Resources */ = {isa = PBXBuildFile; fileRef = 1F8A59F921653483004DFE75 /* sideload_sat.db */; };
+		1F8A5A04216D4696004DFE75 /* MGLLoggingConfiguration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F8A5A01216D4695004DFE75 /* MGLLoggingConfiguration_Private.h */; };
+		1F8A5A05216D4696004DFE75 /* MGLLoggingConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F8A5A02216D4695004DFE75 /* MGLLoggingConfiguration.m */; };
+		1F8A5A06216D4696004DFE75 /* MGLLoggingConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F8A5A03216D4696004DFE75 /* MGLLoggingConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1F95931B1E6DE2B600D5B294 /* MGLNSDateAdditionsTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1F95931A1E6DE2B600D5B294 /* MGLNSDateAdditionsTests.mm */; };
 		1F9EF4061FBA1B0E0063FBB0 /* mapbox_helmet.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 1F9EF4051FBA1B0D0063FBB0 /* mapbox_helmet.pdf */; };
 		1FC481852098F323000D09B4 /* NSPredicate+MGLPrivateAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FC481842098F323000D09B4 /* NSPredicate+MGLPrivateAdditions.h */; };
@@ -318,6 +321,9 @@
 		1F7454A21ECFB00300021D39 /* MGLLight.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLLight.mm; sourceTree = "<group>"; };
 		1F7454AA1ED1DDBD00021D39 /* MGLLightTest.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLLightTest.mm; sourceTree = "<group>"; };
 		1F8A59F921653483004DFE75 /* sideload_sat.db */ = {isa = PBXFileReference; lastKnownFileType = file; name = sideload_sat.db; path = ../../../test/fixtures/offline_database/sideload_sat.db; sourceTree = "<group>"; };
+		1F8A5A01216D4695004DFE75 /* MGLLoggingConfiguration_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLLoggingConfiguration_Private.h; sourceTree = "<group>"; };
+		1F8A5A02216D4695004DFE75 /* MGLLoggingConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLLoggingConfiguration.m; sourceTree = "<group>"; };
+		1F8A5A03216D4696004DFE75 /* MGLLoggingConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLLoggingConfiguration.h; sourceTree = "<group>"; };
 		1F95931A1E6DE2B600D5B294 /* MGLNSDateAdditionsTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLNSDateAdditionsTests.mm; path = ../../darwin/test/MGLNSDateAdditionsTests.mm; sourceTree = "<group>"; };
 		1F9EF4051FBA1B0D0063FBB0 /* mapbox_helmet.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = mapbox_helmet.pdf; sourceTree = "<group>"; };
 		1FC481842098F323000D09B4 /* NSPredicate+MGLPrivateAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSPredicate+MGLPrivateAdditions.h"; sourceTree = "<group>"; };
@@ -1168,6 +1174,9 @@
 				DAE6C3591CC31E0400DB3429 /* MGLTypes.h */,
 				DAE6C37C1CC31E2A00DB3429 /* MGLTypes.m */,
 				DA87A99F1DC9DC6200810D09 /* MGLValueEvaluator.h */,
+				1F8A5A03216D4696004DFE75 /* MGLLoggingConfiguration.h */,
+				1F8A5A01216D4695004DFE75 /* MGLLoggingConfiguration_Private.h */,
+				1F8A5A02216D4695004DFE75 /* MGLLoggingConfiguration.m */,
 			);
 			name = Foundation;
 			path = ../darwin/src;
@@ -1244,8 +1253,10 @@
 				DAE6C3631CC31E0400DB3429 /* MGLPointAnnotation.h in Headers */,
 				DAC2ABC51CC6D343006D18C4 /* MGLAnnotationImage_Private.h in Headers */,
 				DAE6C35F1CC31E0400DB3429 /* MGLOfflinePack.h in Headers */,
+				1F8A5A04216D4696004DFE75 /* MGLLoggingConfiguration_Private.h in Headers */,
 				1FC481852098F323000D09B4 /* NSPredicate+MGLPrivateAdditions.h in Headers */,
 				DAE6C39C1CC31E2A00DB3429 /* NSString+MGLAdditions.h in Headers */,
+				1F8A5A06216D4696004DFE75 /* MGLLoggingConfiguration.h in Headers */,
 				3529039B1D6C63B80002C7DF /* NSPredicate+MGLAdditions.h in Headers */,
 				DA8F25971D51CAC70010E6B5 /* MGLVectorTileSource.h in Headers */,
 				DA7DC9811DED5F5C0027472F /* MGLVectorTileSource_Private.h in Headers */,
@@ -1593,6 +1604,7 @@
 				DAE6C3921CC31E2A00DB3429 /* MGLPolyline.mm in Sources */,
 				3527428A1D4C245800A1ECE6 /* MGLShapeSource.mm in Sources */,
 				DAE6C3B51CC31EF300DB3429 /* MGLCompassCell.m in Sources */,
+				1F8A5A05216D4696004DFE75 /* MGLLoggingConfiguration.m in Sources */,
 				DA8F25901D51CA600010E6B5 /* MGLRasterStyleLayer.mm in Sources */,
 				DAD165751CF4CD7A001FF4B9 /* MGLShapeCollection.mm in Sources */,
 				92FC0AE6207CDD8D007B6B54 /* MGLShapeOfflineRegion.mm in Sources */,

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -59,6 +59,7 @@
 #import "NSColor+MGLAdditions.h"
 #import "NSImage+MGLAdditions.h"
 #import "NSPredicate+MGLPrivateAdditions.h"
+#import "MGLLoggingConfiguration_Private.h"
 
 #import <QuartzCore/QuartzCore.h>
 #import <OpenGL/gl.h>
@@ -257,6 +258,7 @@ public:
 }
 
 - (void)commonInit {
+    MGLLogInfo(@"Initializing.");
     _isTargetingInterfaceBuilder = NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent;
 
     // Set up cross-platform controllers and resources.
@@ -317,6 +319,7 @@ public:
     _mbglMap->jumpTo(options);
     _pendingLatitude = NAN;
     _pendingLongitude = NAN;
+    MGLLogInfo(@"Initialization completed.");
 }
 
 - (mbgl::Size)size {

--- a/platform/macos/src/Mapbox.h
+++ b/platform/macos/src/Mapbox.h
@@ -64,3 +64,4 @@ FOUNDATION_EXPORT MGL_EXPORT const unsigned char MapboxVersionString[];
 #import "MGLMapSnapshotter.h"
 #import "NSExpression+MGLAdditions.h"
 #import "NSPredicate+MGLAdditions.h"
+#import "MGLLoggingConfiguration.h"


### PR DESCRIPTION
Logging is a tool that has been sub-utilized in the iOS maps sdk. The current pr is an effort to improve the communication between the developers and the SDK.

The goals for this PR are:

- [x] Provide a lightweight logging tool (By lightweight I mean no 3rd party libraries and no complex setup).
- [x] Turn on/off logging at developer request.
- [x] Enable different level of logging to the console. 
- [x] Enable developers integrate their own logging infrastructure. 
- [x] Provide a default implementation that relies on iOS technology.
~~- [ ] Enable performance measure.~~

The current API introduces `MGLLogging` as a singleton class with two configurable properties: `loggingLevel` which will be utilized as a reference point to enable logging, this property allows different levels of verbosity where each level includes previous so then the highest level of verbosity comes when is set to `MGLLoggingLevelFault`, and `handler` which is a block handler for the messages. In case that developers wants to connect their current logging infrastructure they will have to set this property with their respective implementation.

/cc @mapbox/maps-ios 
