### PR TITLE
Clear camera callbacks' message queue when the map is destroyed

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
@@ -142,6 +142,14 @@ class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, M
     }
   }
 
+  void onDestroy() {
+    handler.removeCallbacksAndMessages(null);
+    onCameraMoveStarted.clear();
+    onCameraMoveCanceled.clear();
+    onCameraMove.clear();
+    onCameraIdle.clear();
+  }
+
   private static class CameraChangeHandler extends Handler {
 
     private WeakReference<CameraChangeDispatcher> dispatcherWeakReference;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -176,6 +176,7 @@ public final class MapboxMap {
     if (style != null) {
       style.clear();
     }
+    cameraChangeDispatcher.onDestroy();
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/MapboxMapTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/MapboxMapTest.kt
@@ -15,31 +15,33 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class MapboxMapTest {
 
-    private lateinit var mapboxMap: MapboxMap
+  private lateinit var mapboxMap: MapboxMap
 
-    private lateinit var nativeMapView: NativeMapView
+  private lateinit var nativeMapView: NativeMapView
 
-    private lateinit var transform: Transform
+  private lateinit var transform: Transform
 
-    @Before
-    fun setup() {
-        val cameraChangeDispatcher = spyk<CameraChangeDispatcher>()
-        nativeMapView = mockk(relaxed = true)
-        transform = mockk(relaxed = true)
-        mapboxMap = MapboxMap(nativeMapView, transform, mockk(relaxed = true), null, null, cameraChangeDispatcher)
-        every { nativeMapView.isDestroyed } returns false
-        every { nativeMapView.nativePtr } returns 5
-        mapboxMap.injectLocationComponent(spyk())
-        mapboxMap.setStyle(Style.MAPBOX_STREETS)
-        mapboxMap.onFinishLoadingStyle()
-    }
+  private lateinit var cameraChangeDispatcher: CameraChangeDispatcher
 
-    @Test
-    fun testTransitionOptions() {
-        val expected = TransitionOptions(100, 200)
-        mapboxMap.style?.transition = expected
-        verify { nativeMapView.transitionOptions = expected }
-    }
+  @Before
+  fun setup() {
+    cameraChangeDispatcher = spyk()
+    nativeMapView = mockk(relaxed = true)
+    transform = mockk(relaxed = true)
+    mapboxMap = MapboxMap(nativeMapView, transform, mockk(relaxed = true), null, null, cameraChangeDispatcher)
+    every { nativeMapView.isDestroyed } returns false
+    every { nativeMapView.nativePtr } returns 5
+    mapboxMap.injectLocationComponent(spyk())
+    mapboxMap.setStyle(Style.MAPBOX_STREETS)
+    mapboxMap.onFinishLoadingStyle()
+  }
+
+  @Test
+  fun testTransitionOptions() {
+    val expected = TransitionOptions(100, 200)
+    mapboxMap.style?.transition = expected
+    verify { nativeMapView.transitionOptions = expected }
+  }
 
   @Test
   fun testMoveCamera() {
@@ -51,57 +53,63 @@ class MapboxMapTest {
     verify { transform.moveCamera(mapboxMap, update, callback) }
   }
 
-    @Test
-    fun testMinZoom() {
-        mapboxMap.setMinZoomPreference(10.0)
-        verify { transform.minZoom = 10.0 }
-    }
+  @Test
+  fun testMinZoom() {
+    mapboxMap.setMinZoomPreference(10.0)
+    verify { transform.minZoom = 10.0 }
+  }
 
-    @Test
-    fun testMaxZoom() {
-        mapboxMap.setMaxZoomPreference(10.0)
-        verify { transform.maxZoom = 10.0 }
-    }
+  @Test
+  fun testMaxZoom() {
+    mapboxMap.setMaxZoomPreference(10.0)
+    verify { transform.maxZoom = 10.0 }
+  }
 
-    @Test
-    fun testFpsListener() {
-        val fpsChangedListener = mockk<MapboxMap.OnFpsChangedListener>()
-        mapboxMap.onFpsChangedListener = fpsChangedListener
-        assertEquals("Listener should match", fpsChangedListener, mapboxMap.onFpsChangedListener)
-    }
+  @Test
+  fun testFpsListener() {
+    val fpsChangedListener = mockk<MapboxMap.OnFpsChangedListener>()
+    mapboxMap.onFpsChangedListener = fpsChangedListener
+    assertEquals("Listener should match", fpsChangedListener, mapboxMap.onFpsChangedListener)
+  }
 
-    @Test
-    fun testTilePrefetch() {
-        mapboxMap.prefetchesTiles = true
-        verify { nativeMapView.prefetchTiles = true }
-    }
+  @Test
+  fun testTilePrefetch() {
+    mapboxMap.prefetchesTiles = true
+    verify { nativeMapView.prefetchTiles = true }
+  }
 
-    @Test
-    fun testCameraForLatLngBounds() {
-        val bounds = LatLngBounds.Builder().include(LatLng()).include(LatLng(1.0, 1.0)).build()
-        mapboxMap.setLatLngBoundsForCameraTarget(bounds)
-        verify { nativeMapView.setLatLngBounds(bounds) }
-    }
+  @Test
+  fun testCameraForLatLngBounds() {
+    val bounds = LatLngBounds.Builder().include(LatLng()).include(LatLng(1.0, 1.0)).build()
+    mapboxMap.setLatLngBoundsForCameraTarget(bounds)
+    verify { nativeMapView.setLatLngBounds(bounds) }
+  }
 
-    @Test(expected = IllegalArgumentException::class)
-    fun testAnimateCameraChecksDurationPositive() {
-        mapboxMap.animateCamera(CameraUpdateFactory.newLatLng(LatLng(30.0, 30.0)), 0, null)
-    }
+  @Test(expected = IllegalArgumentException::class)
+  fun testAnimateCameraChecksDurationPositive() {
+    mapboxMap.animateCamera(CameraUpdateFactory.newLatLng(LatLng(30.0, 30.0)), 0, null)
+  }
 
-    @Test(expected = IllegalArgumentException::class)
-    fun testEaseCameraChecksDurationPositive() {
-        mapboxMap.easeCamera(CameraUpdateFactory.newLatLng(LatLng(30.0, 30.0)), 0, null)
-    }
+  @Test(expected = IllegalArgumentException::class)
+  fun testEaseCameraChecksDurationPositive() {
+    mapboxMap.easeCamera(CameraUpdateFactory.newLatLng(LatLng(30.0, 30.0)), 0, null)
+  }
 
-    @Test
-    fun testGetNativeMapPtr() {
-        assertEquals(5, mapboxMap.nativeMapPtr)
-    }
+  @Test
+  fun testGetNativeMapPtr() {
+    assertEquals(5, mapboxMap.nativeMapPtr)
+  }
 
   @Test
   fun testNativeMapIsNotCalledOnStateSave() {
     clearMocks(nativeMapView)
     mapboxMap.onSaveInstanceState(mockk(relaxed = true))
     verify { nativeMapView wasNot Called }
+  }
+
+  @Test
+  fun testCameraChangeDispatcherCleared() {
+    mapboxMap.onDestroy()
+    verify { cameraChangeDispatcher.onDestroy() }
   }
 }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/14020.

We are dispatching our own camera callbacks when using Android Animators, and even though we are canceling those correctly, we can run into a situation where there are already callbacks scheduled when the map is being destroyed.

This PR also fixes the formatting of the `MapboxMapTest.kt` file.