### PR TITLE
[ios, macos] Add enablePlacementTransitions to MGLStyle.

### DIFF
--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -271,6 +271,13 @@ MGL_EXPORT
 @property (nonatomic) MGLTransition transition;
 
 /**
+ A boolean value indicating whether label placement transitions are enabled.
+ 
+ The default value of this property is `YES`.
+ */
+@property (nonatomic, assign) BOOL enablePlacementTransitions;
+
+/**
  Returns a source with the given identifier in the current style.
 
  @note Source identifiers are not guaranteed to exist across styles or different

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -534,6 +534,19 @@ static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
     return MGLTransitionFromOptions(transitionOptions);
 }
 
+- (void)setEnablePlacementTransitions:(BOOL)enablePlacementTransitions
+{
+    mbgl::style::TransitionOptions transitionOptions = self.rawStyle->getTransitionOptions();
+    transitionOptions.enablePlacementTransitions = static_cast<bool>(enablePlacementTransitions);
+    self.rawStyle->setTransitionOptions(transitionOptions);
+}
+
+- (BOOL)enablePlacementTransitions
+{
+    mbgl::style::TransitionOptions transitionOptions = self.rawStyle->getTransitionOptions();
+    return transitionOptions.enablePlacementTransitions;
+}
+
 #pragma mark Style light
 
 - (void)setLight:(MGLLight *)light

--- a/platform/darwin/test/MGLStyleTests.mm
+++ b/platform/darwin/test/MGLStyleTests.mm
@@ -470,4 +470,24 @@
     }
 }
 
+#pragma mark Transition tests
+
+- (void)testTransition
+{
+    MGLTransition transitionTest = MGLTransitionMake(5, 4);
+    
+    self.style.transition = transitionTest;
+    
+    XCTAssert(self.style.transition.delay == transitionTest.delay);
+    XCTAssert(self.style.transition.duration == transitionTest.duration);
+}
+
+- (void)testEnablePlacementTransition
+{
+    XCTAssertTrue(self.style.enablePlacementTransitions, @"The default value for enabling placement transitions should be YES.");
+    
+    self.style.enablePlacementTransitions = NO;
+    XCTAssertFalse(self.style.enablePlacementTransitions, @"Enabling placement transitions should be NO.");
+}
+
 @end

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -17,6 +17,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Added support for setting `MGLCollisionBehaviorPre4_0` in `NSUserDefaults`. ([#13426](https://github.com/mapbox/mapbox-gl-native/pull/13426))
 * `-[MGLStyle localizeLabelsIntoLocale:]` and `-[NSExpression(MGLAdditions) mgl_expressionLocalizedIntoLocale:]` can automatically localize styles that use version 8 of the Mapbox Streets source. ([#13481](https://github.com/mapbox/mapbox-gl-native/pull/13481))
 * Fixed symbol flickering during instantaneous transitions. ([#13535](https://github.com/mapbox/mapbox-gl-native/pull/13535))
+* Added an `MGLStyle.enablePlacementTransitions` property to control how long it takes for collided labels to fade out. ([#13565](https://github.com/mapbox/mapbox-gl-native/pull/13565))
 
 ### Map snapshots
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Added support for setting `MGLCollisionBehaviorPre4_0` in `NSUserDefaults`. ([#13426](https://github.com/mapbox/mapbox-gl-native/pull/13426))
 * Added support for automatic localization of version 8 of the Mapbox Streets source. ([#13481](https://github.com/mapbox/mapbox-gl-native/pull/13481))
 * Fixed symbol flickering during instantaneous transitions. ([#13535](https://github.com/mapbox/mapbox-gl-native/pull/13535))
+* Added an `MGLStyle.enablePlacementTransitions` property to control how long it takes for collided labels to fade out. ([#13565](https://github.com/mapbox/mapbox-gl-native/pull/13565))
 
 ### Other changes
 


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/13408 and https://github.com/mapbox/mapbox-gl-native/pull/13035