### PR TITLE
Telemetry bump 3.5.6

### DIFF
--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
     versions = [
             mapboxServices  : '3.4.1',
-            mapboxTelemetry : '3.5.4',
+            mapboxTelemetry : '3.5.6',
             mapboxGestures  : '0.3.0',
             supportLib      : '27.1.1',
             constraintLayout: '1.1.2',


### PR DESCRIPTION
Targeting `release-horchata` as this changes are not compatible with `master` that is already using telemetry `v4.x`.