### PR TITLE
Consolidate `style::Layer` properties API

### DIFF
--- a/include/mbgl/style/layer.hpp
+++ b/include/mbgl/style/layer.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/peer.hpp>
 #include <mbgl/util/immutable.hpp>
 #include <mbgl/util/optional.hpp>
@@ -27,6 +26,7 @@ class CustomLayer;
 class FillExtrusionLayer;
 class HeatmapLayer;
 class LayerObserver;
+class Filter;
 
 /**
  * The runtime representation of a [layer](https://www.mapbox.com/mapbox-gl-style-spec/#layers) from the Mapbox Style
@@ -44,8 +44,11 @@ class LayerObserver;
  *
  *     auto circleLayer = std::make_unique<CircleLayer>("my-circle-layer");
  */
-class Layer : public mbgl::util::noncopyable {
+class Layer {
 public:
+    Layer(const Layer& ) = delete;
+    Layer& operator=(const Layer&) = delete;
+
     virtual ~Layer();
 
     // Check whether this layer is of the given subtype.
@@ -63,60 +66,26 @@ public:
         return is<T>() ? reinterpret_cast<const T*>(this) : nullptr;
     }
 
-    // Convenience method for dynamic dispatch on the concrete layer type. Using
-    // method overloading, this allows consolidation of logic common to vector-based
-    // layers (Fill, FillExtrusion, Line, Circle, or Symbol). For example:
-    //
-    //     struct Visitor {
-    //         void operator()(CustomLayer&) { ... }
-    //         void operator()(RasterLayer&) { ... }
-    //         void operator()(BackgroundLayer&) { ... }
-    //         template <class VectorLayer>
-    //         void operator()(VectorLayer&) { ... }
-    //     };
-    //
-    template <class V>
-    auto accept(V&& visitor) {
-        switch (getType()) {
-        case LayerType::Fill:
-            return std::forward<V>(visitor)(*as<FillLayer>());
-        case LayerType::Line:
-            return std::forward<V>(visitor)(*as<LineLayer>());
-        case LayerType::Circle:
-            return std::forward<V>(visitor)(*as<CircleLayer>());
-        case LayerType::Symbol:
-            return std::forward<V>(visitor)(*as<SymbolLayer>());
-        case LayerType::Raster:
-            return std::forward<V>(visitor)(*as<RasterLayer>());
-        case LayerType::Background:
-            return std::forward<V>(visitor)(*as<BackgroundLayer>());
-        case LayerType::Hillshade:
-            return std::forward<V>(visitor)(*as<HillshadeLayer>());
-        case LayerType::Custom:
-            return std::forward<V>(visitor)(*as<CustomLayer>());
-        case LayerType::FillExtrusion:
-            return std::forward<V>(visitor)(*as<FillExtrusionLayer>());
-        case LayerType::Heatmap:
-            return std::forward<V>(visitor)(*as<HeatmapLayer>());
-        }
-
-        // Not reachable, but placate GCC.
-        assert(false);
-        throw new std::runtime_error("unknown layer type");
-    }
-
     LayerType getType() const;
     std::string getID() const;
+    // Source
+    std::string getSourceID() const;
+    std::string getSourceLayer() const;
+    void setSourceLayer(const std::string& sourceLayer);
+
+    // Filter
+    const Filter& getFilter() const;
+    void setFilter(const Filter&);
 
     // Visibility
     VisibilityType getVisibility() const;
-    virtual void setVisibility(VisibilityType) = 0;
+    void setVisibility(VisibilityType);
 
     // Zoom range
     float getMinZoom() const;
     float getMaxZoom() const;
-    virtual void setMinZoom(float) = 0;
-    virtual void setMaxZoom(float) = 0;
+    void setMinZoom(float);
+    void setMaxZoom(float);
 
     // Dynamic properties
     virtual optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) = 0;
@@ -124,21 +93,25 @@ public:
     optional<conversion::Error> setVisibility(const conversion::Convertible& value);
 
     // Private implementation
+    // TODO : We should not have public mutable data members.
     class Impl;
     Immutable<Impl> baseImpl;
-
-    Layer(Immutable<Impl>);
 
     // Create a layer, copying all properties except id and paint properties from this layer.
     virtual std::unique_ptr<Layer> cloneRef(const std::string& id) const = 0;
 
-    LayerObserver* observer = nullptr;
+    
     void setObserver(LayerObserver*);
 
     // For use in SDK bindings, which store a reference to a platform-native peer
     // object here, so that separately-obtained references to this object share
     // identical platform-native peers.
     util::peer peer;
+protected:
+    Layer(Immutable<Impl>);   
+    virtual Mutable<Impl> mutableBaseImpl() const = 0;
+
+    LayerObserver* observer = nullptr;
 };
 
 } // namespace style

--- a/include/mbgl/style/layers/background_layer.hpp
+++ b/include/mbgl/style/layers/background_layer.hpp
@@ -19,13 +19,6 @@ public:
     BackgroundLayer(const std::string& layerID);
     ~BackgroundLayer() final;
 
-    // Visibility
-    void setVisibility(VisibilityType) final;
-
-    // Zoom range
-    void setMinZoom(float) final;
-    void setMaxZoom(float) final;
-
     // Dynamic properties
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
@@ -58,6 +51,9 @@ public:
     Mutable<Impl> mutableImpl() const;
     BackgroundLayer(Immutable<Impl>);
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
+
+protected:
+    Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
 template <>

--- a/include/mbgl/style/layers/circle_layer.hpp
+++ b/include/mbgl/style/layers/circle_layer.hpp
@@ -19,21 +19,6 @@ public:
     CircleLayer(const std::string& layerID, const std::string& sourceID);
     ~CircleLayer() final;
 
