### PR TITLE
Preserve GLSurfaceView's EGL context on pause

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
@@ -30,6 +30,7 @@ public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceVi
     glSurfaceView.setEGLConfigChooser(new EGLConfigChooser());
     glSurfaceView.setRenderer(this);
     glSurfaceView.setRenderMode(RENDERMODE_WHEN_DIRTY);
+    glSurfaceView.setPreserveEGLContextOnPause(true);
   }
 
   @Override


### PR DESCRIPTION
Closes #12724.

The issue surfaced with the introduction of the `GLSurfaceView` - whenever activity containing a surface is paused, the surface releases the EGL context and forces the surface to be recreated upon coming back to the activity, which forces us to redraw the tiles.

This PR sets the `PreserveEGLContextOnPause` flag which tries to hold on to the EGL context when activity is paused, but only if the hardware allows for it. From documentation:
> Whether the EGL context is actually preserved or not depends upon whether the Android device that the program is running on can support an arbitrary number of EGL contexts or not. Devices that can only support a limited number of EGL contexts must release the EGL context in order to allow multiple applications to share the GPU.

Before:
![ezgif com-video-to-gif 7](https://user-images.githubusercontent.com/16925074/45212501-61792280-b295-11e8-89fe-2797b11729aa.gif)

After:
![ezgif com-video-to-gif 8](https://user-images.githubusercontent.com/16925074/45212504-65a54000-b295-11e8-8802-2ce10a7db3a3.gif)
