### PR TITLE
Harmonize iOS, macOS map SDK bundle identifiers

### DIFF
--- a/platform/darwin/src/MGLLoggingConfiguration.m
+++ b/platform/darwin/src/MGLLoggingConfiguration.m
@@ -57,12 +57,12 @@
                                                     OS_LOG_TYPE_ERROR,
                                                     OS_LOG_TYPE_FAULT };
             dispatch_once(&once, ^ {
-                info_log = os_log_create("com.mapbox.maps", "INFO");
+                info_log = os_log_create("com.mapbox.Mapbox", "INFO");
 #if MGL_LOGGING_ENABLE_DEBUG
-                debug_log = os_log_create("com.mapbox.maps", "DEBUG");
+                debug_log = os_log_create("com.mapbox.Mapbox", "DEBUG");
 #endif
-                error_log = os_log_create("com.mapbox.maps", "ERROR");
-                fault_log = os_log_create("com.mapbox.maps", "FAULT");
+                error_log = os_log_create("com.mapbox.Mapbox", "ERROR");
+                fault_log = os_log_create("com.mapbox.Mapbox", "FAULT");
             });
             
             os_log_t mapbox_log;

--- a/platform/darwin/test/MGLAttributionInfoTests.m
+++ b/platform/darwin/test/MGLAttributionInfoTests.m
@@ -47,17 +47,10 @@
     XCTAssertEqualObjects(infos[3].URL, [NSURL URLWithString:@"https://www.mapbox.com/map-feedback/"]);
     XCTAssertTrue(infos[3].feedbackLink);
     NSURL *styleURL = [MGLStyle satelliteStreetsStyleURLWithVersion:99];
