### PR TITLE
Renderer state

### DIFF
--- a/cmake/core-files.txt
+++ b/cmake/core-files.txt
@@ -176,6 +176,7 @@ include/mbgl/renderer/renderer.hpp
 include/mbgl/renderer/renderer_backend.hpp
 include/mbgl/renderer/renderer_frontend.hpp
 include/mbgl/renderer/renderer_observer.hpp
+include/mbgl/renderer/renderer_state.hpp
 src/mbgl/renderer/backend_scope.cpp
 src/mbgl/renderer/bucket.hpp
 src/mbgl/renderer/bucket_parameters.cpp
@@ -212,6 +213,7 @@ src/mbgl/renderer/renderer.cpp
 src/mbgl/renderer/renderer_backend.cpp
 src/mbgl/renderer/renderer_impl.cpp
 src/mbgl/renderer/renderer_impl.hpp
+src/mbgl/renderer/renderer_state.cpp
 src/mbgl/renderer/style_diff.cpp
 src/mbgl/renderer/style_diff.hpp
 src/mbgl/renderer/tile_mask.hpp

--- a/include/mbgl/renderer/renderer_state.hpp
+++ b/include/mbgl/renderer/renderer_state.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <mbgl/map/camera.hpp>
+#include <mbgl/util/geo.hpp>
+
+namespace mbgl {
+
+class UpdateParameters;
+
+class RendererState {
+public:
+    static CameraOptions getCameraOptions(UpdateParameters&, const EdgeInsets& = {});
+};
+
+} // namespace mbgl

--- a/platform/default/mbgl/gl/headless_frontend.cpp
+++ b/platform/default/mbgl/gl/headless_frontend.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/gl/headless_frontend.hpp>
 #include <mbgl/renderer/renderer.hpp>
+#include <mbgl/renderer/renderer_state.hpp>
 #include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/map/map.hpp>
 #include <mbgl/map/transform_state.hpp>
