### PR TITLE
move TextureView to basic category for UiAutomator scrolling

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -723,7 +723,7 @@
             android:label="@string/activity_textureview_debug">
             <meta-data
                 android:name="@string/category"
-                android:value="@string/category_textureview" />
+                android:value="@string/category_basic" />
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activity.FeatureOverviewActivity" />


### PR DESCRIPTION
This PR moves texture view debug activity to the top of activities, this to improve execution time of UiAutomator tests. 