### PR TITLE
Snapshot attribution

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/attribution/Attribution.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/attribution/Attribution.java
@@ -8,7 +8,7 @@ public class Attribution {
   private static final String OPENSTREETMAP_ABBR = "OSM";
   static final String TELEMETRY = "Telemetry Settings";
 
-  static final String IMPROVE_MAP_URL = "https://www.mapbox.com/feedback/";
+  static final String IMPROVE_MAP_URL = "https://www.mapbox.com/map-feedback/";
   static final String MAPBOX_URL = "https://www.mapbox.com/about/maps/";
   static final String TELEMETRY_URL = "https://www.mapbox.com/telemetry/";
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/attribution/Attribution.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/attribution/Attribution.java
@@ -2,15 +2,23 @@ package com.mapbox.mapboxsdk.attribution;
 
 import android.support.annotation.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class Attribution {
 
   private static final String OPENSTREETMAP = "OpenStreetMap";
   private static final String OPENSTREETMAP_ABBR = "OSM";
   static final String TELEMETRY = "Telemetry Settings";
-
-  static final String IMPROVE_MAP_URL = "https://www.mapbox.com/map-feedback/";
   static final String MAPBOX_URL = "https://www.mapbox.com/about/maps/";
   static final String TELEMETRY_URL = "https://www.mapbox.com/telemetry/";
+  static final List<String> IMPROVE_MAP_URLS = new ArrayList<>();
+
+  static {
+    // Using a List makes URL backwards compatible
+    IMPROVE_MAP_URLS.add("https://www.mapbox.com/feedback/");
+    IMPROVE_MAP_URLS.add("https://www.mapbox.com/map-feedback/");
+  }
 
   private String title;
   private String url;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/attribution/AttributionParser.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/attribution/AttributionParser.java
@@ -157,7 +157,7 @@ public class AttributionParser {
    * @return if the url is valid for improve this map
    */
   private boolean isValidForImproveThisMap(@NonNull String url) {
-    return withImproveMap || !url.equals(Attribution.IMPROVE_MAP_URL);
+    return withImproveMap || !(Attribution.IMPROVE_MAP_URLS.contains(url));
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/attribution/AttributionParseTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/attribution/AttributionParseTest.java
@@ -15,8 +15,8 @@ import static junit.framework.Assert.assertEquals;
 @Config(constants = BuildConfig.class)
 public class AttributionParseTest {
 
-  private static final String STREETS_ATTRIBUTION = "<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\">&copy; Mapbox</a> <a href=\"http://www.openstreetmap.org/about/\" target=\"_blank\">&copy; OpenStreetMap</a> <a class=\"mapbox-improve-map\" href=\"https://www.mapbox.com/feedback/\" target=\"_blank\">Improve this map</a>\n";
-  private static final String SATELLITE_ATTRIBUTION = "<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\">&copy; Mapbox</a> <a href=\"http://www.openstreetmap.org/about/\" target=\"_blank\">&copy; OpenStreetMap</a> <a class=\"mapbox-improve-map\" href=\"https://www.mapbox.com/feedback/\" target=\"_blank\">Improve this map</a> <a href=\"https://www.digitalglobe.com/\" target=\"_blank\">&copy; DigitalGlobe</a>\n";
+  private static final String STREETS_ATTRIBUTION = "<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\">&copy; Mapbox</a> <a href=\"http://www.openstreetmap.org/about/\" target=\"_blank\">&copy; OpenStreetMap</a> <a class=\"mapbox-improve-map\" href=\"https://www.mapbox.com/map-feedback/\" target=\"_blank\">Improve this map</a>\n";
+  private static final String SATELLITE_ATTRIBUTION = "<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\">&copy; Mapbox</a> <a href=\"http://www.openstreetmap.org/about/\" target=\"_blank\">&copy; OpenStreetMap</a> <a class=\"mapbox-improve-map\" href=\"https://www.mapbox.com/map-feedback/\" target=\"_blank\">Improve this map</a> <a href=\"https://www.digitalglobe.com/\" target=\"_blank\">&copy; DigitalGlobe</a>\n";
 
   @Test
   public void testParseAttributionStringSatellite() throws Exception {
@@ -39,7 +39,7 @@ public class AttributionParseTest {
           assertEquals("Title openstreetmap should match", "© OpenStreetMap", attribution.getTitle());
           break;
         case 2:
-          assertEquals("URL improve map should match", "https://www.mapbox.com/feedback/", attribution.getUrl());
+          assertEquals("URL improve map should match", "https://www.mapbox.com/map-feedback/", attribution.getUrl());
           assertEquals("Title improve map should match", "Improve This Map", attribution.getTitle());
           break;
         case 3:
@@ -72,7 +72,7 @@ public class AttributionParseTest {
           assertEquals("Title openstreetmap should match", "© OpenStreetMap", attribution.getTitle());
           break;
         case 2:
-          assertEquals("URL improve map should match", "https://www.mapbox.com/feedback/", attribution.getUrl());
+          assertEquals("URL improve map should match", "https://www.mapbox.com/map-feedback/", attribution.getUrl());
           assertEquals("Title improve map should match", "Improve This Map", attribution.getTitle());
           break;
       }
@@ -98,7 +98,7 @@ public class AttributionParseTest {
           assertEquals("Title openstreetmap should match", "© OpenStreetMap", attribution.getTitle());
           break;
         case 1:
-          assertEquals("URL improve map should match", "https://www.mapbox.com/feedback/", attribution.getUrl());
+          assertEquals("URL improve map should match", "https://www.mapbox.com/map-feedback/", attribution.getUrl());
           assertEquals("Title improve map should match", "Improve This Map", attribution.getTitle());
           break;
       }
@@ -126,7 +126,7 @@ public class AttributionParseTest {
           assertEquals("Title openstreetmap should match", "© OpenStreetMap", attribution.getTitle());
           break;
         case 2:
-          assertEquals("URL improve map should match", "https://www.mapbox.com/feedback/", attribution.getUrl());
+          assertEquals("URL improve map should match", "https://www.mapbox.com/map-feedback/", attribution.getUrl());
           assertEquals("Title improve map should match", "Improve This Map", attribution.getTitle());
           break;
         case 3:
@@ -188,7 +188,7 @@ public class AttributionParseTest {
           assertEquals("Title openstreetmap should match", "OpenStreetMap", attribution.getTitle());
           break;
         case 2:
-          assertEquals("URL improve map should match", "https://www.mapbox.com/feedback/", attribution.getUrl());
+          assertEquals("URL improve map should match", "https://www.mapbox.com/map-feedback/", attribution.getUrl());
           assertEquals("Title improve map should match", "Improve This Map", attribution.getTitle());
           break;
         case 3:
@@ -304,6 +304,21 @@ public class AttributionParseTest {
     assertEquals(
       "Attribution string should match",
       "© Mapbox / OSM / DigitalGlobe",
+      attributionParser.createAttributionString(true)
+    );
+  }
+
+  @Test
+  public void testWithImproveThisMapString() throws Exception {
+    AttributionParser attributionParser = new AttributionParser.Options(RuntimeEnvironment.application)
+      .withAttributionData(STREETS_ATTRIBUTION, "blabla", "")
+      .withImproveMap(true)
+      .withCopyrightSign(false)
+      .build();
+
+    assertEquals(
+      "Attribution string should match",
+      "© Mapbox / OSM / Improve This Map",
       attributionParser.createAttributionString(true)
     );
   }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/13715. it now generates attribution correctly:

![image](https://user-images.githubusercontent.com/2151639/51178246-4ca34000-18c2-11e9-859f-9789caa9f87d.png)
