### PR TITLE
Replace OnMapChange with specific callbacks

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapChangeReceiver.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapChangeReceiver.java
@@ -1,0 +1,239 @@
+package com.mapbox.mapboxsdk.maps;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class MapChangeReceiver implements NativeMapView.StateCallback {
+
+  private final List<MapView.OnCameraWillChangeListener> onCameraWillChangeListenerList = new ArrayList<>();
+  private final List<MapView.OnCameraIsChangingListener> onCameraIsChangingListenerList = new ArrayList<>();
+  private final List<MapView.OnCameraDidChangeListener> onCameraDidChangeListenerList = new ArrayList<>();
+  private final List<MapView.OnWillStartLoadingMapListener> onWillStartLoadingMapListenerList = new ArrayList<>();
+  private final List<MapView.OnDidFinishLoadingMapListener> onDidFinishLoadingMapListenerList = new ArrayList<>();
+  private final List<MapView.OnDidFailLoadingMapListener> onDidFailLoadingMapListenerList = new ArrayList<>();
+  private final List<MapView.OnWillStartRenderingFrameListener> onWillStartRenderingFrameList = new ArrayList<>();
+  private final List<MapView.OnDidFinishRenderingFrameListener> onDidFinishRenderingFrameList = new ArrayList<>();
+  private final List<MapView.OnWillStartRenderingMapListener> onWillStartRenderingMapListenerList = new ArrayList<>();
+  private final List<MapView.OnDidFinishRenderingMapListener> onDidFinishRenderingMapListenerList = new ArrayList<>();
+  private final List<MapView.OnDidFinishLoadingStyleListener> onDidFinishLoadingStyleListenerList = new ArrayList<>();
+  private final List<MapView.OnSourceChangedListener> onSourceChangedListenerList = new ArrayList<>();
+
+  @Override
+  public void onCameraWillChange(boolean animated) {
+    if (!onCameraWillChangeListenerList.isEmpty()) {
+      for (MapView.OnCameraWillChangeListener onCameraWillChangeListener : onCameraWillChangeListenerList) {
+        onCameraWillChangeListener.onCameraWillChange(animated);
+      }
+    }
+  }
+
+  @Override
+  public void onCameraIsChanging() {
+    if (!onCameraIsChangingListenerList.isEmpty()) {
+      for (MapView.OnCameraIsChangingListener onCameraIsChangingListener : onCameraIsChangingListenerList) {
+        onCameraIsChangingListener.onCameraIsChanging();
+      }
+    }
+  }
+
+  @Override
+  public void onCameraDidChange(boolean animated) {
+    if (!onCameraDidChangeListenerList.isEmpty()) {
+      for (MapView.OnCameraDidChangeListener onCameraDidChangeListener : onCameraDidChangeListenerList) {
+        onCameraDidChangeListener.onCameraDidChange(animated);
+      }
+    }
+  }
+
+  @Override
+  public void onWillStartLoadingMap() {
+    if (!onWillStartLoadingMapListenerList.isEmpty()) {
+      for (MapView.OnWillStartLoadingMapListener onWillStartLoadingMapListener : onWillStartLoadingMapListenerList) {
+        onWillStartLoadingMapListener.onWillStartLoadingMap();
+      }
+    }
+  }
+
+  @Override
+  public void onDidFinishLoadingMap() {
+    if (!onDidFinishLoadingMapListenerList.isEmpty()) {
+      for (MapView.OnDidFinishLoadingMapListener onDidFinishLoadingMapListener : onDidFinishLoadingMapListenerList) {
+        onDidFinishLoadingMapListener.onDidFinishLoadingMap();
+      }
+    }
+  }
+
+  @Override
+  public void onDidFailLoadingMap(String error) {
+    if (!onDidFailLoadingMapListenerList.isEmpty()) {
+      for (MapView.OnDidFailLoadingMapListener onDidFailLoadingMapListener : onDidFailLoadingMapListenerList) {
+        onDidFailLoadingMapListener.onDidFailLoadingMap(error);
+      }
+    }
+  }
+
+  @Override
+  public void onWillStartRenderingFrame() {
+    if (!onWillStartRenderingFrameList.isEmpty()) {
+      for (MapView.OnWillStartRenderingFrameListener listener : onWillStartRenderingFrameList) {
+        listener.onWillStartRenderingFrame();
+      }
+    }
+  }
+
+  @Override
+  public void onDidFinishRenderingFrame(boolean fully) {
+    if (!onDidFinishRenderingFrameList.isEmpty()) {
+      for (MapView.OnDidFinishRenderingFrameListener listener : onDidFinishRenderingFrameList) {
+        listener.onDidFinishRenderingFrame(fully);
+      }
+    }
+  }
+
+  @Override
+  public void onWillStartRenderingMap() {
+    if (!onWillStartRenderingMapListenerList.isEmpty()) {
+      for (MapView.OnWillStartRenderingMapListener listener : onWillStartRenderingMapListenerList) {
+        listener.onWillStartRenderingMap();
+      }
+    }
+  }
+
+  @Override
+  public void onDidFinishRenderingMap(boolean fully) {
+    if (!onDidFinishRenderingMapListenerList.isEmpty()) {
+      for (MapView.OnDidFinishRenderingMapListener listener : onDidFinishRenderingMapListenerList) {
+        listener.onDidFinishRenderingMap(fully);
+      }
+    }
+  }
+
+  @Override
+  public void onDidFinishLoadingStyle() {
+    if (!onDidFinishLoadingStyleListenerList.isEmpty()) {
+      for (MapView.OnDidFinishLoadingStyleListener listener : onDidFinishLoadingStyleListenerList) {
+        listener.onDidFinishLoadingStyle();
+      }
+    }
+  }
+
+  @Override
+  public void onSourceChanged(String sourceId) {
+    if (!onSourceChangedListenerList.isEmpty()) {
+      for (MapView.OnSourceChangedListener onSourceChangedListener : onSourceChangedListenerList) {
+        onSourceChangedListener.onSourceChangedListener(sourceId);
+      }
+    }
+  }
+
+  void addOnCameraWillChangeListener(MapView.OnCameraWillChangeListener listener) {
+    onCameraWillChangeListenerList.add(listener);
+  }
+
+  void removeOnCameraWillChangeListener(MapView.OnCameraWillChangeListener listener) {
+    onCameraWillChangeListenerList.remove(listener);
+  }
+
+  void addOnCameraIsChangingListener(MapView.OnCameraIsChangingListener listener) {
+    onCameraIsChangingListenerList.add(listener);
+  }
+
+  void removeOnCameraIsChangingListener(MapView.OnCameraIsChangingListener listener) {
+    onCameraIsChangingListenerList.remove(listener);
+  }
+
+  void addOnCameraDidChangeListener(MapView.OnCameraDidChangeListener listener) {
+    onCameraDidChangeListenerList.add(listener);
+  }
+
+  void removeOnCameraDidChangeListener(MapView.OnCameraDidChangeListener listener) {
+    onCameraDidChangeListenerList.remove(listener);
+  }
+
+  void addOnWillStartLoadingMapListener(MapView.OnWillStartLoadingMapListener listener) {
+    onWillStartLoadingMapListenerList.add(listener);
+  }
+
+  void removeOnWillStartLoadingMapListener(MapView.OnWillStartLoadingMapListener listener) {
+    onWillStartLoadingMapListenerList.remove(listener);
+  }
+
+  void addOnDidFinishLoadingMapListener(MapView.OnDidFinishLoadingMapListener listener) {
+    onDidFinishLoadingMapListenerList.add(listener);
+  }
+
+  void removeOnDidFinishLoadingMapListener(MapView.OnDidFinishLoadingMapListener listener) {
+    onDidFinishLoadingMapListenerList.remove(listener);
+  }
+
+  void addOnDidFailLoadingMapListener(MapView.OnDidFailLoadingMapListener listener) {
+    onDidFailLoadingMapListenerList.add(listener);
+  }
+
+  void removeOnDidFailLoadingMapListener(MapView.OnDidFailLoadingMapListener listener) {
+    onDidFailLoadingMapListenerList.remove(listener);
+  }
+
+  void addOnWillStartRenderingFrameListener(MapView.OnWillStartRenderingFrameListener listener) {
+    onWillStartRenderingFrameList.add(listener);
+  }
+
+  void removeOnWillStartRenderingFrameListener(MapView.OnWillStartRenderingFrameListener listener) {
+    onWillStartRenderingFrameList.remove(listener);
+  }
+
+  void addOnDidFinishRenderingFrameListener(MapView.OnDidFinishRenderingFrameListener listener) {
+    onDidFinishRenderingFrameList.add(listener);
+  }
+
+  void removeOnDidFinishRenderingFrameListener(MapView.OnDidFinishRenderingFrameListener listener) {
+    onDidFinishRenderingFrameList.remove(listener);
+  }
+
+  void addOnWillStartRenderingMapListener(MapView.OnWillStartRenderingMapListener listener) {
+    onWillStartRenderingMapListenerList.add(listener);
+  }
+
+  void removeOnWillStartRenderingMapListener(MapView.OnWillStartRenderingMapListener listener) {
+    onWillStartRenderingMapListenerList.remove(listener);
+  }
+
+  void addOnDidFinishRenderingMapListener(MapView.OnDidFinishRenderingMapListener listener) {
+    onDidFinishRenderingMapListenerList.add(listener);
+  }
+
+  void removeOnDidFinishRenderingMapListener(MapView.OnDidFinishRenderingMapListener listener) {
+    onDidFinishRenderingMapListenerList.remove(listener);
+  }
+
+  void addOnDidFinishLoadingStyleListener(MapView.OnDidFinishLoadingStyleListener listener) {
+    onDidFinishLoadingStyleListenerList.add(listener);
+  }
+
+  void removeOnDidFinishLoadingStyleListener(MapView.OnDidFinishLoadingStyleListener listener) {
+    onDidFinishLoadingStyleListenerList.remove(listener);
+  }
+
+  void addOnSourceChangedListener(MapView.OnSourceChangedListener listener) {
+    onSourceChangedListenerList.add(listener);
+  }
+
+  void removeOnSourceChangedListener(MapView.OnSourceChangedListener listener) {
+    onSourceChangedListenerList.remove(listener);
+  }
+
+  void clear() {
+    onCameraWillChangeListenerList.clear();
+    onCameraIsChangingListenerList.clear();
+    onCameraDidChangeListenerList.clear();
+    onWillStartLoadingMapListenerList.clear();
+    onDidFinishLoadingMapListenerList.clear();
+    onDidFailLoadingMapListenerList.clear();
+    onWillStartRenderingFrameList.clear();
+    onDidFinishRenderingFrameList.clear();
+    onWillStartRenderingMapListenerList.clear();
+    onDidFinishRenderingMapListenerList.clear();
+    onDidFinishLoadingStyleListenerList.clear();
+    onSourceChangedListenerList.clear();
+  }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -78,6 +78,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
 
   private final MapCallback mapCallback = new MapCallback();
   private final CopyOnWriteArrayList<OnMapChangedListener> onMapChangedListeners = new CopyOnWriteArrayList<>();
+  private final MapChangeReceiver mapChangeReceiver = new MapChangeReceiver();
 
   private NativeMapView nativeMapView;
   private MapboxMap mapboxMap;
@@ -321,7 +322,11 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     }
 
     boolean crossSourceCollisions = mapboxMapOptions.getCrossSourceCollisions();
