### PR TITLE
Avoid null pointer when quickly closing activity

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -380,7 +380,9 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
    */
   @UiThread
   public void onStop() {
-    attributionClickListener.onStop();
+    if (attributionClickListener != null) {
+      attributionClickListener.onStop();
+    }
 
     if (mapboxMap != null) {
       // map was destroyed before it was started


### PR DESCRIPTION
Avoid null pointer when quickly closing activity for attribution click handling.
Refs CI failure: https://console.firebase.google.com/project/android-gl-native/testlab/histories/bh.1470d2ab45df6f1f/matrices/5309687223697427015