### PR TITLE
[ios, build] Packaging script improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,23 +253,13 @@ ios-static-analyzer: $(IOS_PROJ_PATH)
 	set -o pipefail && $(IOS_XCODEBUILD_SIM) analyze -scheme 'CI' test $(XCPRETTY)
 
 .PHONY: ipackage
-ipackage: $(IOS_PROJ_PATH)
-	FORMAT=$(FORMAT) BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=$(SYMBOLS) \
-	./platform/ios/scripts/package.sh
-
-.PHONY: ipackage-strip
-ipackage-strip: $(IOS_PROJ_PATH)
-	FORMAT=$(FORMAT) BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=NO \
-	./platform/ios/scripts/package.sh
-
-.PHONY: ipackage-sim
-ipackage-sim: $(IOS_PROJ_PATH)
-	BUILDTYPE=Debug FORMAT=dynamic BUILD_DEVICE=false SYMBOLS=$(SYMBOLS) \
-	./platform/ios/scripts/package.sh
+ipackage: ipackage*
+ipackage%:
+	@echo make ipackage is deprecated — use make iframework.
 
 .PHONY: iframework
 iframework: $(IOS_PROJ_PATH)
-	FORMAT=dynamic BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=$(SYMBOLS) \
+	FORMAT=$(FORMAT) BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=$(SYMBOLS) \
 	./platform/ios/scripts/package.sh
 
 .PHONY: ideploy
@@ -293,6 +283,7 @@ darwin-update-examples:
 .PHONY: check-public-symbols
 check-public-symbols:
 	node platform/darwin/scripts/check-public-symbols.js macOS iOS
+
 endif
 
 #### Linux targets #####################################################

