### PR TITLE
[build] Update CircleCI jobs to Xcode 10.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -38,12 +38,7 @@ workflows:
       - linux-gcc49-debug:
           name: linux-gcc4.9-debug
       - linux-gcc5-debug-coverage
-      - ios-debug-template:
-          name: ios-debug
-          xcode: "9.4.1"
-      - ios-debug-template:
-          name: ios-debug-xcode10
-          xcode: "10.0.0"
+      - ios-debug
       - ios-release-template:
           name: ios-release
       - ios-release-tag:
@@ -678,7 +673,7 @@ jobs:
 # ------------------------------------------------------------------------------
   node-macos-release:
     macos:
-      xcode: "9.4.1"
+      xcode: "10.0.0"
     environment:
       BUILDTYPE: RelWithDebInfo
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -834,12 +829,9 @@ jobs:
             platform/linux/scripts/coveralls.sh
 
 # ------------------------------------------------------------------------------
-  ios-debug-template:
-    parameters:
-      xcode:
-        type: string
+  ios-debug:
     macos:
-      xcode: << parameters.xcode >>
+      xcode: "10.0.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -865,7 +857,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-sanitize-nightly:
     macos:
-      xcode: "9.4.1"
+      xcode: "10.0.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -884,7 +876,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-sanitize-address-nightly:
     macos:
-      xcode: "9.4.1"
+      xcode: "10.0.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -903,7 +895,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-static-analyzer-nightly:
     macos:
-      xcode: "9.4.1"
+      xcode: "10.0.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -994,7 +986,7 @@ jobs:
 # ------------------------------------------------------------------------------
   macos-debug:
     macos:
-      xcode: "9.4.1"
+      xcode: "10.0.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1

--- a/platform/ios/Integration Tests/MBGLIntegrationTests.m
+++ b/platform/ios/Integration Tests/MBGLIntegrationTests.m
@@ -8,7 +8,7 @@
 #pragma mark - Tests
 
 - (void)waitForMapViewToBeRendered {
-    [self waitForMapViewToBeRenderedWithTimeout:5];
+    [self waitForMapViewToBeRenderedWithTimeout:10];
 }
 
 // This test does not strictly need to be in this test file/target. Including here for convenience.

--- a/platform/ios/Integration Tests/MGLCameraTransitionTests.mm
+++ b/platform/ios/Integration Tests/MGLCameraTransitionTests.mm
@@ -34,7 +34,7 @@
     [self.mapView setDirection:90 animated:YES];
 
     // loop, render, and wait
-    [self waitForExpectations:@[expectation] timeout:5];
+    [self waitForExpectations:@[expectation] timeout:10];
 }
 
 
@@ -62,7 +62,7 @@
     };
 
     [self.mapView setDirection:90 animated:YES];
-    [self waitForExpectations:@[expectation] timeout:5];
+    [self waitForExpectations:@[expectation] timeout:10];
 }
 
 - (void)testInterruptingAndResetNorthOnlyOnceInIsChanging {
@@ -106,7 +106,7 @@
     };
 
     [self.mapView setDirection:90 animated:YES];
-    [self waitForExpectations:@[expectation] timeout:5];
+    [self waitForExpectations:@[expectation] timeout:10];
 
     XCTAssertEqualWithAccuracy(self.mapView.direction, 0.0, 0.001, @"Camera should have reset to north. %0.3f", self.mapView.direction);
 }
@@ -222,7 +222,7 @@
 
     // Should take MGLAnimationDuration seconds (0.3)
     [self.mapView setCenterCoordinate:target zoomLevel:15.0 animated:YES];
-    [self waitForExpectations:@[expectation] timeout:5];
+    [self waitForExpectations:@[expectation] timeout:10];
 }
 
 - (void)testFlyToCameraInDelegateMethod {
@@ -323,7 +323,7 @@
     // Should take MGLAnimationDuration
     [self.mapView setCenterCoordinate:target zoomLevel:zoomLevel animated:YES];
 
-    [self waitForExpectations:@[expectation] timeout:5];
+    [self waitForExpectations:@[expectation] timeout:10];
 
     NSLog(@"setCenterCoordinate: %0.4fs", stop1 - stop0);
     NSLog(@"flyToCamera: %0.4fs", stop2 - stop1);
@@ -360,7 +360,7 @@
     };
 
     [self.mapView setDirection:90 animated:YES];
-    [self waitForExpectations:@[expectation] timeout:5];
+    [self waitForExpectations:@[expectation] timeout:10];
 
     XCTAssertEqualWithAccuracy(self.mapView.direction, 0.0, 0.001, @"Camera should have reset to north. %0.3f", self.mapView.direction);
 }
@@ -386,7 +386,7 @@
     };
 
     [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(40.0, 40.0) animated:YES];
