### PR TITLE
Use a valid gestures focal point when resetting a manager

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationCameraController.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationCameraController.java
@@ -77,9 +77,11 @@ final class LocationCameraController {
   void initializeOptions(LocationComponentOptions options) {
     this.options = options;
     if (options.trackingGesturesManagement()) {
-      mapboxMap.setGesturesManager(internalGesturesManager, true, true);
+      if (mapboxMap.getGesturesManager() != internalGesturesManager) {
+        mapboxMap.setGesturesManager(internalGesturesManager, true, true);
+      }
       adjustGesturesThresholds();
-    } else {
+    } else if (mapboxMap.getGesturesManager() != initialGesturesManager) {
       mapboxMap.setGesturesManager(initialGesturesManager, true, true);
     }
   }

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationCameraControllerTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationCameraControllerTest.java
@@ -408,6 +408,7 @@ public class LocationCameraControllerTest {
     MapboxMap mapboxMap = mock(MapboxMap.class);
     AndroidGesturesManager initialGesturesManager = mock(AndroidGesturesManager.class);
     AndroidGesturesManager internalGesturesManager = mock(AndroidGesturesManager.class);
+    when(mapboxMap.getGesturesManager()).thenReturn(initialGesturesManager);
     LocationCameraController camera = buildCamera(mapboxMap, initialGesturesManager, internalGesturesManager);
     LocationComponentOptions options = mock(LocationComponentOptions.class);
     when(options.trackingGesturesManagement()).thenReturn(true);
@@ -421,12 +422,41 @@ public class LocationCameraControllerTest {
     MapboxMap mapboxMap = mock(MapboxMap.class);
     AndroidGesturesManager initialGesturesManager = mock(AndroidGesturesManager.class);
     AndroidGesturesManager internalGesturesManager = mock(AndroidGesturesManager.class);
+    when(mapboxMap.getGesturesManager()).thenReturn(internalGesturesManager);
     LocationCameraController camera = buildCamera(mapboxMap, initialGesturesManager, internalGesturesManager);
     LocationComponentOptions options = mock(LocationComponentOptions.class);
     when(options.trackingGesturesManagement()).thenReturn(false);
     camera.initializeOptions(options);
 
     verify(mapboxMap).setGesturesManager(initialGesturesManager, true, true);
+  }
+
+  @Test
+  public void gesturesManagement_optionNotChangedInitial() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    AndroidGesturesManager initialGesturesManager = mock(AndroidGesturesManager.class);
+    AndroidGesturesManager internalGesturesManager = mock(AndroidGesturesManager.class);
+    when(mapboxMap.getGesturesManager()).thenReturn(initialGesturesManager);
+    LocationCameraController camera = buildCamera(mapboxMap, initialGesturesManager, internalGesturesManager);
+    LocationComponentOptions options = mock(LocationComponentOptions.class);
+    when(options.trackingGesturesManagement()).thenReturn(false);
+    camera.initializeOptions(options);
+
+    verify(mapboxMap, times(0)).setGesturesManager(initialGesturesManager, true, true);
+  }
+
+  @Test
+  public void gesturesManagement_optionNotChangedInternal() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    AndroidGesturesManager initialGesturesManager = mock(AndroidGesturesManager.class);
+    AndroidGesturesManager internalGesturesManager = mock(AndroidGesturesManager.class);
+    when(mapboxMap.getGesturesManager()).thenReturn(internalGesturesManager);
+    LocationCameraController camera = buildCamera(mapboxMap, initialGesturesManager, internalGesturesManager);
+    LocationComponentOptions options = mock(LocationComponentOptions.class);
+    when(options.trackingGesturesManagement()).thenReturn(true);
+    camera.initializeOptions(options);
+
+    verify(mapboxMap, times(0)).setGesturesManager(internalGesturesManager, true, true);
   }
 
   @Test

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/GestureDetectorActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/GestureDetectorActivity.java
@@ -267,7 +267,18 @@ public class GestureDetectorActivity extends AppCompatActivity {
     if (enabled) {
       focalPointLatLng = new LatLng(51.50325, -0.12968);
       marker = mapboxMap.addMarker(new MarkerOptions().position(focalPointLatLng));
-      mapboxMap.easeCamera(CameraUpdateFactory.newLatLngZoom(focalPointLatLng, 16));
+      mapboxMap.easeCamera(CameraUpdateFactory.newLatLngZoom(focalPointLatLng, 16),
+        new MapboxMap.CancelableCallback() {
+          @Override
+          public void onCancel() {
+            recalculateFocalPoint();
+          }
+
+          @Override
+          public void onFinish() {
+            recalculateFocalPoint();
+          }
+        });
     } else {
       if (marker != null) {
         mapboxMap.removeMarker(marker);


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/14246.

The issue was twofold:
- we were resetting the gestures manager, and because of that recreating the internal listeners, with each component's options update
- we kept the scale/rotation focal points in a listeners' fields and re-validating them only during the start or progress of a gesture, however, when we've reset the gestures manager right between gesture's progress and finish methods, the focal point wouldn't have been initialized and resulted in an `NPE`