### PR TITLE
[Android] Add setPreferredFramesPerSecond for MapView

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -426,14 +426,14 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   }
 
   /**
-   *  The preferred frame rate at which the map view is rendered,
+   *  The maximum frame rate at which the map view is rendered,
    *  but it can't excess the ability of device hardware.
    *
-   * @param preferredFramesPerSecond  Can be set to arbitrary integer values.
+   * @param maximumFps  Can be set to arbitrary integer values.
    */
-  public void setPreferredFramesPerSecond(int preferredFramesPerSecond) {
+  public void setMaximumFps(int maximumFps) {
     if (mapRenderer != null) {
-      mapRenderer.setPreferredFramesPerSecond(preferredFramesPerSecond);
+      mapRenderer.setMaximumFps(maximumFps);
     }
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -426,6 +426,18 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   }
 
   /**
+   *  The preferred frame rate at which the map view is rendered,
+   *  but it can't excess the ability of device hardware.
+   *
+   * @param preferredFramesPerSecond  Can be set to arbitrary integer values.
+   */
+  public void setPreferredFramesPerSecond(int preferredFramesPerSecond) {
+    if (mapRenderer != null) {
+      mapRenderer.setPreferredFramesPerSecond(preferredFramesPerSecond);
+    }
+  }
+
+  /**
    * Returns if the map has been destroyed.
    * <p>
    * This method can be used to determine if the result of an asynchronous operation should be set.

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
@@ -5,7 +5,6 @@ import android.support.annotation.CallSuper;
 import android.support.annotation.Keep;
 
 import android.support.annotation.NonNull;
-
 import com.mapbox.mapboxsdk.log.Logger;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.storage.FileSource;
@@ -27,6 +26,7 @@ public abstract class MapRenderer implements MapRendererScheduler {
 
   // Holds the pointer to the native peer after initialisation
   private long nativePtr = 0;
+
   private double expectedRenderTime = 0;
   private MapboxMap.OnFpsChangedListener onFpsChangedListener;
 
@@ -87,7 +87,7 @@ public abstract class MapRenderer implements MapRendererScheduler {
       try {
         Thread.sleep((long) ((expectedRenderTime - renderTime) / 1E6));
       } catch (InterruptedException ex) {
-        ex.printStackTrace();
+        Logger.e(TAG, ex.getMessage());
       }
     }
     if (onFpsChangedListener != null) {
@@ -125,29 +125,26 @@ public abstract class MapRenderer implements MapRendererScheduler {
 
   private native void nativeRender();
 
-  private long frames;
   private long timeElapsed;
 
   private void updateFps() {
-    frames++;
     long currentTime = System.nanoTime();
-    double fps = frames / ((currentTime - timeElapsed) / 1E9);
+    double fps = 1E9 / ((currentTime - timeElapsed));
     onFpsChangedListener.onFpsChanged(fps);
     timeElapsed = currentTime;
-    frames = 0;
   }
 
   /**
-   * The preferred frame rate at which this render is rendered,
+   * The max frame rate at which this render is rendered,
    * but it can't excess the ability of device hardware.
    *
-   * @param preferredFramesPerSecond Can be set to arbitrary integer values.
+   * @param maximumFps Can be set to arbitrary integer values.
    */
-  public void setPreferredFramesPerSecond(int preferredFramesPerSecond) {
-    if (preferredFramesPerSecond <= 0) {
+  public void setMaximumFps(int maximumFps) {
+    if (maximumFps <= 0) {
       // Not valid, just return
       return;
     }
-    expectedRenderTime = 1E9 / preferredFramesPerSecond;
+    expectedRenderTime = 1E9 / maximumFps;
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Locale;
 
 import com.mapbox.mapboxsdk.testapp.utils.IdleZoomListener;
-
 import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility;
@@ -171,10 +170,10 @@ public class DebugModeActivity extends AppCompatActivity implements OnMapReadyCa
 
   private void setupFpsChangeView() {
     findViewById(R.id.fps_30).setOnClickListener(view -> {
-      mapView.setPreferredFramesPerSecond(30);
+      mapView.setMaximumFps(30);
     });
     findViewById(R.id.fps_60).setOnClickListener(view -> {
-      mapView.setPreferredFramesPerSecond(60);
+      mapView.setMaximumFps(60);
     });
   }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Locale;
 
 import com.mapbox.mapboxsdk.testapp.utils.IdleZoomListener;
+
 import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility;
@@ -62,6 +63,7 @@ public class DebugModeActivity extends AppCompatActivity implements OnMapReadyCa
     setupMapView(savedInstanceState);
     setupDebugChangeView();
     setupStyleChangeView();
+    setupFpsChangeView();
   }
 
   private void setupToolbar() {
@@ -164,6 +166,15 @@ public class DebugModeActivity extends AppCompatActivity implements OnMapReadyCa
         }
         mapboxMap.setStyleUrl(STYLES[currentStyleIndex], style -> Timber.d("Style loaded %s", style));
       }
+    });
+  }
+
+  private void setupFpsChangeView() {
+    findViewById(R.id.fps_30).setOnClickListener(view -> {
+      mapView.setPreferredFramesPerSecond(30);
+    });
+    findViewById(R.id.fps_60).setOnClickListener(view -> {
+      mapView.setPreferredFramesPerSecond(60);
     });
   }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_debug_mode.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_debug_mode.xml
@@ -79,6 +79,29 @@
             app:layout_anchor="@id/bottom_sheet"
             app:layout_anchorGravity="bottom|end"/>
 
+        <Button
+            android:id="@+id/fps_60"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end|start"
+            app:backgroundTint="@color/primary"
+            android:layout_margin="@dimen/fab_margin"
+            android:text="@string/fps60"
+            app:layout_anchor="@id/bottom_sheet"
+            app:layout_anchorGravity="top|end"/>
+
+        <Button
+            android:id="@+id/fps_30"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="top|end"
+            android:layout_marginBottom="82dp"
+            app:backgroundTint="@color/primary"
+            android:layout_marginEnd="@dimen/fab_margin"
+            android:layout_marginRight="@dimen/fab_margin"
+            android:text="@string/fps30"
+            app:layout_anchor="@id/fps_60"
+            app:layout_anchorGravity="top"/>
     </android.support.design.widget.CoordinatorLayout>
 
     <android.support.design.widget.NavigationView

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Mapbox Android SDK TestApp</string>
+    <string name="fps30">fps30</string>
+    <string name="fps60">fps60</string>
 </resources>


### PR DESCRIPTION
iOS already added an [API](https://github.com/mapbox/mapbox-gl-native/pull/12501) to let devs set FPS. It is essential in scenarios cpu load is heavy, so it will be better if we could add one on Android side.

I have tested it by myself, it can change the fps roughly, still need some discussions on it. 
