### PR TITLE
Changed event attributes to be JSON serialization friendly.

### DIFF
--- a/platform/darwin/src/MGLShapeOfflineRegion.mm
+++ b/platform/darwin/src/MGLShapeOfflineRegion.mm
@@ -32,7 +32,7 @@
              MMEEventKeyShapeForOfflineRegion: @"shaperegion",
              MMEEventKeyMinZoomLevel: @(self.minimumZoomLevel),
              MMEEventKeyMaxZoomLevel: @(self.maximumZoomLevel),
-             MMEEventKeyStyleURL: self.styleURL
+             MMEEventKeyStyleURL: self.styleURL.absoluteString ?: [NSNull null]
              #endif
              };
 }

--- a/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
+++ b/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
@@ -34,7 +34,7 @@
              };
 }
 
-+ (BOOL)supportsSecureCoding {    
++ (BOOL)supportsSecureCoding {
     return YES;
 }
 

--- a/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
+++ b/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
@@ -34,8 +34,7 @@
              };
 }
 
-+ (BOOL)supportsSecureCoding {
-    
++ (BOOL)supportsSecureCoding {    
     return YES;
 }
 

--- a/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
+++ b/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
@@ -29,12 +29,13 @@
              MMEEventKeyShapeForOfflineRegion: @"tileregion",
              MMEEventKeyMinZoomLevel: @(self.minimumZoomLevel),
              MMEEventKeyMaxZoomLevel: @(self.maximumZoomLevel),
-             MMEEventKeyStyleURL: self.styleURL
+             MMEEventKeyStyleURL: self.styleURL.absoluteString ?: [NSNull null]
              #endif
              };
 }
 
 + (BOOL)supportsSecureCoding {
+    
     return YES;
 }
 


### PR DESCRIPTION
This PR changes the `styleURL` event attribute value to a `NSString` (or `NSNull`)  to avoid a JSON serialization crash in https://github.com/mapbox/mapbox-events-ios/blob/ffda849352a85aa3fd72cda046d37b5db6693e8c/MapboxMobileEvents/MMEAPIClient.m#L220

/cc @captainbarbosa 