### PR TITLE
[core] Remove RenderLinePaintProperties

### DIFF
--- a/src/mbgl/programs/line_program.cpp
+++ b/src/mbgl/programs/line_program.cpp
@@ -19,7 +19,7 @@ using namespace style;
 static_assert(sizeof(LineLayoutVertex) == 12, "expected LineLayoutVertex size");
 
 template <class Values, class...Args>
-Values makeValues(const RenderLinePaintProperties::PossiblyEvaluated& properties,
+Values makeValues(const style::LinePaintProperties::PossiblyEvaluated& properties,
                   const RenderTile& tile,
                   const TransformState& state,
                   const std::array<float, 2>& pixelsToGLUnits,
@@ -38,7 +38,7 @@ Values makeValues(const RenderLinePaintProperties::PossiblyEvaluated& properties
 }
 
 LineProgram::LayoutUniformValues
-LineProgram::layoutUniformValues(const RenderLinePaintProperties::PossiblyEvaluated& properties,
+LineProgram::layoutUniformValues(const style::LinePaintProperties::PossiblyEvaluated& properties,
                                  const RenderTile& tile,
                                  const TransformState& state,
                                  const std::array<float, 2>& pixelsToGLUnits) {
@@ -51,7 +51,7 @@ LineProgram::layoutUniformValues(const RenderLinePaintProperties::PossiblyEvalua
 }
 
 LineSDFProgram::LayoutUniformValues
-LineSDFProgram::layoutUniformValues(const RenderLinePaintProperties::PossiblyEvaluated& properties,
+LineSDFProgram::layoutUniformValues(const style::LinePaintProperties::PossiblyEvaluated& properties,
                                     float pixelRatio,
                                     const RenderTile& tile,
                                     const TransformState& state,
@@ -88,7 +88,7 @@ LineSDFProgram::layoutUniformValues(const RenderLinePaintProperties::PossiblyEva
 }
 
 LinePatternProgram::LayoutUniformValues LinePatternProgram::layoutUniformValues(
-    const RenderLinePaintProperties::PossiblyEvaluated& properties,
+    const style::LinePaintProperties::PossiblyEvaluated& properties,
     const RenderTile& tile,
     const TransformState& state,
     const std::array<float, 2>& pixelsToGLUnits,
@@ -110,7 +110,7 @@ LinePatternProgram::LayoutUniformValues LinePatternProgram::layoutUniformValues(
 }
 
 LineGradientProgram::LayoutUniformValues LineGradientProgram::layoutUniformValues(
-    const RenderLinePaintProperties::PossiblyEvaluated& properties,
+    const style::LinePaintProperties::PossiblyEvaluated& properties,
     const RenderTile& tile,
     const TransformState& state,
     const std::array<float, 2>& pixelsToGLUnits) {

--- a/src/mbgl/programs/line_program.hpp
+++ b/src/mbgl/programs/line_program.hpp
@@ -39,7 +39,7 @@ class LineProgram : public Program<
         uniforms::ratio,
         uniforms::gl_units_to_pixels>,
     TypeList<>,
-    RenderLinePaintProperties>
+    style::LinePaintProperties>
 {
 public:
     using Program::Program;
@@ -90,7 +90,7 @@ public:
     static const int8_t extrudeScale = 63;
 
     static LayoutUniformValues
-    layoutUniformValues(const RenderLinePaintProperties::PossiblyEvaluated&,
+    layoutUniformValues(const style::LinePaintProperties::PossiblyEvaluated&,
                         const RenderTile&,
                         const TransformState&,
                         const std::array<float, 2>& pixelsToGLUnits);
@@ -109,13 +109,13 @@ class LinePatternProgram : public Program<
         uniforms::fade>,
     TypeList<
         textures::image>,
-    RenderLinePaintProperties>
+    style::LinePaintProperties>
 {
 public:
     using Program::Program;
 
     static LayoutUniformValues
-    layoutUniformValues(const RenderLinePaintProperties::PossiblyEvaluated&,
+    layoutUniformValues(const style::LinePaintProperties::PossiblyEvaluated&,
                         const RenderTile&,
                         const TransformState&,
                         const std::array<float, 2>& pixelsToGLUnits,
@@ -140,13 +140,13 @@ class LineSDFProgram : public Program<
         uniforms::sdfgamma>,
     TypeList<
         textures::image>,
-    RenderLinePaintProperties>
+    style::LinePaintProperties>
 {
 public:
     using Program::Program;
 
     static LayoutUniformValues
-    layoutUniformValues(const RenderLinePaintProperties::PossiblyEvaluated&,
+    layoutUniformValues(const style::LinePaintProperties::PossiblyEvaluated&,
                         float pixelRatio,
                         const RenderTile&,
                         const TransformState&,
@@ -167,13 +167,13 @@ class LineGradientProgram : public Program<
         uniforms::gl_units_to_pixels>,
     TypeList<
         textures::image>,
-    RenderLinePaintProperties>
+    style::LinePaintProperties>
 {
 public:
     using Program::Program;
 
     static LayoutUniformValues
-    layoutUniformValues(const RenderLinePaintProperties::PossiblyEvaluated&,
+    layoutUniformValues(const style::LinePaintProperties::PossiblyEvaluated&,
                         const RenderTile&,
                         const TransformState&,
                         const std::array<float, 2>& pixelsToGLUnits);

--- a/src/mbgl/renderer/buckets/line_bucket.cpp
+++ b/src/mbgl/renderer/buckets/line_bucket.cpp
@@ -11,7 +11,7 @@ namespace mbgl {
 using namespace style;
 
 LineBucket::LineBucket(const style::LineLayoutProperties::PossiblyEvaluated layout_,
-                       std::map<std::string, RenderLinePaintProperties::PossiblyEvaluated> layerPaintProperties,
+                       std::map<std::string, style::LinePaintProperties::PossiblyEvaluated> layerPaintProperties,
                        const float zoom_,
                        const uint32_t overscaling_)
     : layout(layout_),

--- a/src/mbgl/renderer/buckets/line_bucket.hpp
+++ b/src/mbgl/renderer/buckets/line_bucket.hpp
@@ -20,7 +20,7 @@ public:
 
     // These aliases are used by the PatternLayout template
     using RenderLayerType = RenderLineLayer;
-    using PossiblyEvaluatedPaintProperties = RenderLinePaintProperties::PossiblyEvaluated;
+    using PossiblyEvaluatedPaintProperties = style::LinePaintProperties::PossiblyEvaluated;
     using PossiblyEvaluatedLayoutProperties = style::LineLayoutProperties::PossiblyEvaluated;
 
     LineBucket(const PossiblyEvaluatedLayoutProperties layout,

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -33,10 +33,7 @@ void RenderLineLayer::transition(const TransitionParameters& parameters) {
 }
 
 void RenderLineLayer::evaluate(const PropertyEvaluationParameters& parameters) {
-    style::Properties<LineFloorwidth>::Unevaluated extra(unevaluated.get<style::LineWidth>());
-    evaluated = RenderLinePaintProperties::PossiblyEvaluated(
-        unevaluated.evaluate(parameters).concat(extra.evaluate(parameters)));
-
+    evaluated = unevaluated.evaluate(parameters);
     crossfade = parameters.getCrossfadeParameters();
 
     passes = (evaluated.get<style::LineOpacity>().constantOr(1.0) > 0

--- a/src/mbgl/renderer/layers/render_line_layer.hpp
+++ b/src/mbgl/renderer/layers/render_line_layer.hpp
@@ -10,15 +10,6 @@
 
 namespace mbgl {
 
-struct LineFloorwidth : style::DataDrivenPaintProperty<float, attributes::floorwidth, uniforms::floorwidth> {
-    using EvaluatorType = DataDrivenPropertyEvaluator<float, true>;
-    static float defaultValue() { return 1.0; }
-};
-
-class RenderLinePaintProperties : public style::ConcatenateProperties<
-    style::LinePaintProperties,
-    style::Properties<LineFloorwidth>> {};
-
 class RenderLineLayer: public RenderLayer {
 public:
     using StyleLayerImpl = style::LineLayer::Impl;
@@ -44,7 +35,7 @@ public:
 
     // Paint properties
     style::LinePaintProperties::Unevaluated unevaluated;
-    RenderLinePaintProperties::PossiblyEvaluated evaluated;
+    style::LinePaintProperties::PossiblyEvaluated evaluated;
 
     const style::LineLayer::Impl& impl() const;
 

--- a/src/mbgl/style/layers/layer.cpp.ejs
+++ b/src/mbgl/style/layers/layer.cpp.ejs
@@ -153,6 +153,9 @@ void <%- camelize(type) %>Layer::set<%- camelize(property.name) %>(<%- propertyV
         return;
     auto impl_ = mutableImpl();
     impl_->paint.template get<<%- camelize(property.name) %>>().value = value;
+<% if (property.name === 'line-width') { -%>
+    impl_->paint.template get<LineFloorWidth>().value = value;
+<% } -%>
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }

--- a/src/mbgl/style/layers/layer_properties.hpp.ejs
+++ b/src/mbgl/style/layers/layer_properties.hpp.ejs
@@ -37,6 +37,13 @@ struct <%- camelize(property.name) %> : <%- paintPropertyType(property, type) %>
     template<typename T> static bool hasOverride(const T& t) { return !!t.<%- camelizeWithLeadingLowercase(property.name) %>; };
 <% } -%>
 };
+<% if (property.name === 'line-width') { -%>
+
+struct LineFloorWidth : DataDrivenPaintProperty<float, attributes::floorwidth, uniforms::floorwidth> {
+    using EvaluatorType = DataDrivenPropertyEvaluator<float, true>;
+    static float defaultValue() { return 1.0f; }
+};
+<% } -%>
 <%   } -%>
 
 <% } -%>
@@ -52,6 +59,9 @@ class <%- camelize(type) %>LayoutProperties : public Properties<
 class <%- camelize(type) %>PaintProperties : public Properties<
 <% for (const property of paintProperties.slice(0, -1)) { -%>
     <%- camelize(property.name) %>,
+<% if (property.name === 'line-width') { -%>
+    LineFloorWidth,
+<% } -%>
 <% } -%>
     <%- camelize(paintProperties.slice(-1)[0].name) %>
 > {};

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -248,6 +248,7 @@ void LineLayer::setLineWidth(PropertyValue<float> value) {
         return;
     auto impl_ = mutableImpl();
     impl_->paint.template get<LineWidth>().value = value;
+    impl_->paint.template get<LineFloorWidth>().value = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }

--- a/src/mbgl/style/layers/line_layer_properties.hpp
+++ b/src/mbgl/style/layers/line_layer_properties.hpp
@@ -52,6 +52,11 @@ struct LineWidth : DataDrivenPaintProperty<float, attributes::width, uniforms::w
     static float defaultValue() { return 1; }
 };
 
+struct LineFloorWidth : DataDrivenPaintProperty<float, attributes::floorwidth, uniforms::floorwidth> {
+    using EvaluatorType = DataDrivenPropertyEvaluator<float, true>;
+    static float defaultValue() { return 1.0f; }
+};
+
 struct LineGapWidth : DataDrivenPaintProperty<float, attributes::gapwidth, uniforms::gapwidth> {
     static float defaultValue() { return 0; }
 };
@@ -88,6 +93,7 @@ class LinePaintProperties : public Properties<
     LineTranslate,
     LineTranslateAnchor,
     LineWidth,
+    LineFloorWidth,
     LineGapWidth,
     LineOffset,
     LineBlur,


### PR DESCRIPTION
This patch removes the `RenderLinePaintProperties` by
making `LineFloorwidth` part of the `style::LinePaintProperties`.

It normalizes paint properties evaluation for the line layer.

Tag https://github.com/mapbox/mapbox-gl-native/issues/13812