### PR TITLE
[core,ios,macos] Re-apply default styles to streets v11, etc. (#13585)

### DIFF
--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
     the constant itself. Such details may change significantly from version to
     version.
  */
-static MGL_EXPORT const NSInteger MGLStyleDefaultVersion = 10;
+static MGL_EXPORT const NSInteger MGLStyleDefaultVersion = 11;
 
 FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLInvalidStyleURLException;
 FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLRedundantLayerException;

--- a/platform/default/mbgl/util/default_styles.hpp
+++ b/platform/default/mbgl/util/default_styles.hpp
@@ -13,12 +13,12 @@ struct DefaultStyle {
     const unsigned currentVersion;
 };
 
-constexpr const DefaultStyle streets          = { "mapbox://styles/mapbox/streets-v10",           "Streets",           10 };
-constexpr const DefaultStyle outdoors         = { "mapbox://styles/mapbox/outdoors-v10",          "Outdoors",          10 };
-constexpr const DefaultStyle light            = { "mapbox://styles/mapbox/light-v9",              "Light",              9 };
-constexpr const DefaultStyle dark             = { "mapbox://styles/mapbox/dark-v9",               "Dark",               9 };
+constexpr const DefaultStyle streets          = { "mapbox://styles/mapbox/streets-v11",           "Streets",           11 };
+constexpr const DefaultStyle outdoors         = { "mapbox://styles/mapbox/outdoors-v11",          "Outdoors",          11 };
+constexpr const DefaultStyle light            = { "mapbox://styles/mapbox/light-v10",             "Light",             10 };
+constexpr const DefaultStyle dark             = { "mapbox://styles/mapbox/dark-v10",              "Dark",              10 };
 constexpr const DefaultStyle satellite        = { "mapbox://styles/mapbox/satellite-v9",          "Satellite",          9 };
-constexpr const DefaultStyle satelliteStreets = { "mapbox://styles/mapbox/satellite-streets-v10", "Satellite Streets", 10 };
+constexpr const DefaultStyle satelliteStreets = { "mapbox://styles/mapbox/satellite-streets-v11", "Satellite Streets", 11 };
 
 const DefaultStyle orderedStyles[] = {
     streets, outdoors, light, dark, satellite, satelliteStreets,

--- a/platform/ios/Integration Tests/MGLStyleURLIntegrationTest.m
+++ b/platform/ios/Integration Tests/MGLStyleURLIntegrationTest.m
@@ -1,0 +1,42 @@
+#import "MGLMapViewIntegrationTest.h"
+
+@interface MGLStyleURLIntegrationTest : MGLMapViewIntegrationTest
+@end
+
+@implementation MGLStyleURLIntegrationTest
+
+- (void)internalTestWithStyleSelector:(SEL)selector {
+    if (![self validAccessToken]) {
+        return;
+    }
+
+    self.mapView.styleURL = [MGLStyle performSelector:selector];
+    [self waitForMapViewToFinishLoadingStyleWithTimeout:5];
+}
+
+
+- (void)testLoadingStreetsStyleURL {
+    [self internalTestWithStyleSelector:@selector(streetsStyleURL)];
+}
+
+- (void)testLoadingOutdoorsStyleURL {
+    [self internalTestWithStyleSelector:@selector(outdoorsStyleURL)];
+}
+
+- (void)testLoadingLightStyleURL {
+    [self internalTestWithStyleSelector:@selector(lightStyleURL)];
+}
+
+- (void)testLoadingDarkStyleURL {
+    [self internalTestWithStyleSelector:@selector(darkStyleURL)];
+}
+
+- (void)testLoadingSatelliteStyleURL {
+    [self internalTestWithStyleSelector:@selector(satelliteStyleURL)];
+}
+
+- (void)testLoadingSatelliteStreetsStyleURL {
+    [self internalTestWithStyleSelector:@selector(satelliteStreetsStyleURL)];
+}
+
+@end

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -431,6 +431,7 @@
 		CA55CD41202C16AA00CE7095 /* MGLCameraChangeReason.h in Headers */ = {isa = PBXBuildFile; fileRef = CA55CD3E202C16AA00CE7095 /* MGLCameraChangeReason.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CA55CD42202C16AA00CE7095 /* MGLCameraChangeReason.h in Headers */ = {isa = PBXBuildFile; fileRef = CA55CD3E202C16AA00CE7095 /* MGLCameraChangeReason.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CA6914B520E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA6914B420E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.m */; };
+		CA88DC3021C85D900059ED5A /* MGLStyleURLIntegrationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CA88DC2F21C85D900059ED5A /* MGLStyleURLIntegrationTest.m */; };
 		CA8FBC0921A47BB100D1203C /* MGLRendererConfigurationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CA8FBC0821A47BB100D1203C /* MGLRendererConfigurationTests.mm */; };
 		CAA69DA4206DCD0E007279CD /* Mapbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA4A26961CB6E795000B7809 /* Mapbox.framework */; };
 		CAA69DA5206DCD0E007279CD /* Mapbox.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DA4A26961CB6E795000B7809 /* Mapbox.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -1096,6 +1097,7 @@
 		CA55CD3E202C16AA00CE7095 /* MGLCameraChangeReason.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLCameraChangeReason.h; sourceTree = "<group>"; };
 		CA5E5042209BDC5F001A8A81 /* MGLTestUtility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MGLTestUtility.h; path = ../../darwin/test/MGLTestUtility.h; sourceTree = "<group>"; };
 		CA6914B420E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MGLAnnotationViewIntegrationTests.m; path = "Annotation Tests/MGLAnnotationViewIntegrationTests.m"; sourceTree = "<group>"; };
+		CA88DC2F21C85D900059ED5A /* MGLStyleURLIntegrationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLStyleURLIntegrationTest.m; sourceTree = "<group>"; };
 		CA8FBC0821A47BB100D1203C /* MGLRendererConfigurationTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLRendererConfigurationTests.mm; path = ../../darwin/test/MGLRendererConfigurationTests.mm; sourceTree = "<group>"; };
 		CAE7AD5320F46EF5003B6782 /* integration-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "integration-Bridging-Header.h"; sourceTree = "<group>"; };
 		CAE7AD5420F46EF5003B6782 /* MGLMapSnapshotterSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MGLMapSnapshotterSwiftTests.swift; sourceTree = "<group>"; };
@@ -1437,6 +1439,7 @@
 				CA0C27932076CA19001CE5B7 /* MGLMapViewIntegrationTest.m */,
 				CA0C27952076CA50001CE5B7 /* MGLMapViewIntegrationTest.h */,
 				CA4EB8C620863487006AB465 /* MGLStyleLayerIntegrationTests.m */,
