### PR TITLE
[android] - update telemetry to 3.5.3, update changelog

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Mapbox welcomes participation and contributions from everyone.  If you'd like to do so please see the [`Contributing Guide`](https://github.com/mapbox/mapbox-gl-native/blob/master/CONTRIBUTING.md) first to get started.
 
+## 6.6.6 - November 8, 2018
+ - Telemetry v3.5.3 [#13326](https://github.com/mapbox/mapbox-gl-native/pull/13326)
+
 ## 6.7.0 - November 7, 2018
  - Handle null getMapAsync invocations, deliver onMapReady only once [#13301](https://github.com/mapbox/mapbox-gl-native/pull/13301)
  - Verify if `text-field` is not null before performing compatibility operations [#13294](https://github.com/mapbox/mapbox-gl-native/pull/13294)

--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
     versions = [
             mapboxServices  : '4.0.0',
-            mapboxTelemetry : '3.5.2',
+            mapboxTelemetry : '3.5.3',
             mapboxGestures  : '0.3.0',
             supportLib      : '27.1.1',
             constraintLayout: '1.1.2',


### PR DESCRIPTION
This PR updates telemetry to 3.5.3 and updates the changelog to match the v6.6.6 release