### PR TITLE
[android] - update telemetry to 3.5.4, update changelog

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -9,6 +9,9 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
  - Reintroduce OnMapChange invocation [#13289](https://github.com/mapbox/mapbox-gl-native/pull/13289)
  - Null-check nativeMapView in case it's destroyed [#13281](https://github.com/mapbox/mapbox-gl-native/pull/13281)
 
+## 6.6.6 - November 8, 2018
+ - Telemetry v3.5.4 [#13330](https://github.com/mapbox/mapbox-gl-native/pull/13330)
+
 ## 6.6.5 - November 2, 2018
  - Telemetry v3.5.2 [#13258](https://github.com/mapbox/mapbox-gl-native/pull/13258)
 

--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
     versions = [
             mapboxServices  : '4.0.0',
-            mapboxTelemetry : '3.5.2',
+            mapboxTelemetry : '3.5.4',
             mapboxGestures  : '0.3.0',
             supportLib      : '27.1.1',
             constraintLayout: '1.1.2',


### PR DESCRIPTION
This PR updates telemetry to 3.5.4 and updates the changelog to match the v6.6.6 release

