### PR TITLE
Keep location component's layers hidden when new style with the "layer-below" option is applied

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationLayerController.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationLayerController.java
@@ -111,6 +111,11 @@ final class LocationLayerController {
       if (layerBelow == null || !layerBelow.equals(newLayerBelowOption)) {
         removeLayers();
         addLayers(newLayerBelowOption);
+        if (isHidden) {
+          for (String layerId : layerMap) {
+            setLayerVisibility(layerId, false);
+          }
+        }
         setRenderMode(renderMode);
       }
     }


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/mapbox/mapbox-gl-native/pull/13749 where the location layers would re-appear after applying a style with a "layer-below" option, even if the component is disabled.