### PR TITLE
Handle null getMapAsync invocations, deliver onMapReady once

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -1143,13 +1143,18 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
       }
     }
 
+    /**
+     * Notify listeners, clear when done
+     */
     private void onMapReady() {
       if (onMapReadyCallbackList.size() > 0) {
-        // Notify listeners, clear when done
         Iterator<OnMapReadyCallback> iterator = onMapReadyCallbackList.iterator();
         while (iterator.hasNext()) {
           OnMapReadyCallback callback = iterator.next();
-          callback.onMapReady(mapboxMap);
+          if (callback != null) {
+            // null checking required for #13279
+            callback.onMapReady(mapboxMap);
+          }
           iterator.remove();
         }
       }
@@ -1184,6 +1189,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     public void onDidFinishLoadingStyle() {
       if (mapboxMap != null) {
         if (initialLoad) {
+          initialLoad = false;
           mapboxMap.onPreMapReady();
           onMapReady();
           mapboxMap.onPostMapReady();


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/13279, noted two issues:
 - `getMapAsync(null)`, while this isn't a valid construct it can still occur when consuming the library from Java.
 - calling `mapboxMap#setStyleJson` from OnMapReady resulted in a stackoverflow which cause was invoking OnMapReady constantly with each `setStyleJson` invocation. 

Wasn't able to quickly write regressions tests around this as our test harness is already in a resumed state. 