### PR TITLE
Fix too-short {prefix} evaluation

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Mapbox welcomes participation and contributions from everyone.  If you'd like to do so please see the [`Contributing Guide`](https://github.com/mapbox/mapbox-gl-native/blob/master/CONTRIBUTING.md) first to get started.
 
+## 7.0.0-alpha.2
+ - Fixed `{prefix}` in tile resource URLs [#13429](https://github.com/mapbox/mapbox-gl-native/pull/13429)
+
 ## 6.7.1 - November 16, 2018
  - Telemetry v3.5.4 [#13330](https://github.com/mapbox/mapbox-gl-native/pull/13330)
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ## 4.7.0
 
+* Fixed an issue where the `{prefix}` token in tile URL templates was evaluated incorrectly when requesting a source’s tiles. ([#13429](https://github.com/mapbox/mapbox-gl-native/pull/13429))
 * Renamed `-[MGLOfflineStorage putResourceWithUrl:data:modified:expires:etag:mustRevalidate:]` to `-[MGLOfflineStorage preloadData:forURL:modificationDate:expirationDate:eTag:mustRevalidate:]`. ([#13318](https://github.com/mapbox/mapbox-gl-native/pull/13318))
 * Fixed sporadic crash when using `MGLMapSnapshotter`. ([#13300](https://github.com/mapbox/mapbox-gl-native/pull/13300))
 * Added `MGLLoggingConfiguration` and `MGLLoggingBlockHandler` that handle error and fault events produced by the SDK. ([#13235](https://github.com/mapbox/mapbox-gl-native/pull/13235))

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+* Fixed an issue where the `{prefix}` token in tile URL templates was evaluated incorrectly when requesting a source’s tiles. ([#13429](https://github.com/mapbox/mapbox-gl-native/pull/13429))
 * Added `-[MGLStyle removeSource:error:]` that returns a `BOOL` indicating success (and an optional `NSError` in case of failure). ([#13399](https://github.com/mapbox/mapbox-gl-native/pull/13399))
 
 ## 0.12.0 - November 8, 2018

--- a/src/mbgl/storage/resource.cpp
+++ b/src/mbgl/storage/resource.cpp
@@ -123,10 +123,10 @@ Resource Resource::tile(const std::string& urlTemplate,
             } else if (token == "bbox-epsg-3857") {
                 return getTileBBox(x, y, z);
             } else if (token == "prefix") {
-                std::string prefix{ 2 };
-                prefix[0] = "0123456789abcdef"[x % 16];
-                prefix[1] = "0123456789abcdef"[y % 16];
-                return prefix;
+                return {{
+                    "0123456789abcdef"[x % 16],
+                    "0123456789abcdef"[y % 16],
+                }};
             } else if (token == "ratio") {
                 return std::string(pixelRatio > 1.0 ? "@2x" : "");
             } else {

--- a/test/storage/resource.test.cpp
+++ b/test/storage/resource.test.cpp
@@ -28,10 +28,10 @@ TEST(Resource, Tile) {
     EXPECT_EQ(2, rasterTile.tileData->y);
     EXPECT_EQ(3, rasterTile.tileData->z);
 
-    Resource vectorTile = Resource::tile("http://example.com/{z}/{x}/{y}.mvt", 2.0, 1, 2, 3, Tileset::Scheme::XYZ);
+    Resource vectorTile = Resource::tile("http://example.com/{prefix}/{z}/{x}/{y}.mvt", 2.0, 1, 2, 3, Tileset::Scheme::XYZ);
     EXPECT_EQ(Resource::Kind::Tile, vectorTile.kind);
-    EXPECT_EQ("http://example.com/3/1/2.mvt", vectorTile.url);
-    EXPECT_EQ("http://example.com/{z}/{x}/{y}.mvt", vectorTile.tileData->urlTemplate);
+    EXPECT_EQ("http://example.com/12/3/1/2.mvt", vectorTile.url);
+    EXPECT_EQ("http://example.com/{prefix}/{z}/{x}/{y}.mvt", vectorTile.tileData->urlTemplate);
     EXPECT_EQ(1, vectorTile.tileData->pixelRatio);
     EXPECT_EQ(1, vectorTile.tileData->x);
     EXPECT_EQ(2, vectorTile.tileData->y);


### PR DESCRIPTION
Fixed an issue where the `{prefix}` token in tile URL templates was evaluated incorrectly when requesting a source’s tiles. The prefix ended up being one character long, even though it should be two characters long ([compare with GL JS](https://github.com/mapbox/mapbox-gl-js/blob/cedefd66f6519f20b9f73a1389e02afa868ca39f/src/source/tile_id.js#L37)):

https://github.com/mapbox/mapbox-gl-native/blob/53bbf9d6991c1eddfa141ddcfb4b7252874e46ec/platform/darwin/docs/guides/Tile%20URL%20Templates.md.ejs#L100-L102

This appears to have been an attempt to use the `std::string` fill constructor, but it ended up creating a one-character-long string consisting of [␂](https://en.wikipedia.org/wiki/^B) and attempting to overwrite the null terminator, which resulted in a one-character-long prefix and a tile that couldn’t be found.

/cc @kkaefer @tobrun