-#if TARGET_OS_IPHONE
     XCTAssertEqualObjects([infos[3] feedbackURLAtCenterCoordinate:mapbox zoomLevel:14],
-                          [NSURL URLWithString:@"https://www.mapbox.com/feedback/?referrer=com.mapbox.sdk.ios#/77.63680/12.98108/14.00/0.0/0"]);
+                          [NSURL URLWithString:@"https://www.mapbox.com/feedback/?referrer=com.mapbox.Mapbox#/77.63680/12.98108/14.00/0.0/0"]);
     XCTAssertEqualObjects([infos[3] feedbackURLForStyleURL:styleURL atCenterCoordinate:mapbox zoomLevel:3.14159 direction:90.9 pitch:12.5],
-                          [NSURL URLWithString:@"https://www.mapbox.com/feedback/?referrer=com.mapbox.sdk.ios&owner=mapbox&id=satellite-streets-v99&access_token&map_sdk_version=1.0.0#/77.63680/12.98108/3.14/90.9/13"]);
-#else
-    XCTAssertEqualObjects([infos[3] feedbackURLAtCenterCoordinate:mapbox zoomLevel:14],
-                          [NSURL URLWithString:@"https://www.mapbox.com/feedback/?referrer=com.mapbox.MapboxGL#/77.63680/12.98108/14.00/0.0/0"]);
-    XCTAssertEqualObjects([infos[3] feedbackURLForStyleURL:styleURL atCenterCoordinate:mapbox zoomLevel:3.14159 direction:90.9 pitch:12.5],
-                          [NSURL URLWithString:@"https://www.mapbox.com/feedback/?referrer=com.mapbox.MapboxGL&owner=mapbox&id=satellite-streets-v99&access_token&map_sdk_version=1.0.0#/77.63680/12.98108/3.14/90.9/13"]);
-#endif
+                          [NSURL URLWithString:@"https://www.mapbox.com/feedback/?referrer=com.mapbox.Mapbox&owner=mapbox&id=satellite-streets-v99&access_token&map_sdk_version=1.0.0#/77.63680/12.98108/3.14/90.9/13"]);
 }
 
 - (void)testStyle {

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Renamed `-[MGLOfflineStorage putResourceWithUrl:data:modified:expires:etag:mustRevalidate:]` to `-[MGLOfflineStorage preloadData:forURL:modificationDate:expirationDate:eTag:mustRevalidate:]`. ([#13318](https://github.com/mapbox/mapbox-gl-native/pull/13318))
 * Fixed sporadic crash when using `MGLMapSnapshotter`. ([#13300](https://github.com/mapbox/mapbox-gl-native/pull/13300))
 * Added `MGLLoggingConfiguration` and `MGLLoggingBlockHandler` that handle error and fault events produced by the SDK. ([#13235](https://github.com/mapbox/mapbox-gl-native/pull/13235))
+* This SDK’s dynamic framework now has a bundle identifier of `com.mapbox.Mapbox`. ([#12857](https://github.com/mapbox/mapbox-gl-native/pull/12857))
 
 ## 4.6.0 - November 7, 2018
 

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -3750,7 +3750,7 @@
 					"$(mbgl_core_LINK_LIBRARIES)",
 					"$(mbgl_filesource_LINK_LIBRARIES)",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.sdk.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.Mapbox;
 				PRODUCT_NAME = Mapbox;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 3.0;
@@ -3793,7 +3793,7 @@
 					"$(mbgl_core_LINK_LIBRARIES)",
 					"$(mbgl_filesource_LINK_LIBRARIES)",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.sdk.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.Mapbox;
 				PRODUCT_NAME = Mapbox;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 3.0;
@@ -3806,7 +3806,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = "framework/Info-static.plist";
-				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.sdk.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.Mapbox;
 				PRODUCT_NAME = Mapbox;
 				SKIP_INSTALL = YES;
 				WRAPPER_EXTENSION = bundle;
@@ -3817,7 +3817,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = "framework/Info-static.plist";
-				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.sdk.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.Mapbox;
 				PRODUCT_NAME = Mapbox;
 				SKIP_INSTALL = YES;
 				WRAPPER_EXTENSION = bundle;

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.12.0 - November 8, 2018
 
 * Renamed `-[MGLOfflineStorage putResourceWithUrl:data:modified:expires:etag:mustRevalidate:]` to `-[MGLOfflineStorage preloadData:forURL:modificationDate:expirationDate:eTag:mustRevalidate:]`. ([#13318](https://github.com/mapbox/mapbox-gl-native/pull/13318))
+* This SDK’s dynamic framework now has a bundle identifier of `com.mapbox.Mapbox`. ([#12857](https://github.com/mapbox/mapbox-gl-native/pull/12857))
 
 ## master
 

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -2014,7 +2014,7 @@
 					"$(mbgl_core_LINK_LIBRARIES)",
 					"$(mbgl_filesource_LINK_LIBRARIES)",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGL;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.Mapbox;
 				PRODUCT_NAME = Mapbox;
 				SKIP_INSTALL = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -2048,7 +2048,7 @@
 					"$(mbgl_core_LINK_LIBRARIES)",
 					"$(mbgl_filesource_LINK_LIBRARIES)",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGL;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.Mapbox;
 				PRODUCT_NAME = Mapbox;
 				SKIP_INSTALL = YES;
 				STRIP_STYLE = "non-global";

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -272,14 +272,13 @@ public:
     _mbglView = new MGLMapViewImpl(self);
 
     // Delete the pre-offline ambient cache at
-    // ~/Library/Caches/com.mapbox.sdk.ios/cache.db.
+    // ~/Library/Caches/com.mapbox.MapboxGL/cache.db.
     NSURL *cachesDirectoryURL = [[NSFileManager defaultManager] URLForDirectory:NSCachesDirectory
                                                                        inDomain:NSUserDomainMask
                                                               appropriateForURL:nil
                                                                          create:NO
                                                                           error:nil];
-    cachesDirectoryURL = [cachesDirectoryURL URLByAppendingPathComponent:
-                          [NSBundle mgl_frameworkBundle].bundleIdentifier];
+    cachesDirectoryURL = [cachesDirectoryURL URLByAppendingPathComponent:@"com.mapbox.MapboxGL"];
     NSURL *legacyCacheURL = [cachesDirectoryURL URLByAppendingPathComponent:@"cache.db"];
     [[NSFileManager defaultManager] removeItemAtURL:legacyCacheURL error:NULL];
 


### PR DESCRIPTION
~~The iOS map SDK’s bundle identifier is now `com.mapbox.MapboxGL`, whether in the form of a static or dynamic framework. This is also consistent with the macOS map SDK. The previous bundle identifier, `com.mapbox.sdk.ios`, was unusual in that it named the platform.~~

The iOS and macOS map SDKs now share the same bundle identifier, `com.mapbox.Mapbox`, for consistency with the product name and module name that they already share in common. The logging subsystems added in #13235 also have this same identifier. The previous bundle identifier on iOS, `com.mapbox.sdk.ios`, was unusual in that it named the platform. Meanwhile, the previous bundle identifier on macOS, `com.mapbox.MapboxGL`, would’ve collided with iosapp’s bundle identifier to produce an error on installation.

Split out from #9319.

/cc @friedbunny