### PR TITLE
Immediately notify core about forced connectivity state

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
@@ -2,11 +2,10 @@ package com.mapbox.mapboxsdk;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
+
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.exceptions.MapboxConfigurationException;
 import com.mapbox.mapboxsdk.log.Logger;
@@ -34,7 +33,6 @@ public final class Mapbox {
   private Context context;
   @Nullable
   private String accessToken;
-  private Boolean connected;
   @Nullable
   private TelemetryDefinition telemetry;
 
@@ -100,8 +98,7 @@ public final class Mapbox {
    */
   public static synchronized void setConnected(Boolean connected) {
     validateMapbox();
-    // Connectivity state overridden by app
-    INSTANCE.connected = connected;
+    ConnectivityReceiver.instance(INSTANCE.context).setConnected(connected);
   }
 
   /**
@@ -112,14 +109,7 @@ public final class Mapbox {
    */
   public static synchronized Boolean isConnected() {
     validateMapbox();
-    if (INSTANCE.connected != null) {
-      // Connectivity state overridden by app
-      return INSTANCE.connected;
-    }
-
-    ConnectivityManager cm = (ConnectivityManager) INSTANCE.context.getSystemService(Context.CONNECTIVITY_SERVICE);
-    NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
-    return (activeNetwork != null && activeNetwork.isConnected());
+    return ConnectivityReceiver.instance(INSTANCE.context).isConnected();
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -6,19 +6,20 @@ import android.graphics.PointF;
 import android.graphics.drawable.ColorDrawable;
 import android.opengl.GLSurfaceView;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.UiThread;
-import android.support.annotation.Nullable;
 import android.support.annotation.CallSuper;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.UiThread;
 import android.support.v4.util.LongSparseArray;
 import android.util.AttributeSet;
+import android.view.KeyEvent;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.TextureView;
 import android.view.View;
-import android.view.KeyEvent;
-import android.view.MotionEvent;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
+
 import com.mapbox.android.gestures.AndroidGesturesManager;
 import com.mapbox.mapboxsdk.MapStrictMode;
 import com.mapbox.mapboxsdk.Mapbox;
@@ -38,11 +39,12 @@ import com.mapbox.mapboxsdk.offline.OfflineRegionDefinition;
 import com.mapbox.mapboxsdk.storage.FileSource;
 import com.mapbox.mapboxsdk.utils.BitmapUtils;
 
-import javax.microedition.khronos.egl.EGLConfig;
-import javax.microedition.khronos.opengles.GL10;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+
+import javax.microedition.khronos.egl.EGLConfig;
+import javax.microedition.khronos.opengles.GL10;
 
 import static com.mapbox.mapboxsdk.maps.widgets.CompassView.TIME_MAP_NORTH_ANIMATION;
 import static com.mapbox.mapboxsdk.maps.widgets.CompassView.TIME_WAIT_IDLE;
@@ -192,7 +194,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     requestDisallowInterceptTouchEvent(true);
 
     // notify Map object about current connectivity state
-    nativeMapView.setReachability(ConnectivityReceiver.instance(context).isConnected(context));
+    nativeMapView.setReachability(Mapbox.isConnected());
 
     // initialise MapboxMap
     if (savedInstanceState == null) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/net/ConnectivityReceiver.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/net/ConnectivityReceiver.java
@@ -8,8 +8,9 @@ import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
-import com.mapbox.mapboxsdk.Mapbox;
+
 import com.mapbox.mapboxsdk.log.Logger;
 
 import java.util.List;
@@ -22,6 +23,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class ConnectivityReceiver extends BroadcastReceiver {
 
   private static final String TAG = "Mbgl-ConnectivityReceiver";
+  private static final String LOG_CONNECTED = "connected - true";
+  private static final String LOG_NOT_CONNECTED = "connected - false";
 
   @SuppressLint("StaticFieldLeak")
   private static ConnectivityReceiver INSTANCE;
@@ -47,6 +50,8 @@ public class ConnectivityReceiver extends BroadcastReceiver {
   private List<ConnectivityListener> listeners = new CopyOnWriteArrayList<>();
   private Context context;
   private int activationCounter;
+  @Nullable
+  private Boolean connected;
 
   private ConnectivityReceiver(@NonNull Context context) {
     this.context = context;
@@ -61,7 +66,7 @@ public class ConnectivityReceiver extends BroadcastReceiver {
   @UiThread
   public void activate() {
     if (activationCounter == 0) {
-      context.registerReceiver(INSTANCE, new IntentFilter("android.net.conn.CONNECTIVITY_CHANGE"));
+      context.registerReceiver(this, new IntentFilter("android.net.conn.CONNECTIVITY_CHANGE"));
     }
     activationCounter++;
   }
@@ -85,12 +90,38 @@ public class ConnectivityReceiver extends BroadcastReceiver {
    */
   @Override
   public void onReceive(@NonNull Context context, Intent intent) {
-    boolean connected = isConnected(context);
-    Logger.v(TAG, String.format("Connected: %s", connected));
+    if (connected != null) {
+      // Connectivity state overridden by app
+      return;
+    }
+
+    notifyListeners(isNetworkActive());
+  }
+
+  /**
+   * Overwrites system connectivity state. To set, use {@link com.mapbox.mapboxsdk.Mapbox#setConnected(Boolean)}.
+   *
+   * @param connected flag to determine the connectivity state, true for connected, false for
+   *                  disconnected, and null for ConnectivityManager to determine.
+   */
+  public void setConnected(Boolean connected) {
+    this.connected = connected;
+
+    boolean state;
+    if (connected != null) {
+      state = connected;
+    } else {
+      state = isNetworkActive();
+    }
+    notifyListeners(state);
+  }
+
+  private void notifyListeners(boolean isConnected) {
+    Logger.v(TAG, isConnected ? LOG_CONNECTED : LOG_NOT_CONNECTED);
 
     // Loop over listeners
     for (ConnectivityListener listener : listeners) {
-      listener.onNetworkStateChanged(connected);
+      listener.onNetworkStateChanged(isConnected);
     }
   }
 
@@ -115,16 +146,13 @@ public class ConnectivityReceiver extends BroadcastReceiver {
   /**
    * Get current connectivity state
    *
-   * @param context current Context
    * @return true if connected
    */
-  public boolean isConnected(@NonNull Context context) {
-    Boolean connected = Mapbox.isConnected();
-    if (connected != null) {
-      // Connectivity state overridden by app
-      return connected;
-    }
+  public boolean isConnected() {
+    return connected != null ? connected : isNetworkActive();
+  }
 
+  private boolean isNetworkActive() {
     ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
     NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
     return (activeNetwork != null && activeNetwork.isConnected());

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/MapboxTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/MapboxTest.java
@@ -68,17 +68,6 @@ public class MapboxTest {
     assertFalse(Mapbox.isAccessTokenValid("blabla"));
   }
 
-  @Test
-  public void testConnected() {
-    injectMapboxSingleton("pk.0000000001");
-
-    // test manual connectivity
-    Mapbox.setConnected(true);
-    assertTrue(Mapbox.isConnected());
-    Mapbox.setConnected(false);
-    assertFalse(Mapbox.isConnected());
-  }
-
   private void injectMapboxSingleton(String accessToken) {
     Mapbox mapbox = new Mapbox(context, accessToken);
     try {


### PR DESCRIPTION
Pushes a forced connectivity state, that can be used to block outgoing communication in offline scenarios, immediately to core instead of bundling it with system connectivity updates. This led to a couple of requests being sent out if the style was loaded from a local resource, regardless of the forced offline state.