### PR TITLE
[ios] Release gazpacho cherry-picks of #13051 & #13029

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -5254,10 +5254,15 @@ public:
         self.targetCoordinate,
     };
     UIEdgeInsets inset = self.edgePaddingForFollowingWithCourse;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if (self.userLocationVerticalAlignment == MGLAnnotationVerticalAlignmentCenter)
     {
         inset.bottom = CGRectGetMaxY(self.bounds) - CGRectGetMidY(self.contentFrame);
     }
+#pragma clang diagnostic pop
+
     [self _setVisibleCoordinates:foci
                            count:sizeof(foci) / sizeof(foci[0])
                      edgePadding:inset
@@ -5317,10 +5322,13 @@ public:
 
         if (direction >= 0)
         {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             if (self.userLocationVerticalAlignment == MGLAnnotationVerticalAlignmentTop)
             {
                 direction += 180;
             }
+#pragma clang diagnostic pop
         }
     }
     return direction;
@@ -6012,7 +6020,9 @@ public:
     }
     
     CGPoint center = CGPointMake(CGRectGetMidX(contentFrame), CGRectGetMidY(contentFrame));
-    
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     switch (self.userLocationVerticalAlignment) {
         case MGLAnnotationVerticalAlignmentCenter:
             break;
@@ -6023,6 +6033,7 @@ public:
             center.y = CGRectGetMaxY(contentFrame);
             break;
     }
+#pragma clang dianostic pop
     
     return center;
 }

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1219,6 +1219,10 @@ public:
         // CADisplayLink.frameInterval does not support more than 60 FPS (and
         // no device that supports >60 FPS ever supported iOS 9).
         NSInteger maximumFrameRate = 60;
+
+        // `0` is an alias for maximum frame rate.
+        newFrameRate = newFrameRate ?: maximumFrameRate;
+
         _displayLink.frameInterval = maximumFrameRate / MIN(newFrameRate, maximumFrameRate);
     }
 }

--- a/platform/ios/src/UIDevice+MGLAdditions.m
+++ b/platform/ios/src/UIDevice+MGLAdditions.m
@@ -4,6 +4,9 @@
 @implementation UIDevice (MGLAdditions)
 
 - (NSString *)modelString {
+#if TARGET_OS_SIMULATOR
+    return [[[NSProcessInfo processInfo] environment] objectForKey:@"SIMULATOR_MODEL_IDENTIFIER"];
+#else
     char *typeSpecifier = "hw.machine";
 
     size_t size;
@@ -16,6 +19,7 @@
 
     free(answer);
     return results;
+#endif
 }
 
 - (BOOL)mgl_isLegacyDevice {
@@ -42,8 +46,6 @@
             return YES;
         }
     }
-
-    // TODO: Also handle simulator using something like `ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"]`.
 
     return NO;
 }


### PR DESCRIPTION
Cherry-picks into `release-gazpacho` for `ios-v4.5.0`.

- #13051 — Fix divide-by-zero when setting FPS on iOS <10.
- #13029 — Ignore deprecation warnings for `MGLMapView.userLocationVerticalAlignment`.

/cc @julianrex @fabian-guerra 