### PR TITLE
[iOS] Exposed mapView's internal gesture recognizers

### DIFF
--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -360,6 +360,24 @@ MGL_EXPORT IB_DESIGNABLE
 
 - (void)removeStyleClass:(NSString *)styleClass __attribute__((unavailable("Support for style classes has been removed.")));
 
+#pragma mark Access internal gesture gesture recognizers
+
+@property (nonatomic, readonly) UITapGestureRecognizer *singleTapGestureRecognizer;
+
+@property (nonatomic, readonly) UITapGestureRecognizer *doubleTap;
+
+@property (nonatomic, readonly) UITapGestureRecognizer *twoFingerTap;
+
+@property (nonatomic, readonly) UIPanGestureRecognizer *pan;
+
+@property (nonatomic, readonly) UIPinchGestureRecognizer *pinch;
+
+@property (nonatomic, readonly) UIRotationGestureRecognizer *rotate;
+
+@property (nonatomic, readonly) UILongPressGestureRecognizer *quickZoom;
+
+@property (nonatomic, readonly) UIPanGestureRecognizer *twoFingerDrag;
+
 #pragma mark Displaying the User’s Location
 
 /**

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -210,14 +210,14 @@ public:
 
 @property (nonatomic, readwrite) MGLStyle *style;
 
-@property (nonatomic) UITapGestureRecognizer *singleTapGestureRecognizer;
-@property (nonatomic) UITapGestureRecognizer *doubleTap;
-@property (nonatomic) UITapGestureRecognizer *twoFingerTap;
-@property (nonatomic) UIPanGestureRecognizer *pan;
-@property (nonatomic) UIPinchGestureRecognizer *pinch;
-@property (nonatomic) UIRotationGestureRecognizer *rotate;
-@property (nonatomic) UILongPressGestureRecognizer *quickZoom;
-@property (nonatomic) UIPanGestureRecognizer *twoFingerDrag;
+@property (nonatomic, readwrite) UITapGestureRecognizer *singleTapGestureRecognizer;
+@property (nonatomic, readwrite) UITapGestureRecognizer *doubleTap;
+@property (nonatomic, readwrite) UITapGestureRecognizer *twoFingerTap;
+@property (nonatomic, readwrite) UIPanGestureRecognizer *pan;
+@property (nonatomic, readwrite) UIPinchGestureRecognizer *pinch;
+@property (nonatomic, readwrite) UIRotationGestureRecognizer *rotate;
+@property (nonatomic, readwrite) UILongPressGestureRecognizer *quickZoom;
+@property (nonatomic, readwrite) UIPanGestureRecognizer *twoFingerDrag;
 
 @property (nonatomic) UIInterfaceOrientation currentOrientation;
 @property (nonatomic) UIInterfaceOrientationMask applicationSupportedInterfaceOrientations;


### PR DESCRIPTION
With this change it is much easier to access the internal gesture recognizers so one doesn't have to search for them in the UIView.gestureRecognizers property any longer.