### PR TITLE
Updated Info.plist docs.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,11 @@
 # iOS
 /platform/ios/ @mapbox/maps-ios-reviewers
+/platform/ios/docs/ @mapbox/docs
 
 # macOS
 /platform/macos/ @1ec5 @mapbox/maps-ios-reviewers
+/platform/macos/docs @mapbox/docs
+
 
 # Darwin
 /platform/darwin/ @1ec5 @mapbox/maps-ios-reviewers

--- a/platform/ios/docs/guides/Info.plist Keys.md
+++ b/platform/ios/docs/guides/Info.plist Keys.md
@@ -29,3 +29,5 @@ The name of the font family to use for client-side text rendering of CJK ideogra
  If this key is set to YES (`true`), collision detection is performed only between symbol style layers based on the same source, as in versions 2.0–3.7 of the Mapbox Maps SDK for iOS. In other words, symbols in an `MGLSymbolStyleLayer` based on one source (for example, an `MGLShapeSource`) may overlap with symbols in another layer that is based on a different source (such as the Mapbox Streets source). This is the case regardless of the `MGLSymbolStyleLayer.iconAllowsOverlap`, `MGLSymbolStyleLayer.iconIgnoresPlacement`, `MGLSymbolStyleLayer.textAllowsOverlap`, and `MGLSymbolStyleLayer.textIgnoresPlacement` properties.
 
 Beginning in version 4.0, the SDK also performs collision detection between style layers based on different sources by default. For the default behavior, omit the `MGLCollisionBehaviorPre4_0` key or set it to NO (`false`).
+
+This property may also be set using `[[NSUserDefaults standardUserDefaults] setObject:@(YES) forKey:@"MGLCollisionBehaviorPre4_0"]`; it will override any value specified in the `Info.plist`.


### PR DESCRIPTION
Updated to reference support for `MGLCollisionBehaviorPre4_0` via `NSUserDefaults.standardUserDefaults`.

See https://github.com/mapbox/mapbox-gl-native/pull/13426.

Also adds @mapbox/docs to the CODEOWNERS file for the docs paths.