### PR TITLE
Deliver OnMapReady only if MapboxMap is not null

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -951,7 +951,8 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
    */
   @UiThread
   public void getMapAsync(final @NonNull OnMapReadyCallback callback) {
-    if (mapCallback.isInitialLoad()) {
+    if (mapCallback.isInitialLoad() || mapboxMap == null) {
+      // Add callback to the list only if the style hasn't loaded, or the drawing surface isn't ready
       mapCallback.addOnMapReadyCallback(callback);
     } else {
       callback.onMapReady(mapboxMap);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/activity/BaseActivityTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/activity/BaseActivityTest.java
@@ -6,17 +6,21 @@ import android.support.test.espresso.IdlingRegistry;
 import android.support.test.espresso.IdlingResourceTimeoutException;
 import android.support.test.espresso.ViewInteraction;
 import android.support.test.rule.ActivityTestRule;
+
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.testapp.R;
 import com.mapbox.mapboxsdk.testapp.action.MapboxMapAction;
 import com.mapbox.mapboxsdk.testapp.action.WaitAction;
 import com.mapbox.mapboxsdk.testapp.utils.OnMapReadyIdlingResource;
+
 import junit.framework.Assert;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
+
 import timber.log.Timber;
 
 import static android.support.test.espresso.Espresso.onView;
@@ -38,7 +42,12 @@ public abstract class BaseActivityTest {
   @Before
   public void beforeTest() {
     try {
-      Timber.e(String.format("%s - %s", testNameRule.getMethodName(), "@Before test: register idle resource"));
+      Timber.e(String.format(
+        "%s - %s - %s",
+        getClass().getSimpleName(),
+        testNameRule.getMethodName(),
+        "@Before test: register idle resource"
+      ));
       idlingResource = new OnMapReadyIdlingResource(rule.getActivity());
       IdlingRegistry.getInstance().register(idlingResource);
       Espresso.onIdle();

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/utils/OnMapReadyIdlingResource.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/utils/OnMapReadyIdlingResource.java
@@ -11,21 +11,20 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.testapp.R;
 
+import junit.framework.Assert;
+
 public class OnMapReadyIdlingResource implements IdlingResource, OnMapReadyCallback {
 
   private MapboxMap mapboxMap;
   private IdlingResource.ResourceCallback resourceCallback;
-  private final Handler handler = new Handler(Looper.getMainLooper());
 
   @WorkerThread
   public OnMapReadyIdlingResource(final Activity activity) {
-    handler.post(new Runnable() {
-      @Override
-      public void run() {
-        MapView mapView = (MapView) activity.findViewById(R.id.mapView);
-        if (mapView != null) {
-          mapView.getMapAsync(OnMapReadyIdlingResource.this);
-        }
+    Handler handler = new Handler(Looper.getMainLooper());
+    handler.post(() -> {
+      MapView mapView = activity.findViewById(R.id.mapView);
+      if (mapView != null) {
+        mapView.getMapAsync(OnMapReadyIdlingResource.this);
       }
     });
   }
@@ -51,6 +50,7 @@ public class OnMapReadyIdlingResource implements IdlingResource, OnMapReadyCallb
 
   @Override
   public void onMapReady(MapboxMap mapboxMap) {
+    Assert.assertNotNull("MapboxMap should not be null", mapboxMap);
     this.mapboxMap = mapboxMap;
     if (resourceCallback != null) {
       resourceCallback.onTransitionToIdle();


### PR DESCRIPTION
This PR fixes a rare case scenario that when `MapView#getMapAsync` would be called precisely between style loaded callback and surface creation, then, `null` would've been delivered in the `OnMapReady` callback. This was causing unclear test timeouts, improved that with an assertion instead.

/cc @tmpsantos 