### PR TITLE
Document that LocationComponentOptions.elevation(0) turns off the shadow.

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentOptions.java
@@ -571,7 +571,8 @@ public class LocationComponentOptions implements Parcelable {
   }
 
   /**
-   * Sets the base elevation of this view, in pixels.
+   * Sets the base elevation of this view, in pixels. To turn off the shadow that appears under
+   * the location icon, set the elevation to 0.
    *
    * @return the elevation currently set for the location component icon
    * @attr ref R.styleable#LocationComponent_elevation


### PR DESCRIPTION
LocationComponentOptions provides ways to set the foreground and background drawable, but no way to set the shadow drawable.  The JavaDoc for LocationComponentOptions doesn't mention the word "shadow" at all, so it seems as though there is no way to turn off the shadow.

But it is possible to turn off the shadow by setting the elevation to zero.  This PR just adds that explanation to the `elevation()` method.