### PR TITLE
[android] - allow snapshot generation without overlain view content

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -1047,10 +1047,15 @@ final class NativeMapView implements NativeMap {
     if (checkState("OnSnapshotReady")) {
       return;
     }
-
-    Bitmap viewContent = viewCallback.getViewContent();
-    if (snapshotReadyCallback != null && mapContent != null && viewContent != null) {
-      snapshotReadyCallback.onSnapshotReady(BitmapUtils.mergeBitmap(mapContent, viewContent));
+    if (snapshotReadyCallback != null && mapContent != null) {
+      if (viewCallback == null) {
+        snapshotReadyCallback.onSnapshotReady(mapContent);
+      } else {
+        Bitmap viewContent = viewCallback.getViewContent();
+        if (viewContent != null) {
+          snapshotReadyCallback.onSnapshotReady(BitmapUtils.mergeBitmap(mapContent, viewContent));
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Attaching a ViewCallback to get the bitmap content of overlain elements is optional/nullable. 
This PR takes nullability of the ViewCallback in account for snapshot creation. 