### PR TITLE
[ios] Update release notes template for correct Cocoapods/Carthage links

### DIFF
--- a/platform/ios/scripts/release-notes-github.md.ejs
+++ b/platform/ios/scripts/release-notes-github.md.ejs
@@ -3,7 +3,7 @@
 <%-CHANGELOG-%>
 
 <% if (isPrerelease) { %>
-To install this pre-release via a dependency manager, see our [CocoaPods](https://github.com/mapbox/mapbox-gl-native/blob/<%-CURRENTVERSION%>/platform/ios/INSTALL.md#CocoaPods) or [Carthage](https://github.com/mapbox/mapbox-gl-native/blob/<%-CURRENTVERSION%>/platform/ios/INSTALL.md#Carthage) instructions.
+To install this pre-release via a dependency manager, see our [CocoaPods](https://github.com/mapbox/mapbox-gl-native/blob/ios-v<%-CURRENTVERSION%>/platform/ios/INSTALL.md#CocoaPods) or [Carthage](https://github.com/mapbox/mapbox-gl-native/blob/ios-v<%-CURRENTVERSION%>/platform/ios/INSTALL.md#Carthage) instructions.
 <% } -%>
 
 Documentation is [available online](https://www.mapbox.com/ios-sdk/api/<%-CURRENTVERSION%>/) or as part of the download.


### PR DESCRIPTION
Fixes the broken Cocoapods/Carthage links in Github release notes.