### PR TITLE
Disable flaky camera tests

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraAnimateTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraAnimateTest.java
@@ -10,6 +10,7 @@ import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 import com.mapbox.mapboxsdk.testapp.activity.espresso.DeviceIndependentTestActivity;
 import com.mapbox.mapboxsdk.testapp.utils.TestConstants;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke;
@@ -23,6 +24,7 @@ public class CameraAnimateTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testAnimateToCameraPositionTarget() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -43,6 +45,7 @@ public class CameraAnimateTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testAnimateToCameraPositionTargetZoom() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -60,6 +63,7 @@ public class CameraAnimateTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testAnimateToCameraPosition() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -89,6 +93,7 @@ public class CameraAnimateTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testAnimateToBounds() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -113,6 +118,7 @@ public class CameraAnimateTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testAnimateToMoveBy() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -131,6 +137,7 @@ public class CameraAnimateTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testAnimateToZoomIn() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -144,6 +151,7 @@ public class CameraAnimateTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testAnimateToZoomOut() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -159,6 +167,7 @@ public class CameraAnimateTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testAnimateToZoomBy() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -173,6 +182,7 @@ public class CameraAnimateTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testAnimateToZoomTo() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraEaseTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraEaseTest.java
@@ -10,6 +10,7 @@ import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 import com.mapbox.mapboxsdk.testapp.activity.espresso.DeviceIndependentTestActivity;
 import com.mapbox.mapboxsdk.testapp.utils.TestConstants;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke;
@@ -23,6 +24,7 @@ public class CameraEaseTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testEaseToCameraPositionTarget() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -43,6 +45,7 @@ public class CameraEaseTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testEaseToCameraPositionTargetZoom() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -60,6 +63,7 @@ public class CameraEaseTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testEaseToCameraPosition() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -89,6 +93,7 @@ public class CameraEaseTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testEaseToBounds() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -113,6 +118,7 @@ public class CameraEaseTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testEaseToMoveBy() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -131,6 +137,7 @@ public class CameraEaseTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testEaseToZoomIn() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -144,6 +151,7 @@ public class CameraEaseTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testEaseToZoomOut() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -159,6 +167,7 @@ public class CameraEaseTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testEaseToZoomBy() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -173,6 +182,7 @@ public class CameraEaseTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testEaseToZoomTo() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraMoveTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraMoveTest.java
@@ -11,6 +11,7 @@ import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 import com.mapbox.mapboxsdk.testapp.activity.espresso.DeviceIndependentTestActivity;
 import com.mapbox.mapboxsdk.testapp.utils.TestConstants;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke;
@@ -24,6 +25,7 @@ public class CameraMoveTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testMoveToCameraPositionTarget() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -44,6 +46,7 @@ public class CameraMoveTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testMoveToCameraPositionTargetZoom() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -61,6 +64,7 @@ public class CameraMoveTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testMoveToCameraPosition() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -90,6 +94,7 @@ public class CameraMoveTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testMoveToBounds() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -114,6 +119,7 @@ public class CameraMoveTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testMoveToMoveBy() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -132,6 +138,7 @@ public class CameraMoveTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testMoveToZoomIn() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -145,6 +152,7 @@ public class CameraMoveTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testMoveToZoomOut() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -160,6 +168,7 @@ public class CameraMoveTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testMoveToZoomBy() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -174,6 +183,7 @@ public class CameraMoveTest extends BaseActivityTest {
   }
 
   @Test
+  @Ignore
   public void testMoveToZoomTo() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {


### PR DESCRIPTION
We recently started to get some spurious/flaky tests runs on firebase related to our camera tests. I believe the change in coalescing updates might be source in combination of us relying on time tests. While we work on callback based tests, let's ignore these tests to unblock other platforms. 