### PR TITLE
[ios, macos] Add Streets-v8 field names to accessibility checks

### DIFF
--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -600,7 +600,7 @@ static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
 - (NSArray<MGLStyleLayer *> *)placeStyleLayers {
     NSSet *streetsSourceIdentifiers = [self.mapboxStreetsSources valueForKey:@"identifier"];
     
-    NSSet *placeSourceLayerIdentifiers = [NSSet setWithObjects:@"marine_label", @"country_label", @"state_label", @"place_label", @"water_label", @"poi_label", @"rail_station_label", @"mountain_peak_label", nil];
+    NSSet *placeSourceLayerIdentifiers = [NSSet setWithObjects:@"marine_label", @"country_label", @"state_label", @"place_label", @"water_label", @"poi_label", @"rail_station_label", @"mountain_peak_label", @"natural_label", @"transit_stop_label", nil];
     NSPredicate *isPlacePredicate = [NSPredicate predicateWithBlock:^BOOL (MGLVectorStyleLayer * _Nullable layer, NSDictionary<NSString *, id> * _Nullable bindings) {
         return [layer isKindOfClass:[MGLVectorStyleLayer class]] && [streetsSourceIdentifiers containsObject:layer.sourceIdentifier] && [placeSourceLayerIdentifiers containsObject:layer.sourceLayerIdentifier];
     }];
@@ -609,9 +609,10 @@ static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
 
 - (NSArray<MGLStyleLayer *> *)roadStyleLayers {
     NSSet *streetsSourceIdentifiers = [self.mapboxStreetsSources valueForKey:@"identifier"];
-    
+
+    NSSet *roadStyleLayerIdentifiers = [NSSet setWithObjects:@"road_label", @"road", nil];
     NSPredicate *isPlacePredicate = [NSPredicate predicateWithBlock:^BOOL (MGLVectorStyleLayer * _Nullable layer, NSDictionary<NSString *, id> * _Nullable bindings) {
-        return [layer isKindOfClass:[MGLVectorStyleLayer class]] && [streetsSourceIdentifiers containsObject:layer.sourceIdentifier] && [layer.sourceLayerIdentifier isEqualToString:@"road_label"];
+        return [layer isKindOfClass:[MGLVectorStyleLayer class]] && [streetsSourceIdentifiers containsObject:layer.sourceIdentifier] && [roadStyleLayerIdentifiers containsObject:layer.sourceLayerIdentifier];
     }];
     return [self.layers filteredArrayUsingPredicate:isPlacePredicate];
 }

--- a/platform/darwin/src/NSString+MGLAdditions.m
+++ b/platform/darwin/src/NSString+MGLAdditions.m
@@ -46,11 +46,17 @@
     if ([script isEqualToString:@"Latn"]) {
         transform = NSStringTransformToLatin;
     } else if ([script isEqualToString:@"Hans"]) {
-        // No transform available.
+        transform = @"Hant-Hans";
+    } else if ([script isEqualToString:@"Hant"]) {
+        transform = @"Hans-Hant";
     } else if ([script isEqualToString:@"Cyrl"]) {
         transform = @"Any-Latin; Latin-Cyrillic";
     } else if ([script isEqualToString:@"Arab"]) {
         transform = @"Any-Latin; Latin-Arabic";
+    } else if ([script isEqualToString:@"Jpan"]) {
+        transform = @"Any-Latin; Latin-Katakana";
+    } else if ([script isEqualToString:@"Kore"]) {
+        transform = @"Any-Latin; Latin-Hangul";
     }
     return transform ? [string stringByApplyingTransform:transform reverse:NO] : string;
 }

