### PR TITLE
Throw exception when setting an maxfps while the mapRenderer isn't created yet

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -430,6 +430,8 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   public void setMaximumFps(int maximumFps) {
     if (mapRenderer != null) {
       mapRenderer.setMaximumFps(maximumFps);
+    } else {
+      throw new IllegalStateException("Calling MapView#setMaximumFps before mapRenderer is created.");
     }
   }
 


### PR DESCRIPTION
To avoid confusion for developers integrating, I'm suggesting to throw a runtime exception when an too early invocation of `setMaximumFps` occurs. Otherwise not setting this configuration might get unnoticed. 