### PR TITLE
Rename ambient cache prewarming method

### DIFF
--- a/platform/darwin/src/MGLOfflineStorage.h
+++ b/platform/darwin/src/MGLOfflineStorage.h
@@ -340,25 +340,28 @@ MGL_EXPORT
 @property (nonatomic, readonly) unsigned long long countOfBytesCompleted;
 
 /*
- * Insert the provided resource into the ambient cache
- * This method mimics the caching that would take place if the equivalent
- * resource were requested in the process of map rendering.
- * Use this method to pre-warm the cache with resources you know
- * will be requested.
- *
- * This call is asynchronous: the data may not be immediately available
- * for in-progress requests, although subsequent requests should have
- * access to the cached data.
- *
- * @param url The URL of the resource to insert
- * @param data Response data to store for this resource. Data is expected to be uncompressed; internally, the cache will compress data as necessary.
- * @param modified Optional "modified" response header
- * @param expires Optional "expires" response header
- * @param etag Optional "entity tag" response header
- * @param mustRevalidate Indicates whether response can be used after it's stale
+ Inserts the provided resource into the ambient cache.
+ 
+ This method mimics the caching that would take place if the equivalent resource
+ were requested in the process of map rendering. Use this method to pre-warm the
+ cache with resources you know will be requested.
+ 
+ This method is asynchronous; the data may not be immediately available for
+ in-progress requests, though subsequent requests should have access to the
+ cached data.
+ 
+ @param data Response data to store for this resource. The data is expected to
+    be uncompressed; internally, the cache will compress data as necessary.
+ @param url The URL at which the data can normally be found.
+ @param modified The date the resource was last modified.
+ @param expires The date after which the resource is no longer valid.
+ @param eTag An HTTP entity tag.
+ @param mustRevalidate A Boolean value indicating whether the data is still
+    usable past the expiration date.
  */
--(void)putResourceWithUrl:(NSURL *)url data:(NSData *)data modified:(NSDate * _Nullable)modified expires:(NSDate * _Nullable)expires etag:(NSString * _Nullable)etag mustRevalidate:(BOOL)mustRevalidate;
+- (void)preloadData:(NSData *)data forURL:(NSURL *)url modificationDate:(nullable NSDate *)modified expirationDate:(nullable NSDate *)expires eTag:(nullable NSString *)eTag mustRevalidate:(BOOL)mustRevalidate NS_SWIFT_NAME(preload(_:for:modifiedOn:expiresOn:eTag:mustRevalidate:));
 
+- (void)putResourceWithUrl:(NSURL *)url data:(NSData *)data modified:(nullable NSDate *)modified expires:(nullable NSDate *)expires etag:(nullable NSString *)etag mustRevalidate:(BOOL)mustRevalidate __attribute__((deprecated("Use -preloadData:forURL:modificationDate:expirationDate:eTag:mustRevalidate:.")));
 
 @end
 

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -490,14 +490,14 @@ const MGLExceptionName MGLUnsupportedRegionTypeException = @"MGLUnsupportedRegio
     return attributes.fileSize;
 }
 
