### PR TITLE
Android specific thread pool that keeps threads attached to JVM

### DIFF
--- a/include/mbgl/platform/thread.hpp
+++ b/include/mbgl/platform/thread.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace mbgl {
+namespace platform {
+
+// Called when a thread is created
+void attachThread();
+
+// Called when a thread is destroyed
+void detachThread();
+
+} // namespace platform
+} // namespace mbgl

--- a/include/mbgl/util/thread.hpp
+++ b/include/mbgl/util/thread.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/util/platform.hpp>
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/util/util.hpp>
+#include <mbgl/platform/thread.hpp>
 
 #include <cassert>
 #include <future>
@@ -55,6 +56,7 @@ public:
         ] () mutable {
             platform::setCurrentThreadName(name);
             platform::makeThreadLowPriority();
+            platform::attachThread();
 
             util::RunLoop loop_(util::RunLoop::Type::New);
             loop = &loop_;
@@ -67,6 +69,7 @@ public:
             (void) establishedActor;
             
             loop = nullptr;
+            platform::detachThread();
         });
     }
 

--- a/platform/android/src/run_loop.cpp
+++ b/platform/android/src/run_loop.cpp
@@ -81,9 +81,6 @@ private:
 };
 
 RunLoop::Impl::Impl(RunLoop* runLoop_, RunLoop::Type type) : runLoop(runLoop_) {
-    using namespace mbgl::android;
-    detach = attach_jni_thread(theJVM, &env, platform::getCurrentThreadName());
-
     loop = ALooper_prepare(0);
     assert(loop);
 
@@ -129,9 +126,6 @@ RunLoop::Impl::~Impl() {
     }
 
     ALooper_release(loop);
-
-    using namespace mbgl::android;
-    detach_jni_thread(theJVM, &env, detach);
 }
 
 void RunLoop::Impl::wake() {

--- a/platform/android/src/run_loop_impl.hpp
+++ b/platform/android/src/run_loop_impl.hpp
@@ -47,9 +47,6 @@ private:
 
     int fds[2];
 
-    JNIEnv *env = nullptr;
-    bool detach = false;
-
     std::unique_ptr<Thread<Alarm>> alarm;
 
     std::mutex mutex;

--- a/platform/android/src/thread.cpp
+++ b/platform/android/src/thread.cpp
@@ -5,10 +5,16 @@
 #include <sys/prctl.h>
 #include <sys/resource.h>
 
+#include <cassert>
+#include "jni.hpp"
+
 // Implementation based on Chromium's platform_thread_android.cc.
 
 namespace mbgl {
 namespace platform {
+
+thread_local static JNIEnv* env;
+thread_local static bool detach;
 
 std::string getCurrentThreadName() {
     char name[32] = "unknown";
@@ -35,9 +41,15 @@ void makeThreadLowPriority() {
 }
 
 void attachThread() {
+    using namespace android;
+    assert(env == nullptr);
+    detach = attach_jni_thread(theJVM, &env, platform::getCurrentThreadName());
 }
 
 void detachThread() {
+    using namespace android;
+    assert(env);
+    detach_jni_thread(theJVM, &env, detach);
 }
 
 } // namespace platform

--- a/platform/android/src/thread.cpp
+++ b/platform/android/src/thread.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/util/logging.hpp>
 #include <mbgl/util/platform.hpp>
+#include <mbgl/platform/thread.hpp>
 
 #include <sys/prctl.h>
 #include <sys/resource.h>
@@ -31,6 +32,12 @@ void makeThreadLowPriority() {
     // Supposedly would set the priority for the whole process, but
     // on Linux/Android it only sets for the current thread.
     setpriority(PRIO_PROCESS, 0, 19);
+}
+
+void attachThread() {
+}
+
+void detachThread() {
 }
 
 } // namespace platform

--- a/platform/darwin/src/nsthread.mm
+++ b/platform/darwin/src/nsthread.mm
@@ -1,6 +1,7 @@
 #import <Foundation/Foundation.h>
 
 #include <mbgl/util/platform.hpp>
+#include <mbgl/platform/thread.hpp>
 
 #include <pthread.h>
 
@@ -21,6 +22,12 @@ void setCurrentThreadName(const std::string& name) {
 
 void makeThreadLowPriority() {
     [[NSThread currentThread] setThreadPriority:0.0];
+}
+
+void attachThread() {
+}
+
+void detachThread() {
 }
 
 }

--- a/platform/default/src/mbgl/util/thread.cpp
+++ b/platform/default/src/mbgl/util/thread.cpp
@@ -1,4 +1,5 @@
 #include <mbgl/util/platform.hpp>
+#include <mbgl/platform/thread.hpp>
 #include <mbgl/util/logging.hpp>
 
 #include <string>
@@ -31,6 +32,12 @@ void makeThreadLowPriority() {
     if (sched_setscheduler(0, SCHED_IDLE, &param) != 0) {
         Log::Warning(Event::General, "Couldn't set thread scheduling policy");
     }
+}
+
+void attachThread() {
+}
+
+void detachThread() {
 }
 
 } // namespace platform

--- a/platform/qt/src/thread.cpp
+++ b/platform/qt/src/thread.cpp
@@ -1,4 +1,5 @@
 #include <mbgl/util/platform.hpp>
+#include <mbgl/platform/thread.hpp>
 
 #include <string>
 
@@ -13,6 +14,12 @@ void setCurrentThreadName(const std::string&) {
 }
 
 void makeThreadLowPriority() {
+}
+
+void attachThread() {
+}
+
+void detachThread() {
 }
 
 } // namespace platform

--- a/src/core-files.json
+++ b/src/core-files.json
@@ -351,6 +351,7 @@
         "mbgl/math/minmax.hpp": "include/mbgl/math/minmax.hpp",
         "mbgl/math/wrap.hpp": "include/mbgl/math/wrap.hpp",
         "mbgl/platform/gl_functions.hpp": "include/mbgl/platform/gl_functions.hpp",
+        "mbgl/platform/thread.hpp": "include/mbgl/platform/thread.hpp",
         "mbgl/renderer/query.hpp": "include/mbgl/renderer/query.hpp",
         "mbgl/renderer/renderer.hpp": "include/mbgl/renderer/renderer.hpp",
         "mbgl/renderer/renderer_frontend.hpp": "include/mbgl/renderer/renderer_frontend.hpp",

--- a/src/mbgl/util/thread_pool.cpp
+++ b/src/mbgl/util/thread_pool.cpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/util/platform.hpp>
 #include <mbgl/util/string.hpp>
+#include <mbgl/platform/thread.hpp>
 
 namespace mbgl {
 
@@ -11,6 +12,7 @@ ThreadPool::ThreadPool(std::size_t count) {
     for (std::size_t i = 0; i < count; ++i) {
         threads.emplace_back([this, i]() {
             platform::setCurrentThreadName(std::string{ "Worker " } + util::toString(i + 1));
+            platform::attachThread();
 
             while (true) {
                 std::unique_lock<std::mutex> lock(mutex);
@@ -20,6 +22,7 @@ ThreadPool::ThreadPool(std::size_t count) {
                 });
 
                 if (terminate) {
+                    platform::detachThread();
                     return;
                 }
 


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/14048.

This PR adds a possibility to listen to thread's lifecycle within the thread pool and changes the Android's shared thread pool implementation to attach each of the threads in the pool to the JVM. This way, we are not constantly attaching/detaching JVM to those threads which was forcing GC runs.