### PR TITLE
Mute warnings about OpenGL deprecation.

### DIFF
--- a/platform/darwin/src/MGLOpenGLStyleLayer.h
+++ b/platform/darwin/src/MGLOpenGLStyleLayer.h
@@ -27,11 +27,14 @@ MGL_EXPORT
 
 @property (nonatomic, weak, readonly) MGLStyle *style;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #if TARGET_OS_IPHONE
 @property (nonatomic, readonly) EAGLContext *context;
 #else
 @property (nonatomic, readonly) CGLContextObj context;
 #endif
+#pragma clang diagnostic pop
 
 - (instancetype)initWithIdentifier:(NSString *)identifier;
 


### PR DESCRIPTION
Follow up to https://github.com/mapbox/mapbox-gl-native/pull/13978

This silences the OpenGL deprecation warnings that occurs in projects pulling in the SDK.

e.g.

```
While building module 'Mapbox' imported from /Users/julianrex/Development/<project>/<custom MGLMapView subclass>:1:
In file included from <module-includes>:1:
In file included from /Users/julianrex/Development/<project>/Carthage/Build/iOS/Mapbox.framework/Headers/Mapbox.h:52:
/Users/julianrex/Development/<project>/Carthage/Build/iOS/Mapbox.framework/Headers/MGLOpenGLStyleLayer.h:31:33: warning: 'EAGLContext' is deprecated: first deprecated in iOS 12.0 - OpenGLES API deprecated. (Define GLES_SILENCE_DEPRECATION to silence these warnings) [-Wdeprecated-declarations]
@property (nonatomic, readonly) EAGLContext *context;
```
