### PR TITLE
[core] Split layer type specific code in mbgl::Programs

### DIFF
--- a/src/core-files.json
+++ b/src/core-files.json
@@ -63,6 +63,7 @@
         "src/mbgl/programs/hillshade_program.cpp",
         "src/mbgl/programs/line_program.cpp",
         "src/mbgl/programs/program_parameters.cpp",
+        "src/mbgl/programs/programs.cpp",
         "src/mbgl/programs/raster_program.cpp",
         "src/mbgl/programs/symbol_program.cpp",
         "src/mbgl/renderer/backend_scope.cpp",

--- a/src/mbgl/programs/background_program.hpp
+++ b/src/mbgl/programs/background_program.hpp
@@ -80,4 +80,13 @@ public:
 using BackgroundLayoutVertex = BackgroundProgram::LayoutVertex;
 using BackgroundAttributes = BackgroundProgram::Attributes;
 
+class BackgroundLayerPrograms final : public LayerTypePrograms  {
+public:
+    BackgroundLayerPrograms(gl::Context& context, const ProgramParameters& programParameters)
+        : background(context, programParameters),
+          backgroundPattern(context, programParameters) {}
+    BackgroundProgram background;
+    BackgroundPatternProgram backgroundPattern;
+};
+
 } // namespace mbgl

--- a/src/mbgl/programs/circle_program.hpp
+++ b/src/mbgl/programs/circle_program.hpp
@@ -48,4 +48,11 @@ public:
 using CircleLayoutVertex = CircleProgram::LayoutVertex;
 using CircleAttributes = CircleProgram::Attributes;
 
+class CircleLayerPrograms final : public LayerTypePrograms  {
+public:
+    CircleLayerPrograms(gl::Context& context, const ProgramParameters& programParameters)
+        : circle(context, programParameters) {}
+    ProgramMap<CircleProgram> circle;
+};
+
 } // namespace mbgl

--- a/src/mbgl/programs/fill_extrusion_program.hpp
+++ b/src/mbgl/programs/fill_extrusion_program.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/programs/program.hpp>
 #include <mbgl/programs/attributes.hpp>
+#include <mbgl/programs/extrusion_texture_program.hpp>
 #include <mbgl/programs/uniforms.hpp>
 #include <mbgl/shaders/fill_extrusion.hpp>
 #include <mbgl/shaders/fill_extrusion_pattern.hpp>
@@ -111,5 +112,17 @@ public:
 
 using FillExtrusionLayoutVertex = FillExtrusionProgram::LayoutVertex;
 using FillExtrusionAttributes = FillExtrusionProgram::Attributes;
+
+
+class FillExtrusionLayerPrograms final : public LayerTypePrograms {
+public:
+    FillExtrusionLayerPrograms(gl::Context& context, const ProgramParameters& programParameters)
+        : fillExtrusion(context, programParameters),
+          fillExtrusionPattern(context, programParameters),
+          extrusionTexture(context, programParameters) {}
+    ProgramMap<FillExtrusionProgram> fillExtrusion;
+    ProgramMap<FillExtrusionPatternProgram> fillExtrusionPattern;
+    ExtrusionTextureProgram extrusionTexture;
+};
 
 } // namespace mbgl

--- a/src/mbgl/programs/fill_program.hpp
+++ b/src/mbgl/programs/fill_program.hpp
@@ -103,4 +103,17 @@ public:
 using FillLayoutVertex = FillProgram::LayoutVertex;
 using FillAttributes = FillProgram::Attributes;
 
+class FillLayerPrograms final : public LayerTypePrograms {
+public:
+    FillLayerPrograms(gl::Context& context, const ProgramParameters& programParameters)
+        : fill(context, programParameters),
+          fillPattern(context, programParameters),
+          fillOutline(context, programParameters),
+          fillOutlinePattern(context, programParameters) {}
+    ProgramMap<FillProgram> fill;
+    ProgramMap<FillPatternProgram> fillPattern;
+    ProgramMap<FillOutlineProgram> fillOutline;
+    ProgramMap<FillOutlinePatternProgram> fillOutlinePattern;
+};
+
 } // namespace mbgl

