### PR TITLE
Avoid printing exception for valid code execution path

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
@@ -82,15 +82,18 @@ public class FileSource {
   @Deprecated
   public static String getCachePath(@NonNull Context context) {
     // Default value
-    boolean setStorageExternal = MapboxConstants.DEFAULT_SET_STORAGE_EXTERNAL;
+    boolean isExternalStorageConfiguration = MapboxConstants.DEFAULT_SET_STORAGE_EXTERNAL;
 
     try {
       // Try getting a custom value from the app Manifest
       ApplicationInfo appInfo = context.getPackageManager().getApplicationInfo(context.getPackageName(),
         PackageManager.GET_META_DATA);
-      setStorageExternal = appInfo.metaData.getBoolean(
-        MapboxConstants.KEY_META_DATA_SET_STORAGE_EXTERNAL,
-        MapboxConstants.DEFAULT_SET_STORAGE_EXTERNAL);
+      if (appInfo.metaData != null) {
+        isExternalStorageConfiguration = appInfo.metaData.getBoolean(
+          MapboxConstants.KEY_META_DATA_SET_STORAGE_EXTERNAL,
+          MapboxConstants.DEFAULT_SET_STORAGE_EXTERNAL
+        );
+      }
     } catch (PackageManager.NameNotFoundException exception) {
       Logger.e(TAG, "Failed to read the package metadata: ", exception);
       MapStrictMode.strictModeViolation(exception);
@@ -100,7 +103,7 @@ public class FileSource {
     }
 
     String cachePath = null;
-    if (setStorageExternal && isExternalStorageReadable()) {
+    if (isExternalStorageConfiguration && isExternalStorageReadable()) {
       try {
         // Try getting the external storage path
         cachePath = context.getExternalFilesDir(null).getAbsolutePath();


### PR DESCRIPTION
This PR avoids printing the exception message as:

```java
 java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.os.BaseBundle.getBoolean(java.lang.String, boolean)' on a null object reference
        at com.mapbox.mapboxsdk.storage.FileSource.getCachePath(FileSource.java:88)
        at com.mapbox.mapboxsdk.storage.FileSource$FileDirsPathsTask.doInBackground(FileSource.java:165)
        at com.mapbox.mapboxsdk.storage.FileSource$FileDirsPathsTask.doInBackground(FileSource.java:155)
        at android.os.AsyncTask$2.call(AsyncTask.java:304)
        at java.util.concurrent.FutureTask.run(FutureTask.java:237)
        at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:243)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1133)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
        at java.lang.Thread.run(Thread.java:761)
```

This occurs when the hosting app doesn't have any metadata setup in their `AndroidManifest.xml`. This is a valid use-case, this PR avoids throwing the exception, and the code change doesn't impact the business logic involved. 