### PR TITLE
[iosapp] Move token setting to build script

### DIFF
--- a/platform/ios/DEVELOPING.md
+++ b/platform/ios/DEVELOPING.md
@@ -152,7 +152,9 @@ To instead run the cross-platform tests in Xcode instead of on the command line:
 
 ## Access tokens
 
-The included applications use Mapbox vector tiles, which require a Mapbox account and API access token. Obtain an access token on the [Mapbox account page](https://www.mapbox.com/studio/account/tokens/). You will be prompted for this access token the first time you launch the demo or benchmarking application. In the iOS Simulator, you can paste your access token by pressing Command-V, holding down the left mouse button in the text field, and pressing the Paste button that appears.
+The included applications use Mapbox vector tiles, which require a Mapbox account and API access token. Obtain an access token on the [Mapbox account page](https://www.mapbox.com/studio/account/tokens/). 
+
+Before running the demo ("`iosapp`") or benchmarking ("`bench`") applications, first create a new text file called `.mapbox` or `mapbox` in your home directory containing your access token. The access token will then be automatically inserted into the application's Info.plist at runtime.
 
 ## Using iosapp
 

--- a/platform/ios/app/MBXAppDelegate.h
+++ b/platform/ios/app/MBXAppDelegate.h
@@ -1,7 +1,5 @@
 #import <UIKit/UIKit.h>
 
-extern NSString * const MBXMapboxAccessTokenDefaultsKey;
-
 @interface MBXAppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;

--- a/platform/ios/app/MBXAppDelegate.m
+++ b/platform/ios/app/MBXAppDelegate.m
@@ -2,8 +2,6 @@
 #import "MBXViewController.h"
 #import <Mapbox/Mapbox.h>
 
-NSString * const MBXMapboxAccessTokenDefaultsKey = @"MBXMapboxAccessToken";
-
 @interface MBXAppDelegate() <MGLMetricsManagerDelegate>
 
 @end
@@ -12,25 +10,11 @@ NSString * const MBXMapboxAccessTokenDefaultsKey = @"MBXMapboxAccessToken";
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-    // Set access token, unless MGLAccountManager already read it in from Info.plist.
-    if ( ! [MGLAccountManager accessToken]) {
-        NSString *accessToken = [[NSProcessInfo processInfo] environment][@"MAPBOX_ACCESS_TOKEN"];
-        if (accessToken) {
-            // Store to preferences so that we can launch the app later on without having to specify
-            // token.
-            [[NSUserDefaults standardUserDefaults] setObject:accessToken forKey:MBXMapboxAccessTokenDefaultsKey];
-        } else {
-            // Try to retrieve from preferences, maybe we've stored them there previously and can reuse
-            // the token.
-            accessToken = [[NSUserDefaults standardUserDefaults] objectForKey:MBXMapboxAccessTokenDefaultsKey];
-        }
-        [MGLAccountManager setAccessToken:accessToken];
 #ifndef MGL_DISABLE_LOGGING
-        [MGLLoggingConfiguration sharedConfiguration].loggingLevel = MGLLoggingLevelFault;
+    [MGLLoggingConfiguration sharedConfiguration].loggingLevel = MGLLoggingLevelFault;
 #endif
-        [MGLMetricsManager sharedManager].delegate = self;
-    }
 
+    [MGLMetricsManager sharedManager].delegate = self;
     return YES;
 }
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -245,44 +245,17 @@ CLLocationCoordinate2D randomWorldCoordinate() {
 
     [self restoreState:nil];
 
-    self.debugLoggingEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:@"MGLMapboxMetricsDebugLoggingEnabled"];
-    self.mapView.showsScale = YES;
-    self.mapView.showsUserHeadingIndicator = YES;
-    self.mapView.experimental_enableFrameRateMeasurement = YES;
-    self.hudLabel.titleLabel.font = [UIFont monospacedDigitSystemFontOfSize:10 weight:UIFontWeightRegular];
-
     if ([MGLAccountManager accessToken].length)
     {
         self.styleIndex = -1;
         [self cycleStyles:self];
     }
-    else
-    {
-        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:@"Access Token" message:@"Enter your Mapbox access token to load Mapbox-hosted tiles and styles:" preferredStyle:UIAlertControllerStyleAlert];
-        [alertController addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField)
-         {
-             textField.keyboardType = UIKeyboardTypeURL;
-             textField.autocorrectionType = UITextAutocorrectionTypeNo;
-             textField.autocapitalizationType = UITextAutocapitalizationTypeNone;
-         }];
 
