### PR TITLE
[core] Placement order matches viewport-y sort

### DIFF
--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -65,6 +65,8 @@ public:
 
     void updateOpacity();
     void sortFeatures(const float angle);
+    // The result contains references to the `symbolInstances` items, sorted by viewport Y.
+    std::vector<std::reference_wrapper<SymbolInstance>> getSortedSymbols(const float angle);
 
     const style::SymbolLayoutProperties::PossiblyEvaluated layout;
     const bool sdfIcons;


### PR DESCRIPTION
Symbols are placed accordingly to their viewport Y order,
if the style `symbol-z-order` is set to `viewport-y`.

This improves rendering of symbol layers, where icons are allowed
to overlap but not text.