### PR TITLE
Backport #13853 to java

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -4,6 +4,10 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 
 ## master
 
+## 7.1.1 - February 1, 2019
+### Bugs
+ - Fix a crash caused by the missing `Timber` dependency [#13847](https://github.com/mapbox/mapbox-gl-native/pull/13847)
+
 ## 7.1.0 - January 30, 2019
 ### Build
  - Revert Android vendorization, add submodule pinning [#13815](https://github.com/mapbox/mapbox-gl-native/pull/13815)


### PR DESCRIPTION
Backports https://github.com/mapbox/mapbox-gl-native/pull/13853 to `release-java`.