### PR TITLE
Speculative fix for Samsung S9/S10 cached shader crash

### DIFF
--- a/src/mbgl/gl/features.hpp
+++ b/src/mbgl/gl/features.hpp
@@ -3,5 +3,5 @@
 #if __APPLE__
     #define MBGL_HAS_BINARY_PROGRAMS 0
 #else
-    #define MBGL_HAS_BINARY_PROGRAMS 1
+    #define MBGL_HAS_BINARY_PROGRAMS 0
 #endif


### PR DESCRIPTION
This is a quick speculative fix for a crash report we've received on Samsung S9/S10 devices displaying multiple maps at a time.