### PR TITLE
Crash when rendering lines with missing patterns

### DIFF
--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -143,8 +143,8 @@ void RenderLineLayer::render(PaintParameters& parameters, RenderSource*) {
                      texsize,
                      crossfade,
                      parameters.pixelRatio),
-                     *posA,
-                     *posB,
+                     posA,
+                     posB,
                      LinePatternProgram::TextureBindings{
                          textures::image::Value{ *geometryTile.iconAtlasTexture->resource, gfx::TextureFilterType::Linear },
                      });

--- a/src/mbgl/renderer/paint_property_binder.hpp
+++ b/src/mbgl/renderer/paint_property_binder.hpp
@@ -148,7 +148,7 @@ public:
     void upload(gfx::Context&) override {}
 
     void setPatternParameters(const optional<ImagePosition>& posA, const optional<ImagePosition>& posB, CrossfadeParameters&) override {
-        if (!posA && !posB) {
+        if (!posA || !posB) {
             return;
         } else {
             constantPatternPositions = std::tuple<std::array<uint16_t, 4>, std::array<uint16_t, 4>> { posB->tlbr(), posA->tlbr() };


### PR DESCRIPTION
Got this crash in [a node render test](https://circleci.com/gh/mapbox/mapbox-gl-native/252082):

```
Thread 1 (Thread 0x7f2058cf3780 (LWP 5322)):
#0  0x00007f2057100428 in __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:54
#1  0x00007f205710202a in __GI_abort () at abort.c:89
#2  0x00007f20570f8bd7 in __assert_fail_base (fmt=<optimized out>, assertion=assertion@entry=0x7f20549ea722 "initialized()", file=file@entry=0x7f20549ea700 "/src/vendor/optional/optional.hpp", line=line@entry=550, function=function@entry=0x7f20549eb6e0 <std::experimental::optional<mbgl::ImagePosition>::operator*()::__PRETTY_FUNCTION__> "T& std::experimental::optional<T>::operator*() [with T = mbgl::ImagePosition]") at assert.c:92
#3  0x00007f20570f8c82 in __GI___assert_fail (assertion=0x7f20549ea722 "initialized()", file=0x7f20549ea700 "/src/vendor/optional/optional.hpp", line=550, function=0x7f20549eb6e0 <std::experimental::optional<mbgl::ImagePosition>::operator*()::__PRETTY_FUNCTION__> "T& std::experimental::optional<T>::operator*() [with T = mbgl::ImagePosition]") at assert.c:101
#4  0x00007f205451140d in std::experimental::optional<mbgl::ImagePosition>::operator* (this=0x7fffbf33fb40) at /src/vendor/optional/optional.hpp:550
#5  0x00007f205456324e in mbgl::RenderLineLayer::render (this=0xb5cc3b0, parameters=...) at ../../../src/mbgl/renderer/layers/render_line_layer.cpp:147
#6  0x00007f2054231c0a in mbgl::Renderer::Impl::render (this=0x2fb22f0, updateParameters=...) at ../../../src/mbgl/renderer/renderer_impl.cpp:548
#7  0x00007f205422a36a in mbgl::Renderer::render (this=0x2f87c10, updateParameters=...) at ../../../src/mbgl/renderer/renderer.cpp:34
#8  0x00007f20543dabcd in mbgl::HeadlessFrontend::<lambda()>::operator()(void) const (__closure=0x2e10718) at ../../../platform/default/src/mbgl/gl/headless_frontend.cpp:23
#9  0x00007f20543db8bb in std::_Function_handler<void(), mbgl::HeadlessFrontend::HeadlessFrontend(mbgl::Size, float, mbgl::Scheduler&, mbgl::optional<std::__cxx11::basic_string<char> >, mbgl::GLContextMode, mbgl::optional<std::__cxx11::basic_string<char> >)::<lambda()> >::_M_invoke(const std::_Any_data &) (__functor=...) at /usr/include/c++/8/bits/std_function.h:297
#10 0x00007f20542093de in std::function<void ()>::operator()() const (this=0x2e10718) at /usr/include/c++/8/bits/std_function.h:687
#11 0x00007f2054209364 in mbgl::util::AsyncTask::Impl::asyncCallback (handle=0x2eae240) at ../../../platform/default/src/mbgl/util/async_task.cpp:43
#12 0x00000000009b580b in uv__async_io (loop=0x217be40 <default_loop_struct>, w=<optimized out>, events=<optimized out>) at ../deps/uv/src/unix/async.c:118
#13 0x00000000009c6e48 in uv__io_poll (loop=loop@entry=0x217be40 <default_loop_struct>, timeout=782) at ../deps/uv/src/unix/linux-core.c:400
#14 0x00000000009b6196 in uv_run (loop=0x217be40 <default_loop_struct>, mode=UV_RUN_DEFAULT) at ../deps/uv/src/unix/core.c:368
#15 0x00000000008d55a5 in node::Start(uv_loop_s*, int, char const* const*, int, char const* const*) ()
#16 0x00000000008d4900 in node::Start(int, char**) ()
#17 0x00007f20570eb830 in __libc_start_main (main=0x89dff0 <main>, argc=6, argv=0x7fffbf344f68, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7fffbf344f58) at ../csu/libc-start.c:291
#18 0x000000000089e0e1 in _start ()
```