### PR TITLE
[ios, macos] Support expressions in formatting parameters.

### DIFF
--- a/platform/darwin/docs/guides/For Style Authors.md.ejs
+++ b/platform/darwin/docs/guides/For Style Authors.md.ejs
@@ -439,7 +439,7 @@ can use to update the formatting of `MGLSymbolStyleLayer.text` property.
 In style JSON | In Objective-C        | In Swift
 --------------|-----------------------|---------
 `text-font`      | `MGLFontNamesAttribute` | `.fontNamesAttribute`
-`font-scale`      | `MGLFontSizeAttribute` | `.fontSizeAttribute`
+`font-scale`      | `MGLFontScaleAttribute` | `.fontScaleAttribute`
 `text-color`  | `MGLFontColorAttribute` | `.fontColorAttribute`
 
 See the “[Predicates and Expressions](predicates-and-expressions.html)” guide for

--- a/platform/darwin/docs/guides/Predicates and Expressions.md
+++ b/platform/darwin/docs/guides/Predicates and Expressions.md
@@ -550,9 +550,9 @@ with the `MGLSymbolStyleLayer.text` property.
 
  Key | Value Type
  --- | ---
- `MGLFontNamesAttribute` | `NSArray<NSString *>*`
- `MGLFontScaleAttribute` | `NSNumber`
- `MGLFontColorAttribute` | `UIColor` or `NSColor` on macos
+ `MGLFontNamesAttribute` | `NSExpression`
+ `MGLFontScaleAttribute` | `NSExpression`
+ `MGLFontColorAttribute` | `NSExpression`
 
 This function corresponds to the
 [`format`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-types-format)

--- a/platform/darwin/docs/guides/Predicates and Expressions.md
+++ b/platform/darwin/docs/guides/Predicates and Expressions.md
@@ -551,7 +551,7 @@ with the `MGLSymbolStyleLayer.text` property.
  Key | Value Type
  --- | ---
  `MGLFontNamesAttribute` | `NSArray<NSString *>*`
- `MGLFontSizeAttribute` | `NSNumber`
+ `MGLFontScaleAttribute` | `NSNumber`
  `MGLFontColorAttribute` | `UIColor` or `NSColor` on macos
 
 This function corresponds to the

--- a/platform/darwin/docs/guides/Predicates and Expressions.md
+++ b/platform/darwin/docs/guides/Predicates and Expressions.md
@@ -550,9 +550,9 @@ with the `MGLSymbolStyleLayer.text` property.
 
  Key | Value Type
  --- | ---
- `MGLFontNamesAttribute` | `NSExpression`
- `MGLFontScaleAttribute` | `NSExpression`
- `MGLFontColorAttribute` | `NSExpression`
+ `MGLFontNamesAttribute` | An `NSExpression` evaluating to an `NSString` array.
+ `MGLFontScaleAttribute` | An `NSExpression` evaluating to an `NSNumber` value.
+ `MGLFontColorAttribute` | An `NSExpression` evaluating to an `UIColor` (iOS) or `NSColor` (macOS).
 
 This function corresponds to the
 [`format`](https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-types-format)

--- a/platform/darwin/src/MGLAttributedExpression.h
+++ b/platform/darwin/src/MGLAttributedExpression.h
@@ -5,7 +5,7 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NSString * MGLAttributedExpressionKey NS_EXTENSIBLE_STRING_ENUM;
 
 FOUNDATION_EXTERN MGL_EXPORT MGLAttributedExpressionKey const MGLFontNamesAttribute;
-FOUNDATION_EXTERN MGL_EXPORT MGLAttributedExpressionKey const MGLFontSizeAttribute;
+FOUNDATION_EXTERN MGL_EXPORT MGLAttributedExpressionKey const MGLFontScaleAttribute;
 FOUNDATION_EXTERN MGL_EXPORT MGLAttributedExpressionKey const MGLFontColorAttribute;
 
 /**
@@ -18,7 +18,7 @@ FOUNDATION_EXTERN MGL_EXPORT MGLAttributedExpressionKey const MGLFontColorAttrib
  let expression = NSExpression(forConstantValue: "Foo")
  let attributes: Dictionary<MGLAttributedExpressionKey, Any> = [.fontNamesAttribute : ["DIN Offc Pro Italic",
                                                                                        "Arial Unicode MS Regular"],
-                                                                .fontSizeAttribute: 1.2,
+                                                                .fontScaleAttribute: 1.2,
                                                                 .fontColorAttribute: redColor]
  let attributedExpression = MGLAttributedExpression(expression, attributes:attributes)
  ```
@@ -38,7 +38,7 @@ MGL_EXPORT
  Key | Value Type
  --- | ---
  `MGLFontNamesAttribute` | `NSArray<NSString *>*`
- `MGLFontSizeAttribute` | `NSNumber`
+ `MGLFontScaleAttribute` | `NSNumber`
  `MGLFontColorAttribute` | `UIColor`
 
  */
