### PR TITLE
Disable debugging extension in ANGLE and refactor vertex array object extension initialization

### DIFF
--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -127,7 +127,11 @@ void Context::initializeExtensions(const std::function<gl::ProcAddress(const cha
         const std::string renderer = reinterpret_cast<const char*>(MBGL_CHECK_ERROR(glGetString(GL_RENDERER)));
         Log::Info(Event::General, "GPU Identifier: %s", renderer.c_str());
 
-        debugging = std::make_unique<extension::Debugging>(fn);
+        // Block ANGLE on Direct3D since the debugging extension is causing crashes
+        if (!(renderer.find("ANGLE") != std::string::npos
+              && renderer.find("Direct3D") != std::string::npos)) {
+            debugging = std::make_unique<extension::Debugging>(fn);
+        }
 
         // Block Adreno 2xx, 3xx as it crashes on glBuffer(Sub)Data
         // Block ARM Mali-T720 (in some MT8163 chipsets) as it crashes on glBindVertexArray

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -124,10 +124,24 @@ void Context::initializeExtensions(const std::function<gl::ProcAddress(const cha
             return nullptr;
         };
 
+        const std::string renderer = reinterpret_cast<const char*>(MBGL_CHECK_ERROR(glGetString(GL_RENDERER)));
+        Log::Info(Event::General, "GPU Identifier: %s", renderer.c_str());
+
         debugging = std::make_unique<extension::Debugging>(fn);
-        if (!disableVAOExtension) {
-            vertexArray = std::make_unique<extension::VertexArray>(fn);
+
+        // Block Adreno 2xx, 3xx as it crashes on glBuffer(Sub)Data
+        // Block ARM Mali-T720 (in some MT8163 chipsets) as it crashes on glBindVertexArray
+        // Block ANGLE on Direct3D as the combination of Qt + Windows + ANGLE leads to crashes
+        if (renderer.find("Adreno (TM) 2") == std::string::npos
+            && renderer.find("Adreno (TM) 3") == std::string::npos
+            && (!(renderer.find("ANGLE") != std::string::npos
+                  && renderer.find("Direct3D") != std::string::npos))
+            && renderer.find("Mali-T720") == std::string::npos
+            && renderer.find("Sapphire 650") == std::string::npos
+            && !disableVAOExtension) {
+                vertexArray = std::make_unique<extension::VertexArray>(fn);
         }
+
 #if MBGL_HAS_BINARY_PROGRAMS
         programBinary = std::make_unique<extension::ProgramBinary>(fn);
 #endif
@@ -286,22 +300,7 @@ UniqueTexture Context::createTexture() {
 }
 
 bool Context::supportsVertexArrays() const {
-    static bool blacklisted = []() {
-        const std::string renderer = reinterpret_cast<const char*>(MBGL_CHECK_ERROR(glGetString(GL_RENDERER)));
-
-        Log::Info(Event::General, "GPU Identifier: %s", renderer.c_str());
-
-        // Blacklist Adreno 2xx, 3xx as it crashes on glBuffer(Sub)Data
-        // Blacklist ARM Mali-T720 (in some MT8163 chipsets) as it crashes on glBindVertexArray
-        return renderer.find("Adreno (TM) 2") != std::string::npos
-            || renderer.find("Adreno (TM) 3") != std::string::npos
-            || renderer.find("Mali-T720") != std::string::npos
-            || renderer.find("Sapphire 650") != std::string::npos;
-
-    }();
-
-    return !blacklisted &&
-           vertexArray &&
+    return vertexArray &&
            vertexArray->genVertexArrays &&
            vertexArray->bindVertexArray &&
            vertexArray->deleteVertexArrays;

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -305,13 +305,8 @@ private:
     std::vector<RenderbufferID> abandonedRenderbuffers;
 
 public:
-    // For testing and Windows because Qt + ANGLE
-    // crashes with VAO enabled.
-#if defined(_WINDOWS)
-    bool disableVAOExtension = true;
-#else
+    // For testing
     bool disableVAOExtension = false;
-#endif
 };
 
 } // namespace gl


### PR DESCRIPTION
Crashes were reported when running debug builds on top of ANGLE. This PR disables said extension on that platform and refactors the vertex array object while at it.

/cc @kkaefer @brunoabinader 