### PR TITLE
[ios] Enable/disable presentsWithTransaction to address #14232

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -24,6 +24,8 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Added `MGLOrnamentPosition` enum and margin properties to customize scale bar, compass, logo, and attribution position within the map view. ([#13911](https://github.com/mapbox/mapbox-gl-native/pull/13911))
 * Added an `MGLMapView.prefetchesTiles` property to configure lower-resolution tile prefetching behavior. ([#14031](https://github.com/mapbox/mapbox-gl-native/pull/14031))
+* Fixed a performance issue seen on iOS 12.2, when an `MGLMapView` is repeatedly removed and re-added in a view hierarchy. ([#14264](https://github.com/mapbox/mapbox-gl-native/pull/14264))
+
 
 ## 4.9.0 - February 27, 2019
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -24,7 +24,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Added `MGLOrnamentPosition` enum and margin properties to customize scale bar, compass, logo, and attribution position within the map view. ([#13911](https://github.com/mapbox/mapbox-gl-native/pull/13911))
 * Added an `MGLMapView.prefetchesTiles` property to configure lower-resolution tile prefetching behavior. ([#14031](https://github.com/mapbox/mapbox-gl-native/pull/14031))
-* Fixed a performance issue seen on iOS 12.2, when an `MGLMapView` is repeatedly removed and re-added in a view hierarchy. ([#14264](https://github.com/mapbox/mapbox-gl-native/pull/14264))
+* Speculatively fixed a performance issue seen on iOS 12.2, when an `MGLMapView` is repeatedly removed and re-added in a view hierarchy. ([#14264](https://github.com/mapbox/mapbox-gl-native/pull/14264))
 
 
 ## 4.9.0 - February 27, 2019

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1263,6 +1263,7 @@ public:
     [self updateDisplayLinkPreferredFramesPerSecond];
 }
 
+#ifdef MGL_RECREATE_GL_IN_AN_EMERGENCY
 // See https://github.com/mapbox/mapbox-gl-native/issues/14232
 - (void)emergencyRecreateGL {
     MGLLogError(@"Rendering took too long - creating GL views");
@@ -1309,6 +1310,7 @@ public:
         MGLLogDebug(@"No window - skipping wakeGL");
     }
 }
+#endif
 
 - (void)willMoveToWindow:(UIWindow *)newWindow {
     [super willMoveToWindow:newWindow];

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -690,6 +690,20 @@ public:
              static_cast<uint32_t>(self.glView.drawableHeight) };
 }
 
++ (GLKView *)GLKViewWithFrame:(CGRect)frame context:(EAGLContext *)context opaque:(BOOL)opaque
+{
+    GLKView *glView = [[GLKView alloc] initWithFrame:frame context:context];
+    glView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    glView.enableSetNeedsDisplay = NO;
+    glView.drawableStencilFormat = GLKViewDrawableStencilFormat8;
+    glView.drawableDepthFormat = GLKViewDrawableDepthFormat16;
+    glView.contentScaleFactor = [UIScreen instancesRespondToSelector:@selector(nativeScale)] ? [[UIScreen mainScreen] nativeScale] : [[UIScreen mainScreen] scale];
+    glView.layer.opaque = opaque;
+    glView.contentMode = UIViewContentModeCenter;
+    
+    return glView;
+}
+
 - (void)createGLView
 {
     if (_context) return;
@@ -701,13 +715,7 @@ public:
 
     // create GL view
     //
-    _glView = [[GLKView alloc] initWithFrame:self.bounds context:_context];
-    _glView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    _glView.enableSetNeedsDisplay = NO;
-    _glView.drawableStencilFormat = GLKViewDrawableStencilFormat8;
-    _glView.drawableDepthFormat = GLKViewDrawableDepthFormat16;
-    _glView.contentScaleFactor = [UIScreen instancesRespondToSelector:@selector(nativeScale)] ? [[UIScreen mainScreen] nativeScale] : [[UIScreen mainScreen] scale];
-    _glView.layer.opaque = _opaque;
+    _glView = [MGLMapView GLKViewWithFrame:self.bounds context:_context opaque:_opaque];
     _glView.delegate = self;
 
     CAEAGLLayer *eaglLayer = MGL_OBJC_DYNAMIC_CAST(_glView.layer, CAEAGLLayer);
@@ -715,7 +723,6 @@ public:
     
     [_glView bindDrawable];
     [self insertSubview:_glView atIndex:0];
-    _glView.contentMode = UIViewContentModeCenter;
 }
 
 - (UIImage *)compassImage
@@ -1300,17 +1307,10 @@ public:
     [self.userLocationAnnotationView removeFromSuperview];
     [_glView removeFromSuperview];
     
-    _glView = [[GLKView alloc] initWithFrame:self.bounds context:_context];
-    _glView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    _glView.enableSetNeedsDisplay = NO;
-    _glView.drawableStencilFormat = GLKViewDrawableStencilFormat8;
-    _glView.drawableDepthFormat = GLKViewDrawableDepthFormat16;
-    _glView.contentScaleFactor = [UIScreen instancesRespondToSelector:@selector(nativeScale)] ? [[UIScreen mainScreen] nativeScale] : [[UIScreen mainScreen] scale];
-    _glView.layer.opaque = _opaque;
+    _glView = [MGLMapView GLKViewWithFrame:self.bounds context:_context opaque:_opaque];
     _glView.delegate = self;
 
     [self insertSubview:_glView atIndex:0];
-    _glView.contentMode = UIViewContentModeCenter;
 
     if (self.annotationContainerView)
     {

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -158,7 +158,7 @@ const CGSize MGLAnnotationAccessibilityElementMinimumSize = CGSizeMake(10, 10);
 
 /// The number of view annotations (excluding the user location view) that must
 /// be descendents of `MGLMapView` before presentsWithTransaction is enabled.
-static const NSUInteger MGLPresentsWithTransactionAnnotationCount = 3;
+static const NSUInteger MGLPresentsWithTransactionAnnotationCount = 0;
 
 /// An indication that the requested annotation was not found or is nonexistent.
 enum { MGLAnnotationTagNotFound = UINT32_MAX };

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1267,6 +1267,22 @@ public:
     [self updateDisplayLinkPreferredFramesPerSecond];
 }
 
+- (void)setEnablePresentsWithTransaction:(BOOL)enablePresentsWithTransaction
+{
+    if (_enablePresentsWithTransaction == enablePresentsWithTransaction)
+    {
+        return;
+    }
+    
+    _enablePresentsWithTransaction = enablePresentsWithTransaction;
+    
+    // If the map is visible, change the layer property too
+    if (self.window) {
+        CAEAGLLayer *eaglLayer = MGL_OBJC_DYNAMIC_CAST(_glView.layer, CAEAGLLayer);
+        eaglLayer.presentsWithTransaction = enablePresentsWithTransaction;
+    }
+}
+
 #ifdef MGL_RECREATE_GL_IN_AN_EMERGENCY
 // See https://github.com/mapbox/mapbox-gl-native/issues/14232
 - (void)emergencyRecreateGL {


### PR DESCRIPTION
Moved from: https://github.com/mapbox/mapbox-gl-native/pull/14264

This is a potential work around for for the slowdown reported in https://github.com/mapbox/mapbox-gl-native/issues/14232. This may not address the associated crash.

As @jmkiley [notes in that issue](https://github.com/mapbox/mapbox-gl-native/issues/14232#issuecomment-477804091) the cause appears to be the introduction of `CAEAGLLayer.presentsWithTransaction` in https://github.com/mapbox/mapbox-gl-native/pull/12895 to synchronize OpenGL and UIKit views.