### PR TITLE
[build] Show ccache stats on CircleCI again

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -220,7 +220,7 @@ commands:
           steps: [ save-node_modules-cache ]
       - when:
           condition: << parameters.ccache >>
-          steps: [ save-ccache ]
+          steps: [ save-ccache, show-ccache-stats ]
       - when:
           condition: << parameters.mason >>
           steps: [ save-mason_packages-cache ]


### PR DESCRIPTION
Follows-up on #12993 to re-add the “Show ccache statistics” step to CircleCI jobs.

/cc @kkaefer 