### PR TITLE
[core] Fix signature of fluent interface setters

### DIFF
--- a/include/mbgl/map/map_options.hpp
+++ b/include/mbgl/map/map_options.hpp
@@ -28,7 +28,7 @@ public:
      * @param mode Map rendering mode.
      * @return MapOptions for chaining options together.
      */
-    MapOptions withMapMode(MapMode mode);
+    MapOptions& withMapMode(MapMode mode);
 
     /**
      * @brief Gets the previously set (or default) map mode.
@@ -45,7 +45,7 @@ public:
      * @param mode Map constrain mode.
      * @return MapOptions for chaining options together.
      */
-    MapOptions withConstrainMode(ConstrainMode mode);
+    MapOptions& withConstrainMode(ConstrainMode mode);
 
     /**
      * @brief Gets the previously set (or default) constrain mode.
@@ -61,7 +61,7 @@ public:
      * @param mode Viewport mode.
      * @return MapOptions for chaining options together.
      */
-    MapOptions withViewportMode(ViewportMode mode);
+    MapOptions& withViewportMode(ViewportMode mode);
 
     /**
      * @brief Gets the previously set (or default) viewport mode.
@@ -77,7 +77,7 @@ public:
      * @param enableCollisions true to enable, false to disable
      * @return MapOptions for chaining options together.
      */
-    MapOptions withCrossSourceCollisions(bool enableCollisions);
+    MapOptions& withCrossSourceCollisions(bool enableCollisions);
 
     /**
      * @brief Gets the previously set (or default) crossSourceCollisions value.

--- a/include/mbgl/storage/resource_options.hpp
+++ b/include/mbgl/storage/resource_options.hpp
@@ -25,7 +25,7 @@ public:
      * @param token Mapbox access token.
      * @return ResourceOptions for chaining options together.
      */
-    ResourceOptions withAccessToken(std::string token);
+    ResourceOptions& withAccessToken(std::string token);
 
     /**
      * @brief Gets the previously set (or default) Mapbox access token.
@@ -40,7 +40,7 @@ public:
      * @param baseURL API base URL.
      * @return ResourceOptions for chaining options together.
      */
-    ResourceOptions withBaseURL(std::string baseURL);
+    ResourceOptions& withBaseURL(std::string baseURL);
 
     /**
      * @brief Gets the previously set (or default) API base URL.
@@ -55,7 +55,7 @@ public:
      * @param path Cache path.
      * @return ResourceOptions for chaining options together.
      */
-    ResourceOptions withCachePath(std::string path);
+    ResourceOptions& withCachePath(std::string path);
 
     /**
      * @brief Gets the previously set (or default) cache path.
@@ -71,7 +71,7 @@ public:
      * @param path Asset path.
      * @return ResourceOptions for chaining options together.
      */
-    ResourceOptions withAssetPath(std::string path);
+    ResourceOptions& withAssetPath(std::string path);
 
     /**
      * @brief Gets the previously set (or default) asset path.
@@ -86,7 +86,7 @@ public:
      * @param size Cache maximum size in bytes.
      * @return reference to ResourceOptions for chaining options together.
      */
-    ResourceOptions withMaximumCacheSize(uint64_t size);
+    ResourceOptions& withMaximumCacheSize(uint64_t size);
 
     /**
      * @brief Gets the previously set (or default) maximum allowed cache size.
@@ -102,7 +102,7 @@ public:
      * @param context Platform context.
      * @return reference to ResourceOptions for chaining options together.
      */
