### PR TITLE
[iOS] Move creation of attributed string to global queue

### DIFF
--- a/platform/darwin/src/MGLAttributionInfo.mm
+++ b/platform/darwin/src/MGLAttributionInfo.mm
@@ -65,10 +65,14 @@
     NSData *htmlData = [styledHTML dataUsingEncoding:NSUTF8StringEncoding];
 
 #if TARGET_OS_IPHONE
-    NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithData:htmlData
-                                                                                          options:options
-                                                                               documentAttributes:nil
-                                                                                            error:NULL];
+    __block NSMutableAttributedString *attributedString;
+    
+    dispatch_sync(dispatch_get_main_queue() , ^{
+        attributedString = [[NSMutableAttributedString alloc] initWithData:htmlData
+                                                                   options:options
+                                                        documentAttributes:nil
+                                                                     error:NULL];
+    });
 #else
     NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithHTML:htmlData
                                                                                           options:options

--- a/platform/darwin/src/MGLAttributionInfo.mm
+++ b/platform/darwin/src/MGLAttributionInfo.mm
@@ -65,9 +65,11 @@
     NSData *htmlData = [styledHTML dataUsingEncoding:NSUTF8StringEncoding];
 
 #if TARGET_OS_IPHONE
+
     __block NSMutableAttributedString *attributedString;
     
     dispatch_sync(dispatch_get_main_queue() , ^{
+        // This initializer should be called from a global or main queue. https://developer.apple.com/documentation/foundation/nsattributedstring/1524613-initwithdata
         attributedString = [[NSMutableAttributedString alloc] initWithData:htmlData
                                                                    options:options
                                                         documentAttributes:nil


### PR DESCRIPTION
This PR addresses a bad access exception with `MGLMapSnapshotter` on iOS 8. Per [Apple docs](https://developer.apple.com/documentation/foundation/nsattributedstring/1524613-initwithdata):

> The HTML importer should not be called from a background thread (that is, the options dictionary includes NSDocumentTypeDocumentAttribute with a value of NSHTMLTextDocumentType). It will try to synchronize with the main thread, fail, and time out. Calling it from the main thread works (but can still time out if the HTML contains references to external resources, which should be avoided at all costs). The HTML import mechanism is meant for implementing something like markdown (that is, text styles, colors, and so on), not for general HTML import.

I've only seen this issue on iOS 8 so far, but will open a PR discuss cherry-picking to master.

cc @ChrisLoer 