### PR TITLE
[android] Adding new variation of LocationComponent#activateLocationComponent

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
@@ -263,6 +263,30 @@ public final class LocationComponent {
   /**
    * This method initializes the component and needs to be called before any other operations are performed.
    * Afterwards, you can manage component's visibility by {@link #setLocationComponentEnabled(boolean)}.
+   *
+   * @param context                  the context
+   * @param style                    the proxy object for current map style. More info at {@link Style}
+   * @param useDefaultLocationEngine true if you want to initialize and use the built-in location engine or false if
+   *                                 there should be no location engine initialized
+   * @param locationEngineRequest    the location request
+   * @param options                  the options
+   */
+  @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
+  public void activateLocationComponent(@NonNull Context context, @NonNull Style style,
+                                        boolean useDefaultLocationEngine,
+                                        @NonNull LocationEngineRequest locationEngineRequest,
+                                        @NonNull LocationComponentOptions options) {
+    setLocationEngineRequest(locationEngineRequest);
+    if (useDefaultLocationEngine) {
+      activateLocationComponent(context, style, options);
+    } else {
+      activateLocationComponent(context, style, null, options);
+    }
+  }
+
+  /**
+   * This method initializes the component and needs to be called before any other operations are performed.
+   * Afterwards, you can manage component's visibility by {@link #setLocationComponentEnabled(boolean)}.
    * <p>
    * <strong>Note</strong>: This method will initialize and use an internal {@link LocationEngine} when enabled.
    *

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
@@ -98,6 +98,26 @@ class LocationComponentTest {
   }
 
   @Test
+  fun activateWithDefaultLocationEngineRequestAndOptionsTest() {
+    locationComponent.activateLocationComponent(context, mockk(), true, locationEngineRequest, locationComponentOptions)
+
+    Assert.assertEquals(locationEngineRequest, locationComponent.locationEngineRequest)
+
+    doReturn(mock(TypedArray::class.java)).`when`(context)
+            .obtainStyledAttributes(R.style.mapbox_LocationComponent, R.styleable.mapbox_LocationComponent)
+
+    val resources = mock(Resources::class.java)
+
+    doReturn(resources).`when`(context).resources
+    doReturn(0f).`when`(resources)
+            .getDimension(R.dimen.mapbox_locationComponentTrackingMultiFingerMoveThreshold)
+    doReturn(0f).`when`(resources)
+            .getDimension(R.dimen.mapbox_locationComponentTrackingMultiFingerMoveThreshold)
+    locationComponent.activateLocationComponent(context, mockk(), true, locationEngineRequest, locationComponentOptions)
+    Assert.assertEquals(locationEngineRequest, locationComponent.locationEngineRequest)
+  }
+
+  @Test
   fun locationUpdatesWhenEnabledDisableTest() {
     locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
     verify(locationEngine, times(0)).removeLocationUpdates(currentListener)


### PR DESCRIPTION
As I looked into the pulsing `LocationComponent` circle functionality, I discovered that the `LocationComponent` could use a new version of the `activateLocationComponent()` method. There wasn't an activation method which took a certain mix of 5 parameters, which I've now added in this pr.