### PR TITLE
Disable leak canary during instrumentation tests

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion androidVersions.targetSdkVersion
         versionCode 13
         versionName "6.0.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "com.mapbox.mapboxsdk.InstrumentationRunner"
     }
 
     compileOptions {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/InstrumentationApplication.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/InstrumentationApplication.kt
@@ -1,0 +1,10 @@
+package com.mapbox.mapboxsdk
+
+import com.mapbox.mapboxsdk.testapp.MapboxApplication
+
+class InstrumentationApplication : MapboxApplication() {
+  override fun initializeLeakCanary(): Boolean {
+    // do not initialize leak canary during instrumentation tests
+    return true
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/InstrumentationRunner.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/InstrumentationRunner.kt
@@ -1,0 +1,11 @@
+package com.mapbox.mapboxsdk
+
+import android.app.Application
+import android.content.Context
+import android.support.test.runner.AndroidJUnitRunner
+
+class InstrumentationRunner : AndroidJUnitRunner() {
+  override fun newApplication(cl: ClassLoader?, className: String?, context: Context?): Application {
+    return super.newApplication(cl, InstrumentationApplication::class.java.name, context)
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/MapboxApplication.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/MapboxApplication.java
@@ -40,7 +40,7 @@ public class MapboxApplication extends Application {
     initializeMapbox();
   }
 
-  private boolean initializeLeakCanary() {
+  protected boolean initializeLeakCanary() {
     if (LeakCanary.isInAnalyzerProcess(this)) {
       // This process is dedicated to LeakCanary for heap analysis.
       // You should not init your app in this process.


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/14237.

The common factor in the https://github.com/mapbox/mapbox-gl-native/issues/14237 was leak canary freezing the app to collect the data, which caused the test to extend the "wait-for-idle" timeout and assert, even though the map was blank.

I wasn't able to reproduce the issue locally, so we can reopen https://github.com/mapbox/mapbox-gl-native/issues/14237 if this PR doesn't fix it. In any case, we should disable leak canary during instrumentation tests anyway.