### PR TITLE
Use appcompat configuration to support vector drawables

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/CompassView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/CompassView.java
@@ -1,6 +1,5 @@
 package com.mapbox.mapboxsdk.maps.widgets;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
@@ -8,10 +7,10 @@ import android.support.annotation.Nullable;
 import android.support.v4.view.ViewCompat;
 import android.support.v4.view.ViewPropertyAnimatorCompat;
 import android.support.v4.view.ViewPropertyAnimatorListenerAdapter;
+import android.support.v7.widget.AppCompatImageView;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageView;
 
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 
@@ -24,8 +23,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
  * use {@link com.mapbox.mapboxsdk.maps.UiSettings}.
  * </p>
  */
-@SuppressLint("AppCompatCustomView")
-public final class CompassView extends ImageView implements Runnable {
+public final class CompassView extends AppCompatImageView implements Runnable {
 
   public static final long TIME_WAIT_IDLE = 500;
   public static final long TIME_MAP_NORTH_ANIMATION = 150;

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_internal.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_internal.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android">
+<merge xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <FrameLayout
         android:id="@+id/markerViewContainer"
@@ -20,7 +20,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:contentDescription="@null"
-        android:src="@drawable/mapbox_logo_icon"/>
+        app:srcCompat="@drawable/mapbox_logo_icon"/>
 
     <ImageView
         android:visibility="gone"
@@ -31,6 +31,6 @@
         android:clickable="true"
         android:focusable="true"
         android:contentDescription="@string/mapbox_attributionsIconContentDescription"
-        android:src="@drawable/mapbox_info_bg_selector"/>
+        app:srcCompat="@drawable/mapbox_info_bg_selector"/>
 
 </merge>


### PR DESCRIPTION
Plausible fix for https://github.com/mapbox/mapbox-gl-native/issues/13099, capturing from [this](https://stackoverflow.com/questions/35819290/invalid-drawable-tag-vector#36015208) SO post.  Still need to test this on an Android 4.4 device, don't have access to one atm. 