### PR TITLE
[ios] Make MGLLocationManager protocol swift friendly. (#14477)

### DIFF
--- a/platform/darwin/src/MGLLocationManager.h
+++ b/platform/darwin/src/MGLLocationManager.h
@@ -31,7 +31,13 @@ NS_ASSUME_NONNULL_BEGIN
  
  @see `CLLocationManager.distanceFilter`
  */
-@property(nonatomic, assign) CLLocationDistance distanceFilter;
+- (CLLocationDistance)distanceFilter;
+
+/**
+ Sets the minimum update distance in meters.
+ @param distanceFilter The distance filter in meters.
+ */
+- (void)setDistanceFilter:(CLLocationDistance) distanceFilter;
 
 /**
  Specifies the accuracy of the location data.
@@ -43,7 +49,14 @@ NS_ASSUME_NONNULL_BEGIN
  
  @see `CLLocationManager.desiredAccuracy`
  */
-@property (nonatomic, assign) CLLocationAccuracy desiredAccuracy;
+- (CLLocationAccuracy)desiredAccuracy;
+
+/**
+ Sets the desired location accuracy.
+ 
+ @param desiredAccuracy The desired location accuracy.
+ */
+- (void)setDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy;
 
 /**
  Specifies the type of user activity associated with the location updates.
@@ -56,7 +69,14 @@ NS_ASSUME_NONNULL_BEGIN
  
  @see `CLLocationManager.activityType`
  */
-@property (nonatomic, assign) CLActivityType activityType;
+- (CLActivityType)activityType;
+
+/**
+ Sets the type of user activity associated with the location updates.
+ 
+ @param activityType The location's manager activity type.
+ */
+- (void)setActivityType:(CLActivityType)activityType;
 
 @required
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fix a bug that wrong position of attribution dialog after rotation. ([#14185](https://github.com/mapbox/mapbox-gl-native/pull/14185))
 * Speculatively fixed a bug where GL rendering could occur in the background. ([#14439](https://github.com/mapbox/mapbox-gl-native/pull/14439))
 * Fixed a bug with jittery callout views when using sprite-based annotations. ([#14445](https://github.com/mapbox/mapbox-gl-native/pull/14445))
+* Improved `MGLLocationManager` optional protocol properties briding to Swift. ([#14477](https://github.com/mapbox/mapbox-gl-native/pull/14477))
 
 ## 4.10.0 - April 17, 2019
 


### PR DESCRIPTION
Cherry picks #14477 into `release-mojito`