### PR TITLE
Instrumented unit tests, add map tests, refactor gen layer tests

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -387,15 +387,29 @@ final class NativeMapView {
     nativeRotateBy(sx / pixelRatio, sy / pixelRatio, ex, ey, duration);
   }
 
-  public void setContentPadding(int[] padding) {
+  public void setContentPadding(float[] padding) {
     if (checkState("setContentPadding")) {
       return;
     }
+    // TopLeftBottomRight
     nativeSetContentPadding(
       padding[1] / pixelRatio,
       padding[0] / pixelRatio,
       padding[3] / pixelRatio,
       padding[2] / pixelRatio);
+  }
+
+  public float[] getContentPadding() {
+    if (checkState("getContentPadding")) {
+      return new float[] {0, 0, 0, 0};
+    }
+    float[] topLeftBottomRight = nativeGetContentPadding();
+    return new float[]{
+      topLeftBottomRight[1] * pixelRatio,
+      topLeftBottomRight[0] * pixelRatio,
+      topLeftBottomRight[3] * pixelRatio,
+      topLeftBottomRight[2] * pixelRatio
+    };
   }
 
   public void setBearing(double degrees) {
@@ -1115,7 +1129,10 @@ final class NativeMapView {
   private native void nativeRotateBy(double sx, double sy, double ex, double ey, long duration);
 
   @Keep
-  private native void nativeSetContentPadding(double top, double left, double bottom, double right);
+  private native void nativeSetContentPadding(float top, float left, float bottom, float right);
+
+  @Keep
+  private native float[] nativeGetContentPadding();
 
   @Keep
   private native void nativeSetBearing(double degrees, long duration);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -64,6 +64,7 @@ final class NativeMapView {
   private ViewCallback viewCallback;
 
   // Used for map change callbacks
+  @Nullable
   private StateCallback stateCallback;
 
   // Device density
@@ -309,6 +310,10 @@ final class NativeMapView {
       return 0;
     }
     return nativeGetPitch();
+  }
+
+  public void setPitch(double pitch) {
+    setPitch(pitch, 0);
   }
 
   public void setPitch(double pitch, long duration) {
@@ -922,62 +927,86 @@ final class NativeMapView {
 
   @Keep
   private void onCameraWillChange(boolean animated) {
-    stateCallback.onCameraWillChange(animated);
+    if (stateCallback != null) {
+      stateCallback.onCameraWillChange(animated);
+    }
   }
 
   @Keep
   private void onCameraIsChanging() {
-    stateCallback.onCameraIsChanging();
+    if (stateCallback != null) {
+      stateCallback.onCameraIsChanging();
+    }
   }
 
   @Keep
   private void onCameraDidChange(boolean animated) {
-    stateCallback.onCameraDidChange(animated);
+    if (stateCallback != null) {
+      stateCallback.onCameraDidChange(animated);
+    }
   }
 
   @Keep
   private void onWillStartLoadingMap() {
-    stateCallback.onWillStartLoadingMap();
+    if (stateCallback != null) {
+      stateCallback.onWillStartLoadingMap();
+    }
   }
 
   @Keep
   private void onDidFinishLoadingMap() {
-    stateCallback.onDidFinishLoadingMap();
+    if (stateCallback != null) {
+      stateCallback.onDidFinishLoadingMap();
+    }
   }
 
   @Keep
   private void onDidFailLoadingMap(String error) {
-    stateCallback.onDidFailLoadingMap(error);
+    if (stateCallback != null) {
+      stateCallback.onDidFailLoadingMap(error);
+    }
   }
 
   @Keep
   private void onWillStartRenderingFrame() {
-    stateCallback.onWillStartRenderingFrame();
+    if (stateCallback != null) {
+      stateCallback.onWillStartRenderingFrame();
+    }
   }
 
   @Keep
   private void onDidFinishRenderingFrame(boolean fully) {
-    stateCallback.onDidFinishRenderingFrame(fully);
+    if (stateCallback != null) {
+      stateCallback.onDidFinishRenderingFrame(fully);
+    }
   }
 
   @Keep
   private void onWillStartRenderingMap() {
-    stateCallback.onWillStartRenderingMap();
+    if (stateCallback != null) {
+      stateCallback.onWillStartRenderingMap();
+    }
   }
 
   @Keep
   private void onDidFinishRenderingMap(boolean fully) {
-    stateCallback.onDidFinishRenderingMap(fully);
+    if (stateCallback != null) {
+      stateCallback.onDidFinishRenderingMap(fully);
+    }
   }
 
   @Keep
   private void onDidFinishLoadingStyle() {
-    stateCallback.onDidFinishLoadingStyle();
+    if (stateCallback != null) {
+      stateCallback.onDidFinishLoadingStyle();
+    }
   }
 
   @Keep
   private void onSourceChanged(String sourceId) {
-    stateCallback.onSourceChanged(sourceId);
+    if (stateCallback != null) {
+      stateCallback.onSourceChanged(sourceId);
+    }
   }
 
   @Keep

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Projection.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Projection.java
@@ -3,7 +3,6 @@ package com.mapbox.mapboxsdk.maps;
 import android.graphics.PointF;
 import android.support.annotation.FloatRange;
 import android.support.annotation.NonNull;
-
 import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.constants.GeometryConstants;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -32,7 +31,11 @@ public class Projection {
 
   void setContentPadding(int[] contentPadding) {
     this.contentPadding = contentPadding;
-    nativeMapView.setContentPadding(contentPadding);
+    float[] output = new float[contentPadding.length];
+    for (int i = 0; i < contentPadding.length; i++) {
+      output[i] = contentPadding[i];
+    }
+    nativeMapView.setContentPadding(output);
   }
 
   int[] getContentPadding() {
@@ -121,10 +124,10 @@ public class Projection {
       top = 0;
       bottom = nativeMapView.getHeight();
     } else {
-      left = contentPadding[0];
-      right = nativeMapView.getWidth() - contentPadding[2];
-      top = contentPadding[1];
-      bottom = nativeMapView.getHeight() - contentPadding[3];
+      left = (float) contentPadding[0];
+      right = (float) (nativeMapView.getWidth() - contentPadding[2]);
+      top = (float) contentPadding[1];
+      bottom = (float) (nativeMapView.getHeight() - contentPadding[3]);
     }
 
     LatLng center = fromScreenLocation(new PointF(left + (right - left) / 2, top + (bottom - top) / 2));

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/BaseLayerTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/BaseLayerTest.kt
@@ -1,0 +1,26 @@
+package com.mapbox.mapboxsdk.maps
+
+import android.support.test.InstrumentationRegistry
+import android.support.test.runner.AndroidJUnit4
+import com.mapbox.mapboxsdk.style.layers.Layer
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+abstract class BaseLayerTest {
+    private lateinit var nativeMapView: NativeMapView
+
+    companion object {
+        const val WIDTH = 500
+        const val HEIGHT = WIDTH
+    }
+
+    fun before() {
+        val context = InstrumentationRegistry.getContext()
+        nativeMapView = NativeMapView(context, false, null, null, NativeMapViewTest.DummyRenderer(context))
+        nativeMapView.resizeView(WIDTH, HEIGHT)
+    }
+
+    fun setupLayer(layer: Layer) {
+        nativeMapView.addLayer(layer)
+    }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/NativeMapViewTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/NativeMapViewTest.kt
@@ -1,0 +1,187 @@
+package com.mapbox.mapboxsdk.maps
+
+import android.content.Context
+import android.graphics.PointF
+import android.support.test.InstrumentationRegistry
+import android.support.test.annotation.UiThreadTest
+import android.support.test.runner.AndroidJUnit4
+import com.mapbox.mapboxsdk.camera.CameraPosition
+import com.mapbox.mapboxsdk.geometry.LatLng
+import com.mapbox.mapboxsdk.maps.renderer.MapRenderer
+import junit.framework.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NativeMapViewTest {
+
+    private lateinit var nativeMapView: NativeMapView
+
+    companion object {
+        const val DELTA = 0.000001
+        const val DELTA_BIG = 1.0
+        const val BEARING_TEST = 60.0
+        const val PITCH_TEST = 40.0
+        const val ZOOM_TEST = 16.0
+        const val WIDTH = 500
+        const val HEIGHT = WIDTH
+        val LATLNG_TEST = LatLng(12.0, 34.0)
+    }
+
+    @Before
+    @UiThreadTest
+    fun before() {
+        val context = InstrumentationRegistry.getContext()
+        nativeMapView = NativeMapView(context, false, null, null, DummyRenderer(context))
+        nativeMapView.resizeView(WIDTH, HEIGHT)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testBearing() {
+        val expected = BEARING_TEST
+        nativeMapView.bearing = expected
+        val actual = nativeMapView.bearing
+        assertEquals("Bearing should match", expected, actual, DELTA)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testLatLng() {
+        val expected = LATLNG_TEST
+        nativeMapView.latLng = expected
+        val actual = nativeMapView.latLng
+        assertEquals("Latitude should match", expected.latitude, actual.latitude, DELTA)
+        assertEquals("Longitude should match", expected.longitude, actual.longitude, DELTA)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testLatLngDefault() {
+        val expected = LatLng()
+        val actual = nativeMapView.latLng
+        assertEquals("Latitude should match", expected.latitude, actual.latitude, DELTA)
+        assertEquals("Longitude should match", expected.longitude, actual.longitude, DELTA)
+    }
+
+
+    @Test
+    @UiThreadTest
+    fun testBearingDefault() {
+        val expected = 0.0
+        val actual = nativeMapView.bearing
+        assertEquals("Bearing should match", expected, actual, DELTA)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testPitch() {
+        val expected = PITCH_TEST
+        nativeMapView.pitch = expected
+        val actual = nativeMapView.pitch
+        assertEquals("Pitch should match", expected, actual, DELTA)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testPitchDefault() {
+        val expected = 0.0
+        val actual = nativeMapView.pitch
+        assertEquals("Pitch should match", expected, actual, DELTA)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testZoom() {
+        val expected = ZOOM_TEST
+        nativeMapView.setZoom(expected, PointF(0.0f, 0.0f), 0)
+        val actual = nativeMapView.zoom
+        assertEquals("Zoom should match", expected, actual, DELTA)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testZoomDefault() {
+        val expected = 0.0
+        val actual = nativeMapView.zoom
+        assertEquals("Zoom should match", expected, actual, DELTA)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testJumpTo() {
+        val expected = CameraPosition.Builder()
+                .bearing(BEARING_TEST)
+                .target(LATLNG_TEST)
+                .tilt(PITCH_TEST)
+                .zoom(ZOOM_TEST)
+                .build()
+        nativeMapView.jumpTo(BEARING_TEST, LATLNG_TEST, PITCH_TEST, ZOOM_TEST)
+        val actual = nativeMapView.cameraPosition
+        assertEquals("Latitude should match", expected.target.latitude, actual.target.latitude, DELTA)
+        assertEquals("Longitude should match", expected.target.longitude, actual.target.longitude, DELTA)
+        assertEquals("Bearing should match", expected.bearing, actual.bearing, DELTA)
+        assertEquals("Pitch should match", expected.tilt, actual.tilt, DELTA)
+        assertEquals("Zoom should match", expected.zoom, actual.zoom, DELTA)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testLatLngForPixel() {
+        val expected = LATLNG_TEST
+        nativeMapView.latLng = LATLNG_TEST
+        val actual = nativeMapView.latLngForPixel(
+                PointF((WIDTH / 2).toFloat(), (HEIGHT / 2).toFloat())
+        )
+        assertEquals("Latitude should match", expected.latitude, actual.latitude, DELTA_BIG)
+        assertEquals("Longitude should match", expected.longitude, actual.longitude, DELTA_BIG)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testPixelForLatLng() {
+        val expected = PointF((WIDTH / 2).toFloat(), (HEIGHT / 2).toFloat())
+        nativeMapView.latLng = LATLNG_TEST
+        val actual = nativeMapView.pixelForLatLng(LATLNG_TEST)
+        assertEquals("X should match", expected.x.toDouble(), actual.x.toDouble(), DELTA_BIG)
+        assertEquals("Y should match", expected.y.toDouble(), actual.y.toDouble(), DELTA_BIG)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testPrefetchTilesTrue(){
+        val expected = true
+        nativeMapView.prefetchesTiles = true
+        val actual = nativeMapView.prefetchesTiles
+        assertEquals("Flag should match", expected, actual)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testPrefetchTilesFalse(){
+        val expected = false
+        nativeMapView.prefetchesTiles = false
+        val actual = nativeMapView.prefetchesTiles
+        assertEquals("Flag should match", expected, actual)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testPrefetchTilesDefault(){
+        val expected = true
+        val actual = nativeMapView.prefetchesTiles
+        assertEquals("Flag should match", expected, actual)
+    }
+
+    class DummyRenderer(context: Context) : MapRenderer(context, null) {
+
+        override fun requestRender() {
+            //no-op
+        }
+
+        override fun queueEvent(runnable: Runnable?) {
+            //no-op
+        }
+    }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/NativeMapViewTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/NativeMapViewTest.kt
@@ -7,7 +7,10 @@ import android.support.test.annotation.UiThreadTest
 import android.support.test.runner.AndroidJUnit4
 import com.mapbox.mapboxsdk.camera.CameraPosition
 import com.mapbox.mapboxsdk.geometry.LatLng
+import com.mapbox.mapboxsdk.geometry.LatLngBounds
+import com.mapbox.mapboxsdk.geometry.ProjectedMeters
 import com.mapbox.mapboxsdk.maps.renderer.MapRenderer
+import com.mapbox.mapboxsdk.testapp.utils.TestConstants
 import junit.framework.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -33,7 +36,7 @@ class NativeMapViewTest {
     @UiThreadTest
     fun before() {
         val context = InstrumentationRegistry.getContext()
-        nativeMapView = NativeMapView(context, false, null, null, DummyRenderer(context))
+        nativeMapView = NativeMapView(context, 2.0f, false, null, null, DummyRenderer(context))
         nativeMapView.resizeView(WIDTH, HEIGHT)
     }
 
@@ -150,7 +153,7 @@ class NativeMapViewTest {
 
     @Test
     @UiThreadTest
-    fun testPrefetchTilesTrue(){
+    fun testPrefetchTilesTrue() {
         val expected = true
         nativeMapView.prefetchesTiles = true
         val actual = nativeMapView.prefetchesTiles
@@ -159,7 +162,7 @@ class NativeMapViewTest {
 
     @Test
     @UiThreadTest
-    fun testPrefetchTilesFalse(){
+    fun testPrefetchTilesFalse() {
         val expected = false
         nativeMapView.prefetchesTiles = false
         val actual = nativeMapView.prefetchesTiles
@@ -168,10 +171,169 @@ class NativeMapViewTest {
 
     @Test
     @UiThreadTest
-    fun testPrefetchTilesDefault(){
+    fun testPrefetchTilesDefault() {
         val expected = true
         val actual = nativeMapView.prefetchesTiles
         assertEquals("Flag should match", expected, actual)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testSetStyleUrl() {
+        val expected = Style.DARK
+        nativeMapView.styleUrl = expected
+        val actual = nativeMapView.styleUrl
+        assertEquals("Style URL should match", expected, actual)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testSetStyleJson() {
+        val expected = "{}"
+        nativeMapView.styleJson = expected
+        val actual = nativeMapView.styleJson
+        assertEquals("Style JSON should match", expected, actual)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testSetContentPadding() {
+        val expected = floatArrayOf(1.0f, 2.0f, 3.0f, 4.0f)
+        nativeMapView.contentPadding = expected
+        val actual = nativeMapView.contentPadding
+        assertEquals("Left should match", expected[0], actual[0])
+        assertEquals("Top should match", expected[1], actual[1])
+        assertEquals("Right should match", expected[2], actual[2])
+        assertEquals("Bottom should match", expected[3], actual[3])
+    }
+
+    @Test
+    @UiThreadTest
+    fun testSetMinZoom() {
+        val expected = 12.0
+        nativeMapView.minZoom = expected
+        val actual = nativeMapView.minZoom
+        assertEquals("Min zoom should match", expected, actual)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testSetMaxZoom() {
+        val expected = 12.0
+        nativeMapView.maxZoom = expected
+        val actual = nativeMapView.maxZoom
+        assertEquals("Max zoom should match", expected, actual)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testGetProjectedMetersAtLatitude() {
+        val expected = 38986.83510557766
+        val actual = nativeMapView.getMetersPerPixelAtLatitude(5.0)
+        assertEquals("Get projected meters should match", expected, actual)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testLatLngForProjectedMeters() {
+        val expected = LatLng(0.01796630538796444, 0.02694945852363162)
+        val actual = nativeMapView.latLngForProjectedMeters(ProjectedMeters(2000.0, 3000.0))
+        assertEquals("Get LatLng for projected meters", expected, actual)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testFlyTo() {
+        val expected = CameraPosition.Builder()
+                .zoom(12.0)
+                .tilt(30.0)
+                .target(LatLng(12.0, 14.0))
+                .bearing(20.0)
+                .build()
+        nativeMapView.flyTo(expected.bearing, expected.target, 0, expected.tilt, expected.zoom)
+        val actual = nativeMapView.cameraPosition
+        assertEquals("Bearing should match", expected.bearing, actual.bearing, TestConstants.BEARING_DELTA)
+        assertEquals("Latitude should match", expected.target.latitude, actual.target.latitude, TestConstants.LAT_LNG_DELTA)
+        assertEquals("Longitude should match", expected.target.longitude, actual.target.longitude, TestConstants.LAT_LNG_DELTA)
+        assertEquals("Tilt should match", expected.tilt, actual.tilt, TestConstants.TILT_DELTA)
+        assertEquals("Zoom should match", expected.zoom, actual.zoom, TestConstants.ZOOM_DELTA)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testEaseTo() {
+        val expected = CameraPosition.Builder()
+                .zoom(12.0)
+                .tilt(30.0)
+                .target(LatLng(12.0, 14.0))
+                .bearing(20.0)
+                .build()
+        nativeMapView.easeTo(expected.bearing, expected.target, 0, expected.tilt, expected.zoom, false)
+        val actual = nativeMapView.cameraPosition
+        assertEquals("Bearing should match", expected.bearing, actual.bearing, TestConstants.BEARING_DELTA)
+        assertEquals("Latitude should match", expected.target.latitude, actual.target.latitude, TestConstants.LAT_LNG_DELTA)
+        assertEquals("Longitude should match", expected.target.longitude, actual.target.longitude, TestConstants.LAT_LNG_DELTA)
+        assertEquals("Tilt should match", expected.tilt, actual.tilt, TestConstants.TILT_DELTA)
+        assertEquals("Zoom should match", expected.zoom, actual.zoom, TestConstants.ZOOM_DELTA)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testResetPosition() {
+        val expected = CameraPosition.Builder()
+                .zoom(0.0)
+                .tilt(0.0)
+                .target(LatLng(0.0, 0.0))
+                .bearing(0.0)
+                .build()
+        nativeMapView.jumpTo(1.0, LatLng(1.0, 2.0), 23.0, 12.0)
+        nativeMapView.resetPosition()
+        val actual = nativeMapView.cameraPosition
+        assertEquals("Bearing should match", expected.bearing, actual.bearing, TestConstants.BEARING_DELTA)
+        assertEquals("Latitude should match", expected.target.latitude, actual.target.latitude, TestConstants.LAT_LNG_DELTA)
+        assertEquals("Longitude should match", expected.target.longitude, actual.target.longitude, TestConstants.LAT_LNG_DELTA)
+        assertEquals("Tilt should match", expected.tilt, actual.tilt, TestConstants.TILT_DELTA)
+        assertEquals("Zoom should match", expected.zoom, actual.zoom, TestConstants.ZOOM_DELTA)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testGetCameraForLatLngBounds() {
+        val expected = CameraPosition.Builder()
+                .zoom(3.5258764777024005)
+                .tilt(0.0)
+                .target(LatLng(23.182767623652808, 13.999999999994088))
+                .bearing(0.0)
+                .build()
+        val actual = nativeMapView.getCameraForLatLngBounds(
+                LatLngBounds.from(30.0, 12.0, 16.0, 16.0),
+                intArrayOf(0, 0, 0, 0),
+                0.0,
+                0.0
+        )
+        assertEquals("Bearing should match", expected.bearing, actual.bearing, TestConstants.BEARING_DELTA)
+        assertEquals("Latitude should match", expected.target.latitude, actual.target.latitude, TestConstants.LAT_LNG_DELTA)
+        assertEquals("Longitude should match", expected.target.longitude, actual.target.longitude, TestConstants.LAT_LNG_DELTA)
+        assertEquals("Tilt should match", expected.tilt, actual.tilt, TestConstants.TILT_DELTA)
+        assertEquals("Zoom should match", expected.zoom, actual.zoom, TestConstants.ZOOM_DELTA)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testMoveBy() {
+        val expected = CameraPosition.Builder()
+                .zoom(0.0)
+                .tilt(0.0)
+                .target(LatLng(4.21494310024160, -4.218749958739409))
+                .bearing(0.0)
+                .build()
+        nativeMapView.moveBy(12.0, 12.0)
+        val actual = nativeMapView.cameraPosition
+        assertEquals("Bearing should match", expected.bearing, actual.bearing, TestConstants.BEARING_DELTA)
+        assertEquals("Latitude should match", expected.target.latitude, actual.target.latitude, TestConstants.LAT_LNG_DELTA)
+        assertEquals("Longitude should match", expected.target.longitude, actual.target.longitude, TestConstants.LAT_LNG_DELTA)
+        assertEquals("Tilt should match", expected.tilt, actual.tilt, TestConstants.TILT_DELTA)
+        assertEquals("Zoom should match", expected.zoom, actual.zoom, TestConstants.ZOOM_DELTA)
     }
 
     class DummyRenderer(context: Context) : MapRenderer(context, null) {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/maps/VisibleRegionTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/maps/VisibleRegionTest.kt
@@ -2,8 +2,6 @@ package com.mapbox.mapboxsdk.testapp.maps
 
 import android.graphics.PointF
 import android.support.test.espresso.UiController
-import com.mapbox.mapboxsdk.camera.CameraPosition
-import com.mapbox.mapboxsdk.camera.CameraUpdate
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.maps.MapView
@@ -67,10 +65,10 @@ class VisibleRegionTest : BaseActivityTest() {
       )
 
       mapboxMap.setPadding(
-        (mapView.width / 4f).toInt(),
-        (mapView.height / 4f).toInt(),
-        (mapView.width / 4f).toInt(),
-        (mapView.height / 4f).toInt())
+        mapView.width / 4,
+        mapView.height / 4,
+        mapView.width / 4,
+        mapView.height / 4)
 
       val visibleRegion = mapboxMap.projection.getVisibleRegion(false)
       val filtered = latLngs.filter { visibleRegion.latLngBounds.contains(it) }
@@ -96,7 +94,7 @@ class VisibleRegionTest : BaseActivityTest() {
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
       )
 
-      mapboxMap.setPadding((mapView.width / 4f).toInt(), 0, 0, 0)
+      mapboxMap.setPadding(mapView.width / 4, 0, 0, 0)
 
       val visibleRegion = mapboxMap.projection.getVisibleRegion(false)
       val filtered = latLngs.filter { visibleRegion.latLngBounds.contains(it) }
@@ -122,7 +120,7 @@ class VisibleRegionTest : BaseActivityTest() {
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
       )
 
-      mapboxMap.setPadding(0, (mapView.height / 4f).toInt(), 0, 0)
+      mapboxMap.setPadding(0, mapView.height / 4, 0, 0)
 
       val visibleRegion = mapboxMap.projection.getVisibleRegion(false)
       val filtered = latLngs.filter { visibleRegion.latLngBounds.contains(it) }
@@ -148,7 +146,7 @@ class VisibleRegionTest : BaseActivityTest() {
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
       )
 
-      mapboxMap.setPadding(0, 0, (mapView.width / 4f).toInt(), 0)
+      mapboxMap.setPadding(0, 0, mapView.width / 4, 0)
 
       val visibleRegion = mapboxMap.projection.getVisibleRegion(false)
       val filtered = latLngs.filter { visibleRegion.latLngBounds.contains(it) }
@@ -174,7 +172,7 @@ class VisibleRegionTest : BaseActivityTest() {
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
       )
 
-      mapboxMap.setPadding(0, 0, 0, (mapView.height / 4f).toInt())
+      mapboxMap.setPadding(0, 0, 0, mapView.height / 4)
 
       val visibleRegion = mapboxMap.projection.getVisibleRegion(false)
       val filtered = latLngs.filter { visibleRegion.latLngBounds.contains(it) }
@@ -222,10 +220,10 @@ class VisibleRegionTest : BaseActivityTest() {
       )
 
       mapboxMap.setPadding(
-        (mapView.width / 4f).toInt(),
-        (mapView.height / 4f).toInt(),
-        (mapView.width / 4f).toInt(),
-        (mapView.height / 4f).toInt())
+        mapView.width / 4,
+        mapView.height / 4,
+        mapView.width / 4,
+        mapView.height / 4)
 
       val visibleRegion = mapboxMap.projection.getVisibleRegion(false)
       val filtered = latLngs.filter { visibleRegion.latLngBounds.contains(it) }
@@ -251,7 +249,7 @@ class VisibleRegionTest : BaseActivityTest() {
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
       )
 
-      mapboxMap.setPadding((mapView.width / 4f).toInt(), 0, 0, 0)
+      mapboxMap.setPadding(mapView.width / 4, 0, 0, 0)
 
       val visibleRegion = mapboxMap.projection.getVisibleRegion(false)
       val filtered = latLngs.filter { visibleRegion.latLngBounds.contains(it) }
@@ -277,7 +275,7 @@ class VisibleRegionTest : BaseActivityTest() {
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
       )
 
-      mapboxMap.setPadding(0, (mapView.height / 4f).toInt(), 0, 0)
+      mapboxMap.setPadding(0, mapView.height / 4, 0, 0)
 
       val visibleRegion = mapboxMap.projection.getVisibleRegion(false)
       val filtered = latLngs.filter { visibleRegion.latLngBounds.contains(it) }
@@ -303,7 +301,7 @@ class VisibleRegionTest : BaseActivityTest() {
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
       )
 
-      mapboxMap.setPadding(0, 0, (mapView.width / 4f).toInt(), 0)
+      mapboxMap.setPadding(0, 0, mapView.width / 4, 0)
 
       val visibleRegion = mapboxMap.projection.getVisibleRegion(false)
       val filtered = latLngs.filter { visibleRegion.latLngBounds.contains(it) }
@@ -329,7 +327,7 @@ class VisibleRegionTest : BaseActivityTest() {
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
       )
 
-      mapboxMap.setPadding(0, 0, 0, (mapView.height / 4f).toInt())
+      mapboxMap.setPadding(0, 0, 0, mapView.height / 4)
 
       val visibleRegion = mapboxMap.projection.getVisibleRegion(false)
       val filtered = latLngs.filter { visibleRegion.latLngBounds.contains(it) }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/BackgroundLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/BackgroundLayerTest.java
@@ -3,167 +3,139 @@
 package com.mapbox.mapboxsdk.testapp.style;
 
 import android.graphics.Color;
+import android.support.test.annotation.UiThreadTest;
 import android.support.test.runner.AndroidJUnit4;
 
+import com.mapbox.mapboxsdk.maps.BaseLayerTest;
+import org.junit.Before;
 import timber.log.Timber;
 
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.BackgroundLayer;
-import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.*;
-import static com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
-import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
 
 /**
  * Basic smoke tests for BackgroundLayer
  */
 @RunWith(AndroidJUnit4.class)
-public class BackgroundLayerTest extends BaseActivityTest {
+public class BackgroundLayerTest extends BaseLayerTest {
 
   private BackgroundLayer layer;
 
-  @Override
-  protected Class getActivityClass() {
-    return EspressoTestActivity.class;
-  }
-
-  private void setupLayer() {
-    Timber.i("Retrieving layer");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      layer = mapboxMap.getStyle().getLayerAs("background");
-    });
+  @Before
+  @UiThreadTest
+  public void beforeTest(){
+    super.before();
+    layer = new BackgroundLayer("my-layer");
+    setupLayer(layer);
   }
 
   @Test
+  @UiThreadTest
   public void testSetVisibility() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("Visibility");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getVisibility().getValue(), VISIBLE);
+    // Get initial
+    assertEquals(layer.getVisibility().getValue(), VISIBLE);
 
-      // Set
-      layer.setProperties(visibility(NONE));
-      assertEquals(layer.getVisibility().getValue(), NONE);
-    });
+    // Set
+    layer.setProperties(visibility(NONE));
+    assertEquals(layer.getVisibility().getValue(), NONE);
   }
 
   @Test
+  @UiThreadTest
   public void testBackgroundColorTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("background-colorTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setBackgroundColorTransition(options);
-      assertEquals(layer.getBackgroundColorTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setBackgroundColorTransition(options);
+    assertEquals(layer.getBackgroundColorTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testBackgroundColorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("background-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getBackgroundColor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getBackgroundColor().getValue());
 
-      // Set and Get
-      String propertyValue = "rgba(0, 0, 0, 1)";
-      layer.setProperties(backgroundColor(propertyValue));
-      assertEquals(layer.getBackgroundColor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = "rgba(0, 0, 0, 1)";
+    layer.setProperties(backgroundColor(propertyValue));
+    assertEquals(layer.getBackgroundColor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testBackgroundColorAsIntConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("background-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      layer.setProperties(backgroundColor(Color.RED));
-      assertEquals(layer.getBackgroundColorAsInt(), Color.RED);
-    });
+    // Set and Get
+    layer.setProperties(backgroundColor(Color.RED));
+    assertEquals(layer.getBackgroundColorAsInt(), Color.RED);
   }
 
   @Test
+  @UiThreadTest
   public void testBackgroundPatternTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("background-patternTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setBackgroundPatternTransition(options);
-      assertEquals(layer.getBackgroundPatternTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setBackgroundPatternTransition(options);
+    assertEquals(layer.getBackgroundPatternTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testBackgroundPatternAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("background-pattern");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getBackgroundPattern().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getBackgroundPattern().getValue());
 
-      // Set and Get
-      String propertyValue = "pedestrian-polygon";
-      layer.setProperties(backgroundPattern(propertyValue));
-      assertEquals(layer.getBackgroundPattern().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = "pedestrian-polygon";
+    layer.setProperties(backgroundPattern(propertyValue));
+    assertEquals(layer.getBackgroundPattern().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testBackgroundOpacityTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("background-opacityTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setBackgroundOpacityTransition(options);
-      assertEquals(layer.getBackgroundOpacityTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setBackgroundOpacityTransition(options);
+    assertEquals(layer.getBackgroundOpacityTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testBackgroundOpacityAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("background-opacity");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getBackgroundOpacity().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getBackgroundOpacity().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(backgroundOpacity(propertyValue));
-      assertEquals(layer.getBackgroundOpacity().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(backgroundOpacity(propertyValue));
+    assertEquals(layer.getBackgroundOpacity().getValue(), propertyValue);
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CircleLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CircleLayerTest.java
@@ -3,558 +3,451 @@
 package com.mapbox.mapboxsdk.testapp.style;
 
 import android.graphics.Color;
+import android.support.test.annotation.UiThreadTest;
 import android.support.test.runner.AndroidJUnit4;
 
+import com.mapbox.mapboxsdk.maps.BaseLayerTest;
+import org.junit.Before;
 import timber.log.Timber;
 
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.CircleLayer;
-import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.*;
-import static com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
-import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
 
 /**
  * Basic smoke tests for CircleLayer
  */
 @RunWith(AndroidJUnit4.class)
-public class CircleLayerTest extends BaseActivityTest {
+public class CircleLayerTest extends BaseLayerTest {
 
   private CircleLayer layer;
 
-  @Override
-  protected Class getActivityClass() {
-    return EspressoTestActivity.class;
-  }
-
-  private void setupLayer() {
-    Timber.i("Retrieving layer");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      if ((layer = mapboxMap.getStyle().getLayerAs("my-layer")) == null) {
-        Timber.i("Adding layer");
-        layer = new CircleLayer("my-layer", "composite");
-        layer.setSourceLayer("composite");
-        mapboxMap.getStyle().addLayer(layer);
-        // Layer reference is now stale, get new reference
-        layer = mapboxMap.getStyle().getLayerAs("my-layer");
-      }
-    });
+  @Before
+  @UiThreadTest
+  public void beforeTest(){
+    super.before();
+    layer = new CircleLayer("my-layer", "composite");
+    layer.setSourceLayer("composite");
+    setupLayer(layer);
   }
 
   @Test
+  @UiThreadTest
   public void testSourceId() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("SourceId");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      // Get source id
-      assertEquals(layer.getSourceId(), "composite");
-    });
+    assertNotNull(layer);
+    assertEquals(layer.getSourceId(), "composite");
   }
 
   @Test
+  @UiThreadTest
   public void testSetVisibility() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("Visibility");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getVisibility().getValue(), VISIBLE);
+    // Get initial
+    assertEquals(layer.getVisibility().getValue(), VISIBLE);
 
-      // Set
-      layer.setProperties(visibility(NONE));
-      assertEquals(layer.getVisibility().getValue(), NONE);
-    });
+    // Set
+    layer.setProperties(visibility(NONE));
+    assertEquals(layer.getVisibility().getValue(), NONE);
   }
 
   @Test
+  @UiThreadTest
   public void testSourceLayer() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("SourceLayer");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getSourceLayer(), "composite");
+    // Get initial
+    assertEquals(layer.getSourceLayer(), "composite");
 
-      // Set
-      final String sourceLayer = "test";
-      layer.setSourceLayer(sourceLayer);
-      assertEquals(layer.getSourceLayer(), sourceLayer);
-    });
+    // Set
+    final String sourceLayer = "test";
+    layer.setSourceLayer(sourceLayer);
+    assertEquals(layer.getSourceLayer(), sourceLayer);
   }
 
   @Test
+  @UiThreadTest
   public void testFilter() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("Filter");
-    invoke(mapboxMap, (uiController, mapboxMap1) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getFilter(), null);
+    // Get initial
+    assertEquals(layer.getFilter(), null);
 
-      // Set
-      Expression filter = eq(get("undefined"), literal(1.0));
-      layer.setFilter(filter);
-      assertEquals(layer.getFilter().toString(), filter.toString());
+    // Set
+    Expression filter = eq(get("undefined"), literal(1.0));
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
 
-      // Set constant
-      filter = literal(true);
-      layer.setFilter(filter);
-      assertEquals(layer.getFilter().toString(), filter.toString());
-    });
+    // Set constant
+    filter = literal(true);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
   }
 
 
 
   @Test
+  @UiThreadTest
   public void testCircleRadiusTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-radiusTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setCircleRadiusTransition(options);
-      assertEquals(layer.getCircleRadiusTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setCircleRadiusTransition(options);
+    assertEquals(layer.getCircleRadiusTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleRadiusAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-radius");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getCircleRadius().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getCircleRadius().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(circleRadius(propertyValue));
-      assertEquals(layer.getCircleRadius().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(circleRadius(propertyValue));
+    assertEquals(layer.getCircleRadius().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleRadiusAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-radius-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getCircleRadius().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getCircleRadius().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(circleRadius(expression));
-      assertEquals(layer.getCircleRadius().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(circleRadius(expression));
+    assertEquals(layer.getCircleRadius().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleColorTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-colorTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setCircleColorTransition(options);
-      assertEquals(layer.getCircleColorTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setCircleColorTransition(options);
+    assertEquals(layer.getCircleColorTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleColorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getCircleColor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getCircleColor().getValue());
 
-      // Set and Get
-      String propertyValue = "rgba(0, 0, 0, 1)";
-      layer.setProperties(circleColor(propertyValue));
-      assertEquals(layer.getCircleColor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = "rgba(0, 0, 0, 1)";
+    layer.setProperties(circleColor(propertyValue));
+    assertEquals(layer.getCircleColor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleColorAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-color-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getCircleColor().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getCircleColor().getExpression());
 
-      // Set and Get
-      Expression expression = toColor(Expression.get("undefined"));
-      layer.setProperties(circleColor(expression));
-      assertEquals(layer.getCircleColor().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = toColor(Expression.get("undefined"));
+    layer.setProperties(circleColor(expression));
+    assertEquals(layer.getCircleColor().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleColorAsIntConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      layer.setProperties(circleColor(Color.RED));
-      assertEquals(layer.getCircleColorAsInt(), Color.RED);
-    });
+    // Set and Get
+    layer.setProperties(circleColor(Color.RED));
+    assertEquals(layer.getCircleColorAsInt(), Color.RED);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleBlurTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-blurTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setCircleBlurTransition(options);
-      assertEquals(layer.getCircleBlurTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setCircleBlurTransition(options);
+    assertEquals(layer.getCircleBlurTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleBlurAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-blur");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getCircleBlur().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getCircleBlur().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(circleBlur(propertyValue));
-      assertEquals(layer.getCircleBlur().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(circleBlur(propertyValue));
+    assertEquals(layer.getCircleBlur().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleBlurAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-blur-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getCircleBlur().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getCircleBlur().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(circleBlur(expression));
-      assertEquals(layer.getCircleBlur().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(circleBlur(expression));
+    assertEquals(layer.getCircleBlur().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleOpacityTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-opacityTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setCircleOpacityTransition(options);
-      assertEquals(layer.getCircleOpacityTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setCircleOpacityTransition(options);
+    assertEquals(layer.getCircleOpacityTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleOpacityAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-opacity");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getCircleOpacity().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getCircleOpacity().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(circleOpacity(propertyValue));
-      assertEquals(layer.getCircleOpacity().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(circleOpacity(propertyValue));
+    assertEquals(layer.getCircleOpacity().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleOpacityAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-opacity-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getCircleOpacity().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getCircleOpacity().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(circleOpacity(expression));
-      assertEquals(layer.getCircleOpacity().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(circleOpacity(expression));
+    assertEquals(layer.getCircleOpacity().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleTranslateTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-translateTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setCircleTranslateTransition(options);
-      assertEquals(layer.getCircleTranslateTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setCircleTranslateTransition(options);
+    assertEquals(layer.getCircleTranslateTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleTranslateAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-translate");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getCircleTranslate().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getCircleTranslate().getValue());
 
-      // Set and Get
-      Float[] propertyValue = new Float[] {0f, 0f};
-      layer.setProperties(circleTranslate(propertyValue));
-      assertEquals(layer.getCircleTranslate().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float[] propertyValue = new Float[] {0f, 0f};
+    layer.setProperties(circleTranslate(propertyValue));
+    assertEquals(layer.getCircleTranslate().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleTranslateAnchorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-translate-anchor");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getCircleTranslateAnchor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getCircleTranslateAnchor().getValue());
 
-      // Set and Get
-      String propertyValue = CIRCLE_TRANSLATE_ANCHOR_MAP;
-      layer.setProperties(circleTranslateAnchor(propertyValue));
-      assertEquals(layer.getCircleTranslateAnchor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = CIRCLE_TRANSLATE_ANCHOR_MAP;
+    layer.setProperties(circleTranslateAnchor(propertyValue));
+    assertEquals(layer.getCircleTranslateAnchor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testCirclePitchScaleAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-pitch-scale");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getCirclePitchScale().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getCirclePitchScale().getValue());
 
-      // Set and Get
-      String propertyValue = CIRCLE_PITCH_SCALE_MAP;
-      layer.setProperties(circlePitchScale(propertyValue));
-      assertEquals(layer.getCirclePitchScale().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = CIRCLE_PITCH_SCALE_MAP;
+    layer.setProperties(circlePitchScale(propertyValue));
+    assertEquals(layer.getCirclePitchScale().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testCirclePitchAlignmentAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-pitch-alignment");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getCirclePitchAlignment().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getCirclePitchAlignment().getValue());
 
-      // Set and Get
-      String propertyValue = CIRCLE_PITCH_ALIGNMENT_MAP;
-      layer.setProperties(circlePitchAlignment(propertyValue));
-      assertEquals(layer.getCirclePitchAlignment().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = CIRCLE_PITCH_ALIGNMENT_MAP;
+    layer.setProperties(circlePitchAlignment(propertyValue));
+    assertEquals(layer.getCirclePitchAlignment().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleStrokeWidthTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-stroke-widthTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setCircleStrokeWidthTransition(options);
-      assertEquals(layer.getCircleStrokeWidthTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setCircleStrokeWidthTransition(options);
+    assertEquals(layer.getCircleStrokeWidthTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleStrokeWidthAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-stroke-width");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getCircleStrokeWidth().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getCircleStrokeWidth().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(circleStrokeWidth(propertyValue));
-      assertEquals(layer.getCircleStrokeWidth().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(circleStrokeWidth(propertyValue));
+    assertEquals(layer.getCircleStrokeWidth().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleStrokeWidthAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-stroke-width-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getCircleStrokeWidth().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getCircleStrokeWidth().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(circleStrokeWidth(expression));
-      assertEquals(layer.getCircleStrokeWidth().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(circleStrokeWidth(expression));
+    assertEquals(layer.getCircleStrokeWidth().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleStrokeColorTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-stroke-colorTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setCircleStrokeColorTransition(options);
-      assertEquals(layer.getCircleStrokeColorTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setCircleStrokeColorTransition(options);
+    assertEquals(layer.getCircleStrokeColorTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleStrokeColorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-stroke-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getCircleStrokeColor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getCircleStrokeColor().getValue());
 
-      // Set and Get
-      String propertyValue = "rgba(0, 0, 0, 1)";
-      layer.setProperties(circleStrokeColor(propertyValue));
-      assertEquals(layer.getCircleStrokeColor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = "rgba(0, 0, 0, 1)";
+    layer.setProperties(circleStrokeColor(propertyValue));
+    assertEquals(layer.getCircleStrokeColor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleStrokeColorAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-stroke-color-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getCircleStrokeColor().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getCircleStrokeColor().getExpression());
 
-      // Set and Get
-      Expression expression = toColor(Expression.get("undefined"));
-      layer.setProperties(circleStrokeColor(expression));
-      assertEquals(layer.getCircleStrokeColor().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = toColor(Expression.get("undefined"));
+    layer.setProperties(circleStrokeColor(expression));
+    assertEquals(layer.getCircleStrokeColor().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleStrokeColorAsIntConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-stroke-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      layer.setProperties(circleStrokeColor(Color.RED));
-      assertEquals(layer.getCircleStrokeColorAsInt(), Color.RED);
-    });
+    // Set and Get
+    layer.setProperties(circleStrokeColor(Color.RED));
+    assertEquals(layer.getCircleStrokeColorAsInt(), Color.RED);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleStrokeOpacityTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-stroke-opacityTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setCircleStrokeOpacityTransition(options);
-      assertEquals(layer.getCircleStrokeOpacityTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setCircleStrokeOpacityTransition(options);
+    assertEquals(layer.getCircleStrokeOpacityTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleStrokeOpacityAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-stroke-opacity");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getCircleStrokeOpacity().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getCircleStrokeOpacity().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(circleStrokeOpacity(propertyValue));
-      assertEquals(layer.getCircleStrokeOpacity().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(circleStrokeOpacity(propertyValue));
+    assertEquals(layer.getCircleStrokeOpacity().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testCircleStrokeOpacityAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("circle-stroke-opacity-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getCircleStrokeOpacity().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getCircleStrokeOpacity().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(circleStrokeOpacity(expression));
-      assertEquals(layer.getCircleStrokeOpacity().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(circleStrokeOpacity(expression));
+    assertEquals(layer.getCircleStrokeOpacity().getExpression(), expression);
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillExtrusionLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillExtrusionLayerTest.java
@@ -3,418 +3,338 @@
 package com.mapbox.mapboxsdk.testapp.style;
 
 import android.graphics.Color;
+import android.support.test.annotation.UiThreadTest;
 import android.support.test.runner.AndroidJUnit4;
 
+import com.mapbox.mapboxsdk.maps.BaseLayerTest;
+import org.junit.Before;
 import timber.log.Timber;
 
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.FillExtrusionLayer;
-import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.*;
-import static com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
-import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
 
 /**
  * Basic smoke tests for FillExtrusionLayer
  */
 @RunWith(AndroidJUnit4.class)
-public class FillExtrusionLayerTest extends BaseActivityTest {
+public class FillExtrusionLayerTest extends BaseLayerTest {
 
   private FillExtrusionLayer layer;
 
-  @Override
-  protected Class getActivityClass() {
-    return EspressoTestActivity.class;
-  }
-
-  private void setupLayer() {
-    Timber.i("Retrieving layer");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      if ((layer = mapboxMap.getStyle().getLayerAs("my-layer")) == null) {
-        Timber.i("Adding layer");
-        layer = new FillExtrusionLayer("my-layer", "composite");
-        layer.setSourceLayer("composite");
-        mapboxMap.getStyle().addLayer(layer);
-        // Layer reference is now stale, get new reference
-        layer = mapboxMap.getStyle().getLayerAs("my-layer");
-      }
-    });
+  @Before
+  @UiThreadTest
+  public void beforeTest(){
+    super.before();
+    layer = new FillExtrusionLayer("my-layer", "composite");
+    layer.setSourceLayer("composite");
+    setupLayer(layer);
   }
 
   @Test
+  @UiThreadTest
   public void testSourceId() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("SourceId");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      // Get source id
-      assertEquals(layer.getSourceId(), "composite");
-    });
+    assertNotNull(layer);
+    assertEquals(layer.getSourceId(), "composite");
   }
 
   @Test
+  @UiThreadTest
   public void testSetVisibility() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("Visibility");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getVisibility().getValue(), VISIBLE);
+    // Get initial
+    assertEquals(layer.getVisibility().getValue(), VISIBLE);
 
-      // Set
-      layer.setProperties(visibility(NONE));
-      assertEquals(layer.getVisibility().getValue(), NONE);
-    });
+    // Set
+    layer.setProperties(visibility(NONE));
+    assertEquals(layer.getVisibility().getValue(), NONE);
   }
 
   @Test
+  @UiThreadTest
   public void testSourceLayer() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("SourceLayer");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getSourceLayer(), "composite");
+    // Get initial
+    assertEquals(layer.getSourceLayer(), "composite");
 
-      // Set
-      final String sourceLayer = "test";
-      layer.setSourceLayer(sourceLayer);
-      assertEquals(layer.getSourceLayer(), sourceLayer);
-    });
+    // Set
+    final String sourceLayer = "test";
+    layer.setSourceLayer(sourceLayer);
+    assertEquals(layer.getSourceLayer(), sourceLayer);
   }
 
   @Test
+  @UiThreadTest
   public void testFilter() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("Filter");
-    invoke(mapboxMap, (uiController, mapboxMap1) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getFilter(), null);
+    // Get initial
+    assertEquals(layer.getFilter(), null);
 
-      // Set
-      Expression filter = eq(get("undefined"), literal(1.0));
-      layer.setFilter(filter);
-      assertEquals(layer.getFilter().toString(), filter.toString());
+    // Set
+    Expression filter = eq(get("undefined"), literal(1.0));
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
 
-      // Set constant
-      filter = literal(true);
-      layer.setFilter(filter);
-      assertEquals(layer.getFilter().toString(), filter.toString());
-    });
+    // Set constant
+    filter = literal(true);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
   }
 
 
 
   @Test
+  @UiThreadTest
   public void testFillExtrusionOpacityTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-extrusion-opacityTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setFillExtrusionOpacityTransition(options);
-      assertEquals(layer.getFillExtrusionOpacityTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setFillExtrusionOpacityTransition(options);
+    assertEquals(layer.getFillExtrusionOpacityTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testFillExtrusionOpacityAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-extrusion-opacity");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillExtrusionOpacity().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getFillExtrusionOpacity().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(fillExtrusionOpacity(propertyValue));
-      assertEquals(layer.getFillExtrusionOpacity().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(fillExtrusionOpacity(propertyValue));
+    assertEquals(layer.getFillExtrusionOpacity().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testFillExtrusionColorTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-extrusion-colorTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setFillExtrusionColorTransition(options);
-      assertEquals(layer.getFillExtrusionColorTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setFillExtrusionColorTransition(options);
+    assertEquals(layer.getFillExtrusionColorTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testFillExtrusionColorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-extrusion-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillExtrusionColor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getFillExtrusionColor().getValue());
 
-      // Set and Get
-      String propertyValue = "rgba(0, 0, 0, 1)";
-      layer.setProperties(fillExtrusionColor(propertyValue));
-      assertEquals(layer.getFillExtrusionColor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = "rgba(0, 0, 0, 1)";
+    layer.setProperties(fillExtrusionColor(propertyValue));
+    assertEquals(layer.getFillExtrusionColor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testFillExtrusionColorAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-extrusion-color-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillExtrusionColor().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getFillExtrusionColor().getExpression());
 
-      // Set and Get
-      Expression expression = toColor(Expression.get("undefined"));
-      layer.setProperties(fillExtrusionColor(expression));
-      assertEquals(layer.getFillExtrusionColor().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = toColor(Expression.get("undefined"));
+    layer.setProperties(fillExtrusionColor(expression));
+    assertEquals(layer.getFillExtrusionColor().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testFillExtrusionColorAsIntConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-extrusion-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      layer.setProperties(fillExtrusionColor(Color.RED));
-      assertEquals(layer.getFillExtrusionColorAsInt(), Color.RED);
-    });
+    // Set and Get
+    layer.setProperties(fillExtrusionColor(Color.RED));
+    assertEquals(layer.getFillExtrusionColorAsInt(), Color.RED);
   }
 
   @Test
+  @UiThreadTest
   public void testFillExtrusionTranslateTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-extrusion-translateTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setFillExtrusionTranslateTransition(options);
-      assertEquals(layer.getFillExtrusionTranslateTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setFillExtrusionTranslateTransition(options);
+    assertEquals(layer.getFillExtrusionTranslateTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testFillExtrusionTranslateAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-extrusion-translate");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillExtrusionTranslate().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getFillExtrusionTranslate().getValue());
 
-      // Set and Get
-      Float[] propertyValue = new Float[] {0f, 0f};
-      layer.setProperties(fillExtrusionTranslate(propertyValue));
-      assertEquals(layer.getFillExtrusionTranslate().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float[] propertyValue = new Float[] {0f, 0f};
+    layer.setProperties(fillExtrusionTranslate(propertyValue));
+    assertEquals(layer.getFillExtrusionTranslate().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testFillExtrusionTranslateAnchorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-extrusion-translate-anchor");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillExtrusionTranslateAnchor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getFillExtrusionTranslateAnchor().getValue());
 
-      // Set and Get
-      String propertyValue = FILL_EXTRUSION_TRANSLATE_ANCHOR_MAP;
-      layer.setProperties(fillExtrusionTranslateAnchor(propertyValue));
-      assertEquals(layer.getFillExtrusionTranslateAnchor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = FILL_EXTRUSION_TRANSLATE_ANCHOR_MAP;
+    layer.setProperties(fillExtrusionTranslateAnchor(propertyValue));
+    assertEquals(layer.getFillExtrusionTranslateAnchor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testFillExtrusionPatternTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-extrusion-patternTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setFillExtrusionPatternTransition(options);
-      assertEquals(layer.getFillExtrusionPatternTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setFillExtrusionPatternTransition(options);
+    assertEquals(layer.getFillExtrusionPatternTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testFillExtrusionPatternAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-extrusion-pattern");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillExtrusionPattern().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getFillExtrusionPattern().getValue());
 
-      // Set and Get
-      String propertyValue = "pedestrian-polygon";
-      layer.setProperties(fillExtrusionPattern(propertyValue));
-      assertEquals(layer.getFillExtrusionPattern().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = "pedestrian-polygon";
+    layer.setProperties(fillExtrusionPattern(propertyValue));
+    assertEquals(layer.getFillExtrusionPattern().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testFillExtrusionPatternAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-extrusion-pattern-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillExtrusionPattern().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getFillExtrusionPattern().getExpression());
 
-      // Set and Get
-      Expression expression = string(Expression.get("undefined"));
-      layer.setProperties(fillExtrusionPattern(expression));
-      assertEquals(layer.getFillExtrusionPattern().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = string(Expression.get("undefined"));
+    layer.setProperties(fillExtrusionPattern(expression));
+    assertEquals(layer.getFillExtrusionPattern().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testFillExtrusionHeightTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-extrusion-heightTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setFillExtrusionHeightTransition(options);
-      assertEquals(layer.getFillExtrusionHeightTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setFillExtrusionHeightTransition(options);
+    assertEquals(layer.getFillExtrusionHeightTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testFillExtrusionHeightAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-extrusion-height");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillExtrusionHeight().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getFillExtrusionHeight().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(fillExtrusionHeight(propertyValue));
-      assertEquals(layer.getFillExtrusionHeight().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(fillExtrusionHeight(propertyValue));
+    assertEquals(layer.getFillExtrusionHeight().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testFillExtrusionHeightAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-extrusion-height-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillExtrusionHeight().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getFillExtrusionHeight().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(fillExtrusionHeight(expression));
-      assertEquals(layer.getFillExtrusionHeight().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(fillExtrusionHeight(expression));
+    assertEquals(layer.getFillExtrusionHeight().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testFillExtrusionBaseTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-extrusion-baseTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setFillExtrusionBaseTransition(options);
-      assertEquals(layer.getFillExtrusionBaseTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setFillExtrusionBaseTransition(options);
+    assertEquals(layer.getFillExtrusionBaseTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testFillExtrusionBaseAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-extrusion-base");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillExtrusionBase().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getFillExtrusionBase().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(fillExtrusionBase(propertyValue));
-      assertEquals(layer.getFillExtrusionBase().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(fillExtrusionBase(propertyValue));
+    assertEquals(layer.getFillExtrusionBase().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testFillExtrusionBaseAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-extrusion-base-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillExtrusionBase().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getFillExtrusionBase().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(fillExtrusionBase(expression));
-      assertEquals(layer.getFillExtrusionBase().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(fillExtrusionBase(expression));
+    assertEquals(layer.getFillExtrusionBase().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testFillExtrusionVerticalGradientAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-extrusion-vertical-gradient");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillExtrusionVerticalGradient().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getFillExtrusionVerticalGradient().getValue());
 
-      // Set and Get
-      Boolean propertyValue = true;
-      layer.setProperties(fillExtrusionVerticalGradient(propertyValue));
-      assertEquals(layer.getFillExtrusionVerticalGradient().getValue(), propertyValue);
-    });
+    // Set and Get
+    Boolean propertyValue = true;
+    layer.setProperties(fillExtrusionVerticalGradient(propertyValue));
+    assertEquals(layer.getFillExtrusionVerticalGradient().getValue(), propertyValue);
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillLayerTest.java
@@ -3,401 +3,324 @@
 package com.mapbox.mapboxsdk.testapp.style;
 
 import android.graphics.Color;
+import android.support.test.annotation.UiThreadTest;
 import android.support.test.runner.AndroidJUnit4;
 
+import com.mapbox.mapboxsdk.maps.BaseLayerTest;
+import org.junit.Before;
 import timber.log.Timber;
 
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.FillLayer;
-import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.*;
-import static com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
-import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
 
 /**
  * Basic smoke tests for FillLayer
  */
 @RunWith(AndroidJUnit4.class)
-public class FillLayerTest extends BaseActivityTest {
+public class FillLayerTest extends BaseLayerTest {
 
   private FillLayer layer;
 
-  @Override
-  protected Class getActivityClass() {
-    return EspressoTestActivity.class;
-  }
-
-  private void setupLayer() {
-    Timber.i("Retrieving layer");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      if ((layer = mapboxMap.getStyle().getLayerAs("my-layer")) == null) {
-        Timber.i("Adding layer");
-        layer = new FillLayer("my-layer", "composite");
-        layer.setSourceLayer("composite");
-        mapboxMap.getStyle().addLayer(layer);
-        // Layer reference is now stale, get new reference
-        layer = mapboxMap.getStyle().getLayerAs("my-layer");
-      }
-    });
+  @Before
+  @UiThreadTest
+  public void beforeTest(){
+    super.before();
+    layer = new FillLayer("my-layer", "composite");
+    layer.setSourceLayer("composite");
+    setupLayer(layer);
   }
 
   @Test
+  @UiThreadTest
   public void testSourceId() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("SourceId");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      // Get source id
-      assertEquals(layer.getSourceId(), "composite");
-    });
+    assertNotNull(layer);
+    assertEquals(layer.getSourceId(), "composite");
   }
 
   @Test
+  @UiThreadTest
   public void testSetVisibility() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("Visibility");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getVisibility().getValue(), VISIBLE);
+    // Get initial
+    assertEquals(layer.getVisibility().getValue(), VISIBLE);
 
-      // Set
-      layer.setProperties(visibility(NONE));
-      assertEquals(layer.getVisibility().getValue(), NONE);
-    });
+    // Set
+    layer.setProperties(visibility(NONE));
+    assertEquals(layer.getVisibility().getValue(), NONE);
   }
 
   @Test
+  @UiThreadTest
   public void testSourceLayer() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("SourceLayer");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getSourceLayer(), "composite");
+    // Get initial
+    assertEquals(layer.getSourceLayer(), "composite");
 
-      // Set
-      final String sourceLayer = "test";
-      layer.setSourceLayer(sourceLayer);
-      assertEquals(layer.getSourceLayer(), sourceLayer);
-    });
+    // Set
+    final String sourceLayer = "test";
+    layer.setSourceLayer(sourceLayer);
+    assertEquals(layer.getSourceLayer(), sourceLayer);
   }
 
   @Test
+  @UiThreadTest
   public void testFilter() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("Filter");
-    invoke(mapboxMap, (uiController, mapboxMap1) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getFilter(), null);
+    // Get initial
+    assertEquals(layer.getFilter(), null);
 
-      // Set
-      Expression filter = eq(get("undefined"), literal(1.0));
-      layer.setFilter(filter);
-      assertEquals(layer.getFilter().toString(), filter.toString());
+    // Set
+    Expression filter = eq(get("undefined"), literal(1.0));
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
 
-      // Set constant
-      filter = literal(true);
-      layer.setFilter(filter);
-      assertEquals(layer.getFilter().toString(), filter.toString());
-    });
+    // Set constant
+    filter = literal(true);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
   }
 
 
 
   @Test
+  @UiThreadTest
   public void testFillAntialiasAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-antialias");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillAntialias().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getFillAntialias().getValue());
 
-      // Set and Get
-      Boolean propertyValue = true;
-      layer.setProperties(fillAntialias(propertyValue));
-      assertEquals(layer.getFillAntialias().getValue(), propertyValue);
-    });
+    // Set and Get
+    Boolean propertyValue = true;
+    layer.setProperties(fillAntialias(propertyValue));
+    assertEquals(layer.getFillAntialias().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testFillOpacityTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-opacityTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setFillOpacityTransition(options);
-      assertEquals(layer.getFillOpacityTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setFillOpacityTransition(options);
+    assertEquals(layer.getFillOpacityTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testFillOpacityAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-opacity");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillOpacity().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getFillOpacity().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(fillOpacity(propertyValue));
-      assertEquals(layer.getFillOpacity().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(fillOpacity(propertyValue));
+    assertEquals(layer.getFillOpacity().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testFillOpacityAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-opacity-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillOpacity().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getFillOpacity().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(fillOpacity(expression));
-      assertEquals(layer.getFillOpacity().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(fillOpacity(expression));
+    assertEquals(layer.getFillOpacity().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testFillColorTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-colorTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setFillColorTransition(options);
-      assertEquals(layer.getFillColorTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setFillColorTransition(options);
+    assertEquals(layer.getFillColorTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testFillColorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillColor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getFillColor().getValue());
 
-      // Set and Get
-      String propertyValue = "rgba(0, 0, 0, 1)";
-      layer.setProperties(fillColor(propertyValue));
-      assertEquals(layer.getFillColor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = "rgba(0, 0, 0, 1)";
+    layer.setProperties(fillColor(propertyValue));
+    assertEquals(layer.getFillColor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testFillColorAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-color-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillColor().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getFillColor().getExpression());
 
-      // Set and Get
-      Expression expression = toColor(Expression.get("undefined"));
-      layer.setProperties(fillColor(expression));
-      assertEquals(layer.getFillColor().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = toColor(Expression.get("undefined"));
+    layer.setProperties(fillColor(expression));
+    assertEquals(layer.getFillColor().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testFillColorAsIntConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      layer.setProperties(fillColor(Color.RED));
-      assertEquals(layer.getFillColorAsInt(), Color.RED);
-    });
+    // Set and Get
+    layer.setProperties(fillColor(Color.RED));
+    assertEquals(layer.getFillColorAsInt(), Color.RED);
   }
 
   @Test
+  @UiThreadTest
   public void testFillOutlineColorTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-outline-colorTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setFillOutlineColorTransition(options);
-      assertEquals(layer.getFillOutlineColorTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setFillOutlineColorTransition(options);
+    assertEquals(layer.getFillOutlineColorTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testFillOutlineColorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-outline-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillOutlineColor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getFillOutlineColor().getValue());
 
-      // Set and Get
-      String propertyValue = "rgba(0, 0, 0, 1)";
-      layer.setProperties(fillOutlineColor(propertyValue));
-      assertEquals(layer.getFillOutlineColor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = "rgba(0, 0, 0, 1)";
+    layer.setProperties(fillOutlineColor(propertyValue));
+    assertEquals(layer.getFillOutlineColor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testFillOutlineColorAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-outline-color-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillOutlineColor().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getFillOutlineColor().getExpression());
 
-      // Set and Get
-      Expression expression = toColor(Expression.get("undefined"));
-      layer.setProperties(fillOutlineColor(expression));
-      assertEquals(layer.getFillOutlineColor().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = toColor(Expression.get("undefined"));
+    layer.setProperties(fillOutlineColor(expression));
+    assertEquals(layer.getFillOutlineColor().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testFillOutlineColorAsIntConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-outline-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      layer.setProperties(fillOutlineColor(Color.RED));
-      assertEquals(layer.getFillOutlineColorAsInt(), Color.RED);
-    });
+    // Set and Get
+    layer.setProperties(fillOutlineColor(Color.RED));
+    assertEquals(layer.getFillOutlineColorAsInt(), Color.RED);
   }
 
   @Test
+  @UiThreadTest
   public void testFillTranslateTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-translateTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setFillTranslateTransition(options);
-      assertEquals(layer.getFillTranslateTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setFillTranslateTransition(options);
+    assertEquals(layer.getFillTranslateTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testFillTranslateAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-translate");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillTranslate().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getFillTranslate().getValue());
 
-      // Set and Get
-      Float[] propertyValue = new Float[] {0f, 0f};
-      layer.setProperties(fillTranslate(propertyValue));
-      assertEquals(layer.getFillTranslate().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float[] propertyValue = new Float[] {0f, 0f};
+    layer.setProperties(fillTranslate(propertyValue));
+    assertEquals(layer.getFillTranslate().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testFillTranslateAnchorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-translate-anchor");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillTranslateAnchor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getFillTranslateAnchor().getValue());
 
-      // Set and Get
-      String propertyValue = FILL_TRANSLATE_ANCHOR_MAP;
-      layer.setProperties(fillTranslateAnchor(propertyValue));
-      assertEquals(layer.getFillTranslateAnchor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = FILL_TRANSLATE_ANCHOR_MAP;
+    layer.setProperties(fillTranslateAnchor(propertyValue));
+    assertEquals(layer.getFillTranslateAnchor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testFillPatternTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-patternTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setFillPatternTransition(options);
-      assertEquals(layer.getFillPatternTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setFillPatternTransition(options);
+    assertEquals(layer.getFillPatternTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testFillPatternAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-pattern");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillPattern().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getFillPattern().getValue());
 
-      // Set and Get
-      String propertyValue = "pedestrian-polygon";
-      layer.setProperties(fillPattern(propertyValue));
-      assertEquals(layer.getFillPattern().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = "pedestrian-polygon";
+    layer.setProperties(fillPattern(propertyValue));
+    assertEquals(layer.getFillPattern().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testFillPatternAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("fill-pattern-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getFillPattern().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getFillPattern().getExpression());
 
-      // Set and Get
-      Expression expression = string(Expression.get("undefined"));
-      layer.setProperties(fillPattern(expression));
-      assertEquals(layer.getFillPattern().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = string(Expression.get("undefined"));
+    layer.setProperties(fillPattern(expression));
+    assertEquals(layer.getFillPattern().getExpression(), expression);
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HeatmapLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HeatmapLayerTest.java
@@ -3,263 +3,213 @@
 package com.mapbox.mapboxsdk.testapp.style;
 
 import android.graphics.Color;
+import android.support.test.annotation.UiThreadTest;
 import android.support.test.runner.AndroidJUnit4;
 
+import com.mapbox.mapboxsdk.maps.BaseLayerTest;
+import org.junit.Before;
 import timber.log.Timber;
 
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.HeatmapLayer;
-import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.*;
-import static com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
-import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
 
 /**
  * Basic smoke tests for HeatmapLayer
  */
 @RunWith(AndroidJUnit4.class)
-public class HeatmapLayerTest extends BaseActivityTest {
+public class HeatmapLayerTest extends BaseLayerTest {
 
   private HeatmapLayer layer;
 
-  @Override
-  protected Class getActivityClass() {
-    return EspressoTestActivity.class;
-  }
-
-  private void setupLayer() {
-    Timber.i("Retrieving layer");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      if ((layer = mapboxMap.getStyle().getLayerAs("my-layer")) == null) {
-        Timber.i("Adding layer");
-        layer = new HeatmapLayer("my-layer", "composite");
-        layer.setSourceLayer("composite");
-        mapboxMap.getStyle().addLayer(layer);
-        // Layer reference is now stale, get new reference
-        layer = mapboxMap.getStyle().getLayerAs("my-layer");
-      }
-    });
+  @Before
+  @UiThreadTest
+  public void beforeTest(){
+    super.before();
+    layer = new HeatmapLayer("my-layer", "composite");
+    layer.setSourceLayer("composite");
+    setupLayer(layer);
   }
 
   @Test
+  @UiThreadTest
   public void testSourceId() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("SourceId");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      // Get source id
-      assertEquals(layer.getSourceId(), "composite");
-    });
+    assertNotNull(layer);
+    assertEquals(layer.getSourceId(), "composite");
   }
 
   @Test
+  @UiThreadTest
   public void testSetVisibility() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("Visibility");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getVisibility().getValue(), VISIBLE);
+    // Get initial
+    assertEquals(layer.getVisibility().getValue(), VISIBLE);
 
-      // Set
-      layer.setProperties(visibility(NONE));
-      assertEquals(layer.getVisibility().getValue(), NONE);
-    });
+    // Set
+    layer.setProperties(visibility(NONE));
+    assertEquals(layer.getVisibility().getValue(), NONE);
   }
 
   @Test
+  @UiThreadTest
   public void testSourceLayer() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("SourceLayer");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getSourceLayer(), "composite");
+    // Get initial
+    assertEquals(layer.getSourceLayer(), "composite");
 
-      // Set
-      final String sourceLayer = "test";
-      layer.setSourceLayer(sourceLayer);
-      assertEquals(layer.getSourceLayer(), sourceLayer);
-    });
+    // Set
+    final String sourceLayer = "test";
+    layer.setSourceLayer(sourceLayer);
+    assertEquals(layer.getSourceLayer(), sourceLayer);
   }
 
   @Test
+  @UiThreadTest
   public void testFilter() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("Filter");
-    invoke(mapboxMap, (uiController, mapboxMap1) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getFilter(), null);
+    // Get initial
+    assertEquals(layer.getFilter(), null);
 
-      // Set
-      Expression filter = eq(get("undefined"), literal(1.0));
-      layer.setFilter(filter);
-      assertEquals(layer.getFilter().toString(), filter.toString());
+    // Set
+    Expression filter = eq(get("undefined"), literal(1.0));
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
 
-      // Set constant
-      filter = literal(true);
-      layer.setFilter(filter);
-      assertEquals(layer.getFilter().toString(), filter.toString());
-    });
+    // Set constant
+    filter = literal(true);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
   }
 
 
 
   @Test
+  @UiThreadTest
   public void testHeatmapRadiusTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("heatmap-radiusTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setHeatmapRadiusTransition(options);
-      assertEquals(layer.getHeatmapRadiusTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setHeatmapRadiusTransition(options);
+    assertEquals(layer.getHeatmapRadiusTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testHeatmapRadiusAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("heatmap-radius");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getHeatmapRadius().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getHeatmapRadius().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(heatmapRadius(propertyValue));
-      assertEquals(layer.getHeatmapRadius().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(heatmapRadius(propertyValue));
+    assertEquals(layer.getHeatmapRadius().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testHeatmapRadiusAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("heatmap-radius-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getHeatmapRadius().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getHeatmapRadius().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(heatmapRadius(expression));
-      assertEquals(layer.getHeatmapRadius().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(heatmapRadius(expression));
+    assertEquals(layer.getHeatmapRadius().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testHeatmapWeightAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("heatmap-weight");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getHeatmapWeight().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getHeatmapWeight().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(heatmapWeight(propertyValue));
-      assertEquals(layer.getHeatmapWeight().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(heatmapWeight(propertyValue));
+    assertEquals(layer.getHeatmapWeight().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testHeatmapWeightAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("heatmap-weight-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getHeatmapWeight().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getHeatmapWeight().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(heatmapWeight(expression));
-      assertEquals(layer.getHeatmapWeight().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(heatmapWeight(expression));
+    assertEquals(layer.getHeatmapWeight().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testHeatmapIntensityTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("heatmap-intensityTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setHeatmapIntensityTransition(options);
-      assertEquals(layer.getHeatmapIntensityTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setHeatmapIntensityTransition(options);
+    assertEquals(layer.getHeatmapIntensityTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testHeatmapIntensityAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("heatmap-intensity");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getHeatmapIntensity().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getHeatmapIntensity().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(heatmapIntensity(propertyValue));
-      assertEquals(layer.getHeatmapIntensity().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(heatmapIntensity(propertyValue));
+    assertEquals(layer.getHeatmapIntensity().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testHeatmapOpacityTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("heatmap-opacityTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setHeatmapOpacityTransition(options);
-      assertEquals(layer.getHeatmapOpacityTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setHeatmapOpacityTransition(options);
+    assertEquals(layer.getHeatmapOpacityTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testHeatmapOpacityAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("heatmap-opacity");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getHeatmapOpacity().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getHeatmapOpacity().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(heatmapOpacity(propertyValue));
-      assertEquals(layer.getHeatmapOpacity().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(heatmapOpacity(propertyValue));
+    assertEquals(layer.getHeatmapOpacity().getValue(), propertyValue);
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HillshadeLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HillshadeLayerTest.java
@@ -3,277 +3,221 @@
 package com.mapbox.mapboxsdk.testapp.style;
 
 import android.graphics.Color;
+import android.support.test.annotation.UiThreadTest;
 import android.support.test.runner.AndroidJUnit4;
 
+import com.mapbox.mapboxsdk.maps.BaseLayerTest;
+import org.junit.Before;
 import timber.log.Timber;
 
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.HillshadeLayer;
-import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.*;
-import static com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
-import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
 
 /**
  * Basic smoke tests for HillshadeLayer
  */
 @RunWith(AndroidJUnit4.class)
-public class HillshadeLayerTest extends BaseActivityTest {
+public class HillshadeLayerTest extends BaseLayerTest {
 
   private HillshadeLayer layer;
 
-  @Override
-  protected Class getActivityClass() {
-    return EspressoTestActivity.class;
-  }
-
-  private void setupLayer() {
-    Timber.i("Retrieving layer");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      if ((layer = mapboxMap.getStyle().getLayerAs("my-layer")) == null) {
-        Timber.i("Adding layer");
-        layer = new HillshadeLayer("my-layer", "composite");
-        layer.setSourceLayer("composite");
-        mapboxMap.getStyle().addLayer(layer);
-        // Layer reference is now stale, get new reference
-        layer = mapboxMap.getStyle().getLayerAs("my-layer");
-      }
-    });
+  @Before
+  @UiThreadTest
+  public void beforeTest(){
+    super.before();
+    layer = new HillshadeLayer("my-layer", "composite");
+    layer.setSourceLayer("composite");
+    setupLayer(layer);
   }
 
   @Test
+  @UiThreadTest
   public void testSourceId() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("SourceId");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      // Get source id
-      assertEquals(layer.getSourceId(), "composite");
-    });
+    assertNotNull(layer);
+    assertEquals(layer.getSourceId(), "composite");
   }
 
   @Test
+  @UiThreadTest
   public void testSetVisibility() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("Visibility");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getVisibility().getValue(), VISIBLE);
+    // Get initial
+    assertEquals(layer.getVisibility().getValue(), VISIBLE);
 
-      // Set
-      layer.setProperties(visibility(NONE));
-      assertEquals(layer.getVisibility().getValue(), NONE);
-    });
+    // Set
+    layer.setProperties(visibility(NONE));
+    assertEquals(layer.getVisibility().getValue(), NONE);
   }
 
   @Test
+  @UiThreadTest
   public void testHillshadeIlluminationDirectionAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("hillshade-illumination-direction");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getHillshadeIlluminationDirection().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getHillshadeIlluminationDirection().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(hillshadeIlluminationDirection(propertyValue));
-      assertEquals(layer.getHillshadeIlluminationDirection().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(hillshadeIlluminationDirection(propertyValue));
+    assertEquals(layer.getHillshadeIlluminationDirection().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testHillshadeIlluminationAnchorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("hillshade-illumination-anchor");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getHillshadeIlluminationAnchor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getHillshadeIlluminationAnchor().getValue());
 
-      // Set and Get
-      String propertyValue = HILLSHADE_ILLUMINATION_ANCHOR_MAP;
-      layer.setProperties(hillshadeIlluminationAnchor(propertyValue));
-      assertEquals(layer.getHillshadeIlluminationAnchor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = HILLSHADE_ILLUMINATION_ANCHOR_MAP;
+    layer.setProperties(hillshadeIlluminationAnchor(propertyValue));
+    assertEquals(layer.getHillshadeIlluminationAnchor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testHillshadeExaggerationTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("hillshade-exaggerationTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setHillshadeExaggerationTransition(options);
-      assertEquals(layer.getHillshadeExaggerationTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setHillshadeExaggerationTransition(options);
+    assertEquals(layer.getHillshadeExaggerationTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testHillshadeExaggerationAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("hillshade-exaggeration");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getHillshadeExaggeration().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getHillshadeExaggeration().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(hillshadeExaggeration(propertyValue));
-      assertEquals(layer.getHillshadeExaggeration().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(hillshadeExaggeration(propertyValue));
+    assertEquals(layer.getHillshadeExaggeration().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testHillshadeShadowColorTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("hillshade-shadow-colorTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setHillshadeShadowColorTransition(options);
-      assertEquals(layer.getHillshadeShadowColorTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setHillshadeShadowColorTransition(options);
+    assertEquals(layer.getHillshadeShadowColorTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testHillshadeShadowColorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("hillshade-shadow-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getHillshadeShadowColor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getHillshadeShadowColor().getValue());
 
-      // Set and Get
-      String propertyValue = "rgba(0, 0, 0, 1)";
-      layer.setProperties(hillshadeShadowColor(propertyValue));
-      assertEquals(layer.getHillshadeShadowColor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = "rgba(0, 0, 0, 1)";
+    layer.setProperties(hillshadeShadowColor(propertyValue));
+    assertEquals(layer.getHillshadeShadowColor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testHillshadeShadowColorAsIntConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("hillshade-shadow-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      layer.setProperties(hillshadeShadowColor(Color.RED));
-      assertEquals(layer.getHillshadeShadowColorAsInt(), Color.RED);
-    });
+    // Set and Get
+    layer.setProperties(hillshadeShadowColor(Color.RED));
+    assertEquals(layer.getHillshadeShadowColorAsInt(), Color.RED);
   }
 
   @Test
+  @UiThreadTest
   public void testHillshadeHighlightColorTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("hillshade-highlight-colorTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setHillshadeHighlightColorTransition(options);
-      assertEquals(layer.getHillshadeHighlightColorTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setHillshadeHighlightColorTransition(options);
+    assertEquals(layer.getHillshadeHighlightColorTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testHillshadeHighlightColorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("hillshade-highlight-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getHillshadeHighlightColor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getHillshadeHighlightColor().getValue());
 
-      // Set and Get
-      String propertyValue = "rgba(0, 0, 0, 1)";
-      layer.setProperties(hillshadeHighlightColor(propertyValue));
-      assertEquals(layer.getHillshadeHighlightColor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = "rgba(0, 0, 0, 1)";
+    layer.setProperties(hillshadeHighlightColor(propertyValue));
+    assertEquals(layer.getHillshadeHighlightColor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testHillshadeHighlightColorAsIntConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("hillshade-highlight-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      layer.setProperties(hillshadeHighlightColor(Color.RED));
-      assertEquals(layer.getHillshadeHighlightColorAsInt(), Color.RED);
-    });
+    // Set and Get
+    layer.setProperties(hillshadeHighlightColor(Color.RED));
+    assertEquals(layer.getHillshadeHighlightColorAsInt(), Color.RED);
   }
 
   @Test
+  @UiThreadTest
   public void testHillshadeAccentColorTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("hillshade-accent-colorTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setHillshadeAccentColorTransition(options);
-      assertEquals(layer.getHillshadeAccentColorTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setHillshadeAccentColorTransition(options);
+    assertEquals(layer.getHillshadeAccentColorTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testHillshadeAccentColorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("hillshade-accent-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getHillshadeAccentColor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getHillshadeAccentColor().getValue());
 
-      // Set and Get
-      String propertyValue = "rgba(0, 0, 0, 1)";
-      layer.setProperties(hillshadeAccentColor(propertyValue));
-      assertEquals(layer.getHillshadeAccentColor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = "rgba(0, 0, 0, 1)";
+    layer.setProperties(hillshadeAccentColor(propertyValue));
+    assertEquals(layer.getHillshadeAccentColor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testHillshadeAccentColorAsIntConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("hillshade-accent-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      layer.setProperties(hillshadeAccentColor(Color.RED));
-      assertEquals(layer.getHillshadeAccentColorAsInt(), Color.RED);
-    });
+    // Set and Get
+    layer.setProperties(hillshadeAccentColor(Color.RED));
+    assertEquals(layer.getHillshadeAccentColorAsInt(), Color.RED);
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
@@ -3,607 +3,491 @@
 package com.mapbox.mapboxsdk.testapp.style;
 
 import android.graphics.Color;
+import android.support.test.annotation.UiThreadTest;
 import android.support.test.runner.AndroidJUnit4;
 
+import com.mapbox.mapboxsdk.maps.BaseLayerTest;
+import org.junit.Before;
 import timber.log.Timber;
 
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.LineLayer;
-import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.*;
-import static com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
-import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
 
 /**
  * Basic smoke tests for LineLayer
  */
 @RunWith(AndroidJUnit4.class)
-public class LineLayerTest extends BaseActivityTest {
+public class LineLayerTest extends BaseLayerTest {
 
   private LineLayer layer;
 
-  @Override
-  protected Class getActivityClass() {
-    return EspressoTestActivity.class;
-  }
-
-  private void setupLayer() {
-    Timber.i("Retrieving layer");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      if ((layer = mapboxMap.getStyle().getLayerAs("my-layer")) == null) {
-        Timber.i("Adding layer");
-        layer = new LineLayer("my-layer", "composite");
-        layer.setSourceLayer("composite");
-        mapboxMap.getStyle().addLayer(layer);
-        // Layer reference is now stale, get new reference
-        layer = mapboxMap.getStyle().getLayerAs("my-layer");
-      }
-    });
+  @Before
+  @UiThreadTest
+  public void beforeTest(){
+    super.before();
+    layer = new LineLayer("my-layer", "composite");
+    layer.setSourceLayer("composite");
+    setupLayer(layer);
   }
 
   @Test
+  @UiThreadTest
   public void testSourceId() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("SourceId");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      // Get source id
-      assertEquals(layer.getSourceId(), "composite");
-    });
+    assertNotNull(layer);
+    assertEquals(layer.getSourceId(), "composite");
   }
 
   @Test
+  @UiThreadTest
   public void testSetVisibility() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("Visibility");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getVisibility().getValue(), VISIBLE);
+    // Get initial
+    assertEquals(layer.getVisibility().getValue(), VISIBLE);
 
-      // Set
-      layer.setProperties(visibility(NONE));
-      assertEquals(layer.getVisibility().getValue(), NONE);
-    });
+    // Set
+    layer.setProperties(visibility(NONE));
+    assertEquals(layer.getVisibility().getValue(), NONE);
   }
 
   @Test
+  @UiThreadTest
   public void testSourceLayer() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("SourceLayer");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getSourceLayer(), "composite");
+    // Get initial
+    assertEquals(layer.getSourceLayer(), "composite");
 
-      // Set
-      final String sourceLayer = "test";
-      layer.setSourceLayer(sourceLayer);
-      assertEquals(layer.getSourceLayer(), sourceLayer);
-    });
+    // Set
+    final String sourceLayer = "test";
+    layer.setSourceLayer(sourceLayer);
+    assertEquals(layer.getSourceLayer(), sourceLayer);
   }
 
   @Test
+  @UiThreadTest
   public void testFilter() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("Filter");
-    invoke(mapboxMap, (uiController, mapboxMap1) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getFilter(), null);
+    // Get initial
+    assertEquals(layer.getFilter(), null);
 
-      // Set
-      Expression filter = eq(get("undefined"), literal(1.0));
-      layer.setFilter(filter);
-      assertEquals(layer.getFilter().toString(), filter.toString());
+    // Set
+    Expression filter = eq(get("undefined"), literal(1.0));
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
 
-      // Set constant
-      filter = literal(true);
-      layer.setFilter(filter);
-      assertEquals(layer.getFilter().toString(), filter.toString());
-    });
+    // Set constant
+    filter = literal(true);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
   }
 
 
 
   @Test
+  @UiThreadTest
   public void testLineCapAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-cap");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getLineCap().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getLineCap().getValue());
 
-      // Set and Get
-      String propertyValue = LINE_CAP_BUTT;
-      layer.setProperties(lineCap(propertyValue));
-      assertEquals(layer.getLineCap().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = LINE_CAP_BUTT;
+    layer.setProperties(lineCap(propertyValue));
+    assertEquals(layer.getLineCap().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testLineJoinAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-join");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getLineJoin().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getLineJoin().getValue());
 
-      // Set and Get
-      String propertyValue = LINE_JOIN_BEVEL;
-      layer.setProperties(lineJoin(propertyValue));
-      assertEquals(layer.getLineJoin().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = LINE_JOIN_BEVEL;
+    layer.setProperties(lineJoin(propertyValue));
+    assertEquals(layer.getLineJoin().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testLineJoinAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-join-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getLineJoin().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getLineJoin().getExpression());
 
-      // Set and Get
-      Expression expression = string(Expression.get("undefined"));
-      layer.setProperties(lineJoin(expression));
-      assertEquals(layer.getLineJoin().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = string(Expression.get("undefined"));
+    layer.setProperties(lineJoin(expression));
+    assertEquals(layer.getLineJoin().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testLineMiterLimitAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-miter-limit");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getLineMiterLimit().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getLineMiterLimit().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(lineMiterLimit(propertyValue));
-      assertEquals(layer.getLineMiterLimit().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(lineMiterLimit(propertyValue));
+    assertEquals(layer.getLineMiterLimit().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testLineRoundLimitAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-round-limit");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getLineRoundLimit().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getLineRoundLimit().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(lineRoundLimit(propertyValue));
-      assertEquals(layer.getLineRoundLimit().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(lineRoundLimit(propertyValue));
+    assertEquals(layer.getLineRoundLimit().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testLineOpacityTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-opacityTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setLineOpacityTransition(options);
-      assertEquals(layer.getLineOpacityTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setLineOpacityTransition(options);
+    assertEquals(layer.getLineOpacityTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testLineOpacityAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-opacity");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getLineOpacity().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getLineOpacity().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(lineOpacity(propertyValue));
-      assertEquals(layer.getLineOpacity().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(lineOpacity(propertyValue));
+    assertEquals(layer.getLineOpacity().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testLineOpacityAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-opacity-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getLineOpacity().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getLineOpacity().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(lineOpacity(expression));
-      assertEquals(layer.getLineOpacity().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(lineOpacity(expression));
+    assertEquals(layer.getLineOpacity().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testLineColorTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-colorTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setLineColorTransition(options);
-      assertEquals(layer.getLineColorTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setLineColorTransition(options);
+    assertEquals(layer.getLineColorTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testLineColorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getLineColor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getLineColor().getValue());
 
-      // Set and Get
-      String propertyValue = "rgba(0, 0, 0, 1)";
-      layer.setProperties(lineColor(propertyValue));
-      assertEquals(layer.getLineColor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = "rgba(0, 0, 0, 1)";
+    layer.setProperties(lineColor(propertyValue));
+    assertEquals(layer.getLineColor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testLineColorAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-color-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getLineColor().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getLineColor().getExpression());
 
-      // Set and Get
-      Expression expression = toColor(Expression.get("undefined"));
-      layer.setProperties(lineColor(expression));
-      assertEquals(layer.getLineColor().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = toColor(Expression.get("undefined"));
+    layer.setProperties(lineColor(expression));
+    assertEquals(layer.getLineColor().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testLineColorAsIntConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      layer.setProperties(lineColor(Color.RED));
-      assertEquals(layer.getLineColorAsInt(), Color.RED);
-    });
+    // Set and Get
+    layer.setProperties(lineColor(Color.RED));
+    assertEquals(layer.getLineColorAsInt(), Color.RED);
   }
 
   @Test
+  @UiThreadTest
   public void testLineTranslateTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-translateTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setLineTranslateTransition(options);
-      assertEquals(layer.getLineTranslateTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setLineTranslateTransition(options);
+    assertEquals(layer.getLineTranslateTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testLineTranslateAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-translate");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getLineTranslate().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getLineTranslate().getValue());
 
-      // Set and Get
-      Float[] propertyValue = new Float[] {0f, 0f};
-      layer.setProperties(lineTranslate(propertyValue));
-      assertEquals(layer.getLineTranslate().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float[] propertyValue = new Float[] {0f, 0f};
+    layer.setProperties(lineTranslate(propertyValue));
+    assertEquals(layer.getLineTranslate().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testLineTranslateAnchorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-translate-anchor");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getLineTranslateAnchor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getLineTranslateAnchor().getValue());
 
-      // Set and Get
-      String propertyValue = LINE_TRANSLATE_ANCHOR_MAP;
-      layer.setProperties(lineTranslateAnchor(propertyValue));
-      assertEquals(layer.getLineTranslateAnchor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = LINE_TRANSLATE_ANCHOR_MAP;
+    layer.setProperties(lineTranslateAnchor(propertyValue));
+    assertEquals(layer.getLineTranslateAnchor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testLineWidthTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-widthTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setLineWidthTransition(options);
-      assertEquals(layer.getLineWidthTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setLineWidthTransition(options);
+    assertEquals(layer.getLineWidthTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testLineWidthAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-width");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getLineWidth().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getLineWidth().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(lineWidth(propertyValue));
-      assertEquals(layer.getLineWidth().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(lineWidth(propertyValue));
+    assertEquals(layer.getLineWidth().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testLineWidthAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-width-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getLineWidth().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getLineWidth().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(lineWidth(expression));
-      assertEquals(layer.getLineWidth().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(lineWidth(expression));
+    assertEquals(layer.getLineWidth().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testLineGapWidthTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-gap-widthTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setLineGapWidthTransition(options);
-      assertEquals(layer.getLineGapWidthTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setLineGapWidthTransition(options);
+    assertEquals(layer.getLineGapWidthTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testLineGapWidthAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-gap-width");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getLineGapWidth().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getLineGapWidth().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(lineGapWidth(propertyValue));
-      assertEquals(layer.getLineGapWidth().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(lineGapWidth(propertyValue));
+    assertEquals(layer.getLineGapWidth().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testLineGapWidthAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-gap-width-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getLineGapWidth().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getLineGapWidth().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(lineGapWidth(expression));
-      assertEquals(layer.getLineGapWidth().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(lineGapWidth(expression));
+    assertEquals(layer.getLineGapWidth().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testLineOffsetTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-offsetTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setLineOffsetTransition(options);
-      assertEquals(layer.getLineOffsetTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setLineOffsetTransition(options);
+    assertEquals(layer.getLineOffsetTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testLineOffsetAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-offset");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getLineOffset().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getLineOffset().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(lineOffset(propertyValue));
-      assertEquals(layer.getLineOffset().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(lineOffset(propertyValue));
+    assertEquals(layer.getLineOffset().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testLineBlurTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-blurTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setLineBlurTransition(options);
-      assertEquals(layer.getLineBlurTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setLineBlurTransition(options);
+    assertEquals(layer.getLineBlurTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testLineBlurAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-blur");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getLineBlur().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getLineBlur().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(lineBlur(propertyValue));
-      assertEquals(layer.getLineBlur().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(lineBlur(propertyValue));
+    assertEquals(layer.getLineBlur().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testLineBlurAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-blur-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getLineBlur().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getLineBlur().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(lineBlur(expression));
-      assertEquals(layer.getLineBlur().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(lineBlur(expression));
+    assertEquals(layer.getLineBlur().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testLineDasharrayTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-dasharrayTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setLineDasharrayTransition(options);
-      assertEquals(layer.getLineDasharrayTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setLineDasharrayTransition(options);
+    assertEquals(layer.getLineDasharrayTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testLineDasharrayAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-dasharray");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getLineDasharray().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getLineDasharray().getValue());
 
-      // Set and Get
-      Float[] propertyValue = new Float[] {};
-      layer.setProperties(lineDasharray(propertyValue));
-      assertEquals(layer.getLineDasharray().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float[] propertyValue = new Float[] {};
+    layer.setProperties(lineDasharray(propertyValue));
+    assertEquals(layer.getLineDasharray().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testLinePatternTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-patternTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setLinePatternTransition(options);
-      assertEquals(layer.getLinePatternTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setLinePatternTransition(options);
+    assertEquals(layer.getLinePatternTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testLinePatternAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-pattern");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getLinePattern().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getLinePattern().getValue());
 
-      // Set and Get
-      String propertyValue = "pedestrian-polygon";
-      layer.setProperties(linePattern(propertyValue));
-      assertEquals(layer.getLinePattern().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = "pedestrian-polygon";
+    layer.setProperties(linePattern(propertyValue));
+    assertEquals(layer.getLinePattern().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testLinePatternAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("line-pattern-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getLinePattern().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getLinePattern().getExpression());
 
-      // Set and Get
-      Expression expression = string(Expression.get("undefined"));
-      layer.setProperties(linePattern(expression));
-      assertEquals(layer.getLinePattern().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = string(Expression.get("undefined"));
+    layer.setProperties(linePattern(expression));
+    assertEquals(layer.getLinePattern().getExpression(), expression);
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RasterLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RasterLayerTest.java
@@ -3,297 +3,238 @@
 package com.mapbox.mapboxsdk.testapp.style;
 
 import android.graphics.Color;
+import android.support.test.annotation.UiThreadTest;
 import android.support.test.runner.AndroidJUnit4;
 
+import com.mapbox.mapboxsdk.maps.BaseLayerTest;
+import org.junit.Before;
 import timber.log.Timber;
 
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.RasterLayer;
-import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.*;
-import static com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
-import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
 
 /**
  * Basic smoke tests for RasterLayer
  */
 @RunWith(AndroidJUnit4.class)
-public class RasterLayerTest extends BaseActivityTest {
+public class RasterLayerTest extends BaseLayerTest {
 
   private RasterLayer layer;
 
-  @Override
-  protected Class getActivityClass() {
-    return EspressoTestActivity.class;
-  }
-
-  private void setupLayer() {
-    Timber.i("Retrieving layer");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      if ((layer = mapboxMap.getStyle().getLayerAs("my-layer")) == null) {
-        Timber.i("Adding layer");
-        layer = new RasterLayer("my-layer", "composite");
-        layer.setSourceLayer("composite");
-        mapboxMap.getStyle().addLayer(layer);
-        // Layer reference is now stale, get new reference
-        layer = mapboxMap.getStyle().getLayerAs("my-layer");
-      }
-    });
+  @Before
+  @UiThreadTest
+  public void beforeTest(){
+    super.before();
+    layer = new RasterLayer("my-layer", "composite");
+    layer.setSourceLayer("composite");
+    setupLayer(layer);
   }
 
   @Test
+  @UiThreadTest
   public void testSourceId() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("SourceId");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      // Get source id
-      assertEquals(layer.getSourceId(), "composite");
-    });
+    assertNotNull(layer);
+    assertEquals(layer.getSourceId(), "composite");
   }
 
   @Test
+  @UiThreadTest
   public void testSetVisibility() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("Visibility");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getVisibility().getValue(), VISIBLE);
+    // Get initial
+    assertEquals(layer.getVisibility().getValue(), VISIBLE);
 
-      // Set
-      layer.setProperties(visibility(NONE));
-      assertEquals(layer.getVisibility().getValue(), NONE);
-    });
+    // Set
+    layer.setProperties(visibility(NONE));
+    assertEquals(layer.getVisibility().getValue(), NONE);
   }
 
   @Test
+  @UiThreadTest
   public void testRasterOpacityTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("raster-opacityTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setRasterOpacityTransition(options);
-      assertEquals(layer.getRasterOpacityTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setRasterOpacityTransition(options);
+    assertEquals(layer.getRasterOpacityTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testRasterOpacityAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("raster-opacity");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getRasterOpacity().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getRasterOpacity().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(rasterOpacity(propertyValue));
-      assertEquals(layer.getRasterOpacity().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(rasterOpacity(propertyValue));
+    assertEquals(layer.getRasterOpacity().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testRasterHueRotateTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("raster-hue-rotateTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setRasterHueRotateTransition(options);
-      assertEquals(layer.getRasterHueRotateTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setRasterHueRotateTransition(options);
+    assertEquals(layer.getRasterHueRotateTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testRasterHueRotateAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("raster-hue-rotate");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getRasterHueRotate().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getRasterHueRotate().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(rasterHueRotate(propertyValue));
-      assertEquals(layer.getRasterHueRotate().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(rasterHueRotate(propertyValue));
+    assertEquals(layer.getRasterHueRotate().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testRasterBrightnessMinTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("raster-brightness-minTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setRasterBrightnessMinTransition(options);
-      assertEquals(layer.getRasterBrightnessMinTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setRasterBrightnessMinTransition(options);
+    assertEquals(layer.getRasterBrightnessMinTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testRasterBrightnessMinAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("raster-brightness-min");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getRasterBrightnessMin().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getRasterBrightnessMin().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(rasterBrightnessMin(propertyValue));
-      assertEquals(layer.getRasterBrightnessMin().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(rasterBrightnessMin(propertyValue));
+    assertEquals(layer.getRasterBrightnessMin().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testRasterBrightnessMaxTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("raster-brightness-maxTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setRasterBrightnessMaxTransition(options);
-      assertEquals(layer.getRasterBrightnessMaxTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setRasterBrightnessMaxTransition(options);
+    assertEquals(layer.getRasterBrightnessMaxTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testRasterBrightnessMaxAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("raster-brightness-max");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getRasterBrightnessMax().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getRasterBrightnessMax().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(rasterBrightnessMax(propertyValue));
-      assertEquals(layer.getRasterBrightnessMax().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(rasterBrightnessMax(propertyValue));
+    assertEquals(layer.getRasterBrightnessMax().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testRasterSaturationTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("raster-saturationTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setRasterSaturationTransition(options);
-      assertEquals(layer.getRasterSaturationTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setRasterSaturationTransition(options);
+    assertEquals(layer.getRasterSaturationTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testRasterSaturationAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("raster-saturation");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getRasterSaturation().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getRasterSaturation().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(rasterSaturation(propertyValue));
-      assertEquals(layer.getRasterSaturation().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(rasterSaturation(propertyValue));
+    assertEquals(layer.getRasterSaturation().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testRasterContrastTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("raster-contrastTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setRasterContrastTransition(options);
-      assertEquals(layer.getRasterContrastTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setRasterContrastTransition(options);
+    assertEquals(layer.getRasterContrastTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testRasterContrastAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("raster-contrast");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getRasterContrast().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getRasterContrast().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(rasterContrast(propertyValue));
-      assertEquals(layer.getRasterContrast().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(rasterContrast(propertyValue));
+    assertEquals(layer.getRasterContrast().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testRasterResamplingAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("raster-resampling");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getRasterResampling().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getRasterResampling().getValue());
 
-      // Set and Get
-      String propertyValue = RASTER_RESAMPLING_LINEAR;
-      layer.setProperties(rasterResampling(propertyValue));
-      assertEquals(layer.getRasterResampling().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = RASTER_RESAMPLING_LINEAR;
+    layer.setProperties(rasterResampling(propertyValue));
+    assertEquals(layer.getRasterResampling().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testRasterFadeDurationAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("raster-fade-duration");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getRasterFadeDuration().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getRasterFadeDuration().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(rasterFadeDuration(propertyValue));
-      assertEquals(layer.getRasterFadeDuration().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(rasterFadeDuration(propertyValue));
+    assertEquals(layer.getRasterFadeDuration().getValue(), propertyValue);
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
@@ -3,1538 +3,1246 @@
 package com.mapbox.mapboxsdk.testapp.style;
 
 import android.graphics.Color;
+import android.support.test.annotation.UiThreadTest;
 import android.support.test.runner.AndroidJUnit4;
 
+import com.mapbox.mapboxsdk.maps.BaseLayerTest;
+import org.junit.Before;
 import timber.log.Timber;
 
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.mapboxsdk.style.types.Formatted;
 import com.mapbox.mapboxsdk.style.types.FormattedSection;
-import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.*;
-import static com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
-import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
 
 /**
  * Basic smoke tests for SymbolLayer
  */
 @RunWith(AndroidJUnit4.class)
-public class SymbolLayerTest extends BaseActivityTest {
+public class SymbolLayerTest extends BaseLayerTest {
 
   private SymbolLayer layer;
 
-  @Override
-  protected Class getActivityClass() {
-    return EspressoTestActivity.class;
-  }
-
-  private void setupLayer() {
-    Timber.i("Retrieving layer");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      if ((layer = mapboxMap.getStyle().getLayerAs("my-layer")) == null) {
-        Timber.i("Adding layer");
-        layer = new SymbolLayer("my-layer", "composite");
-        layer.setSourceLayer("composite");
-        mapboxMap.getStyle().addLayer(layer);
-        // Layer reference is now stale, get new reference
-        layer = mapboxMap.getStyle().getLayerAs("my-layer");
-      }
-    });
+  @Before
+  @UiThreadTest
+  public void beforeTest(){
+    super.before();
+    layer = new SymbolLayer("my-layer", "composite");
+    layer.setSourceLayer("composite");
+    setupLayer(layer);
   }
 
   @Test
+  @UiThreadTest
   public void testSourceId() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("SourceId");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      // Get source id
-      assertEquals(layer.getSourceId(), "composite");
-    });
+    assertNotNull(layer);
+    assertEquals(layer.getSourceId(), "composite");
   }
 
   @Test
+  @UiThreadTest
   public void testSetVisibility() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("Visibility");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getVisibility().getValue(), VISIBLE);
+    // Get initial
+    assertEquals(layer.getVisibility().getValue(), VISIBLE);
 
-      // Set
-      layer.setProperties(visibility(NONE));
-      assertEquals(layer.getVisibility().getValue(), NONE);
-    });
+    // Set
+    layer.setProperties(visibility(NONE));
+    assertEquals(layer.getVisibility().getValue(), NONE);
   }
 
   @Test
+  @UiThreadTest
   public void testSourceLayer() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("SourceLayer");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getSourceLayer(), "composite");
+    // Get initial
+    assertEquals(layer.getSourceLayer(), "composite");
 
-      // Set
-      final String sourceLayer = "test";
-      layer.setSourceLayer(sourceLayer);
-      assertEquals(layer.getSourceLayer(), sourceLayer);
-    });
+    // Set
+    final String sourceLayer = "test";
+    layer.setSourceLayer(sourceLayer);
+    assertEquals(layer.getSourceLayer(), sourceLayer);
   }
 
   @Test
+  @UiThreadTest
   public void testFilter() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("Filter");
-    invoke(mapboxMap, (uiController, mapboxMap1) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getFilter(), null);
+    // Get initial
+    assertEquals(layer.getFilter(), null);
 
-      // Set
-      Expression filter = eq(get("undefined"), literal(1.0));
-      layer.setFilter(filter);
-      assertEquals(layer.getFilter().toString(), filter.toString());
+    // Set
+    Expression filter = eq(get("undefined"), literal(1.0));
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
 
-      // Set constant
-      filter = literal(true);
-      layer.setFilter(filter);
-      assertEquals(layer.getFilter().toString(), filter.toString());
-    });
+    // Set constant
+    filter = literal(true);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
   }
 
 
 
   @Test
+  @UiThreadTest
   public void testSymbolPlacementAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("symbol-placement");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getSymbolPlacement().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getSymbolPlacement().getValue());
 
-      // Set and Get
-      String propertyValue = SYMBOL_PLACEMENT_POINT;
-      layer.setProperties(symbolPlacement(propertyValue));
-      assertEquals(layer.getSymbolPlacement().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = SYMBOL_PLACEMENT_POINT;
+    layer.setProperties(symbolPlacement(propertyValue));
+    assertEquals(layer.getSymbolPlacement().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testSymbolSpacingAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("symbol-spacing");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getSymbolSpacing().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getSymbolSpacing().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(symbolSpacing(propertyValue));
-      assertEquals(layer.getSymbolSpacing().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(symbolSpacing(propertyValue));
+    assertEquals(layer.getSymbolSpacing().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testSymbolAvoidEdgesAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("symbol-avoid-edges");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getSymbolAvoidEdges().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getSymbolAvoidEdges().getValue());
 
-      // Set and Get
-      Boolean propertyValue = true;
-      layer.setProperties(symbolAvoidEdges(propertyValue));
-      assertEquals(layer.getSymbolAvoidEdges().getValue(), propertyValue);
-    });
+    // Set and Get
+    Boolean propertyValue = true;
+    layer.setProperties(symbolAvoidEdges(propertyValue));
+    assertEquals(layer.getSymbolAvoidEdges().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testSymbolZOrderAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("symbol-z-order");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getSymbolZOrder().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getSymbolZOrder().getValue());
 
-      // Set and Get
-      String propertyValue = SYMBOL_Z_ORDER_VIEWPORT_Y;
-      layer.setProperties(symbolZOrder(propertyValue));
-      assertEquals(layer.getSymbolZOrder().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = SYMBOL_Z_ORDER_VIEWPORT_Y;
+    layer.setProperties(symbolZOrder(propertyValue));
+    assertEquals(layer.getSymbolZOrder().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testIconAllowOverlapAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-allow-overlap");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconAllowOverlap().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getIconAllowOverlap().getValue());
 
-      // Set and Get
-      Boolean propertyValue = true;
-      layer.setProperties(iconAllowOverlap(propertyValue));
-      assertEquals(layer.getIconAllowOverlap().getValue(), propertyValue);
-    });
+    // Set and Get
+    Boolean propertyValue = true;
+    layer.setProperties(iconAllowOverlap(propertyValue));
+    assertEquals(layer.getIconAllowOverlap().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testIconIgnorePlacementAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-ignore-placement");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconIgnorePlacement().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getIconIgnorePlacement().getValue());
 
-      // Set and Get
-      Boolean propertyValue = true;
-      layer.setProperties(iconIgnorePlacement(propertyValue));
-      assertEquals(layer.getIconIgnorePlacement().getValue(), propertyValue);
-    });
+    // Set and Get
+    Boolean propertyValue = true;
+    layer.setProperties(iconIgnorePlacement(propertyValue));
+    assertEquals(layer.getIconIgnorePlacement().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testIconOptionalAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-optional");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconOptional().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getIconOptional().getValue());
 
-      // Set and Get
-      Boolean propertyValue = true;
-      layer.setProperties(iconOptional(propertyValue));
-      assertEquals(layer.getIconOptional().getValue(), propertyValue);
-    });
+    // Set and Get
+    Boolean propertyValue = true;
+    layer.setProperties(iconOptional(propertyValue));
+    assertEquals(layer.getIconOptional().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testIconRotationAlignmentAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-rotation-alignment");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconRotationAlignment().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getIconRotationAlignment().getValue());
 
-      // Set and Get
-      String propertyValue = ICON_ROTATION_ALIGNMENT_MAP;
-      layer.setProperties(iconRotationAlignment(propertyValue));
-      assertEquals(layer.getIconRotationAlignment().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = ICON_ROTATION_ALIGNMENT_MAP;
+    layer.setProperties(iconRotationAlignment(propertyValue));
+    assertEquals(layer.getIconRotationAlignment().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testIconSizeAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-size");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconSize().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getIconSize().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(iconSize(propertyValue));
-      assertEquals(layer.getIconSize().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(iconSize(propertyValue));
+    assertEquals(layer.getIconSize().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testIconSizeAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-size-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconSize().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getIconSize().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(iconSize(expression));
-      assertEquals(layer.getIconSize().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(iconSize(expression));
+    assertEquals(layer.getIconSize().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testIconTextFitAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-text-fit");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconTextFit().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getIconTextFit().getValue());
 
-      // Set and Get
-      String propertyValue = ICON_TEXT_FIT_NONE;
-      layer.setProperties(iconTextFit(propertyValue));
-      assertEquals(layer.getIconTextFit().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = ICON_TEXT_FIT_NONE;
+    layer.setProperties(iconTextFit(propertyValue));
+    assertEquals(layer.getIconTextFit().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testIconTextFitPaddingAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-text-fit-padding");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconTextFitPadding().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getIconTextFitPadding().getValue());
 
-      // Set and Get
-      Float[] propertyValue = new Float[] {0f, 0f, 0f, 0f};
-      layer.setProperties(iconTextFitPadding(propertyValue));
-      assertEquals(layer.getIconTextFitPadding().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float[] propertyValue = new Float[] {0f, 0f, 0f, 0f};
+    layer.setProperties(iconTextFitPadding(propertyValue));
+    assertEquals(layer.getIconTextFitPadding().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testIconImageAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-image");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconImage().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getIconImage().getValue());
 
-      // Set and Get
-      String propertyValue = "undefined";
-      layer.setProperties(iconImage(propertyValue));
-      assertEquals(layer.getIconImage().getValue(), propertyValue);
+    // Set and Get
+    String propertyValue = "undefined";
+    layer.setProperties(iconImage(propertyValue));
+    assertEquals(layer.getIconImage().getValue(), propertyValue);
 
-      layer.setProperties(iconImage("{token}"));
-      assertEquals(layer.getIconImage().getExpression(), Expression.toString(Expression.get("token")));
-    });
+    layer.setProperties(iconImage("{token}"));
+    assertEquals(layer.getIconImage().getExpression(), Expression.toString(Expression.get("token")));
   }
 
   @Test
+  @UiThreadTest
   public void testIconImageAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-image-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconImage().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getIconImage().getExpression());
 
-      // Set and Get
-      Expression expression = string(Expression.get("undefined"));
-      layer.setProperties(iconImage(expression));
-      assertEquals(layer.getIconImage().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = string(Expression.get("undefined"));
+    layer.setProperties(iconImage(expression));
+    assertEquals(layer.getIconImage().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testIconRotateAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-rotate");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconRotate().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getIconRotate().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(iconRotate(propertyValue));
-      assertEquals(layer.getIconRotate().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(iconRotate(propertyValue));
+    assertEquals(layer.getIconRotate().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testIconRotateAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-rotate-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconRotate().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getIconRotate().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(iconRotate(expression));
-      assertEquals(layer.getIconRotate().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(iconRotate(expression));
+    assertEquals(layer.getIconRotate().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testIconPaddingAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-padding");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconPadding().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getIconPadding().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(iconPadding(propertyValue));
-      assertEquals(layer.getIconPadding().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(iconPadding(propertyValue));
+    assertEquals(layer.getIconPadding().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testIconKeepUprightAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-keep-upright");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconKeepUpright().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getIconKeepUpright().getValue());
 
-      // Set and Get
-      Boolean propertyValue = true;
-      layer.setProperties(iconKeepUpright(propertyValue));
-      assertEquals(layer.getIconKeepUpright().getValue(), propertyValue);
-    });
+    // Set and Get
+    Boolean propertyValue = true;
+    layer.setProperties(iconKeepUpright(propertyValue));
+    assertEquals(layer.getIconKeepUpright().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testIconOffsetAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-offset");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconOffset().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getIconOffset().getValue());
 
-      // Set and Get
-      Float[] propertyValue = new Float[] {0f, 0f};
-      layer.setProperties(iconOffset(propertyValue));
-      assertEquals(layer.getIconOffset().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float[] propertyValue = new Float[] {0f, 0f};
+    layer.setProperties(iconOffset(propertyValue));
+    assertEquals(layer.getIconOffset().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testIconAnchorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-anchor");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconAnchor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getIconAnchor().getValue());
 
-      // Set and Get
-      String propertyValue = ICON_ANCHOR_CENTER;
-      layer.setProperties(iconAnchor(propertyValue));
-      assertEquals(layer.getIconAnchor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = ICON_ANCHOR_CENTER;
+    layer.setProperties(iconAnchor(propertyValue));
+    assertEquals(layer.getIconAnchor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testIconAnchorAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-anchor-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconAnchor().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getIconAnchor().getExpression());
 
-      // Set and Get
-      Expression expression = string(Expression.get("undefined"));
-      layer.setProperties(iconAnchor(expression));
-      assertEquals(layer.getIconAnchor().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = string(Expression.get("undefined"));
+    layer.setProperties(iconAnchor(expression));
+    assertEquals(layer.getIconAnchor().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testIconPitchAlignmentAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-pitch-alignment");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconPitchAlignment().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getIconPitchAlignment().getValue());
 
-      // Set and Get
-      String propertyValue = ICON_PITCH_ALIGNMENT_MAP;
-      layer.setProperties(iconPitchAlignment(propertyValue));
-      assertEquals(layer.getIconPitchAlignment().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = ICON_PITCH_ALIGNMENT_MAP;
+    layer.setProperties(iconPitchAlignment(propertyValue));
+    assertEquals(layer.getIconPitchAlignment().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextPitchAlignmentAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-pitch-alignment");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextPitchAlignment().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextPitchAlignment().getValue());
 
-      // Set and Get
-      String propertyValue = TEXT_PITCH_ALIGNMENT_MAP;
-      layer.setProperties(textPitchAlignment(propertyValue));
-      assertEquals(layer.getTextPitchAlignment().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = TEXT_PITCH_ALIGNMENT_MAP;
+    layer.setProperties(textPitchAlignment(propertyValue));
+    assertEquals(layer.getTextPitchAlignment().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextRotationAlignmentAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-rotation-alignment");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextRotationAlignment().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextRotationAlignment().getValue());
 
-      // Set and Get
-      String propertyValue = TEXT_ROTATION_ALIGNMENT_MAP;
-      layer.setProperties(textRotationAlignment(propertyValue));
-      assertEquals(layer.getTextRotationAlignment().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = TEXT_ROTATION_ALIGNMENT_MAP;
+    layer.setProperties(textRotationAlignment(propertyValue));
+    assertEquals(layer.getTextRotationAlignment().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextFieldAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-field");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextField().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextField().getValue());
 
-      // Set and Get
-      Formatted propertyValue = new Formatted(new FormattedSection("default"));
+    // Set and Get
+    Formatted propertyValue = new Formatted(new FormattedSection("default"));
+    layer.setProperties(textField("default"));
+    assertEquals(layer.getTextField().getValue(), propertyValue);
+    layer.setProperties(textField(propertyValue));
+    assertEquals(layer.getTextField().getValue(), propertyValue);
 
-      layer.setProperties(textField("default"));
-      assertEquals(layer.getTextField().getValue(), propertyValue);
-
-      layer.setProperties(textField(propertyValue));
-      assertEquals(layer.getTextField().getValue(), propertyValue);
-
-      layer.setProperties(textField("{token}"));
-      assertEquals(layer.getTextField().getExpression(), format(Expression.formatEntry(Expression.toString(Expression.get("token")))));
-    });
+    layer.setProperties(textField("{token}"));
+    assertEquals(layer.getTextField().getExpression(), format(Expression.formatEntry(Expression.toString(Expression.get("token")))));
   }
 
   @Test
+  @UiThreadTest
   public void testTextFieldAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-field-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextField().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getTextField().getExpression());
 
-      // Set and Get
-      Expression expression = format(Expression.formatEntry(Expression.get("undefined"), FormatOption.formatFontScale(2.0), FormatOption.formatTextFont(new String[]{"Open Sans Regular", "Arial Unicode MS Regular"})));
-      layer.setProperties(textField(expression));
-      assertEquals(layer.getTextField().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = format(Expression.formatEntry(Expression.get("undefined"), FormatOption.formatFontScale(2.0), FormatOption.formatTextFont(new String[]{"Open Sans Regular", "Arial Unicode MS Regular"})));
+    layer.setProperties(textField(expression));
+    assertEquals(layer.getTextField().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testTextFontAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-font");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextFont().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextFont().getValue());
 
-      // Set and Get
-      String[] propertyValue = new String[]{"Open Sans Regular", "Arial Unicode MS Regular"};
-      layer.setProperties(textFont(propertyValue));
-      assertEquals(layer.getTextFont().getValue(), propertyValue);
-    });
+    // Set and Get
+    String[] propertyValue = new String[]{"Open Sans Regular", "Arial Unicode MS Regular"};
+    layer.setProperties(textFont(propertyValue));
+    assertEquals(layer.getTextFont().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextSizeAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-size");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextSize().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextSize().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(textSize(propertyValue));
-      assertEquals(layer.getTextSize().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(textSize(propertyValue));
+    assertEquals(layer.getTextSize().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextSizeAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-size-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextSize().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getTextSize().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(textSize(expression));
-      assertEquals(layer.getTextSize().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(textSize(expression));
+    assertEquals(layer.getTextSize().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testTextMaxWidthAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-max-width");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextMaxWidth().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextMaxWidth().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(textMaxWidth(propertyValue));
-      assertEquals(layer.getTextMaxWidth().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(textMaxWidth(propertyValue));
+    assertEquals(layer.getTextMaxWidth().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextMaxWidthAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-max-width-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextMaxWidth().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getTextMaxWidth().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(textMaxWidth(expression));
-      assertEquals(layer.getTextMaxWidth().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(textMaxWidth(expression));
+    assertEquals(layer.getTextMaxWidth().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testTextLineHeightAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-line-height");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextLineHeight().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextLineHeight().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(textLineHeight(propertyValue));
-      assertEquals(layer.getTextLineHeight().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(textLineHeight(propertyValue));
+    assertEquals(layer.getTextLineHeight().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextLetterSpacingAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-letter-spacing");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextLetterSpacing().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextLetterSpacing().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(textLetterSpacing(propertyValue));
-      assertEquals(layer.getTextLetterSpacing().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(textLetterSpacing(propertyValue));
+    assertEquals(layer.getTextLetterSpacing().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextLetterSpacingAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-letter-spacing-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextLetterSpacing().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getTextLetterSpacing().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(textLetterSpacing(expression));
-      assertEquals(layer.getTextLetterSpacing().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(textLetterSpacing(expression));
+    assertEquals(layer.getTextLetterSpacing().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testTextJustifyAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-justify");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextJustify().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextJustify().getValue());
 
-      // Set and Get
-      String propertyValue = TEXT_JUSTIFY_LEFT;
-      layer.setProperties(textJustify(propertyValue));
-      assertEquals(layer.getTextJustify().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = TEXT_JUSTIFY_LEFT;
+    layer.setProperties(textJustify(propertyValue));
+    assertEquals(layer.getTextJustify().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextJustifyAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-justify-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextJustify().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getTextJustify().getExpression());
 
-      // Set and Get
-      Expression expression = string(Expression.get("undefined"));
-      layer.setProperties(textJustify(expression));
-      assertEquals(layer.getTextJustify().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = string(Expression.get("undefined"));
+    layer.setProperties(textJustify(expression));
+    assertEquals(layer.getTextJustify().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testTextAnchorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-anchor");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextAnchor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextAnchor().getValue());
 
-      // Set and Get
-      String propertyValue = TEXT_ANCHOR_CENTER;
-      layer.setProperties(textAnchor(propertyValue));
-      assertEquals(layer.getTextAnchor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = TEXT_ANCHOR_CENTER;
+    layer.setProperties(textAnchor(propertyValue));
+    assertEquals(layer.getTextAnchor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextAnchorAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-anchor-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextAnchor().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getTextAnchor().getExpression());
 
-      // Set and Get
-      Expression expression = string(Expression.get("undefined"));
-      layer.setProperties(textAnchor(expression));
-      assertEquals(layer.getTextAnchor().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = string(Expression.get("undefined"));
+    layer.setProperties(textAnchor(expression));
+    assertEquals(layer.getTextAnchor().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testTextMaxAngleAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-max-angle");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextMaxAngle().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextMaxAngle().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(textMaxAngle(propertyValue));
-      assertEquals(layer.getTextMaxAngle().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(textMaxAngle(propertyValue));
+    assertEquals(layer.getTextMaxAngle().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextRotateAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-rotate");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextRotate().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextRotate().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(textRotate(propertyValue));
-      assertEquals(layer.getTextRotate().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(textRotate(propertyValue));
+    assertEquals(layer.getTextRotate().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextRotateAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-rotate-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextRotate().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getTextRotate().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(textRotate(expression));
-      assertEquals(layer.getTextRotate().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(textRotate(expression));
+    assertEquals(layer.getTextRotate().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testTextPaddingAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-padding");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextPadding().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextPadding().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(textPadding(propertyValue));
-      assertEquals(layer.getTextPadding().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(textPadding(propertyValue));
+    assertEquals(layer.getTextPadding().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextKeepUprightAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-keep-upright");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextKeepUpright().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextKeepUpright().getValue());
 
-      // Set and Get
-      Boolean propertyValue = true;
-      layer.setProperties(textKeepUpright(propertyValue));
-      assertEquals(layer.getTextKeepUpright().getValue(), propertyValue);
-    });
+    // Set and Get
+    Boolean propertyValue = true;
+    layer.setProperties(textKeepUpright(propertyValue));
+    assertEquals(layer.getTextKeepUpright().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextTransformAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-transform");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextTransform().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextTransform().getValue());
 
-      // Set and Get
-      String propertyValue = TEXT_TRANSFORM_NONE;
-      layer.setProperties(textTransform(propertyValue));
-      assertEquals(layer.getTextTransform().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = TEXT_TRANSFORM_NONE;
+    layer.setProperties(textTransform(propertyValue));
+    assertEquals(layer.getTextTransform().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextTransformAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-transform-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextTransform().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getTextTransform().getExpression());
 
-      // Set and Get
-      Expression expression = string(Expression.get("undefined"));
-      layer.setProperties(textTransform(expression));
-      assertEquals(layer.getTextTransform().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = string(Expression.get("undefined"));
+    layer.setProperties(textTransform(expression));
+    assertEquals(layer.getTextTransform().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testTextOffsetAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-offset");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextOffset().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextOffset().getValue());
 
-      // Set and Get
-      Float[] propertyValue = new Float[] {0f, 0f};
-      layer.setProperties(textOffset(propertyValue));
-      assertEquals(layer.getTextOffset().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float[] propertyValue = new Float[] {0f, 0f};
+    layer.setProperties(textOffset(propertyValue));
+    assertEquals(layer.getTextOffset().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextAllowOverlapAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-allow-overlap");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextAllowOverlap().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextAllowOverlap().getValue());
 
-      // Set and Get
-      Boolean propertyValue = true;
-      layer.setProperties(textAllowOverlap(propertyValue));
-      assertEquals(layer.getTextAllowOverlap().getValue(), propertyValue);
-    });
+    // Set and Get
+    Boolean propertyValue = true;
+    layer.setProperties(textAllowOverlap(propertyValue));
+    assertEquals(layer.getTextAllowOverlap().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextIgnorePlacementAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-ignore-placement");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextIgnorePlacement().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextIgnorePlacement().getValue());
 
-      // Set and Get
-      Boolean propertyValue = true;
-      layer.setProperties(textIgnorePlacement(propertyValue));
-      assertEquals(layer.getTextIgnorePlacement().getValue(), propertyValue);
-    });
+    // Set and Get
+    Boolean propertyValue = true;
+    layer.setProperties(textIgnorePlacement(propertyValue));
+    assertEquals(layer.getTextIgnorePlacement().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextOptionalAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-optional");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextOptional().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextOptional().getValue());
 
-      // Set and Get
-      Boolean propertyValue = true;
-      layer.setProperties(textOptional(propertyValue));
-      assertEquals(layer.getTextOptional().getValue(), propertyValue);
-    });
+    // Set and Get
+    Boolean propertyValue = true;
+    layer.setProperties(textOptional(propertyValue));
+    assertEquals(layer.getTextOptional().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testIconOpacityTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-opacityTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setIconOpacityTransition(options);
-      assertEquals(layer.getIconOpacityTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setIconOpacityTransition(options);
+    assertEquals(layer.getIconOpacityTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testIconOpacityAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-opacity");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconOpacity().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getIconOpacity().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(iconOpacity(propertyValue));
-      assertEquals(layer.getIconOpacity().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(iconOpacity(propertyValue));
+    assertEquals(layer.getIconOpacity().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testIconOpacityAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-opacity-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconOpacity().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getIconOpacity().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(iconOpacity(expression));
-      assertEquals(layer.getIconOpacity().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(iconOpacity(expression));
+    assertEquals(layer.getIconOpacity().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testIconColorTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-colorTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setIconColorTransition(options);
-      assertEquals(layer.getIconColorTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setIconColorTransition(options);
+    assertEquals(layer.getIconColorTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testIconColorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconColor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getIconColor().getValue());
 
-      // Set and Get
-      String propertyValue = "rgba(0, 0, 0, 1)";
-      layer.setProperties(iconColor(propertyValue));
-      assertEquals(layer.getIconColor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = "rgba(0, 0, 0, 1)";
+    layer.setProperties(iconColor(propertyValue));
+    assertEquals(layer.getIconColor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testIconColorAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-color-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconColor().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getIconColor().getExpression());
 
-      // Set and Get
-      Expression expression = toColor(Expression.get("undefined"));
-      layer.setProperties(iconColor(expression));
-      assertEquals(layer.getIconColor().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = toColor(Expression.get("undefined"));
+    layer.setProperties(iconColor(expression));
+    assertEquals(layer.getIconColor().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testIconColorAsIntConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      layer.setProperties(iconColor(Color.RED));
-      assertEquals(layer.getIconColorAsInt(), Color.RED);
-    });
+    // Set and Get
+    layer.setProperties(iconColor(Color.RED));
+    assertEquals(layer.getIconColorAsInt(), Color.RED);
   }
 
   @Test
+  @UiThreadTest
   public void testIconHaloColorTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-halo-colorTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setIconHaloColorTransition(options);
-      assertEquals(layer.getIconHaloColorTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setIconHaloColorTransition(options);
+    assertEquals(layer.getIconHaloColorTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testIconHaloColorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-halo-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconHaloColor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getIconHaloColor().getValue());
 
-      // Set and Get
-      String propertyValue = "rgba(0, 0, 0, 1)";
-      layer.setProperties(iconHaloColor(propertyValue));
-      assertEquals(layer.getIconHaloColor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = "rgba(0, 0, 0, 1)";
+    layer.setProperties(iconHaloColor(propertyValue));
+    assertEquals(layer.getIconHaloColor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testIconHaloColorAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-halo-color-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconHaloColor().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getIconHaloColor().getExpression());
 
-      // Set and Get
-      Expression expression = toColor(Expression.get("undefined"));
-      layer.setProperties(iconHaloColor(expression));
-      assertEquals(layer.getIconHaloColor().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = toColor(Expression.get("undefined"));
+    layer.setProperties(iconHaloColor(expression));
+    assertEquals(layer.getIconHaloColor().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testIconHaloColorAsIntConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-halo-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      layer.setProperties(iconHaloColor(Color.RED));
-      assertEquals(layer.getIconHaloColorAsInt(), Color.RED);
-    });
+    // Set and Get
+    layer.setProperties(iconHaloColor(Color.RED));
+    assertEquals(layer.getIconHaloColorAsInt(), Color.RED);
   }
 
   @Test
+  @UiThreadTest
   public void testIconHaloWidthTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-halo-widthTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setIconHaloWidthTransition(options);
-      assertEquals(layer.getIconHaloWidthTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setIconHaloWidthTransition(options);
+    assertEquals(layer.getIconHaloWidthTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testIconHaloWidthAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-halo-width");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconHaloWidth().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getIconHaloWidth().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(iconHaloWidth(propertyValue));
-      assertEquals(layer.getIconHaloWidth().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(iconHaloWidth(propertyValue));
+    assertEquals(layer.getIconHaloWidth().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testIconHaloWidthAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-halo-width-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconHaloWidth().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getIconHaloWidth().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(iconHaloWidth(expression));
-      assertEquals(layer.getIconHaloWidth().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(iconHaloWidth(expression));
+    assertEquals(layer.getIconHaloWidth().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testIconHaloBlurTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-halo-blurTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setIconHaloBlurTransition(options);
-      assertEquals(layer.getIconHaloBlurTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setIconHaloBlurTransition(options);
+    assertEquals(layer.getIconHaloBlurTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testIconHaloBlurAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-halo-blur");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconHaloBlur().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getIconHaloBlur().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(iconHaloBlur(propertyValue));
-      assertEquals(layer.getIconHaloBlur().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(iconHaloBlur(propertyValue));
+    assertEquals(layer.getIconHaloBlur().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testIconHaloBlurAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-halo-blur-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconHaloBlur().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getIconHaloBlur().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(iconHaloBlur(expression));
-      assertEquals(layer.getIconHaloBlur().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(iconHaloBlur(expression));
+    assertEquals(layer.getIconHaloBlur().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testIconTranslateTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-translateTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setIconTranslateTransition(options);
-      assertEquals(layer.getIconTranslateTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setIconTranslateTransition(options);
+    assertEquals(layer.getIconTranslateTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testIconTranslateAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-translate");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconTranslate().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getIconTranslate().getValue());
 
-      // Set and Get
-      Float[] propertyValue = new Float[] {0f, 0f};
-      layer.setProperties(iconTranslate(propertyValue));
-      assertEquals(layer.getIconTranslate().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float[] propertyValue = new Float[] {0f, 0f};
+    layer.setProperties(iconTranslate(propertyValue));
+    assertEquals(layer.getIconTranslate().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testIconTranslateAnchorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("icon-translate-anchor");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getIconTranslateAnchor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getIconTranslateAnchor().getValue());
 
-      // Set and Get
-      String propertyValue = ICON_TRANSLATE_ANCHOR_MAP;
-      layer.setProperties(iconTranslateAnchor(propertyValue));
-      assertEquals(layer.getIconTranslateAnchor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = ICON_TRANSLATE_ANCHOR_MAP;
+    layer.setProperties(iconTranslateAnchor(propertyValue));
+    assertEquals(layer.getIconTranslateAnchor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextOpacityTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-opacityTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setTextOpacityTransition(options);
-      assertEquals(layer.getTextOpacityTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setTextOpacityTransition(options);
+    assertEquals(layer.getTextOpacityTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testTextOpacityAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-opacity");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextOpacity().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextOpacity().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(textOpacity(propertyValue));
-      assertEquals(layer.getTextOpacity().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(textOpacity(propertyValue));
+    assertEquals(layer.getTextOpacity().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextOpacityAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-opacity-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextOpacity().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getTextOpacity().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(textOpacity(expression));
-      assertEquals(layer.getTextOpacity().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(textOpacity(expression));
+    assertEquals(layer.getTextOpacity().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testTextColorTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-colorTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setTextColorTransition(options);
-      assertEquals(layer.getTextColorTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setTextColorTransition(options);
+    assertEquals(layer.getTextColorTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testTextColorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextColor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextColor().getValue());
 
-      // Set and Get
-      String propertyValue = "rgba(0, 0, 0, 1)";
-      layer.setProperties(textColor(propertyValue));
-      assertEquals(layer.getTextColor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = "rgba(0, 0, 0, 1)";
+    layer.setProperties(textColor(propertyValue));
+    assertEquals(layer.getTextColor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextColorAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-color-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextColor().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getTextColor().getExpression());
 
-      // Set and Get
-      Expression expression = toColor(Expression.get("undefined"));
-      layer.setProperties(textColor(expression));
-      assertEquals(layer.getTextColor().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = toColor(Expression.get("undefined"));
+    layer.setProperties(textColor(expression));
+    assertEquals(layer.getTextColor().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testTextColorAsIntConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      layer.setProperties(textColor(Color.RED));
-      assertEquals(layer.getTextColorAsInt(), Color.RED);
-    });
+    // Set and Get
+    layer.setProperties(textColor(Color.RED));
+    assertEquals(layer.getTextColorAsInt(), Color.RED);
   }
 
   @Test
+  @UiThreadTest
   public void testTextHaloColorTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-halo-colorTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setTextHaloColorTransition(options);
-      assertEquals(layer.getTextHaloColorTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setTextHaloColorTransition(options);
+    assertEquals(layer.getTextHaloColorTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testTextHaloColorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-halo-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextHaloColor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextHaloColor().getValue());
 
-      // Set and Get
-      String propertyValue = "rgba(0, 0, 0, 1)";
-      layer.setProperties(textHaloColor(propertyValue));
-      assertEquals(layer.getTextHaloColor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = "rgba(0, 0, 0, 1)";
+    layer.setProperties(textHaloColor(propertyValue));
+    assertEquals(layer.getTextHaloColor().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextHaloColorAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-halo-color-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextHaloColor().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getTextHaloColor().getExpression());
 
-      // Set and Get
-      Expression expression = toColor(Expression.get("undefined"));
-      layer.setProperties(textHaloColor(expression));
-      assertEquals(layer.getTextHaloColor().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = toColor(Expression.get("undefined"));
+    layer.setProperties(textHaloColor(expression));
+    assertEquals(layer.getTextHaloColor().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testTextHaloColorAsIntConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-halo-color");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      layer.setProperties(textHaloColor(Color.RED));
-      assertEquals(layer.getTextHaloColorAsInt(), Color.RED);
-    });
+    // Set and Get
+    layer.setProperties(textHaloColor(Color.RED));
+    assertEquals(layer.getTextHaloColorAsInt(), Color.RED);
   }
 
   @Test
+  @UiThreadTest
   public void testTextHaloWidthTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-halo-widthTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setTextHaloWidthTransition(options);
-      assertEquals(layer.getTextHaloWidthTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setTextHaloWidthTransition(options);
+    assertEquals(layer.getTextHaloWidthTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testTextHaloWidthAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-halo-width");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextHaloWidth().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextHaloWidth().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(textHaloWidth(propertyValue));
-      assertEquals(layer.getTextHaloWidth().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(textHaloWidth(propertyValue));
+    assertEquals(layer.getTextHaloWidth().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextHaloWidthAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-halo-width-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextHaloWidth().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getTextHaloWidth().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(textHaloWidth(expression));
-      assertEquals(layer.getTextHaloWidth().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(textHaloWidth(expression));
+    assertEquals(layer.getTextHaloWidth().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testTextHaloBlurTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-halo-blurTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setTextHaloBlurTransition(options);
-      assertEquals(layer.getTextHaloBlurTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setTextHaloBlurTransition(options);
+    assertEquals(layer.getTextHaloBlurTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testTextHaloBlurAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-halo-blur");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextHaloBlur().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextHaloBlur().getValue());
 
-      // Set and Get
-      Float propertyValue = 0.3f;
-      layer.setProperties(textHaloBlur(propertyValue));
-      assertEquals(layer.getTextHaloBlur().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(textHaloBlur(propertyValue));
+    assertEquals(layer.getTextHaloBlur().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextHaloBlurAsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-halo-blur-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextHaloBlur().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.getTextHaloBlur().getExpression());
 
-      // Set and Get
-      Expression expression = number(Expression.get("undefined"));
-      layer.setProperties(textHaloBlur(expression));
-      assertEquals(layer.getTextHaloBlur().getExpression(), expression);
-    });
+    // Set and Get
+    Expression expression = number(Expression.get("undefined"));
+    layer.setProperties(textHaloBlur(expression));
+    assertEquals(layer.getTextHaloBlur().getExpression(), expression);
   }
 
   @Test
+  @UiThreadTest
   public void testTextTranslateTransition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-translateTransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.setTextTranslateTransition(options);
-      assertEquals(layer.getTextTranslateTransition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setTextTranslateTransition(options);
+    assertEquals(layer.getTextTranslateTransition(), options);
   }
 
   @Test
+  @UiThreadTest
   public void testTextTranslateAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-translate");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextTranslate().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextTranslate().getValue());
 
-      // Set and Get
-      Float[] propertyValue = new Float[] {0f, 0f};
-      layer.setProperties(textTranslate(propertyValue));
-      assertEquals(layer.getTextTranslate().getValue(), propertyValue);
-    });
+    // Set and Get
+    Float[] propertyValue = new Float[] {0f, 0f};
+    layer.setProperties(textTranslate(propertyValue));
+    assertEquals(layer.getTextTranslate().getValue(), propertyValue);
   }
 
   @Test
+  @UiThreadTest
   public void testTextTranslateAnchorAsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("text-translate-anchor");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.getTextTranslateAnchor().getValue());
+    assertNotNull(layer);
+    assertNull(layer.getTextTranslateAnchor().getValue());
 
-      // Set and Get
-      String propertyValue = TEXT_TRANSLATE_ANCHOR_MAP;
-      layer.setProperties(textTranslateAnchor(propertyValue));
-      assertEquals(layer.getTextTranslateAnchor().getValue(), propertyValue);
-    });
+    // Set and Get
+    String propertyValue = TEXT_TRANSLATE_ANCHOR_MAP;
+    layer.setProperties(textTranslateAnchor(propertyValue));
+    assertEquals(layer.getTextTranslateAnchor().getValue(), propertyValue);
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
@@ -7,8 +7,11 @@
 package com.mapbox.mapboxsdk.testapp.style;
 
 import android.graphics.Color;
+import android.support.test.annotation.UiThreadTest;
 import android.support.test.runner.AndroidJUnit4;
 
+import com.mapbox.mapboxsdk.maps.BaseLayerTest;
+import org.junit.Before;
 import timber.log.Timber;
 
 import com.mapbox.mapboxsdk.style.expressions.Expression;
@@ -17,125 +20,96 @@ import com.mapbox.mapboxsdk.style.layers.<%- camelize(type) %>Layer;
 import com.mapbox.mapboxsdk.style.types.Formatted;
 import com.mapbox.mapboxsdk.style.types.FormattedSection;
 <% } -%>
-import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.*;
-import static com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
-import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
 
 /**
  * Basic smoke tests for <%- camelize(type) %>Layer
  */
 @RunWith(AndroidJUnit4.class)
-public class <%- camelize(type) %>LayerTest extends BaseActivityTest {
+public class <%- camelize(type) %>LayerTest extends BaseLayerTest {
 
   private <%- camelize(type) %>Layer layer;
 
-  @Override
-  protected Class getActivityClass() {
-    return EspressoTestActivity.class;
-  }
-
-  private void setupLayer() {
+  @Before
+  @UiThreadTest
+  public void beforeTest(){
+    super.before();
 <% if (type === 'background') { -%>
-    Timber.i("Retrieving layer");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      layer = mapboxMap.getStyle().getLayerAs("background");
-    });
+    layer = new <%- camelize(type) %>Layer("my-layer");
 <% } else { -%>
-    Timber.i("Retrieving layer");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      if ((layer = mapboxMap.getStyle().getLayerAs("my-layer")) == null) {
-        Timber.i("Adding layer");
-        layer = new <%- camelize(type) %>Layer("my-layer", "composite");
-        layer.setSourceLayer("composite");
-        mapboxMap.getStyle().addLayer(layer);
-        // Layer reference is now stale, get new reference
-        layer = mapboxMap.getStyle().getLayerAs("my-layer");
-      }
-    });
+    layer = new <%- camelize(type) %>Layer("my-layer", "composite");
+    layer.setSourceLayer("composite");
 <% } -%>
+    setupLayer(layer);
   }
 <% if (type !== 'background') { -%>
 
   @Test
+  @UiThreadTest
   public void testSourceId() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("SourceId");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      // Get source id
-      assertEquals(layer.getSourceId(), "composite");
-    });
+    assertNotNull(layer);
+    assertEquals(layer.getSourceId(), "composite");
   }
 <% } -%>
 
   @Test
+  @UiThreadTest
   public void testSetVisibility() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("Visibility");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getVisibility().getValue(), VISIBLE);
+    // Get initial
+    assertEquals(layer.getVisibility().getValue(), VISIBLE);
 
-      // Set
-      layer.setProperties(visibility(NONE));
-      assertEquals(layer.getVisibility().getValue(), NONE);
-    });
+    // Set
+    layer.setProperties(visibility(NONE));
+    assertEquals(layer.getVisibility().getValue(), NONE);
   }
 <% if (!(type === 'background' || type === 'raster' || type === 'hillshade')) { -%>
 
   @Test
+  @UiThreadTest
   public void testSourceLayer() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("SourceLayer");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getSourceLayer(), "composite");
+    // Get initial
+    assertEquals(layer.getSourceLayer(), "composite");
 
-      // Set
-      final String sourceLayer = "test";
-      layer.setSourceLayer(sourceLayer);
-      assertEquals(layer.getSourceLayer(), sourceLayer);
-    });
+    // Set
+    final String sourceLayer = "test";
+    layer.setSourceLayer(sourceLayer);
+    assertEquals(layer.getSourceLayer(), sourceLayer);
   }
 
   @Test
+  @UiThreadTest
   public void testFilter() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("Filter");
-    invoke(mapboxMap, (uiController, mapboxMap1) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Get initial
-      assertEquals(layer.getFilter(), null);
+    // Get initial
+    assertEquals(layer.getFilter(), null);
 
-      // Set
-      Expression filter = eq(get("undefined"), literal(1.0));
-      layer.setFilter(filter);
-      assertEquals(layer.getFilter().toString(), filter.toString());
+    // Set
+    Expression filter = eq(get("undefined"), literal(1.0));
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
 
-      // Set constant
-      filter = literal(true);
-      layer.setFilter(filter);
-      assertEquals(layer.getFilter().toString(), filter.toString());
-    });
+    // Set constant
+    filter = literal(true);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
   }
 
 
@@ -145,89 +119,75 @@ public class <%- camelize(type) %>LayerTest extends BaseActivityTest {
 <% if (property.transition) { -%>
 
   @Test
+  @UiThreadTest
   public void test<%- camelize(property.name) %>Transition() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("<%- property.name %>TransitionOptions");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      TransitionOptions options = new TransitionOptions(300, 100);
-      layer.set<%- camelize(property.name) %>Transition(options);
-      assertEquals(layer.get<%- camelize(property.name) %>Transition(), options);
-    });
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.set<%- camelize(property.name) %>Transition(options);
+    assertEquals(layer.get<%- camelize(property.name) %>Transition(), options);
   }
 <% } -%>
 
   @Test
+  @UiThreadTest
   public void test<%- camelize(property.name) %>AsConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("<%- property.name %>");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.get<%- camelize(property.name) %>().getValue());
+    assertNotNull(layer);
+    assertNull(layer.get<%- camelize(property.name) %>().getValue());
 
-      // Set and Get
-      <%- propertyType(property) %> propertyValue = <%- defaultValueJava(property) %>;
+    // Set and Get
+    <%- propertyType(property) %> propertyValue = <%- defaultValueJava(property) %>;
 <% if (property.type === 'formatted') { -%>
-
-      layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>("default"));
-      assertEquals(layer.get<%- camelize(property.name) %>().getValue(), propertyValue);
-
+    layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>("default"));
+    assertEquals(layer.get<%- camelize(property.name) %>().getValue(), propertyValue);
 <% } -%>
-      layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(propertyValue));
-      assertEquals(layer.get<%- camelize(property.name) %>().getValue(), propertyValue);
+    layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(propertyValue));
+    assertEquals(layer.get<%- camelize(property.name) %>().getValue(), propertyValue);
 <% if (property.tokens) { -%>
 
-      layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>("{token}"));
+    layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>("{token}"));
 <% if (property.type === 'formatted') { -%>
-      assertEquals(layer.get<%- camelize(property.name) %>().getExpression(), <%- defaultExpressionJava(property) %>(Expression.formatEntry(Expression.toString(Expression.get("token")))));
+    assertEquals(layer.get<%- camelize(property.name) %>().getExpression(), <%- defaultExpressionJava(property) %>(Expression.formatEntry(Expression.toString(Expression.get("token")))));
 <% } else {-%>
-      assertEquals(layer.get<%- camelize(property.name) %>().getExpression(), Expression.toString(Expression.get("token")));
+    assertEquals(layer.get<%- camelize(property.name) %>().getExpression(), Expression.toString(Expression.get("token")));
 <% } -%>
 <% } -%>
-    });
   }
 <% if (property['property-type'] === 'data-driven' || property['property-type'] === 'cross-faded-data-driven') { -%>
 <% if (!(property.name.endsWith("-font")||property.name.endsWith("-offset"))) { -%>
 
   @Test
+  @UiThreadTest
   public void test<%- camelize(property.name) %>AsExpression() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("<%- property.name %>-expression");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
-      assertNull(layer.get<%- camelize(property.name) %>().getExpression());
+    assertNotNull(layer);
+    assertNull(layer.get<%- camelize(property.name) %>().getExpression());
 
-      // Set and Get
+    // Set and Get
 <% if (property.type === 'formatted') { -%>
-      Expression expression = <%- defaultExpressionJava(property) %>(Expression.formatEntry(Expression.get("undefined"), FormatOption.formatFontScale(2.0), FormatOption.formatTextFont(new String[]{"Open Sans Regular", "Arial Unicode MS Regular"})));
+    Expression expression = <%- defaultExpressionJava(property) %>(Expression.formatEntry(Expression.get("undefined"), FormatOption.formatFontScale(2.0), FormatOption.formatTextFont(new String[]{"Open Sans Regular", "Arial Unicode MS Regular"})));
 <% } else { -%>
-      Expression expression = <%- defaultExpressionJava(property) %>(Expression.get("undefined"));
+    Expression expression = <%- defaultExpressionJava(property) %>(Expression.get("undefined"));
 <% } -%>
-      layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(expression));
-      assertEquals(layer.get<%- camelize(property.name) %>().getExpression(), expression);
-    });
+    layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(expression));
+    assertEquals(layer.get<%- camelize(property.name) %>().getExpression(), expression);
   }
 <% } -%>
 <% } -%>
 <% if (property.type == 'color') { -%>
 
   @Test
+  @UiThreadTest
   public void test<%- camelize(property.name) %>AsIntConstant() {
-    validateTestSetup();
-    setupLayer();
     Timber.i("<%- property.name %>");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(layer);
+    assertNotNull(layer);
 
-      // Set and Get
-      layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(Color.RED));
-      assertEquals(layer.get<%- camelize(property.name) %>AsInt(), Color.RED);
-    });
+    // Set and Get
+    layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(Color.RED));
+    assertEquals(layer.get<%- camelize(property.name) %>AsInt(), Color.RED);
   }
 <% } -%>
 <% } -%>

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -429,8 +429,19 @@ void NativeMapView::setVisibleCoordinateBounds(JNIEnv& env, const jni::Array<jni
     map->easeTo(cameraOptions, animationOptions);
 }
 
-void NativeMapView::setContentPadding(JNIEnv&, double top, double left, double bottom, double right) {
+void NativeMapView::setContentPadding(JNIEnv&, float top, float left, float bottom, float right) {
     insets = {top, left, bottom, right};
+}
+
+jni::Local<jni::Array<jni::jfloat>> NativeMapView::getContentPadding(JNIEnv& env) {
+    auto result = jni::Array<jni::jfloat>::New(env, 4);
+    std::vector<jfloat> vect;
+    vect.push_back(insets.top());
+    vect.push_back(insets.left());
+    vect.push_back(insets.bottom());
+    vect.push_back(insets.right());
+    result.SetRegion<std::vector<jni::jfloat>>(env, 0, vect);
+    return result;
 }
 
 void NativeMapView::scheduleSnapshot(jni::JNIEnv&) {
@@ -1005,6 +1016,7 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
             METHOD(&NativeMapView::resetNorth, "nativeResetNorth"),
             METHOD(&NativeMapView::setVisibleCoordinateBounds, "nativeSetVisibleCoordinateBounds"),
             METHOD(&NativeMapView::setContentPadding, "nativeSetContentPadding"),
+            METHOD(&NativeMapView::getContentPadding, "nativeGetContentPadding"),
             METHOD(&NativeMapView::scheduleSnapshot, "nativeTakeSnapshot"),
             METHOD(&NativeMapView::getCameraPosition, "nativeGetCameraPosition"),
             METHOD(&NativeMapView::updateMarker, "nativeUpdateMarker"),

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -138,7 +138,9 @@ public:
 
     void setVisibleCoordinateBounds(JNIEnv&, const jni::Array<jni::Object<LatLng>>&, const jni::Object<RectF>&, jni::jdouble, jni::jlong);
 
-    void setContentPadding(JNIEnv&, double, double, double, double);
+    void setContentPadding(JNIEnv&, float, float, float, float);
+
+    jni::Local<jni::Array<jni::jfloat>> getContentPadding(JNIEnv&);
 
     void scheduleSnapshot(jni::JNIEnv&);
 


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gl-native/issues/13418
This PR introduces a way to perform unit tests on JNI/core integration. 
It runs instrumented unit tests without using a view hierarchy/activity/espresso:
  - adds basic map tests
  - refactors generated layer tests