### PR TITLE
[ios] Fix divide-by-zero when setting FPS on iOS <10

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1219,6 +1219,10 @@ public:
         // CADisplayLink.frameInterval does not support more than 60 FPS (and
         // no device that supports >60 FPS ever supported iOS 9).
         NSInteger maximumFrameRate = 60;
+
+        // `0` is an alias for maximum frame rate.
+        newFrameRate = newFrameRate ?: maximumFrameRate;
+
         _displayLink.frameInterval = maximumFrameRate / MIN(newFrameRate, maximumFrameRate);
     }
 }

--- a/platform/ios/src/UIDevice+MGLAdditions.m
+++ b/platform/ios/src/UIDevice+MGLAdditions.m
@@ -4,6 +4,9 @@
 @implementation UIDevice (MGLAdditions)
 
 - (NSString *)modelString {
+#if TARGET_OS_SIMULATOR
+    return [[[NSProcessInfo processInfo] environment] objectForKey:@"SIMULATOR_MODEL_IDENTIFIER"];
+#else
     char *typeSpecifier = "hw.machine";
 
     size_t size;
@@ -16,6 +19,7 @@
 
     free(answer);
     return results;
+#endif
 }
 
 - (BOOL)mgl_isLegacyDevice {
@@ -42,8 +46,6 @@
             return YES;
         }
     }
-
-    // TODO: Also handle simulator using something like `ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"]`.
 
     return NO;
 }


### PR DESCRIPTION
Fixes #13037. On iOS 10+, `CADisplayLink.preferredFramesPerSecond` uses `0` to indicate “use native refresh rate to determine maximum frames per second”. This property isn’t available in iOS 9, so it’s necessary to avoid passing in `0` on the legacy code path.

Also added support for device-variable FPS in Simulator.

/cc @fabian-guerra 