### PR TITLE
[android] Telemetry bump to 3.5.7

### DIFF
--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
     versions = [
             mapboxServices  : '3.4.1',
-            mapboxTelemetry : '3.5.6',
+            mapboxTelemetry : '3.5.7',
             mapboxGestures  : '0.3.0',
             supportLib      : '27.1.1',
             constraintLayout: '1.1.2',


### PR DESCRIPTION
This pr bumps the [Mapbox Android telemetry library](https://github.com/mapbox/mapbox-events-android) dependency to 3.5.7 . This pr targets `release-horchata` because in [@LukasPaczos ' pr which bumped it to `3.5.6`](https://github.com/mapbox/mapbox-gl-native/pull/13486), he said:

> Targeting `release-horchata` as this changes are not compatible with `master` that is already using telemetry `v4.x`.