-    nativeMapView = new NativeMapView(getContext(), getPixelRatio(), crossSourceCollisions, this, mapRenderer);
+    nativeMapView = new NativeMapView(
+      getContext(), getPixelRatio(), crossSourceCollisions, this, mapChangeReceiver, mapRenderer
+    );
+
+    // deprecated API
     nativeMapView.addOnMapChangedListener(change -> {
       // dispatch events to external listeners
       if (!onMapChangedListeners.isEmpty()) {
@@ -422,6 +427,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   @UiThread
   public void onDestroy() {
     destroyed = true;
+    mapChangeReceiver.clear();
     onMapChangedListeners.clear();
     mapCallback.clearOnMapReadyCallbacks();
 
@@ -682,6 +688,381 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   //
 
   /**
+   * Set a callback that's invoked when the camera region will change.
+   *
+   * @param listener The callback that's invoked when the camera region will change
+   */
+  public void addOnCameraWillChangeListener(OnCameraWillChangeListener listener) {
+    mapChangeReceiver.addOnCameraWillChangeListener(listener);
+  }
+
+  /**
+   * Remove a callback that's invoked when the camera region will change.
+   *
+   * @param listener The callback that's invoked when the camera region will change
+   */
+  public void removeOnCameraWillChangeListener(OnCameraWillChangeListener listener) {
+    mapChangeReceiver.removeOnCameraWillChangeListener(listener);
+  }
+
+  /**
+   * Set a callback that's invoked when the camera is changing.
+   *
+   * @param listener The callback that's invoked when the camera is changing
+   */
+  public void addOnCameraIsChangingListener(OnCameraIsChangingListener listener) {
+    mapChangeReceiver.addOnCameraIsChangingListener(listener);
+  }
+
+  /**
+   * Remove a callback that's invoked when the camera is changing.
+   *
+   * @param listener The callback that's invoked when the camera is changing
+   */
+  public void removeOnCameraIsChangingListener(OnCameraIsChangingListener listener) {
+    mapChangeReceiver.removeOnCameraIsChangingListener(listener);
+  }
+
+  /**
+   * Set a callback that's invoked when the camera region did change.
+   *
+   * @param listener The callback that's invoked when the camera region did change
+   */
+  public void addOnCameraDidChangeListener(OnCameraDidChangeListener listener) {
+    mapChangeReceiver.addOnCameraDidChangeListener(listener);
+  }
+
+  /**
+   * Set a callback that's invoked when the camera region did change.
+   *
+   * @param listener The callback that's invoked when the camera region did change
+   */
+  public void removeOnCameraDidChangeListener(OnCameraDidChangeListener listener) {
+    mapChangeReceiver.removeOnCameraDidChangeListener(listener);
+  }
+
+  /**
+   * Set a callback that's invoked when the map will start loading.
+   *
+   * @param listener The callback that's invoked when the map will start loading
+   */
+  public void addOnWillStartLoadingMapListener(OnWillStartLoadingMapListener listener) {
+    mapChangeReceiver.addOnWillStartLoadingMapListener(listener);
+  }
+
+  /**
+   * Set a callback that's invoked when the map will start loading.
+   *
+   * @param listener The callback that's invoked when the map will start loading
+   */
+  public void removeOnWillStartLoadingMapListener(OnWillStartLoadingMapListener listener) {
+    mapChangeReceiver.removeOnWillStartLoadingMapListener(listener);
+  }
+
+  /**
+   * Set a callback that's invoked when the map has finished loading.
+   *
+   * @param listener The callback that's invoked when the map has finished loading
+   */
+  public void addOnDidFinishLoadingMapListener(OnDidFinishLoadingMapListener listener) {
+    mapChangeReceiver.addOnDidFinishLoadingMapListener(listener);
+  }
+
+  /**
+   * Set a callback that's invoked when the map has finished loading.
+   *
+   * @param listener The callback that's invoked when the map has finished loading
+   */
+  public void removeOnDidFinishLoadingMapListener(OnDidFinishLoadingMapListener listener) {
+    mapChangeReceiver.removeOnDidFinishLoadingMapListener(listener);
+  }
+
+  /**
+   * Set a callback that's invoked when the map failed to load.
+   *
+   * @param listener The callback that's invoked when the map failed to load
+   */
+  public void addOnDidFailLoadingMapListener(OnDidFailLoadingMapListener listener) {
+    mapChangeReceiver.addOnDidFailLoadingMapListener(listener);
+  }
+
+  /**
+   * Set a callback that's invoked when the map failed to load.
+   *
+   * @param listener The callback that's invoked when the map failed to load
+   */
+  public void removeOnDidFailLoadingMapListener(OnDidFailLoadingMapListener listener) {
+    mapChangeReceiver.removeOnDidFailLoadingMapListener(listener);
+  }
+
+  /**
+   * Set a callback that's invoked when the map will start rendering a frame.
+   *
+   * @param listener The callback that's invoked when the camera will start rendering a frame
+   */
+  public void addOnWillStartRenderingFrameListener(OnWillStartRenderingFrameListener listener) {
+    mapChangeReceiver.addOnWillStartRenderingFrameListener(listener);
+  }
+
+  /**
+   * Set a callback that's invoked when the map will start rendering a frame.
+   *
+   * @param listener The callback that's invoked when the camera will start rendering a frame
+   */
+  public void removeOnWillStartRenderingFrameListener(OnWillStartRenderingFrameListener listener) {
+    mapChangeReceiver.removeOnWillStartRenderingFrameListener(listener);
+  }
+
+  /**
+   * Set a callback that's invoked when the map has finished rendering a frame.
+   *
+   * @param listener The callback that's invoked when the map has finished rendering a frame
+   */
+  public void addOnDidFinishRenderingFrameListener(OnDidFinishRenderingFrameListener listener) {
+    mapChangeReceiver.addOnDidFinishRenderingFrameListener(listener);
+  }
+
+  /**
+   * Set a callback that's invoked when the map has finished rendering a frame.
+   *
+   * @param listener The callback that's invoked when the map has finished rendering a frame
+   */
+  public void removeOnDidFinishRenderingFrameListener(OnDidFinishRenderingFrameListener listener) {
+    mapChangeReceiver.removeOnDidFinishRenderingFrameListener(listener);
+  }
+
+  /**
+   * Set a callback that's invoked when the map will start rendering.
+   *
+   * @param listener The callback that's invoked when the map will start rendering
+   */
+  public void addOnWillStartRenderingMapListener(OnWillStartRenderingMapListener listener) {
+    mapChangeReceiver.addOnWillStartRenderingMapListener(listener);
+  }
+
+  /**
+   * Set a callback that's invoked when the map will start rendering.
+   *
+   * @param listener The callback that's invoked when the map will start rendering
+   */
+  public void removeOnWillStartRenderingMapListener(OnWillStartRenderingMapListener listener) {
+    mapChangeReceiver.removeOnWillStartRenderingMapListener(listener);
+  }
+
+  /**
+   * Set a callback that's invoked when the map has finished rendering.
+   *
+   * @param listener The callback that's invoked when the map has finished rendering
+   */
+  public void addOnDidFinishRenderingMapListener(OnDidFinishRenderingMapListener listener) {
+    mapChangeReceiver.addOnDidFinishRenderingMapListener(listener);
+  }
+
+  /**
+   * Remove a callback that's invoked when the map has finished rendering.
+   *
+   * @param listener The callback that's invoked when the map has finished rendering
+   */
+  public void removeOnDidFinishRenderingMapListener(OnDidFinishRenderingMapListener listener) {
+    mapChangeReceiver.removeOnDidFinishRenderingMapListener(listener);
+  }
+
+  /**
+   * Set a callback that's invoked when the style has finished loading.
+   *
+   * @param listener The callback that's invoked when the style has finished loading
+   */
+  public void addOnDidFinishLoadingStyleListener(OnDidFinishLoadingStyleListener listener) {
+    mapChangeReceiver.addOnDidFinishLoadingStyleListener(listener);
+  }
+
+  /**
+   * Set a callback that's invoked when the style has finished loading.
+   *
+   * @param listener The callback that's invoked when the style has finished loading
+   */
+  public void removeOnDidFinishLoadingStyleListener(OnDidFinishLoadingStyleListener listener) {
+    mapChangeReceiver.removeOnDidFinishLoadingStyleListener(listener);
+  }
+
+  /**
+   * Set a callback that's invoked when a map source has changed.
+   *
+   * @param listener The callback that's invoked when the source has changed
+   */
+  public void addOnSourceChangedListener(OnSourceChangedListener listener) {
+    mapChangeReceiver.addOnSourceChangedListener(listener);
+  }
+
+  /**
+   * Set a callback that's invoked when a map source has changed.
+   *
+   * @param listener The callback that's invoked when the source has changed
+   */
+  public void removeOnSourceChangedListener(OnSourceChangedListener listener) {
+    mapChangeReceiver.removeOnSourceChangedListener(listener);
+  }
+
+  public interface OnCameraWillChangeListener {
+
+    /**
+     * Called when the camera region will change.
+     */
+    void onCameraWillChange(boolean animated);
+  }
+
+  /**
+   * Interface definition for a callback to be invoked when the camera is changing.
+   * <p>
+   * {@link MapView#addOnCameraIsChangingListener(OnCameraIsChangingListener)}
+   * </p>
+   */
+  public interface OnCameraIsChangingListener {
+    /**
+     * Called when the camera is changing.
+     */
+    void onCameraIsChanging();
+  }
+
+  /**
+   * Interface definition for a callback to be invoked when the map region did change.
+   * <p>
+   * {@link MapView#addOnCameraDidChangeListener(OnCameraDidChangeListener)}
+   * </p>
+   */
+  public interface OnCameraDidChangeListener {
+    /**
+     * Called when the camera did change.
+     */
+    void onCameraDidChange(boolean animated);
+  }
+
+  /**
+   * Interface definition for a callback to be invoked when the map will start loading.
+   * <p>
+   * {@link MapView#addOnWillStartLoadingMapListener(OnWillStartLoadingMapListener)}
+   * </p>
+   */
+  public interface OnWillStartLoadingMapListener {
+    /**
+     * Called when the map will start loading.
+     */
+    void onWillStartLoadingMap();
+  }
+
+  /**
+   * Interface definition for a callback to be invoked when the map finished loading.
+   * <p>
+   * {@link MapView#addOnDidFinishLoadingMapListener(OnDidFinishLoadingMapListener)}
+   * </p>
+   */
+  public interface OnDidFinishLoadingMapListener {
+    /**
+     * Called when the map has finished loading.
+     */
+    void onDidFinishLoadingMap();
+  }
+
+  /**
+   * Interface definition for a callback to be invoked when the map is changing.
+   * <p>
+   * {@link MapView#addOnDidFailLoadingMapListener(OnDidFailLoadingMapListener)}
+   * </p>
+   */
+  public interface OnDidFailLoadingMapListener {
+    /**
+     * Called when the map failed to load.
+     *
+     * @param errorMessage The reason why the map failed to load
+     */
+    void onDidFailLoadingMap(String errorMessage);
+  }
+
+  /**
+   * Interface definition for a callback to be invoked when the map will start rendering a frame.
+   * <p>
+   * {@link MapView#addOnWillStartRenderingFrameListener(OnWillStartRenderingFrameListener)}
+   * </p>
+   */
+  public interface OnWillStartRenderingFrameListener {
+    /**
+     * Called when the map will start rendering a frame.
+     */
+    void onWillStartRenderingFrame();
+  }
+
+  /**
+   * Interface definition for a callback to be invoked when the map finished rendering a frame.
+   * <p>
+   * {@link MapView#addOnDidFinishRenderingFrameListener(OnDidFinishRenderingFrameListener)}
+   * </p>
+   */
+  public interface OnDidFinishRenderingFrameListener {
+    /**
+     * Called when the map has finished rendering a frame
+     *
+     * @param fully true if all frames have been rendered, false if partially rendered
+     */
+    void onDidFinishRenderingFrame(boolean fully);
+  }
+
+  /**
+   * Interface definition for a callback to be invoked when the map will start rendering the map.
+   * <p>
+   * {@link MapView#addOnDidFailLoadingMapListener(OnDidFailLoadingMapListener)}
+   * </p>
+   */
+  public interface OnWillStartRenderingMapListener {
+    /**
+     * Called when the map will start rendering.
+     */
+    void onWillStartRenderingMap();
+  }
+
+  /**
+   * Interface definition for a callback to be invoked when the map is changing.
+   * <p>
+   * {@link MapView#addOnDidFinishRenderingMapListener(OnDidFinishRenderingMapListener)}
+   * </p>
+   */
+  public interface OnDidFinishRenderingMapListener {
+    /**
+     * Called when the map has finished rendering.
+     *
+     * @param fully true if map is fully rendered, false if fully rendered
+     */
+    void onDidFinishRenderingMap(boolean fully);
+  }
+
+  /**
+   * Interface definition for a callback to be invoked when the map has loaded the style.
+   * <p>
+   * {@link MapView#addOnDidFailLoadingMapListener(OnDidFailLoadingMapListener)}
+   * </p>
+   */
+  public interface OnDidFinishLoadingStyleListener {
+    /**
+     * Called when a style has finished loading.
+     */
+    void onDidFinishLoadingStyle();
+  }
+
+  /**
+   * Interface definition for a callback to be invoked when a map source has changed.
+   * <p>
+   * {@link MapView#addOnDidFailLoadingMapListener(OnDidFailLoadingMapListener)}
+   * </p>
+   */
+  public interface OnSourceChangedListener {
+    /**
+     * Called when a map source has changed.
+     *
+     * @param id the id of the source that has changed
+     */
+    void onSourceChangedListener(String id);
+  }
+
+  /**
    * <p>
    * Add a callback that's invoked when the displayed map view changes.
    * </p>
@@ -689,7 +1070,9 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
    *
    * @param listener The callback that's invoked on every frame rendered to the map view.
    * @see MapView#removeOnMapChangedListener(OnMapChangedListener)
+   * @deprecated use specific map change callbacks instead
    */
+  @Deprecated
   public void addOnMapChangedListener(@NonNull OnMapChangedListener listener) {
     onMapChangedListeners.add(listener);
   }
@@ -699,7 +1082,9 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
    *
    * @param listener The previously added callback to remove.
    * @see MapView#addOnMapChangedListener(OnMapChangedListener)
+   * @deprecated use specific map change callbacks instead
    */
+  @Deprecated
   public void removeOnMapChangedListener(@NonNull OnMapChangedListener listener) {
     if (onMapChangedListeners.contains(listener)) {
       onMapChangedListeners.remove(listener);
@@ -954,7 +1339,9 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
    *
    * @see MapView#addOnMapChangedListener(OnMapChangedListener)
    * @see MapView.MapChange
+   * @deprecated use specific map change callbacks instead
    */
+  @Deprecated
   public interface OnMapChangedListener {
     /**
      * Called when the displayed map view changes.

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -58,8 +58,11 @@ final class NativeMapView {
   // Used to validate if methods are called from the correct thread
   private final Thread thread;
 
-  // Used for callbacks
+  // Used for view callbacks
   private ViewCallback viewCallback;
+
+  // Used for map change callbacks
+  private StateCallback stateCallback;
 
   // Device density
   private final float pixelRatio;
@@ -85,17 +88,20 @@ final class NativeMapView {
   //
 
   public NativeMapView(final Context context, final boolean crossSourceCollisions, final ViewCallback viewCallback,
-                       final MapRenderer mapRenderer) {
-    this(context, context.getResources().getDisplayMetrics().density, crossSourceCollisions, viewCallback, mapRenderer);
+                       final StateCallback stateCallback, final MapRenderer mapRenderer) {
+    this(context, context.getResources().getDisplayMetrics().density, crossSourceCollisions, viewCallback,
+      stateCallback, mapRenderer);
   }
 
   public NativeMapView(final Context context, final float pixelRatio, final boolean crossSourceCollisions,
-                       final ViewCallback viewCallback, final MapRenderer mapRenderer) {
+                       final ViewCallback viewCallback, final StateCallback stateCallback,
+                       final MapRenderer mapRenderer) {
     this.mapRenderer = mapRenderer;
     this.viewCallback = viewCallback;
     this.fileSource = FileSource.getInstance(context);
     this.pixelRatio = pixelRatio;
     this.thread = Thread.currentThread();
+    this.stateCallback = stateCallback;
     nativeInitialize(this, fileSource, mapRenderer, pixelRatio, crossSourceCollisions);
   }
 
@@ -917,6 +923,90 @@ final class NativeMapView {
   }
 
   @Keep
+  private void onCameraWillChange(boolean animated) {
+    stateCallback.onCameraWillChange(animated);
+    // deprecated API
+    onMapChanged(animated ? MapView.REGION_WILL_CHANGE_ANIMATED : MapView.REGION_WILL_CHANGE);
+  }
+
+  @Keep
+  private void onCameraIsChanging() {
+    stateCallback.onCameraIsChanging();
+    // deprecated API
+    onMapChanged(MapView.REGION_IS_CHANGING);
+  }
+
+  @Keep
+  private void onCameraDidChange(boolean animated) {
+    stateCallback.onCameraDidChange(animated);
+    // deprecated API
+    onMapChanged(animated ? MapView.REGION_DID_CHANGE_ANIMATED : MapView.REGION_DID_CHANGE);
+  }
+
+  @Keep
+  private void onWillStartLoadingMap() {
+    stateCallback.onWillStartLoadingMap();
+    // deprecated API
+    onMapChanged(MapView.WILL_START_LOADING_MAP);
+  }
+
+  @Keep
+  private void onDidFinishLoadingMap() {
+    stateCallback.onDidFinishLoadingMap();
+    // deprecated API
+    onMapChanged(MapView.DID_FINISH_LOADING_MAP);
+  }
+
+  @Keep
+  private void onDidFailLoadingMap(String error) {
+    stateCallback.onDidFailLoadingMap(error);
+    // deprecated API
+    onMapChanged(MapView.DID_FAIL_LOADING_MAP);
+  }
+
+  @Keep
+  private void onWillStartRenderingFrame() {
+    stateCallback.onWillStartRenderingFrame();
+    // deprecated API
+    onMapChanged(MapView.WILL_START_RENDERING_FRAME);
+  }
+
+  @Keep
+  private void onDidFinishRenderingFrame(boolean fully) {
+    stateCallback.onDidFinishRenderingFrame(fully);
+    // deprecated API
+    onMapChanged(fully ? MapView.DID_FINISH_RENDERING_FRAME_FULLY_RENDERED : MapView.DID_FINISH_RENDERING_FRAME);
+  }
+
+  @Keep
+  private void onWillStartRenderingMap() {
+    stateCallback.onWillStartRenderingMap();
+    // deprecated API
+    onMapChanged(MapView.WILL_START_RENDERING_MAP);
+  }
+
+  @Keep
+  private void onDidFinishRenderingMap(boolean fully) {
+    stateCallback.onDidFinishRenderingMap(fully);
+    // deprecated API
+    onMapChanged(fully ? MapView.DID_FINISH_RENDERING_MAP_FULLY_RENDERED : MapView.DID_FINISH_RENDERING_MAP);
+  }
+
+  @Keep
+  private void onDidFinishLoadingStyle() {
+    stateCallback.onDidFinishLoadingStyle();
+    // deprecated API
+    onMapChanged(MapView.DID_FINISH_LOADING_STYLE);
+  }
+
+  @Keep
+  private void onSourceChanged(String sourceId) {
+    stateCallback.onSourceChanged(sourceId);
+    // deprecated API
+    onMapChanged(MapView.SOURCE_DID_CHANGE);
+  }
+
+  @Keep
   protected void onSnapshotReady(Bitmap mapContent) {
     if (checkState("OnSnapshotReady")) {
       return;
@@ -1220,10 +1310,17 @@ final class NativeMapView {
   // MapChangeEvents
   //
 
+  /**
+   * @deprecated use {@link StateCallback} instead
+   */
+  @Deprecated
   void addOnMapChangedListener(@NonNull MapView.OnMapChangedListener listener) {
     onMapChangedListeners.add(listener);
   }
 
+  /**
+   * @deprecated use {@link StateCallback} instead
+   */
   void removeOnMapChangedListener(@NonNull MapView.OnMapChangedListener listener) {
     if (onMapChangedListeners.contains(listener)) {
       onMapChangedListeners.remove(listener);
@@ -1323,5 +1420,31 @@ final class NativeMapView {
     int getHeight();
 
     Bitmap getViewContent();
+  }
+
+  public interface StateCallback {
+    void onCameraWillChange(boolean animated);
+
+    void onCameraIsChanging();
+
+    void onCameraDidChange(boolean animated);
+
+    void onWillStartLoadingMap();
+
+    void onDidFinishLoadingMap();
+
+    void onDidFailLoadingMap(String error);
+
+    void onWillStartRenderingFrame();
+
+    void onDidFinishRenderingFrame(boolean fully);
+
+    void onWillStartRenderingMap();
+
+    void onDidFinishRenderingMap(boolean fully);
+
+    void onDidFinishLoadingStyle();
+
+    void onSourceChanged(String sourceId);
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/MapChangeReceiverTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/MapChangeReceiverTest.java
@@ -1,0 +1,220 @@
+package com.mapbox.mapboxsdk.maps;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests integration of MapChangeDispatcher and see if events are correctly forwarded.
+ */
+public class MapChangeReceiverTest {
+
+  private static final String TEST_STRING = "mapChangeRandom";
+
+  private MapChangeReceiver mapChangeEventManager;
+
+  @Mock
+  private MapView.OnCameraWillChangeListener onCameraWillChangeListener;
+
+  @Mock
+  private MapView.OnCameraDidChangeListener onCameraDidChangeListener;
+
+  @Mock
+  private MapView.OnCameraIsChangingListener onCameraIsChangingListener;
+
+  @Mock
+  private MapView.OnWillStartLoadingMapListener onWillStartLoadingMapListener;
+
+  @Mock
+  private MapView.OnDidFinishLoadingMapListener onDidFinishLoadingMapListener;
+
+  @Mock
+  private MapView.OnDidFailLoadingMapListener onDidFailLoadingMapListener;
+
+  @Mock
+  private MapView.OnWillStartRenderingFrameListener onWillStartRenderingFrameListener;
+
+  @Mock
+  private MapView.OnDidFinishRenderingFrameListener onDidFinishRenderingFrameListener;
+
+  @Mock
+  private MapView.OnWillStartRenderingMapListener onWillStartRenderingMapListener;
+
+  @Mock
+  private MapView.OnDidFinishRenderingMapListener onDidFinishRenderingMapListener;
+
+  @Mock
+  private MapView.OnDidFinishLoadingStyleListener onDidFinishLoadingStyleListener;
+
+  @Mock
+  private MapView.OnSourceChangedListener onSourceChangedListener;
+
+  @Before
+  public void beforeTest() {
+    MockitoAnnotations.initMocks(this);
+    mapChangeEventManager = new MapChangeReceiver();
+  }
+
+  @Test
+  public void testOnCameraRegionWillChangeListener() {
+    mapChangeEventManager.addOnCameraWillChangeListener(onCameraWillChangeListener);
+    mapChangeEventManager.onCameraWillChange(false);
+    verify(onCameraWillChangeListener).onCameraWillChange(false);
+    mapChangeEventManager.removeOnCameraWillChangeListener(onCameraWillChangeListener);
+    mapChangeEventManager.onCameraWillChange(false);
+    verify(onCameraWillChangeListener).onCameraWillChange(false);
+  }
+
+  @Test
+  public void testOnCameraRegionWillChangeAnimatedListener() {
+    mapChangeEventManager.addOnCameraWillChangeListener(onCameraWillChangeListener);
+    mapChangeEventManager.onCameraWillChange(true);
+    verify(onCameraWillChangeListener).onCameraWillChange(true);
+    mapChangeEventManager.removeOnCameraWillChangeListener(onCameraWillChangeListener);
+    mapChangeEventManager.onCameraWillChange(true);
+    verify(onCameraWillChangeListener).onCameraWillChange(true);
+  }
+
+  @Test
+  public void testOnCameraIsChangingListener() {
+    mapChangeEventManager.addOnCameraIsChangingListener(onCameraIsChangingListener);
+    mapChangeEventManager.onCameraIsChanging();
+    verify(onCameraIsChangingListener).onCameraIsChanging();
+    mapChangeEventManager.removeOnCameraIsChangingListener(onCameraIsChangingListener);
+    mapChangeEventManager.onCameraIsChanging();
+    verify(onCameraIsChangingListener).onCameraIsChanging();
+  }
+
+  @Test
+  public void testOnCameraRegionDidChangeListener() {
+    mapChangeEventManager.addOnCameraDidChangeListener(onCameraDidChangeListener);
+    mapChangeEventManager.onCameraDidChange(false);
+    verify(onCameraDidChangeListener).onCameraDidChange(false);
+    mapChangeEventManager.removeOnCameraDidChangeListener(onCameraDidChangeListener);
+    mapChangeEventManager.onCameraDidChange(false);
+    verify(onCameraDidChangeListener).onCameraDidChange(false);
+  }
+
+  @Test
+  public void testOnCameraRegionDidChangeAnimatedListener() {
+    mapChangeEventManager.addOnCameraDidChangeListener(onCameraDidChangeListener);
+    mapChangeEventManager.onCameraDidChange(true);
+    verify(onCameraDidChangeListener).onCameraDidChange(true);
+    mapChangeEventManager.removeOnCameraDidChangeListener(onCameraDidChangeListener);
+    mapChangeEventManager.onCameraDidChange(true);
+    verify(onCameraDidChangeListener).onCameraDidChange(true);
+  }
+
+  @Test
+  public void testOnWillStartLoadingMapListener() {
+    mapChangeEventManager.addOnWillStartLoadingMapListener(onWillStartLoadingMapListener);
+    mapChangeEventManager.onWillStartLoadingMap();
+    verify(onWillStartLoadingMapListener).onWillStartLoadingMap();
+    mapChangeEventManager.removeOnWillStartLoadingMapListener(onWillStartLoadingMapListener);
+    mapChangeEventManager.onWillStartLoadingMap();
+    verify(onWillStartLoadingMapListener).onWillStartLoadingMap();
+  }
+
+  @Test
+  public void testOnDidFinishLoadingMapListener() {
+    mapChangeEventManager.addOnDidFinishLoadingMapListener(onDidFinishLoadingMapListener);
+    mapChangeEventManager.onDidFinishLoadingMap();
+    verify(onDidFinishLoadingMapListener).onDidFinishLoadingMap();
+    mapChangeEventManager.removeOnDidFinishLoadingMapListener(onDidFinishLoadingMapListener);
+    mapChangeEventManager.onDidFinishLoadingMap();
+    verify(onDidFinishLoadingMapListener).onDidFinishLoadingMap();
+  }
+
+  @Test
+  public void testOnDidFailLoadingMapListener() {
+    mapChangeEventManager.addOnDidFailLoadingMapListener(onDidFailLoadingMapListener);
+    mapChangeEventManager.onDidFailLoadingMap(TEST_STRING);
+    verify(onDidFailLoadingMapListener).onDidFailLoadingMap(TEST_STRING);
+    mapChangeEventManager.removeOnDidFailLoadingMapListener(onDidFailLoadingMapListener);
+    mapChangeEventManager.onDidFailLoadingMap(TEST_STRING);
+    verify(onDidFailLoadingMapListener).onDidFailLoadingMap(TEST_STRING);
+  }
+
+  @Test
+  public void testOnWillStartRenderingFrameListener() {
+    mapChangeEventManager.addOnWillStartRenderingFrameListener(onWillStartRenderingFrameListener);
+    mapChangeEventManager.onWillStartRenderingFrame();
+    verify(onWillStartRenderingFrameListener).onWillStartRenderingFrame();
+    mapChangeEventManager.removeOnWillStartRenderingFrameListener(onWillStartRenderingFrameListener);
+    mapChangeEventManager.onWillStartRenderingFrame();
+    verify(onWillStartRenderingFrameListener).onWillStartRenderingFrame();
+  }
+
+  @Test
+  public void testOnDidFinishRenderingFrameListener() {
+    mapChangeEventManager.addOnDidFinishRenderingFrameListener(onDidFinishRenderingFrameListener);
+    mapChangeEventManager.onDidFinishRenderingFrame(true);
+    verify(onDidFinishRenderingFrameListener).onDidFinishRenderingFrame(true);
+    mapChangeEventManager.removeOnDidFinishRenderingFrameListener(onDidFinishRenderingFrameListener);
+    mapChangeEventManager.onDidFinishRenderingFrame(true);
+    verify(onDidFinishRenderingFrameListener).onDidFinishRenderingFrame(true);
+  }
+
+  @Test
+  public void testOnDidFinishRenderingFrameFullyRenderedListener() {
+    mapChangeEventManager.addOnDidFinishRenderingFrameListener(onDidFinishRenderingFrameListener);
+    mapChangeEventManager.onDidFinishRenderingFrame(false);
+    verify(onDidFinishRenderingFrameListener).onDidFinishRenderingFrame(false);
+    mapChangeEventManager.removeOnDidFinishRenderingFrameListener(onDidFinishRenderingFrameListener);
+    mapChangeEventManager.onDidFinishRenderingFrame(false);
+    verify(onDidFinishRenderingFrameListener).onDidFinishRenderingFrame(false);
+  }
+
+  @Test
+  public void testOnWillStartRenderingMapListener() {
+    mapChangeEventManager.addOnWillStartRenderingMapListener(onWillStartRenderingMapListener);
+    mapChangeEventManager.onWillStartRenderingMap();
+    verify(onWillStartRenderingMapListener).onWillStartRenderingMap();
+    mapChangeEventManager.removeOnWillStartRenderingMapListener(onWillStartRenderingMapListener);
+    mapChangeEventManager.onWillStartRenderingMap();
+    verify(onWillStartRenderingMapListener).onWillStartRenderingMap();
+  }
+
+  @Test
+  public void testOnDidFinishRenderingMapListener() {
+    mapChangeEventManager.addOnDidFinishRenderingMapListener(onDidFinishRenderingMapListener);
+    mapChangeEventManager.onDidFinishRenderingMap(true);
+    verify(onDidFinishRenderingMapListener).onDidFinishRenderingMap(true);
+    mapChangeEventManager.removeOnDidFinishRenderingMapListener(onDidFinishRenderingMapListener);
+    mapChangeEventManager.onDidFinishRenderingMap(true);
+    verify(onDidFinishRenderingMapListener).onDidFinishRenderingMap(true);
+  }
+
+  @Test
+  public void testOnDidFinishRenderingMapFullyRenderedListener() {
+    mapChangeEventManager.addOnDidFinishRenderingMapListener(onDidFinishRenderingMapListener);
+    mapChangeEventManager.onDidFinishRenderingMap(false);
+    verify(onDidFinishRenderingMapListener).onDidFinishRenderingMap(false);
+    mapChangeEventManager.removeOnDidFinishRenderingMapListener(onDidFinishRenderingMapListener);
+    mapChangeEventManager.onDidFinishRenderingMap(false);
+    verify(onDidFinishRenderingMapListener).onDidFinishRenderingMap(false);
+  }
+
+  @Test
+  public void testOnDidFinishLoadingStyleListener() {
+    mapChangeEventManager.addOnDidFinishLoadingStyleListener(onDidFinishLoadingStyleListener);
+    mapChangeEventManager.onDidFinishLoadingStyle();
+    verify(onDidFinishLoadingStyleListener).onDidFinishLoadingStyle();
+    mapChangeEventManager.removeOnDidFinishLoadingStyleListener(onDidFinishLoadingStyleListener);
+    mapChangeEventManager.onDidFinishLoadingStyle();
+    verify(onDidFinishLoadingStyleListener).onDidFinishLoadingStyle();
+  }
+
+  @Test
+  public void testOnSourceChangedListener() {
+    mapChangeEventManager.addOnSourceChangedListener(onSourceChangedListener);
+    mapChangeEventManager.onSourceChanged(TEST_STRING);
+    verify(onSourceChangedListener).onSourceChangedListener(TEST_STRING);
+    mapChangeEventManager.removeOnSourceChangedListener(onSourceChangedListener);
+    mapChangeEventManager.onSourceChanged(TEST_STRING);
+    verify(onSourceChangedListener).onSourceChangedListener(TEST_STRING);
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/MapChangeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/MapChangeActivity.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.testapp.activity.maplayout;
 
 import android.os.Bundle;
-import android.support.v4.util.LongSparseArray;
 import android.support.v7.app.AppCompatActivity;
 
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
@@ -25,37 +24,25 @@ public class MapChangeActivity extends AppCompatActivity {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_map_simple);
 
-    final LongSparseArray<String> mapChangeMap = buildMapChangeStringValueSparseArray();
-    mapView = (MapView) findViewById(R.id.mapView);
-    mapView.addOnMapChangedListener(change -> Timber.e("OnMapChange: %s, %s", change, mapChangeMap.get(change)));
-
+    mapView = findViewById(R.id.mapView);
+    mapView.addOnCameraIsChangingListener(() -> Timber.v("OnCameraIsChanging"));
+    mapView.addOnCameraDidChangeListener(animated -> Timber.v("OnCamaraDidChange: animated: %s", animated));
+    mapView.addOnCameraWillChangeListener(animated -> Timber.v("OnCameraWilChange: animated: %s", animated));
+    mapView.addOnDidFailLoadingMapListener(errorMessage -> Timber.v("OnDidFailLoadingMap: %s", errorMessage));
+    mapView.addOnDidFinishLoadingMapListener(() -> Timber.v("OnDidFinishLoadingMap"));
+    mapView.addOnDidFinishLoadingStyleListener(() -> Timber.v("OnDidFinishLoadingStyle"));
+    mapView.addOnDidFinishRenderingFrameListener(fully -> Timber.v("OnDidFinishRenderingFrame: fully: %s", fully));
+    mapView.addOnDidFinishRenderingMapListener(fully -> Timber.v("OnDidFinishRenderingMap: fully: %s", fully));
+    mapView.addOnSourceChangedListener(sourceId -> Timber.v("OnSourceChangedListener: source with id: %s", sourceId));
+    mapView.addOnWillStartLoadingMapListener(() -> Timber.v("OnWillStartLoadingMap"));
+    mapView.addOnWillStartRenderingFrameListener(() -> Timber.v("OnWillStartRenderingFrame"));
+    mapView.addOnWillStartRenderingMapListener(() -> Timber.v("OnWillStartRenderingMap"));
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(map -> {
       mapboxMap = map;
       mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(
         new LatLng(55.754020, 37.620948), 12), 9000);
     });
-  }
-
-  private LongSparseArray<String> buildMapChangeStringValueSparseArray() {
-    LongSparseArray<String> mapChangeArray = new LongSparseArray<>();
-    mapChangeArray.put(MapView.REGION_WILL_CHANGE, "Region will change");
-    mapChangeArray.put(MapView.REGION_WILL_CHANGE_ANIMATED, "Region will change animated");
-    mapChangeArray.put(MapView.REGION_IS_CHANGING, "Region is changing");
-    mapChangeArray.put(MapView.REGION_DID_CHANGE, "Region did change");
-    mapChangeArray.put(MapView.REGION_DID_CHANGE_ANIMATED, "Region did change animated");
-    mapChangeArray.put(MapView.WILL_START_LOADING_MAP, "Will start loading map");
-    mapChangeArray.put(MapView.DID_FINISH_LOADING_MAP, "Did finish loading map");
-    mapChangeArray.put(MapView.DID_FAIL_LOADING_MAP, "Did fail loading map");
-    mapChangeArray.put(MapView.WILL_START_RENDERING_FRAME, "Will start rendering frame");
-    mapChangeArray.put(MapView.DID_FINISH_RENDERING_FRAME, "Did finish rendering frame");
-    mapChangeArray.put(MapView.DID_FINISH_RENDERING_FRAME_FULLY_RENDERED, "Did finish rendering frame fully rendered");
-    mapChangeArray.put(MapView.WILL_START_RENDERING_MAP, "Will start rendering map");
-    mapChangeArray.put(MapView.DID_FINISH_RENDERING_MAP, "Did finish rendering map");
-    mapChangeArray.put(MapView.DID_FINISH_RENDERING_MAP_FULLY_RENDERED, "Did finish rendering map fully rendered");
-    mapChangeArray.put(MapView.DID_FINISH_LOADING_STYLE, "Did finish loading style");
-    mapChangeArray.put(MapView.SOURCE_DID_CHANGE, "Source did change");
-    return mapChangeArray;
   }
 
   @Override

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -95,82 +95,114 @@ NativeMapView::~NativeMapView() {
     vm = nullptr;
 }
 
-/**
- * From mbgl::RendererBackend. Callback to java NativeMapView#onMapChanged(int).
- *
- * May be called from any thread
- */
-void NativeMapView::notifyMapChange(mbgl::MapChange change) {
+void NativeMapView::onCameraWillChange(MapObserver::CameraChangeMode mode) {
     assert(vm != nullptr);
 
     android::UniqueEnv _env = android::AttachEnv();
     static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
-    static auto onMapChanged = javaClass.GetMethod<void (int)>(*_env, "onMapChanged");
-    javaPeer.get(*_env).Call(*_env, onMapChanged, (int) change);
-}
-
-void NativeMapView::onCameraWillChange(MapObserver::CameraChangeMode mode) {
-    if (mode == MapObserver::CameraChangeMode::Immediate) {
-        notifyMapChange(MapChange::MapChangeRegionWillChange);
-    } else {
-        notifyMapChange(MapChange::MapChangeRegionWillChangeAnimated);
-    }
+    static auto onCameraWillChange = javaClass.GetMethod<void (jboolean)>(*_env, "onCameraWillChange");
+    javaPeer.get(*_env).Call(*_env, onCameraWillChange, (jboolean) (mode != MapObserver::CameraChangeMode::Immediate));
 }
 
 void NativeMapView::onCameraIsChanging() {
-    notifyMapChange(MapChange::MapChangeRegionIsChanging);
+    assert(vm != nullptr);
+
+    android::UniqueEnv _env = android::AttachEnv();
+    static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
+    static auto onCameraIsChanging = javaClass.GetMethod<void ()>(*_env, "onCameraIsChanging");
+    javaPeer.get(*_env).Call(*_env, onCameraIsChanging);
 }
 
 void NativeMapView::onCameraDidChange(MapObserver::CameraChangeMode mode) {
-    if (mode == MapObserver::CameraChangeMode::Immediate) {
-        notifyMapChange(MapChange::MapChangeRegionDidChange);
-    } else {
-        notifyMapChange(MapChange::MapChangeRegionDidChangeAnimated);
-    }
+    assert(vm != nullptr);
+
+    android::UniqueEnv _env = android::AttachEnv();
+    static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
+    static auto onCameraDidChange = javaClass.GetMethod<void (jboolean)>(*_env, "onCameraDidChange");
+    javaPeer.get(*_env).Call(*_env, onCameraDidChange, (jboolean) (mode != MapObserver::CameraChangeMode::Immediate));
 }
 
 void NativeMapView::onWillStartLoadingMap() {
-    notifyMapChange(MapChange::MapChangeWillStartLoadingMap);
+    assert(vm != nullptr);
+
+    android::UniqueEnv _env = android::AttachEnv();
+    static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
+    static auto onWillStartLoadingMap = javaClass.GetMethod<void ()>(*_env, "onWillStartLoadingMap");
+    javaPeer.get(*_env).Call(*_env, onWillStartLoadingMap);
 }
 
 void NativeMapView::onDidFinishLoadingMap() {
-    notifyMapChange(MapChange::MapChangeDidFinishLoadingMap);
-}
+    assert(vm != nullptr);
 
-void NativeMapView::onDidFailLoadingMap(std::exception_ptr) {
-    notifyMapChange(MapChange::MapChangeDidFailLoadingMap);
+    android::UniqueEnv _env = android::AttachEnv();
+    static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
+    static auto onDidFinishLoadingMap = javaClass.GetMethod<void ()>(*_env, "onDidFinishLoadingMap");
+    javaPeer.get(*_env).Call(*_env, onDidFinishLoadingMap);}
+
+void NativeMapView::onDidFailLoadingMap(std::exception_ptr exceptionPtr) {
+    assert(vm != nullptr);
+
+    android::UniqueEnv _env = android::AttachEnv();
+    static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
+    static auto onDidFailLoadingMap = javaClass.GetMethod<void (jni::String)>(*_env, "onDidFailLoadingMap");
+    std::string error = mbgl::util::toString(exceptionPtr);
+    javaPeer.get(*_env).Call(*_env, onDidFailLoadingMap, jni::Make<jni::String>(*_env, error));
 }
 
 void NativeMapView::onWillStartRenderingFrame() {
-    notifyMapChange(MapChange::MapChangeWillStartRenderingFrame);
+    assert(vm != nullptr);
+
+    android::UniqueEnv _env = android::AttachEnv();
+    static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
+    static auto onWillStartRenderingFrame = javaClass.GetMethod<void ()>(*_env, "onWillStartRenderingFrame");
+    javaPeer.get(*_env).Call(*_env, onWillStartRenderingFrame);
 }
 
 void NativeMapView::onDidFinishRenderingFrame(MapObserver::RenderMode mode) {
-    if (mode == MapObserver::RenderMode::Partial) {
-        notifyMapChange(MapChange::MapChangeDidFinishRenderingFrame);
-    } else {
-        notifyMapChange(MapChange::MapChangeDidFinishRenderingFrameFullyRendered);
-    }
+    assert(vm != nullptr);
+
+    android::UniqueEnv _env = android::AttachEnv();
+    static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
+    static auto onDidFinishRenderingFrame = javaClass.GetMethod<void (jboolean)>(*_env, "onDidFinishRenderingFrame");
+    javaPeer.get(*_env).Call(*_env, onDidFinishRenderingFrame, (jboolean) (mode != MapObserver::RenderMode::Partial));
 }
 
+
 void NativeMapView::onWillStartRenderingMap() {
-    notifyMapChange(MapChange::MapChangeWillStartRenderingMap);
+    assert(vm != nullptr);
+
+    android::UniqueEnv _env = android::AttachEnv();
+    static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
+    static auto onWillStartRenderingMap = javaClass.GetMethod<void ()>(*_env, "onWillStartRenderingMap");
+    javaPeer.get(*_env).Call(*_env, onWillStartRenderingMap);
 }
 
 void NativeMapView::onDidFinishRenderingMap(MapObserver::RenderMode mode) {
-    if (mode == MapObserver::RenderMode::Partial) {
-        notifyMapChange(MapChange::MapChangeDidFinishRenderingMap);
-    } else {
-        notifyMapChange(MapChange::MapChangeDidFinishRenderingMapFullyRendered);
-    }
+    assert(vm != nullptr);
+
+    android::UniqueEnv _env = android::AttachEnv();
+    static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
+    static auto onDidFinishRenderingMap = javaClass.GetMethod<void (jboolean)>(*_env, "onDidFinishRenderingMap");
+    javaPeer.get(*_env).Call(*_env, onDidFinishRenderingMap, (jboolean) (mode != MapObserver::RenderMode::Partial));
 }
 
 void NativeMapView::onDidFinishLoadingStyle() {
-    notifyMapChange(MapChange::MapChangeDidFinishLoadingStyle);
+    assert(vm != nullptr);
+
+    android::UniqueEnv _env = android::AttachEnv();
+    static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
+    static auto onDidFinishLoadingStyle = javaClass.GetMethod<void ()>(*_env, "onDidFinishLoadingStyle");
+    javaPeer.get(*_env).Call(*_env, onDidFinishLoadingStyle);
 }
 
-void NativeMapView::onSourceChanged(mbgl::style::Source&) {
-    notifyMapChange(MapChange::MapChangeSourceDidChange);
+void NativeMapView::onSourceChanged(mbgl::style::Source& source) {
+    assert(vm != nullptr);
+
+    android::UniqueEnv _env = android::AttachEnv();
+    static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
+    static auto onSourceChanged = javaClass.GetMethod<void (jni::String)>(*_env, "onSourceChanged");
+    auto sourceId = jni::Make<jni::String>(*_env, source.getID());
+    javaPeer.get(*_env).Call(*_env, onSourceChanged, sourceId);
 }
 
 // JNI Methods //

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -56,9 +56,6 @@ public:
 
     virtual ~NativeMapView();
 
-    // Deprecated //
-    void notifyMapChange(mbgl::MapChange);
-
     // mbgl::RendererBackend (mbgl::MapObserver) //
     void onCameraWillChange(MapObserver::CameraChangeMode) override;
     void onCameraIsChanging() override;


### PR DESCRIPTION
PR introduces separate callbacks for all the map change events instead of wiring them through the same OnMapChange callback. This avoids iterating all registered listener and limits the invocations of those callbacks for non-related events.

This PR also aligns naming of callbacks to match core naming more closely:

>  old: region is changing vs new: camera is changing 

Todo:
 - [x] integrate `native_map_view.cpp` changes
 - [x] backwards compatibility with old OnMapChange API
 - [x] add callback definition on java side
 - [x] callback integration (add/remove)
 - [x] deprecate notice
 - [x] add tests

Replaces obsolete closed PR in https://github.com/mapbox/mapbox-gl-native/pull/9498.

 