### PR TITLE
gazpacho backport: Changelog for 6.6.0

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Mapbox welcomes participation and contributions from everyone.  If you'd like to do so please see the [`Contributing Guide`](https://github.com/mapbox/mapbox-gl-native/blob/master/CONTRIBUTING.md) first to get started.
 
-## master
+## 6.6.0 - October 11, 2018
 - Fixed an issue where fill and line layers would occasionally flicker on zoom ([#12982](https://github.com/mapbox/mapbox-gl-native/pull/12982))
 
 ## 6.6.0-beta.1 - October 3, 2018


### PR DESCRIPTION
Backports #13082 to [`release-gazpacho`](https://github.com/mapbox/mapbox-gl-native/tree/release-gazpacho)

---

