### PR TITLE
[core, darwin, android] Add onDidBecomeIdle to MapObserver.

### DIFF
--- a/include/mbgl/map/map_observer.hpp
+++ b/include/mbgl/map/map_observer.hpp
@@ -39,6 +39,7 @@ public:
     virtual void onDidFinishRenderingMap(RenderMode) {}
     virtual void onDidFinishLoadingStyle() {}
     virtual void onSourceChanged(style::Source&) {}
+    virtual void onDidEnterIdle() {}
 };
 
 } // namespace mbgl

--- a/include/mbgl/map/map_observer.hpp
+++ b/include/mbgl/map/map_observer.hpp
@@ -39,7 +39,7 @@ public:
     virtual void onDidFinishRenderingMap(RenderMode) {}
     virtual void onDidFinishLoadingStyle() {}
     virtual void onSourceChanged(style::Source&) {}
-    virtual void onDidEnterIdle() {}
+    virtual void onDidBecomeIdle() {}
 };
 
 } // namespace mbgl

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapChangeReceiver.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapChangeReceiver.java
@@ -26,7 +26,7 @@ class MapChangeReceiver implements NativeMapView.StateCallback {
     = new CopyOnWriteArrayList<>();
   private final List<MapView.OnDidFinishRenderingMapListener> onDidFinishRenderingMapListenerList
     = new CopyOnWriteArrayList<>();
-  private final List<MapView.OnDidEnterIdleListener> onDidEnterIdleListenerList
+  private final List<MapView.OnDidBecomeIdleListener> onDidBecomeIdleListenerList
       = new CopyOnWriteArrayList<>();
   private final List<MapView.OnDidFinishLoadingStyleListener> onDidFinishLoadingStyleListenerList
     = new CopyOnWriteArrayList<>();
@@ -173,15 +173,15 @@ class MapChangeReceiver implements NativeMapView.StateCallback {
   }
 
   @Override
-  public void onDidEnterIdle() {
+  public void onDidBecomeIdle() {
     try {
-      if (!onDidEnterIdleListenerList.isEmpty()) {
-        for (MapView.OnDidEnterIdleListener listener : onDidEnterIdleListenerList) {
-          listener.onDidEnterIdle();
+      if (!onDidBecomeIdleListenerList.isEmpty()) {
+        for (MapView.OnDidBecomeIdleListener listener : onDidBecomeIdleListenerList) {
+          listener.onDidBecomeIdle();
         }
       }
     } catch (Throwable err) {
-      Logger.e(TAG, "Exception in onDidEnterIdle", err);
+      Logger.e(TAG, "Exception in onDidBecomeIdle", err);
       throw err;
     }
   }
@@ -294,12 +294,12 @@ class MapChangeReceiver implements NativeMapView.StateCallback {
     onDidFinishRenderingMapListenerList.remove(listener);
   }
 
-  void addOnDidEnterIdleListener(MapView.OnDidEnterIdleListener listener) {
-    onDidEnterIdleListenerList.add(listener);
+  void addOnDidBecomeIdleListener(MapView.OnDidBecomeIdleListener listener) {
+    onDidBecomeIdleListenerList.add(listener);
   }
 
-  void removeOnDidEnterIdleListener(MapView.OnDidEnterIdleListener listener) {
-    onDidEnterIdleListenerList.remove(listener);
+  void removeOnDidBecomeIdleListener(MapView.OnDidBecomeIdleListener listener) {
+    onDidBecomeIdleListenerList.remove(listener);
   }
 
   void addOnDidFinishLoadingStyleListener(MapView.OnDidFinishLoadingStyleListener listener) {
@@ -329,7 +329,7 @@ class MapChangeReceiver implements NativeMapView.StateCallback {
     onDidFinishRenderingFrameList.clear();
     onWillStartRenderingMapListenerList.clear();
     onDidFinishRenderingMapListenerList.clear();
-    onDidEnterIdleListenerList.clear();
+    onDidBecomeIdleListenerList.clear();
     onDidFinishLoadingStyleListenerList.clear();
     onSourceChangedListenerList.clear();
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapChangeReceiver.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapChangeReceiver.java
@@ -26,6 +26,8 @@ class MapChangeReceiver implements NativeMapView.StateCallback {
     = new CopyOnWriteArrayList<>();
   private final List<MapView.OnDidFinishRenderingMapListener> onDidFinishRenderingMapListenerList
     = new CopyOnWriteArrayList<>();
+  private final List<MapView.OnDidEnterIdleListener> onDidEnterIdleListenerList
+      = new CopyOnWriteArrayList<>();
   private final List<MapView.OnDidFinishLoadingStyleListener> onDidFinishLoadingStyleListenerList
     = new CopyOnWriteArrayList<>();
   private final List<MapView.OnSourceChangedListener> onSourceChangedListenerList = new CopyOnWriteArrayList<>();
@@ -171,6 +173,20 @@ class MapChangeReceiver implements NativeMapView.StateCallback {
   }
 
   @Override
+  public void onDidEnterIdle() {
+    try {
+      if (!onDidEnterIdleListenerList.isEmpty()) {
+        for (MapView.OnDidEnterIdleListener listener : onDidEnterIdleListenerList) {
+          listener.onDidEnterIdle();
+        }
+      }
+    } catch (Throwable err) {
+      Logger.e(TAG, "Exception in onDidEnterIdle", err);
+      throw err;
+    }
+  }
+
+  @Override
   public void onDidFinishLoadingStyle() {
     try {
       if (!onDidFinishLoadingStyleListenerList.isEmpty()) {
@@ -278,6 +294,14 @@ class MapChangeReceiver implements NativeMapView.StateCallback {
     onDidFinishRenderingMapListenerList.remove(listener);
   }
 
+  void addOnDidEnterIdleListener(MapView.OnDidEnterIdleListener listener) {
+    onDidEnterIdleListenerList.add(listener);
+  }
+
+  void removeOnDidEnterIdleListener(MapView.OnDidEnterIdleListener listener) {
+    onDidEnterIdleListenerList.remove(listener);
+  }
+
   void addOnDidFinishLoadingStyleListener(MapView.OnDidFinishLoadingStyleListener listener) {
     onDidFinishLoadingStyleListenerList.add(listener);
   }
@@ -305,6 +329,7 @@ class MapChangeReceiver implements NativeMapView.StateCallback {
     onDidFinishRenderingFrameList.clear();
     onWillStartRenderingMapListenerList.clear();
     onDidFinishRenderingMapListenerList.clear();
+    onDidEnterIdleListenerList.clear();
     onDidFinishLoadingStyleListenerList.clear();
     onSourceChangedListenerList.clear();
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -702,8 +702,8 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
    *
    * @param listener The callback that's invoked when the map has entered the idle state.
    */
-  public void addOnDidEnterIdleListener(OnDidEnterIdleListener listener) {
-    mapChangeReceiver.addOnDidEnterIdleListener(listener);
+  public void addOnDidBecomeIdleListener(OnDidBecomeIdleListener listener) {
+    mapChangeReceiver.addOnDidBecomeIdleListener(listener);
   }
 
   /**
@@ -711,8 +711,8 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
    *
    * @param listener The callback that's invoked when the map has entered the idle state.
    */
-  public void removeOnDidEnterIdleListener(OnDidEnterIdleListener listener) {
-    mapChangeReceiver.removeOnDidEnterIdleListener(listener);
+  public void removeOnDidBecomeIdleListener(OnDidBecomeIdleListener listener) {
+    mapChangeReceiver.removeOnDidBecomeIdleListener(listener);
   }
 
   /**
@@ -893,14 +893,14 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   /**
    * Interface definition for a callback to be invoked when the map has entered the idle state.
    * <p>
-   * {@link MapView#addOnDidEnterIdleListener(OnDidEnterIdleListener)}
+   * {@link MapView#addOnDidBecomeIdleListener(OnDidBecomeIdleListener)}
    * </p>
    */
-  public interface OnDidEnterIdleListener {
+  public interface OnDidBecomeIdleListener {
     /**
      * Called when the map has entered the idle state.
      */
-    void onDidEnterIdle();
+    void onDidBecomeIdle();
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -691,11 +691,31 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   /**
    * Remove a callback that's invoked when the map has finished rendering.
    *
-   * @param listener The callback that's invoked when the map has finished rendering
+   * @param listener The callback that's invoked when the map has has finished rendering.
    */
   public void removeOnDidFinishRenderingMapListener(OnDidFinishRenderingMapListener listener) {
     mapChangeReceiver.removeOnDidFinishRenderingMapListener(listener);
   }
+
+  /**
+   * Set a callback that's invoked when the map has entered the idle state.
+   *
+   * @param listener The callback that's invoked when the map has entered the idle state.
+   */
+  public void addOnDidEnterIdleListener(OnDidEnterIdleListener listener) {
+    mapChangeReceiver.addOnDidEnterIdleListener(listener);
+  }
+
+  /**
+   * Remove a callback that's invoked when the map has entered the idle state.
+   *
+   * @param listener The callback that's invoked when the map has entered the idle state.
+   */
+  public void removeOnDidEnterIdleListener(OnDidEnterIdleListener listener) {
+    mapChangeReceiver.removeOnDidEnterIdleListener(listener);
+  }
+
+  /**
 
   /**
    * Set a callback that's invoked when the style has finished loading.
@@ -868,6 +888,19 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
      * @param fully true if map is fully rendered, false if fully rendered
      */
     void onDidFinishRenderingMap(boolean fully);
+  }
+
+  /**
+   * Interface definition for a callback to be invoked when the map has entered the idle state.
+   * <p>
+   * {@link MapView#addOnDidEnterIdleListener(OnDidEnterIdleListener)}
+   * </p>
+   */
+  public interface OnDidEnterIdleListener {
+    /**
+     * Called when the map has entered the idle state.
+     */
+    void onDidEnterIdle();
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -971,6 +971,11 @@ final class NativeMapView {
   }
 
   @Keep
+  private void onDidEnterIdle() {
+    stateCallback.onDidEnterIdle();
+  }
+
+  @Keep
   private void onDidFinishLoadingStyle() {
     stateCallback.onDidFinishLoadingStyle();
   }
@@ -1425,6 +1430,8 @@ final class NativeMapView {
     void onWillStartRenderingMap();
 
     void onDidFinishRenderingMap(boolean fully);
+
+    void onDidEnterIdle();
 
     void onSourceChanged(String sourceId);
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -971,8 +971,8 @@ final class NativeMapView {
   }
 
   @Keep
-  private void onDidEnterIdle() {
-    stateCallback.onDidEnterIdle();
+  private void onDidBecomeIdle() {
+    stateCallback.onDidBecomeIdle();
   }
 
   @Keep
@@ -1431,7 +1431,7 @@ final class NativeMapView {
 
     void onDidFinishRenderingMap(boolean fully);
 
-    void onDidEnterIdle();
+    void onDidBecomeIdle();
 
     void onSourceChanged(String sourceId);
   }

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/MapChangeReceiverTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/MapChangeReceiverTest.java
@@ -56,7 +56,7 @@ public class MapChangeReceiverTest {
   private MapView.OnDidFinishRenderingMapListener onDidFinishRenderingMapListener;
 
   @Mock
-  private MapView.OnDidEnterIdleListener onDidEnterIdleListener;
+  private MapView.OnDidBecomeIdleListener onDidBecomeIdleListener;
 
   @Mock
   private MapView.OnDidFinishLoadingStyleListener onDidFinishLoadingStyleListener;
@@ -495,29 +495,29 @@ public class MapChangeReceiverTest {
   }
 
   @Test
-  public void testOnDidEnterIdleListener() {
-    mapChangeEventManager.addOnDidEnterIdleListener(onDidEnterIdleListener);
-    mapChangeEventManager.onDidEnterIdle();
-    verify(onDidEnterIdleListener).onDidEnterIdle();
-    mapChangeEventManager.removeOnDidEnterIdleListener(onDidEnterIdleListener);
-    mapChangeEventManager.onDidEnterIdle();
-    verify(onDidEnterIdleListener).onDidEnterIdle();
+  public void testOnDidBecomeIdleListener() {
+    mapChangeEventManager.addOnDidBecomeIdleListener(onDidBecomeIdleListener);
+    mapChangeEventManager.onDidBecomeIdle();
+    verify(onDidBecomeIdleListener).onDidBecomeIdle();
+    mapChangeEventManager.removeOnDidBecomeIdleListener(onDidBecomeIdleListener);
+    mapChangeEventManager.onDidBecomeIdle();
+    verify(onDidBecomeIdleListener).onDidBecomeIdle();
 
-    mapChangeEventManager.addOnDidEnterIdleListener(onDidEnterIdleListener);
+    mapChangeEventManager.addOnDidBecomeIdleListener(onDidBecomeIdleListener);
     Logger.setLoggerDefinition(loggerDefinition);
     Exception exc = new RuntimeException();
-    doThrow(exc).when(onDidEnterIdleListener).onDidEnterIdle();
+    doThrow(exc).when(onDidBecomeIdleListener).onDidBecomeIdle();
     try {
-      mapChangeEventManager.onDidEnterIdle();
+      mapChangeEventManager.onDidBecomeIdle();
       Assert.fail("The exception should've been re-thrown.");
     } catch (RuntimeException throwable) {
       verify(loggerDefinition).e(anyString(), anyString(), eq(exc));
     }
 
     Error err = new ExecutionError("", new Error());
-    doThrow(err).when(onDidEnterIdleListener).onDidEnterIdle();
+    doThrow(err).when(onDidBecomeIdleListener).onDidBecomeIdle();
     try {
-      mapChangeEventManager.onDidEnterIdle();
+      mapChangeEventManager.onDidBecomeIdle();
       Assert.fail("The exception should've been re-thrown.");
     } catch (ExecutionError throwable) {
       verify(loggerDefinition).e(anyString(), anyString(), eq(err));

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/MapChangeReceiverTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/MapChangeReceiverTest.java
@@ -56,6 +56,9 @@ public class MapChangeReceiverTest {
   private MapView.OnDidFinishRenderingMapListener onDidFinishRenderingMapListener;
 
   @Mock
+  private MapView.OnDidEnterIdleListener onDidEnterIdleListener;
+
+  @Mock
   private MapView.OnDidFinishLoadingStyleListener onDidFinishLoadingStyleListener;
 
   @Mock
@@ -485,6 +488,36 @@ public class MapChangeReceiverTest {
     doThrow(err).when(onDidFinishRenderingMapListener).onDidFinishRenderingMap(false);
     try {
       mapChangeEventManager.onDidFinishRenderingMap(false);
+      Assert.fail("The exception should've been re-thrown.");
+    } catch (ExecutionError throwable) {
+      verify(loggerDefinition).e(anyString(), anyString(), eq(err));
+    }
+  }
+
+  @Test
+  public void testOnDidEnterIdleListener() {
+    mapChangeEventManager.addOnDidEnterIdleListener(onDidEnterIdleListener);
+    mapChangeEventManager.onDidEnterIdle();
+    verify(onDidEnterIdleListener).onDidEnterIdle();
+    mapChangeEventManager.removeOnDidEnterIdleListener(onDidEnterIdleListener);
+    mapChangeEventManager.onDidEnterIdle();
+    verify(onDidEnterIdleListener).onDidEnterIdle();
+
+    mapChangeEventManager.addOnDidEnterIdleListener(onDidEnterIdleListener);
+    Logger.setLoggerDefinition(loggerDefinition);
+    Exception exc = new RuntimeException();
+    doThrow(exc).when(onDidEnterIdleListener).onDidEnterIdle();
+    try {
+      mapChangeEventManager.onDidEnterIdle();
+      Assert.fail("The exception should've been re-thrown.");
+    } catch (RuntimeException throwable) {
+      verify(loggerDefinition).e(anyString(), anyString(), eq(exc));
+    }
+
+    Error err = new ExecutionError("", new Error());
+    doThrow(err).when(onDidEnterIdleListener).onDidEnterIdle();
+    try {
+      mapChangeEventManager.onDidEnterIdle();
       Assert.fail("The exception should've been re-thrown.");
     } catch (ExecutionError throwable) {
       verify(loggerDefinition).e(anyString(), anyString(), eq(err));

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/MapChangeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/MapChangeActivity.java
@@ -32,6 +32,7 @@ public class MapChangeActivity extends AppCompatActivity {
     mapView.addOnDidFinishLoadingStyleListener(() -> Timber.v("OnDidFinishLoadingStyle"));
     mapView.addOnDidFinishRenderingFrameListener(fully -> Timber.v("OnDidFinishRenderingFrame: fully: %s", fully));
     mapView.addOnDidFinishRenderingMapListener(fully -> Timber.v("OnDidFinishRenderingMap: fully: %s", fully));
+    mapView.addOnDidEnterIdleListener(() -> Timber.v("OnDidEnterIdle"));
     mapView.addOnSourceChangedListener(sourceId -> Timber.v("OnSourceChangedListener: source with id: %s", sourceId));
     mapView.addOnWillStartLoadingMapListener(() -> Timber.v("OnWillStartLoadingMap"));
     mapView.addOnWillStartRenderingFrameListener(() -> Timber.v("OnWillStartRenderingFrame"));

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/MapChangeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/MapChangeActivity.java
@@ -32,7 +32,7 @@ public class MapChangeActivity extends AppCompatActivity {
     mapView.addOnDidFinishLoadingStyleListener(() -> Timber.v("OnDidFinishLoadingStyle"));
     mapView.addOnDidFinishRenderingFrameListener(fully -> Timber.v("OnDidFinishRenderingFrame: fully: %s", fully));
     mapView.addOnDidFinishRenderingMapListener(fully -> Timber.v("OnDidFinishRenderingMap: fully: %s", fully));
-    mapView.addOnDidEnterIdleListener(() -> Timber.v("OnDidEnterIdle"));
+    mapView.addOnDidBecomeIdleListener(() -> Timber.v("OnDidBecomeIdle"));
     mapView.addOnSourceChangedListener(sourceId -> Timber.v("OnSourceChangedListener: source with id: %s", sourceId));
     mapView.addOnWillStartLoadingMapListener(() -> Timber.v("OnWillStartLoadingMap"));
     mapView.addOnWillStartRenderingFrameListener(() -> Timber.v("OnWillStartRenderingFrame"));

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -186,13 +186,13 @@ void NativeMapView::onDidFinishRenderingMap(MapObserver::RenderMode mode) {
     javaPeer.get(*_env).Call(*_env, onDidFinishRenderingMap, (jboolean) (mode != MapObserver::RenderMode::Partial));
 }
 
-void NativeMapView::onDidEnterIdle() {
+void NativeMapView::onDidBecomeIdle() {
     assert(vm != nullptr);
 
     android::UniqueEnv _env = android::AttachEnv();
     static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
-    static auto onDidEnterIdle = javaClass.GetMethod<void ()>(*_env, "onDidEnterIdle");
-    javaPeer.get(*_env).Call(*_env, onDidEnterIdle);
+    static auto onDidBecomeIdle = javaClass.GetMethod<void ()>(*_env, "onDidBecomeIdle");
+    javaPeer.get(*_env).Call(*_env, onDidBecomeIdle);
 }
 
 void NativeMapView::onDidFinishLoadingStyle() {

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -186,6 +186,15 @@ void NativeMapView::onDidFinishRenderingMap(MapObserver::RenderMode mode) {
     javaPeer.get(*_env).Call(*_env, onDidFinishRenderingMap, (jboolean) (mode != MapObserver::RenderMode::Partial));
 }
 
+void NativeMapView::onDidEnterIdle() {
+    assert(vm != nullptr);
+
+    android::UniqueEnv _env = android::AttachEnv();
+    static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
+    static auto onDidEnterIdle = javaClass.GetMethod<void ()>(*_env, "onDidEnterIdle");
+    javaPeer.get(*_env).Call(*_env, onDidEnterIdle);
+}
+
 void NativeMapView::onDidFinishLoadingStyle() {
     assert(vm != nullptr);
 

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -67,6 +67,7 @@ public:
     void onDidFinishRenderingFrame(MapObserver::RenderMode) override;
     void onWillStartRenderingMap() override;
     void onDidFinishRenderingMap(MapObserver::RenderMode) override;
+    void onDidEnterIdle() override;
     void onDidFinishLoadingStyle() override;
     void onSourceChanged(mbgl::style::Source&) override;
 

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -67,7 +67,7 @@ public:
     void onDidFinishRenderingFrame(MapObserver::RenderMode) override;
     void onWillStartRenderingMap() override;
     void onDidFinishRenderingMap(MapObserver::RenderMode) override;
-    void onDidEnterIdle() override;
+    void onDidBecomeIdle() override;
     void onDidFinishLoadingStyle() override;
     void onSourceChanged(mbgl::style::Source&) override;
 

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -240,6 +240,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)mapViewDidFinishRenderingFrame:(MGLMapView *)mapView fullyRendered:(BOOL)fullyRendered;
 
 /**
+ Tells the delegate that the map view is entering an idle state, and no more
+ drawing will be necessary until new data is loaded or there is some interaction
+ with the map.
+ 
+ - No camera transitions are in progress
+ - All currently requested tiles have loaded
+ - All fade/transition animations have completed
+ 
+ @param mapView The map view that has just entered the idle state.
+ */
+- (void)mapViewDidEnterIdle:(MGLMapView *)mapView;
+
+/**
  Tells the delegate that the map has just finished loading a style.
 
  This method is called during the initialization of the map view and after any

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -250,7 +250,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param mapView The map view that has just entered the idle state.
  */
-- (void)mapViewDidEnterIdle:(MGLMapView *)mapView;
+- (void)mapViewDidBecomeIdle:(MGLMapView *)mapView;
 
 /**
  Tells the delegate that the map has just finished loading a style.

--- a/platform/ios/test/MGLMapViewDelegateIntegrationTests.swift
+++ b/platform/ios/test/MGLMapViewDelegateIntegrationTests.swift
@@ -52,6 +52,8 @@ extension MGLMapViewDelegateIntegrationTests: MGLMapViewDelegate {
     func mapView(_ mapView: MGLMapView, didUpdate userLocation: MGLUserLocation?) {}
 
     func mapViewDidFinishRenderingMap(_ mapView: MGLMapView, fullyRendered: Bool) {}
+    
+     func mapViewDidBecomeIdle(_ mapView: MGLMapView) {}
 
     func mapView(_ mapView: MGLMapView, didFailToLocateUserWithError error: Error) {}
 

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -934,6 +934,16 @@ public:
     }
 }
 
+- (void)mapViewDidEnterIdle {
+    if (!_mbglMap) {
+        return;
+    }
+    
+    if ([self.delegate respondsToSelector:@selector(mapViewDidEnterIdle)]) {
+        [self.delegate mapViewDidEnterIdle:self];
+    }
+}
+
 - (void)mapViewDidFinishLoadingStyle {
     if (!_mbglMap) {
         return;
@@ -3049,6 +3059,10 @@ public:
     void onDidFinishRenderingMap(mbgl::MapObserver::RenderMode mode) override {
         bool fullyRendered = mode == mbgl::MapObserver::RenderMode::Full;
         [nativeView mapViewDidFinishRenderingMapFullyRendered:fullyRendered];
+    }
+    
+    void onDidEnterIdle() override {
+        [nativeView mapViewDidEnterIdle];
     }
 
     void onDidFinishLoadingStyle() override {

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -934,13 +934,13 @@ public:
     }
 }
 
-- (void)mapViewDidEnterIdle {
+- (void)mapViewDidBecomeIdle {
     if (!_mbglMap) {
         return;
     }
     
-    if ([self.delegate respondsToSelector:@selector(mapViewDidEnterIdle)]) {
-        [self.delegate mapViewDidEnterIdle:self];
+    if ([self.delegate respondsToSelector:@selector(mapViewDidBecomeIdle)]) {
+        [self.delegate mapViewDidBecomeIdle:self];
     }
 }
 
@@ -3061,8 +3061,8 @@ public:
         [nativeView mapViewDidFinishRenderingMapFullyRendered:fullyRendered];
     }
     
-    void onDidEnterIdle() override {
-        [nativeView mapViewDidEnterIdle];
+    void onDidBecomeIdle() override {
+        [nativeView mapViewDidBecomeIdle];
     }
 
     void onDidFinishLoadingStyle() override {

--- a/platform/macos/src/MGLMapViewDelegate.h
+++ b/platform/macos/src/MGLMapViewDelegate.h
@@ -162,7 +162,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param mapView The map view that has just entered the idle state.
  */
-- (void)mapViewDidEnterIdle:(MGLMapView *)mapView;
+- (void)mapViewDidBecomeIdle:(MGLMapView *)mapView;
 
 /**
  Tells the delegate that the map has just finished loading a style.

--- a/platform/macos/src/MGLMapViewDelegate.h
+++ b/platform/macos/src/MGLMapViewDelegate.h
@@ -152,6 +152,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)mapViewDidFinishRenderingFrame:(MGLMapView *)mapView fullyRendered:(BOOL)fullyRendered;
 
 /**
+ Tells the delegate that the map view is entering an idle state, and no more
+ drawing will be necessary until new data is loaded or there is some interaction
+ with the map.
+ 
+ - No camera transitions are in progress
+ - All currently requested tiles have loaded
+ - All fade/transition animations have completed
+ 
+ @param mapView The map view that has just entered the idle state.
+ */
+- (void)mapViewDidEnterIdle:(MGLMapView *)mapView;
+
+/**
  Tells the delegate that the map has just finished loading a style.
 
  This method is called during the initialization of the map view and after any

--- a/platform/macos/test/MGLMapViewDelegateIntegrationTests.swift
+++ b/platform/macos/test/MGLMapViewDelegateIntegrationTests.swift
@@ -25,7 +25,7 @@ extension MGLMapViewDelegateIntegrationTests: MGLMapViewDelegate {
 
     func mapViewDidFinishRenderingMap(_ mapView: MGLMapView, fullyRendered: Bool) {}
     
-    func mapViewDidEnterIdle(_ mapView: MGLMapView) {}
+    func mapViewDidBecomeIdle(_ mapView: MGLMapView) {}
 
     func mapViewDidFailLoadingMap(_ mapView: MGLMapView, withError error: Error) {}
     

--- a/platform/macos/test/MGLMapViewDelegateIntegrationTests.swift
+++ b/platform/macos/test/MGLMapViewDelegateIntegrationTests.swift
@@ -24,6 +24,8 @@ extension MGLMapViewDelegateIntegrationTests: MGLMapViewDelegate {
     func mapViewDidFinishRenderingFrame(_ mapView: MGLMapView, fullyRendered: Bool) {}
 
     func mapViewDidFinishRenderingMap(_ mapView: MGLMapView, fullyRendered: Bool) {}
+    
+    func mapViewDidEnterIdle(_ mapView: MGLMapView) {}
 
     func mapViewDidFailLoadingMap(_ mapView: MGLMapView, withError error: Error) {}
     

--- a/scripts/changelog_staging/idle-event.json
+++ b/scripts/changelog_staging/idle-event.json
@@ -1,0 +1,6 @@
+{
+  "core": "Add onDidEnterIdle to MapObserver, which fires whenever render completes and no repaint is scheduled.",
+  "darwin": "Add mapViewDidEnterIdle to MGLMapViewDelegate, which fires whenever render completes and no repaint is scheduled.",
+  "android": "Add onDidEnterIdle listener to MapView, which fires whenever render completes and no repaint is scheduled.",
+  "issue": 13469
+}

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -210,7 +210,7 @@ void Map::Impl::onDidFinishRenderingFrame(RenderMode renderMode, bool needsRepai
         if (needsRepaint || transform.inTransition()) {
             onUpdate();
         } else if (rendererFullyLoaded) {
-            observer.onDidEnterIdle();
+            observer.onDidBecomeIdle();
         }
     } else if (stillImageRequest && rendererFullyLoaded) {
         auto request = std::move(stillImageRequest);

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -209,6 +209,8 @@ void Map::Impl::onDidFinishRenderingFrame(RenderMode renderMode, bool needsRepai
 
         if (needsRepaint || transform.inTransition()) {
             onUpdate();
+        } else if (rendererFullyLoaded) {
+            observer.onDidEnterIdle();
         }
     } else if (stillImageRequest && rendererFullyLoaded) {
         auto request = std::move(stillImageRequest);


### PR DESCRIPTION
'didEnterIdle' fires whenever render completes and no repaint is scheduled.
Fixes issue #13469

Potential issues:

- This logic doesn't know anything about animations that are being driven by the SDK instead of through the core transition logic. In practice I think this probably won't be a huge issue because if the SDK is running an animation, it will keep triggering placement, which will keep the renderer from entering idle.
- Potentially confusing to add an extra event, since we've already got "didFinishRendering/fullyRendered" and "didFinishLoadingMap". However, I think the name "idle" is a pretty good description of this event, and matches up better with what users have expected to get from the other events.

cc @tobrun @julianrex @ansis 