### PR TITLE
[core][android] Introduce mbgl::style::LayerTypeInfo

### DIFF
--- a/include/mbgl/style/layer.hpp
+++ b/include/mbgl/style/layer.hpp
@@ -19,6 +19,21 @@ class LayerObserver;
 class Filter;
 
 /**
+ * @brief Holds static data for a certain layer type.
+ */
+struct LayerTypeInfo {
+    /**
+     * @brief contains the layer type as defined in the style specification;
+     */
+    const char* type;
+    /**
+     * @brief contains \c SourceRequired if the corresponding layer type requires source;
+     * contains \c SourceNotRequired otherwise.
+     */
+    const enum { SourceRequired, SourceNotRequired } source;
+};
+
+/**
  * The runtime representation of a [layer](https://www.mapbox.com/mapbox-gl-style-spec/#layers) from the Mapbox Style
  * Specification.
  *
@@ -83,11 +98,15 @@ public:
     // identical platform-native peers.
     util::peer peer;
     Layer(Immutable<Impl>);
+
+    const LayerTypeInfo* getTypeInfo() const noexcept;
+
 protected:
     virtual Mutable<Impl> mutableBaseImpl() const = 0;
 
     LayerObserver* observer;
 };
+
 
 /**
  * @brief The LayerFactory abstract class
@@ -97,8 +116,8 @@ protected:
 class LayerFactory {
 public:
     virtual ~LayerFactory() = default;
-    /// Returns \c true if this factory can produce layers of the given type of the layers; returns \c false otherwise.
-    virtual bool supportsType(const std::string& type) const noexcept = 0;
+    /// Returns the layer type data.
+    virtual const LayerTypeInfo* getTypeInfo() const noexcept = 0;
     /// Returns a new Layer instance on success call; returns `nulltptr` otherwise. 
     virtual std::unique_ptr<Layer> createLayer(const std::string& id, const conversion::Convertible& value) = 0;
 

--- a/include/mbgl/style/layers/background_layer.hpp
+++ b/include/mbgl/style/layers/background_layer.hpp
@@ -59,15 +59,11 @@ protected:
 class BackgroundLayerFactory : public LayerFactory {
 public:
     BackgroundLayerFactory();
-    // LayerFactory overrides.
     ~BackgroundLayerFactory() override;
-    bool supportsType(const std::string& type) const noexcept final;
+
+    // LayerFactory overrides.
+    const LayerTypeInfo* getTypeInfo() const noexcept final;
     std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
-
-    static BackgroundLayerFactory* get() noexcept;
-
-private:
-    static BackgroundLayerFactory* instance;
 };
 
 } // namespace style

--- a/include/mbgl/style/layers/circle_layer.hpp
+++ b/include/mbgl/style/layers/circle_layer.hpp
@@ -107,15 +107,11 @@ protected:
 class CircleLayerFactory : public LayerFactory {
 public:
     CircleLayerFactory();
-    // LayerFactory overrides.
     ~CircleLayerFactory() override;
-    bool supportsType(const std::string& type) const noexcept final;
+
+    // LayerFactory overrides.
+    const LayerTypeInfo* getTypeInfo() const noexcept final;
     std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
-
-    static CircleLayerFactory* get() noexcept;
-
-private:
-    static CircleLayerFactory* instance;
 };
 
 } // namespace style

--- a/include/mbgl/style/layers/custom_layer.hpp
+++ b/include/mbgl/style/layers/custom_layer.hpp
@@ -90,13 +90,9 @@ public:
     CustomLayerFactory();
     // LayerFactory overrides.
     ~CustomLayerFactory() override;
-    bool supportsType(const std::string& type) const noexcept final;
+
+    const LayerTypeInfo* getTypeInfo() const noexcept final;
     std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
-
-    static CustomLayerFactory* get() noexcept;
-
-private:
-    static CustomLayerFactory* instance;
 };
 
 } // namespace style

--- a/include/mbgl/style/layers/fill_extrusion_layer.hpp
+++ b/include/mbgl/style/layers/fill_extrusion_layer.hpp
@@ -83,15 +83,11 @@ protected:
 class FillExtrusionLayerFactory : public LayerFactory {
 public:
     FillExtrusionLayerFactory();
-    // LayerFactory overrides.
     ~FillExtrusionLayerFactory() override;
-    bool supportsType(const std::string& type) const noexcept final;
+
+    // LayerFactory overrides.
+    const LayerTypeInfo* getTypeInfo() const noexcept final;
     std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
-
-    static FillExtrusionLayerFactory* get() noexcept;
-
-private:
-    static FillExtrusionLayerFactory* instance;
 };
 
 } // namespace style

--- a/include/mbgl/style/layers/fill_layer.hpp
+++ b/include/mbgl/style/layers/fill_layer.hpp
@@ -83,15 +83,11 @@ protected:
 class FillLayerFactory : public LayerFactory {
 public:
     FillLayerFactory();
-    // LayerFactory overrides.
     ~FillLayerFactory() override;
-    bool supportsType(const std::string& type) const noexcept final;
+
+    // LayerFactory overrides.
+    const LayerTypeInfo* getTypeInfo() const noexcept final;
     std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
-
-    static FillLayerFactory* get() noexcept;
-
-private:
-    static FillLayerFactory* instance;
 };
 
 } // namespace style

--- a/include/mbgl/style/layers/heatmap_layer.hpp
+++ b/include/mbgl/style/layers/heatmap_layer.hpp
@@ -72,15 +72,11 @@ protected:
 class HeatmapLayerFactory : public LayerFactory {
 public:
     HeatmapLayerFactory();
-    // LayerFactory overrides.
     ~HeatmapLayerFactory() override;
-    bool supportsType(const std::string& type) const noexcept final;
+
+    // LayerFactory overrides.
+    const LayerTypeInfo* getTypeInfo() const noexcept final;
     std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
-
-    static HeatmapLayerFactory* get() noexcept;
-
-private:
-    static HeatmapLayerFactory* instance;
 };
 
 } // namespace style

--- a/include/mbgl/style/layers/hillshade_layer.hpp
+++ b/include/mbgl/style/layers/hillshade_layer.hpp
@@ -77,15 +77,11 @@ protected:
 class HillshadeLayerFactory : public LayerFactory {
 public:
     HillshadeLayerFactory();
-    // LayerFactory overrides.
     ~HillshadeLayerFactory() override;
-    bool supportsType(const std::string& type) const noexcept final;
+
+    // LayerFactory overrides.
+    const LayerTypeInfo* getTypeInfo() const noexcept final;
     std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
-
-    static HillshadeLayerFactory* get() noexcept;
-
-private:
-    static HillshadeLayerFactory* instance;
 };
 
 } // namespace style

--- a/include/mbgl/style/layers/layer.hpp.ejs
+++ b/include/mbgl/style/layers/layer.hpp.ejs
@@ -75,15 +75,11 @@ protected:
 class <%- camelize(type) %>LayerFactory : public LayerFactory {
 public:
     <%- camelize(type) %>LayerFactory();
-    // LayerFactory overrides.
     ~<%- camelize(type) %>LayerFactory() override;
-    bool supportsType(const std::string& type) const noexcept final;
+
+    // LayerFactory overrides.
+    const LayerTypeInfo* getTypeInfo() const noexcept final;
     std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
-
-    static <%- camelize(type) %>LayerFactory* get() noexcept;
-
-private:
-    static <%- camelize(type) %>LayerFactory* instance;
 };
 
 } // namespace style

--- a/include/mbgl/style/layers/line_layer.hpp
+++ b/include/mbgl/style/layers/line_layer.hpp
@@ -128,15 +128,11 @@ protected:
 class LineLayerFactory : public LayerFactory {
 public:
     LineLayerFactory();
-    // LayerFactory overrides.
     ~LineLayerFactory() override;
-    bool supportsType(const std::string& type) const noexcept final;
+
+    // LayerFactory overrides.
+    const LayerTypeInfo* getTypeInfo() const noexcept final;
     std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
-
-    static LineLayerFactory* get() noexcept;
-
-private:
-    static LineLayerFactory* instance;
 };
 
 } // namespace style

--- a/include/mbgl/style/layers/raster_layer.hpp
+++ b/include/mbgl/style/layers/raster_layer.hpp
@@ -89,15 +89,11 @@ protected:
 class RasterLayerFactory : public LayerFactory {
 public:
     RasterLayerFactory();
-    // LayerFactory overrides.
     ~RasterLayerFactory() override;
-    bool supportsType(const std::string& type) const noexcept final;
+
+    // LayerFactory overrides.
+    const LayerTypeInfo* getTypeInfo() const noexcept final;
     std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
-
-    static RasterLayerFactory* get() noexcept;
-
-private:
-    static RasterLayerFactory* instance;
 };
 
 } // namespace style

--- a/include/mbgl/style/layers/symbol_layer.hpp
+++ b/include/mbgl/style/layers/symbol_layer.hpp
@@ -277,15 +277,11 @@ protected:
 class SymbolLayerFactory : public LayerFactory {
 public:
     SymbolLayerFactory();
-    // LayerFactory overrides.
     ~SymbolLayerFactory() override;
-    bool supportsType(const std::string& type) const noexcept final;
+
+    // LayerFactory overrides.
+    const LayerTypeInfo* getTypeInfo() const noexcept final;
     std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
-
-    static SymbolLayerFactory* get() noexcept;
-
-private:
-    static SymbolLayerFactory* instance;
 };
 
 } // namespace style

--- a/platform/android/src/style/layers/background_layer.cpp
+++ b/platform/android/src/style/layers/background_layer.cpp
@@ -109,12 +109,12 @@ namespace android {
     }  // namespace
 
     jni::Local<jni::Object<Layer>> BackgroundJavaLayerPeerFactory::createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, mbgl::style::Layer& layer) {
-        assert(layer.baseImpl->getLayerFactory() == this);
+        assert(layer.baseImpl->getTypeInfo() == getTypeInfo());
         return createJavaPeer(env, new BackgroundLayer(map, toBackgroundLayer(layer)));
     }
 
     jni::Local<jni::Object<Layer>> BackgroundJavaLayerPeerFactory::createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, std::unique_ptr<mbgl::style::Layer> layer) {
-        assert(layer->baseImpl->getLayerFactory() == this);
+        assert(layer->baseImpl->getTypeInfo() == getTypeInfo());
         return createJavaPeer(env, new BackgroundLayer(map, std::unique_ptr<mbgl::style::BackgroundLayer>(static_cast<mbgl::style::BackgroundLayer*>(layer.release()))));
     }
 

--- a/platform/android/src/style/layers/circle_layer.cpp
+++ b/platform/android/src/style/layers/circle_layer.cpp
@@ -214,12 +214,12 @@ namespace android {
     }  // namespace
 
     jni::Local<jni::Object<Layer>> CircleJavaLayerPeerFactory::createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, mbgl::style::Layer& layer) {
-        assert(layer.baseImpl->getLayerFactory() == this);
+        assert(layer.baseImpl->getTypeInfo() == getTypeInfo());
         return createJavaPeer(env, new CircleLayer(map, toCircleLayer(layer)));
     }
 
     jni::Local<jni::Object<Layer>> CircleJavaLayerPeerFactory::createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, std::unique_ptr<mbgl::style::Layer> layer) {
-        assert(layer->baseImpl->getLayerFactory() == this);
+        assert(layer->baseImpl->getTypeInfo() == getTypeInfo());
         return createJavaPeer(env, new CircleLayer(map, std::unique_ptr<mbgl::style::CircleLayer>(static_cast<mbgl::style::CircleLayer*>(layer.release()))));
     }
 

--- a/platform/android/src/style/layers/fill_extrusion_layer.cpp
+++ b/platform/android/src/style/layers/fill_extrusion_layer.cpp
@@ -168,12 +168,12 @@ namespace android {
     }  // namespace
 
     jni::Local<jni::Object<Layer>> FillExtrusionJavaLayerPeerFactory::createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, mbgl::style::Layer& layer) {
-        assert(layer.baseImpl->getLayerFactory() == this);
+        assert(layer.baseImpl->getTypeInfo() == getTypeInfo());
         return createJavaPeer(env, new FillExtrusionLayer(map, toFillExtrusionLayer(layer)));
     }
 
     jni::Local<jni::Object<Layer>> FillExtrusionJavaLayerPeerFactory::createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, std::unique_ptr<mbgl::style::Layer> layer) {
-        assert(layer->baseImpl->getLayerFactory() == this);
+        assert(layer->baseImpl->getTypeInfo() == getTypeInfo());
         return createJavaPeer(env, new FillExtrusionLayer(map, std::unique_ptr<mbgl::style::FillExtrusionLayer>(static_cast<mbgl::style::FillExtrusionLayer*>(layer.release()))));
     }
 

--- a/platform/android/src/style/layers/fill_layer.cpp
+++ b/platform/android/src/style/layers/fill_layer.cpp
@@ -155,12 +155,12 @@ namespace android {
     }  // namespace
 
     jni::Local<jni::Object<Layer>> FillJavaLayerPeerFactory::createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, mbgl::style::Layer& layer) {
-        assert(layer.baseImpl->getLayerFactory() == this);
+        assert(layer.baseImpl->getTypeInfo() == getTypeInfo());
         return createJavaPeer(env, new FillLayer(map, toFillLayer(layer)));
     }
 
     jni::Local<jni::Object<Layer>> FillJavaLayerPeerFactory::createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, std::unique_ptr<mbgl::style::Layer> layer) {
-        assert(layer->baseImpl->getLayerFactory() == this);
+        assert(layer->baseImpl->getTypeInfo() == getTypeInfo());
         return createJavaPeer(env, new FillLayer(map, std::unique_ptr<mbgl::style::FillLayer>(static_cast<mbgl::style::FillLayer*>(layer.release()))));
     }
 

--- a/platform/android/src/style/layers/heatmap_layer.cpp
+++ b/platform/android/src/style/layers/heatmap_layer.cpp
@@ -123,12 +123,12 @@ namespace android {
     }  // namespace
 
     jni::Local<jni::Object<Layer>> HeatmapJavaLayerPeerFactory::createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, mbgl::style::Layer& layer) {
-        assert(layer.baseImpl->getLayerFactory() == this);
+        assert(layer.baseImpl->getTypeInfo() == getTypeInfo());
         return createJavaPeer(env, new HeatmapLayer(map, toHeatmapLayer(layer)));
     }
 
     jni::Local<jni::Object<Layer>> HeatmapJavaLayerPeerFactory::createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, std::unique_ptr<mbgl::style::Layer> layer) {
-        assert(layer->baseImpl->getLayerFactory() == this);
+        assert(layer->baseImpl->getTypeInfo() == getTypeInfo());
         return createJavaPeer(env, new HeatmapLayer(map, std::unique_ptr<mbgl::style::HeatmapLayer>(static_cast<mbgl::style::HeatmapLayer*>(layer.release()))));
     }
 

--- a/platform/android/src/style/layers/hillshade_layer.cpp
+++ b/platform/android/src/style/layers/hillshade_layer.cpp
@@ -137,12 +137,12 @@ namespace android {
     }  // namespace
 
     jni::Local<jni::Object<Layer>> HillshadeJavaLayerPeerFactory::createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, mbgl::style::Layer& layer) {
-        assert(layer.baseImpl->getLayerFactory() == this);
+        assert(layer.baseImpl->getTypeInfo() == getTypeInfo());
         return createJavaPeer(env, new HillshadeLayer(map, toHillshadeLayer(layer)));
     }
 
     jni::Local<jni::Object<Layer>> HillshadeJavaLayerPeerFactory::createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, std::unique_ptr<mbgl::style::Layer> layer) {
-        assert(layer->baseImpl->getLayerFactory() == this);
+        assert(layer->baseImpl->getTypeInfo() == getTypeInfo());
         return createJavaPeer(env, new HillshadeLayer(map, std::unique_ptr<mbgl::style::HillshadeLayer>(static_cast<mbgl::style::HillshadeLayer*>(layer.release()))));
     }
 

--- a/platform/android/src/style/layers/layer.cpp.ejs
+++ b/platform/android/src/style/layers/layer.cpp.ejs
@@ -101,12 +101,12 @@ namespace android {
     }  // namespace
 
     jni::Local<jni::Object<Layer>> <%- camelize(type) %>JavaLayerPeerFactory::createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, mbgl::style::Layer& layer) {
-        assert(layer.baseImpl->getLayerFactory() == this);
+        assert(layer.baseImpl->getTypeInfo() == getTypeInfo());
         return createJavaPeer(env, new <%- camelize(type) %>Layer(map, to<%- camelize(type) %>Layer(layer)));
     }
 
     jni::Local<jni::Object<Layer>> <%- camelize(type) %>JavaLayerPeerFactory::createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, std::unique_ptr<mbgl::style::Layer> layer) {
-        assert(layer->baseImpl->getLayerFactory() == this);
+        assert(layer->baseImpl->getTypeInfo() == getTypeInfo());
         return createJavaPeer(env, new <%- camelize(type) %>Layer(map, std::unique_ptr<mbgl::style::<%- camelize(type) %>Layer>(static_cast<mbgl::style::<%- camelize(type) %>Layer*>(layer.release()))));
     }
 

--- a/platform/android/src/style/layers/layer_manager.hpp
+++ b/platform/android/src/style/layers/layer_manager.hpp
@@ -28,11 +28,13 @@ public:
 
 private:
     LayerManagerAndroid();
+    void addLayerType(std::unique_ptr<JavaLayerPeerFactory>);
     JavaLayerPeerFactory* getPeerFactory(mbgl::style::Layer*);
     // mbgl:style::LayerManager overrides.
     std::unique_ptr<style::Layer> createLayer(const std::string& type, const std::string& id, const style::conversion::Convertible& value, style::conversion::Error& error) noexcept final;
 
     std::vector<std::unique_ptr<JavaLayerPeerFactory>> factories;
+    std::map<std::string, style::LayerFactory*> typeToFactory;
 };
 
 }

--- a/platform/android/src/style/layers/line_layer.cpp
+++ b/platform/android/src/style/layers/line_layer.cpp
@@ -247,12 +247,12 @@ namespace android {
     }  // namespace
 
     jni::Local<jni::Object<Layer>> LineJavaLayerPeerFactory::createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, mbgl::style::Layer& layer) {
-        assert(layer.baseImpl->getLayerFactory() == this);
+        assert(layer.baseImpl->getTypeInfo() == getTypeInfo());
         return createJavaPeer(env, new LineLayer(map, toLineLayer(layer)));
     }
 
     jni::Local<jni::Object<Layer>> LineJavaLayerPeerFactory::createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, std::unique_ptr<mbgl::style::Layer> layer) {
-        assert(layer->baseImpl->getLayerFactory() == this);
+        assert(layer->baseImpl->getTypeInfo() == getTypeInfo());
         return createJavaPeer(env, new LineLayer(map, std::unique_ptr<mbgl::style::LineLayer>(static_cast<mbgl::style::LineLayer*>(layer.release()))));
     }
 

--- a/platform/android/src/style/layers/raster_layer.cpp
+++ b/platform/android/src/style/layers/raster_layer.cpp
@@ -173,12 +173,12 @@ namespace android {
     }  // namespace
 
     jni::Local<jni::Object<Layer>> RasterJavaLayerPeerFactory::createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, mbgl::style::Layer& layer) {
-        assert(layer.baseImpl->getLayerFactory() == this);
+        assert(layer.baseImpl->getTypeInfo() == getTypeInfo());
         return createJavaPeer(env, new RasterLayer(map, toRasterLayer(layer)));
     }
 
     jni::Local<jni::Object<Layer>> RasterJavaLayerPeerFactory::createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, std::unique_ptr<mbgl::style::Layer> layer) {
-        assert(layer->baseImpl->getLayerFactory() == this);
+        assert(layer->baseImpl->getTypeInfo() == getTypeInfo());
         return createJavaPeer(env, new RasterLayer(map, std::unique_ptr<mbgl::style::RasterLayer>(static_cast<mbgl::style::RasterLayer*>(layer.release()))));
     }
 

--- a/platform/android/src/style/layers/symbol_layer.cpp
+++ b/platform/android/src/style/layers/symbol_layer.cpp
@@ -466,12 +466,12 @@ namespace android {
     }  // namespace
 
     jni::Local<jni::Object<Layer>> SymbolJavaLayerPeerFactory::createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, mbgl::style::Layer& layer) {
-        assert(layer.baseImpl->getLayerFactory() == this);
+        assert(layer.baseImpl->getTypeInfo() == getTypeInfo());
         return createJavaPeer(env, new SymbolLayer(map, toSymbolLayer(layer)));
     }
 
     jni::Local<jni::Object<Layer>> SymbolJavaLayerPeerFactory::createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, std::unique_ptr<mbgl::style::Layer> layer) {
-        assert(layer->baseImpl->getLayerFactory() == this);
+        assert(layer->baseImpl->getTypeInfo() == getTypeInfo());
         return createJavaPeer(env, new SymbolLayer(map, std::unique_ptr<mbgl::style::SymbolLayer>(static_cast<mbgl::style::SymbolLayer*>(layer.release()))));
     }
 

--- a/platform/default/layer_manager.cpp
+++ b/platform/default/layer_manager.cpp
@@ -2,6 +2,7 @@
 #include <mbgl/style/layers/symbol_layer.hpp>
 #include <mbgl/style/layers/background_layer.hpp>
 #include <mbgl/style/layers/circle_layer.hpp>
+#include <mbgl/style/layers/custom_layer.hpp>
 #include <mbgl/style/layers/fill_extrusion_layer.hpp>
 #include <mbgl/style/layers/fill_layer.hpp>
 #include <mbgl/style/layers/heatmap_layer.hpp>
@@ -10,6 +11,7 @@
 #include <mbgl/style/layers/raster_layer.hpp>
 #include <mbgl/style/layers/symbol_layer.hpp>
 
+#include <map>
 #include <memory>
 #include <vector>
 
@@ -19,36 +21,48 @@ namespace style {
 class LayerManagerBase : public LayerManager {
 public:
     LayerManagerBase();
+
 private:
+    void addLayerType(std::unique_ptr<LayerFactory>);
     // LayerManager overrides.
     std::unique_ptr<Layer> createLayer(const std::string& type, const std::string& id, const conversion::Convertible& value, conversion::Error& error) noexcept final;
+
     std::vector<std::unique_ptr<LayerFactory>> factories;
+    std::map<std::string, LayerFactory*> typeToFactory;
 };
 
 LayerManagerBase::LayerManagerBase() {
-    factories.emplace_back(std::unique_ptr<LayerFactory>(new FillLayerFactory));
-    factories.emplace_back(std::unique_ptr<LayerFactory>(new LineLayerFactory));
-    factories.emplace_back(std::unique_ptr<LayerFactory>(new CircleLayerFactory));
-    factories.emplace_back(std::unique_ptr<LayerFactory>(new SymbolLayerFactory));
-    factories.emplace_back(std::unique_ptr<LayerFactory>(new RasterLayerFactory));
-    factories.emplace_back(std::unique_ptr<LayerFactory>(new BackgroundLayerFactory));
-    factories.emplace_back(std::unique_ptr<LayerFactory>(new HillshadeLayerFactory));
-    factories.emplace_back(std::unique_ptr<LayerFactory>(new FillExtrusionLayerFactory));
-    factories.emplace_back(std::unique_ptr<LayerFactory>(new HeatmapLayerFactory));
+    addLayerType(std::make_unique<FillLayerFactory>());
+    addLayerType(std::make_unique<LineLayerFactory>());
+    addLayerType(std::make_unique<CircleLayerFactory>());
+    addLayerType(std::make_unique<SymbolLayerFactory>());
+    addLayerType(std::make_unique<RasterLayerFactory>());
+    addLayerType(std::make_unique<BackgroundLayerFactory>());
+    addLayerType(std::make_unique<HillshadeLayerFactory>());
+    addLayerType(std::make_unique<FillExtrusionLayerFactory>());
+    addLayerType(std::make_unique<HeatmapLayerFactory>());
+    addLayerType(std::make_unique<CustomLayerFactory>());
+}
+
+void LayerManagerBase::addLayerType(std::unique_ptr<LayerFactory> factory) {
+    std::string type{factory->getTypeInfo()->type};
+    if (!type.empty()) {
+        typeToFactory.emplace(std::make_pair(std::move(type), factory.get()));
+    }
+    factories.emplace_back(std::move(factory));
 }
 
 std::unique_ptr<Layer> LayerManagerBase::createLayer(const std::string& type,
                                                      const std::string& id,
                                                      const conversion::Convertible& value,
                                                      conversion::Error& error) noexcept {
-    for (const auto& factory: factories) {
-        if (factory->supportsType(type)) {
-            auto layer = factory->createLayer(id, value);
-            if (!layer) {
-                error.message = "Error parsing a layer of type: " + type;
-            }
-            return layer;
+    auto search = typeToFactory.find(type);
+    if (search != typeToFactory.end()) {
+        auto layer = search->second->createLayer(id, value);
+        if (!layer) {
+            error.message = "Error parsing a layer of type: " + type;
         }
+        return layer;
     }
     error.message = "Unsupported layer type: " + type;
     return nullptr;

--- a/src/mbgl/style/layer.cpp
+++ b/src/mbgl/style/layer.cpp
@@ -107,6 +107,10 @@ optional<conversion::Error> Layer::setVisibility(const conversion::Convertible& 
     return nullopt;
 }
 
+const LayerTypeInfo* Layer::getTypeInfo() const noexcept {
+    return baseImpl->getTypeInfo();
+}
+
 optional<std::string> LayerFactory::getSource(const conversion::Convertible& value) const noexcept {
     auto sourceValue = objectMember(value, "source");
     if (!sourceValue) {

--- a/src/mbgl/style/layer_impl.hpp
+++ b/src/mbgl/style/layer_impl.hpp
@@ -41,8 +41,9 @@ public:
     // Utility function for automatic layer grouping.
     virtual void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const = 0;
 
-    virtual LayerFactory* getLayerFactory() const noexcept = 0;
+    virtual const LayerTypeInfo* getTypeInfo() const noexcept = 0;
 
+    // Note: LayerType is deprecated, do not use it.
     const LayerType type;
     std::string id;
     std::string source;

--- a/src/mbgl/style/layers/background_layer.cpp
+++ b/src/mbgl/style/layers/background_layer.cpp
@@ -14,6 +14,10 @@
 namespace mbgl {
 namespace style {
 
+namespace {
+    const LayerTypeInfo typeInfoBackground{ "background", LayerTypeInfo::SourceNotRequired };
+}  // namespace
+
 BackgroundLayer::BackgroundLayer(const std::string& layerID)
     : Layer(makeMutable<Impl>(LayerType::Background, layerID, std::string())) {
 }
@@ -42,8 +46,8 @@ std::unique_ptr<Layer> BackgroundLayer::cloneRef(const std::string& id_) const {
 void BackgroundLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
 }
 
-LayerFactory* BackgroundLayer::Impl::getLayerFactory() const noexcept {
-    return BackgroundLayerFactory::get();
+const LayerTypeInfo* BackgroundLayer::Impl::getTypeInfo() const noexcept {
+    return &typeInfoBackground;
 }
 
 // Layout properties
@@ -274,23 +278,12 @@ Mutable<Layer::Impl> BackgroundLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
-BackgroundLayerFactory* BackgroundLayerFactory::instance = nullptr;
-
-BackgroundLayerFactory::BackgroundLayerFactory() {
-    assert(!instance);
-    instance = this;
-}
+BackgroundLayerFactory::BackgroundLayerFactory() = default;
 
 BackgroundLayerFactory::~BackgroundLayerFactory() = default;
 
-// static
-BackgroundLayerFactory* BackgroundLayerFactory::get() noexcept {
-    assert(instance);
-    return instance;
-}
-
-bool BackgroundLayerFactory::supportsType(const std::string& type) const noexcept {
-    return type == "background";
+const LayerTypeInfo* BackgroundLayerFactory::getTypeInfo() const noexcept {
+    return &typeInfoBackground;
 }
 
 std::unique_ptr<style::Layer> BackgroundLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {

--- a/src/mbgl/style/layers/background_layer_impl.hpp
+++ b/src/mbgl/style/layers/background_layer_impl.hpp
@@ -13,7 +13,7 @@ public:
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
-    LayerFactory* getLayerFactory() const noexcept final;
+    const LayerTypeInfo* getTypeInfo() const noexcept final;
 
     BackgroundPaintProperties::Transitionable paint;
 };

--- a/src/mbgl/style/layers/circle_layer.cpp
+++ b/src/mbgl/style/layers/circle_layer.cpp
@@ -14,6 +14,10 @@
 namespace mbgl {
 namespace style {
 
+namespace {
+    const LayerTypeInfo typeInfoCircle{ "circle", LayerTypeInfo::SourceRequired };
+}  // namespace
+
 CircleLayer::CircleLayer(const std::string& layerID, const std::string& sourceID)
     : Layer(makeMutable<Impl>(LayerType::Circle, layerID, sourceID)) {
 }
@@ -42,8 +46,8 @@ std::unique_ptr<Layer> CircleLayer::cloneRef(const std::string& id_) const {
 void CircleLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
 }
 
-LayerFactory* CircleLayer::Impl::getLayerFactory() const noexcept {
-    return CircleLayerFactory::get();
+const LayerTypeInfo* CircleLayer::Impl::getTypeInfo() const noexcept {
+    return &typeInfoCircle;
 }
 
 // Layout properties
@@ -691,23 +695,12 @@ Mutable<Layer::Impl> CircleLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
-CircleLayerFactory* CircleLayerFactory::instance = nullptr;
-
-CircleLayerFactory::CircleLayerFactory() {
-    assert(!instance);
-    instance = this;
-}
+CircleLayerFactory::CircleLayerFactory() = default;
 
 CircleLayerFactory::~CircleLayerFactory() = default;
 
-// static
-CircleLayerFactory* CircleLayerFactory::get() noexcept {
-    assert(instance);
-    return instance;
-}
-
-bool CircleLayerFactory::supportsType(const std::string& type) const noexcept {
-    return type == "circle";
+const LayerTypeInfo* CircleLayerFactory::getTypeInfo() const noexcept {
+    return &typeInfoCircle;
 }
 
 std::unique_ptr<style::Layer> CircleLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {

--- a/src/mbgl/style/layers/circle_layer_impl.hpp
+++ b/src/mbgl/style/layers/circle_layer_impl.hpp
@@ -13,7 +13,7 @@ public:
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
-    LayerFactory* getLayerFactory() const noexcept final;
+    const LayerTypeInfo* getTypeInfo() const noexcept final;
 
     CirclePaintProperties::Transitionable paint;
 };

--- a/src/mbgl/style/layers/custom_layer.cpp
+++ b/src/mbgl/style/layers/custom_layer.cpp
@@ -5,6 +5,10 @@
 namespace mbgl {
 namespace style {
 
+namespace {
+    const LayerTypeInfo typeInfoCustom{ "", LayerTypeInfo::SourceNotRequired };
+}  // namespace
+
 CustomLayer::CustomLayer(const std::string& layerID,
                          std::unique_ptr<CustomLayerHost> host)
     : Layer(makeMutable<Impl>(layerID, std::move(host))) {
@@ -39,23 +43,16 @@ Mutable<Layer::Impl> CustomLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
-CustomLayerFactory* CustomLayerFactory::instance = nullptr;
-
-CustomLayerFactory::CustomLayerFactory() {
-    assert(!instance);
-    instance = this;
+const LayerTypeInfo* CustomLayer::Impl::getTypeInfo() const noexcept {
+    return &typeInfoCustom;
 }
+
+CustomLayerFactory::CustomLayerFactory() = default;
 
 CustomLayerFactory::~CustomLayerFactory() = default;
 
-// static
-CustomLayerFactory* CustomLayerFactory::get() noexcept {
-    assert(instance);
-    return instance;
-}
-
-bool CustomLayerFactory::supportsType(const std::string&) const noexcept {
-    return false;
+const LayerTypeInfo* CustomLayerFactory::getTypeInfo() const noexcept {
+    return &typeInfoCustom;
 }
 
 std::unique_ptr<style::Layer> CustomLayerFactory::createLayer(const std::string&, const conversion::Convertible&) {

--- a/src/mbgl/style/layers/custom_layer_impl.cpp
+++ b/src/mbgl/style/layers/custom_layer_impl.cpp
@@ -16,9 +16,5 @@ bool CustomLayer::Impl::hasLayoutDifference(const Layer::Impl&) const {
 void CustomLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
 }
 
-LayerFactory*  CustomLayer::Impl::getLayerFactory() const noexcept {
-    return CustomLayerFactory::get();
-}
-
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/layers/custom_layer_impl.hpp
+++ b/src/mbgl/style/layers/custom_layer_impl.hpp
@@ -18,7 +18,7 @@ public:
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
-    LayerFactory* getLayerFactory() const noexcept final;
+    const LayerTypeInfo* getTypeInfo() const noexcept final;
 
     std::shared_ptr<CustomLayerHost> host;
 };

--- a/src/mbgl/style/layers/fill_extrusion_layer.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer.cpp
@@ -14,6 +14,10 @@
 namespace mbgl {
 namespace style {
 
+namespace {
+    const LayerTypeInfo typeInfoFillExtrusion{ "fill-extrusion", LayerTypeInfo::SourceRequired };
+}  // namespace
+
 FillExtrusionLayer::FillExtrusionLayer(const std::string& layerID, const std::string& sourceID)
     : Layer(makeMutable<Impl>(LayerType::FillExtrusion, layerID, sourceID)) {
 }
@@ -42,8 +46,8 @@ std::unique_ptr<Layer> FillExtrusionLayer::cloneRef(const std::string& id_) cons
 void FillExtrusionLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
 }
 
-LayerFactory* FillExtrusionLayer::Impl::getLayerFactory() const noexcept {
-    return FillExtrusionLayerFactory::get();
+const LayerTypeInfo* FillExtrusionLayer::Impl::getTypeInfo() const noexcept {
+    return &typeInfoFillExtrusion;
 }
 
 // Layout properties
@@ -493,23 +497,12 @@ Mutable<Layer::Impl> FillExtrusionLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
-FillExtrusionLayerFactory* FillExtrusionLayerFactory::instance = nullptr;
-
-FillExtrusionLayerFactory::FillExtrusionLayerFactory() {
-    assert(!instance);
-    instance = this;
-}
+FillExtrusionLayerFactory::FillExtrusionLayerFactory() = default;
 
 FillExtrusionLayerFactory::~FillExtrusionLayerFactory() = default;
 
-// static
-FillExtrusionLayerFactory* FillExtrusionLayerFactory::get() noexcept {
-    assert(instance);
-    return instance;
-}
-
-bool FillExtrusionLayerFactory::supportsType(const std::string& type) const noexcept {
-    return type == "fill-extrusion";
+const LayerTypeInfo* FillExtrusionLayerFactory::getTypeInfo() const noexcept {
+    return &typeInfoFillExtrusion;
 }
 
 std::unique_ptr<style::Layer> FillExtrusionLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {

--- a/src/mbgl/style/layers/fill_extrusion_layer_impl.hpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer_impl.hpp
@@ -13,7 +13,7 @@ public:
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
-    LayerFactory* getLayerFactory() const noexcept final;
+    const LayerTypeInfo* getTypeInfo() const noexcept final;
 
     Properties<>::Unevaluated layout;
     FillExtrusionPaintProperties::Transitionable paint;

--- a/src/mbgl/style/layers/fill_layer.cpp
+++ b/src/mbgl/style/layers/fill_layer.cpp
@@ -14,6 +14,10 @@
 namespace mbgl {
 namespace style {
 
+namespace {
+    const LayerTypeInfo typeInfoFill{ "fill", LayerTypeInfo::SourceRequired };
+}  // namespace
+
 FillLayer::FillLayer(const std::string& layerID, const std::string& sourceID)
     : Layer(makeMutable<Impl>(LayerType::Fill, layerID, sourceID)) {
 }
@@ -42,8 +46,8 @@ std::unique_ptr<Layer> FillLayer::cloneRef(const std::string& id_) const {
 void FillLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
 }
 
-LayerFactory* FillLayer::Impl::getLayerFactory() const noexcept {
-    return FillLayerFactory::get();
+const LayerTypeInfo* FillLayer::Impl::getTypeInfo() const noexcept {
+    return &typeInfoFill;
 }
 
 // Layout properties
@@ -493,23 +497,12 @@ Mutable<Layer::Impl> FillLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
-FillLayerFactory* FillLayerFactory::instance = nullptr;
-
-FillLayerFactory::FillLayerFactory() {
-    assert(!instance);
-    instance = this;
-}
+FillLayerFactory::FillLayerFactory() = default;
 
 FillLayerFactory::~FillLayerFactory() = default;
 
-// static
-FillLayerFactory* FillLayerFactory::get() noexcept {
-    assert(instance);
-    return instance;
-}
-
-bool FillLayerFactory::supportsType(const std::string& type) const noexcept {
-    return type == "fill";
+const LayerTypeInfo* FillLayerFactory::getTypeInfo() const noexcept {
+    return &typeInfoFill;
 }
 
 std::unique_ptr<style::Layer> FillLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {

--- a/src/mbgl/style/layers/fill_layer_impl.hpp
+++ b/src/mbgl/style/layers/fill_layer_impl.hpp
@@ -13,7 +13,7 @@ public:
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
-    LayerFactory* getLayerFactory() const noexcept final;
+    const LayerTypeInfo* getTypeInfo() const noexcept final;
 
     Properties<>::Unevaluated layout;
     FillPaintProperties::Transitionable paint;

--- a/src/mbgl/style/layers/heatmap_layer.cpp
+++ b/src/mbgl/style/layers/heatmap_layer.cpp
@@ -14,6 +14,10 @@
 namespace mbgl {
 namespace style {
 
+namespace {
+    const LayerTypeInfo typeInfoHeatmap{ "heatmap", LayerTypeInfo::SourceRequired };
+}  // namespace
+
 HeatmapLayer::HeatmapLayer(const std::string& layerID, const std::string& sourceID)
     : Layer(makeMutable<Impl>(LayerType::Heatmap, layerID, sourceID)) {
 }
@@ -42,8 +46,8 @@ std::unique_ptr<Layer> HeatmapLayer::cloneRef(const std::string& id_) const {
 void HeatmapLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
 }
 
-LayerFactory* HeatmapLayer::Impl::getLayerFactory() const noexcept {
-    return HeatmapLayerFactory::get();
+const LayerTypeInfo* HeatmapLayer::Impl::getTypeInfo() const noexcept {
+    return &typeInfoHeatmap;
 }
 
 // Layout properties
@@ -378,23 +382,12 @@ Mutable<Layer::Impl> HeatmapLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
-HeatmapLayerFactory* HeatmapLayerFactory::instance = nullptr;
-
-HeatmapLayerFactory::HeatmapLayerFactory() {
-    assert(!instance);
-    instance = this;
-}
+HeatmapLayerFactory::HeatmapLayerFactory() = default;
 
 HeatmapLayerFactory::~HeatmapLayerFactory() = default;
 
-// static
-HeatmapLayerFactory* HeatmapLayerFactory::get() noexcept {
-    assert(instance);
-    return instance;
-}
-
-bool HeatmapLayerFactory::supportsType(const std::string& type) const noexcept {
-    return type == "heatmap";
+const LayerTypeInfo* HeatmapLayerFactory::getTypeInfo() const noexcept {
+    return &typeInfoHeatmap;
 }
 
 std::unique_ptr<style::Layer> HeatmapLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {

--- a/src/mbgl/style/layers/heatmap_layer_impl.hpp
+++ b/src/mbgl/style/layers/heatmap_layer_impl.hpp
@@ -13,7 +13,7 @@ public:
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
-    LayerFactory* getLayerFactory() const noexcept final;
+   const LayerTypeInfo* getTypeInfo() const noexcept final;
 
     HeatmapPaintProperties::Transitionable paint;
 };

--- a/src/mbgl/style/layers/hillshade_layer.cpp
+++ b/src/mbgl/style/layers/hillshade_layer.cpp
@@ -14,6 +14,10 @@
 namespace mbgl {
 namespace style {
 
+namespace {
+    const LayerTypeInfo typeInfoHillshade{ "hillshade", LayerTypeInfo::SourceRequired };
+}  // namespace
+
 HillshadeLayer::HillshadeLayer(const std::string& layerID, const std::string& sourceID)
     : Layer(makeMutable<Impl>(LayerType::Hillshade, layerID, sourceID)) {
 }
@@ -42,8 +46,8 @@ std::unique_ptr<Layer> HillshadeLayer::cloneRef(const std::string& id_) const {
 void HillshadeLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
 }
 
-LayerFactory* HillshadeLayer::Impl::getLayerFactory() const noexcept {
-    return HillshadeLayerFactory::get();
+const LayerTypeInfo* HillshadeLayer::Impl::getTypeInfo() const noexcept {
+    return &typeInfoHillshade;
 }
 
 // Layout properties
@@ -425,23 +429,12 @@ Mutable<Layer::Impl> HillshadeLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
-HillshadeLayerFactory* HillshadeLayerFactory::instance = nullptr;
-
-HillshadeLayerFactory::HillshadeLayerFactory() {
-    assert(!instance);
-    instance = this;
-}
+HillshadeLayerFactory::HillshadeLayerFactory() = default;
 
 HillshadeLayerFactory::~HillshadeLayerFactory() = default;
 
-// static
-HillshadeLayerFactory* HillshadeLayerFactory::get() noexcept {
-    assert(instance);
-    return instance;
-}
-
-bool HillshadeLayerFactory::supportsType(const std::string& type) const noexcept {
-    return type == "hillshade";
+const LayerTypeInfo* HillshadeLayerFactory::getTypeInfo() const noexcept {
+    return &typeInfoHillshade;
 }
 
 std::unique_ptr<style::Layer> HillshadeLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {

--- a/src/mbgl/style/layers/hillshade_layer_impl.hpp
+++ b/src/mbgl/style/layers/hillshade_layer_impl.hpp
@@ -13,7 +13,7 @@ public:
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
-    LayerFactory* getLayerFactory() const noexcept final;
+    const LayerTypeInfo* getTypeInfo() const noexcept final;
 
     HillshadePaintProperties::Transitionable paint;
 };

--- a/src/mbgl/style/layers/layer.cpp.ejs
+++ b/src/mbgl/style/layers/layer.cpp.ejs
@@ -19,6 +19,14 @@
 namespace mbgl {
 namespace style {
 
+namespace {
+<% if (type === 'background') { -%>
+    const LayerTypeInfo typeInfo<%- camelize(type) %>{ "<%- type %>", LayerTypeInfo::SourceNotRequired };
+<% } else { -%>
+    const LayerTypeInfo typeInfo<%- camelize(type) %>{ "<%- type %>", LayerTypeInfo::SourceRequired };
+<% } -%>
+}  // namespace
+
 <% if (type === 'background') { -%>
 <%- camelize(type) %>Layer::<%- camelize(type) %>Layer(const std::string& layerID)
     : Layer(makeMutable<Impl>(LayerType::<%- camelize(type) %>, layerID, std::string())) {
@@ -59,8 +67,8 @@ void <%- camelize(type) %>Layer::Impl::stringifyLayout(rapidjson::Writer<rapidjs
 }
 <% } -%>
 
-LayerFactory* <%- camelize(type) %>Layer::Impl::getLayerFactory() const noexcept {
-    return <%- camelize(type) %>LayerFactory::get();
+const LayerTypeInfo* <%- camelize(type) %>Layer::Impl::getTypeInfo() const noexcept {
+    return &typeInfo<%- camelize(type) %>;
 }
 
 // Layout properties
@@ -264,23 +272,12 @@ Mutable<Layer::Impl> <%- camelize(type) %>Layer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
-<%- camelize(type) %>LayerFactory* <%- camelize(type) %>LayerFactory::instance = nullptr;
-
-<%- camelize(type) %>LayerFactory::<%- camelize(type) %>LayerFactory() {
-    assert(!instance);
-    instance = this;
-}
+<%- camelize(type) %>LayerFactory::<%- camelize(type) %>LayerFactory() = default;
 
 <%- camelize(type) %>LayerFactory::~<%- camelize(type) %>LayerFactory() = default;
 
-// static
-<%- camelize(type) %>LayerFactory* <%- camelize(type) %>LayerFactory::get() noexcept {
-    assert(instance);
-    return instance;
-}
-
-bool <%- camelize(type) %>LayerFactory::supportsType(const std::string& type) const noexcept {
-    return type == "<%- type %>";
+const LayerTypeInfo* <%- camelize(type) %>LayerFactory::getTypeInfo() const noexcept {
+    return &typeInfo<%- camelize(type) %>;
 }
 
 std::unique_ptr<style::Layer> <%- camelize(type) %>LayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -14,6 +14,10 @@
 namespace mbgl {
 namespace style {
 
+namespace {
+    const LayerTypeInfo typeInfoLine{ "line", LayerTypeInfo::SourceRequired };
+}  // namespace
+
 LineLayer::LineLayer(const std::string& layerID, const std::string& sourceID)
     : Layer(makeMutable<Impl>(LayerType::Line, layerID, sourceID)) {
 }
@@ -43,8 +47,8 @@ void LineLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>
     layout.stringify(writer);
 }
 
-LayerFactory* LineLayer::Impl::getLayerFactory() const noexcept {
-    return LineLayerFactory::get();
+const LayerTypeInfo* LineLayer::Impl::getTypeInfo() const noexcept {
+    return &typeInfoLine;
 }
 
 // Layout properties
@@ -832,23 +836,12 @@ Mutable<Layer::Impl> LineLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
-LineLayerFactory* LineLayerFactory::instance = nullptr;
-
-LineLayerFactory::LineLayerFactory() {
-    assert(!instance);
-    instance = this;
-}
+LineLayerFactory::LineLayerFactory() = default;
 
 LineLayerFactory::~LineLayerFactory() = default;
 
-// static
-LineLayerFactory* LineLayerFactory::get() noexcept {
-    assert(instance);
-    return instance;
-}
-
-bool LineLayerFactory::supportsType(const std::string& type) const noexcept {
-    return type == "line";
+const LayerTypeInfo* LineLayerFactory::getTypeInfo() const noexcept {
+    return &typeInfoLine;
 }
 
 std::unique_ptr<style::Layer> LineLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {

--- a/src/mbgl/style/layers/line_layer_impl.hpp
+++ b/src/mbgl/style/layers/line_layer_impl.hpp
@@ -13,7 +13,7 @@ public:
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
-    LayerFactory* getLayerFactory() const noexcept final;
+    const LayerTypeInfo* getTypeInfo() const noexcept final;
 
     LineLayoutProperties::Unevaluated layout;
     LinePaintProperties::Transitionable paint;

--- a/src/mbgl/style/layers/raster_layer.cpp
+++ b/src/mbgl/style/layers/raster_layer.cpp
@@ -14,6 +14,10 @@
 namespace mbgl {
 namespace style {
 
+namespace {
+    const LayerTypeInfo typeInfoRaster{ "raster", LayerTypeInfo::SourceRequired };
+}  // namespace
+
 RasterLayer::RasterLayer(const std::string& layerID, const std::string& sourceID)
     : Layer(makeMutable<Impl>(LayerType::Raster, layerID, sourceID)) {
 }
@@ -42,8 +46,8 @@ std::unique_ptr<Layer> RasterLayer::cloneRef(const std::string& id_) const {
 void RasterLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
 }
 
-LayerFactory* RasterLayer::Impl::getLayerFactory() const noexcept {
-    return RasterLayerFactory::get();
+const LayerTypeInfo* RasterLayer::Impl::getTypeInfo() const noexcept {
+    return &typeInfoRaster;
 }
 
 // Layout properties
@@ -514,23 +518,12 @@ Mutable<Layer::Impl> RasterLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
-RasterLayerFactory* RasterLayerFactory::instance = nullptr;
-
-RasterLayerFactory::RasterLayerFactory() {
-    assert(!instance);
-    instance = this;
-}
+RasterLayerFactory::RasterLayerFactory() = default;
 
 RasterLayerFactory::~RasterLayerFactory() = default;
 
-// static
-RasterLayerFactory* RasterLayerFactory::get() noexcept {
-    assert(instance);
-    return instance;
-}
-
-bool RasterLayerFactory::supportsType(const std::string& type) const noexcept {
-    return type == "raster";
+const LayerTypeInfo* RasterLayerFactory::getTypeInfo() const noexcept {
+    return &typeInfoRaster;
 }
 
 std::unique_ptr<style::Layer> RasterLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {

--- a/src/mbgl/style/layers/raster_layer_impl.hpp
+++ b/src/mbgl/style/layers/raster_layer_impl.hpp
@@ -13,7 +13,7 @@ public:
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
-    LayerFactory* getLayerFactory() const noexcept final;
+    const LayerTypeInfo* getTypeInfo() const noexcept final;
 
     RasterPaintProperties::Transitionable paint;
 };

--- a/src/mbgl/style/layers/symbol_layer.cpp
+++ b/src/mbgl/style/layers/symbol_layer.cpp
@@ -14,6 +14,10 @@
 namespace mbgl {
 namespace style {
 
+namespace {
+    const LayerTypeInfo typeInfoSymbol{ "symbol", LayerTypeInfo::SourceRequired };
+}  // namespace
+
 SymbolLayer::SymbolLayer(const std::string& layerID, const std::string& sourceID)
     : Layer(makeMutable<Impl>(LayerType::Symbol, layerID, sourceID)) {
 }
@@ -43,8 +47,8 @@ void SymbolLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffe
     layout.stringify(writer);
 }
 
-LayerFactory* SymbolLayer::Impl::getLayerFactory() const noexcept {
-    return SymbolLayerFactory::get();
+const LayerTypeInfo* SymbolLayer::Impl::getTypeInfo() const noexcept {
+    return &typeInfoSymbol;
 }
 
 // Layout properties
@@ -1982,23 +1986,12 @@ Mutable<Layer::Impl> SymbolLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
-SymbolLayerFactory* SymbolLayerFactory::instance = nullptr;
-
-SymbolLayerFactory::SymbolLayerFactory() {
-    assert(!instance);
-    instance = this;
-}
+SymbolLayerFactory::SymbolLayerFactory() = default;
 
 SymbolLayerFactory::~SymbolLayerFactory() = default;
 
-// static
-SymbolLayerFactory* SymbolLayerFactory::get() noexcept {
-    assert(instance);
-    return instance;
-}
-
-bool SymbolLayerFactory::supportsType(const std::string& type) const noexcept {
-    return type == "symbol";
+const LayerTypeInfo* SymbolLayerFactory::getTypeInfo() const noexcept {
+    return &typeInfoSymbol;
 }
 
 std::unique_ptr<style::Layer> SymbolLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {

--- a/src/mbgl/style/layers/symbol_layer_impl.hpp
+++ b/src/mbgl/style/layers/symbol_layer_impl.hpp
@@ -13,7 +13,7 @@ public:
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
-    LayerFactory* getLayerFactory() const noexcept final;
+    const LayerTypeInfo* getTypeInfo() const noexcept final;
 
     SymbolLayoutProperties::Unevaluated layout;
     SymbolPaintProperties::Transitionable paint;


### PR DESCRIPTION
The `LayerTypeInfo` contains static meta data about certain layer type.

Each layer module should have a single immutable `LayerTypeInfo` instance
for the represented layer type. Both `LayerImpl` and `LayerFactory` from the
module always refer to the same `LayerTypeInfo` instance, so address of this
instance can be used as a layer module Id during the process life time.

Part of https://github.com/mapbox/mapbox-gl-native/issues/13276 and https://github.com/mapbox/mapbox-gl-native/issues/13136