### PR TITLE
Format expression Android bindings

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
@@ -3224,6 +3224,11 @@ public class Expression {
     return new Expression("collator", new ExpressionMap(map));
   }
 
+  public static Expression format(Expression input) {
+    Map<String, Expression> map = new HashMap<>();
+    return new Expression("format", input, new ExpressionMap(map));
+  }
+
   /**
    * Asserts that the input value is an object. If it is not, the expression is an error
    * The asserted input value is returned as result.

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
@@ -3246,10 +3246,13 @@ public class Expression {
    *     format(
    *       formatEntry(
    *         get("header_property"),
-   *         fontScale(2.0),
-   *         textFont(new String[] {"DIN Offc Pro Regular", "Arial Unicode MS Regular"})
+   *         formatFontScale(2.0),
+   *         formatTextFont(new String[] {"DIN Offc Pro Regular", "Arial Unicode MS Regular"})
    *       ),
-   *       formatEntry(concat(literal("\n"), get("description_property")), fontScale(1.5)),
+   *       formatEntry(concat(literal("\n"), get("description_property")), formatFontScale(1.5))
+   *     )
+   *   )
+   * );
    * }
    * </pre>
    *
@@ -4375,7 +4378,7 @@ public class Expression {
      * @return format option
      */
     @NonNull
-    public static FormatOption fontScale(@NonNull Expression expression) {
+    public static FormatOption formatFontScale(@NonNull Expression expression) {
       return new FormatOption("font-scale", expression);
     }
 
@@ -4389,7 +4392,7 @@ public class Expression {
      * @return format option
      */
     @NonNull
-    public static FormatOption fontScale(double scale) {
+    public static FormatOption formatFontScale(double scale) {
       return new FormatOption("font-scale", literal(scale));
     }
 
@@ -4405,7 +4408,7 @@ public class Expression {
      * @return format option
      */
     @NonNull
-    public static FormatOption textFont(@NonNull Expression expression) {
+    public static FormatOption formatTextFont(@NonNull Expression expression) {
       return new FormatOption("text-font", expression);
     }
 
@@ -4421,7 +4424,7 @@ public class Expression {
      * @return format option
      */
     @NonNull
-    public static FormatOption textFont(@NonNull String[] fontStack) {
+    public static FormatOption formatTextFont(@NonNull String[] fontStack) {
       return new FormatOption("text-font", literal(fontStack));
     }
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyValue.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyValue.java
@@ -62,7 +62,7 @@ public class PropertyValue<T> {
         ? Expression.Converter.convert((JsonArray) value)
         : (Expression) value;
     } else {
-      Logger.w(TAG, "not a expression, try value");
+      Logger.w(TAG, "not an expression, try PropertyValue#getValue()");
       return null;
     }
   }
@@ -87,7 +87,7 @@ public class PropertyValue<T> {
       // noinspection unchecked
       return value;
     } else {
-      Logger.w(TAG, "not a value, try function");
+      Logger.w(TAG, "not a value, try PropertyValue#getExpression()");
       return null;
     }
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/SymbolLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/SymbolLayer.java
@@ -386,7 +386,7 @@ public class SymbolLayer extends Layer {
    * Get the TextField property as {@link Formatted} object
    *
    * @return property wrapper value around String
-   * @see Expression#format(Expression...)
+   * @see Expression#format(Expression.FormatEntry...)
    */
   @SuppressWarnings("unchecked")
   public PropertyValue<Formatted> getFormattedTextField() {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/SymbolLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/SymbolLayer.java
@@ -13,6 +13,8 @@ import static com.mapbox.mapboxsdk.utils.ColorUtils.rgbaToColor;
 import com.google.gson.JsonArray;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+import com.mapbox.mapboxsdk.style.types.Formatted;
+import com.mapbox.mapboxsdk.style.types.FormattedSection;
 
 /**
  * An icon or a text label.
@@ -365,7 +367,31 @@ public class SymbolLayer extends Layer {
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getTextField() {
     checkThread();
-    return (PropertyValue<String>) new PropertyValue("text-field", nativeGetTextField());
+
+    PropertyValue propertyValue = new PropertyValue<>("text-field", nativeGetTextField());
+    if (propertyValue.isExpression()) {
+      return (PropertyValue<String>) propertyValue;
+    } else {
+      Formatted formatted = (Formatted) nativeGetTextField();
+      StringBuilder builder = new StringBuilder();
+      for (FormattedSection section : formatted.getFormattedSections()) {
+        builder.append(section.getText());
+      }
+
+      return (PropertyValue<String>) new PropertyValue("text-field", builder.toString());
+    }
+  }
+
+  /**
+   * Get the TextField property as {@link Formatted} object
+   *
+   * @return property wrapper value around String
+   * @see Expression#format(Expression...)
+   */
+  @SuppressWarnings("unchecked")
+  public PropertyValue<Formatted> getFormattedTextField() {
+    checkThread();
+    return (PropertyValue<Formatted>) new PropertyValue("text-field", nativeGetTextField());
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/layer.java.ejs
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/layer.java.ejs
@@ -199,7 +199,7 @@ public class <%- camelize(type) %>Layer extends Layer {
    * Get the <%- camelize(property.name) %> property as {@link Formatted} object
    *
    * @return property wrapper value around <%- propertyType(property) %>
-   * @see Expression#format(Expression...)
+   * @see Expression#format(Expression.FormatEntry...)
    */
   @SuppressWarnings("unchecked")
   public PropertyValue<Formatted> getFormatted<%- camelize(property.name) %>() {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/layer.java.ejs
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/layer.java.ejs
@@ -18,6 +18,10 @@ import static com.mapbox.mapboxsdk.utils.ColorUtils.rgbaToColor;
 import com.google.gson.JsonArray;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+<% if (type === 'symbol') { -%>
+import com.mapbox.mapboxsdk.style.types.Formatted;
+import com.mapbox.mapboxsdk.style.types.FormattedSection;
+<% } -%>
 
 /**
  * <%- doc %>
@@ -171,8 +175,38 @@ public class <%- camelize(type) %>Layer extends Layer {
   @SuppressWarnings("unchecked")
   public PropertyValue<<%- propertyType(property) %>> get<%- camelize(property.name) %>() {
     checkThread();
+<% if (property.name === 'text-field' && property.type === 'formatted') { -%>
+
+    PropertyValue propertyValue = new PropertyValue<>("text-field", nativeGetTextField());
+    if (propertyValue.isExpression()) {
+      return (PropertyValue<String>) propertyValue;
+    } else {
+      Formatted formatted = (Formatted) nativeGetTextField();
+      StringBuilder builder = new StringBuilder();
+      for (FormattedSection section : formatted.getFormattedSections()) {
+        builder.append(section.getText());
+      }
+
+      return (PropertyValue<String>) new PropertyValue("text-field", builder.toString());
+    }
+<% } else { -%>
     return (PropertyValue<<%- propertyType(property) %>>) new PropertyValue("<%- property.name %>", nativeGet<%- camelize(property.name) %>());
+<% } -%>
   }
+<% if (property.name === 'text-field' && property.type === 'formatted') { -%>
+
+  /**
+   * Get the <%- camelize(property.name) %> property as {@link Formatted} object
+   *
+   * @return property wrapper value around <%- propertyType(property) %>
+   * @see Expression#format(Expression...)
+   */
+  @SuppressWarnings("unchecked")
+  public PropertyValue<Formatted> getFormatted<%- camelize(property.name) %>() {
+    checkThread();
+    return (PropertyValue<Formatted>) new PropertyValue("<%- property.name %>", nativeGet<%- camelize(property.name) %>());
+  }
+<% } -%>
 <% if (property.type == 'color') { -%>
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/types/Formatted.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/types/Formatted.java
@@ -1,0 +1,54 @@
+package com.mapbox.mapboxsdk.style.types;
+
+import android.support.annotation.Keep;
+import android.support.annotation.VisibleForTesting;
+
+import java.util.Arrays;
+
+/**
+ * Represents a string broken into sections annotated with separate formatting options.
+ *
+ * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#types-formatted">Style specification</a>
+ */
+@Keep
+public class Formatted {
+  private final FormattedSection[] formattedSections;
+
+  /**
+   * Create a new formatted text.
+   *
+   * @param formattedSections sections with formatting options
+   */
+  @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
+  public Formatted(FormattedSection[] formattedSections) {
+    this.formattedSections = formattedSections;
+  }
+
+  /**
+   * Returns sections with separate formatting options that are a part of this formatted text.
+   *
+   * @return formatted sections
+   */
+  public FormattedSection[] getFormattedSections() {
+    return formattedSections;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Formatted formatted = (Formatted) o;
+
+    return Arrays.equals(formattedSections, formatted.formattedSections);
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(formattedSections);
+  }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/types/FormattedSection.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/types/FormattedSection.java
@@ -1,0 +1,100 @@
+package com.mapbox.mapboxsdk.style.types;
+
+import android.support.annotation.Keep;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
+
+import java.util.Arrays;
+
+/**
+ * A component of the {@link Formatted}.
+ */
+@Keep
+public class FormattedSection {
+  private String text;
+  private double fontScale;
+  private String[] fontStack;
+
+  /**
+   * Creates a formatted section.
+   *
+   * @param text      displayed string
+   * @param fontScale scale of the font, 1.0 is default
+   * @param fontStack main and fallback fonts that are a part of the style
+   */
+  @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
+  public FormattedSection(@NonNull String text, double fontScale, @Nullable String[] fontStack) {
+    this.text = text;
+    this.fontScale = fontScale;
+    this.fontStack = fontStack;
+  }
+
+  /**
+   * Creates a formatted section.
+   *
+   * @param text      displayed string
+   * @param fontScale scale of the font, 1.0 is default
+   */
+  @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
+  public FormattedSection(@NonNull String text, double fontScale) {
+    this.text = text;
+    this.fontScale = fontScale;
+  }
+
+  /**
+   * Returns the displayed text.
+   *
+   * @return text
+   */
+  @NonNull
+  public String getText() {
+    return text;
+  }
+
+  /**
+   * Returns displayed text's font scale.
+   *
+   * @return font scale, defaults to 1.0
+   */
+  public double getFontScale() {
+    return fontScale;
+  }
+
+  /**
+   * Returns the font stack with main and fallback fonts.
+   *
+   * @return font stack
+   */
+  @Nullable
+  public String[] getFontStack() {
+    return fontStack;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    FormattedSection section = (FormattedSection) o;
+
+    return Double.compare(section.fontScale, fontScale) == 0
+      && (text != null ? text.equals(section.text) : section.text == null)
+      && Arrays.equals(fontStack, section.fontStack);
+  }
+
+  @Override
+  public int hashCode() {
+    int result;
+    long temp;
+    result = text != null ? text.hashCode() : 0;
+    temp = Double.doubleToLongBits(fontScale);
+    result = 31 * result + (int) (temp ^ (temp >>> 32));
+    result = 31 * result + Arrays.hashCode(fontStack);
+    return result;
+  }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.java
@@ -14,8 +14,8 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import static com.mapbox.mapboxsdk.style.expressions.Expression.FormatOption.fontScale;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.FormatOption.textFont;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.FormatOption.formatFontScale;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.FormatOption.formatTextFont;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.abs;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.acos;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.all;
@@ -1420,7 +1420,8 @@ public class ExpressionTest {
       }
     };
     Object[] actual = format(
-      formatEntry(literal("test"), fontScale(literal(1.5)), textFont(literal(new String[] {"awesome"})))
+      formatEntry(
+        literal("test"), formatFontScale(literal(1.5)), formatTextFont(literal(new String[] {"awesome"})))
     ).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
@@ -1455,10 +1456,11 @@ public class ExpressionTest {
       }
     };
     Object[] actual = format(
-      formatEntry(literal("test"), textFont(new String[] {"awesome"})),
-      formatEntry("test2", fontScale(1.5)),
+      formatEntry(literal("test"), formatTextFont(new String[] {"awesome"})),
+      formatEntry("test2", formatFontScale(1.5)),
       formatEntry(literal("test3")),
-      formatEntry(literal("test4"), fontScale(literal(1.5)), textFont(new String[] {"awesome"}))
+      formatEntry(
+        literal("test4"), formatFontScale(literal(1.5)), formatTextFont(new String[] {"awesome"}))
     ).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CircleLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CircleLayerTest.java
@@ -161,7 +161,6 @@ public class CircleLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testCircleColorTransition() {
     validateTestSetup();
@@ -205,7 +204,6 @@ public class CircleLayerTest extends BaseActivityTest {
       assertEquals(layer.getCircleColor().getExpression(), expression);
     });
   }
-
 
   @Test
   public void testCircleColorAsIntConstant() {
@@ -265,7 +263,6 @@ public class CircleLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testCircleOpacityTransition() {
     validateTestSetup();
@@ -309,7 +306,6 @@ public class CircleLayerTest extends BaseActivityTest {
       assertEquals(layer.getCircleOpacity().getExpression(), expression);
     });
   }
-
 
   @Test
   public void testCircleTranslateTransition() {
@@ -426,7 +422,6 @@ public class CircleLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testCircleStrokeColorTransition() {
     validateTestSetup();
@@ -470,7 +465,6 @@ public class CircleLayerTest extends BaseActivityTest {
       assertEquals(layer.getCircleStrokeColor().getExpression(), expression);
     });
   }
-
 
   @Test
   public void testCircleStrokeColorAsIntConstant() {
@@ -529,5 +523,4 @@ public class CircleLayerTest extends BaseActivityTest {
       assertEquals(layer.getCircleStrokeOpacity().getExpression(), expression);
     });
   }
-
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/ExpressionTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/ExpressionTest.java
@@ -30,8 +30,8 @@ import java.io.IOException;
 
 import timber.log.Timber;
 
-import static com.mapbox.mapboxsdk.style.expressions.Expression.FormatOption.fontScale;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.FormatOption.textFont;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.FormatOption.formatFontScale;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.FormatOption.formatTextFont;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.collator;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.eq;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.exponential;
@@ -315,7 +315,7 @@ public class ExpressionTest extends BaseActivityTest {
       mapboxMap.addLayer(layer);
 
       Expression expression = format(
-        formatEntry("test", fontScale(1.75))
+        formatEntry("test", formatFontScale(1.75))
       );
       layer.setProperties(textField(expression));
       waitForLayer(uiController, mapboxMap, latLng);
@@ -344,13 +344,16 @@ public class ExpressionTest extends BaseActivityTest {
 
       Expression expression = format(
         formatEntry(
-          literal("test"), fontScale(1.0), textFont(new String[] {"DIN Offc Pro Regular", "Arial Unicode MS Regular"})
+          literal("test"),
+          formatFontScale(1.0),
+          formatTextFont(new String[] {"DIN Offc Pro Regular", "Arial Unicode MS Regular"})
         )
       );
       layer.setProperties(textField(expression));
       waitForLayer(uiController, mapboxMap, latLng);
-      assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")
-        .isEmpty());
+      assertFalse(
+        mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer").isEmpty()
+      );
 
       assertNull(layer.getTextField().getExpression());
       assertEquals("test", layer.getTextField().getValue());
@@ -375,13 +378,16 @@ public class ExpressionTest extends BaseActivityTest {
 
       Expression expression = format(
         formatEntry(
-          "test", fontScale(0.5), textFont(new String[] {"DIN Offc Pro Regular", "Arial Unicode MS Regular"})
+          "test",
+          formatFontScale(0.5),
+          formatTextFont(new String[] {"DIN Offc Pro Regular", "Arial Unicode MS Regular"})
         )
       );
       layer.setProperties(textField(expression));
       waitForLayer(uiController, mapboxMap, latLng);
-      assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")
-        .isEmpty());
+      assertFalse(
+        mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer").isEmpty()
+      );
 
       assertNull(layer.getTextField().getExpression());
       assertEquals("test", layer.getTextField().getValue());
@@ -404,14 +410,17 @@ public class ExpressionTest extends BaseActivityTest {
 
       Expression expression = format(
         formatEntry(
-          "test", fontScale(1.5), textFont(new String[] {"DIN Offc Pro Regular", "Arial Unicode MS Regular"})
+          "test",
+          formatFontScale(1.5),
+          formatTextFont(new String[] {"DIN Offc Pro Regular", "Arial Unicode MS Regular"})
         ),
-        formatEntry("\ntest2", fontScale(2))
+        formatEntry("\ntest2", formatFontScale(2))
       );
       layer.setProperties(textField(expression));
       waitForLayer(uiController, mapboxMap, latLng);
-      assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")
-        .isEmpty());
+      assertFalse(
+        mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer").isEmpty()
+      );
 
       assertNull(layer.getTextField().getExpression());
       assertEquals("test\ntest2", layer.getTextField().getValue());
@@ -440,8 +449,8 @@ public class ExpressionTest extends BaseActivityTest {
       Expression expression = format(
         formatEntry(
           get("test_property"),
-          fontScale(number(get("test_property_number"))),
-          textFont(new String[] {"Arial Unicode MS Regular", "DIN Offc Pro Regular"})
+          Expression.FormatOption.formatFontScale(number(get("test_property_number"))),
+          formatTextFont(new String[] {"Arial Unicode MS Regular", "DIN Offc Pro Regular"})
         )
       );
       layer.setProperties(textField(expression));
@@ -472,10 +481,10 @@ public class ExpressionTest extends BaseActivityTest {
       Expression expression = format(
         formatEntry(
           get("test_property"),
-          fontScale(1.25),
-          textFont(new String[] {"Arial Unicode MS Regular", "DIN Offc Pro Regular"})
+          formatFontScale(1.25),
+          formatTextFont(new String[] {"Arial Unicode MS Regular", "DIN Offc Pro Regular"})
         ),
-        formatEntry("\ntest2", fontScale(2))
+        formatEntry("\ntest2", formatFontScale(2))
       );
       layer.setProperties(textField(expression));
       waitForLayer(uiController, mapboxMap, latLng);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/ExpressionTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/ExpressionTest.java
@@ -1,16 +1,22 @@
 package com.mapbox.mapboxsdk.testapp.style;
 
 import android.graphics.Color;
+import android.support.test.espresso.UiController;
 import android.support.test.runner.AndroidJUnit4;
 
+import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.CircleLayer;
 import com.mapbox.mapboxsdk.style.layers.FillLayer;
 import com.mapbox.mapboxsdk.style.layers.Layer;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.style.sources.Source;
+import com.mapbox.mapboxsdk.style.types.Formatted;
+import com.mapbox.mapboxsdk.style.types.FormattedSection;
 import com.mapbox.mapboxsdk.testapp.R;
 import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
@@ -24,13 +30,18 @@ import java.io.IOException;
 
 import timber.log.Timber;
 
+import static com.mapbox.mapboxsdk.style.expressions.Expression.FormatOption.fontScale;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.FormatOption.textFont;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.collator;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.eq;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.exponential;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.format;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.formatEntry;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.interpolate;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.literal;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.match;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.number;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.rgb;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.rgba;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.step;
@@ -43,9 +54,11 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleColor;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillAntialias;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillColor;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillOutlineColor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textField;
 import static com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 
 @RunWith(AndroidJUnit4.class)
 public class ExpressionTest extends BaseActivityTest {
@@ -220,7 +233,6 @@ public class ExpressionTest extends BaseActivityTest {
   @Test
   public void testCollatorExpression() {
     validateTestSetup();
-    setupStyle();
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       LatLng latLng = new LatLng(51, 17);
 
@@ -263,6 +275,254 @@ public class ExpressionTest extends BaseActivityTest {
       assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")
         .isEmpty());
     });
+  }
+
+  @Test
+  public void testConstFormatExpressionNoParams() {
+    validateTestSetup();
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      LatLng latLng = new LatLng(51, 17);
+      mapboxMap.addSource(new GeoJsonSource("source", Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude())));
+      SymbolLayer layer = new SymbolLayer("layer", "source");
+      mapboxMap.addLayer(layer);
+
+      Expression expression = format(
+        formatEntry("test")
+      );
+      layer.setProperties(textField(expression));
+      waitForLayer(uiController, mapboxMap, latLng);
+      assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")
+        .isEmpty());
+
+      assertNull(layer.getTextField().getExpression());
+      assertEquals("test", layer.getTextField().getValue());
+
+      Formatted expected = new Formatted(new FormattedSection[] {
+        new FormattedSection("test", 1.0f)
+      });
+      assertNull(layer.getFormattedTextField().getExpression());
+      assertEquals(expected, layer.getFormattedTextField().getValue());
+    });
+  }
+
+  @Test
+  public void testConstFormatExpressionFontScaleParam() {
+    validateTestSetup();
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      LatLng latLng = new LatLng(51, 17);
+      mapboxMap.addSource(new GeoJsonSource("source", Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude())));
+      SymbolLayer layer = new SymbolLayer("layer", "source");
+      mapboxMap.addLayer(layer);
+
+      Expression expression = format(
+        formatEntry("test", fontScale(1.75))
+      );
+      layer.setProperties(textField(expression));
+      waitForLayer(uiController, mapboxMap, latLng);
+      assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")
+        .isEmpty());
+
+      assertNull(layer.getTextField().getExpression());
+      assertEquals("test", layer.getTextField().getValue());
+
+      Formatted expected = new Formatted(new FormattedSection[] {
+        new FormattedSection("test", 1.75f)
+      });
+      assertNull(layer.getFormattedTextField().getExpression());
+      assertEquals(expected, layer.getFormattedTextField().getValue());
+    });
+  }
+
+  @Test
+  public void testConstFormatExpressionTextFontParam() {
+    validateTestSetup();
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      LatLng latLng = new LatLng(51, 17);
+      mapboxMap.addSource(new GeoJsonSource("source", Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude())));
+      SymbolLayer layer = new SymbolLayer("layer", "source");
+      mapboxMap.addLayer(layer);
+
+      Expression expression = format(
+        formatEntry(
+          literal("test"), fontScale(1.0), textFont(new String[] {"DIN Offc Pro Regular", "Arial Unicode MS Regular"})
+        )
+      );
+      layer.setProperties(textField(expression));
+      waitForLayer(uiController, mapboxMap, latLng);
+      assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")
+        .isEmpty());
+
+      assertNull(layer.getTextField().getExpression());
+      assertEquals("test", layer.getTextField().getValue());
+
+      Formatted expected = new Formatted(new FormattedSection[] {
+        new FormattedSection("test", 1.0f,
+          new String[] {"DIN Offc Pro Regular", "Arial Unicode MS Regular"})
+      });
+      assertNull(layer.getFormattedTextField().getExpression());
+      assertEquals(expected, layer.getFormattedTextField().getValue());
+    });
+  }
+
+  @Test
+  public void testConstFormatExpressionAllParams() {
+    validateTestSetup();
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      LatLng latLng = new LatLng(51, 17);
+      mapboxMap.addSource(new GeoJsonSource("source", Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude())));
+      SymbolLayer layer = new SymbolLayer("layer", "source");
+      mapboxMap.addLayer(layer);
+
+      Expression expression = format(
+        formatEntry(
+          "test", fontScale(0.5), textFont(new String[] {"DIN Offc Pro Regular", "Arial Unicode MS Regular"})
+        )
+      );
+      layer.setProperties(textField(expression));
+      waitForLayer(uiController, mapboxMap, latLng);
+      assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")
+        .isEmpty());
+
+      assertNull(layer.getTextField().getExpression());
+      assertEquals("test", layer.getTextField().getValue());
+
+      Formatted expected = new Formatted(new FormattedSection[] {
+        new FormattedSection("test", 0.5f, new String[] {"DIN Offc Pro Regular", "Arial Unicode MS Regular"})});
+      assertNull(layer.getFormattedTextField().getExpression());
+      assertEquals(expected, layer.getFormattedTextField().getValue());
+    });
+  }
+
+  @Test
+  public void testConstFormatExpressionMultipleInputs() {
+    validateTestSetup();
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      LatLng latLng = new LatLng(51, 17);
+      mapboxMap.addSource(new GeoJsonSource("source", Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude())));
+      SymbolLayer layer = new SymbolLayer("layer", "source");
+      mapboxMap.addLayer(layer);
+
+      Expression expression = format(
+        formatEntry(
+          "test", fontScale(1.5), textFont(new String[] {"DIN Offc Pro Regular", "Arial Unicode MS Regular"})
+        ),
+        formatEntry("\ntest2", fontScale(2))
+      );
+      layer.setProperties(textField(expression));
+      waitForLayer(uiController, mapboxMap, latLng);
+      assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")
+        .isEmpty());
+
+      assertNull(layer.getTextField().getExpression());
+      assertEquals("test\ntest2", layer.getTextField().getValue());
+
+      Formatted expected = new Formatted(new FormattedSection[] {
+        new FormattedSection("test", 1.5f, new String[] {"DIN Offc Pro Regular", "Arial Unicode MS Regular"}),
+        new FormattedSection("\ntest2", 2f),
+      });
+      assertNull(layer.getFormattedTextField().getExpression());
+      assertEquals(expected, layer.getFormattedTextField().getValue());
+    });
+  }
+
+  @Test
+  public void testVariableFormatExpression() {
+    validateTestSetup();
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      LatLng latLng = new LatLng(51, 17);
+      Feature feature = Feature.fromGeometry(Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()));
+      feature.addStringProperty("test_property", "test");
+      feature.addNumberProperty("test_property_number", 1.5);
+      mapboxMap.addSource(new GeoJsonSource("source", feature));
+      SymbolLayer layer = new SymbolLayer("layer", "source");
+      mapboxMap.addLayer(layer);
+
+      Expression expression = format(
+        formatEntry(
+          get("test_property"),
+          fontScale(number(get("test_property_number"))),
+          textFont(new String[] {"Arial Unicode MS Regular", "DIN Offc Pro Regular"})
+        )
+      );
+      layer.setProperties(textField(expression));
+      waitForLayer(uiController, mapboxMap, latLng);
+      assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")
+        .isEmpty());
+
+      assertEquals(expression, layer.getTextField().getExpression());
+      assertNull(layer.getTextField().getValue());
+
+      assertEquals(expression, layer.getFormattedTextField().getExpression());
+      assertNull(layer.getFormattedTextField().getValue());
+    });
+  }
+
+  @Test
+  public void testVariableFormatExpressionMultipleInputs() {
+    validateTestSetup();
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      LatLng latLng = new LatLng(51, 17);
+      Feature feature = Feature.fromGeometry(Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()));
+      feature.addStringProperty("test_property", "test");
+      feature.addNumberProperty("test_property_number", 1.5);
+      mapboxMap.addSource(new GeoJsonSource("source", feature));
+      SymbolLayer layer = new SymbolLayer("layer", "source");
+      mapboxMap.addLayer(layer);
+
+      Expression expression = format(
+        formatEntry(
+          get("test_property"),
+          fontScale(1.25),
+          textFont(new String[] {"Arial Unicode MS Regular", "DIN Offc Pro Regular"})
+        ),
+        formatEntry("\ntest2", fontScale(2))
+      );
+      layer.setProperties(textField(expression));
+      waitForLayer(uiController, mapboxMap, latLng);
+      assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")
+        .isEmpty());
+
+      assertEquals(expression, layer.getTextField().getExpression());
+      assertNull(layer.getTextField().getValue());
+
+      assertEquals(expression, layer.getFormattedTextField().getExpression());
+      assertNull(layer.getFormattedTextField().getValue());
+    });
+  }
+
+  @Test
+  public void testFormatExpressionPlainTextCoercion() {
+    validateTestSetup();
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      LatLng latLng = new LatLng(51, 17);
+      mapboxMap.addSource(new GeoJsonSource("source", Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude())));
+      SymbolLayer layer = new SymbolLayer("layer", "source");
+      mapboxMap.addLayer(layer);
+
+      layer.setProperties(textField("test"));
+      waitForLayer(uiController, mapboxMap, latLng);
+      assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")
+        .isEmpty());
+
+      assertNull(layer.getTextField().getExpression());
+      assertEquals("test", layer.getTextField().getValue());
+
+      assertNull(layer.getFormattedTextField().getExpression());
+      Formatted expected = new Formatted(new FormattedSection[] {new FormattedSection("test", 1.0f)});
+      assertEquals(expected, layer.getFormattedTextField().getValue());
+    });
+  }
+
+  private static final long WAIT_TIMEOUT = 5000;
+  private static final long WAIT_DELAY = 150;
+
+  private static void waitForLayer(UiController uiController, MapboxMap mapboxMap, LatLng latLng) {
+    int i = 0;
+    while (mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer").isEmpty()) {
+      i++;
+      assertFalse("Waiting for layer timed out", i * WAIT_DELAY > WAIT_TIMEOUT);
+      uiController.loopMainThreadForAtLeast(WAIT_DELAY);
+    }
   }
 
   private void setupStyle() {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillExtrusionLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillExtrusionLayerTest.java
@@ -190,7 +190,6 @@ public class FillExtrusionLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testFillExtrusionColorAsIntConstant() {
     validateTestSetup();
@@ -292,7 +291,6 @@ public class FillExtrusionLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testFillExtrusionHeightTransition() {
     validateTestSetup();
@@ -337,7 +335,6 @@ public class FillExtrusionLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testFillExtrusionBaseTransition() {
     validateTestSetup();
@@ -381,5 +378,4 @@ public class FillExtrusionLayerTest extends BaseActivityTest {
       assertEquals(layer.getFillExtrusionBase().getExpression(), expression);
     });
   }
-
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillLayerTest.java
@@ -175,7 +175,6 @@ public class FillLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testFillColorTransition() {
     validateTestSetup();
@@ -219,7 +218,6 @@ public class FillLayerTest extends BaseActivityTest {
       assertEquals(layer.getFillColor().getExpression(), expression);
     });
   }
-
 
   @Test
   public void testFillColorAsIntConstant() {
@@ -278,7 +276,6 @@ public class FillLayerTest extends BaseActivityTest {
       assertEquals(layer.getFillOutlineColor().getExpression(), expression);
     });
   }
