### PR TITLE
[darwin] Add platform-agnostic MGLStringFromSize() method

### DIFF
--- a/platform/darwin/src/MGLGeometry_Private.h
+++ b/platform/darwin/src/MGLGeometry_Private.h
@@ -19,10 +19,6 @@ typedef struct MGLRadianCoordinate2D {
     MGLLocationRadians longitude;
 } MGLRadianCoordinate2D;
 
-NS_INLINE NSString *MGLStringFromCLLocationCoordinate2D(CLLocationCoordinate2D coordinate) {
-    return [NSString stringWithFormat:@"(lat: %f, lon: %f)", coordinate.latitude, coordinate.longitude];
-}
-
 /**
  Creates a new `MGLRadianCoordinate2D` from the given latitudinal and longitudinal.
  */
@@ -36,6 +32,20 @@ NS_INLINE MGLRadianCoordinate2D MGLRadianCoordinate2DMake(MGLLocationRadians lat
 /// Returns the smallest rectangle that contains both the given rectangle and
 /// the given point.
 CGRect MGLExtendRect(CGRect rect, CGPoint point);
+
+#if TARGET_OS_IPHONE
+NS_INLINE NSString *MGLStringFromSize(CGSize size) {
+    return NSStringFromCGSize(size);
+}
+#else
+NS_INLINE NSString *MGLStringFromSize(NSSize size) {
+    return NSStringFromSize(size);
+}
+#endif
+
+NS_INLINE NSString *MGLStringFromCLLocationCoordinate2D(CLLocationCoordinate2D coordinate) {
+    return [NSString stringWithFormat:@"(lat: %f, lon: %f)", coordinate.latitude, coordinate.longitude];
+}
 
 mbgl::LatLng MGLLatLngFromLocationCoordinate2D(CLLocationCoordinate2D coordinate);
 

--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -31,16 +31,12 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
 
 @implementation MGLMapSnapshotOptions
 
-- (instancetype _Nonnull)initWithStyleURL:(nullable NSURL *)styleURL camera:(MGLMapCamera *)camera size:(CGSize) size
+- (instancetype _Nonnull)initWithStyleURL:(nullable NSURL *)styleURL camera:(MGLMapCamera *)camera size:(CGSize)size
 {
-#if TARGET_OS_IPHONE
-    NSString *sizeString = NSStringFromCGSize(size);
-#else
-    NSString *sizeString = NSStringFromSize(size);
-#endif
-    MGLLogDebug(@"Initializing withStyleURL: %@ camera: %@ size: %@", styleURL, camera, sizeString);
+    MGLLogDebug(@"Initializing withStyleURL: %@ camera: %@ size: %@", styleURL, camera, MGLStringFromSize(size));
     self = [super init];
-    if (self) {
+    if (self)
+    {
         if ( !styleURL)
         {
             styleURL = [MGLStyle streetsStyleURLWithVersion:MGLStyleDefaultVersion];
@@ -53,7 +49,6 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
 #else
         _scale = [NSScreen mainScreen].backingScaleFactor;
 #endif
-        
     }
     return self;
 }


### PR DESCRIPTION
Follows-up on #13235. Abstracts platform-specific `NSStringFromSize()`/`NSStringFromCGSize()` to `MGLStringFromSize()` — this fixes an “unused variable” warning in `MGLMapSnapshotter` in Release builds.

/cc @fabian-guerra 