### PR TITLE
Add binding integration for cross source collision

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -24,7 +24,6 @@ import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.ZoomButtonsController;
-
 import com.mapbox.android.gestures.AndroidGesturesManager;
 import com.mapbox.mapboxsdk.MapStrictMode;
 import com.mapbox.mapboxsdk.Mapbox;
@@ -47,6 +46,8 @@ import com.mapbox.mapboxsdk.offline.OfflineTilePyramidRegionDefinition;
 import com.mapbox.mapboxsdk.storage.FileSource;
 import com.mapbox.mapboxsdk.utils.BitmapUtils;
 
+import javax.microedition.khronos.egl.EGLConfig;
+import javax.microedition.khronos.opengles.GL10;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.ref.WeakReference;
@@ -54,9 +55,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-
-import javax.microedition.khronos.egl.EGLConfig;
-import javax.microedition.khronos.opengles.GL10;
 
 import static com.mapbox.mapboxsdk.maps.widgets.CompassView.TIME_MAP_NORTH_ANIMATION;
 import static com.mapbox.mapboxsdk.maps.widgets.CompassView.TIME_WAIT_IDLE;
@@ -316,7 +314,8 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
       addView(glSurfaceView, 0);
     }
 
-    nativeMapView = new NativeMapView(getContext(), getPixelRatio(), this, mapRenderer);
+    boolean crossSourceCollisions = mapboxMapOptions.getCrossSourceCollisions();
+    nativeMapView = new NativeMapView(getContext(), getPixelRatio(), crossSourceCollisions, this, mapRenderer);
     nativeMapView.addOnMapChangedListener(change -> {
       // dispatch events to external listeners
       if (!onMapChangedListeners.isEmpty()) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
@@ -82,6 +82,8 @@ public class MapboxMapOptions implements Parcelable {
 
   private float pixelRatio;
 
+  private boolean crossSourceCollisions = true;
+
   /**
    * Creates a new MapboxMapOptions object.
    */
@@ -131,6 +133,7 @@ public class MapboxMapOptions implements Parcelable {
     localIdeographFontFamily = in.readString();
     pixelRatio = in.readFloat();
     foregroundLoadColor = in.readInt();
+    crossSourceCollisions = in.readByte() != 0;
   }
 
   /**
@@ -231,6 +234,9 @@ public class MapboxMapOptions implements Parcelable {
         typedArray.getFloat(R.styleable.mapbox_MapView_mapbox_pixelRatio, 0));
       mapboxMapOptions.foregroundLoadColor(
         typedArray.getInt(R.styleable.mapbox_MapView_mapbox_foregroundLoadColor, LIGHT_GRAY)
+      );
+      mapboxMapOptions.crossSourceCollisions(
+        typedArray.getBoolean(R.styleable.mapbox_MapView_mapbox_cross_source_collisions, true)
       );
     } finally {
       typedArray.recycle();
@@ -567,6 +573,21 @@ public class MapboxMapOptions implements Parcelable {
   }
 
   /**
+   * Enable cross-source symbol collision detection, defaults to true.
+   * <p>
+   * If set to false, symbol layers will only run collision detection against
+   * other symbol layers that are part of the same source.
+   * </p>
+   *
+   * @param crossSourceCollisions true to enable, false to disable
+   * @return This
+   */
+  public MapboxMapOptions crossSourceCollisions(boolean crossSourceCollisions) {
+    this.crossSourceCollisions = crossSourceCollisions;
+    return this;
+  }
+
+  /**
    * Set the font family for generating glyphs locally for ideographs in the &#x27;CJK Unified Ideographs&#x27;
    * and &#x27;Hangul Syllables&#x27; ranges.
    * <p>
@@ -602,6 +623,14 @@ public class MapboxMapOptions implements Parcelable {
     return prefetchesTiles;
   }
 
+  /**
+   * Check whether cross-source symbol collision detection is enabled.
+   *
+   * @return true if enabled
+   */
+  public boolean getCrossSourceCollisions() {
+    return crossSourceCollisions;
+  }
 
   /**
    * Set the flag to render the map surface on top of another surface.
@@ -945,6 +974,7 @@ public class MapboxMapOptions implements Parcelable {
     dest.writeString(localIdeographFontFamily);
     dest.writeFloat(pixelRatio);
     dest.writeInt(foregroundLoadColor);
+    dest.writeByte((byte) (crossSourceCollisions ? 1 : 0));
   }
 
   @Override
@@ -1050,6 +1080,10 @@ public class MapboxMapOptions implements Parcelable {
       return false;
     }
 
+    if (crossSourceCollisions != options.crossSourceCollisions) {
+      return false;
+    }
+
     return false;
   }
 
@@ -1090,6 +1124,7 @@ public class MapboxMapOptions implements Parcelable {
     result = 31 * result + (zMediaOverlay ? 1 : 0);
     result = 31 * result + (localIdeographFontFamily != null ? localIdeographFontFamily.hashCode() : 0);
     result = 31 * result + (int) pixelRatio;
+    result = 31 * result + (crossSourceCollisions ? 1 : 0);
     return result;
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -12,7 +12,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.DisplayMetrics;
-
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.Geometry;
 import com.mapbox.mapboxsdk.LibraryLoader;
@@ -85,18 +84,19 @@ final class NativeMapView {
   // Constructors
   //
 
-  public NativeMapView(final Context context, final ViewCallback viewCallback, final MapRenderer mapRenderer) {
-    this(context, context.getResources().getDisplayMetrics().density, viewCallback, mapRenderer);
+  public NativeMapView(final Context context, final boolean crossSourceCollisions, final ViewCallback viewCallback,
+                       final MapRenderer mapRenderer) {
+    this(context, context.getResources().getDisplayMetrics().density, crossSourceCollisions, viewCallback, mapRenderer);
   }
 
-  public NativeMapView(final Context context, float pixelRatio,
+  public NativeMapView(final Context context, final float pixelRatio, final boolean crossSourceCollisions,
                        final ViewCallback viewCallback, final MapRenderer mapRenderer) {
     this.mapRenderer = mapRenderer;
     this.viewCallback = viewCallback;
     this.fileSource = FileSource.getInstance(context);
     this.pixelRatio = pixelRatio;
     this.thread = Thread.currentThread();
-    nativeInitialize(this, fileSource, mapRenderer, pixelRatio);
+    nativeInitialize(this, fileSource, mapRenderer, pixelRatio, crossSourceCollisions);
   }
 
   //
@@ -936,7 +936,8 @@ final class NativeMapView {
   private native void nativeInitialize(NativeMapView nativeMapView,
                                        FileSource fileSource,
                                        MapRenderer mapRenderer,
-                                       float pixelRatio);
+                                       float pixelRatio,
+                                       boolean crossSourceCollisions);
 
   @Keep
   private native void nativeDestroy();

--- a/platform/android/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
@@ -13,6 +13,7 @@
     <public name="mapbox_styleJson" type="attr" />
     <public name="mapbox_apiBaseUrl" type="attr" />
     <public name="mapbox_localIdeographFontFamily" type="attr" />
+    <public name="mapbox_cross_source_collisions" type="attr" />
     <public name="mapbox_pixelRatio"  type="float" />
 
     <!--Camera-->

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/attrs.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/attrs.xml
@@ -7,6 +7,7 @@
         <attr name="mapbox_styleJson" format="string"/>
         <attr name="mapbox_apiBaseUrl" format="string"/>
         <attr name="mapbox_localIdeographFontFamily" format="string"/>
+        <attr name="mapbox_cross_source_collisions" format="boolean"/>
 
         <!--Camera-->
         <attr name="mapbox_cameraTargetLat" format="float"/>

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/MapboxMapOptionsTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/MapboxMapOptionsTest.java
@@ -2,12 +2,10 @@ package com.mapbox.mapboxsdk.maps;
 
 import android.graphics.Color;
 import android.view.Gravity;
-
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.constants.Style;
 import com.mapbox.mapboxsdk.geometry.LatLng;
-
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -176,6 +174,16 @@ public class MapboxMapOptionsTest {
     // Check mutations
     assertTrue(new MapboxMapOptions().setPrefetchesTiles(true).getPrefetchesTiles());
     assertFalse(new MapboxMapOptions().setPrefetchesTiles(false).getPrefetchesTiles());
+  }
+
+  @Test
+  public void testCrossSourceCollisions() {
+    // Default value
+    assertTrue(new MapboxMapOptions().getCrossSourceCollisions());
+
+    // check mutations
+    assertTrue(new MapboxMapOptions().crossSourceCollisions(true).getCrossSourceCollisions());
+    assertFalse(new MapboxMapOptions().crossSourceCollisions(false).getCrossSourceCollisions());
   }
 }
 

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -60,7 +60,8 @@ NativeMapView::NativeMapView(jni::JNIEnv& _env,
                              jni::Object<NativeMapView> _obj,
                              jni::Object<FileSource> jFileSource,
                              jni::Object<MapRenderer> jMapRenderer,
-                             jni::jfloat _pixelRatio)
+                             jni::jfloat _pixelRatio,
+                             jni::jboolean _crossSourceCollisions)
     : javaPeer(_obj.NewWeakGlobalRef(_env))
     , mapRenderer(MapRenderer::getNativePeer(_env, jMapRenderer))
     , pixelRatio(_pixelRatio)
@@ -83,7 +84,7 @@ NativeMapView::NativeMapView(jni::JNIEnv& _env,
                                       mbgl::Size{ static_cast<uint32_t>(width),
                                                   static_cast<uint32_t>(height) }, pixelRatio,
                                       fileSource, *threadPool, MapMode::Continuous,
-                                      ConstrainMode::HeightOnly, ViewportMode::Default);
+                                      ConstrainMode::HeightOnly, ViewportMode::Default, _crossSourceCollisions);
 }
 
 /**
@@ -958,7 +959,7 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
 
     // Register the peer
     jni::RegisterNativePeer<NativeMapView>(env, NativeMapView::javaClass, "nativePtr",
-            std::make_unique<NativeMapView, JNIEnv&, jni::Object<NativeMapView>, jni::Object<FileSource>, jni::Object<MapRenderer>, jni::jfloat>,
+            std::make_unique<NativeMapView, JNIEnv&, jni::Object<NativeMapView>, jni::Object<FileSource>, jni::Object<MapRenderer>, jni::jfloat, jni::jboolean>,
             "nativeInitialize",
             "nativeDestroy",
             METHOD(&NativeMapView::resizeView, "nativeResizeView"),

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -53,7 +53,8 @@ public:
                   jni::Object<NativeMapView>,
                   jni::Object<FileSource>,
                   jni::Object<MapRenderer>,
-                  jni::jfloat pixelRatio);
+                  jni::jfloat,
+                  jni::jboolean);
 
     virtual ~NativeMapView();
 


### PR DESCRIPTION
Closes #12846, Android binding integration of #12842. Configuration of this is done through the constructor of the map object. This is reflected on the Android side by introducing a configuration as part of MapboxMapOptions and an equivalent xml attribute.

I'm not integrating this configuration in the testapp as we don't expose an example that would benefit from this configuration, I manually verified with a debugger that state is correctly initialized. 

cc @ChrisLoer 