### PR TITLE
Return color string values in the [0-255] range

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/types/FormattedSection.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/types/FormattedSection.java
@@ -184,8 +184,7 @@ public class FormattedSection {
 
   void setTextColor(@NonNull Object textColor) {
     // called from JNI
-    // because core is returning R, G and B components in range of 0 to 1, we need to convert them to be in 0 to 255.
-    setTextColor(ColorUtils.colorToRgbaString(ColorUtils.rgbaToColor((String) textColor)));
+    setTextColor((String) textColor);
   }
 
   @Override

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/ColorUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/ColorUtils.java
@@ -10,6 +10,7 @@ import android.support.annotation.NonNull;
 import android.support.v4.widget.ImageViewCompat;
 import android.util.TypedValue;
 import android.widget.ImageView;
+
 import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.exceptions.ConversionException;
 
@@ -111,12 +112,11 @@ public class ColorUtils {
     ImageViewCompat.setImageTintList(imageView, getSelector(tintColor));
   }
 
-  private static int normalizeColorComponent(String value) {
-    return (int) (Float.parseFloat(value) * 255);
-  }
-
   /**
    * Convert an rgba string to a Color int.
+   * <p>
+   * R, G, B color components have to be in the [0-255] range, while alpha has to be in the [0.0-1.0] range.
+   * For example: "rgba(255, 128, 0, 0.7)".
    *
    * @param value the String representation of rgba
    * @return the int representation of rgba
@@ -124,15 +124,14 @@ public class ColorUtils {
    */
   @ColorInt
   public static int rgbaToColor(@NonNull String value) {
-    Pattern c = Pattern.compile("rgba?\\s*\\(\\s*(\\d+\\.?\\d*)\\s*,\\s*(\\d+\\.?\\d*)\\s*,\\s*(\\d+\\.?\\d*)\\s*,"
-      + "?\\s*(\\d+\\.?\\d*)?\\s*\\)");
+    Pattern c = Pattern.compile("rgba?\\s*\\(\\s*(\\d+)\\s*,\\s*(\\d+)\\s*,\\s*(\\d+)\\s*,?\\s*(\\d+\\.?\\d*)?\\s*\\)");
     Matcher m = c.matcher(value);
     if (m.matches() && m.groupCount() == 3) {
-      return Color.rgb(normalizeColorComponent(m.group(1)), normalizeColorComponent(m.group(2)),
-        normalizeColorComponent(m.group(3)));
+      return Color.rgb(Integer.parseInt(m.group(1)), Integer.parseInt(m.group(2)),
+        Integer.parseInt(m.group(3)));
     } else if (m.matches() && m.groupCount() == 4) {
-      return Color.argb(normalizeColorComponent(m.group(4)), normalizeColorComponent(m.group(1)),
-        normalizeColorComponent(m.group(2)), normalizeColorComponent(m.group(3)));
+      return Color.argb((int) (Float.parseFloat(m.group(4)) * 255), Integer.parseInt(m.group(1)),
+        Integer.parseInt(m.group(2)), Integer.parseInt(m.group(3)));
     } else {
       throw new ConversionException("Not a valid rgb/rgba value");
     }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/BackgroundLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/BackgroundLayerTest.java
@@ -73,7 +73,7 @@ public class BackgroundLayerTest extends BaseLayerTest {
     assertNull(layer.getBackgroundColor().getValue());
 
     // Set and Get
-    String propertyValue = "rgba(0, 0, 0, 1)";
+    String propertyValue = "rgba(255,128,0,0.7)";
     layer.setProperties(backgroundColor(propertyValue));
     assertEquals(layer.getBackgroundColor().getValue(), propertyValue);
   }
@@ -85,8 +85,8 @@ public class BackgroundLayerTest extends BaseLayerTest {
     assertNotNull(layer);
 
     // Set and Get
-    layer.setProperties(backgroundColor(Color.RED));
-    assertEquals(layer.getBackgroundColorAsInt(), Color.RED);
+    layer.setProperties(backgroundColor(Color.argb(127, 255, 127, 0)));
+    assertEquals(layer.getBackgroundColorAsInt(), Color.argb(127, 255, 127, 0));
   }
 
   @Test

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CircleLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CircleLayerTest.java
@@ -157,7 +157,7 @@ public class CircleLayerTest extends BaseLayerTest {
     assertNull(layer.getCircleColor().getValue());
 
     // Set and Get
-    String propertyValue = "rgba(0, 0, 0, 1)";
+    String propertyValue = "rgba(255,128,0,0.7)";
     layer.setProperties(circleColor(propertyValue));
     assertEquals(layer.getCircleColor().getValue(), propertyValue);
   }
@@ -182,8 +182,8 @@ public class CircleLayerTest extends BaseLayerTest {
     assertNotNull(layer);
 
     // Set and Get
-    layer.setProperties(circleColor(Color.RED));
-    assertEquals(layer.getCircleColorAsInt(), Color.RED);
+    layer.setProperties(circleColor(Color.argb(127, 255, 127, 0)));
+    assertEquals(layer.getCircleColorAsInt(), Color.argb(127, 255, 127, 0));
   }
 
   @Test
@@ -384,7 +384,7 @@ public class CircleLayerTest extends BaseLayerTest {
     assertNull(layer.getCircleStrokeColor().getValue());
 
     // Set and Get
-    String propertyValue = "rgba(0, 0, 0, 1)";
+    String propertyValue = "rgba(255,128,0,0.7)";
     layer.setProperties(circleStrokeColor(propertyValue));
     assertEquals(layer.getCircleStrokeColor().getValue(), propertyValue);
   }
@@ -409,8 +409,8 @@ public class CircleLayerTest extends BaseLayerTest {
     assertNotNull(layer);
 
     // Set and Get
-    layer.setProperties(circleStrokeColor(Color.RED));
-    assertEquals(layer.getCircleStrokeColorAsInt(), Color.RED);
+    layer.setProperties(circleStrokeColor(Color.argb(127, 255, 127, 0)));
+    assertEquals(layer.getCircleStrokeColorAsInt(), Color.argb(127, 255, 127, 0));
   }
 
   @Test

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/ExpressionTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/ExpressionTest.java
@@ -378,7 +378,7 @@ public class ExpressionTest extends EspressoTest {
       );
       assertNull(layer.getTextField().getExpression());
       assertEquals(new Formatted(
-        new FormattedSection("test", null, null, "rgba(255, 255, 0, 1)")
+        new FormattedSection("test", null, null, "rgba(255,255,0,1)")
       ), layer.getTextField().getValue());
     });
   }
