### PR TITLE
[ios] Make sure ornaments are in proper positions

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -19,6 +19,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Fixed an issue that caused the tilt gesture to trigger too easily and conflict with pinch or pan gestures. ([#15349](https://github.com/mapbox/mapbox-gl-native/pull/15349))
 * Fixed an issue that caused the map to rotate too easily during a pinch gesture. [(#15562)](https://github.com/mapbox/mapbox-gl-native/pull/15562)
+* Fixed an issue that ornaments could be setting outside the mapview. [(#14373)](https://github.com/mapbox/mapbox-gl-native/pull/14373)
 
 ### Performance improvements
  

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -19,7 +19,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Fixed an issue that caused the tilt gesture to trigger too easily and conflict with pinch or pan gestures. ([#15349](https://github.com/mapbox/mapbox-gl-native/pull/15349))
 * Fixed an issue that caused the map to rotate too easily during a pinch gesture. [(#15562)](https://github.com/mapbox/mapbox-gl-native/pull/15562)
-* Fixed an issue that ornaments could be setting outside the mapview. [(#14373)](https://github.com/mapbox/mapbox-gl-native/pull/14373)
+* Fixed an issue where ornaments could be set outside the map view. [(#14373)](https://github.com/mapbox/mapbox-gl-native/pull/14373)
 
 ### Performance improvements
  

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -967,6 +967,18 @@ public:
         [NSException raise:NSInvalidArgumentException
                     format:@"The attribution is not in the visible area of the mapview. Please check your position and offset settings"];
     }
+    if (!CGRectContainsRect(self.bounds, self.scaleBar.frame)) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"The scaleBar is not in the visible area of the mapview. Please check your position and offset settings"];
+    }
+    if (!CGRectContainsRect(self.bounds, self.compassView.frame)) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"The compassView is not in the visible area of the mapview. Please check your position and offset settings"];
+    }
+    if (!CGRectContainsRect(self.bounds, self.logoView.frame)) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"The logoView is not in the visible area of the mapview. Please check your position and offset settings"];
+    }
 }
 
 /// Updates `contentInset` to reflect the current window geometry.

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -962,6 +962,11 @@ public:
     [self updateUserLocationAnnotationView];
 
     [self updateAttributionAlertView];
+    
+    if (!CGRectContainsRect(self.bounds, self.attributionButton.frame)) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"The attribution is not in the visible area of the mapview. Please check your position and offset settings"];
+    }
 }
 
 /// Updates `contentInset` to reflect the current window geometry.

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -963,22 +963,14 @@ public:
 
     [self updateAttributionAlertView];
     
-    if (!CGRectContainsRect(self.bounds, self.attributionButton.mgl_frameForTransformIdentity)) {
-        [NSException raise:NSInvalidArgumentException
-                    format:@"The attribution is not in the visible area of the mapview. Please check your position and offset settings"];
-    }
-    if (!CGRectContainsRect(self.bounds, self.scaleBar.mgl_frameForTransformIdentity)) {
-        [NSException raise:NSInvalidArgumentException
-                    format:@"The scaleBar is not in the visible area of the mapview. Please check your position and offset settings"];
-    }
-    if (!CGRectContainsRect(self.bounds, self.compassView.mgl_frameForTransformIdentity)) {
-        [NSException raise:NSInvalidArgumentException
-                    format:@"The compassView is not in the visible area of the mapview. Please check your position and offset settings"];
-    }
-    if (!CGRectContainsRect(self.bounds, self.logoView.mgl_frameForTransformIdentity)) {
-        [NSException raise:NSInvalidArgumentException
-                    format:@"The logoView is not in the visible area of the mapview. Please check your position and offset settings"];
-    }
+    MGLAssert(CGRectContainsRect(self.bounds, self.attributionButton.mgl_frameForIdentifyTransform),
+              @"The attribution is not in the visible area of the mapview. Please check your position and offset settings");
+    MGLAssert(CGRectContainsRect(self.bounds, self.scaleBar.mgl_frameForIdentifyTransform),
+              @"The scaleBar is not in the visible area of the mapview. Please check your position and offset settings");
+    MGLAssert(CGRectContainsRect(self.bounds, self.compassView.mgl_frameForIdentifyTransform),
+              @"The compassView is not in the visible area of the mapview. Please check your position and offset settings");
+    MGLAssert(CGRectContainsRect(self.bounds, self.logoView.mgl_frameForIdentifyTransform),
+              @"The logoView is not in the visible area of the mapview. Please check your position and offset settings");
 }
 
 /// Updates `contentInset` to reflect the current window geometry.

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -963,19 +963,19 @@ public:
 
     [self updateAttributionAlertView];
     
-    if (!CGRectContainsRect(self.bounds, self.attributionButton.frame)) {
+    if (!CGRectContainsRect(self.bounds, self.attributionButton.mgl_frameForTransformIdentity)) {
         [NSException raise:NSInvalidArgumentException
                     format:@"The attribution is not in the visible area of the mapview. Please check your position and offset settings"];
     }
-    if (!CGRectContainsRect(self.bounds, self.scaleBar.frame)) {
+    if (!CGRectContainsRect(self.bounds, self.scaleBar.mgl_frameForTransformIdentity)) {
         [NSException raise:NSInvalidArgumentException
                     format:@"The scaleBar is not in the visible area of the mapview. Please check your position and offset settings"];
     }
-    if (!CGRectContainsRect(self.bounds, self.compassView.frame)) {
+    if (!CGRectContainsRect(self.bounds, self.compassView.mgl_frameForTransformIdentity)) {
         [NSException raise:NSInvalidArgumentException
                     format:@"The compassView is not in the visible area of the mapview. Please check your position and offset settings"];
     }
-    if (!CGRectContainsRect(self.bounds, self.logoView.frame)) {
+    if (!CGRectContainsRect(self.bounds, self.logoView.mgl_frameForTransformIdentity)) {
         [NSException raise:NSInvalidArgumentException
                     format:@"The logoView is not in the visible area of the mapview. Please check your position and offset settings"];
     }

--- a/platform/ios/src/UIView+MGLAdditions.h
+++ b/platform/ios/src/UIView+MGLAdditions.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSLayoutXAxisAnchor *)mgl_safeTrailingAnchor;
 
-- (CGRect)mgl_frameForTransformIdentity;
+- (CGRect)mgl_frameForIdentifyTransform;
 
 @end
 

--- a/platform/ios/src/UIView+MGLAdditions.h
+++ b/platform/ios/src/UIView+MGLAdditions.h
@@ -14,6 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSLayoutXAxisAnchor *)mgl_safeTrailingAnchor;
 
+- (CGRect)mgl_frameForTransformIdentity;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/platform/ios/src/UIView+MGLAdditions.m
+++ b/platform/ios/src/UIView+MGLAdditions.m
@@ -66,4 +66,16 @@
     }
 }
 
+- (CGRect)mgl_frameForTransformIdentity {
+    CGPoint center = self.center;
+    CGSize size = self.bounds.size;
+
+    return CGRectMake(
+                      center.x - size.width / 2,
+                      center.y - size.height / 2,
+                      size.width,
+                      size.height
+                      );
+}
+
 @end

--- a/platform/ios/src/UIView+MGLAdditions.m
+++ b/platform/ios/src/UIView+MGLAdditions.m
@@ -66,7 +66,7 @@
     }
 }
 
