### PR TITLE
Allow resetting a custom OkHttp client to the default impl

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/http/HttpRequestImpl.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/http/HttpRequestImpl.java
@@ -3,15 +3,16 @@ package com.mapbox.mapboxsdk.module.http;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.text.TextUtils;
 import android.util.Log;
 import com.mapbox.mapboxsdk.BuildConfig;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
-import com.mapbox.mapboxsdk.http.HttpRequest;
 import com.mapbox.mapboxsdk.http.HttpIdentifier;
 import com.mapbox.mapboxsdk.http.HttpLogger;
-import com.mapbox.mapboxsdk.http.HttpResponder;
+import com.mapbox.mapboxsdk.http.HttpRequest;
 import com.mapbox.mapboxsdk.http.HttpRequestUrl;
+import com.mapbox.mapboxsdk.http.HttpResponder;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.Dispatcher;
@@ -42,7 +43,11 @@ public class HttpRequestImpl implements HttpRequest {
       Build.CPU_ABI)
   );
 
-  private static OkHttpClient client = new OkHttpClient.Builder().dispatcher(getDispatcher()).build();
+  @VisibleForTesting
+  static final OkHttpClient DEFAULT_CLIENT = new OkHttpClient.Builder().dispatcher(getDispatcher()).build();
+
+  @VisibleForTesting
+  static OkHttpClient client = DEFAULT_CLIENT;
 
   private Call call;
 
@@ -94,8 +99,12 @@ public class HttpRequestImpl implements HttpRequest {
     HttpLogger.logEnabled = enabled;
   }
 
-  public static void setOkHttpClient(OkHttpClient okHttpClient) {
-    HttpRequestImpl.client = okHttpClient;
+  public static void setOkHttpClient(@Nullable OkHttpClient okHttpClient) {
+    if (okHttpClient != null) {
+      HttpRequestImpl.client = okHttpClient;
+    } else {
+      HttpRequestImpl.client = DEFAULT_CLIENT;
+    }
   }
 
   private static class OkHttpCallback implements Callback {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/http/HttpRequestUtil.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/http/HttpRequestUtil.java
@@ -1,6 +1,7 @@
 package com.mapbox.mapboxsdk.module.http;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import okhttp3.OkHttpClient;
 import okio.Buffer;
 
@@ -38,10 +39,14 @@ public class HttpRequestUtil {
 
   /**
    * Set the OkHttpClient used for requesting map resources.
+   * <p>
+   * This configuration survives across mapView instances.
+   * Reset the OkHttpClient to the default by passing null as parameter.
+   * </p>
    *
    * @param client the OkHttpClient
    */
-  public static void setOkHttpClient(OkHttpClient client) {
+  public static void setOkHttpClient(@Nullable OkHttpClient client) {
     HttpRequestImpl.setOkHttpClient(client);
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/MapboxInjector.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/MapboxInjector.java
@@ -1,0 +1,29 @@
+package com.mapbox.mapboxsdk;
+
+import android.content.Context;
+
+import java.lang.reflect.Field;
+
+public class MapboxInjector {
+
+  public static void inject(Context context, String accessToken) {
+    Mapbox mapbox = new Mapbox(context, accessToken);
+    try {
+      Field field = Mapbox.class.getDeclaredField("INSTANCE");
+      field.setAccessible(true);
+      field.set(mapbox, mapbox);
+    } catch (Exception exception) {
+      throw new AssertionError();
+    }
+  }
+
+  public static void clear() {
+    try {
+      Field field = Mapbox.class.getDeclaredField("INSTANCE");
+      field.setAccessible(true);
+      field.set(field, null);
+    } catch (Exception exception) {
+      throw new AssertionError();
+    }
+  }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/MapboxTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/MapboxTest.java
@@ -1,12 +1,9 @@
 package com.mapbox.mapboxsdk;
 
 import android.content.Context;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.lang.reflect.Field;
 
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertSame;
@@ -32,13 +29,13 @@ public class MapboxTest {
   @Test
   public void testGetAccessToken() {
     final String accessToken = "pk.0000000001";
-    injectMapboxSingleton(accessToken);
+    MapboxInjector.inject(context, accessToken);
     assertSame(accessToken, Mapbox.getAccessToken());
   }
 
   @Test
   public void testApplicationContext() {
-    injectMapboxSingleton("pk.0000000001");
+    MapboxInjector.inject(context, "pk.0000000001");
     assertNotNull(Mapbox.getApplicationContext());
     assertNotEquals(context, appContext);
     assertEquals(appContext, appContext);
@@ -71,27 +68,7 @@ public class MapboxTest {
 
   @After
   public void after() {
-    clearMapboxSingleton();
+    MapboxInjector.clear();
   }
 
-  private void injectMapboxSingleton(String accessToken) {
-    Mapbox mapbox = new Mapbox(context, accessToken);
-    try {
-      Field field = Mapbox.class.getDeclaredField("INSTANCE");
-      field.setAccessible(true);
-      field.set(mapbox, mapbox);
-    } catch (Exception exception) {
-      throw new AssertionError();
-    }
-  }
-
-  private void clearMapboxSingleton() {
-    try {
-      Field field = Mapbox.class.getDeclaredField("INSTANCE");
-      field.setAccessible(true);
-      field.set(field, null);
-    } catch (Exception exception) {
-      throw new AssertionError();
-    }
-  }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/module/http/HttpRequestUtilTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/module/http/HttpRequestUtilTest.kt
@@ -1,0 +1,35 @@
+package com.mapbox.mapboxsdk.module.http
+
+import com.mapbox.mapboxsdk.MapboxInjector
+import io.mockk.mockk
+import junit.framework.Assert.assertEquals
+import okhttp3.OkHttpClient
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class HttpRequestUtilTest {
+
+  @Test
+  fun replaceHttpClient() {
+    MapboxInjector.inject(mockk(relaxed = true), "")
+
+    assertEquals(HttpRequestImpl.DEFAULT_CLIENT, HttpRequestImpl.client)
+
+    val httpMock = mockk<OkHttpClient>()
+    HttpRequestUtil.setOkHttpClient(httpMock)
+    assertEquals("Http client should have set to the mocked client",
+      httpMock,
+      HttpRequestImpl.client
+    )
+
+    HttpRequestUtil.setOkHttpClient(null)
+    assertEquals("Http client should have been reset to the default client",
+      HttpRequestImpl.DEFAULT_CLIENT,
+      HttpRequestImpl.client
+    )
+
+    MapboxInjector.clear()
+  }
+}


### PR DESCRIPTION
Capturing from @osana that for some use-cases we need to be able to allow resetting a custom http client. This custom client configuration is static and will remain active until the app is killed. To support all kind of use-cases, allowing to reset is a requirement. 