### PR TITLE
[android] Fix intermittent GC of offline callbacks

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
@@ -20,7 +20,6 @@ import com.mapbox.mapboxsdk.utils.FileUtils;
 import com.mapbox.mapboxsdk.utils.ThreadUtils;
 
 import java.io.File;
-import java.lang.ref.WeakReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -270,9 +269,9 @@ public class FileSource {
    * @param path     the new database path
    * @param callback the callback to obtain the result
    */
-  public static void setResourcesCachePath(@NonNull Context context,
+  public static void setResourcesCachePath(final Context context,
                                            @NonNull final String path,
-                                           @NonNull ResourcesCachePathChangeCallback callback) {
+                                           final ResourcesCachePathChangeCallback callback) {
     final String fileSourceActivatedMessage = "Cannot set path, file source is activated."
       + " Make sure that the map or a resources download is not running.";
     if (getInstance(context).isActivated()) {
@@ -282,14 +281,9 @@ public class FileSource {
       // no need to change the path
       callback.onSuccess(path);
     } else {
-      final WeakReference<Context> contextWeakReference = new WeakReference<>(context);
-      final WeakReference<ResourcesCachePathChangeCallback> callbackWeakReference = new WeakReference<>(callback);
       new FileUtils.CheckFileWritePermissionTask(new FileUtils.OnCheckFileWritePermissionListener() {
         @Override
         public void onWritePermissionGranted() {
-          final Context context = contextWeakReference.get();
-          final ResourcesCachePathChangeCallback callback = callbackWeakReference.get();
-
           if (callback == null) {
             Logger.w(TAG, "Lost callback reference.");
             return;
@@ -316,7 +310,6 @@ public class FileSource {
 
         @Override
         public void onError() {
-          final ResourcesCachePathChangeCallback callback = callbackWeakReference.get();
           if (callback != null) {
             String message = "Path is not writable: " + path;
             Logger.e(TAG, message);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/FileUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/FileUtils.java
@@ -6,7 +6,6 @@ import android.support.annotation.NonNull;
 import com.mapbox.mapboxsdk.log.Logger;
 
 import java.io.File;
-import java.lang.ref.WeakReference;
 
 public class FileUtils {
 
@@ -17,10 +16,10 @@ public class FileUtils {
    */
   public static class CheckFileReadPermissionTask extends AsyncTask<File, Void, Boolean> {
     @NonNull
-    private final WeakReference<OnCheckFileReadPermissionListener> listenerWeakReference;
+    private OnCheckFileReadPermissionListener listener;
 
     public CheckFileReadPermissionTask(OnCheckFileReadPermissionListener listener) {
-      this.listenerWeakReference = new WeakReference<>(listener);
+      this.listener = listener;
     }
 
     @Override
@@ -34,21 +33,19 @@ public class FileUtils {
 
     @Override
     protected void onCancelled() {
-      OnCheckFileReadPermissionListener listener = listenerWeakReference.get();
-      if (listener != null) {
-        listener.onError();
-      }
+      OnCheckFileReadPermissionListener localListener = listener;
+      listener = null;
+      localListener.onError();
     }
 
     @Override
     protected void onPostExecute(Boolean result) {
-      OnCheckFileReadPermissionListener listener = listenerWeakReference.get();
-      if (listener != null) {
-        if (result) {
-          listener.onReadPermissionGranted();
-        } else {
-          listener.onError();
-        }
+      OnCheckFileReadPermissionListener localListener = listener;
+      listener = null;
+      if (result) {
+        localListener.onReadPermissionGranted();
+      } else {
+        localListener.onError();
       }
     }
   }
@@ -74,10 +71,10 @@ public class FileUtils {
    */
   public static class CheckFileWritePermissionTask extends AsyncTask<File, Void, Boolean> {
     @NonNull
-    private final WeakReference<OnCheckFileWritePermissionListener> listenerWeakReference;
+    private OnCheckFileWritePermissionListener listener;
 
     public CheckFileWritePermissionTask(OnCheckFileWritePermissionListener listener) {
-      this.listenerWeakReference = new WeakReference<>(listener);
+      this.listener = listener;
     }
 
     @Override
@@ -91,21 +88,19 @@ public class FileUtils {
 
     @Override
     protected void onCancelled() {
-      OnCheckFileWritePermissionListener listener = listenerWeakReference.get();
-      if (listener != null) {
-        listener.onError();
-      }
+      OnCheckFileWritePermissionListener localListener = listener;
+      listener = null;
+      localListener.onError();
     }
 
     @Override
     protected void onPostExecute(Boolean result) {
-      OnCheckFileWritePermissionListener listener = listenerWeakReference.get();
-      if (listener != null) {
-        if (result) {
-          listener.onWritePermissionGranted();
-        } else {
-          listener.onError();
-        }
+      OnCheckFileWritePermissionListener localListener = listener;
+      listener = null;
+      if (result) {
+        localListener.onWritePermissionGranted();
+      } else {
+        localListener.onError();
       }
     }
   }


### PR DESCRIPTION
- Fixes #14297 

We took the second approach explained in https://github.com/mapbox/mapbox-gl-native/issues/14297#issuecomment-488021326

> - Remove the `WeakReference`s and reset the callbacks when `onCancelled` and `onPostExecute` so they're properly GC'ed

Also just to make sure that an exception thrown inside the callback doesn't prevent us from cleaning the listener, we're making the reference local and clearing the field one before calling it. Extra safe 😅 

We've tested this implementation downstream in https://github.com/mapbox/mapbox-navigation-android/pull/1895 and no leaks were reported by LeakCanary.

cc @zugaldia 
