### PR TITLE
[build] Upgrade from Xcode 9.3.0 to 9.3.1 on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1148,7 +1148,7 @@ jobs:
 # ------------------------------------------------------------------------------
   qt5-macos-debug:
     macos:
-      xcode: "9.3.0"
+      xcode: "9.3.1"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1


### PR DESCRIPTION
CircleCI will soon deprecate Xcode 9.3.0. More details [here](https://discuss.circleci.com/t/removing-support-for-xcode-versions-9-0-0-9-3-0-and-9-4-0/30084).

Moving the project from 9.3.0 to 9.3.1 should have no impact on the CircleCI jobs, and it will help avoid problems due to Xcode 9.3.0 image deprecation. Plus it will help the project to hit fewer Xcode bugs.