### PR TITLE
Add 'putResourceForURL' for pre-warming ambient cache

### DIFF
--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -160,10 +160,20 @@ public:
      * expired while the file source was paused.
      */
     void resume();
+    
+    /*
+     * Insert the provided resource into the ambient cache
+     *
+     * Consumers of the resource will expect the uncompressed version; the
+     * OfflineDatabase will determine whether to compress the data on disk.
+     * This call is asynchronous: the data may not be immediately available
+     * for in-progress requests, although subsequent requests should have
+     * access to the cached data.
+     */
+    void put(const Resource&, const Response&);
 
     // For testing only.
     void setOnlineStatus(bool);
-    void put(const Resource&, const Response&);
 
     class Impl;
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
@@ -480,7 +480,9 @@ public class OfflineManager {
    * @param modified Optional "modified" response header, in seconds since 1970, or 0 if not set
    * @param expires Optional "expires" response header, in seconds since 1970, or 0 if not set
    * @param etag Optional "entity tag" response header
+   * @param mustRevalidate Indicates whether response can be used after it's stale
    */
   @Keep
-  public native void putResourceWithUrl(String url, byte[] data, long modified, long expires, String etag);
+  public native void putResourceWithUrl(String url, byte[] data, long modified, long expires,
+                                        String etag, boolean mustRevalidate);
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
@@ -462,4 +462,25 @@ public class OfflineManager {
 
   @Keep
   private native void mergeOfflineRegions(FileSource fileSource, String path, MergeOfflineRegionsCallback callback);
+
+  /**
+   * Insert the provided resource into the ambient cache
+   * This method mimics the caching that would take place if the equivalent
+   * resource were requested in the process of map rendering.
+   * Use this method to pre-warm the cache with resources you know
+   * will be requested.
+   *
+   * This call is asynchronous: the data may not be immediately available
+   * for in-progress requests, although subsequent requests should have
+   * access to the cached data.
+   *
+   * @param url The URL of the resource to insert
+   * @param data Response data to store for this resource. Data is expected to be uncompressed;
+   *             internally, the cache will compress data as necessary.
+   * @param modified Optional "modified" response header, in seconds since 1970, or 0 if not set
+   * @param expires Optional "expires" response header, in seconds since 1970, or 0 if not set
+   * @param etag Optional "entity tag" response header
+   */
+  @Keep
+  public native void putResourceWithUrl(String url, byte[] data, long modified, long expires, String etag);
 }

--- a/platform/android/src/offline/offline_manager.cpp
+++ b/platform/android/src/offline/offline_manager.cpp
@@ -207,13 +207,15 @@ void OfflineManager::putResourceWithUrl(jni::JNIEnv& env,
                                         const jni::Array<jni::jbyte>& arr,
                                         jlong modified,
                                         jlong expires,
-                                        const jni::String& eTag_) {
+                                        const jni::String& eTag_,
+                                        jboolean mustRevalidate) {
     auto url =  jni::Make<std::string>(env, url_);
     auto data = std::make_shared<std::string>(arr.Length(env), char());
     jni::GetArrayRegion(env, *arr, 0, data->size(), reinterpret_cast<jbyte*>(&(*data)[0]));
     mbgl::Resource resource(mbgl::Resource::Kind::Unknown, url);
     mbgl::Response response;
     response.data = data;
+    response.mustRevalidate = mustRevalidate;
     if (eTag_) {
         response.etag = jni::Make<std::string>(env, eTag_);
     }

--- a/platform/android/src/offline/offline_manager.hpp
+++ b/platform/android/src/offline/offline_manager.hpp
@@ -80,7 +80,8 @@ public:
                             const jni::Array<jni::jbyte>& data,
                             jlong modified,
                             jlong expires,
-                            const jni::String& eTag);
+                            const jni::String& eTag,
+                            jboolean mustRevalidate);
 
 
 private:

--- a/platform/android/src/offline/offline_manager.hpp
+++ b/platform/android/src/offline/offline_manager.hpp
@@ -75,6 +75,14 @@ public:
                              const jni::String&,
                              const jni::Object<MergeOfflineRegionsCallback>&);
 
+    void putResourceWithUrl(jni::JNIEnv&,
+                            const jni::String& url,
+                            const jni::Array<jni::jbyte>& data,
+                            jlong modified,
+                            jlong expires,
+                            const jni::String& eTag);
+
+
 private:
     mbgl::DefaultFileSource& fileSource;
 };

--- a/platform/darwin/src/MGLOfflineStorage.h
+++ b/platform/darwin/src/MGLOfflineStorage.h
@@ -339,6 +339,26 @@ MGL_EXPORT
  */
 @property (nonatomic, readonly) unsigned long long countOfBytesCompleted;
 
