### PR TITLE
[core] Refactor renderer implementation

### DIFF
--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -165,7 +165,6 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
     imageManager->notifyIfMissingImageAdded();
     imageManager->setLoaded(updateParameters.spriteLoaded);
 
-
     const LayerDifference layerDiff = diffLayers(layerImpls, updateParameters.layers);
     layerImpls = updateParameters.layers;
 
@@ -191,15 +190,14 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
     // Update layers for class and zoom changes.
     for (const auto& entry : renderLayers) {
         RenderLayer& layer = *entry.second;
-        const bool layerAdded = layerDiff.added.count(entry.first);
-        const bool layerChanged = layerDiff.changed.count(entry.first);
+        const bool layerAddedOrChanged = layerDiff.added.count(entry.first) || layerDiff.changed.count(entry.first);
 
-        if (layerAdded || layerChanged) {
+        if (layerAddedOrChanged) {
             layer.transition(transitionParameters);
             layer.update();
         }
 
-        if (layerAdded || layerChanged || zoomChanged || layer.hasTransition() || layer.hasCrossfade()) {
+        if (layerAddedOrChanged || zoomChanged || layer.hasTransition() || layer.hasCrossfade()) {
             layer.evaluate(evaluationParameters);
         }
     }

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -93,12 +93,13 @@ void GeometryTile::setLayers(const std::vector<Immutable<Layer::Impl>>& layers) 
     pending = true;
 
     std::vector<Immutable<Layer::Impl>> impls;
+    impls.reserve(layers.size());
 
     for (const auto& layer : layers) {
         // Skip irrelevant layers.
-        if (layer->getTypeInfo()->source == LayerTypeInfo::Source::NotRequired ||
-            layer->source != sourceID ||
-            id.overscaledZ < std::floor(layer->minZoom) ||
+        assert(layer->getTypeInfo()->source != LayerTypeInfo::Source::NotRequired);
+        assert(layer->source == sourceID);
+        if (id.overscaledZ < std::floor(layer->minZoom) ||
             id.overscaledZ >= std::ceil(layer->maxZoom) ||
             layer->visibility == VisibilityType::None) {
             continue;


### PR DESCRIPTION
This PR is doing two things:
* Merges initialization of render items and render sources within single loop, so that sources will have the layers paint properties all evaluated before the update (this is required for the work on https://github.com/mapbox/mapbox-gl-native/issues/13812 )

* Performance improvements:  around 5% improvements for `API_renderStill_reuse_*` benchmark tests.