--- a/platform/darwin/test/MGLNSStringAdditionsTests.m
+++ b/platform/darwin/test/MGLNSStringAdditionsTests.m
@@ -42,26 +42,47 @@
 - (void)testTransliteratedString {
     XCTAssertEqualObjects([@"Portland" mgl_stringByTransliteratingIntoScript:@"Latn"], @"Portland");
     XCTAssertEqualObjects([@"Portland" mgl_stringByTransliteratingIntoScript:@"Hans"], @"Portland");
+    XCTAssertEqualObjects([@"Portland" mgl_stringByTransliteratingIntoScript:@"Hant"], @"Portland");
     XCTAssertEqualObjects([@"Portland" mgl_stringByTransliteratingIntoScript:@"Cyrl"], @"Портланд");
     XCTAssertEqualObjects([@"Portland" mgl_stringByTransliteratingIntoScript:@"Arab"], @"پُرتلَند");
+    XCTAssertEqualObjects([@"Portland" mgl_stringByTransliteratingIntoScript:@"Jpan"], @"ポルテランデ");
+    XCTAssertEqualObjects([@"Portland" mgl_stringByTransliteratingIntoScript:@"Kore"], @"폹란드");
     XCTAssertEqualObjects([@"Portland" mgl_stringByTransliteratingIntoScript:@"Fake"], @"Portland");
 
     XCTAssertEqualObjects([@"北京" mgl_stringByTransliteratingIntoScript:@"Latn"], @"běi jīng");
     XCTAssertEqualObjects([@"北京" mgl_stringByTransliteratingIntoScript:@"Hans"], @"北京");
+    XCTAssertEqualObjects([@"北京" mgl_stringByTransliteratingIntoScript:@"Hant"], @"北京");
     XCTAssertEqualObjects([@"北京" mgl_stringByTransliteratingIntoScript:@"Cyrl"], @"бе̌и йӣнг");
     XCTAssertEqualObjects([@"北京" mgl_stringByTransliteratingIntoScript:@"Arab"], @"بِِ̌ جِينگ");
+    XCTAssertEqualObjects([@"北京" mgl_stringByTransliteratingIntoScript:@"Jpan"], @"ベ̌イ ジーング");
+    XCTAssertEqualObjects([@"北京" mgl_stringByTransliteratingIntoScript:@"Kore"], @"베̌이 지̄늑");
     XCTAssertEqualObjects([@"北京" mgl_stringByTransliteratingIntoScript:@"Fake"], @"北京");
+    
+    XCTAssertEqualObjects([@"九龍" mgl_stringByTransliteratingIntoScript:@"Latn"], @"jiǔ lóng");
+    XCTAssertEqualObjects([@"九龍" mgl_stringByTransliteratingIntoScript:@"Hans"], @"九龙");
+    XCTAssertEqualObjects([@"九龍" mgl_stringByTransliteratingIntoScript:@"Hant"], @"九龍");
+    XCTAssertEqualObjects([@"九龍" mgl_stringByTransliteratingIntoScript:@"Cyrl"], @"йиу̌ ло́нг");
+    XCTAssertEqualObjects([@"九龍" mgl_stringByTransliteratingIntoScript:@"Arab"], @"جُِ̌ لُ́نگ");
+    XCTAssertEqualObjects([@"九龍" mgl_stringByTransliteratingIntoScript:@"Jpan"], @"ジウ̌ ロ́ング");
+    XCTAssertEqualObjects([@"九龍" mgl_stringByTransliteratingIntoScript:@"Kore"], @"지우̌ 로́늑");
+    XCTAssertEqualObjects([@"九龍" mgl_stringByTransliteratingIntoScript:@"Fake"], @"九龍");
 
     XCTAssertEqualObjects([@"Mосква" mgl_stringByTransliteratingIntoScript:@"Latn"], @"Moskva");
     XCTAssertEqualObjects([@"Mосква" mgl_stringByTransliteratingIntoScript:@"Hans"], @"Mосква");
+    XCTAssertEqualObjects([@"Mосква" mgl_stringByTransliteratingIntoScript:@"Hant"], @"Mосква");
     XCTAssertEqualObjects([@"Mосква" mgl_stringByTransliteratingIntoScript:@"Cyrl"], @"Москва");
     XCTAssertEqualObjects([@"Mосква" mgl_stringByTransliteratingIntoScript:@"Arab"], @"مُسكڤَ");
+    XCTAssertEqualObjects([@"Mосква" mgl_stringByTransliteratingIntoScript:@"Jpan"], @"モスクヷ");
+    XCTAssertEqualObjects([@"Mосква" mgl_stringByTransliteratingIntoScript:@"Kore"], @"못크바");
     XCTAssertEqualObjects([@"Mосква" mgl_stringByTransliteratingIntoScript:@"Fake"], @"Mосква");
 
     XCTAssertEqualObjects([@"ロンドン" mgl_stringByTransliteratingIntoScript:@"Latn"], @"rondon");
     XCTAssertEqualObjects([@"ロンドン" mgl_stringByTransliteratingIntoScript:@"Hans"], @"ロンドン");
+    XCTAssertEqualObjects([@"ロンドン" mgl_stringByTransliteratingIntoScript:@"Hant"], @"ロンドン");
     XCTAssertEqualObjects([@"ロンドン" mgl_stringByTransliteratingIntoScript:@"Cyrl"], @"рондон");
     XCTAssertEqualObjects([@"ロンドン" mgl_stringByTransliteratingIntoScript:@"Arab"], @"رُندُن");
+    XCTAssertEqualObjects([@"ロンドン" mgl_stringByTransliteratingIntoScript:@"Jpan"], @"ロンドン");
+    XCTAssertEqualObjects([@"ロンドン" mgl_stringByTransliteratingIntoScript:@"Kore"], @"론돈");
     XCTAssertEqualObjects([@"ロンドン" mgl_stringByTransliteratingIntoScript:@"Fake"], @"ロンドン");
 }
 

