### PR TITLE
[ios, macos] Fix format expression parsing.

### DIFF
--- a/platform/darwin/src/NSExpression+MGLAdditions.mm
+++ b/platform/darwin/src/NSExpression+MGLAdditions.mm
@@ -1016,14 +1016,10 @@ NSArray *MGLSubexpressionsWithJSONObjects(NSArray *objects) {
             if ([constantValue isKindOfClass:[MGLAttributedExpression class]]) {
                 MGLAttributedExpression *attributedExpression = (MGLAttributedExpression *)constantValue;
                 id jsonObject = attributedExpression.expression.mgl_jsonExpressionObject;
-                NSMutableArray *attributes = [NSMutableArray array];
-                if ([jsonObject isKindOfClass:[NSArray class]]) {
-                    [attributes addObjectsFromArray:jsonObject];
-                } else {
-                    [attributes addObject:jsonObject];
-                }
+                NSMutableDictionary *attributedDictionary = [NSMutableDictionary dictionary];
+                
                 if (attributedExpression.attributes) {
-                    NSMutableDictionary *attributedDictionary = [NSMutableDictionary dictionaryWithDictionary:attributedExpression.attributes];
+                    attributedDictionary = [NSMutableDictionary dictionaryWithDictionary:attributedExpression.attributes];
                     if (attributedDictionary[MGLFontNamesAttribute]) {
                         attributedDictionary[MGLFontNamesAttribute] = @[@"literal", attributedDictionary[MGLFontNamesAttribute]];
                     }
@@ -1031,12 +1027,8 @@ NSArray *MGLSubexpressionsWithJSONObjects(NSArray *objects) {
                         MGLColor *color = attributedDictionary[MGLFontColorAttribute];
                         attributedDictionary[MGLFontColorAttribute] = color.mgl_jsonExpressionObject;
                     }
-                    [attributes addObject:attributedDictionary];
-                } else {
-                    [attributes addObject:@{}];
-                }
- 
-                return attributes;
+                } 
+                return @[jsonObject, attributedDictionary];
             }
             return self.constantValue;
         }

--- a/platform/darwin/test/MGLExpressionTests.mm
+++ b/platform/darwin/test/MGLExpressionTests.mm
@@ -1063,6 +1063,14 @@ using namespace std::string_literals;
         XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression], expression);
     }
     {
+        MGLAttributedExpression *attribute1 = [[MGLAttributedExpression alloc] initWithExpression:[NSExpression expressionForConstantValue:@"foo"]] ;
+        NSExpression *expression = [NSExpression expressionWithFormat:@"mgl_attributed:(%@)", MGLConstantExpression(attribute1)];
+        
+        NSArray *jsonExpression = @[ @"format", @"foo", @{ } ];
+        XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
+        XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression], expression);
+    }
+    {
         MGLAttributedExpression *attribute1 = [[MGLAttributedExpression alloc] initWithExpression:[NSExpression expressionForConstantValue:@"foo"]
                                                                                        attributes:@{ MGLFontSizeAttribute: @(1.2),
                                                                                                      MGLFontColorAttribute: @"yellow",
@@ -1083,6 +1091,18 @@ using namespace std::string_literals;
         NSExpression *expression = [NSExpression expressionWithFormat:@"mgl_attributed:(%@)", MGLConstantExpression(attribute1)];
         
         NSArray *jsonExpression = @[ @"format", @"foo", @{ @"font-scale": @1.2, @"text-color": @[@"rgb", @255, @0, @0] , @"text-font" : @[ @"literal", @[ @"DIN Offc Pro Bold", @"Arial Unicode MS Bold" ]]} ];
+        XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
+        XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression], expression);
+    }
+    {
+        MGLAttributedExpression *attribute1 = [[MGLAttributedExpression alloc] initWithExpression:[NSExpression expressionWithFormat:@"CAST(x, 'NSString')"]
+                                                                                       attributes:@{ MGLFontSizeAttribute: @(1.2),
+                                                                                                     MGLFontColorAttribute: [MGLColor redColor],
+                                                                                                     MGLFontNamesAttribute: @[ @"DIN Offc Pro Bold", @"Arial Unicode MS Bold" ]
+                                                                                                     }] ;
+        NSExpression *expression = [NSExpression expressionWithFormat:@"mgl_attributed:(%@)", MGLConstantExpression(attribute1)];
+        
+        NSArray *jsonExpression = @[ @"format", @[@"to-string", @[@"get", @"x"]], @{ @"font-scale": @1.2, @"text-color": @[@"rgb", @255, @0, @0] , @"text-font" : @[ @"literal", @[ @"DIN Offc Pro Bold", @"Arial Unicode MS Bold" ]]} ];
         XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
         XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression], expression);
     }


### PR DESCRIPTION
Fixes a parsing issue when a non-constant expression is passed as `MGLAttributedExpression` parameter.