### PR TITLE
Introduce the style::Layer factory classes

### DIFF
--- a/include/mbgl/style/layer.hpp
+++ b/include/mbgl/style/layer.hpp
@@ -30,9 +30,9 @@ class Filter;
  * * Cloning and copying
  *
  * All other functionality lives in the derived classes. To instantiate a layer, create an instance of the desired
- * type, passing the ID:
+ * type, calling `LayerManager`:
  *
- *     auto circleLayer = std::make_unique<CircleLayer>("my-circle-layer");
+ *     auto circleLayer = LayerManager::get()->createLayer("circle", ...);
  */
 class Layer {
 public:
@@ -87,6 +87,43 @@ protected:
     virtual Mutable<Impl> mutableBaseImpl() const = 0;
 
     LayerObserver* observer = nullptr;
+};
+
+/**
+ * @brief The LayerFactory abstract class
+ * 
+ * This class is responsible for creation of the layer objects that belong to a concrete layer type.
+ */
+class LayerFactory {
+public:
+    virtual ~LayerFactory() = default;
+    /// Returns the type of the layers, created by this factory.
+    virtual const char* type() const = 0;
+    /// Returns a new Layer instance on success call; returns `nulltptr` otherwise. 
+    virtual std::unique_ptr<Layer> createLayer(const std::string& id, const conversion::Convertible& value) = 0;
+protected:
+    optional<std::string> getSource(const conversion::Convertible& value) const;
+    bool initSourceLayerAndFilter(Layer*, const conversion::Convertible& value) const;
+};
+
+/**
+ * @brief A singleton class forwarding calls to the corresponding  \c LayerFactory instance.
+ */
+class LayerManager {
+public:
+    /**
+     * @brief A singleton getter.
+     * 
+     * @return LayerManager* 
+     */
+    static LayerManager* get();
+
+    virtual ~LayerManager() = default;
+    /// Returns a new Layer instance on success call; returns `nulltptr` otherwise.
+    virtual std::unique_ptr<Layer> createLayer(const std::string& type, const std::string& id, const conversion::Convertible& value, conversion::Error& error) = 0;
+
+protected:
+    LayerManager() = default;
 };
 
 } // namespace style

--- a/include/mbgl/style/layers/background_layer.hpp
+++ b/include/mbgl/style/layers/background_layer.hpp
@@ -56,5 +56,13 @@ protected:
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
+class BackgroundLayerFactory : public LayerFactory {
+protected:
+    // LayerFactory overrides.
+    ~BackgroundLayerFactory() override;
+    const char* type() const final;
+    std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) override;
+};
+
 } // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/layers/circle_layer.hpp
+++ b/include/mbgl/style/layers/circle_layer.hpp
@@ -104,5 +104,13 @@ protected:
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
+class CircleLayerFactory : public LayerFactory {
+protected:
+    // LayerFactory overrides.
+    ~CircleLayerFactory() override;
+    const char* type() const final;
+    std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) override;
+};
+
 } // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/layers/fill_extrusion_layer.hpp
+++ b/include/mbgl/style/layers/fill_extrusion_layer.hpp
@@ -80,5 +80,13 @@ protected:
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
+class FillExtrusionLayerFactory : public LayerFactory {
+protected:
+    // LayerFactory overrides.
+    ~FillExtrusionLayerFactory() override;
+    const char* type() const final;
+    std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) override;
+};
+
 } // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/layers/fill_layer.hpp
+++ b/include/mbgl/style/layers/fill_layer.hpp
@@ -80,5 +80,13 @@ protected:
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
+class FillLayerFactory : public LayerFactory {
+protected:
+    // LayerFactory overrides.
+    ~FillLayerFactory() override;
+    const char* type() const final;
+    std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) override;
+};
+
 } // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/layers/heatmap_layer.hpp
