### PR TITLE
[build] Fix glfw build failure with older cmake version

### DIFF
--- a/cmake/glfw.cmake
+++ b/cmake/glfw.cmake
@@ -3,7 +3,14 @@ add_executable(mbgl-glfw
 )
 
 # args requires RTTI
-set_source_files_properties(platform/glfw/main.cpp PROPERTIES COMPILE_OPTIONS "-frtti")
+# COMPILE_OPTIONS source file property was added in cmake version 3.11, so use
+# the property if the cmake version is 3.11 and greater. For older version of
+# cmake, use COMPILE_FLAGS to set the RTTI flag.
+if(CMAKE_VERSION VERSION_LESS 3.11.0)
+    set_source_files_properties(platform/glfw/main.cpp PROPERTIES COMPILE_FLAGS "-frtti")
+else()
+    set_source_files_properties(platform/glfw/main.cpp PROPERTIES COMPILE_OPTIONS "-frtti")
+endif()
 
 target_sources(mbgl-glfw
     PRIVATE platform/glfw/glfw_view.hpp

--- a/cmake/offline.cmake
+++ b/cmake/offline.cmake
@@ -3,7 +3,14 @@ add_executable(mbgl-offline
 )
 
 # args requires RTTI
-set_source_files_properties(bin/offline.cpp PROPERTIES COMPILE_OPTIONS "-frtti")
+# COMPILE_OPTIONS source file property was added in cmake version 3.11, so use
+# the property if the cmake version is 3.11 and greater. For older version of
+# cmake, use COMPILE_FLAGS to set the RTTI flag.
+if(CMAKE_VERSION VERSION_LESS 3.11.0)
+    set_source_files_properties(bin/offline.cpp PROPERTIES COMPILE_FLAGS "-frtti")
+else()
+    set_source_files_properties(bin/offline.cpp PROPERTIES COMPILE_OPTIONS "-frtti")
+endif()
 
 target_sources(mbgl-offline
     PRIVATE platform/default/include/mbgl/util/default_styles.hpp

--- a/cmake/render.cmake
+++ b/cmake/render.cmake
@@ -3,7 +3,14 @@ add_executable(mbgl-render
 )
 
 # args requires RTTI
-set_source_files_properties(bin/render.cpp PROPERTIES COMPILE_OPTIONS "-frtti")
+# COMPILE_OPTIONS source file property was added in cmake version 3.11, so use
+# the property if the cmake version is 3.11 and greater. For older version of
+# cmake, use COMPILE_FLAGS to set the RTTI flag.
+if(CMAKE_VERSION VERSION_LESS 3.11.0)
+    set_source_files_properties(bin/render.cpp PROPERTIES COMPILE_FLAGS "-frtti")
+else()
+    set_source_files_properties(bin/render.cpp PROPERTIES COMPILE_OPTIONS "-frtti")
+endif()
 
 target_include_directories(mbgl-render
     PRIVATE platform/default/include


### PR DESCRIPTION
COMPILE_OPTIONS source file property was added in [cmake version 3.11](https://cmake.org/cmake/help/v3.11/release/3.11.html#properties), so using it to set rtti flag on a source file is causing a build failure, if the cmake version is older than 3.11. To fix the build issue with old Cmake version, use COMPILE_FLAGS to set the rtti flag.