### PR TITLE
[linux] Add a new run step to build the offline CLI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -850,6 +850,9 @@ jobs:
       - build-test
       - save-dependencies
       - run-unit-tests
+      - run:
+          name: Build offline CLI
+          command: make offline
 
 # ------------------------------------------------------------------------------
   linux-gcc5-debug-coverage:


### PR DESCRIPTION
I noticed today that I wasn't able to build the offline CLI (`make offline`) on the `release-liquid` branch (separate ticket coming for the specific error). It seems that we currently don't have any CI rules testing that this script correctly builds. This PR adds a new build step to one of the Linux jobs to fix that.

