### PR TITLE
[build] Disable implicit fallthrough warnings for sqlite3

### DIFF
--- a/cmake/sqlite.cmake
+++ b/cmake/sqlite.cmake
@@ -33,4 +33,5 @@ target_compile_definitions(sqlite
 
 target_compile_options(sqlite
     PRIVATE "-Wno-int-conversion"
+    PRIVATE "-Wno-implicit-fallthrough"
 )


### PR DESCRIPTION
The sqlite3 source code has a lot of implicit fallthroughs in case
statements. They are documented with comments but even though gcc
provides options to use these comments to suppress the warnings, that's
not always reliable. For instance, it may fail if an #ifdef follows the
comment or if the comment is within a block scope used for a case.

With gcc version '(Ubuntu 7.3.0-16ubuntu3) 7.3.0' I get warnings similar
to the below:

```
../../../vendor/sqlite/src/sqlite3.c: In function ‘sqlite3_db_status’:
../../../vendor/sqlite/src/sqlite3.c:20251:10: error: this statement may fall through [-Werror=implicit-fallthrough=]
       op = SQLITE_DBSTATUS_CACHE_WRITE+1;
```

So disable the implicit falltrhough warnings for that library. Note that
-Wno-error=implicit-fallthrough is not used to keep the build silent
since this is vendor library.