### PR TITLE
[core] Use ES6 import / export syntax for node test harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build=false || make node",
-    "test": "tape platform/node/test/js/**/*.test.js",
+    "test": "tape -r esm platform/node/test/js/**/*.test.js",
     "test-memory": "node --expose-gc platform/node/test/memory.test.js",
     "test-suite": "run-s test-render test-query test-expressions",
     "test-expressions": "node -r esm platform/node/test/expression.test.js",

--- a/platform/node/index.js
+++ b/platform/node/index.js
@@ -48,4 +48,4 @@ var Map = function(options) {
 Map.prototype = mbgl.Map.prototype;
 Map.prototype.constructor = Map;
 
-module.exports = Object.assign(mbgl, { Map: Map });
+export default Object.assign(mbgl, { Map: Map });

--- a/platform/node/test/js/cancel.test.js
+++ b/platform/node/test/js/cancel.test.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var mockfs = require('./../mockfs');
-var mbgl = require('../../index');
-var test = require('tape');
+import mockfs from './../mockfs';
+import mbgl from '../../index';
+import test from'tape';
 
 var options = {
     request: function(req, callback) {

--- a/platform/node/test/js/map.test.js
+++ b/platform/node/test/js/map.test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var test = require('tape');
-var mbgl = require('../../index');
-var fs = require('fs');
-var path = require('path');
-var style = require('../fixtures/style.json');
+import test from 'tape';
+import mbgl from '../../index';
+import fs from 'fs';
+import path from 'path';
+import style from '../fixtures/style.json';
 
 test('Map', function(t) {
     // This test is skipped because of the req.respond shim in index.js

--- a/platform/node/test/js/request.test.js
+++ b/platform/node/test/js/request.test.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var mockfs = require('../mockfs');
-var mbgl = require('../../index');
-var test = require('tape');
+import mockfs from '../mockfs';
+import mbgl from '../../index';
+import test from 'tape';
 
 [ 'sprite_png', 'sprite_json', 'source_vector', 'glyph' ].forEach(function (resource) {
     test(`render reports an error when the request function responds with an error (${resource})`, function(t) {


### PR DESCRIPTION
Looks like `node-clang39-release` and `node-gcc8-debug` bots were failing because we mix ES5 / ES6 module syntax. This PR attempts to use ES6 syntax wherever possible.