### PR TITLE
Check if the map is destroyed before saving state in a fragment

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapFragment.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapFragment.java
@@ -165,7 +165,9 @@ public final class MapFragment extends Fragment implements OnMapReadyCallback {
   @Override
   public void onSaveInstanceState(@NonNull Bundle outState) {
     super.onSaveInstanceState(outState);
-    map.onSaveInstanceState(outState);
+    if (map != null && !map.isDestroyed()) {
+      map.onSaveInstanceState(outState);
+    }
   }
 
   /**
@@ -183,7 +185,9 @@ public final class MapFragment extends Fragment implements OnMapReadyCallback {
   @Override
   public void onLowMemory() {
     super.onLowMemory();
-    map.onLowMemory();
+    if (map != null && !map.isDestroyed()) {
+      map.onLowMemory();
+    }
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
@@ -160,7 +160,9 @@ public class SupportMapFragment extends Fragment implements OnMapReadyCallback {
   @Override
   public void onSaveInstanceState(@NonNull Bundle outState) {
     super.onSaveInstanceState(outState);
-    map.onSaveInstanceState(outState);
+    if (map != null && !map.isDestroyed()) {
+      map.onSaveInstanceState(outState);
+    }
   }
 
   /**
@@ -178,7 +180,9 @@ public class SupportMapFragment extends Fragment implements OnMapReadyCallback {
   @Override
   public void onLowMemory() {
     super.onLowMemory();
-    map.onLowMemory();
+    if (map != null && !map.isDestroyed()) {
+      map.onLowMemory();
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #12803.

In a `ViewPager` setup, once created fragment doesn't need to be detached when its view is destroyed, meaning, that the out-of-view fragment is re-attached on orientation change but its view is not created, therefore the `MapView` is null. Also, when the fragment is attached, the `onSaveInstanceState` will be called resulting in the `NPE`.