### PR TITLE
[core] SymbolBucket: use single map for paint properties data

### DIFF
--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -469,9 +469,9 @@ void SymbolLayout::createBucket(const ImagePositions&, std::unique_ptr<FeatureIn
             }
         }
 
-        for (auto& pair : bucket->paintPropertyBinders) {
-            pair.second.first.populateVertexVectors(feature, bucket->icon.vertices.vertexSize(), {}, {});
-            pair.second.second.populateVertexVectors(feature, bucket->text.vertices.vertexSize(), {}, {});
+        for (auto& pair : bucket->paintProperties) {
+            pair.second.iconBinders.populateVertexVectors(feature, bucket->icon.vertices.vertexSize(), {}, {});
+            pair.second.textBinders.populateVertexVectors(feature, bucket->text.vertices.vertexSize(), {}, {});
         }
     }
 

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -40,7 +40,7 @@ public:
 class SymbolBucket final : public Bucket {
 public:
     SymbolBucket(style::SymbolLayoutProperties::PossiblyEvaluated,
-                 std::map<std::string, style::SymbolPaintProperties::PossiblyEvaluated>,
+                 const std::map<std::string, style::SymbolPaintProperties::PossiblyEvaluated>&,
                  const style::PropertyValue<float>& textSize,
                  const style::PropertyValue<float>& iconSize,
                  float zoom,
@@ -78,11 +78,12 @@ public:
 
     std::vector<SymbolInstance> symbolInstances;
 
-    std::map<std::string, style::SymbolPaintProperties::PossiblyEvaluated> paintProperties;
-
-    std::map<std::string, std::pair<
-        SymbolIconProgram::PaintPropertyBinders,
-        SymbolSDFTextProgram::PaintPropertyBinders>> paintPropertyBinders;
+    struct PaintProperties {
+        style::SymbolPaintProperties::PossiblyEvaluated evaluated;
+        SymbolIconProgram::PaintPropertyBinders iconBinders;
+        SymbolSDFTextProgram::PaintPropertyBinders textBinders;
+    };
+    std::map<std::string, PaintProperties> paintProperties;
 
     std::unique_ptr<SymbolSizeBinder> textSizeBinder;
 

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -102,7 +102,8 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
         }
         SymbolBucket& bucket = *bucket_;
         assert(bucket.paintProperties.find(getID()) != bucket.paintProperties.end());
-        const auto& evaluated_ = bucket.paintProperties.at(getID());
+        const auto& bucketPaintProperties = bucket.paintProperties.at(getID());
+        const auto& evaluated_ = bucketPaintProperties.evaluated;
         const auto& layout = bucket.layout;
 
         auto draw = [&] (auto& program,
@@ -187,7 +188,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
                          bucket.icon,
                          bucket.iconSizeBinder,
                          values,
-                         bucket.paintPropertyBinders.at(getID()).first,
+                         bucketPaintProperties.iconBinders,
                          paintPropertyValues);
                 }
 
@@ -197,7 +198,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
                          bucket.icon,
                          bucket.iconSizeBinder,
                          values,
-                         bucket.paintPropertyBinders.at(getID()).first,
+                         bucketPaintProperties.iconBinders,
                          paintPropertyValues);
                 }
             } else {
@@ -206,7 +207,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
                      bucket.icon,
                      bucket.iconSizeBinder,
                      values,
-                     bucket.paintPropertyBinders.at(getID()).first,
+                     bucketPaintProperties.iconBinders,
                      paintPropertyValues);
             }
         }
@@ -240,7 +241,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
                      bucket.text,
                      bucket.textSizeBinder,
                      values,
-                     bucket.paintPropertyBinders.at(getID()).second,
+                     bucketPaintProperties.textBinders,
                      paintPropertyValues);
             }
 
@@ -250,7 +251,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
                      bucket.text,
                      bucket.textSizeBinder,
                      values,
-                     bucket.paintPropertyBinders.at(getID()).second,
+                     bucketPaintProperties.textBinders,
                      paintPropertyValues);
             }
         }
@@ -405,7 +406,8 @@ void RenderSymbolLayer::sortRenderTiles(const TransformState& state) {
 }
 
 void RenderSymbolLayer::updateBucketPaintProperties(Bucket* bucket) const {
-    static_cast<SymbolBucket*>(bucket)->paintProperties[getID()] = evaluated;
+    assert(bucket->supportsLayer(*baseImpl));
+    static_cast<SymbolBucket*>(bucket)->paintProperties.at(getID()).evaluated = evaluated;
 }
 
 } // namespace mbgl


### PR DESCRIPTION
Obviates unnecessary lookups, improves readability.