### PR TITLE
Cherry-pick jazzy improvements to release-java

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -331,15 +331,14 @@ commands:
     steps:
     - run:
         name: Install iOS packaging dependencies
-        command: brew install awscli wget
+        command: ./platform/ios/scripts/install-packaging-dependencies.sh
         background: true
 
   install-macos-dependencies:
     steps:
     - run:
         name: Install macOS dependencies
-        command: |
-          brew install cmake ccache
+        command: brew install cmake ccache
 
   install-node-macos-dependencies:
     steps:
@@ -937,8 +936,8 @@ jobs:
       SLACK_CHANNEL: C0ACM9Q2C
     steps:
       - install-macos-dependencies
-      - install-ios-packaging-dependencies
       - install-dependencies
+      - install-ios-packaging-dependencies
       - run:
           name: Build dynamic framework for device and simulator
           command: make iframework
@@ -973,8 +972,8 @@ jobs:
             export SLACK_MESSAGE="<$CIRCLE_BUILD_URL|Release build for \`$CIRCLE_TAG\` started.>"
             scripts/notify-slack.sh
       - install-macos-dependencies
-      - install-ios-packaging-dependencies
       - install-dependencies
+      - install-ios-packaging-dependencies
       - run:
           name: Build, package, and upload iOS release
           command: |

--- a/platform/darwin/docs/theme/assets/css/jazzy.css.scss
+++ b/platform/darwin/docs/theme/assets/css/jazzy.css.scss
@@ -523,6 +523,9 @@ h1 > .anchor-icon { margin-bottom: 2px; }
     background-repeat: no-repeat;
   }
 
