### PR TITLE
Register compass sensor listener only if necessary

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/CompassEngine.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/CompassEngine.java
@@ -55,11 +55,17 @@ public interface CompassEngine {
 
   /**
    * Lifecycle method that can be used for adding or releasing resources.
+   *
+   * @deprecated Use {@link #addCompassListener(CompassListener)}
    */
+  @Deprecated
   void onStart();
 
   /**
    * Lifecycle method that can be used for adding or releasing resources.
+   *
+   * @deprecated Use {@link #removeCompassListener(CompassListener)}
    */
+  @Deprecated
   void onStop();
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/CompassListener.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/CompassListener.java
@@ -7,7 +7,7 @@ public interface CompassListener {
 
   /**
    * Callback's invoked when a new compass update occurs. You can listen into the compass updates
-   * using {@link LocationComponent#addCompassListener(CompassListener)} and implementing these
+   * using {@link CompassEngine#addCompassListener(CompassListener)} and implementing these
    * callbacks. Note that this interface is also used internally to to update the UI chevron/arrow.
    *
    * @param userHeading the new compass heading

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationCameraController.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationCameraController.java
@@ -7,6 +7,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 import android.view.MotionEvent;
+
 import com.mapbox.android.gestures.AndroidGesturesManager;
 import com.mapbox.android.gestures.MoveGestureDetector;
 import com.mapbox.android.gestures.RotateGestureDetector;
@@ -244,6 +245,11 @@ final class LocationCameraController implements MapboxAnimator.OnCameraAnimation
         moveGestureDetector.setMoveThreshold(0f);
       }
     }
+  }
+
+  boolean isConsumingCompass() {
+    return cameraMode == CameraMode.TRACKING_COMPASS
+      || cameraMode == CameraMode.NONE_COMPASS;
   }
 
   private boolean isLocationTracking() {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationLayerController.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationLayerController.java
@@ -11,8 +11,8 @@ import com.google.gson.JsonObject;
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.location.modes.RenderMode;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.layers.Layer;
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
@@ -194,6 +194,10 @@ final class LocationLayerController implements MapboxAnimator.OnLayerAnimationsV
 
   boolean isHidden() {
     return isHidden;
+  }
+
+  boolean isConsumingCompass() {
+    return renderMode == RenderMode.COMPASS;
   }
 
   private void setLayerVisibility(@NonNull String layerId, boolean visible) {

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/CompassEngineTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/CompassEngineTest.java
@@ -1,6 +1,7 @@
 package com.mapbox.mapboxsdk.location;
 
 import android.hardware.Sensor;
+import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.view.WindowManager;
 
@@ -10,7 +11,10 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static com.mapbox.mapboxsdk.location.LocationComponentCompassEngine.SENSOR_DELAY_MICROS;
 import static junit.framework.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -27,8 +31,15 @@ public class CompassEngineTest {
   @Mock
   private SensorManager sensorManager;
 
+  @Mock
+  private Sensor compassSensor;
+
+  @Mock
+  private CompassListener compassListener;
+
   @Before
   public void setUp() throws Exception {
+    when(sensorManager.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR)).thenReturn(compassSensor);
     compassEngine = new LocationComponentCompassEngine(windowManager, sensorManager);
   }
 
@@ -60,5 +71,19 @@ public class CompassEngineTest {
     new LocationComponentCompassEngine(windowManager, sensorManager);
 
     verify(sensorManager, times(1)).getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD);
+  }
+
+  @Test
+  public void listener_registerOnAdd() {
+    compassEngine.addCompassListener(compassListener);
+    verify(sensorManager)
+      .registerListener(any(SensorEventListener.class), eq(compassSensor), eq(SENSOR_DELAY_MICROS));
+  }
+
+  @Test
+  public void listener_unregisterOnRemove() {
+    compassEngine.addCompassListener(compassListener);
+    compassEngine.removeCompassListener(compassListener);
+    verify(sensorManager).unregisterListener(any(SensorEventListener.class), eq(compassSensor));
   }
 }


### PR DESCRIPTION
Register compass sensor listener only if provided data is consumed by the location layer or location camera. The idea here is to remove the overhead of creating new compass animators when they are ultimately ignored.

/cc @BharathMG 