### PR TITLE
[iosapp] Introduce map state manager

### DIFF
--- a/platform/ios/app/MBXState.h
+++ b/platform/ios/app/MBXState.h
@@ -1,0 +1,36 @@
+#import <Foundation/Foundation.h>
+#import <Mapbox/Mapbox.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+FOUNDATION_EXTERN NSString *const MBXCamera;
+FOUNDATION_EXTERN NSString *const MBXShowsUserLocation;
+FOUNDATION_EXTERN NSString *const MBXUserTrackingMode;
+FOUNDATION_EXTERN NSString *const MBXMapShowsHeadingIndicator;
+FOUNDATION_EXTERN NSString *const MBXShowsMapScale;
+FOUNDATION_EXTERN NSString *const MBXShowsZoomLevelOrnament;
+FOUNDATION_EXTERN NSString *const MBXShowsTimeFrameGraph;
+FOUNDATION_EXTERN NSString *const MBXMapFramerateMeasurementEnabled;
+FOUNDATION_EXTERN NSString *const MBXDebugMaskValue;
+FOUNDATION_EXTERN NSString *const MBXDebugLoggingEnabled;
+FOUNDATION_EXTERN NSString *const MBXReuseQueueStatsEnabled;
+
+@interface MBXState : NSObject <NSSecureCoding>
+
+@property (nonatomic, nullable) MGLMapCamera *camera;
+@property (nonatomic) BOOL showsUserLocation;
+@property (nonatomic) MGLUserTrackingMode userTrackingMode;
+@property (nonatomic) BOOL showsUserHeadingIndicator;
+@property (nonatomic) BOOL showsMapScale;
+@property (nonatomic) BOOL showsZoomLevelOrnament;
+@property (nonatomic) BOOL showsTimeFrameGraph;
+@property (nonatomic) BOOL framerateMeasurementEnabled;
+@property (nonatomic) MGLMapDebugMaskOptions debugMask;
+@property (nonatomic) BOOL debugLoggingEnabled;
+@property (nonatomic) BOOL reuseQueueStatsEnabled;
+
+@property (nonatomic, readonly) NSString *debugDescription;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/platform/ios/app/MBXState.m
+++ b/platform/ios/app/MBXState.m
@@ -1,0 +1,74 @@
+#import "MBXState.h"
+
+NSString *const MBXCamera = @"MBXCamera";
+NSString *const MBXUserTrackingMode = @"MBXUserTrackingMode";
+NSString *const MBXShowsUserLocation = @"MBXShowsUserLocation";
+NSString *const MBXDebugMaskValue = @"MBXDebugMaskValue";
+NSString *const MBXShowsZoomLevelOrnament =  @"MBXShowsZoomLevelOrnament";
+NSString *const MBXShowsTimeFrameGraph = @"MBXShowsFrameTimeGraph";
+NSString *const MBXDebugLoggingEnabled = @"MGLMapboxMetricsDebugLoggingEnabled";
+NSString *const MBXShowsMapScale = @"MBXMapShowsScale";
+NSString *const MBXMapShowsHeadingIndicator = @"MBXMapShowsHeadingIndicator";
+NSString *const MBXMapFramerateMeasurementEnabled = @"MBXMapFramerateMeasurementEnabled";
+NSString *const MBXReuseQueueStatsEnabled = @"MBXReuseQueueStatsEnabled";
+
+@interface MBXState()
+
+@end
+
+@implementation MBXState
+
+- (void)encodeWithCoder:(NSCoder *)coder
+{
+    [coder encodeObject:_camera forKey:MBXCamera];
+    [coder encodeObject:[NSNumber numberWithInt:_userTrackingMode] forKey:MBXUserTrackingMode];
+    [coder encodeBool:_showsUserLocation forKey:MBXShowsUserLocation];
+    [coder encodeObject:[NSNumber numberWithInt:_debugMask] forKey:MBXDebugMaskValue];
+    [coder encodeBool:_showsZoomLevelOrnament forKey:MBXShowsZoomLevelOrnament];
+    [coder encodeBool:_showsTimeFrameGraph forKey:MBXShowsTimeFrameGraph];
+    [coder encodeBool:_debugLoggingEnabled forKey:MBXDebugLoggingEnabled];
+    [coder encodeBool:_showsMapScale forKey:MBXShowsMapScale];
+    [coder encodeBool:_showsUserHeadingIndicator forKey:MBXMapShowsHeadingIndicator];
+    [coder encodeBool:_framerateMeasurementEnabled forKey:MBXMapFramerateMeasurementEnabled];
+    [coder encodeBool:_reuseQueueStatsEnabled forKey:MBXReuseQueueStatsEnabled];
+}
+
+- (nullable instancetype)initWithCoder:(nonnull NSCoder *)decoder {
+    if (self = [super init]) {
+        MGLMapCamera *decodedCamera = [decoder decodeObjectForKey:MBXCamera];
+        NSNumber *decodedUserTrackingMode = [decoder decodeObjectForKey:MBXUserTrackingMode];
+        BOOL decodedShowsUserLocation = [decoder decodeBoolForKey:MBXShowsUserLocation];
+        NSNumber *decodedDebugMaskOptions = [decoder decodeObjectForKey:MBXDebugMaskValue];
+        BOOL decodedZoomLevelOrnament = [decoder decodeBoolForKey:MBXShowsZoomLevelOrnament];
+        BOOL decodedShowsTimeFrameGraph = [decoder decodeBoolForKey:MBXShowsTimeFrameGraph];
+        BOOL decodedDebugLoggingEnabled = [decoder decodeBoolForKey:MBXDebugLoggingEnabled];
+        BOOL decodedShowsMapScale = [decoder decodeBoolForKey:MBXShowsMapScale];
+        BOOL decodedShowsUserHeadingIndicator = [decoder decodeBoolForKey:MBXMapShowsHeadingIndicator];
+        BOOL decodedFramerateMeasurementEnabled = [decoder decodeBoolForKey:MBXMapFramerateMeasurementEnabled];
+        BOOL decodedReuseQueueStatsEnabled = [decoder decodeBoolForKey:MBXReuseQueueStatsEnabled];
+
+        _camera = decodedCamera;
+        _userTrackingMode = decodedUserTrackingMode.intValue;
+        _showsUserLocation = decodedShowsUserLocation;
+        _debugMask = decodedDebugMaskOptions.intValue;
+        _showsZoomLevelOrnament = decodedZoomLevelOrnament;
+        _showsTimeFrameGraph = decodedShowsTimeFrameGraph;
+        _debugLoggingEnabled = decodedDebugLoggingEnabled;
+        _showsMapScale = decodedShowsMapScale;
+        _showsUserHeadingIndicator = decodedShowsUserHeadingIndicator;
+        _framerateMeasurementEnabled = decodedFramerateMeasurementEnabled;
+        _reuseQueueStatsEnabled = decodedReuseQueueStatsEnabled;
+    }
+
+    return self;
+}
+
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
+- (NSString*) debugDescription {
+    return [NSString stringWithFormat:@"Camera: %@\nTracking mode: %lu\nShows user location: %@\nDebug mask value: %lu\nShows zoom level ornament: %@\nShows time frame graph: %@\nDebug logging enabled: %@\nShows map scale: %@\nShows user heading indicator: %@\nFramerate measurement enabled: %@", self.camera, (unsigned long)self.userTrackingMode, (self.showsUserLocation) ? @"YES" : @"NO", (unsigned long)self.debugMask, (self.showsZoomLevelOrnament) ? @"YES" : @"NO", (self.showsTimeFrameGraph) ? @"YES" : @"NO", (self.debugLoggingEnabled) ? @"YES" : @"NO", (self.showsMapScale) ? @"YES" : @"NO", (self.showsUserHeadingIndicator) ? @"YES" : @"NO", (self.framerateMeasurementEnabled) ? @"YES" : @"NO", (self.reuseQueueStatsEnabled) ? @"YES" : @"NO"];
+}
+
+@end

