### PR TITLE
LatLngBounds: Fix constrain when crossing antimeridian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ test/fixtures/storage/assets.zip
 buck-out
 .buckd
 
+# Generated file from npm/yarn
+package-lock.json
+
 # Visual Studio Code
 .vscode
 mapbox-gl-native.code-workspace

--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -127,15 +127,7 @@ public:
                       (sw.longitude() + ne.longitude()) / 2);
     }
 
-    LatLng constrain(const LatLng& p) const {
-        if (contains(p)) {
-            return p;
-        }
-        return LatLng {
-            util::clamp(p.latitude(), sw.latitude(), ne.latitude()),
-            util::clamp(p.longitude(), sw.longitude(), ne.longitude())
-        };
-    }
+    LatLng constrain(const LatLng& p) const;
 
     void extend(const LatLng& point) {
         sw = LatLng(std::min(point.latitude(), sw.latitude()),
@@ -170,6 +162,9 @@ private:
 
     LatLngBounds(LatLng sw_, LatLng ne_)
         : sw(std::move(sw_)), ne(std::move(ne_)) {}
+
+    bool containsLatitude(double latitude) const;
+    bool containsLongitude(double longitude, LatLng::WrapMode wrap) const;
 
     friend bool operator==(const LatLngBounds& a, const LatLngBounds& b) {
         return a.sw == b.sw && a.ne == b.ne;

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -124,7 +124,7 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
     const double startScale = state.scale;
     const double startAngle = state.angle;
     const double startPitch = state.pitch;
-    state.panning = latLng != startLatLng;
+    state.panning = unwrappedLatLng != startLatLng;
     state.scaling = scale != startScale;
     state.rotating = angle != startAngle;
 

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -46,7 +46,7 @@ public:
         @param offset The distance to pan the map by, measured in pixels from
             top to bottom and from left to right. */
     void moveBy(const ScreenCoordinate& offset, const AnimationOptions& = {});
-    LatLng getLatLng(const EdgeInsets& = {}) const;
+    LatLng getLatLng(const EdgeInsets& = {}, LatLng::WrapMode = LatLng::Wrapped) const;
     ScreenCoordinate getScreenCoordinate(const EdgeInsets& = {}) const;
 
     // Bounds

--- a/src/mbgl/util/geo.cpp
+++ b/src/mbgl/util/geo.cpp
@@ -39,35 +39,12 @@ bool LatLngBounds::contains(const CanonicalTileID& tileID) const {
 }
 
 bool LatLngBounds::contains(const LatLng& point, LatLng::WrapMode wrap /*= LatLng::Unwrapped*/) const {
-    bool containsLatitude = point.latitude() >= sw.latitude() &&
-                            point.latitude() <= ne.latitude();
-    if (!containsLatitude) {
-        return false;
-    }
-
-    bool containsUnwrappedLongitude = point.longitude() >= sw.longitude() &&
-                                      point.longitude() <= ne.longitude();
-    if (containsUnwrappedLongitude) {
-        return true;
-    } else if (wrap == LatLng::Wrapped) {
-        LatLngBounds wrapped(sw.wrapped(), ne.wrapped());
-        auto ptLon = point.wrapped().longitude();
-        if (crossesAntimeridian()) {
-            return (ptLon >= wrapped.sw.longitude() &&
-                    ptLon <= util::LONGITUDE_MAX) ||
-                   (ptLon <= wrapped.ne.longitude() &&
-                    ptLon >= -util::LONGITUDE_MAX);
-        } else {
-            return (ptLon >= wrapped.sw.longitude() &&
-                    ptLon <= wrapped.ne.longitude());
-        }
-    }
-    return false;
+    return containsLatitude(point.latitude()) && containsLongitude(point.longitude(), wrap);
 }
 
 bool LatLngBounds::contains(const LatLngBounds& area, LatLng::WrapMode wrap /*= LatLng::Unwrapped*/) const {
-    bool containsLatitude = area.north() <= north() && area.south() >= south();
-    if (!containsLatitude) {
+    bool containsAreaLatitude = area.north() <= north() && area.south() >= south();
+    if (!containsAreaLatitude) {
         return false;
     }
 
@@ -111,6 +88,44 @@ bool LatLngBounds::intersects(const LatLngBounds area, LatLng::WrapMode wrap /*=
                    other.west() < wrapped.east();
         }
     }
+    return false;
+}
+
+LatLng LatLngBounds::constrain(const LatLng& p) const {
+    double lat = p.latitude();
+    double lng = p.longitude();
+
+    if (!containsLatitude(lat)) {
+        lat = util::clamp(lat, south(), north());
+    }
+
+    if (!containsLongitude(lng, LatLng::Unwrapped)) {
+        lng = util::clamp(lng, west(), east());
+    }
+
+    return LatLng { lat, lng };
+}
+
+bool LatLngBounds::containsLatitude(double latitude) const {
+    return latitude >= south() && latitude <= north();
+}
+
+bool LatLngBounds::containsLongitude(double longitude, LatLng::WrapMode wrap) const {
+    if (longitude >= west() && longitude <= east()) {
+        return true;
+    }
+
+    if (wrap == LatLng::Wrapped) {
+        LatLngBounds wrapped(sw.wrapped(), ne.wrapped());
+        longitude = LatLng(0.0, longitude).wrapped().longitude();
+        if (crossesAntimeridian()) {
+            return (longitude >= -util::LONGITUDE_MAX && longitude <= wrapped.east()) ||
+                   (longitude >= wrapped.west() && longitude <= util::LONGITUDE_MAX);
+        }
+
+        return longitude >= wrapped.west() && longitude <= wrapped.east();
+    }
+
     return false;
 }
 

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -468,6 +468,23 @@ TEST(Transform, Camera) {
     ASSERT_DOUBLE_EQ(transform.getLatLng().longitude(), 0);
 }
 
+TEST(Transform, IsPanning)
+{
+    Transform transform;
+
+    AnimationOptions easeOptions(Seconds(1));
+    easeOptions.transitionFrameFn = [&transform](double) {
+        ASSERT_TRUE(transform.getState().isPanning());
+    };
+
+    transform.resize({ 1000, 1000 });
+    transform.easeTo(CameraOptions().withCenter(LatLng(0, 360.0)), easeOptions);
+    transform.updateTransitions(transform.getTransitionStart() + Milliseconds(250));
+    transform.updateTransitions(transform.getTransitionStart() + Milliseconds(500));
+    transform.updateTransitions(transform.getTransitionStart() + Milliseconds(750));
+    transform.updateTransitions(transform.getTransitionStart() + transform.getTransitionDuration());
+}
+
 TEST(Transform, DefaultTransform) {
     struct TransformObserver : public mbgl::MapObserver {
         void onCameraWillChange(MapObserver::CameraChangeMode) final {


### PR DESCRIPTION
This PR fixes the constraint behavior when crossing the antimeridian, but also:
- Fixes an issue that caused panning to be set to false when the longitude value that was equal to its wrapped one e.g. when doing a full round over the globe;
- Constrain axes separately in LatLngBounds: this fixes an issue when the bounds crosses the antimeridian and only latitude needed to be constrained;

This PR is an alternative to #13906.

Closes #13672, follow up from #13871

/cc @tobrun 