### PR TITLE
Prevent map view on external display from sleeping in background

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -9,7 +9,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed a bug where the `animated` parameter to `-[MGLMapView selectAnnotation:animated:]` was being ignored. ([#13689](https://github.com/mapbox/mapbox-gl-native/pull/13689))
 * Reinstates version 11 as the default Mapbox Streets style (as introduced in 4.7.0). ([#13690](https://github.com/mapbox/mapbox-gl-native/pull/13690))
 * Added the `-[MGLShapeSource leavesOfCluster:offset:limit:]`, `-[MGLShapeSource childrenOfCluster:]`, `-[MGLShapeSource zoomLevelForExpandingCluster:]` methods for inspecting a cluster in an `MGLShapeSource`s created with the `MGLShapeSourceOptionClustered` option. Feature querying now returns clusters represented by `MGLPointFeatureCluster` objects (that conform to the `MGLCluster` protocol). ([#12952](https://github.com/mapbox/mapbox-gl-native/pull/12952)
-
+* `MGLMapView` no longer freezes on external displays connected through AirPlay or CarPlay when the main device’s screen goes to sleep or the user manually locks the screen. ([#13701](https://github.com/mapbox/mapbox-gl-native/pull/13701))
 
 ## 4.7.1 - December 21, 2018
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -205,6 +205,7 @@ CLLocationCoordinate2D randomWorldCoordinate() {
 @property (nonatomic) BOOL frameTimeGraphEnabled;
 @property (nonatomic) BOOL shouldLimitCameraChanges;
 @property (nonatomic) BOOL randomWalk;
+@property (nonatomic) NSMutableArray<UIWindow *> *helperWindows;
 
 @end
 
@@ -289,6 +290,32 @@ CLLocationCoordinate2D randomWorldCoordinate() {
         }
     }
     [self.mapView addGestureRecognizer:singleTap];
+    
+    // Display a secondary map on any connected external display.
+    // https://developer.apple.com/documentation/uikit/windows_and_screens/displaying_content_on_a_connected_screen?language=objc
+    self.helperWindows = [NSMutableArray array];
+    [[NSNotificationCenter defaultCenter] addObserverForName:UIScreenDidConnectNotification object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
+        UIScreen *helperScreen = note.object;
+        UIWindow *helperWindow = [[UIWindow alloc] initWithFrame:helperScreen.bounds];
+        helperWindow.screen = helperScreen;
+        UIViewController *helperViewController = [[UIViewController alloc] init];
+        MGLMapView *helperMapView = [[MGLMapView alloc] initWithFrame:helperWindow.bounds styleURL:MGLStyle.satelliteStreetsStyleURL];
+        helperMapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        helperMapView.camera = self.mapView.camera;
+        helperMapView.compassView.hidden = YES;
+        helperViewController.view = helperMapView;
+        helperWindow.rootViewController = helperViewController;
+        helperWindow.hidden = NO;
+        [self.helperWindows addObject:helperWindow];
+    }];
+    [[NSNotificationCenter defaultCenter] addObserverForName:UIScreenDidDisconnectNotification object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
+        UIScreen *helperScreen = note.object;
+        for (UIWindow *window in self.helperWindows) {
+            if (window.screen == helperScreen) {
+                [self.helperWindows removeObject:window];
+            }
+        }
+    }];
 }
 
 - (void)saveState:(__unused NSNotification *)notification
@@ -2214,6 +2241,7 @@ CLLocationCoordinate2D randomWorldCoordinate() {
 - (void)mapViewRegionIsChanging:(MGLMapView *)mapView
 {
     [self updateHUD];
+    [self updateHelperMapViews];
 }
 
 - (void)mapView:(MGLMapView *)mapView regionDidChangeWithReason:(MGLCameraChangeReason)reason animated:(BOOL)animated
@@ -2223,10 +2251,18 @@ CLLocationCoordinate2D randomWorldCoordinate() {
     }
 
     [self updateHUD];
+    [self updateHelperMapViews];
 }
 
 - (void)mapView:(MGLMapView *)mapView didUpdateUserLocation:(MGLUserLocation *)userLocation {
     [self updateHUD];
+}
+
+- (void)updateHelperMapViews {
+    for (UIWindow *window in self.helperWindows) {
+        MGLMapView *mapView = (MGLMapView *)window.rootViewController.view;
+        mapView.camera = self.mapView.camera;
+    }
 }
 
 - (void)updateHUD {

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1222,7 +1222,7 @@ public:
             self.mbglMap.setConstrainMode(mbgl::ConstrainMode::HeightOnly);
         }
 
-        _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(updateFromDisplayLink)];
+        _displayLink = [self.window.screen displayLinkWithTarget:self selector:@selector(updateFromDisplayLink)];
         [self updateDisplayLinkPreferredFramesPerSecond];
         [_displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
         _needsDisplayRefresh = YES;
@@ -1301,6 +1301,16 @@ public:
 
 - (void)sleepGL:(__unused NSNotification *)notification
 {
+    // If this view targets an external display, such as AirPlay or CarPlay, we
+    // can safely continue to render OpenGL content without tripping
+    // gpus_ReturnNotPermittedKillClient in libGPUSupportMercury, because the
+    // external connection keeps the application from truly receding to the
+    // background.
+    if (self.window.screen != [UIScreen mainScreen])
+    {
+        return;
+    }
+    
     MGLLogInfo(@"Entering background.");
     MGLAssertIsMainThread();
     


### PR DESCRIPTION
Fixed an issue where an MGLMapView targeting an external display via CarPlay would freeze, ignoring both programmatic changes and user gestures, whenever the main device’s screen fell asleep automatically or the user manually locked the screen.

MGLMapView has to tiptoe around a hard prohibition against OpenGL rendering when the application recedes into the background or enters background mode, exhibited in crashes such as #1198 and #1460. However, if an application integrates the navigation SDK and is connected to CarPlay, the application will stay active even when the screen is locked.

This PR also includes a change to iosapp to show a map view on any connected external display and keep it synchronized with the map on the main display. This iosapp feature only works with AirPlay, not CarPlay, which requires a special delegate and entitlement.

There are a few edge cases to test before we can feel confident about this fix:

* If the user uses the iOS application switcher, the application becomes inactive on both the iOS device and CarPlay. What happens if an animation is scheduled or underway?
* Despite the changelog entry, I’m only speculating that this fix works for AirPlay as it does for CarPlay. In particular, I’ve yet to test the behavior when AirPlay _mirroring_ is enabled (as opposed to distinct content). It’d be unsurprising if the mirrored screen froze, going dark, reflecting the state of the main screen. However, it would be problematic if, when locking the main screen, an ongoing, mirrored animation were to trigger the libGPUSupportMercury crash.
* I haven’t tested whether there’s a regression when an external display is connected but the application isn’t registered for the `audio` (“Audio, AirPlay, and Picture in Picture”) background mode. That case is quite unlikely in conjunction with the navigation SDK and CarPlay, but it’s plausible for ordinary AirPlay-enabled applications.

Fixes mapbox/mapbox-navigation-ios#1774.

/cc @mapbox/maps-ios @mapbox/navigation-ios