### PR TITLE
[core] Map camera setters/getters cleanup

### DIFF
--- a/benchmark/api/query.benchmark.cpp
+++ b/benchmark/api/query.benchmark.cpp
@@ -23,7 +23,7 @@ public:
         fileSource.setAccessToken("foobar");
 
         map.getStyle().loadJSON(util::read_file("benchmark/fixtures/api/style.json"));
-        map.setLatLngZoom({ 40.726989, -73.992857 }, 15); // Manhattan
+        map.jumpTo(CameraOptions().withCenter(LatLng { 40.726989, -73.992857 }).withZoom(15.0)); // Manhattan
         map.getStyle().addImage(std::make_unique<style::Image>("test-icon",
             decodeImage(util::read_file("benchmark/fixtures/api/default_marker.png")), 1.0));
 

--- a/benchmark/api/render.benchmark.cpp
+++ b/benchmark/api/render.benchmark.cpp
@@ -31,7 +31,7 @@ public:
     
 static void prepare(Map& map, optional<std::string> json = {}) {
     map.getStyle().loadJSON(json ? *json : util::read_file("benchmark/fixtures/api/style.json"));
-    map.setLatLngZoom({ 40.726989, -73.992857 }, 15); // Manhattan
+    map.jumpTo(CameraOptions().withCenter(LatLng { 40.726989, -73.992857 }).withZoom(15.0)); // Manhattan
     map.getStyle().addImage(std::make_unique<style::Image>("test-icon",
                                                            decodeImage(util::read_file("benchmark/fixtures/api/default_marker.png")), 1.0));
 }

