### PR TITLE
[core] Port symbol-z-order symbol layout style spec property

### DIFF
--- a/include/mbgl/style/layers/symbol_layer.hpp
+++ b/include/mbgl/style/layers/symbol_layer.hpp
@@ -53,6 +53,10 @@ public:
     PropertyValue<bool> getSymbolAvoidEdges() const;
     void setSymbolAvoidEdges(PropertyValue<bool>);
 
+    static PropertyValue<SymbolZOrderType> getDefaultSymbolZOrder();
+    PropertyValue<SymbolZOrderType> getSymbolZOrder() const;
+    void setSymbolZOrder(PropertyValue<SymbolZOrderType>);
+
     static PropertyValue<bool> getDefaultIconAllowOverlap();
     PropertyValue<bool> getIconAllowOverlap() const;
     void setIconAllowOverlap(PropertyValue<bool>);

--- a/include/mbgl/style/types.hpp
+++ b/include/mbgl/style/types.hpp
@@ -68,6 +68,11 @@ enum class SymbolPlacementType : uint8_t {
     Line,
     LineCenter
 };
+    
+enum class SymbolZOrderType : uint8_t {
+    ViewportY,
+    Source
+};
 
 enum class AlignmentType : uint8_t {
     Map,

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -3,6 +3,7 @@
 Mapbox welcomes participation and contributions from everyone.  If you'd like to do so please see the [`Contributing Guide`](https://github.com/mapbox/mapbox-gl-native/blob/master/CONTRIBUTING.md) first to get started.
 
 ## master
+- Add `symbol-z-order` symbol layout property to style spec [#12783](https://github.com/mapbox/mapbox-gl-native/pull/12783)
 
 ## 6.5.0-beta.1 - September 5, 2018
  - Retain shared thread pool reference [#12811](https://github.com/mapbox/mapbox-gl-native/pull/12811)

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Property.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Property.java
@@ -108,6 +108,27 @@ public final class Property {
   @Retention(RetentionPolicy.SOURCE)
   public @interface SYMBOL_PLACEMENT {}
 
+  // SYMBOL_Z_ORDER: Controls the order in which overlapping symbols in the same layer are rendered
+
+  /**
+   * Symbols will be sorted by their y-position relative to the viewport.
+   */
+  public static final String SYMBOL_Z_ORDER_VIEWPORT_Y = "viewport-y";
+  /**
+   * Symbols will be rendered in the same order as the source data with no sorting applied.
+   */
+  public static final String SYMBOL_Z_ORDER_SOURCE = "source";
+
+  /**
+   * Controls the order in which overlapping symbols in the same layer are rendered
+   */
+  @StringDef({
+      SYMBOL_Z_ORDER_VIEWPORT_Y,
+      SYMBOL_Z_ORDER_SOURCE,
+    })
+  @Retention(RetentionPolicy.SOURCE)
+  public @interface SYMBOL_Z_ORDER {}
+
   // ICON_ROTATION_ALIGNMENT: In combination with `symbol-placement`, determines the rotation behavior of icons.
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyFactory.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyFactory.java
@@ -1765,6 +1765,26 @@ public class PropertyFactory {
   }
 
   /**
+   * Controls the order in which overlapping symbols in the same layer are rendered
+   *
+   * @param value a String value
+   * @return property wrapper around String
+   */
+  public static PropertyValue<String> symbolZOrder(@Property.SYMBOL_Z_ORDER String value) {
+    return new LayoutPropertyValue<>("symbol-z-order", value);
+  }
+
+  /**
+   * Controls the order in which overlapping symbols in the same layer are rendered
+   *
+   * @param value a String value
+   * @return property wrapper around String
+   */
+  public static PropertyValue<Expression> symbolZOrder(Expression value) {
+    return new LayoutPropertyValue<>("symbol-z-order", value);
+  }
+
+  /**
    * If true, the icon will be visible even if it collides with other previously drawn symbols.
    *
    * @param value a Boolean value

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/SymbolLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/SymbolLayer.java
@@ -171,6 +171,17 @@ public class SymbolLayer extends Layer {
   }
 
   /**
+   * Get the SymbolZOrder property
+   *
+   * @return property wrapper value around String
+   */
+  @SuppressWarnings("unchecked")
+  public PropertyValue<String> getSymbolZOrder() {
+    checkThread();
+    return (PropertyValue<String>) new PropertyValue("symbol-z-order", nativeGetSymbolZOrder());
+  }
+
+  /**
    * Get the IconAllowOverlap property
    *
    * @return property wrapper value around Boolean
@@ -1003,6 +1014,9 @@ public class SymbolLayer extends Layer {
 
   @Keep
   private native Object nativeGetSymbolAvoidEdges();
+
+  @Keep
+  private native Object nativeGetSymbolZOrder();
 
   @Keep
   private native Object nativeGetIconAllowOverlap();

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
@@ -160,6 +160,20 @@ public class SymbolLayerTest extends BaseActivityTest {
   }
 
   @Test
+  public void testSymbolZOrderAsConstant() {
+    validateTestSetup();
+    setupLayer();
+    Timber.i("symbol-z-order");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(layer);
+
+      // Set and Get
+      layer.setProperties(symbolZOrder(SYMBOL_Z_ORDER_VIEWPORT_Y));
+      assertEquals((String) layer.getSymbolZOrder().getValue(), (String) SYMBOL_Z_ORDER_VIEWPORT_Y);
+    });
+  }
+
+  @Test
   public void testIconAllowOverlapAsConstant() {
     validateTestSetup();
     setupLayer();

--- a/platform/android/src/style/layers/symbol_layer.cpp
+++ b/platform/android/src/style/layers/symbol_layer.cpp
@@ -50,6 +50,11 @@ namespace android {
         return std::move(*convert<jni::Local<jni::Object<>>>(env, layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getSymbolAvoidEdges()));
     }
 
+    jni::Local<jni::Object<>> SymbolLayer::getSymbolZOrder(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getSymbolZOrder()));
+    }
+
     jni::Local<jni::Object<>> SymbolLayer::getIconAllowOverlap(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         return std::move(*convert<jni::Local<jni::Object<>>>(env, layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getIconAllowOverlap()));
@@ -463,6 +468,7 @@ namespace android {
             METHOD(&SymbolLayer::getSymbolPlacement, "nativeGetSymbolPlacement"),
             METHOD(&SymbolLayer::getSymbolSpacing, "nativeGetSymbolSpacing"),
             METHOD(&SymbolLayer::getSymbolAvoidEdges, "nativeGetSymbolAvoidEdges"),
+            METHOD(&SymbolLayer::getSymbolZOrder, "nativeGetSymbolZOrder"),
             METHOD(&SymbolLayer::getIconAllowOverlap, "nativeGetIconAllowOverlap"),
             METHOD(&SymbolLayer::getIconIgnorePlacement, "nativeGetIconIgnorePlacement"),
             METHOD(&SymbolLayer::getIconOptional, "nativeGetIconOptional"),

--- a/platform/android/src/style/layers/symbol_layer.hpp
+++ b/platform/android/src/style/layers/symbol_layer.hpp
@@ -33,6 +33,8 @@ public:
 
     jni::Local<jni::Object<jni::ObjectTag>> getSymbolAvoidEdges(jni::JNIEnv&);
 
+    jni::Local<jni::Object<jni::ObjectTag>> getSymbolZOrder(jni::JNIEnv&);
+
     jni::Local<jni::Object<jni::ObjectTag>> getIconAllowOverlap(jni::JNIEnv&);
 
     jni::Local<jni::Object<jni::ObjectTag>> getIconIgnorePlacement(jni::JNIEnv&);

--- a/platform/darwin/scripts/style-spec-overrides-v8.json
+++ b/platform/darwin/scripts/style-spec-overrides-v8.json
@@ -39,6 +39,16 @@
     }
   },
   "layout_symbol": {
+    "symbol-z-order": {
+      "values": {
+        "viewport-y": {
+          "doc": "Specify this z order if symbols’ appearance relies on lower features overlapping higher features. For example, symbols with a pin-like appearance would require this z order."
+        },
+        "source": {
+          "doc": "Specify this z order if the order in which features appear in the source is significant."
+        }
+      }
+    },
     "icon-text-fit-padding": {
       "doc": "Size of the additional area added to dimensions determined by `icon-text-fit`."
     },

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -151,6 +151,26 @@ typedef NS_ENUM(NSUInteger, MGLSymbolPlacement) {
 };
 
 /**
+ Controls the order in which overlapping symbols in the same layer are rendered
+
+ Values of this type are used in the `MGLSymbolStyleLayer.symbolZOrder`
+ property.
+ */
+typedef NS_ENUM(NSUInteger, MGLSymbolZOrder) {
+    /**
+     Specify this z order if symbols’ appearance relies on lower features
+     overlapping higher features. For example, symbols with a pin-like
+     appearance would require this z order.
+     */
+    MGLSymbolZOrderViewportY,
+    /**
+     Specify this z order if the order in which features appear in the source is
+     significant.
+     */
+    MGLSymbolZOrderSource,
+};
+
+/**
  Part of the text placed closest to the anchor.
 
  Values of this type are used in the `MGLSymbolStyleLayer.textAnchor`
@@ -1003,6 +1023,32 @@ MGL_EXPORT
  feature attributes.
  */
 @property (nonatomic, null_resettable) NSExpression *symbolSpacing;
+
+/**
+ Controls the order in which overlapping symbols in the same layer are rendered
+ 
+ The default value of this property is an expression that evaluates to
+ `viewport-y`. Set this property to `nil` to reset it to the default value.
+ 
+ You can set this property to an expression containing any of the following:
+ 
+ * Constant `MGLSymbolZOrder` values
+ * Any of the following constant string values:
+   * `viewport-y`: Specify this z order if symbols’ appearance relies on lower
+ features overlapping higher features. For example, symbols with a pin-like
+ appearance would require this z order.
+   * `source`: Specify this z order if the order in which features appear in the
+ source is significant.
+ * Predefined functions, including mathematical and string operators
+ * Conditional expressions
+ * Variable assignments and references to assigned variables
+ * Step functions applied to the `$zoomLevel` variable
+ 
+ This property does not support applying interpolation functions to the
+ `$zoomLevel` variable or applying interpolation or step functions to feature
+ attributes.
+ */
+@property (nonatomic, null_resettable) NSExpression *symbolZOrder;
 
 /**
  Value to use for a text label.
@@ -2139,6 +2185,19 @@ MGL_EXPORT
  The `MGLSymbolPlacement` enumeration representation of the value.
  */
 @property (readonly) MGLSymbolPlacement MGLSymbolPlacementValue;
+
+/**
+ Creates a new value object containing the given `MGLSymbolZOrder` enumeration.
+
+ @param symbolZOrder The value for the new object.
+ @return A new value object that contains the enumeration value.
+ */
++ (instancetype)valueWithMGLSymbolZOrder:(MGLSymbolZOrder)symbolZOrder;
+
+/**
+ The `MGLSymbolZOrder` enumeration representation of the value.
+ */
+@property (readonly) MGLSymbolZOrder MGLSymbolZOrderValue;
 
 /**
  Creates a new value object containing the given `MGLTextAnchor` enumeration.

--- a/platform/darwin/src/MGLSymbolStyleLayer.mm
+++ b/platform/darwin/src/MGLSymbolStyleLayer.mm
@@ -50,6 +50,11 @@ namespace mbgl {
         { MGLSymbolPlacementLineCenter, "line-center" },
     });
 
+    MBGL_DEFINE_ENUM(MGLSymbolZOrder, {
+        { MGLSymbolZOrderViewportY, "viewport-y" },
+        { MGLSymbolZOrderSource, "source" },
+    });
+
     MBGL_DEFINE_ENUM(MGLTextAnchor, {
         { MGLTextAnchorCenter, "center" },
         { MGLTextAnchorLeft, "left" },
@@ -571,6 +576,23 @@ namespace mbgl {
         propertyValue = self.rawLayer->getDefaultSymbolSpacing();
     }
     return MGLStyleValueTransformer<float, NSNumber *>().toExpression(propertyValue);
+}
+
+- (void)setSymbolZOrder:(NSExpression *)symbolZOrder {
+    MGLAssertStyleLayerIsValid();
+
+    auto mbglValue = MGLStyleValueTransformer<mbgl::style::SymbolZOrderType, NSValue *, mbgl::style::SymbolZOrderType, MGLSymbolZOrder>().toPropertyValue<mbgl::style::PropertyValue<mbgl::style::SymbolZOrderType>>(symbolZOrder, false);
+    self.rawLayer->setSymbolZOrder(mbglValue);
+}
+
+- (NSExpression *)symbolZOrder {
+    MGLAssertStyleLayerIsValid();
+
+    auto propertyValue = self.rawLayer->getSymbolZOrder();
+    if (propertyValue.isUndefined()) {
+        propertyValue = self.rawLayer->getDefaultSymbolZOrder();
+    }
+    return MGLStyleValueTransformer<mbgl::style::SymbolZOrderType, NSValue *, mbgl::style::SymbolZOrderType, MGLSymbolZOrder>().toExpression(propertyValue);
 }
 
 - (void)setText:(NSExpression *)text {
@@ -1438,6 +1460,16 @@ namespace mbgl {
     MGLSymbolPlacement symbolPlacement;
     [self getValue:&symbolPlacement];
     return symbolPlacement;
+}
+
++ (NSValue *)valueWithMGLSymbolZOrder:(MGLSymbolZOrder)symbolZOrder {
+    return [NSValue value:&symbolZOrder withObjCType:@encode(MGLSymbolZOrder)];
+}
+
+- (MGLSymbolZOrder)MGLSymbolZOrderValue {
+    MGLSymbolZOrder symbolZOrder;
+    [self getValue:&symbolZOrder];
+    return symbolZOrder;
 }
 
 + (NSValue *)valueWithMGLTextAnchor:(MGLTextAnchor)textAnchor {

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## master
+* Added an `MGLSymbolStyleLayer.symbolZOrder` property for forcing point features in a symbol layer to be layered in the same order that they are specified in the layer’s associated source. [#12783](https://github.com/mapbox/mapbox-gl-native/pull/12783)
+
 ## 4.4.0
 
 ### Styles and rendering

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master
 
+### Styles and rendering
+* Add `symbol-z-order` symbol layout property to style spec [#12783](https://github.com/mapbox/mapbox-gl-native/pull/12783)
+
 ### Other changes
 
 * Fixed bug where completion block passed to `-[MGLMapSnapshotter startWithQueue:completionHandler:]` was not being called in all code paths. ([#12355](https://github.com/mapbox/mapbox-gl-native/pull/12355))

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,4 +1,5 @@
 # master
+- Add `symbol-z-order` symbol layout property to style spec [#12783](https://github.com/mapbox/mapbox-gl-native/pull/12783)
 - Don't default-show text/icons that depend on the placement of a paired icon/text [#12483](https://github.com/mapbox/mapbox-gl-native/issues/12483)
 - Fix symbol querying for annotations near tile boundaries at high zoom. ([#12472](https://github.com/mapbox/mapbox-gl-native/issues/12472))
 - The `Map` constructor now accepts a `mode` option which can be either `"static"` (default) or `"tile"`. It must be set to `"tile"` when rendering individual tiles in order for the symbols to match across tiles.

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -401,10 +401,11 @@ std::vector<float> CalculateTileDistances(const GeometryCoordinates& line, const
 }
 
 void SymbolLayout::createBucket(const ImagePositions&, std::unique_ptr<FeatureIndex>&, std::unordered_map<std::string, std::shared_ptr<Bucket>>& buckets, const bool firstLoad, const bool showCollisionBoxes) {
-    const bool mayOverlap = layout.get<TextAllowOverlap>() || layout.get<IconAllowOverlap>() ||
-        layout.get<TextIgnorePlacement>() || layout.get<IconIgnorePlacement>();
+    const bool zOrderByViewport = layout.get<SymbolZOrder>() == SymbolZOrderType::ViewportY;
+    const bool sortFeaturesByY = zOrderByViewport && (layout.get<TextAllowOverlap>() || layout.get<IconAllowOverlap>() ||
+        layout.get<TextIgnorePlacement>() || layout.get<IconIgnorePlacement>());
     
-    auto bucket = std::make_shared<SymbolBucket>(layout, layerPaintProperties, textSize, iconSize, zoom, sdfIcons, iconsNeedLinear, mayOverlap, bucketLeaderID, std::move(symbolInstances));
+    auto bucket = std::make_shared<SymbolBucket>(layout, layerPaintProperties, textSize, iconSize, zoom, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(symbolInstances));
 
     for (SymbolInstance &symbolInstance : bucket->symbolInstances) {
 

--- a/src/mbgl/style/conversion/constant.cpp
+++ b/src/mbgl/style/conversion/constant.cpp
@@ -59,6 +59,7 @@ template optional<LineJoinType> Converter<LineJoinType>::operator()(const Conver
 template optional<RasterResamplingType> Converter<RasterResamplingType>::operator()(const Convertible&, Error&) const;
 template optional<SymbolAnchorType> Converter<SymbolAnchorType>::operator()(const Convertible&, Error&) const;
 template optional<SymbolPlacementType> Converter<SymbolPlacementType>::operator()(const Convertible&, Error&) const;
+template optional<SymbolZOrderType> Converter<SymbolZOrderType>::operator()(const Convertible&, Error&) const;
 template optional<TextJustifyType> Converter<TextJustifyType>::operator()(const Convertible&, Error&) const;
 template optional<TextTransformType> Converter<TextTransformType>::operator()(const Convertible&, Error&) const;
 template optional<TranslateAnchorType> Converter<TranslateAnchorType>::operator()(const Convertible&, Error&) const;

--- a/src/mbgl/style/conversion/function.cpp
+++ b/src/mbgl/style/conversion/function.cpp
@@ -131,6 +131,8 @@ template optional<PropertyExpression<SymbolAnchorType>>
     convertFunctionToExpression<SymbolAnchorType>(const Convertible&, Error&, bool);
 template optional<PropertyExpression<SymbolPlacementType>>
     convertFunctionToExpression<SymbolPlacementType>(const Convertible&, Error&, bool);
+template optional<PropertyExpression<SymbolZOrderType>>
+    convertFunctionToExpression<SymbolZOrderType>(const Convertible&, Error&, bool);
 template optional<PropertyExpression<TextJustifyType>>
     convertFunctionToExpression<TextJustifyType>(const Convertible&, Error&, bool);
 template optional<PropertyExpression<TextTransformType>>

--- a/src/mbgl/style/conversion/property_value.cpp
+++ b/src/mbgl/style/conversion/property_value.cpp
@@ -74,6 +74,7 @@ template optional<PropertyValue<Position>> Converter<PropertyValue<Position>>::o
 template optional<PropertyValue<RasterResamplingType>> Converter<PropertyValue<RasterResamplingType>>::operator()(conversion::Convertible const&, conversion::Error&, bool, bool) const;
 template optional<PropertyValue<SymbolAnchorType>> Converter<PropertyValue<SymbolAnchorType>>::operator()(conversion::Convertible const&, conversion::Error&, bool, bool) const;
 template optional<PropertyValue<SymbolPlacementType>> Converter<PropertyValue<SymbolPlacementType>>::operator()(conversion::Convertible const&, conversion::Error&, bool, bool) const;
+template optional<PropertyValue<SymbolZOrderType>> Converter<PropertyValue<SymbolZOrderType>>::operator()(conversion::Convertible const&, conversion::Error&, bool, bool) const;
 template optional<PropertyValue<TextJustifyType>> Converter<PropertyValue<TextJustifyType>>::operator()(conversion::Convertible const&, conversion::Error&, bool, bool) const;
 template optional<PropertyValue<TextTransformType>> Converter<PropertyValue<TextTransformType>>::operator()(conversion::Convertible const&, conversion::Error&, bool, bool) const;
 template optional<PropertyValue<TranslateAnchorType>> Converter<PropertyValue<TranslateAnchorType>>::operator()(conversion::Convertible const&, conversion::Error&, bool, bool) const;

--- a/src/mbgl/style/expression/value.cpp
+++ b/src/mbgl/style/expression/value.cpp
@@ -297,6 +297,9 @@ template struct ValueConverter<LineJoinType>;
 
 template type::Type valueTypeToExpressionType<SymbolPlacementType>();
 template struct ValueConverter<SymbolPlacementType>;
+    
+template type::Type valueTypeToExpressionType<SymbolZOrderType>();
+template struct ValueConverter<SymbolZOrderType>;
 
 template type::Type valueTypeToExpressionType<SymbolAnchorType>();
 template struct ValueConverter<SymbolAnchorType>;

--- a/src/mbgl/style/layers/symbol_layer.cpp
+++ b/src/mbgl/style/layers/symbol_layer.cpp
@@ -149,6 +149,22 @@ void SymbolLayer::setSymbolAvoidEdges(PropertyValue<bool> value) {
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
+PropertyValue<SymbolZOrderType> SymbolLayer::getDefaultSymbolZOrder() {
+    return SymbolZOrder::defaultValue();
+}
+
+PropertyValue<SymbolZOrderType> SymbolLayer::getSymbolZOrder() const {
+    return impl().layout.get<SymbolZOrder>();
+}
+
+void SymbolLayer::setSymbolZOrder(PropertyValue<SymbolZOrderType> value) {
+    if (value == getSymbolZOrder())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->layout.get<SymbolZOrder>() = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
 PropertyValue<bool> SymbolLayer::getDefaultIconAllowOverlap() {
     return IconAllowOverlap::defaultValue();
 }
@@ -1440,6 +1456,7 @@ optional<Error> SymbolLayer::setLayoutProperty(const std::string& name, const Co
         SymbolPlacement,
         SymbolSpacing,
         SymbolAvoidEdges,
+        SymbolZOrder,
         IconAllowOverlap,
         IconIgnorePlacement,
         IconOptional,
@@ -1493,6 +1510,12 @@ optional<Error> SymbolLayer::setLayoutProperty(const std::string& name, const Co
     case util::hashFNV1a("symbol-avoid-edges"):
         if (name == "symbol-avoid-edges") {
             property = Property::SymbolAvoidEdges;
+        }
+        break;
+    
+    case util::hashFNV1a("symbol-z-order"):
+        if (name == "symbol-z-order") {
+            property = Property::SymbolZOrder;
         }
         break;
     
@@ -1798,6 +1821,18 @@ optional<Error> SymbolLayer::setLayoutProperty(const std::string& name, const Co
             setTextOptional(*typedValue);
             return nullopt;
         }
+        
+    }
+    
+    if (property == Property::SymbolZOrder) {
+        Error error;
+        optional<PropertyValue<SymbolZOrderType>> typedValue = convert<PropertyValue<SymbolZOrderType>>(value, error, false, false);
+        if (!typedValue) {
+            return error;
+        }
+        
+        setSymbolZOrder(*typedValue);
+        return nullopt;
         
     }
     

--- a/src/mbgl/style/layers/symbol_layer_properties.hpp
+++ b/src/mbgl/style/layers/symbol_layer_properties.hpp
@@ -27,6 +27,11 @@ struct SymbolAvoidEdges : LayoutProperty<bool> {
     static bool defaultValue() { return false; }
 };
 
+struct SymbolZOrder : LayoutProperty<SymbolZOrderType> {
+    static constexpr const char * key = "symbol-z-order";
+    static SymbolZOrderType defaultValue() { return SymbolZOrderType::ViewportY; }
+};
+
 struct IconAllowOverlap : LayoutProperty<bool> {
     static constexpr const char * key = "icon-allow-overlap";
     static bool defaultValue() { return false; }
@@ -252,6 +257,7 @@ class SymbolLayoutProperties : public Properties<
     SymbolPlacement,
     SymbolSpacing,
     SymbolAvoidEdges,
+    SymbolZOrder,
     IconAllowOverlap,
     IconIgnorePlacement,
     IconOptional,

--- a/src/mbgl/style/types.cpp
+++ b/src/mbgl/style/types.cpp
@@ -76,6 +76,11 @@ MBGL_DEFINE_ENUM(SymbolAnchorType, {
     { SymbolAnchorType::BottomLeft, "bottom-left" },
     { SymbolAnchorType::BottomRight, "bottom-right" }
 });
+    
+MBGL_DEFINE_ENUM(SymbolZOrderType, {
+    { SymbolZOrderType::ViewportY, "viewport-y" },
+    { SymbolZOrderType::Source, "source" }
+});
 
 MBGL_DEFINE_ENUM(TextJustifyType, {
     { TextJustifyType::Center, "center" },


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `mb-pages` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [x] briefly describe the changes in this PR
    - Adds symbol-sort-by-y symbol layout property to style spec
    - See discussion in https://github.com/mapbox/mapbox-gl-js/issues/7076
    - https://github.com/mapbox/mapbox-gl-js/pull/7219 will need to be merged before this