--- a/platform/ios/src/MGLMapAccessibilityElement.mm
+++ b/platform/ios/src/MGLMapAccessibilityElement.mm
@@ -78,7 +78,11 @@
         NSMutableArray *facts = [NSMutableArray array];
         
         // Announce the kind of place or POI.
-        if (attributes[@"type"]) {
+        NSString *languageCode = [MGLVectorTileSource preferredMapboxStreetsLanguage];
+        NSString *categoryAttribute = [NSString stringWithFormat:@"category_%@", languageCode];
+        if (attributes[categoryAttribute]) {
+            [facts addObject:attributes[categoryAttribute]];
+        } else if (attributes[@"type"]) {
             // FIXME: Unfortunately, these types aren’t a closed set that can be
             // localized, since they’re based on OpenStreetMap tags.
             NSString *type = [attributes[@"type"] stringByReplacingOccurrencesOfString:@"_"
@@ -88,7 +92,6 @@
         // Announce the kind of airport, rail station, or mountain based on its
         // Maki image name.
         else if (attributes[@"maki"]) {
-            // TODO: Localize Maki image names.
             [facts addObject:attributes[@"maki"]];
         }
         

--- a/platform/ios/src/NSOrthography+MGLAdditions.m
+++ b/platform/ios/src/NSOrthography+MGLAdditions.m
@@ -18,10 +18,16 @@
         return @"Latn";
     } else if ([hansLanguages containsObject:language]) {
         return @"Hans";
+    } else if ([language isEqualToString:@"zh-Hant"]) {
+        return @"Hant";
     } else if ([language isEqualToString:@"ru"]) {
         return @"Cyrl";
     } else if ([language isEqualToString:@"ar"]) {
         return @"Arab";
+    } else if ([language isEqualToString:@"ja"]) {
+        return @"Jpan";
+    } else if ([language isEqualToString:@"ko"]) {
+        return @"Kore";
     } else {
         // Code for undetermined script
         return @"Zyyy";


### PR DESCRIPTION
Updates VoiceOver accessibility style layer checks for [Streets-v8 field names](https://www.mapbox.com/vector-tiles/mapbox-streets-v8/#changelog), per #11867.

/cc @1ec5 