### PR TITLE
Use clcache to speed up windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,14 @@ if(CCACHE_PROGRAM)
         # Clang also thinks that ccache isn't interactive, so we explicitly need to enable color.
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments -fcolor-diagnostics")
     endif()
+elseif(WIN32)
+    find_program(CLCACHE_PROGRAM clcache)
+    if(CLCACHE_PROGRAM)
+        # clcache doesn't work with external pdb files
+        # https://github.com/frerich/clcache/issues/30
+        string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+        string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+    endif()
 else()
     message(STATUS "Can't find ccache — consider installing ccache to improve recompilation performance")
 endif()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,8 @@ image:
 - Visual Studio 2017
 
 environment:
+  PYTHON:  C:\python37
+
   matrix:
   - configuration: Release
 
@@ -54,6 +56,7 @@ cache:
   - '%APPVEYOR_BUILD_FOLDER%\mason_packages'
   - '%APPVEYOR_BUILD_FOLDER%\LLVM-%LLVM_VERSION%-win64.exe'
   - '%APPVEYOR_BUILD_FOLDER%\cmake-3.10.1-win64-x64.zip'
+  - C:\clcache
 
 install:
   - git config --system core.longpaths true
@@ -71,12 +74,16 @@ install:
       }
       scripts\check-sha256.ps1 LLVM-$env:LLVM_VERSION-win64.exe "$env:LLVM_HASH"
       Start-Process -FilePath "LLVM-$env:LLVM_VERSION-win64.exe" -ArgumentList '/S',"/D=C:\LLVM-$env:LLVM_VERSION" -Wait
+  - set PATH=%PYTHON%\Scripts;%PYTHON%;%PATH%
+  - pip install clcache
 
 before_build:
   - set PATH=C:\LLVM-%LLVM_VERSION%\bin;%PATH%
   - set PATH=C:\cmake-3.10.1-win64-x64\bin;%PATH%
-  - set CC=clang-cl
-  - set CXX=clang-cl
+  - set CLCACHE_DIR=c:\clcache
+  - set CLCACHE_CL=clang-cl
+  - set CC=clcache
+  - set CXX=clcache
   - mkdir %APPVEYOR_BUILD_FOLDER%\build
   - cd %APPVEYOR_BUILD_FOLDER%\build
 
@@ -91,4 +98,6 @@ build_script:
        -DCMAKE_PREFIX_PATH=%QT_PREFIX%
        -DCMAKE_MAKE_PROGRAM="%APPVEYOR_BUILD_FOLDER%\platform\qt\ninja.exe"
        ..
+  - clcache -z
   - cmake --build . -- -j %NUMBER_OF_PROCESSORS%
+  - clcache -s

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,77 +33,62 @@ for:
     only:
       - image: Visual Studio 2015
 
-  cache:
-    - '%APPVEYOR_BUILD_FOLDER%\mason_packages'
-    - '%APPVEYOR_BUILD_FOLDER%\LLVM-5.0.1-win64.exe'
-    - '%APPVEYOR_BUILD_FOLDER%\cmake-3.10.1-win64-x64.zip'
-
-  install:
-    - git config --system core.longpaths true
-    - git submodule sync
-    - git submodule update --init
-    - ps: |
-        if (!(Test-Path cmake-3.10.1-win64-x64.zip)) {
-            appveyor DownloadFile https://cmake.org/files/v3.10/cmake-3.10.1-win64-x64.zip
-        }
-        scripts\check-sha256.ps1 cmake-3.10.1-win64-x64.zip 8251F70C85B58F3CA1F24E4A3B0637E2D609B5E4A341D00B70E02E89244D5029
-        Start-Process -FilePath '7z' -ArgumentList 'x','cmake-3.10.1-win64-x64.zip','-oC:\' -Wait
-    - ps: |
-        if (!(Test-Path LLVM-5.0.1-win64.exe)) {
-            appveyor DownloadFile https://releases.llvm.org/5.0.1/LLVM-5.0.1-win64.exe
-        }
-        scripts\check-sha256.ps1 LLVM-5.0.1-win64.exe 981543611D719624ACB29A2CFFD6A479CFF36E8AB5EE8A57D8ECA4F9C4C6956F
-        Start-Process -FilePath 'LLVM-5.0.1-win64.exe' -ArgumentList '/S','/D=C:\LLVM-5.0.1' -Wait
-
-  before_build:
-    - set PATH=C:\LLVM-5.0.1\bin;%PATH%
-    - set PATH=C:\cmake-3.10.1-win64-x64\bin;%PATH%
-    - set CC=clang-cl
-    - set CXX=clang-cl
-    - mkdir %APPVEYOR_BUILD_FOLDER%\build
-    - cd %APPVEYOR_BUILD_FOLDER%\build
-
-  build_script:
-    - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
-    - cmake -G "Ninja" -DMBGL_PLATFORM=qt -DWITH_QT_DECODERS=ON -DWITH_QT_I18N=ON -DWITH_NODEJS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=C:\Qt\5.6.3\msvc2015_64\lib\cmake -DCMAKE_MAKE_PROGRAM="%APPVEYOR_BUILD_FOLDER%\platform\qt\ninja.exe" ..
-    - cmake --build . -- -j %NUMBER_OF_PROCESSORS%
+  environment:
+      LLVM_VERSION: 5.0.1
+      LLVM_HASH: 981543611D719624ACB29A2CFFD6A479CFF36E8AB5EE8A57D8ECA4F9C4C6956F
+      VCVARSALL: 'C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat'
+      QT_PREFIX: 'C:\Qt\5.6.3\msvc2015_64\lib\cmake'
 
 -
   matrix:
     only:
       - image: Visual Studio 2017
 
