### PR TITLE
[ios] Copy-edit changelog for 4.10.0-beta.1

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,17 +4,25 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ## 4.10.0
 
+### Styles and rendering
+
 * Client-side text rendering of CJK ideographs is now enabled by default. ([#13988](https://github.com/mapbox/mapbox-gl-native/pull/13988))
-* Added an MGLMapView.prefetchesTiles property that you can disable if you don’t want to prefetch simplified tiles as a performance optimization. ([#14031](https://github.com/mapbox/mapbox-gl-native/pull/14031))
 * Fixed an issue that caused `MGL_FUNCTION` to ignore multiple formatting parameters when passed a `format` function as parameter. ([#14064](https://github.com/mapbox/mapbox-gl-native/pull/14064))
-* Added a Galician localization. ([#14095](https://github.com/mapbox/mapbox-gl-native/pull/14095))
-* Added `mgl_attributed:` expression operator, which concatenate `MGLAttributedExpression` objects for specifying rich text in the `MGLSymbolStyleLayer.text` property. ([#14094](https://github.com/mapbox/mapbox-gl-native/pull/14094))
-* Fixed a bug that caused offline packs created prior to v4.0.0 (introduced in [#11055](https://github.com/mapbox/mapbox-gl-native/pull/11055)) to be marked as `MGLOfflinePackStateInactive`. ([#14188](https://github.com/mapbox/mapbox-gl-native/pull/14188))
+* Added `mgl_attributed:` expression operator, which concatenates `MGLAttributedExpression` objects for specifying rich text in the `MGLSymbolStyleLayer.text` property. ([#14094](https://github.com/mapbox/mapbox-gl-native/pull/14094))
 * Fixed an issue that caused conditional expressions to crash when passed nested conditional expressions as parameters. ([#14181](https://github.com/mapbox/mapbox-gl-native/pull/14181))
 
-### User interaction
+### Packaging
 
-* Added `MGLOrnamentPosition` enum and margins methods to customize MGLMapView's scale bar, compass, logo and attribution position. ([#13911](https://github.com/mapbox/mapbox-gl-native/pull/13911))
+* Added a Galician localization. ([#14095](https://github.com/mapbox/mapbox-gl-native/pull/14095))
+
+### Offline maps
+
+* Fixed a bug that caused offline packs created prior to v4.0.0 to be marked as `MGLOfflinePackStateInactive`. ([#14188](https://github.com/mapbox/mapbox-gl-native/pull/14188))
+
+### Other changes
+
+* Added `MGLOrnamentPosition` enum and margin properties to customize scale bar, compass, logo, and attribution position within the map view. ([#13911](https://github.com/mapbox/mapbox-gl-native/pull/13911))
+* Added an `MGLMapView.prefetchesTiles` property to configure lower-resolution tile prefetching behavior. ([#14031](https://github.com/mapbox/mapbox-gl-native/pull/14031))
 
 ## 4.9.0 - February 27, 2019
 

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -414,12 +414,12 @@ MGL_EXPORT IB_DESIGNABLE
 /**
  A Boolean value indicating whether the map should prefetch tiles.
  
- When this property is set to YES, the map view prefetches loads tiles designed for a
- low zoom level and displays them until receiving more detailed tiles for the current
- zoom level. The prefetched tiles typically contain simplified versions of each shape,
- improving the map view’s perceived performance.
+ When this property is set to `YES`, the map view prefetches tiles designed for
+ a low zoom level and displays them until receiving more detailed tiles for the
+ current zoom level. The prefetched tiles typically contain simplified versions
+ of each shape, improving the map view’s perceived performance.
  
- The default value of this property is YES.
+ The default value of this property is `YES`.
  */
 @property (nonatomic, assign) BOOL prefetchesTiles;
 
@@ -434,17 +434,18 @@ MGL_EXPORT IB_DESIGNABLE
 #pragma mark Displaying the User’s Location
 
 /**
- The object that this map view uses to start and stop the delivery of location-related
- updates.
+ The object that this map view uses to start and stop the delivery of
+ location-related updates.
 
- To receive the current user location, implement the `-[MGLMapViewDelegate mapView:didUpdateUserLocation:]`
- and `-[MGLMapViewDelegate mapView:didFailToLocateUserWithError:]` methods.
+ To receive the current user location, implement the
+ `-[MGLMapViewDelegate mapView:didUpdateUserLocation:]` and
+ `-[MGLMapViewDelegate mapView:didFailToLocateUserWithError:]` methods.
 
- If setting this property to `nil` or if no custom manager is provided this property
- is set to the default location manager.
+ If setting this property to `nil` or if no custom manager is provided this
+ property is set to the default location manager.
 
- `MGLMapView` uses a default location manager. If you want to substitute your own
- location manager, you should do so by setting this property before setting
+ `MGLMapView` uses a default location manager. If you want to substitute your
+ own location manager, you should do so by setting this property before setting
  `showsUserLocation` to `YES`. To restore the default location manager,
  set this property to `nil`.
  */

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2564,11 +2564,13 @@ public:
     }
 }
 
-- (void)setPrefetchesTiles:(BOOL)prefetchesTiles{
+- (void)setPrefetchesTiles:(BOOL)prefetchesTiles
+{
     _mbglMap->setPrefetchZoomDelta(prefetchesTiles ? mbgl::util::DEFAULT_PREFETCH_ZOOM_DELTA : 0);
 }
 
-- (BOOL)prefetchesTiles{
+- (BOOL)prefetchesTiles
+{
     return _mbglMap->getPrefetchZoomDelta() > 0 ? YES : NO;
 }
 


### PR DESCRIPTION
- Reorganizes and edits changelog entries for 4.10.0, in advance of beta.1.
- A few nitpicky edits of docs and style for #14031.

/cc @jmkiley 