### PR TITLE
Remove default zoom level restrictions when activating the location component

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
@@ -64,10 +64,8 @@ import static com.mapbox.mapboxsdk.location.LocationComponentConstants.DEFAULT_T
  * for more precise location updates, simply add the Google Play Location Services dependency in your build script.
  * This will make the default engine the {@link com.mapbox.android.core.location.GoogleLocationEngine} instead.
  * <p>
- * When activating the component for the first time, the map's max/min zoom levels will be set to
- * {@link LocationComponentOptions#MAX_ZOOM_DEFAULT} and {@link LocationComponentOptions#MIN_ZOOM_DEFAULT} respectively.
- * You can adjust the zoom range with {@link LocationComponentOptions#maxZoom()} and
- * {@link LocationComponentOptions#minZoom()}.
+ * For location puck animation purposes, like navigation,
+ * we recommend limiting the maximum zoom level of the map for the best user experience.
  * <p>
  * Location Component doesn't support state saving out-of-the-box.
  */
@@ -832,9 +830,6 @@ public final class LocationComponent {
     mapboxMap.setPadding(
       options.padding()[0], options.padding()[1], options.padding()[2], options.padding()[3]
     );
-
-    mapboxMap.setMaxZoomPreference(options.maxZoom());
-    mapboxMap.setMinZoomPreference(options.minZoom());
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentOptions.java
@@ -14,7 +14,6 @@ import android.support.annotation.StyleRes;
 
 import com.mapbox.android.gestures.AndroidGesturesManager;
 import com.mapbox.mapboxsdk.R;
-import com.mapbox.mapboxsdk.constants.MapboxConstants;
 
 import java.util.Arrays;
 
@@ -43,16 +42,6 @@ public class LocationComponentOptions implements Parcelable {
    * Default accuracy alpha
    */
   private static final float ACCURACY_ALPHA_DEFAULT = 0.15f;
-
-  /**
-   * Default max map zoom
-   */
-  private static final float MAX_ZOOM_DEFAULT = 18;
-
-  /**
-   * Default min map zoom
-   */
-  private static final float MIN_ZOOM_DEFAULT = 2;
 
   /**
    * Default icon scale factor when the map is zoomed out
@@ -114,8 +103,6 @@ public class LocationComponentOptions implements Parcelable {
   private long staleStateTimeout;
   @Nullable
   private int[] padding;
-  private double maxZoom;
-  private double minZoom;
   private float maxZoomIconScale;
   private float minZoomIconScale;
   private boolean trackingGesturesManagement;
@@ -148,8 +135,6 @@ public class LocationComponentOptions implements Parcelable {
     boolean enableStaleState,
     long staleStateTimeout,
     @Nullable int[] padding,
-    double maxZoom,
-    double minZoom,
     float maxZoomIconScale,
     float minZoomIconScale,
     boolean trackingGesturesManagement,
@@ -183,8 +168,6 @@ public class LocationComponentOptions implements Parcelable {
       throw new NullPointerException("Null padding");
     }
     this.padding = padding;
-    this.maxZoom = maxZoom;
-    this.minZoom = minZoom;
     this.maxZoomIconScale = maxZoomIconScale;
     this.minZoomIconScale = minZoomIconScale;
     this.trackingGesturesManagement = trackingGesturesManagement;
@@ -214,8 +197,6 @@ public class LocationComponentOptions implements Parcelable {
     LocationComponentOptions.Builder builder = new LocationComponentOptions.Builder()
       .enableStaleState(true)
       .staleStateTimeout(STALE_STATE_DELAY_MS)
-      .maxZoom(MAX_ZOOM_DEFAULT)
-      .minZoom(MIN_ZOOM_DEFAULT)
       .maxZoomIconScale(MAX_ZOOM_ICON_SCALE_DEFAULT)
       .minZoomIconScale(MIN_ZOOM_ICON_SCALE_DEFAULT)
       .padding(PADDING_DEFAULT);
@@ -283,23 +264,6 @@ public class LocationComponentOptions implements Parcelable {
       typedArray.getInt(R.styleable.mapbox_LocationComponent_mapbox_iconPaddingRight, 0),
       typedArray.getInt(R.styleable.mapbox_LocationComponent_mapbox_iconPaddingBottom, 0),
     });
-
-    float maxZoom
-      = typedArray.getFloat(R.styleable.mapbox_LocationComponent_mapbox_maxZoom, MAX_ZOOM_DEFAULT);
-    if (maxZoom < MapboxConstants.MINIMUM_ZOOM || maxZoom > MapboxConstants.MAXIMUM_ZOOM) {
-      throw new IllegalArgumentException("Max zoom value must be within "
-        + MapboxConstants.MINIMUM_ZOOM + " and " + MapboxConstants.MAXIMUM_ZOOM);
-    }
-
-    float minZoom
-      = typedArray.getFloat(R.styleable.mapbox_LocationComponent_mapbox_minZoom, MIN_ZOOM_DEFAULT);
-    if (minZoom < MapboxConstants.MINIMUM_ZOOM || minZoom > MapboxConstants.MAXIMUM_ZOOM) {
-      throw new IllegalArgumentException("Min zoom value must be within "
-        + MapboxConstants.MINIMUM_ZOOM + " and " + MapboxConstants.MAXIMUM_ZOOM);
-    }
-
-    builder.maxZoom(maxZoom);
-    builder.minZoom(minZoom);
 
     builder.layerBelow(
       typedArray.getString(R.styleable.mapbox_LocationComponent_mapbox_layer_below));
@@ -648,25 +612,7 @@ public class LocationComponentOptions implements Parcelable {
   }
 
   /**
-   * The maximum zoom level the map can be displayed at.
-   *
-   * @return the maximum zoom level
-   */
-  public double maxZoom() {
-    return maxZoom;
-  }
-
-  /**
-   * The minimum zoom level the map can be displayed at.
-   *
-   * @return the minimum zoom level
-   */
-  public double minZoom() {
-    return minZoom;
-  }
-
-  /**
-   * The scale factor of the location icon when the map is zoomed in. Based on {@link #maxZoom()}.
+   * The scale factor of the location icon when the map is zoomed in.
    * Scaling is linear.
    *
    * @return icon scale factor
@@ -676,7 +622,7 @@ public class LocationComponentOptions implements Parcelable {
   }
 
   /**
-   * The scale factor of the location icon when the map is zoomed out. Based on {@link #minZoom()}.
+   * The scale factor of the location icon when the map is zoomed out.
    * Scaling is linear.
    *
    * @return icon scale factor
@@ -765,8 +711,6 @@ public class LocationComponentOptions implements Parcelable {
       + "enableStaleState=" + enableStaleState + ", "
       + "staleStateTimeout=" + staleStateTimeout + ", "
       + "padding=" + Arrays.toString(padding) + ", "
-      + "maxZoom=" + maxZoom + ", "
-      + "minZoom=" + minZoom + ", "
       + "maxZoomIconScale=" + maxZoomIconScale + ", "
       + "minZoomIconScale=" + minZoomIconScale + ", "
       + "trackingGesturesManagement=" + trackingGesturesManagement + ", "
@@ -817,8 +761,6 @@ public class LocationComponentOptions implements Parcelable {
         && (this.enableStaleState == that.enableStaleState())
         && (this.staleStateTimeout == that.staleStateTimeout())
         && (Arrays.equals(this.padding, that.padding())
-        && (Double.doubleToLongBits(this.maxZoom) == Double.doubleToLongBits(that.maxZoom()))
-        && (Double.doubleToLongBits(this.minZoom) == Double.doubleToLongBits(that.minZoom()))
         && (Float.floatToIntBits(this.maxZoomIconScale) == Float.floatToIntBits(that.maxZoomIconScale()))
         && (Float.floatToIntBits(this.minZoomIconScale) == Float.floatToIntBits(that.minZoomIconScale()))
         && (this.trackingGesturesManagement == that.trackingGesturesManagement())
@@ -883,10 +825,6 @@ public class LocationComponentOptions implements Parcelable {
     h$ *= 1000003;
     h$ ^= Arrays.hashCode(padding);
     h$ *= 1000003;
-    h$ ^= (int) ((Double.doubleToLongBits(maxZoom) >>> 32) ^ Double.doubleToLongBits(maxZoom));
-    h$ *= 1000003;
-    h$ ^= (int) ((Double.doubleToLongBits(minZoom) >>> 32) ^ Double.doubleToLongBits(minZoom));
-    h$ *= 1000003;
     h$ ^= Float.floatToIntBits(maxZoomIconScale);
     h$ *= 1000003;
     h$ ^= Float.floatToIntBits(minZoomIconScale);
@@ -929,8 +867,6 @@ public class LocationComponentOptions implements Parcelable {
           in.readInt() == 1,
           in.readLong(),
           in.createIntArray(),
-          in.readDouble(),
-          in.readDouble(),
           in.readFloat(),
           in.readFloat(),
           in.readInt() == 1,
@@ -1027,8 +963,6 @@ public class LocationComponentOptions implements Parcelable {
     dest.writeInt(enableStaleState() ? 1 : 0);
     dest.writeLong(staleStateTimeout());
     dest.writeIntArray(padding());
-    dest.writeDouble(maxZoom());
-    dest.writeDouble(minZoom());
     dest.writeFloat(maxZoomIconScale());
     dest.writeFloat(minZoomIconScale());
     dest.writeInt(trackingGesturesManagement() ? 1 : 0);
@@ -1104,8 +1038,6 @@ public class LocationComponentOptions implements Parcelable {
     private Long staleStateTimeout;
     @Nullable
     private int[] padding;
-    private Double maxZoom;
-    private Double minZoom;
     private Float maxZoomIconScale;
     private Float minZoomIconScale;
     private Boolean trackingGesturesManagement;
@@ -1141,8 +1073,6 @@ public class LocationComponentOptions implements Parcelable {
       this.enableStaleState = source.enableStaleState();
       this.staleStateTimeout = source.staleStateTimeout();
       this.padding = source.padding();
-      this.maxZoom = source.maxZoom();
-      this.minZoom = source.minZoom();
       this.maxZoomIconScale = source.maxZoomIconScale();
       this.minZoomIconScale = source.minZoomIconScale();
       this.trackingGesturesManagement = source.trackingGesturesManagement();
@@ -1497,35 +1427,12 @@ public class LocationComponentOptions implements Parcelable {
     }
 
     /**
-     * Sets the maximum zoom level the map can be displayed at.
-     * <p>
-     * The default maximum zoomn level is 22. The upper bound for this value is 25.5.
-     *
-     * @param maxZoom The new maximum zoom level.
-     */
-    @NonNull
-    public LocationComponentOptions.Builder maxZoom(double maxZoom) {
-      this.maxZoom = maxZoom;
-      return this;
-    }
-
-    /**
-     * Sets the minimum zoom level the map can be displayed at.
-     *
-     * @param minZoom The new minimum zoom level.
-     */
-    @NonNull
-    public LocationComponentOptions.Builder minZoom(double minZoom) {
-      this.minZoom = minZoom;
-      return this;
-    }
-
-    /**
-     * Sets the scale factor of the location icon when the map is zoomed in. Based on {@link #maxZoom()}.
+     * Sets the scale factor of the location icon when the map is zoomed in.
      * Scaling is linear and the new pixel size of the image will be the original pixel size multiplied by the argument.
      * <p>
      * Set both this and {@link #minZoomIconScale(float)} to 1f to disable location icon scaling.
-     * </p>
+     * <p>
+     * Scaling is based on the maps minimum and maximum zoom levels in time of component's style application.
      *
      * @param maxZoomIconScale icon scale factor
      */
@@ -1536,11 +1443,12 @@ public class LocationComponentOptions implements Parcelable {
     }
 
     /**
-     * Sets the scale factor of the location icon when the map is zoomed out. Based on {@link #maxZoom()}.
+     * Sets the scale factor of the location icon when the map is zoomed out.
      * Scaling is linear and the new pixel size of the image will be the original pixel size multiplied by the argument.
      * <p>
      * Set both this and {@link #maxZoomIconScale(float)} to 1f to disable location icon scaling.
-     * </p>
+     * <p>
+     * Scaling is based on the maps minimum and maximum zoom levels in time of component's style application.
      *
      * @param minZoomIconScale icon scale factor
      */
@@ -1655,12 +1563,6 @@ public class LocationComponentOptions implements Parcelable {
       if (this.padding == null) {
         missing += " padding";
       }
-      if (this.maxZoom == null) {
-        missing += " maxZoom";
-      }
-      if (this.minZoom == null) {
-        missing += " minZoom";
-      }
       if (this.maxZoomIconScale == null) {
         missing += " maxZoomIconScale";
       }
@@ -1706,8 +1608,6 @@ public class LocationComponentOptions implements Parcelable {
         this.enableStaleState,
         this.staleStateTimeout,
         this.padding,
-        this.maxZoom,
-        this.minZoom,
         this.maxZoomIconScale,
         this.minZoomIconScale,
         trackingGesturesManagement,

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationLayerController.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationLayerController.java
@@ -313,12 +313,12 @@ final class LocationLayerController implements MapboxAnimator.OnLayerAnimationsV
   private void styleScaling(@NonNull LocationComponentOptions options) {
     for (String layerId : layerMap) {
       Layer layer = mapboxMap.getLayer(layerId);
-      if (layer != null && layer instanceof SymbolLayer) {
+      if (layer instanceof SymbolLayer) {
         layer.setProperties(
           iconSize(
             interpolate(linear(), zoom(),
-              stop(options.minZoom(), options.minZoomIconScale()),
-              stop(options.maxZoom(), options.maxZoomIconScale())
+              stop(mapboxMap.getMinZoomLevel(), options.minZoomIconScale()),
+              stop(mapboxMap.getMaxZoomLevel(), options.maxZoomIconScale())
             )
           )
         );
@@ -342,7 +342,7 @@ final class LocationLayerController implements MapboxAnimator.OnLayerAnimationsV
     refreshSource();
   }
 
-  @Nullable
+  @NonNull
   private String buildIconString(@Nullable String bitmapName, @NonNull String drawableName) {
     if (bitmapName != null) {
       return bitmapName;

--- a/platform/android/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
@@ -135,10 +135,6 @@
     <public name="mapbox_iconPaddingRight" format="integer" type="attr"/>
     <public name="mapbox_iconPaddingBottom" format="integer" type="attr"/>
 
-    <!-- Map zoom levels -->
-    <public name="mapbox_maxZoom" format="float" type="attr"/>
-    <public name="mapbox_minZoom" format="float" type="attr"/>
-
     <!-- Icon scale based on map zoom levels -->
     <public name="mapbox_maxZoomIconScale" format="float" type="attr"/>
     <public name="mapbox_minZoomIconScale" format="float" type="attr"/>

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/attrs.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/attrs.xml
@@ -159,10 +159,6 @@
         <!-- Map layer configuration -->
         <attr name="mapbox_layer_below" format="string"/>
 
-        <!-- Map zoom levels -->
-        <attr name="mapbox_maxZoom" format="float"/>
-        <attr name="mapbox_minZoom" format="float"/>
-
         <!-- Icon scale based on map zoom levels -->
         <attr name="mapbox_maxZoomIconScale" format="float"/>
         <attr name="mapbox_minZoomIconScale" format="float"/>

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/styles.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/styles.xml
@@ -24,10 +24,6 @@
     <item name="mapbox_iconPaddingRight">0</item>
     <item name="mapbox_iconPaddingBottom">0</item>
 
-    <!-- Map zoom levels -->
-    <item name="mapbox_maxZoom">18</item>
-    <item name="mapbox_minZoom">2</item>
-
     <!-- Location icon scale based on map zoom levels -->
     <item name="mapbox_maxZoomIconScale">1</item>
     <item name="mapbox_minZoomIconScale">0.6</item>


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/13097.

Even though we recommend decreasing the maximum zoom level when animating user location puck, we shouldn't make it a default behavior when activating the component.