### PR TITLE
Add Fragment Activity setup to testapp, fix app compat requirement

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
@@ -595,7 +595,6 @@ public final class UiSettings {
    * <p>
    * Sets the tint of the attribution view. Use this to change the color of the attribution.
    * </p>
-   * By default, the logo is tinted with the primary color of your theme.
    *
    * @param tintColor Color to tint the attribution.
    */

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/ColorUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/ColorUtils.java
@@ -4,14 +4,12 @@ import android.content.Context;
 import android.content.res.ColorStateList;
 import android.content.res.Resources;
 import android.graphics.Color;
-import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.support.annotation.ColorInt;
 import android.support.annotation.NonNull;
-import android.support.v4.graphics.drawable.DrawableCompat;
+import android.support.v4.widget.ImageViewCompat;
 import android.util.TypedValue;
 import android.widget.ImageView;
-
 import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.exceptions.ConversionException;
 
@@ -109,12 +107,10 @@ public class ColorUtils {
    * @param tintColor The color to tint.
    */
   public static void setTintList(@NonNull ImageView imageView, @ColorInt int tintColor) {
-    Drawable originalDrawable = imageView.getDrawable();
-    Drawable wrappedDrawable = DrawableCompat.wrap(originalDrawable);
-    DrawableCompat.setTintList(wrappedDrawable, getSelector(tintColor));
+    ImageViewCompat.setImageTintList(imageView, getSelector(tintColor));
   }
 
-  static int normalizeColorComponent(String value) {
+  private static int normalizeColorComponent(String value) {
     return (int) (Float.parseFloat(value) * 255);
   }
 
@@ -151,7 +147,7 @@ public class ColorUtils {
    * @return String rgba color
    */
   public static String colorToRgbaString(@ColorInt int color) {
-    String alpha = new DecimalFormat("#.###").format(((float)((color >> 24) & 0xFF)) / 255.0f);
+    String alpha = new DecimalFormat("#.###").format(((float) ((color >> 24) & 0xFF)) / 255.0f);
     return String.format(Locale.US, "rgba(%d, %d, %d, %s)",
       (color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF, alpha);
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_internal.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_internal.xml
@@ -14,7 +14,7 @@
         android:layout_height="wrap_content"
         android:contentDescription="@string/mapbox_compassContentDescription"/>
 
-    <ImageView
+    <android.support.v7.widget.AppCompatImageView
         android:visibility="gone"
         android:id="@+id/logoView"
         android:layout_width="wrap_content"
@@ -22,7 +22,7 @@
         android:contentDescription="@null"
         app:srcCompat="@drawable/mapbox_logo_icon"/>
 
-    <ImageView
+    <android.support.v7.widget.AppCompatImageView
         android:visibility="gone"
         android:id="@+id/attributionView"
         android:layout_width="wrap_content"

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -126,6 +126,7 @@
         </activity>
         <activity
             android:name=".activity.camera.CameraPositionActivity"
+            android:theme="@style/NoActionBar"
             android:description="@string/description_cameraposition"
             android:label="@string/activity_camera_position">
             <meta-data

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraPositionActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraPositionActivity.java
@@ -6,14 +6,14 @@ import android.os.Bundle;
 import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
+import android.support.v4.app.FragmentActivity;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
-import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.SeekBar;
 import android.widget.TextView;
-
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -21,13 +21,12 @@ import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.testapp.R;
-
 import timber.log.Timber;
 
 /**
  * Test activity showcasing how to listen to camera change events.
  */
-public class CameraPositionActivity extends AppCompatActivity implements OnMapReadyCallback, View.OnClickListener,
+public class CameraPositionActivity extends FragmentActivity implements OnMapReadyCallback, View.OnClickListener,
   MapboxMap.OnMapLongClickListener {
 
   private MapView mapView;
@@ -39,6 +38,11 @@ public class CameraPositionActivity extends AppCompatActivity implements OnMapRe
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_camera_position);
+
+    Toolbar toolbar = findViewById(R.id.toolbar);
+    toolbar.setTitle(R.string.activity_camera_position);
+    toolbar.setNavigationIcon(R.drawable.ic_ab_back);
+    toolbar.setNavigationOnClickListener(v -> finish());
 
     mapView = (MapView) findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/drawable/ic_ab_back.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/drawable/ic_ab_back.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0"
+        android:autoMirrored="true"
+        android:tint="#FFFFFF">
+    <path
+            android:pathData="M20,11L7.8,11l5.6,-5.6L12,4l-8,8l8,8l1.4,-1.4L7.8,13L20,13L20,11z"
+            android:fillColor="#FFFFFF"/>
+</vector>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_camera_position.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_camera_position.xml
@@ -1,24 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.design.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/coordinator_layout"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/coordinator_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+    <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_height="?android:attr/actionBarSize"
+            android:layout_width="match_parent"
+            android:minHeight="?android:attr/actionBarSize"
+            android:background="@color/primary" />
 
     <com.mapbox.mapboxsdk.maps.MapView
-        android:id="@id/mapView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:mapbox_styleUrl="@string/mapbox_style_mapbox_streets"/>
+            android:id="@id/mapView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="?android:attr/actionBarSize"
+            app:mapbox_uiAttributionTintColor="@color/redAccent"
+            app:mapbox_styleUrl="@string/mapbox_style_mapbox_streets"/>
 
     <android.support.design.widget.FloatingActionButton
-        android:id="@+id/fab"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="end|bottom"
-        android:layout_margin="@dimen/fab_margin"
-        android:src="@drawable/ic_input"
-        app:backgroundTint="@android:color/white"/>
+            android:id="@+id/fab"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end|bottom"
+            android:layout_margin="@dimen/fab_margin"
+            app:srcCompat="@drawable/ic_input"
+            app:backgroundTint="@android:color/white"/>
 
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/13217, Cherry picks solution from https://github.com/mapbox/mapbox-gl-native/pull/13219 + adds a simple example to harden against regressions and replaces tinting by ImageViewCompat equivalent. 

cc @philemonmerlet 