### PR TITLE
(Android) Added getter for the field isComponentInitialized

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
@@ -1509,4 +1509,13 @@ public final class LocationComponent {
       throw new LocationComponentNotInitializedException();
     }
   }
+
+  /**
+   * Returns whether the location component is activated.
+   *
+   * @return true if the component is activated, false otherwise
+   */
+  public boolean isLocationComponentActivated() {
+    return isComponentInitialized;
+  }
 }


### PR DESCRIPTION
This change is meanly because of https://github.com/mapbox/mapbox-gl-native/pull/14068 which is now throwing an exception if the component is not activated yet. This getter should help users to identify if the component is not activated to prevent usage and therefore exceptions.

To fix that issue in 7.3.0 (called in onDestroy of my fragment):
```kotlin
mapView?.getMapAsync { mapboxMap ->
         try {
             mapboxMap.locationComponent.isLocationComponentEnabled = false
         } catch (e: Exception) {
             //do nothing - this needed because mapbox is throwing exception if the location
             //is not activated yet. But currently there is no getter to identify this state.
         }
}
```

In my case I don't want to request the location permission when the app is starting. Without permission I cannot activate the locationComponent but I want to always disable the location component when destroying the fragment. Due to the missing state I can only try to catch the exception which seems not like the right approach at the moment.