### PR TITLE
[android] Small naming tweaks to mentions of Android Maps SDK

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ If you want to contribute code:
 1. Ensure that existing [pull requests](https://github.com/mapbox/mapbox-gl-native/pulls) and [issues](https://github.com/mapbox/mapbox-gl-native/issues) don’t already cover your contribution or question.
 
 1. Pull requests are gladly accepted. If there are any changes that developers using one of the GL SDKs should be aware of, please update the **master** section of the relevant changelog(s):
-  * [Mapbox Android SDK](platform/android/CHANGELOG.md)
+  * [Mapbox Maps SDK for Android](platform/android/CHANGELOG.md)
   * [Mapbox Maps SDK for iOS](platform/ios/CHANGELOG.md)
   * [Mapbox Maps SDK for macOS](platform/macos/CHANGELOG.md)
   * [node-mapbox-gl-native](platform/node/CHANGELOG.md)

--- a/platform/android/tests/README.md
+++ b/platform/android/tests/README.md
@@ -1,7 +1,7 @@
 # Mapbox GL Android Test documentation
 
 ## Testing
-We currently support the following types of testing on the Mapbox Android SDK:
+We currently support the following types of testing on the Mapbox Maps SDK for Android:
 
  - [Unit tests](docs/UNIT_TESTS.md) using [JUnit](http://developer.android.com/tools/testing-support-library/index.html#AndroidJUnitRunner)
  - [UI tests](docs/UI_TESTS.md) using [Espresso](http://developer.android.com/tools/testing-support-library/index.html#Espresso)


### PR DESCRIPTION
This pr cleans up some outdated mentions of the Android Maps SDK.