### PR TITLE
[ios, build] Trigger automated site and docs generation during releases

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -994,6 +994,7 @@ jobs:
             export VERSION_TAG=${CIRCLE_TAG}
             export GITHUB_TOKEN=${DANGER_GITHUB_API_TOKEN}
             platform/ios/scripts/deploy-packages.sh
+            platform/ios/scripts/trigger-external-deploy-steps.sh
       - save-dependencies
       - collect-xcode-build-logs
       - upload-xcode-build-logs

--- a/platform/ios/scripts/install-packaging-dependencies.sh
+++ b/platform/ios/scripts/install-packaging-dependencies.sh
@@ -9,7 +9,14 @@ function finish { >&2 echo -en "\033[0m"; }
 trap finish EXIT
 
 step "Installing packaging dependencies…"
-brew install awscli wget
+
+if [ -z `which aws` ]; then
+    brew install awscli
+fi
+
+if [ -z `which wget` ]; then
+    brew install wget
+fi
 
 if [ -z `which jazzy` ]; then
     step "Installing jazzy…"

--- a/platform/ios/scripts/trigger-external-deploy-steps.sh
+++ b/platform/ios/scripts/trigger-external-deploy-steps.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
+function finish { >&2 echo -en "\033[0m"; }
+trap finish EXIT
+
+SDK_FLAVOR=${SDK_FLAVOR:-"maps"}
+
+step "Triggering automated site and documentation generation for ${SDK_FLAVOR} SDK ${VERSION_TAG}"
+
+request_body="{
+  \"request\": {
+    \"message\": \"[${SDK_FLAVOR}] ${VERSION_TAG} automated site and documentation generation\",
+    \"config\": {
+      \"merge_mode\": \"deep_merge\",
+      \"env\": {
+        \"SDK_FLAVOR\": \"${SDK_FLAVOR}\",
+        \"RELEASE_TAG\": \"${VERSION_TAG}\"
+      }
+    }
+  }
+}"
+
+step "Making request…"
+
+curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "Travis-API-Version: 3" \
+  -H "Authorization: token ${TRAVISCI_API_TOKEN}" \
+  -d "${request_body}" \
+  https://api.travis-ci.com/repo/mapbox%2Fios-sdk/requests


### PR DESCRIPTION
Adds a script to the `ios-release-tag` CI job that triggers an external CI job on our documentation repo (that then builds the docs there).

/cc @mapbox/maps-ios 