### PR TITLE
release-frappe backport: Compare clang-tidy with merge base instead of master

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -359,9 +359,6 @@ jobs:
       - *restore-ccache
       - *reset-ccache-stats
       - run:
-          name: Fetch 'origin/master' branch
-          command: git fetch origin master:refs/remotes/origin/master
-      - run:
           name: Generate compilation database
           command: make compdb
       - run:

--- a/scripts/clang-tools.sh
+++ b/scripts/clang-tools.sh
@@ -2,6 +2,7 @@
 
 set -e
 set -o pipefail
+set -u
 
 CLANG_TIDY_PREFIX=${CLANG_TIDY_PREFIX:-$(scripts/mason.sh PREFIX clang-tidy VERSION 4.0.1)}
 CLANG_TIDY=${CLANG_TIDY:-${CLANG_TIDY_PREFIX}/bin/clang-tidy}
@@ -33,7 +34,7 @@ function run_clang_tidy() {
 }
 
 function run_clang_tidy_diff() {
-    OUTPUT=$(git diff origin/master --src-prefix=${CDUP} --dst-prefix=${CDUP} | \
+    OUTPUT=$(git diff ${CIRCLE_MERGE_BASE} --src-prefix=${CDUP} --dst-prefix=${CDUP} | \
                 ${CLANG_TIDY_PREFIX}/share/clang-tidy-diff.py \
                     -clang-tidy-binary ${CLANG_TIDY} \
                     2>/dev/null)
@@ -45,7 +46,7 @@ function run_clang_tidy_diff() {
 
 function run_clang_format() {
     echo "Running clang-format on $0..."
-    DIFF_FILES=$(git diff origin/master --name-only *cpp)
+    DIFF_FILES=$(git diff ${CIRCLE_MERGE_BASE} --name-only *cpp)
     echo "${DIFF_FILES}" | xargs -I{} -P ${JOBS} bash -c 'run_clang_format' {}
     ${CLANG_FORMAT} -i ${CDUP}/$0 || exit 1
 }

--- a/scripts/environment.js
+++ b/scripts/environment.js
@@ -7,6 +7,7 @@ const github = require('@octokit/rest')();
 const {execSync} = require('child_process');
 
 const pr = process.env['CIRCLE_PULL_REQUEST'];
+const head = process.env['CIRCLE_SHA1'] || 'HEAD';
 if (pr) {
     const number = +pr.match(/\/(\d+)\/?$/)[1];
     return github.pullRequests.get({
@@ -15,17 +16,15 @@ if (pr) {
         number
     }).then(({data}) => {
         const base = data.base.ref;
-        const head = process.env['CIRCLE_SHA1'];
         const mergeBase = execSync(`git merge-base origin/${base} ${head}`).toString().trim();
 
         console.log(`export CIRCLE_TARGET_BRANCH=${base}`);
         console.log(`export CIRCLE_MERGE_BASE=${mergeBase}`);
     });
 } else {
-    const head = process.env['CIRCLE_SHA1'];
     for (const sha of execSync(`git rev-list --max-count=10 ${head}`).toString().trim().split('\n')) {
         const base = execSync(`git branch -r --contains ${sha} origin/master origin/release-*`).toString().split('\n')[0].trim().replace(/^origin\//, '');
-        if (base) {
+        if (base.match(/^(master|release-[a-z]+)$/)) {
             const mergeBase = execSync(`git merge-base origin/${base} ${head}`).toString().trim();
             console.log(`export CIRCLE_TARGET_BRANCH=${base}`);
             console.log(`export CIRCLE_MERGE_BASE=${mergeBase}`);


### PR DESCRIPTION
Backports #12958 to release-frappe
----
