### PR TITLE
Proposed delegate methods to manage annotations' selection animation/movement

### DIFF
--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -1318,10 +1318,6 @@ MGL_EXPORT IB_DESIGNABLE
 @property (nonatomic, copy) NSArray<id <MGLAnnotation>> *selectedAnnotations;
 
 /**
- TODO: update documentation
- TODO: consider deprecation, and replacing with a `selectAnnotation:` that uses the proposed delegate
- methods.
-
  Selects an annotation and displays its callout view.
 
  The `animated` parameter determines whether the map is panned to bring the
@@ -1330,17 +1326,15 @@ MGL_EXPORT IB_DESIGNABLE
  | `animated` parameter | Effect |
  |------------------|--------|
  | `NO`             | The annotation is selected, and the callout is presented. However the map is not panned to bring the annotation or callout onscreen.
- | `YES`            | The annotation is selected, and the callout is presented. If the annotation is offscreen *and* is of type `MGLPointAnnotation`, the map is panned so that the annotation and its callout are brought just onscreen. The annotation is *not* centered within the viewport. |
+ | `YES`            | The annotation is selected, and the callout is presented. If the annotation is offscreen, the map is panned so that the annotation and its callout are brought just onscreen. The annotation is *not* centered within the viewport. |
 
+ Note that a selection initiated by a single tap gesture is always animated.
+ 
  @param annotation The annotation object to select.
  @param animated If `YES`, the annotation and callout view are moved on-screen.
 
  @note In versions prior to `4.0.0` selecting an offscreen annotation did not
  change the camera.
- 
- @note The `animated` parameter can be considered the same as the value returned from
- `-[MGLMapViewDelgate mapView:shouldMoveOnscreenWhenSelectingAnnotation:]`.
- See also `-[MGLMapViewDelegate mapView:shouldAnimateAnnotationSelection:` for animation control
  */
 - (void)selectAnnotation:(id <MGLAnnotation>)annotation animated:(BOOL)animated;
 

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -1318,6 +1318,10 @@ MGL_EXPORT IB_DESIGNABLE
 @property (nonatomic, copy) NSArray<id <MGLAnnotation>> *selectedAnnotations;
 
 /**
+ TODO: update documentation
+ TODO: consider deprecation, and replacing with a `selectAnnotation:` that uses the proposed delegate
+ methods.
+
  Selects an annotation and displays its callout view.
 
  The `animated` parameter determines whether the map is panned to bring the
@@ -1325,14 +1329,18 @@ MGL_EXPORT IB_DESIGNABLE
 
  | `animated` parameter | Effect |
  |------------------|--------|
- | `NO`             | The annotation is selected, and the callout is presented. However the map is not panned to bring the annotation or callout onscreen. The presentation of the callout is animated. |
+ | `NO`             | The annotation is selected, and the callout is presented. However the map is not panned to bring the annotation or callout onscreen.
  | `YES`            | The annotation is selected, and the callout is presented. If the annotation is offscreen *and* is of type `MGLPointAnnotation`, the map is panned so that the annotation and its callout are brought just onscreen. The annotation is *not* centered within the viewport. |
 
  @param annotation The annotation object to select.
- @param animated If `YES`, the annotation and callout view are animated on-screen.
+ @param animated If `YES`, the annotation and callout view are moved on-screen.
 
  @note In versions prior to `4.0.0` selecting an offscreen annotation did not
  change the camera.
+ 
+ @note The `animated` parameter can be considered the same as the value returned from
+ `-[MGLMapViewDelgate mapView:shouldMoveOnscreenWhenSelectingAnnotation:]`.
+ See also `-[MGLMapViewDelegate mapView:shouldAnimateAnnotationSelection:` for animation control
  */
 - (void)selectAnnotation:(id <MGLAnnotation>)annotation animated:(BOOL)animated;
 

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -1320,13 +1320,13 @@ MGL_EXPORT IB_DESIGNABLE
 /**
  Selects an annotation and displays its callout view.
 
- The `animated` parameter determines whether the map is panned to bring the
- annotation on-screen, specifically:
+ The `animated` parameter determines whether the selection is animated including whether the map is
+ panned to bring the annotation into view, specifically:
 
  | `animated` parameter | Effect |
  |------------------|--------|
- | `NO`             | The annotation is selected, and the callout is presented. However the map is not panned to bring the annotation or callout onscreen.
- | `YES`            | The annotation is selected, and the callout is presented. If the annotation is offscreen, the map is panned so that the annotation and its callout are brought just onscreen. The annotation is *not* centered within the viewport. |
+ | `NO`             | The annotation is selected, and the callout is presented. However the map is not panned to bring the annotation or callout into view.
+ | `YES`            | The annotation is selected, and the callout is presented. If the annotation is not visible or is partially visible, the map is panned so that the annotation and its callout are brought into view. The annotation is *not* centered within the viewport. |
 
  Note that a selection initiated by a single tap gesture is always animated.
  
@@ -1337,6 +1337,18 @@ MGL_EXPORT IB_DESIGNABLE
  change the camera.
  */
 - (void)selectAnnotation:(id <MGLAnnotation>)annotation animated:(BOOL)animated;
