### PR TITLE
[ios, build] Changelog fixes for 4.9.0

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
-## master
+## 4.9.0
 
 * Fixed a bug where setting `MGLMapView.userTrackingMode` to `MGLUserTrackingModeFollowWithHeading` or `MGLUserTrackingModeFollowWithCourse` would be ignored if the user’s location was not already available. ([#13849](https://github.com/mapbox/mapbox-gl-native/pull/13849))
 
-## 4.8.0
+## 4.8.0 - January 30, 2019
 
 ### Styles and rendering
 

--- a/platform/ios/scripts/release-notes.js
+++ b/platform/ios/scripts/release-notes.js
@@ -6,7 +6,8 @@ const ejs = require('ejs');
 const _ = require('lodash');
 const semver = require('semver');
 
-const changelog = fs.readFileSync('platform/ios/CHANGELOG.md', 'utf8');
+const changelogPath = 'platform/ios/CHANGELOG.md';
+const changelog = fs.readFileSync(changelogPath, 'utf8');
 
 let outputMode = {};
 switch(process.argv[2]) {
@@ -60,6 +61,11 @@ while (match = regex.exec(changelog)) {
 const versionsInReleaseNotes = _.map(releaseNotes, 'version');
 const bestReleaseNotesForCurrentVersion = semver.minSatisfying(versionsInReleaseNotes, ">=" + currentVersion);
 const currentReleaseNotes = _.find(releaseNotes, { version: bestReleaseNotesForCurrentVersion });
+
+if (!currentReleaseNotes) {
+    console.error('Could not find a release section satisfying %s in %s — did you forget to rename the "master" section to %s?', currentVersion, changelogPath, currentVersion.split("-")[0]);
+    process.exit(1);
+}
 
 /*
   Fill and print the release notes template.


### PR DESCRIPTION
Improves the error case when you forget to change the changelog `master` section to reflect the version you’re trying to release, as I did in #13884. Now, you’ll get a recovery suggestion:

> Could not find a release section satisfying 4.9.0-alpha.1 in platform/ios/CHANGELOG.md — did you forget to rename the "master" section to 4.9.0?

Also, updates the changelog so we can release `ios-v4.9.0-alpha.1`. 😅

/cc @fabian-guerra 