### PR TITLE
[Qt] Support local font family in QMapboxGLSettings

### DIFF
--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -69,6 +69,9 @@ public:
     QString apiBaseUrl() const;
     void setApiBaseUrl(const QString &);
 
+    QString localFontFamily() const;
+    void setLocalFontFamily(const QString &);
+
     std::function<std::string(const std::string &&)> resourceTransform() const;
     void setResourceTransform(const std::function<std::string(const std::string &&)> &);
 
@@ -83,6 +86,7 @@ private:
     QString m_assetPath;
     QString m_accessToken;
     QString m_apiBaseUrl;
+    QString m_localFontFamily;
     std::function<std::string(const std::string &&)> m_resourceTransform;
 };
 

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -446,6 +446,27 @@ void QMapboxGLSettings::setApiBaseUrl(const QString& url)
 }
 
 /*!
+    Returns the local font family. Returns an empty string if no local font family is set.
+*/
+QString QMapboxGLSettings::localFontFamily() const
+{
+    return m_localFontFamily;
+}
+
+/*!
+    Sets the local font family.
+
+   Rendering Chinese/Japanese/Korean (CJK) ideographs and precomposed Hangul Syllables requires
+   downloading large amounts of font data, which can significantly slow map load times. Use the
+   localIdeographFontFamily setting to speed up map load times by using locally available fonts
+   instead of font data fetched from the server.
+*/
+void QMapboxGLSettings::setLocalFontFamily(const QString &family)
+{
+    m_localFontFamily = family;
+}
+
+/*!
     Returns resource transformation callback used to transform requested URLs.
 */
 std::function<std::string(const std::string &&)> QMapboxGLSettings::resourceTransform() const
@@ -1723,6 +1744,7 @@ QMapboxGLPrivate::QMapboxGLPrivate(QMapboxGL *q, const QMapboxGLSettings &settin
     , m_threadPool(mbgl::sharedThreadPool())
     , m_mode(settings.contextMode())
     , m_pixelRatio(pixelRatio_)
+    , m_localFontFamily(settings.localFontFamily())
 {
     // Setup the FileSource
     m_fileSourceObj->setAccessToken(settings.accessToken().toStdString());
@@ -1802,7 +1824,8 @@ void QMapboxGLPrivate::createRenderer()
         m_pixelRatio,
         *m_fileSourceObj,
         *m_threadPool,
-        m_mode
+        m_mode,
+        m_localFontFamily
     );
 
     connect(m_mapRenderer.get(), SIGNAL(needsRendering()), this, SLOT(requestRendering()));

--- a/platform/qt/src/qmapboxgl_map_renderer.cpp
+++ b/platform/qt/src/qmapboxgl_map_renderer.cpp
@@ -25,8 +25,9 @@ static auto *getScheduler() {
 };
 
 QMapboxGLMapRenderer::QMapboxGLMapRenderer(qreal pixelRatio,
-        mbgl::DefaultFileSource &fs, mbgl::ThreadPool &tp, QMapboxGLSettings::GLContextMode mode)
-    : m_renderer(std::make_unique<mbgl::Renderer>(m_backend, pixelRatio, fs, tp, static_cast<mbgl::GLContextMode>(mode)))
+        mbgl::DefaultFileSource &fs, mbgl::ThreadPool &tp, QMapboxGLSettings::GLContextMode mode, const QString &localFontFamily)
+    : m_renderer(std::make_unique<mbgl::Renderer>(m_backend, pixelRatio, fs, tp, static_cast<mbgl::GLContextMode>(mode), mbgl::optional<std::string> {},
+                 localFontFamily.isEmpty() ? mbgl::nullopt : mbgl::optional<std::string> { localFontFamily.toStdString() }))
     , m_forceScheduler(needsToForceScheduler())
 {
     // If we don't have a Scheduler on this thread, which

--- a/platform/qt/src/qmapboxgl_map_renderer.hpp
+++ b/platform/qt/src/qmapboxgl_map_renderer.hpp
@@ -28,7 +28,8 @@ class QMapboxGLMapRenderer : public QObject
 
 public:
     QMapboxGLMapRenderer(qreal pixelRatio, mbgl::DefaultFileSource &,
-            mbgl::ThreadPool &, QMapboxGLSettings::GLContextMode);
+            mbgl::ThreadPool &, QMapboxGLSettings::GLContextMode,
+            const QString &localFontFamily);
     virtual ~QMapboxGLMapRenderer();
 
     void render();

--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -65,5 +65,7 @@ private:
     QMapboxGLSettings::GLContextMode m_mode;
     qreal m_pixelRatio;
 
+    QString m_localFontFamily;
+
     std::atomic_flag m_renderQueued = ATOMIC_FLAG_INIT;
 };


### PR DESCRIPTION
This enables using a locally-generated font glyph from the given font family name.