### PR TITLE
Move "pending test" check into `invokeTest`

### DIFF
--- a/platform/ios/Integration Tests/MGLCameraTransitionTests.mm
+++ b/platform/ios/Integration Tests/MGLCameraTransitionTests.mm
@@ -334,8 +334,6 @@
 #pragma mark - Pending tests
 
 - (void)testContinuallyResettingNorthInIsChangingPENDING {
-    MGL_CHECK_IF_PENDING_TEST_SHOULD_RUN();
-
     // See https://github.com/mapbox/mapbox-gl-native/pull/11614
     // This test currently fails, unsurprisingly, since we're continually
     // setting the camera to the same parameters during its update.
@@ -369,7 +367,6 @@
 
 - (void)testContinuallySettingCoordinateInIsChangingPENDING {
     // See above comment in `-testContinuallyResettingNorthInIsChangingPENDING`
-    MGL_CHECK_IF_PENDING_TEST_SHOULD_RUN();
 
     // Reset to non-zero, prior to testing
     [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(0.0, 0.0) animated:NO];

--- a/platform/ios/Integration Tests/MGLMapViewIntegrationTest.m
+++ b/platform/ios/Integration Tests/MGLMapViewIntegrationTest.m
@@ -6,6 +6,21 @@
 
 @implementation MGLMapViewIntegrationTest
 
+- (void)invokeTest {
+    NSString *selector = NSStringFromSelector(self.invocation.selector);
+    BOOL isPendingTest = [selector hasSuffix:@"PENDING"];
+    
+    if (isPendingTest) {
+        NSString *runPendingTests = [[NSProcessInfo processInfo] environment][@"MAPBOX_RUN_PENDING_TESTS"];
+        if (![runPendingTests boolValue]) {
+            printf("warning: '%s' is a pending test - skipping\n", selector.UTF8String);
+            return;
+        }
+    }
+
+    [super invokeTest];
+}
+
 - (NSString*)validAccessToken {
     NSString *accessToken = [[NSProcessInfo processInfo] environment][@"MAPBOX_ACCESS_TOKEN"];
     if (!accessToken) {

--- a/platform/ios/Integration Tests/Snapshotter Tests/MGLMapSnapshotterTest.m
+++ b/platform/ios/Integration Tests/Snapshotter Tests/MGLMapSnapshotterTest.m
@@ -282,7 +282,7 @@ MGLMapSnapshotter* snapshotterWithCoordinates(CLLocationCoordinate2D coordinates
 }
 
 - (void)testMultipleSnapshottersPENDING {
-    MGL_CHECK_IF_PENDING_TEST_SHOULD_RUN();
+
     if (![self validAccessToken]) {
         return;
     }

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -1027,7 +1027,7 @@
 		ACA65F552140696B00537748 /* MMEDispatchManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MMEDispatchManager.h; path = "vendor/mapbox-events-ios/MapboxMobileEvents/MMEDispatchManager.h"; sourceTree = SOURCE_ROOT; };
 		ACA65F562140697100537748 /* MMEDispatchManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MMEDispatchManager.m; path = "vendor/mapbox-events-ios/MapboxMobileEvents/MMEDispatchManager.m"; sourceTree = SOURCE_ROOT; };
 		CA0C27912076C804001CE5B7 /* MGLShapeSourceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLShapeSourceTests.m; sourceTree = "<group>"; };
-		CA0C27932076CA19001CE5B7 /* MGLMapViewIntegrationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLMapViewIntegrationTest.m; sourceTree = "<group>"; };
+		CA0C27932076CA19001CE5B7 /* MGLMapViewIntegrationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLMapViewIntegrationTest.m; sourceTree = "<group>"; wrapsLines = 0; };
 		CA0C27952076CA50001CE5B7 /* MGLMapViewIntegrationTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLMapViewIntegrationTest.h; sourceTree = "<group>"; };
 		CA1B4A502099FB2200EDD491 /* MGLMapSnapshotterTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLMapSnapshotterTest.m; sourceTree = "<group>"; };
 		CA34C9C2207FD272005C1A06 /* MGLCameraTransitionTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLCameraTransitionTests.mm; sourceTree = "<group>"; };


### PR DESCRIPTION
This PR moves the check for a "pending test" out of the body of the test, instead running the check before `setup` gets called.

For this to work, it requires that pending tests have the suffix `PENDING`. `xcpretty` also picks this up: pending tests will be distinguished by a `⧖` and `[PENDING]` in the build log on CI.

This should help reduce the number of false positive timing-related test fails (e.g. see https://circleci.com/gh/mapbox/mapbox-gl-native/162451).

I've left the macro in place since it's currently being used by non-integration tests too.