### PR TITLE
Fix MGLMapCamera initialization and viewing distance calculations

### DIFF
--- a/platform/darwin/src/MGLMapCamera.h
+++ b/platform/darwin/src/MGLMapCamera.h
@@ -49,7 +49,11 @@ MGL_EXPORT
 
 /**
  Returns a new camera with the given distance, pitch, and heading.
-
+ 
+ This method interprets the distance as a straight-line distance from the
+ viewpoint to the center coordinate. To specify the altitude of the viewpoint,
+ use the `-cameraLookingAtCenterCoordinate:altitude:pitch:heading:` method.
+ 
  @param centerCoordinate The geographic coordinate on which the map should be
     centered.
  @param distance The straight-line distance from the viewpoint to the
@@ -63,9 +67,45 @@ MGL_EXPORT
     The value `180` means the top of the map points due south, and so on.
  */
 + (instancetype)cameraLookingAtCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate
-                                   fromDistance:(CLLocationDistance)distance
+                                 acrossDistance:(CLLocationDistance)distance
                                           pitch:(CGFloat)pitch
                                         heading:(CLLocationDirection)heading;
+
+/**
+ Returns a new camera with the given altitude, pitch, and heading.
+
+ @param centerCoordinate The geographic coordinate on which the map should be
+    centered.
+ @param altitude The altitude (measured in meters) above the map at which the
+    camera should be situated. The altitude may be less than the distance from
+    the camera’s viewpoint to the camera’s focus point.
+ @param pitch The viewing angle of the camera, measured in degrees. A value of
+    `0` results in a camera pointed straight down at the map. Angles greater
+    than `0` result in a camera angled toward the horizon.
+ @param heading The camera’s heading, measured in degrees clockwise from true
+    north. A value of `0` means that the top edge of the map view corresponds to
+    true north. The value `90` means the top of the map is pointing due east.
+    The value `180` means the top of the map points due south, and so on.
+ */
++ (instancetype)cameraLookingAtCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate
+                                       altitude:(CLLocationDistance)altitude
+                                          pitch:(CGFloat)pitch
+                                        heading:(CLLocationDirection)heading;
+
+/**
+ @note This initializer incorrectly interprets the `distance` parameter. To
+    specify the straight-line distance from the viewpoint to `centerCoordinate`,
+    use the `-cameraLookingAtCenterCoordinate:acrossDistance:pitch:heading:`
+    method. To specify the altitude of the viewpoint, use the
+    `-cameraLookingAtCenterCoordinate:altitude:pitch:heading:` method, which has
+    the same behavior as this initializer.
+ */
++ (instancetype)cameraLookingAtCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate
+                                   fromDistance:(CLLocationDistance)distance
+                                          pitch:(CGFloat)pitch
+                                        heading:(CLLocationDirection)heading
+__attribute__((deprecated("Use -cameraLookingAtCenterCoordinate:acrossDistance:pitch:heading: "
+                          "or -cameraLookingAtCenterCoordinate:altitude:pitch:heading:.")));
 
 /**
  Returns a Boolean value indicating whether the given camera is functionally

--- a/platform/darwin/src/MGLMapCamera.h
+++ b/platform/darwin/src/MGLMapCamera.h
@@ -25,8 +25,26 @@ MGL_EXPORT
  */
 @property (nonatomic) CGFloat pitch;
 
-/** Meters above ground level. */
+/**
+ The altitude (measured in meters) above the map at which the camera is
+ situated.
+ 
+ The altitude is the distance from the viewpoint to the map, perpendicular to
+ the map plane. This property does not account for physical elevation.
+ 
+ This property’s value may be less than that of the `viewingDistance` property.
+ Setting this property automatically updates the `viewingDistance` property
+ based on the `pitch` property’s current value.
+ */
 @property (nonatomic) CLLocationDistance altitude;
+
+/**
+ The straight-line distance from the viewpoint to the `centerCoordinate`.
+ 
+ Setting this property automatically updates the `altitude` property based on
+ the `pitch` property’s current value.
+ */
+@property (nonatomic) CLLocationDistance viewingDistance;
 
 /** Returns a new camera with all properties set to 0. */
 + (instancetype)camera;

