### PR TITLE
Remove obsolete catch block in getLayerAs

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -312,7 +312,7 @@ public final class MapboxMap {
   }
 
   /**
-   * Tries to cast the Layer to T, returns null if it's another type.
+   * Tries to cast the Layer to T, throws ClassCastException if it's another type.
    *
    * @param layerId the layer id used to look up a layer
    * @param <T>     the generic attribute of a Layer
@@ -320,15 +320,8 @@ public final class MapboxMap {
    */
   @Nullable
   public <T extends Layer> T getLayerAs(@NonNull String layerId) {
-    try {
-      // noinspection unchecked
-      return (T) nativeMapView.getLayer(layerId);
-    } catch (ClassCastException exception) {
-      String message = String.format("Layer: %s is a different type: ", layerId);
-      Logger.e(TAG, message, exception);
-      MapStrictMode.strictModeViolation(message, exception);
-      return null;
-    }
+    // noinspection unchecked
+    return (T) nativeMapView.getLayer(layerId);
   }
 
   /**


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/12473, removed catch clause as noted in the issue: 
>  `(T)` is reduced to `(Layer)` at Runtime and it just makes the compiler happy, but changes nothing.  Therefor the catch block will never run.  This method removes some need for the callers to cast, but it will not protect them from CastClassExceptions.

The cast class exception is expected, provides same developer experience as with similar constructs in other libraries as for example ButterKnife. 