### PR TITLE
Remove unnecessary camera callbacks loops

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
@@ -1,14 +1,19 @@
 package com.mapbox.mapboxsdk.maps;
 
 import android.os.Handler;
+import android.os.Message;
+import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 
+import java.lang.annotation.Retention;
+import java.lang.ref.WeakReference;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import static com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraIdleListener;
 import static com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraMoveCanceledListener;
 import static com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraMoveListener;
 import static com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraMoveStartedListener;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 /**
  * Class responsible for dispatching camera change events to registered listeners.
@@ -16,7 +21,7 @@ import static com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraMoveStartedListener;
 class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, MapboxMap.OnCameraMoveListener,
   MapboxMap.OnCameraMoveCanceledListener, OnCameraIdleListener {
 
-  private final Handler handler = new Handler();
+  private final CameraChangeHandler handler = new CameraChangeHandler(this);
 
   private boolean idle = true;
   private int moveStartedReason;
@@ -31,83 +36,36 @@ class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, M
   private OnCameraMoveListener onCameraMoveListener;
   private OnCameraIdleListener onCameraIdleListener;
 
-  private final Runnable onCameraMoveStartedRunnable = new Runnable() {
-    @Override
-    public void run() {
-      if (!idle) {
-        return;
-      }
-      idle = false;
+  @Retention(SOURCE)
+  @IntDef( {MOVE_STARTED, MOVE, MOVE_CANCELED, IDLE})
+  @interface CameraChange {
+  }
 
-      // deprecated API
-      if (onCameraMoveStartedListener != null) {
-        onCameraMoveStartedListener.onCameraMoveStarted(moveStartedReason);
-      }
+  private static final int MOVE_STARTED = 0;
+  private static final int MOVE = 1;
+  private static final int MOVE_CANCELED = 2;
+  private static final int IDLE = 3;
 
-      // new API
-      if (!onCameraMoveStarted.isEmpty()) {
-        for (OnCameraMoveStartedListener cameraMoveStartedListener : onCameraMoveStarted) {
-          cameraMoveStartedListener.onCameraMoveStarted(moveStartedReason);
-        }
-      }
-    }
-  };
+  @Override
+  public void onCameraMoveStarted(final int reason) {
+    moveStartedReason = reason;
+    handler.scheduleMessage(MOVE_STARTED);
+  }
 
-  private final Runnable onCameraMoveRunnable = new Runnable() {
-    @Override
-    public void run() {
-      // deprecated API
-      if (onCameraMoveListener != null && !idle) {
-        onCameraMoveListener.onCameraMove();
-      }
+  @Override
+  public void onCameraMove() {
+    handler.scheduleMessage(MOVE);
+  }
 
-      // new API
-      if (!onCameraMove.isEmpty() && !idle) {
-        for (OnCameraMoveListener cameraMoveListener : onCameraMove) {
-          cameraMoveListener.onCameraMove();
-        }
-      }
-    }
-  };
+  @Override
+  public void onCameraMoveCanceled() {
+    handler.scheduleMessage(MOVE_CANCELED);
+  }
 
-  private final Runnable onCameraMoveCancelRunnable = new Runnable() {
-    @Override
-    public void run() {
-      // deprecated API
-      if (onCameraMoveCanceledListener != null && !idle) {
-        onCameraMoveCanceledListener.onCameraMoveCanceled();
-      }
-
-      // new API
-      if (!onCameraMoveCanceled.isEmpty() && !idle) {
-        for (OnCameraMoveCanceledListener cameraMoveCanceledListener : onCameraMoveCanceled) {
-          cameraMoveCanceledListener.onCameraMoveCanceled();
-        }
-      }
-    }
-  };
-
-  private final Runnable onCameraIdleRunnable = new Runnable() {
-    @Override
-    public void run() {
-      if (idle) {
-        return;
-      }
-      idle = true;
-
-      // deprecated API
-      if (onCameraIdleListener != null) {
-        onCameraIdleListener.onCameraIdle();
-      }
-
-      // new API
-      if (!onCameraIdle.isEmpty()) {
-        for (OnCameraIdleListener cameraIdleListener : onCameraIdle) {
-          cameraIdleListener.onCameraIdle();
-        }
-      }
-    }
-  };
+  @Override
+  public void onCameraIdle() {
+    handler.scheduleMessage(IDLE);
+  }
 
   @Deprecated
   void setOnCameraMoveStartedListener(OnCameraMoveStartedListener onCameraMoveStartedListener) {
@@ -127,27 +85,6 @@ class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, M
   @Deprecated
   void setOnCameraIdleListener(OnCameraIdleListener onCameraIdleListener) {
     this.onCameraIdleListener = onCameraIdleListener;
-  }
-
-  @Override
-  public void onCameraMoveStarted(final int reason) {
-    moveStartedReason = reason;
-    handler.post(onCameraMoveStartedRunnable);
-  }
-
-  @Override
-  public void onCameraMove() {
-    handler.post(onCameraMoveRunnable);
-  }
-
-  @Override
-  public void onCameraMoveCanceled() {
-    handler.post(onCameraMoveCancelRunnable);
-  }
-
-  @Override
-  public void onCameraIdle() {
-    handler.post(onCameraIdleRunnable);
   }
 
   void addOnCameraIdleListener(@NonNull OnCameraIdleListener listener) {
@@ -187,6 +124,124 @@ class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, M
   void removeOnCameraMoveListener(OnCameraMoveListener listener) {
     if (onCameraMove.contains(listener)) {
       onCameraMove.remove(listener);
+    }
+  }
+
+  private void executeOnCameraMoveStarted() {
+    if (!idle) {
+      return;
+    }
+    idle = false;
+
+    // deprecated API
+    if (onCameraMoveStartedListener != null) {
+      onCameraMoveStartedListener.onCameraMoveStarted(moveStartedReason);
+    }
+
+    // new API
+    if (!onCameraMoveStarted.isEmpty()) {
+      for (OnCameraMoveStartedListener cameraMoveStartedListener : onCameraMoveStarted) {
+        cameraMoveStartedListener.onCameraMoveStarted(moveStartedReason);
+      }
+    }
+  }
+
+  private void executeOnCameraMove() {
+    // deprecated API
+    if (onCameraMoveListener != null && !idle) {
+      onCameraMoveListener.onCameraMove();
+    }
+
+    // new API
+    if (!onCameraMove.isEmpty() && !idle) {
+      for (OnCameraMoveListener cameraMoveListener : onCameraMove) {
+        cameraMoveListener.onCameraMove();
+      }
+    }
+  }
+
+  private void executeOnCameraMoveCancelled() {
+    // deprecated API
+    if (onCameraMoveCanceledListener != null && !idle) {
+      onCameraMoveCanceledListener.onCameraMoveCanceled();
+    }
+
+    // new API
+    if (!onCameraMoveCanceled.isEmpty() && !idle) {
+      for (OnCameraMoveCanceledListener cameraMoveCanceledListener : onCameraMoveCanceled) {
+        cameraMoveCanceledListener.onCameraMoveCanceled();
+      }
+    }
+  }
+
+  private void executeOnCameraIdle() {
+    if (idle) {
+      return;
+    }
+    idle = true;
+
+    // deprecated API
+    if (onCameraIdleListener != null) {
+      onCameraIdleListener.onCameraIdle();
+    }
+
+    // new API
+    if (!onCameraIdle.isEmpty()) {
+      for (OnCameraIdleListener cameraIdleListener : onCameraIdle) {
+        cameraIdleListener.onCameraIdle();
+      }
+    }
+  }
+
+  private static class CameraChangeHandler extends Handler {
+
+    private WeakReference<CameraChangeDispatcher> dispatcherWeakReference;
+
+    CameraChangeHandler(CameraChangeDispatcher dispatcher) {
+      super();
+      this.dispatcherWeakReference = new WeakReference<>(dispatcher);
+    }
+
+    @Override
+    public void handleMessage(Message msg) {
+      CameraChangeDispatcher dispatcher = dispatcherWeakReference.get();
+      if (dispatcher != null) {
+        switch (msg.what) {
+          case MOVE_STARTED:
+            dispatcher.executeOnCameraMoveStarted();
+            break;
+          case MOVE:
+            dispatcher.executeOnCameraMove();
+            break;
+          case MOVE_CANCELED:
+            dispatcher.executeOnCameraMoveCancelled();
+            break;
+          case IDLE:
+            dispatcher.executeOnCameraIdle();
+            break;
+        }
+      }
+    }
+
+    void scheduleMessage(@CameraChange int change) {
+      CameraChangeDispatcher dispatcher = dispatcherWeakReference.get();
+      if (dispatcher != null) {
+        // if there is a movement that is cancelled/stopped and restarted in the same code block
+        // we can safely assume that the movement will continue, no need for dispatching unnecessary callbacks sequence
+        if (change == MOVE_STARTED) {
+          boolean shouldReturn = !dispatcher.idle && (hasMessages(IDLE) || hasMessages(MOVE_CANCELED));
+          removeMessages(IDLE);
+          removeMessages(MOVE_CANCELED);
+
+          if (shouldReturn) {
+            return;
+          }
+        }
+
+        Message message = new Message();
+        message.what = change;
+        this.sendMessage(message);
+      }
     }
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraPositionActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraPositionActivity.java
@@ -13,6 +13,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.SeekBar;
 import android.widget.TextView;
+
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -20,6 +21,7 @@ import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.testapp.R;
+
 import timber.log.Timber;
 
 /**


### PR DESCRIPTION
Closes #12260.

This PR eliminates the unnecessary `canceled->idle->started` camera callback loops that occurred during gestures execution by clearing the message queue when movement is restarted and by dispatching `cancel` callback only during the start of first gesture execution and `idle` only during the finish of last.