### PR TITLE
Check for Mapbox#INSTANCE when initializing the MapView

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
@@ -180,4 +180,11 @@ public final class Mapbox {
     accessToken = accessToken.trim().toLowerCase(MapboxConstants.MAPBOX_LOCALE);
     return accessToken.length() != 0 && (accessToken.startsWith("pk.") || accessToken.startsWith("sk."));
   }
+
+  /**
+   * Internal use. Check if the {@link Mapbox#INSTANCE} is present.
+   */
+  public static boolean hasInstance() {
+    return INSTANCE != null;
+  }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -26,6 +26,7 @@ import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.annotations.Annotation;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
+import com.mapbox.mapboxsdk.exceptions.MapboxConfigurationException;
 import com.mapbox.mapboxsdk.location.LocationComponent;
 import com.mapbox.mapboxsdk.maps.renderer.MapRenderer;
 import com.mapbox.mapboxsdk.maps.renderer.glsurfaceview.GLSurfaceViewMapRenderer;
@@ -118,6 +119,10 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     if (isInEditMode()) {
       // in IDE layout editor, just return
       return;
+    }
+
+    if (!Mapbox.hasInstance()) {
+      throw new MapboxConfigurationException();
     }
 
     // hide surface until map is fully loaded #10990

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
@@ -3,8 +3,9 @@ package com.mapbox.mapboxsdk.maps.renderer;
 import android.content.Context;
 import android.support.annotation.CallSuper;
 import android.support.annotation.Keep;
-
 import android.support.annotation.NonNull;
+
+import com.mapbox.mapboxsdk.LibraryLoader;
 import com.mapbox.mapboxsdk.log.Logger;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.storage.FileSource;
