### PR TITLE
[android, ios] Fix error in binary size collection script

### DIFF
--- a/scripts/publish_binary_size.js
+++ b/scripts/publish_binary_size.js
@@ -96,18 +96,22 @@ function query(after) {
 
             if (!suite)
                 continue;
-
-            const runs = commit.checkSuites.nodes[0].checkRuns.nodes;
+            const allRuns = commit.checkSuites.nodes[0].checkRuns.nodes;
+            
+            const sizeCheckRuns = allRuns.filter(function (run) {
+              return run.name.match(/Size - (\w+) ([\w-]+)/);
+            });
+            
             const row = [`${commit.oid.slice(0, 7)} - ${commit.messageHeadline}`];
 
             for (let i = 0; i < platforms.length; i++) {
                 const {platform, arch} = platforms[i];
 
-                const run = runs.find((run) => {
+                const run = sizeCheckRuns.find((run) => {
                     const [, p, a] = run.name.match(/Size - (\w+) ([\w-]+)/);
                     return platform === p && arch === a;
                 });
-
+                
                 row[i + 1] = run ? +run.summary.match(/is (\d+) bytes/)[1] : undefined;
             }
             rows.push(row);


### PR DESCRIPTION
It appears that https://github.com/mapbox/mapbox-gl-native/pull/14057 inadvertently broke [`publish_binary_size.js`](https://github.com/mapbox/mapbox-gl-native/blob/master/scripts/publish_binary_size.js) by introducing a new element to [`runs`](https://github.com/mapbox/mapbox-gl-native/blob/master/scripts/publish_binary_size.js#L100) array:

```json
{
    "name": "Doxygen coverage",
    "conclusion": "SUCCESS",
    "title": "6.27%",
    "summary": "There is doxygen documentation for 6.271072151045178% of the public symbols (93 out of 1483)"
}
``` 

This addition causes [`run.name.match(/Size - (\w+) ([\w-]+)/)`](https://github.com/mapbox/mapbox-gl-native/blob/master/scripts/publish_binary_size.js#L107) to fail, so this PR ensures that when we're attempting to match against platform/arch, that we're only doing so with check objects that originate from the [`check_binary_size.js`](https://github.com/mapbox/mapbox-gl-native/blob/master/scripts/check_binary_size.js#L77) script.

cc @LukasPaczos @alexshalamov 