--- a/src/mbgl/programs/heatmap_program.hpp
+++ b/src/mbgl/programs/heatmap_program.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/programs/program.hpp>
 #include <mbgl/programs/attributes.hpp>
+#include <mbgl/programs/heatmap_texture_program.hpp>
 #include <mbgl/programs/uniforms.hpp>
 #include <mbgl/shaders/heatmap.hpp>
 #include <mbgl/util/geometry.hpp>
@@ -45,5 +46,14 @@ public:
 
 using HeatmapLayoutVertex = HeatmapProgram::LayoutVertex;
 using HeatmapAttributes = HeatmapProgram::Attributes;
+
+class HeatmapLayerPrograms final : public LayerTypePrograms  {
+public:
+    HeatmapLayerPrograms(gl::Context& context, const ProgramParameters& programParameters) 
+        : heatmap(context, programParameters),
+          heatmapTexture(context, programParameters) {}
+    ProgramMap<HeatmapProgram> heatmap;
+    HeatmapTextureProgram heatmapTexture;
+};
 
 } // namespace mbgl

--- a/src/mbgl/programs/hillshade_program.hpp
+++ b/src/mbgl/programs/hillshade_program.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/programs/program.hpp>
 #include <mbgl/programs/attributes.hpp>
+#include <mbgl/programs/hillshade_prepare_program.hpp>
 #include <mbgl/programs/uniforms.hpp>
 #include <mbgl/shaders/hillshade.hpp>
 #include <mbgl/util/geometry.hpp>
@@ -51,5 +52,14 @@ public:
 
 using HillshadeLayoutVertex = HillshadeProgram::LayoutVertex;
 using HillshadeAttributes = HillshadeProgram::Attributes;
+
+class HillshadeLayerPrograms final : public LayerTypePrograms  {
+public:
+    HillshadeLayerPrograms(gl::Context& context, const ProgramParameters& programParameters)
+        : hillshade(context, programParameters),
+          hillshadePrepare(context, programParameters) {}
+    HillshadeProgram hillshade;
+    HillshadePrepareProgram hillshadePrepare;
+};
 
 } // namespace mbgl

--- a/src/mbgl/programs/line_program.hpp
+++ b/src/mbgl/programs/line_program.hpp
@@ -178,4 +178,17 @@ public:
 using LineLayoutVertex = LineProgram::LayoutVertex;
 using LineAttributes = LineProgram::Attributes;
 
+class LineLayerPrograms final : public LayerTypePrograms {
+public:
+    LineLayerPrograms(gl::Context& context, const ProgramParameters& programParameters)
+        : line(context, programParameters),
+          lineGradient(context, programParameters),
+          lineSDF(context, programParameters),
+          linePattern(context, programParameters) {}
+    ProgramMap<LineProgram> line;
+    ProgramMap<LineGradientProgram> lineGradient;
+    ProgramMap<LineSDFProgram> lineSDF;
+    ProgramMap<LinePatternProgram> linePattern;
+};
+
 } // namespace mbgl

--- a/src/mbgl/programs/program.hpp
+++ b/src/mbgl/programs/program.hpp
@@ -133,4 +133,9 @@ private:
     std::unordered_map<Bitset, Program> programs;
 };
 
+class LayerTypePrograms {
+public:
+    virtual ~LayerTypePrograms() = default;
+};
+
 } // namespace mbgl

