### PR TITLE
[android] changelog for 6.8.1

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -13,6 +13,11 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 - CameraMode transition animation and result listeners[#13523](https://github.com/mapbox/mapbox-gl-native/pull/13523)
 - Validate if weakreference is still valid [#13555](https://github.com/mapbox/mapbox-gl-native/pull/13555)
 
+## 6.8.1 - December 21, 2018
+
+ - Telemetry bump to 3.5.7 [#13645](https://github.com/mapbox/mapbox-gl-native/pull/13645)
+ - Revert core styles back to streets-v7 source [#13643](https://github.com/mapbox/mapbox-gl-native/pull/13643)
+
 ## 6.8.0 - December 19, 2018
  - Update core styles based on the streets-v8 source. This results in breaking changes for any code that references internal layers and sources of the style [#13615](https://github.com/mapbox/mapbox-gl-native/pull/13615)
  - Fixed compass update time not getting updated [#13569](https://github.com/mapbox/mapbox-gl-native/pull/13569)


### PR DESCRIPTION
This pr updates the changelog with info about the `6.8.1` Maps SDK for Android release