### PR TITLE
[glfw] Remove unused map object

### DIFF
--- a/platform/glfw/main.cpp
+++ b/platform/glfw/main.cpp
@@ -111,8 +111,6 @@ int main(int argc, char *argv[]) {
     mbgl::ThreadPool threadPool(4);
     GLFWRendererFrontend rendererFrontend { std::make_unique<mbgl::Renderer>(backend, view->getPixelRatio(), threadPool), backend };
 
-    mbgl::Map map1(rendererFrontend, backend, threadPool,mbgl::MapOptions(), resourceOptions);
-
     mbgl::Map map(rendererFrontend, backend, threadPool,
                   mbgl::MapOptions().withSize(view->getSize()).withPixelRatio(view->getPixelRatio()), resourceOptions);
 


### PR DESCRIPTION
Remove unused code that was accidentally added in 7af00a4.