### PR TITLE
Remove request render from MapboxMap#onStart

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -128,7 +128,6 @@ public final class MapboxMap {
    * Called when the hosting Activity/Fragment onStart() method is called.
    */
   void onStart() {
-    nativeMapView.update();
     locationComponent.onStart();
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMap.java
@@ -29,8 +29,6 @@ interface NativeMap {
   // Lifecycle API
   //
 
-  void update();
-
   void resizeView(int width, int height);
 
   void onLowMemory();

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -136,15 +136,6 @@ final class NativeMapView implements NativeMap {
   }
 
   @Override
-  public void update() {
-    if (checkState("update")) {
-      return;
-    }
-
-    mapRenderer.requestRender();
-  }
-
-  @Override
   public void resizeView(int width, int height) {
     if (checkState("resizeView")) {
       return;


### PR DESCRIPTION
When looking into #14244, I noticed that we are requesting an unnecessary render. Since https://github.com/mapbox/mapbox-gl-native/pull/9576 this is no longer required. 