### PR TITLE
Android Expression javadoc code snippet tweaks

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
@@ -84,7 +84,7 @@ import java.util.Map;
  *       ))
  *     )
  *   )
- * )
+ * );
  * }
  * </pre>
  */
@@ -337,7 +337,7 @@ public class Expression {
    * FillLayer fillLayer = new FillLayer("layer-id", "source-id");
    * fillLayer.setProperties(
    *     fillColor(
-   *         rgb(255.0f, 255.0f, 255.0f, 1.0f)
+   *         rgba(255.0f, 255.0f, 255.0f, 1.0f)
    *     )
    * );
    * }
@@ -593,7 +593,7 @@ public class Expression {
    * {@code
    * FillLayer fillLayer = new FillLayer("layer-id", "source-id");
    * fillLayer.setFilter(
-   *     neq(get("keyToValue"), "value"))
+   *     neq(get("keyToValue"), "value")
    * );
    * }
    * </pre>
@@ -642,7 +642,7 @@ public class Expression {
    * {@code
    * FillLayer fillLayer = new FillLayer("layer-id", "source-id");
    * fillLayer.setFilter(
-   *     neq(get("keyToValue"), 2.0f))
+   *     neq(get("keyToValue"), 2.0f)
    * );
    * }
    * </pre>
@@ -860,7 +860,7 @@ public class Expression {
    * {@code
    * FillLayer fillLayer = new FillLayer("layer-id", "source-id");
    * fillLayer.setFilter(
-   *     lt(get("keyToValue"), "value"))
+   *     lt(get("keyToValue"), "value")
    * );
    * }
    * </pre>
@@ -1258,7 +1258,7 @@ public class Expression {
    *     iconSize(
    *         switchCase(
    *             get(KEY_TO_BOOLEAN), literal(3.0f),
-   *             get(KEY_TO_OTHER_BOOLEAN), literal(5.0f)
+   *             get(KEY_TO_OTHER_BOOLEAN), literal(5.0f),
    *             literal(1.0f) // default value
    *         )
    *     )
@@ -1292,7 +1292,7 @@ public class Expression {
    *             literal(1), rgba(255, 0, 0, 1.0f),
    *             literal(2), rgba(0, 0, 255.0f, 1.0f),
    *             rgba(0.0f, 255.0f, 0.0f, 1.0f)
-   *         );
+   *         )
    *     )
    * );
    * }
@@ -1324,7 +1324,7 @@ public class Expression {
    *             literal(1), rgba(255, 0, 0, 1.0f),
    *             literal(2), rgba(0, 0, 255.0f, 1.0f),
    *             rgba(0.0f, 255.0f, 0.0f, 1.0f)
-   *         );
+   *         )
    *     )
    * );
    * }
@@ -1351,7 +1351,7 @@ public class Expression {
    *         coalesce(
    *             get("keyToNullValue"),
    *             get("keyToNonNullValue")
-   *         );
+   *         )
    *     )
    * );
    * }
@@ -1377,7 +1377,7 @@ public class Expression {
    * {@code
    * SymbolLayer symbolLayer = new SymbolLayer("layer-id", "source-id");
    * symbolLayer.setProperties(
-   *     textField(get("key-to-value", properties())))
+   *     textField(get("key-to-value", properties()))
    * );
    * }
    * </pre>
@@ -1398,7 +1398,7 @@ public class Expression {
    * {@code
    * SymbolLayer symbolLayer = new SymbolLayer("layer-id", "source-id");
    * symbolLayer.setProperties(
-   *     textField(concat(get("key-to-value"), literal(" "), geometryType())
+   *     textField(concat(get("key-to-value"), literal(" "), geometryType()))
    * );
    * }
    * </pre>
@@ -1448,9 +1448,9 @@ public class Expression {
    *         literal(0.4), rgb(209, 229, 240),
    *         literal(0.6), rgb(253, 219, 199),
    *         literal(0.8), rgb(239, 138, 98),
-   *         literal(1), rgb(178, 24, 43)
+   *         literal(1), rgb(178, 24, 43))
    *     )
-   * )
+   * );
    * }
    * </pre>
    *
@@ -1476,7 +1476,7 @@ public class Expression {
    *         stop(0.5f, rgb(0, 255, 0)),
    *         stop(1f, rgb(255, 0, 0)))
    *     )
-   * )
+   * );
    * }
    * </pre>
    *