-
 
   @Test
   public void testFillOutlineColorAsIntConstant() {
@@ -380,5 +377,4 @@ public class FillLayerTest extends BaseActivityTest {
       assertEquals(layer.getFillPattern().getExpression(), expression);
     });
   }
-
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HeatmapLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HeatmapLayerTest.java
@@ -161,7 +161,6 @@ public class HeatmapLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testHeatmapWeightAsConstant() {
     validateTestSetup();
@@ -190,7 +189,6 @@ public class HeatmapLayerTest extends BaseActivityTest {
       assertEquals(layer.getHeatmapWeight().getExpression(), expression);
     });
   }
-
 
   @Test
   public void testHeatmapIntensityTransition() {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
@@ -160,7 +160,6 @@ public class LineLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testLineMiterLimitAsConstant() {
     validateTestSetup();
@@ -233,7 +232,6 @@ public class LineLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testLineColorTransition() {
     validateTestSetup();
@@ -277,7 +275,6 @@ public class LineLayerTest extends BaseActivityTest {
       assertEquals(layer.getLineColor().getExpression(), expression);
     });
   }
-
 
   @Test
   public void testLineColorAsIntConstant() {
@@ -380,7 +377,6 @@ public class LineLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testLineGapWidthTransition() {
     validateTestSetup();
@@ -424,7 +420,6 @@ public class LineLayerTest extends BaseActivityTest {
       assertEquals(layer.getLineGapWidth().getExpression(), expression);
     });
   }
-
 
   @Test
   public void testLineOffsetTransition() {
@@ -499,7 +494,6 @@ public class LineLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testLineDasharrayTransition() {
     validateTestSetup();
@@ -572,5 +566,4 @@ public class LineLayerTest extends BaseActivityTest {
       assertEquals(layer.getLinePattern().getExpression(), expression);
     });
   }
-
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
@@ -13,8 +13,6 @@ import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.*;
 import static com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke;
@@ -479,18 +477,8 @@ public class SymbolLayerTest extends BaseActivityTest {
       assertEquals((String) layer.getTextField().getValue(), (String) "");
 
       layer.setProperties(textField("{token}"));
-      JsonArray formatExpression = new JsonArray();
-      formatExpression.add("format");
-      JsonArray getExpression = new JsonArray();
-      getExpression.add("get");
-      getExpression.add("token");
-      JsonArray stringCoercion = new JsonArray();
-      stringCoercion.add("to-string");
-      stringCoercion.add(getExpression);
-      formatExpression.add(stringCoercion);
-      formatExpression.add(new JsonObject());
       assertEquals(layer.getTextField().getExpression(),
-         Converter.convert(formatExpression));
+         Expression.format(Expression.toString(Expression.get("token"))));
     });
   }
 
@@ -503,17 +491,7 @@ public class SymbolLayerTest extends BaseActivityTest {
       assertNotNull(layer);
 
       // Set and Get
-      JsonArray formatExpression = new JsonArray();
-      formatExpression.add("format");
-      JsonArray getExpression = new JsonArray();
-      getExpression.add("get");
-      getExpression.add("undefined");
-      JsonArray stringAssertion = new JsonArray();
-      stringAssertion.add("string");
-      stringAssertion.add(getExpression);
-      formatExpression.add(stringAssertion);
-      formatExpression.add(new JsonObject());
-      Expression expression = Converter.convert(formatExpression);
+      Expression expression = Expression.format(string(Expression.get("undefined")));
       layer.setProperties(textField(expression));
       assertEquals(layer.getTextField().getExpression(), expression);
     });

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
@@ -9,6 +9,8 @@ import timber.log.Timber;
 
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
+import com.mapbox.mapboxsdk.style.types.Formatted;
+import com.mapbox.mapboxsdk.style.types.FormattedSection;
 import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 
 import org.junit.Test;
@@ -258,7 +260,6 @@ public class SymbolLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testIconTextFitAsConstant() {
     validateTestSetup();
@@ -319,7 +320,6 @@ public class SymbolLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testIconRotateAsConstant() {
     validateTestSetup();
@@ -348,7 +348,6 @@ public class SymbolLayerTest extends BaseActivityTest {
       assertEquals(layer.getIconRotate().getExpression(), expression);
     });
   }
-
 
   @Test
   public void testIconPaddingAsConstant() {
@@ -421,7 +420,6 @@ public class SymbolLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testIconPitchAlignmentAsConstant() {
     validateTestSetup();
@@ -477,8 +475,28 @@ public class SymbolLayerTest extends BaseActivityTest {
       assertEquals((String) layer.getTextField().getValue(), (String) "");
 
       layer.setProperties(textField("{token}"));
-      assertEquals(layer.getTextField().getExpression(),
-         Expression.format(Expression.toString(Expression.get("token"))));
+      assertEquals(layer.getTextField().getExpression(), Expression.format(Expression.formatEntry(Expression.toString(Expression.get("token")))));
+    });
+  }
+
+  @Test
+  public void testFormattedTextFieldAsConstant() {
+    validateTestSetup();
+    setupLayer();
+    Timber.i("text-field-formatted");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(layer);
+
+      Formatted expected = new Formatted(new FormattedSection[] {
+        new FormattedSection("", 1.0)
+      });
+
+      // Set and Get
+      layer.setProperties(textField(""));
+      assertEquals(layer.getFormattedTextField().getValue(), expected/*(String) ""*/);
+
+      layer.setProperties(textField("{token}"));
+      assertEquals(layer.getFormattedTextField().getExpression(), Expression.format(Expression.formatEntry(Expression.toString(Expression.get("token")))));
     });
   }
 
@@ -491,12 +509,26 @@ public class SymbolLayerTest extends BaseActivityTest {
       assertNotNull(layer);
 
       // Set and Get
-      Expression expression = Expression.format(string(Expression.get("undefined")));
+      Expression expression = string(Expression.get("undefined"));
       layer.setProperties(textField(expression));
-      assertEquals(layer.getTextField().getExpression(), expression);
+      assertEquals(layer.getTextField().getExpression(), Expression.format(Expression.formatEntry(expression)));
     });
   }
 
+  @Test
+  public void testFormattedTextFieldAsExpression() {
+    validateTestSetup();
+    setupLayer();
+    Timber.i("text-field-formatted-expression");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(layer);
+
+      // Set and Get
+      Expression expression = string(Expression.get("undefined"));
+      layer.setProperties(textField(expression));
+      assertEquals(layer.getFormattedTextField().getExpression(), Expression.format(Expression.formatEntry(Expression.string(Expression.get("undefined")))));
+    });
+  }
 
   @Test
   public void testTextFontAsConstant() {
@@ -541,7 +573,6 @@ public class SymbolLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testTextMaxWidthAsConstant() {
     validateTestSetup();
@@ -570,7 +601,6 @@ public class SymbolLayerTest extends BaseActivityTest {
       assertEquals(layer.getTextMaxWidth().getExpression(), expression);
     });
   }
-
 
   @Test
   public void testTextLineHeightAsConstant() {
@@ -615,7 +645,6 @@ public class SymbolLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testTextJustifyAsConstant() {
     validateTestSetup();
@@ -645,7 +674,6 @@ public class SymbolLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testTextAnchorAsConstant() {
     validateTestSetup();
@@ -674,7 +702,6 @@ public class SymbolLayerTest extends BaseActivityTest {
       assertEquals(layer.getTextAnchor().getExpression(), expression);
     });
   }
-
 
   @Test
   public void testTextMaxAngleAsConstant() {
@@ -718,7 +745,6 @@ public class SymbolLayerTest extends BaseActivityTest {
       assertEquals(layer.getTextRotate().getExpression(), expression);
     });
   }
-
 
   @Test
   public void testTextPaddingAsConstant() {
@@ -776,7 +802,6 @@ public class SymbolLayerTest extends BaseActivityTest {
       assertEquals(layer.getTextTransform().getExpression(), expression);
     });
   }
-
 
   @Test
   public void testTextOffsetAsConstant() {
@@ -878,7 +903,6 @@ public class SymbolLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testIconColorTransition() {
     validateTestSetup();
@@ -922,7 +946,6 @@ public class SymbolLayerTest extends BaseActivityTest {
       assertEquals(layer.getIconColor().getExpression(), expression);
     });
   }
-
 
   @Test
   public void testIconColorAsIntConstant() {
@@ -982,7 +1005,6 @@ public class SymbolLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testIconHaloColorAsIntConstant() {
     validateTestSetup();
@@ -1041,7 +1063,6 @@ public class SymbolLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testIconHaloBlurTransition() {
     validateTestSetup();
@@ -1085,7 +1106,6 @@ public class SymbolLayerTest extends BaseActivityTest {
       assertEquals(layer.getIconHaloBlur().getExpression(), expression);
     });
   }
-
 
   @Test
   public void testIconTranslateTransition() {
@@ -1174,7 +1194,6 @@ public class SymbolLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testTextColorTransition() {
     validateTestSetup();
@@ -1218,7 +1237,6 @@ public class SymbolLayerTest extends BaseActivityTest {
       assertEquals(layer.getTextColor().getExpression(), expression);
     });
   }
-
 
   @Test
   public void testTextColorAsIntConstant() {
@@ -1278,7 +1296,6 @@ public class SymbolLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testTextHaloColorAsIntConstant() {
     validateTestSetup();
@@ -1337,7 +1354,6 @@ public class SymbolLayerTest extends BaseActivityTest {
     });
   }
 
-
   @Test
   public void testTextHaloBlurTransition() {
     validateTestSetup();
@@ -1381,7 +1397,6 @@ public class SymbolLayerTest extends BaseActivityTest {
       assertEquals(layer.getTextHaloBlur().getExpression(), expression);
     });
   }
-
 
   @Test
   public void testTextTranslateTransition() {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
@@ -17,10 +17,6 @@ import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-<% if (type === 'symbol') { -%>
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-<% } -%>
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.*;
 import static com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke;
@@ -170,18 +166,8 @@ public class <%- camelize(type) %>LayerTest extends BaseActivityTest {
 
       layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>("{token}"));
 <% if (property.type === 'formatted') { -%>
-      JsonArray formatExpression = new JsonArray();
-      formatExpression.add("format");
-      JsonArray getExpression = new JsonArray();
-      getExpression.add("get");
-      getExpression.add("token");
-      JsonArray stringCoercion = new JsonArray();
-      stringCoercion.add("to-string");
-      stringCoercion.add(getExpression);
-      formatExpression.add(stringCoercion);
-      formatExpression.add(new JsonObject());
-      assertEquals(layer.getTextField().getExpression(),
-         Converter.convert(formatExpression));
+      assertEquals(layer.get<%- camelize(property.name) %>().getExpression(),
+         Expression.format(Expression.toString(Expression.get("token"))));
 <% } else { -%>
       assertEquals(layer.get<%- camelize(property.name) %>().getExpression(), Expression.toString(Expression.get("token")));
 <% } -%>
@@ -201,17 +187,7 @@ public class <%- camelize(type) %>LayerTest extends BaseActivityTest {
 
       // Set and Get
 <% if (property.type === 'formatted') { -%>
-      JsonArray formatExpression = new JsonArray();
-      formatExpression.add("format");
-      JsonArray getExpression = new JsonArray();
-      getExpression.add("get");
-      getExpression.add("undefined");
-      JsonArray stringAssertion = new JsonArray();
-      stringAssertion.add("string");
-      stringAssertion.add(getExpression);
-      formatExpression.add(stringAssertion);
-      formatExpression.add(new JsonObject());
-      Expression expression = Converter.convert(formatExpression);
+      Expression expression = Expression.format(<%- defaultExpressionJava(property) %>(Expression.get("undefined")));
 <% } else { -%>
       Expression expression = <%- defaultExpressionJava(property) %>(Expression.get("undefined"));
 <% } -%>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
@@ -13,6 +13,10 @@ import timber.log.Timber;
 
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.<%- camelize(type) %>Layer;
+<% if (type === 'symbol') { -%>
+import com.mapbox.mapboxsdk.style.types.Formatted;
+import com.mapbox.mapboxsdk.style.types.FormattedSection;
+<% } -%>
 import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 
 import org.junit.Test;
@@ -166,14 +170,38 @@ public class <%- camelize(type) %>LayerTest extends BaseActivityTest {
 
       layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>("{token}"));
 <% if (property.type === 'formatted') { -%>
-      assertEquals(layer.get<%- camelize(property.name) %>().getExpression(),
-         Expression.format(Expression.toString(Expression.get("token"))));
-<% } else { -%>
+      assertEquals(layer.getTextField().getExpression(), Expression.format(Expression.formatEntry(Expression.toString(Expression.get("token")))));
+<% } else {-%>
       assertEquals(layer.get<%- camelize(property.name) %>().getExpression(), Expression.toString(Expression.get("token")));
 <% } -%>
 <% } -%>
     });
   }
+<% if (property.name === 'text-field' && property.type === 'formatted') { -%>
+
+  @Test
+  public void testFormatted<%- camelize(property.name) %>AsConstant() {
+    validateTestSetup();
+    setupLayer();
+    Timber.i("<%- property.name %>-formatted");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(layer);
+
+      Formatted expected = new Formatted(new FormattedSection[] {
+        new FormattedSection("", 1.0)
+      });
+
+      // Set and Get
+      layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(<%- defaultValueJava(property) %>));
+      assertEquals(layer.getFormatted<%- camelize(property.name) %>().getValue(), expected/*(<%- propertyType(property) %>) <%- defaultValueJava(property) %>*/);
+<% if (property.tokens) { -%>
+
+      layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>("{token}"));
+      assertEquals(layer.getFormattedTextField().getExpression(), Expression.format(Expression.formatEntry(Expression.toString(Expression.get("token")))));
+<% } -%>
+    });
+  }
+<% } -%>
 <% if (property['property-type'] === 'data-driven' || property['property-type'] === 'cross-faded-data-driven') { -%>
 <% if (!(property.name.endsWith("-font")||property.name.endsWith("-offset"))) { -%>
 
@@ -186,16 +214,32 @@ public class <%- camelize(type) %>LayerTest extends BaseActivityTest {
       assertNotNull(layer);
 
       // Set and Get
-<% if (property.type === 'formatted') { -%>
-      Expression expression = Expression.format(<%- defaultExpressionJava(property) %>(Expression.get("undefined")));
-<% } else { -%>
       Expression expression = <%- defaultExpressionJava(property) %>(Expression.get("undefined"));
-<% } -%>
       layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(expression));
+<% if (property.type === 'formatted') { -%>
+      assertEquals(layer.getTextField().getExpression(), Expression.format(Expression.formatEntry(expression)));
+<% } else { -%>
       assertEquals(layer.get<%- camelize(property.name) %>().getExpression(), expression);
+<% } -%>
     });
   }
+<% if (property.name === 'text-field' && property.type === 'formatted') { -%>
 
+  @Test
+  public void testFormatted<%- camelize(property.name) %>AsExpression() {
+    validateTestSetup();
+    setupLayer();
+    Timber.i("<%- property.name %>-formatted-expression");
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      assertNotNull(layer);
+
+      // Set and Get
+      Expression expression = <%- defaultExpressionJava(property) %>(Expression.get("undefined"));
+      layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(expression));
+      assertEquals(layer.getFormattedTextField().getExpression(), Expression.format(Expression.formatEntry(Expression.string(Expression.get("undefined")))));
+    });
+  }
+<% } -%>
 <% } -%>
 <% } -%>
 <% if (property.type == 'color') { -%>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/assets/streets.json
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/assets/streets.json
@@ -1,23 +1,17 @@
 {
     "version": 8,
-    "name": "Streets",
+    "name": "mapbox-gl-native-test-style",
     "metadata": {
         "mapbox:autocomposite": true,
         "mapbox:type": "default",
         "mapbox:origin": "streets-v10",
         "mapbox:groups": {
-            "1444934828655.3389": {
-                "name": "Aeroways",
-                "collapsed": true
-            },
+            "1444934828655.3389": {"name": "Aeroways", "collapsed": true},
             "1444933322393.2852": {
                 "name": "POI labels  (scalerank 1)",
                 "collapsed": true
             },
-            "1444855786460.0557": {
-                "name": "Roads",
-                "collapsed": true
-            },
+            "1444855786460.0557": {"name": "Roads", "collapsed": true},
             "1444933575858.6992": {
                 "name": "Highway shields",
                 "collapsed": true
@@ -26,78 +20,47 @@
                 "name": "Admin boundaries",
                 "collapsed": true
             },
-            "1444856151690.9143": {
-                "name": "State labels",
-                "collapsed": true
-            },
-            "1444933721429.3076": {
-                "name": "Road labels",
-                "collapsed": true
-            },
+            "1444856151690.9143": {"name": "State labels", "collapsed": true},
+            "1444933721429.3076": {"name": "Road labels", "collapsed": true},
             "1444933358918.2366": {
                 "name": "POI labels (scalerank 2)",
                 "collapsed": true
             },
-            "1444933808272.805": {
-                "name": "Water labels",
-                "collapsed": true
-            },
+            "1444933808272.805": {"name": "Water labels", "collapsed": true},
             "1444933372896.5967": {
                 "name": "POI labels (scalerank 3)",
                 "collapsed": true
             },
-            "1444855799204.86": {
-                "name": "Bridges",
-                "collapsed": true
-            },
-            "1444856087950.3635": {
-                "name": "Marine labels",
-                "collapsed": true
-            },
-            "1456969573402.7817": {
-                "name": "Hillshading",
-                "collapsed": true
-            },
-            "1444862510685.128": {
-                "name": "City labels",
-                "collapsed": true
-            },
-            "1444855769305.6016": {
-                "name": "Tunnels",
-                "collapsed": true
-            },
-            "1456970288113.8113": {
-                "name": "Landcover",
-                "collapsed": true
-            },
-            "1444856144497.7825": {
-                "name": "Country labels",
-                "collapsed": true
-            },
+            "1444855799204.86": {"name": "Bridges", "collapsed": true},
+            "1444856087950.3635": {"name": "Marine labels", "collapsed": true},
+            "1456969573402.7817": {"name": "Hillshading", "collapsed": true},
+            "1444862510685.128": {"name": "City labels", "collapsed": true},
+            "1444855769305.6016": {"name": "Tunnels", "collapsed": true},
+            "1456970288113.8113": {"name": "Landcover", "collapsed": true},
+            "1444856144497.7825": {"name": "Country labels", "collapsed": true},
             "1444933456003.5437": {
                 "name": "POI labels (scalerank 4)",
                 "collapsed": true
             }
         },
         "mapbox:sdk-support": {
-            "js": "0.46.0",
-            "android": "6.0.0",
-            "ios": "4.0.0"
+            "js": "0.49.0",
+            "android": "6.5.0",
+            "ios": "4.4.0"
         }
     },
-    "center": [
-        -122.4241,
-        37.78
-    ],
+    "center": [-122.4241, 37.78],
     "zoom": 9,
+    "bearing": 0,
+    "pitch": 0,
     "sources": {
         "composite": {
             "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7",
             "type": "vector"
         }
     },
-    "sprite": "mapbox://sprites/lukaspaczos/cjkwfdgzn1fz42rqtvsk6rrmd",
-    "glyphs": "asset://fonts/{fontstack}/{range}.pbf",
+    "sprite": "mapbox://sprites/lukaspaczos/cjnkdt02b0b2p2ss40skwpvs1",
+    "glyphs": "mapbox://fonts/lukaspaczos/{fontstack}/{range}.pbf",
     "layers": [
         {
             "id": "background",
@@ -107,305 +70,152 @@
                 "background-color": {
                     "base": 1,
                     "stops": [
-                        [
-                            11,
-                            "hsl(35, 32%, 91%)"
-                        ],
-                        [
-                            13,
-                            "hsl(35, 12%, 89%)"
-                        ]
+                        [11, "hsl(35, 32%, 91%)"],
+                        [13, "hsl(35, 12%, 89%)"]
                     ]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "landcover_snow",
             "type": "fill",
-            "metadata": {
-                "mapbox:group": "1456970288113.8113"
-            },
+            "metadata": {"mapbox:group": "1456970288113.8113"},
             "source": "composite",
             "source-layer": "landcover",
-            "filter": [
-                "==",
-                "class",
-                "snow"
-            ],
+            "filter": ["==", "class", "snow"],
             "layout": {},
             "paint": {
                 "fill-color": "hsl(0, 0%, 100%)",
                 "fill-opacity": 0.2,
                 "fill-antialias": false
-            },
-            "interactive": true
+            }
         },
         {
             "id": "landcover_wood",
             "type": "fill",
-            "metadata": {
-                "mapbox:group": "1456970288113.8113"
-            },
+            "metadata": {"mapbox:group": "1456970288113.8113"},
             "source": "composite",
             "source-layer": "landcover",
             "maxzoom": 14,
-            "filter": [
-                "==",
-                "class",
-                "wood"
-            ],
+            "filter": ["==", "class", "wood"],
             "layout": {},
             "paint": {
                 "fill-color": "hsl(75, 62%, 81%)",
-                "fill-opacity": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            2,
-                            0.3
-                        ],
-                        [
-                            7,
-                            0
-                        ]
-                    ]
-                },
+                "fill-opacity": {"base": 1.5, "stops": [[2, 0.3], [7, 0]]},
                 "fill-antialias": false
-            },
-            "interactive": true
+            }
         },
         {
             "id": "landcover_scrub",
             "type": "fill",
-            "metadata": {
-                "mapbox:group": "1456970288113.8113"
-            },
+            "metadata": {"mapbox:group": "1456970288113.8113"},
             "source": "composite",
             "source-layer": "landcover",
             "maxzoom": 14,
-            "filter": [
-                "==",
-                "class",
-                "scrub"
-            ],
+            "filter": ["==", "class", "scrub"],
             "layout": {},
             "paint": {
                 "fill-color": "hsl(75, 62%, 81%)",
-                "fill-opacity": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            2,
-                            0.3
-                        ],
-                        [
-                            7,
-                            0
-                        ]
-                    ]
-                },
+                "fill-opacity": {"base": 1.5, "stops": [[2, 0.3], [7, 0]]},
                 "fill-antialias": false
-            },
-            "interactive": true
+            }
         },
         {
             "id": "landcover_grass",
             "type": "fill",
-            "metadata": {
-                "mapbox:group": "1456970288113.8113"
-            },
+            "metadata": {"mapbox:group": "1456970288113.8113"},
             "source": "composite",
             "source-layer": "landcover",
             "maxzoom": 14,
-            "filter": [
-                "==",
-                "class",
-                "grass"
-            ],
+            "filter": ["==", "class", "grass"],
             "layout": {},
             "paint": {
                 "fill-color": "hsl(75, 62%, 81%)",
-                "fill-opacity": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            2,
-                            0.3
-                        ],
-                        [
-                            7,
-                            0
-                        ]
-                    ]
-                },
+                "fill-opacity": {"base": 1.5, "stops": [[2, 0.3], [7, 0]]},
                 "fill-antialias": false
-            },
-            "interactive": true
+            }
         },
         {
             "id": "landcover_crop",
             "type": "fill",
-            "metadata": {
-                "mapbox:group": "1456970288113.8113"
-            },
+            "metadata": {"mapbox:group": "1456970288113.8113"},
             "source": "composite",
             "source-layer": "landcover",
             "maxzoom": 14,
-            "filter": [
-                "==",
-                "class",
-                "crop"
-            ],
+            "filter": ["==", "class", "crop"],
             "layout": {},
             "paint": {
                 "fill-color": "hsl(75, 62%, 81%)",
-                "fill-opacity": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            2,
-                            0.3
-                        ],
-                        [
-                            7,
-                            0
-                        ]
-                    ]
-                },
+                "fill-opacity": {"base": 1.5, "stops": [[2, 0.3], [7, 0]]},
                 "fill-antialias": false
