### PR TITLE
[Android] File source deactivate should be called before callbacks

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegion.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegion.java
@@ -331,8 +331,8 @@ public class OfflineRegion {
         handler.post(new Runnable() {
           @Override
           public void run() {
-            callback.onStatus(status);
             FileSource.getInstance(Mapbox.getApplicationContext()).deactivate();
+            callback.onStatus(status);
           }
         });
       }
@@ -342,8 +342,8 @@ public class OfflineRegion {
         handler.post(new Runnable() {
           @Override
           public void run() {
-            callback.onError(error);
             FileSource.getInstance(Mapbox.getApplicationContext()).deactivate();
+            callback.onError(error);
           }
         });
       }
@@ -377,8 +377,8 @@ public class OfflineRegion {
           handler.post(new Runnable() {
             @Override
             public void run() {
-              callback.onDelete();
               FileSource.getInstance(Mapbox.getApplicationContext()).deactivate();
+              callback.onDelete();
               OfflineRegion.this.finalize();
             }
           });


### PR DESCRIPTION
When `getStatus()` and `delete()` calls are made one after other, this can lead into crash described in #12382. This PR fixes callbacks to be called only after deactivating file source. 

