### PR TITLE
Option to provide custom values for location camera transition

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
@@ -43,6 +43,7 @@ import static com.mapbox.mapboxsdk.location.LocationComponentConstants.DEFAULT_F
 import static com.mapbox.mapboxsdk.location.LocationComponentConstants.DEFAULT_INTERVAL_MILLIS;
 import static com.mapbox.mapboxsdk.location.LocationComponentConstants.DEFAULT_TRACKING_TILT_ANIM_DURATION;
 import static com.mapbox.mapboxsdk.location.LocationComponentConstants.DEFAULT_TRACKING_ZOOM_ANIM_DURATION;
+import static com.mapbox.mapboxsdk.location.LocationComponentConstants.TRANSITION_ANIMATION_DURATION_MS;
 
 /**
  * The Location Component provides location awareness to your mobile application. Enabling this
@@ -524,7 +525,6 @@ public final class LocationComponent {
    * @param cameraMode one of the modes found in {@link CameraMode}
    */
   public void setCameraMode(@CameraMode.Mode int cameraMode) {
-    checkActivationState();
     setCameraMode(cameraMode, null);
   }
 
@@ -550,8 +550,45 @@ public final class LocationComponent {
    */
   public void setCameraMode(@CameraMode.Mode int cameraMode,
                             @Nullable OnLocationCameraTransitionListener transitionListener) {
+    setCameraMode(cameraMode, TRANSITION_ANIMATION_DURATION_MS, null, null, null, transitionListener);
+  }
+
+  /**
+   * Sets the camera mode, which determines how the map camera will track the rendered location.
+   * <p>
+   * When camera is transitioning to a new mode, it will reject inputs like {@link #zoomWhileTracking(double)} or
+   * {@link #tiltWhileTracking(double)}.
+   * Use {@link OnLocationCameraTransitionListener} to listen for the transition state.
+   * <p>
+   * Set values of zoom, bearing and tilt that the camera will transition to. If null is passed to any of those,
+   * current value will be used for that parameter instead.
+   * If the camera is already tracking, provided values are ignored.
+   * <p>
+   * <ul>
+   * <li>{@link CameraMode#NONE}: No camera tracking</li>
+   * <li>{@link CameraMode#NONE_COMPASS}: Camera does not track location, but does track compass bearing</li>
+   * <li>{@link CameraMode#NONE_GPS}: Camera does not track location, but does track GPS bearing</li>
+   * <li>{@link CameraMode#TRACKING}: Camera tracks the user location</li>
+   * <li>{@link CameraMode#TRACKING_COMPASS}: Camera tracks the user location, with bearing provided by a compass</li>
+   * <li>{@link CameraMode#TRACKING_GPS}: Camera tracks the user location, with normalized bearing</li>
+   * <li>{@link CameraMode#TRACKING_GPS_NORTH}: Camera tracks the user location, with bearing always set to north</li>
+   * </ul>
+   *
+   * @param cameraMode         one of the modes found in {@link CameraMode}
+   * @param transitionDuration duration of the transition in milliseconds
+   * @param zoom               target zoom, set to null to use current camera position
+   * @param bearing            target bearing, set to null to use current camera position
+   * @param tilt               target tilt, set to null to use current camera position
+   * @param transitionListener callback that's going to be invoked when the transition animation finishes
+   */
+  public void setCameraMode(@CameraMode.Mode int cameraMode,
+                            long transitionDuration,
+                            @Nullable Double zoom, @Nullable Double bearing, @Nullable Double tilt,
+                            @Nullable OnLocationCameraTransitionListener transitionListener) {
     checkActivationState();
-    locationCameraController.setCameraMode(cameraMode, lastLocation, new CameraTransitionListener(transitionListener));
+    locationCameraController.setCameraMode(
+      cameraMode, lastLocation, transitionDuration, zoom, bearing, tilt,
+      new CameraTransitionListener(transitionListener));
     updateCompassListenerState(true);
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationCameraControllerTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationCameraControllerTest.java
@@ -22,6 +22,7 @@ import org.mockito.stubbing.Answer;
 
 import java.util.Set;
 
+import static com.mapbox.mapboxsdk.location.LocationComponentConstants.TRANSITION_ANIMATION_DURATION_MS;
 import static com.mapbox.mapboxsdk.location.MapboxAnimator.ANIMATOR_CAMERA_COMPASS_BEARING;
 import static com.mapbox.mapboxsdk.location.MapboxAnimator.ANIMATOR_CAMERA_GPS_BEARING;
 import static com.mapbox.mapboxsdk.location.MapboxAnimator.ANIMATOR_CAMERA_LATLNG;
@@ -522,7 +523,7 @@ public class LocationCameraControllerTest {
     camera.initializeOptions(mock(LocationComponentOptions.class));
     OnLocationCameraTransitionListener listener = mock(OnLocationCameraTransitionListener.class);
 
-    camera.setCameraMode(TRACKING, null, listener);
+    camera.setCameraMode(TRACKING, null, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
     Assert.assertEquals(TRACKING, camera.getCameraMode());
     verify(listener).onLocationCameraTransitionFinished(TRACKING);
     verify(mapboxMap, times(0))
@@ -537,7 +538,7 @@ public class LocationCameraControllerTest {
     OnLocationCameraTransitionListener listener = mock(OnLocationCameraTransitionListener.class);
     Location location = mock(Location.class);
 
-    camera.setCameraMode(NONE, location, listener);
+    camera.setCameraMode(NONE, location, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
     verify(listener, times(1)).onLocationCameraTransitionFinished(NONE);
     verify(mapboxMap, times(0))
       .animateCamera(any(CameraUpdate.class), any(Integer.class), any(MapboxMap.CancelableCallback.class));
@@ -564,7 +565,7 @@ public class LocationCameraControllerTest {
     }).when(mapboxMap).animateCamera(any(CameraUpdate.class), any(Integer.class), any(MapboxMap.CancelableCallback
       .class));
 
-    camera.setCameraMode(TRACKING, location, listener);
+    camera.setCameraMode(TRACKING, location, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
     verify(listener).onLocationCameraTransitionFinished(TRACKING);
     verify(mapboxMap)
       .animateCamera(any(CameraUpdate.class), any(Integer.class), any(MapboxMap.CancelableCallback.class));
@@ -582,7 +583,7 @@ public class LocationCameraControllerTest {
     final OnLocationCameraTransitionListener listener = mock(OnLocationCameraTransitionListener.class);
     Location location = mock(Location.class);
 
-    camera.setCameraMode(TRACKING, location, listener);
+    camera.setCameraMode(TRACKING, location, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
 
     doAnswer(new Answer<Void>() {
       @Override
@@ -593,7 +594,7 @@ public class LocationCameraControllerTest {
     }).when(mapboxMap).animateCamera(any(CameraUpdate.class), any(Integer.class), any(MapboxMap.CancelableCallback
       .class));
 
-    camera.setCameraMode(TRACKING_GPS_NORTH, location, listener);
+    camera.setCameraMode(TRACKING_GPS_NORTH, location, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
     verify(listener, times(1)).onLocationCameraTransitionFinished(TRACKING_GPS_NORTH);
     verify(mapboxMap, times(1))
       .animateCamera(any(CameraUpdate.class), any(Integer.class), any(MapboxMap.CancelableCallback.class));
@@ -620,7 +621,7 @@ public class LocationCameraControllerTest {
     }).when(mapboxMap).animateCamera(any(CameraUpdate.class), any(Integer.class), any(MapboxMap.CancelableCallback
       .class));
 
-    camera.setCameraMode(TRACKING, location, listener);
+    camera.setCameraMode(TRACKING, location, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
     verify(listener).onLocationCameraTransitionCanceled(TRACKING);
     verify(mapboxMap)
       .animateCamera(any(CameraUpdate.class), any(Integer.class), any(MapboxMap.CancelableCallback.class));
@@ -645,12 +646,12 @@ public class LocationCameraControllerTest {
     ArgumentCaptor<MapboxMap.CancelableCallback> callbackCaptor
       = ArgumentCaptor.forClass(MapboxMap.CancelableCallback.class);
 
-    camera.setCameraMode(TRACKING, location, listener);
+    camera.setCameraMode(TRACKING, location, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
 
     CameraPosition.Builder builder = new CameraPosition.Builder().target(new LatLng(location));
     verify(mapboxMap).animateCamera(
       eq(CameraUpdateFactory.newCameraPosition(builder.build())),
-      eq((int) LocationComponentConstants.TRANSITION_ANIMATION_DURATION_MS),
+      eq((int) TRANSITION_ANIMATION_DURATION_MS),
       callbackCaptor.capture());
 
     Assert.assertTrue(camera.isTransitioning());
@@ -681,7 +682,7 @@ public class LocationCameraControllerTest {
     ArgumentCaptor<MapboxMap.CancelableCallback> callbackCaptor
       = ArgumentCaptor.forClass(MapboxMap.CancelableCallback.class);
 
-    camera.setCameraMode(TRACKING, location, listener);
+    camera.setCameraMode(TRACKING, location, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
 
     CameraPosition.Builder builder = new CameraPosition.Builder().target(new LatLng(location));
     verify(mapboxMap).moveCamera(
@@ -716,12 +717,12 @@ public class LocationCameraControllerTest {
     ArgumentCaptor<MapboxMap.CancelableCallback> callbackCaptor
       = ArgumentCaptor.forClass(MapboxMap.CancelableCallback.class);
 
-    camera.setCameraMode(TRACKING, location, listener);
+    camera.setCameraMode(TRACKING, location, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
 
     CameraPosition.Builder builder = new CameraPosition.Builder().target(new LatLng(location));
     verify(mapboxMap).animateCamera(
       eq(CameraUpdateFactory.newCameraPosition(builder.build())),
-      eq((int) LocationComponentConstants.TRANSITION_ANIMATION_DURATION_MS),
+      eq((int) TRANSITION_ANIMATION_DURATION_MS),
       callbackCaptor.capture());
 
     Assert.assertTrue(camera.isTransitioning());
@@ -749,12 +750,12 @@ public class LocationCameraControllerTest {
     when(location.getBearing()).thenReturn(30f);
     when(location.getAltitude()).thenReturn(0.0);
 
-    camera.setCameraMode(TRACKING_GPS, location, listener);
+    camera.setCameraMode(TRACKING_GPS, location, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
 
     CameraPosition.Builder builder = new CameraPosition.Builder().target(new LatLng(location)).bearing(30);
     verify(mapboxMap).animateCamera(
       eq(CameraUpdateFactory.newCameraPosition(builder.build())),
-      eq((int) LocationComponentConstants.TRANSITION_ANIMATION_DURATION_MS),
+      eq((int) TRANSITION_ANIMATION_DURATION_MS),
       any(MapboxMap.CancelableCallback.class));
   }
 
@@ -774,12 +775,12 @@ public class LocationCameraControllerTest {
     when(location.getBearing()).thenReturn(30f);
     when(location.getAltitude()).thenReturn(0.0);
 
-    camera.setCameraMode(TRACKING_GPS_NORTH, location, listener);
+    camera.setCameraMode(TRACKING_GPS_NORTH, location, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
 
     CameraPosition.Builder builder = new CameraPosition.Builder().target(new LatLng(location)).bearing(0);
     verify(mapboxMap).animateCamera(
       eq(CameraUpdateFactory.newCameraPosition(builder.build())),
-      eq((int) LocationComponentConstants.TRANSITION_ANIMATION_DURATION_MS),
+      eq((int) TRANSITION_ANIMATION_DURATION_MS),
       any(MapboxMap.CancelableCallback.class));
   }
 
@@ -798,11 +799,11 @@ public class LocationCameraControllerTest {
     ArgumentCaptor<MapboxMap.CancelableCallback> callbackCaptor
       = ArgumentCaptor.forClass(MapboxMap.CancelableCallback.class);
 
-    camera.setCameraMode(TRACKING_GPS, location, listener);
+    camera.setCameraMode(TRACKING_GPS, location, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
 
     verify(mapboxMap).animateCamera(
       any(CameraUpdate.class),
-      eq((int) LocationComponentConstants.TRANSITION_ANIMATION_DURATION_MS),
+      eq((int) TRANSITION_ANIMATION_DURATION_MS),
       callbackCaptor.capture());
 
     LatLng latLng = new LatLng(10, 10);
@@ -821,6 +822,30 @@ public class LocationCameraControllerTest {
     getAnimationListener(ANIMATOR_ZOOM, camera.getAnimationListeners()).onNewAnimationValue(10f);
 
     verify(mapboxMap, times(4)).moveCamera(any(CameraUpdate.class));
+  }
+
+  @Test
+  public void transition_customAnimation() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    when(mapboxMap.getCameraPosition()).thenReturn(CameraPosition.DEFAULT);
+    Projection projection = mock(Projection.class);
+    when(mapboxMap.getProjection()).thenReturn(projection);
+    when(projection.getMetersPerPixelAtLatitude(any(Double.class))).thenReturn(Double.valueOf(1000));
+    LocationCameraController camera = buildCamera(mapboxMap);
+    camera.initializeOptions(mock(LocationComponentOptions.class));
+    Location location = mock(Location.class);
+    CameraUpdate cameraUpdate = CameraUpdateFactory.newCameraPosition(
+      new CameraPosition.Builder()
+        .target(new LatLng(location))
+        .zoom(14.0)
+        .bearing(13.0)
+        .tilt(45.0)
+        .build()
+    );
+
+    camera.setCameraMode(TRACKING, location, 1200, 14.0, 13.0, 45.0, null);
+    verify(mapboxMap)
+      .animateCamera(eq(cameraUpdate), eq(1200), any(MapboxMap.CancelableCallback.class));
   }
 
   private LocationCameraController buildCamera(OnCameraTrackingChangedListener onCameraTrackingChangedListener) {

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
@@ -8,6 +8,7 @@ import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.mapboxsdk.R
 import com.mapbox.mapboxsdk.camera.CameraPosition
+import com.mapbox.mapboxsdk.location.LocationComponentConstants.TRANSITION_ANIMATION_DURATION_MS
 import com.mapbox.mapboxsdk.location.modes.CameraMode
 import com.mapbox.mapboxsdk.location.modes.RenderMode
 import com.mapbox.mapboxsdk.maps.MapboxMap
@@ -174,7 +175,7 @@ class LocationComponentTest {
 
     val callback = ArgumentCaptor.forClass(OnLocationCameraTransitionListener::class.java)
     locationComponent.setCameraMode(CameraMode.TRACKING, listener)
-    verify(locationCameraController).setCameraMode(eq(CameraMode.TRACKING), any(), callback.capture())
+    verify(locationCameraController).setCameraMode(eq(CameraMode.TRACKING), any(), eq(TRANSITION_ANIMATION_DURATION_MS), isNull(), isNull(), isNull(), callback.capture())
     callback.value.onLocationCameraTransitionFinished(CameraMode.TRACKING)
 
     verify(listener).onLocationCameraTransitionFinished(CameraMode.TRACKING)
@@ -192,10 +193,28 @@ class LocationComponentTest {
 
     val callback = ArgumentCaptor.forClass(OnLocationCameraTransitionListener::class.java)
     locationComponent.setCameraMode(CameraMode.TRACKING, listener)
-    verify(locationCameraController).setCameraMode(eq(CameraMode.TRACKING), any(), callback.capture())
+    verify(locationCameraController).setCameraMode(eq(CameraMode.TRACKING), any(), eq(TRANSITION_ANIMATION_DURATION_MS), isNull(), isNull(), isNull(), callback.capture())
     callback.value.onLocationCameraTransitionCanceled(CameraMode.TRACKING)
 
     verify(listener).onLocationCameraTransitionCanceled(CameraMode.TRACKING)
+    verify(locationAnimatorCoordinator).resetAllCameraAnimations(CameraPosition.DEFAULT, false)
+  }
+
+  @Test
+  fun transitionCustomFinishedTest() {
+    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.onStart()
+    locationComponent.isLocationComponentEnabled = true
+    `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
+
+    val listener = mock(OnLocationCameraTransitionListener::class.java)
+
+    val callback = ArgumentCaptor.forClass(OnLocationCameraTransitionListener::class.java)
+    locationComponent.setCameraMode(CameraMode.TRACKING, 1200, 14.0, 13.0, 45.0, listener)
+    verify(locationCameraController).setCameraMode(eq(CameraMode.TRACKING), any(), eq(1200L), eq(14.0), eq(13.0), eq(45.0), callback.capture())
+    callback.value.onLocationCameraTransitionFinished(CameraMode.TRACKING)
+
+    verify(listener).onLocationCameraTransitionFinished(CameraMode.TRACKING)
     verify(locationAnimatorCoordinator).resetAllCameraAnimations(CameraPosition.DEFAULT, false)
   }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationModesActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationModesActivity.java
@@ -16,7 +16,6 @@ import android.widget.Toast;
 import com.mapbox.android.core.location.LocationEngineRequest;
 import com.mapbox.android.core.permissions.PermissionsListener;
 import com.mapbox.android.core.permissions.PermissionsManager;
-import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.location.LocationComponent;
 import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions;
 import com.mapbox.mapboxsdk.location.LocationComponentOptions;
@@ -183,6 +182,22 @@ public class LocationModesActivity extends AppCompatActivity implements OnMapRea
       locationComponent.setMaxAnimationFps(5);
     } else if (id == R.id.action_component_throttling_disabled) {
       locationComponent.setMaxAnimationFps(Integer.MAX_VALUE);
+    } else if (id == R.id.action_component_animate_while_tracking) {
+      locationComponent.zoomWhileTracking(17, 750, new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          // No impl
+        }
+
+        @Override
+        public void onFinish() {
+          locationComponent.tiltWhileTracking(60);
+        }
+      });
+      if (locationComponent.getCameraMode() == CameraMode.NONE) {
+
+        Toast.makeText(this, "Not possible to animate - not tracking", Toast.LENGTH_SHORT).show();
+      }
     }
 
     return super.onOptionsItemSelected(item);
@@ -370,31 +385,18 @@ public class LocationModesActivity extends AppCompatActivity implements OnMapRea
   }
 
   private void setCameraTrackingMode(@CameraMode.Mode int mode) {
-    locationComponent.setCameraMode(mode, new OnLocationCameraTransitionListener() {
-      @Override
-      public void onLocationCameraTransitionFinished(@CameraMode.Mode int cameraMode) {
-        if (mode != CameraMode.NONE) {
-          locationComponent.zoomWhileTracking(15, 750, new MapboxMap.CancelableCallback() {
-            @Override
-            public void onCancel() {
-              // No impl
-            }
-
-            @Override
-            public void onFinish() {
-              locationComponent.tiltWhileTracking(45);
-            }
-          });
-        } else {
-          mapboxMap.easeCamera(CameraUpdateFactory.tiltTo(0));
+    locationComponent.setCameraMode(mode, 1200, 16.0, null, 45.0,
+      new OnLocationCameraTransitionListener() {
+        @Override
+        public void onLocationCameraTransitionFinished(@CameraMode.Mode int cameraMode) {
+          Toast.makeText(LocationModesActivity.this, "Transition finished", Toast.LENGTH_SHORT).show();
         }
-      }
 
-      @Override
-      public void onLocationCameraTransitionCanceled(@CameraMode.Mode int cameraMode) {
-        // No impl
-      }
-    });
+        @Override
+        public void onLocationCameraTransitionCanceled(@CameraMode.Mode int cameraMode) {
+          Toast.makeText(LocationModesActivity.this, "Transition canceled", Toast.LENGTH_SHORT).show();
+        }
+      });
   }
 
   @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/menu/menu_location_mode.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/menu/menu_location_mode.xml
@@ -32,4 +32,8 @@
     <item android:id="@+id/action_component_throttling_disabled"
         android:title="Disable animation throttling"
         app:showAsAction="never"/>
+
+    <item android:id="@+id/action_component_animate_while_tracking"
+        android:title="Animate while tracking"
+        app:showAsAction="never"/>
 </menu>


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/14539.

This PR adds an option to provide custom transition duration, zoom, bearing and tilt values for the location tracking transition animation.
![ezgif com-video-to-gif (34)](https://user-images.githubusercontent.com/16925074/57314707-7d69e800-70f2-11e9-9d5e-8f2d57484501.gif)
