### PR TITLE
Cleanup deprecated methods for 7.0.0

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraUpdateFactory.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraUpdateFactory.java
@@ -88,20 +88,6 @@ public final class CameraUpdateFactory {
   }
 
   /**
-   * Returns a CameraUpdate that scrolls the camera over the map,
-   * shifting the center of view by the specified number of pixels in the x and y directions.
-   *
-   * @param xPixel Amount of pixels to scroll to in x direction
-   * @param yPixel Amount of pixels to scroll to in y direction
-   * @return CameraUpdate Final Camera Position
-   * @deprecated use {@link MapboxMap#scrollBy(float, float)} for more precise displacements when using a padded map.
-   */
-  @Deprecated
-  public static CameraUpdate scrollBy(float xPixel, float yPixel) {
-    return new CameraMoveUpdate(xPixel, yPixel);
-  }
-
-  /**
    * Returns a CameraUpdate that shifts the zoom level of the current camera viewpoint.
    *
    * @param amount Amount of zoom level to change with

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/CompassEngine.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/CompassEngine.java
@@ -52,20 +52,4 @@ public interface CompassEngine {
    * @return last accuracy status
    */
   int getLastAccuracySensorStatus();
-
-  /**
-   * Lifecycle method that can be used for adding or releasing resources.
-   *
-   * @deprecated Use {@link #addCompassListener(CompassListener)}
-   */
-  @Deprecated
-  void onStart();
-
-  /**
-   * Lifecycle method that can be used for adding or releasing resources.
-   *
-   * @deprecated Use {@link #removeCompassListener(CompassListener)}
-   */
-  @Deprecated
-  void onStop();
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
@@ -781,48 +781,6 @@ public final class LocationComponent {
   }
 
   /**
-   * Return the last known {@link CompassEngine} accuracy status of the location component.
-   * <p>
-   * The last known accuracy of the compass sensor, one of SensorManager.SENSOR_STATUS_*
-   *
-   * @return the last know compass accuracy bearing
-   * @deprecated Use {@link #getCompassEngine()}
-   */
-  @Deprecated
-  public float getLastKnownCompassAccuracyStatus() {
-    return compassEngine != null ? compassEngine.getLastAccuracySensorStatus() : 0;
-  }
-
-  /**
-   * Add a compass listener to get heading updates every second. Once the first listener gets added,
-   * the sensor gets initiated and starts returning values.
-   *
-   * @param compassListener a {@link CompassListener} for listening into compass heading and
-   *                        accuracy changes
-   * @deprecated Use {@link #getCompassEngine()}
-   */
-  @Deprecated
-  public void addCompassListener(@NonNull CompassListener compassListener) {
-    if (compassEngine != null) {
-      compassEngine.addCompassListener(compassListener);
-    }
-  }
-
-  /**
-   * Remove a compass listener.
-   *
-   * @param compassListener the {@link CompassListener} which you'd like to remove from the listener
-   *                        list.
-   * @deprecated Use {@link #getCompassEngine()}
-   */
-  @Deprecated
-  public void removeCompassListener(@NonNull CompassListener compassListener) {
-    if (compassEngine != null) {
-      compassEngine.removeCompassListener(compassListener);
-    }
-  }
-
-  /**
    * Adds a listener that gets invoked when the user clicks the displayed location.
    * <p>
    * If there are registered location click listeners and the location is clicked,

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentCompassEngine.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentCompassEngine.java
@@ -109,20 +109,6 @@ class LocationComponentCompassEngine implements CompassEngine, SensorEventListen
   }
 
   @Override
-  public void onStart() {
-    if (!compassListeners.isEmpty()) {
-      registerSensorListeners();
-    }
-  }
-
-  @Override
-  public void onStop() {
-    if (!compassListeners.isEmpty()) {
-      unregisterSensorListeners();
-    }
-  }
-
-  @Override
   public void onSensorChanged(@NonNull SensorEvent event) {
     // check when the last time the compass was updated, return if too soon.
     long currentTime = SystemClock.elapsedRealtime();

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -862,7 +862,11 @@ public final class MapboxMap {
    *
    * @param markerOptions A marker options object that defines how to render the marker
    * @return The {@code Marker} that was added to the map
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   @NonNull
   public Marker addMarker(@NonNull MarkerOptions markerOptions) {
     return annotationManager.addMarker(markerOptions, this);
@@ -877,7 +881,11 @@ public final class MapboxMap {
    *
    * @param markerOptions A marker options object that defines how to render the marker
    * @return The {@code Marker} that was added to the map
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   @NonNull
   public Marker addMarker(@NonNull BaseMarkerOptions markerOptions) {
     return annotationManager.addMarker(markerOptions, this);
@@ -892,7 +900,11 @@ public final class MapboxMap {
    *
    * @param markerOptionsList A list of marker options objects that defines how to render the markers
    * @return A list of the {@code Marker}s that were added to the map
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   @NonNull
   public List<Marker> addMarkers(@NonNull List<? extends
     BaseMarkerOptions> markerOptionsList) {
@@ -905,7 +917,11 @@ public final class MapboxMap {
    * </p>
    *
    * @param updatedMarker An updated marker object
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public void updateMarker(@NonNull Marker updatedMarker) {
     annotationManager.updateMarker(updatedMarker, this);
   }
@@ -915,7 +931,11 @@ public final class MapboxMap {
    *
    * @param polylineOptions A polyline options object that defines how to render the polyline
    * @return The {@code Polyine} that was added to the map
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   @NonNull
   public Polyline addPolyline(@NonNull PolylineOptions polylineOptions) {
     return annotationManager.addPolyline(polylineOptions, this);
@@ -926,7 +946,11 @@ public final class MapboxMap {
    *
    * @param polylineOptionsList A list of polyline options objects that defines how to render the polylines.
    * @return A list of the {@code Polyline}s that were added to the map.
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   @NonNull
   public List<Polyline> addPolylines(@NonNull List<PolylineOptions> polylineOptionsList) {
     return annotationManager.addPolylines(polylineOptionsList, this);
@@ -936,7 +960,11 @@ public final class MapboxMap {
    * Update a polyline on this map.
    *
    * @param polyline An updated polyline object.
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public void updatePolyline(@NonNull Polyline polyline) {
     annotationManager.updatePolyline(polyline);
   }
@@ -946,7 +974,11 @@ public final class MapboxMap {
    *
    * @param polygonOptions A polygon options object that defines how to render the polygon.
    * @return The {@code Polygon} that was added to the map.
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   @NonNull
   public Polygon addPolygon(@NonNull PolygonOptions polygonOptions) {
     return annotationManager.addPolygon(polygonOptions, this);
@@ -957,7 +989,11 @@ public final class MapboxMap {
    *
    * @param polygonOptionsList A list of polygon options objects that defines how to render the polygons
    * @return A list of the {@code Polygon}s that were added to the map
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   @NonNull
   public List<Polygon> addPolygons(@NonNull List<PolygonOptions> polygonOptionsList) {
     return annotationManager.addPolygons(polygonOptionsList, this);
@@ -967,7 +1003,11 @@ public final class MapboxMap {
    * Update a polygon on this map.
    *
    * @param polygon An updated polygon object
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public void updatePolygon(@NonNull Polygon polygon) {
     annotationManager.updatePolygon(polygon);
   }
@@ -979,7 +1019,11 @@ public final class MapboxMap {
    * Calls removeAnnotation() internally.
    *
    * @param marker Marker to remove
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public void removeMarker(@NonNull Marker marker) {
     annotationManager.removeAnnotation(marker);
   }
@@ -991,7 +1035,11 @@ public final class MapboxMap {
    * Calls removeAnnotation() internally.
    *
    * @param polyline Polyline to remove
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public void removePolyline(@NonNull Polyline polyline) {
     annotationManager.removeAnnotation(polyline);
   }
@@ -1003,7 +1051,11 @@ public final class MapboxMap {
    * Calls removeAnnotation() internally.
    *
    * @param polygon Polygon to remove
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public void removePolygon(@NonNull Polygon polygon) {
     annotationManager.removeAnnotation(polygon);
   }
@@ -1012,7 +1064,11 @@ public final class MapboxMap {
    * Removes an annotation from the map.
    *
    * @param annotation The annotation object to remove.
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public void removeAnnotation(@NonNull Annotation annotation) {
     annotationManager.removeAnnotation(annotation);
   }
@@ -1021,7 +1077,11 @@ public final class MapboxMap {
    * Removes an annotation from the map
    *
    * @param id The identifier associated to the annotation to be removed
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public void removeAnnotation(long id) {
     annotationManager.removeAnnotation(id);
   }
@@ -1030,21 +1090,33 @@ public final class MapboxMap {
    * Removes multiple annotations from the map.
    *
    * @param annotationList A list of annotation objects to remove.
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public void removeAnnotations(@NonNull List<? extends Annotation> annotationList) {
     annotationManager.removeAnnotations(annotationList);
   }
 
   /**
    * Removes all annotations from the map.
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public void removeAnnotations() {
     annotationManager.removeAnnotations();
   }
 
   /**
    * Removes all markers, polylines, polygons, overlays, etc from the map.
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public void clear() {
     annotationManager.removeAnnotations();
   }
@@ -1054,7 +1126,11 @@ public final class MapboxMap {
    *
    * @param id the id used to look up an annotation
    * @return An annotation with a matched id, null is returned if no match was found
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   @Nullable
   public Annotation getAnnotation(long id) {
     return annotationManager.getAnnotation(id);
@@ -1065,7 +1141,11 @@ public final class MapboxMap {
    *
    * @return A list of all the annotation objects. The returned object is a copy so modifying this
    * list will not update the map
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   @NonNull
   public List<Annotation> getAnnotations() {
     return annotationManager.getAnnotations();
@@ -1076,7 +1156,11 @@ public final class MapboxMap {
    *
    * @return A list of all the markers objects. The returned object is a copy so modifying this
    * list will not update the map.
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   @NonNull
   public List<Marker> getMarkers() {
     return annotationManager.getMarkers();
@@ -1087,7 +1171,11 @@ public final class MapboxMap {
    *
    * @return A list of all the polygon objects. The returned object is a copy so modifying this
    * list will not update the map.
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   @NonNull
   public List<Polygon> getPolygons() {
     return annotationManager.getPolygons();
@@ -1098,7 +1186,11 @@ public final class MapboxMap {
    *
    * @return A list of all the polylines objects. The returned object is a copy so modifying this
    * list will not update the map.
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   @NonNull
   public List<Polyline> getPolylines() {
     return annotationManager.getPolylines();
@@ -1109,7 +1201,11 @@ public final class MapboxMap {
    *
    * @param listener The callback that's invoked when the user clicks on a marker.
    *                 To unset the callback, use null.
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public void setOnMarkerClickListener(@Nullable OnMarkerClickListener listener) {
     annotationManager.setOnMarkerClickListener(listener);
   }
@@ -1119,7 +1215,11 @@ public final class MapboxMap {
    *
    * @param listener The callback that's invoked when the user clicks on a polygon.
    *                 To unset the callback, use null.
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public void setOnPolygonClickListener(@Nullable OnPolygonClickListener listener) {
     annotationManager.setOnPolygonClickListener(listener);
   }
@@ -1129,7 +1229,11 @@ public final class MapboxMap {
    *
    * @param listener The callback that's invoked when the user clicks on a polyline.
    *                 To unset the callback, use null.
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public void setOnPolylineClickListener(@Nullable OnPolylineClickListener listener) {
     annotationManager.setOnPolylineClickListener(listener);
   }
@@ -1143,7 +1247,11 @@ public final class MapboxMap {
    * Selecting an already selected marker will have no effect.
    *
    * @param marker The marker to select.
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public void selectMarker(@NonNull Marker marker) {
     if (marker == null) {
       Logger.w(TAG, "marker was null, so just returning");
@@ -1154,7 +1262,11 @@ public final class MapboxMap {
 
   /**
    * Deselects any currently selected marker. All markers will have it's info window closed.
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public void deselectMarkers() {
     annotationManager.deselectMarkers();
   }
@@ -1163,7 +1275,11 @@ public final class MapboxMap {
    * Deselects a currently selected marker. The selected marker will have it's info window closed.
    *
    * @param marker the marker to deselect
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public void deselectMarker(@NonNull Marker marker) {
     annotationManager.deselectMarker(marker);
   }
@@ -1172,7 +1288,11 @@ public final class MapboxMap {
    * Gets the currently selected marker.
    *
    * @return The currently selected marker.
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   @NonNull
   public List<Marker> getSelectedMarkers() {
     return annotationManager.getSelectedMarkers();
@@ -1191,7 +1311,11 @@ public final class MapboxMap {
    *
    * @param infoWindowAdapter The callback to be invoked when an info window will be shown.
    *                          To unset the callback, use null.
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public void setInfoWindowAdapter(@Nullable InfoWindowAdapter infoWindowAdapter) {
     annotationManager.getInfoWindowManager().setInfoWindowAdapter(infoWindowAdapter);
   }
@@ -1200,7 +1324,11 @@ public final class MapboxMap {
    * Gets the callback to be invoked when an info window will be shown.
    *
    * @return The callback to be invoked when an info window will be shown.
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   @Nullable
   public InfoWindowAdapter getInfoWindowAdapter() {
     return annotationManager.getInfoWindowManager().getInfoWindowAdapter();
@@ -1210,7 +1338,11 @@ public final class MapboxMap {
    * Changes whether the map allows concurrent multiple infowindows to be shown.
    *
    * @param allow If true, map allows concurrent multiple infowindows to be shown.
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public void setAllowConcurrentMultipleOpenInfoWindows(boolean allow) {
     annotationManager.getInfoWindowManager().setAllowConcurrentMultipleOpenInfoWindows(allow);
   }
@@ -1219,7 +1351,11 @@ public final class MapboxMap {
    * Returns whether the map allows concurrent multiple infowindows to be shown.
    *
    * @return If true, map allows concurrent multiple infowindows to be shown.
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public boolean isAllowConcurrentMultipleOpenInfoWindows() {
     return annotationManager.getInfoWindowManager().isAllowConcurrentMultipleOpenInfoWindows();
   }
@@ -1247,7 +1383,7 @@ public final class MapboxMap {
    * @param latLngBounds the bounds to set the map with
    * @return the camera position that fits the bounds
    */
