### PR TITLE
[ios] Fix for user puck jittering (and annotations lagging)

### DIFF
--- a/platform/darwin/src/MGLFoundation.h
+++ b/platform/darwin/src/MGLFoundation.h
@@ -3,3 +3,10 @@
 #import <Foundation/Foundation.h>
 
 #define MGL_EXPORT __attribute__((visibility ("default")))
+
+/* Using a compound statement (GNU Extension, supported by clang) */
+#define MGL_OBJC_DYNAMIC_CAST(object, type) \
+    ({ \
+        __typeof__( object ) temp##__LINE__ = (object); \
+        (type *)([temp##__LINE__ isKindOfClass:[type class]] ? temp##__LINE__ : nil); \
+    })

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Added an `MGLSymbolStyleLayer.symbolZOrder` property for forcing point features in a symbol layer to be layered in the same order that they are specified in the layer’s associated source. ([#12783](https://github.com/mapbox/mapbox-gl-native/pull/12783))
 * Fixed a crash when a style layer `*-pattern` property evaluates to nil for a particular feature. ([#12896](https://github.com/mapbox/mapbox-gl-native/pull/12896))
+* Fixed an issue with annotations (including the user's location puck) and the GL map lagging relative to each other. ([#12895](https://github.com/mapbox/mapbox-gl-native/pull/12895))
 
 ### Offline maps
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -8,7 +8,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Added an `MGLSymbolStyleLayer.symbolZOrder` property for forcing point features in a symbol layer to be layered in the same order that they are specified in the layer’s associated source. ([#12783](https://github.com/mapbox/mapbox-gl-native/pull/12783))
 * Fixed a crash when a style layer `*-pattern` property evaluates to nil for a particular feature. ([#12896](https://github.com/mapbox/mapbox-gl-native/pull/12896))
-* Fixed an issue with annotations (including the user's location puck) and the GL map lagging relative to each other. ([#12895](https://github.com/mapbox/mapbox-gl-native/pull/12895))
+* Fixed an issue with view annotations (including the user location annotation) and the GL map lagging relative to each other. ([#12895](https://github.com/mapbox/mapbox-gl-native/pull/12895))
 
 ### Offline maps
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -5955,12 +5955,8 @@ public:
     {
         // Smoothly move the user location annotation view and callout view to
         // the new location.
-        [UIView animateWithDuration:duration
-                              delay:0
-                            options:(UIViewAnimationOptionCurveLinear |
-                                     UIViewAnimationOptionAllowUserInteraction |
-                                     UIViewAnimationOptionBeginFromCurrentState)
-                         animations:^{
+        
+        dispatch_block_t animation = ^{
             if (self.selectedAnnotation == self.userLocation)
             {
                 UIView <MGLCalloutView> *calloutView = self.calloutViewForSelectedAnnotation;
@@ -5969,7 +5965,20 @@ public:
                                                  userPoint.y - annotationView.center.y);
             }
             annotationView.center = userPoint;
-        } completion:NULL];
+        };
+        
+        if (duration > 0) {
+            [UIView animateWithDuration:duration
+                                  delay:0
+                                options:(UIViewAnimationOptionCurveLinear |
+                                         UIViewAnimationOptionAllowUserInteraction |
+                                         UIViewAnimationOptionBeginFromCurrentState)
+                             animations:animation
+                             completion:NULL];
+        }
+        else {
+            animation();
+        }
         _userLocationAnimationCompletionDate = [NSDate dateWithTimeIntervalSinceNow:duration];
 
         annotationView.hidden = NO;

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -636,6 +636,10 @@ public:
     _glView.layer.opaque = _opaque;
     _glView.delegate = self;
 
+    // `CAEAGLLayer.presentsWithTransaction` was introduced in iOS 9.
+    CAEAGLLayer *eaglLayer = MGL_OBJC_DYNAMIC_CAST(_glView.layer, CAEAGLLayer);
+    eaglLayer.presentsWithTransaction = YES;
+    
     [_glView bindDrawable];
     [self insertSubview:_glView atIndex:0];
     _glView.contentMode = UIViewContentModeCenter;

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -5771,9 +5771,6 @@ public:
         return;
     }
 
-    [CATransaction begin];
-    [CATransaction setDisableActions:YES];
-
     // If the map is pitched consider the viewport to be exactly the same as the bounds.
     // Otherwise, add a small buffer.
     CGFloat largestWidth = MAX(_largestAnnotationViewSize.width, CGRectGetWidth(self.frame));
@@ -5868,8 +5865,6 @@ public:
             }
         }
     }
-
-    [CATransaction commit];
 }
 
 - (void)updateCalloutView

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -989,8 +989,6 @@ public:
     if ( ! self.dormant || ! _rendererFrontend)
     {
         _rendererFrontend->render();
-
-        [self updateUserLocationAnnotationView];
     }
 }
 
@@ -1121,6 +1119,11 @@ public:
     {
         _needsDisplayRefresh = NO;
 
+        // Update UIKit elements, prior to rendering
+        [self updateUserLocationAnnotationView];
+        [self updateAnnotationViews];
+        [self updateCalloutView];
+        
         [self.glView display];
     }
 
@@ -5713,8 +5716,7 @@ public:
         _isChangingAnnotationLayers = NO;
         [self.style didChangeValueForKey:@"layers"];
     }
-    [self updateAnnotationViews];
-    [self updateCalloutView];
+
     if ([self.delegate respondsToSelector:@selector(mapViewDidFinishRenderingFrame:fullyRendered:)])
     {
         [self.delegate mapViewDidFinishRenderingFrame:self fullyRendered:fullyRendered];

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -636,7 +636,6 @@ public:
     _glView.layer.opaque = _opaque;
     _glView.delegate = self;
 
-    // `CAEAGLLayer.presentsWithTransaction` was introduced in iOS 9.
     CAEAGLLayer *eaglLayer = MGL_OBJC_DYNAMIC_CAST(_glView.layer, CAEAGLLayer);
     eaglLayer.presentsWithTransaction = YES;
     


### PR DESCRIPTION
This PR addresses #12740 and #5489.

Moving UIKit position updates prior to rendering and enabling `CAEAGLLayer.presentsWithTransaction` (introduced in iOS 9) appears to have addressed both these issues.

Running through Instruments show performance hasn't changed dramatically (perhaps even slightly improved), but I'd like to see some additional testing. My main concern is does the user puck behave the same as it used to (not "is it lagging")?

(I'd like to see some additional improvements to how core performs updates, but this is beyond the scope of this fix/PR.)

