### PR TITLE
Harden removed sources (WIP)

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -44,6 +44,8 @@ import com.mapbox.mapboxsdk.offline.OfflineGeometryRegionDefinition;
 import com.mapbox.mapboxsdk.offline.OfflineRegionDefinition;
 import com.mapbox.mapboxsdk.offline.OfflineTilePyramidRegionDefinition;
 import com.mapbox.mapboxsdk.storage.FileSource;
+import com.mapbox.mapboxsdk.style.layers.Layer;
+import com.mapbox.mapboxsdk.style.sources.Source;
 import com.mapbox.mapboxsdk.utils.BitmapUtils;
 
 import java.lang.annotation.Retention;
@@ -131,6 +133,32 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
 
     // hide surface until map is fully loaded #10990
     setForeground(new ColorDrawable(options.getForegroundLoadColor()));
+
+    // Remove all sources from current style when going to load a new style
+    // This avoids crashing when calling updates on sources current style
+    // after underlying style has been cleared
+    addOnWillStartLoadingMapListener(new OnWillStartLoadingMapListener() {
+      @Override
+      public void onWillStartLoadingMap() {
+        if (mapboxMap == null) {
+          return;
+        }
+
+        for (Layer layer : mapboxMap.getLayers()) {
+          // avoid removing composite and annotations layer
+//        if (layer.isRuntimeLayer()) {
+//          mapboxMap.removeLayer(layer);
+//        }
+        }
+
+        for (Source source : mapboxMap.getSources()) {
+          // avoid removing composite and annotations layer
+//        if (source.isRuntimeSource()) {
+//          mapboxMap.removeSource(source);
+//        }
+        }
+      }
+    });
 
     mapboxMapOptions = options;
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -147,15 +147,15 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
         for (Layer layer : mapboxMap.getLayers()) {
           // avoid removing composite and annotations layer
 //        if (layer.isRuntimeLayer()) {
-//          mapboxMap.removeLayer(layer);
+         // mapboxMap.removeLayer(layer);
 //        }
         }
 
         for (Source source : mapboxMap.getSources()) {
           // avoid removing composite and annotations layer
-//        if (source.isRuntimeSource()) {
-//          mapboxMap.removeSource(source);
-//        }
+          if (source.isRuntimeSource()) {
+            mapboxMap.removeSource(source);
+          }
         }
       }
     });

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Layer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Layer.java
@@ -16,6 +16,7 @@ public abstract class Layer {
   private long nativePtr;
   @Keep
   private boolean invalidated;
+  private boolean isRuntimeLayer;
 
   @Keep
   protected Layer(long nativePtr) {
@@ -25,6 +26,7 @@ public abstract class Layer {
 
   public Layer() {
     checkThread();
+    isRuntimeLayer = true;
   }
 
   /**
@@ -132,5 +134,9 @@ public abstract class Layer {
       return ((Expression) value).toArray();
     }
     return value;
+  }
+
+  public boolean isRuntimeLayer() {
+    return isRuntimeLayer;
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/Source.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/Source.java
@@ -11,6 +11,7 @@ public abstract class Source {
 
   @Keep
   private long nativePtr;
+  private boolean runtimeSource;
 
   /**
    * Internal use
@@ -25,6 +26,7 @@ public abstract class Source {
 
   public Source() {
     checkThread();
+    runtimeSource = true;
   }
 
   /**
@@ -71,4 +73,8 @@ public abstract class Source {
 
   @Keep
   protected native String nativeGetAttribution();
+
+  public boolean isRuntimeSource() {
+    return runtimeSource;
+  }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/style/StyleLoad.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/style/StyleLoad.kt
@@ -1,0 +1,84 @@
+package com.mapbox.mapboxsdk.style
+
+import android.support.test.espresso.Espresso
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.UiController
+import android.support.test.espresso.matcher.ViewMatchers.isRoot
+import com.mapbox.geojson.Feature
+import com.mapbox.geojson.FeatureCollection
+import com.mapbox.geojson.Point
+import com.mapbox.mapboxsdk.constants.Style
+import com.mapbox.mapboxsdk.maps.MapboxMap
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer
+import com.mapbox.mapboxsdk.style.sources.CustomGeometrySource
+import com.mapbox.mapboxsdk.style.sources.CustomGeometrySource.THREAD_POOL_LIMIT
+import com.mapbox.mapboxsdk.style.sources.CustomGeometrySource.THREAD_PREFIX
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
+import com.mapbox.mapboxsdk.testapp.action.MapboxMapAction
+import com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke
+import com.mapbox.mapboxsdk.testapp.action.OrientationChangeAction.orientationLandscape
+import com.mapbox.mapboxsdk.testapp.action.OrientationChangeAction.orientationPortrait
+import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest
+import com.mapbox.mapboxsdk.testapp.activity.maplayout.SimpleMapActivity
+import com.mapbox.mapboxsdk.testapp.activity.style.GridSourceActivity
+import org.junit.Assert
+import org.junit.Ignore
+import org.junit.Test
+
+class CustomGeometrySourceTest : BaseActivityTest() {
+
+    override fun getActivityClass(): Class<*> = SimpleMapActivity::class.java
+
+    @Test
+    fun sourceUpdateAfterStyleChange() {
+        validateTestSetup()
+        invoke(mapboxMap) { uiController: UiController, mapboxMap: MapboxMap ->
+            val source = GeoJsonSource(
+                    "source-id",
+                    FeatureCollection.fromFeature(
+                            Feature.fromGeometry(
+                                    Point.fromLngLat(0.0, 0.0)
+                            )
+                    )
+            )
+            mapboxMap.addSource(source)
+
+            mapboxMap.setStyle(Style.DARK)
+
+            uiController.loopMainThreadForAtLeast(300)
+
+            source.setGeoJson(
+                    FeatureCollection.fromFeature(
+                            Feature.fromGeometry(
+                                    Point.fromLngLat(1.0, 1.0)
+                            )
+                    )
+            )
+        }
+    }
+
+    @Test
+    fun layerUpdateAfterStyleChange() {
+        validateTestSetup()
+        invoke(mapboxMap) { uiController: UiController, mapboxMap: MapboxMap ->
+            val source = GeoJsonSource(
+                    "source-id",
+                    FeatureCollection.fromFeature(
+                            Feature.fromGeometry(
+                                    Point.fromLngLat(0.0, 0.0)
+                            )
+                    )
+            )
+            mapboxMap.addSource(source)
+            val layer = SymbolLayer("test", "source-id")
+            mapboxMap.addLayerAbove(layer,"background")
+
+            mapboxMap.setStyle(Style.DARK)
+            layer.setProperties(iconImage("bus-15"))
+            uiController.loopMainThreadForAtLeast(300)
+            layer.setProperties(iconImage("bus-15"))
+        }
+    }
+
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
@@ -97,7 +97,7 @@ public class DebugModeActivity extends AppCompatActivity implements OnMapReadyCa
   public void onMapReady(MapboxMap map) {
     mapboxMap = map;
     mapboxMap.getUiSettings().setZoomControlsEnabled(true);
-
+    mapboxMap.setTransitionDuration(3000);
     setupNavigationView(mapboxMap.getLayers());
 
     setupNavigationView(mapboxMap.getLayers());
@@ -163,7 +163,9 @@ public class DebugModeActivity extends AppCompatActivity implements OnMapReadyCa
         if (currentStyleIndex == STYLES.length) {
           currentStyleIndex = 0;
         }
-        mapboxMap.setStyleUrl(STYLES[currentStyleIndex], style -> Timber.d("Style loaded %s", style));
+        mapboxMap.setStyleUrl(STYLES[currentStyleIndex], style ->
+          Timber.d("Style loaded %s", style));
+          mapboxMap.setTransitionDuration(4500);
       }
     });
   }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/10947, this PR tries to address the following use-case:

> A developer updates a GeoJsonSource every x amount of time and allows his user to switch styles. If the user loads a new style and the developer keeps calling updates on a source from the previous style, the application crashes. 

This crash is reproducible with the test found in this PR. Atm the construction found in MapView.java solves the crash but doesn't feel like the cleanest solution.

The issue seems to stem from the style in core clearing out it's sources when a new style is loaded but we aren't hooking into this to invalidate the Android specific implementation. 