### PR TITLE
PropertyExpression zoom evaluation should not assume zoom is non-constant

### DIFF
--- a/include/mbgl/style/property_expression.hpp
+++ b/include/mbgl/style/property_expression.hpp
@@ -25,8 +25,7 @@ public:
     bool isFeatureConstant() const { return expression::isFeatureConstant(*expression); }
 
     T evaluate(float zoom) const {
-        assert(!expression::isZoomConstant(*expression));
-        assert(expression::isFeatureConstant(*expression));
+        assert(isFeatureConstant());
         const expression::EvaluationResult result = expression->evaluate(expression::EvaluationContext(zoom, nullptr));
         if (result) {
             const optional<T> typed = expression::fromExpressionValue<T>(*result);
@@ -37,8 +36,8 @@ public:
 
     template <class Feature>
     T evaluate(const Feature& feature, T finalDefaultValue) const {
-        assert(expression::isZoomConstant(*expression));
-        assert(!expression::isFeatureConstant(*expression));
+        assert(isZoomConstant());
+        assert(!isFeatureConstant());
         const expression::EvaluationResult result = expression->evaluate(expression::EvaluationContext(&feature));
         if (result) {
             const optional<T> typed = expression::fromExpressionValue<T>(*result);
@@ -49,7 +48,7 @@ public:
 
     template <class Feature>
     T evaluate(float zoom, const Feature& feature, T finalDefaultValue) const {
-        assert(!expression::isFeatureConstant(*expression));
+        assert(!isFeatureConstant());
         const expression::EvaluationResult result = expression->evaluate(expression::EvaluationContext({zoom}, &feature));
         if (result) {
             const optional<T> typed = expression::fromExpressionValue<T>(*result);

--- a/test/style/properties.test.cpp
+++ b/test/style/properties.test.cpp
@@ -1,7 +1,8 @@
 #include <mbgl/test/util.hpp>
 
-#include <mbgl/style/properties.hpp>
 #include <mbgl/style/expression/dsl.hpp>
+#include <mbgl/style/expression/format_expression.hpp>
+#include <mbgl/style/properties.hpp>
 #include <mbgl/renderer/property_evaluator.hpp>
 #include <mbgl/renderer/data_driven_property_evaluator.hpp>
 
@@ -135,4 +136,10 @@ TEST(TransitioningDataDrivenPropertyValue, Evaluate) {
     ASSERT_TRUE(evaluateDataExpression(t0, 0ms).isConstant());
     ASSERT_FALSE(evaluateDataExpression(t1, 0ms).isConstant()) <<
         "A paint property transition to a data-driven evaluates immediately to the final value (see https://github.com/mapbox/mapbox-gl-native/issues/8237).";
+}
+
+TEST(PropertyValue, EvaluateFormatted) {
+    using namespace mbgl::style::expression;
+    using namespace mbgl::style::expression::dsl;
+    ASSERT_EQ(PropertyExpression<Formatted> { format("hello") }.evaluate(12.0).toString(), std::string("hello"));
 }


### PR DESCRIPTION
We shouldn't need to worry a zoom value is non-constant when evaluating according to zoom. This causes a crash when e.g. creating a Formatted expression and evaluating this according to zoom. This can happen if e.g. the [symbol layer is the leader](https://github.com/mapbox/mapbox-gl-native/blob/master/src/mbgl/layout/symbol_layout.cpp#L59).