### PR TITLE
[ios, build] Make jazzy sqlite3 installation version agnostic

### DIFF
--- a/platform/ios/scripts/install-packaging-dependencies.sh
+++ b/platform/ios/scripts/install-packaging-dependencies.sh
@@ -16,8 +16,7 @@ if [ -z `which jazzy` ]; then
 
     CIRCLECI=${CIRCLECI:-false}
     if [[ "${CIRCLECI}" == true ]]; then
-        sudo gem install sqlite3 -v 1.3.13 -- --with-sqlite3-lib=/usr/lib
-        sudo gem install jazzy -v $JAZZY_VERSION --no-document
+        sudo gem install jazzy -v $JAZZY_VERSION --no-document -- --with-sqlite3-lib=/usr/lib
     else
         gem install jazzy -v $JAZZY_VERSION --no-document
     fi


### PR DESCRIPTION
Makes #13874 a bit more resilient by avoiding us having to care about specific sqlite3 gem versions. This has the effect of passing the flag to every gem installed for jazzy, but that _should_ be innocuous.

Follow-up to #13819.

/cc @julianrex 