### PR TITLE
[core][Android][Darwin] LayerManager creates RenderLayer instances

### DIFF
--- a/include/mbgl/style/layers/background_layer.hpp
+++ b/include/mbgl/style/layers/background_layer.hpp
@@ -56,15 +56,13 @@ protected:
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
-class BackgroundLayerFactory : public LayerFactory {
-public:
-    BackgroundLayerFactory();
-    ~BackgroundLayerFactory() override;
+} // namespace style
 
-    // LayerFactory overrides.
-    const LayerTypeInfo* getTypeInfo() const noexcept final;
-    std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
+class BackgroundLayerFactory : public LayerFactory {
+protected:
+    const style::LayerTypeInfo* getTypeInfo() const noexcept final;
+    std::unique_ptr<style::Layer> createLayer(const std::string& id, const style::conversion::Convertible& value) noexcept final;
+    std::unique_ptr<RenderLayer> createRenderLayer(Immutable<style::Layer::Impl>) noexcept final;
 };
 
-} // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/layers/circle_layer.hpp
+++ b/include/mbgl/style/layers/circle_layer.hpp
@@ -104,15 +104,13 @@ protected:
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
-class CircleLayerFactory : public LayerFactory {
-public:
-    CircleLayerFactory();
-    ~CircleLayerFactory() override;
+} // namespace style
 
-    // LayerFactory overrides.
-    const LayerTypeInfo* getTypeInfo() const noexcept final;
-    std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
+class CircleLayerFactory : public LayerFactory {
+protected:
+    const style::LayerTypeInfo* getTypeInfo() const noexcept final;
+    std::unique_ptr<style::Layer> createLayer(const std::string& id, const style::conversion::Convertible& value) noexcept final;
+    std::unique_ptr<RenderLayer> createRenderLayer(Immutable<style::Layer::Impl>) noexcept final;
 };
 
-} // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/layers/custom_layer.hpp
+++ b/include/mbgl/style/layers/custom_layer.hpp
@@ -85,15 +85,13 @@ public:
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
-class CustomLayerFactory : public LayerFactory {
-public:
-    CustomLayerFactory();
-    // LayerFactory overrides.
-    ~CustomLayerFactory() override;
+} // namespace style
 
-    const LayerTypeInfo* getTypeInfo() const noexcept final;
-    std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
+class CustomLayerFactory : public LayerFactory {
+    // LayerFactory overrides.
+    const style::LayerTypeInfo* getTypeInfo() const noexcept final;
+    std::unique_ptr<style::Layer> createLayer(const std::string& id, const style::conversion::Convertible& value) noexcept final;
+    std::unique_ptr<RenderLayer> createRenderLayer(Immutable<style::Layer::Impl>) noexcept final;
 };
 
-} // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/layers/fill_extrusion_layer.hpp
+++ b/include/mbgl/style/layers/fill_extrusion_layer.hpp
@@ -80,15 +80,13 @@ protected:
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
-class FillExtrusionLayerFactory : public LayerFactory {
-public:
-    FillExtrusionLayerFactory();
-    ~FillExtrusionLayerFactory() override;
+} // namespace style
 
-    // LayerFactory overrides.
-    const LayerTypeInfo* getTypeInfo() const noexcept final;
-    std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
+class FillExtrusionLayerFactory : public LayerFactory {
+protected:
+    const style::LayerTypeInfo* getTypeInfo() const noexcept final;
+    std::unique_ptr<style::Layer> createLayer(const std::string& id, const style::conversion::Convertible& value) noexcept final;
+    std::unique_ptr<RenderLayer> createRenderLayer(Immutable<style::Layer::Impl>) noexcept final;
 };
 
-} // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/layers/fill_layer.hpp
+++ b/include/mbgl/style/layers/fill_layer.hpp
@@ -80,15 +80,13 @@ protected:
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
-class FillLayerFactory : public LayerFactory {
-public:
-    FillLayerFactory();
-    ~FillLayerFactory() override;
+} // namespace style
 
-    // LayerFactory overrides.
-    const LayerTypeInfo* getTypeInfo() const noexcept final;
-    std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
+class FillLayerFactory : public LayerFactory {
+protected:
+    const style::LayerTypeInfo* getTypeInfo() const noexcept final;
+    std::unique_ptr<style::Layer> createLayer(const std::string& id, const style::conversion::Convertible& value) noexcept final;
+    std::unique_ptr<RenderLayer> createRenderLayer(Immutable<style::Layer::Impl>) noexcept final;
 };
 
-} // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/layers/heatmap_layer.hpp
+++ b/include/mbgl/style/layers/heatmap_layer.hpp
@@ -69,15 +69,13 @@ protected:
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
-class HeatmapLayerFactory : public LayerFactory {
-public:
-    HeatmapLayerFactory();
-    ~HeatmapLayerFactory() override;
+} // namespace style
 
-    // LayerFactory overrides.
-    const LayerTypeInfo* getTypeInfo() const noexcept final;
-    std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
+class HeatmapLayerFactory : public LayerFactory {
+protected:
+    const style::LayerTypeInfo* getTypeInfo() const noexcept final;
+    std::unique_ptr<style::Layer> createLayer(const std::string& id, const style::conversion::Convertible& value) noexcept final;
+    std::unique_ptr<RenderLayer> createRenderLayer(Immutable<style::Layer::Impl>) noexcept final;
 };
 
-} // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/layers/hillshade_layer.hpp
+++ b/include/mbgl/style/layers/hillshade_layer.hpp
@@ -74,15 +74,13 @@ protected:
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
-class HillshadeLayerFactory : public LayerFactory {
-public:
-    HillshadeLayerFactory();
-    ~HillshadeLayerFactory() override;
+} // namespace style
 
-    // LayerFactory overrides.
-    const LayerTypeInfo* getTypeInfo() const noexcept final;
-    std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
+class HillshadeLayerFactory : public LayerFactory {
+protected:
+    const style::LayerTypeInfo* getTypeInfo() const noexcept final;
+    std::unique_ptr<style::Layer> createLayer(const std::string& id, const style::conversion::Convertible& value) noexcept final;
+    std::unique_ptr<RenderLayer> createRenderLayer(Immutable<style::Layer::Impl>) noexcept final;
 };
 
-} // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/layers/layer.hpp.ejs
+++ b/include/mbgl/style/layers/layer.hpp.ejs
@@ -72,15 +72,13 @@ protected:
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
-class <%- camelize(type) %>LayerFactory : public LayerFactory {
-public:
-    <%- camelize(type) %>LayerFactory();
-    ~<%- camelize(type) %>LayerFactory() override;
+} // namespace style
 
-    // LayerFactory overrides.
-    const LayerTypeInfo* getTypeInfo() const noexcept final;
-    std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
+class <%- camelize(type) %>LayerFactory : public LayerFactory {
+protected:
+    const style::LayerTypeInfo* getTypeInfo() const noexcept final;
+    std::unique_ptr<style::Layer> createLayer(const std::string& id, const style::conversion::Convertible& value) noexcept final;
+    std::unique_ptr<RenderLayer> createRenderLayer(Immutable<style::Layer::Impl>) noexcept final;
 };
 
-} // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/layers/line_layer.hpp
+++ b/include/mbgl/style/layers/line_layer.hpp
@@ -125,15 +125,13 @@ protected:
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
-class LineLayerFactory : public LayerFactory {
-public:
-    LineLayerFactory();
-    ~LineLayerFactory() override;
+} // namespace style
 
-    // LayerFactory overrides.
-    const LayerTypeInfo* getTypeInfo() const noexcept final;
-    std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
+class LineLayerFactory : public LayerFactory {
+protected:
+    const style::LayerTypeInfo* getTypeInfo() const noexcept final;
+    std::unique_ptr<style::Layer> createLayer(const std::string& id, const style::conversion::Convertible& value) noexcept final;
+    std::unique_ptr<RenderLayer> createRenderLayer(Immutable<style::Layer::Impl>) noexcept final;
 };
 
-} // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/layers/raster_layer.hpp
+++ b/include/mbgl/style/layers/raster_layer.hpp
@@ -86,15 +86,13 @@ protected:
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
-class RasterLayerFactory : public LayerFactory {
-public:
-    RasterLayerFactory();
-    ~RasterLayerFactory() override;
+} // namespace style
 
-    // LayerFactory overrides.
-    const LayerTypeInfo* getTypeInfo() const noexcept final;
-    std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
+class RasterLayerFactory : public LayerFactory {
+protected:
+    const style::LayerTypeInfo* getTypeInfo() const noexcept final;
+    std::unique_ptr<style::Layer> createLayer(const std::string& id, const style::conversion::Convertible& value) noexcept final;
+    std::unique_ptr<RenderLayer> createRenderLayer(Immutable<style::Layer::Impl>) noexcept final;
 };
 
-} // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/layers/symbol_layer.hpp
+++ b/include/mbgl/style/layers/symbol_layer.hpp
@@ -274,15 +274,13 @@ protected:
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 
-class SymbolLayerFactory : public LayerFactory {
-public:
-    SymbolLayerFactory();
-    ~SymbolLayerFactory() override;
+} // namespace style
 
-    // LayerFactory overrides.
-    const LayerTypeInfo* getTypeInfo() const noexcept final;
-    std::unique_ptr<style::Layer> createLayer(const std::string& id, const conversion::Convertible& value) final;
+class SymbolLayerFactory : public LayerFactory {
+protected:
+    const style::LayerTypeInfo* getTypeInfo() const noexcept final;
+    std::unique_ptr<style::Layer> createLayer(const std::string& id, const style::conversion::Convertible& value) noexcept final;
+    std::unique_ptr<RenderLayer> createRenderLayer(Immutable<style::Layer::Impl>) noexcept final;
 };
 
-} // namespace style
 } // namespace mbgl

--- a/platform/android/src/style/layers/background_layer.hpp
+++ b/platform/android/src/style/layers/background_layer.hpp
@@ -39,7 +39,7 @@ public:
 
 }; // class BackgroundLayer
 
-class BackgroundJavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::style::BackgroundLayerFactory {
+class BackgroundJavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::BackgroundLayerFactory {
 public:
     ~BackgroundJavaLayerPeerFactory() override;
 
@@ -49,7 +49,7 @@ public:
 
     void registerNative(jni::JNIEnv&) final;
 
-    style::LayerFactory* getLayerFactory() final { return this; }
+    LayerFactory* getLayerFactory() final { return this; }
 
 };  // class BackgroundJavaLayerPeerFactory
 

--- a/platform/android/src/style/layers/circle_layer.hpp
+++ b/platform/android/src/style/layers/circle_layer.hpp
@@ -65,7 +65,7 @@ public:
 
 }; // class CircleLayer
 
-class CircleJavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::style::CircleLayerFactory {
+class CircleJavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::CircleLayerFactory {
 public:
     ~CircleJavaLayerPeerFactory() override;
 
@@ -75,7 +75,7 @@ public:
 
     void registerNative(jni::JNIEnv&) final;
 
-    style::LayerFactory* getLayerFactory() final { return this; }
+    LayerFactory* getLayerFactory() final { return this; }
 
 };  // class CircleJavaLayerPeerFactory
 

--- a/platform/android/src/style/layers/custom_layer.hpp
+++ b/platform/android/src/style/layers/custom_layer.hpp
@@ -25,7 +25,7 @@ public:
 
 }; // class CustomLayer
 
