### PR TITLE
Clear callbacks as part of OnDestroy 

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapFragment.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapFragment.java
@@ -198,6 +198,14 @@ public final class MapFragment extends Fragment implements OnMapReadyCallback {
   public void onDestroyView() {
     super.onDestroyView();
     map.onDestroy();
+  }
+
+  /**
+   * Called when the fragment is destroyed.
+   */
+  @Override
+  public void onDestroy() {
+    super.onDestroy();
     mapReadyCallbackList.clear();
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
@@ -187,12 +187,20 @@ public class SupportMapFragment extends Fragment implements OnMapReadyCallback {
   }
 
   /**
-   * Called when the fragment is view hiearchy is being destroyed.
+   * Called when the fragment is view hierarchy is being destroyed.
    */
   @Override
   public void onDestroyView() {
     super.onDestroyView();
     map.onDestroy();
+  }
+
+  /**
+   * Called when the fragment is destroyed.
+   */
+  @Override
+  public void onDestroy() {
+    super.onDestroy();
     mapReadyCallbackList.clear();
   }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -162,13 +162,24 @@
         <activity
             android:name=".activity.fragment.SupportMapFragmentActivity"
             android:description="@string/description_map_fragment_support"
-            android:label="@string/activity_map_fragment_suport">
+            android:label="@string/activity_map_fragment_support">
             <meta-data
                 android:name="@string/category"
                 android:value="@string/category_fragment" />
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activity.FeatureOverviewActivity" />
+        </activity>
+        <activity
+                android:name=".activity.fragment.FragmentBackStackActivity"
+                android:description="@string/description_map_fragment_backstack"
+                android:label="@string/activity_map_fragment_backstack">
+            <meta-data
+                    android:name="@string/category"
+                    android:value="@string/category_fragment" />
+            <meta-data
+                    android:name="android.support.PARENT_ACTIVITY"
+                    android:value=".activity.FeatureOverviewActivity" />
         </activity>
         <activity
             android:name=".activity.fragment.MultiMapActivity"
@@ -884,9 +895,6 @@
                     android:value=".activity.FeatureOverviewActivity" />
         </activity>
         <!-- For Instrumentation tests -->
-        <activity
-            android:name=".activity.style.RuntimeStyleTestActivity"
-            android:screenOrientation="portrait" />
         <activity
             android:name=".activity.style.RuntimeStyleTimingTestActivity"
             android:screenOrientation="portrait" />

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/FragmentBackStackActivity.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/FragmentBackStackActivity.kt
@@ -1,0 +1,45 @@
+package com.mapbox.mapboxsdk.testapp.activity.fragment
+
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import android.view.View
+import com.mapbox.mapboxsdk.maps.MapboxMap
+import com.mapbox.mapboxsdk.maps.Style
+import com.mapbox.mapboxsdk.maps.SupportMapFragment
+import com.mapbox.mapboxsdk.testapp.R
+import kotlinx.android.synthetic.main.activity_backstack_fragment.*
+
+/**
+ * Test activity showcasing using the MapFragment API as part of a backstacked fragment.
+ */
+class FragmentBackStackActivity : AppCompatActivity() {
+
+    private lateinit var mapFragment: SupportMapFragment
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_backstack_fragment)
+
+        mapFragment = SupportMapFragment.newInstance()
+        mapFragment.getMapAsync { initMap(it) }
+
+        supportFragmentManager.beginTransaction().apply {
+            add(R.id.container, mapFragment)
+        }.commit()
+
+        button.setOnClickListener { handleClick(it) }
+    }
+
+    private fun initMap(mapboxMap: MapboxMap) {
+        mapboxMap.setStyle(Style.SATELLITE) {
+            mapboxMap.setPadding(300, 300, 300, 300)
+        }
+    }
+
+    private fun handleClick(button: View) {
+        supportFragmentManager.beginTransaction().apply {
+            replace(R.id.container, NestedViewPagerActivity.ItemAdapter.EmptyFragment())
+            addToBackStack("map_empty_fragment")
+        }.commit()
+    }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_backstack_fragment.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_backstack_fragment.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             android:layout_width="match_parent"
+             android:layout_height="match_parent">
+
+    <FrameLayout android:id="@+id/container"
+                 android:layout_width="match_parent"
+                 android:layout_height="match_parent"/>
+
+    <Button android:layout_width="match_parent"
+            android:layout_height="58dp"
+            android:id="@+id/button"
+            android:text="Replace with empty fragment"/>
+
+</FrameLayout>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
@@ -5,6 +5,7 @@
     <string name="description_cameraposition">CameraPosition capabilities</string>
     <string name="description_map_fragment">Showcase MapFragment</string>
     <string name="description_map_fragment_support">Showcase SupportMapFragment</string>
+    <string name="description_map_fragment_backstack">Showcase using a Map Fragment with a fragment backstack</string>
     <string name="description_multimap">Activity with multiple maps on screen</string>
     <string name="description_press_for_marker">Add marker to map on long press</string>
     <string name="description_camera_zoom">Different types of zoom methods</string>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="activity_map_fragment_suport">Support Map Fragment</string>
+    <string name="activity_map_fragment_support">Support Map Fragment</string>
     <string name="activity_map_fragment">Map Fragment</string>
+    <string name="activity_map_fragment_backstack">Backstack Map Fragment</string>
     <string name="activity_multimap">Multiple Maps on Screen</string>
     <string name="activity_add_bulk_markers">Add Markers In Bulk</string>
     <string name="activity_animated_symbollayer">Animated SymbolLayer</string>

--- a/platform/android/scripts/exclude-activity-gen.json
+++ b/platform/android/scripts/exclude-activity-gen.json
@@ -45,5 +45,6 @@
   "RuntimeStyleActivity",
   "GridSourceActivity",
   "AnimatedImageSourceActivity",
-  "EspressoTestActivity"
+  "EspressoTestActivity",
+  "FragmentBackStackActivity"
 ]


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/13967

This PR fixes the issue of not being able to restore a backstacked map fragment. The source of the issue stems from clearing out the OnMapReadyCallback as part of OnDestroyView, this is not correct and should only happen as part of OnDestroy. OnDestroyView can be called multiple times in a fragment life time, removing the callback makes reused fragment unusable as the callback isn't fired anymore.

Looked into adding a regression test but we need androidX for that, follow up ticket in https://github.com/mapbox/mapbox-gl-native/issues/14034. 
For now I'm punting on the manual test added.