### PR TITLE
Unify has surface state handling

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -289,12 +289,6 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
           MapView.this.onSurfaceCreated();
           super.onSurfaceCreated(gl, config);
         }
-
-        @Override
-        protected void onSurfaceDestroyed() {
-          super.onSurfaceDestroyed();
-          MapView.this.onSurfaceDestroyed();
-        }
       };
 
       addView(textureView, 0);
@@ -306,12 +300,6 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
         public void onSurfaceCreated(GL10 gl, EGLConfig config) {
           MapView.this.onSurfaceCreated();
           super.onSurfaceCreated(gl, config);
-        }
-
-        @Override
-        protected void onSurfaceDestroyed() {
-          super.onSurfaceDestroyed();
-          MapView.this.onSurfaceDestroyed();
         }
       };
 
@@ -325,7 +313,6 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   }
 
   private void onSurfaceCreated() {
-    nativeMapView.setHasSurface(true);
     post(new Runnable() {
       @Override
       public void run() {
@@ -336,12 +323,6 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
         }
       }
     });
-  }
-
-  private void onSurfaceDestroyed() {
-    if (nativeMapView != null) {
-      nativeMapView.setHasSurface(false);
-    }
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMap.java
@@ -37,10 +37,6 @@ interface NativeMap {
 
   boolean isDestroyed();
 
-  boolean hasSurface();
-
-  void setHasSurface(boolean hasSurface);
-
   //
   // Camera API
   //

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -68,9 +68,6 @@ final class NativeMapView implements NativeMap {
   // Flag to indicate destroy was called
   private boolean destroyed = false;
 
-  // Flag to indicate surface was destroyed
-  private boolean hasSurface = false;
-
   // Holds the pointer to JNI NativeMapView
   @Keep
   private long nativePtr = 0;
@@ -535,7 +532,7 @@ final class NativeMapView implements NativeMap {
   @Override
   @NonNull
   public long[] queryPointAnnotations(RectF rect) {
-    if (checkState("queryPointAnnotations")) {
+    if (checkState("queryPointAnnotations") || !mapRenderer.hasSurface()) {
       return new long[] {};
     }
     return nativeQueryPointAnnotations(rect);
@@ -544,7 +541,7 @@ final class NativeMapView implements NativeMap {
   @Override
   @NonNull
   public long[] queryShapeAnnotations(RectF rectF) {
-    if (checkState("queryShapeAnnotations")) {
+    if (checkState("queryShapeAnnotations") || !mapRenderer.hasSurface()) {
       return new long[] {};
     }
     return nativeQueryShapeAnnotations(rectF);
@@ -893,7 +890,7 @@ final class NativeMapView implements NativeMap {
   public List<Feature> queryRenderedFeatures(@NonNull PointF coordinates,
                                              @Nullable String[] layerIds,
                                              @Nullable Expression filter) {
-    if (checkState("queryRenderedFeatures") || !hasSurface) {
+    if (checkState("queryRenderedFeatures") || !mapRenderer.hasSurface()) {
       return new ArrayList<>();
     }
     Feature[] features = nativeQueryRenderedFeaturesForPoint(coordinates.x / pixelRatio,
@@ -906,7 +903,7 @@ final class NativeMapView implements NativeMap {
   public List<Feature> queryRenderedFeatures(@NonNull RectF coordinates,
                                              @Nullable String[] layerIds,
                                              @Nullable Expression filter) {
-    if (checkState("queryRenderedFeatures") || !hasSurface) {
+    if (checkState("queryRenderedFeatures") || !mapRenderer.hasSurface()) {
       return new ArrayList<>();
     }
     Feature[] features = nativeQueryRenderedFeaturesForBox(
@@ -1424,16 +1421,6 @@ final class NativeMapView implements NativeMap {
   @Override
   public boolean isDestroyed() {
     return destroyed;
-  }
-
-  @Override
-  public boolean hasSurface() {
-    return hasSurface;
-  }
-
-  @Override
-  public void setHasSurface(boolean hasSurface) {
-    this.hasSurface = hasSurface;
   }
 
   public interface ViewCallback {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
@@ -30,9 +30,9 @@ public abstract class MapRenderer implements MapRendererScheduler {
 
   // Holds the pointer to the native peer after initialisation
   private long nativePtr = 0;
-
   private double expectedRenderTime = 0;
   private MapboxMap.OnFpsChangedListener onFpsChangedListener;
+  protected boolean hasSurface;
 
   public MapRenderer(@NonNull Context context, String localIdeographFontFamily) {
     float pixelRatio = context.getResources().getDisplayMetrics().density;
@@ -132,6 +132,8 @@ public abstract class MapRenderer implements MapRendererScheduler {
 
   private native void nativeOnSurfaceDestroyed();
 
+  protected native void nativeReset();
+
   private native void nativeRender();
 
   private long timeElapsed;
@@ -155,5 +157,14 @@ public abstract class MapRenderer implements MapRendererScheduler {
       return;
     }
     expectedRenderTime = 1E9 / maximumFps;
+  }
+
+  /**
+   * Returns true if renderer has a surface to draw on.
+   *
+   * @return returns if renderer has a surface, false otherwise
+   */
+  public boolean hasSurface() {
+    return hasSurface;
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
@@ -22,7 +22,6 @@ public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceVi
 
   @NonNull
   private final GLSurfaceView glSurfaceView;
-  private boolean hasSurface;
 
   public GLSurfaceViewMapRenderer(Context context,
                                   GLSurfaceView glSurfaceView,
@@ -46,7 +45,7 @@ public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceVi
       public void surfaceDestroyed(SurfaceHolder holder) {
         super.surfaceDestroyed(holder);
         hasSurface = false;
-        onSurfaceDestroyed();
+        nativeReset();
       }
     });
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewMapRenderer.java
@@ -43,6 +43,7 @@ public class TextureViewMapRenderer extends MapRenderer {
   @Override
   protected void onSurfaceCreated(GL10 gl, EGLConfig config) {
     super.onSurfaceCreated(gl, config);
+    hasSurface = true;
   }
 
   /**
@@ -58,6 +59,7 @@ public class TextureViewMapRenderer extends MapRenderer {
    */
   @Override
   protected void onSurfaceDestroyed() {
+    hasSurface = false;
     super.onSurfaceDestroyed();
   }
 

--- a/platform/android/src/map_renderer.cpp
+++ b/platform/android/src/map_renderer.cpp
@@ -195,10 +195,15 @@ void MapRenderer::onSurfaceChanged(JNIEnv& env, jint width, jint height) {
     requestRender();
 }
 
-void MapRenderer::onSurfaceDestroyed(JNIEnv&) {
+void MapRenderer::onRendererReset(JNIEnv&) {
     // Make sure to destroy the renderer on the GL Thread
     auto self = ActorRef<MapRenderer>(*this, mailbox);
     self.ask(&MapRenderer::resetRenderer).wait();
+}
+
+// needs to be called on GL thread
+void MapRenderer::onSurfaceDestroyed(JNIEnv&) {
+    resetRenderer();
 }
 
 // Static methods //
@@ -214,6 +219,7 @@ void MapRenderer::registerNative(jni::JNIEnv& env) {
                                          jni::MakePeer<MapRenderer, const jni::Object<MapRenderer>&, jni::jfloat, const jni::String&, const jni::String&>,
                                          "nativeInitialize", "finalize",
                                          METHOD(&MapRenderer::render, "nativeRender"),
+                                         METHOD(&MapRenderer::onRendererReset, "nativeReset"),
                                          METHOD(&MapRenderer::onSurfaceCreated,
                                                 "nativeOnSurfaceCreated"),
                                          METHOD(&MapRenderer::onSurfaceChanged,

--- a/platform/android/src/map_renderer.hpp
+++ b/platform/android/src/map_renderer.hpp
@@ -94,10 +94,11 @@ private:
 
     void onSurfaceChanged(JNIEnv&, jint width, jint height);
 
+    void onSurfaceDestroyed(JNIEnv&);
+
 private:
     // Called on either Main or GL thread //
-
-    void onSurfaceDestroyed(JNIEnv&);
+    void onRendererReset(JNIEnv&);
 
 private:
     jni::WeakReference<jni::Object<MapRenderer>, jni::EnvAttachingDeleter> javaPeer;


### PR DESCRIPTION
Closes #14422, Follow up from https://github.com/mapbox/mapbox-gl-native/pull/14395. This PR unifies state management around having a render surface created. Instead of maintaining it in 2 places NativeMapView + MapRenderer. This PR moves it fully to MapRenderer instead. This solves the issue from #14422.  Validated that both setups work correctly for quering with both TextureView as GLSurfaceView. Running tests on mutliple devices on firebase didn't show any issues. 

![image](https://user-images.githubusercontent.com/2151639/56124417-e38da000-5f76-11e9-88d0-33f5bf09415d.png)