@@ -21,6 +22,10 @@ import javax.microedition.khronos.opengles.GL10;
  */
 @Keep
 public abstract class MapRenderer implements MapRendererScheduler {
+
+  static {
+    LibraryLoader.load();
+  }
 
   private static final String TAG = "Mbgl-MapRenderer";
 

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/MapboxTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/MapboxTest.java
@@ -1,9 +1,19 @@
 package com.mapbox.mapboxsdk;
 
 import android.content.Context;
+import android.content.res.Resources;
+import android.content.res.TypedArray;
+import android.util.AttributeSet;
+import android.util.DisplayMetrics;
+
+import com.mapbox.mapboxsdk.exceptions.MapboxConfigurationException;
+import com.mapbox.mapboxsdk.maps.MapView;
+
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertSame;
@@ -11,6 +21,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -18,6 +31,9 @@ public class MapboxTest {
 
   private Context context;
   private Context appContext;
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
   @Before
   public void before() {
@@ -66,9 +82,28 @@ public class MapboxTest {
     assertFalse(Mapbox.isAccessTokenValid("blabla"));
   }
 
+  @Test
+  public void testNoInstance() {
+    DisplayMetrics displayMetrics = mock(DisplayMetrics.class);
+    Resources resources = mock(Resources.class);
+    when(resources.getDisplayMetrics()).thenReturn(displayMetrics);
+    when(context.getResources()).thenReturn(resources);
+    TypedArray typedArray = mock(TypedArray.class);
+    when(context.obtainStyledAttributes(nullable(AttributeSet.class), any(int[].class), anyInt(), anyInt()))
+      .thenReturn(typedArray);
+
+    expectedException.expect(MapboxConfigurationException.class);
+    expectedException.expectMessage(
+      "\nUsing MapView requires calling Mapbox.getInstance(Context context, String accessToken) before "
+        + "inflating or creating the view. The access token parameter is required when using a Mapbox service."
+        + "\nPlease see https://www.mapbox.com/help/create-api-access-token/ to learn how to create one."
+        + "\nMore information in this guide https://www.mapbox.com/help/first-steps-android-sdk/#access-tokens."
+    );
+    new MapView(context);
+  }
+
   @After
   public void after() {
     MapboxInjector.clear();
   }
-
 }


### PR DESCRIPTION
Checks for the missing configuration right away. Previously, when `Mapbox#geInstance` wasn't called before the view's inflation, the app would crash with the `UnsatisfiedLinkError`:
```
2019-04-08 16:15:43.759 16541-16541/com.mapbox.mapboxsdk.testapp E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.mapbox.mapboxsdk.testapp, PID: 16541
    java.lang.RuntimeException: Unable to start activity ComponentInfo{com.mapbox.mapboxsdk.testapp/com.mapbox.mapboxsdk.testapp.activity.maplayout.SimpleMapActivity}: android.view.InflateException: Binary XML file line #9: Binary XML file line #9: Error inflating class com.mapbox.mapboxsdk.maps.MapView
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2778)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2856)
        at android.app.ActivityThread.-wrap11(Unknown Source:0)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1589)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:164)
        at android.app.ActivityThread.main(ActivityThread.java:6494)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
     Caused by: android.view.InflateException: Binary XML file line #9: Binary XML file line #9: Error inflating class com.mapbox.mapboxsdk.maps.MapView
     Caused by: android.view.InflateException: Binary XML file line #9: Error inflating class com.mapbox.mapboxsdk.maps.MapView
     Caused by: java.lang.reflect.InvocationTargetException
        at java.lang.reflect.Constructor.newInstance0(Native Method)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:334)
        at android.view.LayoutInflater.createView(LayoutInflater.java:647)
        at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:790)
        at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:730)
        at android.view.LayoutInflater.rInflate(LayoutInflater.java:863)
        at android.view.LayoutInflater.rInflateChildren(LayoutInflater.java:824)
        at android.view.LayoutInflater.inflate(LayoutInflater.java:515)
        at android.view.LayoutInflater.inflate(LayoutInflater.java:423)
        at android.view.LayoutInflater.inflate(LayoutInflater.java:374)
        at android.support.v7.app.AppCompatDelegateImplV9.setContentView(AppCompatDelegateImplV9.java:287)
        at android.support.v7.app.AppCompatActivity.setContentView(AppCompatActivity.java:139)
        at com.mapbox.mapboxsdk.testapp.activity.maplayout.SimpleMapActivity.onCreate(SimpleMapActivity.java:19)
        at android.app.Activity.performCreate(Activity.java:7009)
        at android.app.Activity.performCreate(Activity.java:7000)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1214)
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2731)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2856)
        at android.app.ActivityThread.-wrap11(Unknown Source:0)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1589)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:164)
        at android.app.ActivityThread.main(ActivityThread.java:6494)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
     Caused by: java.lang.UnsatisfiedLinkError: No implementation found for void com.mapbox.mapboxsdk.maps.renderer.MapRenderer.nativeInitialize(com.mapbox.mapboxsdk.maps.renderer.MapRenderer, float, java.lang.String, java.lang.String) (tried Java_com_mapbox_mapboxsdk_maps_renderer_MapRenderer_nativeInitialize and Java_com_mapbox_mapboxsdk_maps_renderer_MapRenderer_nativeInitialize__Lcom_mapbox_mapboxsdk_maps_renderer_MapRenderer_2FLjava_lang_String_2Ljava_lang_String_2)
        at com.mapbox.mapboxsdk.maps.renderer.MapRenderer.nativeInitialize(Native Method)
        at com.mapbox.mapboxsdk.maps.renderer.MapRenderer.<init>(MapRenderer.java:43)
        at com.mapbox.mapboxsdk.maps.renderer.glsurfaceview.GLSurfaceViewMapRenderer.<init>(GLSurfaceViewMapRenderer.java:29)
        at com.mapbox.mapboxsdk.maps.MapView$5.<init>(MapView.java:301)
2019-04-08 16:15:43.759 16541-16541/com.mapbox.mapboxsdk.testapp E/AndroidRuntime:     at com.mapbox.mapboxsdk.maps.MapView.initialiseDrawingSurface(MapView.java:301)
        at com.mapbox.mapboxsdk.maps.MapView.initialize(MapView.java:144)
        at com.mapbox.mapboxsdk.maps.MapView.<init>(MapView.java:101)
        	... 26 more
```