### PR TITLE
[Waiting for review][core] Deprioritize offline downloads

### DIFF
--- a/include/mbgl/storage/online_file_source.hpp
+++ b/include/mbgl/storage/online_file_source.hpp
@@ -26,6 +26,7 @@ public:
 
     // For testing only.
     void setOnlineStatus(bool);
+    void setMaximumConcurrentRequestsOverride(uint32_t);
 
 private:
     friend class OnlineFileRequest;

--- a/include/mbgl/storage/resource.hpp
+++ b/include/mbgl/storage/resource.hpp
@@ -24,6 +24,11 @@ public:
         Image
     };
 
+    enum class Priority : bool {
+        Regular,
+        Low
+    };
+
     struct TileData {
         std::string urlTemplate;
         uint8_t pixelRatio;
@@ -44,34 +49,41 @@ public:
 
     Resource(Kind kind_,
              std::string url_,
+             Priority priority_ = Resource::Priority::Regular,
              optional<TileData> tileData_ = {},
              LoadingMethod loadingMethod_ = LoadingMethod::All)
         : kind(kind_),
           loadingMethod(loadingMethod_),
+          priority(priority_),
           url(std::move(url_)),
           tileData(std::move(tileData_)) {
     }
 
+    void setPriority(Priority p) { priority = p; }
+
     bool hasLoadingMethod(LoadingMethod method);
 
-    static Resource style(const std::string& url);
-    static Resource source(const std::string& url);
+    static Resource style(const std::string& url, const Priority priority = Resource::Priority::Regular);
+    static Resource source(const std::string& url, const Priority priority = Resource::Priority::Regular);
     static Resource tile(const std::string& urlTemplate,
                          float pixelRatio,
                          int32_t x,
                          int32_t y,
                          int8_t z,
                          Tileset::Scheme scheme,
+                         const Priority priority = Resource::Priority::Regular,
                          LoadingMethod = LoadingMethod::All);
     static Resource glyphs(const std::string& urlTemplate,
                            const FontStack& fontStack,
-                           const std::pair<uint16_t, uint16_t>& glyphRange);
-    static Resource spriteImage(const std::string& base, float pixelRatio);
-    static Resource spriteJSON(const std::string& base, float pixelRatio);
-    static Resource image(const std::string& url);
-    
+                           const std::pair<uint16_t, uint16_t>& glyphRange,
+                           const Priority priority = Resource::Priority::Regular);
+    static Resource spriteImage(const std::string& base, float pixelRatio, const Priority priority = Resource::Priority::Regular);
+    static Resource spriteJSON(const std::string& base, float pixelRatio, const Priority priority = Resource::Priority::Regular);
+    static Resource image(const std::string& url, const Priority priority = Resource::Priority::Regular);
+
     Kind kind;
     LoadingMethod loadingMethod;
+    Priority priority;
     std::string url;
 
     // Includes auxiliary data if this is a tile request.

--- a/platform/default/online_file_source.cpp
+++ b/platform/default/online_file_source.cpp
@@ -89,13 +89,8 @@ public:
         if (activeRequests.erase(request)) {
             activatePendingRequest();
         } else {
-            auto it = pendingRequestsMap.find(request);
-            if (it != pendingRequestsMap.end()) {
-                pendingRequestsList.erase(it->second);
-                pendingRequestsMap.erase(it);
-            }
+            pendingRequests.remove(request);
         }
-        assert(pendingRequestsMap.size() == pendingRequestsList.size());
     }
 
     void activateOrQueueRequest(OnlineFileRequest* request) {
@@ -111,9 +106,7 @@ public:
     }
 
     void queueRequest(OnlineFileRequest* request) {
-        auto it = pendingRequestsList.insert(pendingRequestsList.end(), request);
-        pendingRequestsMap.emplace(request, std::move(it));
-        assert(pendingRequestsMap.size() == pendingRequestsList.size());
+        pendingRequests.insert(request);
     }
 
     void activateRequest(OnlineFileRequest* request) {
@@ -135,25 +128,17 @@ public:
             callback(response);
         }
 