-            },
-            "interactive": true
+            }
         },
         {
             "id": "national_park",
             "type": "fill",
             "source": "composite",
             "source-layer": "landuse_overlay",
-            "filter": [
-                "==",
-                "class",
-                "national_park"
-            ],
+            "filter": ["==", "class", "national_park"],
             "layout": {},
             "paint": {
                 "fill-color": "hsl(100, 58%, 76%)",
-                "fill-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            6,
-                            0.5
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "fill-opacity": {"base": 1, "stops": [[5, 0], [6, 0.5]]}
+            }
         },
         {
             "id": "hospital",
             "type": "fill",
             "source": "composite",
             "source-layer": "landuse",
-            "filter": [
-                "==",
-                "class",
-                "hospital"
-            ],
+            "filter": ["==", "class", "hospital"],
             "layout": {},
             "paint": {
                 "fill-color": {
                     "base": 1,
                     "stops": [
-                        [
-                            15.5,
-                            "hsl(340, 37%, 87%)"
-                        ],
-                        [
-                            16,
-                            "hsl(340, 63%, 89%)"
-                        ]
+                        [15.5, "hsl(340, 37%, 87%)"],
+                        [16, "hsl(340, 63%, 89%)"]
                     ]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "school",
             "type": "fill",
             "source": "composite",
             "source-layer": "landuse",
-            "filter": [
-                "==",
-                "class",
-                "school"
-            ],
+            "filter": ["==", "class", "school"],
             "layout": {},
             "paint": {
                 "fill-color": {
                     "base": 1,
                     "stops": [
-                        [
-                            15.5,
-                            "hsl(50, 47%, 81%)"
-                        ],
-                        [
-                            16,
-                            "hsl(50, 63%, 84%)"
-                        ]
+                        [15.5, "hsl(50, 47%, 81%)"],
+                        [16, "hsl(50, 63%, 84%)"]
                     ]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "park",
             "type": "fill",
             "source": "composite",
             "source-layer": "landuse",
-            "filter": [
-                "==",
-                "class",
-                "park"
-            ],
+            "filter": ["==", "class", "park"],
             "layout": {},
             "paint": {
                 "fill-color": "hsl(100, 58%, 76%)",
-                "fill-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            6,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "fill-opacity": {"base": 1, "stops": [[5, 0], [6, 1]]}
+            }
         },
         {
             "id": "pitch",
             "type": "fill",
             "source": "composite",
             "source-layer": "landuse",
-            "filter": [
-                "==",
-                "class",
-                "pitch"
-            ],
+            "filter": ["==", "class", "pitch"],
             "layout": {},
-            "paint": {
-                "fill-color": "hsl(100, 57%, 72%)"
-            },
-            "interactive": true
+            "paint": {"fill-color": "hsl(100, 57%, 72%)"}
         },
         {
             "id": "pitch-line",
@@ -413,276 +223,134 @@
             "source": "composite",
             "source-layer": "landuse",
             "minzoom": 15,
-            "filter": [
-                "==",
-                "class",
-                "pitch"
-            ],
-            "layout": {
-                "line-join": "miter"
-            },
-            "paint": {
-                "line-color": "hsl(75, 57%, 84%)"
-            },
-            "interactive": true
+            "filter": ["==", "class", "pitch"],
+            "layout": {"line-join": "miter"},
+            "paint": {"line-color": "hsl(75, 57%, 84%)"}
         },
         {
             "id": "cemetery",
             "type": "fill",
             "source": "composite",
             "source-layer": "landuse",
-            "filter": [
-                "==",
-                "class",
-                "cemetery"
-            ],
+            "filter": ["==", "class", "cemetery"],
             "layout": {},
-            "paint": {
-                "fill-color": "hsl(75, 37%, 81%)"
-            },
-            "interactive": true
+            "paint": {"fill-color": "hsl(75, 37%, 81%)"}
         },
         {
             "id": "industrial",
             "type": "fill",
             "source": "composite",
             "source-layer": "landuse",
-            "filter": [
-                "==",
-                "class",
-                "industrial"
-            ],
+            "filter": ["==", "class", "industrial"],
             "layout": {},
             "paint": {
                 "fill-color": {
                     "base": 1,
                     "stops": [
-                        [
-                            15.5,
-                            "hsl(230, 15%, 86%)"
-                        ],
-                        [
-                            16,
-                            "hsl(230, 29%, 89%)"
-                        ]
+                        [15.5, "hsl(230, 15%, 86%)"],
+                        [16, "hsl(230, 29%, 89%)"]
                     ]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "sand",
             "type": "fill",
             "source": "composite",
             "source-layer": "landuse",
-            "filter": [
-                "==",
-                "class",
-                "sand"
-            ],
+            "filter": ["==", "class", "sand"],
             "layout": {},
-            "paint": {
-                "fill-color": "hsl(60, 46%, 87%)"
-            },
-            "interactive": true
+            "paint": {"fill-color": "hsl(60, 46%, 87%)"}
         },
         {
             "id": "hillshade_highlight_bright",
             "type": "fill",
-            "metadata": {
-                "mapbox:group": "1456969573402.7817"
-            },
+            "metadata": {"mapbox:group": "1456969573402.7817"},
             "source": "composite",
             "source-layer": "hillshade",
             "maxzoom": 16,
-            "filter": [
-                "==",
-                "level",
-                94
-            ],
+            "filter": ["==", "level", 94],
             "layout": {},
             "paint": {
                 "fill-color": "hsl(0, 0%, 100%)",
-                "fill-opacity": {
-                    "stops": [
-                        [
-                            14,
-                            0.12
-                        ],
-                        [
-                            16,
-                            0
-                        ]
-                    ]
-                },
+                "fill-opacity": {"stops": [[14, 0.12], [16, 0]]},
                 "fill-antialias": false
-            },
-            "interactive": true
+            }
         },
         {
             "id": "hillshade_highlight_med",
             "type": "fill",
-            "metadata": {
-                "mapbox:group": "1456969573402.7817"
-            },
+            "metadata": {"mapbox:group": "1456969573402.7817"},
             "source": "composite",
             "source-layer": "hillshade",
             "maxzoom": 16,
-            "filter": [
-                "==",
-                "level",
-                90
-            ],
+            "filter": ["==", "level", 90],
             "layout": {},
             "paint": {
                 "fill-color": "hsl(0, 0%, 100%)",
-                "fill-opacity": {
-                    "stops": [
-                        [
-                            14,
-                            0.12
-                        ],
-                        [
-                            16,
-                            0
-                        ]
-                    ]
-                },
+                "fill-opacity": {"stops": [[14, 0.12], [16, 0]]},
                 "fill-antialias": false
-            },
-            "interactive": true
+            }
         },
         {
             "id": "hillshade_shadow_faint",
             "type": "fill",
-            "metadata": {
-                "mapbox:group": "1456969573402.7817"
-            },
+            "metadata": {"mapbox:group": "1456969573402.7817"},
             "source": "composite",
             "source-layer": "hillshade",
             "maxzoom": 16,
-            "filter": [
-                "==",
-                "level",
-                89
-            ],
+            "filter": ["==", "level", 89],
             "layout": {},
             "paint": {
                 "fill-color": "hsl(56, 59%, 22%)",
-                "fill-opacity": {
-                    "stops": [
-                        [
-                            14,
-                            0.05
-                        ],
-                        [
-                            16,
-                            0
-                        ]
-                    ]
-                },
+                "fill-opacity": {"stops": [[14, 0.05], [16, 0]]},
                 "fill-antialias": false
-            },
-            "interactive": true
+            }
         },
         {
             "id": "hillshade_shadow_med",
             "type": "fill",
-            "metadata": {
-                "mapbox:group": "1456969573402.7817"
-            },
+            "metadata": {"mapbox:group": "1456969573402.7817"},
             "source": "composite",
             "source-layer": "hillshade",
             "maxzoom": 16,
-            "filter": [
-                "==",
-                "level",
-                78
-            ],
+            "filter": ["==", "level", 78],
             "layout": {},
             "paint": {
                 "fill-color": "hsl(56, 59%, 22%)",
-                "fill-opacity": {
-                    "stops": [
-                        [
-                            14,
-                            0.05
-                        ],
-                        [
-                            16,
-                            0
-                        ]
-                    ]
-                },
+                "fill-opacity": {"stops": [[14, 0.05], [16, 0]]},
                 "fill-antialias": false
-            },
-            "interactive": true
+            }
         },
         {
             "id": "hillshade_shadow_dark",
             "type": "fill",
-            "metadata": {
-                "mapbox:group": "1456969573402.7817"
-            },
+            "metadata": {"mapbox:group": "1456969573402.7817"},
             "source": "composite",
             "source-layer": "hillshade",
             "maxzoom": 16,
-            "filter": [
-                "==",
-                "level",
-                67
-            ],
+            "filter": ["==", "level", 67],
             "layout": {},
             "paint": {
                 "fill-color": "hsl(56, 59%, 22%)",
-                "fill-opacity": {
-                    "stops": [
-                        [
-                            14,
-                            0.06
-                        ],
-                        [
-                            16,
-                            0
-                        ]
-                    ]
-                },
+                "fill-opacity": {"stops": [[14, 0.06], [16, 0]]},
                 "fill-antialias": false
-            },
-            "interactive": true
+            }
         },
         {
             "id": "hillshade_shadow_extreme",
             "type": "fill",
-            "metadata": {
-                "mapbox:group": "1456969573402.7817"
-            },
+            "metadata": {"mapbox:group": "1456969573402.7817"},
             "source": "composite",
             "source-layer": "hillshade",
             "maxzoom": 16,
-            "filter": [
-                "==",
-                "level",
-                56
-            ],
+            "filter": ["==", "level", 56],
             "layout": {},
             "paint": {
                 "fill-color": "hsl(56, 59%, 22%)",
-                "fill-opacity": {
-                    "stops": [
-                        [
-                            14,
-                            0.06
-                        ],
-                        [
-                            16,
-                            0
-                        ]
-                    ]
-                },
+                "fill-opacity": {"stops": [[14, 0.06], [16, 0]]},
                 "fill-antialias": false
-            },
-            "interactive": true
+            }
         },
         {
             "id": "waterway-river-canal",
@@ -690,58 +358,16 @@
             "source": "composite",
             "source-layer": "waterway",
             "minzoom": 8,
-            "filter": [
-                "in",
-                "class",
-                "canal",
-                "river"
-            ],
+            "filter": ["in", "class", "canal", "river"],
             "layout": {
-                "line-cap": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            "butt"
-                        ],
-                        [
-                            11,
-                            "round"
-                        ]
-                    ]
-                },
+                "line-cap": {"base": 1, "stops": [[0, "butt"], [11, "round"]]},
                 "line-join": "round"
             },
             "paint": {
                 "line-color": "hsl(205, 87%, 76%)",
-                "line-width": {
-                    "base": 1.3,
-                    "stops": [
-                        [
-                            8.5,
-                            0.1
-                        ],
-                        [
-                            20,
-                            8
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            8,
-                            0
-                        ],
-                        [
-                            8.5,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-width": {"base": 1.3, "stops": [[8.5, 0.1], [20, 8]]},
+                "line-opacity": {"base": 1, "stops": [[8, 0], [8.5, 1]]}
+            }
         },
         {
             "id": "waterway-small",
@@ -749,46 +375,13 @@
             "source": "composite",
             "source-layer": "waterway",
             "minzoom": 13,
-            "filter": [
-                "!in",
-                "class",
-                "canal",
-                "river"
-            ],
-            "layout": {
-                "line-join": "round",
-                "line-cap": "round"
-            },
+            "filter": ["!in", "class", "canal", "river"],
+            "layout": {"line-join": "round", "line-cap": "round"},
             "paint": {
                 "line-color": "hsl(205, 87%, 76%)",
-                "line-width": {
-                    "base": 1.35,
-                    "stops": [
-                        [
-                            13.5,
-                            0.1
-                        ],
-                        [
-                            20,
-                            3
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13,
-                            0
-                        ],
-                        [
-                            13.5,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-width": {"base": 1.35, "stops": [[13.5, 0.1], [20, 3]]},
+                "line-opacity": {"base": 1, "stops": [[13, 0], [13.5, 1]]}
+            }
         },
         {
             "id": "water-shadow",
@@ -800,27 +393,11 @@
                 "fill-color": "hsl(215, 84%, 69%)",
                 "fill-translate": {
                     "base": 1.2,
-                    "stops": [
-                        [
-                            7,
-                            [
-                                0,
-                                0
-                            ]
-                        ],
-                        [
-                            16,
-                            [
-                                -1,
-                                -1
-                            ]
-                        ]
-                    ]
+                    "stops": [[7, [0, 0]], [16, [-1, -1]]]
                 },
                 "fill-translate-anchor": "viewport",
                 "fill-opacity": 1
-            },
-            "interactive": true
+            }
         },
         {
             "id": "water",
@@ -828,10 +405,7 @@
             "source": "composite",
             "source-layer": "water",
             "layout": {},
-            "paint": {
-                "fill-color": "hsl(196, 80%, 70%)"
-            },
-            "interactive": true
+            "paint": {"fill-color": "hsl(196, 80%, 70%)"}
         },
         {
             "id": "barrier_line-land-polygon",
@@ -840,22 +414,11 @@
             "source-layer": "barrier_line",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "Polygon"
-                ],
-                [
-                    "==",
-                    "class",
-                    "land"
-                ]
+                ["==", "$type", "Polygon"],
+                ["==", "class", "land"]
             ],
             "layout": {},
-            "paint": {
-                "fill-color": "hsl(35, 12%, 89%)"
-            },
-            "interactive": true
+            "paint": {"fill-color": "hsl(35, 12%, 89%)"}
         },
         {
             "id": "barrier_line-land-line",
@@ -864,196 +427,86 @@
             "source-layer": "barrier_line",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "==",
-                    "class",
-                    "land"
-                ]
+                ["==", "$type", "LineString"],
+                ["==", "class", "land"]
             ],
-            "layout": {
-                "line-cap": "round"
-            },
+            "layout": {"line-cap": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.99,
-                    "stops": [
-                        [
-                            14,
-                            0.75
-                        ],
-                        [
-                            20,
-                            40
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.99, "stops": [[14, 0.75], [20, 40]]},
                 "line-color": "hsl(35, 12%, 89%)"
-            },
-            "interactive": true
+            }
         },
         {
             "id": "aeroway-polygon",
             "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444934828655.3389"
-            },
+            "metadata": {"mapbox:group": "1444934828655.3389"},
             "source": "composite",
             "source-layer": "aeroway",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "!=",
-                    "type",
-                    "apron"
-                ],
-                [
-                    "==",
-                    "$type",
-                    "Polygon"
-                ]
+                ["!=", "type", "apron"],
+                ["==", "$type", "Polygon"]
             ],
             "layout": {},
             "paint": {
                 "fill-color": {
                     "base": 1,
                     "stops": [
-                        [
-                            15,
-                            "hsl(230, 23%, 82%)"
-                        ],
-                        [
-                            16,
-                            "hsl(230, 37%, 84%)"
-                        ]
+                        [15, "hsl(230, 23%, 82%)"],
+                        [16, "hsl(230, 37%, 84%)"]
                     ]
                 },
-                "fill-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            11,
-                            0
-                        ],
-                        [
-                            11.5,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "fill-opacity": {"base": 1, "stops": [[11, 0], [11.5, 1]]}
+            }
         },
         {
             "id": "aeroway-runway",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444934828655.3389"
-            },
+            "metadata": {"mapbox:group": "1444934828655.3389"},
             "source": "composite",
             "source-layer": "aeroway",
             "minzoom": 9,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "==",
-                    "type",
-                    "runway"
-                ]
+                ["==", "$type", "LineString"],
+                ["==", "type", "runway"]
             ],
             "layout": {},
             "paint": {
                 "line-color": {
                     "base": 1,
                     "stops": [
-                        [
-                            15,
-                            "hsl(230, 23%, 82%)"
-                        ],
-                        [
-                            16,
-                            "hsl(230, 37%, 84%)"
-                        ]
+                        [15, "hsl(230, 23%, 82%)"],
+                        [16, "hsl(230, 37%, 84%)"]
                     ]
                 },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            9,
-                            1
-                        ],
-                        [
-                            18,
-                            80
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-width": {"base": 1.5, "stops": [[9, 1], [18, 80]]}
+            }
         },
         {
             "id": "aeroway-taxiway",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444934828655.3389"
-            },
+            "metadata": {"mapbox:group": "1444934828655.3389"},
             "source": "composite",
             "source-layer": "aeroway",
             "minzoom": 9,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "==",
-                    "type",
-                    "taxiway"
-                ]
+                ["==", "$type", "LineString"],
+                ["==", "type", "taxiway"]
             ],
             "layout": {},
             "paint": {
                 "line-color": {
                     "base": 1,
                     "stops": [
-                        [
-                            15,
-                            "hsl(230, 23%, 82%)"
-                        ],
-                        [
-                            16,
-                            "hsl(230, 37%, 84%)"
-                        ]
+                        [15, "hsl(230, 23%, 82%)"],
+                        [16, "hsl(230, 37%, 84%)"]
                     ]
                 },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            10,
-                            0.5
-                        ],
-                        [
-                            18,
-                            20
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-width": {"base": 1.5, "stops": [[10, 0.5], [18, 20]]}
+            }
         },
         {
             "id": "building-line",
@@ -1063,48 +516,15 @@
             "minzoom": 15,
             "filter": [
                 "all",
-                [
-                    "!=",
-                    "type",
-                    "building:part"
-                ],
-                [
-                    "==",
-                    "underground",
-                    "false"
-                ]
+                ["!=", "type", "building:part"],
+                ["==", "underground", "false"]
             ],
             "layout": {},
             "paint": {
                 "line-color": "hsl(35, 6%, 79%)",
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            15,
-                            0.75
-                        ],
-                        [
-                            20,
-                            3
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            15.5,
-                            0
-                        ],
-                        [
-                            16,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-width": {"base": 1.5, "stops": [[15, 0.75], [20, 3]]},
+                "line-opacity": {"base": 1, "stops": [[15.5, 0], [16, 1]]}
+            }
         },
         {
             "id": "building",
@@ -1114,1736 +534,627 @@
             "minzoom": 15,
             "filter": [
                 "all",
-                [
-                    "!=",
-                    "type",
-                    "building:part"
-                ],
-                [
-                    "==",
-                    "underground",
-                    "false"
-                ]
+                ["!=", "type", "building:part"],
+                ["==", "underground", "false"]
             ],
             "layout": {},
             "paint": {
                 "fill-color": {
                     "base": 1,
                     "stops": [
-                        [
-                            15,
-                            "hsl(35, 11%, 88%)"
-                        ],
-                        [
-                            16,
-                            "hsl(35, 8%, 85%)"
-                        ]
+                        [15, "hsl(35, 11%, 88%)"],
+                        [16, "hsl(35, 8%, 85%)"]
                     ]
                 },
-                "fill-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            15.5,
-                            0
-                        ],
-                        [
-                            16,
-                            1
-                        ]
-                    ]
-                },
+                "fill-opacity": {"base": 1, "stops": [[15.5, 0], [16, 1]]},
                 "fill-outline-color": "hsl(35, 6%, 79%)"
-            },
-            "interactive": true
+            }
         },
         {
             "id": "tunnel-street-low",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "street"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ]
+                    ["==", "class", "street"],
+                    ["==", "structure", "tunnel"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12.5,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-opacity": {
-                    "stops": [
-                        [
-                            11.5,
-                            0
-                        ],
-                        [
-                            12,
-                            1
-                        ],
-                        [
-                            14,
-                            1
-                        ],
-                        [
-                            14.01,
-                            0
-                        ]
-                    ]
+                    "stops": [[11.5, 0], [12, 1], [14, 1], [14.01, 0]]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "tunnel-street_limited-low",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "street_limited"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ]
+                    ["==", "class", "street_limited"],
+                    ["==", "structure", "tunnel"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12.5,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-opacity": {
-                    "stops": [
-                        [
-                            11.5,
-                            0
-                        ],
-                        [
-                            12,
-                            1
-                        ],
-                        [
-                            14,
-                            1
-                        ],
-                        [
-                            14.01,
-                            0
-                        ]
-                    ]
+                    "stops": [[11.5, 0], [12, 1], [14, 1], [14.01, 0]]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "tunnel-service-link-track-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 14,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!=",
-                        "type",
-                        "trunk_link"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ],
-                    [
-                        "in",
-                        "class",
-                        "link",
-                        "service",
-                        "track"
-                    ]
+                    ["!=", "type", "trunk_link"],
+                    ["==", "structure", "tunnel"],
+                    ["in", "class", "link", "service", "track"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.75
-                        ],
-                        [
-                            20,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
                 "line-color": "hsl(230, 19%, 75%)",
-                "line-gap-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            14,
-                            0.5
-                        ],
-                        [
-                            18,
-                            12
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    3,
-                    3
-                ]
-            },
-            "interactive": true
+                "line-gap-width": {"base": 1.5, "stops": [[14, 0.5], [18, 12]]},
+                "line-dasharray": [3, 3]
+            }
         },
         {
             "id": "tunnel-street_limited-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "street_limited"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ]
+                    ["==", "class", "street_limited"],
+                    ["==", "structure", "tunnel"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.75
-                        ],
-                        [
-                            20,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
                 "line-color": "hsl(230, 19%, 75%)",
                 "line-gap-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            13,
-                            0
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[13, 0], [14, 2], [18, 18]]
                 },
-                "line-dasharray": [
-                    3,
-                    3
-                ],
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13.99,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-dasharray": [3, 3],
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]}
+            }
         },
         {
             "id": "tunnel-street-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "street"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ]
+                    ["==", "class", "street"],
+                    ["==", "structure", "tunnel"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.75
-                        ],
-                        [
-                            20,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
                 "line-color": "hsl(230, 19%, 75%)",
                 "line-gap-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            13,
-                            0
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[13, 0], [14, 2], [18, 18]]
                 },
-                "line-dasharray": [
-                    3,
-                    3
-                ],
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13.99,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-dasharray": [3, 3],
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]}
+            }
         },
         {
             "id": "tunnel-secondary-tertiary-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ],
-                    [
-                        "in",
-                        "class",
-                        "secondary",
-                        "tertiary"
-                    ]
+                    ["==", "structure", "tunnel"],
+                    ["in", "class", "secondary", "tertiary"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.2,
-                    "stops": [
-                        [
-                            10,
-                            0.75
-                        ],
-                        [
-                            18,
-                            2
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    3,
-                    3
-                ],
+                "line-width": {"base": 1.2, "stops": [[10, 0.75], [18, 2]]},
+                "line-dasharray": [3, 3],
                 "line-gap-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            8.5,
-                            0.5
-                        ],
-                        [
-                            10,
-                            0.75
-                        ],
-                        [
-                            18,
-                            26
-                        ]
-                    ]
+                    "stops": [[8.5, 0.5], [10, 0.75], [18, 26]]
                 },
                 "line-color": "hsl(230, 19%, 75%)"
-            },
-            "interactive": true
+            }
         },
         {
             "id": "tunnel-primary-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "primary"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ]
+                    ["==", "class", "primary"],
+                    ["==", "structure", "tunnel"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            10,
-                            1
-                        ],
-                        [
-                            16,
-                            2
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    3,
-                    3
-                ],
-                "line-gap-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[10, 1], [16, 2]]},
+                "line-dasharray": [3, 3],
+                "line-gap-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
                 "line-color": "hsl(230, 19%, 75%)"
-            },
-            "interactive": true
+            }
         },
         {
             "id": "tunnel-trunk_link-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 13,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ],
-                    [
-                        "==",
-                        "type",
-                        "trunk_link"
-                    ]
+                    ["==", "structure", "tunnel"],
+                    ["==", "type", "trunk_link"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.75
-                        ],
-                        [
-                            20,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-gap-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
                 },
-                "line-dasharray": [
-                    3,
-                    3
-                ]
-            },
-            "interactive": true
+                "line-dasharray": [3, 3]
+            }
         },
         {
             "id": "tunnel-motorway_link-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 13,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "motorway_link"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ]
+                    ["==", "class", "motorway_link"],
+                    ["==", "structure", "tunnel"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.75
-                        ],
-                        [
-                            20,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-gap-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
                 },
-                "line-dasharray": [
-                    3,
-                    3
-                ]
-            },
-            "interactive": true
+                "line-dasharray": [3, 3]
+            }
         },
         {
             "id": "tunnel-trunk-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "all",
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ],
-                    [
-                        "==",
-                        "type",
-                        "trunk"
-                    ]
-                ]
+                ["==", "$type", "LineString"],
+                ["all", ["==", "structure", "tunnel"], ["==", "type", "trunk"]]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            10,
-                            1
-                        ],
-                        [
-                            16,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[10, 1], [16, 2]]},
                 "line-color": "hsl(0, 0%, 100%)",
-                "line-gap-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                },
+                "line-gap-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
                 "line-opacity": 1,
-                "line-dasharray": [
-                    3,
-                    3
-                ]
-            },
-            "interactive": true
+                "line-dasharray": [3, 3]
+            }
         },
         {
             "id": "tunnel-motorway-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "motorway"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ]
+                    ["==", "class", "motorway"],
+                    ["==", "structure", "tunnel"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            10,
-                            1
-                        ],
-                        [
-                            16,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[10, 1], [16, 2]]},
                 "line-color": "hsl(0, 0%, 100%)",
-                "line-gap-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                },
+                "line-gap-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
                 "line-opacity": 1,
-                "line-dasharray": [
-                    3,
-                    3
-                ]
-            },
-            "interactive": true
+                "line-dasharray": [3, 3]
+            }
         },
         {
             "id": "tunnel-construction",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 14,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "construction"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ]
+                    ["==", "class", "construction"],
+                    ["==", "structure", "tunnel"]
                 ]
             ],
-            "layout": {
-                "line-join": "miter"
-            },
+            "layout": {"line-join": "miter"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12.5,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(230, 24%, 87%)",
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13.99,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                },
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]},
                 "line-dasharray": {
                     "base": 1,
                     "stops": [
-                        [
-                            14,
-                            [
-                                0.4,
-                                0.8
-                            ]
-                        ],
-                        [
-                            15,
-                            [
-                                0.3,
-                                0.6
-                            ]
-                        ],
-                        [
-                            16,
-                            [
-                                0.2,
-                                0.3
-                            ]
-                        ],
-                        [
-                            17,
-                            [
-                                0.2,
-                                0.25
-                            ]
-                        ],
-                        [
-                            18,
-                            [
-                                0.15,
-                                0.15
-                            ]
-                        ]
+                        [14, [0.4, 0.8]],
+                        [15, [0.3, 0.6]],
+                        [16, [0.2, 0.3]],
+                        [17, [0.2, 0.25]],
+                        [18, [0.15, 0.15]]
                     ]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "tunnel-path",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!=",
-                        "type",
-                        "steps"
-                    ],
-                    [
-                        "==",
-                        "class",
-                        "path"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ]
+                    ["!=", "type", "steps"],
+                    ["==", "class", "path"],
+                    ["==", "structure", "tunnel"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            15,
-                            1
-                        ],
-                        [
-                            18,
-                            4
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[15, 1], [18, 4]]},
                 "line-dasharray": {
                     "base": 1,
                     "stops": [
-                        [
-                            14,
-                            [
-                                1,
-                                0
-                            ]
-                        ],
-                        [
-                            15,
-                            [
-                                1.75,
-                                1
-                            ]
-                        ],
-                        [
-                            16,
-                            [
-                                1,
-                                0.75
-                            ]
-                        ],
-                        [
-                            17,
-                            [
-                                1,
-                                0.5
-                            ]
-                        ]
+                        [14, [1, 0]],
+                        [15, [1.75, 1]],
+                        [16, [1, 0.75]],
+                        [17, [1, 0.5]]
                     ]
                 },
                 "line-color": "hsl(35, 26%, 95%)",
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            14,
-                            0
-                        ],
-                        [
-                            14.25,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[14, 0], [14.25, 1]]}
+            }
         },
         {
             "id": "tunnel-steps",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "all",
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ],
-                    [
-                        "==",
-                        "type",
-                        "steps"
-                    ]
-                ]
+                ["==", "$type", "LineString"],
+                ["all", ["==", "structure", "tunnel"], ["==", "type", "steps"]]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            15,
-                            1
-                        ],
-                        [
-                            16,
-                            1.6
-                        ],
-                        [
-                            18,
-                            6
-                        ]
-                    ]
+                    "stops": [[15, 1], [16, 1.6], [18, 6]]
                 },
                 "line-color": "hsl(35, 26%, 95%)",
                 "line-dasharray": {
                     "base": 1,
                     "stops": [
-                        [
-                            14,
-                            [
-                                1,
-                                0
-                            ]
-                        ],
-                        [
-                            15,
-                            [
-                                1.75,
-                                1
-                            ]
-                        ],
-                        [
-                            16,
-                            [
-                                1,
-                                0.75
-                            ]
-                        ],
-                        [
-                            17,
-                            [
-                                0.3,
-                                0.3
-                            ]
-                        ]
+                        [14, [1, 0]],
+                        [15, [1.75, 1]],
+                        [16, [1, 0.75]],
+                        [17, [0.3, 0.3]]
                     ]
                 },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            14,
-                            0
-                        ],
-                        [
-                            14.25,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[14, 0], [14.25, 1]]}
+            }
         },
         {
             "id": "tunnel-trunk_link",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 13,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ],
-                    [
-                        "==",
-                        "type",
-                        "trunk_link"
-                    ]
+                    ["==", "structure", "tunnel"],
+                    ["==", "type", "trunk_link"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(46, 77%, 78%)",
                 "line-opacity": 1,
-                "line-dasharray": [
-                    1,
-                    0
-                ]
-            },
-            "interactive": true
+                "line-dasharray": [1, 0]
+            }
         },
         {
             "id": "tunnel-motorway_link",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 13,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "motorway_link"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ]
+                    ["==", "class", "motorway_link"],
+                    ["==", "structure", "tunnel"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(26, 100%, 78%)",
                 "line-opacity": 1,
-                "line-dasharray": [
-                    1,
-                    0
-                ]
-            },
-            "interactive": true
+                "line-dasharray": [1, 0]
+            }
         },
         {
             "id": "tunnel-pedestrian",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 13,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "pedestrian"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ]