+
+/**
+ Selects an annotation and displays its callout view.
+ 
+ Note that a selection initiated by a single tap gesture is always animated.
+ 
+ @param annotation The annotation object to select.
+ @param animated If `YES`, the annotation and callout view's selection and presentation are animated. This parameter does not control whether the map moves.
+ @param expose If `YES` and the annotation is not visible or is partially visible, the map is panned so that the annotation and its callout are brought into view. The annotation is *not* centered within the viewport.
+ */
+- (void)selectAnnotation:(id <MGLAnnotation>)annotation animated:(BOOL)animated expose:(BOOL)expose;
+
 
 /**
  Deselects an annotation and hides its callout view.

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -1331,7 +1331,7 @@ MGL_EXPORT IB_DESIGNABLE
  Note that a selection initiated by a single tap gesture is always animated.
  
  @param annotation The annotation object to select.
- @param animated If `YES`, the annotation and callout view are moved on-screen.
+ @param animated If `YES`, the annotation and callout view are animated on-screen.
 
  @note In versions prior to `4.0.0` selecting an offscreen annotation did not
  change the camera.

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1718,13 +1718,13 @@ public:
         CGPoint calloutPoint = [singleTap locationInView:self];
         CGRect positionRect = [self positioningRectForAnnotation:annotation defaultCalloutPoint:calloutPoint];
         
-        BOOL moveOnscreen = YES;
+        BOOL expose = YES;
         
-        if ([self.delegate respondsToSelector:@selector(mapView:shouldMoveAnnotationOnscreenInResponseToUserSelection:)]) {
-            moveOnscreen = [self.delegate mapView:self shouldMoveAnnotationOnscreenInResponseToUserSelection:annotation];
+        if ([self.delegate respondsToSelector:@selector(mapView:shouldExposeAnnotationInResponseToUserSelection:)]) {
+            expose = [self.delegate mapView:self shouldExposeAnnotationInResponseToUserSelection:annotation];
         }
         
-        [self selectAnnotation:annotation animated:YES moveOnscreen:moveOnscreen calloutPositioningRect:positionRect];
+        [self selectAnnotation:annotation animated:YES expose:expose calloutPositioningRect:positionRect];
     }
     else if (self.selectedAnnotation)
     {
@@ -4375,17 +4375,17 @@ public:
 
 - (void)selectAnnotation:(id <MGLAnnotation>)annotation animated:(BOOL)animated
 {
-    [self selectAnnotation:annotation animated:animated moveOnscreen:animated];
+    [self selectAnnotation:annotation animated:animated expose:animated];
 }
 
-- (void)selectAnnotation:(id <MGLAnnotation>)annotation animated:(BOOL)animated moveOnscreen:(BOOL)moveOnscreen
+- (void)selectAnnotation:(id <MGLAnnotation>)annotation animated:(BOOL)animated expose:(BOOL)expose
 {
     CGRect positioningRect = [self positioningRectForAnnotation:annotation defaultCalloutPoint:CGPointZero];
     
-    [self selectAnnotation:annotation animated:animated moveOnscreen:moveOnscreen calloutPositioningRect:positioningRect];
+    [self selectAnnotation:annotation animated:animated expose:expose calloutPositioningRect:positioningRect];
 }
 
-- (void)selectAnnotation:(id <MGLAnnotation>)annotation animated:(BOOL)animated moveOnscreen:(BOOL)moveOnscreen calloutPositioningRect:(CGRect)calloutPositioningRect
+- (void)selectAnnotation:(id <MGLAnnotation>)annotation animated:(BOOL)animated expose:(BOOL)expose calloutPositioningRect:(CGRect)calloutPositioningRect
 {
     if ( ! annotation) return;
 
@@ -4500,7 +4500,7 @@ public:
 
         // If the callout view provides inset (outset) information, we can use it to expand our positioning
         // rect, which we then use to help move the annotation on-screen if want need to.
-        if (moveOnscreen) {
+        if (expose) {
             UIEdgeInsets margins = MGLMapViewOffscreenAnnotationPadding;
             
             if ([calloutView respondsToSelector:@selector(marginInsetsHintForPresentationFromRect:)]) {
@@ -4511,9 +4511,9 @@ public:
         }
     }
 
-    if (moveOnscreen)
+    if (expose)
     {
-        moveOnscreen = NO;
+        expose = NO;
 
         // Need to consider the content insets.
         CGRect bounds = constrainedRect;
@@ -4523,14 +4523,14 @@ public:
         
         if (minX < CGRectGetMinX(bounds)) {
             constrainedRect.origin.x = minX;
-            moveOnscreen = YES;
+            expose = YES;
         }
         else {
             CGFloat maxX = CGRectGetMaxX(expandedPositioningRect);
             
             if (maxX > CGRectGetMaxX(bounds)) {
                 constrainedRect.origin.x = maxX - CGRectGetWidth(constrainedRect);
-                moveOnscreen = YES;
+                expose = YES;
             }
         }
 
@@ -4538,14 +4538,14 @@ public:
         
         if (minY < CGRectGetMinY(bounds)) {
             constrainedRect.origin.y = minY;
-            moveOnscreen = YES;
+            expose = YES;
         }
         else {
             CGFloat maxY = CGRectGetMaxY(expandedPositioningRect);
             
             if (maxY > CGRectGetMaxY(bounds)) {
                 constrainedRect.origin.y = maxY - CGRectGetHeight(constrainedRect);
-                moveOnscreen = YES;
+                expose = YES;
             }
         }
     }
@@ -4571,7 +4571,7 @@ public:
         [self.delegate mapView:self didSelectAnnotationView:annotationView];
     }
 
-    if (moveOnscreen)
+    if (expose)
     {
         CGPoint center = CGPointMake(CGRectGetMidX(constrainedRect), CGRectGetMidY(constrainedRect));
         CLLocationCoordinate2D centerCoord = [self convertPoint:center toCoordinateFromView:self];

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1715,11 +1715,11 @@ public:
         
         BOOL moveOnscreen = YES;
         
-        if ([self.delegate respondsToSelector:@selector(mapView:shouldMoveOnscreenWhenSelectingAnnotation:)]) {
-            moveOnscreen = [self.delegate mapView:self shouldMoveOnscreenWhenSelectingAnnotation:annotation];
+        if ([self.delegate respondsToSelector:@selector(mapView:shouldMoveAnnotationOnscreenInResponseToUserSelection:)]) {
+            moveOnscreen = [self.delegate mapView:self shouldMoveAnnotationOnscreenInResponseToUserSelection:annotation];
         }
         
-        [self selectAnnotation:annotation moveOnscreen:moveOnscreen calloutPositioningRect:positionRect];
+        [self selectAnnotation:annotation animated:YES moveOnscreen:moveOnscreen calloutPositioningRect:positionRect];
     }
     else if (self.selectedAnnotation)
     {
@@ -4370,12 +4370,17 @@ public:
 
 - (void)selectAnnotation:(id <MGLAnnotation>)annotation animated:(BOOL)animated
 {
-    CGRect positioningRect = [self positioningRectForAnnotation:annotation defaultCalloutPoint:CGPointZero];
-    
-    [self selectAnnotation:annotation moveOnscreen:animated calloutPositioningRect:positioningRect];
+    [self selectAnnotation:annotation animated:animated moveOnscreen:animated];
 }
 
-- (void)selectAnnotation:(id <MGLAnnotation>)annotation moveOnscreen:(BOOL)moveOnscreen calloutPositioningRect:(CGRect)calloutPositioningRect
+- (void)selectAnnotation:(id <MGLAnnotation>)annotation animated:(BOOL)animated moveOnscreen:(BOOL)moveOnscreen
+{
+    CGRect positioningRect = [self positioningRectForAnnotation:annotation defaultCalloutPoint:CGPointZero];
+    
+    [self selectAnnotation:annotation animated:animated moveOnscreen:moveOnscreen calloutPositioningRect:positioningRect];
+}
+
+- (void)selectAnnotation:(id <MGLAnnotation>)annotation animated:(BOOL)animated moveOnscreen:(BOOL)moveOnscreen calloutPositioningRect:(CGRect)calloutPositioningRect
 {
     if ( ! annotation) return;
 
@@ -4383,12 +4388,6 @@ public:
 
     [self deselectAnnotation:self.selectedAnnotation animated:NO];
 
-    BOOL animateSelection = YES;
-    
-    if ([self.delegate respondsToSelector:@selector(mapView:shouldAnimateAnnotationSelection:)]) {
-        animateSelection = [self.delegate mapView:self shouldAnimateAnnotationSelection:annotation];
-    }
-    
     // Add the annotation to the map if it hasn’t been added yet.
     MGLAnnotationTag annotationTag = [self annotationTagForAnnotation:annotation];
     if (annotationTag == MGLAnnotationTagNotFound && annotation != self.userLocation)
@@ -4409,7 +4408,7 @@ public:
                 calloutPositioningRect = annotationView.frame;
                 [annotationView.superview bringSubviewToFront:annotationView];
 
-                [annotationView setSelected:YES animated:animateSelection];
+                [annotationView setSelected:YES animated:animated];
             }
         }
 
@@ -4545,7 +4544,7 @@ public:
     [calloutView presentCalloutFromRect:calloutPositioningRect
                                  inView:self.glView
                       constrainedToRect:constrainedRect
-                               animated:animateSelection];
+                               animated:animated];
 
     // notify delegate
     if ([self.delegate respondsToSelector:@selector(mapView:didSelectAnnotation:)])
@@ -4562,7 +4561,7 @@ public:
     {
         CGPoint center = CGPointMake(CGRectGetMidX(constrainedRect), CGRectGetMidY(constrainedRect));
         CLLocationCoordinate2D centerCoord = [self convertPoint:center toCoordinateFromView:self];
-        [self setCenterCoordinate:centerCoord animated:animateSelection];
+        [self setCenterCoordinate:centerCoord animated:animated];
     }
 }
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -234,7 +234,6 @@ public:
 /// could be the touch point rather than its centroid)
 @property (nonatomic) CLLocationCoordinate2D anchorCoordinateForSelectedAnnotation;
 
-
 @property (nonatomic) MGLUserLocationAnnotationView *userLocationAnnotationView;
 
 /// Indicates how thoroughly the map view is tracking the user location.
@@ -4428,7 +4427,6 @@ public:
         CGPoint originPoint = [self convertCoordinate:origin toPointToView:self];
         calloutPositioningRect = { .origin = originPoint, .size = CGSizeZero };
     }
-
     
     CGRect expandedPositioningRect = calloutPositioningRect;
 
@@ -4503,7 +4501,6 @@ public:
         // If the callout view provides inset (outset) information, we can use it to expand our positioning
         // rect, which we then use to help move the annotation on-screen if want need to.
         if (moveOnscreen) {
-            
             UIEdgeInsets margins = MGLMapViewOffscreenAnnotationPadding;
             
             if ([calloutView respondsToSelector:@selector(marginInsetsHintForPresentationFromRect:)]) {
@@ -4578,7 +4575,6 @@ public:
     {
         CGPoint center = CGPointMake(CGRectGetMidX(constrainedRect), CGRectGetMidY(constrainedRect));
         CLLocationCoordinate2D centerCoord = [self convertPoint:center toCoordinateFromView:self];
-        
         [self setCenterCoordinate:centerCoord animated:animated];
     }
 }
@@ -5918,7 +5914,6 @@ public:
 
 - (void)updateCalloutView
 {
-    // If we're moving the annotation and callout, don't update
     UIView <MGLCalloutView> *calloutView = self.calloutViewForSelectedAnnotation;
     id <MGLAnnotation> annotation = calloutView.representedObject;
 
@@ -6044,7 +6039,6 @@ public:
 
 /// Intended center point of the user location annotation view with respect to
 /// the overall map view (but respecting the content inset).
-
 - (CGPoint)userLocationAnnotationViewCenter
 {
     if ([self.delegate respondsToSelector:@selector(mapViewUserLocationAnchorPoint:)])

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -4325,12 +4325,6 @@ public:
     });
 }
 
-
-- (BOOL)isBringingAnnotationOnscreenSupportedForAnnotation:(id<MGLAnnotation>)annotation animated:(BOOL)animated {
-    // Consider delegating
-    return animated && [annotation isKindOfClass:[MGLPointAnnotation class]];
-}
-
 - (id <MGLAnnotation>)selectedAnnotation
 {
     if (_userLocationAnnotationIsSelected)
@@ -4433,7 +4427,7 @@ public:
     CGRect expandedPositioningRect = UIEdgeInsetsInsetRect(calloutPositioningRect, MGLMapViewOffscreenAnnotationPadding);
 
     // Used for callout positioning, and moving offscreen annotations onscreen.
-    CGRect constrainedRect = UIEdgeInsetsInsetRect(self.bounds, self.contentInset);
+    CGRect constrainedRect = self.contentFrame;
 
     UIView <MGLCalloutView> *calloutView = nil;
 

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -459,6 +459,35 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)mapView:(MGLMapView *)mapView shapeAnnotationIsEnabled:(MGLShape *)annotation;
 
+
+/**
+ TODO: document
+ Returns a Boolean value indicating whether the annotation should be moved on-screen.
+ 
+ If the delegate does not implement this method, the default is `YES`.
+ 
+ This method is useful in cases where the selection is not programmatic (e.g. user taps an annotation)
+ The value returned from this method can be considered the same as the `animated` parameter passed to
+ `-selectAnnotation:animated:`
+ */
+- (BOOL)mapView:(MGLMapView *)mapView shouldMoveOnscreenWhenSelectingAnnotation:(id <MGLAnnotation>)annotation;
+
+
+/**
+ TODO: document
+ Returns a Boolean value indicating whether the annotation's visual changes should be animated.
+ Specifically this controls:
+ - The annotation's selection change
+ - The presentation of the annotation's callout (if applicable)
+ - When moving an off-screen annotation, whether that movement is animated.
+ 
+ If the delegate does not implement this method, the default is `YES`.
+ 
+ The value returned from this method is NOT the same as the `animated` parameter passed to
+ `-selectAnnotation:animated:`
+ */
+- (BOOL)mapView:(MGLMapView *)mapView shouldAnimateAnnotationSelection:(id <MGLAnnotation>)annotation;
+
 /**
  Tells the delegate that one of its annotations was selected.
 

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -474,7 +474,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)mapView:(MGLMapView *)mapView shouldMoveAnnotationOnscreenInResponseToUserSelection:(id <MGLAnnotation>)annotation;
 
-
 /**
  Tells the delegate that one of its annotations was selected.
 

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -461,32 +461,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 /**
- TODO: document
- Returns a Boolean value indicating whether the annotation should be moved on-screen.
+ Returns a Boolean value indicating whether the annotation should be moved on-screen
+ in response to a single tap selection.
  
- If the delegate does not implement this method, the default is `YES`.
+ If the delegate does not implement this method, the default value is `YES`.
  
- This method is useful in cases where the selection is not programmatic (e.g. user taps an annotation)
- The value returned from this method can be considered the same as the `animated` parameter passed to
- `-selectAnnotation:animated:`
+ Note that user-initiated selections are always animated.
+ 
+ @param mapView The map view that has selected the annotation.
+ @param annotation The object representing the shape annotation.
+ @return A Boolean value indicating whether the annotation should be moved onscreen if it and its callout (if it has one) are offscreen.
  */
