### PR TITLE
Store alternative .so files for symbolicating crash reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -612,7 +612,7 @@ run-android-ui-test-$1-%: platform/android/gradle/configuration.gradle
 # Symbolicate native stack trace with the specified abi
 .PHONY: android-ndk-stack-$1
 android-ndk-stack-$1: platform/android/gradle/configuration.gradle
-	adb logcat | ndk-stack -sym platform/android/MapboxGLAndroidSDK/build/intermediates/cmake/debug/obj/$2/
+	adb logcat | ndk-stack -sym platform/android/MapboxGLAndroidSDK/build/intermediates/transforms/mergeJniLibs/release/0/lib/$2/
 
 # Run render tests with pixelmatch
 .PHONY: run-android-render-test-$1

--- a/circle.yml
+++ b/circle.yml
@@ -554,9 +554,9 @@ jobs:
       - run:
           name: gzip debugable .so files
           command: |
-            gzip platform/android/MapboxGLAndroidSDK/build/intermediates/cmake/debug/obj/armeabi-v7a/libmapbox-gl.so
+            gzip platform/android/MapboxGLAndroidSDK/build/intermediates/transforms/mergeJniLibs/debug/0/lib/armeabi-v7a/libmapbox-gl.so
       - store_artifacts:
-          path: platform/android/MapboxGLAndroidSDK/build/intermediates/cmake/debug/obj/armeabi-v7a/libmapbox-gl.so.gz
+          path: platform/android/MapboxGLAndroidSDK/build/intermediates/transforms/mergeJniLibs/debug/0/lib/armeabi-v7a/libmapbox-gl.so.gz
       - store_artifacts:
           path: platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/debug
           destination: .
@@ -613,21 +613,21 @@ jobs:
       - run:
           name: gzip debugable .so files
           command: |
-            gzip platform/android/MapboxGLAndroidSDK/build/intermediates/cmake/release/obj/arm64-v8a/libmapbox-gl.so && \
-            gzip platform/android/MapboxGLAndroidSDK/build/intermediates/cmake/release/obj/armeabi-v7a/libmapbox-gl.so && \
-            gzip platform/android/MapboxGLAndroidSDK/build/intermediates/cmake/release/obj/x86/libmapbox-gl.so && \
-            gzip platform/android/MapboxGLAndroidSDK/build/intermediates/cmake/release/obj/x86_64/libmapbox-gl.so
+            gzip platform/android/MapboxGLAndroidSDK/build/intermediates/transforms/mergeJniLibs/release/0/lib/arm64-v8a/libmapbox-gl.so && \
+            gzip platform/android/MapboxGLAndroidSDK/build/intermediates/transforms/mergeJniLibs/release/0/lib/armeabi-v7a/libmapbox-gl.so && \
+            gzip platform/android/MapboxGLAndroidSDK/build/intermediates/transforms/mergeJniLibs/release/0/lib/x86/libmapbox-gl.so && \
+            gzip platform/android/MapboxGLAndroidSDK/build/intermediates/transforms/mergeJniLibs/release/0/lib/x86_64/libmapbox-gl.so
       - store_artifacts:
           path: platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/release
           destination: .
       - store_artifacts:
-          path: platform/android/MapboxGLAndroidSDK/build/intermediates/cmake/release/obj/arm64-v8a/libmapbox-gl.so.gz
+          path: platform/android/MapboxGLAndroidSDK/build/intermediates/transforms/mergeJniLibs/release/0/lib/arm64-v8a/libmapbox-gl.so.gz
       - store_artifacts:
-          path: platform/android/MapboxGLAndroidSDK/build/intermediates/cmake/release/obj/armeabi-v7a/libmapbox-gl.so.gz
+          path: platform/android/MapboxGLAndroidSDK/build/intermediates/transforms/mergeJniLibs/release/0/lib/armeabi-v7a/libmapbox-gl.so.gz
       - store_artifacts:
-          path: platform/android/MapboxGLAndroidSDK/build/intermediates/cmake/release/obj/x86/libmapbox-gl.so.gz
+          path: platform/android/MapboxGLAndroidSDK/build/intermediates/transforms/mergeJniLibs/release/0/lib/x86/libmapbox-gl.so.gz
       - store_artifacts:
-          path: platform/android/MapboxGLAndroidSDK/build/intermediates/cmake/release/obj/x86_64/libmapbox-gl.so.gz
+          path: platform/android/MapboxGLAndroidSDK/build/intermediates/transforms/mergeJniLibs/release/0/lib/x86_64/libmapbox-gl.so.gz
       - run:
           name: Record size
           command: platform/android/scripts/metrics.sh


### PR DESCRIPTION
Follow up from https://github.com/mapbox/mapbox-gl-native/pull/12628, that PR introduced storing .so files as part of our build. Trying to run ndk-stack on the stored .so files have resulted in incorrect stacktraces, see https://github.com/mapbox/mapbox-gl-native/issues/12485#issuecomment-415798877. This PR takes stores other .so files as part of our CI build. 