+                    ["==", "class", "pedestrian"],
+                    ["==", "structure", "tunnel"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            14,
-                            0.5
-                        ],
-                        [
-                            18,
-                            12
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[14, 0.5], [18, 12]]},
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-opacity": 1,
                 "line-dasharray": {
                     "base": 1,
-                    "stops": [
-                        [
-                            14,
-                            [
-                                1,
-                                0
-                            ]
-                        ],
-                        [
-                            15,
-                            [
-                                1.5,
-                                0.4
-                            ]
-                        ],
-                        [
-                            16,
-                            [
-                                1,
-                                0.2
-                            ]
-                        ]
-                    ]
+                    "stops": [[14, [1, 0]], [15, [1.5, 0.4]], [16, [1, 0.2]]]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "tunnel-service-link-track",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 14,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!=",
-                        "type",
-                        "trunk_link"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ],
-                    [
-                        "in",
-                        "class",
-                        "link",
-                        "service",
-                        "track"
-                    ]
+                    ["!=", "type", "trunk_link"],
+                    ["==", "structure", "tunnel"],
+                    ["in", "class", "link", "service", "track"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            14,
-                            0.5
-                        ],
-                        [
-                            18,
-                            12
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[14, 0.5], [18, 12]]},
                 "line-color": "hsl(0, 0%, 100%)",
-                "line-dasharray": [
-                    1,
-                    0
-                ]
-            },
-            "interactive": true
+                "line-dasharray": [1, 0]
+            }
         },
         {
             "id": "tunnel-street_limited",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "street_limited"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ]
+                    ["==", "class", "street_limited"],
+                    ["==", "structure", "tunnel"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12.5,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(35, 14%, 93%)",
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13.99,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]}
+            }
         },
         {
             "id": "tunnel-street",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "street"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ]
+                    ["==", "class", "street"],
+                    ["==", "structure", "tunnel"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12.5,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(0, 0%, 100%)",
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13.99,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]}
+            }
         },
         {
             "id": "tunnel-secondary-tertiary",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ],
-                    [
-                        "in",
-                        "class",
-                        "secondary",
-                        "tertiary"
-                    ]
+                    ["==", "structure", "tunnel"],
+                    ["in", "class", "secondary", "tertiary"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            8.5,
-                            0.5
-                        ],
-                        [
-                            10,
-                            0.75
-                        ],
-                        [
-                            18,
-                            26
-                        ]
-                    ]
+                    "stops": [[8.5, 0.5], [10, 0.75], [18, 26]]
                 },
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-opacity": 1,
-                "line-dasharray": [
-                    1,
-                    0
-                ],
+                "line-dasharray": [1, 0],
                 "line-blur": 0
-            },
-            "interactive": true
+            }
         },
         {
             "id": "tunnel-primary",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "primary"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ]
+                    ["==", "class", "primary"],
+                    ["==", "structure", "tunnel"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-opacity": 1,
-                "line-dasharray": [
-                    1,
-                    0
-                ],
+                "line-dasharray": [1, 0],
                 "line-blur": 0
-            },
-            "interactive": true
+            }
         },
         {
             "id": "tunnel-oneway-arrows-blue-minor",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 16,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!=",
-                        "type",
-                        "trunk_link"
-                    ],
-                    [
-                        "==",
-                        "oneway",
-                        "true"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ],
+                    ["!=", "type", "trunk_link"],
+                    ["==", "oneway", "true"],
+                    ["==", "structure", "tunnel"],
                     [
                         "in",
                         "class",
@@ -2859,56 +1170,28 @@
                 "symbol-placement": "line",
                 "icon-image": {
                     "base": 1,
-                    "stops": [
-                        [
-                            17,
-                            "oneway-small"
-                        ],
-                        [
-                            18,
-                            "oneway-large"
-                        ]
-                    ]
+                    "stops": [[17, "oneway-small"], [18, "oneway-large"]]
                 },
                 "symbol-spacing": 200,
                 "icon-padding": 2
             },
-            "paint": {},
-            "interactive": true
+            "paint": {}
         },
         {
             "id": "tunnel-oneway-arrows-blue-major",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 15,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!=",
-                        "type",
-                        "trunk_link"
-                    ],
-                    [
-                        "==",
-                        "oneway",
-                        "true"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ],
+                    ["!=", "type", "trunk_link"],
+                    ["==", "oneway", "true"],
+                    ["==", "structure", "tunnel"],
                     [
                         "in",
                         "class",
@@ -2924,147 +1207,64 @@
                 "symbol-placement": "line",
                 "icon-image": {
                     "base": 1,
-                    "stops": [
-                        [
-                            16,
-                            "oneway-small"
-                        ],
-                        [
-                            17,
-                            "oneway-large"
-                        ]
-                    ]
+                    "stops": [[16, "oneway-small"], [17, "oneway-large"]]
                 },
                 "symbol-spacing": 200,
                 "icon-padding": 2
             },
-            "paint": {},
-            "interactive": true
+            "paint": {}
         },
         {
             "id": "tunnel-trunk",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "all",
-                    [
-                        "==",
-                        "class",
-                        "trunk"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ]
-                ]
+                ["==", "$type", "LineString"],
+                ["all", ["==", "class", "trunk"], ["==", "structure", "tunnel"]]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
                 "line-color": "hsl(46, 77%, 78%)"
-            },
-            "interactive": true
+            }
         },
         {
             "id": "tunnel-motorway",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "motorway"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ]
+                    ["==", "class", "motorway"],
+                    ["==", "structure", "tunnel"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    1,
-                    0
-                ],
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
+                "line-dasharray": [1, 0],
                 "line-opacity": 1,
                 "line-color": "hsl(26, 100%, 78%)",
                 "line-blur": 0
-            },
-            "interactive": true
+            }
         },
         {
             "id": "tunnel-oneway-arrows-white",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444855769305.6016"
-            },
+            "metadata": {"mapbox:group": "1444855769305.6016"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 16,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
                     [
@@ -3074,16 +1274,8 @@
                         "secondary_link",
                         "tertiary_link"
                     ],
-                    [
-                        "==",
-                        "oneway",
-                        "true"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ],
+                    ["==", "oneway", "true"],
+                    ["==", "structure", "tunnel"],
                     [
                         "in",
                         "class",
@@ -3099,21 +1291,14 @@
                 "icon-image": {
                     "base": 1,
                     "stops": [
-                        [
-                            16,
-                            "oneway-white-small"
-                        ],
-                        [
-                            17,
-                            "oneway-white-large"
-                        ]
+                        [16, "oneway-white-small"],
+                        [17, "oneway-white-large"]
                     ]
                 },
                 "symbol-spacing": 200,
                 "icon-padding": 2
             },
-            "paint": {},
-            "interactive": true
+            "paint": {}
         },
         {
             "id": "ferry",
@@ -3122,69 +1307,25 @@
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "==",
-                    "type",
-                    "ferry"
-                ]
+                ["==", "$type", "LineString"],
+                ["==", "type", "ferry"]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
                 "line-color": {
                     "base": 1,
                     "stops": [
-                        [
-                            15,
-                            "hsl(205, 73%, 63%)"
-                        ],
-                        [
-                            17,
-                            "hsl(230, 73%, 63%)"
-                        ]
+                        [15, "hsl(205, 73%, 63%)"],
+                        [17, "hsl(230, 73%, 63%)"]
                     ]
                 },
                 "line-opacity": 1,
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            14,
-                            0.5
-                        ],
-                        [
-                            20,
-                            1
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[14, 0.5], [20, 1]]},
                 "line-dasharray": {
                     "base": 1,
-                    "stops": [
-                        [
-                            12,
-                            [
-                                1,
-                                0
-                            ]
-                        ],
-                        [
-                            13,
-                            [
-                                12,
-                                4
-                            ]
-                        ]
-                    ]
+                    "stops": [[12, [1, 0]], [13, [12, 4]]]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "ferry_auto",
@@ -3193,1879 +1334,648 @@
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "==",
-                    "type",
-                    "ferry_auto"
-                ]
+                ["==", "$type", "LineString"],
+                ["==", "type", "ferry_auto"]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
                 "line-color": {
                     "base": 1,
                     "stops": [
-                        [
-                            15,
-                            "hsl(205, 73%, 63%)"
-                        ],
-                        [
-                            17,
-                            "hsl(230, 73%, 63%)"
-                        ]
+                        [15, "hsl(205, 73%, 63%)"],
+                        [17, "hsl(230, 73%, 63%)"]
                     ]
                 },
                 "line-opacity": 1,
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            14,
-                            0.5
-                        ],
-                        [
-                            20,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-width": {"base": 1.5, "stops": [[14, 0.5], [20, 1]]}
+            }
         },
         {
             "id": "road-path-bg",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "!in",
-                        "type",
-                        "crossing",
-                        "sidewalk",
-                        "steps"
-                    ],
-                    [
-                        "==",
-                        "class",
-                        "path"
-                    ]
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["!in", "type", "crossing", "sidewalk", "steps"],
+                    ["==", "class", "path"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            15,
-                            2
-                        ],
-                        [
-                            18,
-                            7
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    1,
-                    0
-                ],
+                "line-width": {"base": 1.5, "stops": [[15, 2], [18, 7]]},
+                "line-dasharray": [1, 0],
                 "line-color": "hsl(230, 17%, 82%)",
                 "line-blur": 0,
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            14,
-                            0
-                        ],
-                        [
-                            14.25,
-                            0.75
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[14, 0], [14.25, 0.75]]}
+            }
         },
         {
             "id": "road-steps-bg",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "==",
-                        "type",
-                        "steps"
-                    ]
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "type", "steps"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            15,
-                            2
-                        ],
-                        [
-                            17,
-                            4.6
-                        ],
-                        [
-                            18,
-                            7
-                        ]
-                    ]
+                    "stops": [[15, 2], [17, 4.6], [18, 7]]
                 },
                 "line-color": "hsl(230, 17%, 82%)",
-                "line-dasharray": [
-                    1,
-                    0
-                ],
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            14,
-                            0
-                        ],
-                        [
-                            14.25,
-                            0.75
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-dasharray": [1, 0],
+                "line-opacity": {"base": 1, "stops": [[14, 0], [14.25, 0.75]]}
+            }
         },
         {
             "id": "road-sidewalk-bg",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 16,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "in",
-                        "type",
-                        "crossing",
-                        "sidewalk"
-                    ]
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["in", "type", "crossing", "sidewalk"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            15,
-                            2
-                        ],
-                        [
-                            18,
-                            7
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    1,
-                    0
-                ],
+                "line-width": {"base": 1.5, "stops": [[15, 2], [18, 7]]},
+                "line-dasharray": [1, 0],
                 "line-color": "hsl(230, 17%, 82%)",
                 "line-blur": 0,
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            16,
-                            0
-                        ],
-                        [
-                            16.25,
-                            0.75
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[16, 0], [16.25, 0.75]]}
+            }
         },
         {
             "id": "turning-features-outline",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 15,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "Point"
-                ],
-                [
-                    "in",
-                    "class",
-                    "turning_circle",
-                    "turning_loop"
-                ]
+                ["==", "$type", "Point"],
+                ["in", "class", "turning_circle", "turning_loop"]
             ],
             "layout": {
                 "icon-image": "turning-circle-outline",
                 "icon-size": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            14,
-                            0.122
-                        ],
-                        [
-                            18,
-                            0.969
-                        ],
-                        [
-                            20,
-                            1
-                        ]
-                    ]
+                    "stops": [[14, 0.122], [18, 0.969], [20, 1]]
                 },
                 "icon-allow-overlap": true,
                 "icon-ignore-placement": true,
                 "icon-padding": 0,
                 "icon-rotation-alignment": "map"
             },
-            "paint": {},
-            "interactive": true
+            "paint": {}
         },
         {
             "id": "road-pedestrian-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 12,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "pedestrian"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "none"
-                    ]
+                    ["==", "class", "pedestrian"],
+                    ["==", "structure", "none"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            14.5
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[14, 2], [18, 14.5]]},
                 "line-color": "hsl(230, 24%, 87%)",
                 "line-gap-width": 0,
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13.99,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]}
+            }
         },
         {
             "id": "road-street-low",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "all",
-                    [
-                        "==",
-                        "class",
-                        "street"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "none"
-                    ]
-                ]
+                ["==", "$type", "LineString"],
+                ["all", ["==", "class", "street"], ["==", "structure", "none"]]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12.5,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-opacity": {
-                    "stops": [
-                        [
-                            11,
-                            0
-                        ],
-                        [
-                            11.25,
-                            1
-                        ],
-                        [
-                            14,
-                            1
-                        ],
-                        [
-                            14.01,
-                            0
-                        ]
-                    ]
+                    "stops": [[11, 0], [11.25, 1], [14, 1], [14.01, 0]]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "road-street_limited-low",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "street_limited"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "none"
-                    ]
+                    ["==", "class", "street_limited"],
+                    ["==", "structure", "none"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12.5,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-opacity": {
-                    "stops": [
-                        [
-                            11,
-                            0
-                        ],
-                        [
-                            11.25,
-                            1
-                        ],
-                        [
-                            14,
-                            1
-                        ],
-                        [
-                            14.01,
-                            0
-                        ]
-                    ]
+                    "stops": [[11, 0], [11.25, 1], [14, 1], [14.01, 0]]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "road-service-link-track-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 14,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!=",
-                        "type",
-                        "trunk_link"
-                    ],
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "in",
-                        "class",
-                        "link",
-                        "service",
-                        "track"
-                    ]
+                    ["!=", "type", "trunk_link"],
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["in", "class", "link", "service", "track"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.75
-                        ],
-                        [
-                            20,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
                 "line-color": "hsl(230, 24%, 87%)",
-                "line-gap-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            14,
-                            0.5
-                        ],
-                        [
-                            18,
-                            12
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-gap-width": {"base": 1.5, "stops": [[14, 0.5], [18, 12]]}
+            }
         },
         {
             "id": "road-street_limited-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "street_limited"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "none"
-                    ]
+                    ["==", "class", "street_limited"],
+                    ["==", "structure", "none"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.75
-                        ],
-                        [
-                            20,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
                 "line-color": "hsl(230, 24%, 87%)",
                 "line-gap-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            13,
-                            0
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[13, 0], [14, 2], [18, 18]]
                 },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13.99,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]}
+            }
         },
         {
             "id": "road-street-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "all",
-                    [
-                        "==",
-                        "class",
-                        "street"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "none"
-                    ]
-                ]
+                ["==", "$type", "LineString"],
+                ["all", ["==", "class", "street"], ["==", "structure", "none"]]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.75
-                        ],
-                        [
-                            20,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
                 "line-color": "hsl(230, 24%, 87%)",
                 "line-gap-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            13,
-                            0
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[13, 0], [14, 2], [18, 18]]
                 },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13.99,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]}
+            }
         },
         {
             "id": "road-secondary-tertiary-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "in",
-                        "class",
-                        "secondary",
-                        "tertiary"
-                    ]
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["in", "class", "secondary", "tertiary"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.2,
-                    "stops": [
-                        [
-                            10,
-                            0.75
-                        ],
-                        [
-                            18,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.2, "stops": [[10, 0.75], [18, 2]]},
                 "line-color": "hsl(230, 24%, 87%)",
                 "line-gap-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            8.5,
-                            0.5
-                        ],
-                        [
-                            10,
-                            0.75
-                        ],
-                        [
-                            18,
-                            26
-                        ]
-                    ]
+                    "stops": [[8.5, 0.5], [10, 0.75], [18, 26]]
                 },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            9.99,
-                            0
-                        ],
-                        [
-                            10,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[9.99, 0], [10, 1]]}
+            }
         },
         {
             "id": "road-primary-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "==",
-                        "class",
-                        "primary"
-                    ]
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "class", "primary"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            10,
-                            1
-                        ],
-                        [
-                            16,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[10, 1], [16, 2]]},
                 "line-color": "hsl(230, 24%, 87%)",
-                "line-gap-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            9.99,
-                            0
-                        ],
-                        [
-                            10,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-gap-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
+                "line-opacity": {"base": 1, "stops": [[9.99, 0], [10, 1]]}
+            }
         },
         {
             "id": "road-motorway_link-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 10,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "==",
-                        "class",
-                        "motorway_link"
-                    ]
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "class", "motorway_link"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.75
-                        ],
-                        [
-                            20,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-gap-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
                 },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10.99,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[10.99, 0], [11, 1]]}
+            }
         },
         {
             "id": "road-trunk_link-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "==",
-                        "type",
-                        "trunk_link"
-                    ]
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "type", "trunk_link"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.75
-                        ],
-                        [
-                            20,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-gap-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
                 },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10.99,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[10.99, 0], [11, 1]]}
+            }
         },
         {
             "id": "road-trunk-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "==",
-                        "class",
-                        "trunk"
-                    ]
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "class", "trunk"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            10,
-                            1
-                        ],
-                        [
-                            16,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[10, 1], [16, 2]]},
                 "line-color": "hsl(0, 0%, 100%)",
-                "line-gap-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            6,
-                            0
-                        ],
-                        [
-                            6.1,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-gap-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
+                "line-opacity": {"base": 1, "stops": [[6, 0], [6.1, 1]]}
+            }
         },
         {
             "id": "road-motorway-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "==",
-                        "class",
-                        "motorway"
-                    ]
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "class", "motorway"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            10,
-                            1
-                        ],
-                        [
-                            16,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[10, 1], [16, 2]]},
                 "line-color": "hsl(0, 0%, 100%)",
-                "line-gap-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-gap-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]}
+            }
         },
         {
             "id": "road-construction",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 14,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "construction"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "none"
-                    ]
+                    ["==", "class", "construction"],
+                    ["==", "structure", "none"]
                 ]
             ],
-            "layout": {
-                "line-join": "miter"
-            },
+            "layout": {"line-join": "miter"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12.5,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(230, 24%, 87%)",
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13.99,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                },
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]},
                 "line-dasharray": {
                     "base": 1,
                     "stops": [
-                        [
-                            14,
-                            [
-                                0.4,
-                                0.8
-                            ]
-                        ],
-                        [
-                            15,
-                            [
-                                0.3,
-                                0.6
-                            ]
-                        ],
-                        [
-                            16,
-                            [
-                                0.2,
-                                0.3
-                            ]
-                        ],
-                        [
-                            17,
-                            [
-                                0.2,
-                                0.25
-                            ]
-                        ],
-                        [
-                            18,
-                            [
-                                0.15,
-                                0.15
-                            ]
-                        ]
+                        [14, [0.4, 0.8]],
+                        [15, [0.3, 0.6]],
+                        [16, [0.2, 0.3]],
+                        [17, [0.2, 0.25]],
+                        [18, [0.15, 0.15]]
                     ]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "road-sidewalks",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 16,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "in",
-                        "type",
-                        "crossing",
-                        "sidewalk"
-                    ]
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["in", "type", "crossing", "sidewalk"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            15,
-                            1
-                        ],
-                        [
-                            18,
-                            4
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[15, 1], [18, 4]]},
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-dasharray": {
                     "base": 1,
                     "stops": [
-                        [
-                            14,
-                            [
-                                1,
-                                0
-                            ]
-                        ],
-                        [
-                            15,
-                            [
-                                1.75,
-                                1
-                            ]
-                        ],
-                        [
-                            16,
-                            [
-                                1,
-                                0.75
-                            ]
-                        ],
-                        [
-                            17,
-                            [
-                                1,
-                                0.5
-                            ]
-                        ]
+                        [14, [1, 0]],
+                        [15, [1.75, 1]],
+                        [16, [1, 0.75]],
+                        [17, [1, 0.5]]
                     ]
                 },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            16,
-                            0
-                        ],
-                        [
-                            16.25,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[16, 0], [16.25, 1]]}
+            }
         },
         {
             "id": "road-path",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "!in",
-                        "type",
-                        "crossing",
-                        "sidewalk",
-                        "steps"
-                    ],
-                    [
-                        "==",
-                        "class",
-                        "path"
-                    ]
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["!in", "type", "crossing", "sidewalk", "steps"],
+                    ["==", "class", "path"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            15,
-                            1
-                        ],
-                        [
-                            18,
-                            4
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[15, 1], [18, 4]]},
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-dasharray": {
                     "base": 1,
                     "stops": [
-                        [
-                            14,
-                            [
-                                1,
-                                0
-                            ]
-                        ],
-                        [
-                            15,
-                            [
-                                1.75,
-                                1
-                            ]
-                        ],
-                        [
-                            16,
-                            [
-                                1,
-                                0.75
-                            ]
-                        ],
-                        [
-                            17,
-                            [
-                                1,
-                                0.5
-                            ]
-                        ]
+                        [14, [1, 0]],
+                        [15, [1.75, 1]],
+                        [16, [1, 0.75]],
+                        [17, [1, 0.5]]
                     ]
                 },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            14,
-                            0
-                        ],
-                        [
-                            14.25,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[14, 0], [14.25, 1]]}
+            }
         },
         {
             "id": "road-steps",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "==",
-                        "type",
-                        "steps"
-                    ]
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "type", "steps"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            15,
-                            1
-                        ],
-                        [
-                            16,
-                            1.6
-                        ],
-                        [
-                            18,
-                            6
-                        ]
-                    ]
+                    "stops": [[15, 1], [16, 1.6], [18, 6]]
                 },
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-dasharray": {
                     "base": 1,
                     "stops": [
-                        [
-                            14,
-                            [
-                                1,
-                                0
-                            ]
-                        ],
-                        [
-                            15,
-                            [
-                                1.75,
-                                1
-                            ]
-                        ],
-                        [
-                            16,
-                            [
-                                1,
-                                0.75
-                            ]
-                        ],
-                        [
-                            17,
-                            [
-                                0.3,
-                                0.3
-                            ]
-                        ]
+                        [14, [1, 0]],
+                        [15, [1.75, 1]],
+                        [16, [1, 0.75]],
+                        [17, [0.3, 0.3]]
                     ]
                 },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            14,
-                            0
-                        ],
-                        [
-                            14.25,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[14, 0], [14.25, 1]]}
+            }
         },
         {
             "id": "road-trunk_link",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "==",
-                        "type",
-                        "trunk_link"
-                    ]
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "type", "trunk_link"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(46, 85%, 67%)",
                 "line-opacity": 1
-            },
-            "interactive": true
+            }
         },
         {
             "id": "road-motorway_link",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 10,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "==",
-                        "class",
-                        "motorway_link"
-                    ]
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "class", "motorway_link"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(26, 100%, 68%)",
                 "line-opacity": 1
-            },
-            "interactive": true
+            }
         },
         {
             "id": "road-pedestrian",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 12,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "pedestrian"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "none"
-                    ]
+                    ["==", "class", "pedestrian"],
+                    ["==", "structure", "none"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            14,
-                            0.5
-                        ],
-                        [
-                            18,
-                            12
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[14, 0.5], [18, 12]]},
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-opacity": 1,
                 "line-dasharray": {
                     "base": 1,
-                    "stops": [
-                        [
-                            14,
-                            [
-                                1,
-                                0
-                            ]
-                        ],
-                        [
-                            15,
-                            [
-                                1.5,
-                                0.4
-                            ]
-                        ],
-                        [
-                            16,
-                            [
-                                1,
-                                0.2
-                            ]
-                        ]
-                    ]
+                    "stops": [[14, [1, 0]], [15, [1.5, 0.4]], [16, [1, 0.2]]]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "road-pedestrian-polygon-fill",
             "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 12,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "Polygon"
-                ],
+                ["==", "$type", "Polygon"],
                 [
                     "all",
-                    [
-                        "==",
-                        "structure",
-                        "none"
-                    ],
-                    [
-                        "in",
-                        "class",
-                        "path",
-                        "pedestrian"
-                    ]
+                    ["==", "structure", "none"],
+                    ["in", "class", "path", "pedestrian"]
                 ]
             ],
             "layout": {},
@@ -5073,50 +1983,28 @@
                 "fill-color": {
                     "base": 1,
                     "stops": [
-                        [
-                            16,
-                            "hsl(230, 16%, 94%)"
-                        ],
-                        [
-                            16.25,
-                            "hsl(230, 50%, 98%)"
-                        ]
+                        [16, "hsl(230, 16%, 94%)"],
+                        [16.25, "hsl(230, 50%, 98%)"]
                     ]
                 },
                 "fill-outline-color": "hsl(230, 26%, 88%)",
                 "fill-opacity": 1
-            },
-            "interactive": true
+            }
         },
         {
             "id": "road-pedestrian-polygon-pattern",
             "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 12,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "Polygon"
-                ],
+                ["==", "$type", "Polygon"],
                 [
                     "all",
-                    [
-                        "==",
-                        "structure",
-                        "none"
-                    ],
-                    [
-                        "in",
-                        "class",
-                        "path",
-                        "pedestrian"
-                    ]
+                    ["==", "structure", "none"],
+                    ["in", "class", "path", "pedestrian"]
                 ]
             ],
             "layout": {},
@@ -5124,442 +2012,170 @@
                 "fill-color": "hsl(0, 0%, 100%)",
                 "fill-outline-color": "hsl(35, 10%, 83%)",
                 "fill-pattern": "pedestrian-polygon",
-                "fill-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            16,
-                            0
-                        ],
-                        [
-                            16.25,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "fill-opacity": {"base": 1, "stops": [[16, 0], [16.25, 1]]}
+            }
         },
         {
             "id": "road-polygon",
             "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 12,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "Polygon"
-                ],
+                ["==", "$type", "Polygon"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "class",
-                        "motorway",
-                        "path",
-                        "pedestrian",
-                        "trunk"
-                    ],
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ]
+                    ["!in", "class", "motorway", "path", "pedestrian", "trunk"],
+                    ["!in", "structure", "bridge", "tunnel"]
                 ]
             ],
             "layout": {},
             "paint": {
                 "fill-color": "hsl(0, 0%, 100%)",
                 "fill-outline-color": "#d6d9e6"
-            },
-            "interactive": true
+            }
         },
         {
             "id": "road-service-link-track",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 14,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!=",
-                        "type",
-                        "trunk_link"
-                    ],
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "in",
-                        "class",
-                        "link",
-                        "service",
-                        "track"
-                    ]
+                    ["!=", "type", "trunk_link"],
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["in", "class", "link", "service", "track"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            14,
-                            0.5
-                        ],
-                        [
-                            18,
-                            12
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[14, 0.5], [18, 12]]},
                 "line-color": "hsl(0, 0%, 100%)"
-            },
-            "interactive": true
+            }
         },
         {
             "id": "road-street_limited",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "street_limited"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "none"
-                    ]
+                    ["==", "class", "street_limited"],
+                    ["==", "structure", "none"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12.5,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(35, 14%, 93%)",
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13.99,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]}
+            }
         },
         {
             "id": "road-street",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "all",
-                    [
-                        "==",
-                        "class",
-                        "street"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "none"
-                    ]
-                ]
+                ["==", "$type", "LineString"],
+                ["all", ["==", "class", "street"], ["==", "structure", "none"]]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12.5,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(0, 0%, 100%)",
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13.99,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]}
+            }
         },
         {
             "id": "road-secondary-tertiary",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "in",
-                        "class",
-                        "secondary",
-                        "tertiary"
-                    ]
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["in", "class", "secondary", "tertiary"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            8.5,
-                            0.5
-                        ],
-                        [
-                            10,
-                            0.75
-                        ],
-                        [
-                            18,
-                            26
-                        ]
-                    ]
+                    "stops": [[8.5, 0.5], [10, 0.75], [18, 26]]
                 },
                 "line-color": {
                     "base": 1,
-                    "stops": [
-                        [
-                            5,
-                            "hsl(35, 32%, 91%)"
-                        ],
-                        [
-                            8,
-                            "hsl(0, 0%, 100%)"
-                        ]
-                    ]
+                    "stops": [[5, "hsl(35, 32%, 91%)"], [8, "hsl(0, 0%, 100%)"]]
                 },
