### PR TITLE
Remove deprecated javacompile

### DIFF
--- a/platform/android/gradle/gradle-javadoc.gradle
+++ b/platform/android/gradle/gradle-javadoc.gradle
@@ -4,7 +4,7 @@ android.libraryVariants.all { variant ->
         description = "Generates javadoc for build $name"
         failOnError = false
         destinationDir = new File(destinationDir, variant.baseName)
-        source = variant.getJavaCompiler().source
+        source = variant.sourceSets.collect { it.java.sourceFiles }.inject { m, i -> m + i }
         options.windowTitle("Mapbox Maps SDK for Android $VERSION_NAME Reference")
         options.docTitle("Mapbox Maps SDK for Android $VERSION_NAME")
         options.header("Mapbox Maps SDK for Android $VERSION_NAME Reference")


### PR DESCRIPTION
Starting with Android Studio 3.3.0, we will receive a warning when we perform a gradle sync:

> WARNING: API 'variant.getJavaCompile()' is obsolete and has been replaced with 'variant.getJavaCompileProvider()'. It will be removed at the end of 2019. For more information, see https://d.android.com/r/tools/task-configuration-avoidance. To determine what is calling variant.getJavaCompile(), use -Pandroid.debug.obsoleteApi=true on the command line to display a stack trace.

Capturing  a solution from [here](https://github.com/vanniktech/gradle-android-javadoc-plugin/pull/67/files#diff-7f9dfd224d08fdd544b6417324258085R143). We need to replace the following:
```
source = variant.getJavaCompiler().source	
```
with

```
source = variant.sourceSets.collect { it.java.sourceFiles }.inject { m, i -> m + i }
```

cc @mapbox/android, this fix needs to be applied to other projects using the same javadoc configuration

