### PR TITLE
[core] Update to variant 1.1.6

### DIFF
--- a/vendor/variant-files.json
+++ b/vendor/variant-files.json
@@ -5,6 +5,7 @@
         "mapbox/optional.hpp": "vendor/variant/include/mapbox/optional.hpp",
         "mapbox/recursive_wrapper.hpp": "vendor/variant/include/mapbox/recursive_wrapper.hpp",
         "mapbox/variant.hpp": "vendor/variant/include/mapbox/variant.hpp",
+        "mapbox/variant_cast.hpp": "vendor/variant/include/mapbox/variant_cast.hpp",
         "mapbox/variant_io.hpp": "vendor/variant/include/mapbox/variant_io.hpp",
         "mapbox/variant_visitor.hpp": "vendor/variant/include/mapbox/variant_visitor.hpp"
     },


### PR DESCRIPTION
This PR updates variant to version 1.1.6 which includes [a change](https://github.com/mapbox/variant/pull/171) to reduce the number of static analyzer warnings in iOS, and addresses the bulk of warnings reported in https://github.com/mapbox/mapbox-gl-native/issues/7668.

There have been a number of [changes since 1.1.4](https://github.com/mapbox/variant/compare/v1.1.4...v1.1.6) so this will require testing. I have tested iOS unit and integration tests and `iosapp` and all seems well.

@artemp says:
> the `sizeof(variant<...>)` will change potentially as `index_type` is now 32-bit integer by default if I remember correctly