-class CustomJavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::style::CustomLayerFactory {
+class CustomJavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::CustomLayerFactory {
 public:
     ~CustomJavaLayerPeerFactory() override;
 
@@ -35,7 +35,7 @@ public:
 
     void registerNative(jni::JNIEnv&) final;
 
-    style::LayerFactory* getLayerFactory() final { return this; }
+    LayerFactory* getLayerFactory() final { return this; }
 
 };  // class CustomJavaLayerPeerFactory
 

--- a/platform/android/src/style/layers/fill_extrusion_layer.hpp
+++ b/platform/android/src/style/layers/fill_extrusion_layer.hpp
@@ -53,7 +53,7 @@ public:
 
 }; // class FillExtrusionLayer
 
-class FillExtrusionJavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::style::FillExtrusionLayerFactory {
+class FillExtrusionJavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::FillExtrusionLayerFactory {
 public:
     ~FillExtrusionJavaLayerPeerFactory() override;
 
@@ -63,7 +63,7 @@ public:
 
     void registerNative(jni::JNIEnv&) final;
 
-    style::LayerFactory* getLayerFactory() final { return this; }
+    LayerFactory* getLayerFactory() final { return this; }
 
 };  // class FillExtrusionJavaLayerPeerFactory
 

--- a/platform/android/src/style/layers/fill_layer.hpp
+++ b/platform/android/src/style/layers/fill_layer.hpp
@@ -51,7 +51,7 @@ public:
 
 }; // class FillLayer
 
-class FillJavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::style::FillLayerFactory {
+class FillJavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::FillLayerFactory {
 public:
     ~FillJavaLayerPeerFactory() override;
 
@@ -61,7 +61,7 @@ public:
 
     void registerNative(jni::JNIEnv&) final;
 
-    style::LayerFactory* getLayerFactory() final { return this; }
+    LayerFactory* getLayerFactory() final { return this; }
 
 };  // class FillJavaLayerPeerFactory
 

--- a/platform/android/src/style/layers/heatmap_layer.hpp
+++ b/platform/android/src/style/layers/heatmap_layer.hpp
@@ -43,7 +43,7 @@ public:
 
 }; // class HeatmapLayer
 
-class HeatmapJavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::style::HeatmapLayerFactory {
+class HeatmapJavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::HeatmapLayerFactory {
 public:
     ~HeatmapJavaLayerPeerFactory() override;
 
@@ -53,7 +53,7 @@ public:
 
     void registerNative(jni::JNIEnv&) final;
 
-    style::LayerFactory* getLayerFactory() final { return this; }
+    LayerFactory* getLayerFactory() final { return this; }
 
 };  // class HeatmapJavaLayerPeerFactory
 

--- a/platform/android/src/style/layers/hillshade_layer.hpp
+++ b/platform/android/src/style/layers/hillshade_layer.hpp
@@ -47,7 +47,7 @@ public:
 
 }; // class HillshadeLayer
 
-class HillshadeJavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::style::HillshadeLayerFactory {
+class HillshadeJavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::HillshadeLayerFactory {
 public:
     ~HillshadeJavaLayerPeerFactory() override;
 
@@ -57,7 +57,7 @@ public:
 
     void registerNative(jni::JNIEnv&) final;
 
-    style::LayerFactory* getLayerFactory() final { return this; }
+    LayerFactory* getLayerFactory() final { return this; }
 
 };  // class HillshadeJavaLayerPeerFactory
 

--- a/platform/android/src/style/layers/layer.hpp
+++ b/platform/android/src/style/layers/layer.hpp
@@ -117,7 +117,7 @@ public:
      * 
      * @return style::LayerFactory* must not be \c nullptr.
      */
-    virtual style::LayerFactory* getLayerFactory() = 0;
+    virtual LayerFactory* getLayerFactory() = 0;
 };
 
 

--- a/platform/android/src/style/layers/layer.hpp.ejs
+++ b/platform/android/src/style/layers/layer.hpp.ejs
@@ -43,7 +43,7 @@ public:
 
 }; // class <%- camelize(type) %>Layer
 
-class <%- camelize(type) %>JavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::style::<%- camelize(type) %>LayerFactory {
+class <%- camelize(type) %>JavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::<%- camelize(type) %>LayerFactory {
 public:
     ~<%- camelize(type) %>JavaLayerPeerFactory() override;
 
@@ -53,7 +53,7 @@ public:
 
     void registerNative(jni::JNIEnv&) final;
 
-    style::LayerFactory* getLayerFactory() final { return this; }
+    LayerFactory* getLayerFactory() final { return this; }
 
 };  // class <%- camelize(type) %>JavaLayerPeerFactory
 

--- a/platform/android/src/style/layers/layer_manager.hpp
+++ b/platform/android/src/style/layers/layer_manager.hpp
@@ -3,6 +3,8 @@
 #include <mbgl/map/map.hpp>
 #include <mbgl/style/layer.hpp>
 
+#include <mbgl/renderer/render_layer.hpp>
+
 #include "layer.hpp"
 
 #include <jni/jni.hpp>
@@ -16,9 +18,9 @@ namespace android {
 /**
  * @brief A singleton class forwarding calls to the corresponding  \c JavaLayerPeerFactory instance.
  */
-class LayerManagerAndroid : public mbgl::style::LayerManager {
+class LayerManagerAndroid final : public mbgl::LayerManager {
 public:
-    ~LayerManagerAndroid() override;
+    ~LayerManagerAndroid() final;
     static LayerManagerAndroid* get() noexcept;
     
     jni::Local<jni::Object<Layer>> createJavaLayerPeer(jni::JNIEnv&, mbgl::Map&, mbgl::style::Layer&);
@@ -29,13 +31,14 @@ public:
 private:
     LayerManagerAndroid();
     void addLayerType(std::unique_ptr<JavaLayerPeerFactory>);
-    JavaLayerPeerFactory* getPeerFactory(mbgl::style::Layer*);
-    // mbgl:style::LayerManager overrides.
-    std::unique_ptr<style::Layer> createLayer(const std::string& type, const std::string& id, const style::conversion::Convertible& value, style::conversion::Error& error) noexcept final;
+    JavaLayerPeerFactory* getPeerFactory(const mbgl::style::LayerTypeInfo*);
+    // mbgl::LayerManager overrides.
+    LayerFactory* getFactory(const std::string& type) noexcept final;
+    LayerFactory* getFactory(const mbgl::style::LayerTypeInfo* info) noexcept final;
 
     std::vector<std::unique_ptr<JavaLayerPeerFactory>> factories;
-    std::map<std::string, style::LayerFactory*> typeToFactory;
+    std::map<std::string, mbgl::LayerFactory*> typeToFactory;
 };
 
-}
-}
+}  // namespace android
+}  // namespace mbgl

--- a/platform/android/src/style/layers/line_layer.hpp
+++ b/platform/android/src/style/layers/line_layer.hpp
@@ -75,7 +75,7 @@ public:
 
 }; // class LineLayer
 
-class LineJavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::style::LineLayerFactory {
+class LineJavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::LineLayerFactory {
 public:
     ~LineJavaLayerPeerFactory() override;
 
@@ -85,7 +85,7 @@ public:
 
     void registerNative(jni::JNIEnv&) final;
 
-    style::LayerFactory* getLayerFactory() final { return this; }
+    LayerFactory* getLayerFactory() final { return this; }
 
 };  // class LineJavaLayerPeerFactory
 

--- a/platform/android/src/style/layers/raster_layer.hpp
+++ b/platform/android/src/style/layers/raster_layer.hpp
@@ -55,7 +55,7 @@ public:
 
 }; // class RasterLayer
 
-class RasterJavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::style::RasterLayerFactory {
+class RasterJavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::RasterLayerFactory {
 public:
     ~RasterJavaLayerPeerFactory() override;
 
@@ -65,7 +65,7 @@ public:
 
     void registerNative(jni::JNIEnv&) final;
 
-    style::LayerFactory* getLayerFactory() final { return this; }
+    LayerFactory* getLayerFactory() final { return this; }
 
 };  // class RasterJavaLayerPeerFactory
 

--- a/platform/android/src/style/layers/symbol_layer.hpp
+++ b/platform/android/src/style/layers/symbol_layer.hpp
@@ -153,7 +153,7 @@ public:
 
 }; // class SymbolLayer
 
