### PR TITLE
[core] Refactor the number of concurrent http requests when downloading files

### DIFF
--- a/include/mbgl/storage/online_file_source.hpp
+++ b/include/mbgl/storage/online_file_source.hpp
@@ -24,9 +24,11 @@ public:
 
     std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
 
+    void setMaximumConcurrentRequests(uint32_t);
+    uint32_t getMaximumConcurrentRequests() const;
+
     // For testing only.
     void setOnlineStatus(bool);
-    void setMaximumConcurrentRequestsOverride(uint32_t);
 
 private:
     friend class OnlineFileRequest;

--- a/platform/android/src/http_file_source.cpp
+++ b/platform/android/src/http_file_source.cpp
@@ -188,8 +188,4 @@ std::unique_ptr<AsyncRequest> HTTPFileSource::request(const Resource& resource, 
     return std::make_unique<HTTPRequest>(*impl->env, resource, callback);
 }
 
-uint32_t HTTPFileSource::maximumConcurrentRequests() {
-    return 20;
-}
-
 } // namespace mbgl

--- a/platform/darwin/src/http_file_source.mm
+++ b/platform/darwin/src/http_file_source.mm
@@ -192,10 +192,6 @@ HTTPFileSource::HTTPFileSource()
 
 HTTPFileSource::~HTTPFileSource() = default;
 
-uint32_t HTTPFileSource::maximumConcurrentRequests() {
-    return 20;
-}
-
 std::unique_ptr<AsyncRequest> HTTPFileSource::request(const Resource& resource, Callback callback) {
     auto request = std::make_unique<HTTPRequest>(callback);
     auto shared = request->shared; // Explicit copy so that it also gets copied into the completion handler block below.

--- a/platform/default/http_file_source.cpp
+++ b/platform/default/http_file_source.cpp
@@ -492,8 +492,4 @@ std::unique_ptr<AsyncRequest> HTTPFileSource::request(const Resource& resource, 
     return std::make_unique<HTTPRequest>(impl.get(), resource, callback);
 }
 
-uint32_t HTTPFileSource::maximumConcurrentRequests() {
-    return 20;
-}
-
 } // namespace mbgl

--- a/platform/default/mbgl/storage/offline_download.cpp
+++ b/platform/default/mbgl/storage/offline_download.cpp
@@ -1,4 +1,4 @@
-#include <mbgl/storage/file_source.hpp>
+#include <mbgl/storage/online_file_source.hpp>
 #include <mbgl/storage/offline_database.hpp>
 #include <mbgl/storage/offline_download.hpp>
 #include <mbgl/storage/resource.hpp>
@@ -84,7 +84,7 @@ uint64_t tileCount(const OfflineRegionDefinition& definition, style::SourceType 
 OfflineDownload::OfflineDownload(int64_t id_,
                                  OfflineRegionDefinition&& definition_,
                                  OfflineDatabase& offlineDatabase_,
-                                 FileSource& onlineFileSource_)
+                                 OnlineFileSource& onlineFileSource_)
     : id(id_),
       definition(definition_),
       offlineDatabase(offlineDatabase_),
@@ -340,7 +340,7 @@ void OfflineDownload::continueDownload() {
         return;
     }
 
-    while (!resourcesRemaining.empty() && requests.size() < HTTPFileSource::maximumConcurrentRequests()) {
+    while (!resourcesRemaining.empty() && requests.size() < onlineFileSource.getMaximumConcurrentRequests()) {
         ensureResource(resourcesRemaining.front());
         resourcesRemaining.pop_front();
     }

--- a/platform/default/mbgl/storage/offline_download.hpp
+++ b/platform/default/mbgl/storage/offline_download.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/storage/offline.hpp>
 #include <mbgl/storage/resource.hpp>
+#include <mbgl/storage/online_file_source.hpp>
 
 #include <list>
 #include <unordered_set>
@@ -27,7 +28,7 @@ class Parser;
  */
 class OfflineDownload {
 public:
-    OfflineDownload(int64_t id, OfflineRegionDefinition&&, OfflineDatabase& offline, FileSource& online);
+    OfflineDownload(int64_t id, OfflineRegionDefinition&&, OfflineDatabase& offline, OnlineFileSource& online);
     ~OfflineDownload();
 
     void setObserver(std::unique_ptr<OfflineRegionObserver>);
@@ -52,7 +53,7 @@ private:
     int64_t id;
     OfflineRegionDefinition definition;
     OfflineDatabase& offlineDatabase;
-    FileSource& onlineFileSource;
+    OnlineFileSource& onlineFileSource;
     OfflineRegionStatus status;
     std::unique_ptr<OfflineRegionObserver> observer;
 

--- a/platform/qt/src/http_file_source.cpp
+++ b/platform/qt/src/http_file_source.cpp
@@ -98,8 +98,4 @@ std::unique_ptr<AsyncRequest> HTTPFileSource::request(const Resource& resource, 
     return std::make_unique<HTTPRequest>(impl.get(), resource, callback);
 }
 
-uint32_t HTTPFileSource::maximumConcurrentRequests() {
-    return 20;
-}
-
 } // namespace mbgl

--- a/src/mbgl/storage/http_file_source.hpp
+++ b/src/mbgl/storage/http_file_source.hpp
@@ -11,8 +11,6 @@ public:
 
     std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
 
-    static uint32_t maximumConcurrentRequests();
-
     class Impl;
 
 private:

--- a/test/src/mbgl/test/fake_file_source.hpp
+++ b/test/src/mbgl/test/fake_file_source.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/storage/file_source.hpp>
+#include <mbgl/storage/online_file_source.hpp>
 
 #include <algorithm>
 #include <list>
@@ -56,6 +57,19 @@ public:
     }
 
     std::list<FakeFileRequest*> requests;