-                "line-opacity": {
-                    "base": 1.2,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            5.5,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1.2, "stops": [[5, 0], [5.5, 1]]}
+            }
         },
         {
             "id": "road-primary",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "==",
-                        "class",
-                        "primary"
-                    ]
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "class", "primary"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
                 "line-color": {
                     "base": 1,
-                    "stops": [
-                        [
-                            5,
-                            "hsl(35, 32%, 91%)"
-                        ],
-                        [
-                            7,
-                            "hsl(0, 0%, 100%)"
-                        ]
-                    ]
+                    "stops": [[5, "hsl(35, 32%, 91%)"], [7, "hsl(0, 0%, 100%)"]]
                 },
                 "line-opacity": 1
-            },
-            "interactive": true
+            }
         },
         {
             "id": "road-oneway-arrows-blue-minor",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 16,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!=",
-                        "type",
-                        "trunk_link"
-                    ],
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "==",
-                        "oneway",
-                        "true"
-                    ],
+                    ["!=", "type", "trunk_link"],
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "oneway", "true"],
                     [
                         "in",
                         "class",
@@ -5575,58 +2191,29 @@
                 "symbol-placement": "line",
                 "icon-image": {
                     "base": 1,
-                    "stops": [
-                        [
-                            17,
-                            "oneway-small"
-                        ],
-                        [
-                            18,
-                            "oneway-large"
-                        ]
-                    ]
+                    "stops": [[17, "oneway-small"], [18, "oneway-large"]]
                 },
                 "icon-rotation-alignment": "map",
                 "icon-padding": 2,
                 "symbol-spacing": 200
             },
-            "paint": {},
-            "interactive": true
+            "paint": {}
         },
         {
             "id": "road-oneway-arrows-blue-major",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 15,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!=",
-                        "type",
-                        "trunk_link"
-                    ],
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "==",
-                        "oneway",
-                        "true"
-                    ],
+                    ["!=", "type", "trunk_link"],
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "oneway", "true"],
                     [
                         "in",
                         "class",
@@ -5642,355 +2229,157 @@
                 "symbol-placement": "line",
                 "icon-image": {
                     "base": 1,
-                    "stops": [
-                        [
-                            16,
-                            "oneway-small"
-                        ],
-                        [
-                            17,
-                            "oneway-large"
-                        ]
-                    ]
+                    "stops": [[16, "oneway-small"], [17, "oneway-large"]]
                 },
                 "icon-rotation-alignment": "map",
                 "icon-padding": 2,
                 "symbol-spacing": 200
             },
-            "paint": {},
-            "interactive": true
+            "paint": {}
         },
         {
             "id": "road-trunk",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "==",
-                        "class",
-                        "trunk"
-                    ]
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "class", "trunk"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
                 "line-color": {
                     "base": 1,
                     "stops": [
-                        [
-                            6,
-                            "hsl(0, 0%, 100%)"
-                        ],
-                        [
-                            6.1,
-                            "hsl(46, 80%, 60%)"
-                        ],
-                        [
-                            9,
-                            "hsl(46, 85%, 67%)"
-                        ]
+                        [6, "hsl(0, 0%, 100%)"],
+                        [6.1, "hsl(46, 80%, 60%)"],
+                        [9, "hsl(46, 85%, 67%)"]
                     ]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "road-motorway",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "==",
-                        "class",
-                        "motorway"
-                    ]
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "class", "motorway"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
                 "line-color": {
                     "base": 1,
                     "stops": [
-                        [
-                            8,
-                            "hsl(26, 87%, 62%)"
-                        ],
-                        [
-                            9,
-                            "hsl(26, 100%, 68%)"
-                        ]
+                        [8, "hsl(26, 87%, 62%)"],
+                        [9, "hsl(26, 100%, 68%)"]
                     ]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "road-rail",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 13,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "in",
-                        "class",
-                        "major_rail",
-                        "minor_rail"
-                    ]
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["in", "class", "major_rail", "minor_rail"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
                 "line-color": {
                     "stops": [
-                        [
-                            13,
-                            "hsl(50, 17%, 82%)"
-                        ],
-                        [
-                            16,
-                            "hsl(230, 10%, 74%)"
-                        ]
+                        [13, "hsl(50, 17%, 82%)"],
+                        [16, "hsl(230, 10%, 74%)"]
                     ]
                 },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            14,
-                            0.5
-                        ],
-                        [
-                            20,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-width": {"base": 1.5, "stops": [[14, 0.5], [20, 1]]}
+            }
         },
         {
             "id": "road-rail-tracks",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 13,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
-                    [
-                        "in",
-                        "class",
-                        "major_rail",
-                        "minor_rail"
-                    ]
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["in", "class", "major_rail", "minor_rail"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
                 "line-color": {
                     "stops": [
-                        [
-                            13,
-                            "hsl(50, 17%, 82%)"
-                        ],
-                        [
-                            16,
-                            "hsl(230, 10%, 74%)"
-                        ]
+                        [13, "hsl(50, 17%, 82%)"],
+                        [16, "hsl(230, 10%, 74%)"]
                     ]
                 },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            14,
-                            4
-                        ],
-                        [
-                            20,
-                            8
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    0.1,
-                    15
-                ],
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13.75,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-width": {"base": 1.5, "stops": [[14, 4], [20, 8]]},
+                "line-dasharray": [0.1, 15],
+                "line-opacity": {"base": 1, "stops": [[13.75, 0], [14, 1]]}
+            }
         },
         {
             "id": "level-crossings",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 16,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "Point"
-                ],
-                [
-                    "==",
-                    "class",
-                    "level_crossing"
-                ]
+                ["==", "$type", "Point"],
+                ["==", "class", "level_crossing"]
             ],
             "layout": {
                 "icon-size": 1,
                 "icon-image": "level-crossing",
                 "icon-allow-overlap": true
             },
-            "paint": {},
-            "interactive": true
+            "paint": {}
         },
         {
             "id": "road-oneway-arrows-white",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 16,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "structure",
-                        "bridge",
-                        "tunnel"
-                    ],
+                    ["!in", "structure", "bridge", "tunnel"],
                     [
                         "!in",
                         "type",
@@ -5998,11 +2387,7 @@
                         "secondary_link",
                         "tertiary_link"
                     ],
-                    [
-                        "==",
-                        "oneway",
-                        "true"
-                    ],
+                    ["==", "oneway", "true"],
                     [
                         "in",
                         "class",
@@ -6018,1958 +2403,705 @@
                 "icon-image": {
                     "base": 1,
                     "stops": [
-                        [
-                            16,
-                            "oneway-white-small"
-                        ],
-                        [
-                            17,
-                            "oneway-white-large"
-                        ]
+                        [16, "oneway-white-small"],
+                        [17, "oneway-white-large"]
                     ]
                 },
                 "icon-padding": 2,
                 "symbol-spacing": 200
             },
-            "paint": {},
-            "interactive": true
+            "paint": {}
         },
         {
             "id": "turning-features",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444855786460.0557"
-            },
+            "metadata": {"mapbox:group": "1444855786460.0557"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 15,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "Point"
-                ],
-                [
-                    "in",
-                    "class",
-                    "turning_circle",
-                    "turning_loop"
-                ]
+                ["==", "$type", "Point"],
+                ["in", "class", "turning_circle", "turning_loop"]
             ],
             "layout": {
                 "icon-image": "turning-circle",
-                "icon-size": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            14,
-                            0.095
-                        ],
-                        [
-                            18,
-                            1
-                        ]
-                    ]
-                },
+                "icon-size": {"base": 1.5, "stops": [[14, 0.095], [18, 1]]},
                 "icon-allow-overlap": true,
                 "icon-ignore-placement": true,
                 "icon-padding": 0,
                 "icon-rotation-alignment": "map"
             },
-            "paint": {},
-            "interactive": true
+            "paint": {}
         },
         {
             "id": "bridge-path-bg",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!=",
-                        "type",
-                        "steps"
-                    ],
-                    [
-                        "==",
-                        "class",
-                        "path"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ]
+                    ["!=", "type", "steps"],
+                    ["==", "class", "path"],
+                    ["==", "structure", "bridge"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            15,
-                            2
-                        ],
-                        [
-                            18,
-                            7
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    1,
-                    0
-                ],
+                "line-width": {"base": 1.5, "stops": [[15, 2], [18, 7]]},
+                "line-dasharray": [1, 0],
                 "line-color": "hsl(230, 17%, 82%)",
                 "line-blur": 0,
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            15,
-                            0
-                        ],
-                        [
-                            15.25,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[15, 0], [15.25, 1]]}
+            }
         },
         {
             "id": "bridge-steps-bg",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "all",
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
-                    [
-                        "==",
-                        "type",
-                        "steps"
-                    ]
-                ]
+                ["==", "$type", "LineString"],
+                ["all", ["==", "structure", "bridge"], ["==", "type", "steps"]]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            15,
-                            2
-                        ],
-                        [
-                            17,
-                            4.6
-                        ],
-                        [
-                            18,
-                            7
-                        ]
-                    ]
+                    "stops": [[15, 2], [17, 4.6], [18, 7]]
                 },
                 "line-color": "hsl(230, 17%, 82%)",
-                "line-dasharray": [
-                    1,
-                    0
-                ],
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            14,
-                            0
-                        ],
-                        [
-                            14.25,
-                            0.75
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-dasharray": [1, 0],
+                "line-opacity": {"base": 1, "stops": [[14, 0], [14.25, 0.75]]}
+            }
         },
         {
             "id": "bridge-pedestrian-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 13,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "pedestrian"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ]
+                    ["==", "class", "pedestrian"],
+                    ["==", "structure", "bridge"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            14.5
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[14, 2], [18, 14.5]]},
                 "line-color": "hsl(230, 24%, 87%)",
                 "line-gap-width": 0,
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13.99,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]}
+            }
         },
         {
             "id": "bridge-street-low",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "street"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ]
+                    ["==", "class", "street"],
+                    ["==", "structure", "bridge"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12.5,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-opacity": {
-                    "stops": [
-                        [
-                            11.5,
-                            0
-                        ],
-                        [
-                            12,
-                            1
-                        ],
-                        [
-                            14,
-                            1
-                        ],
-                        [
-                            14.01,
-                            0
-                        ]
-                    ]
+                    "stops": [[11.5, 0], [12, 1], [14, 1], [14.01, 0]]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "bridge-street_limited-low",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "street_limited"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ]
+                    ["==", "class", "street_limited"],
+                    ["==", "structure", "bridge"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12.5,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-opacity": {
-                    "stops": [
-                        [
-                            11.5,
-                            0
-                        ],
-                        [
-                            12,
-                            1
-                        ],
-                        [
-                            14,
-                            1
-                        ],
-                        [
-                            14.01,
-                            0
-                        ]
-                    ]
+                    "stops": [[11.5, 0], [12, 1], [14, 1], [14.01, 0]]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "bridge-service-link-track-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 14,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!=",
-                        "type",
-                        "trunk_link"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
-                    [
-                        "in",
-                        "class",
-                        "link",
-                        "service",
-                        "track"
-                    ]
+                    ["!=", "type", "trunk_link"],
+                    ["==", "structure", "bridge"],
+                    ["in", "class", "link", "service", "track"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.75
-                        ],
-                        [
-                            20,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
                 "line-color": "hsl(230, 24%, 87%)",
-                "line-gap-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            14,
-                            0.5
-                        ],
-                        [
-                            18,
-                            12
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-gap-width": {"base": 1.5, "stops": [[14, 0.5], [18, 12]]}
+            }
         },
         {
             "id": "bridge-street_limited-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "street_limited"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ]
+                    ["==", "class", "street_limited"],
+                    ["==", "structure", "bridge"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.75
-                        ],
-                        [
-                            20,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
                 "line-color": "hsl(230, 24%, 87%)",
                 "line-gap-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            13,
-                            0
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[13, 0], [14, 2], [18, 18]]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "bridge-street-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "street"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ]
+                    ["==", "class", "street"],
+                    ["==", "structure", "bridge"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.75
-                        ],
-                        [
-                            20,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
                 "line-color": "hsl(230, 24%, 87%)",
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13.99,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                },
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]},
                 "line-gap-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            13,
-                            0
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[13, 0], [14, 2], [18, 18]]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "bridge-secondary-tertiary-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
-                    [
-                        "in",
-                        "class",
-                        "secondary",
-                        "tertiary"
-                    ]
+                    ["==", "structure", "bridge"],
+                    ["in", "class", "secondary", "tertiary"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.2,
-                    "stops": [
-                        [
-                            10,
-                            0.75
-                        ],
-                        [
-                            18,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.2, "stops": [[10, 0.75], [18, 2]]},
                 "line-color": "hsl(230, 24%, 87%)",
                 "line-gap-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            8.5,
-                            0.5
-                        ],
-                        [
-                            10,
-                            0.75
-                        ],
-                        [
-                            18,
-                            26
-                        ]
-                    ]
+                    "stops": [[8.5, 0.5], [10, 0.75], [18, 26]]
                 },
-                "line-translate": [
-                    0,
-                    0
-                ]
-            },
-            "interactive": true
+                "line-translate": [0, 0]
+            }
         },
         {
             "id": "bridge-primary-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "primary"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ]
+                    ["==", "class", "primary"],
+                    ["==", "structure", "bridge"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            10,
-                            1
-                        ],
-                        [
-                            16,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[10, 1], [16, 2]]},
                 "line-color": "hsl(230, 24%, 87%)",
-                "line-gap-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                },
-                "line-translate": [
-                    0,
-                    0
-                ]
-            },
-            "interactive": true
+                "line-gap-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
+                "line-translate": [0, 0]
+            }
         },
         {
             "id": "bridge-trunk_link-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 13,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "layer",
-                        2,
-                        3,
-                        4,
-                        5
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
-                    [
-                        "==",
-                        "type",
-                        "trunk_link"
-                    ]
+                    ["!in", "layer", 2, 3, 4, 5],
+                    ["==", "structure", "bridge"],
+                    ["==", "type", "trunk_link"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.75
-                        ],
-                        [
-                            20,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-gap-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
                 },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10.99,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[10.99, 0], [11, 1]]}
+            }
         },
         {
             "id": "bridge-motorway_link-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 13,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "layer",
-                        2,
-                        3,
-                        4,
-                        5
-                    ],
-                    [
-                        "==",
-                        "class",
-                        "motorway_link"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ]
+                    ["!in", "layer", 2, 3, 4, 5],
+                    ["==", "class", "motorway_link"],
+                    ["==", "structure", "bridge"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.75
-                        ],
-                        [
-                            20,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-gap-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
                 },
                 "line-opacity": 1
-            },
-            "interactive": true
+            }
         },
         {
             "id": "bridge-trunk-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "layer",
-                        2,
-                        3,
-                        4,
-                        5
-                    ],
-                    [
-                        "==",
-                        "class",
-                        "trunk"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ]
+                    ["!in", "layer", 2, 3, 4, 5],
+                    ["==", "class", "trunk"],
+                    ["==", "structure", "bridge"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            10,
-                            1
-                        ],
-                        [
-                            16,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[10, 1], [16, 2]]},
                 "line-color": "hsl(0, 0%, 100%)",
-                "line-gap-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-gap-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]}
+            }
         },
         {
             "id": "bridge-motorway-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "layer",
-                        2,
-                        3,
-                        4,
-                        5
-                    ],
-                    [
-                        "==",
-                        "class",
-                        "motorway"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ]
+                    ["!in", "layer", 2, 3, 4, 5],
+                    ["==", "class", "motorway"],
+                    ["==", "structure", "bridge"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            10,
-                            1
-                        ],
-                        [
-                            16,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[10, 1], [16, 2]]},
                 "line-color": "hsl(0, 0%, 100%)",
-                "line-gap-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-gap-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]}
+            }
         },
         {
             "id": "bridge-construction",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 14,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "construction"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ]
+                    ["==", "class", "construction"],
+                    ["==", "structure", "bridge"]
                 ]
             ],
-            "layout": {
-                "line-join": "miter"
-            },
+            "layout": {"line-join": "miter"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12.5,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(230, 24%, 87%)",
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13.99,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                },
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]},
                 "line-dasharray": {
                     "base": 1,
                     "stops": [
-                        [
-                            14,
-                            [
-                                0.4,
-                                0.8
-                            ]
-                        ],
-                        [
-                            15,
-                            [
-                                0.3,
-                                0.6
-                            ]
-                        ],
-                        [
-                            16,
-                            [
-                                0.2,
-                                0.3
-                            ]
-                        ],
-                        [
-                            17,
-                            [
-                                0.2,
-                                0.25
-                            ]
-                        ],
-                        [
-                            18,
-                            [
-                                0.15,
-                                0.15
-                            ]
-                        ]
+                        [14, [0.4, 0.8]],
+                        [15, [0.3, 0.6]],
+                        [16, [0.2, 0.3]],
+                        [17, [0.2, 0.25]],
+                        [18, [0.15, 0.15]]
                     ]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "bridge-path",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!=",
-                        "type",
-                        "steps"
-                    ],
-                    [
-                        "==",
-                        "class",
-                        "path"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ]
+                    ["!=", "type", "steps"],
+                    ["==", "class", "path"],
+                    ["==", "structure", "bridge"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            15,
-                            1
-                        ],
-                        [
-                            18,
-                            4
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[15, 1], [18, 4]]},
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-dasharray": {
                     "base": 1,
                     "stops": [
-                        [
-                            14,
-                            [
-                                1,
-                                0
-                            ]
-                        ],
-                        [
-                            15,
-                            [
-                                1.75,
-                                1
-                            ]
-                        ],
-                        [
-                            16,
-                            [
-                                1,
-                                0.75
-                            ]
-                        ],
-                        [
-                            17,
-                            [
-                                1,
-                                0.5
-                            ]
-                        ]
+                        [14, [1, 0]],
+                        [15, [1.75, 1]],
+                        [16, [1, 0.75]],
+                        [17, [1, 0.5]]
                     ]
                 },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            14,
-                            0
-                        ],
-                        [
-                            14.25,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[14, 0], [14.25, 1]]}
+            }
         },
         {
             "id": "bridge-steps",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "all",
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
-                    [
-                        "==",
-                        "type",
-                        "steps"
-                    ]
-                ]
+                ["==", "$type", "LineString"],
+                ["all", ["==", "structure", "bridge"], ["==", "type", "steps"]]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            15,
-                            1
-                        ],
-                        [
-                            16,
-                            1.6
-                        ],
-                        [
-                            18,
-                            6
-                        ]
-                    ]
+                    "stops": [[15, 1], [16, 1.6], [18, 6]]
                 },
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-dasharray": {
                     "base": 1,
                     "stops": [
-                        [
-                            14,
-                            [
-                                1,
-                                0
-                            ]
-                        ],
-                        [
-                            15,
-                            [
-                                1.75,
-                                1
-                            ]
-                        ],
-                        [
-                            16,
-                            [
-                                1,
-                                0.75
-                            ]
-                        ],
-                        [
-                            17,
-                            [
-                                0.3,
-                                0.3
-                            ]
-                        ]
+                        [14, [1, 0]],
+                        [15, [1.75, 1]],
+                        [16, [1, 0.75]],
+                        [17, [0.3, 0.3]]
                     ]
                 },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            14,
-                            0
-                        ],
-                        [
-                            14.25,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[14, 0], [14.25, 1]]}
+            }
         },
         {
             "id": "bridge-trunk_link",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 13,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "layer",
-                        2,
-                        3,
-                        4,
-                        5
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
-                    [
-                        "==",
-                        "type",
-                        "trunk_link"
-                    ]
+                    ["!in", "layer", 2, 3, 4, 5],
+                    ["==", "structure", "bridge"],
+                    ["==", "type", "trunk_link"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(46, 85%, 67%)"
-            },
-            "interactive": true
+            }
         },
         {
             "id": "bridge-motorway_link",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 13,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "layer",
-                        2,
-                        3,
-                        4,
-                        5
-                    ],
-                    [
-                        "==",
-                        "class",
-                        "motorway_link"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ]
+                    ["!in", "layer", 2, 3, 4, 5],
+                    ["==", "class", "motorway_link"],
+                    ["==", "structure", "bridge"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(26, 100%, 68%)"
-            },
-            "interactive": true
+            }
         },
         {
             "id": "bridge-pedestrian",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 13,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "pedestrian"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ]
+                    ["==", "class", "pedestrian"],
+                    ["==", "structure", "bridge"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            14,
-                            0.5
-                        ],
-                        [
-                            18,
-                            12
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[14, 0.5], [18, 12]]},
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-opacity": 1,
                 "line-dasharray": {
                     "base": 1,
-                    "stops": [
-                        [
-                            14,
-                            [
-                                1,
-                                0
-                            ]
-                        ],
-                        [
-                            15,
-                            [
-                                1.5,
-                                0.4
-                            ]
-                        ],
-                        [
-                            16,
-                            [
-                                1,
-                                0.2
-                            ]
-                        ]
-                    ]
+                    "stops": [[14, [1, 0]], [15, [1.5, 0.4]], [16, [1, 0.2]]]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "bridge-service-link-track",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 14,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!=",
-                        "type",
-                        "trunk_link"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
-                    [
-                        "in",
-                        "class",
-                        "link",
-                        "service",
-                        "track"
-                    ]
+                    ["!=", "type", "trunk_link"],
+                    ["==", "structure", "bridge"],
+                    ["in", "class", "link", "service", "track"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            14,
-                            0.5
-                        ],
-                        [
-                            18,
-                            12
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[14, 0.5], [18, 12]]},
                 "line-color": "hsl(0, 0%, 100%)"
-            },
-            "interactive": true
+            }
         },
         {
             "id": "bridge-street_limited",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "street_limited"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ]
+                    ["==", "class", "street_limited"],
+                    ["==", "structure", "bridge"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12.5,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(35, 14%, 93%)",
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13.99,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]}
+            }
         },
         {
             "id": "bridge-street",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "street"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ]
+                    ["==", "class", "street"],
+                    ["==", "structure", "bridge"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12.5,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(0, 0%, 100%)",
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13.99,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]}
+            }
         },
         {
             "id": "bridge-secondary-tertiary",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
-                    [
-                        "in",
-                        "type",
-                        "secondary",
-                        "tertiary"
-                    ]
+                    ["==", "structure", "bridge"],
+                    ["in", "type", "secondary", "tertiary"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            8.5,
-                            0.5
-                        ],
-                        [
-                            10,
-                            0.75
-                        ],
-                        [
-                            18,
-                            26
-                        ]
-                    ]
+                    "stops": [[8.5, 0.5], [10, 0.75], [18, 26]]
                 },
                 "line-color": "hsl(0, 0%, 100%)",
-                "line-opacity": {
-                    "base": 1.2,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            5.5,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1.2, "stops": [[5, 0], [5.5, 1]]}
+            }
         },
         {
             "id": "bridge-primary",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
-                    [
-                        "==",
-                        "type",
-                        "primary"
-                    ]
+                    ["==", "structure", "bridge"],
+                    ["==", "type", "primary"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-opacity": 1
-            },
-            "interactive": true
+            }
         },
         {
             "id": "bridge-oneway-arrows-blue-minor",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 16,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "oneway",
-                        "true"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
+                    ["==", "oneway", "true"],
+                    ["==", "structure", "bridge"],
                     [
                         "in",
                         "class",
@@ -7985,52 +3117,28 @@
                 "symbol-placement": "line",
                 "icon-image": {
                     "base": 1,
-                    "stops": [
-                        [
-                            17,
-                            "oneway-small"
-                        ],
-                        [
-                            18,
-                            "oneway-large"
-                        ]
-                    ]
+                    "stops": [[17, "oneway-small"], [18, "oneway-large"]]
                 },
                 "symbol-spacing": 200,
                 "icon-rotation-alignment": "map",
                 "icon-padding": 2
             },
-            "paint": {},
-            "interactive": true
+            "paint": {}
         },
         {
             "id": "bridge-oneway-arrows-blue-major",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 15,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "oneway",
-                        "true"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
+                    ["==", "oneway", "true"],
+                    ["==", "structure", "bridge"],
                     [
                         "in",
                         "class",
@@ -8046,831 +3154,322 @@
                 "symbol-placement": "line",
                 "icon-image": {
                     "base": 1,
-                    "stops": [
-                        [
-                            16,
-                            "oneway-small"
-                        ],
-                        [
-                            17,
-                            "oneway-large"
-                        ]
-                    ]
+                    "stops": [[16, "oneway-small"], [17, "oneway-large"]]
                 },
                 "symbol-spacing": 200,
                 "icon-rotation-alignment": "map",
                 "icon-padding": 2
             },
-            "paint": {},
-            "interactive": true
+            "paint": {}
         },
         {
             "id": "bridge-trunk",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "layer",
-                        2,
-                        3,
-                        4,
-                        5
-                    ],
-                    [
-                        "==",
-                        "class",
-                        "trunk"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ]
+                    ["!in", "layer", 2, 3, 4, 5],
+                    ["==", "class", "trunk"],
+                    ["==", "structure", "bridge"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
                 "line-color": "hsl(46, 85%, 67%)"
-            },
-            "interactive": true
+            }
         },
         {
             "id": "bridge-motorway",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "!in",
-                        "layer",
-                        2,
-                        3,
-                        4,
-                        5
-                    ],
-                    [
-                        "==",
-                        "class",
-                        "motorway"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ]
+                    ["!in", "layer", 2, 3, 4, 5],
+                    ["==", "class", "motorway"],
+                    ["==", "structure", "bridge"]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
                 "line-color": "hsl(26, 100%, 68%)"
-            },
-            "interactive": true
+            }
         },
         {
             "id": "bridge-rail",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 13,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
-                    [
-                        "in",
-                        "class",
-                        "major_rail",
-                        "minor_rail"
-                    ]
+                    ["==", "structure", "bridge"],
+                    ["in", "class", "major_rail", "minor_rail"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
                 "line-color": {
                     "stops": [
-                        [
-                            13,
-                            "hsl(50, 17%, 82%)"
-                        ],
-                        [
-                            16,
-                            "hsl(230, 10%, 74%)"
-                        ]
+                        [13, "hsl(50, 17%, 82%)"],
+                        [16, "hsl(230, 10%, 74%)"]
                     ]
                 },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            14,
-                            0.5
-                        ],
-                        [
-                            20,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-width": {"base": 1.5, "stops": [[14, 0.5], [20, 1]]}
+            }
         },
         {
             "id": "bridge-rail-tracks",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 13,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
-                    [
-                        "in",
-                        "class",
-                        "major_rail",
-                        "minor_rail"
-                    ]
+                    ["==", "structure", "bridge"],
+                    ["in", "class", "major_rail", "minor_rail"]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
                 "line-color": {
                     "stops": [
-                        [
-                            13,
-                            "hsl(50, 17%, 82%)"
-                        ],
-                        [
-                            16,
-                            "hsl(230, 10%, 74%)"
-                        ]
+                        [13, "hsl(50, 17%, 82%)"],
+                        [16, "hsl(230, 10%, 74%)"]
                     ]
                 },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            14,
-                            4
-                        ],
-                        [
-                            20,
-                            8
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    0.1,
-                    15
-                ],
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13.75,
-                            0
-                        ],
-                        [
-                            20,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-width": {"base": 1.5, "stops": [[14, 4], [20, 8]]},
+                "line-dasharray": [0.1, 15],
+                "line-opacity": {"base": 1, "stops": [[13.75, 0], [20, 1]]}
+            }
         },
         {
             "id": "bridge-trunk_link-2-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 13,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
-                    [
-                        "==",
-                        "type",
-                        "trunk_link"
-                    ],
-                    [
-                        ">=",
-                        "layer",
-                        2
-                    ]
+                    ["==", "structure", "bridge"],
+                    ["==", "type", "trunk_link"],
+                    [">=", "layer", 2]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.75
-                        ],
-                        [
-                            20,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-gap-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
                 },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10.99,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[10.99, 0], [11, 1]]}
+            }
         },
         {
             "id": "bridge-motorway_link-2-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 13,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "motorway_link"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
-                    [
-                        ">=",
-                        "layer",
-                        2
-                    ]
+                    ["==", "class", "motorway_link"],
+                    ["==", "structure", "bridge"],
+                    [">=", "layer", 2]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.75
-                        ],
-                        [
-                            20,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
                 "line-color": "hsl(0, 0%, 100%)",
                 "line-gap-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
                 },
                 "line-opacity": 1
