### PR TITLE
[android] Adding new variation of LocationComponent#activateLocationComponent

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
@@ -189,7 +189,7 @@ public final class LocationComponent {
 
   @VisibleForTesting
   LocationComponent(@NonNull MapboxMap mapboxMap,
-                    @NonNull LocationEngineCallback<LocationEngineResult> currentlistener,
+                    @NonNull LocationEngineCallback<LocationEngineResult> currentListener,
                     @NonNull LocationEngineCallback<LocationEngineResult> lastListener,
                     @NonNull LocationLayerController locationLayerController,
                     @NonNull LocationCameraController locationCameraController,
@@ -198,7 +198,7 @@ public final class LocationComponent {
                     @NonNull CompassEngine compassEngine,
                     @NonNull InternalLocationEngineProvider internalLocationEngineProvider) {
     this.mapboxMap = mapboxMap;
-    this.currentLocationEngineListener = currentlistener;
+    this.currentLocationEngineListener = currentListener;
     this.lastLocationEngineListener = lastListener;
     this.locationLayerController = locationLayerController;
     this.locationCameraController = locationCameraController;
@@ -251,6 +251,27 @@ public final class LocationComponent {
    * @param style                    the proxy object for current map style. More info at {@link Style}
    * @param useDefaultLocationEngine true if you want to initialize and use the built-in location engine or false if
    *                                 there should be no location engine initialized
+   * @param options                  the options for customizing the LocationComponent
+   */
+  @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
+  public void activateLocationComponent(@NonNull Context context, @NonNull Style style,
+                                        boolean useDefaultLocationEngine,
+                                        @NonNull LocationComponentOptions options) {
+    if (useDefaultLocationEngine) {
+      activateLocationComponent(context, style, options);
+    } else {
+      activateLocationComponent(context, style, null, options);
+    }
+  }
+
+  /**
+   * This method initializes the component and needs to be called before any other operations are performed.
+   * Afterwards, you can manage component's visibility by {@link #setLocationComponentEnabled(boolean)}.
+   *
+   * @param context                  the context
+   * @param style                    the proxy object for current map style. More info at {@link Style}
+   * @param useDefaultLocationEngine true if you want to initialize and use the built-in location engine or false if
+   *                                 there should be no location engine initialized
    * @param locationEngineRequest    the location request
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
@@ -274,7 +295,7 @@ public final class LocationComponent {
    * @param useDefaultLocationEngine true if you want to initialize and use the built-in location engine or false if
    *                                 there should be no location engine initialized
    * @param locationEngineRequest    the location request
-   * @param options                  the options
+   * @param options                  the options for customizing the LocationComponent
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
   public void activateLocationComponent(@NonNull Context context, @NonNull Style style,
@@ -313,7 +334,7 @@ public final class LocationComponent {
    *
    * @param context the context
    * @param style   the proxy object for current map style. More info at {@link Style}
-   * @param options the options
+   * @param options the options for customizing the LocationComponent
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
   public void activateLocationComponent(@NonNull Context context, @NonNull Style style,
@@ -391,7 +412,7 @@ public final class LocationComponent {
    *
    * @param locationEngine the engine, or null if you'd like to only force location updates
    * @param style          the proxy object for current map style. More info at {@link Style}
-   * @param options        the options
+   * @param options        the options for customizing the LocationComponent
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
   public void activateLocationComponent(@NonNull Context context, @NonNull Style style,
@@ -410,7 +431,7 @@ public final class LocationComponent {
    * @param style                 the proxy object for current map style. More info at {@link Style}
    * @param locationEngine        the engine, or null if you'd like to only force location updates
    * @param locationEngineRequest the location request
-   * @param options               the options
+   * @param options               the options for customizing the LocationComponent
    */
   public void activateLocationComponent(@NonNull Context context, @NonNull Style style,
                                         @Nullable LocationEngine locationEngine,

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
@@ -105,10 +105,26 @@ class LocationComponentTest {
   }
 
   @Test
+  fun activateWithDefaultLocationEngineAndOptionsTestDefaultLocationEngine() {
+    locationComponent.activateLocationComponent(context, mockk(), true, locationComponentOptions)
+    Assert.assertNotNull(locationComponent.locationComponentOptions)
+    Assert.assertEquals(locationComponentOptions.foregroundName(), locationComponent.locationComponentOptions.foregroundName())
+    Assert.assertEquals(locationComponentOptions.accuracyColor(), locationComponent.locationComponentOptions.accuracyColor())
+  }
+
+  @Test
   fun activateWithDefaultLocationEngineRequestAndOptionsTestCustomLocationEngine() {
     locationComponent.activateLocationComponent(context, mockk(), false, locationEngineRequest, locationComponentOptions)
     Assert.assertEquals(locationEngineRequest, locationComponent.locationEngineRequest)
     Assert.assertNull(locationComponent.locationEngine)
+  }
+
+  @Test
+  fun activateWithDefaultLocationEngineAndOptionsTestCustomLocationEngine() {
+    locationComponent.activateLocationComponent(context, mockk(), false, locationComponentOptions)
+    Assert.assertNotNull(locationComponent.locationComponentOptions)
+    Assert.assertEquals(locationComponentOptions.foregroundName(), locationComponent.locationComponentOptions.foregroundName())
+    Assert.assertEquals(locationComponentOptions.accuracyColor(), locationComponent.locationComponentOptions.accuracyColor())
   }
 
   @Test


### PR DESCRIPTION
As I looked into customizing the `LocationComponent`, I discovered that the `LocationComponent` could use a new version of the `activateLocationComponent()` method. There wasn't an activation method which took a certain mix of 4 parameters. This pr enables the ability to pass in `Context`, `Style`, `useDefaultLocationEngine`, and `LocationComponentOptions` .

<img width="963" alt="screen shot 2019-02-11 at 2 57 32 pm" src="https://user-images.githubusercontent.com/4394910/52600433-79d70580-2e10-11e9-9922-45ea7918b397.png">

<img width="1059" alt="screen shot 2019-02-11 at 3 06 20 pm" src="https://user-images.githubusercontent.com/4394910/52600430-79d70580-2e10-11e9-8819-38f60c005178.png">
<img width="1086" alt="screen shot 2019-02-11 at 2 57 37 pm" src="https://user-images.githubusercontent.com/4394910/52600432-79d70580-2e10-11e9-95dd-a27bb61c8ece.png">


Related: https://github.com/mapbox/mapbox-gl-native/pull/13829