### PR TITLE
Telemetry CN endpoint

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
@@ -117,6 +117,16 @@ public class MapboxConstants {
    */
   public static final String FRAG_ARG_MAPBOXMAPOPTIONS = "MapboxMapOptions";
 
+  /**
+   * CN base url API endpoint
+   */
+  public static final String URL_API_CN = "api.mapbox.cn";
+
+  /**
+   * CN base url events endpoint
+   */
+  public static final String URL_EVENTS_CN = "https://events.mapbox.cn";
+
   // Save instance state keys
   public static final String STATE_HAS_SAVED_STATE = "mapbox_savedState";
   public static final String STATE_CAMERA_POSITION = "mapbox_cameraPosition";

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -22,6 +22,7 @@ import com.mapbox.android.gestures.StandardScaleGestureDetector;
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.Geometry;
 import com.mapbox.mapboxsdk.MapStrictMode;
+import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.annotations.Annotation;
 import com.mapbox.mapboxsdk.annotations.BaseMarkerOptions;
 import com.mapbox.mapboxsdk.annotations.Marker;
@@ -950,7 +951,18 @@ public final class MapboxMap {
   private void setApiBaseUrl(@NonNull MapboxMapOptions options) {
     String apiBaseUrl = options.getApiBaseUrl();
     if (!TextUtils.isEmpty(apiBaseUrl)) {
+      validateTelemetryConfigurationForCnEndpoint(apiBaseUrl);
       nativeMapView.setApiBaseUrl(apiBaseUrl);
+    }
+  }
+
+  private void validateTelemetryConfigurationForCnEndpoint(String apiBaseUrl) {
+    if (apiBaseUrl.contains(MapboxConstants.URL_API_CN)) {
+      // enable cn endpoint for telemetry
+      TelemetryDefinition definition = Mapbox.getTelemetry();
+      if (definition != null) {
+        definition.setApiBaseUrl(MapboxConstants.URL_EVENTS_CN);
+      }
     }
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/TelemetryDefinition.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/TelemetryDefinition.java
@@ -1,26 +1,16 @@
 package com.mapbox.mapboxsdk.maps;
 
+import android.support.annotation.NonNull;
 import com.mapbox.mapboxsdk.offline.OfflineRegionDefinition;
 
 /**
- * Definition of TelemetryImpl collection
+ * Definition of Telemetry
  */
 public interface TelemetryDefinition {
 
-  /**
-   * Register the app user turnstile event
-   */
-  void onAppUserTurnstileEvent();
-
-  /**
-   * Register an end-user gesture interaction event.
-   *
-   * @param eventType type of gesture event occurred
-   * @param latitude  the latitude value of the gesture focal point
-   * @param longitude the longitude value of the gesture focal point
-   * @param zoom      current zoom of the map
-   */
-  void onGestureInteraction(String eventType, double latitude, double longitude, double zoom);
+  //
+  // Configuration
+  //
 
   /**
    * Set the end-user selected state to participate or opt-out in telemetry collection.
@@ -41,9 +31,36 @@ public interface TelemetryDefinition {
   boolean setSessionIdRotationInterval(int interval);
 
   /**
+   * Set the API base url for end point configuration
+   *
+   * @param baseUrl the end point url for telemetry collection
+   */
+  void setApiBaseUrl(@NonNull String baseUrl);
+
+  //
+  // Events
+  //
+
+  /**
    * Register an end-user offline download event.
    *
    * @param offlineDefinition the offline region definition
    */
   void onCreateOfflineRegion(OfflineRegionDefinition offlineDefinition);
+
+  /**
+   * Register the app user turnstile event
+   */
+  void onAppUserTurnstileEvent();
+
+  /**
+   * Register an end-user gesture interaction event.
+   *
+   * @param eventType type of gesture event occurred
+   * @param latitude  the latitude value of the gesture focal point
+   * @param longitude the longitude value of the gesture focal point
+   * @param zoom      current zoom of the map
+   */
+  void onGestureInteraction(String eventType, double latitude, double longitude, double zoom);
+
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/telemetry/TelemetryImpl.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/telemetry/TelemetryImpl.java
@@ -60,6 +60,17 @@ public class TelemetryImpl implements TelemetryDefinition {
     telemetry.push(mapEventFactory.createMapGestureEvent(Event.Type.MAP_CLICK, state));
   }
 
+  @Override
+  public void onCreateOfflineRegion(@NonNull OfflineRegionDefinition offlineDefinition) {
+    MapEventFactory mapEventFactory = new MapEventFactory();
+    telemetry.push(mapEventFactory.createOfflineDownloadStartEvent(
+      offlineDefinition instanceof OfflineTilePyramidRegionDefinition ? "tileregion" : "shaperegion",
+      offlineDefinition.getMinZoom(),
+      offlineDefinition.getMaxZoom(),
+      offlineDefinition.getStyleURL())
+    );
+  }
+
   /**
    * Set the end-user selected state to participate or opt-out in telemetry collection.
    */
@@ -95,14 +106,13 @@ public class TelemetryImpl implements TelemetryDefinition {
     return telemetry.updateSessionIdRotationInterval(new SessionInterval(interval));
   }
 
+  /**
+   * Set the telemetry api end point base url
+   *
+   * @param baseUrl the end point url for telemetry collection
+   */
   @Override
-  public void onCreateOfflineRegion(@NonNull OfflineRegionDefinition offlineDefinition) {
-    MapEventFactory mapEventFactory = new MapEventFactory();
-    telemetry.push(mapEventFactory.createOfflineDownloadStartEvent(
-      offlineDefinition instanceof OfflineTilePyramidRegionDefinition ? "tileregion" : "shaperegion",
-      offlineDefinition.getMinZoom(),
-      offlineDefinition.getMaxZoom(),
-      offlineDefinition.getStyleURL())
-    );
+  public void setApiBaseUrl(@NonNull String baseUrl) {
+    //telemetry.updateApiBaseUrl(baseUrl);
   }
 }


### PR DESCRIPTION
WIP, closes https://github.com/mapbox/mapbox-gl-native/issues/13401. This PR adds integration to configuring telemetry with a cn endpoint when the user has opted in to use the cn endpoint for maps API. 

@electrostat @andrlee 
This PR is blocked as I'm missing the actual API hook in telemetry to change the base url. 
Can this be added? Could we also expose a constant for the cn endpoint url? 
Thank you!

cc @zugaldia 