### PR TITLE
release-gazpacho backport: Add configuration to change the animation duration multiplier when tracking location

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinator.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinator.java
@@ -41,6 +41,7 @@ final class LocationAnimatorCoordinator {
   private float previousAccuracyRadius = -1;
   private float previousCompassBearing = -1;
   private long locationUpdateTimestamp = -1;
+  private float durationMultiplier;
 
   void addLayerListener(MapboxAnimator.OnLayerAnimationsValuesChangeListener listener) {
     layerListeners.add(listener);
@@ -222,8 +223,8 @@ final class LocationAnimatorCoordinator {
     if (previousUpdateTimeStamp == 0) {
       animationDuration = 0;
     } else {
-      animationDuration = (long) ((locationUpdateTimestamp - previousUpdateTimeStamp) * 1.1f)
-      /*make animation slightly longer*/;
+      animationDuration = (long) ((locationUpdateTimestamp - previousUpdateTimeStamp) * durationMultiplier)
+      /* make animation slightly longer with durationMultiplier, defaults to 1.1f */;
     }
 
     animationDuration = Math.min(animationDuration, MAX_ANIMATION_DURATION_MS);
@@ -369,5 +370,9 @@ final class LocationAnimatorCoordinator {
       animator.removeAllListeners();
       animatorArray.put(animatorType, null);
     }
+  }
+
+  void setTrackingAnimationDurationMultiplier(float trackingAnimationDurationMultiplier) {
+    this.durationMultiplier = trackingAnimationDurationMultiplier;
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
@@ -345,6 +345,7 @@ public final class LocationComponent {
     locationCameraController.initializeOptions(options);
     staleStateManager.setEnabled(options.enableStaleState());
     staleStateManager.setDelayTime(options.staleStateTimeout());
+    locationAnimatorCoordinator.setTrackingAnimationDurationMultiplier(options.trackingAnimationDurationMultiplier());
     updateMapWithOptions(options);
   }
 
@@ -769,9 +770,11 @@ public final class LocationComponent {
       options);
     locationCameraController = new LocationCameraController(
       context, mapboxMap, cameraTrackingChangedListener, options, onCameraMoveInvalidateListener);
+
     locationAnimatorCoordinator = new LocationAnimatorCoordinator();
     locationAnimatorCoordinator.addLayerListener(locationLayerController);
     locationAnimatorCoordinator.addCameraListener(locationCameraController);
+    locationAnimatorCoordinator.setTrackingAnimationDurationMultiplier(options.trackingAnimationDurationMultiplier());
 
     WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
     SensorManager sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentOptions.java
@@ -74,6 +74,11 @@ public class LocationComponentOptions implements Parcelable {
    */
   private static final long STALE_STATE_DELAY_MS = 30_000L;
 
+  /**
+   * Default animation duration multiplier
+   */
+  private static final float TRACKING_ANIMATION_DURATION_MULTIPLIER_DEFAULT = 1.1f;
+
   private float accuracyAlpha;
   private int accuracyColor;
   private int backgroundDrawableStale;
@@ -105,6 +110,7 @@ public class LocationComponentOptions implements Parcelable {
   private float trackingInitialMoveThreshold;
   private float trackingMultiFingerMoveThreshold;
   private String layerBelow;
+  private float trackingAnimationDurationMultiplier;
 
   public LocationComponentOptions(
     float accuracyAlpha,
@@ -137,7 +143,8 @@ public class LocationComponentOptions implements Parcelable {
     boolean trackingGesturesManagement,
     float trackingInitialMoveThreshold,
     float trackingMultiFingerMoveThreshold,
-    String layerBelow) {
+    String layerBelow,
+    float trackingAnimationDurationMultiplier) {
     this.accuracyAlpha = accuracyAlpha;
     this.accuracyColor = accuracyColor;
     this.backgroundDrawableStale = backgroundDrawableStale;
@@ -172,6 +179,7 @@ public class LocationComponentOptions implements Parcelable {
     this.trackingInitialMoveThreshold = trackingInitialMoveThreshold;
     this.trackingMultiFingerMoveThreshold = trackingMultiFingerMoveThreshold;
     this.layerBelow = layerBelow;
+    this.trackingAnimationDurationMultiplier = trackingAnimationDurationMultiplier;
   }
 
   /**
@@ -289,6 +297,12 @@ public class LocationComponentOptions implements Parcelable {
       R.styleable.mapbox_LocationComponent_mapbox_maxZoomIconScale, MAX_ZOOM_ICON_SCALE_DEFAULT);
     builder.minZoomIconScale(minScale);
     builder.maxZoomIconScale(maxScale);
+
+    float trackingAnimationDurationMultiplier = typedArray.getFloat(
+      R.styleable.mapbox_LocationComponent_mapbox_trackingAnimationDurationMultiplier,
+      TRACKING_ANIMATION_DURATION_MULTIPLIER_DEFAULT
+    );
+    builder.trackingAnimationDurationMultiplier(trackingAnimationDurationMultiplier);
 
     typedArray.recycle();
 
@@ -699,6 +713,16 @@ public class LocationComponentOptions implements Parcelable {
     return layerBelow;
   }
 
+  /**
+   * Get the tracking animation duration multiplier.
+   *
+   * @return tracking animation duration multiplier
+   * @since 0.9.0
+   */
+  public float trackingAnimationDurationMultiplier() {
+    return trackingAnimationDurationMultiplier;
+  }
+
   @Override
   public String toString() {
     return "LocationComponentOptions{"
@@ -733,6 +757,7 @@ public class LocationComponentOptions implements Parcelable {
       + "trackingInitialMoveThreshold=" + trackingInitialMoveThreshold + ", "
       + "trackingMultiFingerMoveThreshold=" + trackingMultiFingerMoveThreshold + ", "
       + "layerBelow=" + layerBelow
+      + "trackingAnimationDurationMultiplier=" + trackingAnimationDurationMultiplier
       + "}";
   }
 
@@ -785,7 +810,9 @@ public class LocationComponentOptions implements Parcelable {
         == Float.floatToIntBits(that.trackingInitialMoveThreshold()))
         && (Float.floatToIntBits(this.trackingMultiFingerMoveThreshold)
         == Float.floatToIntBits(that.trackingMultiFingerMoveThreshold()))
-        && layerBelow.equals(that.layerBelow));
+        && layerBelow.equals(that.layerBelow))
+        && (Float.floatToIntBits(this.trackingAnimationDurationMultiplier)
+        == Float.floatToIntBits(that.trackingAnimationDurationMultiplier()));
     }
     return false;
   }
@@ -853,6 +880,8 @@ public class LocationComponentOptions implements Parcelable {
     h$ ^= Float.floatToIntBits(trackingInitialMoveThreshold);
     h$ *= 1000003;
     h$ ^= Float.floatToIntBits(trackingMultiFingerMoveThreshold);
+    h$ *= 1000003;
+    h$ ^= Float.floatToIntBits(trackingAnimationDurationMultiplier);
     return h$;
   }
 
@@ -891,7 +920,8 @@ public class LocationComponentOptions implements Parcelable {
           in.readInt() == 1,
           in.readFloat(),
           in.readFloat(),
-          in.readString()
+          in.readString(),
+          in.readFloat()
         );
       }
 
@@ -989,6 +1019,7 @@ public class LocationComponentOptions implements Parcelable {
     dest.writeFloat(trackingInitialMoveThreshold());
     dest.writeFloat(trackingMultiFingerMoveThreshold());
     dest.writeString(layerBelow());
+    dest.writeFloat(trackingAnimationDurationMultiplier);
   }
 
   @Override
@@ -1052,6 +1083,7 @@ public class LocationComponentOptions implements Parcelable {
     private Float trackingInitialMoveThreshold;
     private Float trackingMultiFingerMoveThreshold;
     private String layerBelow;
+    private Float trackingAnimationDurationMultiplier;
 
     Builder() {
     }
@@ -1088,6 +1120,7 @@ public class LocationComponentOptions implements Parcelable {
       this.trackingInitialMoveThreshold = source.trackingInitialMoveThreshold();
       this.trackingMultiFingerMoveThreshold = source.trackingMultiFingerMoveThreshold();
       this.layerBelow = source.layerBelow();
+      this.trackingAnimationDurationMultiplier = source.trackingAnimationDurationMultiplier();
     }
 
     /**
@@ -1511,6 +1544,18 @@ public class LocationComponentOptions implements Parcelable {
       return this;
     }
 
+    /**
+     * Sets the tracking animation duration multiplier.
+     *
+     * @param trackingAnimationDurationMultiplier the tracking animation duration multiplier
+     * @since 0.9.0
+     */
+    public LocationComponentOptions.Builder trackingAnimationDurationMultiplier(
+      float trackingAnimationDurationMultiplier) {
+      this.trackingAnimationDurationMultiplier = trackingAnimationDurationMultiplier;
+      return this;
+    }
+
     LocationComponentOptions autoBuild() {
       String missing = "";
       if (this.accuracyAlpha == null) {
@@ -1570,6 +1615,9 @@ public class LocationComponentOptions implements Parcelable {
       if (this.trackingMultiFingerMoveThreshold == null) {
         missing += " trackingMultiFingerMoveThreshold";
       }
+      if (this.trackingAnimationDurationMultiplier == null) {
+        missing += " trackingAnimationDurationMultiplier";
+      }
       if (!missing.isEmpty()) {
         throw new IllegalStateException("Missing required properties:" + missing);
       }
@@ -1604,7 +1652,8 @@ public class LocationComponentOptions implements Parcelable {
         trackingGesturesManagement,
         this.trackingInitialMoveThreshold,
         this.trackingMultiFingerMoveThreshold,
-        this.layerBelow);
+        this.layerBelow,
+        this.trackingAnimationDurationMultiplier);
     }
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
@@ -149,4 +149,7 @@
     <!-- Camera tracking settings -->
     <public name="mapbox_trackingInitialMoveThreshold" format="float" type="attr"/>
     <public name="mapbox_trackingMultiFingerMoveThreshold" format="float" type="attr"/>
+
+    <!-- Animation duration multiplier -->
+    <public name="mapbox_trackingAnimationDurationMultiplier" format="float" type="attr" />
 </resources>

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/attrs.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/attrs.xml
@@ -175,5 +175,8 @@
         <attr name="mapbox_trackingInitialMoveThreshold" format="dimension"/>
         <attr name="mapbox_trackingMultiFingerMoveThreshold" format="dimension"/>
 
+        <!-- Animation duration multiplier -->
+        <attr name="mapbox_trackingAnimationDurationMultiplier" format="float" />
+
     </declare-styleable>
 </resources>


### PR DESCRIPTION
Backports #13011 to release-gazpacho
----
Closes https://github.com/mapbox/mapbox-gl-native/issues/12992.