### PR TITLE
[build, ios] Update jazzy to 0.9.5

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -331,15 +331,14 @@ commands:
     steps:
     - run:
         name: Install iOS packaging dependencies
-        command: brew install awscli wget
+        command: ./platform/ios/scripts/install-packaging-dependencies.sh
         background: true
 
   install-macos-dependencies:
     steps:
     - run:
         name: Install macOS dependencies
-        command: |
-          brew install cmake ccache
+        command: brew install cmake ccache
 
   install-node-macos-dependencies:
     steps:
@@ -945,8 +944,8 @@ jobs:
       SLACK_CHANNEL: C0ACM9Q2C
     steps:
       - install-macos-dependencies
-      - install-ios-packaging-dependencies
       - install-dependencies
+      - install-ios-packaging-dependencies
       - run:
           name: Build dynamic framework for device and simulator
           command: make iframework
@@ -981,8 +980,8 @@ jobs:
             export SLACK_MESSAGE="<$CIRCLE_BUILD_URL|Release build for \`$CIRCLE_TAG\` started.>"
             scripts/notify-slack.sh
       - install-macos-dependencies
-      - install-ios-packaging-dependencies
       - install-dependencies
+      - install-ios-packaging-dependencies
       - run:
           name: Build, package, and upload iOS release
           command: |

--- a/platform/ios/scripts/document.sh
+++ b/platform/ios/scripts/document.sh
@@ -1,27 +1,13 @@
 #!/usr/bin/env bash
 
-set -e
-set -o pipefail
-set -u
+set -euo pipefail
 
 function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
 function finish { >&2 echo -en "\033[0m"; }
 trap finish EXIT
 
 if [ -z `which jazzy` ]; then
-    step "Installing jazzy…"
-
-    CIRCLECI=${CIRCLECI:-false}
-    if [[ "${CIRCLECI}" == true ]]; then
-        sudo gem install jazzy -v 0.9.4 --no-document
-    else
-        gem install jazzy -v 0.9.4 --no-document
-    fi
-
-    if [ -z `which jazzy` ]; then
-        echo "Unable to install jazzy. See https://github.com/mapbox/mapbox-gl-native/blob/master/platform/ios/INSTALL.md"
-        exit 1
-    fi
+    ./platform/ios/scripts/install-packaging-dependencies.sh
 fi
 
 OUTPUT=${OUTPUT:-documentation}

--- a/platform/ios/scripts/install-packaging-dependencies.sh
+++ b/platform/ios/scripts/install-packaging-dependencies.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+JAZZY_VERSION="0.9.5"
+
+function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
+function finish { >&2 echo -en "\033[0m"; }
+trap finish EXIT
+
+step "Installing packaging dependencies…"
+brew install awscli wget
+
+if [ -z `which jazzy` ]; then
+    step "Installing jazzy…"
+
+    CIRCLECI=${CIRCLECI:-false}
+    if [[ "${CIRCLECI}" == true ]]; then
+        sudo gem install sqlite3 -- --with-sqlite3-lib=/usr/lib
+        sudo gem install jazzy -v $JAZZY_VERSION --no-document
+    else
+        gem install jazzy -v $JAZZY_VERSION --no-document
+    fi
+
+    if [ -z `which jazzy` ]; then
+        echo "Unable to install jazzy ($JAZZY_VERSION). See https://github.com/mapbox/mapbox-gl-native/blob/master/platform/ios/INSTALL.md"
+        exit 1
+    fi
+fi


### PR DESCRIPTION
Updates to jazzy [0.9.5](https://github.com/realm/jazzy/releases/tag/v0.9.5), which now includes docs for unavailable/deprecated methods.

This version of jazzy bumped its sqlite3 dependency version, which, for some reason, caused issues on CircleCI — this was fixed by [manually specifying where to find system sqlite3](https://stackoverflow.com/a/51856164/2094275).

I’ve also broken out the `install-ios-packaging-dependencies` step into its own script and moved the jazzy installation there, so that it can be parallelized during the CI job.

/cc @mapbox/maps-ios @1ec5 