### PR TITLE
Publish SNAPSHOTs to oss.jfrog.org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -707,6 +707,11 @@ android-ui-test: platform/android/gradle/configuration.gradle
 run-android-upload-to-bintray: platform/android/gradle/configuration.gradle
 	cd platform/android && $(MBGL_ANDROID_GRADLE) -Pmapbox.abis=all :MapboxGLAndroidSDK:bintrayUpload
 
+# Uploads the compiled Android SDK SNAPSHOT to oss.jfrog.org
+.PHONY: run-android-upload-to-artifactory
+run-android-upload-to-artifactory: platform/android/gradle/configuration.gradle
+	cd platform/android && $(MBGL_ANDROID_GRADLE) -Pmapbox.abis=all :MapboxGLAndroidSDK:artifactoryPublish
+
 # Dump system graphics information for the test app
 .PHONY: android-gfxinfo
 android-gfxinfo:

--- a/circle.yml
+++ b/circle.yml
@@ -672,6 +672,8 @@ jobs:
               version=$(cat platform/android/MapboxGLAndroidSDK/gradle.properties | grep "VERSION_NAME")
               if [[ $version != *"SNAPSHOT"* ]]; then
                 make run-android-upload-to-bintray
+              else
+                make run-android-upload-to-artifactory
               fi
             fi
 # ------------------------------------------------------------------------------

--- a/platform/android/README.md
+++ b/platform/android/README.md
@@ -98,11 +98,11 @@ More information about building and distributing this project in [DISTRIBUTE.md]
 
 #### Using the SDK snapshot
 
-Instead of using the latest stable release of the Maps SDK for Android, you can use a "snapshot" or the beta version if there is one available. Our snapshots are built every time a Github pull request adds code to this repository's `master` branch. If you'd like to use a snapshot build, your Android project's gradle file should have -SNAPSHOT appended to the SDK version number. For example, the `5.2.0-SNAPSHOT` would look like:
+Instead of using the latest stable release of the Maps SDK for Android, you can use a "snapshot" or the beta version if there is one available. Our snapshots are built every time a Github pull request adds code to this repository's `master` branch. If you'd like to use a snapshot build, your Android project's gradle file should have -SNAPSHOT appended to the SDK version number. For example, the `7.3.0-SNAPSHOT` would look like:
 
 ```java
 // Mapbox SDK dependency
-implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:5.2.0-SNAPSHOT'
+implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:7.3.0-SNAPSHOT'
 ```
 
 You also need to have the section below in your build.gradle root folder to be able to resolve the SNAPSHOT dependencies:
@@ -110,7 +110,7 @@ You also need to have the section below in your build.gradle root folder to be a
 allprojects {
     repositories {
         jcenter()
-        maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
+        maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local/' }
     }
 }
 ```

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         classpath dependenciesList.licensesPlugin
         classpath dependenciesList.kotlinPlugin
         classpath dependenciesList.bintrayPlugin
+        classpath dependenciesList.artifactoryPlugin
         classpath dependenciesList.androidPublishPlugin
     }
 }

--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -25,6 +25,7 @@ ext {
             kotlin          : '1.3.11',
             licenses        : '0.8.42',
             bintray         : '1.8.4',
+            artifactory     : '4.9.3',
             androidPublish  : '3.6.2',
             lint            : '26.1.4',
             gms             : '16.0.0',
@@ -69,6 +70,7 @@ ext {
             kotlinPlugin           : "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
             licensesPlugin         : "com.jaredsburrows:gradle-license-plugin:${versions.licenses}",
             bintrayPlugin          : "com.jfrog.bintray.gradle:gradle-bintray-plugin:${versions.bintray}",
+            artifactoryPlugin      : "org.jfrog.buildinfo:build-info-extractor-gradle:${versions.artifactory}",
             androidPublishPlugin   : "digital.wup:android-maven-publish:${versions.androidPublish}",
 
             lint                   : "com.android.tools.lint:lint:${versions.lint}",

--- a/platform/android/gradle/gradle-bintray.gradle
+++ b/platform/android/gradle/gradle-bintray.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'digital.wup.android-maven-publish'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
+apply plugin: 'com.jfrog.artifactory'
 apply from: file('../gradle/artifact-settings.gradle')
 
 version = project.ext.versionName
@@ -66,6 +67,20 @@ bintray {
             mavenCentralSync {
                 sync = false
             }
+        }
+    }
+}
+
+artifactory {
+    contextUrl = 'http://oss.jfrog.org'
+    publish {
+        repository {
+            repoKey = 'oss-snapshot-local'
+            username = mapboxBintrayUser
+            password = mapboxBintrayApiKey
+        }
+        defaults {
+            publications('MapboxMapsSdkPublication')
         }
     }
 }


### PR DESCRIPTION
Changes the Maps SDK `SNAPSHOT` repository to `https://oss.jfrog.org/artifactory/oss-snapshot-local/`.

/cc @mapbox/android 