### PR TITLE
[core] Simplify render symbol layer initialization

### DIFF
--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -470,12 +470,9 @@ style::SymbolPropertyValues RenderSymbolLayer::textPropertyValues(const style::S
     };
 }
 
-RenderLayer::RenderTiles RenderSymbolLayer::filterRenderTiles(RenderTiles tiles) const {
+void RenderSymbolLayer::setRenderTiles(RenderTiles tiles, const TransformState& state) {
     auto filterFn = [](auto& tile){ return !tile.tile.isRenderable(); };
-    return RenderLayer::filterRenderTiles(std::move(tiles), filterFn);
-}
-
-void RenderSymbolLayer::sortRenderTiles(const TransformState& state) {
+    renderTiles = RenderLayer::filterRenderTiles(std::move(tiles), filterFn);
     // Sort symbol tiles in opposite y position, so tiles with overlapping symbols are drawn
     // on top of each other, with lower symbols being drawn on top of higher symbols.
     std::sort(renderTiles.begin(), renderTiles.end(), [&state](const auto& a, const auto& b) {

--- a/src/mbgl/renderer/layers/render_symbol_layer.hpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.hpp
@@ -57,7 +57,7 @@ class BucketParameters;
 class SymbolLayout;
 class GeometryTileLayer;
 
-class RenderSymbolLayer: public RenderLayer, public RenderLayerSymbolInterface {
+class RenderSymbolLayer final: public RenderLayer, public RenderLayerSymbolInterface {
 public:
     RenderSymbolLayer(Immutable<style::SymbolLayer::Impl>);
     ~RenderSymbolLayer() final = default;
@@ -67,6 +67,7 @@ public:
     bool hasTransition() const override;
     bool hasCrossfade() const override;
     void render(PaintParameters&, RenderSource*) override;
+    void setRenderTiles(RenderTiles, const TransformState&) override;
 
     static style::IconPaintProperties::PossiblyEvaluated iconPaintProperties(const style::SymbolPaintProperties::PossiblyEvaluated&);
     static style::TextPaintProperties::PossiblyEvaluated textPaintProperties(const style::SymbolPaintProperties::PossiblyEvaluated&);
@@ -91,8 +92,6 @@ protected:
                                                           const style::SymbolLayoutProperties::PossiblyEvaluated&);
     static style::SymbolPropertyValues textPropertyValues(const style::SymbolPaintProperties::PossiblyEvaluated&,
                                                           const style::SymbolLayoutProperties::PossiblyEvaluated&);
-    RenderTiles filterRenderTiles(RenderTiles) const final;
-    void sortRenderTiles(const TransformState&) final;
     void updateBucketPaintProperties(Bucket*) const final;
 };
 

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -33,18 +33,9 @@ bool RenderLayer::needsRendering(float zoom) const {
            && baseImpl->maxZoom >= zoom;
 }
 
-void RenderLayer::setRenderTiles(RenderTiles tiles, const TransformState& state) {
-    renderTiles = filterRenderTiles(std::move(tiles));
-    sortRenderTiles(state);
-}
-
-RenderLayer::RenderTiles RenderLayer::filterRenderTiles(RenderTiles tiles) const {
+void RenderLayer::setRenderTiles(RenderTiles tiles, const TransformState&) {
     auto filterFn = [](auto& tile){ return !tile.tile.isRenderable() || tile.tile.holdForFade(); };
-    return filterRenderTiles(std::move(tiles), filterFn);
-}
-
-void RenderLayer::sortRenderTiles(const TransformState&) {
-    // no-op
+    renderTiles = filterRenderTiles(std::move(tiles), filterFn);
 }
 
 const RenderLayerSymbolInterface* RenderLayer::getSymbolInterface() const {

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -63,7 +63,7 @@ public:
             const mat4&) const { return false; };
 
     using RenderTiles = std::vector<std::reference_wrapper<RenderTile>>;
-    void setRenderTiles(RenderTiles, const TransformState&);
+    virtual void setRenderTiles(RenderTiles, const TransformState&);
 
     // Private implementation
     Immutable<style::Layer::Impl> baseImpl;
@@ -84,9 +84,6 @@ protected:
     // in the console to inform the developer.
     void checkRenderability(const PaintParameters&, uint32_t activeBindingCount);
 
-    // Code specific to RenderTiles sorting / filtering
-    virtual RenderTiles filterRenderTiles(RenderTiles) const;
-    virtual void sortRenderTiles(const TransformState&);
     // For some layers, we want Buckets to cache their corresponding paint properties, so that outdated buckets (and
     // the cached paint properties) can be still in use while the tile is loading new buckets (which will
     // correpond to the current paint properties of the layer).


### PR DESCRIPTION
Obviate few extra calls from the renderer impl parts initializing symbol layers.