### PR TITLE
Change easeTo wrapping logic for constrained bounds

### DIFF
--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -83,7 +83,7 @@ void Transform::jumpTo(const CameraOptions& camera) {
  */
 void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& animation) {
     const LatLng unwrappedLatLng = camera.center.value_or(getLatLng());
-    const LatLng latLng = unwrappedLatLng.wrapped();
+    const LatLng latLng = state.bounds ? unwrappedLatLng : unwrappedLatLng.wrapped();
     double zoom = camera.zoom.value_or(getZoom());
     double angle = camera.angle ? -*camera.angle * util::DEG2RAD : getAngle();
     double pitch = camera.pitch ? *camera.pitch * util::DEG2RAD : getPitch();


### PR DESCRIPTION
Closes #13672, follow up from https://github.com/mapbox/mapbox-gl-native/pull/13871. Discussed with @brunoabinader and agreed that this was the correct fix moving forward. We noticed that the easeTo values where wrapped but when you set a bounds that shouldn't be the case.