### PR TITLE
Change the firebase device for arm-v7 test run to htc_m8

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,8 +15,8 @@ workflows:
       - android-arm-template:
           name: android-gnustl-arm-v7
           stl: gnustl_shared
-          firebase_device_id: "cheryl"
-          firebase_device_os: "25"
+          firebase_device_id: "htc_m8"
+          firebase_device_os: "19"
           image: android-ndk-r17c:1d5db0eb34
           abi: arm-v7
       - android-release:


### PR DESCRIPTION
Changes the `android-gnustl-arm-v7` to run instrumentation tests using HTTC One and API 19.