### PR TITLE
Look even more widely for IB designables agent

### DIFF
--- a/platform/darwin/src/NSProcessInfo+MGLAdditions.m
+++ b/platform/darwin/src/NSProcessInfo+MGLAdditions.m
@@ -3,7 +3,8 @@
 @implementation NSProcessInfo (MGLAdditions)
 
 - (BOOL)mgl_isInterfaceBuilderDesignablesAgent {
-    return [self.processName hasPrefix:@"IBDesignablesAgent"];
+    NSString *processName = self.processName;
+    return [processName hasPrefix:@"IBAgent"] || [processName hasPrefix:@"IBDesignablesAgent"];
 }
 
 @end

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -7,7 +7,9 @@
 * Added an `MGLSymbolStyleLayer.symbolZOrder` property for forcing point features in a symbol layer to be layered in the same order that they are specified in the layer’s associated source. ([#12783](https://github.com/mapbox/mapbox-gl-native/pull/12783))
 
 ### Other changes	
+
 * Fixed an issue where `-[MGLMapSnapshotter startWithQueue:completionHandler:]` failed to call its completion handler in some cases. ([#12355](https://github.com/mapbox/mapbox-gl-native/pull/12355))
+* Fixed an issue where `MGLMapView` produced a designable error in Interface Builder storyboards in Xcode 10. ([#12883](https://github.com/mapbox/mapbox-gl-native/pull/12883))
 
 # 0.11.0 - September 13, 2018
 


### PR DESCRIPTION
Cast an even wider net than #12140 when trying to detect the helper process that builds the Interface Builder designable when MGLMapView is displayed in a storyboard or XIB. Detecting the helper process is important because it keeps mbgl and the telemetry subsystem from initializing and causing the designable to time out or raise an exception. The helper process has once again been renamed on each platform, according to the Xcode 10 GM seed release notes:

> Some binaries used by Interface Builder have been renamed for better consistency. Instead of
“Interface Builder Cocoa Touch Tool”, “Interface Builder WatchKit Tool”, and “IBAppleTVTool”, they
are now called “IBAgent-[platform]”. (35400833)

Platform SDK | Xcode 9 | Xcode 10 beta 1 | Xcode 10 GM seed
----|----|----|----
iOS | IBDesignablesAgentCocoaTouch | IBDesignablesAgent-iOS | IBAgent-iOS, IBDesignablesAgent-iOS
macOS | IBDesignablesAgent | IBDesignablesAgent-macOS | IBDesignablesAgent-macOS
tvOS | IBDesignablesAgentAppleTV | IBDesignablesAgent-tvOS | IBAgent-tvOS, IBDesignablesAgent-tvOS

(tvOS is mentioned here because of #9319.)

I left out the iOS changelog blurb because this fix by itself doesn’t address #10072 or #10573.

/cc @fabian-guerra @friedbunny