### PR TITLE
[ios] Cherry-pick #13427 - Expose "local ideograph font family" in map snapshotters

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/cmake-node-module": "^1.1.0",
+    "@mapbox/cmake-node-module": "1.1.0",
     "node-pre-gyp": "^0.10.2",
     "npm-run-all": "^4.0.2"
   },

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
@@ -93,6 +93,7 @@ public class MapSnapshotter {
     private LatLngBounds region;
     private CameraPosition cameraPosition;
     private boolean showLogo = true;
+    private String localIdeographFontFamily;
 
     /**
      * @param width  the width of the image
@@ -164,6 +165,22 @@ public class MapSnapshotter {
     }
 
     /**
+     * Set the font family for generating glyphs locally for ideographs in the &#x27;CJK Unified Ideographs&#x27;
+     * and &#x27;Hangul Syllables&#x27; ranges.
+     * <p>
+     * The font family argument is passed to {@link android.graphics.Typeface#create(String, int)}.
+     * Default system fonts are defined in &#x27;/system/etc/fonts.xml&#x27;
+     *
+     * @param fontFamily font family for local ideograph generation.
+     * @return the mutated {@link Options}
+     */
+    @NonNull
+    public Options withLocalIdeographFontFamily(String fontFamily) {
+      this.localIdeographFontFamily = fontFamily;
+      return this;
+    }
+
+    /**
      * @return the width of the image
      */
     public int getWidth() {
@@ -206,6 +223,14 @@ public class MapSnapshotter {
     public CameraPosition getCameraPosition() {
       return cameraPosition;
     }
+
+    /**
+     * @return the font family used for locally generating ideographs
+     */
+    public String getLocalIdeographFontFamily() {
+      return localIdeographFontFamily;
+    }
+
   }
 
   /**
@@ -223,7 +248,7 @@ public class MapSnapshotter {
 
     nativeInitialize(this, fileSource, options.pixelRatio, options.width,
       options.height, options.styleUrl, options.styleJson, options.region, options.cameraPosition,
-      options.showLogo, programCacheDir);
+      options.showLogo, programCacheDir, options.localIdeographFontFamily);
   }
 
   /**
@@ -498,7 +523,8 @@ public class MapSnapshotter {
                                          FileSource fileSource, float pixelRatio,
                                          int width, int height, String styleUrl, String styleJson,
                                          LatLngBounds region, CameraPosition position,
-                                         boolean showLogo, String programCacheDir);
+                                         boolean showLogo, String programCacheDir,
+                                         String localIdeographFontFamily);
 
   @Keep
   protected native void nativeStart();

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/snapshot/MapSnapshotterActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/snapshot/MapSnapshotterActivity.java
@@ -68,7 +68,8 @@ public class MapSnapshotterActivity extends AppCompatActivity {
       .withPixelRatio(1)
 
       // Optionally the style
-      .withStyle((column + row) % 2 == 0 ? Style.MAPBOX_STREETS : Style.DARK);
+      .withStyle((column + row) % 2 == 0 ? Style.MAPBOX_STREETS : Style.DARK)
+        .withLocalIdeographFontFamily("sans-serif");
 
     // Optionally the visible region
     if (row % 2 == 0) {

--- a/platform/android/src/snapshotter/map_snapshotter.cpp
+++ b/platform/android/src/snapshotter/map_snapshotter.cpp
@@ -24,7 +24,8 @@ MapSnapshotter::MapSnapshotter(jni::JNIEnv& _env,
                                const jni::Object<LatLngBounds>& region,
                                const jni::Object<CameraPosition>& position,
                                jni::jboolean _showLogo,
-                               const jni::String& _programCacheDir)
+                               const jni::String& _programCacheDir,
+                               const jni::String& _localIdeographFontFamily)
         : javaPeer(_env, _obj)
         , pixelRatio(_pixelRatio)
         , threadPool(sharedThreadPool()) {
@@ -65,7 +66,10 @@ MapSnapshotter::MapSnapshotter(jni::JNIEnv& _env,
                                                          pixelRatio,
                                                          cameraOptions,
                                                          bounds,
-                                                         jni::Make<std::string>(_env, _programCacheDir));
+                                                         jni::Make<std::string>(_env, _programCacheDir),
+                                                         _localIdeographFontFamily ?
+                                                            jni::Make<std::string>(_env, _localIdeographFontFamily) :
+                                                            optional<std::string>{});
 
 }
 
@@ -156,7 +160,7 @@ void MapSnapshotter::registerNative(jni::JNIEnv& env) {
 
     // Register the peer
     jni::RegisterNativePeer<MapSnapshotter>(env, javaClass, "nativePtr",
-                                            jni::MakePeer<MapSnapshotter, const jni::Object<MapSnapshotter>&, const jni::Object<FileSource>&, jni::jfloat, jni::jint, jni::jint, const jni::String&, const jni::String&, const jni::Object<LatLngBounds>&, const jni::Object<CameraPosition>&, jni::jboolean, const jni::String&>,
+                                            jni::MakePeer<MapSnapshotter, const jni::Object<MapSnapshotter>&, const jni::Object<FileSource>&, jni::jfloat, jni::jint, jni::jint, const jni::String&, const jni::String&, const jni::Object<LatLngBounds>&, const jni::Object<CameraPosition>&, jni::jboolean, const jni::String&, const jni::String&>,
                                            "nativeInitialize",
                                            "finalize",
                                             METHOD(&MapSnapshotter::setStyleUrl, "setStyleUrl"),

--- a/platform/android/src/snapshotter/map_snapshotter.hpp
+++ b/platform/android/src/snapshotter/map_snapshotter.hpp
@@ -35,7 +35,8 @@ public:
                    const jni::Object<LatLngBounds>& region,
                    const jni::Object<CameraPosition>& position,
                    jni::jboolean showLogo,
-                   const jni::String& programCacheDir);
+                   const jni::String& programCacheDir,
+                   const jni::String& localIdeographFontFamily);
 
     ~MapSnapshotter();
 

--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -15,6 +15,7 @@
 #import "NSBundle+MGLAdditions.h"
 #import "MGLStyle.h"
 #import "MGLAttributionInfo_Private.h"
+#import "MGLRendererConfiguration.h"
 
 #if TARGET_OS_IPHONE
 #import "UIImage+MGLAdditions.h"
@@ -560,8 +561,11 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
         coordinateBounds = MGLLatLngBoundsFromCoordinateBounds(options.coordinateBounds);
     }
     
+    // App-global configuration
+    MGLRendererConfiguration* config = [MGLRendererConfiguration currentConfiguration];
+    
     // Create the snapshotter
-    _mbglMapSnapshotter = std::make_unique<mbgl::MapSnapshotter>(mbglFileSource, _mbglThreadPool, style, size, pixelRatio, cameraOptions, coordinateBounds);
+    _mbglMapSnapshotter = std::make_unique<mbgl::MapSnapshotter>(mbglFileSource, _mbglThreadPool, style, size, pixelRatio, cameraOptions, coordinateBounds, config.cacheDir, config.localFontFamilyName);
 }
 
 @end

--- a/platform/default/mbgl/map/map_snapshotter.cpp
+++ b/platform/default/mbgl/map/map_snapshotter.cpp
@@ -20,7 +20,8 @@ public:
          const float pixelRatio,
          const optional<CameraOptions> cameraOptions,
          const optional<LatLngBounds> region,
-         const optional<std::string> programCacheDir);
+         const optional<std::string> programCacheDir,
+         const optional<std::string> localFontFamily = {});
 
     void setStyleURL(std::string styleURL);
     std::string getStyleURL() const;
@@ -52,9 +53,10 @@ MapSnapshotter::Impl::Impl(FileSource* fileSource,
            const float pixelRatio,
            const optional<CameraOptions> cameraOptions,
            const optional<LatLngBounds> region,
-           const optional<std::string> programCacheDir)
+           const optional<std::string> programCacheDir,
+           const optional<std::string> localFontFamily)
     : scheduler(std::move(scheduler_))
-    , frontend(size, pixelRatio, *fileSource, *scheduler, programCacheDir)
+    , frontend(size, pixelRatio, *fileSource, *scheduler, programCacheDir, GLContextMode::Unique, localFontFamily)
     , map(frontend, MapObserver::nullObserver(), size, pixelRatio, *fileSource, *scheduler, MapMode::Static) {
 
     if (style.first) {
@@ -168,8 +170,9 @@ MapSnapshotter::MapSnapshotter(FileSource* fileSource,
                                const float pixelRatio,
                                const optional<CameraOptions> cameraOptions,
                                const optional<LatLngBounds> region,
-                               const optional<std::string> programCacheDir)
-   : impl(std::make_unique<util::Thread<MapSnapshotter::Impl>>("Map Snapshotter", fileSource, std::move(scheduler), style, size, pixelRatio, cameraOptions, region, programCacheDir)) {
+                               const optional<std::string> programCacheDir,
+                               const optional<std::string> localFontFamily)
+   : impl(std::make_unique<util::Thread<MapSnapshotter::Impl>>("Map Snapshotter", fileSource, std::move(scheduler), style, size, pixelRatio, cameraOptions, region, programCacheDir, localFontFamily)) {
 }
 
 MapSnapshotter::~MapSnapshotter() = default;

--- a/platform/default/mbgl/map/map_snapshotter.hpp
+++ b/platform/default/mbgl/map/map_snapshotter.hpp
@@ -32,7 +32,8 @@ public:
                    const float pixelRatio,
                    const optional<CameraOptions> cameraOptions,
                    const optional<LatLngBounds> region,
-                   const optional<std::string> cacheDir = {});
+                   const optional<std::string> cacheDir = {},
+                   const optional<std::string> localFontFamily = {});
 
     ~MapSnapshotter();
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -3,6 +3,7 @@
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 ## ios8-release-gazpacho
 
+* `MGLMapSnapshotter` now follows "MGLIdeographicFontFamilyName" app setting to reduce font data usage while snapshotting CJK maps [#13427](https://github.com/mapbox/mapbox-gl-native/pull/13427)
 * Restored iOS 8 support for the Mapbox Maps SDK for iOS. ([#13036](https://github.com/mapbox/mapbox-gl-native/pull/13036))
 
 ## 4.5.0 - October 10, 2018

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,6 +4,8 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 ## ios8-release-gazpacho
 
 * `MGLMapSnapshotter` now follows "MGLIdeographicFontFamilyName" app setting to reduce font data usage while snapshotting CJK maps [#13427](https://github.com/mapbox/mapbox-gl-native/pull/13427)
+
+## v4.5.0-cn.1
 * Restored iOS 8 support for the Mapbox Maps SDK for iOS. ([#13036](https://github.com/mapbox/mapbox-gl-native/pull/13036))
 
 ## 4.5.0 - October 10, 2018


### PR DESCRIPTION
This PR cherry-picks #13427 into the iOS 8 branch.

cc @lloydsheng @chriswu42 