### PR TITLE
[core] Refactor RenderLayer and it's subclasses

### DIFF
--- a/cmake/core-files.txt
+++ b/cmake/core-files.txt
@@ -262,6 +262,7 @@ src/mbgl/renderer/layers/render_heatmap_layer.cpp
 src/mbgl/renderer/layers/render_heatmap_layer.hpp
 src/mbgl/renderer/layers/render_hillshade_layer.cpp
 src/mbgl/renderer/layers/render_hillshade_layer.hpp
+src/mbgl/renderer/layers/render_layer_symbol_interface.hpp
 src/mbgl/renderer/layers/render_line_layer.cpp
 src/mbgl/renderer/layers/render_line_layer.hpp
 src/mbgl/renderer/layers/render_raster_layer.cpp

--- a/include/mbgl/style/layer.hpp
+++ b/include/mbgl/style/layer.hpp
@@ -26,11 +26,30 @@ struct LayerTypeInfo {
      * @brief contains the layer type as defined in the style specification;
      */
     const char* type;
+
     /**
-     * @brief contains \c SourceRequired if the corresponding layer type requires source;
-     * contains \c SourceNotRequired otherwise.
+     * @brief contains \c Source::Required if the corresponding layer type
+     * requires source. Contains \c Source::NotRequired otherwise.
      */
-    const enum { SourceRequired, SourceNotRequired } source;
+    const enum class Source { Required, NotRequired } source;
+
+    /**
+     * @brief contains \c Pass3D::Required if the corresponding layer type
+     * requires 3D rendering pass. Contains \c Pass3D::NotRequired otherwise.
+     */
+    const enum class Pass3D { Required, NotRequired } pass3d;
+
+    /**
+     * @brief contains \c Layout::Required if the corresponding layer type
+     * requires layouting. * contains \c Layout::NotRequired otherwise.
+     */
+    const enum class Layout { Required, NotRequired } layout;
+
+    /**
+     * @brief contains \c Clipping::Required if the corresponding layer type
+     * requires clipping. Contains \c Clipping::NotRequired otherwise.
+     */
+    const enum class Clipping { Required, NotRequired } clipping;
 };
 
 /**

--- a/src/mbgl/geometry/feature_index.cpp
+++ b/src/mbgl/geometry/feature_index.cpp
@@ -155,7 +155,7 @@ void FeatureIndex::addFeature(
             assert(geometryTileFeature);
         }
 
-        if (!renderLayer->is<RenderSymbolLayer>() &&
+        if (!renderLayer->getSymbolInterface() &&
              !renderLayer->queryIntersectsFeature(queryGeometry, *geometryTileFeature, tileID.z, transformState, pixelsToTileUnits, posMatrix)) {
             continue;
         }

--- a/src/mbgl/layout/pattern_layout.hpp
+++ b/src/mbgl/layout/pattern_layout.hpp
@@ -37,14 +37,14 @@ public:
                     hasPattern(false) {
 
         using PatternLayer = typename B::RenderLayerType;
-        const auto renderLayer = layers.at(0)->as<PatternLayer>();
+        const auto renderLayer = static_cast<const PatternLayer*>(layers.at(0));
         const typename PatternLayer::StyleLayerImpl& leader = renderLayer->impl();
         layout = leader.layout.evaluate(PropertyEvaluationParameters(zoom));
         sourceLayerID = leader.sourceLayer;
         groupID = renderLayer->getID();
 
         for (const auto& layer : layers) {
-            const typename B::PossiblyEvaluatedPaintProperties evaluatedProps = layer->as<PatternLayer>()->paintProperties();
+            const typename B::PossiblyEvaluatedPaintProperties evaluatedProps = static_cast<const PatternLayer*>(layer)->paintProperties();
             layerPaintProperties.emplace(layer->getID(), std::move(evaluatedProps));
             const auto patternProperty = evaluatedProps.template get<typename PatternLayer::PatternProperty>();
             const auto constantPattern = patternProperty.constantOr(Faded<std::basic_string<char> >{ "", ""});

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -50,11 +50,11 @@ SymbolLayout::SymbolLayout(const BucketParameters& parameters,
       pixelRatio(parameters.pixelRatio),
       tileSize(util::tileSize * overscaling),
       tilePixelRatio(float(util::EXTENT) / tileSize),
-      textSize(layers.at(0)->as<RenderSymbolLayer>()->impl().layout.get<TextSize>()),
-      iconSize(layers.at(0)->as<RenderSymbolLayer>()->impl().layout.get<IconSize>())
+      textSize(toRenderSymbolLayer(layers.at(0))->impl().layout.get<TextSize>()),
+      iconSize(toRenderSymbolLayer(layers.at(0))->impl().layout.get<IconSize>())
     {
 
-    const SymbolLayer::Impl& leader = layers.at(0)->as<RenderSymbolLayer>()->impl();
+    const SymbolLayer::Impl& leader = toRenderSymbolLayer(layers.at(0))->impl();
 
     layout = leader.layout.evaluate(PropertyEvaluationParameters(zoom));
 
@@ -91,8 +91,8 @@ SymbolLayout::SymbolLayout(const BucketParameters& parameters,
 
     for (const auto& layer : layers) {
         layerPaintProperties.emplace(layer->getID(), std::make_pair(
-            layer->as<RenderSymbolLayer>()->iconPaintProperties(),
-            layer->as<RenderSymbolLayer>()->textPaintProperties()
+            toRenderSymbolLayer(layer)->iconPaintProperties(),
+            toRenderSymbolLayer(layer)->textPaintProperties()
         ));
     }
 

--- a/src/mbgl/renderer/buckets/circle_bucket.cpp
+++ b/src/mbgl/renderer/buckets/circle_bucket.cpp
@@ -104,12 +104,7 @@ static float get(const RenderCircleLayer& layer, const std::map<std::string, Cir
 }
 
 float CircleBucket::getQueryRadius(const RenderLayer& layer) const {
-    if (!layer.is<RenderCircleLayer>()) {
-        return 0;
-    }
-
-    auto circleLayer = layer.as<RenderCircleLayer>();
-
+    const RenderCircleLayer* circleLayer = toRenderCircleLayer(&layer);
     float radius = get<CircleRadius>(*circleLayer, paintPropertyBinders);
     float stroke = get<CircleStrokeWidth>(*circleLayer, paintPropertyBinders);
     auto translate = circleLayer->evaluated.get<CircleTranslate>();

--- a/src/mbgl/renderer/buckets/circle_bucket.cpp
+++ b/src/mbgl/renderer/buckets/circle_bucket.cpp
@@ -18,7 +18,7 @@ CircleBucket::CircleBucket(const BucketParameters& parameters, const std::vector
             std::piecewise_construct,
             std::forward_as_tuple(layer->getID()),
             std::forward_as_tuple(
-                layer->as<RenderCircleLayer>()->evaluated,
+                toRenderCircleLayer(layer)->evaluated,
                 parameters.tileID.overscaledZ));
     }
 }

--- a/src/mbgl/renderer/buckets/fill_bucket.cpp
+++ b/src/mbgl/renderer/buckets/fill_bucket.cpp
@@ -137,13 +137,9 @@ bool FillBucket::hasData() const {
 }
 
 float FillBucket::getQueryRadius(const RenderLayer& layer) const {
-    if (!layer.is<RenderFillLayer>()) {
-        return 0;
-    }
-
-    const std::array<float, 2>& translate = layer.as<RenderFillLayer>()->evaluated.get<FillTranslate>();
+    const RenderFillLayer* fillLayer = toRenderFillLayer(&layer);
+    const std::array<float, 2>& translate = fillLayer->evaluated.get<FillTranslate>();
     return util::length(translate[0], translate[1]);
-
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
+++ b/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
@@ -181,11 +181,8 @@ bool FillExtrusionBucket::hasData() const {
 }
 
 float FillExtrusionBucket::getQueryRadius(const RenderLayer& layer) const {
-    if (!layer.is<RenderFillExtrusionLayer>()) {
-        return 0;
-    }
-
-    const std::array<float, 2>& translate = layer.as<RenderFillExtrusionLayer>()->evaluated.get<FillExtrusionTranslate>();
+    const RenderFillExtrusionLayer* fillExtrusionLayer = toRenderFillExtrusionLayer(&layer);
+    const std::array<float, 2>& translate = fillExtrusionLayer->evaluated.get<FillExtrusionTranslate>();
     return util::length(translate[0], translate[1]);
 }
 

--- a/src/mbgl/renderer/buckets/heatmap_bucket.cpp
+++ b/src/mbgl/renderer/buckets/heatmap_bucket.cpp
@@ -18,7 +18,7 @@ HeatmapBucket::HeatmapBucket(const BucketParameters& parameters, const std::vect
             std::piecewise_construct,
             std::forward_as_tuple(layer->getID()),
             std::forward_as_tuple(
-                layer->as<RenderHeatmapLayer>()->evaluated,
+                toRenderHeatmapLayer(layer)->evaluated,
                 parameters.tileID.overscaledZ));
     }
 }

--- a/src/mbgl/renderer/buckets/line_bucket.cpp
+++ b/src/mbgl/renderer/buckets/line_bucket.cpp
@@ -545,16 +545,10 @@ float LineBucket::getLineWidth(const RenderLineLayer& layer) const {
 }
 
 float LineBucket::getQueryRadius(const RenderLayer& layer) const {
-    if (!layer.is<RenderLineLayer>()) {
-        return 0;
-    }
-
-    auto lineLayer = layer.as<RenderLineLayer>();
-
+    const RenderLineLayer* lineLayer = toRenderLineLayer(&layer);
     const std::array<float, 2>& translate = lineLayer->evaluated.get<LineTranslate>();
     float offset = get<LineOffset>(*lineLayer, paintPropertyBinders);
     return getLineWidth(*lineLayer) / 2.0 + std::abs(offset) + util::length(translate[0], translate[1]);
 }
-
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -123,4 +123,12 @@ void RenderBackgroundLayer::render(PaintParameters& parameters, RenderSource*) {
     }
 }
 
+optional<Color> RenderBackgroundLayer::getSolidBackground() const {
+    if (!evaluated.get<BackgroundPattern>().from.empty()) {
+        return nullopt;
+    }
+
+    return { evaluated.get<BackgroundColor>() * evaluated.get<BackgroundOpacity>() };
+}
+
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_background_layer.hpp
+++ b/src/mbgl/renderer/layers/render_background_layer.hpp
@@ -15,6 +15,7 @@ public:
     void evaluate(const PropertyEvaluationParameters&) override;
     bool hasTransition() const override;
     bool hasCrossfade() const override;
+    optional<Color> getSolidBackground() const final;
     void render(PaintParameters&, RenderSource*) override;
 
     std::unique_ptr<Bucket> createBucket(const BucketParameters&, const std::vector<const RenderLayer*>&) const override;

--- a/src/mbgl/renderer/layers/render_background_layer.hpp
+++ b/src/mbgl/renderer/layers/render_background_layer.hpp
@@ -29,9 +29,4 @@ private:
     CrossfadeParameters crossfade;
 };
 
-template <>
-inline bool RenderLayer::is<RenderBackgroundLayer>() const {
-    return type == style::LayerType::Background;
-}
-
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_circle_layer.hpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.hpp
@@ -34,11 +34,6 @@ public:
     const style::CircleLayer::Impl& impl() const;
 };
 
-template <>
-inline bool RenderLayer::is<RenderCircleLayer>() const {
-    return type == style::LayerType::Circle;
-}
-
 inline const RenderCircleLayer* toRenderCircleLayer(const RenderLayer* layer) {
     return static_cast<const RenderCircleLayer*>(layer);
 }

--- a/src/mbgl/renderer/layers/render_circle_layer.hpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.hpp
@@ -39,4 +39,8 @@ inline bool RenderLayer::is<RenderCircleLayer>() const {
     return type == style::LayerType::Circle;
 }
 
+inline const RenderCircleLayer* toRenderCircleLayer(const RenderLayer* layer) {
+    return static_cast<const RenderCircleLayer*>(layer);
+}
+
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_custom_layer.cpp
+++ b/src/mbgl/renderer/layers/render_custom_layer.cpp
@@ -42,6 +42,10 @@ bool RenderCustomLayer::hasCrossfade() const {
     return false;
 }
 
+void RenderCustomLayer::markContextDestroyed() {
+    contextDestroyed = true;
+}
+
 std::unique_ptr<Bucket> RenderCustomLayer::createBucket(const BucketParameters&, const std::vector<const RenderLayer*>&) const {
     assert(false);
     return nullptr;

--- a/src/mbgl/renderer/layers/render_custom_layer.hpp
+++ b/src/mbgl/renderer/layers/render_custom_layer.hpp
@@ -14,15 +14,12 @@ public:
     void evaluate(const PropertyEvaluationParameters&) override;
     bool hasTransition() const override;
     bool hasCrossfade() const override;
+    void markContextDestroyed() final;
 
     std::unique_ptr<Bucket> createBucket(const BucketParameters&, const std::vector<const RenderLayer*>&) const final;
     void render(PaintParameters&, RenderSource*) final;
 
     const style::CustomLayer::Impl& impl() const;
-
-    void markContextDestroyed() {
-        contextDestroyed = true;
-    };
 
 private:
     bool contextDestroyed = false;

--- a/src/mbgl/renderer/layers/render_custom_layer.hpp
+++ b/src/mbgl/renderer/layers/render_custom_layer.hpp
@@ -26,9 +26,4 @@ private:
     std::shared_ptr<style::CustomLayerHost> host;
 };
 
-template <>
-inline bool RenderLayer::is<RenderCustomLayer>() const {
-    return type == style::LayerType::Custom;
-}
-
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -28,10 +28,10 @@ const style::FillExtrusionLayer::Impl& RenderFillExtrusionLayer::impl() const {
 }
 
 std::unique_ptr<Bucket> RenderFillExtrusionLayer::createBucket(const BucketParameters&, const std::vector<const RenderLayer*>&) const {
-    assert(false); // Should be calling createLayout() instead.
+    // Should be calling createLayout() instead.
+    assert(baseImpl->getTypeInfo()->layout == LayerTypeInfo::Layout::NotRequired);
     return nullptr;
 }
-
 
 std::unique_ptr<Layout> RenderFillExtrusionLayer::createLayout(const BucketParameters& parameters,
                         const std::vector<const RenderLayer*>& group,

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.hpp
@@ -51,11 +51,6 @@ private:
     CrossfadeParameters crossfade;
 };
 
-template <>
-inline bool RenderLayer::is<RenderFillExtrusionLayer>() const {
-    return type == style::LayerType::FillExtrusion;
-}
-
 inline const RenderFillExtrusionLayer* toRenderFillExtrusionLayer(const RenderLayer* layer) {
     return static_cast<const RenderFillExtrusionLayer*>(layer);
 }

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.hpp
@@ -56,4 +56,8 @@ inline bool RenderLayer::is<RenderFillExtrusionLayer>() const {
     return type == style::LayerType::FillExtrusion;
 }
 
+inline const RenderFillExtrusionLayer* toRenderFillExtrusionLayer(const RenderLayer* layer) {
+    return static_cast<const RenderFillExtrusionLayer*>(layer);
+}
+
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -26,7 +26,8 @@ const style::FillLayer::Impl& RenderFillLayer::impl() const {
 }
 
 std::unique_ptr<Bucket> RenderFillLayer::createBucket(const BucketParameters&, const std::vector<const RenderLayer*>&) const {
-    assert(false); // Should be calling createLayout() instead.
+    // Should be calling createLayout() instead.
+    assert(baseImpl->getTypeInfo()->layout == LayerTypeInfo::Layout::NotRequired);
     return nullptr;
 }
 

--- a/src/mbgl/renderer/layers/render_fill_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.hpp
@@ -51,4 +51,8 @@ inline bool RenderLayer::is<RenderFillLayer>() const {
     return type == style::LayerType::Fill;
 }
 
+inline const RenderFillLayer* toRenderFillLayer(const RenderLayer* layer) {
+    return static_cast<const RenderFillLayer*>(layer);
+}
+
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_fill_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.hpp
@@ -46,11 +46,6 @@ private:
 
 };
 
-template <>
-inline bool RenderLayer::is<RenderFillLayer>() const {
-    return type == style::LayerType::Fill;
-}
-
 inline const RenderFillLayer* toRenderFillLayer(const RenderLayer* layer) {
     return static_cast<const RenderFillLayer*>(layer);
 }

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -185,6 +185,10 @@ void RenderHeatmapLayer::render(PaintParameters& parameters, RenderSource*) {
     }
 }
 
+void RenderHeatmapLayer::update() {
+    updateColorRamp();
+}
+
 void RenderHeatmapLayer::updateColorRamp() {
     auto colorValue = unevaluated.get<HeatmapColor>().getValue();
     if (colorValue.isUndefined()) {

--- a/src/mbgl/renderer/layers/render_heatmap_layer.hpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.hpp
@@ -44,11 +44,6 @@ private:
     void updateColorRamp();
 };
 
-template <>
-inline bool RenderLayer::is<RenderHeatmapLayer>() const {
-    return type == style::LayerType::Heatmap;
-}
-
 inline const RenderHeatmapLayer* toRenderHeatmapLayer(const RenderLayer* layer) {
     return static_cast<const RenderHeatmapLayer*>(layer);
 }

--- a/src/mbgl/renderer/layers/render_heatmap_layer.hpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.hpp
@@ -49,4 +49,8 @@ inline bool RenderLayer::is<RenderHeatmapLayer>() const {
     return type == style::LayerType::Heatmap;
 }
 
+inline const RenderHeatmapLayer* toRenderHeatmapLayer(const RenderLayer* layer) {
+    return static_cast<const RenderHeatmapLayer*>(layer);
+}
+
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_heatmap_layer.hpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.hpp
@@ -18,6 +18,7 @@ public:
     bool hasTransition() const override;
     bool hasCrossfade() const override;
     void render(PaintParameters&, RenderSource*) override;
+    void update() final;
 
     bool queryIntersectsFeature(
             const GeometryCoordinates&,
@@ -26,8 +27,6 @@ public:
             const TransformState&,
             const float,
             const mat4&) const override;
-
-    void updateColorRamp();
 
     std::unique_ptr<Bucket> createBucket(const BucketParameters&, const std::vector<const RenderLayer*>&) const override;
 
@@ -40,6 +39,9 @@ public:
     PremultipliedImage colorRamp;
     optional<OffscreenTexture> renderTexture;
     optional<gl::Texture> colorRampTexture;
+
+private:
+    void updateColorRamp();
 };
 
 template <>

--- a/src/mbgl/renderer/layers/render_hillshade_layer.hpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.hpp
@@ -31,9 +31,4 @@ private:
     const std::array<float, 2> getLight(const PaintParameters& parameters);
 };
 
-template <>
-inline bool RenderLayer::is<RenderHillshadeLayer>() const {
-    return type == style::LayerType::Hillshade;
-}
-
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_layer_symbol_interface.hpp
+++ b/src/mbgl/renderer/layers/render_layer_symbol_interface.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+#include <string>
+
+namespace mbgl {
+
+class RenderTile;
+class SymbolBucket;
+
+class RenderLayerSymbolInterface {
+public:
+    virtual const std::string& layerID() const = 0;
+    virtual const std::vector<std::reference_wrapper<RenderTile>>& getRenderTiles() const = 0;
+    virtual SymbolBucket* getSymbolBucket(const RenderTile&) const = 0;
+
+protected:
+    virtual ~RenderLayerSymbolInterface() = default;
+};
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -28,7 +28,8 @@ const style::LineLayer::Impl& RenderLineLayer::impl() const {
 }
 
 std::unique_ptr<Bucket> RenderLineLayer::createBucket(const BucketParameters&, const std::vector<const RenderLayer*>&) const {
-    assert(false); // Should be calling createLayout() instead.
+    // Should be calling createLayout() instead.
+    assert(baseImpl->getTypeInfo()->layout == LayerTypeInfo::Layout::NotRequired);
     return nullptr;
 }
 

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -294,4 +294,8 @@ float RenderLineLayer::getLineWidth(const GeometryTileFeature& feature, const fl
 }
 
 
+void RenderLineLayer::update() {
+    updateColorRamp();
+}
+
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_line_layer.hpp
+++ b/src/mbgl/renderer/layers/render_line_layer.hpp
@@ -71,4 +71,8 @@ inline bool RenderLayer::is<RenderLineLayer>() const {
     return type == style::LayerType::Line;
 }
 
+inline const RenderLineLayer* toRenderLineLayer(const RenderLayer* layer) {
+    return static_cast<const RenderLineLayer*>(layer);
+}
+
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_line_layer.hpp
+++ b/src/mbgl/renderer/layers/render_line_layer.hpp
@@ -32,6 +32,7 @@ public:
     bool hasTransition() const override;
     bool hasCrossfade() const override;
     void render(PaintParameters&, RenderSource*) override;
+    void update() final;
 
     RenderLinePaintProperties::PossiblyEvaluated paintProperties() const;
 
@@ -43,7 +44,6 @@ public:
             const float,
             const mat4&) const override;
 
-    void updateColorRamp();
 
     std::unique_ptr<Bucket> createBucket(const BucketParameters&, const std::vector<const RenderLayer*>&) const override;
     std::unique_ptr<Layout> createLayout(const BucketParameters&,
@@ -59,6 +59,7 @@ public:
 
 private:
     float getLineWidth(const GeometryTileFeature&, const float) const;
+    void updateColorRamp();
     CrossfadeParameters crossfade;
     PremultipliedImage colorRamp;
     optional<gl::Texture> colorRampTexture;

--- a/src/mbgl/renderer/layers/render_line_layer.hpp
+++ b/src/mbgl/renderer/layers/render_line_layer.hpp
@@ -51,6 +51,7 @@ public:
                                                std::unique_ptr<GeometryTileLayer>,
                                                GlyphDependencies&,
                                                ImageDependencies&) const override;
+
     // Paint properties
     style::LinePaintProperties::Unevaluated unevaluated;
     RenderLinePaintProperties::PossiblyEvaluated evaluated;

--- a/src/mbgl/renderer/layers/render_line_layer.hpp
+++ b/src/mbgl/renderer/layers/render_line_layer.hpp
@@ -66,11 +66,6 @@ private:
     optional<gl::Texture> colorRampTexture;
 };
 
-template <>
-inline bool RenderLayer::is<RenderLineLayer>() const {
-    return type == style::LayerType::Line;
-}
-
 inline const RenderLineLayer* toRenderLineLayer(const RenderLayer* layer) {
     return static_cast<const RenderLineLayer*>(layer);
 }

--- a/src/mbgl/renderer/layers/render_raster_layer.hpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.hpp
@@ -27,9 +27,4 @@ public:
     const style::RasterLayer::Impl& impl() const;
 };
 
-template <>
-inline bool RenderLayer::is<RenderRasterLayer>() const {
-    return type == style::LayerType::Raster;
-}
-
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -32,7 +32,8 @@ const style::SymbolLayer::Impl& RenderSymbolLayer::impl() const {
 }
 
 std::unique_ptr<Bucket> RenderSymbolLayer::createBucket(const BucketParameters&, const std::vector<const RenderLayer*>&) const {
-    assert(false); // Should be calling createLayout() instead.
+    // Should be calling createLayout() instead.
+    assert(baseImpl->getTypeInfo()->layout == LayerTypeInfo::Layout::NotRequired);
     return nullptr;
 }
 

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -74,6 +74,22 @@ bool RenderSymbolLayer::hasCrossfade() const {
     return false;
 }
 
+const std::string& RenderSymbolLayer::layerID() const {
+    return RenderLayer::getID();
+}
+
+const RenderLayerSymbolInterface* RenderSymbolLayer::getSymbolInterface() const {
+    return this;
+}
+
+const std::vector<std::reference_wrapper<RenderTile>>& RenderSymbolLayer::getRenderTiles() const {
+    return renderTiles;
+}
+
+SymbolBucket* RenderSymbolLayer::getSymbolBucket(const RenderTile& renderTile) const {
+    return renderTile.tile.getBucket<SymbolBucket>(*baseImpl);
+}
+
 void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
     if (parameters.pass == RenderPass::Opaque) {
         return;

--- a/src/mbgl/renderer/layers/render_symbol_layer.hpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.hpp
@@ -88,6 +88,10 @@ public:
     float textSize = 16.0f;
 
     const style::SymbolLayer::Impl& impl() const;
+
+protected:
+    RenderTiles filterRenderTiles(RenderTiles) const final;
+    void sortRenderTiles(const TransformState&) final;
 };
 
 template <>

--- a/src/mbgl/renderer/layers/render_symbol_layer.hpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.hpp
@@ -99,4 +99,8 @@ inline bool RenderLayer::is<RenderSymbolLayer>() const {
     return type == style::LayerType::Symbol;
 }
 
+inline const RenderSymbolLayer* toRenderSymbolLayer(const RenderLayer* layer) {
+    return static_cast<const RenderSymbolLayer*>(layer);
+}
+
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_symbol_layer.hpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.hpp
@@ -101,11 +101,6 @@ protected:
     void sortRenderTiles(const TransformState&) final;
 };
 
-template <>
-inline bool RenderLayer::is<RenderSymbolLayer>() const {
-    return type == style::LayerType::Symbol;
-}
-
 inline const RenderSymbolLayer* toRenderSymbolLayer(const RenderLayer* layer) {
     return static_cast<const RenderSymbolLayer*>(layer);
 }

--- a/src/mbgl/renderer/layers/render_symbol_layer.hpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/text/glyph.hpp>
 #include <mbgl/renderer/render_layer.hpp>
+#include <mbgl/renderer/layers/render_layer_symbol_interface.hpp>
 #include <mbgl/style/image_impl.hpp>
 #include <mbgl/style/layers/symbol_layer_impl.hpp>
 #include <mbgl/style/layers/symbol_layer_properties.hpp>
@@ -56,7 +57,7 @@ class BucketParameters;
 class SymbolLayout;
 class GeometryTileLayer;
 
-class RenderSymbolLayer: public RenderLayer {
+class RenderSymbolLayer: public RenderLayer, public RenderLayerSymbolInterface {
 public:
     RenderSymbolLayer(Immutable<style::SymbolLayer::Impl>);
     ~RenderSymbolLayer() final = default;
@@ -79,6 +80,12 @@ public:
                                                std::unique_ptr<GeometryTileLayer>,
                                                GlyphDependencies&,
                                                ImageDependencies&) const override;
+
+    // RenderLayerSymbolInterface overrides
+    const RenderLayerSymbolInterface* getSymbolInterface() const final;
+    const std::string& layerID() const final;
+    const std::vector<std::reference_wrapper<RenderTile>>& getRenderTiles() const final;
+    SymbolBucket* getSymbolBucket(const RenderTile&) const final;
 
     // Paint properties
     style::SymbolPaintProperties::Unevaluated unevaluated;

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -10,8 +10,9 @@
 #include <mbgl/renderer/layers/render_symbol_layer.hpp>
 #include <mbgl/renderer/layers/render_heatmap_layer.hpp>
 #include <mbgl/renderer/paint_parameters.hpp>
-#include <mbgl/style/types.hpp>
 #include <mbgl/renderer/render_tile.hpp>
+#include <mbgl/style/types.hpp>
+#include <mbgl/tile/tile.hpp>
 #include <mbgl/util/logging.hpp>
 
 namespace mbgl {
@@ -71,8 +72,40 @@ bool RenderLayer::needsRendering(float zoom) const {
            && baseImpl->maxZoom >= zoom;
 }
 
-void RenderLayer::setRenderTiles(std::vector<std::reference_wrapper<RenderTile>> tiles) {
-    renderTiles = std::move(tiles);
+void RenderLayer::setRenderTiles(RenderTiles tiles, const TransformState& state) {
+    renderTiles = filterRenderTiles(std::move(tiles));
+    sortRenderTiles(state);
+}
+
+RenderLayer::RenderTiles RenderLayer::filterRenderTiles(RenderTiles tiles) const {
+    auto filterFn = [](auto& tile){ return !tile.tile.isRenderable() || tile.tile.holdForFade(); };
+    return filterRenderTiles(std::move(tiles), filterFn);
+}
+
+void RenderLayer::sortRenderTiles(const TransformState&) {
+    std::sort(renderTiles.begin(), renderTiles.end(), [](const auto& a, const auto& b) { return a.get().id < b.get().id; });
+}
+
+RenderLayer::RenderTiles RenderLayer::filterRenderTiles(RenderTiles tiles, FilterFunctionPtr filterFn) const {
+    assert(filterFn != nullptr);
+    RenderTiles filtered;
+    // We only need clipping when we're drawing fill or line layers.
+    const bool needsClipping_ =
+            baseImpl->getTypeInfo()->clipping == LayerTypeInfo::Clipping::Required;
+
+    for (auto& tileRef : tiles) {
+        auto& tile = tileRef.get();
+        if (filterFn(tile)) {
+            continue;
+        }
+
+        if (tile.tile.getBucket(*baseImpl)) {
+            tile.used = true;
+            tile.needsClipping |= needsClipping_;
+            filtered.emplace_back(tile);
+        }
+    }
+    return filtered;
 }
 
 void RenderLayer::markContextDestroyed() {

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -86,6 +86,10 @@ void RenderLayer::sortRenderTiles(const TransformState&) {
     std::sort(renderTiles.begin(), renderTiles.end(), [](const auto& a, const auto& b) { return a.get().id < b.get().id; });
 }
 
+const RenderLayerSymbolInterface* RenderLayer::getSymbolInterface() const {
+    return nullptr;
+}
+
 void RenderLayer::update() {
     // no-op
 }

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -90,6 +90,10 @@ void RenderLayer::update() {
     // no-op
 }
 
+optional<Color> RenderLayer::getSolidBackground() const {
+    return nullopt;
+}
+
 RenderLayer::RenderTiles RenderLayer::filterRenderTiles(RenderTiles tiles, FilterFunctionPtr filterFn) const {
     assert(filterFn != nullptr);
     RenderTiles filtered;

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -75,6 +75,10 @@ void RenderLayer::setRenderTiles(std::vector<std::reference_wrapper<RenderTile>>
     renderTiles = std::move(tiles);
 }
 
+void RenderLayer::markContextDestroyed() {
+    // no-op
+}
+
 void RenderLayer::checkRenderability(const PaintParameters& parameters,
                                      const uint32_t activeBindingCount) {
     // Only warn once for every layer.

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -86,6 +86,10 @@ void RenderLayer::sortRenderTiles(const TransformState&) {
     std::sort(renderTiles.begin(), renderTiles.end(), [](const auto& a, const auto& b) { return a.get().id < b.get().id; });
 }
 
+void RenderLayer::update() {
+    // no-op
+}
+
 RenderLayer::RenderTiles RenderLayer::filterRenderTiles(RenderTiles tiles, FilterFunctionPtr filterFn) const {
     assert(filterFn != nullptr);
     RenderTiles filtered;

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -17,6 +17,7 @@ class TransitionParameters;
 class PropertyEvaluationParameters;
 class PaintParameters;
 class RenderSource;
+class RenderLayerSymbolInterface;
 class RenderTile;
 class TransformState;
 
@@ -42,6 +43,9 @@ public:
 
     // Returns true if the layer has a pattern property and is actively crossfading.
     virtual bool hasCrossfade() const = 0;
+
+    // Returns instance of RenderLayerSymbolInterface if RenderLayer supports it.
+    virtual const RenderLayerSymbolInterface* getSymbolInterface() const;
 
     // Check whether this layer is of the given subtype.
     template <class T>
@@ -118,10 +122,6 @@ protected:
     RenderTiles filterRenderTiles(RenderTiles, FilterFunctionPtr) const;
 
 protected:
-    // renderTiles are exposed directly to CrossTileSymbolIndex and Placement so they
-    // can update opacities in the symbol buckets immediately before rendering
-    friend class CrossTileSymbolIndex;
-    friend class Placement;
     // Stores current set of tiles to be rendered for this layer.
     std::vector<std::reference_wrapper<RenderTile>> renderTiles;
 

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -47,21 +47,6 @@ public:
     // Returns instance of RenderLayerSymbolInterface if RenderLayer supports it.
     virtual const RenderLayerSymbolInterface* getSymbolInterface() const;
 
-    // Check whether this layer is of the given subtype.
-    template <class T>
-    bool is() const;
-
-    // Dynamically cast this layer to the given subtype.
-    template <class T>
-    T* as() {
-        return is<T>() ? reinterpret_cast<T*>(this) : nullptr;
-    }
-
-    template <class T>
-    const T* as() const {
-        return is<T>() ? reinterpret_cast<const T*>(this) : nullptr;
-    }
-
     const std::string& getID() const;
 
     // Checks whether this layer needs to be rendered in the given render pass.

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -101,6 +101,9 @@ public:
     // similar to color ramp. Temporarily moved to the base.
     virtual void update();
 
+    // TODO: Only for background layers.
+    virtual optional<Color> getSolidBackground() const;
+
     friend std::string layoutKey(const RenderLayer&);
 
 protected:

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -95,7 +95,14 @@ public:
     void setImpl(Immutable<style::Layer::Impl>);
 
     virtual void markContextDestroyed();
+
+    // TODO: Figure out how to remove this or whether layers other than
+    // RenderHeatmapLayer and RenderLineLayer need paint property updates,
+    // similar to color ramp. Temporarily moved to the base.
+    virtual void update();
+
     friend std::string layoutKey(const RenderLayer&);
+
 protected:
     // Checks whether the current hardware can render this layer. If it can't, we'll show a warning
     // in the console to inform the developer.

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -86,7 +86,10 @@ public:
                                                ImageDependencies&) const {
         return nullptr;
     }
-    void setRenderTiles(std::vector<std::reference_wrapper<RenderTile>>);
+
+    using RenderTiles = std::vector<std::reference_wrapper<RenderTile>>;
+    void setRenderTiles(RenderTiles, const TransformState&);
+
     // Private implementation
     Immutable<style::Layer::Impl> baseImpl;
     void setImpl(Immutable<style::Layer::Impl>);
@@ -97,6 +100,12 @@ protected:
     // Checks whether the current hardware can render this layer. If it can't, we'll show a warning
     // in the console to inform the developer.
     void checkRenderability(const PaintParameters&, uint32_t activeBindingCount);
+
+    // Code specific to RenderTiles sorting / filtering
+    virtual RenderTiles filterRenderTiles(RenderTiles) const;
+    virtual void sortRenderTiles(const TransformState&);
+    using FilterFunctionPtr = bool (*)(RenderTile&);
+    RenderTiles filterRenderTiles(RenderTiles, FilterFunctionPtr) const;
 
 protected:
     // renderTiles are exposed directly to CrossTileSymbolIndex and Placement so they
@@ -111,7 +120,7 @@ protected:
     RenderPass passes = RenderPass::None;
 
 private:
-    // Some layers may not render correctly on some hardware when the vertex attribute limit of
+    // Some layers may not render correctly on some hardware when the vertex attribute limit of
     // that GPU is exceeded. More attributes are used when adding many data driven paint properties
     // to a layer.
     bool hasRenderFailures = false;

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -91,8 +91,8 @@ public:
     Immutable<style::Layer::Impl> baseImpl;
     void setImpl(Immutable<style::Layer::Impl>);
 
+    virtual void markContextDestroyed();
     friend std::string layoutKey(const RenderLayer&);
-
 protected:
     // Checks whether the current hardware can render this layer. If it can't, we'll show a warning
     // in the console to inform the developer.

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -15,7 +15,6 @@
 #include <mbgl/renderer/layers/render_custom_layer.hpp>
 #include <mbgl/renderer/layers/render_fill_extrusion_layer.hpp>
 #include <mbgl/renderer/layers/render_fill_layer.hpp>
-#include <mbgl/renderer/layers/render_heatmap_layer.hpp>
 #include <mbgl/renderer/layers/render_hillshade_layer.hpp>
 #include <mbgl/renderer/style_diff.hpp>
 #include <mbgl/renderer/query.hpp>
@@ -186,14 +185,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
 
         if (layerAdded || layerChanged) {
             layer.transition(transitionParameters);
-
-            if (layer.is<RenderHeatmapLayer>()) {
-                layer.as<RenderHeatmapLayer>()->updateColorRamp();
-            }
-
-            if (layer.is<RenderLineLayer>()) {
-                layer.as<RenderLineLayer>()->updateColorRamp();
-            }
+            layer.update();
         }
 
         if (layerAdded || layerChanged || zoomChanged || layer.hasTransition() || layer.hasCrossfade()) {

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -69,13 +69,13 @@ Renderer::Impl::~Impl() {
     assert(BackendScope::exists());
 
     if (contextLost) {
-        // Signal all RenderCustomLayers that the context was lost
-        // before cleaning up
+        // Signal all RenderLayers that the context was lost
+        // before cleaning up. At the moment, only CustomLayer is
+        // interested whether rendering context is lost. However, it would be
+        // beneficial for dynamically loaded or other custom built-in plugins.
         for (const auto& entry : renderLayers) {
             RenderLayer& layer = *entry.second;
-            if (layer.is<RenderCustomLayer>()) {
-                layer.as<RenderCustomLayer>()->markContextDestroyed();
-            }
+            layer.markContextDestroyed();
         }
     }
 };

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -11,11 +11,6 @@
 #include <mbgl/renderer/property_evaluation_parameters.hpp>
 #include <mbgl/renderer/tile_parameters.hpp>
 #include <mbgl/renderer/render_tile.hpp>
-#include <mbgl/renderer/layers/render_background_layer.hpp>
-#include <mbgl/renderer/layers/render_custom_layer.hpp>
-#include <mbgl/renderer/layers/render_fill_extrusion_layer.hpp>
-#include <mbgl/renderer/layers/render_fill_layer.hpp>
-#include <mbgl/renderer/layers/render_hillshade_layer.hpp>
 #include <mbgl/renderer/style_diff.hpp>
 #include <mbgl/renderer/query.hpp>
 #include <mbgl/renderer/backend_scope.hpp>
@@ -279,8 +274,9 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
 
     Color backgroundColor;
 
-    class RenderItem {
-    public:
+    struct RenderItem {
+        RenderItem(RenderLayer& layer_, RenderSource* source_)
+            : layer(layer_), source(source_) {}
         RenderLayer& layer;
         RenderSource* source;
     };
@@ -308,7 +304,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         }
 
         if (layerImpl->getTypeInfo()->source == LayerTypeInfo::Source::NotRequired) {
-            order.emplace_back(RenderItem { *layer, nullptr });
+            order.emplace_back(*layer, nullptr);
             continue;
         }
 
@@ -319,7 +315,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         }
 
         layer->setRenderTiles(source->getRenderTiles(), parameters.state);
-        order.emplace_back(RenderItem { *layer, source });
+        order.emplace_back(*layer, source);
     }
 
     {

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -299,13 +299,8 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         RenderLayer* layer = getRenderLayer(layerImpl->id);
         assert(layer);
 
-        if (!parameters.staticData.has3D && (
-                layer->is<RenderFillExtrusionLayer>() ||
-                layer->is<RenderHillshadeLayer>() ||
-                layer->is<RenderHeatmapLayer>())) {
-
-            parameters.staticData.has3D = true;
-        }
+        parameters.staticData.has3D |=
+                (layerImpl->getTypeInfo()->pass3d == LayerTypeInfo::Pass3D::Required);
 
         if (!layer->needsRendering(zoomHistory.lastZoom)) {
             continue;

--- a/src/mbgl/style/layers/background_layer.cpp
+++ b/src/mbgl/style/layers/background_layer.cpp
@@ -15,7 +15,13 @@ namespace mbgl {
 namespace style {
 
 namespace {
-    const LayerTypeInfo typeInfoBackground{ "background", LayerTypeInfo::SourceNotRequired };
+    const LayerTypeInfo typeInfoBackground
+        {"background",
+          LayerTypeInfo::Source::NotRequired,
+          LayerTypeInfo::Pass3D::NotRequired,
+          LayerTypeInfo::Layout::NotRequired,
+          LayerTypeInfo::Clipping::NotRequired
+        };
 }  // namespace
 
 BackgroundLayer::BackgroundLayer(const std::string& layerID)

--- a/src/mbgl/style/layers/circle_layer.cpp
+++ b/src/mbgl/style/layers/circle_layer.cpp
@@ -15,7 +15,13 @@ namespace mbgl {
 namespace style {
 
 namespace {
-    const LayerTypeInfo typeInfoCircle{ "circle", LayerTypeInfo::SourceRequired };
+    const LayerTypeInfo typeInfoCircle
+        {"circle",
+          LayerTypeInfo::Source::Required,
+          LayerTypeInfo::Pass3D::NotRequired,
+          LayerTypeInfo::Layout::NotRequired,
+          LayerTypeInfo::Clipping::NotRequired
+        };
 }  // namespace
 
 CircleLayer::CircleLayer(const std::string& layerID, const std::string& sourceID)

--- a/src/mbgl/style/layers/custom_layer.cpp
+++ b/src/mbgl/style/layers/custom_layer.cpp
@@ -6,7 +6,12 @@ namespace mbgl {
 namespace style {
 
 namespace {
-    const LayerTypeInfo typeInfoCustom{ "", LayerTypeInfo::SourceNotRequired };
+    const LayerTypeInfo typeInfoCustom
+    { "",
+      LayerTypeInfo::Source::NotRequired,
+      LayerTypeInfo::Pass3D::NotRequired,
+      LayerTypeInfo::Layout::NotRequired,
+      LayerTypeInfo::Clipping::NotRequired };
 }  // namespace
 
 CustomLayer::CustomLayer(const std::string& layerID,

--- a/src/mbgl/style/layers/fill_extrusion_layer.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer.cpp
@@ -15,7 +15,13 @@ namespace mbgl {
 namespace style {
 
 namespace {
-    const LayerTypeInfo typeInfoFillExtrusion{ "fill-extrusion", LayerTypeInfo::SourceRequired };
+    const LayerTypeInfo typeInfoFillExtrusion
+        {"fill-extrusion",
+          LayerTypeInfo::Source::Required,
+          LayerTypeInfo::Pass3D::Required,
+          LayerTypeInfo::Layout::Required,
+          LayerTypeInfo::Clipping::NotRequired
+        };
 }  // namespace
 
 FillExtrusionLayer::FillExtrusionLayer(const std::string& layerID, const std::string& sourceID)

--- a/src/mbgl/style/layers/fill_layer.cpp
+++ b/src/mbgl/style/layers/fill_layer.cpp
@@ -15,7 +15,13 @@ namespace mbgl {
 namespace style {
 
 namespace {
-    const LayerTypeInfo typeInfoFill{ "fill", LayerTypeInfo::SourceRequired };
+    const LayerTypeInfo typeInfoFill
+        {"fill",
+          LayerTypeInfo::Source::Required,
+          LayerTypeInfo::Pass3D::NotRequired,
+          LayerTypeInfo::Layout::Required,
+          LayerTypeInfo::Clipping::Required
+        };
 }  // namespace
 
 FillLayer::FillLayer(const std::string& layerID, const std::string& sourceID)

--- a/src/mbgl/style/layers/heatmap_layer.cpp
+++ b/src/mbgl/style/layers/heatmap_layer.cpp
@@ -15,7 +15,13 @@ namespace mbgl {
 namespace style {
 
 namespace {
-    const LayerTypeInfo typeInfoHeatmap{ "heatmap", LayerTypeInfo::SourceRequired };
+    const LayerTypeInfo typeInfoHeatmap
+        {"heatmap",
+          LayerTypeInfo::Source::Required,
+          LayerTypeInfo::Pass3D::Required,
+          LayerTypeInfo::Layout::NotRequired,
+          LayerTypeInfo::Clipping::NotRequired
+        };
 }  // namespace
 
 HeatmapLayer::HeatmapLayer(const std::string& layerID, const std::string& sourceID)

--- a/src/mbgl/style/layers/hillshade_layer.cpp
+++ b/src/mbgl/style/layers/hillshade_layer.cpp
@@ -15,7 +15,13 @@ namespace mbgl {
 namespace style {
 
 namespace {
-    const LayerTypeInfo typeInfoHillshade{ "hillshade", LayerTypeInfo::SourceRequired };
+    const LayerTypeInfo typeInfoHillshade
+        {"hillshade",
+          LayerTypeInfo::Source::Required,
+          LayerTypeInfo::Pass3D::Required,
+          LayerTypeInfo::Layout::NotRequired,
+          LayerTypeInfo::Clipping::NotRequired
+        };
 }  // namespace
 
 HillshadeLayer::HillshadeLayer(const std::string& layerID, const std::string& sourceID)

--- a/src/mbgl/style/layers/layer.cpp.ejs
+++ b/src/mbgl/style/layers/layer.cpp.ejs
@@ -19,12 +19,51 @@
 namespace mbgl {
 namespace style {
 
-namespace {
-<% if (type === 'background') { -%>
-    const LayerTypeInfo typeInfo<%- camelize(type) %>{ "<%- type %>", LayerTypeInfo::SourceNotRequired };
-<% } else { -%>
-    const LayerTypeInfo typeInfo<%- camelize(type) %>{ "<%- type %>", LayerTypeInfo::SourceRequired };
-<% } -%>
+namespace {<%
+let layerCapabilities = {};
+let defaults = { caps: { 'Source':   'NotRequired',
+                         'Pass3D':   'NotRequired',
+                         'Layout':   'NotRequired',
+                         'Clipping': 'NotRequired'
+                 },
+                 require: function(cap) {
+                             let copy = Object.assign({}, this);
+                             copy.caps = Object.assign({}, this.caps);
+                             copy.caps[cap] = 'Required';
+                             return copy;
+                 },
+                 finalize: function() {
+                    return Object.keys(this.caps).reduce((acc, key) => {
+                        acc.push(`${key}::${this.caps[key]}`);
+                        return acc;
+                    }, []);
+                 }
+               };
+
+layerCapabilities['background']     = defaults.finalize();
+layerCapabilities['fill']           = defaults.require('Source')
+                                              .require('Layout')
+                                              .require('Clipping')
+                                              .finalize();
+layerCapabilities['fill-extrusion'] = defaults.require('Source')
+                                              .require('Pass3D')
+                                              .require('Layout')
+                                              .finalize();
+layerCapabilities['hillshade']      = defaults.require('Source')
+                                              .require('Pass3D')
+                                              .finalize();
+layerCapabilities['symbol']         = defaults.require('Source')
+                                              .require('Layout')
+                                              .finalize();
+layerCapabilities['circle']         = defaults.require('Source').finalize();
+layerCapabilities['line']           = layerCapabilities['fill'];
+layerCapabilities['heatmap']        = layerCapabilities['hillshade'];
+layerCapabilities['raster']         = layerCapabilities['circle'];
+%>
+    const LayerTypeInfo typeInfo<%- `${camelize(type)}`%>
+        {"<%- type %>",
+          <%-`${layerCapabilities[type].map(cap => `LayerTypeInfo::${cap}`).join(',\n          ')}` %>
+        };
 }  // namespace
 
 <% if (type === 'background') { -%>

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -15,7 +15,13 @@ namespace mbgl {
 namespace style {
 
 namespace {
-    const LayerTypeInfo typeInfoLine{ "line", LayerTypeInfo::SourceRequired };
+    const LayerTypeInfo typeInfoLine
+        {"line",
+          LayerTypeInfo::Source::Required,
+          LayerTypeInfo::Pass3D::NotRequired,
+          LayerTypeInfo::Layout::Required,
+          LayerTypeInfo::Clipping::Required
+        };
 }  // namespace
 
 LineLayer::LineLayer(const std::string& layerID, const std::string& sourceID)

--- a/src/mbgl/style/layers/raster_layer.cpp
+++ b/src/mbgl/style/layers/raster_layer.cpp
@@ -15,7 +15,13 @@ namespace mbgl {
 namespace style {
 
 namespace {
-    const LayerTypeInfo typeInfoRaster{ "raster", LayerTypeInfo::SourceRequired };
+    const LayerTypeInfo typeInfoRaster
+        {"raster",
+          LayerTypeInfo::Source::Required,
+          LayerTypeInfo::Pass3D::NotRequired,
+          LayerTypeInfo::Layout::NotRequired,
+          LayerTypeInfo::Clipping::NotRequired
+        };
 }  // namespace
 
 RasterLayer::RasterLayer(const std::string& layerID, const std::string& sourceID)

--- a/src/mbgl/style/layers/symbol_layer.cpp
+++ b/src/mbgl/style/layers/symbol_layer.cpp
@@ -15,7 +15,13 @@ namespace mbgl {
 namespace style {
 
 namespace {
-    const LayerTypeInfo typeInfoSymbol{ "symbol", LayerTypeInfo::SourceRequired };
+    const LayerTypeInfo typeInfoSymbol
+        {"symbol",
+          LayerTypeInfo::Source::Required,
+          LayerTypeInfo::Pass3D::NotRequired,
+          LayerTypeInfo::Layout::Required,
+          LayerTypeInfo::Clipping::NotRequired
+        };
 }  // namespace
 
 SymbolLayer::SymbolLayer(const std::string& layerID, const std::string& sourceID)

--- a/src/mbgl/text/cross_tile_symbol_index.cpp
+++ b/src/mbgl/text/cross_tile_symbol_index.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/text/cross_tile_symbol_index.hpp>
 #include <mbgl/layout/symbol_instance.hpp>
 #include <mbgl/renderer/buckets/symbol_bucket.hpp>
+#include <mbgl/renderer/layers/render_layer_symbol_interface.hpp>
 #include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/tile/tile.hpp>
 
@@ -164,27 +165,27 @@ bool CrossTileSymbolLayerIndex::removeStaleBuckets(const std::unordered_set<uint
 
 CrossTileSymbolIndex::CrossTileSymbolIndex() {}
 
-bool CrossTileSymbolIndex::addLayer(RenderSymbolLayer& symbolLayer, float lng) {
+bool CrossTileSymbolIndex::addLayer(const RenderLayerSymbolInterface& symbolInterface, float lng) {
 
-    auto& layerIndex = layerIndexes[symbolLayer.getID()];
+    auto& layerIndex = layerIndexes[symbolInterface.layerID()];
 
     bool symbolBucketsChanged = false;
     std::unordered_set<uint32_t> currentBucketIDs;
 
     layerIndex.handleWrapJump(lng);
 
-    for (RenderTile& renderTile : symbolLayer.renderTiles) {
+    for (const RenderTile& renderTile : symbolInterface.getRenderTiles()) {
         if (!renderTile.tile.isRenderable()) {
             continue;
         }
 
-        auto bucket = renderTile.tile.getBucket<SymbolBucket>(*symbolLayer.baseImpl);
+        auto bucket = symbolInterface.getSymbolBucket(renderTile);
         if (!bucket) {
             continue;
         }
         SymbolBucket& symbolBucket = *bucket;
 
-        if (symbolBucket.bucketLeaderID != symbolLayer.getID()) {
+        if (symbolBucket.bucketLeaderID != symbolInterface.layerID()) {
             // Only add this layer if it's the "group leader" for the bucket
             continue;
         }

--- a/src/mbgl/text/cross_tile_symbol_index.hpp
+++ b/src/mbgl/text/cross_tile_symbol_index.hpp
@@ -15,7 +15,7 @@
 namespace mbgl {
 
 class SymbolInstance;
-class RenderSymbolLayer;
+class RenderLayerSymbolInterface;
 class SymbolBucket;
 
 class IndexedSymbolInstance {
@@ -58,7 +58,7 @@ class CrossTileSymbolIndex {
 public:
     CrossTileSymbolIndex();
 
-    bool addLayer(RenderSymbolLayer&, float lng);
+    bool addLayer(const RenderLayerSymbolInterface&, float lng);
     void pruneUnusedLayers(const std::set<std::string>&);
 
     void reset();

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -9,7 +9,7 @@
 
 namespace mbgl {
 
-class RenderSymbolLayer;
+class RenderLayerSymbolInterface;
 class SymbolBucket;
 
 class OpacityState {
@@ -80,9 +80,9 @@ private:
 class Placement {
 public:
     Placement(const TransformState&, MapMode mapMode, const bool crossSourceCollisions);
-    void placeLayer(RenderSymbolLayer&, const mat4&, bool showCollisionBoxes);
+    void placeLayer(const RenderLayerSymbolInterface&, const mat4&, bool showCollisionBoxes);
     void commit(const Placement& prevPlacement, TimePoint);
-    void updateLayerOpacities(RenderSymbolLayer&);
+    void updateLayerOpacities(const RenderLayerSymbolInterface&);
     float symbolFadeChange(TimePoint now) const;
     bool hasTransitions(TimePoint now) const;
 

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -375,7 +375,7 @@ void GeometryTileWorker::parse() {
         // are needed to render the layer. They use the intermediate Layout data structure to accomplish this,
         // and either immediately create a bucket if no images/glyphs are used, or the Layout is stored until
         // the images/glyphs are available to add the features to the buckets.
-        if (leader.as<RenderSymbolLayer>() ||leader.as<RenderLineLayer>() || leader.as<RenderFillLayer>() || leader.as<RenderFillExtrusionLayer>()) {
+        if (leader.baseImpl->getTypeInfo()->layout == LayerTypeInfo::Layout::Required) {
             auto layout = leader.createLayout(parameters, group, std::move(geometryLayer), glyphDependencies, imageDependencies);
             if (layout->hasDependencies()) {
                 layouts.push_back(std::move(layout));


### PR DESCRIPTION
This PR removes casts for RenderLayer derived classes. This will simplify addition or removal of new render layers. The changes are a part of modularization effort described in https://github.com/mapbox/mapbox-gl-native/issues/13276