### PR TITLE
Use a designated thread for GeoJSONSource features conversion

### DIFF
--- a/platform/android/src/style/sources/geojson_source.hpp
+++ b/platform/android/src/style/sources/geojson_source.hpp
@@ -7,6 +7,7 @@
 #include "../../geojson/feature_collection.hpp"
 #include "../../android_renderer_frontend.hpp"
 #include <jni/jni.hpp>
+#include <mbgl/util/thread.hpp>
 
 namespace mbgl {
 namespace android {
@@ -59,8 +60,7 @@ private:
     jni::Local<jni::Object<Source>> createJavaPeer(jni::JNIEnv&);
     std::unique_ptr<Update> awaitingUpdate;
     std::unique_ptr<Update> update;
-    std::shared_ptr<ThreadPool> threadPool;
-    std::unique_ptr<Actor<FeatureConverter>> converter;
+    std::unique_ptr<util::Thread<FeatureConverter>> converter;
 
     template <class JNIType>
     void setCollectionAsync(jni::JNIEnv&, const jni::Object<JNIType>&);


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gl-native/issues/14048.

I've noticed, that constantly detaching and re-attaching threads to the JVM invokes GC. I don't quite understand why, but since we are allowing for only one async features conversion at a time and using a designated thread for the conversion removes a need of constantly attaching new threads from the pool, I think this is a beneficial change.

One downside here is, that now each `GeoJSONSource` instance creates and holds a new thread. A solution might be creating a fixed pool of long-lived threads that are permanently attached to the JVM, and not rotated. Any thoughts on this @ivovandongen?