### PR TITLE
Backport changes for 6.7.2 to horchata

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Mapbox welcomes participation and contributions from everyone.  If you'd like to do so please see the [`Contributing Guide`](https://github.com/mapbox/mapbox-gl-native/blob/master/CONTRIBUTING.md) first to get started.
 
+## master
+- Add "localIdeographFontFamily" setting to MapSnapshotter to reduce font data usage while snapshotting CJK maps [#13427](https://github.com/mapbox/mapbox-gl-native/pull/13427)
+
+## 7.0.0-alpha.2 - November 21, 2018
+ - Add overlay example with custom drawing using paint and canvas [#13431](https://github.com/mapbox/mapbox-gl-native/pull/13431)
+ - Use --info argument to show details during test run [#13415](https://github.com/mapbox/mapbox-gl-native/pull/13415)
+ - Add specific name logging in failure scenarios of PropertyValue [#13409](https://github.com/mapbox/mapbox-gl-native/pull/13409)
+ - Fixed constant layer filter [#13406](https://github.com/mapbox/mapbox-gl-native/pull/13406)
+ - Update map feedback URL [#13396](https://github.com/mapbox/mapbox-gl-native/pull/13396)
+ - Use locale sensitive DecimalFormat for color alpha conversion [#13393](https://github.com/mapbox/mapbox-gl-native/pull/13393)
+ - Fixed `{prefix}` in tile resource URLs [#13429](https://github.com/mapbox/mapbox-gl-native/pull/13429)
+
 ## 6.7.1 - November 16, 2018
  - Telemetry v3.5.4 [#13330](https://github.com/mapbox/mapbox-gl-native/pull/13330)
 

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -3,7 +3,12 @@
 Mapbox welcomes participation and contributions from everyone.  If you'd like to do so please see the [`Contributing Guide`](https://github.com/mapbox/mapbox-gl-native/blob/master/CONTRIBUTING.md) first to get started.
 
 ## master
-- Add "localIdeographFontFamily" setting to MapSnapshotter to reduce font data usage while snapshotting CJK maps [#13427](https://github.com/mapbox/mapbox-gl-native/pull/13427)
+- Add `fill-extrusion-vertical-gradient` fill paint property [#13463](https://github.com/mapbox/mapbox-gl-native/pull/13463)
+
+## 6.7.2 - November 30, 2018
+ - Telemetry v3.5.6 [#13486](https://github.com/mapbox/mapbox-gl-native/pull/13486)
+ - Add "localIdeographFontFamily" setting to MapSnapshotter to reduce font data usage while snapshotting CJK maps [#13427](https://github.com/mapbox/mapbox-gl-native/pull/13427)
+ - Send turnstile event while creating MapSnapshotter instance [#13475](https://github.com/mapbox/mapbox-gl-native/pull/13475)
 
 ## 7.0.0-alpha.2 - November 21, 2018
  - Add overlay example with custom drawing using paint and canvas [#13431](https://github.com/mapbox/mapbox-gl-native/pull/13431)
@@ -35,7 +40,6 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
  - Improved CustomGeometrySource constructor typing [#13200](https://github.com/mapbox/mapbox-gl-native/pull/13200)
  - Removed deprecated MarkerView[#13194](https://github.com/mapbox/mapbox-gl-native/pull/13194)
  - Annotate onMapReady with @NonNull [#13307](https://github.com/mapbox/mapbox-gl-native/pull/13307)
-
 
 ## 6.6.7 - November 8, 2018
  - Telemetry v3.5.4 [#13330](https://github.com/mapbox/mapbox-gl-native/pull/13330)

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
@@ -93,6 +93,7 @@ public class MapSnapshotter {
     private LatLngBounds region;
     private CameraPosition cameraPosition;
     private boolean showLogo = true;
+    private String localIdeographFontFamily;
 
     /**
      * @param width  the width of the image
@@ -164,6 +165,22 @@ public class MapSnapshotter {
     }
 
     /**
+     * Set the font family for generating glyphs locally for ideographs in the &#x27;CJK Unified Ideographs&#x27;
+     * and &#x27;Hangul Syllables&#x27; ranges.
+     * <p>
+     * The font family argument is passed to {@link android.graphics.Typeface#create(String, int)}.
+     * Default system fonts are defined in &#x27;/system/etc/fonts.xml&#x27;
+     *
+     * @param fontFamily font family for local ideograph generation.
+     * @return the mutated {@link Options}
+     */
+    @NonNull
+    public Options withLocalIdeographFontFamily(String fontFamily) {
+      this.localIdeographFontFamily = fontFamily;
+      return this;
+    }
+
+    /**
      * @return the width of the image
      */
     public int getWidth() {
@@ -206,6 +223,14 @@ public class MapSnapshotter {
     public CameraPosition getCameraPosition() {
       return cameraPosition;
     }
+
+    /**
+     * @return the font family used for locally generating ideographs
+     */
+    public String getLocalIdeographFontFamily() {
+      return localIdeographFontFamily;
+    }
+
   }
 
   /**
@@ -223,7 +248,7 @@ public class MapSnapshotter {
 
     nativeInitialize(this, fileSource, options.pixelRatio, options.width,
       options.height, options.styleUrl, options.styleJson, options.region, options.cameraPosition,
-      options.showLogo, programCacheDir);
+      options.showLogo, programCacheDir, options.localIdeographFontFamily);
   }
 
   /**
@@ -498,7 +523,8 @@ public class MapSnapshotter {
                                          FileSource fileSource, float pixelRatio,
                                          int width, int height, String styleUrl, String styleJson,
                                          LatLngBounds region, CameraPosition position,
-                                         boolean showLogo, String programCacheDir);
+                                         boolean showLogo, String programCacheDir,
+                                         String localIdeographFontFamily);
 
   @Keep
   protected native void nativeStart();

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
@@ -17,6 +17,8 @@ import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
+
+import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.attribution.AttributionLayout;
 import com.mapbox.mapboxsdk.attribution.AttributionMeasure;
@@ -25,6 +27,7 @@ import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.constants.Style;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
 import com.mapbox.mapboxsdk.log.Logger;
+import com.mapbox.mapboxsdk.maps.TelemetryDefinition;
 import com.mapbox.mapboxsdk.storage.FileSource;
 import com.mapbox.mapboxsdk.utils.ThreadUtils;
 
@@ -243,6 +246,10 @@ public class MapSnapshotter {
   public MapSnapshotter(@NonNull Context context, @NonNull Options options) {
     checkThread();
     this.context = context.getApplicationContext();
+    TelemetryDefinition telemetry = Mapbox.getTelemetry();
+    if (telemetry != null) {
+      telemetry.onAppUserTurnstileEvent();
+    }
     FileSource fileSource = FileSource.getInstance(context);
     String programCacheDir = FileSource.getInternalCachePath(context);
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/snapshot/MapSnapshotterActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/snapshot/MapSnapshotterActivity.java
@@ -68,7 +68,8 @@ public class MapSnapshotterActivity extends AppCompatActivity {
       .withPixelRatio(1)
 
       // Optionally the style
-      .withStyle((column + row) % 2 == 0 ? Style.MAPBOX_STREETS : Style.DARK);
+      .withStyle((column + row) % 2 == 0 ? Style.MAPBOX_STREETS : Style.DARK)
+        .withLocalIdeographFontFamily("sans-serif");
 
     // Optionally the visible region
     if (row % 2 == 0) {

--- a/platform/android/src/snapshotter/map_snapshotter.cpp
+++ b/platform/android/src/snapshotter/map_snapshotter.cpp
@@ -24,7 +24,8 @@ MapSnapshotter::MapSnapshotter(jni::JNIEnv& _env,
                                const jni::Object<LatLngBounds>& region,
                                const jni::Object<CameraPosition>& position,
                                jni::jboolean _showLogo,
-                               const jni::String& _programCacheDir)
+                               const jni::String& _programCacheDir,
+                               const jni::String& _localIdeographFontFamily)
         : javaPeer(_env, _obj)
         , pixelRatio(_pixelRatio)
         , threadPool(sharedThreadPool()) {
@@ -65,7 +66,10 @@ MapSnapshotter::MapSnapshotter(jni::JNIEnv& _env,
                                                          pixelRatio,
                                                          cameraOptions,
                                                          bounds,
-                                                         jni::Make<std::string>(_env, _programCacheDir));
+                                                         jni::Make<std::string>(_env, _programCacheDir),
+                                                         _localIdeographFontFamily ?
+                                                            jni::Make<std::string>(_env, _localIdeographFontFamily) :
+                                                            optional<std::string>{});
 
 }
 
@@ -156,7 +160,7 @@ void MapSnapshotter::registerNative(jni::JNIEnv& env) {
 
     // Register the peer
     jni::RegisterNativePeer<MapSnapshotter>(env, javaClass, "nativePtr",
-                                            jni::MakePeer<MapSnapshotter, const jni::Object<MapSnapshotter>&, const jni::Object<FileSource>&, jni::jfloat, jni::jint, jni::jint, const jni::String&, const jni::String&, const jni::Object<LatLngBounds>&, const jni::Object<CameraPosition>&, jni::jboolean, const jni::String&>,
+                                            jni::MakePeer<MapSnapshotter, const jni::Object<MapSnapshotter>&, const jni::Object<FileSource>&, jni::jfloat, jni::jint, jni::jint, const jni::String&, const jni::String&, const jni::Object<LatLngBounds>&, const jni::Object<CameraPosition>&, jni::jboolean, const jni::String&, const jni::String&>,
                                            "nativeInitialize",
                                            "finalize",
                                             METHOD(&MapSnapshotter::setStyleUrl, "setStyleUrl"),

--- a/platform/android/src/snapshotter/map_snapshotter.hpp
+++ b/platform/android/src/snapshotter/map_snapshotter.hpp
@@ -35,7 +35,8 @@ public:
                    const jni::Object<LatLngBounds>& region,
                    const jni::Object<CameraPosition>& position,
                    jni::jboolean showLogo,
-                   const jni::String& programCacheDir);
+                   const jni::String& programCacheDir,
+                   const jni::String& localIdeographFontFamily);
 
     ~MapSnapshotter();
 

--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -15,6 +15,7 @@
 #import "NSBundle+MGLAdditions.h"
 #import "MGLStyle.h"
 #import "MGLAttributionInfo_Private.h"
+#import "MGLRendererConfiguration.h"
 
 #if TARGET_OS_IPHONE
 #import "UIImage+MGLAdditions.h"
@@ -158,7 +159,7 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
         [NSException raise:NSInternalInconsistencyException
                     format:@"Already started this snapshotter."];
     }
-    
+
     self.completion = completion;
     self.resultQueue = queue;
     self.cancelled = NO;
@@ -560,8 +561,11 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
         coordinateBounds = MGLLatLngBoundsFromCoordinateBounds(options.coordinateBounds);
     }
     
+    // App-global configuration
+    MGLRendererConfiguration* config = [MGLRendererConfiguration currentConfiguration];
+
     // Create the snapshotter
-    _mbglMapSnapshotter = std::make_unique<mbgl::MapSnapshotter>(mbglFileSource, _mbglThreadPool, style, size, pixelRatio, cameraOptions, coordinateBounds);
+    _mbglMapSnapshotter = std::make_unique<mbgl::MapSnapshotter>(mbglFileSource, _mbglThreadPool, style, size, pixelRatio, cameraOptions, coordinateBounds, config.cacheDir, config.localFontFamilyName);
 }
 
 @end

--- a/platform/default/mbgl/map/map_snapshotter.cpp
+++ b/platform/default/mbgl/map/map_snapshotter.cpp
@@ -20,7 +20,8 @@ public:
          const float pixelRatio,
          const optional<CameraOptions> cameraOptions,
          const optional<LatLngBounds> region,
-         const optional<std::string> programCacheDir);
+         const optional<std::string> programCacheDir,
+         const optional<std::string> localFontFamily = {});
 
     void setStyleURL(std::string styleURL);
     std::string getStyleURL() const;
@@ -52,9 +53,10 @@ MapSnapshotter::Impl::Impl(FileSource* fileSource,
            const float pixelRatio,
            const optional<CameraOptions> cameraOptions,
            const optional<LatLngBounds> region,
-           const optional<std::string> programCacheDir)
+           const optional<std::string> programCacheDir,
+           const optional<std::string> localFontFamily)
     : scheduler(std::move(scheduler_))
-    , frontend(size, pixelRatio, *fileSource, *scheduler, programCacheDir)
+    , frontend(size, pixelRatio, *fileSource, *scheduler, programCacheDir, GLContextMode::Unique, localFontFamily)
     , map(frontend, MapObserver::nullObserver(), size, pixelRatio, *fileSource, *scheduler, MapMode::Static) {
 
     if (style.first) {
@@ -168,8 +170,9 @@ MapSnapshotter::MapSnapshotter(FileSource* fileSource,
                                const float pixelRatio,
                                const optional<CameraOptions> cameraOptions,
                                const optional<LatLngBounds> region,
-                               const optional<std::string> programCacheDir)
-   : impl(std::make_unique<util::Thread<MapSnapshotter::Impl>>("Map Snapshotter", fileSource, std::move(scheduler), style, size, pixelRatio, cameraOptions, region, programCacheDir)) {
+                               const optional<std::string> programCacheDir,
+                               const optional<std::string> localFontFamily)
+   : impl(std::make_unique<util::Thread<MapSnapshotter::Impl>>("Map Snapshotter", fileSource, std::move(scheduler), style, size, pixelRatio, cameraOptions, region, programCacheDir, localFontFamily)) {
 }
 
 MapSnapshotter::~MapSnapshotter() = default;

--- a/platform/default/mbgl/map/map_snapshotter.hpp
+++ b/platform/default/mbgl/map/map_snapshotter.hpp
@@ -32,7 +32,8 @@ public:
                    const float pixelRatio,
                    const optional<CameraOptions> cameraOptions,
                    const optional<LatLngBounds> region,
-                   const optional<std::string> cacheDir = {});
+                   const optional<std::string> cacheDir = {},
+                   const optional<std::string> localFontFamily = {});
 
     ~MapSnapshotter();
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## master
+* `MGLMapSnapshotter` now follows "MGLIdeographicFontFamilyName" app setting to reduce font data usage while snapshotting CJK maps [#13427](https://github.com/mapbox/mapbox-gl-native/pull/13427)
+
+## 4.7.0
+
+* Fixed an issue where the `{prefix}` token in tile URL templates was evaluated incorrectly when requesting a source’s tiles. ([#13429](https://github.com/mapbox/mapbox-gl-native/pull/13429))
+* Renamed `-[MGLOfflineStorage putResourceWithUrl:data:modified:expires:etag:mustRevalidate:]` to `-[MGLOfflineStorage preloadData:forURL:modificationDate:expirationDate:eTag:mustRevalidate:]`. ([#13318](https://github.com/mapbox/mapbox-gl-native/pull/13318))
+* Fixed sporadic crash when using `MGLMapSnapshotter`. ([#13300](https://github.com/mapbox/mapbox-gl-native/pull/13300))
+* Added `MGLLoggingConfiguration` and `MGLLoggingBlockHandler` that handle error and fault events produced by the SDK. ([#13235](https://github.com/mapbox/mapbox-gl-native/pull/13235))
+* This SDK’s dynamic framework now has a bundle identifier of `com.mapbox.Mapbox`. ([#12857](https://github.com/mapbox/mapbox-gl-native/pull/12857))
+* Modified the behavior of the map view so that programmatic camera transitions can no longer be interrupted by user interaction when `MGLMapView.zoomEnabled`, `MGLMapView.rotateEnabled`, `MGLMapView.scrollEnabled`, and `MGLMapView.pitchEnabled` are set to false. ([#13362](https://github.com/mapbox/mapbox-gl-native/pull/13362))
+* Fixed random crashes during app termination. ([#13367](https://github.com/mapbox/mapbox-gl-native/pull/13367))
+* Added `-[MGLStyle removeSource:error:]` that returns a `BOOL` indicating success (and an optional `NSError` in case of failure). ([#13399](https://github.com/mapbox/mapbox-gl-native/pull/13399))
+* Added support for setting `MGLCollisionBehaviorPre4_0` in `NSUserDefaults`. ([#13426](https://github.com/mapbox/mapbox-gl-native/pull/13426))
+
+
 ## 4.6.0 - November 7, 2018
 
 ### Styles and rendering

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog for Mapbox Maps SDK for macOS
 
+## master
+
+* `MGLMapSnapshotter` now follows "MGLIdeographicFontFamilyName" app setting to reduce font data usage while snapshotting CJK maps [#13427](https://github.com/mapbox/mapbox-gl-native/pull/13427)
+* Fixed an issue where the `{prefix}` token in tile URL templates was evaluated incorrectly when requesting a source’s tiles. ([#13429](https://github.com/mapbox/mapbox-gl-native/pull/13429))
+* Added `-[MGLStyle removeSource:error:]` that returns a `BOOL` indicating success (and an optional `NSError` in case of failure). ([#13399](https://github.com/mapbox/mapbox-gl-native/pull/13399))
+* Added support for setting `MGLCollisionBehaviorPre4_0` in `NSUserDefaults`. ([#13426](https://github.com/mapbox/mapbox-gl-native/pull/13426))
+
 ## 0.12.0 - November 8, 2018
+
+* Renamed `-[MGLOfflineStorage putResourceWithUrl:data:modified:expires:etag:mustRevalidate:]` to `-[MGLOfflineStorage preloadData:forURL:modificationDate:expirationDate:eTag:mustRevalidate:]`. ([#13318](https://github.com/mapbox/mapbox-gl-native/pull/13318))
+* This SDK’s dynamic framework now has a bundle identifier of `com.mapbox.Mapbox`. ([#12857](https://github.com/mapbox/mapbox-gl-native/pull/12857))
 
 ### Styles and rendering
 


### PR DESCRIPTION
Backports https://github.com/mapbox/mapbox-gl-native/pull/13427 and https://github.com/mapbox/mapbox-gl-native/pull/13475 to `release-horchata`