### PR TITLE
Remove shell command when activating google cloud 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -311,7 +311,6 @@ commands:
     steps:
     - run:
         name: Log in to Google Cloud Platform
-        shell: /bin/bash -euo pipefail
         command: |
           if [[ -n "${GCLOUD_SERVICE_ACCOUNT_JSON}" && -z "${SKIP_FIREBASE:-}" ]]; then
             echo "${GCLOUD_SERVICE_ACCOUNT_JSON}" > secret.json


### PR DESCRIPTION
My changes in https://github.com/mapbox/mapbox-gl-native/pull/12496/files have regressed and were added again when restructuring the circle configuration file. having `shell: /bin/bash -euo pipefail` results in running into an unbound variable issue when we try to check if a circle ci variable is availble for an external PR (we don't allow running firebase for those).