### PR TITLE
[core] Read style's transition from parser

### DIFF
--- a/src/mbgl/style/parser.hpp
+++ b/src/mbgl/style/parser.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/style/source.hpp>
 #include <mbgl/style/light.hpp>
 
+#include <mbgl/util/constants.hpp>
 #include <mbgl/util/rapidjson.hpp>
 #include <mbgl/util/font_stack.hpp>
 #include <mbgl/util/geo.hpp>
@@ -32,7 +33,7 @@ public:
     std::vector<std::unique_ptr<Source>> sources;
     std::vector<std::unique_ptr<Layer>> layers;
 
-    TransitionOptions transition;
+    TransitionOptions transition { { util::DEFAULT_TRANSITION_DURATION } };
     Light light;
 
     std::string name;

--- a/src/mbgl/style/style_impl.cpp
+++ b/src/mbgl/style/style_impl.cpp
@@ -92,8 +92,7 @@ void Style::Impl::parse(const std::string& json_) {
     layers.clear();
     images.clear();
 
-    transitionOptions = {};
-    transitionOptions.duration = util::DEFAULT_TRANSITION_DURATION;
+    transitionOptions = parser.transition;
 
     for (auto& source : parser.sources) {
         addSource(std::move(source));

--- a/test/style/style.test.cpp
+++ b/test/style/style.test.cpp
@@ -43,6 +43,14 @@ TEST(Style, Properties) {
     ASSERT_EQ("", style.getName());
     ASSERT_EQ(60, *style.getDefaultCamera().pitch);
 
+    style.loadJSON(R"STYLE({})STYLE");
+    ASSERT_EQ(Milliseconds(300), *style.getTransitionOptions().duration);
+    ASSERT_EQ(optional<Duration> {}, style.getTransitionOptions().delay);
+
+    style.loadJSON(R"STYLE({"transition": { "duration": 500, "delay": 50 }})STYLE");
+    ASSERT_EQ(Milliseconds(500), *style.getTransitionOptions().duration);
+    ASSERT_EQ(Milliseconds(50), *style.getTransitionOptions().delay);
+
     style.loadJSON(R"STYLE({"name": 23, "center": {}, "bearing": "north", "zoom": null, "pitch": "wide"})STYLE");
     ASSERT_EQ("", style.getName());
     ASSERT_EQ(LatLng {}, *style.getDefaultCamera().center);


### PR DESCRIPTION
GL Native parses the style transition contents but does not use its value. This change applies the parsed transition, if any, with a fallback to the default transition duration value otherwise.