### PR TITLE
[android] Adding Android code coverage report generation [WIP]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -731,6 +731,16 @@ android-check : android-checkstyle android-lint-sdk android-lint-test-app
 android-checkstyle: platform/android/gradle/configuration.gradle
 	cd platform/android && $(MBGL_ANDROID_GRADLE) -Pmapbox.abis=none :MapboxGLAndroidSDK:checkstyle :MapboxGLAndroidSDKTestApp:checkstyle
 
+# Runs unit test code coverage on the Android code
+.PHONY: android-unit-test-code-coverage
+android-unit-test-code-coverage: platform/android/gradle/configuration.gradle
+	cd platform/android && $(MBGL_ANDROID_GRADLE) -Pmapbox.abis=all clean :MapboxGLAndroidSDK:jacocoTestReportDebug
+
+# Runs unit test code coverage on the Android code
+.PHONY: android-code-coverage-report-to-text-file
+android-code-coverage-report-to-text-file: platform/android/gradle/configuration.gradle
+	textutil -convert txt platform/android/MapboxGLAndroidSDK/build/reports/jacoco/debug/index.html
+
 # Runs lint on the Android SDK code
 .PHONY: android-lint-sdk
 android-lint-sdk: platform/android/gradle/configuration.gradle

--- a/circle.yml
+++ b/circle.yml
@@ -643,6 +643,12 @@ jobs:
       - run:
           name: Build release Test App
           command: make android
+      - run:
+          name: Build unit test code coverage reports for MapboxGLAndroidSDK module
+          command: make android-unit-test-code-coverage
+      - run:
+          name: Convert code coverage report to raw text file
+          command: make android-code-coverage-report-to-text-file
       - save-dependencies: { gradle: true }
       - run:
           name: gzip debugable .so files
@@ -665,6 +671,10 @@ jobs:
       - run:
           name: Record size
           command: platform/android/scripts/metrics.sh
+      - run:
+          name: Report Android code coverage
+          command: |
+              platform/android/scripts/android-code-coverage.sh CI
       - deploy:
           name: Publish to Bintray
           command: |

--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'com.android.library'
 apply plugin: "com.jaredsburrows.license"
 apply plugin: 'kotlin-android'
+apply plugin: "com.vanniktech.android.junit.jacoco"
+
 
 dependencies {
     lintChecks project(":MapboxGLAndroidSDKLint")
@@ -141,6 +143,7 @@ android {
     buildTypes {
         debug {
             jniDebuggable true
+            testCoverageEnabled true
         }
     }
 }

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         classpath dependenciesList.bintrayPlugin
         classpath dependenciesList.artifactoryPlugin
         classpath dependenciesList.androidPublishPlugin
+        classpath dependenciesList.jacocoPlugin
     }
 }
 

--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -27,6 +27,7 @@ ext {
             bintray         : '1.8.4',
             artifactory     : '4.9.3',
             androidPublish  : '3.6.2',
+            jacoco          : '0.13.0',
             lint            : '26.1.4',
             gms             : '16.0.0',
             reLinker        : '1.3.1'
@@ -72,6 +73,7 @@ ext {
             bintrayPlugin          : "com.jfrog.bintray.gradle:gradle-bintray-plugin:${versions.bintray}",
             artifactoryPlugin      : "org.jfrog.buildinfo:build-info-extractor-gradle:${versions.artifactory}",
             androidPublishPlugin   : "digital.wup:android-maven-publish:${versions.androidPublish}",
+            jacocoPlugin           : "com.vanniktech:gradle-android-junit-jacoco-plugin:${versions.jacoco}",
 
             lint                   : "com.android.tools.lint:lint:${versions.lint}",
             lintApi                : "com.android.tools.lint:lint-api:${versions.lint}",

--- a/platform/android/scripts/android-code-coverage.sh
+++ b/platform/android/scripts/android-code-coverage.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+#
+# Get the .txt file generated from the code coverage HTML report
+#
+cov_result="";
+if [ -d platform/android/MapboxGLAndroidSDK/build/reports/jacoco/ ]; then 
+    cov_result=platform/android/MapboxGLAndroidSDK/build/reports/jacoco/debug/index.txt
+    echo "$cov_result"
+    echo "The value of \"cov_result\" is $cov_result."
+
+else
+    echo "Coverage file does not exist. Please run tests before executing"
+    exit 1
+fi
+
+# Retreive the total number of lines in the text file that was created via the coverage report's HTML file
+totalNumberOfLinesInDocument=$(wc -l < platform/android/MapboxGLAndroidSDK/build/reports/jacoco/debug/index.txt)
+echo "The value of \"totalNumberOfLinesInDocument\" is $totalNumberOfLinesInDocument."
+
+# The sixth line from the last line in the text file, is the number of lines missed. The fifth from the bottom is
+# is the total number which exist in the Maps SDK. So to we need to get these numbers, devide the 6th by the 5th,
+# and then multiple the product by 100 to get the coverage percentage.
+
+missed_lines_num=$(sed -n "$(($totalNumberOfLinesInDocument-6)),$(($totalNumberOfLinesInDocument-6))p;$(($totalNumberOfLinesInDocument-6))q" platform/android/MapboxGLAndroidSDK/build/reports/jacoco/debug/index.txt)
+echo "The value of \"missed_lines_num\" is $missed_lines_num."
+
+
+total_lines_num=$(sed -n "$(($totalNumberOfLinesInDocument-5)),$(($totalNumberOfLinesInDocument-5))p;$(($totalNumberOfLinesInDocument-5))q" platform/android/MapboxGLAndroidSDK/build/reports/jacoco/debug/index.txt)
+echo "The value of \"total_lines_num\" is $total_lines_num."
+
+# Convert the line coverage for the dynamic target to a percentage. Currently, 
+# only CI tests are included when calculated code coverage.
+# 
+# percentage= $"(($missed_lines / $total_lines))" | bc
+percentage=$(echo (($missed_lines_num / $total_lines_num)) | bc)
+
+echo "The code coverage percentage is $percentage."
+
+
+# NEED TO MULTIPLY $percentage BY 100
+
+
+# Pass info on to generic code-coverage.sh file
+
+# ./././scripts/code-coverage.sh $percentage "Android" "$1"


### PR DESCRIPTION
This pr installs https://github.com/vanniktech/gradle-android-junit-jacoco-plugin to create code coverage reports for the `MapboxGLAndroidSDK` module.

Then a script is used to push the overall coverage % to our mobile-metrics data warehouse. This pr makes CircleCI do this and this pr is a continuation of @jmkiley 's iOS work in https://github.com/mapbox/mapbox-gl-native/pull/14015. In #14015 , [she creates a generic file which can be used for either iOS or Android reporting](https://github.com/mapbox/mapbox-gl-native/pull/14015/files#diff-1dfeb638bb5a5e01f732618bf6984864).