### PR TITLE
[core]Disable RenderAnnotationSource when annotations are disabled

### DIFF
--- a/src/mbgl/annotation/render_annotation_source.cpp
+++ b/src/mbgl/annotation/render_annotation_source.cpp
@@ -6,12 +6,15 @@
 #include <mbgl/algorithm/generate_clip_ids.hpp>
 #include <mbgl/algorithm/generate_clip_ids_impl.hpp>
 
+#include <mbgl/layermanager/layer_manager.hpp>
+
 namespace mbgl {
 
 using namespace style;
 
 RenderAnnotationSource::RenderAnnotationSource(Immutable<AnnotationSource::Impl> impl_)
     : RenderSource(impl_) {
+    assert(LayerManager::annotationsEnabled);
     tilePyramid.setObserver(this);
 }
 

--- a/src/mbgl/renderer/render_source.cpp
+++ b/src/mbgl/renderer/render_source.cpp
@@ -10,6 +10,8 @@
 #include <mbgl/renderer/sources/render_custom_geometry_source.hpp>
 #include <mbgl/tile/tile.hpp>
 
+#include <mbgl/layermanager/layer_manager.hpp>
+
 namespace mbgl {
 
 using namespace style;
@@ -28,7 +30,12 @@ std::unique_ptr<RenderSource> RenderSource::create(Immutable<Source::Impl> impl)
         assert(false);
         return nullptr;
     case SourceType::Annotations:
-        return std::make_unique<RenderAnnotationSource>(staticImmutableCast<AnnotationSource::Impl>(impl));
+        if (LayerManager::annotationsEnabled) {
+            return std::make_unique<RenderAnnotationSource>(staticImmutableCast<AnnotationSource::Impl>(impl));
+        } else {
+            assert(false);
+            return nullptr;
+        }
     case SourceType::Image:
         return std::make_unique<RenderImageSource>(staticImmutableCast<ImageSource::Impl>(impl));
     case SourceType::CustomVector:


### PR DESCRIPTION
This patch disables creation of `RenderAnnotationSource` instances
and thus saves extra 4Ki on Android when `LayerManager::annotationsEnabled`
is `false`.