### PR TITLE
WIP: bounds across the antimeridian

### DIFF
--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -59,9 +59,9 @@ public:
 
     // If the distance from start to end longitudes is between half and full
     // world, unwrap the start longitude to ensure the shortest path is taken.
-    void unwrapForShortestPath(const LatLng& end) {
+    void unwrapForShortestPath(const LatLng& end, bool limitMaxDegrees = true) {
         const double delta = std::abs(end.lon - lon);
-        if (delta <= util::LONGITUDE_MAX) return;
+        if (delta <= util::LONGITUDE_MAX || (limitMaxDegrees && delta >= util::DEGREES_MAX)) return;
         if (lon > 0 && end.lon < 0) lon -= util::DEGREES_MAX;
         else if (lon < 0 && end.lon > 0) lon += util::DEGREES_MAX;
     }
@@ -133,7 +133,7 @@ public:
         }
         LatLng latLng = p;
         if (crossesAntimeridian()) {
-            latLng.unwrapForShortestPath(ne);
+            latLng.unwrapForShortestPath(ne, false);
         }
         return LatLng {
                 util::clamp(latLng.latitude(), sw.latitude(), ne.latitude()),

--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -61,7 +61,7 @@ public:
     // world, unwrap the start longitude to ensure the shortest path is taken.
     void unwrapForShortestPath(const LatLng& end) {
         const double delta = std::abs(end.lon - lon);
-        if (delta <= util::LONGITUDE_MAX || delta >= util::DEGREES_MAX) return;
+        if (delta <= util::LONGITUDE_MAX) return;
         if (lon > 0 && end.lon < 0) lon -= util::DEGREES_MAX;
         else if (lon < 0 && end.lon > 0) lon += util::DEGREES_MAX;
     }
@@ -128,12 +128,16 @@ public:
     }
 
     LatLng constrain(const LatLng& p) const {
-        if (contains(p)) {
+        if (contains(p, LatLng::WrapMode::Wrapped)) {
             return p;
         }
+        LatLng latLng = p;
+        if (crossesAntimeridian()) {
+            latLng.unwrapForShortestPath(ne);
+        }
         return LatLng {
-            util::clamp(p.latitude(), sw.latitude(), ne.latitude()),
-            util::clamp(p.longitude(), sw.longitude(), ne.longitude())
+                util::clamp(latLng.latitude(), sw.latitude(), ne.latitude()),
+                util::clamp(latLng.longitude(), sw.longitude(), ne.longitude())
         };
     }
 


### PR DESCRIPTION
This PR is more a question/discussion than an actual fix, it attempts to fix the issue from https://github.com/mapbox/mapbox-gl-native/issues/13672:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/2151639/50696314-65e4fa80-103f-11e9-8d5e-186b272d7a33.gif)

This issue is that I'm unable to define a crossing antimerdian bounds that plays well with `Transform::setLatLngBounds`. After briefly looking into the possibilities, I believe that creating such 
 bounds, with constructor `Bounds(sw, ne)`, can in theory be done with:
 - `Bounds(LatLng(-20;-170), LatLng(20;170))`  // by switching the sw/ne order
 - `Bounds(LatLng(-20;170), LatLng(20;190))`  // going over max longitude = crosses IDL

The former approach is taken with gl-js as shown [here](https://github.com/mapbox/mapbox-gl-js/pull/2414) but not possible on gl-native as this generates an invalid bounds by definition [here](https://github.com/mapbox/mapbox-gl-native/blob/master/include/mbgl/util/geo.hpp#L111-L113) (though this could be changed?). 

For now, this has led me down the road to try optimizing for the latter case in this PR.

----------------------------------------------------------------------------

Current state of this PR works well for my specific setup:

![ezgif com-video-to-gif 49](https://user-images.githubusercontent.com/2151639/52219240-84d3e800-289c-11e9-9990-63bb3cb398ad.gif)

But I'm very sure that [this line](https://github.com/mapbox/mapbox-gl-native/compare/tvn-bounds-across-idl?expand=1#diff-cf54d0ce1dec44ab05dcd5daf776c7f8R64) will impact other parts of the code and thus not a correct change.

Would someone be able to :eyes: this and provide some feedback/context?

cc @ansis @ryanhamley @brunoabinader @tmpsantos 





 






