### PR TITLE
[ios, macos] Fix MGLSymbolStyleLayer.text localization issue.

### DIFF
--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -356,6 +356,9 @@ global.propertyDoc = function (propertyName, property, layerType, kind) {
             doc += '* Constant array, whose each element is any of the following constant string values:\n';
             doc += Object.keys(property.values).map(value => '  * `' + value + '`: ' + property.values[value].doc).join('\n') + '\n';
         }
+        if (property.type === 'formatted') {
+            doc += '* Formatted expressions.\n';
+        }
         doc += '* Predefined functions, including mathematical and string operators\n' +
             '* Conditional expressions\n' +
             '* Variable assignments and references to assigned variables\n';

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -1086,6 +1086,7 @@ MGL_EXPORT
  You can set this property to an expression containing any of the following:
  
  * Constant string values
+ * Formatted expressions.
  * Predefined functions, including mathematical and string operators
  * Conditional expressions
  * Variable assignments and references to assigned variables

--- a/platform/darwin/src/NSExpression+MGLAdditions.mm
+++ b/platform/darwin/src/NSExpression+MGLAdditions.mm
@@ -1471,6 +1471,12 @@ NSDictionary<NSNumber *, NSExpression *> *MGLLocalizedStopDictionary(NSDictionar
                 if (localizedValues != self.constantValue) {
                     return [NSExpression expressionForConstantValue:localizedValues];
                 }
+            } else if ([self.constantValue isKindOfClass:[MGLAttributedExpression class]]) {
+                MGLAttributedExpression *attributedExpression = (MGLAttributedExpression *)self.constantValue;
+                NSExpression *localizedExpression = [attributedExpression.expression mgl_expressionLocalizedIntoLocale:locale];
+                MGLAttributedExpression *localizedAttributedExpression = [MGLAttributedExpression attributedExpression:localizedExpression attributes:attributedExpression.attributes];
+                
+                return [NSExpression expressionForConstantValue:localizedAttributedExpression];
             }
             return self;
         }

--- a/platform/darwin/test/MGLExpressionTests.mm
+++ b/platform/darwin/test/MGLExpressionTests.mm
@@ -1200,6 +1200,16 @@ using namespace std::string_literals;
         XCTAssertEqualObjects([original mgl_expressionLocalizedIntoLocale:nil], expected);
     }
     {
+        NSExpression *keyExpression = [NSExpression expressionForKeyPath:@"name_en"];
+        MGLAttributedExpression *attributedExpression = [MGLAttributedExpression attributedExpression:keyExpression attributes:@{}];
+        NSExpression *original = [NSExpression expressionForConstantValue:attributedExpression];
+        
+        NSExpression *coalesceExpression = [NSExpression expressionWithFormat:@"mgl_coalesce({%K, %K})", @"name_en", @"name"];
+        MGLAttributedExpression *expectedAttributedExpression = [MGLAttributedExpression attributedExpression:coalesceExpression attributes:@{}];
+        NSExpression *expected = [NSExpression expressionForConstantValue:expectedAttributedExpression];
+        XCTAssertEqualObjects([original mgl_expressionLocalizedIntoLocale:nil], expected);
+    }
+    {
         NSExpression *original = [NSExpression expressionForKeyPath:@"name_en"];
         NSExpression *expected = [NSExpression expressionWithFormat:@"mgl_coalesce({%K, %K})", @"name_en", @"name"];
         XCTAssertEqualObjects([original mgl_expressionLocalizedIntoLocale:nil], expected);


### PR DESCRIPTION
Fixes #14393 introduced in https://github.com/mapbox/mapbox-gl-native/pull/14094

Localization was not performed due to the introduction of `MGLAttributedExpression` object. At localization time there was not a proper converter for format expressions, returning the same expression thus avoiding localization.

### This is how it looks now on iOS
![german](https://user-images.githubusercontent.com/2745166/55995814-58589580-5c6a-11e9-8248-c25417ccc138.png)

### This is how it looks now on macOS
<img width="1060" alt="germanmacos" src="https://user-images.githubusercontent.com/2745166/55995840-72927380-5c6a-11e9-9874-f1745faf4cbe.png">
