### PR TITLE
Initialize vendor submodules as a CI step

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -535,6 +535,9 @@ jobs:
     steps:
       - install-dependencies: { gradle: true }
       - run:
+          name: Initialize vendor submodules
+          command: git submodule update --init platform/android/vendor
+      - run:
           name: Android nitpick
           command: make run-android-nitpick
       - run:
@@ -598,6 +601,9 @@ jobs:
       IS_LOCAL_DEVELOPMENT: false
     steps:
       - install-dependencies: { gradle: true }
+      - run:
+          name: Initialize vendor submodules
+          command: git submodule update --init platform/android/vendor
       - run:
           name: Android nitpick
           command: make run-android-nitpick

--- a/platform/android/gradle/android-nitpick.gradle
+++ b/platform/android/gradle/android-nitpick.gradle
@@ -14,11 +14,6 @@ task androidNitpick {
         println "Running android nitpick script"
 
         println "Verify vendor submodule pins"
-        exec {
-            workingDir = "${rootDir}"
-            commandLine "git", "submodule", "update", "--init", "--recursive", "vendor"
-            ignoreExitValue = true
-        }
         verifyVendorSubmodulePin(MAPBOX_JAVA_DIR, MAPBOX_JAVA_TAG_PREFIX, versions.mapboxServices)
         verifyVendorSubmodulePin(MAPBOX_TELEMETRY_DIR, MAPBOX_TELEMETRY_TAG_PREFIX, versions.mapboxTelemetry)
         verifyVendorSubmodulePin(MAPBOX_GESTURES_DIR, MAPBOX_GESTURES_TAG_PREFIX, versions.mapboxGestures)
@@ -26,6 +21,7 @@ task androidNitpick {
 }
 
 private def verifyVendorSubmodulePin(def dir, def prefix, def version) {
+    println "Verify vendor submodule pin: ${dir} (${prefix + version})"
     exec {
         workingDir = "${rootDir}/vendor/${dir}"
         commandLine "git", "fetch", "-t"

--- a/platform/android/gradle/gradle-update-vendor-modules.gradle
+++ b/platform/android/gradle/gradle-update-vendor-modules.gradle
@@ -1,5 +1,8 @@
 task updateVendorSubmodules {
     doLast {
-        "git submodule update --init --recursive vendor".execute()
+        exec {
+            workingDir = "${rootDir}"
+            commandLine "git", "submodule", "update", "--init", "vendor"
+        }
     }
 }


### PR DESCRIPTION
We've recently seen `android-nitpick` jobs failing because of uninitialized submodules. This PR tries to initialize the submodules as a CI step (which has been working reliably for all other tests) in addition to the init calls from Gradle (for local development).