### PR TITLE
Interpret negative direction as unchanged when setting visible coordinates

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,7 +4,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ## 4.12.0
 
-* No public-facing changes in v4.12.0-alpha.1.
+* Fixed an issue where `-[MGLMapView setVisibleCoordinates:count:edgePadding:direction:duration:animationTimingFunction:completionHandler:]` interpreted a negative `direction` as due north instead of maintaining the current direction. ([#14575](https://github.com/mapbox/mapbox-gl-native/pull/14575)) 
 
 ## 4.11.0
 

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -744,7 +744,7 @@ MGL_EXPORT
  @param centerCoordinate The new center coordinate for the map.
  @param zoomLevel The new zoom level for the map.
  @param direction The new direction for the map, measured in degrees relative to
-    true north.
+    true north. A negative value leaves the map’s direction unchanged.
  @param animated Specify `YES` if you want the map view to animate scrolling,
     zooming, and rotating to the new location or `NO` if you want the map to
     display the new location immediately.
@@ -761,7 +761,7 @@ MGL_EXPORT
  @param centerCoordinate The new center coordinate for the map.
  @param zoomLevel The new zoom level for the map.
  @param direction The new direction for the map, measured in degrees relative to
-    true north.
+    true north. A negative value leaves the map’s direction unchanged.
  @param animated Specify `YES` if you want the map view to animate scrolling,
     zooming, and rotating to the new location or `NO` if you want the map to
     display the new location immediately.
@@ -942,7 +942,8 @@ MGL_EXPORT
  @param insets The minimum padding (in screen points) that will be visible
     around the given coordinate bounds.
  @param direction The direction to rotate the map to, measured in degrees
-    relative to true north.
+    relative to true north. A negative value leaves the map’s direction
+    unchanged.
  @param duration The duration to animate the change in seconds.
  @param function The timing function to animate the change.
  @param completion The block executed after the animation finishes.

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3589,7 +3589,7 @@ public:
         latLngs.push_back({coordinates[i].latitude, coordinates[i].longitude});
     }
     
-    CLLocationDirection cameraDirection = direction >= 0 ? direction : 0;
+    CLLocationDirection cameraDirection = direction >= 0 ? direction : self.direction;
 
     mbgl::CameraOptions cameraOptions = self.mbglMap.cameraForLatLngs(latLngs, padding, cameraDirection);
 


### PR DESCRIPTION
`-[MGLMapView setVisibleCoordinates:count:edgePadding:direction:duration:animationTimingFunction:completionHandler:]` interprets a negative `direction` as maintaining the current direction instead of rotating to due north.

Fixes #14574.

/cc @mapbox/maps-ios