### PR TITLE
[macos] Fixes MGLMapView.visibleAnnotations

### DIFF
--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Added an `MGLStyle.performsPlacementTransitions` property to control how long it takes for colliding labels to fade out. ([#13565](https://github.com/mapbox/mapbox-gl-native/pull/13565))
 * Fixed a crash when casting large numbers in `NSExpression`. ([#13580](https://github.com/mapbox/mapbox-gl-native/pull/13580))
 * Added the `-[MGLShapeSource leavesOfCluster:offset:limit:]`, `-[MGLShapeSource childrenOfCluster:]`, `-[MGLShapeSource zoomLevelForExpandingCluster:]` methods for inspecting a cluster in an `MGLShapeSource`s created with the `MGLShapeSourceOptionClustered` option. Feature querying now returns clusters represented by `MGLPointFeatureCluster` objects (that conform to the `MGLCluster` protocol). ([#12952](https://github.com/mapbox/mapbox-gl-native/pull/12952)
-* Fixed a bug with `MGLMapView.visibleAnnotations` that resulted in incorrect results and performance degradation.
+* Fixed a bug with `MGLMapView.visibleAnnotations` that resulted in incorrect results and performance degradation. ([#13745](https://github.com/mapbox/mapbox-gl-native/pull/13745))
 
 
 ## 0.13.0 - December 20, 2018

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added an `MGLStyle.performsPlacementTransitions` property to control how long it takes for colliding labels to fade out. ([#13565](https://github.com/mapbox/mapbox-gl-native/pull/13565))
 * Fixed a crash when casting large numbers in `NSExpression`. ([#13580](https://github.com/mapbox/mapbox-gl-native/pull/13580))
 * Added the `-[MGLShapeSource leavesOfCluster:offset:limit:]`, `-[MGLShapeSource childrenOfCluster:]`, `-[MGLShapeSource zoomLevelForExpandingCluster:]` methods for inspecting a cluster in an `MGLShapeSource`s created with the `MGLShapeSourceOptionClustered` option. Feature querying now returns clusters represented by `MGLPointFeatureCluster` objects (that conform to the `MGLCluster` protocol). ([#12952](https://github.com/mapbox/mapbox-gl-native/pull/12952)
+* Fixed a bug with `MGLMapView.visibleAnnotations` that resulted in incorrect results and performance degradation.
 
 
 ## 0.13.0 - December 20, 2018

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -1845,7 +1845,7 @@ public:
 
 - (nullable NSArray<id <MGLAnnotation>> *)visibleAnnotations
 {
-    return [self visibleFeaturesInRect:self.bounds];
+    return [self visibleAnnotationsInRect:self.bounds];
 }
 
 - (nullable NSArray<id <MGLAnnotation>> *)visibleAnnotationsInRect:(CGRect)rect


### PR DESCRIPTION
Fixes a bug where `MGLMapView.visibleAnnotations` was calling `-visibleFeaturesInRect:` rather than `-visibleAnnotationsInRect:`.