### PR TITLE
[core] Use util::readFile for Local and Asset file sources

### DIFF
--- a/platform/default/asset_file_source.cpp
+++ b/platform/default/asset_file_source.cpp
@@ -44,12 +44,13 @@ public:
         } else if (result == -1 && errno == ENOENT) {
             response.error = std::make_unique<Response::Error>(Response::Error::Reason::NotFound);
         } else {
-            try {
-                response.data = std::make_shared<std::string>(util::read_file(path));
-            } catch (...) {
+            const auto data = util::readFile(path);
+            if (!data) {
                 response.error = std::make_unique<Response::Error>(
                     Response::Error::Reason::Other,
-                    util::toString(std::current_exception()));
+                    std::string("Cannot read file ") + path);
+            } else {
+                response.data = std::make_shared<std::string>(std::move(*data));
             }
         }
 

--- a/platform/default/local_file_source.cpp
+++ b/platform/default/local_file_source.cpp
@@ -46,12 +46,13 @@ public:
         } else if (result == -1 && errno == ENOENT) {
             response.error = std::make_unique<Response::Error>(Response::Error::Reason::NotFound);
         } else {
-            try {
-                response.data = std::make_shared<std::string>(util::read_file(path));
-            } catch (...) {
+            const auto data = util::readFile(path);
+            if (!data) {
                 response.error = std::make_unique<Response::Error>(
                     Response::Error::Reason::Other,
-                    util::toString(std::current_exception()));
+                    std::string("Cannot read file ") + path);
+            } else {
+                response.data = std::make_shared<std::string>(std::move(*data));
             }
         }
 


### PR DESCRIPTION
Use exception free util::readFile instead of util::read_file for LocalFileSource and AssetFileSource implementations.

Fixes: #9244