### PR TITLE
CADisplayLink method now takes a parameter as required.

### DIFF
--- a/platform/ios/Integration Tests/MGLMapViewIntegrationTest.m
+++ b/platform/ios/Integration Tests/MGLMapViewIntegrationTest.m
@@ -1,7 +1,7 @@
 #import "MGLMapViewIntegrationTest.h"
 
 @interface MGLMapView (MGLMapViewIntegrationTest)
-- (void)updateFromDisplayLink;
+- (void)updateFromDisplayLink:(CADisplayLink *)displayLink;
 @end
 
 @implementation MGLMapViewIntegrationTest
@@ -147,15 +147,20 @@
     else if (self.mapView) {
         // Before iOS 10 it seems that the display link is not called during the
         // waitForExpectations below
+        
         timer = [NSTimer scheduledTimerWithTimeInterval:1.0/30.0
-                                                 target:self.mapView
-                                               selector:@selector(updateFromDisplayLink)
+                                                 target:self
+                                               selector:@selector(updateMapViewDisplayLinkFromTimer:)
                                                userInfo:nil
                                                 repeats:YES];
     }
 
     [super waitForExpectations:expectations timeout:seconds];
     [timer invalidate];
+}
+
+- (void)updateMapViewDisplayLinkFromTimer:(NSTimer *)timer {
+    [self.mapView updateFromDisplayLink:nil];
 }
 
 - (MGLStyle *)style {

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -484,6 +484,8 @@
 		CA65C4F821E9BB080068B0D4 /* MGLCluster.h in Headers */ = {isa = PBXBuildFile; fileRef = CA65C4F721E9BB080068B0D4 /* MGLCluster.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CA65C4F921E9BB080068B0D4 /* MGLCluster.h in Headers */ = {isa = PBXBuildFile; fileRef = CA65C4F721E9BB080068B0D4 /* MGLCluster.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CA6914B520E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA6914B420E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.m */; };
+		CA7766832229C10E0008DE9E /* MGLCompactCalloutView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA8848451CBAFB9800AB86E3 /* MGLCompactCalloutView.m */; };
+		CA7766842229C11A0008DE9E /* SMCalloutView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA88488A1CBB037E00AB86E3 /* SMCalloutView.m */; };
 		CA88DC3021C85D900059ED5A /* MGLStyleURLIntegrationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CA88DC2F21C85D900059ED5A /* MGLStyleURLIntegrationTest.m */; };
 		CA8FBC0921A47BB100D1203C /* MGLRendererConfigurationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CA8FBC0821A47BB100D1203C /* MGLRendererConfigurationTests.mm */; };
 		CAA69DA4206DCD0E007279CD /* Mapbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA4A26961CB6E795000B7809 /* Mapbox.framework */; };
@@ -3050,10 +3052,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				CA4EB8C720863487006AB465 /* MGLStyleLayerIntegrationTests.m in Sources */,
+				CA7766842229C11A0008DE9E /* SMCalloutView.m in Sources */,
 				CA34C9C3207FD272005C1A06 /* MGLCameraTransitionTests.mm in Sources */,
 				16376B0A1FFD9DAF0000563E /* MBGLIntegrationTests.m in Sources */,
 				CA88DC3021C85D900059ED5A /* MGLStyleURLIntegrationTest.m in Sources */,
 				CA0C27942076CA19001CE5B7 /* MGLMapViewIntegrationTest.m in Sources */,
+				CA7766832229C10E0008DE9E /* MGLCompactCalloutView.m in Sources */,
 				CAE7AD5520F46EF5003B6782 /* MGLMapSnapshotterSwiftTests.swift in Sources */,
 				CA0C27922076C804001CE5B7 /* MGLShapeSourceTests.m in Sources */,
 				077061DA215DA00E000FEF62 /* MGLTestLocationManager.m in Sources */,

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1162,10 +1162,14 @@ public:
 
 #pragma mark - Life Cycle -
 
-- (void)updateFromDisplayLink
+- (void)updateFromDisplayLink:(CADisplayLink *)displayLink
 {
     MGLAssertIsMainThread();
 
+    if (displayLink && displayLink != _displayLink) {
+        return;
+    }
+    
     if (_needsDisplayRefresh)
     {
         _needsDisplayRefresh = NO;
@@ -1231,11 +1235,11 @@ public:
             self.mbglMap.setConstrainMode(mbgl::ConstrainMode::HeightOnly);
         }
 
-        _displayLink = [self.window.screen displayLinkWithTarget:self selector:@selector(updateFromDisplayLink)];
+        _displayLink = [self.window.screen displayLinkWithTarget:self selector:@selector(updateFromDisplayLink:)];
         [self updateDisplayLinkPreferredFramesPerSecond];
         [_displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
         _needsDisplayRefresh = YES;
-        [self updateFromDisplayLink];
+        [self updateFromDisplayLink:_displayLink];
     }
     else if ( ! isVisible && _displayLink)
     {


### PR DESCRIPTION
`-[UIScreen displayLinkWithTarget:selector:]` states that the selector 
> [...] must have the following signature: `- (void)selector:(CADisplayLink *)sender;`

This PR changes the method's signature to match. In addition, the integration test helper method has been updated.