-- (BOOL)mapView:(MGLMapView *)mapView shouldMoveOnscreenWhenSelectingAnnotation:(id <MGLAnnotation>)annotation;
+- (BOOL)mapView:(MGLMapView *)mapView shouldMoveAnnotationOnscreenInResponseToUserSelection:(id <MGLAnnotation>)annotation;
 
-
-/**
- TODO: document
- Returns a Boolean value indicating whether the annotation's visual changes should be animated.
- Specifically this controls:
- - The annotation's selection change
- - The presentation of the annotation's callout (if applicable)
- - When moving an off-screen annotation, whether that movement is animated.
- 
- If the delegate does not implement this method, the default is `YES`.
- 
- The value returned from this method is NOT the same as the `animated` parameter passed to
- `-selectAnnotation:animated:`
- */
-- (BOOL)mapView:(MGLMapView *)mapView shouldAnimateAnnotationSelection:(id <MGLAnnotation>)annotation;
 
 /**
  Tells the delegate that one of its annotations was selected.

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -472,7 +472,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param annotation The object representing the shape annotation.
  @return A Boolean value indicating whether the annotation should be moved onscreen if it and its callout (if it has one) are offscreen.
  */
-- (BOOL)mapView:(MGLMapView *)mapView shouldMoveAnnotationOnscreenInResponseToUserSelection:(id <MGLAnnotation>)annotation;
+- (BOOL)mapView:(MGLMapView *)mapView shouldExposeAnnotationInResponseToUserSelection:(id <MGLAnnotation>)annotation;
 
 /**
  Tells the delegate that one of its annotations was selected.

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -459,9 +459,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)mapView:(MGLMapView *)mapView shapeAnnotationIsEnabled:(MGLShape *)annotation;
 
-
 /**
- Returns a Boolean value indicating whether the annotation should be moved on-screen
+ Returns a Boolean value indicating whether the annotation should be brought into view
  in response to a single tap selection.
  
  If the delegate does not implement this method, the default value is `YES`.
@@ -470,7 +469,8 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param mapView The map view that has selected the annotation.
  @param annotation The object representing the shape annotation.
- @return A Boolean value indicating whether the annotation should be moved onscreen if it and its callout (if it has one) are offscreen.
+ @return A Boolean value indicating whether the annotation should be moved into view. This value
+ can be considered to be the same as the `expose` parameter passed to `-[MGLMapView selectAnnotation:animated:expose:]`
  */
 - (BOOL)mapView:(MGLMapView *)mapView shouldExposeAnnotationInResponseToUserSelection:(id <MGLAnnotation>)annotation;
 

