### PR TITLE
Dismiss the foreground color only when the style is loaded

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -1002,10 +1002,12 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
 
     @Override
     public void onDidFinishRenderingFrame(boolean fully) {
-      renderCount++;
-      if (renderCount == 2) {
-        MapView.this.setForeground(null);
-        removeOnDidFinishRenderingFrameListener(this);
+      if (mapboxMap != null && mapboxMap.getStyle() != null && mapboxMap.getStyle().isFullyLoaded()) {
+        renderCount++;
+        if (renderCount == 3) {
+          MapView.this.setForeground(null);
+          removeOnDidFinishRenderingFrameListener(this);
+        }
       }
     }
 


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/13566.

Brings back the initial implementation where we are waiting for a style to load before dismissing the foreground color. I needed to increase initial frames drawn from 2 to 3 in order to get consistent results.