### PR TITLE
Explicitly declare MapboxIssueRegistry's lint version

### DIFF
--- a/platform/android/MapboxGLAndroidSDKLint/src/main/java/com/mapbox/mapboxsdk/lint/MapboxIssueRegistry.kt
+++ b/platform/android/MapboxGLAndroidSDKLint/src/main/java/com/mapbox/mapboxsdk/lint/MapboxIssueRegistry.kt
@@ -1,9 +1,13 @@
 package com.mapbox.mapboxsdk.lint
 
 import com.android.tools.lint.client.api.IssueRegistry
+import com.android.tools.lint.detector.api.CURRENT_API
 import com.android.tools.lint.detector.api.Issue
 
 class MapboxIssueRegistry : IssueRegistry() {
   override val issues: List<Issue>
     get() = listOf(KeepDetector.ISSUE_NOT_KEPT)
+
+  override val api: Int
+    get() = CURRENT_API
 }


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gl-native/issues/14078.

Fixes:
> jetified-mapbox-android-sdk-7.2.0.aar/.../lint.jar: Lint found an issue registry (com.mapbox.mapboxsdk.lint.MapboxIssueRegistry) which did not specify the Lint API version it was compiled with.
This means that the lint checks are likely not compatible.