### PR TITLE
Resume file source to complete resources cache path change

### DIFF
--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -18,6 +18,9 @@ template <typename T> class Thread;
 
 class ResourceTransform;
 
+// TODO: the callback should include a potential error info when https://github.com/mapbox/mapbox-gl-native/issues/14759 is resolved
+using PathChangeCallback = std::function<void ()>;
+
 class DefaultFileSource : public FileSource {
 public:
     /*
@@ -47,7 +50,7 @@ public:
 
     void setResourceTransform(optional<ActorRef<ResourceTransform>>&&);
 
-    void setResourceCachePath(const std::string&);
+    void setResourceCachePath(const std::string&, optional<ActorRef<PathChangeCallback>>&&);
 
     std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
@@ -312,8 +312,7 @@ public class FileSource {
               Context.MODE_PRIVATE).edit();
           editor.putString(MAPBOX_SHARED_PREFERENCE_RESOURCES_CACHE_PATH, path);
           editor.apply();
-          setResourcesCachePath(applicationContext, path);
-          callback.onSuccess(path);
+          internalSetResourcesCachePath(applicationContext, path, callback);
         }
 
         @Override
@@ -326,11 +325,26 @@ public class FileSource {
     }
   }
 
-  private static void setResourcesCachePath(@NonNull Context context, @NonNull String path) {
-    resourcesCachePathLoaderLock.lock();
-    resourcesCachePath = path;
-    resourcesCachePathLoaderLock.unlock();
-    getInstance(context).setResourceCachePath(path);
+  private static void internalSetResourcesCachePath(@NonNull Context context, @NonNull String path,
+                                                    @NonNull final ResourcesCachePathChangeCallback callback) {
+    final FileSource fileSource = getInstance(context);
+    fileSource.setResourceCachePath(path, new ResourcesCachePathChangeCallback() {
+      @Override
+      public void onSuccess(@NonNull String path) {
+        fileSource.deactivate();
+        resourcesCachePathLoaderLock.lock();
+        resourcesCachePath = path;
+        resourcesCachePathLoaderLock.unlock();
+        callback.onSuccess(path);
+      }
+
+      @Override
+      public void onError(@NonNull String message) {
+        fileSource.deactivate();
+        callback.onError(message);
+      }
+    });
+    fileSource.activate();
   }
 
   private static boolean isPathWritable(String path) {
@@ -388,7 +402,7 @@ public class FileSource {
   public native void setResourceTransform(final ResourceTransformCallback callback);
 
   @Keep
-  private native void setResourceCachePath(String path);
+  private native void setResourceCachePath(String path, ResourcesCachePathChangeCallback callback);
 
   @Keep
   private native void initialize(String accessToken, String cachePath, AssetManager assetManager);

--- a/platform/android/src/file_source.hpp
+++ b/platform/android/src/file_source.hpp
@@ -11,6 +11,7 @@ namespace mbgl {
 
 template <typename T> class Actor;
 class ResourceTransform;
+using mbgl::PathChangeCallback;
 
 namespace android {
 
@@ -28,6 +29,18 @@ public:
         static std::string onURL(jni::JNIEnv&, const jni::Object<FileSource::ResourceTransformCallback>&, int, std::string);
     };
 
+    struct ResourcesCachePathChangeCallback {
+        static constexpr auto Name() { return "com/mapbox/mapboxsdk/storage/FileSource$ResourcesCachePathChangeCallback";}
+
+        static void onSuccess(jni::JNIEnv&,
+                              const jni::Object<FileSource::ResourcesCachePathChangeCallback>&,
+                              const jni::String&);
+
+        static void onError(jni::JNIEnv&,
+                              const jni::Object<FileSource::ResourcesCachePathChangeCallback>&,
+                              const jni::String&);
+    };
+
     FileSource(jni::JNIEnv&, const jni::String&, const jni::String&, const jni::Object<AssetManager>&);
 
     ~FileSource();
@@ -40,7 +53,7 @@ public:
 
     void setResourceTransform(jni::JNIEnv&, const jni::Object<FileSource::ResourceTransformCallback>&);
 
-    void setResourceCachePath(jni::JNIEnv&, const jni::String&);
+    void setResourceCachePath(jni::JNIEnv&, const jni::String&, const jni::Object<FileSource::ResourcesCachePathChangeCallback>&);
 
     void resume(jni::JNIEnv&);
 
@@ -59,6 +72,7 @@ private:
     optional<int> activationCounter;
     mbgl::ResourceOptions resourceOptions;
     std::unique_ptr<Actor<ResourceTransform>> resourceTransform;
+    std::unique_ptr<Actor<PathChangeCallback>> pathChangeCallback;
     std::shared_ptr<mbgl::DefaultFileSource> fileSource;
 };
 

--- a/platform/default/src/mbgl/storage/default_file_source.cpp
+++ b/platform/default/src/mbgl/storage/default_file_source.cpp
@@ -46,8 +46,11 @@ public:
         onlineFileSource.setResourceTransform(std::move(transform));
     }
 
-    void setResourceCachePath(const std::string& path) {
+    void setResourceCachePath(const std::string& path, optional<ActorRef<PathChangeCallback>>&& callback) {
         offlineDatabase->changePath(path);
+        if (callback) {
+            callback->invoke(&PathChangeCallback::operator());
+        }
     }
 
     void listRegions(std::function<void (expected<OfflineRegions, std::exception_ptr>)> callback) {
@@ -252,8 +255,8 @@ void DefaultFileSource::setResourceTransform(optional<ActorRef<ResourceTransform
     impl->actor().invoke(&Impl::setResourceTransform, std::move(transform));
 }
 
-void DefaultFileSource::setResourceCachePath(const std::string& path) {
-    impl->actor().invoke(&Impl::setResourceCachePath, path);
+void DefaultFileSource::setResourceCachePath(const std::string& path, optional<ActorRef<PathChangeCallback>>&& callback) {
+    impl->actor().invoke(&Impl::setResourceCachePath, path, std::move(callback));
 }
 
 std::unique_ptr<AsyncRequest> DefaultFileSource::request(const Resource& resource, Callback callback) {

--- a/test/storage/default_file_source.test.cpp
+++ b/test/storage/default_file_source.test.cpp
@@ -572,6 +572,18 @@ TEST(DefaultFileSource, TEST_REQUIRES_SERVER(SetResourceTransform)) {
     loop.run();
 }
 
+TEST(DefaultFileSource, SetResourceCachePath) {
+    util::RunLoop loop;
+    DefaultFileSource fs(":memory:", ".");
+
+    Actor<PathChangeCallback> callback(loop, [&]() -> void {
+        loop.stop();
+    });
+
+    fs.setResourceCachePath("./new_offline.db", callback.self());
+    loop.run();
+}
+
 // Test that a stale cache file that has must-revalidate set will trigger a response.
 TEST(DefaultFileSource, TEST_REQUIRES_SERVER(RespondToStaleMustRevalidate)) {
     util::RunLoop loop;


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/14334.

I've initially made `DefaultFileSource::setResourceCachePath` synchronous and managed threading on the java side, but now that I think about it, it might be cleaner to use a callback and do the threading on the core side.