### PR TITLE
[darwin, build] Fix RelWithDebInfo name in cmake Xcode config

### DIFF
--- a/cmake/mbgl.cmake
+++ b/cmake/mbgl.cmake
@@ -209,7 +209,7 @@ function(initialize_xcode_cxx_build_settings target)
     set_xcode_property(${target} CLANG_WARN_RANGE_LOOP_ANALYSIS YES)
 
     # -flto
-    set_xcode_property(${target} LLVM_LTO $<$<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebugInfo>>:YES>)
+    set_xcode_property(${target} LLVM_LTO $<$<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>:YES>)
 
     # Make releases debuggable.
     set_xcode_property(${target} GCC_GENERATE_DEBUGGING_SYMBOLS YES)


### PR DESCRIPTION
Fixes a typo in #12502 that misnamed the `RelWithDebInfo` config when setting LTO in the Xcode project via cmake.

/cc @kkaefer