### PR TITLE
Invalidate the camera position when gesture finishes

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -878,6 +878,9 @@ final class MapGestureDetector {
   private void dispatchCameraIdle() {
     // we need to dispatch camera idle callback only if there is no other gestures in progress
     if (noGesturesInProgress()) {
+      // invalidate the camera position, so that it's valid when fetched from the #onIdle event
+      // and doesn't rely on the last frame being rendered
+      transform.invalidateCameraPosition();
       cameraChangeDispatcher.onCameraIdle();
     }
   }


### PR DESCRIPTION
Users have reported an issue, where fetching current camera position from 
`OnCameraIdleListener#onCameraIdle` after gesture execution would not be up to date. For example, below calls to `map.getCameraPosition().zoom` might've resulted in slightly different values after zooming in/out.

```
map.addOnCameraIdleListener(() -> {
  new Handler().postDelayed(() -> Log.i("Test", "Delay at " +  map.getCameraPosition().zoom), 32);
  Log.i("Test", "Idled at " +  map.getCameraPosition().zoom);
});
```

During any gesture execution, we were invalidating the camera position only when the frame has been rendered, which is not guaranteed to happen before `#onCameraIdle` is delivered. We should invalidate before delivering that event to ensure consistency.