### PR TITLE
[ios, build] Bump timeout for ios-release to 5m; fix Slack link

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1087,7 +1087,7 @@ jobs:
       - run:
           name: Send a Slack notification on start
           command: |
-            export SLACK_MESSAGE="Release build for <$CIRCLE_COMPARE_URL|\`$CIRCLE_TAG\`> <$CIRCLE_BUILD_URL|started>."
+            export SLACK_MESSAGE="<$CIRCLE_BUILD_URL|Release build for \`$CIRCLE_TAG\` started.>"
             scripts/notify-slack.sh
       - *restore-node_modules-cache
       - *npm-install
@@ -1114,14 +1114,14 @@ jobs:
           name: Send a Slack notification on failure
           when: on_fail
           command: |
-            export SLACK_MESSAGE="Release build for <$CIRCLE_COMPARE_URL|\`$CIRCLE_TAG\`> <$CIRCLE_BUILD_URL|failed>."
+            export SLACK_MESSAGE="<$CIRCLE_BUILD_URL|Release build for \`$CIRCLE_TAG\` failed.>"
             export SLACK_COLOR="danger"
             scripts/notify-slack.sh
       - run:
           name: Send a Slack notification on success
           when: on_success
           command: |
-            export SLACK_MESSAGE="Release build for <$CIRCLE_COMPARE_URL|\`$CIRCLE_TAG\`> <$CIRCLE_BUILD_URL|succeeded>."
+            export SLACK_MESSAGE="<$CIRCLE_BUILD_URL|Release build for \`$CIRCLE_TAG\` succeeded.>"
             export SLACK_COLOR="good"
             scripts/notify-slack.sh
 

--- a/circle.yml
+++ b/circle.yml
@@ -1056,7 +1056,7 @@ jobs:
       - run:
           name: Build dynamic framework for device and simulator
           command: make iframework
-          no_output_timeout: 2m
+          no_output_timeout: 5m
       - deploy:
           name: Upload nightly build to s3
           command: |


### PR DESCRIPTION
The `ios-release` build can take longer than 2 minutes to link the framework, so this bumps the no-output-timeout to 5 minutes for that build. Follows up on #12899.

Also fixed links in the release deployment Slack notifications.

/cc @julianrex 