### PR TITLE
Return constexpr strings from functions to avoid ODR compile failures

### DIFF
--- a/src/mbgl/style/conversion/stringify.hpp
+++ b/src/mbgl/style/conversion/stringify.hpp
@@ -160,7 +160,7 @@ void stringify(Writer& writer, const PropertyValue<T>& v) {
 template <class Property, class Writer, class T>
 void stringify(Writer& writer, const PropertyValue<T>& value) {
     if (!value.isUndefined()) {
-        writer.Key(Property::key);
+        writer.Key(Property::name());
         stringify(writer, value);
     }
 }

--- a/src/mbgl/style/layers/layer_properties.hpp.ejs
+++ b/src/mbgl/style/layers/layer_properties.hpp.ejs
@@ -19,7 +19,7 @@ namespace style {
 
 <% for (const property of layoutProperties) { -%>
 struct <%- camelize(property.name) %> : <%- layoutPropertyType(property, type) %> {
-    static constexpr const char * key = "<%- property.name %>";
+    static constexpr const char *name() { return "<%- property.name %>"; }
     static <%- evaluatedType(property) %> defaultValue() { return <%- defaultValue(property) %>; }
 };
 

--- a/src/mbgl/style/layers/line_layer_properties.hpp
+++ b/src/mbgl/style/layers/line_layer_properties.hpp
@@ -13,22 +13,22 @@ namespace mbgl {
 namespace style {
 
 struct LineCap : LayoutProperty<LineCapType> {
-    static constexpr const char * key = "line-cap";
+    static constexpr const char *name() { return "line-cap"; }
     static LineCapType defaultValue() { return LineCapType::Butt; }
 };
 
 struct LineJoin : DataDrivenLayoutProperty<LineJoinType> {
-    static constexpr const char * key = "line-join";
+    static constexpr const char *name() { return "line-join"; }
     static LineJoinType defaultValue() { return LineJoinType::Miter; }
 };
 
 struct LineMiterLimit : LayoutProperty<float> {
-    static constexpr const char * key = "line-miter-limit";
+    static constexpr const char *name() { return "line-miter-limit"; }
     static float defaultValue() { return 2; }
 };
 
 struct LineRoundLimit : LayoutProperty<float> {
-    static constexpr const char * key = "line-round-limit";
+    static constexpr const char *name() { return "line-round-limit"; }
     static float defaultValue() { return 1; }
 };
 

--- a/src/mbgl/style/layers/symbol_layer_properties.hpp
+++ b/src/mbgl/style/layers/symbol_layer_properties.hpp
@@ -13,187 +13,187 @@ namespace mbgl {
 namespace style {
 
 struct SymbolPlacement : LayoutProperty<SymbolPlacementType> {
-    static constexpr const char * key = "symbol-placement";
+    static constexpr const char *name() { return "symbol-placement"; }
     static SymbolPlacementType defaultValue() { return SymbolPlacementType::Point; }
 };
 
 struct SymbolSpacing : LayoutProperty<float> {
-    static constexpr const char * key = "symbol-spacing";
+    static constexpr const char *name() { return "symbol-spacing"; }
     static float defaultValue() { return 250; }
 };
 
 struct SymbolAvoidEdges : LayoutProperty<bool> {
-    static constexpr const char * key = "symbol-avoid-edges";
+    static constexpr const char *name() { return "symbol-avoid-edges"; }
     static bool defaultValue() { return false; }
 };
 
 struct SymbolZOrder : LayoutProperty<SymbolZOrderType> {
-    static constexpr const char * key = "symbol-z-order";
+    static constexpr const char *name() { return "symbol-z-order"; }
     static SymbolZOrderType defaultValue() { return SymbolZOrderType::ViewportY; }
 };
 
 struct IconAllowOverlap : LayoutProperty<bool> {
-    static constexpr const char * key = "icon-allow-overlap";
+    static constexpr const char *name() { return "icon-allow-overlap"; }
     static bool defaultValue() { return false; }
 };
 
 struct IconIgnorePlacement : LayoutProperty<bool> {
-    static constexpr const char * key = "icon-ignore-placement";
+    static constexpr const char *name() { return "icon-ignore-placement"; }
     static bool defaultValue() { return false; }
 };
 
 struct IconOptional : LayoutProperty<bool> {
-    static constexpr const char * key = "icon-optional";
+    static constexpr const char *name() { return "icon-optional"; }
     static bool defaultValue() { return false; }
 };
 
 struct IconRotationAlignment : LayoutProperty<AlignmentType> {
-    static constexpr const char * key = "icon-rotation-alignment";
+    static constexpr const char *name() { return "icon-rotation-alignment"; }
     static AlignmentType defaultValue() { return AlignmentType::Auto; }
 };
 
 struct IconSize : DataDrivenLayoutProperty<float> {
-    static constexpr const char * key = "icon-size";
+    static constexpr const char *name() { return "icon-size"; }
     static float defaultValue() { return 1; }
 };
 
 struct IconTextFit : LayoutProperty<IconTextFitType> {
-    static constexpr const char * key = "icon-text-fit";
+    static constexpr const char *name() { return "icon-text-fit"; }
     static IconTextFitType defaultValue() { return IconTextFitType::None; }
 };
 
 struct IconTextFitPadding : LayoutProperty<std::array<float, 4>> {
-    static constexpr const char * key = "icon-text-fit-padding";
+    static constexpr const char *name() { return "icon-text-fit-padding"; }
     static std::array<float, 4> defaultValue() { return {{ 0, 0, 0, 0 }}; }
 };
 
 struct IconImage : DataDrivenLayoutProperty<std::string> {
-    static constexpr const char * key = "icon-image";
+    static constexpr const char *name() { return "icon-image"; }
     static std::string defaultValue() { return ""; }
 };
 
 struct IconRotate : DataDrivenLayoutProperty<float> {
-    static constexpr const char * key = "icon-rotate";
+    static constexpr const char *name() { return "icon-rotate"; }
     static float defaultValue() { return 0; }
 };
 
 struct IconPadding : LayoutProperty<float> {
-    static constexpr const char * key = "icon-padding";
+    static constexpr const char *name() { return "icon-padding"; }
     static float defaultValue() { return 2; }
 };
 
 struct IconKeepUpright : LayoutProperty<bool> {
-    static constexpr const char * key = "icon-keep-upright";
+    static constexpr const char *name() { return "icon-keep-upright"; }
     static bool defaultValue() { return false; }
 };
 
 struct IconOffset : DataDrivenLayoutProperty<std::array<float, 2>> {
-    static constexpr const char * key = "icon-offset";
+    static constexpr const char *name() { return "icon-offset"; }
     static std::array<float, 2> defaultValue() { return {{ 0, 0 }}; }
 };
 
 struct IconAnchor : DataDrivenLayoutProperty<SymbolAnchorType> {
-    static constexpr const char * key = "icon-anchor";
+    static constexpr const char *name() { return "icon-anchor"; }
     static SymbolAnchorType defaultValue() { return SymbolAnchorType::Center; }
 };
 
 struct IconPitchAlignment : LayoutProperty<AlignmentType> {
-    static constexpr const char * key = "icon-pitch-alignment";
+    static constexpr const char *name() { return "icon-pitch-alignment"; }
     static AlignmentType defaultValue() { return AlignmentType::Auto; }
 };
 
 struct TextPitchAlignment : LayoutProperty<AlignmentType> {
-    static constexpr const char * key = "text-pitch-alignment";
+    static constexpr const char *name() { return "text-pitch-alignment"; }
     static AlignmentType defaultValue() { return AlignmentType::Auto; }
 };
 
 struct TextRotationAlignment : LayoutProperty<AlignmentType> {
-    static constexpr const char * key = "text-rotation-alignment";
+    static constexpr const char *name() { return "text-rotation-alignment"; }
     static AlignmentType defaultValue() { return AlignmentType::Auto; }
 };
 
 struct TextField : DataDrivenLayoutProperty<expression::Formatted> {
-    static constexpr const char * key = "text-field";
+    static constexpr const char *name() { return "text-field"; }
     static expression::Formatted defaultValue() { return ""; }
 };
 
 struct TextFont : DataDrivenLayoutProperty<std::vector<std::string>> {
-    static constexpr const char * key = "text-font";
+    static constexpr const char *name() { return "text-font"; }
     static std::vector<std::string> defaultValue() { return { "Open Sans Regular", "Arial Unicode MS Regular" }; }
 };
 
 struct TextSize : DataDrivenLayoutProperty<float> {
-    static constexpr const char * key = "text-size";
+    static constexpr const char *name() { return "text-size"; }
     static float defaultValue() { return 16; }
 };
 
 struct TextMaxWidth : DataDrivenLayoutProperty<float> {
-    static constexpr const char * key = "text-max-width";
+    static constexpr const char *name() { return "text-max-width"; }
     static float defaultValue() { return 10; }
 };
 
 struct TextLineHeight : LayoutProperty<float> {
-    static constexpr const char * key = "text-line-height";
+    static constexpr const char *name() { return "text-line-height"; }
     static float defaultValue() { return 1.2; }
 };
 
 struct TextLetterSpacing : DataDrivenLayoutProperty<float> {
-    static constexpr const char * key = "text-letter-spacing";
+    static constexpr const char *name() { return "text-letter-spacing"; }
     static float defaultValue() { return 0; }
 };
 
 struct TextJustify : DataDrivenLayoutProperty<TextJustifyType> {
-    static constexpr const char * key = "text-justify";
+    static constexpr const char *name() { return "text-justify"; }
     static TextJustifyType defaultValue() { return TextJustifyType::Center; }
 };
 
 struct TextAnchor : DataDrivenLayoutProperty<SymbolAnchorType> {
-    static constexpr const char * key = "text-anchor";
+    static constexpr const char *name() { return "text-anchor"; }
     static SymbolAnchorType defaultValue() { return SymbolAnchorType::Center; }
 };
 
 struct TextMaxAngle : LayoutProperty<float> {
-    static constexpr const char * key = "text-max-angle";
+    static constexpr const char *name() { return "text-max-angle"; }
     static float defaultValue() { return 45; }
 };
 
 struct TextRotate : DataDrivenLayoutProperty<float> {
-    static constexpr const char * key = "text-rotate";
+    static constexpr const char *name() { return "text-rotate"; }
     static float defaultValue() { return 0; }
 };
 
 struct TextPadding : LayoutProperty<float> {
-    static constexpr const char * key = "text-padding";
+    static constexpr const char *name() { return "text-padding"; }
     static float defaultValue() { return 2; }
 };
 
 struct TextKeepUpright : LayoutProperty<bool> {
-    static constexpr const char * key = "text-keep-upright";
+    static constexpr const char *name() { return "text-keep-upright"; }
     static bool defaultValue() { return true; }
 };
 
 struct TextTransform : DataDrivenLayoutProperty<TextTransformType> {
-    static constexpr const char * key = "text-transform";
+    static constexpr const char *name() { return "text-transform"; }
     static TextTransformType defaultValue() { return TextTransformType::None; }
 };
 
 struct TextOffset : DataDrivenLayoutProperty<std::array<float, 2>> {
-    static constexpr const char * key = "text-offset";
+    static constexpr const char *name() { return "text-offset"; }
     static std::array<float, 2> defaultValue() { return {{ 0, 0 }}; }
 };
 
 struct TextAllowOverlap : LayoutProperty<bool> {
-    static constexpr const char * key = "text-allow-overlap";
+    static constexpr const char *name() { return "text-allow-overlap"; }
     static bool defaultValue() { return false; }
 };
 
 struct TextIgnorePlacement : LayoutProperty<bool> {
-    static constexpr const char * key = "text-ignore-placement";
+    static constexpr const char *name() { return "text-ignore-placement"; }
     static bool defaultValue() { return false; }
 };
 
 struct TextOptional : LayoutProperty<bool> {
-    static constexpr const char * key = "text-optional";
+    static constexpr const char *name() { return "text-optional"; }
     static bool defaultValue() { return false; }
 };
 


### PR DESCRIPTION
Some compilers don't include the symbol if there's no definition of the constexpr string. Instead of providing one, we're switching to constexpr functions similar to how jni.hpp does it.