+++ b/include/mbgl/style/layers/heatmap_layer.hpp
@@ -69,5 +69,13 @@ protected:
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
+class HeatmapLayerFactory : public LayerFactory {
+protected:
+    // LayerFactory overrides.
+    ~HeatmapLayerFactory() override;
+    const char* type() const final;
+    std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) override;
+};
+
 } // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/layers/hillshade_layer.hpp
+++ b/include/mbgl/style/layers/hillshade_layer.hpp
@@ -74,5 +74,13 @@ protected:
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
+class HillshadeLayerFactory : public LayerFactory {
+protected:
+    // LayerFactory overrides.
+    ~HillshadeLayerFactory() override;
+    const char* type() const final;
+    std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) override;
+};
+
 } // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/layers/layer.hpp.ejs
+++ b/include/mbgl/style/layers/layer.hpp.ejs
@@ -72,5 +72,13 @@ protected:
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
+class <%- camelize(type) %>LayerFactory : public LayerFactory {
+protected:
+    // LayerFactory overrides.
+    ~<%- camelize(type) %>LayerFactory() override;
+    const char* type() const final;
+    std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) override;
+};
+
 } // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/layers/line_layer.hpp
+++ b/include/mbgl/style/layers/line_layer.hpp
@@ -125,5 +125,13 @@ protected:
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
+class LineLayerFactory : public LayerFactory {
+protected:
+    // LayerFactory overrides.
+    ~LineLayerFactory() override;
+    const char* type() const final;
+    std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) override;
+};
+
 } // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/layers/raster_layer.hpp
+++ b/include/mbgl/style/layers/raster_layer.hpp
@@ -86,5 +86,13 @@ protected:
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
+class RasterLayerFactory : public LayerFactory {
+protected:
+    // LayerFactory overrides.
+    ~RasterLayerFactory() override;
+    const char* type() const final;
+    std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) override;
+};
+
 } // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/layers/symbol_layer.hpp
+++ b/include/mbgl/style/layers/symbol_layer.hpp
@@ -274,5 +274,13 @@ protected:
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
+class SymbolLayerFactory : public LayerFactory {
+protected:
+    // LayerFactory overrides.
+    ~SymbolLayerFactory() override;
+    const char* type() const final;
+    std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) override;
+};
+
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/conversion/layer.cpp
+++ b/src/mbgl/style/conversion/layer.cpp
@@ -2,15 +2,6 @@
 #include <mbgl/style/conversion/constant.hpp>
 #include <mbgl/style/conversion/filter.hpp>
 #include <mbgl/style/conversion_impl.hpp>
