### PR TITLE
[build] Add Slack notifications for important iOS builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -285,6 +285,18 @@ step-library:
       store_artifacts:
         path: build/logs
 
+
+  - &notify-slack-nightly-failure
+      run:
+        name: Send a Slack notification on nightly failure
+        when: on_fail
+        command: |
+          if [[ -z $CIRCLE_COMPARE_URL && $CIRCLE_BRANCH == master ]]; then
+            export SLACK_MESSAGE="Nightly build of \`$CIRCLE_JOB\` <$CIRCLE_BUILD_URL|failed>."
+            export SLACK_COLOR="danger"
+            scripts/notify-slack.sh
+          fi
+
 jobs:
   nitpick:
     docker:
@@ -851,6 +863,7 @@ jobs:
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
+      SLACK_CHANNEL: C0ACM9Q2C
     steps:
       - checkout
       - *restore-node_modules-cache
@@ -870,6 +883,7 @@ jobs:
       - *save-ccache
       - *collect-xcode-build-logs
       - *upload-xcode-build-logs
+      - *notify-slack-nightly-failure
 
 # ------------------------------------------------------------------------------
   ios-sanitize-address:
@@ -878,6 +892,7 @@ jobs:
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
+      SLACK_CHANNEL: C0ACM9Q2C
     steps:
       - checkout
       - *restore-node_modules-cache
@@ -897,6 +912,7 @@ jobs:
       - *save-ccache
       - *collect-xcode-build-logs
       - *upload-xcode-build-logs
+      - *notify-slack-nightly-failure
 
 # ------------------------------------------------------------------------------
   ios-static-analyzer:
@@ -905,6 +921,7 @@ jobs:
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
+      SLACK_CHANNEL: C0ACM9Q2C
     steps:
       - checkout
       - *restore-node_modules-cache
@@ -924,6 +941,7 @@ jobs:
       - *save-ccache
       - *collect-xcode-build-logs
       - *upload-xcode-build-logs
+      - *notify-slack-nightly-failure
 
 # ------------------------------------------------------------------------------
   ios-release:
@@ -932,6 +950,7 @@ jobs:
     environment:
       BUILDTYPE: Release
       HOMEBREW_NO_AUTO_UPDATE: 1
+      SLACK_CHANNEL: C0ACM9Q2C
     steps:
       - checkout
       - *restore-node_modules-cache
@@ -961,6 +980,7 @@ jobs:
       - *save-ccache
       - *collect-xcode-build-logs
       - *upload-xcode-build-logs
+      - *notify-slack-nightly-failure
 
 # ------------------------------------------------------------------------------
   ios-release-tag:
@@ -969,7 +989,13 @@ jobs:
     environment:
       BUILDTYPE: Release
       HOMEBREW_NO_AUTO_UPDATE: 1
+      SLACK_CHANNEL: C0ACM9Q2C
     steps:
+      - run:
+          name: Send a Slack notification on start
+          command: |
+            export SLACK_MESSAGE="Release build for <$CIRCLE_COMPARE_URL|\`$CIRCLE_TAG\`> <$CIRCLE_BUILD_URL|started>."
+            scripts/notify-slack.sh
       - checkout
       - *restore-node_modules-cache
       - *npm-install
@@ -992,6 +1018,20 @@ jobs:
       - *save-ccache
       - *collect-xcode-build-logs
       - *upload-xcode-build-logs
+      - run:
+          name: Send a Slack notification on failure
+          when: on_fail
+          command: |
+            export SLACK_MESSAGE="Release build for <$CIRCLE_COMPARE_URL|\`$CIRCLE_TAG\`> <$CIRCLE_BUILD_URL|failed>."
+            export SLACK_COLOR="danger"
+            scripts/notify-slack.sh
+      - run:
+          name: Send a Slack notification on success
+          when: on_success
+          command: |
+            export SLACK_MESSAGE="Release build for <$CIRCLE_COMPARE_URL|\`$CIRCLE_TAG\`> <$CIRCLE_BUILD_URL|succeeded>."
+            export SLACK_COLOR="good"
+            scripts/notify-slack.sh
 
 # ------------------------------------------------------------------------------
   macos-debug:

--- a/scripts/notify-slack.sh
+++ b/scripts/notify-slack.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -u
+
+SLACK_CHANNEL=${SLACK_CHANNEL:-''}
+SLACK_COLOR=${SLACK_COLOR:-''}
+
+curl -g -H "Content-Type: application/json" -X POST \
+  -d "{\"channel\": \"$SLACK_CHANNEL\", \"attachments\": [{\"text\": \"$SLACK_MESSAGE\", \"color\": \"$SLACK_COLOR\", \"author_name\": \"$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME\"}]}" \
+  $SLACK_WEBHOOK_URL


### PR DESCRIPTION
This PR adds Slack notifications in the `#apple` channel (`C0ACM9Q2C`) when:
- Nightly iOS builds (added in #12689) fail.
- Release deployment jobs start/finish.

### Notes
This re-uses the existing Slack webhook (as the `SLACK_WEBHOOK_URL` envvar), so not specifying `SLACK_CHANNEL` will send a message to the default notification channel (`#gl-bots`).

Here’s the general message format:

<img width="470" alt="screen shot 2018-08-27 at 9 03 24 pm" src="https://user-images.githubusercontent.com/1198851/44694656-bf5b6e00-aa3c-11e8-9e5e-93ce264829ac.png">

I’m still interested in implementing @jfirebaugh’s more inclusive GitHub notifications (https://github.com/mapbox/mapbox-gl-native/pull/12689#issuecomment-414733684) at some point — Slack notifications just happened to dovetail with other asks (and are relatively simple to implement).

### Useful docs
- https://api.slack.com/docs/message-formatting
- https://api.slack.com/docs/message-attachments
- https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
- Reference jobs: [`ios-release-tag`](https://circleci.com/gh/mapbox/mapbox-gl-native/148775), [`ios-release` nightly](https://circleci.com/gh/mapbox/mapbox-gl-native/149969)

/cc @jfirebaugh @julianrex 