### PR TITLE
Update mapbox java to v4.6.0

### DIFF
--- a/platform/android/LICENSE.md
+++ b/platform/android/LICENSE.md
@@ -66,11 +66,6 @@ License: [The Apache Software License](http://www.apache.org/licenses/LICENSE-2.
 
 ===========================================================================
 
-Mapbox GL uses portions of the Converter: Gson.  
-License: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
 Mapbox GL uses portions of the Gson.  
 License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -106,18 +101,7 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
-Mapbox GL uses portions of the Mapbox Services SDK.  
-URL: [https://github.com/mapbox/mapbox-java](https://github.com/mapbox/mapbox-java)  
-License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
 Mapbox GL uses portions of the OkHttp.  
-License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
-Mapbox GL uses portions of the OkHttp Logging Interceptor.  
 License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
@@ -130,11 +114,6 @@ License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 Mapbox GL uses portions of the ReLinker.  
 URL: [https://github.com/KeepSafe/ReLinker](https://github.com/KeepSafe/ReLinker)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
-Mapbox GL uses portions of the Retrofit.  
-License: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 

--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
     ]
 
     versions = [
-            mapboxServices  : '4.3.0',
+            mapboxServices  : '4.6.0',
             mapboxTelemetry : '4.3.0',
             mapboxGestures  : '0.4.0',
             supportLib      : '27.1.1',


### PR DESCRIPTION
This PR updates mapbox-java to [v4.6.0](https://github.com/mapbox/mapbox-java/releases/tag/v4.6.0).