-            },
-            "interactive": true
+            }
         },
         {
             "id": "bridge-trunk-2-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "trunk"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
-                    [
-                        ">=",
-                        "layer",
-                        2
-                    ]
+                    ["==", "class", "trunk"],
+                    ["==", "structure", "bridge"],
+                    [">=", "layer", 2]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            10,
-                            1
-                        ],
-                        [
-                            16,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[10, 1], [16, 2]]},
                 "line-color": "hsl(0, 0%, 100%)",
-                "line-gap-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-gap-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]}
+            }
         },
         {
             "id": "bridge-motorway-2-case",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "motorway"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
-                    [
-                        ">=",
-                        "layer",
-                        2
-                    ]
+                    ["==", "class", "motorway"],
+                    ["==", "structure", "bridge"],
+                    [">=", "layer", 2]
                 ]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            10,
-                            1
-                        ],
-                        [
-                            16,
-                            2
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[10, 1], [16, 2]]},
                 "line-color": "hsl(0, 0%, 100%)",
-                "line-gap-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-gap-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]}
+            }
         },
         {
             "id": "bridge-trunk_link-2",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 13,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
-                    [
-                        "==",
-                        "type",
-                        "trunk_link"
-                    ],
-                    [
-                        ">=",
-                        "layer",
-                        2
-                    ]
+                    ["==", "structure", "bridge"],
+                    ["==", "type", "trunk_link"],
+                    [">=", "layer", 2]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(46, 85%, 67%)"
-            },
-            "interactive": true
+            }
         },
         {
             "id": "bridge-motorway_link-2",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 13,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "motorway_link"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
-                    [
-                        ">=",
-                        "layer",
-                        2
-                    ]
+                    ["==", "class", "motorway_link"],
+                    ["==", "structure", "bridge"],
+                    [">=", "layer", 2]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
                 "line-width": {
                     "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.5
-                        ],
-                        [
-                            14,
-                            2
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
                 },
                 "line-color": "hsl(26, 100%, 68%)"
-            },
-            "interactive": true
+            }
         },
         {
             "id": "bridge-trunk-2",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "trunk"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
-                    [
-                        ">=",
-                        "layer",
-                        2
-                    ]
+                    ["==", "class", "trunk"],
+                    ["==", "structure", "bridge"],
+                    [">=", "layer", 2]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
                 "line-color": "hsl(46, 85%, 67%)"
-            },
-            "interactive": true
+            }
         },
         {
             "id": "bridge-motorway-2",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
-                    [
-                        "==",
-                        "class",
-                        "motorway"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
-                    [
-                        ">=",
-                        "layer",
-                        2
-                    ]
+                    ["==", "class", "motorway"],
+                    ["==", "structure", "bridge"],
+                    [">=", "layer", 2]
                 ]
             ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
+            "layout": {"line-cap": "round", "line-join": "round"},
             "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
                 "line-color": "hsl(26, 100%, 68%)"
-            },
-            "interactive": true
+            }
         },
         {
             "id": "bridge-oneway-arrows-white",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444855799204.86"
-            },
+            "metadata": {"mapbox:group": "1444855799204.86"},
             "source": "composite",
             "source-layer": "road",
             "minzoom": 16,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "all",
                     [
@@ -8880,16 +3479,8 @@
                         "secondary_link",
                         "tertiary_link"
                     ],
-                    [
-                        "==",
-                        "oneway",
-                        "true"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ],
+                    ["==", "oneway", "true"],
+                    ["==", "structure", "bridge"],
                     [
                         "in",
                         "class",
@@ -8905,21 +3496,14 @@
                 "icon-image": {
                     "base": 1,
                     "stops": [
-                        [
-                            16,
-                            "oneway-white-small"
-                        ],
-                        [
-                            17,
-                            "oneway-white-large"
-                        ]
+                        [16, "oneway-white-small"],
+                        [17, "oneway-white-large"]
                     ]
                 },
                 "symbol-spacing": 200,
                 "icon-padding": 2
             },
-            "paint": {},
-            "interactive": true
+            "paint": {}
         },
         {
             "id": "aerialway",
@@ -8929,400 +3513,123 @@
             "minzoom": 13,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "==",
-                    "class",
-                    "aerialway"
-                ]
+                ["==", "$type", "LineString"],
+                ["==", "class", "aerialway"]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
                 "line-color": "hsl(230, 10%, 74%)",
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            14,
-                            0.5
-                        ],
-                        [
-                            20,
-                            1
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-width": {"base": 1.5, "stops": [[14, 0.5], [20, 1]]}
+            }
         },
         {
             "id": "admin-3-4-boundaries-bg",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444934295202.7542"
-            },
+            "metadata": {"mapbox:group": "1444934295202.7542"},
             "source": "composite",
             "source-layer": "admin",
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "maritime",
-                    0
-                ],
-                [
-                    ">=",
-                    "admin_level",
-                    3
-                ]
-            ],
-            "layout": {
-                "line-join": "bevel"
-            },
+            "filter": ["all", ["==", "maritime", 0], [">=", "admin_level", 3]],
+            "layout": {"line-join": "bevel"},
             "paint": {
                 "line-color": {
                     "base": 1,
                     "stops": [
-                        [
-                            8,
-                            "hsl(35, 12%, 89%)"
-                        ],
-                        [
-                            16,
-                            "hsl(230, 49%, 90%)"
-                        ]
+                        [8, "hsl(35, 12%, 89%)"],
+                        [16, "hsl(230, 49%, 90%)"]
                     ]
                 },
-                "line-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            7,
-                            3.75
-                        ],
-                        [
-                            12,
-                            5.5
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            7,
-                            0
-                        ],
-                        [
-                            8,
-                            0.75
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    1,
-                    0
-                ],
-                "line-translate": [
-                    0,
-                    0
-                ],
-                "line-blur": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            3,
-                            0
-                        ],
-                        [
-                            8,
-                            3
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-width": {"base": 1, "stops": [[7, 3.75], [12, 5.5]]},
+                "line-opacity": {"base": 1, "stops": [[7, 0], [8, 0.75]]},
+                "line-dasharray": [1, 0],
+                "line-translate": [0, 0],
+                "line-blur": {"base": 1, "stops": [[3, 0], [8, 3]]}
+            }
         },
         {
             "id": "admin-2-boundaries-bg",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444934295202.7542"
-            },
+            "metadata": {"mapbox:group": "1444934295202.7542"},
             "source": "composite",
             "source-layer": "admin",
             "minzoom": 1,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "admin_level",
-                    2
-                ],
-                [
-                    "==",
-                    "maritime",
-                    0
-                ]
-            ],
-            "layout": {
-                "line-join": "miter"
-            },
+            "filter": ["all", ["==", "admin_level", 2], ["==", "maritime", 0]],
+            "layout": {"line-join": "miter"},
             "paint": {
-                "line-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            3,
-                            3.5
-                        ],
-                        [
-                            10,
-                            8
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1, "stops": [[3, 3.5], [10, 8]]},
                 "line-color": {
                     "base": 1,
                     "stops": [
-                        [
-                            6,
-                            "hsl(35, 12%, 89%)"
-                        ],
-                        [
-                            8,
-                            "hsl(230, 49%, 90%)"
-                        ]
+                        [6, "hsl(35, 12%, 89%)"],
+                        [8, "hsl(230, 49%, 90%)"]
                     ]
                 },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            3,
-                            0
-                        ],
-                        [
-                            4,
-                            0.5
-                        ]
-                    ]
-                },
-                "line-translate": [
-                    0,
-                    0
-                ],
-                "line-blur": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            3,
-                            0
-                        ],
-                        [
-                            10,
-                            2
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-opacity": {"base": 1, "stops": [[3, 0], [4, 0.5]]},
+                "line-translate": [0, 0],
+                "line-blur": {"base": 1, "stops": [[3, 0], [10, 2]]}
+            }
         },
         {
             "id": "admin-3-4-boundaries",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444934295202.7542"
-            },
+            "metadata": {"mapbox:group": "1444934295202.7542"},
             "source": "composite",
             "source-layer": "admin",
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "maritime",
-                    0
-                ],
-                [
-                    ">=",
-                    "admin_level",
-                    3
-                ]
-            ],
-            "layout": {
-                "line-join": "round",
-                "line-cap": "round"
-            },
+            "filter": ["all", ["==", "maritime", 0], [">=", "admin_level", 3]],
+            "layout": {"line-join": "round", "line-cap": "round"},
             "paint": {
                 "line-dasharray": {
                     "base": 1,
-                    "stops": [
-                        [
-                            6,
-                            [
-                                2,
-                                0
-                            ]
-                        ],
-                        [
-                            7,
-                            [
-                                2,
-                                2,
-                                6,
-                                2
-                            ]
-                        ]
-                    ]
+                    "stops": [[6, [2, 0]], [7, [2, 2, 6, 2]]]
                 },
-                "line-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            7,
-                            0.75
-                        ],
-                        [
-                            12,
-                            1.5
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            2,
-                            0
-                        ],
-                        [
-                            3,
-                            1
-                        ]
-                    ]
-                },
+                "line-width": {"base": 1, "stops": [[7, 0.75], [12, 1.5]]},
+                "line-opacity": {"base": 1, "stops": [[2, 0], [3, 1]]},
                 "line-color": {
                     "base": 1,
                     "stops": [
-                        [
-                            3,
-                            "hsl(230, 14%, 77%)"
-                        ],
-                        [
-                            7,
-                            "hsl(230, 8%, 62%)"
-                        ]
+                        [3, "hsl(230, 14%, 77%)"],
+                        [7, "hsl(230, 8%, 62%)"]
                     ]
                 }
-            },
-            "interactive": true
+            }
         },
         {
             "id": "admin-2-boundaries",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444934295202.7542"
-            },
+            "metadata": {"mapbox:group": "1444934295202.7542"},
             "source": "composite",
             "source-layer": "admin",
             "minzoom": 1,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "admin_level",
-                    2
-                ],
-                [
-                    "==",
-                    "disputed",
-                    0
-                ],
-                [
-                    "==",
-                    "maritime",
-                    0
-                ]
+                ["==", "admin_level", 2],
+                ["==", "disputed", 0],
+                ["==", "maritime", 0]
             ],
-            "layout": {
-                "line-join": "round",
-                "line-cap": "round"
-            },
+            "layout": {"line-join": "round", "line-cap": "round"},
             "paint": {
                 "line-color": "hsl(230, 8%, 51%)",
-                "line-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            3,
-                            0.5
-                        ],
-                        [
-                            10,
-                            2
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-width": {"base": 1, "stops": [[3, 0.5], [10, 2]]}
+            }
         },
         {
             "id": "admin-2-boundaries-dispute",
             "type": "line",
-            "metadata": {
-                "mapbox:group": "1444934295202.7542"
-            },
+            "metadata": {"mapbox:group": "1444934295202.7542"},
             "source": "composite",
             "source-layer": "admin",
             "minzoom": 1,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "admin_level",
-                    2
-                ],
-                [
-                    "==",
-                    "disputed",
-                    1
-                ],
-                [
-                    "==",
-                    "maritime",
-                    0
-                ]
+                ["==", "admin_level", 2],
+                ["==", "disputed", 1],
+                ["==", "maritime", 0]
             ],
-            "layout": {
-                "line-join": "round"
-            },
+            "layout": {"line-join": "round"},
             "paint": {
-                "line-dasharray": [
-                    1.5,
-                    1.5
-                ],
+                "line-dasharray": [1.5, 1.5],
                 "line-color": "hsl(230, 8%, 51%)",
-                "line-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            3,
-                            0.5
-                        ],
-                        [
-                            10,
-                            2
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "line-width": {"base": 1, "stops": [[3, 0.5], [10, 2]]}
+            }
         },
         {
             "id": "housenum-label",
@@ -9333,7 +3640,8 @@
             "layout": {
                 "text-field": "{house_num}",
                 "text-font": [
-                    "DIN Offc Pro Italic,Arial Unicode MS Regular"
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
                 ],
                 "text-padding": 4,
                 "text-max-width": 7,
@@ -9344,8 +3652,7 @@
                 "text-halo-color": "hsl(35, 8%, 85%)",
                 "text-halo-width": 0.5,
                 "text-halo-blur": 0
-            },
-            "interactive": true
+            }
         },
         {
             "id": "waterway-label",
@@ -9353,48 +3660,29 @@
             "source": "composite",
             "source-layer": "waterway_label",
             "minzoom": 12,
-            "filter": [
-                "in",
-                "class",
-                "canal",
-                "river"
-            ],
+            "filter": ["in", "class", "canal", "river"],
             "layout": {
                 "text-field": "{name_en}",
                 "text-font": [
-                    "DIN Offc Pro Italic,Arial Unicode MS Regular"
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
                 ],
                 "symbol-placement": "line",
                 "text-pitch-alignment": "viewport",
                 "text-max-angle": 30,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13,
-                            12
-                        ],
-                        [
-                            18,
-                            16
-                        ]
-                    ]
-                }
+                "text-size": {"base": 1, "stops": [[13, 12], [18, 16]]}
             },
             "paint": {
                 "text-halo-width": 0.5,
                 "text-halo-color": "hsl(196, 80%, 70%)",
                 "text-color": "hsl(230, 48%, 44%)",
                 "text-halo-blur": 0.5
-            },
-            "interactive": true
+            }
         },
         {
             "id": "poi-scalerank4-l15",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444933456003.5437"
-            },
+            "metadata": {"mapbox:group": "1444933456003.5437"},
             "source": "composite",
             "source-layer": "poi_label",
             "minzoom": 17,
@@ -9413,43 +3701,21 @@
                     "playground",
                     "zoo"
                 ],
-                [
-                    "==",
-                    "scalerank",
-                    4
-                ],
-                [
-                    ">=",
-                    "localrank",
-                    15
-                ]
+                ["==", "scalerank", 4],
+                [">=", "localrank", 15]
             ],
             "layout": {
                 "text-line-height": 1.1,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            16,
-                            11
-                        ],
-                        [
-                            20,
-                            13
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[16, 11], [20, 13]]},
                 "icon-image": "{maki}-11",
                 "text-max-angle": 38,
                 "symbol-spacing": 250,
                 "text-font": [
-                    "DIN Offc Pro Medium,Arial Unicode MS Regular"
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
                 ],
                 "text-padding": 2,
-                "text-offset": [
-                    0,
-                    0.65
-                ],
+                "text-offset": [0, 0.65],
                 "text-rotation-alignment": "viewport",
                 "text-anchor": "top",
                 "text-field": "{name_en}",
@@ -9461,15 +3727,12 @@
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 0.5,
                 "text-halo-blur": 0.5
-            },
-            "interactive": true
+            }
         },
         {
             "id": "poi-scalerank4-l1",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444933456003.5437"
-            },
+            "metadata": {"mapbox:group": "1444933456003.5437"},
             "source": "composite",
             "source-layer": "poi_label",
             "minzoom": 15,
@@ -9488,43 +3751,21 @@
                     "playground",
                     "zoo"
                 ],
-                [
-                    "<=",
-                    "localrank",
-                    14
-                ],
-                [
-                    "==",
-                    "scalerank",
-                    4
-                ]
+                ["<=", "localrank", 14],
+                ["==", "scalerank", 4]
             ],
             "layout": {
                 "text-line-height": 1.1,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            16,
-                            11
-                        ],
-                        [
-                            20,
-                            13
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[16, 11], [20, 13]]},
                 "icon-image": "{maki}-11",
                 "text-max-angle": 38,
                 "symbol-spacing": 250,
                 "text-font": [
-                    "DIN Offc Pro Medium,Arial Unicode MS Regular"
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
                 ],
                 "text-padding": 1,
-                "text-offset": [
-                    0,
-                    0.65
-                ],
+                "text-offset": [0, 0.65],
                 "text-rotation-alignment": "viewport",
                 "text-anchor": "top",
                 "text-field": "{name_en}",
@@ -9536,25 +3777,18 @@
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 0.5,
                 "text-halo-blur": 0.5
-            },
-            "interactive": true
+            }
         },
         {
             "id": "poi-parks_scalerank4",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444933456003.5437"
-            },
+            "metadata": {"mapbox:group": "1444933456003.5437"},
             "source": "composite",
             "source-layer": "poi_label",
             "minzoom": 15,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "scalerank",
-                    4
-                ],
+                ["==", "scalerank", 4],
                 [
                     "in",
                     "maki",
@@ -9571,30 +3805,16 @@
             ],
             "layout": {
                 "text-line-height": 1.1,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            16,
-                            11
-                        ],
-                        [
-                            20,
-                            13
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[16, 11], [20, 13]]},
                 "icon-image": "{maki}-11",
                 "text-max-angle": 38,
                 "symbol-spacing": 250,
                 "text-font": [
-                    "DIN Offc Pro Medium,Arial Unicode MS Regular"
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
                 ],
                 "text-padding": 1,
-                "text-offset": [
-                    0,
-                    0.65
-                ],
+                "text-offset": [0, 0.65],
                 "text-rotation-alignment": "viewport",
                 "text-anchor": "top",
                 "text-field": "{name_en}",
@@ -9606,15 +3826,12 @@
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 0.5,
                 "text-halo-blur": 0.5
-            },
-            "interactive": true
+            }
         },
         {
             "id": "poi-scalerank3",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444933372896.5967"
-            },
+            "metadata": {"mapbox:group": "1444933372896.5967"},
             "source": "composite",
             "source-layer": "poi_label",
             "filter": [
@@ -9632,38 +3849,20 @@
                     "playground",
                     "zoo"
                 ],
-                [
-                    "==",
-                    "scalerank",
-                    3
-                ]
+                ["==", "scalerank", 3]
             ],
             "layout": {
                 "text-line-height": 1.1,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            16,
-                            11
-                        ],
-                        [
-                            20,
-                            13
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[16, 11], [20, 13]]},
                 "icon-image": "{maki}-11",
                 "text-max-angle": 38,
                 "symbol-spacing": 250,
                 "text-font": [
-                    "DIN Offc Pro Medium,Arial Unicode MS Regular"
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
                 ],
                 "text-padding": 1,
-                "text-offset": [
-                    0,
-                    0.65
-                ],
+                "text-offset": [0, 0.65],
                 "text-rotation-alignment": "viewport",
                 "text-anchor": "top",
                 "text-field": "{name_en}",
@@ -9675,24 +3874,17 @@
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 0.5,
                 "text-halo-blur": 0.5
-            },
-            "interactive": true
+            }
         },
         {
             "id": "poi-parks-scalerank3",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444933372896.5967"
-            },
+            "metadata": {"mapbox:group": "1444933372896.5967"},
             "source": "composite",
             "source-layer": "poi_label",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "scalerank",
-                    3
-                ],
+                ["==", "scalerank", 3],
                 [
                     "in",
                     "maki",
@@ -9709,30 +3901,16 @@
             ],
             "layout": {
                 "text-line-height": 1.1,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            16,
-                            11
-                        ],
-                        [
-                            20,
-                            13
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[16, 11], [20, 13]]},
                 "icon-image": "{maki}-11",
                 "text-max-angle": 38,
                 "symbol-spacing": 250,
                 "text-font": [
-                    "DIN Offc Pro Medium,Arial Unicode MS Regular"
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
                 ],
                 "text-padding": 2,
-                "text-offset": [
-                    0,
-                    0.65
-                ],
+                "text-offset": [0, 0.65],
                 "text-rotation-alignment": "viewport",
                 "text-anchor": "top",
                 "text-field": "{name_en}",
@@ -9744,15 +3922,12 @@
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 0.5,
                 "text-halo-blur": 0.5
-            },
-            "interactive": true
+            }
         },
         {
             "id": "road-label-small",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444933721429.3076"
-            },
+            "metadata": {"mapbox:group": "1444933721429.3076"},
             "source": "composite",
             "source-layer": "road_label",
             "minzoom": 15,
@@ -9772,30 +3947,15 @@
                     "tertiary",
                     "trunk"
                 ],
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ]
+                ["==", "$type", "LineString"]
             ],
             "layout": {
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            15,
-                            10
-                        ],
-                        [
-                            20,
-                            13
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[15, 10], [20, 13]]},
                 "text-max-angle": 30,
                 "symbol-spacing": 250,
                 "text-font": [
-                    "DIN Offc Pro Regular,Arial Unicode MS Regular"
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
                 ],
                 "symbol-placement": "line",
                 "text-padding": 1,
@@ -9809,25 +3969,18 @@
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 1.25,
                 "text-halo-blur": 1
-            },
-            "interactive": true
+            }
         },
         {
             "id": "road-label-medium",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444933721429.3076"
-            },
+            "metadata": {"mapbox:group": "1444933721429.3076"},
             "source": "composite",
             "source-layer": "road_label",
             "minzoom": 11,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
+                ["==", "$type", "LineString"],
                 [
                     "in",
                     "class",
@@ -9838,23 +3991,12 @@
                 ]
             ],
             "layout": {
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            11,
-                            10
-                        ],
-                        [
-                            20,
-                            14
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[11, 10], [20, 14]]},
                 "text-max-angle": 30,
                 "symbol-spacing": 250,
                 "text-font": [
-                    "DIN Offc Pro Regular,Arial Unicode MS Regular"
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
                 ],
                 "symbol-placement": "line",
                 "text-padding": 1,
@@ -9867,15 +4009,12 @@
                 "text-color": "hsl(0, 0%, 0%)",
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 1
-            },
-            "interactive": true
+            }
         },
         {
             "id": "road-label-large",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444933721429.3076"
-            },
+            "metadata": {"mapbox:group": "1444933721429.3076"},
             "source": "composite",
             "source-layer": "road_label",
             "filter": [
@@ -9888,23 +4027,12 @@
                 "trunk"
             ],
             "layout": {
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            9,
-                            10
-                        ],
-                        [
-                            20,
-                            16
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[9, 10], [20, 16]]},
                 "text-max-angle": 30,
                 "symbol-spacing": 250,
                 "text-font": [
-                    "DIN Offc Pro Regular,Arial Unicode MS Regular"
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
                 ],
                 "symbol-placement": "line",
                 "text-padding": 1,
@@ -9918,15 +4046,12 @@
                 "text-halo-color": "hsla(0, 0%, 100%, 0.75)",
                 "text-halo-width": 1,
                 "text-halo-blur": 1
-            },
-            "interactive": true
+            }
         },
         {
             "id": "road-shields-black",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444933575858.6992"
-            },
+            "metadata": {"mapbox:group": "1444933575858.6992"},
             "source": "composite",
             "source-layer": "road_label",
             "filter": [
@@ -9975,45 +4100,18 @@
                     "za-provincial",
                     "za-regional"
                 ],
-                [
-                    "<=",
-                    "reflen",
-                    6
-                ]
+                ["<=", "reflen", 6]
             ],
             "layout": {
                 "text-size": 9,
                 "icon-image": "{shield}-{reflen}",
                 "icon-rotation-alignment": "viewport",
                 "text-max-angle": 38,
-                "symbol-spacing": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            11,
-                            150
-                        ],
-                        [
-                            14,
-                            200
-                        ]
-                    ]
-                },
-                "text-font": [
-                    "DIN Offc Pro Bold,Arial Unicode MS Bold"
-                ],
+                "symbol-spacing": {"base": 1, "stops": [[11, 150], [14, 200]]},
+                "text-font": ["DIN Offc Pro Bold", "Arial Unicode MS Bold"],
                 "symbol-placement": {
                     "base": 1,
-                    "stops": [
-                        [
-                            10,
-                            "point"
-                        ],
-                        [
-                            11,
-                            "line"
-                        ]
-                    ]
+                    "stops": [[10, "point"], [11, "line"]]
                 },
                 "text-padding": 2,
                 "text-rotation-alignment": "viewport",
@@ -10029,24 +4127,17 @@
                 "icon-color": "white",
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 0
-            },
-            "interactive": true
+            }
         },
         {
             "id": "road-shields-white",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444933575858.6992"
-            },
+            "metadata": {"mapbox:group": "1444933575858.6992"},
             "source": "composite",
             "source-layer": "road_label",
             "filter": [
                 "all",
-                [
-                    "<=",
-                    "reflen",
-                    6
-                ],
+                ["<=", "reflen", 6],
                 [
                     "in",
                     "shield",
@@ -10097,34 +4188,11 @@
                 "icon-image": "{shield}-{reflen}",
                 "icon-rotation-alignment": "viewport",
                 "text-max-angle": 38,
-                "symbol-spacing": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            11,
-                            150
-                        ],
-                        [
-                            14,
-                            200
-                        ]
-                    ]
-                },
-                "text-font": [
-                    "DIN Offc Pro Bold,Arial Unicode MS Bold"
-                ],
+                "symbol-spacing": {"base": 1, "stops": [[11, 150], [14, 200]]},
+                "text-font": ["DIN Offc Pro Bold", "Arial Unicode MS Bold"],
                 "symbol-placement": {
                     "base": 1,
-                    "stops": [
-                        [
-                            10,
-                            "point"
-                        ],
-                        [
-                            11,
-                            "line"
-                        ]
-                    ]
+                    "stops": [[10, "point"], [11, "line"]]
                 },
                 "text-padding": 2,
                 "text-rotation-alignment": "viewport",
@@ -10140,54 +4208,31 @@
                 "icon-color": "white",
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 0
-            },
-            "interactive": true
+            }
         },
         {
             "id": "motorway-junction",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444933575858.6992"
-            },
+            "metadata": {"mapbox:group": "1444933575858.6992"},
             "source": "composite",
             "source-layer": "motorway_junction",
             "minzoom": 14,
-            "filter": [
-                "all",
-                [
-                    "<=",
-                    "reflen",
-                    9
-                ],
-                [
-                    ">",
-                    "reflen",
-                    0
-                ]
-            ],
+            "filter": ["all", ["<=", "reflen", 9], [">", "reflen", 0]],
             "layout": {
                 "text-field": "{ref}",
                 "text-size": 9,
                 "icon-image": "motorway-exit-{reflen}",
-                "text-font": [
-                    "DIN Offc Pro Bold,Arial Unicode MS Bold"
-                ]
+                "text-font": ["DIN Offc Pro Bold", "Arial Unicode MS Bold"]
             },
             "paint": {
                 "text-color": "hsl(0, 0%, 100%)",
-                "text-translate": [
-                    0,
-                    0
-                ]
-            },
-            "interactive": true
+                "text-translate": [0, 0]
+            }
         },
         {
             "id": "poi-scalerank2",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444933358918.2366"
-            },
+            "metadata": {"mapbox:group": "1444933358918.2366"},
             "source": "composite",
             "source-layer": "poi_label",
             "filter": [
@@ -10205,49 +4250,20 @@
                     "playground",
                     "zoo"
                 ],
