### PR TITLE
cp podspec bump to release-iowaska

### DIFF
--- a/platform/ios/Mapbox-iOS-SDK-nightly-dynamic.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-nightly-dynamic.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '4.7.0-alpha.3'
+  version = '4.7.0-beta.1'
 
   m.name    = 'Mapbox-iOS-SDK-nightly-dynamic'
   m.version = "#{version}-nightly"

--- a/platform/ios/Mapbox-iOS-SDK-stripped.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-stripped.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '4.7.0-alpha.3'
+  version = '4.7.0-beta.1'
 
   m.name    = 'Mapbox-iOS-SDK-stripped'
   m.version = "#{version}-stripped"

--- a/platform/ios/Mapbox-iOS-SDK.podspec
+++ b/platform/ios/Mapbox-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '4.7.0-alpha.3'
+  version = '4.7.0-beta.1'
 
   m.name    = 'Mapbox-iOS-SDK'
   m.version = version


### PR DESCRIPTION
Cherry picks  the podspec bump for `ios-v4.7.0-beta.1` (https://github.com/mapbox/mapbox-gl-native/pull/13511) into release-iowaska.