### PR TITLE
[android] Introduce AccountsManager to support SKU tokens in API requests

### DIFF
--- a/platform/android/LICENSE.md
+++ b/platform/android/LICENSE.md
@@ -71,6 +71,12 @@ License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
+Mapbox GL uses portions of the Mapbox Accounts SDK for Android.  
+URL: [https://github.com/mapbox/mapbox-accounts-android](https://github.com/mapbox/mapbox-accounts-android)  
+License: [Mapbox Terms of Service](https://www.mapbox.com/tos/)
+
+===========================================================================
+
 Mapbox GL uses portions of the Mapbox Android Core Library.  
 URL: [https://github.com/mapbox/mapbox-events-android](https://github.com/mapbox/mapbox-events-android)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)

--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     api dependenciesList.mapboxAndroidTelemetry
     api dependenciesList.mapboxJavaGeoJSON
     api dependenciesList.mapboxAndroidGestures
+    api dependenciesList.mapboxAndroidAccounts
     implementation dependenciesList.mapboxJavaTurf
     implementation dependenciesList.supportAnnotations
     implementation dependenciesList.supportFragmentV4

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/AccountsManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/AccountsManager.java
@@ -10,9 +10,21 @@ import com.mapbox.android.accounts.v1.MapboxAccounts;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 
 /**
- * This class wraps the functionality provided by MapboxAccounts and manages its state
- * using Android's SharedPreferences for storage. This class is meant for internal SDK
- * usage only.
+ * REMOVAL OR MODIFICATION OF THE FOLLOWING CODE VIOLATES THE MAPBOX TERMS
+ * OF SERVICE
+ *
+ * The following code is used to access Mapbox's Mapping APIs.
+ *
+ * Removal or modification of this code when used with Mapbox's Mapping APIs
+ * can result in termination of your agreement and/or your account with
+ * Mapbox.
+ *
+ * Using this code to access Mapbox Mapping APIs from outside the Mapbox Maps
+ * SDK also violates the Mapbox Terms of Service. On Android, Mapping APIs
+ * should be accessed using the methods documented at
+ * https://www.mapbox.com/android.
+ *
+ * You can access the Mapbox Terms of Service at https://www.mapbox.com/tos/
  */
 class AccountsManager {
   private static final String PREFERENCE_USER_ID = "com.mapbox.mapboxsdk.accounts.userid";

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/AccountsManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/AccountsManager.java
@@ -3,9 +3,10 @@ package com.mapbox.mapboxsdk;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 import android.text.format.DateUtils;
 
-import com.mapbox.core.utils.TextUtils;
+import com.mapbox.android.accounts.v1.MapboxAccounts;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 
 /**
@@ -89,11 +90,11 @@ class AccountsManager {
 
   @NonNull
   private String generateUserId() {
-    return "placeholder"; // TODO
+    return MapboxAccounts.obtainEndUserId();
   }
 
   @NonNull
   private String generateSkuToken(String userId) {
-    return "placeholder"; // TODO
+    return MapboxAccounts.obtainMapsSkuUserToken(userId);
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/AccountsManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/AccountsManager.java
@@ -14,7 +14,7 @@ import java.util.Calendar;
  * using Android's SharedPreferences for storage. This class is meant for internal SDK
  * usage only.
  */
-class MapboxAccounts {
+class AccountsManager {
 
   // TODO: Move to Constants? Repeated in FileSource.
   private static final String MAPBOX_SHARED_PREFERENCES = "MapboxSharedPreferences";
@@ -28,7 +28,7 @@ class MapboxAccounts {
   private long timestamp;
   private String skuToken;
 
-  MapboxAccounts() {
+  AccountsManager() {
     String userId = validateUserId();
     validateRotation(userId);
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/AccountsManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/AccountsManager.java
@@ -15,11 +15,11 @@ import java.util.Calendar;
  * usage only.
  */
 class AccountsManager {
-  private final static String PREFERENCE_USER_ID = "com.mapbox.mapboxsdk.accounts.userid";
-  private final static String PREFERENCE_TIMESTAMP = "com.mapbox.mapboxsdk.accounts.timestamp";
-  private final static String PREFERENCE_SKU_TOKEN = "com.mapbox.mapboxsdk.accounts.skutoken";
+  private static final String PREFERENCE_USER_ID = "com.mapbox.mapboxsdk.accounts.userid";
+  private static final String PREFERENCE_TIMESTAMP = "com.mapbox.mapboxsdk.accounts.timestamp";
+  private static final String PREFERENCE_SKU_TOKEN = "com.mapbox.mapboxsdk.accounts.skutoken";
 
-  private final static long ONE_HOUR_MILLIS = 60 * 60 * 1_000L;
+  static final long ONE_HOUR_MILLIS = 60 * 60 * 1_000L;
 
   private long timestamp;
   private String skuToken;
@@ -64,7 +64,11 @@ class AccountsManager {
   }
 
   private boolean isExpired() {
-    return (getNow() - timestamp > ONE_HOUR_MILLIS);
+    return isExpired(getNow(), timestamp);
+  }
+
+  static boolean isExpired(long now, long then) {
+    return ((now - then) > ONE_HOUR_MILLIS);
   }
 
   private long persistRotation(String skuToken) {
@@ -81,7 +85,7 @@ class AccountsManager {
       .getSharedPreferences(MapboxConstants.MAPBOX_SHARED_PREFERENCES, Context.MODE_PRIVATE);
   }
 
-  private long getNow() {
+  static long getNow() {
     return Calendar.getInstance(MapboxConstants.MAPBOX_LOCALE).getTimeInMillis();
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/AccountsManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/AccountsManager.java
@@ -15,10 +15,6 @@ import java.util.Calendar;
  * usage only.
  */
 class AccountsManager {
-
-  // TODO: Move to Constants? Repeated in FileSource.
-  private static final String MAPBOX_SHARED_PREFERENCES = "MapboxSharedPreferences";
-
   private final static String PREFERENCE_USER_ID = "com.mapbox.mapboxsdk.accounts.userid";
   private final static String PREFERENCE_TIMESTAMP = "com.mapbox.mapboxsdk.accounts.timestamp";
   private final static String PREFERENCE_SKU_TOKEN = "com.mapbox.mapboxsdk.accounts.skutoken";
@@ -81,7 +77,8 @@ class AccountsManager {
   }
 
   private @NonNull SharedPreferences getSharedPreferences() {
-    return Mapbox.getApplicationContext().getSharedPreferences(MAPBOX_SHARED_PREFERENCES, Context.MODE_PRIVATE);
+    return Mapbox.getApplicationContext()
+      .getSharedPreferences(MapboxConstants.MAPBOX_SHARED_PREFERENCES, Context.MODE_PRIVATE);
   }
 
   private long getNow() {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/AccountsManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/AccountsManager.java
@@ -3,11 +3,10 @@ package com.mapbox.mapboxsdk;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
+import android.text.format.DateUtils;
 
 import com.mapbox.core.utils.TextUtils;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
-
-import java.util.Calendar;
 
 /**
  * This class wraps the functionality provided by MapboxAccounts and manages its state
@@ -18,8 +17,6 @@ class AccountsManager {
   private static final String PREFERENCE_USER_ID = "com.mapbox.mapboxsdk.accounts.userid";
   private static final String PREFERENCE_TIMESTAMP = "com.mapbox.mapboxsdk.accounts.timestamp";
   private static final String PREFERENCE_SKU_TOKEN = "com.mapbox.mapboxsdk.accounts.skutoken";
-
-  static final long ONE_HOUR_MILLIS = 60 * 60 * 1_000L;
 
   private long timestamp;
   private String skuToken;
@@ -68,7 +65,7 @@ class AccountsManager {
   }
 
   static boolean isExpired(long now, long then) {
-    return ((now - then) > ONE_HOUR_MILLIS);
+    return ((now - then) > DateUtils.HOUR_IN_MILLIS);
   }
 
   private long persistRotation(String skuToken) {
@@ -80,20 +77,23 @@ class AccountsManager {
     return now;
   }
 
-  private @NonNull SharedPreferences getSharedPreferences() {
+  @NonNull
+  private SharedPreferences getSharedPreferences() {
     return Mapbox.getApplicationContext()
-      .getSharedPreferences(MapboxConstants.MAPBOX_SHARED_PREFERENCES, Context.MODE_PRIVATE);
+        .getSharedPreferences(MapboxConstants.MAPBOX_SHARED_PREFERENCES, Context.MODE_PRIVATE);
   }
 
   static long getNow() {
-    return Calendar.getInstance(MapboxConstants.MAPBOX_LOCALE).getTimeInMillis();
+    return System.currentTimeMillis();
   }
 
-  private @NonNull String generateUserId() {
+  @NonNull
+  private String generateUserId() {
     return "placeholder"; // TODO
   }
 
-  private @NonNull String generateSkuToken(String userId) {
+  @NonNull
+  private String generateSkuToken(String userId) {
     return "placeholder"; // TODO
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
@@ -34,6 +34,8 @@ public final class Mapbox {
   private String accessToken;
   @Nullable
   private TelemetryDefinition telemetry;
+  @Nullable
+  private MapboxAccounts accounts;
 
   /**
    * Get an instance of Mapbox.
@@ -56,6 +58,7 @@ public final class Mapbox {
       INSTANCE = new Mapbox(appContext, accessToken);
       if (isAccessTokenValid(accessToken)) {
         initializeTelemetry();
+        INSTANCE.accounts = new MapboxAccounts();
       }
       ConnectivityReceiver.instance(appContext);
     }
@@ -85,6 +88,11 @@ public final class Mapbox {
     validateMapbox();
     INSTANCE.accessToken = accessToken;
     FileSource.getInstance(getApplicationContext()).setAccessToken(accessToken);
+  }
+
+  public static String getSkuToken() {
+    validateMapbox();
+    return INSTANCE.accounts.getSkuToken();
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
@@ -90,8 +90,13 @@ public final class Mapbox {
     FileSource.getInstance(getApplicationContext()).setAccessToken(accessToken);
   }
 
+  /**
+   * Returns a SKU token, refreshed if necessary. This method is meant for internal SDK
+   * usage only.
+   *
+   * @return the SKU token
+   */
   public static String getSkuToken() {
-    validateMapbox();
     return INSTANCE.accounts.getSkuToken();
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
@@ -35,7 +35,7 @@ public final class Mapbox {
   @Nullable
   private TelemetryDefinition telemetry;
   @Nullable
-  private MapboxAccounts accounts;
+  private AccountsManager accounts;
 
   /**
    * Get an instance of Mapbox.
@@ -58,7 +58,7 @@ public final class Mapbox {
       INSTANCE = new Mapbox(appContext, accessToken);
       if (isAccessTokenValid(accessToken)) {
         initializeTelemetry();
-        INSTANCE.accounts = new MapboxAccounts();
+        INSTANCE.accounts = new AccountsManager();
       }
       ConnectivityReceiver.instance(appContext);
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/MapboxAccounts.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/MapboxAccounts.java
@@ -1,0 +1,68 @@
+package com.mapbox.mapboxsdk;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
+
+import com.mapbox.core.utils.TextUtils;
+import com.mapbox.mapboxsdk.constants.MapboxConstants;
+
+import java.util.Calendar;
+
+class MapboxAccounts {
+
+  // TODO: Move to Constants? Repeated in FileSource.
+  private static final String MAPBOX_SHARED_PREFERENCES = "MapboxSharedPreferences";
+
+  private final static String PREFERENCE_TIMESTAMP = "com.mapbox.mapboxsdk.accounts.timestamp";
+  private final static String PREFERENCE_SKU_TOKEN = "com.mapbox.mapboxsdk.accounts.skutoken";
+
+  private final static long ONE_HOUR_MILLIS = 60 * 60 * 1_000L;
+
+  private long timestamp;
+  private String skuToken;
+
+  MapboxAccounts() {
+    SharedPreferences sharedPreferences = getSharedPreferences();
+    timestamp = sharedPreferences.getLong(PREFERENCE_TIMESTAMP, 0L);
+    skuToken = sharedPreferences.getString(PREFERENCE_SKU_TOKEN, "");
+    if (timestamp == 0L || TextUtils.isEmpty(skuToken)) {
+      skuToken = generateSkuToken();
+      timestamp = persistToken(skuToken);
+    }
+  }
+
+  String getSkuToken() {
+    if (isExpired()) {
+      skuToken = generateSkuToken();
+      timestamp = persistToken(skuToken);
+    }
+
+    return skuToken;
+  }
+
+  private boolean isExpired() {
+    return (getNow() - timestamp > ONE_HOUR_MILLIS);
+  }
+
+  private long persistToken(String skuToken) {
+    long now = getNow();
+    SharedPreferences.Editor editor = getSharedPreferences().edit();
+    editor.putLong(PREFERENCE_TIMESTAMP, now);
+    editor.putString(PREFERENCE_SKU_TOKEN, skuToken);
+    editor.apply();
+    return now;
+  }
+
+  private @NonNull SharedPreferences getSharedPreferences() {
+    return Mapbox.getApplicationContext().getSharedPreferences(MAPBOX_SHARED_PREFERENCES, Context.MODE_PRIVATE);
+  }
+
+  private long getNow() {
+    return Calendar.getInstance(MapboxConstants.MAPBOX_LOCALE).getTimeInMillis();
+  }
+
+  private @NonNull String generateSkuToken() {
+    return "placeholder"; // TODO
+  }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
@@ -13,6 +13,11 @@ public class MapboxConstants {
   public static final Locale MAPBOX_LOCALE = Locale.US;
 
   /**
+   * The name of the desired preferences file for Android's SharedPreferences.
+   */
+  public static final String MAPBOX_SHARED_PREFERENCES = "MapboxSharedPreferences";
+
+  /**
    * Key used to switch storage to external in AndroidManifest.xml
    */
   public static final String KEY_META_DATA_SET_STORAGE_EXTERNAL = "com.mapbox.SetStorageExternal";

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HttpRequestUrl.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HttpRequestUrl.java
@@ -2,6 +2,8 @@ package com.mapbox.mapboxsdk.http;
 
 import android.support.annotation.NonNull;
 
+import com.mapbox.mapboxsdk.Mapbox;
+
 public class HttpRequestUrl {
 
   private HttpRequestUrl() {
@@ -22,7 +24,7 @@ public class HttpRequestUrl {
       } else {
         resourceUrl = resourceUrl + "&";
       }
-      resourceUrl = resourceUrl + "events=true";
+      resourceUrl = resourceUrl + "events=true&sku=" + Mapbox.getSkuToken();
     }
     return resourceUrl;
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/telemetry/TelemetryImpl.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/telemetry/TelemetryImpl.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.support.annotation.FloatRange;
 import android.support.annotation.NonNull;
 
+import com.mapbox.android.accounts.v1.MapboxAccounts;
 import com.mapbox.android.telemetry.AppUserTurnstile;
 import com.mapbox.android.telemetry.MapboxTelemetry;
 import com.mapbox.android.telemetry.SessionInterval;
@@ -40,7 +41,7 @@ public class TelemetryImpl implements TelemetryDefinition {
   public void onAppUserTurnstileEvent() {
     AppUserTurnstile turnstileEvent = new AppUserTurnstile(BuildConfig.MAPBOX_SDK_IDENTIFIER,
       BuildConfig.MAPBOX_SDK_VERSION);
-    turnstileEvent.setSkuId(Mapbox.getSkuToken());
+    turnstileEvent.setSkuId(MapboxAccounts.SKU_ID_MAPS_MAUS);
     telemetry.push(turnstileEvent);
     telemetry.push(MapEventFactory.buildMapLoadEvent(new PhoneState(appContext)));
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/telemetry/TelemetryImpl.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/telemetry/TelemetryImpl.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.FloatRange;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import com.mapbox.android.telemetry.AppUserTurnstile;
 import com.mapbox.android.telemetry.MapboxTelemetry;
@@ -21,9 +20,8 @@ import java.util.UUID;
 
 public class TelemetryImpl implements TelemetryDefinition {
 
-  @Nullable
-  private MapboxTelemetry telemetry;
-  private Context appContext;
+  private final MapboxTelemetry telemetry;
+  private final Context appContext;
 
   public TelemetryImpl() {
     appContext = Mapbox.getApplicationContext();
@@ -42,6 +40,7 @@ public class TelemetryImpl implements TelemetryDefinition {
   public void onAppUserTurnstileEvent() {
     AppUserTurnstile turnstileEvent = new AppUserTurnstile(BuildConfig.MAPBOX_SDK_IDENTIFIER,
       BuildConfig.MAPBOX_SDK_VERSION);
+    turnstileEvent.setSkuId(Mapbox.getSkuToken());
     telemetry.push(turnstileEvent);
     telemetry.push(MapEventFactory.buildMapLoadEvent(new PhoneState(appContext)));
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
@@ -31,7 +31,6 @@ import java.util.concurrent.locks.ReentrantLock;
 public class FileSource {
 
   private static final String TAG = "Mbgl-FileSource";
-  private static final String MAPBOX_SHARED_PREFERENCES = "MapboxSharedPreferences";
   private static final String MAPBOX_SHARED_PREFERENCE_RESOURCES_CACHE_PATH = "fileSourceResourcesCachePath";
   private static final Lock resourcesCachePathLoaderLock = new ReentrantLock();
   private static final Lock internalCachePathLoaderLock = new ReentrantLock();
@@ -107,7 +106,7 @@ public class FileSource {
    */
   @NonNull
   private static String getCachePath(@NonNull Context context) {
-    SharedPreferences preferences = context.getSharedPreferences(MAPBOX_SHARED_PREFERENCES, Context.MODE_PRIVATE);
+    SharedPreferences preferences = context.getSharedPreferences(MapboxConstants.MAPBOX_SHARED_PREFERENCES, Context.MODE_PRIVATE);
     String cachePath = preferences.getString(MAPBOX_SHARED_PREFERENCE_RESOURCES_CACHE_PATH, null);
 
     if (!isPathWritable(cachePath)) {
@@ -116,7 +115,7 @@ public class FileSource {
 
       // Reset stored cache path
       SharedPreferences.Editor editor =
-        context.getSharedPreferences(MAPBOX_SHARED_PREFERENCES, Context.MODE_PRIVATE).edit();
+        context.getSharedPreferences(MapboxConstants.MAPBOX_SHARED_PREFERENCES, Context.MODE_PRIVATE).edit();
       editor.remove(MAPBOX_SHARED_PREFERENCE_RESOURCES_CACHE_PATH).apply();
     }
 
@@ -306,7 +305,7 @@ public class FileSource {
             callback.onError(fileSourceActivatedMessage);
           } else {
             final SharedPreferences.Editor editor =
-              context.getSharedPreferences(MAPBOX_SHARED_PREFERENCES, Context.MODE_PRIVATE).edit();
+              context.getSharedPreferences(MapboxConstants.MAPBOX_SHARED_PREFERENCES, Context.MODE_PRIVATE).edit();
             editor.putString(MAPBOX_SHARED_PREFERENCE_RESOURCES_CACHE_PATH, path);
             editor.apply();
             setResourcesCachePath(context, path);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
@@ -106,7 +106,8 @@ public class FileSource {
    */
   @NonNull
   private static String getCachePath(@NonNull Context context) {
-    SharedPreferences preferences = context.getSharedPreferences(MapboxConstants.MAPBOX_SHARED_PREFERENCES, Context.MODE_PRIVATE);
+    SharedPreferences preferences = context.getSharedPreferences(
+      MapboxConstants.MAPBOX_SHARED_PREFERENCES, Context.MODE_PRIVATE);
     String cachePath = preferences.getString(MAPBOX_SHARED_PREFERENCE_RESOURCES_CACHE_PATH, null);
 
     if (!isPathWritable(cachePath)) {

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/AccountsManagerTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/AccountsManagerTest.java
@@ -1,0 +1,22 @@
+package com.mapbox.mapboxsdk;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AccountsManagerTest {
+  @Test
+  public void testIsExpired() {
+    long now = AccountsManager.getNow();
+
+    long defaultValue = 0L;
+    long tooOld = now - AccountsManager.ONE_HOUR_MILLIS - 1;
+    long futureValue = now + 1;
+    long immediatePast = now - 1;
+
+    Assert.assertTrue(AccountsManager.isExpired(now, defaultValue));
+    Assert.assertTrue(AccountsManager.isExpired(now, tooOld));
+
+    Assert.assertFalse(AccountsManager.isExpired(now, futureValue));
+    Assert.assertFalse(AccountsManager.isExpired(now, immediatePast));
+  }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/AccountsManagerTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/AccountsManagerTest.java
@@ -1,5 +1,7 @@
 package com.mapbox.mapboxsdk;
 
+import android.text.format.DateUtils;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -9,7 +11,7 @@ public class AccountsManagerTest {
     long now = AccountsManager.getNow();
 
     long defaultValue = 0L;
-    long tooOld = now - AccountsManager.ONE_HOUR_MILLIS - 1;
+    long tooOld = now - DateUtils.HOUR_IN_MILLIS - 1;
     long futureValue = now + 1;
     long immediatePast = now - 1;
 

--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -11,6 +11,7 @@ ext {
             mapboxTelemetry : '4.4.1',
             mapboxCore      : '1.3.0',
             mapboxGestures  : '0.4.1',
+            mapboxAccounts  : '0.1.0',
             supportLib      : '27.1.1',
             constraintLayout: '1.1.2',
             uiAutomator     : '2.1.3',
@@ -39,6 +40,7 @@ ext {
             mapboxJavaGeoJSON      : "com.mapbox.mapboxsdk:mapbox-sdk-geojson:${versions.mapboxServices}",
             mapboxAndroidTelemetry : "com.mapbox.mapboxsdk:mapbox-android-telemetry:${versions.mapboxTelemetry}",
             mapboxAndroidGestures  : "com.mapbox.mapboxsdk:mapbox-android-gestures:${versions.mapboxGestures}",
+            mapboxAndroidAccounts  : "com.mapbox.mapboxsdk:mapbox-android-accounts:${versions.mapboxAccounts}",
             mapboxJavaTurf         : "com.mapbox.mapboxsdk:mapbox-sdk-turf:${versions.mapboxServices}",
 
             junit                  : "junit:junit:${versions.junit}",


### PR DESCRIPTION
This PR proposes a new `AccountsManager` object, instantiated within the regular `Mapbox` object, that manages the state and rotation of SKU tokens. SKU tokens are added to Mapbox API requests only.

It relies on Android's `SharedPreferences` for storage, and proposes a centralized `MapboxConstants.MAPBOX_SHARED_PREFERENCES` to be shared with `FileSource` values.

Before being able to merge this PR we need to add two extra dependencies:
- [x] Updated Telemetry SDK supporting SKU token mode for turnstile events.
- [x] `MapboxAccounts` library to generate the content of the SKU tokens.

/cc: @friedbunny 