### PR TITLE
[core] Notify requests about network reachability in priority order

### DIFF
--- a/platform/default/src/mbgl/storage/online_file_source.cpp
+++ b/platform/default/src/mbgl/storage/online_file_source.cpp
@@ -170,8 +170,18 @@ public:
 private:
 
     void networkIsReachableAgain() {
+        // Notify regular priority requests.
         for (auto& request : allRequests) {
-            request->networkIsReachableAgain();
+            if (request->resource.priority == Resource::Priority::Regular) {
+                request->networkIsReachableAgain();
+            }
+        }
+
+        // Notify low priority requests.
+        for (auto& request : allRequests) {
+            if (request->resource.priority == Resource::Priority::Low) {
+                request->networkIsReachableAgain();
+            }
         }
     }
 


### PR DESCRIPTION
When network status is changed to online, all unqueued requests may be processed in nondeterministic. order (unordered_set). Therefore, low-priority request may be made active, while other are put to priority queue. This introduces flakiness for the unit test.

Fixes: #13371