### PR TITLE
[macos] - Update links to new API doc format

### DIFF
--- a/platform/darwin/src/MGLRasterTileSource.h
+++ b/platform/darwin/src/MGLRasterTileSource.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
  integers.
 
  The default value for this option is 512. Version 4 of the
- <a href="https://www.mapbox.com/api-documentation/#maps">Mapbox Maps API</a>
+ <a href="https://www.mapbox.com/api-documentation/maps/#maps">Mapbox Maps API</a>
  requires a value of 256, as do many third-party tile servers, so consult your
  provider’s documentation for the correct value.
 
@@ -52,7 +52,7 @@ FOUNDATION_EXTERN MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionTileSi
  ])
  mapView.style?.addSource(source)
  ```
- 
+
  #### Related examples
  See the <a href="https://www.mapbox.com/ios-sdk/maps/examples/source-custom-raster/">
  Add raster imagery</a> example to learn how to add a `MGLRasterStyleLayer`

--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
  as of the date on which this SDK was published. You can use this constant to
  ascertain the style used by `MGLMapView` and `MGLTilePyramidOfflineRegion` when
  no style URL is specified. Consult the
- <a href="https://www.mapbox.com/api-documentation/#styles">Mapbox Styles API documentation</a>
+ <a href="https://www.mapbox.com/api-documentation/maps/#styles">Mapbox Styles API documentation</a>
  for the most up-to-date style versioning information.
 
  @warning The value of this constant may change in a future release of the SDK.
@@ -52,7 +52,7 @@ FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLRedundantSourceIdentifier
     `-[MGLMapViewDelegate mapView:didFinishLoadingStyle:]` or
     `-[MGLMapViewDelegate mapViewDidFinishLoadingMap:]` methods as indicators
     that it's safe to modify the map's style.
- 
+
  #### Related examples
  See the <a href="https://www.mapbox.com/ios-sdk/maps/examples/default-styles/">
  Default styles</a> example to learn how to initialize an `MGLMapView` object
@@ -182,7 +182,7 @@ MGL_EXPORT
     instance, the raster tile sets included in the style – use the
     `-satelliteStyleURLWithVersion:` method instead. Such details may change
     significantly from version to version.
- 
+
  #### Related example
  See the <a href="https://www.mapbox.com/ios-sdk/maps/examples/satellite-style/">
  Satellite styles</a> example to learn how to initialize a map with the Mapbox
@@ -218,7 +218,7 @@ MGL_EXPORT
     instance, the minimum zoom level that includes roads – use the
     `-satelliteStreetsStyleURLWithVersion:` method instead. Such details may
     change significantly from version to version.
- 
+
  #### Related example
  See the <a href="https://www.mapbox.com/ios-sdk/maps/examples/satellite-style/">
  Satellite styles</a> example to learn how to initialize a map with the Mapbox
@@ -272,7 +272,7 @@ MGL_EXPORT
 
 /**
  A boolean value indicating whether label placement transitions are enabled.
- 
+
  The default value of this property is `YES`.
  */
 @property (nonatomic, assign) BOOL performsPlacementTransitions;
@@ -327,7 +327,7 @@ MGL_EXPORT
 
 /**
  Removes a source from the current style.
- 
+
  @note Source identifiers are not guaranteed to exist across styles or different
  versions of the same style. Applications that use this API must first set the
  style URL to an explicitly versioned style using a convenience method like
@@ -335,11 +335,11 @@ MGL_EXPORT
  inspectable in Interface Builder, or a manually constructed `NSURL`. This
  approach also avoids source identifer name changes that will occur in the default
  style’s sources over time.
- 
+
  @param source The source to remove from the current style.
  @param outError Upon return, if an error has occurred, a pointer to an `NSError`
  object describing the error. Pass in `NULL` to ignore any error.
- 
+
  @return `YES` if `source` was removed successfully. If `NO`, `outError` contains
  an `NSError` object describing the problem.
  */
@@ -424,7 +424,7 @@ MGL_EXPORT
 
  @param layer The layer to insert.
  @param sibling An existing layer in the style.
- 
+
  #### Related examples
  See the <a href="https://www.mapbox.com/ios-sdk/maps/examples/shape-collection/">
  Add multiple shapes from a single shape source</a> example to learn how to
@@ -449,7 +449,7 @@ MGL_EXPORT
 
  @param layer The layer to insert.
  @param sibling An existing layer in the style.
- 
+
  #### Related examples
  See the <a href="https://www.mapbox.com/ios-sdk/maps/examples/image-source/">
  Add an image</a> example to learn how to add a layer to your map above an
@@ -512,7 +512,7 @@ MGL_EXPORT
 
  @param image The image for the name.
  @param name The name of the image to set to the style.
- 
+
  #### Related examples
  See the <a href="https://www.mapbox.com/ios-sdk/maps/examples/clustering-with-images/">
  Use images to cluster point data</a> and <a href="https://www.mapbox.com/ios-sdk/maps/examples/clustering/">
@@ -548,14 +548,14 @@ MGL_EXPORT
 
 /**
  Attempts to localize labels in the style into the given locale.
- 
+
  This method automatically modifies the text property of any symbol style layer
  in the style whose source is the
  <a href="https://www.mapbox.com/vector-tiles/mapbox-streets-v8/#overview">Mapbox Streets source</a>.
  On iOS, the user can set the system’s preferred language in Settings, General
  Settings, Language & Region. On macOS, the user can set the system’s preferred
  language in the Language & Region pane of System Preferences.
- 
+
  @param locale The locale into which labels should be localized. To use the
     system’s preferred language, if supported, specify `nil`. To use the local
     language, specify a locale with the identifier `mul`.


### PR DESCRIPTION
🚧 Do not merge until API documentation changes land 🚧

This PR updates links to the API docs to match the new URL structure.

cc @mapbox/docs