### PR TITLE
Only perform thread checking in debug builds

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
-
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.exceptions.MapboxConfigurationException;
 import com.mapbox.mapboxsdk.log.Logger;
@@ -49,7 +48,8 @@ public final class Mapbox {
   @UiThread
   @NonNull
   public static synchronized Mapbox getInstance(@NonNull Context context, @Nullable String accessToken) {
-    ThreadUtils.checkThread("Mapbox");
+    ThreadUtils.init(context);
+    ThreadUtils.checkThread(TAG);
     if (INSTANCE == null) {
       Context appContext = context.getApplicationContext();
       FileSource.initializeFileDirsPaths(appContext);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
@@ -18,16 +18,15 @@ import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
-
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.attribution.AttributionLayout;
 import com.mapbox.mapboxsdk.attribution.AttributionMeasure;
 import com.mapbox.mapboxsdk.attribution.AttributionParser;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
-import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
 import com.mapbox.mapboxsdk.log.Logger;
+import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.maps.TelemetryDefinition;
 import com.mapbox.mapboxsdk.storage.FileSource;
 import com.mapbox.mapboxsdk.utils.ThreadUtils;
@@ -560,7 +559,7 @@ public class MapSnapshotter {
   }
 
   private void checkThread() {
-    ThreadUtils.checkThread("MapSnapshotter");
+    ThreadUtils.checkThread(TAG);
   }
 
   protected void reset() {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
@@ -194,7 +194,7 @@ public class FileSource {
    */
   @UiThread
   public static void initializeFileDirsPaths(Context context) {
-    ThreadUtils.checkThread("FileSource");
+    ThreadUtils.checkThread(TAG);
     lockPathLoaders();
     if (resourcesCachePath == null || internalCachePath == null) {
       new FileDirsPathsTask().execute(context);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Layer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Layer.java
@@ -3,7 +3,6 @@ package com.mapbox.mapboxsdk.style.layers;
 import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-
 import com.google.gson.JsonElement;
 import com.mapbox.mapboxsdk.LibraryLoader;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
@@ -14,6 +13,8 @@ import com.mapbox.mapboxsdk.utils.ThreadUtils;
  * Base class for the different Layer types
  */
 public abstract class Layer {
+
+  private final static String TAG = "Mbgl-Layer";
 
   @Keep
   private long nativePtr;
@@ -39,7 +40,7 @@ public abstract class Layer {
    * Validates if layer interaction is happening on the UI thread
    */
   protected void checkThread() {
-    ThreadUtils.checkThread("Layer");
+    ThreadUtils.checkThread(TAG);
   }
 
   public void setProperties(@NonNull PropertyValue<?>... properties) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/light/Light.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/light/Light.java
@@ -20,6 +20,8 @@ import com.mapbox.mapboxsdk.utils.ThreadUtils;
 @UiThread
 public class Light {
 
+  private static final String TAG = "Mbgl-Light";
+
   @Keep
   private long nativePtr;
 
@@ -192,7 +194,7 @@ public class Light {
   }
 
   private void checkThread(){
-    ThreadUtils.checkThread("Light");
+    ThreadUtils.checkThread(TAG);
   }
 
   @Keep

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/light/light.java.ejs
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/light/light.java.ejs
@@ -24,6 +24,8 @@ import com.mapbox.mapboxsdk.utils.ThreadUtils;
 @UiThread
 public class Light {
 
+  private static final String TAG = "Mbgl-Light";
+
   @Keep
   private long nativePtr;
 
@@ -121,7 +123,7 @@ public class Light {
 <% } -%>
 
   private void checkThread(){
-    ThreadUtils.checkThread("Light");
+    ThreadUtils.checkThread(TAG);
   }
 
 <% for (const property of properties) { -%>

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/Source.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/Source.java
@@ -1,9 +1,7 @@
 package com.mapbox.mapboxsdk.style.sources;
 
 import android.support.annotation.Keep;
-
 import android.support.annotation.NonNull;
-
 import com.mapbox.mapboxsdk.LibraryLoader;
 import com.mapbox.mapboxsdk.utils.ThreadUtils;
 
@@ -11,6 +9,8 @@ import com.mapbox.mapboxsdk.utils.ThreadUtils;
  * Base Peer class for sources. see source.hpp for the other half of the peer.
  */
 public abstract class Source {
+
+  private static final String TAG = "Mbgl-Source";
 
   @Keep
   private long nativePtr;
@@ -40,7 +40,7 @@ public abstract class Source {
    * Validates if source interaction is happening on the UI thread
    */
   protected void checkThread() {
-    ThreadUtils.checkThread("Source");
+    ThreadUtils.checkThread(TAG);
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/ThreadUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/ThreadUtils.java
@@ -1,17 +1,48 @@
 package com.mapbox.mapboxsdk.utils;
 
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
 import android.os.Looper;
+import android.support.annotation.NonNull;
 import com.mapbox.mapboxsdk.exceptions.CalledFromWorkerThreadException;
 
+/**
+ * Utility class to verify if execution is running on the main thread.
+ * <p>
+ * Verification only runs for debug builds.
+ * </p>
+ */
 public class ThreadUtils {
 
+  private static Boolean debug;
+
   /**
-   * Validates if execution is occuring on the main thread.
+   * Initialises the thread utils, verifies debug state of the consuming app.
+   *
+   * @param context Context hosting the Mapbox Maps SDK for Android
+   * @return this
    */
-  public static void checkThread(String origin) {
-    if (Looper.myLooper() != Looper.getMainLooper()) {
-      throw new CalledFromWorkerThreadException(
-        String.format("%s interactions should happen on the UI thread.",origin));
+  public static ThreadUtils init(@NonNull Context context) {
+    debug = (0 != (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE));
+    return null;
+  }
+
+  /**
+   * Validates if execution is running on the main thread.
+   *
+   * @param origin  the origin of the execution
+   */
+  public static void checkThread(@NonNull String origin) {
+    if (debug == null) {
+      throw new IllegalStateException("ThreadUtils isn't correctly initialised");
+    }
+
+    if (debug) {
+      if (Looper.myLooper() != Looper.getMainLooper()) {
+        throw new CalledFromWorkerThreadException(
+          String.format("%s interactions should happen on the UI thread.", origin)
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #14287, possible solution alternatively the static lazy initialization can be replaced if we can ask users to provide their BuildConfig.DEBUG value through Mapbox.getInstance. 