### PR TITLE
Fix thread assertion while running instrumentation test

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/MapboxTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/MapboxTest.java
@@ -1,5 +1,6 @@
 package com.mapbox.mapboxsdk.maps;
 
+import android.support.test.annotation.UiThreadTest;
 import android.support.test.runner.AndroidJUnit4;
 import com.mapbox.mapboxsdk.Mapbox;
 import org.junit.Test;
@@ -16,6 +17,7 @@ public class MapboxTest {
   private static final String ACCESS_TOKEN_2 = "pk.0000000002";
 
   @Test
+  @UiThreadTest
   public void testConnected() {
     assertTrue(Mapbox.isConnected());
 
@@ -31,6 +33,7 @@ public class MapboxTest {
   }
 
   @Test
+  @UiThreadTest
   public void setAccessToken() {
     String realToken =  Mapbox.getAccessToken();
     Mapbox.setAccessToken(ACCESS_TOKEN);


### PR DESCRIPTION
We were hitting thread id assertion crash in https://github.com/mapbox/mapbox-gl-native/pull/14170. The source of this is that the filesource is created on the UIThread instead of the main thread.