### PR TITLE
[android] Fix order in which repos are being synced

### DIFF
--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -2,8 +2,8 @@ buildscript {
     apply from: "${rootDir}/gradle/dependencies.gradle"
 
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
@@ -15,8 +15,8 @@ buildscript {
 allprojects {
     repositories {
         mavenCentral()
-        jcenter()
         google()
+        jcenter()
         // Snapshot repository
         //maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
     }


### PR DESCRIPTION
While working on setting up android maps sdk with android studio (v.3.2) i ran on the gradle config problem producing the following: 
```
Failed to resolve: support-v4
Open File
Failed to resolve: extensions
Open File
Failed to resolve: support-vector-drawable
Open File
Failed to resolve: livedata-core
Open File
Failed to resolve: runtime
Open File
Failed to resolve: common
Open File
Failed to resolve: viewmodel
Open File
Failed to resolve: monitor
Open File
Failed to resolve: extensions
Open File
Failed to resolve: support-vector-drawable
Open File
Failed to resolve: livedata-core
Open File
Failed to resolve: runtime
Open File
Failed to resolve: common
Show in File
Failed to resolve: viewmodel
Open File
```
I was able to resolve this problem by switching the order in which repositories are listed in `build.gradle` file. I'm not sure if anyone else ran on it before or if there's a better fix for this problem. I'll let @mapbox/maps-android team decide if this fix is useful or abandon this PR if it is not. 