### PR TITLE
[node] Mark node >8 as unsupported in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "xcode": "^1.0.0"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=6 <9"
   },
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build=false || make node",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,4 +1,5 @@
 # master
+- Mark Node versions > 8 as unsupported
 - Add `symbol-z-order` symbol layout property to style spec [#12783](https://github.com/mapbox/mapbox-gl-native/pull/12783)
 - Add `crossSourceCollisions` map option, with default of `true`. When set to `false`, cross-source collision detection is disabled. ([#12820] (https://github.com/mapbox/mapbox-gl-native/issues/12820))
 - Fixed bugs in coercion expression operators ("to-array" applied to empty arrays, "to-color" applied to colors, and "to-number" applied to null) [#12864](https://github.com/mapbox/mapbox-gl-native/pull/12864)


### PR DESCRIPTION
Node 10 can segfault; see https://github.com/mapbox/mapbox-gl-native/issues/12252