### PR TITLE
[ios] add content inset to camera edge padding

### DIFF
--- a/platform/darwin/src/MGLGeometry_Private.h
+++ b/platform/darwin/src/MGLGeometry_Private.h
@@ -100,6 +100,9 @@ NS_INLINE BOOL MGLLocationCoordinate2DIsValid(CLLocationCoordinate2D coordinate)
 NS_INLINE mbgl::EdgeInsets MGLEdgeInsetsFromNSEdgeInsets(UIEdgeInsets insets) {
     return { insets.top, insets.left, insets.bottom, insets.right };
 }
+NS_INLINE UIEdgeInsets NSEdgeInsetsFromMGLEdgeInsets(mbgl::EdgeInsets insets) {
+    return UIEdgeInsetsMake(insets.top(), insets.left(), insets.bottom(), insets.right());
+}
 #else
 NS_INLINE mbgl::EdgeInsets MGLEdgeInsetsFromNSEdgeInsets(NSEdgeInsets insets) {
     return { insets.top, insets.left, insets.bottom, insets.right };

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3649,8 +3649,13 @@ public:
     [self cancelTransitions];
 
     self.cameraChangeReasonBitmask |= MGLCameraChangeReasonProgrammatic;
-
-    mbgl::CameraOptions cameraOptions = [self cameraOptionsObjectForAnimatingToCamera:camera edgePadding:edgePadding];
+    
+    mbgl::EdgeInsets padding = MGLEdgeInsetsFromNSEdgeInsets(edgePadding);
+    padding += MGLEdgeInsetsFromNSEdgeInsets(self.contentInset);
+    
+    mbgl::CameraOptions cameraOptions = [self cameraOptionsObjectForAnimatingToCamera:camera
+                                                                          edgePadding:NSEdgeInsetsFromMGLEdgeInsets(padding)];
+    
     self.mbglMap.easeTo(cameraOptions, animationOptions);
     [self didChangeValueForKey:@"camera"];
 }


### PR DESCRIPTION
Fixes #12818 

For consistency with other camera methods, `-[MGLMapView setCamera:withDuration:animationTimingFunction:edgePadding:completionHandler:]` now adds the `contentInset` to the edge padding when updating the camera.

cc @fabian-guerra @julianrex @1ec5 