### PR TITLE
Clear previous style loaded listener when setting a new style

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/MapboxMapTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/MapboxMapTest.kt
@@ -123,4 +123,32 @@ class MapboxMapTest {
     mapboxMap.onDestroy()
     verify(exactly = 1) { style.clear() }
   }
+
+  @Test
+  fun testStyleCallbackNotCalledWhenPreviousFailed() {
+    val style = mockk<Style>(relaxed = true)
+    val builder = mockk<Style.Builder>(relaxed = true)
+    every { builder.build(nativeMapView) } returns style
+    val onStyleLoadedListener = mockk<Style.OnStyleLoaded>(relaxed = true)
+
+    mapboxMap.setStyle(builder, onStyleLoadedListener)
+    mapboxMap.onFailLoadingStyle()
+    mapboxMap.setStyle(builder, onStyleLoadedListener)
+    mapboxMap.onFinishLoadingStyle()
+    verify(exactly = 1) { onStyleLoadedListener.onStyleLoaded(style) }
+  }
+
+  @Test
+  fun testStyleCallbackNotCalledWhenPreviousNotFinished() {
+    // regression test for #14337
+    val style = mockk<Style>(relaxed = true)
+    val builder = mockk<Style.Builder>(relaxed = true)
+    every { builder.build(nativeMapView) } returns style
+    val onStyleLoadedListener = mockk<Style.OnStyleLoaded>(relaxed = true)
+
+    mapboxMap.setStyle(builder, onStyleLoadedListener)
+    mapboxMap.setStyle(builder, onStyleLoadedListener)
+    mapboxMap.onFinishLoadingStyle()
+    verify(exactly = 1) { onStyleLoadedListener.onStyleLoaded(style) }
+  }
 }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/14337.

To keep the current functionality of having `MapboxMap#getStyle` getters that can be invoked at an arbitrary point in time and await style loaded event, we need to separate the list of tthose getters from the listener passed with the setter.