-        [alertController addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
-        UIAlertAction *OKAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action)
-        {
-            UITextField *textField = alertController.textFields.firstObject;
-            NSString *accessToken = textField.text;
-            [[NSUserDefaults standardUserDefaults] setObject:accessToken forKey:MBXMapboxAccessTokenDefaultsKey];
-            [MGLAccountManager setAccessToken:accessToken];
-
-            self.styleIndex = -1;
-            [self cycleStyles:self];
-            [self.mapView reloadStyle:self];
-        }];
-        [alertController addAction:OKAction];
-        alertController.preferredAction = OKAction;
-
-        [self presentViewController:alertController animated:YES completion:nil];
-    }
+    self.debugLoggingEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:@"MGLMapboxMetricsDebugLoggingEnabled"];
+    self.mapView.showsScale = YES;
+    self.mapView.showsUserHeadingIndicator = YES;
+    self.mapView.experimental_enableFrameRateMeasurement = YES;
+    self.hudLabel.titleLabel.font = [UIFont monospacedDigitSystemFontOfSize:10 weight:UIFontWeightRegular];
 
     // Add fall-through single tap gesture recognizer. This will be called when
     // the map view's tap recognizers fail.

--- a/platform/ios/app/insert_access_token.sh
+++ b/platform/ios/app/insert_access_token.sh
@@ -1,0 +1,17 @@
+if [[ "$CI" ]]; then
+  echo "CI environment, access token not required"
+  exit 0
+else
+  echo "Inserting Mapbox access token..."
+  token_file=~/.mapbox
+  token_file2=~/mapbox
+  token="$(cat $token_file 2>/dev/null || cat $token_file2 2>/dev/null)"
+  if [ "$token" ]; then
+    plutil -replace MGLMapboxAccessToken -string $token "$TARGET_BUILD_DIR/$INFOPLIST_PATH"
+    echo "Token insertion successful"
+  else
+    echo \'error: Missing Mapbox access token\'
+    echo "error: Get an access token from <https://www.mapbox.com/studio/account/tokens/>, then create a new file at $token_file that contains the access token."
+    exit 1
+  fi
+fi

--- a/platform/ios/benchmark/MBXBenchAppDelegate.h
+++ b/platform/ios/benchmark/MBXBenchAppDelegate.h
@@ -1,7 +1,5 @@
 #import <UIKit/UIKit.h>
 
-extern NSString * const MBXMapboxAccessTokenDefaultsKey;
-
 @interface MBXBenchAppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;

--- a/platform/ios/benchmark/MBXBenchAppDelegate.m
+++ b/platform/ios/benchmark/MBXBenchAppDelegate.m
@@ -2,25 +2,10 @@
 #import "MBXBenchViewController.h"
 #import <Mapbox/Mapbox.h>
 
-NSString * const MBXMapboxAccessTokenDefaultsKey = @"MBXMapboxAccessToken";
-
 @implementation MBXBenchAppDelegate
 
 - (BOOL)application:(UIApplication*)application
     didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
-    if (![MGLAccountManager accessToken]) {
-        NSString *accessToken = [[NSProcessInfo processInfo] environment][@"MAPBOX_ACCESS_TOKEN"];
-        if (accessToken) {
-            // Store to preferences so that we can launch the app later on without having to specify
-            // token.
-            [[NSUserDefaults standardUserDefaults] setObject:accessToken forKey:MBXMapboxAccessTokenDefaultsKey];
-        } else {
-            // Try to retrieve from preferences, maybe we've stored them there previously and can reuse
-            // the token.
-            accessToken = [[NSUserDefaults standardUserDefaults] objectForKey:MBXMapboxAccessTokenDefaultsKey];
-        }
-        [MGLAccountManager setAccessToken:accessToken];
-    }
 
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     self.window.rootViewController = [MBXBenchViewController new];

