### PR TITLE
[ios] - Update links to new API doc format

### DIFF
--- a/platform/ios/Integration Tests/MGLStyleLayerIntegrationTests.m
+++ b/platform/ios/Integration Tests/MGLStyleLayerIntegrationTests.m
@@ -15,7 +15,7 @@
 
     MGLCircleStyleLayer *layer = [[MGLCircleStyleLayer alloc] initWithIdentifier: @"tree-style" source:source];
 
-    // The source name from the source's TileJSON metadata: mapbox.com/api-documentation/#retrieve-tilejson-metadata
+    // The source name from the source's TileJSON metadata: mapbox.com/api-documentation/maps/#retrieve-tilejson-metadata
     layer.sourceLayerIdentifier = @"yoshino-trees-a0puw5";
 
     return layer;


### PR DESCRIPTION
🚧 Do not merge until API documentation changes land 🚧

This PR updates links to the API docs to match the new URL structure.

cc @mapbox/docs