### PR TITLE
[build] Log Android/iOS binary sizes to S3

### DIFF
--- a/ci.template
+++ b/ci.template
@@ -148,21 +148,33 @@
                         }
                     },
                     {
-                        "PolicyName": "publish-metrics",
+                      "PolicyName": "publish-metrics",
+                      "PolicyDocument": {
+                        "Statement": [
+                          {
+                            "Action": [
+                              "s3:PutObject",
+                              "s3:GetObject",
+                              "s3:GetObjectAcl"
+                            ],
+                            "Effect": "Allow",
+                            "Resource": ["arn:aws:s3:::mapbox-loading-dock/raw/mobile.binarysize/*"]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                        "PolicyName": "list-loading-dock",
                         "PolicyDocument": {
                             "Statement": [
                                 {
                                     "Action": [
-                                        "s3:DeleteObject",
-                                        "s3:GetObject",
-                                        "s3:GetObjectAcl",
-                                        "s3:PutObject",
-                                        "s3:PutObjectAcl"
+                                        "s3:ListBucket"
                                     ],
-                                    "Effect": "Allow",
                                     "Resource": [
-                                        "arn:aws:s3:::mapbox/mapbox-gl-native/metrics/*"
-                                    ]
+                                        "arn:aws:s3:::mapbox-loading-dock"
+                                    ],
+                                    "Effect": "Allow"
                                 }
                             ]
                         }

--- a/platform/android/scripts/metrics.sh
+++ b/platform/android/scripts/metrics.sh
@@ -13,5 +13,7 @@ scripts/check_binary_size.js "platform/android/MapboxGLAndroidSDK/build/intermed
 scripts/check_binary_size.js "platform/android/MapboxGLAndroidSDK/build/outputs/aar/MapboxGLAndroidSDK-release.aar" "Android AAR"
 
 if [[ $CIRCLE_BRANCH == master ]]; then
-    scripts/publish_binary_size.js
+  # Build source data for http://mapbox.github.io/mapbox-gl-native/metrics/binary-size/
+  # and log binary sizes to metrics warehouse
+  scripts/publish_binary_size.js
 fi

--- a/platform/ios/scripts/metrics.sh
+++ b/platform/ios/scripts/metrics.sh
@@ -19,5 +19,8 @@ scripts/check_binary_size.js "build/ios/pkg/dynamic/Mapbox-stripped-x86_64"  "iO
 scripts/check_binary_size.js "build/ios/pkg/dynamic/Mapbox-stripped"         "iOS Dynamic"
 
 if [[ $CIRCLE_BRANCH == master ]]; then
-    scripts/publish_binary_size.js
+  # Build source data for http://mapbox.github.io/mapbox-gl-native/metrics/binary-size/
+  # and log binary sizes to metrics warehouse
+  scripts/publish_binary_size.js
 fi
+


### PR DESCRIPTION
This PR alters the CircleCI scripts to publish the binary sizes of the Android and iOS Maps SDKs to a central location on AWS S3.