### PR TITLE
Provide default nav experience for singleInstance activity

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesBoxCountActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesBoxCountActivity.java
@@ -4,20 +4,20 @@ import android.graphics.PointF;
 import android.graphics.RectF;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.Toast;
-
 import com.google.gson.JsonElement;
 import com.mapbox.geojson.Feature;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.testapp.utils.NavUtils;
+import timber.log.Timber;
 
 import java.util.List;
 import java.util.Map;
-
-import timber.log.Timber;
 
 /**
  * Test activity showcasing using the query rendered features API to count features in a rectangle.
@@ -93,7 +93,7 @@ public class QueryRenderedFeaturesBoxCountActivity extends AppCompatActivity {
 
     if (mapboxMap != null) {
       // Regression test for #14394
-      mapboxMap.queryRenderedFeatures(new PointF(0,0));
+      mapboxMap.queryRenderedFeatures(new PointF(0, 0));
     }
   }
 
@@ -131,5 +131,24 @@ public class QueryRenderedFeaturesBoxCountActivity extends AppCompatActivity {
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
+  }
+
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    switch (item.getItemId()) {
+      case android.R.id.home:
+        // activity uses singleInstance for testing purposes
+        // code below provides a default navigation when using the app
+        onBackPressed();
+        return true;
+    }
+    return super.onOptionsItemSelected(item);
+  }
+
+  @Override
+  public void onBackPressed() {
+    // activity uses singleInstance for testing purposes
+    // code below provides a default navigation when using the app
+    NavUtils.navigateHome(this);
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/FragmentBackStackActivity.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/FragmentBackStackActivity.kt
@@ -7,6 +7,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.Style
 import com.mapbox.mapboxsdk.maps.SupportMapFragment
 import com.mapbox.mapboxsdk.testapp.R
+import com.mapbox.mapboxsdk.testapp.utils.NavUtils
 import kotlinx.android.synthetic.main.activity_backstack_fragment.*
 
 /**
@@ -14,32 +15,38 @@ import kotlinx.android.synthetic.main.activity_backstack_fragment.*
  */
 class FragmentBackStackActivity : AppCompatActivity() {
 
-    private lateinit var mapFragment: SupportMapFragment
+  private lateinit var mapFragment: SupportMapFragment
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_backstack_fragment)
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_backstack_fragment)
 
-        mapFragment = SupportMapFragment.newInstance()
-        mapFragment.getMapAsync { initMap(it) }
+    mapFragment = SupportMapFragment.newInstance()
+    mapFragment.getMapAsync { initMap(it) }
 
-        supportFragmentManager.beginTransaction().apply {
-            add(R.id.container, mapFragment)
-        }.commit()
+    supportFragmentManager.beginTransaction().apply {
+      add(R.id.container, mapFragment)
+    }.commit()
 
-        button.setOnClickListener { handleClick(it) }
+    button.setOnClickListener { handleClick(it) }
+  }
+
+  private fun initMap(mapboxMap: MapboxMap) {
+    mapboxMap.setStyle(Style.SATELLITE) {
+      mapboxMap.setPadding(300, 300, 300, 300)
     }
+  }
 
-    private fun initMap(mapboxMap: MapboxMap) {
-        mapboxMap.setStyle(Style.SATELLITE) {
-            mapboxMap.setPadding(300, 300, 300, 300)
-        }
-    }
+  private fun handleClick(button: View) {
+    supportFragmentManager.beginTransaction().apply {
+      replace(R.id.container, NestedViewPagerActivity.ItemAdapter.EmptyFragment())
+      addToBackStack("map_empty_fragment")
+    }.commit()
+  }
 
-    private fun handleClick(button: View) {
-        supportFragmentManager.beginTransaction().apply {
-            replace(R.id.container, NestedViewPagerActivity.ItemAdapter.EmptyFragment())
-            addToBackStack("map_empty_fragment")
-        }.commit()
-    }
+  override fun onBackPressed() {
+    // activity uses singleInstance for testing purposes
+    // code below provides a default navigation when using the app
+    NavUtils.navigateHome(this)
+  }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/SimpleMapActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/SimpleMapActivity.java
@@ -2,9 +2,11 @@ package com.mapbox.mapboxsdk.testapp.activity.maplayout;
 
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.view.MenuItem;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.testapp.utils.NavUtils;
 
 /**
  * Test activity showcasing a simple MapView without any MapboxMap interaction.
@@ -64,5 +66,24 @@ public class SimpleMapActivity extends AppCompatActivity {
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    switch (item.getItemId()) {
+      case android.R.id.home:
+        // activity uses singleInstance for testing purposes
+        // code below provides a default navigation when using the app
+        onBackPressed();
+        return true;
+    }
+    return super.onOptionsItemSelected(item);
+  }
+
+  @Override
+  public void onBackPressed() {
+    // activity uses singleInstance for testing purposes
+    // code below provides a default navigation when using the app
+    NavUtils.navigateHome(this);
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/textureview/TextureViewDebugModeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/textureview/TextureViewDebugModeActivity.java
@@ -1,8 +1,10 @@
 package com.mapbox.mapboxsdk.testapp.activity.textureview;
 
+import android.view.MenuItem;
 import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.testapp.activity.maplayout.DebugModeActivity;
+import com.mapbox.mapboxsdk.testapp.utils.NavUtils;
 
 /**
  * Test activity showcasing the different debug modes and allows to cycle between the default map styles.
@@ -14,5 +16,25 @@ public class TextureViewDebugModeActivity extends DebugModeActivity implements O
     MapboxMapOptions mapboxMapOptions = super.setupMapboxMapOptions();
     mapboxMapOptions.textureMode(true);
     return mapboxMapOptions;
+  }
+
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    switch (item.getItemId()) {
+      case android.R.id.home:
+        // activity uses singleInstance for testing purposes
+        // code below provides a default navigation when using the app
+        onBackPressed();
+        return true;
+    }
+    return super.onOptionsItemSelected(item);
+  }
+
+
+  @Override
+  public void onBackPressed() {
+    // activity uses singleInstance for testing purposes
+    // code below provides a default navigation when using the app
+    NavUtils.navigateHome(this);
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/utils/NavUtils.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/utils/NavUtils.java
@@ -1,0 +1,14 @@
+package com.mapbox.mapboxsdk.testapp.utils;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.support.annotation.NonNull;
+import com.mapbox.mapboxsdk.testapp.activity.FeatureOverviewActivity;
+
+public class NavUtils {
+
+  public static void navigateHome(@NonNull Activity context) {
+    context.startActivity(new Intent(context, FeatureOverviewActivity.class));
+    context.finish();
+  }
+}


### PR DESCRIPTION
We recently added `singleInstance `to the AndroidManifest for testing the resume of certain activities. This setup breaks expected app nav experience of the test app. This PR overrides the back behavior of those activities to restore this. 