### PR TITLE
[android] fix surface creation after app backgrounding  for surfaceview

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
@@ -25,6 +25,8 @@ public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceVi
   @NonNull
   private final GLSurfaceView glSurfaceView;
 
+  private boolean requestDestroy;
+
   public GLSurfaceViewMapRenderer(Context context,
                                   GLSurfaceView glSurfaceView,
                                   String localIdeographFontFamily) {
@@ -40,7 +42,7 @@ public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceVi
 
       @Override
       public void surfaceDestroyed(SurfaceHolder holder) {
-        GLSurfaceViewMapRenderer.this.onSurfaceDestroyed();
+        requestDestroy = true;
       }
 
     });
@@ -52,8 +54,26 @@ public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceVi
   }
 
   @Override
+  public void onPause() {
+    super.onPause();
+  }
+
+  @Override
+  public void onDestroy() {
+    if (requestDestroy) {
+      onSurfaceDestroyed();
+    }
+    super.onDestroy();
+  }
+
+  @Override
   public void onStart() {
     glSurfaceView.onResume();
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
   }
 
   @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -76,6 +76,7 @@ dependencies {
     androidTestImplementation dependenciesList.testEspressoCore
     androidTestImplementation dependenciesList.testEspressoIntents
     androidTestImplementation dependenciesList.testEspressoContrib
+    androidTestImplementation dependenciesList.testUiAutomator
 }
 
 apply from: "${rootDir}/gradle/gradle-make.gradle"

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:tools="http://schemas.android.com/tools" package="${applicationId}">
+    <uses-sdk tools:overrideLibrary="android.support.test.uiautomator.v18"/>
+</manifest>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/GLSurfaceViewReopenTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/GLSurfaceViewReopenTest.kt
@@ -1,0 +1,77 @@
+package com.mapbox.mapboxsdk.maps
+
+import android.content.Intent
+import android.support.test.InstrumentationRegistry
+import android.support.test.filters.SdkSuppress
+import android.support.test.runner.AndroidJUnit4
+import android.support.test.uiautomator.*
+import org.hamcrest.CoreMatchers.notNullValue
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.lang.Thread.sleep
+import android.support.test.uiautomator.UiSelector
+import android.support.test.uiautomator.UiScrollable
+
+private const val BASIC_SAMPLE_PACKAGE = "com.mapbox.mapboxsdk.testapp"
+private const val LAUNCH_TIMEOUT = 5000L
+
+@RunWith(AndroidJUnit4::class)
+@SdkSuppress(minSdkVersion = 18)
+class GLSurfaceViewReopenTest {
+
+    private lateinit var device: UiDevice
+
+    @Before
+    fun startSimpleMapActivityFromHomeScreen() {
+        // Initialize UiDevice instance
+        device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+        // Start from the home screen
+        device.pressHome()
+
+        // Wait for launcher
+        val launcherPackage: String = device.launcherPackageName
+        assertThat(launcherPackage, notNullValue())
+        device.wait(Until.hasObject(By.pkg(launcherPackage).depth(0)), LAUNCH_TIMEOUT)
+
+        // Launch the app
+        val context = InstrumentationRegistry.getInstrumentation().context
+        val intent = context.packageManager.getLaunchIntentForPackage(BASIC_SAMPLE_PACKAGE).apply {
+            // Clear out any previous instances
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        }
+        context.startActivity(intent)
+
+        // Wait for the app to appear
+        device.wait(
+                Until.hasObject(By.pkg(BASIC_SAMPLE_PACKAGE).depth(0)),
+                LAUNCH_TIMEOUT
+        )
+
+        // open TextureView debug activity
+        val appView = UiScrollable(UiSelector().scrollable(true))
+        appView.scrollIntoView(UiSelector().text("TextureView debug"))
+        device.findObject(UiSelector().text("TextureView debug")).clickAndWaitForNewWindow()
+
+        // wait for idle
+        device.waitForIdle(LAUNCH_TIMEOUT)
+    }
+
+    @Test
+    fun reopenTextureViewDebugActivity() {
+        // return to home screen
+        device.pressHome()
+
+        // press recent apps button
+        device.pressRecentApps()
+
+        // click to reopen app
+        device.findObject(UiSelector().description("Mapbox Android SDK TestApp")).click()
+
+        // wait for idle
+        device.waitForIdle(LAUNCH_TIMEOUT)
+        sleep(LAUNCH_TIMEOUT)
+    }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/GLSurfaceViewReopenTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/GLSurfaceViewReopenTest.kt
@@ -11,8 +11,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.lang.Thread.sleep
-import android.support.test.uiautomator.UiSelector
-import android.support.test.uiautomator.UiScrollable
 
 private const val BASIC_SAMPLE_PACKAGE = "com.mapbox.mapboxsdk.testapp"
 private const val LAUNCH_TIMEOUT = 5000L
@@ -50,21 +48,19 @@ class GLSurfaceViewReopenTest {
                 LAUNCH_TIMEOUT
         )
 
-        // open TextureView debug activity
-        val appView = UiScrollable(UiSelector().scrollable(true))
-        appView.scrollIntoView(UiSelector().text("TextureView debug"))
-        device.findObject(UiSelector().text("TextureView debug")).clickAndWaitForNewWindow()
+        // open SimpleMapActivity
+        device.findObject(UiSelector().text("Simple Map")).clickAndWaitForNewWindow()
 
         // wait for idle
         device.waitForIdle(LAUNCH_TIMEOUT)
     }
 
     @Test