--- a/platform/ios/benchmark/MBXBenchViewController.mm
+++ b/platform/ios/benchmark/MBXBenchViewController.mm
@@ -53,33 +53,7 @@
 {
     [super viewDidAppear:animated];
 
-    if ([MGLAccountManager accessToken].length) {
-        [self startBenchmarkIteration];
-    } else {
-        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:@"Access Token" message:@"Enter your Mapbox access token to load Mapbox-hosted tiles and styles:" preferredStyle:UIAlertControllerStyleAlert];
-        [alertController addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
-            textField.keyboardType = UIKeyboardTypeURL;
-            textField.autocorrectionType = UITextAutocorrectionTypeNo;
-            textField.autocapitalizationType = UITextAutocapitalizationTypeNone;
-        }];
-
-        [alertController addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
-            [self startBenchmarkIteration];
-        }]];
-        UIAlertAction *OKAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-            UITextField *textField = alertController.textFields.firstObject;
-            NSString *accessToken = textField.text;
-            [[NSUserDefaults standardUserDefaults] setObject:accessToken forKey:MBXMapboxAccessTokenDefaultsKey];
-            [MGLAccountManager setAccessToken:accessToken];
-            [self.mapView reloadStyle:self];
-
-            [self startBenchmarkIteration];
-        }];
-        [alertController addAction:OKAction];
-        alertController.preferredAction = OKAction;
-
-        [self presentViewController:alertController animated:YES completion:nil];
-    }
+    [self startBenchmarkIteration];
 }
 
 size_t idx = 0;

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		071BBB031EE76146001FB02A /* MGLImageSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 071BBAFC1EE75CD4001FB02A /* MGLImageSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		071BBB041EE76147001FB02A /* MGLImageSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 071BBAFC1EE75CD4001FB02A /* MGLImageSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		071BBB071EE77631001FB02A /* MGLImageSourceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 071BBB051EE7761A001FB02A /* MGLImageSourceTests.m */; };
+		074A7F0D2277C093001A62D1 /* insert_access_token.sh in Resources */ = {isa = PBXBuildFile; fileRef = 074A7F0C2277C093001A62D1 /* insert_access_token.sh */; };
+		074A7F0E2277C093001A62D1 /* insert_access_token.sh in Resources */ = {isa = PBXBuildFile; fileRef = 074A7F0C2277C093001A62D1 /* insert_access_token.sh */; };
 		076171C32139C70900668A35 /* MGLMapViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 076171C22139C70900668A35 /* MGLMapViewTests.m */; };
 		076171C72141A91700668A35 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 076171C62141A91700668A35 /* Settings.bundle */; };
 		077061DA215DA00E000FEF62 /* MGLTestLocationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 077061D9215DA00E000FEF62 /* MGLTestLocationManager.m */; };
@@ -811,6 +813,7 @@
 		071BBAFC1EE75CD4001FB02A /* MGLImageSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLImageSource.h; sourceTree = "<group>"; };
 		071BBAFD1EE75CD4001FB02A /* MGLImageSource.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLImageSource.mm; sourceTree = "<group>"; };
 		071BBB051EE7761A001FB02A /* MGLImageSourceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MGLImageSourceTests.m; path = ../../darwin/test/MGLImageSourceTests.m; sourceTree = "<group>"; };
+		074A7F0C2277C093001A62D1 /* insert_access_token.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = insert_access_token.sh; sourceTree = "<group>"; };
 		076171C22139C70900668A35 /* MGLMapViewTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MGLMapViewTests.m; path = ../../darwin/test/MGLMapViewTests.m; sourceTree = "<group>"; };
 		076171C62141A91700668A35 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = Settings.bundle; path = app/Settings.bundle; sourceTree = SOURCE_ROOT; };
 		077061D9215DA00E000FEF62 /* MGLTestLocationManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLTestLocationManager.m; sourceTree = "<group>"; };
@@ -1867,6 +1870,7 @@
 				DA821D041CCC6D59007508D4 /* LaunchScreen.storyboard */,
 				DA1DC99E1CB6E088006E619F /* Assets.xcassets */,
 				DA1DC95E1CB6C1C2006E619F /* Info.plist */,
