### PR TITLE
Update telemetry dependency to 3.2.1

### DIFF
--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
     versions = [
             mapboxServices  : '3.4.1',
-            mapboxTelemetry : '3.1.5',
+            mapboxTelemetry : '3.2.1',
             mapboxGestures  : '0.2.0',
             supportLib      : '27.1.1',
             constraintLayout: '1.1.2',


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/12460.

Updates telemetry dependency from 3.1.5 to 3.2.1.