### PR TITLE
Add Arabic settings, accessibility translations

### DIFF
--- a/platform/ios/framework/Settings.bundle/ar.lproj/Root.strings
+++ b/platform/ios/framework/Settings.bundle/ar.lproj/Root.strings
@@ -1,0 +1,3 @@
+"TELEMETRY_GROUP_TITLE" = "إعدادات الخصوصية";
+"TELEMETRY_SWITCH_TITLE" = "القياس عن بعد";
+"TELEMETRY_GROUP_FOOTER" = "يتيح هذا الإعداد للتطبيق مشاركة المكان وبيانات الاستخدام مجهّلة مع Mapbox.";

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -1243,6 +1243,8 @@
 		DAA4E4061CBB5CBF00178DFB /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
 		DAA4E4131CBB71D400178DFB /* libMapbox.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMapbox.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DAABF73B1CBC59BB005B1825 /* libmbgl-core.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libmbgl-core.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		DAAE9B1B213A634700F7D722 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Root.strings; sourceTree = "<group>"; };
+		DAAE9B1C213A636B00F7D722 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ar; path = ar.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		DAAF72291DA903C700312FA4 /* MGLStyleValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLStyleValue.h; sourceTree = "<group>"; };
 		DAAF722A1DA903C700312FA4 /* MGLStyleValue_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLStyleValue_Private.h; sourceTree = "<group>"; };
 		DABCABA81CB80692000A7C39 /* Bench GL.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Bench GL.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3332,6 +3334,7 @@
 				DAD88E0C202AD06500AAA536 /* da */,
 				DA93409F208563440059919A /* pt-PT */,
 				DAFEB3792093AEA100A86A83 /* ko */,
+				DAAE9B1B213A634700F7D722 /* ar */,
 			);
 			name = Root.strings;
 			sourceTree = "<group>";
@@ -3439,6 +3442,7 @@
 				DAD88E0B202AD04D00AAA536 /* da */,
 				DA93409E208563360059919A /* pt-PT */,
 				DAFEB3782093AE9200A86A83 /* ko */,
+				DAAE9B1C213A636B00F7D722 /* ar */,
 			);
 			name = Localizable.stringsdict;
 			sourceTree = "<group>";

--- a/platform/ios/resources/ar.lproj/Localizable.stringsdict
+++ b/platform/ios/resources/ar.lproj/Localizable.stringsdict
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>MAP_A11Y_VALUE_ANNOTATIONS</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>ld</string>
+			<key>zero</key>
+			<string>لا ملاحظات ظاهرة</string>
+			<key>one</key>
+			<string>ملاحظة واحدة ظاهرة</string>
+			<key>two</key>
+			<string>ملاحظتان ظاهرتان</string>
+			<key>few</key>
+			<string>%d ملاحظات ظاهرة</string>
+			<key>many</key>
+			<string>%d ملاحظة ظاهرة</string>
+			<key>other</key>
+			<string>%d ملاحظة ظاهرة</string>
+		</dict>
+	</dict>
+	<key>MAP_A11Y_VALUE_ROADS</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>ld</string>
+			<key>zero</key>
+			<string>لا طرق ظاهرة</string>
+			<key>one</key>
+			<string>طريق واحد ظاهر</string>
+			<key>two</key>
+			<string>طريقان ظاهران</string>
+			<key>few</key>
+			<string>%d طرق ظاهرة</string>
+			<key>many</key>
+			<string>%d طريقا ظاهرا</string>
+			<key>other</key>
+			<string>%d طريق ظاهر</string>
+		</dict>
+	</dict>
+	<key>MAP_A11Y_VALUE_ZOOM</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@level@</string>
+		<key>level</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>لا تكبير </string>
+			<key>one</key>
+			<string>%dx تكبير </string>
+			<key>two</key>
+			<string>%dx تكبير </string>
+			<key>few</key>
+			<string>%dx تكبير </string>
+			<key>many</key>
+			<string>%dx تكبير </string>
+			<key>other</key>
+			<string>%dx تكبير </string>
+		</dict>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
Added Arabic translations of iOS accessibility strings and the iOS example settings bundle from Transifex.

/ref #12607
/cc @captainbarbosa @RazanQ