### PR TITLE
[qt] Use QVector instead of QList

### DIFF
--- a/platform/qt/include/qmapbox.hpp
+++ b/platform/qt/include/qmapbox.hpp
@@ -2,10 +2,10 @@
 #define QMAPBOX_H
 
 #include <QColor>
-#include <QList>
 #include <QPair>
-#include <QVariant>
 #include <QString>
+#include <QVariant>
+#include <QVector>
 
 // This header follows the Qt coding style: https://wiki.qt.io/Qt_Coding_Style
 
@@ -25,10 +25,10 @@ typedef QPair<double, double> Coordinate;
 typedef QPair<Coordinate, double> CoordinateZoom;
 typedef QPair<double, double> ProjectedMeters;
 
-typedef QList<Coordinate> Coordinates;
-typedef QList<Coordinates> CoordinatesCollection;
+typedef QVector<Coordinate> Coordinates;
+typedef QVector<Coordinates> CoordinatesCollection;
 
-typedef QList<CoordinatesCollection> CoordinatesCollections;
+typedef QVector<CoordinatesCollection> CoordinatesCollections;
 
 struct Q_MAPBOXGL_EXPORT Feature {
     enum Type {
@@ -95,14 +95,14 @@ struct Q_MAPBOXGL_EXPORT FillAnnotation {
 
 typedef QVariant Annotation;
 typedef quint32 AnnotationID;
-typedef QList<AnnotationID> AnnotationIDs;
+typedef QVector<AnnotationID> AnnotationIDs;
 
 enum NetworkMode {
     Online, // Default
     Offline,
 };
 
-Q_MAPBOXGL_EXPORT QList<QPair<QString, QString> >& defaultStyles();
+Q_MAPBOXGL_EXPORT QVector<QPair<QString, QString> >& defaultStyles();
 
 Q_MAPBOXGL_EXPORT NetworkMode networkMode();
 Q_MAPBOXGL_EXPORT void setNetworkMode(NetworkMode);

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -240,7 +240,7 @@ public:
     bool layerExists(const QString &id);
     void removeLayer(const QString &id);
 
-    QList<QString> layerIds() const;
+    QVector<QString> layerIds() const;
 
     void setFilter(const QString &layer, const QVariant &filter);
     QVariant getFilter(const QString &layer) const;

--- a/platform/qt/src/qmapbox.cpp
+++ b/platform/qt/src/qmapbox.cpp
@@ -49,21 +49,21 @@ namespace QMapbox {
 /*!
     \typedef QMapbox::Coordinates
 
-    Alias for QList<QMapbox::Coordinate>.
+    Alias for QVector<QMapbox::Coordinate>.
     A list of QMapbox::Coordinate objects.
 */
 
 /*!
     \typedef QMapbox::CoordinatesCollection
 
-    Alias for QList<QMapbox::Coordinates>.
+    Alias for QVector<QMapbox::Coordinates>.
     A list of QMapbox::Coordinates objects.
 */
 
 /*!
     \typedef QMapbox::CoordinatesCollections
 
-    Alias for QList<QMapbox::CoordinatesCollection>.
+    Alias for QVector<QMapbox::CoordinatesCollection>.
     A list of QMapbox::CoordinatesCollection objects.
 */
 
@@ -150,7 +150,7 @@ namespace QMapbox {
 /*!
     \typedef QMapbox::AnnotationIDs
 
-    Alias for QList<quint32> representing a container of annotation identifiers.
+    Alias for QVector<quint32> representing a container of annotation identifiers.
 */
 
 /*!
@@ -203,14 +203,14 @@ void setNetworkMode(NetworkMode mode)
 }
 
 /*!
-    \fn QList<QPair<QString, QString> >& QMapbox::defaultStyles()
+    \fn QVector<QPair<QString, QString> >& QMapbox::defaultStyles()
 
     Returns a list containing a pair of string objects, representing the style
     URL and name, respectively.
 */
-QList<QPair<QString, QString> >& defaultStyles()
+QVector<QPair<QString, QString> >& defaultStyles()
 {
-    static QList<QPair<QString, QString>> styles;
+    static QVector<QPair<QString, QString>> styles;
 
     if (styles.isEmpty()) {
         for (auto style : mbgl::util::default_styles::orderedStyles) {

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1475,11 +1475,11 @@ void QMapboxGL::removeLayer(const QString& id)
 /*!
     List of all existing layer ids from the current style.
 */
-QList<QString> QMapboxGL::layerIds() const
+QVector<QString> QMapboxGL::layerIds() const
 {
     const auto &layers = d_ptr->mapObj->getStyle().getLayers();
 
-    QList<QString> layerIds;
+    QVector<QString> layerIds;
     layerIds.reserve(layers.size());
 
     for (const mbgl::style::Layer *layer : layers) {


### PR DESCRIPTION
For our use case QVector is more efficient and will
do less memory allocations.

Fixes: #13830