### PR TITLE
[android, darwin] Fix core-only layer creation

### DIFF
--- a/platform/android/src/style/layers/layer_manager.cpp
+++ b/platform/android/src/style/layers/layer_manager.cpp
@@ -24,52 +24,52 @@ namespace android {
 
 LayerManagerAndroid::LayerManagerAndroid() {
 #if defined(MBGL_LAYER_FILL_DISABLE_RUNTIME)
-    addLayerTypeCoreOnly(std::make_unique<FillJavaLayerPeerFactory>());
+    addLayerTypeCoreOnly(std::make_unique<FillLayerFactory>());
 #elif !defined(MBGL_LAYER_FILL_DISABLE_ALL)
     addLayerType(std::make_unique<FillJavaLayerPeerFactory>());
 #endif
 #if defined(MBGL_LAYER_LINE_DISABLE_RUNTIME)
-    addLayerTypeCoreOnly(std::make_unique<LineJavaLayerPeerFactory>());
+    addLayerTypeCoreOnly(std::make_unique<LineLayerFactory>());
 #elif !defined(MBGL_LAYER_LINE_DISABLE_ALL)
     addLayerType(std::make_unique<LineJavaLayerPeerFactory>());
 #endif
 #if defined(MBGL_LAYER_CIRCLE_DISABLE_RUNTIME)
-    addLayerTypeCoreOnly(std::make_unique<CircleJavaLayerPeerFactory>());
+    addLayerTypeCoreOnly(std::make_unique<CircleLayerFactory>());
 #elif !defined(MBGL_LAYER_CIRCLE_DISABLE_ALL)
     addLayerType(std::make_unique<CircleJavaLayerPeerFactory>());
 #endif
 #if defined(MBGL_LAYER_SYMBOL_DISABLE_RUNTIME)
-    addLayerTypeCoreOnly(std::make_unique<SymbolJavaLayerPeerFactory>());
+    addLayerTypeCoreOnly(std::make_unique<SymbolLayerFactory>());
 #elif !defined(MBGL_LAYER_SYMBOL_DISABLE_ALL)
     addLayerType(std::make_unique<SymbolJavaLayerPeerFactory>());
 #endif
 #if defined(MBGL_LAYER_RASTER_DISABLE_RUNTIME)
-    addLayerTypeCoreOnly(std::make_unique<RasterJavaLayerPeerFactory>());
+    addLayerTypeCoreOnly(std::make_unique<RasterLayerFactory>());
 #elif !defined(MBGL_LAYER_RASTER_DISABLE_ALL)
     addLayerType(std::make_unique<RasterJavaLayerPeerFactory>());
 #endif
 #if defined(MBGL_LAYER_BACKGROUND_DISABLE_RUNTIME)
-    addLayerTypeCoreOnly(std::make_unique<BackgroundJavaLayerPeerFactory>());
+    addLayerTypeCoreOnly(std::make_unique<BackgroundLayerFactory>());
 #elif !defined(MBGL_LAYER_BACKGROUND_DISABLE_ALL)
     addLayerType(std::make_unique<BackgroundJavaLayerPeerFactory>());
 #endif
 #if defined(MBGL_LAYER_HILLSHADE_DISABLE_RUNTIME)
-    addLayerTypeCoreOnly(std::make_unique<HillshadeJavaLayerPeerFactory>());
+    addLayerTypeCoreOnly(std::make_unique<HillshadeLayerFactory>());
 #elif !defined(MBGL_LAYER_HILLSHADE_DISABLE_ALL)
     addLayerType(std::make_unique<HillshadeJavaLayerPeerFactory>());
 #endif
 #if defined(MBGL_LAYER_FILL_EXTRUSION_DISABLE_RUNTIME)
-    addLayerTypeCoreOnly(std::make_unique<FillExtrusionJavaLayerPeerFactory>());
+    addLayerTypeCoreOnly(std::make_unique<FillExtrusionLayerFactory>());
 #elif !defined(MBGL_LAYER_FILL_EXTRUSION_DISABLE_ALL)
     addLayerType(std::make_unique<FillExtrusionJavaLayerPeerFactory>());
 #endif
 #if defined(MBGL_LAYER_HEATMAP_DISABLE_RUNTIME)
-    addLayerTypeCoreOnly(std::make_unique<HeatmapJavaLayerPeerFactory>());
+    addLayerTypeCoreOnly(std::make_unique<HeatmapLayerFactory>());
 #elif !defined(MBGL_LAYER_HEATMAP_DISABLE_ALL)
     addLayerType(std::make_unique<HeatmapJavaLayerPeerFactory>());
 #endif
 #if defined(MBGL_LAYER_CUSTOM_DISABLE_RUNTIME)
-    addLayerTypeCoreOnly(std::make_unique<CustomJavaLayerPeerFactory>());
+    addLayerTypeCoreOnly(std::make_unique<CustomLayerFactory>());
 #elif !defined(MBGL_LAYER_CUSTOM_DISABLE_ALL)
     addLayerType(std::make_unique<CustomJavaLayerPeerFactory>());
 #endif

--- a/platform/darwin/src/MGLStyleLayerManager.mm
+++ b/platform/darwin/src/MGLStyleLayerManager.mm
@@ -17,52 +17,52 @@ namespace mbgl {
 
 LayerManagerDarwin::LayerManagerDarwin() {
 #if defined(MBGL_LAYER_FILL_DISABLE_RUNTIME)
-    addLayerTypeCoreOnly(std::make_unique<FillStyleLayerPeerFactory>());
+    addLayerTypeCoreOnly(std::make_unique<FillLayerFactory>());
 #elif !defined(MBGL_LAYER_FILL_DISABLE_ALL)
     addLayerType(std::make_unique<FillStyleLayerPeerFactory>());
 #endif
 #if defined(MBGL_LAYER_LINE_DISABLE_RUNTIME)
-    addLayerTypeCoreOnly(std::make_unique<LineStyleLayerPeerFactory>());
+    addLayerTypeCoreOnly(std::make_unique<LineLayerFactory>());
 #elif !defined(MBGL_LAYER_LINE_DISABLE_ALL)
     addLayerType(std::make_unique<LineStyleLayerPeerFactory>());
 #endif
 #if defined(MBGL_LAYER_CIRCLE_DISABLE_RUNTIME)
-    addLayerTypeCoreOnly(std::make_unique<CircleStyleLayerPeerFactory>());
+    addLayerTypeCoreOnly(std::make_unique<CircleLayerFactory>());
 #elif !defined(MBGL_LAYER_CIRCLE_DISABLE_ALL)
     addLayerType(std::make_unique<CircleStyleLayerPeerFactory>());
 #endif
 #if defined(MBGL_LAYER_SYMBOL_DISABLE_RUNTIME)
-    addLayerTypeCoreOnly(std::make_unique<SymbolStyleLayerPeerFactory>());
+    addLayerTypeCoreOnly(std::make_unique<SymbolLayerFactory>());
 #elif !defined(MBGL_LAYER_SYMBOL_DISABLE_ALL)
     addLayerType(std::make_unique<SymbolStyleLayerPeerFactory>());
 #endif
 #if defined(MBGL_LAYER_RASTER_DISABLE_RUNTIME)
-    addLayerTypeCoreOnly(std::make_unique<RasterStyleLayerPeerFactory>());
+    addLayerTypeCoreOnly(std::make_unique<RasterLayerFactory>());
 #elif !defined(MBGL_LAYER_RASTER_DISABLE_ALL)
     addLayerType(std::make_unique<RasterStyleLayerPeerFactory>());
 #endif
 #if defined(MBGL_LAYER_BACKGROUND_DISABLE_RUNTIME)
-    addLayerTypeCoreOnly(std::make_unique<BackgroundStyleLayerPeerFactory>());
+    addLayerTypeCoreOnly(std::make_unique<BackgroundLayerFactory>());
 #elif !defined(MBGL_LAYER_BACKGROUND_DISABLE_ALL)
     addLayerType(std::make_unique<BackgroundStyleLayerPeerFactory>());
 #endif
 #if defined(MBGL_LAYER_HILLSHADE_DISABLE_RUNTIME)
-    addLayerTypeCoreOnly(std::make_unique<HillshadeStyleLayerPeerFactory>());
+    addLayerTypeCoreOnly(std::make_unique<HillshadeLayerFactory>());
 #elif !defined(MBGL_LAYER_HILLSHADE_DISABLE_ALL)
     addLayerType(std::make_unique<HillshadeStyleLayerPeerFactory>());
 #endif
 #if defined(MBGL_LAYER_FILL_EXTRUSION_DISABLE_RUNTIME)
-    addLayerTypeCoreOnly(std::make_unique<FillExtrusionStyleLayerPeerFactory>());
+    addLayerTypeCoreOnly(std::make_unique<FillExtrusionLayerFactory>());
 #elif !defined(MBGL_LAYER_FILL_EXTRUSION_DISABLE_ALL)
     addLayerType(std::make_unique<FillExtrusionStyleLayerPeerFactory>());
 #endif
 #if defined(MBGL_LAYER_HEATMAP_DISABLE_RUNTIME)
-    addLayerTypeCoreOnly(std::make_unique<HeatmapStyleLayerPeerFactory>());
+    addLayerTypeCoreOnly(std::make_unique<HeatmapLayerFactory>());
 #elif !defined(MBGL_LAYER_HEATMAP_DISABLE_ALL)
     addLayerType(std::make_unique<HeatmapStyleLayerPeerFactory>());
 #endif
 #if defined(MBGL_LAYER_CUSTOM_DISABLE_RUNTIME)
-    addLayerTypeCoreOnly(std::make_unique<OpenGLStyleLayerPeerFactory>());
+    addLayerTypeCoreOnly(std::make_unique<CustomLayerFactory>());
 #elif !defined(MBGL_LAYER_CUSTOM_DISABLE_ALL)
     addLayerType(std::make_unique<OpenGLStyleLayerPeerFactory>());
 #endif


### PR DESCRIPTION
In the layer manager implementations `addLayerTypeCoreOnly()`
should be called with core-only modules.