-    ResourceOptions withPlatformContext(void* context);
+    ResourceOptions& withPlatformContext(void* context);
 
     /**
      * @brief Gets the previously set (or default) platform context.

--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -624,9 +624,9 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
     // App-global configuration
     MGLRendererConfiguration* config = [MGLRendererConfiguration currentConfiguration];
 
-    auto resourceOptions = mbgl::ResourceOptions()
-        .withCachePath([[MGLOfflineStorage sharedOfflineStorage] mbglCachePath])
-        .withAssetPath([NSBundle mainBundle].resourceURL.path.UTF8String);
+    mbgl::ResourceOptions resourceOptions;
+    resourceOptions.withCachePath([[MGLOfflineStorage sharedOfflineStorage] mbglCachePath])
+                   .withAssetPath([NSBundle mainBundle].resourceURL.path.UTF8String);
 
     // Create the snapshotter
     _mbglMapSnapshotter = std::make_unique<mbgl::MapSnapshotter>(

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -226,8 +226,9 @@ const MGLExceptionName MGLUnsupportedRegionTypeException = @"MGLUnsupportedRegio
         }
 
         _mbglCachePath = cachePath.UTF8String;
-        auto options = mbgl::ResourceOptions().withCachePath(_mbglCachePath)
-                                              .withAssetPath([NSBundle mainBundle].resourceURL.path.UTF8String);
+        mbgl::ResourceOptions options;
+        options.withCachePath(_mbglCachePath)
+               .withAssetPath([NSBundle mainBundle].resourceURL.path.UTF8String);
         _mbglFileSource = std::static_pointer_cast<mbgl::DefaultFileSource>(mbgl::FileSource::getSharedFileSource(options));
 
         // Observe for changes to the API base URL (and find out the current one).

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -477,15 +477,15 @@ public:
     BOOL enableCrossSourceCollisions = !config.perSourceCollisions;
     _rendererFrontend = std::make_unique<MGLRenderFrontend>(std::move(renderer), self, *_mbglView);
 
-    auto mapOptions = mbgl::MapOptions()
-        .withMapMode(mbgl::MapMode::Continuous)
-        .withConstrainMode(mbgl::ConstrainMode::None)
-        .withViewportMode(mbgl::ViewportMode::Default)
-        .withCrossSourceCollisions(enableCrossSourceCollisions);
+    mbgl::MapOptions mapOptions;
+    mapOptions.withMapMode(mbgl::MapMode::Continuous)
+              .withConstrainMode(mbgl::ConstrainMode::None)
+              .withViewportMode(mbgl::ViewportMode::Default)
+              .withCrossSourceCollisions(enableCrossSourceCollisions);
 
-    auto resourceOptions = mbgl::ResourceOptions()
-        .withCachePath([[MGLOfflineStorage sharedOfflineStorage] mbglCachePath])
-        .withAssetPath([NSBundle mainBundle].resourceURL.path.UTF8String);
+    mbgl::ResourceOptions resourceOptions;
+    resourceOptions.withCachePath([[MGLOfflineStorage sharedOfflineStorage] mbglCachePath])
+                   .withAssetPath([NSBundle mainBundle].resourceURL.path.UTF8String);
 
     NSAssert(!_mbglMap, @"_mbglMap should be NULL");
     _mbglMap = new mbgl::Map(*_rendererFrontend, *_mbglView, self.size, config.scaleFactor, *_mbglThreadPool, mapOptions, resourceOptions);

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -290,15 +290,15 @@ public:
     BOOL enableCrossSourceCollisions = !config.perSourceCollisions;
     _rendererFrontend = std::make_unique<MGLRenderFrontend>(std::move(renderer), self, *_mbglView, true);
 
-    auto mapOptions = mbgl::MapOptions()
-        .withMapMode(mbgl::MapMode::Continuous)
-        .withConstrainMode(mbgl::ConstrainMode::None)
-        .withViewportMode(mbgl::ViewportMode::Default)
-        .withCrossSourceCollisions(enableCrossSourceCollisions);
+    mbgl::MapOptions mapOptions;
+    mapOptions.withMapMode(mbgl::MapMode::Continuous)
+              .withConstrainMode(mbgl::ConstrainMode::None)
+              .withViewportMode(mbgl::ViewportMode::Default)
+              .withCrossSourceCollisions(enableCrossSourceCollisions);
 
-    auto resourceOptions = mbgl::ResourceOptions()
-        .withCachePath([[MGLOfflineStorage sharedOfflineStorage] mbglCachePath])
-        .withAssetPath([NSBundle mainBundle].resourceURL.path.UTF8String);
+    mbgl::ResourceOptions resourceOptions;
+    resourceOptions.withCachePath([[MGLOfflineStorage sharedOfflineStorage] mbglCachePath])
+                   .withAssetPath([NSBundle mainBundle].resourceURL.path.UTF8String);
 
     _mbglMap = new mbgl::Map(*_rendererFrontend, *_mbglView, self.size, config.scaleFactor, *_mbglThreadPool, mapOptions, resourceOptions);
 

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1706,19 +1706,19 @@ void QMapboxGL::connectionEstablished()
 */
 
 mbgl::MapOptions mapOptionsFromQMapboxGLSettings(const QMapboxGLSettings &settings) {
-    return mbgl::MapOptions()
+    return std::move(mbgl::MapOptions()
         .withMapMode(static_cast<mbgl::MapMode>(settings.mapMode()))
         .withConstrainMode(static_cast<mbgl::ConstrainMode>(settings.constrainMode()))
-        .withViewportMode(static_cast<mbgl::ViewportMode>(settings.viewportMode()));
+        .withViewportMode(static_cast<mbgl::ViewportMode>(settings.viewportMode())));
 }
 
 mbgl::ResourceOptions resourceOptionsFromQMapboxGLSettings(const QMapboxGLSettings &settings) {
-    return mbgl::ResourceOptions()
+    return std::move(mbgl::ResourceOptions()
         .withAccessToken(settings.accessToken().toStdString())
         .withAssetPath(settings.assetPath().toStdString())
         .withBaseURL(settings.apiBaseUrl().toStdString())
         .withCachePath(settings.cacheDatabasePath().toStdString())
-        .withMaximumCacheSize(settings.cacheDatabaseMaximumSize());
+        .withMaximumCacheSize(settings.cacheDatabaseMaximumSize()));
 }
 
 QMapboxGLPrivate::QMapboxGLPrivate(QMapboxGL *q, const QMapboxGLSettings &settings, const QSize &size, qreal pixelRatio_)

