### PR TITLE
[core] Pass only visible render layers to source in renderer

### DIFF
--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -248,17 +248,15 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         for (const auto& layerImpl : *layerImpls) {
             RenderLayer* layer = getRenderLayer(layerImpl->id);
             const auto* layerInfo = layerImpl->getTypeInfo();
-            bool layerNeedsRendering = layer->needsRendering(zoomHistory.lastZoom);
-
+            const bool layerNeedsRendering = layer->needsRendering(zoomHistory.lastZoom);
             staticData->has3D = (staticData->has3D || layerInfo->pass3d == LayerTypeInfo::Pass3D::Required);
 
             if (layerInfo->source != LayerTypeInfo::Source::NotRequired) {
                 if (layerImpl->source == sourceImpl->id) {
-                    sourceNeedsRendering |= layerNeedsRendering;
                     sourceNeedsRelayout = (sourceNeedsRelayout || hasImageDiff || hasLayoutDifference(layerDiff, layerImpl->id));
-                    filteredLayersForSource.push_back(layerImpl);
-
                     if (layerNeedsRendering) {
+                        sourceNeedsRendering = true;
+                        filteredLayersForSource.push_back(layerImpl);
                         renderItems.emplace_back(*layer, source);
                     }
                 }

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -99,9 +99,9 @@ void GeometryTile::setLayers(const std::vector<Immutable<Layer::Impl>>& layers) 
         // Skip irrelevant layers.
         assert(layer->getTypeInfo()->source != LayerTypeInfo::Source::NotRequired);
         assert(layer->source == sourceID);
+        assert(layer->visibility != VisibilityType::None);
         if (id.overscaledZ < std::floor(layer->minZoom) ||
-            id.overscaledZ >= std::ceil(layer->maxZoom) ||
-            layer->visibility == VisibilityType::None) {
+            id.overscaledZ >= std::ceil(layer->maxZoom)) {
             continue;
         }
 


### PR DESCRIPTION
This simplifies the code and make it slightly more performant.

Also, this change enables initialization the `RenderTile.used`
field from inside the source (currently done in render layers).

Tag https://github.com/mapbox/mapbox-gl-native/issues/13812