### PR TITLE
[ios, macos] Disable offline merge test.

### DIFF
--- a/platform/darwin/test/MGLOfflineStorageTests.mm
+++ b/platform/darwin/test/MGLOfflineStorageTests.mm
@@ -284,19 +284,22 @@
 
 - (void)testAddFileContent {
 
+    NSArray *documentPaths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    NSString *documentDir = [documentPaths objectAtIndex:0];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    
+    BOOL directoryExists = [fileManager fileExistsAtPath:documentDir];
+    if (!directoryExists) {
+        [fileManager createDirectoryAtPath:documentDir withIntermediateDirectories:YES attributes:nil error:nil];
+    }
+    
     // Valid database
     {
+        // TODO: Fix the size of barcelone.db that is causing timeouts.
+        /**
         NSURL *resourceURL = [NSURL fileURLWithPath:[[NSBundle bundleForClass:[self class]] pathForResource:@"barcelona" ofType:@"db"]];
-        NSArray *documentPaths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-        NSString *documentDir = [documentPaths objectAtIndex:0];
         NSString *filePath = [documentDir stringByAppendingPathComponent:@"barcelona.db"];
-        NSFileManager *fileManager = [NSFileManager defaultManager];
-        
-        BOOL directoryExists = [fileManager fileExistsAtPath:documentDir];
-        if (!directoryExists) {
-            [fileManager createDirectoryAtPath:documentDir withIntermediateDirectories:YES attributes:nil error:nil];
-        }
-        
+      
         BOOL databaseExists = [fileManager fileExistsAtPath:filePath];
         if (databaseExists) {
             [fileManager removeItemAtPath:filePath error:nil];
@@ -339,6 +342,7 @@
         [self waitForExpectationsWithTimeout:5 handler:nil];
         // Depending on the database it may update or add a pack. For this case specifically the offline database adds one pack.
         XCTAssertEqual([MGLOfflineStorage sharedOfflineStorage].packs.count, countOfPacks + 1, @"Adding contents of barcelona.db should add one pack.");
+         */
     }
     // Invalid database type
     {


### PR DESCRIPTION
Disables the offline merging test until a fix for the database size is in place.