### PR TITLE
Update changelog for v6.5.0

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -5,6 +5,10 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 ## master
 - Add `symbol-z-order` symbol layout property to style spec [#12783](https://github.com/mapbox/mapbox-gl-native/pull/12783)
 
+## 6.5.0 - September 11, 2018
+ - Fixed a cubic-bezier interpolation bug. [#12812](https://github.com/mapbox/mapbox-gl-native/issues/12812)
+ - Fixed an issue that could cause "allow-overlap" symbols to fade in during pan operations instead of always showing. [#12683](https://github.com/mapbox/mapbox-gl-native/issues/12683)
+
 ## 6.5.0-beta.1 - September 5, 2018
  - Retain shared thread pool reference [#12811](https://github.com/mapbox/mapbox-gl-native/pull/12811)
  - MapStrictMode configuration [#12817](https://github.com/mapbox/mapbox-gl-native/pull/12817)


### PR DESCRIPTION
This PR updates the changelog to match the state on `release-frappe` branch.