### PR TITLE
Expose MGLMapView OpenGL context to OpenGL style layers

### DIFF
--- a/platform/darwin/src/MGLOpenGLStyleLayer.h
+++ b/platform/darwin/src/MGLOpenGLStyleLayer.h
@@ -27,6 +27,12 @@ MGL_EXPORT
 
 @property (nonatomic, weak, readonly) MGLStyle *style;
 
+#if TARGET_OS_IPHONE
+@property (nonatomic, readonly) EAGLContext *context;
+#else
+@property (nonatomic, readonly) CGLContextObj context;
+#endif
+
 - (instancetype)initWithIdentifier:(NSString *)identifier;
 
 - (void)didMoveToMapView:(MGLMapView *)mapView;

--- a/platform/darwin/src/MGLOpenGLStyleLayer.mm
+++ b/platform/darwin/src/MGLOpenGLStyleLayer.mm
@@ -107,6 +107,16 @@ private:
     return (mbgl::style::CustomLayer *)super.rawLayer;
 }
 
+#if TARGET_OS_IPHONE
+- (EAGLContext *)context {
+    return self.style.mapView.context;
+}
+#else
+- (CGLContextObj)context {
+    return self.style.mapView.context;
+}
+#endif
+
 #pragma mark - Adding to and removing from a map view
 - (void)addToStyle:(MGLStyle *)style belowLayer:(MGLStyleLayer *)otherLayer {
     self.style = style;

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -195,7 +195,7 @@ public:
                           MGLMultiPointDelegate,
                           MGLAnnotationImageDelegate>
 
-@property (nonatomic) EAGLContext *context;
+@property (nonatomic, readwrite) EAGLContext *context;
 @property (nonatomic) GLKView *glView;
 @property (nonatomic) UIImageView *glSnapshotView;
 

--- a/platform/ios/src/MGLMapView_Private.h
+++ b/platform/ios/src/MGLMapView_Private.h
@@ -13,6 +13,9 @@ FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLUnderlyingMapUnavailableE
 
 @interface MGLMapView (Private)
 
+/// The map view’s OpenGL rendering context.
+@property (nonatomic, readonly) EAGLContext *context;
+
 /// Currently shown popover representing the selected annotation.
 @property (nonatomic) UIView<MGLCalloutView> *calloutViewForSelectedAnnotation;
 

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -707,6 +707,11 @@ public:
     return !_isTargetingInterfaceBuilder;
 }
 
+- (CGLContextObj)context {
+    MGLOpenGLLayer *layer = _isTargetingInterfaceBuilder ? nil : (MGLOpenGLLayer *)self.layer;
+    return layer.openGLContext.CGLContextObj;
+}
+
 - (void)setFrame:(NSRect)frame {
     super.frame = frame;
     if (!_isTargetingInterfaceBuilder) {

--- a/platform/macos/src/MGLMapView_Private.h
+++ b/platform/macos/src/MGLMapView_Private.h
@@ -22,6 +22,9 @@ namespace mbgl {
 /// Center longitude set independently of the center latitude in an inspectable.
 @property (nonatomic) CLLocationDegrees pendingLongitude;
 
+/// The map view’s OpenGL rendering context.
+- (CGLContextObj)context;
+
 /// Asynchronously render a frame of the map.
 - (void)setNeedsGLDisplay;
 


### PR DESCRIPTION
Added a property to MGLOpenGLStyleLayer that contains the map view’s underlying OpenGL rendering context.

Fixes #12945.

/cc @fabian-guerra @julianrex