### PR TITLE
[Core] Add tests for bounding boxes that cross the antimeridian

### DIFF
--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -554,6 +554,7 @@ TEST(Transform, DefaultTransform) {
 TEST(Transform, LatLngBounds) {
     const LatLng nullIsland {};
     const LatLng sanFrancisco { 37.7749, -122.4194 };
+    const LatLng wrappedSanFrancisco { 37.7749, 237.5806};
 
     Transform transform;
     transform.resize({ 1000, 1000 });
@@ -579,6 +580,11 @@ TEST(Transform, LatLngBounds) {
     ASSERT_EQ(transform.getLatLng(), sanFrancisco);
 
     transform.setLatLngBounds(LatLngBounds::hull({ -90.0, -180.0 }, { 0.0, 180.0 }));
+    // ensure a wrapped coordinate works
+    transform.setLatLng(wrappedSanFrancisco);
+    ASSERT_EQ(transform.getLatLng().latitude(), 0.0);
+    ASSERT_EQ(transform.getLatLng().longitude(), sanFrancisco.longitude());
+
     transform.setLatLng(sanFrancisco);
     ASSERT_EQ(transform.getLatLng().latitude(), 0.0);
     ASSERT_EQ(transform.getLatLng().longitude(), sanFrancisco.longitude());

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -554,7 +554,6 @@ TEST(Transform, DefaultTransform) {
 TEST(Transform, LatLngBounds) {
     const LatLng nullIsland {};
     const LatLng sanFrancisco { 37.7749, -122.4194 };
-    const LatLng wrappedSanFrancisco { 37.7749, 237.5806};
 
     Transform transform;
     transform.resize({ 1000, 1000 });
@@ -580,10 +579,15 @@ TEST(Transform, LatLngBounds) {
     ASSERT_EQ(transform.getLatLng(), sanFrancisco);
 
     transform.setLatLngBounds(LatLngBounds::hull({ -90.0, -180.0 }, { 0.0, 180.0 }));
-    // ensure a wrapped coordinate works
-    transform.setLatLng(wrappedSanFrancisco);
-    ASSERT_EQ(transform.getLatLng().latitude(), 0.0);
-    ASSERT_EQ(transform.getLatLng().longitude(), sanFrancisco.longitude());
+    // test that we can limit the bounds vertically while allowing unlimited horizontal scrolling
+    transform.setLatLng(LatLng {45, -180});
+    ASSERT_EQ(transform.getLatLng().latitude(), 0);
+    ASSERT_EQ(transform.getLatLng().longitude(), -180);
+
+    transform.setLatLngBounds(LatLngBounds::hull({ -90.0, -180.0 }, { 0.0, 179.0 }));
+    transform.setLatLng(LatLng {45, 179.5});
+    ASSERT_EQ(transform.getLatLng().latitude(), 0);
+    ASSERT_EQ(transform.getLatLng().longitude(), 179);
 
     transform.setLatLng(sanFrancisco);
     ASSERT_EQ(transform.getLatLng().latitude(), 0.0);

--- a/test/util/geo.test.cpp
+++ b/test/util/geo.test.cpp
@@ -187,6 +187,33 @@ TEST(LatLng, Boundaries) {
     ASSERT_DOUBLE_EQ(0.5, coordinate.longitude());
 }
 
+TEST(LatLngBounds, Antimeridian) {
+    // Bounding box less than 180° that does not cross antimeridian
+                                     //southwest     northeast
+    auto boundsNormalLT = LatLngBounds::hull({-90.0, -20.0},{90.0, 20.0});
+
+    ASSERT_DOUBLE_EQ(-20, boundsNormalLT.west());
+    ASSERT_DOUBLE_EQ(20, boundsNormalLT.east());
+
+    // Bounding box greater than 180° that does not cross antimeridian
+    auto boundsNormalGT = LatLngBounds::hull({-90.0, -100.0},{90.0, 100.0});
+
+    ASSERT_DOUBLE_EQ(-100, boundsNormalGT.west());
+    ASSERT_DOUBLE_EQ(100, boundsNormalGT.east());
+
+    // Bounding box less than 180° that crosses the antimeridian
+    auto boundsAntimeridianLT = LatLngBounds::hull({-90.0, -200.0},{90.0, 160.0});
+
+    ASSERT_DOUBLE_EQ(-200, boundsAntimeridianLT.west());
+    ASSERT_DOUBLE_EQ(160, boundsAntimeridianLT.east());
+
+    // Bounding box greater than 180° that crosses the antimeridian
+    auto boundsAntimeridianGT = LatLngBounds::hull({-90.0, -270.0},{90.0, 0.0});
+
+    ASSERT_DOUBLE_EQ(-270, boundsAntimeridianGT.west());
+    ASSERT_DOUBLE_EQ(0, boundsAntimeridianGT.east());
+}
+
 TEST(LatLngBounds, FromTileID) {
     {
         const LatLngBounds bounds{ CanonicalTileID(0, 0, 0) };
@@ -283,11 +310,11 @@ TEST(LatLngBounds, ContainsBounds_Wrapped) {
     auto unwrapped = LatLngBounds::hull({10.0, 170.0}, { -10.0, -175.0});
     EXPECT_FALSE(bounds.contains(unwrapped));
     EXPECT_FALSE(bounds.contains(unwrapped, LatLng::Wrapped));
-    
+
     unwrapped = LatLngBounds::hull({10.0, 0.0} , {-10.0, -10.0});
     EXPECT_FALSE(bounds.contains(unwrapped));
     EXPECT_FALSE(bounds.contains(unwrapped, LatLng::Wrapped));
-    
+
     unwrapped = LatLngBounds::hull({10.0, -165.0}, {-10.0, -180.0});
     EXPECT_TRUE(bounds.contains(unwrapped));
     EXPECT_TRUE(bounds.contains(unwrapped, LatLng::Wrapped));


### PR DESCRIPTION
The behavior of bounding boxes that cross the antimeridian doesn't seem well-defined or well-coordinated across all our platforms. The vagueness is the source of several bugs and significant confusion. These tests should help define consistent behavior that will make reasoning about the problem easier while avoiding introducing new bugs.

cc @ansis 