### PR TITLE
Let placement transitions use the transition duration, if set, and allow disabling them entirely

### DIFF
--- a/include/mbgl/style/transition_options.hpp
+++ b/include/mbgl/style/transition_options.hpp
@@ -10,16 +10,20 @@ class TransitionOptions {
 public:
     optional<Duration> duration;
     optional<Duration> delay;
+    bool enablePlacementTransitions;
 
     TransitionOptions(optional<Duration> duration_ = {},
-                      optional<Duration> delay_ = {})
+                      optional<Duration> delay_ = {},
+                      bool enablePlacementTransitions_ = true)
         : duration(std::move(duration_)),
-          delay(std::move(delay_)) {}
+          delay(std::move(delay_)),
+          enablePlacementTransitions(enablePlacementTransitions_) {}
 
     TransitionOptions reverseMerge(const TransitionOptions& defaults) const {
         return {
             duration ? duration : defaults.duration,
-            delay ? delay : defaults.delay
+            delay ? delay : defaults.delay,
+            enablePlacementTransitions
         };
     }
 

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -55,7 +55,7 @@ Renderer::Impl::Impl(RendererBackend& backend_,
     , sourceImpls(makeMutable<std::vector<Immutable<style::Source::Impl>>>())
     , layerImpls(makeMutable<std::vector<Immutable<style::Layer::Impl>>>())
     , renderLight(makeMutable<Light::Impl>())
-    , placement(std::make_unique<Placement>(TransformState{}, MapMode::Static, true)) {
+    , placement(std::make_unique<Placement>(TransformState{}, MapMode::Static, TransitionOptions{}, true)) {
     glyphManager->setObserver(this);
 }
 
@@ -338,7 +338,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         std::set<std::string> usedSymbolLayers;
 
         if (placementChanged) {
-            newPlacement = std::make_unique<Placement>(parameters.state, parameters.mapMode, updateParameters.crossSourceCollisions);
+            newPlacement = std::make_unique<Placement>(parameters.state, parameters.mapMode, updateParameters.transitionOptions, updateParameters.crossSourceCollisions);
         }
 
         for (const auto& item : renderItemsWithSymbols) {

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -90,15 +90,19 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
 
     const bool zoomChanged = zoomHistory.update(updateParameters.transformState.getZoom(), updateParameters.timePoint);
 
+    const bool isMapModeContinuous = updateParameters.mode == MapMode::Continuous;
+
+    const TransitionOptions transitionOptions = isMapModeContinuous ? updateParameters.transitionOptions : TransitionOptions();
+
     const TransitionParameters transitionParameters {
         updateParameters.timePoint,
-        updateParameters.mode == MapMode::Continuous ? updateParameters.transitionOptions : TransitionOptions()
+        transitionOptions
     };
 
     const PropertyEvaluationParameters evaluationParameters {
         zoomHistory,
         updateParameters.timePoint,
-        updateParameters.mode == MapMode::Continuous ? util::DEFAULT_TRANSITION_DURATION : Duration::zero()
+        transitionOptions.duration.value_or(isMapModeContinuous ? util::DEFAULT_TRANSITION_DURATION : Duration::zero())
     };
 
     const TileParameters tileParameters {

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -5,6 +5,7 @@
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/text/collision_index.hpp>
 #include <mbgl/layout/symbol_projection.hpp>
+#include <mbgl/style/transition_options.hpp>
 #include <unordered_set>
 
 namespace mbgl {
@@ -79,7 +80,7 @@ private:
     
 class Placement {
 public:
-    Placement(const TransformState&, MapMode mapMode, const bool crossSourceCollisions);
+    Placement(const TransformState&, MapMode, style::TransitionOptions, const bool crossSourceCollisions);
     void placeLayer(const RenderLayerSymbolInterface&, const mat4&, bool showCollisionBoxes);
     void commit(const Placement& prevPlacement, TimePoint);
     void updateLayerOpacities(const RenderLayerSymbolInterface&);
@@ -113,6 +114,8 @@ private:
 
     TransformState state;
     MapMode mapMode;
+    style::TransitionOptions transitionOptions;
+
     TimePoint fadeStartTime;
     TimePoint commitTime;
 


### PR DESCRIPTION
This PR:
- Lets property evaluation transitions use the transition duration, if set, with fallback to the default value (300ms) otherwise;
- Lets label placement transitions use the transition duration, if set, with fallback to the default value (300ms) otherwise;
- Exposes a boolean flag that allows manual override of label placement transitions, allowing the client to disable transitions for that particular case.

@ChrisLoer @ansis please review.