### PR TITLE
Verify no native method is called when saving state

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -500,7 +500,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
    */
   @UiThread
   public void onLowMemory() {
-    if (nativeMapView != null) {
+    if (nativeMapView != null && !destroyed) {
       nativeMapView.onLowMemory();
     }
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
@@ -161,7 +161,7 @@ public class SupportMapFragment extends Fragment implements OnMapReadyCallback {
   @Override
   public void onSaveInstanceState(@NonNull Bundle outState) {
     super.onSaveInstanceState(outState);
-    if (map != null && !map.isDestroyed()) {
+    if (map != null) {
       map.onSaveInstanceState(outState);
     }
   }
@@ -181,7 +181,7 @@ public class SupportMapFragment extends Fragment implements OnMapReadyCallback {
   @Override
   public void onLowMemory() {
     super.onLowMemory();
-    if (map != null && !map.isDestroyed()) {
+    if (map != null) {
       map.onLowMemory();
     }
   }

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/MapboxMapTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/MapboxMapTest.kt
@@ -5,10 +5,7 @@ import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.geometry.LatLngBounds
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.spyk
-import io.mockk.verify
+import io.mockk.*
 import junit.framework.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -27,19 +24,11 @@ class MapboxMapTest {
     @Before
     fun setup() {
         val cameraChangeDispatcher = spyk<CameraChangeDispatcher>()
-        nativeMapView = mockk()
-        transform = mockk()
-        mapboxMap = MapboxMap(nativeMapView, transform, null, null, null, cameraChangeDispatcher)
-        every { nativeMapView.styleUrl = any() } answers {}
-        every { nativeMapView.transitionOptions = any() } answers {}
+        nativeMapView = mockk(relaxed = true)
+        transform = mockk(relaxed = true)
+        mapboxMap = MapboxMap(nativeMapView, transform, mockk(relaxed = true), null, null, cameraChangeDispatcher)
         every { nativeMapView.isDestroyed } returns false
-        every { nativeMapView.setOnFpsChangedListener(any()) } answers {}
-        every { nativeMapView.prefetchTiles = any() } answers {}
         every { nativeMapView.nativePtr } returns 5
-        every { nativeMapView.setLatLngBounds(any()) } answers {}
-        every { transform.minZoom = any() } answers {}
-        every { transform.maxZoom = any() } answers {}
-        every { transform.moveCamera(any(), any(), any()) } answers {}
         mapboxMap.injectLocationComponent(spyk())
         mapboxMap.setStyle(Style.MAPBOX_STREETS)
         mapboxMap.onFinishLoadingStyle()
@@ -108,4 +97,11 @@ class MapboxMapTest {
     fun testGetNativeMapPtr() {
         assertEquals(5, mapboxMap.nativeMapPtr)
     }
+
+  @Test
+  fun testNativeMapIsNotCalledOnStateSave() {
+    clearMocks(nativeMapView)
+    mapboxMap.onSaveInstanceState(mockk(relaxed = true))
+    verify { nativeMapView wasNot Called }
+  }
 }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/13560.

After investigating the potential map leak it turns out that calls to the `MapView` from a fragment that's in a backstack can be justified in order to save state. Because the system is not going to dispatch save state calls when the view is being destroyed, the only chance to save state for a fragment that contains a map can be when it's already been replaced during a transition.

The only thing we need to ensure is that during saving state process there are no calls to the native peer, because the renderer can already be destroyed, which has already been done in https://github.com/mapbox/mapbox-gl-native/pull/13638, this PR adds a test for that case.