### PR TITLE
use --info argument to show details during test run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -651,9 +651,9 @@ run-android-ui-test-%: run-android-ui-test-arm-v7-%
 # Run Java Unit tests on the JVM of the development machine executing this
 .PHONY: run-android-unit-test
 run-android-unit-test: platform/android/gradle/configuration.gradle
-	cd platform/android && $(MBGL_ANDROID_GRADLE) -Pmapbox.abis=none :MapboxGLAndroidSDK:testDebugUnitTest
+	cd platform/android && $(MBGL_ANDROID_GRADLE) -Pmapbox.abis=none :MapboxGLAndroidSDK:testDebugUnitTest --info
 run-android-unit-test-%: platform/android/gradle/configuration.gradle
-	cd platform/android && $(MBGL_ANDROID_GRADLE) -Pmapbox.abis=none :MapboxGLAndroidSDK:testDebugUnitTest --tests "$*"
+	cd platform/android && $(MBGL_ANDROID_GRADLE) -Pmapbox.abis=none :MapboxGLAndroidSDK:testDebugUnitTest  --info --tests "$*"
 
 # Builds a release package of the Android SDK
 .PHONY: apackage


### PR DESCRIPTION
Long time due PR, to improve feedback given by unit test while running it though:

> make run-android-unit-test

This PR adds the info flag so output goes from:

<img width="553" alt="screenshot 2018-11-20 at 11 02 10" src="https://user-images.githubusercontent.com/2151639/48768424-4c6b3780-ecb9-11e8-8985-7c7139260d37.png">

to:

<img width="679" alt="screenshot 2018-11-20 at 11 02 45" src="https://user-images.githubusercontent.com/2151639/48768434-542adc00-ecb9-11e8-8410-5143d2ae6fc8.png">

cc @mapbox/android as this is useful for other android projects with running unit tests on CI. 

