### PR TITLE
[android] track offline download start and offline download complete event

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/TelemetryDefinition.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/TelemetryDefinition.java
@@ -1,6 +1,10 @@
 package com.mapbox.mapboxsdk.maps;
 
+import android.support.annotation.NonNull;
+
 import com.mapbox.mapboxsdk.offline.OfflineRegionDefinition;
+import com.mapbox.mapboxsdk.offline.OfflineRegionError;
+import com.mapbox.mapboxsdk.offline.OfflineRegionStatus;
 
 /**
  * Definition of TelemetryImpl collection
@@ -41,9 +45,26 @@ public interface TelemetryDefinition {
   boolean setSessionIdRotationInterval(int interval);
 
   /**
-   * Register an end-user offline download event.
+   * Register an end-user offline download start event.
    *
    * @param offlineDefinition the offline region definition
    */
-  void onCreateOfflineRegion(OfflineRegionDefinition offlineDefinition);
+  void onOfflineDownloadStart(@NonNull OfflineRegionDefinition offlineDefinition);
+
+  /**
+   * Register an end-user offline download end with success event.
+   *
+   * @param offlineDefinition the offline region definition
+   */
+  void onOfflineDownloadEndSuccess(@NonNull OfflineRegionDefinition offlineDefinition,
+                                   @NonNull OfflineRegionStatus status);
+
+  /**
+   * Register an end-user offline download end with failure event.
+   *
+   * @param offlineDefinition the offline region definition
+   */
+  void onOfflineDownloadEndFailure(@NonNull OfflineRegionDefinition offlineDefinition,
+                                   @NonNull OfflineRegionError error);
+
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
@@ -10,11 +10,9 @@ import android.support.annotation.NonNull;
 
 import com.mapbox.mapboxsdk.LibraryLoader;
 import com.mapbox.mapboxsdk.MapStrictMode;
-import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
 import com.mapbox.mapboxsdk.log.Logger;
-import com.mapbox.mapboxsdk.maps.TelemetryDefinition;
 import com.mapbox.mapboxsdk.net.ConnectivityReceiver;
 import com.mapbox.mapboxsdk.storage.FileSource;
 import com.mapbox.mapboxsdk.utils.FileUtils;
@@ -419,12 +417,6 @@ public class OfflineManager {
         });
       }
     });
-
-    TelemetryDefinition telemetry = Mapbox.getTelemetry();
-    if (telemetry != null) {
-      LatLngBounds bounds = definition.getBounds();
-      telemetry.onCreateOfflineRegion(definition);
-    }
   }
 
   /**


### PR DESCRIPTION
[android] track offline download start and offline download end (success, failure)
instead of offline download created

takes advantage of https://github.com/mapbox/mapbox-events-android/pull/239 