### PR TITLE
[android] Adding areAllGesturesEnabled() boolean retreival method to UiSettings class

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
@@ -939,6 +939,18 @@ public final class UiSettings {
     setQuickZoomGesturesEnabled(enabled);
   }
 
+  /**
+   * <p>
+   * Retrieves the current status of whether all gestures are enabled.
+   * </p>
+   *
+   * @return If true, all gestures are enabled.
+   */
+  public boolean areAllGesturesEnabled() {
+    return rotateGesturesEnabled && tiltGesturesEnabled && zoomGesturesEnabled
+        && scrollGesturesEnabled && doubleTapGesturesEnabled && quickZoomGesturesEnabled;
+  }
+
   private void saveFocalPoint(Bundle outState) {
     outState.putParcelable(MapboxConstants.STATE_USER_FOCAL_POINT, getFocalPoint());
   }

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/UiSettingsTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/UiSettingsTest.java
@@ -384,4 +384,19 @@ public class UiSettingsTest {
     assertEquals("Zoom gesture should be disabled", false, uiSettings.isZoomGesturesEnabled());
     assertEquals("Scroll gesture should be disabled", false, uiSettings.isScrollGesturesEnabled());
   }
+
+  @Test
+  public void testAreAllGesturesEnabled() {
+    uiSettings.setAllGesturesEnabled(true);
+    assertEquals("All gestures check should return true", true,
+        uiSettings.areAllGesturesEnabled());
+  }
+
+  @Test
+  public void testAreAllGesturesEnabledWithOneGestureDisabled() {
+    uiSettings.setAllGesturesEnabled(true);
+    uiSettings.setScrollGesturesEnabled(false);
+    assertEquals("All gestures check should return false", false,
+        uiSettings.areAllGesturesEnabled());
+  }
 }


### PR DESCRIPTION
This pr adds the ability to check whether all `UiSettings` gestures are enabled or not at a certain time. In building some examples, I would've liked to be able to easily check whether _all_ gestures are enabled. It's a pretty specific use case, so no worries if we don't want to add to this SDK because of method count or whatever.