### PR TITLE
[ios, macos] Added missing mapViewDidBecomeIdle for iOS. Fixed typo.

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -5988,6 +5988,16 @@ public:
     }
 }
 
+- (void)mapViewDidBecomeIdle {
+    if (!_mbglMap) {
+        return;
+    }
+    
+    if ([self.delegate respondsToSelector:@selector(mapViewDidBecomeIdle:)]) {
+        [self.delegate mapViewDidBecomeIdle:self];
+    }
+}
+
 - (void)didFinishLoadingStyle {
     if (!_mbglMap)
     {
@@ -6546,6 +6556,10 @@ public:
         [nativeView mapViewDidFinishRenderingMapFullyRendered:fullyRendered];
     }
 
+    void onDidBecomeIdle() override {
+        [nativeView mapViewDidBecomeIdle];
+    }
+    
     void onDidFinishLoadingStyle() override {
         [nativeView didFinishLoadingStyle];
     }

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -939,7 +939,7 @@ public:
         return;
     }
     
-    if ([self.delegate respondsToSelector:@selector(mapViewDidBecomeIdle)]) {
+    if ([self.delegate respondsToSelector:@selector(mapViewDidBecomeIdle:)]) {
         [self.delegate mapViewDidBecomeIdle:self];
     }
 }


### PR DESCRIPTION
Follow on from https://github.com/mapbox/mapbox-gl-native/pull/13513

This PR adds the `mapViewDidBecomeIdle` method to iOS, and fixes the selector check in the macOS version.