### PR TITLE
[core] Reduce presence of the 'useIntegerZoom' option

### DIFF
--- a/src/mbgl/renderer/data_driven_property_evaluator.hpp
+++ b/src/mbgl/renderer/data_driven_property_evaluator.hpp
@@ -7,7 +7,7 @@
 
 namespace mbgl {
 
-template <typename T>
+template <typename T, bool useIntegerZoom = false>
 class DataDrivenPropertyEvaluator {
 public:
     using ResultType = PossiblyEvaluatedPropertyValue<T>;
@@ -25,14 +25,18 @@ public:
     }
 
     ResultType operator()(const style::PropertyExpression<T>& expression) const {
-        if (!expression.isFeatureConstant()) {
-            auto returnExpression = expression;
-            returnExpression.useIntegerZoom = parameters.useIntegerZoom;
-            return ResultType(returnExpression);
-        } else if (!parameters.useIntegerZoom) {
-            return ResultType(expression.evaluate(parameters.z));
-        } else {
+        if (useIntegerZoom) {  // Compiler will optimize out the unused branch.
+            if (!expression.isFeatureConstant()) {
+                auto returnExpression = expression;
+                returnExpression.useIntegerZoom = true;
+                return ResultType(returnExpression);
+            } 
             return ResultType(expression.evaluate(floor(parameters.z)));
+        } else {
+            if (!expression.isFeatureConstant()) {
+                return ResultType(expression);
+            }
+            return ResultType(expression.evaluate(parameters.z));
         }
     }
 

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -47,12 +47,8 @@ void RenderLineLayer::transition(const TransitionParameters& parameters) {
 
 void RenderLineLayer::evaluate(const PropertyEvaluationParameters& parameters) {
     style::Properties<LineFloorwidth>::Unevaluated extra(unevaluated.get<style::LineWidth>());
-
-    auto dashArrayParams = parameters;
-    dashArrayParams.useIntegerZoom = true;
-
     evaluated = RenderLinePaintProperties::PossiblyEvaluated(
-    unevaluated.evaluate(parameters).concat(extra.evaluate(dashArrayParams)));
+        unevaluated.evaluate(parameters).concat(extra.evaluate(parameters)));
 
     crossfade = parameters.getCrossfadeParameters();
 

--- a/src/mbgl/renderer/layers/render_line_layer.hpp
+++ b/src/mbgl/renderer/layers/render_line_layer.hpp
@@ -10,7 +10,8 @@
 namespace mbgl {
 
 struct LineFloorwidth : style::DataDrivenPaintProperty<float, attributes::a_floorwidth, uniforms::u_floorwidth> {
-    static float defaultValue() { return 1; }
+    using EvaluatorType = DataDrivenPropertyEvaluator<float, true>;
+    static float defaultValue() { return 1.0; }
 };
 
 class RenderLinePaintProperties : public style::ConcatenateProperties<

--- a/src/mbgl/renderer/possibly_evaluated_property_value.hpp
+++ b/src/mbgl/renderer/possibly_evaluated_property_value.hpp
@@ -18,9 +18,8 @@ private:
 
 public:
     PossiblyEvaluatedPropertyValue() = default;
-    PossiblyEvaluatedPropertyValue(Value v, bool useIntegerZoom_ = false)
-        : value(std::move(v)),
-          useIntegerZoom(useIntegerZoom_) {}
+    PossiblyEvaluatedPropertyValue(Value v)
+        : value(std::move(v)) {}
 
     bool isConstant() const {
         return value.template is<T>();
@@ -46,16 +45,10 @@ public:
         return this->match(
             [&] (const T& constant_) { return constant_; },
             [&] (const style::PropertyExpression<T>& expression) {
-                if (useIntegerZoom) {
-                    return expression.evaluate(floor(zoom), feature, defaultValue);
-                } else {
-                    return expression.evaluate(zoom, feature, defaultValue);
-                }
+                return expression.evaluate(zoom, feature, defaultValue);
             }
         );
     }
-
-    bool useIntegerZoom;
 };
 
 template <class T>
@@ -69,9 +62,8 @@ private:
 
 public:
     PossiblyEvaluatedPropertyValue() = default;
-    PossiblyEvaluatedPropertyValue(Value v, bool useIntegerZoom_ = false)
-        : value(std::move(v)),
-          useIntegerZoom(useIntegerZoom_) {}
+    PossiblyEvaluatedPropertyValue(Value v)
+        : value(std::move(v)) {}
 
     bool isConstant() const {
         return value.template is<Faded<T>>();
@@ -108,8 +100,6 @@ public:
             }
         );
     }
-
-    bool useIntegerZoom;
 };
 
 

--- a/src/mbgl/renderer/property_evaluation_parameters.hpp
+++ b/src/mbgl/renderer/property_evaluation_parameters.hpp
@@ -18,18 +18,15 @@ public:
         : z(z_),
           now(Clock::time_point::max()),
           zoomHistory(),
-          defaultFadeDuration(0),
-          useIntegerZoom(false) {}
+          defaultFadeDuration(0) {}
 
     PropertyEvaluationParameters(ZoomHistory zoomHistory_,
                           TimePoint now_,
-                          Duration defaultFadeDuration_,
-                          bool useIntegerZoom_ = false)
+                          Duration defaultFadeDuration_)
         : z(zoomHistory_.lastZoom),
           now(std::move(now_)),
           zoomHistory(std::move(zoomHistory_)),
-          defaultFadeDuration(std::move(defaultFadeDuration_)),
-          useIntegerZoom(useIntegerZoom_) {}
+          defaultFadeDuration(std::move(defaultFadeDuration_)) {}
 
     CrossfadeParameters getCrossfadeParameters() const {
         const float fraction = z - std::floor(z);
@@ -47,7 +44,6 @@ public:
     TimePoint now;
     ZoomHistory zoomHistory;
     Duration defaultFadeDuration;
-    bool useIntegerZoom;
 };
 
 } // namespace mbgl


### PR DESCRIPTION
The `useIntegerZoom` presence is now limited: it is removed
from `PossiblyEvaluatedPropertyValue` class specializations
(was never used there!) and from the `PropertyEvaluationParameters`
class, so we do not have to copy `PropertyEvaluationParameters`
instance at `RenderLineLayer::evaluate`.