### PR TITLE
macOS 10.10, Xcode 8 no longer supported

### DIFF
--- a/platform/macos/INSTALL.md
+++ b/platform/macos/INSTALL.md
@@ -4,7 +4,7 @@ This document explains how to build a development version of the Mapbox Maps SDK
 
 ### Requirements
 
-The Mapbox Maps SDK for macOS requires the macOS 10.10.0 SDK (or above) and Xcode 8.0 (or above). To use this SDK with Xcode 7.3.1, download and use a symbols build from the [releases](https://github.com/mapbox/mapbox-gl-native/releases) page.
+The Mapbox Maps SDK for macOS requires the macOS 10.11.0 SDK (or above) and Xcode 9.0 (or above). To use this SDK with Xcode 7.3.1, download and use a symbols build from the [releases](https://github.com/mapbox/mapbox-gl-native/releases) page.
 
 Before building, follow these steps to install prerequisites:
 


### PR DESCRIPTION
This is a followup to #11776 that updates the macOS map SDK’s install-from-source documentation to note the correct build requirements.

/cc @nickidlugash @riastrad @friedbunny