### PR TITLE
Harden fetching camera for bounds when padding is excessive

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -205,8 +205,13 @@ CameraOptions cameraForLatLngs(const std::vector<LatLng>& latLngs, const Transfo
         scaleY -= (padding.top() + padding.bottom()) / height;
         minScale = util::min(scaleX, scaleY);
     }
-    double zoom = transform.getZoom() + util::log2(minScale);
-    zoom = util::clamp(zoom, transform.getState().getMinZoom(), transform.getState().getMaxZoom());
+
+    double zoom = transform.getZoom();
+    if (minScale > 0) {
+        zoom = util::clamp(zoom + util::log2(minScale), transform.getState().getMinZoom(), transform.getState().getMaxZoom());
+    } else {
+        Log::Error(Event::General, "Unable to calculate appropriate zoom level for bounds. Vertical or horizontal padding is greater than map's height or width.");
+    }
 
     // Calculate the center point of a virtual bounds that is extended in all directions by padding.
     ScreenCoordinate centerPixel = nePixel + swPixel;

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -151,6 +151,18 @@ TEST(Map, LatLngBoundsToCamera) {
     EXPECT_NEAR(*virtualCamera.zoom, 1.55467, 1e-5);
 }
 
+TEST(Map, LatLngBoundsToCameraWithExcessivePadding) {
+    MapTest<> test;
+
+    test.map.jumpTo(CameraOptions().withCenter(LatLng { 40.712730, -74.005953 }).withZoom(16.0));
+
+    LatLngBounds bounds = LatLngBounds::hull({15.68169,73.499857}, {53.560711, 134.77281});
+
+    CameraOptions virtualCamera = test.map.cameraForLatLngBounds(bounds, {500, 0, 1200, 0});
+    ASSERT_TRUE(bounds.contains(*virtualCamera.center));
+    EXPECT_NEAR(*virtualCamera.zoom, 16.0, 1e-5);
+}
+
 TEST(Map, LatLngBoundsToCameraWithBearing) {
     MapTest<> test;
 


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/13917.