+/*
+ * Insert the provided resource into the ambient cache
+ * This method mimics the caching that would take place if the equivalent
+ * resource were requested in the process of map rendering.
+ * Use this method to pre-warm the cache with resources you know
+ * will be requested.
+ *
+ * This call is asynchronous: the data may not be immediately available
+ * for in-progress requests, although subsequent requests should have
+ * access to the cached data.
+ *
+ * @param url The URL of the resource to insert
+ * @param data Response data to store for this resource. Data is expected to be uncompressed; internally, the cache will compress data as necessary.
+ * @param modified Optional "modified" response header
+ * @param expires Optional "expires" response header
+ * @param etag Optional "entity tag" response header
+ */
+-(void)putResourceWithUrl:(NSURL *)url data:(NSData *)data modified:(NSDate * _Nullable)modified expires:(NSDate * _Nullable)expires etag:(NSString * _Nullable)etag;
+
+
 @end
 
 /**

--- a/platform/darwin/src/MGLOfflineStorage.h
+++ b/platform/darwin/src/MGLOfflineStorage.h
@@ -355,8 +355,9 @@ MGL_EXPORT
  * @param modified Optional "modified" response header
  * @param expires Optional "expires" response header
  * @param etag Optional "entity tag" response header
+ * @param mustRevalidate Indicates whether response can be used after it's stale
  */
--(void)putResourceWithUrl:(NSURL *)url data:(NSData *)data modified:(NSDate * _Nullable)modified expires:(NSDate * _Nullable)expires etag:(NSString * _Nullable)etag;
+-(void)putResourceWithUrl:(NSURL *)url data:(NSData *)data modified:(NSDate * _Nullable)modified expires:(NSDate * _Nullable)expires etag:(NSString * _Nullable)etag mustRevalidate:(BOOL)mustRevalidate;
 
 
 @end

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -473,21 +473,22 @@ const MGLExceptionName MGLUnsupportedRegionTypeException = @"MGLUnsupportedRegio
     return attributes.fileSize;
 }
 
--(void)putResourceWithUrl:(NSURL *)url data:(NSData *)data modified:(NSDate * _Nullable)modified expires:(NSDate * _Nullable)expires etag:(NSString * _Nullable)etag {
+-(void)putResourceWithUrl:(NSURL *)url data:(NSData *)data modified:(NSDate * _Nullable)modified expires:(NSDate * _Nullable)expires etag:(NSString * _Nullable)etag mustRevalidate:(BOOL)mustRevalidate {
     mbgl::Resource resource(mbgl::Resource::Kind::Unknown, [[url absoluteString] UTF8String]);
     mbgl::Response response;
     response.data = std::make_shared<std::string>(static_cast<const char*>(data.bytes), data.length);
+    response.mustRevalidate = mustRevalidate;
     
     if (etag) {
         response.etag = std::string([etag UTF8String]);
     }
     
     if (modified) {
-        response.modified = mbgl::util::now() + std::chrono::duration_cast<mbgl::Seconds>(MGLDurationFromTimeInterval(modified.timeIntervalSinceNow));
+        response.modified = mbgl::Timestamp() + std::chrono::duration_cast<mbgl::Seconds>(MGLDurationFromTimeInterval(modified.timeIntervalSince1970));
     }
     
     if (expires) {
-        response.expires = mbgl::util::now() + std::chrono::duration_cast<mbgl::Seconds>(MGLDurationFromTimeInterval(expires.timeIntervalSinceNow));
+        response.expires = mbgl::Timestamp() + std::chrono::duration_cast<mbgl::Seconds>(MGLDurationFromTimeInterval(expires.timeIntervalSince1970));
     }
     
     _mbglFileSource->put(resource, response);

--- a/platform/default/default_file_source.cpp
+++ b/platform/default/default_file_source.cpp
@@ -302,15 +302,15 @@ void DefaultFileSource::pause() {
 void DefaultFileSource::resume() {
     impl->resume();
 }
+    
+void DefaultFileSource::put(const Resource& resource, const Response& response) {
+    impl->actor().invoke(&Impl::put, resource, response);
+}
 
 // For testing only:
 
 void DefaultFileSource::setOnlineStatus(const bool status) {
     impl->actor().invoke(&Impl::setOnlineStatus, status);
-}
-
-void DefaultFileSource::put(const Resource& resource, const Response& response) {
-    impl->actor().invoke(&Impl::put, resource, response);
 }
 
 } // namespace mbgl

--- a/scripts/changelog_staging/put-offline-resource.json
+++ b/scripts/changelog_staging/put-offline-resource.json
@@ -1,0 +1,5 @@
+{
+    "darwin": "Add 'putResourceWithURL' method to MGLOfflineStorage to support pre-warming the ambient cache.",
+    "android": "Add 'putResourceWithURL' method to OfflineManager to support pre-warming the ambient cache.",
+    "issue": 13022
+}


### PR DESCRIPTION
This is an attempt at addressing issue https://github.com/mapbox/mapbox-gl-native/issues/13022 by directly exposing the `DefaultFileSource::put` method to the iOS/Android Offline functionality. This PR borrows heavily from @halset's https://github.com/mapbox/mapbox-gl-native/pull/12217, but is smaller in scope in that it's not trying to do bulk insertions (which can now be accomplished with the "mergeOfflineRegion" functionality).

This is a kind of awkward fit with `MGLOfflineStorage` and `OfflineManager` because at least the way we present the interface they're not directly related to the ambient cache (even though under the hood they're managing the same database). But it also felt like overkill to add a whole set of extra "ambient cache" wrapper classes.

@tobrun, I haven't figured out a good way to write tests for this on the Android side -- because we don't expose FileSource requests through to the Java code, there's no easy way to verify that after calling "put" the data round trips through the cache. Do you have any suggestions? The one thing I could think of is to write an explicit test function that does the verification on the C++ side instead of the Java side, but that feels pretty clunky.

/cc @ansis @kkaefer 