--(void)putResourceWithUrl:(NSURL *)url data:(NSData *)data modified:(NSDate * _Nullable)modified expires:(NSDate * _Nullable)expires etag:(NSString * _Nullable)etag mustRevalidate:(BOOL)mustRevalidate {
-    mbgl::Resource resource(mbgl::Resource::Kind::Unknown, [[url absoluteString] UTF8String]);
+- (void)preloadData:(NSData *)data forURL:(NSURL *)url modificationDate:(nullable NSDate *)modified expirationDate:(nullable NSDate *)expires eTag:(nullable NSString *)eTag mustRevalidate:(BOOL)mustRevalidate {
+    mbgl::Resource resource(mbgl::Resource::Kind::Unknown, url.absoluteString.UTF8String);
     mbgl::Response response;
     response.data = std::make_shared<std::string>(static_cast<const char*>(data.bytes), data.length);
     response.mustRevalidate = mustRevalidate;
     
-    if (etag) {
-        response.etag = std::string([etag UTF8String]);
+    if (eTag) {
+        response.etag = std::string(eTag.UTF8String);
     }
     
     if (modified) {
@@ -511,5 +511,8 @@ const MGLExceptionName MGLUnsupportedRegionTypeException = @"MGLUnsupportedRegio
     _mbglFileSource->put(resource, response);
 }
 
+- (void)putResourceWithUrl:(NSURL *)url data:(NSData *)data modified:(nullable NSDate *)modified expires:(nullable NSDate *)expires etag:(nullable NSString *)etag mustRevalidate:(BOOL)mustRevalidate {
+    [self preloadData:data forURL:url modificationDate:modified expirationDate:expires eTag:etag mustRevalidate:mustRevalidate];
+}
 
 @end

--- a/platform/darwin/test/MGLOfflineStorageTests.mm
+++ b/platform/darwin/test/MGLOfflineStorageTests.mm
@@ -395,12 +395,13 @@
     
 }
 
--(void) testPutResourceForURL {
+- (void)testPutResourceForURL {
     NSURL *styleURL = [NSURL URLWithString:@"https://api.mapbox.com/some/thing"];
     
     MGLOfflineStorage *os = [MGLOfflineStorage sharedOfflineStorage];
     std::string testData("test data");
-    [os putResourceWithUrl:styleURL data:[NSData dataWithBytes:testData.c_str() length:testData.length()] modified:nil expires:nil etag:nil mustRevalidate:NO];
+    NSData *data = [NSData dataWithBytes:testData.c_str() length:testData.length()];
+    [os preloadData:data forURL:styleURL modificationDate:nil expirationDate:nil eTag:nil mustRevalidate:NO];
     
     auto fs = os.mbglFileSource;
     const mbgl::Resource resource { mbgl::Resource::Unknown, "https://api.mapbox.com/some/thing" };
@@ -420,14 +421,15 @@
     CFRunLoopRun();
 }
 
--(void) testPutResourceForURLWithTimestamps {
+- (void)testPutResourceForURLWithTimestamps {
     NSURL *styleURL = [NSURL URLWithString:@"https://api.mapbox.com/some/thing"];
     
     MGLOfflineStorage *os = [MGLOfflineStorage sharedOfflineStorage];
     std::string testData("test data");
-    NSDate* now = [NSDate date];
-    NSDate* future = [now dateByAddingTimeInterval:600];
-    [os putResourceWithUrl:styleURL data:[NSData dataWithBytes:testData.c_str() length:testData.length()] modified:now expires:future etag:@"some etag" mustRevalidate:YES];
+    NSDate *now = [NSDate date];
+    NSDate *future = [now dateByAddingTimeInterval:600];
+    NSData *data = [NSData dataWithBytes:testData.c_str() length:testData.length()];
+    [os preloadData:data forURL:styleURL modificationDate:now expirationDate:future eTag:@"some etag" mustRevalidate:YES];
     
     auto fs = os.mbglFileSource;
     const mbgl::Resource resource { mbgl::Resource::Unknown, "https://api.mapbox.com/some/thing" };

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## master
+
+* Renamed `-[MGLOfflineStorage putResourceWithUrl:data:modified:expires:etag:mustRevalidate:]` to `-[MGLOfflineStorage preloadData:forURL:modificationDate:expirationDate:eTag:mustRevalidate:]`. ([#13318](https://github.com/mapbox/mapbox-gl-native/pull/13318))
+
 ## 4.6.0 - November 7, 2018
 
 ### Styles and rendering

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+* Renamed `-[MGLOfflineStorage putResourceWithUrl:data:modified:expires:etag:mustRevalidate:]` to `-[MGLOfflineStorage preloadData:forURL:modificationDate:expirationDate:eTag:mustRevalidate:]`. ([#13318](https://github.com/mapbox/mapbox-gl-native/pull/13318))
+
+## master
+
 ### Styles and rendering
 
 * Added an `MGLSymbolStyleLayer.symbolZOrder` property for forcing point features in a symbol layer to be layered in the same order that they are specified in the layer’s associated source. ([#12783](https://github.com/mapbox/mapbox-gl-native/pull/12783))


### PR DESCRIPTION
Renamed `-[MGLOfflineStorage putResourceWithUrl:data:modified:expires:etag:mustRevalidate:]` to `-[MGLOfflineStorage preloadData:forURL:modificationDate:expirationDate:eTag:mustRevalidate:]` to conform to [Cocoa naming guidelines](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingMethods.html) in Objective-C and [Swift API design guidelines](https://swift.org/documentation/api-design-guidelines/) in Swift.

/ref #13119
/cc @fabian-guerra @ChrisLoer