--- a/platform/ios/app/MBXStateManager.h
+++ b/platform/ios/app/MBXStateManager.h
@@ -1,0 +1,19 @@
+#import <Foundation/Foundation.h>
+#import "MBXViewController.h"
+@class MBXState;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MBXStateManager : NSObject
+
++ (instancetype) sharedManager;
+
+- (MBXState *)currentState;
+
+- (void)saveState:(MBXState*)mapViewController;
+
+- (void)resetState;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/platform/ios/app/MBXStateManager.m
+++ b/platform/ios/app/MBXStateManager.m
@@ -1,0 +1,43 @@
+#import "MBXStateManager.h"
+#import <Mapbox/Mapbox.h>
+#import "MBXState.h"
+#import "MBXViewController.h"
+
+@interface MBXStateManager()
+
+@property (strong, nonatomic) MBXState *currentState;
+
+@end
+
+@implementation MBXStateManager
+
++ (instancetype) sharedManager {
+    static dispatch_once_t once;
+    static MBXStateManager* sharedManager;
+    dispatch_once(&once, ^{
+        sharedManager = [[self alloc] init];
+    });
+
+    return sharedManager;
+}
+
+- (MBXState*)currentState {
+    NSData *encodedMapState = [[NSUserDefaults standardUserDefaults] objectForKey:@"mapStateKey"];
+    MBXState *currentState = (MBXState *)[NSKeyedUnarchiver unarchiveObjectWithData: encodedMapState];
+
+    return currentState;
+}
+
+- (void)saveState:(MBXState*)mapState {
+    NSData *encodedMapState = [NSKeyedArchiver archivedDataWithRootObject:mapState];
+    [[NSUserDefaults standardUserDefaults] setObject:encodedMapState forKey:@"mapStateKey"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
+- (void)resetState {
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"mapStateKey"];
+}
+
+
+
+@end

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		071BBB071EE77631001FB02A /* MGLImageSourceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 071BBB051EE7761A001FB02A /* MGLImageSourceTests.m */; };
 		074A7F0D2277C093001A62D1 /* insert_access_token.sh in Resources */ = {isa = PBXBuildFile; fileRef = 074A7F0C2277C093001A62D1 /* insert_access_token.sh */; };
 		074A7F0E2277C093001A62D1 /* insert_access_token.sh in Resources */ = {isa = PBXBuildFile; fileRef = 074A7F0C2277C093001A62D1 /* insert_access_token.sh */; };
