### PR TITLE
Option to disable smooth animation of compass and accuracy values

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinator.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinator.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.location;
 
 import android.animation.Animator;
-import android.animation.AnimatorSet;
 import android.location.Location;
 import android.os.SystemClock;
 import android.support.annotation.NonNull;
@@ -44,6 +43,13 @@ final class LocationAnimatorCoordinator {
   private float previousCompassBearing = -1;
   private long locationUpdateTimestamp = -1;
   private float durationMultiplier;
+  private final MapboxAnimatorSetProvider animatorSetProvider;
+  private boolean compassAnimationEnabled;
+  private boolean accuracyAnimationEnabled;
+
+  LocationAnimatorCoordinator(@NonNull MapboxAnimatorSetProvider animatorSetProvider) {
+    this.animatorSetProvider = animatorSetProvider;
+  }
 
   void addLayerListener(MapboxAnimator.OnLayerAnimationsValuesChangeListener listener) {
     layerListeners.add(listener);
@@ -97,7 +103,7 @@ final class LocationAnimatorCoordinator {
     float previousCameraBearing = (float) currentCameraPosition.bearing;
 
     updateCompassAnimators(targetCompassBearing, previousLayerBearing, previousCameraBearing);
-    playCompassAnimators(COMPASS_UPDATE_RATE_MS);
+    playCompassAnimators(compassAnimationEnabled ? COMPASS_UPDATE_RATE_MS : 0);
 
     previousCompassBearing = targetCompassBearing;
   }
@@ -109,7 +115,7 @@ final class LocationAnimatorCoordinator {
 
     float previousAccuracyRadius = getPreviousAccuracyRadius();
     updateAccuracyAnimators(targetAccuracyRadius, previousAccuracyRadius);
-    playAccuracyAnimator(noAnimation ? 0 : ACCURACY_RADIUS_ANIMATION_DURATION);
+    playAccuracyAnimator(noAnimation || !accuracyAnimationEnabled ? 0 : ACCURACY_RADIUS_ANIMATION_DURATION);
 
     this.previousAccuracyRadius = targetAccuracyRadius;
   }
@@ -249,27 +255,20 @@ final class LocationAnimatorCoordinator {
     locationAnimators.add(animatorArray.get(ANIMATOR_LAYER_GPS_BEARING));
     locationAnimators.add(animatorArray.get(ANIMATOR_CAMERA_LATLNG));
     locationAnimators.add(animatorArray.get(ANIMATOR_CAMERA_GPS_BEARING));
-    AnimatorSet locationAnimatorSet = new AnimatorSet();
-    locationAnimatorSet.playTogether(locationAnimators);
-    locationAnimatorSet.setInterpolator(new LinearInterpolator());
-    locationAnimatorSet.setDuration(duration);
-    locationAnimatorSet.start();
+    animatorSetProvider.startAnimation(locationAnimators, new LinearInterpolator(), duration);
   }
 
   private void playCompassAnimators(long duration) {
     List<Animator> compassAnimators = new ArrayList<>();
     compassAnimators.add(animatorArray.get(ANIMATOR_LAYER_COMPASS_BEARING));
     compassAnimators.add(animatorArray.get(ANIMATOR_CAMERA_COMPASS_BEARING));
-    AnimatorSet compassAnimatorSet = new AnimatorSet();
-    compassAnimatorSet.playTogether(compassAnimators);
-    compassAnimatorSet.setDuration(duration);
-    compassAnimatorSet.start();
+    animatorSetProvider.startAnimation(compassAnimators, new LinearInterpolator(), duration);
   }
 
   private void playAccuracyAnimator(long duration) {
-    MapboxAnimator animator = animatorArray.get(ANIMATOR_LAYER_ACCURACY);
-    animator.setDuration(duration);
-    animator.start();
+    List<Animator> accuracyAnimators = new ArrayList<>();
+    accuracyAnimators.add(animatorArray.get(ANIMATOR_LAYER_ACCURACY));
+    animatorSetProvider.startAnimation(accuracyAnimators, new LinearInterpolator(), duration);
   }
 
   private void playZoomAnimator(long duration) {
@@ -288,11 +287,7 @@ final class LocationAnimatorCoordinator {
     List<Animator> locationAnimators = new ArrayList<>();
     locationAnimators.add(animatorArray.get(ANIMATOR_CAMERA_LATLNG));
     locationAnimators.add(animatorArray.get(ANIMATOR_CAMERA_GPS_BEARING));
-    AnimatorSet locationAnimatorSet = new AnimatorSet();
-    locationAnimatorSet.playTogether(locationAnimators);
-    locationAnimatorSet.setInterpolator(new FastOutSlowInInterpolator());
-    locationAnimatorSet.setDuration(duration);
-    locationAnimatorSet.start();
+    animatorSetProvider.startAnimation(locationAnimators, new FastOutSlowInInterpolator(), duration);
   }
 
   void resetAllCameraAnimations(@NonNull CameraPosition currentCameraPosition, boolean isGpsNorth) {
@@ -380,5 +375,13 @@ final class LocationAnimatorCoordinator {
 
   void setTrackingAnimationDurationMultiplier(float trackingAnimationDurationMultiplier) {
     this.durationMultiplier = trackingAnimationDurationMultiplier;
+  }
+
+  void setCompassAnimationEnabled(boolean compassAnimationEnabled) {
+    this.compassAnimationEnabled = compassAnimationEnabled;
+  }
+
+  void setAccuracyAnimationEnabled(boolean accuracyAnimationEnabled) {
+    this.accuracyAnimationEnabled = accuracyAnimationEnabled;
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
@@ -542,6 +542,8 @@ public final class LocationComponent {
       staleStateManager.setEnabled(options.enableStaleState());
       staleStateManager.setDelayTime(options.staleStateTimeout());
       locationAnimatorCoordinator.setTrackingAnimationDurationMultiplier(options.trackingAnimationDurationMultiplier());
+      locationAnimatorCoordinator.setCompassAnimationEnabled(options.compassAnimationEnabled());
+      locationAnimatorCoordinator.setAccuracyAnimationEnabled(options.accuracyAnimationEnabled());
       updateMapWithOptions(options);
     }
   }
@@ -993,7 +995,7 @@ public final class LocationComponent {
     locationCameraController = new LocationCameraController(
       context, mapboxMap, cameraTrackingChangedListener, options, onCameraMoveInvalidateListener);
 
-    locationAnimatorCoordinator = new LocationAnimatorCoordinator();
+    locationAnimatorCoordinator = new LocationAnimatorCoordinator(MapboxAnimatorSetProvider.getInstance());
     locationAnimatorCoordinator.addLayerListener(locationLayerController);
     locationAnimatorCoordinator.addCameraListener(locationCameraController);
     locationAnimatorCoordinator.setTrackingAnimationDurationMultiplier(options

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentConstants.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentConstants.java
@@ -6,7 +6,7 @@ package com.mapbox.mapboxsdk.location;
 final class LocationComponentConstants {
 
   // Controls the compass update rate in milliseconds
-  static final int COMPASS_UPDATE_RATE_MS = 500;
+  static final long COMPASS_UPDATE_RATE_MS = 500;
 
   // Sets the transition animation duration when switching camera modes.
   static final long TRANSITION_ANIMATION_DURATION_MS = 750;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentOptions.java
@@ -110,6 +110,8 @@ public class LocationComponentOptions implements Parcelable {
   private float trackingMultiFingerMoveThreshold;
   private String layerBelow;
   private float trackingAnimationDurationMultiplier;
+  private boolean compassAnimationEnabled;
+  private boolean accuracyAnimationEnabled;
 
   public LocationComponentOptions(
     float accuracyAlpha,
@@ -141,7 +143,9 @@ public class LocationComponentOptions implements Parcelable {
     float trackingInitialMoveThreshold,
     float trackingMultiFingerMoveThreshold,
     String layerBelow,
-    float trackingAnimationDurationMultiplier) {
+    float trackingAnimationDurationMultiplier,
+    boolean compassAnimationEnabled,
+    boolean accuracyAnimationEnabled) {
     this.accuracyAlpha = accuracyAlpha;
     this.accuracyColor = accuracyColor;
     this.backgroundDrawableStale = backgroundDrawableStale;
@@ -175,6 +179,8 @@ public class LocationComponentOptions implements Parcelable {
     this.trackingMultiFingerMoveThreshold = trackingMultiFingerMoveThreshold;
     this.layerBelow = layerBelow;
     this.trackingAnimationDurationMultiplier = trackingAnimationDurationMultiplier;
+    this.compassAnimationEnabled = compassAnimationEnabled;
+    this.accuracyAnimationEnabled = accuracyAnimationEnabled;
   }
 
   /**
@@ -281,6 +287,14 @@ public class LocationComponentOptions implements Parcelable {
     );
     builder.trackingAnimationDurationMultiplier(trackingAnimationDurationMultiplier);
 
+    builder.compassAnimationEnabled = typedArray.getBoolean(
+      R.styleable.mapbox_LocationComponent_mapbox_compassAnimationEnabled, true
+    );
+
+    builder.accuracyAnimationEnabled = typedArray.getBoolean(
+      R.styleable.mapbox_LocationComponent_mapbox_accuracyAnimationEnabled, true
+    );
+
     typedArray.recycle();
 
     return builder.build();
@@ -347,7 +361,7 @@ public class LocationComponentOptions implements Parcelable {
 
   /**
    * String image name, identical to one used in
-   * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+   * the first parameter of {@link com.mapbox.mapboxsdk.maps.Style.Builder#addImage(String, Bitmap)}, the
    * component, will use this image in place of the provided or default mapbox_foregroundDrawableStale.
    * <p>
    * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
@@ -374,7 +388,7 @@ public class LocationComponentOptions implements Parcelable {
 
   /**
    * String image name, identical to one used in
-   * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+   * the first parameter of {@link com.mapbox.mapboxsdk.maps.Style.Builder#addImage(String, Bitmap)}, the
    * component, will used this image in place of the provided or default mapbox_foregroundDrawableStale.
    * <p>
    * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
@@ -401,7 +415,7 @@ public class LocationComponentOptions implements Parcelable {
 
   /**
    * String image name, identical to one used in
-   * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+   * the first parameter of {@link com.mapbox.mapboxsdk.maps.Style.Builder#addImage(String, Bitmap)}, the
    * component, will used this image in place of the provided or default mapbox_gpsDrawable.
    * <p>
    * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
@@ -428,7 +442,7 @@ public class LocationComponentOptions implements Parcelable {
 
   /**
    * String image name, identical to one used in
-   * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+   * the first parameter of {@link com.mapbox.mapboxsdk.maps.Style.Builder#addImage(String, Bitmap)}, the
    * component, will used this image in place of the provided or default mapbox_foregroundDrawable.
    * <p>
    * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
@@ -455,7 +469,7 @@ public class LocationComponentOptions implements Parcelable {
 
   /**
    * String image name, identical to one used in
-   * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+   * the first parameter of {@link com.mapbox.mapboxsdk.maps.Style.Builder#addImage(String, Bitmap)}, the
    * component, will used this image in place of the provided or default mapbox_backgroundDrawable.
    * <p>
    * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
@@ -482,7 +496,7 @@ public class LocationComponentOptions implements Parcelable {
 
   /**
    * String image name, identical to one used in
-   * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+   * the first parameter of {@link com.mapbox.mapboxsdk.maps.Style.Builder#addImage(String, Bitmap)}, the
    * component, will used this image in place of the provided or default mapbox_bearingDrawable.
    * <p>
    * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
@@ -684,6 +698,25 @@ public class LocationComponentOptions implements Parcelable {
     return trackingAnimationDurationMultiplier;
   }
 
+  /**
+   * Enable or disable smooth animation of compass values for {@link com.mapbox.mapboxsdk.location.modes.CameraMode}
+   * and {@link com.mapbox.mapboxsdk.location.modes.RenderMode}.
+   *
+   * @return whether smooth compass animation is enabled
+   */
+  public boolean compassAnimationEnabled() {
+    return compassAnimationEnabled;
+  }
+
+  /**
+   * Enable or disable smooth animation of the accuracy circle around the user's position.
+   *
+   * @return whether smooth animation of the accuracy circle is enabled
+   */
+  public boolean accuracyAnimationEnabled() {
+    return accuracyAnimationEnabled;
+  }
+
   @NonNull
   @Override
   public String toString() {
@@ -836,6 +869,10 @@ public class LocationComponentOptions implements Parcelable {
     h$ ^= Float.floatToIntBits(trackingMultiFingerMoveThreshold);
     h$ *= 1000003;
     h$ ^= Float.floatToIntBits(trackingAnimationDurationMultiplier);
+    h$ *= 1000003;
+    h$ ^= compassAnimationEnabled ? 1231 : 1237;
+    h$ *= 1000003;
+    h$ ^= accuracyAnimationEnabled ? 1231 : 1237;
     return h$;
   }
 
@@ -873,7 +910,9 @@ public class LocationComponentOptions implements Parcelable {
           in.readFloat(),
           in.readFloat(),
           in.readString(),
-          in.readFloat()
+          in.readFloat(),
+          in.readInt() == 1,
+          in.readInt() == 1
         );
       }
 
@@ -970,6 +1009,8 @@ public class LocationComponentOptions implements Parcelable {
     dest.writeFloat(trackingMultiFingerMoveThreshold());
     dest.writeString(layerBelow());
     dest.writeFloat(trackingAnimationDurationMultiplier);
+    dest.writeInt(compassAnimationEnabled() ? 1 : 0);
+    dest.writeInt(accuracyAnimationEnabled() ? 1 : 0);
   }
 
   @Override
@@ -1045,6 +1086,8 @@ public class LocationComponentOptions implements Parcelable {
     private Float trackingMultiFingerMoveThreshold;
     private String layerBelow;
     private Float trackingAnimationDurationMultiplier;
+    private Boolean compassAnimationEnabled;
+    private Boolean accuracyAnimationEnabled;
 
     Builder() {
     }
@@ -1080,6 +1123,8 @@ public class LocationComponentOptions implements Parcelable {
       this.trackingMultiFingerMoveThreshold = source.trackingMultiFingerMoveThreshold();
       this.layerBelow = source.layerBelow();
       this.trackingAnimationDurationMultiplier = source.trackingAnimationDurationMultiplier();
+      this.compassAnimationEnabled = source.compassAnimationEnabled();
+      this.accuracyAnimationEnabled = source.accuracyAnimationEnabled();
     }
 
     /**
@@ -1124,7 +1169,7 @@ public class LocationComponentOptions implements Parcelable {
 
     /**
      * Given a String image name, identical to one used in
-     * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+     * the first parameter of {@link com.mapbox.mapboxsdk.maps.Style.Builder#addImage(String, Bitmap)}, the
      * component, will used this image in place of the provided or default mapbox_backgroundDrawableStale.
      * <p>
      * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
@@ -1155,7 +1200,7 @@ public class LocationComponentOptions implements Parcelable {
 
     /**
      * Given a String image name, identical to one used in
-     * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+     * the first parameter of {@link com.mapbox.mapboxsdk.maps.Style.Builder#addImage(String, Bitmap)}, the
      * component, will used this image in place of the provided or default mapbox_foregroundDrawableStale.
      * <p>
      * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
@@ -1186,7 +1231,7 @@ public class LocationComponentOptions implements Parcelable {
 
     /**
      * Given a String image name, identical to one used in
-     * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+     * the first parameter of {@link com.mapbox.mapboxsdk.maps.Style.Builder#addImage(String, Bitmap)}, the
      * component, will used this image in place of the provided or default mapbox_gpsDrawable.
      * <p>
      * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
@@ -1217,7 +1262,7 @@ public class LocationComponentOptions implements Parcelable {
 
     /**
      * Given a String image name, identical to one used in
-     * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+     * the first parameter of {@link com.mapbox.mapboxsdk.maps.Style.Builder#addImage(String, Bitmap)}, the
      * component, will used this image in place of the provided or default mapbox_foregroundDrawable.
      * <p>
      * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
@@ -1248,7 +1293,7 @@ public class LocationComponentOptions implements Parcelable {
 
     /**
      * Given a String image name, identical to one used in
-     * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+     * the first parameter of {@link com.mapbox.mapboxsdk.maps.Style.Builder#addImage(String, Bitmap)}, the
      * component, will used this image in place of the provided or default mapbox_backgroundDrawable.
      * <p>
      * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
@@ -1279,7 +1324,7 @@ public class LocationComponentOptions implements Parcelable {
 
     /**
      * Given a String image name, identical to one used in
-     * the first parameter of {@link com.mapbox.mapboxsdk.maps.MapboxMap#addImage(String, Bitmap)}, the
+     * the first parameter of {@link com.mapbox.mapboxsdk.maps.Style.Builder#addImage(String, Bitmap)}, the
      * component, will used this image in place of the provided or default mapbox_bearingDrawable.
      * <p>
      * A maki-icon name (example: "circle-15") may also be provided.  These are images that can be loaded
@@ -1524,6 +1569,27 @@ public class LocationComponentOptions implements Parcelable {
       return this;
     }
 
+    /**
+     * Enable or disable smooth animation of compass values for {@link com.mapbox.mapboxsdk.location.modes.CameraMode}
+     * and {@link com.mapbox.mapboxsdk.location.modes.RenderMode}.
+     *
+     * @return whether smooth compass animation is enabled
+     */
+    public LocationComponentOptions.Builder compassAnimationEnabled(Boolean compassAnimationEnabled) {
+      this.compassAnimationEnabled = compassAnimationEnabled;
+      return this;
+    }
+
+    /**
+     * Enable or disable smooth animation of the accuracy circle around the user's position.
+     *
+     * @return whether smooth animation of the accuracy circle is enabled
+     */
+    public Builder accuracyAnimationEnabled(Boolean accuracyAnimationEnabled) {
+      this.accuracyAnimationEnabled = accuracyAnimationEnabled;
+      return this;
+    }
+
     @Nullable
     LocationComponentOptions autoBuild() {
       String missing = "";
@@ -1614,7 +1680,9 @@ public class LocationComponentOptions implements Parcelable {
         this.trackingInitialMoveThreshold,
         this.trackingMultiFingerMoveThreshold,
         this.layerBelow,
-        this.trackingAnimationDurationMultiplier);
+        this.trackingAnimationDurationMultiplier,
+        this.compassAnimationEnabled,
+        this.accuracyAnimationEnabled);
     }
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxAnimatorSetProvider.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxAnimatorSetProvider.java
@@ -1,0 +1,32 @@
+package com.mapbox.mapboxsdk.location;
+
+import android.animation.Animator;
+import android.animation.AnimatorSet;
+import android.support.annotation.NonNull;
+import android.view.animation.Interpolator;
+
+import java.util.List;
+
+class MapboxAnimatorSetProvider {
+  private static MapboxAnimatorSetProvider instance;
+
+  private MapboxAnimatorSetProvider() {
+    // private constructor
+  }
+
+  static MapboxAnimatorSetProvider getInstance() {
+    if (instance == null) {
+      instance = new MapboxAnimatorSetProvider();
+    }
+    return instance;
+  }
+
+  void startAnimation(@NonNull List<Animator> animators, @NonNull Interpolator interpolator,
+                      long duration) {
+    AnimatorSet locationAnimatorSet = new AnimatorSet();
+    locationAnimatorSet.playTogether(animators);
+    locationAnimatorSet.setInterpolator(interpolator);
+    locationAnimatorSet.setDuration(duration);
+    locationAnimatorSet.start();
+  }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
@@ -143,4 +143,10 @@
 
     <!-- Animation duration multiplier -->
     <public name="mapbox_trackingAnimationDurationMultiplier" format="float" type="attr" />
+
+    <!-- Compass animation -->
+    <public name="mapbox_compassAnimationEnabled" format="boolean" type="attr" />
+
+    <!-- Accuracy animation-->
+    <public name="mapbox_accuracyAnimationEnabled" format="boolean" type="attr" />
 </resources>

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/attrs.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/attrs.xml
@@ -169,5 +169,11 @@
         <!-- Animation duration multiplier -->
         <attr name="mapbox_trackingAnimationDurationMultiplier" format="float" />
 
+        <!-- Compass animation -->
+        <attr name="mapbox_compassAnimationEnabled" format="boolean" />
+
+        <!-- Accuracy animation-->
+        <attr name="mapbox_accuracyAnimationEnabled" format="boolean" />
+
     </declare-styleable>
 </resources>

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinatorTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinatorTest.kt
@@ -1,11 +1,16 @@
 package com.mapbox.mapboxsdk.location
 
+import android.animation.Animator
 import android.location.Location
+import android.view.animation.LinearInterpolator
 import com.mapbox.mapboxsdk.camera.CameraPosition
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.location.LocationComponentConstants.DEFAULT_TRACKING_TILT_ANIM_DURATION
 import com.mapbox.mapboxsdk.location.LocationComponentConstants.DEFAULT_TRACKING_ZOOM_ANIM_DURATION
 import com.mapbox.mapboxsdk.location.MapboxAnimator.*
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import junit.framework.Assert.assertEquals
 import junit.framework.Assert.assertTrue
 import org.junit.Before
@@ -20,9 +25,12 @@ class LocationAnimatorCoordinatorTest {
   private lateinit var locationAnimatorCoordinator: LocationAnimatorCoordinator
   private val cameraPosition: CameraPosition = CameraPosition.DEFAULT
 
+  private val animatorSetProvider: MapboxAnimatorSetProvider = mockk()
+
   @Before
   fun setUp() {
-    locationAnimatorCoordinator = LocationAnimatorCoordinator()
+    locationAnimatorCoordinator = LocationAnimatorCoordinator(animatorSetProvider)
+    every { animatorSetProvider.startAnimation(any(), any(), any()) } answers {}
   }
 
   @Test
@@ -125,9 +133,6 @@ class LocationAnimatorCoordinatorTest {
 
     val layerAccuracy = locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_ACCURACY]?.target as Float
     assertEquals(layerAccuracy, accuracy)
-
-    val animationDuration = locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_ACCURACY]?.duration as Long
-    assertEquals(LocationComponentConstants.ACCURACY_RADIUS_ANIMATION_DURATION, animationDuration)
   }
 
   @Test
@@ -144,9 +149,6 @@ class LocationAnimatorCoordinatorTest {
 
     val layerAccuracy = locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_ACCURACY]?.target as Float
     assertEquals(layerAccuracy, accuracy)
-
-    val animationDuration = locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_ACCURACY]?.duration as Long
-    assertEquals(0L, animationDuration)
   }
 
   @Test
@@ -280,5 +282,51 @@ class LocationAnimatorCoordinatorTest {
     locationAnimatorCoordinator.removeCameraListener(cameraListener)
 
     assertTrue(locationAnimatorCoordinator.cameraListeners.isEmpty())
+  }
+
+  @Test
+  fun feedNewCompassBearing_withAnimation() {
+    locationAnimatorCoordinator.setCompassAnimationEnabled(true)
+    locationAnimatorCoordinator.feedNewCompassBearing(77f, cameraPosition)
+
+    val animators = mutableListOf<Animator>(
+      locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_COMPASS_BEARING],
+      locationAnimatorCoordinator.animatorArray[ANIMATOR_CAMERA_COMPASS_BEARING])
+
+    verify(exactly = 1) { animatorSetProvider.startAnimation(eq(animators), ofType(LinearInterpolator::class), eq(LocationComponentConstants.COMPASS_UPDATE_RATE_MS)) }
+  }
+
+  @Test
+  fun feedNewCompassBearing_withoutAnimation() {
+    locationAnimatorCoordinator.setCompassAnimationEnabled(false)
+    locationAnimatorCoordinator.feedNewCompassBearing(77f, cameraPosition)
+
+    val animators = mutableListOf<Animator>(
+      locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_COMPASS_BEARING],
+      locationAnimatorCoordinator.animatorArray[ANIMATOR_CAMERA_COMPASS_BEARING])
+
+    verify(exactly = 1) { animatorSetProvider.startAnimation(eq(animators), ofType(LinearInterpolator::class), eq(0)) }
+  }
+
+  @Test
+  fun feedNewAccuracy_withAnimation() {
+    locationAnimatorCoordinator.setAccuracyAnimationEnabled(true)
+    locationAnimatorCoordinator.feedNewAccuracyRadius(150f, false)
+
+    val animators = mutableListOf<Animator>(
+      locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_ACCURACY])
+
+    verify(exactly = 1) { animatorSetProvider.startAnimation(eq(animators), ofType(LinearInterpolator::class), eq(LocationComponentConstants.ACCURACY_RADIUS_ANIMATION_DURATION)) }
+  }
+
+  @Test
+  fun feedNewAccuracy_withoutAnimation() {
+    locationAnimatorCoordinator.setAccuracyAnimationEnabled(false)
+    locationAnimatorCoordinator.feedNewAccuracyRadius(150f, false)
+
+    val animators = mutableListOf<Animator>(
+      locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_ACCURACY])
+
+    verify(exactly = 1) { animatorSetProvider.startAnimation(eq(animators), ofType(LinearInterpolator::class), eq(0)) }
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/styles.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/styles.xml
@@ -48,6 +48,8 @@
         <item name="mapbox_accuracyColor">#FF82C6</item>
 
         <item name="mapbox_elevation">0dp</item>
+        <item name="mapbox_compassAnimationEnabled">false</item>
+        <item name="mapbox_accuracyAnimationEnabled">false</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Since smooth animation in the `LocationComponent` can have a significant battery impact this PR adds an option to disable the smooth animation of the compass and accuracy values.

![ezgif com-video-to-gif 28](https://user-images.githubusercontent.com/16925074/49948837-82848b80-fef4-11e8-8164-b12d48816308.gif)

Option to disable locaiton tracking animation is tracked in https://github.com/mapbox/mapbox-gl-native/issues/13225.