### PR TITLE
Update ios build locations (does not include macos changes).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,13 +196,14 @@ endif
 ifeq ($(HOST_PLATFORM), macos)
 
 IOS_OUTPUT_PATH = build/ios
+IOS_DERIVED_DATA = $(IOS_OUTPUT_PATH)/Build
 IOS_PROJ_PATH = $(IOS_OUTPUT_PATH)/mbgl.xcodeproj
 IOS_WORK_PATH = platform/ios/ios.xcworkspace
 IOS_USER_DATA_PATH = $(IOS_WORK_PATH)/xcuserdata/$(USER).xcuserdatad
 
 IOS_XCODEBUILD_SIM = xcodebuild \
 	  ARCHS=x86_64 ONLY_ACTIVE_ARCH=YES \
-	  -derivedDataPath $(IOS_OUTPUT_PATH) \
+	  -derivedDataPath $(IOS_DERIVED_DATA) \
 	  -configuration $(BUILDTYPE) -sdk iphonesimulator \
 	  -destination 'platform=iOS Simulator,name=iPhone 6,OS=latest' \
 	  -workspace $(IOS_WORK_PATH)

--- a/platform/ios/WorkspaceSettings.xcsettings
+++ b/platform/ios/WorkspaceSettings.xcsettings
@@ -5,13 +5,13 @@
 	<key>BuildLocationStyle</key>
 	<string>CustomLocation</string>
 	<key>CustomBuildIntermediatesPath</key>
-	<string>../../build/ios</string>
+	<string>../../build/ios/Build/Intermediates</string>
 	<key>CustomBuildLocationType</key>
 	<string>RelativeToWorkspace</string>
 	<key>CustomBuildProductsPath</key>
-	<string>../../build/ios</string>
+	<string>../../build/ios/Build/Products</string>
 	<key>DerivedDataCustomLocation</key>
-	<string>../../build/ios</string>
+	<string>../../build/ios/DerivedData</string>
 	<key>DerivedDataLocationStyle</key>
 	<string>WorkspaceRelativePath</string>
 	<key>IssueFilterStyle</key>


### PR DESCRIPTION
This PR changes the locations of the "derived data" folders - essentially inserting another folder between `build/ios` and the products & intermediates locations. 

This also adds a folder for the Xcode generated caches (e.g. `ModuleCache.noindex`) into a folder (currently called) `DerivedData`.

![screen shot 2019-01-10 at 5 42 52 pm](https://user-images.githubusercontent.com/3765757/51001978-dab4aa80-14ff-11e9-880c-7558c09f47cc.png)

This PR is to get around an issue where cleaning a target will delete the `mbgl.xcodeproj` project file and `config.xcconfig` file, meaning that the developer needs to `make iproj` before being able to build.

These workspace changes seem to work when building in Xcode, though when building from the command line (e.g. `make iframework`) the Xcode generated files end up in the root of `build/ios` rather than in `build/ios/DerivedData`. Any suggestions here @friedbunny?

EDIT: I have a commit waiting where I modified `package.sh` which improves this situation, but holding off on pushing that in light of [my comment below](https://github.com/mapbox/mapbox-gl-native/pull/13718#issuecomment-453522193).

/cc @jmkiley 


