### PR TITLE
[iOS] Add turnstile events for Snapshotter

### DIFF
--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -17,6 +17,7 @@
 #import "MGLAttributionInfo_Private.h"
 #import "MGLLoggingConfiguration_Private.h"
 #import "MGLRendererConfiguration.h"
+#import "MGLMapboxEvents.h"
 
 #if TARGET_OS_IPHONE
 #import "UIImage+MGLAdditions.h"
@@ -74,6 +75,7 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
         _latLngForFn = std::move(latLngForFn);
         _scale = scale;
         _image = image;
+        [MGLMapboxEvents pushTurnstileEvent];
     }
     return self;
 }

--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -17,7 +17,9 @@
 #import "MGLAttributionInfo_Private.h"
 #import "MGLLoggingConfiguration_Private.h"
 #import "MGLRendererConfiguration.h"
+#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
 #import "MGLMapboxEvents.h"
+#endif
 
 #if TARGET_OS_IPHONE
 #import "UIImage+MGLAdditions.h"
@@ -75,7 +77,9 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
         _latLngForFn = std::move(latLngForFn);
         _scale = scale;
         _image = image;
+#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
         [MGLMapboxEvents pushTurnstileEvent];
+#endif
     }
     return self;
 }


### PR DESCRIPTION
Snapshotter (i.e. https://www.mapbox.com/android-docs/maps/overview/snapshotter) is part of the Maps SDK and should be sending turnstile events before usage on both iOS and Android (Snapshotter requests need the same access token we use for regular tile requests).
We should add turnstile events for Snapshotter.