--- a/src/mbgl/programs/programs.cpp
+++ b/src/mbgl/programs/programs.cpp
@@ -1,0 +1,87 @@
+#include <mbgl/programs/programs.hpp>
+
+#include <mbgl/programs/background_program.hpp>
+#include <mbgl/programs/circle_program.hpp>
+#include <mbgl/programs/heatmap_program.hpp>
+#include <mbgl/programs/hillshade_program.hpp>
+#include <mbgl/programs/fill_extrusion_program.hpp>
+#include <mbgl/programs/fill_program.hpp>
+#include <mbgl/programs/line_program.hpp>
+#include <mbgl/programs/raster_program.hpp>
+#include <mbgl/programs/symbol_program.hpp>
+
+namespace mbgl {
+
+Programs::Programs(gl::Context& context_, const ProgramParameters& programParameters_)
+    : debug(context_, programParameters_),
+      clippingMask(context_, programParameters_),
+      context(context_),
+      programParameters(std::move(programParameters_)) {
+}
+
+Programs::~Programs() = default;
+
+BackgroundLayerPrograms& Programs::getBackgroundLayerPrograms() noexcept {
+    if (!backgroundPrograms) {
+        backgroundPrograms = std::make_unique<BackgroundLayerPrograms>(context, programParameters);
+    }
+    return static_cast<BackgroundLayerPrograms&>(*backgroundPrograms);   
+}
+
+RasterLayerPrograms& Programs::getRasterLayerPrograms() noexcept {
+    if (!rasterPrograms) {
+        rasterPrograms = std::make_unique<RasterLayerPrograms>(context, programParameters);
+    }
+    return static_cast<RasterLayerPrograms&>(*rasterPrograms);   
+}
+
+HeatmapLayerPrograms& Programs::getHeatmapLayerPrograms() noexcept {
+    if (!heatmapPrograms) {
+        heatmapPrograms = std::make_unique<HeatmapLayerPrograms>(context, programParameters);
+    }
+    return static_cast<HeatmapLayerPrograms&>(*heatmapPrograms);   
+}
+
+HillshadeLayerPrograms& Programs::getHillshadeLayerPrograms() noexcept {
+    if (!hillshadePrograms) {
+        hillshadePrograms = std::make_unique<HillshadeLayerPrograms>(context, programParameters);
+    }
+    return static_cast<HillshadeLayerPrograms&>(*hillshadePrograms);   
+}
+
+FillLayerPrograms& Programs::getFillLayerPrograms() noexcept {
+    if (!fillPrograms) {
+        fillPrograms = std::make_unique<FillLayerPrograms>(context, programParameters);
+    }
+    return static_cast<FillLayerPrograms&>(*fillPrograms);   
+}
+
+FillExtrusionLayerPrograms& Programs::getFillExtrusionLayerPrograms() noexcept {
+    if (!fillExtrusionPrograms) {
+        fillExtrusionPrograms = std::make_unique<FillExtrusionLayerPrograms>(context, programParameters);
+    }
+    return static_cast<FillExtrusionLayerPrograms&>(*fillExtrusionPrograms);   
+}
+
+CircleLayerPrograms& Programs::getCircleLayerPrograms() noexcept {
+    if (!circlePrograms) {
+        circlePrograms = std::make_unique<CircleLayerPrograms>(context, programParameters);
+    }
+    return static_cast<CircleLayerPrograms&>(*circlePrograms);   
+}
+
+LineLayerPrograms& Programs::getLineLayerPrograms() noexcept {
+    if (!linePrograms) {
+        linePrograms = std::make_unique<LineLayerPrograms>(context, programParameters);
+    }
+    return static_cast<LineLayerPrograms&>(*linePrograms);   
+}
+
+SymbolLayerPrograms& Programs::getSymbolLayerPrograms() noexcept {
+    if (!symbolPrograms) {
+        symbolPrograms = std::make_unique<SymbolLayerPrograms>(context, programParameters);
+    }
+    return static_cast<SymbolLayerPrograms&>(*symbolPrograms);   
+}
+
+} // namespace mbgl

--- a/src/mbgl/programs/programs.hpp
+++ b/src/mbgl/programs/programs.hpp
@@ -1,82 +1,54 @@
 #pragma once
 
-#include <mbgl/programs/background_program.hpp>
-#include <mbgl/programs/circle_program.hpp>
 #include <mbgl/programs/clipping_mask_program.hpp>
-#include <mbgl/programs/extrusion_texture_program.hpp>
-#include <mbgl/programs/fill_program.hpp>
-#include <mbgl/programs/fill_extrusion_program.hpp>
-#include <mbgl/programs/heatmap_program.hpp>
-#include <mbgl/programs/heatmap_texture_program.hpp>
-#include <mbgl/programs/hillshade_program.hpp>
-#include <mbgl/programs/hillshade_prepare_program.hpp>
-#include <mbgl/programs/line_program.hpp>
-#include <mbgl/programs/raster_program.hpp>
-#include <mbgl/programs/symbol_program.hpp>
 #include <mbgl/programs/debug_program.hpp>
