### PR TITLE
[core] Remove clipping option from RenderTile and style::Layer

### DIFF
--- a/include/mbgl/style/layer.hpp
+++ b/include/mbgl/style/layer.hpp
@@ -45,12 +45,6 @@ struct LayerTypeInfo {
     const enum class Layout { Required, NotRequired } layout;
 
     /**
-     * @brief contains \c Clipping::Required if the corresponding layer type
-     * requires clipping. Contains \c Clipping::NotRequired otherwise.
-     */
-    const enum class Clipping { Required, NotRequired } clipping;
-
-    /**
      * @brief contains \c FadingTiles::Required if the corresponding layer type
      * requires rendering on fading tiles. Contains \c FadingTiles::NotRequired otherwise.
      */

--- a/src/mbgl/renderer/render_tile.hpp
+++ b/src/mbgl/renderer/render_tile.hpp
@@ -26,7 +26,6 @@ public:
     mat4 matrix;
     mat4 nearClippedMatrix;
     bool used = false;
-    bool needsClipping = false;
 
     mat4 translatedMatrix(const std::array<float, 2>& translate,
                           style::TranslateAnchorType anchor,

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -255,7 +255,6 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
                                                            : static_cast<bool>(tile.getBucket(*layerProperties->baseImpl));
             if (layerRenderableInTile) {
                 renderTile.used = true;
-                renderTile.needsClipping = (renderTile.needsClipping || typeInfo->clipping == LayerTypeInfo::Clipping::Required);
             }
         }
     }

--- a/src/mbgl/style/layers/background_layer.cpp
+++ b/src/mbgl/style/layers/background_layer.cpp
@@ -23,7 +23,6 @@ const LayerTypeInfo* BackgroundLayer::Impl::staticTypeInfo() noexcept {
           LayerTypeInfo::Source::NotRequired,
           LayerTypeInfo::Pass3D::NotRequired,
           LayerTypeInfo::Layout::NotRequired,
-          LayerTypeInfo::Clipping::NotRequired,
           LayerTypeInfo::FadingTiles::NotRequired
         };
     return &typeInfo;

--- a/src/mbgl/style/layers/circle_layer.cpp
+++ b/src/mbgl/style/layers/circle_layer.cpp
@@ -23,7 +23,6 @@ const LayerTypeInfo* CircleLayer::Impl::staticTypeInfo() noexcept {
           LayerTypeInfo::Source::Required,
           LayerTypeInfo::Pass3D::NotRequired,
           LayerTypeInfo::Layout::NotRequired,
-          LayerTypeInfo::Clipping::NotRequired,
           LayerTypeInfo::FadingTiles::NotRequired
         };
     return &typeInfo;

--- a/src/mbgl/style/layers/custom_layer.cpp
+++ b/src/mbgl/style/layers/custom_layer.cpp
@@ -13,7 +13,6 @@ namespace {
       LayerTypeInfo::Source::NotRequired,
       LayerTypeInfo::Pass3D::NotRequired,
       LayerTypeInfo::Layout::NotRequired,
-      LayerTypeInfo::Clipping::NotRequired,
       LayerTypeInfo::FadingTiles::NotRequired };
 }  // namespace
 

--- a/src/mbgl/style/layers/fill_extrusion_layer.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer.cpp
@@ -23,7 +23,6 @@ const LayerTypeInfo* FillExtrusionLayer::Impl::staticTypeInfo() noexcept {
           LayerTypeInfo::Source::Required,
           LayerTypeInfo::Pass3D::Required,
           LayerTypeInfo::Layout::Required,
-          LayerTypeInfo::Clipping::NotRequired,
           LayerTypeInfo::FadingTiles::NotRequired
         };
     return &typeInfo;

--- a/src/mbgl/style/layers/fill_layer.cpp
+++ b/src/mbgl/style/layers/fill_layer.cpp
@@ -23,7 +23,6 @@ const LayerTypeInfo* FillLayer::Impl::staticTypeInfo() noexcept {
           LayerTypeInfo::Source::Required,
           LayerTypeInfo::Pass3D::NotRequired,
           LayerTypeInfo::Layout::Required,
-          LayerTypeInfo::Clipping::Required,
           LayerTypeInfo::FadingTiles::NotRequired
         };
     return &typeInfo;

