### PR TITLE
Update snapshot version to v7.5.0

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/gradle.properties
+++ b/platform/android/MapboxGLAndroidSDK/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=7.4.0-SNAPSHOT
+VERSION_NAME=7.5.0-SNAPSHOT
 
 # Only build native dependencies for the current ABI
 # See https://code.google.com/p/android/issues/detail?id=221098#c20


### PR DESCRIPTION
We are currently building v7.4.0-SNAPSHOT builds on both release-mojito as master. 
Master needs a bump to v7.5.0 to match the upcoming release-n. 