### PR TITLE
[build, ios] Add canary Xcode 10 CircleCI job

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -34,6 +34,7 @@ workflows:
       - linux-gcc4.9-debug
       - linux-gcc5-debug-coverage
       - ios-debug
+      - ios-debug-xcode10
       - ios-release
       - ios-release-tag:
           filters:
@@ -918,6 +919,39 @@ jobs:
   ios-debug:
     macos:
       xcode: "9.4.1"
+    environment:
+      BUILDTYPE: Debug
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - checkout
+      - *restore-node_modules-cache
+      - *npm-install
+      - *prepare-environment
+      - *install-macos-dependencies
+      - *prepare-ccache
+      - *restore-mason_packages-cache
+      - *restore-ccache
+      - *reset-ccache-stats
+      - *build-ios-test
+      - *build-ios-integration-test
+      - *check-public-symbols
+      - run:
+          name: Lint plist files
+          command: make ios-lint
+      - run:
+          name: Nitpick Darwin code generation
+          command: scripts/nitpick/generated-code.js darwin
+      - *show-ccache-stats
+      - *save-node_modules-cache
+      - *save-mason_packages-cache
+      - *save-ccache
+      - *collect-xcode-build-logs
+      - *upload-xcode-build-logs
+
+# ------------------------------------------------------------------------------
+  ios-debug-xcode10:
+    macos:
+      xcode: "10.0.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1

--- a/platform/darwin/test/MGLDocumentationExampleTests.swift
+++ b/platform/darwin/test/MGLDocumentationExampleTests.swift
@@ -34,7 +34,7 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
         mapView = MGLMapView(frame: CGRect(x: 0, y: 0, width: 256, height: 256), styleURL: MGLDocumentationExampleTests.styleURL)
         mapView.delegate = self
         styleLoadingExpectation = expectation(description: "Map view should finish loading style")
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
 
     override func tearDown() {

--- a/platform/darwin/test/MGLDocumentationGuideTests.swift
+++ b/platform/darwin/test/MGLDocumentationGuideTests.swift
@@ -37,7 +37,7 @@ class MGLDocumentationGuideTests: XCTestCase, MGLMapViewDelegate {
         mapView = MGLMapView(frame: CGRect(x: 0, y: 0, width: 256, height: 256), styleURL: styleURL)
         mapView.delegate = self
         styleLoadingExpectation = expectation(description: "Map view should finish loading style")
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     override func tearDown() {

--- a/platform/darwin/test/MGLOfflineStorageTests.mm
+++ b/platform/darwin/test/MGLOfflineStorageTests.mm
@@ -86,7 +86,7 @@
         pack = completionHandlerPack;
         [additionCompletionHandlerExpectation fulfill];
     }];
-    [self waitForExpectationsWithTimeout:2 handler:nil];
+    [self waitForExpectationsWithTimeout:5 handler:nil];
 
     XCTAssertEqual([MGLOfflineStorage sharedOfflineStorage].packs.count, countOfPacks + 1, @"Added pack should have been added to the canonical collection of packs owned by the shared offline storage object. This assertion can fail if this test is run before -testAAALoadPacks.");
 
@@ -124,7 +124,7 @@
         return notificationPack == pack && pack.state == MGLOfflinePackStateInactive;
     }];
     [pack requestProgress];
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:5 handler:nil];
 }
 
 - (void)testAddPackForGeometry {
@@ -157,7 +157,7 @@
         pack = completionHandlerPack;
         [additionCompletionHandlerExpectation fulfill];
     }];
-    [self waitForExpectationsWithTimeout:2 handler:nil];
+    [self waitForExpectationsWithTimeout:5 handler:nil];
     
     XCTAssertEqual([MGLOfflineStorage sharedOfflineStorage].packs.count, countOfPacks + 1, @"Added pack should have been added to the canonical collection of packs owned by the shared offline storage object. This assertion can fail if this test is run before -testAAALoadPacks.");
     
@@ -195,7 +195,7 @@
         return notificationPack == pack && pack.state == MGLOfflinePackStateInactive;
     }];
     [pack requestProgress];
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:5 handler:nil];
     pack = nil;
 }
 