--- a/src/mbgl/style/layers/heatmap_layer.cpp
+++ b/src/mbgl/style/layers/heatmap_layer.cpp
@@ -23,7 +23,6 @@ const LayerTypeInfo* HeatmapLayer::Impl::staticTypeInfo() noexcept {
           LayerTypeInfo::Source::Required,
           LayerTypeInfo::Pass3D::Required,
           LayerTypeInfo::Layout::NotRequired,
-          LayerTypeInfo::Clipping::NotRequired,
           LayerTypeInfo::FadingTiles::NotRequired
         };
     return &typeInfo;

--- a/src/mbgl/style/layers/hillshade_layer.cpp
+++ b/src/mbgl/style/layers/hillshade_layer.cpp
@@ -23,7 +23,6 @@ const LayerTypeInfo* HillshadeLayer::Impl::staticTypeInfo() noexcept {
           LayerTypeInfo::Source::Required,
           LayerTypeInfo::Pass3D::Required,
           LayerTypeInfo::Layout::NotRequired,
-          LayerTypeInfo::Clipping::NotRequired,
           LayerTypeInfo::FadingTiles::NotRequired
         };
     return &typeInfo;

--- a/src/mbgl/style/layers/layer.cpp.ejs
+++ b/src/mbgl/style/layers/layer.cpp.ejs
@@ -25,7 +25,6 @@ let layerCapabilities = {};
 let defaults = { caps: { 'Source':   'NotRequired',
                          'Pass3D':   'NotRequired',
                          'Layout':   'NotRequired',
-                         'Clipping': 'NotRequired',
                          'FadingTiles': 'NotRequired'
                  },
                  require: function(cap) {
@@ -45,7 +44,6 @@ let defaults = { caps: { 'Source':   'NotRequired',
 layerCapabilities['background']     = defaults.finalize();
 layerCapabilities['fill']           = defaults.require('Source')
                                               .require('Layout')
-                                              .require('Clipping')
                                               .finalize();
 layerCapabilities['fill-extrusion'] = defaults.require('Source')
                                               .require('Pass3D')

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -23,7 +23,6 @@ const LayerTypeInfo* LineLayer::Impl::staticTypeInfo() noexcept {
           LayerTypeInfo::Source::Required,
           LayerTypeInfo::Pass3D::NotRequired,
           LayerTypeInfo::Layout::Required,
-          LayerTypeInfo::Clipping::Required,
           LayerTypeInfo::FadingTiles::NotRequired
         };
     return &typeInfo;

--- a/src/mbgl/style/layers/raster_layer.cpp
+++ b/src/mbgl/style/layers/raster_layer.cpp
@@ -23,7 +23,6 @@ const LayerTypeInfo* RasterLayer::Impl::staticTypeInfo() noexcept {
           LayerTypeInfo::Source::Required,
           LayerTypeInfo::Pass3D::NotRequired,
           LayerTypeInfo::Layout::NotRequired,
-          LayerTypeInfo::Clipping::NotRequired,
           LayerTypeInfo::FadingTiles::NotRequired
         };
     return &typeInfo;

--- a/src/mbgl/style/layers/symbol_layer.cpp
+++ b/src/mbgl/style/layers/symbol_layer.cpp
@@ -23,7 +23,6 @@ const LayerTypeInfo* SymbolLayer::Impl::staticTypeInfo() noexcept {
           LayerTypeInfo::Source::Required,
           LayerTypeInfo::Pass3D::NotRequired,
           LayerTypeInfo::Layout::Required,
-          LayerTypeInfo::Clipping::NotRequired,
           LayerTypeInfo::FadingTiles::Required
         };
     return &typeInfo;


### PR DESCRIPTION
Not used after https://github.com/mapbox/mapbox-gl-native/commit/08163713e239ab7756dc9bbe9b6e2c4986f168d3