-- (CGRect)mgl_frameForTransformIdentity {
+- (CGRect)mgl_frameForIdentifyTransform {
     CGPoint center = self.center;
     CGSize size = self.bounds.size;
 

--- a/platform/ios/test/MGLMapViewLayoutTests.m
+++ b/platform/ios/test/MGLMapViewLayoutTests.m
@@ -7,13 +7,13 @@
 
 @interface UIView (MGLAdditions)
 
-- (CGRect)mgl_frameForTransformIdentity;
+- (CGRect)mgl_frameForIdentifyTransform;
 
 @end
 
 @implementation UIView (MGLAdditions)
 
-- (CGRect)mgl_frameForTransformIdentity {
+- (CGRect)mgl_frameForIdentifyTransform {
     CGPoint center = self.center;
     CGSize size = self.bounds.size;
 
@@ -190,8 +190,8 @@
         [self.superView setNeedsLayout];
         [self.superView layoutIfNeeded];
 
-        XCTAssertEqualWithAccuracy(CGRectGetMinX(compassView.mgl_frameForTransformIdentity), testData.expectedOrigin.x, accuracy);
-        XCTAssertEqualWithAccuracy(CGRectGetMinY(compassView.mgl_frameForTransformIdentity), testData.expectedOrigin.y, accuracy);
+        XCTAssertEqualWithAccuracy(CGRectGetMinX(compassView.mgl_frameForIdentifyTransform), testData.expectedOrigin.x, accuracy);
+        XCTAssertEqualWithAccuracy(CGRectGetMinY(compassView.mgl_frameForIdentifyTransform), testData.expectedOrigin.y, accuracy);
     }
 }
 
@@ -205,14 +205,15 @@
     for (MGLOrnamentTestData *testData in testDataList) {
         self.mapView.compassViewPosition = testData.position;
         self.mapView.compassViewMargins = testData.offset;
+        // A tranform value which would led compassView's frame outside mapview's bounds
         self.mapView.compassView.transform = CGAffineTransformMake(0.7, -0.8, 0.6, 0.7, 0, 0);
 
         //invoke layout
         [self.superView setNeedsLayout];
         [self.superView layoutIfNeeded];
 
-        XCTAssertEqualWithAccuracy(CGRectGetMinX(compassView.mgl_frameForTransformIdentity), testData.expectedOrigin.x, accuracy);
-        XCTAssertEqualWithAccuracy(CGRectGetMinY(compassView.mgl_frameForTransformIdentity), testData.expectedOrigin.y, accuracy);
+        XCTAssertEqualWithAccuracy(CGRectGetMinX(compassView.mgl_frameForIdentifyTransform), testData.expectedOrigin.x, accuracy);
+        XCTAssertEqualWithAccuracy(CGRectGetMinY(compassView.mgl_frameForIdentifyTransform), testData.expectedOrigin.y, accuracy);
     }
 }
 
@@ -231,8 +232,8 @@
         XCTAssertThrowsSpecificNamed(
                                      [self.superView layoutIfNeeded],
                                      NSException,
-                                     NSInvalidArgumentException,
-                                     @"should throw NSInvalidArgumentException"
+                                     NSInternalInconsistencyException,
+                                     @"should throw NSInternalInconsistencyException"
                                      );
     }
 }
