### PR TITLE
[android] Revert core styles URLs back to streets-v7 source

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/Style.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/Style.java
@@ -34,25 +34,25 @@ public class Style {
    * constant means your map style will always use the latest version and may change as we
    * improve the style.
    */
-  public static final String MAPBOX_STREETS = "mapbox://styles/mapbox/streets-v11";
+  public static final String MAPBOX_STREETS = "mapbox://styles/mapbox/streets-v10";
 
   /**
    * Outdoors: A general-purpose style tailored to outdoor activities. Using this constant means
    * your map style will always use the latest version and may change as we improve the style.
    */
-  public static final String OUTDOORS = "mapbox://styles/mapbox/outdoors-v11";
+  public static final String OUTDOORS = "mapbox://styles/mapbox/outdoors-v10";
 
   /**
    * Light: Subtle light backdrop for data visualizations. Using this constant means your map
    * style will always use the latest version and may change as we improve the style.
    */
-  public static final String LIGHT = "mapbox://styles/mapbox/light-v10";
+  public static final String LIGHT = "mapbox://styles/mapbox/light-v9";
 
   /**
    * Dark: Subtle dark backdrop for data visualizations. Using this constant means your map style
    * will always use the latest version and may change as we improve the style.
    */
-  public static final String DARK = "mapbox://styles/mapbox/dark-v10";
+  public static final String DARK = "mapbox://styles/mapbox/dark-v9";
 
   /**
    * Satellite: A beautiful global satellite and aerial imagery layer. Using this constant means
@@ -65,7 +65,7 @@ public class Style {
    * constant means your map style will always use the latest version and may change as we
    * improve the style.
    */
-  public static final String SATELLITE_STREETS = "mapbox://styles/mapbox/satellite-streets-v11";
+  public static final String SATELLITE_STREETS = "mapbox://styles/mapbox/satellite-streets-v10";
 
   /**
    * Traffic Day: Color-coded roads based on live traffic congestion data. Traffic data is currently

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/strings.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/strings.xml
@@ -19,12 +19,12 @@
     <!-- these are public -->
     <!-- Using one of these constants means your map style will always use the latest version and
      may change as we improve the style. -->
-    <string name="mapbox_style_mapbox_streets" translatable="false">mapbox://styles/mapbox/streets-v11</string>
-    <string name="mapbox_style_outdoors" translatable="false">mapbox://styles/mapbox/outdoors-v11</string>
-    <string name="mapbox_style_light" translatable="false">mapbox://styles/mapbox/light-v10</string>
-    <string name="mapbox_style_dark" translatable="false">mapbox://styles/mapbox/dark-v10</string>
+    <string name="mapbox_style_mapbox_streets" translatable="false">mapbox://styles/mapbox/streets-v10</string>
+    <string name="mapbox_style_outdoors" translatable="false">mapbox://styles/mapbox/outdoors-v10</string>
+    <string name="mapbox_style_light" translatable="false">mapbox://styles/mapbox/light-v9</string>
+    <string name="mapbox_style_dark" translatable="false">mapbox://styles/mapbox/dark-v9</string>
     <string name="mapbox_style_satellite" translatable="false">mapbox://styles/mapbox/satellite-v9</string>
-    <string name="mapbox_style_satellite_streets" translatable="false">mapbox://styles/mapbox/satellite-streets-v11</string>
+    <string name="mapbox_style_satellite_streets" translatable="false">mapbox://styles/mapbox/satellite-streets-v10</string>
     <string name="mapbox_style_traffic_day" translatable="false">mapbox://styles/mapbox/traffic-day-v2</string>
     <string name="mapbox_style_traffic_night" translatable="false">mapbox://styles/mapbox/traffic-night-v2</string>
 </resources>


### PR DESCRIPTION
This pr reverts changes made in https://github.com/mapbox/mapbox-gl-native/pull/13615, which had bumped the style URLs to v10/v11. This pr is the same as https://github.com/mapbox/mapbox-gl-native/pull/13643 (now closed), but targets the `release-horchata` branch in preparation for an easier `6.8.1` release.

More info can be found at https://www.mapbox.com/vector-tiles/mapbox-streets-v8/

