### PR TITLE
Update clustering example with filter configuration 

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/GeoJsonClusteringActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/GeoJsonClusteringActivity.java
@@ -168,7 +168,7 @@ public class GeoJsonClusteringActivity extends AppCompatActivity {
         )
       )
     );
-
+    unclustered.setFilter(has("mag"));
     mapboxMap.addLayer(unclustered);
 
     for (int i = 0; i < layers.length; i++) {


### PR DESCRIPTION
Closes #12798, with the addition of symbol placement, fading of symbols was added. 
Adding a filter configuration on the unclustered layer resolves the issue from #12798.

cc @langsmith as we have other examples downstream that can be updated