@@ -239,7 +239,7 @@
         XCTAssertEqual(pack.state, MGLOfflinePackStateInvalid, @"Removed pack should be invalid in the completion handler.");
         [completionHandlerExpectation fulfill];
     }];
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:5 handler:nil];
 
     XCTAssertEqual(pack.state, MGLOfflinePackStateInvalid, @"Removed pack should have been invalidated synchronously.");
 

--- a/platform/darwin/test/MGLStyleLayerTests.m
+++ b/platform/darwin/test/MGLStyleLayerTests.m
@@ -37,6 +37,13 @@
     if (isBoolean) {
         if ([components.firstObject isEqualToString:@"is"]) {
             [components removeObjectAtIndex:0];
+
+            // Xcode 10 incorrectly classifies "optional" as a verb, so return early to avoid the verb checks.
+            // https://openradar.appspot.com/44149950
+            if ([components.lastObject isEqualToString:@"optional"] && NSFoundationVersionNumber >= 1548) {
+                return;
+            }
+
             if (![components.lastObject.lexicalClasses containsObject:NSLinguisticTagAdjective]) {
                 XCTAssertTrue([components.lastObject.lexicalClasses containsObject:NSLinguisticTagVerb],
                               @"Boolean getter %@ that starts with “is” should contain an adjective, past participle, or verb.", name);

--- a/platform/darwin/test/MGLStyleTests.mm
+++ b/platform/darwin/test/MGLStyleTests.mm
@@ -33,7 +33,7 @@
     self.mapView.delegate = self;
     if (!self.mapView.style) {
         _styleLoadingExpectation = [self expectationWithDescription:@"Map view should finish loading style."];
-        [self waitForExpectationsWithTimeout:1 handler:nil];
+        [self waitForExpectationsWithTimeout:5 handler:nil];
     }
 }
 

--- a/platform/ios/Integration Tests/Annotation Tests/MGLAnnotationViewIntegrationTests.m
+++ b/platform/ios/Integration Tests/Annotation Tests/MGLAnnotationViewIntegrationTests.m
@@ -102,7 +102,7 @@
         [timerExpired fulfill];
     });
 
-    [self waitForExpectations:@[timerExpired, self.renderFinishedExpectation] timeout:1.0];
+    [self waitForExpectations:@[timerExpired, self.renderFinishedExpectation] timeout:5];
 }
 
 @end

--- a/platform/ios/Integration Tests/MBGLIntegrationTests.m
+++ b/platform/ios/Integration Tests/MBGLIntegrationTests.m
@@ -186,7 +186,7 @@
         XCTAssertNil(mapView2.style);
 
         self.styleLoadingExpectation = [self expectationWithDescription:@"Map view should finish loading style."];
-        [self waitForExpectationsWithTimeout:1 handler:nil];
+        [self waitForExpectationsWithTimeout:5 handler:nil];
 
         MGLOpenGLStyleLayer *layer = [[MGLOpenGLStyleLayer alloc] initWithIdentifier:@"gl-layer"];
         weakLayer = layer;

--- a/platform/ios/Integration Tests/MGLCameraTransitionTests.mm
+++ b/platform/ios/Integration Tests/MGLCameraTransitionTests.mm
@@ -34,7 +34,7 @@
     [self.mapView setDirection:90 animated:YES];
 
     // loop, render, and wait
-    [self waitForExpectations:@[expectation] timeout:1.5];
+    [self waitForExpectations:@[expectation] timeout:5];
 }
 
 
@@ -62,7 +62,7 @@
     };
 
     [self.mapView setDirection:90 animated:YES];
-    [self waitForExpectations:@[expectation] timeout:1.5];
+    [self waitForExpectations:@[expectation] timeout:5];
 }
 
 - (void)testInterruptingAndResetNorthOnlyOnceInIsChanging {
@@ -106,7 +106,7 @@
     };
 
     [self.mapView setDirection:90 animated:YES];
-    [self waitForExpectations:@[expectation] timeout:1.5];
+    [self waitForExpectations:@[expectation] timeout:5];
 
     XCTAssertEqualWithAccuracy(self.mapView.direction, 0.0, 0.001, @"Camera should have reset to north. %0.3f", self.mapView.direction);
 }
