### PR TITLE
[core] Keep shared_ptr to thread pool in CustomGeometrySource

### DIFF
--- a/include/mbgl/style/sources/custom_geometry_source.hpp
+++ b/include/mbgl/style/sources/custom_geometry_source.hpp
@@ -12,6 +12,7 @@ class OverscaledTileID;
 class CanonicalTileID;
 template <class T>
 class Actor;
+class ThreadPool;
 
 namespace style {
 
@@ -46,6 +47,7 @@ public:
     class Impl;
     const Impl& impl() const;
 private:
+    std::shared_ptr<ThreadPool> threadPool;
     std::unique_ptr<Actor<CustomTileLoader>> loader;
 };
 

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -5,9 +5,11 @@
 
 #include <mbgl/annotation/annotation.hpp>
 #include <mbgl/style/style.hpp>
+#include <mbgl/style/sources/custom_geometry_source.hpp>
 #include <mbgl/style/image.hpp>
 #include <mbgl/style/transition_options.hpp>
 #include <mbgl/style/layers/fill_extrusion_layer.hpp>
+#include <mbgl/style/layers/line_layer.hpp>
 #include <mbgl/style/expression/dsl.hpp>
 #include <mbgl/util/logging.hpp>
 #include <mbgl/util/platform.hpp>
@@ -128,6 +130,7 @@ GLFWView::GLFWView(bool fullscreen_, bool benchmark_)
     printf("- Press `A` to cycle through Mapbox offices in the world + dateline monument\n");
     printf("- Press `B` to cycle through the color, stencil, and depth buffer\n");
     printf("- Press `D` to cycle through camera bounds: inside, crossing IDL at left, crossing IDL at right, and disabled\n");
+    printf("- Press `T` to add custom geometry source\n");
     printf("\n");
     printf("- Press `1` through `6` to add increasing numbers of point annotations for testing\n");
     printf("- Press `7` through `0` to add increasing numbers of shape annotations for testing\n");
@@ -320,6 +323,9 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
                 }
             }
         } break;
+        case GLFW_KEY_T:
+            view->toggleCustomSource();
+            break;
         }
     }
 
@@ -674,6 +680,51 @@ void GLFWView::toggle3DExtrusions(bool visible) {
     extrusionLayer->setFillExtrusionBase(PropertyExpression<float>(get("min_height")));
 
     map->getStyle().addLayer(std::move(extrusionLayer));
+}
+
+void GLFWView::toggleCustomSource() {
+    if (!map->getStyle().getSource("custom")) {
+        mbgl::style::CustomGeometrySource::Options options;
+        options.cancelTileFunction = [](const mbgl::CanonicalTileID&) {};
+        options.fetchTileFunction = [&](const mbgl::CanonicalTileID& tileID) {
+            double gridSpacing = 0.1;
+            mbgl::FeatureCollection features;
+            const mbgl::LatLngBounds bounds(tileID);
+            for (double y = ceil(bounds.north() / gridSpacing) * gridSpacing; y >= floor(bounds.south() / gridSpacing) * gridSpacing; y -= gridSpacing) {
+
+                mapbox::geojson::line_string gridLine;
+                gridLine.emplace_back(bounds.west(), y);
+                gridLine.emplace_back(bounds.east(), y);
+
+                features.emplace_back(gridLine);
+            }
+
+            for (double x = floor(bounds.west() / gridSpacing) * gridSpacing; x <= ceil(bounds.east() / gridSpacing) * gridSpacing; x += gridSpacing) {
+                mapbox::geojson::line_string gridLine;
+                gridLine.emplace_back(x, bounds.south());
+                gridLine.emplace_back(x, bounds.north());
+
+                features.emplace_back(gridLine);
+            }
+            auto source = static_cast<mbgl::style::CustomGeometrySource *>(map->getStyle().getSource("custom"));
+            if (source) {
+                source->setTileData(tileID, features);
+                source->invalidateTile(tileID);
+            }
+        };
+        map->getStyle().addSource(std::make_unique<mbgl::style::CustomGeometrySource>("custom", options));
+    }
+
+    auto* layer = map->getStyle().getLayer("grid");
+
+    if (!layer) {
+        auto lineLayer = std::make_unique<mbgl::style::LineLayer>("grid", "custom");
+        lineLayer->setLineColor(mbgl::Color{ 1.0, 0.0, 0.0, 1.0 });
+        map->getStyle().addLayer(std::move(lineLayer));
+    } else {
+        layer->setVisibility(layer->getVisibility() == mbgl::style::VisibilityType::Visible ?
+                             mbgl::style::VisibilityType::None : mbgl::style::VisibilityType::Visible);
+    }
 }
 
 namespace mbgl {

--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -84,6 +84,7 @@ private:
     void addRandomCustomPointAnnotations(int count);
     void addAnimatedAnnotation();
     void updateAnimatedAnnotations();
+    void toggleCustomSource();
 
     void clearAnnotations();
     void popAnnotation();

--- a/src/mbgl/style/custom_tile_loader.hpp
+++ b/src/mbgl/style/custom_tile_loader.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/actor/actor_ref.hpp>
 
 #include <map>
+#include <mutex>
 
 namespace mbgl {
 
@@ -38,7 +39,7 @@ private:
     std::unordered_map<CanonicalTileID, std::vector<OverscaledIDFunctionTuple>> tileCallbackMap;
     // Keep around a cache of tile data to serve back for wrapped and over-zooomed tiles
     std::map<CanonicalTileID, std::unique_ptr<GeoJSON>> dataCache;
-
+    std::mutex dataMutex;
 };
 
 } // namespace style

--- a/src/mbgl/style/sources/custom_geometry_source.cpp
+++ b/src/mbgl/style/sources/custom_geometry_source.cpp
@@ -14,7 +14,8 @@ namespace style {
 CustomGeometrySource::CustomGeometrySource(std::string id,
                                        const CustomGeometrySource::Options options)
     : Source(makeMutable<CustomGeometrySource::Impl>(std::move(id), options)),
-    loader(std::make_unique<Actor<CustomTileLoader>>(*sharedThreadPool(), options.fetchTileFunction, options.cancelTileFunction)) {
+    threadPool(sharedThreadPool()),
+    loader(std::make_unique<Actor<CustomTileLoader>>(*threadPool, options.fetchTileFunction, options.cancelTileFunction)) {
 }
 
 CustomGeometrySource::~CustomGeometrySource() = default;


### PR DESCRIPTION
`CustomGeometrySource` should keep strong reference to shared thread pool that is used by `CustomTileLoader`.

Access to `CustomTileLoader`'s data members must be synchronized, since they are accessed / modified from multiple threads in the thread pool.

Fixes: #14411