### PR TITLE
[ios] Bump podspecs & update changelog for 4.4.0-alpha.2

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -15,10 +15,12 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 ### Offline
 * Improved SQLite error handling for offline databases that return specific errors. [#12224](https://github.com/mapbox/mapbox-gl-native/pull/12224)
 * Added the ability to define an offline region with an arbitrary shape. [#11447](https://github.com/mapbox/mapbox-gl-native/pull/11447)
+* Added the ability to merge offline regions from an externally prepared database into the main offline database. [#12608](https://github.com/mapbox/mapbox-gl-native/pull/12608)
 
-### Styles
+### Styles and rendering
 * Reduced the amount of memory consumed by font data after changing the style. [#12414](https://github.com/mapbox/mapbox-gl-native/pull/12414)
 * Modified how invalid values for "text-font" are handled. These are now warnings instead of errors. [#12414](https://github.com/mapbox/mapbox-gl-native/pull/12414)
+* Added an `MGLLineStyleLayer.lineGradient` property that can be used to define a gradient with which to color a line feature. [#12575](https://github.com/mapbox/mapbox-gl-native/pull/12575/)
 
 ## 4.3.0 - August 15, 2018
 

--- a/platform/ios/Mapbox-iOS-SDK-nightly-dynamic.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-nightly-dynamic.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '4.4.0-alpha.1'
+  version = '4.4.0-alpha.2'
 
   m.name    = 'Mapbox-iOS-SDK-nightly-dynamic'
   m.version = "#{version}-nightly"

--- a/platform/ios/Mapbox-iOS-SDK-symbols.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-symbols.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '4.4.0-alpha.1'
+  version = '4.4.0-alpha.2'
 
   m.name    = 'Mapbox-iOS-SDK-symbols'
   m.version = "#{version}-symbols"

--- a/platform/ios/Mapbox-iOS-SDK.podspec
+++ b/platform/ios/Mapbox-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '4.4.0-alpha.1'
+  version = '4.4.0-alpha.2'
 
   m.name    = 'Mapbox-iOS-SDK'
   m.version = version


### PR DESCRIPTION
Updates the iOS changelog and associated Podspecs for v4.4.0-alpha.2.

Changes since 4.4.0-alpha.1: https://github.com/mapbox/mapbox-gl-native/compare/ios-v4.4.0-alpha.1...master