### PR TITLE
[tests, darwin] Standardize on 10 second timeout for map loading

### DIFF
--- a/platform/darwin/test/MGLDocumentationExampleTests.swift
+++ b/platform/darwin/test/MGLDocumentationExampleTests.swift
@@ -34,7 +34,7 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
         mapView = MGLMapView(frame: CGRect(x: 0, y: 0, width: 256, height: 256), styleURL: MGLDocumentationExampleTests.styleURL)
         mapView.delegate = self
         styleLoadingExpectation = expectation(description: "Map view should finish loading style")
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
 
     override func tearDown() {

--- a/platform/darwin/test/MGLDocumentationGuideTests.swift
+++ b/platform/darwin/test/MGLDocumentationGuideTests.swift
@@ -37,7 +37,7 @@ class MGLDocumentationGuideTests: XCTestCase, MGLMapViewDelegate {
         mapView = MGLMapView(frame: CGRect(x: 0, y: 0, width: 256, height: 256), styleURL: styleURL)
         mapView.delegate = self
         styleLoadingExpectation = expectation(description: "Map view should finish loading style")
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
     
     override func tearDown() {

--- a/platform/ios/Integration Tests/MGLMapViewIntegrationTest.m
+++ b/platform/ios/Integration Tests/MGLMapViewIntegrationTest.m
@@ -48,7 +48,7 @@
     [window makeKeyAndVisible];
 
     if (!self.mapView.style) {
-        [self waitForMapViewToFinishLoadingStyleWithTimeout:5];
+        [self waitForMapViewToFinishLoadingStyleWithTimeout:10];
     }
 }
 

--- a/platform/ios/test/MGLMapViewLayoutTests.m
+++ b/platform/ios/test/MGLMapViewLayoutTests.m
@@ -35,7 +35,7 @@
     [self.superView addConstraints:[verticalConstraints arrayByAddingObjectsFromArray:horizonatalConstraints]];
 
     self.styleLoadingExpectation = [self expectationWithDescription:@"Map view should finish loading style."];
-    [self waitForExpectationsWithTimeout:5 handler:nil];
+    [self waitForExpectationsWithTimeout:10 handler:nil];
 
     self.mapView.showsScale = YES;
 


### PR DESCRIPTION
5 second timeouts have been intermittently failing on CI for me an others, and it looks like we already use 10 seconds in many places. My concern in making this change is that we're obscuring some regression in loading time, but because the CI network/compute environment is so variable, CI timeouts are probably not a super-effective way to catch performance regressions anyway?

/cc @friedbunny @fabian-guerra @chaupow 