-        assert(pendingRequestsMap.size() == pendingRequestsList.size());
     }
 
     void activatePendingRequest() {
-        if (pendingRequestsList.empty()) {
-            return;
-        }
 
-        OnlineFileRequest* request = pendingRequestsList.front();
-        pendingRequestsList.pop_front();
+        auto request = pendingRequests.pop();
 
-        pendingRequestsMap.erase(request);
-
-        activateRequest(request);
-        assert(pendingRequestsMap.size() == pendingRequestsList.size());
+        if (request) activateRequest(*request);
     }
 
     bool isPending(OnlineFileRequest* request) {
-        return pendingRequestsMap.find(request) != pendingRequestsMap.end();
+        return pendingRequests.contains(request);
     }
 
     bool isActive(OnlineFileRequest* request) {
@@ -169,12 +154,89 @@ public:
         networkIsReachableAgain();
     }
 
+    void setMaximumConcurrentRequestsOverride(const uint32_t override) {
+        maximumConcurrentRequestsOverride = override;
+    }
+
 private:
+
+    uint32_t getMaximumConcurrentRequests() {
+        if (maximumConcurrentRequestsOverride > 0) return maximumConcurrentRequestsOverride;
+        else return HTTPFileSource::maximumConcurrentRequests();
+    }
+
     void networkIsReachableAgain() {
         for (auto& request : allRequests) {
             request->networkIsReachableAgain();
         }
     }
+
+    // Using Pending Requests as an priority queue which processes
+    // file requests in a FIFO manner but prefers regular requests
+    // over offline requests with a low priority such that low priority
+    // requests do not throttle regular requests.
+    //
+    // The order of a queue is therefore:
+    //
+    // hi0 -- hi1 -- hi2 -- hi3 -- lo0 -- lo1 --lo2
+    //                              ^
+    //                              firstLowPriorityRequest
+
+    struct PendingRequests {
+        PendingRequests() : queue(), firstLowPriorityRequest(queue.begin()) {}
+
+        std::list<OnlineFileRequest*> queue;
+        std::list<OnlineFileRequest*>::iterator firstLowPriorityRequest;
+
+        void remove(OnlineFileRequest* request) {
+            auto it = std::find(queue.begin(), queue.end(), request);
+            if (it != queue.end()) {
+                if (it == firstLowPriorityRequest) {
+                    firstLowPriorityRequest++;
+                }
+                queue.erase(it);
+
+                if (queue.empty()) {
+                    first_low = queue.begin();
+                }
+            }
+        }
+
+        void insert(OnlineFileRequest* request) {
+            if (request->resource.priority == Resource::Priority::Regular) {
+                firstLowPriorityRequest = queue.insert(firstLowPriorityRequest, request);
+                firstLowPriorityRequest++;
+            }
+            else {
+                if (firstLowPriorityRequest == queue.end()) {
+                    firstLowPriorityRequest = queue.insert(queue.end(), request);
+                }
+                else {
+                    queue.insert(queue.end(), request);
+                }
+            }
+        }
+
+
+        optional<OnlineFileRequest*> pop() {
+            if (queue.empty()) {
+                return optional<OnlineFileRequest*>();
+            }
+
+            if (queue.begin() == firstLowPriorityRequest) {
+                firstLowPriorityRequest++;
+            }
+
+            OnlineFileRequest* next = queue.front();
+            queue.pop_front();
+            return optional<OnlineFileRequest*>(next);
+        }
+
+        bool contains(OnlineFileRequest* request) {
+            return (std::find(queue.begin(), queue.end(), request) != queue.end());
+        }
+
+    };
 
     optional<ActorRef<ResourceTransform>> resourceTransform;
 
