### PR TITLE
[core] Adds target branch parameter to clang-tools.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,6 @@ tidy: compdb
 
 .PHONY: check
 check: compdb
-	@echo TARGET_BRANCH=$(TARGET_BRANCH)
 	scripts/clang-tools.sh $(MACOS_COMPDB_PATH) $(TARGET_BRANCH) --diff
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 export BUILDTYPE ?= Debug
 export IS_LOCAL_DEVELOPMENT ?= true
 export WITH_CXX11ABI ?= $(shell scripts/check-cxx11abi.sh)
+export TARGET_BRANCH ?= master
+
 
 ifeq ($(BUILDTYPE), Release)
 else ifeq ($(BUILDTYPE), RelWithDebInfo)
@@ -191,12 +193,12 @@ compdb: $(BUILD_DEPS) $(TEST_DEPS) $(MACOS_COMPDB_PATH)/Makefile
 
 .PHONY: tidy
 tidy: compdb
-	scripts/clang-tools.sh $(MACOS_COMPDB_PATH)
+	scripts/clang-tools.sh $(MACOS_COMPDB_PATH) $(TARGET_BRANCH)
 
 .PHONY: check
 check: compdb
-	scripts/clang-tools.sh $(MACOS_COMPDB_PATH) --diff
-
+	@echo TARGET_BRANCH=$(TARGET_BRANCH)
+	scripts/clang-tools.sh $(MACOS_COMPDB_PATH) $(TARGET_BRANCH) --diff
 endif
 
 #### iOS targets ##############################################################
@@ -383,11 +385,11 @@ compdb: $(LINUX_BUILD)
 
 .PHONY: tidy
 tidy: compdb
-	scripts/clang-tools.sh $(LINUX_OUTPUT_PATH)
+	scripts/clang-tools.sh $(LINUX_OUTPUT_PATH) $(TARGET_BRANCH)
 
 .PHONY: check
 check: compdb
-	scripts/clang-tools.sh $(LINUX_OUTPUT_PATH) --diff
+	scripts/clang-tools.sh $(LINUX_OUTPUT_PATH) $(TARGET_BRANCH) --diff
 
 endif
 

--- a/circle.yml
+++ b/circle.yml
@@ -503,7 +503,7 @@ jobs:
           command: make compdb
       - run:
           name: Run Clang checks
-          command: make check
+          command: make check TARGET_BRANCH=${CIRCLE_TARGET_BRANCH:master}
           no_output_timeout: 20m
       - save-dependencies: { ccache: false }
 

--- a/scripts/clang-tools.sh
+++ b/scripts/clang-tools.sh
@@ -33,7 +33,7 @@ function run_clang_tidy() {
 }
 
 function run_clang_tidy_diff() {
-    OUTPUT=$(git diff origin/master --src-prefix=${CDUP} --dst-prefix=${CDUP} | \
+    OUTPUT=$(git diff origin/$2 --src-prefix=${CDUP} --dst-prefix=${CDUP} | \
                 ${CLANG_TIDY_PREFIX}/share/clang-tidy-diff.py \
                     -clang-tidy-binary ${CLANG_TIDY} \
                     2>/dev/null)
@@ -45,7 +45,7 @@ function run_clang_tidy_diff() {
 
 function run_clang_format() {
     echo "Running clang-format on $0..."
-    DIFF_FILES=$(git diff origin/master --name-only *cpp)
+    DIFF_FILES=$(git diff origin/$2 --name-only *cpp)
     echo "${DIFF_FILES}" | xargs -I{} -P ${JOBS} bash -c 'run_clang_format' {}
     ${CLANG_FORMAT} -i ${CDUP}/$0 || exit 1
 }
@@ -54,7 +54,7 @@ export -f run_clang_tidy run_clang_tidy_diff run_clang_format
 
 echo "Running Clang checks... (this might take a while)"
 
-if [[ -n $2 ]] && [[ $2 == "--diff" ]]; then
+if [[ -n $3 ]] && [[ $3 == "--diff" ]]; then
     run_clang_tidy_diff $@
     # XXX disabled until we run clang-format over the entire codebase.
     #run_clang_format $@


### PR DESCRIPTION
This PR changes `clang-tools.sh` so that it no longer always compares against `master`. The script will use `CIRCLE_TARGET_BRANCH`, if it is available (which is exported from https://github.com/mapbox/mapbox-gl-native/blob/master/scripts/environment.js). h/t @friedbunny 

This should help reduce `clang-tidy` fails on release branches.

A variant of this has been tested on the `release-liquid` branch.