### PR TITLE
Update proguard config to not warn about AutoValue

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/proguard-rules.pro
+++ b/platform/android/MapboxGLAndroidSDK/proguard-rules.pro
@@ -25,6 +25,7 @@
 
 # config for mapbox-sdk-geojson:3.0.1
 -keep class com.mapbox.geojson.** { *; }
+-dontwarn com.google.auto.value.**
 -dontnote com.google.gson.internal.UnsafeAllocator
 
 # config for mapbox-android-gestures:0.0.1-20180228.152340-13

--- a/platform/android/MapboxGLAndroidSDKTestApp/proguard-rules.pro
+++ b/platform/android/MapboxGLAndroidSDKTestApp/proguard-rules.pro
@@ -2,8 +2,6 @@
 -dontwarn android.support.**
 -dontwarn java.lang.**
 -dontwarn org.codehaus.**
--keep class com.google.**
--dontwarn com.google.**
 -dontwarn java.nio.**
 
 -keep class com.mapbox.mapboxsdk.testapp.model.customlayer.ExampleCustomLayer { *; }


### PR DESCRIPTION
This issue went unnoticed due to a proguard test app configuration.

Closes #12919 