### PR TITLE
[core] Use util::readFile for Local and Asset file sources

### DIFF
--- a/cmake/filesource-files.txt
+++ b/cmake/filesource-files.txt
@@ -10,6 +10,8 @@ src/mbgl/storage/asset_file_source.hpp
 platform/default/src/mbgl/storage/asset_file_source.cpp
 src/mbgl/storage/local_file_source.hpp
 platform/default/src/mbgl/storage/local_file_source.cpp
+platform/default/include/mbgl/storage/local_file_request.hpp
+platform/default/src/mbgl/storage/local_file_request.cpp
 
 # Offline
 include/mbgl/storage/offline.hpp

--- a/platform/default/include/mbgl/storage/local_file_request.hpp
+++ b/platform/default/include/mbgl/storage/local_file_request.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <mbgl/util/string.hpp>
+
+namespace mbgl {
+
+template <typename>
+class ActorRef;
+class FileSourceRequest;
+
+void requestLocalFile(const std::string&, ActorRef<FileSourceRequest>);
+
+} // namespace mbgl

--- a/platform/default/src/mbgl/storage/asset_file_source.cpp
+++ b/platform/default/src/mbgl/storage/asset_file_source.cpp
@@ -44,12 +44,13 @@ public:
         } else if (result == -1 && errno == ENOENT) {
             response.error = std::make_unique<Response::Error>(Response::Error::Reason::NotFound);
         } else {
-            try {
-                response.data = std::make_shared<std::string>(util::read_file(path));
-            } catch (...) {
+            auto data = util::readFile(path);
+            if (!data) {
                 response.error = std::make_unique<Response::Error>(
                     Response::Error::Reason::Other,
-                    util::toString(std::current_exception()));
+                    std::string("Cannot read file ") + path);
+            } else {
+                response.data = std::make_shared<std::string>(std::move(*data));
             }
         }
 

--- a/platform/default/src/mbgl/storage/asset_file_source.cpp
+++ b/platform/default/src/mbgl/storage/asset_file_source.cpp
@@ -1,14 +1,10 @@
 #include <mbgl/storage/asset_file_source.hpp>
 #include <mbgl/storage/file_source_request.hpp>
+#include <mbgl/storage/local_file_request.hpp>
 #include <mbgl/storage/response.hpp>
 #include <mbgl/util/string.hpp>
 #include <mbgl/util/thread.hpp>
 #include <mbgl/util/url.hpp>
-#include <mbgl/util/util.hpp>
-#include <mbgl/util/io.hpp>
-
-#include <sys/types.h>
-#include <sys/stat.h>
 
 namespace {
 
@@ -25,9 +21,8 @@ public:
     }
 
     void request(const std::string& url, ActorRef<FileSourceRequest> req) {
-        Response response;
-
         if (!acceptsURL(url)) {
+            Response response;
             response.error = std::make_unique<Response::Error>(Response::Error::Reason::Other,
                                                                "Invalid asset URL");
             req.invoke(&FileSourceRequest::setResponse, response);
@@ -36,25 +31,7 @@ public:
 
         // Cut off the protocol and prefix with path.
         const auto path = root + "/" + mbgl::util::percentDecode(url.substr(assetProtocol.size()));
-        struct stat buf;
-        int result = stat(path.c_str(), &buf);
-
-        if (result == 0 && (S_IFDIR & buf.st_mode)) {
-            response.error = std::make_unique<Response::Error>(Response::Error::Reason::NotFound);
-        } else if (result == -1 && errno == ENOENT) {
-            response.error = std::make_unique<Response::Error>(Response::Error::Reason::NotFound);
-        } else {
-            auto data = util::readFile(path);
-            if (!data) {
-                response.error = std::make_unique<Response::Error>(
-                    Response::Error::Reason::Other,
-                    std::string("Cannot read file ") + path);
-            } else {
-                response.data = std::make_shared<std::string>(std::move(*data));
-            }
-        }
-
-        req.invoke(&FileSourceRequest::setResponse, response);
+        requestLocalFile(path, std::move(req));
     }
 
 private:

--- a/platform/default/src/mbgl/storage/local_file_request.cpp
+++ b/platform/default/src/mbgl/storage/local_file_request.cpp
@@ -1,0 +1,37 @@
+#include <mbgl/storage/file_source_request.hpp>
+#include <mbgl/storage/response.hpp>
+#include <mbgl/util/io.hpp>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#if defined(_WINDOWS) && !defined(S_ISDIR)
+#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
+#endif
+
+namespace mbgl {
+
+void requestLocalFile(const std::string& path, ActorRef<FileSourceRequest> req) {
+    Response response;
+    struct stat buf;
+    int result = stat(path.c_str(), &buf);
+
+    if (result == 0 && (S_IFDIR & buf.st_mode)) {
+        response.error = std::make_unique<Response::Error>(Response::Error::Reason::NotFound);
+    } else if (result == -1 && errno == ENOENT) {
+        response.error = std::make_unique<Response::Error>(Response::Error::Reason::NotFound);
+    } else {
+        auto data = util::readFile(path);
+        if (!data) {
+            response.error = std::make_unique<Response::Error>(
+                Response::Error::Reason::Other,
+                std::string("Cannot read file ") + path);
+        } else {
+            response.data = std::make_shared<std::string>(std::move(*data));
+        }
+    }
+
+    req.invoke(&FileSourceRequest::setResponse, response);
+}
+
+} // namespace mbgl

--- a/platform/default/src/mbgl/storage/local_file_source.cpp
+++ b/platform/default/src/mbgl/storage/local_file_source.cpp
@@ -46,12 +46,13 @@ public:
         } else if (result == -1 && errno == ENOENT) {
             response.error = std::make_unique<Response::Error>(Response::Error::Reason::NotFound);
         } else {
-            try {
-                response.data = std::make_shared<std::string>(util::read_file(path));
-            } catch (...) {
+            auto data = util::readFile(path);
+            if (!data) {
                 response.error = std::make_unique<Response::Error>(
                     Response::Error::Reason::Other,
-                    util::toString(std::current_exception()));
+                    std::string("Cannot read file ") + path);
+            } else {
+                response.data = std::make_shared<std::string>(std::move(*data));
             }
         }
 

