### PR TITLE
[ios, macos] Premultiply color values for mgl_color

### DIFF
--- a/platform/darwin/test/MGLExpressionTests.mm
+++ b/platform/darwin/test/MGLExpressionTests.mm
@@ -282,9 +282,14 @@ using namespace std::string_literals;
         XCTAssertEqualObjects([expression expressionValueWithObject:nil context:nil], color);
     }
     {
-        MGLColor *color = [MGLColor mgl_colorWithColor:{ 255.0/255, 239.0/255, 213.0/255, 0.5 }]; // papayawhip
+        // Transform color components to non-premultiplied values
+        float alpha = 0.5;
+        float red = (255.0 * alpha) / 255;
+        float green = (239.0 * alpha) / 255;
+        float blue = (213.0 * alpha) / 255;
+        MGLColor *color = [MGLColor mgl_colorWithColor:{ red, green, blue, alpha }]; // papayawhip
         NSExpression *expression = [NSExpression expressionForConstantValue:color];
-        NSArray *jsonExpression = @[@"rgba", @255, @239, @213, @0.5];
+        NSArray *jsonExpression = @[@"rgba", @127.5, @119.5, @106.5, @0.5];
         XCTAssertEqualObjects(expression.mgl_jsonExpressionObject, jsonExpression);
         XCTAssertEqualObjects([expression expressionValueWithObject:nil context:nil], color);
     }

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Fixed an Interface Builder crash when using an `MGLMapView` in a storyboard. ([#14379](https://github.com/mapbox/mapbox-gl-native/pull/14379))
 * Fix a bug that wrong position of attribution dialog after rotation. ([#14185](https://github.com/mapbox/mapbox-gl-native/pull/14185))
+* Fixed a bug where non-opaque `UIColor` values were ignored when assigned to a style layer color property. ([#14406](https://github.com/mapbox/mapbox-gl-native/pull/14406))
 
 ## 4.10.0
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Added `mgl_attributed:` expression operator, which concatenate `MGLAttributedExpression` objects for specifying rich text in the `MGLSymbolStyleLayer.text` property. ([#14094](https://github.com/mapbox/mapbox-gl-native/pull/14094))
 * Fixed an issue that caused conditional expressions to crash when passed nested conditional expressions as parameters. ([#14181](https://github.com/mapbox/mapbox-gl-native/pull/14181))
 * Added `-[MGLMapViewDelegate mapView:didFailToLoadImage:]` to load missing symbol icons in the style if they are not found. ([#14302](https://github.com/mapbox/mapbox-gl-native/pull/14302))
+* Fixed a bug where non-opaque `NSColor` values were ignored when assigned to a style layer color property. ([#14406](https://github.com/mapbox/mapbox-gl-native/pull/14406))
 
 ### Offline
 

--- a/platform/macos/src/NSColor+MGLAdditions.mm
+++ b/platform/macos/src/NSColor+MGLAdditions.mm
@@ -15,15 +15,34 @@
     }
     [srgbColor getRed:&r green:&g blue:&b alpha:&a];
 
-    return { (float)r, (float)g, (float)b, (float)a };
+    // NSColor provides non-premultiplied color components, so we have to premultiply each
+    // color component with the alpha value to transform it into a valid
+    // mbgl::Color which expects premultiplied color components.
+    return { static_cast<float>(r*a), static_cast<float>(g*a), static_cast<float>(b*a), static_cast<float>(a) };
 }
 
 + (NSColor *)mgl_colorWithColor:(mbgl::Color)color {
+    // If there is no alpha value, return original color values.
+    if (color.a == 0.0f) {
+        // macOS 10.12 Sierra and below uses calibrated RGB by default.
+        if ([NSColor redColor].colorSpaceName == NSCalibratedRGBColorSpace) {
+            return [NSColor colorWithCalibratedRed:color.r green:color.g blue:color.b alpha:color.a];
+        } else {
+            return [NSColor colorWithRed:color.r green:color.g blue:color.b alpha:color.a];
+        }
+    }
+    
+    // mbgl::Color provides premultiplied color components, so we have to convert color
+    // components to non-premultiplied values to return a valid NSColor object.
+    float red = static_cast<float>((color.r / color.a));
+    float green = static_cast<float>((color.g / color.a));
+    float blue = static_cast<float>((color.b / color.a));
+
     // macOS 10.12 Sierra and below uses calibrated RGB by default.
     if ([NSColor redColor].colorSpaceName == NSCalibratedRGBColorSpace) {
-        return [NSColor colorWithCalibratedRed:color.r green:color.g blue:color.b alpha:color.a];
+        return [NSColor colorWithCalibratedRed:red green:green blue:blue alpha:color.a];
     } else {
-        return [NSColor colorWithRed:color.r green:color.g blue:color.b alpha:color.a];
+        return [NSColor colorWithRed:red green:green blue:blue alpha:color.a];
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/14329

![halo](https://user-images.githubusercontent.com/10850812/56003762-f7868880-5c7c-11e9-88df-6349e7366617.png)

Left: `MGLSymbolStyleLayer.textHaloColor` set to `[UIColor colorWithRed:1 green:1 blue:1 alpha:1]`
Right: `MGLSymbolStyleLayer.textHaloColor` set to `[UIColor colorWithRed:1 green:1 blue:1 alpha:0.4]`