### PR TITLE
[core] consolidate Axonometric rendering API

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -9,6 +9,7 @@
 #include <mbgl/annotation/annotation.hpp>
 #include <mbgl/map/camera.hpp>
 #include <mbgl/util/geometry.hpp>
+#include <mbgl/map/projection_mode.hpp>
 
 #include <cstdint>
 #include <string>
@@ -101,13 +102,9 @@ public:
     void setViewportMode(ViewportMode);
     ViewportMode getViewportMode() const;
 
-    // Projection mode
-    void setAxonometric(bool);
-    bool getAxonometric() const;
-    void setXSkew(double ySkew);
-    double getXSkew() const;
-    void setYSkew(double ySkew);
-    double getYSkew() const;
+    //Projection Mode
+    void setProjectionMode(const ProjectionMode&);
+    ProjectionMode getProjectionMode() const;
 
     // Size
     void setSize(Size);

--- a/include/mbgl/map/projection_mode.hpp
+++ b/include/mbgl/map/projection_mode.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <mbgl/util/optional.hpp>
+
+#include <functional>
+
+namespace mbgl {
+
+/**
+ * @brief Holds values for Axonometric rendering. All fields are
+ * optional.
+ */
+struct ProjectionMode {
+    ProjectionMode& withAxonometric(bool o) { axonometric = o; return *this; }
+    ProjectionMode& withXSkew(double o) { xSkew = o; return *this; }
+    ProjectionMode& withYSkew(double o) { ySkew = o; return *this; }
+
+    /**
+     * @brief Set to True to enable axonometric rendering, false otherwise.
+     */
+    optional<bool> axonometric;
+
+    /**
+     * @brief The X skew value represents how much to skew on the x-axis.
+     */
+    optional<double> xSkew;
+
+    /**
+     * @brief The Y skew value represents how much to skew on the y-axis.
+     */
+    optional<double> ySkew;
+};
+
+}  // namespace mbgl

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -3,6 +3,7 @@
 #include "node_feature.hpp"
 #include "node_conversion.hpp"
 
+#include <mbgl/map/projection_mode.hpp>
 #include <mbgl/util/exception.hpp>
 #include <mbgl/renderer/renderer.hpp>
 #include <mbgl/gl/headless_frontend.hpp>
