### PR TITLE
[core] LayerManager can disable annotations

### DIFF
--- a/include/mbgl/style/layer.hpp
+++ b/include/mbgl/style/layer.hpp
@@ -152,6 +152,12 @@ protected:
 
 /**
  * @brief A singleton class responsible for creating layer instances.
+ * 
+ * The LayerManager has implementation per platform. The LayerManager implementation
+ * defines what layer types are available and it can also disable annotations.
+ * 
+ * Linker excludes the unreachable code for the disabled annotations and layers
+ * from the binaries, significantly reducing their size.
  */
 class LayerManager {
 public:
@@ -167,6 +173,22 @@ public:
                                               const style::conversion::Convertible& value, style::conversion::Error& error) noexcept;
     /// Returns a new RenderLayer instance on success call; returns `nulltptr` otherwise.
     std::unique_ptr<RenderLayer> createRenderLayer(Immutable<style::Layer::Impl>) noexcept;
+
+    /**
+     * @brief a build-time flag to enable/disable annotations in mapbox-gl-native core.
+     * 
+     * At the moment, the annotations implementation in core is creating concrete
+     * layer instances apart from LayerManager/LayerFactory code path.
+     * 
+     * So, annotations must be disabled if the LayerManager implementation does
+     * not provide line, fill or symbol layers (those, used by the annotations 
+     * implementation).
+     * 
+     * Note: in future, annotations implemantation will be moved from the core to platform 
+     * SDK (see https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation)
+     * and this flag won't be needed any more.
+     */
+    static const bool annotationsEnabled;
 
 protected:
     virtual ~LayerManager() = default;

--- a/platform/android/src/style/layers/layer_manager.cpp
+++ b/platform/android/src/style/layers/layer_manager.cpp
@@ -100,4 +100,6 @@ LayerManager* LayerManager::get() noexcept {
     return android::LayerManagerAndroid::get();
 }
 
+const bool LayerManager::annotationsEnabled = true;
+
 } // namespace mbgl

--- a/platform/darwin/src/MGLStyleLayerManager.mm
+++ b/platform/darwin/src/MGLStyleLayerManager.mm
@@ -78,4 +78,6 @@ LayerManager* LayerManager::get() noexcept {
     return LayerManagerDarwin::get();
 }
 
+const bool LayerManager::annotationsEnabled = true;
+
 } // namespace mbgl

--- a/platform/default/layer_manager.cpp
+++ b/platform/default/layer_manager.cpp
@@ -73,4 +73,6 @@ LayerManager* LayerManager::get() noexcept {
     return &instance;
 }
 
+const bool LayerManager::annotationsEnabled = true;
+
 } // namespace mbgl

--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -13,6 +13,15 @@
 
 #include <boost/function_output_iterator.hpp>
 
