### PR TITLE
Update isEmulator check

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/egl/EGLConfigChooser.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/egl/EGLConfigChooser.java
@@ -306,7 +306,14 @@ public class EGLConfigChooser implements GLSurfaceView.EGLConfigChooser {
    * Detect if we are in emulator.
    */
   private boolean inEmulator() {
-    return System.getProperty("ro.kernel.qemu") != null;
+    return Build.FINGERPRINT.startsWith("generic")
+      || Build.FINGERPRINT.startsWith("unknown")
+      || Build.MODEL.contains("google_sdk")
+      || Build.MODEL.contains("Emulator")
+      || Build.MODEL.contains("Android SDK built for x86")
+      || (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
+      || "google_sdk".equals(Build.PRODUCT)
+      || System.getProperty("ro.kernel.qemu") != null;
   }
 
   /**


### PR DESCRIPTION
Closes #12829, this update our EGLConfigChooser with an updated isEmulator check. This seem to improve performance of running a map on a emulator (compliant of this in https://github.com/mapbox/mapbox-gl-native/issues/12629#issuecomment-413474282). 