-#include <mbgl/programs/collision_box_program.hpp>
 #include <mbgl/programs/program_parameters.hpp>
+#include <memory>
 
 namespace mbgl {
 
+class BackgroundLayerPrograms;
+
+class CircleLayerPrograms;
+class RasterLayerPrograms;
+class HeatmapLayerPrograms;
+class HillshadeLayerPrograms;
+class FillLayerPrograms;
+class FillExtrusionLayerPrograms;
+class LineLayerPrograms;
+class SymbolLayerPrograms;
+
 class Programs {
 public:
-    Programs(gl::Context& context, const ProgramParameters& programParameters)
-        : background(context, programParameters),
-          backgroundPattern(context, programParameters),
-          circle(context, programParameters),
-          extrusionTexture(context, programParameters),
-          fill(context, programParameters),
-          fillExtrusion(context, programParameters),
-          fillExtrusionPattern(context, programParameters),
-          fillPattern(context, programParameters),
-          fillOutline(context, programParameters),
-          fillOutlinePattern(context, programParameters),
-          heatmap(context, programParameters),
-          heatmapTexture(context, programParameters),
-          hillshade(context, programParameters),
-          hillshadePrepare(context, programParameters),
-          line(context, programParameters),
-          lineGradient(context, programParameters),
-          lineSDF(context, programParameters),
-          linePattern(context, programParameters),
-          raster(context, programParameters),
-          symbolIcon(context, programParameters),
-          symbolIconSDF(context, programParameters),
-          symbolGlyph(context, programParameters),
-          debug(context, programParameters),
-          collisionBox(context, programParameters),
-          collisionCircle(context, programParameters),
-          clippingMask(context, programParameters) {
-    }
+    Programs(gl::Context&, const ProgramParameters&);
+    ~Programs();
 
-    BackgroundProgram background;
-    BackgroundPatternProgram backgroundPattern;
-    ProgramMap<CircleProgram> circle;
-    ExtrusionTextureProgram extrusionTexture;
-    ProgramMap<FillProgram> fill;
-    ProgramMap<FillExtrusionProgram> fillExtrusion;
-    ProgramMap<FillExtrusionPatternProgram> fillExtrusionPattern;
-    ProgramMap<FillPatternProgram> fillPattern;
-    ProgramMap<FillOutlineProgram> fillOutline;
-    ProgramMap<FillOutlinePatternProgram> fillOutlinePattern;
-    ProgramMap<HeatmapProgram> heatmap;
-    HeatmapTextureProgram heatmapTexture;
-    HillshadeProgram hillshade;
-    HillshadePrepareProgram hillshadePrepare;
-    ProgramMap<LineProgram> line;
-    ProgramMap<LineGradientProgram> lineGradient;
-    ProgramMap<LineSDFProgram> lineSDF;
-    ProgramMap<LinePatternProgram> linePattern;
-    RasterProgram raster;
-    ProgramMap<SymbolIconProgram> symbolIcon;
-    ProgramMap<SymbolSDFIconProgram> symbolIconSDF;
-    ProgramMap<SymbolSDFTextProgram> symbolGlyph;
+    BackgroundLayerPrograms& getBackgroundLayerPrograms() noexcept;
+    RasterLayerPrograms& getRasterLayerPrograms() noexcept;
+    HeatmapLayerPrograms& getHeatmapLayerPrograms() noexcept;
+    CircleLayerPrograms& getCircleLayerPrograms() noexcept;
+    HillshadeLayerPrograms& getHillshadeLayerPrograms() noexcept;
+    FillLayerPrograms& getFillLayerPrograms() noexcept;
+    FillExtrusionLayerPrograms& getFillExtrusionLayerPrograms() noexcept;
+    LineLayerPrograms& getLineLayerPrograms() noexcept;
+    SymbolLayerPrograms& getSymbolLayerPrograms() noexcept;
 
     DebugProgram debug;
-    CollisionBoxProgram collisionBox;
-    CollisionCircleProgram collisionCircle;
     ClippingMaskProgram clippingMask;
+
+private:
+    std::unique_ptr<LayerTypePrograms> backgroundPrograms;
+    std::unique_ptr<LayerTypePrograms> circlePrograms;
+    std::unique_ptr<LayerTypePrograms> rasterPrograms;
+    std::unique_ptr<LayerTypePrograms> heatmapPrograms;
+    std::unique_ptr<LayerTypePrograms> hillshadePrograms;
+    std::unique_ptr<LayerTypePrograms> fillPrograms;
+    std::unique_ptr<LayerTypePrograms> fillExtrusionPrograms;
+    std::unique_ptr<LayerTypePrograms> linePrograms;
+    std::unique_ptr<LayerTypePrograms> symbolPrograms;
+
+    gl::Context& context;
+    ProgramParameters programParameters;
 };
 
 } // namespace mbgl

