### PR TITLE
Kotlin sanity activity test generation

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/DraggableMarkerActivity.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/DraggableMarkerActivity.kt
@@ -44,6 +44,9 @@ class DraggableMarkerActivity : AppCompatActivity() {
     supportActionBar?.height ?: 0
   }
 
+  // View property is required for activity sanity tests
+  // we perform reflection on this requires using findViewById
+  private lateinit var mapView: MapView
   private lateinit var mapboxMap: MapboxMap
   private val featureCollection = FeatureCollection.fromFeatures(mutableListOf())
   private val source = GeoJsonSource(sourceId, featureCollection)
@@ -59,6 +62,7 @@ class DraggableMarkerActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_draggable_marker)
 
+    mapView = findViewById(R.id.mapView)
     mapView.onCreate(savedInstanceState)
     mapView.getMapAsync { mapboxMap ->
       this.mapboxMap = mapboxMap

--- a/platform/android/scripts/generate-test-code.js
+++ b/platform/android/scripts/generate-test-code.js
@@ -36,8 +36,14 @@ for(const subPackage of subPackages) {
     }
 
     for (const activity of activities) {
-      // strip .java from input file
-      const activityName = activity.slice(0, -5);
+      var activityName;
+      if (activity.slice(-5) === '.java') {
+        // .java file
+        activityName = activity.slice(0, -5);
+      } else {
+        // .kt file
+        activityName = activity.slice(0, -3);
+      }
 
       // create path for test file
       const filePath = testBasePath+"/"+subPackage+"/"+activityName+'Test.java';


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/12806, this PR updates the sanity activity test generation script to be Kotlin compatible.

You below can see it generates the DraggableMarkerActivity test correctly.

![image](https://user-images.githubusercontent.com/2151639/45034270-48832e00-b057-11e8-8101-05b89c2eb7d3.png)

Due to https://github.com/mapbox/mapbox-gl-native/issues/12712, I will have to disable this test for now though.
