### PR TITLE
[android] Mapbox Java SDK bump to 4.8.0

### DIFF
--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
     ]
 
     versions = [
-            mapboxServices  : '4.7.0',
+            mapboxServices  : '4.8.0',
             mapboxTelemetry : '4.4.1',
             mapboxCore      : '1.3.0',
             mapboxGestures  : '0.4.2',


### PR DESCRIPTION
This PR bumps Mapbox Java SDK to 4.8.0

addresses https://github.com/mapbox/mapbox-java/issues/1024
