### PR TITLE
Enable CODEOWNERS for iOS/macOS/Darwin directories.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 # iOS
-/platform/ios/ @maps-ios-reviewers
+/platform/ios/ @mapbox/maps-ios-reviewers
 
 # macOS
-/platform/macos/ @1ec5 @maps-ios-reviewers
+/platform/macos/ @1ec5 @mapbox/maps-ios-reviewers
 
 # Darwin
-/platform/darwin/ @maps-ios-reviewers
+/platform/darwin/ @mapbox/maps-ios-reviewers
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# iOS
+/platform/ios/ @maps-ios-reviewers
+
+# macOS
+/platform/macos/ @1ec5 @maps-ios-reviewers
+
+# Darwin
+/platform/darwin/ @maps-ios-reviewers
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,5 @@
 /platform/macos/ @1ec5 @mapbox/maps-ios-reviewers
 
 # Darwin
-/platform/darwin/ @mapbox/maps-ios-reviewers
+/platform/darwin/ @1ec5 @mapbox/maps-ios-reviewers
 


### PR DESCRIPTION
This may be short-lived, but still could be useful - and I think it's worth an experiment. I've kept it deliberately light too.

I didn't assume to add an Android/Qt/etc sections - but feel free to add.

/cc @chloekraw @1ec5 