### PR TITLE
Get vector drawables using AppCompatResources and set them programmatically

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/IconFactory.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/IconFactory.java
@@ -9,13 +9,13 @@ import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
-import android.support.v4.content.ContextCompat;
 import android.util.DisplayMetrics;
 import android.view.WindowManager;
 
 import com.mapbox.mapboxsdk.MapStrictMode;
 import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.exceptions.TooManyIconsException;
+import com.mapbox.mapboxsdk.utils.BitmapUtils;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -30,7 +30,7 @@ import java.io.InputStream;
  *
  * @deprecated As of 7.0.0,
  * use <a href="https://github.com/mapbox/mapbox-plugins-android/tree/master/plugin-annotation">
- *   Mapbox Annotation Plugin</a> instead
+ * Mapbox Annotation Plugin</a> instead
  */
 @Deprecated
 public final class IconFactory {
@@ -100,7 +100,7 @@ public final class IconFactory {
    * @return The icon that was loaded from the asset or {@code null} if failed to load.
    */
   public Icon fromResource(@DrawableRes int resourceId) {
-    Drawable drawable = ContextCompat.getDrawable(context, resourceId);
+    Drawable drawable = BitmapUtils.getDrawableFromRes(context, resourceId);
     if (drawable instanceof BitmapDrawable) {
       BitmapDrawable bitmapDrawable = (BitmapDrawable) drawable;
       return fromBitmap(bitmapDrawable.getBitmap());

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LayerBitmapProvider.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LayerBitmapProvider.java
@@ -6,13 +6,11 @@ import android.graphics.drawable.Drawable;
 import android.support.annotation.ColorInt;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
-import android.support.v4.content.ContextCompat;
 
 import com.mapbox.mapboxsdk.R;
+import com.mapbox.mapboxsdk.utils.BitmapUtils;
 
 import static com.mapbox.mapboxsdk.location.Utils.generateShadow;
-import static com.mapbox.mapboxsdk.location.Utils.getBitmapFromDrawable;
-import static com.mapbox.mapboxsdk.location.Utils.getDrawable;
 
 class LayerBitmapProvider {
 
@@ -23,12 +21,12 @@ class LayerBitmapProvider {
   }
 
   Bitmap generateBitmap(@DrawableRes int drawableRes, @ColorInt Integer tintColor) {
-    Drawable drawable = getDrawable(context, drawableRes, tintColor);
-    return getBitmapFromDrawable(drawable);
+    Drawable drawable = BitmapUtils.getDrawableFromRes(context, drawableRes, tintColor);
+    return BitmapUtils.getBitmapFromDrawable(drawable);
   }
 
   Bitmap generateShadowBitmap(@NonNull LocationComponentOptions options) {
-    Drawable shadowDrawable = ContextCompat.getDrawable(context, R.drawable.mapbox_user_icon_shadow);
+    Drawable shadowDrawable = BitmapUtils.getDrawableFromRes(context, R.drawable.mapbox_user_icon_shadow);
     return generateShadow(shadowDrawable, options.elevation());
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/Utils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/Utils.java
@@ -1,18 +1,11 @@
 package com.mapbox.mapboxsdk.location;
 
-import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
-import android.graphics.PorterDuff;
-import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.location.Location;
-import android.os.Build;
-import android.support.annotation.ColorInt;
-import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v4.content.ContextCompat;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
@@ -43,20 +36,6 @@ public final class Utils {
     return heading;
   }
 
-  static Bitmap getBitmapFromDrawable(Drawable drawable) {
-    if (drawable instanceof BitmapDrawable) {
-      return ((BitmapDrawable) drawable).getBitmap();
-    } else {
-      // width and height are equal for all assets since they are ovals.
-      Bitmap bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(),
-        drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
-      Canvas canvas = new Canvas(bitmap);
-      drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
-      drawable.draw(canvas);
-      return bitmap;
-    }
-  }
-
   static Bitmap generateShadow(Drawable drawable, float elevation) {
     int width = drawable.getIntrinsicWidth();
     int height = drawable.getIntrinsicHeight();
@@ -67,22 +46,6 @@ public final class Utils {
     bitmap = Bitmap.createScaledBitmap(bitmap,
       toEven(width + elevation), toEven(height + elevation), false);
     return bitmap;
-  }
-
-  @Nullable
-  static Drawable getDrawable(@NonNull Context context, @DrawableRes int drawableRes,
-                              @Nullable @ColorInt Integer tintColor) {
-    Drawable drawable = ContextCompat.getDrawable(context, drawableRes);
-    if (tintColor == null) {
-      return drawable;
-    }
-
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      drawable.setTint(tintColor);
-    } else {
-      drawable.mutate().setColorFilter(tintColor, PorterDuff.Mode.SRC_IN);
-    }
-    return drawable;
   }
 
   static float calculateZoomLevelRadius(@NonNull MapboxMap mapboxMap, @Nullable Location location) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -129,7 +129,9 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     View view = LayoutInflater.from(context).inflate(R.layout.mapbox_mapview_internal, this);
     compassView = view.findViewById(R.id.compassView);
     attrView = view.findViewById(R.id.attributionView);
+    attrView.setImageDrawable(BitmapUtils.getDrawableFromRes(getContext(), R.drawable.mapbox_info_bg_selector));
     logoView = view.findViewById(R.id.logoView);
+    logoView.setImageDrawable(BitmapUtils.getDrawableFromRes(getContext(), R.drawable.mapbox_logo_icon));
 
     // add accessibility support
     setContentDescription(context.getString(R.string.mapbox_mapActionDescription));

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/ImageSource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/ImageSource.java
@@ -9,10 +9,10 @@ import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
-import android.support.v4.content.ContextCompat;
 
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.geometry.LatLngQuad;
+import com.mapbox.mapboxsdk.utils.BitmapUtils;
 
 import java.net.URL;
 
@@ -115,7 +115,7 @@ public class ImageSource extends Source {
   public void setImage(@DrawableRes int resourceId) throws IllegalArgumentException {
     checkThread();
     Context context = Mapbox.getApplicationContext();
-    Drawable drawable = ContextCompat.getDrawable(context, resourceId);
+    Drawable drawable = BitmapUtils.getDrawableFromRes(context, resourceId);
     if (drawable instanceof BitmapDrawable) {
       BitmapDrawable bitmapDrawable = (BitmapDrawable) drawable;
       nativeSetImage(bitmapDrawable.getBitmap());

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/BitmapUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/BitmapUtils.java
@@ -4,11 +4,16 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
+import android.graphics.PorterDuff;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.support.annotation.ColorInt;
+import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
+import android.support.v7.content.res.AppCompatResources;
 import android.view.View;
 
 import java.io.ByteArrayOutputStream;
@@ -124,6 +129,45 @@ public class BitmapUtils {
     return new BitmapDrawable(context.getResources(), compass);
   }
 
+  /**
+   * Get a drawable from a resource.
+   *
+   * @param context     Context to obtain {@link android.content.res.Resources}
+   * @param drawableRes Drawable resource
+   * @return The drawable created from the resource
+   */
+  @Nullable
+  public static Drawable getDrawableFromRes(@NonNull Context context, @DrawableRes int drawableRes) {
+    return getDrawableFromRes(context, drawableRes, null);
+  }
+
+  /**
+   * Get a tinted drawable from a resource.
+   *
+   * @param context     Context to obtain {@link android.content.res.Resources}
+   * @param drawableRes Drawable resource
+   * @param tintColor   Tint color
+   * @return The drawable created from the resource
+   */
+  @Nullable
+  public static Drawable getDrawableFromRes(@NonNull Context context, @DrawableRes int drawableRes,
+                                            @Nullable @ColorInt Integer tintColor) {
+    Drawable drawable = AppCompatResources.getDrawable(context, drawableRes);
+    if (drawable == null) {
+      return null;
+    }
+
+    if (tintColor == null) {
+      return drawable;
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      drawable.setTint(tintColor);
+    } else {
+      drawable.mutate().setColorFilter(tintColor, PorterDuff.Mode.SRC_IN);
+    }
+    return drawable;
+  }
 
   /**
    * Validates if the bytes of a bitmap matches another

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_internal.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_internal.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
 
     <com.mapbox.mapboxsdk.maps.widgets.CompassView
         android:id="@+id/compassView"
@@ -12,8 +12,7 @@
         android:id="@+id/logoView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:contentDescription="@null"
-        app:srcCompat="@drawable/mapbox_logo_icon"/>
+        android:contentDescription="@null"/>
 
     <android.support.v7.widget.AppCompatImageView
         android:visibility="gone"
@@ -23,7 +22,6 @@
         android:adjustViewBounds="true"
         android:clickable="true"
         android:focusable="true"
-        android:contentDescription="@string/mapbox_attributionsIconContentDescription"
-        app:srcCompat="@drawable/mapbox_info_bg_selector"/>
+        android:contentDescription="@string/mapbox_attributionsIconContentDescription"/>
 
 </merge>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
@@ -13,7 +13,6 @@ import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.matcher.ViewMatchers.*
 import android.support.test.rule.GrantPermissionRule
 import android.support.test.runner.AndroidJUnit4
-import android.support.v4.content.ContextCompat
 import com.mapbox.geojson.Point
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
 import com.mapbox.mapboxsdk.geometry.LatLng
@@ -28,6 +27,7 @@ import com.mapbox.mapboxsdk.maps.Style
 import com.mapbox.mapboxsdk.testapp.activity.EspressoTest
 import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity
 import com.mapbox.mapboxsdk.testapp.utils.TestingAsyncUtils
+import com.mapbox.mapboxsdk.utils.BitmapUtils
 import com.mapbox.mapboxsdk.utils.ColorUtils
 import org.hamcrest.CoreMatchers.*
 import org.junit.*
@@ -277,7 +277,7 @@ class LocationComponentTest : EspressoTest() {
 
         component.isLocationComponentEnabled = true
 
-        val foregroundDrawable = ContextCompat.getDrawable(context, R.drawable.ic_media_play)
+        val foregroundDrawable = BitmapUtils.getDrawableFromRes(context, R.drawable.ic_media_play)
         foregroundDrawable?.let {
           mapboxMap.addImageFromDrawable("custom-foreground-bitmap", it)
           mapboxMap.addImageFromDrawable("custom-background-bitmap", it)
@@ -324,7 +324,7 @@ class LocationComponentTest : EspressoTest() {
 
         component.renderMode = RenderMode.GPS
         component.forceLocationUpdate(location)
-        val foregroundDrawable = ContextCompat.getDrawable(context, R.drawable.ic_media_play)
+        val foregroundDrawable = BitmapUtils.getDrawableFromRes(context, R.drawable.ic_media_play)
         foregroundDrawable?.let {
           mapboxMap.addImageFromDrawable("custom-foreground-bitmap", it)
           mapboxMap.addImageFromDrawable("custom-gps-bitmap", it)

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/AnimatedImageSourceActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/AnimatedImageSourceActivity.java
@@ -7,7 +7,6 @@ import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
-import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 
 import com.mapbox.mapboxsdk.Mapbox;
@@ -20,6 +19,7 @@ import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.layers.RasterLayer;
 import com.mapbox.mapboxsdk.style.sources.ImageSource;
 import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.utils.BitmapUtils;
 
 /**
  * Test activity showing how to use a series of images to create an animation
@@ -112,7 +112,7 @@ public class AnimatedImageSourceActivity extends AppCompatActivity implements On
 
     Bitmap getBitmap(int resourceId) {
       Context context = Mapbox.getApplicationContext();
-      Drawable drawable = ContextCompat.getDrawable(context, resourceId);
+      Drawable drawable = BitmapUtils.getDrawableFromRes(context, resourceId);
       if (drawable instanceof BitmapDrawable) {
         BitmapDrawable bitmapDrawable = (BitmapDrawable) drawable;
         return bitmapDrawable.getBitmap();


### PR DESCRIPTION
This PR should enable running the map in the activities that extend from `android.app.Activity` on KItKat and below.

I have verified the behavior on Android versions `9.0` and `4.3` and encountered no issues.