### PR TITLE
Transform cleanup

### DIFF
--- a/benchmark/util/tilecover.benchmark.cpp
+++ b/benchmark/util/tilecover.benchmark.cpp
@@ -22,11 +22,8 @@ static void TileCoverPitchedViewport(benchmark::State& state) {
     Transform transform;
     transform.resize({ 512, 512 });
     // slightly offset center so that tile order is better defined
-    transform.setLatLng({ 0.1, -0.1 });
-    transform.setZoom(8);
-    transform.setAngle(5.0);
-    transform.setPitch(40.0 * M_PI / 180.0);
-    
+    transform.jumpTo(CameraOptions().withCenter(LatLng { 0.1, -0.1 }).withZoom(8.0).withAngle(5.0).withPitch(40.0));
+
     std::size_t length = 0;
     while (state.KeepRunning()) {
         auto tiles = util::tileCover(transform.getState(), 8);

--- a/include/mbgl/map/camera.hpp
+++ b/include/mbgl/map/camera.hpp
@@ -15,6 +15,13 @@ namespace mbgl {
     center point when both are set.
     */
 struct CameraOptions {
+    CameraOptions& withCenter(const optional<LatLng>& o) { center = o; return *this; }
+    CameraOptions& withPadding(const EdgeInsets& p) { padding = p; return *this; }
+    CameraOptions& withAnchor(const optional<ScreenCoordinate>& o) { anchor = o; return *this; }
+    CameraOptions& withZoom(const optional<double>& o) { zoom = o; return *this; }
+    CameraOptions& withAngle(const optional<double>& o) { angle = o; return *this; }
+    CameraOptions& withPitch(const optional<double>& o) { pitch = o; return *this; }
+
     /** Coordinate at the center of the map. */
     optional<LatLng> center;
 

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -75,7 +75,6 @@ public:
 
     // Position
     void moveBy(const ScreenCoordinate&, const AnimationOptions& = {});
-    void setLatLng(const LatLng&, optional<ScreenCoordinate>, const AnimationOptions& = {});
     void setLatLng(const LatLng&, const EdgeInsets&, const AnimationOptions& = {});
     void setLatLng(const LatLng&, const AnimationOptions& = {});
     LatLng getLatLng(const EdgeInsets& = {}) const;

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -261,18 +261,18 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
                 static double routeDistance = ruler.lineDistance(lineString);
                 static double routeProgress = 0;
                 routeProgress += 0.0005;
-                if (routeProgress > 1.0) routeProgress = 0;
+                if (routeProgress > 1.0) {
+                    routeProgress = 0.0;
+                }
 
-                double distance = routeProgress * routeDistance;
-                auto point = ruler.along(lineString, distance);
+                auto point = ruler.along(lineString, routeProgress * routeDistance);
+                const mbgl::LatLng center { point.y, point.x };
                 auto latLng = routeMap->getLatLng();
-                routeMap->setLatLng({ point.y, point.x });
                 double bearing = ruler.bearing({ latLng.longitude(), latLng.latitude() }, point);
                 double easing = bearing - routeMap->getBearing();
                 easing += easing > 180.0 ? -360.0 : easing < -180 ? 360.0 : 0;
-                routeMap->setBearing(routeMap->getBearing() + (easing / 20));
-                routeMap->setPitch(60.0);
-                routeMap->setZoom(18.0);
+                bearing = routeMap->getBearing() + (easing / 20);
+                routeMap->jumpTo(mbgl::CameraOptions().withCenter(center).withZoom(18.0).withAngle(bearing).withPitch(60.0));
             };
             view->animateRouteCallback(view->map);
         } break;

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1579,7 +1579,7 @@ public:
             {
                 CLLocationCoordinate2D centerCoordinate = _previousPinchCenterCoordinate;
                 self.mbglMap.setLatLng(MGLLatLngFromLocationCoordinate2D(centerCoordinate),
-                                    mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y });
+                                    mbgl::EdgeInsets { centerPoint.y, centerPoint.x, self.size.height - centerPoint.y, self.size.width - centerPoint.x });
             }
         }
         [self cameraIsChanging];

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -304,18 +304,12 @@ void Map::moveBy(const ScreenCoordinate& point, const AnimationOptions& animatio
 
 void Map::setLatLng(const LatLng& latLng, const AnimationOptions& animation) {
     impl->cameraMutated = true;
-    setLatLng(latLng, optional<ScreenCoordinate> {}, animation);
+    setLatLng(latLng, animation);
 }
 
 void Map::setLatLng(const LatLng& latLng, const EdgeInsets& padding, const AnimationOptions& animation) {
     impl->cameraMutated = true;
     impl->transform.setLatLng(latLng, padding, animation);
-    impl->onUpdate();
-}
-
-void Map::setLatLng(const LatLng& latLng, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
-    impl->cameraMutated = true;
-    impl->transform.setLatLng(latLng, anchor, animation);
     impl->onUpdate();
 }
 

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -323,22 +323,15 @@ void Transform::moveBy(const ScreenCoordinate& offset, const AnimationOptions& a
 }
 
 void Transform::setLatLng(const LatLng& latLng, const AnimationOptions& animation) {
-    setLatLng(latLng, optional<ScreenCoordinate> {}, animation);
+    CameraOptions camera;
+    camera.center = latLng;
+    easeTo(camera, animation);
 }
 
 void Transform::setLatLng(const LatLng& latLng, const EdgeInsets& padding, const AnimationOptions& animation) {
     CameraOptions camera;
     camera.center = latLng;
     camera.padding = padding;
-    easeTo(camera, animation);
-}
-
-void Transform::setLatLng(const LatLng& latLng, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
-    CameraOptions camera;
-    camera.center = latLng;
-    if (anchor) {
-        camera.padding = EdgeInsets(anchor->y, anchor->x, state.size.height - anchor->y, state.size.width - anchor->x);
-    }
     easeTo(camera, animation);
 }
 

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -48,7 +48,6 @@ public:
     void moveBy(const ScreenCoordinate& offset, const AnimationOptions& = {});
     void setLatLng(const LatLng&, const AnimationOptions& = {});
     void setLatLng(const LatLng&, const EdgeInsets&, const AnimationOptions& = {});
-    void setLatLng(const LatLng&, optional<ScreenCoordinate>, const AnimationOptions& = {});
     void setLatLngZoom(const LatLng&, double zoom, const AnimationOptions& = {});
     void setLatLngZoom(const LatLng&, double zoom, const EdgeInsets&, const AnimationOptions& = {});
     LatLng getLatLng(const EdgeInsets& = {}) const;

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -46,10 +46,6 @@ public:
         @param offset The distance to pan the map by, measured in pixels from
             top to bottom and from left to right. */
     void moveBy(const ScreenCoordinate& offset, const AnimationOptions& = {});
-    void setLatLng(const LatLng&, const AnimationOptions& = {});
-    void setLatLng(const LatLng&, const EdgeInsets&, const AnimationOptions& = {});
-    void setLatLngZoom(const LatLng&, double zoom, const AnimationOptions& = {});
-    void setLatLngZoom(const LatLng&, double zoom, const EdgeInsets&, const AnimationOptions& = {});
     LatLng getLatLng(const EdgeInsets& = {}) const;
     ScreenCoordinate getScreenCoordinate(const EdgeInsets& = {}) const;
 
@@ -63,53 +59,19 @@ public:
 
     // Zoom
 
-    /** Sets the zoom level, keeping the given point fixed within the view.
-        @param zoom The new zoom level. */
-    void setZoom(double zoom, const AnimationOptions& = {});
-    /** Sets the zoom level, keeping the given point fixed within the view.
-        @param zoom The new zoom level.
-        @param anchor A point relative to the top-left corner of the view.
-            If unspecified, the center point is fixed within the view. */
-    void setZoom(double zoom, optional<ScreenCoordinate> anchor, const AnimationOptions& = {});
-    /** Sets the zoom level, keeping the center point fixed within the inset view.
-        @param zoom The new zoom level.
-        @param padding The viewport padding that affects the fixed center point. */
-    void setZoom(double zoom, const EdgeInsets& padding, const AnimationOptions& = {});
     /** Returns the zoom level. */
     double getZoom() const;
 
     // Angle
 
     void rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second, const AnimationOptions& = {});