@@ -252,8 +253,8 @@
         [self.superView setNeedsLayout];
         [self.superView layoutIfNeeded];
 
-        XCTAssertEqualWithAccuracy(CGRectGetMinX(scaleBar.mgl_frameForTransformIdentity), testData.expectedOrigin.x, accuracy);
-        XCTAssertEqualWithAccuracy(CGRectGetMinY(scaleBar.mgl_frameForTransformIdentity), testData.expectedOrigin.y, accuracy);
+        XCTAssertEqualWithAccuracy(CGRectGetMinX(scaleBar.mgl_frameForIdentifyTransform), testData.expectedOrigin.x, accuracy);
+        XCTAssertEqualWithAccuracy(CGRectGetMinY(scaleBar.mgl_frameForIdentifyTransform), testData.expectedOrigin.y, accuracy);
     }
 }
 
@@ -272,8 +273,8 @@
         XCTAssertThrowsSpecificNamed(
                                      [self.superView layoutIfNeeded],
                                      NSException,
-                                     NSInvalidArgumentException,
-                                     @"should throw NSInvalidArgumentException"
+                                     NSInternalInconsistencyException,
+                                     @"should throw NSInternalInconsistencyException"
                                      );
     }
 }
@@ -293,8 +294,8 @@
         [self.superView setNeedsLayout];
         [self.superView layoutIfNeeded];
 
-        XCTAssertEqualWithAccuracy(CGRectGetMinX(attributionButton.mgl_frameForTransformIdentity), testData.expectedOrigin.x, accuracy);
-        XCTAssertEqualWithAccuracy(CGRectGetMinY(attributionButton.mgl_frameForTransformIdentity), testData.expectedOrigin.y, accuracy);
+        XCTAssertEqualWithAccuracy(CGRectGetMinX(attributionButton.mgl_frameForIdentifyTransform), testData.expectedOrigin.x, accuracy);
+        XCTAssertEqualWithAccuracy(CGRectGetMinY(attributionButton.mgl_frameForIdentifyTransform), testData.expectedOrigin.y, accuracy);
     }
 }
 
@@ -313,8 +314,8 @@
         XCTAssertThrowsSpecificNamed(
                                      [self.superView layoutIfNeeded],
                                      NSException,
-                                     NSInvalidArgumentException,
-                                     @"should throw NSInvalidArgumentException"
+                                     NSInternalInconsistencyException,
+                                     @"should throw NSInternalInconsistencyException"
                                      );
     }
 }
@@ -334,8 +335,8 @@
         [self.superView setNeedsLayout];
         [self.superView layoutIfNeeded];
 