-    fun reopenTextureViewDebugActivity() {
+    fun reopenSimpleMapActivity() {
         // return to home screen
         device.pressHome()
 
-        // press recent apps button
+        // press recents apps button
         device.pressRecentApps()
 
         // click to reopen app

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/TextureViewReopenTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/TextureViewReopenTest.kt
@@ -1,0 +1,73 @@
+package com.mapbox.mapboxsdk.maps
+
+import android.content.Intent
+import android.support.test.InstrumentationRegistry
+import android.support.test.filters.SdkSuppress
+import android.support.test.runner.AndroidJUnit4
+import android.support.test.uiautomator.*
+import org.hamcrest.CoreMatchers.notNullValue
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.lang.Thread.sleep
+
+private const val BASIC_SAMPLE_PACKAGE = "com.mapbox.mapboxsdk.testapp"
+private const val LAUNCH_TIMEOUT = 5000L
+
+@RunWith(AndroidJUnit4::class)
+@SdkSuppress(minSdkVersion = 18)
+class TextureViewReopenTest {
+
+    private lateinit var device: UiDevice
+
+    @Before
+    fun startSimpleMapActivityFromHomeScreen() {
+        // Initialize UiDevice instance
+        device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+        // Start from the home screen
+        device.pressHome()
+
+        // Wait for launcher
+        val launcherPackage: String = device.launcherPackageName
+        assertThat(launcherPackage, notNullValue())
+        device.wait(Until.hasObject(By.pkg(launcherPackage).depth(0)), LAUNCH_TIMEOUT)
+
+        // Launch the app
+        val context = InstrumentationRegistry.getInstrumentation().context
+        val intent = context.packageManager.getLaunchIntentForPackage(BASIC_SAMPLE_PACKAGE).apply {
+            // Clear out any previous instances
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        }
+        context.startActivity(intent)
+
+        // Wait for the app to appear
+        device.wait(
+                Until.hasObject(By.pkg(BASIC_SAMPLE_PACKAGE).depth(0)),
+                LAUNCH_TIMEOUT
+        )
+
+        // open SimpleMapActivity
+        device.findObject(UiSelector().text("Simple Map")).clickAndWaitForNewWindow()
+
+        // wait for idle
+        device.waitForIdle(LAUNCH_TIMEOUT)
+    }
+
+    @Test
+    fun reopenSimpleMapActivity() {
+        // return to home screen
+        device.pressHome()
+
+        // press recents apps button
+        device.pressRecentApps()
+
+        // click to reopen app
+        device.findObject(UiSelector().description("Mapbox Android SDK TestApp")).click()
+
+        // wait for idle
+        device.waitForIdle(LAUNCH_TIMEOUT)
+        sleep(LAUNCH_TIMEOUT)
+    }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/TextureViewReopenTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/TextureViewReopenTest.kt
@@ -11,6 +11,8 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.lang.Thread.sleep
+import android.support.test.uiautomator.UiSelector
+import android.support.test.uiautomator.UiScrollable
 
 private const val BASIC_SAMPLE_PACKAGE = "com.mapbox.mapboxsdk.testapp"
 private const val LAUNCH_TIMEOUT = 5000L
@@ -48,19 +50,21 @@ class TextureViewReopenTest {
                 LAUNCH_TIMEOUT
         )
 
-        // open SimpleMapActivity
-        device.findObject(UiSelector().text("Simple Map")).clickAndWaitForNewWindow()
+        // open TextureView debug activity
+        val appView = UiScrollable(UiSelector().scrollable(true))
+        appView.scrollIntoView(UiSelector().text("TextureView debug"))
+        device.findObject(UiSelector().text("TextureView debug")).clickAndWaitForNewWindow()
 
         // wait for idle
         device.waitForIdle(LAUNCH_TIMEOUT)
     }
 
     @Test
-    fun reopenSimpleMapActivity() {
+    fun reopenTextureViewDebugActivity() {
         // return to home screen
         device.pressHome()
 
-        // press recents apps button
+        // press recent apps button
         device.pressRecentApps()
 
         // click to reopen app

--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -12,6 +12,7 @@ ext {
             mapboxGestures  : '0.4.0',
             supportLib      : '27.1.1',
             constraintLayout: '1.1.2',
+            uiAutomator     : '2.1.3',
             espresso        : '3.0.2',
             testRunner      : '1.0.2',
             leakCanary      : '1.6.2',
@@ -45,6 +46,7 @@ ext {
             testEspressoCore       : "com.android.support.test.espresso:espresso-core:${versions.espresso}",
             testEspressoIntents    : "com.android.support.test.espresso:espresso-intents:${versions.espresso}",
             testEspressoContrib    : "com.android.support.test.espresso:espresso-contrib:${versions.espresso}",
+            testUiAutomator        : "com.android.support.test.uiautomator:uiautomator-v18:${versions.uiAutomator}",
 
             supportAnnotations     : "com.android.support:support-annotations:${versions.supportLib}",
             supportAppcompatV7     : "com.android.support:appcompat-v7:${versions.supportLib}",

--- a/platform/android/src/map_renderer.cpp
+++ b/platform/android/src/map_renderer.cpp
@@ -184,7 +184,12 @@ void MapRenderer::onSurfaceCreated(JNIEnv&) {
     }
 }
 
-void MapRenderer::onSurfaceChanged(JNIEnv&, jint width, jint height) {
+void MapRenderer::onSurfaceChanged(JNIEnv& env, jint width, jint height) {
+    if (!renderer) {
+        // In case the surface has been destroyed (due to app back-grounding)
+        onSurfaceCreated(env);
+    }
+
     backend->resizeFramebuffer(width, height);
     framebufferSizeChanged = true;
     requestRender();

--- a/platform/android/src/map_renderer.hpp
+++ b/platform/android/src/map_renderer.hpp
@@ -94,7 +94,9 @@ private:
 
     void onSurfaceChanged(JNIEnv&, jint width, jint height);
 
-    // Called on Main thread
+private:
+    // Called on either Main or GL thread //
+
     void onSurfaceDestroyed(JNIEnv&);
 
 private:


### PR DESCRIPTION
When using the GLSurfaceView  with setPreserveEGLContextOnPause set to true, the onContextCreated from GLSurfaceView#Renderer is never called when resuming an activity. In this case, MapRenderer#onSurfaceChanged will just assume the EGL context is still alive and create a new Renderer and RenderBackend.

@tobrun Thanks for the test case!

Fixes #13417