### PR TITLE
Bring back 16718b0 and unit test static block remover

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -164,4 +164,5 @@ configurations {
 apply from: "${rootDir}/gradle/gradle-javadoc.gradle"
 apply from: "${rootDir}/gradle/gradle-publish.gradle"
 apply from: "${rootDir}/gradle/gradle-checkstyle.gradle"
+apply from: "${rootDir}/gradle/gradle-tests-staticblockremover.gradle"
 apply from: "${rootDir}/gradle/gradle-dependencies-graph.gradle"

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Layer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Layer.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.google.gson.JsonElement;
+import com.mapbox.mapboxsdk.LibraryLoader;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.types.Formatted;
 import com.mapbox.mapboxsdk.utils.ThreadUtils;
@@ -19,6 +20,10 @@ public abstract class Layer {
   @Keep
   private boolean invalidated;
   private boolean detached;
+
+  static {
+    LibraryLoader.load();
+  }
 
   @Keep
   protected Layer(long nativePtr) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/Source.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/Source.java
@@ -3,6 +3,8 @@ package com.mapbox.mapboxsdk.style.sources;
 import android.support.annotation.Keep;
 
 import android.support.annotation.NonNull;
+
+import com.mapbox.mapboxsdk.LibraryLoader;
 import com.mapbox.mapboxsdk.utils.ThreadUtils;
 
 /**
@@ -14,6 +16,10 @@ public abstract class Source {
   private long nativePtr;
 
   protected boolean detached;
+
+  static {
+    LibraryLoader.load();
+  }
 
   /**
    * Internal use

--- a/platform/android/gradle/gradle-tests-staticblockremover.gradle
+++ b/platform/android/gradle/gradle-tests-staticblockremover.gradle
@@ -1,0 +1,66 @@
+buildscript {
+    repositories {
+        mavenCentral()
+        mavenLocal()
+    }
+
+    dependencies {
+        classpath 'com.darylteo.gradle:javassist-plugin:0.4.1'
+    }
+}
+
+import com.darylteo.gradle.javassist.tasks.TransformationTask
+import com.darylteo.gradle.javassist.transformers.ClassTransformer
+import javassist.CtClass
+import javassist.CtConstructor
+
+class StaticBlockRemover extends ClassTransformer {
+
+    private static final SOURCE = "com.mapbox.mapboxsdk.style.sources.Source";
+    private static final LAYER = "com.mapbox.mapboxsdk.style.layers.Layer";
+    private static
+    final NATIVE_CONNECTIVITY_LISTENER = "com.mapbox.mapboxsdk.net.NativeConnectivityListener";
+    private static final OFFLINE_MANAGER = "com.mapbox.mapboxsdk.offline.OfflineManager";
+    private static final OFFLINE_REGION = "com.mapbox.mapboxsdk.offline.OfflineRegion";
+    private static final List<String> excludes = new ArrayList<>();
+
+    static {
+        excludes.add(SOURCE)
+        excludes.add(LAYER)
+        excludes.add(NATIVE_CONNECTIVITY_LISTENER)
+        excludes.add(OFFLINE_MANAGER)
+        excludes.add(OFFLINE_REGION)
+    }
+
+    public void applyTransformations(CtClass clazz) throws Exception {
+        if (shouldFilter(clazz)) {
+            CtConstructor constructor = clazz.getClassInitializer()
+            if (constructor != null) {
+                clazz.removeConstructor(constructor)
+            }
+        }
+    }
+
+    public boolean shouldFilter(CtClass clazz) {
+        return hasAStaticBlock(clazz);
+    }
+
+    private boolean hasAStaticBlock(CtClass clazz) {
+        String name = clazz.getName();
+        return excludes.contains(name);
+    }
+}
+
+task removeStatic(type: TransformationTask) {
+    // TODO Find a better way to get output classes path
+    String fromToDirPath = buildDir.getAbsolutePath() + "/intermediates/classes/debug"
+    from fromToDirPath
+    transformation = new StaticBlockRemover()
+    into fromToDirPath
+}
+
+afterEvaluate {
+    compileDebugUnitTestJavaWithJavac.doLast {
+        tasks.removeStatic.execute()
+    }
+}


### PR DESCRIPTION
Reverts https://github.com/mapbox/mapbox-gl-native/pull/13753 (re-adds 16718b0df77119dd4bbebc383bfbd70afb1c0518) and brings back static code block remover to allow executing unit tests with mocked classes that try to statically load the native library. The remover now runs straight after Java unit test compilation.