### PR TITLE
add onStyleImageMissing to allow dynamically loaded or generated images

### DIFF
--- a/include/mbgl/map/map_observer.hpp
+++ b/include/mbgl/map/map_observer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/style/source.hpp>
+#include <mbgl/style/image.hpp>
 
 #include <cstdint>
 #include <string>
@@ -46,7 +47,7 @@ public:
     virtual void onDidFinishLoadingStyle() {}
     virtual void onSourceChanged(style::Source&) {}
     virtual void onDidBecomeIdle() {}
-    virtual void onStyleImageMissing(const std::string&) {}
+    virtual void onStyleImageMissing(const std::string&, std::function<void(optional<std::unique_ptr<mbgl::style::Image>>)> callback) { callback({}); }
 };
 
 } // namespace mbgl

--- a/include/mbgl/map/map_observer.hpp
+++ b/include/mbgl/map/map_observer.hpp
@@ -46,6 +46,7 @@ public:
     virtual void onDidFinishLoadingStyle() {}
     virtual void onSourceChanged(style::Source&) {}
     virtual void onDidBecomeIdle() {}
+    virtual void onStyleImageMissing(const std::string&) {}
 };
 
 } // namespace mbgl

--- a/include/mbgl/map/map_observer.hpp
+++ b/include/mbgl/map/map_observer.hpp
@@ -47,7 +47,7 @@ public:
     virtual void onDidFinishLoadingStyle() {}
     virtual void onSourceChanged(style::Source&) {}
     virtual void onDidBecomeIdle() {}
-    virtual void onStyleImageMissing(const std::string&, std::function<void(optional<std::unique_ptr<mbgl::style::Image>>)> callback) { callback({}); }
+    virtual void onStyleImageMissing(const std::string&) {}
 };
 
 } // namespace mbgl

--- a/include/mbgl/renderer/renderer_observer.hpp
+++ b/include/mbgl/renderer/renderer_observer.hpp
@@ -33,7 +33,8 @@ public:
     virtual void onDidFinishRenderingMap() {}
 
     // Style is missing an image
-    virtual void onStyleImageMissing(const std::string&, std::function<void()> done) { done(); }
+    using StyleImageMissingCallback = std::function<void()>;
+    virtual void onStyleImageMissing(const std::string&, StyleImageMissingCallback done) { done(); }
 };
 
 } // namespace mbgl

--- a/include/mbgl/renderer/renderer_observer.hpp
+++ b/include/mbgl/renderer/renderer_observer.hpp
@@ -31,6 +31,9 @@ public:
 
     // Final frame
     virtual void onDidFinishRenderingMap() {}
+
+    // Style is missing an image
+    virtual void onStyleImageMissing(const std::string&) {}
 };
 
 } // namespace mbgl

--- a/include/mbgl/renderer/renderer_observer.hpp
+++ b/include/mbgl/renderer/renderer_observer.hpp
@@ -33,7 +33,7 @@ public:
     virtual void onDidFinishRenderingMap() {}
 
     // Style is missing an image
-    virtual void onStyleImageMissing(const std::string&) {}
+    virtual void onStyleImageMissing(const std::string&, std::function<void()> done) { done(); }
 };
 
 } // namespace mbgl

--- a/platform/darwin/src/MGLRendererFrontend.h
+++ b/platform/darwin/src/MGLRendererFrontend.h
@@ -49,7 +49,12 @@ public:
         
         mbgl::BackendScope guard { mbglBackend, mbgl::BackendScope::ScopeType::Implicit };
         