--- a/src/mbgl/programs/raster_program.hpp
+++ b/src/mbgl/programs/raster_program.hpp
@@ -65,4 +65,11 @@ public:
 using RasterLayoutVertex = RasterProgram::LayoutVertex;
 using RasterAttributes = RasterProgram::Attributes;
 
+class RasterLayerPrograms final : public LayerTypePrograms {
+public:
+    RasterLayerPrograms(gl::Context& context, const ProgramParameters& programParameters)
+        : raster(context, programParameters) {}
+    RasterProgram raster;
+};
+
 } // namespace mbgl

--- a/src/mbgl/programs/symbol_program.hpp
+++ b/src/mbgl/programs/symbol_program.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/util/interpolate.hpp>
 
 #include <mbgl/programs/attributes.hpp>
+#include <mbgl/programs/collision_box_program.hpp>
 #include <mbgl/programs/uniforms.hpp>
 #include <mbgl/programs/segment.hpp>
 #include <mbgl/shaders/symbol_icon.hpp>
@@ -447,5 +448,20 @@ using SymbolSDFTextProgram = SymbolSDFProgram<style::TextPaintProperties>;
 using SymbolLayoutVertex = SymbolLayoutAttributes::Vertex;
 using SymbolIconAttributes = SymbolIconProgram::Attributes;
 using SymbolTextAttributes = SymbolSDFTextProgram::Attributes;
