### PR TITLE
Refine MGLLineStyleLayer.lineGradient documentation

### DIFF
--- a/platform/darwin/scripts/style-spec-overrides-v8.json
+++ b/platform/darwin/scripts/style-spec-overrides-v8.json
@@ -98,6 +98,9 @@
     }
   },
   "paint_line": {
+    "line-gradient": {
+      "doc": "The color gradient with which the line will be drawn. This property only has an effect on lines defined by an `MGLShapeSource` whose `MGLShapeSourceOptionLineDistanceMetrics` option is set to `YES`."
+    },
     "line-pattern": {
       "doc": "Name of image in style images to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512)."
     },

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -368,8 +368,9 @@ MGL_EXPORT
 
 #if TARGET_OS_IPHONE
 /**
- Defines a gradient with which to color a line feature. Can only be used with
- GeoJSON sources that specify `"lineMetrics": true`.
+ The color gradient with which the line will be drawn. This property only has an
+ effect on lines defined by an `MGLShapeSource` whose
+ `MGLShapeSourceOptionLineDistanceMetrics` option is set to `YES`.
  
  This property is only applied to the style if `lineDasharray` is set to `nil`,
  and `linePattern` is set to `nil`, and the data source requirements are met.
@@ -389,8 +390,9 @@ MGL_EXPORT
 @property (nonatomic, null_resettable) NSExpression *lineGradient;
 #else
 /**
- Defines a gradient with which to color a line feature. Can only be used with
- GeoJSON sources that specify `"lineMetrics": true`.
+ The color gradient with which the line will be drawn. This property only has an
+ effect on lines defined by an `MGLShapeSource` whose
+ `MGLShapeSourceOptionLineDistanceMetrics` option is set to `YES`.
  
  This property is only applied to the style if `lineDasharray` is set to `nil`,
  and `linePattern` is set to `nil`, and the data source requirements are met.


### PR DESCRIPTION
Rewrote the `MGLLineStyleLayer.lineGradient` documentation to be expressed in terms of iOS/macOS map SDK symbols instead of JSON from the style specification.

Fixes #13000.

/cc @fabian-guerra @pozdnyakov