### PR TITLE
[core] Release unused ImageManager's reources via reduceMemoryUse API

### DIFF
--- a/src/mbgl/renderer/image_manager.cpp
+++ b/src/mbgl/renderer/image_manager.cpp
@@ -288,4 +288,11 @@ gfx::TextureBinding ImageManager::textureBinding(gfx::Context& context) {
     return { atlasTexture->getResource(), gfx::TextureFilterType::Linear };
 }
 
+ImageRequestor::ImageRequestor(ImageManager& imageManager_) : imageManager(imageManager_) {
+}
+
+ImageRequestor::~ImageRequestor() {
+    imageManager.removeRequestor(*this);
+}
+
 } // namespace mbgl

--- a/src/mbgl/renderer/image_manager.hpp
+++ b/src/mbgl/renderer/image_manager.hpp
@@ -56,12 +56,14 @@ public:
     void getImages(ImageRequestor&, ImageRequestPair&&);
     void removeRequestor(ImageRequestor&);
     void notifyIfMissingImageAdded();
+    void reduceMemoryUse();
 
     ImageVersionMap updatedImageVersions;
 
 private:
     void checkMissingAndNotify(ImageRequestor&, const ImageRequestPair&);
     void notify(ImageRequestor&, const ImageRequestPair&) const;
+    void removePattern(const std::string&);
 
     bool loaded = false;
 
@@ -71,6 +73,7 @@ private:
         unsigned int callbacksRemaining;
     };
     std::map<ImageRequestor*, MissingImageRequestPair> missingImageRequestors;
+    std::map<std::string, std::set<ImageRequestor*>> requestedImages;
     ImageMap images;
 
     ImageManagerObserver* observer = nullptr;

--- a/src/mbgl/renderer/image_manager.hpp
+++ b/src/mbgl/renderer/image_manager.hpp
@@ -19,11 +19,7 @@ namespace gfx {
 class Context;
 } // namespace gfx
 
-class ImageRequestor {
-public:
-    virtual ~ImageRequestor() = default;
-    virtual void onImagesAvailable(ImageMap icons, ImageMap patterns, ImageVersionMap versionMap, uint64_t imageCorrelationID) = 0;
-};
+class ImageRequestor;
 
 /*
     ImageManager does two things:
@@ -103,6 +99,15 @@ private:
     PremultipliedImage atlasImage;
     mbgl::optional<gfx::Texture> atlasTexture;
     bool dirty = true;
+};
+
+class ImageRequestor {
+public:
+    explicit ImageRequestor(ImageManager&);
+    virtual ~ImageRequestor();
+    virtual void onImagesAvailable(ImageMap icons, ImageMap patterns, ImageVersionMap versionMap, uint64_t imageCorrelationID) = 0;
+private:
+    ImageManager& imageManager;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -685,6 +685,9 @@ void Renderer::Impl::reduceMemoryUse() {
     }
     backend.getContext().performCleanup();
     observer->onInvalidate();
+    if (imageManager) {
+        imageManager->reduceMemoryUse();
+    }
 }
 
 void Renderer::Impl::dumDebugLogs() {

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -42,6 +42,7 @@ GeometryTile::GeometryTile(const OverscaledTileID& id_,
                            std::string sourceID_,
                            const TileParameters& parameters)
     : Tile(Kind::Geometry, id_),
+      ImageRequestor(parameters.imageManager),
       sourceID(std::move(sourceID_)),
       mailbox(std::make_shared<Mailbox>(*Scheduler::GetCurrent())),
       worker(parameters.workerScheduler,
@@ -60,7 +61,6 @@ GeometryTile::GeometryTile(const OverscaledTileID& id_,
 
 GeometryTile::~GeometryTile() {
     glyphManager.removeRequestor(*this);
-    imageManager.removeRequestor(*this);
     markObsolete();
 }
 

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -22,7 +22,7 @@ class TileParameters;
 class GlyphAtlas;
 class ImageAtlas;
 
-class GeometryTile : public Tile, public GlyphRequestor, ImageRequestor {
+class GeometryTile : public Tile, public GlyphRequestor, public ImageRequestor {
 public:
     GeometryTile(const OverscaledTileID&,
                  std::string sourceID,

--- a/test/renderer/image_manager.test.cpp
+++ b/test/renderer/image_manager.test.cpp
@@ -108,6 +108,8 @@ TEST(ImageManager, RemoveReleasesBinPackRect) {
 
 class StubImageRequestor : public ImageRequestor {
 public:
+    StubImageRequestor(ImageManager& imageManager) : ImageRequestor(imageManager) {}
+
     void onImagesAvailable(ImageMap icons, ImageMap patterns, std::unordered_map<std::string, uint32_t> versionMap, uint64_t imageCorrelationID_) final {
         if (imagesAvailable && imageCorrelationID == imageCorrelationID_) imagesAvailable(icons, patterns, versionMap);
     }
@@ -118,7 +120,7 @@ public:
 
 TEST(ImageManager, NotifiesRequestorWhenSpriteIsLoaded) {
     ImageManager imageManager;
-    StubImageRequestor requestor;
+    StubImageRequestor requestor(imageManager);
     bool notified = false;
 
     ImageManagerObserver observer;
@@ -142,7 +144,7 @@ TEST(ImageManager, NotifiesRequestorWhenSpriteIsLoaded) {
 
 TEST(ImageManager, NotifiesRequestorImmediatelyIfDependenciesAreSatisfied) {
     ImageManager imageManager;
-    StubImageRequestor requestor;
+    StubImageRequestor requestor(imageManager);
     bool notified = false;
 
     requestor.imagesAvailable = [&] (ImageMap, ImageMap, std::unordered_map<std::string, uint32_t>) {
@@ -170,7 +172,7 @@ class StubImageManagerObserver : public ImageManagerObserver {
 
 TEST(ImageManager, OnStyleImageMissingBeforeSpriteLoaded) {
     ImageManager imageManager;
-    StubImageRequestor requestor;
+    StubImageRequestor requestor(imageManager);
     StubImageManagerObserver observer;
 
     imageManager.setObserver(&observer);
@@ -203,7 +205,7 @@ TEST(ImageManager, OnStyleImageMissingBeforeSpriteLoaded) {
 
 TEST(ImageManager, OnStyleImageMissingAfterSpriteLoaded) {
     ImageManager imageManager;
-    StubImageRequestor requestor;
+    StubImageRequestor requestor(imageManager);
     StubImageManagerObserver observer;
 
     imageManager.setObserver(&observer);


### PR DESCRIPTION
This PR provides basic resource cleanup mechanism for the `ImageManager` class.

Client can perform resource cleanup by invoking [`Renderer::reduceMemoryUse()`](https://github.com/mapbox/mapbox-gl-native/blob/master/include/mbgl/renderer/renderer.hpp#L58)
preferably, when rendering engine is idle, e.g., when [`onDidBecomeIdle`](https://github.com/mapbox/mapbox-gl-native/blob/master/include/mbgl/map/map_observer.hpp#L49) callback is called.