--- a/platform/darwin/src/MGLMapCamera.mm
+++ b/platform/darwin/src/MGLMapCamera.mm
@@ -47,14 +47,43 @@ BOOL MGLEqualFloatWithAccuracy(CGFloat left, CGFloat right, CGFloat accuracy)
 }
 
 + (instancetype)cameraLookingAtCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate
-                                   fromDistance:(CLLocationDistance)distance
+                                 acrossDistance:(CLLocationDistance)distance
+                                          pitch:(CGFloat)pitch
+                                        heading:(CLLocationDirection)heading
+{
+    // Angle at the viewpoint formed by the straight lines running perpendicular
+    // to the ground and toward the center coordinate.
+    CLLocationDirection eyeAngle = 90 - pitch;
+    CLLocationDistance altitude = distance * sin(MGLRadiansFromDegrees(eyeAngle));
+    
+    return [[self alloc] initWithCenterCoordinate:centerCoordinate
+                                         altitude:altitude
+                                            pitch:pitch
+                                          heading:heading];
+}
+
++ (instancetype)cameraLookingAtCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate
+                                       altitude:(CLLocationDistance)altitude
                                           pitch:(CGFloat)pitch
                                         heading:(CLLocationDirection)heading
 {
     return [[self alloc] initWithCenterCoordinate:centerCoordinate
-                                         altitude:distance
+                                         altitude:altitude
                                             pitch:pitch
                                           heading:heading];
+}
+
++ (instancetype)cameraLookingAtCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate
+                                   fromDistance:(CLLocationDistance)distance
+                                          pitch:(CGFloat)pitch
+                                        heading:(CLLocationDirection)heading
+{
+    // TODO: Remove this compatibility shim in favor of `-cameraLookingAtCenterCoordinate:acrossDistance:pitch:heading:.
+    // https://github.com/mapbox/mapbox-gl-native/issues/12943
+    return [MGLMapCamera cameraLookingAtCenterCoordinate:centerCoordinate
+                                                altitude:distance
+                                                   pitch:pitch
+                                                 heading:heading];
 }
 
 - (instancetype)initWithCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate

--- a/platform/darwin/src/MGLMapCamera.mm
+++ b/platform/darwin/src/MGLMapCamera.mm
@@ -131,6 +131,20 @@ BOOL MGLEqualFloatWithAccuracy(CGFloat left, CGFloat right, CGFloat accuracy)
                                                                heading:_heading];
 }
 
