### PR TITLE
Bump gradle tools for AS 3.1.4

### DIFF
--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.1.4'
         classpath dependenciesList.licensesPlugin
         classpath dependenciesList.kotlinPlugin
     }


### PR DESCRIPTION
AS 3.1.4 was released a couple weeks back, time to bump the gradle tools version.