@@ -1683,7 +1683,7 @@ public class Expression {
    * {@code
    * FillLayer fillLayer = new FillLayer("layer-id", "source-id");
    * fillLayer.setFilter(
-   *     has("keyToValue", get("keyToObject))
+   *     has("keyToValue", get("keyToObject"))
    * );
    * }
    * </pre>
@@ -1728,7 +1728,7 @@ public class Expression {
    * {@code
    * CircleLayer circleLayer = new CircleLayer("layer-id", "source-id");
    * circleLayer.setProperties(
-   *     circleRadius(product(literal(10.0f), ln2())))
+   *     circleRadius(product(literal(10.0f), ln2()))
    * );
    * }
    * </pre>
@@ -1749,7 +1749,7 @@ public class Expression {
    * {@code
    * CircleLayer circleLayer = new CircleLayer("layer-id", "source-id");
    * circleLayer.setProperties(
-   *     circleRadius(product(literal(10.0f), pi())))
+   *     circleRadius(product(literal(10.0f), pi()))
    * );
    * }
    * </pre>
@@ -1770,7 +1770,7 @@ public class Expression {
    * {@code
    * CircleLayer circleLayer = new CircleLayer("layer-id", "source-id");
    * circleLayer.setProperties(
-   *     circleRadius(product(literal(10.0f), e())))
+   *     circleRadius(product(literal(10.0f), e()))
    * );
    * }
    * </pre>
@@ -1791,7 +1791,7 @@ public class Expression {
    * {@code
    * CircleLayer circleLayer = new CircleLayer("layer-id", "source-id");
    * circleLayer.setProperties(
-   *     circleRadius(sum(literal(10.0f), ln2(), pi())))
+   *     circleRadius(sum(literal(10.0f), ln2(), pi()))
    * );
    * }
    * </pre>
@@ -1813,7 +1813,7 @@ public class Expression {
    * {@code
    * CircleLayer circleLayer = new CircleLayer("layer-id", "source-id");
    * circleLayer.setProperties(
-   *     circleRadius(sum(10.0f, 5.0f, 3.0f)))
+   *     circleRadius(sum(10.0f, 5.0f, 3.0f))
    * );
    * }
    * </pre>
@@ -1839,7 +1839,7 @@ public class Expression {
    * {@code
    * CircleLayer circleLayer = new CircleLayer("layer-id", "source-id");
    * circleLayer.setProperties(
-   *     circleRadius(product(literal(10.0f), ln2())))
+   *     circleRadius(product(literal(10.0f), ln2()))
    * );
    * }
    * </pre>
@@ -1861,7 +1861,7 @@ public class Expression {
    * {@code
    * CircleLayer circleLayer = new CircleLayer("layer-id", "source-id");
    * circleLayer.setProperties(
-   *     circleRadius(product(10.0f, 2.0f)))
+   *     circleRadius(product(10.0f, 2.0f))
    * );
    * }
    * </pre>
@@ -1931,7 +1931,7 @@ public class Expression {
    * {@code
    * CircleLayer circleLayer = new CircleLayer("layer-id", "source-id");
    * circleLayer.setProperties(
-   *     circleRadius(subtract(literal(10.0f), pi())))
+   *     circleRadius(subtract(literal(10.0f), pi()))
    * );
    * }
    * </pre>
@@ -1954,7 +1954,7 @@ public class Expression {
    * {@code
    * CircleLayer circleLayer = new CircleLayer("layer-id", "source-id");
    * circleLayer.setProperties(
-   *     circleRadius(subtract(10.0f, 20.0f)))
+   *     circleRadius(subtract(10.0f, 20.0f))
    * );
    * }
    * </pre>
@@ -1977,7 +1977,7 @@ public class Expression {
    * {@code
    * CircleLayer circleLayer = new CircleLayer("layer-id", "source-id");
    * circleLayer.setProperties(
-   *     circleRadius(division(literal(10.0f), pi())))
+   *     circleRadius(division(literal(10.0f), pi()))
    * );
    * }
    * </pre>
@@ -2000,7 +2000,7 @@ public class Expression {
    * {@code
    * CircleLayer circleLayer = new CircleLayer("layer-id", "source-id");
    * circleLayer.setProperties(
-   *     circleRadius(division(10.0f, 20.0f)))
+   *     circleRadius(division(10.0f, 20.0f))
    * );
    * }
    * </pre>
@@ -2069,7 +2069,7 @@ public class Expression {
    * {@code
    * CircleLayer circleLayer = new CircleLayer("layer-id", "source-id");
    * circleLayer.setProperties(
-   *     circleRadius(pow(pi(), literal(2.0f))
+   *     circleRadius(pow(pi(), literal(2.0f)))
    * );
    * }
    * </pre>
@@ -2357,7 +2357,7 @@ public class Expression {
    * {@code
    * CircleLayer circleLayer = new CircleLayer("layer-id", "source-id");
    * circleLayer.setProperties(
-   *     circleRadius(cos(0)))
+   *     circleRadius(cos(0))
    * );
    * }
    * </pre>
@@ -2555,7 +2555,7 @@ public class Expression {
    * {@code
    * CircleLayer circleLayer = new CircleLayer("layer-id", "source-id");
    * circleLayer.setProperties(
-   *     circleRadius(min(pi(), literal(3.14f), literal(3.15f))
+   *     circleRadius(min(pi(), literal(3.14f), literal(3.15f)))
    * );
    * }
    * </pre>
@@ -2603,7 +2603,7 @@ public class Expression {
    * {@code
    * CircleLayer circleLayer = new CircleLayer("layer-id", "source-id");
    * circleLayer.setProperties(
-   *     circleRadius(max(pi(), 3.14f, 3.15f))
+   *     circleRadius(max(pi(), product(pi(), pi())))
    * );
    * }
    * </pre>
@@ -2834,7 +2834,7 @@ public class Expression {
    * CircleLayer circleLayer = new CircleLayer("layer-id", "source-id");
    * circleLayer.setProperties(
    * circleColor(switchCase(
-   * eq(literal("it"), resolvedLocale(collator(true, true, "it"))), literal(ColorUtils.colorToRgbaString(Color.GREEN)),
+   * eq(literal("it"), resolvedLocale(collator(true, true, Locale.ITALY))), literal(ColorUtils.colorToRgbaString(Color.GREEN)),
    * literal(ColorUtils.colorToRgbaString(Color.RED))))
    * );
    * }
@@ -2894,7 +2894,7 @@ public class Expression {
    *   textField(
    *     switchCase(
    *       isSupportedScript("ಗೌರವಾರ್ಥವಾಗಿ"), literal("ಗೌರವಾರ್ಥವಾಗಿ"),
-   *       literal("not-compatible")
+   *       literal("not-compatible"))
    *     )
    *   )
    * );
@@ -2923,7 +2923,7 @@ public class Expression {
    * {@code
    * SymbolLayer symbolLayer = new SymbolLayer("layer-id", "source-id");
    * symbolLayer.setProperties(
-   *     textField(upcase(get("key-to-string-value"))
+   *     textField(upcase(get("key-to-string-value")))
    * );
    * }
    * </pre>
@@ -2975,7 +2975,7 @@ public class Expression {
    * {@code
    * SymbolLayer symbolLayer = new SymbolLayer("layer-id", "source-id");
    * symbolLayer.setProperties(
-   *     textField(downcase(get("key-to-string-value"))
+   *     textField(downcase(get("key-to-string-value")))
    * );
    * }
    * </pre>
@@ -3001,7 +3001,7 @@ public class Expression {
    * {@code
    * SymbolLayer symbolLayer = new SymbolLayer("layer-id", "source-id");
    * symbolLayer.setProperties(
-   *     textField(upcase("key-to-string-value")
+   *     textField(upcase("key-to-string-value"))
    * );
    * }
    * </pre>
@@ -3023,7 +3023,7 @@ public class Expression {
    * {@code
    * SymbolLayer symbolLayer = new SymbolLayer("layer-id", "source-id");
    * symbolLayer.setProperties(
-   *     textField(concat(get("key-to-string-value"), literal("other string"))
+   *     textField(concat(get("key-to-string-value"), literal("other string")))
    * );
    * }
    * </pre>
@@ -3374,7 +3374,7 @@ public class Expression {
    * {@code
    * SymbolLayer symbolLayer = new SymbolLayer("layer-id", "source-id");
    * symbolLayer.setProperties(
-   *     textField(toString(get("key-to-number-value")))
+   *     textField(get("key-to-number-value"))
    * );
    * }
    * </pre>
@@ -3424,7 +3424,7 @@ public class Expression {
    * {@code
    * CircleLayer circleLayer = new CircleLayer("layer-id", "source-id");
    * circleLayer.setProperties(
-   *     circleRadius(toBool(get("key-to-value"));
+   *     circleRadius(toBool(get("key-to-value")))
    * );
    * }
    * </pre>
@@ -3506,14 +3506,14 @@ public class Expression {
    * </p>
    * <pre>
    * {@code
-   * FillLayer fillLayer = new fillLayer("layer-id", "source-id");
+   * FillLayer fillLayer = new FillLayer("layer-id", "source-id");
    * fillLayer.setProperties(
    *     fillColor(
    *       interpolate(
    *         exponential(0.5f), zoom(),
-   *         literal(1.0f), color(Color.RED),
-   *         literal(5.0f, color(Color.BLUE),
-   *         literal(10.0f, color(Color.GREEN)
+   *         stop(1.0f, color(Color.RED)),
+   *         stop(5.0f, color(Color.BLUE)),
+   *         stop(10.0f, color(Color.GREEN))
    *       )
    *     )
    * );
@@ -3543,7 +3543,7 @@ public class Expression {
    *     circleRadius(
    *         step(zoom(), literal(0.0f),
    *         stop(1.0f, 2.5f),
-   *         stop(10.0f, 5.0f)
+   *         stop(10.0f, 5.0f))
    *     )
    * );
    * }
@@ -3573,7 +3573,7 @@ public class Expression {
    *     circleRadius(
    *         step(zoom(), literal(0.0f),
    *         literal(1.0f), literal(2.5f),
-   *         literal(10.0f), literal(5.0f)
+   *         literal(10.0f), literal(5.0f))
    *     )
    * );
    * }
@@ -3605,7 +3605,7 @@ public class Expression {
    *     circleRadius(
    *         step(zoom(), literal(0.0f),
    *         literal(1.0f), literal(2.5f),
-   *         literal(10.0f), literal(5.0f)
+   *         literal(10.0f), literal(5.0f))
    *     )
    * );
    * }
@@ -3637,7 +3637,7 @@ public class Expression {
    *     circleRadius(
    *         step(zoom(), literal(0.0f),
    *         stop(1, 2.5f),
-   *         stop(10, 5.0f)
+   *         stop(10, 5.0f))
    *     )
    * );
    * }
@@ -3669,7 +3669,7 @@ public class Expression {
    *     circleRadius(
    *         step(zoom(), literal(0.0f),
    *         stop(1, 2.5f),
-   *         stop(10, 5.0f)
+   *         stop(10, 5.0f))
    *     )
    * );
    * }
@@ -3701,7 +3701,7 @@ public class Expression {
    *     circleRadius(
    *         step(1.0f, 0.0f,
    *         literal(1.0f), literal(2.5f),
-   *         literal(10.0f), literal(5.0f)
+   *         literal(10.0f), literal(5.0f))
    *     )
    * );
    * }
@@ -3733,7 +3733,7 @@ public class Expression {
    *     circleRadius(
    *         step(zoom(), 0.0f,
    *         literal(1.0f), literal(2.5f),
-   *         literal(10.0f), literal(5.0f)
+   *         literal(10.0f), literal(5.0f))
    *     )
    * );
    * }
@@ -3765,7 +3765,7 @@ public class Expression {
    *     circleRadius(
    *         step(zoom(), 0.0f,
    *         stop(1, 2.5f),
-   *         stop(10, 5.0f)
+   *         stop(10, 5.0f))
    *     )
    * );
    * }
@@ -3797,7 +3797,7 @@ public class Expression {
    *     circleRadius(
    *         step(zoom(), 0.0f,
    *         stop(1, 2.5f),
-   *         stop(10, 5.0f)
+   *         stop(10, 5.0f))
    *     )
    * );
    * }
@@ -3823,16 +3823,16 @@ public class Expression {
    * </p>
    * <pre>
    * {@code
-   * FillLayer fillLayer = new fillLayer("layer-id", "source-id");
+   * FillLayer fillLayer = new FillLayer("layer-id", "source-id");
    * fillLayer.setProperties(
-   *     fillColor(
-   *       interpolate(
-   *         exponential(0.5f), zoom(),
-   *         literal(1.0f), color(Color.RED),
-   *         literal(5.0f, color(Color.BLUE),
-   *         literal(10.0f, color(Color.GREEN)
+   *   fillColor(
+   *     interpolate(exponential(0.5f), zoom(),
+   *        stop(1.0f, color(Color.RED)),
+   *        stop(5.0f, color(Color.BLUE)),
+   *        stop(10.0f, color(Color.GREEN)
    *       )
    *     )
+   *   )
    * );
    * }
    * </pre>
@@ -3858,14 +3858,14 @@ public class Expression {
    * </p>
    * <pre>
    * {@code
-   * FillLayer fillLayer = new fillLayer("layer-id", "source-id");
+   * FillLayer fillLayer = new FillLayer("layer-id", "source-id");
    * fillLayer.setProperties(
    *     fillColor(
    *       interpolate(
    *         exponential(0.5f), zoom(),
-   *         literal(1.0f), color(Color.RED),
-   *         literal(5.0f, color(Color.BLUE),
-   *         literal(10.0f, color(Color.GREEN)
+   *         stop(1.0f, color(Color.RED)),
+   *         stop(5.0f, color(Color.BLUE)),
+   *         stop(10.0f, color(Color.GREEN))
    *       )
    *     )
    * );
@@ -3890,14 +3890,14 @@ public class Expression {
    * </p>
    * <pre>
    * {@code
-   * FillLayer fillLayer = new fillLayer("layer-id", "source-id");
+   * FillLayer fillLayer = new FillLayer("layer-id", "source-id");
    * fillLayer.setProperties(
    *     fillColor(
    *       interpolate(
    *         linear(), zoom(),
-   *         literal(1.0f), color(Color.RED),
-   *         literal(5.0f, color(Color.BLUE),
-   *         literal(10.0f, color(Color.GREEN)
+   *         stop(1.0f, color(Color.RED)),
+   *         stop(5.0f, color(Color.BLUE)),
+   *         stop(10.0f, color(Color.GREEN))
    *       )
    *     )
    * );
@@ -3921,14 +3921,14 @@ public class Expression {
    * </p>
    * <pre>
    * {@code
-   * FillLayer fillLayer = new fillLayer("layer-id", "source-id");
+   * FillLayer fillLayer = new FillLayer("layer-id", "source-id");
    * fillLayer.setProperties(
    *     fillColor(
    *       interpolate(
    *         exponential(0.5f), zoom(),
-   *         literal(1.0f), color(Color.RED),
-   *         literal(5.0f, color(Color.BLUE),
-   *         literal(10.0f, color(Color.GREEN)
+   *         stop(1.0f, color(Color.RED)),
+   *         stop(5.0f, color(Color.BLUE)),
+   *         stop(10.0f, color(Color.GREEN))
    *       )
    *     )
    * );
@@ -3953,14 +3953,14 @@ public class Expression {
    * </p>
    * <pre>
    * {@code
-   * FillLayer fillLayer = new fillLayer("layer-id", "source-id");
+   * FillLayer fillLayer = new FillLayer("layer-id", "source-id");
    * fillLayer.setProperties(
    *     fillColor(
    *       interpolate(
-   *         exponential(get("keyToValue"), zoom(),
-   *         literal(1.0f), color(Color.RED),
-   *         literal(5.0f, color(Color.BLUE),
-   *         literal(10.0f, color(Color.GREEN)
+   *         exponential(get("keyToValue")), zoom(),
+   *         stop(1.0f, color(Color.RED)),
+   *         stop(5.0f, color(Color.BLUE)),
+   *         stop(10.0f, color(Color.GREEN))
    *       )
    *     )
    * );
@@ -3982,14 +3982,14 @@ public class Expression {
    * </p>
    * <pre>
    * {@code
-   * FillLayer fillLayer = new fillLayer("layer-id", "source-id");
+   * FillLayer fillLayer = new FillLayer("layer-id", "source-id");
    * fillLayer.setProperties(
    *     fillColor(
    *       interpolate(
    *         cubicBezier(0.42f, 0.0f, 1.0f, 1.0f), zoom(),
-   *         literal(1.0f), color(Color.RED),
-   *         literal(5.0f, color(Color.BLUE),
-   *         literal(10.0f, color(Color.GREEN)
+   *         stop(1.0f, color(Color.RED)),
+   *         stop(5.0f, color(Color.BLUE)),
+   *         stop(10.0f, color(Color.GREEN))
    *       )
    *     )
    * );
@@ -4015,14 +4015,14 @@ public class Expression {
    * </p>
    * <pre>
    * {@code
-   * FillLayer fillLayer = new fillLayer("layer-id", "source-id");
+   * FillLayer fillLayer = new FillLayer("layer-id", "source-id");
    * fillLayer.setProperties(
    *     fillColor(
    *       interpolate(
    *         cubicBezier(0.42f, 0.0f, 1.0f, 1.0f), zoom(),
-   *         literal(1.0f), color(Color.RED),
-   *         literal(5.0f, color(Color.BLUE),
-   *         literal(10.0f, color(Color.GREEN)
+   *         stop(1.0f, color(Color.RED)),
+   *         stop(5.0f, color(Color.BLUE)),
+   *         stop(10.0f, color(Color.GREEN))
    *       )
    *     )
    * );


### PR DESCRIPTION
Resolves #12830 by updating the API ref docs' code snippet examples. I manually copy/pasted each Expression method's code snippet into an activity to make sure that there were no errors, missing parenthesis, or conflicts. There were 158 methods to check. This was....not fun. Anyways, should be good to go here @mapbox/maps-android 