### PR TITLE
[build] Retry failed GitHub API requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "npm-run-all": "^4.0.2"
   },
   "devDependencies": {
-    "@octokit/rest": "^15.15.1",
+    "@octokit/rest": "^16.0.0",
+    "@octokit/plugin-retry": "^2.2.0",
     "aws-sdk": "^2.285.1",
     "csscolorparser": "^1.0.2",
     "ejs": "^2.4.1",

--- a/scripts/check_binary_size.js
+++ b/scripts/check_binary_size.js
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 const jwt = require('jsonwebtoken');
-const github = require('@octokit/rest')();
+const github = require('@octokit/rest').plugin(require('@octokit/plugin-retry'))({
+    retry: { doNotRetry: [ /* Empty — retry on any error code. */ ] }
+})
 const prettyBytes = require('pretty-bytes');
 const fs = require('fs');
 

--- a/scripts/publish_binary_size.js
+++ b/scripts/publish_binary_size.js
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 const jwt = require('jsonwebtoken');
-const github = require('@octokit/rest')();
+const github = require('@octokit/rest').plugin(require('@octokit/plugin-retry'))({
+    retry: { doNotRetry: [ /* Empty — retry on any error code. */ ] }
+})
 const zlib = require('zlib');
 const AWS = require('aws-sdk');
 

--- a/scripts/publish_doxygen_coverage.js
+++ b/scripts/publish_doxygen_coverage.js
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 const jwt = require('jsonwebtoken');
-const github = require('@octokit/rest')();
+const github = require('@octokit/rest').plugin(require('@octokit/plugin-retry'))({
+    retry: { doNotRetry: [ /* Empty — retry on any error code. */ ] }
+})
 const zlib = require('zlib');
 const AWS = require('aws-sdk');
 const fs = require('fs');


### PR DESCRIPTION
Implements [octokit/plugin-retry.js](https://github.com/octokit/plugin-retry.js) for our various scripts' GitHub API usage.

There [have been occasions](https://circleci.com/gh/mapbox/mapbox-gl-native/243765) where GitHub gives us a bogus error code and fails our CI job, so retrying a few times ([three, to be precise](https://github.com/octokit/plugin-retry.js/blob/f44fc3878542e8a0b5be4e03d7bf63ffb684f0f8/lib/index.js#L11)) might end up saving us a failed job in times of bad internet weather.

This currently runs up against a deprecation in the latest octokit/rest release series, which is annoying ~and should be fixed before we merge this~.

```
{ Deprecation: [@octokit/rest] octokit.authenticate() is deprecated. Use "auth" constructor option instead.
    at authenticate (/Users/distiller/project/node_modules/@octokit/rest/plugins/authentication-deprecated/authenticate.js:9:44)
    at Object.<anonymous> (/Users/distiller/project/scripts/check_binary_size.js:37:8)
    ... }
```

/cc @captainbarbosa @anderco 