### PR TITLE
Deprecated ZoomButtonsController support

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
@@ -13,6 +13,7 @@ import android.support.annotation.Nullable;
 import android.support.v4.content.res.ResourcesCompat;
 import android.util.AttributeSet;
 import android.view.Gravity;
+
 import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
@@ -497,7 +498,10 @@ public class MapboxMapOptions implements Parcelable {
    *
    * @param enabled True and gesture will be enabled
    * @return This
+   * @deprecated {@link android.widget.ZoomButtonsController}, this functionality and UI is better handled with
+   * custom views and layouts rather than a dedicated zoom-control widget.
    */
+  @Deprecated
   public MapboxMapOptions zoomControlsEnabled(boolean enabled) {
     zoomControlsEnabled = enabled;
     return this;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
@@ -732,7 +732,10 @@ public final class UiSettings {
    * By default the zoom controls are enabled if the device is only single touch capable;
    *
    * @param zoomControlsEnabled If true, the zoom controls are enabled.
+   * @deprecated {@link android.widget.ZoomButtonsController}, this functionality and UI is better handled with
+   * custom views and layouts rather than a dedicated zoom-control widget.
    */
+  @Deprecated
   public void setZoomControlsEnabled(boolean zoomControlsEnabled) {
     this.zoomControlsEnabled = zoomControlsEnabled;
   }


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gl-native/issues/12275. We are deprecating the support for `ZoomButtonsController` and it's going to be completely dropped with the next semver major release.