### PR TITLE
[core] OverscaledTileID::isChildOf should check wrap values.

### DIFF
--- a/include/mbgl/tile/tile_id.hpp
+++ b/include/mbgl/tile/tile_id.hpp
@@ -181,7 +181,8 @@ inline uint32_t OverscaledTileID::overscaleFactor() const {
 }
 
 inline bool OverscaledTileID::isChildOf(const OverscaledTileID& rhs) const {
-    return overscaledZ > rhs.overscaledZ &&
+    return wrap == rhs.wrap &&
+           overscaledZ > rhs.overscaledZ &&
            (canonical == rhs.canonical || canonical.isChildOf(rhs.canonical));
 }
 

--- a/scripts/changelog_staging/tile-is-child.json
+++ b/scripts/changelog_staging/tile-is-child.json
@@ -1,0 +1,4 @@
+{
+  "core": "Fix OverscaledTileID::isChildOf to exclude tiles with different wrap. Incorrect child detection could cause flickering for symbols displaying in two wrapped world copies at the same time.",
+  "issue": 13478
+}

--- a/test/tile/tile_id.test.cpp
+++ b/test/tile/tile_id.test.cpp
@@ -186,6 +186,7 @@ TEST(TileID, Overscaled) {
     EXPECT_TRUE(OverscaledTileID(4, 2, 3).isChildOf(OverscaledTileID(3, 1, 1)));
     EXPECT_TRUE(OverscaledTileID(5, 0, { 4, 2, 3 }).isChildOf(OverscaledTileID(3, 1, 1)));
     EXPECT_TRUE(OverscaledTileID(6, 0, { 4, 2, 3 }).isChildOf(OverscaledTileID(3, 1, 1)));
+    EXPECT_FALSE(OverscaledTileID(6, -1, { 4, 2, 3 }).isChildOf(OverscaledTileID(3, 1, 1)));
     EXPECT_TRUE(OverscaledTileID(7, 0, { 4, 2, 3 }).isChildOf(OverscaledTileID(3, 1, 1)));
 
     EXPECT_FALSE(OverscaledTileID(2, 0, 0).isChildOf(OverscaledTileID(5, 0, { 4, 2, 3 })));
@@ -194,6 +195,7 @@ TEST(TileID, Overscaled) {
     EXPECT_FALSE(OverscaledTileID(5, 0, { 4, 2, 3 }).isChildOf(OverscaledTileID(5, 0, { 4, 2, 3 })));
     EXPECT_TRUE(OverscaledTileID(6, 0, { 4, 2, 3 }).isChildOf(OverscaledTileID(5, 0, { 4, 2, 3 })));
     EXPECT_TRUE(OverscaledTileID(7, 0, { 4, 2, 3 }).isChildOf(OverscaledTileID(5, 0, { 4, 2, 3 })));
+    EXPECT_FALSE(OverscaledTileID(7, 1, { 4, 2, 3 }).isChildOf(OverscaledTileID(5, 0, { 4, 2, 3 })));
 
     EXPECT_FALSE(OverscaledTileID(2, 0, 0).isChildOf(OverscaledTileID(6, 0, { 4, 2, 3 })));
     EXPECT_FALSE(OverscaledTileID(3, 1, 1).isChildOf(OverscaledTileID(6, 0, { 4, 2, 3 })));
@@ -201,7 +203,8 @@ TEST(TileID, Overscaled) {
     EXPECT_FALSE(OverscaledTileID(5, 0, { 4, 2, 3 }).isChildOf(OverscaledTileID(6, 0, { 4, 2, 3 })));
     EXPECT_FALSE(OverscaledTileID(6, 0, { 4, 2, 3 }).isChildOf(OverscaledTileID(6, 0, { 4, 2, 3 })));
     EXPECT_TRUE(OverscaledTileID(7, 0, { 4, 2, 3 }).isChildOf(OverscaledTileID(6, 0, { 4, 2, 3 })));
-
+    EXPECT_FALSE(OverscaledTileID(7, 0, { 4, 2, 3 }).isChildOf(OverscaledTileID(6, -1, { 4, 2, 3 })));
+    
     EXPECT_FALSE(OverscaledTileID(2, 0, 0).isChildOf(OverscaledTileID(5, 0, { 4, 0, 0 })));
     EXPECT_FALSE(OverscaledTileID(3, 1, 1).isChildOf(OverscaledTileID(5, 0, { 4, 0, 0 })));
     EXPECT_FALSE(OverscaledTileID(4, 2, 3).isChildOf(OverscaledTileID(5, 0, { 4, 0, 0 })));


### PR DESCRIPTION
Fixes issue #13478. Port of https://github.com/mapbox/mapbox-gl-js/pull/7644.

On the native side, we already checked wrap values in `UnwrappedTileID::isChildOf` -- I've tried to think of reasons we might have intentionally avoided checking in `OverscaledTileID`, but I can't think of any yet.

cc @kkaefer @ansis 