### PR TITLE
[core, node] Use es5 syntax for imports in expressions tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build=false || make node",
-    "test": "tape -r esm platform/node/test/js/**/*.test.js",
+    "test": "tape platform/node/test/js/**/*.test.js",
     "test-memory": "node --expose-gc platform/node/test/memory.test.js",
     "test-suite": "run-s test-render test-query test-expressions",
     "test-expressions": "node -r esm platform/node/test/expression.test.js",

--- a/platform/node/index.js
+++ b/platform/node/index.js
@@ -48,4 +48,4 @@ var Map = function(options) {
 Map.prototype = mbgl.Map.prototype;
 Map.prototype.constructor = Map;
 
-export default Object.assign(mbgl, { Map: Map });
+module.exports = Object.assign(mbgl, { Map: Map });

--- a/platform/node/test/expression.test.js
+++ b/platform/node/test/expression.test.js
@@ -1,6 +1,6 @@
-import {run} from '../../../mapbox-gl-js/test/integration/lib/expression';
-import mbgl from '../index';
-import ignores from './ignores.json';
+const {run} = require('../../../mapbox-gl-js/test/integration/lib/expression');
+const mbgl = require('../index');
+const ignores = require('./ignores.json');
 
 let tests;
 

--- a/platform/node/test/js/cancel.test.js
+++ b/platform/node/test/js/cancel.test.js
@@ -1,8 +1,8 @@
 'use strict';
 
-import mockfs from './../mockfs';
-import mbgl from '../../index';
-import test from'tape';
+var mockfs = require('./../mockfs');
+var mbgl = require('../../index');
+var test = require('tape');
 
 var options = {
     request: function(req, callback) {

--- a/platform/node/test/js/map.test.js
+++ b/platform/node/test/js/map.test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-import test from 'tape';
-import mbgl from '../../index';
-import fs from 'fs';
-import path from 'path';
-import style from '../fixtures/style.json';
+var test = require('tape');
+var mbgl = require('../../index');
+var fs = require('fs');
+var path = require('path');
+var style = require('../fixtures/style.json');
 
 test('Map', function(t) {
     // This test is skipped because of the req.respond shim in index.js

--- a/platform/node/test/js/request.test.js
+++ b/platform/node/test/js/request.test.js
@@ -1,8 +1,8 @@
 'use strict';
 
-import mockfs from '../mockfs';
-import mbgl from '../../index';
-import test from 'tape';
+var mockfs = require('../mockfs');
+var mbgl = require('../../index');
+var test = require('tape');
 
 [ 'sprite_png', 'sprite_json', 'source_vector', 'glyph' ].forEach(function (resource) {
     test(`render reports an error when the request function responds with an error (${resource})`, function(t) {


### PR DESCRIPTION
Instead of forcing ES6 module syntax, at this point, it is less disruptive to fix expression tests to use ES5 import syntax.