+
+class SymbolLayerPrograms final : public LayerTypePrograms {
+public:
+    SymbolLayerPrograms(gl::Context& context, const ProgramParameters& programParameters)
+        : symbolIcon(context, programParameters),
+          symbolIconSDF(context, programParameters),
+          symbolGlyph(context, programParameters),
+          collisionBox(context, programParameters),
+          collisionCircle(context, programParameters) {}
+    ProgramMap<SymbolIconProgram> symbolIcon;
+    ProgramMap<SymbolSDFIconProgram> symbolIconSDF;
+    ProgramMap<SymbolSDFTextProgram> symbolGlyph;
+    CollisionBoxProgram collisionBox;
+    CollisionCircleProgram collisionCircle;
+};
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -96,7 +96,7 @@ void RenderBackgroundLayer::render(PaintParameters& parameters, RenderSource*) {
 
         for (const auto& tileID : util::tileCover(parameters.state, parameters.state.getIntegerZoom())) {
             draw(
-                parameters.programs.backgroundPattern,
+                parameters.programs.getBackgroundLayerPrograms().backgroundPattern,
                 BackgroundPatternUniforms::values(
                     parameters.matrixForTile(tileID),
                     evaluated.get<BackgroundOpacity>(),
@@ -112,7 +112,7 @@ void RenderBackgroundLayer::render(PaintParameters& parameters, RenderSource*) {
     } else {
         for (const auto& tileID : util::tileCover(parameters.state, parameters.state.getIntegerZoom())) {
             draw(
-                parameters.programs.background,
+                parameters.programs.getBackgroundLayerPrograms().background,
                 BackgroundProgram::UniformValues {
                     uniforms::u_matrix::Value( parameters.matrixForTile(tileID) ),
                     uniforms::u_color::Value( evaluated.get<BackgroundColor>() ),

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -68,7 +68,7 @@ void RenderCircleLayer::render(PaintParameters& parameters, RenderSource*) {
 
         const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
 
-        auto& programInstance = parameters.programs.circle.get(evaluated);
+        auto& programInstance = parameters.programs.getCircleLayerPrograms().circle.get(evaluated);
    
         const auto allUniformValues = programInstance.computeAllUniformValues(
             CircleProgram::UniformValues {

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -126,7 +126,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters, RenderSource*
                 FillExtrusionBucket& bucket = *bucket_;
 
                 draw(
-                    parameters.programs.fillExtrusion.get(evaluated),
+                    parameters.programs.getFillExtrusionLayerPrograms().fillExtrusion.get(evaluated),
                     bucket,
                     FillExtrusionUniforms::values(
                         tile.translatedClipMatrix(evaluated.get<FillExtrusionTranslate>(),
@@ -153,7 +153,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters, RenderSource*
                 FillExtrusionBucket& bucket = *bucket_;
 
                 draw(
-                    parameters.programs.fillExtrusionPattern.get(evaluated),
+                    parameters.programs.getFillExtrusionLayerPrograms().fillExtrusionPattern.get(evaluated),
                     bucket,
                     FillExtrusionPatternUniforms::values(
                         tile.translatedClipMatrix(evaluated.get<FillExtrusionTranslate>(),
@@ -184,7 +184,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters, RenderSource*
         const Properties<>::PossiblyEvaluated properties;
         const ExtrusionTextureProgram::PaintPropertyBinders paintAttributeData{ properties, 0 };
         
-        auto& programInstance = parameters.programs.extrusionTexture;
+        auto& programInstance = parameters.programs.getFillExtrusionLayerPrograms().extrusionTexture;
 
         const auto allUniformValues = programInstance.computeAllUniformValues(
             ExtrusionTextureProgram::UniformValues{

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -133,7 +133,7 @@ void RenderFillLayer::render(PaintParameters& parameters, RenderSource*) {
             // or when it's translucent and we're drawing translucent fragments.
             if ((evaluated.get<FillColor>().constantOr(Color()).a >= 1.0f
               && evaluated.get<FillOpacity>().constantOr(0) >= 1.0f) == (parameters.pass == RenderPass::Opaque)) {
-                draw(parameters.programs.fill,
+                draw(parameters.programs.getFillLayerPrograms().fill,
                      gl::Triangles(),
                      parameters.depthModeForSublayer(1, parameters.pass == RenderPass::Opaque
                         ? gl::DepthMode::ReadWrite
@@ -143,7 +143,7 @@ void RenderFillLayer::render(PaintParameters& parameters, RenderSource*) {
             }
 
             if (evaluated.get<FillAntialias>() && parameters.pass == RenderPass::Translucent) {
-                draw(parameters.programs.fillOutline,
+                draw(parameters.programs.getFillLayerPrograms().fillOutline,
                      gl::Lines{ 2.0f },
                      parameters.depthModeForSublayer(
                          unevaluated.get<FillOutlineColor>().isUndefined() ? 2 : 0,
@@ -219,14 +219,14 @@ void RenderFillLayer::render(PaintParameters& parameters, RenderSource*) {
                 );
             };
 
-            draw(parameters.programs.fillPattern,
+            draw(parameters.programs.getFillLayerPrograms().fillPattern,
                  gl::Triangles(),
                  parameters.depthModeForSublayer(1, gl::DepthMode::ReadWrite),
                  *bucket.triangleIndexBuffer,
                  bucket.triangleSegments);
 
             if (evaluated.get<FillAntialias>() && unevaluated.get<FillOutlineColor>().isUndefined()) {
-                draw(parameters.programs.fillOutlinePattern,
+                draw(parameters.programs.getFillLayerPrograms().fillOutlinePattern,
                      gl::Lines { 2.0f },
                      parameters.depthModeForSublayer(2, gl::DepthMode::ReadOnly),
                      *bucket.lineIndexBuffer,

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -101,7 +101,7 @@ void RenderHeatmapLayer::render(PaintParameters& parameters, RenderSource*) {
 
             const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
 
-            auto& programInstance = parameters.programs.heatmap.get(evaluated);
+            auto& programInstance = parameters.programs.getHeatmapLayerPrograms().heatmap.get(evaluated);
        
             const auto allUniformValues = programInstance.computeAllUniformValues(
                 HeatmapProgram::UniformValues {
@@ -148,7 +148,7 @@ void RenderHeatmapLayer::render(PaintParameters& parameters, RenderSource*) {
         const Properties<>::PossiblyEvaluated properties;
         const HeatmapTextureProgram::PaintPropertyBinders paintAttributeData{ properties, 0 };
 
-        auto& programInstance = parameters.programs.heatmapTexture;
+        auto& programInstance = parameters.programs.getHeatmapLayerPrograms().heatmapTexture;
 
         const auto allUniformValues = programInstance.computeAllUniformValues(
             HeatmapTextureProgram::UniformValues{

--- a/src/mbgl/renderer/layers/render_hillshade_layer.cpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.cpp
@@ -73,7 +73,7 @@ void RenderHillshadeLayer::render(PaintParameters& parameters, RenderSource* src
                      const auto& indexBuffer,
                      const auto& segments,
                      const UnwrappedTileID& id) {
-        auto& programInstance = parameters.programs.hillshade;
+        auto& programInstance = parameters.programs.getHillshadeLayerPrograms().hillshade;
 
         const HillshadeProgram::PaintPropertyBinders paintAttributeData{ evaluated, 0 };
 
@@ -138,7 +138,7 @@ void RenderHillshadeLayer::render(PaintParameters& parameters, RenderSource* src
             const Properties<>::PossiblyEvaluated properties;
             const HillshadePrepareProgram::PaintPropertyBinders paintAttributeData{ properties, 0 };
             
-            auto& programInstance = parameters.programs.hillshadePrepare;
+            auto& programInstance = parameters.programs.getHillshadeLayerPrograms().hillshadePrepare;
 
             const auto allUniformValues = programInstance.computeAllUniformValues(
                 HillshadePrepareProgram::UniformValues {

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -126,7 +126,7 @@ void RenderLineLayer::render(PaintParameters& parameters, RenderSource*) {
 
             parameters.lineAtlas.bind(parameters.context, 0);
 
-            draw(parameters.programs.lineSDF,
+            draw(parameters.programs.getLineLayerPrograms().lineSDF,
                  LineSDFProgram::uniformValues(
                      evaluated,
                      parameters.pixelRatio,
@@ -148,7 +148,7 @@ void RenderLineLayer::render(PaintParameters& parameters, RenderSource*) {
             optional<ImagePosition> posA = geometryTile.getPattern(linePatternValue.from);
             optional<ImagePosition> posB = geometryTile.getPattern(linePatternValue.to);
 
-            draw(parameters.programs.linePattern,
+            draw(parameters.programs.getLineLayerPrograms().linePattern,
                  LinePatternProgram::uniformValues(
                      evaluated,
                      tile,
@@ -165,14 +165,14 @@ void RenderLineLayer::render(PaintParameters& parameters, RenderSource*) {
             }
             parameters.context.bindTexture(*colorRampTexture, 0, gl::TextureFilter::Linear);
 
-            draw(parameters.programs.lineGradient,
+            draw(parameters.programs.getLineLayerPrograms().lineGradient,
                  LineGradientProgram::uniformValues(
                     evaluated,
                     tile,
                     parameters.state,
                     parameters.pixelsToGLUnits), {}, {});
         } else {
-            draw(parameters.programs.line,
+            draw(parameters.programs.getLineLayerPrograms().line,
                  LineProgram::uniformValues(
                      evaluated,
                      tile,

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -83,7 +83,7 @@ void RenderRasterLayer::render(PaintParameters& parameters, RenderSource* source
                      const auto& vertexBuffer,
                      const auto& indexBuffer,
                      const auto& segments) {
-        auto& programInstance = parameters.programs.raster;
+        auto& programInstance = parameters.programs.getRasterLayerPrograms().raster;
 
         const auto allUniformValues = programInstance.computeAllUniformValues(
             RasterProgram::UniformValues {

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -181,7 +181,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
 
             if (bucket.sdfIcons) {
                 if (values.hasHalo) {
-                    draw(parameters.programs.symbolIconSDF,
+                    draw(parameters.programs.getSymbolLayerPrograms().symbolIconSDF,
                          SymbolSDFIconProgram::uniformValues(false, values, texsize, parameters.pixelsToGLUnits, alongLine, tile, parameters.state, parameters.symbolFadeChange, SymbolSDFPart::Halo),
                          bucket.icon,
                          bucket.iconSizeBinder,
@@ -191,7 +191,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
                 }
 
                 if (values.hasFill) {
-                    draw(parameters.programs.symbolIconSDF,
+                    draw(parameters.programs.getSymbolLayerPrograms().symbolIconSDF,
                          SymbolSDFIconProgram::uniformValues(false, values, texsize, parameters.pixelsToGLUnits, alongLine, tile, parameters.state, parameters.symbolFadeChange, SymbolSDFPart::Fill),
                          bucket.icon,
                          bucket.iconSizeBinder,
@@ -200,7 +200,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
                          paintPropertyValues);
                 }
             } else {
-                draw(parameters.programs.symbolIcon,
+                draw(parameters.programs.getSymbolLayerPrograms().symbolIcon,
                      SymbolIconProgram::uniformValues(false, values, texsize, parameters.pixelsToGLUnits, alongLine, tile, parameters.state, parameters.symbolFadeChange),
                      bucket.icon,
                      bucket.iconSizeBinder,
@@ -234,7 +234,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
             const Size texsize = geometryTile.glyphAtlasTexture->size;
 
             if (values.hasHalo) {
-                draw(parameters.programs.symbolGlyph,
+                draw(parameters.programs.getSymbolLayerPrograms().symbolGlyph,
                      SymbolSDFTextProgram::uniformValues(true, values, texsize, parameters.pixelsToGLUnits, alongLine, tile, parameters.state, parameters.symbolFadeChange, SymbolSDFPart::Halo),
                      bucket.text,
                      bucket.textSizeBinder,
@@ -244,7 +244,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
             }
 
             if (values.hasFill) {
-                draw(parameters.programs.symbolGlyph,
+                draw(parameters.programs.getSymbolLayerPrograms().symbolGlyph,
                      SymbolSDFTextProgram::uniformValues(true, values, texsize, parameters.pixelsToGLUnits, alongLine, tile, parameters.state, parameters.symbolFadeChange, SymbolSDFPart::Fill),
                      bucket.text,
                      bucket.textSizeBinder,
@@ -266,7 +266,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
                     parameters.pixelsToGLUnits[1] / (pixelRatio * scale)
                     
                 }};
-            parameters.programs.collisionBox.draw(
+            parameters.programs.getSymbolLayerPrograms().collisionBox.draw(
                 parameters.context,
                 gl::Lines { 1.0f },
                 gl::DepthMode::disabled(),
@@ -301,7 +301,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
                     
                 }};
 
-            parameters.programs.collisionCircle.draw(
+            parameters.programs.getSymbolLayerPrograms().collisionCircle.draw(
                 parameters.context,
                 gl::Triangles(),
                 gl::DepthMode::disabled(),

--- a/src/mbgl/renderer/render_static_data.hpp
+++ b/src/mbgl/renderer/render_static_data.hpp
@@ -2,7 +2,10 @@
 
 #include <mbgl/gl/vertex_buffer.hpp>
 #include <mbgl/gl/index_buffer.hpp>
+#include <mbgl/programs/background_program.hpp>
+#include <mbgl/programs/extrusion_texture_program.hpp>
 #include <mbgl/programs/programs.hpp>
+#include <mbgl/programs/raster_program.hpp>
 #include <mbgl/util/optional.hpp>
 
 #include <string>


### PR DESCRIPTION
Programs code for a certain layer type is encapsulated within
a dedicated `<layer type>Programs` class, inherited from
the generic base `LayerTypePrograms` class.

`mbgl::Programs::get<layer type>Programs()` lazily initializes the
layer type-specific programs code using pointer to the base class,
which allows LTO to remove this code from binaries (if the corresponding
`get<layer type>Programs()` method can never be invoked).

Tagging https://github.com/mapbox/mapbox-gl-native/issues/13276