### PR TITLE
Avoid passing FileSource to mbgl::Renderer{,Impl}

### DIFF
--- a/benchmark/api/query.benchmark.cpp
+++ b/benchmark/api/query.benchmark.cpp
@@ -34,7 +34,7 @@ public:
     util::RunLoop loop;
     DefaultFileSource fileSource{ "benchmark/fixtures/api/cache.db", "." };
     ThreadPool threadPool{ 4 };
-    HeadlessFrontend frontend { { 1000, 1000 }, 1, fileSource, threadPool };
+    HeadlessFrontend frontend { { 1000, 1000 }, 1, threadPool };
     Map map { frontend, MapObserver::nullObserver(), frontend.getSize(), 1,
               fileSource, threadPool, MapOptions().withMapMode(MapMode::Static) };
     ScreenBox box{{ 0, 0 }, { 1000, 1000 }};

--- a/benchmark/api/render.benchmark.cpp
+++ b/benchmark/api/render.benchmark.cpp
@@ -41,7 +41,7 @@ static void prepare(Map& map, optional<std::string> json = {}) {
 
 static void API_renderStill_reuse_map(::benchmark::State& state) {
     RenderBenchmark bench;
-    HeadlessFrontend frontend { { 1000, 1000 }, 1, bench.fileSource, bench.threadPool };
+    HeadlessFrontend frontend { { 1000, 1000 }, 1, bench.threadPool };
     Map map { frontend, MapObserver::nullObserver(), frontend.getSize(), 1,
               bench.fileSource, bench.threadPool, MapOptions().withMapMode(MapMode::Static) };
     prepare(map);
@@ -53,7 +53,7 @@ static void API_renderStill_reuse_map(::benchmark::State& state) {
 
 static void API_renderStill_reuse_map_switch_styles(::benchmark::State& state) {
     RenderBenchmark bench;
-    HeadlessFrontend frontend { { 1000, 1000 }, 1, bench.fileSource, bench.threadPool };
+    HeadlessFrontend frontend { { 1000, 1000 }, 1, bench.threadPool };
     Map map { frontend, MapObserver::nullObserver(), frontend.getSize(), 1,
               bench.fileSource, bench.threadPool, MapOptions().withMapMode(MapMode::Static) };
     
@@ -69,7 +69,7 @@ static void API_renderStill_recreate_map(::benchmark::State& state) {
     RenderBenchmark bench;
     
     while (state.KeepRunning()) {
-        HeadlessFrontend frontend { { 1000, 1000 }, 1, bench.fileSource, bench.threadPool };
+        HeadlessFrontend frontend { { 1000, 1000 }, 1, bench.threadPool };
         Map map { frontend, MapObserver::nullObserver(), frontend.getSize(), 1,
                   bench.fileSource, bench.threadPool, MapOptions().withMapMode(MapMode::Static) };
         prepare(map);

--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -84,7 +84,7 @@ int main(int argc, char *argv[]) {
     }
 
     ThreadPool threadPool(4);
-    HeadlessFrontend frontend({ width, height }, pixelRatio, fileSource, threadPool);
+    HeadlessFrontend frontend({ width, height }, pixelRatio, threadPool);
     Map map(frontend, MapObserver::nullObserver(), frontend.getSize(), pixelRatio,
             fileSource, threadPool, MapOptions().withMapMode(MapMode::Static));
 

--- a/include/mbgl/renderer/renderer.hpp
+++ b/include/mbgl/renderer/renderer.hpp
@@ -13,7 +13,6 @@
 
 namespace mbgl {
 
-class FileSource;
 class RendererBackend;
 class RendererObserver;
 class RenderedQueryOptions;
@@ -23,7 +22,7 @@ class UpdateParameters;
 
 class Renderer {
 public:
-    Renderer(RendererBackend&, float pixelRatio_, FileSource&, Scheduler&,
+    Renderer(RendererBackend&, float pixelRatio_, Scheduler&,
              GLContextMode = GLContextMode::Unique,
              const optional<std::string> programCacheDir = {},
              const optional<std::string> localFontFamily = {});

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
@@ -31,12 +31,11 @@ public abstract class MapRenderer implements MapRendererScheduler {
   private MapboxMap.OnFpsChangedListener onFpsChangedListener;
 
   public MapRenderer(@NonNull Context context, String localIdeographFontFamily) {
-    FileSource fileSource = FileSource.getInstance(context);
     float pixelRatio = context.getResources().getDisplayMetrics().density;
     String programCacheDir = FileSource.getInternalCachePath(context);
 
     // Initialise native peer
-    nativeInitialize(this, fileSource, pixelRatio, programCacheDir, localIdeographFontFamily);
+    nativeInitialize(this, pixelRatio, programCacheDir, localIdeographFontFamily);
   }
 
   public void onStart() {
@@ -115,7 +114,6 @@ public abstract class MapRenderer implements MapRendererScheduler {
   }
 
   private native void nativeInitialize(MapRenderer self,
-                                       FileSource fileSource,
                                        float pixelRatio,
                                        String programCacheDir,
                                        String localIdeographFontFamily);

--- a/platform/android/src/android_renderer_frontend.cpp
+++ b/platform/android/src/android_renderer_frontend.cpp
@@ -3,7 +3,6 @@
 #include <mbgl/actor/scheduler.hpp>
 #include <mbgl/renderer/renderer.hpp>
 #include <mbgl/renderer/renderer_observer.hpp>
-#include <mbgl/storage/file_source.hpp>
 #include <mbgl/util/async_task.hpp>
 #include <mbgl/util/thread.hpp>
 #include <mbgl/util/run_loop.hpp>

--- a/platform/android/src/map_renderer.cpp
+++ b/platform/android/src/map_renderer.cpp
@@ -9,20 +9,17 @@
 #include "attach_env.hpp"
 #include "android_renderer_backend.hpp"
 #include "map_renderer_runnable.hpp"
-#include "file_source.hpp"
 
 namespace mbgl {
 namespace android {
 
 MapRenderer::MapRenderer(jni::JNIEnv& _env,
                          const jni::Object<MapRenderer>& obj,
-                         const jni::Object<FileSource>& _fileSource,
                          jni::jfloat pixelRatio_,
                          const jni::String& programCacheDir_,
                          const jni::String& localIdeographFontFamily_)
         : javaPeer(_env, obj)
         , pixelRatio(pixelRatio_)
-        , fileSource(FileSource::getDefaultFileSource(_env, _fileSource))
         , programCacheDir(jni::Make<std::string>(_env, programCacheDir_))
         , localIdeographFontFamily(localIdeographFontFamily_ ? jni::Make<std::string>(_env, localIdeographFontFamily_) : optional<std::string>{})
         , threadPool(sharedThreadPool())
@@ -174,7 +171,7 @@ void MapRenderer::onSurfaceCreated(JNIEnv&) {
 
     // Create the new backend and renderer
     backend = std::make_unique<AndroidRendererBackend>();
-    renderer = std::make_unique<Renderer>(*backend, pixelRatio, fileSource, *threadPool,
+    renderer = std::make_unique<Renderer>(*backend, pixelRatio, *threadPool,
                                           GLContextMode::Unique, programCacheDir, localIdeographFontFamily);
     rendererRef = std::make_unique<ActorRef<Renderer>>(*renderer, mailbox);
 
@@ -211,7 +208,7 @@ void MapRenderer::registerNative(jni::JNIEnv& env) {
 
     // Register the peer
     jni::RegisterNativePeer<MapRenderer>(env, javaClass, "nativePtr",
-                                         jni::MakePeer<MapRenderer, const jni::Object<MapRenderer>&, const jni::Object<FileSource>&, jni::jfloat, const jni::String&, const jni::String&>,
+                                         jni::MakePeer<MapRenderer, const jni::Object<MapRenderer>&, jni::jfloat, const jni::String&, const jni::String&>,
                                          "nativeInitialize", "finalize",
                                          METHOD(&MapRenderer::render, "nativeRender"),
                                          METHOD(&MapRenderer::onSurfaceCreated,

--- a/platform/android/src/map_renderer.hpp
+++ b/platform/android/src/map_renderer.hpp
@@ -23,7 +23,6 @@ class UpdateParameters;
 namespace android {
 
 class AndroidRendererBackend;
-class FileSource;
 
 /**
  * The MapRenderer is a peer class that encapsulates the actions
@@ -42,7 +41,6 @@ public:
 
     MapRenderer(jni::JNIEnv& _env,
                 const jni::Object<MapRenderer>&,
-                const jni::Object<FileSource>&,
                 jni::jfloat pixelRatio,
                 const jni::String& programCacheDir,
                 const jni::String& localIdeographFontFamily);
@@ -103,7 +101,6 @@ private:
     jni::WeakReference<jni::Object<MapRenderer>, jni::EnvAttachingDeleter> javaPeer;
 
     float pixelRatio;
-    DefaultFileSource& fileSource;
     std::string programCacheDir;
     optional<std::string> localIdeographFontFamily;
 

--- a/platform/default/include/mbgl/gl/headless_frontend.hpp
+++ b/platform/default/include/mbgl/gl/headless_frontend.hpp
@@ -11,7 +11,6 @@
 
 namespace mbgl {
 
-class FileSource;
 class Scheduler;
 class Renderer;
 class RendererBackend;
@@ -20,8 +19,8 @@ class TransformState;
 
 class HeadlessFrontend : public RendererFrontend {
 public:
-    HeadlessFrontend(float pixelRatio_, FileSource&, Scheduler&, const optional<std::string> programCacheDir = {}, GLContextMode mode = GLContextMode::Unique, const optional<std::string> localFontFamily = {});
-    HeadlessFrontend(Size, float pixelRatio_, FileSource&, Scheduler&, const optional<std::string> programCacheDir = {}, GLContextMode mode = GLContextMode::Unique, const optional<std::string> localFontFamily = {});
+    HeadlessFrontend(float pixelRatio_, Scheduler&, const optional<std::string> programCacheDir = {}, GLContextMode mode = GLContextMode::Unique, const optional<std::string> localFontFamily = {});
+    HeadlessFrontend(Size, float pixelRatio_, Scheduler&, const optional<std::string> programCacheDir = {}, GLContextMode mode = GLContextMode::Unique, const optional<std::string> localFontFamily = {});
     ~HeadlessFrontend() override;
 
     void reset() override;

--- a/platform/default/src/mbgl/gl/headless_frontend.cpp
+++ b/platform/default/src/mbgl/gl/headless_frontend.cpp
@@ -8,11 +8,11 @@
 
 namespace mbgl {
 
-HeadlessFrontend::HeadlessFrontend(float pixelRatio_, FileSource& fileSource, Scheduler& scheduler, const optional<std::string> programCacheDir, GLContextMode mode, const optional<std::string> localFontFamily)
-    : HeadlessFrontend({ 256, 256 }, pixelRatio_, fileSource, scheduler, programCacheDir, mode, localFontFamily) {
+HeadlessFrontend::HeadlessFrontend(float pixelRatio_, Scheduler& scheduler, const optional<std::string> programCacheDir, GLContextMode mode, const optional<std::string> localFontFamily)
+    : HeadlessFrontend({ 256, 256 }, pixelRatio_, scheduler, programCacheDir, mode, localFontFamily) {
 }
 
-HeadlessFrontend::HeadlessFrontend(Size size_, float pixelRatio_, FileSource& fileSource, Scheduler& scheduler, const optional<std::string> programCacheDir, GLContextMode mode, const optional<std::string> localFontFamily)
+HeadlessFrontend::HeadlessFrontend(Size size_, float pixelRatio_, Scheduler& scheduler, const optional<std::string> programCacheDir, GLContextMode mode, const optional<std::string> localFontFamily)
     : size(size_),
     pixelRatio(pixelRatio_),
     backend({ static_cast<uint32_t>(size.width * pixelRatio),
@@ -23,7 +23,7 @@ HeadlessFrontend::HeadlessFrontend(Size size_, float pixelRatio_, FileSource& fi
             renderer->render(*updateParameters);
         }
     }),
-    renderer(std::make_unique<Renderer>(backend, pixelRatio, fileSource, scheduler, mode, programCacheDir, localFontFamily)) {
+    renderer(std::make_unique<Renderer>(backend, pixelRatio, scheduler, mode, programCacheDir, localFontFamily)) {
 }
 
 HeadlessFrontend::~HeadlessFrontend() = default;

--- a/platform/default/src/mbgl/map/map_snapshotter.cpp
+++ b/platform/default/src/mbgl/map/map_snapshotter.cpp
@@ -57,7 +57,7 @@ MapSnapshotter::Impl::Impl(FileSource* fileSource,
            const optional<std::string> programCacheDir,
            const optional<std::string> localFontFamily)
     : scheduler(std::move(scheduler_))
-    , frontend(size, pixelRatio, *fileSource, *scheduler, programCacheDir, GLContextMode::Unique, localFontFamily)
+    , frontend(size, pixelRatio, *scheduler, programCacheDir, GLContextMode::Unique, localFontFamily)
     , map(frontend, MapObserver::nullObserver(), size, pixelRatio, *fileSource, *scheduler, MapOptions().withMapMode(MapMode::Static)) {
 
     if (style.first) {

--- a/platform/glfw/main.cpp
+++ b/platform/glfw/main.cpp
@@ -108,7 +108,7 @@ int main(int argc, char *argv[]) {
     }
 
     mbgl::ThreadPool threadPool(4);
-    GLFWRendererFrontend rendererFrontend { std::make_unique<mbgl::Renderer>(backend, view->getPixelRatio(), fileSource, threadPool), backend };
+    GLFWRendererFrontend rendererFrontend { std::make_unique<mbgl::Renderer>(backend, view->getPixelRatio(), threadPool), backend };
     mbgl::Map map(rendererFrontend, backend, view->getSize(), view->getPixelRatio(), fileSource, threadPool, mbgl::MapOptions());
 
     backend.setMap(&map);

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -473,7 +473,7 @@ public:
     MGLRendererConfiguration *config = [MGLRendererConfiguration currentConfiguration];
     _mbglThreadPool = mbgl::sharedThreadPool();
 
-    auto renderer = std::make_unique<mbgl::Renderer>(*_mbglView, config.scaleFactor, *config.fileSource, *_mbglThreadPool, config.contextMode, config.cacheDir, config.localFontFamilyName);
+    auto renderer = std::make_unique<mbgl::Renderer>(*_mbglView, config.scaleFactor, *_mbglThreadPool, config.contextMode, config.cacheDir, config.localFontFamilyName);
     BOOL enableCrossSourceCollisions = !config.perSourceCollisions;
     _rendererFrontend = std::make_unique<MGLRenderFrontend>(std::move(renderer), self, *_mbglView);
 

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -286,7 +286,7 @@ public:
     _mbglThreadPool = mbgl::sharedThreadPool();
     MGLRendererConfiguration *config = [MGLRendererConfiguration currentConfiguration];
 
-    auto renderer = std::make_unique<mbgl::Renderer>(*_mbglView, config.scaleFactor, *config.fileSource, *_mbglThreadPool, config.contextMode, config.cacheDir, config.localFontFamilyName);
+    auto renderer = std::make_unique<mbgl::Renderer>(*_mbglView, config.scaleFactor, *_mbglThreadPool, config.contextMode, config.cacheDir, config.localFontFamilyName);
     BOOL enableCrossSourceCollisions = !config.perSourceCollisions;
     _rendererFrontend = std::make_unique<MGLRenderFrontend>(std::move(renderer), self, *_mbglView, true);
 

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -620,7 +620,7 @@ void NodeMap::cancel() {
         reinterpret_cast<NodeMap *>(h->data)->renderFinished();
     });
 
-    frontend = std::make_unique<mbgl::HeadlessFrontend>(mbgl::Size{ 256, 256 }, pixelRatio, fileSource, threadpool);
+    frontend = std::make_unique<mbgl::HeadlessFrontend>(mbgl::Size{ 256, 256 }, pixelRatio, threadpool);
     mbgl::MapOptions options;
     options.withMapMode(mode)
            .withConstrainMode(mbgl::ConstrainMode::HeightOnly)
@@ -1206,7 +1206,7 @@ NodeMap::NodeMap(v8::Local<v8::Object> options)
     }())
     , mapObserver(NodeMapObserver())
     , fileSource(this)
-    , frontend(std::make_unique<mbgl::HeadlessFrontend>(mbgl::Size { 256, 256 }, pixelRatio, fileSource, threadpool))
+    , frontend(std::make_unique<mbgl::HeadlessFrontend>(mbgl::Size { 256, 256 }, pixelRatio, threadpool))
     , map(std::make_unique<mbgl::Map>(*frontend,
                                       mapObserver,
                                       frontend->getSize(),

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1828,7 +1828,6 @@ void QMapboxGLPrivate::createRenderer()
 
     m_mapRenderer = std::make_unique<QMapboxGLMapRenderer>(
         m_pixelRatio,
-        *m_fileSourceObj,
         *m_threadPool,
         m_mode,
         m_localFontFamily

--- a/platform/qt/src/qmapboxgl_map_renderer.cpp
+++ b/platform/qt/src/qmapboxgl_map_renderer.cpp
@@ -24,9 +24,8 @@ static auto *getScheduler() {
     return scheduler.localData().get();
 };
 
-QMapboxGLMapRenderer::QMapboxGLMapRenderer(qreal pixelRatio,
-        mbgl::DefaultFileSource &fs, mbgl::ThreadPool &tp, QMapboxGLSettings::GLContextMode mode, const QString &localFontFamily)
-    : m_renderer(std::make_unique<mbgl::Renderer>(m_backend, pixelRatio, fs, tp, static_cast<mbgl::GLContextMode>(mode), mbgl::optional<std::string> {},
+QMapboxGLMapRenderer::QMapboxGLMapRenderer(qreal pixelRatio, mbgl::ThreadPool &tp, QMapboxGLSettings::GLContextMode mode, const QString &localFontFamily)
+    : m_renderer(std::make_unique<mbgl::Renderer>(m_backend, pixelRatio, tp, static_cast<mbgl::GLContextMode>(mode), mbgl::optional<std::string> {},
                  localFontFamily.isEmpty() ? mbgl::nullopt : mbgl::optional<std::string> { localFontFamily.toStdString() }))
     , m_forceScheduler(needsToForceScheduler())
 {

--- a/platform/qt/src/qmapboxgl_map_renderer.hpp
+++ b/platform/qt/src/qmapboxgl_map_renderer.hpp
@@ -6,7 +6,6 @@
 #include <mbgl/renderer/renderer.hpp>
 #include <mbgl/renderer/renderer_backend.hpp>
 #include <mbgl/renderer/renderer_observer.hpp>
-#include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/util/shared_thread_pool.hpp>
 #include <mbgl/util/util.hpp>
 
@@ -27,9 +26,7 @@ class QMapboxGLMapRenderer : public QObject
     Q_OBJECT
 
 public:
-    QMapboxGLMapRenderer(qreal pixelRatio, mbgl::DefaultFileSource &,
-            mbgl::ThreadPool &, QMapboxGLSettings::GLContextMode,
-            const QString &localFontFamily);
+    QMapboxGLMapRenderer(qreal pixelRatio, mbgl::ThreadPool &, QMapboxGLSettings::GLContextMode, const QString &localFontFamily);
     virtual ~QMapboxGLMapRenderer();
 
     void render();

--- a/platform/qt/src/qmapboxgl_renderer_backend.hpp
+++ b/platform/qt/src/qmapboxgl_renderer_backend.hpp
@@ -3,7 +3,6 @@
 #include "qmapboxgl.hpp"
 
 #include <mbgl/renderer/renderer_backend.hpp>
-#include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/util/shared_thread_pool.hpp>
 
 class QMapboxGLRendererBackend : public mbgl::RendererBackend

--- a/src/mbgl/annotation/annotation_tile.cpp
+++ b/src/mbgl/annotation/annotation_tile.cpp
@@ -1,7 +1,6 @@
 #include <mbgl/annotation/annotation_tile.hpp>
 #include <mbgl/annotation/annotation_manager.hpp>
 #include <mbgl/util/constants.hpp>
-#include <mbgl/storage/file_source.hpp>
 #include <mbgl/renderer/tile_parameters.hpp>
 
 #include <utility>

--- a/src/mbgl/map/map_impl.cpp
+++ b/src/mbgl/map/map_impl.cpp
@@ -73,6 +73,7 @@ void Map::Impl::onUpdate() {
         style->impl->getSourceImpls(),
         style->impl->getLayerImpls(),
         annotationManager,
+        fileSource,
         prefetchZoomDelta,
         bool(stillImageRequest),
         crossSourceCollisions

--- a/src/mbgl/renderer/renderer.cpp
+++ b/src/mbgl/renderer/renderer.cpp
@@ -9,12 +9,11 @@ namespace mbgl {
 
 Renderer::Renderer(RendererBackend& backend,
                    float pixelRatio_,
-                   FileSource& fileSource_,
                    Scheduler& scheduler_,
                    GLContextMode contextMode_,
                    const optional<std::string> programCacheDir_,
                    const optional<std::string> localFontFamily_)
-        : impl(std::make_unique<Impl>(backend, pixelRatio_, fileSource_, scheduler_,
+        : impl(std::make_unique<Impl>(backend, pixelRatio_, scheduler_,
                                       contextMode_, std::move(programCacheDir_), std::move(localFontFamily_))) {
 }
 

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -37,14 +37,12 @@ static RendererObserver& nullObserver() {
 
 Renderer::Impl::Impl(RendererBackend& backend_,
                      float pixelRatio_,
-                     FileSource& fileSource_,
                      Scheduler& scheduler_,
                      GLContextMode contextMode_,
                      const optional<std::string> programCacheDir_,
                      const optional<std::string> localFontFamily_)
     : backend(backend_)
     , scheduler(scheduler_)
-    , fileSource(fileSource_)
     , observer(&nullObserver())
     , contextMode(contextMode_)
     , pixelRatio(pixelRatio_)
@@ -78,7 +76,7 @@ void Renderer::Impl::setObserver(RendererObserver* observer_) {
 
 void Renderer::Impl::render(const UpdateParameters& updateParameters) {
     if (!glyphManager) {
-        glyphManager = std::make_unique<GlyphManager>(fileSource, std::make_unique<LocalGlyphRasterizer>(localFontFamily));
+        glyphManager = std::make_unique<GlyphManager>(updateParameters.fileSource, std::make_unique<LocalGlyphRasterizer>(localFontFamily));
         glyphManager->setObserver(this);
     }
 
@@ -118,7 +116,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         updateParameters.debugOptions,
         updateParameters.transformState,
         scheduler,
-        fileSource,
+        updateParameters.fileSource,
         updateParameters.mode,
         updateParameters.annotationManager,
         *imageManager,

--- a/src/mbgl/renderer/renderer_impl.hpp
+++ b/src/mbgl/renderer/renderer_impl.hpp
@@ -27,7 +27,6 @@ class UpdateParameters;
 class RenderStaticData;
 class RenderedQueryOptions;
 class SourceQueryOptions;
-class FileSource;
 class Scheduler;
 class GlyphManager;
 class ImageManager;
@@ -37,7 +36,7 @@ class CrossTileSymbolIndex;
 class Renderer::Impl : public GlyphManagerObserver,
                        public RenderSourceObserver{
 public:
-    Impl(RendererBackend&, float pixelRatio_, FileSource&, Scheduler&, GLContextMode,
+    Impl(RendererBackend&, float pixelRatio_, Scheduler&, GLContextMode,
          const optional<std::string> programCacheDir, const optional<std::string> localFontFamily_);
     ~Impl() final;
 
@@ -91,7 +90,6 @@ private:
 
     RendererBackend& backend;
     Scheduler& scheduler;
-    FileSource& fileSource;
 
     RendererObserver* observer;
 

--- a/src/mbgl/renderer/renderer_impl.hpp
+++ b/src/mbgl/renderer/renderer_impl.hpp
@@ -38,7 +38,7 @@ class Renderer::Impl : public GlyphManagerObserver,
                        public RenderSourceObserver{
 public:
     Impl(RendererBackend&, float pixelRatio_, FileSource&, Scheduler&, GLContextMode,
-         const optional<std::string> programCacheDir, const optional<std::string> localFontFamily);
+         const optional<std::string> programCacheDir, const optional<std::string> localFontFamily_);
     ~Impl() final;
 
     void markContextLost() {
@@ -98,6 +98,7 @@ private:
     const GLContextMode contextMode;
     const float pixelRatio;
     const optional<std::string> programCacheDir;
+    const optional<std::string> localFontFamily;
 
     enum class RenderState {
         Never,

--- a/src/mbgl/renderer/update_parameters.hpp
+++ b/src/mbgl/renderer/update_parameters.hpp
@@ -14,6 +14,7 @@
 namespace mbgl {
 
 class AnnotationManager;
+class FileSource;
 
 class UpdateParameters {
 public:
@@ -33,6 +34,7 @@ public:
     const Immutable<std::vector<Immutable<style::Layer::Impl>>> layers;
 
     AnnotationManager& annotationManager;
+    FileSource& fileSource;
 
     const uint8_t prefetchZoomDelta;
     

--- a/test/api/annotations.test.cpp
+++ b/test/api/annotations.test.cpp
@@ -31,7 +31,7 @@ public:
     StubFileSource fileSource;
     ThreadPool threadPool { 4 };
     float pixelRatio { 1 };
-    HeadlessFrontend frontend { pixelRatio, fileSource, threadPool };
+    HeadlessFrontend frontend { pixelRatio, threadPool };
 
     Map map { frontend, MapObserver::nullObserver(), frontend.getSize(), pixelRatio, fileSource,
               threadPool, MapOptions().withMapMode(MapMode::Static)};

--- a/test/api/api_misuse.test.cpp
+++ b/test/api/api_misuse.test.cpp
@@ -25,7 +25,7 @@ TEST(API, RenderWithoutCallback) {
     StubFileSource fileSource;
     ThreadPool threadPool(4);
     float pixelRatio { 1 };
-    HeadlessFrontend frontend { pixelRatio, fileSource, threadPool };
+    HeadlessFrontend frontend { pixelRatio, threadPool };
 
     auto map = std::make_unique<Map>(frontend, MapObserver::nullObserver(), frontend.getSize(),
                                      pixelRatio, fileSource, threadPool,

--- a/test/api/custom_geometry_source.test.cpp
+++ b/test/api/custom_geometry_source.test.cpp
@@ -23,7 +23,7 @@ TEST(CustomGeometrySource, Grid) {
     DefaultFileSource fileSource(":memory:", "test/fixtures/api/assets");
     auto threadPool = sharedThreadPool();
     float pixelRatio { 1 };
-    HeadlessFrontend frontend { pixelRatio, fileSource, *threadPool };
+    HeadlessFrontend frontend { pixelRatio, *threadPool };
     Map map(frontend, MapObserver::nullObserver(), frontend.getSize(), pixelRatio, fileSource,
             *threadPool, MapOptions().withMapMode(MapMode::Static));
     map.getStyle().loadJSON(util::read_file("test/fixtures/api/water.json"));

--- a/test/api/custom_layer.test.cpp
+++ b/test/api/custom_layer.test.cpp
@@ -93,7 +93,7 @@ TEST(CustomLayer, Basic) {
     DefaultFileSource fileSource(":memory:", "test/fixtures/api/assets");
     ThreadPool threadPool(4);
     float pixelRatio { 1 };
-    HeadlessFrontend frontend { pixelRatio, fileSource, threadPool };
+    HeadlessFrontend frontend { pixelRatio, threadPool };
     Map map(frontend, MapObserver::nullObserver(), frontend.getSize(), pixelRatio, fileSource,
             threadPool, MapOptions().withMapMode(MapMode::Static));
     map.getStyle().loadJSON(util::read_file("test/fixtures/api/water.json"));

--- a/test/api/query.test.cpp
+++ b/test/api/query.test.cpp
@@ -36,7 +36,7 @@ public:
     StubFileSource fileSource;
     ThreadPool threadPool { 4 };
     float pixelRatio { 1 };
-    HeadlessFrontend frontend { pixelRatio, fileSource, threadPool };
+    HeadlessFrontend frontend { pixelRatio, threadPool };
     Map map { frontend, MapObserver::nullObserver(), frontend.getSize(), pixelRatio, fileSource,
               threadPool, MapOptions().withMapMode(MapMode::Static)};
 };

--- a/test/api/recycle_map.cpp
+++ b/test/api/recycle_map.cpp
@@ -28,7 +28,7 @@ TEST(API, RecycleMapUpdateImages) {
     ThreadPool threadPool(4);
     float pixelRatio { 1 };
 
-    HeadlessFrontend frontend { pixelRatio, fileSource, threadPool };
+    HeadlessFrontend frontend { pixelRatio, threadPool };
     auto map = std::make_unique<Map>(frontend, MapObserver::nullObserver(), frontend.getSize(),
                                      pixelRatio, fileSource, threadPool,
                                      MapOptions().withMapMode(MapMode::Static));

--- a/test/gl/context.test.cpp
+++ b/test/gl/context.test.cpp
@@ -90,7 +90,7 @@ TEST(GLContextMode, Shared) {
     ThreadPool threadPool(4);
     float pixelRatio { 1 };
 
-    HeadlessFrontend frontend { pixelRatio, fileSource, threadPool, {}, GLContextMode::Shared };
+    HeadlessFrontend frontend { pixelRatio, threadPool, {}, GLContextMode::Shared };
 
     Map map(frontend, MapObserver::nullObserver(), frontend.getSize(), pixelRatio,
             fileSource, threadPool, MapOptions().withMapMode(MapMode::Static));

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -38,7 +38,7 @@ public:
     Map map;
 
     MapTest(float pixelRatio = 1, MapMode mode = MapMode::Static)
-        : frontend(pixelRatio, fileSource, threadPool)
+        : frontend(pixelRatio, threadPool)
         , map(frontend, observer, frontend.getSize(), pixelRatio,
               fileSource, threadPool, MapOptions().withMapMode(mode)) {
     }
@@ -48,7 +48,7 @@ public:
             float pixelRatio = 1, MapMode mode = MapMode::Static,
             typename std::enable_if<std::is_same<T, DefaultFileSource>::value>::type* = 0)
             : fileSource { cachePath, assetRoot }
-            , frontend(pixelRatio, fileSource, threadPool)
+            , frontend(pixelRatio, threadPool)
             , map(frontend, observer, frontend.getSize(), pixelRatio,
                   fileSource, threadPool, MapOptions().withMapMode(mode)) {
     }
@@ -685,7 +685,7 @@ TEST(Map, TEST_DISABLED_ON_CI(ContinuousRendering)) {
 
     util::Timer timer;
 
-    HeadlessFrontend frontend(pixelRatio, fileSource, threadPool);
+    HeadlessFrontend frontend(pixelRatio, threadPool);
 
     StubMapObserver observer;
     observer.didFinishRenderingFrameCallback = [&] (MapObserver::RenderMode) {

--- a/test/map/prefetch.test.cpp
+++ b/test/map/prefetch.test.cpp
@@ -37,7 +37,7 @@ TEST(Map, PrefetchTiles) {
         runLoop.stop();
     };
 
-    HeadlessFrontend frontend { { 512, 512 }, 1, fileSource, threadPool };
+    HeadlessFrontend frontend { { 512, 512 }, 1, threadPool };
     Map map(frontend, observer, frontend.getSize(), 1, fileSource, threadPool,
             MapOptions().withMapMode(MapMode::Continuous));
 

--- a/test/text/local_glyph_rasterizer.test.cpp
+++ b/test/text/local_glyph_rasterizer.test.cpp
@@ -33,7 +33,7 @@ namespace {
 class LocalGlyphRasterizerTest {
 public:
     LocalGlyphRasterizerTest(const optional<std::string> fontFamily)
-        : frontend(pixelRatio, fileSource, threadPool, optional<std::string>(), GLContextMode::Unique, fontFamily)
+        : frontend(pixelRatio, threadPool, optional<std::string>(), GLContextMode::Unique, fontFamily)
     {
     }
 

--- a/test/util/memory.test.cpp
+++ b/test/util/memory.test.cpp
@@ -71,7 +71,7 @@ TEST(Memory, Vector) {
     MemoryTest test;
     float ratio { 2 };
 
-    HeadlessFrontend frontend { { 256, 256 }, ratio, test.fileSource, test.threadPool };
+    HeadlessFrontend frontend { { 256, 256 }, ratio, test.threadPool };
     Map map(frontend, MapObserver::nullObserver(), frontend.getSize(), ratio, test.fileSource,
             test.threadPool, MapOptions().withMapMode(MapMode::Static));
     map.jumpTo(CameraOptions().withZoom(16));
@@ -84,7 +84,7 @@ TEST(Memory, Raster) {
     MemoryTest test;
     float ratio { 2 };
 
-    HeadlessFrontend frontend { { 256, 256 }, ratio, test.fileSource, test.threadPool };
+    HeadlessFrontend frontend { { 256, 256 }, ratio, test.threadPool };
     Map map(frontend, MapObserver::nullObserver(), frontend.getSize(), ratio, test.fileSource,
             test.threadPool, MapOptions().withMapMode(MapMode::Static));
     map.getStyle().loadURL("mapbox://satellite");
@@ -122,7 +122,7 @@ TEST(Memory, Footprint) {
     class FrontendAndMap {
     public:
         FrontendAndMap(MemoryTest& test_, const char* style)
-            : frontend(Size{ 256, 256 }, 2, test_.fileSource, test_.threadPool)
+            : frontend(Size{ 256, 256 }, 2, test_.threadPool)
             , map(frontend, MapObserver::nullObserver(), frontend.getSize(), 2, test_.fileSource
             , test_.threadPool, MapOptions().withMapMode(MapMode::Static)) {
             map.jumpTo(CameraOptions().withZoom(16));


### PR DESCRIPTION
Our `Renderer::Impl` forwards `FileSource` for two things: `GlyphManager` and `TileLoader<>` (the latter contained on each `Tile`-derived class). These objects are _currently_ only used by `Renderer::Impl`, so it is safe to pass them along via `UpdateParameters` instead.

This causes the `Renderer` object to not depend on a `FileSource` to be passed on its ctor, and thus clears the way for having `FileSource` being instantiated internally from `Map` object, which also won't need to receive a `FileSource` on its ctor - a further PR for that is on the way.

This is an intermediary step towards having `Renderer` not to depend at all from network requests.