### PR TITLE
[qt] fix missing alpha channel for `QColor`

### DIFF
--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -941,13 +941,13 @@ mbgl::optional<mbgl::Annotation> asMapboxGLAnnotation(const QMapbox::Annotation 
         return { mbgl::SymbolAnnotation(mbgl::Point<double> { pair.second, pair.first }, symbolAnnotation.icon.toStdString()) };
     } else if (annotation.canConvert<QMapbox::LineAnnotation>()) {
         QMapbox::LineAnnotation lineAnnotation = annotation.value<QMapbox::LineAnnotation>();
-        auto color = mbgl::Color::parse(lineAnnotation.color.name().toStdString());
+        auto color = mbgl::Color::parse(mbgl::style::conversion::convertColor(lineAnnotation.color));
         return { mbgl::LineAnnotation(asMapboxGLGeometry(lineAnnotation.geometry), lineAnnotation.opacity, lineAnnotation.width, { *color }) };
     } else if (annotation.canConvert<QMapbox::FillAnnotation>()) {
         QMapbox::FillAnnotation fillAnnotation = annotation.value<QMapbox::FillAnnotation>();
-        auto color = mbgl::Color::parse(fillAnnotation.color.name().toStdString());
+        auto color = mbgl::Color::parse(mbgl::style::conversion::convertColor(fillAnnotation.color));
         if (fillAnnotation.outlineColor.canConvert<QColor>()) {
-            auto outlineColor = mbgl::Color::parse(fillAnnotation.outlineColor.value<QColor>().name().toStdString());
+            auto outlineColor = mbgl::Color::parse(mbgl::style::conversion::convertColor(fillAnnotation.outlineColor.value<QColor>()));
             return { mbgl::FillAnnotation(asMapboxGLGeometry(fillAnnotation.geometry), fillAnnotation.opacity, { *color }, { *outlineColor }) };
         } else {
             return { mbgl::FillAnnotation(asMapboxGLGeometry(fillAnnotation.geometry), fillAnnotation.opacity, { *color }, {}) };

--- a/platform/qt/src/qt_conversion.hpp
+++ b/platform/qt/src/qt_conversion.hpp
@@ -13,6 +13,8 @@ namespace mbgl {
 namespace style {
 namespace conversion {
 
+std::string convertColor(const QColor &color);
+
 template <>
 class ConversionTraits<QVariant> {
 public:
@@ -96,7 +98,7 @@ public:
         if (value.type() == QVariant::String) {
             return value.toString().toStdString();
         } else if (value.type() == QVariant::Color) {
-            return value.value<QColor>().name().toStdString();
+            return convertColor(value.value<QColor>());
         } else {
             return {};
         }
@@ -108,7 +110,7 @@ public:
         } else if (value.type() == QVariant::String) {
             return { value.toString().toStdString() };
         } else if (value.type() == QVariant::Color) {
-            return { value.value<QColor>().name().toStdString() };
+            return { convertColor(value.value<QColor>()) };
         } else if (value.type() == QVariant::Int) {
             return { int64_t(value.toInt()) };
         } else if (value.canConvert(QVariant::Double)) {
@@ -149,6 +151,11 @@ private:
 template <class T, class...Args>
 optional<T> convert(const QVariant& value, Error& error, Args&&...args) {
     return convert<T>(Convertible(value), error, std::forward<Args>(args)...);
+}
+
+inline std::string convertColor(const QColor &color) {
+    return QString::asprintf("rgba(%d,%d,%d,%lf)",
+        color.red(), color.green(), color.blue(), color.alphaF()).toStdString();
 }
 
 } // namespace conversion


### PR DESCRIPTION
`QColor::name()` produces `#rrggbb` format where alpha is missing.
Use `rgba(...)` string instead when convert `QColor` to mapbox style.

Note: `QColor::name(QColor::HexArgb)` produces `#aarrggbb` format string,
but mapbox does not support this format apparently.