### PR TITLE
[android] Mapbox Java SDK bump to 4.7.0

### DIFF
--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
     ]
 
     versions = [
-            mapboxServices  : '4.6.0',
+            mapboxServices  : '4.7.0',
             mapboxTelemetry : '4.4.1',
             mapboxCore      : '1.3.0',
             mapboxGestures  : '0.4.2',


### PR DESCRIPTION
Initial commit to update Mapbox Java SDK version to 4.7.0-alpha.1 for testing.
If successful the same PR will be used to update to 4.7.0 final release (that will follow the pre-release).