### PR TITLE
[core] TilePyramid has sorted render tiles

### DIFF
--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -43,7 +43,7 @@ RenderLayer::RenderTiles RenderLayer::filterRenderTiles(RenderTiles tiles) const
 }
 
 void RenderLayer::sortRenderTiles(const TransformState&) {
-    std::sort(renderTiles.begin(), renderTiles.end(), [](const auto& a, const auto& b) { return a.get().id < b.get().id; });
+    // no-op
 }
 
 const RenderLayerSymbolInterface* RenderLayer::getSymbolInterface() const {

--- a/src/mbgl/renderer/render_source.hpp
+++ b/src/mbgl/renderer/render_source.hpp
@@ -58,7 +58,7 @@ public:
     virtual void startRender(PaintParameters&) = 0;
     virtual void finishRender(PaintParameters&) = 0;
 
-    // Returns an unsorted list of RenderTiles.
+    // Returns a list of RenderTiles, sorted by tile id.
     virtual std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() = 0;
 
     virtual std::unordered_map<std::string, std::vector<Feature>>

--- a/src/mbgl/renderer/sources/render_geojson_source.cpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.cpp
@@ -96,11 +96,11 @@ void RenderGeoJSONSource::update(Immutable<style::Source::Impl> baseImpl_,
 
     if (data.lock() != data_) {
         data = data_;
-        tilePyramid.cache.clear();
+        tilePyramid.reduceMemoryUse();
 
         if (data_) {
             const uint8_t maxZ = impl().getZoomRange().max;
-            for (const auto& pair : tilePyramid.tiles) {
+            for (const auto& pair : tilePyramid.getTiles()) {
                 if (pair.first.canonical.z <= maxZ) {
                     static_cast<GeoJSONTile*>(pair.second.get())->updateData(data_->getTile(pair.first.canonical));
                 }
@@ -109,8 +109,7 @@ void RenderGeoJSONSource::update(Immutable<style::Source::Impl> baseImpl_,
     }
 
     if (!data_) {
-        tilePyramid.tiles.clear();
-        tilePyramid.renderTiles.clear();
+        tilePyramid.clearAll();
         return;
     }
 

--- a/src/mbgl/renderer/sources/render_raster_dem_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.cpp
@@ -38,9 +38,7 @@ void RenderRasterDEMSource::update(Immutable<style::Source::Impl> baseImpl_,
         maxzoom = tileset->zoomRange.max;
         // TODO: this removes existing buckets, and will cause flickering.
         // Should instead refresh tile data in place.
-        tilePyramid.tiles.clear();
-        tilePyramid.renderTiles.clear();
-        tilePyramid.cache.clear();
+        tilePyramid.clearAll();
     }
     // Allow clearing the tile pyramid first, before the early return in case
     //  the new tileset is not yet available or has an error in loading

--- a/src/mbgl/renderer/sources/render_raster_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_source.cpp
@@ -36,9 +36,7 @@ void RenderRasterSource::update(Immutable<style::Source::Impl> baseImpl_,
 
         // TODO: this removes existing buckets, and will cause flickering.
         // Should instead refresh tile data in place.
-        tilePyramid.tiles.clear();
-        tilePyramid.renderTiles.clear();
-        tilePyramid.cache.clear();
+        tilePyramid.clearAll();
     }
     // Allow clearing the tile pyramid first, before the early return in case
     //  the new tileset is not yet available or has an error in loading

--- a/src/mbgl/renderer/sources/render_vector_source.cpp
+++ b/src/mbgl/renderer/sources/render_vector_source.cpp
@@ -39,9 +39,7 @@ void RenderVectorSource::update(Immutable<style::Source::Impl> baseImpl_,
 
         // TODO: this removes existing buckets, and will cause flickering.
         // Should instead refresh tile data in place.
-        tilePyramid.tiles.clear();
-        tilePyramid.renderTiles.clear();
-        tilePyramid.cache.clear();
+        tilePyramid.clearAll();
     }
     // Allow clearing the tile pyramid first, before the early return in case
     //  the new tileset is not yet available or has an error in loading

--- a/src/mbgl/renderer/tile_pyramid.hpp
+++ b/src/mbgl/renderer/tile_pyramid.hpp
@@ -66,12 +66,16 @@ public:
     void setObserver(TileObserver*);
     void dumpDebugLogs() const;
 
-    bool enabled = false;
+    const std::map<OverscaledTileID, std::unique_ptr<Tile>>& getTiles() const { return tiles; }
+    void clearAll();
+
+private:
+    void addRenderTile(const UnwrappedTileID& tileID, Tile& tile);
 
     std::map<OverscaledTileID, std::unique_ptr<Tile>> tiles;
     TileCache cache;
 
-    std::vector<RenderTile> renderTiles;
+    std::list<RenderTile> renderTiles;
 
     TileObserver* observer = nullptr;
 


### PR DESCRIPTION
Thus we obviate unneeded extra sorting of render tiles at each render layer.