@@ -222,7 +222,7 @@
 
     // Should take MGLAnimationDuration seconds (0.3)
     [self.mapView setCenterCoordinate:target zoomLevel:15.0 animated:YES];
-    [self waitForExpectations:@[expectation] timeout:1.5];
+    [self waitForExpectations:@[expectation] timeout:5];
 }
 
 - (void)testFlyToCameraInDelegateMethod {
@@ -323,7 +323,7 @@
     // Should take MGLAnimationDuration
     [self.mapView setCenterCoordinate:target zoomLevel:zoomLevel animated:YES];
 
-    [self waitForExpectations:@[expectation] timeout:2.0];
+    [self waitForExpectations:@[expectation] timeout:5];
 
     NSLog(@"setCenterCoordinate: %0.4fs", stop1 - stop0);
     NSLog(@"flyToCamera: %0.4fs", stop2 - stop1);
@@ -362,7 +362,7 @@
     };
 
     [self.mapView setDirection:90 animated:YES];
-    [self waitForExpectations:@[expectation] timeout:1.5];
+    [self waitForExpectations:@[expectation] timeout:5];
 
     XCTAssertEqualWithAccuracy(self.mapView.direction, 0.0, 0.001, @"Camera should have reset to north. %0.3f", self.mapView.direction);
 }
@@ -389,7 +389,7 @@
     };
 
     [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(40.0, 40.0) animated:YES];
-    [self waitForExpectations:@[expectation] timeout:1.5];
+    [self waitForExpectations:@[expectation] timeout:5];
 
     XCTAssertEqualWithAccuracy(self.mapView.direction, 0.0, 0.001, @"Camera should have reset to north. %0.3f", self.mapView.direction);
 }

--- a/platform/ios/Integration Tests/MGLMapViewIntegrationTest.m
+++ b/platform/ios/Integration Tests/MGLMapViewIntegrationTest.m
@@ -33,7 +33,7 @@
     [window makeKeyAndVisible];
 
     if (!self.mapView.style) {
-        [self waitForMapViewToFinishLoadingStyleWithTimeout:1];
+        [self waitForMapViewToFinishLoadingStyleWithTimeout:5];
     }
 }
 

--- a/platform/ios/test/MGLAnnotationViewTests.m
+++ b/platform/ios/test/MGLAnnotationViewTests.m
@@ -85,7 +85,7 @@ static NSString * const MGLTestAnnotationReuseIdentifer = @"MGLTestAnnotationReu
     MGLTestAnnotation *annotation = [[MGLTestAnnotation alloc] init];
     [_mapView addAnnotation:annotation];
 
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:5 handler:nil];
 
     XCTAssert(_mapView.annotations.count == 1, @"number of annotations should be 1");
     XCTAssertNotNil(_annotationView.annotation, @"annotation property should not be nil");

--- a/platform/ios/test/MGLMapViewLayoutTests.m
+++ b/platform/ios/test/MGLMapViewLayoutTests.m
@@ -35,7 +35,7 @@
     [self.superView addConstraints:[verticalConstraints arrayByAddingObjectsFromArray:horizonatalConstraints]];
 
     self.styleLoadingExpectation = [self expectationWithDescription:@"Map view should finish loading style."];
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:5 handler:nil];
 
     self.mapView.showsScale = YES;
 


### PR DESCRIPTION
Fixes #12756. Updating to Xcode 10 proved to be slightly troublesome:

- 5882c1a bumped most every expectation wait timeout to 5 seconds, which seems to satisfy CircleCI. Tests always ran successfully locally, but the original timeouts were overrun without any apparent pattern on CI (and we may yet need to bump further). Cause is unknown.
- [Foundation in Xcode 10 incorrectly classifies the word "optional" as a verb](https://openradar.appspot.com/44149950).

Let’s keep this build optional and let it run alongside the current Xcode 9.4.1 builds and, if it proves reliable, we can migrate the rest of the builds next week before `ios-v4.5.0-alpha.2`. We should do our best to publish `ios-v4.5.0` with Xcode 10.

/cc @mapbox/maps-ios 
