### PR TITLE
[qt] add global projection functions

### DIFF
--- a/platform/qt/include/qmapbox.hpp
+++ b/platform/qt/include/qmapbox.hpp
@@ -127,6 +127,10 @@ public:
     virtual void deinitialize() = 0;
 };
 
+double metersPerPixelAtLatitude(double latitude, double zoom);
+ProjectedMeters projectedMetersForCoordinate(const Coordinate &);
+Coordinate coordinateForProjectedMeters(const ProjectedMeters &);
+
 } // namespace QMapbox
 
 Q_DECLARE_METATYPE(QMapbox::Coordinate);

--- a/platform/qt/include/qmapbox.hpp
+++ b/platform/qt/include/qmapbox.hpp
@@ -127,9 +127,9 @@ public:
     virtual void deinitialize() = 0;
 };
 
-double metersPerPixelAtLatitude(double latitude, double zoom);
-ProjectedMeters projectedMetersForCoordinate(const Coordinate &);
-Coordinate coordinateForProjectedMeters(const ProjectedMeters &);
+Q_MAPBOXGL_EXPORT double metersPerPixelAtLatitude(double latitude, double zoom);
+Q_MAPBOXGL_EXPORT ProjectedMeters projectedMetersForCoordinate(const Coordinate &);
+Q_MAPBOXGL_EXPORT Coordinate coordinateForProjectedMeters(const ProjectedMeters &);
 
 } // namespace QMapbox
 

--- a/platform/qt/src/qmapbox.cpp
+++ b/platform/qt/src/qmapbox.cpp
@@ -4,6 +4,7 @@
 #include <mbgl/util/default_styles.hpp>
 #include <mbgl/util/geometry.hpp>
 #include <mbgl/util/traits.hpp>
+#include <mbgl/util/projection.hpp>
 
 #include <QOpenGLContext>
 
@@ -220,6 +221,32 @@ QVector<QPair<QString, QString> >& defaultStyles()
     }
 
     return styles;
+}
+
+/*!
+    Returns the amount of meters per pixel from a given \a latitude and \a zoom.
+*/
+double metersPerPixelAtLatitude(double latitude, double zoom)
+{
+    return mbgl::Projection::getMetersPerPixelAtLatitude(latitude, zoom);
+}
+
+/*!
+    Return the projected meters for a given \a coordinate object.
+*/
+ProjectedMeters projectedMetersForCoordinate(const Coordinate &coordinate)
+{
+    auto projectedMeters = mbgl::Projection::projectedMetersForLatLng(mbgl::LatLng { coordinate.first, coordinate.second });
+    return QMapbox::ProjectedMeters(projectedMeters.northing(), projectedMeters.easting());
+}
+
+/*!
+    Returns the coordinate for a given \a projectedMeters object.
+*/
+Coordinate coordinateForProjectedMeters(const ProjectedMeters &projectedMeters)
+{
+    auto latLng = mbgl::Projection::latLngForProjectedMeters(mbgl::ProjectedMeters { projectedMeters.first, projectedMeters.second });
+    return QMapbox::Coordinate(latLng.latitude(), latLng.longitude());
 }
 
 } // namespace QMapbox

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1169,7 +1169,7 @@ void QMapboxGL::addAnnotationIcon(const QString &name, const QImage &icon)
 */
 double QMapboxGL::metersPerPixelAtLatitude(double latitude_, double zoom_) const
 {
-    return mbgl::Projection::getMetersPerPixelAtLatitude(latitude_, zoom_);
+    return QMapbox::metersPerPixelAtLatitude(latitude_, zoom_);
 }
 
 /*!
@@ -1177,8 +1177,7 @@ double QMapboxGL::metersPerPixelAtLatitude(double latitude_, double zoom_) const
 */
 QMapbox::ProjectedMeters QMapboxGL::projectedMetersForCoordinate(const QMapbox::Coordinate &coordinate_) const
 {
-    auto projectedMeters = mbgl::Projection::projectedMetersForLatLng(mbgl::LatLng { coordinate_.first, coordinate_.second });
-    return QMapbox::ProjectedMeters(projectedMeters.northing(), projectedMeters.easting());
+    return QMapbox::projectedMetersForCoordinate(coordinate_);
 }
 
 /*!
@@ -1186,8 +1185,7 @@ QMapbox::ProjectedMeters QMapboxGL::projectedMetersForCoordinate(const QMapbox::
 */
 QMapbox::Coordinate QMapboxGL::coordinateForProjectedMeters(const QMapbox::ProjectedMeters &projectedMeters) const
 {
-    auto latLng = mbgl::Projection::latLngForProjectedMeters(mbgl::ProjectedMeters { projectedMeters.first, projectedMeters.second });
-    return QMapbox::Coordinate(latLng.latitude(), latLng.longitude());
+    return QMapbox::coordinateForProjectedMeters(projectedMeters);
 }
 
 /*!


### PR DESCRIPTION
There are 3 methods in QMapboxGL which can be static method.

QMapboxGL::metersPerPixelAtLatitude
QMapboxGL::projectedMetersForCoordinate
QMapboxGL::coordinateForProjectedMeters

Add these functions into QMapbox namespace as global functions.
The methods in QMapboxGL are kept for backward compatibility.