### PR TITLE
[ios] Check for valid superview to avoid crash on iOS 9

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fix a bug that wrong position of attribution dialog after rotation. ([#14185](https://github.com/mapbox/mapbox-gl-native/pull/14185))
 * Fixed a bug with jittery callout views when using sprite-based annotations. ([#14445](https://github.com/mapbox/mapbox-gl-native/pull/14445))
 * Improved `MGLLocationManager` optional protocol properties briding to Swift. ([#14477](https://github.com/mapbox/mapbox-gl-native/pull/14477))
+* Fixed a layout constraints crash on iOS 9 when a view is removed from its superview. ([#14529](https://github.com/mapbox/mapbox-gl-native/pull/14529))
 
 ## 4.10.0 - April 17, 2019
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1377,7 +1377,10 @@ public:
 - (void)didMoveToSuperview
 {
     [self validateDisplayLink];
-    [self installConstraints];
+    if (self.superview)
+    {
+        [self installConstraints];
+    }
     [super didMoveToSuperview];
 }
 


### PR DESCRIPTION
Checks for a valid superview before installing constraints. This avoids a crash on iOS 9.

The crash was reproduced with `ios-sdk-examples` on an iPad running iOS 9.3. (And this PR was tested on the same.)

/cc @lloydsheng @chloekraw 