### PR TITLE
[ios] Fix automatical dismissal when tapping.

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1772,7 +1772,13 @@ public:
     }
     else if (self.selectedAnnotation)
     {
-        [self deselectAnnotation:self.selectedAnnotation animated:YES];
+        BOOL deselect = YES;
+        if ([self.selectedAnnotation respondsToSelector:@selector(dismissesAutomatically)]) {
+            deselect = [self.selectedAnnotation performSelector:@selector(dismissesAutomatically)];
+        }
+        if (deselect) {
+            [self deselectAnnotation:self.selectedAnnotation animated:YES];
+        }
     }
 }
 


### PR DESCRIPTION
Fixes an issue where `MGLAnnotationViews` based annotations are dismissed even tho `dismissesAutomatically` is set to `NO`