### PR TITLE
[ios, build] Check symbol namespacing for mapbox-events-ios

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,8 +280,8 @@ style-code: darwin-style-code
 darwin-update-examples:
 	node platform/darwin/scripts/update-examples.js
 
-.PHONY: check-public-symbols
-check-public-symbols:
+.PHONY: darwin-check-public-symbols
+darwin-check-public-symbols:
 	node platform/darwin/scripts/check-public-symbols.js macOS iOS
 
 endif

--- a/Makefile
+++ b/Makefile
@@ -252,6 +252,10 @@ ios-sanitize-address: $(IOS_PROJ_PATH)
 ios-static-analyzer: $(IOS_PROJ_PATH)
 	set -o pipefail && $(IOS_XCODEBUILD_SIM) analyze -scheme 'CI' test $(XCPRETTY)
 
+.PHONY: ios-check-events-symbols
+ios-check-events-symbols:
+	./platform/ios/scripts/check-events-symbols.sh
+
 .PHONY: ipackage
 ipackage: ipackage*
 ipackage%:

--- a/circle.yml
+++ b/circle.yml
@@ -294,7 +294,7 @@ commands:
     steps:
     - run:
         name: Check public symbols
-        command: make check-public-symbols
+        command: make darwin-check-public-symbols
 
 
   conditionally-skip-firebase:

--- a/circle.yml
+++ b/circle.yml
@@ -854,6 +854,9 @@ jobs:
           name: Lint plist files
           command: make ios-lint
       - run:
+          name: Check symbol namespacing for mapbox-events-ios
+          command: make ios-check-events-symbols
+      - run:
           name: Nitpick Darwin code generation
           command: scripts/nitpick/generated-code.js darwin
       - save-dependencies

--- a/platform/ios/DEVELOPING.md
+++ b/platform/ios/DEVELOPING.md
@@ -65,7 +65,7 @@ To add any Objective-C type, constant, or member to the iOS SDK’s public inter
 
 To add an Objective-C class, protocol, category, typedef, enumeration, or global constant to the iOS maps SDK’s public interface:
 
-1. _(Optional.)_ Add the macro `MGL_EXPORT` prior to the declaration for classes and global constants when adding them in shared headers located in `platform/darwin`. To use this macro, include `MGLFoundation.h`. You can check whether all public symbols are exported correctly by running `make check-public-symbols`.
+1. _(Optional.)_ Add the macro `MGL_EXPORT` prior to the declaration for classes and global constants when adding them in shared headers located in `platform/darwin`. To use this macro, include `MGLFoundation.h`. You can check whether all public symbols are exported correctly by running `make darwin-check-public-symbols`.
 1. _(Optional.)_ Add the type or constant’s name to the relevant category in the `custom_categories` section of [the jazzy configuration file](./jazzy.yml). This is required for classes and protocols and also recommended for any other type that is strongly associated with a particular class or protocol. If you leave out this step, the symbol will appear in an “Other” section in the generated HTML documentation’s table of contents.
 1. _(Optional.)_ If the symbol would also be publicly exposed in the macOS maps SDK, consult [the companion macOS document](../macos/DEVELOPING.md#making-a-type-or-constant-public) for further instructions.
 

--- a/platform/ios/scripts/check-events-symbols.sh
+++ b/platform/ios/scripts/check-events-symbols.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -u
+
+function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
+function finish { >&2 echo -en "\033[0m"; }
+trap finish EXIT
+
+FRAMEWORK=build/ios/pkg/dynamic/Mapbox.framework/Mapbox
+
+step "Looking for Mapbox.framework…"
+
+if [ -f ${FRAMEWORK} ]; then
+    echo "Found framework: ${FRAMEWORK}"
+else
+    echo "No framework found — building dynamic Mapbox.framework…"
+    make iframework BUILD_DEVICE=false
+fi
+
+step "Checking for un-namespaced symbols from mapbox-events-ios…"
+
+# Symbols from mapbox-events-ios are prefixed MME. To avoid duplicate symbol
+# warnings when multiple copes of mapbox-events-ios are included in a project,
+# the maps SDK prefixes these symbols with MGL_.
+SYMBOLS=$( nm ${FRAMEWORK} | grep \$_MME || true )
+
+if [ -z "${SYMBOLS}" ]; then
+    echo "✅ Found no un-namespaced symbols."
+else
+    echo "❗️ Found un-namespaced symbols:"
+    echo "${SYMBOLS}"
+    exit 1
+fi

--- a/platform/macos/DEVELOPING.md
+++ b/platform/macos/DEVELOPING.md
@@ -40,7 +40,7 @@ To add any Objective-C type, constant, or member to the macOS maps SDK’s publi
 
 To add an Objective-C class, protocol, category, typedef, enumeration, or global constant to the macOS maps SDK’s public interface:
 
-1. _(Optional.)_ Add the macro `MGL_EXPORT` prior to the declaration for classes and global constants. To use this macro, include `MGLFoundation.h`. You can check whether all public symbols are exported correctly by running `make check-public-symbols`.
+1. _(Optional.)_ Add the macro `MGL_EXPORT` prior to the declaration for classes and global constants. To use this macro, include `MGLFoundation.h`. You can check whether all public symbols are exported correctly by running `make darwin-check-public-symbols`.
 1. _(Optional.)_ Add the type or constant’s name to the relevant category in the `custom_categories` section of [the jazzy configuration file](./jazzy.yml). This is required for classes and protocols and also recommended for any other type that is strongly associated with a particular class or protocol. If you leave out this step, the symbol will appear in an “Other” section in the generated HTML documentation’s table of contents.
 1. _(Optional.)_ If the symbol would also be publicly exposed in the iOS maps SDK, consult [the companion iOS document](../ios/DEVELOPING.md#making-a-type-or-constant-public) for further instructions.
 


### PR DESCRIPTION
Check for proper symbol namespacing of mapbox-events-ios in the `ios-debug` CircleCI job or by running `make ios-check-events-symbols`, in an effort to avoid situations such as https://github.com/mapbox/mapbox-events-ios/issues/70. This depends on https://github.com/mapbox/mapbox-events-ios/pull/75.

Also renamed `make check-public-symbols` to `make darwin-check-public-symbols`.

/cc @rclee @julianrex 