-#include <mbgl/style/layers/background_layer.hpp>
-#include <mbgl/style/layers/circle_layer.hpp>
-#include <mbgl/style/layers/fill_layer.hpp>
-#include <mbgl/style/layers/fill_extrusion_layer.hpp>
-#include <mbgl/style/layers/heatmap_layer.hpp>
-#include <mbgl/style/layers/hillshade_layer.hpp>
-#include <mbgl/style/layers/line_layer.hpp>
-#include <mbgl/style/layers/raster_layer.hpp>
-#include <mbgl/style/layers/symbol_layer.hpp>
 
 namespace mbgl {
 namespace style {
@@ -27,81 +18,6 @@ optional<Error> setPaintProperties(Layer& layer, const Convertible& value) {
     return eachMember(*paintValue, [&] (const std::string& k, const Convertible& v) {
         return layer.setPaintProperty(k, v);
     });
-}
-
-template <class LayerType>
-optional<std::unique_ptr<Layer>> convertVectorLayer(const std::string& id, const Convertible& value, Error& error) {
-    auto sourceValue = objectMember(value, "source");
-    if (!sourceValue) {
-        error.message = "layer must have a source";
-        return nullopt;
-    }
-
-    optional<std::string> source = toString(*sourceValue);
-    if (!source) {
-        error.message = "layer source must be a string";
-        return nullopt;
-    }
-
-    std::unique_ptr<LayerType> layer = std::make_unique<LayerType>(id, *source);
-
-    auto sourceLayerValue = objectMember(value, "source-layer");
-    if (sourceLayerValue) {
-        optional<std::string> sourceLayer = toString(*sourceLayerValue);
-        if (!sourceLayer) {
-            error.message = "layer source-layer must be a string";
-            return nullopt;
-        }
-        layer->setSourceLayer(*sourceLayer);
-    }
-
-    auto filterValue = objectMember(value, "filter");
-    if (filterValue) {
-        optional<Filter> filter = convert<Filter>(*filterValue, error);
-        if (!filter) {
-            return nullopt;
-        }
-        layer->setFilter(*filter);
-    }
-
-    return { std::move(layer) };
-}
-
-static optional<std::unique_ptr<Layer>> convertRasterLayer(const std::string& id, const Convertible& value, Error& error) {
-    auto sourceValue = objectMember(value, "source");
-    if (!sourceValue) {
-        error.message = "layer must have a source";
-        return nullopt;
-    }
-
-    optional<std::string> source = toString(*sourceValue);
-    if (!source) {
-        error.message = "layer source must be a string";
-        return nullopt;
-    }
-
-    return { std::make_unique<RasterLayer>(id, *source) };
-}
-
-static optional<std::unique_ptr<Layer>> convertHillshadeLayer(const std::string& id, const Convertible& value, Error& error) {
-    auto sourceValue = objectMember(value, "source");
-    if (!sourceValue) {
-        error.message = "layer must have a source";
-        return nullopt;
-    }
-
-    optional<std::string> source = toString(*sourceValue);
-    if (!source) {
-        error.message = "layer source must be a string";
-        return nullopt;
-    }
-
-    return { std::make_unique<HillshadeLayer>(id, *source) };
-}
-
-
-static optional<std::unique_ptr<Layer>> convertBackgroundLayer(const std::string& id, const Convertible&, Error&) {
-    return { std::make_unique<BackgroundLayer>(id) };
 }
 
 optional<std::unique_ptr<Layer>> Converter<std::unique_ptr<Layer>>::operator()(const Convertible& value, Error& error) const {
@@ -134,36 +50,10 @@ optional<std::unique_ptr<Layer>> Converter<std::unique_ptr<Layer>>::operator()(c
         return nullopt;
     }
 
-    optional<std::unique_ptr<Layer>> converted;
-
-    if (*type == "fill") {
-        converted = convertVectorLayer<FillLayer>(*id, value, error);
-    } else if (*type == "fill-extrusion") {
-        converted = convertVectorLayer<FillExtrusionLayer>(*id, value, error);
-    } else if (*type == "line") {
-        converted = convertVectorLayer<LineLayer>(*id, value, error);
-    } else if (*type == "circle") {
-        converted = convertVectorLayer<CircleLayer>(*id, value, error);
-    } else if (*type == "symbol") {
-        converted = convertVectorLayer<SymbolLayer>(*id, value, error);
-    } else if (*type == "raster") {
-        converted = convertRasterLayer(*id, value, error);
-    } else if (*type == "heatmap") {
-        converted = convertVectorLayer<HeatmapLayer>(*id, value, error);
-    } else if (*type == "hillshade") {
-        converted = convertHillshadeLayer(*id, value, error);
-    } else if (*type == "background") {
-        converted = convertBackgroundLayer(*id, value, error);
-    } else {
-        error.message = "invalid layer type";
+    std::unique_ptr<Layer> layer = LayerManager::get()->createLayer(*type, *id, value, error);
+    if (!layer) {
         return nullopt;
     }
-
-    if (!converted) {
-        return converted;
-    }
-
-    std::unique_ptr<Layer> layer = std::move(*converted);
 
     auto minzoomValue = objectMember(value, "minzoom");
     if (minzoomValue) {

--- a/src/mbgl/style/layer.cpp
+++ b/src/mbgl/style/layer.cpp
@@ -2,7 +2,19 @@
 #include <mbgl/style/layer_impl.hpp>
 #include <mbgl/style/layer_observer.hpp>
 #include <mbgl/style/conversion/constant.hpp>
+#include <mbgl/style/conversion/filter.hpp>
 #include <mbgl/style/conversion_impl.hpp>
+
+#include <mbgl/style/layers/symbol_layer.hpp>
+#include <mbgl/style/layers/background_layer.hpp>
+#include <mbgl/style/layers/circle_layer.hpp>
+#include <mbgl/style/layers/fill_extrusion_layer.hpp>
+#include <mbgl/style/layers/fill_layer.hpp>
+#include <mbgl/style/layers/heatmap_layer.hpp>
+#include <mbgl/style/layers/hillshade_layer.hpp>
+#include <mbgl/style/layers/line_layer.hpp>
+#include <mbgl/style/layers/raster_layer.hpp>
+#include <mbgl/style/layers/symbol_layer.hpp>
 
 namespace mbgl {
 namespace style {
@@ -105,6 +117,90 @@ optional<conversion::Error> Layer::setVisibility(const conversion::Convertible& 
     setVisibility(*visibility);
     return nullopt;
 }
+
+optional<std::string> LayerFactory::getSource(const conversion::Convertible& value) const {
+    auto sourceValue = objectMember(value, "source");
+    if (!sourceValue) {
+        return nullopt;
+    }
+
+    optional<std::string> source = toString(*sourceValue);
+    if (!source) {
+        return nullopt;
+    }
+
+    return source;
+}
+
+bool LayerFactory::initSourceLayerAndFilter(Layer* layer, const conversion::Convertible& value) const {
+    auto sourceLayerValue = objectMember(value, "source-layer");
+    if (sourceLayerValue) {
+        optional<std::string> sourceLayer = toString(*sourceLayerValue);
+        if (!sourceLayer) {
+            return false;
+        }
+        layer->setSourceLayer(*sourceLayer);
+    }
+
+    auto filterValue = objectMember(value, "filter");
+    if (filterValue) {
+        conversion::Error error;
+        optional<Filter> filter = conversion::convert<Filter>(*filterValue, error);
+        if (!filter) {
+            return false;
+        }
+        layer->setFilter(*filter);
+    }
+
+    return true;
+}
+
+// TODO: Move the LayerManager implementation to the dedicated .cpp file per platform.
+class LayerManagerImpl : public LayerManager {
+public:
+    void addLayerFactory(LayerFactory* factory) {
+        factories.emplace(std::make_pair(factory->type(), std::unique_ptr<LayerFactory>(factory)));
+    }
+private:
+    // LayerManager overrides.
+    std::unique_ptr<Layer> createLayer(const std::string& type, const std::string& id, const conversion::Convertible& value, conversion::Error& error) final;
+
+    std::unordered_map<std::string, std::unique_ptr<LayerFactory>> factories;
+};
+
+std::unique_ptr<Layer> LayerManagerImpl::createLayer(const std::string& type, const std::string& id, const conversion::Convertible& value, conversion::Error& error) {
+    auto search = factories.find(type);
+    if (search != factories.end()) {
+        if (auto layer = search->second->createLayer(id, value)) {
+            return layer;
+        }
+        error.message = "Error parsing a layer of type: " + type;
+    } else {
+        error.message = "Unsupported layer type: " + type;
+    }
+    return nullptr;
+}
+
+// static 
+LayerManager* LayerManager::get() {
+    static LayerManager* instance = nullptr;
+    if (instance == nullptr) {
+       static LayerManagerImpl impl;
+       impl.addLayerFactory(new FillLayerFactory);
+       impl.addLayerFactory(new LineLayerFactory);
+       impl.addLayerFactory(new CircleLayerFactory);
+       impl.addLayerFactory(new SymbolLayerFactory);
+       impl.addLayerFactory(new RasterLayerFactory);
+       impl.addLayerFactory(new BackgroundLayerFactory);
+       impl.addLayerFactory(new HillshadeLayerFactory);
+       impl.addLayerFactory(new FillExtrusionLayerFactory);
+       impl.addLayerFactory(new HeatmapLayerFactory);
+
+       instance = &impl;
+    }
+    return instance;
+}
+
 
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/layers/background_layer.cpp
+++ b/src/mbgl/style/layers/background_layer.cpp
@@ -270,5 +270,16 @@ Mutable<Layer::Impl> BackgroundLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
+BackgroundLayerFactory::~BackgroundLayerFactory() = default;
+
+const char* BackgroundLayerFactory::type() const {
+    return "background";
+}
+
+std::unique_ptr<style::Layer> BackgroundLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {
+    (void)value;
+    return std::unique_ptr<style::Layer>(new BackgroundLayer(id));
+}
+
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/layers/circle_layer.cpp
+++ b/src/mbgl/style/layers/circle_layer.cpp
@@ -687,5 +687,24 @@ Mutable<Layer::Impl> CircleLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
+CircleLayerFactory::~CircleLayerFactory() = default;
+
+const char* CircleLayerFactory::type() const {
+    return "circle";
+}
+
+std::unique_ptr<style::Layer> CircleLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {
+    optional<std::string> source = getSource(value);
+    if (!source) {
+        return nullptr;
+    }
+
+    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new CircleLayer(id, *source));
+    if (!initSourceLayerAndFilter(layer.get(), value)) {
+        return nullptr;
+    }
+    return layer;
+}
+
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/layers/fill_extrusion_layer.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer.cpp
@@ -489,5 +489,24 @@ Mutable<Layer::Impl> FillExtrusionLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
+FillExtrusionLayerFactory::~FillExtrusionLayerFactory() = default;
+
+const char* FillExtrusionLayerFactory::type() const {
+    return "fill-extrusion";
+}
+
+std::unique_ptr<style::Layer> FillExtrusionLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {
+    optional<std::string> source = getSource(value);
+    if (!source) {
+        return nullptr;
+    }
+
+    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new FillExtrusionLayer(id, *source));
+    if (!initSourceLayerAndFilter(layer.get(), value)) {
+        return nullptr;
+    }
+    return layer;
+}
+
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/layers/fill_layer.cpp
+++ b/src/mbgl/style/layers/fill_layer.cpp
@@ -489,5 +489,24 @@ Mutable<Layer::Impl> FillLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
+FillLayerFactory::~FillLayerFactory() = default;
+
+const char* FillLayerFactory::type() const {
+    return "fill";
+}
+
+std::unique_ptr<style::Layer> FillLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {
+    optional<std::string> source = getSource(value);
+    if (!source) {
+        return nullptr;
+    }
+
+    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new FillLayer(id, *source));
+    if (!initSourceLayerAndFilter(layer.get(), value)) {
+        return nullptr;
+    }
+    return layer;
+}
+
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/layers/heatmap_layer.cpp
+++ b/src/mbgl/style/layers/heatmap_layer.cpp
@@ -374,5 +374,24 @@ Mutable<Layer::Impl> HeatmapLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
+HeatmapLayerFactory::~HeatmapLayerFactory() = default;
+
+const char* HeatmapLayerFactory::type() const {
+    return "heatmap";
+}
+
+std::unique_ptr<style::Layer> HeatmapLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {
+    optional<std::string> source = getSource(value);
+    if (!source) {
+        return nullptr;
+    }
+
+    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new HeatmapLayer(id, *source));
+    if (!initSourceLayerAndFilter(layer.get(), value)) {
+        return nullptr;
+    }
+    return layer;
+}
+
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/layers/hillshade_layer.cpp
+++ b/src/mbgl/style/layers/hillshade_layer.cpp
@@ -421,5 +421,21 @@ Mutable<Layer::Impl> HillshadeLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
+HillshadeLayerFactory::~HillshadeLayerFactory() = default;
+
+const char* HillshadeLayerFactory::type() const {
+    return "hillshade";
+}
+
+std::unique_ptr<style::Layer> HillshadeLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {
+    optional<std::string> source = getSource(value);
+    if (!source) {
+        return nullptr;
+    }
+
+    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new HillshadeLayer(id, *source));
+    return layer;
+}
+
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/layers/layer.cpp.ejs
+++ b/src/mbgl/style/layers/layer.cpp.ejs
@@ -260,5 +260,31 @@ Mutable<Layer::Impl> <%- camelize(type) %>Layer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
+<%- camelize(type) %>LayerFactory::~<%- camelize(type) %>LayerFactory() = default;
+
+const char* <%- camelize(type) %>LayerFactory::type() const {
+    return "<%- type %>";
+}
+
+std::unique_ptr<style::Layer> <%- camelize(type) %>LayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {
+<% if (type === 'background') { -%>
+    (void)value;
+    return std::unique_ptr<style::Layer>(new <%- camelize(type) %>Layer(id));
+<% } else { -%>
+    optional<std::string> source = getSource(value);
+    if (!source) {
+        return nullptr;
+    }
+
+    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new <%- camelize(type) %>Layer(id, *source));
+<% if (type !== 'raster' && type !== 'hillshade') { -%>
+    if (!initSourceLayerAndFilter(layer.get(), value)) {
+        return nullptr;
+    }
+<% } -%>
+    return layer;
+<% } -%>
+}
+
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -828,5 +828,24 @@ Mutable<Layer::Impl> LineLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
+LineLayerFactory::~LineLayerFactory() = default;
+
+const char* LineLayerFactory::type() const {
+    return "line";
+}
+
+std::unique_ptr<style::Layer> LineLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {
+    optional<std::string> source = getSource(value);
+    if (!source) {
+        return nullptr;
+    }
+
+    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new LineLayer(id, *source));
+    if (!initSourceLayerAndFilter(layer.get(), value)) {
+        return nullptr;
+    }
+    return layer;
+}
+
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/layers/raster_layer.cpp
+++ b/src/mbgl/style/layers/raster_layer.cpp
@@ -510,5 +510,21 @@ Mutable<Layer::Impl> RasterLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
+RasterLayerFactory::~RasterLayerFactory() = default;
+
+const char* RasterLayerFactory::type() const {
+    return "raster";
+}
+
+std::unique_ptr<style::Layer> RasterLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {
+    optional<std::string> source = getSource(value);
+    if (!source) {
+        return nullptr;
+    }
+
+    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new RasterLayer(id, *source));
+    return layer;
+}
+
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/layers/symbol_layer.cpp
+++ b/src/mbgl/style/layers/symbol_layer.cpp
@@ -1978,5 +1978,24 @@ Mutable<Layer::Impl> SymbolLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
+SymbolLayerFactory::~SymbolLayerFactory() = default;
+
+const char* SymbolLayerFactory::type() const {
+    return "symbol";
+}
+
+std::unique_ptr<style::Layer> SymbolLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {
+    optional<std::string> source = getSource(value);
+    if (!source) {
+        return nullptr;
+    }
+
+    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new SymbolLayer(id, *source));
+    if (!initSourceLayerAndFilter(layer.get(), value)) {
+        return nullptr;
+    }
+    return layer;
+}
+
 } // namespace style
 } // namespace mbgl


### PR DESCRIPTION
This patch introduces the initial implementation of
- A `LayerFactory` abstract class that creates `style::Layer` instances of
  a certain layer type (line, hillshade, round, ..)
- A singleton `LayerManager` class, which is responsible for initializing
  the `LayerFactory` instances and forwarding the `create()` calls to the
  corresponding factory.