### PR TITLE
Fix sign flip in programmatic camera rotation

### DIFF
--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -1221,7 +1221,7 @@ public:
                                            camera.centerCoordinate.latitude,
                                            self.frame.size);
     if (camera.heading >= 0) {
-        options.angle = -camera.heading;
+        options.angle = camera.heading;
     }
     if (camera.pitch >= 0) {
         options.pitch = camera.pitch;


### PR DESCRIPTION
This is a followup to #13212 that fixes an issue where the `mbgl::CameraOptions`’ heading was misinterpreted as going counterclockwise instead of clockwise. I had removed the redundant negative sign from the iOS implementation but accidentally left it in the macOS implementation.

/cc @julianrex @friedbunny