### PR TITLE
Circle with radius expressed in physical measurement 

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -942,6 +942,18 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activity.FeatureOverviewActivity" />
         </activity>
+        <activity
+            android:name=".activity.turf.PhysicalUnitCircleActivity"
+            android:description="@string/description_physical_circle"
+            android:label="@string/activity_physical_circle">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_turf" />
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".activity.FeatureOverviewActivity" />
+        </activity>
+
         <!-- For Instrumentation tests -->
         <activity
             android:name=".activity.style.RuntimeStyleTimingTestActivity"

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/turf/PhysicalUnitCircleActivity.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/turf/PhysicalUnitCircleActivity.kt
@@ -1,0 +1,118 @@
+package com.mapbox.mapboxsdk.testapp.activity.turf
+
+import android.graphics.Color
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import android.widget.SeekBar
+import com.mapbox.geojson.Point
+import com.mapbox.mapboxsdk.camera.CameraPosition
+import com.mapbox.mapboxsdk.geometry.LatLng
+import com.mapbox.mapboxsdk.maps.Style
+import com.mapbox.mapboxsdk.style.layers.BackgroundLayer
+import com.mapbox.mapboxsdk.style.layers.FillLayer
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.backgroundColor
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillColor
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
+import com.mapbox.mapboxsdk.testapp.R
+import com.mapbox.turf.TurfTransformation
+import kotlinx.android.synthetic.main.activity_physical_circle.*
+
+/**
+ * An Activity that showcases how to create a Circle with radius expressed in physical units using a FillLayer.
+ */
+class PhysicalUnitCircleActivity : AppCompatActivity(), SeekBar.OnSeekBarChangeListener {
+
+  companion object {
+    const val LAYER_ID = "circle-id"
+    const val SOURCE_ID = "circle-id"
+  }
+
+  private lateinit var source: GeoJsonSource
+  private var steps: Int = 10
+  private var radius: Double = 9000.0
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_physical_circle)
+    mapView.onCreate(savedInstanceState)
+    mapView.getMapAsync { mapboxMap ->
+
+      mapboxMap.cameraPosition = CameraPosition.Builder()
+        .target(LatLng(22.928207, 15.011543))
+        .zoom(10.0)
+        .build()
+
+      source = GeoJsonSource(SOURCE_ID, TurfTransformation.circle(
+        Point.fromLngLat(0.0, 0.0), 9000.0, 10, "meters")
+      )
+
+      stepsBar.setOnSeekBarChangeListener(this)
+      radiusBar.setOnSeekBarChangeListener(this)
+
+      mapboxMap.setStyle(Style.Builder()
+        .fromUrl(Style.SATELLITE_STREETS)
+        .withLayer(FillLayer(LAYER_ID, SOURCE_ID).withProperties(fillColor(Color.RED)))
+        .withSource(source)
+      )
+    }
+  }
+
+  override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
+    seekBar?.let {
+      if (it.id == stepsBar.id) {
+        steps = progress
+      } else {
+        radius = progress.toDouble()
+      }
+
+      source.setGeoJson(TurfTransformation.circle(
+        Point.fromLngLat(0.0, 0.0), radius, steps, "meters")
+      )
+    }
+  }
+
+  override fun onStartTrackingTouch(seekBar: SeekBar?) {
+    // no-op
+  }
+
+  override fun onStopTrackingTouch(seekBar: SeekBar?) {
+    // no-op
+  }
+
+  override fun onStart() {
+    super.onStart()
+    mapView.onStart()
+  }
+
+  override fun onResume() {
+    super.onResume()
+    mapView.onResume()
+  }
+
+  override fun onPause() {
+    super.onPause()
+    mapView.onPause()
+  }
+
+  override fun onStop() {
+    super.onStop()
+    mapView.onStop()
+  }
+
+  override fun onLowMemory() {
+    super.onLowMemory()
+    mapView.onLowMemory()
+  }
+
+  override fun onDestroy() {
+    super.onDestroy()
+    mapView.onDestroy()
+  }
+
+  override fun onSaveInstanceState(outState: Bundle?) {
+    super.onSaveInstanceState(outState)
+    outState?.let {
+      mapView.onSaveInstanceState(it)
+    }
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_physical_circle.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_physical_circle.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".activity.style.DraggableMarkerActivity">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+            android:id="@+id/mapView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
+
+    <SeekBar
+            android:id="@+id/stepsBar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="64dp"
+            android:progress="10"
+            android:max="64"
+            android:layout_alignParentBottom="true"/>
+
+    <SeekBar
+            android:id="@+id/radiusBar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="48dp"
+            android:progress="9000"
+            android:max="15000"
+            android:layout_above="@id/stepsBar"/>
+
+</RelativeLayout>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/categories.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/categories.xml
@@ -17,4 +17,5 @@
     <string name="category_location">Location</string>
     <string name="category_integration">_Integration</string>
     <string name="category_telemetry">Telemetry</string>
+    <string name="category_turf">Turf</string>
 </resources>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
@@ -82,4 +82,5 @@
     <string name="description_recyclerview_glsurfaceview">Show a GLSurfaceView MapView as a recyclerView item</string>
     <string name="description_nested_viewpager">Show a MapView inside a viewpager inside a recyclerView</string>
     <string name="description_performance_measurement">Show the use PerformanceEvent for performance measurements</string>
+    <string name="description_physical_circle">Use TurfTransformation#circle() to show a Cirlce expressed in physical units</string>
 </resources>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
@@ -82,4 +82,5 @@
     <string name="activity_recyclerview_glsurfaceview">RecyclerView GLSurfaceView</string>
     <string name="activity_nested_viewpager">Nested ViewPager</string>
     <string name="activity_performance_measurement">Performance Measurement</string>
+    <string name="activity_physical_circle">Physical Unit Circle</string>
 </resources>


### PR DESCRIPTION
Example of using `TurfTransformation#circle()`, closes https://github.com/mapbox/mapbox-gl-native/issues/4312. 
The progress bar allows to update the steps precision parameter.

![ezgif com-video-to-gif (58)](https://user-images.githubusercontent.com/2151639/56138270-dc768a00-5f96-11e9-9a7d-4a5bf7870c2b.gif)
