### PR TITLE
Fix deadlock in http request on hitting tile limit

### DIFF
--- a/platform/android/src/async_task.cpp
+++ b/platform/android/src/async_task.cpp
@@ -13,7 +13,6 @@ class AsyncTask::Impl : public RunLoop::Impl::Runnable {
 public:
     Impl(std::function<void()>&& fn)
         : queued(true), task(std::move(fn)) {
-        loop->initRunnable(this);
     }
 
     ~Impl() {

--- a/platform/android/src/run_loop_impl.hpp
+++ b/platform/android/src/run_loop_impl.hpp
@@ -26,8 +26,6 @@ public:
 
         virtual void runTask() = 0;
         virtual TimePoint dueTime() const = 0;
-
-        std::list<Runnable*>::iterator iter;
     };
 
     Impl(RunLoop*, RunLoop::Type);
@@ -37,7 +35,6 @@ public:
 
     void addRunnable(Runnable*);
     void removeRunnable(Runnable*);
-    void initRunnable(Runnable*);
 
     Milliseconds processRunnables();
 
@@ -55,9 +52,8 @@ private:
 
     std::unique_ptr<Thread<Alarm>> alarm;
 
-    std::recursive_mutex mtx;
+    std::mutex mutex;
     std::list<Runnable*> runnables;
-    std::list<Runnable*>::iterator nextRunnable = runnables.end();
 };
 
 } // namespace util

--- a/platform/android/src/timer.cpp
+++ b/platform/android/src/timer.cpp
@@ -10,21 +10,20 @@ namespace util {
 
 class Timer::Impl : public RunLoop::Impl::Runnable {
 public:
-    Impl() {
-        loop->initRunnable(this);
-    }
+    Impl() = default;
 
     ~Impl() {
         stop();
     }
 
-    void start(Duration timeout, Duration repeat_, std::function<void ()>&& task_) {
+    void start(Duration timeout, Duration repeat_, std::function<void()>&& task_) {
         stop();
 
         repeat = repeat_;
         task = std::move(task_);
         // Prevent overflows when timeout is set to Duration::max()
-        due = (timeout == Duration::max()) ? std::chrono::time_point<Clock>::max() : Clock::now() + timeout;
+        due = (timeout == Duration::max()) ? std::chrono::time_point<Clock>::max() : Clock::now() +
+                                                                                     timeout;
         loop->addRunnable(this);
     }
 
@@ -59,8 +58,7 @@ private:
     std::function<void()> task;
 };
 
-Timer::Timer()
-    : impl(std::make_unique<Impl>()) {
+Timer::Timer() : impl(std::make_unique<Impl>()) {
 }
 
 Timer::~Timer() = default;


### PR DESCRIPTION
Fixes #13669

When hitting the tile limit for offline downloads the filesource thread deadlocks. The callback of the http requests triggers the clearing of all outstanding http request (including the one hitting the limit) and then a lock is requested for a second time in the cancel method called from the http request destructor.

In this case, cancel should not request a lock again, but just set the native pointer to 0. 