### PR TITLE
[ios] Update Podspecs for v4.12.0-alpha.1

### DIFF
--- a/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '4.11.0-beta.2'
+  version = '4.12.0-alpha.1'
 
   m.name    = 'Mapbox-iOS-SDK-snapshot-dynamic'
   m.version = "#{version}-snapshot"

--- a/platform/ios/Mapbox-iOS-SDK-stripped.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-stripped.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '4.11.0-beta.2'
+  version = '4.12.0-alpha.1'
 
   m.name    = 'Mapbox-iOS-SDK-stripped'
   m.version = "#{version}-stripped"

--- a/platform/ios/Mapbox-iOS-SDK.podspec
+++ b/platform/ios/Mapbox-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '4.11.0-beta.2'
+  version = '4.12.0-alpha.1'
 
   m.name    = 'Mapbox-iOS-SDK'
   m.version = version


### PR DESCRIPTION
Podspec bumps for v4.12.0-alpha.1.

I didn't end up finding any commits [between v4.11.0-beta.2 and v4.12.0-alpha.1](https://github.com/mapbox/mapbox-gl-native/compare/ios-v4.11.0-beta.2...master) that warranted a changelog entry.