### PR TITLE
[android] Android README link and writing updates

### DIFF
--- a/platform/android/README.md
+++ b/platform/android/README.md
@@ -2,21 +2,27 @@
 
 [![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native/tree/master)
 
+[![](https://www.mapbox.com/android-docs/assets/overview-map-sdk-322-9abe118316efb5910b6101e222a2e57c.png)](https://docs.mapbox.com/android/maps/overview/)
+
 A library based on [Mapbox GL Native](../../README.md) for embedding interactive map views with scalable, customizable vector maps onto Android devices.
 
 ## Getting Started
 
-Alright. So, actually, you may be in the wrong place. From here on in, this README is going to be for people who are interested in working on and improving on Mapbox GL Native for Android.
+Alright. So, actually, you may be in the wrong place. From here on in, this README is going to be for people who are interested in working on and improving the Maps SDK for Android.
 
-**To view our current API documentation, see our [JavaDoc](https://www.mapbox.com/android-sdk/api).**
+Visit [https://docs.mapbox.com/android/maps/overview](https://docs.mapbox.com/android/maps/overview/) to see current documentation on the Maps SDK for Android.
 
-**To install and use the Mapbox Maps SDK for Android in an application, see the [Mapbox Maps SDK for Android website](https://www.mapbox.com/install/android/).**
+To view the current API Javadoc files on the Maps SDK for Android, visit [https://docs.mapbox.com/android/maps/overview](https://docs.mapbox.com/android/maps/overview) and click on `API Reference` towards the top of the page
 
-[![](https://www.mapbox.com/android-docs/assets/overview-map-sdk-322-9abe118316efb5910b6101e222a2e57c.png)](https://www.mapbox.com/android-sdk/)
+![screen shot 2019-02-26 at 11 21 17 am](https://user-images.githubusercontent.com/4394910/53440121-a9f9d900-39b8-11e9-99c0-93719dae4c18.png)
+ 
+
+To install and use the Mapbox Maps SDK for Android in an application, see [the Mapbox website's Android install flow](https://www.mapbox.com/install/android/).
+
 
 ### Setup environment
 
-**These instructions are for developers interested in making code-level contributions to the SDK itself. If you instead want to use the SDK in your app, see above.**
+These instructions are for developers interested in making code-level contributions to the SDK itself. If you instead want to use the SDK in your app, see above.
 
 #### Getting the source
 


### PR DESCRIPTION
This pr updates the Android README file. There was a dead link and other info needed updating.

This pr also finishes https://github.com/mapbox/mapbox-gl-native/pull/9372 . Once https://github.com/mapbox/android-docs/issues/123 lands, we can update the link to API javadocs in this repo's Android README file.

cc @colleenmcginnis 