### PR TITLE
Code gen: sort style properties alphabetically

### DIFF
--- a/include/mbgl/style/layers/background_layer.hpp
+++ b/include/mbgl/style/layers/background_layer.hpp
@@ -30,17 +30,17 @@ public:
     void setBackgroundColorTransition(const TransitionOptions&);
     TransitionOptions getBackgroundColorTransition() const;
 
-    static PropertyValue<std::string> getDefaultBackgroundPattern();
-    const PropertyValue<std::string>& getBackgroundPattern() const;
-    void setBackgroundPattern(const PropertyValue<std::string>&);
-    void setBackgroundPatternTransition(const TransitionOptions&);
-    TransitionOptions getBackgroundPatternTransition() const;
-
     static PropertyValue<float> getDefaultBackgroundOpacity();
     const PropertyValue<float>& getBackgroundOpacity() const;
     void setBackgroundOpacity(const PropertyValue<float>&);
     void setBackgroundOpacityTransition(const TransitionOptions&);
     TransitionOptions getBackgroundOpacityTransition() const;
+
+    static PropertyValue<std::string> getDefaultBackgroundPattern();
+    const PropertyValue<std::string>& getBackgroundPattern() const;
+    void setBackgroundPattern(const PropertyValue<std::string>&);
+    void setBackgroundPatternTransition(const TransitionOptions&);
+    TransitionOptions getBackgroundPatternTransition() const;
 
     // Private implementation
 

--- a/include/mbgl/style/layers/circle_layer.hpp
+++ b/include/mbgl/style/layers/circle_layer.hpp
@@ -24,11 +24,11 @@ public:
 
     // Paint properties
 
-    static PropertyValue<float> getDefaultCircleRadius();
-    const PropertyValue<float>& getCircleRadius() const;
-    void setCircleRadius(const PropertyValue<float>&);
-    void setCircleRadiusTransition(const TransitionOptions&);
-    TransitionOptions getCircleRadiusTransition() const;
+    static PropertyValue<float> getDefaultCircleBlur();
+    const PropertyValue<float>& getCircleBlur() const;
+    void setCircleBlur(const PropertyValue<float>&);
+    void setCircleBlurTransition(const TransitionOptions&);
+    TransitionOptions getCircleBlurTransition() const;
 
     static PropertyValue<Color> getDefaultCircleColor();
     const PropertyValue<Color>& getCircleColor() const;
@@ -36,35 +36,11 @@ public:
     void setCircleColorTransition(const TransitionOptions&);
     TransitionOptions getCircleColorTransition() const;
 
-    static PropertyValue<float> getDefaultCircleBlur();
-    const PropertyValue<float>& getCircleBlur() const;
-    void setCircleBlur(const PropertyValue<float>&);
-    void setCircleBlurTransition(const TransitionOptions&);
-    TransitionOptions getCircleBlurTransition() const;
-
     static PropertyValue<float> getDefaultCircleOpacity();
     const PropertyValue<float>& getCircleOpacity() const;
     void setCircleOpacity(const PropertyValue<float>&);
     void setCircleOpacityTransition(const TransitionOptions&);
     TransitionOptions getCircleOpacityTransition() const;
-
-    static PropertyValue<std::array<float, 2>> getDefaultCircleTranslate();
-    const PropertyValue<std::array<float, 2>>& getCircleTranslate() const;
-    void setCircleTranslate(const PropertyValue<std::array<float, 2>>&);
-    void setCircleTranslateTransition(const TransitionOptions&);
-    TransitionOptions getCircleTranslateTransition() const;
-
-    static PropertyValue<TranslateAnchorType> getDefaultCircleTranslateAnchor();
-    const PropertyValue<TranslateAnchorType>& getCircleTranslateAnchor() const;
-    void setCircleTranslateAnchor(const PropertyValue<TranslateAnchorType>&);
-    void setCircleTranslateAnchorTransition(const TransitionOptions&);
-    TransitionOptions getCircleTranslateAnchorTransition() const;
-
-    static PropertyValue<CirclePitchScaleType> getDefaultCirclePitchScale();
-    const PropertyValue<CirclePitchScaleType>& getCirclePitchScale() const;
-    void setCirclePitchScale(const PropertyValue<CirclePitchScaleType>&);
-    void setCirclePitchScaleTransition(const TransitionOptions&);
-    TransitionOptions getCirclePitchScaleTransition() const;
 
     static PropertyValue<AlignmentType> getDefaultCirclePitchAlignment();
     const PropertyValue<AlignmentType>& getCirclePitchAlignment() const;
@@ -72,11 +48,17 @@ public:
     void setCirclePitchAlignmentTransition(const TransitionOptions&);
     TransitionOptions getCirclePitchAlignmentTransition() const;
 
-    static PropertyValue<float> getDefaultCircleStrokeWidth();
-    const PropertyValue<float>& getCircleStrokeWidth() const;
-    void setCircleStrokeWidth(const PropertyValue<float>&);
-    void setCircleStrokeWidthTransition(const TransitionOptions&);
-    TransitionOptions getCircleStrokeWidthTransition() const;
+    static PropertyValue<CirclePitchScaleType> getDefaultCirclePitchScale();
+    const PropertyValue<CirclePitchScaleType>& getCirclePitchScale() const;
+    void setCirclePitchScale(const PropertyValue<CirclePitchScaleType>&);
+    void setCirclePitchScaleTransition(const TransitionOptions&);
+    TransitionOptions getCirclePitchScaleTransition() const;
+
+    static PropertyValue<float> getDefaultCircleRadius();
+    const PropertyValue<float>& getCircleRadius() const;
+    void setCircleRadius(const PropertyValue<float>&);
+    void setCircleRadiusTransition(const TransitionOptions&);
+    TransitionOptions getCircleRadiusTransition() const;
 
     static PropertyValue<Color> getDefaultCircleStrokeColor();
     const PropertyValue<Color>& getCircleStrokeColor() const;
@@ -89,6 +71,24 @@ public:
     void setCircleStrokeOpacity(const PropertyValue<float>&);
     void setCircleStrokeOpacityTransition(const TransitionOptions&);
     TransitionOptions getCircleStrokeOpacityTransition() const;
+
+    static PropertyValue<float> getDefaultCircleStrokeWidth();
+    const PropertyValue<float>& getCircleStrokeWidth() const;
+    void setCircleStrokeWidth(const PropertyValue<float>&);
+    void setCircleStrokeWidthTransition(const TransitionOptions&);
+    TransitionOptions getCircleStrokeWidthTransition() const;
+
+    static PropertyValue<std::array<float, 2>> getDefaultCircleTranslate();
+    const PropertyValue<std::array<float, 2>>& getCircleTranslate() const;
+    void setCircleTranslate(const PropertyValue<std::array<float, 2>>&);
+    void setCircleTranslateTransition(const TransitionOptions&);
+    TransitionOptions getCircleTranslateTransition() const;
+
+    static PropertyValue<TranslateAnchorType> getDefaultCircleTranslateAnchor();
+    const PropertyValue<TranslateAnchorType>& getCircleTranslateAnchor() const;
+    void setCircleTranslateAnchor(const PropertyValue<TranslateAnchorType>&);
+    void setCircleTranslateAnchorTransition(const TransitionOptions&);
+    TransitionOptions getCircleTranslateAnchorTransition() const;
 
     // Private implementation
 

--- a/include/mbgl/style/layers/fill_extrusion_layer.hpp
+++ b/include/mbgl/style/layers/fill_extrusion_layer.hpp
@@ -24,17 +24,35 @@ public:
 
     // Paint properties
 
-    static PropertyValue<float> getDefaultFillExtrusionOpacity();
-    const PropertyValue<float>& getFillExtrusionOpacity() const;
-    void setFillExtrusionOpacity(const PropertyValue<float>&);
-    void setFillExtrusionOpacityTransition(const TransitionOptions&);
-    TransitionOptions getFillExtrusionOpacityTransition() const;
+    static PropertyValue<float> getDefaultFillExtrusionBase();
+    const PropertyValue<float>& getFillExtrusionBase() const;
+    void setFillExtrusionBase(const PropertyValue<float>&);
+    void setFillExtrusionBaseTransition(const TransitionOptions&);
+    TransitionOptions getFillExtrusionBaseTransition() const;
 
     static PropertyValue<Color> getDefaultFillExtrusionColor();
     const PropertyValue<Color>& getFillExtrusionColor() const;
     void setFillExtrusionColor(const PropertyValue<Color>&);
     void setFillExtrusionColorTransition(const TransitionOptions&);
     TransitionOptions getFillExtrusionColorTransition() const;
+
+    static PropertyValue<float> getDefaultFillExtrusionHeight();
+    const PropertyValue<float>& getFillExtrusionHeight() const;
+    void setFillExtrusionHeight(const PropertyValue<float>&);
+    void setFillExtrusionHeightTransition(const TransitionOptions&);
+    TransitionOptions getFillExtrusionHeightTransition() const;
+
+    static PropertyValue<float> getDefaultFillExtrusionOpacity();
+    const PropertyValue<float>& getFillExtrusionOpacity() const;
+    void setFillExtrusionOpacity(const PropertyValue<float>&);
+    void setFillExtrusionOpacityTransition(const TransitionOptions&);
+    TransitionOptions getFillExtrusionOpacityTransition() const;
+
+    static PropertyValue<std::string> getDefaultFillExtrusionPattern();
+    const PropertyValue<std::string>& getFillExtrusionPattern() const;
+    void setFillExtrusionPattern(const PropertyValue<std::string>&);
+    void setFillExtrusionPatternTransition(const TransitionOptions&);
+    TransitionOptions getFillExtrusionPatternTransition() const;
 
     static PropertyValue<std::array<float, 2>> getDefaultFillExtrusionTranslate();
     const PropertyValue<std::array<float, 2>>& getFillExtrusionTranslate() const;
@@ -47,24 +65,6 @@ public:
     void setFillExtrusionTranslateAnchor(const PropertyValue<TranslateAnchorType>&);
     void setFillExtrusionTranslateAnchorTransition(const TransitionOptions&);
     TransitionOptions getFillExtrusionTranslateAnchorTransition() const;
-
-    static PropertyValue<std::string> getDefaultFillExtrusionPattern();
-    const PropertyValue<std::string>& getFillExtrusionPattern() const;
-    void setFillExtrusionPattern(const PropertyValue<std::string>&);
-    void setFillExtrusionPatternTransition(const TransitionOptions&);
-    TransitionOptions getFillExtrusionPatternTransition() const;
-
-    static PropertyValue<float> getDefaultFillExtrusionHeight();
-    const PropertyValue<float>& getFillExtrusionHeight() const;
-    void setFillExtrusionHeight(const PropertyValue<float>&);
-    void setFillExtrusionHeightTransition(const TransitionOptions&);
-    TransitionOptions getFillExtrusionHeightTransition() const;
-
-    static PropertyValue<float> getDefaultFillExtrusionBase();
-    const PropertyValue<float>& getFillExtrusionBase() const;
-    void setFillExtrusionBase(const PropertyValue<float>&);
-    void setFillExtrusionBaseTransition(const TransitionOptions&);
-    TransitionOptions getFillExtrusionBaseTransition() const;
 
     static PropertyValue<bool> getDefaultFillExtrusionVerticalGradient();
     const PropertyValue<bool>& getFillExtrusionVerticalGradient() const;

--- a/include/mbgl/style/layers/fill_layer.hpp
+++ b/include/mbgl/style/layers/fill_layer.hpp
@@ -30,23 +30,29 @@ public:
     void setFillAntialiasTransition(const TransitionOptions&);
     TransitionOptions getFillAntialiasTransition() const;
 
-    static PropertyValue<float> getDefaultFillOpacity();
-    const PropertyValue<float>& getFillOpacity() const;
-    void setFillOpacity(const PropertyValue<float>&);
-    void setFillOpacityTransition(const TransitionOptions&);
-    TransitionOptions getFillOpacityTransition() const;
-
     static PropertyValue<Color> getDefaultFillColor();
     const PropertyValue<Color>& getFillColor() const;
     void setFillColor(const PropertyValue<Color>&);
     void setFillColorTransition(const TransitionOptions&);
     TransitionOptions getFillColorTransition() const;
 
+    static PropertyValue<float> getDefaultFillOpacity();
+    const PropertyValue<float>& getFillOpacity() const;
+    void setFillOpacity(const PropertyValue<float>&);
+    void setFillOpacityTransition(const TransitionOptions&);
+    TransitionOptions getFillOpacityTransition() const;
+
     static PropertyValue<Color> getDefaultFillOutlineColor();
     const PropertyValue<Color>& getFillOutlineColor() const;
     void setFillOutlineColor(const PropertyValue<Color>&);
     void setFillOutlineColorTransition(const TransitionOptions&);
     TransitionOptions getFillOutlineColorTransition() const;
+
+    static PropertyValue<std::string> getDefaultFillPattern();
+    const PropertyValue<std::string>& getFillPattern() const;
+    void setFillPattern(const PropertyValue<std::string>&);
+    void setFillPatternTransition(const TransitionOptions&);
+    TransitionOptions getFillPatternTransition() const;
 
     static PropertyValue<std::array<float, 2>> getDefaultFillTranslate();
     const PropertyValue<std::array<float, 2>>& getFillTranslate() const;
@@ -59,12 +65,6 @@ public:
     void setFillTranslateAnchor(const PropertyValue<TranslateAnchorType>&);
     void setFillTranslateAnchorTransition(const TransitionOptions&);
     TransitionOptions getFillTranslateAnchorTransition() const;
-
-    static PropertyValue<std::string> getDefaultFillPattern();
-    const PropertyValue<std::string>& getFillPattern() const;
-    void setFillPattern(const PropertyValue<std::string>&);
-    void setFillPatternTransition(const TransitionOptions&);
-    TransitionOptions getFillPatternTransition() const;
 
     // Private implementation
 

--- a/include/mbgl/style/layers/heatmap_layer.hpp
+++ b/include/mbgl/style/layers/heatmap_layer.hpp
@@ -25,6 +25,24 @@ public:
 
     // Paint properties
 
+    static ColorRampPropertyValue getDefaultHeatmapColor();
+    const ColorRampPropertyValue& getHeatmapColor() const;
+    void setHeatmapColor(const ColorRampPropertyValue&);
+    void setHeatmapColorTransition(const TransitionOptions&);
+    TransitionOptions getHeatmapColorTransition() const;
+
+    static PropertyValue<float> getDefaultHeatmapIntensity();
+    const PropertyValue<float>& getHeatmapIntensity() const;
+    void setHeatmapIntensity(const PropertyValue<float>&);
+    void setHeatmapIntensityTransition(const TransitionOptions&);
+    TransitionOptions getHeatmapIntensityTransition() const;
+
+    static PropertyValue<float> getDefaultHeatmapOpacity();
+    const PropertyValue<float>& getHeatmapOpacity() const;
+    void setHeatmapOpacity(const PropertyValue<float>&);
+    void setHeatmapOpacityTransition(const TransitionOptions&);
+    TransitionOptions getHeatmapOpacityTransition() const;
+
     static PropertyValue<float> getDefaultHeatmapRadius();
     const PropertyValue<float>& getHeatmapRadius() const;
     void setHeatmapRadius(const PropertyValue<float>&);
@@ -36,24 +54,6 @@ public:
     void setHeatmapWeight(const PropertyValue<float>&);
     void setHeatmapWeightTransition(const TransitionOptions&);
     TransitionOptions getHeatmapWeightTransition() const;
-
-    static PropertyValue<float> getDefaultHeatmapIntensity();
-    const PropertyValue<float>& getHeatmapIntensity() const;
-    void setHeatmapIntensity(const PropertyValue<float>&);
-    void setHeatmapIntensityTransition(const TransitionOptions&);
-    TransitionOptions getHeatmapIntensityTransition() const;
-
-    static ColorRampPropertyValue getDefaultHeatmapColor();
-    const ColorRampPropertyValue& getHeatmapColor() const;
-    void setHeatmapColor(const ColorRampPropertyValue&);
-    void setHeatmapColorTransition(const TransitionOptions&);
-    TransitionOptions getHeatmapColorTransition() const;
-
-    static PropertyValue<float> getDefaultHeatmapOpacity();
-    const PropertyValue<float>& getHeatmapOpacity() const;
-    void setHeatmapOpacity(const PropertyValue<float>&);
-    void setHeatmapOpacityTransition(const TransitionOptions&);
-    TransitionOptions getHeatmapOpacityTransition() const;
 
     // Private implementation
 

--- a/include/mbgl/style/layers/hillshade_layer.hpp
+++ b/include/mbgl/style/layers/hillshade_layer.hpp
@@ -24,17 +24,11 @@ public:
 
     // Paint properties
 
-    static PropertyValue<float> getDefaultHillshadeIlluminationDirection();
-    const PropertyValue<float>& getHillshadeIlluminationDirection() const;
-    void setHillshadeIlluminationDirection(const PropertyValue<float>&);
-    void setHillshadeIlluminationDirectionTransition(const TransitionOptions&);
-    TransitionOptions getHillshadeIlluminationDirectionTransition() const;
-
-    static PropertyValue<HillshadeIlluminationAnchorType> getDefaultHillshadeIlluminationAnchor();
-    const PropertyValue<HillshadeIlluminationAnchorType>& getHillshadeIlluminationAnchor() const;
-    void setHillshadeIlluminationAnchor(const PropertyValue<HillshadeIlluminationAnchorType>&);
-    void setHillshadeIlluminationAnchorTransition(const TransitionOptions&);
-    TransitionOptions getHillshadeIlluminationAnchorTransition() const;
+    static PropertyValue<Color> getDefaultHillshadeAccentColor();
+    const PropertyValue<Color>& getHillshadeAccentColor() const;
+    void setHillshadeAccentColor(const PropertyValue<Color>&);
+    void setHillshadeAccentColorTransition(const TransitionOptions&);
+    TransitionOptions getHillshadeAccentColorTransition() const;
 
     static PropertyValue<float> getDefaultHillshadeExaggeration();
     const PropertyValue<float>& getHillshadeExaggeration() const;
@@ -42,23 +36,29 @@ public:
     void setHillshadeExaggerationTransition(const TransitionOptions&);
     TransitionOptions getHillshadeExaggerationTransition() const;
 
-    static PropertyValue<Color> getDefaultHillshadeShadowColor();
-    const PropertyValue<Color>& getHillshadeShadowColor() const;
-    void setHillshadeShadowColor(const PropertyValue<Color>&);
-    void setHillshadeShadowColorTransition(const TransitionOptions&);
-    TransitionOptions getHillshadeShadowColorTransition() const;
-
     static PropertyValue<Color> getDefaultHillshadeHighlightColor();
     const PropertyValue<Color>& getHillshadeHighlightColor() const;
     void setHillshadeHighlightColor(const PropertyValue<Color>&);
     void setHillshadeHighlightColorTransition(const TransitionOptions&);
     TransitionOptions getHillshadeHighlightColorTransition() const;
 
-    static PropertyValue<Color> getDefaultHillshadeAccentColor();
-    const PropertyValue<Color>& getHillshadeAccentColor() const;
-    void setHillshadeAccentColor(const PropertyValue<Color>&);
-    void setHillshadeAccentColorTransition(const TransitionOptions&);
-    TransitionOptions getHillshadeAccentColorTransition() const;
+    static PropertyValue<HillshadeIlluminationAnchorType> getDefaultHillshadeIlluminationAnchor();
+    const PropertyValue<HillshadeIlluminationAnchorType>& getHillshadeIlluminationAnchor() const;
+    void setHillshadeIlluminationAnchor(const PropertyValue<HillshadeIlluminationAnchorType>&);
+    void setHillshadeIlluminationAnchorTransition(const TransitionOptions&);
+    TransitionOptions getHillshadeIlluminationAnchorTransition() const;
+
+    static PropertyValue<float> getDefaultHillshadeIlluminationDirection();
+    const PropertyValue<float>& getHillshadeIlluminationDirection() const;
+    void setHillshadeIlluminationDirection(const PropertyValue<float>&);
+    void setHillshadeIlluminationDirectionTransition(const TransitionOptions&);
+    TransitionOptions getHillshadeIlluminationDirectionTransition() const;
+
+    static PropertyValue<Color> getDefaultHillshadeShadowColor();
+    const PropertyValue<Color>& getHillshadeShadowColor() const;
+    void setHillshadeShadowColor(const PropertyValue<Color>&);
+    void setHillshadeShadowColorTransition(const TransitionOptions&);
+    TransitionOptions getHillshadeShadowColorTransition() const;
 
     // Private implementation
 

--- a/include/mbgl/style/layers/line_layer.hpp
+++ b/include/mbgl/style/layers/line_layer.hpp
@@ -45,17 +45,53 @@ public:
 
     // Paint properties
 
-    static PropertyValue<float> getDefaultLineOpacity();
-    const PropertyValue<float>& getLineOpacity() const;
-    void setLineOpacity(const PropertyValue<float>&);
-    void setLineOpacityTransition(const TransitionOptions&);
-    TransitionOptions getLineOpacityTransition() const;
+    static PropertyValue<float> getDefaultLineBlur();
+    const PropertyValue<float>& getLineBlur() const;
+    void setLineBlur(const PropertyValue<float>&);
+    void setLineBlurTransition(const TransitionOptions&);
+    TransitionOptions getLineBlurTransition() const;
 
     static PropertyValue<Color> getDefaultLineColor();
     const PropertyValue<Color>& getLineColor() const;
     void setLineColor(const PropertyValue<Color>&);
     void setLineColorTransition(const TransitionOptions&);
     TransitionOptions getLineColorTransition() const;
+
+    static PropertyValue<std::vector<float>> getDefaultLineDasharray();
+    const PropertyValue<std::vector<float>>& getLineDasharray() const;
+    void setLineDasharray(const PropertyValue<std::vector<float>>&);
+    void setLineDasharrayTransition(const TransitionOptions&);
+    TransitionOptions getLineDasharrayTransition() const;
+
+    static PropertyValue<float> getDefaultLineGapWidth();
+    const PropertyValue<float>& getLineGapWidth() const;
+    void setLineGapWidth(const PropertyValue<float>&);
+    void setLineGapWidthTransition(const TransitionOptions&);
+    TransitionOptions getLineGapWidthTransition() const;
+
+    static ColorRampPropertyValue getDefaultLineGradient();
+    const ColorRampPropertyValue& getLineGradient() const;
+    void setLineGradient(const ColorRampPropertyValue&);
+    void setLineGradientTransition(const TransitionOptions&);
+    TransitionOptions getLineGradientTransition() const;
+
+    static PropertyValue<float> getDefaultLineOffset();
+    const PropertyValue<float>& getLineOffset() const;
+    void setLineOffset(const PropertyValue<float>&);
+    void setLineOffsetTransition(const TransitionOptions&);
+    TransitionOptions getLineOffsetTransition() const;
+
+    static PropertyValue<float> getDefaultLineOpacity();
+    const PropertyValue<float>& getLineOpacity() const;
+    void setLineOpacity(const PropertyValue<float>&);
+    void setLineOpacityTransition(const TransitionOptions&);
+    TransitionOptions getLineOpacityTransition() const;
+
+    static PropertyValue<std::string> getDefaultLinePattern();
+    const PropertyValue<std::string>& getLinePattern() const;
+    void setLinePattern(const PropertyValue<std::string>&);
+    void setLinePatternTransition(const TransitionOptions&);
+    TransitionOptions getLinePatternTransition() const;
 
     static PropertyValue<std::array<float, 2>> getDefaultLineTranslate();
     const PropertyValue<std::array<float, 2>>& getLineTranslate() const;
@@ -74,42 +110,6 @@ public:
     void setLineWidth(const PropertyValue<float>&);
     void setLineWidthTransition(const TransitionOptions&);
     TransitionOptions getLineWidthTransition() const;
-
-    static PropertyValue<float> getDefaultLineGapWidth();
-    const PropertyValue<float>& getLineGapWidth() const;
-    void setLineGapWidth(const PropertyValue<float>&);
-    void setLineGapWidthTransition(const TransitionOptions&);
-    TransitionOptions getLineGapWidthTransition() const;
-
-    static PropertyValue<float> getDefaultLineOffset();
-    const PropertyValue<float>& getLineOffset() const;
-    void setLineOffset(const PropertyValue<float>&);
-    void setLineOffsetTransition(const TransitionOptions&);
-    TransitionOptions getLineOffsetTransition() const;
-
-    static PropertyValue<float> getDefaultLineBlur();
-    const PropertyValue<float>& getLineBlur() const;
-    void setLineBlur(const PropertyValue<float>&);
-    void setLineBlurTransition(const TransitionOptions&);
-    TransitionOptions getLineBlurTransition() const;
-
-    static PropertyValue<std::vector<float>> getDefaultLineDasharray();
-    const PropertyValue<std::vector<float>>& getLineDasharray() const;
-    void setLineDasharray(const PropertyValue<std::vector<float>>&);
-    void setLineDasharrayTransition(const TransitionOptions&);
-    TransitionOptions getLineDasharrayTransition() const;
-
-    static PropertyValue<std::string> getDefaultLinePattern();
-    const PropertyValue<std::string>& getLinePattern() const;
-    void setLinePattern(const PropertyValue<std::string>&);
-    void setLinePatternTransition(const TransitionOptions&);
-    TransitionOptions getLinePatternTransition() const;
-
-    static ColorRampPropertyValue getDefaultLineGradient();
-    const ColorRampPropertyValue& getLineGradient() const;
-    void setLineGradient(const ColorRampPropertyValue&);
-    void setLineGradientTransition(const TransitionOptions&);
-    TransitionOptions getLineGradientTransition() const;
 
     // Private implementation
 

--- a/include/mbgl/style/layers/raster_layer.hpp
+++ b/include/mbgl/style/layers/raster_layer.hpp
@@ -24,17 +24,11 @@ public:
 
     // Paint properties
 
-    static PropertyValue<float> getDefaultRasterOpacity();
-    const PropertyValue<float>& getRasterOpacity() const;
-    void setRasterOpacity(const PropertyValue<float>&);
-    void setRasterOpacityTransition(const TransitionOptions&);
-    TransitionOptions getRasterOpacityTransition() const;
-
-    static PropertyValue<float> getDefaultRasterHueRotate();
-    const PropertyValue<float>& getRasterHueRotate() const;
-    void setRasterHueRotate(const PropertyValue<float>&);
-    void setRasterHueRotateTransition(const TransitionOptions&);
-    TransitionOptions getRasterHueRotateTransition() const;
+    static PropertyValue<float> getDefaultRasterBrightnessMax();
+    const PropertyValue<float>& getRasterBrightnessMax() const;
+    void setRasterBrightnessMax(const PropertyValue<float>&);
+    void setRasterBrightnessMaxTransition(const TransitionOptions&);
+    TransitionOptions getRasterBrightnessMaxTransition() const;
 
     static PropertyValue<float> getDefaultRasterBrightnessMin();
     const PropertyValue<float>& getRasterBrightnessMin() const;
@@ -42,23 +36,29 @@ public:
     void setRasterBrightnessMinTransition(const TransitionOptions&);
     TransitionOptions getRasterBrightnessMinTransition() const;
 
-    static PropertyValue<float> getDefaultRasterBrightnessMax();
-    const PropertyValue<float>& getRasterBrightnessMax() const;
-    void setRasterBrightnessMax(const PropertyValue<float>&);
-    void setRasterBrightnessMaxTransition(const TransitionOptions&);
-    TransitionOptions getRasterBrightnessMaxTransition() const;
-
-    static PropertyValue<float> getDefaultRasterSaturation();
-    const PropertyValue<float>& getRasterSaturation() const;
-    void setRasterSaturation(const PropertyValue<float>&);
-    void setRasterSaturationTransition(const TransitionOptions&);
-    TransitionOptions getRasterSaturationTransition() const;
-
     static PropertyValue<float> getDefaultRasterContrast();
     const PropertyValue<float>& getRasterContrast() const;
     void setRasterContrast(const PropertyValue<float>&);
     void setRasterContrastTransition(const TransitionOptions&);
     TransitionOptions getRasterContrastTransition() const;
+
+    static PropertyValue<float> getDefaultRasterFadeDuration();
+    const PropertyValue<float>& getRasterFadeDuration() const;
+    void setRasterFadeDuration(const PropertyValue<float>&);
+    void setRasterFadeDurationTransition(const TransitionOptions&);
+    TransitionOptions getRasterFadeDurationTransition() const;
+
+    static PropertyValue<float> getDefaultRasterHueRotate();
+    const PropertyValue<float>& getRasterHueRotate() const;
+    void setRasterHueRotate(const PropertyValue<float>&);
+    void setRasterHueRotateTransition(const TransitionOptions&);
+    TransitionOptions getRasterHueRotateTransition() const;
+
+    static PropertyValue<float> getDefaultRasterOpacity();
+    const PropertyValue<float>& getRasterOpacity() const;
+    void setRasterOpacity(const PropertyValue<float>&);
+    void setRasterOpacityTransition(const TransitionOptions&);
+    TransitionOptions getRasterOpacityTransition() const;
 
     static PropertyValue<RasterResamplingType> getDefaultRasterResampling();
     const PropertyValue<RasterResamplingType>& getRasterResampling() const;
@@ -66,11 +66,11 @@ public:
     void setRasterResamplingTransition(const TransitionOptions&);
     TransitionOptions getRasterResamplingTransition() const;
 
-    static PropertyValue<float> getDefaultRasterFadeDuration();
-    const PropertyValue<float>& getRasterFadeDuration() const;
-    void setRasterFadeDuration(const PropertyValue<float>&);
-    void setRasterFadeDurationTransition(const TransitionOptions&);
-    TransitionOptions getRasterFadeDurationTransition() const;
+    static PropertyValue<float> getDefaultRasterSaturation();
+    const PropertyValue<float>& getRasterSaturation() const;
+    void setRasterSaturation(const PropertyValue<float>&);
+    void setRasterSaturationTransition(const TransitionOptions&);
+    TransitionOptions getRasterSaturationTransition() const;
 
     // Private implementation
 

--- a/include/mbgl/style/layers/symbol_layer.hpp
+++ b/include/mbgl/style/layers/symbol_layer.hpp
@@ -26,37 +26,45 @@ public:
 
     // Layout properties
 
-    static PropertyValue<SymbolPlacementType> getDefaultSymbolPlacement();
-    const PropertyValue<SymbolPlacementType>& getSymbolPlacement() const;
-    void setSymbolPlacement(const PropertyValue<SymbolPlacementType>&);
-
-    static PropertyValue<float> getDefaultSymbolSpacing();
-    const PropertyValue<float>& getSymbolSpacing() const;
-    void setSymbolSpacing(const PropertyValue<float>&);
-
-    static PropertyValue<bool> getDefaultSymbolAvoidEdges();
-    const PropertyValue<bool>& getSymbolAvoidEdges() const;
-    void setSymbolAvoidEdges(const PropertyValue<bool>&);
-
-    static PropertyValue<float> getDefaultSymbolSortKey();
-    const PropertyValue<float>& getSymbolSortKey() const;
-    void setSymbolSortKey(const PropertyValue<float>&);
-
-    static PropertyValue<SymbolZOrderType> getDefaultSymbolZOrder();
-    const PropertyValue<SymbolZOrderType>& getSymbolZOrder() const;
-    void setSymbolZOrder(const PropertyValue<SymbolZOrderType>&);
-
     static PropertyValue<bool> getDefaultIconAllowOverlap();
     const PropertyValue<bool>& getIconAllowOverlap() const;
     void setIconAllowOverlap(const PropertyValue<bool>&);
+
+    static PropertyValue<SymbolAnchorType> getDefaultIconAnchor();
+    const PropertyValue<SymbolAnchorType>& getIconAnchor() const;
+    void setIconAnchor(const PropertyValue<SymbolAnchorType>&);
 
     static PropertyValue<bool> getDefaultIconIgnorePlacement();
     const PropertyValue<bool>& getIconIgnorePlacement() const;
     void setIconIgnorePlacement(const PropertyValue<bool>&);
 
+    static PropertyValue<std::string> getDefaultIconImage();
+    const PropertyValue<std::string>& getIconImage() const;
+    void setIconImage(const PropertyValue<std::string>&);
+
+    static PropertyValue<bool> getDefaultIconKeepUpright();
+    const PropertyValue<bool>& getIconKeepUpright() const;
+    void setIconKeepUpright(const PropertyValue<bool>&);
+
+    static PropertyValue<std::array<float, 2>> getDefaultIconOffset();
+    const PropertyValue<std::array<float, 2>>& getIconOffset() const;
+    void setIconOffset(const PropertyValue<std::array<float, 2>>&);
+
     static PropertyValue<bool> getDefaultIconOptional();
     const PropertyValue<bool>& getIconOptional() const;
     void setIconOptional(const PropertyValue<bool>&);
+
+    static PropertyValue<float> getDefaultIconPadding();
+    const PropertyValue<float>& getIconPadding() const;
+    void setIconPadding(const PropertyValue<float>&);
+
+    static PropertyValue<AlignmentType> getDefaultIconPitchAlignment();
+    const PropertyValue<AlignmentType>& getIconPitchAlignment() const;
+    void setIconPitchAlignment(const PropertyValue<AlignmentType>&);
+
+    static PropertyValue<float> getDefaultIconRotate();
+    const PropertyValue<float>& getIconRotate() const;
+    void setIconRotate(const PropertyValue<float>&);
 
     static PropertyValue<AlignmentType> getDefaultIconRotationAlignment();
     const PropertyValue<AlignmentType>& getIconRotationAlignment() const;
@@ -74,41 +82,33 @@ public:
     const PropertyValue<std::array<float, 4>>& getIconTextFitPadding() const;
     void setIconTextFitPadding(const PropertyValue<std::array<float, 4>>&);
 
-    static PropertyValue<std::string> getDefaultIconImage();
-    const PropertyValue<std::string>& getIconImage() const;
-    void setIconImage(const PropertyValue<std::string>&);
+    static PropertyValue<bool> getDefaultSymbolAvoidEdges();
+    const PropertyValue<bool>& getSymbolAvoidEdges() const;
+    void setSymbolAvoidEdges(const PropertyValue<bool>&);
 
