### PR TITLE
[core] [CP] Less strict rules for adding render layers to sources

### DIFF
--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -28,11 +28,14 @@ bool RenderLayer::hasRenderPass(RenderPass pass) const {
     return bool(passes & pass);
 }
 
-bool RenderLayer::needsRendering(float zoom) const {
+bool RenderLayer::needsRendering() const {
     return passes != RenderPass::None
-           && baseImpl->visibility != style::VisibilityType::None
-           && baseImpl->minZoom <= zoom
-           && baseImpl->maxZoom >= zoom;
+           && baseImpl->visibility != style::VisibilityType::None;
+}
+
+bool RenderLayer::supportsZoom(float zoom) const {
+    // TODO: shall we use rounding or epsilon comparisons?
+    return baseImpl->minZoom <= zoom && baseImpl->maxZoom >= zoom;
 }
 
 void RenderLayer::setRenderTiles(RenderTiles tiles, const TransformState&) {

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -57,7 +57,10 @@ public:
     bool hasRenderPass(RenderPass) const;
 
     // Checks whether this layer can be rendered.
-    bool needsRendering(float zoom) const;
+    bool needsRendering() const;
+
+    // Checks whether the given zoom is inside this layer zoom range.
+    bool supportsZoom(float zoom) const;
 
     virtual void render(PaintParameters&, RenderSource*) = 0;
 

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -250,23 +250,26 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
             const Immutable<Layer::Impl>& layerImpl = *it;
             RenderLayer* layer = getRenderLayer(layerImpl->id);
             const auto* layerInfo = layerImpl->getTypeInfo();
-            const bool layerNeedsRendering = layer->needsRendering(zoomHistory.lastZoom);
+            const bool layerNeedsRendering = layer->needsRendering();
+            const bool zoomFitsLayer = layer->supportsZoom(zoomHistory.lastZoom);
             staticData->has3D = (staticData->has3D || layerInfo->pass3d == LayerTypeInfo::Pass3D::Required);
 
             if (layerInfo->source != LayerTypeInfo::Source::NotRequired) {
                 if (layerImpl->source == sourceImpl->id) {
                     sourceNeedsRelayout = (sourceNeedsRelayout || hasImageDiff || hasLayoutDifference(layerDiff, layerImpl->id));
                     if (layerNeedsRendering) {
-                        sourceNeedsRendering = true;
                         filteredLayersForSource.push_back(layer->evaluatedProperties);
-                        renderItemsEmplaceHint = renderItems.emplace_hint(renderItemsEmplaceHint, *layer, source, index);
+                        if (zoomFitsLayer) {
+                            sourceNeedsRendering = true;
+                            renderItemsEmplaceHint = renderItems.emplace_hint(renderItemsEmplaceHint, *layer, source, index);
+                        }
                     }
                 }
                 continue;
             } 
 
             // Handle layers without source.
-            if (layerNeedsRendering && sourceImpl.get() == sourceImpls->at(0).get()) {
+            if (layerNeedsRendering && zoomFitsLayer && sourceImpl.get() == sourceImpls->at(0).get()) {
                 if (!backend.contextIsShared() && layerImpl.get() == layerImpls->at(0).get()) {
                     const auto& solidBackground = layer->getSolidBackground();
                     if (solidBackground) {
@@ -632,9 +635,10 @@ std::vector<Feature> Renderer::Impl::queryRenderedFeatures(const ScreenLineStrin
     // Combine all results based on the style layer renderItems.
     for (const auto& layerImpl : *layerImpls) {
         const RenderLayer* layer = getRenderLayer(layerImpl->id);
-        if (!layer->needsRendering(zoomHistory.lastZoom)) {
+        if (!layer->needsRendering() || !layer->supportsZoom(zoomHistory.lastZoom)) {
             continue;
         }
+
         auto it = resultsByLayer.find(layer->baseImpl->id);
         if (it != resultsByLayer.end()) {
             std::move(it->second.begin(), it->second.end(), std::back_inserter(result));


### PR DESCRIPTION
This is the partial revert of 8faf47a

Zoom check at `RenderLayer::needsRendering()` was too strict, which prevented adding tile buckets for the layers whose `minZoom` was just slightly bigger than `zoomHistory.lastZoom` (e.g. lastZoom: 11.9522, min zoom: 12).

Fixes: #14523