### PR TITLE
Migrate tests, playground to Swift 4.2

### DIFF
--- a/platform/darwin/test/MGLSDKTestHelpers.swift
+++ b/platform/darwin/test/MGLSDKTestHelpers.swift
@@ -40,12 +40,7 @@ extension MGLSDKTestHelpers {
         for i in 0..<Int(methodCount) {
             let method = methodList![i]
             let selector = method_getName(method)
-            #if os(macOS)
-                methods.insert(selector.description)
-            #else
-                XCTAssertNotNil(selector)
-                methods.insert(selector!.description)
-            #endif
+            methods.insert(selector.description)
         }
         free(methodList)
         return methods

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -2867,7 +2867,7 @@
 					};
 					DA2E88501CC036F400F24E7B = {
 						CreatedOnToolsVersion = 7.3;
-						LastSwiftMigration = 0820;
+						LastSwiftMigration = 1010;
 					};
 					DA8847D11CBAF91600AB86E3 = {
 						CreatedOnToolsVersion = 7.3;
@@ -3900,7 +3900,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.test;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "../darwin/test/test-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = RelWithDebInfo;
 		};
@@ -4142,7 +4142,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "../darwin/test/test-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -4172,7 +4172,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.test;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "../darwin/test/test-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Migrated tests and the playground to Swift 4.2, resolving the following build warnings:

```
Warning Group
:-1: Swift 3 mode has been deprecated and will be removed in a later version of Xcode. Please migrate "test" to Swift 4.2 using "Convert > To Current Swift Syntax…" in the Edit menu. (in target 'test')
Swift Conversion Group
Conversion to Swift 4.2 is available
```

/cc @friedbunny @fabian-guerra