++ (NSSet<NSString *> *)keyPathsForValuesAffectingViewingDistance {
+    return [NSSet setWithObjects:@"altitude", @"pitch", nil];
+}
+
+- (CLLocationDistance)viewingDistance {
+    CLLocationDirection eyeAngle = 90 - self.pitch;
+    return self.altitude / sin(MGLRadiansFromDegrees(eyeAngle));
+}
+
+- (void)setViewingDistance:(CLLocationDistance)distance {
+    CLLocationDirection eyeAngle = 90 - self.pitch;
+    self.altitude = distance * sin(MGLRadiansFromDegrees(eyeAngle));
+}
+
 - (NSString *)description
 {
     return [NSString stringWithFormat:@"<%@: %p; centerCoordinate = %f, %f; altitude = %.0fm; heading = %.0f°; pitch = %.0f°>",

--- a/platform/darwin/src/MGLMapSnapshotter.h
+++ b/platform/darwin/src/MGLMapSnapshotter.h
@@ -149,7 +149,7 @@ typedef void (^MGLMapSnapshotCompletionHandler)(MGLMapSnapshot* _Nullable snapsh
  ### Example
  
  ```swift
- let camera = MGLMapCamera(lookingAtCenter: CLLocationCoordinate2D(latitude: 37.7184, longitude: -122.4365), fromDistance: 100, pitch: 20, heading: 0)
+ let camera = MGLMapCamera(lookingAtCenter: CLLocationCoordinate2D(latitude: 37.7184, longitude: -122.4365), altitude: 100, pitch: 20, heading: 0)
  
  let options = MGLMapSnapshotOptions(styleURL: MGLStyle.satelliteStreetsStyleURL, camera: camera, size: CGSize(width: 320, height: 480))
  options.zoomLevel = 10

--- a/platform/darwin/test/MGLDocumentationExampleTests.swift
+++ b/platform/darwin/test/MGLDocumentationExampleTests.swift
@@ -376,7 +376,7 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
         }
         
         //#-example-code
-        let camera = MGLMapCamera(lookingAtCenter: CLLocationCoordinate2D(latitude: 37.7184, longitude: -122.4365), fromDistance: 100, pitch: 20, heading: 0)
+        let camera = MGLMapCamera(lookingAtCenter: CLLocationCoordinate2D(latitude: 37.7184, longitude: -122.4365), altitude: 100, pitch: 20, heading: 0)
 
         let options = MGLMapSnapshotOptions(styleURL: MGLStyle.satelliteStreetsStyleURL, camera: camera, size: CGSize(width: 320, height: 480))
         options.zoomLevel = 10

--- a/platform/darwin/test/MGLMapCameraTests.m
+++ b/platform/darwin/test/MGLMapCameraTests.m
@@ -9,6 +9,45 @@
 
 @implementation MGLMapCameraTests
 
+- (void)testEyeCoordinateInitialization {
+    CLLocationCoordinate2D fountainSquare = CLLocationCoordinate2DMake(39.10152215, -84.5124439696089);
+    CLLocationCoordinate2D unionTerminal = CLLocationCoordinate2DMake(39.10980955, -84.5352778794236);
+    
+    MGLMapCamera *camera = [MGLMapCamera cameraLookingAtCenterCoordinate:fountainSquare
+                                                       fromEyeCoordinate:fountainSquare
+                                                             eyeAltitude:1000];
+    MKMapCamera *mkCamera = [MKMapCamera cameraLookingAtCenterCoordinate:fountainSquare
+                                                       fromEyeCoordinate:fountainSquare
+                                                             eyeAltitude:1000];
+    XCTAssertEqual(camera.centerCoordinate.latitude, fountainSquare.latitude);
+    XCTAssertEqual(camera.centerCoordinate.longitude, fountainSquare.longitude);
+    XCTAssertEqual(camera.centerCoordinate.latitude, mkCamera.centerCoordinate.latitude);
+    XCTAssertEqual(camera.centerCoordinate.longitude, mkCamera.centerCoordinate.longitude);
+    XCTAssertEqual(camera.altitude, 1000, @"Eye altitude should be equivalent to altitude in untilted camera.");
+    XCTAssertEqual(camera.altitude, mkCamera.altitude, @"Eye altitude in untilted camera should match MapKit.");
+    XCTAssertEqual(camera.pitch, 0, @"Camera directly over center coordinate should be untilted.");
+    XCTAssertEqual(camera.pitch, mkCamera.pitch, @"Camera directly over center coordinate should have same pitch as MapKit.");
+    XCTAssertEqual(camera.heading, 0, @"Camera directly over center coordinate should be unrotated.");
+    XCTAssertEqual(camera.heading, mkCamera.heading, @"Camera directly over center coordinate should have same heading as MapKit.");
+    
+    camera = [MGLMapCamera cameraLookingAtCenterCoordinate:fountainSquare
+                                         fromEyeCoordinate:unionTerminal
+                                               eyeAltitude:1000];
+    mkCamera = [MKMapCamera cameraLookingAtCenterCoordinate:fountainSquare
+                                          fromEyeCoordinate:unionTerminal
+                                                eyeAltitude:1000];
+    XCTAssertEqual(camera.centerCoordinate.latitude, fountainSquare.latitude);
+    XCTAssertEqual(camera.centerCoordinate.longitude, fountainSquare.longitude);
+    XCTAssertEqual(camera.centerCoordinate.latitude, mkCamera.centerCoordinate.latitude);
+    XCTAssertEqual(camera.centerCoordinate.longitude, mkCamera.centerCoordinate.longitude);
+    XCTAssertEqual(camera.altitude, 1000);
+    XCTAssertEqual(camera.altitude, mkCamera.altitude, @"Eye altitude in tilted camera should match MapKit.");
+    XCTAssertEqualWithAccuracy(camera.pitch, 65.3469146074, 0.01);
+    XCTAssertEqual(camera.pitch, mkCamera.pitch);
+    XCTAssertEqualWithAccuracy(camera.heading, 115.066396383, 0.01);
+    XCTAssertEqualWithAccuracy(camera.heading, mkCamera.heading, 0.01);
+}
+
 - (void)testViewingDistanceInitialization {
     CLLocationCoordinate2D fountainSquare = CLLocationCoordinate2DMake(39.10152215, -84.5124439696089);
     MGLMapCamera *camera = [MGLMapCamera cameraLookingAtCenterCoordinate:fountainSquare

--- a/platform/darwin/test/MGLMapCameraTests.m
+++ b/platform/darwin/test/MGLMapCameraTests.m
@@ -9,7 +9,7 @@
 
 @implementation MGLMapCameraTests
 
-- (void)testViewingDistance {
+- (void)testViewingDistanceInitialization {
     CLLocationCoordinate2D fountainSquare = CLLocationCoordinate2DMake(39.10152215, -84.5124439696089);
     MGLMapCamera *camera = [MGLMapCamera cameraLookingAtCenterCoordinate:fountainSquare
                                                           acrossDistance:10000
@@ -44,6 +44,24 @@
                                                      pitch:60
                                                    heading:0];
     XCTAssertEqual(camera.altitude, 10000, @"Tilted camera should use altitude verbatim.");
+}
+
+- (void)testViewingDistance {
+    MGLMapCamera *camera = [MGLMapCamera camera];
+    camera.altitude = 10000;
+    XCTAssertEqual(camera.altitude, 10000);
+    XCTAssertEqual(camera.viewingDistance, 10000);
+    camera.viewingDistance = 10000;
+    XCTAssertEqual(camera.altitude, 10000);
+    XCTAssertEqual(camera.viewingDistance, 10000);
+    
+    camera.pitch = 60;
+    camera.altitude = 10000;
+    XCTAssertEqual(camera.altitude, 10000);
+    XCTAssertEqualWithAccuracy(camera.viewingDistance, 20000, 0.01);
+    camera.viewingDistance = 10000;
+    XCTAssertEqualWithAccuracy(camera.altitude, 5000, 0.01);
+    XCTAssertEqual(camera.viewingDistance, 10000);
 }
 
 @end

--- a/platform/darwin/test/MGLMapCameraTests.m
+++ b/platform/darwin/test/MGLMapCameraTests.m
@@ -1,0 +1,49 @@
+#import <XCTest/XCTest.h>
+#import <CoreLocation/CoreLocation.h>
+#import <Mapbox/Mapbox.h>
+#import <MapKit/MapKit.h>
+
+@interface MGLMapCameraTests : XCTestCase
+
+@end
+
+@implementation MGLMapCameraTests
+
+- (void)testViewingDistance {
+    CLLocationCoordinate2D fountainSquare = CLLocationCoordinate2DMake(39.10152215, -84.5124439696089);
+    MGLMapCamera *camera = [MGLMapCamera cameraLookingAtCenterCoordinate:fountainSquare
+                                                          acrossDistance:10000
+                                                                   pitch:0
+                                                                 heading:0];
+    MKMapCamera *mkCamera = [MKMapCamera cameraLookingAtCenterCoordinate:fountainSquare
+                                                            fromDistance:10000
+                                                                   pitch:0
+                                                                 heading:0];
+    XCTAssertEqualWithAccuracy(camera.altitude, 10000, 0.01, @"Untilted camera should use distance verbatim.");
+    XCTAssertEqualWithAccuracy(camera.altitude, mkCamera.altitude, 0.01, @"Untilted camera altitude should match MapKit.");
+    
+    camera = [MGLMapCamera cameraLookingAtCenterCoordinate:fountainSquare
+                                                  altitude:10000
+                                                     pitch:0
+                                                   heading:0];
+    XCTAssertEqual(camera.altitude, 10000, @"Untilted camera should use altitude verbatim.");
+    
+    camera = [MGLMapCamera cameraLookingAtCenterCoordinate:fountainSquare
+                                            acrossDistance:10000
+                                                     pitch:60
+                                                   heading:0];
+    mkCamera = [MKMapCamera cameraLookingAtCenterCoordinate:fountainSquare
+                                               fromDistance:10000
+                                                      pitch:60
+                                                    heading:0];
+    XCTAssertEqualWithAccuracy(camera.altitude, 5000, 0.01, @"Tilted camera altitude should account for pitch.");
+    XCTAssertEqualWithAccuracy(camera.altitude, mkCamera.altitude, 0.01, @"Tilted camera altitude should match MapKit.");
+    
+    camera = [MGLMapCamera cameraLookingAtCenterCoordinate:fountainSquare
+                                                  altitude:10000
+                                                     pitch:60
+                                                   heading:0];
+    XCTAssertEqual(camera.altitude, 10000, @"Tilted camera should use altitude verbatim.");
+}
+
+@end

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -18,6 +18,9 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 ### Other changes	
 
 * Added `MGLAltitudeForZoomLevel` and `MGLZoomLevelForAltitude` to public API for conversion between zoom levels and altitudes. ([#12986](https://github.com/mapbox/mapbox-gl-native/pull/12986))
+* Deprecated the `+[MGLMapCamera cameraLookingAtCenterCoordinate:fromDistance:pitch:heading:]` method in favor of `+[MGLMapCamera cameraLookingAtCenterCoordinate:altitude:pitch:heading:]` and `+[MGLMapCamera cameraLookingAtCenterCoordinate:acrossDistance:pitch:heading:]`. ([#12966](https://github.com/mapbox/mapbox-gl-native/pull/12966))
+* Fixed an issue where `+[MGLMapCamera cameraLookingAtCenterCoordinate:fromEyeCoordinate:eyeAltitude:]` created a camera looking from the wrong eye coordinate. ([#12966](https://github.com/mapbox/mapbox-gl-native/pull/12966))
+* Added an `MGLMapCamera.viewingDistance` property based on the existing `MGLMapCamera.altitude` property. ([#12966](https://github.com/mapbox/mapbox-gl-native/pull/12966))
 * Fixed an issue where `-[MGLMapSnapshotter startWithQueue:completionHandler:]` failed to call its completion handler in some cases. ([#12355](https://github.com/mapbox/mapbox-gl-native/pull/12355))
 * Fixed bugs in coercion expression operators ("to-array" applied to empty arrays, "to-color" applied to colors, and "to-number" applied to null) [#12864](https://github.com/mapbox/mapbox-gl-native/pull/12864)
 * Added the `MGLCollisionBehaviorPre4_0` Info.plist key for applications that require the collision detection behavior in version v3.7 of the SDK. ([#12941](https://github.com/mapbox/mapbox-gl-native/pull/12941))

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -1561,7 +1561,7 @@ CLLocationCoordinate2D randomWorldCoordinate() {
 
     [annotations removeObjectAtIndex:0];
     MGLMapCamera *camera = [MGLMapCamera cameraLookingAtCenterCoordinate:nextAnnotation.coordinate
-                                                            fromDistance:10
+                                                          acrossDistance:10
                                                                    pitch:arc4random_uniform(60)
                                                                  heading:arc4random_uniform(360)];
     __weak MBXViewController *weakSelf = self;
@@ -1740,7 +1740,7 @@ CLLocationCoordinate2D randomWorldCoordinate() {
     [self addAnnotations:50 aroundCoordinate:annotation.coordinate radius:100000.0]; // 100km
 
     MGLMapCamera *camera = [MGLMapCamera cameraLookingAtCenterCoordinate:annotation.coordinate
-                                                            fromDistance:10000.0
+                                                                altitude:10000.0
                                                                    pitch:drand48()*60.0
                                                                  heading:drand48()*360];
     [self.mapView flyToCamera:camera

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -450,6 +450,7 @@
 		DA6408DC1DA4E7D300908C90 /* MGLVectorStyleLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = DA6408D91DA4E7D300908C90 /* MGLVectorStyleLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA6408DD1DA4E7D300908C90 /* MGLVectorStyleLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = DA6408DA1DA4E7D300908C90 /* MGLVectorStyleLayer.m */; };
 		DA6408DE1DA4E7D300908C90 /* MGLVectorStyleLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = DA6408DA1DA4E7D300908C90 /* MGLVectorStyleLayer.m */; };
+		DA695426215B1E76002041A4 /* MGLMapCameraTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA695425215B1E75002041A4 /* MGLMapCameraTests.m */; };
 		DA704CC21F65A475004B3F28 /* MGLMapAccessibilityElement.h in Headers */ = {isa = PBXBuildFile; fileRef = DA704CC01F65A475004B3F28 /* MGLMapAccessibilityElement.h */; };
 		DA704CC31F65A475004B3F28 /* MGLMapAccessibilityElement.h in Headers */ = {isa = PBXBuildFile; fileRef = DA704CC01F65A475004B3F28 /* MGLMapAccessibilityElement.h */; };
 		DA704CC41F65A475004B3F28 /* MGLMapAccessibilityElement.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA704CC11F65A475004B3F28 /* MGLMapAccessibilityElement.mm */; };
@@ -1110,6 +1111,7 @@
 		DA618B2B1E68932D00CB7F44 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA6408D91DA4E7D300908C90 /* MGLVectorStyleLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLVectorStyleLayer.h; sourceTree = "<group>"; };
 		DA6408DA1DA4E7D300908C90 /* MGLVectorStyleLayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLVectorStyleLayer.m; sourceTree = "<group>"; };
+		DA695425215B1E75002041A4 /* MGLMapCameraTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MGLMapCameraTests.m; path = ../../darwin/test/MGLMapCameraTests.m; sourceTree = "<group>"; };
 		DA704CBB1F637311004B3F28 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Foundation.strings; sourceTree = "<group>"; };
 		DA704CBC1F637405004B3F28 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = uk; path = uk.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		DA704CBD1F63746E004B3F28 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
@@ -1859,6 +1861,7 @@
 				DA0CD58F1CF56F6A00A5F5A5 /* MGLFeatureTests.mm */,
 				DA2E885C1CC0382C00F24E7B /* MGLGeometryTests.mm */,
 				DA5DB1291FABF1EE001C2326 /* MGLMapAccessibilityElementTests.m */,
+				DA695425215B1E75002041A4 /* MGLMapCameraTests.m */,
 				076171C22139C70900668A35 /* MGLMapViewTests.m */,
 				16376B481FFEED010000563E /* MGLMapViewLayoutTests.m */,
 				9658C154204761FC00D8A674 /* MGLMapViewScaleBarTests.m */,
@@ -2885,6 +2888,7 @@
 				35B8E08C1D6C8B5100E768D2 /* MGLPredicateTests.mm in Sources */,
 				96036A0620059BBA00510F3D /* MGLNSOrthographyAdditionsTests.m in Sources */,
 				1F95931D1E6DE2E900D5B294 /* MGLNSDateAdditionsTests.mm in Sources */,
+				DA695426215B1E76002041A4 /* MGLMapCameraTests.m in Sources */,
 				DD58A4C61D822BD000E1F038 /* MGLExpressionTests.mm in Sources */,
 				3575798B1D502B0C000B822E /* MGLBackgroundStyleLayerTests.mm in Sources */,
 				9658C155204761FC00D8A674 /* MGLMapViewScaleBarTests.m in Sources */,

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2395,9 +2395,9 @@ public:
     auto camera = _mbglMap->getStyle().getDefaultCamera();
     CGFloat pitch = *camera.pitch;
     CLLocationDirection heading = mbgl::util::wrap(*camera.angle, 0., 360.);
-    CLLocationDistance distance = MGLAltitudeForZoomLevel(*camera.zoom, pitch, 0, self.frame.size);
+    CLLocationDistance altitude = MGLAltitudeForZoomLevel(*camera.zoom, pitch, 0, self.frame.size);
     self.camera = [MGLMapCamera cameraLookingAtCenterCoordinate:MGLLocationCoordinate2DFromLatLng(*camera.center)
-                                                   fromDistance:distance
+                                                       altitude:altitude
                                                           pitch:pitch
                                                         heading:heading];
 }
@@ -3472,7 +3472,7 @@ public:
     CLLocationDirection direction = cameraOptions.angle ? mbgl::util::wrap(-MGLDegreesFromRadians(*cameraOptions.angle), 0., 360.) : self.direction;
     CGFloat pitch = cameraOptions.pitch ? MGLDegreesFromRadians(*cameraOptions.pitch) : _mbglMap->getPitch();
     CLLocationDistance altitude = MGLAltitudeForZoomLevel(zoomLevel, pitch, centerCoordinate.latitude, self.frame.size);
-    return [MGLMapCamera cameraLookingAtCenterCoordinate:centerCoordinate fromDistance:altitude pitch:pitch heading:direction];
+    return [MGLMapCamera cameraLookingAtCenterCoordinate:centerCoordinate altitude:altitude pitch:pitch heading:direction];
 }
 
 /// Returns a CameraOptions object that specifies parameters for animating to

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -14,6 +14,9 @@
 ### Other changes	
 
 * Added `MGLAltitudeForZoomLevel` and `MGLZoomLevelForAltitude` to public API for conversion between zoom levels and altitudes. ([#12986](https://github.com/mapbox/mapbox-gl-native/pull/12986))
+* Deprecated the `+[MGLMapCamera cameraLookingAtCenterCoordinate:fromDistance:pitch:heading:]` method in favor of `+[MGLMapCamera cameraLookingAtCenterCoordinate:altitude:pitch:heading:]` and `+[MGLMapCamera cameraLookingAtCenterCoordinate:acrossDistance:pitch:heading:]`. ([#12966](https://github.com/mapbox/mapbox-gl-native/pull/12966))
+* Fixed an issue where `+[MGLMapCamera cameraLookingAtCenterCoordinate:fromEyeCoordinate:eyeAltitude:]` created a camera looking from the wrong eye coordinate. ([#12966](https://github.com/mapbox/mapbox-gl-native/pull/12966))
+* Added an `MGLMapCamera.viewingDistance` property based on the existing `MGLMapCamera.altitude` property. ([#12966](https://github.com/mapbox/mapbox-gl-native/pull/12966))
 * Fixed an issue where `-[MGLMapSnapshotter startWithQueue:completionHandler:]` failed to call its completion handler in some cases. ([#12355](https://github.com/mapbox/mapbox-gl-native/pull/12355))
 * Fixed an issue where `MGLMapView` produced a designable error in Interface Builder storyboards in Xcode 10. ([#12883](https://github.com/mapbox/mapbox-gl-native/pull/12883))
 * Fixed bugs in coercion expression operators ("to-array" applied to empty arrays, "to-color" applied to colors, and "to-number" applied to null) [#12864](https://github.com/mapbox/mapbox-gl-native/pull/12864)

--- a/platform/macos/app/MapDocument.m
+++ b/platform/macos/app/MapDocument.m
@@ -653,7 +653,7 @@ NSArray<id <MGLAnnotation>> *MBXFlattenedShapes(NSArray<id <MGLAnnotation>> *sha
 
     [annotations removeObjectAtIndex:0];
     MGLMapCamera *camera = [MGLMapCamera cameraLookingAtCenterCoordinate:nextAnnotation.coordinate
-                                                            fromDistance:0
+                                                          acrossDistance:0
                                                                    pitch:arc4random_uniform(60)
                                                                  heading:arc4random_uniform(360)];
     __weak MapDocument *weakSelf = self;

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		DA57D4B11EBC699800793288 /* MGLDocumentationGuideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA57D4B01EBC699800793288 /* MGLDocumentationGuideTests.swift */; };
 		DA6408D71DA4E5DA00908C90 /* MGLVectorStyleLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = DA6408D51DA4E5DA00908C90 /* MGLVectorStyleLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA6408D81DA4E5DA00908C90 /* MGLVectorStyleLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = DA6408D61DA4E5DA00908C90 /* MGLVectorStyleLayer.m */; };
+		DA695424215B1E6C002041A4 /* MGLMapCameraTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA695423215B1E6C002041A4 /* MGLMapCameraTests.m */; };
 		DA7262071DEEDD460043BB89 /* MGLOpenGLStyleLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = DA7262051DEEDD460043BB89 /* MGLOpenGLStyleLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA7262081DEEDD460043BB89 /* MGLOpenGLStyleLayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA7262061DEEDD460043BB89 /* MGLOpenGLStyleLayer.mm */; };
 		DA7DC9811DED5F5C0027472F /* MGLVectorTileSource_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DA7DC9801DED5F5C0027472F /* MGLVectorTileSource_Private.h */; };
@@ -458,6 +459,7 @@
 		DA618B2A1E6892B500CB7F44 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA6408D51DA4E5DA00908C90 /* MGLVectorStyleLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLVectorStyleLayer.h; sourceTree = "<group>"; };
 		DA6408D61DA4E5DA00908C90 /* MGLVectorStyleLayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLVectorStyleLayer.m; sourceTree = "<group>"; };
+		DA695423215B1E6C002041A4 /* MGLMapCameraTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MGLMapCameraTests.m; path = ../../darwin/test/MGLMapCameraTests.m; sourceTree = "<group>"; };
 		DA704CBA1F6372E8004B3F28 /* ru */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Foundation.strings; sourceTree = "<group>"; };
 		DA704CBE1F637531004B3F28 /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA704CBF1F637548004B3F28 /* hu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1116,6 +1118,7 @@
 				1F95931A1E6DE2B600D5B294 /* MGLNSDateAdditionsTests.mm */,
 				DA0CD58D1CF56F5800A5F5A5 /* MGLFeatureTests.mm */,
 				DAE6C3C81CC34BD800DB3429 /* MGLGeometryTests.mm */,
+				DA695423215B1E6C002041A4 /* MGLMapCameraTests.m */,
 				076171C4213A0DC200668A35 /* MGLMapViewTests.m */,
 				DAE7DEC31E24549F007505A6 /* MGLNSStringAdditionsTests.m */,
 				DAE6C3C91CC34BD800DB3429 /* MGLOfflinePackTests.m */,
@@ -1615,6 +1618,7 @@
 				1F7454AB1ED1DDBD00021D39 /* MGLLightTest.mm in Sources */,
 				07A240941F675674002C8210 /* MGLComputedShapeSourceTests.m in Sources */,
 				DAEDC4371D606291000224FF /* MGLAttributionButtonTests.m in Sources */,
+				DA695424215B1E6C002041A4 /* MGLMapCameraTests.m in Sources */,
 				920A3E591E6F859D00C16EFC /* MGLSourceQueryTests.m in Sources */,
 				DA35A2B61CCA14D700E826B2 /* MGLCompassDirectionFormatterTests.m in Sources */,
 				35C6DF871E214C1800ACA483 /* MGLDistanceFormatterTests.m in Sources */,

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -1320,7 +1320,7 @@ public:
                                                           centerCoordinate.latitude,
                                                           self.frame.size);
     return [MGLMapCamera cameraLookingAtCenterCoordinate:centerCoordinate
-                                            fromDistance:altitude
+                                                altitude:altitude
                                                    pitch:pitch
                                                  heading:direction];
 }


### PR DESCRIPTION
MGLMapCamera can now be expressed in terms of viewing distance. `+[MGLMapCamera cameraLookingAtCenterCoordinate:fromDistance:pitch:heading:]` incorrectly treated the distance as an altitude. Due to backwards compatibility concerns, this method can’t be fixed in place until the next semver-major release. Instead, separate `+cameraLookingAtCenterCoordinate:correctlyFromDistance:pitch:heading:` and `+cameraLookingAtCenterCoordinate:altitude:pitch:heading:` methods have been added, and the original method has been deprecated to head-off continuing confusion.

A `viewingDistance` property has been added to MGLMapCamera. This property is computed from the `altitude` and `pitch` properties, so there isn’t any parallel state to keep track of. The benefit of this approach over #12938 is that there are fewer, more testable code paths, and developers using this SDK can officially take advantage of the `viewingDistance` property without having to forward-declare anything. One can imagine an `eyeCoordinate` property being added along the same lines in the future.

Rewrote `+[MGLMapCamera cameraLookingAtCenterCoordinate:fromEyeCoordinate:eyeAltitude:]` to produce the right heading and pitch (and thus respect the specified eye coordinate).

Please double-check my trigonometry. ~~I still need to add unit tests before this PR can land.~~

Fixes #12943 and fixes #12967. Supersedes #12938 and part of #12518.

/cc @d-prukop @fabian-guerra @julianrex