### PR TITLE
[ios, macos] Fix conditional expression parsing error.

### DIFF
--- a/platform/darwin/src/NSExpression+MGLAdditions.mm
+++ b/platform/darwin/src/NSExpression+MGLAdditions.mm
@@ -1230,27 +1230,10 @@ NSArray *MGLSubexpressionsWithJSONObjects(NSArray *objects) {
         }
             
         case NSConditionalExpressionType: {
-            NSMutableArray *arguments = [NSMutableArray arrayWithObjects:self.predicate.mgl_jsonExpressionObject, nil];
+            NSMutableArray *arguments = [NSMutableArray arrayWithObjects:@"case", self.predicate.mgl_jsonExpressionObject, nil];
+            [arguments addObject:self.trueExpression.mgl_jsonExpressionObject];
+            [arguments addObject:self.falseExpression.mgl_jsonExpressionObject];
             
-            if (self.trueExpression.expressionType == NSConditionalExpressionType) {
-                // Fold nested conditionals into a single case expression.
-                NSArray *trueArguments = self.trueExpression.mgl_jsonExpressionObject;
-                trueArguments = [trueArguments subarrayWithRange:NSMakeRange(1, trueArguments.count - 1)];
-                [arguments addObjectsFromArray:trueArguments];
-            } else {
-                [arguments addObject:self.trueExpression.mgl_jsonExpressionObject];
-            }
-            
-            if (self.falseExpression.expressionType == NSConditionalExpressionType) {
-                // Fold nested conditionals into a single case expression.
-                NSArray *falseArguments = self.falseExpression.mgl_jsonExpressionObject;
-                falseArguments = [falseArguments subarrayWithRange:NSMakeRange(1, falseArguments.count - 1)];
-                [arguments addObjectsFromArray:falseArguments];
-            } else {
-                [arguments addObject:self.falseExpression.mgl_jsonExpressionObject];
-            }
-            
-            [arguments insertObject:@"case" atIndex:0];
             return arguments;
         }
             

--- a/platform/darwin/test/MGLExpressionTests.mm
+++ b/platform/darwin/test/MGLExpressionTests.mm
@@ -846,12 +846,9 @@ using namespace std::string_literals;
     }
     {
         NSExpression *expression = [NSExpression expressionWithFormat:@"TERNARY(0 = 1, TRUE, TERNARY(1 = 2, TRUE, FALSE))"];
-        NSArray *jsonExpression = @[@"case", @[@"==", @0, @1], @YES, @[@"==", @1, @2], @YES, @NO];
+        NSArray *jsonExpression = @[@"case", @[@"==", @0, @1], @YES, @[@"case", @[@"==", @1, @2], @YES, @NO]];
         XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
         XCTAssertEqualObjects([expression expressionValueWithObject:nil context:nil], @NO);
-        expression = [NSExpression expressionWithFormat:@"MGL_IF(%@, TRUE, %@, TRUE, FALSE)",
-                      MGLConstantExpression([NSPredicate predicateWithFormat:@"0 = 1"]),
-                      MGLConstantExpression([NSPredicate predicateWithFormat:@"1 = 2"])];
         XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression], expression);
     }
     {

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Added a Galician localization. ([#14095](https://github.com/mapbox/mapbox-gl-native/pull/14095))
 * Added `mgl_attributed:` expression operator, which concatenate `MGLAttributedExpression` objects for specifying rich text in the `MGLSymbolStyleLayer.text` property. ([#14094](https://github.com/mapbox/mapbox-gl-native/pull/14094))
 * Fixed a bug that caused offline packs created prior to v4.0.0 (introduced in [#11055](https://github.com/mapbox/mapbox-gl-native/pull/11055)) to be marked as `MGLOfflinePackStateInactive`. ([#14188](https://github.com/mapbox/mapbox-gl-native/pull/14188))
+* Fixed an issue that caused conditional expressions to crash when passed nested conditional expressions as parameters. ([#14181](https://github.com/mapbox/mapbox-gl-native/pull/14181))
 
 ### User interaction
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Added `MGLNetworkConfiguration` class to customize the SDK's `NSURLSessionConfiguration` object. ([#11447](https://github.com/mapbox/mapbox-gl-native/pull/13886))
 * Fixed an issue that caused `MGL_FUNCTION` to ignore multiple formatting parameters when passed a `format` function as parameter. ([#14064](https://github.com/mapbox/mapbox-gl-native/pull/14064))
 * Added `mgl_attributed:` expression operator, which concatenate `MGLAttributedExpression` objects for specifying rich text in the `MGLSymbolStyleLayer.text` property. ([#14094](https://github.com/mapbox/mapbox-gl-native/pull/14094))
+* Fixed an issue that caused conditional expressions to crash when passed nested conditional expressions as parameters. ([#14181](https://github.com/mapbox/mapbox-gl-native/pull/14181))
 
 ### Offline
 


### PR DESCRIPTION
Fixes a parsing issue when conditional nested expressions are passed as parameters of `expressionForConditional`.

cc @riastrad 