### PR TITLE
Introduce BoundOptions

### DIFF
--- a/include/mbgl/map/bound_options.hpp
+++ b/include/mbgl/map/bound_options.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <mbgl/util/geo.hpp>
+#include <mbgl/util/optional.hpp>
+
+namespace mbgl {
+
+/**
+ * @brief Holds options to limit what parts of a map are visible. All fields are
+ * optional.
+ */
+struct BoundOptions {
+    /// Sets the latitude and longitude bounds to which the camera center are constrained
+    BoundOptions& withLatLngBounds(LatLngBounds b) { bounds = b; return *this; }
+    /// Sets the minimum zoom level
+    BoundOptions& withMinZoom(double z) { minZoom = z; return *this; }
+    /// Sets the maximum zoom level
+    BoundOptions& withMaxZoom(double z) { maxZoom = z; return *this; }
+
+    /// Constrain the center of the camera to be within these bounds.
+    optional<LatLngBounds> bounds;
+
+    /// Maximum zoom level allowed.
+    optional<double> maxZoom;
+
+    /// Minimum zoom level allowed.
+    optional<double> minZoom;
+};
+
+}  // namespace mbgl

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -77,8 +77,8 @@ public:
     LatLngBounds latLngBoundsForCamera(const CameraOptions&) const;
 
     // Bounds
-    void setLatLngBounds(optional<LatLngBounds>);
-    optional<LatLngBounds> getLatLngBounds() const;
+    void setLatLngBounds(LatLngBounds);
+    LatLngBounds getLatLngBounds() const;
     void setMinZoom(double);
     double getMinZoom() const;
     void setMaxZoom(double);

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -83,10 +83,6 @@ public:
     double getMinZoom() const;
     void setMaxZoom(double);
     double getMaxZoom() const;
-    void setMinPitch(double);
-    double getMinPitch() const;
-    void setMaxPitch(double);
-    double getMaxPitch() const;
 
     // North Orientation
     void setNorthOrientation(NorthOrientation);

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/util/optional.hpp>
 #include <mbgl/util/chrono.hpp>
+#include <mbgl/map/bound_options.hpp>
 #include <mbgl/map/map_observer.hpp>
 #include <mbgl/map/map_options.hpp>
 #include <mbgl/map/mode.hpp>
@@ -76,13 +77,15 @@ public:
     CameraOptions cameraForGeometry(const Geometry<double>&, const EdgeInsets&, optional<double> bearing = {}, optional<double> pitch = {}) const;
     LatLngBounds latLngBoundsForCamera(const CameraOptions&) const;
 
-    // Bounds
-    void setLatLngBounds(LatLngBounds);
-    LatLngBounds getLatLngBounds() const;
-    void setMinZoom(double);
-    double getMinZoom() const;
-    void setMaxZoom(double);
-    double getMaxZoom() const;
+    /// @name Bounds
+    /// @{
+
+    void setBounds(const BoundOptions& options);
+
+    /// Returns the current map bound options. All optional fields in BoundOptions are set.
+    BoundOptions getBounds() const;
+
+    /// @}
 
     // North Orientation
     void setNorthOrientation(NorthOrientation);

--- a/include/mbgl/util/constants.hpp
+++ b/include/mbgl/util/constants.hpp
@@ -33,6 +33,7 @@ constexpr double EARTH_RADIUS_M = 6378137;
 constexpr double LATITUDE_MAX = 85.051128779806604;
 constexpr double LONGITUDE_MAX = 180;
 constexpr double DEGREES_MAX = 360;
+constexpr double PITCH_MIN = 0.0;
 constexpr double PITCH_MAX = M_PI / 3;
 constexpr double MIN_ZOOM = 0.0;
 constexpr double MAX_ZOOM = 25.5;

--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -105,6 +105,15 @@ public:
         return bounds;
     }
 
