### PR TITLE
[android] hook into surface holder to cleanup renderer on the right thread before the surface is destroyed

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
@@ -75,6 +75,11 @@ public abstract class MapRenderer implements MapRendererScheduler {
   }
 
   @CallSuper
+  protected void onSurfaceDestroyed() {
+    nativeOnSurfaceDestroyed();
+  }
+
+  @CallSuper
   protected void onDrawFrame(GL10 gl) {
     long startTime = System.nanoTime();
     try {
@@ -122,6 +127,8 @@ public abstract class MapRenderer implements MapRendererScheduler {
   private native void nativeOnSurfaceCreated();
 
   private native void nativeOnSurfaceChanged(int width, int height);
+
+  private native void nativeOnSurfaceDestroyed();
 
   private native void nativeRender();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.opengl.GLSurfaceView;
 
 import android.support.annotation.NonNull;
+import android.view.SurfaceHolder;
+
 import com.mapbox.mapboxsdk.maps.renderer.MapRenderer;
 import com.mapbox.mapboxsdk.maps.renderer.egl.EGLConfigChooser;
 
@@ -33,6 +35,15 @@ public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceVi
     glSurfaceView.setRenderer(this);
     glSurfaceView.setRenderMode(RENDERMODE_WHEN_DIRTY);
     glSurfaceView.setPreserveEGLContextOnPause(true);
+
+    glSurfaceView.getHolder().addCallback(new SurfaceHolderCallbackAdapter() {
+
+      @Override
+      public void surfaceDestroyed(SurfaceHolder holder) {
+        GLSurfaceViewMapRenderer.this.onSurfaceDestroyed();
+      }
+
+    });
   }
 
   @Override

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/SurfaceHolderCallbackAdapter.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/SurfaceHolderCallbackAdapter.java
@@ -1,0 +1,21 @@
+package com.mapbox.mapboxsdk.maps.renderer.glsurfaceview;
+
+import android.view.SurfaceHolder;
+
+class SurfaceHolderCallbackAdapter implements SurfaceHolder.Callback {
+
+  @Override
+  public void surfaceCreated(SurfaceHolder holder) {
+
+  }
+
+  @Override
+  public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
+
+  }
+
+  @Override
+  public void surfaceDestroyed(SurfaceHolder holder) {
+
+  }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewMapRenderer.java
@@ -57,6 +57,14 @@ public class TextureViewMapRenderer extends MapRenderer {
    * Overridden to provide package access
    */
   @Override
+  protected void onSurfaceDestroyed() {
+    super.onSurfaceDestroyed();
+  }
+
+  /**
+   * Overridden to provide package access
+   */
+  @Override
   protected void onDrawFrame(GL10 gl) {
     super.onDrawFrame(gl);
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewRenderThread.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewRenderThread.java
@@ -197,6 +197,7 @@ class TextureViewRenderThread extends Thread implements TextureView.SurfaceTextu
             if (destroySurface) {
               eglHolder.destroySurface();
               destroySurface = false;
+              mapRenderer.onSurfaceDestroyed();
               break;
             }
 

--- a/platform/android/src/map_renderer.hpp
+++ b/platform/android/src/map_renderer.hpp
@@ -94,6 +94,9 @@ private:
 
     void onSurfaceChanged(JNIEnv&, jint width, jint height);
 
+    // Called on Main thread
+    void onSurfaceDestroyed(JNIEnv&);
+
 private:
     jni::WeakReference<jni::Object<MapRenderer>, jni::EnvAttachingDeleter> javaPeer;
 


### PR DESCRIPTION
Fixes #11685