### PR TITLE
Remove hybrid library table from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,7 @@ This repository hosts the cross-platform Mapbox GL Native library, plus convenie
 | [node-mapbox-gl-native](platform/node/) | Node.js                            | [![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native/tree/master) |
 | [Mapbox Maps SDK for Qt](platform/qt)            | C++03                              | [![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native/tree/master) [![AppVeyor CI build status](https://ci.appveyor.com/api/projects/status/3q12kbcooc6df8uc?svg=true)](https://ci.appveyor.com/project/Mapbox/mapbox-gl-native) |
 
-Additional Mapbox GL Native–based libraries for **hybrid applications** are developed outside of this repository:
-
-| Toolkit                                  | Android | iOS | Developer   |
-| ---------------------------------------- | --------|-----|------------ |
-| [React Native](https://github.com/mapbox/react-native-mapbox-gl/) ([npm](https://www.npmjs.com/package/@mapbox/react-native-mapbox-gl)) | :white_check_mark: | :white_check_mark: | Mapbox |
-| [NativeScript](https://market.nativescript.org/plugins/nativescript-mapbox/) ([npm](https://www.npmjs.com/package/nativescript-mapbox/)) | :white_check_mark: | :white_check_mark: | Telerik |
-
-If your platform or hybrid application framework isn’t listed here, consider embedding [Mapbox GL JS](https://github.com/mapbox/mapbox-gl-js) using the standard Web capabilities on your platform.
+[Additional Mapbox GL Native–based libraries](https://wiki.openstreetmap.org/wiki/Mapbox_GL#Libraries) for **hybrid applications** are developed outside of this repository. If your platform or hybrid application framework isn’t listed there, consider embedding [Mapbox GL JS](https://github.com/mapbox/mapbox-gl-js) using the standard Web capabilities on your platform.
 
 ## License
 


### PR DESCRIPTION
Most of the hybrid libraries have already been removed. Of the remaining libraries, the React Native SDK is the most actively maintained, but it’s transitioning away from Mapbox stewardship: https://github.com/mapbox/react-native-mapbox-gl/issues/1238#issuecomment-461585880. [This OpenStreetMap Wiki article](https://wiki.openstreetmap.org/wiki/Mapbox_GL) has a fuller listing of GL-based libraries enjoying varying degrees of maintenance. (It would also be possible to link to a mapbox-gl-native wiki page, but this existing page is more maintainable.)

/cc @chloekraw @zugaldia @nitaliano