### PR TITLE
[core] Traverse expression tree when checking for property overrides

### DIFF
--- a/src/mbgl/style/expression/value.cpp
+++ b/src/mbgl/style/expression/value.cpp
@@ -166,6 +166,11 @@ mbgl::Value ValueConverter<mbgl::Value>::fromExpressionValue(const Value& value)
                     }
                     options.emplace("text-font", std::vector<mbgl::Value>{ std::string("literal"), fontStack });
                 }
+
+                if (section.textColor) {
+                    options.emplace("text-color", fromExpressionValue(*section.textColor));
+                }
+
                 serialized.push_back(options);
             }
             return serialized;


### PR DESCRIPTION
Before this change, symbol layer was only checking whether top level 'text-field' layout property expression is FormatExpression and if it has paint property overrides. This change takes into account that 'text-field' might have nested expressions, thus, requires traversal over child expressions.

Fixes: #14254
Render test: https://github.com/mapbox/mapbox-gl-js/pull/8093