### PR TITLE
Clear singleton instance of Mapbox after running unit tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -544,14 +544,14 @@ jobs:
           name: Check code style
           command: make android-check
       - run:
+          name: Run Android unit tests
+          command: make run-android-unit-test
+      - run:
           name: Build libmapbox-gl.so for arm-v7
           command: make android-lib-arm-v7
       - run:
           name: Compile Core tests for arm-v7
           command: make android-test-lib-arm-v7
-      - run:
-          name: Test phone module
-          command: make run-android-unit-test
       - run:
           name: Generate Espresso sanity tests
           command: make test-code-android

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/MapboxTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/MapboxTest.java
@@ -2,6 +2,7 @@ package com.mapbox.mapboxsdk;
 
 import android.content.Context;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -68,12 +69,27 @@ public class MapboxTest {
     assertFalse(Mapbox.isAccessTokenValid("blabla"));
   }
 
+  @After
+  public void after() {
+    clearMapboxSingleton();
+  }
+
   private void injectMapboxSingleton(String accessToken) {
     Mapbox mapbox = new Mapbox(context, accessToken);
     try {
       Field field = Mapbox.class.getDeclaredField("INSTANCE");
       field.setAccessible(true);
       field.set(mapbox, mapbox);
+    } catch (Exception exception) {
+      throw new AssertionError();
+    }
+  }
+
+  private void clearMapboxSingleton() {
+    try {
+      Field field = Mapbox.class.getDeclaredField("INSTANCE");
+      field.setAccessible(true);
+      field.set(field, null);
     } catch (Exception exception) {
       throw new AssertionError();
     }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/13987. Refs https://github.com/mapbox/mapbox-gl-native/pull/13974.

Generally, an attempt of loading the native library during unit tests should fail and be caught [here](https://github.com/mapbox/mapbox-gl-native/blob/master/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/loader/LibraryLoaderProviderImpl.java#L39), however, if the `MapboxTest` has run beforehand, it'd have provided a static, mocked `Context` for this instance of the JVM and allow an attempted native library load during all following tests which as expected fails to provide a valid directory path resulting in an `NPE` inside of the `ReLinker` implementation.