+    /// Returns an infinite bound, a bound for which the constrain method returns its
+    /// input unmodified.
+    ///
+    /// Note: this is different than LatLngBounds::world() since arbitrary unwrapped
+    /// coordinates are also inside the bounds.
+    static LatLngBounds unbounded() {
+        return {};
+    }
+
     // Constructs a LatLngBounds object with the tile's exact boundaries.
     LatLngBounds(const CanonicalTileID&);
 
@@ -159,15 +168,19 @@ public:
 private:
     LatLng sw;
     LatLng ne;
+    bool bounded = true;
 
     LatLngBounds(LatLng sw_, LatLng ne_)
         : sw(std::move(sw_)), ne(std::move(ne_)) {}
+
+    LatLngBounds()
+        : sw({-90, -180}), ne({90, 180}), bounded(false) {}
 
     bool containsLatitude(double latitude) const;
     bool containsLongitude(double longitude, LatLng::WrapMode wrap) const;
 
     friend bool operator==(const LatLngBounds& a, const LatLngBounds& b) {
-        return a.sw == b.sw && a.ne == b.ne;
+        return (!a.bounded && !b.bounded) || (a.bounded && b.bounded && a.sw == b.sw && a.ne == b.ne);
     }
 
     friend bool operator!=(const LatLngBounds& a, const LatLngBounds& b) {

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -287,11 +287,13 @@ void NativeMapView::setStyleJson(jni::JNIEnv& env, const jni::String& json) {
 }
 
 void NativeMapView::setLatLngBounds(jni::JNIEnv& env, const jni::Object<mbgl::android::LatLngBounds>& jBounds) {
+    mbgl::BoundOptions bounds;
     if (jBounds) {
-        map->setLatLngBounds(mbgl::android::LatLngBounds::getLatLngBounds(env, jBounds));
+        bounds.withLatLngBounds(mbgl::android::LatLngBounds::getLatLngBounds(env, jBounds));
     } else {
-        map->setLatLngBounds(mbgl::LatLngBounds::world());
+        bounds.withLatLngBounds(mbgl::LatLngBounds::world());
     }
+    map->setBounds(bounds);
 }
 
 void NativeMapView::cancelTransitions(jni::JNIEnv&) {
@@ -424,19 +426,19 @@ void NativeMapView::resetZoom(jni::JNIEnv&) {
 }
 
 void NativeMapView::setMinZoom(jni::JNIEnv&, jni::jdouble zoom) {
-    map->setMinZoom(zoom);
+    map->setBounds(BoundOptions().withMinZoom(zoom));
 }
 
 jni::jdouble NativeMapView::getMinZoom(jni::JNIEnv&) {
-    return map->getMinZoom();
+    return *map->getBounds().minZoom;
 }
 
 void NativeMapView::setMaxZoom(jni::JNIEnv&, jni::jdouble zoom) {
-    map->setMaxZoom(zoom);
+    map->setBounds(BoundOptions().withMaxZoom(zoom));
 }
 
 jni::jdouble NativeMapView::getMaxZoom(jni::JNIEnv&) {
-    return map->getMaxZoom();
+    return *map->getBounds().maxZoom;
 }
 
 void NativeMapView::rotateBy(jni::JNIEnv&, jni::jdouble sx, jni::jdouble sy, jni::jdouble ex, jni::jdouble ey, jni::jlong duration) {

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -296,7 +296,7 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
             mbgl::LatLngBounds bound = bounds[nextBound++];
             nextBound = nextBound % bounds.size();
 
-            view->map->setLatLngBounds(bound);
+            view->map->setBounds(mbgl::BoundOptions().withLatLngBounds(bound));
 
             if (bound == mbgl::LatLngBounds::unbounded()) {
                 view->map->removeAnnotation(boundAnnotationID);

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1661,7 +1661,7 @@ public:
             newScale += scale / (velocity * duration) * 0.1;
         }
 
-        if (newScale <= 0 || log2(newScale) < self.mbglMap.getMinZoom())
+        if (newScale <= 0 || log2(newScale) < *self.mbglMap.getBounds().minZoom)
         {
             velocity = 0;
         }
@@ -1927,7 +1927,7 @@ public:
 
     if ( ! self.isZoomEnabled) return;
 
-    if ([self zoomLevel] == self.mbglMap.getMinZoom()) return;
+    if ([self zoomLevel] == *self.mbglMap.getBounds().minZoom) return;
 
     [self cancelTransitions];
 
@@ -1979,7 +1979,7 @@ public:
     {
         CGFloat distance = [quickZoom locationInView:quickZoom.view].y - self.quickZoomStart;
 
-        CGFloat newZoom = MAX(log2f(self.scale) + (distance / 75), self.mbglMap.getMinZoom());
+        CGFloat newZoom = MAX(log2f(self.scale) + (distance / 75), *self.mbglMap.getBounds().minZoom);
 
         if ([self zoomLevel] == newZoom) return;
 
@@ -3251,23 +3251,23 @@ public:
 - (void)setMinimumZoomLevel:(double)minimumZoomLevel
 {
     MGLLogDebug(@"Setting minimumZoomLevel: %f", minimumZoomLevel);
-    self.mbglMap.setMinZoom(minimumZoomLevel);
+    self.mbglMap.setBounds(mbgl::BoundOptions().withMinZoom(minimumZoomLevel));
 }
 
 - (double)minimumZoomLevel
 {
-    return self.mbglMap.getMinZoom();
+    return *self.mbglMap.getBounds().minZoom;
 }
 
 - (void)setMaximumZoomLevel:(double)maximumZoomLevel
 {
     MGLLogDebug(@"Setting maximumZoomLevel: %f", maximumZoomLevel);
-    self.mbglMap.setMaxZoom(maximumZoomLevel);
+    self.mbglMap.setBounds(mbgl::BoundOptions().withMaxZoom(maximumZoomLevel));
 }
 
 - (double)maximumZoomLevel
 {
-    return self.mbglMap.getMaxZoom();
+    return *self.mbglMap.getBounds().maxZoom;
 }
 
 - (MGLCoordinateBounds)visibleCoordinateBounds
@@ -5847,7 +5847,7 @@ public:
 
 - (CGFloat)currentMinimumZoom
 {
-    return fmaxf(self.mbglMap.getMinZoom(), MGLMinimumZoom);
+    return fmaxf(*self.mbglMap.getBounds().minZoom, MGLMinimumZoom);
 }
 
 - (BOOL)isRotationAllowed

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -328,7 +328,7 @@ public:
     mbgl::CameraOptions options;
     options.center = mbgl::LatLng(0, 0);
     options.padding = MGLEdgeInsetsFromNSEdgeInsets(self.contentInsets);
-    options.zoom = _mbglMap->getMinZoom();
+    options.zoom = *_mbglMap->getBounds().minZoom;
     _mbglMap->jumpTo(options);
     _pendingLatitude = NAN;
     _pendingLongitude = NAN;
@@ -1094,21 +1094,21 @@ public:
 - (void)setMinimumZoomLevel:(double)minimumZoomLevel
 {
     MGLLogDebug(@"Setting minimumZoomLevel: %f", minimumZoomLevel);
-    _mbglMap->setMinZoom(minimumZoomLevel);
+    _mbglMap->setBounds(mbgl::BoundOptions().withMinZoom(minimumZoomLevel));
 }
 
 - (void)setMaximumZoomLevel:(double)maximumZoomLevel
 {
     MGLLogDebug(@"Setting maximumZoomLevel: %f", maximumZoomLevel);
-    _mbglMap->setMaxZoom(maximumZoomLevel);
+    _mbglMap->setBounds(mbgl::BoundOptions().withMaxZoom(maximumZoomLevel));
 }
 
 - (double)maximumZoomLevel {
-    return _mbglMap->getMaxZoom();
+    return *_mbglMap->getBounds().maxZoom;
 }
 
 - (double)minimumZoomLevel {
-    return _mbglMap->getMinZoom();
+    return *_mbglMap->getBounds().minZoom;
 }
 
 /// Respond to a click on the zoom control.

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -765,7 +765,7 @@ void QMapboxGL::setZoom(double zoom_)
 */
 double QMapboxGL::minimumZoom() const
 {
-    return d_ptr->mapObj->getMinZoom();
+    return *d_ptr->mapObj->getBounds().minZoom;
 }
 
 /*!
@@ -775,7 +775,7 @@ double QMapboxGL::minimumZoom() const
 */
 double QMapboxGL::maximumZoom() const
 {
-    return d_ptr->mapObj->getMaxZoom();
+    return *d_ptr->mapObj->getBounds().maxZoom;
 }
 
 /*!

--- a/src/core-files.json
+++ b/src/core-files.json
@@ -327,6 +327,7 @@
         "mbgl/layermanager/line_layer_factory.hpp": "include/mbgl/layermanager/line_layer_factory.hpp",
         "mbgl/layermanager/raster_layer_factory.hpp": "include/mbgl/layermanager/raster_layer_factory.hpp",
         "mbgl/layermanager/symbol_layer_factory.hpp": "include/mbgl/layermanager/symbol_layer_factory.hpp",
+        "mbgl/map/bound_options.hpp": "include/mbgl/map/bound_options.hpp",
         "mbgl/map/camera.hpp": "include/mbgl/map/camera.hpp",
         "mbgl/map/change.hpp": "include/mbgl/map/change.hpp",
         "mbgl/map/map.hpp": "include/mbgl/map/map.hpp",

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -275,13 +275,13 @@ LatLngBounds Map::latLngBoundsForCamera(const CameraOptions& camera) const {
 
 #pragma mark - Bounds
 
-optional<LatLngBounds> Map::getLatLngBounds() const {
+LatLngBounds Map::getLatLngBounds() const {
     return impl->transform.getState().getLatLngBounds();
 }
 
-void Map::setLatLngBounds(optional<LatLngBounds> bounds) {
+void Map::setLatLngBounds(LatLngBounds bounds) {
     impl->cameraMutated = true;
-    impl->transform.setLatLngBounds(bounds);
+    impl->transform.setLatLngBounds(std::move(bounds));
     impl->onUpdate();
 }
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -307,28 +307,6 @@ double Map::getMaxZoom() const {
     return impl->transform.getState().getMaxZoom();
 }
 
-void Map::setMinPitch(double minPitch) {
-    impl->transform.setMinPitch(minPitch * util::DEG2RAD);
-    if (impl->transform.getPitch() < minPitch) {
-        jumpTo(CameraOptions().withPitch(minPitch));
-    }
-}
-
-double Map::getMinPitch() const {
-    return impl->transform.getState().getMinPitch() * util::RAD2DEG;
-}
-
-void Map::setMaxPitch(double maxPitch) {
-    impl->transform.setMaxPitch(maxPitch * util::DEG2RAD);
-    if (impl->transform.getPitch() > maxPitch) {
-        jumpTo(CameraOptions().withPitch(maxPitch));
-    }
-}
-
-double Map::getMaxPitch() const {
-    return impl->transform.getState().getMaxPitch() * util::RAD2DEG;
-}
-
 #pragma mark - Size
 
 void Map::setSize(const Size size) {

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -275,36 +275,41 @@ LatLngBounds Map::latLngBoundsForCamera(const CameraOptions& camera) const {
 
 #pragma mark - Bounds
 
-LatLngBounds Map::getLatLngBounds() const {
-    return impl->transform.getState().getLatLngBounds();
-}
+void Map::setBounds(const BoundOptions& options) {
+    bool changeCamera = false;
+    CameraOptions cameraOptions;
 
-void Map::setLatLngBounds(LatLngBounds bounds) {
-    impl->cameraMutated = true;
-    impl->transform.setLatLngBounds(std::move(bounds));
-    impl->onUpdate();
-}
+    if (options.bounds) {
+        changeCamera = true;
+        impl->transform.setLatLngBounds(*options.bounds);
+    }
 
-void Map::setMinZoom(const double minZoom) {
-    impl->transform.setMinZoom(minZoom);
-    if (impl->transform.getZoom() < minZoom) {
-        jumpTo(CameraOptions().withZoom(minZoom));
+    if (options.minZoom) {
+        impl->transform.setMinZoom(*options.minZoom);
+        if (impl->transform.getZoom() < *options.minZoom) {
+            changeCamera = true;
+            cameraOptions.withZoom(*options.minZoom);
+        }
+    }
+
+    if (options.maxZoom) {
+        impl->transform.setMaxZoom(*options.maxZoom);
+        if (impl->transform.getZoom() > *options.maxZoom) {
+            changeCamera = true;
+            cameraOptions.withZoom(*options.maxZoom);
+        }
+    }
+
+    if (changeCamera) {
+        jumpTo(cameraOptions);
     }
 }
 
-double Map::getMinZoom() const {
-    return impl->transform.getState().getMinZoom();
-}
-
-void Map::setMaxZoom(const double maxZoom) {
-    impl->transform.setMaxZoom(maxZoom);
-    if (impl->transform.getZoom() > maxZoom) {
-        jumpTo(CameraOptions().withZoom(maxZoom));
-    }
-}
-
-double Map::getMaxZoom() const {
-    return impl->transform.getState().getMaxZoom();
+BoundOptions Map::getBounds() const {
+    return BoundOptions()
+        .withLatLngBounds(impl->transform.getState().getLatLngBounds())
+        .withMinZoom(impl->transform.getState().getMinZoom())
+        .withMaxZoom(impl->transform.getState().getMaxZoom());
 }
 
 #pragma mark - Size

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -85,7 +85,7 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
     const EdgeInsets& padding = camera.padding;
     LatLng startLatLng = getLatLng(padding, LatLng::Unwrapped);
     const LatLng& unwrappedLatLng = camera.center.value_or(startLatLng);
-    const LatLng& latLng = state.bounds ? unwrappedLatLng : unwrappedLatLng.wrapped();
+    const LatLng& latLng = state.bounds != LatLngBounds::unbounded() ? unwrappedLatLng : unwrappedLatLng.wrapped();
     double zoom = camera.zoom.value_or(getZoom());
     double bearing = camera.bearing ? -*camera.bearing * util::DEG2RAD : getBearing();
     double pitch = camera.pitch ? *camera.pitch * util::DEG2RAD : getPitch();
@@ -94,7 +94,7 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
         return;
     }
 
-    if (!state.bounds) {
+    if (state.bounds == LatLngBounds::unbounded()) {
         if (isGestureInProgress()) {
             // If gesture in progress, we transfer the wrap rounds from the end longitude into
             // start, so the "scroll effect" of rounding the world is the same while assuring the
@@ -344,11 +344,11 @@ double Transform::getZoom() const {
 
 #pragma mark - Bounds
 
-void Transform::setLatLngBounds(optional<LatLngBounds> bounds) {
-    if (bounds && !bounds->valid()) {
+void Transform::setLatLngBounds(LatLngBounds bounds) {
+    if (!bounds.valid()) {
         throw std::runtime_error("failed to set bounds: bounds are invalid");
     }
-    state.setLatLngBounds(bounds);
+    state.setLatLngBounds(std::move(bounds));
 }
 
 void Transform::setMinZoom(const double minZoom) {

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -116,7 +116,7 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
     // Constrain camera options.
     zoom = util::clamp(zoom, state.getMinZoom(), state.getMaxZoom());
     const double scale = state.zoomScale(zoom);
-    pitch = util::clamp(pitch, state.min_pitch, state.max_pitch);
+    pitch = util::clamp(pitch, util::PITCH_MIN, util::PITCH_MAX);
 
     // Minimize rotation by taking the shorter path around the circle.
     bearing = _normalizeAngle(bearing, state.bearing);
@@ -181,7 +181,7 @@ void Transform::flyTo(const CameraOptions &camera, const AnimationOptions &anima
 
     // Constrain camera options.
     zoom = util::clamp(zoom, state.getMinZoom(), state.getMaxZoom());
-    pitch = util::clamp(pitch, state.min_pitch, state.max_pitch);
+    pitch = util::clamp(pitch, util::PITCH_MIN, util::PITCH_MAX);
 
     // Minimize rotation by taking the shorter path around the circle.
     bearing = _normalizeAngle(bearing, state.bearing);
@@ -359,16 +359,6 @@ void Transform::setMinZoom(const double minZoom) {
 void Transform::setMaxZoom(const double maxZoom) {
     if (std::isnan(maxZoom)) return;
     state.setMaxZoom(maxZoom);
-}
-
-void Transform::setMinPitch(double minPitch) {
-    if (std::isnan(minPitch)) return;
-    state.setMinPitch(minPitch);
-}
-
-void Transform::setMaxPitch(double maxPitch) {
-    if (std::isnan(maxPitch)) return;
-    state.setMaxPitch(maxPitch);
 }
 
 #pragma mark - Bearing

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -55,8 +55,6 @@ public:
     void setLatLngBounds(optional<LatLngBounds>);
     void setMinZoom(double);
     void setMaxZoom(double);
-    void setMinPitch(double);
-    void setMaxPitch(double);
 
     // Zoom
 

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -52,7 +52,7 @@ public:
 
     // Bounds
 
-    void setLatLngBounds(optional<LatLngBounds>);
+    void setLatLngBounds(LatLngBounds);
     void setMinZoom(double);
     void setMaxZoom(double);
 

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -221,26 +221,6 @@ double TransformState::getMaxZoom() const {
     return scaleZoom(max_scale);
 }
 
-void TransformState::setMinPitch(double minPitch) {
-    if (minPitch <= getMaxPitch()) {
-        min_pitch = minPitch;
-    }
-}
-
-double TransformState::getMinPitch() const {
-    return min_pitch;
-}
-
-void TransformState::setMaxPitch(double maxPitch) {
-    if (maxPitch >= getMinPitch()) {
-        max_pitch = maxPitch;
-    }
-}
-
-double TransformState::getMaxPitch() const {
-    return max_pitch;
-}
-
 #pragma mark - Rotation
 
 float TransformState::getBearing() const {

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -9,7 +9,8 @@
 namespace mbgl {
 
 TransformState::TransformState(ConstrainMode constrainMode_, ViewportMode viewportMode_)
-    : constrainMode(constrainMode_)
+    : bounds(LatLngBounds::unbounded())
+    , constrainMode(constrainMode_)
     , viewportMode(viewportMode_)
 {
 }
@@ -185,14 +186,14 @@ double TransformState::getZoomFraction() const {
 
 #pragma mark - Bounds
 
-void TransformState::setLatLngBounds(optional<LatLngBounds> bounds_) {
+void TransformState::setLatLngBounds(LatLngBounds bounds_) {
     if (bounds_ != bounds) {
         bounds = bounds_;
         setLatLngZoom(getLatLng(LatLng::Unwrapped), getZoom());
     }
 }
 
-optional<LatLngBounds> TransformState::getLatLngBounds() const {
+LatLngBounds TransformState::getLatLngBounds() const {
     return bounds;
 }
 
@@ -379,9 +380,7 @@ void TransformState::moveLatLng(const LatLng& latLng, const ScreenCoordinate& an
 
 void TransformState::setLatLngZoom(const LatLng& latLng, double zoom) {
     LatLng constrained = latLng;
-    if (bounds) {
-        constrained = bounds->constrain(latLng);
-    }
+    constrained = bounds.constrain(latLng);
 
     double newScale = util::clamp(zoomScale(zoom), min_scale, max_scale);
     const double newWorldSize = newScale * util::tileSize;

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -61,10 +61,6 @@ public:
     double getMinZoom() const;
     void setMaxZoom(double);
     double getMaxZoom() const;
-    void setMinPitch(double);
-    double getMinPitch() const;
-    void setMaxPitch(double);
-    double getMaxPitch() const;
 
     // Rotation
     float getBearing() const;
@@ -102,8 +98,6 @@ private:
     // Limit the amount of zooming possible on the map.
     double min_scale = std::pow(2, 0);
     double max_scale = std::pow(2, util::DEFAULT_MAX_ZOOM);
-    double min_pitch = 0.0;
-    double max_pitch = util::PITCH_MAX;
 
     NorthOrientation orientation = NorthOrientation::Upwards;
 

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -55,8 +55,8 @@ public:
     double getZoomFraction() const;
 
     // Bounds
-    void setLatLngBounds(optional<LatLngBounds>);
-    optional<LatLngBounds> getLatLngBounds() const;
+    void setLatLngBounds(LatLngBounds);
+    LatLngBounds getLatLngBounds() const;
     void setMinZoom(double);
     double getMinZoom() const;
     void setMaxZoom(double);
@@ -93,7 +93,7 @@ private:
     bool rotatedNorth() const;
     void constrain(double& scale, double& x, double& y) const;
 
-    optional<LatLngBounds> bounds;
+    LatLngBounds bounds;
 
     // Limit the amount of zooming possible on the map.
     double min_scale = std::pow(2, 0);

--- a/src/mbgl/util/geo.cpp
+++ b/src/mbgl/util/geo.cpp
@@ -92,6 +92,10 @@ bool LatLngBounds::intersects(const LatLngBounds area, LatLng::WrapMode wrap /*=
 }
 
 LatLng LatLngBounds::constrain(const LatLng& p) const {
+    if (!bounded) {
+        return p;
+    }
+
     double lat = p.latitude();
     double lng = p.longitude();
 

--- a/test/api/annotations.test.cpp
+++ b/test/api/annotations.test.cpp
@@ -85,7 +85,7 @@ TEST(Annotations, LineAnnotation) {
     test.map.addAnnotation(annotation);
     test.checkRendering("line_annotation");
 
-    test.map.jumpTo(CameraOptions().withZoom(test.map.getMaxZoom()));
+    test.map.jumpTo(CameraOptions().withZoom(*test.map.getBounds().maxZoom));
     test.checkRendering("line_annotation_max_zoom");
 }
 
@@ -100,7 +100,7 @@ TEST(Annotations, FillAnnotation) {
     test.map.addAnnotation(annotation);
     test.checkRendering("fill_annotation");
 
-    test.map.jumpTo(CameraOptions().withZoom(test.map.getMaxZoom()));
+    test.map.jumpTo(CameraOptions().withZoom(*test.map.getBounds().maxZoom));
     test.checkRendering("fill_annotation_max_zoom");
 }
 
@@ -481,11 +481,11 @@ TEST(Annotations, ChangeMaxZoom) {
     annotation.color = Color::red();
     annotation.width = { 5 };
 
-    test.map.setMaxZoom(6);
+    test.map.setBounds(BoundOptions().withMaxZoom(6));
     test.map.getStyle().loadJSON(util::read_file("test/fixtures/api/empty.json"));
     test.map.addAnnotation(annotation);
-    test.map.setMaxZoom(14);
-    test.map.jumpTo(CameraOptions().withZoom(test.map.getMaxZoom()));
+    test.map.setBounds(BoundOptions().withMaxZoom(14));
+    test.map.jumpTo(CameraOptions().withZoom(*test.map.getBounds().maxZoom));
     test.checkRendering("line_annotation_max_zoom");
 }
 

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -282,6 +282,32 @@ TEST(Map, ProjectionMode) {
     EXPECT_EQ(*options.ySkew, 0.0);
 }
 
+TEST(Map, BoundOptions) {
+    MapTest<> test;
+
+    LatLngBounds llb = LatLngBounds::hull({-10, -10}, {10, 10});
+    test.map.setBounds(BoundOptions().withMinZoom(4).withMaxZoom(10).withLatLngBounds(llb));
+    auto bounds = test.map.getBounds();
+
+    EXPECT_EQ(*bounds.minZoom, 4);
+    EXPECT_EQ(*bounds.maxZoom, 10);
+    EXPECT_EQ(*bounds.bounds, llb);
+}
+
+TEST(Map, DefaultBoundOptions) {
+    MapTest<> test;
+
+    auto bounds = test.map.getBounds();
+
+    EXPECT_TRUE(bounds.minZoom);
+    EXPECT_TRUE(bounds.maxZoom);
+    EXPECT_TRUE(bounds.bounds);
+
+    EXPECT_EQ(*bounds.minZoom, util::MIN_ZOOM);
+    EXPECT_EQ(*bounds.maxZoom, util::DEFAULT_MAX_ZOOM);
+    EXPECT_EQ(*bounds.bounds, LatLngBounds::unbounded());
+}
+
 TEST(Map, SetStyleInvalidJSON) {
     Log::setObserver(std::make_unique<FixtureLogObserver>());
 

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -761,22 +761,3 @@ TEST(Transform, LatLngBounds) {
     transform.moveBy(ScreenCoordinate { 500, 0 });
     ASSERT_DOUBLE_EQ(transform.getLatLng().longitude(), 120.0);
 }
-
-TEST(Transform, PitchBounds) {
-    Transform transform;
-    transform.resize({ 1000, 1000 });
-
-    transform.jumpTo(CameraOptions().withCenter(LatLng()).withZoom(transform.getState().getMaxZoom()));
-
-    ASSERT_DOUBLE_EQ(transform.getState().getPitch() * util::RAD2DEG, 0.0);
-    ASSERT_DOUBLE_EQ(transform.getState().getMinPitch() * util::RAD2DEG, 0.0);
-    ASSERT_DOUBLE_EQ(transform.getState().getMaxPitch() * util::RAD2DEG, 60.0);
-
-    transform.setMinPitch(45.0 * util::DEG2RAD);
-    transform.jumpTo(CameraOptions().withPitch(0));
-    ASSERT_NEAR(transform.getState().getPitch() * util::RAD2DEG, 45.0, 1e-5);
-
-    transform.setMaxPitch(55.0 * util::DEG2RAD);
-    transform.jumpTo(CameraOptions().withPitch(60.0));
-    ASSERT_NEAR(transform.getState().getPitch() * util::RAD2DEG, 55.0, 1e-5);
-}

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -583,7 +583,7 @@ TEST(Transform, LatLngBounds) {
     transform.jumpTo(CameraOptions().withCenter(LatLng()).withZoom(transform.getState().getMaxZoom()));
 
     // Default bounds.
-    ASSERT_EQ(transform.getState().getLatLngBounds(), optional<LatLngBounds> {});
+    ASSERT_EQ(transform.getState().getLatLngBounds(), LatLngBounds::unbounded());
     ASSERT_EQ(transform.getLatLng(), nullIsland);
 
     // Invalid bounds.
@@ -591,7 +591,7 @@ TEST(Transform, LatLngBounds) {
         transform.setLatLngBounds(LatLngBounds::empty());
         ASSERT_TRUE(false) << "Should throw";
     } catch (...) {
-        ASSERT_EQ(transform.getState().getLatLngBounds(), optional<LatLngBounds> {});
+        ASSERT_EQ(transform.getState().getLatLngBounds(), LatLngBounds::unbounded());
     }
 
     transform.jumpTo(CameraOptions().withCenter(sanFrancisco));


### PR DESCRIPTION
Simplify the map api by grouping different bounds related options into `BoundOptions`.

(based on @nagineni's #14059 )