### PR TITLE
[android] Retain a shared thread pool reference

### DIFF
--- a/platform/android/src/style/sources/geojson_source.cpp
+++ b/platform/android/src/style/sources/geojson_source.cpp
@@ -45,15 +45,17 @@ namespace android {
     GeoJSONSource::GeoJSONSource(jni::JNIEnv& env, jni::String sourceId, jni::Object<> options)
         : Source(env, std::make_unique<mbgl::style::GeoJSONSource>(
                 jni::Make<std::string>(env, sourceId),
-                convertGeoJSONOptions(env, options))
-            ), converter(std::make_unique<Actor<FeatureConverter>>(*sharedThreadPool())) {
+                convertGeoJSONOptions(env, options)))
+        , threadPool(sharedThreadPool())
+        , converter(std::make_unique<Actor<FeatureConverter>>(*threadPool)) {
     }
 
     GeoJSONSource::GeoJSONSource(jni::JNIEnv& env,
                                  mbgl::style::Source& coreSource,
                                  AndroidRendererFrontend& frontend)
-            : Source(env, coreSource, createJavaPeer(env), frontend)
-            , converter(std::make_unique<Actor<FeatureConverter>>(*sharedThreadPool())) {
+        : Source(env, coreSource, createJavaPeer(env), frontend)
+        , threadPool(sharedThreadPool())
+        , converter(std::make_unique<Actor<FeatureConverter>>(*threadPool)) {
     }
 
     GeoJSONSource::~GeoJSONSource() = default;

--- a/platform/android/src/style/sources/geojson_source.hpp
+++ b/platform/android/src/style/sources/geojson_source.hpp
@@ -62,6 +62,7 @@ private:
     jni::Object<Source> createJavaPeer(jni::JNIEnv&);
     std::unique_ptr<Update> awaitingUpdate;
     std::unique_ptr<Update> update;
+    std::shared_ptr<ThreadPool> threadPool;
     std::unique_ptr<Actor<FeatureConverter>> converter;
 
     template <class JNIType>


### PR DESCRIPTION
Otherwise it may be prematurely deleted.

Fixes #12712. We may want a different long term fix, but this should adequately address the issue for the upcoming release.