### PR TITLE
[core] change loop variable type to auto

### DIFF
--- a/src/mbgl/style/expression/match.cpp
+++ b/src/mbgl/style/expression/match.cpp
@@ -11,7 +11,7 @@ namespace expression {
 template <typename T>
 void Match<T>::eachChild(const std::function<void(const Expression&)>& visit) const {
     visit(*input);
-    for (const std::pair<T, std::shared_ptr<Expression>>& branch : branches) {
+    for (const auto& branch : branches) {
         visit(*branch.second);
     }
     visit(*otherwise);


### PR DESCRIPTION
We used `const std::pair<T, std::shared_ptr<Expression>>`, but the actual type is `const std::pair<const T, std::shared_ptr<Expression>>` which resulted in an implicit copy