### PR TITLE
[core, offline] Limit offline downloads to use half of maximum concurrent file requests.

### DIFF
--- a/platform/default/mbgl/storage/offline_download.cpp
+++ b/platform/default/mbgl/storage/offline_download.cpp
@@ -88,7 +88,8 @@ OfflineDownload::OfflineDownload(int64_t id_,
     : id(id_),
       definition(definition_),
       offlineDatabase(offlineDatabase_),
-      onlineFileSource(onlineFileSource_) {
+      onlineFileSource(onlineFileSource_),
+      maximumConcurrentRequests(std::max<uint32_t>(HTTPFileSource::maximumConcurrentRequests() / 2, 1)) {
     setObserver(nullptr);
 }
 
@@ -338,7 +339,7 @@ void OfflineDownload::continueDownload() {
         return;
     }
 
-    while (!resourcesRemaining.empty() && requests.size() < HTTPFileSource::maximumConcurrentRequests()) {
+    while (!resourcesRemaining.empty() && requests.size() < maximumConcurrentRequests) {
         ensureResource(resourcesRemaining.front());
         resourcesRemaining.pop_front();
     }

--- a/platform/default/mbgl/storage/offline_download.hpp
+++ b/platform/default/mbgl/storage/offline_download.hpp
@@ -63,6 +63,8 @@ private:
 
     void queueResource(Resource);
     void queueTiles(style::SourceType, uint16_t tileSize, const Tileset&);
+    
+    uint32_t maximumConcurrentRequests;
 };
 
 } // namespace mbgl

--- a/test/storage/offline_download.test.cpp
+++ b/test/storage/offline_download.test.cpp
@@ -295,7 +295,7 @@ TEST(OfflineDownload, DoesNotFloodTheFileSourceWithRequests) {
     fileSource.respond(Resource::Kind::Style, test.response("style.json"));
     test.loop.runOnce();
 
-    EXPECT_EQ(HTTPFileSource::maximumConcurrentRequests(), fileSource.requests.size());
+    EXPECT_EQ(std::max<uint32_t>(HTTPFileSource::maximumConcurrentRequests() / 2, 1), fileSource.requests.size());
 }
 
 TEST(OfflineDownload, GetStatusNoResources) {


### PR DESCRIPTION
Fixes issue #12655: don't let offline downloads starve interactive tile downloads.

I started to look at implementing a dual-priority queue in `OnlineFileSource`, and I don't think it would be too hard to do. But as I was looking at the code, I realized that `OfflineDownload` already limits the number of concurrent requests it makes. Setting that concurrent request limit to something less than the maximum number of concurrent requests in `OnlineFileSource` ensures that there will always be some spots open for interactive downloads. I arbitrarily chose 50% (or 10 concurrent downloads given our current implementations) and played around with browsing tiles while simultaneously doing offline downloads in the macosapp -- seemed to work fine.

The downside to this dead-simple approach is that the offline downloads are in some sense "throttled" even when there are no interactive tile requests, but I'm not sure it's a significant concern in practice: my guess would be that 10 concurrent requests is still enough to saturate most network connections.

/cc @tobrun @kkaefer @lilykaiser 