### PR TITLE
Fixed compass update time not getting updated

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentCompassEngine.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentCompassEngine.java
@@ -127,9 +127,6 @@ class LocationComponentCompassEngine implements CompassEngine, SensorEventListen
     if (event.sensor.getType() == Sensor.TYPE_ROTATION_VECTOR) {
       rotationVectorValue = getRotationVectorFromSensorEvent(event);
       updateOrientation();
-
-      // Update the compassUpdateNextTimestamp
-      compassUpdateNextTimestamp = currentTime + LocationComponentConstants.COMPASS_UPDATE_RATE_MS;
     } else if (event.sensor.getType() == Sensor.TYPE_ORIENTATION) {
       notifyCompassChangeListeners((event.values[0] + 360) % 360);
     } else if (event.sensor.getType() == Sensor.TYPE_ACCELEROMETER) {
@@ -139,6 +136,9 @@ class LocationComponentCompassEngine implements CompassEngine, SensorEventListen
       magneticValues = lowPassFilter(getRotationVectorFromSensorEvent(event), magneticValues);
       updateOrientation();
     }
+
+    // Update the compassUpdateNextTimestamp
+    compassUpdateNextTimestamp = currentTime + LocationComponentConstants.COMPASS_UPDATE_RATE_MS;
   }
 
   @Override


### PR DESCRIPTION
`compassUpdateNextTimestamp` was only getting updated for `TYPE_ROTATION_VECTOR` sensor. Because of this, compass readings from all other sensors are processed at very fast rate (we saw close to 10 times per second).