### PR TITLE
Declare that the static framework defines a module

### DIFF
--- a/platform/ios/Mapbox-iOS-SDK-static-part.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-static-part.podspec
@@ -9,4 +9,6 @@
   m.module_name = 'Mapbox'
   m.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' }
 
+  m.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+
 end

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -3783,6 +3783,7 @@
 			baseConfigurationReference = 55D8C9941D0F133500F42F10 /* config.xcconfig */;
 			buildSettings = {
 				BITCODE_GENERATION_MODE = bitcode;
+				DEFINES_MODULE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(mbgl_core_INCLUDE_DIRECTORIES)",
 					"$(mbgl_filesource_INCLUDE_DIRECTORIES)",
@@ -3814,6 +3815,7 @@
 			baseConfigurationReference = 55D8C9941D0F133500F42F10 /* config.xcconfig */;
 			buildSettings = {
 				BITCODE_GENERATION_MODE = bitcode;
+				DEFINES_MODULE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(mbgl_core_INCLUDE_DIRECTORIES)",
 					"$(mbgl_filesource_INCLUDE_DIRECTORIES)",


### PR DESCRIPTION
Fixed build errors in the dynamic+static scheme and `make ipackage` by ensuring that both the dynamic and static targets have the same `DEFINES_MODULE` build setting.

Fixes #11794. Fixes #12339.
/cc @friedbunny