### PR TITLE
Add performance test setup

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -77,6 +77,7 @@ dependencies {
     androidTestImplementation dependenciesList.testEspressoCore
     androidTestImplementation dependenciesList.testEspressoIntents
     androidTestImplementation dependenciesList.testEspressoContrib
+    androidTestImplementation dependenciesList.testUiAutomator
 }
 
 apply from: "${rootDir}/gradle/gradle-make.gradle"

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:tools="http://schemas.android.com/tools"
+          package="com.mapbox.mapboxsdk">
+    <uses-sdk tools:overrideLibrary="android.support.test.uiautomator.v18"/>
+</manifest>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/perf/AnimationTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/perf/AnimationTest.java
@@ -1,0 +1,35 @@
+package com.mapbox.mapboxsdk.perf;
+
+import android.Manifest;
+import android.support.test.rule.GrantPermissionRule;
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke;
+
+public class AnimationTest extends BasePerfTest {
+
+  private static final int ANIMATION_DURATION = 5000;
+
+  @Rule
+  public GrantPermissionRule permissionRule =
+    GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+  @Test
+  public void testAnimation() {
+    validateTestSetup();
+    invoke(mapboxMap, (uiController, mapboxMap) -> {
+      mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(
+        new LatLng(60.168577, 24.938001), 12), ANIMATION_DURATION);
+      uiController.loopMainThreadForAtLeast(ANIMATION_DURATION);
+    });
+  }
+
+  @Override
+  protected Class getActivityClass() {
+    return EspressoTestActivity.class;
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/perf/BasePerfTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/perf/BasePerfTest.java
@@ -1,0 +1,24 @@
+package com.mapbox.mapboxsdk.perf;
+
+import com.mapbox.mapboxsdk.rules.*;
+import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
+import org.junit.Rule;
+
+public abstract class BasePerfTest extends BaseActivityTest {
+
+  @Rule
+  public TraceRule traceRule = new TraceRule();
+
+  @Rule
+  public BatteryStatsDumpsysRule batteryRule = new BatteryStatsDumpsysRule();
+
+  @Rule
+  public GraphicsDumpsysRule graphicsRule = new GraphicsDumpsysRule();
+
+  @Rule
+  public CpuInfoDumpsysRule cpuInfoRule = new CpuInfoDumpsysRule();
+
+  @Rule
+  public MemoryInfoDumpsysRule memoryInfoRule = new MemoryInfoDumpsysRule();
+
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/rules/AbstractDumpsysRule.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/rules/AbstractDumpsysRule.java
@@ -1,0 +1,72 @@
+package com.mapbox.mapboxsdk.rules;
+
+import android.os.Trace;
+import android.support.annotation.NonNull;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.uiautomator.UiDevice;
+
+import org.junit.rules.ExternalResource;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
+import static com.mapbox.mapboxsdk.utils.TestStorageUtils.buildFileNameFrom;
+import static com.mapbox.mapboxsdk.utils.TestStorageUtils.storeResponse;
+
+/**
+ * Abstract class to execute dumpsys commands, It will first reset the dumpsys data for the given service.
+ */
+abstract class AbstractDumpsysRule extends ExternalResource {
+
+  private Logger logger = Logger.getLogger(this.getClass().getName());
+  private String packageName;
+  private String fileName;
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    String testName = description.getMethodName();
+    packageName = InstrumentationRegistry.getTargetContext().getPackageName();
+    fileName = buildFileNameFrom(testName);
+    return super.apply(base, description);
+  }
+
+  @Override
+  public void before() {
+    try {
+      UiDevice
+        .getInstance(getInstrumentation())
+        .executeShellCommand(String.format("dumpsys %s %s --reset", dumpsysService(), packageName));
+    } catch (Exception exception) {
+      logger.log(Level.SEVERE, "Unable to reset dumpsys", exception);
+    }
+  }
+
+  @Override
+  public void after() {
+    try {
+      Trace.beginSection("Taking Dumpsys");
+      String response = UiDevice
+        .getInstance(getInstrumentation())
+        .executeShellCommand(String.format("dumpsys %s %s %s", dumpsysService(), packageName, extraOptions()));
+      storeResponse(response, dumpsysService(), fileName);
+      logger.log(Level.INFO, "Response is: " + response);
+    } catch (Exception exception) {
+      logger.log(Level.SEVERE, "Unable to take a dumpsys", exception);
+    } finally {
+      Trace.endSection();
+    }
+    logger.log(Level.INFO, "Dumpsys taken");
+  }
+
+  @NonNull
+  protected String extraOptions() {
+    return "";
+  }
+
+  protected abstract String dumpsysService();
+}
+
+

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/rules/BatteryStatsDumpsysRule.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/rules/BatteryStatsDumpsysRule.java
@@ -1,0 +1,11 @@
+package com.mapbox.mapboxsdk.rules;
+
+public class BatteryStatsDumpsysRule extends AbstractDumpsysRule {
+
+  private static final String BATTERY_STATS = "batterystats";
+
+  @Override
+  protected String dumpsysService() {
+    return BATTERY_STATS;
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/rules/CpuInfoDumpsysRule.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/rules/CpuInfoDumpsysRule.java
@@ -1,0 +1,9 @@
+package com.mapbox.mapboxsdk.rules;
+
+public class CpuInfoDumpsysRule extends AbstractDumpsysRule {
+
+  @Override
+  protected String dumpsysService() {
+    return "cpuinfo";
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/rules/GraphicsDumpsysRule.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/rules/GraphicsDumpsysRule.java
@@ -1,0 +1,25 @@
+package com.mapbox.mapboxsdk.rules;
+
+import android.os.Build;
+import android.support.annotation.NonNull;
+
+/**
+ * This rule executes a dumpsys graphics data dump after performing the test. If the API level is
+ * less than 23 then this rule will do nothing since this dumpsys command isn't supported.
+ */
+public class GraphicsDumpsysRule extends AbstractDumpsysRule {
+
+  private static final String GFX_INFO = "gfxinfo";
+  private static final String FRAME_STATS = "framestats";
+
+  @Override
+  protected String dumpsysService() {
+    return GFX_INFO;
+  }
+
+  @NonNull
+  @Override
+  protected String extraOptions() {
+    return Build.VERSION.SDK_INT >= 23 ? FRAME_STATS : "";
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/rules/MemoryInfoDumpsysRule.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/rules/MemoryInfoDumpsysRule.java
@@ -1,0 +1,9 @@
+package com.mapbox.mapboxsdk.rules;
+
+public class MemoryInfoDumpsysRule extends AbstractDumpsysRule {
+
+  @Override
+  protected String dumpsysService() {
+    return "procstats";
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/rules/TraceRule.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/rules/TraceRule.java
@@ -1,0 +1,36 @@
+package com.mapbox.mapboxsdk.rules;
+
+import android.os.Trace;
+
+import org.junit.rules.ExternalResource;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * This rule enables {@link Trace Tracing} for each test. The section name
+ * used for the Trace API is the name of the test being run.
+ * <p>
+ * To enable AndroidTracing on a test simply add this rule like so and it will be enabled/disabled
+ * when the platform support for Tracing exists (API Level 18 or higher).
+ * <p>
+ */
+public class TraceRule extends ExternalResource {
+
+  private String testName;
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    testName = description.getMethodName();
+    return super.apply(base, description);
+  }
+
+  @Override
+  public void before() {
+    Trace.beginSection(testName);
+  }
+
+  @Override
+  public void after() {
+    Trace.endSection();
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/action/MapboxMapAction.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/action/MapboxMapAction.java
@@ -7,6 +7,7 @@ import android.view.View;
 
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 
+import com.mapbox.mapboxsdk.testapp.R;
 import org.hamcrest.Matcher;
 
 import static android.support.test.espresso.Espresso.onView;
@@ -39,7 +40,7 @@ public class MapboxMapAction implements ViewAction {
   }
 
   public static void invoke(MapboxMap mapboxMap, OnInvokeActionListener invokeViewAction) {
-    onView(withId(android.R.id.content)).perform(new MapboxMapAction(invokeViewAction, mapboxMap));
+    onView(withId(R.id.mapView)).perform(new MapboxMapAction(invokeViewAction, mapboxMap));
   }
 
   public interface OnInvokeActionListener {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/utils/TestStorageUtils.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/utils/TestStorageUtils.java
@@ -1,0 +1,57 @@
+package com.mapbox.mapboxsdk.utils;
+
+import android.os.Environment;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import timber.log.Timber;
+
+public class TestStorageUtils {
+
+  private static final String PERF_FOLDER = "performance";
+  private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy_MM_dd_HH_mm_ss");
+  private static final String TXT_EXTENSION = ".txt";
+
+  public static String buildFileNameFrom(String testName) {
+    return testName + obtainCurrentTimeStamp() + TXT_EXTENSION;
+  }
+
+  public static void storeResponse(String response, String dumpsysService, String fileName) {
+    if (isExternalStorageWritable()) {
+      File pathToExternalStorage = Environment.getExternalStorageDirectory();
+      String storageAbsolutePath = pathToExternalStorage.getAbsolutePath();
+      String pathname = String.format("%s/%s/%s", storageAbsolutePath, PERF_FOLDER, dumpsysService);
+      File appDirectory = new File(pathname);
+      appDirectory.mkdirs();
+      File saveFilePath = new File(appDirectory, fileName);
+      write(response, saveFilePath);
+    }
+  }
+
+  private static String obtainCurrentTimeStamp() {
+    Date now = new Date();
+    return DATE_FORMAT.format(now);
+  }
+
+  private static boolean isExternalStorageWritable() {
+    String state = Environment.getExternalStorageState();
+    return Environment.MEDIA_MOUNTED.equals(state);
+  }
+
+  private static void write(String response, File saveFilePath) {
+    try {
+      FileOutputStream fos = new FileOutputStream(saveFilePath);
+      OutputStreamWriter outDataWriter = new OutputStreamWriter(fos);
+      outDataWriter.write(response);
+      outDataWriter.close();
+      fos.flush();
+      fos.close();
+    } catch (Exception exception) {
+      Timber.e(exception);
+    }
+  }
+}

--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -23,7 +23,8 @@ ext {
             okhttp          : '3.11.0',
             kotlin          : '1.2.51',
             licenses        : '0.8.41',
-            lint            : '26.1.3'
+            lint            : '26.1.3',
+            uiAutomator     : '2.1.3'
     ]
 
     dependenciesList = [
@@ -44,6 +45,7 @@ ext {
             testEspressoCore       : "com.android.support.test.espresso:espresso-core:${versions.espresso}",
             testEspressoIntents    : "com.android.support.test.espresso:espresso-intents:${versions.espresso}",
             testEspressoContrib    : "com.android.support.test.espresso:espresso-contrib:${versions.espresso}",
+            testUiAutomator        : "com.android.support.test.uiautomator:uiautomator-v18:${versions.uiAutomator}",
 
             supportAnnotations     : "com.android.support:support-annotations:${versions.supportLib}",
             supportAppcompatV7     : "com.android.support:appcompat-v7:${versions.supportLib}",


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/10917 (code-wise),
Refs https://github.com/mapbox/mapbox-navigation-android/pull/1491 (thank you for running with this @danesfeder). 

This PR adds an abstract performance test class and an animation example. When executing `AnimationTest#testAnimation()` it will execute all the rules defined in `BasePerfTest` and writes the results to the `sdcard/performance/..` folder. 

##### TODO:
 - [ ] add AWC-CLI integration to CI
 - [ ] execute AWS Device Farm run and hold execution on CI
 - [ ] collect data from AWS Device farm run
 - [ ] store data on ? 

![image](https://user-images.githubusercontent.com/2151639/48065798-f8962400-e1cb-11e8-991e-41c06d21bfe3.png)

![image](https://user-images.githubusercontent.com/2151639/48065825-09df3080-e1cc-11e8-9aca-de1b2d268f81.png)

cc @alexshalamov @tmpsantos @zugaldia @julianrex 