--- a/platform/ios/DEVELOPING.md
+++ b/platform/ios/DEVELOPING.md
@@ -36,14 +36,7 @@ Install [jazzy](https://github.com/realm/jazzy) for generating API documentation
 [sudo] gem install jazzy
 ```
 
-Build and package the SDK by using one of the following commands:
-
-* `make ipackage` builds both dynamic and static frameworks in the Debug configuration for devices and the iOS Simulator.
-* `make iframework` builds a dynamic framework in the Debug configuration for devices and the iOS Simulator. The CocoaPods pod downloads the output of this target.
-* `make ipackage-sim` builds a dynamic framework in the Debug configuration for the iOS simulator. This is the fastest target.
-* `make ipackage-strip` builds both dynamic and static frameworks in the Debug configuration, stripped of debug symbols, for devices and the iOS Simulator.
-
-You can customize the build output by passing the following arguments into the `make` invocation:
+Build and package the SDK by using the `make iframework` command. You can customize the build output by passing the following arguments into the `make` invocation:
 
 * `BUILDTYPE=Release` will optimize for distribution. Defaults to `Debug`.
 * `BUILD_DEVICE=false` builds only for the iOS Simulator.

--- a/platform/ios/INSTALL.md
+++ b/platform/ios/INSTALL.md
@@ -81,7 +81,7 @@ A nightly build of the dynamic framework, based on the master branch, is availab
 
 You can alternatively install the SDK as a static framework:
 
-1. Build from source using the `make ipackage` command.
+1. Build from source using the `make iframework FORMAT=static BUILDTYPE=Release` command.
 
 1. Drag the Mapbox.bundle and Mapbox.framework from the `build/ios/pkg/static/` directory into the Project navigator. In the sheet that appears, make sure “Copy items if needed” is checked, then click Finish. Open the project editor and select your application target to verify that the following changes occurred automatically:
 
@@ -109,7 +109,7 @@ You can alternatively install the SDK as a static framework:
 To test pre-releases and/or betas, you can reference the pre-release like so in your Podfile:
 
 ```rb
-pod 'Mapbox-iOS-SDK', podspec: 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/<insert branch or tag>/platform/ios/Mapbox-iOS-SDK.podspec'
+pod 'Mapbox-iOS-SDK-symbols', podspec: 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/<insert branch or tag>/platform/ios/Mapbox-iOS-SDK-symbols.podspec'
 ```
 
 ##### Testing nightly releases with CocoaPods

--- a/platform/ios/scripts/deploy-packages.sh
+++ b/platform/ios/scripts/deploy-packages.sh
@@ -111,8 +111,6 @@ if [[ "${GITHUB_RELEASE}" == true ]]; then
         --description "${RELEASE_NOTES}"
 fi
 
-buildPackageStyle "ipackage" "symbols"
-buildPackageStyle "ipackage-strip"
 buildPackageStyle "iframework" "symbols-dynamic"
 buildPackageStyle "iframework SYMBOLS=NO" "dynamic"
 

--- a/platform/ios/scripts/package.sh
+++ b/platform/ios/scripts/package.sh
@@ -14,12 +14,15 @@ BUILDTYPE=${BUILDTYPE:-Debug}
 BUILD_FOR_DEVICE=${BUILD_DEVICE:-true}
 SYMBOLS=${SYMBOLS:-YES}
 
+FORMAT=${FORMAT:-dynamic}
 BUILD_DYNAMIC=true
-BUILD_STATIC=true
+BUILD_STATIC=false
 if [[ ${FORMAT} == "static" ]]; then
+    BUILD_STATIC=true
     BUILD_DYNAMIC=false
-elif [[ ${FORMAT} == "dynamic" ]]; then
-    BUILD_STATIC=false
+elif [[ ${FORMAT} != "dynamic" ]]; then
+    echo "Error: FORMAT must be dynamic or static."
+    exit 1
 fi
 
 SDK=iphonesimulator
@@ -32,7 +35,7 @@ function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
 function finish { >&2 echo -en "\033[0m"; }
 trap finish EXIT
 
-step "Configuring ${FORMAT:-dynamic and static} ${BUILDTYPE} framework for ${SDK} ${IOS_SDK_VERSION}; symbols: ${SYMBOLS}"
+step "Configuring ${FORMAT} framework for ${SDK} ${IOS_SDK_VERSION} (symbols: ${SYMBOLS}, buildtype: ${BUILDTYPE})"
 
 xcodebuild -version
 
@@ -59,13 +62,11 @@ SHORT_VERSION=${SEM_VERSION%-*}
 step "Building targets (build ${PROJ_VERSION}, version ${SEM_VERSION})"
 
 SCHEME='dynamic'
-if [[ ${BUILD_DYNAMIC} == true && ${BUILD_STATIC} == true ]]; then
-    SCHEME+='+static'
-elif [[ ${BUILD_STATIC} == true ]]; then
+if [[ ${BUILD_STATIC} == true ]]; then
     SCHEME='static'
 fi
 
-step "Building for iOS Simulator using scheme ${SCHEME}"
+step "Building ${FORMAT} framework for iOS Simulator using ${SCHEME} scheme"
 xcodebuild \
     CURRENT_PROJECT_VERSION=${PROJ_VERSION} \
     CURRENT_SHORT_VERSION=${SHORT_VERSION} \
@@ -80,7 +81,7 @@ xcodebuild \
     -jobs ${JOBS} | tee ${LOG_PATH} | xcpretty
 
 if [[ ${BUILD_FOR_DEVICE} == true ]]; then
-    step "Building for iOS devices using scheme ${SCHEME}"
+    step "Building ${FORMAT} framework for iOS devices using ${SCHEME} scheme"
     xcodebuild \
         CURRENT_PROJECT_VERSION=${PROJ_VERSION} \
         CURRENT_SHORT_VERSION=${SHORT_VERSION} \

--- a/platform/ios/scripts/publish.sh
+++ b/platform/ios/scripts/publish.sh
@@ -30,20 +30,33 @@ rm -f ../${ZIP}
 zip -yr ../${ZIP} *
 
 #
+# report file sizes
+#
+step "Echoing file sizes…"
+du -sh ../${ZIP}
+du -sch *
+du -sch dynamic/*
+
+#
 # upload
 #
+PROGRESS=
+if [ -n "${CI:-}" ]; then
+    PROGRESS="--no-progress"
+fi
+
 step "Uploading ${ZIP} to s3…"
 REPO_NAME=$(basename $TRAVIS_REPO_SLUG)
-aws s3 cp ../${ZIP} s3://mapbox/$REPO_NAME/ios/builds/ --acl public-read
+aws s3 cp ../${ZIP} s3://mapbox/$REPO_NAME/ios/builds/ --acl public-read ${PROGRESS}
 echo "URL: https://mapbox.s3.amazonaws.com/$REPO_NAME/ios/builds/${ZIP}"
 
 #
-# update nightly
+# upload & update nightly
 #
 if [[ ${PUBLISH_VERSION} =~ "nightly" ]]; then
     step "Updating ${PUBLISH_VERSION} to ${PUBLISH_STYLE}…"
     GENERIC_NIGHTLY_FILENAME="mapbox-ios-sdk-${PUBLISH_VERSION}.zip"
     aws s3 cp \
         s3://mapbox/$REPO_NAME/ios/builds/${ZIP} \
-        s3://mapbox/$REPO_NAME/ios/builds/${GENERIC_NIGHTLY_FILENAME} --acl public-read
+        s3://mapbox/$REPO_NAME/ios/builds/${GENERIC_NIGHTLY_FILENAME} --acl public-read ${PROGRESS}
 fi


### PR DESCRIPTION
- Fixes #12841 by ceasing to publish the static framework in release deployments.
- Deprecates `make ipackage` (and company) in favor of `make iframework` with arguments.
- Improved logging during deployments — less verbosity, more details about file sizes.

It’s still possible to build the static framework by invoking `make iframework FORMAT=static` (and, indeed, it currently appears to succeed).

/cc @mapbox/maps-ios @1ec5 