### PR TITLE
[ios][documentation] two-way link delegate methods and relevant classes

### DIFF
--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -130,10 +130,10 @@ FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLResourceNotFoundException
  your Mapbox account. They also deter other developers from using your styles
  without your permission.
  
- Because `MGLMapView` loads asynchronously, several delegate methods are available
- for receiving map-related updates. These methods can be ensure that certain operations
- have completed before taking any action. Information on these methods can be found in
-`MGLMapViewDelegate` protocol documentation.
+ Because `MGLMapView` loads asynchronously, several delegate methods are available 
+ for receiving map-related updates. These methods can be used to ensure that certain operations
+ have completed before taking any additional actions. Information on these methods is located
+ in the `MGLMapViewDelegate` protocol documentation.
 
  Adding your own gesture recognizer to `MGLMapView` will block the corresponding
  gesture recognizer built into `MGLMapView`. To avoid conflicts, define which

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -129,6 +129,10 @@ FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLResourceNotFoundException
  Access tokens associate requests to Mapbox’s vector tile and style APIs with
  your Mapbox account. They also deter other developers from using your styles
  without your permission.
+ 
+ Because `MGLMapView` loads asynchronously, sever delegate methods are available
+ for receiving map-related updates. Information on these methods can be found in
+`MGLMapViewDelegate` protocol documentation.
 
  Adding your own gesture recognizer to `MGLMapView` will block the corresponding
  gesture recognizer built into `MGLMapView`. To avoid conflicts, define which

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -130,8 +130,9 @@ FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLResourceNotFoundException
  your Mapbox account. They also deter other developers from using your styles
  without your permission.
  
- Because `MGLMapView` loads asynchronously, sever delegate methods are available
- for receiving map-related updates. Information on these methods can be found in
+ Because `MGLMapView` loads asynchronously, several delegate methods are available
+ for receiving map-related updates. These methods can be ensure that certain operations
+ have completed before taking any action. Information on these methods can be found in
 `MGLMapViewDelegate` protocol documentation.
 
  Adding your own gesture recognizer to `MGLMapView` will block the corresponding


### PR DESCRIPTION
Closes #13110

This update adds two-way linking between all delegate methods and the classes they can be used with to iOS's API documentation. This is necessary in order to make it clearer when delegate methods are available for use with a given class. 

More info in the original ticket.