### PR TITLE
[ios] Don't pause camera animations if zoom/pitch/rotate/scroll are disabled

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed sporadic crash when using `MGLMapSnapshotter`. ([#13300](https://github.com/mapbox/mapbox-gl-native/pull/13300))
 * Added `MGLLoggingConfiguration` and `MGLLoggingBlockHandler` that handle error and fault events produced by the SDK. ([#13235](https://github.com/mapbox/mapbox-gl-native/pull/13235))
 * This SDK’s dynamic framework now has a bundle identifier of `com.mapbox.Mapbox`. ([#12857](https://github.com/mapbox/mapbox-gl-native/pull/12857))
+* Modified the behavior of the map view so that programmatic camera transitions can no longer be interrupted by user interaction when `MGLMapView.zoomEnabled`, `MGLMapView.rotateEnabled`, `MGLMapView.scrollEnabled`, and `MGLMapView.pitchEnabled` are set to false. ([#13362](https://github.com/mapbox/mapbox-gl-native/pull/13362))
 
 ## 4.6.0 - November 7, 2018
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1380,11 +1380,17 @@ public:
 
 - (void)touchesBegan:(__unused NSSet<UITouch *> *)touches withEvent:(__unused UIEvent *)event
 {
+    if (!self.zoomEnabled && !self.pitchEnabled && !self.rotateEnabled && !self.scrollEnabled)
+    {
+        return;
+    };
+    
     _mbglMap->setGestureInProgress(false);
     if (self.userTrackingState == MGLUserTrackingStateBegan)
     {
         [self setUserTrackingMode:MGLUserTrackingModeNone animated:NO];
     }
+    
     [self cancelTransitions];
 }
 


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/11415.

Currently when a camera animation is triggered programmatically, if the `zoomEnabled` / `pitchEnabled` / `scrollEnabled` / `rotateEnabled` are all set to `NO`/`FALSE`, user interaction causes the transition to stop. This PR reverses that decision, so that a programmatic camera transition will continue if the above four properties are set to `NO`/`FALSE`