### PR TITLE
[core, ios] Clean up some comments and warnings

### DIFF
--- a/platform/default/src/mbgl/storage/sqlite3.cpp
+++ b/platform/default/src/mbgl/storage/sqlite3.cpp
@@ -276,14 +276,6 @@ template <> void Query::bind(int offset, const char *value) {
     stmt.impl->check(sqlite3_bind_text(stmt.impl->stmt, offset, value, -1, SQLITE_STATIC));
 }
 
-// We currently cannot use sqlite3_bind_blob64 / sqlite3_bind_text64 because they
-// were introduced in SQLite 3.8.7, and we need to support earlier versions:
-//    Android 11: 3.7
-//    Android 21: 3.8
-//    Android 24: 3.9
-// Per https://developer.android.com/reference/android/database/sqlite/package-summary.
-// The first iOS version with 3.8.7+ was 9.0, with 3.8.8.
-
 void Query::bind(int offset, const char * value, std::size_t length, bool retain) {
     assert(stmt.impl);
     if (length > std::numeric_limits<int>::max()) {

--- a/platform/ios/app/MBXOfflinePacksTableViewController.m
+++ b/platform/ios/app/MBXOfflinePacksTableViewController.m
@@ -102,9 +102,9 @@ static NSString * const MBXOfflinePacksTableViewActiveCellReuseIdentifier = @"Ac
             name = nameField.placeholder;
         }
 
-        NSString *fontFamilyName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"MGLIdeographicFontFamilyName"];
         MGLTilePyramidOfflineRegion *region = [[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:mapView.styleURL bounds:mapView.visibleCoordinateBounds fromZoomLevel:mapView.zoomLevel toZoomLevel:mapView.maximumZoomLevel];
-        region.includesIdeographicGlyphs = fontFamilyName;
+        BOOL hasIdeographicFontFamilyName = !![[NSBundle mainBundle] objectForInfoDictionaryKey:@"MGLIdeographicFontFamilyName"];
+        region.includesIdeographicGlyphs = hasIdeographicFontFamilyName;
         NSData *context = [NSKeyedArchiver archivedDataWithRootObject:@{
             MBXOfflinePackContextNameKey: name,
         }];

--- a/vendor/icu.cmake
+++ b/vendor/icu.cmake
@@ -28,6 +28,7 @@ target_compile_definitions(icu PRIVATE
 
 target_compile_options(icu PRIVATE
     -Wno-error
+    -Wno-shorten-64-to-32
 )
 
 target_include_directories(icu SYSTEM PUBLIC


### PR DESCRIPTION
Closes #12606 (by removing the non-actionable note). Also silences/fixes some warnings.

/cc @tmpsantos @kkaefer 