### PR TITLE
Use locale sensitive DecimalFormat for color alpha conversion

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/ColorUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/ColorUtils.java
@@ -14,6 +14,7 @@ import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.exceptions.ConversionException;
 
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -147,7 +148,10 @@ public class ColorUtils {
    * @return String rgba color
    */
   public static String colorToRgbaString(@ColorInt int color) {
-    String alpha = new DecimalFormat("#.###").format(((float) ((color >> 24) & 0xFF)) / 255.0f);
+    NumberFormat numberFormat = NumberFormat.getNumberInstance(Locale.US);
+    DecimalFormat decimalFormat = (DecimalFormat) numberFormat;
+    decimalFormat.applyPattern("#.###");
+    String alpha = decimalFormat.format(((float) ((color >> 24) & 0xFF)) / 255.0f);
     return String.format(Locale.US, "rgba(%d, %d, %d, %s)",
       (color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF, alpha);
   }


### PR DESCRIPTION
Fixes an issue where the alpha value of the `ColorInt` -> `String` conversion would be converted with a system locale instead of the fixed one.