### PR TITLE
Restore location layer visibility with new "layer-below"

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationLayerController.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationLayerController.java
@@ -107,6 +107,7 @@ final class LocationLayerController implements MapboxAnimator.OnLayerAnimationsV
       if (layerBelow == null || !layerBelow.equals(newLayerBelowOption)) {
         removeLayers();
         addLayers(newLayerBelowOption);
+        setRenderMode(renderMode);
       }
     }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationLayerControllerTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationLayerControllerTest.kt
@@ -388,6 +388,29 @@ class LocationLayerControllerTest : EspressoTest() {
     executeComponentTest(componentAction)
   }
 
+  @Test
+  fun applyStyle_layerBelow_restoreLayerVisibility() {
+    val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
+      override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
+                                             uiController: UiController, context: Context) {
+        component.activateLocationComponent(context,  mapboxMap.style!!,false)
+        component.isLocationComponentEnabled = true
+        component.forceLocationUpdate(location)
+        mapboxMap.waitForLayer(uiController, location, FOREGROUND_LAYER)
+        uiController.loopMainThreadForAtLeast(150)
+
+        component.applyStyle(LocationComponentOptions.builder(context).layerBelow("road-label").build())
+
+        assertThat(mapboxMap.isLayerVisible(FOREGROUND_LAYER), `is`(true))
+        assertThat(mapboxMap.isLayerVisible(BACKGROUND_LAYER), `is`(true))
+        assertThat(mapboxMap.isLayerVisible(SHADOW_LAYER), `is`(true))
+        assertThat(mapboxMap.isLayerVisible(ACCURACY_LAYER), `is`(true))
+        assertThat(mapboxMap.isLayerVisible(BEARING_LAYER), `is`(false))
+      }
+    }
+    executeComponentTest(componentAction)
+  }
+
   @After
   override fun afterTest() {
     super.afterTest()


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/mapbox/mapbox-gl-native/pull/13749 where layer visibility wasn't restored after applying new `"layer-below"` option.