### PR TITLE
Fetch tags during nitpick, bump gestures library to v0.4.0

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -6,10 +6,7 @@ dependencies {
     lintChecks project(":MapboxGLAndroidSDKLint")
     api dependenciesList.mapboxAndroidTelemetry
     api dependenciesList.mapboxJavaGeoJSON
-    api (dependenciesList.mapboxAndroidGestures) {
-        // workaround until https://github.com/mapbox/mapbox-gestures-android/issues/50 is released
-        exclude group: 'com.jakewharton.timber', module: 'timber'
-    }
+    api dependenciesList.mapboxAndroidGestures
     implementation dependenciesList.mapboxJavaTurf
     implementation dependenciesList.supportAppcompatV7
     implementation dependenciesList.supportAnnotations

--- a/platform/android/gradle/android-nitpick.gradle
+++ b/platform/android/gradle/android-nitpick.gradle
@@ -25,6 +25,11 @@ task androidNitpick {
 }
 
 private def verifyVendorSubmodulePin(def dir, def prefix, def version) {
+    exec {
+        workingDir = "${rootDir}/vendor/${dir}"
+        commandLine "git", "fetch", "-t"
+    }
+
     def output = new ByteArrayOutputStream()
     exec {
         workingDir = "${rootDir}/vendor/${dir}"

--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
     versions = [
             mapboxServices  : '4.3.0',
             mapboxTelemetry : '4.2.0',
-            mapboxGestures  : '0.3.0',
+            mapboxGestures  : '0.4.0',
             supportLib      : '27.1.1',
             constraintLayout: '1.1.2',
             espresso        : '3.0.2',


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gestures-android/issues/59.
Closes https://github.com/mapbox/mapbox-gl-native/issues/13844.

This PR also adds an explicit fetch for release tags of vendor repositories.