### PR TITLE
Replace remaining hardcoded delays with the idle event

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/maps/StyleLoadTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/maps/StyleLoadTest.kt
@@ -10,6 +10,7 @@ import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
 import com.mapbox.mapboxsdk.testapp.action.MapboxMapAction
 import com.mapbox.mapboxsdk.testapp.activity.EspressoTest
 import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity
+import com.mapbox.mapboxsdk.testapp.utils.TestingAsyncUtils
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -32,9 +33,9 @@ class StyleLoadTest : EspressoTest() {
             val source = GeoJsonSource("id")
             val layer = SymbolLayer("id", "id")
             mapboxMap.setStyle(Style.Builder().withSource(source).withLayer(layer))
-            uiController.loopMainThreadForAtLeast(100)
+            TestingAsyncUtils.waitForLayer(uiController, mapView)
             mapboxMap.setStyle(Style.Builder().fromUrl(Style.MAPBOX_STREETS))
-            uiController.loopMainThreadForAtLeast(100)
+            TestingAsyncUtils.waitForLayer(uiController, mapView)
             source.setGeoJson("{}")
         }
     }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CustomGeometrySourceTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CustomGeometrySourceTest.kt
@@ -12,6 +12,7 @@ import com.mapbox.mapboxsdk.testapp.activity.BaseTest
 import com.mapbox.mapboxsdk.testapp.activity.style.GridSourceActivity
 import com.mapbox.mapboxsdk.testapp.activity.style.GridSourceActivity.ID_GRID_LAYER
 import com.mapbox.mapboxsdk.testapp.activity.style.GridSourceActivity.ID_GRID_SOURCE
+import com.mapbox.mapboxsdk.testapp.utils.TestingAsyncUtils
 import org.junit.Assert
 import org.junit.Ignore
 import org.junit.Test
@@ -41,9 +42,9 @@ class CustomGeometrySourceTest : BaseTest() {
     validateTestSetup()
     invoke(mapboxMap) { uiController, mapboxMap ->
       mapboxMap.style!!.removeLayer(ID_GRID_LAYER)
-      uiController.loopMainThreadForAtLeast(3000)
+      TestingAsyncUtils.waitForLayer(uiController, idlingResource.mapView)
       mapboxMap.style!!.removeSource(ID_GRID_SOURCE)
-      uiController.loopMainThreadForAtLeast(1000)
+      TestingAsyncUtils.waitForLayer(uiController, idlingResource.mapView)
       Assert.assertTrue("There should be no threads running when the source is removed.",
         Thread.getAllStackTraces().keys.filter {
           it.name.startsWith(CustomGeometrySource.THREAD_PREFIX)
@@ -57,12 +58,12 @@ class CustomGeometrySourceTest : BaseTest() {
     validateTestSetup()
     invoke(mapboxMap) { uiController, mapboxMap ->
       mapboxMap.style!!.removeLayer((rule.activity as GridSourceActivity).layer)
-      uiController.loopMainThreadForAtLeast(3000)
+      TestingAsyncUtils.waitForLayer(uiController, idlingResource.mapView)
       mapboxMap.style!!.removeSource(ID_GRID_SOURCE)
-      uiController.loopMainThreadForAtLeast(1000)
+      TestingAsyncUtils.waitForLayer(uiController, idlingResource.mapView)
       mapboxMap.style!!.addSource((rule.activity as GridSourceActivity).source)
       mapboxMap.style!!.addLayer((rule.activity as GridSourceActivity).layer)
-      uiController.loopMainThreadForAtLeast(1000)
+      TestingAsyncUtils.waitForLayer(uiController, idlingResource.mapView)
       Assert.assertTrue("Threads should be restarted when the source is re-added to the map.",
         Thread.getAllStackTraces().keys.filter {
           it.name.startsWith(CustomGeometrySource.THREAD_PREFIX)

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/ExpressionTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/ExpressionTest.java
@@ -250,7 +250,7 @@ public class ExpressionTest extends EspressoTest {
           )
         ));
       mapboxMap.getStyle().addLayer(layer);
-      uiController.loopMainThreadForAtLeast(1000);
+      TestingAsyncUtils.INSTANCE.waitForLayer(uiController, idlingResource.getMapView());
       assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")
         .isEmpty());
 
@@ -260,7 +260,7 @@ public class ExpressionTest extends EspressoTest {
           literal(ColorUtils.colorToRgbaString(Color.RED))
         )
       ));
-      uiController.loopMainThreadForAtLeast(1000);
+      TestingAsyncUtils.INSTANCE.waitForLayer(uiController, idlingResource.getMapView());
       assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")
         .isEmpty());
 
@@ -270,7 +270,7 @@ public class ExpressionTest extends EspressoTest {
           literal(ColorUtils.colorToRgbaString(Color.RED))
         )
       ));
-      uiController.loopMainThreadForAtLeast(1000);
+      TestingAsyncUtils.INSTANCE.waitForLayer(uiController, idlingResource.getMapView());
       assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")
         .isEmpty());
     });

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/GeoJsonSourceTests.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/GeoJsonSourceTests.java
@@ -16,6 +16,7 @@ import com.mapbox.mapboxsdk.testapp.R;
 import com.mapbox.mapboxsdk.testapp.action.MapboxMapAction;
 import com.mapbox.mapboxsdk.testapp.activity.EspressoTest;
 import com.mapbox.mapboxsdk.testapp.utils.ResourceUtils;
+import com.mapbox.mapboxsdk.testapp.utils.TestingAsyncUtils;
 
 import org.hamcrest.Matcher;
 import org.junit.Test;
@@ -26,7 +27,7 @@ import java.io.IOException;
 import timber.log.Timber;
 
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for {@link GeoJsonSource}
@@ -93,11 +94,10 @@ public class GeoJsonSourceTests extends EspressoTest {
       }
 
       source.setGeoJson(Point.fromLngLat(20, 55));
-      uiController.loopMainThreadForAtLeast(1000);
-      assertTrue(
-        mapboxMap.queryRenderedFeatures(
-          mapboxMap.getProjection().toScreenLocation(
-            new LatLng(55, 20)), "layer").size() == 1);
+      TestingAsyncUtils.INSTANCE.waitForLayer(uiController, idlingResource.getMapView());
+      assertEquals(1, mapboxMap.queryRenderedFeatures(
+        mapboxMap.getProjection().toScreenLocation(
+          new LatLng(55, 20)), "layer").size());
     });
   }
 


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gl-native/pull/13913 and replaces all remaining hardcoded delays in favor of the `onIdle` event. This should resolve the flakiness of the tests like https://circleci.com/gh/mapbox/mapbox-gl-native/235346.