### PR TITLE
[ios] Enable test run-order randomization

### DIFF
--- a/platform/darwin/test/MGLAttributionInfoTests.m
+++ b/platform/darwin/test/MGLAttributionInfoTests.m
@@ -9,6 +9,14 @@
 
 @implementation MGLAttributionInfoTests
 
+- (void)setUp {
+    [MGLAccountManager setAccessToken:@"pk.feedcafedeadbeefbadebede"];
+}
+
+- (void)tearDown {
+    [MGLAccountManager setAccessToken:nil];
+}
+
 - (void)testParsing {
     static NSString * const htmlStrings[] = {
         @"<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\">&copy; Mapbox</a> "
@@ -50,7 +58,7 @@
     XCTAssertEqualObjects([infos[3] feedbackURLAtCenterCoordinate:mapbox zoomLevel:14],
                           [NSURL URLWithString:@"https://apps.mapbox.com/feedback/?referrer=com.mapbox.Mapbox#/77.63680/12.98108/14.00/0.0/0"]);
     XCTAssertEqualObjects([infos[3] feedbackURLForStyleURL:styleURL atCenterCoordinate:mapbox zoomLevel:3.14159 direction:90.9 pitch:12.5],
-                          [NSURL URLWithString:@"https://apps.mapbox.com/feedback/?referrer=com.mapbox.Mapbox&owner=mapbox&id=satellite-streets-v99&access_token&map_sdk_version=1.0.0#/77.63680/12.98108/3.14/90.9/13"]);
+                          [NSURL URLWithString:@"https://apps.mapbox.com/feedback/?referrer=com.mapbox.Mapbox&owner=mapbox&id=satellite-streets-v99&access_token=pk.feedcafedeadbeefbadebede&map_sdk_version=1.0.0#/77.63680/12.98108/3.14/90.9/13"]);
 }
 
 - (void)testStyle {

--- a/platform/darwin/test/MGLMapViewTests.m
+++ b/platform/darwin/test/MGLMapViewTests.m
@@ -36,6 +36,7 @@ static MGLMapView *mapView;
 
 + (void)tearDown {
     mapView = nil;
+    [MGLAccountManager setAccessToken:nil];
     [super tearDown];
 }
 

--- a/platform/ios/Integration Tests/MGLMapViewIntegrationTest.m
+++ b/platform/ios/Integration Tests/MGLMapViewIntegrationTest.m
@@ -57,6 +57,7 @@
     self.renderFinishedExpectation = nil;
     self.mapView = nil;
     self.style = nil;
+    [MGLAccountManager setAccessToken:nil];
 
     [super tearDown];
 }

--- a/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/dynamic.xcscheme
+++ b/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/dynamic.xcscheme
@@ -43,7 +43,8 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "DA2E88501CC036F400F24E7B"

--- a/platform/ios/test/MGLMapViewLayoutTests.m
+++ b/platform/ios/test/MGLMapViewLayoutTests.m
@@ -58,6 +58,7 @@
 - (void)tearDown {
     self.styleLoadingExpectation = nil;
     self.mapView = nil;
+    [MGLAccountManager setAccessToken:nil];
 
     [super tearDown];
 }

--- a/platform/ios/test/MGLMapViewScaleBarTests.m
+++ b/platform/ios/test/MGLMapViewScaleBarTests.m
@@ -19,6 +19,7 @@
 
 - (void)tearDown {
     self.mapView = nil;
+    [MGLAccountManager setAccessToken:nil];
 
     [super tearDown];
 }


### PR DESCRIPTION
Enable Xcode 10’s [“Randomize execution order”](https://useyourloaf.com/blog/xcode-10-random-and-parallel-tests/) setting for tests, so that we might be alerted to tests that mistakenly rely on shared state from the default deterministic order of execution.

May (or may not) rely on #13943 being fixed first.

/cc @mapbox/maps-ios 