### PR TITLE
[ios] Make PingFang as the default local font family

### DIFF
--- a/platform/darwin/src/MGLRendererConfiguration.h
+++ b/platform/darwin/src/MGLRendererConfiguration.h
@@ -34,8 +34,9 @@ MGL_EXPORT
  Currently only used for CJK glyphs. Changing this at run time is not currently
  supported. Enable client-side rendering of CJK glyphs by setting
  `MGLIdeographicFontFamilyName` in your containing app's Info.plist to a value
- which will be available at run time, e.g. "PingFang". */
-@property (nonatomic, readonly) mbgl::optional<std::string> localFontFamilyName;
+ which will be available at run time. Default font for local ideograph font family
+ is "PingFang". */
+@property (nonatomic, readonly) std::string localFontFamilyName;
 
 /**
  A Boolean value indicating whether symbol layers may enable per-source symbol

--- a/platform/darwin/src/MGLRendererConfiguration.mm
+++ b/platform/darwin/src/MGLRendererConfiguration.mm
@@ -77,10 +77,10 @@ static NSString * const MGLCollisionBehaviorPre4_0Key = @"MGLCollisionBehaviorPr
     return mbgl::optional<std::string>();
 }
 
-- (mbgl::optional<std::string>)localFontFamilyName {
+- (std::string)localFontFamilyName {
     NSString *fontFamilyName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"MGLIdeographicFontFamilyName"];
 
-    return fontFamilyName ? std::string([fontFamilyName UTF8String]) : mbgl::optional<std::string>();
+    return fontFamilyName ? std::string([fontFamilyName UTF8String]) : std::string("PingFang");
 }
 
 @end

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Improved tilt gesture performance. ([#13902](https://github.com/mapbox/mapbox-gl-native/pull/13902))
 * Fixed a bug where `layoutSubviews` was always called on device rotation, regardless of the application's or top-most view controller's supported orientations. ([#13900](https://github.com/mapbox/mapbox-gl-native/pull/13900))
 * Added `MGLNetworkConfiguration` class to customize the SDK's `NSURLSessionConfiguration` object. ([#11447](https://github.com/mapbox/mapbox-gl-native/pull/13886))
+* Made PingFang as the default local font family for CJK glyphs. ([#13988](https://github.com/mapbox/mapbox-gl-native/pull/13988))
 
 ## 4.8.0 - January 30, 2019
 


### PR DESCRIPTION
Without set `localIdeographicFontFamily` would slowdown maps containing CJK fonts. We should switch "localIdeographicFontFamily" default to "on".