@@ -53,6 +54,14 @@ Renderer* HeadlessFrontend::getRenderer() {
 
 RendererBackend* HeadlessFrontend::getBackend() {
     return &backend;
+}
+
+CameraOptions HeadlessFrontend::getCameraOptions() {
+    if (updateParameters)
+        return RendererState::getCameraOptions(*updateParameters);
+
+    static CameraOptions nullCamera;
+    return nullCamera;
 }
 
 void HeadlessFrontend::setSize(Size size_) {

--- a/platform/default/mbgl/gl/headless_frontend.hpp
+++ b/platform/default/mbgl/gl/headless_frontend.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mbgl/map/camera.hpp>
 #include <mbgl/renderer/mode.hpp>
 #include <mbgl/renderer/renderer_frontend.hpp>
 #include <mbgl/gl/headless_backend.hpp>
@@ -32,6 +33,7 @@ public:
 
     Renderer* getRenderer();
     RendererBackend* getBackend();
+    CameraOptions getCameraOptions();
 
     PremultipliedImage readStillImage();
     PremultipliedImage render(Map&);

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -64,13 +64,7 @@ void Transform::resize(const Size size) {
 #pragma mark - Camera
 
 CameraOptions Transform::getCameraOptions(const EdgeInsets& padding) const {
-    CameraOptions camera;
-    camera.center = getLatLng(padding);
-    camera.padding = padding;
-    camera.zoom = getZoom();
-    camera.angle = getAngle();
-    camera.pitch = getPitch();
-    return camera;
+    return state.getCameraOptions(padding);
 }
 
 /**

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -130,6 +130,26 @@ ViewportMode TransformState::getViewportMode() const {
     return viewportMode;
 }
 
+#pragma mark - Camera options
+
+CameraOptions TransformState::getCameraOptions(const EdgeInsets& padding) const {
+    CameraOptions camera;
+
+    if (padding.isFlush()) {
+        camera.center = getLatLng();
+    } else {
+        ScreenCoordinate point = padding.getCenter(size.width, size.height);
+        point.y = size.height - point.y;
+        camera.center = screenCoordinateToLatLng(point).wrapped();
+    }
+    camera.padding = padding;
+    camera.zoom = getZoom();
+    camera.angle = -angle * util::RAD2DEG;
+    camera.pitch = pitch * util::RAD2DEG;
+
+    return camera;
+}
+
 #pragma mark - Position
 
 LatLng TransformState::getLatLng(LatLng::WrapMode wrapMode) const {

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -144,8 +144,8 @@ CameraOptions TransformState::getCameraOptions(const EdgeInsets& padding) const 
     }
     camera.padding = padding;
     camera.zoom = getZoom();
-    camera.angle = -angle * util::RAD2DEG;
-    camera.pitch = pitch * util::RAD2DEG;
+    camera.angle = angle;
+    camera.pitch = pitch;
 
     return camera;
 }

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -20,6 +20,7 @@ class UnwrappedTileID;
 
 class TransformState {
     friend class Transform;
+    friend class RendererState;
 
 public:
     TransformState(ConstrainMode = ConstrainMode::HeightOnly, ViewportMode = ViewportMode::Default);

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/map/mode.hpp>
+#include <mbgl/map/camera.hpp>
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/geometry.hpp>
 #include <mbgl/util/constants.hpp>
@@ -39,6 +40,8 @@ public:
 
     // Viewport mode
     ViewportMode getViewportMode() const;
+
+    CameraOptions getCameraOptions(const EdgeInsets&) const;
 
     // Position
     LatLng getLatLng(LatLng::WrapMode = LatLng::Unwrapped) const;

--- a/src/mbgl/renderer/renderer_state.cpp
+++ b/src/mbgl/renderer/renderer_state.cpp
@@ -1,0 +1,10 @@
+#include <mbgl/renderer/renderer_state.hpp>
+#include <mbgl/renderer/update_parameters.hpp>
+
+namespace mbgl {
+
+CameraOptions RendererState::getCameraOptions(UpdateParameters& updateParameters, const EdgeInsets& padding) {
+    return updateParameters.transformState.getCameraOptions(padding);
+}
+
+} // namespace mbgl

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -49,6 +49,34 @@ public:
     }
 };
 
+TEST(Map, RendererState) {
+    MapTest<> test;
+
+    // Map hasn't notified the frontend about an update yet.
+    CameraOptions nullOptions;
+    ASSERT_EQ(test.frontend.getCameraOptions(), nullOptions);
+
+    LatLng coordinate { 1, 1 };
+    double zoom = 12.0;
+    double pitchInDegrees = 45.0;
+    double bearingInDegrees = 30.0;
+
+    test.map.getStyle().loadJSON(util::read_file("test/fixtures/api/empty.json"));
+    test.map.setLatLngZoom(coordinate, zoom);
+    test.map.setPitch(pitchInDegrees);
+    test.map.setBearing(bearingInDegrees);
+
+    test.runLoop.runOnce();
+    test.frontend.render(test.map);
+
+    const CameraOptions& options = test.frontend.getCameraOptions();
+    EXPECT_NEAR(options.center->latitude(), coordinate.latitude(), 1e-7);
+    EXPECT_NEAR(options.center->longitude(), coordinate.longitude(), 1e-7);
+    ASSERT_DOUBLE_EQ(*options.zoom, zoom);
+    ASSERT_DOUBLE_EQ(*options.pitch, pitchInDegrees * mbgl::util::DEG2RAD);
+    EXPECT_NEAR(*options.angle, -bearingInDegrees * mbgl::util::DEG2RAD, 1e-7);
+}
+
 TEST(Map, LatLngBehavior) {
     MapTest<> test;
 


### PR DESCRIPTION
Introduces a Memento-like `RendererState` object that will be responsible for fetching renderer state-related data (being camera positioning the first in the list), while preserving the encapsulation of `mbgl::UpdateParameters`.

/cc @kkaefer @tmpsantos 