### PR TITLE
Revert adding nullable annotations

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
@@ -33,10 +33,8 @@ public final class Mapbox {
   private static Mapbox INSTANCE;
 
   private Context context;
-  @Nullable
   private String accessToken;
   private Boolean connected;
-  @Nullable
   private TelemetryDefinition telemetry;
 
   /**
@@ -49,7 +47,6 @@ public final class Mapbox {
    * @param accessToken Mapbox access token
    * @return the single instance of Mapbox
    */
-  @NonNull
   @UiThread
   public static synchronized Mapbox getInstance(@NonNull Context context, @Nullable String accessToken) {
     ThreadUtils.checkThread("Mapbox");
@@ -174,7 +171,7 @@ public final class Mapbox {
    * @param accessToken the access token to validate
    * @return true is valid, false otherwise
    */
-  static boolean isAccessTokenValid(@Nullable String accessToken) {
+  static boolean isAccessTokenValid(String accessToken) {
     if (accessToken == null) {
       return false;
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/Annotation.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/Annotation.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.annotations;
 
 import android.support.annotation.NonNull;
 
-import android.support.annotation.Nullable;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 
@@ -122,11 +121,11 @@ public abstract class Annotation implements Comparable<Annotation> {
    * @return returns true both id's match else returns false.
    */
   @Override
-  public boolean equals(@Nullable Object object) {
+  public boolean equals(Object object) {
     if (this == object) {
       return true;
     }
-    if (!(object instanceof Annotation)) {
+    if (object == null || !(object instanceof Annotation)) {
       return false;
     }
     Annotation that = (Annotation) object;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/BasePointCollection.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/BasePointCollection.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.annotations;
 
 import android.support.annotation.Keep;
 
-import android.support.annotation.NonNull;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
 import java.util.ArrayList;
@@ -28,7 +27,6 @@ public abstract class BasePointCollection extends Annotation {
    *
    * @return A {@link List} of points.
    */
-  @NonNull
   public List<LatLng> getPoints() {
     return new ArrayList<>(points);
   }
@@ -39,7 +37,7 @@ public abstract class BasePointCollection extends Annotation {
    *
    * @param points A {@link List} of {@link LatLng} points making up the polyline.
    */
-  public void setPoints(@NonNull List<LatLng> points) {
+  public void setPoints(List<LatLng> points) {
     this.points = new ArrayList<>(points);
     update();
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/Bubble.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/Bubble.java
@@ -8,26 +8,22 @@ import android.graphics.PixelFormat;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
-import android.support.annotation.NonNull;
 
 class Bubble extends Drawable {
 
-  @NonNull
   private RectF rect;
   private float arrowWidth;
   private float arrowHeight;
   private float arrowPosition;
   private float cornersRadius;
-  @NonNull
   private Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
   private float strokeWidth;
   private Paint strokePaint;
   private Path strokePath;
-  @NonNull
   private Path path = new Path();
 
-  Bubble(@NonNull RectF rect, @NonNull ArrowDirection arrowDirection, float arrowWidth, float arrowHeight,
-         float arrowPosition, float cornersRadius, int bubbleColor, float strokeWidth, int strokeColor) {
+  Bubble(RectF rect, ArrowDirection arrowDirection, float arrowWidth, float arrowHeight, float arrowPosition,
+         float cornersRadius, int bubbleColor, float strokeWidth, int strokeColor) {
     this.rect = rect;
     this.arrowWidth = arrowWidth;
     this.arrowHeight = arrowHeight;
@@ -53,7 +49,7 @@ class Bubble extends Drawable {
   }
 
   @Override
-  public void draw(@NonNull Canvas canvas) {
+  public void draw(Canvas canvas) {
     if (strokeWidth > 0) {
       canvas.drawPath(strokePath, strokePaint);
     }
@@ -85,7 +81,7 @@ class Bubble extends Drawable {
     return (int) rect.height();
   }
 
-  private void initPath(@NonNull ArrowDirection arrowDirection, @NonNull Path path, float strokeWidth) {
+  private void initPath(ArrowDirection arrowDirection, Path path, float strokeWidth) {
     switch (arrowDirection.getValue()) {
       case ArrowDirection.LEFT:
         if (cornersRadius <= 0) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/BubbleLayout.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/BubbleLayout.java
@@ -5,7 +5,6 @@ import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.RectF;
-import android.support.annotation.NonNull;
 import android.util.AttributeSet;
 import android.util.DisplayMetrics;
 import android.widget.LinearLayout;
@@ -18,7 +17,6 @@ import com.mapbox.mapboxsdk.R;
 public class BubbleLayout extends LinearLayout {
 
   public static final float DEFAULT_STROKE_WIDTH = -1;
-  @NonNull
   private ArrowDirection arrowDirection;
   private float arrowWidth;
   private float arrowHeight;
@@ -34,7 +32,7 @@ public class BubbleLayout extends LinearLayout {
    *
    * @param context The context used to inflate this bubble layout
    */
-  public BubbleLayout(@NonNull Context context) {
+  public BubbleLayout(Context context) {
     this(context, null, 0);
   }
 
@@ -44,7 +42,7 @@ public class BubbleLayout extends LinearLayout {
    * @param context The context used to inflate this bubble layout
    * @param attrs   The attribute set to initialise this bubble layout from
    */
-  public BubbleLayout(@NonNull Context context, AttributeSet attrs) {
+  public BubbleLayout(Context context, AttributeSet attrs) {
     this(context, attrs, 0);
   }
 
@@ -55,7 +53,7 @@ public class BubbleLayout extends LinearLayout {
    * @param attrs        The attribute set to initialise this bubble layout from
    * @param defStyleAttr The default style to apply this bubble layout with
    */
-  public BubbleLayout(@NonNull Context context, AttributeSet attrs, int defStyleAttr) {
+  public BubbleLayout(Context context, AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
 
     TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.mapbox_BubbleLayout);
@@ -86,7 +84,7 @@ public class BubbleLayout extends LinearLayout {
   }
 
   @Override
-  protected void dispatchDraw(@NonNull Canvas canvas) {
+  protected void dispatchDraw(Canvas canvas) {
     if (bubble != null) {
       bubble.draw(canvas);
     }
@@ -113,8 +111,7 @@ public class BubbleLayout extends LinearLayout {
    * @param arrowDirection The direction of the arrow
    * @return this
    */
-  @NonNull
-  public BubbleLayout setArrowDirection(@NonNull ArrowDirection arrowDirection) {
+  public BubbleLayout setArrowDirection(ArrowDirection arrowDirection) {
     resetPadding();
     this.arrowDirection = arrowDirection;
     initPadding();
@@ -136,7 +133,6 @@ public class BubbleLayout extends LinearLayout {
    * @param arrowWidth The width of the arrow
    * @return this
    */
-  @NonNull
   public BubbleLayout setArrowWidth(float arrowWidth) {
     resetPadding();
     this.arrowWidth = arrowWidth;
@@ -159,7 +155,6 @@ public class BubbleLayout extends LinearLayout {
    * @param arrowHeight The height of the arrow
    * @return this
    */
-  @NonNull
   public BubbleLayout setArrowHeight(float arrowHeight) {
     resetPadding();
     this.arrowHeight = arrowHeight;
@@ -182,7 +177,6 @@ public class BubbleLayout extends LinearLayout {
    * @param arrowPosition The arrow position
    * @return this
    */
-  @NonNull
   public BubbleLayout setArrowPosition(float arrowPosition) {
     resetPadding();
     this.arrowPosition = arrowPosition;
@@ -205,7 +199,6 @@ public class BubbleLayout extends LinearLayout {
    * @param cornersRadius The corner radius
    * @return this
    */
-  @NonNull
   public BubbleLayout setCornersRadius(float cornersRadius) {
     this.cornersRadius = cornersRadius;
     requestLayout();
@@ -227,7 +220,6 @@ public class BubbleLayout extends LinearLayout {
    * @param bubbleColor The buble color
    * @return this
    */
-  @NonNull
   public BubbleLayout setBubbleColor(int bubbleColor) {
     this.bubbleColor = bubbleColor;
     requestLayout();
@@ -249,7 +241,6 @@ public class BubbleLayout extends LinearLayout {
    * @param strokeWidth The stroke width
    * @return this
    */
-  @NonNull
   public BubbleLayout setStrokeWidth(float strokeWidth) {
     resetPadding();
     this.strokeWidth = strokeWidth;
@@ -272,7 +263,6 @@ public class BubbleLayout extends LinearLayout {
    * @param strokeColor The stroke color
    * @return this
    */
-  @NonNull
   public BubbleLayout setStrokeColor(int strokeColor) {
     this.strokeColor = strokeColor;
     requestLayout();

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/BubblePopupHelper.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/BubblePopupHelper.java
@@ -11,7 +11,6 @@ import com.mapbox.mapboxsdk.R;
 
 class BubblePopupHelper {
 
-  @NonNull
   static PopupWindow create(@NonNull Context context, @NonNull BubbleLayout bubbleLayout) {
     PopupWindow popupWindow = new PopupWindow(context);
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/Icon.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/Icon.java
@@ -1,8 +1,6 @@
 package com.mapbox.mapboxsdk.annotations;
 
 import android.graphics.Bitmap;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.util.DisplayMetrics;
 
 import java.nio.ByteBuffer;
@@ -71,7 +69,6 @@ public class Icon {
    *
    * @return the bytes of the bitmap
    */
-  @NonNull
   public byte[] toBytes() {
     if (mBitmap == null) {
       throw new IllegalStateException("Required to set a Icon before calling toBytes");
@@ -88,7 +85,7 @@ public class Icon {
    * @return True if the icon being passed in matches this icon object. Else, false.
    */
   @Override
-  public boolean equals(@Nullable Object object) {
+  public boolean equals(Object object) {
     if (this == object) {
       return true;
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/InfoWindow.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/InfoWindow.java
@@ -4,8 +4,6 @@ import android.content.res.Resources;
 import android.graphics.PointF;
 import android.os.Build;
 import android.support.annotation.LayoutRes;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -49,17 +47,17 @@ public class InfoWindow {
   @LayoutRes
   private int layoutRes;
 
-  InfoWindow(@NonNull MapView mapView, int layoutResId, @NonNull MapboxMap mapboxMap) {
+  InfoWindow(MapView mapView, int layoutResId, MapboxMap mapboxMap) {
     layoutRes = layoutResId;
     View view = LayoutInflater.from(mapView.getContext()).inflate(layoutResId, mapView, false);
     initialize(view, mapboxMap);
   }
 
-  InfoWindow(@NonNull View view, @NonNull MapboxMap mapboxMap) {
+  InfoWindow(View view, MapboxMap mapboxMap) {
     initialize(view, mapboxMap);
   }
 
-  private void initialize(@NonNull View view, @NonNull MapboxMap mapboxMap) {
+  private void initialize(View view, MapboxMap mapboxMap) {
     this.mapboxMap = new WeakReference<>(mapboxMap);
     isVisible = false;
     this.view = new WeakReference<>(view);
@@ -118,8 +116,7 @@ public class InfoWindow {
    *                    the view from the object position.
    * @return this {@link InfoWindow}.
    */
-  @NonNull
-  InfoWindow open(@NonNull MapView mapView, Marker boundMarker, @NonNull LatLng position, int offsetX, int offsetY) {
+  InfoWindow open(MapView mapView, Marker boundMarker, LatLng position, int offsetX, int offsetY) {
     setBoundMarker(boundMarker);
 
     MapView.LayoutParams lp = new MapView.LayoutParams(MapView.LayoutParams.WRAP_CONTENT,
@@ -216,7 +213,6 @@ public class InfoWindow {
    *
    * @return This {@link InfoWindow}
    */
-  @NonNull
   InfoWindow close() {
     MapboxMap mapboxMap = this.mapboxMap.get();
     if (isVisible && mapboxMap != null) {
@@ -243,7 +239,7 @@ public class InfoWindow {
    *
    * @param overlayItem the tapped overlay item
    */
-  void adaptDefaultMarker(@NonNull Marker overlayItem, MapboxMap mapboxMap, @NonNull MapView mapView) {
+  void adaptDefaultMarker(Marker overlayItem, MapboxMap mapboxMap, MapView mapView) {
     View view = this.view.get();
     if (view == null) {
       view = LayoutInflater.from(mapView.getContext()).inflate(layoutRes, mapView, false);
@@ -269,13 +265,11 @@ public class InfoWindow {
     }
   }
 
-  @NonNull
   InfoWindow setBoundMarker(Marker boundMarker) {
     this.boundMarker = new WeakReference<>(boundMarker);
     return this;
   }
 
-  @Nullable
   Marker getBoundMarker() {
     if (boundMarker == null) {
       return null;
@@ -313,7 +307,6 @@ public class InfoWindow {
     }
   }
 
-  @Nullable
   private final ViewTreeObserver.OnGlobalLayoutListener contentUpdateListener =
     new ViewTreeObserver.OnGlobalLayoutListener() {
       @Override
@@ -336,7 +329,6 @@ public class InfoWindow {
    *
    * @return This {@link InfoWindow}'s current View.
    */
-  @Nullable
   public View getView() {
     return view != null ? view.get() : null;
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/Marker.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/Marker.java
@@ -31,15 +31,12 @@ public class Marker extends Annotation {
   @Keep
   private LatLng position;
   private String snippet;
-  @Nullable
   private Icon icon;
   //Redundantly stored for JNI access
-  @Nullable
   @Keep
   private String iconId;
   private String title;
 
-  @Nullable
   private InfoWindow infoWindow;
   private boolean infoWindowShown;
 
@@ -164,7 +161,6 @@ public class Marker extends Annotation {
    *
    * @return The {@link Icon} the marker is using.
    */
-  @Nullable
   public Icon getIcon() {
     return icon;
   }
@@ -216,7 +212,6 @@ public class Marker extends Annotation {
    * @param mapView   The hosting map view.
    * @return The info window that was shown.
    */
-  @Nullable
   public InfoWindow showInfoWindow(@NonNull MapboxMap mapboxMap, @NonNull MapView mapView) {
     setMapboxMap(mapboxMap);
     setMapView(mapView);
@@ -238,14 +233,12 @@ public class Marker extends Annotation {
     return showInfoWindow(infoWindow, mapView);
   }
 
-  @NonNull
   private InfoWindow showInfoWindow(InfoWindow iw, MapView mapView) {
     iw.open(mapView, this, getPosition(), rightOffsetPixels, topOffsetPixels);
     infoWindowShown = true;
     return iw;
   }
 
-  @Nullable
   private InfoWindow getInfoWindow(@NonNull MapView mapView) {
     if (infoWindow == null && mapView.getContext() != null) {
       infoWindow = new InfoWindow(mapView, R.layout.mapbox_infowindow_content, getMapboxMap());

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerOptions.java
@@ -4,8 +4,6 @@ import android.graphics.Bitmap;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import com.mapbox.mapboxsdk.exceptions.InvalidMarkerPositionException;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
@@ -42,7 +40,6 @@ public final class MarkerOptions extends BaseMarkerOptions<Marker, MarkerOptions
     }
   }
 
-  @NonNull
   @Override
   public MarkerOptions getThis() {
     return this;
@@ -131,7 +128,7 @@ public final class MarkerOptions extends BaseMarkerOptions<Marker, MarkerOptions
 
   public static final Parcelable.Creator<MarkerOptions> CREATOR =
     new Parcelable.Creator<MarkerOptions>() {
-      public MarkerOptions createFromParcel(@NonNull Parcel in) {
+      public MarkerOptions createFromParcel(Parcel in) {
         return new MarkerOptions(in);
       }
 
@@ -149,7 +146,7 @@ public final class MarkerOptions extends BaseMarkerOptions<Marker, MarkerOptions
    * Else, false.
    */
   @Override
-  public boolean equals(@Nullable Object o) {
+  public boolean equals(Object o) {
     if (this == o) {
       return true;
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerView.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.annotations;
 
 import android.support.annotation.FloatRange;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.mapbox.mapboxsdk.Mapbox;
@@ -68,7 +67,7 @@ public class MarkerView extends Marker {
    *
    * @param baseMarkerViewOptions the builder used to construct the MarkerView
    */
-  public MarkerView(@NonNull BaseMarkerViewOptions baseMarkerViewOptions) {
+  public MarkerView(BaseMarkerViewOptions baseMarkerViewOptions) {
     super(baseMarkerViewOptions);
     this.alpha = baseMarkerViewOptions.getAlpha();
     this.anchorU = baseMarkerViewOptions.getAnchorU();
@@ -385,7 +384,7 @@ public class MarkerView extends Marker {
    * @param mapboxMap the MapboxMap instances.
    */
   @Override
-  public void setMapboxMap(@Nullable MapboxMap mapboxMap) {
+  public void setMapboxMap(MapboxMap mapboxMap) {
     super.setMapboxMap(mapboxMap);
     if (mapboxMap != null) {
       if (isFlat()) {
@@ -411,7 +410,6 @@ public class MarkerView extends Marker {
    *
    * @return the String representation.
    */
-  @NonNull
   @Override
   public String toString() {
     return "MarkerView [position[" + getPosition() + "]]";

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
@@ -36,7 +36,6 @@ import java.util.Map;
 @Deprecated
 public class MarkerViewManager implements MapView.OnMapChangedListener {
 
-  @NonNull
   private final ViewGroup markerViewContainer;
   private final ViewTreeObserver.OnPreDrawListener markerViewPreDrawObserver =
     new ViewTreeObserver.OnPreDrawListener() {
@@ -57,7 +56,6 @@ public class MarkerViewManager implements MapView.OnMapChangedListener {
 
   private boolean enabled;
   private long updateTime;
-  @Nullable
   private MapboxMap.OnMarkerViewClickListener onMarkerViewClickListener;
   private boolean isWaitingForRenderInvoke;
 
@@ -332,7 +330,7 @@ public class MarkerViewManager implements MapView.OnMapChangedListener {
    * @param convertView the View presentation of the MarkerView.
    * @param adapter     the adapter used to adapt the marker to the convertView.
    */
-  public void select(@NonNull MarkerView marker, View convertView, @NonNull MapboxMap.MarkerViewAdapter adapter) {
+  public void select(@NonNull MarkerView marker, View convertView, MapboxMap.MarkerViewAdapter adapter) {
     select(marker, convertView, adapter, true);
   }
 
@@ -349,8 +347,8 @@ public class MarkerViewManager implements MapView.OnMapChangedListener {
    * @param adapter       the adapter used to adapt the marker to the convertView.
    * @param callbackToMap indicates if select marker must be called on MapboxMap.
    */
-  public void select(@NonNull MarkerView marker, @Nullable View convertView,
-                     @NonNull MapboxMap.MarkerViewAdapter adapter, boolean callbackToMap) {
+  public void select(@NonNull MarkerView marker, View convertView, MapboxMap.MarkerViewAdapter adapter,
+                     boolean callbackToMap) {
     if (convertView != null) {
       if (adapter.onSelect(marker, convertView, false)) {
         if (callbackToMap) {
@@ -381,7 +379,7 @@ public class MarkerViewManager implements MapView.OnMapChangedListener {
    * @return the MarkerView adapter.
    */
   @Nullable
-  public MapboxMap.MarkerViewAdapter getViewAdapter(@NonNull MarkerView markerView) {
+  public MapboxMap.MarkerViewAdapter getViewAdapter(MarkerView markerView) {
     MapboxMap.MarkerViewAdapter adapter = null;
     for (MapboxMap.MarkerViewAdapter a : markerViewAdapters) {
       if (a.getMarkerClass().equals(markerView.getClass())) {
@@ -402,7 +400,7 @@ public class MarkerViewManager implements MapView.OnMapChangedListener {
    *
    * @param marker the MarkerView to remove.
    */
-  public void removeMarkerView(@Nullable MarkerView marker) {
+  public void removeMarkerView(MarkerView marker) {
     final View viewHolder = markerViewMap.get(marker);
     if (viewHolder != null && marker != null) {
       for (final MapboxMap.MarkerViewAdapter<?> adapter : markerViewAdapters) {
@@ -427,7 +425,7 @@ public class MarkerViewManager implements MapView.OnMapChangedListener {
    *
    * @param markerViewAdapter the MarkerViewAdapter to add.
    */
-  public void addMarkerViewAdapter(@NonNull MapboxMap.MarkerViewAdapter markerViewAdapter) {
+  public void addMarkerViewAdapter(MapboxMap.MarkerViewAdapter markerViewAdapter) {
     if (markerViewAdapter.getMarkerClass().equals(MarkerView.class)) {
       throw new RuntimeException("Providing a custom MarkerViewAdapter requires subclassing MarkerView");
     }
@@ -443,7 +441,6 @@ public class MarkerViewManager implements MapView.OnMapChangedListener {
    *
    * @return a List of MarkerViewAdapters.
    */
-  @NonNull
   public List<MapboxMap.MarkerViewAdapter> getMarkerViewAdapters() {
     return markerViewAdapters;
   }
@@ -562,7 +559,7 @@ public class MarkerViewManager implements MapView.OnMapChangedListener {
    * @param markerView that the click event occurred
    * @return true if the marker view click has been handled, false if not
    */
-  public boolean onClickMarkerView(@NonNull MarkerView markerView) {
+  public boolean onClickMarkerView(MarkerView markerView) {
     boolean clickHandled = false;
 
     MapboxMap.MarkerViewAdapter adapter = getViewAdapter(markerView);
@@ -584,7 +581,7 @@ public class MarkerViewManager implements MapView.OnMapChangedListener {
    *
    * @param marker that we are ensuring info window offset
    */
-  public void ensureInfoWindowOffset(@NonNull MarkerView marker) {
+  public void ensureInfoWindowOffset(MarkerView marker) {
     View view = null;
     if (markerViewMap.containsKey(marker)) {
       view = markerViewMap.get(marker);
@@ -623,13 +620,12 @@ public class MarkerViewManager implements MapView.OnMapChangedListener {
     }
   }
 
-  @NonNull
   public ViewGroup getMarkerViewContainer() {
     return markerViewContainer;
   }
 
-  public void addOnMarkerViewAddedListener(@NonNull MarkerView markerView, OnMarkerViewAddedListener listener) {
-    markerViewAddedListenerMap.put(markerView.getId(), listener);
+  public void addOnMarkerViewAddedListener(MarkerView markerView, OnMarkerViewAddedListener onMarkerViewAddedListener) {
+    markerViewAddedListenerMap.put(markerView.getId(), onMarkerViewAddedListener);
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewOptions.java
@@ -4,8 +4,6 @@ import android.graphics.Bitmap;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import com.mapbox.mapboxsdk.exceptions.InvalidMarkerPositionException;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
@@ -55,7 +53,6 @@ public class MarkerViewOptions extends BaseMarkerViewOptions<MarkerView, MarkerV
    *
    * @return the object for which this method was called.
    */
-  @NonNull
   @Override
   public MarkerViewOptions getThis() {
     return this;
@@ -80,7 +77,7 @@ public class MarkerViewOptions extends BaseMarkerViewOptions<MarkerView, MarkerV
    *              {@link #PARCELABLE_WRITE_RETURN_VALUE}.
    */
   @Override
-  public void writeToParcel(@NonNull Parcel out, int flags) {
+  public void writeToParcel(Parcel out, int flags) {
     out.writeParcelable(getPosition(), flags);
     out.writeString(getSnippet());
     out.writeString(getTitle());
@@ -126,7 +123,7 @@ public class MarkerViewOptions extends BaseMarkerViewOptions<MarkerView, MarkerV
 
   public static final Parcelable.Creator<MarkerViewOptions> CREATOR =
     new Parcelable.Creator<MarkerViewOptions>() {
-      public MarkerViewOptions createFromParcel(@NonNull Parcel in) {
+      public MarkerViewOptions createFromParcel(Parcel in) {
         return new MarkerViewOptions(in);
       }
 
@@ -144,7 +141,7 @@ public class MarkerViewOptions extends BaseMarkerViewOptions<MarkerView, MarkerV
    * {@link PolylineOptions} object. Else, false.
    */
   @Override
-  public boolean equals(@Nullable Object object) {
+  public boolean equals(Object object) {
     if (this == object) {
       return true;
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/Polygon.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/Polygon.java
@@ -3,7 +3,6 @@ package com.mapbox.mapboxsdk.annotations;
 import android.graphics.Color;
 import android.support.annotation.Keep;
 
-import android.support.annotation.NonNull;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 
@@ -80,7 +79,7 @@ public final class Polygon extends BasePointCollection {
    *
    * @param holes A {@link List} of {@link List} of {@link LatLng} points making up the holes.
    */
-  public void setHoles(@NonNull List<? extends List<LatLng>> holes) {
+  public void setHoles(List<? extends List<LatLng>> holes) {
     this.holes = new ArrayList<>(holes);
     update();
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/PolygonOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/PolygonOptions.java
@@ -4,8 +4,6 @@ package com.mapbox.mapboxsdk.annotations;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
 import java.util.ArrayList;
@@ -18,7 +16,7 @@ public final class PolygonOptions implements Parcelable {
 
   public static final Parcelable.Creator<PolygonOptions> CREATOR =
     new Parcelable.Creator<PolygonOptions>() {
-      public PolygonOptions createFromParcel(@NonNull Parcel in) {
+      public PolygonOptions createFromParcel(Parcel in) {
         return new PolygonOptions(in);
       }
 
@@ -82,7 +80,6 @@ public final class PolygonOptions implements Parcelable {
    * @param point {@link LatLng} point to be added to polygon geometry.
    * @return This {@link PolygonOptions} object with the given point added to the outline.
    */
-  @NonNull
   public PolygonOptions add(LatLng point) {
     polygon.addPoint(point);
     return this;
@@ -94,7 +91,6 @@ public final class PolygonOptions implements Parcelable {
    * @param points {@link LatLng} points to be added to polygon geometry.
    * @return This {@link PolygonOptions} object with the given points added to the outline.
    */
-  @NonNull
   public PolygonOptions add(LatLng... points) {
     for (LatLng point : points) {
       add(point);
@@ -109,7 +105,6 @@ public final class PolygonOptions implements Parcelable {
    *               geometry
    * @return This {@link PolygonOptions} object with the given points added to the outline.
    */
-  @NonNull
   public PolygonOptions addAll(Iterable<LatLng> points) {
     for (LatLng point : points) {
       add(point);
@@ -123,7 +118,6 @@ public final class PolygonOptions implements Parcelable {
    * @param hole {@link List} list made up of {@link LatLng} points defining the hole
    * @return This {@link PolygonOptions} object with the given hole added to the outline.
    */
-  @NonNull
   public PolygonOptions addHole(List<LatLng> hole) {
     polygon.addHole(hole);
     return this;
@@ -135,7 +129,6 @@ public final class PolygonOptions implements Parcelable {
    * @param holes {@link List} list made up of {@link LatLng} holes to be added to polygon geometry
    * @return This {@link PolygonOptions} object with the given holes added to the outline.
    */
-  @NonNull
   public PolygonOptions addHole(List<LatLng>... holes) {
     for (List<LatLng> hole : holes) {
       addHole(hole);
@@ -149,7 +142,6 @@ public final class PolygonOptions implements Parcelable {
    * @param holes {@link Iterable} list made up of {@link List} list of {@link LatLng} holes defining the hole geometry
    * @return This {@link PolygonOptions} object with the given holes added to the outline.
    */
-  @NonNull
   public PolygonOptions addAllHoles(Iterable<List<LatLng>> holes) {
     for (List<LatLng> hole : holes) {
       addHole(hole);
@@ -163,7 +155,6 @@ public final class PolygonOptions implements Parcelable {
    * @param alpha float value between 0 (not visible) and 1.
    * @return This {@link PolygonOptions} object with the given polygon alpha value.
    */
-  @NonNull
   public PolygonOptions alpha(float alpha) {
     polygon.setAlpha(alpha);
     return this;
@@ -184,7 +175,6 @@ public final class PolygonOptions implements Parcelable {
    * @param color 32-bit ARGB color.
    * @return This {@link PolylineOptions} object with a new color set.
    */
-  @NonNull
   public PolygonOptions fillColor(int color) {
     polygon.setFillColor(color);
     return this;
@@ -214,7 +204,6 @@ public final class PolygonOptions implements Parcelable {
    * @param color 32-bit ARGB color.
    * @return This {@link PolygonOptions} object with a new stroke color set.
    */
-  @NonNull
   public PolygonOptions strokeColor(int color) {
     polygon.setStrokeColor(color);
     return this;
@@ -258,7 +247,7 @@ public final class PolygonOptions implements Parcelable {
    * {@link PolygonOptions} object. Else, false.
    */
   @Override
-  public boolean equals(@Nullable Object o) {
+  public boolean equals(Object o) {
     if (this == o) {
       return true;
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/PolylineOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/PolylineOptions.java
@@ -3,8 +3,6 @@ package com.mapbox.mapboxsdk.annotations;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
 import java.util.ArrayList;
@@ -18,7 +16,7 @@ public final class PolylineOptions implements Parcelable {
 
   public static final Parcelable.Creator<PolylineOptions> CREATOR =
     new Parcelable.Creator<PolylineOptions>() {
-      public PolylineOptions createFromParcel(@NonNull Parcel in) {
+      public PolylineOptions createFromParcel(Parcel in) {
         return new PolylineOptions(in);
       }
 
@@ -78,7 +76,6 @@ public final class PolylineOptions implements Parcelable {
    * @param point {@link LatLng} point to be added to polyline geometry.
    * @return This {@link PolylineOptions} object with the given point on the end.
    */
-  @NonNull
   public PolylineOptions add(LatLng point) {
     polyline.addPoint(point);
     return this;
@@ -90,7 +87,6 @@ public final class PolylineOptions implements Parcelable {
    * @param points {@link LatLng} points defining the polyline geometry.
    * @return This {@link PolylineOptions} object with the given point on the end.
    */
-  @NonNull
   public PolylineOptions add(LatLng... points) {
     for (LatLng point : points) {
       add(point);
@@ -105,7 +101,6 @@ public final class PolylineOptions implements Parcelable {
    *               geometry
    * @return This {@link PolylineOptions} object with the given points on the end.
    */
-  @NonNull
   public PolylineOptions addAll(Iterable<LatLng> points) {
     for (LatLng point : points) {
       add(point);
@@ -119,7 +114,6 @@ public final class PolylineOptions implements Parcelable {
    * @param alpha float value between 0 (not visible) and 1.
    * @return This {@link PolylineOptions} object with the given polyline alpha value.
    */
-  @NonNull
   public PolylineOptions alpha(float alpha) {
     polyline.setAlpha(alpha);
     return this;
@@ -140,7 +134,6 @@ public final class PolylineOptions implements Parcelable {
    * @param color 32-bit ARGB color.
    * @return This {@link PolylineOptions} object with a new color set.
    */
-  @NonNull
   public PolylineOptions color(int color) {
     polyline.setColor(color);
     return this;
@@ -179,7 +172,6 @@ public final class PolylineOptions implements Parcelable {
    * @param width float value defining width of polyline using unit pixels.
    * @return This {@link PolylineOptions} object with a new width set.
    */
-  @NonNull
   public PolylineOptions width(float width) {
     polyline.setWidth(width);
     return this;
@@ -204,7 +196,7 @@ public final class PolylineOptions implements Parcelable {
    * Else, false.
    */
   @Override
-  public boolean equals(@Nullable Object o) {
+  public boolean equals(Object o) {
     if (this == o) {
       return true;
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/attribution/Attribution.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/attribution/Attribution.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxsdk.attribution;
 
-import android.support.annotation.Nullable;
-
 public class Attribution {
 
   private static final String OPENSTREETMAP = "OpenStreetMap";
@@ -36,7 +34,7 @@ public class Attribution {
   }
 
   @Override
-  public boolean equals(@Nullable Object o) {
+  public boolean equals(Object o) {
     if (this == o) {
       return true;
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/attribution/AttributionLayout.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/attribution/AttributionLayout.java
@@ -2,14 +2,11 @@ package com.mapbox.mapboxsdk.attribution;
 
 import android.graphics.Bitmap;
 import android.graphics.PointF;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 public class AttributionLayout {
 
-  @Nullable
   private Bitmap logo;
-  @Nullable
   private PointF anchorPoint;
   private boolean shortText;
 
@@ -19,12 +16,10 @@ public class AttributionLayout {
     this.shortText = shortText;
   }
 
-  @Nullable
   public Bitmap getLogo() {
     return logo;
   }
 
-  @Nullable
   public PointF getAnchorPoint() {
     return anchorPoint;
   }
@@ -34,7 +29,7 @@ public class AttributionLayout {
   }
 
   @Override
-  public boolean equals(@Nullable Object o) {
+  public boolean equals(Object o) {
     if (this == o) {
       return true;
     }
@@ -57,7 +52,6 @@ public class AttributionLayout {
     return result;
   }
 
-  @NonNull
   @Override
   public String toString() {
     return "AttributionLayout{"

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/attribution/AttributionMeasure.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/attribution/AttributionMeasure.java
@@ -2,8 +2,6 @@ package com.mapbox.mapboxsdk.attribution;
 
 import android.graphics.Bitmap;
 import android.graphics.PointF;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.widget.TextView;
 
 import java.util.Arrays;
@@ -29,7 +27,6 @@ public class AttributionMeasure {
     this.margin = margin;
   }
 
-  @Nullable
   public AttributionLayout measure() {
     Chain chain = new Chain(
       new FullLogoLongTextCommand(),
@@ -48,8 +45,7 @@ public class AttributionMeasure {
 
 
   private static class FullLogoLongTextCommand implements Command {
-    @Nullable
-    public AttributionLayout execute(@NonNull AttributionMeasure measure) {
+    public AttributionLayout execute(AttributionMeasure measure) {
       float width = measure.getLogoContainerWidth() + measure.getTextViewContainerWidth();
       boolean fitBounds = width <= measure.getMaxSize();
       if (fitBounds) {
@@ -61,9 +57,8 @@ public class AttributionMeasure {
   }
 
   private static class FullLogoShortTextCommand implements Command {
-    @Nullable
     @Override
-    public AttributionLayout execute(@NonNull AttributionMeasure measure) {
+    public AttributionLayout execute(AttributionMeasure measure) {
       float width = measure.getLogoContainerWidth() + measure.getTextViewShortContainerWidth();
       boolean fitBounds = width <= measure.getMaxSizeShort();
       if (fitBounds) {
@@ -75,9 +70,8 @@ public class AttributionMeasure {
   }
 
   private static class SmallLogoLongTextCommand implements Command {
-    @Nullable
     @Override
-    public AttributionLayout execute(@NonNull AttributionMeasure measure) {
+    public AttributionLayout execute(AttributionMeasure measure) {
       float width = measure.getLogoSmallContainerWidth() + measure.getTextViewContainerWidth();
       boolean fitBounds = width <= measure.getMaxSize();
       if (fitBounds) {
@@ -89,9 +83,8 @@ public class AttributionMeasure {
   }
 
   private static class SmallLogoShortTextCommand implements Command {
-    @Nullable
     @Override
-    public AttributionLayout execute(@NonNull AttributionMeasure measure) {
+    public AttributionLayout execute(AttributionMeasure measure) {
       float width = measure.getLogoContainerWidth() + measure.getTextViewShortContainerWidth();
       boolean fitBounds = width <= measure.getMaxSizeShort();
       if (fitBounds) {
@@ -103,9 +96,8 @@ public class AttributionMeasure {
   }
 
   private static class LongTextCommand implements Command {
-    @Nullable
     @Override
-    public AttributionLayout execute(@NonNull AttributionMeasure measure) {
+    public AttributionLayout execute(AttributionMeasure measure) {
       float width = measure.getTextViewContainerWidth() + measure.margin;
       boolean fitBounds = width <= measure.getMaxSize();
       if (fitBounds) {
@@ -116,9 +108,8 @@ public class AttributionMeasure {
   }
 
   private static class ShortTextCommand implements Command {
-    @Nullable
     @Override
-    public AttributionLayout execute(@NonNull AttributionMeasure measure) {
+    public AttributionLayout execute(AttributionMeasure measure) {
       float width = measure.getTextViewShortContainerWidth() + measure.margin;
       boolean fitBounds = width <= measure.getMaxSizeShort();
       if (fitBounds) {
@@ -130,7 +121,6 @@ public class AttributionMeasure {
   }
 
   private static class NoTextCommand implements Command {
-    @NonNull
     @Override
     public AttributionLayout execute(AttributionMeasure measure) {
       return new AttributionLayout(null, null, false);
@@ -155,7 +145,6 @@ public class AttributionMeasure {
       this.commands = Arrays.asList(commands);
     }
 
-    @Nullable
     public AttributionLayout start(AttributionMeasure measure) {
       AttributionLayout attributionLayout = null;
       for (Command command : commands) {
@@ -169,7 +158,6 @@ public class AttributionMeasure {
   }
 
   public interface Command {
-    @Nullable
     AttributionLayout execute(AttributionMeasure measure);
   }
 
@@ -205,43 +193,36 @@ public class AttributionMeasure {
     private TextView textViewShort;
     private float marginPadding;
 
-    @NonNull
     public Builder setSnapshot(Bitmap snapshot) {
       this.snapshot = snapshot;
       return this;
     }
 
-    @NonNull
     public Builder setLogo(Bitmap logo) {
       this.logo = logo;
       return this;
     }
 
-    @NonNull
     public Builder setLogoSmall(Bitmap logoSmall) {
       this.logoSmall = logoSmall;
       return this;
     }
 
-    @NonNull
     public Builder setTextView(TextView textView) {
       this.textView = textView;
       return this;
     }
 
-    @NonNull
     public Builder setTextViewShort(TextView textViewShort) {
       this.textViewShort = textViewShort;
       return this;
     }
 
-    @NonNull
     public Builder setMarginPadding(float marginPadding) {
       this.marginPadding = marginPadding;
       return this;
     }
 
-    @NonNull
     public AttributionMeasure build() {
       return new AttributionMeasure(snapshot, logo, logoSmall, textView, textViewShort, marginPadding);
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/attribution/AttributionParser.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/attribution/AttributionParser.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.attribution;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
 import android.text.Html;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
@@ -45,7 +44,6 @@ public class AttributionParser {
    *
    * @return the attributions
    */
-  @NonNull
   public Set<Attribution> getAttributions() {
     return attributions;
   }
@@ -55,7 +53,6 @@ public class AttributionParser {
    *
    * @return the parsed attribution string
    */
-  @NonNull
   public String createAttributionString() {
     return createAttributionString(false);
   }
@@ -66,7 +63,6 @@ public class AttributionParser {
    * @param shortenedOutput if attribution string should contain shortened output
    * @return the parsed attribution string
    */
-  @NonNull
   public String createAttributionString(boolean shortenedOutput) {
     StringBuilder stringBuilder = new StringBuilder(withCopyrightSign ? "" : "© ");
     int counter = 0;
@@ -105,7 +101,7 @@ public class AttributionParser {
    * @param htmlBuilder the html builder
    * @param urlSpan     the url span to be parsed
    */
-  private void parseUrlSpan(@NonNull SpannableStringBuilder htmlBuilder, URLSpan urlSpan) {
+  private void parseUrlSpan(SpannableStringBuilder htmlBuilder, URLSpan urlSpan) {
     String url = urlSpan.getURL();
     if (isUrlValid(url)) {
       String anchor = parseAnchorValue(htmlBuilder, urlSpan);
@@ -122,7 +118,7 @@ public class AttributionParser {
    * @param url the url to be validated
    * @return if the url is valid
    */
-  private boolean isUrlValid(@NonNull String url) {
+  private boolean isUrlValid(String url) {
     return isValidForImproveThisMap(url) && isValidForMapbox(url);
   }
 
@@ -156,7 +152,7 @@ public class AttributionParser {
    * @param url the url to be validated
    * @return if the url is valid for improve this map
    */
-  private boolean isValidForImproveThisMap(@NonNull String url) {
+  private boolean isValidForImproveThisMap(String url) {
     return withImproveMap || !url.equals(Attribution.IMPROVE_MAP_URL);
   }
 
@@ -166,7 +162,7 @@ public class AttributionParser {
    * @param url the url to be validated
    * @return if the url is valid for Mapbox
    */
-  private boolean isValidForMapbox(@NonNull String url) {
+  private boolean isValidForMapbox(String url) {
     return withMapboxAttribution || !url.equals(Attribution.MAPBOX_URL);
   }
 
@@ -177,7 +173,6 @@ public class AttributionParser {
    * @param urlSpan     the current urlSpan
    * @return the parsed anchor value
    */
-  @NonNull
   private String parseAnchorValue(SpannableStringBuilder htmlBuilder, URLSpan urlSpan) {
     int start = htmlBuilder.getSpanStart(urlSpan);
     int end = htmlBuilder.getSpanEnd(urlSpan);
@@ -193,8 +188,7 @@ public class AttributionParser {
    * @param anchor the attribution string to strip
    * @return the stripped attribution string without the copyright sign
    */
-  @NonNull
-  private String stripCopyright(@NonNull String anchor) {
+  private String stripCopyright(String anchor) {
     if (!withCopyrightSign && anchor.startsWith("© ")) {
       anchor = anchor.substring(2, anchor.length());
     }
@@ -248,43 +242,36 @@ public class AttributionParser {
     private boolean withMapboxAttribution = true;
     private String[] attributionDataStringArray;
 
-    @NonNull
     public Options withAttributionData(String... attributionData) {
       this.attributionDataStringArray = attributionData;
       return this;
     }
 
-    @NonNull
     public Options withImproveMap(boolean withImproveMap) {
       this.withImproveMap = withImproveMap;
       return this;
     }
 
-    @NonNull
     public Options withCopyrightSign(boolean withCopyrightSign) {
       this.withCopyrightSign = withCopyrightSign;
       return this;
     }
 
-    @NonNull
     public Options withTelemetryAttribution(boolean withTelemetryAttribution) {
       this.withTelemetryAttribution = withTelemetryAttribution;
       return this;
     }
 
-    @NonNull
     public Options withMapboxAttribution(boolean withMapboxAttribution) {
       this.withMapboxAttribution = withMapboxAttribution;
       return this;
     }
 
-    @NonNull
     public Options withContext(Context context) {
       this.context = new WeakReference<>(context);
       return this;
     }
 
-    @NonNull
     public AttributionParser build() {
       if (attributionDataStringArray == null) {
         throw new IllegalStateException("Using builder without providing attribution data");

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraPosition.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraPosition.java
@@ -6,8 +6,6 @@ import android.os.Parcelable;
 import android.support.annotation.FloatRange;
 import android.support.annotation.Keep;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -127,7 +125,7 @@ public final class CameraPosition implements Parcelable {
    * Else, false.
    */
   @Override
-  public boolean equals(@Nullable Object o) {
+  public boolean equals(Object o) {
     if (this == o) {
       return true;
     }
@@ -170,7 +168,6 @@ public final class CameraPosition implements Parcelable {
   public static final class Builder {
 
     private double bearing = -1;
-    @Nullable
     private LatLng target = null;
     private double tilt = -1;
     private double zoom = -1;
@@ -187,7 +184,7 @@ public final class CameraPosition implements Parcelable {
      *
      * @param previous Existing CameraPosition values to use
      */
-    public Builder(@Nullable CameraPosition previous) {
+    public Builder(CameraPosition previous) {
       super();
       if (previous != null) {
         this.bearing = previous.bearing;
@@ -202,7 +199,7 @@ public final class CameraPosition implements Parcelable {
      *
      * @param typedArray TypedArray containing attribute values
      */
-    public Builder(@Nullable TypedArray typedArray) {
+    public Builder(TypedArray typedArray) {
       super();
       if (typedArray != null) {
         this.bearing = typedArray.getFloat(R.styleable.mapbox_MapView_mapbox_cameraBearing, 0.0f);
@@ -219,7 +216,7 @@ public final class CameraPosition implements Parcelable {
      *
      * @param update Update containing camera options
      */
-    public Builder(@Nullable CameraUpdateFactory.CameraPositionUpdate update) {
+    public Builder(CameraUpdateFactory.CameraPositionUpdate update) {
       super();
       if (update != null) {
         bearing = update.getBearing();
@@ -234,7 +231,7 @@ public final class CameraPosition implements Parcelable {
      *
      * @param update Update containing camera options
      */
-    public Builder(@Nullable CameraUpdateFactory.ZoomUpdate update) {
+    public Builder(CameraUpdateFactory.ZoomUpdate update) {
       super();
       if (update != null) {
         this.zoom = update.getZoom();
@@ -247,7 +244,6 @@ public final class CameraPosition implements Parcelable {
      * @param bearing Bearing
      * @return this
      */
-    @NonNull
     public Builder bearing(double bearing) {
       double direction = bearing;
 
@@ -268,7 +264,6 @@ public final class CameraPosition implements Parcelable {
      * @param location target of the camera
      * @return this
      */
-    @NonNull
     public Builder target(LatLng location) {
       this.target = location;
       return this;
@@ -283,7 +278,6 @@ public final class CameraPosition implements Parcelable {
      * @param tilt Tilt value of the camera
      * @return this
      */
-    @NonNull
     public Builder tilt(@FloatRange(from = MapboxConstants.MINIMUM_TILT,
       to = MapboxConstants.MAXIMUM_TILT) double tilt) {
       this.tilt = MathUtils.clamp(tilt, MapboxConstants.MINIMUM_TILT, MapboxConstants.MAXIMUM_TILT);
@@ -299,7 +293,6 @@ public final class CameraPosition implements Parcelable {
      * @param zoom Zoom value of the camera
      * @return this
      */
-    @NonNull
     public Builder zoom(@FloatRange(from = MapboxConstants.MINIMUM_ZOOM,
       to = MapboxConstants.MAXIMUM_ZOOM) double zoom) {
       this.zoom = zoom;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLng.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLng.java
@@ -6,8 +6,6 @@ import android.os.Parcelable;
 import android.support.annotation.FloatRange;
 import android.support.annotation.Keep;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import com.mapbox.mapboxsdk.constants.GeometryConstants;
 
 
@@ -29,7 +27,7 @@ public class LatLng implements ILatLng, Parcelable {
    * Inner class responsible for recreating Parcels into objects.
    */
   public static final Parcelable.Creator<LatLng> CREATOR = new Parcelable.Creator<LatLng>() {
-    public LatLng createFromParcel(@NonNull Parcel in) {
+    public LatLng createFromParcel(Parcel in) {
       return new LatLng(in);
     }
 
@@ -209,7 +207,6 @@ public class LatLng implements ILatLng, Parcelable {
    *
    * @return new LatLng object with wrapped Longitude
    */
-  @NonNull
   public LatLng wrap() {
     return new LatLng(latitude, wrap(longitude, GeometryConstants.MIN_LONGITUDE, GeometryConstants.MAX_LONGITUDE));
   }
@@ -247,7 +244,7 @@ public class LatLng implements ILatLng, Parcelable {
    * @return True if equal, false if not
    */
   @Override
-  public boolean equals(@Nullable Object object) {
+  public boolean equals(Object object) {
     if (this == object) {
       return true;
     }
@@ -284,7 +281,6 @@ public class LatLng implements ILatLng, Parcelable {
    *
    * @return the string representation
    */
-  @NonNull
   @Override
   public String toString() {
     return "LatLng [latitude=" + latitude + ", longitude=" + longitude + ", altitude=" + altitude + "]";
@@ -307,7 +303,7 @@ public class LatLng implements ILatLng, Parcelable {
    * @param flags Additional flags about how the object should be written
    */
   @Override
-  public void writeToParcel(@NonNull Parcel out, int flags) {
+  public void writeToParcel(Parcel out, int flags) {
     out.writeDouble(latitude);
     out.writeDouble(longitude);
     out.writeDouble(altitude);
@@ -319,7 +315,7 @@ public class LatLng implements ILatLng, Parcelable {
    * @param other Other LatLng to compare to
    * @return distance in meters
    */
-  public double distanceTo(@NonNull LatLng other) {
+  public double distanceTo(LatLng other) {
     if (latitude == other.latitude && longitude == other.longitude) {
       // return 0.0 to avoid a NaN
       return 0.0;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLngBounds.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLngBounds.java
@@ -68,7 +68,6 @@ public class LatLngBounds implements Parcelable {
    *
    * @return LatLng center of this LatLngBounds
    */
-  @NonNull
   public LatLng getCenter() {
     double latCenter = (this.latitudeNorth + this.latitudeSouth) / 2.0;
     double longCenter;
@@ -127,7 +126,6 @@ public class LatLngBounds implements Parcelable {
    *
    * @return LatLng of the south west corner
    */
-  @NonNull
   public LatLng getSouthWest() {
     return new LatLng(latitudeSouth, longitudeWest);
   }
@@ -137,7 +135,6 @@ public class LatLngBounds implements Parcelable {
    *
    * @return LatLng of the north east corner
    */
-  @NonNull
   public LatLng getNorthEast() {
     return new LatLng(latitudeNorth, longitudeEast);
   }
@@ -147,7 +144,6 @@ public class LatLngBounds implements Parcelable {
    *
    * @return LatLng of the south east corner
    */
-  @NonNull
   public LatLng getSouthEast() {
     return new LatLng(latitudeSouth, longitudeEast);
   }
@@ -157,7 +153,6 @@ public class LatLngBounds implements Parcelable {
    *
    * @return LatLng of the north west corner
    */
-  @NonNull
   public LatLng getNorthWest() {
     return new LatLng(latitudeNorth, longitudeWest);
   }
@@ -167,7 +162,6 @@ public class LatLngBounds implements Parcelable {
    *
    * @return LatLngSpan area
    */
-  @NonNull
   public LatLngSpan getSpan() {
     return new LatLngSpan(getLatitudeSpan(), getLongitudeSpan());
   }
@@ -222,7 +216,6 @@ public class LatLngBounds implements Parcelable {
    *
    * @return the string representation
    */
-  @NonNull
   @Override
   public String toString() {
     return "N:" + this.latitudeNorth + "; E:" + this.longitudeEast + "; S:" + this.latitudeSouth
@@ -283,7 +276,6 @@ public class LatLngBounds implements Parcelable {
    *
    * @return an array of 2 LatLng objects.
    */
-  @NonNull
   public LatLng[] toLatLngs() {
     return new LatLng[] {getNorthEast(), getSouthWest()};
   }
@@ -373,8 +365,7 @@ public class LatLngBounds implements Parcelable {
    * @param latLng the latitude lognitude pair to include in the bounds.
    * @return the newly constructed bounds
    */
-  @NonNull
-  public LatLngBounds include(@NonNull LatLng latLng) {
+  public LatLngBounds include(LatLng latLng) {
     return new LatLngBounds.Builder()
       .include(getNorthEast())
       .include(getSouthWest())
@@ -427,7 +418,7 @@ public class LatLngBounds implements Parcelable {
    * @param latLng the point which may be contained
    * @return true, if the point is contained within the bounds
    */
-  public boolean contains(@NonNull final ILatLng latLng) {
+  public boolean contains(final ILatLng latLng) {
     return containsLatitude(latLng.getLatitude())
       && containsLongitude(latLng.getLongitude());
   }
@@ -438,7 +429,7 @@ public class LatLngBounds implements Parcelable {
    * @param other the bounds which may be contained
    * @return true, if the bounds is contained within the bounds
    */
-  public boolean contains(@NonNull final LatLngBounds other) {
+  public boolean contains(final LatLngBounds other) {
     return contains(other.getNorthEast())
       && contains(other.getSouthWest());
   }
@@ -638,7 +629,7 @@ public class LatLngBounds implements Parcelable {
   public static final Parcelable.Creator<LatLngBounds> CREATOR =
     new Parcelable.Creator<LatLngBounds>() {
       @Override
-      public LatLngBounds createFromParcel(@NonNull final Parcel in) {
+      public LatLngBounds createFromParcel(final Parcel in) {
         return readFromParcel(in);
       }
 
@@ -678,7 +669,7 @@ public class LatLngBounds implements Parcelable {
    * @param flags Additional flags about how the object should be written
    */
   @Override
-  public void writeToParcel(@NonNull final Parcel out, final int flags) {
+  public void writeToParcel(final Parcel out, final int flags) {
     out.writeDouble(this.latitudeNorth);
     out.writeDouble(this.longitudeEast);
     out.writeDouble(this.latitudeSouth);
@@ -721,8 +712,7 @@ public class LatLngBounds implements Parcelable {
      * @param latLngs the List of LatLng objects to be added
      * @return this
      */
-    @NonNull
-    public Builder includes(@NonNull List<LatLng> latLngs) {
+    public Builder includes(List<LatLng> latLngs) {
       latLngList.addAll(latLngs);
       return this;
     }
@@ -733,7 +723,6 @@ public class LatLngBounds implements Parcelable {
      * @param latLng the LatLng to be added
      * @return this
      */
-    @NonNull
     public Builder include(@NonNull LatLng latLng) {
       latLngList.add(latLng);
       return this;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLngQuad.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLngQuad.java
@@ -3,7 +3,6 @@ package com.mapbox.mapboxsdk.geometry;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.Keep;
-import android.support.annotation.NonNull;
 
 /**
  * A geographical area representing a non-aligned quadrilateral
@@ -52,7 +51,7 @@ public class LatLngQuad implements Parcelable {
 
   public static final Parcelable.Creator<LatLngQuad> CREATOR = new Parcelable.Creator<LatLngQuad>() {
     @Override
-    public LatLngQuad createFromParcel(@NonNull final Parcel in) {
+    public LatLngQuad createFromParcel(final Parcel in) {
       return readFromParcel(in);
     }
 
@@ -77,14 +76,14 @@ public class LatLngQuad implements Parcelable {
   }
 
   @Override
-  public void writeToParcel(@NonNull final Parcel out, final int arg1) {
+  public void writeToParcel(final Parcel out, final int arg1) {
     topLeft.writeToParcel(out, arg1);
     topRight.writeToParcel(out, arg1);
     bottomRight.writeToParcel(out, arg1);
     bottomLeft.writeToParcel(out, arg1);
   }
 
-  private static LatLngQuad readFromParcel(@NonNull final Parcel in) {
+  private static LatLngQuad readFromParcel(final Parcel in) {
     final LatLng topLeft = new LatLng(in);
     final LatLng topRight = new LatLng(in);
     final LatLng bottomRight = new LatLng(in);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLngSpan.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLngSpan.java
@@ -91,7 +91,7 @@ public class LatLngSpan implements Parcelable {
   public static final Parcelable.Creator<LatLngSpan> CREATOR =
     new Parcelable.Creator<LatLngSpan>() {
       @Override
-      public LatLngSpan createFromParcel(@NonNull Parcel in) {
+      public LatLngSpan createFromParcel(Parcel in) {
         return new LatLngSpan(in);
       }
 
@@ -118,7 +118,7 @@ public class LatLngSpan implements Parcelable {
    * @param flags Additional flags about how the object should be written
    */
   @Override
-  public void writeToParcel(@NonNull Parcel out, int flags) {
+  public void writeToParcel(Parcel out, int flags) {
     out.writeDouble(mLatitudeSpan);
     out.writeDouble(mLongitudeSpan);
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/ProjectedMeters.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/ProjectedMeters.java
@@ -3,8 +3,6 @@ package com.mapbox.mapboxsdk.geometry;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.Keep;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 /**
  * ProjectedMeters is a projection of longitude, latitude points in Mercator meters.
@@ -20,7 +18,7 @@ public class ProjectedMeters implements IProjectedMeters, Parcelable {
    * Inner class responsible for recreating Parcels into objects.
    */
   public static final Creator<ProjectedMeters> CREATOR = new Creator<ProjectedMeters>() {
-    public ProjectedMeters createFromParcel(@NonNull Parcel in) {
+    public ProjectedMeters createFromParcel(Parcel in) {
       return new ProjectedMeters(in);
     }
 
@@ -92,7 +90,7 @@ public class ProjectedMeters implements IProjectedMeters, Parcelable {
    * @return true if equal, false if not
    */
   @Override
-  public boolean equals(@Nullable Object other) {
+  public boolean equals(Object other) {
     if (this == other) {
       return true;
     }
@@ -127,7 +125,6 @@ public class ProjectedMeters implements IProjectedMeters, Parcelable {
    *
    * @return the string representation of this
    */
-  @NonNull
   @Override
   public String toString() {
     return "ProjectedMeters [northing=" + northing + ", easting=" + easting + "]";
@@ -150,7 +147,7 @@ public class ProjectedMeters implements IProjectedMeters, Parcelable {
    * @param flags Additional flags about how the object should be written
    */
   @Override
-  public void writeToParcel(@NonNull Parcel out, int flags) {
+  public void writeToParcel(Parcel out, int flags) {
     out.writeDouble(northing);
     out.writeDouble(easting);
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/VisibleRegion.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/VisibleRegion.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.geometry;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
 
 /**
  * Contains the four points defining the four-sided polygon that is visible in a map's camera.
@@ -99,7 +98,6 @@ public class VisibleRegion implements Parcelable {
    *
    * @return the string representation of this
    */
-  @NonNull
   @Override
   public String toString() {
     return "[farLeft [" + farLeft + "], farRight [" + farRight + "], nearLeft [" + nearLeft + "], nearRight ["
@@ -136,7 +134,7 @@ public class VisibleRegion implements Parcelable {
    * @param flags Additional flags about how the object should be written
    */
   @Override
-  public void writeToParcel(@NonNull Parcel out, int flags) {
+  public void writeToParcel(Parcel out, int flags) {
     out.writeParcelable(farLeft, flags);
     out.writeParcelable(farRight, flags);
     out.writeParcelable(nearLeft, flags);
@@ -149,7 +147,7 @@ public class VisibleRegion implements Parcelable {
    */
   public static final Parcelable.Creator<VisibleRegion> CREATOR =
     new Parcelable.Creator<VisibleRegion>() {
-      public VisibleRegion createFromParcel(@NonNull Parcel in) {
+      public VisibleRegion createFromParcel(Parcel in) {
         return new VisibleRegion(in);
       }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HttpRequestUrl.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HttpRequestUrl.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxsdk.http;
 
-import android.support.annotation.NonNull;
-
 public class HttpRequestUrl {
 
   private HttpRequestUrl() {
@@ -15,7 +13,7 @@ public class HttpRequestUrl {
    * @param querySize   the query size of the resource request
    * @return the adapted resource url
    */
-  public static String buildResourceUrl(@NonNull String host, String resourceUrl, int querySize) {
+  public static String buildResourceUrl(String host, String resourceUrl, int querySize) {
     if (isValidMapboxEndpoint(host)) {
       if (querySize == 0) {
         resourceUrl = resourceUrl + "?";

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/LocalRequestTask.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/LocalRequestTask.java
@@ -3,8 +3,6 @@ package com.mapbox.mapboxsdk.http;
 import android.content.res.AssetManager;
 import android.os.AsyncTask;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import com.mapbox.mapboxsdk.MapStrictMode;
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.log.Logger;
@@ -22,7 +20,6 @@ class LocalRequestTask extends AsyncTask<String, Void, byte[]> {
     this.requestResponse = requestResponse;
   }
 
-  @Nullable
   @Override
   protected byte[] doInBackground(String... strings) {
     return loadFile(Mapbox.getApplicationContext().getAssets(),
@@ -33,15 +30,14 @@ class LocalRequestTask extends AsyncTask<String, Void, byte[]> {
   }
 
   @Override
-  protected void onPostExecute(@Nullable byte[] bytes) {
+  protected void onPostExecute(byte[] bytes) {
     super.onPostExecute(bytes);
     if (bytes != null && requestResponse != null) {
       requestResponse.onResponse(bytes);
     }
   }
 
-  @Nullable
-  private static byte[] loadFile(AssetManager assets, @NonNull String path) {
+  private static byte[] loadFile(AssetManager assets, String path) {
     byte[] buffer = null;
     try (InputStream input = assets.open(path)) {
       int size = input.available();

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/CameraCompassBearingAnimator.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/CameraCompassBearingAnimator.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.location;
 
 import android.animation.ValueAnimator;
-import android.support.annotation.NonNull;
 
 import java.util.List;
 
@@ -17,7 +16,7 @@ class CameraCompassBearingAnimator extends MapboxFloatAnimator<MapboxAnimator.On
   }
 
   @Override
-  public void onAnimationUpdate(@NonNull ValueAnimator animation) {
+  public void onAnimationUpdate(ValueAnimator animation) {
     for (OnCameraAnimationsValuesChangeListener listener : updateListeners) {
       listener.onNewCompassBearingValue((Float) animation.getAnimatedValue());
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/CameraGpsBearingAnimator.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/CameraGpsBearingAnimator.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.location;
 
 import android.animation.ValueAnimator;
-import android.support.annotation.NonNull;
 
 import java.util.List;
 
@@ -16,7 +15,7 @@ class CameraGpsBearingAnimator extends MapboxFloatAnimator<MapboxAnimator.OnCame
   }
 
   @Override
-  public void onAnimationUpdate(@NonNull ValueAnimator animation) {
+  public void onAnimationUpdate(ValueAnimator animation) {
     for (OnCameraAnimationsValuesChangeListener listener : updateListeners) {
       listener.onNewGpsBearingValue((Float) animation.getAnimatedValue());
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/CameraLatLngAnimator.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/CameraLatLngAnimator.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.location;
 
 import android.animation.ValueAnimator;
 
-import android.support.annotation.NonNull;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
 import java.util.List;
@@ -18,7 +17,7 @@ class CameraLatLngAnimator extends MapboxLatLngAnimator<MapboxAnimator.OnCameraA
   }
 
   @Override
-  public void onAnimationUpdate(@NonNull ValueAnimator animation) {
+  public void onAnimationUpdate(ValueAnimator animation) {
     for (OnCameraAnimationsValuesChangeListener listener : updateListeners) {
       listener.onNewLatLngValue((LatLng) animation.getAnimatedValue());
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LatLngEvaluator.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LatLngEvaluator.java
@@ -2,16 +2,14 @@ package com.mapbox.mapboxsdk.location;
 
 import android.animation.TypeEvaluator;
 
-import android.support.annotation.NonNull;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
 class LatLngEvaluator implements TypeEvaluator<LatLng> {
 
   private final LatLng latLng = new LatLng();
 
-  @NonNull
   @Override
-  public LatLng evaluate(float fraction, @NonNull LatLng startValue, @NonNull LatLng endValue) {
+  public LatLng evaluate(float fraction, LatLng startValue, LatLng endValue) {
     latLng.setLatitude(startValue.getLatitude()
       + ((endValue.getLatitude() - startValue.getLatitude()) * fraction));
     latLng.setLongitude(startValue.getLongitude()

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LayerAccuracyAnimator.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LayerAccuracyAnimator.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.location;
 
 import android.animation.ValueAnimator;
-import android.support.annotation.NonNull;
 
 import java.util.List;
 
@@ -17,7 +16,7 @@ class LayerAccuracyAnimator extends MapboxFloatAnimator<MapboxAnimator.OnLayerAn
   }
 
   @Override
-  public void onAnimationUpdate(@NonNull ValueAnimator animation) {
+  public void onAnimationUpdate(ValueAnimator animation) {
     for (OnLayerAnimationsValuesChangeListener listener : updateListeners) {
       listener.onNewAccuracyRadiusValue((Float) animation.getAnimatedValue());
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LayerBitmapProvider.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LayerBitmapProvider.java
@@ -5,7 +5,6 @@ import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.ColorInt;
 import android.support.annotation.DrawableRes;
-import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
 
 import com.mapbox.mapboxsdk.R;
@@ -27,7 +26,7 @@ class LayerBitmapProvider {
     return getBitmapFromDrawable(drawable);
   }
 
-  Bitmap generateShadowBitmap(@NonNull LocationComponentOptions options) {
+  Bitmap generateShadowBitmap(LocationComponentOptions options) {
     Drawable shadowDrawable = ContextCompat.getDrawable(context, R.drawable.mapbox_user_icon_shadow);
     return generateShadow(shadowDrawable, options.elevation());
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LayerCompassBearingAnimator.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LayerCompassBearingAnimator.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.location;
 
 import android.animation.ValueAnimator;
-import android.support.annotation.NonNull;
 
 import java.util.List;
 
@@ -17,7 +16,7 @@ class LayerCompassBearingAnimator extends MapboxFloatAnimator<MapboxAnimator.OnL
   }
 
   @Override
-  public void onAnimationUpdate(@NonNull ValueAnimator animation) {
+  public void onAnimationUpdate(ValueAnimator animation) {
     for (OnLayerAnimationsValuesChangeListener listener : updateListeners) {
       listener.onNewCompassBearingValue((Float) animation.getAnimatedValue());
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LayerFeatureProvider.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LayerFeatureProvider.java
@@ -13,7 +13,7 @@ import static com.mapbox.mapboxsdk.location.LocationComponentConstants.PROPERTY_
 class LayerFeatureProvider {
 
   @NonNull
-  Feature generateLocationFeature(@Nullable Feature locationFeature, @NonNull LocationComponentOptions options) {
+  Feature generateLocationFeature(@Nullable Feature locationFeature, LocationComponentOptions options) {
     if (locationFeature != null) {
       return locationFeature;
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LayerGpsBearingAnimator.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LayerGpsBearingAnimator.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.location;
 
 import android.animation.ValueAnimator;
-import android.support.annotation.NonNull;
 
 import java.util.List;
 
@@ -16,7 +15,7 @@ class LayerGpsBearingAnimator extends MapboxFloatAnimator<MapboxAnimator.OnLayer
   }
 
   @Override
-  public void onAnimationUpdate(@NonNull ValueAnimator animation) {
+  public void onAnimationUpdate(ValueAnimator animation) {
     for (OnLayerAnimationsValuesChangeListener listener : updateListeners) {
       listener.onNewGpsBearingValue((Float) animation.getAnimatedValue());
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LayerLatLngAnimator.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LayerLatLngAnimator.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.location;
 
 import android.animation.ValueAnimator;
 
-import android.support.annotation.NonNull;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
 import java.util.List;
@@ -18,7 +17,7 @@ class LayerLatLngAnimator extends MapboxLatLngAnimator<MapboxAnimator.OnLayerAni
   }
 
   @Override
-  public void onAnimationUpdate(@NonNull ValueAnimator animation) {
+  public void onAnimationUpdate(ValueAnimator animation) {
     for (OnLayerAnimationsValuesChangeListener listener : updateListeners) {
       listener.onNewLatLngValue((LatLng) animation.getAnimatedValue());
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LayerSourceProvider.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LayerSourceProvider.java
@@ -1,6 +1,5 @@
 package com.mapbox.mapboxsdk.location;
 
-import android.support.annotation.NonNull;
 import com.mapbox.geojson.Feature;
 import com.mapbox.mapboxsdk.style.layers.CircleLayer;
 import com.mapbox.mapboxsdk.style.layers.Layer;
@@ -51,7 +50,6 @@ class LayerSourceProvider {
 
   private static final String EMPTY_STRING = "";
 
-  @NonNull
   GeoJsonSource generateSource(Feature locationFeature) {
     return new GeoJsonSource(
       LOCATION_SOURCE,
@@ -60,8 +58,7 @@ class LayerSourceProvider {
     );
   }
 
-  @NonNull
-  Layer generateLayer(@NonNull String layerId) {
+  Layer generateLayer(String layerId) {
     SymbolLayer layer = new SymbolLayer(layerId, LOCATION_SOURCE);
     layer.setProperties(
       iconAllowOverlap(true),
@@ -97,7 +94,6 @@ class LayerSourceProvider {
     return layer;
   }
 
-  @NonNull
   Layer generateAccuracyLayer() {
     return new CircleLayer(ACCURACY_LAYER, LOCATION_SOURCE)
       .withProperties(

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinator.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinator.java
@@ -295,18 +295,18 @@ final class LocationAnimatorCoordinator {
     locationAnimatorSet.start();
   }
 
-  void resetAllCameraAnimations(@NonNull CameraPosition currentCameraPosition, boolean isGpsNorth) {
+  void resetAllCameraAnimations(CameraPosition currentCameraPosition, boolean isGpsNorth) {
     resetCameraCompassAnimation(currentCameraPosition);
     boolean snap = resetCameraLocationAnimations(currentCameraPosition, isGpsNorth);
     playCameraLocationAnimators(snap ? 0 : TRANSITION_ANIMATION_DURATION_MS);
   }
 
-  private boolean resetCameraLocationAnimations(@NonNull CameraPosition currentCameraPosition, boolean isGpsNorth) {
+  private boolean resetCameraLocationAnimations(CameraPosition currentCameraPosition, boolean isGpsNorth) {
     resetCameraGpsBearingAnimation(currentCameraPosition, isGpsNorth);
     return resetCameraLatLngAnimation(currentCameraPosition);
   }
 
-  private boolean resetCameraLatLngAnimation(@NonNull CameraPosition currentCameraPosition) {
+  private boolean resetCameraLatLngAnimation(CameraPosition currentCameraPosition) {
     CameraLatLngAnimator animator = (CameraLatLngAnimator) animatorArray.get(ANIMATOR_CAMERA_LATLNG);
     if (animator == null) {
       return false;
@@ -320,7 +320,7 @@ final class LocationAnimatorCoordinator {
     return immediateAnimation(previousCameraTarget, currentTarget, currentCameraPosition.zoom);
   }
 
-  private void resetCameraGpsBearingAnimation(@NonNull CameraPosition currentCameraPosition, boolean isGpsNorth) {
+  private void resetCameraGpsBearingAnimation(CameraPosition currentCameraPosition, boolean isGpsNorth) {
     CameraGpsBearingAnimator animator = (CameraGpsBearingAnimator) animatorArray.get(ANIMATOR_CAMERA_GPS_BEARING);
     if (animator == null) {
       return;
@@ -334,7 +334,7 @@ final class LocationAnimatorCoordinator {
       new CameraGpsBearingAnimator(previousCameraBearing, normalizedCameraBearing, cameraListeners));
   }
 
-  private void resetCameraCompassAnimation(@NonNull CameraPosition currentCameraPosition) {
+  private void resetCameraCompassAnimation(CameraPosition currentCameraPosition) {
     CameraCompassBearingAnimator animator =
       (CameraCompassBearingAnimator) animatorArray.get(ANIMATOR_CAMERA_COMPASS_BEARING);
     if (animator == null) {
@@ -382,7 +382,7 @@ final class LocationAnimatorCoordinator {
     this.durationMultiplier = trackingAnimationDurationMultiplier;
   }
 
-  private boolean immediateAnimation(LatLng current, @NonNull LatLng target, double zoom) {
+  private boolean immediateAnimation(LatLng current, LatLng target, double zoom) {
     // TODO: calculate the value based on the projection
     double distance = current.distanceTo(target);
     if (zoom > 10) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationCameraController.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationCameraController.java
@@ -3,7 +3,6 @@ package com.mapbox.mapboxsdk.location;
 import android.content.Context;
 import android.graphics.PointF;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 import android.view.MotionEvent;
 
@@ -35,7 +34,7 @@ final class LocationCameraController implements MapboxAnimator.OnCameraAnimation
     Context context,
     MapboxMap mapboxMap,
     OnCameraTrackingChangedListener internalCameraTrackingChangedListener,
-    @NonNull LocationComponentOptions options,
+    LocationComponentOptions options,
     OnCameraMoveInvalidateListener onCameraMoveInvalidateListener) {
     this.mapboxMap = mapboxMap;
 
@@ -93,7 +92,7 @@ final class LocationCameraController implements MapboxAnimator.OnCameraAnimation
     onCameraMoveInvalidateListener.onInvalidateCameraMove();
   }
 
-  private void setLatLng(@NonNull LatLng latLng) {
+  private void setLatLng(LatLng latLng) {
     mapboxMap.moveCamera(CameraUpdateFactory.newLatLng(latLng));
     onCameraMoveInvalidateListener.onInvalidateCameraMove();
   }
@@ -109,7 +108,7 @@ final class LocationCameraController implements MapboxAnimator.OnCameraAnimation
   }
 
   @Override
-  public void onNewLatLngValue(@NonNull LatLng latLng) {
+  public void onNewLatLngValue(LatLng latLng) {
     if (cameraMode == CameraMode.TRACKING
       || cameraMode == CameraMode.TRACKING_COMPASS
       || cameraMode == CameraMode.TRACKING_GPS
@@ -188,7 +187,6 @@ final class LocationCameraController implements MapboxAnimator.OnCameraAnimation
     }
   }
 
-  @NonNull
   @VisibleForTesting
   MapboxMap.OnMoveListener onMoveListener = new MapboxMap.OnMoveListener() {
     private boolean interrupt;
@@ -228,7 +226,6 @@ final class LocationCameraController implements MapboxAnimator.OnCameraAnimation
     }
   };
 
-  @NonNull
   private MapboxMap.OnRotateListener onRotateListener = new MapboxMap.OnRotateListener() {
     @Override
     public void onRotateBegin(@NonNull RotateGestureDetector detector) {
@@ -248,7 +245,6 @@ final class LocationCameraController implements MapboxAnimator.OnCameraAnimation
     }
   };
 
-  @NonNull
   private MapboxMap.OnFlingListener onFlingListener = new MapboxMap.OnFlingListener() {
     @Override
     public void onFling() {
@@ -263,7 +259,7 @@ final class LocationCameraController implements MapboxAnimator.OnCameraAnimation
     }
 
     @Override
-    public boolean onTouchEvent(@Nullable MotionEvent motionEvent) {
+    public boolean onTouchEvent(MotionEvent motionEvent) {
       if (motionEvent != null) {
         int action = motionEvent.getActionMasked();
         if (action == MotionEvent.ACTION_UP) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
@@ -75,12 +75,9 @@ import static com.mapbox.mapboxsdk.location.LocationComponentConstants.DEFAULT_T
 public final class LocationComponent {
   private static final String TAG = "Mbgl-LocationComponent";
 
-  @NonNull
   private final MapboxMap mapboxMap;
   private LocationComponentOptions options;
-  @Nullable
   private LocationEngine locationEngine;
-  @Nullable
   private CompassEngine compassEngine;
   private boolean usingInternalLocationEngine;
 
@@ -93,7 +90,6 @@ public final class LocationComponent {
    * Holds last location which is being returned in the {@link #getLastKnownLocation()}
    * when there is no {@link #locationEngine} set or when the last location returned by the engine is null.
    */
-  @Nullable
   private Location lastLocation;
   private CameraPosition lastCameraPosition;
 
@@ -343,7 +339,7 @@ public final class LocationComponent {
    *
    * @param options to update the current style
    */
-  public void applyStyle(@NonNull LocationComponentOptions options) {
+  public void applyStyle(LocationComponentOptions options) {
     this.options = options;
     locationLayerController.applyStyle(options);
     locationCameraController.initializeOptions(options);
@@ -835,7 +831,7 @@ public final class LocationComponent {
    *
    * @param location the latest user location
    */
-  private void updateLocation(@Nullable final Location location, boolean fromLastLocation) {
+  private void updateLocation(final Location location, boolean fromLastLocation) {
     if (location == null) {
       return;
     } else if (!isLayerReady) {
@@ -906,7 +902,6 @@ public final class LocationComponent {
     locationAnimatorCoordinator.feedNewAccuracyRadius(Utils.calculateZoomLevelRadius(mapboxMap, location), noAnimation);
   }
 
-  @NonNull
   private OnCameraMoveListener onCameraMoveListener = new OnCameraMoveListener() {
     @Override
     public void onCameraMove() {
@@ -914,7 +909,6 @@ public final class LocationComponent {
     }
   };
 
-  @NonNull
   private OnCameraIdleListener onCameraIdleListener = new OnCameraIdleListener() {
     @Override
     public void onCameraIdle() {
@@ -922,7 +916,6 @@ public final class LocationComponent {
     }
   };
 
-  @NonNull
   private OnMapClickListener onMapClickListener = new OnMapClickListener() {
     @Override
     public void onMapClick(@NonNull LatLng point) {
@@ -934,7 +927,6 @@ public final class LocationComponent {
     }
   };
 
-  @NonNull
   private MapboxMap.OnMapLongClickListener onMapLongClickListener = new MapboxMap.OnMapLongClickListener() {
     @Override
     public void onMapLongClick(@NonNull LatLng point) {
@@ -946,7 +938,6 @@ public final class LocationComponent {
     }
   };
 
-  @NonNull
   private OnLocationStaleListener onLocationStaleListener = new OnLocationStaleListener() {
     @Override
     public void onStaleStateChange(boolean isStale) {
@@ -958,7 +949,6 @@ public final class LocationComponent {
     }
   };
 
-  @NonNull
   private OnCameraMoveInvalidateListener onCameraMoveInvalidateListener = new OnCameraMoveInvalidateListener() {
     @Override
     public void onInvalidateCameraMove() {
@@ -966,7 +956,6 @@ public final class LocationComponent {
     }
   };
 
-  @NonNull
   private CompassListener compassListener = new CompassListener() {
     @Override
     public void onCompassChanged(float userHeading) {
@@ -979,7 +968,6 @@ public final class LocationComponent {
     }
   };
 
-  @NonNull
   private LocationEngineListener locationEngineListener = new LocationEngineListener() {
     @Override
     @SuppressWarnings( {"MissingPermission"})
@@ -995,7 +983,6 @@ public final class LocationComponent {
     }
   };
 
-  @NonNull
   private OnCameraTrackingChangedListener cameraTrackingChangedListener = new OnCameraTrackingChangedListener() {
     @Override
     public void onCameraTrackingDismissed() {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentCompassEngine.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentCompassEngine.java
@@ -31,7 +31,6 @@ class LocationComponentCompassEngine implements CompassEngine, SensorEventListen
   private static final float ALPHA = 0.45f;
 
   private final WindowManager windowManager;
-  @NonNull
   private final SensorManager sensorManager;
   private final List<CompassListener> compassListeners = new ArrayList<>();
 
@@ -43,18 +42,14 @@ class LocationComponentCompassEngine implements CompassEngine, SensorEventListen
   @Nullable
   private Sensor magneticFieldSensor;
 
-  @NonNull
   private float[] truncatedRotationVectorValue = new float[4];
-  @NonNull
   private float[] rotationMatrix = new float[9];
   private float[] rotationVectorValue;
   private float lastHeading;
   private int lastAccuracySensorStatus;
 
   private long compassUpdateNextTimestamp;
-  @Nullable
   private float[] gravityValues = new float[3];
-  @Nullable
   private float[] magneticValues = new float[3];
 
   /**
@@ -114,7 +109,7 @@ class LocationComponentCompassEngine implements CompassEngine, SensorEventListen
   }
 
   @Override
-  public void onSensorChanged(@NonNull SensorEvent event) {
+  public void onSensorChanged(SensorEvent event) {
     // check when the last time the compass was updated, return if too soon.
     long currentTime = SystemClock.elapsedRealtime();
     if (currentTime < compassUpdateNextTimestamp) {
@@ -238,8 +233,7 @@ class LocationComponentCompassEngine implements CompassEngine, SensorEventListen
    * @param smoothedValues array of float, that contains previous state
    * @return float filtered array of float
    */
-  @Nullable
-  private float[] lowPassFilter(@NonNull float[] newValues, @Nullable float[] smoothedValues) {
+  private float[] lowPassFilter(float[] newValues, float[] smoothedValues) {
     if (smoothedValues == null) {
       return newValues;
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentOptions.java
@@ -82,37 +82,25 @@ public class LocationComponentOptions implements Parcelable {
   private float accuracyAlpha;
   private int accuracyColor;
   private int backgroundDrawableStale;
-  @Nullable
   private String backgroundStaleName;
   private int foregroundDrawableStale;
-  @Nullable
   private String foregroundStaleName;
   private int gpsDrawable;
-  @Nullable
   private String gpsName;
   private int foregroundDrawable;
-  @Nullable
   private String foregroundName;
   private int backgroundDrawable;
-  @Nullable
   private String backgroundName;
   private int bearingDrawable;
-  @Nullable
   private String bearingName;
-  @Nullable
   private Integer bearingTintColor;
-  @Nullable
   private Integer foregroundTintColor;
-  @Nullable
   private Integer backgroundTintColor;
-  @Nullable
   private Integer foregroundStaleTintColor;
-  @Nullable
   private Integer backgroundStaleTintColor;
   private float elevation;
   private boolean enableStaleState;
   private long staleStateTimeout;
-  @Nullable
   private int[] padding;
   private double maxZoom;
   private double minZoom;
@@ -147,7 +135,7 @@ public class LocationComponentOptions implements Parcelable {
     float elevation,
     boolean enableStaleState,
     long staleStateTimeout,
-    @Nullable int[] padding,
+    int[] padding,
     double maxZoom,
     double minZoom,
     float maxZoomIconScale,
@@ -204,7 +192,6 @@ public class LocationComponentOptions implements Parcelable {
    * @return a new {@link LocationComponentOptions} object with the settings you defined in your style
    * resource
    */
-  @Nullable
   public static LocationComponentOptions createFromAttributes(@NonNull Context context,
                                                               @StyleRes int styleRes) {
 
@@ -329,7 +316,6 @@ public class LocationComponentOptions implements Parcelable {
    *
    * @return the builder which contains the values defined in this current instance as defaults.
    */
-  @NonNull
   public Builder toBuilder() {
     return new Builder(this);
   }
@@ -342,8 +328,7 @@ public class LocationComponentOptions implements Parcelable {
    * @param context your activities context used to acquire the style resource
    * @return the builder which contains the default values defined by the style resource
    */
-  @NonNull
-  public static Builder builder(@NonNull Context context) {
+  public static Builder builder(Context context) {
     return LocationComponentOptions.createFromAttributes(context,
       R.style.mapbox_LocationComponent).toBuilder();
   }
@@ -641,7 +626,6 @@ public class LocationComponentOptions implements Parcelable {
    *
    * @return integer array of padding values
    */
-  @Nullable
   @SuppressWarnings("mutable")
   public int[] padding() {
     return padding;
@@ -739,7 +723,6 @@ public class LocationComponentOptions implements Parcelable {
     return trackingAnimationDurationMultiplier;
   }
 
-  @NonNull
   @Override
   public String toString() {
     return "LocationComponentOptions{"
@@ -949,7 +932,7 @@ public class LocationComponentOptions implements Parcelable {
     };
 
   @Override
-  public void writeToParcel(@NonNull Parcel dest, int flags) {
+  public void writeToParcel(Parcel dest, int flags) {
     dest.writeFloat(accuracyAlpha());
     dest.writeInt(accuracyColor());
     dest.writeInt(backgroundDrawableStale());
@@ -1072,37 +1055,25 @@ public class LocationComponentOptions implements Parcelable {
     private Float accuracyAlpha;
     private Integer accuracyColor;
     private Integer backgroundDrawableStale;
-    @Nullable
     private String backgroundStaleName;
     private Integer foregroundDrawableStale;
-    @Nullable
     private String foregroundStaleName;
     private Integer gpsDrawable;
-    @Nullable
     private String gpsName;
     private Integer foregroundDrawable;
-    @Nullable
     private String foregroundName;
     private Integer backgroundDrawable;
-    @Nullable
     private String backgroundName;
     private Integer bearingDrawable;
-    @Nullable
     private String bearingName;
-    @Nullable
     private Integer bearingTintColor;
-    @Nullable
     private Integer foregroundTintColor;
-    @Nullable
     private Integer backgroundTintColor;
-    @Nullable
     private Integer foregroundStaleTintColor;
-    @Nullable
     private Integer backgroundStaleTintColor;
     private Float elevation;
     private Boolean enableStaleState;
     private Long staleStateTimeout;
-    @Nullable
     private int[] padding;
     private Double maxZoom;
     private Double minZoom;
@@ -1160,7 +1131,6 @@ public class LocationComponentOptions implements Parcelable {
      * @return this builder for chaining options together
      * @attr ref R.styleable#LocationComponent_accuracyAlpha
      */
-    @NonNull
     public LocationComponentOptions.Builder accuracyAlpha(float accuracyAlpha) {
       this.accuracyAlpha = accuracyAlpha;
       return this;
@@ -1173,7 +1143,6 @@ public class LocationComponentOptions implements Parcelable {
      * @return this builder for chaining options together
      * @attr ref R.styleable#LocationComponent_accuracyColor
      */
-    @NonNull
     public LocationComponentOptions.Builder accuracyColor(int accuracyColor) {
       this.accuracyColor = accuracyColor;
       return this;
@@ -1186,7 +1155,6 @@ public class LocationComponentOptions implements Parcelable {
      * @return this builder for chaining options together
      * @attr ref R.styleable#LocationComponent_backgroundDrawableStale
      */
-    @NonNull
     public LocationComponentOptions.Builder backgroundDrawableStale(int backgroundDrawableStale) {
       this.backgroundDrawableStale = backgroundDrawableStale;
       return this;
@@ -1204,7 +1172,6 @@ public class LocationComponentOptions implements Parcelable {
      * @param backgroundStaleName String icon or maki-icon name
      * @return this builder for chaining options together
      */
-    @NonNull
     public LocationComponentOptions.Builder backgroundStaleName(@Nullable String backgroundStaleName) {
       this.backgroundStaleName = backgroundStaleName;
       return this;
@@ -1217,7 +1184,6 @@ public class LocationComponentOptions implements Parcelable {
      * @return this builder for chaining options together
      * @attr ref R.styleable#LocationComponent_foregroundDrawableStale
      */
-    @NonNull
     public LocationComponentOptions.Builder foregroundDrawableStale(int foregroundDrawableStale) {
       this.foregroundDrawableStale = foregroundDrawableStale;
       return this;
@@ -1235,7 +1201,6 @@ public class LocationComponentOptions implements Parcelable {
      * @param foregroundStaleName String icon or maki-icon name
      * @return this builder for chaining options together
      */
-    @NonNull
     public LocationComponentOptions.Builder foregroundStaleName(@Nullable String foregroundStaleName) {
       this.foregroundStaleName = foregroundStaleName;
       return this;
@@ -1248,7 +1213,6 @@ public class LocationComponentOptions implements Parcelable {
      * @return this builder for chaining options together
      * @attr ref R.styleable#LocationComponent_gpsDrawable
      */
-    @NonNull
     public LocationComponentOptions.Builder gpsDrawable(int gpsDrawable) {
       this.gpsDrawable = gpsDrawable;
       return this;
@@ -1266,7 +1230,6 @@ public class LocationComponentOptions implements Parcelable {
      * @param gpsName String icon or maki-icon name
      * @return this builder for chaining options together
      */
-    @NonNull
     public LocationComponentOptions.Builder gpsName(@Nullable String gpsName) {
       this.gpsName = gpsName;
       return this;
@@ -1279,7 +1242,6 @@ public class LocationComponentOptions implements Parcelable {
      * @return this builder for chaining options together
      * @attr ref R.styleable#LocationComponent_foregroundDrawable
      */
-    @NonNull
     public LocationComponentOptions.Builder foregroundDrawable(int foregroundDrawable) {
       this.foregroundDrawable = foregroundDrawable;
       return this;
@@ -1297,7 +1259,6 @@ public class LocationComponentOptions implements Parcelable {
      * @param foregroundName String icon or maki-icon name
      * @return this builder for chaining options together
      */
-    @NonNull
     public LocationComponentOptions.Builder foregroundName(@Nullable String foregroundName) {
       this.foregroundName = foregroundName;
       return this;
@@ -1310,7 +1271,6 @@ public class LocationComponentOptions implements Parcelable {
      * @return this builder for chaining options together
      * @attr ref R.styleable#LocationComponent_backgroundDrawable
      */
-    @NonNull
     public LocationComponentOptions.Builder backgroundDrawable(int backgroundDrawable) {
       this.backgroundDrawable = backgroundDrawable;
       return this;
@@ -1328,7 +1288,6 @@ public class LocationComponentOptions implements Parcelable {
      * @param backgroundName String icon or maki-icon name
      * @return this builder for chaining options together
      */
-    @NonNull
     public LocationComponentOptions.Builder backgroundName(@Nullable String backgroundName) {
       this.backgroundName = backgroundName;
       return this;
@@ -1341,7 +1300,6 @@ public class LocationComponentOptions implements Parcelable {
      * @return this builder for chaining options together
      * @attr ref R.styleable#LocationComponent_bearingDrawable
      */
-    @NonNull
     public LocationComponentOptions.Builder bearingDrawable(int bearingDrawable) {
       this.bearingDrawable = bearingDrawable;
       return this;
@@ -1359,7 +1317,6 @@ public class LocationComponentOptions implements Parcelable {
      * @param bearingName String icon or maki-icon name
      * @return this builder for chaining options together
      */
-    @NonNull
     public LocationComponentOptions.Builder bearingName(@Nullable String bearingName) {
       this.bearingName = bearingName;
       return this;
@@ -1372,7 +1329,6 @@ public class LocationComponentOptions implements Parcelable {
      * @return this builder for chaining options together
      * @attr ref R.styleable#LocationComponent_bearingTintColor
      */
-    @NonNull
     public LocationComponentOptions.Builder bearingTintColor(@Nullable Integer bearingTintColor) {
       this.bearingTintColor = bearingTintColor;
       return this;
@@ -1385,7 +1341,6 @@ public class LocationComponentOptions implements Parcelable {
      * @return this builder for chaining options together
      * @attr ref R.styleable#LocationComponent_foregroundTintColor
      */
-    @NonNull
     public LocationComponentOptions.Builder foregroundTintColor(@Nullable Integer foregroundTintColor) {
       this.foregroundTintColor = foregroundTintColor;
       return this;
@@ -1398,7 +1353,6 @@ public class LocationComponentOptions implements Parcelable {
      * @return this builder for chaining options together
      * @attr ref R.styleable#LocationComponent_backgroundTintColor
      */
-    @NonNull
     public LocationComponentOptions.Builder backgroundTintColor(@Nullable Integer backgroundTintColor) {
       this.backgroundTintColor = backgroundTintColor;
       return this;
@@ -1411,7 +1365,6 @@ public class LocationComponentOptions implements Parcelable {
      * @return this builder for chaining options together
      * @attr ref R.styleable#LocationComponent_foregroundStaleTintColor
      */
-    @NonNull
     public LocationComponentOptions.Builder foregroundStaleTintColor(@Nullable Integer foregroundStaleTintColor) {
       this.foregroundStaleTintColor = foregroundStaleTintColor;
       return this;
@@ -1424,7 +1377,6 @@ public class LocationComponentOptions implements Parcelable {
      * @return this builder for chaining options together
      * @attr ref R.styleable#LocationComponent_backgroundStaleTintColor
      */
-    @NonNull
     public LocationComponentOptions.Builder backgroundStaleTintColor(@Nullable Integer backgroundStaleTintColor) {
       this.backgroundStaleTintColor = backgroundStaleTintColor;
       return this;
@@ -1437,7 +1389,6 @@ public class LocationComponentOptions implements Parcelable {
      * @return this builder for chaining options together
      * @attr ref R.styleable#LocationComponent_elevation
      */
-    @NonNull
     public LocationComponentOptions.Builder elevation(float elevation) {
       this.elevation = elevation;
       return this;
@@ -1451,7 +1402,6 @@ public class LocationComponentOptions implements Parcelable {
      * @return this builder for chaining options together
      * @attr ref R.styleable#LocationComponent_enableStaleState
      */
-    @NonNull
     public LocationComponentOptions.Builder enableStaleState(boolean enabled) {
       this.enableStaleState = enabled;
       return this;
@@ -1467,7 +1417,6 @@ public class LocationComponentOptions implements Parcelable {
      * @return this builder for chaining options together
      * @attr ref R.styleable#LocationComponent_staleStateTimeout
      */
-    @NonNull
     public LocationComponentOptions.Builder staleStateTimeout(long timeout) {
       this.staleStateTimeout = timeout;
       return this;
@@ -1487,8 +1436,7 @@ public class LocationComponentOptions implements Parcelable {
      *
      * @param padding The margins for the map in pixels (left, top, right, bottom).
      */
-    @NonNull
-    public LocationComponentOptions.Builder padding(@Nullable int[] padding) {
+    public LocationComponentOptions.Builder padding(int[] padding) {
       if (padding == null) {
         throw new NullPointerException("Null padding");
       }
@@ -1503,7 +1451,6 @@ public class LocationComponentOptions implements Parcelable {
      *
      * @param maxZoom The new maximum zoom level.
      */
-    @NonNull
     public LocationComponentOptions.Builder maxZoom(double maxZoom) {
       this.maxZoom = maxZoom;
       return this;
@@ -1514,7 +1461,6 @@ public class LocationComponentOptions implements Parcelable {
      *
      * @param minZoom The new minimum zoom level.
      */
-    @NonNull
     public LocationComponentOptions.Builder minZoom(double minZoom) {
       this.minZoom = minZoom;
       return this;
@@ -1529,7 +1475,6 @@ public class LocationComponentOptions implements Parcelable {
      *
      * @param maxZoomIconScale icon scale factor
      */
-    @NonNull
     public LocationComponentOptions.Builder maxZoomIconScale(float maxZoomIconScale) {
       this.maxZoomIconScale = maxZoomIconScale;
       return this;
@@ -1544,7 +1489,6 @@ public class LocationComponentOptions implements Parcelable {
      *
      * @param minZoomIconScale icon scale factor
      */
-    @NonNull
     public LocationComponentOptions.Builder minZoomIconScale(float minZoomIconScale) {
       this.minZoomIconScale = minZoomIconScale;
       return this;
@@ -1564,7 +1508,6 @@ public class LocationComponentOptions implements Parcelable {
      * @see Builder#trackingInitialMoveThreshold(float)
      * @see Builder#trackingMultiFingerMoveThreshold(float)
      */
-    @NonNull
     public LocationComponentOptions.Builder trackingGesturesManagement(boolean trackingGesturesManagement) {
       this.trackingGesturesManagement = trackingGesturesManagement;
       return this;
@@ -1575,7 +1518,6 @@ public class LocationComponentOptions implements Parcelable {
      *
      * @param moveThreshold the minimum movement
      */
-    @NonNull
     public LocationComponentOptions.Builder trackingInitialMoveThreshold(float moveThreshold) {
       this.trackingInitialMoveThreshold = moveThreshold;
       return this;
@@ -1587,7 +1529,6 @@ public class LocationComponentOptions implements Parcelable {
      *
      * @param moveThreshold the minimum movement
      */
-    @NonNull
     public LocationComponentOptions.Builder trackingMultiFingerMoveThreshold(float moveThreshold) {
       this.trackingMultiFingerMoveThreshold = moveThreshold;
       return this;
@@ -1598,7 +1539,6 @@ public class LocationComponentOptions implements Parcelable {
      *
      * @param layerBelow the id to set the location component below to.
      */
-    @NonNull
     public LocationComponentOptions.Builder layerBelow(String layerBelow) {
       this.layerBelow = layerBelow;
       return this;
@@ -1610,7 +1550,6 @@ public class LocationComponentOptions implements Parcelable {
      * @param trackingAnimationDurationMultiplier the tracking animation duration multiplier
      * @since 0.9.0
      */
-    @NonNull
     public LocationComponentOptions.Builder trackingAnimationDurationMultiplier(
       float trackingAnimationDurationMultiplier) {
       this.trackingAnimationDurationMultiplier = trackingAnimationDurationMultiplier;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationLayerController.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationLayerController.java
@@ -73,7 +73,7 @@ final class LocationLayerController implements MapboxAnimator.OnLayerAnimationsV
 
   LocationLayerController(MapboxMap mapboxMap, LayerSourceProvider layerSourceProvider,
                           LayerFeatureProvider featureProvider, LayerBitmapProvider bitmapProvider,
-                          @NonNull LocationComponentOptions options) {
+                          LocationComponentOptions options) {
     this.mapboxMap = mapboxMap;
     this.layerSourceProvider = layerSourceProvider;
     this.bitmapProvider = bitmapProvider;
@@ -192,7 +192,7 @@ final class LocationLayerController implements MapboxAnimator.OnLayerAnimationsV
     return isHidden;
   }
 
-  private void setLayerVisibility(@NonNull String layerId, boolean visible) {
+  private void setLayerVisibility(String layerId, boolean visible) {
     Layer layer = mapboxMap.getLayer(layerId);
     if (layer != null) {
       String targetVisibility = visible ? VISIBLE : NONE;
@@ -202,7 +202,7 @@ final class LocationLayerController implements MapboxAnimator.OnLayerAnimationsV
     }
   }
 
-  private void addLayers(@NonNull String idBelowLayer) {
+  private void addLayers(String idBelowLayer) {
     addSymbolLayer(BEARING_LAYER, idBelowLayer);
     addSymbolLayer(FOREGROUND_LAYER, BEARING_LAYER);
     addSymbolLayer(BACKGROUND_LAYER, FOREGROUND_LAYER);
@@ -210,7 +210,7 @@ final class LocationLayerController implements MapboxAnimator.OnLayerAnimationsV
     addAccuracyLayer();
   }
 
-  private void addSymbolLayer(@NonNull String layerId, @NonNull String beforeLayerId) {
+  private void addSymbolLayer(String layerId, String beforeLayerId) {
     Layer layer = layerSourceProvider.generateLayer(layerId);
     addLayerToMap(layer, beforeLayerId);
   }
@@ -220,12 +220,12 @@ final class LocationLayerController implements MapboxAnimator.OnLayerAnimationsV
     addLayerToMap(accuracyLayer, BACKGROUND_LAYER);
   }
 
-  private void addLayerToMap(@NonNull Layer layer, @NonNull String idBelowLayer) {
+  private void addLayerToMap(Layer layer, @NonNull String idBelowLayer) {
     mapboxMap.addLayerBelow(layer, idBelowLayer);
     layerMap.add(layer.getId());
   }
 
-  private void setBearingProperty(@NonNull String propertyId, float bearing) {
+  private void setBearingProperty(String propertyId, float bearing) {
     locationFeature.addNumberProperty(propertyId, bearing);
     refreshSource();
   }
@@ -276,7 +276,7 @@ final class LocationLayerController implements MapboxAnimator.OnLayerAnimationsV
     mapboxMap.addImage(BACKGROUND_STALE_ICON, backgroundStaleBitmap);
   }
 
-  private void styleShadow(@NonNull LocationComponentOptions options) {
+  private void styleShadow(LocationComponentOptions options) {
     mapboxMap.addImage(SHADOW_ICON, bitmapProvider.generateShadowBitmap(options));
   }
 
@@ -310,7 +310,7 @@ final class LocationLayerController implements MapboxAnimator.OnLayerAnimationsV
     mapboxMap.addImage(FOREGROUND_STALE_ICON, foregroundBitmapStale);
   }
 
-  private void styleScaling(@NonNull LocationComponentOptions options) {
+  private void styleScaling(LocationComponentOptions options) {
     for (String layerId : layerMap) {
       Layer layer = mapboxMap.getLayer(layerId);
       if (layer != null && layer instanceof SymbolLayer) {
@@ -342,7 +342,6 @@ final class LocationLayerController implements MapboxAnimator.OnLayerAnimationsV
     refreshSource();
   }
 
-  @Nullable
   private String buildIconString(@Nullable String bitmapName, @NonNull String drawableName) {
     if (bitmapName != null) {
       return bitmapName;
@@ -362,7 +361,7 @@ final class LocationLayerController implements MapboxAnimator.OnLayerAnimationsV
   // Map click event
   //
 
-  boolean onMapClick(@NonNull LatLng point) {
+  boolean onMapClick(LatLng point) {
     PointF screenLoc = mapboxMap.getProjection().toScreenLocation(point);
     List<Feature> features = mapboxMap.queryRenderedFeatures(screenLoc,
       BACKGROUND_LAYER,

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxCameraAnimatorAdapter.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxCameraAnimatorAdapter.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 abstract class MapboxCameraAnimatorAdapter extends
   MapboxFloatAnimator<MapboxAnimator.OnCameraAnimationsValuesChangeListener> {
-  @Nullable
   private final MapboxMap.CancelableCallback cancelableCallback;
 
   MapboxCameraAnimatorAdapter(Float previous, Float target,

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxFloatAnimator.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxFloatAnimator.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.location;
 
 import android.animation.FloatEvaluator;
 import android.animation.TypeEvaluator;
-import android.support.annotation.NonNull;
 
 import java.util.List;
 
@@ -11,7 +10,6 @@ abstract class MapboxFloatAnimator<L> extends MapboxAnimator<Float, L> {
     super(previous, target, updateListeners);
   }
 
-  @NonNull
   @Override
   TypeEvaluator provideEvaluator() {
     return new FloatEvaluator();

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxLatLngAnimator.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxLatLngAnimator.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.location;
 
 import android.animation.TypeEvaluator;
 
-import android.support.annotation.NonNull;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
 import java.util.List;
@@ -13,7 +12,6 @@ abstract class MapboxLatLngAnimator<L> extends MapboxAnimator<LatLng, L> {
     super(previous, target, updateListeners);
   }
 
-  @NonNull
   @Override
   TypeEvaluator provideEvaluator() {
     return new LatLngEvaluator();

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/StaleStateManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/StaleStateManager.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.location;
 
 import android.os.Handler;
-import android.support.annotation.NonNull;
 
 /**
  * Class controls the location stale state when the {@link android.location.Location} hasn't
@@ -13,7 +12,6 @@ class StaleStateManager {
 
   private boolean isEnabled;
   private final OnLocationStaleListener innerOnLocationStaleListeners;
-  @NonNull
   private final Handler handler;
   private boolean isStale = true;
   private long delayTime;
@@ -25,7 +23,6 @@ class StaleStateManager {
     delayTime = options.staleStateTimeout();
   }
 
-  @NonNull
   private Runnable staleStateRunnable = new Runnable() {
     @Override
     public void run() {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/TiltAnimator.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/TiltAnimator.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.location;
 
 import android.animation.ValueAnimator;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.mapbox.mapboxsdk.maps.MapboxMap;
@@ -20,7 +19,7 @@ class TiltAnimator extends MapboxCameraAnimatorAdapter {
   }
 
   @Override
-  public void onAnimationUpdate(@NonNull ValueAnimator animation) {
+  public void onAnimationUpdate(ValueAnimator animation) {
     for (OnCameraAnimationsValuesChangeListener listener : updateListeners) {
       listener.onNewTiltValue((Float) animation.getAnimatedValue());
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/Utils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/Utils.java
@@ -65,9 +65,8 @@ public final class Utils {
     return bitmap;
   }
 
-  @Nullable
   static Drawable getDrawable(@NonNull Context context, @DrawableRes int drawableRes,
-                              @Nullable @ColorInt Integer tintColor) {
+                              @ColorInt Integer tintColor) {
     Drawable drawable = ContextCompat.getDrawable(context, drawableRes);
     if (tintColor == null) {
       return drawable;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/ZoomAnimator.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/ZoomAnimator.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.location;
 
 import android.animation.ValueAnimator;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.mapbox.mapboxsdk.maps.MapboxMap;
@@ -21,7 +20,7 @@ class ZoomAnimator extends MapboxCameraAnimatorAdapter {
   }
 
   @Override
-  public void onAnimationUpdate(@NonNull ValueAnimator animation) {
+  public void onAnimationUpdate(ValueAnimator animation) {
     for (OnCameraAnimationsValuesChangeListener listener : updateListeners) {
       listener.onNewZoomValue((Float) animation.getAnimatedValue());
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AnnotationContainer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AnnotationContainer.java
@@ -27,7 +27,6 @@ class AnnotationContainer implements Annotations {
     return annotations.get(id);
   }
 
-  @NonNull
   @Override
   public List<Annotation> obtainAll() {
     List<Annotation> annotations = new ArrayList<>();

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AnnotationManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AnnotationManager.java
@@ -45,17 +45,13 @@ class AnnotationManager {
   private final MapView mapView;
   private final IconManager iconManager;
   private final InfoWindowManager infoWindowManager = new InfoWindowManager();
-  @NonNull
   private final MarkerViewManager markerViewManager;
   private final LongSparseArray<Annotation> annotationsArray;
   private final List<Marker> selectedMarkers = new ArrayList<>();
 
   private MapboxMap mapboxMap;
-  @Nullable
   private MapboxMap.OnMarkerClickListener onMarkerClickListener;
-  @Nullable
   private MapboxMap.OnPolygonClickListener onPolygonClickListener;
-  @Nullable
   private MapboxMap.OnPolylineClickListener onPolylineClickListener;
 
   private Annotations annotations;
@@ -64,8 +60,8 @@ class AnnotationManager {
   private Polygons polygons;
   private Polylines polylines;
 
-  AnnotationManager(@Nullable NativeMapView view, MapView mapView, LongSparseArray<Annotation> annotationsArray,
-                    @NonNull MarkerViewManager markerViewManager, IconManager iconManager, Annotations annotations,
+  AnnotationManager(NativeMapView view, MapView mapView, LongSparseArray<Annotation> annotationsArray,
+                    MarkerViewManager markerViewManager, IconManager iconManager, Annotations annotations,
                     Markers markers, Polygons polygons, Polylines polylines, ShapeAnnotations shapeAnnotations) {
     this.mapView = mapView;
     this.annotationsArray = annotationsArray;
@@ -84,7 +80,6 @@ class AnnotationManager {
 
   // TODO refactor MapboxMap out for Projection and Transform
   // Requires removing MapboxMap from Annotations by using Peer model from #6912
-  @NonNull
   AnnotationManager bind(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
     this.markerViewManager.bind(mapboxMap);
@@ -229,7 +224,7 @@ class AnnotationManager {
     return polygons.addBy(polygonOptionsList, mapboxMap);
   }
 
-  void updatePolygon(@NonNull Polygon polygon) {
+  void updatePolygon(Polygon polygon) {
     if (!isAddedToMap(polygon)) {
       logNonAdded(polygon);
       return;
@@ -253,7 +248,7 @@ class AnnotationManager {
     return polylines.addBy(polylineOptionsList, mapboxMap);
   }
 
-  void updatePolyline(@NonNull Polyline polyline) {
+  void updatePolyline(Polyline polyline) {
     if (!isAddedToMap(polyline)) {
       logNonAdded(polyline);
       return;
@@ -338,22 +333,19 @@ class AnnotationManager {
     selectedMarkers.remove(marker);
   }
 
-  @NonNull
   List<Marker> getSelectedMarkers() {
     return selectedMarkers;
   }
 
-  @NonNull
   InfoWindowManager getInfoWindowManager() {
     return infoWindowManager;
   }
 
-  @NonNull
   MarkerViewManager getMarkerViewManager() {
     return markerViewManager;
   }
 
-  void adjustTopOffsetPixels(@NonNull MapboxMap mapboxMap) {
+  void adjustTopOffsetPixels(MapboxMap mapboxMap) {
     int count = annotationsArray.size();
     for (int i = 0; i < count; i++) {
       Annotation annotation = annotationsArray.get(i);
@@ -372,11 +364,11 @@ class AnnotationManager {
     }
   }
 
-  private boolean isAddedToMap(@Nullable Annotation annotation) {
+  private boolean isAddedToMap(Annotation annotation) {
     return annotation != null && annotation.getId() != -1 && annotationsArray.indexOfKey(annotation.getId()) > -1;
   }
 
-  private void logNonAdded(@NonNull Annotation annotation) {
+  private void logNonAdded(Annotation annotation) {
     Logger.w(TAG, String.format(
       "Attempting to update non-added %s with value %s", annotation.getClass().getCanonicalName(), annotation)
     );
@@ -386,7 +378,7 @@ class AnnotationManager {
   // Click event
   //
 
-  boolean onTap(@NonNull PointF tapPoint) {
+  boolean onTap(PointF tapPoint) {
     MarkerHit markerHit = getMarkerHitFromTouchArea(tapPoint);
     long markerId = new MarkerHitResolver(mapboxMap).execute(markerHit);
     if (markerId != NO_ANNOTATION_ID) {
@@ -448,11 +440,11 @@ class AnnotationManager {
     return true;
   }
 
-  private boolean onClickMarker(@NonNull Marker marker) {
+  private boolean onClickMarker(Marker marker) {
     return onMarkerClickListener != null && onMarkerClickListener.onMarkerClick(marker);
   }
 
-  private void toggleMarkerSelectionState(@NonNull Marker marker) {
+  private void toggleMarkerSelectionState(Marker marker) {
     if (!selectedMarkers.contains(marker)) {
       selectMarker(marker);
     } else {
@@ -468,8 +460,7 @@ class AnnotationManager {
       this.shapeAnnotations = shapeAnnotations;
     }
 
-    @Nullable
-    public Annotation execute(@NonNull ShapeAnnotationHit shapeHit) {
+    public Annotation execute(ShapeAnnotationHit shapeHit) {
       Annotation foundAnnotation = null;
       List<Annotation> annotations = shapeAnnotations.obtainAllIn(shapeHit.tapPoint);
       if (annotations.size() > 0) {
@@ -481,24 +472,18 @@ class AnnotationManager {
 
   private static class MarkerHitResolver {
 
-    @NonNull
     private final MarkerViewManager markerViewManager;
-    @NonNull
     private final Projection projection;
     private final int minimalTouchSize;
 
-    @Nullable
     private View view;
     private Bitmap bitmap;
     private int bitmapWidth;
     private int bitmapHeight;
     private PointF markerLocation;
 
-    @NonNull
     private Rect hitRectView = new Rect();
-    @NonNull
     private RectF hitRectMarker = new RectF();
-    @NonNull
     private RectF highestSurfaceIntersection = new RectF();
 
     private long closestMarkerId = NO_ANNOTATION_ID;
@@ -509,7 +494,7 @@ class AnnotationManager {
       this.minimalTouchSize = (int) (32 * Mapbox.getApplicationContext().getResources().getDisplayMetrics().density);
     }
 
-    public long execute(@NonNull MarkerHit markerHit) {
+    public long execute(MarkerHit markerHit) {
       resolveForMarkers(markerHit);
       return closestMarkerId;
     }
@@ -524,7 +509,7 @@ class AnnotationManager {
       }
     }
 
-    private void resolveForMarkerView(@NonNull MarkerHit markerHit, @NonNull MarkerView markerView) {
+    private void resolveForMarkerView(MarkerHit markerHit, MarkerView markerView) {
       view = markerViewManager.getView(markerView);
       if (view != null) {
         view.getHitRect(hitRectView);
@@ -533,7 +518,7 @@ class AnnotationManager {
       }
     }
 
-    private void resolveForMarker(@NonNull MarkerHit markerHit, Marker marker) {
+    private void resolveForMarker(MarkerHit markerHit, Marker marker) {
       markerLocation = projection.toScreenLocation(marker.getPosition());
       bitmap = marker.getIcon().getBitmap();
 
@@ -555,7 +540,7 @@ class AnnotationManager {
       hitTestMarker(markerHit, marker, hitRectMarker);
     }
 
-    private void hitTestMarker(@NonNull MarkerHit markerHit, @NonNull Marker marker, @NonNull RectF hitRectMarker) {
+    private void hitTestMarker(MarkerHit markerHit, Marker marker, RectF hitRectMarker) {
       if (hitRectMarker.contains(markerHit.getTapPointX(), markerHit.getTapPointY())) {
         hitRectMarker.intersect(markerHit.tapRect);
         if (isRectangleHighestSurfaceIntersection(hitRectMarker)) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
@@ -8,7 +8,6 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.Toast;
@@ -41,9 +40,7 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
   private static final String MAP_FEEDBACK_URL = "https://www.mapbox.com/map-feedback";
   private static final String MAP_FEEDBACK_LOCATION_FORMAT = MAP_FEEDBACK_URL + "/#/%f/%f/%d";
 
-  @NonNull
   private final Context context;
-  @NonNull
   private final MapboxMap mapboxMap;
   private Set<Attribution> attributionSet;
 
@@ -54,7 +51,7 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
 
   // Called when someone presses the attribution icon on the map
   @Override
-  public void onClick(@NonNull View view) {
+  public void onClick(View view) {
     attributionSet = new AttributionBuilder(mapboxMap, view.getContext()).build();
 
     boolean isActivityFinishing = false;
@@ -69,7 +66,7 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
     }
   }
 
-  protected void showAttributionDialog(@NonNull String[] attributionTitles) {
+  protected void showAttributionDialog(String[] attributionTitles) {
     AlertDialog.Builder builder = new AlertDialog.Builder(context);
     builder.setTitle(R.string.mapbox_attributionsDialogTitle);
     builder.setAdapter(new ArrayAdapter<>(context, R.layout.mapbox_attribution_list_item, attributionTitles), this);
@@ -104,7 +101,7 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
     builder.setMessage(R.string.mapbox_attributionTelemetryMessage);
     builder.setPositiveButton(R.string.mapbox_attributionTelemetryPositive, new DialogInterface.OnClickListener() {
       @Override
-      public void onClick(@NonNull DialogInterface dialog, int which) {
+      public void onClick(DialogInterface dialog, int which) {
         TelemetryDefinition telemetry = Mapbox.getTelemetry();
         if (telemetry != null) {
           telemetry.setUserTelemetryRequestState(true);
@@ -114,14 +111,14 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
     });
     builder.setNeutralButton(R.string.mapbox_attributionTelemetryNeutral, new DialogInterface.OnClickListener() {
       @Override
-      public void onClick(@NonNull DialogInterface dialog, int which) {
+      public void onClick(DialogInterface dialog, int which) {
         showWebPage(context.getResources().getString(R.string.mapbox_telemetryLink));
         dialog.cancel();
       }
     });
     builder.setNegativeButton(R.string.mapbox_attributionTelemetryNegative, new DialogInterface.OnClickListener() {
       @Override
-      public void onClick(@NonNull DialogInterface dialog, int which) {
+      public void onClick(DialogInterface dialog, int which) {
         TelemetryDefinition telemetry = Mapbox.getTelemetry();
         if (telemetry != null) {
           telemetry.setUserTelemetryRequestState(false);
@@ -141,8 +138,7 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
     showWebPage(url);
   }
 
-  @NonNull
-  private String buildMapFeedbackMapUrl(@Nullable CameraPosition cameraPosition) {
+  private String buildMapFeedbackMapUrl(CameraPosition cameraPosition) {
     // appends current location to the map feedback url if available
     return cameraPosition != null ? String.format(Locale.getDefault(),
       MAP_FEEDBACK_LOCATION_FORMAT, cameraPosition.target.getLongitude(), cameraPosition.target.getLatitude(),
@@ -164,7 +160,6 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
   private static class AttributionBuilder {
 
     private final MapboxMap mapboxMap;
-    @NonNull
     private final WeakReference<Context> context;
 
     AttributionBuilder(MapboxMap mapboxMap, Context context) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
@@ -203,7 +203,7 @@ class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, M
     }
 
     @Override
-    public void handleMessage(@NonNull Message msg) {
+    public void handleMessage(Message msg) {
       CameraChangeDispatcher dispatcher = dispatcherWeakReference.get();
       if (dispatcher != null) {
         switch (msg.what) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/FocalPointChangeListener.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/FocalPointChangeListener.java
@@ -1,12 +1,11 @@
 package com.mapbox.mapboxsdk.maps;
 
 import android.graphics.PointF;
-import android.support.annotation.NonNull;
 
 /**
  * Interface definition of a callback that is invoked when the focal point will change.
  */
 public interface FocalPointChangeListener {
 
-  void onFocalPointChanged(@NonNull PointF pointF);
+  void onFocalPointChanged(PointF pointF);
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/IconManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/IconManager.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.maps;
 
 import android.graphics.Bitmap;
 
-import android.support.annotation.NonNull;
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.annotations.Icon;
 import com.mapbox.mapboxsdk.annotations.IconFactory;
@@ -38,7 +37,7 @@ class IconManager {
     loadIcon(IconFactory.recreate(IconFactory.ICON_MARKERVIEW_ID, IconFactory.ICON_MARKERVIEW_BITMAP));
   }
 
-  Icon loadIconForMarker(@NonNull Marker marker) {
+  Icon loadIconForMarker(Marker marker) {
     Icon icon = marker.getIcon();
     if (icon == null) {
       // TODO replace with anchor implementation, we are faking an anchor by adding extra pixels and diving height by 2
@@ -51,14 +50,14 @@ class IconManager {
     return icon;
   }
 
-  void loadIconForMarkerView(@NonNull MarkerView marker) {
+  void loadIconForMarkerView(MarkerView marker) {
     Icon icon = marker.getIcon();
     Bitmap bitmap = icon.getBitmap();
     updateHighestIconSize(bitmap);
     addIcon(icon, false);
   }
 
-  int getTopOffsetPixelsForIcon(@NonNull Icon icon) {
+  int getTopOffsetPixelsForIcon(Icon icon) {
     return (int) (nativeMapView.getTopOffsetPixelsForAnnotationSymbol(icon.getId()) * nativeMapView.getPixelRatio());
   }
 
@@ -78,11 +77,11 @@ class IconManager {
     return icon;
   }
 
-  private void addIcon(@NonNull Icon icon) {
+  private void addIcon(Icon icon) {
     addIcon(icon, true);
   }
 
-  private void addIcon(@NonNull Icon icon, boolean addIconToMap) {
+  private void addIcon(Icon icon, boolean addIconToMap) {
     if (!iconMap.keySet().contains(icon)) {
       iconMap.put(icon, 1);
       if (addIconToMap) {
@@ -126,7 +125,7 @@ class IconManager {
     }
   }
 
-  void ensureIconLoaded(@NonNull Marker marker, @NonNull MapboxMap mapboxMap) {
+  void ensureIconLoaded(Marker marker, MapboxMap mapboxMap) {
     Icon icon = marker.getIcon();
     if (icon == null) {
       icon = loadDefaultIconForMarker(marker);
@@ -135,7 +134,7 @@ class IconManager {
     setTopOffsetPixels(marker, mapboxMap, icon);
   }
 
-  private void setTopOffsetPixels(Marker marker, @NonNull MapboxMap mapboxMap, @NonNull Icon icon) {
+  private void setTopOffsetPixels(Marker marker, MapboxMap mapboxMap, Icon icon) {
     // this seems to be a costly operation according to the profiler so I'm trying to save some calls
     Marker previousMarker = marker.getId() != -1 ? (Marker) mapboxMap.getAnnotation(marker.getId()) : null;
     if (previousMarker == null || previousMarker.getIcon() == null || previousMarker.getIcon() != marker.getIcon()) {
@@ -143,7 +142,7 @@ class IconManager {
     }
   }
 
-  void iconCleanup(@NonNull Icon icon) {
+  void iconCleanup(Icon icon) {
     Integer refCounter = iconMap.get(icon);
     if (refCounter != null) {
       refCounter--;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/InfoWindowManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/InfoWindowManager.java
@@ -23,15 +23,11 @@ class InfoWindowManager {
 
   private final List<InfoWindow> infoWindows = new ArrayList<>();
 
-  @Nullable
   private MapboxMap.InfoWindowAdapter infoWindowAdapter;
   private boolean allowConcurrentMultipleInfoWindows;
 
-  @Nullable
   private MapboxMap.OnInfoWindowClickListener onInfoWindowClickListener;
-  @Nullable
   private MapboxMap.OnInfoWindowLongClickListener onInfoWindowLongClickListener;
-  @Nullable
   private MapboxMap.OnInfoWindowCloseListener onInfoWindowCloseListener;
 
   void update() {
@@ -46,7 +42,6 @@ class InfoWindowManager {
     this.infoWindowAdapter = infoWindowAdapter;
   }
 
-  @Nullable
   MapboxMap.InfoWindowAdapter getInfoWindowAdapter() {
     return infoWindowAdapter;
   }
@@ -59,7 +54,7 @@ class InfoWindowManager {
     return allowConcurrentMultipleInfoWindows;
   }
 
-  boolean isInfoWindowValidForMarker(@Nullable Marker marker) {
+  boolean isInfoWindowValidForMarker(Marker marker) {
     return marker != null && (!TextUtils.isEmpty(marker.getTitle()) || !TextUtils.isEmpty(marker.getSnippet()));
   }
 
@@ -67,7 +62,6 @@ class InfoWindowManager {
     onInfoWindowClickListener = listener;
   }
 
-  @Nullable
   MapboxMap.OnInfoWindowClickListener getOnInfoWindowClickListener() {
     return onInfoWindowClickListener;
   }
@@ -76,7 +70,6 @@ class InfoWindowManager {
     onInfoWindowLongClickListener = listener;
   }
 
-  @Nullable
   MapboxMap.OnInfoWindowLongClickListener getOnInfoWindowLongClickListener() {
     return onInfoWindowLongClickListener;
   }
@@ -85,7 +78,6 @@ class InfoWindowManager {
     onInfoWindowCloseListener = listener;
   }
 
-  @Nullable
   MapboxMap.OnInfoWindowCloseListener getOnInfoWindowCloseListener() {
     return onInfoWindowCloseListener;
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapFragment.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapFragment.java
@@ -124,7 +124,7 @@ public final class MapFragment extends Fragment implements OnMapReadyCallback {
    * @param mapboxMap The public api controller of the map
    */
   @Override
-  public void onMapReady(@NonNull MapboxMap mapboxMap) {
+  public void onMapReady(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
     for (OnMapReadyCallback onMapReadyCallback : mapReadyCallbackList) {
       onMapReadyCallback.onMapReady(mapboxMap);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapFragment.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapFragment.java
@@ -51,7 +51,6 @@ public final class MapFragment extends Fragment implements OnMapReadyCallback {
    * @param mapboxMapOptions The configuration options to be used.
    * @return MapFragment instantiated.
    */
-  @NonNull
   public static MapFragment newInstance(@Nullable MapboxMapOptions mapboxMapOptions) {
     MapFragment mapFragment = new MapFragment();
     mapFragment.setArguments(MapFragmentUtils.createFragmentArgs(mapboxMapOptions));
@@ -66,7 +65,7 @@ public final class MapFragment extends Fragment implements OnMapReadyCallback {
    * @param savedInstanceState The saved instance state for the map fragment.
    */
   @Override
-  public void onInflate(@NonNull Context context, AttributeSet attrs, Bundle savedInstanceState) {
+  public void onInflate(Context context, AttributeSet attrs, Bundle savedInstanceState) {
     super.onInflate(context, attrs, savedInstanceState);
     setArguments(MapFragmentUtils.createFragmentArgs(MapboxMapOptions.createFromAttributes(context, attrs)));
   }
@@ -93,7 +92,7 @@ public final class MapFragment extends Fragment implements OnMapReadyCallback {
    * @return The view created
    */
   @Override
-  public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+  public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     super.onCreateView(inflater, container, savedInstanceState);
     Context context = inflater.getContext();
     map = new MapView(context, MapFragmentUtils.resolveArgs(context, getArguments()));
@@ -228,6 +227,6 @@ public final class MapFragment extends Fragment implements OnMapReadyCallback {
      *
      * @param mapView The created mapview
      */
-    void onMapViewReady(@NonNull MapView mapView);
+    void onMapViewReady(MapView mapView);
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -6,7 +6,6 @@ import android.animation.ValueAnimator;
 import android.content.Context;
 import android.graphics.PointF;
 import android.os.Handler;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.view.InputDevice;
 import android.view.MotionEvent;
@@ -82,7 +81,6 @@ final class MapGestureDetector {
   /**
    * User-set focal point.
    */
-  @Nullable
   private PointF focalPoint;
 
   private AndroidGesturesManager gesturesManager;
@@ -96,10 +94,9 @@ final class MapGestureDetector {
    * Cancels scheduled velocity animations if user doesn't lift fingers within
    * {@link MapboxConstants#SCHEDULED_ANIMATION_TIMEOUT}
    */
-  @NonNull
   private Handler animationsTimeoutHandler = new Handler();
 
-  MapGestureDetector(@Nullable Context context, Transform transform, Projection projection, UiSettings uiSettings,
+  MapGestureDetector(Context context, Transform transform, Projection projection, UiSettings uiSettings,
                      AnnotationManager annotationManager, CameraChangeDispatcher cameraChangeDispatcher) {
     this.annotationManager = annotationManager;
     this.transform = transform;
@@ -118,7 +115,7 @@ final class MapGestureDetector {
     }
   }
 
-  private void initializeGestureListeners(@NonNull Context context, boolean attachDefaultListeners) {
+  private void initializeGestureListeners(Context context, boolean attachDefaultListeners) {
     if (attachDefaultListeners) {
       StandardGestureListener standardGestureListener = new StandardGestureListener();
       MoveGestureListener moveGestureListener = new MoveGestureListener();
@@ -140,7 +137,7 @@ final class MapGestureDetector {
     }
   }
 
-  private void initializeGesturesManager(@NonNull AndroidGesturesManager androidGesturesManager,
+  private void initializeGesturesManager(AndroidGesturesManager androidGesturesManager,
                                          boolean setDefaultMutuallyExclusives) {
     if (setDefaultMutuallyExclusives) {
       Set<Integer> shoveScaleSet = new HashSet<>();
@@ -170,7 +167,7 @@ final class MapGestureDetector {
    *
    * @param focalPoint the center point for gestures
    */
-  void setFocalPoint(@Nullable PointF focalPoint) {
+  void setFocalPoint(PointF focalPoint) {
     if (focalPoint == null) {
       // resetting focal point,
       if (uiSettings.getFocalPoint() != null) {
@@ -205,7 +202,7 @@ final class MapGestureDetector {
    * @param motionEvent the MotionEvent
    * @return True if touch event is handled
    */
-  boolean onTouchEvent(@Nullable MotionEvent motionEvent) {
+  boolean onTouchEvent(MotionEvent motionEvent) {
     // Framework can return null motion events in edge cases #9432
     if (motionEvent == null) {
       return false;
@@ -256,7 +253,7 @@ final class MapGestureDetector {
     dispatchCameraIdle();
   }
 
-  private void cancelAnimator(@Nullable Animator animator) {
+  private void cancelAnimator(Animator animator) {
     if (animator != null && animator.isStarted()) {
       animator.cancel();
     }
@@ -265,7 +262,6 @@ final class MapGestureDetector {
   /**
    * Posted on main thread with {@link #animationsTimeoutHandler}. Cancels all scheduled animators if needed.
    */
-  @NonNull
   private Runnable cancelAnimatorsRunnable = new Runnable() {
     @Override
     public void run() {
@@ -440,7 +436,7 @@ final class MapGestureDetector {
 
   private final class MoveGestureListener extends MoveGestureDetector.SimpleOnMoveGestureListener {
     @Override
-    public boolean onMoveBegin(@NonNull MoveGestureDetector detector) {
+    public boolean onMoveBegin(MoveGestureDetector detector) {
       if (!uiSettings.isScrollGesturesEnabled()) {
         return false;
       }
@@ -452,7 +448,7 @@ final class MapGestureDetector {
     }
 
     @Override
-    public boolean onMove(@NonNull MoveGestureDetector detector, float distanceX, float distanceY) {
+    public boolean onMove(MoveGestureDetector detector, float distanceX, float distanceY) {
       // first move event is often delivered with no displacement
       if (distanceX != 0 || distanceY != 0) {
         // dispatching camera start event only when the movement actually occurred
@@ -468,7 +464,7 @@ final class MapGestureDetector {
     }
 
     @Override
-    public void onMoveEnd(@NonNull MoveGestureDetector detector, float velocityX, float velocityY) {
+    public void onMoveEnd(MoveGestureDetector detector, float velocityX, float velocityY) {
       dispatchCameraIdle();
       notifyOnMoveEndListeners(detector);
     }
@@ -478,7 +474,6 @@ final class MapGestureDetector {
 
     private final float minimumVelocity;
 
-    @Nullable
     private PointF scaleFocalPoint;
     private boolean quickZoom;
 
@@ -487,7 +482,7 @@ final class MapGestureDetector {
     }
 
     @Override
-    public boolean onScaleBegin(@NonNull StandardScaleGestureDetector detector) {
+    public boolean onScaleBegin(StandardScaleGestureDetector detector) {
       if (!uiSettings.isZoomGesturesEnabled()) {
         return false;
       }
@@ -520,7 +515,7 @@ final class MapGestureDetector {
     }
 
     @Override
-    public boolean onScale(@NonNull StandardScaleGestureDetector detector) {
+    public boolean onScale(StandardScaleGestureDetector detector) {
       // dispatching camera start event only when the movement actually occurred
       cameraChangeDispatcher.onCameraMoveStarted(CameraChangeDispatcher.REASON_API_GESTURE);
 
@@ -536,7 +531,7 @@ final class MapGestureDetector {
     }
 
     @Override
-    public void onScaleEnd(@NonNull StandardScaleGestureDetector detector, float velocityX, float velocityY) {
+    public void onScaleEnd(StandardScaleGestureDetector detector, float velocityX, float velocityY) {
       if (quickZoom) {
         //if quickzoom, re-enabling move gesture detector
         gesturesManager.getMoveGestureDetector().setEnabled(true);
@@ -566,7 +561,7 @@ final class MapGestureDetector {
       scheduleAnimator(scaleAnimator);
     }
 
-    private void setScaleFocalPoint(@NonNull StandardScaleGestureDetector detector) {
+    private void setScaleFocalPoint(StandardScaleGestureDetector detector) {
       if (focalPoint != null) {
         // around user provided focal point
         scaleFocalPoint = focalPoint;
@@ -602,7 +597,6 @@ final class MapGestureDetector {
   }
 
   private final class RotateGestureListener extends RotateGestureDetector.SimpleOnRotateGestureListener {
-    @Nullable
     private PointF rotateFocalPoint;
     private final float minimumScaleSpanWhenRotating;
     private final float minimumAngularVelocity;
@@ -616,7 +610,7 @@ final class MapGestureDetector {
     }
 
     @Override
-    public boolean onRotateBegin(@NonNull RotateGestureDetector detector) {
+    public boolean onRotateBegin(RotateGestureDetector detector) {
       if (!uiSettings.isRotateGesturesEnabled()) {
         return false;
       }
@@ -641,7 +635,7 @@ final class MapGestureDetector {
     }
 
     @Override
-    public boolean onRotate(@NonNull RotateGestureDetector detector, float rotationDegreesSinceLast,
+    public boolean onRotate(RotateGestureDetector detector, float rotationDegreesSinceLast,
                             float rotationDegreesSinceFirst) {
       // dispatching camera start event only when the movement actually occurred
       cameraChangeDispatcher.onCameraMoveStarted(CameraChangeDispatcher.REASON_API_GESTURE);
@@ -660,8 +654,7 @@ final class MapGestureDetector {
     }
 
     @Override
-    public void onRotateEnd(@NonNull RotateGestureDetector detector, float velocityX, float velocityY,
-                            float angularVelocity) {
+    public void onRotateEnd(RotateGestureDetector detector, float velocityX, float velocityY, float angularVelocity) {
       if (uiSettings.isIncreaseScaleThresholdWhenRotating()) {
         // resetting default scale threshold values
         gesturesManager.getStandardScaleGestureDetector().setSpanSinceStartThreshold(defaultSpanSinceStartThreshold);
@@ -690,7 +683,7 @@ final class MapGestureDetector {
       scheduleAnimator(rotateAnimator);
     }
 
-    private void setRotateFocalPoint(@NonNull RotateGestureDetector detector) {
+    private void setRotateFocalPoint(RotateGestureDetector detector) {
       if (focalPoint != null) {
         // User provided focal point
         rotateFocalPoint = focalPoint;
@@ -706,7 +699,7 @@ final class MapGestureDetector {
       animator.setInterpolator(new DecelerateInterpolator());
       animator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
         @Override
-        public void onAnimationUpdate(@NonNull ValueAnimator animation) {
+        public void onAnimationUpdate(ValueAnimator animation) {
           transform.setBearing(
             transform.getRawBearing() + (float) animation.getAnimatedValue(),
             rotateFocalPoint.x, rotateFocalPoint.y,
@@ -740,7 +733,7 @@ final class MapGestureDetector {
 
   private final class ShoveGestureListener extends ShoveGestureDetector.SimpleOnShoveGestureListener {
     @Override
-    public boolean onShoveBegin(@NonNull ShoveGestureDetector detector) {
+    public boolean onShoveBegin(ShoveGestureDetector detector) {
       if (!uiSettings.isTiltGesturesEnabled()) {
         return false;
       }
@@ -758,8 +751,7 @@ final class MapGestureDetector {
     }
 
     @Override
-    public boolean onShove(@NonNull ShoveGestureDetector detector, float deltaPixelsSinceLast,
-                           float deltaPixelsSinceStart) {
+    public boolean onShove(ShoveGestureDetector detector, float deltaPixelsSinceLast, float deltaPixelsSinceStart) {
       // dispatching camera start event only when the movement actually occurred
       cameraChangeDispatcher.onCameraMoveStarted(CameraChangeDispatcher.REASON_API_GESTURE);
 
@@ -777,7 +769,7 @@ final class MapGestureDetector {
     }
 
     @Override
-    public void onShoveEnd(@NonNull ShoveGestureDetector detector, float velocityX, float velocityY) {
+    public void onShoveEnd(ShoveGestureDetector detector, float velocityX, float velocityY) {
       dispatchCameraIdle();
 
       // re-enabling move gesture
@@ -789,7 +781,7 @@ final class MapGestureDetector {
 
   private final class TapGestureListener implements MultiFingerTapGestureDetector.OnMultiFingerTapGestureListener {
     @Override
-    public boolean onMultiFingerTap(@NonNull MultiFingerTapGestureDetector detector, int pointersCount) {
+    public boolean onMultiFingerTap(MultiFingerTapGestureDetector detector, int pointersCount) {
       if (!uiSettings.isZoomGesturesEnabled() || pointersCount != 2) {
         return false;
       }
@@ -815,15 +807,15 @@ final class MapGestureDetector {
     }
   }
 
-  private Animator createScaleAnimator(double currentZoom, double zoomAddition,
-                                       @NonNull final PointF animationFocalPoint, long animationTime) {
+  private Animator createScaleAnimator(double currentZoom, double zoomAddition, final PointF animationFocalPoint,
+                                       long animationTime) {
     ValueAnimator animator = ValueAnimator.ofFloat((float) currentZoom, (float) (currentZoom + zoomAddition));
     animator.setDuration(animationTime);
     animator.setInterpolator(new DecelerateInterpolator());
     animator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
 
       @Override
-      public void onAnimationUpdate(@NonNull ValueAnimator animation) {
+      public void onAnimationUpdate(ValueAnimator animation) {
         transform.setZoom((Float) animation.getAnimatedValue(), animationFocalPoint);
       }
     });
@@ -856,7 +848,7 @@ final class MapGestureDetector {
    * @param runImmediately if true, animation will be started right away, otherwise it will wait until
    *                       {@link MotionEvent#ACTION_UP} is registered.
    */
-  void zoomInAnimated(@NonNull PointF zoomFocalPoint, boolean runImmediately) {
+  void zoomInAnimated(PointF zoomFocalPoint, boolean runImmediately) {
     zoomAnimated(true, zoomFocalPoint, runImmediately);
   }
 
@@ -867,11 +859,11 @@ final class MapGestureDetector {
    * @param runImmediately if true, animation will be started right away, otherwise it will wait until
    *                       {@link MotionEvent#ACTION_UP} is registered.
    */
-  void zoomOutAnimated(@NonNull PointF zoomFocalPoint, boolean runImmediately) {
+  void zoomOutAnimated(PointF zoomFocalPoint, boolean runImmediately) {
     zoomAnimated(false, zoomFocalPoint, runImmediately);
   }
 
-  private void zoomAnimated(boolean zoomIn, @NonNull PointF zoomFocalPoint, boolean runImmediately) {
+  private void zoomAnimated(boolean zoomIn, PointF zoomFocalPoint, boolean runImmediately) {
     //canceling here as well, because when using a button it will not be canceled automatically by onDown()
     cancelAnimator(scaleAnimator);
 
@@ -909,7 +901,7 @@ final class MapGestureDetector {
       && (!uiSettings.isTiltGesturesEnabled() || !gesturesManager.getShoveGestureDetector().isInProgress());
   }
 
-  private void sendTelemetryEvent(String eventType, @NonNull PointF focalPoint) {
+  private void sendTelemetryEvent(String eventType, PointF focalPoint) {
     TelemetryDefinition telemetry = Mapbox.getTelemetry();
     if (telemetry != null) {
       CameraPosition cameraPosition = transform.getCameraPosition();
@@ -927,7 +919,7 @@ final class MapGestureDetector {
     return mapZoom >= MapboxConstants.MINIMUM_ZOOM && mapZoom <= MapboxConstants.MAXIMUM_ZOOM;
   }
 
-  void notifyOnMapClickListeners(@NonNull PointF tapPoint) {
+  void notifyOnMapClickListeners(PointF tapPoint) {
     // deprecated API
     if (onMapClickListener != null) {
       onMapClickListener.onMapClick(projection.fromScreenLocation(tapPoint));
@@ -939,7 +931,7 @@ final class MapGestureDetector {
     }
   }
 
-  void notifyOnMapLongClickListeners(@NonNull PointF longClickPoint) {
+  void notifyOnMapLongClickListeners(PointF longClickPoint) {
     // deprecated API
     if (onMapLongClickListener != null) {
       onMapLongClickListener.onMapLongClick(projection.fromScreenLocation(longClickPoint));
@@ -975,73 +967,73 @@ final class MapGestureDetector {
     }
   }
 
-  void notifyOnMoveBeginListeners(@NonNull MoveGestureDetector detector) {
+  void notifyOnMoveBeginListeners(MoveGestureDetector detector) {
     for (MapboxMap.OnMoveListener listener : onMoveListenerList) {
       listener.onMoveBegin(detector);
     }
   }
 
-  void notifyOnMoveListeners(@NonNull MoveGestureDetector detector) {
+  void notifyOnMoveListeners(MoveGestureDetector detector) {
     for (MapboxMap.OnMoveListener listener : onMoveListenerList) {
       listener.onMove(detector);
     }
   }
 
-  void notifyOnMoveEndListeners(@NonNull MoveGestureDetector detector) {
+  void notifyOnMoveEndListeners(MoveGestureDetector detector) {
     for (MapboxMap.OnMoveListener listener : onMoveListenerList) {
       listener.onMoveEnd(detector);
     }
   }
 
-  void notifyOnRotateBeginListeners(@NonNull RotateGestureDetector detector) {
+  void notifyOnRotateBeginListeners(RotateGestureDetector detector) {
     for (MapboxMap.OnRotateListener listener : onRotateListenerList) {
       listener.onRotateBegin(detector);
     }
   }
 
-  void notifyOnRotateListeners(@NonNull RotateGestureDetector detector) {
+  void notifyOnRotateListeners(RotateGestureDetector detector) {
     for (MapboxMap.OnRotateListener listener : onRotateListenerList) {
       listener.onRotate(detector);
     }
   }
 
-  void notifyOnRotateEndListeners(@NonNull RotateGestureDetector detector) {
+  void notifyOnRotateEndListeners(RotateGestureDetector detector) {
     for (MapboxMap.OnRotateListener listener : onRotateListenerList) {
       listener.onRotateEnd(detector);
     }
   }
 
-  void notifyOnScaleBeginListeners(@NonNull StandardScaleGestureDetector detector) {
+  void notifyOnScaleBeginListeners(StandardScaleGestureDetector detector) {
     for (MapboxMap.OnScaleListener listener : onScaleListenerList) {
       listener.onScaleBegin(detector);
     }
   }
 
-  void notifyOnScaleListeners(@NonNull StandardScaleGestureDetector detector) {
+  void notifyOnScaleListeners(StandardScaleGestureDetector detector) {
     for (MapboxMap.OnScaleListener listener : onScaleListenerList) {
       listener.onScale(detector);
     }
   }
 
-  void notifyOnScaleEndListeners(@NonNull StandardScaleGestureDetector detector) {
+  void notifyOnScaleEndListeners(StandardScaleGestureDetector detector) {
     for (MapboxMap.OnScaleListener listener : onScaleListenerList) {
       listener.onScaleEnd(detector);
     }
   }
 
-  void notifyOnShoveBeginListeners(@NonNull ShoveGestureDetector detector) {
+  void notifyOnShoveBeginListeners(ShoveGestureDetector detector) {
     for (MapboxMap.OnShoveListener listener : onShoveListenerList) {
       listener.onShoveBegin(detector);
     }
   }
 
-  void notifyOnShoveListeners(@NonNull ShoveGestureDetector detector) {
+  void notifyOnShoveListeners(ShoveGestureDetector detector) {
     for (MapboxMap.OnShoveListener listener : onShoveListenerList) {
       listener.onShove(detector);
     }
   }
 
-  void notifyOnShoveEndListeners(@NonNull ShoveGestureDetector detector) {
+  void notifyOnShoveEndListeners(ShoveGestureDetector detector) {
     for (MapboxMap.OnShoveListener listener : onShoveListenerList) {
       listener.onShoveEnd(detector);
     }
@@ -1131,8 +1123,8 @@ final class MapGestureDetector {
     return gesturesManager;
   }
 
-  void setGesturesManager(@NonNull Context context, @NonNull AndroidGesturesManager gesturesManager,
-                          boolean attachDefaultListeners, boolean setDefaultMutuallyExclusives) {
+  void setGesturesManager(Context context, AndroidGesturesManager gesturesManager, boolean attachDefaultListeners,
+                          boolean setDefaultMutuallyExclusives) {
     initializeGesturesManager(gesturesManager, setDefaultMutuallyExclusives);
     initializeGestureListeners(context, attachDefaultListeners);
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapKeyListener.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapKeyListener.java
@@ -4,7 +4,6 @@ import android.graphics.PointF;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.ViewConfiguration;
@@ -24,7 +23,6 @@ final class MapKeyListener {
   private final UiSettings uiSettings;
   private final MapGestureDetector mapGestureDetector;
 
-  @Nullable
   private TrackballLongPressTimeOut currentTrackballLongPressTimeOut;
 
   MapKeyListener(Transform transform, UiSettings uiSettings, MapGestureDetector mapGestureDetector) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -80,9 +80,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   private final CopyOnWriteArrayList<OnMapChangedListener> onMapChangedListeners = new CopyOnWriteArrayList<>();
   private final MapChangeReceiver mapChangeReceiver = new MapChangeReceiver();
 
-  @Nullable
   private NativeMapView nativeMapView;
-  @Nullable
   private MapboxMap mapboxMap;
   private MapboxMapOptions mapboxMapOptions;
   private MapRenderer mapRenderer;
@@ -94,12 +92,9 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   private ImageView attrView;
   private ImageView logoView;
 
-  @Nullable
   private MapGestureDetector mapGestureDetector;
-  @Nullable
   private MapKeyListener mapKeyListener;
   private MapZoomButtonController mapZoomButtonController;
-  @Nullable
   private Bundle savedInstanceState;
 
   @UiThread
@@ -236,7 +231,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     };
   }
 
-  private MapboxMap.OnCompassAnimationListener createCompassAnimationListener(@NonNull final CameraChangeDispatcher
+  private MapboxMap.OnCompassAnimationListener createCompassAnimationListener(final CameraChangeDispatcher
                                                                                 cameraChangeDispatcher) {
     return new MapboxMap.OnCompassAnimationListener() {
       @Override
@@ -252,7 +247,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     };
   }
 
-  private OnClickListener createCompassClickListener(@NonNull final CameraChangeDispatcher cameraChangeDispatcher) {
+  private OnClickListener createCompassClickListener(final CameraChangeDispatcher cameraChangeDispatcher) {
     return new OnClickListener() {
       @Override
       public void onClick(View v) {
@@ -465,7 +460,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   }
 
   @Override
-  public boolean onTouchEvent(@NonNull MotionEvent event) {
+  public boolean onTouchEvent(MotionEvent event) {
     if (!isMapInitialized() || !isZoomButtonControllerInitialized() || !isGestureDetectorInitialized()) {
       return super.onTouchEvent(event);
     }
@@ -477,7 +472,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   }
 
   @Override
-  public boolean onKeyDown(int keyCode, @NonNull KeyEvent event) {
+  public boolean onKeyDown(int keyCode, KeyEvent event) {
     return mapKeyListener.onKeyDown(keyCode, event) || super.onKeyDown(keyCode, event);
   }
 
@@ -487,17 +482,17 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   }
 
   @Override
-  public boolean onKeyUp(int keyCode, @NonNull KeyEvent event) {
+  public boolean onKeyUp(int keyCode, KeyEvent event) {
     return mapKeyListener.onKeyUp(keyCode, event) || super.onKeyUp(keyCode, event);
   }
 
   @Override
-  public boolean onTrackballEvent(@NonNull MotionEvent event) {
+  public boolean onTrackballEvent(MotionEvent event) {
     return mapKeyListener.onTrackballEvent(event) || super.onTrackballEvent(event);
   }
 
   @Override
-  public boolean onGenericMotionEvent(@NonNull MotionEvent event) {
+  public boolean onGenericMotionEvent(MotionEvent event) {
     if (!isGestureDetectorInitialized()) {
       return super.onGenericMotionEvent(event);
     }
@@ -505,7 +500,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   }
 
   @Override
-  public boolean onHoverEvent(@NonNull MotionEvent event) {
+  public boolean onHoverEvent(MotionEvent event) {
     if (!isZoomButtonControllerInitialized()) {
       return super.onHoverEvent(event);
     }
@@ -595,9 +590,9 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     }
   }
 
-  private void setOfflineRegionDefinition(@NonNull String styleUrl, LatLng latLng, double minZoom, double maxZoom) {
+  private void setOfflineRegionDefinition(String styleUrl, LatLng cameraTarget, double minZoom, double maxZoom) {
     CameraPosition cameraPosition = new CameraPosition.Builder()
-      .target(latLng)
+      .target(cameraTarget)
       .zoom(minZoom)
       .build();
     setStyleUrl(styleUrl);
@@ -683,7 +678,6 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   // ViewCallback
   //
 
-  @Nullable
   @Override
   public Bitmap getViewContent() {
     return BitmapUtils.createBitmapFromView(this);
@@ -1123,7 +1117,6 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     return mapGestureDetector != null;
   }
 
-  @Nullable
   MapboxMap getMapboxMap() {
     return mapboxMap;
   }
@@ -1665,11 +1658,10 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
    */
   private static class AttributionClickListener implements OnClickListener {
 
-    @NonNull
     private final AttributionDialogManager defaultDialogManager;
     private UiSettings uiSettings;
 
-    private AttributionClickListener(@NonNull Context context, @NonNull MapboxMap mapboxMap) {
+    private AttributionClickListener(Context context, MapboxMap mapboxMap) {
       this.defaultDialogManager = new AttributionDialogManager(context, mapboxMap);
       this.uiSettings = mapboxMap.getUiSettings();
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -77,7 +77,6 @@ public final class MapboxMap {
   private final OnGesturesManagerInteractionListener onGesturesManagerInteractionListener;
 
   private LocationComponent locationComponent;
-  @Nullable
   private MapboxMap.OnFpsChangedListener onFpsChangedListener;
 
   MapboxMap(NativeMapView map, Transform transform, UiSettings ui, Projection projection,
@@ -680,7 +679,7 @@ public final class MapboxMap {
    * @param update The change that should be applied to the camera.
    * @see com.mapbox.mapboxsdk.camera.CameraUpdateFactory for a set of updates.
    */
-  public final void easeCamera(@NonNull CameraUpdate update) {
+  public final void easeCamera(CameraUpdate update) {
     easeCamera(update, MapboxConstants.ANIMATION_DURATION);
   }
 
@@ -1058,7 +1057,7 @@ public final class MapboxMap {
    * @param style The bundled style.
    * @see Style
    */
-  public void setStyle(@NonNull @Style.StyleUrl String style) {
+  public void setStyle(@Style.StyleUrl String style) {
     setStyleUrl(style);
   }
 
@@ -1074,7 +1073,7 @@ public final class MapboxMap {
    * @param callback The callback to be invoked when the style has finished loading
    * @see Style
    */
-  public void setStyle(@NonNull @Style.StyleUrl String style, @Nullable OnStyleLoadedListener callback) {
+  public void setStyle(@Style.StyleUrl String style, @Nullable OnStyleLoadedListener callback) {
     setStyleUrl(style, callback);
   }
 
@@ -1753,7 +1752,7 @@ public final class MapboxMap {
    */
   @NonNull
   @Deprecated
-  public CameraPosition getCameraForGeometry(@NonNull Geometry geometry, double bearing, @NonNull int[] padding) {
+  public CameraPosition getCameraForGeometry(Geometry geometry, double bearing, int[] padding) {
     return getCameraForGeometry(geometry, padding, bearing, transform.getTilt());
   }
 
@@ -2423,7 +2422,7 @@ public final class MapboxMap {
      *
      * @param position The CameraPosition at the end of the last camera change.
      */
-    void onCameraChange(@NonNull CameraPosition position);
+    void onCameraChange(CameraPosition position);
   }
 
   /**
@@ -2705,7 +2704,6 @@ public final class MapboxMap {
 
     private Context context;
     private final Class<U> persistentClass;
-    @NonNull
     private final Pools.SimplePool<View> viewReusePool;
 
     /**
@@ -2789,7 +2787,6 @@ public final class MapboxMap {
      *
      * @return the pool associated to this adapter
      */
-    @NonNull
     public final Pools.SimplePool<View> getViewReusePool() {
       return viewReusePool;
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
@@ -143,7 +143,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param attrs   Attributeset containing configuration
    * @return the MapboxMapOptions created from attributes
    */
-  @NonNull
   public static MapboxMapOptions createFromAttributes(@NonNull Context context, @Nullable AttributeSet attrs) {
     MapboxMapOptions mapboxMapOptions = new MapboxMapOptions();
     float pxlRatio = context.getResources().getDisplayMetrics().density;
@@ -251,7 +250,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param apiBaseUrl The base of our API endpoint
    * @return This
    */
-  @NonNull
   public MapboxMapOptions apiBaseUrl(String apiBaseUrl) {
     this.apiBaseUrl = apiBaseUrl;
     return this;
@@ -263,7 +261,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param cameraPosition Inital camera position
    * @return This
    */
-  @NonNull
   public MapboxMapOptions camera(CameraPosition cameraPosition) {
     this.cameraPosition = cameraPosition;
     return this;
@@ -275,7 +272,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param styleUrl Url to be used to load a styleUrl
    * @return This
    */
-  @NonNull
   public MapboxMapOptions styleUrl(String styleUrl) {
     this.styleUrl = styleUrl;
     return this;
@@ -287,7 +283,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param styleJson json to used as style
    * @return This
    */
-  @NonNull
   public MapboxMapOptions styleJson(String styleJson) {
     this.styleJson = styleJson;
     return this;
@@ -299,7 +294,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param enabled True is debug is enabled
    * @return This
    */
-  @NonNull
   public MapboxMapOptions debugActive(boolean enabled) {
     debugActive = enabled;
     return this;
@@ -311,7 +305,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param minZoom Zoom level to be used
    * @return This
    */
-  @NonNull
   public MapboxMapOptions minZoomPreference(double minZoom) {
     this.minZoom = minZoom;
     return this;
@@ -323,7 +316,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param maxZoom Zoom level to be used
    * @return This
    */
-  @NonNull
   public MapboxMapOptions maxZoomPreference(double maxZoom) {
     this.maxZoom = maxZoom;
     return this;
@@ -335,7 +327,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param enabled True and mapbox_compass_icon is shown
    * @return This
    */
-  @NonNull
   public MapboxMapOptions compassEnabled(boolean enabled) {
     compassEnabled = enabled;
     return this;
@@ -347,7 +338,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param gravity Android SDK Gravity.
    * @return This
    */
-  @NonNull
   public MapboxMapOptions compassGravity(int gravity) {
     compassGravity = gravity;
     return this;
@@ -359,7 +349,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param margins 4 long array for LTRB margins
    * @return This
    */
-  @NonNull
   public MapboxMapOptions compassMargins(int[] margins) {
     compassMargins = margins;
     return this;
@@ -374,7 +363,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param compassFadeWhenFacingNorth true is mapbox_compass_icon fades to invisble
    * @return This
    */
-  @NonNull
   public MapboxMapOptions compassFadesWhenFacingNorth(boolean compassFadeWhenFacingNorth) {
     this.fadeCompassFacingNorth = compassFadeWhenFacingNorth;
     return this;
@@ -389,7 +377,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param compass the drawable to show as image compass
    * @return This
    */
-  @NonNull
   public MapboxMapOptions compassImage(Drawable compass) {
     this.compassImage = compass;
     return this;
@@ -401,7 +388,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param enabled True and logo is shown
    * @return This
    */
-  @NonNull
   public MapboxMapOptions logoEnabled(boolean enabled) {
     logoEnabled = enabled;
     return this;
@@ -413,7 +399,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param gravity Android SDK Gravity.
    * @return This
    */
-  @NonNull
   public MapboxMapOptions logoGravity(int gravity) {
     logoGravity = gravity;
     return this;
@@ -425,7 +410,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param margins 4 long array for LTRB margins
    * @return This
    */
-  @NonNull
   public MapboxMapOptions logoMargins(int[] margins) {
     logoMargins = margins;
     return this;
@@ -437,7 +421,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param enabled True and attribution is shown
    * @return This
    */
-  @NonNull
   public MapboxMapOptions attributionEnabled(boolean enabled) {
     attributionEnabled = enabled;
     return this;
@@ -449,7 +432,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param gravity Android SDK Gravity.
    * @return This
    */
-  @NonNull
   public MapboxMapOptions attributionGravity(int gravity) {
     attributionGravity = gravity;
     return this;
@@ -461,7 +443,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param margins 4 long array for LTRB margins
    * @return This
    */
-  @NonNull
   public MapboxMapOptions attributionMargins(int[] margins) {
     attributionMargins = margins;
     return this;
@@ -473,7 +454,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param color integer resembling a color
    * @return This
    */
-  @NonNull
   public MapboxMapOptions attributionTintColor(@ColorInt int color) {
     attributionTintColor = color;
     return this;
@@ -485,7 +465,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param enabled True and gesture will be enabled
    * @return This
    */
-  @NonNull
   public MapboxMapOptions rotateGesturesEnabled(boolean enabled) {
     rotateGesturesEnabled = enabled;
     return this;
@@ -497,7 +476,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param enabled True and gesture will be enabled
    * @return This
    */
-  @NonNull
   public MapboxMapOptions scrollGesturesEnabled(boolean enabled) {
     scrollGesturesEnabled = enabled;
     return this;
@@ -509,7 +487,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param enabled True and gesture will be enabled
    * @return This
    */
-  @NonNull
   public MapboxMapOptions tiltGesturesEnabled(boolean enabled) {
     tiltGesturesEnabled = enabled;
     return this;
@@ -521,7 +498,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param enabled True and gesture will be enabled
    * @return This
    */
-  @NonNull
   public MapboxMapOptions zoomControlsEnabled(boolean enabled) {
     zoomControlsEnabled = enabled;
     return this;
@@ -533,7 +509,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param enabled True and gesture will be enabled
    * @return This
    */
-  @NonNull
   public MapboxMapOptions zoomGesturesEnabled(boolean enabled) {
     zoomGesturesEnabled = enabled;
     return this;
@@ -545,7 +520,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param enabled True and gesture will be enabled
    * @return This
    */
-  @NonNull
   public MapboxMapOptions doubleTapGesturesEnabled(boolean enabled) {
     doubleTapGesturesEnabled = enabled;
     return this;
@@ -564,13 +538,11 @@ public class MapboxMapOptions implements Parcelable {
    * @param textureMode True to enable texture mode
    * @return This
    */
-  @NonNull
   public MapboxMapOptions textureMode(boolean textureMode) {
     this.textureMode = textureMode;
     return this;
   }
 
-  @NonNull
   public MapboxMapOptions translucentTextureSurface(boolean translucentTextureSurface) {
     this.translucentTextureSurface = translucentTextureSurface;
     return this;
@@ -582,7 +554,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param loadColor the color to show during map creation
    * @return This
    */
-  @NonNull
   public MapboxMapOptions foregroundLoadColor(@ColorInt int loadColor) {
     this.foregroundLoadColor = loadColor;
     return this;
@@ -596,7 +567,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param enable true to enable
    * @return This
    */
-  @NonNull
   public MapboxMapOptions setPrefetchesTiles(boolean enable) {
     this.prefetchesTiles = enable;
     return this;
@@ -612,7 +582,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param crossSourceCollisions true to enable, false to disable
    * @return This
    */
-  @NonNull
   public MapboxMapOptions crossSourceCollisions(boolean crossSourceCollisions) {
     this.crossSourceCollisions = crossSourceCollisions;
     return this;
@@ -628,7 +597,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param fontFamily font family for local ideograph generation.
    * @return This
    */
-  @NonNull
   public MapboxMapOptions localIdeographFontFamily(String fontFamily) {
     this.localIdeographFontFamily = fontFamily;
     return this;
@@ -641,7 +609,6 @@ public class MapboxMapOptions implements Parcelable {
    * @param pixelRatio the custom pixel ratio of the map under construction
    * @return This
    */
-  @NonNull
   public MapboxMapOptions pixelRatio(float pixelRatio) {
     this.pixelRatio = pixelRatio;
     return this;
@@ -952,7 +919,7 @@ public class MapboxMapOptions implements Parcelable {
   }
 
   public static final Parcelable.Creator<MapboxMapOptions> CREATOR = new Parcelable.Creator<MapboxMapOptions>() {
-    public MapboxMapOptions createFromParcel(@NonNull Parcel in) {
+    public MapboxMapOptions createFromParcel(Parcel in) {
       return new MapboxMapOptions(in);
     }
 
@@ -967,7 +934,7 @@ public class MapboxMapOptions implements Parcelable {
   }
 
   @Override
-  public void writeToParcel(@NonNull Parcel dest, int flags) {
+  public void writeToParcel(Parcel dest, int flags) {
     dest.writeParcelable(cameraPosition, flags);
     dest.writeByte((byte) (debugActive ? 1 : 0));
 
@@ -1011,7 +978,7 @@ public class MapboxMapOptions implements Parcelable {
   }
 
   @Override
-  public boolean equals(@Nullable Object o) {
+  public boolean equals(Object o) {
     if (this == o) {
       return true;
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MarkerContainer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MarkerContainer.java
@@ -48,7 +48,6 @@ class MarkerContainer implements Markers {
     return marker;
   }
 
-  @NonNull
   @Override
   public List<Marker> addBy(@NonNull List<? extends BaseMarkerOptions> markerOptionsList, @NonNull MapboxMap
     mapboxMap) {
@@ -83,7 +82,6 @@ class MarkerContainer implements Markers {
     annotations.setValueAt(annotations.indexOfKey(updatedMarker.getId()), updatedMarker);
   }
 
-  @NonNull
   @Override
   public List<Marker> obtainAll() {
     List<Marker> markers = new ArrayList<>();
@@ -139,7 +137,6 @@ class MarkerContainer implements Markers {
     return marker;
   }
 
-  @NonNull
   @Override
   public List<MarkerView> addViewsBy(@NonNull List<? extends BaseMarkerViewOptions> markerViewOptions, @NonNull
     MapboxMap mapboxMap) {
@@ -163,7 +160,6 @@ class MarkerContainer implements Markers {
     return markers;
   }
 
-  @NonNull
   @Override
   public List<MarkerView> obtainViewsIn(@NonNull RectF rectangle) {
     float pixelRatio = nativeMapView.getPixelRatio();
@@ -214,13 +210,12 @@ class MarkerContainer implements Markers {
     return marker;
   }
 
-  private void ensureIconLoaded(Marker marker, @NonNull MapboxMap mapboxMap) {
+  private void ensureIconLoaded(Marker marker, MapboxMap mapboxMap) {
     if (!(marker instanceof MarkerView)) {
       iconManager.ensureIconLoaded(marker, mapboxMap);
     }
   }
 
-  @NonNull
   private List<Annotation> obtainAnnotations() {
     List<Annotation> annotations = new ArrayList<>();
     for (int i = 0; i < this.annotations.size(); i++) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Markers.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Markers.java
@@ -25,7 +25,6 @@ interface Markers {
 
   List<Marker> obtainAll();
 
-  @NonNull
   List<Marker> obtainAllIn(@NonNull RectF rectangle);
 
   MarkerView addViewBy(@NonNull BaseMarkerViewOptions markerOptions, @NonNull MapboxMap mapboxMap,

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -50,23 +50,18 @@ final class NativeMapView {
   private static final String TAG = "Mbgl-NativeMapView";
 
   //Hold a reference to prevent it from being GC'd as long as it's used on the native side
-  @NonNull
   private final FileSource fileSource;
 
   // Used to schedule work on the MapRenderer Thread
-  @NonNull
   private final MapRenderer mapRenderer;
 
   // Used to validate if methods are called from the correct thread
-  @NonNull
   private final Thread thread;
 
   // Used for view callbacks
-  @NonNull
   private ViewCallback viewCallback;
 
   // Used for map change callbacks
-  @NonNull
   private StateCallback stateCallback;
 
   // Device density
@@ -92,16 +87,15 @@ final class NativeMapView {
   // Constructors
   //
 
-  public NativeMapView(@NonNull final Context context, final boolean crossSourceCollisions,
-                       @NonNull final ViewCallback viewCallback, @NonNull final StateCallback stateCallback,
-                       @NonNull final MapRenderer mapRenderer) {
-    this(context, context.getResources().getDisplayMetrics().density,
-      crossSourceCollisions, viewCallback, stateCallback, mapRenderer);
+  public NativeMapView(final Context context, final boolean crossSourceCollisions, final ViewCallback viewCallback,
+                       final StateCallback stateCallback, final MapRenderer mapRenderer) {
+    this(context, context.getResources().getDisplayMetrics().density, crossSourceCollisions, viewCallback,
+      stateCallback, mapRenderer);
   }
 
-  public NativeMapView(@NonNull final Context context, final float pixelRatio, final boolean crossSourceCollisions,
-                       @NonNull final ViewCallback viewCallback, @NonNull final StateCallback stateCallback,
-                       @NonNull final MapRenderer mapRenderer) {
+  public NativeMapView(final Context context, final float pixelRatio, final boolean crossSourceCollisions,
+                       final ViewCallback viewCallback, final StateCallback stateCallback,
+                       final MapRenderer mapRenderer) {
     this.mapRenderer = mapRenderer;
     this.viewCallback = viewCallback;
     this.fileSource = FileSource.getInstance(context);
@@ -249,14 +243,14 @@ final class NativeMapView {
     nativeMoveBy(dx / pixelRatio, dy / pixelRatio, duration);
   }
 
-  public void setLatLng(@NonNull LatLng latLng) {
+  public void setLatLng(LatLng latLng) {
     if (checkState("setLatLng")) {
       return;
     }
     setLatLng(latLng, 0);
   }
 
-  public void setLatLng(@NonNull LatLng latLng, long duration) {
+  public void setLatLng(LatLng latLng, long duration) {
     if (checkState("setLatLng")) {
       return;
     }
@@ -322,7 +316,7 @@ final class NativeMapView {
     nativeSetPitch(pitch, duration);
   }
 
-  public void setZoom(double zoom, @NonNull PointF focalPoint, long duration) {
+  public void setZoom(double zoom, PointF focalPoint, long duration) {
     if (checkState("setZoom")) {
       return;
     }
@@ -447,8 +441,7 @@ final class NativeMapView {
     return nativeAddMarkers(markers)[0];
   }
 
-  @NonNull
-  public long[] addMarkers(@NonNull List<Marker> markers) {
+  public long[] addMarkers(List<Marker> markers) {
     if (checkState("addMarkers")) {
       return new long[] {};
     }
@@ -463,8 +456,7 @@ final class NativeMapView {
     return nativeAddPolylines(polylines)[0];
   }
 
-  @NonNull
-  public long[] addPolylines(@NonNull List<Polyline> polylines) {
+  public long[] addPolylines(List<Polyline> polylines) {
     if (checkState("addPolylines")) {
       return new long[] {};
     }
@@ -479,15 +471,14 @@ final class NativeMapView {
     return nativeAddPolygons(polygons)[0];
   }
 
-  @NonNull
-  public long[] addPolygons(@NonNull List<Polygon> polygons) {
+  public long[] addPolygons(List<Polygon> polygons) {
     if (checkState("addPolygons")) {
       return new long[] {};
     }
     return nativeAddPolygons(polygons.toArray(new Polygon[polygons.size()]));
   }
 
-  public void updateMarker(@NonNull Marker marker) {
+  public void updateMarker(Marker marker) {
     if (checkState("updateMarker")) {
       return;
     }
@@ -496,14 +487,14 @@ final class NativeMapView {
     nativeUpdateMarker(marker.getId(), position.getLatitude(), position.getLongitude(), icon.getId());
   }
 
-  public void updatePolygon(@NonNull Polygon polygon) {
+  public void updatePolygon(Polygon polygon) {
     if (checkState("updatePolygon")) {
       return;
     }
     nativeUpdatePolygon(polygon.getId(), polygon);
   }
 
-  public void updatePolyline(@NonNull Polyline polyline) {
+  public void updatePolyline(Polyline polyline) {
     if (checkState("updatePolyline")) {
       return;
     }
@@ -525,7 +516,6 @@ final class NativeMapView {
     nativeRemoveAnnotations(ids);
   }
 
-  @NonNull
   public long[] queryPointAnnotations(RectF rect) {
     if (checkState("queryPointAnnotations")) {
       return new long[] {};
@@ -533,7 +523,6 @@ final class NativeMapView {
     return nativeQueryPointAnnotations(rect);
   }
 
-  @NonNull
   public long[] queryShapeAnnotations(RectF rectF) {
     if (checkState("queryShapeAnnotations")) {
       return new long[] {};
@@ -611,14 +600,14 @@ final class NativeMapView {
     return nativeGetMetersPerPixelAtLatitude(lat, getZoom()) / pixelRatio;
   }
 
-  public ProjectedMeters projectedMetersForLatLng(@NonNull LatLng latLng) {
+  public ProjectedMeters projectedMetersForLatLng(LatLng latLng) {
     if (checkState("projectedMetersForLatLng")) {
       return null;
     }
     return nativeProjectedMetersForLatLng(latLng.getLatitude(), latLng.getLongitude());
   }
 
-  public LatLng latLngForProjectedMeters(@NonNull ProjectedMeters projectedMeters) {
+  public LatLng latLngForProjectedMeters(ProjectedMeters projectedMeters) {
     if (checkState("latLngForProjectedMeters")) {
       return new LatLng();
     }
@@ -626,8 +615,7 @@ final class NativeMapView {
       projectedMeters.getEasting()).wrap();
   }
 
-  @NonNull
-  public PointF pixelForLatLng(@NonNull LatLng latLng) {
+  public PointF pixelForLatLng(LatLng latLng) {
     if (checkState("pixelForLatLng")) {
       return new PointF();
     }
@@ -636,7 +624,7 @@ final class NativeMapView {
     return pointF;
   }
 
-  public LatLng latLngForPixel(@NonNull PointF pixel) {
+  public LatLng latLngForPixel(PointF pixel) {
     if (checkState("latLngForPixel")) {
       return new LatLng();
     }
@@ -650,14 +638,14 @@ final class NativeMapView {
     return nativeGetTopOffsetPixelsForAnnotationSymbol(symbolName);
   }
 
-  public void jumpTo(double angle, @NonNull LatLng center, double pitch, double zoom) {
+  public void jumpTo(double angle, LatLng center, double pitch, double zoom) {
     if (checkState("jumpTo")) {
       return;
     }
     nativeJumpTo(angle, center.getLatitude(), center.getLongitude(), pitch, zoom);
   }
 
-  public void easeTo(double angle, @NonNull LatLng center, long duration, double pitch, double zoom,
+  public void easeTo(double angle, LatLng center, long duration, double pitch, double zoom,
                      boolean easingInterpolator) {
     if (checkState("easeTo")) {
       return;
@@ -666,14 +654,13 @@ final class NativeMapView {
       easingInterpolator);
   }
 
-  public void flyTo(double angle, @NonNull LatLng center, long duration, double pitch, double zoom) {
+  public void flyTo(double angle, LatLng center, long duration, double pitch, double zoom) {
     if (checkState("flyTo")) {
       return;
     }
     nativeFlyTo(angle, center.getLatitude(), center.getLongitude(), duration, pitch, zoom);
   }
 
-  @NonNull
   public CameraPosition getCameraPosition() {
     if (checkState("getCameraValues")) {
       return new CameraPosition.Builder().build();
@@ -1020,7 +1007,7 @@ final class NativeMapView {
   }
 
   @Keep
-  protected void onSnapshotReady(@Nullable Bitmap mapContent) {
+  protected void onSnapshotReady(Bitmap mapContent) {
     if (checkState("OnSnapshotReady")) {
       return;
     }
@@ -1051,14 +1038,12 @@ final class NativeMapView {
   @Keep
   private native void nativeSetStyleUrl(String url);
 
-  @NonNull
   @Keep
   private native String nativeGetStyleUrl();
 
   @Keep
   private native void nativeSetStyleJson(String newStyleJson);
 
-  @NonNull
   @Keep
   private native String nativeGetStyleJson();
 
@@ -1077,16 +1062,13 @@ final class NativeMapView {
   @Keep
   private native void nativeSetLatLng(double latitude, double longitude, long duration);
 
-  @NonNull
   @Keep
   private native LatLng nativeGetLatLng();
 
-  @NonNull
   @Keep
   private native CameraPosition nativeGetCameraForLatLngBounds(
     LatLngBounds latLngBounds, double top, double left, double bottom, double right, double bearing, double tilt);
 
-  @NonNull
   @Keep
   private native CameraPosition nativeGetCameraForGeometry(
     Geometry geometry, double top, double left, double bottom, double right, double bearing, double tilt);
@@ -1142,26 +1124,21 @@ final class NativeMapView {
   @Keep
   private native void nativeUpdateMarker(long markerId, double lat, double lon, String iconId);
 
-  @NonNull
   @Keep
   private native long[] nativeAddMarkers(Marker[] markers);
 
-  @NonNull
   @Keep
   private native long[] nativeAddPolylines(Polyline[] polylines);
 
-  @NonNull
   @Keep
   private native long[] nativeAddPolygons(Polygon[] polygons);
 
   @Keep
   private native void nativeRemoveAnnotations(long[] id);
 
-  @NonNull
   @Keep
   private native long[] nativeQueryPointAnnotations(RectF rect);
 
-  @NonNull
   @Keep
   private native long[] nativeQueryShapeAnnotations(RectF rect);
 
@@ -1196,19 +1173,15 @@ final class NativeMapView {
   @Keep
   private native double nativeGetMetersPerPixelAtLatitude(double lat, double zoom);
 
-  @NonNull
   @Keep
   private native ProjectedMeters nativeProjectedMetersForLatLng(double latitude, double longitude);
 
-  @NonNull
   @Keep
   private native LatLng nativeLatLngForProjectedMeters(double northing, double easting);
 
-  @NonNull
   @Keep
   private native PointF nativePixelForLatLng(double lat, double lon);
 
-  @NonNull
   @Keep
   private native LatLng nativeLatLngForPixel(float x, float y);
 
@@ -1227,7 +1200,6 @@ final class NativeMapView {
   private native void nativeFlyTo(double angle, double latitude, double longitude,
                                   long duration, double pitch, double zoom);
 
-  @NonNull
   @Keep
   private native CameraPosition nativeGetCameraPosition();
 
@@ -1243,11 +1215,9 @@ final class NativeMapView {
   @Keep
   private native void nativeSetTransitionDelay(long delay);
 
-  @NonNull
   @Keep
   private native Layer[] nativeGetLayers();
 
-  @NonNull
   @Keep
   private native Layer nativeGetLayer(String layerId);
 
@@ -1260,22 +1230,18 @@ final class NativeMapView {
   @Keep
   private native void nativeAddLayerAt(long layerPtr, int index) throws CannotAddLayerException;
 
-  @NonNull
   @Keep
   private native Layer nativeRemoveLayerById(String layerId);
 
   @Keep
   private native void nativeRemoveLayer(long layerId);
 
-  @NonNull
   @Keep
   private native Layer nativeRemoveLayerAt(int index);
 
-  @NonNull
   @Keep
   private native Source[] nativeGetSources();
 
-  @NonNull
   @Keep
   private native Source nativeGetSource(String sourceId);
 
@@ -1294,7 +1260,6 @@ final class NativeMapView {
   @Keep
   private native void nativeRemoveImage(String name);
 
-  @NonNull
   @Keep
   private native Bitmap nativeGetImage(String name);
 
@@ -1307,20 +1272,17 @@ final class NativeMapView {
   @Keep
   private native void nativeTakeSnapshot();
 
-  @NonNull
   @Keep
   private native Feature[] nativeQueryRenderedFeaturesForPoint(float x, float y,
                                                                String[] layerIds,
                                                                Object[] filter);
 
-  @NonNull
   @Keep
   private native Feature[] nativeQueryRenderedFeaturesForBox(float left, float top,
                                                              float right, float bottom,
                                                              String[] layerIds,
                                                              Object[] filter);
 
-  @NonNull
   @Keep
   private native Light nativeGetLight();
 
@@ -1377,7 +1339,7 @@ final class NativeMapView {
     nativeTakeSnapshot();
   }
 
-  public void setOnFpsChangedListener(@NonNull final MapboxMap.OnFpsChangedListener listener) {
+  public void setOnFpsChangedListener(final MapboxMap.OnFpsChangedListener listener) {
     final Handler handler = new Handler();
     mapRenderer.queueEvent(new Runnable() {
 
@@ -1415,7 +1377,6 @@ final class NativeMapView {
       this.sdf = sdf;
     }
 
-    @NonNull
     @Override
     protected List<Image> doInBackground(HashMap<String, Bitmap>... params) {
       HashMap<String, Bitmap> bitmapHashMap = params[0];
@@ -1445,7 +1406,7 @@ final class NativeMapView {
     }
 
     @Override
-    protected void onPostExecute(@NonNull List<Image> images) {
+    protected void onPostExecute(List<Image> images) {
       super.onPostExecute(images);
       if (nativeMapView != null && !nativeMapView.checkState("nativeAddImages")) {
         nativeMapView.nativeAddImages(images.toArray(new Image[images.size()]));
@@ -1458,7 +1419,6 @@ final class NativeMapView {
 
     int getHeight();
 
-    @Nullable
     Bitmap getViewContent();
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/OnMapReadyCallback.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/OnMapReadyCallback.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxsdk.maps;
 
-import android.support.annotation.NonNull;
-
 /**
  * Interface definition for a callback to be invoked when the map is ready to be used.
  * <p>
@@ -18,5 +16,5 @@ public interface OnMapReadyCallback {
    * @param mapboxMap An instance of MapboxMap associated with the {@link MapFragment} or
    *                  {@link MapView} that defines the callback.
    */
-  void onMapReady(@NonNull MapboxMap mapboxMap);
+  void onMapReady(MapboxMap mapboxMap);
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/PolygonContainer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/PolygonContainer.java
@@ -36,7 +36,6 @@ class PolygonContainer implements Polygons {
     return polygon;
   }
 
-  @NonNull
   @Override
   public List<Polygon> addBy(@NonNull List<PolygonOptions> polygonOptionsList, @NonNull MapboxMap mapboxMap) {
     int count = polygonOptionsList.size();
@@ -63,12 +62,11 @@ class PolygonContainer implements Polygons {
   }
 
   @Override
-  public void update(@NonNull Polygon polygon) {
+  public void update(Polygon polygon) {
     nativeMapView.updatePolygon(polygon);
     annotations.setValueAt(annotations.indexOfKey(polygon.getId()), polygon);
   }
 
-  @NonNull
   @Override
   public List<Polygon> obtainAll() {
     List<Polygon> polygons = new ArrayList<>();

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/PolylineContainer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/PolylineContainer.java
@@ -36,7 +36,6 @@ class PolylineContainer implements Polylines {
     return polyline;
   }
 
-  @NonNull
   @Override
   public List<Polyline> addBy(@NonNull List<PolylineOptions> polylineOptionsList, @NonNull MapboxMap mapboxMap) {
     int count = polylineOptionsList.size();
@@ -62,12 +61,11 @@ class PolylineContainer implements Polylines {
   }
 
   @Override
-  public void update(@NonNull Polyline polyline) {
+  public void update(Polyline polyline) {
     nativeMapView.updatePolyline(polyline);
     annotations.setValueAt(annotations.indexOfKey(polyline.getId()), polyline);
   }
 
-  @NonNull
   @Override
   public List<Polyline> obtainAll() {
     List<Polyline> polylines = new ArrayList<>();

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Projection.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Projection.java
@@ -21,7 +21,6 @@ import java.util.List;
  */
 public class Projection {
 
-  @NonNull
   private final NativeMapView nativeMapView;
   private int[] contentPadding;
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/ShapeAnnotationContainer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/ShapeAnnotationContainer.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.maps;
 
 import android.graphics.RectF;
-import android.support.annotation.NonNull;
 import android.support.v4.util.LongSparseArray;
 
 import com.mapbox.mapboxsdk.annotations.Annotation;
@@ -19,15 +18,13 @@ class ShapeAnnotationContainer implements ShapeAnnotations {
     this.annotations = annotations;
   }
 
-  @NonNull
   @Override
-  public List<Annotation> obtainAllIn(@NonNull RectF rectangle) {
+  public List<Annotation> obtainAllIn(RectF rectangle) {
     RectF rect = nativeMapView.getDensityDependantRectangle(rectangle);
     long[] annotationIds = nativeMapView.queryShapeAnnotations(rect);
     return getAnnotationsFromIds(annotationIds);
   }
 
-  @NonNull
   private List<Annotation> getAnnotationsFromIds(long[] annotationIds) {
     List<Annotation> shapeAnnotations = new ArrayList<>();
     for (long annotationId : annotationIds) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
@@ -119,7 +119,7 @@ public class SupportMapFragment extends Fragment implements OnMapReadyCallback {
   }
 
   @Override
-  public void onMapReady(@NonNull MapboxMap mapboxMap) {
+  public void onMapReady(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
     for (OnMapReadyCallback onMapReadyCallback : mapReadyCallbackList) {
       onMapReadyCallback.onMapReady(mapboxMap);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
@@ -51,7 +51,6 @@ public class SupportMapFragment extends Fragment implements OnMapReadyCallback {
    * @param mapboxMapOptions The configuration options to be used.
    * @return MapFragment created.
    */
-  @NonNull
   public static SupportMapFragment newInstance(@Nullable MapboxMapOptions mapboxMapOptions) {
     SupportMapFragment mapFragment = new SupportMapFragment();
     mapFragment.setArguments(MapFragmentUtils.createFragmentArgs(mapboxMapOptions));
@@ -79,7 +78,7 @@ public class SupportMapFragment extends Fragment implements OnMapReadyCallback {
    * @param savedInstanceState The saved instance state for the map fragment.
    */
   @Override
-  public void onInflate(@NonNull Context context, AttributeSet attrs, Bundle savedInstanceState) {
+  public void onInflate(Context context, AttributeSet attrs, Bundle savedInstanceState) {
     super.onInflate(context, attrs, savedInstanceState);
     setArguments(MapFragmentUtils.createFragmentArgs(MapboxMapOptions.createFromAttributes(context, attrs)));
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/TelemetryDefinition.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/TelemetryDefinition.java
@@ -1,6 +1,5 @@
 package com.mapbox.mapboxsdk.maps;
 
-import android.support.annotation.NonNull;
 import com.mapbox.mapboxsdk.offline.OfflineRegionDefinition;
 
 /**
@@ -21,7 +20,7 @@ public interface TelemetryDefinition {
    * @param longitude the longitude value of the gesture focal point
    * @param zoom      current zoom of the map
    */
-  void onGestureInteraction(@NonNull String eventType, double latitude, double longitude, double zoom);
+  void onGestureInteraction(String eventType, double latitude, double longitude, double zoom);
 
   /**
    * Set the end-user selected state to participate or opt-out in telemetry collection.
@@ -46,5 +45,5 @@ public interface TelemetryDefinition {
    *
    * @param offlineDefinition the offline region definition
    */
-  void onCreateOfflineRegion(@NonNull OfflineRegionDefinition offlineDefinition);
+  void onCreateOfflineRegion(OfflineRegionDefinition offlineDefinition);
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
@@ -31,12 +31,9 @@ final class Transform implements MapView.OnMapChangedListener {
   private final MarkerViewManager markerViewManager;
   private final Handler handler = new Handler();
 
-  @Nullable
   private CameraPosition cameraPosition;
-  @Nullable
   private MapboxMap.CancelableCallback cameraCancelableCallback;
 
-  @Nullable
   private MapboxMap.OnCameraChangeListener onCameraChangeListener;
 
   private CameraChangeDispatcher cameraChangeDispatcher;
@@ -61,7 +58,6 @@ final class Transform implements MapView.OnMapChangedListener {
   // Camera API
   //
 
-  @Nullable
   @UiThread
   public final CameraPosition getCameraPosition() {
     if (cameraPosition == null) {
@@ -96,8 +92,7 @@ final class Transform implements MapView.OnMapChangedListener {
   }
 
   @UiThread
-  final void moveCamera(@NonNull MapboxMap mapboxMap, @NonNull CameraUpdate update,
-                        @Nullable final MapboxMap.CancelableCallback callback) {
+  final void moveCamera(MapboxMap mapboxMap, CameraUpdate update, final MapboxMap.CancelableCallback callback) {
     CameraPosition cameraPosition = update.getCameraPosition(mapboxMap);
     if (isValidCameraPosition(cameraPosition)) {
       cancelTransitions();
@@ -117,9 +112,8 @@ final class Transform implements MapView.OnMapChangedListener {
   }
 
   @UiThread
-  final void easeCamera(@NonNull MapboxMap mapboxMap, @NonNull CameraUpdate update, int durationMs,
-                        boolean easingInterpolator, @Nullable final MapboxMap.CancelableCallback callback,
-                        boolean isDismissable) {
+  final void easeCamera(MapboxMap mapboxMap, CameraUpdate update, int durationMs, boolean easingInterpolator,
+                        final MapboxMap.CancelableCallback callback, boolean isDismissable) {
     CameraPosition cameraPosition = update.getCameraPosition(mapboxMap);
     if (isValidCameraPosition(cameraPosition)) {
       cancelTransitions();
@@ -135,8 +129,8 @@ final class Transform implements MapView.OnMapChangedListener {
   }
 
   @UiThread
-  final void animateCamera(@NonNull MapboxMap mapboxMap, @NonNull CameraUpdate update, int durationMs,
-                           @Nullable final MapboxMap.CancelableCallback callback) {
+  final void animateCamera(MapboxMap mapboxMap, CameraUpdate update, int durationMs,
+                           final MapboxMap.CancelableCallback callback) {
     CameraPosition cameraPosition = update.getCameraPosition(mapboxMap);
     if (isValidCameraPosition(cameraPosition)) {
       cancelTransitions();

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
@@ -30,21 +30,15 @@ import com.mapbox.mapboxsdk.utils.ColorUtils;
  */
 public final class UiSettings {
 
-  @NonNull
   private final FocalPointChangeListener focalPointChangeListener;
-  @NonNull
   private final Projection projection;
-  @NonNull
   private final CompassView compassView;
   private final int[] compassMargins = new int[4];
 
-  @NonNull
   private final ImageView attributionsView;
   private final int[] attributionsMargins = new int[4];
-  @Nullable
   private AttributionDialogManager attributionDialogManager;
 
-  @NonNull
   private final View logoView;
   private final int[] logoMargins = new int[4];
 
@@ -71,7 +65,6 @@ public final class UiSettings {
 
   private boolean deselectMarkersOnTap = true;
 
-  @Nullable
   private PointF userProvidedFocalPoint;
 
   UiSettings(@NonNull Projection projection, @NonNull FocalPointChangeListener listener,
@@ -94,7 +87,7 @@ public final class UiSettings {
     initialiseZoomControl(context);
   }
 
-  void onSaveInstanceState(@NonNull Bundle outState) {
+  void onSaveInstanceState(Bundle outState) {
     saveGestures(outState);
     saveCompass(outState);
     saveLogo(outState);
@@ -151,7 +144,7 @@ public final class UiSettings {
       savedInstanceState.getBoolean(MapboxConstants.STATE_INCREASE_SCALE_THRESHOLD));
   }
 
-  private void initialiseCompass(MapboxMapOptions options, @NonNull Resources resources) {
+  private void initialiseCompass(MapboxMapOptions options, Resources resources) {
     setCompassEnabled(options.getCompassEnabled());
     setCompassGravity(options.getCompassGravity());
     int[] compassMargins = options.getCompassMargins();
@@ -192,13 +185,13 @@ public final class UiSettings {
       compassView.getContext(), savedInstanceState.getByteArray(MapboxConstants.STATE_COMPASS_IMAGE_BITMAP)));
   }
 
-  private void initialiseLogo(MapboxMapOptions options, @NonNull Resources resources) {
+  private void initialiseLogo(MapboxMapOptions options, Resources resources) {
     setLogoEnabled(options.getLogoEnabled());
     setLogoGravity(options.getLogoGravity());
     setLogoMargins(resources, options.getLogoMargins());
   }
 
-  private void setLogoMargins(@NonNull Resources resources, @Nullable int[] logoMargins) {
+  private void setLogoMargins(Resources resources, int[] logoMargins) {
     if (logoMargins != null) {
       setLogoMargins(logoMargins[0], logoMargins[1], logoMargins[2], logoMargins[3]);
     } else {
@@ -226,7 +219,7 @@ public final class UiSettings {
       savedInstanceState.getInt(MapboxConstants.STATE_LOGO_MARGIN_BOTTOM));
   }
 
-  private void initialiseAttribution(@NonNull Context context, MapboxMapOptions options) {
+  private void initialiseAttribution(Context context, MapboxMapOptions options) {
     setAttributionEnabled(options.getAttributionEnabled());
     setAttributionGravity(options.getAttributionGravity());
     setAttributionMargins(context, options.getAttributionMargins());
@@ -235,7 +228,7 @@ public final class UiSettings {
       ? attributionTintColor : ColorUtils.getPrimaryColor(context));
   }
 
-  private void setAttributionMargins(@NonNull Context context, @Nullable int[] attributionMargins) {
+  private void setAttributionMargins(Context context, int[] attributionMargins) {
     if (attributionMargins != null) {
       setAttributionMargins(attributionMargins[0], attributionMargins[1],
         attributionMargins[2], attributionMargins[3]);
@@ -551,7 +544,7 @@ public final class UiSettings {
    *
    * @param attributionDialogManager the manager class used for showing attribution
    */
-  public void setAttributionDialogManager(@Nullable AttributionDialogManager attributionDialogManager) {
+  public void setAttributionDialogManager(@NonNull AttributionDialogManager attributionDialogManager) {
     this.attributionDialogManager = attributionDialogManager;
   }
 
@@ -560,7 +553,7 @@ public final class UiSettings {
    *
    * @return the active manager class used for showing attribution
    */
-  @Nullable
+  @NonNull
   public AttributionDialogManager getAttributionDialogManager() {
     return attributionDialogManager;
   }
@@ -982,7 +975,6 @@ public final class UiSettings {
    *
    * @return The focal point
    */
-  @Nullable
   public PointF getFocalPoint() {
     return userProvidedFocalPoint;
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.support.annotation.CallSuper;
 import android.support.annotation.Keep;
 
-import android.support.annotation.NonNull;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.storage.FileSource;
 
@@ -26,7 +25,7 @@ public abstract class MapRenderer implements MapRendererScheduler {
 
   private MapboxMap.OnFpsChangedListener onFpsChangedListener;
 
-  public MapRenderer(@NonNull Context context, String localIdeographFontFamily) {
+  public MapRenderer(Context context, String localIdeographFontFamily) {
     FileSource fileSource = FileSource.getInstance(context);
     float pixelRatio = context.getResources().getDisplayMetrics().density;
     String programCacheDir = FileSource.getInternalCachePath(context);
@@ -65,7 +64,7 @@ public abstract class MapRenderer implements MapRendererScheduler {
   }
 
   @CallSuper
-  protected void onSurfaceChanged(@NonNull GL10 gl, int width, int height) {
+  protected void onSurfaceChanged(GL10 gl, int width, int height) {
     gl.glViewport(0, 0, width, height);
     nativeOnSurfaceChanged(width, height);
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRendererScheduler.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRendererScheduler.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.maps.renderer;
 
 import android.support.annotation.Keep;
-import android.support.annotation.NonNull;
 
 /**
  * Can be used to schedule work on the map renderer
@@ -13,6 +12,6 @@ public interface MapRendererScheduler {
   void requestRender();
 
   @Keep
-  void queueEvent(@NonNull Runnable runnable);
+  void queueEvent(Runnable runnable);
 
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/egl/EGLConfigChooser.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/egl/EGLConfigChooser.java
@@ -67,7 +67,7 @@ public class EGLConfigChooser implements GLSurfaceView.EGLConfigChooser {
   }
 
   @Override
-  public EGLConfig chooseConfig(@NonNull EGL10 egl, EGLDisplay display) {
+  public EGLConfig chooseConfig(EGL10 egl, EGLDisplay display) {
     int[] configAttribs = getConfigAttributes();
 
     // Determine number of possible configurations
@@ -90,7 +90,6 @@ public class EGLConfigChooser implements GLSurfaceView.EGLConfigChooser {
     return config;
   }
 
-  @NonNull
   private int[] getNumberOfConfigurations(EGL10 egl, EGLDisplay display, int[] configAttributes) {
     int[] numConfigs = new int[1];
     if (!egl.eglChooseConfig(display, configAttributes, null, 0, numConfigs)) {
@@ -102,7 +101,6 @@ public class EGLConfigChooser implements GLSurfaceView.EGLConfigChooser {
     return numConfigs;
   }
 
-  @NonNull
   private EGLConfig[] getPossibleConfigurations(EGL10 egl, EGLDisplay display,
                                                 int[] configAttributes, int[] numConfigs) {
     EGLConfig[] configs = new EGLConfig[numConfigs[0]];
@@ -141,7 +139,7 @@ public class EGLConfigChooser implements GLSurfaceView.EGLConfigChooser {
     }
   }
 
-  private EGLConfig chooseBestMatchConfig(@NonNull EGL10 egl, EGLDisplay display, EGLConfig[] configs) {
+  private EGLConfig chooseBestMatchConfig(EGL10 egl, EGLDisplay display, EGLConfig[] configs) {
     class Config implements Comparable<Config> {
       private final BufferFormat bufferFormat;
       private final DepthStencilFormat depthStencilFormat;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
@@ -3,7 +3,6 @@ package com.mapbox.mapboxsdk.maps.renderer.glsurfaceview;
 import android.content.Context;
 import android.opengl.GLSurfaceView;
 
-import android.support.annotation.NonNull;
 import com.mapbox.mapboxsdk.maps.renderer.MapRenderer;
 import com.mapbox.mapboxsdk.maps.renderer.egl.EGLConfigChooser;
 
@@ -20,7 +19,6 @@ import static android.opengl.GLSurfaceView.RENDERMODE_WHEN_DIRTY;
  */
 public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceView.Renderer {
 
-  @NonNull
   private final GLSurfaceView glSurfaceView;
 
   public GLSurfaceViewMapRenderer(Context context,

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewRenderThread.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewRenderThread.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.maps.renderer.textureview;
 
 import android.graphics.SurfaceTexture;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
 import android.view.TextureView;
 import com.mapbox.mapboxsdk.log.Logger;
@@ -27,9 +26,7 @@ class TextureViewRenderThread extends Thread implements TextureView.SurfaceTextu
 
   private static final String TAG = "Mbgl-TextureViewRenderThread";
 
-  @NonNull
   private final TextureViewMapRenderer mapRenderer;
-  @NonNull
   private final EGLHolder eglHolder;
 
   // Lock used for synchronization
@@ -37,7 +34,6 @@ class TextureViewRenderThread extends Thread implements TextureView.SurfaceTextu
 
   // Guarded by lock
   private final ArrayList<Runnable> eventQueue = new ArrayList<>();
-  @Nullable
   private SurfaceTexture surface;
   private int width;
   private int height;
@@ -122,7 +118,7 @@ class TextureViewRenderThread extends Thread implements TextureView.SurfaceTextu
   /**
    * May be called from any thread
    */
-  void queueEvent(@NonNull Runnable runnable) {
+  void queueEvent(Runnable runnable) {
     if (runnable == null) {
       throw new IllegalArgumentException("runnable must not be null");
     }
@@ -332,7 +328,6 @@ class TextureViewRenderThread extends Thread implements TextureView.SurfaceTextu
     private boolean translucentSurface;
 
     private EGL10 egl;
-    @Nullable
     private EGLConfig eglConfig;
     private EGLDisplay eglDisplay = EGL10.EGL_NO_DISPLAY;
     private EGLContext eglContext = EGL10.EGL_NO_CONTEXT;
@@ -375,7 +370,6 @@ class TextureViewRenderThread extends Thread implements TextureView.SurfaceTextu
       }
     }
 
-    @NonNull
     GL10 createGL() {
       return (GL10) eglContext.getGL();
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/CompassView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/CompassView.java
@@ -3,7 +3,6 @@ package com.mapbox.mapboxsdk.maps.widgets;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.support.v4.view.ViewCompat;
 import android.support.v4.view.ViewPropertyAnimatorCompat;
 import android.support.v4.view.ViewPropertyAnimatorListenerAdapter;
@@ -31,22 +30,21 @@ public final class CompassView extends AppCompatImageView implements Runnable {
 
   private float rotation = 0.0f;
   private boolean fadeCompassViewFacingNorth = true;
-  @Nullable
   private ViewPropertyAnimatorCompat fadeAnimator;
   private MapboxMap.OnCompassAnimationListener compassAnimationListener;
   private boolean isAnimating = false;
 
-  public CompassView(@NonNull Context context) {
+  public CompassView(Context context) {
     super(context);
     initialize(context);
   }
 
-  public CompassView(@NonNull Context context, AttributeSet attrs) {
+  public CompassView(Context context, AttributeSet attrs) {
     super(context, attrs);
     initialize(context);
   }
 
-  public CompassView(@NonNull Context context, AttributeSet attrs, int defStyleAttr) {
+  public CompassView(Context context, AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
     initialize(context);
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/http/HttpRequestImpl.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/http/HttpRequestImpl.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.module.http;
 
 import android.os.Build;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
 import com.mapbox.mapboxsdk.BuildConfig;
@@ -47,8 +46,8 @@ public class HttpRequestImpl implements HttpRequest {
   private Call call;
 
   @Override
-  public void executeRequest(HttpResponder httpRequest, long nativePtr, @NonNull String resourceUrl,
-                             @NonNull String etag, @NonNull String modified) {
+  public void executeRequest(HttpResponder httpRequest, long nativePtr, String resourceUrl,
+                             String etag, String modified) {
     OkHttpCallback callback = new OkHttpCallback(httpRequest);
     try {
       HttpUrl httpUrl = HttpUrl.parse(resourceUrl);
@@ -148,7 +147,7 @@ public class HttpRequestImpl implements HttpRequest {
         body);
     }
 
-    private void handleFailure(@Nullable Call call, Exception e) {
+    private void handleFailure(Call call, Exception e) {
       String errorMessage = e.getMessage() != null ? e.getMessage() : "Error processing the request";
       int type = getFailureType(e);
 
@@ -170,7 +169,6 @@ public class HttpRequestImpl implements HttpRequest {
     }
   }
 
-  @NonNull
   private static Dispatcher getDispatcher() {
     Dispatcher dispatcher = new Dispatcher();
     // Matches core limit set on

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/http/HttpRequestUtil.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/http/HttpRequestUtil.java
@@ -1,6 +1,5 @@
 package com.mapbox.mapboxsdk.module.http;
 
-import android.support.annotation.NonNull;
 import okhttp3.OkHttpClient;
 import okio.Buffer;
 
@@ -45,7 +44,6 @@ public class HttpRequestUtil {
     HttpRequestImpl.setOkHttpClient(client);
   }
 
-  @NonNull
   static String toHumanReadableAscii(String s) {
     for (int i = 0, length = s.length(), c; i < length; i += Character.charCount(c)) {
       c = s.codePointAt(i);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/telemetry/TelemetryImpl.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/telemetry/TelemetryImpl.java
@@ -1,8 +1,6 @@
 package com.mapbox.mapboxsdk.module.telemetry;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import com.mapbox.android.telemetry.AppUserTurnstile;
 import com.mapbox.android.telemetry.Event;
 import com.mapbox.android.telemetry.MapEventFactory;
@@ -25,7 +23,6 @@ public class TelemetryImpl implements TelemetryDefinition {
 
   private static final String TAG = "Mbgl-TelemetryImpl";
   private static TelemetryImpl instance;
-  @Nullable
   private MapboxTelemetry telemetry;
 
   /**
@@ -157,7 +154,7 @@ public class TelemetryImpl implements TelemetryDefinition {
    * @deprecated use {@link #setSessionIdRotationInterval(int)} instead
    */
   @Deprecated
-  public static boolean updateSessionIdRotationInterval(@NonNull SessionInterval interval) {
+  public static boolean updateSessionIdRotationInterval(SessionInterval interval) {
     try {
       Field field = interval.getClass().getDeclaredField("interval");
       field.setAccessible(true);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/net/ConnectivityReceiver.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/net/ConnectivityReceiver.java
@@ -32,7 +32,7 @@ public class ConnectivityReceiver extends BroadcastReceiver {
    * @param context the context to extract the application context from
    * @return single instance of ConnectivityReceiver
    */
-  public static synchronized ConnectivityReceiver instance(@NonNull Context context) {
+  public static synchronized ConnectivityReceiver instance(Context context) {
     if (INSTANCE == null) {
       // Register new instance
       INSTANCE = new ConnectivityReceiver(context.getApplicationContext());
@@ -43,7 +43,6 @@ public class ConnectivityReceiver extends BroadcastReceiver {
     return INSTANCE;
   }
 
-  @NonNull
   private List<ConnectivityListener> listeners = new CopyOnWriteArrayList<>();
   private Context context;
   private int activationCounter;
@@ -84,7 +83,7 @@ public class ConnectivityReceiver extends BroadcastReceiver {
    * {@inheritDoc}
    */
   @Override
-  public void onReceive(@NonNull Context context, Intent intent) {
+  public void onReceive(Context context, Intent intent) {
     boolean connected = isConnected(context);
     Logger.v(TAG, String.format("Connected: %s", connected));
 
@@ -118,7 +117,7 @@ public class ConnectivityReceiver extends BroadcastReceiver {
    * @param context current Context
    * @return true if connected
    */
-  public boolean isConnected(@NonNull Context context) {
+  public boolean isConnected(Context context) {
     Boolean connected = Mapbox.isConnected();
     if (connected != null) {
       // Connectivity state overridden by app

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineGeometryRegionDefinition.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineGeometryRegionDefinition.java
@@ -4,8 +4,6 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.Keep;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.Geometry;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
@@ -26,7 +24,6 @@ public class OfflineGeometryRegionDefinition implements OfflineRegionDefinition,
 
   @Keep
   private String styleURL;
-  @Nullable
   @Keep
   private Geometry geometry;
   @Keep
@@ -77,7 +74,6 @@ public class OfflineGeometryRegionDefinition implements OfflineRegionDefinition,
     return styleURL;
   }
 
-  @Nullable
   public Geometry getGeometry() {
     return geometry;
   }
@@ -87,7 +83,6 @@ public class OfflineGeometryRegionDefinition implements OfflineRegionDefinition,
    * to retain backwards compatibility
    * @return the {@link LatLngBounds} or null
    */
-  @Nullable
   @Override
   public LatLngBounds getBounds() {
     if (geometry == null) {
@@ -120,7 +115,7 @@ public class OfflineGeometryRegionDefinition implements OfflineRegionDefinition,
   }
 
   @Override
-  public void writeToParcel(@NonNull Parcel dest, int flags) {
+  public void writeToParcel(Parcel dest, int flags) {
     dest.writeString(styleURL);
     dest.writeString(Feature.fromGeometry(geometry).toJson());
     dest.writeDouble(minZoom);
@@ -129,7 +124,7 @@ public class OfflineGeometryRegionDefinition implements OfflineRegionDefinition,
   }
 
   public static final Creator CREATOR = new Creator() {
-    public OfflineGeometryRegionDefinition createFromParcel(@NonNull Parcel in) {
+    public OfflineGeometryRegionDefinition createFromParcel(Parcel in) {
       return new OfflineGeometryRegionDefinition(in);
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
@@ -161,7 +161,7 @@ public class OfflineManager {
    * @param context the context used to host the offline manager
    * @return the single instance of offline manager
    */
-  public static synchronized OfflineManager getInstance(@NonNull Context context) {
+  public static synchronized OfflineManager getInstance(Context context) {
     if (instance == null) {
       instance = new OfflineManager(context);
     }
@@ -267,9 +267,7 @@ public class OfflineManager {
   }
 
   private static final class CopyTempDatabaseFileTask extends AsyncTask<Object, Void, Object> {
-    @NonNull
     private final WeakReference<OfflineManager> offlineManagerWeakReference;
-    @NonNull
     private final WeakReference<MergeOfflineRegionsCallback> callbackWeakReference;
 
     CopyTempDatabaseFileTask(OfflineManager offlineManager, MergeOfflineRegionsCallback callback) {
@@ -307,7 +305,7 @@ public class OfflineManager {
     }
   }
 
-  private static void copyTempDatabaseFile(@NonNull File sourceFile, File destFile) throws IOException {
+  private static void copyTempDatabaseFile(File sourceFile, File destFile) throws IOException {
     if (!destFile.exists() && !destFile.createNewFile()) {
       throw new IOException("Unable to copy database file for merge.");
     }
@@ -382,7 +380,7 @@ public class OfflineManager {
    * @param callback   the callback to be invoked
    */
   public void createOfflineRegion(@NonNull OfflineRegionDefinition definition, @NonNull byte[] metadata,
-                                  @NonNull final CreateOfflineRegionCallback callback) {
+                                  final CreateOfflineRegionCallback callback) {
     if (!isValidOfflineRegionDefinition(definition)) {
       callback.onError(
         String.format(context.getString(R.string.mapbox_offline_error_region_definition_invalid),

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineTilePyramidRegionDefinition.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineTilePyramidRegionDefinition.java
@@ -4,7 +4,6 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.Keep;
 
-import android.support.annotation.NonNull;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
 
@@ -102,7 +101,7 @@ public class OfflineTilePyramidRegionDefinition implements OfflineRegionDefiniti
   }
 
   @Override
-  public void writeToParcel(@NonNull Parcel dest, int flags) {
+  public void writeToParcel(Parcel dest, int flags) {
     dest.writeString(styleURL);
     dest.writeDouble(bounds.getLatNorth());
     dest.writeDouble(bounds.getLonEast());
@@ -114,7 +113,7 @@ public class OfflineTilePyramidRegionDefinition implements OfflineRegionDefiniti
   }
 
   public static final Parcelable.Creator CREATOR = new Parcelable.Creator() {
-    public OfflineTilePyramidRegionDefinition createFromParcel(@NonNull Parcel in) {
+    public OfflineTilePyramidRegionDefinition createFromParcel(Parcel in) {
       return new OfflineTilePyramidRegionDefinition(in);
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshot.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshot.java
@@ -4,7 +4,6 @@ import android.graphics.Bitmap;
 import android.graphics.PointF;
 import android.support.annotation.Keep;
 
-import android.support.annotation.NonNull;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
 /**
@@ -44,7 +43,6 @@ public class MapSnapshot {
    * @param latLng the geographical coordinates
    * @return the point on the image
    */
-  @NonNull
   @Keep
   public native PointF pixelForLatLng(LatLng latLng);
 
@@ -54,7 +52,6 @@ public class MapSnapshot {
    * @param pointF the point in pixels
    * @return the geographical coordinates
    */
-  @NonNull
   @Keep
   public native LatLng latLngForPixel(PointF pointF);
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
@@ -50,7 +50,7 @@ public class MapSnapshotter {
      *
      * @param snapshot the snapshot
      */
-    void onSnapshotReady(@NonNull MapSnapshot snapshot);
+    void onSnapshotReady(MapSnapshot snapshot);
 
   }
 
@@ -68,7 +68,7 @@ public class MapSnapshotter {
      *
      * @param error the error message
      */
-    void onError(@NonNull String error);
+    void onError(String error);
   }
 
   private static final int LOGO_MARGIN_DP = 4;
@@ -78,9 +78,7 @@ public class MapSnapshotter {
   private long nativePtr = 0;
 
   private final Context context;
-  @Nullable
   private SnapshotReadyCallback callback;
-  @Nullable
   private ErrorHandler errorHandler;
 
   /**
@@ -112,7 +110,6 @@ public class MapSnapshotter {
      * @param url The style URL to use
      * @return the mutated {@link Options}
      */
-    @NonNull
     public Options withStyle(String url) {
       this.styleUrl = url;
       return this;
@@ -122,7 +119,6 @@ public class MapSnapshotter {
      * @param styleJson The style json to use
      * @return the mutated {@link Options}
      */
-    @NonNull
     public Options withStyleJson(String styleJson) {
       this.styleJson = styleJson;
       return this;
@@ -133,7 +129,6 @@ public class MapSnapshotter {
      *               This is applied after the camera position
      * @return the mutated {@link Options}
      */
-    @NonNull
     public Options withRegion(LatLngBounds region) {
       this.region = region;
       return this;
@@ -143,7 +138,6 @@ public class MapSnapshotter {
      * @param pixelRatio the pixel ratio to use (default: 1)
      * @return the mutated {@link Options}
      */
-    @NonNull
     public Options withPixelRatio(float pixelRatio) {
       this.pixelRatio = pixelRatio;
       return this;
@@ -155,7 +149,6 @@ public class MapSnapshotter {
      *                       by region if set in conjunction.
      * @return the mutated {@link Options}
      */
-    @NonNull
     public Options withCameraPosition(CameraPosition cameraPosition) {
       this.cameraPosition = cameraPosition;
       return this;
@@ -165,7 +158,6 @@ public class MapSnapshotter {
      * @param showLogo The flag indicating to show the Mapbox logo.
      * @return the mutated {@link Options}
      */
-    @NonNull
     public Options withLogo(boolean showLogo) {
       this.showLogo = showLogo;
       return this;
@@ -317,24 +309,21 @@ public class MapSnapshotter {
    *
    * @param mapSnapshot the map snapshot to draw the overlay on
    */
-  protected void addOverlay(@NonNull MapSnapshot mapSnapshot) {
+  protected void addOverlay(MapSnapshot mapSnapshot) {
     Bitmap snapshot = mapSnapshot.getBitmap();
     Canvas canvas = new Canvas(snapshot);
     int margin = (int) context.getResources().getDisplayMetrics().density * LOGO_MARGIN_DP;
     drawOverlay(mapSnapshot, snapshot, canvas, margin);
   }
 
-  private void drawOverlay(@NonNull MapSnapshot mapSnapshot, @NonNull Bitmap snapshot,
-                           @NonNull Canvas canvas, int margin) {
+  private void drawOverlay(MapSnapshot mapSnapshot, Bitmap snapshot, Canvas canvas, int margin) {
     AttributionMeasure measure = getAttributionMeasure(mapSnapshot, snapshot, margin);
     AttributionLayout layout = measure.measure();
     drawLogo(mapSnapshot, canvas, margin, layout);
     drawAttribution(mapSnapshot, canvas, measure, layout);
   }
 
-  @NonNull
-  private AttributionMeasure getAttributionMeasure(@NonNull MapSnapshot mapSnapshot, @NonNull Bitmap snapshot,
-                                                   int margin) {
+  private AttributionMeasure getAttributionMeasure(MapSnapshot mapSnapshot, Bitmap snapshot, int margin) {
     Logo logo = createScaledLogo(snapshot);
     TextView longText = createTextView(mapSnapshot, false, logo.getScale());
     TextView shortText = createTextView(mapSnapshot, true, logo.getScale());
@@ -349,22 +338,21 @@ public class MapSnapshotter {
       .build();
   }
 
-  private void drawLogo(MapSnapshot mapSnapshot, @NonNull Canvas canvas, int margin,
-                        @NonNull AttributionLayout layout) {
+  private void drawLogo(MapSnapshot mapSnapshot, Canvas canvas, int margin, AttributionLayout layout) {
     if (mapSnapshot.isShowLogo()) {
       drawLogo(mapSnapshot.getBitmap(), canvas, margin, layout);
     }
   }
 
-  private void drawLogo(@NonNull Bitmap snapshot, @NonNull Canvas canvas, int margin, AttributionLayout placement) {
+  private void drawLogo(Bitmap snapshot, Canvas canvas, int margin, AttributionLayout placement) {
     Bitmap selectedLogo = placement.getLogo();
     if (selectedLogo != null) {
       canvas.drawBitmap(selectedLogo, margin, snapshot.getHeight() - selectedLogo.getHeight() - margin, null);
     }
   }
 
-  private void drawAttribution(@NonNull MapSnapshot mapSnapshot, @NonNull Canvas canvas,
-                               @NonNull AttributionMeasure measure, @NonNull AttributionLayout layout) {
+  private void drawAttribution(MapSnapshot mapSnapshot, Canvas canvas,
+                               AttributionMeasure measure, AttributionLayout layout) {
     // draw attribution
     PointF anchorPoint = layout.getAnchorPoint();
     if (anchorPoint != null) {
@@ -385,8 +373,7 @@ public class MapSnapshotter {
     canvas.restore();
   }
 
-  @NonNull
-  private TextView createTextView(@NonNull MapSnapshot mapSnapshot, boolean shortText, float scale) {
+  private TextView createTextView(MapSnapshot mapSnapshot, boolean shortText, float scale) {
     int textColor = ResourcesCompat.getColor(context.getResources(), R.color.mapbox_gray_dark, context.getTheme());
     int widthMeasureSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
     int heightMeasureSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
@@ -412,7 +399,6 @@ public class MapSnapshotter {
    * @param shortText   indicates if the short variant of the string should be parsed
    * @return the parsed attribution string
    */
-  @NonNull
   private String createAttributionString(MapSnapshot mapSnapshot, boolean shortText) {
     AttributionParser attributionParser = new AttributionParser.Options()
       .withAttributionData(mapSnapshot.getAttributions())
@@ -471,7 +457,7 @@ public class MapSnapshotter {
    * @param snapshot the generated snapshot
    */
   @Keep
-  protected void onSnapshotReady(@NonNull final MapSnapshot snapshot) {
+  protected void onSnapshotReady(final MapSnapshot snapshot) {
     new Handler().post(new Runnable() {
       @Override
       public void run() {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
@@ -8,7 +8,6 @@ import android.os.AsyncTask;
 import android.os.Environment;
 import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
 
 import com.mapbox.mapboxsdk.MapStrictMode;
@@ -30,7 +29,6 @@ public class FileSource {
   private static final String TAG = "Mbgl-FileSource";
   private static final Lock resourcesCachePathLoaderLock = new ReentrantLock();
   private static final Lock internalCachePathLoaderLock = new ReentrantLock();
-  @Nullable
   private static String resourcesCachePath;
   private static String internalCachePath;
 
@@ -63,7 +61,7 @@ public class FileSource {
    * @return the single instance of FileSource
    */
   @UiThread
-  public static synchronized FileSource getInstance(@NonNull Context context) {
+  public static synchronized FileSource getInstance(Context context) {
     if (INSTANCE == null) {
       INSTANCE = new FileSource(getResourcesCachePath(context), context.getResources().getAssets());
     }
@@ -78,9 +76,8 @@ public class FileSource {
    * @return the files directory path
    * @deprecated Use {@link #getResourcesCachePath(Context)} instead.
    */
-  @Nullable
   @Deprecated
-  public static String getCachePath(@NonNull Context context) {
+  public static String getCachePath(Context context) {
     // Default value
     boolean isExternalStorageConfiguration = MapboxConstants.DEFAULT_SET_STORAGE_EXTERNAL;
 
@@ -165,7 +162,6 @@ public class FileSource {
       unlockPathLoaders();
     }
 
-    @NonNull
     @Override
     protected String[] doInBackground(Context... contexts) {
       return new String[] {
@@ -188,8 +184,7 @@ public class FileSource {
    * @param context the context to derive the files directory path from
    * @return the files directory path
    */
-  @Nullable
-  public static String getResourcesCachePath(@NonNull Context context) {
+  public static String getResourcesCachePath(Context context) {
     resourcesCachePathLoaderLock.lock();
     try {
       if (resourcesCachePath == null) {
@@ -207,7 +202,7 @@ public class FileSource {
    * @param context the context to derive the internal cache path from
    * @return the internal cache path
    */
-  public static String getInternalCachePath(@NonNull Context context) {
+  public static String getInternalCachePath(Context context) {
     internalCachePathLoaderLock.lock();
     try {
       if (internalCachePath == null) {
@@ -248,7 +243,6 @@ public class FileSource {
   @Keep
   public native void setAccessToken(@NonNull String accessToken);
 
-  @NonNull
   @Keep
   public native String getAccessToken();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
@@ -90,9 +90,7 @@ import java.util.Map;
  */
 public class Expression {
 
-  @Nullable
   private final String operator;
-  @Nullable
   private final Expression[] arguments;
 
   /**
@@ -437,7 +435,7 @@ public class Expression {
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-==">Style specification</a>
    */
-  public static Expression eq(@NonNull Expression compareOne, boolean compareTwo) {
+  public static Expression eq(Expression compareOne, boolean compareTwo) {
     return eq(compareOne, literal(compareTwo));
   }
 
@@ -2236,7 +2234,7 @@ public class Expression {
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-ln">Style specification</a>
    */
-  public static Expression ln(@NonNull Number number) {
+  public static Expression ln(Number number) {
     return ln(literal(number));
   }
 
@@ -2688,7 +2686,7 @@ public class Expression {
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-round">Style specification</a>
    */
-  public static Expression round(@NonNull Number number) {
+  public static Expression round(Number number) {
     return round(literal(number));
   }
 
@@ -2732,7 +2730,7 @@ public class Expression {
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-abs">Style specification</a>
    */
-  public static Expression abs(@NonNull Number number) {
+  public static Expression abs(Number number) {
     return abs(literal(number));
   }
 
@@ -2776,7 +2774,7 @@ public class Expression {
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-abs">Style specification</a>
    */
-  public static Expression ceil(@NonNull Number number) {
+  public static Expression ceil(Number number) {
     return ceil(literal(number));
   }
 
@@ -2820,7 +2818,7 @@ public class Expression {
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-abs">Style specification</a>
    */
-  public static Expression floor(@NonNull Number number) {
+  public static Expression floor(Number number) {
     return floor(literal(number));
   }
 
@@ -2906,7 +2904,7 @@ public class Expression {
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-is-supported-script">Style specification</a>
    */
-  public static Expression isSupportedScript(@NonNull String string) {
+  public static Expression isSupportedScript(String string) {
     return new Expression("is-supported-script", literal(string));
   }
 
@@ -3497,7 +3495,7 @@ public class Expression {
    * @return expression
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-step">Style specification</a>
    */
-  public static Expression step(@NonNull Expression input, @NonNull Expression defaultOutput, @NonNull Expression... stops) {
+  public static Expression step(@NonNull Expression input, @NonNull Expression defaultOutput, Expression... stops) {
     return new Expression("step", join(new Expression[] {input, defaultOutput}, stops));
   }
 
@@ -3724,7 +3722,7 @@ public class Expression {
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-interpolate">Style specification</a>
    */
   public static Expression interpolate(@NonNull Interpolator interpolation,
-                                       @NonNull Expression number, @NonNull Expression... stops) {
+                                       @NonNull Expression number, Expression... stops) {
     return new Expression("interpolate", join(new Expression[] {interpolation, number}, stops));
   }
 
@@ -3931,7 +3929,6 @@ public class Expression {
    * @param right the right part of an expression
    * @return the joined expression
    */
-  @NonNull
   private static Expression[] join(Expression[] left, Expression[] right) {
     Expression[] output = new Expression[left.length + right.length];
     System.arraycopy(left, 0, output, 0, left.length);
@@ -4024,7 +4021,7 @@ public class Expression {
    * @return true if equal, false if not
    */
   @Override
-  public boolean equals(@Nullable Object o) {
+  public boolean equals(Object o) {
     super.equals(o);
     if (this == o) {
       return true;
@@ -4124,7 +4121,7 @@ public class Expression {
      * @return true if equal, false if not
      */
     @Override
-    public boolean equals(@Nullable Object o) {
+    public boolean equals(Object o) {
       if (this == o) {
         return true;
       }
@@ -4152,7 +4149,6 @@ public class Expression {
       return result;
     }
 
-    @NonNull
     private static String unwrapStringLiteral(String value) {
       if (value.length() > 1 &&
         value.charAt(0) == '\"' && value.charAt(value.length() - 1) == '\"') {
@@ -4205,7 +4201,6 @@ public class Expression {
      * @param stops the stops to convert
      * @return the converted stops as an expression array
      */
-    @NonNull
     static Expression[] toExpressionArray(Stop... stops) {
       Expression[] expressions = new Expression[stops.length * 2];
       Stop stop;
@@ -4337,7 +4332,6 @@ public class Expression {
      *
      * @return the string representation of the expression array
      */
-    @NonNull
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder("[\"literal\"], [");
@@ -4369,7 +4363,6 @@ public class Expression {
       this.map = map;
     }
 
-    @NonNull
     @Override
     public Object toValue() {
       Map<String, Object> unwrappedMap = new HashMap<>();
@@ -4385,7 +4378,6 @@ public class Expression {
       return unwrappedMap;
     }
 
-    @NonNull
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
@@ -4405,7 +4397,7 @@ public class Expression {
     }
 
     @Override
-    public boolean equals(@Nullable Object o) {
+    public boolean equals(Object o) {
       if (this == o) {
         return true;
       }
@@ -4440,7 +4432,6 @@ public class Expression {
    * @param object the object to convert to an object array
    * @return the converted object array
    */
-  @NonNull
   static Object[] toObjectArray(Object object) {
     // object is a primitive array
     int len = java.lang.reflect.Array.getLength(object);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/BackgroundLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/BackgroundLayer.java
@@ -51,7 +51,6 @@ public class BackgroundLayer extends Layer {
    * @param properties the var-args properties
    * @return This
    */
-  @NonNull
   public BackgroundLayer withProperties(@NonNull PropertyValue<?>... properties) {
     setProperties(properties);
     return this;
@@ -64,7 +63,6 @@ public class BackgroundLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getBackgroundColor() {
     checkThread();
@@ -93,7 +91,6 @@ public class BackgroundLayer extends Layer {
    *
    * @return transition options for String
    */
-  @NonNull
   public TransitionOptions getBackgroundColorTransition() {
     checkThread();
     return nativeGetBackgroundColorTransition();
@@ -104,7 +101,7 @@ public class BackgroundLayer extends Layer {
    *
    * @param options transition options for String
    */
-  public void setBackgroundColorTransition(@NonNull TransitionOptions options) {
+  public void setBackgroundColorTransition(TransitionOptions options) {
     checkThread();
     nativeSetBackgroundColorTransition(options.getDuration(), options.getDelay());
   }
@@ -114,7 +111,6 @@ public class BackgroundLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getBackgroundPattern() {
     checkThread();
@@ -126,7 +122,6 @@ public class BackgroundLayer extends Layer {
    *
    * @return transition options for String
    */
-  @NonNull
   public TransitionOptions getBackgroundPatternTransition() {
     checkThread();
     return nativeGetBackgroundPatternTransition();
@@ -137,7 +132,7 @@ public class BackgroundLayer extends Layer {
    *
    * @param options transition options for String
    */
-  public void setBackgroundPatternTransition(@NonNull TransitionOptions options) {
+  public void setBackgroundPatternTransition(TransitionOptions options) {
     checkThread();
     nativeSetBackgroundPatternTransition(options.getDuration(), options.getDelay());
   }
@@ -147,7 +142,6 @@ public class BackgroundLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getBackgroundOpacity() {
     checkThread();
@@ -159,7 +153,6 @@ public class BackgroundLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getBackgroundOpacityTransition() {
     checkThread();
     return nativeGetBackgroundOpacityTransition();
@@ -170,38 +163,32 @@ public class BackgroundLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setBackgroundOpacityTransition(@NonNull TransitionOptions options) {
+  public void setBackgroundOpacityTransition(TransitionOptions options) {
     checkThread();
     nativeSetBackgroundOpacityTransition(options.getDuration(), options.getDelay());
   }
 
-  @NonNull
   @Keep
   private native Object nativeGetBackgroundColor();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetBackgroundColorTransition();
 
   @Keep
   private native void nativeSetBackgroundColorTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetBackgroundPattern();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetBackgroundPatternTransition();
 
   @Keep
   private native void nativeSetBackgroundPatternTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetBackgroundOpacity();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetBackgroundOpacityTransition();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/CircleLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/CircleLayer.java
@@ -62,7 +62,6 @@ public class CircleLayer extends Layer {
    * @param sourceLayer the source layer to set
    * @return This
    */
-  @NonNull
   public CircleLayer withSourceLayer(String sourceLayer) {
     setSourceLayer(sourceLayer);
     return this;
@@ -73,7 +72,6 @@ public class CircleLayer extends Layer {
    *
    * @return id of the source
    */
-  @NonNull
   public String getSourceId() {
     checkThread();
     return nativeGetSourceId();
@@ -84,7 +82,6 @@ public class CircleLayer extends Layer {
    *
    * @return sourceLayer the source layer to get
    */
-  @NonNull
   public String getSourceLayer() {
     checkThread();
     return nativeGetSourceLayer();
@@ -95,7 +92,7 @@ public class CircleLayer extends Layer {
    *
    * @param filter the expression filter to set
    */
-  public void setFilter(@NonNull Expression filter) {
+  public void setFilter(Expression filter) {
     checkThread();
     nativeSetFilter(filter.toArray());
   }
@@ -106,8 +103,7 @@ public class CircleLayer extends Layer {
    * @param filter the expression filter to set
    * @return This
    */
-  @NonNull
-  public CircleLayer withFilter(@NonNull Expression filter) {
+  public CircleLayer withFilter(Expression filter) {
     setFilter(filter);
     return this;
   }
@@ -134,7 +130,6 @@ public class CircleLayer extends Layer {
    * @param properties the var-args properties
    * @return This
    */
-  @NonNull
   public CircleLayer withProperties(@NonNull PropertyValue<?>... properties) {
     setProperties(properties);
     return this;
@@ -147,7 +142,6 @@ public class CircleLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getCircleRadius() {
     checkThread();
@@ -159,7 +153,6 @@ public class CircleLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getCircleRadiusTransition() {
     checkThread();
     return nativeGetCircleRadiusTransition();
@@ -170,7 +163,7 @@ public class CircleLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setCircleRadiusTransition(@NonNull TransitionOptions options) {
+  public void setCircleRadiusTransition(TransitionOptions options) {
     checkThread();
     nativeSetCircleRadiusTransition(options.getDuration(), options.getDelay());
   }
@@ -180,7 +173,6 @@ public class CircleLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getCircleColor() {
     checkThread();
@@ -209,7 +201,6 @@ public class CircleLayer extends Layer {
    *
    * @return transition options for String
    */
-  @NonNull
   public TransitionOptions getCircleColorTransition() {
     checkThread();
     return nativeGetCircleColorTransition();
@@ -220,7 +211,7 @@ public class CircleLayer extends Layer {
    *
    * @param options transition options for String
    */
-  public void setCircleColorTransition(@NonNull TransitionOptions options) {
+  public void setCircleColorTransition(TransitionOptions options) {
     checkThread();
     nativeSetCircleColorTransition(options.getDuration(), options.getDelay());
   }
@@ -230,7 +221,6 @@ public class CircleLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getCircleBlur() {
     checkThread();
@@ -242,7 +232,6 @@ public class CircleLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getCircleBlurTransition() {
     checkThread();
     return nativeGetCircleBlurTransition();
@@ -253,7 +242,7 @@ public class CircleLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setCircleBlurTransition(@NonNull TransitionOptions options) {
+  public void setCircleBlurTransition(TransitionOptions options) {
     checkThread();
     nativeSetCircleBlurTransition(options.getDuration(), options.getDelay());
   }
@@ -263,7 +252,6 @@ public class CircleLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getCircleOpacity() {
     checkThread();
@@ -275,7 +263,6 @@ public class CircleLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getCircleOpacityTransition() {
     checkThread();
     return nativeGetCircleOpacityTransition();
@@ -286,7 +273,7 @@ public class CircleLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setCircleOpacityTransition(@NonNull TransitionOptions options) {
+  public void setCircleOpacityTransition(TransitionOptions options) {
     checkThread();
     nativeSetCircleOpacityTransition(options.getDuration(), options.getDelay());
   }
@@ -296,7 +283,6 @@ public class CircleLayer extends Layer {
    *
    * @return property wrapper value around Float[]
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float[]> getCircleTranslate() {
     checkThread();
@@ -308,7 +294,6 @@ public class CircleLayer extends Layer {
    *
    * @return transition options for Float[]
    */
-  @NonNull
   public TransitionOptions getCircleTranslateTransition() {
     checkThread();
     return nativeGetCircleTranslateTransition();
@@ -319,7 +304,7 @@ public class CircleLayer extends Layer {
    *
    * @param options transition options for Float[]
    */
-  public void setCircleTranslateTransition(@NonNull TransitionOptions options) {
+  public void setCircleTranslateTransition(TransitionOptions options) {
     checkThread();
     nativeSetCircleTranslateTransition(options.getDuration(), options.getDelay());
   }
@@ -329,7 +314,6 @@ public class CircleLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getCircleTranslateAnchor() {
     checkThread();
@@ -341,7 +325,6 @@ public class CircleLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getCirclePitchScale() {
     checkThread();
@@ -353,7 +336,6 @@ public class CircleLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getCirclePitchAlignment() {
     checkThread();
@@ -365,7 +347,6 @@ public class CircleLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getCircleStrokeWidth() {
     checkThread();
@@ -377,7 +358,6 @@ public class CircleLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getCircleStrokeWidthTransition() {
     checkThread();
     return nativeGetCircleStrokeWidthTransition();
@@ -388,7 +368,7 @@ public class CircleLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setCircleStrokeWidthTransition(@NonNull TransitionOptions options) {
+  public void setCircleStrokeWidthTransition(TransitionOptions options) {
     checkThread();
     nativeSetCircleStrokeWidthTransition(options.getDuration(), options.getDelay());
   }
@@ -398,7 +378,6 @@ public class CircleLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getCircleStrokeColor() {
     checkThread();
@@ -427,7 +406,6 @@ public class CircleLayer extends Layer {
    *
    * @return transition options for String
    */
-  @NonNull
   public TransitionOptions getCircleStrokeColorTransition() {
     checkThread();
     return nativeGetCircleStrokeColorTransition();
@@ -438,7 +416,7 @@ public class CircleLayer extends Layer {
    *
    * @param options transition options for String
    */
-  public void setCircleStrokeColorTransition(@NonNull TransitionOptions options) {
+  public void setCircleStrokeColorTransition(TransitionOptions options) {
     checkThread();
     nativeSetCircleStrokeColorTransition(options.getDuration(), options.getDelay());
   }
@@ -448,7 +426,6 @@ public class CircleLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getCircleStrokeOpacity() {
     checkThread();
@@ -460,7 +437,6 @@ public class CircleLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getCircleStrokeOpacityTransition() {
     checkThread();
     return nativeGetCircleStrokeOpacityTransition();
@@ -471,105 +447,86 @@ public class CircleLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setCircleStrokeOpacityTransition(@NonNull TransitionOptions options) {
+  public void setCircleStrokeOpacityTransition(TransitionOptions options) {
     checkThread();
     nativeSetCircleStrokeOpacityTransition(options.getDuration(), options.getDelay());
   }
 
-  @NonNull
   @Keep
   private native Object nativeGetCircleRadius();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetCircleRadiusTransition();
 
   @Keep
   private native void nativeSetCircleRadiusTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetCircleColor();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetCircleColorTransition();
 
   @Keep
   private native void nativeSetCircleColorTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetCircleBlur();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetCircleBlurTransition();
 
   @Keep
   private native void nativeSetCircleBlurTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetCircleOpacity();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetCircleOpacityTransition();
 
   @Keep
   private native void nativeSetCircleOpacityTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetCircleTranslate();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetCircleTranslateTransition();
 
   @Keep
   private native void nativeSetCircleTranslateTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetCircleTranslateAnchor();
 
-  @NonNull
   @Keep
   private native Object nativeGetCirclePitchScale();
 
-  @NonNull
   @Keep
   private native Object nativeGetCirclePitchAlignment();
 
-  @NonNull
   @Keep
   private native Object nativeGetCircleStrokeWidth();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetCircleStrokeWidthTransition();
 
   @Keep
   private native void nativeSetCircleStrokeWidthTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetCircleStrokeColor();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetCircleStrokeColorTransition();
 
   @Keep
   private native void nativeSetCircleStrokeColorTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetCircleStrokeOpacity();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetCircleStrokeOpacityTransition();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/FillExtrusionLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/FillExtrusionLayer.java
@@ -62,7 +62,6 @@ public class FillExtrusionLayer extends Layer {
    * @param sourceLayer the source layer to set
    * @return This
    */
-  @NonNull
   public FillExtrusionLayer withSourceLayer(String sourceLayer) {
     setSourceLayer(sourceLayer);
     return this;
@@ -73,7 +72,6 @@ public class FillExtrusionLayer extends Layer {
    *
    * @return id of the source
    */
-  @NonNull
   public String getSourceId() {
     checkThread();
     return nativeGetSourceId();
@@ -84,7 +82,6 @@ public class FillExtrusionLayer extends Layer {
    *
    * @return sourceLayer the source layer to get
    */
-  @NonNull
   public String getSourceLayer() {
     checkThread();
     return nativeGetSourceLayer();
@@ -95,7 +92,7 @@ public class FillExtrusionLayer extends Layer {
    *
    * @param filter the expression filter to set
    */
-  public void setFilter(@NonNull Expression filter) {
+  public void setFilter(Expression filter) {
     checkThread();
     nativeSetFilter(filter.toArray());
   }
@@ -106,8 +103,7 @@ public class FillExtrusionLayer extends Layer {
    * @param filter the expression filter to set
    * @return This
    */
-  @NonNull
-  public FillExtrusionLayer withFilter(@NonNull Expression filter) {
+  public FillExtrusionLayer withFilter(Expression filter) {
     setFilter(filter);
     return this;
   }
@@ -134,7 +130,6 @@ public class FillExtrusionLayer extends Layer {
    * @param properties the var-args properties
    * @return This
    */
-  @NonNull
   public FillExtrusionLayer withProperties(@NonNull PropertyValue<?>... properties) {
     setProperties(properties);
     return this;
@@ -147,7 +142,6 @@ public class FillExtrusionLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getFillExtrusionOpacity() {
     checkThread();
@@ -159,7 +153,6 @@ public class FillExtrusionLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getFillExtrusionOpacityTransition() {
     checkThread();
     return nativeGetFillExtrusionOpacityTransition();
@@ -170,7 +163,7 @@ public class FillExtrusionLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setFillExtrusionOpacityTransition(@NonNull TransitionOptions options) {
+  public void setFillExtrusionOpacityTransition(TransitionOptions options) {
     checkThread();
     nativeSetFillExtrusionOpacityTransition(options.getDuration(), options.getDelay());
   }
@@ -180,7 +173,6 @@ public class FillExtrusionLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getFillExtrusionColor() {
     checkThread();
@@ -209,7 +201,6 @@ public class FillExtrusionLayer extends Layer {
    *
    * @return transition options for String
    */
-  @NonNull
   public TransitionOptions getFillExtrusionColorTransition() {
     checkThread();
     return nativeGetFillExtrusionColorTransition();
@@ -220,7 +211,7 @@ public class FillExtrusionLayer extends Layer {
    *
    * @param options transition options for String
    */
-  public void setFillExtrusionColorTransition(@NonNull TransitionOptions options) {
+  public void setFillExtrusionColorTransition(TransitionOptions options) {
     checkThread();
     nativeSetFillExtrusionColorTransition(options.getDuration(), options.getDelay());
   }
@@ -230,7 +221,6 @@ public class FillExtrusionLayer extends Layer {
    *
    * @return property wrapper value around Float[]
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float[]> getFillExtrusionTranslate() {
     checkThread();
@@ -242,7 +232,6 @@ public class FillExtrusionLayer extends Layer {
    *
    * @return transition options for Float[]
    */
-  @NonNull
   public TransitionOptions getFillExtrusionTranslateTransition() {
     checkThread();
     return nativeGetFillExtrusionTranslateTransition();
@@ -253,7 +242,7 @@ public class FillExtrusionLayer extends Layer {
    *
    * @param options transition options for Float[]
    */
-  public void setFillExtrusionTranslateTransition(@NonNull TransitionOptions options) {
+  public void setFillExtrusionTranslateTransition(TransitionOptions options) {
     checkThread();
     nativeSetFillExtrusionTranslateTransition(options.getDuration(), options.getDelay());
   }
@@ -263,7 +252,6 @@ public class FillExtrusionLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getFillExtrusionTranslateAnchor() {
     checkThread();
@@ -275,7 +263,6 @@ public class FillExtrusionLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getFillExtrusionPattern() {
     checkThread();
@@ -287,7 +274,6 @@ public class FillExtrusionLayer extends Layer {
    *
    * @return transition options for String
    */
-  @NonNull
   public TransitionOptions getFillExtrusionPatternTransition() {
     checkThread();
     return nativeGetFillExtrusionPatternTransition();
@@ -298,7 +284,7 @@ public class FillExtrusionLayer extends Layer {
    *
    * @param options transition options for String
    */
-  public void setFillExtrusionPatternTransition(@NonNull TransitionOptions options) {
+  public void setFillExtrusionPatternTransition(TransitionOptions options) {
     checkThread();
     nativeSetFillExtrusionPatternTransition(options.getDuration(), options.getDelay());
   }
@@ -308,7 +294,6 @@ public class FillExtrusionLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getFillExtrusionHeight() {
     checkThread();
@@ -320,7 +305,6 @@ public class FillExtrusionLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getFillExtrusionHeightTransition() {
     checkThread();
     return nativeGetFillExtrusionHeightTransition();
@@ -331,7 +315,7 @@ public class FillExtrusionLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setFillExtrusionHeightTransition(@NonNull TransitionOptions options) {
+  public void setFillExtrusionHeightTransition(TransitionOptions options) {
     checkThread();
     nativeSetFillExtrusionHeightTransition(options.getDuration(), options.getDelay());
   }
@@ -341,7 +325,6 @@ public class FillExtrusionLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getFillExtrusionBase() {
     checkThread();
@@ -353,7 +336,6 @@ public class FillExtrusionLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getFillExtrusionBaseTransition() {
     checkThread();
     return nativeGetFillExtrusionBaseTransition();
@@ -364,75 +346,62 @@ public class FillExtrusionLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setFillExtrusionBaseTransition(@NonNull TransitionOptions options) {
+  public void setFillExtrusionBaseTransition(TransitionOptions options) {
     checkThread();
     nativeSetFillExtrusionBaseTransition(options.getDuration(), options.getDelay());
   }
 
-  @NonNull
   @Keep
   private native Object nativeGetFillExtrusionOpacity();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetFillExtrusionOpacityTransition();
 
   @Keep
   private native void nativeSetFillExtrusionOpacityTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetFillExtrusionColor();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetFillExtrusionColorTransition();
 
   @Keep
   private native void nativeSetFillExtrusionColorTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetFillExtrusionTranslate();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetFillExtrusionTranslateTransition();
 
   @Keep
   private native void nativeSetFillExtrusionTranslateTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetFillExtrusionTranslateAnchor();
 
-  @NonNull
   @Keep
   private native Object nativeGetFillExtrusionPattern();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetFillExtrusionPatternTransition();
 
   @Keep
   private native void nativeSetFillExtrusionPatternTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetFillExtrusionHeight();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetFillExtrusionHeightTransition();
 
   @Keep
   private native void nativeSetFillExtrusionHeightTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetFillExtrusionBase();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetFillExtrusionBaseTransition();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/FillLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/FillLayer.java
@@ -62,7 +62,6 @@ public class FillLayer extends Layer {
    * @param sourceLayer the source layer to set
    * @return This
    */
-  @NonNull
   public FillLayer withSourceLayer(String sourceLayer) {
     setSourceLayer(sourceLayer);
     return this;
@@ -73,7 +72,6 @@ public class FillLayer extends Layer {
    *
    * @return id of the source
    */
-  @NonNull
   public String getSourceId() {
     checkThread();
     return nativeGetSourceId();
@@ -84,7 +82,6 @@ public class FillLayer extends Layer {
    *
    * @return sourceLayer the source layer to get
    */
-  @NonNull
   public String getSourceLayer() {
     checkThread();
     return nativeGetSourceLayer();
@@ -95,7 +92,7 @@ public class FillLayer extends Layer {
    *
    * @param filter the expression filter to set
    */
-  public void setFilter(@NonNull Expression filter) {
+  public void setFilter(Expression filter) {
     checkThread();
     nativeSetFilter(filter.toArray());
   }
@@ -106,8 +103,7 @@ public class FillLayer extends Layer {
    * @param filter the expression filter to set
    * @return This
    */
-  @NonNull
-  public FillLayer withFilter(@NonNull Expression filter) {
+  public FillLayer withFilter(Expression filter) {
     setFilter(filter);
     return this;
   }
@@ -134,7 +130,6 @@ public class FillLayer extends Layer {
    * @param properties the var-args properties
    * @return This
    */
-  @NonNull
   public FillLayer withProperties(@NonNull PropertyValue<?>... properties) {
     setProperties(properties);
     return this;
@@ -147,7 +142,6 @@ public class FillLayer extends Layer {
    *
    * @return property wrapper value around Boolean
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Boolean> getFillAntialias() {
     checkThread();
@@ -159,7 +153,6 @@ public class FillLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getFillOpacity() {
     checkThread();
@@ -171,7 +164,6 @@ public class FillLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getFillOpacityTransition() {
     checkThread();
     return nativeGetFillOpacityTransition();
@@ -182,7 +174,7 @@ public class FillLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setFillOpacityTransition(@NonNull TransitionOptions options) {
+  public void setFillOpacityTransition(TransitionOptions options) {
     checkThread();
     nativeSetFillOpacityTransition(options.getDuration(), options.getDelay());
   }
@@ -192,7 +184,6 @@ public class FillLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getFillColor() {
     checkThread();
@@ -221,7 +212,6 @@ public class FillLayer extends Layer {
    *
    * @return transition options for String
    */
-  @NonNull
   public TransitionOptions getFillColorTransition() {
     checkThread();
     return nativeGetFillColorTransition();
@@ -232,7 +222,7 @@ public class FillLayer extends Layer {
    *
    * @param options transition options for String
    */
-  public void setFillColorTransition(@NonNull TransitionOptions options) {
+  public void setFillColorTransition(TransitionOptions options) {
     checkThread();
     nativeSetFillColorTransition(options.getDuration(), options.getDelay());
   }
@@ -242,7 +232,6 @@ public class FillLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getFillOutlineColor() {
     checkThread();
@@ -271,7 +260,6 @@ public class FillLayer extends Layer {
    *
    * @return transition options for String
    */
-  @NonNull
   public TransitionOptions getFillOutlineColorTransition() {
     checkThread();
     return nativeGetFillOutlineColorTransition();
@@ -282,7 +270,7 @@ public class FillLayer extends Layer {
    *
    * @param options transition options for String
    */
-  public void setFillOutlineColorTransition(@NonNull TransitionOptions options) {
+  public void setFillOutlineColorTransition(TransitionOptions options) {
     checkThread();
     nativeSetFillOutlineColorTransition(options.getDuration(), options.getDelay());
   }
@@ -292,7 +280,6 @@ public class FillLayer extends Layer {
    *
    * @return property wrapper value around Float[]
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float[]> getFillTranslate() {
     checkThread();
@@ -304,7 +291,6 @@ public class FillLayer extends Layer {
    *
    * @return transition options for Float[]
    */
-  @NonNull
   public TransitionOptions getFillTranslateTransition() {
     checkThread();
     return nativeGetFillTranslateTransition();
@@ -315,7 +301,7 @@ public class FillLayer extends Layer {
    *
    * @param options transition options for Float[]
    */
-  public void setFillTranslateTransition(@NonNull TransitionOptions options) {
+  public void setFillTranslateTransition(TransitionOptions options) {
     checkThread();
     nativeSetFillTranslateTransition(options.getDuration(), options.getDelay());
   }
@@ -325,7 +311,6 @@ public class FillLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getFillTranslateAnchor() {
     checkThread();
@@ -337,7 +322,6 @@ public class FillLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getFillPattern() {
     checkThread();
@@ -349,7 +333,6 @@ public class FillLayer extends Layer {
    *
    * @return transition options for String
    */
-  @NonNull
   public TransitionOptions getFillPatternTransition() {
     checkThread();
     return nativeGetFillPatternTransition();
@@ -360,68 +343,56 @@ public class FillLayer extends Layer {
    *
    * @param options transition options for String
    */
-  public void setFillPatternTransition(@NonNull TransitionOptions options) {
+  public void setFillPatternTransition(TransitionOptions options) {
     checkThread();
     nativeSetFillPatternTransition(options.getDuration(), options.getDelay());
   }
 
-  @NonNull
   @Keep
   private native Object nativeGetFillAntialias();
 
-  @NonNull
   @Keep
   private native Object nativeGetFillOpacity();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetFillOpacityTransition();
 
   @Keep
   private native void nativeSetFillOpacityTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetFillColor();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetFillColorTransition();
 
   @Keep
   private native void nativeSetFillColorTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetFillOutlineColor();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetFillOutlineColorTransition();
 
   @Keep
   private native void nativeSetFillOutlineColorTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetFillTranslate();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetFillTranslateTransition();
 
   @Keep
   private native void nativeSetFillTranslateTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetFillTranslateAnchor();
 
-  @NonNull
   @Keep
   private native Object nativeGetFillPattern();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetFillPatternTransition();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/HeatmapLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/HeatmapLayer.java
@@ -62,7 +62,6 @@ public class HeatmapLayer extends Layer {
    * @param sourceLayer the source layer to set
    * @return This
    */
-  @NonNull
   public HeatmapLayer withSourceLayer(String sourceLayer) {
     setSourceLayer(sourceLayer);
     return this;
@@ -73,7 +72,6 @@ public class HeatmapLayer extends Layer {
    *
    * @return id of the source
    */
-  @NonNull
   public String getSourceId() {
     checkThread();
     return nativeGetSourceId();
@@ -84,7 +82,6 @@ public class HeatmapLayer extends Layer {
    *
    * @return sourceLayer the source layer to get
    */
-  @NonNull
   public String getSourceLayer() {
     checkThread();
     return nativeGetSourceLayer();
@@ -95,7 +92,7 @@ public class HeatmapLayer extends Layer {
    *
    * @param filter the expression filter to set
    */
-  public void setFilter(@NonNull Expression filter) {
+  public void setFilter(Expression filter) {
     checkThread();
     nativeSetFilter(filter.toArray());
   }
@@ -106,8 +103,7 @@ public class HeatmapLayer extends Layer {
    * @param filter the expression filter to set
    * @return This
    */
-  @NonNull
-  public HeatmapLayer withFilter(@NonNull Expression filter) {
+  public HeatmapLayer withFilter(Expression filter) {
     setFilter(filter);
     return this;
   }
@@ -134,7 +130,6 @@ public class HeatmapLayer extends Layer {
    * @param properties the var-args properties
    * @return This
    */
-  @NonNull
   public HeatmapLayer withProperties(@NonNull PropertyValue<?>... properties) {
     setProperties(properties);
     return this;
@@ -147,7 +142,6 @@ public class HeatmapLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getHeatmapRadius() {
     checkThread();
@@ -159,7 +153,6 @@ public class HeatmapLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getHeatmapRadiusTransition() {
     checkThread();
     return nativeGetHeatmapRadiusTransition();
@@ -170,7 +163,7 @@ public class HeatmapLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setHeatmapRadiusTransition(@NonNull TransitionOptions options) {
+  public void setHeatmapRadiusTransition(TransitionOptions options) {
     checkThread();
     nativeSetHeatmapRadiusTransition(options.getDuration(), options.getDelay());
   }
@@ -180,7 +173,6 @@ public class HeatmapLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getHeatmapWeight() {
     checkThread();
@@ -192,7 +184,6 @@ public class HeatmapLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getHeatmapIntensity() {
     checkThread();
@@ -204,7 +195,6 @@ public class HeatmapLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getHeatmapIntensityTransition() {
     checkThread();
     return nativeGetHeatmapIntensityTransition();
@@ -215,7 +205,7 @@ public class HeatmapLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setHeatmapIntensityTransition(@NonNull TransitionOptions options) {
+  public void setHeatmapIntensityTransition(TransitionOptions options) {
     checkThread();
     nativeSetHeatmapIntensityTransition(options.getDuration(), options.getDelay());
   }
@@ -225,7 +215,6 @@ public class HeatmapLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getHeatmapColor() {
     checkThread();
@@ -254,7 +243,6 @@ public class HeatmapLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getHeatmapOpacity() {
     checkThread();
@@ -266,7 +254,6 @@ public class HeatmapLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getHeatmapOpacityTransition() {
     checkThread();
     return nativeGetHeatmapOpacityTransition();
@@ -277,46 +264,38 @@ public class HeatmapLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setHeatmapOpacityTransition(@NonNull TransitionOptions options) {
+  public void setHeatmapOpacityTransition(TransitionOptions options) {
     checkThread();
     nativeSetHeatmapOpacityTransition(options.getDuration(), options.getDelay());
   }
 
-  @NonNull
   @Keep
   private native Object nativeGetHeatmapRadius();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetHeatmapRadiusTransition();
 
   @Keep
   private native void nativeSetHeatmapRadiusTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetHeatmapWeight();
 
-  @NonNull
   @Keep
   private native Object nativeGetHeatmapIntensity();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetHeatmapIntensityTransition();
 
   @Keep
   private native void nativeSetHeatmapIntensityTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetHeatmapColor();
 
-  @NonNull
   @Keep
   private native Object nativeGetHeatmapOpacity();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetHeatmapOpacityTransition();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/HillshadeLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/HillshadeLayer.java
@@ -62,7 +62,6 @@ public class HillshadeLayer extends Layer {
    * @param sourceLayer the source layer to set
    * @return This
    */
-  @NonNull
   public HillshadeLayer withSourceLayer(String sourceLayer) {
     setSourceLayer(sourceLayer);
     return this;
@@ -73,7 +72,6 @@ public class HillshadeLayer extends Layer {
    *
    * @return id of the source
    */
-  @NonNull
   public String getSourceId() {
     checkThread();
     return nativeGetSourceId();
@@ -85,7 +83,6 @@ public class HillshadeLayer extends Layer {
    * @param properties the var-args properties
    * @return This
    */
-  @NonNull
   public HillshadeLayer withProperties(@NonNull PropertyValue<?>... properties) {
     setProperties(properties);
     return this;
@@ -98,7 +95,6 @@ public class HillshadeLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getHillshadeIlluminationDirection() {
     checkThread();
@@ -110,7 +106,6 @@ public class HillshadeLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getHillshadeIlluminationAnchor() {
     checkThread();
@@ -122,7 +117,6 @@ public class HillshadeLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getHillshadeExaggeration() {
     checkThread();
@@ -134,7 +128,6 @@ public class HillshadeLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getHillshadeExaggerationTransition() {
     checkThread();
     return nativeGetHillshadeExaggerationTransition();
@@ -145,7 +138,7 @@ public class HillshadeLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setHillshadeExaggerationTransition(@NonNull TransitionOptions options) {
+  public void setHillshadeExaggerationTransition(TransitionOptions options) {
     checkThread();
     nativeSetHillshadeExaggerationTransition(options.getDuration(), options.getDelay());
   }
@@ -155,7 +148,6 @@ public class HillshadeLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getHillshadeShadowColor() {
     checkThread();
@@ -184,7 +176,6 @@ public class HillshadeLayer extends Layer {
    *
    * @return transition options for String
    */
-  @NonNull
   public TransitionOptions getHillshadeShadowColorTransition() {
     checkThread();
     return nativeGetHillshadeShadowColorTransition();
@@ -195,7 +186,7 @@ public class HillshadeLayer extends Layer {
    *
    * @param options transition options for String
    */
-  public void setHillshadeShadowColorTransition(@NonNull TransitionOptions options) {
+  public void setHillshadeShadowColorTransition(TransitionOptions options) {
     checkThread();
     nativeSetHillshadeShadowColorTransition(options.getDuration(), options.getDelay());
   }
@@ -205,7 +196,6 @@ public class HillshadeLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getHillshadeHighlightColor() {
     checkThread();
@@ -234,7 +224,6 @@ public class HillshadeLayer extends Layer {
    *
    * @return transition options for String
    */
-  @NonNull
   public TransitionOptions getHillshadeHighlightColorTransition() {
     checkThread();
     return nativeGetHillshadeHighlightColorTransition();
@@ -245,7 +234,7 @@ public class HillshadeLayer extends Layer {
    *
    * @param options transition options for String
    */
-  public void setHillshadeHighlightColorTransition(@NonNull TransitionOptions options) {
+  public void setHillshadeHighlightColorTransition(TransitionOptions options) {
     checkThread();
     nativeSetHillshadeHighlightColorTransition(options.getDuration(), options.getDelay());
   }
@@ -255,7 +244,6 @@ public class HillshadeLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getHillshadeAccentColor() {
     checkThread();
@@ -284,7 +272,6 @@ public class HillshadeLayer extends Layer {
    *
    * @return transition options for String
    */
-  @NonNull
   public TransitionOptions getHillshadeAccentColorTransition() {
     checkThread();
     return nativeGetHillshadeAccentColorTransition();
@@ -295,57 +282,47 @@ public class HillshadeLayer extends Layer {
    *
    * @param options transition options for String
    */
-  public void setHillshadeAccentColorTransition(@NonNull TransitionOptions options) {
+  public void setHillshadeAccentColorTransition(TransitionOptions options) {
     checkThread();
     nativeSetHillshadeAccentColorTransition(options.getDuration(), options.getDelay());
   }
 
-  @NonNull
   @Keep
   private native Object nativeGetHillshadeIlluminationDirection();
 
-  @NonNull
   @Keep
   private native Object nativeGetHillshadeIlluminationAnchor();
 
-  @NonNull
   @Keep
   private native Object nativeGetHillshadeExaggeration();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetHillshadeExaggerationTransition();
 
   @Keep
   private native void nativeSetHillshadeExaggerationTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetHillshadeShadowColor();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetHillshadeShadowColorTransition();
 
   @Keep
   private native void nativeSetHillshadeShadowColorTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetHillshadeHighlightColor();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetHillshadeHighlightColorTransition();
 
   @Keep
   private native void nativeSetHillshadeHighlightColorTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetHillshadeAccentColor();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetHillshadeAccentColorTransition();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Layer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Layer.java
@@ -3,7 +3,6 @@ package com.mapbox.mapboxsdk.style.layers;
 import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 
-import android.support.annotation.Nullable;
 import com.google.gson.JsonElement;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.utils.ThreadUtils;
@@ -51,13 +50,11 @@ public abstract class Layer {
     }
   }
 
-  @NonNull
   public String getId() {
     checkThread();
     return nativeGetId();
   }
 
-  @NonNull
   public PropertyValue<String> getVisibility() {
     checkThread();
     return new PaintPropertyValue<>("visibility", (String) nativeGetVisibility());
@@ -87,11 +84,9 @@ public abstract class Layer {
   @Keep
   protected native void finalize() throws Throwable;
 
-  @NonNull
   @Keep
   protected native String nativeGetId();
 
-  @NonNull
   @Keep
   protected native Object nativeGetVisibility();
 
@@ -104,18 +99,15 @@ public abstract class Layer {
   @Keep
   protected native void nativeSetFilter(Object[] filter);
 
-  @NonNull
   @Keep
   protected native JsonElement nativeGetFilter();
 
   @Keep
   protected native void nativeSetSourceLayer(String sourceLayer);
 
-  @NonNull
   @Keep
   protected native String nativeGetSourceLayer();
 
-  @NonNull
   @Keep
   protected native String nativeGetSourceId();
 
@@ -135,8 +127,7 @@ public abstract class Layer {
     return nativePtr;
   }
 
-  @Nullable
-  private Object convertValue(@Nullable Object value) {
+  private Object convertValue(Object value) {
     if (value != null && value instanceof Expression) {
       return ((Expression) value).toArray();
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/LineLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/LineLayer.java
@@ -62,7 +62,6 @@ public class LineLayer extends Layer {
    * @param sourceLayer the source layer to set
    * @return This
    */
-  @NonNull
   public LineLayer withSourceLayer(String sourceLayer) {
     setSourceLayer(sourceLayer);
     return this;
@@ -73,7 +72,6 @@ public class LineLayer extends Layer {
    *
    * @return id of the source
    */
-  @NonNull
   public String getSourceId() {
     checkThread();
     return nativeGetSourceId();
@@ -84,7 +82,6 @@ public class LineLayer extends Layer {
    *
    * @return sourceLayer the source layer to get
    */
-  @NonNull
   public String getSourceLayer() {
     checkThread();
     return nativeGetSourceLayer();
@@ -95,7 +92,7 @@ public class LineLayer extends Layer {
    *
    * @param filter the expression filter to set
    */
-  public void setFilter(@NonNull Expression filter) {
+  public void setFilter(Expression filter) {
     checkThread();
     nativeSetFilter(filter.toArray());
   }
@@ -106,8 +103,7 @@ public class LineLayer extends Layer {
    * @param filter the expression filter to set
    * @return This
    */
-  @NonNull
-  public LineLayer withFilter(@NonNull Expression filter) {
+  public LineLayer withFilter(Expression filter) {
     setFilter(filter);
     return this;
   }
@@ -134,7 +130,6 @@ public class LineLayer extends Layer {
    * @param properties the var-args properties
    * @return This
    */
-  @NonNull
   public LineLayer withProperties(@NonNull PropertyValue<?>... properties) {
     setProperties(properties);
     return this;
@@ -147,7 +142,6 @@ public class LineLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getLineCap() {
     checkThread();
@@ -159,7 +153,6 @@ public class LineLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getLineJoin() {
     checkThread();
@@ -171,7 +164,6 @@ public class LineLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getLineMiterLimit() {
     checkThread();
@@ -183,7 +175,6 @@ public class LineLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getLineRoundLimit() {
     checkThread();
@@ -195,7 +186,6 @@ public class LineLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getLineOpacity() {
     checkThread();
@@ -207,7 +197,6 @@ public class LineLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getLineOpacityTransition() {
     checkThread();
     return nativeGetLineOpacityTransition();
@@ -218,7 +207,7 @@ public class LineLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setLineOpacityTransition(@NonNull TransitionOptions options) {
+  public void setLineOpacityTransition(TransitionOptions options) {
     checkThread();
     nativeSetLineOpacityTransition(options.getDuration(), options.getDelay());
   }
@@ -228,7 +217,6 @@ public class LineLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getLineColor() {
     checkThread();
@@ -257,7 +245,6 @@ public class LineLayer extends Layer {
    *
    * @return transition options for String
    */
-  @NonNull
   public TransitionOptions getLineColorTransition() {
     checkThread();
     return nativeGetLineColorTransition();
@@ -268,7 +255,7 @@ public class LineLayer extends Layer {
    *
    * @param options transition options for String
    */
-  public void setLineColorTransition(@NonNull TransitionOptions options) {
+  public void setLineColorTransition(TransitionOptions options) {
     checkThread();
     nativeSetLineColorTransition(options.getDuration(), options.getDelay());
   }
@@ -278,7 +265,6 @@ public class LineLayer extends Layer {
    *
    * @return property wrapper value around Float[]
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float[]> getLineTranslate() {
     checkThread();
@@ -290,7 +276,6 @@ public class LineLayer extends Layer {
    *
    * @return transition options for Float[]
    */
-  @NonNull
   public TransitionOptions getLineTranslateTransition() {
     checkThread();
     return nativeGetLineTranslateTransition();
@@ -301,7 +286,7 @@ public class LineLayer extends Layer {
    *
    * @param options transition options for Float[]
    */
-  public void setLineTranslateTransition(@NonNull TransitionOptions options) {
+  public void setLineTranslateTransition(TransitionOptions options) {
     checkThread();
     nativeSetLineTranslateTransition(options.getDuration(), options.getDelay());
   }
@@ -311,7 +296,6 @@ public class LineLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getLineTranslateAnchor() {
     checkThread();
@@ -323,7 +307,6 @@ public class LineLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getLineWidth() {
     checkThread();
@@ -335,7 +318,6 @@ public class LineLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getLineWidthTransition() {
     checkThread();
     return nativeGetLineWidthTransition();
@@ -346,7 +328,7 @@ public class LineLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setLineWidthTransition(@NonNull TransitionOptions options) {
+  public void setLineWidthTransition(TransitionOptions options) {
     checkThread();
     nativeSetLineWidthTransition(options.getDuration(), options.getDelay());
   }
@@ -356,7 +338,6 @@ public class LineLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getLineGapWidth() {
     checkThread();
@@ -368,7 +349,6 @@ public class LineLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getLineGapWidthTransition() {
     checkThread();
     return nativeGetLineGapWidthTransition();
@@ -379,7 +359,7 @@ public class LineLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setLineGapWidthTransition(@NonNull TransitionOptions options) {
+  public void setLineGapWidthTransition(TransitionOptions options) {
     checkThread();
     nativeSetLineGapWidthTransition(options.getDuration(), options.getDelay());
   }
@@ -389,7 +369,6 @@ public class LineLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getLineOffset() {
     checkThread();
@@ -401,7 +380,6 @@ public class LineLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getLineOffsetTransition() {
     checkThread();
     return nativeGetLineOffsetTransition();
@@ -412,7 +390,7 @@ public class LineLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setLineOffsetTransition(@NonNull TransitionOptions options) {
+  public void setLineOffsetTransition(TransitionOptions options) {
     checkThread();
     nativeSetLineOffsetTransition(options.getDuration(), options.getDelay());
   }
@@ -422,7 +400,6 @@ public class LineLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getLineBlur() {
     checkThread();
@@ -434,7 +411,6 @@ public class LineLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getLineBlurTransition() {
     checkThread();
     return nativeGetLineBlurTransition();
@@ -445,7 +421,7 @@ public class LineLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setLineBlurTransition(@NonNull TransitionOptions options) {
+  public void setLineBlurTransition(TransitionOptions options) {
     checkThread();
     nativeSetLineBlurTransition(options.getDuration(), options.getDelay());
   }
@@ -455,7 +431,6 @@ public class LineLayer extends Layer {
    *
    * @return property wrapper value around Float[]
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float[]> getLineDasharray() {
     checkThread();
@@ -467,7 +442,6 @@ public class LineLayer extends Layer {
    *
    * @return transition options for Float[]
    */
-  @NonNull
   public TransitionOptions getLineDasharrayTransition() {
     checkThread();
     return nativeGetLineDasharrayTransition();
@@ -478,7 +452,7 @@ public class LineLayer extends Layer {
    *
    * @param options transition options for Float[]
    */
-  public void setLineDasharrayTransition(@NonNull TransitionOptions options) {
+  public void setLineDasharrayTransition(TransitionOptions options) {
     checkThread();
     nativeSetLineDasharrayTransition(options.getDuration(), options.getDelay());
   }
@@ -488,7 +462,6 @@ public class LineLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getLinePattern() {
     checkThread();
@@ -500,7 +473,6 @@ public class LineLayer extends Layer {
    *
    * @return transition options for String
    */
-  @NonNull
   public TransitionOptions getLinePatternTransition() {
     checkThread();
     return nativeGetLinePatternTransition();
@@ -511,7 +483,7 @@ public class LineLayer extends Layer {
    *
    * @param options transition options for String
    */
-  public void setLinePatternTransition(@NonNull TransitionOptions options) {
+  public void setLinePatternTransition(TransitionOptions options) {
     checkThread();
     nativeSetLinePatternTransition(options.getDuration(), options.getDelay());
   }
@@ -521,7 +493,6 @@ public class LineLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getLineGradient() {
     checkThread();
@@ -545,126 +516,102 @@ public class LineLayer extends Layer {
     }
   }
 
-  @NonNull
   @Keep
   private native Object nativeGetLineCap();
 
-  @NonNull
   @Keep
   private native Object nativeGetLineJoin();
 
-  @NonNull
   @Keep
   private native Object nativeGetLineMiterLimit();
 
-  @NonNull
   @Keep
   private native Object nativeGetLineRoundLimit();
 
-  @NonNull
   @Keep
   private native Object nativeGetLineOpacity();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetLineOpacityTransition();
 
   @Keep
   private native void nativeSetLineOpacityTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetLineColor();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetLineColorTransition();
 
   @Keep
   private native void nativeSetLineColorTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetLineTranslate();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetLineTranslateTransition();
 
   @Keep
   private native void nativeSetLineTranslateTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetLineTranslateAnchor();
 
-  @NonNull
   @Keep
   private native Object nativeGetLineWidth();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetLineWidthTransition();
 
   @Keep
   private native void nativeSetLineWidthTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetLineGapWidth();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetLineGapWidthTransition();
 
   @Keep
   private native void nativeSetLineGapWidthTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetLineOffset();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetLineOffsetTransition();
 
   @Keep
   private native void nativeSetLineOffsetTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetLineBlur();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetLineBlurTransition();
 
   @Keep
   private native void nativeSetLineBlurTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetLineDasharray();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetLineDasharrayTransition();
 
   @Keep
   private native void nativeSetLineDasharrayTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetLinePattern();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetLinePatternTransition();
 
   @Keep
   private native void nativeSetLinePatternTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetLineGradient();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyValue.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyValue.java
@@ -17,7 +17,6 @@ public class PropertyValue<T> {
 
   private static final String TAG = "Mbgl-PropertyValue";
 
-  @NonNull
   public final String name;
   public final T value;
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/RasterLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/RasterLayer.java
@@ -62,7 +62,6 @@ public class RasterLayer extends Layer {
    * @param sourceLayer the source layer to set
    * @return This
    */
-  @NonNull
   public RasterLayer withSourceLayer(String sourceLayer) {
     setSourceLayer(sourceLayer);
     return this;
@@ -73,7 +72,6 @@ public class RasterLayer extends Layer {
    *
    * @return id of the source
    */
-  @NonNull
   public String getSourceId() {
     checkThread();
     return nativeGetSourceId();
@@ -85,7 +83,6 @@ public class RasterLayer extends Layer {
    * @param properties the var-args properties
    * @return This
    */
-  @NonNull
   public RasterLayer withProperties(@NonNull PropertyValue<?>... properties) {
     setProperties(properties);
     return this;
@@ -98,7 +95,6 @@ public class RasterLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getRasterOpacity() {
     checkThread();
@@ -110,7 +106,6 @@ public class RasterLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getRasterOpacityTransition() {
     checkThread();
     return nativeGetRasterOpacityTransition();
@@ -121,7 +116,7 @@ public class RasterLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setRasterOpacityTransition(@NonNull TransitionOptions options) {
+  public void setRasterOpacityTransition(TransitionOptions options) {
     checkThread();
     nativeSetRasterOpacityTransition(options.getDuration(), options.getDelay());
   }
@@ -131,7 +126,6 @@ public class RasterLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getRasterHueRotate() {
     checkThread();
@@ -143,7 +137,6 @@ public class RasterLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getRasterHueRotateTransition() {
     checkThread();
     return nativeGetRasterHueRotateTransition();
@@ -154,7 +147,7 @@ public class RasterLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setRasterHueRotateTransition(@NonNull TransitionOptions options) {
+  public void setRasterHueRotateTransition(TransitionOptions options) {
     checkThread();
     nativeSetRasterHueRotateTransition(options.getDuration(), options.getDelay());
   }
@@ -164,7 +157,6 @@ public class RasterLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getRasterBrightnessMin() {
     checkThread();
@@ -176,7 +168,6 @@ public class RasterLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getRasterBrightnessMinTransition() {
     checkThread();
     return nativeGetRasterBrightnessMinTransition();
@@ -187,7 +178,7 @@ public class RasterLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setRasterBrightnessMinTransition(@NonNull TransitionOptions options) {
+  public void setRasterBrightnessMinTransition(TransitionOptions options) {
     checkThread();
     nativeSetRasterBrightnessMinTransition(options.getDuration(), options.getDelay());
   }
@@ -197,7 +188,6 @@ public class RasterLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getRasterBrightnessMax() {
     checkThread();
@@ -209,7 +199,6 @@ public class RasterLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getRasterBrightnessMaxTransition() {
     checkThread();
     return nativeGetRasterBrightnessMaxTransition();
@@ -220,7 +209,7 @@ public class RasterLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setRasterBrightnessMaxTransition(@NonNull TransitionOptions options) {
+  public void setRasterBrightnessMaxTransition(TransitionOptions options) {
     checkThread();
     nativeSetRasterBrightnessMaxTransition(options.getDuration(), options.getDelay());
   }
@@ -230,7 +219,6 @@ public class RasterLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getRasterSaturation() {
     checkThread();
@@ -242,7 +230,6 @@ public class RasterLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getRasterSaturationTransition() {
     checkThread();
     return nativeGetRasterSaturationTransition();
@@ -253,7 +240,7 @@ public class RasterLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setRasterSaturationTransition(@NonNull TransitionOptions options) {
+  public void setRasterSaturationTransition(TransitionOptions options) {
     checkThread();
     nativeSetRasterSaturationTransition(options.getDuration(), options.getDelay());
   }
@@ -263,7 +250,6 @@ public class RasterLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getRasterContrast() {
     checkThread();
@@ -275,7 +261,6 @@ public class RasterLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getRasterContrastTransition() {
     checkThread();
     return nativeGetRasterContrastTransition();
@@ -286,7 +271,7 @@ public class RasterLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setRasterContrastTransition(@NonNull TransitionOptions options) {
+  public void setRasterContrastTransition(TransitionOptions options) {
     checkThread();
     nativeSetRasterContrastTransition(options.getDuration(), options.getDelay());
   }
@@ -296,7 +281,6 @@ public class RasterLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getRasterResampling() {
     checkThread();
@@ -308,84 +292,69 @@ public class RasterLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getRasterFadeDuration() {
     checkThread();
     return (PropertyValue<Float>) new PropertyValue("raster-fade-duration", nativeGetRasterFadeDuration());
   }
 
-  @NonNull
   @Keep
   private native Object nativeGetRasterOpacity();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetRasterOpacityTransition();
 
   @Keep
   private native void nativeSetRasterOpacityTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetRasterHueRotate();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetRasterHueRotateTransition();
 
   @Keep
   private native void nativeSetRasterHueRotateTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetRasterBrightnessMin();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetRasterBrightnessMinTransition();
 
   @Keep
   private native void nativeSetRasterBrightnessMinTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetRasterBrightnessMax();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetRasterBrightnessMaxTransition();
 
   @Keep
   private native void nativeSetRasterBrightnessMaxTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetRasterSaturation();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetRasterSaturationTransition();
 
   @Keep
   private native void nativeSetRasterSaturationTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetRasterContrast();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetRasterContrastTransition();
 
   @Keep
   private native void nativeSetRasterContrastTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetRasterResampling();
 
-  @NonNull
   @Keep
   private native Object nativeGetRasterFadeDuration();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/SymbolLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/SymbolLayer.java
@@ -62,7 +62,6 @@ public class SymbolLayer extends Layer {
    * @param sourceLayer the source layer to set
    * @return This
    */
-  @NonNull
   public SymbolLayer withSourceLayer(String sourceLayer) {
     setSourceLayer(sourceLayer);
     return this;
@@ -73,7 +72,6 @@ public class SymbolLayer extends Layer {
    *
    * @return id of the source
    */
-  @NonNull
   public String getSourceId() {
     checkThread();
     return nativeGetSourceId();
@@ -84,7 +82,6 @@ public class SymbolLayer extends Layer {
    *
    * @return sourceLayer the source layer to get
    */
-  @NonNull
   public String getSourceLayer() {
     checkThread();
     return nativeGetSourceLayer();
@@ -95,7 +92,7 @@ public class SymbolLayer extends Layer {
    *
    * @param filter the expression filter to set
    */
-  public void setFilter(@NonNull Expression filter) {
+  public void setFilter(Expression filter) {
     checkThread();
     nativeSetFilter(filter.toArray());
   }
@@ -106,8 +103,7 @@ public class SymbolLayer extends Layer {
    * @param filter the expression filter to set
    * @return This
    */
-  @NonNull
-  public SymbolLayer withFilter(@NonNull Expression filter) {
+  public SymbolLayer withFilter(Expression filter) {
     setFilter(filter);
     return this;
   }
@@ -134,7 +130,6 @@ public class SymbolLayer extends Layer {
    * @param properties the var-args properties
    * @return This
    */
-  @NonNull
   public SymbolLayer withProperties(@NonNull PropertyValue<?>... properties) {
     setProperties(properties);
     return this;
@@ -147,7 +142,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getSymbolPlacement() {
     checkThread();
@@ -159,7 +153,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getSymbolSpacing() {
     checkThread();
@@ -171,7 +164,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Boolean
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Boolean> getSymbolAvoidEdges() {
     checkThread();
@@ -183,7 +175,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getSymbolZOrder() {
     checkThread();
@@ -195,7 +186,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Boolean
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Boolean> getIconAllowOverlap() {
     checkThread();
@@ -207,7 +197,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Boolean
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Boolean> getIconIgnorePlacement() {
     checkThread();
@@ -219,7 +208,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Boolean
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Boolean> getIconOptional() {
     checkThread();
@@ -231,7 +219,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getIconRotationAlignment() {
     checkThread();
@@ -243,7 +230,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getIconSize() {
     checkThread();
@@ -255,7 +241,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getIconTextFit() {
     checkThread();
@@ -267,7 +252,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float[]
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float[]> getIconTextFitPadding() {
     checkThread();
@@ -279,7 +263,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getIconImage() {
     checkThread();
@@ -291,7 +274,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getIconRotate() {
     checkThread();
@@ -303,7 +285,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getIconPadding() {
     checkThread();
@@ -315,7 +296,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Boolean
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Boolean> getIconKeepUpright() {
     checkThread();
@@ -327,7 +307,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float[]
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float[]> getIconOffset() {
     checkThread();
@@ -339,7 +318,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getIconAnchor() {
     checkThread();
@@ -351,7 +329,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getIconPitchAlignment() {
     checkThread();
@@ -363,7 +340,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getTextPitchAlignment() {
     checkThread();
@@ -375,7 +351,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getTextRotationAlignment() {
     checkThread();
@@ -387,7 +362,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getTextField() {
     checkThread();
@@ -399,7 +373,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around String[]
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String[]> getTextFont() {
     checkThread();
@@ -411,7 +384,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getTextSize() {
     checkThread();
@@ -423,7 +395,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getTextMaxWidth() {
     checkThread();
@@ -435,7 +406,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getTextLineHeight() {
     checkThread();
@@ -447,7 +417,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getTextLetterSpacing() {
     checkThread();
@@ -459,7 +428,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getTextJustify() {
     checkThread();
@@ -471,7 +439,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getTextAnchor() {
     checkThread();
@@ -483,7 +450,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getTextMaxAngle() {
     checkThread();
@@ -495,7 +461,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getTextRotate() {
     checkThread();
@@ -507,7 +472,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getTextPadding() {
     checkThread();
@@ -519,7 +483,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Boolean
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Boolean> getTextKeepUpright() {
     checkThread();
@@ -531,7 +494,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getTextTransform() {
     checkThread();
@@ -543,7 +505,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float[]
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float[]> getTextOffset() {
     checkThread();
@@ -555,7 +516,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Boolean
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Boolean> getTextAllowOverlap() {
     checkThread();
@@ -567,7 +527,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Boolean
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Boolean> getTextIgnorePlacement() {
     checkThread();
@@ -579,7 +538,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Boolean
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Boolean> getTextOptional() {
     checkThread();
@@ -591,7 +549,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getIconOpacity() {
     checkThread();
@@ -603,7 +560,6 @@ public class SymbolLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getIconOpacityTransition() {
     checkThread();
     return nativeGetIconOpacityTransition();
@@ -614,7 +570,7 @@ public class SymbolLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setIconOpacityTransition(@NonNull TransitionOptions options) {
+  public void setIconOpacityTransition(TransitionOptions options) {
     checkThread();
     nativeSetIconOpacityTransition(options.getDuration(), options.getDelay());
   }
@@ -624,7 +580,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getIconColor() {
     checkThread();
@@ -653,7 +608,6 @@ public class SymbolLayer extends Layer {
    *
    * @return transition options for String
    */
-  @NonNull
   public TransitionOptions getIconColorTransition() {
     checkThread();
     return nativeGetIconColorTransition();
@@ -664,7 +618,7 @@ public class SymbolLayer extends Layer {
    *
    * @param options transition options for String
    */
-  public void setIconColorTransition(@NonNull TransitionOptions options) {
+  public void setIconColorTransition(TransitionOptions options) {
     checkThread();
     nativeSetIconColorTransition(options.getDuration(), options.getDelay());
   }
@@ -674,7 +628,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getIconHaloColor() {
     checkThread();
@@ -703,7 +656,6 @@ public class SymbolLayer extends Layer {
    *
    * @return transition options for String
    */
-  @NonNull
   public TransitionOptions getIconHaloColorTransition() {
     checkThread();
     return nativeGetIconHaloColorTransition();
@@ -714,7 +666,7 @@ public class SymbolLayer extends Layer {
    *
    * @param options transition options for String
    */
-  public void setIconHaloColorTransition(@NonNull TransitionOptions options) {
+  public void setIconHaloColorTransition(TransitionOptions options) {
     checkThread();
     nativeSetIconHaloColorTransition(options.getDuration(), options.getDelay());
   }
@@ -724,7 +676,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getIconHaloWidth() {
     checkThread();
@@ -736,7 +687,6 @@ public class SymbolLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getIconHaloWidthTransition() {
     checkThread();
     return nativeGetIconHaloWidthTransition();
@@ -747,7 +697,7 @@ public class SymbolLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setIconHaloWidthTransition(@NonNull TransitionOptions options) {
+  public void setIconHaloWidthTransition(TransitionOptions options) {
     checkThread();
     nativeSetIconHaloWidthTransition(options.getDuration(), options.getDelay());
   }
@@ -757,7 +707,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getIconHaloBlur() {
     checkThread();
@@ -769,7 +718,6 @@ public class SymbolLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getIconHaloBlurTransition() {
     checkThread();
     return nativeGetIconHaloBlurTransition();
@@ -780,7 +728,7 @@ public class SymbolLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setIconHaloBlurTransition(@NonNull TransitionOptions options) {
+  public void setIconHaloBlurTransition(TransitionOptions options) {
     checkThread();
     nativeSetIconHaloBlurTransition(options.getDuration(), options.getDelay());
   }
@@ -790,7 +738,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float[]
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float[]> getIconTranslate() {
     checkThread();
@@ -802,7 +749,6 @@ public class SymbolLayer extends Layer {
    *
    * @return transition options for Float[]
    */
-  @NonNull
   public TransitionOptions getIconTranslateTransition() {
     checkThread();
     return nativeGetIconTranslateTransition();
@@ -813,7 +759,7 @@ public class SymbolLayer extends Layer {
    *
    * @param options transition options for Float[]
    */
-  public void setIconTranslateTransition(@NonNull TransitionOptions options) {
+  public void setIconTranslateTransition(TransitionOptions options) {
     checkThread();
     nativeSetIconTranslateTransition(options.getDuration(), options.getDelay());
   }
@@ -823,7 +769,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getIconTranslateAnchor() {
     checkThread();
@@ -835,7 +780,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getTextOpacity() {
     checkThread();
@@ -847,7 +791,6 @@ public class SymbolLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getTextOpacityTransition() {
     checkThread();
     return nativeGetTextOpacityTransition();
@@ -858,7 +801,7 @@ public class SymbolLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setTextOpacityTransition(@NonNull TransitionOptions options) {
+  public void setTextOpacityTransition(TransitionOptions options) {
     checkThread();
     nativeSetTextOpacityTransition(options.getDuration(), options.getDelay());
   }
@@ -868,7 +811,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getTextColor() {
     checkThread();
@@ -897,7 +839,6 @@ public class SymbolLayer extends Layer {
    *
    * @return transition options for String
    */
-  @NonNull
   public TransitionOptions getTextColorTransition() {
     checkThread();
     return nativeGetTextColorTransition();
@@ -908,7 +849,7 @@ public class SymbolLayer extends Layer {
    *
    * @param options transition options for String
    */
-  public void setTextColorTransition(@NonNull TransitionOptions options) {
+  public void setTextColorTransition(TransitionOptions options) {
     checkThread();
     nativeSetTextColorTransition(options.getDuration(), options.getDelay());
   }
@@ -918,7 +859,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getTextHaloColor() {
     checkThread();
@@ -947,7 +887,6 @@ public class SymbolLayer extends Layer {
    *
    * @return transition options for String
    */
-  @NonNull
   public TransitionOptions getTextHaloColorTransition() {
     checkThread();
     return nativeGetTextHaloColorTransition();
@@ -958,7 +897,7 @@ public class SymbolLayer extends Layer {
    *
    * @param options transition options for String
    */
-  public void setTextHaloColorTransition(@NonNull TransitionOptions options) {
+  public void setTextHaloColorTransition(TransitionOptions options) {
     checkThread();
     nativeSetTextHaloColorTransition(options.getDuration(), options.getDelay());
   }
@@ -968,7 +907,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getTextHaloWidth() {
     checkThread();
@@ -980,7 +918,6 @@ public class SymbolLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getTextHaloWidthTransition() {
     checkThread();
     return nativeGetTextHaloWidthTransition();
@@ -991,7 +928,7 @@ public class SymbolLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setTextHaloWidthTransition(@NonNull TransitionOptions options) {
+  public void setTextHaloWidthTransition(TransitionOptions options) {
     checkThread();
     nativeSetTextHaloWidthTransition(options.getDuration(), options.getDelay());
   }
@@ -1001,7 +938,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getTextHaloBlur() {
     checkThread();
@@ -1013,7 +949,6 @@ public class SymbolLayer extends Layer {
    *
    * @return transition options for Float
    */
-  @NonNull
   public TransitionOptions getTextHaloBlurTransition() {
     checkThread();
     return nativeGetTextHaloBlurTransition();
@@ -1024,7 +959,7 @@ public class SymbolLayer extends Layer {
    *
    * @param options transition options for Float
    */
-  public void setTextHaloBlurTransition(@NonNull TransitionOptions options) {
+  public void setTextHaloBlurTransition(TransitionOptions options) {
     checkThread();
     nativeSetTextHaloBlurTransition(options.getDuration(), options.getDelay());
   }
@@ -1034,7 +969,6 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around Float[]
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<Float[]> getTextTranslate() {
     checkThread();
@@ -1046,7 +980,6 @@ public class SymbolLayer extends Layer {
    *
    * @return transition options for Float[]
    */
-  @NonNull
   public TransitionOptions getTextTranslateTransition() {
     checkThread();
     return nativeGetTextTranslateTransition();
@@ -1057,7 +990,7 @@ public class SymbolLayer extends Layer {
    *
    * @param options transition options for Float[]
    */
-  public void setTextTranslateTransition(@NonNull TransitionOptions options) {
+  public void setTextTranslateTransition(TransitionOptions options) {
     checkThread();
     nativeSetTextTranslateTransition(options.getDuration(), options.getDelay());
   }
@@ -1067,298 +1000,234 @@ public class SymbolLayer extends Layer {
    *
    * @return property wrapper value around String
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getTextTranslateAnchor() {
     checkThread();
     return (PropertyValue<String>) new PropertyValue("text-translate-anchor", nativeGetTextTranslateAnchor());
   }
 
-  @NonNull
   @Keep
   private native Object nativeGetSymbolPlacement();
 
-  @NonNull
   @Keep
   private native Object nativeGetSymbolSpacing();
 
-  @NonNull
   @Keep
   private native Object nativeGetSymbolAvoidEdges();
 
-  @NonNull
   @Keep
   private native Object nativeGetSymbolZOrder();
 
-  @NonNull
   @Keep
   private native Object nativeGetIconAllowOverlap();
 
-  @NonNull
   @Keep
   private native Object nativeGetIconIgnorePlacement();
 
-  @NonNull
   @Keep
   private native Object nativeGetIconOptional();
 
-  @NonNull
   @Keep
   private native Object nativeGetIconRotationAlignment();
 
-  @NonNull
   @Keep
   private native Object nativeGetIconSize();
 
-  @NonNull
   @Keep
   private native Object nativeGetIconTextFit();
 
-  @NonNull
   @Keep
   private native Object nativeGetIconTextFitPadding();
 
-  @NonNull
   @Keep
   private native Object nativeGetIconImage();
 
-  @NonNull
   @Keep
   private native Object nativeGetIconRotate();
 
-  @NonNull
   @Keep
   private native Object nativeGetIconPadding();
 
-  @NonNull
   @Keep
   private native Object nativeGetIconKeepUpright();
 
-  @NonNull
   @Keep
   private native Object nativeGetIconOffset();
 
-  @NonNull
   @Keep
   private native Object nativeGetIconAnchor();
 
-  @NonNull
   @Keep
   private native Object nativeGetIconPitchAlignment();
 
-  @NonNull
   @Keep
   private native Object nativeGetTextPitchAlignment();
 
-  @NonNull
   @Keep
   private native Object nativeGetTextRotationAlignment();
 
-  @NonNull
   @Keep
   private native Object nativeGetTextField();
 
-  @NonNull
   @Keep
   private native Object nativeGetTextFont();
 
-  @NonNull
   @Keep
   private native Object nativeGetTextSize();
 
-  @NonNull
   @Keep
   private native Object nativeGetTextMaxWidth();
 
-  @NonNull
   @Keep
   private native Object nativeGetTextLineHeight();
 
-  @NonNull
   @Keep
   private native Object nativeGetTextLetterSpacing();
 
-  @NonNull
   @Keep
   private native Object nativeGetTextJustify();
 
-  @NonNull
   @Keep
   private native Object nativeGetTextAnchor();
 
-  @NonNull
   @Keep
   private native Object nativeGetTextMaxAngle();
 
-  @NonNull
   @Keep
   private native Object nativeGetTextRotate();
 
-  @NonNull
   @Keep
   private native Object nativeGetTextPadding();
 
-  @NonNull
   @Keep
   private native Object nativeGetTextKeepUpright();
 
-  @NonNull
   @Keep
   private native Object nativeGetTextTransform();
 
-  @NonNull
   @Keep
   private native Object nativeGetTextOffset();
 
-  @NonNull
   @Keep
   private native Object nativeGetTextAllowOverlap();
 
-  @NonNull
   @Keep
   private native Object nativeGetTextIgnorePlacement();
 
-  @NonNull
   @Keep
   private native Object nativeGetTextOptional();
 
-  @NonNull
   @Keep
   private native Object nativeGetIconOpacity();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetIconOpacityTransition();
 
   @Keep
   private native void nativeSetIconOpacityTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetIconColor();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetIconColorTransition();
 
   @Keep
   private native void nativeSetIconColorTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetIconHaloColor();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetIconHaloColorTransition();
 
   @Keep
   private native void nativeSetIconHaloColorTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetIconHaloWidth();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetIconHaloWidthTransition();
 
   @Keep
   private native void nativeSetIconHaloWidthTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetIconHaloBlur();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetIconHaloBlurTransition();
 
   @Keep
   private native void nativeSetIconHaloBlurTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetIconTranslate();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetIconTranslateTransition();
 
   @Keep
   private native void nativeSetIconTranslateTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetIconTranslateAnchor();
 
-  @NonNull
   @Keep
   private native Object nativeGetTextOpacity();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetTextOpacityTransition();
 
   @Keep
   private native void nativeSetTextOpacityTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetTextColor();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetTextColorTransition();
 
   @Keep
   private native void nativeSetTextColorTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetTextHaloColor();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetTextHaloColorTransition();
 
   @Keep
   private native void nativeSetTextHaloColorTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetTextHaloWidth();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetTextHaloWidthTransition();
 
   @Keep
   private native void nativeSetTextHaloWidthTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetTextHaloBlur();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetTextHaloBlurTransition();
 
   @Keep
   private native void nativeSetTextHaloBlurTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetTextTranslate();
 
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetTextTranslateTransition();
 
   @Keep
   private native void nativeSetTextTranslateTransition(long duration, long delay);
 
-  @NonNull
   @Keep
   private native Object nativeGetTextTranslateAnchor();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/TransitionOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/TransitionOptions.java
@@ -1,8 +1,6 @@
 package com.mapbox.mapboxsdk.style.layers;
 
 import android.support.annotation.Keep;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 /**
  * Resembles transition property from the style specification.
@@ -56,7 +54,7 @@ public class TransitionOptions {
   }
 
   @Override
-  public boolean equals(@Nullable Object o) {
+  public boolean equals(Object o) {
     if (this == o) {
       return true;
     }
@@ -79,7 +77,6 @@ public class TransitionOptions {
     return result;
   }
 
-  @NonNull
   @Override
   public String toString() {
     return "TransitionOptions{"

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/layer.java.ejs
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/layer.java.ejs
@@ -82,7 +82,6 @@ public class <%- camelize(type) %>Layer extends Layer {
    * @param sourceLayer the source layer to set
    * @return This
    */
-  @NonNull
   public <%- camelize(type) %>Layer withSourceLayer(String sourceLayer) {
     setSourceLayer(sourceLayer);
     return this;
@@ -95,7 +94,6 @@ public class <%- camelize(type) %>Layer extends Layer {
    *
    * @return id of the source
    */
-  @NonNull
   public String getSourceId() {
     checkThread();
     return nativeGetSourceId();
@@ -108,7 +106,6 @@ public class <%- camelize(type) %>Layer extends Layer {
    *
    * @return sourceLayer the source layer to get
    */
-  @NonNull
   public String getSourceLayer() {
     checkThread();
     return nativeGetSourceLayer();
@@ -119,7 +116,7 @@ public class <%- camelize(type) %>Layer extends Layer {
    *
    * @param filter the expression filter to set
    */
-  public void setFilter(@NonNull Expression filter) {
+  public void setFilter(Expression filter) {
     checkThread();
     nativeSetFilter(filter.toArray());
   }
@@ -130,8 +127,7 @@ public class <%- camelize(type) %>Layer extends Layer {
    * @param filter the expression filter to set
    * @return This
    */
-  @NonNull
-  public <%- camelize(type) %>Layer withFilter(@NonNull Expression filter) {
+  public <%- camelize(type) %>Layer withFilter(Expression filter) {
     setFilter(filter);
     return this;
   }
@@ -159,7 +155,6 @@ public class <%- camelize(type) %>Layer extends Layer {
    * @param properties the var-args properties
    * @return This
    */
-  @NonNull
   public <%- camelize(type) %>Layer withProperties(@NonNull PropertyValue<?>... properties) {
     setProperties(properties);
     return this;
@@ -173,7 +168,6 @@ public class <%- camelize(type) %>Layer extends Layer {
    *
    * @return property wrapper value around <%- propertyType(property) %>
    */
-  @NonNull
   @SuppressWarnings("unchecked")
   public PropertyValue<<%- propertyType(property) %>> get<%- camelize(property.name) %>() {
     checkThread();
@@ -205,7 +199,6 @@ public class <%- camelize(type) %>Layer extends Layer {
    *
    * @return transition options for <%- propertyType(property) %>
    */
-  @NonNull
   public TransitionOptions get<%- camelize(property.name) %>Transition() {
     checkThread();
     return nativeGet<%- camelize(property.name) %>Transition();
@@ -216,7 +209,7 @@ public class <%- camelize(type) %>Layer extends Layer {
    *
    * @param options transition options for <%- propertyType(property) %>
    */
-  public void set<%- camelize(property.name) %>Transition(@NonNull TransitionOptions options) {
+  public void set<%- camelize(property.name) %>Transition(TransitionOptions options) {
     checkThread();
     nativeSet<%- camelize(property.name) %>Transition(options.getDuration(), options.getDelay());
   }
@@ -224,12 +217,10 @@ public class <%- camelize(type) %>Layer extends Layer {
 <% } -%>
 
 <% for (const property of properties) { -%>
-  @NonNull
   @Keep
   private native Object nativeGet<%- camelize(property.name) %>();
 
 <% if (property.transition) { -%>
-  @NonNull
   @Keep
   private native TransitionOptions nativeGet<%- camelize(property.name) %>Transition();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/light/Light.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/light/Light.java
@@ -49,7 +49,6 @@ public class Light {
    *
    * @return anchor as String
    */
-  @NonNull
   @Property.ANCHOR public String getAnchor() {
     checkThread();
     return nativeGetAnchor();
@@ -70,7 +69,6 @@ public class Light {
    *
    * @return position as Position
    */
-  @NonNull
   public Position getPosition() {
     checkThread();
     return nativeGetPosition();
@@ -81,7 +79,6 @@ public class Light {
    *
    * @return transition options for position
    */
-  @NonNull
   public TransitionOptions getPositionTransition() {
     checkThread();
     return nativeGetPositionTransition();
@@ -92,7 +89,7 @@ public class Light {
    *
    * @param options transition options for position
    */
-  public void setPositionTransition(@NonNull TransitionOptions options) {
+  public void setPositionTransition(TransitionOptions options) {
     checkThread();
     nativeSetPositionTransition(options.getDuration(), options.getDelay());
   }
@@ -122,7 +119,6 @@ public class Light {
    *
    * @return color as String
    */
-  @NonNull
    public String getColor() {
     checkThread();
     return nativeGetColor();
@@ -133,7 +129,6 @@ public class Light {
    *
    * @return transition options for color
    */
-  @NonNull
   public TransitionOptions getColorTransition() {
     checkThread();
     return nativeGetColorTransition();
@@ -144,7 +139,7 @@ public class Light {
    *
    * @param options transition options for color
    */
-  public void setColorTransition(@NonNull TransitionOptions options) {
+  public void setColorTransition(TransitionOptions options) {
     checkThread();
     nativeSetColorTransition(options.getDuration(), options.getDelay());
   }
@@ -164,7 +159,6 @@ public class Light {
    *
    * @return intensity as Float
    */
-  @NonNull
    public float getIntensity() {
     checkThread();
     return nativeGetIntensity();
@@ -175,7 +169,6 @@ public class Light {
    *
    * @return transition options for intensity
    */
-  @NonNull
   public TransitionOptions getIntensityTransition() {
     checkThread();
     return nativeGetIntensityTransition();
@@ -186,7 +179,7 @@ public class Light {
    *
    * @param options transition options for intensity
    */
-  public void setIntensityTransition(@NonNull TransitionOptions options) {
+  public void setIntensityTransition(TransitionOptions options) {
     checkThread();
     nativeSetIntensityTransition(options.getDuration(), options.getDelay());
   }
@@ -198,16 +191,13 @@ public class Light {
   @Keep
   private native void nativeSetAnchor(String anchor);
 
-  @NonNull
   @Keep
   private native String nativeGetAnchor();
   @Keep
   private native void nativeSetPosition(Position position);
 
-  @NonNull
   @Keep
   private native Position nativeGetPosition();
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetPositionTransition();
 
@@ -216,10 +206,8 @@ public class Light {
   @Keep
   private native void nativeSetColor(String color);
 
-  @NonNull
   @Keep
   private native String nativeGetColor();
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetColorTransition();
 
@@ -228,10 +216,8 @@ public class Light {
   @Keep
   private native void nativeSetIntensity(float intensity);
 
-  @NonNull
   @Keep
   private native float nativeGetIntensity();
-  @NonNull
   @Keep
   private native TransitionOptions nativeGetIntensityTransition();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/light/Position.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/light/Position.java
@@ -1,8 +1,6 @@
 package com.mapbox.mapboxsdk.style.light;
 
 import android.support.annotation.Keep;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 /**
  * Position of the light source relative to lit (extruded) geometries.
@@ -51,7 +49,7 @@ public class Position {
   }
 
   @Override
-  public boolean equals(@Nullable Object o) {
+  public boolean equals(Object o) {
     if (this == o) {
       return true;
     }
@@ -78,7 +76,6 @@ public class Position {
     return result;
   }
 
-  @NonNull
   @Override
   public String toString() {
     return "Position{"

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/light/light.java.ejs
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/light/light.java.ejs
@@ -55,7 +55,6 @@ public class Light {
    *
    * @return <%- property.name %> as Position
    */
-  @NonNull
   public Position get<%- camelize(property.name) %>() {
     checkThread();
     return nativeGet<%- camelize(property.name) %>();
@@ -89,7 +88,6 @@ public class Light {
    *
    * @return <%- property.name %> as <%- propertyType(property) %>
    */
-  @NonNull
   <%- propertyTypeAnnotation(property) %> public <%- propertyJavaType(property) %> get<%- camelize(property.name) %>() {
     checkThread();
     return nativeGet<%- camelize(property.name) %>();
@@ -102,7 +100,6 @@ public class Light {
    *
    * @return transition options for <%- property.name %>
    */
-  @NonNull
   public TransitionOptions get<%- camelize(property.name) %>Transition() {
     checkThread();
     return nativeGet<%- camelize(property.name) %>Transition();
@@ -113,7 +110,7 @@ public class Light {
    *
    * @param options transition options for <%- property.name %>
    */
-  public void set<%- camelize(property.name) %>Transition(@NonNull TransitionOptions options) {
+  public void set<%- camelize(property.name) %>Transition(TransitionOptions options) {
     checkThread();
     nativeSet<%- camelize(property.name) %>Transition(options.getDuration(), options.getDelay());
   }
@@ -129,19 +126,16 @@ public class Light {
   @Keep
   private native void nativeSet<%- camelize(property.name) %>(Position position);
 
-  @NonNull
   @Keep
   private native Position nativeGet<%- camelize(property.name) %>();
 <% } else { -%>
   @Keep
   private native void nativeSet<%- camelize(property.name) %>(<%- propertyJavaType(property) -%> <%- property.name %>);
 
-  @NonNull
   @Keep
   private native <%- propertyJavaType(property) -%> nativeGet<%- camelize(property.name) %>();
 <% } -%>
 <% if (property.transition) { -%>
-  @NonNull
   @Keep
   private native TransitionOptions nativeGet<%- camelize(property.name) %>Transition();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/CustomGeometrySource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/CustomGeometrySource.java
@@ -129,7 +129,6 @@ public class CustomGeometrySource extends Source {
   @Keep
   protected native void initialize(String sourceId, Object options);
 
-  @NonNull
   @Keep
   private native Feature[] querySourceFeatures(Object[] filter);
 
@@ -180,7 +179,7 @@ public class CustomGeometrySource extends Source {
     }
   }
 
-  private void executeRequest(@NonNull GeometryTileRequest request) {
+  private void executeRequest(GeometryTileRequest request) {
     executorLock.lock();
     try {
       if (executor != null && !executor.isShutdown()) {
@@ -236,7 +235,6 @@ public class CustomGeometrySource extends Source {
           final AtomicInteger threadCount = new AtomicInteger();
           final int poolId = poolCount.getAndIncrement();
 
-          @NonNull
           @Override
           public Thread newThread(@NonNull Runnable runnable) {
             return new Thread(
@@ -279,7 +277,7 @@ public class CustomGeometrySource extends Source {
       return Arrays.hashCode(new int[] {z, x, y});
     }
 
-    public boolean equals(@Nullable Object object) {
+    public boolean equals(Object object) {
       if (object == this) {
         return true;
       }
@@ -301,7 +299,6 @@ public class CustomGeometrySource extends Source {
     private final GeometryTileProvider provider;
     private final Map<TileID, GeometryTileRequest> awaiting;
     private final Map<TileID, AtomicBoolean> inProgress;
-    @NonNull
     private final WeakReference<CustomGeometrySource> sourceRef;
     private final AtomicBoolean cancelled;
 
@@ -365,7 +362,7 @@ public class CustomGeometrySource extends Source {
     }
 
     @Override
-    public boolean equals(@Nullable Object o) {
+    public boolean equals(Object o) {
       if (this == o) {
         return true;
       }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/CustomGeometrySourceOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/CustomGeometrySourceOptions.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxsdk.style.sources;
 
-import android.support.annotation.NonNull;
-
 /**
  * Builder class for composing CustomGeometrySource objects.
  */
@@ -13,7 +11,6 @@ public class CustomGeometrySourceOptions extends GeoJsonOptions {
    * @param wrap defaults to false
    * @return the current instance for chaining
    */
-  @NonNull
   public CustomGeometrySourceOptions withWrap(boolean wrap) {
     this.put("wrap", wrap);
     return this;
@@ -26,7 +23,6 @@ public class CustomGeometrySourceOptions extends GeoJsonOptions {
    * @param clip defaults to false
    * @return the current instance for chaining
    */
-  @NonNull
   public CustomGeometrySourceOptions withClip(boolean clip) {
     this.put("clip", clip);
     return this;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/GeoJsonOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/GeoJsonOptions.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxsdk.style.sources;
 
-import android.support.annotation.NonNull;
-
 import java.util.HashMap;
 
 /**
@@ -18,7 +16,6 @@ public class GeoJsonOptions extends HashMap<String, Object> {
    * @param minZoom the minimum zoom - Defaults to 0.
    * @return the current instance for chaining
    */
-  @NonNull
   public GeoJsonOptions withMinZoom(int minZoom) {
     this.put("minzoom", minZoom);
     return this;
@@ -30,7 +27,6 @@ public class GeoJsonOptions extends HashMap<String, Object> {
    * @param maxZoom the maximum zoom - Defaults to 25.5
    * @return the current instance for chaining
    */
-  @NonNull
   public GeoJsonOptions withMaxZoom(int maxZoom) {
     this.put("maxzoom", maxZoom);
     return this;
@@ -43,7 +39,6 @@ public class GeoJsonOptions extends HashMap<String, Object> {
    * @param buffer the buffer size - Defaults to 128.
    * @return the current instance for chaining
    */
-  @NonNull
   public GeoJsonOptions withBuffer(int buffer) {
     this.put("buffer", buffer);
     return this;
@@ -55,7 +50,6 @@ public class GeoJsonOptions extends HashMap<String, Object> {
    * @param lineMetrics true to calculate line distance metrics.
    * @return the current instance for chaining
    */
-  @NonNull
   public GeoJsonOptions withLineMetrics(boolean lineMetrics) {
     this.put("lineMetrics", lineMetrics);
     return this;
@@ -67,7 +61,6 @@ public class GeoJsonOptions extends HashMap<String, Object> {
    * @param tolerance the tolerance - Defaults to 0.375
    * @return the current instance for chaining
    */
-  @NonNull
   public GeoJsonOptions withTolerance(float tolerance) {
     this.put("tolerance", tolerance);
     return this;
@@ -79,7 +72,6 @@ public class GeoJsonOptions extends HashMap<String, Object> {
    * @param cluster cluster? - Defaults to false
    * @return the current instance for chaining
    */
-  @NonNull
   public GeoJsonOptions withCluster(boolean cluster) {
     this.put("cluster", cluster);
     return this;
@@ -92,7 +84,6 @@ public class GeoJsonOptions extends HashMap<String, Object> {
    *                       zoom features are not clustered)
    * @return the current instance for chaining
    */
-  @NonNull
   public GeoJsonOptions withClusterMaxZoom(int clusterMaxZoom) {
     this.put("clusterMaxZoom", clusterMaxZoom);
     return this;
@@ -104,7 +95,6 @@ public class GeoJsonOptions extends HashMap<String, Object> {
    * @param clusterRadius cluster radius - Defaults to 50
    * @return the current instance for chaining
    */
-  @NonNull
   public GeoJsonOptions withClusterRadius(int clusterRadius) {
     this.put("clusterRadius", clusterRadius);
     return this;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/GeoJsonSource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/GeoJsonSource.java
@@ -62,7 +62,7 @@ public class GeoJsonSource extends Source {
    * @param id      the source id
    * @param geoJson raw Json FeatureCollection
    */
-  public GeoJsonSource(String id, @Nullable String geoJson) {
+  public GeoJsonSource(String id, String geoJson) {
     super();
     if (geoJson == null || geoJson.startsWith("http")) {
       throw new IllegalArgumentException("Expected a raw json body");
@@ -78,7 +78,7 @@ public class GeoJsonSource extends Source {
    * @param geoJson raw Json body
    * @param options options
    */
-  public GeoJsonSource(String id, @Nullable String geoJson, GeoJsonOptions options) {
+  public GeoJsonSource(String id, String geoJson, GeoJsonOptions options) {
     super();
     if (geoJson == null || geoJson.startsWith("http")) {
       throw new IllegalArgumentException("Expected a raw json body");
@@ -236,7 +236,7 @@ public class GeoJsonSource extends Source {
    *
    * @param url the GeoJSON FeatureCollection url
    */
-  public void setUrl(@NonNull URL url) {
+  public void setUrl(URL url) {
     checkThread();
     setUrl(url.toExternalForm());
   }
@@ -279,7 +279,6 @@ public class GeoJsonSource extends Source {
   @Keep
   protected native void nativeSetUrl(String url);
 
-  @NonNull
   @Keep
   protected native String nativeGetUrl();
 
@@ -295,7 +294,6 @@ public class GeoJsonSource extends Source {
   @Keep
   private native void nativeSetGeometry(Geometry geometry);
 
-  @NonNull
   @Keep
   private native Feature[] querySourceFeatures(Object[] filter);
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/ImageSource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/ImageSource.java
@@ -46,7 +46,7 @@ public class ImageSource extends Source {
    * @param coordinates The Latitude and Longitude of the four corners of the image
    * @param url         remote json file
    */
-  public ImageSource(String id, LatLngQuad coordinates, @NonNull URL url) {
+  public ImageSource(String id, LatLngQuad coordinates, URL url) {
     super();
     initialize(id, coordinates);
     setUrl(url);
@@ -83,7 +83,7 @@ public class ImageSource extends Source {
    *
    * @param url An Image url
    */
-  public void setUrl(@NonNull URL url) {
+  public void setUrl(URL url) {
     setUrl(url.toExternalForm());
   }
 
@@ -149,7 +149,6 @@ public class ImageSource extends Source {
   @Keep
   protected native void nativeSetUrl(String url);
 
-  @NonNull
   @Keep
   protected native String nativeGetUrl();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/RasterDemSource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/RasterDemSource.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.style.sources;
 
 import android.support.annotation.Keep;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
 
@@ -98,7 +97,6 @@ public class RasterDemSource extends Source {
   @Keep
   protected native void finalize() throws Throwable;
 
-  @NonNull
   @Keep
   protected native String nativeGetUrl();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/RasterSource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/RasterSource.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.style.sources;
 
 import android.support.annotation.Keep;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.net.URL;
@@ -97,7 +96,6 @@ public class RasterSource extends Source {
   @Keep
   protected native void finalize() throws Throwable;
 
-  @NonNull
   @Keep
   protected native String nativeGetUrl();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/Source.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/Source.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.style.sources;
 
 import android.support.annotation.Keep;
 
-import android.support.annotation.NonNull;
 import com.mapbox.mapboxsdk.utils.ThreadUtils;
 
 /**
@@ -40,7 +39,6 @@ public abstract class Source {
    *
    * @return the source id
    */
-  @NonNull
   public String getId() {
     checkThread();
     return nativeGetId();
@@ -54,7 +52,6 @@ public abstract class Source {
    *
    * @return the string representation of the attribution in html format
    */
-  @NonNull
   public String getAttribution() {
     checkThread();
     return nativeGetAttribution();
@@ -69,11 +66,9 @@ public abstract class Source {
     return nativePtr;
   }
 
-  @NonNull
   @Keep
   protected native String nativeGetId();
 
-  @NonNull
   @Keep
   protected native String nativeGetAttribution();
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/TileSet.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/TileSet.java
@@ -1,6 +1,5 @@
 package com.mapbox.mapboxsdk.style.sources;
 
-import android.support.annotation.NonNull;
 import android.support.annotation.Size;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -282,11 +281,10 @@ public class TileSet {
     this.center = center;
   }
 
-  public void setCenter(@NonNull LatLng center) {
+  public void setCenter(LatLng center) {
     this.center = new Float[] {(float) center.getLongitude(), (float) center.getLatitude()};
   }
 
-  @NonNull
   Map<String, Object> toValueObject() {
     Map<String, Object> result = new HashMap<>();
     result.put("tilejson", tilejson);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/VectorSource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/VectorSource.java
@@ -97,11 +97,9 @@ public class VectorSource extends Source {
   @Keep
   protected native void finalize() throws Throwable;
 
-  @NonNull
   @Keep
   protected native String nativeGetUrl();
 
-  @NonNull
   @Keep
   private native Feature[] querySourceFeatures(String[] sourceLayerId,
                                                Object[] filter);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/text/LocalGlyphRasterizer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/text/LocalGlyphRasterizer.java
@@ -7,7 +7,6 @@ import android.graphics.Bitmap;
 import android.graphics.PorterDuff;
 import android.graphics.Typeface;
 import android.support.annotation.Keep;
-import android.support.annotation.NonNull;
 import android.support.annotation.WorkerThread;
 
 /**
@@ -16,9 +15,7 @@ import android.support.annotation.WorkerThread;
  */
 public class LocalGlyphRasterizer {
   private final Bitmap bitmap;
-  @NonNull
   private final Paint paint;
-  @NonNull
   private final Canvas canvas;
 
   LocalGlyphRasterizer() {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/AnimatorUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/AnimatorUtils.java
@@ -35,7 +35,7 @@ public class AnimatorUtils {
    * @param duration    the duration of the animator
    * @param listener    the animator end listener
    */
-  public static void animate(@Nullable final View view, @AnimatorRes int animatorRes, int duration,
+  public static void animate(final View view, @AnimatorRes int animatorRes, int duration,
                              @Nullable final OnAnimationEndListener listener) {
     if (view == null) {
       return;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/BitmapUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/BitmapUtils.java
@@ -7,7 +7,6 @@ import android.graphics.Canvas;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.view.View;
 
 import java.io.ByteArrayOutputStream;
@@ -59,8 +58,7 @@ public class BitmapUtils {
    * @param sourceDrawable The source drawable
    * @return The underlying bitmap
    */
-  @Nullable
-  public static Bitmap getBitmapFromDrawable(@Nullable Drawable sourceDrawable) {
+  public static Bitmap getBitmapFromDrawable(Drawable sourceDrawable) {
     if (sourceDrawable == null) {
       return null;
     }
@@ -90,8 +88,7 @@ public class BitmapUtils {
    * @param drawable The source drawable
    * @return The byte array of source drawable
    */
-  @Nullable
-  public static byte[] getByteArrayFromDrawable(@Nullable Drawable drawable) {
+  public static byte[] getByteArrayFromDrawable(Drawable drawable) {
     if (drawable == null) {
       return null;
     }
@@ -112,8 +109,7 @@ public class BitmapUtils {
    * @param array   The source byte array
    * @return The drawable created from source byte array
    */
-  @Nullable
-  public static Drawable getDrawableFromByteArray(@NonNull Context context, @Nullable byte[] array) {
+  public static Drawable getDrawableFromByteArray(Context context, byte[] array) {
     if (array == null) {
       return null;
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/ColorUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/ColorUtils.java
@@ -126,7 +126,7 @@ public class ColorUtils {
    * @throws ConversionException on illegal input
    */
   @ColorInt
-  public static int rgbaToColor(@NonNull String value) {
+  public static int rgbaToColor(String value) {
     Pattern c = Pattern.compile("rgba?\\s*\\(\\s*(\\d+\\.?\\d*)\\s*,\\s*(\\d+\\.?\\d*)\\s*,\\s*(\\d+\\.?\\d*)\\s*,"
       + "?\\s*(\\d+\\.?\\d*)?\\s*\\)");
     Matcher m = c.matcher(value);
@@ -193,7 +193,7 @@ public class ColorUtils {
     };
   }
 
-  private static int getColorCompat(@NonNull Context context, int id) {
+  private static int getColorCompat(Context context, int id) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       return context.getResources().getColor(id, context.getTheme());
     } else {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/FileUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/FileUtils.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.utils;
 
 import android.os.AsyncTask;
-import android.support.annotation.NonNull;
 
 import java.io.File;
 import java.lang.ref.WeakReference;
@@ -12,7 +11,6 @@ public class FileUtils {
    * Task checking whether app's process can read a file.
    */
   public static class CheckFileReadPermissionTask extends AsyncTask<File, Void, Boolean> {
-    @NonNull
     private final WeakReference<OnCheckFileReadPermissionListener> listenerWeakReference;
 
     public CheckFileReadPermissionTask(OnCheckFileReadPermissionListener listener) {
@@ -69,7 +67,6 @@ public class FileUtils {
    * Task checking whether app's process can write to a file.
    */
   public static class CheckFileWritePermissionTask extends AsyncTask<File, Void, Boolean> {
-    @NonNull
     private final WeakReference<OnCheckFileWritePermissionListener> listenerWeakReference;
 
     public CheckFileWritePermissionTask(OnCheckFileWritePermissionListener listener) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/MapFragmentUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/MapFragmentUtils.java
@@ -3,8 +3,6 @@ package com.mapbox.mapboxsdk.utils;
 import android.content.Context;
 import android.os.Bundle;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
 
@@ -23,7 +21,6 @@ public class MapFragmentUtils {
    * @param options The MapboxMapOptions to convert
    * @return a bundle of converted fragment arguments
    */
-  @NonNull
   public static Bundle createFragmentArgs(MapboxMapOptions options) {
     Bundle bundle = new Bundle();
     bundle.putParcelable(MapboxConstants.FRAG_ARG_MAPBOXMAPOPTIONS, options);
@@ -37,8 +34,7 @@ public class MapFragmentUtils {
    * @param args    The fragment arguments
    * @return converted MapboxMapOptions
    */
-  @Nullable
-  public static MapboxMapOptions resolveArgs(@NonNull Context context, @Nullable Bundle args) {
+  public static MapboxMapOptions resolveArgs(Context context, Bundle args) {
     MapboxMapOptions options;
     if (args != null && args.containsKey(MapboxConstants.FRAG_ARG_MAPBOXMAPOPTIONS)) {
       options = args.getParcelable(MapboxConstants.FRAG_ARG_MAPBOXMAPOPTIONS);

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/annotations/AnnotationTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/annotations/AnnotationTest.java
@@ -1,6 +1,5 @@
 package com.mapbox.mapboxsdk.annotations;
 
-import android.support.annotation.NonNull;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 
 import org.junit.Before;
@@ -21,7 +20,6 @@ public class AnnotationTest {
   @InjectMocks
   private MapboxMap mapboxMap = mock(MapboxMap.class);
   private Annotation annotation;
-  @NonNull
   private Annotation compare = new Annotation() {
     @Override
     public long getId() {

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentOptionsTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentOptionsTest.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 
-import android.support.annotation.NonNull;
 import com.mapbox.mapboxsdk.R;
 
 import org.junit.Before;
@@ -28,7 +27,6 @@ public class LocationComponentOptionsTest {
   @Mock
   private Resources resources;
 
-  @NonNull
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationLayerControllerTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationLayerControllerTest.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.location;
 
 import android.graphics.Bitmap;
 
-import android.support.annotation.NonNull;
 import com.google.gson.JsonElement;
 import com.mapbox.geojson.Feature;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -443,13 +442,13 @@ public class LocationLayerControllerTest {
     verify(locationFeature, times(0)).addNumberProperty(PROPERTY_ACCURACY_RADIUS, accuracyRadiusValue);
   }
 
-  private LayerFeatureProvider buildFeatureProvider(@NonNull LocationComponentOptions options) {
+  private LayerFeatureProvider buildFeatureProvider(LocationComponentOptions options) {
     LayerFeatureProvider provider = mock(LayerFeatureProvider.class);
     when(provider.generateLocationFeature(null, options)).thenReturn(mock(Feature.class));
     return provider;
   }
 
-  private LayerFeatureProvider buildFeatureProvider(Feature feature, @NonNull LocationComponentOptions options) {
+  private LayerFeatureProvider buildFeatureProvider(Feature feature, LocationComponentOptions options) {
     LayerFeatureProvider provider = mock(LayerFeatureProvider.class);
     when(provider.generateLocationFeature(null, options)).thenReturn(feature);
     return provider;

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/MapboxMapTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/MapboxMapTest.java
@@ -1,6 +1,5 @@
 package com.mapbox.mapboxsdk.maps;
 
-import android.support.annotation.Nullable;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
@@ -12,7 +11,6 @@ import static org.mockito.Mockito.mock;
 
 public class MapboxMapTest {
 
-  @Nullable
   private MapboxMap mapboxMap;
 
   @Before

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/utils/MockParcel.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/utils/MockParcel.java
@@ -4,7 +4,6 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 
-import android.support.annotation.Nullable;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -29,12 +28,10 @@ import static org.mockito.Mockito.when;
 
 public class MockParcel {
 
-  @Nullable
   public static Parcelable obtain(@NonNull Parcelable object) {
     return obtain(object, 0);
   }
 
-  @Nullable
   public static Parcelable obtain(@NonNull Parcelable object, int describeContentsValue) {
     testDescribeContents(object, describeContentsValue);
     testParcelableArray(object);
@@ -169,56 +166,48 @@ public class MockParcel {
 
     private void setupReads() {
       when(mockedParcel.readInt()).then(new Answer<Integer>() {
-        @NonNull
         @Override
         public Integer answer(InvocationOnMock invocation) throws Throwable {
           return (Integer) objects.get(position++);
         }
       });
       when(mockedParcel.readByte()).thenAnswer(new Answer<Byte>() {
-        @NonNull
         @Override
         public Byte answer(InvocationOnMock invocation) throws Throwable {
           return (Byte) objects.get(position++);
         }
       });
       when(mockedParcel.readLong()).thenAnswer(new Answer<Long>() {
-        @NonNull
         @Override
         public Long answer(InvocationOnMock invocation) throws Throwable {
           return (Long) objects.get(position++);
         }
       });
       when(mockedParcel.readString()).thenAnswer(new Answer<String>() {
-        @NonNull
         @Override
         public String answer(InvocationOnMock invocation) throws Throwable {
           return (String) objects.get(position++);
         }
       });
       when(mockedParcel.readDouble()).thenAnswer(new Answer<Double>() {
-        @NonNull
         @Override
         public Double answer(InvocationOnMock invocation) throws Throwable {
           return (Double) objects.get(position++);
         }
       });
       when(mockedParcel.readFloat()).thenAnswer(new Answer<Float>() {
-        @NonNull
         @Override
         public Float answer(InvocationOnMock invocation) throws Throwable {
           return (Float) objects.get(position++);
         }
       });
       when(mockedParcel.readParcelable(Parcelable.class.getClassLoader())).thenAnswer(new Answer<Parcelable>() {
-        @NonNull
         @Override
         public Parcelable answer(InvocationOnMock invocation) throws Throwable {
           return (Parcelable) objects.get(position++);
         }
       });
       when(mockedParcel.readParcelableArray(Parcelable.class.getClassLoader())).thenAnswer(new Answer<Object[]>() {
-        @NonNull
         @Override
         public Object[] answer(InvocationOnMock invocation) throws Throwable {
           int size = (Integer) objects.get(position++);
@@ -235,7 +224,6 @@ public class MockParcel {
         }
       });
       when(mockedParcel.createIntArray()).then(new Answer<int[]>() {
-        @Nullable
         @Override
         public int[] answer(InvocationOnMock invocation) throws Throwable {
           int size = (Integer) objects.get(position++);
@@ -255,9 +243,8 @@ public class MockParcel {
 
     private void setupOthers() {
       doAnswer(new Answer<Void>() {
-        @Nullable
         @Override
-        public Void answer(@NonNull InvocationOnMock invocation) throws Throwable {
+        public Void answer(InvocationOnMock invocation) throws Throwable {
           position = ((Integer) invocation.getArguments()[0]);
           return null;
         }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/utils/OnMapReadyIdlingResource.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/utils/OnMapReadyIdlingResource.java
@@ -3,7 +3,6 @@ package com.mapbox.mapboxsdk.testapp.utils;
 import android.app.Activity;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.NonNull;
 import android.support.annotation.WorkerThread;
 import android.support.test.espresso.IdlingResource;
 
@@ -51,7 +50,7 @@ public class OnMapReadyIdlingResource implements IdlingResource, OnMapReadyCallb
   }
 
   @Override
-  public void onMapReady(@NonNull MapboxMap mapboxMap) {
+  public void onMapReady(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
     if (resourceCallback != null) {
       resourceCallback.onTransitionToIdle();

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/MarkerViewsInRectangleActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/MarkerViewsInRectangleActivity.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.testapp.activity.annotation;
 
 import android.graphics.RectF;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.Toast;
@@ -44,7 +43,7 @@ public class MarkerViewsInRectangleActivity extends AppCompatActivity implements
   }
 
   @Override
-  public void onMapReady(@NonNull MapboxMap mapboxMap) {
+  public void onMapReady(MapboxMap mapboxMap) {
     MarkerViewsInRectangleActivity.this.mapboxMap = mapboxMap;
     selectionBox.setOnClickListener(this);
     mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(52.0907, 5.1214), 16));

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/PolygonActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/PolygonActivity.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.testapp.activity.annotation;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -75,7 +74,7 @@ public class PolygonActivity extends AppCompatActivity implements OnMapReadyCall
   }
 
   @Override
-  public void onMapReady(@NonNull MapboxMap map) {
+  public void onMapReady(MapboxMap map) {
     mapboxMap = map;
 
     map.setOnPolygonClickListener(polygon -> Toast.makeText(

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraAnimationTypeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraAnimationTypeActivity.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.testapp.activity.camera;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.Toast;
@@ -63,7 +62,7 @@ public class CameraAnimationTypeActivity extends AppCompatActivity implements On
   }
 
   @Override
-  public void onMapReady(@NonNull MapboxMap map) {
+  public void onMapReady(MapboxMap map) {
     mapboxMap = map;
     mapboxMap.getUiSettings().setAttributionEnabled(false);
     mapboxMap.getUiSettings().setLogoEnabled(false);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraAnimatorActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraAnimatorActivity.java
@@ -5,7 +5,6 @@ import android.animation.AnimatorSet;
 import android.animation.TypeEvaluator;
 import android.animation.ValueAnimator;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.v4.util.LongSparseArray;
 import android.support.v4.view.animation.FastOutLinearInInterpolator;
 import android.support.v4.view.animation.FastOutSlowInInterpolator;
@@ -79,7 +78,7 @@ public class CameraAnimatorActivity extends AppCompatActivity implements OnMapRe
   }
 
   @Override
-  public void onMapReady(@NonNull final MapboxMap map) {
+  public void onMapReady(final MapboxMap map) {
     mapboxMap = map;
     initFab();
   }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/GestureDetectorActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/GestureDetectorActivity.java
@@ -5,7 +5,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.ColorInt;
 import android.support.annotation.IntDef;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
@@ -69,7 +68,7 @@ public class GestureDetectorActivity extends AppCompatActivity {
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(new OnMapReadyCallback() {
       @Override
-      public void onMapReady(@NonNull MapboxMap mapboxMap) {
+      public void onMapReady(MapboxMap mapboxMap) {
         GestureDetectorActivity.this.mapboxMap = mapboxMap;
         initializeMap();
       }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/MaxMinZoomActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/MaxMinZoomActivity.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.testapp.activity.camera;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 
 import com.mapbox.mapboxsdk.constants.Style;
@@ -32,7 +31,7 @@ public class MaxMinZoomActivity extends AppCompatActivity implements OnMapReadyC
   }
 
   @Override
-  public void onMapReady(@NonNull final MapboxMap map) {
+  public void onMapReady(final MapboxMap map) {
     mapboxMap = map;
     mapboxMap.setMinZoomPreference(3);
     mapboxMap.setMaxZoomPreference(5);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/ScrollByActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/ScrollByActivity.java
@@ -60,7 +60,7 @@ public class ScrollByActivity extends AppCompatActivity implements OnMapReadyCal
   }
 
   @Override
-  public void onMapReady(@NonNull MapboxMap map) {
+  public void onMapReady(MapboxMap map) {
     mapboxMap = map;
     UiSettings uiSettings = mapboxMap.getUiSettings();
     uiSettings.setLogoEnabled(false);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/espresso/DeviceIndependentTestActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/espresso/DeviceIndependentTestActivity.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.testapp.activity.espresso;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
@@ -25,7 +24,7 @@ public class DeviceIndependentTestActivity extends AppCompatActivity implements 
   }
 
   @Override
-  public void onMapReady(@NonNull MapboxMap map) {
+  public void onMapReady(MapboxMap map) {
     mapboxMap = map;
   }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/espresso/EspressoTestActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/espresso/EspressoTestActivity.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.testapp.activity.espresso;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 
 import com.mapbox.mapboxsdk.maps.MapView;
@@ -29,7 +28,7 @@ public class EspressoTestActivity extends AppCompatActivity implements OnMapRead
   }
 
   @Override
-  public void onMapReady(@NonNull MapboxMap map) {
+  public void onMapReady(MapboxMap map) {
     mapboxMap = map;
   }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/MapFragmentActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/MapFragmentActivity.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.testapp.activity.fragment;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
@@ -69,7 +68,7 @@ public class MapFragmentActivity extends AppCompatActivity implements MapFragmen
   }
 
   @Override
-  public void onMapReady(@NonNull MapboxMap map) {
+  public void onMapReady(MapboxMap map) {
     mapboxMap = map;
   }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/SupportMapFragmentActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/SupportMapFragmentActivity.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.testapp.activity.fragment;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
@@ -70,7 +69,7 @@ public class SupportMapFragmentActivity extends AppCompatActivity implements Map
   }
 
   @Override
-  public void onMapReady(@NonNull MapboxMap map) {
+  public void onMapReady(MapboxMap map) {
     mapboxMap = map;
   }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/imagegenerator/SnapshotActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/imagegenerator/SnapshotActivity.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.testapp.activity.imagegenerator;
 
 import android.graphics.Bitmap;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
@@ -39,7 +38,7 @@ public class SnapshotActivity extends AppCompatActivity implements OnMapReadyCal
   }
 
   @Override
-  public void onMapReady(@NonNull MapboxMap map) {
+  public void onMapReady(MapboxMap map) {
     mapboxMap = map;
     mapboxMap.setStyleUrl(Style.OUTDOORS);
     FloatingActionButton fab = (FloatingActionButton) findViewById(R.id.fab);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/infowindow/DynamicInfoWindowAdapterActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/infowindow/DynamicInfoWindowAdapterActivity.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.testapp.activity.infowindow;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.v4.content.res.ResourcesCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.widget.TextView;
@@ -41,7 +40,7 @@ public class DynamicInfoWindowAdapterActivity extends AppCompatActivity implemen
   }
 
   @Override
-  public void onMapReady(@NonNull MapboxMap map) {
+  public void onMapReady(MapboxMap map) {
     mapboxMap = map;
 
     // Add info window adapter

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationMapChangeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationMapChangeActivity.java
@@ -75,7 +75,7 @@ public class LocationMapChangeActivity extends AppCompatActivity implements OnMa
   }
 
   @Override
-  public void onMapReady(@NonNull MapboxMap mapboxMap) {
+  public void onMapReady(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
     activateLocationComponent();
   }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationModesActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationModesActivity.java
@@ -131,7 +131,7 @@ public class LocationModesActivity extends AppCompatActivity implements OnMapRea
 
   @SuppressLint("MissingPermission")
   @Override
-  public void onMapReady(@NonNull MapboxMap mapboxMap) {
+  public void onMapReady(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
 
     locationEngine = new LocationEngineProvider(this).obtainBestLocationEngineAvailable();

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/ManualLocationUpdatesActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/ManualLocationUpdatesActivity.java
@@ -115,7 +115,7 @@ public class ManualLocationUpdatesActivity extends AppCompatActivity implements 
   }
 
   @Override
-  public void onMapReady(@NonNull MapboxMap mapboxMap) {
+  public void onMapReady(MapboxMap mapboxMap) {
     locationEngine = new LocationEngineProvider(this).obtainBestLocationEngineAvailable();
     locationEngine.addLocationEngineListener(this);
     locationEngine.setPriority(LocationEnginePriority.HIGH_ACCURACY);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/BottomSheetActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/BottomSheetActivity.java
@@ -152,7 +152,7 @@ public class BottomSheetActivity extends AppCompatActivity {
     }
 
     @Override
-    public void onMapReady(@NonNull MapboxMap mapboxMap) {
+    public void onMapReady(MapboxMap mapboxMap) {
       mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(37.760545, -122.436055), 15));
     }
 
@@ -227,7 +227,7 @@ public class BottomSheetActivity extends AppCompatActivity {
     }
 
     @Override
-    public void onMapReady(@NonNull MapboxMap mapboxMap) {
+    public void onMapReady(MapboxMap mapboxMap) {
       mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(37.760545, -122.436055), 15));
     }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.testapp.activity.maplayout;
 
 import android.content.Context;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBar;
@@ -95,7 +94,7 @@ public class DebugModeActivity extends AppCompatActivity implements OnMapReadyCa
   }
 
   @Override
-  public void onMapReady(@NonNull MapboxMap map) {
+  public void onMapReady(MapboxMap map) {
     mapboxMap = map;
     mapboxMap.getUiSettings().setZoomControlsEnabled(true);
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/LatLngBoundsForCameraActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/LatLngBoundsForCameraActivity.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.testapp.activity.maplayout;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 import android.view.Gravity;
 import android.view.View;
@@ -40,7 +39,7 @@ public class LatLngBoundsForCameraActivity extends AppCompatActivity implements 
   }
 
   @Override
-  public void onMapReady(@NonNull MapboxMap mapboxMap) {
+  public void onMapReady(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
     mapboxMap.setLatLngBoundsForCameraTarget(ICELAND_BOUNDS);
     mapboxMap.setMinZoomPreference(2);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/GradientLineActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/GradientLineActivity.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.testapp.activity.style;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
@@ -49,7 +48,7 @@ public class GradientLineActivity extends AppCompatActivity implements OnMapRead
   }
 
   @Override
-  public void onMapReady(@NonNull MapboxMap map) {
+  public void onMapReady(MapboxMap map) {
     this.mapboxMap = map;
 
     try {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/SymbolGeneratorActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/SymbolGeneratorActivity.java
@@ -87,7 +87,7 @@ public class SymbolGeneratorActivity extends AppCompatActivity implements OnMapR
   }
 
   @Override
-  public void onMapReady(@NonNull final MapboxMap map) {
+  public void onMapReady(final MapboxMap map) {
     mapboxMap = map;
     addSymbolClickListener();
     new LoadDataTask(this).execute();

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/SymbolLayerActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/SymbolLayerActivity.java
@@ -89,7 +89,7 @@ public class SymbolLayerActivity extends AppCompatActivity implements MapboxMap.
   }
 
   @Override
-  public void onMapReady(@NonNull MapboxMap mapboxMap) {
+  public void onMapReady(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
 
     // Add a sdf image for the makers

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/textureview/TextureViewDebugModeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/textureview/TextureViewDebugModeActivity.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.testapp.activity.textureview;
 
 import android.content.Context;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBar;
@@ -95,7 +94,7 @@ public class TextureViewDebugModeActivity extends AppCompatActivity implements O
   }
 
   @Override
-  public void onMapReady(@NonNull MapboxMap map) {
+  public void onMapReady(MapboxMap map) {
     mapboxMap = map;
     mapboxMap.getUiSettings().setZoomControlsEnabled(true);
 


### PR DESCRIPTION
This PR reverts https://github.com/mapbox/mapbox-gl-native/pull/13071, that PR breaked SemVer when consuming our library from kotlin code (kotlin uses `@NonNull` and `@Nullable` annotations to determine the type of an object). We will be revisiting this again with an upcoming SemVer release.
.