--- a/src/mbgl/map/map_options.cpp
+++ b/src/mbgl/map/map_options.cpp
@@ -16,36 +16,36 @@ MapOptions::~MapOptions() = default;
 MapOptions::MapOptions(MapOptions&&) = default;
 MapOptions::MapOptions(const MapOptions& other) : impl_(std::make_unique<Impl>(*other.impl_)) {}
 
-MapOptions MapOptions::withMapMode(MapMode mode) {
+MapOptions& MapOptions::withMapMode(MapMode mode) {
     impl_->mapMode = mode;
-    return std::move(*this);
+    return *this;
 }
 
 MapMode MapOptions::mapMode() const {
     return impl_->mapMode;
 }
 
-MapOptions MapOptions::withConstrainMode(ConstrainMode mode) {
+MapOptions& MapOptions::withConstrainMode(ConstrainMode mode) {
     impl_->constrainMode = mode;
-    return std::move(*this);
+    return *this;
 }
 
 ConstrainMode MapOptions::constrainMode() const {
     return impl_->constrainMode;
 }
 
-MapOptions MapOptions::withViewportMode(ViewportMode mode) {
+MapOptions& MapOptions::withViewportMode(ViewportMode mode) {
     impl_->viewportMode = mode;
-    return std::move(*this);
+    return *this;
 }
 
 ViewportMode MapOptions::viewportMode() const {
     return impl_->viewportMode;
 }
 
-MapOptions MapOptions::withCrossSourceCollisions(bool enableCollisions) {
+MapOptions& MapOptions::withCrossSourceCollisions(bool enableCollisions) {
     impl_->crossSourceCollisions = enableCollisions;
-    return std::move(*this);
+    return *this;
 }
 
 bool MapOptions::crossSourceCollisions() const {

--- a/src/mbgl/storage/resource_options.cpp
+++ b/src/mbgl/storage/resource_options.cpp
@@ -19,54 +19,54 @@ ResourceOptions::~ResourceOptions() = default;
 ResourceOptions::ResourceOptions(ResourceOptions&&)  = default;
 ResourceOptions::ResourceOptions(const ResourceOptions& other) : impl_(std::make_unique<Impl>(*other.impl_)) {}
 
-ResourceOptions ResourceOptions::withAccessToken(std::string token) {
+ResourceOptions& ResourceOptions::withAccessToken(std::string token) {
     impl_->accessToken = std::move(token);
-    return std::move(*this);
+    return *this;
 }
 
 const std::string& ResourceOptions::accessToken() const {
     return impl_->accessToken;
 }
 
-ResourceOptions ResourceOptions::withBaseURL(std::string url) {
+ResourceOptions& ResourceOptions::withBaseURL(std::string url) {
     impl_->baseURL = std::move(url);
-    return std::move(*this);
+    return *this;
 }
 
 const std::string& ResourceOptions::baseURL() const {
     return impl_->baseURL;
 }
 
-ResourceOptions ResourceOptions::withCachePath(std::string path) {
+ResourceOptions& ResourceOptions::withCachePath(std::string path) {
     impl_->cachePath = std::move(path);
-    return std::move(*this);
+    return *this;
 }
 
 const std::string& ResourceOptions::cachePath() const {
     return impl_->cachePath;
 }
 
-ResourceOptions ResourceOptions::withAssetPath(std::string path) {
+ResourceOptions& ResourceOptions::withAssetPath(std::string path) {
     impl_->assetPath = std::move(path);
-    return std::move(*this);
+    return *this;
 }
 
 const std::string& ResourceOptions::assetPath() const {
     return impl_->assetPath;
 }
 
-ResourceOptions ResourceOptions::withMaximumCacheSize(uint64_t size) {
+ResourceOptions& ResourceOptions::withMaximumCacheSize(uint64_t size) {
     impl_->maximumSize = size;
-    return std::move(*this);
+    return *this;
 }
 
 uint64_t ResourceOptions::maximumCacheSize() const {
     return impl_->maximumSize;
 }
 
-ResourceOptions ResourceOptions::withPlatformContext(void* context) {
+ResourceOptions& ResourceOptions::withPlatformContext(void* context) {
     impl_->platformContext = context;
-    return std::move(*this);
+    return *this;
 }
 
 void* ResourceOptions::platformContext() const {


### PR DESCRIPTION
It seems we need the reference in `with*` methods - otherwise the last with() call moves the pointer to a rvalue that immediately goes out of scope :disappointed: 

Partially reverts the fluent interface signature change for setters in mapbox/mapbox-gl-native#14189.