### PR TITLE
Query when renderer is being recreated

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -292,8 +292,8 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
 
         @Override
         protected void onSurfaceDestroyed() {
-          MapView.this.onSurfaceDestroyed();
           super.onSurfaceDestroyed();
+          MapView.this.onSurfaceDestroyed();
         }
       };
 
@@ -310,8 +310,8 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
 
         @Override
         protected void onSurfaceDestroyed() {
-          MapView.this.onSurfaceDestroyed();
           super.onSurfaceDestroyed();
+          MapView.this.onSurfaceDestroyed();
         }
       };
 
@@ -442,7 +442,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
       mapboxMap.onDestroy();
     }
 
-    if (nativeMapView != null && nativeMapView.hasSurface()) {
+    if (nativeMapView != null) {
       // null when destroying an activity programmatically mapbox-navigation-android/issues/503
       nativeMapView.destroy();
       nativeMapView = null;
@@ -762,7 +762,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   }
 
   /**
-   * /**
+   *
    * Set a callback that's invoked when the style has finished loading.
    *
    * @param listener The callback that's invoked when the style has finished loading

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -19,7 +19,6 @@ import android.view.TextureView;
 import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
-
 import com.mapbox.android.gestures.AndroidGesturesManager;
 import com.mapbox.mapboxsdk.MapStrictMode;
 import com.mapbox.mapboxsdk.Mapbox;
@@ -36,12 +35,11 @@ import com.mapbox.mapboxsdk.net.ConnectivityReceiver;
 import com.mapbox.mapboxsdk.storage.FileSource;
 import com.mapbox.mapboxsdk.utils.BitmapUtils;
 
+import javax.microedition.khronos.egl.EGLConfig;
+import javax.microedition.khronos.opengles.GL10;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
-import javax.microedition.khronos.egl.EGLConfig;
-import javax.microedition.khronos.opengles.GL10;
 
 import static com.mapbox.mapboxsdk.maps.widgets.CompassView.TIME_MAP_NORTH_ANIMATION;
 import static com.mapbox.mapboxsdk.maps.widgets.CompassView.TIME_WAIT_IDLE;
@@ -74,7 +72,6 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   private MapboxMapOptions mapboxMapOptions;
   private MapRenderer mapRenderer;
   private boolean destroyed;
-  private boolean hasSurface;
 
   private CompassView compassView;
   private PointF focalPoint;
@@ -292,6 +289,12 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
           MapView.this.onSurfaceCreated();
           super.onSurfaceCreated(gl, config);
         }
+
+        @Override
+        protected void onSurfaceDestroyed() {
+          MapView.this.onSurfaceDestroyed();
+          super.onSurfaceDestroyed();
+        }
       };
 
       addView(textureView, 0);
@@ -303,6 +306,12 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
         public void onSurfaceCreated(GL10 gl, EGLConfig config) {
           MapView.this.onSurfaceCreated();
           super.onSurfaceCreated(gl, config);
+        }
+
+        @Override
+        protected void onSurfaceDestroyed() {
+          MapView.this.onSurfaceDestroyed();
+          super.onSurfaceDestroyed();
         }
       };
 
@@ -316,7 +325,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   }
 
   private void onSurfaceCreated() {
-    hasSurface = true;
+    nativeMapView.setHasSurface(true);
     post(new Runnable() {
       @Override
       public void run() {
@@ -327,6 +336,12 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
         }
       }
     });
+  }
+
+  private void onSurfaceDestroyed() {
+    if (nativeMapView != null) {
+      nativeMapView.setHasSurface(false);
+    }
   }
 
   /**
@@ -427,7 +442,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
       mapboxMap.onDestroy();
     }
 
-    if (nativeMapView != null && hasSurface) {
+    if (nativeMapView != null && nativeMapView.hasSurface()) {
       // null when destroying an activity programmatically mapbox-navigation-android/issues/503
       nativeMapView.destroy();
       nativeMapView = null;
@@ -439,10 +454,10 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   }
 
   /**
-   *  The maximum frame rate at which the map view is rendered,
-   *  but it can't excess the ability of device hardware.
+   * The maximum frame rate at which the map view is rendered,
+   * but it can't excess the ability of device hardware.
    *
-   * @param maximumFps  Can be set to arbitrary integer values.
+   * @param maximumFps Can be set to arbitrary integer values.
    */
   public void setMaximumFps(int maximumFps) {
     if (mapRenderer != null) {
@@ -747,8 +762,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   }
 
   /**
-
-   /**
+   * /**
    * Set a callback that's invoked when the style has finished loading.
    *
    * @param listener The callback that's invoked when the style has finished loading

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -12,7 +12,6 @@ import android.support.annotation.Size;
 import android.support.annotation.UiThread;
 import android.text.TextUtils;
 import android.view.View;
-
 import com.mapbox.android.gestures.AndroidGesturesManager;
 import com.mapbox.android.gestures.MoveGestureDetector;
 import com.mapbox.android.gestures.RotateGestureDetector;
@@ -1882,20 +1881,25 @@ public final class MapboxMap {
   }
 
   /**
-   * Queries the map for rendered features
+   * Queries the map for rendered features.
+   * <p>
+   * Returns an empty list if either the map or underlying render surface has been destroyed.
+   * </p>
    *
    * @param coordinates the point to query
    * @param layerIds    optionally - only query these layers
    * @return the list of feature
    */
   @NonNull
-  public List<Feature> queryRenderedFeatures(@NonNull PointF coordinates, @Nullable String...
-    layerIds) {
+  public List<Feature> queryRenderedFeatures(@NonNull PointF coordinates, @Nullable String... layerIds) {
     return nativeMapView.queryRenderedFeatures(coordinates, layerIds, null);
   }
 
   /**
    * Queries the map for rendered features
+   * <p>
+   * Returns an empty list if either the map or underlying render surface has been destroyed.
+   * </p>
    *
    * @param coordinates the point to query
    * @param filter      filters the returned features with an expression
@@ -1911,19 +1915,24 @@ public final class MapboxMap {
 
   /**
    * Queries the map for rendered features
+   * <p>
+   * Returns an empty list if either the map or underlying render surface has been destroyed.
+   * </p>
    *
    * @param coordinates the box to query
    * @param layerIds    optionally - only query these layers
    * @return the list of feature
    */
   @NonNull
-  public List<Feature> queryRenderedFeatures(@NonNull RectF coordinates,
-                                             @Nullable String... layerIds) {
+  public List<Feature> queryRenderedFeatures(@NonNull RectF coordinates, @Nullable String... layerIds) {
     return nativeMapView.queryRenderedFeatures(coordinates, layerIds, null);
   }
 
   /**
    * Queries the map for rendered features
+   * <p>
+   * Returns an empty list if either the map or underlying render surface has been destroyed.
+   * </p>
    *
    * @param coordinates the box to query
    * @param filter      filters the returned features with an expression

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMap.java
@@ -37,6 +37,10 @@ interface NativeMap {
 
   boolean isDestroyed();
 
+  boolean hasSurface();
+
+  void setHasSurface(boolean hasSurface);
+
   //
   // Camera API
   //

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -65,8 +65,11 @@ final class NativeMapView implements NativeMap {
   // Device density
   private final float pixelRatio;
 
-  // Flag to indicating destroy was called
+  // Flag to indicate destroy was called
   private boolean destroyed = false;
+
+  // Flag to indicate surface was destroyed
+  private boolean hasSurface = false;
 
   // Holds the pointer to JNI NativeMapView
   @Keep
@@ -890,7 +893,7 @@ final class NativeMapView implements NativeMap {
   public List<Feature> queryRenderedFeatures(@NonNull PointF coordinates,
                                              @Nullable String[] layerIds,
                                              @Nullable Expression filter) {
-    if (checkState("queryRenderedFeatures")) {
+    if (checkState("queryRenderedFeatures") || !hasSurface) {
       return new ArrayList<>();
     }
     Feature[] features = nativeQueryRenderedFeaturesForPoint(coordinates.x / pixelRatio,
@@ -903,7 +906,7 @@ final class NativeMapView implements NativeMap {
   public List<Feature> queryRenderedFeatures(@NonNull RectF coordinates,
                                              @Nullable String[] layerIds,
                                              @Nullable Expression filter) {
-    if (checkState("queryRenderedFeatures")) {
+    if (checkState("queryRenderedFeatures") || !hasSurface) {
       return new ArrayList<>();
     }
     Feature[] features = nativeQueryRenderedFeaturesForBox(
@@ -1416,6 +1419,16 @@ final class NativeMapView implements NativeMap {
   @Override
   public boolean isDestroyed() {
     return destroyed;
+  }
+
+  @Override
+  public boolean hasSurface() {
+    return hasSurface;
+  }
+
+  @Override
+  public void setHasSurface(boolean hasSurface) {
+    this.hasSurface = hasSurface;
   }
 
   public interface ViewCallback {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.support.annotation.CallSuper;
 import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
-
 import com.mapbox.mapboxsdk.LibraryLoader;
 import com.mapbox.mapboxsdk.log.Logger;
 import com.mapbox.mapboxsdk.maps.MapboxMap;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
@@ -22,6 +22,7 @@ public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceVi
 
   @NonNull
   private final GLSurfaceView glSurfaceView;
+  private boolean hasSurface;
 
   public GLSurfaceViewMapRenderer(Context context,
                                   GLSurfaceView glSurfaceView,
@@ -33,11 +34,18 @@ public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceVi
     glSurfaceView.setRenderer(this);
     glSurfaceView.setRenderMode(RENDERMODE_WHEN_DIRTY);
     glSurfaceView.setPreserveEGLContextOnPause(true);
-
     glSurfaceView.getHolder().addCallback(new SurfaceHolderCallbackAdapter() {
 
       @Override
+      public void surfaceCreated(SurfaceHolder holder) {
+        super.surfaceCreated(holder);
+        hasSurface = true;
+      }
+
+      @Override
       public void surfaceDestroyed(SurfaceHolder holder) {
+        super.surfaceDestroyed(holder);
+        hasSurface = false;
         onSurfaceDestroyed();
       }
     });
@@ -74,6 +82,11 @@ public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceVi
   }
 
   @Override
+  protected void onSurfaceDestroyed() {
+    super.onSurfaceDestroyed();
+  }
+
+  @Override
   public void onSurfaceChanged(GL10 gl, int width, int height) {
     super.onSurfaceChanged(gl, width, height);
   }
@@ -90,6 +103,9 @@ public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceVi
    */
   @Override
   public void requestRender() {
+    if (!hasSurface) {
+      return;
+    }
     glSurfaceView.requestRender();
   }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/integration/QueryRenderedFeaturesBoxCountTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/integration/QueryRenderedFeaturesBoxCountTest.kt
@@ -1,0 +1,30 @@
+package com.mapbox.mapboxsdk.integration
+
+import android.support.test.filters.LargeTest
+import android.support.test.rule.ActivityTestRule
+import android.support.test.runner.AndroidJUnit4
+import com.mapbox.mapboxsdk.testapp.activity.feature.QueryRenderedFeaturesBoxCountActivity
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Regression test that validates reopening an Activity and querying the map before surface recreation #14394
+ */
+@RunWith(AndroidJUnit4::class)
+class QueryRenderedFeaturesBoxCountTest : BaseIntegrationTest() {
+
+  @get:Rule
+  var activityRule: ActivityTestRule<QueryRenderedFeaturesBoxCountActivity> =
+    ActivityTestRule(QueryRenderedFeaturesBoxCountActivity::class.java)
+
+  @Test
+  @LargeTest
+  fun reopenQueryRendererFeaturesActivity() {
+    device.waitForIdle()
+    device.pressHome()
+    device.waitForIdle()
+    device.launchActivity(activityRule.activity, QueryRenderedFeaturesBoxCountActivity::class.java)
+    device.waitForIdle()
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -608,7 +608,8 @@
         <activity
             android:name=".activity.feature.QueryRenderedFeaturesBoxCountActivity"
             android:description="@string/description_query_rendered_features_box_count"
-            android:label="@string/activity_query_rendered_features_box_count">
+            android:label="@string/activity_query_rendered_features_box_count"
+            android:launchMode="singleInstance">
             <meta-data
                 android:name="@string/category"
                 android:value="@string/category_features" />

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesBoxCountActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesBoxCountActivity.java
@@ -1,5 +1,6 @@
 package com.mapbox.mapboxsdk.testapp.activity.feature;
 
+import android.graphics.PointF;
 import android.graphics.RectF;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -89,6 +90,11 @@ public class QueryRenderedFeaturesBoxCountActivity extends AppCompatActivity {
   protected void onStart() {
     super.onStart();
     mapView.onStart();
+
+    if (mapboxMap != null) {
+      // Regression test for #14394
+      mapboxMap.queryRenderedFeatures(new PointF(0,0));
+    }
   }
 
   @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/SimpleMapActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/SimpleMapActivity.java
@@ -1,8 +1,10 @@
 package com.mapbox.mapboxsdk.testapp.activity.maplayout;
 
+import android.graphics.PointF;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.testapp.R;
 
@@ -12,6 +14,7 @@ import com.mapbox.mapboxsdk.testapp.R;
 public class SimpleMapActivity extends AppCompatActivity {
 
   private MapView mapView;
+  private MapboxMap mapboxMap;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -19,15 +22,22 @@ public class SimpleMapActivity extends AppCompatActivity {
     setContentView(R.layout.activity_map_simple);
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
-    mapView.getMapAsync(mapboxMap -> mapboxMap.setStyle(
-      new Style.Builder().fromUrl(Style.MAPBOX_STREETS)
-    ));
+    mapView.getMapAsync(map -> {
+      mapboxMap = map;
+      mapboxMap.setStyle(
+        new Style.Builder().fromUrl(Style.MAPBOX_STREETS)
+      );
+    });
   }
 
   @Override
   protected void onStart() {
     super.onStart();
     mapView.onStart();
+    if (mapboxMap != null) {
+      // Regression test for #14394
+      mapboxMap.queryRenderedFeatures(new PointF(0,0));
+    }
   }
 
   @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/SimpleMapActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/SimpleMapActivity.java
@@ -1,10 +1,8 @@
 package com.mapbox.mapboxsdk.testapp.activity.maplayout;
 
-import android.graphics.PointF;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.testapp.R;
 
@@ -14,7 +12,6 @@ import com.mapbox.mapboxsdk.testapp.R;
 public class SimpleMapActivity extends AppCompatActivity {
 
   private MapView mapView;
-  private MapboxMap mapboxMap;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -22,22 +19,15 @@ public class SimpleMapActivity extends AppCompatActivity {
     setContentView(R.layout.activity_map_simple);
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
-    mapView.getMapAsync(map -> {
-      mapboxMap = map;
-      mapboxMap.setStyle(
-        new Style.Builder().fromUrl(Style.MAPBOX_STREETS)
-      );
-    });
+    mapView.getMapAsync(mapboxMap -> mapboxMap.setStyle(
+      new Style.Builder().fromUrl(Style.MAPBOX_STREETS)
+    ));
   }
 
   @Override
   protected void onStart() {
     super.onStart();
     mapView.onStart();
-    if (mapboxMap != null) {
-      // Regression test for #14394
-      mapboxMap.queryRenderedFeatures(new PointF(0,0));
-    }
   }
 
   @Override


### PR DESCRIPTION
Closes #14394, this PR hardens querying the map when the underlying surface is being recreated. With 7.3.0, we changed the lifespan of the renderer to match the surface (instead of the MapView). This change resulted in that the API found on our core renderer isn't usable directly after resuming an Activity. Checking if we have a surface solves that but this is something we need to revisit in the long run in a cleaner way.

This PR adds a regression test, additional javadoc explaining the issue and the actual fix. 

cc @Guardiola31337  