### PR TITLE
Release global reference async updater GeoJsonSource

### DIFF
--- a/platform/android/src/style/sources/geojson_source.cpp
+++ b/platform/android/src/style/sources/geojson_source.cpp
@@ -174,6 +174,7 @@ namespace android {
         };
 
         setAsync(converterFn);
+        global.release();
     }
 
     void GeoJSONSource::setAsync(Update::Converter converterFn) {


### PR DESCRIPTION
Closes #14010, this PR fixes occurrences of global reference overflow with the LocationComponent. 

Before this fix, you can see that AuoValue instances are allocated on the JNI heap and aren't released:

![image](https://user-images.githubusercontent.com/2151639/54270905-b5d0c800-4580-11e9-98eb-8b5015b33e4d.png)

After this fix, you can see that they are properly deallocated:

![Screenshot from 2019-03-13 11-03-01](https://user-images.githubusercontent.com/2151639/54270808-891cb080-4580-11e9-8c58-1eac2025b70e.png)
