### PR TITLE
Optionally exclude CJK glyphs from offline downloads

### DIFF
--- a/bin/offline.cpp
+++ b/bin/offline.cpp
@@ -101,6 +101,7 @@ int main(int argc, char *argv[]) {
     args::ValueFlag<double> minZoomValue(argumentParser, "number", "Min zoom level", {"minZoom"});
     args::ValueFlag<double> maxZoomValue(argumentParser, "number", "Max zoom level", {"maxZoom"});
     args::ValueFlag<double> pixelRatioValue(argumentParser, "number", "Pixel ratio", {"pixelRatio"});
+    args::ValueFlag<bool> includeIdeographsValue(argumentParser, "boolean", "Include CJK glyphs", {"includeIdeographs"});
 
     try {
         argumentParser.ParseCLI(argc, argv);
@@ -127,6 +128,7 @@ int main(int argc, char *argv[]) {
     const double minZoom = minZoomValue ? args::get(minZoomValue) : 0.0;
     const double maxZoom = maxZoomValue ? args::get(maxZoomValue) : 15.0;
     const double pixelRatio = pixelRatioValue ? args::get(pixelRatioValue) : 1.0;
+    const bool includeIdeographs = includeIdeographsValue ? args::get(includeIdeographsValue) : false;
     const std::string output = outputValue ? args::get(outputValue) : "offline.db";
     
     using namespace mbgl;
@@ -136,7 +138,7 @@ int main(int argc, char *argv[]) {
             try {
                 std::string json = readFile(geometryValue.Get());
                 auto geometry = parseGeometry(json);
-                return OfflineRegionDefinition{ OfflineGeometryRegionDefinition(style, geometry, minZoom, maxZoom, pixelRatio) };
+                return OfflineRegionDefinition{ OfflineGeometryRegionDefinition(style, geometry, minZoom, maxZoom, pixelRatio, includeIdeographs) };
             } catch(const std::runtime_error& e) {
                 std::cerr << "Could not parse geojson file " << geometryValue.Get() << ": " << e.what() << std::endl;
                 exit(1);
@@ -148,7 +150,7 @@ int main(int argc, char *argv[]) {
             const double south = southValue ? args::get(southValue) : 38.1;
             const double east = eastValue ? args::get(eastValue) : -121.7;
             LatLngBounds boundingBox = LatLngBounds::hull(LatLng(north, west), LatLng(south, east));
-            return OfflineRegionDefinition{ OfflineTilePyramidRegionDefinition(style, boundingBox, minZoom, maxZoom, pixelRatio) };
+            return OfflineRegionDefinition{ OfflineTilePyramidRegionDefinition(style, boundingBox, minZoom, maxZoom, pixelRatio, includeIdeographs) };
         }
     }();
 

--- a/include/mbgl/storage/offline.hpp
+++ b/include/mbgl/storage/offline.hpp
@@ -29,7 +29,7 @@ class TileID;
  */
 class OfflineTilePyramidRegionDefinition {
 public:
-    OfflineTilePyramidRegionDefinition(std::string, LatLngBounds, double, double, float);
+    OfflineTilePyramidRegionDefinition(std::string, LatLngBounds, double, double, float, bool);
 
     /* Private */
     const std::string styleURL;
@@ -37,6 +37,7 @@ public:
     const double minZoom;
     const double maxZoom;
     const float pixelRatio;
+    const bool includeIdeographs;
 };
 
 /*
@@ -52,7 +53,7 @@ public:
  */
 class OfflineGeometryRegionDefinition {
 public:
-    OfflineGeometryRegionDefinition(std::string styleURL, Geometry<double>, double minZoom, double maxZoom, float pixelRatio);
+    OfflineGeometryRegionDefinition(std::string styleURL, Geometry<double>, double minZoom, double maxZoom, float pixelRatio, bool includeIdeographs);
 
     /* Private */
     const std::string styleURL;
@@ -60,6 +61,7 @@ public:
     const double minZoom;
     const double maxZoom;
     const float pixelRatio;
+    const bool includeIdeographs;
 };
 
 /*

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineGeometryRegionDefinition.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineGeometryRegionDefinition.java
@@ -21,6 +21,8 @@ import com.mapbox.turf.TurfMeasurement;
  * tiles from minZoom up to the maximum zoom level provided by that source.
  * <p>
  * pixelRatio must be ≥ 0 and should typically be 1.0 or 2.0.
+ * <p>
+ * if includeIdeographs is false, offline region will not include CJK glyphs
  */
 public class OfflineGeometryRegionDefinition implements OfflineRegionDefinition, Parcelable {
 
@@ -35,6 +37,8 @@ public class OfflineGeometryRegionDefinition implements OfflineRegionDefinition,
   private double maxZoom;
   @Keep
   private float pixelRatio;
+  @Keep
+  private boolean includeIdeographs;
 
   /**
    * Constructor to create an OfflineGeometryRegionDefinition from parameters.
@@ -47,13 +51,31 @@ public class OfflineGeometryRegionDefinition implements OfflineRegionDefinition,
    */
   @Keep
   public OfflineGeometryRegionDefinition(
-    String styleURL, Geometry geometry, double minZoom, double maxZoom, float pixelRatio) {
+      String styleURL, Geometry geometry, double minZoom, double maxZoom, float pixelRatio) {
+    this(styleURL, geometry, minZoom, maxZoom, pixelRatio, true);
+  }
+
+  /**
+   * Constructor to create an OfflineGeometryRegionDefinition from parameters.
+   *
+   * @param styleURL   the style
+   * @param geometry   the geometry
+   * @param minZoom    min zoom
+   * @param maxZoom    max zoom
+   * @param pixelRatio pixel ratio of the device
+   * @param includeIdeographs include glyphs for CJK languages
+   */
+  @Keep
+  public OfflineGeometryRegionDefinition(
+    String styleURL, Geometry geometry, double minZoom, double maxZoom, float pixelRatio,
+    boolean includeIdeographs) {
     // Note: Also used in JNI
     this.styleURL = styleURL;
     this.geometry = geometry;
     this.minZoom = minZoom;
     this.maxZoom = maxZoom;
     this.pixelRatio = pixelRatio;
+    this.includeIdeographs = includeIdeographs;
   }
 
   /**
@@ -108,6 +130,11 @@ public class OfflineGeometryRegionDefinition implements OfflineRegionDefinition,
   @Override
   public float getPixelRatio() {
     return pixelRatio;
+  }
+
+  @Override
+  public boolean getIncludeIdeographs() {
+    return includeIdeographs;
   }
 
   @NonNull

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegionDefinition.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegionDefinition.java
@@ -48,7 +48,20 @@ public interface OfflineRegionDefinition {
   float getPixelRatio();
 
   /**
-   * Gest the type of the OfflineRegionDefinition for telemetry ("tileregion", "shaperegion").
+   * Specifies whether to include ideographic glyphs in downloaded font data.
+   * Ideographic glyphs make up the majority of downloaded font data, but
+   * it is possible to configure the renderer to use locally installed fonts
+   * instead of relying on fonts downloaded as part of the offline pack.
+   *
+   * Defaults to `true`
+   *
+   * @return true if offline region will include ideographic glyphs
+   * @see MapboxMapOptions localIdeographFontFamily
+   */
+  boolean getIncludeIdeographs();
+
+  /**
+   * Gets the type of the OfflineRegionDefinition for telemetry ("tileregion", "shaperegion").
    *
    * @return The type of the OfflineRegionDefinition.
    */

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineTilePyramidRegionDefinition.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineTilePyramidRegionDefinition.java
@@ -18,6 +18,8 @@ import com.mapbox.mapboxsdk.geometry.LatLngBounds;
  * tiles from minZoom up to the maximum zoom level provided by that source.
  * <p>
  * pixelRatio must be &#x2265; 0 and should typically be 1.0 or 2.0.
+ * <p>
+ * if includeIdeographs is false, offline region will not include CJK glyphs
  */
 public class OfflineTilePyramidRegionDefinition implements OfflineRegionDefinition, Parcelable {
 
@@ -31,6 +33,8 @@ public class OfflineTilePyramidRegionDefinition implements OfflineRegionDefiniti
   private double maxZoom;
   @Keep
   private float pixelRatio;
+  @Keep
+  private boolean includeIdeographs;
 
   /**
    * Constructor to create an OfflineTilePyramidDefinition from parameters.
@@ -43,13 +47,31 @@ public class OfflineTilePyramidRegionDefinition implements OfflineRegionDefiniti
    */
   @Keep
   public OfflineTilePyramidRegionDefinition(
-    String styleURL, LatLngBounds bounds, double minZoom, double maxZoom, float pixelRatio) {
+      String styleURL, LatLngBounds bounds, double minZoom, double maxZoom, float pixelRatio) {
+    this(styleURL, bounds, minZoom, maxZoom, pixelRatio, true);
+  }
+
+  /**
+   * Constructor to create an OfflineTilePyramidDefinition from parameters.
+   *
+   * @param styleURL   the style
+   * @param bounds     the bounds
+   * @param minZoom    min zoom
+   * @param maxZoom    max zoom
+   * @param pixelRatio pixel ratio of the device
+   * @param includeIdeographs include glyphs for CJK languages
+   */
+  @Keep
+  public OfflineTilePyramidRegionDefinition(
+    String styleURL, LatLngBounds bounds, double minZoom, double maxZoom, float pixelRatio,
+    boolean includeIdeographs) {
     // Note: Also used in JNI
     this.styleURL = styleURL;
     this.bounds = bounds;
     this.minZoom = minZoom;
     this.maxZoom = maxZoom;
     this.pixelRatio = pixelRatio;
+    this.includeIdeographs = includeIdeographs;
   }
 
   /**
@@ -92,6 +114,11 @@ public class OfflineTilePyramidRegionDefinition implements OfflineRegionDefiniti
   @Override
   public float getPixelRatio() {
     return pixelRatio;
+  }
+
+  @Override
+  public boolean getIncludeIdeographs() {
+    return includeIdeographs;
   }
 
   @NonNull

--- a/platform/android/src/offline/offline_region_definition.cpp
+++ b/platform/android/src/offline/offline_region_definition.cpp
@@ -29,14 +29,15 @@ mbgl::OfflineRegionDefinition OfflineRegionDefinition::getDefinition(JNIEnv& env
 
 jni::Local<jni::Object<OfflineRegionDefinition>> OfflineTilePyramidRegionDefinition::New(jni::JNIEnv& env, const mbgl::OfflineTilePyramidRegionDefinition& definition) {
     static auto& javaClass = jni::Class<OfflineTilePyramidRegionDefinition>::Singleton(env);
-    static auto constructor = javaClass.GetConstructor<jni::String, jni::Object<LatLngBounds>, jni::jdouble, jni::jdouble, jni::jfloat>(env);
+    static auto constructor = javaClass.GetConstructor<jni::String, jni::Object<LatLngBounds>, jni::jdouble, jni::jdouble, jni::jfloat, jni::jboolean>(env);
 
     return javaClass.New(env, constructor,
         jni::Make<jni::String>(env, definition.styleURL),
         LatLngBounds::New(env, definition.bounds),
         definition.minZoom,
         definition.maxZoom,
-        definition.pixelRatio);
+        definition.pixelRatio,
+        jni::jboolean(definition.includeIdeographs));
 }
 
 mbgl::OfflineTilePyramidRegionDefinition OfflineTilePyramidRegionDefinition::getDefinition(jni::JNIEnv& env, const jni::Object<OfflineTilePyramidRegionDefinition>& jDefinition) {
@@ -47,13 +48,15 @@ mbgl::OfflineTilePyramidRegionDefinition OfflineTilePyramidRegionDefinition::get
     static auto minZoomF = javaClass.GetField<jni::jdouble>(env, "minZoom");
     static auto maxZoomF = javaClass.GetField<jni::jdouble>(env, "maxZoom");
     static auto pixelRatioF = javaClass.GetField<jni::jfloat>(env, "pixelRatio");
+    static auto includeIdeographsF = javaClass.GetField<jni::jboolean >(env, "includeIdeographs");
 
     return mbgl::OfflineTilePyramidRegionDefinition(
         jni::Make<std::string>(env, jDefinition.Get(env, styleURLF)),
         LatLngBounds::getLatLngBounds(env, jDefinition.Get(env, boundsF)),
         jDefinition.Get(env, minZoomF),
         jDefinition.Get(env, maxZoomF),
-        jDefinition.Get(env, pixelRatioF)
+        jDefinition.Get(env, pixelRatioF),
+        jDefinition.Get(env, includeIdeographsF)
     );
 }
 
@@ -65,14 +68,15 @@ void OfflineTilePyramidRegionDefinition::registerNative(jni::JNIEnv& env) {
 
 jni::Local<jni::Object<OfflineRegionDefinition>> OfflineGeometryRegionDefinition::New(jni::JNIEnv& env, const mbgl::OfflineGeometryRegionDefinition& definition) {
     static auto& javaClass = jni::Class<OfflineGeometryRegionDefinition>::Singleton(env);
-    static auto constructor = javaClass.GetConstructor<jni::String, jni::Object<geojson::Geometry>, jni::jdouble, jni::jdouble, jni::jfloat>(env);
+    static auto constructor = javaClass.GetConstructor<jni::String, jni::Object<geojson::Geometry>, jni::jdouble, jni::jdouble, jni::jfloat, jni::jboolean>(env);
 
     return javaClass.New(env, constructor,
         jni::Make<jni::String>(env, definition.styleURL),
         geojson::Geometry::New(env, definition.geometry),
         definition.minZoom,
         definition.maxZoom,
-        definition.pixelRatio);
+        definition.pixelRatio,
+        jni::jboolean(definition.includeIdeographs));
 }
 
 mbgl::OfflineGeometryRegionDefinition OfflineGeometryRegionDefinition::getDefinition(jni::JNIEnv& env, const jni::Object<OfflineGeometryRegionDefinition>& jDefinition) {
@@ -83,13 +87,15 @@ mbgl::OfflineGeometryRegionDefinition OfflineGeometryRegionDefinition::getDefini
     static auto minZoomF = javaClass.GetField<jni::jdouble>(env, "minZoom");
     static auto maxZoomF = javaClass.GetField<jni::jdouble>(env, "maxZoom");
     static auto pixelRatioF = javaClass.GetField<jni::jfloat>(env, "pixelRatio");
+    static auto includeIdeographsF = javaClass.GetField<jni::jboolean>(env, "includeIdeographs");
 
     return mbgl::OfflineGeometryRegionDefinition(
         jni::Make<std::string>(env, jDefinition.Get(env, styleURLF)),
         geojson::Geometry::convert(env, jDefinition.Get(env, geometryF)),
         jDefinition.Get(env, minZoomF),
         jDefinition.Get(env, maxZoomF),
-        jDefinition.Get(env, pixelRatioF)
+        jDefinition.Get(env, pixelRatioF),
+        jDefinition.Get(env, includeIdeographsF)
     );
 }
 

--- a/platform/darwin/src/MGLOfflineRegion.h
+++ b/platform/darwin/src/MGLOfflineRegion.h
@@ -19,6 +19,19 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly) NSURL *styleURL;
 
+/**
+ Specifies whether to include ideographic glyphs in downloaded font data.
+ Ideographic glyphs make up the majority of downloaded font data, but
+ it is possible to configure the renderer to use locally installed fonts
+ instead of relying on fonts downloaded as part of the offline pack.
+ See `MGLIdeographicFontFamilyName` setting. Also, for regions outside of
+ China, Japan, and Korea, these glyphs will rarely appear for non-CJK users.
+ 
+ By default, this property is set to `YES`, so that the offline pack will
+ include ideographic glyphs.
+ */
+@property (nonatomic) BOOL includesIdeographicGlyphs;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLShapeOfflineRegion.mm
+++ b/platform/darwin/src/MGLShapeOfflineRegion.mm
@@ -26,6 +26,7 @@
 }
 
 @synthesize styleURL = _styleURL;
+@synthesize includesIdeographicGlyphs = _includesIdeographicGlyphs;
 
 -(NSDictionary *)offlineStartEventAttributes {
     return @{
@@ -71,6 +72,7 @@
         _shape = shape;
         _minimumZoomLevel = minimumZoomLevel;
         _maximumZoomLevel = maximumZoomLevel;
+        _includesIdeographicGlyphs = YES;
     }
     return self;
 }
@@ -78,7 +80,9 @@
 - (instancetype)initWithOfflineRegionDefinition:(const mbgl::OfflineGeometryRegionDefinition &)definition {
     NSURL *styleURL = [NSURL URLWithString:@(definition.styleURL.c_str())];
     MGLShape *shape = MGLShapeFromGeoJSON(definition.geometry);
-    return [self initWithStyleURL:styleURL shape:shape fromZoomLevel:definition.minZoom toZoomLevel:definition.maxZoom];
+    MGLShapeOfflineRegion* result = [self initWithStyleURL:styleURL shape:shape fromZoomLevel:definition.minZoom toZoomLevel:definition.maxZoom];
+    result.includesIdeographicGlyphs = definition.includeIdeographs;
+    return result;
 }
 
 - (const mbgl::OfflineRegionDefinition)offlineRegionDefinition {
@@ -90,7 +94,7 @@
     return mbgl::OfflineGeometryRegionDefinition(_styleURL.absoluteString.UTF8String,
                                                  _shape.geometryObject,
                                                  _minimumZoomLevel, _maximumZoomLevel,
-                                                 scaleFactor);
+                                                 scaleFactor, _includesIdeographicGlyphs);
 }
 
 - (nullable instancetype)initWithCoder:(NSCoder *)coder {
@@ -100,7 +104,9 @@
     double minimumZoomLevel = [coder decodeDoubleForKey:@"minimumZoomLevel"];
     double maximumZoomLevel = [coder decodeDoubleForKey:@"maximumZoomLevel"];
 
-    return [self initWithStyleURL:styleURL shape:shape fromZoomLevel:minimumZoomLevel toZoomLevel:maximumZoomLevel];
+    MGLShapeOfflineRegion* result = [self initWithStyleURL:styleURL shape:shape fromZoomLevel:minimumZoomLevel toZoomLevel:maximumZoomLevel];
+    result.includesIdeographicGlyphs = [coder decodeBoolForKey:@"includesIdeographicGlyphs"];
+    return result;
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder
@@ -109,10 +115,13 @@
     [coder encodeObject:_shape forKey:@"shape"];
     [coder encodeDouble:_maximumZoomLevel forKey:@"maximumZoomLevel"];
     [coder encodeDouble:_minimumZoomLevel forKey:@"minimumZoomLevel"];
+    [coder encodeBool:_includesIdeographicGlyphs forKey:@"includesIdeographicGlyphs"];
 }
 
 - (id)copyWithZone:(nullable NSZone *)zone {
-    return [[[self class] allocWithZone:zone] initWithStyleURL:_styleURL shape:_shape fromZoomLevel:_minimumZoomLevel toZoomLevel:_maximumZoomLevel];
+    MGLShapeOfflineRegion* result = [[[self class] allocWithZone:zone] initWithStyleURL:_styleURL shape:_shape fromZoomLevel:_minimumZoomLevel toZoomLevel:_maximumZoomLevel];
+    result.includesIdeographicGlyphs = _includesIdeographicGlyphs;
+    return result;
 }
 
 - (BOOL)isEqual:(id)other {
@@ -127,13 +136,15 @@
     return (_minimumZoomLevel == otherRegion->_minimumZoomLevel
             && _maximumZoomLevel == otherRegion->_maximumZoomLevel
             && _shape.geometryObject == otherRegion->_shape.geometryObject
-            && [_styleURL isEqual:otherRegion->_styleURL]);
+            && [_styleURL isEqual:otherRegion->_styleURL]
+            && _includesIdeographicGlyphs == otherRegion->_includesIdeographicGlyphs);
 }
 
 - (NSUInteger)hash {
     return (_styleURL.hash
             + _shape.hash
-            + @(_minimumZoomLevel).hash + @(_maximumZoomLevel).hash);
+            + @(_minimumZoomLevel).hash + @(_maximumZoomLevel).hash
+            + @(_includesIdeographicGlyphs).hash);
 }
 
 @end

--- a/platform/darwin/test/MGLOfflineRegionTests.m
+++ b/platform/darwin/test/MGLOfflineRegionTests.m
@@ -25,8 +25,9 @@
 
     XCTAssertEqualObjects(original.styleURL, copy.styleURL, @"Style URL has changed.");
     XCTAssert(MGLCoordinateBoundsEqualToCoordinateBounds(original.bounds, copy.bounds), @"Bounds have changed.");
-    XCTAssertEqual(original.minimumZoomLevel, original.minimumZoomLevel, @"Minimum zoom level has changed.");
-    XCTAssertEqual(original.maximumZoomLevel, original.maximumZoomLevel, @"Maximum zoom level has changed.");
+    XCTAssertEqual(original.minimumZoomLevel, copy.minimumZoomLevel, @"Minimum zoom level has changed.");
+    XCTAssertEqual(original.maximumZoomLevel, copy.maximumZoomLevel, @"Maximum zoom level has changed.");
+    XCTAssertEqual(original.includesIdeographicGlyphs, copy.includesIdeographicGlyphs, @"Include ideographs has changed.");
 }
 
 - (void)testGeometryRegionEquality {
@@ -36,13 +37,15 @@
     XCTAssertNil(error);
     
     MGLShapeOfflineRegion *original = [[MGLShapeOfflineRegion alloc] initWithStyleURL:[MGLStyle lightStyleURLWithVersion:MGLStyleDefaultVersion] shape:shape fromZoomLevel:5 toZoomLevel:10];
+    original.includesIdeographicGlyphs = NO;
     MGLShapeOfflineRegion *copy = [original copy];
     XCTAssertEqualObjects(original, copy, @"Shape region should be equal to its copy.");
     
     XCTAssertEqualObjects(original.styleURL, copy.styleURL, @"Style URL has changed.");
     XCTAssertEqualObjects(original.shape, copy.shape, @"Geometry has changed.");
-    XCTAssertEqual(original.minimumZoomLevel, original.minimumZoomLevel, @"Minimum zoom level has changed.");
-    XCTAssertEqual(original.maximumZoomLevel, original.maximumZoomLevel, @"Maximum zoom level has changed.");
+    XCTAssertEqual(original.minimumZoomLevel, copy.minimumZoomLevel, @"Minimum zoom level has changed.");
+    XCTAssertEqual(original.maximumZoomLevel, copy.maximumZoomLevel, @"Maximum zoom level has changed.");
+    XCTAssertEqual(original.includesIdeographicGlyphs, copy.includesIdeographicGlyphs, @"Include ideographs has changed.");
 }
 
 @end

--- a/platform/darwin/test/MGLOfflineStorageTests.mm
+++ b/platform/darwin/test/MGLOfflineStorageTests.mm
@@ -140,7 +140,7 @@
     MGLShape *shape = [MGLShape shapeWithData: [geojson dataUsingEncoding:NSUTF8StringEncoding] encoding: NSUTF8StringEncoding error:&error];
     XCTAssertNil(error);
     MGLShapeOfflineRegion *region = [[MGLShapeOfflineRegion alloc] initWithStyleURL:styleURL shape:shape fromZoomLevel:zoomLevel toZoomLevel:zoomLevel];
-    
+    region.includesIdeographicGlyphs = NO;
     
     NSString *nameKey = @"Name";
     NSString *name = @"Utrecht centrum";

--- a/platform/ios/app/MBXOfflinePacksTableViewController.m
+++ b/platform/ios/app/MBXOfflinePacksTableViewController.m
@@ -102,7 +102,9 @@ static NSString * const MBXOfflinePacksTableViewActiveCellReuseIdentifier = @"Ac
             name = nameField.placeholder;
         }
 
