### PR TITLE
Remove support v7

### DIFF
--- a/platform/android/LICENSE.md
+++ b/platform/android/LICENSE.md
@@ -1,11 +1,5 @@
 <!-- This file was generated. Use `make android-license` to update. -->  
 ## Additional Mapbox GL licenses  
-Mapbox GL uses portions of the Android AppCompat Library v7.  
-URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
-License: [The Apache Software License](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
 Mapbox GL uses portions of the Android Arch-Common.  
 URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -42,12 +36,6 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support AnimatedVectorDrawable.  
-URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
-License: [The Apache Software License](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
 Mapbox GL uses portions of the Android Support Library Annotations.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -73,12 +61,6 @@ License: [The Apache Software License](http://www.apache.org/licenses/LICENSE-2.
 ===========================================================================
 
 Mapbox GL uses portions of the Android Support Library fragment.  
-URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
-License: [The Apache Software License](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
-Mapbox GL uses portions of the Android Support VectorDrawable.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License](http://www.apache.org/licenses/LICENSE-2.0.txt)
 

--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     api dependenciesList.mapboxJavaGeoJSON
     api dependenciesList.mapboxAndroidGestures
     implementation dependenciesList.mapboxJavaTurf
-    implementation dependenciesList.supportAppcompatV7
     implementation dependenciesList.supportAnnotations
     implementation dependenciesList.supportFragmentV4
     implementation dependenciesList.okhttp3

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/CompassView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/CompassView.java
@@ -7,10 +7,10 @@ import android.support.annotation.Nullable;
 import android.support.v4.view.ViewCompat;
 import android.support.v4.view.ViewPropertyAnimatorCompat;
 import android.support.v4.view.ViewPropertyAnimatorListenerAdapter;
-import android.support.v7.widget.AppCompatImageView;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 
@@ -23,7 +23,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
  * use {@link com.mapbox.mapboxsdk.maps.UiSettings}.
  * </p>
  */
-public final class CompassView extends AppCompatImageView implements Runnable {
+public final class CompassView extends ImageView implements Runnable {
 
   public static final long TIME_WAIT_IDLE = 500;
   public static final long TIME_MAP_NORTH_ANIMATION = 150;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/BitmapUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/BitmapUtils.java
@@ -13,7 +13,6 @@ import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
-import android.support.v7.content.res.AppCompatResources;
 import android.view.View;
 
 import java.io.ByteArrayOutputStream;
@@ -152,7 +151,7 @@ public class BitmapUtils {
   @Nullable
   public static Drawable getDrawableFromRes(@NonNull Context context, @DrawableRes int drawableRes,
                                             @Nullable @ColorInt Integer tintColor) {
-    Drawable drawable = AppCompatResources.getDrawable(context, drawableRes);
+    Drawable drawable = context.getResources().getDrawable(drawableRes);
     if (drawable == null) {
       return null;
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_internal.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_internal.xml
@@ -7,14 +7,14 @@
         android:layout_height="wrap_content"
         android:contentDescription="@string/mapbox_compassContentDescription"/>
 
-    <android.support.v7.widget.AppCompatImageView
+    <ImageView
         android:visibility="gone"
         android:id="@+id/logoView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:contentDescription="@null"/>
 
-    <android.support.v7.widget.AppCompatImageView
+    <ImageView
         android:visibility="gone"
         android:id="@+id/attributionView"
         android:layout_width="wrap_content"


### PR DESCRIPTION
Remove support v7 library. Tested on Redmi2(Android 4.4), no issue found for compassView and attribution.