### PR TITLE
Avoid recursive loading, add library loading to peer objects.

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/LibraryLoader.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/LibraryLoader.java
@@ -16,16 +16,13 @@ public abstract class LibraryLoader {
   private static final LibraryLoader DEFAULT = new LibraryLoader() {
     @Override
     public void load(String name) {
-      if (!loaded) {
-        System.loadLibrary(name);
-      }
-      loaded = true;
+      System.loadLibrary(name);
     }
   };
 
   private static volatile LibraryLoader loader = DEFAULT;
 
-  protected static boolean loaded;
+  private static boolean loaded;
 
   /**
    * Set the library loader that loads the shared library.
@@ -44,7 +41,10 @@ public abstract class LibraryLoader {
    */
   public static void load() {
     try {
-      loader.load("mapbox-gl");
+      if (!loaded) {
+        loader.load("mapbox-gl");
+      }
+      loaded = true;
     } catch (UnsatisfiedLinkError error) {
       String message = "Failed to load native shared library.";
       Logger.e(TAG, message, error);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/LibraryLoader.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/LibraryLoader.java
@@ -16,11 +16,16 @@ public abstract class LibraryLoader {
   private static final LibraryLoader DEFAULT = new LibraryLoader() {
     @Override
     public void load(String name) {
-      System.loadLibrary(name);
+      if (!loaded) {
+        System.loadLibrary(name);
+      }
+      loaded = true;
     }
   };
 
   private static volatile LibraryLoader loader = DEFAULT;
+
+  protected static boolean loaded;
 
   /**
    * Set the library loader that loads the shared library.

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Layer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Layer.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.google.gson.JsonElement;
+import com.mapbox.mapboxsdk.LibraryLoader;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.types.Formatted;
 import com.mapbox.mapboxsdk.utils.ThreadUtils;
@@ -19,6 +20,10 @@ public abstract class Layer {
   @Keep
   private boolean invalidated;
   private boolean detached;
+
+  static {
+    LibraryLoader.load();
+  }
 
   @Keep
   protected Layer(long nativePtr) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/Source.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/Source.java
@@ -3,6 +3,8 @@ package com.mapbox.mapboxsdk.style.sources;
 import android.support.annotation.Keep;
 
 import android.support.annotation.NonNull;
+
+import com.mapbox.mapboxsdk.LibraryLoader;
 import com.mapbox.mapboxsdk.utils.ThreadUtils;
 
 /**
@@ -14,6 +16,10 @@ public abstract class Source {
   private long nativePtr;
 
   protected boolean detached;
+
+  static {
+    LibraryLoader.load();
+  }
 
   /**
    * Internal use


### PR DESCRIPTION
This PR does addresses two items:
 - avoid recursive loading and the printed warning 
 - add library loading to classes that can be used as peer objects