### PR TITLE
Use updated docker images

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -367,18 +367,28 @@ commands:
         command: make test-node
 
   run-node-linux-tests:
+    parameters:
+      node_version:
+        type: string
+        default: v8
     steps:
     - run:
         name: Run node tests
         command: |
+          . "$NVM_DIR/nvm.sh" && nvm use << parameters.node_version >>
           xvfb-run --server-args="-screen 0 1024x768x24" \
             logbt -- apitrace trace --api=egl -v make test-node
 
   run-node-linux-tests-recycle-map:
+    parameters:
+      node_version:
+        type: string
+        default: v8
     steps:
     - run:
         name: Run node tests (recycling the map object)
         command: |
+          . "$NVM_DIR/nvm.sh" && nvm use << parameters.node_version >>
           xvfb-run --server-args="-screen 0 1024x768x24" \
             logbt -- apitrace trace --api=egl -v make test-node-recycle-map
 
@@ -440,7 +450,7 @@ commands:
 jobs:
   nitpick:
     docker:
-      - image: mbgl/7d2403f42e:linux-clang-4
+      - image: mbgl/linux-clang-4:d121f629f7
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 4
@@ -475,7 +485,7 @@ jobs:
 # ------------------------------------------------------------------------------
   clang-tidy:
     docker:
-      - image: mbgl/7d2403f42e:linux-clang-3.9
+      - image: mbgl/linux-clang-3.9:2077f965ed
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 4
@@ -502,7 +512,7 @@ jobs:
         type: string
         default: "c++_static"
     docker:
-      - image: mbgl/feb0443038:android-ndk-r17
+      - image: mbgl/android-ndk-r17c:dd161efed6
     resource_class: large
     working_directory: /src
     environment:
@@ -564,7 +574,7 @@ jobs:
 # ------------------------------------------------------------------------------
   android-release:
     docker:
-      - image: mbgl/feb0443038:android-ndk-r17
+      - image: mbgl/android-ndk-r17c:dd161efed6
     resource_class: large
     working_directory: /src
     environment:
@@ -629,7 +639,7 @@ jobs:
 # ------------------------------------------------------------------------------
   node-clang39-release:
     docker:
-      - image: mbgl/7d2403f42e:linux-clang-3.9
+      - image: mbgl/linux-clang-3.9:2077f965ed
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 4
@@ -648,7 +658,7 @@ jobs:
 # ------------------------------------------------------------------------------
   node-gcc6-debug:
     docker:
-      - image: mbgl/7d2403f42e:linux-gcc-6
+      - image: mbgl/linux-gcc-6:d461f83b52
     resource_class: large
     working_directory: /src
     environment:
@@ -686,7 +696,7 @@ jobs:
 # ------------------------------------------------------------------------------
   linux-clang-38-libcxx-debug:
     docker:
-      - image: mbgl/7d2403f42e:linux-clang-3.8-libcxx
+      - image: mbgl/linux-clang-3.8-libcxx:d6800bdbb4
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 4
@@ -702,7 +712,7 @@ jobs:
 # ------------------------------------------------------------------------------
   linux-clang4-sanitize-address:
     docker:
-      - image: mbgl/7d2403f42e:linux-clang-4
+      - image: mbgl/linux-clang-4:d121f629f7
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 4
@@ -728,7 +738,7 @@ jobs:
 # ------------------------------------------------------------------------------
   linux-clang4-sanitize-undefined:
     docker:
-      - image: mbgl/7d2403f42e:linux-clang-4
+      - image: mbgl/linux-clang-4:d121f629f7
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 4
@@ -754,7 +764,7 @@ jobs:
 # ------------------------------------------------------------------------------
   linux-clang4-sanitize-thread:
     docker:
-      - image: mbgl/7d2403f42e:linux-clang-4
+      - image: mbgl/linux-clang-4:d121f629f7
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 4
@@ -780,7 +790,7 @@ jobs:
 # ------------------------------------------------------------------------------
   linux-gcc49-debug:
     docker:
-      - image: mbgl/7d2403f42e:linux-gcc-4.9
+      - image: mbgl/linux-gcc-4.9:e3818a77c1
     resource_class: large
     working_directory: /src
     environment:
@@ -801,7 +811,7 @@ jobs:
 # ------------------------------------------------------------------------------
   linux-gcc5-debug-coverage:
     docker:
-      - image: mbgl/7d2403f42e:linux-gcc-5
+      - image: mbgl/linux-gcc-5:54f59e3ac5
     resource_class: large
     working_directory: /src
     environment:
@@ -1006,7 +1016,7 @@ jobs:
 # ------------------------------------------------------------------------------
   qt5-linux-gcc5-release:
     docker:
-      - image: mbgl/7d2403f42e:linux-gcc-5-qt-5.9
+      - image: mbgl/linux-gcc-5-qt-5.9:5132cfd29f
     resource_class: large
     working_directory: /src
     environment:


### PR DESCRIPTION
Migrate to new Docker images built in https://github.com/mapbox/mbgl-ci-images/pull/31

This is a preparatory PR for moving some checks to newer compilers and testing multiple node versions.