-    static PropertyValue<float> getDefaultIconRotate();
-    const PropertyValue<float>& getIconRotate() const;
-    void setIconRotate(const PropertyValue<float>&);
+    static PropertyValue<SymbolPlacementType> getDefaultSymbolPlacement();
+    const PropertyValue<SymbolPlacementType>& getSymbolPlacement() const;
+    void setSymbolPlacement(const PropertyValue<SymbolPlacementType>&);
 
-    static PropertyValue<float> getDefaultIconPadding();
-    const PropertyValue<float>& getIconPadding() const;
-    void setIconPadding(const PropertyValue<float>&);
+    static PropertyValue<float> getDefaultSymbolSortKey();
+    const PropertyValue<float>& getSymbolSortKey() const;
+    void setSymbolSortKey(const PropertyValue<float>&);
 
-    static PropertyValue<bool> getDefaultIconKeepUpright();
-    const PropertyValue<bool>& getIconKeepUpright() const;
-    void setIconKeepUpright(const PropertyValue<bool>&);
+    static PropertyValue<float> getDefaultSymbolSpacing();
+    const PropertyValue<float>& getSymbolSpacing() const;
+    void setSymbolSpacing(const PropertyValue<float>&);
 
-    static PropertyValue<std::array<float, 2>> getDefaultIconOffset();
-    const PropertyValue<std::array<float, 2>>& getIconOffset() const;
-    void setIconOffset(const PropertyValue<std::array<float, 2>>&);
+    static PropertyValue<SymbolZOrderType> getDefaultSymbolZOrder();
+    const PropertyValue<SymbolZOrderType>& getSymbolZOrder() const;
+    void setSymbolZOrder(const PropertyValue<SymbolZOrderType>&);
 
-    static PropertyValue<SymbolAnchorType> getDefaultIconAnchor();
-    const PropertyValue<SymbolAnchorType>& getIconAnchor() const;
-    void setIconAnchor(const PropertyValue<SymbolAnchorType>&);
+    static PropertyValue<bool> getDefaultTextAllowOverlap();
+    const PropertyValue<bool>& getTextAllowOverlap() const;
+    void setTextAllowOverlap(const PropertyValue<bool>&);
 
-    static PropertyValue<AlignmentType> getDefaultIconPitchAlignment();
-    const PropertyValue<AlignmentType>& getIconPitchAlignment() const;
-    void setIconPitchAlignment(const PropertyValue<AlignmentType>&);
-
-    static PropertyValue<AlignmentType> getDefaultTextPitchAlignment();
-    const PropertyValue<AlignmentType>& getTextPitchAlignment() const;
-    void setTextPitchAlignment(const PropertyValue<AlignmentType>&);
-
-    static PropertyValue<AlignmentType> getDefaultTextRotationAlignment();
-    const PropertyValue<AlignmentType>& getTextRotationAlignment() const;
-    void setTextRotationAlignment(const PropertyValue<AlignmentType>&);
+    static PropertyValue<SymbolAnchorType> getDefaultTextAnchor();
+    const PropertyValue<SymbolAnchorType>& getTextAnchor() const;
+    void setTextAnchor(const PropertyValue<SymbolAnchorType>&);
 
     static PropertyValue<expression::Formatted> getDefaultTextField();
     const PropertyValue<expression::Formatted>& getTextField() const;
@@ -118,87 +118,87 @@ public:
     const PropertyValue<std::vector<std::string>>& getTextFont() const;
     void setTextFont(const PropertyValue<std::vector<std::string>>&);
 
-    static PropertyValue<float> getDefaultTextSize();
-    const PropertyValue<float>& getTextSize() const;
-    void setTextSize(const PropertyValue<float>&);
-
-    static PropertyValue<float> getDefaultTextMaxWidth();
-    const PropertyValue<float>& getTextMaxWidth() const;
-    void setTextMaxWidth(const PropertyValue<float>&);
-
-    static PropertyValue<float> getDefaultTextLineHeight();
-    const PropertyValue<float>& getTextLineHeight() const;
-    void setTextLineHeight(const PropertyValue<float>&);
-
-    static PropertyValue<float> getDefaultTextLetterSpacing();
-    const PropertyValue<float>& getTextLetterSpacing() const;
-    void setTextLetterSpacing(const PropertyValue<float>&);
+    static PropertyValue<bool> getDefaultTextIgnorePlacement();
+    const PropertyValue<bool>& getTextIgnorePlacement() const;
+    void setTextIgnorePlacement(const PropertyValue<bool>&);
 
     static PropertyValue<TextJustifyType> getDefaultTextJustify();
     const PropertyValue<TextJustifyType>& getTextJustify() const;
     void setTextJustify(const PropertyValue<TextJustifyType>&);
 
-    static PropertyValue<float> getDefaultTextRadialOffset();
-    const PropertyValue<float>& getTextRadialOffset() const;
-    void setTextRadialOffset(const PropertyValue<float>&);
+    static PropertyValue<bool> getDefaultTextKeepUpright();
+    const PropertyValue<bool>& getTextKeepUpright() const;
+    void setTextKeepUpright(const PropertyValue<bool>&);
 
-    static PropertyValue<std::vector<TextVariableAnchorType>> getDefaultTextVariableAnchor();
-    const PropertyValue<std::vector<TextVariableAnchorType>>& getTextVariableAnchor() const;
-    void setTextVariableAnchor(const PropertyValue<std::vector<TextVariableAnchorType>>&);
+    static PropertyValue<float> getDefaultTextLetterSpacing();
+    const PropertyValue<float>& getTextLetterSpacing() const;
+    void setTextLetterSpacing(const PropertyValue<float>&);
 
-    static PropertyValue<SymbolAnchorType> getDefaultTextAnchor();
-    const PropertyValue<SymbolAnchorType>& getTextAnchor() const;
-    void setTextAnchor(const PropertyValue<SymbolAnchorType>&);
+    static PropertyValue<float> getDefaultTextLineHeight();
+    const PropertyValue<float>& getTextLineHeight() const;
+    void setTextLineHeight(const PropertyValue<float>&);
 
     static PropertyValue<float> getDefaultTextMaxAngle();
     const PropertyValue<float>& getTextMaxAngle() const;
     void setTextMaxAngle(const PropertyValue<float>&);
 
-    static PropertyValue<float> getDefaultTextRotate();
-    const PropertyValue<float>& getTextRotate() const;
-    void setTextRotate(const PropertyValue<float>&);
-
-    static PropertyValue<float> getDefaultTextPadding();
-    const PropertyValue<float>& getTextPadding() const;
-    void setTextPadding(const PropertyValue<float>&);
-
-    static PropertyValue<bool> getDefaultTextKeepUpright();
-    const PropertyValue<bool>& getTextKeepUpright() const;
-    void setTextKeepUpright(const PropertyValue<bool>&);
-
-    static PropertyValue<TextTransformType> getDefaultTextTransform();
-    const PropertyValue<TextTransformType>& getTextTransform() const;
-    void setTextTransform(const PropertyValue<TextTransformType>&);
+    static PropertyValue<float> getDefaultTextMaxWidth();
+    const PropertyValue<float>& getTextMaxWidth() const;
+    void setTextMaxWidth(const PropertyValue<float>&);
 
     static PropertyValue<std::array<float, 2>> getDefaultTextOffset();
     const PropertyValue<std::array<float, 2>>& getTextOffset() const;
     void setTextOffset(const PropertyValue<std::array<float, 2>>&);
 
-    static PropertyValue<bool> getDefaultTextAllowOverlap();
-    const PropertyValue<bool>& getTextAllowOverlap() const;
-    void setTextAllowOverlap(const PropertyValue<bool>&);
-
-    static PropertyValue<bool> getDefaultTextIgnorePlacement();
-    const PropertyValue<bool>& getTextIgnorePlacement() const;
-    void setTextIgnorePlacement(const PropertyValue<bool>&);
-
     static PropertyValue<bool> getDefaultTextOptional();
     const PropertyValue<bool>& getTextOptional() const;
     void setTextOptional(const PropertyValue<bool>&);
 
-    // Paint properties
+    static PropertyValue<float> getDefaultTextPadding();
+    const PropertyValue<float>& getTextPadding() const;
+    void setTextPadding(const PropertyValue<float>&);
 
-    static PropertyValue<float> getDefaultIconOpacity();
-    const PropertyValue<float>& getIconOpacity() const;
-    void setIconOpacity(const PropertyValue<float>&);
-    void setIconOpacityTransition(const TransitionOptions&);
-    TransitionOptions getIconOpacityTransition() const;
+    static PropertyValue<AlignmentType> getDefaultTextPitchAlignment();
+    const PropertyValue<AlignmentType>& getTextPitchAlignment() const;
+    void setTextPitchAlignment(const PropertyValue<AlignmentType>&);
+
+    static PropertyValue<float> getDefaultTextRadialOffset();
+    const PropertyValue<float>& getTextRadialOffset() const;
+    void setTextRadialOffset(const PropertyValue<float>&);
+
+    static PropertyValue<float> getDefaultTextRotate();
+    const PropertyValue<float>& getTextRotate() const;
+    void setTextRotate(const PropertyValue<float>&);
+
+    static PropertyValue<AlignmentType> getDefaultTextRotationAlignment();
+    const PropertyValue<AlignmentType>& getTextRotationAlignment() const;
+    void setTextRotationAlignment(const PropertyValue<AlignmentType>&);
+
+    static PropertyValue<float> getDefaultTextSize();
+    const PropertyValue<float>& getTextSize() const;
+    void setTextSize(const PropertyValue<float>&);
+
+    static PropertyValue<TextTransformType> getDefaultTextTransform();
+    const PropertyValue<TextTransformType>& getTextTransform() const;
+    void setTextTransform(const PropertyValue<TextTransformType>&);
+
+    static PropertyValue<std::vector<TextVariableAnchorType>> getDefaultTextVariableAnchor();
+    const PropertyValue<std::vector<TextVariableAnchorType>>& getTextVariableAnchor() const;
+    void setTextVariableAnchor(const PropertyValue<std::vector<TextVariableAnchorType>>&);
+
+    // Paint properties
 
     static PropertyValue<Color> getDefaultIconColor();
     const PropertyValue<Color>& getIconColor() const;
     void setIconColor(const PropertyValue<Color>&);
     void setIconColorTransition(const TransitionOptions&);
     TransitionOptions getIconColorTransition() const;
+
+    static PropertyValue<float> getDefaultIconHaloBlur();
+    const PropertyValue<float>& getIconHaloBlur() const;
+    void setIconHaloBlur(const PropertyValue<float>&);
+    void setIconHaloBlurTransition(const TransitionOptions&);
+    TransitionOptions getIconHaloBlurTransition() const;
 
     static PropertyValue<Color> getDefaultIconHaloColor();
     const PropertyValue<Color>& getIconHaloColor() const;
@@ -212,11 +212,11 @@ public:
     void setIconHaloWidthTransition(const TransitionOptions&);
     TransitionOptions getIconHaloWidthTransition() const;
 
-    static PropertyValue<float> getDefaultIconHaloBlur();
-    const PropertyValue<float>& getIconHaloBlur() const;
-    void setIconHaloBlur(const PropertyValue<float>&);
-    void setIconHaloBlurTransition(const TransitionOptions&);
-    TransitionOptions getIconHaloBlurTransition() const;
+    static PropertyValue<float> getDefaultIconOpacity();
+    const PropertyValue<float>& getIconOpacity() const;
+    void setIconOpacity(const PropertyValue<float>&);
+    void setIconOpacityTransition(const TransitionOptions&);
+    TransitionOptions getIconOpacityTransition() const;
 
     static PropertyValue<std::array<float, 2>> getDefaultIconTranslate();
     const PropertyValue<std::array<float, 2>>& getIconTranslate() const;
@@ -230,17 +230,17 @@ public:
     void setIconTranslateAnchorTransition(const TransitionOptions&);
     TransitionOptions getIconTranslateAnchorTransition() const;
 
-    static PropertyValue<float> getDefaultTextOpacity();
-    const PropertyValue<float>& getTextOpacity() const;
-    void setTextOpacity(const PropertyValue<float>&);
-    void setTextOpacityTransition(const TransitionOptions&);
-    TransitionOptions getTextOpacityTransition() const;
-
     static PropertyValue<Color> getDefaultTextColor();
     const PropertyValue<Color>& getTextColor() const;
     void setTextColor(const PropertyValue<Color>&);
     void setTextColorTransition(const TransitionOptions&);
     TransitionOptions getTextColorTransition() const;
+
+    static PropertyValue<float> getDefaultTextHaloBlur();
+    const PropertyValue<float>& getTextHaloBlur() const;
+    void setTextHaloBlur(const PropertyValue<float>&);
+    void setTextHaloBlurTransition(const TransitionOptions&);
+    TransitionOptions getTextHaloBlurTransition() const;
 
     static PropertyValue<Color> getDefaultTextHaloColor();
     const PropertyValue<Color>& getTextHaloColor() const;
@@ -254,11 +254,11 @@ public:
     void setTextHaloWidthTransition(const TransitionOptions&);
     TransitionOptions getTextHaloWidthTransition() const;
 
-    static PropertyValue<float> getDefaultTextHaloBlur();
-    const PropertyValue<float>& getTextHaloBlur() const;
-    void setTextHaloBlur(const PropertyValue<float>&);
-    void setTextHaloBlurTransition(const TransitionOptions&);
-    TransitionOptions getTextHaloBlurTransition() const;
+    static PropertyValue<float> getDefaultTextOpacity();
+    const PropertyValue<float>& getTextOpacity() const;
+    void setTextOpacity(const PropertyValue<float>&);
+    void setTextOpacityTransition(const TransitionOptions&);
+    TransitionOptions getTextOpacityTransition() const;
 
     static PropertyValue<std::array<float, 2>> getDefaultTextTranslate();
     const PropertyValue<std::array<float, 2>>& getTextTranslate() const;

--- a/include/mbgl/style/light.hpp
+++ b/include/mbgl/style/light.hpp
@@ -23,12 +23,6 @@ public:
     void setAnchorTransition(const TransitionOptions&);
     TransitionOptions getAnchorTransition() const;
 
-    static Position getDefaultPosition();
-    PropertyValue<Position> getPosition() const;
-    void setPosition(PropertyValue<Position>);
-    void setPositionTransition(const TransitionOptions&);
-    TransitionOptions getPositionTransition() const;
-
     static Color getDefaultColor();
     PropertyValue<Color> getColor() const;
     void setColor(PropertyValue<Color>);
@@ -40,6 +34,12 @@ public:
     void setIntensity(PropertyValue<float>);
     void setIntensityTransition(const TransitionOptions&);
     TransitionOptions getIntensityTransition() const;
+
+    static Position getDefaultPosition();
+    PropertyValue<Position> getPosition() const;
+    void setPosition(PropertyValue<Position>);
+    void setPositionTransition(const TransitionOptions&);
+    TransitionOptions getPositionTransition() const;
 
     class Impl;
     Immutable<Impl> impl;

