### PR TITLE
Refactor: redundant project-unproject in easeTo

### DIFF
--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -107,9 +107,6 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
         }
     }
 
-    const Point<double> startPoint = Projection::project(startLatLng, state.scale);
-    const Point<double> endPoint = Projection::project(latLng, state.scale);
-
     ScreenCoordinate center = getScreenCoordinate(padding);
     center.y = state.size.height - center.y;
 
@@ -132,8 +129,8 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
     state.rotating = bearing != startBearing;
 
     startTransition(camera, animation, [=](double t) {
-        Point<double> framePoint = util::interpolate(startPoint, endPoint, t);
-        LatLng frameLatLng = Projection::unproject(framePoint, startScale);
+        LatLng frameLatLng(util::interpolate(startLatLng.latitude(), latLng.latitude(), t),
+                           util::interpolate(startLatLng.longitude(), latLng.longitude(), t));
         double frameScale = util::interpolate(startScale, scale, t);
         state.setLatLngZoom(frameLatLng, state.scaleZoom(frameScale));
 

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -371,7 +371,7 @@ TEST(Transform, Antimeridian) {
     transform.jumpTo(CameraOptions().withCenter(coordinateWaikiri).withZoom(10.0));
     ScreenCoordinate pixelWaikiri = transform.latLngToScreenCoordinate(coordinateWaikiri);
     ASSERT_DOUBLE_EQ(500, pixelWaikiri.x);
-    ASSERT_DOUBLE_EQ(500, pixelWaikiri.y);
+    ASSERT_NEAR(500, pixelWaikiri.y, 1e-10);
 
     transform.jumpTo(CameraOptions().withCenter(LatLng { coordinateWaikiri.latitude(), 180.0213 }));
     ScreenCoordinate pixelWaikiriLongest = transform.latLngToScreenCoordinate(coordinateWaikiri);


### PR DESCRIPTION
Trivial change in easeTo: since project and unproject use startScale, no need for it:
interpolate geo coords instead.