### PR TITLE
[ios] Enable/disable presentsWithTransaction when moving to/from a window

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -24,6 +24,8 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Added `MGLOrnamentPosition` enum and margin properties to customize scale bar, compass, logo, and attribution position within the map view. ([#13911](https://github.com/mapbox/mapbox-gl-native/pull/13911))
 * Added an `MGLMapView.prefetchesTiles` property to configure lower-resolution tile prefetching behavior. ([#14031](https://github.com/mapbox/mapbox-gl-native/pull/14031))
+* Fixed a performance issue seen on iOS 12.2, when an `MGLMapView` is repeatedly removed and re-added in a view hierarchy. ([#14264](https://github.com/mapbox/mapbox-gl-native/pull/14264))
+
 
 ## 4.9.0 - February 27, 2019
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1266,6 +1266,8 @@ public:
     // Just performing a sleepGL/wakeGL pair isn't sufficient - in this case
     // we can still get errors when calling bindDrawable. Here we completely
     // recreate the GLKView
+    
+    [self.userLocationAnnotationView removeFromSuperview];
     [_glView removeFromSuperview];
     
     _glView = [[GLKView alloc] initWithFrame:self.bounds context:_context];
@@ -1276,10 +1278,17 @@ public:
     _glView.contentScaleFactor = [UIScreen instancesRespondToSelector:@selector(nativeScale)] ? [[UIScreen mainScreen] nativeScale] : [[UIScreen mainScreen] scale];
     _glView.layer.opaque = _opaque;
     _glView.delegate = self;
-    
+
     [self insertSubview:_glView atIndex:0];
     _glView.contentMode = UIViewContentModeCenter;
 
+    if (self.annotationContainerView)
+    {
+        [_glView insertSubview:self.annotationContainerView atIndex:0];
+    }
+    
+    [self updateUserLocationAnnotationView];
+    
     // Do not bind...yet
     
     if (self.window) {


### PR DESCRIPTION
This is a potential work around for for the slowdown reported in https://github.com/mapbox/mapbox-gl-native/issues/14232. This may not address the associated crash.

As @jmkiley [notes in that issue](https://github.com/mapbox/mapbox-gl-native/issues/14232#issuecomment-477804091) the cause appears to be the introduction of `CAEAGLLayer.presentsWithTransaction` in https://github.com/mapbox/mapbox-gl-native/pull/12895 to synchronize OpenGL and UIKit views.

/cc @kkaefer 