+  .discouraged {
+    text-decoration: line-through;
+  }
   .declaration-note {
     font-size: 13px;
     color: #808080;
@@ -571,6 +574,7 @@ h1 > .anchor-icon { margin-bottom: 2px; }
   padding: 6px 12px;
   margin: 12px 0;
   border-left: $aside_border;
+  border-radius: 4px;
   overflow-y: hidden;
   .aside-title {
     font-size: 10px;
@@ -579,7 +583,6 @@ h1 > .anchor-icon { margin-bottom: 2px; }
     text-transform: uppercase;
     padding: 2px 8px;
     display: inline;
-    border-radius: 4px;
     margin: 0;
     -webkit-user-select: none;
   }
@@ -590,19 +593,17 @@ h1 > .anchor-icon { margin-bottom: 2px; }
 
 .language {
   background: $color_light;
-  border-radius: 4px;
   border-left: $declaration_language_border;
 }
 
 .aside.aside-see, .aside.aside-note, {
   background: $color_light;
-  border-radius: 4px;
   .aside-title {
     padding-left: 0px;
   }
 }
 
-.aside-warning {
+.aside-warning, .aside-deprecated, .aside-unavailable {
   border-left: $aside_warning_border;
   .aside-title {
     color: $aside_warning_color;

--- a/platform/darwin/docs/theme/templates/deprecation.mustache
+++ b/platform/darwin/docs/theme/templates/deprecation.mustache
@@ -1,0 +1,12 @@
+{{#deprecation_message}}
+<div class="aside aside-deprecated">
+  <p class="aside-title">Deprecated</p>
+  {{{deprecation_message}}}
+</div>
+{{/deprecation_message}}
+{{#unavailable_message}}
+<div class="aside aside-unavailable">
+  <p class="aside-title">Unavailable</p>
+  {{{unavailable_message}}}
+</div>
+{{/unavailable_message}}

--- a/platform/darwin/docs/theme/templates/doc.mustache
+++ b/platform/darwin/docs/theme/templates/doc.mustache
@@ -43,6 +43,7 @@
         <section class="section">
           <div class="section-content">
             {{^hide_name}}<a href="#/{{name}}"><h1 id="{{name}}">{{name}}<span class="anchor-icon" /></h1></a>{{/hide_name}}
+            {{> deprecation}}
             {{#declaration}}
               <div class="declaration">
                 <div class="language">

--- a/platform/darwin/docs/theme/templates/task.mustache
+++ b/platform/darwin/docs/theme/templates/task.mustache
@@ -15,7 +15,7 @@
         <code>
         <a name="/{{usr}}"></a>
         <a name="//apple_ref/{{language_stub}}/{{dash_type}}/{{name}}" class="dashAnchor"></a>
-        <a class="token" href="#/{{usr}}"><span class="token-name">{{name}}</span><span class="token-icon" /></a>
+        <a class="token {{#usage_discouraged}}discouraged{{/usage_discouraged}}" href="#/{{usr}}"><span class="token-name">{{name}}</span><span class="token-icon" /></a>
         </code>
         {{#default_impl_abstract}}
           <span class="declaration-note">
@@ -30,6 +30,7 @@
       </div>
       <div class="height-container">
         <section class="section">
+          {{> deprecation}}
           {{#abstract}}
           <div class="abstract">
             {{{abstract}}}

--- a/platform/darwin/src/MGLShape.h
+++ b/platform/darwin/src/MGLShape.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  `MGLShape` is an abstract class that represents a shape or annotation. Shapes
- constitute the content of a map – not only the overlays atop the map, but also
+ constitute the content of a map — not only the overlays atop the map, but also
  the content that forms the base map.
 
  Create instances of `MGLPointAnnotation`, `MGLPointCollection`, `MGLPolyline`,

--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -12,8 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  A version number identifying the default version of the Mapbox Streets style
- obtained through the `-streetsStyleURL` method. This version number may also be
- passed into the `-streetsStyleURLWithVersion:` method.
+ obtained through the `MGLStyle.streetsStyleURL` method. This version number may also be
+ passed into the `+[MGLStyle streetsStyleURLWithVersion:]` method.
 
  The value of this constant generally corresponds to the latest released version
  as of the date on which this SDK was published. You can use this constant to
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @warning The value of this constant may change in a future release of the SDK.
     If you use any feature that depends on a specific aspect of a default style
-    – for instance, the minimum zoom level that includes roads – you may use the
+    — for instance, the minimum zoom level that includes roads — you may use the
     current value of this constant or the underlying style URL, but do not use
     the constant itself. Such details may change significantly from version to
     version.
@@ -41,11 +41,11 @@ FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLRedundantSourceIdentifier
  The proxy object for the current map style.
 
  MGLStyle provides a set of convenience methods for changing Mapbox
- default styles using `-[MGLMapView styleURL]`.
+ default styles using `MGLMapView.styleURL`.
  <a href="https://www.mapbox.com/maps/">Learn more about Mapbox default styles</a>.
 
  It is also possible to directly manipulate the current map style
- via `-[MGLMapView style]` by updating the style's data sources or layers.
+ via `MGLMapView.style` by updating the style's data sources or layers.
 
  @note Wait until the map style has finished loading before modifying a map's
     style via any of the `MGLStyle` instance methods below. You can use the
@@ -74,9 +74,9 @@ MGL_EXPORT
  is specified explicitly.
 
  @warning The return value may change in a future release of the SDK. If you use
-    any feature that depends on a specific aspect of a default style – for
-    instance, the minimum zoom level that includes roads – use the
-    `-streetsStyleURLWithVersion:` method instead. Such details may change
+    any feature that depends on a specific aspect of a default style — for
+    instance, the minimum zoom level that includes roads — use the
+    `+streetsStyleURLWithVersion:` method instead. Such details may change
     significantly from version to version.
  */
 @property (class, nonatomic, readonly) NSURL *streetsStyleURL;
@@ -104,9 +104,9 @@ MGL_EXPORT
  Outdoors is a general-purpose style tailored to outdoor activities.
 
  @warning The return value may change in a future release of the SDK. If you use
-    any feature that depends on a specific aspect of a default style – for
-    instance, the minimum zoom level that includes roads – use the
-    `-outdoorsStyleURLWithVersion:` method instead. Such details may change
+    any feature that depends on a specific aspect of a default style — for
+    instance, the minimum zoom level that includes roads — use the
+    `+outdoorsStyleURLWithVersion:` method instead. Such details may change
     significantly from version to version.
  */
 @property (class, nonatomic, readonly) NSURL *outdoorsStyleURL;
@@ -128,9 +128,9 @@ MGL_EXPORT
  Light is a subtle, light-colored backdrop for data visualizations.
 
  @warning The return value may change in a future release of the SDK. If you use
-    any feature that depends on a specific aspect of a default style – for
-    instance, the minimum zoom level that includes roads – use the
-    `-lightStyleURLWithVersion:` method instead. Such details may change
+    any feature that depends on a specific aspect of a default style — for
+    instance, the minimum zoom level that includes roads — use the
+    `+lightStyleURLWithVersion:` method instead. Such details may change
     significantly from version to version.
  */
 @property (class, nonatomic, readonly) NSURL *lightStyleURL;
@@ -153,9 +153,9 @@ MGL_EXPORT
  Dark is a subtle, dark-colored backdrop for data visualizations.
 
  @warning The return value may change in a future release of the SDK. If you use
-    any feature that depends on a specific aspect of a default style – for
-    instance, the minimum zoom level that includes roads – use the
-    `-darkStyleURLWithVersion:` method instead. Such details may change
+    any feature that depends on a specific aspect of a default style — for
+    instance, the minimum zoom level that includes roads — use the
+    `+darkStyleURLWithVersion:` method instead. Such details may change
     significantly from version to version.
  */
 @property (class, nonatomic, readonly) NSURL *darkStyleURL;
@@ -178,9 +178,9 @@ MGL_EXPORT
  Satellite is high-resolution satellite and aerial imagery.
 
  @warning The return value may change in a future release of the SDK. If you use
-    any feature that depends on a specific aspect of a default style – for
-    instance, the raster tile sets included in the style – use the
-    `-satelliteStyleURLWithVersion:` method instead. Such details may change
+    any feature that depends on a specific aspect of a default style — for
+    instance, the raster tile sets included in the style — use the
+    `+satelliteStyleURLWithVersion:` method instead. Such details may change
     significantly from version to version.
 
  #### Related example
@@ -214,9 +214,9 @@ MGL_EXPORT
  Streets.
 
  @warning The return value may change in a future release of the SDK. If you use
-    any feature that depends on a specific aspect of a default style – for
-    instance, the minimum zoom level that includes roads – use the
-    `-satelliteStreetsStyleURLWithVersion:` method instead. Such details may
+    any feature that depends on a specific aspect of a default style — for
+    instance, the minimum zoom level that includes roads — use the
+    `+satelliteStreetsStyleURLWithVersion:` method instead. Such details may
     change significantly from version to version.
 
  #### Related example

--- a/platform/ios/scripts/document.sh
+++ b/platform/ios/scripts/document.sh
@@ -1,27 +1,13 @@
 #!/usr/bin/env bash
 
-set -e
-set -o pipefail
-set -u
+set -euo pipefail
 
 function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
 function finish { >&2 echo -en "\033[0m"; }
 trap finish EXIT
 
 if [ -z `which jazzy` ]; then
-    step "Installing jazzy…"
-
-    CIRCLECI=${CIRCLECI:-false}
-    if [[ "${CIRCLECI}" == true ]]; then
-        sudo gem install jazzy -v 0.9.4 --no-document
-    else
-        gem install jazzy -v 0.9.4 --no-document
-    fi
-
-    if [ -z `which jazzy` ]; then
-        echo "Unable to install jazzy. See https://github.com/mapbox/mapbox-gl-native/blob/master/platform/ios/INSTALL.md"
-        exit 1
-    fi
+    ./platform/ios/scripts/install-packaging-dependencies.sh
 fi
 
 OUTPUT=${OUTPUT:-documentation}

--- a/platform/ios/scripts/install-packaging-dependencies.sh
+++ b/platform/ios/scripts/install-packaging-dependencies.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+JAZZY_VERSION="0.9.5"
+
+function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
+function finish { >&2 echo -en "\033[0m"; }
+trap finish EXIT
+
+step "Installing packaging dependencies…"
+brew install awscli wget
+
+if [ -z `which jazzy` ]; then
+    step "Installing jazzy…"
+
+    CIRCLECI=${CIRCLECI:-false}
+    if [[ "${CIRCLECI}" == true ]]; then
+        sudo gem install sqlite3 -- --with-sqlite3-lib=/usr/lib
+        sudo gem install jazzy -v $JAZZY_VERSION --no-document
+    else
+        gem install jazzy -v $JAZZY_VERSION --no-document
+    fi
+
+    if [ -z `which jazzy` ]; then
+        echo "Unable to install jazzy ($JAZZY_VERSION). See https://github.com/mapbox/mapbox-gl-native/blob/master/platform/ios/INSTALL.md"
+        exit 1
+    fi
+fi

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -450,7 +450,7 @@ MGL_EXPORT IB_DESIGNABLE
  transition. If you don’t want to animate the change, use the
  `-setUserLocationVerticalAlignment:animated:` method instead.
  */
-@property (nonatomic, assign) MGLAnnotationVerticalAlignment userLocationVerticalAlignment __attribute__((deprecated("Use -[MGLMapViewDelegate mapViewUserLocationAnchorPoint:] instead.")));
+@property (nonatomic, assign) MGLAnnotationVerticalAlignment userLocationVerticalAlignment __attribute__((deprecated("Use `-[MGLMapViewDelegate mapViewUserLocationAnchorPoint:]` instead.")));
 
 /**
  Sets the vertical alignment of the user location annotation within the
@@ -461,7 +461,7 @@ MGL_EXPORT IB_DESIGNABLE
     position within the map view. If `NO`, the user location annotation
     instantaneously moves to its new position.
  */
-- (void)setUserLocationVerticalAlignment:(MGLAnnotationVerticalAlignment)alignment animated:(BOOL)animated __attribute__((deprecated("Use -[MGLMapViewDelegate mapViewUserLocationAnchorPoint:] instead.")));
+- (void)setUserLocationVerticalAlignment:(MGLAnnotationVerticalAlignment)alignment animated:(BOOL)animated __attribute__((deprecated("Use `-[MGLMapViewDelegate mapViewUserLocationAnchorPoint:]` instead.")));
 
 /**
  Updates the position of the user location annotation view by retreiving the user's last

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -346,7 +346,7 @@ NS_ASSUME_NONNULL_BEGIN
  the map view with respect to the content insets.
 
  This method will override any values set by `MGLMapView.userLocationVerticalAlignment`
- or `-[MGLMapView setUserLocationVerticalAlignment:]`.
+ or `-[MGLMapView setUserLocationVerticalAlignment:animated:]`.
 
  @param mapView The map view that is tracking the user's location.
  */


### PR DESCRIPTION
Cherry-picks jazzy improvements from #13819 and #13827 to `release-java`.

/cc @fabian-guerra 