+		075AF842227B6762008D7A4C /* MBXState.m in Sources */ = {isa = PBXBuildFile; fileRef = 075AF841227B6762008D7A4C /* MBXState.m */; };
+		075AF845227B67C6008D7A4C /* MBXStateManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 075AF844227B67C6008D7A4C /* MBXStateManager.m */; };
 		076171C32139C70900668A35 /* MGLMapViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 076171C22139C70900668A35 /* MGLMapViewTests.m */; };
 		076171C72141A91700668A35 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 076171C62141A91700668A35 /* Settings.bundle */; };
 		077061DA215DA00E000FEF62 /* MGLTestLocationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 077061D9215DA00E000FEF62 /* MGLTestLocationManager.m */; };
@@ -854,6 +856,10 @@
 		071BBAFD1EE75CD4001FB02A /* MGLImageSource.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLImageSource.mm; sourceTree = "<group>"; };
 		071BBB051EE7761A001FB02A /* MGLImageSourceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MGLImageSourceTests.m; path = ../../darwin/test/MGLImageSourceTests.m; sourceTree = "<group>"; };
 		074A7F0C2277C093001A62D1 /* insert_access_token.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = insert_access_token.sh; sourceTree = "<group>"; };
+		075AF840227B6762008D7A4C /* MBXState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MBXState.h; sourceTree = "<group>"; };
+		075AF841227B6762008D7A4C /* MBXState.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MBXState.m; sourceTree = "<group>"; };
+		075AF843227B67C5008D7A4C /* MBXStateManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MBXStateManager.h; sourceTree = "<group>"; };
+		075AF844227B67C6008D7A4C /* MBXStateManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MBXStateManager.m; sourceTree = "<group>"; };
 		076171C22139C70900668A35 /* MGLMapViewTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MGLMapViewTests.m; path = ../../darwin/test/MGLMapViewTests.m; sourceTree = "<group>"; };
 		076171C62141A91700668A35 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = Settings.bundle; path = app/Settings.bundle; sourceTree = SOURCE_ROOT; };
 		077061D9215DA00E000FEF62 /* MGLTestLocationManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLTestLocationManager.m; sourceTree = "<group>"; };
@@ -1969,6 +1975,10 @@
 				076171C62141A91700668A35 /* Settings.bundle */,
 				9604FC341F313A5E003EEA02 /* Fixtures */,
 				DA1DC94D1CB6C1C2006E619F /* Supporting Files */,
+				075AF840227B6762008D7A4C /* MBXState.h */,
+				075AF841227B6762008D7A4C /* MBXState.m */,
+				075AF843227B67C5008D7A4C /* MBXStateManager.h */,
+				075AF844227B67C6008D7A4C /* MBXStateManager.m */,
 			);
 			name = "Demo App";
 			path = app;
@@ -3186,7 +3196,9 @@
 				DA1DC9991CB6E054006E619F /* MBXAppDelegate.m in Sources */,
 				6FA9341721EF372100AA9CA8 /* MBXOrnamentsViewController.m in Sources */,
 				DA1DC96B1CB6C6B7006E619F /* MBXOfflinePacksTableViewController.m in Sources */,
+				075AF845227B67C6008D7A4C /* MBXStateManager.m in Sources */,
 				DA1DC96A1CB6C6B7006E619F /* MBXCustomCalloutView.m in Sources */,
+				075AF842227B6762008D7A4C /* MBXState.m in Sources */,
 				927FBCFC1F4DAA8300F8BF1F /* MBXSnapshotsViewController.m in Sources */,
 				DA1DC99B1CB6E064006E619F /* MBXViewController.m in Sources */,
 				40FDA76B1CCAAA6800442548 /* MBXAnnotationView.m in Sources */,


### PR DESCRIPTION
This PR refactors how `iosapp` saves the current map when the application's state changes. Instead of registering values within `NSUserDefaults` inside `MBXViewController`, we'll now make use of a `[MBXStateManager sharedManager]` singleton, which will become responsible for saving/restoring/resetting the state of the map.