### PR TITLE
[docs] Remove Deprecated Framework Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ Additional Mapbox GL Native–based libraries for **hybrid applications** are de
 | Toolkit                                  | Android | iOS | Developer   |
 | ---------------------------------------- | --------|-----|------------ |
 | [React Native](https://github.com/mapbox/react-native-mapbox-gl/) ([npm](https://www.npmjs.com/package/@mapbox/react-native-mapbox-gl)) | :white_check_mark: | :white_check_mark: | Mapbox |
-| [Apache Cordova](http://plugins.telerik.com/cordova/plugin/mapbox/) ([npm](https://www.npmjs.com/package/cordova-plugin-mapbox)) | :white_check_mark: | :white_check_mark: | Telerik |
 | [NativeScript](https://market.nativescript.org/plugins/nativescript-mapbox/) ([npm](https://www.npmjs.com/package/nativescript-mapbox/)) | :white_check_mark: | :white_check_mark: | Telerik |
-| [Xamarin](https://components.xamarin.com/view/mapboxsdk/) | :white_check_mark: | :white_check_mark: | Xamarin |
 
 If your platform or hybrid application framework isn’t listed here, consider embedding [Mapbox GL JS](https://github.com/mapbox/mapbox-gl-js) using the standard Web capabilities on your platform.
 


### PR DESCRIPTION
The Cordova & Xamarin plugins have been deprecated. This PR updates the README's`hybrid applications` table to reflect this fact.