### PR TITLE
[build] Run cmake again when source file lists changes

### DIFF
--- a/cmake/mbgl.cmake
+++ b/cmake/mbgl.cmake
@@ -130,6 +130,7 @@ function(load_sources_list VAR FILELIST)
         endif()
     endforeach()
     set(${VAR} "${_FILES}" PARENT_SCOPE)
+    set_property(DIRECTORY "${CMAKE_SOURCE_DIR}" APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${FILELIST}")
 endfunction()
 
 function(target_sources_from_file TARGET TYPE FILELIST)


### PR DESCRIPTION
Since commit bded6c65d59b ([build] use plain text files for file lists
to simplify integration with other build systems) adding new source
files would not cause cmake to be re-ran since it doesn't automatically
track the plain text files. Fix that by explicitly adding those files to
CMAKE_CONFIGURE_DEPENDS.