+        NSString *fontFamilyName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"MGLIdeographicFontFamilyName"];
         MGLTilePyramidOfflineRegion *region = [[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:mapView.styleURL bounds:mapView.visibleCoordinateBounds fromZoomLevel:mapView.zoomLevel toZoomLevel:mapView.maximumZoomLevel];
+        region.includesIdeographicGlyphs = fontFamilyName;
         NSData *context = [NSKeyedArchiver archivedDataWithRootObject:@{
             MBXOfflinePackContextNameKey: name,
         }];

--- a/platform/macos/app/Base.lproj/MapDocument.xib
+++ b/platform/macos/app/Base.lproj/MapDocument.xib
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14306.4" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14306.4"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="MapDocument">
             <connections>
                 <outlet property="addOfflinePackWindow" destination="NmZ-Tf-v2O" id="ZPE-9L-vPJ"/>
+                <outlet property="includeIdeographsBox" destination="Jbt-z6-eg9" id="bsz-FH-emx"/>
                 <outlet property="mapView" destination="q4d-kF-8Hi" id="7hI-dS-A5R"/>
                 <outlet property="mapViewContextMenu" destination="XbX-6a-Mgy" id="YD0-1r-5N2"/>
                 <outlet property="maximumOfflinePackZoomLevelField" destination="5sj-XD-neD" id="Edu-lU-3j9"/>
@@ -55,10 +56,10 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="388" y="211" width="642" height="480"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
             <view key="contentView" id="TuG-C5-zLS">
                 <rect key="frame" x="0.0" y="0.0" width="642" height="480"/>
-                <autoresizingMask key="autoresizingMask"/>
+                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <splitView autosaveName="MBXLayersSplitView" dividerStyle="thin" vertical="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IPR-fm-vk8">
                         <rect key="frame" x="0.0" y="0.0" width="642" height="480"/>
@@ -130,11 +131,11 @@
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="185" id="VQs-2Z-hmP"/>
                                 </constraints>
-                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="NDx-rn-TLj">
+                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="NDx-rn-TLj">
                                     <rect key="frame" x="0.0" y="464" width="163" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
-                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="0vt-rI-sHB">
+                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="0vt-rI-sHB">
                                     <rect key="frame" x="147" y="480" width="16" height="0.0"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
@@ -310,38 +311,38 @@
         <window title="Add Offline Pack" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="NmZ-Tf-v2O">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="109" y="131" width="392" height="192"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
-            <view key="contentView" id="Aqq-bl-feU">
-                <rect key="frame" x="0.0" y="0.0" width="392" height="192"/>
+            <rect key="contentRect" x="109" y="131" width="392" height="221"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+            <view key="contentView" misplaced="YES" id="Aqq-bl-feU">
+                <rect key="frame" x="0.0" y="0.0" width="392" height="221"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Xjw-df-oAz">
-                        <rect key="frame" x="98" y="155" width="276" height="17"/>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Xjw-df-oAz">
+                        <rect key="frame" x="98" y="184" width="276" height="17"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" title="Add offline pack" id="Iec-RB-iqn">
                             <font key="font" metaFont="systemBold"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sui-dp-hbb">
-                        <rect key="frame" x="98" y="78" width="44" height="17"/>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sui-dp-hbb">
+                        <rect key="frame" x="98" y="107" width="44" height="17"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Name:" id="2El-Zw-T6E">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="D3l-hX-2Dh">
-                        <rect key="frame" x="98" y="105" width="276" height="42"/>
+                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="D3l-hX-2Dh">
+                        <rect key="frame" x="98" y="134" width="276" height="42"/>
                         <textFieldCell key="cell" selectable="YES" title="Mapbox GL will download all the resources needed for viewing the currently visible coordinate bounds in the current style." id="3Gw-Zy-sBT">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tUU-DX-RxU">
-                        <rect key="frame" x="148" y="75" width="224" height="22"/>
+                    <textField verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tUU-DX-RxU">
+                        <rect key="frame" x="148" y="104" width="224" height="22"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="lwQ-N1-PTI">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -351,24 +352,16 @@
                             <outlet property="nextKeyView" destination="Xo1-tZ-WQ6" id="VIu-TG-LQu"/>
                         </connections>
                     </textField>
-                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="p5T-3H-wqL">
-                        <rect key="frame" x="20" y="108" width="64" height="64"/>
+                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="p5T-3H-wqL">
+                        <rect key="frame" x="20" y="137" width="64" height="64"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="64" id="2Xy-pC-rE3"/>
                             <constraint firstAttribute="width" constant="64" id="SWY-Rg-9R8"/>
                         </constraints>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSApplicationIcon" id="cww-fO-sNX"/>
                     </imageView>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hhq-J9-mzB">
-                        <rect key="frame" x="98" y="52" width="44" height="17"/>
-                        <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="From:" id="fkO-YX-Yzt">
-                            <font key="font" metaFont="system"/>
-                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
-                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Xo1-tZ-WQ6">
-                        <rect key="frame" x="148" y="49" width="96" height="22"/>
+                    <textField verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Xo1-tZ-WQ6">
+                        <rect key="frame" x="148" y="78" width="96" height="22"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="96" id="8Rw-FU-HGV"/>
                         </constraints>
@@ -384,16 +377,16 @@
                             <outlet property="nextKeyView" destination="5sj-XD-neD" id="90r-pR-v8j"/>
                         </connections>
                     </textField>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8r0-F0-e5i">
-                        <rect key="frame" x="250" y="52" width="20" height="17"/>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8r0-F0-e5i">
+                        <rect key="frame" x="250" y="81" width="20" height="17"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="to:" id="RBS-Uj-AVT">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5sj-XD-neD">
-                        <rect key="frame" x="276" y="49" width="96" height="22"/>
+                    <textField verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5sj-XD-neD">
+                        <rect key="frame" x="276" y="78" width="96" height="22"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="96" id="faj-tE-bfc"/>
                         </constraints>
@@ -406,7 +399,7 @@
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                         <connections>
-                            <outlet property="nextKeyView" destination="tUU-DX-RxU" id="o5A-2J-9Sl"/>
+                            <outlet property="nextKeyView" destination="Jbt-z6-eg9" id="273-nM-wgO"/>
                         </connections>
                     </textField>
                     <button verticalHuggingPriority="750" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="EyW-0r-iV7">
@@ -435,6 +428,25 @@ Gw
                             <action selector="confirmAddingOfflinePack:" target="-2" id="Ljo-bK-4BU"/>
                         </connections>
                     </button>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Jbt-z6-eg9">
+                        <rect key="frame" x="98" y="54" width="198" height="18"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="check" title="Include CJK characters" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="whL-VW-8fY">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <outlet property="nextKeyView" destination="tUU-DX-RxU" id="bQK-xN-9lx"/>
+                        </connections>
+                    </button>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hhq-J9-mzB">
+                        <rect key="frame" x="98" y="81" width="44" height="17"/>
+                        <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="From:" id="fkO-YX-Yzt">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
                 </subviews>
                 <constraints>
                     <constraint firstItem="hhq-J9-mzB" firstAttribute="firstBaseline" secondItem="Xo1-tZ-WQ6" secondAttribute="firstBaseline" id="0Rv-Ze-u9B"/>
@@ -471,7 +483,7 @@ Gw
             <connections>
                 <outlet property="initialFirstResponder" destination="tUU-DX-RxU" id="W2D-pZ-p0s"/>
             </connections>
-            <point key="canvasLocation" x="79" y="867"/>
+            <point key="canvasLocation" x="79" y="881.5"/>
         </window>
     </objects>
     <resources>

--- a/platform/macos/app/MapDocument.m
+++ b/platform/macos/app/MapDocument.m
@@ -82,6 +82,7 @@ NSArray<id <MGLAnnotation>> *MBXFlattenedShapes(NSArray<id <MGLAnnotation>> *sha
 @property (weak) IBOutlet NSNumberFormatter *minimumOfflinePackZoomLevelFormatter;
 @property (weak) IBOutlet NSTextField *maximumOfflinePackZoomLevelField;
 @property (weak) IBOutlet NSNumberFormatter *maximumOfflinePackZoomLevelFormatter;
+@property (weak) IBOutlet NSButton *includesIdeographicGlyphsBox;
 
 @end
 
@@ -931,6 +932,8 @@ NSArray<id <MGLAnnotation>> *MBXFlattenedShapes(NSArray<id <MGLAnnotation>> *sha
     self.minimumOfflinePackZoomLevelFormatter.maximum = @(ceil(self.mapView.maximumZoomLevel));
     self.maximumOfflinePackZoomLevelFormatter.maximum = @(ceil(self.mapView.maximumZoomLevel));
     
+    NSString *fontFamilyName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"MGLIdeographicFontFamilyName"];
+    self.includesIdeographicGlyphsBox.state = fontFamilyName ? NSOffState : NSOnState;
     [self.addOfflinePackWindow makeFirstResponder:self.offlinePackNameField];
     
     __weak __typeof__(self) weakSelf = self;
@@ -945,6 +948,7 @@ NSArray<id <MGLAnnotation>> *MBXFlattenedShapes(NSArray<id <MGLAnnotation>> *sha
                                                            bounds:strongSelf.mapView.visibleCoordinateBounds
                                                     fromZoomLevel:strongSelf.minimumOfflinePackZoomLevelField.integerValue
                                                       toZoomLevel:strongSelf.maximumOfflinePackZoomLevelField.integerValue];
+        region.includesIdeographicGlyphs = strongSelf.includesIdeographicGlyphsBox.state == NSOnState;
         NSString *name = strongSelf.offlinePackNameField.stringValue;
         if (!name.length) {
             name = strongSelf.offlinePackNameField.placeholderString;

--- a/scripts/changelog_staging/no-offline-cjk.json
+++ b/scripts/changelog_staging/no-offline-cjk.json
@@ -1,0 +1,6 @@
+{
+  "core": "Add `--includeIdeographs` option to mbgl-offline tool to include CJK glyphs in offline region, at the cost of increased size requirements.",
+  "darwin": "Added the `MGLOfflineRegion.includesIdeographicGlyphs` property, which you can set to NO to exclude CJK glyphs and save space.",
+  "android": "Added the `includeIdeographs` property to `OfflineRegionDefinition`, which you can set to false to exclude CJK glyphs and save space.",
+  "issue": 11561
+}

--- a/src/mbgl/text/glyph_range.hpp
+++ b/src/mbgl/text/glyph_range.hpp
@@ -11,6 +11,8 @@ using GlyphRange = std::pair<uint16_t, uint16_t>;
 
 constexpr uint32_t GLYPHS_PER_GLYPH_RANGE = 256;
 constexpr uint32_t GLYPH_RANGES_PER_FONT_STACK = 256;
+// 256 - 126 ranges skipped w/ i18n::allowsFixedWidthGlyphGeneration
+constexpr uint32_t NON_IDEOGRAPH_GLYPH_RANGES_PER_FONT_STACK = 130;
 
 } // end namespace mbgl
 

--- a/test/storage/offline.test.cpp
+++ b/test/storage/offline.test.cpp
@@ -8,7 +8,7 @@ using SourceType = mbgl::style::SourceType;
 
 
 TEST(OfflineTilePyramidRegionDefinition, EncodeDecode) {
-    OfflineTilePyramidRegionDefinition region("mapbox://style", LatLngBounds::hull({ 37.6609, -122.5744 }, { 37.8271, -122.3204 }), 0, 20, 1.0);
+    OfflineTilePyramidRegionDefinition region("mapbox://style", LatLngBounds::hull({ 37.6609, -122.5744 }, { 37.8271, -122.3204 }), 0, 20, 1.0, true);
 
     auto encoded = encodeOfflineRegionDefinition(region);
     auto decoded = decodeOfflineRegionDefinition(encoded).get<OfflineTilePyramidRegionDefinition>();
@@ -19,10 +19,11 @@ TEST(OfflineTilePyramidRegionDefinition, EncodeDecode) {
     EXPECT_EQ(decoded.pixelRatio, region.pixelRatio);
     EXPECT_EQ(decoded.bounds.southwest(), region.bounds.southwest());
     EXPECT_EQ(decoded.bounds.northeast(), region.bounds.northeast());
+    EXPECT_EQ(decoded.includeIdeographs, region.includeIdeographs);
 }
 
 TEST(OfflineGeometryRegionDefinition, EncodeDecode) {
-    OfflineGeometryRegionDefinition region("mapbox://style", Point<double>(-122.5744, 37.6609), 0, 2, 1.0);
+    OfflineGeometryRegionDefinition region("mapbox://style", Point<double>(-122.5744, 37.6609), 0, 2, 1.0, false);
 
     auto encoded = encodeOfflineRegionDefinition(region);
     auto decoded = decodeOfflineRegionDefinition(encoded).get<OfflineGeometryRegionDefinition>();
@@ -32,4 +33,5 @@ TEST(OfflineGeometryRegionDefinition, EncodeDecode) {
     EXPECT_EQ(decoded.maxZoom, region.maxZoom);
     EXPECT_EQ(decoded.pixelRatio, region.pixelRatio);
     EXPECT_EQ(decoded.geometry, region.geometry);
+    EXPECT_EQ(decoded.includeIdeographs, region.includeIdeographs);
 }

--- a/test/storage/offline_database.test.cpp
+++ b/test/storage/offline_database.test.cpp
@@ -412,7 +412,7 @@ TEST(OfflineDatabase, PutTileNotFound) {
 TEST(OfflineDatabase, CreateRegion) {
     FixtureLog log;
     OfflineDatabase db(":memory:");
-    OfflineTilePyramidRegionDefinition definition { "http://example.com/style", LatLngBounds::hull({1, 2}, {3, 4}), 5, 6, 2.0 };
+    OfflineTilePyramidRegionDefinition definition { "http://example.com/style", LatLngBounds::hull({1, 2}, {3, 4}), 5, 6, 2.0, true };
     OfflineRegionMetadata metadata {{ 1, 2, 3 }};
     auto region = db.createRegion(definition, metadata);
     ASSERT_TRUE(region);
@@ -426,6 +426,7 @@ TEST(OfflineDatabase, CreateRegion) {
                 EXPECT_EQ(definition.minZoom, def.minZoom);
                 EXPECT_EQ(definition.maxZoom, def.maxZoom);
                 EXPECT_EQ(definition.pixelRatio, def.pixelRatio);
+                EXPECT_EQ(definition.includeIdeographs, def.includeIdeographs);
             }, [](auto&) {
                 EXPECT_FALSE(false);
             }
@@ -436,7 +437,7 @@ TEST(OfflineDatabase, CreateRegion) {
 TEST(OfflineDatabase, UpdateMetadata) {
     FixtureLog log;
     OfflineDatabase db(":memory:");
-    OfflineTilePyramidRegionDefinition definition { "http://example.com/style", LatLngBounds::hull({1, 2}, {3, 4}), 5, 6, 2.0 };
+    OfflineTilePyramidRegionDefinition definition { "http://example.com/style", LatLngBounds::hull({1, 2}, {3, 4}), 5, 6, 2.0, true };
     OfflineRegionMetadata metadata {{ 1, 2, 3 }};
     auto region = db.createRegion(definition, metadata);
     ASSERT_TRUE(region);
@@ -452,7 +453,7 @@ TEST(OfflineDatabase, UpdateMetadata) {
 TEST(OfflineDatabase, ListRegions) {
     FixtureLog log;
     OfflineDatabase db(":memory:");
-    OfflineTilePyramidRegionDefinition definition { "http://example.com/style", LatLngBounds::hull({1, 2}, {3, 4}), 5, 6, 2.0 };
+    OfflineTilePyramidRegionDefinition definition { "http://example.com/style", LatLngBounds::hull({1, 2}, {3, 4}), 5, 6, 2.0, false };
     OfflineRegionMetadata metadata {{ 1, 2, 3 }};
 
     auto region = db.createRegion(definition, metadata);
@@ -469,6 +470,7 @@ TEST(OfflineDatabase, ListRegions) {
                 EXPECT_EQ(definition.minZoom, def.minZoom);
                 EXPECT_EQ(definition.maxZoom, def.maxZoom);
                 EXPECT_EQ(definition.pixelRatio, def.pixelRatio);
+                EXPECT_EQ(definition.includeIdeographs, def.includeIdeographs);
             },
             [&](auto&) {
                 EXPECT_FALSE(false);
@@ -481,7 +483,7 @@ TEST(OfflineDatabase, ListRegions) {
 TEST(OfflineDatabase, GetRegionDefinition) {
     FixtureLog log;
     OfflineDatabase db(":memory:");
-    OfflineTilePyramidRegionDefinition definition { "http://example.com/style", LatLngBounds::hull({1, 2}, {3, 4}), 5, 6, 2.0 };
+    OfflineTilePyramidRegionDefinition definition { "http://example.com/style", LatLngBounds::hull({1, 2}, {3, 4}), 5, 6, 2.0, false };
     OfflineRegionMetadata metadata {{ 1, 2, 3 }};
 
     EXPECT_EQ(0u, log.uncheckedCount());
@@ -494,6 +496,7 @@ TEST(OfflineDatabase, GetRegionDefinition) {
                 EXPECT_EQ(definition.minZoom, result.minZoom);
                 EXPECT_EQ(definition.maxZoom, result.maxZoom);
                 EXPECT_EQ(definition.pixelRatio, result.pixelRatio);
+                EXPECT_EQ(definition.includeIdeographs, result.includeIdeographs);
             },
             [&](auto&) {
                 EXPECT_FALSE(false);
@@ -504,7 +507,7 @@ TEST(OfflineDatabase, GetRegionDefinition) {
 TEST(OfflineDatabase, DeleteRegion) {
     FixtureLog log;
     OfflineDatabase db(":memory:");
-    OfflineTilePyramidRegionDefinition definition { "http://example.com/style", LatLngBounds::hull({1, 2}, {3, 4}), 5, 6, 2.0 };
+    OfflineTilePyramidRegionDefinition definition { "http://example.com/style", LatLngBounds::hull({1, 2}, {3, 4}), 5, 6, 2.0, true };
     OfflineRegionMetadata metadata {{ 1, 2, 3 }};
     auto region = db.createRegion(definition, metadata);
     ASSERT_TRUE(region);
@@ -526,7 +529,7 @@ TEST(OfflineDatabase, DeleteRegion) {
 TEST(OfflineDatabase, CreateRegionInfiniteMaxZoom) {
     FixtureLog log;
     OfflineDatabase db(":memory:");
-    OfflineTilePyramidRegionDefinition definition { "", LatLngBounds::world(), 0, INFINITY, 1.0 };
+    OfflineTilePyramidRegionDefinition definition { "", LatLngBounds::world(), 0, INFINITY, 1.0, false };
     OfflineRegionMetadata metadata;
     auto region = db.createRegion(definition, metadata);
     ASSERT_TRUE(region);
@@ -619,7 +622,7 @@ TEST(OfflineDatabase, PutEvictsLeastRecentlyUsedResources) {
 TEST(OfflineDatabase, PutRegionResourceDoesNotEvict) {
     FixtureLog log;
     OfflineDatabase db(":memory:", 1024 * 100);
-    OfflineTilePyramidRegionDefinition definition { "", LatLngBounds::world(), 0, INFINITY, 1.0 };
+    OfflineTilePyramidRegionDefinition definition { "", LatLngBounds::world(), 0, INFINITY, 1.0, true };
     auto region = db.createRegion(definition, OfflineRegionMetadata());
     ASSERT_TRUE(region);
 
@@ -656,7 +659,7 @@ TEST(OfflineDatabase, PutFailsWhenEvictionInsuffices) {
 TEST(OfflineDatabase, GetRegionCompletedStatus) {
     FixtureLog log;
     OfflineDatabase db(":memory:");
-    OfflineTilePyramidRegionDefinition definition { "http://example.com/style", LatLngBounds::hull({1, 2}, {3, 4}), 5, 6, 2.0 };
+    OfflineTilePyramidRegionDefinition definition { "http://example.com/style", LatLngBounds::hull({1, 2}, {3, 4}), 5, 6, 2.0, false };
     OfflineRegionMetadata metadata;
     auto region = db.createRegion(definition, metadata);
     ASSERT_TRUE(region);
@@ -695,7 +698,7 @@ TEST(OfflineDatabase, GetRegionCompletedStatus) {
 TEST(OfflineDatabase, HasRegionResource) {
     FixtureLog log;
     OfflineDatabase db(":memory:", 1024 * 100);
-    OfflineTilePyramidRegionDefinition definition { "", LatLngBounds::world(), 0, INFINITY, 1.0 };
+    OfflineTilePyramidRegionDefinition definition { "", LatLngBounds::world(), 0, INFINITY, 1.0, true };
     auto region = db.createRegion(definition, OfflineRegionMetadata());
     ASSERT_TRUE(region);
 
@@ -719,7 +722,7 @@ TEST(OfflineDatabase, HasRegionResource) {
 TEST(OfflineDatabase, HasRegionResourceTile) {
     FixtureLog log;
     OfflineDatabase db(":memory:", 1024 * 100);
-    OfflineTilePyramidRegionDefinition definition { "", LatLngBounds::world(), 0, INFINITY, 1.0 };
+    OfflineTilePyramidRegionDefinition definition { "", LatLngBounds::world(), 0, INFINITY, 1.0, false };
     auto region = db.createRegion(definition, OfflineRegionMetadata());
     ASSERT_TRUE(region);
 
@@ -753,7 +756,7 @@ TEST(OfflineDatabase, HasRegionResourceTile) {
 TEST(OfflineDatabase, OfflineMapboxTileCount) {
     FixtureLog log;
     OfflineDatabase db(":memory:");
-    OfflineTilePyramidRegionDefinition definition { "http://example.com/style", LatLngBounds::hull({1, 2}, {3, 4}), 5, 6, 2.0 };
+    OfflineTilePyramidRegionDefinition definition { "http://example.com/style", LatLngBounds::hull({1, 2}, {3, 4}), 5, 6, 2.0 , true};
     OfflineRegionMetadata metadata;
 
     auto region1 = db.createRegion(definition, metadata);
@@ -814,7 +817,7 @@ TEST(OfflineDatabase, OfflineMapboxTileCount) {
 TEST(OfflineDatabase, BatchInsertion) {
     FixtureLog log;
     OfflineDatabase db(":memory:", 1024 * 100);
-    OfflineTilePyramidRegionDefinition definition { "", LatLngBounds::world(), 0, INFINITY, 1.0 };
+    OfflineTilePyramidRegionDefinition definition { "", LatLngBounds::world(), 0, INFINITY, 1.0, true };
     auto region = db.createRegion(definition, OfflineRegionMetadata());
     ASSERT_TRUE(region);
 
@@ -840,7 +843,7 @@ TEST(OfflineDatabase, BatchInsertionMapboxTileCountExceeded) {
     FixtureLog log;
     OfflineDatabase db(":memory:", 1024 * 100);
     db.setOfflineMapboxTileCountLimit(1);
-    OfflineTilePyramidRegionDefinition definition { "", LatLngBounds::world(), 0, INFINITY, 1.0 };
+    OfflineTilePyramidRegionDefinition definition { "", LatLngBounds::world(), 0, INFINITY, 1.0, false };
     auto region = db.createRegion(definition, OfflineRegionMetadata());
     ASSERT_TRUE(region);
 
@@ -1051,7 +1054,7 @@ TEST(OfflineDatabase, TEST_REQUIRES_WRITE(DisallowedIO)) {
 
     // First, create a region object so that we can try deleting it later.
     OfflineTilePyramidRegionDefinition definition(
-        "mapbox://style", LatLngBounds::hull({ 37.66, -122.57 }, { 37.83, -122.32 }), 0, 8, 2);
+        "mapbox://style", LatLngBounds::hull({ 37.66, -122.57 }, { 37.83, -122.32 }), 0, 8, 2, false);
     auto region = db.createRegion(definition, {});
     ASSERT_TRUE(region);
 

--- a/test/storage/offline_download.test.cpp
+++ b/test/storage/offline_download.test.cpp
@@ -66,7 +66,7 @@ public:
     std::size_t size = 0;
 
     auto createRegion() {
-        OfflineTilePyramidRegionDefinition definition { "", LatLngBounds::hull({1, 2}, {3, 4}), 5, 6, 1.0 };
+        OfflineTilePyramidRegionDefinition definition { "", LatLngBounds::hull({1, 2}, {3, 4}), 5, 6, 1.0, true };
         OfflineRegionMetadata metadata;
         return db.createRegion(definition, metadata);
     }
@@ -87,7 +87,7 @@ TEST(OfflineDownload, NoSubresources) {
     ASSERT_TRUE(region);
     OfflineDownload download(
         region->getID(),
-        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0),
+        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0, false),
         test.db, test.fileSource);
 
     test.fileSource.styleResponse = [&] (const Resource& resource) {
@@ -128,7 +128,7 @@ TEST(OfflineDownload, InlineSource) {
     ASSERT_TRUE(region);
     OfflineDownload download(
         region->getID(),
-        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0),
+        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0, true),
         test.db, test.fileSource);
 
     test.fileSource.styleResponse = [&] (const Resource& resource) {
@@ -169,7 +169,7 @@ TEST(OfflineDownload, GeoJSONSource) {
     ASSERT_TRUE(region);
     OfflineDownload download(
         region->getID(),
-        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0),
+        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0, false),
         test.db, test.fileSource);
 
     test.fileSource.styleResponse = [&] (const Resource& resource) {
@@ -205,7 +205,7 @@ TEST(OfflineDownload, Activate) {
     ASSERT_TRUE(region);
     OfflineDownload download(
         region->getID(),
-        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0),
+        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0, true),
         test.db, test.fileSource);
 
     test.fileSource.styleResponse = [&] (const Resource& resource) {
@@ -276,6 +276,83 @@ TEST(OfflineDownload, Activate) {
     test.loop.run();
 }
 
+TEST(OfflineDownload, ExcludeIdeographs) {
+    OfflineTest test;
+    auto region = test.createRegion();
+    ASSERT_TRUE(region);
+    OfflineDownload download(
+                             region->getID(),
+                             OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0, false),
+                             test.db, test.fileSource);
+    
+    test.fileSource.styleResponse = [&] (const Resource& resource) {
+        EXPECT_EQ("http://127.0.0.1:3000/style.json", resource.url);
+        return test.response("style.json");
+    };
+    
+    test.fileSource.spriteImageResponse = [&] (const Resource& resource) {
+        EXPECT_TRUE(resource.url == "http://127.0.0.1:3000/sprite.png" ||
+                    resource.url == "http://127.0.0.1:3000/sprite@2x.png");
+        return test.response("sprite.png");
+    };
+    
+    test.fileSource.imageResponse = [&] (const Resource& resource) {
+        EXPECT_EQ("http://127.0.0.1:3000/radar.gif", resource.url);
+        return test.response("radar.gif");
+    };
+    
+    test.fileSource.spriteJSONResponse = [&] (const Resource& resource) {
+        EXPECT_TRUE(resource.url == "http://127.0.0.1:3000/sprite.json" ||
+                    resource.url == "http://127.0.0.1:3000/sprite@2x.json");
+        return test.response("sprite.json");
+    };
+    
+    test.fileSource.glyphsResponse = [&] (const Resource&) {
+        return test.response("glyph.pbf");
+    };
+    
+    test.fileSource.sourceResponse = [&] (const Resource& resource) {
+        EXPECT_EQ("http://127.0.0.1:3000/streets.json", resource.url);
+        return test.response("streets.json");
+    };
+    
+    test.fileSource.tileResponse = [&] (const Resource& resource) {
+        const Resource::TileData& tile = *resource.tileData;
+        EXPECT_EQ("http://127.0.0.1:3000/{z}-{x}-{y}.vector.pbf", tile.urlTemplate);
+        EXPECT_EQ(1, tile.pixelRatio);
+        EXPECT_EQ(0, tile.x);
+        EXPECT_EQ(0, tile.y);
+        EXPECT_EQ(0, tile.z);
+        return test.response("0-0-0.vector.pbf");
+    };
+    
+    auto observer = std::make_unique<MockObserver>();
+    
+    observer->statusChangedFn = [&] (OfflineRegionStatus status) {
+        if (status.complete()) {
+            EXPECT_EQ(138u, status.completedResourceCount); // 130 glyphs, 2 sprite images, 2 sprite jsons, 1 tile, 1 style, source, image
+            EXPECT_EQ(test.size, status.completedResourceSize);
+            
+            download.setState(OfflineRegionDownloadState::Inactive);
+            OfflineRegionStatus computedStatus = download.getStatus();
+            EXPECT_EQ(OfflineRegionDownloadState::Inactive, computedStatus.downloadState);
+            EXPECT_EQ(status.requiredResourceCount, computedStatus.requiredResourceCount);
+            EXPECT_EQ(status.completedResourceCount, computedStatus.completedResourceCount);
+            EXPECT_EQ(status.completedResourceSize, computedStatus.completedResourceSize);
+            EXPECT_EQ(status.completedTileCount, computedStatus.completedTileCount);
+            EXPECT_EQ(status.completedTileSize, computedStatus.completedTileSize);
+            EXPECT_TRUE(status.requiredResourceCountIsPrecise);
+            
+            test.loop.stop();
+        }
+    };
+    
+    download.setObserver(std::move(observer));
+    download.setState(OfflineRegionDownloadState::Active);
+    
+    test.loop.run();
+}
+
 TEST(OfflineDownload, DoesNotFloodTheFileSourceWithRequests) {
     OfflineTest test;
     FakeOnlineFileSource fileSource;
@@ -283,7 +360,7 @@ TEST(OfflineDownload, DoesNotFloodTheFileSourceWithRequests) {
     ASSERT_TRUE(region);
     OfflineDownload download(
         region->getID(),
-        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0),
+        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0, true),
         test.db, fileSource);
 
     auto observer = std::make_unique<MockObserver>();
@@ -306,7 +383,7 @@ TEST(OfflineDownload, GetStatusNoResources) {
     ASSERT_TRUE(region);
     OfflineDownload download(
         region->getID(),
-        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0),
+        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0, false),
         test.db, test.fileSource);
     OfflineRegionStatus status = download.getStatus();
 
@@ -324,7 +401,7 @@ TEST(OfflineDownload, GetStatusStyleComplete) {
     ASSERT_TRUE(region);
     OfflineDownload download(
         region->getID(),
-        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0),
+        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0, true),
         test.db, test.fileSource);
 
     test.db.putRegionResource(1,
@@ -347,7 +424,7 @@ TEST(OfflineDownload, GetStatusStyleAndSourceComplete) {
     ASSERT_TRUE(region);
     OfflineDownload download(
         region->getID(),
-        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0),
+        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0, true),
         test.db, test.fileSource);
 
     test.db.putRegionResource(1,
@@ -374,7 +451,7 @@ TEST(OfflineDownload, RequestError) {
     ASSERT_TRUE(region);
     OfflineDownload download(
         region->getID(),
-        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0),
+        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0, false),
         test.db, test.fileSource);
 
     test.fileSource.styleResponse = [&] (const Resource&) {
@@ -403,7 +480,7 @@ TEST(OfflineDownload, RequestErrorsAreRetried) {
     ASSERT_TRUE(region);
     OfflineDownload download(
         region->getID(),
-        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0),
+        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0, true),
         test.db, test.fileSource);
 
     test.fileSource.styleResponse = [&] (const Resource&) {
@@ -437,7 +514,7 @@ TEST(OfflineDownload, TileCountLimitExceededNoTileResponse) {
     ASSERT_TRUE(region);
     OfflineDownload download(
         region->getID(),
-        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0),
+        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0, false),
         test.db, test.fileSource);
 
     uint64_t tileLimit = 0;
@@ -480,7 +557,7 @@ TEST(OfflineDownload, TileCountLimitExceededWithTileResponse) {
     ASSERT_TRUE(region);
     OfflineDownload download(
         region->getID(),
-        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0),
+        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0, true),
         test.db, test.fileSource);
 
     uint64_t tileLimit = 1;
@@ -535,7 +612,7 @@ TEST(OfflineDownload, WithPreviouslyExistingTile) {
     ASSERT_TRUE(region);
     OfflineDownload download(
         region->getID(),
-        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0),
+        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0, false),
         test.db, test.fileSource);
 
     test.fileSource.styleResponse = [&] (const Resource& resource) {
@@ -570,7 +647,7 @@ TEST(OfflineDownload, ReactivatePreviouslyCompletedDownload) {
     ASSERT_TRUE(region);
     OfflineDownload download(
         region->getID(),
-        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0),
+        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0, true),
         test.db, test.fileSource);
 
     test.fileSource.styleResponse = [&] (const Resource& resource) {
@@ -596,7 +673,7 @@ TEST(OfflineDownload, ReactivatePreviouslyCompletedDownload) {
 
     OfflineDownload redownload(
         region->getID(),
-        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0),
+        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0, false),
         test.db, test.fileSource);
 
     std::vector<OfflineRegionStatus> statusesAfterReactivate;
@@ -638,7 +715,7 @@ TEST(OfflineDownload, Deactivate) {
     ASSERT_TRUE(region);
     OfflineDownload download(
         region->getID(),
-        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0),
+        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0, false),
         test.db, test.fileSource);
 
     test.fileSource.styleResponse = [&] (const Resource& resource) {
@@ -669,7 +746,7 @@ TEST(OfflineDownload, AllOfflineRequestsHaveLowPriority) {
     ASSERT_TRUE(region);
     OfflineDownload download(
         region->getID(),
-        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0),
+        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0, true),
         test.db, test.fileSource);
 
     test.fileSource.styleResponse = [&] (const Resource& resource) {
@@ -740,7 +817,7 @@ TEST(OfflineDownload, DiskFull) {
 
     OfflineDownload download(
         region->getID(),
-        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0),
+        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/style.json", LatLngBounds::world(), 0.0, 0.0, 1.0, false),
         test.db, test.fileSource);
 
     bool hasRequestedStyle = false;


### PR DESCRIPTION
This is a proof-of-concept for a fix to issue #11561 -- for small offline packs, the size of the pack is dominated by the space taken up by CJK glyphs, even though many or most people won't use them:

- For maps intended for CJK audiences, we typically recommend using local CJK glyph generation, so it's not necessary to cache the glyphs in an offline pack.
- For offline maps intended for non-CJK audiences, it is likely that the offline region covers an area in which there are no or very few CJK glyphs, so there's a good chance it's OK to exclude them.

For a z1/z2 offline region of Satellite Streets, it looks like excluding CJK glyphs brings the bundle size down from ~90MB to ~12MB.

<img width="637" alt="screenshot 2018-12-18 17 27 18" src="https://user-images.githubusercontent.com/375121/50193291-c9a2c000-02ea-11e9-84f4-c7fe76c7903d.png">

Currently the code defaults to the existing behavior of including the glyphs. We should consider defaulting to excluding the glyphs.

TODO:

- [x] Android implementation
- [x] Automated tests
- [x] Documentation

cc @1ec5 @lloydsheng @kkaefer 