### PR TITLE
Support running instrumented tests on more devices

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/integration/BaseIntegrationTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/integration/BaseIntegrationTest.kt
@@ -2,10 +2,12 @@ package com.mapbox.mapboxsdk.integration
 
 import android.content.Context
 import android.content.Intent
-import android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP
+import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.support.test.InstrumentationRegistry
 import android.support.test.uiautomator.*
 import org.junit.Before
+
+const val TIMEOUT_UI_SEARCH_WAIT = 5000L
 
 abstract class BaseIntegrationTest {
 
@@ -17,12 +19,18 @@ abstract class BaseIntegrationTest {
   }
 }
 
+/**
+ * Launches an activity with FLAG_ACTIVITY_NEW_TASK.
+ * <p>
+ * To resume an activity, you need to add a single instance launchmode to your manifest configuration.
+ * <p>
+ */
 fun UiDevice.launchActivity(context: Context, clazz: Class<*>) {
   val applicationPackage = InstrumentationRegistry.getTargetContext().packageName
   val intent = Intent(context, clazz)
-  intent.addFlags(FLAG_ACTIVITY_SINGLE_TOP)
+  intent.addFlags(FLAG_ACTIVITY_NEW_TASK)
   InstrumentationRegistry.getContext().startActivity(intent)
-  wait(Until.hasObject(By.pkg(applicationPackage).depth(0)), 5000)
+  wait(Until.hasObject(By.pkg(applicationPackage).depth(0)), TIMEOUT_UI_SEARCH_WAIT)
 }
 
 fun UiDevice.scrollRecyclerViewTo(recycleItem: String) {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/integration/FragmentBackStackTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/integration/FragmentBackStackTest.kt
@@ -3,9 +3,14 @@ package com.mapbox.mapboxsdk.integration
 import android.support.test.filters.LargeTest
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
+import android.support.test.uiautomator.By
+import android.support.test.uiautomator.SearchCondition
 import android.support.test.uiautomator.UiSelector
+import android.support.test.uiautomator.Until
+import com.mapbox.mapboxsdk.testapp.R
 import com.mapbox.mapboxsdk.testapp.activity.fragment.FragmentBackStackActivity
 import com.mapbox.mapboxsdk.testapp.activity.maplayout.SimpleMapActivity
+import kotlinx.android.synthetic.main.activity_backstack_fragment.view.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -22,7 +27,7 @@ class FragmentBackStackTest : BaseIntegrationTest() {
 
   @Test
   @LargeTest
-  fun backPressedOnBackStackResumed(){
+  fun backPressedOnBackStackResumed() {
     device.waitForIdle()
     clickReplaceFragmentButton()
     device.pressHome()
@@ -32,12 +37,16 @@ class FragmentBackStackTest : BaseIntegrationTest() {
     device.waitForIdle()
   }
 
-  private fun clickReplaceFragmentButton(){
-    device.findObject(UiSelector().text("REPLACE WITH EMPTY FRAGMENT")).click()
+  private fun clickReplaceFragmentButton() {
+    device.findObject(UiSelector().description(textDescription)).click()
   }
 
-  private fun backPressBackStack(){
+  private fun backPressBackStack() {
     device.pressBack() // pops fragment, showing map
     device.pressBack() // finish activity
+  }
+
+  private companion object {
+    const val textDescription = "btn_change_fragment"
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/integration/GLSurfaceViewReopenTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/integration/GLSurfaceViewReopenTest.kt
@@ -24,6 +24,7 @@ class GLSurfaceViewReopenTest : BaseIntegrationTest() {
     device.waitForIdle()
     device.pressHome()
     device.waitForIdle()
-    device.launchActivity(activityRule.activity.applicationContext, SimpleMapActivity::class.java)
+    device.launchActivity(activityRule.activity, SimpleMapActivity::class.java)
+    device.waitForIdle()
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/integration/TextureViewReopenTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/integration/TextureViewReopenTest.kt
@@ -27,6 +27,7 @@ class TextureViewReopenTest : BaseIntegrationTest() {
     device.waitForIdle()
     device.pressHome()
     device.waitForIdle()
-    device.launchActivity(activityRule.activity.applicationContext, TextureViewDebugModeActivity::class.java)
+    device.launchActivity(activityRule.activity, TextureViewDebugModeActivity::class.java)
+    device.waitForIdle()
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/maps/widgets/AttributionTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/maps/widgets/AttributionTest.java
@@ -3,6 +3,7 @@ package com.mapbox.mapboxsdk.testapp.maps.widgets;
 import android.app.Instrumentation;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.support.test.espresso.UiController;
 import android.support.test.espresso.ViewAction;
 import android.support.test.espresso.intent.Intents;
@@ -31,12 +32,14 @@ import static android.support.test.espresso.intent.Intents.intended;
 import static android.support.test.espresso.intent.Intents.intending;
 import static android.support.test.espresso.intent.matcher.IntentMatchers.hasAction;
 import static android.support.test.espresso.intent.matcher.IntentMatchers.hasData;
+import static android.support.test.espresso.matcher.RootMatchers.isDialog;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.anything;
 import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assume.assumeTrue;
 
 public class AttributionTest extends EspressoTest {
 
@@ -126,15 +129,20 @@ public class AttributionTest extends EspressoTest {
 
   @Test
   public void testTelemetryDialog() {
+    assumeTrue(
+      "Can only run on API Level 23 or newer because of instability",
+      Build.VERSION.SDK_INT >= 23
+    );
+
     validateTestSetup();
 
     // click on View to open dialog
     onView(withId(R.id.attributionView)).perform(click());
-    onView(withText(R.string.mapbox_attributionsDialogTitle)).check(matches(isDisplayed()));
+    onView(withText(R.string.mapbox_attributionsDialogTitle)).inRoot(isDialog()).check(matches(isDisplayed()));
 
     // click on item to open second dialog
-    onView(withText(R.string.mapbox_telemetrySettings)).perform(click());
-    onView(withText(R.string.mapbox_attributionTelemetryTitle)).check(matches(isDisplayed()));
+    onView(withText(R.string.mapbox_telemetrySettings)).inRoot(isDialog()).perform(click());
+    onView(withText(R.string.mapbox_attributionTelemetryTitle)).inRoot(isDialog()).check(matches(isDisplayed()));
   }
 
   @After

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -173,7 +173,8 @@
         <activity
                 android:name=".activity.fragment.FragmentBackStackActivity"
                 android:description="@string/description_map_fragment_backstack"
-                android:label="@string/activity_map_fragment_backstack">
+                android:label="@string/activity_map_fragment_backstack"
+                android:launchMode="singleInstance">
             <meta-data
                     android:name="@string/category"
                     android:value="@string/category_integration" />
@@ -407,7 +408,8 @@
         <activity
             android:name=".activity.maplayout.SimpleMapActivity"
             android:description="@string/description_simple_map"
-            android:label="@string/activity_simple_map">
+            android:label="@string/activity_simple_map"
+            android:launchMode="singleInstance">
             <meta-data
                 android:name="@string/category"
                 android:value="@string/category_basic" />
@@ -720,7 +722,8 @@
         <activity
             android:name=".activity.textureview.TextureViewDebugModeActivity"
             android:description="@string/description_textureview_debug"
-            android:label="@string/activity_textureview_debug">
+            android:label="@string/activity_textureview_debug"
+            android:launchMode="singleInstance">
             <meta-data
                 android:name="@string/category"
                 android:value="@string/category_basic" />

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_backstack_fragment.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_backstack_fragment.xml
@@ -10,6 +10,7 @@
     <Button android:layout_width="match_parent"
             android:layout_height="58dp"
             android:id="@+id/button"
+            android:contentDescription="btn_change_fragment"
             android:text="Replace with empty fragment"/>
 
 </FrameLayout>


### PR DESCRIPTION
Been running large pool tests on firebase to make sure our testsuite supports all devices:
 - refactor to launchmode single instance as this doesn't work for pre 6 and post 9 android os versions
 - ignore telemetry dialog test, after multiple iterations, not able to make this run reliably on all devices
 - use description selector instead of text as some devices make text uppercase when used in a button