### PR TITLE
[core] Expose a way of flushing the graphics pipeline

### DIFF
--- a/include/mbgl/renderer/renderer.hpp
+++ b/include/mbgl/renderer/renderer.hpp
@@ -34,6 +34,8 @@ public:
 
     void render(const UpdateParameters&);
 
+    void flush();
+
     // Feature queries
     std::vector<Feature> queryRenderedFeatures(const ScreenLineString&, const RenderedQueryOptions& options = {}) const;
     std::vector<Feature> queryRenderedFeatures(const ScreenCoordinate& point, const RenderedQueryOptions& options = {}) const;

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -775,5 +775,9 @@ void Context::performCleanup() {
     }
 }
 
+void Context::flush() {
+    MBGL_CHECK_ERROR(glFinish());
+}
+
 } // namespace gl
 } // namespace mbgl

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -116,6 +116,11 @@ public:
     // Only call this while the OpenGL context is exclusive to this thread.
     void reset();
 
+    // Flush pending graphics commands. Will block until the pipeline
+    // is empty. Should be used only with a very good reason because
+    // it will have a performance impact.
+    void flush();
+
     bool empty() const {
         return pooledTextures.empty()
             && abandonedPrograms.empty()

--- a/src/mbgl/renderer/renderer.cpp
+++ b/src/mbgl/renderer/renderer.cpp
@@ -34,6 +34,10 @@ void Renderer::render(const UpdateParameters& updateParameters) {
     impl->render(updateParameters);
 }
 
+void Renderer::flush() {
+    impl->flush();
+}
+
 std::vector<Feature> Renderer::queryRenderedFeatures(const ScreenLineString& geometry, const RenderedQueryOptions& options) const {
     return impl->queryRenderedFeatures(geometry, options);
 }

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -614,6 +614,12 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
     parameters.context.performCleanup();
 }
 
+void  Renderer::Impl::flush() {
+    assert(BackendScope::exists());
+
+    backend.getContext().flush();
+}
+
 std::vector<Feature> Renderer::Impl::queryRenderedFeatures(const ScreenLineString& geometry, const RenderedQueryOptions& options) const {
     std::vector<const RenderLayer*> layers;
     if (options.layerIDs) {

--- a/src/mbgl/renderer/renderer_impl.hpp
+++ b/src/mbgl/renderer/renderer_impl.hpp
@@ -48,6 +48,8 @@ public:
 
     void render(const UpdateParameters&);
 
+    void flush();
+
     std::vector<Feature> queryRenderedFeatures(const ScreenLineString&, const RenderedQueryOptions&) const;
     std::vector<Feature> querySourceFeatures(const std::string& sourceID, const SourceQueryOptions&) const;
     std::vector<Feature> queryShapeAnnotations(const ScreenLineString&) const;


### PR DESCRIPTION
Useful for apps before going to background that are restricted by the OS of performing any operation.