@@ -49,7 +49,7 @@ MGL_EXPORT
  Key | Value Type
  --- | ---
  `MGLFontNamesAttribute` | `NSArray<NSString *>*`
- `MGLFontSizeAttribute` | `NSNumber`
+ `MGLFontScaleAttribute` | `NSNumber`
  `MGLFontColorAttribute` | `NSColor`
  */
 @property (strong, nonatomic, readonly) NSDictionary<MGLAttributedExpressionKey, id> *attributes;
@@ -69,7 +69,7 @@ MGL_EXPORT
 /**
  Creates an `MGLAttributedExpression` object initialized with an expression and the format attributes for font names and font size.
  */
-+ (instancetype)attributedExpression:(NSExpression *)expression fontNames:(nullable NSArray<NSString*> *)fontNames fontSize:(nullable NSNumber *)fontSize;
++ (instancetype)attributedExpression:(NSExpression *)expression fontNames:(nullable NSArray<NSString*> *)fontNames fontScale:(nullable NSNumber *)fontScale;
 
 /**
  Creates an `MGLAttributedExpression` object initialized with an expression and the format attributes dictionary.

--- a/platform/darwin/src/MGLAttributedExpression.h
+++ b/platform/darwin/src/MGLAttributedExpression.h
@@ -2,10 +2,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NSString * MGLAttributedExpressionKey NS_EXTENSIBLE_STRING_ENUM;
+/** Options for `MGLAttributedExpression.attributes`. */
+typedef NSString * MGLAttributedExpressionKey NS_TYPED_ENUM;
 
+/** The font name string array expression used to format the text. */
 FOUNDATION_EXTERN MGL_EXPORT MGLAttributedExpressionKey const MGLFontNamesAttribute;
+
+/** The font scale number expression relative to `MGLSymbolStyleLayer.textFontSize` used to format the text. */
 FOUNDATION_EXTERN MGL_EXPORT MGLAttributedExpressionKey const MGLFontScaleAttribute;
+
+/** The font color expression used to format the text. */
 FOUNDATION_EXTERN MGL_EXPORT MGLAttributedExpressionKey const MGLFontColorAttribute;
 
 /**
@@ -16,10 +22,10 @@ FOUNDATION_EXTERN MGL_EXPORT MGLAttributedExpressionKey const MGLFontColorAttrib
  ```swift
  let redColor = UIColor.red
  let expression = NSExpression(forConstantValue: "Foo")
- let attributes: Dictionary<MGLAttributedExpressionKey, NSExpression> = [.fontNamesAttribute : NSExpression(forConstantValue: ["DIN Offc Pro Italic",
-                                                                                                                               "Arial Unicode MS Regular"]),
-                                                                         .fontScaleAttribute: NSExpression(forConstantValue: 1.2),
-                                                                         .fontColorAttribute: NSExpression(forConstantValue: redColor)]
+ let attributes: [MGLAttributedExpressionKey: NSExpression] = [.fontNamesAttribute : NSExpression(forConstantValue: ["DIN Offc Pro Italic",
+                                                                                                                     "Arial Unicode MS Regular"]),
+                                                               .fontScaleAttribute: NSExpression(forConstantValue: 1.2),
+                                                               .fontColorAttribute: NSExpression(forConstantValue: redColor)]
  let attributedExpression = MGLAttributedExpression(expression, attributes:attributes)
  ```
  
@@ -37,9 +43,9 @@ MGL_EXPORT
  The formatting attributes dictionary.
  Key | Value Type
  --- | ---
- `MGLFontNamesAttribute` | `NSExpression`
- `MGLFontScaleAttribute` | `NSExpression`
- `MGLFontColorAttribute` | `NSExpression`
+ `MGLFontNamesAttribute` | An `NSExpression` evaluating to an `NSString` array.
+ `MGLFontScaleAttribute` | An `NSExpression` evaluating to an `NSNumber` value.
+ `MGLFontColorAttribute` | An `NSExpression` evaluating to an `UIColor`.
 
  */
 @property (strong, nonatomic, readonly) NSDictionary<MGLAttributedExpressionKey, NSExpression *> *attributes;
