### PR TITLE
Fix OnMapReady delivery when a new style is requested before the map is initialized

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapChangeReceiver.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapChangeReceiver.java
@@ -1,22 +1,30 @@
 package com.mapbox.mapboxsdk.maps;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 class MapChangeReceiver implements NativeMapView.StateCallback {
 
-  private final List<MapView.OnCameraWillChangeListener> onCameraWillChangeListenerList = new ArrayList<>();
-  private final List<MapView.OnCameraIsChangingListener> onCameraIsChangingListenerList = new ArrayList<>();
-  private final List<MapView.OnCameraDidChangeListener> onCameraDidChangeListenerList = new ArrayList<>();
-  private final List<MapView.OnWillStartLoadingMapListener> onWillStartLoadingMapListenerList = new ArrayList<>();
-  private final List<MapView.OnDidFinishLoadingMapListener> onDidFinishLoadingMapListenerList = new ArrayList<>();
-  private final List<MapView.OnDidFailLoadingMapListener> onDidFailLoadingMapListenerList = new ArrayList<>();
-  private final List<MapView.OnWillStartRenderingFrameListener> onWillStartRenderingFrameList = new ArrayList<>();
-  private final List<MapView.OnDidFinishRenderingFrameListener> onDidFinishRenderingFrameList = new ArrayList<>();
-  private final List<MapView.OnWillStartRenderingMapListener> onWillStartRenderingMapListenerList = new ArrayList<>();
-  private final List<MapView.OnDidFinishRenderingMapListener> onDidFinishRenderingMapListenerList = new ArrayList<>();
-  private final List<MapView.OnDidFinishLoadingStyleListener> onDidFinishLoadingStyleListenerList = new ArrayList<>();
-  private final List<MapView.OnSourceChangedListener> onSourceChangedListenerList = new ArrayList<>();
+  private final List<MapView.OnCameraWillChangeListener> onCameraWillChangeListenerList = new CopyOnWriteArrayList<>();
+  private final List<MapView.OnCameraIsChangingListener> onCameraIsChangingListenerList = new CopyOnWriteArrayList<>();
+  private final List<MapView.OnCameraDidChangeListener> onCameraDidChangeListenerList = new CopyOnWriteArrayList<>();
+  private final List<MapView.OnWillStartLoadingMapListener> onWillStartLoadingMapListenerList
+    = new CopyOnWriteArrayList<>();
+  private final List<MapView.OnDidFinishLoadingMapListener> onDidFinishLoadingMapListenerList
+    = new CopyOnWriteArrayList<>();
+  private final List<MapView.OnDidFailLoadingMapListener> onDidFailLoadingMapListenerList
+    = new CopyOnWriteArrayList<>();
+  private final List<MapView.OnWillStartRenderingFrameListener> onWillStartRenderingFrameList
+    = new CopyOnWriteArrayList<>();
+  private final List<MapView.OnDidFinishRenderingFrameListener> onDidFinishRenderingFrameList
+    = new CopyOnWriteArrayList<>();
+  private final List<MapView.OnWillStartRenderingMapListener> onWillStartRenderingMapListenerList
+    = new CopyOnWriteArrayList<>();
+  private final List<MapView.OnDidFinishRenderingMapListener> onDidFinishRenderingMapListenerList
+    = new CopyOnWriteArrayList<>();
+  private final List<MapView.OnDidFinishLoadingStyleListener> onDidFinishLoadingStyleListenerList
+    = new CopyOnWriteArrayList<>();
+  private final List<MapView.OnSourceChangedListener> onSourceChangedListenerList = new CopyOnWriteArrayList<>();
 
   @Override
   public void onCameraWillChange(boolean animated) {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/utils/StyleChangeIdlingResource.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/utils/StyleChangeIdlingResource.kt
@@ -33,12 +33,10 @@ class StyleChangeIdlingResource : IdlingResource {
 
   fun waitForStyle(mapView: MapView, mapboxMap: MapboxMap, styleUrl: String) {
     isIdle = false
-    mapView.addOnMapChangedListener(object : MapView.OnMapChangedListener {
-      override fun onMapChanged(change: Int) {
-        if (change == MapView.DID_FINISH_LOADING_STYLE) {
-          mapView.removeOnMapChangedListener(this)
-          setIdle()
-        }
+    mapView.addOnDidFinishLoadingStyleListener(object : MapView.OnDidFinishLoadingStyleListener {
+      override fun onDidFinishLoadingStyle() {
+        mapView.removeOnDidFinishLoadingStyleListener(this)
+        setIdle()
       }
     })
     mapboxMap.setStyleUrl(styleUrl)

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/BulkMarkerActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/BulkMarkerActivity.java
@@ -16,6 +16,7 @@ import android.widget.ArrayAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
+
 import com.mapbox.mapboxsdk.annotations.Icon;
 import com.mapbox.mapboxsdk.annotations.MarkerOptions;
 import com.mapbox.mapboxsdk.annotations.MarkerViewOptions;
@@ -25,7 +26,6 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.testapp.R;
 import com.mapbox.mapboxsdk.testapp.utils.GeoParseUtil;
 import com.mapbox.mapboxsdk.testapp.utils.IconUtils;
-import timber.log.Timber;
 
 import java.io.IOException;
 import java.lang.ref.WeakReference;
@@ -34,6 +34,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
+
+import timber.log.Timber;
 
 /**
  * Test activity showcasing adding a large amount of Markers or MarkerViews.
@@ -224,12 +226,17 @@ public class BulkMarkerActivity extends AppCompatActivity implements AdapterView
 
         viewCountView = (TextView) findViewById(R.id.countView);
 
-        mapView.addOnMapChangedListener(change -> {
-          if (change == MapView.REGION_IS_CHANGING || change == MapView.REGION_DID_CHANGE) {
-            if (!mapboxMap.getMarkerViewManager().getMarkerViewAdapters().isEmpty()) {
-              viewCountView.setText(String.format(Locale.getDefault(), "ViewCache size %d",
-                mapboxMap.getMarkerViewManager().getMarkerViewContainer().getChildCount()));
-            }
+        mapView.addOnCameraIsChangingListener(new MapView.OnCameraIsChangingListener() {
+          @Override
+          public void onCameraIsChanging() {
+            onCameraChange();
+          }
+        });
+
+        mapView.addOnCameraDidChangeListener(new MapView.OnCameraDidChangeListener() {
+          @Override
+          public void onCameraDidChange(boolean animated) {
+            onCameraChange();
           }
         });
 
@@ -241,6 +248,13 @@ public class BulkMarkerActivity extends AppCompatActivity implements AdapterView
               Toast.LENGTH_SHORT).show();
             return false;
           });
+      }
+    }
+
+    private void onCameraChange() {
+      if (!mapboxMap.getMarkerViewManager().getMarkerViewAdapters().isEmpty()) {
+        viewCountView.setText(String.format(Locale.getDefault(), "ViewCache size %d",
+          mapboxMap.getMarkerViewManager().getMarkerViewContainer().getChildCount()));
       }
     }
   }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/MarkerViewActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/MarkerViewActivity.java
@@ -58,6 +58,7 @@ public class MarkerViewActivity extends AppCompatActivity {
 
   private MapboxMap mapboxMap;
   private MapView mapView;
+  private TextView viewCountView;
 
   // MarkerView location updates
   private MarkerView movingMarkerOne;
@@ -77,7 +78,7 @@ public class MarkerViewActivity extends AppCompatActivity {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_marker_view);
 
-    final TextView viewCountView = (TextView) findViewById(R.id.countView);
+    viewCountView = (TextView) findViewById(R.id.countView);
     mapView = (MapView) findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(mapboxMap -> {
@@ -140,18 +141,12 @@ public class MarkerViewActivity extends AppCompatActivity {
       markerViewManager.addMarkerViewAdapter(new CountryAdapter(MarkerViewActivity.this, mapboxMap));
       markerViewManager.addMarkerViewAdapter(new TextAdapter(MarkerViewActivity.this, mapboxMap));
 
-      final ViewGroup markerViewContainer = markerViewManager.getMarkerViewContainer();
 
       // add a change listener to validate the size of amount of child views
-      mapView.addOnMapChangedListener(change -> {
-        if (change == MapView.REGION_IS_CHANGING || change == MapView.REGION_DID_CHANGE) {
-          if (!markerViewManager.getMarkerViewAdapters().isEmpty() && viewCountView != null) {
-            viewCountView.setText(String.format(
-              Locale.getDefault(),
-              getString(R.string.viewcache_size),
-              markerViewContainer.getChildCount())
-            );
-          }
+      mapView.addOnCameraDidChangeListener(new MapView.OnCameraDidChangeListener() {
+        @Override
+        public void onCameraDidChange(boolean animated) {
+          setViewCount();
         }
       });
 
@@ -192,6 +187,18 @@ public class MarkerViewActivity extends AppCompatActivity {
       mapboxMap.selectMarker(markerRightOffScreen);
       mapboxMap.selectMarker(markerRightBottomOffScreen);
     });
+  }
+
+  private void setViewCount() {
+    final MarkerViewManager markerViewManager = mapboxMap.getMarkerViewManager();
+    final ViewGroup markerViewContainer = markerViewManager.getMarkerViewContainer();
+    if (!markerViewManager.getMarkerViewAdapters().isEmpty() && viewCountView != null) {
+      viewCountView.setText(String.format(
+        Locale.getDefault(),
+        getString(R.string.viewcache_size),
+        markerViewContainer.getChildCount())
+      );
+    }
   }
 
   private void loopMarkerRotate() {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/MapFragmentActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/MapFragmentActivity.java
@@ -2,6 +2,7 @@ package com.mapbox.mapboxsdk.testapp.activity.fragment;
 
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.constants.Style;
@@ -20,7 +21,7 @@ import com.mapbox.mapboxsdk.testapp.R;
  * </p>
  */
 public class MapFragmentActivity extends AppCompatActivity implements MapFragment.OnMapViewReadyCallback,
-  OnMapReadyCallback, MapView.OnMapChangedListener {
+  OnMapReadyCallback, MapView.OnDidFinishRenderingFrameListener {
 
   private MapboxMap mapboxMap;
   private MapView mapView;
@@ -31,10 +32,10 @@ public class MapFragmentActivity extends AppCompatActivity implements MapFragmen
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_map_fragment);
     if (savedInstanceState == null) {
-      MapFragment mapFragment =  MapFragment.newInstance(createFragmentOptions());
+      MapFragment mapFragment = MapFragment.newInstance(createFragmentOptions());
       getFragmentManager()
         .beginTransaction()
-        .add(R.id.fragment_container,mapFragment, "com.mapbox.map")
+        .add(R.id.fragment_container, mapFragment, "com.mapbox.map")
         .commit();
       mapFragment.getMapAsync(this);
     }
@@ -64,7 +65,7 @@ public class MapFragmentActivity extends AppCompatActivity implements MapFragmen
   @Override
   public void onMapViewReady(MapView map) {
     mapView = map;
-    mapView.addOnMapChangedListener(this);
+    mapView.addOnDidFinishRenderingFrameListener(this);
   }
 
   @Override
@@ -73,17 +74,17 @@ public class MapFragmentActivity extends AppCompatActivity implements MapFragmen
   }
 
   @Override
-  public void onMapChanged(int change) {
-    if (initialCameraAnimation && change == MapView.DID_FINISH_RENDERING_MAP_FULLY_RENDERED && mapboxMap != null) {
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.removeOnDidFinishRenderingFrameListener(this);
+  }
+
+  @Override
+  public void onDidFinishRenderingFrame(boolean fully) {
+    if (initialCameraAnimation && fully && mapboxMap != null) {
       mapboxMap.animateCamera(
         CameraUpdateFactory.newCameraPosition(new CameraPosition.Builder().tilt(45.0).build()), 5000);
       initialCameraAnimation = false;
     }
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.removeOnMapChangedListener(this);
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/SupportMapFragmentActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/SupportMapFragmentActivity.java
@@ -2,6 +2,7 @@ package com.mapbox.mapboxsdk.testapp.activity.fragment;
 
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.constants.Style;
@@ -21,7 +22,7 @@ import com.mapbox.mapboxsdk.testapp.R;
  * </p>
  */
 public class SupportMapFragmentActivity extends AppCompatActivity implements MapFragment.OnMapViewReadyCallback,
-  OnMapReadyCallback, MapView.OnMapChangedListener {
+  OnMapReadyCallback, MapView.OnDidFinishRenderingFrameListener {
 
   private MapboxMap mapboxMap;
   private MapView mapView;
@@ -65,7 +66,7 @@ public class SupportMapFragmentActivity extends AppCompatActivity implements Map
   @Override
   public void onMapViewReady(MapView map) {
     mapView = map;
-    mapView.addOnMapChangedListener(this);
+    mapView.addOnDidFinishRenderingFrameListener(this);
   }
 
   @Override
@@ -74,17 +75,17 @@ public class SupportMapFragmentActivity extends AppCompatActivity implements Map
   }
 
   @Override
-  public void onMapChanged(int change) {
-    if (initialCameraAnimation && change == MapView.DID_FINISH_RENDERING_MAP_FULLY_RENDERED && mapboxMap != null) {
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.removeOnDidFinishRenderingFrameListener(this);
+  }
+
+  @Override
+  public void onDidFinishRenderingFrame(boolean fully) {
+    if (initialCameraAnimation && fully && mapboxMap != null) {
       mapboxMap.animateCamera(
         CameraUpdateFactory.newCameraPosition(new CameraPosition.Builder().tilt(45.0).build()), 5000);
       initialCameraAnimation = false;
     }
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.removeOnMapChangedListener(this);
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
@@ -80,9 +80,9 @@ public class DebugModeActivity extends AppCompatActivity implements OnMapReadyCa
 
   private void setupMapView(Bundle savedInstanceState) {
     mapView = (MapView) findViewById(R.id.mapView);
-    mapView.addOnMapChangedListener(change -> {
-      if (change == MapView.DID_FINISH_LOADING_STYLE && mapboxMap != null) {
-        Timber.v("New style loaded with JSON: %s", mapboxMap.getStyleJson());
+
+    mapView.addOnDidFinishLoadingStyleListener(() -> {
+      if (mapboxMap != null) {
         setupNavigationView(mapboxMap.getLayers());
       }
     });
@@ -99,6 +99,8 @@ public class DebugModeActivity extends AppCompatActivity implements OnMapReadyCa
     mapboxMap.getUiSettings().setZoomControlsEnabled(true);
 
     setupNavigationView(mapboxMap.getLayers());
+
+    setupNavigationView(mapboxMap.getLayers());
     setupZoomView();
     setFpsView();
   }
@@ -111,6 +113,7 @@ public class DebugModeActivity extends AppCompatActivity implements OnMapReadyCa
   }
 
   private void setupNavigationView(List<Layer> layerList) {
+    Timber.v("New style loaded with JSON: %s", mapboxMap.getStyleJson());
     final LayerListAdapter adapter = new LayerListAdapter(this, layerList);
     ListView listView = (ListView) findViewById(R.id.listView);
     listView.setAdapter(adapter);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/textureview/TextureViewDebugModeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/textureview/TextureViewDebugModeActivity.java
@@ -80,9 +80,9 @@ public class TextureViewDebugModeActivity extends AppCompatActivity implements O
 
   private void setupMapView(Bundle savedInstanceState) {
     mapView = (MapView) findViewById(R.id.mapView);
-    mapView.addOnMapChangedListener(change -> {
-      if (change == MapView.DID_FINISH_LOADING_STYLE && mapboxMap != null) {
-        Timber.v("New style loaded with JSON: %s", mapboxMap.getStyleJson());
+
+    mapView.addOnDidFinishLoadingStyleListener(() -> {
+      if (mapboxMap != null) {
         setupNavigationView(mapboxMap.getLayers());
       }
     });
@@ -109,6 +109,7 @@ public class TextureViewDebugModeActivity extends AppCompatActivity implements O
   }
 
   private void setupNavigationView(List<Layer> layerList) {
+    Timber.v("New style loaded with JSON: %s", mapboxMap.getStyleJson());
     final LayerListAdapter adapter = new LayerListAdapter(this, layerList);
     ListView listView = (ListView) findViewById(R.id.listView);
     listView.setAdapter(adapter);


### PR DESCRIPTION
Fixes a small regression introduced by the https://github.com/mapbox/mapbox-gl-native/pull/13133 - when requesting a new style before the drawing surface is initialized, before, we were relying on `NativeMapView` being created after the view hierarchy is established, which means, that calls like [`mapView#setStyleUrl`](https://github.com/mapbox/mapbox-gl-native/blob/7a9461a8d439458b18656ecfb839923adc5f0e9b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/offline/OfflineActivity.java#L79) done in the `#onCreate` would add the style to the `MapboxMapOptions`, because `NativeMapView` was still `null`. Now, we are initializing the `NativeMapView` immediately, which means that calling `mapView#setStyleUrl` would start loading the style instantly introducing a race condition - we would either create the drawing surface before the style is loaded, then the execution continued as expected, or the style would've loaded first, resulting in not delivering `OnMapReady` at all.

The other part of this PR removes the usage of the deprecated `OnMapChange` listener across the project.