-        XCTAssertEqualWithAccuracy(CGRectGetMinX(logoView.mgl_frameForTransformIdentity), testData.expectedOrigin.x, accuracy);
-        XCTAssertEqualWithAccuracy(CGRectGetMinY(logoView.mgl_frameForTransformIdentity), testData.expectedOrigin.y, accuracy);
+        XCTAssertEqualWithAccuracy(CGRectGetMinX(logoView.mgl_frameForIdentifyTransform), testData.expectedOrigin.x, accuracy);
+        XCTAssertEqualWithAccuracy(CGRectGetMinY(logoView.mgl_frameForIdentifyTransform), testData.expectedOrigin.y, accuracy);
     }
 }
 
@@ -354,8 +355,8 @@
         XCTAssertThrowsSpecificNamed(
                                      [self.superView layoutIfNeeded],
                                      NSException,
-                                     NSInvalidArgumentException,
-                                     @"should throw NSInvalidArgumentException"
+                                     NSInternalInconsistencyException,
+                                     @"should throw NSInternalInconsistencyException"
                                      );
     }
 }

--- a/platform/ios/test/MGLMapViewLayoutTests.m
+++ b/platform/ios/test/MGLMapViewLayoutTests.m
@@ -4,6 +4,30 @@
 #import "MGLAccountManager.h"
 
 
+
+@interface UIView (MGLAdditions)
+
+- (CGRect)mgl_frameForTransformIdentity;
+
+@end
+
+@implementation UIView (MGLAdditions)
+
+- (CGRect)mgl_frameForTransformIdentity {
+    CGPoint center = self.center;
+    CGSize size = self.bounds.size;
+
+    return CGRectMake(
+                      center.x - size.width / 2,
+                      center.y - size.height / 2,
+                      size.width,
+                      size.height
+                      );
+}
+
+@end
+
+
 @interface MGLOrnamentTestData : NSObject
 
 @property (nonatomic) MGLOrnamentPosition position;
@@ -140,7 +164,7 @@
                                       expectedOrigin:CGPointMake(margin, margin)],
              [MGLOrnamentTestData createWithPosition:MGLOrnamentPositionTopRight
                                               offset:CGPointMake(margin, margin)
-                                      expectedOrigin:CGPointMake(CGRectGetMaxX(self.mapView.bounds) - margin - CGRectGetWidth(view.frame), 4)],
+                                      expectedOrigin:CGPointMake(CGRectGetMaxX(self.mapView.bounds) - margin - CGRectGetWidth(view.frame), margin)],
              [MGLOrnamentTestData createWithPosition:MGLOrnamentPositionBottomLeft
                                               offset:CGPointMake(margin, margin)
                                       expectedOrigin:CGPointMake(margin,  CGRectGetMaxY(self.mapView.bounds) - margin - bottomSafeAreaInset - CGRectGetHeight(view.frame))],
@@ -166,16 +190,37 @@
         [self.superView setNeedsLayout];
         [self.superView layoutIfNeeded];
 
