### PR TITLE
[android] Add layer_manager_initialize.cpp file

### DIFF
--- a/platform/android/core-files.json
+++ b/platform/android/core-files.json
@@ -64,6 +64,7 @@
         "platform/android/src/style/layers/hillshade_layer.cpp",
         "platform/android/src/style/layers/layer.cpp",
         "platform/android/src/style/layers/layer_manager.cpp",
+        "platform/android/src/style/layers/layer_manager_initialize.cpp",
         "platform/android/src/style/layers/line_layer.cpp",
         "platform/android/src/style/layers/raster_layer.cpp",
         "platform/android/src/style/layers/symbol_layer.cpp",

--- a/platform/android/src/style/layers/layer_manager.cpp
+++ b/platform/android/src/style/layers/layer_manager.cpp
@@ -6,33 +6,12 @@
 #include <mbgl/style/conversion/filter.hpp>
 #include <mbgl/style/conversion_impl.hpp>
 
-#include "background_layer.hpp"
-#include "circle_layer.hpp"
-#include "custom_layer.hpp"
-#include "fill_extrusion_layer.hpp"
-#include "fill_layer.hpp"
-#include "heatmap_layer.hpp"
-#include "hillshade_layer.hpp"
-#include "line_layer.hpp"
-#include "raster_layer.hpp"
-#include "symbol_layer.hpp"
-#include "fill_extrusion_layer.hpp"
-
 namespace mbgl {
 
 namespace android {
 
 LayerManagerAndroid::LayerManagerAndroid() {
-    addLayerType(std::make_unique<FillJavaLayerPeerFactory>());
-    addLayerType(std::make_unique<LineJavaLayerPeerFactory>());
-    addLayerType(std::make_unique<CircleJavaLayerPeerFactory>());
-    addLayerType(std::make_unique<SymbolJavaLayerPeerFactory>());
-    addLayerType(std::make_unique<RasterJavaLayerPeerFactory>());
-    addLayerType(std::make_unique<BackgroundJavaLayerPeerFactory>());
-    addLayerType(std::make_unique<HillshadeJavaLayerPeerFactory>());
-    addLayerType(std::make_unique<FillExtrusionJavaLayerPeerFactory>());
-    addLayerType(std::make_unique<HeatmapJavaLayerPeerFactory>());
-    addLayerType(std::make_unique<CustomJavaLayerPeerFactory>());
+   initialize();
 }
 
 LayerManagerAndroid::~LayerManagerAndroid() = default;
@@ -122,7 +101,5 @@ LayerManagerAndroid* LayerManagerAndroid::get() noexcept {
 LayerManager* LayerManager::get() noexcept {
     return android::LayerManagerAndroid::get();
 }
-
-const bool LayerManager::annotationsEnabled = true;
 
 } // namespace mbgl

--- a/platform/android/src/style/layers/layer_manager.hpp
+++ b/platform/android/src/style/layers/layer_manager.hpp
@@ -29,6 +29,8 @@ public:
 
 private:
     LayerManagerAndroid();
+
+    void initialize();
     /**
      * @brief Enables a layer type for both JSON style and runtime API.
      */

--- a/platform/android/src/style/layers/layer_manager_initialize.cpp
+++ b/platform/android/src/style/layers/layer_manager_initialize.cpp
@@ -1,0 +1,36 @@
+#include "layer_manager.hpp"
+
+#include "background_layer.hpp"
+#include "circle_layer.hpp"
+#include "custom_layer.hpp"
+#include "fill_extrusion_layer.hpp"
+#include "fill_layer.hpp"
+#include "heatmap_layer.hpp"
+#include "hillshade_layer.hpp"
+#include "line_layer.hpp"
+#include "raster_layer.hpp"
+#include "symbol_layer.hpp"
+#include "fill_extrusion_layer.hpp"
+
+namespace mbgl {
+
+namespace android {
+
+void LayerManagerAndroid::initialize() {
+    addLayerType(std::make_unique<FillJavaLayerPeerFactory>());
+    addLayerType(std::make_unique<LineJavaLayerPeerFactory>());
+    addLayerType(std::make_unique<CircleJavaLayerPeerFactory>());
+    addLayerType(std::make_unique<SymbolJavaLayerPeerFactory>());
+    addLayerType(std::make_unique<RasterJavaLayerPeerFactory>());
+    addLayerType(std::make_unique<BackgroundJavaLayerPeerFactory>());
+    addLayerType(std::make_unique<HillshadeJavaLayerPeerFactory>());
+    addLayerType(std::make_unique<FillExtrusionJavaLayerPeerFactory>());
+    addLayerType(std::make_unique<HeatmapJavaLayerPeerFactory>());
+    addLayerType(std::make_unique<CustomJavaLayerPeerFactory>());
+}
+
+} // namespace android
+
+const bool LayerManager::annotationsEnabled = true;
+
+} // namespace mbgl


### PR DESCRIPTION
The newly added `layer_manager_initialize.cpp` file encapsulates the
parts of the layer manager implementation, responsible for
enabling/disabling of the layer modules.

The client code can provide its own `layer_manager_initialize.cpp` file
in order to disable certain layer types.