### PR TITLE
Cast round json element properties to int64_t instead of the uint64_t

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/geometry/GeoJsonConversionTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/geometry/GeoJsonConversionTest.java
@@ -1,13 +1,21 @@
 package com.mapbox.mapboxsdk.testapp.geometry;
 
+import com.google.gson.JsonArray;
+import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.Polygon;
+import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
+import com.mapbox.mapboxsdk.style.expressions.Expression;
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.mapboxsdk.style.sources.CustomGeometrySource;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.style.sources.GeometryTileProvider;
 import com.mapbox.mapboxsdk.testapp.activity.EspressoTest;
+import com.mapbox.mapboxsdk.testapp.utils.Utils;
+
 import org.junit.Test;
 
 import static com.mapbox.geojson.Feature.fromGeometry;
@@ -18,6 +26,7 @@ import static com.mapbox.geojson.MultiLineString.fromLineString;
 import static com.mapbox.geojson.MultiPolygon.fromPolygon;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Instrumentation test to validate java geojson conversion to c++
@@ -44,7 +53,7 @@ public class GeoJsonConversionTest extends EspressoTest {
     onMapView().perform(getMapboxMapAction((uiController, mapboxMap) -> {
       mapboxMap.getStyle().addSource(
         new CustomGeometrySource("test-id",
-          new CustomProvider(fromFeatures(singletonList(fromGeometry(Point.fromLngLat(0.0,0.0)))))
+          new CustomProvider(fromFeatures(singletonList(fromGeometry(Point.fromLngLat(0.0, 0.0)))))
         )
       );
       mapboxMap.getStyle().addLayer(new SymbolLayer("test-id", "test-id"));
@@ -114,6 +123,34 @@ public class GeoJsonConversionTest extends EspressoTest {
         )
       );
       mapboxMap.getStyle().addLayer(new SymbolLayer("test-id", "test-id"));
+    }));
+  }
+
+  @Test
+  public void testNegativeNumberPropertyConversion() {
+    validateTestSetup();
+    onMapView().perform(getMapboxMapAction((uiController, mapboxMap) -> {
+      LatLng latLng = new LatLng();
+      Feature feature = Feature.fromGeometry(Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()));
+
+      JsonArray foregroundJsonArray = new JsonArray();
+      foregroundJsonArray.add(0f);
+      foregroundJsonArray.add(-3f);
+      feature.addProperty("property", foregroundJsonArray);
+
+      GeoJsonSource source = new GeoJsonSource("source", feature);
+      mapboxMap.getStyle().addSource(source);
+
+      SymbolLayer layer = new SymbolLayer("layer", "source")
+        .withProperties(
+          PropertyFactory.iconOffset(Expression.get("property")),
+          PropertyFactory.iconImage("zoo-15")
+        );
+      mapboxMap.getStyle().addLayer(layer);
+
+      Utils.waitForLayer(uiController, mapboxMap, latLng, "layer");
+
+      assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng)).isEmpty());
     }));
   }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/ExpressionTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/ExpressionTest.java
@@ -1,13 +1,11 @@
 package com.mapbox.mapboxsdk.testapp.style;
 
 import android.graphics.Color;
-import android.support.test.espresso.UiController;
 import android.support.test.runner.AndroidJUnit4;
 
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.CircleLayer;
 import com.mapbox.mapboxsdk.style.layers.FillLayer;
@@ -55,6 +53,7 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillColor;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillOutlineColor;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textField;
 import static com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke;
+import static com.mapbox.mapboxsdk.testapp.utils.Utils.waitForLayer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -291,7 +290,7 @@ public class ExpressionTest extends EspressoTest {
         formatEntry("test")
       );
       layer.setProperties(textField(expression));
-      waitForLayer(uiController, mapboxMap, latLng);
+      waitForLayer(uiController, mapboxMap, latLng, "layer");
       assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")
         .isEmpty());
 
@@ -314,7 +313,7 @@ public class ExpressionTest extends EspressoTest {
         formatEntry("test", formatFontScale(1.75))
       );
       layer.setProperties(textField(expression));
-      waitForLayer(uiController, mapboxMap, latLng);
+      waitForLayer(uiController, mapboxMap, latLng, "layer");
       assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")
         .isEmpty());
 
@@ -340,7 +339,7 @@ public class ExpressionTest extends EspressoTest {
         )
       );
       layer.setProperties(textField(expression));
-      waitForLayer(uiController, mapboxMap, latLng);
+      waitForLayer(uiController, mapboxMap, latLng, "layer");
       assertFalse(
         mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer").isEmpty()
       );
@@ -371,7 +370,7 @@ public class ExpressionTest extends EspressoTest {
         )
       );
       layer.setProperties(textField(expression));
