### PR TITLE
Save debug cache state vs map state

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -75,6 +75,8 @@ public final class MapboxMap {
   @Nullable
   private Style style;
 
+  private boolean debugActive;
+
   MapboxMap(NativeMapView map, Transform transform, UiSettings ui, Projection projection,
             OnGesturesManagerInteractionListener listener, CameraChangeDispatcher cameraChangeDispatcher) {
     this.nativeMapView = map;
@@ -145,7 +147,7 @@ public final class MapboxMap {
    */
   void onSaveInstanceState(@NonNull Bundle outState) {
     outState.putParcelable(MapboxConstants.STATE_CAMERA_POSITION, transform.getCameraPosition());
-    outState.putBoolean(MapboxConstants.STATE_DEBUG_ACTIVE, nativeMapView.getDebug());
+    outState.putBoolean(MapboxConstants.STATE_DEBUG_ACTIVE, isDebugActive());
     uiSettings.onSaveInstanceState(outState);
   }
 
@@ -696,7 +698,7 @@ public final class MapboxMap {
    * @return If true, map debug information is currently shown.
    */
   public boolean isDebugActive() {
-    return nativeMapView.getDebug();
+    return debugActive;
   }
 
   /**
@@ -708,6 +710,7 @@ public final class MapboxMap {
    * @param debugActive If true, map debug information is shown.
    */
   public void setDebugActive(boolean debugActive) {
+    this.debugActive = debugActive;
     nativeMapView.setDebug(debugActive);
   }
 
@@ -722,6 +725,7 @@ public final class MapboxMap {
    */
   public void cycleDebugOptions() {
     nativeMapView.cycleDebugOptions();
+    this.debugActive = nativeMapView.getDebug();
   }
 
   //


### PR DESCRIPTION
While testing https://github.com/mapbox/mapbox-gl-native/issues/13560. I'm noticing that a fragment can call onSaveInstanceState when it's in the fragment backstack. This means that the view and underlying NativeMapView have already been destroyed and we shouldn't talk to NativeMapView to save state. This PR caches the debug value so it can be restored on orientation change without NativeMapView involvement. 