### PR TITLE
Camera's center and anchor points are mutually exclusive

### DIFF
--- a/include/mbgl/map/camera.hpp
+++ b/include/mbgl/map/camera.hpp
@@ -10,7 +10,10 @@
 namespace mbgl {
 
 /** Various options for describing the viewpoint of a map. All fields are
-    optional. */
+    optional.
+    Anchor and center points are mutually exclusive, with preference for the
+    center point when both are set.
+    */
 struct CameraOptions {
     /** Coordinate at the center of the map. */
     optional<LatLng> center;

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -561,7 +561,9 @@ void Transform::startTransition(const CameraOptions& camera,
     observer.onCameraWillChange(isAnimated ? MapObserver::CameraChangeMode::Animated : MapObserver::CameraChangeMode::Immediate);
 
     // Associate the anchor, if given, with a coordinate.
-    optional<ScreenCoordinate> anchor = camera.anchor;
+    // Anchor and center points are mutually exclusive, with preference for the
+    // center point when both are set.
+    optional<ScreenCoordinate> anchor = camera.center ? nullopt : camera.anchor;
     LatLng anchorLatLng;
     if (anchor) {
         anchor->y = state.size.height - anchor->y;

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -476,6 +476,19 @@ TEST(Transform, Camera) {
     transform.updateTransitions(transform.getTransitionStart() + Milliseconds(750));
     transform.updateTransitions(transform.getTransitionStart() + transform.getTransitionDuration());
     ASSERT_FALSE(transform.inTransition());
+
+    // Anchor and center points are mutually exclusive.
+    CameraOptions camera;
+    camera.center = LatLng { 0, 0 };
+    camera.anchor = ScreenCoordinate { 0, 0 }; // top-left
+    camera.zoom = transform.getState().getMaxZoom();
+    transform.easeTo(camera, AnimationOptions(Seconds(1)));
+    transform.updateTransitions(transform.getTransitionStart() + Milliseconds(250));
+    transform.updateTransitions(transform.getTransitionStart() + Milliseconds(500));
+    transform.updateTransitions(transform.getTransitionStart() + Milliseconds(750));
+    transform.updateTransitions(transform.getTransitionStart() + transform.getTransitionDuration());
+    ASSERT_DOUBLE_EQ(transform.getLatLng().latitude(), 0);
+    ASSERT_DOUBLE_EQ(transform.getLatLng().longitude(), 0);
 }
 
 TEST(Transform, DefaultTransform) {


### PR DESCRIPTION
CameraOptions' anchor point is useful when zooming, rotating or pitching, as makes sure the location below the given screen coordinate always stays visible. Because it moves the map center internally, it cannot be used together with the camera center, which also moves the map center.

This means that these values are mutually exclusive. If both values are set, the anchor gets ignored.

Also took the opportunity to clean up `Transform` codebase, removing redundant functions that could be replaced with `{ease,jump}To`.

/cc @asheemmamoowala @1ec5 for review.

Fixes #13338 