### PR TITLE
Avoid flipping some layer icons

### DIFF
--- a/platform/macos/app/Assets.xcassets/Layers/background.imageset/Contents.json
+++ b/platform/macos/app/Assets.xcassets/Layers/background.imageset/Contents.json
@@ -4,6 +4,10 @@
       "idiom" : "universal",
       "filename" : "background.pdf",
       "language-direction" : "left-to-right"
+    },
+    {
+      "idiom" : "universal",
+      "language-direction" : "right-to-left"
     }
   ],
   "info" : {

--- a/platform/macos/app/Assets.xcassets/Layers/heatmap.imageset/Contents.json
+++ b/platform/macos/app/Assets.xcassets/Layers/heatmap.imageset/Contents.json
@@ -4,6 +4,10 @@
       "idiom" : "universal",
       "filename" : "heatmap.pdf",
       "language-direction" : "left-to-right"
+    },
+    {
+      "idiom" : "universal",
+      "language-direction" : "right-to-left"
     }
   ],
   "info" : {

--- a/platform/macos/app/Assets.xcassets/Layers/hillshade.imageset/Contents.json
+++ b/platform/macos/app/Assets.xcassets/Layers/hillshade.imageset/Contents.json
@@ -4,6 +4,10 @@
       "idiom" : "universal",
       "filename" : "hillshade.pdf",
       "language-direction" : "left-to-right"
+    },
+    {
+      "idiom" : "universal",
+      "language-direction" : "right-to-left"
     }
   ],
   "info" : {


### PR DESCRIPTION
Avoid flipping the background, heatmap, and hillshade icons in macosapp’s Layers sidebar in right-to-left languages.

/cc @friedbunny