### PR TITLE
[android] Adding builder pattern for LocationComponent activation

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
@@ -11,7 +11,6 @@ import android.support.annotation.Nullable;
 import android.support.annotation.RequiresPermission;
 import android.support.annotation.StyleRes;
 import android.support.annotation.VisibleForTesting;
-import android.util.Log;
 import android.view.WindowManager;
 
 import com.mapbox.android.core.location.LocationEngine;
@@ -502,13 +501,10 @@ public final class LocationComponent {
 
     // Set the LocationEngine if one was given to LocationComponentActivationOptions
     if (locationComponentActivationOptions.locationEngine() != null) {
-      Log.d(TAG, "activateLocationComponent: locationComponentActivationOptions.locationEngine() != null");
       setLocationEngine(locationEngine);
     } else if (locationComponentActivationOptions.useDefaultLocationEngine()) {
-      Log.d(TAG, "activateLocationComponent: locationComponentActivationOptions.useDefaultLocationEngine()");
       initializeLocationEngine(locationComponentActivationOptions.context());
     } else {
-      Log.d(TAG, "activateLocationComponent: setLocationEngine(null);");
       setLocationEngine(null);
     }
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
@@ -459,16 +459,15 @@ public final class LocationComponent {
     applyStyle(options);
   }
 
+  /**
+   * This method initializes the component and needs to be called before any other operations are performed.
+   * Afterwards, you can manage component's visibility by {@link #setLocationComponentEnabled(boolean)}.
+   *
+   * @param locationComponentActivationOptions a fully built {@link LocationComponentActivationOptions} object
+   */
   public void activateLocationComponent(@NonNull LocationComponentActivationOptions
                                           locationComponentActivationOptions) {
-
-    Log.d(TAG, "locationComponentActivationOptions context packageName = " + locationComponentActivationOptions.context().getPackageName());
-    Log.d(TAG, "locationComponentActivationOptions style URL = " + locationComponentActivationOptions.style().getUrl());
-    Log.d(TAG, "locationComponentActivationOptions styleRes = " + locationComponentActivationOptions.styleRes());
-
-    if (locationComponentActivationOptions.context() != null
-      && locationComponentActivationOptions.style() != null
-      && locationComponentActivationOptions.locationComponentOptions() != null) {
+    if (locationComponentActivationOptions.locationComponentOptions() != null) {
       initialize(locationComponentActivationOptions.context(), locationComponentActivationOptions.style(),
         locationComponentActivationOptions.locationComponentOptions());
     }
@@ -485,24 +484,14 @@ public final class LocationComponent {
       setLocationEngine(null);
     }
 
-    // TODO: How to do some sort of null check on an int for locationComponentActivationOptions.styleRes() ?
-    if (locationComponentActivationOptions.styleRes() <0 &&
-      locationComponentActivationOptions.locationComponentOptions() == null
-      && locationComponentActivationOptions.context() != null) {
-
-      applyStyle(LocationComponentOptions.createFromAttributes(locationComponentActivationOptions.context(),
-        R.style.mapbox_LocationComponent));
-
-    } else if (locationComponentActivationOptions.styleRes() <0
-      && locationComponentActivationOptions.locationComponentOptions() == null
-      && locationComponentActivationOptions.context() != null) {
-
+    if (locationComponentActivationOptions.styleRes() == 0 &&
+      locationComponentActivationOptions.locationComponentOptions() == null) {
+        applyStyle(LocationComponentOptions.createFromAttributes(
+          locationComponentActivationOptions.context(), R.style.mapbox_LocationComponent));
+    } else if (locationComponentActivationOptions.styleRes() != 0) {
       applyStyle(LocationComponentOptions.createFromAttributes(locationComponentActivationOptions.context(),
         locationComponentActivationOptions.styleRes()));
-    } else if (locationComponentActivationOptions.styleRes() < 0
-      && locationComponentActivationOptions.locationComponentOptions() != null
-      && locationComponentActivationOptions.context() != null) {
-
+    } else if (locationComponentActivationOptions.locationComponentOptions() != null) {
       applyStyle(locationComponentActivationOptions.locationComponentOptions());
     }
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
@@ -481,8 +481,8 @@ public final class LocationComponent {
     // Initialize the LocationComponent with Context, the map's `Style`, and either custom LocationComponentOptions
     // or backup options created from default/custom attributes
     initialize(locationComponentActivationOptions.context(), locationComponentActivationOptions.style(),
-      locationComponentActivationOptions.locationComponentOptions() != null ?
-        locationComponentActivationOptions.locationComponentOptions() :
+      locationComponentActivationOptions.locationComponentOptions() != null
+        ? locationComponentActivationOptions.locationComponentOptions() :
         locationComponentOptionsToUseIfCustomOptionsAreNull);
 
     // Apply the LocationComponent styling
@@ -490,8 +490,8 @@ public final class LocationComponent {
       applyStyle(locationComponentActivationOptions.locationComponentOptions());
     } else if (locationComponentActivationOptions.styleRes() != 0) {
       applyStyle(locationComponentOptionsToUseIfCustomOptionsAreNull);
-    } else if (locationComponentActivationOptions.styleRes() == 0 &&
-      locationComponentActivationOptions.locationComponentOptions() == null) {
+    } else if (locationComponentActivationOptions.styleRes() == 0
+      && locationComponentActivationOptions.locationComponentOptions() == null) {
       applyStyle(locationComponentOptionsToUseIfCustomOptionsAreNull);
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
@@ -11,6 +11,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.RequiresPermission;
 import android.support.annotation.StyleRes;
 import android.support.annotation.VisibleForTesting;
+import android.util.Log;
 import android.view.WindowManager;
 
 import com.mapbox.android.core.location.LocationEngine;
@@ -217,8 +218,11 @@ public final class LocationComponent {
    *
    * @param context the context
    * @param style   the proxy object for current map style. More info at {@link Style}
+   * @deprecated As of 7.2.0,
+   * use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
+  @Deprecated
   public void activateLocationComponent(@NonNull Context context, @NonNull Style style) {
     activateLocationComponent(context, style,
       LocationComponentOptions.createFromAttributes(context, R.style.mapbox_LocationComponent));
@@ -232,8 +236,11 @@ public final class LocationComponent {
    * @param style                    the proxy object for current map style. More info at {@link Style}
    * @param useDefaultLocationEngine true if you want to initialize and use the built-in location engine or false if
    *                                 there should be no location engine initialized
+   * @deprecated As of 7.2.0,
+   * use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
+  @Deprecated
   public void activateLocationComponent(@NonNull Context context, @NonNull Style style,
                                         boolean useDefaultLocationEngine) {
     if (useDefaultLocationEngine) {
@@ -252,8 +259,11 @@ public final class LocationComponent {
    * @param useDefaultLocationEngine true if you want to initialize and use the built-in location engine or false if
    *                                 there should be no location engine initialized
    * @param locationEngineRequest    the location request
+   * @deprecated As of 7.2.0,
+   * use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
+  @Deprecated
   public void activateLocationComponent(@NonNull Context context, @NonNull Style style,
                                         boolean useDefaultLocationEngine,
                                         @NonNull LocationEngineRequest locationEngineRequest) {
@@ -275,8 +285,11 @@ public final class LocationComponent {
    *                                 there should be no location engine initialized
    * @param locationEngineRequest    the location request
    * @param options                  the options
+   * @deprecated As of 7.2.0,
+   * use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
+  @Deprecated
   public void activateLocationComponent(@NonNull Context context, @NonNull Style style,
                                         boolean useDefaultLocationEngine,
                                         @NonNull LocationEngineRequest locationEngineRequest,
@@ -298,8 +311,11 @@ public final class LocationComponent {
    * @param context  the context
    * @param style    the proxy object for current map style. More info at {@link Style}
    * @param styleRes the LocationComponent style res
+   * @deprecated As of 7.2.0,
+   * use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
+  @Deprecated
   public void activateLocationComponent(@NonNull Context context, @NonNull Style style, @StyleRes int styleRes) {
     activateLocationComponent(context, style, LocationComponentOptions.createFromAttributes(context, styleRes));
   }
@@ -314,8 +330,11 @@ public final class LocationComponent {
    * @param context the context
    * @param style   the proxy object for current map style. More info at {@link Style}
    * @param options the options
+   * @deprecated As of 7.2.0,
+   * use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
+  @Deprecated
   public void activateLocationComponent(@NonNull Context context, @NonNull Style style,
                                         @NonNull LocationComponentOptions options) {
     initialize(context, style, options);
@@ -331,8 +350,11 @@ public final class LocationComponent {
    * @param style          the proxy object for current map style. More info at {@link Style}
    * @param locationEngine the engine, or null if you'd like to only force location updates
    * @param styleRes       the LocationComponent style res
+   * @deprecated As of 7.2.0,
+   * use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
+  @Deprecated
   public void activateLocationComponent(@NonNull Context context, @NonNull Style style,
                                         @Nullable LocationEngine locationEngine, @StyleRes int styleRes) {
     activateLocationComponent(context, style, locationEngine,
@@ -348,8 +370,11 @@ public final class LocationComponent {
    * @param locationEngine        the engine, or null if you'd like to only force location updates
    * @param locationEngineRequest the location request
    * @param styleRes              the LocationComponent style res
+   * @deprecated As of 7.2.0,
+   * use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
+  @Deprecated
   public void activateLocationComponent(@NonNull Context context, @NonNull Style style,
                                         @Nullable LocationEngine locationEngine,
                                         @NonNull LocationEngineRequest locationEngineRequest, @StyleRes int styleRes) {
@@ -363,8 +388,11 @@ public final class LocationComponent {
    * @param context        the context
    * @param style          the proxy object for current map style. More info at {@link Style}
    * @param locationEngine the engine
+   * @deprecated As of 7.2.0,
+   * use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
+  @Deprecated
   public void activateLocationComponent(@NonNull Context context, @NonNull Style style,
                                         @Nullable LocationEngine locationEngine) {
     activateLocationComponent(context, style, locationEngine, R.style.mapbox_LocationComponent);
@@ -377,8 +405,11 @@ public final class LocationComponent {
    * @param style                 the proxy object for current map style. More info at {@link Style}
    * @param locationEngine        the engine
    * @param locationEngineRequest the location request
+   * @deprecated As of 7.2.0,
+   * use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
+  @Deprecated
   public void activateLocationComponent(@NonNull Context context, @NonNull Style style,
                                         @Nullable LocationEngine locationEngine,
                                         @NonNull LocationEngineRequest locationEngineRequest) {
@@ -392,8 +423,11 @@ public final class LocationComponent {
    * @param locationEngine the engine, or null if you'd like to only force location updates
    * @param style          the proxy object for current map style. More info at {@link Style}
    * @param options        the options
+   * @deprecated As of 7.2.0,
+   * use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
+  @Deprecated
   public void activateLocationComponent(@NonNull Context context, @NonNull Style style,
                                         @Nullable LocationEngine locationEngine,
                                         @NonNull LocationComponentOptions options) {
@@ -411,7 +445,10 @@ public final class LocationComponent {
    * @param locationEngine        the engine, or null if you'd like to only force location updates
    * @param locationEngineRequest the location request
    * @param options               the options
+   * @deprecated As of 7.2.0,
+   * use {@link LocationComponentActivationOptions.Builder} instead
    */
+  @Deprecated
   public void activateLocationComponent(@NonNull Context context, @NonNull Style style,
                                         @Nullable LocationEngine locationEngine,
                                         @NonNull LocationEngineRequest locationEngineRequest,
@@ -421,6 +458,55 @@ public final class LocationComponent {
     setLocationEngine(locationEngine);
     applyStyle(options);
   }
+
+  public void activateLocationComponent(@NonNull LocationComponentActivationOptions
+                                          locationComponentActivationOptions) {
+
+    Log.d(TAG, "locationComponentActivationOptions context packageName = " + locationComponentActivationOptions.context().getPackageName());
+    Log.d(TAG, "locationComponentActivationOptions style URL = " + locationComponentActivationOptions.style().getUrl());
+    Log.d(TAG, "locationComponentActivationOptions styleRes = " + locationComponentActivationOptions.styleRes());
+
+    if (locationComponentActivationOptions.context() != null
+      && locationComponentActivationOptions.style() != null
+      && locationComponentActivationOptions.locationComponentOptions() != null) {
+      initialize(locationComponentActivationOptions.context(), locationComponentActivationOptions.style(),
+        locationComponentActivationOptions.locationComponentOptions());
+    }
+
+    if (locationComponentActivationOptions.locationEngineRequest() != null) {
+      setLocationEngineRequest(locationComponentActivationOptions.locationEngineRequest());
+    }
+
+    if (locationComponentActivationOptions.locationEngine() != null) {
+      setLocationEngine(locationEngine);
+    } else if (locationComponentActivationOptions.useDefaultLocationEngine()) {
+      initializeLocationEngine(locationComponentActivationOptions.context());
+    } else {
+      setLocationEngine(null);
+    }
+
+    // TODO: How to do some sort of null check on an int for locationComponentActivationOptions.styleRes() ?
+    if (locationComponentActivationOptions.styleRes() <0 &&
+      locationComponentActivationOptions.locationComponentOptions() == null
+      && locationComponentActivationOptions.context() != null) {
+
+      applyStyle(LocationComponentOptions.createFromAttributes(locationComponentActivationOptions.context(),
+        R.style.mapbox_LocationComponent));
+
+    } else if (locationComponentActivationOptions.styleRes() <0
+      && locationComponentActivationOptions.locationComponentOptions() == null
+      && locationComponentActivationOptions.context() != null) {
+
+      applyStyle(LocationComponentOptions.createFromAttributes(locationComponentActivationOptions.context(),
+        locationComponentActivationOptions.styleRes()));
+    } else if (locationComponentActivationOptions.styleRes() < 0
+      && locationComponentActivationOptions.locationComponentOptions() != null
+      && locationComponentActivationOptions.context() != null) {
+
+      applyStyle(locationComponentActivationOptions.locationComponentOptions());
+    }
+  }
+
 
   /**
    * Manage component's visibility after activation.

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
@@ -217,8 +217,7 @@ public final class LocationComponent {
    *
    * @param context the context
    * @param style   the proxy object for current map style. More info at {@link Style}
-   * @deprecated As of 7.2.0,
-   * use {@link LocationComponentActivationOptions.Builder} instead
+   * @deprecated use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
   @Deprecated
@@ -235,8 +234,7 @@ public final class LocationComponent {
    * @param style                    the proxy object for current map style. More info at {@link Style}
    * @param useDefaultLocationEngine true if you want to initialize and use the built-in location engine or false if
    *                                 there should be no location engine initialized
-   * @deprecated As of 7.2.0,
-   * use {@link LocationComponentActivationOptions.Builder} instead
+   * @deprecated use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
   @Deprecated
@@ -258,8 +256,7 @@ public final class LocationComponent {
    * @param useDefaultLocationEngine true if you want to initialize and use the built-in location engine or false if
    *                                 there should be no location engine initialized
    * @param locationEngineRequest    the location request
-   * @deprecated As of 7.2.0,
-   * use {@link LocationComponentActivationOptions.Builder} instead
+   * @deprecated use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
   @Deprecated
@@ -284,8 +281,7 @@ public final class LocationComponent {
    *                                 there should be no location engine initialized
    * @param locationEngineRequest    the location request
    * @param options                  the options
-   * @deprecated As of 7.2.0,
-   * use {@link LocationComponentActivationOptions.Builder} instead
+   * @deprecated use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
   @Deprecated
@@ -310,8 +306,7 @@ public final class LocationComponent {
    * @param context  the context
    * @param style    the proxy object for current map style. More info at {@link Style}
    * @param styleRes the LocationComponent style res
-   * @deprecated As of 7.2.0,
-   * use {@link LocationComponentActivationOptions.Builder} instead
+   * @deprecated use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
   @Deprecated
@@ -329,8 +324,7 @@ public final class LocationComponent {
    * @param context the context
    * @param style   the proxy object for current map style. More info at {@link Style}
    * @param options the options
-   * @deprecated As of 7.2.0,
-   * use {@link LocationComponentActivationOptions.Builder} instead
+   * @deprecated use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
   @Deprecated
@@ -349,8 +343,7 @@ public final class LocationComponent {
    * @param style          the proxy object for current map style. More info at {@link Style}
    * @param locationEngine the engine, or null if you'd like to only force location updates
    * @param styleRes       the LocationComponent style res
-   * @deprecated As of 7.2.0,
-   * use {@link LocationComponentActivationOptions.Builder} instead
+   * @deprecated use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
   @Deprecated
@@ -369,8 +362,7 @@ public final class LocationComponent {
    * @param locationEngine        the engine, or null if you'd like to only force location updates
    * @param locationEngineRequest the location request
    * @param styleRes              the LocationComponent style res
-   * @deprecated As of 7.2.0,
-   * use {@link LocationComponentActivationOptions.Builder} instead
+   * @deprecated use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
   @Deprecated
@@ -387,8 +379,7 @@ public final class LocationComponent {
    * @param context        the context
    * @param style          the proxy object for current map style. More info at {@link Style}
    * @param locationEngine the engine
-   * @deprecated As of 7.2.0,
-   * use {@link LocationComponentActivationOptions.Builder} instead
+   * @deprecated use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
   @Deprecated
@@ -404,8 +395,7 @@ public final class LocationComponent {
    * @param style                 the proxy object for current map style. More info at {@link Style}
    * @param locationEngine        the engine
    * @param locationEngineRequest the location request
-   * @deprecated As of 7.2.0,
-   * use {@link LocationComponentActivationOptions.Builder} instead
+   * @deprecated use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
   @Deprecated
@@ -422,8 +412,7 @@ public final class LocationComponent {
    * @param locationEngine the engine, or null if you'd like to only force location updates
    * @param style          the proxy object for current map style. More info at {@link Style}
    * @param options        the options
-   * @deprecated As of 7.2.0,
-   * use {@link LocationComponentActivationOptions.Builder} instead
+   * @deprecated use {@link LocationComponentActivationOptions.Builder} instead
    */
   @RequiresPermission(anyOf = {ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION})
   @Deprecated
@@ -444,8 +433,7 @@ public final class LocationComponent {
    * @param locationEngine        the engine, or null if you'd like to only force location updates
    * @param locationEngineRequest the location request
    * @param options               the options
-   * @deprecated As of 7.2.0,
-   * use {@link LocationComponentActivationOptions.Builder} instead
+   * @deprecated use {@link LocationComponentActivationOptions.Builder} instead
    */
   @Deprecated
   public void activateLocationComponent(@NonNull Context context, @NonNull Style style,
@@ -462,48 +450,39 @@ public final class LocationComponent {
    * This method initializes the component and needs to be called before any other operations are performed.
    * Afterwards, you can manage component's visibility by {@link #setLocationComponentEnabled(boolean)}.
    *
-   * @param locationComponentActivationOptions a fully built {@link LocationComponentActivationOptions} object
+   * @param activationOptions a fully built {@link LocationComponentActivationOptions} object
    */
   public void activateLocationComponent(@NonNull LocationComponentActivationOptions
-                                          locationComponentActivationOptions) {
-    // Create LocationComponentOptions from attributes ahead of time for usage if
-    // locationComponentActivationOptions.locationComponentOptions() is null
-    LocationComponentOptions locationComponentOptionsToUseIfCustomOptionsAreNull =
-      LocationComponentOptions.createFromAttributes(
-        locationComponentActivationOptions.context(), R.style.mapbox_LocationComponent);
-
-    if (locationComponentActivationOptions.styleRes() != 0) {
-      locationComponentOptionsToUseIfCustomOptionsAreNull = LocationComponentOptions.createFromAttributes(
-        locationComponentActivationOptions.context(), locationComponentActivationOptions.styleRes());
+                                            activationOptions) {
+    LocationComponentOptions options = activationOptions.locationComponentOptions();
+    if (options == null) {
+      int styleRes = activationOptions.styleRes();
+      if (styleRes == 0) {
+        styleRes = R.style.mapbox_LocationComponent;
+      }
+      options = LocationComponentOptions.createFromAttributes(activationOptions.context(), styleRes);
     }
 
     // Initialize the LocationComponent with Context, the map's `Style`, and either custom LocationComponentOptions
     // or backup options created from default/custom attributes
-    initialize(locationComponentActivationOptions.context(), locationComponentActivationOptions.style(),
-      locationComponentActivationOptions.locationComponentOptions() != null
-        ? locationComponentActivationOptions.locationComponentOptions() :
-        locationComponentOptionsToUseIfCustomOptionsAreNull);
+    initialize(activationOptions.context(), activationOptions.style(), options);
 
     // Apply the LocationComponent styling
-    if (locationComponentActivationOptions.locationComponentOptions() != null) {
-      applyStyle(locationComponentActivationOptions.locationComponentOptions());
-    } else if (locationComponentActivationOptions.styleRes() != 0) {
-      applyStyle(locationComponentOptionsToUseIfCustomOptionsAreNull);
-    } else if (locationComponentActivationOptions.styleRes() == 0
-      && locationComponentActivationOptions.locationComponentOptions() == null) {
-      applyStyle(locationComponentOptionsToUseIfCustomOptionsAreNull);
-    }
+    // TODO avoid doubling style initialization
+    applyStyle(options);
 
     // Set the LocationEngine request if one was given to LocationComponentActivationOptions
-    if (locationComponentActivationOptions.locationEngineRequest() != null) {
-      setLocationEngineRequest(locationComponentActivationOptions.locationEngineRequest());
+    LocationEngineRequest locationEngineRequest = activationOptions.locationEngineRequest();
+    if (locationEngineRequest != null) {
+      setLocationEngineRequest(locationEngineRequest);
     }
 
     // Set the LocationEngine if one was given to LocationComponentActivationOptions
-    if (locationComponentActivationOptions.locationEngine() != null) {
+    LocationEngine locationEngine = activationOptions.locationEngine();
+    if (locationEngine != null) {
       setLocationEngine(locationEngine);
-    } else if (locationComponentActivationOptions.useDefaultLocationEngine()) {
-      initializeLocationEngine(locationComponentActivationOptions.context());
+    } else if (activationOptions.useDefaultLocationEngine()) {
+      initializeLocationEngine(activationOptions.context());
     } else {
       setLocationEngine(null);
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
@@ -481,10 +481,12 @@ public final class LocationComponent {
     LocationEngine locationEngine = activationOptions.locationEngine();
     if (locationEngine != null) {
       setLocationEngine(locationEngine);
-    } else if (activationOptions.useDefaultLocationEngine()) {
-      initializeLocationEngine(activationOptions.context());
     } else {
-      setLocationEngine(null);
+      if (activationOptions.useDefaultLocationEngine()) {
+        initializeLocationEngine(activationOptions.context());
+      } else {
+        setLocationEngine(null);
+      }
     }
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptions.java
@@ -174,7 +174,12 @@ public class LocationComponentActivationOptions {
       }
       if (style == null) {
         throw new NullPointerException(
-          "Style in LocationComponentActivationOptions is null. Wait for the map to fully load before " +
+          "Style in LocationComponentActivationOptions is null. Make sure the Style object isn't null." +
+            " Wait for the map to fully load before passing the Style object to LocationComponentActivationOptions.");
+      }
+      if (!style.isFullyLoaded()) {
+        throw new IllegalArgumentException(
+          "Style in LocationComponentActivationOptions isn't fully loaded. Wait for the map to fully load before " +
             "passing the Style object to LocationComponentActivationOptions.");
       }
       return new LocationComponentActivationOptions(context, style, locationEngine, locationEngineRequest,

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptions.java
@@ -81,7 +81,7 @@ public class LocationComponentActivationOptions {
 
   /**
    * The location request which the {@link LocationComponent} should use
-   * @return
+   * @return the LocationEngineRequest object
    */
   @Nullable
   public LocationEngineRequest locationEngineRequest() {
@@ -164,9 +164,9 @@ public class LocationComponentActivationOptions {
     public LocationComponentActivationOptions build() {
       if (styleRes != 0 && locationComponentOptions != null) {
         throw new IllegalArgumentException(
-          "You've provided both a style resource and a LocationComponentOptions object to the " +
-            "LocationComponentActivationOptions builder. You can't use both and " +
-            "you must choose one of the two to style the LocationComponent.");
+          "You've provided both a style resource and a LocationComponentOptions object to the "
+            + "LocationComponentActivationOptions builder. You can't use both and "
+            + "you must choose one of the two to style the LocationComponent.");
       }
       if (context == null) {
         throw new NullPointerException(
@@ -174,13 +174,13 @@ public class LocationComponentActivationOptions {
       }
       if (style == null) {
         throw new NullPointerException(
-          "Style in LocationComponentActivationOptions is null. Make sure the Style object isn't null." +
-            " Wait for the map to fully load before passing the Style object to LocationComponentActivationOptions.");
+          "Style in LocationComponentActivationOptions is null. Make sure the Style object isn't null."
+            + " Wait for the map to fully load before passing the Style object to LocationComponentActivationOptions.");
       }
       if (!style.isFullyLoaded()) {
         throw new IllegalArgumentException(
-          "Style in LocationComponentActivationOptions isn't fully loaded. Wait for the map to fully load before " +
-            "passing the Style object to LocationComponentActivationOptions.");
+          "Style in LocationComponentActivationOptions isn't fully loaded. Wait for the map to fully load before "
+            + "passing the Style object to LocationComponentActivationOptions.");
       }
       return new LocationComponentActivationOptions(context, style, locationEngine, locationEngineRequest,
         locationComponentOptions, styleRes, useDefaultLocationEngine);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptions.java
@@ -9,17 +9,20 @@ import com.mapbox.android.core.location.LocationEngineRequest;
 import com.mapbox.mapboxsdk.maps.Style;
 
 /**
+ * A class which holds the various options for activating the Maps SDK's {@link LocationComponent} to eventually
+ * show the device location on the map.
+ *
  * since 7.2.0
  */
 public class LocationComponentActivationOptions {
 
-  private Context context;
-  private Style style;
-  private LocationEngine locationEngine;
-  private LocationEngineRequest locationEngineRequest;
-  private LocationComponentOptions locationComponentOptions;
-  private int styleRes;
-  private boolean useDefaultLocationEngine;
+  private final Context context;
+  private final Style style;
+  private final LocationEngine locationEngine;
+  private final LocationEngineRequest locationEngineRequest;
+  private final LocationComponentOptions locationComponentOptions;
+  private final int styleRes;
+  private final boolean useDefaultLocationEngine;
 
   LocationComponentActivationOptions(@NonNull Context context, @NonNull Style style,
                                      @Nullable LocationEngine locationEngine,
@@ -51,7 +54,7 @@ public class LocationComponentActivationOptions {
    *
    * @return the application's current context
    */
-  @Nullable
+  @NonNull
   public Context context() {
     return context;
   }
@@ -61,7 +64,7 @@ public class LocationComponentActivationOptions {
    *
    * @return the map's fully loaded Style object
    */
-  @Nullable
+  @NonNull
   public Style style() {
     return style;
   }
@@ -95,9 +98,9 @@ public class LocationComponentActivationOptions {
   }
 
   /**
-   * the LocationComponent style res
+   * the LocationComponent style resource (e.g. R.style.style_name)
    *
-   * @return
+   * @return the style resource.
    */
   @Nullable
   public int styleRes() {
@@ -105,7 +108,7 @@ public class LocationComponentActivationOptions {
   }
 
   /**
-   * true if you want to initialize and use the built-in location engine or false if there should be no
+   * True if you want to initialize and use the built-in location engine or false if there should be no
    * location engine initialized
    * @return whether the default LocationEngine is used
    */
@@ -133,10 +136,6 @@ public class LocationComponentActivationOptions {
       this.style = style;
     }
 
-    public Builder() {
-
-    }
-    
     public Builder locationEngine(LocationEngine locationEngine) {
       this.locationEngine = locationEngine;
       return this;
@@ -163,6 +162,21 @@ public class LocationComponentActivationOptions {
     }
 
     public LocationComponentActivationOptions build() {
+      if (styleRes != 0 && locationComponentOptions != null) {
+        throw new IllegalArgumentException(
+          "You've provided both a style resource and a LocationComponentOptions object to the " +
+            "LocationComponentActivationOptions builder. You can't use both and " +
+            "you must choose one of the two to style the LocationComponent.");
+      }
+      if (context == null) {
+        throw new NullPointerException(
+          "Context in LocationComponentActivationOptions is null.");
+      }
+      if (style == null) {
+        throw new NullPointerException(
+          "Style in LocationComponentActivationOptions is null. Wait for the map to fully load before " +
+            "passing the Style object to LocationComponentActivationOptions.");
+      }
       return new LocationComponentActivationOptions(context, style, locationEngine, locationEngineRequest,
         locationComponentOptions, styleRes, useDefaultLocationEngine);
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptions.java
@@ -1,0 +1,170 @@
+package com.mapbox.mapboxsdk.location;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.mapbox.android.core.location.LocationEngine;
+import com.mapbox.android.core.location.LocationEngineRequest;
+import com.mapbox.mapboxsdk.maps.Style;
+
+/**
+ * since 7.2.0
+ */
+public class LocationComponentActivationOptions {
+
+  private Context context;
+  private Style style;
+  private LocationEngine locationEngine;
+  private LocationEngineRequest locationEngineRequest;
+  private LocationComponentOptions locationComponentOptions;
+  private int styleRes;
+  private boolean useDefaultLocationEngine;
+
+  LocationComponentActivationOptions(@NonNull Context context, @NonNull Style style,
+                                     @Nullable LocationEngine locationEngine,
+                                     @Nullable LocationEngineRequest locationEngineRequest,
+                                     @Nullable LocationComponentOptions locationComponentOptions,
+                                     int styleRes,
+                                     boolean useDefaultLocationEngine) {
+    this.context = context;
+    this.style = style;
+    this.locationEngine = locationEngine;
+    this.locationEngineRequest = locationEngineRequest;
+    this.locationComponentOptions = locationComponentOptions;
+    this.styleRes = styleRes;
+    this.useDefaultLocationEngine = useDefaultLocationEngine;
+  }
+
+  /**
+   * Convenience method to retrieve a {@link LocationComponentActivationOptions} object which is ready to build with
+   *
+   * @return a builder object
+   */
+  @NonNull
+  public static Builder builder(@NonNull Context context, @NonNull Style fullyLoadedMapStyle) {
+    return new LocationComponentActivationOptions.Builder(context, fullyLoadedMapStyle);
+  }
+
+  /**
+   * The application's current context
+   *
+   * @return the application's current context
+   */
+  @Nullable
+  public Context context() {
+    return context;
+  }
+
+  /**
+   * The proxy object for current map style. More info at {@link Style}
+   *
+   * @return the map's fully loaded Style object
+   */
+  @Nullable
+  public Style style() {
+    return style;
+  }
+
+  /**
+   * The {@link LocationEngine} which the {@link LocationComponent} should use
+   *
+   * @return the engine, or null if you'd like to only force location updates
+   */
+  @Nullable
+  public LocationEngine locationEngine() {
+    return locationEngine;
+  }
+
+  /**
+   * The location request which the {@link LocationComponent} should use
+   * @return
+   */
+  @Nullable
+  public LocationEngineRequest locationEngineRequest() {
+    return locationEngineRequest;
+  }
+
+  /**
+   * A built {@link LocationComponentOptions} object, which holds the various {@link LocationComponent} styling options
+   * @return the options for styling the actual LocationComponent
+   */
+  @Nullable
+  public LocationComponentOptions locationComponentOptions() {
+    return locationComponentOptions;
+  }
+
+  /**
+   * the LocationComponent style res
+   *
+   * @return
+   */
+  @Nullable
+  public int styleRes() {
+    return styleRes;
+  }
+
+  /**
+   * true if you want to initialize and use the built-in location engine or false if there should be no
+   * location engine initialized
+   * @return whether the default LocationEngine is used
+   */
+  @Nullable
+  public boolean useDefaultLocationEngine() {
+    return useDefaultLocationEngine;
+  }
+
+  /**
+   * Builder class for constructing a new instance of {@link LocationComponentActivationOptions}.
+   *
+   * since 7.2.0
+   */
+  public static class Builder {
+    private Context context;
+    private Style style;
+    private LocationEngine locationEngine;
+    private LocationEngineRequest locationEngineRequest;
+    private LocationComponentOptions locationComponentOptions;
+    private int styleRes;
+    private boolean useDefaultLocationEngine;
+
+    public Builder(Context context, Style style) {
+      this.context = context;
+      this.style = style;
+    }
+
+    public Builder() {
+
+    }
+    
+    public Builder locationEngine(LocationEngine locationEngine) {
+      this.locationEngine = locationEngine;
+      return this;
+    }
+
+    public Builder locationEngineRequest(LocationEngineRequest locationEngineRequest) {
+      this.locationEngineRequest = locationEngineRequest;
+      return this;
+    }
+
+    public Builder locationComponentOptions(LocationComponentOptions locationComponentOptions) {
+      this.locationComponentOptions = locationComponentOptions;
+      return this;
+    }
+
+    public Builder styleRes(int styleRes) {
+      this.styleRes = styleRes;
+      return this;
+    }
+
+    public Builder useDefaultLocationEngine(boolean useDefaultLocationEngine) {
+      this.useDefaultLocationEngine = useDefaultLocationEngine;
+      return this;
+    }
+
+    public LocationComponentActivationOptions build() {
+      return new LocationComponentActivationOptions(context, style, locationEngine, locationEngineRequest,
+        locationComponentOptions, styleRes, useDefaultLocationEngine);
+    }
+  }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptions.java
@@ -11,8 +11,6 @@ import com.mapbox.mapboxsdk.maps.Style;
 /**
  * A class which holds the various options for activating the Maps SDK's {@link LocationComponent} to eventually
  * show the device location on the map.
- *
- * since 7.2.0
  */
 public class LocationComponentActivationOptions {
 
@@ -24,7 +22,7 @@ public class LocationComponentActivationOptions {
   private final int styleRes;
   private final boolean useDefaultLocationEngine;
 
-  LocationComponentActivationOptions(@NonNull Context context, @NonNull Style style,
+  private LocationComponentActivationOptions(@NonNull Context context, @NonNull Style style,
                                      @Nullable LocationEngine locationEngine,
                                      @Nullable LocationEngineRequest locationEngineRequest,
                                      @Nullable LocationComponentOptions locationComponentOptions,
@@ -102,7 +100,6 @@ public class LocationComponentActivationOptions {
    *
    * @return the style resource.
    */
-  @Nullable
   public int styleRes() {
     return styleRes;
   }
@@ -112,15 +109,12 @@ public class LocationComponentActivationOptions {
    * location engine initialized
    * @return whether the default LocationEngine is used
    */
-  @Nullable
   public boolean useDefaultLocationEngine() {
     return useDefaultLocationEngine;
   }
 
   /**
    * Builder class for constructing a new instance of {@link LocationComponentActivationOptions}.
-   *
-   * since 7.2.0
    */
   public static class Builder {
     private Context context;
@@ -129,13 +123,39 @@ public class LocationComponentActivationOptions {
     private LocationEngineRequest locationEngineRequest;
     private LocationComponentOptions locationComponentOptions;
     private int styleRes;
-    private boolean useDefaultLocationEngine;
 
-    public Builder(Context context, Style style) {
+    /**
+     *  Set to true as the default in case a true/false value isn't declared via the builder's
+     *  {@link LocationComponentActivationOptions#useDefaultLocationEngine()} method.
+     *
+     *  Please be aware that this activation boolean is ignored when a non-null
+     *  {@link LocationEngine} is set via the builder's `locationEngine()` method.
+     */
+    private boolean useDefaultLocationEngine = true;
+
+    /**
+     * Constructor for the {@link LocationComponentActivationOptions} builder class.
+     * While other activation options are optional, the activation process always requires
+     * context and a fully-loaded map {@link Style} object, which is why the two are in this
+     * constructor.
+     */
+    public Builder(@NonNull Context context, @NonNull Style style) {
       this.context = context;
       this.style = style;
     }
 
+    /**
+     * Deliver your own {@link LocationEngine} to the LocationComponent.
+     *
+     * The true/false
+     * {@link LocationComponentActivationOptions#builder(Context, Style)#useDefaultLocationEngine}
+     * activation option is ignored when a non-null {@link LocationEngine} is set via
+     * this `locationEngine()` method.
+     *
+     * @param locationEngine a {@link LocationEngine} object
+     *
+     * @return The {@link Builder} class with a set LocationEngine.
+     */
     public Builder locationEngine(LocationEngine locationEngine) {
       this.locationEngine = locationEngine;
       return this;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptions.java
@@ -23,11 +23,11 @@ public class LocationComponentActivationOptions {
   private final boolean useDefaultLocationEngine;
 
   private LocationComponentActivationOptions(@NonNull Context context, @NonNull Style style,
-                                     @Nullable LocationEngine locationEngine,
-                                     @Nullable LocationEngineRequest locationEngineRequest,
-                                     @Nullable LocationComponentOptions locationComponentOptions,
-                                     int styleRes,
-                                     boolean useDefaultLocationEngine) {
+                                             @Nullable LocationEngine locationEngine,
+                                             @Nullable LocationEngineRequest locationEngineRequest,
+                                             @Nullable LocationComponentOptions locationComponentOptions,
+                                             int styleRes,
+                                             boolean useDefaultLocationEngine) {
     this.context = context;
     this.style = style;
     this.locationEngine = locationEngine;
@@ -70,7 +70,7 @@ public class LocationComponentActivationOptions {
   /**
    * The {@link LocationEngine} which the {@link LocationComponent} should use
    *
-   * @return the engine, or null if you'd like to only force location updates
+   * @return the engine
    */
   @Nullable
   public LocationEngine locationEngine() {
@@ -79,6 +79,7 @@ public class LocationComponentActivationOptions {
 
   /**
    * The location request which the {@link LocationComponent} should use
+   *
    * @return the LocationEngineRequest object
    */
   @Nullable
@@ -88,6 +89,7 @@ public class LocationComponentActivationOptions {
 
   /**
    * A built {@link LocationComponentOptions} object, which holds the various {@link LocationComponent} styling options
+   *
    * @return the options for styling the actual LocationComponent
    */
   @Nullable
@@ -96,7 +98,7 @@ public class LocationComponentActivationOptions {
   }
 
   /**
-   * the LocationComponent style resource (e.g. R.style.style_name)
+   * The LocationComponent style resource (e.g. R.style.style_name)
    *
    * @return the style resource.
    */
@@ -107,6 +109,7 @@ public class LocationComponentActivationOptions {
   /**
    * True if you want to initialize and use the built-in location engine or false if there should be no
    * location engine initialized
+   *
    * @return whether the default LocationEngine is used
    */
   public boolean useDefaultLocationEngine() {
@@ -117,19 +120,19 @@ public class LocationComponentActivationOptions {
    * Builder class for constructing a new instance of {@link LocationComponentActivationOptions}.
    */
   public static class Builder {
-    private Context context;
-    private Style style;
+    private final Context context;
+    private final Style style;
     private LocationEngine locationEngine;
     private LocationEngineRequest locationEngineRequest;
     private LocationComponentOptions locationComponentOptions;
     private int styleRes;
 
     /**
-     *  Set to true as the default in case a true/false value isn't declared via the builder's
-     *  {@link LocationComponentActivationOptions#useDefaultLocationEngine()} method.
-     *
-     *  Please be aware that this activation boolean is ignored when a non-null
-     *  {@link LocationEngine} is set via the builder's `locationEngine()` method.
+     * Set to true as the default in case a true/false value isn't declared via the builder's
+     * {@link LocationComponentActivationOptions#useDefaultLocationEngine()} method.
+     * <p>
+     * Please be aware that this activation boolean is ignored when a non-null
+     * {@link LocationEngine} is set via the builder's `locationEngine()` method.
      */
     private boolean useDefaultLocationEngine = true;
 
@@ -146,64 +149,93 @@ public class LocationComponentActivationOptions {
 
     /**
      * Deliver your own {@link LocationEngine} to the LocationComponent.
-     *
+     * <p>
      * The true/false
      * {@link LocationComponentActivationOptions#builder(Context, Style)#useDefaultLocationEngine}
      * activation option is ignored when a non-null {@link LocationEngine} is set via
      * this `locationEngine()` method.
      *
      * @param locationEngine a {@link LocationEngine} object
-     *
-     * @return The {@link Builder} class with a set LocationEngine.
+     * @return the {@link Builder} object being constructed
      */
-    public Builder locationEngine(LocationEngine locationEngine) {
+    @NonNull
+    public Builder locationEngine(@Nullable LocationEngine locationEngine) {
       this.locationEngine = locationEngine;
       return this;
     }
 
+    /**
+     * @param locationEngineRequest the location request which the
+     *                              {@link LocationComponent} should use
+     * @return the {@link Builder} object being constructed
+     */
     public Builder locationEngineRequest(LocationEngineRequest locationEngineRequest) {
       this.locationEngineRequest = locationEngineRequest;
       return this;
     }
 
+    /**
+     * @param locationComponentOptions a built {@link LocationComponentOptions} object,
+     *                                 which holds the various {@link LocationComponent}
+     *                                 styling options
+     * @return the {@link Builder} object being constructed
+     */
     public Builder locationComponentOptions(LocationComponentOptions locationComponentOptions) {
       this.locationComponentOptions = locationComponentOptions;
       return this;
     }
 
+    /**
+     * @param styleRes the LocationComponent style resource (e.g. R.style.style_name)
+     * @return the {@link Builder} object being constructed
+     */
     public Builder styleRes(int styleRes) {
       this.styleRes = styleRes;
       return this;
     }
 
+    /**
+     * @param useDefaultLocationEngine true if you want to initialize and use the
+     *                                 built-in location engine or false if there
+     *                                 should be no location engine initialized
+     * @return the {@link Builder} object being constructed
+     */
     public Builder useDefaultLocationEngine(boolean useDefaultLocationEngine) {
       this.useDefaultLocationEngine = useDefaultLocationEngine;
       return this;
     }
 
+    /**
+     * Method which actually builds the {@link LocationComponentActivationOptions} object while
+     * taking the various options into account.
+     *
+     * @return a built {@link LocationComponentActivationOptions} object
+     */
     public LocationComponentActivationOptions build() {
       if (styleRes != 0 && locationComponentOptions != null) {
         throw new IllegalArgumentException(
-          "You've provided both a style resource and a LocationComponentOptions object to the "
-            + "LocationComponentActivationOptions builder. You can't use both and "
-            + "you must choose one of the two to style the LocationComponent.");
+            "You've provided both a style resource and a LocationComponentOptions object to the "
+                + "LocationComponentActivationOptions builder. You can't use both and "
+                + "you must choose one of the two to style the LocationComponent.");
       }
       if (context == null) {
         throw new NullPointerException(
-          "Context in LocationComponentActivationOptions is null.");
+            "Context in LocationComponentActivationOptions is null.");
       }
       if (style == null) {
         throw new NullPointerException(
-          "Style in LocationComponentActivationOptions is null. Make sure the Style object isn't null."
-            + " Wait for the map to fully load before passing the Style object to LocationComponentActivationOptions.");
+            "Style in LocationComponentActivationOptions is null. Make sure the "
+                + "Style object isn't null. Wait for the map to fully load before passing "
+                + "the Style object to LocationComponentActivationOptions.");
       }
       if (!style.isFullyLoaded()) {
         throw new IllegalArgumentException(
-          "Style in LocationComponentActivationOptions isn't fully loaded. Wait for the map to fully load before "
-            + "passing the Style object to LocationComponentActivationOptions.");
+            "Style in LocationComponentActivationOptions isn't fully loaded. Wait for the "
+                + "map to fully load before passing the Style object to "
+                + "LocationComponentActivationOptions.");
       }
-      return new LocationComponentActivationOptions(context, style, locationEngine, locationEngineRequest,
-        locationComponentOptions, styleRes, useDefaultLocationEngine);
+      return new LocationComponentActivationOptions(context, style, locationEngine,
+          locationEngineRequest, locationComponentOptions, styleRes, useDefaultLocationEngine);
     }
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptions.java
@@ -198,6 +198,9 @@ public class LocationComponentActivationOptions {
      * @param useDefaultLocationEngine true if you want to initialize and use the
      *                                 built-in location engine or false if there
      *                                 should be no location engine initialized
+     *                                 This is ignored when null is set as the parameter
+     *                                 for {@link LocationComponentActivationOptions#builder
+     *                                 (Context, Style)#locationEngine()}.
      * @return the {@link Builder} object being constructed
      */
     public Builder useDefaultLocationEngine(boolean useDefaultLocationEngine) {

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptionsTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptionsTest.java
@@ -1,0 +1,107 @@
+package com.mapbox.mapboxsdk.location;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.content.res.TypedArray;
+import android.support.annotation.NonNull;
+
+import com.mapbox.mapboxsdk.R;
+import com.mapbox.mapboxsdk.maps.Style;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoRule;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LocationComponentActivationOptionsTest {
+
+  @Mock
+  private Context context;
+  @Mock
+  private TypedArray array;
+  @Mock
+  private Resources resources;
+  @Mock
+  private Style style;
+
+  @Rule
+  public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @NonNull
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Before
+  public void setUp() throws Exception {
+    when(context.obtainStyledAttributes(R.style.mapbox_LocationComponent, R.styleable.mapbox_LocationComponent))
+      .thenReturn(array);
+    when(array.getResourceId(R.styleable.mapbox_LocationComponent_mapbox_foregroundDrawable, -1))
+      .thenReturn(R.drawable.mapbox_user_icon);
+    when(context.getResources()).thenReturn(resources);
+  }
+
+  @Test
+  public void sanity() throws Exception {
+    when(style.isFullyLoaded()).thenReturn(true);
+
+    LocationComponentOptions locationComponentOptions = LocationComponentOptions.builder(context)
+      .accuracyAlpha(0.5f)
+      .build();
+    assertNotNull(locationComponentOptions);
+
+    LocationComponentActivationOptions locationComponentActivationOptions =
+      LocationComponentActivationOptions.builder(context, style)
+        .locationComponentOptions(locationComponentOptions)
+        .useDefaultLocationEngine(true)
+        .build();
+    assertNotNull(locationComponentActivationOptions);
+  }
+
+  @Test
+  public void includingBothStyleResAndComponentOptions_causesExceptionToBeThrown() throws Exception {
+    when(style.isFullyLoaded()).thenReturn(true);
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("You've provided both a style resource and a LocationComponentOptions object to the " +
+      "LocationComponentActivationOptions builder. You can't use both and " +
+      "you must choose one of the two to style the LocationComponent.");
+
+    LocationComponentOptions locationComponentOptions = LocationComponentOptions.builder(context)
+      .accuracyAlpha(0.5f)
+      .build();
+    assertNotNull(locationComponentOptions);
+
+    LocationComponentActivationOptions.builder(context, style)
+      .locationComponentOptions(locationComponentOptions)
+      .styleRes(R.style.mapbox_LocationComponent)
+      .build();
+  }
+
+  @Test
+  public void nullStyle_causesExceptionToBeThrown() throws Exception {
+    when(style.isFullyLoaded()).thenReturn(false);
+
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("Style in LocationComponentActivationOptions is null. Wait for the map to fully load before " +
+      "passing the Style object to LocationComponentActivationOptions.");
+
+    LocationComponentOptions locationComponentOptions = LocationComponentOptions.builder(context)
+      .accuracyAlpha(0.5f)
+      .build();
+    assertNotNull(locationComponentOptions);
+
+    LocationComponentActivationOptions.builder(context, style)
+      .locationComponentOptions(locationComponentOptions)
+      .styleRes(R.style.mapbox_LocationComponent)
+      .build();
+  }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptionsTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptionsTest.java
@@ -68,12 +68,11 @@ public class LocationComponentActivationOptionsTest {
 
   @Test
   public void includingBothStyleResAndComponentOptions_causesExceptionToBeThrown() throws Exception {
-    when(style.isFullyLoaded()).thenReturn(true);
 
     thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("You've provided both a style resource and a LocationComponentOptions object to the " +
-      "LocationComponentActivationOptions builder. You can't use both and " +
-      "you must choose one of the two to style the LocationComponent.");
+    thrown.expectMessage("You've provided both a style resource and a LocationComponentOptions"
+      + " object to the LocationComponentActivationOptions builder. You can't use both and "
+      + "you must choose one of the two to style the LocationComponent.");
 
     LocationComponentOptions locationComponentOptions = LocationComponentOptions.builder(context)
       .accuracyAlpha(0.5f)
@@ -87,21 +86,31 @@ public class LocationComponentActivationOptionsTest {
   }
 
   @Test
-  public void nullStyle_causesExceptionToBeThrown() throws Exception {
-    when(style.isFullyLoaded()).thenReturn(false);
-
+  public void nullContext_causesExceptionToBeThrown() throws Exception {
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("Style in LocationComponentActivationOptions is null. Wait for the map to fully load before " +
-      "passing the Style object to LocationComponentActivationOptions.");
+    thrown.expectMessage("Context in LocationComponentActivationOptions is null.");
 
     LocationComponentOptions locationComponentOptions = LocationComponentOptions.builder(context)
       .accuracyAlpha(0.5f)
       .build();
     assertNotNull(locationComponentOptions);
 
-    LocationComponentActivationOptions.builder(context, style)
-      .locationComponentOptions(locationComponentOptions)
-      .styleRes(R.style.mapbox_LocationComponent)
+    LocationComponentActivationOptions.builder(null, style)
+      .build();
+  }
+
+  @Test
+  public void nullStyle_causesExceptionToBeThrown() throws Exception {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("Style in LocationComponentActivationOptions is null. Make sure the Style object isn't null."
+      + " Wait for the map to fully load before passing the Style object to LocationComponentActivationOptions.");
+
+    LocationComponentOptions locationComponentOptions = LocationComponentOptions.builder(context)
+      .accuracyAlpha(0.5f)
+      .build();
+    assertNotNull(locationComponentOptions);
+
+    LocationComponentActivationOptions.builder(context, null)
       .build();
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptionsTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptionsTest.java
@@ -77,7 +77,6 @@ public class LocationComponentActivationOptionsTest {
     LocationComponentOptions locationComponentOptions = LocationComponentOptions.builder(context)
       .accuracyAlpha(0.5f)
       .build();
-    assertNotNull(locationComponentOptions);
 
     LocationComponentActivationOptions.builder(context, style)
       .locationComponentOptions(locationComponentOptions)
@@ -90,11 +89,6 @@ public class LocationComponentActivationOptionsTest {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("Context in LocationComponentActivationOptions is null.");
 
-    LocationComponentOptions locationComponentOptions = LocationComponentOptions.builder(context)
-      .accuracyAlpha(0.5f)
-      .build();
-    assertNotNull(locationComponentOptions);
-
     LocationComponentActivationOptions.builder(null, style)
       .build();
   }
@@ -104,11 +98,6 @@ public class LocationComponentActivationOptionsTest {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("Style in LocationComponentActivationOptions is null. Make sure the Style object isn't null."
       + " Wait for the map to fully load before passing the Style object to LocationComponentActivationOptions.");
-
-    LocationComponentOptions locationComponentOptions = LocationComponentOptions.builder(context)
-      .accuracyAlpha(0.5f)
-      .build();
-    assertNotNull(locationComponentOptions);
 
     LocationComponentActivationOptions.builder(context, null)
       .build();
@@ -123,11 +112,6 @@ public class LocationComponentActivationOptionsTest {
     thrown.expectMessage("Style in LocationComponentActivationOptions isn't fully loaded. Wait for the "
         + "map to fully load before passing the Style object to "
         + "LocationComponentActivationOptions.");
-
-    LocationComponentOptions locationComponentOptions = LocationComponentOptions.builder(context)
-        .accuracyAlpha(0.5f)
-        .build();
-    assertNotNull(locationComponentOptions);
 
     LocationComponentActivationOptions.builder(context, style)
         .build();

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptionsTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptionsTest.java
@@ -113,4 +113,23 @@ public class LocationComponentActivationOptionsTest {
     LocationComponentActivationOptions.builder(context, null)
       .build();
   }
+
+  @Test
+  public void locationComponent_exceptionThrownWithDefaultLocationEngineButNotFullyLoadedStyle() throws Exception {
+
+    when(style.isFullyLoaded()).thenReturn(false);
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Style in LocationComponentActivationOptions isn't fully loaded. Wait for the "
+        + "map to fully load before passing the Style object to "
+        + "LocationComponentActivationOptions.");
+
+    LocationComponentOptions locationComponentOptions = LocationComponentOptions.builder(context)
+        .accuracyAlpha(0.5f)
+        .build();
+    assertNotNull(locationComponentOptions);
+
+    LocationComponentActivationOptions.builder(context, style)
+        .build();
+  }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
@@ -52,6 +52,9 @@ class LocationComponentTest : EspressoTest() {
     initLocation
   }
 
+  private lateinit var locationComponentActivationOptions: LocationComponentActivationOptions
+
+
   override fun validateTestSetup() {
     super.validateTestSetup()
     assertThat(mapboxMap.style, notNullValue())
@@ -70,7 +73,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style)
+
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .build())
         component.isLocationComponentEnabled = true
 
         val locationEngine = component.locationEngine
@@ -89,15 +95,21 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(
-          context,
-          style,
-          LocationComponentOptions.builder(context)
-            .staleStateTimeout(200)
-            .enableStaleState(false)
-            .accuracyAlpha(.5f)
-            .accuracyColor(Color.BLUE)
-            .build())
+
+        locationComponentActivationOptions = LocationComponentActivationOptions
+                .builder(context, style)
+                .locationComponentOptions(
+                        LocationComponentOptions.builder(context)
+                                .staleStateTimeout(200)
+                                .enableStaleState(false)
+                                .accuracyAlpha(.5f)
+                                .accuracyColor(Color.BLUE)
+                                .build()
+                )
+                .build()
+
+        component.activateLocationComponent(locationComponentActivationOptions)
+
         component.isLocationComponentEnabled = true
 
         val locationEngine = component.locationEngine
@@ -121,16 +133,20 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(
-          context,
-          style,
-          null,
-          LocationComponentOptions.builder(context)
-            .staleStateTimeout(200)
-            .enableStaleState(false)
-            .accuracyAlpha(.5f)
-            .accuracyColor(Color.BLUE)
-            .build())
+
+          locationComponentActivationOptions = LocationComponentActivationOptions
+                  .builder(context, style)
+                  .locationComponentOptions(
+                          LocationComponentOptions.builder(context)
+                                  .staleStateTimeout(200)
+                                  .enableStaleState(false)
+                                  .accuracyAlpha(.5f)
+                                  .accuracyColor(Color.BLUE)
+                                  .build()
+                  )
+                  .build()
+        component.activateLocationComponent(locationComponentActivationOptions)
+
         component.isLocationComponentEnabled = true
 
         val locationEngine = component.locationEngine
@@ -155,7 +171,11 @@ class LocationComponentTest : EspressoTest() {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
         mapboxMap.setStyle(Style.Builder().fromUrl(Style.LIGHT))
-        component.activateLocationComponent(context, style, false)
+
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
       }
     }
 
@@ -168,7 +188,11 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
 
         // Source should be present but empty
@@ -198,13 +222,18 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context,
-          style,
-          null,
-          LocationComponentOptions.builder(context)
-            .staleStateTimeout(200)
-            .enableStaleState(false)
-            .build())
+
+
+        locationComponentActivationOptions = LocationComponentActivationOptions
+                  .builder(context, style)
+                  .locationComponentOptions(
+                          LocationComponentOptions.builder(context)
+                                  .staleStateTimeout(200)
+                                  .enableStaleState(false)
+                                  .build())
+                  .build()
+        component.activateLocationComponent(locationComponentActivationOptions)
+
         component.isLocationComponentEnabled = true
 
         component.forceLocationUpdate(location)
@@ -228,16 +257,20 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context,
-          style,
-          null,
-          LocationComponentOptions.builder(context)
-            .foregroundName("custom-foreground-bitmap")
-            .backgroundName("custom-background-bitmap")
-            .foregroundStaleName("custom-foreground-stale-bitmap")
-            .backgroundStaleName("custom-background-stale-bitmap")
-            .bearingName("custom-bearing-bitmap")
-            .build())
+
+          locationComponentActivationOptions = LocationComponentActivationOptions
+                  .builder(context, style)
+                  .locationComponentOptions(
+                          LocationComponentOptions.builder(context)
+                                  .foregroundName("custom-foreground-bitmap")
+                                  .backgroundName("custom-background-bitmap")
+                                  .foregroundStaleName("custom-foreground-stale-bitmap")
+                                  .backgroundStaleName("custom-background-stale-bitmap")
+                                  .bearingName("custom-bearing-bitmap")
+                                  .build())
+                  .build()
+        component.activateLocationComponent(locationComponentActivationOptions)
+
         component.isLocationComponentEnabled = true
 
         val foregroundDrawable = ContextCompat.getDrawable(context, R.drawable.ic_media_play)
@@ -271,13 +304,17 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context,
-          style,
-          null,
-          LocationComponentOptions.builder(context)
-            .foregroundName("custom-foreground-bitmap")
-            .gpsName("custom-gps-bitmap")
-            .build())
+
+        locationComponentActivationOptions = LocationComponentActivationOptions
+                .builder(context, style)
+                .locationComponentOptions(
+                        LocationComponentOptions.builder(context)
+                                .foregroundName("custom-foreground-bitmap")
+                                .gpsName("custom-gps-bitmap")
+                                .build())
+                .build()
+        component.activateLocationComponent(locationComponentActivationOptions)
+
         component.isLocationComponentEnabled = true
 
         component.renderMode = RenderMode.GPS
@@ -303,13 +340,16 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context,
-          style,
-          null,
-          LocationComponentOptions.builder(context)
-            .foregroundName("custom-foreground-bitmap")
-            .gpsName("custom-gps-bitmap")
-            .build())
+
+        locationComponentActivationOptions = LocationComponentActivationOptions
+                .builder(context, style)
+                .locationComponentOptions(
+                        LocationComponentOptions.builder(context)
+                                .foregroundName("custom-foreground-bitmap")
+                                .gpsName("custom-gps-bitmap")
+                                .build())
+                .build()
+        component.activateLocationComponent(locationComponentActivationOptions)
         component.isLocationComponentEnabled = true
 
         component.renderMode = RenderMode.GPS
@@ -335,12 +375,15 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context,
-          style,
-          null,
-          LocationComponentOptions.builder(context)
-            .gpsName("custom-gps-bitmap")
-            .build())
+
+        locationComponentActivationOptions = LocationComponentActivationOptions
+                .builder(context, style)
+                .locationComponentOptions(
+                        LocationComponentOptions.builder(context)
+                                .gpsName("custom-gps-bitmap")
+                                .build())
+                .build()
+        component.activateLocationComponent(locationComponentActivationOptions)
         component.isLocationComponentEnabled = true
 
         component.renderMode = RenderMode.GPS
@@ -366,12 +409,16 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context,
-          style,
-          null,
-          LocationComponentOptions.builder(context)
-            .staleStateTimeout(200)
-            .build())
+
+        locationComponentActivationOptions = LocationComponentActivationOptions
+                .builder(context, style)
+                .locationComponentOptions(
+                        LocationComponentOptions.builder(context)
+                                .staleStateTimeout(200)
+                                .build())
+                .build()
+        component.activateLocationComponent(locationComponentActivationOptions)
+
         component.isLocationComponentEnabled = true
 
         component.forceLocationUpdate(location)
@@ -398,7 +445,12 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
+
         component.isLocationComponentEnabled = true
         component.forceLocationUpdate(location)
         TestingAsyncUtils.waitForLayer(uiController, idlingResource.mapView)
@@ -425,12 +477,16 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context,
-          style,
-          null,
-          LocationComponentOptions.builder(context)
-            .accuracyColor(color)
-            .build())
+
+        locationComponentActivationOptions = LocationComponentActivationOptions
+                .builder(context, style)
+                .locationComponentOptions(
+                        LocationComponentOptions.builder(context)
+                                .accuracyColor(color)
+                                .build())
+                .build()
+        component.activateLocationComponent(locationComponentActivationOptions)
+
         component.isLocationComponentEnabled = true
 
         component.forceLocationUpdate(location)
@@ -453,7 +509,12 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
+
         component.isLocationComponentEnabled = true
         component.forceLocationUpdate(location)
         TestingAsyncUtils.waitForLayer(uiController, idlingResource.mapView)
@@ -473,7 +534,11 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.forceLocationUpdate(location)
         TestingAsyncUtils.waitForLayer(uiController, idlingResource.mapView)
@@ -496,7 +561,11 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.forceLocationUpdate(location)
         component.isLocationComponentEnabled = false
@@ -520,7 +589,11 @@ class LocationComponentTest : EspressoTest() {
         component.onStop()
         component.onStart()
         assertThat(component.isLocationComponentEnabled, `is`(false))
-        component.activateLocationComponent(context, style, false)
+
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         assertThat(component.isLocationComponentEnabled, `is`(true))
       }
@@ -534,7 +607,12 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
+
         component.isLocationComponentEnabled = true
         assertThat(component.isLocationComponentEnabled, `is`(true))
         component.onStop()
@@ -551,7 +629,11 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(
+                LocationComponentActivationOptions
+                        .builder(context, style)
+                        .useDefaultLocationEngine(false)
+                        .build())
         component.isLocationComponentEnabled = true
         component.isLocationComponentEnabled = false
         assertThat(component.isLocationComponentEnabled, `is`(false))
@@ -569,7 +651,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
 
         component.onStop()
@@ -588,7 +673,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         mapboxMap.setStyle(Style.Builder().fromUrl(Style.DARK))
         component.onStop()
@@ -605,7 +693,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.onStop()
         component.forceLocationUpdate(location)
@@ -623,7 +714,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.onStop()
         component.forceLocationUpdate(location)
@@ -644,7 +738,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.forceLocationUpdate(location)
         mapboxMap.setStyle(Style.Builder().fromUrl(Style.LIGHT))
@@ -672,7 +769,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         styleChangeIdlingResource.waitForStyle(mapboxMap, MAPBOX_HEAVY_STYLE)
         val options = LocationComponentOptions.builder(context)
@@ -680,7 +780,7 @@ class LocationComponentTest : EspressoTest() {
           .build()
 
         pushSourceUpdates(styleChangeIdlingResource) {
-          component.applyStyle(options)
+        component.applyStyle(options)
         }
 
         TestingAsyncUtils.waitForLayer(uiController, idlingResource.mapView)
@@ -698,12 +798,15 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         styleChangeIdlingResource.waitForStyle(mapboxMap, MAPBOX_HEAVY_STYLE)
 
         pushSourceUpdates(styleChangeIdlingResource) {
-          component.forceLocationUpdate(location)
+        component.forceLocationUpdate(location)
         }
 
         TestingAsyncUtils.waitForLayer(uiController, idlingResource.mapView)
@@ -723,7 +826,12 @@ class LocationComponentTest : EspressoTest() {
                                              style: Style, uiController: UiController, context: Context) {
         styleChangeIdlingResource.waitForStyle(mapboxMap, MAPBOX_HEAVY_STYLE)
         TestingAsyncUtils.waitForLayer(uiController, idlingResource.mapView)
-        component.activateLocationComponent(context, mapboxMap.style!!, false)
+
+        locationComponentActivationOptions = LocationComponentActivationOptions
+                .builder(context, mapboxMap.style!!)
+                .useDefaultLocationEngine(false)
+                .build()
+        component.activateLocationComponent(locationComponentActivationOptions)
         component.isLocationComponentEnabled = true
 
         val options = LocationComponentOptions.builder(context)
@@ -731,8 +839,8 @@ class LocationComponentTest : EspressoTest() {
           .build()
 
         pushSourceUpdates(styleChangeIdlingResource) {
-          component.forceLocationUpdate(location)
-          component.applyStyle(options)
+        component.forceLocationUpdate(location)
+        component.applyStyle(options)
         }
       }
     }
@@ -748,7 +856,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.renderMode = RenderMode.GPS
         location.bearing = 77f
@@ -773,7 +884,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.cameraMode = CameraMode.TRACKING_GPS
         location.bearing = 77f
@@ -806,7 +920,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.cameraMode = CameraMode.NONE_GPS
         val latitude = mapboxMap.cameraPosition.target.latitude
@@ -842,7 +959,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.cameraMode = CameraMode.NONE
         val latitude = mapboxMap.cameraPosition.target.latitude
@@ -879,7 +999,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.cameraMode = CameraMode.TRACKING
         component.cameraMode = CameraMode.NONE
@@ -898,7 +1021,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.cameraMode = CameraMode.NONE
         val zoom = mapboxMap.cameraPosition.zoom
@@ -918,7 +1044,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.cameraMode = CameraMode.TRACKING
         component.zoomWhileTracking(10.0)
@@ -938,7 +1067,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.cameraMode = CameraMode.TRACKING
         component.zoomWhileTracking(15.0)
@@ -959,7 +1091,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
 
         component.cameraMode = CameraMode.TRACKING
@@ -983,7 +1118,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.cameraMode = CameraMode.TRACKING
         component.zoomWhileTracking(15.0)
@@ -1004,7 +1142,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.cameraMode = CameraMode.NONE
         val tilt = mapboxMap.cameraPosition.tilt
@@ -1024,7 +1165,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.cameraMode = CameraMode.TRACKING
         component.tiltWhileTracking(30.0)
@@ -1044,7 +1188,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.cameraMode = CameraMode.TRACKING
         component.tiltWhileTracking(30.0)
@@ -1065,7 +1212,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.cameraMode = CameraMode.TRACKING
         val tilt = mapboxMap.cameraPosition.tilt
@@ -1088,7 +1238,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.cameraMode = CameraMode.TRACKING
         component.tiltWhileTracking(30.0)
@@ -1108,7 +1261,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.cameraMode = CameraMode.TRACKING_GPS
         component.forceLocationUpdate(location)
@@ -1133,7 +1289,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.cameraMode = CameraMode.NONE
         component.forceLocationUpdate(location)
@@ -1159,7 +1318,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         assertTrue(component.compassEngine is LocationComponentCompassEngine)
       }
@@ -1173,7 +1335,10 @@ class LocationComponentTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         val engine: CompassEngine = object : CompassEngine {
           override fun addCompassListener(compassListener: CompassListener) {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
@@ -80,7 +80,7 @@ class LocationComponentTest : EspressoTest() {
         component.isLocationComponentEnabled = true
 
         val locationEngine = component.locationEngine
-        assertThat(locationEngine, nullValue())
+        assertThat(locationEngine, notNullValue())
 
         TestingAsyncUtils.waitForLayer(uiController, idlingResource.mapView)
       }
@@ -115,7 +115,7 @@ class LocationComponentTest : EspressoTest() {
         val locationEngine = component.locationEngine
         val componentOptions = component.locationComponentOptions
 
-        assertThat(locationEngine, nullValue())
+        assertThat(locationEngine, notNullValue())
         assertThat(componentOptions, notNullValue())
 
         TestingAsyncUtils.waitForLayer(uiController, idlingResource.mapView)
@@ -136,6 +136,7 @@ class LocationComponentTest : EspressoTest() {
 
           locationComponentActivationOptions = LocationComponentActivationOptions
                   .builder(context, style)
+                  .locationEngine(null)
                   .locationComponentOptions(
                           LocationComponentOptions.builder(context)
                                   .staleStateTimeout(200)

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
@@ -80,7 +80,7 @@ class LocationComponentTest : EspressoTest() {
         component.isLocationComponentEnabled = true
 
         val locationEngine = component.locationEngine
-        assertThat(locationEngine, notNullValue())
+        assertThat(locationEngine, nullValue())
 
         TestingAsyncUtils.waitForLayer(uiController, idlingResource.mapView)
       }
@@ -115,7 +115,7 @@ class LocationComponentTest : EspressoTest() {
         val locationEngine = component.locationEngine
         val componentOptions = component.locationComponentOptions
 
-        assertThat(locationEngine, notNullValue())
+        assertThat(locationEngine, nullValue())
         assertThat(componentOptions, notNullValue())
 
         TestingAsyncUtils.waitForLayer(uiController, idlingResource.mapView)
@@ -164,7 +164,7 @@ class LocationComponentTest : EspressoTest() {
     executeComponentTest(componentAction)
   }
 
-  @Test(expected = IllegalStateException::class)
+  @Test(expected = IllegalArgumentException::class)
   fun settingMapStyleImmediatelyBeforeLoadingComponent_throwsInvalidStyle() {
     validateTestSetup()
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
@@ -228,7 +228,7 @@ class LocationComponentTest : EspressoTest() {
 
         locationComponentActivationOptions = LocationComponentActivationOptions
                   .builder(context, style)
-                .locationEngine(null)
+                .useDefaultLocationEngine(false)
                 .locationComponentOptions(
                           LocationComponentOptions.builder(context)
                                   .staleStateTimeout(200)
@@ -263,7 +263,7 @@ class LocationComponentTest : EspressoTest() {
 
           locationComponentActivationOptions = LocationComponentActivationOptions
                   .builder(context, style)
-                  .locationEngine(null)
+                  .useDefaultLocationEngine(false)
                   .locationComponentOptions(
                           LocationComponentOptions.builder(context)
                                   .foregroundName("custom-foreground-bitmap")
@@ -311,7 +311,7 @@ class LocationComponentTest : EspressoTest() {
 
         locationComponentActivationOptions = LocationComponentActivationOptions
                 .builder(context, style)
-                .locationEngine(null)
+                .useDefaultLocationEngine(false)
                 .locationComponentOptions(
                         LocationComponentOptions.builder(context)
                                 .foregroundName("custom-foreground-bitmap")
@@ -348,7 +348,7 @@ class LocationComponentTest : EspressoTest() {
 
         locationComponentActivationOptions = LocationComponentActivationOptions
                 .builder(context, style)
-                .locationEngine(null)
+                .useDefaultLocationEngine(false)
                 .locationComponentOptions(
                         LocationComponentOptions.builder(context)
                                 .foregroundName("custom-foreground-bitmap")
@@ -384,7 +384,7 @@ class LocationComponentTest : EspressoTest() {
 
         locationComponentActivationOptions = LocationComponentActivationOptions
                 .builder(context, style)
-                .locationEngine(null)
+                .useDefaultLocationEngine(false)
                 .locationComponentOptions(
                         LocationComponentOptions.builder(context)
                                 .gpsName("custom-gps-bitmap")
@@ -419,7 +419,7 @@ class LocationComponentTest : EspressoTest() {
 
         locationComponentActivationOptions = LocationComponentActivationOptions
                 .builder(context, style)
-                .locationEngine(null)
+                .useDefaultLocationEngine(false)
                 .locationComponentOptions(
                         LocationComponentOptions.builder(context)
                                 .staleStateTimeout(200)
@@ -488,7 +488,7 @@ class LocationComponentTest : EspressoTest() {
 
         locationComponentActivationOptions = LocationComponentActivationOptions
                 .builder(context, style)
-                .locationEngine(null)
+                .useDefaultLocationEngine(false)
                 .locationComponentOptions(
                         LocationComponentOptions.builder(context)
                                 .accuracyColor(color)

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
@@ -230,7 +230,8 @@ class LocationComponentTest : EspressoTest() {
 
         locationComponentActivationOptions = LocationComponentActivationOptions
                   .builder(context, style)
-                  .locationComponentOptions(
+                .locationEngine(null)
+                .locationComponentOptions(
                           LocationComponentOptions.builder(context)
                                   .staleStateTimeout(200)
                                   .enableStaleState(false)
@@ -264,6 +265,7 @@ class LocationComponentTest : EspressoTest() {
 
           locationComponentActivationOptions = LocationComponentActivationOptions
                   .builder(context, style)
+                  .locationEngine(null)
                   .locationComponentOptions(
                           LocationComponentOptions.builder(context)
                                   .foregroundName("custom-foreground-bitmap")
@@ -311,6 +313,7 @@ class LocationComponentTest : EspressoTest() {
 
         locationComponentActivationOptions = LocationComponentActivationOptions
                 .builder(context, style)
+                .locationEngine(null)
                 .locationComponentOptions(
                         LocationComponentOptions.builder(context)
                                 .foregroundName("custom-foreground-bitmap")
@@ -347,6 +350,7 @@ class LocationComponentTest : EspressoTest() {
 
         locationComponentActivationOptions = LocationComponentActivationOptions
                 .builder(context, style)
+                .locationEngine(null)
                 .locationComponentOptions(
                         LocationComponentOptions.builder(context)
                                 .foregroundName("custom-foreground-bitmap")
@@ -382,6 +386,7 @@ class LocationComponentTest : EspressoTest() {
 
         locationComponentActivationOptions = LocationComponentActivationOptions
                 .builder(context, style)
+                .locationEngine(null)
                 .locationComponentOptions(
                         LocationComponentOptions.builder(context)
                                 .gpsName("custom-gps-bitmap")
@@ -485,6 +490,7 @@ class LocationComponentTest : EspressoTest() {
 
         locationComponentActivationOptions = LocationComponentActivationOptions
                 .builder(context, style)
+                .locationEngine(null)
                 .locationComponentOptions(
                         LocationComponentOptions.builder(context)
                                 .accuracyColor(color)

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
@@ -137,6 +137,7 @@ class LocationComponentTest : EspressoTest() {
           locationComponentActivationOptions = LocationComponentActivationOptions
                   .builder(context, style)
                   .locationEngine(null)
+                  .useDefaultLocationEngine(false)
                   .locationComponentOptions(
                           LocationComponentOptions.builder(context)
                                   .staleStateTimeout(200)
@@ -153,10 +154,7 @@ class LocationComponentTest : EspressoTest() {
         val locationEngine = component.locationEngine
         val componentOptions = component.locationComponentOptions
 
-        // notNullValue() used for LocationEngine because
-        // com.mapbox.android.core.location.LocationEngineProxy
-        // should be returned, rather than `null`
-        assertThat(locationEngine, notNullValue())
+        assertThat(locationEngine, nullValue())
         assertThat(componentOptions, notNullValue())
 
         TestingAsyncUtils.waitForLayer(uiController, idlingResource.mapView)

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
@@ -416,6 +416,7 @@ class LocationComponentTest : EspressoTest() {
 
         locationComponentActivationOptions = LocationComponentActivationOptions
                 .builder(context, style)
+                .locationEngine(null)
                 .locationComponentOptions(
                         LocationComponentOptions.builder(context)
                                 .staleStateTimeout(200)

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
@@ -153,7 +153,10 @@ class LocationComponentTest : EspressoTest() {
         val locationEngine = component.locationEngine
         val componentOptions = component.locationComponentOptions
 
-        assertThat(locationEngine, nullValue())
+        // notNullValue() used for LocationEngine because
+        // com.mapbox.android.core.location.LocationEngineProxy
+        // should be returned, rather than `null`
+        assertThat(locationEngine, notNullValue())
         assertThat(componentOptions, notNullValue())
 
         TestingAsyncUtils.waitForLayer(uiController, idlingResource.mapView)

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationLayerControllerTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationLayerControllerTest.kt
@@ -69,7 +69,10 @@ class LocationLayerControllerTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.renderMode = RenderMode.NORMAL
         TestingAsyncUtils.waitForLayer(uiController, idlingResource.mapView)
@@ -89,7 +92,10 @@ class LocationLayerControllerTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.renderMode = RenderMode.NORMAL
         component.forceLocationUpdate(location)
@@ -110,7 +116,10 @@ class LocationLayerControllerTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.renderMode = RenderMode.COMPASS
         component.forceLocationUpdate(location)
@@ -131,7 +140,10 @@ class LocationLayerControllerTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.renderMode = RenderMode.GPS
         component.forceLocationUpdate(location)
@@ -152,7 +164,10 @@ class LocationLayerControllerTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.forceLocationUpdate(location)
         component.isLocationComponentEnabled = false
@@ -174,7 +189,10 @@ class LocationLayerControllerTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.renderMode = RenderMode.NORMAL
         component.forceLocationUpdate(location)
@@ -197,7 +215,10 @@ class LocationLayerControllerTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.renderMode = RenderMode.NORMAL
         component.forceLocationUpdate(location)
@@ -226,7 +247,10 @@ class LocationLayerControllerTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.applyStyle(LocationComponentOptions.builder(context).staleStateTimeout(100).build())
         component.forceLocationUpdate(location)
@@ -249,7 +273,10 @@ class LocationLayerControllerTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.forceLocationUpdate(location)
         TestingAsyncUtils.waitForLayer(uiController, idlingResource.mapView)
@@ -276,7 +303,10 @@ class LocationLayerControllerTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.applyStyle(LocationComponentOptions.builder(context).staleStateTimeout(1).build())
         styleChangeIdlingResource.waitForStyle(mapboxMap, MAPBOX_HEAVY_STYLE)
@@ -299,7 +329,10 @@ class LocationLayerControllerTest : EspressoTest() {
         styleChangeIdlingResource.waitForStyle(mapboxMap, MAPBOX_HEAVY_STYLE)
         uiController.loopMainThreadForAtLeast(100)
         var show = true
-        component.activateLocationComponent(context, mapboxMap.style!!, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, mapboxMap.style!!)
+                .useDefaultLocationEngine(false)
+                .build())
         pushSourceUpdates(styleChangeIdlingResource) {
           component.isLocationComponentEnabled = show
           show = !show
@@ -319,7 +352,10 @@ class LocationLayerControllerTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(location), 16.0))
         component.forceLocationUpdate(location)
@@ -339,7 +375,10 @@ class LocationLayerControllerTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.forceLocationUpdate(location)
 
@@ -369,7 +408,10 @@ class LocationLayerControllerTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.forceLocationUpdate(location)
 
@@ -397,7 +439,10 @@ class LocationLayerControllerTest : EspressoTest() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
       override fun onLocationComponentAction(component: LocationComponent, mapboxMap: MapboxMap,
                                              style: Style, uiController: UiController, context: Context) {
-        component.activateLocationComponent(context, style, false)
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
         component.isLocationComponentEnabled = true
         component.forceLocationUpdate(location)
         TestingAsyncUtils.waitForLayer(uiController, idlingResource.mapView)

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -862,6 +862,17 @@
                 android:value=".activity.FeatureOverviewActivity" />
         </activity>
         <activity
+            android:name=".activity.location.LocationComponentActivationActivity"
+            android:description="@string/description_location_activation_builder"
+            android:label="@string/activity_location_activation_builder">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_location" />
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".activity.FeatureOverviewActivity" />
+        </activity>
+        <activity
                 android:name=".activity.maplayout.RecyclerViewActivity"
                 android:description="@string/description_recyclerview"
                 android:label="@string/activity_recyclerview">

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationComponentActivationActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationComponentActivationActivity.java
@@ -5,7 +5,6 @@ import android.graphics.Color;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
-import android.util.Log;
 import android.widget.Toast;
 
 import com.mapbox.android.core.permissions.PermissionsListener;

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationComponentActivationActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationComponentActivationActivity.java
@@ -87,6 +87,7 @@ public class LocationComponentActivationActivity extends AppCompatActivity imple
 
     LocationComponentActivationOptions locationComponentActivationOptions = LocationComponentActivationOptions
       .builder(this, style)
+      .locationComponentOptions(locationComponentOptions)
       .useDefaultLocationEngine(true)
       .build();
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationComponentActivationActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationComponentActivationActivity.java
@@ -13,6 +13,7 @@ import com.mapbox.android.core.permissions.PermissionsManager;
 import com.mapbox.mapboxsdk.location.LocationComponent;
 import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions;
 import com.mapbox.mapboxsdk.location.LocationComponentOptions;
+import com.mapbox.mapboxsdk.location.modes.CameraMode;
 import com.mapbox.mapboxsdk.location.modes.RenderMode;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
@@ -81,18 +82,18 @@ public class LocationComponentActivationActivity extends AppCompatActivity imple
       .elevation(5)
       .accuracyAlpha(.6f)
       .accuracyColor(Color.GREEN)
-      .foregroundDrawable(R.drawable.mapbox_marker_icon_default)
+      .foregroundDrawable(R.drawable.mapbox_logo_helmet)
       .build();
 
     LocationComponentActivationOptions locationComponentActivationOptions = LocationComponentActivationOptions
       .builder(this, style)
-      .locationComponentOptions(locationComponentOptions)
       .useDefaultLocationEngine(true)
       .build();
 
     locationComponent.activateLocationComponent(locationComponentActivationOptions);
     locationComponent.setLocationComponentEnabled(true);
-    locationComponent.setRenderMode(RenderMode.COMPASS);
+    locationComponent.setRenderMode(RenderMode.NORMAL);
+    locationComponent.setCameraMode(CameraMode.TRACKING);
   }
 
   @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationComponentActivationActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationComponentActivationActivity.java
@@ -1,0 +1,139 @@
+package com.mapbox.mapboxsdk.testapp.activity.location;
+
+import android.annotation.SuppressLint;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+import android.widget.Toast;
+
+import com.mapbox.android.core.permissions.PermissionsListener;
+import com.mapbox.android.core.permissions.PermissionsManager;
+import com.mapbox.mapboxsdk.location.LocationComponent;
+import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions;
+import com.mapbox.mapboxsdk.location.LocationComponentOptions;
+import com.mapbox.mapboxsdk.location.modes.RenderMode;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.testapp.R;
+
+import java.util.List;
+
+public class LocationComponentActivationActivity extends AppCompatActivity implements OnMapReadyCallback {
+
+  private MapView mapView;
+  private MapboxMap mapboxMap;
+  private PermissionsManager permissionsManager;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_location_layer_activation_builder);
+
+    mapView = findViewById(R.id.mapView);
+
+    mapView.onCreate(savedInstanceState);
+
+    if (PermissionsManager.areLocationPermissionsGranted(this)) {
+      mapView.getMapAsync(this);
+    } else {
+      permissionsManager = new PermissionsManager(new PermissionsListener() {
+        @Override
+        public void onExplanationNeeded(List<String> permissionsToExplain) {
+          Toast.makeText(LocationComponentActivationActivity.this, "You need to accept location permissions.",
+            Toast.LENGTH_SHORT).show();
+        }
+
+        @Override
+        public void onPermissionResult(boolean granted) {
+          if (granted) {
+            mapView.getMapAsync(LocationComponentActivationActivity.this);
+          } else {
+            finish();
+          }
+        }
+      });
+      permissionsManager.requestLocationPermissions(this);
+    }
+  }
+
+  @Override
+  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+    permissionsManager.onRequestPermissionsResult(requestCode, permissions, grantResults);
+  }
+
+  @Override
+  public void onMapReady(@NonNull MapboxMap mapboxMap) {
+    this.mapboxMap = mapboxMap;
+    mapboxMap.setStyle(Style.DARK,
+      style -> activateLocationComponent(style));
+  }
+
+  @SuppressLint("MissingPermission")
+  private void activateLocationComponent(@NonNull Style style) {
+    LocationComponent locationComponent = mapboxMap.getLocationComponent();
+
+    LocationComponentOptions locationComponentOptions = LocationComponentOptions.builder(this)
+      .elevation(5)
+      .accuracyAlpha(.6f)
+      .accuracyColor(Color.GREEN)
+      .foregroundDrawable(R.drawable.mapbox_marker_icon_default)
+      .build();
+
+    LocationComponentActivationOptions locationComponentActivationOptions = LocationComponentActivationOptions
+      .builder(this, style)
+      .locationComponentOptions(locationComponentOptions)
+      .useDefaultLocationEngine(true)
+      .build();
+
+    locationComponent.activateLocationComponent(locationComponentActivationOptions);
+    locationComponent.setLocationComponentEnabled(true);
+    locationComponent.setRenderMode(RenderMode.COMPASS);
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationFragmentActivity.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationFragmentActivity.kt
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.testapp.activity.location
 
 import android.annotation.SuppressLint
 import android.app.Fragment
-import android.location.Location
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.view.LayoutInflater
@@ -10,21 +9,18 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import android.widget.Toast
-import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineCallback
-import com.mapbox.android.core.location.LocationEngineProvider
 import com.mapbox.android.core.location.LocationEngineResult
 import com.mapbox.android.core.permissions.PermissionsListener
 import com.mapbox.android.core.permissions.PermissionsManager
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
 import com.mapbox.mapboxsdk.geometry.LatLng
+import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions
 import com.mapbox.mapboxsdk.maps.MapView
 import com.mapbox.mapboxsdk.maps.MapboxMap
-import com.mapbox.mapboxsdk.location.LocationComponent
 import com.mapbox.mapboxsdk.maps.Style
 import com.mapbox.mapboxsdk.testapp.R
 import kotlinx.android.synthetic.main.activity_location_layer_fragment.*
-import java.lang.Exception
 
 class LocationFragmentActivity : AppCompatActivity() {
   private lateinit var permissionsManager: PermissionsManager
@@ -105,10 +101,15 @@ class LocationFragmentActivity : AppCompatActivity() {
       mapView.getMapAsync {
         mapboxMap = it
         it.setStyle(Style.MAPBOX_STREETS) { style ->
-            val component = mapboxMap.locationComponent
-            component.activateLocationComponent(activity, style)
-            component.isLocationComponentEnabled = true
-            component.locationEngine?.getLastLocation(this)
+          val component = mapboxMap.locationComponent
+
+          component.activateLocationComponent(LocationComponentActivationOptions
+                  .builder(activity, style)
+                  .useDefaultLocationEngine(true)
+                  .build())
+
+          component.isLocationComponentEnabled = true
+          component.locationEngine?.getLastLocation(this)
         }
       }
     }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationMapChangeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationMapChangeActivity.java
@@ -7,9 +7,11 @@ import android.support.design.widget.FloatingActionButton;
 import android.support.v7.app.AppCompatActivity;
 import android.widget.Toast;
 
+import com.mapbox.android.core.location.LocationEngineRequest;
 import com.mapbox.android.core.permissions.PermissionsListener;
 import com.mapbox.android.core.permissions.PermissionsManager;
 import com.mapbox.mapboxsdk.location.LocationComponent;
+import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions;
 import com.mapbox.mapboxsdk.location.modes.RenderMode;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
@@ -80,7 +82,13 @@ public class LocationMapChangeActivity extends AppCompatActivity implements OnMa
   @SuppressLint("MissingPermission")
   private void activateLocationComponent(@NonNull Style style) {
     LocationComponent locationComponent = mapboxMap.getLocationComponent();
-    locationComponent.activateLocationComponent(this, style);
+
+    locationComponent.activateLocationComponent(
+      LocationComponentActivationOptions
+        .builder(this, style)
+        .useDefaultLocationEngine(true)
+        .build());
+
     locationComponent.setLocationComponentEnabled(true);
     locationComponent.setRenderMode(RenderMode.COMPASS);
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationMapChangeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationMapChangeActivity.java
@@ -7,7 +7,6 @@ import android.support.design.widget.FloatingActionButton;
 import android.support.v7.app.AppCompatActivity;
 import android.widget.Toast;
 
-import com.mapbox.android.core.location.LocationEngineRequest;
 import com.mapbox.android.core.permissions.PermissionsListener;
 import com.mapbox.android.core.permissions.PermissionsManager;
 import com.mapbox.mapboxsdk.location.LocationComponent;

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationModesActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationModesActivity.java
@@ -2,7 +2,6 @@ package com.mapbox.mapboxsdk.testapp.activity.location;
 
 import android.annotation.SuppressLint;
 import android.content.res.Configuration;
-import android.graphics.Color;
 import android.location.Location;
 import android.os.Bundle;
 import android.support.annotation.NonNull;

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationModesActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationModesActivity.java
@@ -2,6 +2,7 @@ package com.mapbox.mapboxsdk.testapp.activity.location;
 
 import android.annotation.SuppressLint;
 import android.content.res.Configuration;
+import android.graphics.Color;
 import android.location.Location;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -18,6 +19,7 @@ import com.mapbox.android.core.permissions.PermissionsListener;
 import com.mapbox.android.core.permissions.PermissionsManager;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.location.LocationComponent;
+import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions;
 import com.mapbox.mapboxsdk.location.LocationComponentOptions;
 import com.mapbox.mapboxsdk.location.OnCameraTrackingChangedListener;
 import com.mapbox.mapboxsdk.location.OnLocationCameraTransitionListener;
@@ -126,12 +128,16 @@ public class LocationModesActivity extends AppCompatActivity implements OnMapRea
 
     mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
       locationComponent = mapboxMap.getLocationComponent();
-      locationComponent.activateLocationComponent(this, style, true,
-        new LocationEngineRequest.Builder(750)
-          .setFastestInterval(750)
-          .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
-          .build()
-      );
+      locationComponent.activateLocationComponent(
+        LocationComponentActivationOptions
+          .builder(this, style)
+          .useDefaultLocationEngine(true)
+          .locationEngineRequest(new LocationEngineRequest.Builder(750)
+            .setFastestInterval(750)
+            .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
+            .build())
+          .build());
+
       toggleStyle();
       locationComponent.setLocationComponentEnabled(true);
       locationComponent.addOnLocationClickListener(this);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/ManualLocationUpdatesActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/ManualLocationUpdatesActivity.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v7.app.AppCompatActivity;
 import android.widget.Toast;
+
 import com.mapbox.android.core.location.LocationEngine;
 import com.mapbox.android.core.location.LocationEngineProvider;
 import com.mapbox.android.core.location.LocationEngineRequest;
@@ -13,6 +14,7 @@ import com.mapbox.android.core.permissions.PermissionsListener;
 import com.mapbox.android.core.permissions.PermissionsManager;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
 import com.mapbox.mapboxsdk.location.LocationComponent;
+import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions;
 import com.mapbox.mapboxsdk.location.modes.RenderMode;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
@@ -109,14 +111,16 @@ public class ManualLocationUpdatesActivity extends AppCompatActivity implements 
   public void onMapReady(@NonNull MapboxMap mapboxMap) {
     mapboxMap.setStyle(new Style.Builder().fromUrl(Style.MAPBOX_STREETS), style -> {
       locationComponent = mapboxMap.getLocationComponent();
+
       locationComponent.activateLocationComponent(
-        this,
-        style,
-        locationEngine,
-        new LocationEngineRequest.Builder(500)
-          .setFastestInterval(500)
-          .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
+        LocationComponentActivationOptions
+          .builder(this, style)
+          .locationEngine(locationEngine)
+          .locationEngineRequest(new LocationEngineRequest.Builder(500)
+            .setFastestInterval(500)
+            .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY).build())
           .build());
+
       locationComponent.setLocationComponentEnabled(true);
       locationComponent.setRenderMode(RenderMode.COMPASS);
     });

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_location_layer_activation_builder.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_location_layer_activation_builder.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinator_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginBottom="0dp"
+        app:mapbox_uiAttribution="false"/>
+
+</android.support.design.widget.CoordinatorLayout>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
@@ -75,6 +75,7 @@
     <string name="description_location_modes">Showcases location render and tracking modes</string>
     <string name="description_location_fragment">Uses LocationComponent in a Fragment</string>
     <string name="description_location_manual">Force location updates and don\'t rely on the engine</string>
+    <string name="description_location_activation_builder">Use LocationComponentActivationOptions to set options</string>
     <string name="description_recyclerview">Show a MapView as a recyclerView item</string>
     <string name="description_nested_viewpager">Show a MapView inside a viewpager inside a recyclerView</string>
 </resources>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
@@ -75,6 +75,7 @@
     <string name="activity_location_modes">Location Modes Activity</string>
     <string name="activity_location_fragment">Location Fragment</string>
     <string name="activity_location_manual">Manual Location updates</string>
+    <string name="activity_location_activation_builder">Build Location Activation</string>
     <string name="activity_recyclerview">RecyclerView</string>
     <string name="activity_nested_viewpager">Nested ViewPager</string>
 </resources>


### PR DESCRIPTION
This pr adds a builder to activate the `LocationComponent` and resolves https://github.com/mapbox/mapbox-gl-native/issues/13931.