### PR TITLE
[ios] Log event when offline pack is created

### DIFF
--- a/platform/darwin/src/MGLOfflineRegion_Private.h
+++ b/platform/darwin/src/MGLOfflineRegion_Private.h
@@ -14,6 +14,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (const mbgl::OfflineRegionDefinition)offlineRegionDefinition;
 
+/**
+ Attributes to be passed into the offline download start event
+ */
+@property (nonatomic, readonly) NSDictionary *offlineStartEventAttributes;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -7,8 +7,14 @@
 #import "MGLOfflinePack_Private.h"
 #import "MGLOfflineRegion_Private.h"
 #import "MGLTilePyramidOfflineRegion.h"
+#import "MGLShapeOfflineRegion.h"
 #import "NSBundle+MGLAdditions.h"
 #import "NSValue+MGLAdditions.h"
+
+#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
+#import "MMEConstants.h"
+#import "MGLMapboxEvents.h"
+#endif
 
 #include <mbgl/actor/actor.hpp>
 #include <mbgl/actor/scheduler.hpp>
@@ -358,6 +364,17 @@ const MGLExceptionName MGLUnsupportedRegionTypeException = @"MGLUnsupportedRegio
         if (completion) {
             completion(pack, error);
         }
+            
+        #if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
+            NSMutableDictionary *offlineDownloadStartEventAttributes = [NSMutableDictionary dictionaryWithObject:MMEventTypeOfflineDownloadStart forKey:MMEEventKeyEvent];
+        
+            if ([region conformsToProtocol:@protocol(MGLOfflineRegion_Private)]) {
+                NSDictionary *regionAttributes = ((id<MGLOfflineRegion_Private>)region).offlineStartEventAttributes;
+                [offlineDownloadStartEventAttributes addEntriesFromDictionary:regionAttributes];
+            }
+        
+            [MGLMapboxEvents pushEvent:MMEventTypeOfflineDownloadStart withAttributes:offlineDownloadStartEventAttributes];
+        #endif
     }];
 }
 

--- a/platform/darwin/src/MGLShapeOfflineRegion.mm
+++ b/platform/darwin/src/MGLShapeOfflineRegion.mm
@@ -12,6 +12,10 @@
 #import "MGLShape_Private.h"
 #import "MGLStyle.h"
 
+#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
+#import "MMEConstants.h"
+#endif
+
 @interface MGLShapeOfflineRegion () <MGLOfflineRegion_Private, MGLShapeOfflineRegion_Private>
 
 @end
@@ -21,6 +25,17 @@
 }
 
 @synthesize styleURL = _styleURL;
+
+-(NSDictionary *)offlineStartEventAttributes {
+    return @{
+             #if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
+             MMEEventKeyShapeForOfflineRegion: @"shaperegion",
+             MMEEventKeyMinZoomLevel: @(self.minimumZoomLevel),
+             MMEEventKeyMaxZoomLevel: @(self.maximumZoomLevel),
+             MMEEventKeyStyleURL: self.styleURL
+             #endif
+             };
+}
 
 + (BOOL)supportsSecureCoding {
     return YES;

--- a/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
+++ b/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
@@ -9,6 +9,10 @@
 #import "MGLGeometry_Private.h"
 #import "MGLStyle.h"
 
+#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
+#import "MMEConstants.h"
+#endif
+
 @interface MGLTilePyramidOfflineRegion () <MGLOfflineRegion_Private, MGLTilePyramidOfflineRegion_Private>
 
 @end
@@ -18,6 +22,17 @@
 }
 
 @synthesize styleURL = _styleURL;
+
+-(NSDictionary *)offlineStartEventAttributes {
+    return @{
+             #if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
+             MMEEventKeyShapeForOfflineRegion: @"tileregion",
+             MMEEventKeyMinZoomLevel: @(self.minimumZoomLevel),
+             MMEEventKeyMaxZoomLevel: @(self.maximumZoomLevel),
+             MMEEventKeyStyleURL: self.styleURL
+             #endif
+             };
+}
 
 + (BOOL)supportsSecureCoding {
     return YES;


### PR DESCRIPTION
Part II of https://github.com/mapbox/mapbox-gl-native/issues/12751.

Integrates the new offline event into the Mapbox Maps SDK framework, logging an event when a new region is added with`[MGLSharedOfflineStorage addPackForRegion:withContext:completionHandler:]`.

This PR also bumps `mapbox-events-ios` to the current https://github.com/mapbox/mapbox-events-ios/commit/61fca377e82b4cfb5e99feea1f465eff1dabbf4e commit on `master` in order to take advantage of the corresponding new event class and constants.