### PR TITLE
[android] Explicitly delete local JNI references

### DIFF
--- a/platform/android/src/logger.cpp
+++ b/platform/android/src/logger.cpp
@@ -28,6 +28,9 @@ void Logger::log(jni::JNIEnv& env, EventSeverity severity, const std::string &ms
         auto static error = _class.GetStaticMethod<Signature>(env, "e");
         _class.Call(env, error, tag, message);
     }
+
+    DeleteLocalRef(env, tag);
+    DeleteLocalRef(env, message);
 }
 
 } // namespace android


### PR DESCRIPTION
This method seems to be called in a loop, leading to a local reference table overflow if not explicitly deleted.

See https://github.com/mapbox/mapbox-gl-native/pull/12716#pullrequestreview-150462731