-      waitForLayer(uiController, mapboxMap, latLng);
+      waitForLayer(uiController, mapboxMap, latLng, "layer");
       assertFalse(
         mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer").isEmpty()
       );
@@ -404,7 +403,7 @@ public class ExpressionTest extends EspressoTest {
         formatEntry("\ntest2", formatFontScale(2))
       );
       layer.setProperties(textField(expression));
-      waitForLayer(uiController, mapboxMap, latLng);
+      waitForLayer(uiController, mapboxMap, latLng, "layer");
       assertFalse(
         mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer").isEmpty()
       );
@@ -438,7 +437,7 @@ public class ExpressionTest extends EspressoTest {
         )
       );
       layer.setProperties(textField(expression));
-      waitForLayer(uiController, mapboxMap, latLng);
+      waitForLayer(uiController, mapboxMap, latLng, "layer");
       assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")
         .isEmpty());
 
@@ -468,7 +467,7 @@ public class ExpressionTest extends EspressoTest {
         formatEntry("\ntest2", formatFontScale(2))
       );
       layer.setProperties(textField(expression));
-      waitForLayer(uiController, mapboxMap, latLng);
+      waitForLayer(uiController, mapboxMap, latLng, "layer");
       assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")
         .isEmpty());
 
@@ -488,7 +487,7 @@ public class ExpressionTest extends EspressoTest {
       mapboxMap.getStyle().addLayer(layer);
 
       layer.setProperties(textField("test"));
-      waitForLayer(uiController, mapboxMap, latLng);
+      waitForLayer(uiController, mapboxMap, latLng, "layer");
       assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")
         .isEmpty());
 
@@ -513,25 +512,13 @@ public class ExpressionTest extends EspressoTest {
         new FormattedSection("\ntest", 0.5, new String[] {"Arial Unicode MS Regular", "DIN Offc Pro Regular"})
       );
       layer.setProperties(textField(formatted));
-      waitForLayer(uiController, mapboxMap, latLng);
+      waitForLayer(uiController, mapboxMap, latLng, "layer");
       assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")
         .isEmpty());
 
       assertNull(layer.getTextField().getExpression());
       assertEquals(formatted, layer.getTextField().getValue());
     });
-  }
-
-  private static final long WAIT_TIMEOUT = 5000;
-  private static final long WAIT_DELAY = 150;
-
-  private static void waitForLayer(UiController uiController, MapboxMap mapboxMap, LatLng latLng) {
-    int i = 0;
-    while (mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer").isEmpty()) {
-      i++;
-      assertFalse("Waiting for layer timed out", i * WAIT_DELAY > WAIT_TIMEOUT);
-      uiController.loopMainThreadForAtLeast(WAIT_DELAY);
-    }
   }
 
   private void setupStyle() {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/utils/Utils.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/utils/Utils.java
@@ -1,0 +1,23 @@
+package com.mapbox.mapboxsdk.testapp.utils;
+
+import android.support.test.espresso.UiController;
+
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+
+import static org.junit.Assert.assertFalse;
+
+public class Utils {
+
+  private static final long WAIT_TIMEOUT = 5000;
+  private static final long WAIT_DELAY = 150;
+
+  public static void waitForLayer(UiController uiController, MapboxMap mapboxMap, LatLng latLng, String... layerIds) {
+    int i = 0;
+    while (mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), layerIds).isEmpty()) {
+      i++;
+      assertFalse("Waiting for layer timed out", i * WAIT_DELAY > WAIT_TIMEOUT);
+      uiController.loopMainThreadForAtLeast(WAIT_DELAY);
+    }
+  }
+}

--- a/platform/android/src/gson/json_element.cpp
+++ b/platform/android/src/gson/json_element.cpp
@@ -68,8 +68,8 @@ mbgl::Value JsonElement::convert(jni::JNIEnv &env, const jni::Object<JsonElement
         } else if (primitive.Call(env, isNumber)) {
             auto value = primitive.Call(env, getAsDouble);
             if (value == math::Math::rint(env, value)) {
-                // uint64_t
-                return static_cast<uint64_t>(primitive.Call(env, getAsInteger));
+                // int64_t
+                return static_cast<int64_t>(primitive.Call(env, getAsInteger));
             } else {
                 // double
                 return value;

--- a/src/mbgl/renderer/sources/render_geojson_source.cpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.cpp
@@ -166,7 +166,7 @@ RenderGeoJSONSource::queryFeatureExtensions(const Feature& feature,
         return {};
     }
 
-    const auto clusterID = getProperty<uint64_t>(feature.properties, "cluster_id");
+    const auto clusterID = getProperty<int64_t>(feature.properties, "cluster_id");
     if (!clusterID) {
         return {};
     }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/13881.

I was only able to come up with an Android regression test of the exact issue from #13881. I still don't exactly understand the particular rendering problem, so I'd love some more clarity if anyone has ideas of what is going wrong here.