### PR TITLE
[core] shader program must always match bucket in render symbol layer

### DIFF
--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -9,9 +9,9 @@ namespace mbgl {
 using namespace style;
 
 SymbolBucket::SymbolBucket(style::SymbolLayoutProperties::PossiblyEvaluated layout_,
-                           const std::map<std::string, std::pair<
+                           std::map<std::string, std::pair<
                                style::IconPaintProperties::PossiblyEvaluated,
-                               style::TextPaintProperties::PossiblyEvaluated>>& layerPaintProperties,
+                               style::TextPaintProperties::PossiblyEvaluated>> layerPaintProperties,
                            const style::PropertyValue<float>& textSize,
                            const style::PropertyValue<float>& iconSize,
                            float zoom,
@@ -27,10 +27,11 @@ SymbolBucket::SymbolBucket(style::SymbolLayoutProperties::PossiblyEvaluated layo
       sortFeaturesByY(sortFeaturesByY_),
       bucketLeaderID(std::move(bucketName_)),
       symbolInstances(std::move(symbolInstances_)),
+      paintProperties(std::move(layerPaintProperties)),
       textSizeBinder(SymbolSizeBinder::create(zoom, textSize, TextSize::defaultValue())),
       iconSizeBinder(SymbolSizeBinder::create(zoom, iconSize, IconSize::defaultValue())) {
 
-    for (const auto& pair : layerPaintProperties) {
+    for (const auto& pair : paintProperties) {
         paintPropertyBinders.emplace(
             std::piecewise_construct,
             std::forward_as_tuple(pair.first),

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -40,7 +40,7 @@ public:
 class SymbolBucket : public Bucket {
 public:
     SymbolBucket(style::SymbolLayoutProperties::PossiblyEvaluated,
-                 const std::map<std::string, std::pair<style::IconPaintProperties::PossiblyEvaluated, style::TextPaintProperties::PossiblyEvaluated>>&,
+                 std::map<std::string, std::pair<style::IconPaintProperties::PossiblyEvaluated, style::TextPaintProperties::PossiblyEvaluated>>,
                  const style::PropertyValue<float>& textSize,
                  const style::PropertyValue<float>& iconSize,
                  float zoom,
@@ -75,6 +75,10 @@ public:
     bool sortUploaded = false;
 
     std::vector<SymbolInstance> symbolInstances;
+
+    std::map<std::string, std::pair<
+            style::IconPaintProperties::PossiblyEvaluated,
+            style::TextPaintProperties::PossiblyEvaluated>> paintProperties;
 
     std::map<std::string, std::pair<
         SymbolIconProgram::PaintPropertyBinders,

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -153,7 +153,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
 
         if (bucket.hasIconData()) {
             auto values = iconPropertyValues(layout);
-            auto paintPropertyValues = iconPaintProperties();
+            const auto& paintPropertyValues = bucket.paintProperties.at(getID()).first;
 
             const bool alongLine = layout.get<SymbolPlacement>() != SymbolPlacementType::Point &&
                 layout.get<IconRotationAlignment>() == AlignmentType::Map;
@@ -214,7 +214,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
             parameters.context.bindTexture(*geometryTile.glyphAtlasTexture, 0, gl::TextureFilter::Linear);
 
             auto values = textPropertyValues(layout);
-            auto paintPropertyValues = textPaintProperties();
+            const auto& paintPropertyValues = bucket.paintProperties.at(getID()).second;
 
             const bool alongLine = layout.get<SymbolPlacement>() != SymbolPlacementType::Point &&
                 layout.get<TextRotationAlignment>() == AlignmentType::Map;


### PR DESCRIPTION
Before this change, `RenderSymbolLayer` with updated style was trying to render
symbols using the previous bucket (with paint property binders that matched a previous program).