@@ -398,7 +398,7 @@ public class ExpressionTest extends EspressoTest {
           "test",
           formatFontScale(0.5),
           formatTextFont(new String[] {"DIN Offc Pro Regular", "Arial Unicode MS Regular"}),
-          formatTextColor(rgb(126.7, 0, 0))
+          formatTextColor(rgb(126, 0, 0))
         )
       );
       layer.setProperties(textField(expression));
@@ -412,7 +412,7 @@ public class ExpressionTest extends EspressoTest {
         new FormattedSection("test",
           0.5,
           new String[] {"DIN Offc Pro Regular", "Arial Unicode MS Regular"},
-          "rgba(126, 0, 0, 1)")
+          "rgba(126,0,0,1)")
       ), layer.getTextField().getValue());
     });
   }
@@ -433,7 +433,8 @@ public class ExpressionTest extends EspressoTest {
           formatFontScale(1.5),
           formatTextFont(new String[] {"DIN Offc Pro Regular", "Arial Unicode MS Regular"})
         ),
-        formatEntry("\ntest2", formatFontScale(2), formatTextColor(Color.BLUE))
+        formatEntry("\ntest2", formatFontScale(2), formatTextColor(Color.BLUE)),
+        formatEntry("\ntest3", formatFontScale(2.5), formatTextColor(toColor(literal("rgba(0, 128, 255, 0.5)"))))
       );
       layer.setProperties(textField(expression));
       TestingAsyncUtils.INSTANCE.waitForLayer(uiController, mapView);