--- a/scripts/generate-style-code.js
+++ b/scripts/generate-style-code.js
@@ -197,6 +197,8 @@ const layerCpp = ejs.compile(fs.readFileSync('src/mbgl/style/layers/layer.cpp.ej
 const propertiesHpp = ejs.compile(fs.readFileSync('src/mbgl/style/layers/layer_properties.hpp.ejs', 'utf8'), {strict: true});
 const propertiesCpp = ejs.compile(fs.readFileSync('src/mbgl/style/layers/layer_properties.cpp.ejs', 'utf8'), {strict: true});
 
+const collator = new Intl.Collator("en-US");
+
 // Add this mock property that our SDF line shader needs so that it gets added to the list of
 // "data driven" properties.
 spec.paint_line['line-floor-width'] = {
@@ -214,11 +216,19 @@ const layers = Object.keys(spec.layer.type.values).map((type) => {
     return memo;
   }, []);
 
+  // JSON doesn't have a defined order. We're going to sort them alphabetically
+  // to get a deterministic order.
+  layoutProperties.sort((a, b) => collator.compare(a.name, b.name));
+
   const paintProperties = Object.keys(spec[`paint_${type}`]).reduce((memo, name) => {
     spec[`paint_${type}`][name].name = name;
     memo.push(spec[`paint_${type}`][name]);
     return memo;
   }, []);
+
+  // JSON doesn't have a defined order. We're going to sort them alphabetically
+  // to get a deterministic order.
+  paintProperties.sort((a, b) => collator.compare(a.name, b.name));
 
   return {
     type: type,
@@ -253,6 +263,10 @@ const lightProperties = Object.keys(spec[`light`]).reduce((memo, name) => {
   memo.push(property);
   return memo;
 }, []);
+
+// JSON doesn't have a defined order. We're going to sort them alphabetically
+// to get a deterministic order.
+lightProperties.sort((a, b) => collator.compare(a.name, b.name));
 
 const lightHpp = ejs.compile(fs.readFileSync('include/mbgl/style/light.hpp.ejs', 'utf8'), {strict: true});
 const lightCpp = ejs.compile(fs.readFileSync('src/mbgl/style/light.cpp.ejs', 'utf8'), {strict: true});

--- a/src/mbgl/style/layers/background_layer.cpp
+++ b/src/mbgl/style/layers/background_layer.cpp
@@ -90,33 +90,6 @@ TransitionOptions BackgroundLayer::getBackgroundColorTransition() const {
     return impl().paint.template get<BackgroundColor>().options;
 }
 
-PropertyValue<std::string> BackgroundLayer::getDefaultBackgroundPattern() {
-    return { "" };
-}
-
-const PropertyValue<std::string>& BackgroundLayer::getBackgroundPattern() const {
-    return impl().paint.template get<BackgroundPattern>().value;
-}
-
-void BackgroundLayer::setBackgroundPattern(const PropertyValue<std::string>& value) {
-    if (value == getBackgroundPattern())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<BackgroundPattern>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void BackgroundLayer::setBackgroundPatternTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<BackgroundPattern>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions BackgroundLayer::getBackgroundPatternTransition() const {
-    return impl().paint.template get<BackgroundPattern>().options;
-}
-
 PropertyValue<float> BackgroundLayer::getDefaultBackgroundOpacity() {
     return { 1 };
 }
@@ -144,25 +117,52 @@ TransitionOptions BackgroundLayer::getBackgroundOpacityTransition() const {
     return impl().paint.template get<BackgroundOpacity>().options;
 }
 
+PropertyValue<std::string> BackgroundLayer::getDefaultBackgroundPattern() {
+    return { "" };
+}
+
+const PropertyValue<std::string>& BackgroundLayer::getBackgroundPattern() const {
+    return impl().paint.template get<BackgroundPattern>().value;
+}
+
+void BackgroundLayer::setBackgroundPattern(const PropertyValue<std::string>& value) {
+    if (value == getBackgroundPattern())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<BackgroundPattern>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void BackgroundLayer::setBackgroundPatternTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<BackgroundPattern>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions BackgroundLayer::getBackgroundPatternTransition() const {
+    return impl().paint.template get<BackgroundPattern>().options;
+}
+
 using namespace conversion;
 
 optional<Error> BackgroundLayer::setPaintProperty(const std::string& name, const Convertible& value) {
     enum class Property : uint8_t {
         BackgroundColor,
-        BackgroundPattern,
         BackgroundOpacity,
+        BackgroundPattern,
         BackgroundColorTransition,
-        BackgroundPatternTransition,
         BackgroundOpacityTransition,
+        BackgroundPatternTransition,
     };
 
     MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
         { "background-color", static_cast<uint8_t>(Property::BackgroundColor) },
-        { "background-pattern", static_cast<uint8_t>(Property::BackgroundPattern) },
         { "background-opacity", static_cast<uint8_t>(Property::BackgroundOpacity) },
+        { "background-pattern", static_cast<uint8_t>(Property::BackgroundPattern) },
         { "background-color-transition", static_cast<uint8_t>(Property::BackgroundColorTransition) },
-        { "background-pattern-transition", static_cast<uint8_t>(Property::BackgroundPatternTransition) },
-        { "background-opacity-transition", static_cast<uint8_t>(Property::BackgroundOpacityTransition) }
+        { "background-opacity-transition", static_cast<uint8_t>(Property::BackgroundOpacityTransition) },
+        { "background-pattern-transition", static_cast<uint8_t>(Property::BackgroundPatternTransition) }
     });
 
     const auto it = properties.find(name.c_str());
@@ -185,18 +185,6 @@ optional<Error> BackgroundLayer::setPaintProperty(const std::string& name, const
         
     }
     
-    if (property == Property::BackgroundPattern) {
-        Error error;
-        optional<PropertyValue<std::string>> typedValue = convert<PropertyValue<std::string>>(value, error, false, false);
-        if (!typedValue) {
-            return error;
-        }
-        
-        setBackgroundPattern(*typedValue);
-        return nullopt;
-        
-    }
-    
     if (property == Property::BackgroundOpacity) {
         Error error;
         optional<PropertyValue<float>> typedValue = convert<PropertyValue<float>>(value, error, false, false);
@@ -205,6 +193,18 @@ optional<Error> BackgroundLayer::setPaintProperty(const std::string& name, const
         }
         
         setBackgroundOpacity(*typedValue);
+        return nullopt;
+        
+    }
+    
+    if (property == Property::BackgroundPattern) {
+        Error error;
+        optional<PropertyValue<std::string>> typedValue = convert<PropertyValue<std::string>>(value, error, false, false);
+        if (!typedValue) {
+            return error;
+        }
+        
+        setBackgroundPattern(*typedValue);
         return nullopt;
         
     }
@@ -221,13 +221,13 @@ optional<Error> BackgroundLayer::setPaintProperty(const std::string& name, const
         return nullopt;
     }
     
-    if (property == Property::BackgroundPatternTransition) {
-        setBackgroundPatternTransition(*transition);
+    if (property == Property::BackgroundOpacityTransition) {
+        setBackgroundOpacityTransition(*transition);
         return nullopt;
     }
     
-    if (property == Property::BackgroundOpacityTransition) {
-        setBackgroundOpacityTransition(*transition);
+    if (property == Property::BackgroundPatternTransition) {
+        setBackgroundPatternTransition(*transition);
         return nullopt;
     }
     

--- a/src/mbgl/style/layers/background_layer_properties.hpp
+++ b/src/mbgl/style/layers/background_layer_properties.hpp
@@ -18,18 +18,18 @@ struct BackgroundColor : PaintProperty<Color> {
     static Color defaultValue() { return Color::black(); }
 };
 
-struct BackgroundPattern : CrossFadedPaintProperty<std::string> {
-    static std::string defaultValue() { return ""; }
-};
-
 struct BackgroundOpacity : PaintProperty<float> {
     static float defaultValue() { return 1; }
 };
 
+struct BackgroundPattern : CrossFadedPaintProperty<std::string> {
+    static std::string defaultValue() { return ""; }
+};
+
 class BackgroundPaintProperties : public Properties<
     BackgroundColor,
-    BackgroundPattern,
-    BackgroundOpacity
+    BackgroundOpacity,
+    BackgroundPattern
 > {};
 
 class BackgroundLayerProperties final : public LayerProperties {

--- a/src/mbgl/style/layers/circle_layer.cpp
+++ b/src/mbgl/style/layers/circle_layer.cpp
@@ -63,31 +63,31 @@ void CircleLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffe
 
 // Paint properties
 
-PropertyValue<float> CircleLayer::getDefaultCircleRadius() {
-    return { 5 };
+PropertyValue<float> CircleLayer::getDefaultCircleBlur() {
+    return { 0 };
 }
 
-const PropertyValue<float>& CircleLayer::getCircleRadius() const {
-    return impl().paint.template get<CircleRadius>().value;
+const PropertyValue<float>& CircleLayer::getCircleBlur() const {
+    return impl().paint.template get<CircleBlur>().value;
 }
 
-void CircleLayer::setCircleRadius(const PropertyValue<float>& value) {
-    if (value == getCircleRadius())
+void CircleLayer::setCircleBlur(const PropertyValue<float>& value) {
+    if (value == getCircleBlur())
         return;
     auto impl_ = mutableImpl();
-    impl_->paint.template get<CircleRadius>().value = value;
+    impl_->paint.template get<CircleBlur>().value = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
 
-void CircleLayer::setCircleRadiusTransition(const TransitionOptions& options) {
+void CircleLayer::setCircleBlurTransition(const TransitionOptions& options) {
     auto impl_ = mutableImpl();
-    impl_->paint.template get<CircleRadius>().options = options;
+    impl_->paint.template get<CircleBlur>().options = options;
     baseImpl = std::move(impl_);
 }
 
-TransitionOptions CircleLayer::getCircleRadiusTransition() const {
-    return impl().paint.template get<CircleRadius>().options;
+TransitionOptions CircleLayer::getCircleBlurTransition() const {
+    return impl().paint.template get<CircleBlur>().options;
 }
 
 PropertyValue<Color> CircleLayer::getDefaultCircleColor() {
@@ -117,33 +117,6 @@ TransitionOptions CircleLayer::getCircleColorTransition() const {
     return impl().paint.template get<CircleColor>().options;
 }
 
-PropertyValue<float> CircleLayer::getDefaultCircleBlur() {
-    return { 0 };
-}
-
-const PropertyValue<float>& CircleLayer::getCircleBlur() const {
-    return impl().paint.template get<CircleBlur>().value;
-}
-
-void CircleLayer::setCircleBlur(const PropertyValue<float>& value) {
-    if (value == getCircleBlur())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<CircleBlur>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void CircleLayer::setCircleBlurTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<CircleBlur>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions CircleLayer::getCircleBlurTransition() const {
-    return impl().paint.template get<CircleBlur>().options;
-}
-
 PropertyValue<float> CircleLayer::getDefaultCircleOpacity() {
     return { 1 };
 }
@@ -169,87 +142,6 @@ void CircleLayer::setCircleOpacityTransition(const TransitionOptions& options) {
 
 TransitionOptions CircleLayer::getCircleOpacityTransition() const {
     return impl().paint.template get<CircleOpacity>().options;
-}
-
-PropertyValue<std::array<float, 2>> CircleLayer::getDefaultCircleTranslate() {
-    return { {{ 0, 0 }} };
-}
-
-const PropertyValue<std::array<float, 2>>& CircleLayer::getCircleTranslate() const {
-    return impl().paint.template get<CircleTranslate>().value;
-}
-
-void CircleLayer::setCircleTranslate(const PropertyValue<std::array<float, 2>>& value) {
-    if (value == getCircleTranslate())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<CircleTranslate>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void CircleLayer::setCircleTranslateTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<CircleTranslate>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions CircleLayer::getCircleTranslateTransition() const {
-    return impl().paint.template get<CircleTranslate>().options;
-}
-
-PropertyValue<TranslateAnchorType> CircleLayer::getDefaultCircleTranslateAnchor() {
-    return { TranslateAnchorType::Map };
-}
-
-const PropertyValue<TranslateAnchorType>& CircleLayer::getCircleTranslateAnchor() const {
-    return impl().paint.template get<CircleTranslateAnchor>().value;
-}
-
-void CircleLayer::setCircleTranslateAnchor(const PropertyValue<TranslateAnchorType>& value) {
-    if (value == getCircleTranslateAnchor())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<CircleTranslateAnchor>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void CircleLayer::setCircleTranslateAnchorTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<CircleTranslateAnchor>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions CircleLayer::getCircleTranslateAnchorTransition() const {
-    return impl().paint.template get<CircleTranslateAnchor>().options;
-}
-
-PropertyValue<CirclePitchScaleType> CircleLayer::getDefaultCirclePitchScale() {
-    return { CirclePitchScaleType::Map };
-}
-
-const PropertyValue<CirclePitchScaleType>& CircleLayer::getCirclePitchScale() const {
-    return impl().paint.template get<CirclePitchScale>().value;
-}
-
-void CircleLayer::setCirclePitchScale(const PropertyValue<CirclePitchScaleType>& value) {
-    if (value == getCirclePitchScale())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<CirclePitchScale>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void CircleLayer::setCirclePitchScaleTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<CirclePitchScale>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions CircleLayer::getCirclePitchScaleTransition() const {
-    return impl().paint.template get<CirclePitchScale>().options;
 }
 
 PropertyValue<AlignmentType> CircleLayer::getDefaultCirclePitchAlignment() {
@@ -279,31 +171,58 @@ TransitionOptions CircleLayer::getCirclePitchAlignmentTransition() const {
     return impl().paint.template get<CirclePitchAlignment>().options;
 }
 
-PropertyValue<float> CircleLayer::getDefaultCircleStrokeWidth() {
-    return { 0 };
+PropertyValue<CirclePitchScaleType> CircleLayer::getDefaultCirclePitchScale() {
+    return { CirclePitchScaleType::Map };
 }
 
-const PropertyValue<float>& CircleLayer::getCircleStrokeWidth() const {
-    return impl().paint.template get<CircleStrokeWidth>().value;
+const PropertyValue<CirclePitchScaleType>& CircleLayer::getCirclePitchScale() const {
+    return impl().paint.template get<CirclePitchScale>().value;
 }
 
-void CircleLayer::setCircleStrokeWidth(const PropertyValue<float>& value) {
-    if (value == getCircleStrokeWidth())
+void CircleLayer::setCirclePitchScale(const PropertyValue<CirclePitchScaleType>& value) {
+    if (value == getCirclePitchScale())
         return;
     auto impl_ = mutableImpl();
-    impl_->paint.template get<CircleStrokeWidth>().value = value;
+    impl_->paint.template get<CirclePitchScale>().value = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
 
-void CircleLayer::setCircleStrokeWidthTransition(const TransitionOptions& options) {
+void CircleLayer::setCirclePitchScaleTransition(const TransitionOptions& options) {
     auto impl_ = mutableImpl();
-    impl_->paint.template get<CircleStrokeWidth>().options = options;
+    impl_->paint.template get<CirclePitchScale>().options = options;
     baseImpl = std::move(impl_);
 }
 
-TransitionOptions CircleLayer::getCircleStrokeWidthTransition() const {
-    return impl().paint.template get<CircleStrokeWidth>().options;
+TransitionOptions CircleLayer::getCirclePitchScaleTransition() const {
+    return impl().paint.template get<CirclePitchScale>().options;
+}
+
+PropertyValue<float> CircleLayer::getDefaultCircleRadius() {
+    return { 5 };
+}
+
+const PropertyValue<float>& CircleLayer::getCircleRadius() const {
+    return impl().paint.template get<CircleRadius>().value;
+}
+
+void CircleLayer::setCircleRadius(const PropertyValue<float>& value) {
+    if (value == getCircleRadius())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<CircleRadius>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void CircleLayer::setCircleRadiusTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<CircleRadius>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions CircleLayer::getCircleRadiusTransition() const {
+    return impl().paint.template get<CircleRadius>().options;
 }
 
 PropertyValue<Color> CircleLayer::getDefaultCircleStrokeColor() {
@@ -360,57 +279,138 @@ TransitionOptions CircleLayer::getCircleStrokeOpacityTransition() const {
     return impl().paint.template get<CircleStrokeOpacity>().options;
 }
 
+PropertyValue<float> CircleLayer::getDefaultCircleStrokeWidth() {
+    return { 0 };
+}
+
+const PropertyValue<float>& CircleLayer::getCircleStrokeWidth() const {
+    return impl().paint.template get<CircleStrokeWidth>().value;
+}
+
+void CircleLayer::setCircleStrokeWidth(const PropertyValue<float>& value) {
+    if (value == getCircleStrokeWidth())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<CircleStrokeWidth>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void CircleLayer::setCircleStrokeWidthTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<CircleStrokeWidth>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions CircleLayer::getCircleStrokeWidthTransition() const {
+    return impl().paint.template get<CircleStrokeWidth>().options;
+}
+
+PropertyValue<std::array<float, 2>> CircleLayer::getDefaultCircleTranslate() {
+    return { {{ 0, 0 }} };
+}
+
+const PropertyValue<std::array<float, 2>>& CircleLayer::getCircleTranslate() const {
+    return impl().paint.template get<CircleTranslate>().value;
+}
+
+void CircleLayer::setCircleTranslate(const PropertyValue<std::array<float, 2>>& value) {
+    if (value == getCircleTranslate())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<CircleTranslate>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void CircleLayer::setCircleTranslateTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<CircleTranslate>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions CircleLayer::getCircleTranslateTransition() const {
+    return impl().paint.template get<CircleTranslate>().options;
+}
+
+PropertyValue<TranslateAnchorType> CircleLayer::getDefaultCircleTranslateAnchor() {
+    return { TranslateAnchorType::Map };
+}
+
+const PropertyValue<TranslateAnchorType>& CircleLayer::getCircleTranslateAnchor() const {
+    return impl().paint.template get<CircleTranslateAnchor>().value;
+}
+
+void CircleLayer::setCircleTranslateAnchor(const PropertyValue<TranslateAnchorType>& value) {
+    if (value == getCircleTranslateAnchor())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<CircleTranslateAnchor>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void CircleLayer::setCircleTranslateAnchorTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<CircleTranslateAnchor>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions CircleLayer::getCircleTranslateAnchorTransition() const {
+    return impl().paint.template get<CircleTranslateAnchor>().options;
+}
+
 using namespace conversion;
 
 optional<Error> CircleLayer::setPaintProperty(const std::string& name, const Convertible& value) {
     enum class Property : uint8_t {
-        CircleRadius,
-        CircleColor,
         CircleBlur,
+        CircleColor,
         CircleOpacity,
-        CircleTranslate,
-        CircleTranslateAnchor,
-        CirclePitchScale,
         CirclePitchAlignment,
-        CircleStrokeWidth,
+        CirclePitchScale,
+        CircleRadius,
         CircleStrokeColor,
         CircleStrokeOpacity,
-        CircleRadiusTransition,
-        CircleColorTransition,
+        CircleStrokeWidth,
+        CircleTranslate,
+        CircleTranslateAnchor,
         CircleBlurTransition,
+        CircleColorTransition,
         CircleOpacityTransition,
-        CircleTranslateTransition,
-        CircleTranslateAnchorTransition,
-        CirclePitchScaleTransition,
         CirclePitchAlignmentTransition,
-        CircleStrokeWidthTransition,
+        CirclePitchScaleTransition,
+        CircleRadiusTransition,
         CircleStrokeColorTransition,
         CircleStrokeOpacityTransition,
+        CircleStrokeWidthTransition,
+        CircleTranslateTransition,
+        CircleTranslateAnchorTransition,
     };
 
     MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        { "circle-radius", static_cast<uint8_t>(Property::CircleRadius) },
-        { "circle-color", static_cast<uint8_t>(Property::CircleColor) },
         { "circle-blur", static_cast<uint8_t>(Property::CircleBlur) },
+        { "circle-color", static_cast<uint8_t>(Property::CircleColor) },
         { "circle-opacity", static_cast<uint8_t>(Property::CircleOpacity) },
-        { "circle-translate", static_cast<uint8_t>(Property::CircleTranslate) },
-        { "circle-translate-anchor", static_cast<uint8_t>(Property::CircleTranslateAnchor) },
-        { "circle-pitch-scale", static_cast<uint8_t>(Property::CirclePitchScale) },
         { "circle-pitch-alignment", static_cast<uint8_t>(Property::CirclePitchAlignment) },
-        { "circle-stroke-width", static_cast<uint8_t>(Property::CircleStrokeWidth) },
+        { "circle-pitch-scale", static_cast<uint8_t>(Property::CirclePitchScale) },
+        { "circle-radius", static_cast<uint8_t>(Property::CircleRadius) },
         { "circle-stroke-color", static_cast<uint8_t>(Property::CircleStrokeColor) },
         { "circle-stroke-opacity", static_cast<uint8_t>(Property::CircleStrokeOpacity) },
-        { "circle-radius-transition", static_cast<uint8_t>(Property::CircleRadiusTransition) },
-        { "circle-color-transition", static_cast<uint8_t>(Property::CircleColorTransition) },
+        { "circle-stroke-width", static_cast<uint8_t>(Property::CircleStrokeWidth) },
+        { "circle-translate", static_cast<uint8_t>(Property::CircleTranslate) },
+        { "circle-translate-anchor", static_cast<uint8_t>(Property::CircleTranslateAnchor) },
         { "circle-blur-transition", static_cast<uint8_t>(Property::CircleBlurTransition) },
+        { "circle-color-transition", static_cast<uint8_t>(Property::CircleColorTransition) },
         { "circle-opacity-transition", static_cast<uint8_t>(Property::CircleOpacityTransition) },
-        { "circle-translate-transition", static_cast<uint8_t>(Property::CircleTranslateTransition) },
-        { "circle-translate-anchor-transition", static_cast<uint8_t>(Property::CircleTranslateAnchorTransition) },
-        { "circle-pitch-scale-transition", static_cast<uint8_t>(Property::CirclePitchScaleTransition) },
         { "circle-pitch-alignment-transition", static_cast<uint8_t>(Property::CirclePitchAlignmentTransition) },
-        { "circle-stroke-width-transition", static_cast<uint8_t>(Property::CircleStrokeWidthTransition) },
+        { "circle-pitch-scale-transition", static_cast<uint8_t>(Property::CirclePitchScaleTransition) },
+        { "circle-radius-transition", static_cast<uint8_t>(Property::CircleRadiusTransition) },
         { "circle-stroke-color-transition", static_cast<uint8_t>(Property::CircleStrokeColorTransition) },
-        { "circle-stroke-opacity-transition", static_cast<uint8_t>(Property::CircleStrokeOpacityTransition) }
+        { "circle-stroke-opacity-transition", static_cast<uint8_t>(Property::CircleStrokeOpacityTransition) },
+        { "circle-stroke-width-transition", static_cast<uint8_t>(Property::CircleStrokeWidthTransition) },
+        { "circle-translate-transition", static_cast<uint8_t>(Property::CircleTranslateTransition) },
+        { "circle-translate-anchor-transition", static_cast<uint8_t>(Property::CircleTranslateAnchorTransition) }
     });
 
     const auto it = properties.find(name.c_str());
@@ -421,16 +421,11 @@ optional<Error> CircleLayer::setPaintProperty(const std::string& name, const Con
     auto property = static_cast<Property>(it->second);
 
         
-    if (property == Property::CircleRadius || property == Property::CircleBlur || property == Property::CircleOpacity || property == Property::CircleStrokeWidth || property == Property::CircleStrokeOpacity) {
+    if (property == Property::CircleBlur || property == Property::CircleOpacity || property == Property::CircleRadius || property == Property::CircleStrokeOpacity || property == Property::CircleStrokeWidth) {
         Error error;
         optional<PropertyValue<float>> typedValue = convert<PropertyValue<float>>(value, error, true, false);
         if (!typedValue) {
             return error;
-        }
-        
-        if (property == Property::CircleRadius) {
-            setCircleRadius(*typedValue);
-            return nullopt;
         }
         
         if (property == Property::CircleBlur) {
@@ -443,13 +438,18 @@ optional<Error> CircleLayer::setPaintProperty(const std::string& name, const Con
             return nullopt;
         }
         
-        if (property == Property::CircleStrokeWidth) {
-            setCircleStrokeWidth(*typedValue);
+        if (property == Property::CircleRadius) {
+            setCircleRadius(*typedValue);
             return nullopt;
         }
         
         if (property == Property::CircleStrokeOpacity) {
             setCircleStrokeOpacity(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::CircleStrokeWidth) {
+            setCircleStrokeWidth(*typedValue);
             return nullopt;
         }
         
@@ -471,6 +471,30 @@ optional<Error> CircleLayer::setPaintProperty(const std::string& name, const Con
             setCircleStrokeColor(*typedValue);
             return nullopt;
         }
+        
+    }
+    
+    if (property == Property::CirclePitchAlignment) {
+        Error error;
+        optional<PropertyValue<AlignmentType>> typedValue = convert<PropertyValue<AlignmentType>>(value, error, false, false);
+        if (!typedValue) {
+            return error;
+        }
+        
+        setCirclePitchAlignment(*typedValue);
+        return nullopt;
+        
+    }
+    
+    if (property == Property::CirclePitchScale) {
+        Error error;
+        optional<PropertyValue<CirclePitchScaleType>> typedValue = convert<PropertyValue<CirclePitchScaleType>>(value, error, false, false);
+        if (!typedValue) {
+            return error;
+        }
+        
+        setCirclePitchScale(*typedValue);
+        return nullopt;
         
     }
     
@@ -498,30 +522,6 @@ optional<Error> CircleLayer::setPaintProperty(const std::string& name, const Con
         
     }
     
-    if (property == Property::CirclePitchScale) {
-        Error error;
-        optional<PropertyValue<CirclePitchScaleType>> typedValue = convert<PropertyValue<CirclePitchScaleType>>(value, error, false, false);
-        if (!typedValue) {
-            return error;
-        }
-        
-        setCirclePitchScale(*typedValue);
-        return nullopt;
-        
-    }
-    
-    if (property == Property::CirclePitchAlignment) {
-        Error error;
-        optional<PropertyValue<AlignmentType>> typedValue = convert<PropertyValue<AlignmentType>>(value, error, false, false);
-        if (!typedValue) {
-            return error;
-        }
-        
-        setCirclePitchAlignment(*typedValue);
-        return nullopt;
-        
-    }
-    
 
     Error error;
     optional<TransitionOptions> transition = convert<TransitionOptions>(value, error);
@@ -529,8 +529,8 @@ optional<Error> CircleLayer::setPaintProperty(const std::string& name, const Con
         return error;
     }
     
-    if (property == Property::CircleRadiusTransition) {
-        setCircleRadiusTransition(*transition);
+    if (property == Property::CircleBlurTransition) {
+        setCircleBlurTransition(*transition);
         return nullopt;
     }
     
@@ -539,28 +539,8 @@ optional<Error> CircleLayer::setPaintProperty(const std::string& name, const Con
         return nullopt;
     }
     
-    if (property == Property::CircleBlurTransition) {
-        setCircleBlurTransition(*transition);
-        return nullopt;
-    }
-    
     if (property == Property::CircleOpacityTransition) {
         setCircleOpacityTransition(*transition);
-        return nullopt;
-    }
-    
-    if (property == Property::CircleTranslateTransition) {
-        setCircleTranslateTransition(*transition);
-        return nullopt;
-    }
-    
-    if (property == Property::CircleTranslateAnchorTransition) {
-        setCircleTranslateAnchorTransition(*transition);
-        return nullopt;
-    }
-    
-    if (property == Property::CirclePitchScaleTransition) {
-        setCirclePitchScaleTransition(*transition);
         return nullopt;
     }
     
@@ -569,8 +549,13 @@ optional<Error> CircleLayer::setPaintProperty(const std::string& name, const Con
         return nullopt;
     }
     
-    if (property == Property::CircleStrokeWidthTransition) {
-        setCircleStrokeWidthTransition(*transition);
+    if (property == Property::CirclePitchScaleTransition) {
+        setCirclePitchScaleTransition(*transition);
+        return nullopt;
+    }
+    
+    if (property == Property::CircleRadiusTransition) {
+        setCircleRadiusTransition(*transition);
         return nullopt;
     }
     
@@ -581,6 +566,21 @@ optional<Error> CircleLayer::setPaintProperty(const std::string& name, const Con
     
     if (property == Property::CircleStrokeOpacityTransition) {
         setCircleStrokeOpacityTransition(*transition);
+        return nullopt;
+    }
+    
+    if (property == Property::CircleStrokeWidthTransition) {
+        setCircleStrokeWidthTransition(*transition);
+        return nullopt;
+    }
+    
+    if (property == Property::CircleTranslateTransition) {
+        setCircleTranslateTransition(*transition);
+        return nullopt;
+    }
+    
+    if (property == Property::CircleTranslateAnchorTransition) {
+        setCircleTranslateAnchorTransition(*transition);
         return nullopt;
     }
     

--- a/src/mbgl/style/layers/circle_layer_properties.hpp
+++ b/src/mbgl/style/layers/circle_layer_properties.hpp
@@ -14,40 +14,28 @@
 namespace mbgl {
 namespace style {
 
-struct CircleRadius : DataDrivenPaintProperty<float, attributes::radius, uniforms::radius> {
-    static float defaultValue() { return 5; }
+struct CircleBlur : DataDrivenPaintProperty<float, attributes::blur, uniforms::blur> {
+    static float defaultValue() { return 0; }
 };
 
 struct CircleColor : DataDrivenPaintProperty<Color, attributes::color, uniforms::color> {
     static Color defaultValue() { return Color::black(); }
 };
 
-struct CircleBlur : DataDrivenPaintProperty<float, attributes::blur, uniforms::blur> {
-    static float defaultValue() { return 0; }
-};
-
 struct CircleOpacity : DataDrivenPaintProperty<float, attributes::opacity, uniforms::opacity> {
     static float defaultValue() { return 1; }
-};
-
-struct CircleTranslate : PaintProperty<std::array<float, 2>> {
-    static std::array<float, 2> defaultValue() { return {{ 0, 0 }}; }
-};
-
-struct CircleTranslateAnchor : PaintProperty<TranslateAnchorType> {
-    static TranslateAnchorType defaultValue() { return TranslateAnchorType::Map; }
-};
-
-struct CirclePitchScale : PaintProperty<CirclePitchScaleType> {
-    static CirclePitchScaleType defaultValue() { return CirclePitchScaleType::Map; }
 };
 
 struct CirclePitchAlignment : PaintProperty<AlignmentType> {
     static AlignmentType defaultValue() { return AlignmentType::Viewport; }
 };
 
-struct CircleStrokeWidth : DataDrivenPaintProperty<float, attributes::stroke_width, uniforms::stroke_width> {
-    static float defaultValue() { return 0; }
+struct CirclePitchScale : PaintProperty<CirclePitchScaleType> {
+    static CirclePitchScaleType defaultValue() { return CirclePitchScaleType::Map; }
+};
+
+struct CircleRadius : DataDrivenPaintProperty<float, attributes::radius, uniforms::radius> {
+    static float defaultValue() { return 5; }
 };
 
 struct CircleStrokeColor : DataDrivenPaintProperty<Color, attributes::stroke_color, uniforms::stroke_color> {
@@ -58,18 +46,30 @@ struct CircleStrokeOpacity : DataDrivenPaintProperty<float, attributes::stroke_o
     static float defaultValue() { return 1; }
 };
 
+struct CircleStrokeWidth : DataDrivenPaintProperty<float, attributes::stroke_width, uniforms::stroke_width> {
+    static float defaultValue() { return 0; }
+};
+
+struct CircleTranslate : PaintProperty<std::array<float, 2>> {
+    static std::array<float, 2> defaultValue() { return {{ 0, 0 }}; }
+};
+
+struct CircleTranslateAnchor : PaintProperty<TranslateAnchorType> {
+    static TranslateAnchorType defaultValue() { return TranslateAnchorType::Map; }
+};
+
 class CirclePaintProperties : public Properties<
-    CircleRadius,
-    CircleColor,
     CircleBlur,
+    CircleColor,
     CircleOpacity,
-    CircleTranslate,
-    CircleTranslateAnchor,
-    CirclePitchScale,
     CirclePitchAlignment,
-    CircleStrokeWidth,
+    CirclePitchScale,
+    CircleRadius,
     CircleStrokeColor,
-    CircleStrokeOpacity
+    CircleStrokeOpacity,
+    CircleStrokeWidth,
+    CircleTranslate,
+    CircleTranslateAnchor
 > {};
 
 class CircleLayerProperties final : public LayerProperties {

--- a/src/mbgl/style/layers/fill_extrusion_layer.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer.cpp
@@ -63,31 +63,31 @@ void FillExtrusionLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::Stri
 
 // Paint properties
 
-PropertyValue<float> FillExtrusionLayer::getDefaultFillExtrusionOpacity() {
-    return { 1 };
+PropertyValue<float> FillExtrusionLayer::getDefaultFillExtrusionBase() {
+    return { 0 };
 }
 
-const PropertyValue<float>& FillExtrusionLayer::getFillExtrusionOpacity() const {
-    return impl().paint.template get<FillExtrusionOpacity>().value;
+const PropertyValue<float>& FillExtrusionLayer::getFillExtrusionBase() const {
+    return impl().paint.template get<FillExtrusionBase>().value;
 }
 
-void FillExtrusionLayer::setFillExtrusionOpacity(const PropertyValue<float>& value) {
-    if (value == getFillExtrusionOpacity())
+void FillExtrusionLayer::setFillExtrusionBase(const PropertyValue<float>& value) {
+    if (value == getFillExtrusionBase())
         return;
     auto impl_ = mutableImpl();
-    impl_->paint.template get<FillExtrusionOpacity>().value = value;
+    impl_->paint.template get<FillExtrusionBase>().value = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
 
-void FillExtrusionLayer::setFillExtrusionOpacityTransition(const TransitionOptions& options) {
+void FillExtrusionLayer::setFillExtrusionBaseTransition(const TransitionOptions& options) {
     auto impl_ = mutableImpl();
-    impl_->paint.template get<FillExtrusionOpacity>().options = options;
+    impl_->paint.template get<FillExtrusionBase>().options = options;
     baseImpl = std::move(impl_);
 }
 
-TransitionOptions FillExtrusionLayer::getFillExtrusionOpacityTransition() const {
-    return impl().paint.template get<FillExtrusionOpacity>().options;
+TransitionOptions FillExtrusionLayer::getFillExtrusionBaseTransition() const {
+    return impl().paint.template get<FillExtrusionBase>().options;
 }
 
 PropertyValue<Color> FillExtrusionLayer::getDefaultFillExtrusionColor() {
@@ -115,6 +115,87 @@ void FillExtrusionLayer::setFillExtrusionColorTransition(const TransitionOptions
 
 TransitionOptions FillExtrusionLayer::getFillExtrusionColorTransition() const {
     return impl().paint.template get<FillExtrusionColor>().options;
+}
+
+PropertyValue<float> FillExtrusionLayer::getDefaultFillExtrusionHeight() {
+    return { 0 };
+}
+
+const PropertyValue<float>& FillExtrusionLayer::getFillExtrusionHeight() const {
+    return impl().paint.template get<FillExtrusionHeight>().value;
+}
+
+void FillExtrusionLayer::setFillExtrusionHeight(const PropertyValue<float>& value) {
+    if (value == getFillExtrusionHeight())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<FillExtrusionHeight>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void FillExtrusionLayer::setFillExtrusionHeightTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<FillExtrusionHeight>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions FillExtrusionLayer::getFillExtrusionHeightTransition() const {
+    return impl().paint.template get<FillExtrusionHeight>().options;
+}
+
+PropertyValue<float> FillExtrusionLayer::getDefaultFillExtrusionOpacity() {
+    return { 1 };
+}
+
+const PropertyValue<float>& FillExtrusionLayer::getFillExtrusionOpacity() const {
+    return impl().paint.template get<FillExtrusionOpacity>().value;
+}
+
+void FillExtrusionLayer::setFillExtrusionOpacity(const PropertyValue<float>& value) {
+    if (value == getFillExtrusionOpacity())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<FillExtrusionOpacity>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void FillExtrusionLayer::setFillExtrusionOpacityTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<FillExtrusionOpacity>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions FillExtrusionLayer::getFillExtrusionOpacityTransition() const {
+    return impl().paint.template get<FillExtrusionOpacity>().options;
+}
+
+PropertyValue<std::string> FillExtrusionLayer::getDefaultFillExtrusionPattern() {
+    return { "" };
+}
+
+const PropertyValue<std::string>& FillExtrusionLayer::getFillExtrusionPattern() const {
+    return impl().paint.template get<FillExtrusionPattern>().value;
+}
+
+void FillExtrusionLayer::setFillExtrusionPattern(const PropertyValue<std::string>& value) {
+    if (value == getFillExtrusionPattern())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<FillExtrusionPattern>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void FillExtrusionLayer::setFillExtrusionPatternTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<FillExtrusionPattern>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions FillExtrusionLayer::getFillExtrusionPatternTransition() const {
+    return impl().paint.template get<FillExtrusionPattern>().options;
 }
 
 PropertyValue<std::array<float, 2>> FillExtrusionLayer::getDefaultFillExtrusionTranslate() {
@@ -171,87 +252,6 @@ TransitionOptions FillExtrusionLayer::getFillExtrusionTranslateAnchorTransition(
     return impl().paint.template get<FillExtrusionTranslateAnchor>().options;
 }
 
-PropertyValue<std::string> FillExtrusionLayer::getDefaultFillExtrusionPattern() {
-    return { "" };
-}
-
-const PropertyValue<std::string>& FillExtrusionLayer::getFillExtrusionPattern() const {
-    return impl().paint.template get<FillExtrusionPattern>().value;
-}
-
-void FillExtrusionLayer::setFillExtrusionPattern(const PropertyValue<std::string>& value) {
-    if (value == getFillExtrusionPattern())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<FillExtrusionPattern>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void FillExtrusionLayer::setFillExtrusionPatternTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<FillExtrusionPattern>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions FillExtrusionLayer::getFillExtrusionPatternTransition() const {
-    return impl().paint.template get<FillExtrusionPattern>().options;
-}
-
-PropertyValue<float> FillExtrusionLayer::getDefaultFillExtrusionHeight() {
-    return { 0 };
-}
-
-const PropertyValue<float>& FillExtrusionLayer::getFillExtrusionHeight() const {
-    return impl().paint.template get<FillExtrusionHeight>().value;
-}
-
-void FillExtrusionLayer::setFillExtrusionHeight(const PropertyValue<float>& value) {
-    if (value == getFillExtrusionHeight())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<FillExtrusionHeight>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void FillExtrusionLayer::setFillExtrusionHeightTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<FillExtrusionHeight>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions FillExtrusionLayer::getFillExtrusionHeightTransition() const {
-    return impl().paint.template get<FillExtrusionHeight>().options;
-}
-
-PropertyValue<float> FillExtrusionLayer::getDefaultFillExtrusionBase() {
-    return { 0 };
-}
-
-const PropertyValue<float>& FillExtrusionLayer::getFillExtrusionBase() const {
-    return impl().paint.template get<FillExtrusionBase>().value;
-}
-
-void FillExtrusionLayer::setFillExtrusionBase(const PropertyValue<float>& value) {
-    if (value == getFillExtrusionBase())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<FillExtrusionBase>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void FillExtrusionLayer::setFillExtrusionBaseTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<FillExtrusionBase>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions FillExtrusionLayer::getFillExtrusionBaseTransition() const {
-    return impl().paint.template get<FillExtrusionBase>().options;
-}
-
 PropertyValue<bool> FillExtrusionLayer::getDefaultFillExtrusionVerticalGradient() {
     return { true };
 }
@@ -283,40 +283,40 @@ using namespace conversion;
 
 optional<Error> FillExtrusionLayer::setPaintProperty(const std::string& name, const Convertible& value) {
     enum class Property : uint8_t {
-        FillExtrusionOpacity,
+        FillExtrusionBase,
         FillExtrusionColor,
+        FillExtrusionHeight,
+        FillExtrusionOpacity,
+        FillExtrusionPattern,
         FillExtrusionTranslate,
         FillExtrusionTranslateAnchor,
-        FillExtrusionPattern,
-        FillExtrusionHeight,
-        FillExtrusionBase,
         FillExtrusionVerticalGradient,
-        FillExtrusionOpacityTransition,
+        FillExtrusionBaseTransition,
         FillExtrusionColorTransition,
+        FillExtrusionHeightTransition,
+        FillExtrusionOpacityTransition,
+        FillExtrusionPatternTransition,
         FillExtrusionTranslateTransition,
         FillExtrusionTranslateAnchorTransition,
-        FillExtrusionPatternTransition,
-        FillExtrusionHeightTransition,
-        FillExtrusionBaseTransition,
         FillExtrusionVerticalGradientTransition,
     };
 
     MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        { "fill-extrusion-opacity", static_cast<uint8_t>(Property::FillExtrusionOpacity) },
+        { "fill-extrusion-base", static_cast<uint8_t>(Property::FillExtrusionBase) },
         { "fill-extrusion-color", static_cast<uint8_t>(Property::FillExtrusionColor) },
+        { "fill-extrusion-height", static_cast<uint8_t>(Property::FillExtrusionHeight) },
+        { "fill-extrusion-opacity", static_cast<uint8_t>(Property::FillExtrusionOpacity) },
+        { "fill-extrusion-pattern", static_cast<uint8_t>(Property::FillExtrusionPattern) },
         { "fill-extrusion-translate", static_cast<uint8_t>(Property::FillExtrusionTranslate) },
         { "fill-extrusion-translate-anchor", static_cast<uint8_t>(Property::FillExtrusionTranslateAnchor) },
-        { "fill-extrusion-pattern", static_cast<uint8_t>(Property::FillExtrusionPattern) },
-        { "fill-extrusion-height", static_cast<uint8_t>(Property::FillExtrusionHeight) },
-        { "fill-extrusion-base", static_cast<uint8_t>(Property::FillExtrusionBase) },
         { "fill-extrusion-vertical-gradient", static_cast<uint8_t>(Property::FillExtrusionVerticalGradient) },
-        { "fill-extrusion-opacity-transition", static_cast<uint8_t>(Property::FillExtrusionOpacityTransition) },
+        { "fill-extrusion-base-transition", static_cast<uint8_t>(Property::FillExtrusionBaseTransition) },
         { "fill-extrusion-color-transition", static_cast<uint8_t>(Property::FillExtrusionColorTransition) },
+        { "fill-extrusion-height-transition", static_cast<uint8_t>(Property::FillExtrusionHeightTransition) },
+        { "fill-extrusion-opacity-transition", static_cast<uint8_t>(Property::FillExtrusionOpacityTransition) },
+        { "fill-extrusion-pattern-transition", static_cast<uint8_t>(Property::FillExtrusionPatternTransition) },
         { "fill-extrusion-translate-transition", static_cast<uint8_t>(Property::FillExtrusionTranslateTransition) },
         { "fill-extrusion-translate-anchor-transition", static_cast<uint8_t>(Property::FillExtrusionTranslateAnchorTransition) },
-        { "fill-extrusion-pattern-transition", static_cast<uint8_t>(Property::FillExtrusionPatternTransition) },
-        { "fill-extrusion-height-transition", static_cast<uint8_t>(Property::FillExtrusionHeightTransition) },
-        { "fill-extrusion-base-transition", static_cast<uint8_t>(Property::FillExtrusionBaseTransition) },
         { "fill-extrusion-vertical-gradient-transition", static_cast<uint8_t>(Property::FillExtrusionVerticalGradientTransition) }
     });
 
@@ -328,6 +328,37 @@ optional<Error> FillExtrusionLayer::setPaintProperty(const std::string& name, co
     auto property = static_cast<Property>(it->second);
 
         
+    if (property == Property::FillExtrusionBase || property == Property::FillExtrusionHeight) {
+        Error error;
+        optional<PropertyValue<float>> typedValue = convert<PropertyValue<float>>(value, error, true, false);
+        if (!typedValue) {
+            return error;
+        }
+        
+        if (property == Property::FillExtrusionBase) {
+            setFillExtrusionBase(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::FillExtrusionHeight) {
+            setFillExtrusionHeight(*typedValue);
+            return nullopt;
+        }
+        
+    }
+    
+    if (property == Property::FillExtrusionColor) {
+        Error error;
+        optional<PropertyValue<Color>> typedValue = convert<PropertyValue<Color>>(value, error, true, false);
+        if (!typedValue) {
+            return error;
+        }
+        
+        setFillExtrusionColor(*typedValue);
+        return nullopt;
+        
+    }
+    
     if (property == Property::FillExtrusionOpacity) {
         Error error;
         optional<PropertyValue<float>> typedValue = convert<PropertyValue<float>>(value, error, false, false);
@@ -340,14 +371,14 @@ optional<Error> FillExtrusionLayer::setPaintProperty(const std::string& name, co
         
     }
     
-    if (property == Property::FillExtrusionColor) {
+    if (property == Property::FillExtrusionPattern) {
         Error error;
-        optional<PropertyValue<Color>> typedValue = convert<PropertyValue<Color>>(value, error, true, false);
+        optional<PropertyValue<std::string>> typedValue = convert<PropertyValue<std::string>>(value, error, true, false);
         if (!typedValue) {
             return error;
         }
         
-        setFillExtrusionColor(*typedValue);
+        setFillExtrusionPattern(*typedValue);
         return nullopt;
         
     }
@@ -376,37 +407,6 @@ optional<Error> FillExtrusionLayer::setPaintProperty(const std::string& name, co
         
     }
     
-    if (property == Property::FillExtrusionPattern) {
-        Error error;
-        optional<PropertyValue<std::string>> typedValue = convert<PropertyValue<std::string>>(value, error, true, false);
-        if (!typedValue) {
-            return error;
-        }
-        
-        setFillExtrusionPattern(*typedValue);
-        return nullopt;
-        
-    }
-    
-    if (property == Property::FillExtrusionHeight || property == Property::FillExtrusionBase) {
-        Error error;
-        optional<PropertyValue<float>> typedValue = convert<PropertyValue<float>>(value, error, true, false);
-        if (!typedValue) {
-            return error;
-        }
-        
-        if (property == Property::FillExtrusionHeight) {
-            setFillExtrusionHeight(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::FillExtrusionBase) {
-            setFillExtrusionBase(*typedValue);
-            return nullopt;
-        }
-        
-    }
-    
     if (property == Property::FillExtrusionVerticalGradient) {
         Error error;
         optional<PropertyValue<bool>> typedValue = convert<PropertyValue<bool>>(value, error, false, false);
@@ -426,13 +426,28 @@ optional<Error> FillExtrusionLayer::setPaintProperty(const std::string& name, co
         return error;
     }
     
-    if (property == Property::FillExtrusionOpacityTransition) {
-        setFillExtrusionOpacityTransition(*transition);
+    if (property == Property::FillExtrusionBaseTransition) {
+        setFillExtrusionBaseTransition(*transition);
         return nullopt;
     }
     
     if (property == Property::FillExtrusionColorTransition) {
         setFillExtrusionColorTransition(*transition);
+        return nullopt;
+    }
+    
+    if (property == Property::FillExtrusionHeightTransition) {
+        setFillExtrusionHeightTransition(*transition);
+        return nullopt;
+    }
+    
+    if (property == Property::FillExtrusionOpacityTransition) {
+        setFillExtrusionOpacityTransition(*transition);
+        return nullopt;
+    }
+    
+    if (property == Property::FillExtrusionPatternTransition) {
+        setFillExtrusionPatternTransition(*transition);
         return nullopt;
     }
     
@@ -443,21 +458,6 @@ optional<Error> FillExtrusionLayer::setPaintProperty(const std::string& name, co
     
     if (property == Property::FillExtrusionTranslateAnchorTransition) {
         setFillExtrusionTranslateAnchorTransition(*transition);
-        return nullopt;
-    }
-    
-    if (property == Property::FillExtrusionPatternTransition) {
-        setFillExtrusionPatternTransition(*transition);
-        return nullopt;
-    }
-    
-    if (property == Property::FillExtrusionHeightTransition) {
-        setFillExtrusionHeightTransition(*transition);
-        return nullopt;
-    }
-    
-    if (property == Property::FillExtrusionBaseTransition) {
-        setFillExtrusionBaseTransition(*transition);
         return nullopt;
     }
     

--- a/src/mbgl/style/layers/fill_extrusion_layer_properties.hpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer_properties.hpp
@@ -14,12 +14,24 @@
 namespace mbgl {
 namespace style {
 
-struct FillExtrusionOpacity : PaintProperty<float> {
-    static float defaultValue() { return 1; }
+struct FillExtrusionBase : DataDrivenPaintProperty<float, attributes::base, uniforms::base> {
+    static float defaultValue() { return 0; }
 };
 
 struct FillExtrusionColor : DataDrivenPaintProperty<Color, attributes::color, uniforms::color> {
     static Color defaultValue() { return Color::black(); }
+};
+
+struct FillExtrusionHeight : DataDrivenPaintProperty<float, attributes::height, uniforms::height> {
+    static float defaultValue() { return 0; }
+};
+
+struct FillExtrusionOpacity : PaintProperty<float> {
+    static float defaultValue() { return 1; }
+};
+
+struct FillExtrusionPattern : CrossFadedDataDrivenPaintProperty<std::string, attributes::pattern_to, uniforms::pattern_to, attributes::pattern_from, uniforms::pattern_from> {
+    static std::string defaultValue() { return ""; }
 };
 
 struct FillExtrusionTranslate : PaintProperty<std::array<float, 2>> {
@@ -30,30 +42,18 @@ struct FillExtrusionTranslateAnchor : PaintProperty<TranslateAnchorType> {
     static TranslateAnchorType defaultValue() { return TranslateAnchorType::Map; }
 };
 
-struct FillExtrusionPattern : CrossFadedDataDrivenPaintProperty<std::string, attributes::pattern_to, uniforms::pattern_to, attributes::pattern_from, uniforms::pattern_from> {
-    static std::string defaultValue() { return ""; }
-};
-
-struct FillExtrusionHeight : DataDrivenPaintProperty<float, attributes::height, uniforms::height> {
-    static float defaultValue() { return 0; }
-};
-
-struct FillExtrusionBase : DataDrivenPaintProperty<float, attributes::base, uniforms::base> {
-    static float defaultValue() { return 0; }
-};
-
 struct FillExtrusionVerticalGradient : PaintProperty<bool> {
     static bool defaultValue() { return true; }
 };
 
 class FillExtrusionPaintProperties : public Properties<
-    FillExtrusionOpacity,
+    FillExtrusionBase,
     FillExtrusionColor,
+    FillExtrusionHeight,
+    FillExtrusionOpacity,
+    FillExtrusionPattern,
     FillExtrusionTranslate,
     FillExtrusionTranslateAnchor,
-    FillExtrusionPattern,
-    FillExtrusionHeight,
-    FillExtrusionBase,
     FillExtrusionVerticalGradient
 > {};
 

--- a/src/mbgl/style/layers/fill_layer.cpp
+++ b/src/mbgl/style/layers/fill_layer.cpp
@@ -90,33 +90,6 @@ TransitionOptions FillLayer::getFillAntialiasTransition() const {
     return impl().paint.template get<FillAntialias>().options;
 }
 
-PropertyValue<float> FillLayer::getDefaultFillOpacity() {
-    return { 1 };
-}
-
-const PropertyValue<float>& FillLayer::getFillOpacity() const {
-    return impl().paint.template get<FillOpacity>().value;
-}
-
-void FillLayer::setFillOpacity(const PropertyValue<float>& value) {
-    if (value == getFillOpacity())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<FillOpacity>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void FillLayer::setFillOpacityTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<FillOpacity>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions FillLayer::getFillOpacityTransition() const {
-    return impl().paint.template get<FillOpacity>().options;
-}
-
 PropertyValue<Color> FillLayer::getDefaultFillColor() {
     return { Color::black() };
 }
@@ -144,6 +117,33 @@ TransitionOptions FillLayer::getFillColorTransition() const {
     return impl().paint.template get<FillColor>().options;
 }
 
+PropertyValue<float> FillLayer::getDefaultFillOpacity() {
+    return { 1 };
+}
+
+const PropertyValue<float>& FillLayer::getFillOpacity() const {
+    return impl().paint.template get<FillOpacity>().value;
+}
+
+void FillLayer::setFillOpacity(const PropertyValue<float>& value) {
+    if (value == getFillOpacity())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<FillOpacity>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void FillLayer::setFillOpacityTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<FillOpacity>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions FillLayer::getFillOpacityTransition() const {
+    return impl().paint.template get<FillOpacity>().options;
+}
+
 PropertyValue<Color> FillLayer::getDefaultFillOutlineColor() {
     return { {} };
 }
@@ -169,6 +169,33 @@ void FillLayer::setFillOutlineColorTransition(const TransitionOptions& options) 
 
 TransitionOptions FillLayer::getFillOutlineColorTransition() const {
     return impl().paint.template get<FillOutlineColor>().options;
+}
+
+PropertyValue<std::string> FillLayer::getDefaultFillPattern() {
+    return { "" };
+}
+
+const PropertyValue<std::string>& FillLayer::getFillPattern() const {
+    return impl().paint.template get<FillPattern>().value;
+}
+
+void FillLayer::setFillPattern(const PropertyValue<std::string>& value) {
+    if (value == getFillPattern())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<FillPattern>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void FillLayer::setFillPatternTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<FillPattern>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions FillLayer::getFillPatternTransition() const {
+    return impl().paint.template get<FillPattern>().options;
 }
 
 PropertyValue<std::array<float, 2>> FillLayer::getDefaultFillTranslate() {
@@ -225,68 +252,41 @@ TransitionOptions FillLayer::getFillTranslateAnchorTransition() const {
     return impl().paint.template get<FillTranslateAnchor>().options;
 }
 
-PropertyValue<std::string> FillLayer::getDefaultFillPattern() {
-    return { "" };
-}
-
-const PropertyValue<std::string>& FillLayer::getFillPattern() const {
-    return impl().paint.template get<FillPattern>().value;
-}
-
-void FillLayer::setFillPattern(const PropertyValue<std::string>& value) {
-    if (value == getFillPattern())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<FillPattern>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void FillLayer::setFillPatternTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<FillPattern>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions FillLayer::getFillPatternTransition() const {
-    return impl().paint.template get<FillPattern>().options;
-}
-
 using namespace conversion;
 
 optional<Error> FillLayer::setPaintProperty(const std::string& name, const Convertible& value) {
     enum class Property : uint8_t {
         FillAntialias,
-        FillOpacity,
         FillColor,
+        FillOpacity,
         FillOutlineColor,
+        FillPattern,
         FillTranslate,
         FillTranslateAnchor,
-        FillPattern,
         FillAntialiasTransition,
-        FillOpacityTransition,
         FillColorTransition,
+        FillOpacityTransition,
         FillOutlineColorTransition,
+        FillPatternTransition,
         FillTranslateTransition,
         FillTranslateAnchorTransition,
-        FillPatternTransition,
     };
 
     MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
         { "fill-antialias", static_cast<uint8_t>(Property::FillAntialias) },
-        { "fill-opacity", static_cast<uint8_t>(Property::FillOpacity) },
         { "fill-color", static_cast<uint8_t>(Property::FillColor) },
+        { "fill-opacity", static_cast<uint8_t>(Property::FillOpacity) },
         { "fill-outline-color", static_cast<uint8_t>(Property::FillOutlineColor) },
+        { "fill-pattern", static_cast<uint8_t>(Property::FillPattern) },
         { "fill-translate", static_cast<uint8_t>(Property::FillTranslate) },
         { "fill-translate-anchor", static_cast<uint8_t>(Property::FillTranslateAnchor) },
-        { "fill-pattern", static_cast<uint8_t>(Property::FillPattern) },
         { "fill-antialias-transition", static_cast<uint8_t>(Property::FillAntialiasTransition) },
-        { "fill-opacity-transition", static_cast<uint8_t>(Property::FillOpacityTransition) },
         { "fill-color-transition", static_cast<uint8_t>(Property::FillColorTransition) },
+        { "fill-opacity-transition", static_cast<uint8_t>(Property::FillOpacityTransition) },
         { "fill-outline-color-transition", static_cast<uint8_t>(Property::FillOutlineColorTransition) },
+        { "fill-pattern-transition", static_cast<uint8_t>(Property::FillPatternTransition) },
         { "fill-translate-transition", static_cast<uint8_t>(Property::FillTranslateTransition) },
-        { "fill-translate-anchor-transition", static_cast<uint8_t>(Property::FillTranslateAnchorTransition) },
-        { "fill-pattern-transition", static_cast<uint8_t>(Property::FillPatternTransition) }
+        { "fill-translate-anchor-transition", static_cast<uint8_t>(Property::FillTranslateAnchorTransition) }
     });
 
     const auto it = properties.find(name.c_str());
@@ -309,18 +309,6 @@ optional<Error> FillLayer::setPaintProperty(const std::string& name, const Conve
         
     }
     
-    if (property == Property::FillOpacity) {
-        Error error;
-        optional<PropertyValue<float>> typedValue = convert<PropertyValue<float>>(value, error, true, false);
-        if (!typedValue) {
-            return error;
-        }
-        
-        setFillOpacity(*typedValue);
-        return nullopt;
-        
-    }
-    
     if (property == Property::FillColor || property == Property::FillOutlineColor) {
         Error error;
         optional<PropertyValue<Color>> typedValue = convert<PropertyValue<Color>>(value, error, true, false);
@@ -337,6 +325,30 @@ optional<Error> FillLayer::setPaintProperty(const std::string& name, const Conve
             setFillOutlineColor(*typedValue);
             return nullopt;
         }
+        
+    }
+    
+    if (property == Property::FillOpacity) {
+        Error error;
+        optional<PropertyValue<float>> typedValue = convert<PropertyValue<float>>(value, error, true, false);
+        if (!typedValue) {
+            return error;
+        }
+        
+        setFillOpacity(*typedValue);
+        return nullopt;
+        
+    }
+    
+    if (property == Property::FillPattern) {
+        Error error;
+        optional<PropertyValue<std::string>> typedValue = convert<PropertyValue<std::string>>(value, error, true, false);
+        if (!typedValue) {
+            return error;
+        }
+        
+        setFillPattern(*typedValue);
+        return nullopt;
         
     }
     
@@ -364,18 +376,6 @@ optional<Error> FillLayer::setPaintProperty(const std::string& name, const Conve
         
     }
     
-    if (property == Property::FillPattern) {
-        Error error;
-        optional<PropertyValue<std::string>> typedValue = convert<PropertyValue<std::string>>(value, error, true, false);
-        if (!typedValue) {
-            return error;
-        }
-        
-        setFillPattern(*typedValue);
-        return nullopt;
-        
-    }
-    
 
     Error error;
     optional<TransitionOptions> transition = convert<TransitionOptions>(value, error);
@@ -388,18 +388,23 @@ optional<Error> FillLayer::setPaintProperty(const std::string& name, const Conve
         return nullopt;
     }
     
-    if (property == Property::FillOpacityTransition) {
-        setFillOpacityTransition(*transition);
-        return nullopt;
-    }
-    
     if (property == Property::FillColorTransition) {
         setFillColorTransition(*transition);
         return nullopt;
     }
     
+    if (property == Property::FillOpacityTransition) {
+        setFillOpacityTransition(*transition);
+        return nullopt;
+    }
+    
     if (property == Property::FillOutlineColorTransition) {
         setFillOutlineColorTransition(*transition);
+        return nullopt;
+    }
+    
+    if (property == Property::FillPatternTransition) {
+        setFillPatternTransition(*transition);
         return nullopt;
     }
     
@@ -410,11 +415,6 @@ optional<Error> FillLayer::setPaintProperty(const std::string& name, const Conve
     
     if (property == Property::FillTranslateAnchorTransition) {
         setFillTranslateAnchorTransition(*transition);
-        return nullopt;
-    }
-    
-    if (property == Property::FillPatternTransition) {
-        setFillPatternTransition(*transition);
         return nullopt;
     }
     

--- a/src/mbgl/style/layers/fill_layer_properties.hpp
+++ b/src/mbgl/style/layers/fill_layer_properties.hpp
@@ -18,16 +18,20 @@ struct FillAntialias : PaintProperty<bool> {
     static bool defaultValue() { return true; }
 };
 
-struct FillOpacity : DataDrivenPaintProperty<float, attributes::opacity, uniforms::opacity> {
-    static float defaultValue() { return 1; }
-};
-
 struct FillColor : DataDrivenPaintProperty<Color, attributes::color, uniforms::color> {
     static Color defaultValue() { return Color::black(); }
 };
 
+struct FillOpacity : DataDrivenPaintProperty<float, attributes::opacity, uniforms::opacity> {
+    static float defaultValue() { return 1; }
+};
+
 struct FillOutlineColor : DataDrivenPaintProperty<Color, attributes::outline_color, uniforms::outline_color> {
     static Color defaultValue() { return {}; }
+};
+
+struct FillPattern : CrossFadedDataDrivenPaintProperty<std::string, attributes::pattern_to, uniforms::pattern_to, attributes::pattern_from, uniforms::pattern_from> {
+    static std::string defaultValue() { return ""; }
 };
 
 struct FillTranslate : PaintProperty<std::array<float, 2>> {
@@ -38,18 +42,14 @@ struct FillTranslateAnchor : PaintProperty<TranslateAnchorType> {
     static TranslateAnchorType defaultValue() { return TranslateAnchorType::Map; }
 };
 
-struct FillPattern : CrossFadedDataDrivenPaintProperty<std::string, attributes::pattern_to, uniforms::pattern_to, attributes::pattern_from, uniforms::pattern_from> {
-    static std::string defaultValue() { return ""; }
-};
-
 class FillPaintProperties : public Properties<
     FillAntialias,
-    FillOpacity,
     FillColor,
+    FillOpacity,
     FillOutlineColor,
+    FillPattern,
     FillTranslate,
-    FillTranslateAnchor,
-    FillPattern
+    FillTranslateAnchor
 > {};
 
 class FillLayerProperties final : public LayerProperties {

--- a/src/mbgl/style/layers/heatmap_layer.cpp
+++ b/src/mbgl/style/layers/heatmap_layer.cpp
@@ -63,6 +63,89 @@ void HeatmapLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuff
 
 // Paint properties
 
+ColorRampPropertyValue HeatmapLayer::getDefaultHeatmapColor() {
+    conversion::Error error;
+    std::string rawValue = R"JSON(["interpolate",["linear"],["heatmap-density"],0,"rgba(0, 0, 255, 0)",0.1,"royalblue",0.3,"cyan",0.5,"lime",0.7,"yellow",1,"red"])JSON";
+    return *conversion::convertJSON<ColorRampPropertyValue>(rawValue, error);
+}
+
+const ColorRampPropertyValue& HeatmapLayer::getHeatmapColor() const {
+    return impl().paint.template get<HeatmapColor>().value;
+}
+
+void HeatmapLayer::setHeatmapColor(const ColorRampPropertyValue& value) {
+    if (value == getHeatmapColor())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<HeatmapColor>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void HeatmapLayer::setHeatmapColorTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<HeatmapColor>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions HeatmapLayer::getHeatmapColorTransition() const {
+    return impl().paint.template get<HeatmapColor>().options;
+}
+
+PropertyValue<float> HeatmapLayer::getDefaultHeatmapIntensity() {
+    return { 1 };
+}
+
+const PropertyValue<float>& HeatmapLayer::getHeatmapIntensity() const {
+    return impl().paint.template get<HeatmapIntensity>().value;
+}
+
+void HeatmapLayer::setHeatmapIntensity(const PropertyValue<float>& value) {
+    if (value == getHeatmapIntensity())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<HeatmapIntensity>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void HeatmapLayer::setHeatmapIntensityTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<HeatmapIntensity>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions HeatmapLayer::getHeatmapIntensityTransition() const {
+    return impl().paint.template get<HeatmapIntensity>().options;
+}
+
+PropertyValue<float> HeatmapLayer::getDefaultHeatmapOpacity() {
+    return { 1 };
+}
+
+const PropertyValue<float>& HeatmapLayer::getHeatmapOpacity() const {
+    return impl().paint.template get<HeatmapOpacity>().value;
+}
+
+void HeatmapLayer::setHeatmapOpacity(const PropertyValue<float>& value) {
+    if (value == getHeatmapOpacity())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<HeatmapOpacity>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void HeatmapLayer::setHeatmapOpacityTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<HeatmapOpacity>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions HeatmapLayer::getHeatmapOpacityTransition() const {
+    return impl().paint.template get<HeatmapOpacity>().options;
+}
+
 PropertyValue<float> HeatmapLayer::getDefaultHeatmapRadius() {
     return { 30 };
 }
@@ -117,116 +200,33 @@ TransitionOptions HeatmapLayer::getHeatmapWeightTransition() const {
     return impl().paint.template get<HeatmapWeight>().options;
 }
 
-PropertyValue<float> HeatmapLayer::getDefaultHeatmapIntensity() {
-    return { 1 };
-}
-
-const PropertyValue<float>& HeatmapLayer::getHeatmapIntensity() const {
-    return impl().paint.template get<HeatmapIntensity>().value;
-}
-
-void HeatmapLayer::setHeatmapIntensity(const PropertyValue<float>& value) {
-    if (value == getHeatmapIntensity())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<HeatmapIntensity>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void HeatmapLayer::setHeatmapIntensityTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<HeatmapIntensity>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions HeatmapLayer::getHeatmapIntensityTransition() const {
-    return impl().paint.template get<HeatmapIntensity>().options;
-}
-
-ColorRampPropertyValue HeatmapLayer::getDefaultHeatmapColor() {
-    conversion::Error error;
-    std::string rawValue = R"JSON(["interpolate",["linear"],["heatmap-density"],0,"rgba(0, 0, 255, 0)",0.1,"royalblue",0.3,"cyan",0.5,"lime",0.7,"yellow",1,"red"])JSON";
-    return *conversion::convertJSON<ColorRampPropertyValue>(rawValue, error);
-}
-
-const ColorRampPropertyValue& HeatmapLayer::getHeatmapColor() const {
-    return impl().paint.template get<HeatmapColor>().value;
-}
-
-void HeatmapLayer::setHeatmapColor(const ColorRampPropertyValue& value) {
-    if (value == getHeatmapColor())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<HeatmapColor>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void HeatmapLayer::setHeatmapColorTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<HeatmapColor>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions HeatmapLayer::getHeatmapColorTransition() const {
-    return impl().paint.template get<HeatmapColor>().options;
-}
-
-PropertyValue<float> HeatmapLayer::getDefaultHeatmapOpacity() {
-    return { 1 };
-}
-
-const PropertyValue<float>& HeatmapLayer::getHeatmapOpacity() const {
-    return impl().paint.template get<HeatmapOpacity>().value;
-}
-
-void HeatmapLayer::setHeatmapOpacity(const PropertyValue<float>& value) {
-    if (value == getHeatmapOpacity())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<HeatmapOpacity>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void HeatmapLayer::setHeatmapOpacityTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<HeatmapOpacity>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions HeatmapLayer::getHeatmapOpacityTransition() const {
-    return impl().paint.template get<HeatmapOpacity>().options;
-}
-
 using namespace conversion;
 
 optional<Error> HeatmapLayer::setPaintProperty(const std::string& name, const Convertible& value) {
     enum class Property : uint8_t {
+        HeatmapColor,
+        HeatmapIntensity,
+        HeatmapOpacity,
         HeatmapRadius,
         HeatmapWeight,
-        HeatmapIntensity,
-        HeatmapColor,
-        HeatmapOpacity,
+        HeatmapColorTransition,
+        HeatmapIntensityTransition,
+        HeatmapOpacityTransition,
         HeatmapRadiusTransition,
         HeatmapWeightTransition,
-        HeatmapIntensityTransition,
-        HeatmapColorTransition,
-        HeatmapOpacityTransition,
     };
 
     MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
+        { "heatmap-color", static_cast<uint8_t>(Property::HeatmapColor) },
+        { "heatmap-intensity", static_cast<uint8_t>(Property::HeatmapIntensity) },
+        { "heatmap-opacity", static_cast<uint8_t>(Property::HeatmapOpacity) },
         { "heatmap-radius", static_cast<uint8_t>(Property::HeatmapRadius) },
         { "heatmap-weight", static_cast<uint8_t>(Property::HeatmapWeight) },
-        { "heatmap-intensity", static_cast<uint8_t>(Property::HeatmapIntensity) },
-        { "heatmap-color", static_cast<uint8_t>(Property::HeatmapColor) },
-        { "heatmap-opacity", static_cast<uint8_t>(Property::HeatmapOpacity) },
-        { "heatmap-radius-transition", static_cast<uint8_t>(Property::HeatmapRadiusTransition) },
-        { "heatmap-weight-transition", static_cast<uint8_t>(Property::HeatmapWeightTransition) },
-        { "heatmap-intensity-transition", static_cast<uint8_t>(Property::HeatmapIntensityTransition) },
         { "heatmap-color-transition", static_cast<uint8_t>(Property::HeatmapColorTransition) },
-        { "heatmap-opacity-transition", static_cast<uint8_t>(Property::HeatmapOpacityTransition) }
+        { "heatmap-intensity-transition", static_cast<uint8_t>(Property::HeatmapIntensityTransition) },
+        { "heatmap-opacity-transition", static_cast<uint8_t>(Property::HeatmapOpacityTransition) },
+        { "heatmap-radius-transition", static_cast<uint8_t>(Property::HeatmapRadiusTransition) },
+        { "heatmap-weight-transition", static_cast<uint8_t>(Property::HeatmapWeightTransition) }
     });
 
     const auto it = properties.find(name.c_str());
@@ -237,22 +237,15 @@ optional<Error> HeatmapLayer::setPaintProperty(const std::string& name, const Co
     auto property = static_cast<Property>(it->second);
 
         
-    if (property == Property::HeatmapRadius || property == Property::HeatmapWeight) {
+    if (property == Property::HeatmapColor) {
         Error error;
-        optional<PropertyValue<float>> typedValue = convert<PropertyValue<float>>(value, error, true, false);
+        optional<ColorRampPropertyValue> typedValue = convert<ColorRampPropertyValue>(value, error, false, false);
         if (!typedValue) {
             return error;
         }
         
-        if (property == Property::HeatmapRadius) {
-            setHeatmapRadius(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::HeatmapWeight) {
-            setHeatmapWeight(*typedValue);
-            return nullopt;
-        }
+        setHeatmapColor(*typedValue);
+        return nullopt;
         
     }
     
@@ -275,15 +268,22 @@ optional<Error> HeatmapLayer::setPaintProperty(const std::string& name, const Co
         
     }
     
-    if (property == Property::HeatmapColor) {
+    if (property == Property::HeatmapRadius || property == Property::HeatmapWeight) {
         Error error;
-        optional<ColorRampPropertyValue> typedValue = convert<ColorRampPropertyValue>(value, error, false, false);
+        optional<PropertyValue<float>> typedValue = convert<PropertyValue<float>>(value, error, true, false);
         if (!typedValue) {
             return error;
         }
         
-        setHeatmapColor(*typedValue);
-        return nullopt;
+        if (property == Property::HeatmapRadius) {
+            setHeatmapRadius(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::HeatmapWeight) {
+            setHeatmapWeight(*typedValue);
+            return nullopt;
+        }
         
     }
     
@@ -294,13 +294,8 @@ optional<Error> HeatmapLayer::setPaintProperty(const std::string& name, const Co
         return error;
     }
     
-    if (property == Property::HeatmapRadiusTransition) {
-        setHeatmapRadiusTransition(*transition);
-        return nullopt;
-    }
-    
-    if (property == Property::HeatmapWeightTransition) {
-        setHeatmapWeightTransition(*transition);
+    if (property == Property::HeatmapColorTransition) {
+        setHeatmapColorTransition(*transition);
         return nullopt;
     }
     
@@ -309,13 +304,18 @@ optional<Error> HeatmapLayer::setPaintProperty(const std::string& name, const Co
         return nullopt;
     }
     
-    if (property == Property::HeatmapColorTransition) {
-        setHeatmapColorTransition(*transition);
+    if (property == Property::HeatmapOpacityTransition) {
+        setHeatmapOpacityTransition(*transition);
         return nullopt;
     }
     
-    if (property == Property::HeatmapOpacityTransition) {
-        setHeatmapOpacityTransition(*transition);
+    if (property == Property::HeatmapRadiusTransition) {
+        setHeatmapRadiusTransition(*transition);
+        return nullopt;
+    }
+    
+    if (property == Property::HeatmapWeightTransition) {
+        setHeatmapWeightTransition(*transition);
         return nullopt;
     }
     

--- a/src/mbgl/style/layers/heatmap_layer_properties.hpp
+++ b/src/mbgl/style/layers/heatmap_layer_properties.hpp
@@ -14,6 +14,17 @@
 namespace mbgl {
 namespace style {
 
+struct HeatmapColor : ColorRampProperty {
+};
+
+struct HeatmapIntensity : PaintProperty<float> {
+    static float defaultValue() { return 1; }
+};
+
+struct HeatmapOpacity : PaintProperty<float> {
+    static float defaultValue() { return 1; }
+};
+
 struct HeatmapRadius : DataDrivenPaintProperty<float, attributes::radius, uniforms::radius> {
     static float defaultValue() { return 30; }
 };
@@ -22,23 +33,12 @@ struct HeatmapWeight : DataDrivenPaintProperty<float, attributes::weight, unifor
     static float defaultValue() { return 1; }
 };
 
-struct HeatmapIntensity : PaintProperty<float> {
-    static float defaultValue() { return 1; }
-};
-
-struct HeatmapColor : ColorRampProperty {
-};
-
-struct HeatmapOpacity : PaintProperty<float> {
-    static float defaultValue() { return 1; }
-};
-
 class HeatmapPaintProperties : public Properties<
-    HeatmapRadius,
-    HeatmapWeight,
-    HeatmapIntensity,
     HeatmapColor,
-    HeatmapOpacity
+    HeatmapIntensity,
+    HeatmapOpacity,
+    HeatmapRadius,
+    HeatmapWeight
 > {};
 
 class HeatmapLayerProperties final : public LayerProperties {

--- a/src/mbgl/style/layers/hillshade_layer.cpp
+++ b/src/mbgl/style/layers/hillshade_layer.cpp
@@ -63,58 +63,31 @@ void HillshadeLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBu
 
 // Paint properties
 
-PropertyValue<float> HillshadeLayer::getDefaultHillshadeIlluminationDirection() {
-    return { 335 };
+PropertyValue<Color> HillshadeLayer::getDefaultHillshadeAccentColor() {
+    return { Color::black() };
 }
 
-const PropertyValue<float>& HillshadeLayer::getHillshadeIlluminationDirection() const {
-    return impl().paint.template get<HillshadeIlluminationDirection>().value;
+const PropertyValue<Color>& HillshadeLayer::getHillshadeAccentColor() const {
+    return impl().paint.template get<HillshadeAccentColor>().value;
 }
 
-void HillshadeLayer::setHillshadeIlluminationDirection(const PropertyValue<float>& value) {
-    if (value == getHillshadeIlluminationDirection())
+void HillshadeLayer::setHillshadeAccentColor(const PropertyValue<Color>& value) {
+    if (value == getHillshadeAccentColor())
         return;
     auto impl_ = mutableImpl();
-    impl_->paint.template get<HillshadeIlluminationDirection>().value = value;
+    impl_->paint.template get<HillshadeAccentColor>().value = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
 
-void HillshadeLayer::setHillshadeIlluminationDirectionTransition(const TransitionOptions& options) {
+void HillshadeLayer::setHillshadeAccentColorTransition(const TransitionOptions& options) {
     auto impl_ = mutableImpl();
-    impl_->paint.template get<HillshadeIlluminationDirection>().options = options;
+    impl_->paint.template get<HillshadeAccentColor>().options = options;
     baseImpl = std::move(impl_);
 }
 
-TransitionOptions HillshadeLayer::getHillshadeIlluminationDirectionTransition() const {
-    return impl().paint.template get<HillshadeIlluminationDirection>().options;
-}
-
-PropertyValue<HillshadeIlluminationAnchorType> HillshadeLayer::getDefaultHillshadeIlluminationAnchor() {
-    return { HillshadeIlluminationAnchorType::Viewport };
-}
-
-const PropertyValue<HillshadeIlluminationAnchorType>& HillshadeLayer::getHillshadeIlluminationAnchor() const {
-    return impl().paint.template get<HillshadeIlluminationAnchor>().value;
-}
-
-void HillshadeLayer::setHillshadeIlluminationAnchor(const PropertyValue<HillshadeIlluminationAnchorType>& value) {
-    if (value == getHillshadeIlluminationAnchor())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<HillshadeIlluminationAnchor>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void HillshadeLayer::setHillshadeIlluminationAnchorTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<HillshadeIlluminationAnchor>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions HillshadeLayer::getHillshadeIlluminationAnchorTransition() const {
-    return impl().paint.template get<HillshadeIlluminationAnchor>().options;
+TransitionOptions HillshadeLayer::getHillshadeAccentColorTransition() const {
+    return impl().paint.template get<HillshadeAccentColor>().options;
 }
 
 PropertyValue<float> HillshadeLayer::getDefaultHillshadeExaggeration() {
@@ -144,33 +117,6 @@ TransitionOptions HillshadeLayer::getHillshadeExaggerationTransition() const {
     return impl().paint.template get<HillshadeExaggeration>().options;
 }
 
-PropertyValue<Color> HillshadeLayer::getDefaultHillshadeShadowColor() {
-    return { Color::black() };
-}
-
-const PropertyValue<Color>& HillshadeLayer::getHillshadeShadowColor() const {
-    return impl().paint.template get<HillshadeShadowColor>().value;
-}
-
-void HillshadeLayer::setHillshadeShadowColor(const PropertyValue<Color>& value) {
-    if (value == getHillshadeShadowColor())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<HillshadeShadowColor>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void HillshadeLayer::setHillshadeShadowColorTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<HillshadeShadowColor>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions HillshadeLayer::getHillshadeShadowColorTransition() const {
-    return impl().paint.template get<HillshadeShadowColor>().options;
-}
-
 PropertyValue<Color> HillshadeLayer::getDefaultHillshadeHighlightColor() {
     return { Color::white() };
 }
@@ -198,64 +144,118 @@ TransitionOptions HillshadeLayer::getHillshadeHighlightColorTransition() const {
     return impl().paint.template get<HillshadeHighlightColor>().options;
 }
 
-PropertyValue<Color> HillshadeLayer::getDefaultHillshadeAccentColor() {
-    return { Color::black() };
+PropertyValue<HillshadeIlluminationAnchorType> HillshadeLayer::getDefaultHillshadeIlluminationAnchor() {
+    return { HillshadeIlluminationAnchorType::Viewport };
 }
 
-const PropertyValue<Color>& HillshadeLayer::getHillshadeAccentColor() const {
-    return impl().paint.template get<HillshadeAccentColor>().value;
+const PropertyValue<HillshadeIlluminationAnchorType>& HillshadeLayer::getHillshadeIlluminationAnchor() const {
+    return impl().paint.template get<HillshadeIlluminationAnchor>().value;
 }
 
-void HillshadeLayer::setHillshadeAccentColor(const PropertyValue<Color>& value) {
-    if (value == getHillshadeAccentColor())
+void HillshadeLayer::setHillshadeIlluminationAnchor(const PropertyValue<HillshadeIlluminationAnchorType>& value) {
+    if (value == getHillshadeIlluminationAnchor())
         return;
     auto impl_ = mutableImpl();
-    impl_->paint.template get<HillshadeAccentColor>().value = value;
+    impl_->paint.template get<HillshadeIlluminationAnchor>().value = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
 
-void HillshadeLayer::setHillshadeAccentColorTransition(const TransitionOptions& options) {
+void HillshadeLayer::setHillshadeIlluminationAnchorTransition(const TransitionOptions& options) {
     auto impl_ = mutableImpl();
-    impl_->paint.template get<HillshadeAccentColor>().options = options;
+    impl_->paint.template get<HillshadeIlluminationAnchor>().options = options;
     baseImpl = std::move(impl_);
 }
 
-TransitionOptions HillshadeLayer::getHillshadeAccentColorTransition() const {
-    return impl().paint.template get<HillshadeAccentColor>().options;
+TransitionOptions HillshadeLayer::getHillshadeIlluminationAnchorTransition() const {
+    return impl().paint.template get<HillshadeIlluminationAnchor>().options;
+}
+
+PropertyValue<float> HillshadeLayer::getDefaultHillshadeIlluminationDirection() {
+    return { 335 };
+}
+
+const PropertyValue<float>& HillshadeLayer::getHillshadeIlluminationDirection() const {
+    return impl().paint.template get<HillshadeIlluminationDirection>().value;
+}
+
+void HillshadeLayer::setHillshadeIlluminationDirection(const PropertyValue<float>& value) {
+    if (value == getHillshadeIlluminationDirection())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<HillshadeIlluminationDirection>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void HillshadeLayer::setHillshadeIlluminationDirectionTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<HillshadeIlluminationDirection>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions HillshadeLayer::getHillshadeIlluminationDirectionTransition() const {
+    return impl().paint.template get<HillshadeIlluminationDirection>().options;
+}
+
+PropertyValue<Color> HillshadeLayer::getDefaultHillshadeShadowColor() {
+    return { Color::black() };
+}
+
+const PropertyValue<Color>& HillshadeLayer::getHillshadeShadowColor() const {
+    return impl().paint.template get<HillshadeShadowColor>().value;
+}
+
+void HillshadeLayer::setHillshadeShadowColor(const PropertyValue<Color>& value) {
+    if (value == getHillshadeShadowColor())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<HillshadeShadowColor>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void HillshadeLayer::setHillshadeShadowColorTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<HillshadeShadowColor>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions HillshadeLayer::getHillshadeShadowColorTransition() const {
+    return impl().paint.template get<HillshadeShadowColor>().options;
 }
 
 using namespace conversion;
 
 optional<Error> HillshadeLayer::setPaintProperty(const std::string& name, const Convertible& value) {
     enum class Property : uint8_t {
-        HillshadeIlluminationDirection,
-        HillshadeIlluminationAnchor,
-        HillshadeExaggeration,
-        HillshadeShadowColor,
-        HillshadeHighlightColor,
         HillshadeAccentColor,
-        HillshadeIlluminationDirectionTransition,
-        HillshadeIlluminationAnchorTransition,
-        HillshadeExaggerationTransition,
-        HillshadeShadowColorTransition,
-        HillshadeHighlightColorTransition,
+        HillshadeExaggeration,
+        HillshadeHighlightColor,
+        HillshadeIlluminationAnchor,
+        HillshadeIlluminationDirection,
+        HillshadeShadowColor,
         HillshadeAccentColorTransition,
+        HillshadeExaggerationTransition,
+        HillshadeHighlightColorTransition,
+        HillshadeIlluminationAnchorTransition,
+        HillshadeIlluminationDirectionTransition,
+        HillshadeShadowColorTransition,
     };
 
     MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        { "hillshade-illumination-direction", static_cast<uint8_t>(Property::HillshadeIlluminationDirection) },
-        { "hillshade-illumination-anchor", static_cast<uint8_t>(Property::HillshadeIlluminationAnchor) },
-        { "hillshade-exaggeration", static_cast<uint8_t>(Property::HillshadeExaggeration) },
-        { "hillshade-shadow-color", static_cast<uint8_t>(Property::HillshadeShadowColor) },
-        { "hillshade-highlight-color", static_cast<uint8_t>(Property::HillshadeHighlightColor) },
         { "hillshade-accent-color", static_cast<uint8_t>(Property::HillshadeAccentColor) },
-        { "hillshade-illumination-direction-transition", static_cast<uint8_t>(Property::HillshadeIlluminationDirectionTransition) },
-        { "hillshade-illumination-anchor-transition", static_cast<uint8_t>(Property::HillshadeIlluminationAnchorTransition) },
+        { "hillshade-exaggeration", static_cast<uint8_t>(Property::HillshadeExaggeration) },
+        { "hillshade-highlight-color", static_cast<uint8_t>(Property::HillshadeHighlightColor) },
+        { "hillshade-illumination-anchor", static_cast<uint8_t>(Property::HillshadeIlluminationAnchor) },
+        { "hillshade-illumination-direction", static_cast<uint8_t>(Property::HillshadeIlluminationDirection) },
+        { "hillshade-shadow-color", static_cast<uint8_t>(Property::HillshadeShadowColor) },
+        { "hillshade-accent-color-transition", static_cast<uint8_t>(Property::HillshadeAccentColorTransition) },
         { "hillshade-exaggeration-transition", static_cast<uint8_t>(Property::HillshadeExaggerationTransition) },
-        { "hillshade-shadow-color-transition", static_cast<uint8_t>(Property::HillshadeShadowColorTransition) },
         { "hillshade-highlight-color-transition", static_cast<uint8_t>(Property::HillshadeHighlightColorTransition) },
-        { "hillshade-accent-color-transition", static_cast<uint8_t>(Property::HillshadeAccentColorTransition) }
+        { "hillshade-illumination-anchor-transition", static_cast<uint8_t>(Property::HillshadeIlluminationAnchorTransition) },
+        { "hillshade-illumination-direction-transition", static_cast<uint8_t>(Property::HillshadeIlluminationDirectionTransition) },
+        { "hillshade-shadow-color-transition", static_cast<uint8_t>(Property::HillshadeShadowColorTransition) }
     });
 
     const auto it = properties.find(name.c_str());
@@ -266,20 +266,44 @@ optional<Error> HillshadeLayer::setPaintProperty(const std::string& name, const 
     auto property = static_cast<Property>(it->second);
 
         
-    if (property == Property::HillshadeIlluminationDirection || property == Property::HillshadeExaggeration) {
+    if (property == Property::HillshadeAccentColor || property == Property::HillshadeHighlightColor || property == Property::HillshadeShadowColor) {
+        Error error;
+        optional<PropertyValue<Color>> typedValue = convert<PropertyValue<Color>>(value, error, false, false);
+        if (!typedValue) {
+            return error;
+        }
+        
+        if (property == Property::HillshadeAccentColor) {
+            setHillshadeAccentColor(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::HillshadeHighlightColor) {
+            setHillshadeHighlightColor(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::HillshadeShadowColor) {
+            setHillshadeShadowColor(*typedValue);
+            return nullopt;
+        }
+        
+    }
+    
+    if (property == Property::HillshadeExaggeration || property == Property::HillshadeIlluminationDirection) {
         Error error;
         optional<PropertyValue<float>> typedValue = convert<PropertyValue<float>>(value, error, false, false);
         if (!typedValue) {
             return error;
         }
         
-        if (property == Property::HillshadeIlluminationDirection) {
-            setHillshadeIlluminationDirection(*typedValue);
+        if (property == Property::HillshadeExaggeration) {
+            setHillshadeExaggeration(*typedValue);
             return nullopt;
         }
         
-        if (property == Property::HillshadeExaggeration) {
-            setHillshadeExaggeration(*typedValue);
+        if (property == Property::HillshadeIlluminationDirection) {
+            setHillshadeIlluminationDirection(*typedValue);
             return nullopt;
         }
         
@@ -297,30 +321,6 @@ optional<Error> HillshadeLayer::setPaintProperty(const std::string& name, const 
         
     }
     
-    if (property == Property::HillshadeShadowColor || property == Property::HillshadeHighlightColor || property == Property::HillshadeAccentColor) {
-        Error error;
-        optional<PropertyValue<Color>> typedValue = convert<PropertyValue<Color>>(value, error, false, false);
-        if (!typedValue) {
-            return error;
-        }
-        
-        if (property == Property::HillshadeShadowColor) {
-            setHillshadeShadowColor(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::HillshadeHighlightColor) {
-            setHillshadeHighlightColor(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::HillshadeAccentColor) {
-            setHillshadeAccentColor(*typedValue);
-            return nullopt;
-        }
-        
-    }
-    
 
     Error error;
     optional<TransitionOptions> transition = convert<TransitionOptions>(value, error);
@@ -328,13 +328,8 @@ optional<Error> HillshadeLayer::setPaintProperty(const std::string& name, const 
         return error;
     }
     
-    if (property == Property::HillshadeIlluminationDirectionTransition) {
-        setHillshadeIlluminationDirectionTransition(*transition);
-        return nullopt;
-    }
-    
-    if (property == Property::HillshadeIlluminationAnchorTransition) {
-        setHillshadeIlluminationAnchorTransition(*transition);
+    if (property == Property::HillshadeAccentColorTransition) {
+        setHillshadeAccentColorTransition(*transition);
         return nullopt;
     }
     
@@ -343,18 +338,23 @@ optional<Error> HillshadeLayer::setPaintProperty(const std::string& name, const 
         return nullopt;
     }
     
-    if (property == Property::HillshadeShadowColorTransition) {
-        setHillshadeShadowColorTransition(*transition);
-        return nullopt;
-    }
-    
     if (property == Property::HillshadeHighlightColorTransition) {
         setHillshadeHighlightColorTransition(*transition);
         return nullopt;
     }
     
-    if (property == Property::HillshadeAccentColorTransition) {
-        setHillshadeAccentColorTransition(*transition);
+    if (property == Property::HillshadeIlluminationAnchorTransition) {
+        setHillshadeIlluminationAnchorTransition(*transition);
+        return nullopt;
+    }
+    
+    if (property == Property::HillshadeIlluminationDirectionTransition) {
+        setHillshadeIlluminationDirectionTransition(*transition);
+        return nullopt;
+    }
+    
+    if (property == Property::HillshadeShadowColorTransition) {
+        setHillshadeShadowColorTransition(*transition);
         return nullopt;
     }
     

--- a/src/mbgl/style/layers/hillshade_layer_properties.hpp
+++ b/src/mbgl/style/layers/hillshade_layer_properties.hpp
@@ -14,37 +14,37 @@
 namespace mbgl {
 namespace style {
 
-struct HillshadeIlluminationDirection : PaintProperty<float> {
-    static float defaultValue() { return 335; }
-};
-
-struct HillshadeIlluminationAnchor : PaintProperty<HillshadeIlluminationAnchorType> {
-    static HillshadeIlluminationAnchorType defaultValue() { return HillshadeIlluminationAnchorType::Viewport; }
+struct HillshadeAccentColor : PaintProperty<Color> {
+    static Color defaultValue() { return Color::black(); }
 };
 
 struct HillshadeExaggeration : PaintProperty<float> {
     static float defaultValue() { return 0.5; }
 };
 
-struct HillshadeShadowColor : PaintProperty<Color> {
-    static Color defaultValue() { return Color::black(); }
-};
-
 struct HillshadeHighlightColor : PaintProperty<Color> {
     static Color defaultValue() { return Color::white(); }
 };
 
-struct HillshadeAccentColor : PaintProperty<Color> {
+struct HillshadeIlluminationAnchor : PaintProperty<HillshadeIlluminationAnchorType> {
+    static HillshadeIlluminationAnchorType defaultValue() { return HillshadeIlluminationAnchorType::Viewport; }
+};
+
+struct HillshadeIlluminationDirection : PaintProperty<float> {
+    static float defaultValue() { return 335; }
+};
+
+struct HillshadeShadowColor : PaintProperty<Color> {
     static Color defaultValue() { return Color::black(); }
 };
 
 class HillshadePaintProperties : public Properties<
-    HillshadeIlluminationDirection,
-    HillshadeIlluminationAnchor,
+    HillshadeAccentColor,
     HillshadeExaggeration,
-    HillshadeShadowColor,
     HillshadeHighlightColor,
-    HillshadeAccentColor
+    HillshadeIlluminationAnchor,
+    HillshadeIlluminationDirection,
+    HillshadeShadowColor
 > {};
 
 class HillshadeLayerProperties final : public LayerProperties {

--- a/src/mbgl/style/layers/layer_properties.hpp.ejs
+++ b/src/mbgl/style/layers/layer_properties.hpp.ejs
@@ -33,19 +33,15 @@ struct <%- camelize(property.name) %> : ColorRampProperty {
 <%   } else { -%>
 struct <%- camelize(property.name) %> : <%- paintPropertyType(property, type) %> {
     static <%- evaluatedType(property) %> defaultValue() { return <%- defaultValue(property) %>; }
+<% if (property.name === 'line-floor-width') { -%>
+    using EvaluatorType = DataDrivenPropertyEvaluator<float, true>;
+<% } -%>
 <% if (isOverridable(property)) { -%>
     static constexpr const char *name() { return "<%- property.name %>"; }
     static constexpr auto expressionType() { return expression::type::<%- expressionType(property) %>{}; };
     template<typename T> static bool hasOverride(const T& t) { return !!t.<%- camelizeWithLeadingLowercase(property.name) %>; };
 <% } -%>
 };
-<% if (property.name === 'line-width') { -%>
-
-struct LineFloorWidth : DataDrivenPaintProperty<float, attributes::floorwidth, uniforms::floorwidth> {
-    using EvaluatorType = DataDrivenPropertyEvaluator<float, true>;
-    static float defaultValue() { return 1.0f; }
-};
-<% } -%>
 <%   } -%>
 
 <% } -%>
@@ -61,9 +57,6 @@ class <%- camelize(type) %>LayoutProperties : public Properties<
 class <%- camelize(type) %>PaintProperties : public Properties<
 <% for (const property of paintProperties.slice(0, -1)) { -%>
     <%- camelize(property.name) %>,
-<% if (property.name === 'line-width') { -%>
-    LineFloorWidth,
-<% } -%>
 <% } -%>
     <%- camelize(paintProperties.slice(-1)[0].name) %>
 > {};

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -128,31 +128,31 @@ void LineLayer::setLineRoundLimit(const PropertyValue<float>& value) {
 
 // Paint properties
 
-PropertyValue<float> LineLayer::getDefaultLineOpacity() {
-    return { 1 };
+PropertyValue<float> LineLayer::getDefaultLineBlur() {
+    return { 0 };
 }
 
-const PropertyValue<float>& LineLayer::getLineOpacity() const {
-    return impl().paint.template get<LineOpacity>().value;
+const PropertyValue<float>& LineLayer::getLineBlur() const {
+    return impl().paint.template get<LineBlur>().value;
 }
 
-void LineLayer::setLineOpacity(const PropertyValue<float>& value) {
-    if (value == getLineOpacity())
+void LineLayer::setLineBlur(const PropertyValue<float>& value) {
+    if (value == getLineBlur())
         return;
     auto impl_ = mutableImpl();
-    impl_->paint.template get<LineOpacity>().value = value;
+    impl_->paint.template get<LineBlur>().value = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
 
-void LineLayer::setLineOpacityTransition(const TransitionOptions& options) {
+void LineLayer::setLineBlurTransition(const TransitionOptions& options) {
     auto impl_ = mutableImpl();
-    impl_->paint.template get<LineOpacity>().options = options;
+    impl_->paint.template get<LineBlur>().options = options;
     baseImpl = std::move(impl_);
 }
 
-TransitionOptions LineLayer::getLineOpacityTransition() const {
-    return impl().paint.template get<LineOpacity>().options;
+TransitionOptions LineLayer::getLineBlurTransition() const {
+    return impl().paint.template get<LineBlur>().options;
 }
 
 PropertyValue<Color> LineLayer::getDefaultLineColor() {
@@ -180,6 +180,168 @@ void LineLayer::setLineColorTransition(const TransitionOptions& options) {
 
 TransitionOptions LineLayer::getLineColorTransition() const {
     return impl().paint.template get<LineColor>().options;
+}
+
+PropertyValue<std::vector<float>> LineLayer::getDefaultLineDasharray() {
+    return { {  } };
+}
+
+const PropertyValue<std::vector<float>>& LineLayer::getLineDasharray() const {
+    return impl().paint.template get<LineDasharray>().value;
+}
+
+void LineLayer::setLineDasharray(const PropertyValue<std::vector<float>>& value) {
+    if (value == getLineDasharray())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<LineDasharray>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void LineLayer::setLineDasharrayTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<LineDasharray>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions LineLayer::getLineDasharrayTransition() const {
+    return impl().paint.template get<LineDasharray>().options;
+}
+
+PropertyValue<float> LineLayer::getDefaultLineGapWidth() {
+    return { 0 };
+}
+
+const PropertyValue<float>& LineLayer::getLineGapWidth() const {
+    return impl().paint.template get<LineGapWidth>().value;
+}
+
+void LineLayer::setLineGapWidth(const PropertyValue<float>& value) {
+    if (value == getLineGapWidth())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<LineGapWidth>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void LineLayer::setLineGapWidthTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<LineGapWidth>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions LineLayer::getLineGapWidthTransition() const {
+    return impl().paint.template get<LineGapWidth>().options;
+}
+
+ColorRampPropertyValue LineLayer::getDefaultLineGradient() {
+    return { {} };
+}
+
+const ColorRampPropertyValue& LineLayer::getLineGradient() const {
+    return impl().paint.template get<LineGradient>().value;
+}
+
+void LineLayer::setLineGradient(const ColorRampPropertyValue& value) {
+    if (value == getLineGradient())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<LineGradient>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void LineLayer::setLineGradientTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<LineGradient>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions LineLayer::getLineGradientTransition() const {
+    return impl().paint.template get<LineGradient>().options;
+}
+
+PropertyValue<float> LineLayer::getDefaultLineOffset() {
+    return { 0 };
+}
+
+const PropertyValue<float>& LineLayer::getLineOffset() const {
+    return impl().paint.template get<LineOffset>().value;
+}
+
+void LineLayer::setLineOffset(const PropertyValue<float>& value) {
+    if (value == getLineOffset())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<LineOffset>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void LineLayer::setLineOffsetTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<LineOffset>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions LineLayer::getLineOffsetTransition() const {
+    return impl().paint.template get<LineOffset>().options;
+}
+
+PropertyValue<float> LineLayer::getDefaultLineOpacity() {
+    return { 1 };
+}
+
+const PropertyValue<float>& LineLayer::getLineOpacity() const {
+    return impl().paint.template get<LineOpacity>().value;
+}
+
+void LineLayer::setLineOpacity(const PropertyValue<float>& value) {
+    if (value == getLineOpacity())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<LineOpacity>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void LineLayer::setLineOpacityTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<LineOpacity>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions LineLayer::getLineOpacityTransition() const {
+    return impl().paint.template get<LineOpacity>().options;
+}
+
+PropertyValue<std::string> LineLayer::getDefaultLinePattern() {
+    return { "" };
+}
+
+const PropertyValue<std::string>& LineLayer::getLinePattern() const {
+    return impl().paint.template get<LinePattern>().value;
+}
+
+void LineLayer::setLinePattern(const PropertyValue<std::string>& value) {
+    if (value == getLinePattern())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<LinePattern>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void LineLayer::setLinePatternTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<LinePattern>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions LineLayer::getLinePatternTransition() const {
+    return impl().paint.template get<LinePattern>().options;
 }
 
 PropertyValue<std::array<float, 2>> LineLayer::getDefaultLineTranslate() {
@@ -264,219 +426,57 @@ TransitionOptions LineLayer::getLineWidthTransition() const {
     return impl().paint.template get<LineWidth>().options;
 }
 
-PropertyValue<float> LineLayer::getDefaultLineGapWidth() {
-    return { 0 };
-}
-
-const PropertyValue<float>& LineLayer::getLineGapWidth() const {
-    return impl().paint.template get<LineGapWidth>().value;
-}
-
-void LineLayer::setLineGapWidth(const PropertyValue<float>& value) {
-    if (value == getLineGapWidth())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<LineGapWidth>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void LineLayer::setLineGapWidthTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<LineGapWidth>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions LineLayer::getLineGapWidthTransition() const {
-    return impl().paint.template get<LineGapWidth>().options;
-}
-
-PropertyValue<float> LineLayer::getDefaultLineOffset() {
-    return { 0 };
-}
-
-const PropertyValue<float>& LineLayer::getLineOffset() const {
-    return impl().paint.template get<LineOffset>().value;
-}
-
-void LineLayer::setLineOffset(const PropertyValue<float>& value) {
-    if (value == getLineOffset())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<LineOffset>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void LineLayer::setLineOffsetTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<LineOffset>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions LineLayer::getLineOffsetTransition() const {
-    return impl().paint.template get<LineOffset>().options;
-}
-
-PropertyValue<float> LineLayer::getDefaultLineBlur() {
-    return { 0 };
-}
-
-const PropertyValue<float>& LineLayer::getLineBlur() const {
-    return impl().paint.template get<LineBlur>().value;
-}
-
-void LineLayer::setLineBlur(const PropertyValue<float>& value) {
-    if (value == getLineBlur())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<LineBlur>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void LineLayer::setLineBlurTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<LineBlur>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions LineLayer::getLineBlurTransition() const {
-    return impl().paint.template get<LineBlur>().options;
-}
-
-PropertyValue<std::vector<float>> LineLayer::getDefaultLineDasharray() {
-    return { {  } };
-}
-
-const PropertyValue<std::vector<float>>& LineLayer::getLineDasharray() const {
-    return impl().paint.template get<LineDasharray>().value;
-}
-
-void LineLayer::setLineDasharray(const PropertyValue<std::vector<float>>& value) {
-    if (value == getLineDasharray())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<LineDasharray>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void LineLayer::setLineDasharrayTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<LineDasharray>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions LineLayer::getLineDasharrayTransition() const {
-    return impl().paint.template get<LineDasharray>().options;
-}
-
-PropertyValue<std::string> LineLayer::getDefaultLinePattern() {
-    return { "" };
-}
-
-const PropertyValue<std::string>& LineLayer::getLinePattern() const {
-    return impl().paint.template get<LinePattern>().value;
-}
-
-void LineLayer::setLinePattern(const PropertyValue<std::string>& value) {
-    if (value == getLinePattern())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<LinePattern>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void LineLayer::setLinePatternTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<LinePattern>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions LineLayer::getLinePatternTransition() const {
-    return impl().paint.template get<LinePattern>().options;
-}
-
-ColorRampPropertyValue LineLayer::getDefaultLineGradient() {
-    return { {} };
-}
-
-const ColorRampPropertyValue& LineLayer::getLineGradient() const {
-    return impl().paint.template get<LineGradient>().value;
-}
-
-void LineLayer::setLineGradient(const ColorRampPropertyValue& value) {
-    if (value == getLineGradient())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<LineGradient>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void LineLayer::setLineGradientTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<LineGradient>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions LineLayer::getLineGradientTransition() const {
-    return impl().paint.template get<LineGradient>().options;
-}
-
 using namespace conversion;
 
 optional<Error> LineLayer::setPaintProperty(const std::string& name, const Convertible& value) {
     enum class Property : uint8_t {
-        LineOpacity,
+        LineBlur,
         LineColor,
+        LineDasharray,
+        LineGapWidth,
+        LineGradient,
+        LineOffset,
+        LineOpacity,
+        LinePattern,
         LineTranslate,
         LineTranslateAnchor,
         LineWidth,
-        LineGapWidth,
-        LineOffset,
-        LineBlur,
-        LineDasharray,
-        LinePattern,
-        LineGradient,
-        LineOpacityTransition,
+        LineBlurTransition,
         LineColorTransition,
+        LineDasharrayTransition,
+        LineGapWidthTransition,
+        LineGradientTransition,
+        LineOffsetTransition,
+        LineOpacityTransition,
+        LinePatternTransition,
         LineTranslateTransition,
         LineTranslateAnchorTransition,
         LineWidthTransition,
-        LineGapWidthTransition,
-        LineOffsetTransition,
-        LineBlurTransition,
-        LineDasharrayTransition,
-        LinePatternTransition,
-        LineGradientTransition,
     };
 
     MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        { "line-opacity", static_cast<uint8_t>(Property::LineOpacity) },
+        { "line-blur", static_cast<uint8_t>(Property::LineBlur) },
         { "line-color", static_cast<uint8_t>(Property::LineColor) },
+        { "line-dasharray", static_cast<uint8_t>(Property::LineDasharray) },
+        { "line-gap-width", static_cast<uint8_t>(Property::LineGapWidth) },
+        { "line-gradient", static_cast<uint8_t>(Property::LineGradient) },
+        { "line-offset", static_cast<uint8_t>(Property::LineOffset) },
+        { "line-opacity", static_cast<uint8_t>(Property::LineOpacity) },
+        { "line-pattern", static_cast<uint8_t>(Property::LinePattern) },
         { "line-translate", static_cast<uint8_t>(Property::LineTranslate) },
         { "line-translate-anchor", static_cast<uint8_t>(Property::LineTranslateAnchor) },
         { "line-width", static_cast<uint8_t>(Property::LineWidth) },
-        { "line-gap-width", static_cast<uint8_t>(Property::LineGapWidth) },
-        { "line-offset", static_cast<uint8_t>(Property::LineOffset) },
-        { "line-blur", static_cast<uint8_t>(Property::LineBlur) },
-        { "line-dasharray", static_cast<uint8_t>(Property::LineDasharray) },
-        { "line-pattern", static_cast<uint8_t>(Property::LinePattern) },
-        { "line-gradient", static_cast<uint8_t>(Property::LineGradient) },
-        { "line-opacity-transition", static_cast<uint8_t>(Property::LineOpacityTransition) },
+        { "line-blur-transition", static_cast<uint8_t>(Property::LineBlurTransition) },
         { "line-color-transition", static_cast<uint8_t>(Property::LineColorTransition) },
+        { "line-dasharray-transition", static_cast<uint8_t>(Property::LineDasharrayTransition) },
+        { "line-gap-width-transition", static_cast<uint8_t>(Property::LineGapWidthTransition) },
+        { "line-gradient-transition", static_cast<uint8_t>(Property::LineGradientTransition) },
+        { "line-offset-transition", static_cast<uint8_t>(Property::LineOffsetTransition) },
+        { "line-opacity-transition", static_cast<uint8_t>(Property::LineOpacityTransition) },
+        { "line-pattern-transition", static_cast<uint8_t>(Property::LinePatternTransition) },
         { "line-translate-transition", static_cast<uint8_t>(Property::LineTranslateTransition) },
         { "line-translate-anchor-transition", static_cast<uint8_t>(Property::LineTranslateAnchorTransition) },
-        { "line-width-transition", static_cast<uint8_t>(Property::LineWidthTransition) },
-        { "line-gap-width-transition", static_cast<uint8_t>(Property::LineGapWidthTransition) },
-        { "line-offset-transition", static_cast<uint8_t>(Property::LineOffsetTransition) },
-        { "line-blur-transition", static_cast<uint8_t>(Property::LineBlurTransition) },
-        { "line-dasharray-transition", static_cast<uint8_t>(Property::LineDasharrayTransition) },
-        { "line-pattern-transition", static_cast<uint8_t>(Property::LinePatternTransition) },
-        { "line-gradient-transition", static_cast<uint8_t>(Property::LineGradientTransition) }
+        { "line-width-transition", static_cast<uint8_t>(Property::LineWidthTransition) }
     });
 
     const auto it = properties.find(name.c_str());
@@ -487,20 +487,15 @@ optional<Error> LineLayer::setPaintProperty(const std::string& name, const Conve
     auto property = static_cast<Property>(it->second);
 
         
-    if (property == Property::LineOpacity || property == Property::LineWidth || property == Property::LineGapWidth || property == Property::LineOffset || property == Property::LineBlur) {
+    if (property == Property::LineBlur || property == Property::LineGapWidth || property == Property::LineOffset || property == Property::LineOpacity || property == Property::LineWidth) {
         Error error;
         optional<PropertyValue<float>> typedValue = convert<PropertyValue<float>>(value, error, true, false);
         if (!typedValue) {
             return error;
         }
         
-        if (property == Property::LineOpacity) {
-            setLineOpacity(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::LineWidth) {
-            setLineWidth(*typedValue);
+        if (property == Property::LineBlur) {
+            setLineBlur(*typedValue);
             return nullopt;
         }
         
@@ -514,8 +509,13 @@ optional<Error> LineLayer::setPaintProperty(const std::string& name, const Conve
             return nullopt;
         }
         
-        if (property == Property::LineBlur) {
-            setLineBlur(*typedValue);
+        if (property == Property::LineOpacity) {
+            setLineOpacity(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::LineWidth) {
+            setLineWidth(*typedValue);
             return nullopt;
         }
         
@@ -529,6 +529,42 @@ optional<Error> LineLayer::setPaintProperty(const std::string& name, const Conve
         }
         
         setLineColor(*typedValue);
+        return nullopt;
+        
+    }
+    
+    if (property == Property::LineDasharray) {
+        Error error;
+        optional<PropertyValue<std::vector<float>>> typedValue = convert<PropertyValue<std::vector<float>>>(value, error, false, false);
+        if (!typedValue) {
+            return error;
+        }
+        
+        setLineDasharray(*typedValue);
+        return nullopt;
+        
+    }
+    
+    if (property == Property::LineGradient) {
+        Error error;
+        optional<ColorRampPropertyValue> typedValue = convert<ColorRampPropertyValue>(value, error, false, false);
+        if (!typedValue) {
+            return error;
+        }
+        
+        setLineGradient(*typedValue);
+        return nullopt;
+        
+    }
+    
+    if (property == Property::LinePattern) {
+        Error error;
+        optional<PropertyValue<std::string>> typedValue = convert<PropertyValue<std::string>>(value, error, true, false);
+        if (!typedValue) {
+            return error;
+        }
+        
+        setLinePattern(*typedValue);
         return nullopt;
         
     }
@@ -557,42 +593,6 @@ optional<Error> LineLayer::setPaintProperty(const std::string& name, const Conve
         
     }
     
-    if (property == Property::LineDasharray) {
-        Error error;
-        optional<PropertyValue<std::vector<float>>> typedValue = convert<PropertyValue<std::vector<float>>>(value, error, false, false);
-        if (!typedValue) {
-            return error;
-        }
-        
-        setLineDasharray(*typedValue);
-        return nullopt;
-        
-    }
-    
-    if (property == Property::LinePattern) {
-        Error error;
-        optional<PropertyValue<std::string>> typedValue = convert<PropertyValue<std::string>>(value, error, true, false);
-        if (!typedValue) {
-            return error;
-        }
-        
-        setLinePattern(*typedValue);
-        return nullopt;
-        
-    }
-    
-    if (property == Property::LineGradient) {
-        Error error;
-        optional<ColorRampPropertyValue> typedValue = convert<ColorRampPropertyValue>(value, error, false, false);
-        if (!typedValue) {
-            return error;
-        }
-        
-        setLineGradient(*typedValue);
-        return nullopt;
-        
-    }
-    
 
     Error error;
     optional<TransitionOptions> transition = convert<TransitionOptions>(value, error);
@@ -600,13 +600,43 @@ optional<Error> LineLayer::setPaintProperty(const std::string& name, const Conve
         return error;
     }
     
-    if (property == Property::LineOpacityTransition) {
-        setLineOpacityTransition(*transition);
+    if (property == Property::LineBlurTransition) {
+        setLineBlurTransition(*transition);
         return nullopt;
     }
     
     if (property == Property::LineColorTransition) {
         setLineColorTransition(*transition);
+        return nullopt;
+    }
+    
+    if (property == Property::LineDasharrayTransition) {
+        setLineDasharrayTransition(*transition);
+        return nullopt;
+    }
+    
+    if (property == Property::LineGapWidthTransition) {
+        setLineGapWidthTransition(*transition);
+        return nullopt;
+    }
+    
+    if (property == Property::LineGradientTransition) {
+        setLineGradientTransition(*transition);
+        return nullopt;
+    }
+    
+    if (property == Property::LineOffsetTransition) {
+        setLineOffsetTransition(*transition);
+        return nullopt;
+    }
+    
+    if (property == Property::LineOpacityTransition) {
+        setLineOpacityTransition(*transition);
+        return nullopt;
+    }
+    
+    if (property == Property::LinePatternTransition) {
+        setLinePatternTransition(*transition);
         return nullopt;
     }
     
@@ -622,36 +652,6 @@ optional<Error> LineLayer::setPaintProperty(const std::string& name, const Conve
     
     if (property == Property::LineWidthTransition) {
         setLineWidthTransition(*transition);
-        return nullopt;
-    }
-    
-    if (property == Property::LineGapWidthTransition) {
-        setLineGapWidthTransition(*transition);
-        return nullopt;
-    }
-    
-    if (property == Property::LineOffsetTransition) {
-        setLineOffsetTransition(*transition);
-        return nullopt;
-    }
-    
-    if (property == Property::LineBlurTransition) {
-        setLineBlurTransition(*transition);
-        return nullopt;
-    }
-    
-    if (property == Property::LineDasharrayTransition) {
-        setLineDasharrayTransition(*transition);
-        return nullopt;
-    }
-    
-    if (property == Property::LinePatternTransition) {
-        setLinePatternTransition(*transition);
-        return nullopt;
-    }
-    
-    if (property == Property::LineGradientTransition) {
-        setLineGradientTransition(*transition);
         return nullopt;
     }
     

--- a/src/mbgl/style/layers/line_layer_properties.hpp
+++ b/src/mbgl/style/layers/line_layer_properties.hpp
@@ -34,12 +34,40 @@ struct LineRoundLimit : LayoutProperty<float> {
     static float defaultValue() { return 1; }
 };
 
-struct LineOpacity : DataDrivenPaintProperty<float, attributes::opacity, uniforms::opacity> {
-    static float defaultValue() { return 1; }
+struct LineBlur : DataDrivenPaintProperty<float, attributes::blur, uniforms::blur> {
+    static float defaultValue() { return 0; }
 };
 
 struct LineColor : DataDrivenPaintProperty<Color, attributes::color, uniforms::color> {
     static Color defaultValue() { return Color::black(); }
+};
+
+struct LineDasharray : CrossFadedPaintProperty<std::vector<float>> {
+    static std::vector<float> defaultValue() { return {  }; }
+};
+
+struct LineFloorWidth : DataDrivenPaintProperty<float, attributes::floorwidth, uniforms::floorwidth> {
+    static float defaultValue() { return 1; }
+    using EvaluatorType = DataDrivenPropertyEvaluator<float, true>;
+};
+
+struct LineGapWidth : DataDrivenPaintProperty<float, attributes::gapwidth, uniforms::gapwidth> {
+    static float defaultValue() { return 0; }
+};
+
+struct LineGradient : ColorRampProperty {
+};
+
+struct LineOffset : DataDrivenPaintProperty<float, attributes::offset, uniforms::offset> {
+    static float defaultValue() { return 0; }
+};
+
+struct LineOpacity : DataDrivenPaintProperty<float, attributes::opacity, uniforms::opacity> {
+    static float defaultValue() { return 1; }
+};
+
+struct LinePattern : CrossFadedDataDrivenPaintProperty<std::string, attributes::pattern_to, uniforms::pattern_to, attributes::pattern_from, uniforms::pattern_from> {
+    static std::string defaultValue() { return ""; }
 };
 
 struct LineTranslate : PaintProperty<std::array<float, 2>> {
@@ -54,34 +82,6 @@ struct LineWidth : DataDrivenPaintProperty<float, attributes::width, uniforms::w
     static float defaultValue() { return 1; }
 };
 
-struct LineGapWidth : DataDrivenPaintProperty<float, attributes::gapwidth, uniforms::gapwidth> {
-    static float defaultValue() { return 0; }
-};
-
-struct LineOffset : DataDrivenPaintProperty<float, attributes::offset, uniforms::offset> {
-    static float defaultValue() { return 0; }
-};
-
-struct LineBlur : DataDrivenPaintProperty<float, attributes::blur, uniforms::blur> {
-    static float defaultValue() { return 0; }
-};
-
-struct LineDasharray : CrossFadedPaintProperty<std::vector<float>> {
-    static std::vector<float> defaultValue() { return {  }; }
-};
-
-struct LinePattern : CrossFadedDataDrivenPaintProperty<std::string, attributes::pattern_to, uniforms::pattern_to, attributes::pattern_from, uniforms::pattern_from> {
-    static std::string defaultValue() { return ""; }
-};
-
-struct LineGradient : ColorRampProperty {
-};
-
-struct LineFloorWidth : DataDrivenPaintProperty<float, attributes::floorwidth, uniforms::floorwidth> {
-    static float defaultValue() { return 1; }
-    using EvaluatorType = DataDrivenPropertyEvaluator<float, true>;
-};
-
 class LineLayoutProperties : public Properties<
     LineCap,
     LineJoin,
@@ -90,18 +90,18 @@ class LineLayoutProperties : public Properties<
 > {};
 
 class LinePaintProperties : public Properties<
-    LineOpacity,
+    LineBlur,
     LineColor,
+    LineDasharray,
+    LineFloorWidth,
+    LineGapWidth,
+    LineGradient,
+    LineOffset,
+    LineOpacity,
+    LinePattern,
     LineTranslate,
     LineTranslateAnchor,
-    LineWidth,
-    LineGapWidth,
-    LineOffset,
-    LineBlur,
-    LineDasharray,
-    LinePattern,
-    LineGradient,
-    LineFloorWidth
+    LineWidth
 > {};
 
 class LineLayerProperties final : public LayerProperties {

--- a/src/mbgl/style/layers/line_layer_properties.hpp
+++ b/src/mbgl/style/layers/line_layer_properties.hpp
@@ -54,11 +54,6 @@ struct LineWidth : DataDrivenPaintProperty<float, attributes::width, uniforms::w
     static float defaultValue() { return 1; }
 };
 
-struct LineFloorWidth : DataDrivenPaintProperty<float, attributes::floorwidth, uniforms::floorwidth> {
-    using EvaluatorType = DataDrivenPropertyEvaluator<float, true>;
-    static float defaultValue() { return 1.0f; }
-};
-
 struct LineGapWidth : DataDrivenPaintProperty<float, attributes::gapwidth, uniforms::gapwidth> {
     static float defaultValue() { return 0; }
 };
@@ -82,6 +77,11 @@ struct LinePattern : CrossFadedDataDrivenPaintProperty<std::string, attributes::
 struct LineGradient : ColorRampProperty {
 };
 
+struct LineFloorWidth : DataDrivenPaintProperty<float, attributes::floorwidth, uniforms::floorwidth> {
+    static float defaultValue() { return 1; }
+    using EvaluatorType = DataDrivenPropertyEvaluator<float, true>;
+};
+
 class LineLayoutProperties : public Properties<
     LineCap,
     LineJoin,
@@ -95,13 +95,13 @@ class LinePaintProperties : public Properties<
     LineTranslate,
     LineTranslateAnchor,
     LineWidth,
-    LineFloorWidth,
     LineGapWidth,
     LineOffset,
     LineBlur,
     LineDasharray,
     LinePattern,
-    LineGradient
+    LineGradient,
+    LineFloorWidth
 > {};
 
 class LineLayerProperties final : public LayerProperties {

--- a/src/mbgl/style/layers/raster_layer.cpp
+++ b/src/mbgl/style/layers/raster_layer.cpp
@@ -63,58 +63,31 @@ void RasterLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffe
 
 // Paint properties
 
-PropertyValue<float> RasterLayer::getDefaultRasterOpacity() {
+PropertyValue<float> RasterLayer::getDefaultRasterBrightnessMax() {
     return { 1 };
 }
 
-const PropertyValue<float>& RasterLayer::getRasterOpacity() const {
-    return impl().paint.template get<RasterOpacity>().value;
+const PropertyValue<float>& RasterLayer::getRasterBrightnessMax() const {
+    return impl().paint.template get<RasterBrightnessMax>().value;
 }
 
-void RasterLayer::setRasterOpacity(const PropertyValue<float>& value) {
-    if (value == getRasterOpacity())
+void RasterLayer::setRasterBrightnessMax(const PropertyValue<float>& value) {
+    if (value == getRasterBrightnessMax())
         return;
     auto impl_ = mutableImpl();
-    impl_->paint.template get<RasterOpacity>().value = value;
+    impl_->paint.template get<RasterBrightnessMax>().value = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
 
-void RasterLayer::setRasterOpacityTransition(const TransitionOptions& options) {
+void RasterLayer::setRasterBrightnessMaxTransition(const TransitionOptions& options) {
     auto impl_ = mutableImpl();
-    impl_->paint.template get<RasterOpacity>().options = options;
+    impl_->paint.template get<RasterBrightnessMax>().options = options;
     baseImpl = std::move(impl_);
 }
 
-TransitionOptions RasterLayer::getRasterOpacityTransition() const {
-    return impl().paint.template get<RasterOpacity>().options;
-}
-
-PropertyValue<float> RasterLayer::getDefaultRasterHueRotate() {
-    return { 0 };
-}
-
-const PropertyValue<float>& RasterLayer::getRasterHueRotate() const {
-    return impl().paint.template get<RasterHueRotate>().value;
-}
-
-void RasterLayer::setRasterHueRotate(const PropertyValue<float>& value) {
-    if (value == getRasterHueRotate())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<RasterHueRotate>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void RasterLayer::setRasterHueRotateTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<RasterHueRotate>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions RasterLayer::getRasterHueRotateTransition() const {
-    return impl().paint.template get<RasterHueRotate>().options;
+TransitionOptions RasterLayer::getRasterBrightnessMaxTransition() const {
+    return impl().paint.template get<RasterBrightnessMax>().options;
 }
 
 PropertyValue<float> RasterLayer::getDefaultRasterBrightnessMin() {
@@ -144,60 +117,6 @@ TransitionOptions RasterLayer::getRasterBrightnessMinTransition() const {
     return impl().paint.template get<RasterBrightnessMin>().options;
 }
 
-PropertyValue<float> RasterLayer::getDefaultRasterBrightnessMax() {
-    return { 1 };
-}
-
-const PropertyValue<float>& RasterLayer::getRasterBrightnessMax() const {
-    return impl().paint.template get<RasterBrightnessMax>().value;
-}
-
-void RasterLayer::setRasterBrightnessMax(const PropertyValue<float>& value) {
-    if (value == getRasterBrightnessMax())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<RasterBrightnessMax>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void RasterLayer::setRasterBrightnessMaxTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<RasterBrightnessMax>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions RasterLayer::getRasterBrightnessMaxTransition() const {
-    return impl().paint.template get<RasterBrightnessMax>().options;
-}
-
-PropertyValue<float> RasterLayer::getDefaultRasterSaturation() {
-    return { 0 };
-}
-
-const PropertyValue<float>& RasterLayer::getRasterSaturation() const {
-    return impl().paint.template get<RasterSaturation>().value;
-}
-
-void RasterLayer::setRasterSaturation(const PropertyValue<float>& value) {
-    if (value == getRasterSaturation())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<RasterSaturation>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void RasterLayer::setRasterSaturationTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<RasterSaturation>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions RasterLayer::getRasterSaturationTransition() const {
-    return impl().paint.template get<RasterSaturation>().options;
-}
-
 PropertyValue<float> RasterLayer::getDefaultRasterContrast() {
     return { 0 };
 }
@@ -223,33 +142,6 @@ void RasterLayer::setRasterContrastTransition(const TransitionOptions& options) 
 
 TransitionOptions RasterLayer::getRasterContrastTransition() const {
     return impl().paint.template get<RasterContrast>().options;
-}
-
-PropertyValue<RasterResamplingType> RasterLayer::getDefaultRasterResampling() {
-    return { RasterResamplingType::Linear };
-}
-
-const PropertyValue<RasterResamplingType>& RasterLayer::getRasterResampling() const {
-    return impl().paint.template get<RasterResampling>().value;
-}
-
-void RasterLayer::setRasterResampling(const PropertyValue<RasterResamplingType>& value) {
-    if (value == getRasterResampling())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<RasterResampling>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void RasterLayer::setRasterResamplingTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<RasterResampling>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions RasterLayer::getRasterResamplingTransition() const {
-    return impl().paint.template get<RasterResampling>().options;
 }
 
 PropertyValue<float> RasterLayer::getDefaultRasterFadeDuration() {
@@ -279,45 +171,153 @@ TransitionOptions RasterLayer::getRasterFadeDurationTransition() const {
     return impl().paint.template get<RasterFadeDuration>().options;
 }
 
+PropertyValue<float> RasterLayer::getDefaultRasterHueRotate() {
+    return { 0 };
+}
+
+const PropertyValue<float>& RasterLayer::getRasterHueRotate() const {
+    return impl().paint.template get<RasterHueRotate>().value;
+}
+
+void RasterLayer::setRasterHueRotate(const PropertyValue<float>& value) {
+    if (value == getRasterHueRotate())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<RasterHueRotate>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void RasterLayer::setRasterHueRotateTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<RasterHueRotate>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions RasterLayer::getRasterHueRotateTransition() const {
+    return impl().paint.template get<RasterHueRotate>().options;
+}
+
+PropertyValue<float> RasterLayer::getDefaultRasterOpacity() {
+    return { 1 };
+}
+
+const PropertyValue<float>& RasterLayer::getRasterOpacity() const {
+    return impl().paint.template get<RasterOpacity>().value;
+}
+
+void RasterLayer::setRasterOpacity(const PropertyValue<float>& value) {
+    if (value == getRasterOpacity())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<RasterOpacity>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void RasterLayer::setRasterOpacityTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<RasterOpacity>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions RasterLayer::getRasterOpacityTransition() const {
+    return impl().paint.template get<RasterOpacity>().options;
+}
+
+PropertyValue<RasterResamplingType> RasterLayer::getDefaultRasterResampling() {
+    return { RasterResamplingType::Linear };
+}
+
+const PropertyValue<RasterResamplingType>& RasterLayer::getRasterResampling() const {
+    return impl().paint.template get<RasterResampling>().value;
+}
+
+void RasterLayer::setRasterResampling(const PropertyValue<RasterResamplingType>& value) {
+    if (value == getRasterResampling())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<RasterResampling>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void RasterLayer::setRasterResamplingTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<RasterResampling>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions RasterLayer::getRasterResamplingTransition() const {
+    return impl().paint.template get<RasterResampling>().options;
+}
+
+PropertyValue<float> RasterLayer::getDefaultRasterSaturation() {
+    return { 0 };
+}
+
+const PropertyValue<float>& RasterLayer::getRasterSaturation() const {
+    return impl().paint.template get<RasterSaturation>().value;
+}
+
+void RasterLayer::setRasterSaturation(const PropertyValue<float>& value) {
+    if (value == getRasterSaturation())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<RasterSaturation>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void RasterLayer::setRasterSaturationTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<RasterSaturation>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions RasterLayer::getRasterSaturationTransition() const {
+    return impl().paint.template get<RasterSaturation>().options;
+}
+
 using namespace conversion;
 
 optional<Error> RasterLayer::setPaintProperty(const std::string& name, const Convertible& value) {
     enum class Property : uint8_t {
-        RasterOpacity,
-        RasterHueRotate,
-        RasterBrightnessMin,
         RasterBrightnessMax,
-        RasterSaturation,
+        RasterBrightnessMin,
         RasterContrast,
-        RasterResampling,
         RasterFadeDuration,
-        RasterOpacityTransition,
-        RasterHueRotateTransition,
-        RasterBrightnessMinTransition,
+        RasterHueRotate,
+        RasterOpacity,
+        RasterResampling,
+        RasterSaturation,
         RasterBrightnessMaxTransition,
-        RasterSaturationTransition,
+        RasterBrightnessMinTransition,
         RasterContrastTransition,
-        RasterResamplingTransition,
         RasterFadeDurationTransition,
+        RasterHueRotateTransition,
+        RasterOpacityTransition,
+        RasterResamplingTransition,
+        RasterSaturationTransition,
     };
 
     MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        { "raster-opacity", static_cast<uint8_t>(Property::RasterOpacity) },
-        { "raster-hue-rotate", static_cast<uint8_t>(Property::RasterHueRotate) },
-        { "raster-brightness-min", static_cast<uint8_t>(Property::RasterBrightnessMin) },
         { "raster-brightness-max", static_cast<uint8_t>(Property::RasterBrightnessMax) },
-        { "raster-saturation", static_cast<uint8_t>(Property::RasterSaturation) },
+        { "raster-brightness-min", static_cast<uint8_t>(Property::RasterBrightnessMin) },
         { "raster-contrast", static_cast<uint8_t>(Property::RasterContrast) },
-        { "raster-resampling", static_cast<uint8_t>(Property::RasterResampling) },
         { "raster-fade-duration", static_cast<uint8_t>(Property::RasterFadeDuration) },
-        { "raster-opacity-transition", static_cast<uint8_t>(Property::RasterOpacityTransition) },
-        { "raster-hue-rotate-transition", static_cast<uint8_t>(Property::RasterHueRotateTransition) },
-        { "raster-brightness-min-transition", static_cast<uint8_t>(Property::RasterBrightnessMinTransition) },
+        { "raster-hue-rotate", static_cast<uint8_t>(Property::RasterHueRotate) },
+        { "raster-opacity", static_cast<uint8_t>(Property::RasterOpacity) },
+        { "raster-resampling", static_cast<uint8_t>(Property::RasterResampling) },
+        { "raster-saturation", static_cast<uint8_t>(Property::RasterSaturation) },
         { "raster-brightness-max-transition", static_cast<uint8_t>(Property::RasterBrightnessMaxTransition) },
-        { "raster-saturation-transition", static_cast<uint8_t>(Property::RasterSaturationTransition) },
+        { "raster-brightness-min-transition", static_cast<uint8_t>(Property::RasterBrightnessMinTransition) },
         { "raster-contrast-transition", static_cast<uint8_t>(Property::RasterContrastTransition) },
+        { "raster-fade-duration-transition", static_cast<uint8_t>(Property::RasterFadeDurationTransition) },
+        { "raster-hue-rotate-transition", static_cast<uint8_t>(Property::RasterHueRotateTransition) },
+        { "raster-opacity-transition", static_cast<uint8_t>(Property::RasterOpacityTransition) },
         { "raster-resampling-transition", static_cast<uint8_t>(Property::RasterResamplingTransition) },
-        { "raster-fade-duration-transition", static_cast<uint8_t>(Property::RasterFadeDurationTransition) }
+        { "raster-saturation-transition", static_cast<uint8_t>(Property::RasterSaturationTransition) }
     });
 
     const auto it = properties.find(name.c_str());
@@ -328,26 +328,11 @@ optional<Error> RasterLayer::setPaintProperty(const std::string& name, const Con
     auto property = static_cast<Property>(it->second);
 
         
-    if (property == Property::RasterOpacity || property == Property::RasterHueRotate || property == Property::RasterBrightnessMin || property == Property::RasterBrightnessMax || property == Property::RasterSaturation || property == Property::RasterContrast || property == Property::RasterFadeDuration) {
+    if (property == Property::RasterBrightnessMax || property == Property::RasterBrightnessMin || property == Property::RasterContrast || property == Property::RasterFadeDuration || property == Property::RasterHueRotate || property == Property::RasterOpacity || property == Property::RasterSaturation) {
         Error error;
         optional<PropertyValue<float>> typedValue = convert<PropertyValue<float>>(value, error, false, false);
         if (!typedValue) {
             return error;
-        }
-        
-        if (property == Property::RasterOpacity) {
-            setRasterOpacity(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::RasterHueRotate) {
-            setRasterHueRotate(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::RasterBrightnessMin) {
-            setRasterBrightnessMin(*typedValue);
-            return nullopt;
         }
         
         if (property == Property::RasterBrightnessMax) {
@@ -355,8 +340,8 @@ optional<Error> RasterLayer::setPaintProperty(const std::string& name, const Con
             return nullopt;
         }
         
-        if (property == Property::RasterSaturation) {
-            setRasterSaturation(*typedValue);
+        if (property == Property::RasterBrightnessMin) {
+            setRasterBrightnessMin(*typedValue);
             return nullopt;
         }
         
@@ -367,6 +352,21 @@ optional<Error> RasterLayer::setPaintProperty(const std::string& name, const Con
         
         if (property == Property::RasterFadeDuration) {
             setRasterFadeDuration(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::RasterHueRotate) {
+            setRasterHueRotate(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::RasterOpacity) {
+            setRasterOpacity(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::RasterSaturation) {
+            setRasterSaturation(*typedValue);
             return nullopt;
         }
         
@@ -391,13 +391,8 @@ optional<Error> RasterLayer::setPaintProperty(const std::string& name, const Con
         return error;
     }
     
-    if (property == Property::RasterOpacityTransition) {
-        setRasterOpacityTransition(*transition);
-        return nullopt;
-    }
-    
-    if (property == Property::RasterHueRotateTransition) {
-        setRasterHueRotateTransition(*transition);
+    if (property == Property::RasterBrightnessMaxTransition) {
+        setRasterBrightnessMaxTransition(*transition);
         return nullopt;
     }
     
@@ -406,18 +401,23 @@ optional<Error> RasterLayer::setPaintProperty(const std::string& name, const Con
         return nullopt;
     }
     
-    if (property == Property::RasterBrightnessMaxTransition) {
-        setRasterBrightnessMaxTransition(*transition);
-        return nullopt;
-    }
-    
-    if (property == Property::RasterSaturationTransition) {
-        setRasterSaturationTransition(*transition);
-        return nullopt;
-    }
-    
     if (property == Property::RasterContrastTransition) {
         setRasterContrastTransition(*transition);
+        return nullopt;
+    }
+    
+    if (property == Property::RasterFadeDurationTransition) {
+        setRasterFadeDurationTransition(*transition);
+        return nullopt;
+    }
+    
+    if (property == Property::RasterHueRotateTransition) {
+        setRasterHueRotateTransition(*transition);
+        return nullopt;
+    }
+    
+    if (property == Property::RasterOpacityTransition) {
+        setRasterOpacityTransition(*transition);
         return nullopt;
     }
     
@@ -426,8 +426,8 @@ optional<Error> RasterLayer::setPaintProperty(const std::string& name, const Con
         return nullopt;
     }
     
-    if (property == Property::RasterFadeDurationTransition) {
-        setRasterFadeDurationTransition(*transition);
+    if (property == Property::RasterSaturationTransition) {
+        setRasterSaturationTransition(*transition);
         return nullopt;
     }
     

--- a/src/mbgl/style/layers/raster_layer_properties.hpp
+++ b/src/mbgl/style/layers/raster_layer_properties.hpp
@@ -14,23 +14,11 @@
 namespace mbgl {
 namespace style {
 
-struct RasterOpacity : PaintProperty<float> {
-    static float defaultValue() { return 1; }
-};
-
-struct RasterHueRotate : PaintProperty<float> {
-    static float defaultValue() { return 0; }
-};
-
-struct RasterBrightnessMin : PaintProperty<float> {
-    static float defaultValue() { return 0; }
-};
-
 struct RasterBrightnessMax : PaintProperty<float> {
     static float defaultValue() { return 1; }
 };
 
-struct RasterSaturation : PaintProperty<float> {
+struct RasterBrightnessMin : PaintProperty<float> {
     static float defaultValue() { return 0; }
 };
 
@@ -38,23 +26,35 @@ struct RasterContrast : PaintProperty<float> {
     static float defaultValue() { return 0; }
 };
 
-struct RasterResampling : PaintProperty<RasterResamplingType> {
-    static RasterResamplingType defaultValue() { return RasterResamplingType::Linear; }
-};
-
 struct RasterFadeDuration : PaintProperty<float> {
     static float defaultValue() { return 300; }
 };
 
+struct RasterHueRotate : PaintProperty<float> {
+    static float defaultValue() { return 0; }
+};
+
+struct RasterOpacity : PaintProperty<float> {
+    static float defaultValue() { return 1; }
+};
+
+struct RasterResampling : PaintProperty<RasterResamplingType> {
+    static RasterResamplingType defaultValue() { return RasterResamplingType::Linear; }
+};
+
+struct RasterSaturation : PaintProperty<float> {
+    static float defaultValue() { return 0; }
+};
+
 class RasterPaintProperties : public Properties<
-    RasterOpacity,
-    RasterHueRotate,
-    RasterBrightnessMin,
     RasterBrightnessMax,
-    RasterSaturation,
+    RasterBrightnessMin,
     RasterContrast,
+    RasterFadeDuration,
+    RasterHueRotate,
+    RasterOpacity,
     RasterResampling,
-    RasterFadeDuration
+    RasterSaturation
 > {};
 
 class RasterLayerProperties final : public LayerProperties {

--- a/src/mbgl/style/layers/symbol_layer.cpp
+++ b/src/mbgl/style/layers/symbol_layer.cpp
@@ -61,86 +61,6 @@ void SymbolLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffe
 
 // Layout properties
 
-PropertyValue<SymbolPlacementType> SymbolLayer::getDefaultSymbolPlacement() {
-    return SymbolPlacement::defaultValue();
-}
-
-const PropertyValue<SymbolPlacementType>& SymbolLayer::getSymbolPlacement() const {
-    return impl().layout.get<SymbolPlacement>();
-}
-
-void SymbolLayer::setSymbolPlacement(const PropertyValue<SymbolPlacementType>& value) {
-    if (value == getSymbolPlacement())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->layout.get<SymbolPlacement>() = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-PropertyValue<float> SymbolLayer::getDefaultSymbolSpacing() {
-    return SymbolSpacing::defaultValue();
-}
-
-const PropertyValue<float>& SymbolLayer::getSymbolSpacing() const {
-    return impl().layout.get<SymbolSpacing>();
-}
-
-void SymbolLayer::setSymbolSpacing(const PropertyValue<float>& value) {
-    if (value == getSymbolSpacing())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->layout.get<SymbolSpacing>() = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-PropertyValue<bool> SymbolLayer::getDefaultSymbolAvoidEdges() {
-    return SymbolAvoidEdges::defaultValue();
-}
-
-const PropertyValue<bool>& SymbolLayer::getSymbolAvoidEdges() const {
-    return impl().layout.get<SymbolAvoidEdges>();
-}
-
-void SymbolLayer::setSymbolAvoidEdges(const PropertyValue<bool>& value) {
-    if (value == getSymbolAvoidEdges())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->layout.get<SymbolAvoidEdges>() = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-PropertyValue<float> SymbolLayer::getDefaultSymbolSortKey() {
-    return SymbolSortKey::defaultValue();
-}
-
-const PropertyValue<float>& SymbolLayer::getSymbolSortKey() const {
-    return impl().layout.get<SymbolSortKey>();
-}
-
-void SymbolLayer::setSymbolSortKey(const PropertyValue<float>& value) {
-    if (value == getSymbolSortKey())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->layout.get<SymbolSortKey>() = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-PropertyValue<SymbolZOrderType> SymbolLayer::getDefaultSymbolZOrder() {
-    return SymbolZOrder::defaultValue();
-}
-
-const PropertyValue<SymbolZOrderType>& SymbolLayer::getSymbolZOrder() const {
-    return impl().layout.get<SymbolZOrder>();
-}
-
-void SymbolLayer::setSymbolZOrder(const PropertyValue<SymbolZOrderType>& value) {
-    if (value == getSymbolZOrder())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->layout.get<SymbolZOrder>() = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
 PropertyValue<bool> SymbolLayer::getDefaultIconAllowOverlap() {
     return IconAllowOverlap::defaultValue();
 }
@@ -154,6 +74,22 @@ void SymbolLayer::setIconAllowOverlap(const PropertyValue<bool>& value) {
         return;
     auto impl_ = mutableImpl();
     impl_->layout.get<IconAllowOverlap>() = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+PropertyValue<SymbolAnchorType> SymbolLayer::getDefaultIconAnchor() {
+    return IconAnchor::defaultValue();
+}
+
+const PropertyValue<SymbolAnchorType>& SymbolLayer::getIconAnchor() const {
+    return impl().layout.get<IconAnchor>();
+}
+
+void SymbolLayer::setIconAnchor(const PropertyValue<SymbolAnchorType>& value) {
+    if (value == getIconAnchor())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->layout.get<IconAnchor>() = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
@@ -173,6 +109,54 @@ void SymbolLayer::setIconIgnorePlacement(const PropertyValue<bool>& value) {
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
+PropertyValue<std::string> SymbolLayer::getDefaultIconImage() {
+    return IconImage::defaultValue();
+}
+
+const PropertyValue<std::string>& SymbolLayer::getIconImage() const {
+    return impl().layout.get<IconImage>();
+}
+
+void SymbolLayer::setIconImage(const PropertyValue<std::string>& value) {
+    if (value == getIconImage())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->layout.get<IconImage>() = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+PropertyValue<bool> SymbolLayer::getDefaultIconKeepUpright() {
+    return IconKeepUpright::defaultValue();
+}
+
+const PropertyValue<bool>& SymbolLayer::getIconKeepUpright() const {
+    return impl().layout.get<IconKeepUpright>();
+}
+
+void SymbolLayer::setIconKeepUpright(const PropertyValue<bool>& value) {
+    if (value == getIconKeepUpright())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->layout.get<IconKeepUpright>() = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+PropertyValue<std::array<float, 2>> SymbolLayer::getDefaultIconOffset() {
+    return IconOffset::defaultValue();
+}
+
+const PropertyValue<std::array<float, 2>>& SymbolLayer::getIconOffset() const {
+    return impl().layout.get<IconOffset>();
+}
+
+void SymbolLayer::setIconOffset(const PropertyValue<std::array<float, 2>>& value) {
+    if (value == getIconOffset())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->layout.get<IconOffset>() = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
 PropertyValue<bool> SymbolLayer::getDefaultIconOptional() {
     return IconOptional::defaultValue();
 }
@@ -186,6 +170,54 @@ void SymbolLayer::setIconOptional(const PropertyValue<bool>& value) {
         return;
     auto impl_ = mutableImpl();
     impl_->layout.get<IconOptional>() = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+PropertyValue<float> SymbolLayer::getDefaultIconPadding() {
+    return IconPadding::defaultValue();
+}
+
+const PropertyValue<float>& SymbolLayer::getIconPadding() const {
+    return impl().layout.get<IconPadding>();
+}
+
+void SymbolLayer::setIconPadding(const PropertyValue<float>& value) {
+    if (value == getIconPadding())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->layout.get<IconPadding>() = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+PropertyValue<AlignmentType> SymbolLayer::getDefaultIconPitchAlignment() {
+    return IconPitchAlignment::defaultValue();
+}
+
+const PropertyValue<AlignmentType>& SymbolLayer::getIconPitchAlignment() const {
+    return impl().layout.get<IconPitchAlignment>();
+}
+
+void SymbolLayer::setIconPitchAlignment(const PropertyValue<AlignmentType>& value) {
+    if (value == getIconPitchAlignment())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->layout.get<IconPitchAlignment>() = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+PropertyValue<float> SymbolLayer::getDefaultIconRotate() {
+    return IconRotate::defaultValue();
+}
+
+const PropertyValue<float>& SymbolLayer::getIconRotate() const {
+    return impl().layout.get<IconRotate>();
+}
+
+void SymbolLayer::setIconRotate(const PropertyValue<float>& value) {
+    if (value == getIconRotate())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->layout.get<IconRotate>() = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
@@ -253,147 +285,115 @@ void SymbolLayer::setIconTextFitPadding(const PropertyValue<std::array<float, 4>
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
-PropertyValue<std::string> SymbolLayer::getDefaultIconImage() {
-    return IconImage::defaultValue();
+PropertyValue<bool> SymbolLayer::getDefaultSymbolAvoidEdges() {
+    return SymbolAvoidEdges::defaultValue();
 }
 
-const PropertyValue<std::string>& SymbolLayer::getIconImage() const {
-    return impl().layout.get<IconImage>();
+const PropertyValue<bool>& SymbolLayer::getSymbolAvoidEdges() const {
+    return impl().layout.get<SymbolAvoidEdges>();
 }
 
-void SymbolLayer::setIconImage(const PropertyValue<std::string>& value) {
-    if (value == getIconImage())
+void SymbolLayer::setSymbolAvoidEdges(const PropertyValue<bool>& value) {
+    if (value == getSymbolAvoidEdges())
         return;
     auto impl_ = mutableImpl();
-    impl_->layout.get<IconImage>() = value;
+    impl_->layout.get<SymbolAvoidEdges>() = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
-PropertyValue<float> SymbolLayer::getDefaultIconRotate() {
-    return IconRotate::defaultValue();
+PropertyValue<SymbolPlacementType> SymbolLayer::getDefaultSymbolPlacement() {
+    return SymbolPlacement::defaultValue();
 }
 
-const PropertyValue<float>& SymbolLayer::getIconRotate() const {
-    return impl().layout.get<IconRotate>();
+const PropertyValue<SymbolPlacementType>& SymbolLayer::getSymbolPlacement() const {
+    return impl().layout.get<SymbolPlacement>();
 }
 
-void SymbolLayer::setIconRotate(const PropertyValue<float>& value) {
-    if (value == getIconRotate())
+void SymbolLayer::setSymbolPlacement(const PropertyValue<SymbolPlacementType>& value) {
+    if (value == getSymbolPlacement())
         return;
     auto impl_ = mutableImpl();
-    impl_->layout.get<IconRotate>() = value;
+    impl_->layout.get<SymbolPlacement>() = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
-PropertyValue<float> SymbolLayer::getDefaultIconPadding() {
-    return IconPadding::defaultValue();
+PropertyValue<float> SymbolLayer::getDefaultSymbolSortKey() {
+    return SymbolSortKey::defaultValue();
 }
 
-const PropertyValue<float>& SymbolLayer::getIconPadding() const {
-    return impl().layout.get<IconPadding>();
+const PropertyValue<float>& SymbolLayer::getSymbolSortKey() const {
+    return impl().layout.get<SymbolSortKey>();
 }
 
-void SymbolLayer::setIconPadding(const PropertyValue<float>& value) {
-    if (value == getIconPadding())
+void SymbolLayer::setSymbolSortKey(const PropertyValue<float>& value) {
+    if (value == getSymbolSortKey())
         return;
     auto impl_ = mutableImpl();
-    impl_->layout.get<IconPadding>() = value;
+    impl_->layout.get<SymbolSortKey>() = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
-PropertyValue<bool> SymbolLayer::getDefaultIconKeepUpright() {
-    return IconKeepUpright::defaultValue();
+PropertyValue<float> SymbolLayer::getDefaultSymbolSpacing() {
+    return SymbolSpacing::defaultValue();
 }
 
-const PropertyValue<bool>& SymbolLayer::getIconKeepUpright() const {
-    return impl().layout.get<IconKeepUpright>();
+const PropertyValue<float>& SymbolLayer::getSymbolSpacing() const {
+    return impl().layout.get<SymbolSpacing>();
 }
 
-void SymbolLayer::setIconKeepUpright(const PropertyValue<bool>& value) {
-    if (value == getIconKeepUpright())
+void SymbolLayer::setSymbolSpacing(const PropertyValue<float>& value) {
+    if (value == getSymbolSpacing())
         return;
     auto impl_ = mutableImpl();
-    impl_->layout.get<IconKeepUpright>() = value;
+    impl_->layout.get<SymbolSpacing>() = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
-PropertyValue<std::array<float, 2>> SymbolLayer::getDefaultIconOffset() {
-    return IconOffset::defaultValue();
+PropertyValue<SymbolZOrderType> SymbolLayer::getDefaultSymbolZOrder() {
+    return SymbolZOrder::defaultValue();
 }
 
-const PropertyValue<std::array<float, 2>>& SymbolLayer::getIconOffset() const {
-    return impl().layout.get<IconOffset>();
+const PropertyValue<SymbolZOrderType>& SymbolLayer::getSymbolZOrder() const {
+    return impl().layout.get<SymbolZOrder>();
 }
 
-void SymbolLayer::setIconOffset(const PropertyValue<std::array<float, 2>>& value) {
-    if (value == getIconOffset())
+void SymbolLayer::setSymbolZOrder(const PropertyValue<SymbolZOrderType>& value) {
+    if (value == getSymbolZOrder())
         return;
     auto impl_ = mutableImpl();
-    impl_->layout.get<IconOffset>() = value;
+    impl_->layout.get<SymbolZOrder>() = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
-PropertyValue<SymbolAnchorType> SymbolLayer::getDefaultIconAnchor() {
-    return IconAnchor::defaultValue();
+PropertyValue<bool> SymbolLayer::getDefaultTextAllowOverlap() {
+    return TextAllowOverlap::defaultValue();
 }
 
-const PropertyValue<SymbolAnchorType>& SymbolLayer::getIconAnchor() const {
-    return impl().layout.get<IconAnchor>();
+const PropertyValue<bool>& SymbolLayer::getTextAllowOverlap() const {
+    return impl().layout.get<TextAllowOverlap>();
 }
 
-void SymbolLayer::setIconAnchor(const PropertyValue<SymbolAnchorType>& value) {
-    if (value == getIconAnchor())
+void SymbolLayer::setTextAllowOverlap(const PropertyValue<bool>& value) {
+    if (value == getTextAllowOverlap())
         return;
     auto impl_ = mutableImpl();
-    impl_->layout.get<IconAnchor>() = value;
+    impl_->layout.get<TextAllowOverlap>() = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
-PropertyValue<AlignmentType> SymbolLayer::getDefaultIconPitchAlignment() {
-    return IconPitchAlignment::defaultValue();
+PropertyValue<SymbolAnchorType> SymbolLayer::getDefaultTextAnchor() {
+    return TextAnchor::defaultValue();
 }
 
-const PropertyValue<AlignmentType>& SymbolLayer::getIconPitchAlignment() const {
-    return impl().layout.get<IconPitchAlignment>();
+const PropertyValue<SymbolAnchorType>& SymbolLayer::getTextAnchor() const {
+    return impl().layout.get<TextAnchor>();
 }
 
-void SymbolLayer::setIconPitchAlignment(const PropertyValue<AlignmentType>& value) {
-    if (value == getIconPitchAlignment())
+void SymbolLayer::setTextAnchor(const PropertyValue<SymbolAnchorType>& value) {
+    if (value == getTextAnchor())
         return;
     auto impl_ = mutableImpl();
-    impl_->layout.get<IconPitchAlignment>() = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-PropertyValue<AlignmentType> SymbolLayer::getDefaultTextPitchAlignment() {
-    return TextPitchAlignment::defaultValue();
-}
-
-const PropertyValue<AlignmentType>& SymbolLayer::getTextPitchAlignment() const {
-    return impl().layout.get<TextPitchAlignment>();
-}
-
-void SymbolLayer::setTextPitchAlignment(const PropertyValue<AlignmentType>& value) {
-    if (value == getTextPitchAlignment())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->layout.get<TextPitchAlignment>() = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-PropertyValue<AlignmentType> SymbolLayer::getDefaultTextRotationAlignment() {
-    return TextRotationAlignment::defaultValue();
-}
-
-const PropertyValue<AlignmentType>& SymbolLayer::getTextRotationAlignment() const {
-    return impl().layout.get<TextRotationAlignment>();
-}
-
-void SymbolLayer::setTextRotationAlignment(const PropertyValue<AlignmentType>& value) {
-    if (value == getTextRotationAlignment())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->layout.get<TextRotationAlignment>() = value;
+    impl_->layout.get<TextAnchor>() = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
@@ -429,67 +429,19 @@ void SymbolLayer::setTextFont(const PropertyValue<std::vector<std::string>>& val
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
-PropertyValue<float> SymbolLayer::getDefaultTextSize() {
-    return TextSize::defaultValue();
+PropertyValue<bool> SymbolLayer::getDefaultTextIgnorePlacement() {
+    return TextIgnorePlacement::defaultValue();
 }
 
-const PropertyValue<float>& SymbolLayer::getTextSize() const {
-    return impl().layout.get<TextSize>();
+const PropertyValue<bool>& SymbolLayer::getTextIgnorePlacement() const {
+    return impl().layout.get<TextIgnorePlacement>();
 }
 
-void SymbolLayer::setTextSize(const PropertyValue<float>& value) {
-    if (value == getTextSize())
+void SymbolLayer::setTextIgnorePlacement(const PropertyValue<bool>& value) {
+    if (value == getTextIgnorePlacement())
         return;
     auto impl_ = mutableImpl();
-    impl_->layout.get<TextSize>() = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-PropertyValue<float> SymbolLayer::getDefaultTextMaxWidth() {
-    return TextMaxWidth::defaultValue();
-}
-
-const PropertyValue<float>& SymbolLayer::getTextMaxWidth() const {
-    return impl().layout.get<TextMaxWidth>();
-}
-
-void SymbolLayer::setTextMaxWidth(const PropertyValue<float>& value) {
-    if (value == getTextMaxWidth())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->layout.get<TextMaxWidth>() = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-PropertyValue<float> SymbolLayer::getDefaultTextLineHeight() {
-    return TextLineHeight::defaultValue();
-}
-
-const PropertyValue<float>& SymbolLayer::getTextLineHeight() const {
-    return impl().layout.get<TextLineHeight>();
-}
-
-void SymbolLayer::setTextLineHeight(const PropertyValue<float>& value) {
-    if (value == getTextLineHeight())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->layout.get<TextLineHeight>() = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-PropertyValue<float> SymbolLayer::getDefaultTextLetterSpacing() {
-    return TextLetterSpacing::defaultValue();
-}
-
-const PropertyValue<float>& SymbolLayer::getTextLetterSpacing() const {
-    return impl().layout.get<TextLetterSpacing>();
-}
-
-void SymbolLayer::setTextLetterSpacing(const PropertyValue<float>& value) {
-    if (value == getTextLetterSpacing())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->layout.get<TextLetterSpacing>() = value;
+    impl_->layout.get<TextIgnorePlacement>() = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
@@ -509,51 +461,51 @@ void SymbolLayer::setTextJustify(const PropertyValue<TextJustifyType>& value) {
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
-PropertyValue<float> SymbolLayer::getDefaultTextRadialOffset() {
-    return TextRadialOffset::defaultValue();
+PropertyValue<bool> SymbolLayer::getDefaultTextKeepUpright() {
+    return TextKeepUpright::defaultValue();
 }
 
-const PropertyValue<float>& SymbolLayer::getTextRadialOffset() const {
-    return impl().layout.get<TextRadialOffset>();
+const PropertyValue<bool>& SymbolLayer::getTextKeepUpright() const {
+    return impl().layout.get<TextKeepUpright>();
 }
 
-void SymbolLayer::setTextRadialOffset(const PropertyValue<float>& value) {
-    if (value == getTextRadialOffset())
+void SymbolLayer::setTextKeepUpright(const PropertyValue<bool>& value) {
+    if (value == getTextKeepUpright())
         return;
     auto impl_ = mutableImpl();
-    impl_->layout.get<TextRadialOffset>() = value;
+    impl_->layout.get<TextKeepUpright>() = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
-PropertyValue<std::vector<TextVariableAnchorType>> SymbolLayer::getDefaultTextVariableAnchor() {
-    return TextVariableAnchor::defaultValue();
+PropertyValue<float> SymbolLayer::getDefaultTextLetterSpacing() {
+    return TextLetterSpacing::defaultValue();
 }
 
-const PropertyValue<std::vector<TextVariableAnchorType>>& SymbolLayer::getTextVariableAnchor() const {
-    return impl().layout.get<TextVariableAnchor>();
+const PropertyValue<float>& SymbolLayer::getTextLetterSpacing() const {
+    return impl().layout.get<TextLetterSpacing>();
 }
 
-void SymbolLayer::setTextVariableAnchor(const PropertyValue<std::vector<TextVariableAnchorType>>& value) {
-    if (value == getTextVariableAnchor())
+void SymbolLayer::setTextLetterSpacing(const PropertyValue<float>& value) {
+    if (value == getTextLetterSpacing())
         return;
     auto impl_ = mutableImpl();
-    impl_->layout.get<TextVariableAnchor>() = value;
+    impl_->layout.get<TextLetterSpacing>() = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
-PropertyValue<SymbolAnchorType> SymbolLayer::getDefaultTextAnchor() {
-    return TextAnchor::defaultValue();
+PropertyValue<float> SymbolLayer::getDefaultTextLineHeight() {
+    return TextLineHeight::defaultValue();
 }
 
-const PropertyValue<SymbolAnchorType>& SymbolLayer::getTextAnchor() const {
-    return impl().layout.get<TextAnchor>();
+const PropertyValue<float>& SymbolLayer::getTextLineHeight() const {
+    return impl().layout.get<TextLineHeight>();
 }
 
-void SymbolLayer::setTextAnchor(const PropertyValue<SymbolAnchorType>& value) {
-    if (value == getTextAnchor())
+void SymbolLayer::setTextLineHeight(const PropertyValue<float>& value) {
+    if (value == getTextLineHeight())
         return;
     auto impl_ = mutableImpl();
-    impl_->layout.get<TextAnchor>() = value;
+    impl_->layout.get<TextLineHeight>() = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
@@ -573,67 +525,19 @@ void SymbolLayer::setTextMaxAngle(const PropertyValue<float>& value) {
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
-PropertyValue<float> SymbolLayer::getDefaultTextRotate() {
-    return TextRotate::defaultValue();
+PropertyValue<float> SymbolLayer::getDefaultTextMaxWidth() {
+    return TextMaxWidth::defaultValue();
 }
 
-const PropertyValue<float>& SymbolLayer::getTextRotate() const {
-    return impl().layout.get<TextRotate>();
+const PropertyValue<float>& SymbolLayer::getTextMaxWidth() const {
+    return impl().layout.get<TextMaxWidth>();
 }
 
-void SymbolLayer::setTextRotate(const PropertyValue<float>& value) {
-    if (value == getTextRotate())
+void SymbolLayer::setTextMaxWidth(const PropertyValue<float>& value) {
+    if (value == getTextMaxWidth())
         return;
     auto impl_ = mutableImpl();
-    impl_->layout.get<TextRotate>() = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-PropertyValue<float> SymbolLayer::getDefaultTextPadding() {
-    return TextPadding::defaultValue();
-}
-
-const PropertyValue<float>& SymbolLayer::getTextPadding() const {
-    return impl().layout.get<TextPadding>();
-}
-
-void SymbolLayer::setTextPadding(const PropertyValue<float>& value) {
-    if (value == getTextPadding())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->layout.get<TextPadding>() = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-PropertyValue<bool> SymbolLayer::getDefaultTextKeepUpright() {
-    return TextKeepUpright::defaultValue();
-}
-
-const PropertyValue<bool>& SymbolLayer::getTextKeepUpright() const {
-    return impl().layout.get<TextKeepUpright>();
-}
-
-void SymbolLayer::setTextKeepUpright(const PropertyValue<bool>& value) {
-    if (value == getTextKeepUpright())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->layout.get<TextKeepUpright>() = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-PropertyValue<TextTransformType> SymbolLayer::getDefaultTextTransform() {
-    return TextTransform::defaultValue();
-}
-
-const PropertyValue<TextTransformType>& SymbolLayer::getTextTransform() const {
-    return impl().layout.get<TextTransform>();
-}
-
-void SymbolLayer::setTextTransform(const PropertyValue<TextTransformType>& value) {
-    if (value == getTextTransform())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->layout.get<TextTransform>() = value;
+    impl_->layout.get<TextMaxWidth>() = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
@@ -653,38 +557,6 @@ void SymbolLayer::setTextOffset(const PropertyValue<std::array<float, 2>>& value
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
-PropertyValue<bool> SymbolLayer::getDefaultTextAllowOverlap() {
-    return TextAllowOverlap::defaultValue();
-}
-
-const PropertyValue<bool>& SymbolLayer::getTextAllowOverlap() const {
-    return impl().layout.get<TextAllowOverlap>();
-}
-
-void SymbolLayer::setTextAllowOverlap(const PropertyValue<bool>& value) {
-    if (value == getTextAllowOverlap())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->layout.get<TextAllowOverlap>() = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-PropertyValue<bool> SymbolLayer::getDefaultTextIgnorePlacement() {
-    return TextIgnorePlacement::defaultValue();
-}
-
-const PropertyValue<bool>& SymbolLayer::getTextIgnorePlacement() const {
-    return impl().layout.get<TextIgnorePlacement>();
-}
-
-void SymbolLayer::setTextIgnorePlacement(const PropertyValue<bool>& value) {
-    if (value == getTextIgnorePlacement())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->layout.get<TextIgnorePlacement>() = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
 PropertyValue<bool> SymbolLayer::getDefaultTextOptional() {
     return TextOptional::defaultValue();
 }
@@ -701,35 +573,136 @@ void SymbolLayer::setTextOptional(const PropertyValue<bool>& value) {
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
-
-// Paint properties
-
-PropertyValue<float> SymbolLayer::getDefaultIconOpacity() {
-    return { 1 };
+PropertyValue<float> SymbolLayer::getDefaultTextPadding() {
+    return TextPadding::defaultValue();
 }
 
-const PropertyValue<float>& SymbolLayer::getIconOpacity() const {
-    return impl().paint.template get<IconOpacity>().value;
+const PropertyValue<float>& SymbolLayer::getTextPadding() const {
+    return impl().layout.get<TextPadding>();
 }
 
-void SymbolLayer::setIconOpacity(const PropertyValue<float>& value) {
-    if (value == getIconOpacity())
+void SymbolLayer::setTextPadding(const PropertyValue<float>& value) {
+    if (value == getTextPadding())
         return;
     auto impl_ = mutableImpl();
-    impl_->paint.template get<IconOpacity>().value = value;
+    impl_->layout.get<TextPadding>() = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+PropertyValue<AlignmentType> SymbolLayer::getDefaultTextPitchAlignment() {
+    return TextPitchAlignment::defaultValue();
+}
+
+const PropertyValue<AlignmentType>& SymbolLayer::getTextPitchAlignment() const {
+    return impl().layout.get<TextPitchAlignment>();
+}
+
+void SymbolLayer::setTextPitchAlignment(const PropertyValue<AlignmentType>& value) {
+    if (value == getTextPitchAlignment())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->layout.get<TextPitchAlignment>() = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+PropertyValue<float> SymbolLayer::getDefaultTextRadialOffset() {
+    return TextRadialOffset::defaultValue();
+}
+
+const PropertyValue<float>& SymbolLayer::getTextRadialOffset() const {
+    return impl().layout.get<TextRadialOffset>();
+}
+
+void SymbolLayer::setTextRadialOffset(const PropertyValue<float>& value) {
+    if (value == getTextRadialOffset())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->layout.get<TextRadialOffset>() = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+PropertyValue<float> SymbolLayer::getDefaultTextRotate() {
+    return TextRotate::defaultValue();
+}
+
+const PropertyValue<float>& SymbolLayer::getTextRotate() const {
+    return impl().layout.get<TextRotate>();
+}
+
+void SymbolLayer::setTextRotate(const PropertyValue<float>& value) {
+    if (value == getTextRotate())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->layout.get<TextRotate>() = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+PropertyValue<AlignmentType> SymbolLayer::getDefaultTextRotationAlignment() {
+    return TextRotationAlignment::defaultValue();
+}
+
+const PropertyValue<AlignmentType>& SymbolLayer::getTextRotationAlignment() const {
+    return impl().layout.get<TextRotationAlignment>();
+}
+
+void SymbolLayer::setTextRotationAlignment(const PropertyValue<AlignmentType>& value) {
+    if (value == getTextRotationAlignment())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->layout.get<TextRotationAlignment>() = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+PropertyValue<float> SymbolLayer::getDefaultTextSize() {
+    return TextSize::defaultValue();
+}
+
+const PropertyValue<float>& SymbolLayer::getTextSize() const {
+    return impl().layout.get<TextSize>();
+}
+
+void SymbolLayer::setTextSize(const PropertyValue<float>& value) {
+    if (value == getTextSize())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->layout.get<TextSize>() = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+PropertyValue<TextTransformType> SymbolLayer::getDefaultTextTransform() {
+    return TextTransform::defaultValue();
+}
+
+const PropertyValue<TextTransformType>& SymbolLayer::getTextTransform() const {
+    return impl().layout.get<TextTransform>();
+}
+
+void SymbolLayer::setTextTransform(const PropertyValue<TextTransformType>& value) {
+    if (value == getTextTransform())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->layout.get<TextTransform>() = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+PropertyValue<std::vector<TextVariableAnchorType>> SymbolLayer::getDefaultTextVariableAnchor() {
+    return TextVariableAnchor::defaultValue();
+}
+
+const PropertyValue<std::vector<TextVariableAnchorType>>& SymbolLayer::getTextVariableAnchor() const {
+    return impl().layout.get<TextVariableAnchor>();
+}
+
+void SymbolLayer::setTextVariableAnchor(const PropertyValue<std::vector<TextVariableAnchorType>>& value) {
+    if (value == getTextVariableAnchor())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->layout.get<TextVariableAnchor>() = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
 
-void SymbolLayer::setIconOpacityTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<IconOpacity>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions SymbolLayer::getIconOpacityTransition() const {
-    return impl().paint.template get<IconOpacity>().options;
-}
+// Paint properties
 
 PropertyValue<Color> SymbolLayer::getDefaultIconColor() {
     return { Color::black() };
@@ -756,6 +729,33 @@ void SymbolLayer::setIconColorTransition(const TransitionOptions& options) {
 
 TransitionOptions SymbolLayer::getIconColorTransition() const {
     return impl().paint.template get<IconColor>().options;
+}
+
+PropertyValue<float> SymbolLayer::getDefaultIconHaloBlur() {
+    return { 0 };
+}
+
+const PropertyValue<float>& SymbolLayer::getIconHaloBlur() const {
+    return impl().paint.template get<IconHaloBlur>().value;
+}
+
+void SymbolLayer::setIconHaloBlur(const PropertyValue<float>& value) {
+    if (value == getIconHaloBlur())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<IconHaloBlur>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void SymbolLayer::setIconHaloBlurTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<IconHaloBlur>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions SymbolLayer::getIconHaloBlurTransition() const {
+    return impl().paint.template get<IconHaloBlur>().options;
 }
 
 PropertyValue<Color> SymbolLayer::getDefaultIconHaloColor() {
@@ -812,31 +812,31 @@ TransitionOptions SymbolLayer::getIconHaloWidthTransition() const {
     return impl().paint.template get<IconHaloWidth>().options;
 }
 
-PropertyValue<float> SymbolLayer::getDefaultIconHaloBlur() {
-    return { 0 };
+PropertyValue<float> SymbolLayer::getDefaultIconOpacity() {
+    return { 1 };
 }
 
-const PropertyValue<float>& SymbolLayer::getIconHaloBlur() const {
-    return impl().paint.template get<IconHaloBlur>().value;
+const PropertyValue<float>& SymbolLayer::getIconOpacity() const {
+    return impl().paint.template get<IconOpacity>().value;
 }
 
-void SymbolLayer::setIconHaloBlur(const PropertyValue<float>& value) {
-    if (value == getIconHaloBlur())
+void SymbolLayer::setIconOpacity(const PropertyValue<float>& value) {
+    if (value == getIconOpacity())
         return;
     auto impl_ = mutableImpl();
-    impl_->paint.template get<IconHaloBlur>().value = value;
+    impl_->paint.template get<IconOpacity>().value = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
 
-void SymbolLayer::setIconHaloBlurTransition(const TransitionOptions& options) {
+void SymbolLayer::setIconOpacityTransition(const TransitionOptions& options) {
     auto impl_ = mutableImpl();
-    impl_->paint.template get<IconHaloBlur>().options = options;
+    impl_->paint.template get<IconOpacity>().options = options;
     baseImpl = std::move(impl_);
 }
 
-TransitionOptions SymbolLayer::getIconHaloBlurTransition() const {
-    return impl().paint.template get<IconHaloBlur>().options;
+TransitionOptions SymbolLayer::getIconOpacityTransition() const {
+    return impl().paint.template get<IconOpacity>().options;
 }
 
 PropertyValue<std::array<float, 2>> SymbolLayer::getDefaultIconTranslate() {
@@ -893,33 +893,6 @@ TransitionOptions SymbolLayer::getIconTranslateAnchorTransition() const {
     return impl().paint.template get<IconTranslateAnchor>().options;
 }
 
-PropertyValue<float> SymbolLayer::getDefaultTextOpacity() {
-    return { 1 };
-}
-
-const PropertyValue<float>& SymbolLayer::getTextOpacity() const {
-    return impl().paint.template get<TextOpacity>().value;
-}
-
-void SymbolLayer::setTextOpacity(const PropertyValue<float>& value) {
-    if (value == getTextOpacity())
-        return;
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<TextOpacity>().value = value;
-    baseImpl = std::move(impl_);
-    observer->onLayerChanged(*this);
-}
-
-void SymbolLayer::setTextOpacityTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->paint.template get<TextOpacity>().options = options;
-    baseImpl = std::move(impl_);
-}
-
-TransitionOptions SymbolLayer::getTextOpacityTransition() const {
-    return impl().paint.template get<TextOpacity>().options;
-}
-
 PropertyValue<Color> SymbolLayer::getDefaultTextColor() {
     return { Color::black() };
 }
@@ -945,6 +918,33 @@ void SymbolLayer::setTextColorTransition(const TransitionOptions& options) {
 
 TransitionOptions SymbolLayer::getTextColorTransition() const {
     return impl().paint.template get<TextColor>().options;
+}
+
+PropertyValue<float> SymbolLayer::getDefaultTextHaloBlur() {
+    return { 0 };
+}
+
+const PropertyValue<float>& SymbolLayer::getTextHaloBlur() const {
+    return impl().paint.template get<TextHaloBlur>().value;
+}
+
+void SymbolLayer::setTextHaloBlur(const PropertyValue<float>& value) {
+    if (value == getTextHaloBlur())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<TextHaloBlur>().value = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
+
+void SymbolLayer::setTextHaloBlurTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->paint.template get<TextHaloBlur>().options = options;
+    baseImpl = std::move(impl_);
+}
+
+TransitionOptions SymbolLayer::getTextHaloBlurTransition() const {
+    return impl().paint.template get<TextHaloBlur>().options;
 }
 
 PropertyValue<Color> SymbolLayer::getDefaultTextHaloColor() {
@@ -1001,31 +1001,31 @@ TransitionOptions SymbolLayer::getTextHaloWidthTransition() const {
     return impl().paint.template get<TextHaloWidth>().options;
 }
 
-PropertyValue<float> SymbolLayer::getDefaultTextHaloBlur() {
-    return { 0 };
+PropertyValue<float> SymbolLayer::getDefaultTextOpacity() {
+    return { 1 };
 }
 
-const PropertyValue<float>& SymbolLayer::getTextHaloBlur() const {
-    return impl().paint.template get<TextHaloBlur>().value;
+const PropertyValue<float>& SymbolLayer::getTextOpacity() const {
+    return impl().paint.template get<TextOpacity>().value;
 }
 
-void SymbolLayer::setTextHaloBlur(const PropertyValue<float>& value) {
-    if (value == getTextHaloBlur())
+void SymbolLayer::setTextOpacity(const PropertyValue<float>& value) {
+    if (value == getTextOpacity())
         return;
     auto impl_ = mutableImpl();
-    impl_->paint.template get<TextHaloBlur>().value = value;
+    impl_->paint.template get<TextOpacity>().value = value;
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
 
-void SymbolLayer::setTextHaloBlurTransition(const TransitionOptions& options) {
+void SymbolLayer::setTextOpacityTransition(const TransitionOptions& options) {
     auto impl_ = mutableImpl();
-    impl_->paint.template get<TextHaloBlur>().options = options;
+    impl_->paint.template get<TextOpacity>().options = options;
     baseImpl = std::move(impl_);
 }
 
-TransitionOptions SymbolLayer::getTextHaloBlurTransition() const {
-    return impl().paint.template get<TextHaloBlur>().options;
+TransitionOptions SymbolLayer::getTextOpacityTransition() const {
+    return impl().paint.template get<TextOpacity>().options;
 }
 
 PropertyValue<std::array<float, 2>> SymbolLayer::getDefaultTextTranslate() {
@@ -1086,63 +1086,63 @@ using namespace conversion;
 
 optional<Error> SymbolLayer::setPaintProperty(const std::string& name, const Convertible& value) {
     enum class Property : uint8_t {
-        IconOpacity,
         IconColor,
+        IconHaloBlur,
         IconHaloColor,
         IconHaloWidth,
-        IconHaloBlur,
+        IconOpacity,
         IconTranslate,
         IconTranslateAnchor,
-        TextOpacity,
         TextColor,
+        TextHaloBlur,
         TextHaloColor,
         TextHaloWidth,
-        TextHaloBlur,
+        TextOpacity,
         TextTranslate,
         TextTranslateAnchor,
-        IconOpacityTransition,
         IconColorTransition,
+        IconHaloBlurTransition,
         IconHaloColorTransition,
         IconHaloWidthTransition,
-        IconHaloBlurTransition,
+        IconOpacityTransition,
         IconTranslateTransition,
         IconTranslateAnchorTransition,
-        TextOpacityTransition,
         TextColorTransition,
+        TextHaloBlurTransition,
         TextHaloColorTransition,
         TextHaloWidthTransition,
-        TextHaloBlurTransition,
+        TextOpacityTransition,
         TextTranslateTransition,
         TextTranslateAnchorTransition,
     };
 
     MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        { "icon-opacity", static_cast<uint8_t>(Property::IconOpacity) },
         { "icon-color", static_cast<uint8_t>(Property::IconColor) },
+        { "icon-halo-blur", static_cast<uint8_t>(Property::IconHaloBlur) },
         { "icon-halo-color", static_cast<uint8_t>(Property::IconHaloColor) },
         { "icon-halo-width", static_cast<uint8_t>(Property::IconHaloWidth) },
-        { "icon-halo-blur", static_cast<uint8_t>(Property::IconHaloBlur) },
+        { "icon-opacity", static_cast<uint8_t>(Property::IconOpacity) },
         { "icon-translate", static_cast<uint8_t>(Property::IconTranslate) },
         { "icon-translate-anchor", static_cast<uint8_t>(Property::IconTranslateAnchor) },
-        { "text-opacity", static_cast<uint8_t>(Property::TextOpacity) },
         { "text-color", static_cast<uint8_t>(Property::TextColor) },
+        { "text-halo-blur", static_cast<uint8_t>(Property::TextHaloBlur) },
         { "text-halo-color", static_cast<uint8_t>(Property::TextHaloColor) },
         { "text-halo-width", static_cast<uint8_t>(Property::TextHaloWidth) },
-        { "text-halo-blur", static_cast<uint8_t>(Property::TextHaloBlur) },
+        { "text-opacity", static_cast<uint8_t>(Property::TextOpacity) },
         { "text-translate", static_cast<uint8_t>(Property::TextTranslate) },
         { "text-translate-anchor", static_cast<uint8_t>(Property::TextTranslateAnchor) },
-        { "icon-opacity-transition", static_cast<uint8_t>(Property::IconOpacityTransition) },
         { "icon-color-transition", static_cast<uint8_t>(Property::IconColorTransition) },
+        { "icon-halo-blur-transition", static_cast<uint8_t>(Property::IconHaloBlurTransition) },
         { "icon-halo-color-transition", static_cast<uint8_t>(Property::IconHaloColorTransition) },
         { "icon-halo-width-transition", static_cast<uint8_t>(Property::IconHaloWidthTransition) },
-        { "icon-halo-blur-transition", static_cast<uint8_t>(Property::IconHaloBlurTransition) },
+        { "icon-opacity-transition", static_cast<uint8_t>(Property::IconOpacityTransition) },
         { "icon-translate-transition", static_cast<uint8_t>(Property::IconTranslateTransition) },
         { "icon-translate-anchor-transition", static_cast<uint8_t>(Property::IconTranslateAnchorTransition) },
-        { "text-opacity-transition", static_cast<uint8_t>(Property::TextOpacityTransition) },
         { "text-color-transition", static_cast<uint8_t>(Property::TextColorTransition) },
+        { "text-halo-blur-transition", static_cast<uint8_t>(Property::TextHaloBlurTransition) },
         { "text-halo-color-transition", static_cast<uint8_t>(Property::TextHaloColorTransition) },
         { "text-halo-width-transition", static_cast<uint8_t>(Property::TextHaloWidthTransition) },
-        { "text-halo-blur-transition", static_cast<uint8_t>(Property::TextHaloBlurTransition) },
+        { "text-opacity-transition", static_cast<uint8_t>(Property::TextOpacityTransition) },
         { "text-translate-transition", static_cast<uint8_t>(Property::TextTranslateTransition) },
         { "text-translate-anchor-transition", static_cast<uint8_t>(Property::TextTranslateAnchorTransition) }
     });
@@ -1155,45 +1155,6 @@ optional<Error> SymbolLayer::setPaintProperty(const std::string& name, const Con
     auto property = static_cast<Property>(it->second);
 
         
-    if (property == Property::IconOpacity || property == Property::IconHaloWidth || property == Property::IconHaloBlur || property == Property::TextOpacity || property == Property::TextHaloWidth || property == Property::TextHaloBlur) {
-        Error error;
-        optional<PropertyValue<float>> typedValue = convert<PropertyValue<float>>(value, error, true, false);
-        if (!typedValue) {
-            return error;
-        }
-        
-        if (property == Property::IconOpacity) {
-            setIconOpacity(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::IconHaloWidth) {
-            setIconHaloWidth(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::IconHaloBlur) {
-            setIconHaloBlur(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::TextOpacity) {
-            setTextOpacity(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::TextHaloWidth) {
-            setTextHaloWidth(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::TextHaloBlur) {
-            setTextHaloBlur(*typedValue);
-            return nullopt;
-        }
-        
-    }
-    
     if (property == Property::IconColor || property == Property::IconHaloColor || property == Property::TextColor || property == Property::TextHaloColor) {
         Error error;
         optional<PropertyValue<Color>> typedValue = convert<PropertyValue<Color>>(value, error, true, false);
@@ -1218,6 +1179,45 @@ optional<Error> SymbolLayer::setPaintProperty(const std::string& name, const Con
         
         if (property == Property::TextHaloColor) {
             setTextHaloColor(*typedValue);
+            return nullopt;
+        }
+        
+    }
+    
+    if (property == Property::IconHaloBlur || property == Property::IconHaloWidth || property == Property::IconOpacity || property == Property::TextHaloBlur || property == Property::TextHaloWidth || property == Property::TextOpacity) {
+        Error error;
+        optional<PropertyValue<float>> typedValue = convert<PropertyValue<float>>(value, error, true, false);
+        if (!typedValue) {
+            return error;
+        }
+        
+        if (property == Property::IconHaloBlur) {
+            setIconHaloBlur(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::IconHaloWidth) {
+            setIconHaloWidth(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::IconOpacity) {
+            setIconOpacity(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::TextHaloBlur) {
+            setTextHaloBlur(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::TextHaloWidth) {
+            setTextHaloWidth(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::TextOpacity) {
+            setTextOpacity(*typedValue);
             return nullopt;
         }
         
@@ -1268,13 +1268,13 @@ optional<Error> SymbolLayer::setPaintProperty(const std::string& name, const Con
         return error;
     }
     
-    if (property == Property::IconOpacityTransition) {
-        setIconOpacityTransition(*transition);
+    if (property == Property::IconColorTransition) {
+        setIconColorTransition(*transition);
         return nullopt;
     }
     
-    if (property == Property::IconColorTransition) {
-        setIconColorTransition(*transition);
+    if (property == Property::IconHaloBlurTransition) {
+        setIconHaloBlurTransition(*transition);
         return nullopt;
     }
     
@@ -1288,8 +1288,8 @@ optional<Error> SymbolLayer::setPaintProperty(const std::string& name, const Con
         return nullopt;
     }
     
-    if (property == Property::IconHaloBlurTransition) {
-        setIconHaloBlurTransition(*transition);
+    if (property == Property::IconOpacityTransition) {
+        setIconOpacityTransition(*transition);
         return nullopt;
     }
     
@@ -1303,13 +1303,13 @@ optional<Error> SymbolLayer::setPaintProperty(const std::string& name, const Con
         return nullopt;
     }
     
-    if (property == Property::TextOpacityTransition) {
-        setTextOpacityTransition(*transition);
+    if (property == Property::TextColorTransition) {
+        setTextColorTransition(*transition);
         return nullopt;
     }
     
-    if (property == Property::TextColorTransition) {
-        setTextColorTransition(*transition);
+    if (property == Property::TextHaloBlurTransition) {
+        setTextHaloBlurTransition(*transition);
         return nullopt;
     }
     
@@ -1323,8 +1323,8 @@ optional<Error> SymbolLayer::setPaintProperty(const std::string& name, const Con
         return nullopt;
     }
     
-    if (property == Property::TextHaloBlurTransition) {
-        setTextHaloBlurTransition(*transition);
+    if (property == Property::TextOpacityTransition) {
+        setTextOpacityTransition(*transition);
         return nullopt;
     }
     
@@ -1347,88 +1347,88 @@ optional<Error> SymbolLayer::setLayoutProperty(const std::string& name, const Co
         return Layer::setVisibility(value);
     }
     enum class Property {
-        SymbolPlacement,
-        SymbolSpacing,
-        SymbolAvoidEdges,
-        SymbolSortKey,
-        SymbolZOrder,
         IconAllowOverlap,
+        IconAnchor,
         IconIgnorePlacement,
+        IconImage,
+        IconKeepUpright,
+        IconOffset,
         IconOptional,
+        IconPadding,
+        IconPitchAlignment,
+        IconRotate,
         IconRotationAlignment,
         IconSize,
         IconTextFit,
         IconTextFitPadding,
-        IconImage,
-        IconRotate,
-        IconPadding,
-        IconKeepUpright,
-        IconOffset,
-        IconAnchor,
-        IconPitchAlignment,
-        TextPitchAlignment,
-        TextRotationAlignment,
+        SymbolAvoidEdges,
+        SymbolPlacement,
+        SymbolSortKey,
+        SymbolSpacing,
+        SymbolZOrder,
+        TextAllowOverlap,
+        TextAnchor,
         TextField,
         TextFont,
-        TextSize,
-        TextMaxWidth,
-        TextLineHeight,
-        TextLetterSpacing,
-        TextJustify,
-        TextRadialOffset,
-        TextVariableAnchor,
-        TextAnchor,
-        TextMaxAngle,
-        TextRotate,
-        TextPadding,
-        TextKeepUpright,
-        TextTransform,
-        TextOffset,
-        TextAllowOverlap,
         TextIgnorePlacement,
+        TextJustify,
+        TextKeepUpright,
+        TextLetterSpacing,
+        TextLineHeight,
+        TextMaxAngle,
+        TextMaxWidth,
+        TextOffset,
         TextOptional,
+        TextPadding,
+        TextPitchAlignment,
+        TextRadialOffset,
+        TextRotate,
+        TextRotationAlignment,
+        TextSize,
+        TextTransform,
+        TextVariableAnchor,
     };
     MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        { "symbol-placement", static_cast<uint8_t>(Property::SymbolPlacement) },
-        { "symbol-spacing", static_cast<uint8_t>(Property::SymbolSpacing) },
-        { "symbol-avoid-edges", static_cast<uint8_t>(Property::SymbolAvoidEdges) },
-        { "symbol-sort-key", static_cast<uint8_t>(Property::SymbolSortKey) },
-        { "symbol-z-order", static_cast<uint8_t>(Property::SymbolZOrder) },
         { "icon-allow-overlap", static_cast<uint8_t>(Property::IconAllowOverlap) },
+        { "icon-anchor", static_cast<uint8_t>(Property::IconAnchor) },
         { "icon-ignore-placement", static_cast<uint8_t>(Property::IconIgnorePlacement) },
+        { "icon-image", static_cast<uint8_t>(Property::IconImage) },
+        { "icon-keep-upright", static_cast<uint8_t>(Property::IconKeepUpright) },
+        { "icon-offset", static_cast<uint8_t>(Property::IconOffset) },
         { "icon-optional", static_cast<uint8_t>(Property::IconOptional) },
+        { "icon-padding", static_cast<uint8_t>(Property::IconPadding) },
+        { "icon-pitch-alignment", static_cast<uint8_t>(Property::IconPitchAlignment) },
+        { "icon-rotate", static_cast<uint8_t>(Property::IconRotate) },
         { "icon-rotation-alignment", static_cast<uint8_t>(Property::IconRotationAlignment) },
         { "icon-size", static_cast<uint8_t>(Property::IconSize) },
         { "icon-text-fit", static_cast<uint8_t>(Property::IconTextFit) },
         { "icon-text-fit-padding", static_cast<uint8_t>(Property::IconTextFitPadding) },
-        { "icon-image", static_cast<uint8_t>(Property::IconImage) },
-        { "icon-rotate", static_cast<uint8_t>(Property::IconRotate) },
-        { "icon-padding", static_cast<uint8_t>(Property::IconPadding) },
-        { "icon-keep-upright", static_cast<uint8_t>(Property::IconKeepUpright) },
-        { "icon-offset", static_cast<uint8_t>(Property::IconOffset) },
-        { "icon-anchor", static_cast<uint8_t>(Property::IconAnchor) },
-        { "icon-pitch-alignment", static_cast<uint8_t>(Property::IconPitchAlignment) },
-        { "text-pitch-alignment", static_cast<uint8_t>(Property::TextPitchAlignment) },
-        { "text-rotation-alignment", static_cast<uint8_t>(Property::TextRotationAlignment) },
+        { "symbol-avoid-edges", static_cast<uint8_t>(Property::SymbolAvoidEdges) },
+        { "symbol-placement", static_cast<uint8_t>(Property::SymbolPlacement) },
+        { "symbol-sort-key", static_cast<uint8_t>(Property::SymbolSortKey) },
+        { "symbol-spacing", static_cast<uint8_t>(Property::SymbolSpacing) },
+        { "symbol-z-order", static_cast<uint8_t>(Property::SymbolZOrder) },
+        { "text-allow-overlap", static_cast<uint8_t>(Property::TextAllowOverlap) },
+        { "text-anchor", static_cast<uint8_t>(Property::TextAnchor) },
         { "text-field", static_cast<uint8_t>(Property::TextField) },
         { "text-font", static_cast<uint8_t>(Property::TextFont) },
-        { "text-size", static_cast<uint8_t>(Property::TextSize) },
-        { "text-max-width", static_cast<uint8_t>(Property::TextMaxWidth) },
-        { "text-line-height", static_cast<uint8_t>(Property::TextLineHeight) },
-        { "text-letter-spacing", static_cast<uint8_t>(Property::TextLetterSpacing) },
-        { "text-justify", static_cast<uint8_t>(Property::TextJustify) },
-        { "text-radial-offset", static_cast<uint8_t>(Property::TextRadialOffset) },
-        { "text-variable-anchor", static_cast<uint8_t>(Property::TextVariableAnchor) },
-        { "text-anchor", static_cast<uint8_t>(Property::TextAnchor) },
-        { "text-max-angle", static_cast<uint8_t>(Property::TextMaxAngle) },
-        { "text-rotate", static_cast<uint8_t>(Property::TextRotate) },
-        { "text-padding", static_cast<uint8_t>(Property::TextPadding) },
-        { "text-keep-upright", static_cast<uint8_t>(Property::TextKeepUpright) },
-        { "text-transform", static_cast<uint8_t>(Property::TextTransform) },
-        { "text-offset", static_cast<uint8_t>(Property::TextOffset) },
-        { "text-allow-overlap", static_cast<uint8_t>(Property::TextAllowOverlap) },
         { "text-ignore-placement", static_cast<uint8_t>(Property::TextIgnorePlacement) },
-        { "text-optional", static_cast<uint8_t>(Property::TextOptional) }
+        { "text-justify", static_cast<uint8_t>(Property::TextJustify) },
+        { "text-keep-upright", static_cast<uint8_t>(Property::TextKeepUpright) },
+        { "text-letter-spacing", static_cast<uint8_t>(Property::TextLetterSpacing) },
+        { "text-line-height", static_cast<uint8_t>(Property::TextLineHeight) },
+        { "text-max-angle", static_cast<uint8_t>(Property::TextMaxAngle) },
+        { "text-max-width", static_cast<uint8_t>(Property::TextMaxWidth) },
+        { "text-offset", static_cast<uint8_t>(Property::TextOffset) },
+        { "text-optional", static_cast<uint8_t>(Property::TextOptional) },
+        { "text-padding", static_cast<uint8_t>(Property::TextPadding) },
+        { "text-pitch-alignment", static_cast<uint8_t>(Property::TextPitchAlignment) },
+        { "text-radial-offset", static_cast<uint8_t>(Property::TextRadialOffset) },
+        { "text-rotate", static_cast<uint8_t>(Property::TextRotate) },
+        { "text-rotation-alignment", static_cast<uint8_t>(Property::TextRotationAlignment) },
+        { "text-size", static_cast<uint8_t>(Property::TextSize) },
+        { "text-transform", static_cast<uint8_t>(Property::TextTransform) },
+        { "text-variable-anchor", static_cast<uint8_t>(Property::TextVariableAnchor) }
     });
 
     const auto it = properties.find(name.c_str());
@@ -1439,62 +1439,11 @@ optional<Error> SymbolLayer::setLayoutProperty(const std::string& name, const Co
     auto property = static_cast<Property>(it->second);
 
         
-    if (property == Property::SymbolPlacement) {
-        Error error;
-        optional<PropertyValue<SymbolPlacementType>> typedValue = convert<PropertyValue<SymbolPlacementType>>(value, error, false, false);
-        if (!typedValue) {
-            return error;
-        }
-        
-        setSymbolPlacement(*typedValue);
-        return nullopt;
-        
-    }
-    
-    if (property == Property::SymbolSpacing || property == Property::IconPadding || property == Property::TextLineHeight || property == Property::TextMaxAngle || property == Property::TextPadding) {
-        Error error;
-        optional<PropertyValue<float>> typedValue = convert<PropertyValue<float>>(value, error, false, false);
-        if (!typedValue) {
-            return error;
-        }
-        
-        if (property == Property::SymbolSpacing) {
-            setSymbolSpacing(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::IconPadding) {
-            setIconPadding(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::TextLineHeight) {
-            setTextLineHeight(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::TextMaxAngle) {
-            setTextMaxAngle(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::TextPadding) {
-            setTextPadding(*typedValue);
-            return nullopt;
-        }
-        
-    }
-    
-    if (property == Property::SymbolAvoidEdges || property == Property::IconAllowOverlap || property == Property::IconIgnorePlacement || property == Property::IconOptional || property == Property::IconKeepUpright || property == Property::TextKeepUpright || property == Property::TextAllowOverlap || property == Property::TextIgnorePlacement || property == Property::TextOptional) {
+    if (property == Property::IconAllowOverlap || property == Property::IconIgnorePlacement || property == Property::IconKeepUpright || property == Property::IconOptional || property == Property::SymbolAvoidEdges || property == Property::TextAllowOverlap || property == Property::TextIgnorePlacement || property == Property::TextKeepUpright || property == Property::TextOptional) {
         Error error;
         optional<PropertyValue<bool>> typedValue = convert<PropertyValue<bool>>(value, error, false, false);
         if (!typedValue) {
             return error;
-        }
-        
-        if (property == Property::SymbolAvoidEdges) {
-            setSymbolAvoidEdges(*typedValue);
-            return nullopt;
         }
         
         if (property == Property::IconAllowOverlap) {
@@ -1507,18 +1456,18 @@ optional<Error> SymbolLayer::setLayoutProperty(const std::string& name, const Co
             return nullopt;
         }
         
-        if (property == Property::IconOptional) {
-            setIconOptional(*typedValue);
-            return nullopt;
-        }
-        
         if (property == Property::IconKeepUpright) {
             setIconKeepUpright(*typedValue);
             return nullopt;
         }
         
-        if (property == Property::TextKeepUpright) {
-            setTextKeepUpright(*typedValue);
+        if (property == Property::IconOptional) {
+            setIconOptional(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::SymbolAvoidEdges) {
+            setSymbolAvoidEdges(*typedValue);
             return nullopt;
         }
         
@@ -1532,6 +1481,11 @@ optional<Error> SymbolLayer::setLayoutProperty(const std::string& name, const Co
             return nullopt;
         }
         
+        if (property == Property::TextKeepUpright) {
+            setTextKeepUpright(*typedValue);
+            return nullopt;
+        }
+        
         if (property == Property::TextOptional) {
             setTextOptional(*typedValue);
             return nullopt;
@@ -1539,117 +1493,22 @@ optional<Error> SymbolLayer::setLayoutProperty(const std::string& name, const Co
         
     }
     
-    if (property == Property::SymbolSortKey || property == Property::IconSize || property == Property::IconRotate || property == Property::TextSize || property == Property::TextMaxWidth || property == Property::TextLetterSpacing || property == Property::TextRadialOffset || property == Property::TextRotate) {
+    if (property == Property::IconAnchor || property == Property::TextAnchor) {
         Error error;
-        optional<PropertyValue<float>> typedValue = convert<PropertyValue<float>>(value, error, true, false);
+        optional<PropertyValue<SymbolAnchorType>> typedValue = convert<PropertyValue<SymbolAnchorType>>(value, error, true, false);
         if (!typedValue) {
             return error;
         }
         
-        if (property == Property::SymbolSortKey) {
-            setSymbolSortKey(*typedValue);
+        if (property == Property::IconAnchor) {
+            setIconAnchor(*typedValue);
             return nullopt;
         }
         
-        if (property == Property::IconSize) {
-            setIconSize(*typedValue);
+        if (property == Property::TextAnchor) {
+            setTextAnchor(*typedValue);
             return nullopt;
         }
-        
-        if (property == Property::IconRotate) {
-            setIconRotate(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::TextSize) {
-            setTextSize(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::TextMaxWidth) {
-            setTextMaxWidth(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::TextLetterSpacing) {
-            setTextLetterSpacing(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::TextRadialOffset) {
-            setTextRadialOffset(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::TextRotate) {
-            setTextRotate(*typedValue);
-            return nullopt;
-        }
-        
-    }
-    
-    if (property == Property::SymbolZOrder) {
-        Error error;
-        optional<PropertyValue<SymbolZOrderType>> typedValue = convert<PropertyValue<SymbolZOrderType>>(value, error, false, false);
-        if (!typedValue) {
-            return error;
-        }
-        
-        setSymbolZOrder(*typedValue);
-        return nullopt;
-        
-    }
-    
-    if (property == Property::IconRotationAlignment || property == Property::IconPitchAlignment || property == Property::TextPitchAlignment || property == Property::TextRotationAlignment) {
-        Error error;
-        optional<PropertyValue<AlignmentType>> typedValue = convert<PropertyValue<AlignmentType>>(value, error, false, false);
-        if (!typedValue) {
-            return error;
-        }
-        
-        if (property == Property::IconRotationAlignment) {
-            setIconRotationAlignment(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::IconPitchAlignment) {
-            setIconPitchAlignment(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::TextPitchAlignment) {
-            setTextPitchAlignment(*typedValue);
-            return nullopt;
-        }
-        
-        if (property == Property::TextRotationAlignment) {
-            setTextRotationAlignment(*typedValue);
-            return nullopt;
-        }
-        
-    }
-    
-    if (property == Property::IconTextFit) {
-        Error error;
-        optional<PropertyValue<IconTextFitType>> typedValue = convert<PropertyValue<IconTextFitType>>(value, error, false, false);
-        if (!typedValue) {
-            return error;
-        }
-        
-        setIconTextFit(*typedValue);
-        return nullopt;
-        
-    }
-    
-    if (property == Property::IconTextFitPadding) {
-        Error error;
-        optional<PropertyValue<std::array<float, 4>>> typedValue = convert<PropertyValue<std::array<float, 4>>>(value, error, false, false);
-        if (!typedValue) {
-            return error;
-        }
-        
-        setIconTextFitPadding(*typedValue);
-        return nullopt;
         
     }
     
@@ -1684,22 +1543,163 @@ optional<Error> SymbolLayer::setLayoutProperty(const std::string& name, const Co
         
     }
     
-    if (property == Property::IconAnchor || property == Property::TextAnchor) {
+    if (property == Property::IconPadding || property == Property::SymbolSpacing || property == Property::TextLineHeight || property == Property::TextMaxAngle || property == Property::TextPadding) {
         Error error;
-        optional<PropertyValue<SymbolAnchorType>> typedValue = convert<PropertyValue<SymbolAnchorType>>(value, error, true, false);
+        optional<PropertyValue<float>> typedValue = convert<PropertyValue<float>>(value, error, false, false);
         if (!typedValue) {
             return error;
         }
         
-        if (property == Property::IconAnchor) {
-            setIconAnchor(*typedValue);
+        if (property == Property::IconPadding) {
+            setIconPadding(*typedValue);
             return nullopt;
         }
         
-        if (property == Property::TextAnchor) {
-            setTextAnchor(*typedValue);
+        if (property == Property::SymbolSpacing) {
+            setSymbolSpacing(*typedValue);
             return nullopt;
         }
+        
+        if (property == Property::TextLineHeight) {
+            setTextLineHeight(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::TextMaxAngle) {
+            setTextMaxAngle(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::TextPadding) {
+            setTextPadding(*typedValue);
+            return nullopt;
+        }
+        
+    }
+    
+    if (property == Property::IconPitchAlignment || property == Property::IconRotationAlignment || property == Property::TextPitchAlignment || property == Property::TextRotationAlignment) {
+        Error error;
+        optional<PropertyValue<AlignmentType>> typedValue = convert<PropertyValue<AlignmentType>>(value, error, false, false);
+        if (!typedValue) {
+            return error;
+        }
+        
+        if (property == Property::IconPitchAlignment) {
+            setIconPitchAlignment(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::IconRotationAlignment) {
+            setIconRotationAlignment(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::TextPitchAlignment) {
+            setTextPitchAlignment(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::TextRotationAlignment) {
+            setTextRotationAlignment(*typedValue);
+            return nullopt;
+        }
+        
+    }
+    
+    if (property == Property::IconRotate || property == Property::IconSize || property == Property::SymbolSortKey || property == Property::TextLetterSpacing || property == Property::TextMaxWidth || property == Property::TextRadialOffset || property == Property::TextRotate || property == Property::TextSize) {
+        Error error;
+        optional<PropertyValue<float>> typedValue = convert<PropertyValue<float>>(value, error, true, false);
+        if (!typedValue) {
+            return error;
+        }
+        
+        if (property == Property::IconRotate) {
+            setIconRotate(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::IconSize) {
+            setIconSize(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::SymbolSortKey) {
+            setSymbolSortKey(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::TextLetterSpacing) {
+            setTextLetterSpacing(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::TextMaxWidth) {
+            setTextMaxWidth(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::TextRadialOffset) {
+            setTextRadialOffset(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::TextRotate) {
+            setTextRotate(*typedValue);
+            return nullopt;
+        }
+        
+        if (property == Property::TextSize) {
+            setTextSize(*typedValue);
+            return nullopt;
+        }
+        
+    }
+    
+    if (property == Property::IconTextFit) {
+        Error error;
+        optional<PropertyValue<IconTextFitType>> typedValue = convert<PropertyValue<IconTextFitType>>(value, error, false, false);
+        if (!typedValue) {
+            return error;
+        }
+        
+        setIconTextFit(*typedValue);
+        return nullopt;
+        
+    }
+    
+    if (property == Property::IconTextFitPadding) {
+        Error error;
+        optional<PropertyValue<std::array<float, 4>>> typedValue = convert<PropertyValue<std::array<float, 4>>>(value, error, false, false);
+        if (!typedValue) {
+            return error;
+        }
+        
+        setIconTextFitPadding(*typedValue);
+        return nullopt;
+        
+    }
+    
+    if (property == Property::SymbolPlacement) {
+        Error error;
+        optional<PropertyValue<SymbolPlacementType>> typedValue = convert<PropertyValue<SymbolPlacementType>>(value, error, false, false);
+        if (!typedValue) {
+            return error;
+        }
+        
+        setSymbolPlacement(*typedValue);
+        return nullopt;
+        
+    }
+    
+    if (property == Property::SymbolZOrder) {
+        Error error;
+        optional<PropertyValue<SymbolZOrderType>> typedValue = convert<PropertyValue<SymbolZOrderType>>(value, error, false, false);
+        if (!typedValue) {
+            return error;
+        }
+        
+        setSymbolZOrder(*typedValue);
+        return nullopt;
         
     }
     
@@ -1739,18 +1739,6 @@ optional<Error> SymbolLayer::setLayoutProperty(const std::string& name, const Co
         
     }
     
-    if (property == Property::TextVariableAnchor) {
-        Error error;
-        optional<PropertyValue<std::vector<TextVariableAnchorType>>> typedValue = convert<PropertyValue<std::vector<TextVariableAnchorType>>>(value, error, false, false);
-        if (!typedValue) {
-            return error;
-        }
-        
-        setTextVariableAnchor(*typedValue);
-        return nullopt;
-        
-    }
-    
     if (property == Property::TextTransform) {
         Error error;
         optional<PropertyValue<TextTransformType>> typedValue = convert<PropertyValue<TextTransformType>>(value, error, true, false);
@@ -1759,6 +1747,18 @@ optional<Error> SymbolLayer::setLayoutProperty(const std::string& name, const Co
         }
         
         setTextTransform(*typedValue);
+        return nullopt;
+        
+    }
+    
+    if (property == Property::TextVariableAnchor) {
+        Error error;
+        optional<PropertyValue<std::vector<TextVariableAnchorType>>> typedValue = convert<PropertyValue<std::vector<TextVariableAnchorType>>>(value, error, false, false);
+        if (!typedValue) {
+            return error;
+        }
+        
+        setTextVariableAnchor(*typedValue);
         return nullopt;
         
     }

--- a/src/mbgl/style/layers/symbol_layer_properties.hpp
+++ b/src/mbgl/style/layers/symbol_layer_properties.hpp
@@ -14,34 +14,14 @@
 namespace mbgl {
 namespace style {
 
-struct SymbolPlacement : LayoutProperty<SymbolPlacementType> {
-    static constexpr const char *name() { return "symbol-placement"; }
-    static SymbolPlacementType defaultValue() { return SymbolPlacementType::Point; }
-};
-
-struct SymbolSpacing : LayoutProperty<float> {
-    static constexpr const char *name() { return "symbol-spacing"; }
-    static float defaultValue() { return 250; }
-};
-
-struct SymbolAvoidEdges : LayoutProperty<bool> {
-    static constexpr const char *name() { return "symbol-avoid-edges"; }
-    static bool defaultValue() { return false; }
-};
-
-struct SymbolSortKey : DataDrivenLayoutProperty<float> {
-    static constexpr const char *name() { return "symbol-sort-key"; }
-    static float defaultValue() { return 0; }
-};
-
-struct SymbolZOrder : LayoutProperty<SymbolZOrderType> {
-    static constexpr const char *name() { return "symbol-z-order"; }
-    static SymbolZOrderType defaultValue() { return SymbolZOrderType::Auto; }
-};
-
 struct IconAllowOverlap : LayoutProperty<bool> {
     static constexpr const char *name() { return "icon-allow-overlap"; }
     static bool defaultValue() { return false; }
+};
+
+struct IconAnchor : DataDrivenLayoutProperty<SymbolAnchorType> {
+    static constexpr const char *name() { return "icon-anchor"; }
+    static SymbolAnchorType defaultValue() { return SymbolAnchorType::Center; }
 };
 
 struct IconIgnorePlacement : LayoutProperty<bool> {
@@ -49,9 +29,39 @@ struct IconIgnorePlacement : LayoutProperty<bool> {
     static bool defaultValue() { return false; }
 };
 
+struct IconImage : DataDrivenLayoutProperty<std::string> {
+    static constexpr const char *name() { return "icon-image"; }
+    static std::string defaultValue() { return ""; }
+};
+
+struct IconKeepUpright : LayoutProperty<bool> {
+    static constexpr const char *name() { return "icon-keep-upright"; }
+    static bool defaultValue() { return false; }
+};
+
+struct IconOffset : DataDrivenLayoutProperty<std::array<float, 2>> {
+    static constexpr const char *name() { return "icon-offset"; }
+    static std::array<float, 2> defaultValue() { return {{ 0, 0 }}; }
+};
+
 struct IconOptional : LayoutProperty<bool> {
     static constexpr const char *name() { return "icon-optional"; }
     static bool defaultValue() { return false; }
+};
+
+struct IconPadding : LayoutProperty<float> {
+    static constexpr const char *name() { return "icon-padding"; }
+    static float defaultValue() { return 2; }
+};
+
+struct IconPitchAlignment : LayoutProperty<AlignmentType> {
+    static constexpr const char *name() { return "icon-pitch-alignment"; }
+    static AlignmentType defaultValue() { return AlignmentType::Auto; }
+};
+
+struct IconRotate : DataDrivenLayoutProperty<float> {
+    static constexpr const char *name() { return "icon-rotate"; }
+    static float defaultValue() { return 0; }
 };
 
 struct IconRotationAlignment : LayoutProperty<AlignmentType> {
@@ -74,49 +84,39 @@ struct IconTextFitPadding : LayoutProperty<std::array<float, 4>> {
     static std::array<float, 4> defaultValue() { return {{ 0, 0, 0, 0 }}; }
 };
 
-struct IconImage : DataDrivenLayoutProperty<std::string> {
-    static constexpr const char *name() { return "icon-image"; }
-    static std::string defaultValue() { return ""; }
-};
-
-struct IconRotate : DataDrivenLayoutProperty<float> {
-    static constexpr const char *name() { return "icon-rotate"; }
-    static float defaultValue() { return 0; }
-};
-
-struct IconPadding : LayoutProperty<float> {
-    static constexpr const char *name() { return "icon-padding"; }
-    static float defaultValue() { return 2; }
-};
-
-struct IconKeepUpright : LayoutProperty<bool> {
-    static constexpr const char *name() { return "icon-keep-upright"; }
+struct SymbolAvoidEdges : LayoutProperty<bool> {
+    static constexpr const char *name() { return "symbol-avoid-edges"; }
     static bool defaultValue() { return false; }
 };
 
-struct IconOffset : DataDrivenLayoutProperty<std::array<float, 2>> {
-    static constexpr const char *name() { return "icon-offset"; }
-    static std::array<float, 2> defaultValue() { return {{ 0, 0 }}; }
+struct SymbolPlacement : LayoutProperty<SymbolPlacementType> {
+    static constexpr const char *name() { return "symbol-placement"; }
+    static SymbolPlacementType defaultValue() { return SymbolPlacementType::Point; }
 };
 
-struct IconAnchor : DataDrivenLayoutProperty<SymbolAnchorType> {
-    static constexpr const char *name() { return "icon-anchor"; }
+struct SymbolSortKey : DataDrivenLayoutProperty<float> {
+    static constexpr const char *name() { return "symbol-sort-key"; }
+    static float defaultValue() { return 0; }
+};
+
+struct SymbolSpacing : LayoutProperty<float> {
+    static constexpr const char *name() { return "symbol-spacing"; }
+    static float defaultValue() { return 250; }
+};
+
+struct SymbolZOrder : LayoutProperty<SymbolZOrderType> {
+    static constexpr const char *name() { return "symbol-z-order"; }
+    static SymbolZOrderType defaultValue() { return SymbolZOrderType::Auto; }
+};
+
+struct TextAllowOverlap : LayoutProperty<bool> {
+    static constexpr const char *name() { return "text-allow-overlap"; }
+    static bool defaultValue() { return false; }
+};
+
+struct TextAnchor : DataDrivenLayoutProperty<SymbolAnchorType> {
+    static constexpr const char *name() { return "text-anchor"; }
     static SymbolAnchorType defaultValue() { return SymbolAnchorType::Center; }
-};
-
-struct IconPitchAlignment : LayoutProperty<AlignmentType> {
-    static constexpr const char *name() { return "icon-pitch-alignment"; }
-    static AlignmentType defaultValue() { return AlignmentType::Auto; }
-};
-
-struct TextPitchAlignment : LayoutProperty<AlignmentType> {
-    static constexpr const char *name() { return "text-pitch-alignment"; }
-    static AlignmentType defaultValue() { return AlignmentType::Auto; }
-};
-
-struct TextRotationAlignment : LayoutProperty<AlignmentType> {
-    static constexpr const char *name() { return "text-rotation-alignment"; }
-    static AlignmentType defaultValue() { return AlignmentType::Auto; }
 };
 
 struct TextField : DataDrivenLayoutProperty<expression::Formatted> {
@@ -129,24 +129,9 @@ struct TextFont : DataDrivenLayoutProperty<std::vector<std::string>> {
     static std::vector<std::string> defaultValue() { return { "Open Sans Regular", "Arial Unicode MS Regular" }; }
 };
 
-struct TextSize : DataDrivenLayoutProperty<float> {
-    static constexpr const char *name() { return "text-size"; }
-    static float defaultValue() { return 16; }
-};
-
-struct TextMaxWidth : DataDrivenLayoutProperty<float> {
-    static constexpr const char *name() { return "text-max-width"; }
-    static float defaultValue() { return 10; }
-};
-
-struct TextLineHeight : LayoutProperty<float> {
-    static constexpr const char *name() { return "text-line-height"; }
-    static float defaultValue() { return 1.2; }
-};
-
-struct TextLetterSpacing : DataDrivenLayoutProperty<float> {
-    static constexpr const char *name() { return "text-letter-spacing"; }
-    static float defaultValue() { return 0; }
+struct TextIgnorePlacement : LayoutProperty<bool> {
+    static constexpr const char *name() { return "text-ignore-placement"; }
+    static bool defaultValue() { return false; }
 };
 
 struct TextJustify : DataDrivenLayoutProperty<TextJustifyType> {
@@ -154,19 +139,19 @@ struct TextJustify : DataDrivenLayoutProperty<TextJustifyType> {
     static TextJustifyType defaultValue() { return TextJustifyType::Center; }
 };
 
-struct TextRadialOffset : DataDrivenLayoutProperty<float> {
-    static constexpr const char *name() { return "text-radial-offset"; }
+struct TextKeepUpright : LayoutProperty<bool> {
+    static constexpr const char *name() { return "text-keep-upright"; }
+    static bool defaultValue() { return true; }
+};
+
+struct TextLetterSpacing : DataDrivenLayoutProperty<float> {
+    static constexpr const char *name() { return "text-letter-spacing"; }
     static float defaultValue() { return 0; }
 };
 
-struct TextVariableAnchor : LayoutProperty<std::vector<TextVariableAnchorType>> {
-    static constexpr const char *name() { return "text-variable-anchor"; }
-    static std::vector<TextVariableAnchorType> defaultValue() { return {  }; }
-};
-
-struct TextAnchor : DataDrivenLayoutProperty<SymbolAnchorType> {
-    static constexpr const char *name() { return "text-anchor"; }
-    static SymbolAnchorType defaultValue() { return SymbolAnchorType::Center; }
+struct TextLineHeight : LayoutProperty<float> {
+    static constexpr const char *name() { return "text-line-height"; }
+    static float defaultValue() { return 1.2; }
 };
 
 struct TextMaxAngle : LayoutProperty<float> {
@@ -174,24 +159,9 @@ struct TextMaxAngle : LayoutProperty<float> {
     static float defaultValue() { return 45; }
 };
 
-struct TextRotate : DataDrivenLayoutProperty<float> {
-    static constexpr const char *name() { return "text-rotate"; }
-    static float defaultValue() { return 0; }
-};
-
-struct TextPadding : LayoutProperty<float> {
-    static constexpr const char *name() { return "text-padding"; }
-    static float defaultValue() { return 2; }
-};
-
-struct TextKeepUpright : LayoutProperty<bool> {
-    static constexpr const char *name() { return "text-keep-upright"; }
-    static bool defaultValue() { return true; }
-};
-
-struct TextTransform : DataDrivenLayoutProperty<TextTransformType> {
-    static constexpr const char *name() { return "text-transform"; }
-    static TextTransformType defaultValue() { return TextTransformType::None; }
+struct TextMaxWidth : DataDrivenLayoutProperty<float> {
+    static constexpr const char *name() { return "text-max-width"; }
+    static float defaultValue() { return 10; }
 };
 
 struct TextOffset : DataDrivenLayoutProperty<std::array<float, 2>> {
@@ -199,27 +169,57 @@ struct TextOffset : DataDrivenLayoutProperty<std::array<float, 2>> {
     static std::array<float, 2> defaultValue() { return {{ 0, 0 }}; }
 };
 
-struct TextAllowOverlap : LayoutProperty<bool> {
-    static constexpr const char *name() { return "text-allow-overlap"; }
-    static bool defaultValue() { return false; }
-};
-
-struct TextIgnorePlacement : LayoutProperty<bool> {
-    static constexpr const char *name() { return "text-ignore-placement"; }
-    static bool defaultValue() { return false; }
-};
-
 struct TextOptional : LayoutProperty<bool> {
     static constexpr const char *name() { return "text-optional"; }
     static bool defaultValue() { return false; }
 };
 
-struct IconOpacity : DataDrivenPaintProperty<float, attributes::opacity, uniforms::opacity> {
-    static float defaultValue() { return 1; }
+struct TextPadding : LayoutProperty<float> {
+    static constexpr const char *name() { return "text-padding"; }
+    static float defaultValue() { return 2; }
+};
+
+struct TextPitchAlignment : LayoutProperty<AlignmentType> {
+    static constexpr const char *name() { return "text-pitch-alignment"; }
+    static AlignmentType defaultValue() { return AlignmentType::Auto; }
+};
+
+struct TextRadialOffset : DataDrivenLayoutProperty<float> {
+    static constexpr const char *name() { return "text-radial-offset"; }
+    static float defaultValue() { return 0; }
+};
+
+struct TextRotate : DataDrivenLayoutProperty<float> {
+    static constexpr const char *name() { return "text-rotate"; }
+    static float defaultValue() { return 0; }
+};
+
+struct TextRotationAlignment : LayoutProperty<AlignmentType> {
+    static constexpr const char *name() { return "text-rotation-alignment"; }
+    static AlignmentType defaultValue() { return AlignmentType::Auto; }
+};
+
+struct TextSize : DataDrivenLayoutProperty<float> {
+    static constexpr const char *name() { return "text-size"; }
+    static float defaultValue() { return 16; }
+};
+
+struct TextTransform : DataDrivenLayoutProperty<TextTransformType> {
+    static constexpr const char *name() { return "text-transform"; }
+    static TextTransformType defaultValue() { return TextTransformType::None; }
+};
+
+struct TextVariableAnchor : LayoutProperty<std::vector<TextVariableAnchorType>> {
+    static constexpr const char *name() { return "text-variable-anchor"; }
+    static std::vector<TextVariableAnchorType> defaultValue() { return {  }; }
 };
 
 struct IconColor : DataDrivenPaintProperty<Color, attributes::fill_color, uniforms::fill_color> {
     static Color defaultValue() { return Color::black(); }
+};
+
+struct IconHaloBlur : DataDrivenPaintProperty<float, attributes::halo_blur, uniforms::halo_blur> {
+    static float defaultValue() { return 0; }
 };
 
 struct IconHaloColor : DataDrivenPaintProperty<Color, attributes::halo_color, uniforms::halo_color> {
@@ -230,8 +230,8 @@ struct IconHaloWidth : DataDrivenPaintProperty<float, attributes::halo_width, un
     static float defaultValue() { return 0; }
 };
 
-struct IconHaloBlur : DataDrivenPaintProperty<float, attributes::halo_blur, uniforms::halo_blur> {
-    static float defaultValue() { return 0; }
+struct IconOpacity : DataDrivenPaintProperty<float, attributes::opacity, uniforms::opacity> {
+    static float defaultValue() { return 1; }
 };
 
 struct IconTranslate : PaintProperty<std::array<float, 2>> {
@@ -242,15 +242,15 @@ struct IconTranslateAnchor : PaintProperty<TranslateAnchorType> {
     static TranslateAnchorType defaultValue() { return TranslateAnchorType::Map; }
 };
 
-struct TextOpacity : DataDrivenPaintProperty<float, attributes::opacity, uniforms::opacity> {
-    static float defaultValue() { return 1; }
-};
-
 struct TextColor : DataDrivenPaintProperty<Color, attributes::fill_color, uniforms::fill_color, true> {
     static Color defaultValue() { return Color::black(); }
     static constexpr const char *name() { return "text-color"; }
     static constexpr auto expressionType() { return expression::type::ColorType{}; };
     template<typename T> static bool hasOverride(const T& t) { return !!t.textColor; };
+};
+
+struct TextHaloBlur : DataDrivenPaintProperty<float, attributes::halo_blur, uniforms::halo_blur> {
+    static float defaultValue() { return 0; }
 };
 
 struct TextHaloColor : DataDrivenPaintProperty<Color, attributes::halo_color, uniforms::halo_color> {
@@ -261,8 +261,8 @@ struct TextHaloWidth : DataDrivenPaintProperty<float, attributes::halo_width, un
     static float defaultValue() { return 0; }
 };
 
-struct TextHaloBlur : DataDrivenPaintProperty<float, attributes::halo_blur, uniforms::halo_blur> {
-    static float defaultValue() { return 0; }
+struct TextOpacity : DataDrivenPaintProperty<float, attributes::opacity, uniforms::opacity> {
+    static float defaultValue() { return 1; }
 };
 
 struct TextTranslate : PaintProperty<std::array<float, 2>> {
@@ -274,61 +274,61 @@ struct TextTranslateAnchor : PaintProperty<TranslateAnchorType> {
 };
 
 class SymbolLayoutProperties : public Properties<
-    SymbolPlacement,
-    SymbolSpacing,
-    SymbolAvoidEdges,
-    SymbolSortKey,
-    SymbolZOrder,
     IconAllowOverlap,
+    IconAnchor,
     IconIgnorePlacement,
+    IconImage,
+    IconKeepUpright,
+    IconOffset,
     IconOptional,
+    IconPadding,
+    IconPitchAlignment,
+    IconRotate,
     IconRotationAlignment,
     IconSize,
     IconTextFit,
     IconTextFitPadding,
-    IconImage,
-    IconRotate,
-    IconPadding,
-    IconKeepUpright,
-    IconOffset,
-    IconAnchor,
-    IconPitchAlignment,
-    TextPitchAlignment,
-    TextRotationAlignment,
+    SymbolAvoidEdges,
+    SymbolPlacement,
+    SymbolSortKey,
+    SymbolSpacing,
+    SymbolZOrder,
+    TextAllowOverlap,
+    TextAnchor,
     TextField,
     TextFont,
-    TextSize,
-    TextMaxWidth,
-    TextLineHeight,
-    TextLetterSpacing,
-    TextJustify,
-    TextRadialOffset,
-    TextVariableAnchor,
-    TextAnchor,
-    TextMaxAngle,
-    TextRotate,
-    TextPadding,
-    TextKeepUpright,
-    TextTransform,
-    TextOffset,
-    TextAllowOverlap,
     TextIgnorePlacement,
-    TextOptional
+    TextJustify,
+    TextKeepUpright,
+    TextLetterSpacing,
+    TextLineHeight,
+    TextMaxAngle,
+    TextMaxWidth,
+    TextOffset,
+    TextOptional,
+    TextPadding,
+    TextPitchAlignment,
+    TextRadialOffset,
+    TextRotate,
+    TextRotationAlignment,
+    TextSize,
+    TextTransform,
+    TextVariableAnchor
 > {};
 
 class SymbolPaintProperties : public Properties<
-    IconOpacity,
     IconColor,
+    IconHaloBlur,
     IconHaloColor,
     IconHaloWidth,
-    IconHaloBlur,
+    IconOpacity,
     IconTranslate,
     IconTranslateAnchor,
-    TextOpacity,
     TextColor,
+    TextHaloBlur,
     TextHaloColor,
     TextHaloWidth,
-    TextHaloBlur,
+    TextOpacity,
     TextTranslate,
     TextTranslateAnchor
 > {};

--- a/src/mbgl/style/light.cpp
+++ b/src/mbgl/style/light.cpp
@@ -50,32 +50,6 @@ TransitionOptions Light::getAnchorTransition() const {
     return impl->properties.template get<LightAnchor>().options;
 }
 
-Position Light::getDefaultPosition() {
-    return LightPosition::defaultValue();
-}
-
-PropertyValue<Position> Light::getPosition() const {
-    return impl->properties.template get<LightPosition>().value;
-}
-
-void Light::setPosition(PropertyValue<Position> property) {
-    auto impl_ = mutableImpl();
-    impl_->properties.template get<LightPosition>().value = property;
-    impl = std::move(impl_);
-    observer->onLightChanged(*this);
-}
-
-void Light::setPositionTransition(const TransitionOptions& options) {
-    auto impl_ = mutableImpl();
-    impl_->properties.template get<LightPosition>().options = options;
-    impl = std::move(impl_);
-    observer->onLightChanged(*this);
-}
-
-TransitionOptions Light::getPositionTransition() const {
-    return impl->properties.template get<LightPosition>().options;
-}
-
 Color Light::getDefaultColor() {
     return LightColor::defaultValue();
 }
@@ -126,6 +100,32 @@ void Light::setIntensityTransition(const TransitionOptions& options) {
 
 TransitionOptions Light::getIntensityTransition() const {
     return impl->properties.template get<LightIntensity>().options;
+}
+
+Position Light::getDefaultPosition() {
+    return LightPosition::defaultValue();
+}
+
+PropertyValue<Position> Light::getPosition() const {
+    return impl->properties.template get<LightPosition>().value;
+}
+
+void Light::setPosition(PropertyValue<Position> property) {
+    auto impl_ = mutableImpl();
+    impl_->properties.template get<LightPosition>().value = property;
+    impl = std::move(impl_);
+    observer->onLightChanged(*this);
+}
+
+void Light::setPositionTransition(const TransitionOptions& options) {
+    auto impl_ = mutableImpl();
+    impl_->properties.template get<LightPosition>().options = options;
+    impl = std::move(impl_);
+    observer->onLightChanged(*this);
+}
+
+TransitionOptions Light::getPositionTransition() const {
+    return impl->properties.template get<LightPosition>().options;
 }
 
 

--- a/test/style/conversion/stringify.test.cpp
+++ b/test/style/conversion/stringify.test.cpp
@@ -142,5 +142,5 @@ TEST(Stringify, Layout) {
     SymbolLayoutProperties::Unevaluated layout;
     layout.get<SymbolAvoidEdges>() = true;
     layout.get<IconPadding>() = 2.0;
-    ASSERT_EQ(stringify(layout), "{\"symbol-avoid-edges\":true,\"icon-padding\":2.0}");
+    ASSERT_EQ(stringify(layout), "{\"icon-padding\":2.0,\"symbol-avoid-edges\":true}");
 }


### PR DESCRIPTION
JSON keys in our style specification don't have a defined order. This change sorts them alphabetically so that we can rely on the order remaining them same across code generation runs.