### PR TITLE
Keep strong references to the FileSource/OfflineManager operations callbacks

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
@@ -2,11 +2,12 @@ package com.mapbox.mapboxsdk.offline;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.os.AsyncTask;
 import android.os.Handler;
 import android.os.Looper;
+import android.support.annotation.AnyThread;
 import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
+import android.support.annotation.UiThread;
 
 import com.mapbox.mapboxsdk.LibraryLoader;
 import com.mapbox.mapboxsdk.Mapbox;
@@ -21,7 +22,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.lang.ref.WeakReference;
 import java.nio.channels.FileChannel;
 
 /**
@@ -32,6 +32,7 @@ import java.nio.channels.FileChannel;
  *
  * @see <a href="https://docs.mapbox.com/help/troubleshooting/mobile-offline/">Offline Maps Information/</a>
  */
+@UiThread
 public class OfflineManager {
 
   private static final String TAG = "Mbgl - OfflineManager";
@@ -156,6 +157,7 @@ public class OfflineManager {
     return instance;
   }
 
+  @AnyThread
   private Handler getHandler() {
     if (handler == null) {
       handler = new Handler(Looper.getMainLooper());
@@ -205,6 +207,8 @@ public class OfflineManager {
    * Merge offline regions from a secondary database into the main offline database.
    * <p>
    * When the merge is completed, or fails, the {@link MergeOfflineRegionsCallback} will be invoked on the main thread.
+   * The callback reference is <b>strongly kept</b> throughout the process,
+   * so it needs to be wrapped in a weak reference or released on the client side if necessary.
    * <p>
    * The secondary database may need to be upgraded to the latest schema.
    * This is done in-place and requires write-access to the provided path.
@@ -225,73 +229,50 @@ public class OfflineManager {
    */
   public void mergeOfflineRegions(@NonNull String path, @NonNull final MergeOfflineRegionsCallback callback) {
     final File src = new File(path);
-    new FileUtils.CheckFileReadPermissionTask(new FileUtils.OnCheckFileReadPermissionListener() {
+    new Thread(new Runnable() {
       @Override
-      public void onReadPermissionGranted() {
-        new FileUtils.CheckFileWritePermissionTask(new FileUtils.OnCheckFileWritePermissionListener() {
-          @Override
-          public void onWritePermissionGranted() {
-            // path writable, merge and update schema in place if necessary
-            mergeOfflineDatabaseFiles(src, callback, false);
+      public void run() {
+        String errorMessage = null;
+        if (src.canWrite()) {
+          getHandler().post(new Runnable() {
+            @Override
+            public void run() {
+              // path writable, merge and update schema in place if necessary
+              mergeOfflineDatabaseFiles(src, callback, false);
+            }
+          });
+        } else if (src.canRead()) {
+          // path not writable, copy the the file to temp directory
+          final File dst = new File(FileSource.getInternalCachePath(context), src.getName());
+          try {
+            copyTempDatabaseFile(src, dst);
+            getHandler().post(new Runnable() {
+              @Override
+              public void run() {
+                // merge and update schema using the copy
+                OfflineManager.this.mergeOfflineDatabaseFiles(dst, callback, true);
+              }
+            });
+          } catch (IOException ex) {
+            ex.printStackTrace();
+            errorMessage = ex.getMessage();
           }
+        } else {
+          // path not readable, abort
+          errorMessage = "Secondary database needs to be located in a readable path.";
+        }
 
-          @Override
-          public void onError() {
-            // path not writable, copy the the file to temp directory, then merge and update schema on a copy if
-            // necessary
-            File dst = new File(FileSource.getInternalCachePath(context), src.getName());
-            new CopyTempDatabaseFileTask(OfflineManager.this, callback).execute(src, dst);
-          }
-        }).execute(src);
-      }
-
-      @Override
-      public void onError() {
-        // path not readable, abort
-        callback.onError("Secondary database needs to be located in a readable path.");
-      }
-    }).execute(src);
-  }
-
-  private static final class CopyTempDatabaseFileTask extends AsyncTask<Object, Void, Object> {
-    @NonNull
-    private final WeakReference<OfflineManager> offlineManagerWeakReference;
-    @NonNull
-    private final WeakReference<MergeOfflineRegionsCallback> callbackWeakReference;
-
-    CopyTempDatabaseFileTask(OfflineManager offlineManager, MergeOfflineRegionsCallback callback) {
-      this.offlineManagerWeakReference = new WeakReference<>(offlineManager);
-      this.callbackWeakReference = new WeakReference<>(callback);
-    }
-
-    @Override
-    protected Object doInBackground(Object... objects) {
-      File src = (File) objects[0];
-      File dst = (File) objects[1];
-
-      try {
-        copyTempDatabaseFile(src, dst);
-        return dst;
-      } catch (IOException ex) {
-        return ex.getMessage();
-      }
-    }
-
-    @Override
-    protected void onPostExecute(Object object) {
-      MergeOfflineRegionsCallback callback = callbackWeakReference.get();
-      if (callback != null) {
-        OfflineManager offlineManager = offlineManagerWeakReference.get();
-        if (object instanceof File && offlineManager != null) {
-          // successfully copied the file, perform merge
-          File dst = (File) object;
-          offlineManager.mergeOfflineDatabaseFiles(dst, callback, true);
-        } else if (object instanceof String) {
-          // error occurred
-          callback.onError((String) object);
+        if (errorMessage != null) {
+          final String finalErrorMessage = errorMessage;
+          getHandler().post(new Runnable() {
+            @Override
+            public void run() {
+              callback.onError(finalErrorMessage);
+            }
+          });
         }
       }
-    }
+    }).start();
   }
 
   private static void copyTempDatabaseFile(@NonNull File sourceFile, File destFile) throws IOException {
@@ -324,13 +305,13 @@ public class OfflineManager {
     mergeOfflineRegions(fileSource, file.getAbsolutePath(), new MergeOfflineRegionsCallback() {
       @Override
       public void onMerge(final OfflineRegion[] offlineRegions) {
+        if (isTemporaryFile) {
+          file.delete();
+        }
         getHandler().post(new Runnable() {
           @Override
           public void run() {
             fileSource.deactivate();
-            if (isTemporaryFile) {
-              file.delete();
-            }
             callback.onMerge(offlineRegions);
           }
         });
@@ -338,13 +319,13 @@ public class OfflineManager {
 
       @Override
       public void onError(final String error) {
+        if (isTemporaryFile) {
+          file.delete();
+        }
         getHandler().post(new Runnable() {
           @Override
           public void run() {
             fileSource.deactivate();
-            if (isTemporaryFile) {
-              file.delete();
-            }
             callback.onError(error);
           }
         });

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/FileUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/FileUtils.java
@@ -6,7 +6,6 @@ import android.support.annotation.NonNull;
 import com.mapbox.mapboxsdk.log.Logger;
 
 import java.io.File;
-import java.lang.ref.WeakReference;
 
 public class FileUtils {
 
@@ -14,13 +13,16 @@ public class FileUtils {
 
   /**
    * Task checking whether app's process can read a file.
+   * <p>
+   * The callback reference is <b>strongly kept</b> throughout the process,
+   * so it needs to be wrapped in a weak reference or released on the client side if necessary.
    */
   public static class CheckFileReadPermissionTask extends AsyncTask<File, Void, Boolean> {
     @NonNull
-    private final WeakReference<OnCheckFileReadPermissionListener> listenerWeakReference;
+    private final OnCheckFileReadPermissionListener listener;
 
-    public CheckFileReadPermissionTask(OnCheckFileReadPermissionListener listener) {
-      this.listenerWeakReference = new WeakReference<>(listener);
+    public CheckFileReadPermissionTask(@NonNull OnCheckFileReadPermissionListener listener) {
+      this.listener = listener;
     }
 
     @Override
@@ -34,21 +36,15 @@ public class FileUtils {
 
     @Override
     protected void onCancelled() {
-      OnCheckFileReadPermissionListener listener = listenerWeakReference.get();
-      if (listener != null) {
-        listener.onError();
-      }
+      listener.onError();
     }
 
     @Override
     protected void onPostExecute(Boolean result) {
-      OnCheckFileReadPermissionListener listener = listenerWeakReference.get();
-      if (listener != null) {
-        if (result) {
-          listener.onReadPermissionGranted();
-        } else {
-          listener.onError();
-        }
+      if (result) {
+        listener.onReadPermissionGranted();
+      } else {
+        listener.onError();
       }
     }
   }
@@ -71,13 +67,16 @@ public class FileUtils {
 
   /**
    * Task checking whether app's process can write to a file.
+   * <p>
+   * The callback reference is <b>strongly kept</b> throughout the process,
+   * so it needs to be wrapped in a weak reference or released on the client side if necessary.
    */
   public static class CheckFileWritePermissionTask extends AsyncTask<File, Void, Boolean> {
     @NonNull
-    private final WeakReference<OnCheckFileWritePermissionListener> listenerWeakReference;
+    private final OnCheckFileWritePermissionListener listener;
 
-    public CheckFileWritePermissionTask(OnCheckFileWritePermissionListener listener) {
-      this.listenerWeakReference = new WeakReference<>(listener);
+    public CheckFileWritePermissionTask(@NonNull OnCheckFileWritePermissionListener listener) {
+      this.listener = listener;
     }
 
     @Override
@@ -91,21 +90,15 @@ public class FileUtils {
 
     @Override
     protected void onCancelled() {
-      OnCheckFileWritePermissionListener listener = listenerWeakReference.get();
-      if (listener != null) {
-        listener.onError();
-      }
+      listener.onError();
     }
 
     @Override
     protected void onPostExecute(Boolean result) {
-      OnCheckFileWritePermissionListener listener = listenerWeakReference.get();
-      if (listener != null) {
-        if (result) {
-          listener.onWritePermissionGranted();
-        } else {
-          listener.onError();
-        }
+      if (result) {
+        listener.onWritePermissionGranted();
+      } else {
+        listener.onError();
       }
     }
   }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceMapTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceMapTest.kt
@@ -36,12 +36,12 @@ open class FileSourceMapTest {
   fun changeResourcesPathWhileMapVisible() {
     val latch = CountDownLatch(1)
     rule.activity.runOnUiThread {
-      FileSource.setResourcesCachePath(rule.activity, fileSourceTestUtils.testPath, object : FileSource.ResourcesCachePathChangeCallback {
-        override fun onSuccess(path: String?) {
+      FileSource.setResourcesCachePath(fileSourceTestUtils.testPath, object : FileSource.ResourcesCachePathChangeCallback {
+        override fun onSuccess(path: String) {
           Assert.fail("Requested resources change while the map is running should fail")
         }
 
-        override fun onError(message: String?) {
+        override fun onError(message: String) {
           Assert.assertEquals("Cannot set path, file source is activated."
             + " Make sure that the map or a resources download is not running.", message)
           latch.countDown()

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceTestUtils.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceTestUtils.kt
@@ -33,14 +33,13 @@ class FileSourceTestUtils(private val activity: Activity) {
     val latch = CountDownLatch(1)
     activity.runOnUiThread {
       FileSource.setResourcesCachePath(
-        activity,
         path,
         object : FileSource.ResourcesCachePathChangeCallback {
-          override fun onSuccess(path: String?) {
+          override fun onSuccess(path: String) {
             latch.countDown()
           }
 
-          override fun onError(message: String?) {
+          override fun onError(message: String) {
             Assert.fail("Resource path change failed - path: $path, message: $message")
           }
         })

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/offline/ChangeResourcesCachePathActivity.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/offline/ChangeResourcesCachePathActivity.kt
@@ -32,6 +32,8 @@ class ChangeResourcesCachePathActivity : AppCompatActivity(),
 
   private lateinit var offlineManager: OfflineManager
 
+  private val callback = PathChangeCallback(this)
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_change_resources_cache_path)
@@ -50,18 +52,23 @@ class ChangeResourcesCachePathActivity : AppCompatActivity(),
     Toast.makeText(this, "Current path: $path", Toast.LENGTH_LONG).show()
   }
 
+  override fun onDestroy() {
+    super.onDestroy()
+    callback.onActivityDestroy()
+  }
+
   override fun onItemClick(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
     listView.onItemClickListener = null
     val path: String = adapter.getItem(position) as String
-    FileSource.setResourcesCachePath(this, path, this)
+    FileSource.setResourcesCachePath(path, callback)
   }
 
-  override fun onError(message: String?) {
+  override fun onError(message: String) {
     listView.onItemClickListener = this
     Toast.makeText(this, "Error: $message", Toast.LENGTH_LONG).show()
   }
 
-  override fun onSuccess(path: String?) {
+  override fun onSuccess(path: String) {
     listView.onItemClickListener = this
     Toast.makeText(this, "New path: $path", Toast.LENGTH_LONG).show()
 
@@ -116,6 +123,21 @@ class ChangeResourcesCachePathActivity : AppCompatActivity(),
       }
     }
     return paths
+  }
+
+  private class PathChangeCallback(private var activity: ChangeResourcesCachePathActivity?) : FileSource.ResourcesCachePathChangeCallback {
+
+    override fun onSuccess(path: String) {
+      activity?.onSuccess(path)
+    }
+
+    override fun onError(message: String) {
+      activity?.onError(message)
+    }
+
+    fun onActivityDestroy() {
+      activity = null
+    }
   }
 
   class PathAdapter(private val context: Context, private val paths: List<String>) : BaseAdapter() {


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/14485 and fixes https://github.com/mapbox/mapbox-gl-native/issues/14297.
Refs https://github.com/mapbox/mapbox-gl-native/pull/14589#issuecomment-489646621.

This PR aims to remove weak references overuse during the offline database merge and resources path change operations. This could lead to the callback reference during any step of the process to be garbage collected if not kept on the client side and result in a no-op.

The initial idea of keeping weak references to the callbacks was to ensure that we are not outliving the hosting activity, which might've been passed with the callback reference. However, the callback is not required to be depending on the hosting activity and it can (and should) be wrapped in a weak reference on the client side if that's the case, which is out of our control.

In any way, debugging why the callback has outlived the hosting object is much easier than looking for a cause of a no-op, which is why I believe that this change is a general improvement.

TODO:
- [x] offline merge
- [x] resources cache path change
- [x] ~deprecate `FileUtils` methods~ opted to keep them around

This is an initial proposal, please let me know what you think @Guardiola31337 @tobrun and I can move forward with the remaining to-do items if you think the approach is correct.