--- a/platform/ios/test/MGLMapViewDelegateIntegrationTests.swift
+++ b/platform/ios/test/MGLMapViewDelegateIntegrationTests.swift
@@ -33,7 +33,7 @@ extension MGLMapViewDelegateIntegrationTests: MGLMapViewDelegate {
 
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {}
 
-    func mapView(_ mapView: MGLMapView, shouldMoveAnnotationOnscreenInResponseToUserSelection annotation: MGLAnnotation) -> Bool { return true }
+    func mapView(_ mapView: MGLMapView, shouldExposeAnnotationInResponseToUserSelection annotation: MGLAnnotation) -> Bool { return true }
     func mapView(_ mapView: MGLMapView, didSelect annotation: MGLAnnotation) {}
 
     func mapView(_ mapView: MGLMapView, didDeselect annotation: MGLAnnotation) {}

--- a/platform/ios/test/MGLMapViewDelegateIntegrationTests.swift
+++ b/platform/ios/test/MGLMapViewDelegateIntegrationTests.swift
@@ -33,9 +33,9 @@ extension MGLMapViewDelegateIntegrationTests: MGLMapViewDelegate {
 
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {}
 
-    func mapView(_ mapView: MGLMapView, shouldMoveOnscreenWhenSelecting annotation: MGLAnnotation) -> Bool {}
+    func mapView(_ mapView: MGLMapView, shouldMoveOnscreenWhenSelecting annotation: MGLAnnotation) -> Bool { return true }
     
-    func mapView(_ mapView: MGLMapView, shouldAnimateAnnotationSelection annotation: MGLAnnotation) -> Bool {}
+    func mapView(_ mapView: MGLMapView, shouldAnimateAnnotationSelection annotation: MGLAnnotation) -> Bool { return true }
     
     func mapView(_ mapView: MGLMapView, didSelect annotation: MGLAnnotation) {}
 

--- a/platform/ios/test/MGLMapViewDelegateIntegrationTests.swift
+++ b/platform/ios/test/MGLMapViewDelegateIntegrationTests.swift
@@ -33,10 +33,7 @@ extension MGLMapViewDelegateIntegrationTests: MGLMapViewDelegate {
 
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {}
 
-    func mapView(_ mapView: MGLMapView, shouldMoveOnscreenWhenSelecting annotation: MGLAnnotation) -> Bool { return true }
-    
-    func mapView(_ mapView: MGLMapView, shouldAnimateAnnotationSelection annotation: MGLAnnotation) -> Bool { return true }
-    
+    func mapView(_ mapView: MGLMapView, shouldMoveAnnotationOnscreenInResponseToUserSelection annotation: MGLAnnotation) -> Bool { return true }
     func mapView(_ mapView: MGLMapView, didSelect annotation: MGLAnnotation) {}
 
     func mapView(_ mapView: MGLMapView, didDeselect annotation: MGLAnnotation) {}

--- a/platform/ios/test/MGLMapViewDelegateIntegrationTests.swift
+++ b/platform/ios/test/MGLMapViewDelegateIntegrationTests.swift
@@ -33,6 +33,10 @@ extension MGLMapViewDelegateIntegrationTests: MGLMapViewDelegate {
 
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {}
 
+    func mapView(_ mapView: MGLMapView, shouldMoveOnscreenWhenSelecting annotation: MGLAnnotation) -> Bool {}
+    
+    func mapView(_ mapView: MGLMapView, shouldAnimateAnnotationSelection annotation: MGLAnnotation) -> Bool {}
+    
     func mapView(_ mapView: MGLMapView, didSelect annotation: MGLAnnotation) {}
 
     func mapView(_ mapView: MGLMapView, didDeselect annotation: MGLAnnotation) {}

--- a/platform/ios/vendor/SMCalloutView/SMCalloutView.m
+++ b/platform/ios/vendor/SMCalloutView/SMCalloutView.m
@@ -269,6 +269,8 @@ NSTimeInterval const kMGLSMCalloutViewRepositionDelayForUIScrollView = 1.0/3.0;
 
 - (UIEdgeInsets)marginInsetsHintForPresentationFromRect:(CGRect)rect {
 
+    const CGFloat defaultMargin = 20.0f;
+    
     // form our subviews based on our content set so far
     [self rebuildSubviews];
 
@@ -281,16 +283,16 @@ NSTimeInterval const kMGLSMCalloutViewRepositionDelayForUIScrollView = 1.0/3.0;
     CGFloat horizontalMargin = fmaxf(0, ceilf((CALLOUT_MIN_WIDTH-rect.size.width)/2));
 
     UIEdgeInsets insets = {
-        .top = 0.0f,
-        .right = -horizontalMargin,
+        .top    = 0.0f,
+        .right  = -defaultMargin - horizontalMargin,
         .bottom = 0.0f,
-        .left = -horizontalMargin
+        .left   = -defaultMargin - horizontalMargin
     };
 
     if (self.permittedArrowDirection == MGLSMCalloutArrowDirectionUp)
-        insets.bottom -= size.height;
+        insets.bottom -= (defaultMargin + size.height);
     else
-        insets.top -= size.height;
+        insets.top -= (defaultMargin + size.height);
 
     return insets;
 }

--- a/platform/macos/src/MGLMapViewDelegate.h
+++ b/platform/macos/src/MGLMapViewDelegate.h
@@ -256,6 +256,22 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)mapView:(MGLMapView *)mapView shapeAnnotationIsEnabled:(MGLShape *)annotation;
 
 /**
+ Returns a Boolean value indicating whether the annotation should be brought into view
+ in response to selection by clicking.
+ 
+ If the delegate does not implement this method, the default value is `YES`.
+ 
+ Note that user-initiated selections are always animated.
+ 
+ @param mapView The map view that has selected the annotation.
+ @param annotation The object representing the shape annotation.
+ @return A Boolean value indicating whether the annotation should be moved into view. This value
+ can be considered to be the same as the `expose` parameter passed to `-[MGLMapView selectAnnotation:animated:expose:]`
+ */
+- (BOOL)mapView:(MGLMapView *)mapView shouldExposeAnnotationInResponseToUserSelection:(id <MGLAnnotation>)annotation;
+
+
+/**
  Tells the delegate that one of its annotations has been selected.
 
  You can use this method to track changes to the selection state of annotations.

--- a/platform/macos/test/MGLAnnotationTests.m
+++ b/platform/macos/test/MGLAnnotationTests.m
@@ -11,7 +11,7 @@
 - (void)setUp
 {
     [super setUp];
-    _mapView = [[MGLMapView alloc] initWithFrame:CGRectMake(0, 0, 64, 64)];
+    _mapView = [[MGLMapView alloc] initWithFrame:CGRectMake(0, 0, 256, 256)];
     _mapView.delegate = self;
 }
 

--- a/platform/macos/test/MGLMapViewDelegateIntegrationTests.swift
+++ b/platform/macos/test/MGLMapViewDelegateIntegrationTests.swift
@@ -29,6 +29,8 @@ extension MGLMapViewDelegateIntegrationTests: MGLMapViewDelegate {
     
     func mapView(_ mapView: MGLMapView, shapeAnnotationIsEnabled annotation: MGLShape) -> Bool { return false }
 
+    func mapView(_ mapView: MGLMapView, shouldExposeAnnotationInResponseToUserSelection annotation: MGLAnnotation) -> Bool { return true }
+    
     func mapView(_ mapView: MGLMapView, didDeselect annotation: MGLAnnotation) {}
 
     func mapView(_ mapView: MGLMapView, didSelect annotation: MGLAnnotation) {}


### PR DESCRIPTION
This WIP PR addresses #12064.

The following is outdated, and will be updated: 

> Instead of a single delegate method, this PR proposes 2 optional methods:
> 
> 1. `-[MGLMapViewDelegate mapView:shouldMoveOnscreenWhenSelectingAnnotation:`
The value returned from this method can be considered the same as the `animated` parameter passed to `selectAnnotation:animated:` (as such, perhaps, it's worth considering deprecating that method in favour of a `selectAnnotation:` method that uses the proposed delegate method.). 
>
>    This will allow for developers to decide whether an annotation should be moved onscreen on a per-annotation basis.
>
> 2. `-[MGLMapViewDelegate mapView:shouldAnimateAnnotationSelection:`
A sibling method that determines whether the above movement, the annotation selection and the callout presentation should be animated. 
>
>    I've added this second method for symmetry reasons, but it might make sense to hold off on this one for the time being.

/cc @chloekraw 




