### PR TITLE
[android] Cherrypick for changelog update for stable 7.2.0 release

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -4,6 +4,11 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 
 ## master
 
+## 7.2.0 - February 27, 2019
+
+### Bugs
+- fix surface creation after app backgrounding for surfaceview[#13976](https://github.com/mapbox/mapbox-gl-native/pull/13976)
+
 ## 7.2.0-beta.1 - February 21, 2019
 
 ### Bugs


### PR DESCRIPTION
Cherrypicks https://github.com/mapbox/mapbox-gl-native/pull/14003 into `kombucha` branch for the stable `7.2.0` release of the Maps SDK for Android.