### PR TITLE
[ios, build] Remove unnecessary clean step from release packaging

### DIFF
--- a/platform/ios/scripts/deploy-packages.sh
+++ b/platform/ios/scripts/deploy-packages.sh
@@ -94,7 +94,6 @@ git checkout ${VERSION_TAG}
 
 step "Deploying version ${PUBLISH_VERSION}…"
 
-make clean && make distclean
 npm install --ignore-scripts
 mkdir -p ${BINARY_DIRECTORY}
 


### PR DESCRIPTION
Removes a holdover `clean` step from the days when we built the SDK releases by hand (_uphill both ways and so on_). This should reduce the release build time by a bit (and subsequent rebuilds by a lot), now that it’s able to take advantage of ccache and cached dependencies.

/cc @julianrex 