### PR TITLE
[ios] Update pre-release installation instructions

### DIFF
--- a/platform/ios/INSTALL.md
+++ b/platform/ios/INSTALL.md
@@ -104,12 +104,14 @@ You can alternatively install the SDK as a static framework:
 
 #### CocoaPods
 
+For instructions on installing stable release versions of the Mapbox Maps SDK for iOS with CocoaPods, see [our website](https://www.mapbox.com/install/ios/cocoapods/).
+
 ##### Testing pre-releases with CocoaPods
 
-To test pre-releases and/or betas, you can reference the pre-release like so in your Podfile:
+To test pre-releases of the dynamic framework, directly specify the version in your Podfile:
 
 ```rb
-pod 'Mapbox-iOS-SDK-symbols', podspec: 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/<insert branch or tag>/platform/ios/Mapbox-iOS-SDK-symbols.podspec'
+pod 'Mapbox-iOS-SDK', '~> x.x.x-alpha.1'
 ```
 
 ##### Testing nightly releases with CocoaPods
@@ -140,7 +142,11 @@ For instructions on installing stable release versions of the Mapbox Maps SDK fo
 
 ##### Testing pre-releases with Carthage
 
-Carthage currently does not support pre-release versions of binaries.
+To test pre-releases of the dynamic framework, directly specify the version in your Cartfile:
+
+```json
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> x.x.x-alpha.1
+```
 
 ##### Using your own build with Carthage
 

--- a/platform/ios/scripts/release-notes-github.md.ejs
+++ b/platform/ios/scripts/release-notes-github.md.ejs
@@ -3,10 +3,7 @@
 <%-CHANGELOG-%>
 
 <% if (isPrerelease) { %>
-To install this prerelease via CocoaPods, point your Podfile to either of these URLs:
-
-* https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v<%-CURRENTVERSION%>/platform/ios/Mapbox-iOS-SDK.podspec
-* https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v<%-CURRENTVERSION%>/platform/ios/Mapbox-iOS-SDK-symbols.podspec
+To install this pre-release via a dependency manager, see our [CocoaPods](https://github.com/mapbox/mapbox-gl-native/blob/<%-CURRENTVERSION%>/platform/ios/INSTALL.md#CocoaPods) or [Carthage](https://github.com/mapbox/mapbox-gl-native/blob/<%-CURRENTVERSION%>/platform/ios/INSTALL.md#Carthage) instructions.
 <% } -%>
 
 Documentation is [available online](https://www.mapbox.com/ios-sdk/api/<%-CURRENTVERSION%>/) or as part of the download.


### PR DESCRIPTION
Fixes #6235. It’s now possible to consume pre-release builds via both CocoaPods and Carthage.

/cc @mapbox/maps-ios 