### PR TITLE
Ignore android-nitpick's non-zero exit value when updating submodules

### DIFF
--- a/platform/android/gradle/android-nitpick.gradle
+++ b/platform/android/gradle/android-nitpick.gradle
@@ -17,6 +17,7 @@ task androidNitpick {
         exec {
             workingDir = "${rootDir}"
             commandLine "git", "submodule", "update", "--init", "--recursive", "vendor"
+            ignoreExitValue = true
         }
         verifyVendorSubmodulePin(MAPBOX_JAVA_DIR, MAPBOX_JAVA_TAG_PREFIX, versions.mapboxServices)
         verifyVendorSubmodulePin(MAPBOX_TELEMETRY_DIR, MAPBOX_TELEMETRY_TAG_PREFIX, versions.mapboxTelemetry)


### PR DESCRIPTION
`android-nitpick` CI job is failing sporadically because the submodule update returns non-zero value which crashes Gradle's execute block. I'm not seeing any other solution for now besides ignoring that.

/cc @tmpsantos @rclee 