### PR TITLE
Set snapshot version to 7.1.0

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/gradle.properties
+++ b/platform/android/MapboxGLAndroidSDK/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.mapbox.mapboxsdk
-VERSION_NAME=7.0.0-SNAPSHOT
+VERSION_NAME=7.1.0-SNAPSHOT
 
 POM_DESCRIPTION=Mapbox GL Android SDK
 POM_URL=https://github.com/mapbox/mapbox-gl-native


### PR DESCRIPTION
Extracted snapshot version update from https://github.com/mapbox/mapbox-gl-native/pull/13536 as that is blocked by https://github.com/mapbox/mapbox-gl-native/pull/12972