+// Note: LayerManager::annotationsEnabled is defined
+// at compile time, so that linker (with LTO on) is able
+// to optimize out the unreachable code.
+#define CHECK_ANNOTATIONS_ENABLED_AND_RETURN(result) \
+if (!LayerManager::annotationsEnabled) {             \
+    assert(false);                                   \
+    return result;                                   \
+}
+
 namespace mbgl {
 
 using namespace style;
@@ -28,14 +37,17 @@ AnnotationManager::AnnotationManager(Style& style_)
 AnnotationManager::~AnnotationManager() = default;
 
 void AnnotationManager::setStyle(Style& style_) {
+    CHECK_ANNOTATIONS_ENABLED_AND_RETURN();
     style = style_;
 }
 
 void AnnotationManager::onStyleLoaded() {
+    CHECK_ANNOTATIONS_ENABLED_AND_RETURN();
     updateStyle();
 }
 
 AnnotationID AnnotationManager::addAnnotation(const Annotation& annotation) {
+    CHECK_ANNOTATIONS_ENABLED_AND_RETURN(nextID++);
     std::lock_guard<std::mutex> lock(mutex);
     AnnotationID id = nextID++;
     Annotation::visit(annotation, [&] (const auto& annotation_) {
@@ -46,6 +58,7 @@ AnnotationID AnnotationManager::addAnnotation(const Annotation& annotation) {
 }
 
 bool AnnotationManager::updateAnnotation(const AnnotationID& id, const Annotation& annotation) {
+    CHECK_ANNOTATIONS_ENABLED_AND_RETURN(true);
     std::lock_guard<std::mutex> lock(mutex);
     Annotation::visit(annotation, [&] (const auto& annotation_) {
         this->update(id, annotation_);
@@ -54,6 +67,7 @@ bool AnnotationManager::updateAnnotation(const AnnotationID& id, const Annotatio
 }
 
 void AnnotationManager::removeAnnotation(const AnnotationID& id) {
+    CHECK_ANNOTATIONS_ENABLED_AND_RETURN();
     std::lock_guard<std::mutex> lock(mutex);
     remove(id);
     dirty = true;
@@ -119,6 +133,7 @@ void AnnotationManager::update(const AnnotationID& id, const FillAnnotation& ann
 }
 
 void AnnotationManager::remove(const AnnotationID& id) {
+    CHECK_ANNOTATIONS_ENABLED_AND_RETURN();
     if (symbolAnnotations.find(id) != symbolAnnotations.end()) {
         symbolTree.remove(symbolAnnotations.at(id));
         symbolAnnotations.erase(id);
@@ -194,6 +209,7 @@ void AnnotationManager::updateStyle() {
 }
 
 void AnnotationManager::updateData() {
+    CHECK_ANNOTATIONS_ENABLED_AND_RETURN();
     std::lock_guard<std::mutex> lock(mutex);
     if (dirty) {
         for (auto& tile : tiles) {
@@ -204,12 +220,14 @@ void AnnotationManager::updateData() {
 }
 
 void AnnotationManager::addTile(AnnotationTile& tile) {
+    CHECK_ANNOTATIONS_ENABLED_AND_RETURN();
     std::lock_guard<std::mutex> lock(mutex);
     tiles.insert(&tile);
     tile.setData(getTileData(tile.id.canonical));
 }
 
 void AnnotationManager::removeTile(AnnotationTile& tile) {
+    CHECK_ANNOTATIONS_ENABLED_AND_RETURN();
     std::lock_guard<std::mutex> lock(mutex);
     tiles.erase(&tile);
 }
@@ -221,6 +239,7 @@ static std::string prefixedImageID(const std::string& id) {
 }
 
 void AnnotationManager::addImage(std::unique_ptr<style::Image> image) {
+    CHECK_ANNOTATIONS_ENABLED_AND_RETURN();
     std::lock_guard<std::mutex> lock(mutex);
     const std::string id = prefixedImageID(image->getID());
     images.erase(id);
@@ -230,6 +249,7 @@ void AnnotationManager::addImage(std::unique_ptr<style::Image> image) {
 }
 
 void AnnotationManager::removeImage(const std::string& id_) {
+    CHECK_ANNOTATIONS_ENABLED_AND_RETURN();
     std::lock_guard<std::mutex> lock(mutex);
     const std::string id = prefixedImageID(id_);
     images.erase(id);
@@ -237,10 +257,11 @@ void AnnotationManager::removeImage(const std::string& id_) {
 }
 
 double AnnotationManager::getTopOffsetPixelsForImage(const std::string& id_) {
+    CHECK_ANNOTATIONS_ENABLED_AND_RETURN(0.0);
     std::lock_guard<std::mutex> lock(mutex);
     const std::string id = prefixedImageID(id_);
     auto it = images.find(id);
-    return it != images.end() ? -(it->second.getImage().size.height / it->second.getPixelRatio()) / 2 : 0;
+    return it != images.end() ? -(it->second.getImage().size.height / it->second.getPixelRatio()) / 2 : 0.0;
 }
 
 } // namespace mbgl

--- a/src/mbgl/annotation/annotation_manager.hpp
+++ b/src/mbgl/annotation/annotation_manager.hpp
@@ -84,8 +84,6 @@ private:
     ImageMap images;
 
     std::unordered_set<AnnotationTile*> tiles;
-
-    friend class AnnotationTile;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/renderer.cpp
+++ b/src/mbgl/renderer/renderer.cpp
@@ -55,6 +55,9 @@ std::vector<Feature> Renderer::queryRenderedFeatures(const ScreenBox& box, const
 }
 
 AnnotationIDs Renderer::queryPointAnnotations(const ScreenBox& box) const {
+    if (!LayerManager::annotationsEnabled) {
+        return {};
+    }
     RenderedQueryOptions options;
     options.layerIDs = {{ AnnotationManager::PointLayerID }};
     auto features = queryRenderedFeatures(box, options);
@@ -62,6 +65,9 @@ AnnotationIDs Renderer::queryPointAnnotations(const ScreenBox& box) const {
 }
 
 AnnotationIDs Renderer::queryShapeAnnotations(const ScreenBox& box) const {
+    if (!LayerManager::annotationsEnabled) {
+        return {};
+    }
     auto features = impl->queryShapeAnnotations({
         box.min,
         {box.max.x, box.min.y},
@@ -73,6 +79,9 @@ AnnotationIDs Renderer::queryShapeAnnotations(const ScreenBox& box) const {
 }
     
 AnnotationIDs Renderer::getAnnotationIDs(const std::vector<Feature>& features) const {
+    if (!LayerManager::annotationsEnabled) {
+        return {};
+    }
     std::set<AnnotationID> set;
     for (auto &feature : features) {
         assert(feature.id.is<uint64_t>());

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -85,8 +85,9 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
     }
     
     assert(BackendScope::exists());
-    
-    updateParameters.annotationManager.updateData();
+    if (LayerManager::annotationsEnabled) {
+        updateParameters.annotationManager.updateData();
+    }
 
     const bool zoomChanged = zoomHistory.update(updateParameters.transformState.getZoom(), updateParameters.timePoint);
 
@@ -698,6 +699,7 @@ std::vector<Feature> Renderer::Impl::queryRenderedFeatures(const ScreenLineStrin
 }
 
 std::vector<Feature> Renderer::Impl::queryShapeAnnotations(const ScreenLineString& geometry) const {
+    assert(LayerManager::annotationsEnabled);
     std::vector<const RenderLayer*> shapeAnnotationLayers;
     RenderedQueryOptions options;
     for (const auto& layerImpl : *layerImpls) {


### PR DESCRIPTION
At the moment, the annotations implementation in the `mapbox-gl-native` core is creating concrete layer instances apart from `LayerManager/LayerFactory` code path.

So, annotations must be disabled if the `LayerManager` implementation does not provide line, fill or symbol layers (those, used by the annotations).

Note: in future, annotations implementation will be moved from the core to the
platform SDK level(see https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation) and `LayerManager` won't need to disable it.

Tagging https://github.com/mapbox/mapbox-gl-native/issues/13276