### PR TITLE
Extrusions: Do not try to triangulate non-polygon type features

### DIFF
--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -157,7 +157,6 @@
   "render-tests/remove-feature-state/default": "https://github.com/mapbox/mapbox-gl-native/issues/12413",
   "render-tests/remove-feature-state/vector-source": "https://github.com/mapbox/mapbox-gl-native/issues/12413",
   "render-tests/regressions/mapbox-gl-js#8026": "skip - js specific",
-  "render-tests/fill-extrusion-geometry/linestring": "https://github.com/mapbox/mapbox-gl-native/pull/14240",
   "query-tests/remove-feature-state/default": "https://github.com/mapbox/mapbox-gl-native/issues/12413",
   "query-tests/fill-extrusion/base-in": "https://github.com/mapbox/mapbox-gl-native/issues/13139",
   "query-tests/fill-extrusion/box-in": "https://github.com/mapbox/mapbox-gl-native/issues/13139",

--- a/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
+++ b/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
@@ -139,20 +139,21 @@ void FillExtrusionBucket::addFeature(const GeometryTileFeature& feature,
                 }
             }
         }
+        //only triangulate and draw the area of the feature if it is a polygon since other features (e.g. LineString) do not have a base area
+        if(feature.getType() == FeatureType::Polygon) {
+            std::vector<uint32_t> indices = mapbox::earcut(polygon);
 
-        std::vector<uint32_t> indices = mapbox::earcut(polygon);
+            std::size_t nIndices = indices.size();
+            assert(nIndices % 3 == 0);
 
-        std::size_t nIndices = indices.size();
-        assert(nIndices % 3 == 0);
-
-        for (uint32_t i = 0; i < nIndices; i += 3) {
-            // Counter-Clockwise winding order.
-            triangles.emplace_back(flatIndices[indices[i]], flatIndices[indices[i + 2]],
-                                   flatIndices[indices[i + 1]]);
+            for (uint32_t i = 0; i < nIndices; i += 3) {
+                // Counter-Clockwise winding order.
+                triangles.emplace_back(flatIndices[indices[i]], flatIndices[indices[i + 2]],
+                                       flatIndices[indices[i + 1]]);
+            }
+            triangleSegment.indexLength += nIndices;
         }
-
         triangleSegment.vertexLength += totalVertices;
-        triangleSegment.indexLength += nIndices;
     }
 
     for (auto& pair : paintPropertyBinders) {


### PR DESCRIPTION
Trying to triangulate the base area of a feature without base area (e.g.
GeoJSON LineStrings) just creates invalid excess triangles,
yielding visual artifacts

There is an equivalent pull request for mapbox-gl-js, which I have just posted