### PR TITLE
[core] Don't log GL renderer string on every context initialization

### DIFF
--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -124,8 +124,11 @@ void Context::initializeExtensions(const std::function<gl::ProcAddress(const cha
             return nullptr;
         };
 
-        const std::string renderer = reinterpret_cast<const char*>(MBGL_CHECK_ERROR(glGetString(GL_RENDERER)));
-        Log::Info(Event::General, "GPU Identifier: %s", renderer.c_str());
+        static const std::string renderer = []() {
+            std::string r = reinterpret_cast<const char*>(MBGL_CHECK_ERROR(glGetString(GL_RENDERER)));
+            Log::Info(Event::General, "GPU Identifier: %s", r.c_str());
+            return r;
+        }();
 
         // Block ANGLE on Direct3D since the debugging extension is causing crashes
         if (!(renderer.find("ANGLE") != std::string::npos


### PR DESCRIPTION
Commit 1c53dc9ca8d9 ([core] Refactor vertex array object extension
initialization) changed where the GL renderer string is checked in order
to prevent the vertex array extension initialization in certain
platforms and in doing so made the logging of that string more frequent,
once per context initialization instead of at most once per process.
This is a lot more verbose, specially when running unit tests, so make
sure that string is logged at most once as it was previously.