-        renderer->render(*updateParameters);
+        // onStyleImageMissing might be called during a render. The user implemented method
+        // could trigger a call to MGLRenderFrontend#update which overwrites `updateParameters`.
+        // Copy the shared pointer here so that the parameters aren't destroyed while `render(...)` is
+        // still using them.
+        auto updateParameters_ = updateParameters;
+        renderer->render(*updateParameters_);
     }
     
     mbgl::Renderer* getRenderer() {

--- a/platform/glfw/glfw_renderer_frontend.cpp
+++ b/platform/glfw/glfw_renderer_frontend.cpp
@@ -32,7 +32,12 @@ void GLFWRendererFrontend::render() {
     
     mbgl::BackendScope guard { glfwView, mbgl::BackendScope::ScopeType::Implicit };
 
-    renderer->render(*updateParameters);
+    // onStyleImageMissing might be called during a render. The user implemented method
+    // could trigger a call to MGLRenderFrontend#update which overwrites `updateParameters`.
+    // Copy the shared pointer here so that the parameters aren't destroyed while `render(...)` is
+    // still using them.
+    auto updateParameters_ = updateParameters;
+    renderer->render(*updateParameters_);
 }
 
 mbgl::Renderer* GLFWRendererFrontend::getRenderer() {

--- a/src/core-files.json
+++ b/src/core-files.json
@@ -615,6 +615,7 @@
         "mbgl/renderer/group_by_layout.hpp": "src/mbgl/renderer/group_by_layout.hpp",
         "mbgl/renderer/image_atlas.hpp": "src/mbgl/renderer/image_atlas.hpp",
         "mbgl/renderer/image_manager.hpp": "src/mbgl/renderer/image_manager.hpp",
+        "mbgl/renderer/image_manager_observer.hpp": "src/mbgl/renderer/image_manager_observer.hpp",
         "mbgl/renderer/layers/render_background_layer.hpp": "src/mbgl/renderer/layers/render_background_layer.hpp",
         "mbgl/renderer/layers/render_circle_layer.hpp": "src/mbgl/renderer/layers/render_circle_layer.hpp",
         "mbgl/renderer/layers/render_custom_layer.hpp": "src/mbgl/renderer/layers/render_custom_layer.hpp",

--- a/src/mbgl/gfx/context.hpp
+++ b/src/mbgl/gfx/context.hpp
@@ -100,10 +100,24 @@ public:
         texture.size = image.size;
     }
 
+    template <typename Image>
+    void updateTextureSub(Texture& texture,
+                       const Image& image,
+                       const uint16_t offsetX,
+                       const uint16_t offsetY,
+                       TextureChannelDataType type = TextureChannelDataType::UnsignedByte) {
+        assert(image.size.width + offsetX <= texture.size.width);
+        assert(image.size.height + offsetY <= texture.size.height);
+        auto format = image.channels == 4 ? TexturePixelType::RGBA : TexturePixelType::Alpha;
+        updateTextureResourceSub(*texture.resource, offsetX, offsetY, image.size, image.data.get(), format, type);
+    }
+
 protected:
     virtual std::unique_ptr<TextureResource> createTextureResource(
         Size, const void* data, TexturePixelType, TextureChannelDataType) = 0;
     virtual void updateTextureResource(const TextureResource&, Size, const void* data,
+        TexturePixelType, TextureChannelDataType) = 0;
+    virtual void updateTextureResourceSub(const TextureResource&, uint16_t xOffset, uint16_t yOffset, Size, const void* data,
         TexturePixelType, TextureChannelDataType) = 0;
 
 public:

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -555,7 +555,7 @@ void Context::updateTextureResourceSub(const gfx::TextureResource& resource,
                                     gfx::TextureChannelDataType type) {
     // Always use texture unit 0 for manipulating it.
     activeTextureUnit = 0;
-    texture[0] = reinterpret_cast<const gl::TextureResource&>(resource).texture;
+    texture[0] = static_cast<const gl::TextureResource&>(resource).texture;
     MBGL_CHECK_ERROR(glTexSubImage2D(GL_TEXTURE_2D, 0,
                                   xOffset, yOffset,
                                   size.width, size.height,

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -546,6 +546,24 @@ void Context::updateTextureResource(const gfx::TextureResource& resource,
                                   Enum<gfx::TextureChannelDataType>::to(type), data));
 }
 
+void Context::updateTextureResourceSub(const gfx::TextureResource& resource,
+                                    const uint16_t xOffset,
+                                    const uint16_t yOffset,
+                                    const Size size,
+                                    const void* data,
+                                    gfx::TexturePixelType format,
+                                    gfx::TextureChannelDataType type) {
+    // Always use texture unit 0 for manipulating it.
+    activeTextureUnit = 0;
+    texture[0] = reinterpret_cast<const gl::TextureResource&>(resource).texture;
+    MBGL_CHECK_ERROR(glTexSubImage2D(GL_TEXTURE_2D, 0,
+                                  xOffset, yOffset,
+                                  size.width, size.height,
+                                  Enum<gfx::TexturePixelType>::to(format),
+                                  Enum<gfx::TextureChannelDataType>::to(type), data));
+}
+
+
 std::unique_ptr<gfx::DrawScopeResource> Context::createDrawScopeResource() {
     return std::make_unique<gl::DrawScopeResource>(createVertexArray());
 }

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -211,6 +211,7 @@ private:
 
     std::unique_ptr<gfx::TextureResource> createTextureResource(Size, const void* data, gfx::TexturePixelType, gfx::TextureChannelDataType) override;
     void updateTextureResource(const gfx::TextureResource&, Size, const void* data, gfx::TexturePixelType, gfx::TextureChannelDataType) override;
+    void updateTextureResourceSub(const gfx::TextureResource&, const uint16_t xOffset, const uint16_t yOffset, Size, const void* data, gfx::TexturePixelType, gfx::TextureChannelDataType) override;
 
     std::unique_ptr<gfx::DrawScopeResource> createDrawScopeResource() override;
 

--- a/src/mbgl/map/map_impl.cpp
+++ b/src/mbgl/map/map_impl.cpp
@@ -172,4 +172,8 @@ void Map::Impl::jumpTo(const CameraOptions& camera) {
     onUpdate();
 }
 
+void Map::Impl::onStyleImageMissing(const std::string& id) {
+    observer.onStyleImageMissing(id);
+}
+
 } // namespace mbgl

--- a/src/mbgl/map/map_impl.cpp
+++ b/src/mbgl/map/map_impl.cpp
@@ -172,8 +172,19 @@ void Map::Impl::jumpTo(const CameraOptions& camera) {
     onUpdate();
 }
 
-void Map::Impl::onStyleImageMissing(const std::string& id) {
-    observer.onStyleImageMissing(id);
+void Map::Impl::onStyleImageMissing(const std::string& id, std::function<void()> done) {
+
+    if (style->getImage(id) != nullptr) {
+        done();
+        return;
+    }
+
+    observer.onStyleImageMissing(id, [this, done](optional<std::unique_ptr<mbgl::style::Image>> image = {}) {
+        if (image) {
+            style->addImage(std::move(*image));
+        }
+        done();
+    });
 }
 
 } // namespace mbgl

--- a/src/mbgl/map/map_impl.cpp
+++ b/src/mbgl/map/map_impl.cpp
@@ -174,17 +174,11 @@ void Map::Impl::jumpTo(const CameraOptions& camera) {
 
 void Map::Impl::onStyleImageMissing(const std::string& id, std::function<void()> done) {
 
-    if (style->getImage(id) != nullptr) {
-        done();
-        return;
+    if (style->getImage(id) == nullptr) {
+        observer.onStyleImageMissing(id);
     }
 
-    observer.onStyleImageMissing(id, [this, done](optional<std::unique_ptr<mbgl::style::Image>> image = {}) {
-        if (image) {
-            style->addImage(std::move(*image));
-        }
-        done();
-    });
+    done();
 }
 
 } // namespace mbgl

--- a/src/mbgl/map/map_impl.cpp
+++ b/src/mbgl/map/map_impl.cpp
@@ -172,7 +172,7 @@ void Map::Impl::jumpTo(const CameraOptions& camera) {
     onUpdate();
 }
 
-void Map::Impl::onStyleImageMissing(const std::string& id, RendererObserver::StyleImageMissingCallback done) {
+void Map::Impl::onStyleImageMissing(const std::string& id, std::function<void()> done) {
 
     if (style->getImage(id) == nullptr) {
         observer.onStyleImageMissing(id);

--- a/src/mbgl/map/map_impl.cpp
+++ b/src/mbgl/map/map_impl.cpp
@@ -172,13 +172,14 @@ void Map::Impl::jumpTo(const CameraOptions& camera) {
     onUpdate();
 }
 
-void Map::Impl::onStyleImageMissing(const std::string& id, std::function<void()> done) {
+void Map::Impl::onStyleImageMissing(const std::string& id, RendererObserver::StyleImageMissingCallback done) {
 
     if (style->getImage(id) == nullptr) {
         observer.onStyleImageMissing(id);
     }
 
     done();
+    onUpdate();
 }
 
 } // namespace mbgl

--- a/src/mbgl/map/map_impl.hpp
+++ b/src/mbgl/map/map_impl.hpp
@@ -47,7 +47,7 @@ public:
     void onDidFinishRenderingFrame(RenderMode, bool) final;
     void onWillStartRenderingMap() final;
     void onDidFinishRenderingMap() final;
-    void onStyleImageMissing(const std::string&) final;
+    void onStyleImageMissing(const std::string&, std::function<void()>) final;
 
     // Map
     void jumpTo(const CameraOptions&);

--- a/src/mbgl/map/map_impl.hpp
+++ b/src/mbgl/map/map_impl.hpp
@@ -47,7 +47,7 @@ public:
     void onDidFinishRenderingFrame(RenderMode, bool) final;
     void onWillStartRenderingMap() final;
     void onDidFinishRenderingMap() final;
-    void onStyleImageMissing(const std::string&, RendererObserver::StyleImageMissingCallback) final;
+    void onStyleImageMissing(const std::string&, std::function<void()>) final;
 
     // Map
     void jumpTo(const CameraOptions&);

--- a/src/mbgl/map/map_impl.hpp
+++ b/src/mbgl/map/map_impl.hpp
@@ -47,7 +47,7 @@ public:
     void onDidFinishRenderingFrame(RenderMode, bool) final;
     void onWillStartRenderingMap() final;
     void onDidFinishRenderingMap() final;
-    void onStyleImageMissing(const std::string&, std::function<void()>) final;
+    void onStyleImageMissing(const std::string&, RendererObserver::StyleImageMissingCallback) final;
 
     // Map
     void jumpTo(const CameraOptions&);

--- a/src/mbgl/map/map_impl.hpp
+++ b/src/mbgl/map/map_impl.hpp
@@ -47,6 +47,7 @@ public:
     void onDidFinishRenderingFrame(RenderMode, bool) final;
     void onWillStartRenderingMap() final;
     void onDidFinishRenderingMap() final;
+    void onStyleImageMissing(const std::string&) final;
 
     // Map
     void jumpTo(const CameraOptions&);

--- a/src/mbgl/renderer/image_atlas.hpp
+++ b/src/mbgl/renderer/image_atlas.hpp
@@ -9,12 +9,20 @@
 
 namespace mbgl {
 
+namespace gfx {
+    class Texture;
+    class Context;
+} // namespace gfx
+
+class ImageManager;
+
 class ImagePosition {
 public:
-    ImagePosition(const mapbox::Bin&, const style::Image::Impl&);
+    ImagePosition(const mapbox::Bin&, const style::Image::Impl&, uint32_t version = 0);
 
     float pixelRatio;
     Rect<uint16_t> textureRect;
+    uint32_t version;
 
     std::array<uint16_t, 2> tl() const {
         return {{
@@ -51,8 +59,12 @@ public:
     PremultipliedImage image;
     ImagePositions iconPositions;
     ImagePositions patternPositions;
+
+    void patchUpdatedImages(gfx::Context&, gfx::Texture&, const ImageManager&);
+private:
+    void patchUpdatedImage(gfx::Context&, gfx::Texture&, ImagePosition& position, const ImageManager& imageManager, const std::string& name, uint16_t version);
 };
 
-ImageAtlas makeImageAtlas(const ImageMap&, const ImageMap&);
+ImageAtlas makeImageAtlas(const ImageMap&, const ImageMap&, const std::unordered_map<std::string, uint32_t>& versionMap);
 
 } // namespace mbgl

--- a/src/mbgl/renderer/image_manager.cpp
+++ b/src/mbgl/renderer/image_manager.cpp
@@ -113,7 +113,7 @@ void ImageManager::removeRequestor(ImageRequestor& requestor) {
     missingImageRequestors.erase(&requestor);
 }
 
-void ImageManager::imagesAdded() {
+void ImageManager::notifyIfMissingImageAdded() {
     for (auto it = missingImageRequestors.begin(); it != missingImageRequestors.end();) {
         if (it->second.callbacksRemaining == 0) {
             notify(*it->first, it->second.pair);
@@ -132,7 +132,6 @@ void ImageManager::checkMissingAndNotify(ImageRequestor& requestor, const ImageR
             missing++;
         }
     }
-
 
     if (missing > 0) {
         ImageRequestor* requestorPtr = &requestor;
@@ -161,7 +160,7 @@ void ImageManager::checkMissingAndNotify(ImageRequestor& requestor, const ImageR
 void ImageManager::notify(ImageRequestor& requestor, const ImageRequestPair& pair) const {
     ImageMap iconMap;
     ImageMap patternMap;
-    std::unordered_map<std::string, uint32_t> versionMap;
+    ImageVersionMap versionMap;
 
     for (const auto& dependency : pair.first) {
         auto it = images.find(dependency.first);

--- a/src/mbgl/renderer/image_manager.cpp
+++ b/src/mbgl/renderer/image_manager.cpp
@@ -120,9 +120,9 @@ void ImageManager::checkMissingAndNotify(ImageRequestor& requestor, const ImageR
             auto it = images.find(dependency.first);
             if (it == images.end()) {
                 observer->onStyleImageMissing(dependency.first, [this, requestorPtr]() {
-                    auto missing = missingImageRequestors.find(requestorPtr);
-                    if (missing != missingImageRequestors.end()) {
-                        missing->second.callbacksRemaining--;
+                    auto requestorIt = missingImageRequestors.find(requestorPtr);
+                    if (requestorIt != missingImageRequestors.end()) {
+                        requestorIt ->second.callbacksRemaining--;
                     }
                 });
             }

--- a/src/mbgl/renderer/image_manager.cpp
+++ b/src/mbgl/renderer/image_manager.cpp
@@ -120,9 +120,9 @@ void ImageManager::checkMissingAndNotify(ImageRequestor& requestor, const ImageR
             auto it = images.find(dependency.first);
             if (it == images.end()) {
                 observer->onStyleImageMissing(dependency.first, [this, requestorPtr]() {
-                    auto it = missingImageRequestors.find(requestorPtr);
-                    if (it != missingImageRequestors.end()) {
-                        it->second.callbacksRemaining--;
+                    auto missing = missingImageRequestors.find(requestorPtr);
+                    if (missing != missingImageRequestors.end()) {
+                        missing->second.callbacksRemaining--;
                     }
                 });
             }

--- a/src/mbgl/renderer/image_manager.hpp
+++ b/src/mbgl/renderer/image_manager.hpp
@@ -64,7 +64,11 @@ private:
     bool loaded = false;
 
     std::unordered_map<ImageRequestor*, ImageRequestPair> requestors;
-    std::unordered_map<ImageRequestor*, ImageRequestPair> missingImageRequestors;
+    struct MissingImageRequestPair {
+        ImageRequestPair pair;
+        int callbacksRemaining;
+    };
+    std::unordered_map<ImageRequestor*, MissingImageRequestPair> missingImageRequestors;
     ImageMap images;
 
     ImageManagerObserver* observer = nullptr;

--- a/src/mbgl/renderer/image_manager.hpp
+++ b/src/mbgl/renderer/image_manager.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/util/immutable.hpp>
 #include <mbgl/util/optional.hpp>
 #include <mbgl/gfx/texture.hpp>
+#include <mbgl/renderer/image_manager_observer.hpp>
 
 #include <mapbox/shelf-pack.hpp>
 
@@ -39,6 +40,8 @@ public:
     ImageManager();
     ~ImageManager();
 
+    void setObserver(ImageManagerObserver*);
+
     void setLoaded(bool);
     bool isLoaded() const;
 
@@ -52,14 +55,19 @@ public:
 
     void getImages(ImageRequestor&, ImageRequestPair&&);
     void removeRequestor(ImageRequestor&);
+    void imagesAdded();
 
 private:
+    void checkMissingAndNotify(ImageRequestor&, const ImageRequestPair&);
     void notify(ImageRequestor&, const ImageRequestPair&) const;
 
     bool loaded = false;
 
     std::unordered_map<ImageRequestor*, ImageRequestPair> requestors;
+    std::unordered_map<ImageRequestor*, ImageRequestPair> missingImageRequestors;
     ImageMap images;
+
+    ImageManagerObserver* observer = nullptr;
 
 // Pattern stuff
 public:

--- a/src/mbgl/renderer/image_manager.hpp
+++ b/src/mbgl/renderer/image_manager.hpp
@@ -22,7 +22,7 @@ class Context;
 class ImageRequestor {
 public:
     virtual ~ImageRequestor() = default;
-    virtual void onImagesAvailable(ImageMap icons, ImageMap patterns, std::unordered_map<std::string, uint32_t> versionMap, uint64_t imageCorrelationID) = 0;
+    virtual void onImagesAvailable(ImageMap icons, ImageMap patterns, ImageVersionMap versionMap, uint64_t imageCorrelationID) = 0;
 };
 
 /*
@@ -55,9 +55,9 @@ public:
 
     void getImages(ImageRequestor&, ImageRequestPair&&);
     void removeRequestor(ImageRequestor&);
-    void imagesAdded();
+    void notifyIfMissingImageAdded();
 
-    std::map<std::string, uint32_t> updatedImageVersions;
+    ImageVersionMap updatedImageVersions;
 
 private:
     void checkMissingAndNotify(ImageRequestor&, const ImageRequestPair&);

--- a/src/mbgl/renderer/image_manager.hpp
+++ b/src/mbgl/renderer/image_manager.hpp
@@ -22,7 +22,7 @@ class Context;
 class ImageRequestor {
 public:
     virtual ~ImageRequestor() = default;
-    virtual void onImagesAvailable(ImageMap icons, ImageMap patterns, uint64_t imageCorrelationID) = 0;
+    virtual void onImagesAvailable(ImageMap icons, ImageMap patterns, std::unordered_map<std::string, uint32_t> versionMap, uint64_t imageCorrelationID) = 0;
 };
 
 /*
@@ -50,12 +50,14 @@ public:
     const style::Image::Impl* getImage(const std::string&) const;
 
     void addImage(Immutable<style::Image::Impl>);
-    void updateImage(Immutable<style::Image::Impl>);
+    bool updateImage(Immutable<style::Image::Impl>);
     void removeImage(const std::string&);
 
     void getImages(ImageRequestor&, ImageRequestPair&&);
     void removeRequestor(ImageRequestor&);
     void imagesAdded();
+
+    std::map<std::string, uint32_t> updatedImageVersions;
 
 private:
     void checkMissingAndNotify(ImageRequestor&, const ImageRequestPair&);
@@ -63,12 +65,12 @@ private:
 
     bool loaded = false;
 
-    std::unordered_map<ImageRequestor*, ImageRequestPair> requestors;
+    std::map<ImageRequestor*, ImageRequestPair> requestors;
     struct MissingImageRequestPair {
         ImageRequestPair pair;
-        int callbacksRemaining;
+        unsigned int callbacksRemaining;
     };
-    std::unordered_map<ImageRequestor*, MissingImageRequestPair> missingImageRequestors;
+    std::map<ImageRequestor*, MissingImageRequestPair> missingImageRequestors;
     ImageMap images;
 
     ImageManagerObserver* observer = nullptr;

--- a/src/mbgl/renderer/image_manager_observer.hpp
+++ b/src/mbgl/renderer/image_manager_observer.hpp
@@ -6,7 +6,7 @@ class ImageManagerObserver {
 public:
     virtual ~ImageManagerObserver() = default;
 
-    virtual void onStyleImageMissing(const std::string&) {}
+    virtual void onStyleImageMissing(const std::string&, std::function<void()>) {}
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/image_manager_observer.hpp
+++ b/src/mbgl/renderer/image_manager_observer.hpp
@@ -8,8 +8,7 @@ class ImageManagerObserver {
 public:
     virtual ~ImageManagerObserver() = default;
 
-    using StyleImageMissingCallback = std::function<void()>;
-    virtual void onStyleImageMissing(const std::string&, RendererObserver::StyleImageMissingCallback done) { done(); }
+    virtual void onStyleImageMissing(const std::string&, std::function<void()> done) { done(); }
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/image_manager_observer.hpp
+++ b/src/mbgl/renderer/image_manager_observer.hpp
@@ -1,12 +1,15 @@
 #pragma once
 
+#include <mbgl/renderer/renderer_observer.hpp>
+
 namespace mbgl {
 
 class ImageManagerObserver {
 public:
     virtual ~ImageManagerObserver() = default;
 
-    virtual void onStyleImageMissing(const std::string&, std::function<void()>) {}
+    using StyleImageMissingCallback = std::function<void()>;
+    virtual void onStyleImageMissing(const std::string&, RendererObserver::StyleImageMissingCallback done) { done(); }
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/image_manager_observer.hpp
+++ b/src/mbgl/renderer/image_manager_observer.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace mbgl {
+
+class ImageManagerObserver {
+public:
+    virtual ~ImageManagerObserver() = default;
+
+    virtual void onStyleImageMissing(const std::string&) {}
+};
+
+} // namespace mbgl

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -83,6 +83,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
 
     if (!imageManager) {
         imageManager = std::make_unique<ImageManager>();
+        imageManager->setObserver(this);
     }
 
     if (updateParameters.mode != MapMode::Continuous) {
@@ -158,6 +159,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         imageManager->updateImage(entry.second.after);
     }
 
+    imageManager->imagesAdded();
     imageManager->setLoaded(updateParameters.spriteLoaded);
 
 
@@ -832,6 +834,10 @@ void Renderer::Impl::onTileError(RenderSource& source, const OverscaledTileID& t
 
 void Renderer::Impl::onTileChanged(RenderSource&, const OverscaledTileID&) {
     observer->onInvalidate();
+}
+
+void Renderer::Impl::onStyleImageMissing(const std::string& id) {
+    observer->onStyleImageMissing(id);
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -159,8 +159,8 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         imageManager->updateImage(entry.second.after);
     }
 
-    imageManager->imagesAdded();
     imageManager->setLoaded(updateParameters.spriteLoaded);
+    imageManager->imagesAdded();
 
 
     const LayerDifference layerDiff = diffLayers(layerImpls, updateParameters.layers);
@@ -836,8 +836,8 @@ void Renderer::Impl::onTileChanged(RenderSource&, const OverscaledTileID&) {
     observer->onInvalidate();
 }
 
-void Renderer::Impl::onStyleImageMissing(const std::string& id) {
-    observer->onStyleImageMissing(id);
+void Renderer::Impl::onStyleImageMissing(const std::string& id, std::function<void()> done) {
+    observer->onStyleImageMissing(id, done);
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -144,6 +144,9 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
     const ImageDifference imageDiff = diffImages(imageImpls, updateParameters.images);
     imageImpls = updateParameters.images;
 
+    // Only trigger tile reparse for changed images. Changed images only need a relayout when they have a different size.
+    bool hasImageDiff = !imageDiff.removed.empty();
+
     // Remove removed images from sprite atlas.
     for (const auto& entry : imageDiff.removed) {
         imageManager->removeImage(entry.first);
@@ -156,11 +159,11 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
 
     // Update changed images.
     for (const auto& entry : imageDiff.changed) {
-        imageManager->updateImage(entry.second.after);
+        hasImageDiff = imageManager->updateImage(entry.second.after) || hasImageDiff;
     }
 
-    imageManager->setLoaded(updateParameters.spriteLoaded);
     imageManager->imagesAdded();
+    imageManager->setLoaded(updateParameters.spriteLoaded);
 
 
     const LayerDifference layerDiff = diffLayers(layerImpls, updateParameters.layers);
@@ -216,8 +219,6 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         renderSource->setObserver(this);
         renderSources.emplace(entry.first, std::move(renderSource));
     }
-
-    const bool hasImageDiff = !(imageDiff.added.empty() && imageDiff.removed.empty() && imageDiff.changed.empty());
 
     // Update all sources.
     for (const auto& source : *sourceImpls) {

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -162,7 +162,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         hasImageDiff = imageManager->updateImage(entry.second.after) || hasImageDiff;
     }
 
-    imageManager->imagesAdded();
+    imageManager->notifyIfMissingImageAdded();
     imageManager->setLoaded(updateParameters.spriteLoaded);
 
 
@@ -838,7 +838,7 @@ void Renderer::Impl::onTileChanged(RenderSource&, const OverscaledTileID&) {
 }
 
 void Renderer::Impl::onStyleImageMissing(const std::string& id, std::function<void()> done) {
-    observer->onStyleImageMissing(id, done);
+    observer->onStyleImageMissing(id, std::move(done));
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/renderer_impl.hpp
+++ b/src/mbgl/renderer/renderer_impl.hpp
@@ -89,7 +89,7 @@ private:
     void onTileError(RenderSource&, const OverscaledTileID&, std::exception_ptr) override;
 
     // ImageManagerObserver implementation
-    void onStyleImageMissing(const std::string&) override;
+    void onStyleImageMissing(const std::string&, std::function<void()>) override;
 
     void updateFadingTiles();
 

--- a/src/mbgl/renderer/renderer_impl.hpp
+++ b/src/mbgl/renderer/renderer_impl.hpp
@@ -11,6 +11,7 @@
 #include <mbgl/map/zoom_history.hpp>
 #include <mbgl/text/cross_tile_symbol_index.hpp>
 #include <mbgl/text/glyph_manager_observer.hpp>
+#include <mbgl/renderer/image_manager_observer.hpp>
 #include <mbgl/text/placement.hpp>
 
 #include <memory>
@@ -34,6 +35,7 @@ class LineAtlas;
 class CrossTileSymbolIndex;
 
 class Renderer::Impl : public GlyphManagerObserver,
+                       public ImageManagerObserver,
                        public RenderSourceObserver{
 public:
     Impl(RendererBackend&, float pixelRatio_, Scheduler&, GLContextMode,
@@ -85,6 +87,9 @@ private:
     // RenderSourceObserver implementation.
     void onTileChanged(RenderSource&, const OverscaledTileID&) override;
     void onTileError(RenderSource&, const OverscaledTileID&, std::exception_ptr) override;
+
+    // ImageManagerObserver implementation
+    void onStyleImageMissing(const std::string&) override;
 
     void updateFadingTiles();
 

--- a/src/mbgl/style/image_impl.hpp
+++ b/src/mbgl/style/image_impl.hpp
@@ -34,5 +34,6 @@ enum class ImageType : bool {
 using ImageMap = std::unordered_map<std::string, Immutable<style::Image::Impl>>;
 using ImageDependencies = std::unordered_map<std::string, ImageType>;
 using ImageRequestPair = std::pair<ImageDependencies, uint64_t>;
+using ImageVersionMap = std::unordered_map<std::string, uint32_t>;
 
 } // namespace mbgl

--- a/src/mbgl/style/style_impl.cpp
+++ b/src/mbgl/style/style_impl.cpp
@@ -254,6 +254,7 @@ bool Style::Impl::isLoaded() const {
 void Style::Impl::addImage(std::unique_ptr<style::Image> image) {
     images.remove(image->getID()); // We permit using addImage to update.
     images.add(std::move(image));
+    observer->onUpdate();
 }
 
 void Style::Impl::removeImage(const std::string& id) {

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -156,7 +156,7 @@ void GeometryTile::getGlyphs(GlyphDependencies glyphDependencies) {
     glyphManager.getGlyphs(*this, std::move(glyphDependencies));
 }
 
-void GeometryTile::onImagesAvailable(ImageMap images, ImageMap patterns, std::unordered_map<std::string, uint32_t> versionMap, uint64_t imageCorrelationID) {
+void GeometryTile::onImagesAvailable(ImageMap images, ImageMap patterns, ImageVersionMap versionMap, uint64_t imageCorrelationID) {
     worker.self().invoke(&GeometryTileWorker::onImagesAvailable, std::move(images), std::move(patterns), std::move(versionMap), imageCorrelationID);
 }
 

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -156,8 +156,8 @@ void GeometryTile::getGlyphs(GlyphDependencies glyphDependencies) {
     glyphManager.getGlyphs(*this, std::move(glyphDependencies));
 }
 
-void GeometryTile::onImagesAvailable(ImageMap images, ImageMap patterns, uint64_t imageCorrelationID) {
-    worker.self().invoke(&GeometryTileWorker::onImagesAvailable, std::move(images), std::move(patterns), imageCorrelationID);
+void GeometryTile::onImagesAvailable(ImageMap images, ImageMap patterns, std::unordered_map<std::string, uint32_t> versionMap, uint64_t imageCorrelationID) {
+    worker.self().invoke(&GeometryTileWorker::onImagesAvailable, std::move(images), std::move(patterns), std::move(versionMap), imageCorrelationID);
 }
 
 void GeometryTile::getImages(ImageRequestPair pair) {
@@ -191,6 +191,10 @@ void GeometryTile::upload(gfx::Context& context) {
     if (iconAtlas.image.valid()) {
         iconAtlasTexture = context.createTexture(iconAtlas.image);
         iconAtlas.image = {};
+    }
+
+    if (iconAtlasTexture) {
+        iconAtlas.patchUpdatedImages(context, *iconAtlasTexture, imageManager);
     }
 }
 

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -37,7 +37,7 @@ public:
     void setShowCollisionBoxes(const bool showCollisionBoxes) override;
 
     void onGlyphsAvailable(GlyphMap) override;
-    void onImagesAvailable(ImageMap, ImageMap, uint64_t imageCorrelationID) override;
+    void onImagesAvailable(ImageMap, ImageMap, std::unordered_map<std::string,uint32_t> versionMap, uint64_t imageCorrelationID) override;
     
     void getGlyphs(GlyphDependencies);
     void getImages(ImageRequestPair);

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -37,7 +37,7 @@ public:
     void setShowCollisionBoxes(const bool showCollisionBoxes) override;
 
     void onGlyphsAvailable(GlyphMap) override;
-    void onImagesAvailable(ImageMap, ImageMap, std::unordered_map<std::string,uint32_t> versionMap, uint64_t imageCorrelationID) override;
+    void onImagesAvailable(ImageMap, ImageMap, ImageVersionMap versionMap, uint64_t imageCorrelationID) override;
     
     void getGlyphs(GlyphDependencies);
     void getImages(ImageRequestPair);

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -278,12 +278,13 @@ void GeometryTileWorker::onGlyphsAvailable(GlyphMap newGlyphMap) {
     symbolDependenciesChanged();
 }
 
-void GeometryTileWorker::onImagesAvailable(ImageMap newIconMap, ImageMap newPatternMap, uint64_t imageCorrelationID_) {
+void GeometryTileWorker::onImagesAvailable(ImageMap newIconMap, ImageMap newPatternMap, std::unordered_map<std::string, uint32_t> newVersionMap, uint64_t imageCorrelationID_) {
     if (imageCorrelationID != imageCorrelationID_) {
         return; // Ignore outdated image request replies.
     }
     imageMap = std::move(newIconMap);
     patternMap = std::move(newPatternMap);
+    versionMap = std::move(newVersionMap);
     pendingImageDependencies.clear();
     symbolDependenciesChanged();
 }
@@ -441,7 +442,7 @@ void GeometryTileWorker::finalizeLayout() {
     
     MBGL_TIMING_START(watch)
     optional<AlphaImage> glyphAtlasImage;
-    ImageAtlas iconAtlas = makeImageAtlas(imageMap, patternMap);
+    ImageAtlas iconAtlas = makeImageAtlas(imageMap, patternMap, versionMap);
     if (!layouts.empty()) {
         GlyphAtlas glyphAtlas = makeGlyphAtlas(glyphMap);
         glyphAtlasImage = std::move(glyphAtlas.image);

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -278,7 +278,7 @@ void GeometryTileWorker::onGlyphsAvailable(GlyphMap newGlyphMap) {
     symbolDependenciesChanged();
 }
 
-void GeometryTileWorker::onImagesAvailable(ImageMap newIconMap, ImageMap newPatternMap, std::unordered_map<std::string, uint32_t> newVersionMap, uint64_t imageCorrelationID_) {
+void GeometryTileWorker::onImagesAvailable(ImageMap newIconMap, ImageMap newPatternMap, ImageVersionMap newVersionMap, uint64_t imageCorrelationID_) {
     if (imageCorrelationID != imageCorrelationID_) {
         return; // Ignore outdated image request replies.
     }

--- a/src/mbgl/tile/geometry_tile_worker.hpp
+++ b/src/mbgl/tile/geometry_tile_worker.hpp
@@ -44,7 +44,7 @@ public:
     void setShowCollisionBoxes(bool showCollisionBoxes_, uint64_t correlationID_);
     
     void onGlyphsAvailable(GlyphMap glyphs);
-    void onImagesAvailable(ImageMap icons, ImageMap patterns, uint64_t imageCorrelationID);
+    void onImagesAvailable(ImageMap icons, ImageMap patterns, std::unordered_map<std::string, uint32_t> versionMap, uint64_t imageCorrelationID);
 
 private:
     void coalesced();
@@ -96,6 +96,7 @@ private:
     GlyphMap glyphMap;
     ImageMap imageMap;
     ImageMap patternMap;
+    std::unordered_map<std::string, uint32_t> versionMap;
     
     bool showCollisionBoxes;
     bool firstLoad = true;

--- a/src/mbgl/tile/geometry_tile_worker.hpp
+++ b/src/mbgl/tile/geometry_tile_worker.hpp
@@ -44,7 +44,7 @@ public:
     void setShowCollisionBoxes(bool showCollisionBoxes_, uint64_t correlationID_);
     
     void onGlyphsAvailable(GlyphMap glyphs);
-    void onImagesAvailable(ImageMap icons, ImageMap patterns, std::unordered_map<std::string, uint32_t> versionMap, uint64_t imageCorrelationID);
+    void onImagesAvailable(ImageMap icons, ImageMap patterns, ImageVersionMap versionMap, uint64_t imageCorrelationID);
 
 private:
     void coalesced();
@@ -96,7 +96,7 @@ private:
     GlyphMap glyphMap;
     ImageMap imageMap;
     ImageMap patternMap;
-    std::unordered_map<std::string, uint32_t> versionMap;
+    ImageVersionMap versionMap;
     
     bool showCollisionBoxes;
     bool firstLoad = true;

--- a/test/renderer/image_manager.test.cpp
+++ b/test/renderer/image_manager.test.cpp
@@ -3,6 +3,7 @@
 #include <mbgl/test/stub_style_observer.hpp>
 
 #include <mbgl/renderer/image_manager.hpp>
+#include <mbgl/renderer/image_manager_observer.hpp>
 #include <mbgl/sprite/sprite_parser.hpp>
 #include <mbgl/style/image_impl.hpp>
 #include <mbgl/util/io.hpp>
@@ -107,11 +108,11 @@ TEST(ImageManager, RemoveReleasesBinPackRect) {
 
 class StubImageRequestor : public ImageRequestor {
 public:
-    void onImagesAvailable(ImageMap icons, ImageMap patterns, uint64_t imageCorrelationID_) final {
-        if (imagesAvailable && imageCorrelationID == imageCorrelationID_) imagesAvailable(icons, patterns);
+    void onImagesAvailable(ImageMap icons, ImageMap patterns, std::unordered_map<std::string, uint32_t> versionMap, uint64_t imageCorrelationID_) final {
+        if (imagesAvailable && imageCorrelationID == imageCorrelationID_) imagesAvailable(icons, patterns, versionMap);
     }
 
-    std::function<void (ImageMap, ImageMap)> imagesAvailable;
+    std::function<void (ImageMap, ImageMap, std::unordered_map<std::string, uint32_t>)> imagesAvailable;
     uint64_t imageCorrelationID = 0;
 };
 
@@ -120,7 +121,10 @@ TEST(ImageManager, NotifiesRequestorWhenSpriteIsLoaded) {
     StubImageRequestor requestor;
     bool notified = false;
 
-    requestor.imagesAvailable = [&] (ImageMap, ImageMap) {
+    ImageManagerObserver observer;
+    imageManager.setObserver(&observer);
+
+    requestor.imagesAvailable = [&] (ImageMap, ImageMap, std::unordered_map<std::string, uint32_t>) {
         notified = true;
     };
 
@@ -131,6 +135,8 @@ TEST(ImageManager, NotifiesRequestorWhenSpriteIsLoaded) {
     ASSERT_FALSE(notified);
 
     imageManager.setLoaded(true);
+    ASSERT_FALSE(notified);
+    imageManager.imagesAdded();
     ASSERT_TRUE(notified);
 }
 
@@ -139,7 +145,7 @@ TEST(ImageManager, NotifiesRequestorImmediatelyIfDependenciesAreSatisfied) {
     StubImageRequestor requestor;
     bool notified = false;
 
-    requestor.imagesAvailable = [&] (ImageMap, ImageMap) {
+    requestor.imagesAvailable = [&] (ImageMap, ImageMap, std::unordered_map<std::string, uint32_t>) {
         notified = true;
     };
 

--- a/test/renderer/image_manager.test.cpp
+++ b/test/renderer/image_manager.test.cpp
@@ -136,7 +136,7 @@ TEST(ImageManager, NotifiesRequestorWhenSpriteIsLoaded) {
 
     imageManager.setLoaded(true);
     ASSERT_FALSE(notified);
-    imageManager.imagesAdded();
+    imageManager.notifyIfMissingImageAdded();
     ASSERT_TRUE(notified);
 }
 


### PR DESCRIPTION
ports https://github.com/mapbox/mapbox-gl-js/pull/7987

This adds a `onStyleImageMissing` method to `MapObserver` that gets called with the id of each missing icon. Missing images can be provided by calling `Style#addImage` from within the listener. If an image is not added it is skipped and tile parsing continues.

```cpp
virtual void onStyleImageMissing(const std::string&)
```

how the listener is called:

- `ImageManager` calls `Renderer::Impl#onStyleImageMissing` with id and callback
- `Renderer::Impl#onStyleImageMissing` calls the observer set by `RendererFrontend` with id and callback
- the platform's `RendererFrontend` calls the `Map::Impl#onStyleImageMissing` on the map thread with id and callback
- `Map::Impl#onStyleImageMissing` calls `MapObserver#onStyleImageMissing` with *just the id* and then calls the callback after the listener has been called

`RendererFrontend` is responsible for invoking the callback on the render thread.

---

TODO
- [ ] fix build
- [ ] Android bindings
- [ ] iOS bindings
- [ ] avoid unecessary tile reparsing when images are added (-js doesn't do this, I need to look into why this is necessary and how we can work around it)