### PR TITLE
Require context in AttributionParser.Options

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/attribution/AttributionParser.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/attribution/AttributionParser.java
@@ -241,12 +241,16 @@ public class AttributionParser {
    * </p>
    */
   public static class Options {
-    private WeakReference<Context> context;
+    private final WeakReference<Context> context;
     private boolean withImproveMap = true;
     private boolean withCopyrightSign = true;
     private boolean withTelemetryAttribution = false;
     private boolean withMapboxAttribution = true;
     private String[] attributionDataStringArray;
+
+    public Options(@NonNull Context context) {
+      this.context = new WeakReference<>(context);
+    }
 
     @NonNull
     public Options withAttributionData(String... attributionData) {
@@ -275,12 +279,6 @@ public class AttributionParser {
     @NonNull
     public Options withMapboxAttribution(boolean withMapboxAttribution) {
       this.withMapboxAttribution = withMapboxAttribution;
-      return this;
-    }
-
-    @NonNull
-    public Options withContext(Context context) {
-      this.context = new WeakReference<>(context);
       return this;
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
@@ -187,10 +187,9 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
         }
       }
 
-      return new AttributionParser.Options()
+      return new AttributionParser.Options(context)
         .withCopyrightSign(true)
         .withImproveMap(true)
-        .withContext(context)
         .withTelemetryAttribution(true)
         .withAttributionData(attributions.toArray(new String[attributions.size()]))
         .build().getAttributions();

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
@@ -415,7 +415,7 @@ public class MapSnapshotter {
    */
   @NonNull
   private String createAttributionString(MapSnapshot mapSnapshot, boolean shortText) {
-    AttributionParser attributionParser = new AttributionParser.Options()
+    AttributionParser attributionParser = new AttributionParser.Options(context)
       .withAttributionData(mapSnapshot.getAttributions())
       .withCopyrightSign(false)
       .withImproveMap(false)

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/attribution/AttributionParseTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/attribution/AttributionParseTest.java
@@ -20,9 +20,8 @@ public class AttributionParseTest {
 
   @Test
   public void testParseAttributionStringSatellite() throws Exception {
-    AttributionParser attributionParser = new AttributionParser.Options()
+    AttributionParser attributionParser = new AttributionParser.Options(RuntimeEnvironment.application)
       .withAttributionData(SATELLITE_ATTRIBUTION)
-      .withContext(RuntimeEnvironment.application)
       .build();
 
     Set<Attribution> attributionList = attributionParser.getAttributions();
@@ -54,9 +53,8 @@ public class AttributionParseTest {
 
   @Test
   public void testParseAttributionStringStreets() throws Exception {
-    AttributionParser attributionParser = new AttributionParser.Options()
+    AttributionParser attributionParser = new AttributionParser.Options(RuntimeEnvironment.application)
       .withAttributionData(STREETS_ATTRIBUTION)
-      .withContext(RuntimeEnvironment.application)
       .build();
 
     Set<Attribution> attributionList = attributionParser.getAttributions();
@@ -84,10 +82,9 @@ public class AttributionParseTest {
 
   @Test
   public void testParseAttributionWithoutMapbox() throws Exception {
-    AttributionParser attributionParser = new AttributionParser.Options()
+    AttributionParser attributionParser = new AttributionParser.Options(RuntimeEnvironment.application)
       .withAttributionData(STREETS_ATTRIBUTION)
       .withMapboxAttribution(false)
-      .withContext(RuntimeEnvironment.application)
       .build();
 
     Set<Attribution> attributionList = attributionParser.getAttributions();
@@ -111,9 +108,8 @@ public class AttributionParseTest {
 
   @Test
   public void testParseAttributionArrayString() throws Exception {
-    AttributionParser attributionParser = new AttributionParser.Options()
+    AttributionParser attributionParser = new AttributionParser.Options(RuntimeEnvironment.application)
       .withAttributionData(new String[] {STREETS_ATTRIBUTION, "", SATELLITE_ATTRIBUTION})
-      .withContext(RuntimeEnvironment.application)
       .build();
     Set<Attribution> attributionList = attributionParser.getAttributions();
     assertEquals("Size of list should match", 4, attributionList.size());
@@ -144,10 +140,9 @@ public class AttributionParseTest {
 
   @Test
   public void testHideImproveThisMapAttributionArrayString() throws Exception {
-    AttributionParser attributionParser = new AttributionParser.Options()
+    AttributionParser attributionParser = new AttributionParser.Options(RuntimeEnvironment.application)
       .withAttributionData(SATELLITE_ATTRIBUTION)
       .withImproveMap(false)
-      .withContext(RuntimeEnvironment.application)
       .build();
     Set<Attribution> attributionList = attributionParser.getAttributions();
     assertEquals("Size of list should match", 3, attributionList.size());
@@ -174,10 +169,9 @@ public class AttributionParseTest {
 
   @Test
   public void testParseHideCopyrightAttributionArrayString() throws Exception {
-    AttributionParser attributionParser = new AttributionParser.Options()
+    AttributionParser attributionParser = new AttributionParser.Options(RuntimeEnvironment.application)
       .withAttributionData(STREETS_ATTRIBUTION, "", SATELLITE_ATTRIBUTION)
       .withCopyrightSign(false)
-      .withContext(RuntimeEnvironment.application)
       .build();
     Set<Attribution> attributionList = attributionParser.getAttributions();
     assertEquals("Size of list should match", 4, attributionList.size());
@@ -208,11 +202,10 @@ public class AttributionParseTest {
 
   @Test
   public void testOutputWithoutCopyRightString() throws Exception {
-    AttributionParser attributionParser = new AttributionParser.Options()
+    AttributionParser attributionParser = new AttributionParser.Options(RuntimeEnvironment.application)
       .withAttributionData(STREETS_ATTRIBUTION)
       .withCopyrightSign(false)
       .withImproveMap(false)
-      .withContext(RuntimeEnvironment.application)
       .build();
 
     assertEquals(
@@ -225,10 +218,9 @@ public class AttributionParseTest {
 
   @Test
   public void testOutputWithCopyRightString() throws Exception {
-    AttributionParser attributionParser = new AttributionParser.Options()
+    AttributionParser attributionParser = new AttributionParser.Options(RuntimeEnvironment.application)
       .withAttributionData(STREETS_ATTRIBUTION)
       .withImproveMap(false)
-      .withContext(RuntimeEnvironment.application)
       .build();
 
     assertEquals(
@@ -240,12 +232,11 @@ public class AttributionParseTest {
 
   @Test
   public void testOutputWithoutCopyRightWithoutMapboxString() throws Exception {
-    AttributionParser attributionParser = new AttributionParser.Options()
+    AttributionParser attributionParser = new AttributionParser.Options(RuntimeEnvironment.application)
       .withAttributionData(STREETS_ATTRIBUTION)
       .withCopyrightSign(false)
       .withImproveMap(false)
       .withMapboxAttribution(false)
-      .withContext(RuntimeEnvironment.application)
       .build();
 
     assertEquals(
@@ -257,11 +248,10 @@ public class AttributionParseTest {
 
   @Test
   public void testOutputWithCopyRightWithoutMapboxString() throws Exception {
-    AttributionParser attributionParser = new AttributionParser.Options()
+    AttributionParser attributionParser = new AttributionParser.Options(RuntimeEnvironment.application)
       .withAttributionData(STREETS_ATTRIBUTION)
       .withImproveMap(false)
       .withMapboxAttribution(false)
-      .withContext(RuntimeEnvironment.application)
       .build();
 
     assertEquals(
@@ -273,12 +263,11 @@ public class AttributionParseTest {
 
   @Test
   public void testOutputSatelliteString() throws Exception {
-    AttributionParser attributionParser = new AttributionParser.Options()
+    AttributionParser attributionParser = new AttributionParser.Options(RuntimeEnvironment.application)
       .withAttributionData(STREETS_ATTRIBUTION, SATELLITE_ATTRIBUTION, "blabla", "")
       .withImproveMap(false)
       .withCopyrightSign(false)
       .withMapboxAttribution(false)
-      .withContext(RuntimeEnvironment.application)
       .build();
 
     assertEquals(
@@ -290,12 +279,11 @@ public class AttributionParseTest {
 
   @Test
   public void testShortOpenStreetMapString() throws Exception {
-    AttributionParser attributionParser = new AttributionParser.Options()
+    AttributionParser attributionParser = new AttributionParser.Options(RuntimeEnvironment.application)
       .withAttributionData(STREETS_ATTRIBUTION, SATELLITE_ATTRIBUTION, "blabla", "")
       .withImproveMap(false)
       .withCopyrightSign(false)
       .withMapboxAttribution(false)
-      .withContext(RuntimeEnvironment.application)
       .build();
 
     assertEquals(
@@ -307,11 +295,10 @@ public class AttributionParseTest {
 
   @Test
   public void testShortOpenStreetMapWithoutCopyrightString() throws Exception {
-    AttributionParser attributionParser = new AttributionParser.Options()
+    AttributionParser attributionParser = new AttributionParser.Options(RuntimeEnvironment.application)
       .withAttributionData(STREETS_ATTRIBUTION, SATELLITE_ATTRIBUTION, "blabla", "")
       .withImproveMap(false)
       .withCopyrightSign(false)
-      .withContext(RuntimeEnvironment.application)
       .build();
 
     assertEquals(


### PR DESCRIPTION
If `context` has not been passed as an `AttributionParser` option, it was going to crash when getting a translated string.
```
java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Object java.lang.ref.WeakReference.get()' on a null object reference
    at com.mapbox.mapboxsdk.attribution.AttributionParser.translateImproveThisMapAnchor(AttributionParser.java:146)
    at com.mapbox.mapboxsdk.attribution.AttributionParser.parseUrlSpan(AttributionParser.java:113)
    at com.mapbox.mapboxsdk.attribution.AttributionParser.parseAttributions(AttributionParser.java:98)
    at com.mapbox.mapboxsdk.attribution.AttributionParser.parse(AttributionParser.java:87)
    at com.mapbox.mapboxsdk.attribution.AttributionParser$Options.build(AttributionParser.java:302)
    at com.mapbox.mapboxsdk.snapshotter.MapSnapshotter.createAttributionString(MapSnapshotter.java:448)
    at com.mapbox.mapboxsdk.snapshotter.MapSnapshotter.createTextView(MapSnapshotter.java:429)
    at com.mapbox.mapboxsdk.snapshotter.MapSnapshotter.getAttributionMeasure(MapSnapshotter.java:365)
    at com.mapbox.mapboxsdk.snapshotter.MapSnapshotter.drawOverlay(MapSnapshotter.java:355)
    at com.mapbox.mapboxsdk.snapshotter.MapSnapshotter.addOverlay(MapSnapshotter.java:350)
    at com.mapbox.mapboxsdk.snapshotter.MapSnapshotter$1.run(MapSnapshotter.java:506)
```