-    // Source
-    const std::string& getSourceID() const;
-    const std::string& getSourceLayer() const;
-    void setSourceLayer(const std::string& sourceLayer);
-
-    void setFilter(const Filter&);
-    const Filter& getFilter() const;
-
-    // Visibility
-    void setVisibility(VisibilityType) final;
-
-    // Zoom range
-    void setMinZoom(float) final;
-    void setMaxZoom(float) final;
-
     // Dynamic properties
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
@@ -114,6 +99,9 @@ public:
     Mutable<Impl> mutableImpl() const;
     CircleLayer(Immutable<Impl>);
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
+
+protected:
+    Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
 template <>

--- a/include/mbgl/style/layers/custom_layer.hpp
+++ b/include/mbgl/style/layers/custom_layer.hpp
@@ -68,13 +68,6 @@ public:
 
     ~CustomLayer() final;
 
-    // Visibility
-    void setVisibility(VisibilityType) final;
-
-    // Zoom range
-    void setMinZoom(float) final;
-    void setMaxZoom(float) final;
-
     // Dynamic properties
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
@@ -88,10 +81,9 @@ public:
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
 
     CustomLayer(const CustomLayer&) = delete;
-};
 
-template <>
-bool Layer::is<CustomLayer>() const;
+    Mutable<Layer::Impl> mutableBaseImpl() const final;
+};
 
 } // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/layers/fill_extrusion_layer.hpp
+++ b/include/mbgl/style/layers/fill_extrusion_layer.hpp
@@ -19,21 +19,6 @@ public:
     FillExtrusionLayer(const std::string& layerID, const std::string& sourceID);
     ~FillExtrusionLayer() final;
 
-    // Source
-    const std::string& getSourceID() const;
-    const std::string& getSourceLayer() const;
-    void setSourceLayer(const std::string& sourceLayer);
-
-    void setFilter(const Filter&);
-    const Filter& getFilter() const;
-
-    // Visibility
-    void setVisibility(VisibilityType) final;
-
-    // Zoom range
-    void setMinZoom(float) final;
-    void setMaxZoom(float) final;
-
     // Dynamic properties
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
@@ -90,6 +75,9 @@ public:
     Mutable<Impl> mutableImpl() const;
     FillExtrusionLayer(Immutable<Impl>);
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
+
+protected:
+    Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
 template <>

--- a/include/mbgl/style/layers/fill_layer.hpp
+++ b/include/mbgl/style/layers/fill_layer.hpp
@@ -19,21 +19,6 @@ public:
     FillLayer(const std::string& layerID, const std::string& sourceID);
     ~FillLayer() final;
 
-    // Source
-    const std::string& getSourceID() const;
-    const std::string& getSourceLayer() const;
-    void setSourceLayer(const std::string& sourceLayer);
-
-    void setFilter(const Filter&);
-    const Filter& getFilter() const;
-
-    // Visibility
-    void setVisibility(VisibilityType) final;
-
-    // Zoom range
-    void setMinZoom(float) final;
-    void setMaxZoom(float) final;
-
     // Dynamic properties
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
@@ -90,6 +75,9 @@ public:
     Mutable<Impl> mutableImpl() const;
     FillLayer(Immutable<Impl>);
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
+
+protected:
+    Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
 template <>

--- a/include/mbgl/style/layers/heatmap_layer.hpp
+++ b/include/mbgl/style/layers/heatmap_layer.hpp
@@ -20,21 +20,6 @@ public:
     HeatmapLayer(const std::string& layerID, const std::string& sourceID);
     ~HeatmapLayer() final;
 
-    // Source
-    const std::string& getSourceID() const;
-    const std::string& getSourceLayer() const;
-    void setSourceLayer(const std::string& sourceLayer);
-
-    void setFilter(const Filter&);
-    const Filter& getFilter() const;
-
-    // Visibility
-    void setVisibility(VisibilityType) final;
-
-    // Zoom range
-    void setMinZoom(float) final;
-    void setMaxZoom(float) final;
-
     // Dynamic properties
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
@@ -79,6 +64,9 @@ public:
     Mutable<Impl> mutableImpl() const;
     HeatmapLayer(Immutable<Impl>);
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
+
+protected:
+    Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
 template <>

--- a/include/mbgl/style/layers/hillshade_layer.hpp
+++ b/include/mbgl/style/layers/hillshade_layer.hpp
@@ -19,16 +19,6 @@ public:
     HillshadeLayer(const std::string& layerID, const std::string& sourceID);
     ~HillshadeLayer() final;
 
-    // Source
-    const std::string& getSourceID() const;
-
-    // Visibility
-    void setVisibility(VisibilityType) final;
-
-    // Zoom range
-    void setMinZoom(float) final;
-    void setMaxZoom(float) final;
-
     // Dynamic properties
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
@@ -79,6 +69,9 @@ public:
     Mutable<Impl> mutableImpl() const;
     HillshadeLayer(Immutable<Impl>);
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
+
+protected:
+    Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
 template <>

--- a/include/mbgl/style/layers/layer.hpp.ejs
+++ b/include/mbgl/style/layers/layer.hpp.ejs
@@ -35,25 +35,6 @@ public:
 <% } -%>
     ~<%- camelize(type) %>Layer() final;
 