-        XCTAssertEqualWithAccuracy(CGRectGetMinX(compassView.frame), testData.expectedOrigin.x, accuracy);
-        XCTAssertEqualWithAccuracy(CGRectGetMinY(compassView.frame), testData.expectedOrigin.y, accuracy);
+        XCTAssertEqualWithAccuracy(CGRectGetMinX(compassView.mgl_frameForTransformIdentity), testData.expectedOrigin.x, accuracy);
+        XCTAssertEqualWithAccuracy(CGRectGetMinY(compassView.mgl_frameForTransformIdentity), testData.expectedOrigin.y, accuracy);
+    }
+}
+
+- (void)testCompassPlacementWithTransform {
+    double accuracy = 0.01;
+    CGFloat margin = 4.0;
+
+    UIView *compassView = self.mapView.compassView;
+    NSArray *testDataList = [self makeTestDataListWithView:compassView margin:margin];
+
+    for (MGLOrnamentTestData *testData in testDataList) {
+        self.mapView.compassViewPosition = testData.position;
+        self.mapView.compassViewMargins = testData.offset;
+        self.mapView.compassView.transform = CGAffineTransformMake(0.7, -0.8, 0.6, 0.7, 0, 0);
+
+        //invoke layout
+        [self.superView setNeedsLayout];
+        [self.superView layoutIfNeeded];
+
+        XCTAssertEqualWithAccuracy(CGRectGetMinX(compassView.mgl_frameForTransformIdentity), testData.expectedOrigin.x, accuracy);
+        XCTAssertEqualWithAccuracy(CGRectGetMinY(compassView.mgl_frameForTransformIdentity), testData.expectedOrigin.y, accuracy);
     }
 }
 
 - (void)testCompassPlacementInvalidPosition {
     CGFloat margin = -_superView.bounds.size.width;
 
-    UIView *scaleBar = self.mapView.scaleBar;
-    NSArray *testDataList = [self makeTestDataListWithView:scaleBar margin:margin];
+    UIView *compassView = self.mapView.compassView;
+    NSArray *testDataList = [self makeTestDataListWithView:compassView margin:margin];
 
     for (MGLOrnamentTestData *testData in testDataList) {
         self.mapView.compassViewPosition = testData.position;
@@ -207,8 +252,8 @@
         [self.superView setNeedsLayout];
         [self.superView layoutIfNeeded];
 
-        XCTAssertEqualWithAccuracy(CGRectGetMinX(scaleBar.frame), testData.expectedOrigin.x, accuracy);
-        XCTAssertEqualWithAccuracy(CGRectGetMinY(scaleBar.frame), testData.expectedOrigin.y, accuracy);
+        XCTAssertEqualWithAccuracy(CGRectGetMinX(scaleBar.mgl_frameForTransformIdentity), testData.expectedOrigin.x, accuracy);
+        XCTAssertEqualWithAccuracy(CGRectGetMinY(scaleBar.mgl_frameForTransformIdentity), testData.expectedOrigin.y, accuracy);
     }
 }
 
@@ -248,8 +293,8 @@
         [self.superView setNeedsLayout];
         [self.superView layoutIfNeeded];
 
-        XCTAssertEqualWithAccuracy(CGRectGetMinX(attributionButton.frame), testData.expectedOrigin.x, accuracy);
-        XCTAssertEqualWithAccuracy(CGRectGetMinY(attributionButton.frame), testData.expectedOrigin.y, accuracy);
+        XCTAssertEqualWithAccuracy(CGRectGetMinX(attributionButton.mgl_frameForTransformIdentity), testData.expectedOrigin.x, accuracy);
+        XCTAssertEqualWithAccuracy(CGRectGetMinY(attributionButton.mgl_frameForTransformIdentity), testData.expectedOrigin.y, accuracy);
     }
 }
 
@@ -289,16 +334,16 @@
         [self.superView setNeedsLayout];
         [self.superView layoutIfNeeded];
 
-        XCTAssertEqualWithAccuracy(CGRectGetMinX(logoView.frame), testData.expectedOrigin.x, accuracy);
-        XCTAssertEqualWithAccuracy(CGRectGetMinY(logoView.frame), testData.expectedOrigin.y, accuracy);
+        XCTAssertEqualWithAccuracy(CGRectGetMinX(logoView.mgl_frameForTransformIdentity), testData.expectedOrigin.x, accuracy);
+        XCTAssertEqualWithAccuracy(CGRectGetMinY(logoView.mgl_frameForTransformIdentity), testData.expectedOrigin.y, accuracy);
     }
 }
 
 - (void)testLogoPlacementInvalidPosition {
     CGFloat margin = -_superView.bounds.size.width;
 
-    UIView *attributionButton = self.mapView.attributionButton;
-    NSArray *testDataList = [self makeTestDataListWithView:attributionButton margin:margin];
+    UIView *logoView = self.mapView.logoView;
+    NSArray *testDataList = [self makeTestDataListWithView:logoView margin:margin];
 
     for (MGLOrnamentTestData *testData in testDataList) {
         self.mapView.logoViewPosition = testData.position;

--- a/platform/ios/test/MGLMapViewLayoutTests.m
+++ b/platform/ios/test/MGLMapViewLayoutTests.m
@@ -211,6 +211,27 @@
     }
 }
 
