### PR TITLE
Use eternal map in style:Layer implementations

### DIFF
--- a/src/mbgl/style/layers/background_layer.cpp
+++ b/src/mbgl/style/layers/background_layer.cpp
@@ -9,7 +9,8 @@
 #include <mbgl/style/conversion/transition_options.hpp>
 #include <mbgl/style/conversion/json.hpp>
 #include <mbgl/style/conversion_impl.hpp>
-#include <mbgl/util/fnv_hash.hpp>
+
+#include <mapbox/eternal.hpp>
 
 namespace mbgl {
 namespace style {
@@ -145,8 +146,7 @@ TransitionOptions BackgroundLayer::getBackgroundOpacityTransition() const {
 using namespace conversion;
 
 optional<Error> BackgroundLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-        Unknown,
+    enum class Property : uint8_t {
         BackgroundColor,
         BackgroundPattern,
         BackgroundOpacity,
@@ -155,44 +155,21 @@ optional<Error> BackgroundLayer::setPaintProperty(const std::string& name, const
         BackgroundOpacityTransition,
     };
 
-    Property property = Property::Unknown;
-    switch (util::hashFNV1a(name.c_str())) {
-    case util::hashFNV1a("background-color"):
-        if (name == "background-color") {
-            property = Property::BackgroundColor;
-        }
-        break;
-    case util::hashFNV1a("background-color-transition"):
-        if (name == "background-color-transition") {
-            property = Property::BackgroundColorTransition;
-        }
-        break;
-    case util::hashFNV1a("background-pattern"):
-        if (name == "background-pattern") {
-            property = Property::BackgroundPattern;
-        }
-        break;
-    case util::hashFNV1a("background-pattern-transition"):
-        if (name == "background-pattern-transition") {
-            property = Property::BackgroundPatternTransition;
-        }
-        break;
-    case util::hashFNV1a("background-opacity"):
-        if (name == "background-opacity") {
-            property = Property::BackgroundOpacity;
-        }
-        break;
-    case util::hashFNV1a("background-opacity-transition"):
-        if (name == "background-opacity-transition") {
-            property = Property::BackgroundOpacityTransition;
-        }
-        break;
-    
-    }
+    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
+        { "background-color", static_cast<uint8_t>(Property::BackgroundColor) },
+        { "background-pattern", static_cast<uint8_t>(Property::BackgroundPattern) },
+        { "background-opacity", static_cast<uint8_t>(Property::BackgroundOpacity) },
+        { "background-color-transition", static_cast<uint8_t>(Property::BackgroundColorTransition) },
+        { "background-pattern-transition", static_cast<uint8_t>(Property::BackgroundPatternTransition) },
+        { "background-opacity-transition", static_cast<uint8_t>(Property::BackgroundOpacityTransition) }
+    });
 
-    if (property == Property::Unknown) {
+    const auto it = properties.find(name.c_str());
+    if (it == properties.end()) {
         return Error { "layer doesn't support this property" };
     }
+
+    Property property = static_cast<Property>(it->second);
 
         
     if (property == Property::BackgroundColor) {
@@ -261,21 +238,6 @@ optional<Error> BackgroundLayer::setLayoutProperty(const std::string& name, cons
     if (name == "visibility") {
         return Layer::setVisibility(value);
     }
-
-    enum class Property {
-        Unknown,
-    };
-
-    Property property = Property::Unknown;
-    switch (util::hashFNV1a(name.c_str())) {
-    
-    }
-
-    if (property == Property::Unknown) {
-        return Error { "layer doesn't support this property" };
-    }
-
-        
 
     return Error { "layer doesn't support this property" };
 }

--- a/src/mbgl/style/layers/circle_layer.cpp
+++ b/src/mbgl/style/layers/circle_layer.cpp
@@ -9,7 +9,8 @@
 #include <mbgl/style/conversion/transition_options.hpp>
 #include <mbgl/style/conversion/json.hpp>
 #include <mbgl/style/conversion_impl.hpp>
-#include <mbgl/util/fnv_hash.hpp>
+
+#include <mapbox/eternal.hpp>
 
 namespace mbgl {
 namespace style {
@@ -361,8 +362,7 @@ TransitionOptions CircleLayer::getCircleStrokeOpacityTransition() const {
 using namespace conversion;
 
 optional<Error> CircleLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-        Unknown,
+    enum class Property : uint8_t {
         CircleRadius,
         CircleColor,
         CircleBlur,
@@ -387,124 +387,37 @@ optional<Error> CircleLayer::setPaintProperty(const std::string& name, const Con
         CircleStrokeOpacityTransition,
     };
 
-    Property property = Property::Unknown;
-    switch (util::hashFNV1a(name.c_str())) {
-    case util::hashFNV1a("circle-radius"):
-        if (name == "circle-radius") {
-            property = Property::CircleRadius;
-        }
-        break;
-    case util::hashFNV1a("circle-radius-transition"):
-        if (name == "circle-radius-transition") {
-            property = Property::CircleRadiusTransition;
-        }
-        break;
-    case util::hashFNV1a("circle-color"):
-        if (name == "circle-color") {
-            property = Property::CircleColor;
-        }
-        break;
-    case util::hashFNV1a("circle-color-transition"):
-        if (name == "circle-color-transition") {
-            property = Property::CircleColorTransition;
-        }
-        break;
-    case util::hashFNV1a("circle-blur"):
-        if (name == "circle-blur") {
-            property = Property::CircleBlur;
-        }
-        break;
-    case util::hashFNV1a("circle-blur-transition"):
-        if (name == "circle-blur-transition") {
-            property = Property::CircleBlurTransition;
-        }
-        break;
-    case util::hashFNV1a("circle-opacity"):
-        if (name == "circle-opacity") {
-            property = Property::CircleOpacity;
-        }
-        break;
-    case util::hashFNV1a("circle-opacity-transition"):
-        if (name == "circle-opacity-transition") {
-            property = Property::CircleOpacityTransition;
-        }
-        break;
-    case util::hashFNV1a("circle-translate"):
-        if (name == "circle-translate") {
-            property = Property::CircleTranslate;
-        }
-        break;
-    case util::hashFNV1a("circle-translate-transition"):
-        if (name == "circle-translate-transition") {
-            property = Property::CircleTranslateTransition;
-        }
-        break;
-    case util::hashFNV1a("circle-translate-anchor"):
-        if (name == "circle-translate-anchor") {
-            property = Property::CircleTranslateAnchor;
-        }
-        break;
-    case util::hashFNV1a("circle-translate-anchor-transition"):
-        if (name == "circle-translate-anchor-transition") {
-            property = Property::CircleTranslateAnchorTransition;
-        }
-        break;
-    case util::hashFNV1a("circle-pitch-scale"):
-        if (name == "circle-pitch-scale") {
-            property = Property::CirclePitchScale;
-        }
-        break;
-    case util::hashFNV1a("circle-pitch-scale-transition"):
-        if (name == "circle-pitch-scale-transition") {
-            property = Property::CirclePitchScaleTransition;
-        }
-        break;
-    case util::hashFNV1a("circle-pitch-alignment"):
-        if (name == "circle-pitch-alignment") {
-            property = Property::CirclePitchAlignment;
-        }
-        break;
-    case util::hashFNV1a("circle-pitch-alignment-transition"):
-        if (name == "circle-pitch-alignment-transition") {
-            property = Property::CirclePitchAlignmentTransition;
-        }
-        break;
-    case util::hashFNV1a("circle-stroke-width"):
-        if (name == "circle-stroke-width") {
-            property = Property::CircleStrokeWidth;
-        }
-        break;
-    case util::hashFNV1a("circle-stroke-width-transition"):
-        if (name == "circle-stroke-width-transition") {
-            property = Property::CircleStrokeWidthTransition;
-        }
-        break;
-    case util::hashFNV1a("circle-stroke-color"):
-        if (name == "circle-stroke-color") {
-            property = Property::CircleStrokeColor;
-        }
-        break;
-    case util::hashFNV1a("circle-stroke-color-transition"):
-        if (name == "circle-stroke-color-transition") {
-            property = Property::CircleStrokeColorTransition;
-        }
-        break;
-    case util::hashFNV1a("circle-stroke-opacity"):
-        if (name == "circle-stroke-opacity") {
-            property = Property::CircleStrokeOpacity;
-        }
-        break;
-    case util::hashFNV1a("circle-stroke-opacity-transition"):
-        if (name == "circle-stroke-opacity-transition") {
-            property = Property::CircleStrokeOpacityTransition;
-        }
-        break;
-    
-    }
+    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
+        { "circle-radius", static_cast<uint8_t>(Property::CircleRadius) },
+        { "circle-color", static_cast<uint8_t>(Property::CircleColor) },
+        { "circle-blur", static_cast<uint8_t>(Property::CircleBlur) },
+        { "circle-opacity", static_cast<uint8_t>(Property::CircleOpacity) },
+        { "circle-translate", static_cast<uint8_t>(Property::CircleTranslate) },
+        { "circle-translate-anchor", static_cast<uint8_t>(Property::CircleTranslateAnchor) },
+        { "circle-pitch-scale", static_cast<uint8_t>(Property::CirclePitchScale) },
+        { "circle-pitch-alignment", static_cast<uint8_t>(Property::CirclePitchAlignment) },
+        { "circle-stroke-width", static_cast<uint8_t>(Property::CircleStrokeWidth) },
+        { "circle-stroke-color", static_cast<uint8_t>(Property::CircleStrokeColor) },
+        { "circle-stroke-opacity", static_cast<uint8_t>(Property::CircleStrokeOpacity) },
+        { "circle-radius-transition", static_cast<uint8_t>(Property::CircleRadiusTransition) },
+        { "circle-color-transition", static_cast<uint8_t>(Property::CircleColorTransition) },
+        { "circle-blur-transition", static_cast<uint8_t>(Property::CircleBlurTransition) },
+        { "circle-opacity-transition", static_cast<uint8_t>(Property::CircleOpacityTransition) },
+        { "circle-translate-transition", static_cast<uint8_t>(Property::CircleTranslateTransition) },
+        { "circle-translate-anchor-transition", static_cast<uint8_t>(Property::CircleTranslateAnchorTransition) },
+        { "circle-pitch-scale-transition", static_cast<uint8_t>(Property::CirclePitchScaleTransition) },
+        { "circle-pitch-alignment-transition", static_cast<uint8_t>(Property::CirclePitchAlignmentTransition) },
+        { "circle-stroke-width-transition", static_cast<uint8_t>(Property::CircleStrokeWidthTransition) },
+        { "circle-stroke-color-transition", static_cast<uint8_t>(Property::CircleStrokeColorTransition) },
+        { "circle-stroke-opacity-transition", static_cast<uint8_t>(Property::CircleStrokeOpacityTransition) }
+    });
 
-    if (property == Property::Unknown) {
+    const auto it = properties.find(name.c_str());
+    if (it == properties.end()) {
         return Error { "layer doesn't support this property" };
     }
+
+    Property property = static_cast<Property>(it->second);
 
         
     if (property == Property::CircleRadius || property == Property::CircleBlur || property == Property::CircleOpacity || property == Property::CircleStrokeWidth || property == Property::CircleStrokeOpacity) {
@@ -678,21 +591,6 @@ optional<Error> CircleLayer::setLayoutProperty(const std::string& name, const Co
     if (name == "visibility") {
         return Layer::setVisibility(value);
     }
-
-    enum class Property {
-        Unknown,
-    };
-
-    Property property = Property::Unknown;
-    switch (util::hashFNV1a(name.c_str())) {
-    
-    }
-
-    if (property == Property::Unknown) {
-        return Error { "layer doesn't support this property" };
-    }
-
-        
 
     return Error { "layer doesn't support this property" };
 }

--- a/src/mbgl/style/layers/fill_extrusion_layer.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer.cpp
@@ -9,7 +9,8 @@
 #include <mbgl/style/conversion/transition_options.hpp>
 #include <mbgl/style/conversion/json.hpp>
 #include <mbgl/style/conversion_impl.hpp>
-#include <mbgl/util/fnv_hash.hpp>
+
+#include <mapbox/eternal.hpp>
 
 namespace mbgl {
 namespace style {
@@ -280,8 +281,7 @@ TransitionOptions FillExtrusionLayer::getFillExtrusionVerticalGradientTransition
 using namespace conversion;
 
 optional<Error> FillExtrusionLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-        Unknown,
+    enum class Property : uint8_t {
         FillExtrusionOpacity,
         FillExtrusionColor,
         FillExtrusionTranslate,
@@ -300,94 +300,31 @@ optional<Error> FillExtrusionLayer::setPaintProperty(const std::string& name, co
         FillExtrusionVerticalGradientTransition,
     };
 
-    Property property = Property::Unknown;
-    switch (util::hashFNV1a(name.c_str())) {
-    case util::hashFNV1a("fill-extrusion-opacity"):
-        if (name == "fill-extrusion-opacity") {
-            property = Property::FillExtrusionOpacity;
-        }
-        break;
-    case util::hashFNV1a("fill-extrusion-opacity-transition"):
-        if (name == "fill-extrusion-opacity-transition") {
-            property = Property::FillExtrusionOpacityTransition;
-        }
-        break;
-    case util::hashFNV1a("fill-extrusion-color"):
-        if (name == "fill-extrusion-color") {
-            property = Property::FillExtrusionColor;
-        }
-        break;
-    case util::hashFNV1a("fill-extrusion-color-transition"):
-        if (name == "fill-extrusion-color-transition") {
-            property = Property::FillExtrusionColorTransition;
-        }
-        break;
-    case util::hashFNV1a("fill-extrusion-translate"):
-        if (name == "fill-extrusion-translate") {
-            property = Property::FillExtrusionTranslate;
-        }
-        break;
-    case util::hashFNV1a("fill-extrusion-translate-transition"):
-        if (name == "fill-extrusion-translate-transition") {
-            property = Property::FillExtrusionTranslateTransition;
-        }
-        break;
-    case util::hashFNV1a("fill-extrusion-translate-anchor"):
-        if (name == "fill-extrusion-translate-anchor") {
-            property = Property::FillExtrusionTranslateAnchor;
-        }
-        break;
-    case util::hashFNV1a("fill-extrusion-translate-anchor-transition"):
-        if (name == "fill-extrusion-translate-anchor-transition") {
-            property = Property::FillExtrusionTranslateAnchorTransition;
-        }
-        break;
-    case util::hashFNV1a("fill-extrusion-pattern"):
-        if (name == "fill-extrusion-pattern") {
-            property = Property::FillExtrusionPattern;
-        }
-        break;
-    case util::hashFNV1a("fill-extrusion-pattern-transition"):
-        if (name == "fill-extrusion-pattern-transition") {
-            property = Property::FillExtrusionPatternTransition;
-        }
-        break;
-    case util::hashFNV1a("fill-extrusion-height"):
-        if (name == "fill-extrusion-height") {
-            property = Property::FillExtrusionHeight;
-        }
-        break;
-    case util::hashFNV1a("fill-extrusion-height-transition"):
-        if (name == "fill-extrusion-height-transition") {
-            property = Property::FillExtrusionHeightTransition;
-        }
-        break;
-    case util::hashFNV1a("fill-extrusion-base"):
-        if (name == "fill-extrusion-base") {
-            property = Property::FillExtrusionBase;
-        }
-        break;
-    case util::hashFNV1a("fill-extrusion-base-transition"):
-        if (name == "fill-extrusion-base-transition") {
-            property = Property::FillExtrusionBaseTransition;
-        }
-        break;
-    case util::hashFNV1a("fill-extrusion-vertical-gradient"):
-        if (name == "fill-extrusion-vertical-gradient") {
-            property = Property::FillExtrusionVerticalGradient;
-        }
-        break;
-    case util::hashFNV1a("fill-extrusion-vertical-gradient-transition"):
-        if (name == "fill-extrusion-vertical-gradient-transition") {
-            property = Property::FillExtrusionVerticalGradientTransition;
-        }
-        break;
-    
-    }
+    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
+        { "fill-extrusion-opacity", static_cast<uint8_t>(Property::FillExtrusionOpacity) },
+        { "fill-extrusion-color", static_cast<uint8_t>(Property::FillExtrusionColor) },
+        { "fill-extrusion-translate", static_cast<uint8_t>(Property::FillExtrusionTranslate) },
+        { "fill-extrusion-translate-anchor", static_cast<uint8_t>(Property::FillExtrusionTranslateAnchor) },
+        { "fill-extrusion-pattern", static_cast<uint8_t>(Property::FillExtrusionPattern) },
+        { "fill-extrusion-height", static_cast<uint8_t>(Property::FillExtrusionHeight) },
+        { "fill-extrusion-base", static_cast<uint8_t>(Property::FillExtrusionBase) },
+        { "fill-extrusion-vertical-gradient", static_cast<uint8_t>(Property::FillExtrusionVerticalGradient) },
+        { "fill-extrusion-opacity-transition", static_cast<uint8_t>(Property::FillExtrusionOpacityTransition) },
+        { "fill-extrusion-color-transition", static_cast<uint8_t>(Property::FillExtrusionColorTransition) },
+        { "fill-extrusion-translate-transition", static_cast<uint8_t>(Property::FillExtrusionTranslateTransition) },
+        { "fill-extrusion-translate-anchor-transition", static_cast<uint8_t>(Property::FillExtrusionTranslateAnchorTransition) },
+        { "fill-extrusion-pattern-transition", static_cast<uint8_t>(Property::FillExtrusionPatternTransition) },
+        { "fill-extrusion-height-transition", static_cast<uint8_t>(Property::FillExtrusionHeightTransition) },
+        { "fill-extrusion-base-transition", static_cast<uint8_t>(Property::FillExtrusionBaseTransition) },
+        { "fill-extrusion-vertical-gradient-transition", static_cast<uint8_t>(Property::FillExtrusionVerticalGradientTransition) }
+    });
 
-    if (property == Property::Unknown) {
+    const auto it = properties.find(name.c_str());
+    if (it == properties.end()) {
         return Error { "layer doesn't support this property" };
     }
+
+    Property property = static_cast<Property>(it->second);
 
         
     if (property == Property::FillExtrusionOpacity) {
@@ -536,21 +473,6 @@ optional<Error> FillExtrusionLayer::setLayoutProperty(const std::string& name, c
     if (name == "visibility") {
         return Layer::setVisibility(value);
     }
-
-    enum class Property {
-        Unknown,
-    };
-
-    Property property = Property::Unknown;
-    switch (util::hashFNV1a(name.c_str())) {
-    
-    }
-
-    if (property == Property::Unknown) {
-        return Error { "layer doesn't support this property" };
-    }
-
-        
 
     return Error { "layer doesn't support this property" };
 }

--- a/src/mbgl/style/layers/fill_layer.cpp
+++ b/src/mbgl/style/layers/fill_layer.cpp
@@ -9,7 +9,8 @@
 #include <mbgl/style/conversion/transition_options.hpp>
 #include <mbgl/style/conversion/json.hpp>
 #include <mbgl/style/conversion_impl.hpp>
-#include <mbgl/util/fnv_hash.hpp>
+
+#include <mapbox/eternal.hpp>
 
 namespace mbgl {
 namespace style {
@@ -253,8 +254,7 @@ TransitionOptions FillLayer::getFillPatternTransition() const {
 using namespace conversion;
 
 optional<Error> FillLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-        Unknown,
+    enum class Property : uint8_t {
         FillAntialias,
         FillOpacity,
         FillColor,
@@ -271,84 +271,29 @@ optional<Error> FillLayer::setPaintProperty(const std::string& name, const Conve
         FillPatternTransition,
     };
 
-    Property property = Property::Unknown;
-    switch (util::hashFNV1a(name.c_str())) {
-    case util::hashFNV1a("fill-antialias"):
-        if (name == "fill-antialias") {
-            property = Property::FillAntialias;
-        }
-        break;
-    case util::hashFNV1a("fill-antialias-transition"):
-        if (name == "fill-antialias-transition") {
-            property = Property::FillAntialiasTransition;
-        }
-        break;
-    case util::hashFNV1a("fill-opacity"):
-        if (name == "fill-opacity") {
-            property = Property::FillOpacity;
-        }
-        break;
-    case util::hashFNV1a("fill-opacity-transition"):
-        if (name == "fill-opacity-transition") {
-            property = Property::FillOpacityTransition;
-        }
-        break;
-    case util::hashFNV1a("fill-color"):
-        if (name == "fill-color") {
-            property = Property::FillColor;
-        }
-        break;
-    case util::hashFNV1a("fill-color-transition"):
-        if (name == "fill-color-transition") {
-            property = Property::FillColorTransition;
-        }
-        break;
-    case util::hashFNV1a("fill-outline-color"):
-        if (name == "fill-outline-color") {
-            property = Property::FillOutlineColor;
-        }
-        break;
-    case util::hashFNV1a("fill-outline-color-transition"):
-        if (name == "fill-outline-color-transition") {
-            property = Property::FillOutlineColorTransition;
-        }
-        break;
-    case util::hashFNV1a("fill-translate"):
-        if (name == "fill-translate") {
-            property = Property::FillTranslate;
-        }
-        break;
-    case util::hashFNV1a("fill-translate-transition"):
-        if (name == "fill-translate-transition") {
-            property = Property::FillTranslateTransition;
-        }
-        break;
-    case util::hashFNV1a("fill-translate-anchor"):
-        if (name == "fill-translate-anchor") {
-            property = Property::FillTranslateAnchor;
-        }
-        break;
-    case util::hashFNV1a("fill-translate-anchor-transition"):
-        if (name == "fill-translate-anchor-transition") {
-            property = Property::FillTranslateAnchorTransition;
-        }
-        break;
-    case util::hashFNV1a("fill-pattern"):
-        if (name == "fill-pattern") {
-            property = Property::FillPattern;
-        }
-        break;
-    case util::hashFNV1a("fill-pattern-transition"):
-        if (name == "fill-pattern-transition") {
-            property = Property::FillPatternTransition;
-        }
-        break;
-    
-    }
+    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
+        { "fill-antialias", static_cast<uint8_t>(Property::FillAntialias) },
+        { "fill-opacity", static_cast<uint8_t>(Property::FillOpacity) },
+        { "fill-color", static_cast<uint8_t>(Property::FillColor) },
+        { "fill-outline-color", static_cast<uint8_t>(Property::FillOutlineColor) },
+        { "fill-translate", static_cast<uint8_t>(Property::FillTranslate) },
+        { "fill-translate-anchor", static_cast<uint8_t>(Property::FillTranslateAnchor) },
+        { "fill-pattern", static_cast<uint8_t>(Property::FillPattern) },
+        { "fill-antialias-transition", static_cast<uint8_t>(Property::FillAntialiasTransition) },
+        { "fill-opacity-transition", static_cast<uint8_t>(Property::FillOpacityTransition) },
+        { "fill-color-transition", static_cast<uint8_t>(Property::FillColorTransition) },
+        { "fill-outline-color-transition", static_cast<uint8_t>(Property::FillOutlineColorTransition) },
+        { "fill-translate-transition", static_cast<uint8_t>(Property::FillTranslateTransition) },
+        { "fill-translate-anchor-transition", static_cast<uint8_t>(Property::FillTranslateAnchorTransition) },
+        { "fill-pattern-transition", static_cast<uint8_t>(Property::FillPatternTransition) }
+    });
 
-    if (property == Property::Unknown) {
+    const auto it = properties.find(name.c_str());
+    if (it == properties.end()) {
         return Error { "layer doesn't support this property" };
     }
+
+    Property property = static_cast<Property>(it->second);
 
         
     if (property == Property::FillAntialias) {
@@ -480,21 +425,6 @@ optional<Error> FillLayer::setLayoutProperty(const std::string& name, const Conv
     if (name == "visibility") {
         return Layer::setVisibility(value);
     }
-
-    enum class Property {
-        Unknown,
-    };
-
-    Property property = Property::Unknown;
-    switch (util::hashFNV1a(name.c_str())) {
-    
-    }
-
-    if (property == Property::Unknown) {
-        return Error { "layer doesn't support this property" };
-    }
-
-        
 
     return Error { "layer doesn't support this property" };
 }

--- a/src/mbgl/style/layers/heatmap_layer.cpp
+++ b/src/mbgl/style/layers/heatmap_layer.cpp
@@ -9,7 +9,8 @@
 #include <mbgl/style/conversion/transition_options.hpp>
 #include <mbgl/style/conversion/json.hpp>
 #include <mbgl/style/conversion_impl.hpp>
-#include <mbgl/util/fnv_hash.hpp>
+
+#include <mapbox/eternal.hpp>
 
 namespace mbgl {
 namespace style {
@@ -201,8 +202,7 @@ TransitionOptions HeatmapLayer::getHeatmapOpacityTransition() const {
 using namespace conversion;
 
 optional<Error> HeatmapLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-        Unknown,
+    enum class Property : uint8_t {
         HeatmapRadius,
         HeatmapWeight,
         HeatmapIntensity,
@@ -215,64 +215,25 @@ optional<Error> HeatmapLayer::setPaintProperty(const std::string& name, const Co
         HeatmapOpacityTransition,
     };
 
-    Property property = Property::Unknown;
-    switch (util::hashFNV1a(name.c_str())) {
-    case util::hashFNV1a("heatmap-radius"):
-        if (name == "heatmap-radius") {
-            property = Property::HeatmapRadius;
-        }
-        break;
-    case util::hashFNV1a("heatmap-radius-transition"):
-        if (name == "heatmap-radius-transition") {
-            property = Property::HeatmapRadiusTransition;
-        }
-        break;
-    case util::hashFNV1a("heatmap-weight"):
-        if (name == "heatmap-weight") {
-            property = Property::HeatmapWeight;
-        }
-        break;
-    case util::hashFNV1a("heatmap-weight-transition"):
-        if (name == "heatmap-weight-transition") {
-            property = Property::HeatmapWeightTransition;
-        }
-        break;
-    case util::hashFNV1a("heatmap-intensity"):
-        if (name == "heatmap-intensity") {
-            property = Property::HeatmapIntensity;
-        }
-        break;
-    case util::hashFNV1a("heatmap-intensity-transition"):
-        if (name == "heatmap-intensity-transition") {
-            property = Property::HeatmapIntensityTransition;
-        }
-        break;
-    case util::hashFNV1a("heatmap-color"):
-        if (name == "heatmap-color") {
-            property = Property::HeatmapColor;
-        }
-        break;
-    case util::hashFNV1a("heatmap-color-transition"):
-        if (name == "heatmap-color-transition") {
-            property = Property::HeatmapColorTransition;
-        }
-        break;
-    case util::hashFNV1a("heatmap-opacity"):
-        if (name == "heatmap-opacity") {
-            property = Property::HeatmapOpacity;
-        }
-        break;
-    case util::hashFNV1a("heatmap-opacity-transition"):
-        if (name == "heatmap-opacity-transition") {
-            property = Property::HeatmapOpacityTransition;
-        }
-        break;
-    
-    }
+    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
+        { "heatmap-radius", static_cast<uint8_t>(Property::HeatmapRadius) },
+        { "heatmap-weight", static_cast<uint8_t>(Property::HeatmapWeight) },
+        { "heatmap-intensity", static_cast<uint8_t>(Property::HeatmapIntensity) },
+        { "heatmap-color", static_cast<uint8_t>(Property::HeatmapColor) },
+        { "heatmap-opacity", static_cast<uint8_t>(Property::HeatmapOpacity) },
+        { "heatmap-radius-transition", static_cast<uint8_t>(Property::HeatmapRadiusTransition) },
+        { "heatmap-weight-transition", static_cast<uint8_t>(Property::HeatmapWeightTransition) },
+        { "heatmap-intensity-transition", static_cast<uint8_t>(Property::HeatmapIntensityTransition) },
+        { "heatmap-color-transition", static_cast<uint8_t>(Property::HeatmapColorTransition) },
+        { "heatmap-opacity-transition", static_cast<uint8_t>(Property::HeatmapOpacityTransition) }
+    });
 
-    if (property == Property::Unknown) {
+    const auto it = properties.find(name.c_str());
+    if (it == properties.end()) {
         return Error { "layer doesn't support this property" };
     }
+
+    Property property = static_cast<Property>(it->second);
 
         
     if (property == Property::HeatmapRadius || property == Property::HeatmapWeight) {
@@ -365,21 +326,6 @@ optional<Error> HeatmapLayer::setLayoutProperty(const std::string& name, const C
     if (name == "visibility") {
         return Layer::setVisibility(value);
     }
-
-    enum class Property {
-        Unknown,
-    };
-
-    Property property = Property::Unknown;
-    switch (util::hashFNV1a(name.c_str())) {
-    
-    }
-
-    if (property == Property::Unknown) {
-        return Error { "layer doesn't support this property" };
-    }
-
-        
 
     return Error { "layer doesn't support this property" };
 }

--- a/src/mbgl/style/layers/hillshade_layer.cpp
+++ b/src/mbgl/style/layers/hillshade_layer.cpp
@@ -9,7 +9,8 @@
 #include <mbgl/style/conversion/transition_options.hpp>
 #include <mbgl/style/conversion/json.hpp>
 #include <mbgl/style/conversion_impl.hpp>
-#include <mbgl/util/fnv_hash.hpp>
+
+#include <mapbox/eternal.hpp>
 
 namespace mbgl {
 namespace style {
@@ -226,8 +227,7 @@ TransitionOptions HillshadeLayer::getHillshadeAccentColorTransition() const {
 using namespace conversion;
 
 optional<Error> HillshadeLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-        Unknown,
+    enum class Property : uint8_t {
         HillshadeIlluminationDirection,
         HillshadeIlluminationAnchor,
         HillshadeExaggeration,
@@ -242,74 +242,27 @@ optional<Error> HillshadeLayer::setPaintProperty(const std::string& name, const 
         HillshadeAccentColorTransition,
     };
 
-    Property property = Property::Unknown;
-    switch (util::hashFNV1a(name.c_str())) {
-    case util::hashFNV1a("hillshade-illumination-direction"):
-        if (name == "hillshade-illumination-direction") {
-            property = Property::HillshadeIlluminationDirection;
-        }
-        break;
-    case util::hashFNV1a("hillshade-illumination-direction-transition"):
-        if (name == "hillshade-illumination-direction-transition") {
-            property = Property::HillshadeIlluminationDirectionTransition;
-        }
-        break;
-    case util::hashFNV1a("hillshade-illumination-anchor"):
-        if (name == "hillshade-illumination-anchor") {
-            property = Property::HillshadeIlluminationAnchor;
-        }
-        break;
-    case util::hashFNV1a("hillshade-illumination-anchor-transition"):
-        if (name == "hillshade-illumination-anchor-transition") {
-            property = Property::HillshadeIlluminationAnchorTransition;
-        }
-        break;
-    case util::hashFNV1a("hillshade-exaggeration"):
-        if (name == "hillshade-exaggeration") {
-            property = Property::HillshadeExaggeration;
-        }
-        break;
-    case util::hashFNV1a("hillshade-exaggeration-transition"):
-        if (name == "hillshade-exaggeration-transition") {
-            property = Property::HillshadeExaggerationTransition;
-        }
-        break;
-    case util::hashFNV1a("hillshade-shadow-color"):
-        if (name == "hillshade-shadow-color") {
-            property = Property::HillshadeShadowColor;
-        }
-        break;
-    case util::hashFNV1a("hillshade-shadow-color-transition"):
-        if (name == "hillshade-shadow-color-transition") {
-            property = Property::HillshadeShadowColorTransition;
-        }
-        break;
-    case util::hashFNV1a("hillshade-highlight-color"):
-        if (name == "hillshade-highlight-color") {
-            property = Property::HillshadeHighlightColor;
-        }
-        break;
-    case util::hashFNV1a("hillshade-highlight-color-transition"):
-        if (name == "hillshade-highlight-color-transition") {
-            property = Property::HillshadeHighlightColorTransition;
-        }
-        break;
-    case util::hashFNV1a("hillshade-accent-color"):
-        if (name == "hillshade-accent-color") {
-            property = Property::HillshadeAccentColor;
-        }
-        break;
-    case util::hashFNV1a("hillshade-accent-color-transition"):
-        if (name == "hillshade-accent-color-transition") {
-            property = Property::HillshadeAccentColorTransition;
-        }
-        break;
-    
-    }
+    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
+        { "hillshade-illumination-direction", static_cast<uint8_t>(Property::HillshadeIlluminationDirection) },
+        { "hillshade-illumination-anchor", static_cast<uint8_t>(Property::HillshadeIlluminationAnchor) },
+        { "hillshade-exaggeration", static_cast<uint8_t>(Property::HillshadeExaggeration) },
+        { "hillshade-shadow-color", static_cast<uint8_t>(Property::HillshadeShadowColor) },
+        { "hillshade-highlight-color", static_cast<uint8_t>(Property::HillshadeHighlightColor) },
+        { "hillshade-accent-color", static_cast<uint8_t>(Property::HillshadeAccentColor) },
+        { "hillshade-illumination-direction-transition", static_cast<uint8_t>(Property::HillshadeIlluminationDirectionTransition) },
+        { "hillshade-illumination-anchor-transition", static_cast<uint8_t>(Property::HillshadeIlluminationAnchorTransition) },
+        { "hillshade-exaggeration-transition", static_cast<uint8_t>(Property::HillshadeExaggerationTransition) },
+        { "hillshade-shadow-color-transition", static_cast<uint8_t>(Property::HillshadeShadowColorTransition) },
+        { "hillshade-highlight-color-transition", static_cast<uint8_t>(Property::HillshadeHighlightColorTransition) },
+        { "hillshade-accent-color-transition", static_cast<uint8_t>(Property::HillshadeAccentColorTransition) }
+    });
 
-    if (property == Property::Unknown) {
+    const auto it = properties.find(name.c_str());
+    if (it == properties.end()) {
         return Error { "layer doesn't support this property" };
     }
+
+    Property property = static_cast<Property>(it->second);
 
         
     if (property == Property::HillshadeIlluminationDirection || property == Property::HillshadeExaggeration) {
@@ -412,21 +365,6 @@ optional<Error> HillshadeLayer::setLayoutProperty(const std::string& name, const
     if (name == "visibility") {
         return Layer::setVisibility(value);
     }
-
-    enum class Property {
-        Unknown,
-    };
-
-    Property property = Property::Unknown;
-    switch (util::hashFNV1a(name.c_str())) {
-    
-    }
-
-    if (property == Property::Unknown) {
-        return Error { "layer doesn't support this property" };
-    }
-
-        
 
     return Error { "layer doesn't support this property" };
 }

--- a/src/mbgl/style/layers/layer.cpp.ejs
+++ b/src/mbgl/style/layers/layer.cpp.ejs
@@ -14,7 +14,8 @@
 #include <mbgl/style/conversion/transition_options.hpp>
 #include <mbgl/style/conversion/json.hpp>
 #include <mbgl/style/conversion_impl.hpp>
-#include <mbgl/util/fnv_hash.hpp>
+
+#include <mapbox/eternal.hpp>
 
 namespace mbgl {
 namespace style {
@@ -170,8 +171,7 @@ TransitionOptions <%- camelize(type) %>Layer::get<%- camelize(property.name) %>T
 using namespace conversion;
 
 optional<Error> <%- camelize(type) %>Layer::setPaintProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-        Unknown,
+    enum class Property : uint8_t {
 <% for (const property of paintProperties) { -%>
         <%- camelize(property.name) %>,
 <% } -%>
@@ -180,25 +180,17 @@ optional<Error> <%- camelize(type) %>Layer::setPaintProperty(const std::string& 
 <% } -%>
     };
 
-    Property property = Property::Unknown;
-    switch (util::hashFNV1a(name.c_str())) {
-    <% for (const property of paintProperties) { -%>
-case util::hashFNV1a("<%- property.name %>"):
-        if (name == "<%- property.name %>") {
-            property = Property::<%- camelize(property.name) %>;
-        }
-        break;
-    case util::hashFNV1a("<%- property.name %>-transition"):
-        if (name == "<%- property.name %>-transition") {
-            property = Property::<%- camelize(property.name) %>Transition;
-        }
-        break;
-    <% } %>
-    }
+    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
+        <%- paintProperties.map(p => `{ "${p.name}", static_cast<uint8_t>(Property::${camelize(p.name)}) }`).join(',\n        ') %>,
+        <%- paintProperties.map(p => `{ "${p.name}-transition", static_cast<uint8_t>(Property::${camelize(p.name)}Transition) }`).join(',\n        ') %>
+    });
 
-    if (property == Property::Unknown) {
+    const auto it = properties.find(name.c_str());
+    if (it == properties.end()) {
         return Error { "layer doesn't support this property" };
     }
+
+    Property property = static_cast<Property>(it->second);
 
     <%
         const paintConversions = {};
@@ -250,28 +242,22 @@ optional<Error> <%- camelize(type) %>Layer::setLayoutProperty(const std::string&
     if (name == "visibility") {
         return Layer::setVisibility(value);
     }
-
+<% if (layoutProperties.length) { -%>
     enum class Property {
-        Unknown,
 <% for (const property of layoutProperties) { -%>
         <%- camelize(property.name) %>,
 <% } -%>
     };
+    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
+        <%- layoutProperties.map(p => `{ "${p.name}", static_cast<uint8_t>(Property::${camelize(p.name)}) }`).join(',\n        ') %>
+    });
 
-    Property property = Property::Unknown;
-    switch (util::hashFNV1a(name.c_str())) {
-    <% for (const property of layoutProperties) { %>
-    case util::hashFNV1a("<%- property.name %>"):
-        if (name == "<%- property.name %>") {
-            property = Property::<%- camelize(property.name) %>;
-        }
-        break;
-    <% } %>
-    }
-
-    if (property == Property::Unknown) {
+    const auto it = properties.find(name.c_str());
+    if (it == properties.end()) {
         return Error { "layer doesn't support this property" };
     }
+
+    Property property = static_cast<Property>(it->second);
 
     <%
         const layoutConversions = {};
@@ -303,7 +289,7 @@ optional<Error> <%- camelize(type) %>Layer::setLayoutProperty(const std::string&
         <% } %>
     }
     <% } %>
-
+<% } /* if (layoutProperties.length) */ %>
     return Error { "layer doesn't support this property" };
 }
 

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -9,7 +9,8 @@
 #include <mbgl/style/conversion/transition_options.hpp>
 #include <mbgl/style/conversion/json.hpp>
 #include <mbgl/style/conversion_impl.hpp>
-#include <mbgl/util/fnv_hash.hpp>
+
+#include <mapbox/eternal.hpp>
 
 namespace mbgl {
 namespace style {
@@ -426,8 +427,7 @@ TransitionOptions LineLayer::getLineGradientTransition() const {
 using namespace conversion;
 
 optional<Error> LineLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-        Unknown,
+    enum class Property : uint8_t {
         LineOpacity,
         LineColor,
         LineTranslate,
@@ -452,124 +452,37 @@ optional<Error> LineLayer::setPaintProperty(const std::string& name, const Conve
         LineGradientTransition,
     };
 
-    Property property = Property::Unknown;
-    switch (util::hashFNV1a(name.c_str())) {
-    case util::hashFNV1a("line-opacity"):
-        if (name == "line-opacity") {
-            property = Property::LineOpacity;
-        }
-        break;
-    case util::hashFNV1a("line-opacity-transition"):
-        if (name == "line-opacity-transition") {
-            property = Property::LineOpacityTransition;
-        }
-        break;
-    case util::hashFNV1a("line-color"):
-        if (name == "line-color") {
-            property = Property::LineColor;
-        }
-        break;
-    case util::hashFNV1a("line-color-transition"):
-        if (name == "line-color-transition") {
-            property = Property::LineColorTransition;
-        }
-        break;
-    case util::hashFNV1a("line-translate"):
-        if (name == "line-translate") {
-            property = Property::LineTranslate;
-        }
-        break;
-    case util::hashFNV1a("line-translate-transition"):
-        if (name == "line-translate-transition") {
-            property = Property::LineTranslateTransition;
-        }
-        break;
-    case util::hashFNV1a("line-translate-anchor"):
-        if (name == "line-translate-anchor") {
-            property = Property::LineTranslateAnchor;
-        }
-        break;
-    case util::hashFNV1a("line-translate-anchor-transition"):
-        if (name == "line-translate-anchor-transition") {
-            property = Property::LineTranslateAnchorTransition;
-        }
-        break;
-    case util::hashFNV1a("line-width"):
-        if (name == "line-width") {
-            property = Property::LineWidth;
-        }
-        break;
-    case util::hashFNV1a("line-width-transition"):
-        if (name == "line-width-transition") {
-            property = Property::LineWidthTransition;
-        }
-        break;
-    case util::hashFNV1a("line-gap-width"):
-        if (name == "line-gap-width") {
-            property = Property::LineGapWidth;
-        }
-        break;
-    case util::hashFNV1a("line-gap-width-transition"):
-        if (name == "line-gap-width-transition") {
-            property = Property::LineGapWidthTransition;
-        }
-        break;
-    case util::hashFNV1a("line-offset"):
-        if (name == "line-offset") {
-            property = Property::LineOffset;
-        }
-        break;
-    case util::hashFNV1a("line-offset-transition"):
-        if (name == "line-offset-transition") {
-            property = Property::LineOffsetTransition;
-        }
-        break;
-    case util::hashFNV1a("line-blur"):
-        if (name == "line-blur") {
-            property = Property::LineBlur;
-        }
-        break;
-    case util::hashFNV1a("line-blur-transition"):
-        if (name == "line-blur-transition") {
-            property = Property::LineBlurTransition;
-        }
-        break;
-    case util::hashFNV1a("line-dasharray"):
-        if (name == "line-dasharray") {
-            property = Property::LineDasharray;
-        }
-        break;
-    case util::hashFNV1a("line-dasharray-transition"):
-        if (name == "line-dasharray-transition") {
-            property = Property::LineDasharrayTransition;
-        }
-        break;
-    case util::hashFNV1a("line-pattern"):
-        if (name == "line-pattern") {
-            property = Property::LinePattern;
-        }
-        break;
-    case util::hashFNV1a("line-pattern-transition"):
-        if (name == "line-pattern-transition") {
-            property = Property::LinePatternTransition;
-        }
-        break;
-    case util::hashFNV1a("line-gradient"):
-        if (name == "line-gradient") {
-            property = Property::LineGradient;
-        }
-        break;
-    case util::hashFNV1a("line-gradient-transition"):
-        if (name == "line-gradient-transition") {
-            property = Property::LineGradientTransition;
-        }
-        break;
-    
-    }
+    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
+        { "line-opacity", static_cast<uint8_t>(Property::LineOpacity) },
+        { "line-color", static_cast<uint8_t>(Property::LineColor) },
+        { "line-translate", static_cast<uint8_t>(Property::LineTranslate) },
+        { "line-translate-anchor", static_cast<uint8_t>(Property::LineTranslateAnchor) },
+        { "line-width", static_cast<uint8_t>(Property::LineWidth) },
+        { "line-gap-width", static_cast<uint8_t>(Property::LineGapWidth) },
+        { "line-offset", static_cast<uint8_t>(Property::LineOffset) },
+        { "line-blur", static_cast<uint8_t>(Property::LineBlur) },
+        { "line-dasharray", static_cast<uint8_t>(Property::LineDasharray) },
+        { "line-pattern", static_cast<uint8_t>(Property::LinePattern) },
+        { "line-gradient", static_cast<uint8_t>(Property::LineGradient) },
+        { "line-opacity-transition", static_cast<uint8_t>(Property::LineOpacityTransition) },
+        { "line-color-transition", static_cast<uint8_t>(Property::LineColorTransition) },
+        { "line-translate-transition", static_cast<uint8_t>(Property::LineTranslateTransition) },
+        { "line-translate-anchor-transition", static_cast<uint8_t>(Property::LineTranslateAnchorTransition) },
+        { "line-width-transition", static_cast<uint8_t>(Property::LineWidthTransition) },
+        { "line-gap-width-transition", static_cast<uint8_t>(Property::LineGapWidthTransition) },
+        { "line-offset-transition", static_cast<uint8_t>(Property::LineOffsetTransition) },
+        { "line-blur-transition", static_cast<uint8_t>(Property::LineBlurTransition) },
+        { "line-dasharray-transition", static_cast<uint8_t>(Property::LineDasharrayTransition) },
+        { "line-pattern-transition", static_cast<uint8_t>(Property::LinePatternTransition) },
+        { "line-gradient-transition", static_cast<uint8_t>(Property::LineGradientTransition) }
+    });
 
-    if (property == Property::Unknown) {
+    const auto it = properties.find(name.c_str());
+    if (it == properties.end()) {
         return Error { "layer doesn't support this property" };
     }
+
+    Property property = static_cast<Property>(it->second);
 
         
     if (property == Property::LineOpacity || property == Property::LineWidth || property == Property::LineGapWidth || property == Property::LineOffset || property == Property::LineBlur) {
@@ -748,47 +661,25 @@ optional<Error> LineLayer::setLayoutProperty(const std::string& name, const Conv
     if (name == "visibility") {
         return Layer::setVisibility(value);
     }
-
     enum class Property {
-        Unknown,
         LineCap,
         LineJoin,
         LineMiterLimit,
         LineRoundLimit,
     };
+    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
+        { "line-cap", static_cast<uint8_t>(Property::LineCap) },
+        { "line-join", static_cast<uint8_t>(Property::LineJoin) },
+        { "line-miter-limit", static_cast<uint8_t>(Property::LineMiterLimit) },
+        { "line-round-limit", static_cast<uint8_t>(Property::LineRoundLimit) }
+    });
 
-    Property property = Property::Unknown;
-    switch (util::hashFNV1a(name.c_str())) {
-    
-    case util::hashFNV1a("line-cap"):
-        if (name == "line-cap") {
-            property = Property::LineCap;
-        }
-        break;
-    
-    case util::hashFNV1a("line-join"):
-        if (name == "line-join") {
-            property = Property::LineJoin;
-        }
-        break;
-    
-    case util::hashFNV1a("line-miter-limit"):
-        if (name == "line-miter-limit") {
-            property = Property::LineMiterLimit;
-        }
-        break;
-    
-    case util::hashFNV1a("line-round-limit"):
-        if (name == "line-round-limit") {
-            property = Property::LineRoundLimit;
-        }
-        break;
-    
-    }
-
-    if (property == Property::Unknown) {
+    const auto it = properties.find(name.c_str());
+    if (it == properties.end()) {
         return Error { "layer doesn't support this property" };
     }
+
+    Property property = static_cast<Property>(it->second);
 
         
     if (property == Property::LineCap) {

--- a/src/mbgl/style/layers/raster_layer.cpp
+++ b/src/mbgl/style/layers/raster_layer.cpp
@@ -9,7 +9,8 @@
 #include <mbgl/style/conversion/transition_options.hpp>
 #include <mbgl/style/conversion/json.hpp>
 #include <mbgl/style/conversion_impl.hpp>
-#include <mbgl/util/fnv_hash.hpp>
+
+#include <mapbox/eternal.hpp>
 
 namespace mbgl {
 namespace style {
@@ -280,8 +281,7 @@ TransitionOptions RasterLayer::getRasterFadeDurationTransition() const {
 using namespace conversion;
 
 optional<Error> RasterLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-        Unknown,
+    enum class Property : uint8_t {
         RasterOpacity,
         RasterHueRotate,
         RasterBrightnessMin,
@@ -300,94 +300,31 @@ optional<Error> RasterLayer::setPaintProperty(const std::string& name, const Con
         RasterFadeDurationTransition,
     };
 
-    Property property = Property::Unknown;
-    switch (util::hashFNV1a(name.c_str())) {
-    case util::hashFNV1a("raster-opacity"):
-        if (name == "raster-opacity") {
-            property = Property::RasterOpacity;
-        }
-        break;
-    case util::hashFNV1a("raster-opacity-transition"):
-        if (name == "raster-opacity-transition") {
-            property = Property::RasterOpacityTransition;
-        }
-        break;
-    case util::hashFNV1a("raster-hue-rotate"):
-        if (name == "raster-hue-rotate") {
-            property = Property::RasterHueRotate;
-        }
-        break;
-    case util::hashFNV1a("raster-hue-rotate-transition"):
-        if (name == "raster-hue-rotate-transition") {
-            property = Property::RasterHueRotateTransition;
-        }
-        break;
-    case util::hashFNV1a("raster-brightness-min"):
-        if (name == "raster-brightness-min") {
-            property = Property::RasterBrightnessMin;
-        }
-        break;
-    case util::hashFNV1a("raster-brightness-min-transition"):
-        if (name == "raster-brightness-min-transition") {
-            property = Property::RasterBrightnessMinTransition;
-        }
-        break;
-    case util::hashFNV1a("raster-brightness-max"):
-        if (name == "raster-brightness-max") {
-            property = Property::RasterBrightnessMax;
-        }
-        break;
-    case util::hashFNV1a("raster-brightness-max-transition"):
-        if (name == "raster-brightness-max-transition") {
-            property = Property::RasterBrightnessMaxTransition;
-        }
-        break;
-    case util::hashFNV1a("raster-saturation"):
-        if (name == "raster-saturation") {
-            property = Property::RasterSaturation;
-        }
-        break;
-    case util::hashFNV1a("raster-saturation-transition"):
-        if (name == "raster-saturation-transition") {
-            property = Property::RasterSaturationTransition;
-        }
-        break;
-    case util::hashFNV1a("raster-contrast"):
-        if (name == "raster-contrast") {
-            property = Property::RasterContrast;
-        }
-        break;
-    case util::hashFNV1a("raster-contrast-transition"):
-        if (name == "raster-contrast-transition") {
-            property = Property::RasterContrastTransition;
-        }
-        break;
-    case util::hashFNV1a("raster-resampling"):
-        if (name == "raster-resampling") {
-            property = Property::RasterResampling;
-        }
-        break;
-    case util::hashFNV1a("raster-resampling-transition"):
-        if (name == "raster-resampling-transition") {
-            property = Property::RasterResamplingTransition;
-        }
-        break;
-    case util::hashFNV1a("raster-fade-duration"):
-        if (name == "raster-fade-duration") {
-            property = Property::RasterFadeDuration;
-        }
-        break;
-    case util::hashFNV1a("raster-fade-duration-transition"):
-        if (name == "raster-fade-duration-transition") {
-            property = Property::RasterFadeDurationTransition;
-        }
-        break;
-    
-    }
+    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
+        { "raster-opacity", static_cast<uint8_t>(Property::RasterOpacity) },
+        { "raster-hue-rotate", static_cast<uint8_t>(Property::RasterHueRotate) },
+        { "raster-brightness-min", static_cast<uint8_t>(Property::RasterBrightnessMin) },
+        { "raster-brightness-max", static_cast<uint8_t>(Property::RasterBrightnessMax) },
+        { "raster-saturation", static_cast<uint8_t>(Property::RasterSaturation) },
+        { "raster-contrast", static_cast<uint8_t>(Property::RasterContrast) },
+        { "raster-resampling", static_cast<uint8_t>(Property::RasterResampling) },
+        { "raster-fade-duration", static_cast<uint8_t>(Property::RasterFadeDuration) },
+        { "raster-opacity-transition", static_cast<uint8_t>(Property::RasterOpacityTransition) },
+        { "raster-hue-rotate-transition", static_cast<uint8_t>(Property::RasterHueRotateTransition) },
+        { "raster-brightness-min-transition", static_cast<uint8_t>(Property::RasterBrightnessMinTransition) },
+        { "raster-brightness-max-transition", static_cast<uint8_t>(Property::RasterBrightnessMaxTransition) },
+        { "raster-saturation-transition", static_cast<uint8_t>(Property::RasterSaturationTransition) },
+        { "raster-contrast-transition", static_cast<uint8_t>(Property::RasterContrastTransition) },
+        { "raster-resampling-transition", static_cast<uint8_t>(Property::RasterResamplingTransition) },
+        { "raster-fade-duration-transition", static_cast<uint8_t>(Property::RasterFadeDurationTransition) }
+    });
 
-    if (property == Property::Unknown) {
+    const auto it = properties.find(name.c_str());
+    if (it == properties.end()) {
         return Error { "layer doesn't support this property" };
     }
+
+    Property property = static_cast<Property>(it->second);
 
         
     if (property == Property::RasterOpacity || property == Property::RasterHueRotate || property == Property::RasterBrightnessMin || property == Property::RasterBrightnessMax || property == Property::RasterSaturation || property == Property::RasterContrast || property == Property::RasterFadeDuration) {
@@ -501,21 +438,6 @@ optional<Error> RasterLayer::setLayoutProperty(const std::string& name, const Co
     if (name == "visibility") {
         return Layer::setVisibility(value);
     }
-
-    enum class Property {
-        Unknown,
-    };
-
-    Property property = Property::Unknown;
-    switch (util::hashFNV1a(name.c_str())) {
-    
-    }
-
-    if (property == Property::Unknown) {
-        return Error { "layer doesn't support this property" };
-    }
-
-        
 
     return Error { "layer doesn't support this property" };
 }

--- a/src/mbgl/style/layers/symbol_layer.cpp
+++ b/src/mbgl/style/layers/symbol_layer.cpp
@@ -9,7 +9,8 @@
 #include <mbgl/style/conversion/transition_options.hpp>
 #include <mbgl/style/conversion/json.hpp>
 #include <mbgl/style/conversion_impl.hpp>
-#include <mbgl/util/fnv_hash.hpp>
+
+#include <mapbox/eternal.hpp>
 
 namespace mbgl {
 namespace style {
@@ -1035,8 +1036,7 @@ TransitionOptions SymbolLayer::getTextTranslateAnchorTransition() const {
 using namespace conversion;
 
 optional<Error> SymbolLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-        Unknown,
+    enum class Property : uint8_t {
         IconOpacity,
         IconColor,
         IconHaloColor,
@@ -1067,154 +1067,43 @@ optional<Error> SymbolLayer::setPaintProperty(const std::string& name, const Con
         TextTranslateAnchorTransition,
     };
 
-    Property property = Property::Unknown;
-    switch (util::hashFNV1a(name.c_str())) {
-    case util::hashFNV1a("icon-opacity"):
-        if (name == "icon-opacity") {
-            property = Property::IconOpacity;
-        }
-        break;
-    case util::hashFNV1a("icon-opacity-transition"):
-        if (name == "icon-opacity-transition") {
-            property = Property::IconOpacityTransition;
-        }
-        break;
-    case util::hashFNV1a("icon-color"):
-        if (name == "icon-color") {
-            property = Property::IconColor;
-        }
-        break;
-    case util::hashFNV1a("icon-color-transition"):
-        if (name == "icon-color-transition") {
-            property = Property::IconColorTransition;
-        }
-        break;
-    case util::hashFNV1a("icon-halo-color"):
-        if (name == "icon-halo-color") {
-            property = Property::IconHaloColor;
-        }
-        break;
-    case util::hashFNV1a("icon-halo-color-transition"):
-        if (name == "icon-halo-color-transition") {
-            property = Property::IconHaloColorTransition;
-        }
-        break;
-    case util::hashFNV1a("icon-halo-width"):
-        if (name == "icon-halo-width") {
-            property = Property::IconHaloWidth;
-        }
-        break;
-    case util::hashFNV1a("icon-halo-width-transition"):
-        if (name == "icon-halo-width-transition") {
-            property = Property::IconHaloWidthTransition;
-        }
-        break;
-    case util::hashFNV1a("icon-halo-blur"):
-        if (name == "icon-halo-blur") {
-            property = Property::IconHaloBlur;
-        }
-        break;
-    case util::hashFNV1a("icon-halo-blur-transition"):
-        if (name == "icon-halo-blur-transition") {
-            property = Property::IconHaloBlurTransition;
-        }
-        break;
-    case util::hashFNV1a("icon-translate"):
-        if (name == "icon-translate") {
-            property = Property::IconTranslate;
-        }
-        break;
-    case util::hashFNV1a("icon-translate-transition"):
-        if (name == "icon-translate-transition") {
-            property = Property::IconTranslateTransition;
-        }
-        break;
-    case util::hashFNV1a("icon-translate-anchor"):
-        if (name == "icon-translate-anchor") {
-            property = Property::IconTranslateAnchor;
-        }
-        break;
-    case util::hashFNV1a("icon-translate-anchor-transition"):
-        if (name == "icon-translate-anchor-transition") {
-            property = Property::IconTranslateAnchorTransition;
-        }
-        break;
-    case util::hashFNV1a("text-opacity"):
-        if (name == "text-opacity") {
-            property = Property::TextOpacity;
-        }
-        break;
-    case util::hashFNV1a("text-opacity-transition"):
-        if (name == "text-opacity-transition") {
-            property = Property::TextOpacityTransition;
-        }
-        break;
-    case util::hashFNV1a("text-color"):
-        if (name == "text-color") {
-            property = Property::TextColor;
-        }
-        break;
-    case util::hashFNV1a("text-color-transition"):
-        if (name == "text-color-transition") {
-            property = Property::TextColorTransition;
-        }
-        break;
-    case util::hashFNV1a("text-halo-color"):
-        if (name == "text-halo-color") {
-            property = Property::TextHaloColor;
-        }
-        break;
-    case util::hashFNV1a("text-halo-color-transition"):
-        if (name == "text-halo-color-transition") {
-            property = Property::TextHaloColorTransition;
-        }
-        break;
-    case util::hashFNV1a("text-halo-width"):
-        if (name == "text-halo-width") {
-            property = Property::TextHaloWidth;
-        }
-        break;
-    case util::hashFNV1a("text-halo-width-transition"):
-        if (name == "text-halo-width-transition") {
-            property = Property::TextHaloWidthTransition;
-        }
-        break;
-    case util::hashFNV1a("text-halo-blur"):
-        if (name == "text-halo-blur") {
-            property = Property::TextHaloBlur;
-        }
-        break;
-    case util::hashFNV1a("text-halo-blur-transition"):
-        if (name == "text-halo-blur-transition") {
-            property = Property::TextHaloBlurTransition;
-        }
-        break;
-    case util::hashFNV1a("text-translate"):
-        if (name == "text-translate") {
-            property = Property::TextTranslate;
-        }
-        break;
-    case util::hashFNV1a("text-translate-transition"):
-        if (name == "text-translate-transition") {
-            property = Property::TextTranslateTransition;
-        }
-        break;
-    case util::hashFNV1a("text-translate-anchor"):
-        if (name == "text-translate-anchor") {
-            property = Property::TextTranslateAnchor;
-        }
-        break;
-    case util::hashFNV1a("text-translate-anchor-transition"):
-        if (name == "text-translate-anchor-transition") {
-            property = Property::TextTranslateAnchorTransition;
-        }
-        break;
-    
-    }
+    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
+        { "icon-opacity", static_cast<uint8_t>(Property::IconOpacity) },
+        { "icon-color", static_cast<uint8_t>(Property::IconColor) },
+        { "icon-halo-color", static_cast<uint8_t>(Property::IconHaloColor) },
+        { "icon-halo-width", static_cast<uint8_t>(Property::IconHaloWidth) },
+        { "icon-halo-blur", static_cast<uint8_t>(Property::IconHaloBlur) },
+        { "icon-translate", static_cast<uint8_t>(Property::IconTranslate) },
+        { "icon-translate-anchor", static_cast<uint8_t>(Property::IconTranslateAnchor) },
+        { "text-opacity", static_cast<uint8_t>(Property::TextOpacity) },
+        { "text-color", static_cast<uint8_t>(Property::TextColor) },
+        { "text-halo-color", static_cast<uint8_t>(Property::TextHaloColor) },
+        { "text-halo-width", static_cast<uint8_t>(Property::TextHaloWidth) },
+        { "text-halo-blur", static_cast<uint8_t>(Property::TextHaloBlur) },
+        { "text-translate", static_cast<uint8_t>(Property::TextTranslate) },
+        { "text-translate-anchor", static_cast<uint8_t>(Property::TextTranslateAnchor) },
+        { "icon-opacity-transition", static_cast<uint8_t>(Property::IconOpacityTransition) },
+        { "icon-color-transition", static_cast<uint8_t>(Property::IconColorTransition) },
+        { "icon-halo-color-transition", static_cast<uint8_t>(Property::IconHaloColorTransition) },
+        { "icon-halo-width-transition", static_cast<uint8_t>(Property::IconHaloWidthTransition) },
+        { "icon-halo-blur-transition", static_cast<uint8_t>(Property::IconHaloBlurTransition) },
+        { "icon-translate-transition", static_cast<uint8_t>(Property::IconTranslateTransition) },
+        { "icon-translate-anchor-transition", static_cast<uint8_t>(Property::IconTranslateAnchorTransition) },
+        { "text-opacity-transition", static_cast<uint8_t>(Property::TextOpacityTransition) },
+        { "text-color-transition", static_cast<uint8_t>(Property::TextColorTransition) },
+        { "text-halo-color-transition", static_cast<uint8_t>(Property::TextHaloColorTransition) },
+        { "text-halo-width-transition", static_cast<uint8_t>(Property::TextHaloWidthTransition) },
+        { "text-halo-blur-transition", static_cast<uint8_t>(Property::TextHaloBlurTransition) },
+        { "text-translate-transition", static_cast<uint8_t>(Property::TextTranslateTransition) },
+        { "text-translate-anchor-transition", static_cast<uint8_t>(Property::TextTranslateAnchorTransition) }
+    });
 
-    if (property == Property::Unknown) {
+    const auto it = properties.find(name.c_str());
+    if (it == properties.end()) {
         return Error { "layer doesn't support this property" };
     }
+
+    Property property = static_cast<Property>(it->second);
 
         
     if (property == Property::IconOpacity || property == Property::IconHaloWidth || property == Property::IconHaloBlur || property == Property::TextOpacity || property == Property::TextHaloWidth || property == Property::TextHaloBlur) {
@@ -1408,9 +1297,7 @@ optional<Error> SymbolLayer::setLayoutProperty(const std::string& name, const Co
     if (name == "visibility") {
         return Layer::setVisibility(value);
     }
-
     enum class Property {
-        Unknown,
         SymbolPlacement,
         SymbolSpacing,
         SymbolAvoidEdges,
@@ -1449,237 +1336,52 @@ optional<Error> SymbolLayer::setLayoutProperty(const std::string& name, const Co
         TextIgnorePlacement,
         TextOptional,
     };
+    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
+        { "symbol-placement", static_cast<uint8_t>(Property::SymbolPlacement) },
+        { "symbol-spacing", static_cast<uint8_t>(Property::SymbolSpacing) },
+        { "symbol-avoid-edges", static_cast<uint8_t>(Property::SymbolAvoidEdges) },
+        { "symbol-z-order", static_cast<uint8_t>(Property::SymbolZOrder) },
+        { "icon-allow-overlap", static_cast<uint8_t>(Property::IconAllowOverlap) },
+        { "icon-ignore-placement", static_cast<uint8_t>(Property::IconIgnorePlacement) },
+        { "icon-optional", static_cast<uint8_t>(Property::IconOptional) },
+        { "icon-rotation-alignment", static_cast<uint8_t>(Property::IconRotationAlignment) },
+        { "icon-size", static_cast<uint8_t>(Property::IconSize) },
+        { "icon-text-fit", static_cast<uint8_t>(Property::IconTextFit) },
+        { "icon-text-fit-padding", static_cast<uint8_t>(Property::IconTextFitPadding) },
+        { "icon-image", static_cast<uint8_t>(Property::IconImage) },
+        { "icon-rotate", static_cast<uint8_t>(Property::IconRotate) },
+        { "icon-padding", static_cast<uint8_t>(Property::IconPadding) },
+        { "icon-keep-upright", static_cast<uint8_t>(Property::IconKeepUpright) },
+        { "icon-offset", static_cast<uint8_t>(Property::IconOffset) },
+        { "icon-anchor", static_cast<uint8_t>(Property::IconAnchor) },
+        { "icon-pitch-alignment", static_cast<uint8_t>(Property::IconPitchAlignment) },
+        { "text-pitch-alignment", static_cast<uint8_t>(Property::TextPitchAlignment) },
+        { "text-rotation-alignment", static_cast<uint8_t>(Property::TextRotationAlignment) },
+        { "text-field", static_cast<uint8_t>(Property::TextField) },
+        { "text-font", static_cast<uint8_t>(Property::TextFont) },
+        { "text-size", static_cast<uint8_t>(Property::TextSize) },
+        { "text-max-width", static_cast<uint8_t>(Property::TextMaxWidth) },
+        { "text-line-height", static_cast<uint8_t>(Property::TextLineHeight) },
+        { "text-letter-spacing", static_cast<uint8_t>(Property::TextLetterSpacing) },
+        { "text-justify", static_cast<uint8_t>(Property::TextJustify) },
+        { "text-anchor", static_cast<uint8_t>(Property::TextAnchor) },
+        { "text-max-angle", static_cast<uint8_t>(Property::TextMaxAngle) },
+        { "text-rotate", static_cast<uint8_t>(Property::TextRotate) },
+        { "text-padding", static_cast<uint8_t>(Property::TextPadding) },
+        { "text-keep-upright", static_cast<uint8_t>(Property::TextKeepUpright) },
+        { "text-transform", static_cast<uint8_t>(Property::TextTransform) },
+        { "text-offset", static_cast<uint8_t>(Property::TextOffset) },
+        { "text-allow-overlap", static_cast<uint8_t>(Property::TextAllowOverlap) },
+        { "text-ignore-placement", static_cast<uint8_t>(Property::TextIgnorePlacement) },
+        { "text-optional", static_cast<uint8_t>(Property::TextOptional) }
+    });
 
-    Property property = Property::Unknown;
-    switch (util::hashFNV1a(name.c_str())) {
-    
-    case util::hashFNV1a("symbol-placement"):
-        if (name == "symbol-placement") {
-            property = Property::SymbolPlacement;
-        }
-        break;
-    
-    case util::hashFNV1a("symbol-spacing"):
-        if (name == "symbol-spacing") {
-            property = Property::SymbolSpacing;
-        }
-        break;
-    
-    case util::hashFNV1a("symbol-avoid-edges"):
-        if (name == "symbol-avoid-edges") {
-            property = Property::SymbolAvoidEdges;
-        }
-        break;
-    
-    case util::hashFNV1a("symbol-z-order"):
-        if (name == "symbol-z-order") {
-            property = Property::SymbolZOrder;
-        }
-        break;
-    
-    case util::hashFNV1a("icon-allow-overlap"):
-        if (name == "icon-allow-overlap") {
-            property = Property::IconAllowOverlap;
-        }
-        break;
-    
-    case util::hashFNV1a("icon-ignore-placement"):
-        if (name == "icon-ignore-placement") {
-            property = Property::IconIgnorePlacement;
-        }
-        break;
-    
-    case util::hashFNV1a("icon-optional"):
-        if (name == "icon-optional") {
-            property = Property::IconOptional;
-        }
-        break;
-    
-    case util::hashFNV1a("icon-rotation-alignment"):
-        if (name == "icon-rotation-alignment") {
-            property = Property::IconRotationAlignment;
-        }
-        break;
-    
-    case util::hashFNV1a("icon-size"):
-        if (name == "icon-size") {
-            property = Property::IconSize;
-        }
-        break;
-    
-    case util::hashFNV1a("icon-text-fit"):
-        if (name == "icon-text-fit") {
-            property = Property::IconTextFit;
-        }
-        break;
-    
-    case util::hashFNV1a("icon-text-fit-padding"):
-        if (name == "icon-text-fit-padding") {
-            property = Property::IconTextFitPadding;
-        }
-        break;
-    
-    case util::hashFNV1a("icon-image"):
-        if (name == "icon-image") {
-            property = Property::IconImage;
-        }
-        break;
-    
-    case util::hashFNV1a("icon-rotate"):
-        if (name == "icon-rotate") {
-            property = Property::IconRotate;
-        }
-        break;
-    
-    case util::hashFNV1a("icon-padding"):
-        if (name == "icon-padding") {
-            property = Property::IconPadding;
-        }
-        break;
-    
-    case util::hashFNV1a("icon-keep-upright"):
-        if (name == "icon-keep-upright") {
-            property = Property::IconKeepUpright;
-        }
-        break;
-    
-    case util::hashFNV1a("icon-offset"):
-        if (name == "icon-offset") {
-            property = Property::IconOffset;
-        }
-        break;
-    
-    case util::hashFNV1a("icon-anchor"):
-        if (name == "icon-anchor") {
-            property = Property::IconAnchor;
-        }
-        break;
-    
-    case util::hashFNV1a("icon-pitch-alignment"):
-        if (name == "icon-pitch-alignment") {
-            property = Property::IconPitchAlignment;
-        }
-        break;
-    
-    case util::hashFNV1a("text-pitch-alignment"):
-        if (name == "text-pitch-alignment") {
-            property = Property::TextPitchAlignment;
-        }
-        break;
-    
-    case util::hashFNV1a("text-rotation-alignment"):
-        if (name == "text-rotation-alignment") {
-            property = Property::TextRotationAlignment;
-        }
-        break;
-    
-    case util::hashFNV1a("text-field"):
-        if (name == "text-field") {
-            property = Property::TextField;
-        }
-        break;
-    
-    case util::hashFNV1a("text-font"):
-        if (name == "text-font") {
-            property = Property::TextFont;
-        }
-        break;
-    
-    case util::hashFNV1a("text-size"):
-        if (name == "text-size") {
-            property = Property::TextSize;
-        }
-        break;
-    
-    case util::hashFNV1a("text-max-width"):
-        if (name == "text-max-width") {
-            property = Property::TextMaxWidth;
-        }
-        break;
-    
-    case util::hashFNV1a("text-line-height"):
-        if (name == "text-line-height") {
-            property = Property::TextLineHeight;
-        }
-        break;
-    
-    case util::hashFNV1a("text-letter-spacing"):
-        if (name == "text-letter-spacing") {
-            property = Property::TextLetterSpacing;
-        }
-        break;
-    
-    case util::hashFNV1a("text-justify"):
-        if (name == "text-justify") {
-            property = Property::TextJustify;
-        }
-        break;
-    
-    case util::hashFNV1a("text-anchor"):
-        if (name == "text-anchor") {
-            property = Property::TextAnchor;
-        }
-        break;
-    
-    case util::hashFNV1a("text-max-angle"):
-        if (name == "text-max-angle") {
-            property = Property::TextMaxAngle;
-        }
-        break;
-    
-    case util::hashFNV1a("text-rotate"):
-        if (name == "text-rotate") {
-            property = Property::TextRotate;
-        }
-        break;
-    
-    case util::hashFNV1a("text-padding"):
-        if (name == "text-padding") {
-            property = Property::TextPadding;
-        }
-        break;
-    
-    case util::hashFNV1a("text-keep-upright"):
-        if (name == "text-keep-upright") {
-            property = Property::TextKeepUpright;
-        }
-        break;
-    
-    case util::hashFNV1a("text-transform"):
-        if (name == "text-transform") {
-            property = Property::TextTransform;
-        }
-        break;
-    
-    case util::hashFNV1a("text-offset"):
-        if (name == "text-offset") {
-            property = Property::TextOffset;
-        }
-        break;
-    
-    case util::hashFNV1a("text-allow-overlap"):
-        if (name == "text-allow-overlap") {
-            property = Property::TextAllowOverlap;
-        }
-        break;
-    
-    case util::hashFNV1a("text-ignore-placement"):
-        if (name == "text-ignore-placement") {
-            property = Property::TextIgnorePlacement;
-        }
-        break;
-    
-    case util::hashFNV1a("text-optional"):
-        if (name == "text-optional") {
-            property = Property::TextOptional;
-        }
-        break;
-    
-    }
-
-    if (property == Property::Unknown) {
+    const auto it = properties.find(name.c_str());
+    if (it == properties.end()) {
         return Error { "layer doesn't support this property" };
     }
+
+    Property property = static_cast<Property>(it->second);
 
         
     if (property == Property::SymbolPlacement) {

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -11,8 +11,8 @@
 #include <mbgl/style/sources/geojson_source.hpp>
 #include <mbgl/style/sources/image_source.hpp>
 #include <mbgl/style/sources/custom_geometry_source.hpp>
-#include <mbgl/style/layers/hillshade_layer.cpp>
-#include <mbgl/style/layers/raster_layer.cpp>
+#include <mbgl/style/layers/hillshade_layer.hpp>
+#include <mbgl/style/layers/raster_layer.hpp>
 #include <mbgl/style/layers/line_layer.hpp>
 
 #include <mbgl/renderer/sources/render_raster_source.hpp>


### PR DESCRIPTION
Use `mapbox::eternal::hash_map` in `...Layer::setPaintProperty()` and  `...Layer::setLayoutProperty()` methods to decrease code size, binary size and improve performance.