### PR TITLE
Verify if `text-field` is not null before performing compatibility operations

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/SymbolLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/SymbolLayer.java
@@ -372,13 +372,18 @@ public class SymbolLayer extends Layer {
     if (propertyValue.isExpression()) {
       return (PropertyValue<String>) propertyValue;
     } else {
+      String text = null;
+
       Formatted formatted = (Formatted) nativeGetTextField();
-      StringBuilder builder = new StringBuilder();
-      for (FormattedSection section : formatted.getFormattedSections()) {
-        builder.append(section.getText());
+      if (formatted != null) {
+        StringBuilder builder = new StringBuilder();
+        for (FormattedSection section : formatted.getFormattedSections()) {
+          builder.append(section.getText());
+        }
+        text = builder.toString();
       }
 
-      return (PropertyValue<String>) new PropertyValue("text-field", builder.toString());
+      return (PropertyValue<String>) new PropertyValue("text-field", text);
     }
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/layer.java.ejs
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/layer.java.ejs
@@ -181,13 +181,18 @@ public class <%- camelize(type) %>Layer extends Layer {
     if (propertyValue.isExpression()) {
       return (PropertyValue<String>) propertyValue;
     } else {
+      String text = null;
+
       Formatted formatted = (Formatted) nativeGetTextField();
-      StringBuilder builder = new StringBuilder();
-      for (FormattedSection section : formatted.getFormattedSections()) {
-        builder.append(section.getText());
+      if (formatted != null) {
+        StringBuilder builder = new StringBuilder();
+        for (FormattedSection section : formatted.getFormattedSections()) {
+          builder.append(section.getText());
+        }
+        text = builder.toString();
       }
 
-      return (PropertyValue<String>) new PropertyValue("text-field", builder.toString());
+      return (PropertyValue<String>) new PropertyValue("text-field", text);
     }
 <% } else { -%>
     return (PropertyValue<<%- propertyType(property) %>>) new PropertyValue("<%- property.name %>", nativeGet<%- camelize(property.name) %>());

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/BackgroundLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/BackgroundLayerTest.java
@@ -82,6 +82,7 @@ public class BackgroundLayerTest extends BaseActivityTest {
     Timber.i("background-color");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getBackgroundColor().getValue());
 
       // Set and Get
       layer.setProperties(backgroundColor("rgba(0, 0, 0, 1)"));
@@ -125,6 +126,7 @@ public class BackgroundLayerTest extends BaseActivityTest {
     Timber.i("background-pattern");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getBackgroundPattern().getValue());
 
       // Set and Get
       layer.setProperties(backgroundPattern("pedestrian-polygon"));
@@ -154,6 +156,7 @@ public class BackgroundLayerTest extends BaseActivityTest {
     Timber.i("background-opacity");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getBackgroundOpacity().getValue());
 
       // Set and Get
       layer.setProperties(backgroundOpacity(0.3f));

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CircleLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CircleLayerTest.java
@@ -139,6 +139,7 @@ public class CircleLayerTest extends BaseActivityTest {
     Timber.i("circle-radius");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getCircleRadius().getValue());
 
       // Set and Get
       layer.setProperties(circleRadius(0.3f));
@@ -153,6 +154,7 @@ public class CircleLayerTest extends BaseActivityTest {
     Timber.i("circle-radius-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getCircleRadius().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -183,6 +185,7 @@ public class CircleLayerTest extends BaseActivityTest {
     Timber.i("circle-color");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getCircleColor().getValue());
 
       // Set and Get
       layer.setProperties(circleColor("rgba(0, 0, 0, 1)"));
@@ -197,6 +200,7 @@ public class CircleLayerTest extends BaseActivityTest {
     Timber.i("circle-color-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getCircleColor().getExpression());
 
       // Set and Get
       Expression expression = toColor(Expression.get("undefined"));
@@ -241,6 +245,7 @@ public class CircleLayerTest extends BaseActivityTest {
     Timber.i("circle-blur");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getCircleBlur().getValue());
 
       // Set and Get
       layer.setProperties(circleBlur(0.3f));
@@ -255,6 +260,7 @@ public class CircleLayerTest extends BaseActivityTest {
     Timber.i("circle-blur-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getCircleBlur().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -285,6 +291,7 @@ public class CircleLayerTest extends BaseActivityTest {
     Timber.i("circle-opacity");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getCircleOpacity().getValue());
 
       // Set and Get
       layer.setProperties(circleOpacity(0.3f));
@@ -299,6 +306,7 @@ public class CircleLayerTest extends BaseActivityTest {
     Timber.i("circle-opacity-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getCircleOpacity().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -329,6 +337,7 @@ public class CircleLayerTest extends BaseActivityTest {
     Timber.i("circle-translate");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float[]) layer.getCircleTranslate().getValue());
 
       // Set and Get
       layer.setProperties(circleTranslate(new Float[] {0f, 0f}));
@@ -343,6 +352,7 @@ public class CircleLayerTest extends BaseActivityTest {
     Timber.i("circle-translate-anchor");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getCircleTranslateAnchor().getValue());
 
       // Set and Get
       layer.setProperties(circleTranslateAnchor(CIRCLE_TRANSLATE_ANCHOR_MAP));
@@ -357,6 +367,7 @@ public class CircleLayerTest extends BaseActivityTest {
     Timber.i("circle-pitch-scale");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getCirclePitchScale().getValue());
 
       // Set and Get
       layer.setProperties(circlePitchScale(CIRCLE_PITCH_SCALE_MAP));
@@ -371,6 +382,7 @@ public class CircleLayerTest extends BaseActivityTest {
     Timber.i("circle-pitch-alignment");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getCirclePitchAlignment().getValue());
 
       // Set and Get
       layer.setProperties(circlePitchAlignment(CIRCLE_PITCH_ALIGNMENT_MAP));
@@ -400,6 +412,7 @@ public class CircleLayerTest extends BaseActivityTest {
     Timber.i("circle-stroke-width");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getCircleStrokeWidth().getValue());
 
       // Set and Get
       layer.setProperties(circleStrokeWidth(0.3f));
@@ -414,6 +427,7 @@ public class CircleLayerTest extends BaseActivityTest {
     Timber.i("circle-stroke-width-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getCircleStrokeWidth().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -444,6 +458,7 @@ public class CircleLayerTest extends BaseActivityTest {
     Timber.i("circle-stroke-color");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getCircleStrokeColor().getValue());
 
       // Set and Get
       layer.setProperties(circleStrokeColor("rgba(0, 0, 0, 1)"));
@@ -458,6 +473,7 @@ public class CircleLayerTest extends BaseActivityTest {
     Timber.i("circle-stroke-color-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getCircleStrokeColor().getExpression());
 
       // Set and Get
       Expression expression = toColor(Expression.get("undefined"));
@@ -502,6 +518,7 @@ public class CircleLayerTest extends BaseActivityTest {
     Timber.i("circle-stroke-opacity");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getCircleStrokeOpacity().getValue());
 
       // Set and Get
       layer.setProperties(circleStrokeOpacity(0.3f));
@@ -516,6 +533,7 @@ public class CircleLayerTest extends BaseActivityTest {
     Timber.i("circle-stroke-opacity-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getCircleStrokeOpacity().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillExtrusionLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillExtrusionLayerTest.java
@@ -139,6 +139,7 @@ public class FillExtrusionLayerTest extends BaseActivityTest {
     Timber.i("fill-extrusion-opacity");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getFillExtrusionOpacity().getValue());
 
       // Set and Get
       layer.setProperties(fillExtrusionOpacity(0.3f));
@@ -168,6 +169,7 @@ public class FillExtrusionLayerTest extends BaseActivityTest {
     Timber.i("fill-extrusion-color");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getFillExtrusionColor().getValue());
 
       // Set and Get
       layer.setProperties(fillExtrusionColor("rgba(0, 0, 0, 1)"));
@@ -182,6 +184,7 @@ public class FillExtrusionLayerTest extends BaseActivityTest {
     Timber.i("fill-extrusion-color-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getFillExtrusionColor().getExpression());
 
       // Set and Get
       Expression expression = toColor(Expression.get("undefined"));
@@ -226,6 +229,7 @@ public class FillExtrusionLayerTest extends BaseActivityTest {
     Timber.i("fill-extrusion-translate");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float[]) layer.getFillExtrusionTranslate().getValue());
 
       // Set and Get
       layer.setProperties(fillExtrusionTranslate(new Float[] {0f, 0f}));
@@ -240,6 +244,7 @@ public class FillExtrusionLayerTest extends BaseActivityTest {
     Timber.i("fill-extrusion-translate-anchor");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getFillExtrusionTranslateAnchor().getValue());
 
       // Set and Get
       layer.setProperties(fillExtrusionTranslateAnchor(FILL_EXTRUSION_TRANSLATE_ANCHOR_MAP));
@@ -269,6 +274,7 @@ public class FillExtrusionLayerTest extends BaseActivityTest {
     Timber.i("fill-extrusion-pattern");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getFillExtrusionPattern().getValue());
 
       // Set and Get
       layer.setProperties(fillExtrusionPattern("pedestrian-polygon"));
@@ -283,6 +289,7 @@ public class FillExtrusionLayerTest extends BaseActivityTest {
     Timber.i("fill-extrusion-pattern-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getFillExtrusionPattern().getExpression());
 
       // Set and Get
       Expression expression = string(Expression.get("undefined"));
@@ -313,6 +320,7 @@ public class FillExtrusionLayerTest extends BaseActivityTest {
     Timber.i("fill-extrusion-height");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getFillExtrusionHeight().getValue());
 
       // Set and Get
       layer.setProperties(fillExtrusionHeight(0.3f));
@@ -327,6 +335,7 @@ public class FillExtrusionLayerTest extends BaseActivityTest {
     Timber.i("fill-extrusion-height-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getFillExtrusionHeight().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -357,6 +366,7 @@ public class FillExtrusionLayerTest extends BaseActivityTest {
     Timber.i("fill-extrusion-base");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getFillExtrusionBase().getValue());
 
       // Set and Get
       layer.setProperties(fillExtrusionBase(0.3f));
@@ -371,6 +381,7 @@ public class FillExtrusionLayerTest extends BaseActivityTest {
     Timber.i("fill-extrusion-base-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getFillExtrusionBase().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillLayerTest.java
@@ -124,6 +124,7 @@ public class FillLayerTest extends BaseActivityTest {
     Timber.i("fill-antialias");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Boolean) layer.getFillAntialias().getValue());
 
       // Set and Get
       layer.setProperties(fillAntialias(true));
@@ -153,6 +154,7 @@ public class FillLayerTest extends BaseActivityTest {
     Timber.i("fill-opacity");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getFillOpacity().getValue());
 
       // Set and Get
       layer.setProperties(fillOpacity(0.3f));
@@ -167,6 +169,7 @@ public class FillLayerTest extends BaseActivityTest {
     Timber.i("fill-opacity-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getFillOpacity().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -197,6 +200,7 @@ public class FillLayerTest extends BaseActivityTest {
     Timber.i("fill-color");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getFillColor().getValue());
 
       // Set and Get
       layer.setProperties(fillColor("rgba(0, 0, 0, 1)"));
@@ -211,6 +215,7 @@ public class FillLayerTest extends BaseActivityTest {
     Timber.i("fill-color-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getFillColor().getExpression());
 
       // Set and Get
       Expression expression = toColor(Expression.get("undefined"));
@@ -255,6 +260,7 @@ public class FillLayerTest extends BaseActivityTest {
     Timber.i("fill-outline-color");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getFillOutlineColor().getValue());
 
       // Set and Get
       layer.setProperties(fillOutlineColor("rgba(0, 0, 0, 1)"));
@@ -269,6 +275,7 @@ public class FillLayerTest extends BaseActivityTest {
     Timber.i("fill-outline-color-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getFillOutlineColor().getExpression());
 
       // Set and Get
       Expression expression = toColor(Expression.get("undefined"));
@@ -313,6 +320,7 @@ public class FillLayerTest extends BaseActivityTest {
     Timber.i("fill-translate");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float[]) layer.getFillTranslate().getValue());
 
       // Set and Get
       layer.setProperties(fillTranslate(new Float[] {0f, 0f}));
@@ -327,6 +335,7 @@ public class FillLayerTest extends BaseActivityTest {
     Timber.i("fill-translate-anchor");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getFillTranslateAnchor().getValue());
 
       // Set and Get
       layer.setProperties(fillTranslateAnchor(FILL_TRANSLATE_ANCHOR_MAP));
@@ -356,6 +365,7 @@ public class FillLayerTest extends BaseActivityTest {
     Timber.i("fill-pattern");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getFillPattern().getValue());
 
       // Set and Get
       layer.setProperties(fillPattern("pedestrian-polygon"));
@@ -370,6 +380,7 @@ public class FillLayerTest extends BaseActivityTest {
     Timber.i("fill-pattern-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getFillPattern().getExpression());
 
       // Set and Get
       Expression expression = string(Expression.get("undefined"));

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HeatmapLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HeatmapLayerTest.java
@@ -139,6 +139,7 @@ public class HeatmapLayerTest extends BaseActivityTest {
     Timber.i("heatmap-radius");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getHeatmapRadius().getValue());
 
       // Set and Get
       layer.setProperties(heatmapRadius(0.3f));
@@ -153,6 +154,7 @@ public class HeatmapLayerTest extends BaseActivityTest {
     Timber.i("heatmap-radius-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getHeatmapRadius().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -168,6 +170,7 @@ public class HeatmapLayerTest extends BaseActivityTest {
     Timber.i("heatmap-weight");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getHeatmapWeight().getValue());
 
       // Set and Get
       layer.setProperties(heatmapWeight(0.3f));
@@ -182,6 +185,7 @@ public class HeatmapLayerTest extends BaseActivityTest {
     Timber.i("heatmap-weight-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getHeatmapWeight().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -212,6 +216,7 @@ public class HeatmapLayerTest extends BaseActivityTest {
     Timber.i("heatmap-intensity");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getHeatmapIntensity().getValue());
 
       // Set and Get
       layer.setProperties(heatmapIntensity(0.3f));
@@ -241,6 +246,7 @@ public class HeatmapLayerTest extends BaseActivityTest {
     Timber.i("heatmap-opacity");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getHeatmapOpacity().getValue());
 
       // Set and Get
       layer.setProperties(heatmapOpacity(0.3f));

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HillshadeLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HillshadeLayerTest.java
@@ -86,6 +86,7 @@ public class HillshadeLayerTest extends BaseActivityTest {
     Timber.i("hillshade-illumination-direction");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getHillshadeIlluminationDirection().getValue());
 
       // Set and Get
       layer.setProperties(hillshadeIlluminationDirection(0.3f));
@@ -100,6 +101,7 @@ public class HillshadeLayerTest extends BaseActivityTest {
     Timber.i("hillshade-illumination-anchor");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getHillshadeIlluminationAnchor().getValue());
 
       // Set and Get
       layer.setProperties(hillshadeIlluminationAnchor(HILLSHADE_ILLUMINATION_ANCHOR_MAP));
@@ -129,6 +131,7 @@ public class HillshadeLayerTest extends BaseActivityTest {
     Timber.i("hillshade-exaggeration");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getHillshadeExaggeration().getValue());
 
       // Set and Get
       layer.setProperties(hillshadeExaggeration(0.3f));
@@ -158,6 +161,7 @@ public class HillshadeLayerTest extends BaseActivityTest {
     Timber.i("hillshade-shadow-color");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getHillshadeShadowColor().getValue());
 
       // Set and Get
       layer.setProperties(hillshadeShadowColor("rgba(0, 0, 0, 1)"));
@@ -201,6 +205,7 @@ public class HillshadeLayerTest extends BaseActivityTest {
     Timber.i("hillshade-highlight-color");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getHillshadeHighlightColor().getValue());
 
       // Set and Get
       layer.setProperties(hillshadeHighlightColor("rgba(0, 0, 0, 1)"));
@@ -244,6 +249,7 @@ public class HillshadeLayerTest extends BaseActivityTest {
     Timber.i("hillshade-accent-color");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getHillshadeAccentColor().getValue());
 
       // Set and Get
       layer.setProperties(hillshadeAccentColor("rgba(0, 0, 0, 1)"));

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
@@ -124,6 +124,7 @@ public class LineLayerTest extends BaseActivityTest {
     Timber.i("line-cap");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getLineCap().getValue());
 
       // Set and Get
       layer.setProperties(lineCap(LINE_CAP_BUTT));
@@ -138,6 +139,7 @@ public class LineLayerTest extends BaseActivityTest {
     Timber.i("line-join");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getLineJoin().getValue());
 
       // Set and Get
       layer.setProperties(lineJoin(LINE_JOIN_BEVEL));
@@ -152,6 +154,7 @@ public class LineLayerTest extends BaseActivityTest {
     Timber.i("line-join-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getLineJoin().getExpression());
 
       // Set and Get
       Expression expression = string(Expression.get("undefined"));
@@ -167,6 +170,7 @@ public class LineLayerTest extends BaseActivityTest {
     Timber.i("line-miter-limit");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getLineMiterLimit().getValue());
 
       // Set and Get
       layer.setProperties(lineMiterLimit(0.3f));
@@ -181,6 +185,7 @@ public class LineLayerTest extends BaseActivityTest {
     Timber.i("line-round-limit");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getLineRoundLimit().getValue());
 
       // Set and Get
       layer.setProperties(lineRoundLimit(0.3f));
@@ -210,6 +215,7 @@ public class LineLayerTest extends BaseActivityTest {
     Timber.i("line-opacity");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getLineOpacity().getValue());
 
       // Set and Get
       layer.setProperties(lineOpacity(0.3f));
@@ -224,6 +230,7 @@ public class LineLayerTest extends BaseActivityTest {
     Timber.i("line-opacity-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getLineOpacity().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -254,6 +261,7 @@ public class LineLayerTest extends BaseActivityTest {
     Timber.i("line-color");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getLineColor().getValue());
 
       // Set and Get
       layer.setProperties(lineColor("rgba(0, 0, 0, 1)"));
@@ -268,6 +276,7 @@ public class LineLayerTest extends BaseActivityTest {
     Timber.i("line-color-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getLineColor().getExpression());
 
       // Set and Get
       Expression expression = toColor(Expression.get("undefined"));
@@ -312,6 +321,7 @@ public class LineLayerTest extends BaseActivityTest {
     Timber.i("line-translate");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float[]) layer.getLineTranslate().getValue());
 
       // Set and Get
       layer.setProperties(lineTranslate(new Float[] {0f, 0f}));
@@ -326,6 +336,7 @@ public class LineLayerTest extends BaseActivityTest {
     Timber.i("line-translate-anchor");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getLineTranslateAnchor().getValue());
 
       // Set and Get
       layer.setProperties(lineTranslateAnchor(LINE_TRANSLATE_ANCHOR_MAP));
@@ -355,6 +366,7 @@ public class LineLayerTest extends BaseActivityTest {
     Timber.i("line-width");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getLineWidth().getValue());
 
       // Set and Get
       layer.setProperties(lineWidth(0.3f));
@@ -369,6 +381,7 @@ public class LineLayerTest extends BaseActivityTest {
     Timber.i("line-width-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getLineWidth().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -399,6 +412,7 @@ public class LineLayerTest extends BaseActivityTest {
     Timber.i("line-gap-width");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getLineGapWidth().getValue());
 
       // Set and Get
       layer.setProperties(lineGapWidth(0.3f));
@@ -413,6 +427,7 @@ public class LineLayerTest extends BaseActivityTest {
     Timber.i("line-gap-width-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getLineGapWidth().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -443,6 +458,7 @@ public class LineLayerTest extends BaseActivityTest {
     Timber.i("line-offset");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getLineOffset().getValue());
 
       // Set and Get
       layer.setProperties(lineOffset(0.3f));
@@ -472,6 +488,7 @@ public class LineLayerTest extends BaseActivityTest {
     Timber.i("line-blur");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getLineBlur().getValue());
 
       // Set and Get
       layer.setProperties(lineBlur(0.3f));
@@ -486,6 +503,7 @@ public class LineLayerTest extends BaseActivityTest {
     Timber.i("line-blur-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getLineBlur().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -516,6 +534,7 @@ public class LineLayerTest extends BaseActivityTest {
     Timber.i("line-dasharray");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float[]) layer.getLineDasharray().getValue());
 
       // Set and Get
       layer.setProperties(lineDasharray(new Float[] {}));
@@ -545,6 +564,7 @@ public class LineLayerTest extends BaseActivityTest {
     Timber.i("line-pattern");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getLinePattern().getValue());
 
       // Set and Get
       layer.setProperties(linePattern("pedestrian-polygon"));
@@ -559,6 +579,7 @@ public class LineLayerTest extends BaseActivityTest {
     Timber.i("line-pattern-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getLinePattern().getExpression());
 
       // Set and Get
       Expression expression = string(Expression.get("undefined"));

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RasterLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RasterLayerTest.java
@@ -101,6 +101,7 @@ public class RasterLayerTest extends BaseActivityTest {
     Timber.i("raster-opacity");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getRasterOpacity().getValue());
 
       // Set and Get
       layer.setProperties(rasterOpacity(0.3f));
@@ -130,6 +131,7 @@ public class RasterLayerTest extends BaseActivityTest {
     Timber.i("raster-hue-rotate");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getRasterHueRotate().getValue());
 
       // Set and Get
       layer.setProperties(rasterHueRotate(0.3f));
@@ -159,6 +161,7 @@ public class RasterLayerTest extends BaseActivityTest {
     Timber.i("raster-brightness-min");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getRasterBrightnessMin().getValue());
 
       // Set and Get
       layer.setProperties(rasterBrightnessMin(0.3f));
@@ -188,6 +191,7 @@ public class RasterLayerTest extends BaseActivityTest {
     Timber.i("raster-brightness-max");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getRasterBrightnessMax().getValue());
 
       // Set and Get
       layer.setProperties(rasterBrightnessMax(0.3f));
@@ -217,6 +221,7 @@ public class RasterLayerTest extends BaseActivityTest {
     Timber.i("raster-saturation");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getRasterSaturation().getValue());
 
       // Set and Get
       layer.setProperties(rasterSaturation(0.3f));
@@ -246,6 +251,7 @@ public class RasterLayerTest extends BaseActivityTest {
     Timber.i("raster-contrast");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getRasterContrast().getValue());
 
       // Set and Get
       layer.setProperties(rasterContrast(0.3f));
@@ -260,6 +266,7 @@ public class RasterLayerTest extends BaseActivityTest {
     Timber.i("raster-resampling");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getRasterResampling().getValue());
 
       // Set and Get
       layer.setProperties(rasterResampling(RASTER_RESAMPLING_LINEAR));
@@ -274,6 +281,7 @@ public class RasterLayerTest extends BaseActivityTest {
     Timber.i("raster-fade-duration");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getRasterFadeDuration().getValue());
 
       // Set and Get
       layer.setProperties(rasterFadeDuration(0.3f));

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
@@ -126,6 +126,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("symbol-placement");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getSymbolPlacement().getValue());
 
       // Set and Get
       layer.setProperties(symbolPlacement(SYMBOL_PLACEMENT_POINT));
@@ -140,6 +141,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("symbol-spacing");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getSymbolSpacing().getValue());
 
       // Set and Get
       layer.setProperties(symbolSpacing(0.3f));
@@ -154,6 +156,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("symbol-avoid-edges");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Boolean) layer.getSymbolAvoidEdges().getValue());
 
       // Set and Get
       layer.setProperties(symbolAvoidEdges(true));
@@ -168,6 +171,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("symbol-z-order");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getSymbolZOrder().getValue());
 
       // Set and Get
       layer.setProperties(symbolZOrder(SYMBOL_Z_ORDER_VIEWPORT_Y));
@@ -182,6 +186,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-allow-overlap");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Boolean) layer.getIconAllowOverlap().getValue());
 
       // Set and Get
       layer.setProperties(iconAllowOverlap(true));
@@ -196,6 +201,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-ignore-placement");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Boolean) layer.getIconIgnorePlacement().getValue());
 
       // Set and Get
       layer.setProperties(iconIgnorePlacement(true));
@@ -210,6 +216,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-optional");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Boolean) layer.getIconOptional().getValue());
 
       // Set and Get
       layer.setProperties(iconOptional(true));
@@ -224,6 +231,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-rotation-alignment");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getIconRotationAlignment().getValue());
 
       // Set and Get
       layer.setProperties(iconRotationAlignment(ICON_ROTATION_ALIGNMENT_MAP));
@@ -238,6 +246,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-size");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getIconSize().getValue());
 
       // Set and Get
       layer.setProperties(iconSize(0.3f));
@@ -252,6 +261,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-size-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getIconSize().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -267,6 +277,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-text-fit");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getIconTextFit().getValue());
 
       // Set and Get
       layer.setProperties(iconTextFit(ICON_TEXT_FIT_NONE));
@@ -281,6 +292,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-text-fit-padding");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float[]) layer.getIconTextFitPadding().getValue());
 
       // Set and Get
       layer.setProperties(iconTextFitPadding(new Float[] {0f, 0f, 0f, 0f}));
@@ -295,6 +307,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-image");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getIconImage().getValue());
 
       // Set and Get
       layer.setProperties(iconImage("undefined"));
@@ -312,6 +325,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-image-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getIconImage().getExpression());
 
       // Set and Get
       Expression expression = string(Expression.get("undefined"));
@@ -327,6 +341,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-rotate");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getIconRotate().getValue());
 
       // Set and Get
       layer.setProperties(iconRotate(0.3f));
@@ -341,6 +356,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-rotate-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getIconRotate().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -356,6 +372,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-padding");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getIconPadding().getValue());
 
       // Set and Get
       layer.setProperties(iconPadding(0.3f));
@@ -370,6 +387,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-keep-upright");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Boolean) layer.getIconKeepUpright().getValue());
 
       // Set and Get
       layer.setProperties(iconKeepUpright(true));
@@ -384,6 +402,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-offset");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float[]) layer.getIconOffset().getValue());
 
       // Set and Get
       layer.setProperties(iconOffset(new Float[] {0f, 0f}));
@@ -398,6 +417,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-anchor");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getIconAnchor().getValue());
 
       // Set and Get
       layer.setProperties(iconAnchor(ICON_ANCHOR_CENTER));
@@ -412,6 +432,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-anchor-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getIconAnchor().getExpression());
 
       // Set and Get
       Expression expression = string(Expression.get("undefined"));
@@ -427,6 +448,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-pitch-alignment");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getIconPitchAlignment().getValue());
 
       // Set and Get
       layer.setProperties(iconPitchAlignment(ICON_PITCH_ALIGNMENT_MAP));
@@ -441,6 +463,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-pitch-alignment");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getTextPitchAlignment().getValue());
 
       // Set and Get
       layer.setProperties(textPitchAlignment(TEXT_PITCH_ALIGNMENT_MAP));
@@ -455,6 +478,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-rotation-alignment");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getTextRotationAlignment().getValue());
 
       // Set and Get
       layer.setProperties(textRotationAlignment(TEXT_ROTATION_ALIGNMENT_MAP));
@@ -469,6 +493,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-field");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getTextField().getValue());
 
       // Set and Get
       layer.setProperties(textField(""));
@@ -486,6 +511,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-field-formatted");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getTextField().getValue());
 
       Formatted expected = new Formatted(new FormattedSection[] {
         new FormattedSection("", 1.0)
@@ -507,6 +533,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-field-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getTextField().getExpression());
 
       // Set and Get
       Expression expression = string(Expression.get("undefined"));
@@ -522,6 +549,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-field-formatted-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getTextField().getExpression());
 
       // Set and Get
       Expression expression = string(Expression.get("undefined"));
@@ -537,6 +565,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-font");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String[]) layer.getTextFont().getValue());
 
       // Set and Get
       layer.setProperties(textFont(new String[]{"Open Sans Regular", "Arial Unicode MS Regular"}));
@@ -551,6 +580,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-size");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getTextSize().getValue());
 
       // Set and Get
       layer.setProperties(textSize(0.3f));
@@ -565,6 +595,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-size-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getTextSize().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -580,6 +611,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-max-width");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getTextMaxWidth().getValue());
 
       // Set and Get
       layer.setProperties(textMaxWidth(0.3f));
@@ -594,6 +626,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-max-width-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getTextMaxWidth().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -609,6 +642,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-line-height");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getTextLineHeight().getValue());
 
       // Set and Get
       layer.setProperties(textLineHeight(0.3f));
@@ -623,6 +657,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-letter-spacing");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getTextLetterSpacing().getValue());
 
       // Set and Get
       layer.setProperties(textLetterSpacing(0.3f));
@@ -637,6 +672,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-letter-spacing-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getTextLetterSpacing().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -652,6 +688,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-justify");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getTextJustify().getValue());
 
       // Set and Get
       layer.setProperties(textJustify(TEXT_JUSTIFY_LEFT));
@@ -666,6 +703,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-justify-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getTextJustify().getExpression());
 
       // Set and Get
       Expression expression = string(Expression.get("undefined"));
@@ -681,6 +719,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-anchor");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getTextAnchor().getValue());
 
       // Set and Get
       layer.setProperties(textAnchor(TEXT_ANCHOR_CENTER));
@@ -695,6 +734,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-anchor-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getTextAnchor().getExpression());
 
       // Set and Get
       Expression expression = string(Expression.get("undefined"));
@@ -710,6 +750,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-max-angle");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getTextMaxAngle().getValue());
 
       // Set and Get
       layer.setProperties(textMaxAngle(0.3f));
@@ -724,6 +765,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-rotate");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getTextRotate().getValue());
 
       // Set and Get
       layer.setProperties(textRotate(0.3f));
@@ -738,6 +780,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-rotate-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getTextRotate().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -753,6 +796,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-padding");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getTextPadding().getValue());
 
       // Set and Get
       layer.setProperties(textPadding(0.3f));
@@ -767,6 +811,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-keep-upright");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Boolean) layer.getTextKeepUpright().getValue());
 
       // Set and Get
       layer.setProperties(textKeepUpright(true));
@@ -781,6 +826,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-transform");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getTextTransform().getValue());
 
       // Set and Get
       layer.setProperties(textTransform(TEXT_TRANSFORM_NONE));
@@ -795,6 +841,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-transform-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getTextTransform().getExpression());
 
       // Set and Get
       Expression expression = string(Expression.get("undefined"));
@@ -810,6 +857,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-offset");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float[]) layer.getTextOffset().getValue());
 
       // Set and Get
       layer.setProperties(textOffset(new Float[] {0f, 0f}));
@@ -824,6 +872,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-allow-overlap");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Boolean) layer.getTextAllowOverlap().getValue());
 
       // Set and Get
       layer.setProperties(textAllowOverlap(true));
@@ -838,6 +887,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-ignore-placement");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Boolean) layer.getTextIgnorePlacement().getValue());
 
       // Set and Get
       layer.setProperties(textIgnorePlacement(true));
@@ -852,6 +902,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-optional");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Boolean) layer.getTextOptional().getValue());
 
       // Set and Get
       layer.setProperties(textOptional(true));
@@ -881,6 +932,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-opacity");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getIconOpacity().getValue());
 
       // Set and Get
       layer.setProperties(iconOpacity(0.3f));
@@ -895,6 +947,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-opacity-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getIconOpacity().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -925,6 +978,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-color");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getIconColor().getValue());
 
       // Set and Get
       layer.setProperties(iconColor("rgba(0, 0, 0, 1)"));
@@ -939,6 +993,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-color-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getIconColor().getExpression());
 
       // Set and Get
       Expression expression = toColor(Expression.get("undefined"));
@@ -983,6 +1038,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-halo-color");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getIconHaloColor().getValue());
 
       // Set and Get
       layer.setProperties(iconHaloColor("rgba(0, 0, 0, 1)"));
@@ -997,6 +1053,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-halo-color-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getIconHaloColor().getExpression());
 
       // Set and Get
       Expression expression = toColor(Expression.get("undefined"));
@@ -1041,6 +1098,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-halo-width");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getIconHaloWidth().getValue());
 
       // Set and Get
       layer.setProperties(iconHaloWidth(0.3f));
@@ -1055,6 +1113,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-halo-width-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getIconHaloWidth().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -1085,6 +1144,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-halo-blur");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getIconHaloBlur().getValue());
 
       // Set and Get
       layer.setProperties(iconHaloBlur(0.3f));
@@ -1099,6 +1159,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-halo-blur-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getIconHaloBlur().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -1129,6 +1190,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-translate");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float[]) layer.getIconTranslate().getValue());
 
       // Set and Get
       layer.setProperties(iconTranslate(new Float[] {0f, 0f}));
@@ -1143,6 +1205,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("icon-translate-anchor");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getIconTranslateAnchor().getValue());
 
       // Set and Get
       layer.setProperties(iconTranslateAnchor(ICON_TRANSLATE_ANCHOR_MAP));
@@ -1172,6 +1235,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-opacity");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getTextOpacity().getValue());
 
       // Set and Get
       layer.setProperties(textOpacity(0.3f));
@@ -1186,6 +1250,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-opacity-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getTextOpacity().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -1216,6 +1281,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-color");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getTextColor().getValue());
 
       // Set and Get
       layer.setProperties(textColor("rgba(0, 0, 0, 1)"));
@@ -1230,6 +1296,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-color-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getTextColor().getExpression());
 
       // Set and Get
       Expression expression = toColor(Expression.get("undefined"));
@@ -1274,6 +1341,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-halo-color");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getTextHaloColor().getValue());
 
       // Set and Get
       layer.setProperties(textHaloColor("rgba(0, 0, 0, 1)"));
@@ -1288,6 +1356,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-halo-color-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getTextHaloColor().getExpression());
 
       // Set and Get
       Expression expression = toColor(Expression.get("undefined"));
@@ -1332,6 +1401,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-halo-width");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getTextHaloWidth().getValue());
 
       // Set and Get
       layer.setProperties(textHaloWidth(0.3f));
@@ -1346,6 +1416,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-halo-width-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getTextHaloWidth().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -1376,6 +1447,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-halo-blur");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float) layer.getTextHaloBlur().getValue());
 
       // Set and Get
       layer.setProperties(textHaloBlur(0.3f));
@@ -1390,6 +1462,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-halo-blur-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.getTextHaloBlur().getExpression());
 
       // Set and Get
       Expression expression = number(Expression.get("undefined"));
@@ -1420,6 +1493,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-translate");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((Float[]) layer.getTextTranslate().getValue());
 
       // Set and Get
       layer.setProperties(textTranslate(new Float[] {0f, 0f}));
@@ -1434,6 +1508,7 @@ public class SymbolLayerTest extends BaseActivityTest {
     Timber.i("text-translate-anchor");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((String) layer.getTextTranslateAnchor().getValue());
 
       // Set and Get
       layer.setProperties(textTranslateAnchor(TEXT_TRANSLATE_ANCHOR_MAP));

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
@@ -162,6 +162,7 @@ public class <%- camelize(type) %>LayerTest extends BaseActivityTest {
     Timber.i("<%- property.name %>");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((<%- propertyType(property) %>) layer.get<%- camelize(property.name) %>().getValue());
 
       // Set and Get
       layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(<%- defaultValueJava(property) %>));
@@ -186,6 +187,7 @@ public class <%- camelize(type) %>LayerTest extends BaseActivityTest {
     Timber.i("<%- property.name %>-formatted");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull((<%- propertyType(property) %>) layer.get<%- camelize(property.name) %>().getValue());
 
       Formatted expected = new Formatted(new FormattedSection[] {
         new FormattedSection("", 1.0)
@@ -212,6 +214,7 @@ public class <%- camelize(type) %>LayerTest extends BaseActivityTest {
     Timber.i("<%- property.name %>-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.get<%- camelize(property.name) %>().getExpression());
 
       // Set and Get
       Expression expression = <%- defaultExpressionJava(property) %>(Expression.get("undefined"));
@@ -232,6 +235,7 @@ public class <%- camelize(type) %>LayerTest extends BaseActivityTest {
     Timber.i("<%- property.name %>-formatted-expression");
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(layer);
+      assertNull(layer.get<%- camelize(property.name) %>().getExpression());
 
       // Set and Get
       Expression expression = <%- defaultExpressionJava(property) %>(Expression.get("undefined"));


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/13284.