+- (void)testAttributionButtonPlacementInvalidPosition {
+    CGFloat margin = -400.0;
+    
+    UIView *attributionButton = self.mapView.attributionButton;
+    NSArray *testDataList = [self makeTestDataListWithView:attributionButton margin:margin];
+    
+    for (MGLOrnamentTestData *testData in testDataList) {
+        self.mapView.attributionButtonPosition = testData.position;
+        self.mapView.attributionButtonMargins = testData.offset;
+        
+        //invoke layout
+        [self.superView setNeedsLayout];
+        XCTAssertThrowsSpecificNamed(
+                                     [self.superView layoutIfNeeded],
+                                     NSException,
+                                     NSInvalidArgumentException,
+                                     @"should throw NSInvalidArgumentException"
+                                     );
+    }
+}
+
 - (void)testLogoPlacement {
     double accuracy = 0.01;
     CGFloat margin = 4.0;

--- a/platform/ios/test/MGLMapViewLayoutTests.m
+++ b/platform/ios/test/MGLMapViewLayoutTests.m
@@ -171,6 +171,27 @@
     }
 }
 
+- (void)testCompassPlacementInvalidPosition {
+    CGFloat margin = -_superView.bounds.size.width;
+
+    UIView *scaleBar = self.mapView.scaleBar;
+    NSArray *testDataList = [self makeTestDataListWithView:scaleBar margin:margin];
+
+    for (MGLOrnamentTestData *testData in testDataList) {
+        self.mapView.compassViewPosition = testData.position;
+        self.mapView.compassViewMargins = testData.offset;
+
+        //invoke layout
+        [self.superView setNeedsLayout];
+        XCTAssertThrowsSpecificNamed(
+                                     [self.superView layoutIfNeeded],
+                                     NSException,
+                                     NSInvalidArgumentException,
+                                     @"should throw NSInvalidArgumentException"
+                                     );
+    }
+}
+
 - (void)testScalebarPlacement {
     double accuracy = 0.01;
     CGFloat margin = 4.0;
@@ -188,6 +209,27 @@
 
         XCTAssertEqualWithAccuracy(CGRectGetMinX(scaleBar.frame), testData.expectedOrigin.x, accuracy);
         XCTAssertEqualWithAccuracy(CGRectGetMinY(scaleBar.frame), testData.expectedOrigin.y, accuracy);
+    }
+}
+
+- (void)testScalebarPlacementInvalidPosition {
+    CGFloat margin = -_superView.bounds.size.width;
+
+    UIView *scaleBar = self.mapView.scaleBar;
+    NSArray *testDataList = [self makeTestDataListWithView:scaleBar margin:margin];
+
+    for (MGLOrnamentTestData *testData in testDataList) {
+        self.mapView.scaleBarPosition = testData.position;
+        self.mapView.scaleBarMargins = testData.offset;
+
+        //invoke layout
+        [self.superView setNeedsLayout];
+        XCTAssertThrowsSpecificNamed(
+                                     [self.superView layoutIfNeeded],
+                                     NSException,
+                                     NSInvalidArgumentException,
+                                     @"should throw NSInvalidArgumentException"
+                                     );
     }
 }
 
@@ -212,15 +254,15 @@
 }
 
 - (void)testAttributionButtonPlacementInvalidPosition {
-    CGFloat margin = -400.0;
-    
+    CGFloat margin = -_superView.bounds.size.width;
+
     UIView *attributionButton = self.mapView.attributionButton;
     NSArray *testDataList = [self makeTestDataListWithView:attributionButton margin:margin];
     
     for (MGLOrnamentTestData *testData in testDataList) {
         self.mapView.attributionButtonPosition = testData.position;
         self.mapView.attributionButtonMargins = testData.offset;
-        
+
         //invoke layout
         [self.superView setNeedsLayout];
         XCTAssertThrowsSpecificNamed(
@@ -251,5 +293,27 @@
         XCTAssertEqualWithAccuracy(CGRectGetMinY(logoView.frame), testData.expectedOrigin.y, accuracy);
     }
 }
+
+- (void)testLogoPlacementInvalidPosition {
+    CGFloat margin = -_superView.bounds.size.width;
+
+    UIView *attributionButton = self.mapView.attributionButton;
+    NSArray *testDataList = [self makeTestDataListWithView:attributionButton margin:margin];
+
+    for (MGLOrnamentTestData *testData in testDataList) {
+        self.mapView.logoViewPosition = testData.position;
+        self.mapView.logoViewMargins = testData.offset;
+
+        //invoke layout
+        [self.superView setNeedsLayout];
+        XCTAssertThrowsSpecificNamed(
+                                     [self.superView layoutIfNeeded],
+                                     NSException,
+                                     NSInvalidArgumentException,
+                                     @"should throw NSInvalidArgumentException"
+                                     );
+    }
+}
+
 
 @end


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/14065. We'd like to invoke `NSException` to make sure ornaments are in proper positions.