### PR TITLE
Mapbox Java SDK upgrade to 4.6.0 

### DIFF
--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
     ]
 
     versions = [
-            mapboxServices  : '4.3.0',
+            mapboxServices  : '4.6.0',
             mapboxTelemetry : '4.3.0',
             mapboxGestures  : '0.4.0',
             supportLib      : '27.1.1',


### PR DESCRIPTION
Mapbox Java SDK upgrade to [4.6.0 ](https://github.com/mapbox/mapbox-java/releases).

It includes removal of java files from Mapbox Java SDK jars.
GeoJson implementation is no longer dependent on AutoValue library.
The above two items contributed to a quoter size reduction of the geojson jar.

closes https://github.com/mapbox/mapbox-java/issues/994