### PR TITLE
Correct the code_coverage time to follow ISO 8601

### DIFF
--- a/scripts/code-coverage.sh
+++ b/scripts/code-coverage.sh
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 #
-# This script takes three values: $1 should be a decimal value reflecting the 
+# This script takes three values: $1 should be a decimal value reflecting the
 # percentage of lines covered, with a maximum value of 100.0, $2 is
 # the platform the percentage pertains to (iOS or Android), and $3 is the
 # test scheme being run (on iOS, this is currently CI).
@@ -21,19 +21,18 @@ circle_sha=""
 if [[ $CIRCLE_SHA1 ]]; then
     circle_sha="$CIRCLE_SHA1"
 fi
-# Create a formatted JSON file that contains the current coverage. 
+# Create a formatted JSON file that contains the current coverage.
 
-current_date=$(TZ=UTC date +"%F-%T")
+current_date=$(TZ=UTC date +"%FT%T%z")
 file_name=$2_coverage.json
 cat <<EOF > $file_name
-    {"code_coverage":$1,"platform":"$2","sdk":"Maps","scheme":"$3","created_at":"$current_date","sha":"$circle_sha"}
+{"code_coverage":$1,"platform":"$2","sdk":"Maps","scheme":"$3","created_at":"$current_date","sha":"$circle_sha"}
 EOF
 gzip -f $file_name
 
-if [ -z `which aws` ]; then	
-    brew install awscli	
+if [ -z `which aws` ]; then
+    brew install awscli
 fi
 
 aws s3 cp $file_name.gz s3://mapbox-loading-dock/raw/mobile.codecoverage/$current_date/
 echo $
-


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gl-native/pull/14145.

Fixes the code coverage report time to follow ISO 8601 and corrects the resulting file formatting.