### PR TITLE
[core] Add Style::setPersistentTransitionOptions

### DIFF
--- a/include/mbgl/style/style.hpp
+++ b/include/mbgl/style/style.hpp
@@ -3,6 +3,7 @@
 #include <mbgl/style/transition_options.hpp>
 #include <mbgl/map/camera.hpp>
 #include <mbgl/util/geo.hpp>
+#include <mbgl/util/optional.hpp>
 
 #include <string>
 #include <vector>
@@ -38,6 +39,9 @@ public:
     // TransitionOptions
     TransitionOptions getTransitionOptions() const;
     void setTransitionOptions(const TransitionOptions&);
+
+    // Overrides style or runtime-defined transition options. This is meant to persist between style changes.
+    void setPersistentTransitionOptions(optional<TransitionOptions>);
 
     // Light
           Light* getLight();

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -47,6 +47,11 @@ void Style::setTransitionOptions(const TransitionOptions& options) {
     impl->setTransitionOptions(options);
 }
 
+void Style::setPersistentTransitionOptions(optional<TransitionOptions> options) {
+    impl->mutated = true;
+    impl->setPersistentTransitionOptions(options);
+}
+
 void Style::setLight(std::unique_ptr<Light> light) {
     impl->setLight(std::move(light));
 }

--- a/src/mbgl/style/style_impl.cpp
+++ b/src/mbgl/style/style_impl.cpp
@@ -130,8 +130,12 @@ void Style::Impl::setTransitionOptions(const TransitionOptions& options) {
     transitionOptions = options;
 }
 
+void Style::Impl::setPersistentTransitionOptions(optional<TransitionOptions> options) {
+    persistentTransitionOptions = options;
+}
+
 TransitionOptions Style::Impl::getTransitionOptions() const {
-    return transitionOptions;
+    return persistentTransitionOptions.value_or(transitionOptions);
 }
 
 void Style::Impl::addSource(std::unique_ptr<Source> source) {

--- a/src/mbgl/style/style_impl.hpp
+++ b/src/mbgl/style/style_impl.hpp
@@ -75,6 +75,7 @@ public:
 
     TransitionOptions getTransitionOptions() const;
     void setTransitionOptions(const TransitionOptions&);
+    void setPersistentTransitionOptions(optional<TransitionOptions>);
 
     void setLight(std::unique_ptr<Light>);
     Light* getLight() const;
@@ -112,6 +113,7 @@ private:
     Collection<Source> sources;
     Collection<Layer> layers;
     TransitionOptions transitionOptions;
+    optional<TransitionOptions> persistentTransitionOptions;
     std::unique_ptr<Light> light;
 
     // Defaults

--- a/test/style/style.test.cpp
+++ b/test/style/style.test.cpp
@@ -43,6 +43,13 @@ TEST(Style, Properties) {
     ASSERT_EQ("", style.getName());
     ASSERT_EQ(60, *style.getDefaultCamera().pitch);
 
+    const TransitionOptions immediateOptions { { Milliseconds(0) }, { Milliseconds(0) } };
+    style.setPersistentTransitionOptions(immediateOptions);
+    style.loadJSON(R"STYLE({"transition": { "duration": 500, "delay": 50 }})STYLE");
+    ASSERT_EQ(Milliseconds(0), *style.getTransitionOptions().duration);
+    ASSERT_EQ(Milliseconds(0), *style.getTransitionOptions().delay);
+
+    style.setPersistentTransitionOptions({});
     style.loadJSON(R"STYLE({})STYLE");
     ASSERT_EQ(Milliseconds(300), *style.getTransitionOptions().duration);
     ASSERT_EQ(optional<Duration> {}, style.getTransitionOptions().delay);


### PR DESCRIPTION
A follow-up to https://github.com/mapbox/mapbox-gl-native/pull/13035 - this adds a new style setter for optional persistent transition options. Style or runtime-defined transition options are reset whenever the style changes. Thus, this allows transition options to persist in such cases.

This is especially useful when transitioning between styles (and we want to avoid e.g. fade-in/fade-out of symbol objects), and on special cases where we want to always override the style-defined or the runtime-defined transition options.