-  @NonNull
+  @Nullable
   public CameraPosition getCameraForLatLngBounds(@NonNull LatLngBounds latLngBounds) {
     // we use current camera tilt value to provide expected transformations as #11993
     return getCameraForLatLngBounds(latLngBounds, new int[] {0, 0, 0, 0});
@@ -1261,7 +1397,7 @@ public final class MapboxMap {
    * @param padding      the padding to apply to the bounds
    * @return the camera position that fits the bounds and padding
    */
-  @NonNull
+  @Nullable
   public CameraPosition getCameraForLatLngBounds(@NonNull LatLngBounds latLngBounds,
                                                  @NonNull @Size(value = 4) int[] padding) {
     // we use current camera tilt/bearing value to provide expected transformations as #11993
@@ -1277,7 +1413,7 @@ public final class MapboxMap {
    * @param tilt         to transform the camera position with
    * @return the camera position that fits the bounds and given bearing and tilt
    */
-  @NonNull
+  @Nullable
   public CameraPosition getCameraForLatLngBounds(@NonNull LatLngBounds latLngBounds,
                                                  @FloatRange(from = MapboxConstants.MINIMUM_DIRECTION,
                                                    to = MapboxConstants.MAXIMUM_DIRECTION) double bearing,
@@ -1296,7 +1432,7 @@ public final class MapboxMap {
    * @param tilt         to transform the camera position with
    * @return the camera position that fits the bounds, bearing and tilt
    */
-  @NonNull
+  @Nullable
   public CameraPosition getCameraForLatLngBounds(@NonNull LatLngBounds latLngBounds,
                                                  @NonNull @Size(value = 4) int[] padding,
                                                  @FloatRange(from = MapboxConstants.MINIMUM_DIRECTION,
@@ -1312,7 +1448,7 @@ public final class MapboxMap {
    * @param geometry the geometry to wraps the map with
    * @return the camera position that fits the geometry inside
    */
-  @NonNull
+  @Nullable
   public CameraPosition getCameraForGeometry(@NonNull Geometry geometry) {
     // we use current camera tilt value to provide expected transformations as #11993
     return getCameraForGeometry(geometry, new int[] {0, 0, 0, 0});
@@ -1325,7 +1461,7 @@ public final class MapboxMap {
    * @param padding  the padding to apply to the bounds
    * @return the camera position that fits the geometry inside and padding
    */
-  @NonNull
+  @Nullable
   public CameraPosition getCameraForGeometry(@NonNull Geometry geometry,
                                              @NonNull @Size(value = 4) int[] padding) {
     // we use current camera tilt/bearing value to provide expected transformations as #11993
@@ -1340,7 +1476,7 @@ public final class MapboxMap {
    * @param tilt     the tilt at which to compute the geometry's bounds
    * @return the camera position that the geometry inside with bearing and tilt
    */
-  @NonNull
+  @Nullable
   public CameraPosition getCameraForGeometry(@NonNull Geometry geometry,
                                              @FloatRange(from = MapboxConstants.MINIMUM_DIRECTION,
                                                to = MapboxConstants.MAXIMUM_DIRECTION) double bearing,
@@ -1358,7 +1494,7 @@ public final class MapboxMap {
    * @param tilt     the tilt at which to compute the geometry's bounds
    * @return the camera position that fits the geometry inside with padding, bearing and tilt
    */
-  @NonNull
+  @Nullable
   public CameraPosition getCameraForGeometry(@NonNull Geometry geometry,
                                              @NonNull @Size(value = 4) int[] padding,
                                              @FloatRange(from = MapboxConstants.MINIMUM_DIRECTION,
@@ -1366,21 +1502,6 @@ public final class MapboxMap {
                                              @FloatRange(from = MapboxConstants.MINIMUM_TILT,
                                                to = MapboxConstants.MAXIMUM_TILT) double tilt) {
     return nativeMapView.getCameraForGeometry(geometry, padding, bearing, tilt);
-  }
-
-  /**
-   * Get a camera position that fits a provided shape with a given bearing and padding.
-   *
-   * @param geometry the geometry to wraps the map with
-   * @param bearing  the bearing at which to compute the geometry's bounds
-   * @param padding  the padding to apply to the bounds
-   * @return the camera position that fits the geometry inside with padding and bearing
-   * @deprecated use Mapbox{@link #getCameraForGeometry(Geometry, int[], double, double)} instead
-   */
-  @NonNull
-  @Deprecated
-  public CameraPosition getCameraForGeometry(@NonNull Geometry geometry, double bearing, @NonNull int[] padding) {
-    return getCameraForGeometry(geometry, padding, bearing, transform.getTilt());
   }
 
   //
@@ -2055,7 +2176,11 @@ public final class MapboxMap {
    * Interface definition for a callback to be invoked when the user clicks on a marker.
    *
    * @see MapboxMap#setOnMarkerClickListener(OnMarkerClickListener)
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public interface OnMarkerClickListener {
     /**
      * Called when the user clicks on a marker.
@@ -2070,7 +2195,11 @@ public final class MapboxMap {
    * Interface definition for a callback to be invoked when the user clicks on a polygon.
    *
    * @see MapboxMap#setOnPolygonClickListener(OnPolygonClickListener)
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public interface OnPolygonClickListener {
     /**
      * Called when the user clicks on a polygon.
@@ -2084,7 +2213,11 @@ public final class MapboxMap {
    * Interface definition for a callback to be invoked when the user clicks on a polyline.
    *
    * @see MapboxMap#setOnPolylineClickListener(OnPolylineClickListener)
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public interface OnPolylineClickListener {
     /**
      * Called when the user clicks on a polyline.
@@ -2143,7 +2276,11 @@ public final class MapboxMap {
    * Interface definition for a callback to be invoked when an info window will be shown.
    *
    * @see MapboxMap#setInfoWindowAdapter(InfoWindowAdapter)
+   * @deprecated As of 7.0.0,
+   * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
+   *   Mapbox Annotation Plugin</a> instead
    */
+  @Deprecated
   public interface InfoWindowAdapter {
     /**
      * Called when an info window will be shown as a result of a marker click.

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
@@ -76,11 +76,9 @@ public class FileSource {
    *
    * @param context the context to derive the files directory path from
    * @return the files directory path
-   * @deprecated Use {@link #getResourcesCachePath(Context)} instead.
    */
-  @Nullable
-  @Deprecated
-  public static String getCachePath(@NonNull Context context) {
+  @NonNull
+  private static String getCachePath(@NonNull Context context) {
     // Default value
     boolean isExternalStorageConfiguration = MapboxConstants.DEFAULT_SET_STORAGE_EXTERNAL;
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
@@ -1219,12 +1219,6 @@ class LocationComponentTest : BaseActivityTest() {
           override fun getLastAccuracySensorStatus(): Int {
             return 0
           }
-
-          override fun onStart() {
-          }
-
-          override fun onStop() {
-          }
         }
 
         component.compassEngine = engine

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/TransformTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/TransformTest.kt
@@ -6,7 +6,6 @@ import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke
 import com.mapbox.mapboxsdk.testapp.activity.BaseActivityTest
 import com.mapbox.mapboxsdk.testapp.activity.maplayout.SimpleMapActivity
-import com.mapbox.mapboxsdk.testapp.utils.TestConstants
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -17,34 +16,6 @@ class TransformTest: BaseActivityTest() {
 
     companion object {
         val initialCameraUpdate = CameraUpdateFactory.newLatLngZoom(LatLng(12.0,12.0), 12.0)!!
-        val scrollByCameraUpdate = CameraUpdateFactory.scrollBy(400.0f,0.0f)!!
-    }
-
-    @Test
-    fun cameraUpdateScrollByWithPadding() {
-        validateTestSetup()
-        invoke(mapboxMap) { uiController: UiController, mapboxMap: MapboxMap ->
-            mapboxMap.moveCamera(initialCameraUpdate)
-            mapboxMap.moveCamera(scrollByCameraUpdate)
-            val expectedCameraPosition = mapboxMap.cameraPosition
-
-            mapboxMap.moveCamera(initialCameraUpdate)
-            mapboxMap.setPadding(250,250,0,0)
-            mapboxMap.moveCamera(scrollByCameraUpdate)
-            val actualCameraPosition = mapboxMap.cameraPosition
-
-            assertEquals("Camera position latitude should match",
-                    expectedCameraPosition.target.latitude,
-                    actualCameraPosition.target.longitude,
-                    TestConstants.LAT_LNG_DELTA
-            )
-
-            assertEquals("Camera position longitude should match",
-                    expectedCameraPosition.target.longitude,
-                    actualCameraPosition.target.longitude,
-                    TestConstants.LAT_LNG_DELTA
-            )
-        }
     }
 
     @Test
@@ -63,5 +34,4 @@ class TransformTest: BaseActivityTest() {
             assertEquals("Camera position should match", expectedCameraPosition, actualCameraPosition)
         }
     }
-
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraAnimateTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraAnimateTest.java
@@ -1,6 +1,5 @@
 package com.mapbox.mapboxsdk.testapp.camera;
 
-import android.graphics.PointF;
 import android.support.test.espresso.Espresso;
 import android.support.test.espresso.IdlingRegistry;
 import android.support.test.espresso.idling.CountingIdlingResource;
@@ -153,35 +152,6 @@ public class CameraAnimateTest extends BaseActivityTest {
           animationIdlingResource.decrement();
         }
       });
-    });
-
-    Espresso.onIdle();
-  }
-
-  @Test
-  public void testAnimateToMoveBy() {
-    validateTestSetup();
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      final PointF centerPoint = mapboxMap.getProjection().toScreenLocation(mapboxMap.getCameraPosition().target);
-      final LatLng moveTarget = new LatLng(2, 2);
-      final PointF moveTargetPoint = mapboxMap.getProjection().toScreenLocation(moveTarget);
-
-      animationIdlingResource.increment();
-      mapboxMap.animateCamera(
-        CameraUpdateFactory.scrollBy(moveTargetPoint.x - centerPoint.x, moveTargetPoint.y - centerPoint.y),
-        new MapboxMap.CancelableCallback() {
-          @Override
-          public void onCancel() {
-            verifyCameraPosition(mapboxMap, moveTarget, mapboxMap.getCameraPosition().zoom, 0, 0);
-            animationIdlingResource.decrement();
-          }
-
-          @Override
-          public void onFinish() {
-            verifyCameraPosition(mapboxMap, moveTarget, mapboxMap.getCameraPosition().zoom, 0, 0);
-            animationIdlingResource.decrement();
-          }
-        });
     });
 
     Espresso.onIdle();

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraEaseTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraEaseTest.java
@@ -1,6 +1,5 @@
 package com.mapbox.mapboxsdk.testapp.camera;
 
-import android.graphics.PointF;
 import android.support.test.espresso.Espresso;
 import android.support.test.espresso.IdlingRegistry;
 import android.support.test.espresso.idling.CountingIdlingResource;
@@ -150,35 +149,6 @@ public class CameraEaseTest extends BaseActivityTest {
           @Override
           public void onFinish() {
             verifyCameraPosition(mapboxMap, centerBounds, mapboxMap.getCameraPosition().zoom, 0, 0);
-            animationIdlingResource.decrement();
-          }
-        });
-    });
-
-    Espresso.onIdle();
-  }
-
-  @Test
-  public void testEaseToMoveBy() {
-    validateTestSetup();
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      final PointF centerPoint = mapboxMap.getProjection().toScreenLocation(mapboxMap.getCameraPosition().target);
-      final LatLng moveTarget = new LatLng(2, 2);
-      final PointF moveTargetPoint = mapboxMap.getProjection().toScreenLocation(moveTarget);
-
-      animationIdlingResource.increment();
-      mapboxMap.easeCamera(CameraUpdateFactory.scrollBy(
-        moveTargetPoint.x - centerPoint.x, moveTargetPoint.y - centerPoint.y),
-        new MapboxMap.CancelableCallback() {
-          @Override
-          public void onCancel() {
-            verifyCameraPosition(mapboxMap, moveTarget, mapboxMap.getCameraPosition().zoom, 0, 0);
-            animationIdlingResource.decrement();
-          }
-
-          @Override
-          public void onFinish() {
-            verifyCameraPosition(mapboxMap, moveTarget, mapboxMap.getCameraPosition().zoom, 0, 0);
             animationIdlingResource.decrement();
           }
         });

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraForTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraForTest.java
@@ -244,8 +244,10 @@ public class CameraForTest extends BaseActivityTest {
     validateTestSetup();
     onMapView().perform(getMapboxMapAction((uiController, mapboxMap) -> {
       List<List<Point>> polygonDefinition = getPolygonDefinition();
-      CameraPosition actualPosition = mapboxMap.getCameraForGeometry(Polygon.fromLngLats(polygonDefinition), 45,
-        new int[] {5, 5, 5, 5});
+      CameraPosition actualPosition = mapboxMap.getCameraForGeometry(
+        Polygon.fromLngLats(polygonDefinition),
+        new int[] {5, 5, 5, 5},
+        45, 0);
       CameraPosition expectedPosition = new CameraPosition.Builder()
         .target(new LatLng()).zoom(3.63).tilt(0).bearing(45).build();
       assertEquals("Latitude should match",

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraMoveTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraMoveTest.java
@@ -1,7 +1,6 @@
 
 package com.mapbox.mapboxsdk.testapp.camera;
 
-import android.graphics.PointF;
 import android.support.test.espresso.Espresso;
 import android.support.test.espresso.IdlingRegistry;
 import android.support.test.espresso.idling.CountingIdlingResource;
@@ -150,35 +149,6 @@ public class CameraMoveTest extends BaseActivityTest {
           @Override
           public void onFinish() {
             verifyCameraPosition(mapboxMap, centerBounds, mapboxMap.getCameraPosition().zoom, 0, 0);
-            animationIdlingResource.decrement();
-          }
-        });
-    });
-
-    Espresso.onIdle();
-  }
-
-  @Test
-  public void testMoveToMoveBy() {
-    validateTestSetup();
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      final PointF centerPoint = mapboxMap.getProjection().toScreenLocation(mapboxMap.getCameraPosition().target);
-      final LatLng moveTarget = new LatLng(2, 2);
-      final PointF moveTargetPoint = mapboxMap.getProjection().toScreenLocation(moveTarget);
-
-      animationIdlingResource.increment();
-      mapboxMap.moveCamera(CameraUpdateFactory.scrollBy(
-        moveTargetPoint.x - centerPoint.x, moveTargetPoint.y - centerPoint.y),
-        new MapboxMap.CancelableCallback() {
-          @Override
-          public void onCancel() {
-            verifyCameraPosition(mapboxMap, moveTarget, mapboxMap.getCameraPosition().zoom, 0, 0);
-            animationIdlingResource.decrement();
-          }
-
-          @Override
-          public void onFinish() {
-            verifyCameraPosition(mapboxMap, moveTarget, mapboxMap.getCameraPosition().zoom, 0, 0);
             animationIdlingResource.decrement();
           }
         });

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/ScrollByActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/ScrollByActivity.java
@@ -11,7 +11,7 @@ import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
 import android.widget.SeekBar;
 import android.widget.TextView;
-import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
+
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
@@ -69,10 +69,10 @@ public class ScrollByActivity extends AppCompatActivity implements OnMapReadyCal
     uiSettings.setAttributionEnabled(false);
     FloatingActionButton fab = findViewById(R.id.fab);
     fab.setColorFilter(ContextCompat.getColor(ScrollByActivity.this, R.color.primary));
-    fab.setOnClickListener(view -> mapboxMap.easeCamera(
-      CameraUpdateFactory.scrollBy(seekBarX.getProgress() * MULTIPLIER_PER_PIXEL,
+    fab.setOnClickListener(view -> mapboxMap.scrollBy(
+      seekBarX.getProgress() * MULTIPLIER_PER_PIXEL,
       seekBarY.getProgress() * MULTIPLIER_PER_PIXEL)
-    ));
+    );
   }
 
   @Override


### PR DESCRIPTION
Removes remaining deprecated methods and deprecates annotation related methods found in the `MapboxMap`.