### PR TITLE
Force attribution, title-casing tests to pass

### DIFF
--- a/platform/darwin/test/MGLNSStringAdditionsTests.m
+++ b/platform/darwin/test/MGLNSStringAdditionsTests.m
@@ -9,7 +9,7 @@
 @implementation MGLNSStringAdditionsTests
 
 - (void)testTitleCasedString {
-    NSLocale *locale = [NSLocale currentLocale];
+    NSLocale *locale = [NSLocale localeWithLocaleIdentifier:@"en-US"];
 
     XCTAssertEqualObjects([@"© OpenStreetMap" mgl_titleCasedStringWithLocale:locale], @"© OpenStreetMap");
     XCTAssertEqualObjects([@"© OSM" mgl_titleCasedStringWithLocale:locale], @"© OSM");

--- a/platform/darwin/test/MGLTileSetTests.mm
+++ b/platform/darwin/test/MGLTileSetTests.mm
@@ -69,16 +69,11 @@
 #if TARGET_OS_IPHONE
     UIColor *redColor = [UIColor redColor];
 #else
-    NSColor *redColor;
-    if ([NSColor redColor].colorSpaceName == NSCalibratedRGBColorSpace) {
-        // CSS uses the sRGB color space.
-        redColor = [NSColor colorWithSRGBRed:1 green:0 blue:0 alpha:1];
-    } else {
-        // AppKit incorrectly uses calibrated RGB when exporting HTML, so input
-        // calibrated RGB to ensure round-tripping.
-        // <rdar://problem/46115233> <http://www.openradar.me/46115233>
-        redColor = [NSColor colorWithCalibratedRed:1 green:0 blue:0 alpha:1];
-    }
+    // CSS uses the sRGB color space.
+    // AppKit incorrectly uses calibrated RGB when exporting HTML, so input
+    // calibrated RGB to ensure round-tripping.
+    // <rdar://problem/46115233> <http://www.openradar.me/46115233>
+    NSColor *redColor = [NSColor colorWithCalibratedRed:1 green:0 blue:0 alpha:1];
 #endif
     NSAttributedString *gl = [[NSAttributedString alloc] initWithString:@"GL" attributes:@{
         NSBackgroundColorAttributeName: redColor,

--- a/platform/darwin/test/MGLTileSetTests.mm
+++ b/platform/darwin/test/MGLTileSetTests.mm
@@ -69,10 +69,16 @@
 #if TARGET_OS_IPHONE
     UIColor *redColor = [UIColor redColor];
 #else
-    // CSS uses the sRGB color space. In macOS 10.12 Sierra and below,
-    // -[NSColor redColor] is in the calibrated RGB space and has a slightly
-    // different sRGB value than on iOS and macOS 10.13 High Sierra.
-    NSColor *redColor = [NSColor colorWithSRGBRed:1 green:0 blue:0 alpha:1];
+    NSColor *redColor;
+    if ([NSColor redColor].colorSpaceName == NSCalibratedRGBColorSpace) {
+        // CSS uses the sRGB color space.
+        redColor = [NSColor colorWithSRGBRed:1 green:0 blue:0 alpha:1];
+    } else {
+        // AppKit incorrectly uses calibrated RGB when exporting HTML, so input
+        // calibrated RGB to ensure round-tripping.
+        // <rdar://problem/46115233> <http://www.openradar.me/46115233>
+        redColor = [NSColor colorWithCalibratedRed:1 green:0 blue:0 alpha:1];
+    }
 #endif
     NSAttributedString *gl = [[NSAttributedString alloc] initWithString:@"GL" attributes:@{
         NSBackgroundColorAttributeName: redColor,


### PR DESCRIPTION
This is a followup to #11391 that ensures the attribution and title-casing tests pass on iOS and macOS regardless of system version or locale. The changes include a workaround for an AppKit bug and a hard-coded locale identifier (for folks like me who run macOS or iOS in a language other than English).

Fixes #13386.

/cc @julianrex @friedbunny