### PR TITLE
Replace reflection setup in instrumentation tests

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/activity/BaseActivityTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/activity/BaseActivityTest.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.support.test.espresso.Espresso;
 import android.support.test.espresso.IdlingRegistry;
 import android.support.test.espresso.IdlingResourceTimeoutException;
 import android.support.test.espresso.ViewInteraction;
@@ -46,16 +47,14 @@ public abstract class BaseActivityTest {
       Timber.e(String.format("%s - %s", testNameRule.getMethodName(), "@Before test: register idle resource"));
       idlingResource = new OnMapReadyIdlingResource(rule.getActivity());
       IdlingRegistry.getInstance().register(idlingResource);
-      checkViewIsDisplayed(R.id.mapView);
+      Espresso.onIdle();
       mapboxMap = idlingResource.getMapboxMap();
     } catch (IdlingResourceTimeoutException idlingResourceTimeoutException) {
-      Timber.e("Idling resource timed out. Couldn't not validate if map is ready.");
-      throw new RuntimeException("Could not start test for " + getActivityClass().getSimpleName() + ".\n"
-        + "The ViewHierarchy doesn't contain a view with resource id = R.id.mapView or \n"
-        + "the Activity doesn't contain an instance variable with a name equal to mapboxMap.\n"
-        + "You can resolve this issue by adding the requirements above or\n add "
-        + getActivityClass().getSimpleName() + " to the platform/android/scripts/exclude-activity-gen.json to blacklist"
-        + " the Activity from being generated.\n");
+      throw new RuntimeException(String.format("Could not start %s test for %s.\n  Either the ViewHierarchy doesn't "
+          + "contain a view with resource id = R.id.mapView or \n the hosting Activity wasn't in an idle state.",
+        testNameRule.getMethodName(),
+        getActivityClass().getSimpleName())
+      );
     }
   }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/utils/OnMapReadyIdlingResource.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/utils/OnMapReadyIdlingResource.java
@@ -2,29 +2,30 @@ package com.mapbox.mapboxsdk.testapp.utils;
 
 import android.app.Activity;
 import android.os.Handler;
+import android.os.Looper;
 import android.support.annotation.WorkerThread;
 import android.support.test.espresso.IdlingResource;
 
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
-
-import java.lang.reflect.Field;
+import com.mapbox.mapboxsdk.testapp.R;
 
 public class OnMapReadyIdlingResource implements IdlingResource, OnMapReadyCallback {
 
   private MapboxMap mapboxMap;
   private IdlingResource.ResourceCallback resourceCallback;
+  private final Handler handler = new Handler(Looper.getMainLooper());
 
   @WorkerThread
-  public OnMapReadyIdlingResource(Activity activity) {
-    new Handler(activity.getMainLooper()).post(() -> {
-      try {
-        Field field = activity.getClass().getDeclaredField("mapView");
-        field.setAccessible(true);
-        ((MapView) field.get(activity)).getMapAsync(OnMapReadyIdlingResource.this);
-      } catch (Exception err) {
-        throw new RuntimeException(err);
+  public OnMapReadyIdlingResource(final Activity activity) {
+    handler.post(new Runnable() {
+      @Override
+      public void run() {
+        MapView mapView = (MapView) activity.findViewById(R.id.mapView);
+        if (mapView != null) {
+          mapView.getMapAsync(OnMapReadyIdlingResource.this);
+        }
       }
     });
   }


### PR DESCRIPTION
We recently seen an increased report of flaky instrumentation tests on CI. This PR changes the way instrumentation tests are initialised by using `findViewById` instead of reflection. The reflection usage for this use-case stems from being able to reflect on the MapboxMap field and was later replaced with MapView for speed. A simpler, more robust way to get MapView can be done with use findViewById instead. This should solve the flaky tests on CI. 