--- a/platform/default/src/mbgl/storage/local_file_source.cpp
+++ b/platform/default/src/mbgl/storage/local_file_source.cpp
@@ -1,18 +1,10 @@
 #include <mbgl/storage/local_file_source.hpp>
 #include <mbgl/storage/file_source_request.hpp>
+#include <mbgl/storage/local_file_request.hpp>
 #include <mbgl/storage/response.hpp>
 #include <mbgl/util/string.hpp>
 #include <mbgl/util/thread.hpp>
 #include <mbgl/util/url.hpp>
-#include <mbgl/util/util.hpp>
-#include <mbgl/util/io.hpp>
-
-#include <sys/types.h>
-#include <sys/stat.h>
-
-#if defined(_WINDOWS) && !defined(S_ISDIR)
-#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
-#endif
 
 namespace {
 
@@ -27,9 +19,8 @@ public:
     Impl(ActorRef<Impl>) {}
 
     void request(const std::string& url, ActorRef<FileSourceRequest> req) {
-        Response response;
-
         if (!acceptsURL(url)) {
+            Response response;
             response.error = std::make_unique<Response::Error>(Response::Error::Reason::Other,
                                                                "Invalid file URL");
             req.invoke(&FileSourceRequest::setResponse, response);
@@ -38,27 +29,8 @@ public:
 
         // Cut off the protocol and prefix with path.
         const auto path = mbgl::util::percentDecode(url.substr(fileProtocol.size()));
-        struct stat buf;
-        int result = stat(path.c_str(), &buf);
-
-        if (result == 0 && S_ISDIR(buf.st_mode)) {
-            response.error = std::make_unique<Response::Error>(Response::Error::Reason::NotFound);
-        } else if (result == -1 && errno == ENOENT) {
-            response.error = std::make_unique<Response::Error>(Response::Error::Reason::NotFound);
-        } else {
-            auto data = util::readFile(path);
-            if (!data) {
-                response.error = std::make_unique<Response::Error>(
-                    Response::Error::Reason::Other,
-                    std::string("Cannot read file ") + path);
-            } else {
-                response.data = std::make_shared<std::string>(std::move(*data));
-            }
-        }
-
-        req.invoke(&FileSourceRequest::setResponse, response);
+        requestLocalFile(path, std::move(req));
     }
-
 };
 
 LocalFileSource::LocalFileSource()


### PR DESCRIPTION
Use exception free util::readFile instead of util::read_file for LocalFileSource and AssetFileSource implementations.

Fixes: #9244