### PR TITLE
Add icon for fill extrusion layers to macosapp

### DIFF
--- a/platform/macos/app/Assets.xcassets/Layers/fill-extrusion.imageset/Contents.json
+++ b/platform/macos/app/Assets.xcassets/Layers/fill-extrusion.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "filename" : "fill-extrusion.pdf"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
+  }
+}

--- a/platform/macos/app/Assets.xcassets/Layers/fill-extrusion.imageset/fill-extrusion.pdf
+++ b/platform/macos/app/Assets.xcassets/Layers/fill-extrusion.imageset/fill-extrusion.pdf
@@ -1,0 +1,72 @@
+%PDF-1.5
+%µí®û
+3 0 obj
+<< /Length 4 0 R
+   /Filter /FlateDecode
+>>
+stream
+xœ“ÏNÃ0Æï}
+Ÿ‘0qş9y$$ƒ#â€@lBô08ğú8MÉ’Lë:ÔCm¥ÎçŸ?w?(ÔŠƒ5P&jr_[¸yQ°ıˆ™†`„9÷è”…O`LŒ)™|â8îªß¯éy¸J
+Ù‚9º>†§géDÁÛ`áö@SÅuz‘†×±ÜŠ¤ô¡%‡6úÒ„Áà¹d
+­öMGsí#l¤§px³rzzÓy@&’Ks&³›»­šÁyÆ¬aP‡Xå?½À	H1˜C	¨¬ÆHfGV.W“§9gâ¤Õ–®ƒ«iÆ&+xŒ“c³ZO•Ü_i&3Š¢O&—Àkãt\í`õŸ5¾ÔÂ–kÕ–úà5;¨‚ÀÊ…pŒ™—oÙÈöÏİõ¥!æÍ;ãdû_îúÚÌe3uB›ƒzI[ÆŞ´eº®v]íÊØ9¶ÌÖV&´Íğüº$
+endstream
+endobj
+4 0 obj
+   358
+endobj
+2 0 obj
+<<
+   /ExtGState <<
+      /a0 << /CA 0.156863 /ca 0.156863 >>
+      /a1 << /CA 1 /ca 1 >>
+   >>
+>>
+endobj
+5 0 obj
+<< /Type /Page
+   /Parent 1 0 R
+   /MediaBox [ 0 0 12 12 ]
+   /Contents 3 0 R
+   /Group <<
+      /Type /Group
+      /S /Transparency
+      /I true
+      /CS /DeviceRGB
+   >>
+   /Resources 2 0 R
+>>
+endobj
+1 0 obj
+<< /Type /Pages
+   /Kids [ 5 0 R ]
+   /Count 1
+>>
+endobj
+6 0 obj
+<< /Creator (cairo 1.14.8 (http://cairographics.org))
+   /Producer (cairo 1.14.8 (http://cairographics.org))
+>>
+endobj
+7 0 obj
+<< /Type /Catalog
+   /Pages 1 0 R
+>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000798 00000 n 
+0000000472 00000 n 
+0000000015 00000 n 
+0000000450 00000 n 
+0000000586 00000 n 
+0000000863 00000 n 
+0000000990 00000 n 
+trailer
+<< /Size 8
+   /Root 7 0 R
+   /Info 6 0 R
+>>
+startxref
+1042
+%%EOF

--- a/platform/macos/app/StyleLayerIconTransformer.m
+++ b/platform/macos/app/StyleLayerIconTransformer.m
@@ -22,6 +22,9 @@
     if ([layer isKindOfClass:[MGLFillStyleLayer class]]) {
         return [NSImage imageNamed:@"fill"];
     }
+    if ([layer isKindOfClass:[MGLFillExtrusionStyleLayer class]]) {
+        return [NSImage imageNamed:@"fill-extrusion"];
+    }
     if ([layer isKindOfClass:[MGLLineStyleLayer class]]) {
         return [NSImage imageNamed:@"NSListViewTemplate"];
     }

--- a/platform/macos/app/resources/fill-extrusion.svg
+++ b/platform/macos/app/resources/fill-extrusion.svg
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg4148"
+   version="1.1"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
+   sodipodi:docname="fill-extrusion.svg"
+   inkscape:export-filename="/Users/mxn/Desktop/symbol.png"
+   inkscape:export-xdpi="90.000244"
+   inkscape:export-ydpi="90.000244">
+  <defs
+     id="defs4150">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="27.393974 : 17.772818 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="-8.2635625 : 18.670616 : 1"
+       inkscape:persp3d-origin="3.017385 : 22.114843 : 1"
+       id="perspective909" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.9195959"
+     inkscape:cx="-4.7399183"
+     inkscape:cy="19.282107"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1280"
+     inkscape:window-height="755"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     inkscape:snap-nodes="false"
+     inkscape:snap-others="false"
+     inkscape:snap-grids="false"
+     inkscape:snap-to-guides="false"
+     inkscape:snap-global="true"
+     inkscape:snap-page="true" />
+  <metadata
+     id="metadata4153">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <g
+       sodipodi:type="inkscape:box3d"
+       id="g1023"
+       style="opacity:1;fill:#000000;fill-opacity:0.15686275;fill-rule:evenodd;stroke:#000000;stroke-width:1.00157475;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:perspectiveID="#perspective909"
+       inkscape:corner0="1.0855329 : -0.011103979 : 0 : 1"
+       inkscape:corner7="0.098433878 : -0.023326662 : 0.57925509 : 1">
+      <path
+         sodipodi:type="inkscape:box3dside"
+         id="path1025"
+         style="fill:#353564;fill-rule:evenodd;stroke:#000000;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:box3dsidetype="6"
+         d="m 15.705552,1037.8317 v 5.8607 l -5.210258,-2.1739 v -4.5868 z"
+         points="15.705552,1043.6924 10.495294,1041.5185 10.495294,1036.9317 15.705552,1037.8317 " />
+      <path
+         sodipodi:type="inkscape:box3dside"
+         id="path1029"
+         style="fill:#8686bf;fill-rule:evenodd;stroke:#000000;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:box3dsidetype="3"
+         d="m 15.705552,1037.8317 -10.5037094,2.9137 v 11.1274 l 10.5037094,-8.1804 z"
+         points="5.2018426,1040.7454 5.2018426,1051.8728 15.705552,1043.6924 15.705552,1037.8317 " />
+      <path
+         sodipodi:type="inkscape:box3dside"
+         id="path1031"
+         style="fill:#d7d7ff;fill-rule:evenodd;stroke:#000000;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:box3dsidetype="14"
+         d="m 5.2018426,1040.7454 v 11.1274 l -4.64919579,-6.2775 v -7.2854 z"
+         points="5.2018426,1051.8728 0.55264681,1045.5953 0.55264681,1038.3099 5.2018426,1040.7454 " />
+      <path
+         sodipodi:type="inkscape:box3dside"
+         id="path1027"
+         style="fill:#4d4d9f;fill-rule:evenodd;stroke:#000000;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:box3dsidetype="5"
+         d="m 15.705552,1037.8317 -10.5037094,2.9137 -4.64919579,-2.4355 9.94264719,-1.3782 z"
+         points="5.2018426,1040.7454 0.55264681,1038.3099 10.495294,1036.9317 15.705552,1037.8317 " />
+      <path
+         sodipodi:type="inkscape:box3dside"
+         id="path1033"
+         style="fill:#afafde;fill-rule:evenodd;stroke:#000000;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:box3dsidetype="13"
+         d="m 15.705552,1043.6924 -10.5037094,8.1804 -4.64919579,-6.2775 9.94264719,-4.0768 z"
+         points="5.2018426,1051.8728 0.55264681,1045.5953 10.495294,1041.5185 15.705552,1043.6924 " />
+      <path
+         sodipodi:type="inkscape:box3dside"
+         id="path1035"
+         style="fill:#e9e9ff;fill-rule:evenodd;stroke:#000000;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:box3dsidetype="11"
+         d="m 10.495294,1036.9317 -9.94264719,1.3782 v 7.2854 l 9.94264719,-4.0768 z"
+         points="0.55264681,1038.3099 0.55264681,1045.5953 10.495294,1041.5185 10.495294,1036.9317 " />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
The Layers sidebar in macosapp now adorns fill extrusion layers with 3D boxes instead of whitespace.

<img width="176" alt="extrusions" src="https://user-images.githubusercontent.com/1231218/47505037-dc55c700-d85c-11e8-8de5-34a90732857d.png">

Fixes #11755.

/cc @friedbunny