### PR TITLE
[android] Update to changelog with stable 7.2.0 changes

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -4,6 +4,14 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 
 ## master
 
+## 7.2.0 - February 27, 2019
+
+### Bugs
+- fix surface creation after app backgrounding for surfaceview[#13976](https://github.com/mapbox/mapbox-gl-native/pull/13976)
+
+### Features
+- make ReLinker default library loader[#13974](https://github.com/mapbox/mapbox-gl-native/pull/13974)
+
 ## 7.2.0-beta.1 - February 21, 2019
 
 ### Bugs
@@ -11,7 +19,6 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 
 ### Features
 - Set localIdeographFontFamily default to sans-serif[#13925](https://github.com/mapbox/mapbox-gl-native/pull/13925)
-
 
 ## 7.2.0-alpha.2 - February 14, 2019
 

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -9,9 +9,6 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 ### Bugs
 - fix surface creation after app backgrounding for surfaceview[#13976](https://github.com/mapbox/mapbox-gl-native/pull/13976)
 
-### Features
-- make ReLinker default library loader[#13974](https://github.com/mapbox/mapbox-gl-native/pull/13974)
-
 ## 7.2.0-beta.1 - February 21, 2019
 
 ### Bugs


### PR DESCRIPTION
Adds stable 7.2.0 version changes to Android changelog. Part of today's stable 7.2.0 release.