### PR TITLE
[build] Skip Android device tests via commit message

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -422,7 +422,7 @@ jobs:
       - run:
           name: Check if Firebase should be skipped
           command: |
-            SHOULD_SKIP=$( git log -1 | grep -i -E -e "\[(skip.firebase|firebase.skip)\]" -e "\[((i|mac)os)+(, (i|mac)os)?\]" )
+            SHOULD_SKIP=$( git log -1 | grep -i -E -e "\[(skip.firebase|firebase.skip)\]" -e "\[((i|mac)os)+(, (i|mac)os)?\]" -e "\[darwin\]" )
             if [ -n "${SHOULD_SKIP}" ]; then
               echo "Skipping Firebase tests."
               echo 'export SKIP_FIREBASE=1' >> $BASH_ENV

--- a/circle.yml
+++ b/circle.yml
@@ -420,9 +420,17 @@ jobs:
       - *save-ccache
       - *save-gradle-cache
       - run:
+          name: Check if Firebase should be skipped
+          command: |
+            SHOULD_SKIP=$( git log -1 | grep -i -E -e "\[(skip.firebase|firebase.skip)\]" -e "\[((i|mac)os)+(, (i|mac)os)?\]" )
+            if [ -n "${SHOULD_SKIP}" ]; then
+              echo "Skipping Firebase tests."
+              echo 'export SKIP_FIREBASE=1' >> $BASH_ENV
+            fi
+      - run:
           name: Log in to Google Cloud Platform
           command: |
-            if [ -n "${GCLOUD_SERVICE_ACCOUNT_JSON}" ]; then
+            if [[ -n "${GCLOUD_SERVICE_ACCOUNT_JSON}" && -z "${SKIP_FIREBASE}" ]]; then
               echo "${GCLOUD_SERVICE_ACCOUNT_JSON}" > secret.json
               gcloud auth activate-service-account --key-file secret.json --project android-gl-native
               rm secret.json
@@ -431,7 +439,7 @@ jobs:
           name: Run instrumentation tests on Firebase
           no_output_timeout: 1200
           command: |
-            if [ -n "${GCLOUD_SERVICE_ACCOUNT_JSON}" ]; then
+            if [[ -n "${GCLOUD_SERVICE_ACCOUNT_JSON}" && -z "${SKIP_FIREBASE}" ]]; then
               gcloud firebase test android models list
               gcloud firebase test android run --type instrumentation \
                 --app platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/debug/MapboxGLAndroidSDKTestApp-debug.apk \

--- a/circle.yml
+++ b/circle.yml
@@ -422,7 +422,7 @@ jobs:
       - run:
           name: Check if Firebase should be skipped
           command: |
-            SKIPPABLE_TAG=$( git log -1 | grep -ioE -e "\[(skip.firebase|firebase.skip)\]" -e "\[((i|mac)os)+(, (i|mac)os)?\]" -e "\[darwin\]" | cat )
+            SKIPPABLE_TAG=$( git log -1 | grep -ioE -e "\[(skip.firebase|firebase.skip)\]" -e "\[((i|mac)os)+(, (i|mac)os)?\]" -e "\[darwin\]" || true )
             if [ -n "${SKIPPABLE_TAG}" ]; then
               echo "Skipping Firebase tests because commit message contained: '${SKIPPABLE_TAG}'"
               echo 'export SKIP_FIREBASE=1' >> $BASH_ENV

--- a/circle.yml
+++ b/circle.yml
@@ -422,9 +422,9 @@ jobs:
       - run:
           name: Check if Firebase should be skipped
           command: |
-            SHOULD_SKIP=$( git log -1 | grep -i -E -e "\[(skip.firebase|firebase.skip)\]" -e "\[((i|mac)os)+(, (i|mac)os)?\]" -e "\[darwin\]" )
-            if [ -n "${SHOULD_SKIP}" ]; then
-              echo "Skipping Firebase tests."
+            SKIPPABLE_TAG=$( git log -1 | grep -ioE -e "\[(skip.firebase|firebase.skip)\]" -e "\[((i|mac)os)+(, (i|mac)os)?\]" -e "\[darwin\]" | cat )
+            if [ -n "${SKIPPABLE_TAG}" ]; then
+              echo "Skipping Firebase tests because commit message contained: '${SKIPPABLE_TAG}'"
               echo 'export SKIP_FIREBASE=1' >> $BASH_ENV
             fi
       - run:


### PR DESCRIPTION
Closes #10883. The `android-debug-arm-v7` build is our longest-running CI job, largely because it runs tests on Firebase’s device farm (which can take anywhere from 10 to 30 minutes). For Android or core commits we’ve decided this is acceptable, but for changes that don’t touch the Android platform these tests constitute a significant time penalty for no benefit.

To that end:

- Add `[skip firebase]` anywhere in your commit message to avoid running Firebase tests for that commit.
- Firebase tests are automatically skipped if the commit message includes `[ios]`, `[macos]`, some combination thereof, or `[darwin]`.
- Only skips if included in the most recent commit message.

/cc @mapbox/maps-ios @mapbox/maps-android 