### PR TITLE
Make library loader modular

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/LibraryLoader.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/LibraryLoader.java
@@ -1,52 +1,14 @@
 package com.mapbox.mapboxsdk;
 
-import com.mapbox.mapboxsdk.log.Logger;
-
 /**
  * Loads the mapbox-gl shared library
  * <p>
  * By default uses the {@link System#loadLibrary(String)},
- * use {@link #setLibraryLoader(LibraryLoader)} to provide an alternative library loading hook.
+ * use {@link Mapbox#setModuleProvider(ModuleProvider)} to provide an alternative library loading hook.
  * </p>
  */
-public abstract class LibraryLoader {
+public interface LibraryLoader {
 
-  private static final String TAG = "Mbgl-LibraryLoader";
+  void load();
 
-  private static final LibraryLoader DEFAULT = new LibraryLoader() {
-    @Override
-    public void load(String name) {
-      System.loadLibrary(name);
-    }
-  };
-
-  private static volatile LibraryLoader loader = DEFAULT;
-
-  /**
-   * Set the library loader that loads the shared library.
-   *
-   * @param libraryLoader the library loader
-   */
-  public static void setLibraryLoader(LibraryLoader libraryLoader) {
-    loader = libraryLoader;
-  }
-
-  /**
-   * Loads "libmapbox-gl.so" native shared library.
-   * <p>
-   * Catches UnsatisfiedLinkErrors and prints a warning to logcat.
-   * </p>
-   */
-  public static void load() {
-    try {
-      loader.load("mapbox-gl");
-    } catch (UnsatisfiedLinkError error) {
-      String message = "Failed to load native shared library.";
-      Logger.e(TAG, message, error);
-      MapStrictMode.strictModeViolation(message, error);
-    }
-  }
-
-  public abstract void load(String name);
 }
-

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/ModuleProvider.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/ModuleProvider.java
@@ -26,4 +26,10 @@ public interface ModuleProvider {
   @Nullable
   TelemetryDefinition obtainTelemetry();
 
+  /**
+   * Get the concrete implementation of LibraryLoader
+   */
+  @Nullable
+  LibraryLoader obtainLibraryLoader();
+
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -17,6 +17,7 @@ import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.Geometry;
 import com.mapbox.mapboxsdk.LibraryLoader;
 import com.mapbox.mapboxsdk.MapStrictMode;
+import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.annotations.Icon;
 import com.mapbox.mapboxsdk.annotations.Marker;
 import com.mapbox.mapboxsdk.annotations.Polygon;
@@ -81,7 +82,10 @@ final class NativeMapView {
   private MapboxMap.SnapshotReadyCallback snapshotReadyCallback;
 
   static {
-    LibraryLoader.load();
+    LibraryLoader libraryLoader = Mapbox.getLibraryLoader();
+    if (libraryLoader != null) {
+      libraryLoader.load();
+    }
   }
 
   //

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/ModuleProviderImpl.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/ModuleProviderImpl.java
@@ -1,10 +1,14 @@
-package com.mapbox.mapboxsdk;
+package com.mapbox.mapboxsdk.module;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+
+import com.mapbox.mapboxsdk.LibraryLoader;
+import com.mapbox.mapboxsdk.ModuleProvider;
 import com.mapbox.mapboxsdk.http.HttpRequest;
 import com.mapbox.mapboxsdk.maps.TelemetryDefinition;
 import com.mapbox.mapboxsdk.module.http.HttpRequestImpl;
+import com.mapbox.mapboxsdk.module.loader.LibraryLoaderImpl;
 import com.mapbox.mapboxsdk.module.telemetry.TelemetryImpl;
 
 public class ModuleProviderImpl implements ModuleProvider {
@@ -19,5 +23,11 @@ public class ModuleProviderImpl implements ModuleProvider {
   @Nullable
   public TelemetryDefinition obtainTelemetry() {
     return new TelemetryImpl();
+  }
+
+  @Nullable
+  @Override
+  public LibraryLoader obtainLibraryLoader() {
+    return new LibraryLoaderImpl();
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/loader/LibraryLoaderImpl.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/loader/LibraryLoaderImpl.java
@@ -1,0 +1,41 @@
+package com.mapbox.mapboxsdk.module.loader;
+
+import com.mapbox.mapboxsdk.LibraryLoader;
+import com.mapbox.mapboxsdk.MapStrictMode;
+import com.mapbox.mapboxsdk.ModuleProvider;
+import com.mapbox.mapboxsdk.log.Logger;
+
+import static android.content.ContentValues.TAG;
+
+/**
+ * Loads the mapbox-gl shared library
+ * <p>
+ * By default uses the {@link System#loadLibrary(String)},
+ * use {@link com.mapbox.mapboxsdk.Mapbox#setModuleProvider(ModuleProvider)} to provide an alternative
+ * library loading hook.
+ * </p>
+ */
+public class LibraryLoaderImpl implements LibraryLoader {
+
+  private boolean loaded;
+
+  @Override
+  public void load() {
+    if (loaded) {
+      return;
+    }
+
+    try {
+      System.loadLibrary("mapbox-gl");
+      loaded = true;
+    } catch (UnsatisfiedLinkError error) {
+      String message = "Failed to load native shared library.";
+      Logger.e(TAG, message, error);
+      MapStrictMode.strictModeViolation(message, error);
+    } catch (java.lang.NoClassDefFoundError error){
+      String message = "Failed to load native shared library.";
+      Logger.e(TAG, message, error);
+      MapStrictMode.strictModeViolation(message, error);
+    }
+  }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/net/NativeConnectivityListener.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/net/NativeConnectivityListener.java
@@ -3,14 +3,22 @@ package com.mapbox.mapboxsdk.net;
 import android.support.annotation.Keep;
 
 import com.mapbox.mapboxsdk.LibraryLoader;
+import com.mapbox.mapboxsdk.MapStrictMode;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.log.Logger;
 
 /**
  * Updates the native library's connectivity state
  */
 class NativeConnectivityListener implements ConnectivityListener {
 
+  private static final String TAG = "NativeConnectivity";
+
   static {
-    LibraryLoader.load();
+    LibraryLoader libraryLoader = Mapbox.getLibraryLoader();
+    if (libraryLoader != null) {
+      libraryLoader.load();
+    }
   }
 
   @Keep
@@ -24,7 +32,12 @@ class NativeConnectivityListener implements ConnectivityListener {
   }
 
   NativeConnectivityListener() {
-    initialize();
+    try {
+      initialize();
+    } catch (UnsatisfiedLinkError error) {
+      Logger.e(TAG, error.getMessage());
+      MapStrictMode.strictModeViolation(error);
+    }
   }
 
   @Override

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
@@ -39,7 +39,10 @@ public class OfflineManager {
   //
 
   static {
-    LibraryLoader.load();
+    LibraryLoader libraryLoader = Mapbox.getLibraryLoader();
+    if (libraryLoader != null) {
+      libraryLoader.load();
+    }
   }
 
   // Native peer pointer

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegion.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegion.java
@@ -25,7 +25,10 @@ public class OfflineRegion {
   //
 
   static {
-    LibraryLoader.load();
+    LibraryLoader libraryLoader = Mapbox.getLibraryLoader();
+    if (libraryLoader != null) {
+      libraryLoader.load();
+    }
   }
 
   // Members

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/ModuleProviderTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/ModuleProviderTest.kt
@@ -1,0 +1,52 @@
+package com.mapbox.mapboxsdk
+
+import android.content.Context
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import junit.framework.Assert.assertNotNull
+import junit.framework.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+class ModuleProviderTest {
+
+    private val context: Context = mockk()
+    private lateinit var moduleProvider: ModuleProvider
+
+    @Before
+    fun setUp() {
+        moduleProvider = mockk()
+        every {  moduleProvider.obtainTelemetry() } answers { mockk() }
+        every { context.applicationContext } answers { context }
+        every { context.filesDir } answers { File("") }
+        every { context.cacheDir } answers { File("") }
+    }
+
+    @Test
+    fun verifyTelemetryStartup() {
+        Mapbox.setModuleProvider(moduleProvider)
+        Mapbox.initialize(context, "pk.abcdefghijk")
+        verify { moduleProvider.obtainTelemetry() }
+        assertNotNull(Mapbox.getTelemetry())
+    }
+
+    @Test
+    fun verifyTelemetryNotStartup() {
+        Mapbox.setModuleProvider(moduleProvider)
+        Mapbox.initialize(context, null)
+        verify(exactly = 0) { moduleProvider.obtainTelemetry() }
+        assertNull(Mapbox.getTelemetry())
+    }
+
+    @Test
+    fun verifyLibraryLoader() {
+        Mapbox.setModuleProvider(moduleProvider)
+        Mapbox.initialize(context, null)
+        verify { moduleProvider.obtainLibraryLoader() }
+    }
+}


### PR DESCRIPTION
This PR makes library loader modular, the interaction model with providing a custom library loader has slightly changed because of the modular approach. Users can set a custom library loader by providing a custom ModuleProvider to Mapbox.java.