-<% if (type !== 'background') { -%>
-    // Source
-    const std::string& getSourceID() const;
-<% if (type !== 'raster' && type !== 'hillshade') { -%>
-    const std::string& getSourceLayer() const;
-    void setSourceLayer(const std::string& sourceLayer);
-
-    void setFilter(const Filter&);
-    const Filter& getFilter() const;
-<% } -%>
-
-<% } -%>
-    // Visibility
-    void setVisibility(VisibilityType) final;
-
-    // Zoom range
-    void setMinZoom(float) final;
-    void setMaxZoom(float) final;
-
     // Dynamic properties
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
@@ -86,6 +67,9 @@ public:
     Mutable<Impl> mutableImpl() const;
     <%- camelize(type) %>Layer(Immutable<Impl>);
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
+
+protected:
+    Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
 template <>

--- a/include/mbgl/style/layers/line_layer.hpp
+++ b/include/mbgl/style/layers/line_layer.hpp
@@ -22,21 +22,6 @@ public:
     LineLayer(const std::string& layerID, const std::string& sourceID);
     ~LineLayer() final;
 
-    // Source
-    const std::string& getSourceID() const;
-    const std::string& getSourceLayer() const;
-    void setSourceLayer(const std::string& sourceLayer);
-
-    void setFilter(const Filter&);
-    const Filter& getFilter() const;
-
-    // Visibility
-    void setVisibility(VisibilityType) final;
-
-    // Zoom range
-    void setMinZoom(float) final;
-    void setMaxZoom(float) final;
-
     // Dynamic properties
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
@@ -135,6 +120,9 @@ public:
     Mutable<Impl> mutableImpl() const;
     LineLayer(Immutable<Impl>);
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
+
+protected:
+    Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
 template <>

--- a/include/mbgl/style/layers/raster_layer.hpp
+++ b/include/mbgl/style/layers/raster_layer.hpp
@@ -19,16 +19,6 @@ public:
     RasterLayer(const std::string& layerID, const std::string& sourceID);
     ~RasterLayer() final;
 
-    // Source
-    const std::string& getSourceID() const;
-
-    // Visibility
-    void setVisibility(VisibilityType) final;
-
-    // Zoom range
-    void setMinZoom(float) final;
-    void setMaxZoom(float) final;
-
     // Dynamic properties
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
@@ -91,6 +81,9 @@ public:
     Mutable<Impl> mutableImpl() const;
     RasterLayer(Immutable<Impl>);
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
+
+protected:
+    Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
 template <>

--- a/include/mbgl/style/layers/symbol_layer.hpp
+++ b/include/mbgl/style/layers/symbol_layer.hpp
@@ -21,21 +21,6 @@ public:
     SymbolLayer(const std::string& layerID, const std::string& sourceID);
     ~SymbolLayer() final;
 
-    // Source
-    const std::string& getSourceID() const;
-    const std::string& getSourceLayer() const;
-    void setSourceLayer(const std::string& sourceLayer);
-
-    void setFilter(const Filter&);
-    const Filter& getFilter() const;
-
-    // Visibility
-    void setVisibility(VisibilityType) final;
-
-    // Zoom range
-    void setMinZoom(float) final;
-    void setMaxZoom(float) final;
-
     // Dynamic properties
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
@@ -284,6 +269,9 @@ public:
     Mutable<Impl> mutableImpl() const;
     SymbolLayer(Immutable<Impl>);
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
+
+protected:
+    Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
 template <>

--- a/include/mbgl/util/immutable.hpp
+++ b/include/mbgl/util/immutable.hpp
@@ -39,11 +39,17 @@ private:
 
     template <class S> friend class Immutable;
     template <class S, class... Args> friend Mutable<S> makeMutable(Args&&...);
