### PR TITLE
[core] Change toLowerHex to produce lower hex sequences

### DIFF
--- a/src/mbgl/util/url.cpp
+++ b/src/mbgl/util/url.cpp
@@ -24,7 +24,7 @@ inline bool isSchemeCharacter(char c) {
 
 inline char toLowerHex(char c) {
     c &= 0x0F;
-    return '0' + c + (c > 9 ? 7 : 0);
+    return '0' + c + (c > 9 ? 39 : 0);
 }
 
 } // namespace

--- a/test/util/url.test.cpp
+++ b/test/util/url.test.cpp
@@ -7,7 +7,7 @@
 using namespace mbgl::util;
 
 TEST(URL, percentEncode) {
-    EXPECT_EQ("%22%C3%A9nc%C3%B8%C3%B0ing%22", percentEncode("\"éncøðing\""));
+    EXPECT_EQ("%22%c3%a9nc%c3%b8%c3%b0ing%22", percentEncode("\"éncøðing\""));
 }
 
 TEST(URL, percentDecode) {


### PR DESCRIPTION
Noticed that toLowerHex does not produce low case hex sequences, therefore, some of the benchmark tests are failing, as the [cache database](https://github.com/mapbox/mapbox-gl-native/blob/master/benchmark/fixtures/api/cache.db) contains lower case sequences.