### PR TITLE
[android] Enable core-only layers

### DIFF
--- a/platform/android/src/style/layers/layer_manager.hpp
+++ b/platform/android/src/style/layers/layer_manager.hpp
@@ -29,13 +29,27 @@ public:
 
 private:
     LayerManagerAndroid();
-    void addLayerType(std::unique_ptr<JavaLayerPeerFactory>);
+    /**
+     * @brief Enables a layer type for both JSON style an runtime API.
+     */
+    void addLayerType(std::unique_ptr<JavaLayerPeerFactory>); 
+    /**
+     * @brief Enables a layer type for JSON style only.
+     *
+     * We might not want to expose runtime API for some layer types
+     * in order to save binary size - JNI glue code for these layer types
+     * won't be added to the binary. 
+     */
+    void addLayerTypeCoreOnly(std::unique_ptr<mbgl::LayerFactory>);
+
+    void registerCoreFactory(mbgl::LayerFactory*);
     JavaLayerPeerFactory* getPeerFactory(const mbgl::style::LayerTypeInfo*);
     // mbgl::LayerManager overrides.
     LayerFactory* getFactory(const std::string& type) noexcept final;
     LayerFactory* getFactory(const mbgl::style::LayerTypeInfo* info) noexcept final;
 
-    std::vector<std::unique_ptr<JavaLayerPeerFactory>> factories;
+    std::vector<std::unique_ptr<JavaLayerPeerFactory>> peerFactories;
+    std::vector<std::unique_ptr<mbgl::LayerFactory>> coreFactories;
     std::map<std::string, mbgl::LayerFactory*> typeToFactory;
 };
 


### PR DESCRIPTION
`LayerManagerAndroid` can add layer types that are enabled only for JSON style.
It allows to save binary size - JNI glue code for these layer types won't be
added to the binaries.

tagging #13276