+
 };
+
+class FakeOnlineFileSource : public OnlineFileSource, public FakeFileSource {
+public:
+    std::unique_ptr<AsyncRequest> request(const Resource& resource, Callback callback) override {
+        return FakeFileSource::request(resource, callback);
+    }
+
+    bool respond(Resource::Kind kind, const Response& response) {
+        return FakeFileSource::respond(kind, response);
+    }
+};
+
 
 } // namespace mbgl

--- a/test/src/mbgl/test/stub_file_source.hpp
+++ b/test/src/mbgl/test/stub_file_source.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/storage/file_source.hpp>
+#include <mbgl/storage/online_file_source.hpp>
 #include <mbgl/util/timer.hpp>
 
 #include <unordered_map>
@@ -37,6 +38,8 @@ public:
     ResponseFunction imageResponse;
 
 private:
+    friend class StubOnlineFileSource;
+
     // The default behavior is to throw if no per-kind callback has been set.
     optional<Response> defaultResponse(const Resource&);
 
@@ -44,5 +47,16 @@ private:
     ResponseType type;
     util::Timer timer;
 };
+
+class StubOnlineFileSource : public StubFileSource, public OnlineFileSource {
+public:
+
+    StubOnlineFileSource(ResponseType t = ResponseType::Asynchronous) : StubFileSource(t) {};
+    ~StubOnlineFileSource() override = default;
+
+    std::unique_ptr<AsyncRequest> request(const Resource& r, Callback c) override { return StubFileSource::request(r, c); };
+    void remove(AsyncRequest* r) { StubFileSource::remove(r); };
+};
+
 
 } // namespace mbgl

--- a/test/storage/offline_download.test.cpp
+++ b/test/storage/offline_download.test.cpp
@@ -61,7 +61,7 @@ public:
     }
 
     util::RunLoop loop;
-    StubFileSource fileSource;
+    StubOnlineFileSource fileSource;
     OfflineDatabase db;
     std::size_t size = 0;
 
@@ -277,8 +277,8 @@ TEST(OfflineDownload, Activate) {
 }
 
 TEST(OfflineDownload, DoesNotFloodTheFileSourceWithRequests) {
-    FakeFileSource fileSource;
     OfflineTest test;
+    FakeOnlineFileSource fileSource;
     auto region = test.createRegion();
     ASSERT_TRUE(region);
     OfflineDownload download(
@@ -297,7 +297,7 @@ TEST(OfflineDownload, DoesNotFloodTheFileSourceWithRequests) {
     fileSource.respond(Resource::Kind::Style, test.response("style.json"));
     test.loop.runOnce();
 
-    EXPECT_EQ(HTTPFileSource::maximumConcurrentRequests(), fileSource.requests.size());
+    EXPECT_EQ(fileSource.getMaximumConcurrentRequests(), fileSource.requests.size());
 }
 
 TEST(OfflineDownload, GetStatusNoResources) {

--- a/test/storage/online_file_source.test.cpp
+++ b/test/storage/online_file_source.test.cpp
@@ -517,6 +517,15 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(LowHighPriorityRequestsMany)) {
     loop.run();
 }
 
+TEST(OnlineFileSource, TEST_REQUIRES_SERVER(MaximumConcurrentRequests)) {
+    util::RunLoop loop;
+    OnlineFileSource fs;
+
+    ASSERT_EQ(fs.getMaximumConcurrentRequests(), 20u);
+
+    fs.setMaximumConcurrentRequests(10);
+    ASSERT_EQ(fs.getMaximumConcurrentRequests(), 10u);
+}
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RequestSameUrlMultipleTimes)) {
     util::RunLoop loop;
     OnlineFileSource fs;

--- a/test/storage/online_file_source.test.cpp
+++ b/test/storage/online_file_source.test.cpp
@@ -433,7 +433,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(LowHighPriorityRequests)) {
     std::size_t response_counter = 0;
     const std::size_t NUM_REQUESTS = 3;
 
-    fs.setMaximumConcurrentRequestsOverride(1);
+    fs.setMaximumConcurrentRequests(1);
 
     NetworkStatus::Set(NetworkStatus::Status::Offline);
 
@@ -473,7 +473,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(LowHighPriorityRequestsMany)) {
     int correct_regular = 0;
 
 
-    fs.setMaximumConcurrentRequestsOverride(1);
+    fs.setMaximumConcurrentRequests(1);
 
     NetworkStatus::Set(NetworkStatus::Status::Offline);
 


### PR DESCRIPTION
Working towards https://github.com/mapbox/mapbox-gl-native/issues/13130

> Proposal
> Instead of a static function in HTTPFileSource the number of concurrent requests should be a member variable in either FileSource or OnlineFileSource.

## Todos

- [x] Implement
- [x] Prepare for review
     - [x] clean up commits and their messages
- [ ] add changelog