### PR TITLE
Include fix-it suggestions in deprecation warnings

### DIFF
--- a/platform/darwin/src/MGLOfflineStorage.h
+++ b/platform/darwin/src/MGLOfflineStorage.h
@@ -371,7 +371,7 @@ MGL_EXPORT
  */
 - (void)preloadData:(NSData *)data forURL:(NSURL *)url modificationDate:(nullable NSDate *)modified expirationDate:(nullable NSDate *)expires eTag:(nullable NSString *)eTag mustRevalidate:(BOOL)mustRevalidate NS_SWIFT_NAME(preload(_:for:modifiedOn:expiresOn:eTag:mustRevalidate:));
 
-- (void)putResourceWithUrl:(NSURL *)url data:(NSData *)data modified:(nullable NSDate *)modified expires:(nullable NSDate *)expires etag:(nullable NSString *)etag mustRevalidate:(BOOL)mustRevalidate __attribute__((deprecated("Use -preloadData:forURL:modificationDate:expirationDate:eTag:mustRevalidate:.")));
+- (void)putResourceWithUrl:(NSURL *)url data:(NSData *)data modified:(nullable NSDate *)modified expires:(nullable NSDate *)expires etag:(nullable NSString *)etag mustRevalidate:(BOOL)mustRevalidate __attribute__((deprecated("", "-preloadData:forURL:modificationDate:expirationDate:eTag:mustRevalidate:")));
 
 @end
 

--- a/platform/darwin/src/NSExpression+MGLAdditions.h
+++ b/platform/darwin/src/NSExpression+MGLAdditions.h
@@ -91,7 +91,7 @@ FOUNDATION_EXTERN MGL_EXPORT const MGLExpressionInterpolationMode MGLExpressionI
  */
 @property (class, nonatomic, readonly) NSExpression *featureAttributesVariableExpression;
 
-@property (class, nonatomic, readonly) NSExpression *featurePropertiesVariableExpression __attribute__((deprecated("Use -featureAttributesVariableExpression.")));
+@property (class, nonatomic, readonly) NSExpression *featurePropertiesVariableExpression __attribute__((deprecated("", "featureAttributesVariableExpression")));
 
 #pragma mark Creating Conditional Expressions
 


### PR DESCRIPTION
Clang now supports an additional argument to the [`deprecated`](http://clang.llvm.org/docs/AttributeReference.html#deprecated) attribute that results in a fix-it suggestion, similar to the `renamed:` argument to the `@availability()` attribute in Swift:

<img width="718" alt="deprecated" src="https://user-images.githubusercontent.com/1231218/57062731-eb875880-6c75-11e9-89b4-5fa0477437f6.png">

This PR upgrades a couple deprecation warnings to use the new syntax. Some occurrences could not be upgraded, because it looks like fix-it suggestions only work correctly when a member is merely renamed, not moved to another class.

/cc @mapbox/maps-ios