-class SymbolJavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::style::SymbolLayerFactory {
+class SymbolJavaLayerPeerFactory final : public JavaLayerPeerFactory,  public mbgl::SymbolLayerFactory {
 public:
     ~SymbolJavaLayerPeerFactory() override;
 
@@ -163,7 +163,7 @@ public:
 
     void registerNative(jni::JNIEnv&) final;
 
-    style::LayerFactory* getLayerFactory() final { return this; }
+    LayerFactory* getLayerFactory() final { return this; }
 
 };  // class SymbolJavaLayerPeerFactory
 

--- a/platform/darwin/src/MGLBackgroundStyleLayer_Private.h
+++ b/platform/darwin/src/MGLBackgroundStyleLayer_Private.h
@@ -8,9 +8,9 @@
 
 namespace mbgl {
 
-class BackgroundStyleLayerPeerFactory : public LayerPeerFactory, public mbgl::style::BackgroundLayerFactory {
+class BackgroundStyleLayerPeerFactory : public LayerPeerFactory, public mbgl::BackgroundLayerFactory {
     // LayerPeerFactory overrides.
-    style::LayerFactory* getCoreLayerFactory() final { return this; }
+    LayerFactory* getCoreLayerFactory() final { return this; }
     virtual MGLStyleLayer* createPeer(style::Layer*) final;
 };
 

--- a/platform/darwin/src/MGLCircleStyleLayer_Private.h
+++ b/platform/darwin/src/MGLCircleStyleLayer_Private.h
@@ -8,9 +8,9 @@
 
 namespace mbgl {
 
-class CircleStyleLayerPeerFactory : public LayerPeerFactory, public mbgl::style::CircleLayerFactory {
+class CircleStyleLayerPeerFactory : public LayerPeerFactory, public mbgl::CircleLayerFactory {
     // LayerPeerFactory overrides.
-    style::LayerFactory* getCoreLayerFactory() final { return this; }
+    LayerFactory* getCoreLayerFactory() final { return this; }
     virtual MGLStyleLayer* createPeer(style::Layer*) final;
 };
 

--- a/platform/darwin/src/MGLFillExtrusionStyleLayer_Private.h
+++ b/platform/darwin/src/MGLFillExtrusionStyleLayer_Private.h
@@ -8,9 +8,9 @@
 
 namespace mbgl {
 
-class FillExtrusionStyleLayerPeerFactory : public LayerPeerFactory, public mbgl::style::FillExtrusionLayerFactory {
+class FillExtrusionStyleLayerPeerFactory : public LayerPeerFactory, public mbgl::FillExtrusionLayerFactory {
     // LayerPeerFactory overrides.
-    style::LayerFactory* getCoreLayerFactory() final { return this; }
+    LayerFactory* getCoreLayerFactory() final { return this; }
     virtual MGLStyleLayer* createPeer(style::Layer*) final;
 };
 

--- a/platform/darwin/src/MGLFillStyleLayer_Private.h
+++ b/platform/darwin/src/MGLFillStyleLayer_Private.h
@@ -8,9 +8,9 @@
 
 namespace mbgl {
 
-class FillStyleLayerPeerFactory : public LayerPeerFactory, public mbgl::style::FillLayerFactory {
+class FillStyleLayerPeerFactory : public LayerPeerFactory, public mbgl::FillLayerFactory {
     // LayerPeerFactory overrides.
-    style::LayerFactory* getCoreLayerFactory() final { return this; }
+    LayerFactory* getCoreLayerFactory() final { return this; }
     virtual MGLStyleLayer* createPeer(style::Layer*) final;
 };
 

--- a/platform/darwin/src/MGLHeatmapStyleLayer_Private.h
+++ b/platform/darwin/src/MGLHeatmapStyleLayer_Private.h
@@ -8,9 +8,9 @@
 
 namespace mbgl {
 
-class HeatmapStyleLayerPeerFactory : public LayerPeerFactory, public mbgl::style::HeatmapLayerFactory {
+class HeatmapStyleLayerPeerFactory : public LayerPeerFactory, public mbgl::HeatmapLayerFactory {
     // LayerPeerFactory overrides.
-    style::LayerFactory* getCoreLayerFactory() final { return this; }
+    LayerFactory* getCoreLayerFactory() final { return this; }
     virtual MGLStyleLayer* createPeer(style::Layer*) final;
 };
 

--- a/platform/darwin/src/MGLHillshadeStyleLayer_Private.h
+++ b/platform/darwin/src/MGLHillshadeStyleLayer_Private.h
@@ -8,9 +8,9 @@
 
 namespace mbgl {
 
-class HillshadeStyleLayerPeerFactory : public LayerPeerFactory, public mbgl::style::HillshadeLayerFactory {
+class HillshadeStyleLayerPeerFactory : public LayerPeerFactory, public mbgl::HillshadeLayerFactory {
     // LayerPeerFactory overrides.
-    style::LayerFactory* getCoreLayerFactory() final { return this; }
+    LayerFactory* getCoreLayerFactory() final { return this; }
     virtual MGLStyleLayer* createPeer(style::Layer*) final;
 };
 

--- a/platform/darwin/src/MGLLineStyleLayer_Private.h
+++ b/platform/darwin/src/MGLLineStyleLayer_Private.h
@@ -8,9 +8,9 @@
 
 namespace mbgl {
 
-class LineStyleLayerPeerFactory : public LayerPeerFactory, public mbgl::style::LineLayerFactory {
+class LineStyleLayerPeerFactory : public LayerPeerFactory, public mbgl::LineLayerFactory {
     // LayerPeerFactory overrides.
-    style::LayerFactory* getCoreLayerFactory() final { return this; }
+    LayerFactory* getCoreLayerFactory() final { return this; }
     virtual MGLStyleLayer* createPeer(style::Layer*) final;
 };
 

--- a/platform/darwin/src/MGLOpenGLStyleLayer_Private.h
+++ b/platform/darwin/src/MGLOpenGLStyleLayer_Private.h
@@ -6,9 +6,9 @@
 
 namespace mbgl {
     
-class OpenGLStyleLayerPeerFactory : public LayerPeerFactory, public mbgl::style::CustomLayerFactory {
+class OpenGLStyleLayerPeerFactory : public LayerPeerFactory, public mbgl::CustomLayerFactory {
     // LayerPeerFactory overrides.
-    style::LayerFactory* getCoreLayerFactory() final { return this; }
+    LayerFactory* getCoreLayerFactory() final { return this; }
     virtual MGLStyleLayer* createPeer(style::Layer*) final;
 };
     

--- a/platform/darwin/src/MGLRasterStyleLayer_Private.h
+++ b/platform/darwin/src/MGLRasterStyleLayer_Private.h
@@ -8,9 +8,9 @@
 
 namespace mbgl {
 
-class RasterStyleLayerPeerFactory : public LayerPeerFactory, public mbgl::style::RasterLayerFactory {
+class RasterStyleLayerPeerFactory : public LayerPeerFactory, public mbgl::RasterLayerFactory {
     // LayerPeerFactory overrides.
-    style::LayerFactory* getCoreLayerFactory() final { return this; }
+    LayerFactory* getCoreLayerFactory() final { return this; }
     virtual MGLStyleLayer* createPeer(style::Layer*) final;
 };
 

--- a/platform/darwin/src/MGLStyleLayerManager.h
+++ b/platform/darwin/src/MGLStyleLayerManager.h
@@ -10,7 +10,7 @@
 
 namespace mbgl {
 
-class LayerManagerDarwin : public style::LayerManager {
+class LayerManagerDarwin : public LayerManager {
 public:
     static LayerManagerDarwin* get() noexcept;
     ~LayerManagerDarwin();
@@ -20,11 +20,13 @@ public:
 private:
     LayerManagerDarwin();
     void addLayerType(std::unique_ptr<LayerPeerFactory>);
-    // LayerManager overrides.
-    std::unique_ptr<style::Layer> createLayer(const std::string& type, const std::string& id, const style::conversion::Convertible& value, style::conversion::Error& error) noexcept final;
-    
+    LayerPeerFactory* getPeerFactory(const style::LayerTypeInfo* typeInfo);
+    // mbgl::LayerManager overrides.
+    LayerFactory* getFactory(const std::string& type) noexcept final;
+    LayerFactory* getFactory(const mbgl::style::LayerTypeInfo* info) noexcept final;
+
     std::vector<std::unique_ptr<LayerPeerFactory>> factories;
-    std::map<std::string, style::LayerFactory*> typeToFactory;
+    std::map<std::string, LayerFactory*> typeToFactory;
 };
     
 }  // namespace mbgl

--- a/platform/darwin/src/MGLStyleLayer_Private.h
+++ b/platform/darwin/src/MGLStyleLayer_Private.h
@@ -90,7 +90,7 @@ public:
     /**
      Get the corresponding core layer factory.
      */
-    virtual style::LayerFactory* getCoreLayerFactory() = 0;
+    virtual LayerFactory* getCoreLayerFactory() = 0;
     /**
      Creates an MGLStyleLayer instance with a raw pointer to the backing store.
      */

--- a/platform/darwin/src/MGLStyleLayer_Private.h.ejs
+++ b/platform/darwin/src/MGLStyleLayer_Private.h.ejs
@@ -15,9 +15,9 @@
 
 namespace mbgl {
 
-class <%- camelize(type) %>StyleLayerPeerFactory : public LayerPeerFactory, public mbgl::style::<%- camelize(type) %>LayerFactory {
+class <%- camelize(type) %>StyleLayerPeerFactory : public LayerPeerFactory, public mbgl::<%- camelize(type) %>LayerFactory {
     // LayerPeerFactory overrides.
-    style::LayerFactory* getCoreLayerFactory() final { return this; }
+    LayerFactory* getCoreLayerFactory() final { return this; }
     virtual MGLStyleLayer* createPeer(style::Layer*) final;
 };
 

--- a/platform/darwin/src/MGLSymbolStyleLayer_Private.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer_Private.h
@@ -8,9 +8,9 @@
 
 namespace mbgl {
 
-class SymbolStyleLayerPeerFactory : public LayerPeerFactory, public mbgl::style::SymbolLayerFactory {
+class SymbolStyleLayerPeerFactory : public LayerPeerFactory, public mbgl::SymbolLayerFactory {
     // LayerPeerFactory overrides.
-    style::LayerFactory* getCoreLayerFactory() final { return this; }
+    LayerFactory* getCoreLayerFactory() final { return this; }
     virtual MGLStyleLayer* createPeer(style::Layer*) final;
 };
 

--- a/platform/darwin/test/MGLBackgroundStyleLayerTests.mm
+++ b/platform/darwin/test/MGLBackgroundStyleLayerTests.mm
@@ -22,7 +22,7 @@
 - (void)testProperties {
     MGLBackgroundStyleLayer *layer = [[MGLBackgroundStyleLayer alloc] initWithIdentifier:@"layerID"];
     XCTAssertNotEqual(layer.rawLayer, nullptr);
-    XCTAssertEqual(layer.rawLayer->getType(), mbgl::style::LayerType::Background);
+    XCTAssertEqualObjects(@(layer.rawLayer->getTypeInfo()->type), @"background");
     auto rawLayer = static_cast<mbgl::style::BackgroundLayer*>(layer.rawLayer);
 
     MGLTransition transitionTest = MGLTransitionMake(5, 4);

--- a/platform/darwin/test/MGLCircleStyleLayerTests.mm
+++ b/platform/darwin/test/MGLCircleStyleLayerTests.mm
@@ -43,7 +43,7 @@
 
     MGLCircleStyleLayer *layer = [[MGLCircleStyleLayer alloc] initWithIdentifier:@"layerID" source:source];
     XCTAssertNotEqual(layer.rawLayer, nullptr);
-    XCTAssertEqual(layer.rawLayer->getType(), mbgl::style::LayerType::Circle);
+    XCTAssertEqualObjects(@(layer.rawLayer->getTypeInfo()->type), @"circle");
     auto rawLayer = static_cast<mbgl::style::CircleLayer*>(layer.rawLayer);
 
     MGLTransition transitionTest = MGLTransitionMake(5, 4);

--- a/platform/darwin/test/MGLFillExtrusionStyleLayerTests.mm
+++ b/platform/darwin/test/MGLFillExtrusionStyleLayerTests.mm
@@ -43,7 +43,7 @@
 
     MGLFillExtrusionStyleLayer *layer = [[MGLFillExtrusionStyleLayer alloc] initWithIdentifier:@"layerID" source:source];
     XCTAssertNotEqual(layer.rawLayer, nullptr);
-    XCTAssertEqual(layer.rawLayer->getType(), mbgl::style::LayerType::FillExtrusion);
+    XCTAssertEqualObjects(@(layer.rawLayer->getTypeInfo()->type), @"fill-extrusion");
     auto rawLayer = static_cast<mbgl::style::FillExtrusionLayer*>(layer.rawLayer);
 
     MGLTransition transitionTest = MGLTransitionMake(5, 4);

--- a/platform/darwin/test/MGLFillStyleLayerTests.mm
+++ b/platform/darwin/test/MGLFillStyleLayerTests.mm
@@ -43,7 +43,7 @@
 
     MGLFillStyleLayer *layer = [[MGLFillStyleLayer alloc] initWithIdentifier:@"layerID" source:source];
     XCTAssertNotEqual(layer.rawLayer, nullptr);
-    XCTAssertEqual(layer.rawLayer->getType(), mbgl::style::LayerType::Fill);
+    XCTAssertEqualObjects(@(layer.rawLayer->getTypeInfo()->type), @"fill");
     auto rawLayer = static_cast<mbgl::style::FillLayer*>(layer.rawLayer);
 
     MGLTransition transitionTest = MGLTransitionMake(5, 4);

--- a/platform/darwin/test/MGLHeatmapStyleLayerTests.mm
+++ b/platform/darwin/test/MGLHeatmapStyleLayerTests.mm
@@ -43,7 +43,7 @@
 
     MGLHeatmapStyleLayer *layer = [[MGLHeatmapStyleLayer alloc] initWithIdentifier:@"layerID" source:source];
     XCTAssertNotEqual(layer.rawLayer, nullptr);
-    XCTAssertEqual(layer.rawLayer->getType(), mbgl::style::LayerType::Heatmap);
+    XCTAssertEqualObjects(@(layer.rawLayer->getTypeInfo()->type), @"heatmap");
     auto rawLayer = static_cast<mbgl::style::HeatmapLayer*>(layer.rawLayer);
 
     MGLTransition transitionTest = MGLTransitionMake(5, 4);

--- a/platform/darwin/test/MGLHillshadeStyleLayerTests.mm
+++ b/platform/darwin/test/MGLHillshadeStyleLayerTests.mm
@@ -25,7 +25,7 @@
 
     MGLHillshadeStyleLayer *layer = [[MGLHillshadeStyleLayer alloc] initWithIdentifier:@"layerID" source:source];
     XCTAssertNotEqual(layer.rawLayer, nullptr);
-    XCTAssertEqual(layer.rawLayer->getType(), mbgl::style::LayerType::Hillshade);
+    XCTAssertEqualObjects(@(layer.rawLayer->getTypeInfo()->type), @"hillshade");
     auto rawLayer = static_cast<mbgl::style::HillshadeLayer*>(layer.rawLayer);
 
     MGLTransition transitionTest = MGLTransitionMake(5, 4);

--- a/platform/darwin/test/MGLLineStyleLayerTests.mm
+++ b/platform/darwin/test/MGLLineStyleLayerTests.mm
@@ -43,7 +43,7 @@
 
     MGLLineStyleLayer *layer = [[MGLLineStyleLayer alloc] initWithIdentifier:@"layerID" source:source];
     XCTAssertNotEqual(layer.rawLayer, nullptr);
-    XCTAssertEqual(layer.rawLayer->getType(), mbgl::style::LayerType::Line);
+    XCTAssertEqualObjects(@(layer.rawLayer->getTypeInfo()->type), @"line");
     auto rawLayer = static_cast<mbgl::style::LineLayer*>(layer.rawLayer);
 
     MGLTransition transitionTest = MGLTransitionMake(5, 4);

--- a/platform/darwin/test/MGLRasterStyleLayerTests.mm
+++ b/platform/darwin/test/MGLRasterStyleLayerTests.mm
@@ -25,7 +25,7 @@
 
     MGLRasterStyleLayer *layer = [[MGLRasterStyleLayer alloc] initWithIdentifier:@"layerID" source:source];
     XCTAssertNotEqual(layer.rawLayer, nullptr);
-    XCTAssertEqual(layer.rawLayer->getType(), mbgl::style::LayerType::Raster);
+    XCTAssertEqualObjects(@(layer.rawLayer->getTypeInfo()->type), @"raster");
     auto rawLayer = static_cast<mbgl::style::RasterLayer*>(layer.rawLayer);
 
     MGLTransition transitionTest = MGLTransitionMake(5, 4);

--- a/platform/darwin/test/MGLStyleLayerTests.mm.ejs
+++ b/platform/darwin/test/MGLStyleLayerTests.mm.ejs
@@ -54,7 +54,7 @@
     MGL<%- camelize(type) %>StyleLayer *layer = [[MGL<%- camelize(type) %>StyleLayer alloc] initWithIdentifier:@"layerID" source:source];
 <% } -%>
     XCTAssertNotEqual(layer.rawLayer, nullptr);
-    XCTAssertEqual(layer.rawLayer->getType(), mbgl::style::LayerType::<%- camelize(type) %>);
+    XCTAssertEqualObjects(@(layer.rawLayer->getTypeInfo()->type), @"<%- type %>");
     auto rawLayer = static_cast<mbgl::style::<%- camelize(type) %>Layer*>(layer.rawLayer);
 
     MGLTransition transitionTest = MGLTransitionMake(5, 4);

--- a/platform/darwin/test/MGLSymbolStyleLayerTests.mm
+++ b/platform/darwin/test/MGLSymbolStyleLayerTests.mm
@@ -43,7 +43,7 @@
 
     MGLSymbolStyleLayer *layer = [[MGLSymbolStyleLayer alloc] initWithIdentifier:@"layerID" source:source];
     XCTAssertNotEqual(layer.rawLayer, nullptr);
-    XCTAssertEqual(layer.rawLayer->getType(), mbgl::style::LayerType::Symbol);
+    XCTAssertEqualObjects(@(layer.rawLayer->getTypeInfo()->type), @"symbol");
     auto rawLayer = static_cast<mbgl::style::SymbolLayer*>(layer.rawLayer);
 
     MGLTransition transitionTest = MGLTransitionMake(5, 4);

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -3770,6 +3770,10 @@
 					"$(geometry_cflags)",
 					"$(geojson_cflags)",
 				);
+                                OTHER_LDFLAGS = (
+                                        "$(mbgl_core_LINK_LIBRARIES)",
+                                        "$(mbgl_filesource_LINK_LIBRARIES)",
+                                );
 				OTHER_SWIFT_FLAGS = "-warnings-as-errors";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.test;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3797,6 +3801,10 @@
 					"$(geometry_cflags)",
 					"$(geojson_cflags)",
 				);
+                                OTHER_LDFLAGS = (
+                                        "$(mbgl_core_LINK_LIBRARIES)",
+                                        "$(mbgl_filesource_LINK_LIBRARIES)",
+                                );
 				OTHER_SWIFT_FLAGS = "-warnings-as-errors";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.test;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -2144,6 +2144,10 @@
 					"$(geometry_cflags)",
 					"$(geojson_cflags)",
 				);
+                                OTHER_LDFLAGS = (
+                                        "$(mbgl_core_LINK_LIBRARIES)",
+                                        "$(mbgl_filesource_LINK_LIBRARIES)",
+                                );
 				OTHER_SWIFT_FLAGS = "-warnings-as-errors";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.test;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2172,6 +2176,10 @@
 					"$(geometry_cflags)",
 					"$(geojson_cflags)",
 				);
+                                OTHER_LDFLAGS = (
+                                        "$(mbgl_core_LINK_LIBRARIES)",
+                                        "$(mbgl_filesource_LINK_LIBRARIES)",
+                                );
 				OTHER_SWIFT_FLAGS = "-warnings-as-errors";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.test;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/src/mbgl/annotation/fill_annotation_impl.cpp
+++ b/src/mbgl/annotation/fill_annotation_impl.cpp
@@ -21,7 +21,6 @@ void FillAnnotationImpl::updateStyle(Style::Impl& style) const {
         layer = style.addLayer(std::move(newLayer), AnnotationManager::PointLayerID);
     }
 
-    assert(layer->getType() == LayerType::Fill);
     auto* fillLayer = static_cast<FillLayer*>(layer);
     fillLayer->setFillOpacity(annotation.opacity);
     fillLayer->setFillColor(annotation.color);

--- a/src/mbgl/annotation/line_annotation_impl.cpp
+++ b/src/mbgl/annotation/line_annotation_impl.cpp
@@ -22,7 +22,6 @@ void LineAnnotationImpl::updateStyle(Style::Impl& style) const {
         layer = style.addLayer(std::move(newLayer), AnnotationManager::PointLayerID);
     }
 
-    assert(layer->getType() == LayerType::Line);
     LineLayer* lineLayer = static_cast<LineLayer*>(layer);
     lineLayer->setLineOpacity(annotation.opacity);
     lineLayer->setLineWidth(annotation.width);

--- a/src/mbgl/renderer/group_by_layout.cpp
+++ b/src/mbgl/renderer/group_by_layout.cpp
@@ -18,7 +18,7 @@ std::string layoutKey(const RenderLayer& layer) {
     rapidjson::Writer<rapidjson::StringBuffer> writer(s);
 
     writer.StartArray();
-    writer.Uint(static_cast<uint32_t>(layer.type));
+    writer.Uint64(reinterpret_cast<uint64_t>(layer.baseImpl->getTypeInfo()));
     writer.String(layer.baseImpl->source);
     writer.String(layer.baseImpl->sourceLayer);
     writer.Double(layer.baseImpl->minZoom);

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -14,7 +14,7 @@ namespace mbgl {
 using namespace style;
 
 RenderBackgroundLayer::RenderBackgroundLayer(Immutable<style::BackgroundLayer::Impl> _impl)
-    : RenderLayer(style::LayerType::Background, _impl),
+    : RenderLayer(std::move(_impl)),
       unevaluated(impl().paint.untransitioned()) {
 }
 

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -15,7 +15,7 @@ namespace mbgl {
 using namespace style;
 
 RenderCircleLayer::RenderCircleLayer(Immutable<style::CircleLayer::Impl> _impl)
-    : RenderLayer(style::LayerType::Circle, _impl),
+    : RenderLayer(std::move(_impl)),
       unevaluated(impl().paint.untransitioned()) {
 }
 

--- a/src/mbgl/renderer/layers/render_custom_layer.cpp
+++ b/src/mbgl/renderer/layers/render_custom_layer.cpp
@@ -13,7 +13,7 @@ namespace mbgl {
 using namespace style;
 
 RenderCustomLayer::RenderCustomLayer(Immutable<style::CustomLayer::Impl> _impl)
-    : RenderLayer(LayerType::Custom, _impl), host(_impl->host) {
+    : RenderLayer(std::move(_impl)), host(impl().host) {
     assert(BackendScope::exists());
     host->initialize();
 }

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -19,7 +19,7 @@ namespace mbgl {
 using namespace style;
 
 RenderFillExtrusionLayer::RenderFillExtrusionLayer(Immutable<style::FillExtrusionLayer::Impl> _impl)
-    : RenderLayer(style::LayerType::FillExtrusion, _impl),
+    : RenderLayer(std::move(_impl)),
       unevaluated(impl().paint.untransitioned()) {
 }
 

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -17,7 +17,7 @@ namespace mbgl {
 using namespace style;
 
 RenderFillLayer::RenderFillLayer(Immutable<style::FillLayer::Impl> _impl)
-    : RenderLayer(style::LayerType::Fill, _impl),
+    : RenderLayer(std::move(_impl)),
       unevaluated(impl().paint.untransitioned()) {
 }
 

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -17,7 +17,7 @@ namespace mbgl {
 using namespace style;
 
 RenderHeatmapLayer::RenderHeatmapLayer(Immutable<style::HeatmapLayer::Impl> _impl)
-    : RenderLayer(style::LayerType::Heatmap, _impl),
+    : RenderLayer(std::move(_impl)),
     unevaluated(impl().paint.untransitioned()), colorRamp({256, 1}) {
 }
 

--- a/src/mbgl/renderer/layers/render_hillshade_layer.cpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.cpp
@@ -16,7 +16,7 @@ namespace mbgl {
 
 using namespace style;
 RenderHillshadeLayer::RenderHillshadeLayer(Immutable<style::HillshadeLayer::Impl> _impl)
-    : RenderLayer(style::LayerType::Hillshade, _impl),
+    : RenderLayer(std::move(_impl)),
       unevaluated(impl().paint.untransitioned()) {
 }
 

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -18,7 +18,7 @@ namespace mbgl {
 using namespace style;
 
 RenderLineLayer::RenderLineLayer(Immutable<style::LineLayer::Impl> _impl)
-    : RenderLayer(style::LayerType::Line, _impl),
+    : RenderLayer(std::move(_impl)),
       unevaluated(impl().paint.untransitioned()),
       colorRamp({256, 1}) {
 }

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -14,7 +14,7 @@ namespace mbgl {
 using namespace style;
 
 RenderRasterLayer::RenderRasterLayer(Immutable<style::RasterLayer::Impl> _impl)
-    : RenderLayer(style::LayerType::Raster, _impl),
+    : RenderLayer(std::move(_impl)),
       unevaluated(impl().paint.untransitioned()) {
 }
 

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -23,7 +23,7 @@ namespace mbgl {
 using namespace style;
 
 RenderSymbolLayer::RenderSymbolLayer(Immutable<style::SymbolLayer::Impl> _impl)
-    : RenderLayer(style::LayerType::Symbol, _impl),
+    : RenderLayer(std::move(_impl)),
       unevaluated(impl().paint.untransitioned()) {
 }
 

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -1,14 +1,4 @@
 #include <mbgl/renderer/render_layer.hpp>
-#include <mbgl/renderer/layers/render_background_layer.hpp>
-#include <mbgl/renderer/layers/render_circle_layer.hpp>
-#include <mbgl/renderer/layers/render_custom_layer.hpp>
-#include <mbgl/renderer/layers/render_fill_extrusion_layer.hpp>
-#include <mbgl/renderer/layers/render_fill_layer.hpp>
-#include <mbgl/renderer/layers/render_hillshade_layer.hpp>
-#include <mbgl/renderer/layers/render_line_layer.hpp>
-#include <mbgl/renderer/layers/render_raster_layer.hpp>
-#include <mbgl/renderer/layers/render_symbol_layer.hpp>
-#include <mbgl/renderer/layers/render_heatmap_layer.hpp>
 #include <mbgl/renderer/paint_parameters.hpp>
 #include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/style/types.hpp>
@@ -19,42 +9,12 @@ namespace mbgl {
 
 using namespace style;
 
-std::unique_ptr<RenderLayer> RenderLayer::create(Immutable<Layer::Impl> impl) {
-    switch (impl->type) {
-    case LayerType::Fill:
-        return std::make_unique<RenderFillLayer>(staticImmutableCast<FillLayer::Impl>(impl));
-    case LayerType::Line:
-        return std::make_unique<RenderLineLayer>(staticImmutableCast<LineLayer::Impl>(impl));
-    case LayerType::Circle:
-        return std::make_unique<RenderCircleLayer>(staticImmutableCast<CircleLayer::Impl>(impl));
-    case LayerType::Symbol:
-        return std::make_unique<RenderSymbolLayer>(staticImmutableCast<SymbolLayer::Impl>(impl));
-    case LayerType::Raster:
-        return std::make_unique<RenderRasterLayer>(staticImmutableCast<RasterLayer::Impl>(impl));
-    case LayerType::Hillshade:
-        return std::make_unique<RenderHillshadeLayer>(staticImmutableCast<HillshadeLayer::Impl>(impl));
-    case LayerType::Background:
-        return std::make_unique<RenderBackgroundLayer>(staticImmutableCast<BackgroundLayer::Impl>(impl));
-    case LayerType::Custom:
-        return std::make_unique<RenderCustomLayer>(staticImmutableCast<CustomLayer::Impl>(impl));
-    case LayerType::FillExtrusion:
-        return std::make_unique<RenderFillExtrusionLayer>(staticImmutableCast<FillExtrusionLayer::Impl>(impl));
-    case LayerType::Heatmap:
-        return std::make_unique<RenderHeatmapLayer>(staticImmutableCast<HeatmapLayer::Impl>(impl));
-    }
-
-    // Not reachable, but placate GCC.
-    assert(false);
-    return nullptr;
-}
-
-RenderLayer::RenderLayer(style::LayerType type_, Immutable<style::Layer::Impl> baseImpl_)
-        : type(type_),
-          baseImpl(baseImpl_) {
+RenderLayer::RenderLayer(Immutable<style::Layer::Impl> baseImpl_)
+    : baseImpl(std::move(baseImpl_)) {
 }
 
 void RenderLayer::setImpl(Immutable<style::Layer::Impl> impl) {
-    baseImpl = impl;
+    baseImpl = std::move(impl);
 }
 
 const std::string& RenderLayer::getID() const {

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -23,13 +23,9 @@ class TransformState;
 
 class RenderLayer {
 protected:
-    RenderLayer(style::LayerType, Immutable<style::Layer::Impl>);
-
-    const style::LayerType type;
+    RenderLayer(Immutable<style::Layer::Impl>);
 
 public:
-    static std::unique_ptr<RenderLayer> create(Immutable<style::Layer::Impl>);
-
     virtual ~RenderLayer() = default;
 
     // Begin transitions for any properties that have changed since the last frame.
@@ -92,8 +88,6 @@ public:
 
     // TODO: Only for background layers.
     virtual optional<Color> getSolidBackground() const;
-
-    friend std::string layoutKey(const RenderLayer&);
 
 protected:
     // Checks whether the current hardware can render this layer. If it can't, we'll show a warning

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -164,7 +164,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
 
     // Create render layers for newly added layers.
     for (const auto& entry : layerDiff.added) {
-        renderLayers.emplace(entry.first, RenderLayer::create(entry.second));
+        renderLayers.emplace(entry.first, LayerManager::get()->createRenderLayer(entry.second));
     }
 
     // Update render layers for changed layers.

--- a/src/mbgl/renderer/style_diff.cpp
+++ b/src/mbgl/renderer/style_diff.cpp
@@ -62,8 +62,7 @@ SourceDifference diffSources(const Immutable<std::vector<ImmutableSource>>& a,
 LayerDifference diffLayers(const Immutable<std::vector<ImmutableLayer>>& a,
                            const Immutable<std::vector<ImmutableLayer>>& b) {
     return diff(a, b, [] (const ImmutableLayer& lhs, const ImmutableLayer& rhs) {
-        return std::tie(lhs->id, lhs->type)
-            == std::tie(rhs->id, rhs->type);
+        return (lhs->id == rhs->id) && (lhs->getTypeInfo() == rhs->getTypeInfo());
     });
 }
 

--- a/src/mbgl/style/layer_impl.cpp
+++ b/src/mbgl/style/layer_impl.cpp
@@ -3,9 +3,8 @@
 namespace mbgl {
 namespace style {
 
-Layer::Impl::Impl(LayerType type_, std::string layerID, std::string sourceID)
-    : type(type_),
-      id(std::move(layerID)),
+Layer::Impl::Impl(std::string layerID, std::string sourceID)
+    : id(std::move(layerID)),
       source(std::move(sourceID)) {
 }
 

--- a/src/mbgl/style/layer_impl.hpp
+++ b/src/mbgl/style/layer_impl.hpp
@@ -29,7 +29,7 @@ namespace style {
  */
 class Layer::Impl {
 public:
-    Impl(LayerType, std::string layerID, std::string sourceID);
+    Impl(std::string layerID, std::string sourceID);
     virtual ~Impl() = default;
 
     Impl& operator=(const Impl&) = delete;
@@ -47,8 +47,6 @@ public:
     // Populates the given \a fontStack with fonts being used by the layer.
     virtual void populateFontStack(std::set<FontStack>& fontStack) const;
 
-    // Note: LayerType is deprecated, do not use it.
-    const LayerType type;
     std::string id;
     std::string source;
     std::string sourceLayer;
@@ -60,6 +58,11 @@ public:
 protected:
     Impl(const Impl&) = default;
 };
+
+// To be used in the inherited classes.
+#define DECLARE_LAYER_TYPE_INFO \
+const LayerTypeInfo* getTypeInfo() const noexcept final { return staticTypeInfo(); } \
+static const LayerTypeInfo* staticTypeInfo() noexcept
 
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/layers/background_layer.cpp
+++ b/src/mbgl/style/layers/background_layer.cpp
@@ -11,21 +11,27 @@
 #include <mbgl/style/conversion_impl.hpp>
 #include <mbgl/util/fnv_hash.hpp>
 
+#include <mbgl/renderer/layers/render_background_layer.hpp>
+
 namespace mbgl {
 namespace style {
 
-namespace {
-    const LayerTypeInfo typeInfoBackground
+
+// static
+const LayerTypeInfo* BackgroundLayer::Impl::staticTypeInfo() noexcept {
+    const static LayerTypeInfo typeInfo
         {"background",
           LayerTypeInfo::Source::NotRequired,
           LayerTypeInfo::Pass3D::NotRequired,
           LayerTypeInfo::Layout::NotRequired,
           LayerTypeInfo::Clipping::NotRequired
         };
-}  // namespace
+    return &typeInfo;
+}
+
 
 BackgroundLayer::BackgroundLayer(const std::string& layerID)
-    : Layer(makeMutable<Impl>(LayerType::Background, layerID, std::string())) {
+    : Layer(makeMutable<Impl>(layerID, std::string())) {
 }
 
 BackgroundLayer::BackgroundLayer(Immutable<Impl> impl_)
@@ -50,10 +56,6 @@ std::unique_ptr<Layer> BackgroundLayer::cloneRef(const std::string& id_) const {
 }
 
 void BackgroundLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
-}
-
-const LayerTypeInfo* BackgroundLayer::Impl::getTypeInfo() const noexcept {
-    return &typeInfoBackground;
 }
 
 // Layout properties
@@ -284,18 +286,20 @@ Mutable<Layer::Impl> BackgroundLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
-BackgroundLayerFactory::BackgroundLayerFactory() = default;
-
-BackgroundLayerFactory::~BackgroundLayerFactory() = default;
-
-const LayerTypeInfo* BackgroundLayerFactory::getTypeInfo() const noexcept {
-    return &typeInfoBackground;
-}
-
-std::unique_ptr<style::Layer> BackgroundLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {
-    (void)value;
-    return std::unique_ptr<style::Layer>(new BackgroundLayer(id));
-}
-
 } // namespace style
+
+const style::LayerTypeInfo* BackgroundLayerFactory::getTypeInfo() const noexcept {
+    return style::BackgroundLayer::Impl::staticTypeInfo();
+}
+
+std::unique_ptr<style::Layer> BackgroundLayerFactory::createLayer(const std::string& id, const style::conversion::Convertible& value) noexcept {
+    (void)value;
+    return std::unique_ptr<style::Layer>(new style::BackgroundLayer(id));
+}
+
+std::unique_ptr<RenderLayer> BackgroundLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
+    assert(impl->getTypeInfo() == getTypeInfo());
+    return std::make_unique<RenderBackgroundLayer>(staticImmutableCast<style::BackgroundLayer::Impl>(std::move(impl)));
+}
+
 } // namespace mbgl

--- a/src/mbgl/style/layers/background_layer_impl.hpp
+++ b/src/mbgl/style/layers/background_layer_impl.hpp
@@ -13,9 +13,10 @@ public:
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
-    const LayerTypeInfo* getTypeInfo() const noexcept final;
 
     BackgroundPaintProperties::Transitionable paint;
+
+    DECLARE_LAYER_TYPE_INFO;
 };
 
 } // namespace style

--- a/src/mbgl/style/layers/circle_layer_impl.cpp
+++ b/src/mbgl/style/layers/circle_layer_impl.cpp
@@ -4,7 +4,7 @@ namespace mbgl {
 namespace style {
 
 bool CircleLayer::Impl::hasLayoutDifference(const Layer::Impl& other) const {
-    assert(other.type == LayerType::Circle);
+    assert(other.getTypeInfo() == getTypeInfo());
     const auto& impl = static_cast<const style::CircleLayer::Impl&>(other);
     return filter     != impl.filter ||
            visibility != impl.visibility ||

--- a/src/mbgl/style/layers/circle_layer_impl.hpp
+++ b/src/mbgl/style/layers/circle_layer_impl.hpp
@@ -13,9 +13,10 @@ public:
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
-    const LayerTypeInfo* getTypeInfo() const noexcept final;
 
     CirclePaintProperties::Transitionable paint;
+
+    DECLARE_LAYER_TYPE_INFO;
 };
 
 } // namespace style

--- a/src/mbgl/style/layers/custom_layer.cpp
+++ b/src/mbgl/style/layers/custom_layer.cpp
@@ -2,6 +2,8 @@
 #include <mbgl/style/layers/custom_layer_impl.hpp>
 #include <mbgl/style/layer_observer.hpp>
 
+#include <mbgl/renderer/layers/render_custom_layer.hpp>
+
 namespace mbgl {
 namespace style {
 
@@ -48,22 +50,24 @@ Mutable<Layer::Impl> CustomLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
-const LayerTypeInfo* CustomLayer::Impl::getTypeInfo() const noexcept {
+// static
+const LayerTypeInfo* CustomLayer::Impl::staticTypeInfo() noexcept {
     return &typeInfoCustom;
 }
 
-CustomLayerFactory::CustomLayerFactory() = default;
+} // namespace style
 
-CustomLayerFactory::~CustomLayerFactory() = default;
-
-const LayerTypeInfo* CustomLayerFactory::getTypeInfo() const noexcept {
-    return &typeInfoCustom;
+const style::LayerTypeInfo* CustomLayerFactory::getTypeInfo() const noexcept {
+    return &style::typeInfoCustom;
 }
 
-std::unique_ptr<style::Layer> CustomLayerFactory::createLayer(const std::string&, const conversion::Convertible&) {
+std::unique_ptr<style::Layer> CustomLayerFactory::createLayer(const std::string&, const style::conversion::Convertible&) noexcept {
     assert(false);
     return nullptr;
 }
 
-} // namespace style
+std::unique_ptr<RenderLayer> CustomLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
+    return std::make_unique<RenderCustomLayer>(staticImmutableCast<style::CustomLayer::Impl>(std::move(impl)));
+}
+
 } // namespace mbgl

--- a/src/mbgl/style/layers/custom_layer_impl.cpp
+++ b/src/mbgl/style/layers/custom_layer_impl.cpp
@@ -5,7 +5,7 @@ namespace style {
 
 CustomLayer::Impl::Impl(const std::string& id_,
                         std::unique_ptr<CustomLayerHost> host_)
-    : Layer::Impl(LayerType::Custom, id_, std::string()) {
+    : Layer::Impl(id_, std::string()) {
     host = std::move(host_);
 }
 

--- a/src/mbgl/style/layers/custom_layer_impl.hpp
+++ b/src/mbgl/style/layers/custom_layer_impl.hpp
@@ -18,9 +18,10 @@ public:
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
-    const LayerTypeInfo* getTypeInfo() const noexcept final;
 
     std::shared_ptr<CustomLayerHost> host;
+
+    DECLARE_LAYER_TYPE_INFO;
 };
 
 } // namespace style

--- a/src/mbgl/style/layers/fill_extrusion_layer_impl.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer_impl.cpp
@@ -4,7 +4,7 @@ namespace mbgl {
 namespace style {
 
 bool FillExtrusionLayer::Impl::hasLayoutDifference(const Layer::Impl& other) const {
-    assert(other.type == LayerType::FillExtrusion);
+    assert(other.getTypeInfo() == getTypeInfo());
     const auto& impl = static_cast<const style::FillExtrusionLayer::Impl&>(other);
     return filter     != impl.filter ||
            visibility != impl.visibility ||

--- a/src/mbgl/style/layers/fill_extrusion_layer_impl.hpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer_impl.hpp
@@ -13,10 +13,11 @@ public:
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
-    const LayerTypeInfo* getTypeInfo() const noexcept final;
 
     Properties<>::Unevaluated layout;
     FillExtrusionPaintProperties::Transitionable paint;
+
+    DECLARE_LAYER_TYPE_INFO;
 };
 
 } // namespace style

--- a/src/mbgl/style/layers/fill_layer.cpp
+++ b/src/mbgl/style/layers/fill_layer.cpp
@@ -11,21 +11,27 @@
 #include <mbgl/style/conversion_impl.hpp>
 #include <mbgl/util/fnv_hash.hpp>
 
+#include <mbgl/renderer/layers/render_fill_layer.hpp>
+
 namespace mbgl {
 namespace style {
 
-namespace {
-    const LayerTypeInfo typeInfoFill
+
+// static
+const LayerTypeInfo* FillLayer::Impl::staticTypeInfo() noexcept {
+    const static LayerTypeInfo typeInfo
         {"fill",
           LayerTypeInfo::Source::Required,
           LayerTypeInfo::Pass3D::NotRequired,
           LayerTypeInfo::Layout::Required,
           LayerTypeInfo::Clipping::Required
         };
-}  // namespace
+    return &typeInfo;
+}
+
 
 FillLayer::FillLayer(const std::string& layerID, const std::string& sourceID)
-    : Layer(makeMutable<Impl>(LayerType::Fill, layerID, sourceID)) {
+    : Layer(makeMutable<Impl>(layerID, sourceID)) {
 }
 
 FillLayer::FillLayer(Immutable<Impl> impl_)
@@ -50,10 +56,6 @@ std::unique_ptr<Layer> FillLayer::cloneRef(const std::string& id_) const {
 }
 
 void FillLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
-}
-
-const LayerTypeInfo* FillLayer::Impl::getTypeInfo() const noexcept {
-    return &typeInfoFill;
 }
 
 // Layout properties
@@ -503,26 +505,28 @@ Mutable<Layer::Impl> FillLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
-FillLayerFactory::FillLayerFactory() = default;
+} // namespace style
 
-FillLayerFactory::~FillLayerFactory() = default;
-
-const LayerTypeInfo* FillLayerFactory::getTypeInfo() const noexcept {
-    return &typeInfoFill;
+const style::LayerTypeInfo* FillLayerFactory::getTypeInfo() const noexcept {
+    return style::FillLayer::Impl::staticTypeInfo();
 }
 
-std::unique_ptr<style::Layer> FillLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {
+std::unique_ptr<style::Layer> FillLayerFactory::createLayer(const std::string& id, const style::conversion::Convertible& value) noexcept {
     optional<std::string> source = getSource(value);
     if (!source) {
         return nullptr;
     }
 
-    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new FillLayer(id, *source));
+    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new style::FillLayer(id, *source));
     if (!initSourceLayerAndFilter(layer.get(), value)) {
         return nullptr;
     }
     return layer;
 }
 
-} // namespace style
+std::unique_ptr<RenderLayer> FillLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
+    assert(impl->getTypeInfo() == getTypeInfo());
+    return std::make_unique<RenderFillLayer>(staticImmutableCast<style::FillLayer::Impl>(std::move(impl)));
+}
+
 } // namespace mbgl

--- a/src/mbgl/style/layers/fill_layer_impl.cpp
+++ b/src/mbgl/style/layers/fill_layer_impl.cpp
@@ -4,7 +4,7 @@ namespace mbgl {
 namespace style {
 
 bool FillLayer::Impl::hasLayoutDifference(const Layer::Impl& other) const {
-    assert(other.type == LayerType::Fill);
+    assert(other.getTypeInfo() == getTypeInfo());
     const auto& impl = static_cast<const style::FillLayer::Impl&>(other);
     return filter     != impl.filter ||
            visibility != impl.visibility ||

--- a/src/mbgl/style/layers/fill_layer_impl.hpp
+++ b/src/mbgl/style/layers/fill_layer_impl.hpp
@@ -13,10 +13,11 @@ public:
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
-    const LayerTypeInfo* getTypeInfo() const noexcept final;
 
     Properties<>::Unevaluated layout;
     FillPaintProperties::Transitionable paint;
+
+    DECLARE_LAYER_TYPE_INFO;
 };
 
 } // namespace style

--- a/src/mbgl/style/layers/heatmap_layer.cpp
+++ b/src/mbgl/style/layers/heatmap_layer.cpp
@@ -11,21 +11,27 @@
 #include <mbgl/style/conversion_impl.hpp>
 #include <mbgl/util/fnv_hash.hpp>
 
+#include <mbgl/renderer/layers/render_heatmap_layer.hpp>
+
 namespace mbgl {
 namespace style {
 
-namespace {
-    const LayerTypeInfo typeInfoHeatmap
+
+// static
+const LayerTypeInfo* HeatmapLayer::Impl::staticTypeInfo() noexcept {
+    const static LayerTypeInfo typeInfo
         {"heatmap",
           LayerTypeInfo::Source::Required,
           LayerTypeInfo::Pass3D::Required,
           LayerTypeInfo::Layout::NotRequired,
           LayerTypeInfo::Clipping::NotRequired
         };
-}  // namespace
+    return &typeInfo;
+}
+
 
 HeatmapLayer::HeatmapLayer(const std::string& layerID, const std::string& sourceID)
-    : Layer(makeMutable<Impl>(LayerType::Heatmap, layerID, sourceID)) {
+    : Layer(makeMutable<Impl>(layerID, sourceID)) {
 }
 
 HeatmapLayer::HeatmapLayer(Immutable<Impl> impl_)
@@ -50,10 +56,6 @@ std::unique_ptr<Layer> HeatmapLayer::cloneRef(const std::string& id_) const {
 }
 
 void HeatmapLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
-}
-
-const LayerTypeInfo* HeatmapLayer::Impl::getTypeInfo() const noexcept {
-    return &typeInfoHeatmap;
 }
 
 // Layout properties
@@ -388,26 +390,28 @@ Mutable<Layer::Impl> HeatmapLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
-HeatmapLayerFactory::HeatmapLayerFactory() = default;
+} // namespace style
 
-HeatmapLayerFactory::~HeatmapLayerFactory() = default;
-
-const LayerTypeInfo* HeatmapLayerFactory::getTypeInfo() const noexcept {
-    return &typeInfoHeatmap;
+const style::LayerTypeInfo* HeatmapLayerFactory::getTypeInfo() const noexcept {
+    return style::HeatmapLayer::Impl::staticTypeInfo();
 }
 
-std::unique_ptr<style::Layer> HeatmapLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {
+std::unique_ptr<style::Layer> HeatmapLayerFactory::createLayer(const std::string& id, const style::conversion::Convertible& value) noexcept {
     optional<std::string> source = getSource(value);
     if (!source) {
         return nullptr;
     }
 
-    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new HeatmapLayer(id, *source));
+    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new style::HeatmapLayer(id, *source));
     if (!initSourceLayerAndFilter(layer.get(), value)) {
         return nullptr;
     }
     return layer;
 }
 
-} // namespace style
+std::unique_ptr<RenderLayer> HeatmapLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
+    assert(impl->getTypeInfo() == getTypeInfo());
+    return std::make_unique<RenderHeatmapLayer>(staticImmutableCast<style::HeatmapLayer::Impl>(std::move(impl)));
+}
+
 } // namespace mbgl

--- a/src/mbgl/style/layers/heatmap_layer_impl.cpp
+++ b/src/mbgl/style/layers/heatmap_layer_impl.cpp
@@ -4,7 +4,7 @@ namespace mbgl {
 namespace style {
 
 bool HeatmapLayer::Impl::hasLayoutDifference(const Layer::Impl& other) const {
-    assert(other.type == LayerType::Heatmap);
+    assert(other.getTypeInfo() == getTypeInfo());
     const auto& impl = static_cast<const style::HeatmapLayer::Impl&>(other);
     return filter     != impl.filter ||
            visibility != impl.visibility ||

--- a/src/mbgl/style/layers/heatmap_layer_impl.hpp
+++ b/src/mbgl/style/layers/heatmap_layer_impl.hpp
@@ -13,9 +13,10 @@ public:
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
-   const LayerTypeInfo* getTypeInfo() const noexcept final;
 
     HeatmapPaintProperties::Transitionable paint;
+
+    DECLARE_LAYER_TYPE_INFO;
 };
 
 } // namespace style

--- a/src/mbgl/style/layers/hillshade_layer.cpp
+++ b/src/mbgl/style/layers/hillshade_layer.cpp
@@ -11,21 +11,27 @@
 #include <mbgl/style/conversion_impl.hpp>
 #include <mbgl/util/fnv_hash.hpp>
 
+#include <mbgl/renderer/layers/render_hillshade_layer.hpp>
+
 namespace mbgl {
 namespace style {
 
-namespace {
-    const LayerTypeInfo typeInfoHillshade
+
+// static
+const LayerTypeInfo* HillshadeLayer::Impl::staticTypeInfo() noexcept {
+    const static LayerTypeInfo typeInfo
         {"hillshade",
           LayerTypeInfo::Source::Required,
           LayerTypeInfo::Pass3D::Required,
           LayerTypeInfo::Layout::NotRequired,
           LayerTypeInfo::Clipping::NotRequired
         };
-}  // namespace
+    return &typeInfo;
+}
+
 
 HillshadeLayer::HillshadeLayer(const std::string& layerID, const std::string& sourceID)
-    : Layer(makeMutable<Impl>(LayerType::Hillshade, layerID, sourceID)) {
+    : Layer(makeMutable<Impl>(layerID, sourceID)) {
 }
 
 HillshadeLayer::HillshadeLayer(Immutable<Impl> impl_)
@@ -50,10 +56,6 @@ std::unique_ptr<Layer> HillshadeLayer::cloneRef(const std::string& id_) const {
 }
 
 void HillshadeLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
-}
-
-const LayerTypeInfo* HillshadeLayer::Impl::getTypeInfo() const noexcept {
-    return &typeInfoHillshade;
 }
 
 // Layout properties
@@ -435,23 +437,25 @@ Mutable<Layer::Impl> HillshadeLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
-HillshadeLayerFactory::HillshadeLayerFactory() = default;
+} // namespace style
 
-HillshadeLayerFactory::~HillshadeLayerFactory() = default;
-
-const LayerTypeInfo* HillshadeLayerFactory::getTypeInfo() const noexcept {
-    return &typeInfoHillshade;
+const style::LayerTypeInfo* HillshadeLayerFactory::getTypeInfo() const noexcept {
+    return style::HillshadeLayer::Impl::staticTypeInfo();
 }
 
-std::unique_ptr<style::Layer> HillshadeLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {
+std::unique_ptr<style::Layer> HillshadeLayerFactory::createLayer(const std::string& id, const style::conversion::Convertible& value) noexcept {
     optional<std::string> source = getSource(value);
     if (!source) {
         return nullptr;
     }
 
-    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new HillshadeLayer(id, *source));
+    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new style::HillshadeLayer(id, *source));
     return layer;
 }
 
-} // namespace style
+std::unique_ptr<RenderLayer> HillshadeLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
+    assert(impl->getTypeInfo() == getTypeInfo());
+    return std::make_unique<RenderHillshadeLayer>(staticImmutableCast<style::HillshadeLayer::Impl>(std::move(impl)));
+}
+
 } // namespace mbgl

--- a/src/mbgl/style/layers/hillshade_layer_impl.hpp
+++ b/src/mbgl/style/layers/hillshade_layer_impl.hpp
@@ -13,9 +13,10 @@ public:
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
-    const LayerTypeInfo* getTypeInfo() const noexcept final;
 
     HillshadePaintProperties::Transitionable paint;
+
+    DECLARE_LAYER_TYPE_INFO;
 };
 
 } // namespace style

--- a/src/mbgl/style/layers/layer.cpp.ejs
+++ b/src/mbgl/style/layers/layer.cpp.ejs
@@ -16,10 +16,12 @@
 #include <mbgl/style/conversion_impl.hpp>
 #include <mbgl/util/fnv_hash.hpp>
 
+#include <mbgl/renderer/layers/render_<%- type.replace('-', '_') %>_layer.hpp>
+
 namespace mbgl {
 namespace style {
 
-namespace {<%
+<%
 let layerCapabilities = {};
 let defaults = { caps: { 'Source':   'NotRequired',
                          'Pass3D':   'NotRequired',
@@ -60,19 +62,23 @@ layerCapabilities['line']           = layerCapabilities['fill'];
 layerCapabilities['heatmap']        = layerCapabilities['hillshade'];
 layerCapabilities['raster']         = layerCapabilities['circle'];
 %>
-    const LayerTypeInfo typeInfo<%- `${camelize(type)}`%>
+// static
+const LayerTypeInfo* <%- camelize(type) %>Layer::Impl::staticTypeInfo() noexcept {
+    const static LayerTypeInfo typeInfo
         {"<%- type %>",
           <%-`${layerCapabilities[type].map(cap => `LayerTypeInfo::${cap}`).join(',\n          ')}` %>
         };
-}  // namespace
+    return &typeInfo;
+}
+
 
 <% if (type === 'background') { -%>
 <%- camelize(type) %>Layer::<%- camelize(type) %>Layer(const std::string& layerID)
-    : Layer(makeMutable<Impl>(LayerType::<%- camelize(type) %>, layerID, std::string())) {
+    : Layer(makeMutable<Impl>(layerID, std::string())) {
 }
 <% } else { -%>
 <%- camelize(type) %>Layer::<%- camelize(type) %>Layer(const std::string& layerID, const std::string& sourceID)
-    : Layer(makeMutable<Impl>(LayerType::<%- camelize(type) %>, layerID, sourceID)) {
+    : Layer(makeMutable<Impl>(layerID, sourceID)) {
 }
 <% } -%>
 
@@ -105,10 +111,6 @@ void <%- camelize(type) %>Layer::Impl::stringifyLayout(rapidjson::Writer<rapidjs
 void <%- camelize(type) %>Layer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
 }
 <% } -%>
-
-const LayerTypeInfo* <%- camelize(type) %>Layer::Impl::getTypeInfo() const noexcept {
-    return &typeInfo<%- camelize(type) %>;
-}
 
 // Layout properties
 
@@ -311,25 +313,23 @@ Mutable<Layer::Impl> <%- camelize(type) %>Layer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
-<%- camelize(type) %>LayerFactory::<%- camelize(type) %>LayerFactory() = default;
+} // namespace style
 
-<%- camelize(type) %>LayerFactory::~<%- camelize(type) %>LayerFactory() = default;
-
-const LayerTypeInfo* <%- camelize(type) %>LayerFactory::getTypeInfo() const noexcept {
-    return &typeInfo<%- camelize(type) %>;
+const style::LayerTypeInfo* <%- camelize(type) %>LayerFactory::getTypeInfo() const noexcept {
+    return style::<%- camelize(type) %>Layer::Impl::staticTypeInfo();
 }
 
-std::unique_ptr<style::Layer> <%- camelize(type) %>LayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {
+std::unique_ptr<style::Layer> <%- camelize(type) %>LayerFactory::createLayer(const std::string& id, const style::conversion::Convertible& value) noexcept {
 <% if (type === 'background') { -%>
     (void)value;
-    return std::unique_ptr<style::Layer>(new <%- camelize(type) %>Layer(id));
+    return std::unique_ptr<style::Layer>(new style::<%- camelize(type) %>Layer(id));
 <% } else { -%>
     optional<std::string> source = getSource(value);
     if (!source) {
         return nullptr;
     }
 
-    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new <%- camelize(type) %>Layer(id, *source));
+    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new style::<%- camelize(type) %>Layer(id, *source));
 <% if (type !== 'raster' && type !== 'hillshade') { -%>
     if (!initSourceLayerAndFilter(layer.get(), value)) {
         return nullptr;
@@ -339,5 +339,9 @@ std::unique_ptr<style::Layer> <%- camelize(type) %>LayerFactory::createLayer(con
 <% } -%>
 }
 
-} // namespace style
+std::unique_ptr<RenderLayer> <%- camelize(type) %>LayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
+    assert(impl->getTypeInfo() == getTypeInfo());
+    return std::make_unique<Render<%- camelize(type) %>Layer>(staticImmutableCast<style::<%- camelize(type) %>Layer::Impl>(std::move(impl)));
+}
+
 } // namespace mbgl

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -11,21 +11,27 @@
 #include <mbgl/style/conversion_impl.hpp>
 #include <mbgl/util/fnv_hash.hpp>
 
+#include <mbgl/renderer/layers/render_line_layer.hpp>
+
 namespace mbgl {
 namespace style {
 
-namespace {
-    const LayerTypeInfo typeInfoLine
+
+// static
+const LayerTypeInfo* LineLayer::Impl::staticTypeInfo() noexcept {
+    const static LayerTypeInfo typeInfo
         {"line",
           LayerTypeInfo::Source::Required,
           LayerTypeInfo::Pass3D::NotRequired,
           LayerTypeInfo::Layout::Required,
           LayerTypeInfo::Clipping::Required
         };
-}  // namespace
+    return &typeInfo;
+}
+
 
 LineLayer::LineLayer(const std::string& layerID, const std::string& sourceID)
-    : Layer(makeMutable<Impl>(LayerType::Line, layerID, sourceID)) {
+    : Layer(makeMutable<Impl>(layerID, sourceID)) {
 }
 
 LineLayer::LineLayer(Immutable<Impl> impl_)
@@ -51,10 +57,6 @@ std::unique_ptr<Layer> LineLayer::cloneRef(const std::string& id_) const {
 
 void LineLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>& writer) const {
     layout.stringify(writer);
-}
-
-const LayerTypeInfo* LineLayer::Impl::getTypeInfo() const noexcept {
-    return &typeInfoLine;
 }
 
 // Layout properties
@@ -842,26 +844,28 @@ Mutable<Layer::Impl> LineLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
-LineLayerFactory::LineLayerFactory() = default;
+} // namespace style
 
-LineLayerFactory::~LineLayerFactory() = default;
-
-const LayerTypeInfo* LineLayerFactory::getTypeInfo() const noexcept {
-    return &typeInfoLine;
+const style::LayerTypeInfo* LineLayerFactory::getTypeInfo() const noexcept {
+    return style::LineLayer::Impl::staticTypeInfo();
 }
 
-std::unique_ptr<style::Layer> LineLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {
+std::unique_ptr<style::Layer> LineLayerFactory::createLayer(const std::string& id, const style::conversion::Convertible& value) noexcept {
     optional<std::string> source = getSource(value);
     if (!source) {
         return nullptr;
     }
 
-    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new LineLayer(id, *source));
+    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new style::LineLayer(id, *source));
     if (!initSourceLayerAndFilter(layer.get(), value)) {
         return nullptr;
     }
     return layer;
 }
 
-} // namespace style
+std::unique_ptr<RenderLayer> LineLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
+    assert(impl->getTypeInfo() == getTypeInfo());
+    return std::make_unique<RenderLineLayer>(staticImmutableCast<style::LineLayer::Impl>(std::move(impl)));
+}
+
 } // namespace mbgl

--- a/src/mbgl/style/layers/line_layer_impl.cpp
+++ b/src/mbgl/style/layers/line_layer_impl.cpp
@@ -4,7 +4,7 @@ namespace mbgl {
 namespace style {
 
 bool LineLayer::Impl::hasLayoutDifference(const Layer::Impl& other) const {
-    assert(other.type == LayerType::Line);
+    assert(other.getTypeInfo() == getTypeInfo());
     const auto& impl = static_cast<const style::LineLayer::Impl&>(other);
     return filter     != impl.filter ||
            visibility != impl.visibility ||

--- a/src/mbgl/style/layers/line_layer_impl.hpp
+++ b/src/mbgl/style/layers/line_layer_impl.hpp
@@ -13,10 +13,11 @@ public:
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
-    const LayerTypeInfo* getTypeInfo() const noexcept final;
 
     LineLayoutProperties::Unevaluated layout;
     LinePaintProperties::Transitionable paint;
+
+    DECLARE_LAYER_TYPE_INFO;
 };
 
 } // namespace style

--- a/src/mbgl/style/layers/raster_layer.cpp
+++ b/src/mbgl/style/layers/raster_layer.cpp
@@ -11,21 +11,27 @@
 #include <mbgl/style/conversion_impl.hpp>
 #include <mbgl/util/fnv_hash.hpp>
 
+#include <mbgl/renderer/layers/render_raster_layer.hpp>
+
 namespace mbgl {
 namespace style {
 
-namespace {
-    const LayerTypeInfo typeInfoRaster
+
+// static
+const LayerTypeInfo* RasterLayer::Impl::staticTypeInfo() noexcept {
+    const static LayerTypeInfo typeInfo
         {"raster",
           LayerTypeInfo::Source::Required,
           LayerTypeInfo::Pass3D::NotRequired,
           LayerTypeInfo::Layout::NotRequired,
           LayerTypeInfo::Clipping::NotRequired
         };
-}  // namespace
+    return &typeInfo;
+}
+
 
 RasterLayer::RasterLayer(const std::string& layerID, const std::string& sourceID)
-    : Layer(makeMutable<Impl>(LayerType::Raster, layerID, sourceID)) {
+    : Layer(makeMutable<Impl>(layerID, sourceID)) {
 }
 
 RasterLayer::RasterLayer(Immutable<Impl> impl_)
@@ -50,10 +56,6 @@ std::unique_ptr<Layer> RasterLayer::cloneRef(const std::string& id_) const {
 }
 
 void RasterLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
-}
-
-const LayerTypeInfo* RasterLayer::Impl::getTypeInfo() const noexcept {
-    return &typeInfoRaster;
 }
 
 // Layout properties
@@ -524,23 +526,25 @@ Mutable<Layer::Impl> RasterLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }
 
-RasterLayerFactory::RasterLayerFactory() = default;
+} // namespace style
 
-RasterLayerFactory::~RasterLayerFactory() = default;
-
-const LayerTypeInfo* RasterLayerFactory::getTypeInfo() const noexcept {
-    return &typeInfoRaster;
+const style::LayerTypeInfo* RasterLayerFactory::getTypeInfo() const noexcept {
+    return style::RasterLayer::Impl::staticTypeInfo();
 }
 
-std::unique_ptr<style::Layer> RasterLayerFactory::createLayer(const std::string& id, const conversion::Convertible& value) {
+std::unique_ptr<style::Layer> RasterLayerFactory::createLayer(const std::string& id, const style::conversion::Convertible& value) noexcept {
     optional<std::string> source = getSource(value);
     if (!source) {
         return nullptr;
     }
 
-    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new RasterLayer(id, *source));
+    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new style::RasterLayer(id, *source));
     return layer;
 }
 
-} // namespace style
+std::unique_ptr<RenderLayer> RasterLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
+    assert(impl->getTypeInfo() == getTypeInfo());
+    return std::make_unique<RenderRasterLayer>(staticImmutableCast<style::RasterLayer::Impl>(std::move(impl)));
+}
+
 } // namespace mbgl

--- a/src/mbgl/style/layers/raster_layer_impl.hpp
+++ b/src/mbgl/style/layers/raster_layer_impl.hpp
@@ -13,9 +13,10 @@ public:
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
-    const LayerTypeInfo* getTypeInfo() const noexcept final;
 
     RasterPaintProperties::Transitionable paint;
+
+    DECLARE_LAYER_TYPE_INFO;
 };
 
 } // namespace style

--- a/src/mbgl/style/layers/symbol_layer_impl.cpp
+++ b/src/mbgl/style/layers/symbol_layer_impl.cpp
@@ -6,7 +6,7 @@ namespace mbgl {
 namespace style {
 
 bool SymbolLayer::Impl::hasLayoutDifference(const Layer::Impl& other) const {
-    assert(other.type == LayerType::Symbol);
+    assert(other.getTypeInfo() == getTypeInfo());
     const auto& impl = static_cast<const style::SymbolLayer::Impl&>(other);
     return filter     != impl.filter ||
            visibility != impl.visibility ||

--- a/src/mbgl/style/layers/symbol_layer_impl.hpp
+++ b/src/mbgl/style/layers/symbol_layer_impl.hpp
@@ -13,11 +13,12 @@ public:
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
-    const LayerTypeInfo* getTypeInfo() const noexcept final;
     void populateFontStack(std::set<FontStack>& fontStack) const final;
 
     SymbolLayoutProperties::Unevaluated layout;
     SymbolPaintProperties::Transitionable paint;
+
+    DECLARE_LAYER_TYPE_INFO;
 };
 
 } // namespace style

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -97,8 +97,7 @@ void GeometryTile::setLayers(const std::vector<Immutable<Layer::Impl>>& layers) 
 
     for (const auto& layer : layers) {
         // Skip irrelevant layers.
-        if (layer->type == LayerType::Background ||
-            layer->type == LayerType::Custom ||
+        if (layer->getTypeInfo()->source == LayerTypeInfo::Source::NotRequired ||
             layer->source != sourceID ||
             id.overscaledZ < std::floor(layer->minZoom) ||
             id.overscaledZ >= std::ceil(layer->maxZoom) ||

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -312,7 +312,7 @@ static std::vector<std::unique_ptr<RenderLayer>> toRenderLayers(const std::vecto
     std::vector<std::unique_ptr<RenderLayer>> renderLayers;
     renderLayers.reserve(layers.size());
     for (auto& layer : layers) {
-        renderLayers.push_back(RenderLayer::create(layer));
+        renderLayers.push_back(LayerManager::get()->createRenderLayer(layer));
 
         renderLayers.back()->transition(TransitionParameters {
             Clock::time_point::max(),

--- a/test/gl/context.test.cpp
+++ b/test/gl/context.test.cpp
@@ -95,7 +95,7 @@ TEST(GLContextMode, Shared) {
 
     // Set transparent background layer.
     auto layer = map.getStyle().getLayer("background");
-    ASSERT_EQ(LayerType::Background, layer->getType());
+    ASSERT_STREQ("background", layer->getTypeInfo()->type);
     static_cast<BackgroundLayer*>(layer)->setBackgroundColor( { { 1.0f, 0.0f, 0.0f, 0.5f } } );
 
     {

--- a/test/renderer/group_by_layout.test.cpp
+++ b/test/renderer/group_by_layout.test.cpp
@@ -15,7 +15,7 @@ static std::vector<std::unique_ptr<RenderLayer>> toRenderLayers(const std::vecto
     std::vector<std::unique_ptr<RenderLayer>> result;
     result.reserve(layers.size());
     for (auto& layer : layers) {
-        result.push_back(RenderLayer::create(layer->baseImpl));
+        result.push_back(LayerManager::get()->createRenderLayer(layer->baseImpl));
     }
     return result;
 }

--- a/test/style/conversion/layer.test.cpp
+++ b/test/style/conversion/layer.test.cpp
@@ -25,7 +25,7 @@ TEST(StyleConversion, LayerTransition) {
             }
         }
     })JSON");
-	ASSERT_EQ(LayerType::Background, layer->getType());
+    ASSERT_STREQ("background", layer->getTypeInfo()->type);
     ASSERT_EQ(400ms, *static_cast<BackgroundLayer*>(layer.get())->impl().paint
         .get<BackgroundColor>().options.duration);
     ASSERT_EQ(500ms, *static_cast<BackgroundLayer*>(layer.get())->impl().paint

--- a/test/style/style_layer.test.cpp
+++ b/test/style/style_layer.test.cpp
@@ -54,7 +54,7 @@ const auto duration = 1.0f;
 
 TEST(Layer, BackgroundProperties) {
     auto layer = std::make_unique<BackgroundLayer>("background");
-    ASSERT_EQ(LayerType::Background, layer->getType());
+    ASSERT_STREQ("background", layer->getTypeInfo()->type);
 
     // Paint properties
 
@@ -70,7 +70,7 @@ TEST(Layer, BackgroundProperties) {
 
 TEST(Layer, CircleProperties) {
     auto layer = std::make_unique<CircleLayer>("circle", "source");
-    ASSERT_EQ(LayerType::Circle, layer->getType());
+    ASSERT_STREQ("circle", layer->getTypeInfo()->type);
 
     // Paint properties
 
@@ -95,7 +95,7 @@ TEST(Layer, CircleProperties) {
 
 TEST(Layer, FillProperties) {
     auto layer = std::make_unique<FillLayer>("fill", "source");
-    ASSERT_EQ(LayerType::Fill, layer->getType());
+    ASSERT_STREQ("fill", layer->getTypeInfo()->type);
 
     // Paint properties
 
@@ -123,7 +123,7 @@ TEST(Layer, FillProperties) {
 
 TEST(Layer, LineProperties) {
     auto layer = std::make_unique<LineLayer>("line", "source");
-    ASSERT_EQ(LayerType::Line, layer->getType());
+    ASSERT_STREQ("line", layer->getTypeInfo()->type);
 
     // Layout properties
 
@@ -174,7 +174,7 @@ TEST(Layer, LineProperties) {
 
 TEST(Layer, RasterProperties) {
     auto layer = std::make_unique<RasterLayer>("raster", "source");
-    ASSERT_EQ(LayerType::Raster, layer->getType());
+    ASSERT_STREQ("raster", layer->getTypeInfo()->type);
 
     // Paint properties
 


### PR DESCRIPTION
`LayerManager` is now responsible for `RenderLayer` instances creation,
so that there is a single entry point for creating of objects, which
correspond to a certain layer type.

The `LayerType type` field is dropped from `Layer::Impl`.

Tag https://github.com/mapbox/mapbox-gl-native/issues/13276