### PR TITLE
[core] Forward evaluation context directly to evaluated property

### DIFF
--- a/include/mbgl/style/expression/format_section_override.hpp
+++ b/include/mbgl/style/expression/format_section_override.hpp
@@ -27,7 +27,11 @@ public:
                 return section.at(propertyName);
             }
         }
-        return defaultValue.evaluate(*context.feature, *context.zoom, T());
+
+        return defaultValue.match(
+                [&context] (const style::PropertyExpression<T>& e) { return e.getExpression().evaluate(context); },
+                [] (const T& t) -> EvaluationResult { return t; }
+        );
     }
 
     void eachChild(const std::function<void(const Expression&)>& fn) const final {


### PR DESCRIPTION
So that default value owned by the FormatSectionOverride, can be evaluated based on required context parameters. Therefore, FormatSectionOverride does not need to validate evaluation context.

Even though [PropertyExpression.FormatSectionOverride ](https://github.com/mapbox/mapbox-gl-native/blob/master/test/style/property_expression.test.cpp#L154) is covering such cases, unit test was only failing on debug arm builds, e.g., `make run-android-core-test-arm-v8-PropertyExpression.FormatSectionOverride`.