### PR TITLE
[core] Fix VectorTileFeature::getValue() semantics after geometry@v1.0.0

### DIFF
--- a/src/mbgl/tile/vector_tile_data.cpp
+++ b/src/mbgl/tile/vector_tile_data.cpp
@@ -22,7 +22,8 @@ FeatureType VectorTileFeature::getType() const {
 }
 
 optional<Value> VectorTileFeature::getValue(const std::string& key) const {
-    return feature.getValue(key);
+    const optional<Value> value(feature.getValue(key));
+    return value->is<NullValue>() ? nullopt : std::move(value);
 }
 
 std::unordered_map<std::string, Value> VectorTileFeature::getProperties() const {


### PR DESCRIPTION
As pointed out by @amatissart [here](https://github.com/mapbox/mapbox-gl-native/pull/13349#issuecomment-441398537), the semantics for obtaining a vector tile feature data has changed after geometry.hpp replaced its optional usage. This makes `VectorTileFeature::getValue()` always return a value (using null_value_t when a value is not found) instead of a `nullopt`. Because we use a [`operator-bool`-based check](https://github.com/mapbox/mapbox-gl-native/blob/master/src/mbgl/style/expression/compound_expression.cpp#L344) for evaluating "has", it is now always returning true for vector tile sources.

Unfortunately we did not catch this as all our expression tests are run using GeoJSON sources.

/cc @julianrex @osana as this is a regression fix for both `ios-v4.7.0-alpha.{1,2}` and `android-v7.0.0-alpha.{1,2}`.