### PR TITLE
Re-enable camera tests

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -684,6 +684,23 @@ public final class MapboxMap {
   }
 
   /**
+   * Gradually move the camera by the default duration, zoom will not be affected unless specified
+   * within {@link CameraUpdate}. If {@link #getCameraPosition()} is called during the animation,
+   * it will return the current location of the camera in flight.
+   *
+   * @param update   The change that should be applied to the camera.
+   * @param callback An optional callback to be notified from the main thread when the animation
+   *                 stops. If the animation stops due to its natural completion, the callback
+   *                 will be notified with onFinish(). If the animation stops due to interruption
+   *                 by a later camera movement or a user gesture, onCancel() will be called.
+   *                 Do not update or ease the camera from within onCancel().
+   * @see com.mapbox.mapboxsdk.camera.CameraUpdateFactory for a set of updates.
+   */
+  public final void easeCamera(CameraUpdate update, @Nullable final MapboxMap.CancelableCallback callback) {
+    easeCamera(update, MapboxConstants.ANIMATION_DURATION, callback);
+  }
+
+  /**
    * Gradually move the camera by a specified duration in milliseconds, zoom will not be affected
    * unless specified within {@link CameraUpdate}. If {@link #getCameraPosition()} is called
    * during the animation, it will return the current location of the camera in flight.

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraAnimateTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraAnimateTest.java
@@ -1,16 +1,19 @@
 package com.mapbox.mapboxsdk.testapp.camera;
 
 import android.graphics.PointF;
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.IdlingRegistry;
+import android.support.test.espresso.idling.CountingIdlingResource;
 
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 import com.mapbox.mapboxsdk.testapp.activity.espresso.DeviceIndependentTestActivity;
 import com.mapbox.mapboxsdk.testapp.utils.TestConstants;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke;
@@ -18,13 +21,21 @@ import static org.junit.Assert.assertEquals;
 
 public class CameraAnimateTest extends BaseActivityTest {
 
+  private final CountingIdlingResource animationIdlingResource =
+    new CountingIdlingResource("animation_idling_resource");
+
   @Override
   protected Class getActivityClass() {
     return DeviceIndependentTestActivity.class;
   }
 
+  @Override
+  public void beforeTest() {
+    super.beforeTest();
+    IdlingRegistry.getInstance().register(animationIdlingResource);
+  }
+
   @Test
-  @Ignore
   public void testAnimateToCameraPositionTarget() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -34,36 +45,54 @@ public class CameraAnimateTest extends BaseActivityTest {
         new LatLng()).zoom(zoom).bearing(0).tilt(0).build();
       CameraPosition cameraPosition = mapboxMap.getCameraPosition();
       assertEquals("Default camera position should match default", cameraPosition, initialPosition);
-      mapboxMap.animateCamera(CameraUpdateFactory.newLatLng(moveTarget));
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera position latitude should match", cameraPosition.target.getLatitude(),
-        moveTarget.getLatitude(), TestConstants.LAT_LNG_DELTA);
-      assertEquals("Moved camera position longitude should match", cameraPosition.target.getLongitude(),
-        moveTarget.getLongitude(), TestConstants.LAT_LNG_DELTA);
+
+      animationIdlingResource.increment();
+      mapboxMap.animateCamera(CameraUpdateFactory.newLatLng(moveTarget), new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          verifyCameraPosition(mapboxMap, moveTarget, zoom, 0, 0);
+          animationIdlingResource.decrement();
+        }
+
+        @Override
+        public void onFinish() {
+          verifyCameraPosition(mapboxMap, moveTarget, zoom, 0, 0);
+          animationIdlingResource.decrement();
+        }
+      });
     });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testAnimateToCameraPositionTargetZoom() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       final float moveZoom = 15.5f;
       final LatLng moveTarget = new LatLng(1.0000000001, 1.0000000003);
-      mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(moveTarget, moveZoom));
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera position latitude should match", cameraPosition.target.getLatitude(),
-        moveTarget.getLatitude(), TestConstants.LAT_LNG_DELTA);
-      assertEquals("Moved camera position longitude should match", cameraPosition.target.getLongitude(),
-        moveTarget.getLongitude(), TestConstants.LAT_LNG_DELTA);
-      assertEquals("Moved zoom should match", cameraPosition.zoom, moveZoom, TestConstants.ZOOM_DELTA);
+
+      animationIdlingResource.increment();
+      mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(moveTarget, moveZoom), new MapboxMap
+        .CancelableCallback() {
+        @Override
+        public void onCancel() {
+          verifyCameraPosition(mapboxMap, moveTarget, moveZoom, 0, 0);
+          animationIdlingResource.decrement();
+        }
+
+        @Override
+        public void onFinish() {
+          verifyCameraPosition(mapboxMap, moveTarget, moveZoom, 0, 0);
+          animationIdlingResource.decrement();
+        }
+      });
     });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testAnimateToCameraPosition() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -72,28 +101,33 @@ public class CameraAnimateTest extends BaseActivityTest {
       final float moveTilt = 45.5f;
       final float moveBearing = 12.5f;
 
+      animationIdlingResource.increment();
       mapboxMap.animateCamera(CameraUpdateFactory.newCameraPosition(
         new CameraPosition.Builder()
           .target(moveTarget)
           .zoom(moveZoom)
           .tilt(moveTilt)
           .bearing(moveBearing)
-          .build())
-      );
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera position latitude should match", cameraPosition.target.getLatitude(),
-        moveTarget.getLatitude(), TestConstants.LAT_LNG_DELTA);
-      assertEquals("Moved camera position longitude should match", cameraPosition.target.getLongitude(),
-        moveTarget.getLongitude(), TestConstants.LAT_LNG_DELTA);
-      assertEquals("Moved zoom should match", cameraPosition.zoom, moveZoom, TestConstants.ZOOM_DELTA);
-      assertEquals("Moved zoom should match", cameraPosition.tilt, moveTilt, TestConstants.TILT_DELTA);
-      assertEquals("Moved bearing should match", cameraPosition.bearing, moveBearing, TestConstants.BEARING_DELTA);
+          .build()),
+        new MapboxMap.CancelableCallback() {
+          @Override
+          public void onCancel() {
+            verifyCameraPosition(mapboxMap, moveTarget, moveZoom, moveBearing, moveTilt);
+            animationIdlingResource.decrement();
+          }
+
+          @Override
+          public void onFinish() {
+            verifyCameraPosition(mapboxMap, moveTarget, moveZoom, moveBearing, moveTilt);
+            animationIdlingResource.decrement();
+          }
+        });
     });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testAnimateToBounds() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -103,96 +137,191 @@ public class CameraAnimateTest extends BaseActivityTest {
       final LatLngBounds.Builder builder = new LatLngBounds.Builder();
       builder.include(cornerOne);
       builder.include(cornerTwo);
-      mapboxMap.animateCamera(CameraUpdateFactory.newLatLngBounds(builder.build(), 0));
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera position latitude should match center bounds",
-        cameraPosition.target.getLatitude(),
-        centerBounds.getLatitude(),
-        TestConstants.LAT_LNG_DELTA);
-      assertEquals("Moved camera position longitude should match center bounds",
-        cameraPosition.target.getLongitude(),
-        centerBounds.getLongitude(),
-        TestConstants.LAT_LNG_DELTA);
+
+      animationIdlingResource.increment();
+      mapboxMap.animateCamera(CameraUpdateFactory.newLatLngBounds(builder.build(), 0), new MapboxMap
+        .CancelableCallback() {
+        @Override
+        public void onCancel() {
+          verifyCameraPosition(mapboxMap, centerBounds, mapboxMap.getCameraPosition().zoom, 0, 0);
+          animationIdlingResource.decrement();
+        }
+
+        @Override
+        public void onFinish() {
+          verifyCameraPosition(mapboxMap, centerBounds, mapboxMap.getCameraPosition().zoom, 0, 0);
+          animationIdlingResource.decrement();
+        }
+      });
     });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testAnimateToMoveBy() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       final PointF centerPoint = mapboxMap.getProjection().toScreenLocation(mapboxMap.getCameraPosition().target);
       final LatLng moveTarget = new LatLng(2, 2);
       final PointF moveTargetPoint = mapboxMap.getProjection().toScreenLocation(moveTarget);
-      mapboxMap.animateCamera(CameraUpdateFactory.scrollBy(
-        moveTargetPoint.x - centerPoint.x, moveTargetPoint.y - centerPoint.y));
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera position latitude should match", cameraPosition.target.getLatitude(),
-        moveTarget.getLatitude(), TestConstants.LAT_LNG_DELTA_LARGE);
-      assertEquals("Moved camera position longitude should match", cameraPosition.target.getLongitude(),
-        moveTarget.getLongitude(), TestConstants.LAT_LNG_DELTA_LARGE);
+
+      animationIdlingResource.increment();
+      mapboxMap.animateCamera(
+        CameraUpdateFactory.scrollBy(moveTargetPoint.x - centerPoint.x, moveTargetPoint.y - centerPoint.y),
+        new MapboxMap.CancelableCallback() {
+          @Override
+          public void onCancel() {
+            verifyCameraPosition(mapboxMap, moveTarget, mapboxMap.getCameraPosition().zoom, 0, 0);
+            animationIdlingResource.decrement();
+          }
+
+          @Override
+          public void onFinish() {
+            verifyCameraPosition(mapboxMap, moveTarget, mapboxMap.getCameraPosition().zoom, 0, 0);
+            animationIdlingResource.decrement();
+          }
+        });
     });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testAnimateToZoomIn() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       float zoom = 1.0f;
-      mapboxMap.animateCamera(CameraUpdateFactory.zoomIn());
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera zoom should match moved camera zoom", cameraPosition.zoom, zoom + 1,
-        TestConstants.ZOOM_DELTA);
+
+      animationIdlingResource.increment();
+      mapboxMap.animateCamera(CameraUpdateFactory.zoomIn(), new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom + 1, 0, 0);
+          animationIdlingResource.decrement();
+        }
+
+        @Override
+        public void onFinish() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom + 1, 0, 0);
+          animationIdlingResource.decrement();
+        }
+      });
     });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testAnimateToZoomOut() {
     validateTestSetup();
+    float zoom = 10.0f;
     invoke(mapboxMap, (uiController, mapboxMap) -> {
-      float zoom = 10.0f;
-      mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(), zoom));
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      mapboxMap.animateCamera(CameraUpdateFactory.zoomOut());
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera zoom should match moved camera zoom", cameraPosition.zoom, zoom - 1,
-        TestConstants.ZOOM_DELTA);
+      animationIdlingResource.increment();
+      mapboxMap.animateCamera(
+        CameraUpdateFactory.newLatLngZoom(new LatLng(), zoom),
+        new MapboxMap.CancelableCallback() {
+          @Override
+          public void onCancel() {
+            verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom, 0, 0);
+            animationIdlingResource.decrement();
+          }
+
+          @Override
+          public void onFinish() {
+            verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom, 0, 0);
+            animationIdlingResource.decrement();
+          }
+        });
     });
+
+    invoke(mapboxMap, ((uiController, mapboxMap1) -> {
+      animationIdlingResource.increment();
+      mapboxMap.animateCamera(CameraUpdateFactory.zoomOut(), new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom - 1, 0, 0);
+          animationIdlingResource.decrement();
+        }
+
+        @Override
+        public void onFinish() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom - 1, 0, 0);
+          animationIdlingResource.decrement();
+        }
+      });
+    }));
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testAnimateToZoomBy() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       float zoom = 1.0f;
       final float zoomBy = 2.45f;
-      mapboxMap.animateCamera(CameraUpdateFactory.zoomBy(zoomBy));
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera zoom should match moved camera zoom", cameraPosition.zoom, zoom + zoomBy,
-        TestConstants.ZOOM_DELTA);
+
+      animationIdlingResource.increment();
+      mapboxMap.animateCamera(CameraUpdateFactory.zoomBy(zoomBy), new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom + zoomBy, 0, 0);
+          animationIdlingResource.decrement();
+        }
+
+        @Override
+        public void onFinish() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom + zoomBy, 0, 0);
+          animationIdlingResource.decrement();
+        }
+      });
     });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testAnimateToZoomTo() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       final float zoomTo = 2.45f;
-      mapboxMap.animateCamera(CameraUpdateFactory.zoomTo(zoomTo));
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera zoom should match moved camera zoom", cameraPosition.zoom, zoomTo,
-        TestConstants.ZOOM_DELTA);
+
+      animationIdlingResource.increment();
+      mapboxMap.animateCamera(CameraUpdateFactory.zoomTo(zoomTo), new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoomTo, 0, 0);
+          animationIdlingResource.decrement();
+        }
+
+        @Override
+        public void onFinish() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoomTo, 0, 0);
+          animationIdlingResource.decrement();
+        }
+      });
     });
+
+    Espresso.onIdle();
+  }
+
+  @Override
+  public void afterTest() {
+    super.afterTest();
+    IdlingRegistry.getInstance().unregister(animationIdlingResource);
+  }
+
+  private void verifyCameraPosition(MapboxMap mapboxMap, LatLng moveTarget, double moveZoom, double moveBearing,
+                                    double moveTilt) {
+    CameraPosition cameraPosition = mapboxMap.getCameraPosition();
+    assertEquals("Moved camera position latitude should match", cameraPosition.target.getLatitude(),
+      moveTarget.getLatitude(), TestConstants.LAT_LNG_DELTA);
+    assertEquals("Moved camera position longitude should match", cameraPosition.target.getLongitude(),
+      moveTarget.getLongitude(), TestConstants.LAT_LNG_DELTA);
+    assertEquals("Moved zoom should match", cameraPosition.zoom, moveZoom, TestConstants.ZOOM_DELTA);
+    assertEquals("Moved zoom should match", cameraPosition.tilt, moveTilt, TestConstants.TILT_DELTA);
+    assertEquals("Moved bearing should match", cameraPosition.bearing, moveBearing, TestConstants.BEARING_DELTA);
   }
 }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraEaseTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraEaseTest.java
@@ -1,11 +1,15 @@
 package com.mapbox.mapboxsdk.testapp.camera;
 
 import android.graphics.PointF;
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.IdlingRegistry;
+import android.support.test.espresso.idling.CountingIdlingResource;
 
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 import com.mapbox.mapboxsdk.testapp.activity.espresso.DeviceIndependentTestActivity;
 import com.mapbox.mapboxsdk.testapp.utils.TestConstants;
@@ -18,13 +22,21 @@ import static org.junit.Assert.assertEquals;
 
 public class CameraEaseTest extends BaseActivityTest {
 
+  private final CountingIdlingResource animationIdlingResource =
+    new CountingIdlingResource("animation_idling_resource");
+
   @Override
   protected Class getActivityClass() {
     return DeviceIndependentTestActivity.class;
   }
 
+  @Override
+  public void beforeTest() {
+    super.beforeTest();
+    IdlingRegistry.getInstance().register(animationIdlingResource);
+  }
+
   @Test
-  @Ignore
   public void testEaseToCameraPositionTarget() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -34,36 +46,53 @@ public class CameraEaseTest extends BaseActivityTest {
         new LatLng()).zoom(zoom).bearing(0).tilt(0).build();
       CameraPosition cameraPosition = mapboxMap.getCameraPosition();
       assertEquals("Default camera position should match default", cameraPosition, initialPosition);
-      mapboxMap.easeCamera(CameraUpdateFactory.newLatLng(moveTarget));
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera position latitude should match", cameraPosition.target.getLatitude(),
-        moveTarget.getLatitude(), TestConstants.LAT_LNG_DELTA);
-      assertEquals("Moved camera position longitude should match", cameraPosition.target.getLongitude(),
-        moveTarget.getLongitude(), TestConstants.LAT_LNG_DELTA);
+
+      animationIdlingResource.increment();
+      mapboxMap.easeCamera(CameraUpdateFactory.newLatLng(moveTarget), new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          verifyCameraPosition(mapboxMap, moveTarget, zoom, 0, 0);
+          animationIdlingResource.decrement();
+        }
+
+        @Override
+        public void onFinish() {
+          verifyCameraPosition(mapboxMap, moveTarget, zoom, 0, 0);
+          animationIdlingResource.decrement();
+        }
+      });
     });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testEaseToCameraPositionTargetZoom() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       final float moveZoom = 15.5f;
       final LatLng moveTarget = new LatLng(1.0000000001, 1.0000000003);
-      mapboxMap.easeCamera(CameraUpdateFactory.newLatLngZoom(moveTarget, moveZoom));
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera position latitude should match", cameraPosition.target.getLatitude(),
-        moveTarget.getLatitude(), TestConstants.LAT_LNG_DELTA);
-      assertEquals("Moved camera position longitude should match", cameraPosition.target.getLongitude(),
-        moveTarget.getLongitude(), TestConstants.LAT_LNG_DELTA);
-      assertEquals("Moved zoom should match", cameraPosition.zoom, moveZoom, TestConstants.ZOOM_DELTA);
+
+      animationIdlingResource.increment();
+      mapboxMap.easeCamera(CameraUpdateFactory.newLatLngZoom(moveTarget, moveZoom), new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          verifyCameraPosition(mapboxMap, moveTarget, moveZoom, 0, 0);
+          animationIdlingResource.decrement();
+        }
+
+        @Override
+        public void onFinish() {
+          verifyCameraPosition(mapboxMap, moveTarget, moveZoom, 0, 0);
+          animationIdlingResource.decrement();
+        }
+      });
     });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testEaseToCameraPosition() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -72,28 +101,34 @@ public class CameraEaseTest extends BaseActivityTest {
       final float moveTilt = 45.5f;
       final float moveBearing = 12.5f;
 
+      animationIdlingResource.increment();
       mapboxMap.easeCamera(CameraUpdateFactory.newCameraPosition(
         new CameraPosition.Builder()
           .target(moveTarget)
           .zoom(moveZoom)
           .tilt(moveTilt)
           .bearing(moveBearing)
-          .build())
+          .build()),
+        new MapboxMap.CancelableCallback() {
+          @Override
+          public void onCancel() {
+            verifyCameraPosition(mapboxMap, moveTarget, moveZoom, moveBearing, moveTilt);
+            animationIdlingResource.decrement();
+          }
+
+          @Override
+          public void onFinish() {
+            verifyCameraPosition(mapboxMap, moveTarget, moveZoom, moveBearing, moveTilt);
+            animationIdlingResource.decrement();
+          }
+        }
       );
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera position latitude should match", cameraPosition.target.getLatitude(),
-        moveTarget.getLatitude(), TestConstants.LAT_LNG_DELTA);
-      assertEquals("Moved camera position longitude should match", cameraPosition.target.getLongitude(),
-        moveTarget.getLongitude(), TestConstants.LAT_LNG_DELTA);
-      assertEquals("Moved zoom should match", cameraPosition.zoom, moveZoom, TestConstants.ZOOM_DELTA);
-      assertEquals("Moved zoom should match", cameraPosition.tilt, moveTilt, TestConstants.TILT_DELTA);
-      assertEquals("Moved bearing should match", cameraPosition.bearing, moveBearing, TestConstants.BEARING_DELTA);
     });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testEaseToBounds() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -103,95 +138,186 @@ public class CameraEaseTest extends BaseActivityTest {
       final LatLngBounds.Builder builder = new LatLngBounds.Builder();
       builder.include(cornerOne);
       builder.include(cornerTwo);
-      mapboxMap.easeCamera(CameraUpdateFactory.newLatLngBounds(builder.build(), 0));
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera position latitude should match center bounds",
-        cameraPosition.target.getLatitude(),
-        centerBounds.getLatitude(),
-        TestConstants.LAT_LNG_DELTA);
-      assertEquals("Moved camera position longitude should match center bounds",
-        cameraPosition.target.getLongitude(),
-        centerBounds.getLongitude(),
-        TestConstants.LAT_LNG_DELTA);
+
+      animationIdlingResource.increment();
+      mapboxMap.easeCamera(CameraUpdateFactory.newLatLngBounds(builder.build(), 0),
+        new MapboxMap.CancelableCallback() {
+          @Override
+          public void onCancel() {
+            verifyCameraPosition(mapboxMap, centerBounds, mapboxMap.getCameraPosition().zoom, 0, 0);
+            animationIdlingResource.decrement();
+          }
+
+          @Override
+          public void onFinish() {
+            verifyCameraPosition(mapboxMap, centerBounds, mapboxMap.getCameraPosition().zoom, 0, 0);
+            animationIdlingResource.decrement();
+          }
+        });
     });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testEaseToMoveBy() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       final PointF centerPoint = mapboxMap.getProjection().toScreenLocation(mapboxMap.getCameraPosition().target);
       final LatLng moveTarget = new LatLng(2, 2);
       final PointF moveTargetPoint = mapboxMap.getProjection().toScreenLocation(moveTarget);
+
+      animationIdlingResource.increment();
       mapboxMap.easeCamera(CameraUpdateFactory.scrollBy(
-        moveTargetPoint.x - centerPoint.x, moveTargetPoint.y - centerPoint.y));
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera position latitude should match", cameraPosition.target.getLatitude(),
-        moveTarget.getLatitude(), TestConstants.LAT_LNG_DELTA_LARGE);
-      assertEquals("Moved camera position longitude should match", cameraPosition.target.getLongitude(),
-        moveTarget.getLongitude(), TestConstants.LAT_LNG_DELTA_LARGE);
+        moveTargetPoint.x - centerPoint.x, moveTargetPoint.y - centerPoint.y),
+        new MapboxMap.CancelableCallback() {
+          @Override
+          public void onCancel() {
+            verifyCameraPosition(mapboxMap, moveTarget, mapboxMap.getCameraPosition().zoom, 0, 0);
+            animationIdlingResource.decrement();
+          }
+
+          @Override
+          public void onFinish() {
+            verifyCameraPosition(mapboxMap, moveTarget, mapboxMap.getCameraPosition().zoom, 0, 0);
+            animationIdlingResource.decrement();
+          }
+        });
     });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testEaseToZoomIn() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       float zoom = 1.0f;
-      mapboxMap.easeCamera(CameraUpdateFactory.zoomIn());
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera zoom should match moved camera zoom", cameraPosition.zoom, zoom + 1,
-        TestConstants.ZOOM_DELTA);
+
+      animationIdlingResource.increment();
+      mapboxMap.easeCamera(CameraUpdateFactory.zoomIn(), new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom + 1, 0, 0);
+          animationIdlingResource.decrement();
+        }
+
+        @Override
+        public void onFinish() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom + 1, 0, 0);
+          animationIdlingResource.decrement();
+        }
+      });
     });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testEaseToZoomOut() {
+    float zoom = 10.0f;
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
-      float zoom = 10.0f;
-      mapboxMap.easeCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(), zoom));
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      mapboxMap.easeCamera(CameraUpdateFactory.zoomOut());
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera zoom should match moved camera zoom", cameraPosition.zoom, zoom - 1,
-        TestConstants.ZOOM_DELTA);
+      animationIdlingResource.increment();
+      mapboxMap.easeCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(), zoom), new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom, 0, 0);
+          animationIdlingResource.decrement();
+        }
+
+        @Override
+        public void onFinish() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom, 0, 0);
+          animationIdlingResource.decrement();
+        }
+      });
     });
+
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      animationIdlingResource.increment();
+      mapboxMap.easeCamera(CameraUpdateFactory.zoomOut(), new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom - 1, 0, 0);
+          animationIdlingResource.decrement();
+        }
+
+        @Override
+        public void onFinish() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom - 1, 0, 0);
+          animationIdlingResource.decrement();
+        }
+      });
+    });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testEaseToZoomBy() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       float zoom = 1.0f;
       final float zoomBy = 2.45f;
-      mapboxMap.easeCamera(CameraUpdateFactory.zoomBy(zoomBy));
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera zoom should match moved camera zoom", cameraPosition.zoom, zoom + zoomBy,
-        TestConstants.ZOOM_DELTA);
+
+      animationIdlingResource.increment();
+      mapboxMap.easeCamera(CameraUpdateFactory.zoomBy(zoomBy), new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom + zoomBy, 0, 0);
+          animationIdlingResource.decrement();
+        }
+
+        @Override
+        public void onFinish() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom + zoomBy, 0, 0);
+          animationIdlingResource.decrement();
+        }
+      });
     });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testEaseToZoomTo() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       final float zoomTo = 2.45f;
-      mapboxMap.easeCamera(CameraUpdateFactory.zoomTo(zoomTo));
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera zoom should match moved camera zoom", cameraPosition.zoom, zoomTo,
-        TestConstants.ZOOM_DELTA);
+      mapboxMap.easeCamera(CameraUpdateFactory.zoomTo(zoomTo), new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoomTo, 0, 0);
+          animationIdlingResource.decrement();
+        }
+
+        @Override
+        public void onFinish() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoomTo, 0, 0);
+          animationIdlingResource.decrement();
+        }
+      });
     });
+
+    Espresso.onIdle();
+  }
+
+  @Override
+  public void afterTest() {
+    super.afterTest();
+    IdlingRegistry.getInstance().unregister(animationIdlingResource);
+  }
+
+  private void verifyCameraPosition(MapboxMap mapboxMap, LatLng moveTarget, double moveZoom, double moveBearing,
+                                    double moveTilt) {
+    CameraPosition cameraPosition = mapboxMap.getCameraPosition();
+    assertEquals("Moved camera position latitude should match", cameraPosition.target.getLatitude(),
+      moveTarget.getLatitude(), TestConstants.LAT_LNG_DELTA);
+    assertEquals("Moved camera position longitude should match", cameraPosition.target.getLongitude(),
+      moveTarget.getLongitude(), TestConstants.LAT_LNG_DELTA);
+    assertEquals("Moved zoom should match", cameraPosition.zoom, moveZoom, TestConstants.ZOOM_DELTA);
+    assertEquals("Moved zoom should match", cameraPosition.tilt, moveTilt, TestConstants.TILT_DELTA);
+    assertEquals("Moved bearing should match", cameraPosition.bearing, moveBearing, TestConstants.BEARING_DELTA);
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraEaseTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraEaseTest.java
@@ -14,7 +14,6 @@ import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 import com.mapbox.mapboxsdk.testapp.activity.espresso.DeviceIndependentTestActivity;
 import com.mapbox.mapboxsdk.testapp.utils.TestConstants;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke;
@@ -285,6 +284,8 @@ public class CameraEaseTest extends BaseActivityTest {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       final float zoomTo = 2.45f;
+
+      animationIdlingResource.increment();
       mapboxMap.easeCamera(CameraUpdateFactory.zoomTo(zoomTo), new MapboxMap.CancelableCallback() {
         @Override
         public void onCancel() {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraMoveTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraMoveTest.java
@@ -2,16 +2,19 @@
 package com.mapbox.mapboxsdk.testapp.camera;
 
 import android.graphics.PointF;
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.IdlingRegistry;
+import android.support.test.espresso.idling.CountingIdlingResource;
 
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 import com.mapbox.mapboxsdk.testapp.activity.espresso.DeviceIndependentTestActivity;
 import com.mapbox.mapboxsdk.testapp.utils.TestConstants;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke;
@@ -19,13 +22,21 @@ import static org.junit.Assert.assertEquals;
 
 public class CameraMoveTest extends BaseActivityTest {
 
+  private final CountingIdlingResource animationIdlingResource =
+    new CountingIdlingResource("animation_idling_resource");
+
   @Override
   protected Class getActivityClass() {
     return DeviceIndependentTestActivity.class;
   }
 
+  @Override
+  public void beforeTest() {
+    super.beforeTest();
+    IdlingRegistry.getInstance().register(animationIdlingResource);
+  }
+
   @Test
-  @Ignore
   public void testMoveToCameraPositionTarget() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -35,36 +46,53 @@ public class CameraMoveTest extends BaseActivityTest {
         new LatLng()).zoom(zoom).bearing(0).tilt(0).build();
       CameraPosition cameraPosition = mapboxMap.getCameraPosition();
       assertEquals("Default camera position should match default", cameraPosition, initialPosition);
-      mapboxMap.moveCamera(CameraUpdateFactory.newLatLng(moveTarget));
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera position latitude should match", cameraPosition.target.getLatitude(),
-        moveTarget.getLatitude(), TestConstants.LAT_LNG_DELTA);
-      assertEquals("Moved camera position longitude should match", cameraPosition.target.getLongitude(),
-        moveTarget.getLongitude(), TestConstants.LAT_LNG_DELTA);
+
+      animationIdlingResource.increment();
+      mapboxMap.moveCamera(CameraUpdateFactory.newLatLng(moveTarget), new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          verifyCameraPosition(mapboxMap, moveTarget, zoom, 0, 0);
+          animationIdlingResource.decrement();
+        }
+
+        @Override
+        public void onFinish() {
+          verifyCameraPosition(mapboxMap, moveTarget, zoom, 0, 0);
+          animationIdlingResource.decrement();
+        }
+      });
     });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testMoveToCameraPositionTargetZoom() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       final float moveZoom = 15.5f;
       final LatLng moveTarget = new LatLng(1.0000000001, 1.0000000003);
-      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(moveTarget, moveZoom));
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera position latitude should match", cameraPosition.target.getLatitude(),
-        moveTarget.getLatitude(), TestConstants.LAT_LNG_DELTA);
-      assertEquals("Moved camera position longitude should match", cameraPosition.target.getLongitude(),
-        moveTarget.getLongitude(), TestConstants.LAT_LNG_DELTA);
-      assertEquals("Moved zoom should match", cameraPosition.zoom, moveZoom, TestConstants.ZOOM_DELTA);
+
+      animationIdlingResource.increment();
+      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(moveTarget, moveZoom), new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          verifyCameraPosition(mapboxMap, moveTarget, moveZoom, 0, 0);
+          animationIdlingResource.decrement();
+        }
+
+        @Override
+        public void onFinish() {
+          verifyCameraPosition(mapboxMap, moveTarget, moveZoom, 0, 0);
+          animationIdlingResource.decrement();
+        }
+      });
     });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testMoveToCameraPosition() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -73,28 +101,33 @@ public class CameraMoveTest extends BaseActivityTest {
       final float moveTilt = 45.5f;
       final float moveBearing = 12.5f;
 
+      animationIdlingResource.increment();
       mapboxMap.moveCamera(CameraUpdateFactory.newCameraPosition(
         new CameraPosition.Builder()
           .target(moveTarget)
           .zoom(moveZoom)
           .tilt(moveTilt)
           .bearing(moveBearing)
-          .build())
-      );
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera position latitude should match", cameraPosition.target.getLatitude(),
-        moveTarget.getLatitude(), TestConstants.LAT_LNG_DELTA);
-      assertEquals("Moved camera position longitude should match", cameraPosition.target.getLongitude(),
-        moveTarget.getLongitude(), TestConstants.LAT_LNG_DELTA);
-      assertEquals("Moved zoom should match", cameraPosition.zoom, moveZoom, TestConstants.ZOOM_DELTA);
-      assertEquals("Moved zoom should match", cameraPosition.tilt, moveTilt, TestConstants.TILT_DELTA);
-      assertEquals("Moved bearing should match", cameraPosition.bearing, moveBearing, TestConstants.BEARING_DELTA);
+          .build()),
+        new MapboxMap.CancelableCallback() {
+          @Override
+          public void onCancel() {
+            verifyCameraPosition(mapboxMap, moveTarget, moveZoom, moveBearing, moveTilt);
+            animationIdlingResource.decrement();
+          }
+
+          @Override
+          public void onFinish() {
+            verifyCameraPosition(mapboxMap, moveTarget, moveZoom, moveBearing, moveTilt);
+            animationIdlingResource.decrement();
+          }
+        });
     });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testMoveToBounds() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
@@ -104,96 +137,188 @@ public class CameraMoveTest extends BaseActivityTest {
       final LatLngBounds.Builder builder = new LatLngBounds.Builder();
       builder.include(cornerOne);
       builder.include(cornerTwo);
-      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngBounds(builder.build(), 0));
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera position latitude should match center bounds",
-        cameraPosition.target.getLatitude(),
-        centerBounds.getLatitude(),
-        TestConstants.LAT_LNG_DELTA);
-      assertEquals("Moved camera position longitude should match center bounds",
-        cameraPosition.target.getLongitude(),
-        centerBounds.getLongitude(),
-        TestConstants.LAT_LNG_DELTA);
+
+      animationIdlingResource.increment();
+      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngBounds(builder.build(), 0),
+        new MapboxMap.CancelableCallback() {
+          @Override
+          public void onCancel() {
+            verifyCameraPosition(mapboxMap, centerBounds, mapboxMap.getCameraPosition().zoom, 0, 0);
+            animationIdlingResource.decrement();
+          }
+
+          @Override
+          public void onFinish() {
+            verifyCameraPosition(mapboxMap, centerBounds, mapboxMap.getCameraPosition().zoom, 0, 0);
+            animationIdlingResource.decrement();
+          }
+        });
     });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testMoveToMoveBy() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       final PointF centerPoint = mapboxMap.getProjection().toScreenLocation(mapboxMap.getCameraPosition().target);
       final LatLng moveTarget = new LatLng(2, 2);
       final PointF moveTargetPoint = mapboxMap.getProjection().toScreenLocation(moveTarget);
+
+      animationIdlingResource.increment();
       mapboxMap.moveCamera(CameraUpdateFactory.scrollBy(
-        moveTargetPoint.x - centerPoint.x, moveTargetPoint.y - centerPoint.y));
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera position latitude should match", cameraPosition.target.getLatitude(),
-        moveTarget.getLatitude(), TestConstants.LAT_LNG_DELTA_LARGE);
-      assertEquals("Moved camera position longitude should match", cameraPosition.target.getLongitude(),
-        moveTarget.getLongitude(), TestConstants.LAT_LNG_DELTA_LARGE);
+        moveTargetPoint.x - centerPoint.x, moveTargetPoint.y - centerPoint.y),
+        new MapboxMap.CancelableCallback() {
+          @Override
+          public void onCancel() {
+            verifyCameraPosition(mapboxMap, moveTarget, mapboxMap.getCameraPosition().zoom, 0, 0);
+            animationIdlingResource.decrement();
+          }
+
+          @Override
+          public void onFinish() {
+            verifyCameraPosition(mapboxMap, moveTarget, mapboxMap.getCameraPosition().zoom, 0, 0);
+            animationIdlingResource.decrement();
+          }
+        });
     });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testMoveToZoomIn() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       float zoom = 1.0f;
-      mapboxMap.moveCamera(CameraUpdateFactory.zoomIn());
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera zoom should match moved camera zoom", cameraPosition.zoom, zoom + 1,
-        TestConstants.ZOOM_DELTA);
+
+      animationIdlingResource.increment();
+      mapboxMap.moveCamera(CameraUpdateFactory.zoomIn(), new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom + 1, 0, 0);
+          animationIdlingResource.decrement();
+        }
+
+        @Override
+        public void onFinish() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom + 1, 0, 0);
+          animationIdlingResource.decrement();
+        }
+      });
     });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testMoveToZoomOut() {
+    float zoom = 10.0f;
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
-      float zoom = 10.0f;
-      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(), zoom));
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      mapboxMap.moveCamera(CameraUpdateFactory.zoomOut());
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera zoom should match moved camera zoom", cameraPosition.zoom, zoom - 1,
-        TestConstants.ZOOM_DELTA);
+      animationIdlingResource.increment();
+      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(), zoom), new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom, 0, 0);
+          animationIdlingResource.decrement();
+        }
+
+        @Override
+        public void onFinish() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom, 0, 0);
+          animationIdlingResource.decrement();
+        }
+      });
     });
+
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      animationIdlingResource.increment();
+      mapboxMap.moveCamera(CameraUpdateFactory.zoomOut(), new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom - 1, 0, 0);
+          animationIdlingResource.decrement();
+        }
+
+        @Override
+        public void onFinish() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom - 1, 0, 0);
+          animationIdlingResource.decrement();
+        }
+      });
+    });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testMoveToZoomBy() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       float zoom = 1.0f;
       final float zoomBy = 2.45f;
-      mapboxMap.moveCamera(CameraUpdateFactory.zoomBy(zoomBy));
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera zoom should match moved camera zoom", cameraPosition.zoom, zoom + zoomBy,
-        TestConstants.ZOOM_DELTA);
+
+      animationIdlingResource.increment();
+      mapboxMap.moveCamera(CameraUpdateFactory.zoomBy(zoomBy), new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom + zoomBy, 0, 0);
+          animationIdlingResource.decrement();
+        }
+
+        @Override
+        public void onFinish() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoom + zoomBy, 0, 0);
+          animationIdlingResource.decrement();
+        }
+      });
     });
+
+    Espresso.onIdle();
   }
 
   @Test
-  @Ignore
   public void testMoveToZoomTo() {
     validateTestSetup();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       final float zoomTo = 2.45f;
-      mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(zoomTo));
-      uiController.loopMainThreadForAtLeast(TestConstants.ANIMATION_TEST_TIME);
-      CameraPosition cameraPosition = mapboxMap.getCameraPosition();
-      assertEquals("Moved camera zoom should match moved camera zoom", cameraPosition.zoom, zoomTo,
-        TestConstants.ZOOM_DELTA);
+
+      animationIdlingResource.increment();
+      mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(zoomTo), new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoomTo, 0, 0);
+          animationIdlingResource.decrement();
+        }
+
+        @Override
+        public void onFinish() {
+          verifyCameraPosition(mapboxMap, mapboxMap.getCameraPosition().target, zoomTo, 0, 0);
+          animationIdlingResource.decrement();
+        }
+      });
     });
+
+    Espresso.onIdle();
+  }
+
+  @Override
+  public void afterTest() {
+    super.afterTest();
+    IdlingRegistry.getInstance().unregister(animationIdlingResource);
+  }
+
+  private void verifyCameraPosition(MapboxMap mapboxMap, LatLng moveTarget, double moveZoom, double moveBearing,
+                                    double moveTilt) {
+    CameraPosition cameraPosition = mapboxMap.getCameraPosition();
+    assertEquals("Moved camera position latitude should match", cameraPosition.target.getLatitude(),
+      moveTarget.getLatitude(), TestConstants.LAT_LNG_DELTA);
+    assertEquals("Moved camera position longitude should match", cameraPosition.target.getLongitude(),
+      moveTarget.getLongitude(), TestConstants.LAT_LNG_DELTA);
+    assertEquals("Moved zoom should match", cameraPosition.zoom, moveZoom, TestConstants.ZOOM_DELTA);
+    assertEquals("Moved zoom should match", cameraPosition.tilt, moveTilt, TestConstants.TILT_DELTA);
+    assertEquals("Moved bearing should match", cameraPosition.bearing, moveBearing, TestConstants.BEARING_DELTA);
   }
 }
-


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gl-native/pull/12822.

Reworks camera tests to use cancelable callback instead of delay loops.