+				074A7F0C2277C093001A62D1 /* insert_access_token.sh */,
 				96E027251E57C76E004B8E66 /* Localizable.strings */,
 				076171C62141A91700668A35 /* Settings.bundle */,
 				9604FC341F313A5E003EEA02 /* Fixtures */,
@@ -2674,6 +2678,7 @@
 				DA1DC9471CB6C1C2006E619F /* Frameworks */,
 				DA1DC9481CB6C1C2006E619F /* Resources */,
 				DA4A269A1CB6F5D3000B7809 /* Embed Frameworks */,
+				074A7F0B2277BD67001A62D1 /* Insert Mapbox Access Token */,
 			);
 			buildRules = (
 			);
@@ -2763,6 +2768,7 @@
 				DABCABA51CB80692000A7C39 /* Frameworks */,
 				DABCABA61CB80692000A7C39 /* Resources */,
 				DAA4E40C1CBB6C9600178DFB /* Embed Frameworks */,
+				07796BA2227908CB0059CAF1 /* Insert Mapbox Access Token */,
 			);
 			buildRules = (
 			);
@@ -2896,6 +2902,7 @@
 				353BAEF61D646370009A8DA9 /* amsterdam.geojson in Resources */,
 				DA1DC9711CB6C6CE006E619F /* polyline.geojson in Resources */,
 				DD4823761D94AE6C00EB71B7 /* line_filter_style.json in Resources */,
+				074A7F0D2277C093001A62D1 /* insert_access_token.sh in Resources */,
 				076171C72141A91700668A35 /* Settings.bundle in Resources */,
 				DA821D071CCC6D59007508D4 /* Main.storyboard in Resources */,
 				DA1DC9731CB6C6CE006E619F /* threestates.geojson in Resources */,
@@ -2925,6 +2932,7 @@
 				DA8933BC1CCD2CA100E68420 /* Foundation.strings in Resources */,
 				DA8933A31CCC95B000E68420 /* Localizable.strings in Resources */,
 				960D0C361ECF5AAF008E151F /* Images.xcassets in Resources */,
+				074A7F0E2277C093001A62D1 /* insert_access_token.sh in Resources */,
 				DA8933F01CCD387900E68420 /* strip-frameworks.sh in Resources */,
 				DAC49C5C1CD02BC9009E1AA3 /* Localizable.stringsdict in Resources */,
 				DA8933BF1CCD2CAD00E68420 /* Foundation.stringsdict in Resources */,
@@ -2957,6 +2965,48 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		074A7F0B2277BD67001A62D1 /* Insert Mapbox Access Token */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
+			);
+			name = "Insert Mapbox Access Token";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "$SRCROOT/app/insert_access_token.sh\n";
+		};
+		07796BA2227908CB0059CAF1 /* Insert Mapbox Access Token */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/$(INFOPLIST_PATH)",
+			);
+			name = "Insert Mapbox Access Token";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/(INFOPLIST_PATH)",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "$SRCROOT/app/insert_access_token.sh\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		16376B031FFD9DAF0000563E /* Sources */ = {


### PR DESCRIPTION
This PR alters the way a Mapbox access token is set for the `iosapp` target.

Previously, this was copy/pasted into the text field of a `UIAlertController`. Because the iOS simulator has been finicky about copy/pasting and manually typing in an access token is not ideal, this step now emulates how access tokens are set in [`ios-sdk-examples`](https://github.com/mapbox/ios-sdk-examples/blob/master/Examples/insert-mapbox-token.sh), where a token is set in a `mapbox_access_token` text file and then is added to the Info.plist via a run script phase at runtime.