@@ -446,17 +447,12 @@ void NodeMap::startRender(NodeMap::RenderOptions options) {
     camera.bearing = options.bearing;
     camera.pitch = options.pitch;
 
-    if (map->getAxonometric() != options.axonometric) {
-        map->setAxonometric(options.axonometric);
-    }
+    auto projectionOptions = mbgl::ProjectionMode()
+        .withAxonometric(options.axonometric)
+        .withXSkew(options.xSkew)
+        .withYSkew(options.ySkew);
 
-    if (map->getXSkew() != options.xSkew) {
-        map->setXSkew(options.xSkew);
-    }
-
-    if (map->getYSkew() != options.ySkew) {
-        map->setYSkew(options.ySkew);
-    }
+    map->setProjectionMode(projectionOptions);
 
     map->renderStill(camera, options.debugOptions, [this](const std::exception_ptr eptr) {
         if (eptr) {
@@ -1035,7 +1031,8 @@ void NodeMap::SetAxonometric(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     }
 
     try {
-        nodeMap->map->setAxonometric(info[0]->BooleanValue());
+        nodeMap->map->setProjectionMode(mbgl::ProjectionMode()
+                                        .withAxonometric(info[0]->BooleanValue()));
     } catch (const std::exception &ex) {
         return Nan::ThrowError(ex.what());
     }
@@ -1052,7 +1049,8 @@ void NodeMap::SetXSkew(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     }
 
     try {
-        nodeMap->map->setXSkew(info[0]->NumberValue());
+        nodeMap->map->setProjectionMode(mbgl::ProjectionMode()
+                                        .withXSkew(info[0]->NumberValue()));
     } catch (const std::exception &ex) {
         return Nan::ThrowError(ex.what());
     }
@@ -1069,7 +1067,8 @@ void NodeMap::SetYSkew(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     }
 
     try {
-        nodeMap->map->setYSkew(info[0]->NumberValue());
+        nodeMap->map->setProjectionMode(mbgl::ProjectionMode()
+                                        .withYSkew(info[0]->NumberValue()));
     } catch (const std::exception &ex) {
         return Nan::ThrowError(ex.what());
     }

--- a/src/core-files.json
+++ b/src/core-files.json
@@ -330,6 +330,7 @@
         "mbgl/map/map.hpp": "include/mbgl/map/map.hpp",
         "mbgl/map/map_observer.hpp": "include/mbgl/map/map_observer.hpp",
         "mbgl/map/mode.hpp": "include/mbgl/map/mode.hpp",
+        "mbgl/map/projection_mode.hpp": "include/mbgl/map/projection_mode.hpp",
         "mbgl/math/clamp.hpp": "include/mbgl/math/clamp.hpp",
         "mbgl/math/log2.hpp": "include/mbgl/math/log2.hpp",
         "mbgl/math/minmax.hpp": "include/mbgl/math/minmax.hpp",

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -378,31 +378,13 @@ ViewportMode Map::getViewportMode() const {
 
 #pragma mark - Projection mode
 
-void Map::setAxonometric(bool axonometric) {
-    impl->transform.setAxonometric(axonometric);
+void Map::setProjectionMode(const ProjectionMode& options) {
+    impl->transform.setProjectionMode(options);
     impl->onUpdate();
 }
 
-bool Map::getAxonometric() const {
-    return impl->transform.getAxonometric();
-}
-
-void Map::setXSkew(double xSkew) {
-    impl->transform.setXSkew(xSkew);
-    impl->onUpdate();
-}
-
-double Map::getXSkew() const {
-    return impl->transform.getXSkew();
-}
-
-void Map::setYSkew(double ySkew) {
-    impl->transform.setYSkew(ySkew);
-    impl->onUpdate();
-}
-
-double Map::getYSkew() const {
-    return impl->transform.getYSkew();
+ProjectionMode Map::getProjectionMode() const {
+    return impl->transform.getProjectionMode();
 }
 
 #pragma mark - Projection

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -435,28 +435,17 @@ ViewportMode Transform::getViewportMode() const {
 
 #pragma mark - Projection mode
 
-void Transform::setAxonometric(bool axonometric) {
-    state.axonometric = axonometric;
+void Transform::setProjectionMode(const ProjectionMode& options) {
+    state.axonometric = options.axonometric.value_or(state.axonometric);
+    state.xSkew = options.xSkew.value_or(state.xSkew);
+    state.ySkew = options.ySkew.value_or(state.ySkew);
 }
 
-bool Transform::getAxonometric() const {
-    return state.axonometric;
-}
-
-void Transform::setXSkew(double xSkew) {
-    state.xSkew = xSkew;
-}
-
-double Transform::getXSkew() const {
-    return state.xSkew;
-}
-
-void Transform::setYSkew(double ySkew) {
-    state.ySkew = ySkew;
-}
-
-double Transform::getYSkew() const {
-    return state.ySkew;
+ProjectionMode Transform::getProjectionMode() const {
+    return ProjectionMode()
+        .withAxonometric(state.axonometric)
+        .withXSkew(state.xSkew)
+        .withYSkew(state.ySkew);
 }
 
 #pragma mark - Transition

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/map/camera.hpp>
+#include <mbgl/map/projection_mode.hpp>
 #include <mbgl/map/map_observer.hpp>
 #include <mbgl/map/mode.hpp>
 #include <mbgl/map/transform_state.hpp>
@@ -84,12 +85,8 @@ public:
     ViewportMode getViewportMode() const;
 
     // Projection mode
-    void setAxonometric(bool);
-    bool getAxonometric() const;
-    void setXSkew(double xSkew);
-    double getXSkew() const;
-    void setYSkew(double ySkew);
-    double getYSkew() const;
+    void setProjectionMode(const ProjectionMode&);
+    ProjectionMode getProjectionMode() const;
 
     // Transitions
     bool inTransition() const;

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -268,6 +268,17 @@ TEST(Map, SetStyleDefaultCamera) {
     EXPECT_DOUBLE_EQ(*camera.zoom, 0.5);
 }
 
+TEST(Map, ProjectionMode) {
+    MapTest<> test;
+
+    test.map.setProjectionMode(ProjectionMode().withAxonometric(true).withXSkew(1.0).withYSkew(0.0));
+    auto options = test.map.getProjectionMode();
+
+    EXPECT_TRUE(*options.axonometric);
+    EXPECT_EQ(*options.xSkew, 1.0);
+    EXPECT_EQ(*options.ySkew, 0.0);
+}
+
 TEST(Map, SetStyleInvalidJSON) {
     Log::setObserver(std::make_unique<FixtureLogObserver>());
 

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -472,6 +472,17 @@ TEST(Transform, Camera) {
     ASSERT_DOUBLE_EQ(transform.getLatLng().longitude(), 0);
 }
 
+TEST(Transform, ProjectionMode) {
+    Transform transform;
+
+    transform.setProjectionMode(ProjectionMode().withAxonometric(true).withXSkew(1.0).withYSkew(0.0));
+    auto options = transform.getProjectionMode();
+
+    EXPECT_TRUE(*options.axonometric);
+    EXPECT_EQ(*options.xSkew, 1.0);
+    EXPECT_EQ(*options.ySkew, 0.0);
+}
+
 TEST(Transform, IsPanning)
 {
     Transform transform;


### PR DESCRIPTION
Instead of having individual APIs for setting axonometric and skew options, create ProjectionMode struct that holds all the relevant options for Axonometric rendering and introduce setter/getter on the Map for those options.