### PR TITLE
[core] Cherry pick cubic-bezier fix

### DIFF
--- a/include/mbgl/style/expression/interpolator.hpp
+++ b/include/mbgl/style/expression/interpolator.hpp
@@ -33,7 +33,13 @@ public:
     CubicBezierInterpolator(double x1_, double y1_, double x2_, double y2_) : ub(x1_, y1_, x2_, y2_) {}
     
     double interpolationFactor(const Range<double>& inputLevels, const double input) const {
-        return ub.solve(input / (inputLevels.max - inputLevels.min), 1e-6);
+        return ub.solve(util::interpolationFactor(1.0,
+                                                  Range<float> {
+                                                      static_cast<float>(inputLevels.min),
+                                                      static_cast<float>(inputLevels.max)
+                                                  },
+                                                  input),
+                        1e-6);
     }
     
     bool operator==(const CubicBezierInterpolator& rhs) const {

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -4,6 +4,8 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 
 ## master
 
+- Fixed a cubic-bezier interpolation bug. ([#12812] (https://github.com/mapbox/mapbox-gl-native/issues/12812))
+
 ## 6.5.0-beta.1 - September 5, 2018
  - Retain shared thread pool reference [#12811](https://github.com/mapbox/mapbox-gl-native/pull/12811)
  - MapStrictMode configuration [#12817](https://github.com/mapbox/mapbox-gl-native/pull/12817)

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -29,6 +29,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed a sporadic crash with location updates. ([#12584](https://github.com/mapbox/mapbox-gl-native/pull/12584))
 * Fixed a crash that occurred during power state changes. ([#12584](https://github.com/mapbox/mapbox-gl-native/pull/12584))
 * Fixed a crash related to telemetry upload. ([#12584](https://github.com/mapbox/mapbox-gl-native/pull/12584))
+* Fixed a cubic-bezier interpolation bug. ([#12812] (https://github.com/mapbox/mapbox-gl-native/issues/12812))
 
 ## 4.3.0 - August 15, 2018
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -21,6 +21,7 @@
 * The `-[MGLMapView annotationAtPoint:]` method can now return annotations near tile boundaries at high zoom levels. ([#12570](https://github.com/mapbox/mapbox-gl-native/pull/12570))
 * Added an `-[MGLMapViewDelegate mapView:shapeAnnotationIsEnabled:]` method to specify whether an annotation is selectable. ([#12352](https://github.com/mapbox/mapbox-gl-native/pull/12352))
 * Fixed inconsistencies in exception naming. ([#12583](https://github.com/mapbox/mapbox-gl-native/issues/12583))
+* Fixed a cubic-bezier interpolation bug. ([#12812] (https://github.com/mapbox/mapbox-gl-native/issues/12812))
 
 # 0.10.0 - August 15, 2018
 

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Remove unnecessary memory use when collision debug mode is not enabled ([#12294](https://github.com/mapbox/mapbox-gl-native/issues/12294))
 - Added support for rendering `symbol-placement: line-center` ([#12337](https://github.com/mapbox/mapbox-gl-native/pull/12337))
 - Add support for feature expressions in `line-pattern`, `fill-pattern`, and `fill-extrusion-pattern` properties. [#12284](https://github.com/mapbox/mapbox-gl-native/pull/12284)
+- Fixed a cubic-bezier interpolation bug. ([#12812] (https://github.com/mapbox/mapbox-gl-native/issues/12812))
 
 # 3.5.8 - October 19, 2017
 - Fixes an issue that causes memory leaks when not deleting the frontend object


### PR DESCRIPTION
CP fix to #12812 and add changelog entries. This PR doesn't bump the GL JS pin for tests on the `release-frappe` branch, so we're depending on manual testing done by @nickidlugash and I.

We want to get this out in `release-frappe` because the next core-styles release is blocked on it.

/cc @julianrex @tobrun @jfirebaugh 