### PR TITLE
Ignore equal offline region's download state updates

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegion.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegion.java
@@ -306,6 +306,10 @@ public class OfflineRegion {
    * @param state the download state
    */
   public void setDownloadState(@DownloadState int state) {
+    if (this.state == state) {
+      return;
+    }
+
     if (state == STATE_ACTIVE) {
       fileSource.activate();
     } else {


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/14398.

Ignores equal updates to not alter the `FileSource's` counter.