### PR TITLE
[core] Fix cubic-bezier interpolation for zooms outside stop range.

### DIFF
--- a/include/mbgl/style/expression/interpolator.hpp
+++ b/include/mbgl/style/expression/interpolator.hpp
@@ -33,7 +33,13 @@ public:
     CubicBezierInterpolator(double x1_, double y1_, double x2_, double y2_) : ub(x1_, y1_, x2_, y2_) {}
     
     double interpolationFactor(const Range<double>& inputLevels, const double input) const {
-        return ub.solve(input / (inputLevels.max - inputLevels.min), 1e-6);
+        return ub.solve(util::interpolationFactor(1.0,
+                                                  Range<float> {
+                                                      static_cast<float>(inputLevels.min),
+                                                      static_cast<float>(inputLevels.max)
+                                                  },
+                                                  input),
+                        1e-6);
     }
     
     bool operator==(const CubicBezierInterpolator& rhs) const {


### PR DESCRIPTION
Fixes issue #12812.
Using `util::interpolationFactor` handles the case where inputLevels.min == inputLevels.max, so it returns an interpolation factor of "0" instead of dividing by 0.

@nickidlugash, can you build this branch, try it out with your style, and make sure you get the results you expect?

@jfirebaugh, does this look right to you? I'll start work on a regression test for this on the gl js side...