@@ -48,9 +54,9 @@ MGL_EXPORT
  The formatting attributes dictionary.
  Key | Value Type
  --- | ---
- `MGLFontNamesAttribute` | `NSExpression`
- `MGLFontScaleAttribute` | `NSExpression`
- `MGLFontColorAttribute` | `NSExpression`
+ `MGLFontNamesAttribute` | An `NSExpression` evaluating to an `NSString` array.
+ `MGLFontScaleAttribute` | An `NSExpression` evaluating to an `NSNumber` value.
+ `MGLFontColorAttribute` | An `NSExpression` evaluating to an `NSColor` on macos.
  */
 @property (strong, nonatomic, readonly) NSDictionary<MGLAttributedExpressionKey, NSExpression *> *attributes;
 #endif

--- a/platform/darwin/src/MGLAttributedExpression.h
+++ b/platform/darwin/src/MGLAttributedExpression.h
@@ -16,10 +16,10 @@ FOUNDATION_EXTERN MGL_EXPORT MGLAttributedExpressionKey const MGLFontColorAttrib
  ```swift
  let redColor = UIColor.red
  let expression = NSExpression(forConstantValue: "Foo")
- let attributes: Dictionary<MGLAttributedExpressionKey, Any> = [.fontNamesAttribute : ["DIN Offc Pro Italic",
-                                                                                       "Arial Unicode MS Regular"],
-                                                                .fontScaleAttribute: 1.2,
-                                                                .fontColorAttribute: redColor]
+ let attributes: Dictionary<MGLAttributedExpressionKey, NSExpression> = [.fontNamesAttribute : NSExpression(forConstantValue: ["DIN Offc Pro Italic",
+                                                                                                                               "Arial Unicode MS Regular"]),
+                                                                         .fontScaleAttribute: NSExpression(forConstantValue: 1.2),
+                                                                         .fontColorAttribute: NSExpression(forConstantValue: redColor)]
  let attributedExpression = MGLAttributedExpression(expression, attributes:attributes)
  ```
  
@@ -37,22 +37,22 @@ MGL_EXPORT
  The formatting attributes dictionary.
  Key | Value Type
  --- | ---
- `MGLFontNamesAttribute` | `NSArray<NSString *>*`
- `MGLFontScaleAttribute` | `NSNumber`
- `MGLFontColorAttribute` | `UIColor`
+ `MGLFontNamesAttribute` | `NSExpression`
+ `MGLFontScaleAttribute` | `NSExpression`
+ `MGLFontColorAttribute` | `NSExpression`
 
  */
-@property (strong, nonatomic, readonly) NSDictionary<MGLAttributedExpressionKey, id> *attributes;
+@property (strong, nonatomic, readonly) NSDictionary<MGLAttributedExpressionKey, NSExpression *> *attributes;
 #else
 /**
  The formatting attributes dictionary.
  Key | Value Type
  --- | ---
- `MGLFontNamesAttribute` | `NSArray<NSString *>*`
- `MGLFontScaleAttribute` | `NSNumber`
- `MGLFontColorAttribute` | `NSColor`
+ `MGLFontNamesAttribute` | `NSExpression`
+ `MGLFontScaleAttribute` | `NSExpression`
+ `MGLFontColorAttribute` | `NSExpression`
  */
-@property (strong, nonatomic, readonly) NSDictionary<MGLAttributedExpressionKey, id> *attributes;
+@property (strong, nonatomic, readonly) NSDictionary<MGLAttributedExpressionKey, NSExpression *> *attributes;
 #endif
 
 
@@ -64,7 +64,7 @@ MGL_EXPORT
 /** 
  Returns an `MGLAttributedExpression` object initialized with an expression and text format attributes.
  */
-- (instancetype)initWithExpression:(NSExpression *)expression attributes:(nonnull NSDictionary <MGLAttributedExpressionKey, id> *)attrs;
+- (instancetype)initWithExpression:(NSExpression *)expression attributes:(nonnull NSDictionary <MGLAttributedExpressionKey, NSExpression *> *)attrs;
 
 /**
  Creates an `MGLAttributedExpression` object initialized with an expression and the format attributes for font names and font size.
@@ -74,7 +74,7 @@ MGL_EXPORT
 /**
  Creates an `MGLAttributedExpression` object initialized with an expression and the format attributes dictionary.
  */
