### PR TITLE
Update core styles based on the streets-v8 source

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Style.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Style.java
@@ -756,25 +756,25 @@ public class Style {
    * constant means your map style will always use the latest version and may change as we
    * improve the style.
    */
-  public static final String MAPBOX_STREETS = "mapbox://styles/mapbox/streets-v10";
+  public static final String MAPBOX_STREETS = "mapbox://styles/mapbox/streets-v11";
 
   /**
    * Outdoors: A general-purpose style tailored to outdoor activities. Using this constant means
    * your map style will always use the latest version and may change as we improve the style.
    */
-  public static final String OUTDOORS = "mapbox://styles/mapbox/outdoors-v10";
+  public static final String OUTDOORS = "mapbox://styles/mapbox/outdoors-v11";
 
   /**
    * Light: Subtle light backdrop for data visualizations. Using this constant means your map
    * style will always use the latest version and may change as we improve the style.
    */
-  public static final String LIGHT = "mapbox://styles/mapbox/light-v9";
+  public static final String LIGHT = "mapbox://styles/mapbox/light-v10";
 
   /**
    * Dark: Subtle dark backdrop for data visualizations. Using this constant means your map style
    * will always use the latest version and may change as we improve the style.
    */
-  public static final String DARK = "mapbox://styles/mapbox/dark-v9";
+  public static final String DARK = "mapbox://styles/mapbox/dark-v10";
 
   /**
    * Satellite: A beautiful global satellite and aerial imagery layer. Using this constant means
@@ -787,7 +787,7 @@ public class Style {
    * constant means your map style will always use the latest version and may change as we
    * improve the style.
    */
-  public static final String SATELLITE_STREETS = "mapbox://styles/mapbox/satellite-streets-v10";
+  public static final String SATELLITE_STREETS = "mapbox://styles/mapbox/satellite-streets-v11";
 
   /**
    * Traffic Day: Color-coded roads based on live traffic congestion data. Traffic data is currently

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/strings.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/strings.xml
@@ -19,12 +19,12 @@
     <!-- these are public -->
     <!-- Using one of these constants means your map style will always use the latest version and
      may change as we improve the style. -->
-    <string name="mapbox_style_mapbox_streets" translatable="false">mapbox://styles/mapbox/streets-v10</string>
-    <string name="mapbox_style_outdoors" translatable="false">mapbox://styles/mapbox/outdoors-v10</string>
-    <string name="mapbox_style_light" translatable="false">mapbox://styles/mapbox/light-v9</string>
-    <string name="mapbox_style_dark" translatable="false">mapbox://styles/mapbox/dark-v9</string>
+    <string name="mapbox_style_mapbox_streets" translatable="false">mapbox://styles/mapbox/streets-v11</string>
+    <string name="mapbox_style_outdoors" translatable="false">mapbox://styles/mapbox/outdoors-v11</string>
+    <string name="mapbox_style_light" translatable="false">mapbox://styles/mapbox/light-v10</string>
+    <string name="mapbox_style_dark" translatable="false">mapbox://styles/mapbox/dark-v10</string>
     <string name="mapbox_style_satellite" translatable="false">mapbox://styles/mapbox/satellite-v9</string>
-    <string name="mapbox_style_satellite_streets" translatable="false">mapbox://styles/mapbox/satellite-streets-v10</string>
+    <string name="mapbox_style_satellite_streets" translatable="false">mapbox://styles/mapbox/satellite-streets-v11</string>
     <string name="mapbox_style_traffic_day" translatable="false">mapbox://styles/mapbox/traffic-day-v2</string>
     <string name="mapbox_style_traffic_night" translatable="false">mapbox://styles/mapbox/traffic-night-v2</string>
 </resources>


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gl-native/issues/13553.

This introduces breaking changes in layer/sources names in the listed core style, more about the `streets-v8` source [here](https://www.mapbox.com/vector-tiles/mapbox-streets-v8/).

Includes updates to:
`streets-v11`
`outdoors-v11`
`light-v10`
`dark-v10`
`satellite-streets-v11`