### PR TITLE
Remove style load test from instrumented unit tests

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/NativeMapViewTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/NativeMapViewTest.kt
@@ -179,24 +179,6 @@ class NativeMapViewTest {
 
     @Test
     @UiThreadTest
-    fun testSetStyleUrl() {
-        val expected = Style.DARK
-        nativeMapView.styleUrl = expected
-        val actual = nativeMapView.styleUrl
-        assertEquals("Style URL should match", expected, actual)
-    }
-
-    @Test
-    @UiThreadTest
-    fun testSetStyleJson() {
-        val expected = "{}"
-        nativeMapView.styleJson = expected
-        val actual = nativeMapView.styleJson
-        assertEquals("Style JSON should match", expected, actual)
-    }
-
-    @Test
-    @UiThreadTest
     fun testSetContentPadding() {
         val expected = floatArrayOf(1.0f, 2.0f, 3.0f, 4.0f)
         nativeMapView.contentPadding = expected


### PR DESCRIPTION
Closes #13554, we aren't destroying the NativeMapView as part of the tests, this patches things up for now by not executing any tests that would involve loading a style. Long term I'm looking into a different setup for these kind of tests.