### PR TITLE
[ios, macos] Update code comments to mapbox-streets-v8

### DIFF
--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -551,7 +551,7 @@ MGL_EXPORT
  
  This method automatically modifies the text property of any symbol style layer
  in the style whose source is the
- <a href="https://www.mapbox.com/vector-tiles/mapbox-streets-v7/#overview">Mapbox Streets source</a>.
+ <a href="https://www.mapbox.com/vector-tiles/mapbox-streets-v8/#overview">Mapbox Streets source</a>.
  On iOS, the user can set the system’s preferred language in Settings, General
  Settings, Language & Region. On macOS, the user can set the system’s preferred
  language in the Language & Region pane of System Preferences.

--- a/platform/darwin/src/NSExpression+MGLAdditions.h
+++ b/platform/darwin/src/NSExpression+MGLAdditions.h
@@ -204,7 +204,7 @@ FOUNDATION_EXTERN MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionI
  
  This method assumes the receiver refers to the feature attributes that are
  available in vector tiles supplied by the
- <a href="https://www.mapbox.com/vector-tiles/mapbox-streets-v7/#overview">Mapbox Streets source</a>.
+ <a href="https://www.mapbox.com/vector-tiles/mapbox-streets-v8/#overview">Mapbox Streets source</a>.
  On iOS, the user can set the system’s preferred language in Settings, General
  Settings, Language & Region. On macOS, the user can set the system’s preferred
  language in the Language & Region pane of System Preferences.


### PR DESCRIPTION
Updates the documentation in `MGLStyle.h` and `NSExpression+MGLAdditions.h` to point to the new `mapbox-streets-v8` instead of `mapbox-streets-v7`.

I checked this for Android too but couldn't find anywhere where `mapbox-streets-v*` was being referenced within inline documentation.

There are a few places where `mapbox-streets-v7` is used for testing purposes, but I've left those alone for now.

Note to future releaser: No changelog entry required for this change.