### PR TITLE
[ios] Fix issue where MGLAnnotationViews jump around during MGLMapView frame animation

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1005,7 +1005,7 @@ public:
     // degradation. The only time the scale bar's intrinsic content size _must_ invalidated
     // is here as a reaction to this object's view dimension changes.
     [self.scaleBar invalidateIntrinsicContentSize];
-    
+
     [super layoutSubviews];
 
     [self adjustContentInset];
@@ -1025,6 +1025,7 @@ public:
     }
 
     [self updateUserLocationAnnotationView];
+    [self updateAnnotationViews];
 }
 
 /// Updates `contentInset` to reflect the current window geometry.


### PR DESCRIPTION
Fixes #13366

Note: user still needs to call `mapView.layoutIfNeeded()` inside the UIView animation block in order to fully resolve this issue — I tried performing the updates in `setFrame` but wound up getting a C++ crash that I wasn't able to resolve