-    [self waitForExpectations:@[expectation] timeout:5];
+    [self waitForExpectations:@[expectation] timeout:10];
 
     XCTAssertEqualWithAccuracy(self.mapView.direction, 0.0, 0.001, @"Camera should have reset to north. %0.3f", self.mapView.direction);
 }

--- a/platform/ios/Integration Tests/MGLStyleLayerIntegrationTests.m
+++ b/platform/ios/Integration Tests/MGLStyleLayerIntegrationTests.m
@@ -37,7 +37,7 @@
     XCTAssertThrowsSpecificNamed((layer.circleColor = interpExpression), NSException, NSInvalidArgumentException);
 
     [self.mapView.style addLayer:layer];
-    [self waitForMapViewToBeRenderedWithTimeout:5];
+    [self waitForMapViewToBeRenderedWithTimeout:10];
 }
 
 - (void)testForSteppingExpressionRenderCrashWithEmptyStops {
@@ -55,7 +55,7 @@
     XCTAssertThrowsSpecificNamed((layer.circleColor = steppingExpression), NSException, NSInvalidArgumentException);
 
     [self.mapView.style addLayer:layer];
-    [self waitForMapViewToBeRenderedWithTimeout:5];
+    [self waitForMapViewToBeRenderedWithTimeout:10];
 }
 
 @end

--- a/platform/ios/Integration Tests/Snapshotter Tests/MGLMapSnapshotterSwiftTests.swift
+++ b/platform/ios/Integration Tests/Snapshotter Tests/MGLMapSnapshotterSwiftTests.swift
@@ -22,7 +22,7 @@ class MGLMapSnapshotterSwiftTests: MGLMapViewIntegrationTest {
             return
         }
 
-        let timeout: TimeInterval = 5.0
+        let timeout: TimeInterval = 10.0
         let expectation = self.expectation(description: "snapshot")
 
         let options = MGLMapSnapshotterSwiftTests.snapshotterOptions(size: mapView.bounds.size)

--- a/platform/ios/Integration Tests/Snapshotter Tests/MGLMapSnapshotterTest.m
+++ b/platform/ios/Integration Tests/Snapshotter Tests/MGLMapSnapshotterTest.m
@@ -66,7 +66,7 @@ MGLMapSnapshotter* snapshotterWithCoordinates(CLLocationCoordinate2D coordinates
         return;
     }
 
-    NSTimeInterval timeout         = 5.0;
+    NSTimeInterval timeout         = 10.0;
     XCTestExpectation *expectation = [self expectationWithDescription:@"snapshot"];
     CGSize size                    = self.mapView.bounds.size;
     CLLocationCoordinate2D coord   = CLLocationCoordinate2DMake(30.0, 30.0);
@@ -118,7 +118,7 @@ MGLMapSnapshotter* snapshotterWithCoordinates(CLLocationCoordinate2D coordinates
         return;
     }
 
-    NSTimeInterval timeout         = 5.0;
+    NSTimeInterval timeout         = 10.0;
     XCTestExpectation *expectation = [self expectationWithDescription:@"snapshot"];
     CGSize size                    = self.mapView.bounds.size;
     CLLocationCoordinate2D coord   = CLLocationCoordinate2DMake(30.0, 30.0);
@@ -186,7 +186,7 @@ MGLMapSnapshotter* snapshotterWithCoordinates(CLLocationCoordinate2D coordinates
 
     [snapshotter cancel];
 
-    [self waitForExpectations:@[expectation] timeout:0.5];
+    [self waitForExpectations:@[expectation] timeout:5.0];
 }
 
 - (void)testAllocatingSnapshotOnBackgroundQueue {
@@ -379,7 +379,7 @@ MGLMapSnapshotter* snapshotterWithCoordinates(CLLocationCoordinate2D coordinates
         [expectation fulfill];
     }];
 
-    [self waitForExpectations:@[expectation] timeout:5.0];
+    [self waitForExpectations:@[expectation] timeout:10.0];
 }
 
 - (void)testSnapshotPointConversionCoordinateOrdering {
@@ -426,7 +426,7 @@ MGLMapSnapshotter* snapshotterWithCoordinates(CLLocationCoordinate2D coordinates
         [expectation fulfill];
     }];
 
-    [self waitForExpectations:@[expectation] timeout:5.0];
+    [self waitForExpectations:@[expectation] timeout:10.0];
 }
 
 


### PR DESCRIPTION
- Updates the remaining iOS/macOS/node jobs on CircleCI to use Xcode 10, replacing the test job from #12911. Release builds had been using Xcode 10 since #12969.
- Bumps integration tests timeouts to 10 seconds, following in the grand tradition of #12978 and #13127. This will hopefully (but probably not) fix #13061.

/cc @mapbox/maps-ios 