### PR TITLE
[darwin, android, core] Expose "local ideograph font family" in map snapshotters

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Mapbox welcomes participation and contributions from everyone.  If you'd like to do so please see the [`Contributing Guide`](https://github.com/mapbox/mapbox-gl-native/blob/master/CONTRIBUTING.md) first to get started.
 
+## master
+- Add "localIdeographFontFamily" setting to MapSnapshotter to reduce font data usage while snapshotting CJK maps [#13427](https://github.com/mapbox/mapbox-gl-native/pull/13427)
+
 ## 7.0.0-alpha.2 - November 21, 2018
  - Add overlay example with custom drawing using paint and canvas [#13431](https://github.com/mapbox/mapbox-gl-native/pull/13431)
  - Use --info argument to show details during test run [#13415](https://github.com/mapbox/mapbox-gl-native/pull/13415)

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
@@ -95,6 +95,7 @@ public class MapSnapshotter {
     private LatLngBounds region;
     private CameraPosition cameraPosition;
     private boolean showLogo = true;
+    private String localIdeographFontFamily;
 
     /**
      * @param width  the width of the image
@@ -172,6 +173,22 @@ public class MapSnapshotter {
     }
 
     /**
+     * Set the font family for generating glyphs locally for ideographs in the &#x27;CJK Unified Ideographs&#x27;
+     * and &#x27;Hangul Syllables&#x27; ranges.
+     * <p>
+     * The font family argument is passed to {@link android.graphics.Typeface#create(String, int)}.
+     * Default system fonts are defined in &#x27;/system/etc/fonts.xml&#x27;
+     *
+     * @param fontFamily font family for local ideograph generation.
+     * @return the mutated {@link Options}
+     */
+    @NonNull
+    public Options withLocalIdeographFontFamily(String fontFamily) {
+      this.localIdeographFontFamily = fontFamily;
+      return this;
+    }
+
+    /**
      * @return the width of the image
      */
     public int getWidth() {
@@ -214,6 +231,14 @@ public class MapSnapshotter {
     public CameraPosition getCameraPosition() {
       return cameraPosition;
     }
+
+    /**
+     * @return the font family used for locally generating ideographs
+     */
+    public String getLocalIdeographFontFamily() {
+      return localIdeographFontFamily;
+    }
+
   }
 
   /**
@@ -231,7 +256,7 @@ public class MapSnapshotter {
 
     nativeInitialize(this, fileSource, options.pixelRatio, options.width,
       options.height, options.styleUrl, options.styleJson, options.region, options.cameraPosition,
-      options.showLogo, programCacheDir);
+      options.showLogo, programCacheDir, options.localIdeographFontFamily);
   }
 
   /**
@@ -513,7 +538,8 @@ public class MapSnapshotter {
                                          FileSource fileSource, float pixelRatio,
                                          int width, int height, String styleUrl, String styleJson,
                                          LatLngBounds region, CameraPosition position,
-                                         boolean showLogo, String programCacheDir);
+                                         boolean showLogo, String programCacheDir,
+                                         String localIdeographFontFamily);
 
   @Keep
   protected native void nativeStart();

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/snapshot/MapSnapshotterActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/snapshot/MapSnapshotterActivity.java
@@ -68,7 +68,8 @@ public class MapSnapshotterActivity extends AppCompatActivity {
       .withPixelRatio(1)
 
       // Optionally the style
-      .withStyle((column + row) % 2 == 0 ? Style.MAPBOX_STREETS : Style.DARK);
+      .withStyle((column + row) % 2 == 0 ? Style.MAPBOX_STREETS : Style.DARK)
+        .withLocalIdeographFontFamily("sans-serif");
 
     // Optionally the visible region
     if (row % 2 == 0) {

--- a/platform/android/src/snapshotter/map_snapshotter.cpp
+++ b/platform/android/src/snapshotter/map_snapshotter.cpp
@@ -24,7 +24,8 @@ MapSnapshotter::MapSnapshotter(jni::JNIEnv& _env,
                                const jni::Object<LatLngBounds>& region,
                                const jni::Object<CameraPosition>& position,
                                jni::jboolean _showLogo,
-                               const jni::String& _programCacheDir)
+                               const jni::String& _programCacheDir,
+                               const jni::String& _localIdeographFontFamily)
         : javaPeer(_env, _obj)
         , pixelRatio(_pixelRatio)
         , threadPool(sharedThreadPool()) {
@@ -65,7 +66,10 @@ MapSnapshotter::MapSnapshotter(jni::JNIEnv& _env,
                                                          pixelRatio,
                                                          cameraOptions,
                                                          bounds,
-                                                         jni::Make<std::string>(_env, _programCacheDir));
+                                                         jni::Make<std::string>(_env, _programCacheDir),
+                                                         _localIdeographFontFamily ?
+                                                            jni::Make<std::string>(_env, _localIdeographFontFamily) :
+                                                            optional<std::string>{});
 
 }
 
@@ -156,7 +160,7 @@ void MapSnapshotter::registerNative(jni::JNIEnv& env) {
 
     // Register the peer
     jni::RegisterNativePeer<MapSnapshotter>(env, javaClass, "nativePtr",
-                                            jni::MakePeer<MapSnapshotter, const jni::Object<MapSnapshotter>&, const jni::Object<FileSource>&, jni::jfloat, jni::jint, jni::jint, const jni::String&, const jni::String&, const jni::Object<LatLngBounds>&, const jni::Object<CameraPosition>&, jni::jboolean, const jni::String&>,
+                                            jni::MakePeer<MapSnapshotter, const jni::Object<MapSnapshotter>&, const jni::Object<FileSource>&, jni::jfloat, jni::jint, jni::jint, const jni::String&, const jni::String&, const jni::Object<LatLngBounds>&, const jni::Object<CameraPosition>&, jni::jboolean, const jni::String&, const jni::String&>,
                                            "nativeInitialize",
                                            "finalize",
                                             METHOD(&MapSnapshotter::setStyleUrl, "setStyleUrl"),

--- a/platform/android/src/snapshotter/map_snapshotter.hpp
+++ b/platform/android/src/snapshotter/map_snapshotter.hpp
@@ -35,7 +35,8 @@ public:
                    const jni::Object<LatLngBounds>& region,
                    const jni::Object<CameraPosition>& position,
                    jni::jboolean showLogo,
-                   const jni::String& programCacheDir);
+                   const jni::String& programCacheDir,
+                   const jni::String& localIdeographFontFamily);
 
     ~MapSnapshotter();
 

--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -16,6 +16,7 @@
 #import "MGLStyle.h"
 #import "MGLAttributionInfo_Private.h"
 #import "MGLLoggingConfiguration_Private.h"
+#import "MGLRendererConfiguration.h"
 
 #if TARGET_OS_IPHONE
 #import "UIImage+MGLAdditions.h"
@@ -615,8 +616,11 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
         coordinateBounds = MGLLatLngBoundsFromCoordinateBounds(options.coordinateBounds);
     }
     
+    // App-global configuration
+    MGLRendererConfiguration* config = [MGLRendererConfiguration currentConfiguration];
+    
     // Create the snapshotter
-    _mbglMapSnapshotter = std::make_unique<mbgl::MapSnapshotter>(mbglFileSource, _mbglThreadPool, style, size, pixelRatio, cameraOptions, coordinateBounds);
+    _mbglMapSnapshotter = std::make_unique<mbgl::MapSnapshotter>(mbglFileSource, _mbglThreadPool, style, size, pixelRatio, cameraOptions, coordinateBounds, config.cacheDir, config.localFontFamilyName);
 }
 
 @end

--- a/platform/default/mbgl/map/map_snapshotter.cpp
+++ b/platform/default/mbgl/map/map_snapshotter.cpp
@@ -20,7 +20,8 @@ public:
          const float pixelRatio,
          const optional<CameraOptions> cameraOptions,
          const optional<LatLngBounds> region,
-         const optional<std::string> programCacheDir);
+         const optional<std::string> programCacheDir,
+         const optional<std::string> localFontFamily = {});
 
     void setStyleURL(std::string styleURL);
     std::string getStyleURL() const;
@@ -52,9 +53,10 @@ MapSnapshotter::Impl::Impl(FileSource* fileSource,
            const float pixelRatio,
            const optional<CameraOptions> cameraOptions,
            const optional<LatLngBounds> region,
-           const optional<std::string> programCacheDir)
+           const optional<std::string> programCacheDir,
+           const optional<std::string> localFontFamily)
     : scheduler(std::move(scheduler_))
-    , frontend(size, pixelRatio, *fileSource, *scheduler, programCacheDir)
+    , frontend(size, pixelRatio, *fileSource, *scheduler, programCacheDir, GLContextMode::Unique, localFontFamily)
     , map(frontend, MapObserver::nullObserver(), size, pixelRatio, *fileSource, *scheduler, MapMode::Static) {
 
     if (style.first) {
@@ -168,8 +170,9 @@ MapSnapshotter::MapSnapshotter(FileSource* fileSource,
                                const float pixelRatio,
                                const optional<CameraOptions> cameraOptions,
                                const optional<LatLngBounds> region,
-                               const optional<std::string> programCacheDir)
-   : impl(std::make_unique<util::Thread<MapSnapshotter::Impl>>("Map Snapshotter", fileSource, std::move(scheduler), style, size, pixelRatio, cameraOptions, region, programCacheDir)) {
+                               const optional<std::string> programCacheDir,
+                               const optional<std::string> localFontFamily)
+   : impl(std::make_unique<util::Thread<MapSnapshotter::Impl>>("Map Snapshotter", fileSource, std::move(scheduler), style, size, pixelRatio, cameraOptions, region, programCacheDir, localFontFamily)) {
 }
 
 MapSnapshotter::~MapSnapshotter() = default;

--- a/platform/default/mbgl/map/map_snapshotter.hpp
+++ b/platform/default/mbgl/map/map_snapshotter.hpp
@@ -32,7 +32,8 @@ public:
                    const float pixelRatio,
                    const optional<CameraOptions> cameraOptions,
                    const optional<LatLngBounds> region,
-                   const optional<std::string> cacheDir = {});
+                   const optional<std::string> cacheDir = {},
+                   const optional<std::string> localFontFamily = {});
 
     ~MapSnapshotter();
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## master
+* `MGLMapSnapshotter` now follows "MGLIdeographicFontFamilyName" app setting to reduce font data usage while snapshotting CJK maps [#13427](https://github.com/mapbox/mapbox-gl-native/pull/13427)
+
 ## 4.7.0
 
 * Fixed an issue where the `{prefix}` token in tile URL templates was evaluated incorrectly when requesting a source’s tiles. ([#13429](https://github.com/mapbox/mapbox-gl-native/pull/13429))

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+* `MGLMapSnapshotter` now follows "MGLIdeographicFontFamilyName" app setting to reduce font data usage while snapshotting CJK maps [#13427](https://github.com/mapbox/mapbox-gl-native/pull/13427)
 * Fixed an issue where the `{prefix}` token in tile URL templates was evaluated incorrectly when requesting a source’s tiles. ([#13429](https://github.com/mapbox/mapbox-gl-native/pull/13429))
 * Added `-[MGLStyle removeSource:error:]` that returns a `BOOL` indicating success (and an optional `NSError` in case of failure). ([#13399](https://github.com/mapbox/mapbox-gl-native/pull/13399))
 * Added support for setting `MGLCollisionBehaviorPre4_0` in `NSUserDefaults`. ([#13426](https://github.com/mapbox/mapbox-gl-native/pull/13426))


### PR DESCRIPTION
The core part of this PR exposes a "local ideograph font family" option on `MapSnapshotter` and passes it through to the underlying renderer.

The darwin implementation picks up the `localFontFamilyName` that's already read out of the application bundle by `MGLRendererConfiguration`. I tested this manually in the macosapp, using a breakpoint to ensure that local fonts were being used during snapshot generation.

The Android implementation is more of a guess: I added `localIdeographFontFamily` as an option in `MapSnapshotter::Options` and hooked it up to the underlying core snapshotter. This seemed closest to the way the rest of the configuration works, but it is unfortunate that it requires the user to pay attention and set the value every time they create a `MapSnapshotter`. This might be less of an issue if we change the default value to be enabled. @LukasPaczos or @tobrun I could use input on what you think is the right way to do this. Also I haven't tested at all yet because my Android debug environment is messed up.

This continues to be an area with poor test coverage. 😞 The problem is that the behavior is inherently inconsistent between machines.

cc @lloydsheng @chriswu42 @LukasPaczos @julianrex 