-  cache:
-    - '%APPVEYOR_BUILD_FOLDER%\mason_packages'
-    - '%APPVEYOR_BUILD_FOLDER%\LLVM-6.0.0-win64.exe'
-    - '%APPVEYOR_BUILD_FOLDER%\cmake-3.10.1-win64-x64.zip'
+  environment:
+    LLVM_VERSION: 6.0.0
+    LLVM_HASH: 2501887b2f638d3f65b0336f354b96f8108b563522d81e841d5c88c34af283dd
+    VCVARSALL: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat'
+    QT_PREFIX: 'C:\Qt\5.11.1\msvc2017_64\lib\cmake'
 
-  install:
-    - git config --system core.longpaths true
-    - git submodule sync
-    - git submodule update --init
-    - ps: |
-        if (!(Test-Path cmake-3.10.1-win64-x64.zip)) {
-            appveyor DownloadFile https://cmake.org/files/v3.10/cmake-3.10.1-win64-x64.zip
-        }
-        scripts\check-sha256.ps1 cmake-3.10.1-win64-x64.zip 8251F70C85B58F3CA1F24E4A3B0637E2D609B5E4A341D00B70E02E89244D5029
-        Start-Process -FilePath '7z' -ArgumentList 'x','cmake-3.10.1-win64-x64.zip','-oC:\' -Wait
-    - ps: |
-        if (!(Test-Path LLVM-6.0.0-win64.exe)) {
-            appveyor DownloadFile https://releases.llvm.org/6.0.0/LLVM-6.0.0-win64.exe
-        }
-        scripts\check-sha256.ps1 LLVM-6.0.0-win64.exe 2501887b2f638d3f65b0336f354b96f8108b563522d81e841d5c88c34af283dd
-        Start-Process -FilePath 'LLVM-6.0.0-win64.exe' -ArgumentList '/S','/D=C:\LLVM-6.0.0' -Wait
+cache:
+  - '%APPVEYOR_BUILD_FOLDER%\mason_packages'
+  - '%APPVEYOR_BUILD_FOLDER%\LLVM-%LLVM_VERSION%-win64.exe'
+  - '%APPVEYOR_BUILD_FOLDER%\cmake-3.10.1-win64-x64.zip'
 
-  before_build:
-    - set PATH=C:\LLVM-6.0.0\bin;%PATH%
-    - set PATH=C:\cmake-3.10.1-win64-x64\bin;%PATH%
-    - set CC=clang-cl
-    - set CXX=clang-cl
-    - mkdir %APPVEYOR_BUILD_FOLDER%\build
-    - cd %APPVEYOR_BUILD_FOLDER%\build
+install:
+  - git config --system core.longpaths true
+  - git submodule sync
+  - git submodule update --init
+  - ps: |
+      if (!(Test-Path cmake-3.10.1-win64-x64.zip)) {
+          appveyor DownloadFile https://cmake.org/files/v3.10/cmake-3.10.1-win64-x64.zip
+      }
+      scripts\check-sha256.ps1 cmake-3.10.1-win64-x64.zip 8251F70C85B58F3CA1F24E4A3B0637E2D609B5E4A341D00B70E02E89244D5029
+      Start-Process -FilePath '7z' -ArgumentList 'x','cmake-3.10.1-win64-x64.zip','-oC:\' -Wait
+  - ps: |
+      if (!(Test-Path "LLVM-$env:LLVM_VERSION-win64.exe")) {
+          appveyor DownloadFile "https://releases.llvm.org/$env:LLVM_VERSION/LLVM-$env:LLVM_VERSION-win64.exe"
+      }
+      scripts\check-sha256.ps1 LLVM-$env:LLVM_VERSION-win64.exe "$env:LLVM_HASH"
+      Start-Process -FilePath "LLVM-$env:LLVM_VERSION-win64.exe" -ArgumentList '/S',"/D=C:\LLVM-$env:LLVM_VERSION" -Wait
 
-  build_script:
-    - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
-    - cmake -G "Ninja" -DMBGL_PLATFORM=qt -DWITH_QT_DECODERS=ON -DWITH_QT_I18N=ON -DWITH_NODEJS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=C:\Qt\5.11.1\msvc2017_64\lib\cmake -DCMAKE_MAKE_PROGRAM="%APPVEYOR_BUILD_FOLDER%\platform\qt\ninja.exe" ..
-    - cmake --build . -- -j %NUMBER_OF_PROCESSORS%
+before_build:
+  - set PATH=C:\LLVM-%LLVM_VERSION%\bin;%PATH%
+  - set PATH=C:\cmake-3.10.1-win64-x64\bin;%PATH%
+  - set CC=clang-cl
+  - set CXX=clang-cl
+  - mkdir %APPVEYOR_BUILD_FOLDER%\build
+  - cd %APPVEYOR_BUILD_FOLDER%\build
+
+build_script:
+  - call "%VCVARSALL%" amd64
+  - cmake -G "Ninja"
+       -DMBGL_PLATFORM=qt
+       -DWITH_QT_DECODERS=ON
+       -DWITH_QT_I18N=ON
+       -DWITH_NODEJS=OFF
+       -DCMAKE_BUILD_TYPE=Release
+       -DCMAKE_PREFIX_PATH=%QT_PREFIX%
+       -DCMAKE_MAKE_PROGRAM="%APPVEYOR_BUILD_FOLDER%\platform\qt\ninja.exe"
+       ..
+  - cmake --build . -- -j %NUMBER_OF_PROCESSORS%


### PR DESCRIPTION
clcache is similar to ccache but for microsoft compilers. Using it should result in faster builds.