### PR TITLE
[ios] Address bad access exception in `MGLAttributionInfo`

### DIFF
--- a/platform/darwin/src/MGLAttributionInfo.mm
+++ b/platform/darwin/src/MGLAttributionInfo.mm
@@ -65,10 +65,15 @@
     NSData *htmlData = [styledHTML dataUsingEncoding:NSUTF8StringEncoding];
 
 #if TARGET_OS_IPHONE
-    NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithData:htmlData
-                                                                                          options:options
-                                                                               documentAttributes:nil
-                                                                                            error:NULL];
+    __block NSMutableAttributedString *attributedString;
+    
+    dispatch_sync(dispatch_get_main_queue() , ^{
+        // This initializer should be called from a global or main queue. https://developer.apple.com/documentation/foundation/nsattributedstring/1524613-initwithdata
+        attributedString = [[NSMutableAttributedString alloc] initWithData:htmlData
+                                                                   options:options
+                                                        documentAttributes:nil
+                                                                     error:NULL];
+    });
 #else
     NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithHTML:htmlData
                                                                                           options:options

--- a/platform/darwin/src/MGLAttributionInfo.mm
+++ b/platform/darwin/src/MGLAttributionInfo.mm
@@ -66,14 +66,19 @@
 
 #if TARGET_OS_IPHONE
     __block NSMutableAttributedString *attributedString;
+    dispatch_block_t initialization = ^{
+            // This initializer should be called from a global or main queue. https://developer.apple.com/documentation/foundation/nsattributedstring/1524613-initwithdata
+            attributedString = [[NSMutableAttributedString alloc] initWithData:htmlData
+                                                                       options:options
+                                                            documentAttributes:nil
+                                                                         error:NULL];
+    };
     
-    dispatch_sync(dispatch_get_main_queue() , ^{
-        // This initializer should be called from a global or main queue. https://developer.apple.com/documentation/foundation/nsattributedstring/1524613-initwithdata
-        attributedString = [[NSMutableAttributedString alloc] initWithData:htmlData
-                                                                   options:options
-                                                        documentAttributes:nil
-                                                                     error:NULL];
-    });
+    if (![[NSThread currentThread] isMainThread]) {
+        dispatch_sync(dispatch_get_main_queue(), initialization);
+    } else {
+        initialization();
+    }
 #else
     NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithHTML:htmlData
                                                                                           options:options


### PR DESCRIPTION
Continues discussion from https://github.com/mapbox/mapbox-gl-native/pull/13298 in order to add the fix to `master`. 

- [ ] Pregenerate the `NSMutableAttributionString`
- [x] Measure performance (https://github.com/mapbox/mapbox-gl-native/pull/13298#issuecomment-436406944)

This PR addresses a bad access exception with `MGLMapSnapshotter` on iOS 8. Per [Apple docs](https://developer.apple.com/documentation/foundation/nsattributedstring/1524613-initwithdata):

> The HTML importer should not be called from a background thread (that is, the options dictionary includes NSDocumentTypeDocumentAttribute with a value of NSHTMLTextDocumentType). It will try to synchronize with the main thread, fail, and time out. Calling it from the main thread works (but can still time out if the HTML contains references to external resources, which should be avoided at all costs). The HTML import mechanism is meant for implementing something like markdown (that is, text styles, colors, and so on), not for general HTML import.

cc @julianrex @ChrisLoer 