### PR TITLE
Increase result's delta in camera animation tests

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/utils/TestConstants.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/utils/TestConstants.java
@@ -1,16 +1,10 @@
 package com.mapbox.mapboxsdk.testapp.utils;
 
-import com.mapbox.mapboxsdk.constants.MapboxConstants;
-
 public class TestConstants {
-
-  public static final long ANIMATION_TEST_TIME = MapboxConstants.ANIMATION_DURATION * 2;
-
-  public static final double LAT_LNG_DELTA_LARGE = 0.01;
-  public static final double LAT_LNG_DELTA = 0.001;
-  public static final double BEARING_DELTA = 0.01;
-  public static final double TILT_DELTA = 0.01;
-  public static final double ZOOM_DELTA = 0.01;
+  public static final double LAT_LNG_DELTA = 0.1;
+  public static final double BEARING_DELTA = 0.1;
+  public static final double TILT_DELTA = 0.3;
+  public static final double ZOOM_DELTA = 0.3;
 
   public static final String TEXT_MARKER_TEXT = "Text";
   public static final String TEXT_MARKER_TITLE = "Marker";


### PR DESCRIPTION
Because our camera animation tests are mainly performed on high zoom levels, we need to increase the acceptable delta of the final camera position to decrease not-meaningful test failures. The precision of the transformation should not be a concern on the Android side of the test suite.