### PR TITLE
[core] Remove paintProperties() method from some render layers

### DIFF
--- a/src/mbgl/layout/pattern_layout.hpp
+++ b/src/mbgl/layout/pattern_layout.hpp
@@ -13,7 +13,7 @@ public:
     std::string max;
 };
 
-using PatternLayerMap = std::unordered_map<std::string, PatternDependency>;
+using PatternLayerMap = std::map<std::string, PatternDependency>;
 
 class PatternFeature  {
 public:
@@ -44,8 +44,7 @@ public:
         groupID = renderLayer->getID();
 
         for (const auto& layer : layers) {
-            const typename B::PossiblyEvaluatedPaintProperties evaluatedProps = static_cast<const PatternLayer*>(layer)->paintProperties();
-            layerPaintProperties.emplace(layer->getID(), std::move(evaluatedProps));
+            const typename B::PossiblyEvaluatedPaintProperties evaluatedProps = static_cast<const PatternLayer*>(layer)->evaluated;
             const auto patternProperty = evaluatedProps.template get<typename PatternLayer::PatternProperty>();
             const auto constantPattern = patternProperty.constantOr(Faded<std::basic_string<char> >{ "", ""});
             // determine if layer group has any layers that use *-pattern property and add
@@ -57,6 +56,7 @@ public:
                 patternDependencies.emplace(constantPattern.to, ImageType::Pattern);
                 patternDependencies.emplace(constantPattern.from, ImageType::Pattern);
             }
+            layerPaintProperties.emplace(layer->getID(), std::move(evaluatedProps));
         }
 
         const size_t featureCount = sourceLayer->featureCount();
@@ -65,7 +65,7 @@ public:
             if (!leader.filter(style::expression::EvaluationContext { this->zoom, feature.get() }))
                 continue;
 
-            std::unordered_map<std::string, PatternDependency> patternDependencyMap;
+            PatternLayerMap patternDependencyMap;
             if (hasPattern) {
                 for (const auto& layer : layers) {
                     const auto it = layerPaintProperties.find(layer->getID());

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -14,7 +14,7 @@ class Context;
 
 class RenderLayer;
 class PatternDependency;
-using PatternLayerMap = std::unordered_map<std::string, PatternDependency>;
+using PatternLayerMap = std::map<std::string, PatternDependency>;
 
 class Bucket {
 public:

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -218,18 +218,6 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters, RenderSource*
             getID());
     }
 }
-style::FillExtrusionPaintProperties::PossiblyEvaluated RenderFillExtrusionLayer::paintProperties() const {
-    return FillExtrusionPaintProperties::PossiblyEvaluated {
-        evaluated.get<style::FillExtrusionOpacity>(),
-        evaluated.get<style::FillExtrusionColor>(),
-        evaluated.get<style::FillExtrusionTranslate>(),
-        evaluated.get<style::FillExtrusionTranslateAnchor>(),
-        evaluated.get<style::FillExtrusionPattern>(),
-        evaluated.get<style::FillExtrusionHeight>(),
-        evaluated.get<style::FillExtrusionBase>(),
-        evaluated.get<style::FillExtrusionVerticalGradient>()
-    };
-}
 
 bool RenderFillExtrusionLayer::queryIntersectsFeature(
         const GeometryCoordinates& queryGeometry,

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.hpp
@@ -26,7 +26,6 @@ public:
     bool hasTransition() const override;
     bool hasCrossfade() const override;
     void render(PaintParameters&, RenderSource*) override;
-    style::FillExtrusionPaintProperties::PossiblyEvaluated paintProperties() const;
 
     bool queryIntersectsFeature(
         const GeometryCoordinates&,

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -236,18 +236,6 @@ void RenderFillLayer::render(PaintParameters& parameters, RenderSource*) {
     }
 }
 
-style::FillPaintProperties::PossiblyEvaluated RenderFillLayer::paintProperties() const {
-    return FillPaintProperties::PossiblyEvaluated {
-        evaluated.get<style::FillAntialias>(),
-        evaluated.get<style::FillOpacity>(),
-        evaluated.get<style::FillColor>(),
-        evaluated.get<style::FillOutlineColor>(),
-        evaluated.get<style::FillTranslate>(),
-        evaluated.get<style::FillTranslateAnchor>(),
-        evaluated.get<style::FillPattern>()
-    };
-}
-
 bool RenderFillLayer::queryIntersectsFeature(
         const GeometryCoordinates& queryGeometry,
         const GeometryTileFeature& feature,

--- a/src/mbgl/renderer/layers/render_fill_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.hpp
@@ -22,7 +22,6 @@ public:
     bool hasTransition() const override;
     bool hasCrossfade() const override;
     void render(PaintParameters&, RenderSource*) override;
-    style::FillPaintProperties::PossiblyEvaluated paintProperties() const;
 
     bool queryIntersectsFeature(
             const GeometryCoordinates&,

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -264,24 +264,6 @@ void RenderLineLayer::updateColorRamp() {
     }
 }
 
-RenderLinePaintProperties::PossiblyEvaluated RenderLineLayer::paintProperties() const {
-    return RenderLinePaintProperties::PossiblyEvaluated {
-        evaluated.get<style::LineOpacity>(),
-        evaluated.get<style::LineColor>(),
-        evaluated.get<style::LineTranslate>(),
-        evaluated.get<style::LineTranslateAnchor>(),
-        evaluated.get<style::LineWidth>(),
-        evaluated.get<style::LineGapWidth>(),
-        evaluated.get<style::LineOffset>(),
-        evaluated.get<style::LineBlur>(),
-        evaluated.get<style::LineDasharray>(),
-        evaluated.get<style::LinePattern>(),
-        evaluated.get<style::LineGradient>(),
-        evaluated.get<LineFloorwidth>()
-
-    };
-}
-
 float RenderLineLayer::getLineWidth(const GeometryTileFeature& feature, const float zoom) const {
     float lineWidth = evaluated.get<style::LineWidth>()
             .evaluate(feature, zoom, style::LineWidth::defaultValue());
@@ -293,7 +275,6 @@ float RenderLineLayer::getLineWidth(const GeometryTileFeature& feature, const fl
         return lineWidth;
     }
 }
-
 
 void RenderLineLayer::update() {
     updateColorRamp();

--- a/src/mbgl/renderer/layers/render_line_layer.hpp
+++ b/src/mbgl/renderer/layers/render_line_layer.hpp
@@ -17,8 +17,6 @@ class RenderLinePaintProperties : public style::ConcatenateProperties<
     style::LinePaintProperties,
     style::Properties<LineFloorwidth>> {};
 
-class LineBucket;
-
 class RenderLineLayer: public RenderLayer {
 public:
     using StyleLayerImpl = style::LineLayer::Impl;
@@ -33,8 +31,6 @@ public:
     bool hasCrossfade() const override;
     void render(PaintParameters&, RenderSource*) override;
     void update() final;
-
-    RenderLinePaintProperties::PossiblyEvaluated paintProperties() const;
 
     bool queryIntersectsFeature(
             const GeometryCoordinates&,


### PR DESCRIPTION
PatternLayout can directly access layer's `evaluated` field.