### PR TITLE
Ability to choose which Layers to compile

### DIFF
--- a/platform/android/src/style/layers/layer_manager.cpp
+++ b/platform/android/src/style/layers/layer_manager.cpp
@@ -23,16 +23,56 @@ namespace mbgl {
 namespace android {
 
 LayerManagerAndroid::LayerManagerAndroid() {
+#if defined(MBGL_LAYER_FILL_DISABLE_RUNTIME)
+    addLayerTypeCoreOnly(std::make_unique<FillJavaLayerPeerFactory>());
+#elif !defined(MBGL_LAYER_FILL_DISABLE_ALL)
     addLayerType(std::make_unique<FillJavaLayerPeerFactory>());
+#endif
+#if defined(MBGL_LAYER_LINE_DISABLE_RUNTIME)
+    addLayerTypeCoreOnly(std::make_unique<LineJavaLayerPeerFactory>());
+#elif !defined(MBGL_LAYER_LINE_DISABLE_ALL)
     addLayerType(std::make_unique<LineJavaLayerPeerFactory>());
+#endif
+#if defined(MBGL_LAYER_CIRCLE_DISABLE_RUNTIME)
+    addLayerTypeCoreOnly(std::make_unique<CircleJavaLayerPeerFactory>());
+#elif !defined(MBGL_LAYER_CIRCLE_DISABLE_ALL)
     addLayerType(std::make_unique<CircleJavaLayerPeerFactory>());
+#endif
+#if defined(MBGL_LAYER_SYMBOL_DISABLE_RUNTIME)
+    addLayerTypeCoreOnly(std::make_unique<SymbolJavaLayerPeerFactory>());
+#elif !defined(MBGL_LAYER_SYMBOL_DISABLE_ALL)
     addLayerType(std::make_unique<SymbolJavaLayerPeerFactory>());
+#endif
+#if defined(MBGL_LAYER_RASTER_DISABLE_RUNTIME)
+    addLayerTypeCoreOnly(std::make_unique<RasterJavaLayerPeerFactory>());
+#elif !defined(MBGL_LAYER_RASTER_DISABLE_ALL)
     addLayerType(std::make_unique<RasterJavaLayerPeerFactory>());
+#endif
+#if defined(MBGL_LAYER_BACKGROUND_DISABLE_RUNTIME)
+    addLayerTypeCoreOnly(std::make_unique<BackgroundJavaLayerPeerFactory>());
+#elif !defined(MBGL_LAYER_BACKGROUND_DISABLE_ALL)
     addLayerType(std::make_unique<BackgroundJavaLayerPeerFactory>());
+#endif
+#if defined(MBGL_LAYER_HILLSHADE_DISABLE_RUNTIME)
+    addLayerTypeCoreOnly(std::make_unique<HillshadeJavaLayerPeerFactory>());
+#elif !defined(MBGL_LAYER_HILLSHADE_DISABLE_ALL)
     addLayerType(std::make_unique<HillshadeJavaLayerPeerFactory>());
+#endif
+#if defined(MBGL_LAYER_FILL_EXTRUSION_DISABLE_RUNTIME)
+    addLayerTypeCoreOnly(std::make_unique<FillExtrusionJavaLayerPeerFactory>());
+#elif !defined(MBGL_LAYER_FILL_EXTRUSION_DISABLE_ALL)
     addLayerType(std::make_unique<FillExtrusionJavaLayerPeerFactory>());
+#endif
+#if defined(MBGL_LAYER_HEATMAP_DISABLE_RUNTIME)
+    addLayerTypeCoreOnly(std::make_unique<HeatmapJavaLayerPeerFactory>());
+#elif !defined(MBGL_LAYER_HEATMAP_DISABLE_ALL)
     addLayerType(std::make_unique<HeatmapJavaLayerPeerFactory>());
+#endif
+#if defined(MBGL_LAYER_CUSTOM_DISABLE_RUNTIME)
+    addLayerTypeCoreOnly(std::make_unique<CustomJavaLayerPeerFactory>());
+#elif !defined(MBGL_LAYER_CUSTOM_DISABLE_ALL)
     addLayerType(std::make_unique<CustomJavaLayerPeerFactory>());
+#endif
 }
 
 LayerManagerAndroid::~LayerManagerAndroid() = default;
@@ -111,7 +151,7 @@ LayerFactory* LayerManagerAndroid::getFactory(const mbgl::style::LayerTypeInfo* 
     return nullptr;
 }
 
-// static 
+// static
 LayerManagerAndroid* LayerManagerAndroid::get() noexcept {
     static LayerManagerAndroid impl;
     return &impl;
@@ -123,6 +163,10 @@ LayerManager* LayerManager::get() noexcept {
     return android::LayerManagerAndroid::get();
 }
 
+#if defined(MBGL_LAYER_LINE_DISABLE_ALL) || defined(MBGL_LAYER_SYMBOL_DISABLE_ALL) || defined(MBGL_LAYER_FILL_DISABLE_ALL)
+const bool LayerManager::annotationsEnabled = false;
+#else
 const bool LayerManager::annotationsEnabled = true;
+#endif
 
 } // namespace mbgl

--- a/platform/darwin/src/MGLStyleLayerManager.mm
+++ b/platform/darwin/src/MGLStyleLayerManager.mm
@@ -16,16 +16,56 @@
 namespace mbgl {
 
 LayerManagerDarwin::LayerManagerDarwin() {
+#if defined(MBGL_LAYER_FILL_DISABLE_RUNTIME)
+    addLayerTypeCoreOnly(std::make_unique<FillStyleLayerPeerFactory>());
+#elif !defined(MBGL_LAYER_FILL_DISABLE_ALL)
     addLayerType(std::make_unique<FillStyleLayerPeerFactory>());
+#endif
+#if defined(MBGL_LAYER_LINE_DISABLE_RUNTIME)
+    addLayerTypeCoreOnly(std::make_unique<LineStyleLayerPeerFactory>());
+#elif !defined(MBGL_LAYER_LINE_DISABLE_ALL)
     addLayerType(std::make_unique<LineStyleLayerPeerFactory>());
+#endif
+#if defined(MBGL_LAYER_CIRCLE_DISABLE_RUNTIME)
+    addLayerTypeCoreOnly(std::make_unique<CircleStyleLayerPeerFactory>());
+#elif !defined(MBGL_LAYER_CIRCLE_DISABLE_ALL)
     addLayerType(std::make_unique<CircleStyleLayerPeerFactory>());
+#endif
+#if defined(MBGL_LAYER_SYMBOL_DISABLE_RUNTIME)
+    addLayerTypeCoreOnly(std::make_unique<SymbolStyleLayerPeerFactory>());
+#elif !defined(MBGL_LAYER_SYMBOL_DISABLE_ALL)
     addLayerType(std::make_unique<SymbolStyleLayerPeerFactory>());
+#endif
+#if defined(MBGL_LAYER_RASTER_DISABLE_RUNTIME)
+    addLayerTypeCoreOnly(std::make_unique<RasterStyleLayerPeerFactory>());
+#elif !defined(MBGL_LAYER_RASTER_DISABLE_ALL)
     addLayerType(std::make_unique<RasterStyleLayerPeerFactory>());
+#endif
+#if defined(MBGL_LAYER_BACKGROUND_DISABLE_RUNTIME)
+    addLayerTypeCoreOnly(std::make_unique<BackgroundStyleLayerPeerFactory>());
+#elif !defined(MBGL_LAYER_BACKGROUND_DISABLE_ALL)
     addLayerType(std::make_unique<BackgroundStyleLayerPeerFactory>());
+#endif
+#if defined(MBGL_LAYER_HILLSHADE_DISABLE_RUNTIME)
+    addLayerTypeCoreOnly(std::make_unique<HillshadeStyleLayerPeerFactory>());
+#elif !defined(MBGL_LAYER_HILLSHADE_DISABLE_ALL)
     addLayerType(std::make_unique<HillshadeStyleLayerPeerFactory>());
+#endif
+#if defined(MBGL_LAYER_FILL_EXTRUSION_DISABLE_RUNTIME)
+    addLayerTypeCoreOnly(std::make_unique<FillExtrusionStyleLayerPeerFactory>());
+#elif !defined(MBGL_LAYER_FILL_EXTRUSION_DISABLE_ALL)
     addLayerType(std::make_unique<FillExtrusionStyleLayerPeerFactory>());
+#endif
+#if defined(MBGL_LAYER_HEATMAP_DISABLE_RUNTIME)
+    addLayerTypeCoreOnly(std::make_unique<HeatmapStyleLayerPeerFactory>());
+#elif !defined(MBGL_LAYER_HEATMAP_DISABLE_ALL)
     addLayerType(std::make_unique<HeatmapStyleLayerPeerFactory>());
+#endif
+#if defined(MBGL_LAYER_CUSTOM_DISABLE_RUNTIME)
+    addLayerTypeCoreOnly(std::make_unique<OpenGLStyleLayerPeerFactory>());
+#elif !defined(MBGL_LAYER_CUSTOM_DISABLE_ALL)
     addLayerType(std::make_unique<OpenGLStyleLayerPeerFactory>());
+#endif
 }
 
 LayerManagerDarwin::~LayerManagerDarwin() = default;
@@ -98,6 +138,10 @@ LayerManager* LayerManager::get() noexcept {
     return LayerManagerDarwin::get();
 }
 
+#if defined(MBGL_LAYER_LINE_DISABLE_ALL) || defined(MBGL_LAYER_SYMBOL_DISABLE_ALL) || defined(MBGL_LAYER_FILL_DISABLE_ALL)
+const bool LayerManager::annotationsEnabled = false;
+#else
 const bool LayerManager::annotationsEnabled = true;
+#endif
 
 } // namespace mbgl

--- a/platform/default/src/mbgl/layermanager/layer_manager.cpp
+++ b/platform/default/src/mbgl/layermanager/layer_manager.cpp
@@ -16,7 +16,7 @@
 #include <vector>
 
 namespace mbgl {
- 
+
 class LayerManagerDefault final : public LayerManager {
 public:
     LayerManagerDefault();
@@ -32,16 +32,36 @@ private:
 };
 
 LayerManagerDefault::LayerManagerDefault() {
+#if !defined(MBGL_LAYER_FILL_DISABLE_ALL)
     addLayerType(std::make_unique<FillLayerFactory>());
+#endif
+#if !defined(MBGL_LAYER_LINE_DISABLE_ALL)
     addLayerType(std::make_unique<LineLayerFactory>());
+#endif
+#if !defined(MBGL_LAYER_CIRCLE_DISABLE_ALL)
     addLayerType(std::make_unique<CircleLayerFactory>());
+#endif
+#if !defined(MBGL_LAYER_SYMBOL_DISABLE_ALL)
     addLayerType(std::make_unique<SymbolLayerFactory>());
+#endif
+#if !defined(MBGL_LAYER_RASTER_DISABLE_ALL)
     addLayerType(std::make_unique<RasterLayerFactory>());
+#endif
+#if !defined(MBGL_LAYER_BACKGROUND_DISABLE_ALL)
     addLayerType(std::make_unique<BackgroundLayerFactory>());
+#endif
+#if !defined(MBGL_LAYER_HILLSHADE_DISABLE_ALL)
     addLayerType(std::make_unique<HillshadeLayerFactory>());
+#endif
+#if !defined(MBGL_LAYER_FILL_EXTRUSION_DISABLE_ALL)
     addLayerType(std::make_unique<FillExtrusionLayerFactory>());
+#endif
+#if !defined(MBGL_LAYER_HEATMAP_DISABLE_ALL)
     addLayerType(std::make_unique<HeatmapLayerFactory>());
+#endif
+#if !defined(MBGL_LAYER_CUSTOM_DISABLE_ALL)
     addLayerType(std::make_unique<CustomLayerFactory>());
+#endif
 }
 
 void LayerManagerDefault::addLayerType(std::unique_ptr<LayerFactory> factory) {
@@ -68,12 +88,16 @@ LayerFactory* LayerManagerDefault::getFactory(const std::string& type) noexcept 
     return (search != typeToFactory.end()) ? search->second : nullptr;
 }
 
-// static 
+// static
 LayerManager* LayerManager::get() noexcept {
     static LayerManagerDefault instance;
     return &instance;
 }
 
+#if defined(MBGL_LAYER_LINE_DISABLE_ALL) || defined(MBGL_LAYER_SYMBOL_DISABLE_ALL) || defined(MBGL_LAYER_FILL_DISABLE_ALL)
+const bool LayerManager::annotationsEnabled = false;
+#else
 const bool LayerManager::annotationsEnabled = true;
+#endif
 
 } // namespace mbgl


### PR DESCRIPTION
Add two pre-processor flags for each layer that allow you to control how they will be compiled into your application. By default all layers are added and there is no change to how the SDK is currently compiled in master. This will give people who use compile the SDK by source to choose which layers they want in their build process without the need for maintaining any additional code.

```
LAYER_{LAYER_NAME}_DISABLE_ALL
```
Removes the layer completely from your application

```
LAYER_{LAYER_NAME}_DISABLE_RUNTIME
```
Adds the layer but only to the core. The goal with calling this flag RUNTIME was to allow it to both be used by Andriod and iOS so the flags would match. 