### PR TITLE
[ios] Fix constraints removal on iOS 9.

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1377,7 +1377,6 @@ public:
 - (void)didMoveToSuperview
 {
     [self validateDisplayLink];
-    [self installConstraints];
     [super didMoveToSuperview];
 }
 


### PR DESCRIPTION
Speculatively fixes a crash on iOS 9 devices that remove `MGLMapView` from the view hierarchy.