### PR TITLE
Bring back style loading test to native map

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/NativeMapViewTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/NativeMapViewTest.kt
@@ -13,6 +13,7 @@ import com.mapbox.mapboxsdk.maps.renderer.MapRenderer
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions
 import com.mapbox.mapboxsdk.testapp.utils.TestConstants
 import junit.framework.Assert.*
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -39,6 +40,30 @@ class NativeMapViewTest {
         val context = InstrumentationRegistry.getContext()
         nativeMapView = NativeMapView(context, 2.0f, false, null, null, DummyRenderer(context))
         nativeMapView.resizeView(WIDTH, HEIGHT)
+    }
+
+    @After
+    @UiThreadTest
+    fun after() {
+        nativeMapView.destroy()
+    }
+
+    @Test
+    @UiThreadTest
+    fun testSetStyleUrl() {
+        val expected = Style.DARK
+        nativeMapView.styleUrl = expected
+        val actual = nativeMapView.styleUrl
+        assertEquals("Style URL should match", expected, actual)
+    }
+
+    @Test
+    @UiThreadTest
+    fun testSetStyleJson() {
+        val expected = "{}"
+        nativeMapView.styleJson = expected
+        val actual = nativeMapView.styleJson
+        assertEquals("Style JSON should match", expected, actual)
     }
 
     @Test


### PR DESCRIPTION
With the addition of onDestroy to the test + https://github.com/mapbox/mapbox-gl-native/pull/13926, we shouldn't be hitting the issue of https://github.com/mapbox/mapbox-gl-native/issues/13554 anymore.