-+ (instancetype)attributedExpression:(NSExpression *)expression attributes:(nonnull NSDictionary <MGLAttributedExpressionKey, id> *)attrs;
++ (instancetype)attributedExpression:(NSExpression *)expression attributes:(nonnull NSDictionary <MGLAttributedExpressionKey, NSExpression *> *)attrs;
 
 @end
 

--- a/platform/darwin/src/MGLAttributedExpression.m
+++ b/platform/darwin/src/MGLAttributedExpression.m
@@ -18,18 +18,18 @@ const MGLAttributedExpressionKey MGLFontColorAttribute = @"text-color";
     NSMutableDictionary *attrs = [NSMutableDictionary dictionary];
     
     if (fontNames && fontNames.count > 0) {
-        attrs[MGLFontNamesAttribute] = fontNames;
+        attrs[MGLFontNamesAttribute] = [NSExpression expressionForConstantValue:fontNames];
     }
     
     if (fontScale) {
-        attrs[MGLFontScaleAttribute] = fontScale;
+        attrs[MGLFontScaleAttribute] = [NSExpression expressionForConstantValue:fontScale];
     }
     
     attributedExpression = [[self alloc] initWithExpression:expression attributes:attrs];
     return attributedExpression;
 }
 
-+ (instancetype)attributedExpression:(NSExpression *)expression attributes:(nonnull NSDictionary<MGLAttributedExpressionKey,id> *)attrs {
++ (instancetype)attributedExpression:(NSExpression *)expression attributes:(nonnull NSDictionary<MGLAttributedExpressionKey, NSExpression *> *)attrs {
     MGLAttributedExpression *attributedExpression;
     
     attributedExpression = [[self alloc] initWithExpression:expression attributes:attrs];
@@ -37,7 +37,7 @@ const MGLAttributedExpressionKey MGLFontColorAttribute = @"text-color";
     return attributedExpression;
 }
 
-- (instancetype)initWithExpression:(NSExpression *)expression attributes:(nonnull NSDictionary<MGLAttributedExpressionKey,id> *)attrs {
+- (instancetype)initWithExpression:(NSExpression *)expression attributes:(nonnull NSDictionary<MGLAttributedExpressionKey, NSExpression *> *)attrs {
     if (self = [super init])
     {
         MGLLogInfo(@"Starting %@ initialization.", NSStringFromClass([self class]));

--- a/platform/darwin/src/MGLAttributedExpression.m
+++ b/platform/darwin/src/MGLAttributedExpression.m
@@ -2,7 +2,7 @@
 #import "MGLLoggingConfiguration_Private.h"
 
 const MGLAttributedExpressionKey MGLFontNamesAttribute = @"text-font";
-const MGLAttributedExpressionKey MGLFontSizeAttribute = @"font-scale";
+const MGLAttributedExpressionKey MGLFontScaleAttribute = @"font-scale";
 const MGLAttributedExpressionKey MGLFontColorAttribute = @"text-color";
 
 @implementation MGLAttributedExpression
@@ -12,7 +12,7 @@ const MGLAttributedExpressionKey MGLFontColorAttribute = @"text-color";
     return self;
 }
 
-+ (instancetype)attributedExpression:(NSExpression *)expression fontNames:(nullable NSArray<NSString *> *)fontNames fontSize:(nullable NSNumber *)fontSize {
++ (instancetype)attributedExpression:(NSExpression *)expression fontNames:(nullable NSArray<NSString *> *)fontNames fontScale:(nullable NSNumber *)fontScale {
     MGLAttributedExpression *attributedExpression;
     
     NSMutableDictionary *attrs = [NSMutableDictionary dictionary];
@@ -21,8 +21,8 @@ const MGLAttributedExpressionKey MGLFontColorAttribute = @"text-color";
         attrs[MGLFontNamesAttribute] = fontNames;
     }
     
-    if (fontSize) {
-        attrs[MGLFontSizeAttribute] = fontSize;
+    if (fontScale) {
+        attrs[MGLFontScaleAttribute] = fontScale;
     }
     
     attributedExpression = [[self alloc] initWithExpression:expression attributes:attrs];

--- a/platform/darwin/test/MGLDocumentationExampleTests.swift
+++ b/platform/darwin/test/MGLDocumentationExampleTests.swift
@@ -550,10 +550,10 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
         let redColor = UIColor.red
         #endif
         let expression = NSExpression(forConstantValue: "Foo")
-        let attributes: Dictionary<MGLAttributedExpressionKey, Any> = [.fontNamesAttribute : ["DIN Offc Pro Italic",
-                                                                                              "Arial Unicode MS Regular"],
-                                                                       .fontScaleAttribute: 1.2,
-                                                                       .fontColorAttribute: redColor]
+        let attributes: Dictionary<MGLAttributedExpressionKey, NSExpression> = [.fontNamesAttribute : NSExpression(forConstantValue: ["DIN Offc Pro Italic",
+                                                                                                                                      "Arial Unicode MS Regular"]),
+                                                                                .fontScaleAttribute: NSExpression(forConstantValue: 1.2),
+                                                                                .fontColorAttribute: NSExpression(forConstantValue: redColor)]
         let attributedExpression = MGLAttributedExpression(expression, attributes:attributes)
         //#-end-example-code
         

--- a/platform/darwin/test/MGLDocumentationExampleTests.swift
+++ b/platform/darwin/test/MGLDocumentationExampleTests.swift
@@ -550,10 +550,10 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
         let redColor = UIColor.red
         #endif
         let expression = NSExpression(forConstantValue: "Foo")
-        let attributes: Dictionary<MGLAttributedExpressionKey, NSExpression> = [.fontNamesAttribute : NSExpression(forConstantValue: ["DIN Offc Pro Italic",
-                                                                                                                                      "Arial Unicode MS Regular"]),
-                                                                                .fontScaleAttribute: NSExpression(forConstantValue: 1.2),
-                                                                                .fontColorAttribute: NSExpression(forConstantValue: redColor)]
+        let attributes: [MGLAttributedExpressionKey: NSExpression] = [.fontNamesAttribute : NSExpression(forConstantValue: ["DIN Offc Pro Italic",
+                                                                                                                            "Arial Unicode MS Regular"]),
+                                                                      .fontScaleAttribute: NSExpression(forConstantValue: 1.2),
+                                                                      .fontColorAttribute: NSExpression(forConstantValue: redColor)]
         let attributedExpression = MGLAttributedExpression(expression, attributes:attributes)
         //#-end-example-code
         

--- a/platform/darwin/test/MGLDocumentationExampleTests.swift
+++ b/platform/darwin/test/MGLDocumentationExampleTests.swift
@@ -552,7 +552,7 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
         let expression = NSExpression(forConstantValue: "Foo")
         let attributes: Dictionary<MGLAttributedExpressionKey, Any> = [.fontNamesAttribute : ["DIN Offc Pro Italic",
                                                                                               "Arial Unicode MS Regular"],
-                                                                       .fontSizeAttribute: 1.2,
+                                                                       .fontScaleAttribute: 1.2,
                                                                        .fontColorAttribute: redColor]
         let attributedExpression = MGLAttributedExpression(expression, attributes:attributes)
         //#-end-example-code

--- a/platform/darwin/test/MGLExpressionTests.mm
+++ b/platform/darwin/test/MGLExpressionTests.mm
@@ -1048,8 +1048,8 @@ using namespace std::string_literals;
     }
     {
         MGLAttributedExpression *attribute1 = [[MGLAttributedExpression alloc] initWithExpression:[NSExpression expressionForConstantValue:@"foo"]
-                                                                                       attributes:@{ MGLFontScaleAttribute: @(1.2),
-                                                                                                     MGLFontColorAttribute: @"yellow"}] ;
+                                                                                       attributes:@{ MGLFontScaleAttribute: MGLConstantExpression(@(1.2)),
+                                                                                                     MGLFontColorAttribute: MGLConstantExpression(@"yellow") }] ;
         NSExpression *expression = [NSExpression expressionWithFormat:@"mgl_attributed:(%@)", MGLConstantExpression(attribute1)];
         
         NSExpression *compatibilityExpression = [NSExpression expressionForFunction:@"mgl_attributed:" arguments:@[MGLConstantExpression(attribute1)]];
@@ -1068,22 +1068,25 @@ using namespace std::string_literals;
         XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression], expression);
     }
     {
+        NSExpression *fontNames = [NSExpression expressionForAggregate:@[ MGLConstantExpression(@"DIN Offc Pro Bold"), MGLConstantExpression(@"Arial Unicode MS Bold") ]];
         MGLAttributedExpression *attribute1 = [[MGLAttributedExpression alloc] initWithExpression:[NSExpression expressionForConstantValue:@"foo"]
-                                                                                       attributes:@{ MGLFontScaleAttribute: @(1.2),
-                                                                                                     MGLFontColorAttribute: @"yellow",
-                                                                                                     MGLFontNamesAttribute: @[ @"DIN Offc Pro Bold", @"Arial Unicode MS Bold" ]
+                                                                                       attributes:@{ MGLFontScaleAttribute: MGLConstantExpression(@(1.2)),
+                                                                                                     MGLFontColorAttribute: MGLConstantExpression(@"yellow"),
+                                                                                                     MGLFontNamesAttribute: fontNames
                                                                                                      }] ;
         NSExpression *expression = [NSExpression expressionWithFormat:@"mgl_attributed:(%@)", MGLConstantExpression(attribute1)];
         
         NSArray *jsonExpression = @[ @"format", @"foo", @{ @"font-scale": @1.2, @"text-color": @"yellow" , @"text-font" : @[ @"literal", @[ @"DIN Offc Pro Bold", @"Arial Unicode MS Bold" ]]} ];
         XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
+        NSExpression *exp = [NSExpression expressionWithMGLJSONObject:jsonExpression];
         XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression], expression);
     }
     {
+        NSExpression *fontNames = [NSExpression expressionForAggregate:@[ MGLConstantExpression(@"DIN Offc Pro Bold"), MGLConstantExpression(@"Arial Unicode MS Bold") ]];
         MGLAttributedExpression *attribute1 = [[MGLAttributedExpression alloc] initWithExpression:[NSExpression expressionForConstantValue:@"foo"]
-                                                                                       attributes:@{ MGLFontScaleAttribute: @(1.2),
-                                                                                                     MGLFontColorAttribute: [MGLColor redColor],
-                                                                                                     MGLFontNamesAttribute: @[ @"DIN Offc Pro Bold", @"Arial Unicode MS Bold" ]
+                                                                                       attributes:@{ MGLFontScaleAttribute: MGLConstantExpression(@(1.2)),
+                                                                                                     MGLFontColorAttribute: MGLConstantExpression([MGLColor redColor]),
+                                                                                                     MGLFontNamesAttribute: fontNames
                                                                                                      }] ;
         NSExpression *expression = [NSExpression expressionWithFormat:@"mgl_attributed:(%@)", MGLConstantExpression(attribute1)];
         
@@ -1092,10 +1095,11 @@ using namespace std::string_literals;
         XCTAssertEqualObjects([NSExpression expressionWithMGLJSONObject:jsonExpression], expression);
     }
     {
+        NSExpression *fontNames = [NSExpression expressionForAggregate:@[ MGLConstantExpression(@"DIN Offc Pro Bold"), MGLConstantExpression(@"Arial Unicode MS Bold") ]];
         MGLAttributedExpression *attribute1 = [[MGLAttributedExpression alloc] initWithExpression:[NSExpression expressionWithFormat:@"CAST(x, 'NSString')"]
-                                                                                       attributes:@{ MGLFontScaleAttribute: @(1.2),
-                                                                                                     MGLFontColorAttribute: [MGLColor redColor],
-                                                                                                     MGLFontNamesAttribute: @[ @"DIN Offc Pro Bold", @"Arial Unicode MS Bold" ]
+                                                                                       attributes:@{ MGLFontScaleAttribute: MGLConstantExpression(@(1.2)),
+                                                                                                     MGLFontColorAttribute: MGLConstantExpression([MGLColor redColor]),
+                                                                                                     MGLFontNamesAttribute: fontNames
                                                                                                      }] ;
         NSExpression *expression = [NSExpression expressionWithFormat:@"mgl_attributed:(%@)", MGLConstantExpression(attribute1)];
         

--- a/platform/darwin/test/MGLExpressionTests.mm
+++ b/platform/darwin/test/MGLExpressionTests.mm
@@ -992,16 +992,16 @@ using namespace std::string_literals;
     {
         MGLAttributedExpression *attribute1 = [MGLAttributedExpression attributedExpression:[NSExpression expressionForConstantValue:@"foo"]
                                                                                   fontNames:nil
-                                                                                   fontSize:@(1.2)];
+                                                                                  fontScale:@(1.2)];
         MGLAttributedExpression *attribute2 = [MGLAttributedExpression attributedExpression:[NSExpression expressionForConstantValue:@"biz"]
                                                                                   fontNames:nil
-                                                                                   fontSize:@(1.0)];
+                                                                                  fontScale:@(1.0)];
         MGLAttributedExpression *attribute3 = [MGLAttributedExpression attributedExpression:[NSExpression expressionForConstantValue:@"bar"]
                                                                                   fontNames:nil
-                                                                                   fontSize:@(0.8)];
+                                                                                  fontScale:@(0.8)];
         MGLAttributedExpression *attribute4 = [MGLAttributedExpression attributedExpression:[NSExpression expressionForConstantValue:@"\r"]
                                                                                   fontNames:@[]
-                                                                                   fontSize:nil];
+                                                                                  fontScale:nil];
         NSExpression *expression = [NSExpression expressionWithFormat:@"mgl_attributed:(%@, %@, %@, %@)",
                                     MGLConstantExpression(attribute1),
                                     MGLConstantExpression(attribute4),
@@ -1014,16 +1014,16 @@ using namespace std::string_literals;
     {
         MGLAttributedExpression *attribute1 = [MGLAttributedExpression attributedExpression:[NSExpression expressionForConstantValue:@"foo"]
                                                                                   fontNames:nil
-                                                                                   fontSize:@(1.2)];
+                                                                                  fontScale:@(1.2)];
         MGLAttributedExpression *attribute2 = [MGLAttributedExpression attributedExpression:[NSExpression expressionForConstantValue:@"biz"]
                                                                                   fontNames:nil
-                                                                                   fontSize:@(1.0)];
+                                                                                  fontScale:@(1.0)];
         MGLAttributedExpression *attribute3 = [MGLAttributedExpression attributedExpression:[NSExpression expressionForConstantValue:@"bar"]
                                                                                   fontNames:nil
-                                                                                   fontSize:@(0.8)];
+                                                                                  fontScale:@(0.8)];
         MGLAttributedExpression *attribute4 = [MGLAttributedExpression attributedExpression:[NSExpression expressionForConstantValue:@"\n"]
                                                                                   fontNames:@[]
-                                                                                   fontSize:nil];
+                                                                                  fontScale:nil];
         NSExpression *expression = [NSExpression expressionWithFormat:@"mgl_attributed:(%@, %@, %@, %@)",
                                     MGLConstantExpression(attribute1),
                                     MGLConstantExpression(attribute4),
@@ -1036,7 +1036,7 @@ using namespace std::string_literals;
     {
         MGLAttributedExpression *attribute1 = [MGLAttributedExpression attributedExpression:[NSExpression expressionForConstantValue:@"foo"]
                                                                                   fontNames:nil
-                                                                                   fontSize:@(1.2)];
+                                                                                   fontScale:@(1.2)];
         NSExpression *expression = [NSExpression expressionWithFormat:@"mgl_attributed:(%@)", MGLConstantExpression(attribute1)];
         
         NSExpression *compatibilityExpression = [NSExpression expressionForFunction:@"mgl_attributed:" arguments:@[MGLConstantExpression(attribute1)]];
@@ -1048,7 +1048,7 @@ using namespace std::string_literals;
     }
     {
         MGLAttributedExpression *attribute1 = [[MGLAttributedExpression alloc] initWithExpression:[NSExpression expressionForConstantValue:@"foo"]
-                                                                                       attributes:@{ MGLFontSizeAttribute: @(1.2),
+                                                                                       attributes:@{ MGLFontScaleAttribute: @(1.2),
                                                                                                      MGLFontColorAttribute: @"yellow"}] ;
         NSExpression *expression = [NSExpression expressionWithFormat:@"mgl_attributed:(%@)", MGLConstantExpression(attribute1)];
         
@@ -1069,7 +1069,7 @@ using namespace std::string_literals;
     }
     {
         MGLAttributedExpression *attribute1 = [[MGLAttributedExpression alloc] initWithExpression:[NSExpression expressionForConstantValue:@"foo"]
-                                                                                       attributes:@{ MGLFontSizeAttribute: @(1.2),
+                                                                                       attributes:@{ MGLFontScaleAttribute: @(1.2),
                                                                                                      MGLFontColorAttribute: @"yellow",
                                                                                                      MGLFontNamesAttribute: @[ @"DIN Offc Pro Bold", @"Arial Unicode MS Bold" ]
                                                                                                      }] ;
@@ -1081,7 +1081,7 @@ using namespace std::string_literals;
     }
     {
         MGLAttributedExpression *attribute1 = [[MGLAttributedExpression alloc] initWithExpression:[NSExpression expressionForConstantValue:@"foo"]
-                                                                                       attributes:@{ MGLFontSizeAttribute: @(1.2),
+                                                                                       attributes:@{ MGLFontScaleAttribute: @(1.2),
                                                                                                      MGLFontColorAttribute: [MGLColor redColor],
                                                                                                      MGLFontNamesAttribute: @[ @"DIN Offc Pro Bold", @"Arial Unicode MS Bold" ]
                                                                                                      }] ;
@@ -1093,7 +1093,7 @@ using namespace std::string_literals;
     }
     {
         MGLAttributedExpression *attribute1 = [[MGLAttributedExpression alloc] initWithExpression:[NSExpression expressionWithFormat:@"CAST(x, 'NSString')"]
-                                                                                       attributes:@{ MGLFontSizeAttribute: @(1.2),
+                                                                                       attributes:@{ MGLFontScaleAttribute: @(1.2),
                                                                                                      MGLFontColorAttribute: [MGLColor redColor],
                                                                                                      MGLFontNamesAttribute: @[ @"DIN Offc Pro Bold", @"Arial Unicode MS Bold" ]
                                                                                                      }] ;
@@ -1106,16 +1106,16 @@ using namespace std::string_literals;
     {
         MGLAttributedExpression *attribute1 = [MGLAttributedExpression attributedExpression:[NSExpression expressionForConstantValue:@"foo"]
                                                                                   fontNames:nil
-                                                                                   fontSize:@(1.2)];
+                                                                                  fontScale:@(1.2)];
         MGLAttributedExpression *attribute2 = [MGLAttributedExpression attributedExpression:[NSExpression expressionForConstantValue:@"biz"]
                                                                                   fontNames:nil
-                                                                                   fontSize:@(1.0)];
+                                                                                  fontScale:@(1.0)];
         MGLAttributedExpression *attribute3 = [MGLAttributedExpression attributedExpression:[NSExpression expressionForConstantValue:@"bar"]
                                                                                   fontNames:nil
-                                                                                   fontSize:@(0.8)];
+                                                                                  fontScale:@(0.8)];
         MGLAttributedExpression *attribute4 = [MGLAttributedExpression attributedExpression:[NSExpression expressionForConstantValue:@"\n"]
                                                                                   fontNames:@[]
-                                                                                   fontSize:nil];
+                                                                                  fontScale:nil];
         NSExpression *expression = [NSExpression mgl_expressionForAttributedExpressions:@[MGLConstantExpression(attribute1),
                                                                                           MGLConstantExpression(attribute4),
                                                                                           MGLConstantExpression(attribute2),

--- a/platform/ios/docs/guides/For Style Authors.md
+++ b/platform/ios/docs/guides/For Style Authors.md
@@ -426,7 +426,7 @@ can use to update the formatting of `MGLSymbolStyleLayer.text` property.
 In style JSON | In Objective-C        | In Swift
 --------------|-----------------------|---------
 `text-font`      | `MGLFontNamesAttribute` | `.fontNamesAttribute`
-`font-scale`      | `MGLFontSizeAttribute` | `.fontSizeAttribute`
+`font-scale`      | `MGLFontScaleAttribute` | `.fontScaleAttribute`
 `text-color`  | `MGLFontColorAttribute` | `.fontColorAttribute`
 
 See the “[Predicates and Expressions](predicates-and-expressions.html)” guide for

--- a/platform/macos/docs/guides/For Style Authors.md
+++ b/platform/macos/docs/guides/For Style Authors.md
@@ -419,7 +419,7 @@ can use to update the formatting of `MGLSymbolStyleLayer.text` property.
 In style JSON | In Objective-C        | In Swift
 --------------|-----------------------|---------
 `text-font`      | `MGLFontNamesAttribute` | `.fontNamesAttribute`
-`font-scale`      | `MGLFontSizeAttribute` | `.fontSizeAttribute`
+`font-scale`      | `MGLFontScaleAttribute` | `.fontScaleAttribute`
 `text-color`  | `MGLFontColorAttribute` | `.fontColorAttribute`
 
 See the “[Predicates and Expressions](predicates-and-expressions.html)” guide for


### PR DESCRIPTION
This adds compatibility with JS to support expressions as formatting parameters. Originally the `MGLAttributedExpression` attributes dictionary supported raw constant values, this pr changes that to support only expressions.