-                [
-                    "==",
-                    "scalerank",
-                    2
-                ]
+                ["==", "scalerank", 2]
             ],
             "layout": {
                 "text-line-height": 1.1,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            14,
-                            11
-                        ],
-                        [
-                            20,
-                            14
-                        ]
-                    ]
-                },
-                "icon-image": {
-                    "stops": [
-                        [
-                            14,
-                            "{maki}-11"
-                        ],
-                        [
-                            15,
-                            "{maki}-15"
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[14, 11], [20, 14]]},
+                "icon-image": {"stops": [[14, "{maki}-11"], [15, "{maki}-15"]]},
                 "text-max-angle": 38,
                 "symbol-spacing": 250,
                 "text-font": [
-                    "DIN Offc Pro Medium,Arial Unicode MS Regular"
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
                 ],
                 "text-padding": 2,
-                "text-offset": [
-                    0,
-                    0.65
-                ],
+                "text-offset": [0, 0.65],
                 "text-rotation-alignment": "viewport",
                 "text-anchor": "top",
                 "text-field": "{name_en}",
@@ -10259,24 +4275,17 @@
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 0.5,
                 "text-halo-blur": 0.5
-            },
-            "interactive": true
+            }
         },
         {
             "id": "poi-parks-scalerank2",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444933358918.2366"
-            },
+            "metadata": {"mapbox:group": "1444933358918.2366"},
             "source": "composite",
             "source-layer": "poi_label",
             "filter": [
                 "all",
-                [
-                    "==",
-                    "scalerank",
-                    2
-                ],
+                ["==", "scalerank", 2],
                 [
                     "in",
                     "maki",
@@ -10293,41 +4302,16 @@
             ],
             "layout": {
                 "text-line-height": 1.1,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            14,
-                            11
-                        ],
-                        [
-                            20,
-                            14
-                        ]
-                    ]
-                },
-                "icon-image": {
-                    "stops": [
-                        [
-                            14,
-                            "{maki}-11"
-                        ],
-                        [
-                            15,
-                            "{maki}-15"
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[14, 11], [20, 14]]},
+                "icon-image": {"stops": [[14, "{maki}-11"], [15, "{maki}-15"]]},
                 "text-max-angle": 38,
                 "symbol-spacing": 250,
                 "text-font": [
-                    "DIN Offc Pro Medium,Arial Unicode MS Regular"
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
                 ],
                 "text-padding": 2,
-                "text-offset": [
-                    0,
-                    0.65
-                ],
+                "text-offset": [0, 0.65],
                 "text-rotation-alignment": "viewport",
                 "text-anchor": "top",
                 "text-field": "{name_en}",
@@ -10339,8 +4323,7 @@
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 0.5,
                 "text-halo-blur": 0.5
-            },
-            "interactive": true
+            }
         },
         {
             "id": "rail-label",
@@ -10348,49 +4331,22 @@
             "source": "composite",
             "source-layer": "rail_station_label",
             "minzoom": 12,
-            "filter": [
-                "!=",
-                "maki",
-                "entrance"
-            ],
+            "filter": ["!=", "maki", "entrance"],
             "layout": {
                 "text-line-height": 1.1,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            16,
-                            11
-                        ],
-                        [
-                            20,
-                            13
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[16, 11], [20, 13]]},
                 "icon-image": "{network}",
                 "symbol-spacing": 250,
                 "text-font": [
-                    "DIN Offc Pro Medium,Arial Unicode MS Regular"
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
                 ],
-                "text-offset": [
-                    0,
-                    0.85
-                ],
+                "text-offset": [0, 0.85],
                 "text-rotation-alignment": "viewport",
                 "text-anchor": "top",
                 "text-field": {
                     "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            ""
-                        ],
-                        [
-                            13,
-                            "{name_en}"
-                        ]
-                    ]
+                    "stops": [[0, ""], [13, "{name_en}"]]
                 },
                 "text-letter-spacing": 0.01,
                 "icon-padding": 0,
@@ -10402,100 +4358,47 @@
                 "text-halo-width": 0.5,
                 "icon-halo-width": 4,
                 "icon-halo-color": "#fff",
-                "text-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13.99,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                },
+                "text-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]},
                 "text-halo-blur": 0.5
-            },
-            "interactive": true
+            }
         },
         {
             "id": "water-label-sm",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444933808272.805"
-            },
+            "metadata": {"mapbox:group": "1444933808272.805"},
             "source": "composite",
             "source-layer": "water_label",
             "minzoom": 15,
-            "filter": [
-                "<=",
-                "area",
-                10000
-            ],
+            "filter": ["<=", "area", 10000],
             "layout": {
                 "text-field": "{name_en}",
                 "text-font": [
-                    "DIN Offc Pro Italic,Arial Unicode MS Regular"
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
                 ],
                 "text-max-width": 7,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            16,
-                            13
-                        ],
-                        [
-                            20,
-                            16
-                        ]
-                    ]
-                }
+                "text-size": {"base": 1, "stops": [[16, 13], [20, 16]]}
             },
-            "paint": {
-                "text-color": "hsl(230, 48%, 44%)"
-            },
-            "interactive": true
+            "paint": {"text-color": "hsl(230, 48%, 44%)"}
         },
         {
             "id": "water-label",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444933808272.805"
-            },
+            "metadata": {"mapbox:group": "1444933808272.805"},
             "source": "composite",
             "source-layer": "water_label",
             "minzoom": 5,
-            "filter": [
-                ">",
-                "area",
-                10000
-            ],
+            "filter": [">", "area", 10000],
             "layout": {
                 "text-field": "{name_en}",
                 "text-font": [
-                    "DIN Offc Pro Italic,Arial Unicode MS Regular"
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
                 ],
                 "text-max-width": 7,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            13,
-                            13
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
-                }
+                "text-size": {"base": 1, "stops": [[13, 13], [18, 18]]}
             },
-            "paint": {
-                "text-color": "hsl(230, 48%, 44%)"
-            },
-            "interactive": true
+            "paint": {"text-color": "hsl(230, 48%, 44%)"}
         },
         {
             "id": "place-residential",
@@ -10505,52 +4408,20 @@
             "maxzoom": 18,
             "filter": [
                 "all",
-                [
-                    "all",
-                    [
-                        "<=",
-                        "localrank",
-                        10
-                    ],
-                    [
-                        "==",
-                        "type",
-                        "residential"
-                    ]
-                ],
-                [
-                    "in",
-                    "$type",
-                    "LineString",
-                    "Point",
-                    "Polygon"
-                ]
+                ["all", ["<=", "localrank", 10], ["==", "type", "residential"]],
+                ["in", "$type", "LineString", "Point", "Polygon"]
             ],
             "layout": {
                 "text-line-height": 1.2,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10,
-                            11
-                        ],
-                        [
-                            18,
-                            14
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[10, 11], [18, 14]]},
                 "text-max-angle": 38,
                 "symbol-spacing": 250,
                 "text-font": [
-                    "DIN Offc Pro Regular,Arial Unicode MS Regular"
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
                 ],
                 "text-padding": 2,
-                "text-offset": [
-                    0,
-                    0
-                ],
+                "text-offset": [0, 0],
                 "text-rotation-alignment": "viewport",
                 "text-field": "{name_en}",
                 "text-max-width": 7
@@ -10560,24 +4431,17 @@
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 1,
                 "text-halo-blur": 0.5
-            },
-            "interactive": true
+            }
         },
         {
             "id": "poi-parks-scalerank1",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444933322393.2852"
-            },
+            "metadata": {"mapbox:group": "1444933322393.2852"},
             "source": "composite",
             "source-layer": "poi_label",
             "filter": [
                 "all",
-                [
-                    "<=",
-                    "scalerank",
-                    1
-                ],
+                ["<=", "scalerank", 1],
                 [
                     "in",
                     "maki",
@@ -10594,41 +4458,16 @@
             ],
             "layout": {
                 "text-line-height": 1.1,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10,
-                            11
-                        ],
-                        [
-                            18,
-                            14
-                        ]
-                    ]
-                },
-                "icon-image": {
-                    "stops": [
-                        [
-                            13,
-                            "{maki}-11"
-                        ],
-                        [
-                            14,
-                            "{maki}-15"
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[10, 11], [18, 14]]},
+                "icon-image": {"stops": [[13, "{maki}-11"], [14, "{maki}-15"]]},
                 "text-max-angle": 38,
                 "symbol-spacing": 250,
                 "text-font": [
-                    "DIN Offc Pro Medium,Arial Unicode MS Regular"
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
                 ],
                 "text-padding": 2,
-                "text-offset": [
-                    0,
-                    0.65
-                ],
+                "text-offset": [0, 0.65],
                 "text-rotation-alignment": "viewport",
                 "text-anchor": "top",
                 "text-field": "{name_en}",
@@ -10640,15 +4479,12 @@
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 0.5,
                 "text-halo-blur": 0.5
-            },
-            "interactive": true
+            }
         },
         {
             "id": "poi-scalerank1",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444933322393.2852"
-            },
+            "metadata": {"mapbox:group": "1444933322393.2852"},
             "source": "composite",
             "source-layer": "poi_label",
             "filter": [
@@ -10666,49 +4502,20 @@
                     "playground",
                     "zoo"
                 ],
-                [
-                    "<=",
-                    "scalerank",
-                    1
-                ]
+                ["<=", "scalerank", 1]
             ],
             "layout": {
                 "text-line-height": 1.1,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10,
-                            11
-                        ],
-                        [
-                            18,
-                            14
-                        ]
-                    ]
-                },
-                "icon-image": {
-                    "stops": [
-                        [
-                            13,
-                            "{maki}-11"
-                        ],
-                        [
-                            14,
-                            "{maki}-15"
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[10, 11], [18, 14]]},
+                "icon-image": {"stops": [[13, "{maki}-11"], [14, "{maki}-15"]]},
                 "text-max-angle": 38,
                 "symbol-spacing": 250,
                 "text-font": [
-                    "DIN Offc Pro Medium,Arial Unicode MS Regular"
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
                 ],
                 "text-padding": 2,
-                "text-offset": [
-                    0,
-                    0.65
-                ],
+                "text-offset": [0, 0.65],
                 "text-rotation-alignment": "viewport",
                 "text-anchor": "top",
                 "text-field": "{name_en}",
@@ -10720,8 +4527,7 @@
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 0.5,
                 "text-halo-blur": 0.5
-            },
-            "interactive": true
+            }
         },
         {
             "id": "airport-label",
@@ -10729,61 +4535,21 @@
             "source": "composite",
             "source-layer": "airport_label",
             "minzoom": 9,
-            "filter": [
-                "<=",
-                "scalerank",
-                2
-            ],
+            "filter": ["<=", "scalerank", 2],
             "layout": {
                 "text-line-height": 1.1,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10,
-                            12
-                        ],
-                        [
-                            18,
-                            18
-                        ]
-                    ]
-                },
-                "icon-image": {
-                    "stops": [
-                        [
-                            12,
-                            "{maki}-11"
-                        ],
-                        [
-                            13,
-                            "{maki}-15"
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[10, 12], [18, 18]]},
+                "icon-image": {"stops": [[12, "{maki}-11"], [13, "{maki}-15"]]},
                 "symbol-spacing": 250,
                 "text-font": [
-                    "DIN Offc Pro Medium,Arial Unicode MS Regular"
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
                 ],
                 "text-padding": 2,
-                "text-offset": [
-                    0,
-                    0.75
-                ],
+                "text-offset": [0, 0.75],
                 "text-rotation-alignment": "viewport",
                 "text-anchor": "top",
-                "text-field": {
-                    "stops": [
-                        [
-                            11,
-                            "{ref}"
-                        ],
-                        [
-                            12,
-                            "{name_en}"
-                        ]
-                    ]
-                },
+                "text-field": {"stops": [[11, "{ref}"], [12, "{name_en}"]]},
                 "text-letter-spacing": 0.01,
                 "text-max-width": 9
             },
@@ -10792,8 +4558,7 @@
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 0.5,
                 "text-halo-blur": 0.5
-            },
-            "interactive": true
+            }
         },
         {
             "id": "place-islet-archipelago-aboriginal",
@@ -10810,29 +4575,15 @@
             ],
             "layout": {
                 "text-line-height": 1.2,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10,
-                            11
-                        ],
-                        [
-                            18,
-                            16
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[10, 11], [18, 16]]},
                 "text-max-angle": 38,
                 "symbol-spacing": 250,
                 "text-font": [
-                    "DIN Offc Pro Regular,Arial Unicode MS Regular"
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
                 ],
                 "text-padding": 2,
-                "text-offset": [
-                    0,
-                    0
-                ],
+                "text-offset": [0, 0],
                 "text-rotation-alignment": "viewport",
                 "text-field": "{name_en}",
                 "text-letter-spacing": 0.01,
@@ -10842,8 +4593,7 @@
                 "text-color": "hsl(230, 29%, 35%)",
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 1
-            },
-            "interactive": true
+            }
         },
         {
             "id": "place-neighbourhood",
@@ -10852,41 +4602,25 @@
             "source-layer": "place_label",
             "minzoom": 10,
             "maxzoom": 16,
-            "filter": [
-                "==",
-                "type",
-                "neighbourhood"
-            ],
+            "filter": ["==", "type", "neighbourhood"],
             "layout": {
                 "text-field": "{name_en}",
                 "text-transform": "uppercase",
                 "text-letter-spacing": 0.1,
                 "text-max-width": 7,
                 "text-font": [
-                    "DIN Offc Pro Regular,Arial Unicode MS Regular"
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
                 ],
                 "text-padding": 3,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            12,
-                            11
-                        ],
-                        [
-                            16,
-                            16
-                        ]
-                    ]
-                }
+                "text-size": {"base": 1, "stops": [[12, 11], [16, 16]]}
             },
             "paint": {
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 1,
                 "text-color": "hsl(230, 29%, 35%)",
                 "text-halo-blur": 0.5
-            },
-            "interactive": true
+            }
         },
         {
             "id": "place-suburb",
@@ -10895,41 +4629,25 @@
             "source-layer": "place_label",
             "minzoom": 10,
             "maxzoom": 16,
-            "filter": [
-                "==",
-                "type",
-                "suburb"
-            ],
+            "filter": ["==", "type", "suburb"],
             "layout": {
                 "text-field": "{name_en}",
                 "text-transform": "uppercase",
                 "text-font": [
-                    "DIN Offc Pro Regular,Arial Unicode MS Regular"
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
                 ],
                 "text-letter-spacing": 0.15,
                 "text-max-width": 7,
                 "text-padding": 3,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            11,
-                            11
-                        ],
-                        [
-                            15,
-                            18
-                        ]
-                    ]
-                }
+                "text-size": {"base": 1, "stops": [[11, 11], [15, 18]]}
             },
             "paint": {
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 1,
                 "text-color": "hsl(230, 29%, 35%)",
                 "text-halo-blur": 0.5
-            },
-            "interactive": true
+            }
         },
         {
             "id": "place-hamlet",
@@ -10938,36 +4656,20 @@
             "source-layer": "place_label",
             "minzoom": 10,
             "maxzoom": 16,
-            "filter": [
-                "==",
-                "type",
-                "hamlet"
-            ],
+            "filter": ["==", "type", "hamlet"],
             "layout": {
                 "text-field": "{name_en}",
                 "text-font": [
-                    "DIN Offc Pro Regular,Arial Unicode MS Regular"
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
                 ],
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            12,
-                            11.5
-                        ],
-                        [
-                            15,
-                            16
-                        ]
-                    ]
-                }
+                "text-size": {"base": 1, "stops": [[12, 11.5], [15, 16]]}
             },
             "paint": {
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 1.25,
                 "text-color": "hsl(0, 0%, 0%)"
-            },
-            "interactive": true
+            }
         },
         {
             "id": "place-village",
@@ -10976,37 +4678,21 @@
             "source-layer": "place_label",
             "minzoom": 8,
             "maxzoom": 15,
-            "filter": [
-                "==",
-                "type",
-                "village"
-            ],
+            "filter": ["==", "type", "village"],
             "layout": {
                 "text-field": "{name_en}",
                 "text-font": [
-                    "DIN Offc Pro Regular,Arial Unicode MS Regular"
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
                 ],
                 "text-max-width": 7,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10,
-                            11.5
-                        ],
-                        [
-                            16,
-                            18
-                        ]
-                    ]
-                }
+                "text-size": {"base": 1, "stops": [[10, 11.5], [16, 18]]}
             },
             "paint": {
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 1.25,
                 "text-color": "hsl(0, 0%, 0%)"
-            },
-            "interactive": true
+            }
         },
         {
             "id": "place-town",
@@ -11015,11 +4701,7 @@
             "source-layer": "place_label",
             "minzoom": 6,
             "maxzoom": 15,
-            "filter": [
-                "==",
-                "type",
-                "town"
-            ],
+            "filter": ["==", "type", "town"],
             "layout": {
                 "icon-image": "dot-9",
                 "text-font": {
@@ -11027,85 +4709,32 @@
                     "stops": [
                         [
                             11,
-                            [
-                                "DIN Offc Pro Regular,Arial Unicode MS Regular"
-                            ]
+                            ["DIN Offc Pro Regular", "Arial Unicode MS Regular"]
                         ],
                         [
                             12,
-                            [
-                                "DIN Offc Pro Medium,Arial Unicode MS Regular"
-                            ]
+                            ["DIN Offc Pro Medium", "Arial Unicode MS Regular"]
                         ]
                     ]
                 },
                 "text-offset": {
                     "base": 1,
-                    "stops": [
-                        [
-                            7,
-                            [
-                                0,
-                                -0.15
-                            ]
-                        ],
-                        [
-                            8,
-                            [
-                                0,
-                                0
-                            ]
-                        ]
-                    ]
+                    "stops": [[7, [0, -0.15]], [8, [0, 0]]]
                 },
                 "text-anchor": {
                     "base": 1,
-                    "stops": [
-                        [
-                            7,
-                            "bottom"
-                        ],
-                        [
-                            8,
-                            "center"
-                        ]
-                    ]
+                    "stops": [[7, "bottom"], [8, "center"]]
                 },
                 "text-field": "{name_en}",
                 "text-max-width": 7,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            7,
-                            11.5
-                        ],
-                        [
-                            15,
-                            20
-                        ]
-                    ]
-                }
+                "text-size": {"base": 1, "stops": [[7, 11.5], [15, 20]]}
             },
             "paint": {
                 "text-color": "hsl(0, 0%, 0%)",
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 1.25,
-                "icon-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            7.99,
-                            1
-                        ],
-                        [
-                            8,
-                            0
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "icon-opacity": {"base": 1, "stops": [[7.99, 1], [8, 0]]}
+            }
         },
         {
             "id": "place-island",
@@ -11113,36 +4742,18 @@
             "source": "composite",
             "source-layer": "place_label",
             "maxzoom": 16,
-            "filter": [
-                "==",
-                "type",
-                "island"
-            ],
+            "filter": ["==", "type", "island"],
             "layout": {
                 "text-line-height": 1.2,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10,
-                            11
-                        ],
-                        [
-                            18,
-                            16
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[10, 11], [18, 16]]},
                 "text-max-angle": 38,
                 "symbol-spacing": 250,
                 "text-font": [
-                    "DIN Offc Pro Regular,Arial Unicode MS Regular"
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
                 ],
                 "text-padding": 2,
-                "text-offset": [
-                    0,
-                    0
-                ],
+                "text-offset": [0, 0],
                 "text-rotation-alignment": "viewport",
                 "text-field": "{name_en}",
                 "text-letter-spacing": 0.01,
@@ -11152,99 +4763,40 @@
                 "text-color": "hsl(230, 29%, 35%)",
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 1
-            },
-            "interactive": true
+            }
         },
         {
             "id": "place-city-sm",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444862510685.128"
-            },
+            "metadata": {"mapbox:group": "1444862510685.128"},
             "source": "composite",
             "source-layer": "place_label",
             "maxzoom": 14,
             "filter": [
                 "all",
-                [
-                    "!in",
-                    "scalerank",
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5
-                ],
-                [
-                    "==",
-                    "type",
-                    "city"
-                ]
+                ["!in", "scalerank", 0, 1, 2, 3, 4, 5],
+                ["==", "type", "city"]
             ],
             "layout": {
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            6,
-                            12
-                        ],
-                        [
-                            14,
-                            22
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[6, 12], [14, 22]]},
                 "icon-image": "dot-9",
                 "text-font": {
                     "base": 1,
                     "stops": [
                         [
                             7,
-                            [
-                                "DIN Offc Pro Regular,Arial Unicode MS Regular"
-                            ]
+                            ["DIN Offc Pro Regular", "Arial Unicode MS Regular"]
                         ],
-                        [
-                            8,
-                            [
-                                "DIN Offc Pro Medium,Arial Unicode MS Regular"
-                            ]
-                        ]
+                        [8, ["DIN Offc Pro Medium", "Arial Unicode MS Regular"]]
                     ]
                 },
                 "text-offset": {
                     "base": 1,
-                    "stops": [
-                        [
-                            7.99,
-                            [
-                                0,
-                                -0.2
-                            ]
-                        ],
-                        [
-                            8,
-                            [
-                                0,
-                                0
-                            ]
-                        ]
-                    ]
+                    "stops": [[7.99, [0, -0.2]], [8, [0, 0]]]
                 },
                 "text-anchor": {
                     "base": 1,
-                    "stops": [
-                        [
-                            7,
-                            "bottom"
-                        ],
-                        [
-                            8,
-                            "center"
-                        ]
-                    ]
+                    "stops": [[7, "bottom"], [8, "center"]]
                 },
                 "text-field": "{name_en}",
                 "text-max-width": 7
@@ -11253,172 +4805,65 @@
                 "text-color": "hsl(0, 0%, 0%)",
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 1.25,
-                "icon-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            7.99,
-                            1
-                        ],
-                        [
-                            8,
-                            0
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "icon-opacity": {"base": 1, "stops": [[7.99, 1], [8, 0]]}
+            }
         },
         {
             "id": "place-city-md-s",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444862510685.128"
-            },
+            "metadata": {"mapbox:group": "1444862510685.128"},
             "source": "composite",
             "source-layer": "place_label",
             "maxzoom": 14,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "type",
-                    "city"
-                ],
-                [
-                    "in",
-                    "ldir",
-                    "E",
-                    "S",
-                    "SE",
-                    "SW"
-                ],
-                [
-                    "in",
-                    "scalerank",
-                    3,
-                    4,
-                    5
-                ]
+                ["==", "type", "city"],
+                ["in", "ldir", "E", "S", "SE", "SW"],
+                ["in", "scalerank", 3, 4, 5]
             ],
             "layout": {
                 "text-field": "{name_en}",
                 "icon-image": "dot-10",
                 "text-anchor": {
                     "base": 1,
-                    "stops": [
-                        [
-                            7,
-                            "top"
-                        ],
-                        [
-                            8,
-                            "center"
-                        ]
-                    ]
+                    "stops": [[7, "top"], [8, "center"]]
                 },
                 "text-offset": {
                     "base": 1,
-                    "stops": [
-                        [
-                            7.99,
-                            [
-                                0,
-                                0.1
-                            ]
-                        ],
-                        [
-                            8,
-                            [
-                                0,
-                                0
-                            ]
-                        ]
-                    ]
+                    "stops": [[7.99, [0, 0.1]], [8, [0, 0]]]
                 },
                 "text-font": {
                     "base": 1,
                     "stops": [
                         [
                             7,
-                            [
-                                "DIN Offc Pro Regular,Arial Unicode MS Regular"
-                            ]
+                            ["DIN Offc Pro Regular", "Arial Unicode MS Regular"]
                         ],
-                        [
-                            8,
-                            [
-                                "DIN Offc Pro Medium,Arial Unicode MS Regular"
-                            ]
-                        ]
+                        [8, ["DIN Offc Pro Medium", "Arial Unicode MS Regular"]]
                     ]
                 },
-                "text-size": {
-                    "base": 0.9,
-                    "stops": [
-                        [
-                            5,
-                            12
-                        ],
-                        [
-                            12,
-                            22
-                        ]
-                    ]
-                }
+                "text-size": {"base": 0.9, "stops": [[5, 12], [12, 22]]}
             },
             "paint": {
                 "text-halo-width": 1,
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-color": "hsl(0, 0%, 0%)",
                 "text-halo-blur": 1,
-                "icon-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            7.99,
-                            1
-                        ],
-                        [
-                            8,
-                            0
-                        ]
-                    ]
-                }
-            },
-            "interactive": true
+                "icon-opacity": {"base": 1, "stops": [[7.99, 1], [8, 0]]}
+            }
         },
         {
             "id": "place-city-md-n",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444862510685.128"
-            },
+            "metadata": {"mapbox:group": "1444862510685.128"},
             "source": "composite",
             "source-layer": "place_label",
             "maxzoom": 14,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "type",
-                    "city"
-                ],
-                [
-                    "in",
-                    "ldir",
-                    "N",
-                    "NE",
-                    "NW",
-                    "W"
-                ],
-                [
-                    "in",
-                    "scalerank",
-                    3,
-                    4,
-                    5
-                ]
+                ["==", "type", "city"],
+                ["in", "ldir", "N", "NE", "NW", "W"],
+                ["in", "scalerank", 3, 4, 5]
             ],
             "layout": {
                 "icon-image": "dot-10",
@@ -11427,117 +4872,44 @@
                     "stops": [
                         [
                             7,
-                            [
-                                "DIN Offc Pro Regular,Arial Unicode MS Regular"
-                            ]
+                            ["DIN Offc Pro Regular", "Arial Unicode MS Regular"]
                         ],
-                        [
-                            8,
-                            [
-                                "DIN Offc Pro Medium,Arial Unicode MS Regular"
-                            ]
-                        ]
+                        [8, ["DIN Offc Pro Medium", "Arial Unicode MS Regular"]]
                     ]
                 },
                 "text-offset": {
                     "base": 1,
-                    "stops": [
-                        [
-                            7.99,
-                            [
-                                0,
-                                -0.25
-                            ]
-                        ],
-                        [
-                            8,
-                            [
-                                0,
-                                0
-                            ]
-                        ]
-                    ]
+                    "stops": [[7.99, [0, -0.25]], [8, [0, 0]]]
                 },
                 "text-anchor": {
                     "base": 1,
-                    "stops": [
-                        [
-                            7,
-                            "bottom"
-                        ],
-                        [
-                            8,
-                            "center"
-                        ]
-                    ]
+                    "stops": [[7, "bottom"], [8, "center"]]
                 },
                 "text-field": "{name_en}",
                 "text-max-width": 7,
-                "text-size": {
-                    "base": 0.9,
-                    "stops": [
-                        [
-                            5,
-                            12
-                        ],
-                        [
-                            12,
-                            22
-                        ]
-                    ]
-                }
+                "text-size": {"base": 0.9, "stops": [[5, 12], [12, 22]]}
             },
             "paint": {
                 "text-color": "hsl(0, 0%, 0%)",
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 1,
-                "icon-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            7.99,
-                            1
-                        ],
-                        [
-                            8,
-                            0
-                        ]
-                    ]
-                },
+                "icon-opacity": {"base": 1, "stops": [[7.99, 1], [8, 0]]},
                 "text-halo-blur": 1
-            },
-            "interactive": true
+            }
         },
         {
             "id": "place-city-lg-s",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444862510685.128"
-            },
+            "metadata": {"mapbox:group": "1444862510685.128"},
             "source": "composite",
             "source-layer": "place_label",
             "minzoom": 1,
             "maxzoom": 14,
             "filter": [
                 "all",
-                [
-                    "<=",
-                    "scalerank",
-                    2
-                ],
-                [
-                    "==",
-                    "type",
-                    "city"
-                ],
-                [
-                    "in",
-                    "ldir",
-                    "E",
-                    "S",
-                    "SE",
-                    "SW"
-                ]
+                ["<=", "scalerank", 2],
+                ["==", "type", "city"],
+                ["in", "ldir", "E", "S", "SE", "SW"]
             ],
             "layout": {
                 "icon-image": "dot-11",
@@ -11546,117 +4918,44 @@
                     "stops": [
                         [
                             7,
-                            [
-                                "DIN Offc Pro Regular,Arial Unicode MS Regular"
-                            ]
+                            ["DIN Offc Pro Regular", "Arial Unicode MS Regular"]
                         ],
-                        [
-                            8,
-                            [
-                                "DIN Offc Pro Medium,Arial Unicode MS Regular"
-                            ]
-                        ]
+                        [8, ["DIN Offc Pro Medium", "Arial Unicode MS Regular"]]
                     ]
                 },
                 "text-offset": {
                     "base": 1,
-                    "stops": [
-                        [
-                            7.99,
-                            [
-                                0,
-                                0.15
-                            ]
-                        ],
-                        [
-                            8,
-                            [
-                                0,
-                                0
-                            ]
-                        ]
-                    ]
+                    "stops": [[7.99, [0, 0.15]], [8, [0, 0]]]
                 },
                 "text-anchor": {
                     "base": 1,
-                    "stops": [
-                        [
-                            7,
-                            "top"
-                        ],
-                        [
-                            8,
-                            "center"
-                        ]
-                    ]
+                    "stops": [[7, "top"], [8, "center"]]
                 },
                 "text-field": "{name_en}",
                 "text-max-width": 7,
