### PR TITLE
Adjust coverage tracking threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,9 @@
 ignore:
   - "test/"
   - "vendor/"
-        
+
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%


### PR DESCRIPTION
This changes the default threshold to 1% (from `0%`) for when to fail a build due to negative coverage changes.

The reasoning here is that some tests are unreliable (more on this at #13324) and are causing %0.1 fluctuations in coverage for PRs which should not impact coverage (like #13357 and #13360). This change is a stopgap measure to avoid developer pain, until the cause of the unreliability can be understood and mitigated.

/cc @jmkiley 

Docs for adjusting thresholds at https://docs.codecov.io/docs/commit-status