### PR TITLE
[android] Quick typo fix for OnDidFinishRenderingMapListener method

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -911,7 +911,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     /**
      * Called when the map has finished rendering.
      *
-     * @param fully true if map is fully rendered, false if fully rendered
+     * @param fully true if map is fully rendered, false if not fully rendered
      */
     void onDidFinishRenderingMap(boolean fully);
   }


### PR DESCRIPTION
This just adds the word `not` in front of `fully rendered` in the Javadoc comment for the `OnDidFinishRenderingMapListener` method.