### PR TITLE
Remove view tree observer

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -5,7 +5,6 @@ import android.graphics.Bitmap;
 import android.graphics.PointF;
 import android.graphics.drawable.ColorDrawable;
 import android.opengl.GLSurfaceView;
-import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.CallSuper;
 import android.support.annotation.IntDef;
@@ -20,7 +19,6 @@ import android.view.MotionEvent;
 import android.view.TextureView;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.ZoomButtonsController;
@@ -149,8 +147,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     // add accessibility support
     setContentDescription(context.getString(R.string.mapbox_mapActionDescription));
     setWillNotDraw(false);
-
-    getViewTreeObserver().addOnGlobalLayoutListener(new MapViewLayoutListener(this, options));
+    initialiseDrawingSurface(options);
   }
 
   private void initialiseMap() {
@@ -1371,30 +1368,6 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
      *               {@link #SOURCE_DID_CHANGE}.
      */
     void onMapChanged(@MapChange int change);
-  }
-
-  private static class MapViewLayoutListener implements ViewTreeObserver.OnGlobalLayoutListener {
-
-    private WeakReference<MapView> mapViewWeakReference;
-    private MapboxMapOptions options;
-
-    MapViewLayoutListener(MapView mapView, MapboxMapOptions options) {
-      this.mapViewWeakReference = new WeakReference<>(mapView);
-      this.options = options;
-    }
-
-    @Override
-    public void onGlobalLayout() {
-      MapView mapView = mapViewWeakReference.get();
-      if (mapView != null) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-          mapView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
-        } else {
-          mapView.getViewTreeObserver().removeGlobalOnLayoutListener(this);
-        }
-        mapView.initialiseDrawingSurface(options);
-      }
-    }
   }
 
   private class FocalPointInvalidator implements FocalPointChangeListener {


### PR DESCRIPTION
This PR removes our view tree observer setup on the MapView initialisation code. This concept was used in the past to make sure the view was measured and that calls to getWidth and getHeight returned not 0 values. With the introduction of async rendering however we introduced the following:

```java
  private void onSurfaceCreated() {
    hasSurface = true;
    post(new Runnable() {
      @Override
      public void run() {
        // Initialise only when not destroyed and only once
        if (!destroyed && mapboxMap == null) {
          MapView.this.initialiseMap();
          mapboxMap.onStart();
        }
      }
    });
```

Which has the same effect as the ViewTreeObserver setup. It will postpone our setup so components as UiSettings and similar can be initialised with a valid height/width. This change unblocks showing a MapView in a RecyclerView when the item itself isn't visible at Activity start (refs #13132). 