### PR TITLE
[ios, macos, docs] Move MGLShapeOfflineRegion to offline section

### DIFF
--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -107,6 +107,7 @@ custom_categories:
       - MGLOfflinePackProgress
       - MGLOfflinePackState
       - MGLTilePyramidOfflineRegion
+      - MGLShapeOfflineRegion
   - name: Geometry
     children:
       - MGLCoordinateBounds

--- a/platform/macos/jazzy.yml
+++ b/platform/macos/jazzy.yml
@@ -92,6 +92,7 @@ custom_categories:
       - MGLOfflinePackProgress
       - MGLOfflinePackState
       - MGLTilePyramidOfflineRegion
+      - MGLShapeOfflineRegion
   - name: Geometry
     children:
       - MGLCoordinateBounds


### PR DESCRIPTION
In the [4.4.0-beta.1](https://www.mapbox.com/ios-sdk/api/4.4.0-beta.1/Classes/MGLShapeOfflineRegion.html#/MGLShapeOfflineRegion) docs, the new `MGLShapeOfflineRegion` class gets placed into the "Other Classes" category of the API documentation. This happens automatically since we never specified what category this class falls under. This PR moves the class under the "Offline Maps" section instead by explicitly assigning it a category, since it is related to the other offline classes.