-    /** Sets the angle of rotation.
-        @param angle The new angle of rotation, measured in radians
-            counterclockwise from true north. */
-    void setAngle(double angle, const AnimationOptions& = {});
-    /** Sets the angle of rotation, keeping the given point fixed within the view.
-        @param angle The new angle of rotation, measured in radians
-            counterclockwise from true north.
-        @param anchor A point relative to the top-left corner of the view. */
-    void setAngle(double angle, optional<ScreenCoordinate> anchor, const AnimationOptions& = {});
-    /** Sets the angle of rotation, keeping the center point fixed within the inset view.
-        @param angle The new angle of rotation, measured in radians
-            counterclockwise from true north.
-        @param padding The viewport padding that affects the fixed center point. */
-    void setAngle(double angle, const EdgeInsets& padding, const AnimationOptions& = {});
     /** Returns the angle of rotation.
         @return The angle of rotation, measured in radians counterclockwise from
             true north. */
     double getAngle() const;
 
     // Pitch
-    /** Sets the pitch angle.
-        @param angle The new pitch angle, measured in radians toward the
-            horizon. */
-    void setPitch(double pitch, const AnimationOptions& = {});
-    /** Sets the pitch angle, keeping the given point fixed within the view.
-        @param angle The new pitch angle, measured in radians toward the
-            horizon.
-        @param anchor A point relative to the top-left corner of the view. */
-    void setPitch(double pitch, optional<ScreenCoordinate> anchor, const AnimationOptions& = {});
+
     double getPitch() const;
 
     // North Orientation

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -133,21 +133,20 @@ ViewportMode TransformState::getViewportMode() const {
 #pragma mark - Camera options
 
 CameraOptions TransformState::getCameraOptions(const EdgeInsets& padding) const {
-    CameraOptions camera;
-
+    LatLng center;
     if (padding.isFlush()) {
-        camera.center = getLatLng();
+        center = getLatLng();
     } else {
         ScreenCoordinate point = padding.getCenter(size.width, size.height);
         point.y = size.height - point.y;
-        camera.center = screenCoordinateToLatLng(point).wrapped();
+        center = screenCoordinateToLatLng(point).wrapped();
     }
-    camera.padding = padding;
-    camera.zoom = getZoom();
-    camera.angle = -angle * util::RAD2DEG;
-    camera.pitch = pitch * util::RAD2DEG;
-
-    return camera;
+    return CameraOptions()
+        .withCenter(center)
+        .withPadding(padding)
+        .withZoom(getZoom())
+        .withAngle(-angle * util::RAD2DEG)
+        .withPitch(pitch * util::RAD2DEG);
 }
 
 #pragma mark - Position

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -14,45 +14,45 @@ TEST(Transform, InvalidZoom) {
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(0, transform.getZoom());
 
-    transform.setZoom(1);
+    transform.jumpTo(CameraOptions().withZoom(1.0));
+
     ASSERT_DOUBLE_EQ(1, transform.getZoom());
 
     const double invalid = NAN;
 
-    transform.setZoom(invalid);
+    transform.jumpTo(CameraOptions().withZoom(invalid));
 
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(1, transform.getZoom());
 
-    transform.setLatLngZoom({ 0, 0 }, invalid);
+    transform.jumpTo(CameraOptions().withCenter(LatLng()).withZoom(invalid));
 
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(1, transform.getZoom());
 
-    transform.setZoom(transform.getState().getMaxZoom() + 0.1);
+    transform.jumpTo(CameraOptions().withZoom(transform.getState().getMaxZoom() + 0.1));
     ASSERT_DOUBLE_EQ(transform.getZoom(), transform.getState().getMaxZoom());
 
-    CameraOptions cameraOptions;
-    cameraOptions.center = LatLng { util::LATITUDE_MAX, util::LONGITUDE_MAX };
-    cameraOptions.zoom = transform.getState().getMaxZoom();
-
     // Executing flyTo with an empty size causes frameZoom to be NaN.
-    transform.flyTo(cameraOptions);
+    transform.flyTo(CameraOptions()
+                        .withCenter(LatLng{ util::LATITUDE_MAX, util::LONGITUDE_MAX })
+                        .withZoom(transform.getState().getMaxZoom()));
     transform.updateTransitions(transform.getTransitionStart() + transform.getTransitionDuration());
     ASSERT_DOUBLE_EQ(transform.getZoom(), transform.getState().getMaxZoom());
 
     // Executing flyTo with maximum zoom level to the same zoom level causes
     // frameZoom to be bigger than maximum zoom.
     transform.resize(Size { 100, 100 });
-    transform.flyTo(cameraOptions);
+    transform.flyTo(CameraOptions()
+                        .withCenter(LatLng{ util::LATITUDE_MAX, util::LONGITUDE_MAX })
+                        .withZoom(transform.getState().getMaxZoom()));
     transform.updateTransitions(transform.getTransitionStart() + transform.getTransitionDuration());
 
     ASSERT_TRUE(transform.getState().valid());
     ASSERT_DOUBLE_EQ(transform.getState().getMaxZoom(), transform.getZoom());
 }
-
 
 TEST(Transform, InvalidBearing) {
     Transform transform;
@@ -61,28 +61,26 @@ TEST(Transform, InvalidBearing) {
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(0, transform.getZoom());
 
-    transform.setZoom(1);
-    transform.setAngle(2);
-
+    transform.jumpTo(CameraOptions().withZoom(1.0).withAngle(2.0));
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(1, transform.getZoom());
-    ASSERT_DOUBLE_EQ(2, transform.getAngle());
+    ASSERT_NEAR(-2.0 * util::DEG2RAD, transform.getAngle(), 1e-15);
 
     const double invalid = NAN;
-    transform.setAngle(invalid);
 
+    transform.jumpTo(CameraOptions().withAngle(invalid));
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(1, transform.getZoom());
-    ASSERT_DOUBLE_EQ(2, transform.getAngle());
+    ASSERT_NEAR(-2.0 * util::DEG2RAD, transform.getAngle(), 1e-15);
 }
 
 TEST(Transform, IntegerZoom) {
     Transform transform;
 
     auto checkIntegerZoom = [&transform](uint8_t zoomInt, double zoom) {
-        transform.setZoom(zoom);
+        transform.jumpTo(CameraOptions().withZoom(zoom));
         ASSERT_NEAR(transform.getZoom(), zoom, 0.0001);
         ASSERT_EQ(transform.getState().getIntegerZoom(), zoomInt);
         ASSERT_NEAR(transform.getState().getZoomFraction(), zoom - zoomInt, 0.0001);
@@ -104,9 +102,9 @@ TEST(Transform, PerspectiveProjection) {
 
     Transform transform;
     transform.resize({ 1000, 1000 });
-    transform.setZoom(10);
-    transform.setPitch(0.9);
-    transform.setLatLng(LatLng(38, -77));
+
+    // 0.9 rad ~ 51.5662 deg
+    transform.jumpTo(CameraOptions().withCenter(LatLng { 38.0, -77.0 }).withZoom(10.0).withPitch(51.5662));
 
     // expected values are from mapbox-gl-js
 
@@ -134,9 +132,9 @@ TEST(Transform, PerspectiveProjection) {
 TEST(Transform, UnwrappedLatLng) {
     Transform transform;
     transform.resize({ 1000, 1000 });
-    transform.setZoom(10);
-    transform.setPitch(0.9);
-    transform.setLatLng(LatLng(38, -77));
+
+    // 0.9 rad ~ 51.5662 deg
+    transform.jumpTo(CameraOptions().withCenter(LatLng { 38.0, -77.0 }).withZoom(10.0).withPitch(51.5662));
 
     const TransformState& state = transform.getState();
 
@@ -162,39 +160,29 @@ TEST(Transform, UnwrappedLatLng) {
 }
 
 TEST(Transform, ConstrainHeightOnly) {
-    LatLng loc;
-
     Transform transform;
     transform.resize({ 1000, 1000 });
-    transform.setZoom(util::MAX_ZOOM);
 
-    transform.setLatLng(LatLngBounds::world().southwest());
-    loc = transform.getLatLng();
-    ASSERT_NEAR(-util::LATITUDE_MAX, loc.latitude(), 0.001);
-    ASSERT_NEAR(util::LONGITUDE_MAX, std::abs(loc.longitude()), 0.001);
+    transform.jumpTo(CameraOptions().withCenter(LatLngBounds::world().southwest()).withZoom(util::MAX_ZOOM));
+    ASSERT_NEAR(-util::LATITUDE_MAX, transform.getLatLng().latitude(), 0.001);
+    ASSERT_NEAR(util::LONGITUDE_MAX, std::abs(transform.getLatLng().longitude()), 0.001);
 
-    transform.setLatLng(LatLngBounds::world().northeast());
-    loc = transform.getLatLng();
-    ASSERT_NEAR(util::LATITUDE_MAX, loc.latitude(), 0.001);
-    ASSERT_NEAR(util::LONGITUDE_MAX, std::abs(loc.longitude()), 0.001);
+    transform.jumpTo(CameraOptions().withCenter(LatLngBounds::world().northeast()));
+    ASSERT_NEAR(util::LATITUDE_MAX, transform.getLatLng().latitude(), 0.001);
+    ASSERT_NEAR(util::LONGITUDE_MAX, std::abs(transform.getLatLng().longitude()), 0.001);
 }
 
 TEST(Transform, ConstrainWidthAndHeight) {
-    LatLng loc;
-
     Transform transform(MapObserver::nullObserver(), ConstrainMode::WidthAndHeight);
     transform.resize({ 1000, 1000 });
-    transform.setZoom(util::MAX_ZOOM);
 
-    transform.setLatLng(LatLngBounds::world().southwest());
-    loc = transform.getLatLng();
-    ASSERT_NEAR(-util::LATITUDE_MAX, loc.latitude(), 0.001);
-    ASSERT_NEAR(-util::LONGITUDE_MAX, loc.longitude(), 0.001);
+    transform.jumpTo(CameraOptions().withCenter(LatLngBounds::world().southwest()).withZoom(util::MAX_ZOOM));
+    ASSERT_NEAR(-util::LATITUDE_MAX, transform.getLatLng().latitude(), 0.001);
+    ASSERT_NEAR(-util::LONGITUDE_MAX, transform.getLatLng().longitude(), 0.001);
 
-    transform.setLatLng(LatLngBounds::world().northeast());
-    loc = transform.getLatLng();
-    ASSERT_NEAR(util::LATITUDE_MAX, loc.latitude(), 0.001);
-    ASSERT_NEAR(util::LONGITUDE_MAX, std::abs(loc.longitude()), 0.001);
+    transform.jumpTo(CameraOptions().withCenter(LatLngBounds::world().northeast()));
+    ASSERT_NEAR(util::LATITUDE_MAX, transform.getLatLng().latitude(), 0.001);
+    ASSERT_NEAR(util::LONGITUDE_MAX, std::abs(transform.getLatLng().longitude()), 0.001);
 }
 
 TEST(Transform, Anchor) {
@@ -202,97 +190,90 @@ TEST(Transform, Anchor) {
     transform.resize({ 1000, 1000 });
 
     const LatLng latLng { 10, -100 };
-    transform.setLatLngZoom(latLng, 10);
+    const ScreenCoordinate anchorPoint = { 150, 150 };
 
+    transform.jumpTo(CameraOptions().withCenter(latLng).withZoom(10.0));
     ASSERT_DOUBLE_EQ(latLng.latitude(), transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(latLng.longitude(), transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(10, transform.getZoom());
     ASSERT_DOUBLE_EQ(0, transform.getAngle());
 
-    const optional<ScreenCoordinate> invalidAnchorPoint {};
-    const ScreenCoordinate anchorPoint = { 150, 150 };
-
     const LatLng anchorLatLng = transform.getState().screenCoordinateToLatLng(anchorPoint);
     ASSERT_NE(latLng.latitude(), anchorLatLng.latitude());
     ASSERT_NE(latLng.longitude(), anchorLatLng.longitude());
 
-    transform.setLatLngZoom(latLng, 2);
-    transform.setZoom(3);
+    transform.jumpTo(CameraOptions().withCenter(latLng).withZoom(3.0));
     ASSERT_DOUBLE_EQ(3, transform.getZoom());
     ASSERT_DOUBLE_EQ(latLng.latitude(), transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(latLng.longitude(), transform.getLatLng().longitude());
 
-    transform.setZoom(3.5, invalidAnchorPoint);
+    transform.jumpTo(CameraOptions().withZoom(3.5));
     ASSERT_DOUBLE_EQ(3.5, transform.getZoom());
     ASSERT_DOUBLE_EQ(latLng.latitude(), transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(latLng.longitude(), transform.getLatLng().longitude());
 
-    transform.setZoom(5.5, anchorPoint);
+    transform.jumpTo(CameraOptions().withZoom(5.5).withAnchor(anchorPoint));
     ASSERT_DOUBLE_EQ(5.5, transform.getZoom());
     ASSERT_NE(latLng.latitude(), transform.getLatLng().latitude());
     ASSERT_NE(latLng.longitude(), transform.getLatLng().longitude());
 
-    transform.setLatLngZoom(latLng, 10);
-    transform.setZoom(3);
+    transform.jumpTo(CameraOptions().withCenter(latLng).withZoom(3.0));
     ASSERT_DOUBLE_EQ(3, transform.getZoom());
     ASSERT_NEAR(latLng.latitude(), transform.getLatLng().latitude(), 0.000001);
     ASSERT_NEAR(latLng.longitude(), transform.getLatLng().longitude(), 0.000001);
 
-    transform.setZoom(5, invalidAnchorPoint);
+    transform.jumpTo(CameraOptions().withZoom(5.0));
     ASSERT_DOUBLE_EQ(5, transform.getZoom());
     ASSERT_NEAR(latLng.latitude(), transform.getLatLng().latitude(), 0.000001);
     ASSERT_NEAR(latLng.longitude(), transform.getLatLng().longitude(), 0.000001);
 
-    transform.setZoom(7, anchorPoint);
+    transform.jumpTo(CameraOptions().withZoom(7.0).withAnchor(anchorPoint));
     ASSERT_DOUBLE_EQ(7, transform.getZoom());
     ASSERT_NE(latLng.latitude(), transform.getLatLng().latitude());
     ASSERT_NE(latLng.longitude(), transform.getLatLng().longitude());
 
-    transform.setLatLngZoom(latLng, 10);
-    transform.setZoom(2);
+    transform.jumpTo(CameraOptions().withCenter(latLng).withZoom(2.0));
     ASSERT_DOUBLE_EQ(2, transform.getZoom());
     ASSERT_NEAR(latLng.latitude(), transform.getLatLng().latitude(), 0.000001);
     ASSERT_NEAR(latLng.longitude(), transform.getLatLng().longitude(), 0.000001);
 
-    transform.setZoom(4, invalidAnchorPoint);
+    transform.jumpTo(CameraOptions().withZoom(4.0));
     ASSERT_DOUBLE_EQ(4, transform.getZoom());
     ASSERT_NEAR(latLng.latitude(), transform.getLatLng().latitude(), 0.000001);
     ASSERT_NEAR(latLng.longitude(), transform.getLatLng().longitude(), 0.000001);
 
-    transform.setZoom(8, anchorPoint);
+    transform.jumpTo(CameraOptions().withZoom(8.0).withAnchor(anchorPoint));
     ASSERT_DOUBLE_EQ(8, transform.getZoom());
     ASSERT_NE(latLng.latitude(), transform.getLatLng().latitude());
     ASSERT_NE(latLng.longitude(), transform.getLatLng().longitude());
 
-    transform.setLatLngZoom(latLng, 10);
-    transform.setAngle(M_PI_4);
+    transform.jumpTo(CameraOptions().withCenter(latLng).withZoom(10.0).withAngle(-45.0));
     ASSERT_NEAR(M_PI_4, transform.getAngle(), 0.000001);
     ASSERT_DOUBLE_EQ(latLng.latitude(), transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(latLng.longitude(), transform.getLatLng().longitude());
 
-    transform.setAngle(0, invalidAnchorPoint);
+    transform.jumpTo(CameraOptions().withAngle(0.0));
     ASSERT_DOUBLE_EQ(0, transform.getAngle());
     ASSERT_DOUBLE_EQ(latLng.latitude(), transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(latLng.longitude(), transform.getLatLng().longitude());
 
-    transform.setAngle(45 * util::DEG2RAD, anchorPoint);
-    ASSERT_NEAR(45 / util::RAD2DEG, transform.getAngle(), 0.000001);
+    transform.jumpTo(CameraOptions().withAngle(45.0).withAnchor(anchorPoint));
+    ASSERT_NEAR(-45.0 * util::DEG2RAD, transform.getAngle(), 0.000001);
     ASSERT_NEAR(anchorLatLng.latitude(), transform.getLatLng().latitude(), 1);
     ASSERT_NEAR(anchorLatLng.longitude(), transform.getLatLng().longitude(), 1);
 
-    transform.setLatLngZoom(latLng, 10);
-    transform.setPitch(10 * util::DEG2RAD);
-    ASSERT_DOUBLE_EQ(10 / util::RAD2DEG, transform.getPitch());
+    transform.jumpTo(CameraOptions().withCenter(latLng).withZoom(10.0).withPitch(10.0));
+    ASSERT_DOUBLE_EQ(10.0 * util::DEG2RAD, transform.getPitch());
     ASSERT_DOUBLE_EQ(latLng.latitude(), transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(latLng.longitude(), transform.getLatLng().longitude());
 
-    transform.setPitch(15 * util::DEG2RAD, invalidAnchorPoint);
-    ASSERT_DOUBLE_EQ(15 / util::RAD2DEG, transform.getPitch());
+    transform.jumpTo(CameraOptions().withPitch(15.0));
+    ASSERT_DOUBLE_EQ(15.0 * util::DEG2RAD, transform.getPitch());
     ASSERT_DOUBLE_EQ(latLng.latitude(), transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(latLng.longitude(), transform.getLatLng().longitude());
 
-    transform.setPitch(20 * util::DEG2RAD, anchorPoint);
-    ASSERT_DOUBLE_EQ(20 / util::RAD2DEG, transform.getPitch());
+    transform.jumpTo(CameraOptions().withPitch(20.0).withAnchor(anchorPoint));
+    ASSERT_DOUBLE_EQ(20.0 * util::DEG2RAD, transform.getPitch());
     ASSERT_NEAR(anchorLatLng.latitude(), transform.getLatLng().latitude(), 1);
     ASSERT_NEAR(anchorLatLng.longitude(), transform.getLatLng().longitude(), 1);
 }
@@ -304,7 +285,7 @@ TEST(Transform, Padding) {
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
 
-    transform.setLatLngZoom({ 10, -100 }, 10);
+    transform.jumpTo(CameraOptions().withCenter(LatLng { 10, -100 }).withZoom(10.0));
 
     const LatLng trueCenter = transform.getLatLng();
     ASSERT_DOUBLE_EQ(10, trueCenter.latitude());
@@ -327,7 +308,8 @@ TEST(Transform, Padding) {
 TEST(Transform, MoveBy) {
     Transform transform;
     transform.resize({ 1000, 1000 });
-    transform.setLatLngZoom({ 0, 0 }, 10);
+
+    transform.jumpTo(CameraOptions().withCenter(LatLng()).withZoom(10.0));
 
     LatLng trueCenter = transform.getLatLng();
     ASSERT_DOUBLE_EQ(0, trueCenter.latitude());
@@ -354,7 +336,8 @@ TEST(Transform, MoveBy) {
 TEST(Transform, Antimeridian) {
     Transform transform;
     transform.resize({ 1000, 1000 });
-    transform.setLatLngZoom({ 0, 0 }, 1);
+
+    transform.jumpTo(CameraOptions().withCenter(LatLng()).withZoom(1.0));
 
     // San Francisco
     const LatLng coordinateSanFrancisco { 37.7833, -122.4167 };
@@ -362,7 +345,7 @@ TEST(Transform, Antimeridian) {
     ASSERT_NEAR(151.79409149185352, pixelSF.x, 1e-2);
     ASSERT_NEAR(383.76774094913071, pixelSF.y, 1e-2);
 
-    transform.setLatLng({ 0, -181 });
+    transform.jumpTo(CameraOptions().withCenter(LatLng { 0.0, -181.0 }));
 
     ScreenCoordinate pixelSFLongest = transform.latLngToScreenCoordinate(coordinateSanFrancisco);
     ASSERT_NEAR(-357.36306616412816, pixelSFLongest.x, 1e-2);
@@ -374,19 +357,19 @@ TEST(Transform, Antimeridian) {
     ASSERT_NEAR(666.63617954008976, pixelSFShortest.x, 1e-2);
     ASSERT_DOUBLE_EQ(pixelSF.y, pixelSFShortest.y);
 
-    transform.setLatLng({ 0, 179 });
+    transform.jumpTo(CameraOptions().withCenter(LatLng { 0.0, 179.0 }));
     pixelSFShortest = transform.latLngToScreenCoordinate(coordinateSanFrancisco);
     ASSERT_DOUBLE_EQ(pixelSFLongest.x, pixelSFShortest.x);
     ASSERT_DOUBLE_EQ(pixelSFLongest.y, pixelSFShortest.y);
 
     // Waikiri
     const LatLng coordinateWaikiri{ -16.9310, 179.9787 };
-    transform.setLatLngZoom(coordinateWaikiri, 10);
+    transform.jumpTo(CameraOptions().withCenter(coordinateWaikiri).withZoom(10.0));
     ScreenCoordinate pixelWaikiri = transform.latLngToScreenCoordinate(coordinateWaikiri);
     ASSERT_NEAR(500, pixelWaikiri.x, 1e-2);
     ASSERT_NEAR(500, pixelWaikiri.y, 1e-2);
 
-    transform.setLatLng({ coordinateWaikiri.latitude(), 180.0213 });
+    transform.jumpTo(CameraOptions().withCenter(LatLng { coordinateWaikiri.latitude(), 180.0213 }));
     ScreenCoordinate pixelWaikiriLongest = transform.latLngToScreenCoordinate(coordinateWaikiri);
     ASSERT_NEAR(524725.96438108233, pixelWaikiriLongest.x, 1e-2);
     ASSERT_DOUBLE_EQ(pixelWaikiri.y, pixelWaikiriLongest.y);
@@ -401,7 +384,7 @@ TEST(Transform, Antimeridian) {
     ASSERT_NEAR(coordinateWaikiri.latitude(), coordinateFromPixel.latitude(), 0.000001);
     ASSERT_NEAR(coordinateWaikiri.longitude(), coordinateFromPixel.longitude(), 0.000001);
 
-    transform.setLatLng({ coordinateWaikiri.latitude(), -179.9787 });
+    transform.jumpTo(CameraOptions().withCenter(LatLng { coordinateWaikiri.latitude(), 180.0213 }));
     pixelWaikiriShortest = transform.latLngToScreenCoordinate(coordinateWaikiri);
     ASSERT_DOUBLE_EQ(pixelWaikiriLongest.x, pixelWaikiriShortest.x);
     ASSERT_DOUBLE_EQ(pixelWaikiriLongest.y, pixelWaikiriShortest.y);
@@ -416,20 +399,14 @@ TEST(Transform, Camera) {
     transform.resize({ 1000, 1000 });
 
     const LatLng latLng1 { 45, 135 };
-    CameraOptions cameraOptions1;
-    cameraOptions1.zoom = 20;
-    cameraOptions1.center = latLng1;
+    CameraOptions cameraOptions1 = CameraOptions().withCenter(latLng1).withZoom(20.0);
     transform.jumpTo(cameraOptions1);
-
     ASSERT_DOUBLE_EQ(latLng1.latitude(), transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(latLng1.longitude(), transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(20, transform.getZoom());
 
     const LatLng latLng2 { -45, -135 };
-    CameraOptions cameraOptions2;
-    cameraOptions2.zoom = 10;
-    cameraOptions2.center = latLng2;
-
+    CameraOptions cameraOptions2 = CameraOptions().withCenter(latLng2).withZoom(10.0);
     transform.jumpTo(cameraOptions2);
     ASSERT_DOUBLE_EQ(latLng2.latitude(), transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(latLng2.longitude(), transform.getLatLng().longitude());
@@ -570,7 +547,8 @@ TEST(Transform, LatLngBounds) {
 
     Transform transform;
     transform.resize({ 1000, 1000 });
-    transform.setLatLngZoom({ 0, 0 }, transform.getState().getMaxZoom());
+
+    transform.jumpTo(CameraOptions().withCenter(LatLng()).withZoom(transform.getState().getMaxZoom()));
 
     // Default bounds.
     ASSERT_EQ(transform.getState().getLatLngBounds(), optional<LatLngBounds> {});
@@ -584,7 +562,7 @@ TEST(Transform, LatLngBounds) {
         ASSERT_EQ(transform.getState().getLatLngBounds(), optional<LatLngBounds> {});
     }
 
-    transform.setLatLng(sanFrancisco);
+    transform.jumpTo(CameraOptions().withCenter(sanFrancisco));
     ASSERT_EQ(transform.getLatLng(), sanFrancisco);
 
     // Single location.
@@ -592,17 +570,17 @@ TEST(Transform, LatLngBounds) {
     ASSERT_EQ(transform.getLatLng(), sanFrancisco);
 
     transform.setLatLngBounds(LatLngBounds::hull({ -90.0, -180.0 }, { 0.0, 180.0 }));
-    transform.setLatLng(sanFrancisco);
+    transform.jumpTo(CameraOptions().withCenter(sanFrancisco));
     ASSERT_EQ(transform.getLatLng().latitude(), 0.0);
     ASSERT_EQ(transform.getLatLng().longitude(), sanFrancisco.longitude());
 
     transform.setLatLngBounds(LatLngBounds::hull({ -90.0, 0.0 }, { 90.0, 180.0 }));
-    transform.setLatLng(sanFrancisco);
+    transform.jumpTo(CameraOptions().withCenter(sanFrancisco));
     ASSERT_EQ(transform.getLatLng().latitude(), sanFrancisco.latitude());
     ASSERT_EQ(transform.getLatLng().longitude(), 0.0);
 
     transform.setLatLngBounds(LatLngBounds::hull({ -90.0, 0.0 }, { 0.0, 180.0 }));
-    transform.setLatLng(sanFrancisco);
+    transform.jumpTo(CameraOptions().withCenter(sanFrancisco));
     ASSERT_EQ(transform.getLatLng().latitude(), 0.0);
     ASSERT_EQ(transform.getLatLng().longitude(), 0.0);
 }
@@ -610,17 +588,18 @@ TEST(Transform, LatLngBounds) {
 TEST(Transform, PitchBounds) {
     Transform transform;
     transform.resize({ 1000, 1000 });
-    transform.setLatLngZoom({ 0, 0 }, transform.getState().getMaxZoom());
+
+    transform.jumpTo(CameraOptions().withCenter(LatLng()).withZoom(transform.getState().getMaxZoom()));
 
     ASSERT_DOUBLE_EQ(transform.getState().getPitch() * util::RAD2DEG, 0.0);
     ASSERT_DOUBLE_EQ(transform.getState().getMinPitch() * util::RAD2DEG, 0.0);
     ASSERT_DOUBLE_EQ(transform.getState().getMaxPitch() * util::RAD2DEG, 60.0);
 
     transform.setMinPitch(45.0 * util::DEG2RAD);
-    transform.setPitch(0.0 * util::DEG2RAD);
+    transform.jumpTo(CameraOptions().withPitch(0));
     ASSERT_NEAR(transform.getState().getPitch() * util::RAD2DEG, 45.0, 1e-5);
 
     transform.setMaxPitch(55.0 * util::DEG2RAD);
-    transform.setPitch(60.0 * util::DEG2RAD);
+    transform.jumpTo(CameraOptions().withPitch(60.0));
     ASSERT_NEAR(transform.getState().getPitch() * util::RAD2DEG, 55.0, 1e-5);
 }

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -76,7 +76,7 @@ public:
         Log::setObserver(std::make_unique<Log::NullObserver>());
 
         transform.resize({ 512, 512 });
-        transform.setLatLngZoom({0, 0}, 0);
+        transform.jumpTo(CameraOptions().withCenter(LatLng()).withZoom(0.0));
 
         transformState = transform.getState();
     }

--- a/test/util/tile_cover.test.cpp
+++ b/test/util/tile_cover.test.cpp
@@ -34,13 +34,11 @@ TEST(TileCover, Pitch) {
     Transform transform;
     transform.resize({ 512, 512 });
     // slightly offset center so that tile order is better defined
-    transform.setLatLng({ 0.1, -0.1 });
-    transform.setZoom(2);
-    transform.setAngle(5.0);
-    transform.setPitch(40.0 * M_PI / 180.0);
+
+    transform.jumpTo(CameraOptions().withCenter(LatLng { 0.1, -0.1, }).withZoom(2.0).withAngle(5.0).withPitch(40.0));
 
     EXPECT_EQ((std::vector<UnwrappedTileID>{
-        { 2, 1, 2 }, { 2, 1, 1 }, { 2, 2, 2 }, { 2, 2, 1 }, { 2, 3, 2 }
+        { 2, 1, 1 }, { 2, 2, 1 }, { 2, 1, 2 }, { 2, 2, 2 }
     }),
               util::tileCover(transform.getState(), 2));
 }


### PR DESCRIPTION
A follow-up to #13445, this PR refactors `Transform` to reduce its API surface.