### PR TITLE
[ios] Uppercase'd "string" to remove cmake warning

### DIFF
--- a/platform/ios/toolchain.cmake
+++ b/platform/ios/toolchain.cmake
@@ -89,14 +89,14 @@ set (CMAKE_FIND_LIBRARY_SUFFIXES ".dylib" ".so" ".a")
 
 
 # Point to the latest SDK.
-set (CMAKE_OSX_SYSROOT "iphoneos" CACHE string "Sysroot used for iOS support")
+set (CMAKE_OSX_SYSROOT "iphoneos" CACHE STRING "Sysroot used for iOS support")
 
 
 
-set (CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD)" CACHE string  "Build architecture for iOS")
+set (CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD)" CACHE STRING  "Build architecture for iOS")
 
 # Set the find root to the iOS developer roots and to user defined paths
-set (CMAKE_FIND_ROOT_PATH ${CMAKE_IOS_DEVELOPER_ROOT} ${CMAKE_IOS_SDK_ROOT} ${CMAKE_PREFIX_PATH} CACHE string  "iOS find search path root")
+set (CMAKE_FIND_ROOT_PATH ${CMAKE_IOS_DEVELOPER_ROOT} ${CMAKE_IOS_SDK_ROOT} ${CMAKE_PREFIX_PATH} CACHE STRING  "iOS find search path root")
 
 # default to searching for frameworks first
 set (CMAKE_FIND_FRAMEWORK FIRST)


### PR DESCRIPTION
To quieten warnings like

```
CMake Warning (dev) at /Users/distiller/project/platform/ios/toolchain.cmake:92 (set):
  implicitly converting 'string' to 'STRING' type.
Call Stack (most recent call first):
  /Users/distiller/project/build/ios/CMakeFiles/3.14.1/CMakeSystem.cmake:6 (include)
  /Users/distiller/project/build/ios/CMakeFiles/CMakeTmp/CMakeLists.txt:2 (project)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at /Users/distiller/project/platform/ios/toolchain.cmake:96 (set):
  implicitly converting 'string' to 'STRING' type.
Call Stack (most recent call first):
  /Users/distiller/project/build/ios/CMakeFiles/3.14.1/CMakeSystem.cmake:6 (include)
  /Users/distiller/project/build/ios/CMakeFiles/CMakeTmp/CMakeLists.txt:2 (project)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at /Users/distiller/project/platform/ios/toolchain.cmake:99 (set):
  implicitly converting 'string' to 'STRING' type.
Call Stack (most recent call first):
  /Users/distiller/project/build/ios/CMakeFiles/3.14.1/CMakeSystem.cmake:6 (include)
  /Users/distiller/project/build/ios/CMakeFiles/CMakeTmp/CMakeLists.txt:2 (project)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

we're seeing in CI logs.