### PR TITLE
Don't call OnSurfaceCreated from the main thread

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
@@ -40,11 +40,6 @@ public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceVi
       public void surfaceDestroyed(SurfaceHolder holder) {
         onSurfaceDestroyed();
       }
-
-      @Override
-      public void surfaceCreated(SurfaceHolder holder) {
-        onSurfaceCreated(null, null);
-      }
     });
   }
 


### PR DESCRIPTION
Follow up from https://github.com/mapbox/mapbox-gl-native/pull/14127, closes https://github.com/mapbox/mapbox-gl-native/issues/14224.  We shouldn't call `MapRenderer#OnSurfaceCreated` from the `SurfaceHolderCallback`. This callback is invoked on the main thread and is invoked in pair with the already existing one on the render thread (this was a misassumption made in #14127 that this wasn't invoked in pairs).

This solves the root crash of 

> JNI DETECTED ERROR IN APPLICATION: thread Thread[1,tid=12787,Native,Thread*=0x77ea6c2a00,peer=0x73a481c8,"main"] using JNIEnv* from thread Thread[60,tid=12894,Runnable,Thread*=0x77cccb3000,peer=0x12dcaaa0,"GLThread 12903"]
2019-03-26 20:35:03.152 12787-12787/com.mapbox.mapboxsdk.testapp A/zygote64: java_vm_ext.cc:534]     in call to DeleteGlobalRef

Which resulted in a  bunch of undefined behavior crashes as https://github.com/mapbox/mapbox-gl-native/issues/14224.

Have been running tests for hours and everything seems stable.