### PR TITLE
[Android] Allow offline and snapshotter to be disabled.

### DIFF
--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -35,19 +35,23 @@
 #include "map_renderer.hpp"
 #include "map_renderer_runnable.hpp"
 #include "native_map_view.hpp"
+#ifndef MODULE_OFFLINE_DISABLE
 #include "offline/offline_manager.hpp"
 #include "offline/offline_region.hpp"
 #include "offline/offline_region_definition.hpp"
 #include "offline/offline_region_error.hpp"
 #include "offline/offline_region_status.hpp"
+#endif
 #include "style/transition_options.hpp"
 #include "style/layers/layer_manager.hpp"
 #include "style/sources/source.hpp"
 #include "style/light.hpp"
 #include "style/formatted.hpp"
 #include "style/formatted_section.hpp"
+#ifndef MODULE_SNAPSHOT_DISABLE
 #include "snapshotter/map_snapshotter.hpp"
 #include "snapshotter/map_snapshot.hpp"
+#endif
 #include "text/collator_jni.hpp"
 #include "text/local_glyph_rasterizer_jni.hpp"
 #include "logger.hpp"
@@ -175,6 +179,7 @@ void registerNatives(JavaVM *vm) {
     ConnectivityListener::registerNative(env);
 
     // Offline
+#ifndef MODULE_OFFLINE_DISABLE
     OfflineManager::registerNative(env);
     OfflineRegion::registerNative(env);
     OfflineRegionDefinition::registerNative(env);
@@ -182,10 +187,13 @@ void registerNatives(JavaVM *vm) {
     OfflineGeometryRegionDefinition::registerNative(env);
     OfflineRegionError::registerNative(env);
     OfflineRegionStatus::registerNative(env);
+#endif
 
     // Snapshotter
+#ifndef MODULE_SNAPSHOT_DISABLE
     MapSnapshotter::registerNative(env);
     MapSnapshot::registerNative(env);
+#endif
 
     // text
     LocalGlyphRasterizer::registerNative(env);

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -35,7 +35,7 @@
 #include "map_renderer.hpp"
 #include "map_renderer_runnable.hpp"
 #include "native_map_view.hpp"
-#ifndef MODULE_OFFLINE_DISABLE
+#ifndef MBGL_MODULE_OFFLINE_DISABLE
 #include "offline/offline_manager.hpp"
 #include "offline/offline_region.hpp"
 #include "offline/offline_region_definition.hpp"
@@ -48,7 +48,7 @@
 #include "style/light.hpp"
 #include "style/formatted.hpp"
 #include "style/formatted_section.hpp"
-#ifndef MODULE_SNAPSHOT_DISABLE
+#ifndef MBGL_MODULE_SNAPSHOT_DISABLE
 #include "snapshotter/map_snapshotter.hpp"
 #include "snapshotter/map_snapshot.hpp"
 #endif
@@ -179,7 +179,7 @@ void registerNatives(JavaVM *vm) {
     ConnectivityListener::registerNative(env);
 
     // Offline
-#ifndef MODULE_OFFLINE_DISABLE
+#ifndef MBGL_MODULE_OFFLINE_DISABLE
     OfflineManager::registerNative(env);
     OfflineRegion::registerNative(env);
     OfflineRegionDefinition::registerNative(env);
@@ -190,7 +190,7 @@ void registerNatives(JavaVM *vm) {
 #endif
 
     // Snapshotter
-#ifndef MODULE_SNAPSHOT_DISABLE
+#ifndef MBGL_MODULE_SNAPSHOT_DISABLE
     MapSnapshotter::registerNative(env);
     MapSnapshot::registerNative(env);
 #endif


### PR DESCRIPTION
Add the ability to remove both the snapshotter and offline code with pre-processor flags. This saves about 31kb in final APK if they are not being used.