### PR TITLE
[mac, ios] Enable core-only layers

### DIFF
--- a/platform/android/src/style/layers/layer_manager.hpp
+++ b/platform/android/src/style/layers/layer_manager.hpp
@@ -30,7 +30,7 @@ public:
 private:
     LayerManagerAndroid();
     /**
-     * @brief Enables a layer type for both JSON style an runtime API.
+     * @brief Enables a layer type for both JSON style and runtime API.
      */
     void addLayerType(std::unique_ptr<JavaLayerPeerFactory>); 
     /**

--- a/platform/darwin/src/MGLStyleLayerManager.h
+++ b/platform/darwin/src/MGLStyleLayerManager.h
@@ -20,13 +20,27 @@ public:
 
 private:
     LayerManagerDarwin();
+    /**
+     * Enables a layer type for both JSON style and runtime API.
+     */
     void addLayerType(std::unique_ptr<LayerPeerFactory>);
+    /**
+     * Enables a layer type for JSON style only.
+     *
+     * We might not want to expose runtime API for some layer types
+     * in order to save binary size (the corresponding SDK layer wrappers
+     * should be excluded from the project build).
+     */
+    void addLayerTypeCoreOnly(std::unique_ptr<mbgl::LayerFactory>);
+
+    void registerCoreFactory(LayerFactory*);
     LayerPeerFactory* getPeerFactory(const style::LayerTypeInfo* typeInfo);
     // mbgl::LayerManager overrides.
     LayerFactory* getFactory(const std::string& type) noexcept final;
     LayerFactory* getFactory(const mbgl::style::LayerTypeInfo* info) noexcept final;
 
-    std::vector<std::unique_ptr<LayerPeerFactory>> factories;
+    std::vector<std::unique_ptr<LayerPeerFactory>> peerFactories;
+    std::vector<std::unique_ptr<LayerFactory>> coreFactories;
     std::map<std::string, LayerFactory*> typeToFactory;
 };
     


### PR DESCRIPTION
`LayerManagerDarwin` can add layer types that are enabled only for JSON style.
It allows to exclude the SDK wrappers for these layers from the project and decrease binary size.

tagging #13276