### PR TITLE
[build] Fix ios-release-tag slack notification

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -991,12 +991,12 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: 1
       SLACK_CHANNEL: C0ACM9Q2C
     steps:
+      - checkout
       - run:
           name: Send a Slack notification on start
           command: |
             export SLACK_MESSAGE="Release build for <$CIRCLE_COMPARE_URL|\`$CIRCLE_TAG\`> <$CIRCLE_BUILD_URL|started>."
             scripts/notify-slack.sh
-      - checkout
       - *restore-node_modules-cache
       - *npm-install
       - *prepare-environment


### PR DESCRIPTION
Follows-up on #12750 — when I moved the Slack notification configuration to a checked-in script, I forgot to move the `checkout` step for `ios-release-tag` above the “start” notification.

/cc @captainbarbosa 