### PR TITLE
fix firing onStyleImageMissing after sprite has loaded

### DIFF
--- a/src/mbgl/renderer/image_manager.cpp
+++ b/src/mbgl/renderer/image_manager.cpp
@@ -95,6 +95,7 @@ void ImageManager::getImages(ImageRequestor& requestor, ImageRequestPair&& pair)
         for (const auto& dependency : pair.first) {
             if (images.find(dependency.first) == images.end()) {
                 hasAllDependencies = false;
+                break;
             }
         }
 

--- a/src/mbgl/renderer/image_manager.cpp
+++ b/src/mbgl/renderer/image_manager.cpp
@@ -90,19 +90,19 @@ void ImageManager::getImages(ImageRequestor& requestor, ImageRequestPair&& pair)
     // if all icons are available. If any are missing, call `onStyleImageMissing`
     // to give the user a chance to provide the icon. If they are not provided
     // by the next frame we'll assume they are permanently missing.
-    bool hasAllDependencies = true;
     if (!isLoaded()) {
+        bool hasAllDependencies = true;
         for (const auto& dependency : pair.first) {
             if (images.find(dependency.first) == images.end()) {
                 hasAllDependencies = false;
             }
         }
-    }
 
-    if (hasAllDependencies) {
-        notify(requestor, pair);
-    } else if (!isLoaded()) {
-        requestors.emplace(&requestor, std::move(pair));
+        if (hasAllDependencies) {
+            notify(requestor, pair);
+        } else {
+            requestors.emplace(&requestor, std::move(pair));
+        }
     } else {
         checkMissingAndNotify(requestor, std::move(pair));
     }


### PR DESCRIPTION
This fixes a significant bug that I introduced while cleaning up https://github.com/mapbox/mapbox-gl-native/pull/14253. And more importantly, this adds test coverage that should have been included in the original PR.

The cleanup introduced a bug where the onStyleImageMissing observer method was only called before the sprite has been loaded. This fixes that.