+    template <class S, class U> friend Mutable<S> staticMutableCast(const Mutable<U>&);
 };
 
 template <class T, class... Args>
 Mutable<T> makeMutable(Args&&... args) {
     return Mutable<T>(std::make_shared<T>(std::forward<Args>(args)...));
+}
+
+template <class S, class U>
+Mutable<S> staticMutableCast(const Mutable<U>& u) {
+    return Mutable<S>(std::static_pointer_cast<S>(u.ptr));
 }
 
 /**

--- a/platform/android/src/style/layers/layer.cpp
+++ b/platform/android/src/style/layers/layer.cpp
@@ -109,20 +109,6 @@ namespace android {
         }
     }
 
-    struct SetFilterEvaluator {
-        style::Filter filter;
-
-        void operator()(style::BackgroundLayer&) { Log::Warning(mbgl::Event::JNI, "BackgroundLayer doesn't support filters"); }
-        void operator()(style::CustomLayer&) { Log::Warning(mbgl::Event::JNI, "CustomLayer doesn't support filters"); }
-        void operator()(style::RasterLayer&) { Log::Warning(mbgl::Event::JNI, "RasterLayer doesn't support filters"); }
-        void operator()(style::HillshadeLayer&) { Log::Warning(mbgl::Event::JNI, "HillshadeLayer doesn't support filters"); }
-
-        template <class LayerType>
-        void operator()(LayerType& layer) {
-            layer.setFilter(filter);
-        }
-    };
-
     void Layer::setFilter(jni::JNIEnv& env, const jni::Array<jni::Object<>>& jfilter) {
         using namespace mbgl::style;
         using namespace mbgl::style::conversion;
@@ -134,31 +120,14 @@ namespace android {
             return;
         }
 
-        layer.accept(SetFilterEvaluator {std::move(*converted)});
+        layer.setFilter(std::move(*converted));
     }
-
-    struct GetFilterEvaluator {
-        mbgl::style::Filter noop(std::string layerType) {
-            Log::Warning(mbgl::Event::JNI, "%s doesn't support filter", layerType.c_str());
-            return {};
-        }
-
-        mbgl::style::Filter operator()(style::BackgroundLayer&) { return noop("BackgroundLayer"); }
-        mbgl::style::Filter operator()(style::CustomLayer&) { return noop("CustomLayer"); }
-        mbgl::style::Filter operator()(style::RasterLayer&) { return noop("RasterLayer"); }
-        mbgl::style::Filter operator()(style::HillshadeLayer&) { return noop("HillshadeLayer"); }
-
-        template <class LayerType>
-            mbgl::style::Filter operator()(LayerType& layer) {
-            return layer.getFilter();
-        }
-    };
 
     jni::Local<jni::Object<gson::JsonElement>> Layer::getFilter(jni::JNIEnv& env) {
         using namespace mbgl::style;
         using namespace mbgl::style::conversion;
 
-        Filter filter = layer.accept(GetFilterEvaluator());
+        Filter filter = layer.getFilter();
         if (filter.expression) {
             mbgl::Value expressionValue = (*filter.expression)->serialize();
             return gson::JsonElement::New(env, expressionValue);
@@ -167,62 +136,16 @@ namespace android {
         }
     }
 
-    struct SetSourceLayerEvaluator {
-        std::string sourceLayer;
-
-        void operator()(style::BackgroundLayer&) { Log::Warning(mbgl::Event::JNI, "BackgroundLayer doesn't support source layer"); }
-        void operator()(style::CustomLayer&) { Log::Warning(mbgl::Event::JNI, "CustomLayer doesn't support source layer"); }
-        void operator()(style::RasterLayer&) { Log::Warning(mbgl::Event::JNI, "RasterLayer doesn't support source layer"); }
-        void operator()(style::HillshadeLayer&) { Log::Warning(mbgl::Event::JNI, "HillshadeLayer doesn't support source layer"); }
-
-        template <class LayerType>
-        void operator()(LayerType& layer) {
-            layer.setSourceLayer(sourceLayer);
-        }
-    };
-
     void Layer::setSourceLayer(jni::JNIEnv& env, const jni::String& sourceLayer) {
-        layer.accept(SetSourceLayerEvaluator {jni::Make<std::string>(env, sourceLayer)});
+        layer.setSourceLayer(jni::Make<std::string>(env, sourceLayer));
     }
-
-    struct GetSourceLayerEvaluator {
-        std::string noop(std::string layerType) {
-            Log::Warning(mbgl::Event::JNI, "%s doesn't support source layer", layerType.c_str());
-            return {};
-        }
-
-        std::string operator()(style::BackgroundLayer&) { return noop("BackgroundLayer"); }
-        std::string operator()(style::CustomLayer&) { return noop("CustomLayer"); }
-        std::string operator()(style::RasterLayer&) { return noop("RasterLayer"); }
-        std::string operator()(style::HillshadeLayer&) { return noop("HillshadeLayer"); }
-
-        template <class LayerType>
-        std::string operator()(LayerType& layer) {
-            return layer.getSourceLayer();
-        }
-    };
 
     jni::Local<jni::String> Layer::getSourceLayer(jni::JNIEnv& env) {
-        return jni::Make<jni::String>(env, layer.accept(GetSourceLayerEvaluator()));
+        return jni::Make<jni::String>(env, layer.getSourceLayer());
     }
 
-    struct GetSourceIdEvaluator {
-        std::string noop(std::string layerType) {
-            Log::Warning(mbgl::Event::JNI, "%s doesn't support get source id", layerType.c_str());
-            return {};
-        }
-
-        std::string operator()(style::BackgroundLayer&) { return noop("BackgroundLayer"); }
-        std::string operator()(style::CustomLayer&) { return noop("CustomLayer"); }
-
-        template <class LayerType>
-        std::string operator()(LayerType& layer) {
-            return layer.getSourceID();
-        }
-    };
-
     jni::Local<jni::String> Layer::getSourceId(jni::JNIEnv& env) {
-        return jni::Make<jni::String>(env, layer.accept(GetSourceIdEvaluator()));
+        return jni::Make<jni::String>(env, layer.getSourceID());
     }
 
     jni::jfloat Layer::getMinZoom(jni::JNIEnv&){

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -892,31 +892,6 @@ void NodeMap::SetPaintProperty(const Nan::FunctionCallbackInfo<v8::Value>& info)
     info.GetReturnValue().SetUndefined();
 }
 
-struct SetFilterVisitor {
-    mbgl::style::Filter& filter;
-
-    void operator()(mbgl::style::CustomLayer&) {
-        Nan::ThrowTypeError("layer doesn't support filters");
-    }
-
-    void operator()(mbgl::style::RasterLayer&) {
-        Nan::ThrowTypeError("layer doesn't support filters");
-    }
-
-    void operator()(mbgl::style::HillshadeLayer&) {
-        Nan::ThrowTypeError("layer doesn't support filters");
-    }
-
-    void operator()(mbgl::style::BackgroundLayer&) {
-        Nan::ThrowTypeError("layer doesn't support filters");
-    }
-
-    template <class VectorLayer>
-    void operator()(VectorLayer& layer) {
-        layer.setFilter(filter);
-    }
-};
-
 void NodeMap::SetFilter(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     using namespace mbgl::style;
     using namespace mbgl::style::conversion;
@@ -949,7 +924,7 @@ void NodeMap::SetFilter(const Nan::FunctionCallbackInfo<v8::Value>& info) {
         filter = std::move(*converted);
     }
 
-    layer->accept(SetFilterVisitor { filter });
+    layer->setFilter(filter);
 }
 
 void NodeMap::SetCenter(const Nan::FunctionCallbackInfo<v8::Value>& info) {

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1533,38 +1533,14 @@ void QMapboxGL::setFilter(const QString& layer, const QVariant& filter)
         return;
     }
 
-    Filter filter_;
-
     Error error;
     mbgl::optional<Filter> converted = convert<Filter>(filter, error);
     if (!converted) {
         qWarning() << "Error parsing filter:" << error.message.c_str();
         return;
     }
-    filter_ = std::move(*converted);
 
-    if (layer_->is<FillLayer>()) {
-        layer_->as<FillLayer>()->setFilter(filter_);
-        return;
-    }
-    if (layer_->is<LineLayer>()) {
-        layer_->as<LineLayer>()->setFilter(filter_);
-        return;
-    }
-    if (layer_->is<SymbolLayer>()) {
-        layer_->as<SymbolLayer>()->setFilter(filter_);
-        return;
-    }
-    if (layer_->is<CircleLayer>()) {
-        layer_->as<CircleLayer>()->setFilter(filter_);
-        return;
-    }
-    if (layer_->is<FillExtrusionLayer>()) {
-        layer_->as<FillExtrusionLayer>()->setFilter(filter_);
-        return;
-    }
-
-    qWarning() << "Layer doesn't support filters";
+    layer_->setFilter(std::move(*converted));
 }
 
 QVariant QVariantFromValue(const mbgl::Value &value) {
@@ -1617,24 +1593,7 @@ QVariant QMapboxGL::getFilter(const QString &layer)  const {
         return QVariant();
     }
 
-    Filter filter_;
-
-    if (layer_->is<FillLayer>()) {
-        filter_ = layer_->as<FillLayer>()->getFilter();
-    } else if (layer_->is<LineLayer>()) {
-        filter_ = layer_->as<LineLayer>()->getFilter();
-    } else if (layer_->is<SymbolLayer>()) {
-        filter_ = layer_->as<SymbolLayer>()->getFilter();
-    } else if (layer_->is<CircleLayer>()) {
-        filter_ = layer_->as<CircleLayer>()->getFilter();
-    } else if (layer_->is<FillExtrusionLayer>()) {
-        filter_ = layer_->as<FillExtrusionLayer>()->getFilter();
-    } else {
-        qWarning() << "Layer doesn't support filters";
-        return QVariant();
-    }
-
-    auto serialized = filter_.serialize();
+    auto serialized = layer_->getFilter().serialize();
     return QVariantFromValue(serialized);
 }
 

--- a/src/mbgl/style/layer.cpp
+++ b/src/mbgl/style/layer.cpp
@@ -24,8 +24,42 @@ std::string Layer::getID() const {
     return baseImpl->id;
 }
 
+std::string Layer::getSourceID() const {
+    return baseImpl->source;
+}
+
+std::string Layer::getSourceLayer() const {
+    return baseImpl->sourceLayer;
+}
+
+void Layer::setSourceLayer(const std::string& sourceLayer) {
+    auto impl_ = mutableBaseImpl();
+    impl_->sourceLayer = sourceLayer;
+    baseImpl = std::move(impl_);
+}
+
+const Filter& Layer::getFilter() const {
+    return baseImpl->filter;
+}
+
+void Layer::setFilter(const Filter& filter) {
+    auto impl_ = mutableBaseImpl();
+    impl_->filter = filter;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
 VisibilityType Layer::getVisibility() const {
     return baseImpl->visibility;
+}
+
+void Layer::setVisibility(VisibilityType value) {
+    if (value == getVisibility())
+        return;
+    auto impl_ = mutableBaseImpl();
+    impl_->visibility = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
 }
 
 float Layer::getMinZoom() const {
@@ -34,6 +68,20 @@ float Layer::getMinZoom() const {
 
 float Layer::getMaxZoom() const {
     return baseImpl->maxZoom;
+}
+
+void Layer::setMinZoom(float minZoom) {
+    auto impl_ = mutableBaseImpl();
+    impl_->minZoom = minZoom;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void Layer::setMaxZoom(float maxZoom) {
+    auto impl_ = mutableBaseImpl();
+    impl_->maxZoom = maxZoom;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
 }
 
 void Layer::setObserver(LayerObserver* observer_) {

--- a/src/mbgl/style/layers/background_layer.cpp
+++ b/src/mbgl/style/layers/background_layer.cpp
@@ -42,34 +42,6 @@ std::unique_ptr<Layer> BackgroundLayer::cloneRef(const std::string& id_) const {
 void BackgroundLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
 }
 
-
-// Visibility
-
-void BackgroundLayer::setVisibility(VisibilityType value) {
-    if (value == getVisibility())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->visibility = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-// Zoom range
-
-void BackgroundLayer::setMinZoom(float minZoom) {
-    auto impl_ = mutableImpl();
-    impl_->minZoom = minZoom;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void BackgroundLayer::setMaxZoom(float maxZoom) {
-    auto impl_ = mutableImpl();
-    impl_->maxZoom = maxZoom;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
 // Layout properties
 
 
@@ -292,6 +264,10 @@ optional<Error> BackgroundLayer::setLayoutProperty(const std::string& name, cons
         
 
     return Error { "layer doesn't support this property" };
+}
+
+Mutable<Layer::Impl> BackgroundLayer::mutableBaseImpl() const {
+    return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
 } // namespace style

--- a/src/mbgl/style/layers/circle_layer.cpp
+++ b/src/mbgl/style/layers/circle_layer.cpp
@@ -42,62 +42,6 @@ std::unique_ptr<Layer> CircleLayer::cloneRef(const std::string& id_) const {
 void CircleLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
 }
 
-// Source
-
-const std::string& CircleLayer::getSourceID() const {
-    return impl().source;
-}
-
-void CircleLayer::setSourceLayer(const std::string& sourceLayer) {
-    auto impl_ = mutableImpl();
-    impl_->sourceLayer = sourceLayer;
-    baseImpl = std::move(impl_);
-}
-
-const std::string& CircleLayer::getSourceLayer() const {
-    return impl().sourceLayer;
-}
-
-// Filter
-
-void CircleLayer::setFilter(const Filter& filter) {
-    auto impl_ = mutableImpl();
-    impl_->filter = filter;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-const Filter& CircleLayer::getFilter() const {
-    return impl().filter;
-}
-
-// Visibility
-
-void CircleLayer::setVisibility(VisibilityType value) {
-    if (value == getVisibility())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->visibility = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-// Zoom range
-
-void CircleLayer::setMinZoom(float minZoom) {
-    auto impl_ = mutableImpl();
-    impl_->minZoom = minZoom;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void CircleLayer::setMaxZoom(float maxZoom) {
-    auto impl_ = mutableImpl();
-    impl_->maxZoom = maxZoom;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
 // Layout properties
 
 
@@ -737,6 +681,10 @@ optional<Error> CircleLayer::setLayoutProperty(const std::string& name, const Co
         
 
     return Error { "layer doesn't support this property" };
+}
+
+Mutable<Layer::Impl> CircleLayer::mutableBaseImpl() const {
+    return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
 } // namespace style

--- a/src/mbgl/style/layers/custom_layer.cpp
+++ b/src/mbgl/style/layers/custom_layer.cpp
@@ -25,31 +25,6 @@ std::unique_ptr<Layer> CustomLayer::cloneRef(const std::string&) const {
     return nullptr;
 }
 
-// Visibility
-
-void CustomLayer::setVisibility(VisibilityType value) {
-    if (value == getVisibility())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->visibility = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-// Zoom range
-
-void CustomLayer::setMinZoom(float minZoom) {
-    auto impl_ = mutableImpl();
-    impl_->minZoom = minZoom;
-    baseImpl = std::move(impl_);
-}
-
-void CustomLayer::setMaxZoom(float maxZoom) {
-    auto impl_ = mutableImpl();
-    impl_->maxZoom = maxZoom;
-    baseImpl = std::move(impl_);
-}
-
 using namespace conversion;
 
 optional<Error> CustomLayer::setPaintProperty(const std::string&, const Convertible&) {
@@ -58,6 +33,10 @@ optional<Error> CustomLayer::setPaintProperty(const std::string&, const Converti
 
 optional<Error> CustomLayer::setLayoutProperty(const std::string&, const Convertible&) {
     return Error { "layer doesn't support this property" };
+}
+
+Mutable<Layer::Impl> CustomLayer::mutableBaseImpl() const {
+    return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
 template <>

--- a/src/mbgl/style/layers/fill_extrusion_layer.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer.cpp
@@ -42,62 +42,6 @@ std::unique_ptr<Layer> FillExtrusionLayer::cloneRef(const std::string& id_) cons
 void FillExtrusionLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
 }
 
-// Source
-
-const std::string& FillExtrusionLayer::getSourceID() const {
-    return impl().source;
-}
-
-void FillExtrusionLayer::setSourceLayer(const std::string& sourceLayer) {
-    auto impl_ = mutableImpl();
-    impl_->sourceLayer = sourceLayer;
-    baseImpl = std::move(impl_);
-}
-
-const std::string& FillExtrusionLayer::getSourceLayer() const {
-    return impl().sourceLayer;
-}
-
-// Filter
-
-void FillExtrusionLayer::setFilter(const Filter& filter) {
-    auto impl_ = mutableImpl();
-    impl_->filter = filter;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-const Filter& FillExtrusionLayer::getFilter() const {
-    return impl().filter;
-}
-
-// Visibility
-
-void FillExtrusionLayer::setVisibility(VisibilityType value) {
-    if (value == getVisibility())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->visibility = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-// Zoom range
-
-void FillExtrusionLayer::setMinZoom(float minZoom) {
-    auto impl_ = mutableImpl();
-    impl_->minZoom = minZoom;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void FillExtrusionLayer::setMaxZoom(float maxZoom) {
-    auto impl_ = mutableImpl();
-    impl_->maxZoom = maxZoom;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
 // Layout properties
 
 
@@ -539,6 +483,10 @@ optional<Error> FillExtrusionLayer::setLayoutProperty(const std::string& name, c
         
 
     return Error { "layer doesn't support this property" };
+}
+
+Mutable<Layer::Impl> FillExtrusionLayer::mutableBaseImpl() const {
+    return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
 } // namespace style

--- a/src/mbgl/style/layers/fill_layer.cpp
+++ b/src/mbgl/style/layers/fill_layer.cpp
@@ -42,62 +42,6 @@ std::unique_ptr<Layer> FillLayer::cloneRef(const std::string& id_) const {
 void FillLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
 }
 
-// Source
-
-const std::string& FillLayer::getSourceID() const {
-    return impl().source;
-}
-
-void FillLayer::setSourceLayer(const std::string& sourceLayer) {
-    auto impl_ = mutableImpl();
-    impl_->sourceLayer = sourceLayer;
-    baseImpl = std::move(impl_);
-}
-
-const std::string& FillLayer::getSourceLayer() const {
-    return impl().sourceLayer;
-}
-
-// Filter
-
-void FillLayer::setFilter(const Filter& filter) {
-    auto impl_ = mutableImpl();
-    impl_->filter = filter;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-const Filter& FillLayer::getFilter() const {
-    return impl().filter;
-}
-
-// Visibility
-
-void FillLayer::setVisibility(VisibilityType value) {
-    if (value == getVisibility())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->visibility = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-// Zoom range
-
-void FillLayer::setMinZoom(float minZoom) {
-    auto impl_ = mutableImpl();
-    impl_->minZoom = minZoom;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void FillLayer::setMaxZoom(float maxZoom) {
-    auto impl_ = mutableImpl();
-    impl_->maxZoom = maxZoom;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
 // Layout properties
 
 
@@ -539,6 +483,10 @@ optional<Error> FillLayer::setLayoutProperty(const std::string& name, const Conv
         
 
     return Error { "layer doesn't support this property" };
+}
+
+Mutable<Layer::Impl> FillLayer::mutableBaseImpl() const {
+    return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
 } // namespace style

--- a/src/mbgl/style/layers/heatmap_layer.cpp
+++ b/src/mbgl/style/layers/heatmap_layer.cpp
@@ -42,62 +42,6 @@ std::unique_ptr<Layer> HeatmapLayer::cloneRef(const std::string& id_) const {
 void HeatmapLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
 }
 
-// Source
-
-const std::string& HeatmapLayer::getSourceID() const {
-    return impl().source;
-}
-
-void HeatmapLayer::setSourceLayer(const std::string& sourceLayer) {
-    auto impl_ = mutableImpl();
-    impl_->sourceLayer = sourceLayer;
-    baseImpl = std::move(impl_);
-}
-
-const std::string& HeatmapLayer::getSourceLayer() const {
-    return impl().sourceLayer;
-}
-
-// Filter
-
-void HeatmapLayer::setFilter(const Filter& filter) {
-    auto impl_ = mutableImpl();
-    impl_->filter = filter;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-const Filter& HeatmapLayer::getFilter() const {
-    return impl().filter;
-}
-
-// Visibility
-
-void HeatmapLayer::setVisibility(VisibilityType value) {
-    if (value == getVisibility())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->visibility = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-// Zoom range
-
-void HeatmapLayer::setMinZoom(float minZoom) {
-    auto impl_ = mutableImpl();
-    impl_->minZoom = minZoom;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void HeatmapLayer::setMaxZoom(float maxZoom) {
-    auto impl_ = mutableImpl();
-    impl_->maxZoom = maxZoom;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
 // Layout properties
 
 
@@ -424,6 +368,10 @@ optional<Error> HeatmapLayer::setLayoutProperty(const std::string& name, const C
         
 
     return Error { "layer doesn't support this property" };
+}
+
+Mutable<Layer::Impl> HeatmapLayer::mutableBaseImpl() const {
+    return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
 } // namespace style

--- a/src/mbgl/style/layers/hillshade_layer.cpp
+++ b/src/mbgl/style/layers/hillshade_layer.cpp
@@ -42,40 +42,6 @@ std::unique_ptr<Layer> HillshadeLayer::cloneRef(const std::string& id_) const {
 void HillshadeLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
 }
 
-// Source
-
-const std::string& HillshadeLayer::getSourceID() const {
-    return impl().source;
-}
-
-
-// Visibility
-
-void HillshadeLayer::setVisibility(VisibilityType value) {
-    if (value == getVisibility())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->visibility = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-// Zoom range
-
-void HillshadeLayer::setMinZoom(float minZoom) {
-    auto impl_ = mutableImpl();
-    impl_->minZoom = minZoom;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void HillshadeLayer::setMaxZoom(float maxZoom) {
-    auto impl_ = mutableImpl();
-    impl_->maxZoom = maxZoom;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
 // Layout properties
 
 
@@ -449,6 +415,10 @@ optional<Error> HillshadeLayer::setLayoutProperty(const std::string& name, const
         
 
     return Error { "layer doesn't support this property" };
+}
+
+Mutable<Layer::Impl> HillshadeLayer::mutableBaseImpl() const {
+    return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
 } // namespace style

--- a/src/mbgl/style/layers/layer.cpp.ejs
+++ b/src/mbgl/style/layers/layer.cpp.ejs
@@ -59,66 +59,6 @@ void <%- camelize(type) %>Layer::Impl::stringifyLayout(rapidjson::Writer<rapidjs
 }
 <% } -%>
 
-<% if (type !== 'background') { -%>
-// Source
-
-const std::string& <%- camelize(type) %>Layer::getSourceID() const {
-    return impl().source;
-}
-
-<% if (type !== 'raster' && type !== 'hillshade') { -%>
-void <%- camelize(type) %>Layer::setSourceLayer(const std::string& sourceLayer) {
-    auto impl_ = mutableImpl();
-    impl_->sourceLayer = sourceLayer;
-    baseImpl = std::move(impl_);
-}
-
-const std::string& <%- camelize(type) %>Layer::getSourceLayer() const {
-    return impl().sourceLayer;
-}
-
-// Filter
-
-void <%- camelize(type) %>Layer::setFilter(const Filter& filter) {
-    auto impl_ = mutableImpl();
-    impl_->filter = filter;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-const Filter& <%- camelize(type) %>Layer::getFilter() const {
-    return impl().filter;
-}
-<% } -%>
-<% } -%>
-
-// Visibility
-
-void <%- camelize(type) %>Layer::setVisibility(VisibilityType value) {
-    if (value == getVisibility())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->visibility = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-// Zoom range
-
-void <%- camelize(type) %>Layer::setMinZoom(float minZoom) {
-    auto impl_ = mutableImpl();
-    impl_->minZoom = minZoom;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void <%- camelize(type) %>Layer::setMaxZoom(float maxZoom) {
-    auto impl_ = mutableImpl();
-    impl_->maxZoom = maxZoom;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
 // Layout properties
 
 <% for (const property of layoutProperties) { -%>
@@ -314,6 +254,10 @@ optional<Error> <%- camelize(type) %>Layer::setLayoutProperty(const std::string&
     <% } %>
 
     return Error { "layer doesn't support this property" };
+}
+
+Mutable<Layer::Impl> <%- camelize(type) %>Layer::mutableBaseImpl() const {
+    return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
 } // namespace style

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -43,62 +43,6 @@ void LineLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>
     layout.stringify(writer);
 }
 
-// Source
-
-const std::string& LineLayer::getSourceID() const {
-    return impl().source;
-}
-
-void LineLayer::setSourceLayer(const std::string& sourceLayer) {
-    auto impl_ = mutableImpl();
-    impl_->sourceLayer = sourceLayer;
-    baseImpl = std::move(impl_);
-}
-
-const std::string& LineLayer::getSourceLayer() const {
-    return impl().sourceLayer;
-}
-
-// Filter
-
-void LineLayer::setFilter(const Filter& filter) {
-    auto impl_ = mutableImpl();
-    impl_->filter = filter;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-const Filter& LineLayer::getFilter() const {
-    return impl().filter;
-}
-
-// Visibility
-
-void LineLayer::setVisibility(VisibilityType value) {
-    if (value == getVisibility())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->visibility = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-// Zoom range
-
-void LineLayer::setMinZoom(float minZoom) {
-    auto impl_ = mutableImpl();
-    impl_->minZoom = minZoom;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void LineLayer::setMaxZoom(float maxZoom) {
-    auto impl_ = mutableImpl();
-    impl_->maxZoom = maxZoom;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
 // Layout properties
 
 PropertyValue<LineCapType> LineLayer::getDefaultLineCap() {
@@ -878,6 +822,10 @@ optional<Error> LineLayer::setLayoutProperty(const std::string& name, const Conv
     
 
     return Error { "layer doesn't support this property" };
+}
+
+Mutable<Layer::Impl> LineLayer::mutableBaseImpl() const {
+    return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
 } // namespace style

--- a/src/mbgl/style/layers/raster_layer.cpp
+++ b/src/mbgl/style/layers/raster_layer.cpp
@@ -42,40 +42,6 @@ std::unique_ptr<Layer> RasterLayer::cloneRef(const std::string& id_) const {
 void RasterLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
 }
 
-// Source
-
-const std::string& RasterLayer::getSourceID() const {
-    return impl().source;
-}
-
-
-// Visibility
-
-void RasterLayer::setVisibility(VisibilityType value) {
-    if (value == getVisibility())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->visibility = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-// Zoom range
-
-void RasterLayer::setMinZoom(float minZoom) {
-    auto impl_ = mutableImpl();
-    impl_->minZoom = minZoom;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void RasterLayer::setMaxZoom(float maxZoom) {
-    auto impl_ = mutableImpl();
-    impl_->maxZoom = maxZoom;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
 // Layout properties
 
 
@@ -538,6 +504,10 @@ optional<Error> RasterLayer::setLayoutProperty(const std::string& name, const Co
         
 
     return Error { "layer doesn't support this property" };
+}
+
+Mutable<Layer::Impl> RasterLayer::mutableBaseImpl() const {
+    return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
 } // namespace style

--- a/src/mbgl/style/layers/symbol_layer.cpp
+++ b/src/mbgl/style/layers/symbol_layer.cpp
@@ -43,62 +43,6 @@ void SymbolLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffe
     layout.stringify(writer);
 }
 
-// Source
-
-const std::string& SymbolLayer::getSourceID() const {
-    return impl().source;
-}
-
-void SymbolLayer::setSourceLayer(const std::string& sourceLayer) {
-    auto impl_ = mutableImpl();
-    impl_->sourceLayer = sourceLayer;
-    baseImpl = std::move(impl_);
-}
-
-const std::string& SymbolLayer::getSourceLayer() const {
-    return impl().sourceLayer;
-}
-
-// Filter
-
-void SymbolLayer::setFilter(const Filter& filter) {
-    auto impl_ = mutableImpl();
-    impl_->filter = filter;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-const Filter& SymbolLayer::getFilter() const {
-    return impl().filter;
-}
-
-// Visibility
-
-void SymbolLayer::setVisibility(VisibilityType value) {
-    if (value == getVisibility())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->visibility = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-// Zoom range
-
-void SymbolLayer::setMinZoom(float minZoom) {
-    auto impl_ = mutableImpl();
-    impl_->minZoom = minZoom;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void SymbolLayer::setMaxZoom(float maxZoom) {
-    auto impl_ = mutableImpl();
-    impl_->maxZoom = maxZoom;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
 // Layout properties
 
 PropertyValue<SymbolPlacementType> SymbolLayer::getDefaultSymbolPlacement() {
@@ -2028,6 +1972,10 @@ optional<Error> SymbolLayer::setLayoutProperty(const std::string& name, const Co
     
 
     return Error { "layer doesn't support this property" };
+}
+
+Mutable<Layer::Impl> SymbolLayer::mutableBaseImpl() const {
+    return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
 } // namespace style


### PR DESCRIPTION
The `style::Layer` class now exposes all the properties contained at `style::LayerImpl`.
This allowed to drop `style::Layer::accept()` method usage, avoid the repeated generated code
and thus save some binary size.

This patch is a part of the layers modularization effort.