### PR TITLE
Fix Android crash on SQLite log warning

### DIFF
--- a/platform/default/sqlite3.cpp
+++ b/platform/default/sqlite3.cpp
@@ -97,6 +97,13 @@ public:
 template <typename T>
 using optional = std::experimental::optional<T>;
 
+
+#ifndef NDEBUG
+void logSqlMessage(void *, const int err, const char *msg) {
+    mbgl::Log::Record(mbgl::EventSeverity::Debug, mbgl::Event::Database, err, "%s", msg);
+}
+#endif
+
 __attribute__((constructor))
 static void initalize() {
     if (sqlite3_libversion_number() / 1000000 != SQLITE_VERSION_NUMBER / 1000000) {
@@ -109,9 +116,7 @@ static void initalize() {
 
 #ifndef NDEBUG
     // Enable SQLite logging before initializing the database.
-    sqlite3_config(SQLITE_CONFIG_LOG, [](void *, const int err, const char *msg) {
-        mbgl::Log::Record(mbgl::EventSeverity::Debug, mbgl::Event::Database, err, "%s", msg);
-    }, nullptr);
+    sqlite3_config(SQLITE_CONFIG_LOG, &logSqlMessage, nullptr);
 #endif
 }
 


### PR DESCRIPTION
Switch from lambda expression to a named function to prevent this crash on Android:

<img width="1143" alt="screen shot 2018-09-11 at 18 15 37" src="https://user-images.githubusercontent.com/11619675/45452237-4db52e00-b692-11e8-897b-6f83507c834f.png">

cc @kkaefer @LukasPaczos 