+				CA88DC2F21C85D900059ED5A /* MGLStyleURLIntegrationTest.m */,
 				077061DB215DA11F000FEF62 /* MGLTestLocationManager.h */,
 				077061D9215DA00E000FEF62 /* MGLTestLocationManager.m */,
 			);
@@ -2933,6 +2936,7 @@
 				CA4EB8C720863487006AB465 /* MGLStyleLayerIntegrationTests.m in Sources */,
 				CA34C9C3207FD272005C1A06 /* MGLCameraTransitionTests.mm in Sources */,
 				16376B0A1FFD9DAF0000563E /* MBGLIntegrationTests.m in Sources */,
+				CA88DC3021C85D900059ED5A /* MGLStyleURLIntegrationTest.m in Sources */,
 				CA0C27942076CA19001CE5B7 /* MGLMapViewIntegrationTest.m in Sources */,
 				CAE7AD5520F46EF5003B6782 /* MGLMapSnapshotterSwiftTests.swift in Sources */,
 				CA0C27922076C804001CE5B7 /* MGLShapeSourceTests.m in Sources */,

--- a/test/util/mapbox.test.cpp
+++ b/test/util/mapbox.test.cpp
@@ -92,9 +92,9 @@ TEST(Mapbox, SpriteURL) {
         "https://api.mapbox.com/styles/v1/mapbox/streets-v8/draft/sprite@2x.png?access_token=key",
         mbgl::util::mapbox::normalizeSpriteURL(util::API_BASE_URL, "mapbox://sprites/mapbox/streets-v8/draft@2x.png", "key"));
     EXPECT_EQ(
-        "https://api.mapbox.com/styles/v1/mapbox/streets-v10/sprite?access_token=key&fresh=true.png",
+        "https://api.mapbox.com/styles/v1/mapbox/streets-v11/sprite?access_token=key&fresh=true.png",
         mbgl::util::mapbox::normalizeSpriteURL(util::API_BASE_URL,
-            "mapbox://sprites/mapbox/streets-v10?fresh=true.png",
+            "mapbox://sprites/mapbox/streets-v11?fresh=true.png",
             "key"));
     EXPECT_EQ("mapbox://////", mbgl::util::mapbox::normalizeSpriteURL(util::API_BASE_URL, "mapbox://////", "key"));
 }


### PR DESCRIPTION
Brings back streets v11 to `release-iowaska`