### PR TITLE
Validate license generation with nitpick on CI

### DIFF
--- a/platform/android/gradle/android-nitpick.gradle
+++ b/platform/android/gradle/android-nitpick.gradle
@@ -17,6 +17,8 @@ task androidNitpick {
         verifyVendorSubmodulePin(MAPBOX_JAVA_DIR, MAPBOX_JAVA_TAG_PREFIX, versions.mapboxServices)
         verifyVendorSubmodulePin(MAPBOX_TELEMETRY_DIR, MAPBOX_TELEMETRY_TAG_PREFIX, versions.mapboxTelemetry)
         verifyVendorSubmodulePin(MAPBOX_GESTURES_DIR, MAPBOX_GESTURES_TAG_PREFIX, versions.mapboxGestures)
+        
+        verifyLicenseGeneration()
     }
 }
 
@@ -51,4 +53,12 @@ private def verifyVendorSubmodulePin(def dir, def prefix, def version) {
                 "If you've bumped the pin, make sure to verify the version tag prefix in the android-nitpick.gradle file.")
     }
     output.close()
+}
+
+private def verifyLicenseGeneration() {
+    println "Verify license generation with git diff..."
+    exec {
+      workingDir = "${rootDir}"
+      commandLine "python", "scripts/validate-license.py"
+    }
 }

--- a/platform/android/scripts/validate-license.py
+++ b/platform/android/scripts/validate-license.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python
+
+from subprocess import call
+from subprocess import Popen, PIPE
+import sys
+
+## Run license generation
+call('cd ../../ && make android-license', shell=True)
+
+## Git diff changes
+p = Popen(['git', 'diff', '--name-only', 'LICENSE.md'], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+output, err = p.communicate(b"input data that is passed to subprocess' stdin")
+if "platform/android/LICENSE.md" in output:
+   raise ValueError("""An error ocurred while validating the license generation. 
+            Changes were detected to the license generation output 
+            but weren't commited. Run make android-license and 
+            commit the changeset to make this validation pass.""")


### PR DESCRIPTION
Closes #14163.

If you forget to update the LICENSE.md for PRs that should have updated it then CI will fail with:

```error
ValueError: An error occurred while validating the license generation. 
            Changes were detected to the license generation output 
            but weren't committed. Run make android-license and 
            commit the changeset to make this validation pass.

> Task :MapboxGLAndroidSDK:androidNitpick FAILED

FAILURE: Build failed with an exception.

```