@@ -445,7 +446,8 @@ public class ExpressionTest extends EspressoTest {
       assertEquals(new Formatted(
         new FormattedSection("test", 1.5,
           new String[] {"DIN Offc Pro Regular", "Arial Unicode MS Regular"}),
-        new FormattedSection("\ntest2", 2.0, null, "rgba(0, 0, 255, 1)")
+        new FormattedSection("\ntest2", 2.0, null, "rgba(0,0,255,1)"),
+        new FormattedSection("\ntest3", 2.5, null, "rgba(0,128,255,0.5)")
       ), layer.getTextField().getValue());
     });
   }
@@ -547,9 +549,9 @@ public class ExpressionTest extends EspressoTest {
       Formatted formatted = new Formatted(
         new FormattedSection("test", 1.5),
         new FormattedSection("\ntest", 0.5, new String[] {"Arial Unicode MS Regular", "DIN Offc Pro Regular"}),
-        new FormattedSection("test", null, null, "rgba(0, 255, 0, 1)")
+        new FormattedSection("test", null, null, "rgba(0,255,0,1)")
       );
-      layer.setProperties(textField(formatted), textColor("rgba(128, 0, 0, 1)"));
+      layer.setProperties(textField(formatted), textColor("rgba(128,0,0,1)"));
       TestingAsyncUtils.INSTANCE.waitForLayer(uiController, mapView);
 
       assertFalse(mapboxMap.queryRenderedFeatures(mapboxMap.getProjection().toScreenLocation(latLng), "layer")

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillExtrusionLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillExtrusionLayerTest.java
@@ -144,7 +144,7 @@ public class FillExtrusionLayerTest extends BaseLayerTest {
     assertNull(layer.getFillExtrusionColor().getValue());
 
     // Set and Get
-    String propertyValue = "rgba(0, 0, 0, 1)";
+    String propertyValue = "rgba(255,128,0,0.7)";
     layer.setProperties(fillExtrusionColor(propertyValue));
     assertEquals(layer.getFillExtrusionColor().getValue(), propertyValue);
   }
@@ -169,8 +169,8 @@ public class FillExtrusionLayerTest extends BaseLayerTest {
     assertNotNull(layer);
 
     // Set and Get
-    layer.setProperties(fillExtrusionColor(Color.RED));
-    assertEquals(layer.getFillExtrusionColorAsInt(), Color.RED);
+    layer.setProperties(fillExtrusionColor(Color.argb(127, 255, 127, 0)));
+    assertEquals(layer.getFillExtrusionColorAsInt(), Color.argb(127, 255, 127, 0));
   }
 
   @Test

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillLayerTest.java
@@ -170,7 +170,7 @@ public class FillLayerTest extends BaseLayerTest {
     assertNull(layer.getFillColor().getValue());
 
     // Set and Get
-    String propertyValue = "rgba(0, 0, 0, 1)";
+    String propertyValue = "rgba(255,128,0,0.7)";
     layer.setProperties(fillColor(propertyValue));
     assertEquals(layer.getFillColor().getValue(), propertyValue);
   }
@@ -195,8 +195,8 @@ public class FillLayerTest extends BaseLayerTest {
     assertNotNull(layer);
 
     // Set and Get
-    layer.setProperties(fillColor(Color.RED));
-    assertEquals(layer.getFillColorAsInt(), Color.RED);
+    layer.setProperties(fillColor(Color.argb(127, 255, 127, 0)));
+    assertEquals(layer.getFillColorAsInt(), Color.argb(127, 255, 127, 0));
   }
 
   @Test
@@ -219,7 +219,7 @@ public class FillLayerTest extends BaseLayerTest {
     assertNull(layer.getFillOutlineColor().getValue());
 
     // Set and Get
-    String propertyValue = "rgba(0, 0, 0, 1)";
+    String propertyValue = "rgba(255,128,0,0.7)";
     layer.setProperties(fillOutlineColor(propertyValue));
     assertEquals(layer.getFillOutlineColor().getValue(), propertyValue);
   }
@@ -244,8 +244,8 @@ public class FillLayerTest extends BaseLayerTest {
     assertNotNull(layer);
 
     // Set and Get
-    layer.setProperties(fillOutlineColor(Color.RED));
-    assertEquals(layer.getFillOutlineColorAsInt(), Color.RED);
+    layer.setProperties(fillOutlineColor(Color.argb(127, 255, 127, 0)));
+    assertEquals(layer.getFillOutlineColorAsInt(), Color.argb(127, 255, 127, 0));
   }
 
   @Test

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HillshadeLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HillshadeLayerTest.java
@@ -133,7 +133,7 @@ public class HillshadeLayerTest extends BaseLayerTest {
     assertNull(layer.getHillshadeShadowColor().getValue());
 
     // Set and Get
-    String propertyValue = "rgba(0, 0, 0, 1)";
+    String propertyValue = "rgba(255,128,0,0.7)";
     layer.setProperties(hillshadeShadowColor(propertyValue));
     assertEquals(layer.getHillshadeShadowColor().getValue(), propertyValue);
   }
@@ -145,8 +145,8 @@ public class HillshadeLayerTest extends BaseLayerTest {
     assertNotNull(layer);
 
     // Set and Get
-    layer.setProperties(hillshadeShadowColor(Color.RED));
-    assertEquals(layer.getHillshadeShadowColorAsInt(), Color.RED);
+    layer.setProperties(hillshadeShadowColor(Color.argb(127, 255, 127, 0)));
+    assertEquals(layer.getHillshadeShadowColorAsInt(), Color.argb(127, 255, 127, 0));
   }
 
   @Test
@@ -169,7 +169,7 @@ public class HillshadeLayerTest extends BaseLayerTest {
     assertNull(layer.getHillshadeHighlightColor().getValue());
 
     // Set and Get
-    String propertyValue = "rgba(0, 0, 0, 1)";
+    String propertyValue = "rgba(255,128,0,0.7)";
     layer.setProperties(hillshadeHighlightColor(propertyValue));
     assertEquals(layer.getHillshadeHighlightColor().getValue(), propertyValue);
   }
@@ -181,8 +181,8 @@ public class HillshadeLayerTest extends BaseLayerTest {
     assertNotNull(layer);
 
     // Set and Get
-    layer.setProperties(hillshadeHighlightColor(Color.RED));
-    assertEquals(layer.getHillshadeHighlightColorAsInt(), Color.RED);
+    layer.setProperties(hillshadeHighlightColor(Color.argb(127, 255, 127, 0)));
+    assertEquals(layer.getHillshadeHighlightColorAsInt(), Color.argb(127, 255, 127, 0));
   }
 
   @Test
@@ -205,7 +205,7 @@ public class HillshadeLayerTest extends BaseLayerTest {
     assertNull(layer.getHillshadeAccentColor().getValue());
 
     // Set and Get
-    String propertyValue = "rgba(0, 0, 0, 1)";
+    String propertyValue = "rgba(255,128,0,0.7)";
     layer.setProperties(hillshadeAccentColor(propertyValue));
     assertEquals(layer.getHillshadeAccentColor().getValue(), propertyValue);
   }
@@ -217,7 +217,7 @@ public class HillshadeLayerTest extends BaseLayerTest {
     assertNotNull(layer);
 
     // Set and Get
-    layer.setProperties(hillshadeAccentColor(Color.RED));
-    assertEquals(layer.getHillshadeAccentColorAsInt(), Color.RED);
+    layer.setProperties(hillshadeAccentColor(Color.argb(127, 255, 127, 0)));
+    assertEquals(layer.getHillshadeAccentColorAsInt(), Color.argb(127, 255, 127, 0));
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LightTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LightTest.java
@@ -103,8 +103,8 @@ public class LightTest extends BaseTest {
     invoke(mapboxMap, (uiController, mapboxMap) -> {
       assertNotNull(light);
       // Set and Get
-      light.setColor("rgba(0, 0, 0, 1)");
-      assertEquals("Color should match", "rgba(0, 0, 0, 1)".replaceAll("\\s+", ""), light.getColor());
+      light.setColor("rgba(255,128,0,0.7)");
+      assertEquals("Color should match", "rgba(255,128,0,0.7)", light.getColor());
     });
   }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
@@ -222,7 +222,7 @@ public class LineLayerTest extends BaseLayerTest {
     assertNull(layer.getLineColor().getValue());
 
     // Set and Get
-    String propertyValue = "rgba(0, 0, 0, 1)";
+    String propertyValue = "rgba(255,128,0,0.7)";
     layer.setProperties(lineColor(propertyValue));
     assertEquals(layer.getLineColor().getValue(), propertyValue);
   }
@@ -247,8 +247,8 @@ public class LineLayerTest extends BaseLayerTest {
     assertNotNull(layer);
 
     // Set and Get
-    layer.setProperties(lineColor(Color.RED));
-    assertEquals(layer.getLineColorAsInt(), Color.RED);
+    layer.setProperties(lineColor(Color.argb(127, 255, 127, 0)));
+    assertEquals(layer.getLineColorAsInt(), Color.argb(127, 255, 127, 0));
   }
 
   @Test

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
@@ -856,7 +856,7 @@ public class SymbolLayerTest extends BaseLayerTest {
     assertNull(layer.getIconColor().getValue());
 
     // Set and Get
-    String propertyValue = "rgba(0, 0, 0, 1)";
+    String propertyValue = "rgba(255,128,0,0.7)";
     layer.setProperties(iconColor(propertyValue));
     assertEquals(layer.getIconColor().getValue(), propertyValue);
   }
@@ -881,8 +881,8 @@ public class SymbolLayerTest extends BaseLayerTest {
     assertNotNull(layer);
 
     // Set and Get
-    layer.setProperties(iconColor(Color.RED));
-    assertEquals(layer.getIconColorAsInt(), Color.RED);
+    layer.setProperties(iconColor(Color.argb(127, 255, 127, 0)));
+    assertEquals(layer.getIconColorAsInt(), Color.argb(127, 255, 127, 0));
   }
 
   @Test
@@ -905,7 +905,7 @@ public class SymbolLayerTest extends BaseLayerTest {
     assertNull(layer.getIconHaloColor().getValue());
 
     // Set and Get
-    String propertyValue = "rgba(0, 0, 0, 1)";
+    String propertyValue = "rgba(255,128,0,0.7)";
     layer.setProperties(iconHaloColor(propertyValue));
     assertEquals(layer.getIconHaloColor().getValue(), propertyValue);
   }
@@ -930,8 +930,8 @@ public class SymbolLayerTest extends BaseLayerTest {
     assertNotNull(layer);
 
     // Set and Get
-    layer.setProperties(iconHaloColor(Color.RED));
-    assertEquals(layer.getIconHaloColorAsInt(), Color.RED);
+    layer.setProperties(iconHaloColor(Color.argb(127, 255, 127, 0)));
+    assertEquals(layer.getIconHaloColorAsInt(), Color.argb(127, 255, 127, 0));
   }
 
   @Test
@@ -1106,7 +1106,7 @@ public class SymbolLayerTest extends BaseLayerTest {
     assertNull(layer.getTextColor().getValue());
 
     // Set and Get
-    String propertyValue = "rgba(0, 0, 0, 1)";
+    String propertyValue = "rgba(255,128,0,0.7)";
     layer.setProperties(textColor(propertyValue));
     assertEquals(layer.getTextColor().getValue(), propertyValue);
   }
@@ -1131,8 +1131,8 @@ public class SymbolLayerTest extends BaseLayerTest {
     assertNotNull(layer);
 
     // Set and Get
-    layer.setProperties(textColor(Color.RED));
-    assertEquals(layer.getTextColorAsInt(), Color.RED);
+    layer.setProperties(textColor(Color.argb(127, 255, 127, 0)));
+    assertEquals(layer.getTextColorAsInt(), Color.argb(127, 255, 127, 0));
   }
 
   @Test
@@ -1155,7 +1155,7 @@ public class SymbolLayerTest extends BaseLayerTest {
     assertNull(layer.getTextHaloColor().getValue());
 
     // Set and Get
-    String propertyValue = "rgba(0, 0, 0, 1)";
+    String propertyValue = "rgba(255,128,0,0.7)";
     layer.setProperties(textHaloColor(propertyValue));
     assertEquals(layer.getTextHaloColor().getValue(), propertyValue);
   }
@@ -1180,8 +1180,8 @@ public class SymbolLayerTest extends BaseLayerTest {
     assertNotNull(layer);
 
     // Set and Get
-    layer.setProperties(textHaloColor(Color.RED));
-    assertEquals(layer.getTextHaloColorAsInt(), Color.RED);
+    layer.setProperties(textHaloColor(Color.argb(127, 255, 127, 0)));
+    assertEquals(layer.getTextHaloColorAsInt(), Color.argb(127, 255, 127, 0));
   }
 
   @Test

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
@@ -186,8 +186,8 @@ public class <%- camelize(type) %>LayerTest extends BaseLayerTest {
     assertNotNull(layer);
 
     // Set and Get
-    layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(Color.RED));
-    assertEquals(layer.get<%- camelize(property.name) %>AsInt(), Color.RED);
+    layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(Color.argb(127, 255, 127, 0)));
+    assertEquals(layer.get<%- camelize(property.name) %>AsInt(), Color.argb(127, 255, 127, 0));
   }
 <% } -%>
 <% } -%>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/light.junit.ejs
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/light.junit.ejs
@@ -86,7 +86,7 @@ public class LightTest extends BaseTest {
       // Set and Get
       light.set<%- camelize(property.name) %>(<%- defaultValueJava(property) %>);
 <% if (property.name == 'color') { -%>
-      assertEquals("<%- camelize(property.name) %> should match", <%- defaultValueJava(property) %>.replaceAll("\\s+", ""), light.get<%- camelize(property.name) %>());
+      assertEquals("<%- camelize(property.name) %> should match", <%- defaultValueJava(property) %>, light.get<%- camelize(property.name) %>());
 <% } else { -%>
       assertEquals("<%- camelize(property.name) %> should match", <%- defaultValueJava(property) %>, light.get<%- camelize(property.name) %>());
 <% } -%>

--- a/platform/android/scripts/generate-style-code.js
+++ b/platform/android/scripts/generate-style-code.js
@@ -193,7 +193,7 @@ global.defaultValueJava = function(property) {
       case 'enum':
         return snakeCaseUpper(property.name) + "_" + snakeCaseUpper(Object.keys(property.values)[0]);
       case 'color':
-        return '"rgba(0, 0, 0, 1)"';
+        return '"rgba(255,128,0,0.7)"';
       case 'array':
              switch (property.value) {
               case 'string':

--- a/platform/android/src/conversion/constant.cpp
+++ b/platform/android/src/conversion/constant.cpp
@@ -25,18 +25,7 @@ Result<jni::Local<jni::Object<>>> Converter<jni::Local<jni::Object<>>, std::stri
 }
 
 Result<jni::Local<jni::Object<>>> Converter<jni::Local<jni::Object<>>, Color>::operator()(jni::JNIEnv& env, const Color& value) const {
-    std::string result;
-    result.reserve(32);
-    result += "rgba(";
-    result += util::toString(value.r);
-    result += ", ";
-    result += util::toString(value.g);
-    result += ", ";
-    result += util::toString(value.b);
-    result += ", ";
-    result += util::toString(value.a);
-    result += ")";
-    return jni::Make<jni::String>(env, result);
+    return jni::Make<jni::String>(env, value.stringify());
 }
 
 Result<jni::Local<jni::Object<>>> Converter<jni::Local<jni::Object<>>, style::expression::Formatted>::operator()(jni::JNIEnv& env, const style::expression::Formatted& value) const {

--- a/src/mbgl/util/color.cpp
+++ b/src/mbgl/util/color.cpp
@@ -39,7 +39,7 @@ std::array<double, 4> Color::toArray() const {
             r * 255 / a,
             g * 255 / a,
             b * 255 / a,
-            a,
+            floor(a * 100 + .5) / 100 // round to 2 decimal places
         }};
     }
 }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/14130.

Fixes the color string round tripping which makes all the places where the string is used compliant with the `rgba` color option from [the spec](https://docs.mapbox.com/mapbox-gl-js/style-spec/#types-color). All other color string types will be converted to `rgba` when being fetched back from the core and we don't have a good mechanism in place to fight that.

String alpha value will be rounded to 2 decimal points.