### PR TITLE
[ios, build] Build releases with Xcode 10.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1066,7 +1066,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-release:
     macos:
-      xcode: "9.4.1"
+      xcode: "10.0.0"
     environment:
       BUILDTYPE: Release
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -1106,7 +1106,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-release-tag:
     macos:
-      xcode: "9.4.1"
+      xcode: "10.0.0"
     environment:
       BUILDTYPE: Release
       HOMEBREW_NO_AUTO_UPDATE: 1


### PR DESCRIPTION
Tests are still occasionally timing-out with the Xcode 10 canary job (#12911) so we can’t quite update all of the CI jobs yet, but I’d like to try publishing `ios-v4.5.0-alpha.2` and nightlies/snapshots with Xcode 10 to get some app-integration testing going elsewhere.

/cc @mapbox/maps-ios 