-                "text-size": {
-                    "base": 0.9,
-                    "stops": [
-                        [
-                            4,
-                            12
-                        ],
-                        [
-                            10,
-                            22
-                        ]
-                    ]
-                }
+                "text-size": {"base": 0.9, "stops": [[4, 12], [10, 22]]}
             },
             "paint": {
                 "text-color": "hsl(0, 0%, 0%)",
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 1,
-                "icon-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            7.99,
-                            1
-                        ],
-                        [
-                            8,
-                            0
-                        ]
-                    ]
-                },
+                "icon-opacity": {"base": 1, "stops": [[7.99, 1], [8, 0]]},
                 "text-halo-blur": 1
-            },
-            "interactive": true
+            }
         },
         {
             "id": "place-city-lg-n",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444862510685.128"
-            },
+            "metadata": {"mapbox:group": "1444862510685.128"},
             "source": "composite",
             "source-layer": "place_label",
             "minzoom": 1,
             "maxzoom": 14,
             "filter": [
                 "all",
-                [
-                    "<=",
-                    "scalerank",
-                    2
-                ],
-                [
-                    "==",
-                    "type",
-                    "city"
-                ],
-                [
-                    "in",
-                    "ldir",
-                    "N",
-                    "NE",
-                    "NW",
-                    "W"
-                ]
+                ["<=", "scalerank", 2],
+                ["==", "type", "city"],
+                ["in", "ldir", "N", "NE", "NW", "W"]
             ],
             "layout": {
                 "icon-image": "dot-11",
@@ -11665,141 +4964,52 @@
                     "stops": [
                         [
                             7,
-                            [
-                                "DIN Offc Pro Regular,Arial Unicode MS Regular"
-                            ]
+                            ["DIN Offc Pro Regular", "Arial Unicode MS Regular"]
                         ],
-                        [
-                            8,
-                            [
-                                "DIN Offc Pro Medium,Arial Unicode MS Regular"
-                            ]
-                        ]
+                        [8, ["DIN Offc Pro Medium", "Arial Unicode MS Regular"]]
                     ]
                 },
                 "text-offset": {
                     "base": 1,
-                    "stops": [
-                        [
-                            7.99,
-                            [
-                                0,
-                                -0.25
-                            ]
-                        ],
-                        [
-                            8,
-                            [
-                                0,
-                                0
-                            ]
-                        ]
-                    ]
+                    "stops": [[7.99, [0, -0.25]], [8, [0, 0]]]
                 },
                 "text-anchor": {
                     "base": 1,
-                    "stops": [
-                        [
-                            7,
-                            "bottom"
-                        ],
-                        [
-                            8,
-                            "center"
-                        ]
-                    ]
+                    "stops": [[7, "bottom"], [8, "center"]]
                 },
                 "text-field": "{name_en}",
                 "text-max-width": 7,
-                "text-size": {
-                    "base": 0.9,
-                    "stops": [
-                        [
-                            4,
-                            12
-                        ],
-                        [
-                            10,
-                            22
-                        ]
-                    ]
-                }
+                "text-size": {"base": 0.9, "stops": [[4, 12], [10, 22]]}
             },
             "paint": {
                 "text-color": "hsl(0, 0%, 0%)",
                 "text-opacity": 1,
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 1,
-                "icon-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            7.99,
-                            1
-                        ],
-                        [
-                            8,
-                            0
-                        ]
-                    ]
-                },
+                "icon-opacity": {"base": 1, "stops": [[7.99, 1], [8, 0]]},
                 "text-halo-blur": 1
-            },
-            "interactive": true
+            }
         },
         {
             "id": "marine-label-sm-ln",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444856087950.3635"
-            },
+            "metadata": {"mapbox:group": "1444856087950.3635"},
             "source": "composite",
             "source-layer": "marine_label",
             "minzoom": 3,
             "maxzoom": 10,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    ">=",
-                    "labelrank",
-                    4
-                ]
+                ["==", "$type", "LineString"],
+                [">=", "labelrank", 4]
             ],
             "layout": {
                 "text-line-height": 1.1,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            3,
-                            12
-                        ],
-                        [
-                            6,
-                            16
-                        ]
-                    ]
-                },
-                "symbol-spacing": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            4,
-                            100
-                        ],
-                        [
-                            6,
-                            400
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[3, 12], [6, 16]]},
+                "symbol-spacing": {"base": 1, "stops": [[4, 100], [6, 400]]},
                 "text-font": [
-                    "DIN Offc Pro Italic,Arial Unicode MS Regular"
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
                 ],
                 "symbol-placement": "line",
                 "text-pitch-alignment": "viewport",
@@ -11807,103 +5017,50 @@
                 "text-letter-spacing": 0.1,
                 "text-max-width": 5
             },
-            "paint": {
-                "text-color": "hsl(205, 83%, 88%)"
-            },
-            "interactive": true
+            "paint": {"text-color": "hsl(205, 83%, 88%)"}
         },
         {
             "id": "marine-label-sm-pt",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444856087950.3635"
-            },
+            "metadata": {"mapbox:group": "1444856087950.3635"},
             "source": "composite",
             "source-layer": "marine_label",
             "minzoom": 3,
             "maxzoom": 10,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "$type",
-                    "Point"
-                ],
-                [
-                    ">=",
-                    "labelrank",
-                    4
-                ]
-            ],
+            "filter": ["all", ["==", "$type", "Point"], [">=", "labelrank", 4]],
             "layout": {
                 "text-field": "{name_en}",
                 "text-max-width": 5,
                 "text-letter-spacing": 0.1,
                 "text-line-height": 1.5,
                 "text-font": [
-                    "DIN Offc Pro Italic,Arial Unicode MS Regular"
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
                 ],
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            3,
-                            12
-                        ],
-                        [
-                            6,
-                            16
-                        ]
-                    ]
-                }
+                "text-size": {"base": 1, "stops": [[3, 12], [6, 16]]}
             },
-            "paint": {
-                "text-color": "hsl(205, 83%, 88%)"
-            },
-            "interactive": true
+            "paint": {"text-color": "hsl(205, 83%, 88%)"}
         },
         {
             "id": "marine-label-md-ln",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444856087950.3635"
-            },
+            "metadata": {"mapbox:group": "1444856087950.3635"},
             "source": "composite",
             "source-layer": "marine_label",
             "minzoom": 2,
             "maxzoom": 8,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "in",
-                    "labelrank",
-                    2,
-                    3
-                ]
+                ["==", "$type", "LineString"],
+                ["in", "labelrank", 2, 3]
             ],
             "layout": {
                 "text-line-height": 1.1,
-                "text-size": {
-                    "base": 1.1,
-                    "stops": [
-                        [
-                            2,
-                            12
-                        ],
-                        [
-                            5,
-                            20
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1.1, "stops": [[2, 12], [5, 20]]},
                 "symbol-spacing": 250,
                 "text-font": [
-                    "DIN Offc Pro Italic,Arial Unicode MS Regular"
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
                 ],
                 "symbol-placement": "line",
                 "text-pitch-alignment": "viewport",
@@ -11911,34 +5068,20 @@
                 "text-letter-spacing": 0.15,
                 "text-max-width": 5
             },
-            "paint": {
-                "text-color": "hsl(205, 83%, 88%)"
-            },
-            "interactive": true
+            "paint": {"text-color": "hsl(205, 83%, 88%)"}
         },
         {
             "id": "marine-label-md-pt",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444856087950.3635"
-            },
+            "metadata": {"mapbox:group": "1444856087950.3635"},
             "source": "composite",
             "source-layer": "marine_label",
             "minzoom": 2,
             "maxzoom": 8,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "Point"
-                ],
-                [
-                    "in",
-                    "labelrank",
-                    2,
-                    3
-                ]
+                ["==", "$type", "Point"],
+                ["in", "labelrank", 2, 3]
             ],
             "layout": {
                 "text-field": "{name_en}",
@@ -11946,49 +5089,25 @@
                 "text-letter-spacing": 0.15,
                 "text-line-height": 1.5,
                 "text-font": [
-                    "DIN Offc Pro Italic,Arial Unicode MS Regular"
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
                 ],
-                "text-size": {
-                    "base": 1.1,
-                    "stops": [
-                        [
-                            2,
-                            14
-                        ],
-                        [
-                            5,
-                            20
-                        ]
-                    ]
-                }
+                "text-size": {"base": 1.1, "stops": [[2, 14], [5, 20]]}
             },
-            "paint": {
-                "text-color": "hsl(205, 83%, 88%)"
-            },
-            "interactive": true
+            "paint": {"text-color": "hsl(205, 83%, 88%)"}
         },
         {
             "id": "marine-label-lg-ln",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444856087950.3635"
-            },
+            "metadata": {"mapbox:group": "1444856087950.3635"},
             "source": "composite",
             "source-layer": "marine_label",
             "minzoom": 1,
             "maxzoom": 4,
             "filter": [
                 "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "==",
-                    "labelrank",
-                    1
-                ]
+                ["==", "$type", "LineString"],
+                ["==", "labelrank", 1]
             ],
             "layout": {
                 "text-field": "{name_en}",
@@ -11998,122 +5117,51 @@
                 "symbol-placement": "line",
                 "text-pitch-alignment": "viewport",
                 "text-font": [
-                    "DIN Offc Pro Italic,Arial Unicode MS Regular"
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
                 ],
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            1,
-                            14
-                        ],
-                        [
-                            4,
-                            30
-                        ]
-                    ]
-                }
+                "text-size": {"base": 1, "stops": [[1, 14], [4, 30]]}
             },
-            "paint": {
-                "text-color": "hsl(205, 83%, 88%)"
-            },
-            "interactive": true
+            "paint": {"text-color": "hsl(205, 83%, 88%)"}
         },
         {
             "id": "marine-label-lg-pt",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444856087950.3635"
-            },
+            "metadata": {"mapbox:group": "1444856087950.3635"},
             "source": "composite",
             "source-layer": "marine_label",
             "minzoom": 1,
             "maxzoom": 4,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "$type",
-                    "Point"
-                ],
-                [
-                    "==",
-                    "labelrank",
-                    1
-                ]
-            ],
+            "filter": ["all", ["==", "$type", "Point"], ["==", "labelrank", 1]],
             "layout": {
                 "text-field": "{name_en}",
                 "text-max-width": 4,
                 "text-letter-spacing": 0.25,
                 "text-line-height": 1.5,
                 "text-font": [
-                    "DIN Offc Pro Italic,Arial Unicode MS Regular"
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
                 ],
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            1,
-                            14
-                        ],
-                        [
-                            4,
-                            30
-                        ]
-                    ]
-                }
+                "text-size": {"base": 1, "stops": [[1, 14], [4, 30]]}
             },
-            "paint": {
-                "text-color": "hsl(205, 83%, 88%)"
-            },
-            "interactive": true
+            "paint": {"text-color": "hsl(205, 83%, 88%)"}
         },
         {
             "id": "state-label-sm",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444856151690.9143"
-            },
+            "metadata": {"mapbox:group": "1444856151690.9143"},
             "source": "composite",
             "source-layer": "state_label",
             "minzoom": 3,
             "maxzoom": 9,
-            "filter": [
-                "<",
-                "area",
-                20000
-            ],
+            "filter": ["<", "area", 20000],
             "layout": {
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            6,
-                            10
-                        ],
-                        [
-                            9,
-                            14
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[6, 10], [9, 14]]},
                 "text-transform": "uppercase",
-                "text-font": [
-                    "DIN Offc Pro Bold,Arial Unicode MS Bold"
-                ],
+                "text-font": ["DIN Offc Pro Bold", "Arial Unicode MS Bold"],
                 "text-field": {
                     "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            "{abbr}"
-                        ],
-                        [
-                            6,
-                            "{name_en}"
-                        ]
-                    ]
+                    "stops": [[0, "{abbr}"], [6, "{name_en}"]]
                 },
                 "text-letter-spacing": 0.15,
                 "text-max-width": 5
@@ -12123,62 +5171,24 @@
                 "text-color": "hsl(0, 0%, 0%)",
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 1
-            },
-            "interactive": true
+            }
         },
         {
             "id": "state-label-md",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444856151690.9143"
-            },
+            "metadata": {"mapbox:group": "1444856151690.9143"},
             "source": "composite",
             "source-layer": "state_label",
             "minzoom": 3,
             "maxzoom": 8,
-            "filter": [
-                "all",
-                [
-                    "<",
-                    "area",
-                    80000
-                ],
-                [
-                    ">=",
-                    "area",
-                    20000
-                ]
-            ],
+            "filter": ["all", ["<", "area", 80000], [">=", "area", 20000]],
             "layout": {
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            5,
-                            10
-                        ],
-                        [
-                            8,
-                            16
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[5, 10], [8, 16]]},
                 "text-transform": "uppercase",
-                "text-font": [
-                    "DIN Offc Pro Bold,Arial Unicode MS Bold"
-                ],
+                "text-font": ["DIN Offc Pro Bold", "Arial Unicode MS Bold"],
                 "text-field": {
                     "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            "{abbr}"
-                        ],
-                        [
-                            5,
-                            "{name_en}"
-                        ]
-                    ]
+                    "stops": [[0, "{abbr}"], [5, "{name_en}"]]
                 },
                 "text-letter-spacing": 0.15,
                 "text-max-width": 6
@@ -12188,55 +5198,25 @@
                 "text-color": "hsl(0, 0%, 0%)",
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 1
-            },
-            "interactive": true
+            }
         },
         {
             "id": "state-label-lg",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444856151690.9143"
-            },
+            "metadata": {"mapbox:group": "1444856151690.9143"},
             "source": "composite",
             "source-layer": "state_label",
             "minzoom": 3,
             "maxzoom": 7,
-            "filter": [
-                ">=",
-                "area",
-                80000
-            ],
+            "filter": [">=", "area", 80000],
             "layout": {
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            4,
-                            10
-                        ],
-                        [
-                            7,
-                            18
-                        ]
-                    ]
-                },
+                "text-size": {"base": 1, "stops": [[4, 10], [7, 18]]},
                 "text-transform": "uppercase",
-                "text-font": [
-                    "DIN Offc Pro Bold,Arial Unicode MS Bold"
-                ],
+                "text-font": ["DIN Offc Pro Bold", "Arial Unicode MS Bold"],
                 "text-padding": 1,
                 "text-field": {
                     "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            "{abbr}"
-                        ],
-                        [
-                            4,
-                            "{name_en}"
-                        ]
-                    ]
+                    "stops": [[0, "{abbr}"], [4, "{name_en}"]]
                 },
                 "text-letter-spacing": 0.15,
                 "text-max-width": 6
@@ -12246,202 +5226,106 @@
                 "text-color": "hsl(0, 0%, 0%)",
                 "text-halo-color": "hsl(0, 0%, 100%)",
                 "text-halo-width": 1
-            },
-            "interactive": true
+            }
         },
         {
             "id": "country-label-sm",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444856144497.7825"
-            },
+            "metadata": {"mapbox:group": "1444856144497.7825"},
             "source": "composite",
             "source-layer": "country_label",
             "minzoom": 1,
             "maxzoom": 10,
-            "filter": [
-                ">=",
-                "scalerank",
-                5
-            ],
+            "filter": [">=", "scalerank", 5],
             "layout": {
                 "text-field": "{name_en}",
                 "text-max-width": 6,
                 "text-font": [
-                    "DIN Offc Pro Medium,Arial Unicode MS Regular"
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
                 ],
-                "text-size": {
-                    "base": 0.9,
-                    "stops": [
-                        [
-                            5,
-                            14
-                        ],
-                        [
-                            9,
-                            22
-                        ]
-                    ]
-                }
+                "text-size": {"base": 0.9, "stops": [[5, 14], [9, 22]]}
             },
             "paint": {
                 "text-color": "hsl(0, 0%, 0%)",
                 "text-halo-color": {
                     "base": 1,
                     "stops": [
-                        [
-                            2,
-                            "rgba(255,255,255,0.75)"
-                        ],
-                        [
-                            3,
-                            "hsl(0, 0%, 100%)"
-                        ]
+                        [2, "rgba(255,255,255,0.75)"],
+                        [3, "hsl(0, 0%, 100%)"]
                     ]
                 },
                 "text-halo-width": 1.25
-            },
-            "interactive": true
+            }
         },
         {
             "id": "country-label-md",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444856144497.7825"
-            },
+            "metadata": {"mapbox:group": "1444856144497.7825"},
             "source": "composite",
             "source-layer": "country_label",
             "minzoom": 1,
             "maxzoom": 8,
-            "filter": [
-                "in",
-                "scalerank",
-                3,
-                4
-            ],
+            "filter": ["in", "scalerank", 3, 4],
             "layout": {
                 "text-field": {
                     "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            "{code}"
-                        ],
-                        [
-                            2,
-                            "{name_en}"
-                        ]
-                    ]
+                    "stops": [[0, "{code}"], [2, "{name_en}"]]
                 },
                 "text-max-width": 6,
                 "text-font": [
-                    "DIN Offc Pro Medium,Arial Unicode MS Regular"
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
                 ],
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            3,
-                            10
-                        ],
-                        [
-                            8,
-                            24
-                        ]
-                    ]
-                }
+                "text-size": {"base": 1, "stops": [[3, 10], [8, 24]]}
             },
             "paint": {
                 "text-color": "hsl(0, 0%, 0%)",
                 "text-halo-color": {
                     "base": 1,
                     "stops": [
-                        [
-                            2,
-                            "rgba(255,255,255,0.75)"
-                        ],
-                        [
-                            3,
-                            "hsl(0, 0%, 100%)"
-                        ]
+                        [2, "rgba(255,255,255,0.75)"],
+                        [3, "hsl(0, 0%, 100%)"]
                     ]
                 },
                 "text-halo-width": 1.25
-            },
-            "interactive": true
+            }
         },
         {
             "id": "country-label-lg",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444856144497.7825"
-            },
+            "metadata": {"mapbox:group": "1444856144497.7825"},
             "source": "composite",
             "source-layer": "country_label",
             "minzoom": 1,
             "maxzoom": 7,
-            "filter": [
-                "in",
-                "scalerank",
-                1,
-                2
-            ],
+            "filter": ["in", "scalerank", 1, 2],
             "layout": {
                 "text-field": "{name_en}",
-                "text-max-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            5
-                        ],
-                        [
-                            3,
-                            6
-                        ]
-                    ]
-                },
+                "text-max-width": {"base": 1, "stops": [[0, 5], [3, 6]]},
                 "text-font": [
-                    "DIN Offc Pro Medium,Arial Unicode MS Regular"
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
                 ],
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            1,
-                            10
-                        ],
-                        [
-                            6,
-                            24
-                        ]
-                    ]
-                }
+                "text-size": {"base": 1, "stops": [[1, 10], [6, 24]]}
             },
             "paint": {
                 "text-color": "hsl(0, 0%, 0%)",
                 "text-halo-color": {
                     "base": 1,
                     "stops": [
-                        [
-                            2,
-                            "rgba(255,255,255,0.75)"
-                        ],
-                        [
-                            3,
-                            "hsl(0, 0%, 100%)"
-                        ]
+                        [2, "rgba(255,255,255,0.75)"],
+                        [3, "hsl(0, 0%, 100%)"]
                     ]
                 },
                 "text-halo-width": 1.25
-            },
-            "interactive": true
+            }
         }
     ],
-    "created": "2018-08-16T10:31:44.982Z",
-    "id": "cjkwfdgzn1fz42rqtvsk6rrmd",
-    "modified": "2018-08-16T10:31:44.982Z",
+    "created": "2018-10-22T14:13:43.210Z",
+    "id": "cjnkdt02b0b2p2ss40skwpvs1",
+    "modified": "2018-10-22T14:14:35.211Z",
     "owner": "lukaspaczos",
-    "visibility": "private",
+    "visibility": "public",
     "draft": false
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/SymbolLayerActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/SymbolLayerActivity.java
@@ -10,6 +10,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.ViewGroup;
+
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.mapbox.geojson.Feature;
@@ -29,6 +30,11 @@ import com.mapbox.mapboxsdk.utils.BitmapUtils;
 
 import java.util.List;
 
+import static com.mapbox.mapboxsdk.style.expressions.Expression.FormatOption.formatFontScale;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.FormatOption.formatTextFont;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.concat;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.format;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.formatEntry;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.literal;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.switchCase;
@@ -118,7 +124,16 @@ public class SymbolLayerActivity extends AppCompatActivity implements MapboxMap.
           iconSize(switchCase(toBool(get(SELECTED_FEATURE_PROPERTY)), literal(3.0f), literal(1.0f))),
           iconAnchor(Property.ICON_ANCHOR_BOTTOM),
           iconColor(Color.RED),
-          textField(get(TITLE_FEATURE_PROPERTY)),
+          textField(
+            format(
+              formatEntry("this is", formatFontScale(0.75)),
+              formatEntry(
+                concat(literal("\n"), get(TITLE_FEATURE_PROPERTY)),
+                formatFontScale(1.25),
+                formatTextFont(new String[] {"DIN Offc Pro Bold", "Arial Unicode MS Regular"})
+              )
+            )
+          ),
           textFont(new String[] {"DIN Offc Pro Regular", "Arial Unicode MS Regular"}),
           textColor(Color.RED),
           textAllowOverlap(true),

--- a/platform/android/core-files.txt
+++ b/platform/android/core-files.txt
@@ -125,6 +125,10 @@ platform/android/src/style/position.cpp
 platform/android/src/style/position.hpp
 platform/android/src/style/light.cpp
 platform/android/src/style/light.hpp
+platform/android/src/style/formatted.cpp
+platform/android/src/style/formatted.hpp
+platform/android/src/style/formatted_section.cpp
+platform/android/src/style/formatted_section.hpp
 
 # Native map
 platform/android/src/native_map_view.cpp

--- a/platform/android/src/conversion/constant.cpp
+++ b/platform/android/src/conversion/constant.cpp
@@ -1,5 +1,6 @@
 #include "constant.hpp"
 #include "collection.hpp"
+#include "../style/formatted.hpp"
 
 #include <mbgl/util/string.hpp>
 
@@ -39,7 +40,7 @@ Result<jni::Local<jni::Object<>>> Converter<jni::Local<jni::Object<>>, Color>::o
 }
 
 Result<jni::Local<jni::Object<>>> Converter<jni::Local<jni::Object<>>, style::expression::Formatted>::operator()(jni::JNIEnv& env, const style::expression::Formatted& value) const {
-    return jni::Make<jni::String>(env, value.toString());
+    return Formatted::New(env, value);
 }
 
 Result<jni::Local<jni::Object<>>> Converter<jni::Local<jni::Object<>>, std::vector<std::string>>::operator()(jni::JNIEnv& env, const std::vector<std::string>& value) const {

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -1,6 +1,8 @@
 #include "jni.hpp"
 
 #include <mbgl/util/logging.hpp>
+#include <src/style/formatted.hpp>
+#include <src/style/formatted_section.hpp>
 
 #include "annotation/marker.hpp"
 #include "annotation/polygon.hpp"
@@ -162,6 +164,8 @@ void registerNatives(JavaVM *vm) {
     Source::registerNative(env);
     Light::registerNative(env);
     Position::registerNative(env);
+    Formatted::registerNative(env);
+    FormattedSection::registerNative(env);
 
     // Map
     CameraPosition::registerNative(env);

--- a/platform/android/src/style/formatted.cpp
+++ b/platform/android/src/style/formatted.cpp
@@ -1,0 +1,43 @@
+#include "formatted.hpp"
+#include "formatted_section.hpp"
+
+namespace mbgl {
+namespace android {
+
+void Formatted::registerNative(jni::JNIEnv& env) {
+    jni::Class<Formatted>::Singleton(env);
+}
+
+jni::Local<jni::Object<Formatted>> Formatted::New(jni::JNIEnv& env, const style::expression::Formatted& value) {
+    static auto& formatted = jni::Class<Formatted>::Singleton(env);
+    static auto formattedConstructor = formatted.GetConstructor<jni::Array<jni::Object<FormattedSection>>>(env);
+    static auto& formattedSection = jni::Class<FormattedSection>::Singleton(env);
+
+    auto sections = jni::Array<jni::Object<FormattedSection>>::New(env, value.sections.size());
+    for (std::size_t i = 0; i < value.sections.size(); i++) {
+        auto section = value.sections.at(i);
+        auto text = jni::Make<jni::String>(env, section.text);
+
+        double fontScale = 1.0;
+        if (section.fontScale) {
+            fontScale = section.fontScale.value();
+        }
+
+        if (section.fontStack) {
+            auto fontStack = jni::Array<jni::String>::New(env, section.fontStack.value().size());
+            for (std::size_t j = 0; j < section.fontStack.value().size(); j++) {
+                fontStack.Set(env, j, jni::Make<jni::String>(env, section.fontStack.value().at(j)));
+            }
+            static auto formattedSectionConstructor = formattedSection.GetConstructor<jni::String, double, jni::Array<jni::String>>(env);
+            sections.Set(env, i, formattedSection.New(env, formattedSectionConstructor, text, fontScale, fontStack));
+        } else {
+            static auto formattedSectionConstructor = formattedSection.GetConstructor<jni::String, double>(env);
+            sections.Set(env, i, formattedSection.New(env, formattedSectionConstructor, text, fontScale));
+        }
+    }
+
+    return formatted.New(env, formattedConstructor, sections);
+}
+
+} // namespace android
+} // namespace mbgl

--- a/platform/android/src/style/formatted.hpp
+++ b/platform/android/src/style/formatted.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <mbgl/util/noncopyable.hpp>
+
+#include <jni/jni.hpp>
+#include <mbgl/style/expression/formatted.hpp>
+
+namespace mbgl {
+    namespace android {
+
+        using SuperTag = jni::ObjectTag;
+        class Formatted : private mbgl::util::noncopyable {
+        public:
+            static constexpr auto Name() { return "com/mapbox/mapboxsdk/style/types/Formatted"; };
+
+            static jni::Local<jni::Object<Formatted>>
+            New(jni::JNIEnv&, const style::expression::Formatted &value);
+
+            static void registerNative(jni::JNIEnv &);
+        };
+
+    } // namespace android
+} // namespace mbgl

--- a/platform/android/src/style/formatted_section.cpp
+++ b/platform/android/src/style/formatted_section.cpp
@@ -1,0 +1,11 @@
+#include "formatted_section.hpp"
+
+namespace mbgl {
+namespace android {
+
+void FormattedSection::registerNative(jni::JNIEnv& env) {
+    jni::Class<FormattedSection>::Singleton(env);
+}
+
+} // namespace android
+} // namespace mbgl

--- a/platform/android/src/style/formatted_section.hpp
+++ b/platform/android/src/style/formatted_section.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <mbgl/util/noncopyable.hpp>
+
+#include <jni/jni.hpp>
+
+namespace mbgl {
+namespace android {
+
+class FormattedSection : private mbgl::util::noncopyable {
+public:
+    static constexpr auto Name() { return "com/mapbox/mapboxsdk/style/types/FormattedSection"; };
+
+    static void registerNative(jni::JNIEnv&);
+};
+
+} // namespace android
+} // namespace mbgl

--- a/platform/android/src/style/position.cpp
+++ b/platform/android/src/style/position.cpp
@@ -31,5 +31,5 @@ float Position::getPolarAngle(jni::JNIEnv& env, const jni::Object<Position>& pos
     return position.Get(env, field);
 }
 
-} // namespace andr[oid
+} // namespace android
 } // namespace mbgl


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gl-native/pull/12624, exposes `format` expression on Android.

Setting the `text-field` using the expression, or plain text, works as expected, however, getting the `text-field` property back from core reveals a couple of issues:
 - Plain text is returned as expected.
 - Any expression, other than `format`, is returned wrapped by `format` expression. This includes tokens (which are beforehand converted from plain text to expressions and this is expected).
 - When value is passed initially as the `format` expression, it's being returned as `String`, which is expected because of [this implementation](https://github.com/mapbox/mapbox-gl-native/pull/12624/files#diff-dc7d81f6247193e64e085c48fc54e29cR33).

Currently, above issues cause a bunch of tests to fail.

/cc @ChrisLoer 