### PR TITLE
[Qt] UpdateParameters should always be available when rendering

### DIFF
--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1817,11 +1817,13 @@ void QMapboxGLPrivate::update(std::shared_ptr<mbgl::UpdateParameters> parameters
 {
     std::lock_guard<std::recursive_mutex> lock(m_mapRendererMutex);
 
+    m_updateParameters = std::move(parameters);
+
     if (!m_mapRenderer) {
         return;
     }
 
-    m_mapRenderer->updateParameters(std::move(parameters));
+    m_mapRenderer->updateParameters(std::move(m_updateParameters));
 
     requestRendering();
 }
@@ -1856,6 +1858,11 @@ void QMapboxGLPrivate::createRenderer()
     connect(m_mapRenderer.get(), SIGNAL(needsRendering()), this, SLOT(requestRendering()));
 
     m_mapRenderer->setObserver(m_rendererObserver);
+
+    if (m_updateParameters) {
+        m_mapRenderer->updateParameters(m_updateParameters);
+        requestRendering();
+    }
 }
 
 void QMapboxGLPrivate::destroyRenderer()

--- a/platform/qt/src/qmapboxgl_map_renderer.cpp
+++ b/platform/qt/src/qmapboxgl_map_renderer.cpp
@@ -71,9 +71,8 @@ void QMapboxGLMapRenderer::render()
         // Lock on the parameters
         std::lock_guard<std::mutex> lock(m_updateMutex);
 
-        if (!m_updateParameters) {
-            return;
-        }
+        // UpdateParameters should always be available when rendering.
+        assert(m_updateParameters);
 
         // Hold on to the update parameters during render
         params = m_updateParameters;

--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -54,6 +54,7 @@ private:
 
     std::recursive_mutex m_mapRendererMutex;
     std::shared_ptr<mbgl::RendererObserver> m_rendererObserver;
+    std::shared_ptr<mbgl::UpdateParameters> m_updateParameters;
 
     std::unique_ptr<QMapboxGLMapObserver> m_mapObserver;
     std::shared_ptr<mbgl::DefaultFileSource> m_fileSourceObj;


### PR DESCRIPTION
In some scenarios, an update (or a series of) could happen _before_ the renderer frontend is ready, causing the [update parameters to be lost](https://github.com/mapbox/mapbox-gl-native/blob/master/platform/qt/src/qmapboxgl.cpp#L1820). Usually, this is not a problem because after the renderer is ready, further updates are handled just fine, but in cases where there are no more pending updates left, the view is left in a blank state.

To address that, we need to temporarily buffer the last update parameter prior to handling it over to the renderer frontend. We only need the last update parameter as it is self-contained and does not depend on previous updates.