### PR TITLE
[core] Avoid wrapping longitude values of exactly 180 and 360 (#12797)

### DIFF
--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -61,7 +61,7 @@ public:
     // world, unwrap the start longitude to ensure the shortest path is taken.
     void unwrapForShortestPath(const LatLng& end) {
         const double delta = std::abs(end.lon - lon);
-        if (delta < util::LONGITUDE_MAX || delta > util::DEGREES_MAX) return;
+        if (delta <= util::LONGITUDE_MAX || delta >= util::DEGREES_MAX) return;
         if (lon > 0 && end.lon < 0) lon -= util::DEGREES_MAX;
         else if (lon < 0 && end.lon > 0) lon += util::DEGREES_MAX;
     }

--- a/scripts/changelog_staging/invalid-latlngbounds.json
+++ b/scripts/changelog_staging/invalid-latlngbounds.json
@@ -1,0 +1,4 @@
+{
+    "core": "When using longitude values of +-180° in LatLngBounds, the longitude was being improperly wrapped resulting in an unexpected bounding box.",
+    "issue": 12797
+}


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/12797

The thinking here is that 180 and 360 are special values that do not need to be wrapped. In the case of #12797 `unwrapForShortestPath` was causing a bug because `-180` was being converted to `180` and confining the viewport to the antimeridian when it should have been possible to scroll horizontally around the world. 

TODO:
- [ ] ~add test(s)~ - not needed for this. tests for generalized bounding box behavior are in progress at https://github.com/mapbox/mapbox-gl-native/pull/13087
- [x] update CHANGELOG