--- a/benchmark/util/tilecover.benchmark.cpp
+++ b/benchmark/util/tilecover.benchmark.cpp
@@ -22,7 +22,7 @@ static void TileCoverPitchedViewport(benchmark::State& state) {
     Transform transform;
     transform.resize({ 512, 512 });
     // slightly offset center so that tile order is better defined
-    transform.jumpTo(CameraOptions().withCenter(LatLng { 0.1, -0.1 }).withZoom(8.0).withAngle(5.0).withPitch(40.0));
+    transform.jumpTo(CameraOptions().withCenter(LatLng { 0.1, -0.1 }).withZoom(8.0).withBearing(5.0).withPitch(40.0));
 
     std::size_t length = 0;
     while (state.KeepRunning()) {

--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -94,7 +94,7 @@ int main(int argc, char *argv[]) {
     map.jumpTo(CameraOptions()
                    .withCenter(LatLng { lat, lon })
                    .withZoom(zoom)
-                   .withAngle(bearing)
+                   .withBearing(bearing)
                    .withPitch(pitch));
 
     if (debug) {

--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -91,9 +91,11 @@ int main(int argc, char *argv[]) {
     }
 
     map.getStyle().loadURL(style);
-    map.setLatLngZoom({ lat, lon }, zoom);
-    map.setBearing(bearing);
-    map.setPitch(pitch);
+    map.jumpTo(CameraOptions()
+                   .withCenter(LatLng { lat, lon })
+                   .withZoom(zoom)
+                   .withAngle(bearing)
+                   .withPitch(pitch));
 
     if (debug) {
         map.setDebug(debug ? mbgl::MapDebugOptions::TileBorders | mbgl::MapDebugOptions::ParseStatus : mbgl::MapDebugOptions::NoDebug);

--- a/include/mbgl/map/camera.hpp
+++ b/include/mbgl/map/camera.hpp
@@ -19,7 +19,7 @@ struct CameraOptions {
     CameraOptions& withPadding(const EdgeInsets& p) { padding = p; return *this; }
     CameraOptions& withAnchor(const optional<ScreenCoordinate>& o) { anchor = o; return *this; }
     CameraOptions& withZoom(const optional<double>& o) { zoom = o; return *this; }
-    CameraOptions& withAngle(const optional<double>& o) { angle = o; return *this; }
+    CameraOptions& withBearing(const optional<double>& o) { bearing = o; return *this; }
     CameraOptions& withPitch(const optional<double>& o) { pitch = o; return *this; }
 
     /** Coordinate at the center of the map. */
@@ -38,7 +38,7 @@ struct CameraOptions {
     optional<double> zoom;
 
     /** Bearing, measured in degrees from true north. Wrapped to [0, 360). */
-    optional<double> angle;
+    optional<double> bearing;
 
     /** Pitch toward the horizon measured in degrees , with 0 deg resulting in a
         two-dimensional map. */
@@ -50,7 +50,7 @@ constexpr bool operator==(const CameraOptions& a, const CameraOptions& b) {
         && a.padding == b.padding
         && a.anchor == b.anchor
         && a.zoom == b.zoom
-        && a.angle == b.angle
+        && a.bearing == b.bearing
         && a.pitch == b.pitch;
 }
 

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -100,12 +100,6 @@ public:
 
     // Rotation
     void rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second, const AnimationOptions& = {});
-    void setBearing(double degrees, const AnimationOptions& = {});
-    void setBearing(double degrees, optional<ScreenCoordinate>, const AnimationOptions& = {});
-    void setBearing(double degrees, const EdgeInsets&, const AnimationOptions& = {});
-    double getBearing() const;
-    void resetNorth(const AnimationOptions& = {{mbgl::Milliseconds(500)}});
-    void resetNorth(const EdgeInsets&, const AnimationOptions& = {{mbgl::Milliseconds(500)}});
 
     // North Orientation
     void setNorthOrientation(NorthOrientation);

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -64,7 +64,7 @@ public:
     bool isPanning() const;
 
     // Camera
-    CameraOptions getCameraOptions(const EdgeInsets&) const;
+    CameraOptions getCameraOptions(const EdgeInsets& = {}) const;
     void jumpTo(const CameraOptions&);
     void easeTo(const CameraOptions&, const AnimationOptions&);
     void flyTo(const CameraOptions&, const AnimationOptions&);
@@ -81,14 +81,7 @@ public:
     void resetPosition(const EdgeInsets& = {});
 
     // Zoom
-    void scaleBy(double scale, optional<ScreenCoordinate> anchor, const AnimationOptions& animation);
-    void setZoom(double zoom, const AnimationOptions& = {});
-    void setZoom(double zoom, optional<ScreenCoordinate>, const AnimationOptions& = {});
-    void setZoom(double zoom, const EdgeInsets&, const AnimationOptions& = {});
-    double getZoom() const;
-    void setLatLngZoom(const LatLng&, double zoom, const AnimationOptions& = {});
-    void setLatLngZoom(const LatLng&, double zoom, const EdgeInsets&, const AnimationOptions& = {});
-    void resetZoom();
+    void scaleBy(double scale, optional<ScreenCoordinate> anchor, const AnimationOptions& animation = {});
 
     // Pitch
     void pitchBy(double pitch, const AnimationOptions& animation = {});
@@ -159,9 +152,9 @@ public:
     // Tile prefetching
     //
     // When loading a map, if `PrefetchZoomDelta` is set to any number greater than 0, the map will
-    // first request a tile for `zoom = getZoom() - delta` in a attempt to display a full map at
-    // lower resolution as quick as possible. It will get clamped at the tile source minimum zoom.
-    // The default `delta` is 4.
+    // first request a tile for `zoom - delta` in a attempt to display a full map at lower
+    // resolution as quick as possible. It will get clamped at the tile source minimum zoom. The
+    // default `delta` is 4.
     void setPrefetchZoomDelta(uint8_t delta);
     uint8_t getPrefetchZoomDelta() const;
 

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -90,6 +90,9 @@ public:
     void setLatLngZoom(const LatLng&, double zoom, const EdgeInsets&, const AnimationOptions& = {});
     void resetZoom();
 
+    // Pitch
+    void pitchBy(double pitch, const AnimationOptions& animation = {});
+
     // Bounds
     void setLatLngBounds(optional<LatLngBounds>);
     optional<LatLngBounds> getLatLngBounds() const;

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -107,11 +107,6 @@ public:
     void resetNorth(const AnimationOptions& = {{mbgl::Milliseconds(500)}});
     void resetNorth(const EdgeInsets&, const AnimationOptions& = {{mbgl::Milliseconds(500)}});
 
-    // Pitch
-    void setPitch(double pitch, const AnimationOptions& = {});
-    void setPitch(double pitch, optional<ScreenCoordinate>, const AnimationOptions& = {});
-    double getPitch() const;
-
     // North Orientation
     void setNorthOrientation(NorthOrientation);
     NorthOrientation getNorthOrientation() const;

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -68,19 +68,14 @@ public:
     void jumpTo(const CameraOptions&);
     void easeTo(const CameraOptions&, const AnimationOptions&);
     void flyTo(const CameraOptions&, const AnimationOptions&);
+    void moveBy(const ScreenCoordinate&, const AnimationOptions& = {});
+    void scaleBy(double scale, optional<ScreenCoordinate> anchor, const AnimationOptions& animation = {});
+    void pitchBy(double pitch, const AnimationOptions& animation = {});
+    void rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second, const AnimationOptions& = {});
     CameraOptions cameraForLatLngBounds(const LatLngBounds&, const EdgeInsets&, optional<double> bearing = {}, optional<double> pitch = {}) const;
     CameraOptions cameraForLatLngs(const std::vector<LatLng>&, const EdgeInsets&, optional<double> bearing = {}, optional<double> pitch = {}) const;
     CameraOptions cameraForGeometry(const Geometry<double>&, const EdgeInsets&, optional<double> bearing = {}, optional<double> pitch = {}) const;
     LatLngBounds latLngBoundsForCamera(const CameraOptions&) const;
-
-    // Position
-    void moveBy(const ScreenCoordinate&, const AnimationOptions& = {});
-
-    // Zoom
-    void scaleBy(double scale, optional<ScreenCoordinate> anchor, const AnimationOptions& animation = {});
-
-    // Pitch
-    void pitchBy(double pitch, const AnimationOptions& animation = {});
 
     // Bounds
     void setLatLngBounds(optional<LatLngBounds>);
@@ -93,9 +88,6 @@ public:
     double getMinPitch() const;
     void setMaxPitch(double);
     double getMaxPitch() const;
-
-    // Rotation
-    void rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second, const AnimationOptions& = {});
 
     // North Orientation
     void setNorthOrientation(NorthOrientation);

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -75,10 +75,6 @@ public:
 
     // Position
     void moveBy(const ScreenCoordinate&, const AnimationOptions& = {});
-    void setLatLng(const LatLng&, const EdgeInsets&, const AnimationOptions& = {});
-    void setLatLng(const LatLng&, const AnimationOptions& = {});
-    LatLng getLatLng(const EdgeInsets& = {}) const;
-    void resetPosition(const EdgeInsets& = {});
 
     // Zoom
     void scaleBy(double scale, optional<ScreenCoordinate> anchor, const AnimationOptions& animation = {});

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -81,6 +81,7 @@ public:
     void resetPosition(const EdgeInsets& = {});
 
     // Zoom
+    void scaleBy(double scale, optional<ScreenCoordinate> anchor, const AnimationOptions& animation);
     void setZoom(double zoom, const AnimationOptions& = {});
     void setZoom(double zoom, optional<ScreenCoordinate>, const AnimationOptions& = {});
     void setZoom(double zoom, const EdgeInsets&, const AnimationOptions& = {});

--- a/platform/android/.project
+++ b/platform/android/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>android</name>
+	<comment>Project android created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/platform/android/.settings/org.eclipse.buildship.core.prefs
+++ b/platform/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,2 @@
+connection.project.dir=
+eclipse.preferences.version=1

--- a/platform/android/src/map/camera_position.cpp
+++ b/platform/android/src/map/camera_position.cpp
@@ -14,7 +14,7 @@ jni::Local<jni::Object<CameraPosition>> CameraPosition::New(jni::JNIEnv &env, mb
 
     // convert bearing, measured in radians counterclockwise from true north.
     // Wrapped to [−π rad, π rad). Android binding from 0 to 360 degrees
-    double bearing_degrees = options.angle.value_or(0);
+    double bearing_degrees = options.bearing.value_or(0);
     while (bearing_degrees > 360) {
         bearing_degrees -= 360;
     }

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -439,20 +439,20 @@ void NativeMapView::rotateBy(jni::JNIEnv&, jni::jdouble sx, jni::jdouble sy, jni
 }
 
 void NativeMapView::setBearing(jni::JNIEnv&, jni::jdouble degrees, jni::jlong duration) {
-    map->setBearing(degrees, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
+    map->easeTo(mbgl::CameraOptions().withAngle(degrees), mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
 }
 
 void NativeMapView::setBearingXY(jni::JNIEnv&, jni::jdouble degrees, jni::jdouble cx, jni::jdouble cy, jni::jlong duration) {
-    mbgl::ScreenCoordinate center(cx, cy);
-    map->setBearing(degrees, center, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
+    mbgl::ScreenCoordinate anchor(cx, cy);
+    map->easeTo(mbgl::CameraOptions().withAngle(degrees).withAnchor(anchor), mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
 }
 
 jni::jdouble NativeMapView::getBearing(jni::JNIEnv&) {
-    return map->getBearing();
+    return *map->getCameraOptions().angle;
 }
 
 void NativeMapView::resetNorth(jni::JNIEnv&) {
-    map->resetNorth();
+    map->easeTo(mbgl::CameraOptions().withAngle(0.0), mbgl::AnimationOptions {{mbgl::Milliseconds(500)}});
 }
 
 void NativeMapView::setVisibleCoordinateBounds(JNIEnv& env, const jni::Array<jni::Object<LatLng>>& coordinates, const jni::Object<RectF>& padding, jdouble direction, jni::jlong duration) {

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -395,11 +395,12 @@ void NativeMapView::resetPosition(jni::JNIEnv&) {
 }
 
 jni::jdouble NativeMapView::getPitch(jni::JNIEnv&) {
-    return map->getPitch();
+    return *map->getCameraOptions().pitch;
 }
 
 void NativeMapView::setPitch(jni::JNIEnv&, jni::jdouble pitch, jni::jlong duration) {
-    map->setPitch(pitch, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
+    map->easeTo(mbgl::CameraOptions().withPitch(pitch),
+                mbgl::AnimationOptions{ mbgl::Milliseconds(duration) });
 }
 
 void NativeMapView::setZoom(jni::JNIEnv&, jni::jdouble zoom, jni::jdouble x, jni::jdouble y, jni::jlong duration) {

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -305,10 +305,10 @@ void NativeMapView::moveBy(jni::JNIEnv&, jni::jdouble dx, jni::jdouble dy, jni::
     map->moveBy({dx, dy}, animationOptions);
 }
 
-void NativeMapView::jumpTo(jni::JNIEnv&, jni::jdouble angle, jni::jdouble latitude, jni::jdouble longitude, jni::jdouble pitch, jni::jdouble zoom) {
+void NativeMapView::jumpTo(jni::JNIEnv&, jni::jdouble bearing, jni::jdouble latitude, jni::jdouble longitude, jni::jdouble pitch, jni::jdouble zoom) {
     mbgl::CameraOptions options;
-    if (angle != -1) {
-        options.angle = angle;
+    if (bearing != -1) {
+        options.bearing = bearing;
     }
     options.center = mbgl::LatLng(latitude, longitude);
     options.padding = insets;
@@ -322,10 +322,10 @@ void NativeMapView::jumpTo(jni::JNIEnv&, jni::jdouble angle, jni::jdouble latitu
     map->jumpTo(options);
 }
 
-void NativeMapView::easeTo(jni::JNIEnv&, jni::jdouble angle, jni::jdouble latitude, jni::jdouble longitude, jni::jlong duration, jni::jdouble pitch, jni::jdouble zoom, jni::jboolean easing) {
+void NativeMapView::easeTo(jni::JNIEnv&, jni::jdouble bearing, jni::jdouble latitude, jni::jdouble longitude, jni::jlong duration, jni::jdouble pitch, jni::jdouble zoom, jni::jboolean easing) {
     mbgl::CameraOptions cameraOptions;
-    if (angle != -1) {
-        cameraOptions.angle = angle;
+    if (bearing != -1) {
+        cameraOptions.bearing = bearing;
     }
     cameraOptions.center = mbgl::LatLng(latitude, longitude);
     cameraOptions.padding = insets;
@@ -346,10 +346,10 @@ void NativeMapView::easeTo(jni::JNIEnv&, jni::jdouble angle, jni::jdouble latitu
     map->easeTo(cameraOptions, animationOptions);
 }
 
-void NativeMapView::flyTo(jni::JNIEnv&, jni::jdouble angle, jni::jdouble latitude, jni::jdouble longitude, jni::jlong duration, jni::jdouble pitch, jni::jdouble zoom) {
+void NativeMapView::flyTo(jni::JNIEnv&, jni::jdouble bearing, jni::jdouble latitude, jni::jdouble longitude, jni::jlong duration, jni::jdouble pitch, jni::jdouble zoom) {
     mbgl::CameraOptions cameraOptions;
-    if (angle != -1) {
-        cameraOptions.angle = angle;
+    if (bearing != -1) {
+        cameraOptions.bearing = bearing;
     }
     cameraOptions.center = mbgl::LatLng(latitude, longitude);
     cameraOptions.padding = insets;
@@ -439,20 +439,20 @@ void NativeMapView::rotateBy(jni::JNIEnv&, jni::jdouble sx, jni::jdouble sy, jni
 }
 
 void NativeMapView::setBearing(jni::JNIEnv&, jni::jdouble degrees, jni::jlong duration) {
-    map->easeTo(mbgl::CameraOptions().withAngle(degrees), mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
+    map->easeTo(mbgl::CameraOptions().withBearing(degrees), mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
 }
 
 void NativeMapView::setBearingXY(jni::JNIEnv&, jni::jdouble degrees, jni::jdouble cx, jni::jdouble cy, jni::jlong duration) {
     mbgl::ScreenCoordinate anchor(cx, cy);
-    map->easeTo(mbgl::CameraOptions().withAngle(degrees).withAnchor(anchor), mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
+    map->easeTo(mbgl::CameraOptions().withBearing(degrees).withAnchor(anchor), mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
 }
 
 jni::jdouble NativeMapView::getBearing(jni::JNIEnv&) {
-    return *map->getCameraOptions().angle;
+    return *map->getCameraOptions().bearing;
 }
 
 void NativeMapView::resetNorth(jni::JNIEnv&) {
-    map->easeTo(mbgl::CameraOptions().withAngle(0.0), mbgl::AnimationOptions {{mbgl::Milliseconds(500)}});
+    map->easeTo(mbgl::CameraOptions().withBearing(0.0), mbgl::AnimationOptions {{mbgl::Milliseconds(500)}});
 }
 
 void NativeMapView::setVisibleCoordinateBounds(JNIEnv& env, const jni::Array<jni::Object<LatLng>>& coordinates, const jni::Object<RectF>& padding, jdouble direction, jni::jlong duration) {
@@ -469,7 +469,7 @@ void NativeMapView::setVisibleCoordinateBounds(JNIEnv& env, const jni::Array<jni
     mbgl::EdgeInsets mbglInsets = { RectF::getTop(env, padding), RectF::getLeft(env, padding), RectF::getBottom(env, padding), RectF::getRight(env, padding) };
     mbgl::CameraOptions cameraOptions = map->cameraForLatLngs(latLngs, mbglInsets);
     if (direction >= 0) {
-        cameraOptions.angle = direction;
+        cameraOptions.bearing = direction;
     }
 
     mbgl::AnimationOptions animationOptions;

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -403,15 +403,16 @@ void NativeMapView::setPitch(jni::JNIEnv&, jni::jdouble pitch, jni::jlong durati
 }
 
 void NativeMapView::setZoom(jni::JNIEnv&, jni::jdouble zoom, jni::jdouble x, jni::jdouble y, jni::jlong duration) {
-    map->setZoom(zoom, mbgl::ScreenCoordinate{x,y}, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
+    map->easeTo(mbgl::CameraOptions().withZoom(zoom).withAnchor(mbgl::ScreenCoordinate{ x, y }),
+                mbgl::AnimationOptions{ mbgl::Milliseconds(duration) });
 }
 
 jni::jdouble NativeMapView::getZoom(jni::JNIEnv&) {
-    return map->getZoom();
+    return *map->getCameraOptions().zoom;
 }
 
 void NativeMapView::resetZoom(jni::JNIEnv&) {
-    map->resetZoom();
+    map->jumpTo(mbgl::CameraOptions().withZoom(0.0));
 }
 
 void NativeMapView::setMinZoom(jni::JNIEnv&, jni::jdouble zoom) {

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -366,11 +366,12 @@ void NativeMapView::flyTo(jni::JNIEnv&, jni::jdouble bearing, jni::jdouble latit
 }
 
 jni::Local<jni::Object<LatLng>> NativeMapView::getLatLng(JNIEnv& env) {
-    return LatLng::New(env, map->getLatLng(insets));
+    return LatLng::New(env, *map->getCameraOptions(insets).center);
 }
 
 void NativeMapView::setLatLng(jni::JNIEnv&, jni::jdouble latitude, jni::jdouble longitude, jni::jlong duration) {
-    map->setLatLng(mbgl::LatLng(latitude, longitude), insets, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
+    map->easeTo(mbgl::CameraOptions().withCenter(mbgl::LatLng(latitude, longitude)).withPadding(insets),
+                mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
 }
 
 jni::Local<jni::Object<CameraPosition>> NativeMapView::getCameraForLatLngBounds(jni::JNIEnv& env, const jni::Object<LatLngBounds>& jBounds, double top, double left, double bottom, double right, double bearing, double tilt) {
@@ -391,7 +392,7 @@ void NativeMapView::setReachability(jni::JNIEnv&, jni::jboolean reachable) {
 }
 
 void NativeMapView::resetPosition(jni::JNIEnv&) {
-    map->resetPosition();
+    map->jumpTo(mbgl::CameraOptions().withCenter(mbgl::LatLng {}).withZoom(0.0).withBearing(0.0).withPitch(0.0));
 }
 
 jni::jdouble NativeMapView::getPitch(jni::JNIEnv&) {

--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -607,7 +607,7 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
     if (CLLocationCoordinate2DIsValid(options.camera.centerCoordinate)) {
         cameraOptions.center = MGLLatLngFromLocationCoordinate2D(options.camera.centerCoordinate);
     }
-    cameraOptions.angle = MAX(0, options.camera.heading);
+    cameraOptions.bearing = MAX(0, options.camera.heading);
     cameraOptions.zoom = MAX(0, options.zoomLevel);
     cameraOptions.pitch = MAX(0, options.camera.pitch);
     

--- a/platform/default/src/mbgl/map/map_snapshotter.cpp
+++ b/platform/default/src/mbgl/map/map_snapshotter.cpp
@@ -82,7 +82,7 @@ void MapSnapshotter::Impl::snapshot(ActorRef<MapSnapshotter::Callback> callback)
         // and can be used to translate for geographic to screen
         // coordinates
         assert (frontend.getTransformState());
-        PointForFn pointForFn { [=, center=map.getLatLng(), transformState = *frontend.getTransformState()] (const LatLng& latLng) {
+        PointForFn pointForFn { [=, center = *map.getCameraOptions().center, transformState = *frontend.getTransformState()] (const LatLng& latLng) {
             LatLng unwrappedLatLng = latLng.wrapped();
             unwrappedLatLng.unwrapForShortestPath(center);
             Transform transform { transformState };

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -209,7 +209,7 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
 #endif // MBGL_USE_GLES2
         case GLFW_KEY_N:
             if (!mods)
-                view->map->easeTo(mbgl::CameraOptions().withAngle(0.0), mbgl::AnimationOptions {{mbgl::Milliseconds(500)}});
+                view->map->easeTo(mbgl::CameraOptions().withBearing(0.0), mbgl::AnimationOptions {{mbgl::Milliseconds(500)}});
             break;
         case GLFW_KEY_Z:
             view->nextOrientation();
@@ -273,10 +273,10 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
                 const mbgl::LatLng center { point.y, point.x };
                 auto latLng = *camera.center;
                 double bearing = ruler.bearing({ latLng.longitude(), latLng.latitude() }, point);
-                double easing = bearing - *camera.angle;
+                double easing = bearing - *camera.bearing;
                 easing += easing > 180.0 ? -360.0 : easing < -180 ? 360.0 : 0;
-                bearing = *camera.angle + (easing / 20);
-                routeMap->jumpTo(mbgl::CameraOptions().withCenter(center).withZoom(18.0).withAngle(bearing).withPitch(60.0));
+                bearing = *camera.bearing + (easing / 20);
+                routeMap->jumpTo(mbgl::CameraOptions().withCenter(center).withZoom(18.0).withBearing(bearing).withPitch(60.0));
             };
             view->animateRouteCallback(view->map);
         } break;

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -184,7 +184,7 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
             break;
         case GLFW_KEY_X:
             if (!mods)
-                view->map->resetPosition();
+                view->map->jumpTo(mbgl::CameraOptions().withCenter(mbgl::LatLng {}).withZoom(0.0).withBearing(0.0).withPitch(0.0));
             break;
         case GLFW_KEY_O:
             view->onlineStatusCallback();

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -209,7 +209,7 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
 #endif // MBGL_USE_GLES2
         case GLFW_KEY_N:
             if (!mods)
-                view->map->resetNorth();
+                view->map->easeTo(mbgl::CameraOptions().withAngle(0.0), mbgl::AnimationOptions {{mbgl::Milliseconds(500)}});
             break;
         case GLFW_KEY_Z:
             view->nextOrientation();
@@ -267,13 +267,15 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
                     routeProgress = 0.0;
                 }
 
+                auto camera = routeMap->getCameraOptions();
+
                 auto point = ruler.along(lineString, routeProgress * routeDistance);
                 const mbgl::LatLng center { point.y, point.x };
-                auto latLng = routeMap->getLatLng();
+                auto latLng = *camera.center;
                 double bearing = ruler.bearing({ latLng.longitude(), latLng.latitude() }, point);
-                double easing = bearing - routeMap->getBearing();
+                double easing = bearing - *camera.angle;
                 easing += easing > 180.0 ? -360.0 : easing < -180 ? 360.0 : 0;
-                bearing = routeMap->getBearing() + (easing / 20);
+                bearing = *camera.angle + (easing / 20);
                 routeMap->jumpTo(mbgl::CameraOptions().withCenter(center).withZoom(18.0).withAngle(bearing).withPitch(60.0));
             };
             view->animateRouteCallback(view->map);

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -553,7 +553,7 @@ void GLFWView::onMouseMove(GLFWwindow *window, double x, double y) {
     } else if (view->pitching) {
         const double dy = y - view->lastY;
         if (dy) {
-            view->map->setPitch(view->map->getPitch() - dy / 2);
+            view->map->pitchBy(dy / 2);
         }
     }
     view->lastX = x;

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -487,7 +487,7 @@ void GLFWView::onScroll(GLFWwindow *window, double /*xOffset*/, double yOffset) 
         scale = 1.0 / scale;
     }
 
-    view->map->setZoom(view->map->getZoom() + ::log2(scale), mbgl::ScreenCoordinate { view->lastX, view->lastY });
+    view->map->scaleBy(scale, mbgl::ScreenCoordinate { view->lastX, view->lastY });
 }
 
 void GLFWView::onWindowResize(GLFWwindow *window, int width, int height) {
@@ -530,9 +530,9 @@ void GLFWView::onMouseClick(GLFWwindow *window, int button, int action, int modi
             double now = glfwGetTime();
             if (now - view->lastClick < 0.4 /* ms */) {
                 if (modifiers & GLFW_MOD_SHIFT) {
-                    view->map->setZoom(view->map->getZoom() - 1, mbgl::ScreenCoordinate { view->lastX, view->lastY }, mbgl::AnimationOptions{{mbgl::Milliseconds(500)}});
+                    view->map->scaleBy(0.5, mbgl::ScreenCoordinate { view->lastX, view->lastY }, mbgl::AnimationOptions{{mbgl::Milliseconds(500)}});
                 } else {
-                    view->map->setZoom(view->map->getZoom() + 1, mbgl::ScreenCoordinate { view->lastX, view->lastY }, mbgl::AnimationOptions{{mbgl::Milliseconds(500)}});
+                    view->map->scaleBy(2.0, mbgl::ScreenCoordinate { view->lastX, view->lastY }, mbgl::AnimationOptions{{mbgl::Milliseconds(500)}});
                 }
             }
             view->lastClick = now;

--- a/platform/glfw/main.cpp
+++ b/platform/glfw/main.cpp
@@ -117,9 +117,11 @@ int main(int argc, char *argv[]) {
         style = std::string("file://") + style;
     }
 
-    map.setLatLngZoom(mbgl::LatLng(settings.latitude, settings.longitude), settings.zoom);
-    map.setBearing(settings.bearing);
-    map.setPitch(settings.pitch);
+    map.jumpTo(mbgl::CameraOptions()
+                   .withCenter(mbgl::LatLng {settings.latitude, settings.longitude})
+                   .withZoom(settings.zoom)
+                   .withAngle(settings.bearing)
+                   .withPitch(settings.pitch));
     map.setDebug(mbgl::MapDebugOptions(settings.debug));
 
     view->setOnlineStatusCallback([&settings, &fileSource]() {
@@ -172,12 +174,12 @@ int main(int argc, char *argv[]) {
     view->run();
 
     // Save settings
-    mbgl::LatLng latLng = map.getLatLng();
-    settings.latitude = latLng.latitude();
-    settings.longitude = latLng.longitude();
-    settings.zoom = map.getZoom();
-    settings.bearing = map.getBearing();
-    settings.pitch = map.getPitch();
+    mbgl::CameraOptions camera = map.getCameraOptions();
+    settings.latitude = camera.center->latitude();
+    settings.longitude = camera.center->longitude();
+    settings.zoom = *camera.zoom;
+    settings.bearing = *camera.angle;
+    settings.pitch = *camera.pitch;
     settings.debug = mbgl::EnumType(map.getDebug());
     settings.save();
     mbgl::Log::Info(mbgl::Event::General,

--- a/platform/glfw/main.cpp
+++ b/platform/glfw/main.cpp
@@ -120,7 +120,7 @@ int main(int argc, char *argv[]) {
     map.jumpTo(mbgl::CameraOptions()
                    .withCenter(mbgl::LatLng {settings.latitude, settings.longitude})
                    .withZoom(settings.zoom)
-                   .withAngle(settings.bearing)
+                   .withBearing(settings.bearing)
                    .withPitch(settings.pitch));
     map.setDebug(mbgl::MapDebugOptions(settings.debug));
 
@@ -178,7 +178,7 @@ int main(int argc, char *argv[]) {
     settings.latitude = camera.center->latitude();
     settings.longitude = camera.center->longitude();
     settings.zoom = *camera.zoom;
-    settings.bearing = *camera.angle;
+    settings.bearing = *camera.bearing;
     settings.pitch = *camera.pitch;
     settings.debug = mbgl::EnumType(map.getDebug());
     settings.save();

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1693,8 +1693,10 @@ public:
             if (self.userTrackingMode == MGLUserTrackingModeNone && pinch.numberOfTouches == _previousPinchNumberOfTouches)
             {
                 CLLocationCoordinate2D centerCoordinate = _previousPinchCenterCoordinate;
-                self.mbglMap.setLatLng(MGLLatLngFromLocationCoordinate2D(centerCoordinate),
-                                    mbgl::EdgeInsets { centerPoint.y, centerPoint.x, self.size.height - centerPoint.y, self.size.width - centerPoint.x });
+                mbgl::EdgeInsets padding { centerPoint.y, centerPoint.x, self.size.height - centerPoint.y, self.size.width - centerPoint.x };
+                self.mbglMap.jumpTo(mbgl::CameraOptions()
+                                        .withCenter(MGLLatLngFromLocationCoordinate2D(centerCoordinate))
+                                        .withPadding(padding));
             }
         }
         [self cameraIsChanging];
@@ -3173,7 +3175,7 @@ public:
 - (CLLocationCoordinate2D)centerCoordinate
 {
     mbgl::EdgeInsets padding = MGLEdgeInsetsFromNSEdgeInsets(self.contentInset);
-    return MGLLocationCoordinate2DFromLatLng(self.mbglMap.getLatLng(padding));
+    return MGLLocationCoordinate2DFromLatLng(*self.mbglMap.getCameraOptions(padding).center);
 }
 
 - (void)setCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate zoomLevel:(double)zoomLevel animated:(BOOL)animated
@@ -3791,7 +3793,7 @@ public:
     }
 
     mbgl::CameraOptions mapCamera = self.mbglMap.getCameraOptions();
-    CLLocationCoordinate2D centerCoordinate = MGLLocationCoordinate2DFromLatLng(cameraOptions.center ? *cameraOptions.center : self.mbglMap.getLatLng());
+    CLLocationCoordinate2D centerCoordinate = MGLLocationCoordinate2DFromLatLng(cameraOptions.center ? *cameraOptions.center : *mapCamera.center);
     double zoomLevel = cameraOptions.zoom ? *cameraOptions.zoom : self.zoomLevel;
     CLLocationDirection direction = cameraOptions.bearing ? mbgl::util::wrap(*cameraOptions.bearing, 0., 360.) : self.direction;
     CGFloat pitch = cameraOptions.pitch ? *cameraOptions.pitch : *mapCamera.pitch;

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2072,7 +2072,7 @@ public:
     
     if (twoFingerDrag.state == UIGestureRecognizerStateBegan)
     {
-        initialPitch = self.mbglMap.getPitch();
+        initialPitch = *self.mbglMap.getCameraOptions().pitch;
         [self trackGestureEvent:MMEEventGesturePitchStart forRecognizer:twoFingerDrag];
         [self notifyGestureDidBegin];
     }
@@ -2091,7 +2091,9 @@ public:
 
         if ([self _shouldChangeFromCamera:oldCamera toCamera:toCamera])
         {
-            self.mbglMap.setPitch(pitchNew, mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y });
+            self.mbglMap.jumpTo(mbgl::CameraOptions()
+                                    .withPitch(pitchNew)
+                                    .withAnchor(mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y }));
         }
 
         [self cameraIsChanging];
@@ -3780,10 +3782,11 @@ public:
         return nil;
     }
 
+    mbgl::CameraOptions mapCamera = self.mbglMap.getCameraOptions();
     CLLocationCoordinate2D centerCoordinate = MGLLocationCoordinate2DFromLatLng(cameraOptions.center ? *cameraOptions.center : self.mbglMap.getLatLng());
     double zoomLevel = cameraOptions.zoom ? *cameraOptions.zoom : self.zoomLevel;
     CLLocationDirection direction = cameraOptions.angle ? mbgl::util::wrap(*cameraOptions.angle, 0., 360.) : self.direction;
-    CGFloat pitch = cameraOptions.pitch ? *cameraOptions.pitch : self.mbglMap.getPitch();
+    CGFloat pitch = cameraOptions.pitch ? *cameraOptions.pitch : *mapCamera.pitch;
     CLLocationDistance altitude = MGLAltitudeForZoomLevel(zoomLevel, pitch, centerCoordinate.latitude, self.frame.size);
     return [MGLMapCamera cameraLookingAtCenterCoordinate:centerCoordinate altitude:altitude pitch:pitch heading:direction];
 }

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1771,7 +1771,7 @@ public:
     {
         [self trackGestureEvent:MMEEventGestureRotateStart forRecognizer:rotate];
 
-        self.angle = MGLRadiansFromDegrees(*self.mbglMap.getCameraOptions().angle) * -1;
+        self.angle = MGLRadiansFromDegrees(*self.mbglMap.getCameraOptions().bearing) * -1;
 
         if (self.userTrackingMode != MGLUserTrackingModeNone)
         {
@@ -1799,7 +1799,7 @@ public:
         if ([self _shouldChangeFromCamera:oldCamera toCamera:toCamera])
         {
            self.mbglMap.jumpTo(mbgl::CameraOptions()
-                                   .withAngle(newDegrees)
+                                   .withBearing(newDegrees)
                                    .withAnchor(mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y}));
         }
 
@@ -1836,7 +1836,7 @@ public:
             if ([self _shouldChangeFromCamera:oldCamera toCamera:toCamera])
             {
                 self.mbglMap.easeTo(mbgl::CameraOptions()
-                                       .withAngle(newDegrees)
+                                       .withBearing(newDegrees)
                                        .withAnchor(mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y }),
                                     MGLDurationFromTimeInterval(decelerationRate));
 
@@ -2145,7 +2145,7 @@ public:
     MGLMapCamera *camera;
     
     mbgl::ScreenCoordinate anchor = mbgl::ScreenCoordinate { anchorPoint.x, anchorPoint.y };
-    currentCameraOptions.angle = degrees;
+    currentCameraOptions.bearing = degrees;
     currentCameraOptions.anchor = anchor;
     camera = [self cameraForCameraOptions:currentCameraOptions];
     
@@ -2573,7 +2573,7 @@ public:
     MGLLogInfo(@"Resetting the map to the current style’s default viewport.");
     auto camera = self.mbglMap.getStyle().getDefaultCamera();
     CGFloat pitch = *camera.pitch;
-    CLLocationDirection heading = mbgl::util::wrap(*camera.angle, 0., 360.);
+    CLLocationDirection heading = mbgl::util::wrap(*camera.bearing, 0., 360.);
     CLLocationDistance altitude = MGLAltitudeForZoomLevel(*camera.zoom, pitch, 0, self.frame.size);
     self.camera = [MGLMapCamera cameraLookingAtCenterCoordinate:MGLLocationCoordinate2DFromLatLng(*camera.center)
                                                        altitude:altitude
@@ -3231,7 +3231,7 @@ public:
     cameraOptions.zoom = zoomLevel;
     if (direction >= 0)
     {
-        cameraOptions.angle = direction;
+        cameraOptions.bearing = direction;
     }
 
     mbgl::AnimationOptions animationOptions;
@@ -3487,7 +3487,7 @@ public:
 
 - (CLLocationDirection)direction
 {
-    return *self.mbglMap.getCameraOptions().angle;
+    return *self.mbglMap.getCameraOptions().bearing;
 }
 
 - (void)setDirection:(CLLocationDirection)direction animated:(BOOL)animated
@@ -3520,7 +3520,7 @@ public:
     if (self.userTrackingMode == MGLUserTrackingModeNone)
     {
         self.mbglMap.easeTo(mbgl::CameraOptions()
-                                .withAngle(direction)
+                                .withBearing(direction)
                                 .withPadding(MGLEdgeInsetsFromNSEdgeInsets(self.contentInset)),
                             MGLDurationFromTimeInterval(duration));
     }
@@ -3528,7 +3528,7 @@ public:
     {
         CGPoint anchor = self.userLocationAnnotationViewCenter;
         self.mbglMap.easeTo(mbgl::CameraOptions()
-                                .withAngle(direction)
+                                .withBearing(direction)
                                 .withAnchor(mbgl::ScreenCoordinate { anchor.x, anchor.y }),
                             MGLDurationFromTimeInterval(duration));
     }
@@ -3793,7 +3793,7 @@ public:
     mbgl::CameraOptions mapCamera = self.mbglMap.getCameraOptions();
     CLLocationCoordinate2D centerCoordinate = MGLLocationCoordinate2DFromLatLng(cameraOptions.center ? *cameraOptions.center : self.mbglMap.getLatLng());
     double zoomLevel = cameraOptions.zoom ? *cameraOptions.zoom : self.zoomLevel;
-    CLLocationDirection direction = cameraOptions.angle ? mbgl::util::wrap(*cameraOptions.angle, 0., 360.) : self.direction;
+    CLLocationDirection direction = cameraOptions.bearing ? mbgl::util::wrap(*cameraOptions.bearing, 0., 360.) : self.direction;
     CGFloat pitch = cameraOptions.pitch ? *cameraOptions.pitch : *mapCamera.pitch;
     CLLocationDistance altitude = MGLAltitudeForZoomLevel(zoomLevel, pitch, centerCoordinate.latitude, self.frame.size);
     return [MGLMapCamera cameraLookingAtCenterCoordinate:centerCoordinate altitude:altitude pitch:pitch heading:direction];
@@ -3814,7 +3814,7 @@ public:
                                            self.frame.size);
     if (camera.heading >= 0)
     {
-        options.angle = camera.heading;
+        options.bearing = camera.heading;
     }
     if (camera.pitch >= 0)
     {

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -1124,7 +1124,7 @@ public:
 }
 
 - (CLLocationDirection)direction {
-    return *_mbglMap->getCameraOptions().angle;
+    return *_mbglMap->getCameraOptions().bearing;
 }
 
 - (void)setDirection:(CLLocationDirection)direction {
@@ -1136,14 +1136,14 @@ public:
     MGLLogDebug(@"Setting direction: %f animated: %@", direction, MGLStringFromBOOL(animated));
     [self willChangeValueForKey:@"direction"];
     _mbglMap->easeTo(mbgl::CameraOptions()
-                         .withAngle(direction)
+                         .withBearing(direction)
                          .withPadding(MGLEdgeInsetsFromNSEdgeInsets(self.contentInsets)),
                      MGLDurationFromTimeInterval(animated ? MGLAnimationDuration : 0));
     [self didChangeValueForKey:@"direction"];
 }
 
 - (void)offsetDirectionBy:(CLLocationDegrees)delta animated:(BOOL)animated {
-    [self setDirection:*_mbglMap->getCameraOptions().angle + delta animated:animated];
+    [self setDirection:*_mbglMap->getCameraOptions().bearing + delta animated:animated];
 }
 
 + (NSSet<NSString *> *)keyPathsForValuesAffectingCamera {
@@ -1262,7 +1262,7 @@ public:
                                            camera.centerCoordinate.latitude,
                                            self.frame.size);
     if (camera.heading >= 0) {
-        options.angle = camera.heading;
+        options.bearing = camera.heading;
     }
     if (camera.pitch >= 0) {
         options.pitch = camera.pitch;
@@ -1361,7 +1361,7 @@ public:
     mbgl::CameraOptions mapCamera = _mbglMap->getCameraOptions();
     CLLocationCoordinate2D centerCoordinate = MGLLocationCoordinate2DFromLatLng(cameraOptions.center ? *cameraOptions.center : _mbglMap->getLatLng());
     double zoomLevel = cameraOptions.zoom ? *cameraOptions.zoom : self.zoomLevel;
-    CLLocationDirection direction = cameraOptions.angle ? mbgl::util::wrap(*cameraOptions.angle, 0., 360.) : self.direction;
+    CLLocationDirection direction = cameraOptions.bearing ? mbgl::util::wrap(*cameraOptions.bearing, 0., 360.) : self.direction;
     CGFloat pitch = cameraOptions.pitch ? *cameraOptions.pitch : *mapCamera.pitch;
     CLLocationDistance altitude = MGLAltitudeForZoomLevel(zoomLevel, pitch,
                                                           centerCoordinate.latitude,
@@ -1487,7 +1487,7 @@ public:
             if (self.rotateEnabled) {
                 CLLocationDirection newDirection = _directionAtBeginningOfGesture - delta.x / 10;
                 [self willChangeValueForKey:@"direction"];
-                _mbglMap->jumpTo(mbgl::CameraOptions().withAngle(newDirection).withAnchor(center));
+                _mbglMap->jumpTo(mbgl::CameraOptions().withBearing(newDirection).withAnchor(center));
                 didChangeCamera = YES;
                 [self didChangeValueForKey:@"direction"];
             }
@@ -1626,7 +1626,7 @@ public:
         NSPoint rotationPoint = [gestureRecognizer locationInView:self];
         mbgl::ScreenCoordinate anchor(rotationPoint.x, self.bounds.size.height - rotationPoint.y);
         _mbglMap->jumpTo(mbgl::CameraOptions()
-                             .withAngle(_directionAtBeginningOfGesture + gestureRecognizer.rotationInDegrees)
+                             .withBearing(_directionAtBeginningOfGesture + gestureRecognizer.rotationInDegrees)
                              .withAnchor(anchor));
         
         if ([self.delegate respondsToSelector:@selector(mapView:shouldChangeFromCamera:toCamera:)]

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -1357,10 +1357,11 @@ public:
 }
 
 - (MGLMapCamera *)cameraForCameraOptions:(const mbgl::CameraOptions &)cameraOptions {
+    mbgl::CameraOptions mapCamera = _mbglMap->getCameraOptions();
     CLLocationCoordinate2D centerCoordinate = MGLLocationCoordinate2DFromLatLng(cameraOptions.center ? *cameraOptions.center : _mbglMap->getLatLng());
     double zoomLevel = cameraOptions.zoom ? *cameraOptions.zoom : self.zoomLevel;
     CLLocationDirection direction = cameraOptions.angle ? mbgl::util::wrap(*cameraOptions.angle, 0., 360.) : self.direction;
-    CGFloat pitch = cameraOptions.pitch ? *cameraOptions.pitch : _mbglMap->getPitch();
+    CGFloat pitch = cameraOptions.pitch ? *cameraOptions.pitch : *mapCamera.pitch;
     CLLocationDistance altitude = MGLAltitudeForZoomLevel(zoomLevel, pitch,
                                                           centerCoordinate.latitude,
                                                           self.frame.size);
@@ -1477,7 +1478,7 @@ public:
 
         if (gestureRecognizer.state == NSGestureRecognizerStateBegan) {
             _directionAtBeginningOfGesture = self.direction;
-            _pitchAtBeginningOfGesture = _mbglMap->getPitch();
+            _pitchAtBeginningOfGesture = *_mbglMap->getCameraOptions().pitch;
         } else if (gestureRecognizer.state == NSGestureRecognizerStateChanged) {
             MGLMapCamera *oldCamera = self.camera;
             BOOL didChangeCamera = NO;
@@ -1490,7 +1491,7 @@ public:
                 [self didChangeValueForKey:@"direction"];
             }
             if (self.pitchEnabled) {
-                _mbglMap->setPitch(_pitchAtBeginningOfGesture + delta.y / 5, center);
+                _mbglMap->jumpTo(mbgl::CameraOptions().withPitch(_pitchAtBeginningOfGesture + delta.y / 5).withAnchor(center));
                 didChangeCamera = YES;
             }
             

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -996,7 +996,7 @@ public:
 
 - (CLLocationCoordinate2D)centerCoordinate {
     mbgl::EdgeInsets padding = MGLEdgeInsetsFromNSEdgeInsets(self.contentInsets);
-    return MGLLocationCoordinate2DFromLatLng(_mbglMap->getLatLng(padding));
+    return MGLLocationCoordinate2DFromLatLng(*_mbglMap->getCameraOptions(padding).center);
 }
 
 - (void)setCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate {
@@ -1007,9 +1007,10 @@ public:
 - (void)setCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate animated:(BOOL)animated {
     MGLLogDebug(@"Setting centerCoordinate: %@ animated: %@", MGLStringFromCLLocationCoordinate2D(centerCoordinate), MGLStringFromBOOL(animated));
     [self willChangeValueForKey:@"centerCoordinate"];
-    _mbglMap->setLatLng(MGLLatLngFromLocationCoordinate2D(centerCoordinate),
-                        MGLEdgeInsetsFromNSEdgeInsets(self.contentInsets),
-                        MGLDurationFromTimeInterval(animated ? MGLAnimationDuration : 0));
+    _mbglMap->easeTo(mbgl::CameraOptions()
+                         .withCenter(MGLLatLngFromLocationCoordinate2D(centerCoordinate))
+                         .withPadding(MGLEdgeInsetsFromNSEdgeInsets(self.contentInsets)),
+                     MGLDurationFromTimeInterval(animated ? MGLAnimationDuration : 0));
     [self didChangeValueForKey:@"centerCoordinate"];
 }
 
@@ -1359,7 +1360,7 @@ public:
 
 - (MGLMapCamera *)cameraForCameraOptions:(const mbgl::CameraOptions &)cameraOptions {
     mbgl::CameraOptions mapCamera = _mbglMap->getCameraOptions();
-    CLLocationCoordinate2D centerCoordinate = MGLLocationCoordinate2DFromLatLng(cameraOptions.center ? *cameraOptions.center : _mbglMap->getLatLng());
+    CLLocationCoordinate2D centerCoordinate = MGLLocationCoordinate2DFromLatLng(cameraOptions.center ? *cameraOptions.center : *mapCamera.center);
     double zoomLevel = cameraOptions.zoom ? *cameraOptions.zoom : self.zoomLevel;
     CLLocationDirection direction = cameraOptions.bearing ? mbgl::util::wrap(*cameraOptions.bearing, 0., 360.) : self.direction;
     CGFloat pitch = cameraOptions.pitch ? *cameraOptions.pitch : *mapCamera.pitch;

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -942,7 +942,7 @@ void NodeMap::SetCenter(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     if (center->Length() > 1) { latitude = Nan::Get(center, 1).ToLocalChecked()->NumberValue(); }
 
     try {
-        nodeMap->map->setLatLng(mbgl::LatLng { latitude, longitude });
+        nodeMap->map->jumpTo(mbgl::CameraOptions().withCenter(mbgl::LatLng { latitude, longitude }));
     } catch (const std::exception &ex) {
         return Nan::ThrowError(ex.what());
     }

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -993,7 +993,7 @@ void NodeMap::SetPitch(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     }
 
     try {
-        nodeMap->map->setPitch(info[0]->NumberValue());
+        nodeMap->map->jumpTo(mbgl::CameraOptions().withPitch(info[0]->NumberValue()));
     } catch (const std::exception &ex) {
         return Nan::ThrowError(ex.what());
     }

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -959,7 +959,7 @@ void NodeMap::SetZoom(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     }
 
     try {
-        nodeMap->map->setZoom(info[0]->NumberValue());
+        nodeMap->map->jumpTo(mbgl::CameraOptions().withZoom(info[0]->NumberValue()));
     } catch (const std::exception &ex) {
         return Nan::ThrowError(ex.what());
     }

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -443,7 +443,7 @@ void NodeMap::startRender(NodeMap::RenderOptions options) {
     mbgl::CameraOptions camera;
     camera.center = mbgl::LatLng { options.latitude, options.longitude };
     camera.zoom = options.zoom;
-    camera.angle = options.bearing;
+    camera.bearing = options.bearing;
     camera.pitch = options.pitch;
 
     if (map->getAxonometric() != options.axonometric) {
@@ -976,7 +976,7 @@ void NodeMap::SetBearing(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     }
 
     try {
-        nodeMap->map->jumpTo(mbgl::CameraOptions().withAngle(info[0]->NumberValue()));
+        nodeMap->map->jumpTo(mbgl::CameraOptions().withBearing(info[0]->NumberValue()));
     } catch (const std::exception &ex) {
         return Nan::ThrowError(ex.what());
     }

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -976,7 +976,7 @@ void NodeMap::SetBearing(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     }
 
     try {
-        nodeMap->map->setBearing(info[0]->NumberValue());
+        nodeMap->map->jumpTo(mbgl::CameraOptions().withAngle(info[0]->NumberValue()));
     } catch (const std::exception &ex) {
         return Nan::ThrowError(ex.what());
     }

--- a/platform/qt/app/mapwindow.cpp
+++ b/platform/qt/app/mapwindow.cpp
@@ -437,7 +437,7 @@ void MapWindow::mouseMoveEvent(QMouseEvent *ev)
 
     if (!delta.isNull()) {
         if (ev->buttons() == Qt::LeftButton && ev->modifiers() & Qt::ShiftModifier) {
-            m_map->setPitch(m_map->pitch() - delta.y());
+            m_map->pitchBy(delta.y());
         } else if (ev->buttons() == Qt::LeftButton) {
             m_map->moveBy(delta);
         } else if (ev->buttons() == Qt::RightButton) {

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -94,7 +94,7 @@ struct Q_MAPBOXGL_EXPORT QMapboxGLCameraOptions {
     QVariant center;  // Coordinate
     QVariant anchor;  // QPointF
     QVariant zoom;    // double
-    QVariant angle;   // double
+    QVariant bearing; // double
     QVariant pitch;   // double
 };
 

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -182,6 +182,7 @@ public:
 
     double pitch() const;
     void setPitch(double pitch);
+    void pitchBy(double pitch);
 
     NorthOrientation northOrientation() const;
     void setNorthOrientation(NorthOrientation);

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1246,21 +1246,8 @@ QMapbox::CoordinateZoom QMapboxGL::coordinateZoomForBounds(const QMapbox::Coordi
     double newBearing, double newPitch)
 
 {
-    // FIXME: mbgl::Map::cameraForLatLngBounds should
-    // take bearing and pitch as input too, so this
-    // hack won't be needed.
-    double currentBearing = bearing();
-    double currentPitch = pitch();
-
-    setBearing(newBearing);
-    setPitch(newPitch);
-
     auto bounds = mbgl::LatLngBounds::hull(mbgl::LatLng { sw.first, sw.second }, mbgl::LatLng { ne.first, ne.second });
-    mbgl::CameraOptions camera = d_ptr->mapObj->cameraForLatLngBounds(bounds, d_ptr->margins);
-
-    setBearing(currentBearing);
-    setPitch(currentPitch);
-
+    mbgl::CameraOptions camera = d_ptr->mapObj->cameraForLatLngBounds(bounds, d_ptr->margins, newBearing, newPitch);
     return {{ (*camera.center).latitude(), (*camera.center).longitude() }, *camera.zoom };
 }
 

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -685,12 +685,12 @@ void QMapboxGL::setStyleUrl(const QString &url)
 */
 double QMapboxGL::latitude() const
 {
-    return d_ptr->mapObj->getLatLng(d_ptr->margins).latitude();
+    return d_ptr->mapObj->getCameraOptions(d_ptr->margins).center->latitude();
 }
 
 void QMapboxGL::setLatitude(double latitude_)
 {
-    d_ptr->mapObj->setLatLng(mbgl::LatLng { latitude_, longitude() }, d_ptr->margins);
+    d_ptr->mapObj->jumpTo(mbgl::CameraOptions().withCenter(mbgl::LatLng { latitude_, longitude() }).withPadding(d_ptr->margins));
 }
 
 /*!
@@ -703,12 +703,12 @@ void QMapboxGL::setLatitude(double latitude_)
 */
 double QMapboxGL::longitude() const
 {
-    return d_ptr->mapObj->getLatLng(d_ptr->margins).longitude();
+    return d_ptr->mapObj->getCameraOptions(d_ptr->margins).center->longitude();
 }
 
 void QMapboxGL::setLongitude(double longitude_)
 {
-    d_ptr->mapObj->setLatLng(mbgl::LatLng { latitude(), longitude_ }, d_ptr->margins);
+    d_ptr->mapObj->jumpTo(mbgl::CameraOptions().withCenter(mbgl::LatLng { latitude(), longitude_ }).withPadding(d_ptr->margins));
 }
 
 /*!
@@ -784,13 +784,15 @@ double QMapboxGL::maximumZoom() const
 */
 Coordinate QMapboxGL::coordinate() const
 {
-    const mbgl::LatLng& latLng = d_ptr->mapObj->getLatLng(d_ptr->margins);
+    const mbgl::LatLng& latLng = *d_ptr->mapObj->getCameraOptions(d_ptr->margins).center;
     return Coordinate(latLng.latitude(), latLng.longitude());
 }
 
 void QMapboxGL::setCoordinate(const QMapbox::Coordinate &coordinate_)
 {
-    d_ptr->mapObj->setLatLng(mbgl::LatLng { coordinate_.first, coordinate_.second }, d_ptr->margins);
+    d_ptr->mapObj->jumpTo(mbgl::CameraOptions()
+                              .withCenter(mbgl::LatLng { coordinate_.first, coordinate_.second })
+                              .withPadding(d_ptr->margins));
 }
 
 /*!

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -726,12 +726,12 @@ void QMapboxGL::setLongitude(double longitude_)
 */
 double QMapboxGL::scale() const
 {
-    return std::pow(2.0, d_ptr->mapObj->getZoom());
+    return std::pow(2.0, zoom());
 }
 
 void QMapboxGL::setScale(double scale_, const QPointF &center)
 {
-    d_ptr->mapObj->setZoom(::log2(scale_), mbgl::ScreenCoordinate { center.x(), center.y() });
+    d_ptr->mapObj->jumpTo(mbgl::CameraOptions().withZoom(::log2(scale_)).withAnchor(mbgl::ScreenCoordinate { center.x(), center.y() }));
 }
 
 /*!
@@ -746,12 +746,12 @@ void QMapboxGL::setScale(double scale_, const QPointF &center)
 */
 double QMapboxGL::zoom() const
 {
-    return d_ptr->mapObj->getZoom();
+    return *d_ptr->mapObj->getCameraOptions().zoom;
 }
 
 void QMapboxGL::setZoom(double zoom_)
 {
-    d_ptr->mapObj->setZoom(zoom_, d_ptr->margins);
+    d_ptr->mapObj->jumpTo(mbgl::CameraOptions().withZoom(zoom_).withPadding(d_ptr->margins));
 }
 
 /*!
@@ -806,8 +806,10 @@ void QMapboxGL::setCoordinate(const QMapbox::Coordinate &coordinate_)
 */
 void QMapboxGL::setCoordinateZoom(const QMapbox::Coordinate &coordinate_, double zoom_)
 {
-    d_ptr->mapObj->setLatLngZoom(
-            mbgl::LatLng { coordinate_.first, coordinate_.second }, zoom_, d_ptr->margins);
+    d_ptr->mapObj->jumpTo(mbgl::CameraOptions()
+                              .withCenter(mbgl::LatLng { coordinate_.first, coordinate_.second })
+                              .withZoom(zoom_)
+                              .withPadding(d_ptr->margins));
 }
 
 /*!

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -855,17 +855,21 @@ void QMapboxGL::jumpTo(const QMapboxGLCameraOptions& camera)
 */
 double QMapboxGL::bearing() const
 {
-    return d_ptr->mapObj->getBearing();
+    return *d_ptr->mapObj->getCameraOptions().angle;
 }
 
 void QMapboxGL::setBearing(double degrees)
 {
-    d_ptr->mapObj->setBearing(degrees, d_ptr->margins);
+    d_ptr->mapObj->jumpTo(mbgl::CameraOptions()
+                              .withAngle(degrees)
+                              .withPadding(d_ptr->margins));
 }
 
 void QMapboxGL::setBearing(double degrees, const QPointF &center)
 {
-    d_ptr->mapObj->setBearing(degrees, mbgl::ScreenCoordinate { center.x(), center.y() });
+    d_ptr->mapObj->jumpTo(mbgl::CameraOptions()
+                              .withAngle(degrees)
+                              .withAnchor(mbgl::ScreenCoordinate { center.x(), center.y() }));
 }
 
 /*!

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1126,7 +1126,7 @@ void QMapboxGL::moveBy(const QPointF &offset)
     can be used for implementing a pinch gesture.
 */
 void QMapboxGL::scaleBy(double scale_, const QPointF &center) {
-    d_ptr->mapObj->setZoom(d_ptr->mapObj->getZoom() + ::log2(scale_), mbgl::ScreenCoordinate { center.x(), center.y() });
+    d_ptr->mapObj->scaleBy(scale_, mbgl::ScreenCoordinate { center.x(), center.y() });
 }
 
 /*!

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -885,6 +885,11 @@ void QMapboxGL::setPitch(double pitch_)
     d_ptr->mapObj->setPitch(pitch_);
 }
 
+void QMapboxGL::pitchBy(double pitch_)
+{
+    d_ptr->mapObj->pitchBy(pitch_);
+}
+
 /*!
     Returns the north orientation mode.
 */

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -879,12 +879,12 @@ void QMapboxGL::setBearing(double degrees, const QPointF &center)
 */
 double QMapboxGL::pitch() const
 {
-    return d_ptr->mapObj->getPitch();
+    return *d_ptr->mapObj->getCameraOptions().pitch;
 }
 
 void QMapboxGL::setPitch(double pitch_)
 {
-    d_ptr->mapObj->setPitch(pitch_);
+    d_ptr->mapObj->jumpTo(mbgl::CameraOptions().withPitch(pitch_));
 }
 
 void QMapboxGL::pitchBy(double pitch_)

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -829,8 +829,8 @@ void QMapboxGL::jumpTo(const QMapboxGLCameraOptions& camera)
     if (camera.zoom.isValid()) {
         mbglCamera.zoom = camera.zoom.value<double>();
     }
-    if (camera.angle.isValid()) {
-        mbglCamera.angle = camera.angle.value<double>();
+    if (camera.bearing.isValid()) {
+        mbglCamera.bearing = camera.bearing.value<double>();
     }
     if (camera.pitch.isValid()) {
         mbglCamera.pitch = camera.pitch.value<double>();
@@ -855,20 +855,20 @@ void QMapboxGL::jumpTo(const QMapboxGLCameraOptions& camera)
 */
 double QMapboxGL::bearing() const
 {
-    return *d_ptr->mapObj->getCameraOptions().angle;
+    return *d_ptr->mapObj->getCameraOptions().bearing;
 }
 
 void QMapboxGL::setBearing(double degrees)
 {
     d_ptr->mapObj->jumpTo(mbgl::CameraOptions()
-                              .withAngle(degrees)
+                              .withBearing(degrees)
                               .withPadding(d_ptr->margins));
 }
 
 void QMapboxGL::setBearing(double degrees, const QPointF &center)
 {
     d_ptr->mapObj->jumpTo(mbgl::CameraOptions()
-                              .withAngle(degrees)
+                              .withBearing(degrees)
                               .withAnchor(mbgl::ScreenCoordinate { center.x(), center.y() }));
 }
 

--- a/src/mbgl/layout/symbol_projection.cpp
+++ b/src/mbgl/layout/symbol_projection.cpp
@@ -62,7 +62,7 @@ namespace mbgl {
         if (pitchWithMap) {
             matrix::scale(m, m, 1 / pixelsToTileUnits, 1 / pixelsToTileUnits, 1);
             if (!rotateWithMap) {
-                matrix::rotate_z(m, m, state.getAngle());
+                matrix::rotate_z(m, m, state.getBearing());
             }
         } else {
             matrix::scale(m, m, state.getSize().width / 2.0, -(state.getSize().height / 2.0), 1.0);
@@ -82,7 +82,7 @@ namespace mbgl {
             matrix::multiply(m, m, posMatrix);
             matrix::scale(m, m, pixelsToTileUnits, pixelsToTileUnits, 1);
             if (!rotateWithMap) {
-                matrix::rotate_z(m, m, -state.getAngle());
+                matrix::rotate_z(m, m, -state.getBearing());
             }
         } else {
             matrix::scale(m, m, 1, -1, 1);

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -181,7 +181,7 @@ LatLng Map::getLatLng(const EdgeInsets& padding) const {
 
 void Map::resetPosition(const EdgeInsets& padding) {
     impl->cameraMutated = true;
-    impl->transform.jumpTo(CameraOptions().withCenter(LatLng()).withPadding(padding).withZoom(0.0).withAngle(0.0).withPitch(0.0));
+    impl->transform.jumpTo(CameraOptions().withCenter(LatLng()).withPadding(padding).withZoom(0.0).withBearing(0.0).withPitch(0.0));
     impl->onUpdate();
 }
 
@@ -260,11 +260,11 @@ CameraOptions Map::cameraForLatLngs(const std::vector<LatLng>& latLngs, const Ed
     Transform transform(impl->transform.getState());
 
     if (bearing || pitch) {
-        transform.jumpTo(CameraOptions().withAngle(bearing).withPitch(pitch));
+        transform.jumpTo(CameraOptions().withBearing(bearing).withPitch(pitch));
     }
 
     return mbgl::cameraForLatLngs(latLngs, transform, padding)
-        .withAngle(-transform.getAngle() * util::RAD2DEG)
+        .withBearing(-transform.getBearing() * util::RAD2DEG)
         .withPitch(transform.getPitch() * util::RAD2DEG);
 }
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -167,24 +167,6 @@ void Map::moveBy(const ScreenCoordinate& point, const AnimationOptions& animatio
     impl->onUpdate();
 }
 
-void Map::setLatLng(const LatLng& latLng, const AnimationOptions& animation) {
-    easeTo(CameraOptions().withCenter(latLng), animation);
-}
-
-void Map::setLatLng(const LatLng& latLng, const EdgeInsets& padding, const AnimationOptions& animation) {
-    easeTo(CameraOptions().withCenter(latLng).withPadding(padding), animation);
-}
-
-LatLng Map::getLatLng(const EdgeInsets& padding) const {
-    return impl->transform.getLatLng(padding);
-}
-
-void Map::resetPosition(const EdgeInsets& padding) {
-    impl->cameraMutated = true;
-    impl->transform.jumpTo(CameraOptions().withCenter(LatLng()).withPadding(padding).withZoom(0.0).withBearing(0.0).withPitch(0.0));
-    impl->onUpdate();
-}
-
 #pragma mark - Zoom
 
 void Map::scaleBy(double scale, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
@@ -438,7 +420,7 @@ ScreenCoordinate Map::pixelForLatLng(const LatLng& latLng) const {
     // antimeridian, we unwrap the point longitude so it would be seen if
     // e.g. the next antimeridian side is visible.
     LatLng unwrappedLatLng = latLng.wrapped();
-    unwrappedLatLng.unwrapForShortestPath(getLatLng());
+    unwrappedLatLng.unwrapForShortestPath(impl->transform.getLatLng());
     return impl->transform.latLngToScreenCoordinate(unwrappedLatLng);
 }
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -317,6 +317,12 @@ void Map::resetZoom() {
     setZoom(0);
 }
 
+#pragma mark - Pitch
+
+void Map::pitchBy(double pitch, const AnimationOptions& animation) {
+    easeTo(CameraOptions().withPitch((impl->transform.getPitch() * util::RAD2DEG) - pitch), animation);
+}
+
 #pragma mark - Bounds
 
 optional<LatLngBounds> Map::getLatLngBounds() const {

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -187,6 +187,11 @@ void Map::resetPosition(const EdgeInsets& padding) {
 
 #pragma mark - Zoom
 
+void Map::scaleBy(double scale, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
+    double zoom = getZoom() + impl->transform.getState().scaleZoom(scale);
+    easeTo(CameraOptions().withZoom(zoom).withAnchor(anchor), animation);
+}
+
 void Map::setZoom(double zoom, const AnimationOptions& animation) {
     easeTo(CameraOptions().withZoom(zoom), animation);
 }

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -188,32 +188,8 @@ void Map::resetPosition(const EdgeInsets& padding) {
 #pragma mark - Zoom
 
 void Map::scaleBy(double scale, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
-    double zoom = getZoom() + impl->transform.getState().scaleZoom(scale);
+    const double zoom = impl->transform.getZoom() + impl->transform.getState().scaleZoom(scale);
     easeTo(CameraOptions().withZoom(zoom).withAnchor(anchor), animation);
-}
-
-void Map::setZoom(double zoom, const AnimationOptions& animation) {
-    easeTo(CameraOptions().withZoom(zoom), animation);
-}
-
-void Map::setZoom(double zoom, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
-    easeTo(CameraOptions().withZoom(zoom).withAnchor(anchor), animation);
-}
-
-void Map::setZoom(double zoom, const EdgeInsets& padding, const AnimationOptions& animation) {
-    easeTo(CameraOptions().withZoom(zoom).withPadding(padding), animation);
-}
-
-double Map::getZoom() const {
-    return impl->transform.getZoom();
-}
-
-void Map::setLatLngZoom(const LatLng& latLng, double zoom, const AnimationOptions& animation) {
-    easeTo(CameraOptions().withCenter(latLng).withZoom(zoom), animation);
-}
-
-void Map::setLatLngZoom(const LatLng& latLng, double zoom, const EdgeInsets& padding, const AnimationOptions& animation) {
-    easeTo(CameraOptions().withCenter(latLng).withZoom(zoom).withPadding(padding), animation);
 }
 
 CameraOptions Map::cameraForLatLngBounds(const LatLngBounds& bounds, const EdgeInsets& padding, optional<double> bearing, optional<double> pitch) const {
@@ -312,11 +288,6 @@ LatLngBounds Map::latLngBoundsForCamera(const CameraOptions& camera) const {
     );
 }
 
-void Map::resetZoom() {
-    impl->cameraMutated = true;
-    setZoom(0);
-}
-
 #pragma mark - Pitch
 
 void Map::pitchBy(double pitch, const AnimationOptions& animation) {
@@ -337,8 +308,8 @@ void Map::setLatLngBounds(optional<LatLngBounds> bounds) {
 
 void Map::setMinZoom(const double minZoom) {
     impl->transform.setMinZoom(minZoom);
-    if (getZoom() < minZoom) {
-        setZoom(minZoom);
+    if (impl->transform.getZoom() < minZoom) {
+        jumpTo(CameraOptions().withZoom(minZoom));
     }
 }
 
@@ -348,8 +319,8 @@ double Map::getMinZoom() const {
 
 void Map::setMaxZoom(const double maxZoom) {
     impl->transform.setMaxZoom(maxZoom);
-    if (getZoom() > maxZoom) {
-        setZoom(maxZoom);
+    if (impl->transform.getZoom() > maxZoom) {
+        jumpTo(CameraOptions().withZoom(maxZoom));
     }
 }
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -330,8 +330,8 @@ double Map::getMaxZoom() const {
 
 void Map::setMinPitch(double minPitch) {
     impl->transform.setMinPitch(minPitch * util::DEG2RAD);
-    if (getPitch() < minPitch) {
-        setPitch(minPitch);
+    if (impl->transform.getPitch() < minPitch) {
+        jumpTo(CameraOptions().withPitch(minPitch));
     }
 }
 
@@ -341,8 +341,8 @@ double Map::getMinPitch() const {
 
 void Map::setMaxPitch(double maxPitch) {
     impl->transform.setMaxPitch(maxPitch * util::DEG2RAD);
-    if (getPitch() > maxPitch) {
-        setPitch(maxPitch);
+    if (impl->transform.getPitch() > maxPitch) {
+        jumpTo(CameraOptions().withPitch(maxPitch));
     }
 }
 
@@ -387,20 +387,6 @@ double Map::getBearing() const {
 
 void Map::resetNorth(const AnimationOptions& animation) {
     easeTo(CameraOptions().withAngle(0.0), animation);
-}
-
-#pragma mark - Pitch
-
-void Map::setPitch(double pitch, const AnimationOptions& animation) {
-    easeTo(CameraOptions().withPitch(pitch), animation);
-}
-
-void Map::setPitch(double pitch, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
-    easeTo(CameraOptions().withPitch(pitch).withAnchor(anchor), animation);
-}
-
-double Map::getPitch() const {
-    return impl->transform.getPitch() * util::RAD2DEG;
 }
 
 #pragma mark - North Orientation

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -369,26 +369,6 @@ void Map::rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second
     impl->onUpdate();
 }
 
-void Map::setBearing(double degrees, const AnimationOptions& animation) {
-    easeTo(CameraOptions().withAngle(degrees), animation);
-}
-
-void Map::setBearing(double degrees, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
-    return easeTo(CameraOptions().withAngle(degrees).withAnchor(anchor), animation);
-}
-
-void Map::setBearing(double degrees, const EdgeInsets& padding, const AnimationOptions& animation) {
-    easeTo(CameraOptions().withAngle(degrees).withPadding(padding), animation);
-}
-
-double Map::getBearing() const {
-    return -impl->transform.getAngle() * util::RAD2DEG;
-}
-
-void Map::resetNorth(const AnimationOptions& animation) {
-    easeTo(CameraOptions().withAngle(0.0), animation);
-}
-
 #pragma mark - North Orientation
 
 void Map::setNorthOrientation(NorthOrientation orientation) {

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -159,19 +159,25 @@ void Map::flyTo(const CameraOptions& camera, const AnimationOptions& animation) 
     impl->onUpdate();
 }
 
-#pragma mark - Position
-
 void Map::moveBy(const ScreenCoordinate& point, const AnimationOptions& animation) {
     impl->cameraMutated = true;
     impl->transform.moveBy(point, animation);
     impl->onUpdate();
 }
 
-#pragma mark - Zoom
+void Map::pitchBy(double pitch, const AnimationOptions& animation) {
+    easeTo(CameraOptions().withPitch((impl->transform.getPitch() * util::RAD2DEG) - pitch), animation);
+}
 
 void Map::scaleBy(double scale, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
     const double zoom = impl->transform.getZoom() + impl->transform.getState().scaleZoom(scale);
     easeTo(CameraOptions().withZoom(zoom).withAnchor(anchor), animation);
+}
+
+void Map::rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second, const AnimationOptions& animation) {
+    impl->cameraMutated = true;
+    impl->transform.rotateBy(first, second, animation);
+    impl->onUpdate();
 }
 
 CameraOptions Map::cameraForLatLngBounds(const LatLngBounds& bounds, const EdgeInsets& padding, optional<double> bearing, optional<double> pitch) const {
@@ -270,12 +276,6 @@ LatLngBounds Map::latLngBoundsForCamera(const CameraOptions& camera) const {
     );
 }
 
-#pragma mark - Pitch
-
-void Map::pitchBy(double pitch, const AnimationOptions& animation) {
-    easeTo(CameraOptions().withPitch((impl->transform.getPitch() * util::RAD2DEG) - pitch), animation);
-}
-
 #pragma mark - Bounds
 
 optional<LatLngBounds> Map::getLatLngBounds() const {
@@ -341,14 +341,6 @@ void Map::setSize(const Size size) {
 
 Size Map::getSize() const {
     return impl->transform.getState().getSize();
-}
-
-#pragma mark - Rotation
-
-void Map::rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second, const AnimationOptions& animation) {
-    impl->cameraMutated = true;
-    impl->transform.rotateBy(first, second, animation);
-    impl->onUpdate();
 }
 
 #pragma mark - North Orientation

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -62,13 +62,10 @@ public:
     /** Returns the zoom level. */
     double getZoom() const;
 
-    // Angle
+    // Bearing
 
     void rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second, const AnimationOptions& = {});
-    /** Returns the angle of rotation.
-        @return The angle of rotation, measured in radians counterclockwise from
-            true north. */
-    double getAngle() const;
+    double getBearing() const;
 
     // Pitch
 

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -61,7 +61,7 @@ void TransformState::getProjMatrix(mat4& projMatrix, uint16_t nearZ, bool aligne
         default: matrix::rotate_x(projMatrix, projMatrix, getPitch()); break;
     }
 
-    matrix::rotate_z(projMatrix, projMatrix, getAngle() + getNorthOrientationAngle());
+    matrix::rotate_z(projMatrix, projMatrix, getBearing() + getNorthOrientationAngle());
 
     const double dx = pixel_x() - size.width / 2.0f, dy = pixel_y() - size.height / 2.0f;
     matrix::translate(projMatrix, projMatrix, dx, dy, 0);
@@ -86,10 +86,10 @@ void TransformState::getProjMatrix(mat4& projMatrix, uint16_t nearZ, bool aligne
     // it is always <= 0.5 pixels.
     if (aligned) {
         const float xShift = float(size.width % 2) / 2, yShift = float(size.height % 2) / 2;
-        const double angleCos = std::cos(angle), angleSin = std::sin(angle);
+        const double bearingCos = std::cos(bearing), bearingSin = std::sin(bearing);
         double devNull;
-        const float dxa = -std::modf(dx, &devNull) + angleCos * xShift + angleSin * yShift;
-        const float dya = -std::modf(dy, &devNull) + angleCos * yShift + angleSin * xShift;
+        const float dxa = -std::modf(dx, &devNull) + bearingCos * xShift + bearingSin * yShift;
+        const float dya = -std::modf(dy, &devNull) + bearingCos * yShift + bearingSin * xShift;
         matrix::translate(projMatrix, projMatrix, dxa > 0.5 ? dxa - 1 : dxa, dya > 0.5 ? dya - 1 : dya, 0);
     }
 }
@@ -145,7 +145,7 @@ CameraOptions TransformState::getCameraOptions(const EdgeInsets& padding) const 
         .withCenter(center)
         .withPadding(padding)
         .withZoom(getZoom())
-        .withAngle(-angle * util::RAD2DEG)
+        .withBearing(-bearing * util::RAD2DEG)
         .withPitch(pitch * util::RAD2DEG);
 }
 
@@ -243,8 +243,8 @@ double TransformState::getMaxPitch() const {
 
 #pragma mark - Rotation
 
-float TransformState::getAngle() const {
-    return angle;
+float TransformState::getBearing() const {
+    return bearing;
 }
 
 float TransformState::getFieldOfView() const {

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -67,7 +67,7 @@ public:
     double getMaxPitch() const;
 
     // Rotation
-    float getAngle() const;
+    float getBearing() const;
     float getFieldOfView() const;
     float getCameraToCenterDistance() const;
     float getPitch() const;
@@ -131,7 +131,7 @@ private:
 
     // map position
     double x = 0, y = 0;
-    double angle = 0;
+    double bearing = 0;
     double scale = 1;
     // This fov value is somewhat arbitrary. The altitude of the camera used
     // to be defined as 1.5 screen heights above the ground, which was an

--- a/src/mbgl/programs/fill_extrusion_program.cpp
+++ b/src/mbgl/programs/fill_extrusion_program.cpp
@@ -21,7 +21,7 @@ std::array<float, 3> lightPosition(const EvaluatedLight& light, const TransformS
     mat3 lightMat;
     matrix::identity(lightMat);
     if (light.get<LightAnchor>() == LightAnchorType::Viewport) {
-        matrix::rotate(lightMat, lightMat, -state.getAngle());
+        matrix::rotate(lightMat, lightMat, -state.getBearing());
     }
     matrix::transformMat3f(lightPos, lightPos, lightMat);
     return lightPos;

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -142,7 +142,7 @@ bool RenderCircleLayer::queryIntersectsFeature(
             queryGeometry,
             evaluated.get<style::CircleTranslate>(),
             evaluated.get<style::CircleTranslateAnchor>(),
-            transformState.getAngle(),
+            transformState.getBearing(),
             pixelsToTileUnits).value_or(queryGeometry);
 
     // Evaluate functions

--- a/src/mbgl/renderer/layers/render_custom_layer.cpp
+++ b/src/mbgl/renderer/layers/render_custom_layer.cpp
@@ -74,7 +74,7 @@ void RenderCustomLayer::render(PaintParameters& paintParameters, RenderSource*) 
     parameters.latitude = state.getLatLng().latitude();
     parameters.longitude = state.getLatLng().longitude();
     parameters.zoom = state.getZoom();
-    parameters.bearing = -state.getAngle() * util::RAD2DEG;
+    parameters.bearing = -state.getBearing() * util::RAD2DEG;
     parameters.pitch = state.getPitch();
     parameters.fieldOfView = state.getFieldOfView();
     mat4 projMatrix;

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -218,7 +218,7 @@ bool RenderFillExtrusionLayer::queryIntersectsFeature(
             queryGeometry,
             evaluated.get<style::FillExtrusionTranslate>(),
             evaluated.get<style::FillExtrusionTranslateAnchor>(),
-            transformState.getAngle(),
+            transformState.getBearing(),
             pixelsToTileUnits);
 
     return util::polygonIntersectsMultiPolygon(translatedQueryGeometry.value_or(queryGeometry), feature.getGeometries());

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -233,7 +233,7 @@ bool RenderFillLayer::queryIntersectsFeature(
             queryGeometry,
             evaluated.get<style::FillTranslate>(),
             evaluated.get<style::FillTranslateAnchor>(),
-            transformState.getAngle(),
+            transformState.getBearing(),
             pixelsToTileUnits);
 
     return util::polygonIntersectsMultiPolygon(translatedQueryGeometry.value_or(queryGeometry), feature.getGeometries());

--- a/src/mbgl/renderer/layers/render_hillshade_layer.cpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.cpp
@@ -32,7 +32,7 @@ const std::array<float, 2> RenderHillshadeLayer::getLatRange(const UnwrappedTile
 
 const std::array<float, 2> RenderHillshadeLayer::getLight(const PaintParameters& parameters){
     float azimuthal = evaluated.get<HillshadeIlluminationDirection>() * util::DEG2RAD;
-    if (evaluated.get<HillshadeIlluminationAnchor>() == HillshadeIlluminationAnchorType::Viewport) azimuthal = azimuthal - parameters.state.getAngle();
+    if (evaluated.get<HillshadeIlluminationAnchor>() == HillshadeIlluminationAnchorType::Viewport) azimuthal = azimuthal - parameters.state.getBearing();
     return {{evaluated.get<HillshadeExaggeration>(), azimuthal}};
 }
 

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -207,7 +207,7 @@ bool RenderLineLayer::queryIntersectsFeature(
             queryGeometry,
             evaluated.get<style::LineTranslate>(),
             evaluated.get<style::LineTranslateAnchor>(),
-            transformState.getAngle(),
+            transformState.getBearing(),
             pixelsToTileUnits);
 
     // Evaluate function

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -379,8 +379,8 @@ void RenderSymbolLayer::sortRenderTiles(const TransformState& state) {
         Point<float> pa(a.get().id.canonical.x, a.get().id.canonical.y);
         Point<float> pb(b.get().id.canonical.x, b.get().id.canonical.y);
 
-        auto par = util::rotate(pa, state.getAngle());
-        auto pbr = util::rotate(pb, state.getAngle());
+        auto par = util::rotate(pa, state.getBearing());
+        auto pbr = util::rotate(pb, state.getBearing());
 
         return std::tie(b.get().id.canonical.z, par.y, par.x) < std::tie(a.get().id.canonical.z, pbr.y, pbr.x);
     });

--- a/src/mbgl/renderer/render_tile.cpp
+++ b/src/mbgl/renderer/render_tile.cpp
@@ -23,8 +23,8 @@ mat4 RenderTile::translateVtxMatrix(const mat4& tileMatrix,
     mat4 vtxMatrix;
 
     const float angle = inViewportPixelUnits ?
-        (anchor == TranslateAnchorType::Map ? state.getAngle() : 0) :
-        (anchor == TranslateAnchorType::Viewport ? -state.getAngle() : 0);
+        (anchor == TranslateAnchorType::Map ? state.getBearing() : 0) :
+        (anchor == TranslateAnchorType::Viewport ? -state.getBearing() : 0);
 
     Point<float> translate = util::rotate(Point<float>{ translation[0], translation[1] }, angle);
 

--- a/src/mbgl/style/style_impl.cpp
+++ b/src/mbgl/style/style_impl.cpp
@@ -105,7 +105,7 @@ void Style::Impl::parse(const std::string& json_) {
     name = parser.name;
     defaultCamera.center = parser.latLng;
     defaultCamera.zoom = parser.zoom;
-    defaultCamera.angle = parser.bearing;
+    defaultCamera.bearing = parser.bearing;
     defaultCamera.pitch = parser.pitch;
 
     setLight(std::make_unique<Light>(parser.light));

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -399,7 +399,7 @@ void Placement::updateBucketOpacities(SymbolBucket& bucket, std::set<uint32_t>& 
     }
 
     bucket.updateOpacity();
-    bucket.sortFeatures(state.getAngle());
+    bucket.sortFeatures(state.getBearing());
     auto retainedData = retainedQueryData.find(bucket.bucketInstanceId);
     if (retainedData != retainedQueryData.end()) {
         retainedData->second.featureSortOrder = bucket.featureSortOrder;

--- a/test/api/annotations.test.cpp
+++ b/test/api/annotations.test.cpp
@@ -53,7 +53,7 @@ TEST(Annotations, SymbolAnnotation) {
 //    auto size = test.frontend.getSize();
 //    auto screenBox = ScreenBox { {}, { double(size.width), double(size.height) } };
 //    for (uint8_t zoom = test.map.getMinZoom(); zoom <= test.map.getMaxZoom(); ++zoom) {
-//        test.map.setZoom(zoom);
+//        test.map.jumpTo(CameraOptions().withZoom(zoom));
 //        test.checkRendering("point_annotation");
 //        EXPECT_EQ(test.map.queryPointAnnotations(screenBox).size(), 1u);
 //    }
@@ -67,7 +67,7 @@ TEST(Annotations, SymbolAnnotationTileBoundary) {
     test.map.getStyle().loadJSON(util::read_file("test/fixtures/api/empty.json"));
     test.map.addAnnotationImage(namedMarker("default_marker"));
     test.map.addAnnotation(SymbolAnnotation { Point<double>(0.000000000000001, 0.00000000000001), "default_marker" });
-    test.map.setZoom(10);
+    test.map.jumpTo(CameraOptions().withZoom(10));
     test.checkRendering("point_annotation");
 }
 
@@ -83,7 +83,7 @@ TEST(Annotations, LineAnnotation) {
     test.map.addAnnotation(annotation);
     test.checkRendering("line_annotation");
 
-    test.map.setZoom(test.map.getMaxZoom());
+    test.map.jumpTo(CameraOptions().withZoom(test.map.getMaxZoom()));
     test.checkRendering("line_annotation_max_zoom");
 }
 
@@ -98,7 +98,7 @@ TEST(Annotations, FillAnnotation) {
     test.map.addAnnotation(annotation);
     test.checkRendering("fill_annotation");
 
-    test.map.setZoom(test.map.getMaxZoom());
+    test.map.jumpTo(CameraOptions().withZoom(test.map.getMaxZoom()));
     test.checkRendering("fill_annotation_max_zoom");
 }
 
@@ -106,7 +106,7 @@ TEST(Annotations, AntimeridianAnnotationSmall) {
     AnnotationTest test;
 
     double antimeridian = 180;
-    test.map.setLatLngZoom(mbgl::LatLng(0, antimeridian), 0);
+    test.map.jumpTo(CameraOptions().withCenter(LatLng { 0, antimeridian }).withZoom(0.0));
     test.map.getStyle().loadJSON(util::read_file("test/fixtures/api/empty.json"));
 
     LineString<double> line = {{ { antimeridian, 20 }, { antimeridian, -20 } }};
@@ -127,7 +127,7 @@ TEST(Annotations, AntimeridianAnnotationLarge) {
     AnnotationTest test;
 
     double antimeridian = 180;
-    test.map.setLatLngZoom(mbgl::LatLng(0, antimeridian), 0);
+    test.map.jumpTo(CameraOptions().withCenter(mbgl::LatLng(0.0, antimeridian)).withZoom(0.0));
     test.map.getStyle().loadJSON(util::read_file("test/fixtures/api/empty.json"));
 
     LineString<double> line = {{ { antimeridian, 20 }, { antimeridian, -20 } }};
@@ -384,9 +384,9 @@ TEST(Annotations, QueryFractionalZoomLevels) {
         }
     }
 
-    test.map.setLatLngZoom({ 5, 5 }, 0);
+    test.map.jumpTo(CameraOptions().withCenter(mbgl::LatLng(5.0, 5.0)).withZoom(0.0));
     for (uint16_t zoomSteps = 10; zoomSteps <= 20; ++zoomSteps) {
-        test.map.setZoom(zoomSteps / 10.0);
+        test.map.jumpTo(CameraOptions().withZoom(zoomSteps / 10.0));
         test.frontend.render(test.map);
         auto features = test.frontend.getRenderer()->queryRenderedFeatures(box);
 
@@ -408,7 +408,7 @@ TEST(Annotations, VisibleFeatures) {
 
     test.map.getStyle().loadJSON(util::read_file("test/fixtures/api/empty.json"));
     test.map.addAnnotationImage(namedMarker("default_marker"));
-    test.map.setLatLngZoom({ 5, 5 }, 3);
+    test.map.jumpTo(CameraOptions().withCenter(mbgl::LatLng(5.0, 5.0)).withZoom(3.0));
 
     std::vector<mbgl::AnnotationID> ids;
     for (int longitude = 0; longitude < 10; longitude += 2) {
@@ -428,8 +428,7 @@ TEST(Annotations, VisibleFeatures) {
     features.erase(std::unique(features.begin(), features.end(), sameID), features.end());
     EXPECT_EQ(features.size(), ids.size());
 
-    test.map.setBearing(0);
-    test.map.setZoom(4);
+    test.map.jumpTo(CameraOptions().withZoom(4.0).withAngle(0.0));
     test.frontend.render(test.map);
     features = test.frontend.getRenderer()->queryRenderedFeatures(box);
     std::sort(features.begin(), features.end(), sortID);
@@ -452,7 +451,7 @@ TEST(Annotations, DebugEmpty) {
 
     test.map.getStyle().loadJSON(util::read_file("test/fixtures/api/empty.json"));
     test.map.setDebug(MapDebugOptions::TileBorders);
-    test.map.setZoom(1);
+    test.map.jumpTo(CameraOptions().withZoom(1.0));
 
     test.checkRendering("debug_empty");
 }
@@ -465,7 +464,7 @@ TEST(Annotations, DebugSparse) {
 
     test.map.getStyle().loadJSON(util::read_file("test/fixtures/api/empty.json"));
     test.map.setDebug(MapDebugOptions::TileBorders);
-    test.map.setZoom(1);
+    test.map.jumpTo(CameraOptions().withZoom(1.0));
     test.map.addAnnotationImage(namedMarker("default_marker"));
     test.map.addAnnotation(SymbolAnnotation { Point<double>(10, 10), "default_marker" });
 
@@ -484,7 +483,7 @@ TEST(Annotations, ChangeMaxZoom) {
     test.map.getStyle().loadJSON(util::read_file("test/fixtures/api/empty.json"));
     test.map.addAnnotation(annotation);
     test.map.setMaxZoom(14);
-    test.map.setZoom(test.map.getMaxZoom());
+    test.map.jumpTo(CameraOptions().withZoom(test.map.getMaxZoom()));
     test.checkRendering("line_annotation_max_zoom");
 }
 

--- a/test/api/annotations.test.cpp
+++ b/test/api/annotations.test.cpp
@@ -418,7 +418,7 @@ TEST(Annotations, VisibleFeatures) {
     }
 
     // Change bearing *after* adding annotations causes them to be reordered.
-    test.map.setBearing(45);
+    test.map.jumpTo(CameraOptions().withAngle(45.0));
     test.frontend.render(test.map);
 
     auto features = test.frontend.getRenderer()->queryRenderedFeatures(box, {});

--- a/test/api/annotations.test.cpp
+++ b/test/api/annotations.test.cpp
@@ -418,7 +418,7 @@ TEST(Annotations, VisibleFeatures) {
     }
 
     // Change bearing *after* adding annotations causes them to be reordered.
-    test.map.jumpTo(CameraOptions().withAngle(45.0));
+    test.map.jumpTo(CameraOptions().withBearing(45.0));
     test.frontend.render(test.map);
 
     auto features = test.frontend.getRenderer()->queryRenderedFeatures(box, {});
@@ -428,7 +428,7 @@ TEST(Annotations, VisibleFeatures) {
     features.erase(std::unique(features.begin(), features.end(), sameID), features.end());
     EXPECT_EQ(features.size(), ids.size());
 
-    test.map.jumpTo(CameraOptions().withZoom(4.0).withAngle(0.0));
+    test.map.jumpTo(CameraOptions().withZoom(4.0).withBearing(0.0));
     test.frontend.render(test.map);
     features = test.frontend.getRenderer()->queryRenderedFeatures(box);
     std::sort(features.begin(), features.end(), sortID);

--- a/test/api/custom_geometry_source.test.cpp
+++ b/test/api/custom_geometry_source.test.cpp
@@ -26,7 +26,7 @@ TEST(CustomGeometrySource, Grid) {
     Map map(frontend, MapObserver::nullObserver(), frontend.getSize(), pixelRatio, fileSource,
             *threadPool, MapMode::Static);
     map.getStyle().loadJSON(util::read_file("test/fixtures/api/water.json"));
-    map.setLatLngZoom({ 37.8, -122.5 }, 10);
+    map.jumpTo(CameraOptions().withCenter(LatLng { 37.8, -122.5 }).withZoom(10.0));
 
     CustomGeometrySource::Options options;
     options.fetchTileFunction = [&map](const mbgl::CanonicalTileID& tileID) {

--- a/test/api/custom_layer.test.cpp
+++ b/test/api/custom_layer.test.cpp
@@ -96,7 +96,7 @@ TEST(CustomLayer, Basic) {
     Map map(frontend, MapObserver::nullObserver(), frontend.getSize(), pixelRatio, fileSource,
             threadPool, MapMode::Static);
     map.getStyle().loadJSON(util::read_file("test/fixtures/api/water.json"));
-    map.setLatLngZoom({ 37.8, -122.5 }, 10);
+    map.jumpTo(CameraOptions().withCenter(LatLng { 37.8, -122.5 }).withZoom(10.0));
     map.getStyle().addLayer(std::make_unique<CustomLayer>(
         "custom",
         std::make_unique<TestLayer>()));

--- a/test/api/query.test.cpp
+++ b/test/api/query.test.cpp
@@ -59,7 +59,7 @@ std::vector<Feature> getTopClusterFeature(QueryTest& test) {
     clusterLayer->setIconImage("test-icon"s);
     clusterLayer->setIconSize(12.0f);
 
-    test.map.setLatLngZoom(coordinate, 0);
+    test.map.jumpTo(CameraOptions().withCenter(coordinate).withZoom(0.0));
     test.map.getStyle().addSource(std::move(source));
     test.map.getStyle().addLayer(std::move(clusterLayer));
     test.loop.runOnce();

--- a/test/gl/context.test.cpp
+++ b/test/gl/context.test.cpp
@@ -93,7 +93,7 @@ TEST(GLContextMode, Shared) {
 
     Map map(frontend, MapObserver::nullObserver(), frontend.getSize(), pixelRatio, fileSource, threadPool, MapMode::Static);
     map.getStyle().loadJSON(util::read_file("test/fixtures/api/water.json"));
-    map.setLatLngZoom({ 37.8, -122.5 }, 10);
+    map.jumpTo(CameraOptions().withCenter(LatLng { 37.8, -122.5 }).withZoom(10.0));
 
     // Set transparent background layer.
     auto layer = map.getStyle().getLayer("background");

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -127,10 +127,10 @@ TEST(Map, LatLngBehavior) {
     MapTest<> test;
 
     test.map.jumpTo(CameraOptions().withCenter(LatLng { 1.0, 1.0 }).withZoom(0.0));
-    auto latLng1 = test.map.getLatLng();
+    auto latLng1 = *test.map.getCameraOptions().center;
 
-    test.map.setLatLng({ 1, 1 });
-    auto latLng2 = test.map.getLatLng();
+    test.map.jumpTo(CameraOptions().withCenter(LatLng { 1.0, 1.0 }));
+    auto latLng2 = *test.map.getCameraOptions().center;
 
     ASSERT_DOUBLE_EQ(latLng1.latitude(), latLng2.latitude());
     ASSERT_DOUBLE_EQ(latLng1.longitude(), latLng2.longitude());

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -64,7 +64,7 @@ TEST(Map, RendererState) {
     double bearingInDegrees = 30.0;
 
     test.map.getStyle().loadJSON(util::read_file("test/fixtures/api/empty.json"));
-    test.map.jumpTo(CameraOptions().withCenter(coordinate).withZoom(zoom).withPitch(pitchInDegrees).withAngle(bearingInDegrees));
+    test.map.jumpTo(CameraOptions().withCenter(coordinate).withZoom(zoom).withPitch(pitchInDegrees).withBearing(bearingInDegrees));
 
     test.runLoop.runOnce();
     test.frontend.render(test.map);
@@ -75,7 +75,7 @@ TEST(Map, RendererState) {
     EXPECT_NEAR(options.center->longitude(), coordinate.longitude(), 1e-7);
     ASSERT_DOUBLE_EQ(*options.zoom, zoom);
     ASSERT_DOUBLE_EQ(*options.pitch, pitchInDegrees);
-    EXPECT_NEAR(*options.angle, bearingInDegrees, 1e-7);
+    EXPECT_NEAR(*options.bearing, bearingInDegrees, 1e-7);
 
     {
         const LatLng& latLng = test.frontend.latLngForPixel(ScreenCoordinate { 0, 0 });
@@ -148,7 +148,7 @@ TEST(Map, LatLngBoundsToCamera) {
     EXPECT_NEAR(*virtualCamera.zoom, 1.55467, 1e-5);
 }
 
-TEST(Map, LatLngBoundsToCameraWithAngle) {
+TEST(Map, LatLngBoundsToCameraWithBearing) {
     MapTest<> test;
 
     test.map.jumpTo(CameraOptions().withCenter(LatLng { 40.712730, -74.005953 }).withZoom(16.0));
@@ -158,10 +158,10 @@ TEST(Map, LatLngBoundsToCameraWithAngle) {
     CameraOptions virtualCamera = test.map.cameraForLatLngBounds(bounds, {}, 35.0);
     ASSERT_TRUE(bounds.contains(*virtualCamera.center));
     EXPECT_NEAR(*virtualCamera.zoom, 1.21385, 1e-5);
-    EXPECT_NEAR(virtualCamera.angle.value_or(0), 35.0, 1e-5);
+    EXPECT_NEAR(virtualCamera.bearing.value_or(0), 35.0, 1e-5);
 }
 
-TEST(Map, LatLngBoundsToCameraWithAngleAndPitch) {
+TEST(Map, LatLngBoundsToCameraWithBearingAndPitch) {
     MapTest<> test;
     
     test.map.jumpTo(CameraOptions().withCenter(LatLng { 40.712730, -74.005953 }).withZoom(16.0));
@@ -172,7 +172,7 @@ TEST(Map, LatLngBoundsToCameraWithAngleAndPitch) {
     ASSERT_TRUE(bounds.contains(*virtualCamera.center));
     EXPECT_NEAR(*virtualCamera.zoom, 13.66272, 1e-5);
     ASSERT_DOUBLE_EQ(*virtualCamera.pitch, 20.0);
-    EXPECT_NEAR(virtualCamera.angle.value_or(0), 35.0, 1e-5);
+    EXPECT_NEAR(virtualCamera.bearing.value_or(0), 35.0, 1e-5);
 }
 
 TEST(Map, LatLngsToCamera) {
@@ -181,19 +181,19 @@ TEST(Map, LatLngsToCamera) {
     std::vector<LatLng> latLngs{{ 40.712730, 74.005953 }, {15.68169,73.499857}, {30.82678, 83.4082}};
 
     CameraOptions virtualCamera = test.map.cameraForLatLngs(latLngs, {}, 23.0);
-    EXPECT_NEAR(virtualCamera.angle.value_or(0), 23.0, 1e-5);
+    EXPECT_NEAR(virtualCamera.bearing.value_or(0), 23.0, 1e-5);
     EXPECT_NEAR(virtualCamera.zoom.value_or(0), 2.75434, 1e-5);
     EXPECT_NEAR(virtualCamera.center->latitude(), 28.49288, 1e-5);
     EXPECT_NEAR(virtualCamera.center->longitude(), 74.97437, 1e-5);
 }
 
-TEST(Map, LatLngsToCameraWithAngleAndPitch) {
+TEST(Map, LatLngsToCameraWithBearingAndPitch) {
     MapTest<> test;
     
     std::vector<LatLng> latLngs{{ 40.712730, 74.005953 }, {15.68169,73.499857}, {30.82678, 83.4082}};
     
     CameraOptions virtualCamera = test.map.cameraForLatLngs(latLngs, {}, 23, 20);
-    EXPECT_NEAR(virtualCamera.angle.value_or(0), 23.0, 1e-5);
+    EXPECT_NEAR(virtualCamera.bearing.value_or(0), 23.0, 1e-5);
     EXPECT_NEAR(virtualCamera.zoom.value_or(0), 3.04378, 1e-5);
     EXPECT_NEAR(virtualCamera.center->latitude(), 28.53718, 1e-5);
     EXPECT_NEAR(virtualCamera.center->longitude(), 74.31746, 1e-5);
@@ -256,7 +256,7 @@ TEST(Map, SetStyleDefaultCamera) {
     CameraOptions camera = test.map.getCameraOptions();
     EXPECT_DOUBLE_EQ(*camera.zoom, 0.0);
     EXPECT_DOUBLE_EQ(*camera.pitch, 0.0);
-    EXPECT_DOUBLE_EQ(*camera.angle, 0.0);
+    EXPECT_DOUBLE_EQ(*camera.bearing, 0.0);
     EXPECT_EQ(*camera.center, LatLng {});
 
     test.map.getStyle().loadJSON(util::read_file("test/fixtures/api/empty-zoomed.json"));

--- a/test/map/prefetch.test.cpp
+++ b/test/map/prefetch.test.cpp
@@ -58,7 +58,7 @@ TEST(Map, PrefetchTiles) {
         // Force tile reloading.
         map.getStyle().loadJSON(util::read_file("test/fixtures/map/prefetch/empty.json"));
         map.getStyle().loadJSON(util::read_file("test/fixtures/map/prefetch/style.json"));
-        map.setLatLngZoom({ 40.726989, -73.992857 }, zoom); // Manhattan
+        map.jumpTo(CameraOptions().withCenter(LatLng { 40.726989, -73.992857 }).withZoom(zoom)); // Manhattan
         runLoop.run();
 
         ASSERT_EQ(tiles.size(), expected.size());

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -61,19 +61,19 @@ TEST(Transform, InvalidBearing) {
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(0, transform.getZoom());
 
-    transform.jumpTo(CameraOptions().withZoom(1.0).withAngle(2.0));
+    transform.jumpTo(CameraOptions().withZoom(1.0).withBearing(2.0));
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(1, transform.getZoom());
-    ASSERT_NEAR(-2.0 * util::DEG2RAD, transform.getAngle(), 1e-15);
+    ASSERT_NEAR(-2.0 * util::DEG2RAD, transform.getBearing(), 1e-15);
 
     const double invalid = NAN;
 
-    transform.jumpTo(CameraOptions().withAngle(invalid));
+    transform.jumpTo(CameraOptions().withBearing(invalid));
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(1, transform.getZoom());
-    ASSERT_NEAR(-2.0 * util::DEG2RAD, transform.getAngle(), 1e-15);
+    ASSERT_NEAR(-2.0 * util::DEG2RAD, transform.getBearing(), 1e-15);
 }
 
 TEST(Transform, IntegerZoom) {
@@ -196,7 +196,7 @@ TEST(Transform, Anchor) {
     ASSERT_DOUBLE_EQ(latLng.latitude(), transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(latLng.longitude(), transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(10, transform.getZoom());
-    ASSERT_DOUBLE_EQ(0, transform.getAngle());
+    ASSERT_DOUBLE_EQ(0, transform.getBearing());
 
     const LatLng anchorLatLng = transform.getState().screenCoordinateToLatLng(anchorPoint);
     ASSERT_NE(latLng.latitude(), anchorLatLng.latitude());
@@ -247,18 +247,18 @@ TEST(Transform, Anchor) {
     ASSERT_NE(latLng.latitude(), transform.getLatLng().latitude());
     ASSERT_NE(latLng.longitude(), transform.getLatLng().longitude());
 
-    transform.jumpTo(CameraOptions().withCenter(latLng).withZoom(10.0).withAngle(-45.0));
-    ASSERT_NEAR(M_PI_4, transform.getAngle(), 0.000001);
+    transform.jumpTo(CameraOptions().withCenter(latLng).withZoom(10.0).withBearing(-45.0));
+    ASSERT_NEAR(M_PI_4, transform.getBearing(), 0.000001);
     ASSERT_DOUBLE_EQ(latLng.latitude(), transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(latLng.longitude(), transform.getLatLng().longitude());
 
-    transform.jumpTo(CameraOptions().withAngle(0.0));
-    ASSERT_DOUBLE_EQ(0, transform.getAngle());
+    transform.jumpTo(CameraOptions().withBearing(0.0));
+    ASSERT_DOUBLE_EQ(0, transform.getBearing());
     ASSERT_DOUBLE_EQ(latLng.latitude(), transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(latLng.longitude(), transform.getLatLng().longitude());
 
-    transform.jumpTo(CameraOptions().withAngle(45.0).withAnchor(anchorPoint));
-    ASSERT_NEAR(-45.0 * util::DEG2RAD, transform.getAngle(), 0.000001);
+    transform.jumpTo(CameraOptions().withBearing(45.0).withAnchor(anchorPoint));
+    ASSERT_NEAR(-45.0 * util::DEG2RAD, transform.getBearing(), 0.000001);
     ASSERT_NEAR(anchorLatLng.latitude(), transform.getLatLng().latitude(), 1);
     ASSERT_NEAR(anchorLatLng.longitude(), transform.getLatLng().longitude(), 1);
 

--- a/test/style/style.test.cpp
+++ b/test/style/style.test.cpp
@@ -33,7 +33,7 @@ TEST(Style, Properties) {
     style.loadJSON(R"STYLE({"bearing": 24})STYLE");
     ASSERT_EQ("", style.getName());
     ASSERT_EQ(LatLng {}, *style.getDefaultCamera().center);
-    ASSERT_EQ(24, *style.getDefaultCamera().angle);
+    ASSERT_EQ(24, *style.getDefaultCamera().bearing);
 
     style.loadJSON(R"STYLE({"zoom": 13.3})STYLE");
     ASSERT_EQ("", style.getName());
@@ -55,7 +55,7 @@ TEST(Style, Properties) {
     ASSERT_EQ("", style.getName());
     ASSERT_EQ(LatLng {}, *style.getDefaultCamera().center);
     ASSERT_EQ(0, *style.getDefaultCamera().zoom);
-    ASSERT_EQ(0, *style.getDefaultCamera().angle);
+    ASSERT_EQ(0, *style.getDefaultCamera().bearing);
     ASSERT_EQ(0, *style.getDefaultCamera().pitch);
 }
 

--- a/test/util/memory.test.cpp
+++ b/test/util/memory.test.cpp
@@ -73,7 +73,7 @@ TEST(Memory, Vector) {
     HeadlessFrontend frontend { { 256, 256 }, ratio, test.fileSource, test.threadPool };
     Map map(frontend, MapObserver::nullObserver(), frontend.getSize(), ratio, test.fileSource,
             test.threadPool, MapMode::Static);
-    map.setZoom(16); // more map features
+    map.jumpTo(CameraOptions().withZoom(16));
     map.getStyle().loadURL("mapbox://streets");
 
     frontend.render(map);
@@ -123,7 +123,7 @@ TEST(Memory, Footprint) {
         FrontendAndMap(MemoryTest& test_, const char* style)
             : frontend(Size{ 256, 256 }, 2, test_.fileSource, test_.threadPool)
             , map(frontend, MapObserver::nullObserver(), frontend.getSize(), 2, test_.fileSource, test_.threadPool, MapMode::Static) {
-            map.setZoom(16);
+            map.jumpTo(CameraOptions().withZoom(16));
             map.getStyle().loadURL(style);
             frontend.render(map);
         }

--- a/test/util/tile_cover.test.cpp
+++ b/test/util/tile_cover.test.cpp
@@ -35,7 +35,7 @@ TEST(TileCover, Pitch) {
     transform.resize({ 512, 512 });
     // slightly offset center so that tile order is better defined
 
-    transform.jumpTo(CameraOptions().withCenter(LatLng { 0.1, -0.1, }).withZoom(2.0).withAngle(5.0).withPitch(40.0));
+    transform.jumpTo(CameraOptions().withCenter(LatLng { 0.1, -0.1, }).withZoom(2.0).withBearing(5.0).withPitch(40.0));
 
     EXPECT_EQ((std::vector<UnwrappedTileID>{
         { 2, 1, 1 }, { 2, 2, 1 }, { 2, 1, 2 }, { 2, 2, 2 }


### PR DESCRIPTION
This PR introduces `Map::{scale,pitch}By` and removes redundant individual camera setters and getters, which helps to reduce our (core) public interface surface (-14.69% for `map.hpp`).

Important to notice this does not modify the platform public interfaces.