### PR TITLE
Use ReLinker as default library loader for the test app

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     implementation dependenciesList.supportConstraintLayout
 
     implementation dependenciesList.gmsLocation
+    implementation dependenciesList.reLinker
     implementation dependenciesList.timber
     debugImplementation dependenciesList.leakCanaryDebug
     releaseImplementation dependenciesList.leakCanaryRelease

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/MapboxApplication.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/MapboxApplication.java
@@ -4,6 +4,8 @@ import android.app.Application;
 import android.os.StrictMode;
 import android.text.TextUtils;
 
+import com.getkeepsafe.relinker.ReLinker;
+import com.mapbox.mapboxsdk.LibraryLoader;
 import com.mapbox.mapboxsdk.MapStrictMode;
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.log.Logger;
@@ -23,6 +25,7 @@ import static timber.log.Timber.DebugTree;
  */
 public class MapboxApplication extends Application {
 
+  private static final String TAG = "MapboxApplication";
   private static final String DEFAULT_MAPBOX_ACCESS_TOKEN = "YOUR_MAPBOX_ACCESS_TOKEN_GOES_HERE";
   private static final String ACCESS_TOKEN_NOT_SET_MESSAGE = "In order to run the Test App you need to set a valid "
     + "access token. During development, you can set the MAPBOX_ACCESS_TOKEN environment variable for the SDK to "
@@ -35,6 +38,7 @@ public class MapboxApplication extends Application {
     if (!initializeLeakCanary()) {
       return;
     }
+    initializeLibraryLoader();
     initializeLogger();
     initializeStrictMode();
     initializeMapbox();
@@ -48,6 +52,15 @@ public class MapboxApplication extends Application {
     }
     LeakCanary.install(this);
     return true;
+  }
+
+  private void initializeLibraryLoader() {
+    LibraryLoader.setLibraryLoader(new LibraryLoader() {
+      @Override
+      public void load(String name) {
+        ReLinker.log(message -> Logger.v(TAG, message)).loadLibrary(MapboxApplication.this, name);
+      }
+    });
   }
 
   private void initializeLogger() {

--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -22,7 +22,8 @@ ext {
             kotlin          : '1.2.51',
             licenses        : '0.8.41',
             lint            : '26.1.3',
-            gms             : '16.0.0'
+            gms             : '16.0.0',
+            reLinker        : '1.3.1'
     ]
 
     vendorArtifacts = [
@@ -66,6 +67,7 @@ ext {
             okhttp3                : "com.squareup.okhttp3:okhttp:${versions.okhttp}",
             leakCanaryDebug        : "com.squareup.leakcanary:leakcanary-android:${versions.leakCanary}",
             leakCanaryRelease      : "com.squareup.leakcanary:leakcanary-android-no-op:${versions.leakCanary}",
+            reLinker               : "com.getkeepsafe.relinker:relinker:${versions.reLinker}",
 
             kotlinLib              : "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}",
             kotlinPlugin           : "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",


### PR DESCRIPTION
ReLinker is useful to improve reliability for native library loading on older Android versions. It's also useful for identifying causes for `UnsatisfiedLinkError` errors. 

For example:

> System.loadLibrary(name);

java.lang.UnsatisfiedLinkError: No implementation found for void com.mapbox.mapboxsdk.net.NativeConnectivityListener.initialize() (tried Java_com_mapbox_mapboxsdk_net_NativeConnectivityListener_initialize and Java_com_mapbox_mapboxsdk_net_NativeConnectivityListener_initialize__)

> ReLinker.loadLibrary(context, name);

Loading the library normally failed: java.lang.UnsatisfiedLinkError: dlopen failed: could not load library "libc++_shared.so" needed by "libmapbox-gl.so"; caused by library "libc++_shared.so" not found