### PR TITLE
Added pragma to remove iOS build warning 

### DIFF
--- a/src/mbgl/text/language_tag.cpp
+++ b/src/mbgl/text/language_tag.cpp
@@ -6,6 +6,7 @@
 #pragma GCC diagnostic ignored "-Wshadow"
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
 #pragma clang diagnostic ignored "-Wtautological-constant-compare"
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/phoenix_core.hpp>


### PR DESCRIPTION
Removes warning "unknown warning group '-Wtautological-constant-compare', ignored" on iOS build