### PR TITLE
[Core] Ensure queryRenderedFeatures accounts for icons with *-offset …

### DIFF
--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -93,7 +93,6 @@
   "render-tests/fill-pattern/update-feature-state": "skip - port https://github.com/mapbox/mapbox-gl-js/pull/6263 - needs issue",
   "render-tests/geojson/inline-linestring-fill": "current behavior is arbitrary",
   "render-tests/geojson/inline-polygon-symbol": "behavior needs reconciliation with gl-js",
-  "render-tests/icon-rotate/with-offset": "https://github.com/mapbox/mapbox-gl-native/issues/11872",
   "render-tests/mixed-zoom/z10-z11": "https://github.com/mapbox/mapbox-gl-native/issues/10397",
   "render-tests/raster-masking/overlapping-zoom": "https://github.com/mapbox/mapbox-gl-native/issues/10195",
   "render-tests/real-world/bangkok": "https://github.com/mapbox/mapbox-gl-native/issues/10412",

--- a/scripts/changelog_staging/queryrenderedfeatures-with-icon-rotate.json
+++ b/scripts/changelog_staging/queryrenderedfeatures-with-icon-rotate.json
@@ -1,0 +1,4 @@
+{
+    "core": "Fix bug in which using `icon-rotate` and `icon-offset` together prevented `queryRenderedFeatures` from returning the symbol",
+    "issue": 12909
+}

--- a/src/mbgl/layout/symbol_instance.cpp
+++ b/src/mbgl/layout/symbol_instance.cpp
@@ -23,15 +23,16 @@ SymbolInstance::SymbolInstance(Anchor& anchor_,
                                const std::size_t layoutFeatureIndex_,
                                const std::size_t dataFeatureIndex_,
                                const std::u16string& key_,
-                               const float overscaling) :
+                               const float overscaling,
+                               const float rotate) :
     anchor(anchor_),
     line(line_),
     hasText(false),
     hasIcon(shapedIcon),
 
     // Create the collision features that will be used to check whether this symbol instance can be placed
-    textCollisionFeature(line_, anchor, shapedTextOrientations.first, textBoxScale, textPadding, textPlacement, indexedFeature, overscaling),
-    iconCollisionFeature(line_, anchor, shapedIcon, iconBoxScale, iconPadding, indexedFeature),
+    textCollisionFeature(line_, anchor, shapedTextOrientations.first, textBoxScale, textPadding, textPlacement, indexedFeature, overscaling, rotate),
+    iconCollisionFeature(line_, anchor, shapedIcon, iconBoxScale, iconPadding, indexedFeature, rotate),
     layoutFeatureIndex(layoutFeatureIndex_),
     dataFeatureIndex(dataFeatureIndex_),
     textOffset(textOffset_),

--- a/src/mbgl/layout/symbol_instance.hpp
+++ b/src/mbgl/layout/symbol_instance.hpp
@@ -31,7 +31,8 @@ public:
                    const std::size_t layoutFeatureIndex,
                    const std::size_t dataFeatureIndex,
                    const std::u16string& key,
-                   const float overscaling);
+                   const float overscaling,
+                   const float rotate);
 
     Anchor anchor;
     GeometryCoordinates line;

--- a/src/mbgl/text/collision_feature.cpp
+++ b/src/mbgl/text/collision_feature.cpp
@@ -37,6 +37,8 @@ CollisionFeature::CollisionFeature(const GeometryCoordinates& line,
         bboxifyLabel(line, anchorPoint, anchor.segment, length, height, overscaling);
     } else {
         if (rotate) {
+            // Account for *-rotate in point collision boxes
+            // Doesn't account for icon-text-fit
             const float rotateRadians = rotate * M_PI / 180.0;
 
             const Point<float> tl = util::rotate(Point<float>(x1, y1), rotateRadians);
@@ -44,6 +46,9 @@ CollisionFeature::CollisionFeature(const GeometryCoordinates& line,
             const Point<float> bl = util::rotate(Point<float>(x1, y2), rotateRadians);
             const Point<float> br = util::rotate(Point<float>(x2, y2), rotateRadians);
             
+            // Collision features require an "on-axis" geometry,
+            // so take the envelope of the rotated geometry
+            // (may be quite large for wide labels rotated 45 degrees)
             const float xMin = std::min({tl.x, tr.x, bl.x, br.x});
             const float xMax = std::max({tl.x, tr.x, bl.x, br.x});
             const float yMin = std::min({tl.y, tr.y, bl.y, br.y});

--- a/src/mbgl/text/collision_feature.hpp
+++ b/src/mbgl/text/collision_feature.hpp
@@ -52,8 +52,9 @@ public:
                      const float padding,
                      const style::SymbolPlacementType placement,
                      const IndexedSubfeature& indexedFeature_,
-                     const float overscaling)
-        : CollisionFeature(line, anchor, shapedText.top, shapedText.bottom, shapedText.left, shapedText.right, boxScale, padding, placement, indexedFeature_, overscaling) {}
+                     const float overscaling,
+                     const float rotate)
+        : CollisionFeature(line, anchor, shapedText.top, shapedText.bottom, shapedText.left, shapedText.right, boxScale, padding, placement, indexedFeature_, overscaling, rotate) {}
 
     // for icons
     // Icons collision features are always SymbolPlacementType::Point, which means the collision feature
@@ -66,7 +67,8 @@ public:
                      optional<PositionedIcon> shapedIcon,
                      const float boxScale,
                      const float padding,
-                     const IndexedSubfeature& indexedFeature_)
+                     const IndexedSubfeature& indexedFeature_,
+                     const float rotate)
         : CollisionFeature(line, anchor,
                            (shapedIcon ? shapedIcon->top() : 0),
                            (shapedIcon ? shapedIcon->bottom() : 0),
@@ -75,7 +77,7 @@ public:
                            boxScale,
                            padding,
                            style::SymbolPlacementType::Point,
-                           indexedFeature_, 1) {}
+                           indexedFeature_, 1, rotate) {}
 
     CollisionFeature(const GeometryCoordinates& line,
                      const Anchor&,
@@ -87,7 +89,8 @@ public:
                      const float padding,
                      const style::SymbolPlacementType,
                      IndexedSubfeature,
-                     const float overscaling);
+                     const float overscaling,
+                     const float rotate);
 
     std::vector<CollisionBox> boxes;
     IndexedSubfeature indexedFeature;

--- a/test/text/cross_tile_symbol_index.test.cpp
+++ b/test/text/cross_tile_symbol_index.test.cpp
@@ -11,7 +11,7 @@ SymbolInstance makeSymbolInstance(float x, float y, std::u16string key) {
     style::SymbolLayoutProperties::Evaluated layout_;
     IndexedSubfeature subfeature(0, "", "", 0);
     Anchor anchor(x, y, 0, 0);
-    return {anchor, line, shaping, {}, layout_, 0, 0, 0, style::SymbolPlacementType::Point, {{0, 0}}, 0, 0, {{0, 0}}, positions, subfeature, 0, 0, key, 0 };
+    return {anchor, line, shaping, {}, layout_, 0, 0, 0, style::SymbolPlacementType::Point, {{0, 0}}, 0, 0, {{0, 0}}, positions, subfeature, 0, 0, key, 0, 0};
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/12909 and implements https://github.com/mapbox/mapbox-gl-native/issues/11872

This is a pretty straightforward port of https://github.com/mapbox/mapbox-gl-js/pull/6631 which allows icons with `icon-rotate` and `icon-offset` to show up in `queryRenderedFeatures` results as expected.
