### PR TITLE
[ios, macos, docs] Move MGLShapeOfflineRegion to offline section 🍒 cherry pick

### DIFF
--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -107,6 +107,7 @@ custom_categories:
       - MGLOfflinePackProgress
       - MGLOfflinePackState
       - MGLTilePyramidOfflineRegion
+      - MGLShapeOfflineRegion
   - name: Geometry
     children:
       - MGLCoordinateBounds

--- a/platform/macos/jazzy.yml
+++ b/platform/macos/jazzy.yml
@@ -92,6 +92,7 @@ custom_categories:
       - MGLOfflinePackProgress
       - MGLOfflinePackState
       - MGLTilePyramidOfflineRegion
+      - MGLShapeOfflineRegion
   - name: Geometry
     children:
       - MGLCoordinateBounds


### PR DESCRIPTION
[Cherry picks](https://git-scm.com/docs/git-cherry-pick) the commit from https://github.com/mapbox/mapbox-gl-native/pull/12853 to the `release-frappe` branch in preparation of Wednesday's ios-v4.4.0 stable release.