### PR TITLE
Check supported interface orientations into account when rotating device/view layout

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Fixed a bug where setting `MGLMapView.userTrackingMode` to `MGLUserTrackingModeFollowWithHeading` or `MGLUserTrackingModeFollowWithCourse` would be ignored if the user’s location was not already available. ([#13849](https://github.com/mapbox/mapbox-gl-native/pull/13849))
 * Improved tilt gesture performance. ([#13902](https://github.com/mapbox/mapbox-gl-native/pull/13902))
+* Fixed a bug where `layoutSubviews` was always called on device rotation, regardless of the application's or top-most view controller's supported orientations. ([#13900](https://github.com/mapbox/mapbox-gl-native/pull/13900))
 
 ## 4.8.0 - January 30, 2019
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -219,6 +219,9 @@ public:
 @property (nonatomic) UILongPressGestureRecognizer *quickZoom;
 @property (nonatomic) UIPanGestureRecognizer *twoFingerDrag;
 
+@property (nonatomic) UIInterfaceOrientation currentOrientation;
+@property (nonatomic, readonly) UIInterfaceOrientationMask applicationSupportedInterfaceOrientations;
+
 @property (nonatomic) MGLCameraChangeReason cameraChangeReasonBitmask;
 
 /// Mapping from reusable identifiers to annotation images.
@@ -609,9 +612,11 @@ public:
     // so causes a loop when asking for location permission. See: https://github.com/mapbox/mapbox-gl-native/issues/11225
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveMemoryWarning) name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
+
+    // Device orientation management
+    self.currentOrientation = UIInterfaceOrientationUnknown;
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(deviceOrientationDidChange:) name:UIDeviceOrientationDidChangeNotification object:nil];
     [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
-
 
     // set initial position
     //
@@ -1299,8 +1304,122 @@ public:
     [super didMoveToSuperview];
 }
 
+
+- (UIInterfaceOrientationMask)applicationSupportedInterfaceOrientations {
+    static UIInterfaceOrientationMask orientationMask = UIInterfaceOrientationMaskAll;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        
+        // "The system intersects the view controller's supported orientations with
+        // the app's supported orientations (as determined by the Info.plist file or
+        // the app delegate's application:supportedInterfaceOrientationsForWindow:
+        // method) and the device's supported orientations to determine whether to rotate.
+        
+        UIApplication *application = [UIApplication sharedApplication];
+        
+        if (self.window && [application.delegate respondsToSelector:@selector(application:supportedInterfaceOrientationsForWindow:)]) {
+            orientationMask = [application.delegate application:application supportedInterfaceOrientationsForWindow:self.window];
+            return;
+        }
+        
+        // No application delegate
+        
+        NSString *key;
+        
+        switch ([[UIDevice currentDevice] userInterfaceIdiom]) {
+            case UIUserInterfaceIdiomPhone:
+                key = @"UISupportedInterfaceOrientations~iphone";
+                break;
+                
+            case UIUserInterfaceIdiomPad:
+                key = @"UISupportedInterfaceOrientations~ipad";
+                break;
+                
+            default:
+                break;
+        }
+
+        NSArray *orientations;
+        
+        if (key)
+            orientations = [[NSBundle mainBundle] objectForInfoDictionaryKey:key];
+        
+        if (!orientations) {
+            orientations = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UISupportedInterfaceOrientations"];
+        }
+        
+        // Application's info plist provided supported orientations.
+        if (orientations.count > 0) {
+            orientationMask = 0;
+            
+            NSDictionary *lookup =
+            @{
+              @"UIInterfaceOrientationPortrait" : @(UIInterfaceOrientationMaskPortrait),
+              @"UIInterfaceOrientationPortraitUpsideDown" : @(UIInterfaceOrientationMaskPortraitUpsideDown),
+              @"UIInterfaceOrientationLandscapeLeft" : @(UIInterfaceOrientationMaskLandscapeLeft),
+              @"UIInterfaceOrientationLandscapeRight" : @(UIInterfaceOrientationMaskLandscapeRight)
+              };
+            
+            for (NSString *orientation in orientations) {
+                UIInterfaceOrientationMask mask = ((NSNumber*)lookup[orientation]).unsignedIntegerValue;
+                orientationMask |= mask;
+            }
+        }
+    });
+    
+    return orientationMask;
+}
+
 - (void)deviceOrientationDidChange:(__unused NSNotification *)notification
 {
+    UIDeviceOrientation deviceOrientation = [[UIDevice currentDevice] orientation];
+
+    // The docs for `UIViewController.supportedInterfaceOrientations` states:
+    //
+    //  When the user changes the device orientation, the system calls this method
+    //  on the root view controller or the topmost presented view controller that
+    //  fills the window. If the view controller supports the new orientation, the
+    //  window and view controller are rotated to the new orientation. This method
+    //  is only called if the view controller's shouldAutorotate method returns YES.
+    //
+    // We want to match similar behaviour. However, it may be preferable to look
+    // at the owning view controller (in cases where the map view may be covered
+    // by another view. TODO:
+    //
+    // ???
+    
+//  UIViewController *viewController = [self viewControllerForLayoutGuides];
+    UIViewController *viewController = [self.window.rootViewController mgl_topMostViewController];
+
+    if (![viewController shouldAutorotate]) {
+        return;
+    }
+
+    if ((self.currentOrientation == (UIInterfaceOrientation)deviceOrientation) &&
+        (self.currentOrientation != UIInterfaceOrientationUnknown)) {
+        return;
+    }
+
+    // "The system intersects the view controller's supported orientations with
+    // the app's supported orientations (as determined by the Info.plist file or
+    // the app delegate's application:supportedInterfaceOrientationsForWindow:
+    // method) and the device's supported orientations to determine whether to rotate.
+    
+    UIInterfaceOrientationMask supportedOrientations = viewController.supportedInterfaceOrientations;
+    supportedOrientations &= self.applicationSupportedInterfaceOrientations;
+    
+    // Interface orientations are defined by device orientations
+    UIInterfaceOrientationMask interfaceOrientation = 1 << deviceOrientation;
+    UIInterfaceOrientationMask validOrientation = interfaceOrientation & UIInterfaceOrientationMaskAll;
+    
+    if (!(validOrientation & supportedOrientations)) {
+        return;
+    }
+    
+    self.currentOrientation = (UIInterfaceOrientation)deviceOrientation;
+
+    // Q. Do we need to re-layout if we're just going from Portrait -> Portrait
+    // Upside Down (or from Left to Right)?
     [self setNeedsLayout];
 }
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1329,30 +1329,7 @@ public:
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         // No application delegate
-        
-        NSString *key;
-        
-        switch ([[UIDevice currentDevice] userInterfaceIdiom]) {
-            case UIUserInterfaceIdiomPhone:
-                key = @"UISupportedInterfaceOrientations~iphone";
-                break;
-                
-            case UIUserInterfaceIdiomPad:
-                key = @"UISupportedInterfaceOrientations~ipad";
-                break;
-                
-            default:
-                break;
-        }
-        
-        NSArray *orientations;
-        
-        if (key)
-            orientations = [[NSBundle mainBundle] objectForInfoDictionaryKey:key];
-        
-        if (!orientations) {
-            orientations = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UISupportedInterfaceOrientations"];
-        }
+        NSArray *orientations = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UISupportedInterfaceOrientations"];
         
         // Application's info plist provided supported orientations.
         if (orientations.count > 0) {

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1369,7 +1369,6 @@ public:
     // at the owning view controller (in cases where the map view may be covered
     // by another view.
     
-//  UIViewController *viewController = [self viewControllerForLayoutGuides];
     UIViewController *viewController = [self.window.rootViewController mgl_topMostViewController];
     
     if (![viewController shouldAutorotate]) {


### PR DESCRIPTION
See https://github.com/mapbox/mapbox-gl-native/issues/13895

Since we don't provide a view controller or hooks for `-[UIViewController viewWillTransitionToSize:withTransitionCoordinator:]` we call ` [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications]` to detect device rotation.

However, we do not currently take into account the application's (and view controller's) supported interface orientations. And as such, `layoutSubviews` is called on each device rotation (even if the UI doesn't change).

This ~experimental~ branch/PR adds those checks:

From the Apple documentation for `UIViewController.supportedInterfaceOrientations`:

> When the user changes the device orientation, the system calls this method on the root view controller or the topmost presented view controller that fills the window. If the view controller supports the new orientation, the window and view controller are rotated to the new orientation. This method is only called if the view controller's shouldAutorotate method returns YES.

This PR checks the top-most view controller's `shouldAutorotate`...

> Override this method to report all of the orientations that the view controller supports. [...] The system intersects the view controller's supported orientations with the app's supported orientations (as determined by the Info.plist file or the app delegate's `application:supportedInterfaceOrientationsForWindow:` method) and the device's supported orientations to determine whether to rotate.

... and also checks that view controller's `supportedInterfaceOrientations` intersected with the orientations provided by the application (as noted above).

Note: this PR checks the top-most view controller rather than the view controller that hosts the map view.
