### PR TITLE
Ignore unused arguments for all configurations

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -81,11 +81,10 @@ android {
                     // Enable ccache if the user has installed it.
                     if (ccache?.trim()) {
                         arguments "-DANDROID_CCACHE=" + ccache
-                        // ccache splits up the compile command until multiple invocations and uses -E
-                        // with one of them, and clang doesn't like unused arguments in that case.
-                        cFlags "-Qunused-arguments"
-                        cppFlags "-Qunused-arguments"
                     }
+
+                    cFlags "-Qunused-arguments"
+                    cppFlags "-Qunused-arguments"
 
                     targets "mapbox-gl"
 


### PR DESCRIPTION
We already had some end-users reports on this (eg. https://github.com/mapbox/mapbox-gl-native/issues/13151). Those users were unable to build a release variant of the library due to unused arguments in our vendor packages. I'm now hitting the same issue in mobile-metrics. This PR enforces using `-Qunused-arguments`, not solely for ccache enabled build environments. 