@@ -190,8 +252,9 @@ private:
      * `pendingRequests`. Requests in the active state are in `activeRequests`.
      */
     std::unordered_set<OnlineFileRequest*> allRequests;
-    std::list<OnlineFileRequest*> pendingRequestsList;
-    std::unordered_map<OnlineFileRequest*, std::list<OnlineFileRequest*>::iterator> pendingRequestsMap;
+
+    PendingRequests pendingRequests;
+
     std::unordered_set<OnlineFileRequest*> activeRequests;
 
     bool online = true;

--- a/src/mbgl/storage/resource.cpp
+++ b/src/mbgl/storage/resource.cpp
@@ -39,44 +39,49 @@ static std::string getTileBBox(int32_t x, int32_t y, int8_t z) {
             util::toString(max.x) + "," + util::toString(max.y));
 }
 
-Resource Resource::style(const std::string& url) {
+Resource Resource::style(const std::string& url, const Priority priority) {
     return Resource {
         Resource::Kind::Style,
-        url
+        url,
+        priority
     };
 }
 
-Resource Resource::source(const std::string& url) {
+Resource Resource::source(const std::string& url, const Priority priority) {
     return Resource {
         Resource::Kind::Source,
-        url
+        url,
+        priority
     };
 }
 
-Resource Resource::image(const std::string& url) {
+Resource Resource::image(const std::string& url, const Priority priority) {
     return Resource {
         Resource::Kind::Image,
-        url
+        url,
+        priority
     };
 }
 
-Resource Resource::spriteImage(const std::string& base, float pixelRatio) {
+Resource Resource::spriteImage(const std::string& base, float pixelRatio, const Priority priority) {
     util::URL url(base);
     return Resource{ Resource::Kind::SpriteImage,
                      base.substr(0, url.path.first + url.path.second) +
                          (pixelRatio > 1 ? "@2x" : "") + ".png" +
-                         base.substr(url.query.first, url.query.second) };
+                         base.substr(url.query.first, url.query.second),
+                     priority };
 }
 
-Resource Resource::spriteJSON(const std::string& base, float pixelRatio) {
+Resource Resource::spriteJSON(const std::string& base, float pixelRatio, const Priority priority) {
     util::URL url(base);
     return Resource{ Resource::Kind::SpriteJSON,
                      base.substr(0, url.path.first + url.path.second) +
                          (pixelRatio > 1 ? "@2x" : "") + ".json" +
-                         base.substr(url.query.first, url.query.second) };
+                         base.substr(url.query.first, url.query.second),
+                     priority };
 }
 
-Resource Resource::glyphs(const std::string& urlTemplate, const FontStack& fontStack, const std::pair<uint16_t, uint16_t>& glyphRange) {
+Resource Resource::glyphs(const std::string& urlTemplate, const FontStack& fontStack, const std::pair<uint16_t, uint16_t>& glyphRange, const Priority priority) {
     return Resource {
         Resource::Kind::Glyphs,
         util::replaceTokens(urlTemplate, [&](const std::string& token) -> optional<std::string> {
@@ -87,7 +92,8 @@ Resource Resource::glyphs(const std::string& urlTemplate, const FontStack& fontS
             } else {
                 return {};
             }
-        })
+        }),
+        priority
     };
 }
 
@@ -97,6 +103,7 @@ Resource Resource::tile(const std::string& urlTemplate,
                         int32_t y,
                         int8_t z,
                         Tileset::Scheme scheme,
+                        const Priority priority,
                         LoadingMethod loadingMethod) {
     bool supportsRatio = urlTemplate.find("{ratio}") != std::string::npos;
     if (scheme == Tileset::Scheme::TMS) {
@@ -126,6 +133,7 @@ Resource Resource::tile(const std::string& urlTemplate,
                 return {};
             }
         }),
+        priority,
         Resource::TileData {
             urlTemplate,
             uint8_t(supportsRatio && pixelRatio > 1.0 ? 2 : 1),

--- a/src/mbgl/tile/tile_loader_impl.hpp
+++ b/src/mbgl/tile/tile_loader_impl.hpp
@@ -23,6 +23,7 @@ TileLoader<T>::TileLoader(T& tile_,
         id.canonical.y,
         id.canonical.z,
         tileset.scheme,
+        Resource::Priority::Regular,
         Resource::LoadingMethod::CacheOnly)),
       fileSource(parameters.fileSource) {
     assert(!request);

--- a/test/storage/default_file_source.test.cpp
+++ b/test/storage/default_file_source.test.cpp
@@ -251,7 +251,7 @@ TEST(DefaultFileSource, OptionalNonExpired) {
     util::RunLoop loop;
     DefaultFileSource fs(":memory:", ".");
 
-    const Resource optionalResource { Resource::Unknown, "http://127.0.0.1:3000/test", {}, Resource::LoadingMethod::CacheOnly };
+    const Resource optionalResource { Resource::Unknown, "http://127.0.0.1:3000/test", Resource::Priority::Regular, {}, Resource::LoadingMethod::CacheOnly };
 
     using namespace std::chrono_literals;
 
@@ -281,7 +281,7 @@ TEST(DefaultFileSource, OptionalExpired) {
     util::RunLoop loop;
     DefaultFileSource fs(":memory:", ".");
 
-    const Resource optionalResource { Resource::Unknown, "http://127.0.0.1:3000/test", {}, Resource::LoadingMethod::CacheOnly };
+    const Resource optionalResource { Resource::Unknown, "http://127.0.0.1:3000/test", Resource::Priority::Regular, {}, Resource::LoadingMethod::CacheOnly };
 
     using namespace std::chrono_literals;
 
@@ -327,7 +327,7 @@ TEST(DefaultFileSource, OptionalNotFound) {
     util::RunLoop loop;
     DefaultFileSource fs(":memory:", ".");
 
-    const Resource optionalResource { Resource::Unknown, "http://127.0.0.1:3000/test", {}, Resource::LoadingMethod::CacheOnly };
+    const Resource optionalResource { Resource::Unknown, "http://127.0.0.1:3000/test", Resource::Priority::Regular, {}, Resource::LoadingMethod::CacheOnly };
 
     using namespace std::chrono_literals;
 

--- a/test/storage/offline_download.test.cpp
+++ b/test/storage/offline_download.test.cpp
@@ -663,7 +663,7 @@ TEST(OfflineDownload, Deactivate) {
 }
 
 
-TEST(OfflineDownload, LowPriorityRequests) {
+TEST(OfflineDownload, AllOfflineRequestsHaveLowPriority) {
     OfflineTest test;
     auto region = test.createRegion();
     ASSERT_TRUE(region);

--- a/test/storage/online_file_source.test.cpp
+++ b/test/storage/online_file_source.test.cpp
@@ -425,3 +425,94 @@ TEST(OnlineFileSource, ChangeAPIBaseURL){
     fs.setAPIBaseURL(customURL);
     EXPECT_EQ(customURL, fs.getAPIBaseURL());
 }
+
+
+TEST(OnlineFileSource, TEST_REQUIRES_SERVER(LowHighPriorityRequests)) {
+    util::RunLoop loop;
+    OnlineFileSource fs;
+    std::size_t response_counter = 0;
+    const std::size_t NUM_REQUESTS = 3;
+
+    fs.setMaximumConcurrentRequestsOverride(1);
+
+    NetworkStatus::Set(NetworkStatus::Status::Offline);
+
+    // requesting a low priority resource
+    Resource low_prio{ Resource::Unknown, "http://127.0.0.1:3000/load/1" };
+    low_prio.setPriority(Resource::Priority::Low);
+    std::unique_ptr<AsyncRequest> req_0 = fs.request(low_prio, [&](Response) {
+        response_counter++;
+        req_0.reset();
+        EXPECT_EQ(response_counter, NUM_REQUESTS); // make sure this is responded last
+        loop.stop();
+    });
+
+    // requesting two "regular" resources
+    Resource regular1{ Resource::Unknown, "http://127.0.0.1:3000/load/2" };
+    std::unique_ptr<AsyncRequest> req_1 = fs.request(regular1, [&](Response) {
+        response_counter++;
+        req_1.reset();
+    });
+    Resource regular2{ Resource::Unknown, "http://127.0.0.1:3000/load/3" };
+    std::unique_ptr<AsyncRequest> req_2 = fs.request(regular2, [&](Response) {
+        response_counter++;
+        req_2.reset();
+    });
+
+    NetworkStatus::Set(NetworkStatus::Status::Online);
+
+    loop.run();
+}
+
+
+TEST(OnlineFileSource, TEST_REQUIRES_SERVER(LowHighPriorityRequestsMany)) {
+    util::RunLoop loop;
+    OnlineFileSource fs;
+    int response_counter = 0;
+    int correct_low = 0;
+    int correct_regular = 0;
+
+
+    fs.setMaximumConcurrentRequestsOverride(1);
+
+    NetworkStatus::Set(NetworkStatus::Status::Offline);
+
+    std::vector<std::unique_ptr<AsyncRequest>> collector;
+
+    for (int num_reqs = 0; num_reqs < 20; num_reqs++) {
+        if (num_reqs % 2 == 0) {
+            std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/load/" + std::to_string(num_reqs), Resource::Priority::Regular }, [&](Response) {
+                response_counter++;
+
+                if (response_counter <= 10) { // count the high priority requests that arrive late correctly
+                    correct_regular++;
+                }
+            });
+            collector.push_back(std::move(req));
+        }
+        else {
+            std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/load/" + std::to_string(num_reqs), Resource::Priority::Low }, [&](Response) {
+                response_counter++;
+
+                if (response_counter > 10) { // count the low priority requests that arrive late correctly
+                    correct_low++;
+                }
+
+                // stop and check correctness after last low priority request is responded
+                if (20 == response_counter) {
+                    loop.stop();
+                    for (auto& collected_req : collector) {
+                        collected_req.reset();
+                    }
+                    ASSERT_TRUE(correct_low >= 9);
+                    ASSERT_TRUE(correct_regular >= 9);
+                }
+            });
+            collector.push_back(std::move(req));
+        }
+    }
+
+    NetworkStatus::Set(NetworkStatus::Status::Online);
+
+    loop.run();
+}


### PR DESCRIPTION
Working towards targeting https://github.com/mapbox/mapbox-gl-native/issues/12655:

> This issue covers prioritizing all regular requests, i.e. all requests necessary to show the current map view, above offline download request. This should resolve the issue outlined in #11461.



### Current approach:
- Add a priority-aware logic to favour "regular" requests over offline requests
    - currently implemented by adding two queues in `OnlineFileSource` 
- Set requests made by `OfflineDownload` to low priority
    - currently realised by adding a `bool isLowPriority` flag to `Resource`

### Todos:
- [x] implement current approach
- [x] get feedback on approach
     - currently, offline requests set their resources to low priority by calling `setLowPriority()` [here](https://github.com/mapbox/mapbox-gl-native/pull/13019/files#diff-96708c3e34c0b762818fdb34f5ebe873R56). Would it be better to set the priority flag via an input parameter in the constructors? Should it be a parameter that defaults to zero? Or would it be better to enforce it being set explicitly?
- [x] test whether this is actually working as intended
- [x] check manually if there's an improvement by downloading data and scrolling in the app
- [x] clean up code
     - rename commit messages to precede with `[core]` 
- [ ] get a code review

related work: https://github.com/mapbox/mapbox-gl-native/pull/12910