### PR TITLE
[core][android] Provide API to control eviction of cached images

### DIFF
--- a/include/mbgl/map/map_observer.hpp
+++ b/include/mbgl/map/map_observer.hpp
@@ -48,6 +48,9 @@ public:
     virtual void onSourceChanged(style::Source&) {}
     virtual void onDidBecomeIdle() {}
     virtual void onStyleImageMissing(const std::string&) {}
+    // This method should return true if unused image can be removed,
+    // false otherwise. By default, unused image will be removed.
+    virtual bool onCanRemoveUnusedStyleImage(const std::string&) { return true; }
 };
 
 } // namespace mbgl

--- a/include/mbgl/renderer/renderer_observer.hpp
+++ b/include/mbgl/renderer/renderer_observer.hpp
@@ -35,6 +35,7 @@ public:
     // Style is missing an image
     using StyleImageMissingCallback = std::function<void()>;
     virtual void onStyleImageMissing(const std::string&, StyleImageMissingCallback done) { done(); }
+    virtual void onRemoveUnusedStyleImages(const std::vector<std::string>&) {}
 };
 
 } // namespace mbgl

--- a/include/mbgl/util/constants.hpp
+++ b/include/mbgl/util/constants.hpp
@@ -48,6 +48,10 @@ constexpr uint8_t DEFAULT_PREFETCH_ZOOM_DELTA = 4;
 
 constexpr uint64_t DEFAULT_MAX_CACHE_SIZE = 50 * 1024 * 1024;
 
+// Default ImageManager's cache size for images added via onStyleImageMissing API.
+// Average sprite size with 1.0 pixel ratio is ~2kB, 8kB for pixel ratio of 2.0.
+constexpr std::size_t DEFAULT_ON_DEMAND_IMAGES_CACHE_SIZE = 100 * 8192;
+
 constexpr Duration DEFAULT_TRANSITION_DURATION = Milliseconds(300);
 constexpr Seconds CLOCK_SKEW_RETRY_TIMEOUT { 30 };
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapChangeReceiver.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapChangeReceiver.java
@@ -33,6 +33,8 @@ class MapChangeReceiver implements NativeMapView.StateCallback {
   private final List<MapView.OnSourceChangedListener> onSourceChangedListenerList = new CopyOnWriteArrayList<>();
   private final List<MapView.OnStyleImageMissingListener> onStyleImageMissingListenerList
     = new CopyOnWriteArrayList<>();
+  private final List<MapView.OnCanRemoveUnusedStyleImageListener> onCanRemoveUnusedStyleImageListenerList
+    = new CopyOnWriteArrayList<>();
 
   @Override
   public void onCameraWillChange(boolean animated) {
@@ -230,6 +232,29 @@ class MapChangeReceiver implements NativeMapView.StateCallback {
     }
   }
 
+  @Override
+  public boolean onCanRemoveUnusedStyleImage(String imageId) {
+    if (onCanRemoveUnusedStyleImageListenerList.isEmpty()) {
+      return true;
+    }
+
+    try {
+      if (!onCanRemoveUnusedStyleImageListenerList.isEmpty()) {
+        boolean canRemove = true;
+        for (MapView.OnCanRemoveUnusedStyleImageListener listener : onCanRemoveUnusedStyleImageListenerList) {
+          canRemove &= listener.onCanRemoveUnusedStyleImage(imageId);
+        }
+
+        return canRemove;
+      }
+    } catch (Throwable err) {
+      Logger.e(TAG, "Exception in onCanRemoveUnusedStyleImage", err);
+      throw err;
+    }
+
+    return true;
+  }
+
   void addOnCameraWillChangeListener(MapView.OnCameraWillChangeListener listener) {
     onCameraWillChangeListenerList.add(listener);
   }
@@ -342,6 +367,14 @@ class MapChangeReceiver implements NativeMapView.StateCallback {
     onStyleImageMissingListenerList.remove(listener);
   }
 
+  void addOnCanRemoveUnusedStyleImageListener(MapView.OnCanRemoveUnusedStyleImageListener listener) {
+    onCanRemoveUnusedStyleImageListenerList.add(listener);
+  }
+
+  void removeOnCanRemoveUnusedStyleImageListener(MapView.OnCanRemoveUnusedStyleImageListener listener) {
+    onCanRemoveUnusedStyleImageListenerList.remove(listener);
+  }
+
   void clear() {
     onCameraWillChangeListenerList.clear();
     onCameraIsChangingListenerList.clear();
@@ -357,5 +390,6 @@ class MapChangeReceiver implements NativeMapView.StateCallback {
     onDidFinishLoadingStyleListenerList.clear();
     onSourceChangedListenerList.clear();
     onStyleImageMissingListenerList.clear();
+    onCanRemoveUnusedStyleImageListenerList.clear();
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -798,6 +798,33 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   }
 
   /**
+   * Set a callback that's invoked when map needs to release unused image resources.
+   *
+   * A callback will be called only for unused images that were provided by the client via
+   * {@link OnStyleImageMissingListener#onStyleImageMissing(String)} listener interface.
+   *
+   * By default, platform will remove unused images from the style. By adding listener, default
+   * behavior can be overridden and client can control whether to release unused resources.
+   *
+   * @param listener The callback that's invoked when map needs to release unused image resources
+   */
+  public void addOnCanRemoveUnusedStyleImageListener(@NonNull OnCanRemoveUnusedStyleImageListener listener) {
+    mapChangeReceiver.addOnCanRemoveUnusedStyleImageListener(listener);
+  }
+
+  /**
+   * Removes a callback that's invoked when map needs to release unused image resources.
+   *
+   * When all listeners are removed, platform will fallback to default behavior, which is to remove
+   * unused images from the style.
+   *
+   * @param listener The callback that's invoked when map needs to release unused image resources
+   */
+  public void removeOnCanRemoveUnusedStyleImageListener(@NonNull OnCanRemoveUnusedStyleImageListener listener) {
+    mapChangeReceiver.removeOnCanRemoveUnusedStyleImageListener(listener);
+  }
+
+  /**
    * Interface definition for a callback to be invoked when the camera will change.
    * <p>
    * {@link MapView#addOnCameraWillChangeListener(OnCameraWillChangeListener)}
@@ -992,6 +1019,22 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
      * @param id the id of the icon that is missing
      */
     void onStyleImageMissing(@NonNull String id);
+  }
+
+  /**
+   * Interface definition for a callback to be invoked with an unused image identifier.
+   * <p>
+   * {@link MapView#addOnCanRemoveUnusedStyleImageListener(OnCanRemoveUnusedStyleImageListener)}
+   * </p>
+   */
+  public interface OnCanRemoveUnusedStyleImageListener {
+    /**
+     * Called when the map needs to release unused image resources.
+     *
+     * @param id of an image that is not used by the map and can be removed from the style.
+     * @return true if image can be removed, false otherwise.
+     */
+    boolean onCanRemoveUnusedStyleImage(@NonNull String id);
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -1051,6 +1051,15 @@ final class NativeMapView implements NativeMap {
   }
 
   @Keep
+  private boolean onCanRemoveUnusedStyleImage(String imageId) {
+    if (stateCallback != null) {
+      return stateCallback.onCanRemoveUnusedStyleImage(imageId);
+    }
+
+    return true;
+  }
+
+  @Keep
   protected void onSnapshotReady(@Nullable Bitmap mapContent) {
     if (checkState("OnSnapshotReady")) {
       return;
@@ -1463,5 +1472,7 @@ final class NativeMapView implements NativeMap {
     void onSourceChanged(String sourceId);
 
     void onStyleImageMissing(String imageId);
+
+    boolean onCanRemoveUnusedStyleImage(String imageId);
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/maps/RemoveUnusedImagesTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/maps/RemoveUnusedImagesTest.kt
@@ -1,0 +1,162 @@
+package com.mapbox.mapboxsdk.testapp.maps
+
+import android.graphics.Bitmap
+import android.support.test.rule.ActivityTestRule
+import android.support.test.runner.AndroidJUnit4
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
+import com.mapbox.mapboxsdk.geometry.LatLng
+import com.mapbox.mapboxsdk.maps.MapView
+import com.mapbox.mapboxsdk.maps.MapboxMap
+import com.mapbox.mapboxsdk.maps.Style
+import com.mapbox.mapboxsdk.testapp.R
+import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+@RunWith(AndroidJUnit4::class)
+class RemoveUnusedImagesTest {
+
+  @Rule
+  @JvmField
+  var rule = ActivityTestRule(EspressoTestActivity::class.java)
+
+  private lateinit var mapView: MapView
+  private lateinit var mapboxMap: MapboxMap
+  private val latch = CountDownLatch(1)
+
+  @Before
+  fun setup() {
+    rule.runOnUiThread {
+      mapView = rule.activity.findViewById(R.id.mapView)
+      mapView.getMapAsync {
+        mapboxMap = it;
+        mapboxMap.setStyle(Style.Builder().fromJson(styleJson))
+      }
+    }
+  }
+
+  @Test
+  fun testRemoveUnusedImagesUserProvidedListener() {
+    var callbackLatch = CountDownLatch(2)
+    rule.runOnUiThread {
+      mapView.addOnStyleImageMissingListener {
+        mapboxMap.style!!.addImage(it, Bitmap.createBitmap(512, 512,  Bitmap.Config.ARGB_8888))
+      }
+
+      // Remove layer and source, so that rendered tiles are no longer used, therefore, map must
+      // notify client about unused images.
+      mapView.addOnDidBecomeIdleListener {
+        mapboxMap.style!!.removeLayer("icon")
+        mapboxMap.style!!.removeSource("geojson")
+      }
+
+      mapView.addOnCanRemoveUnusedStyleImageListener {
+        callbackLatch.countDown()
+        mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(0.0, 120.0), 8.0))
+        mapView.addOnDidFinishRenderingFrameListener {
+          assertNotNull(mapboxMap.style!!.getImage("small"))
+          assertNotNull(mapboxMap.style!!.getImage("large"))
+          latch.countDown()
+        }
+        return@addOnCanRemoveUnusedStyleImageListener false
+      }
+    }
+
+    if(!latch.await(5, TimeUnit.SECONDS) && !callbackLatch.await(5, TimeUnit.SECONDS)){
+      throw TimeoutException()
+    }
+  }
+
+  @Test
+  fun testRemoveUnusedImagesDefaultListener() {
+    rule.runOnUiThread {
+      mapView.addOnStyleImageMissingListener {
+        mapboxMap.style!!.addImage(it, Bitmap.createBitmap(512, 512,  Bitmap.Config.ARGB_8888))
+      }
+
+      // Remove layer and source, so that rendered tiles are no longer used, thus
+      // map must request removal of unused images.
+      mapView.addOnDidBecomeIdleListener {
+        mapboxMap.style!!.removeLayer("icon")
+        mapboxMap.style!!.removeSource("geojson")
+        mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(0.0, 120.0), 8.0))
+
+        // Wait for the next frame and check that images were removed from the style.
+        mapView.addOnDidFinishRenderingFrameListener {
+          if (mapboxMap.style!!.getImage("small") == null && mapboxMap.style!!.getImage("large") == null) {
+            latch.countDown()
+          }
+        }
+      }
+    }
+
+    if(!latch.await(5, TimeUnit.SECONDS)){
+      throw TimeoutException()
+    }
+  }
+
+  companion object {
+    private const val styleJson = """
+    {
+      "version": 8,
+      "name": "Mapbox Streets",
+      "sources": {
+        "geojson": {
+          "type": "geojson",
+          "data": {
+            "type": "FeatureCollection",
+            "features": [
+              {
+                "type": "Feature",
+                "properties": {
+                  "image": "small"
+                },
+                "geometry": {
+                  "type": "Point",
+                  "coordinates": [
+                    0,
+                    0
+                  ]
+                }
+              },
+              {
+                "type": "Feature",
+                "properties": {
+                  "image": "large"
+                },
+                "geometry": {
+                  "type": "Point",
+                  "coordinates": [
+                    1,
+                    1
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      "layers": [{
+        "id": "bg",
+        "type": "background",
+        "paint": {
+          "background-color": "#f00"
+        }
+      },{
+        "id": "icon",
+        "type": "symbol",
+        "source": "geojson",
+        "layout": {
+          "icon-image": ["get", "image"]
+        }
+      }]
+    }
+    """
+  }
+}

--- a/platform/android/src/android_renderer_frontend.cpp
+++ b/platform/android/src/android_renderer_frontend.cpp
@@ -54,6 +54,10 @@ public:
         delegate.invoke(&RendererObserver::onStyleImageMissing, id, done);
     }
 
+    void onRemoveUnusedStyleImages(const std::vector<std::string>& ids) override {
+        delegate.invoke(&RendererObserver::onRemoveUnusedStyleImages, ids);
+    }
+
 private:
     std::shared_ptr<Mailbox> mailbox;
     ActorRef<RendererObserver> delegate;

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -271,6 +271,20 @@ void NativeMapView::onStyleImageMissing(const std::string& imageId) {
     }
 }
 
+bool NativeMapView::onCanRemoveUnusedStyleImage(const std::string& imageId) {
+    assert(vm != nullptr);
+
+    android::UniqueEnv _env = android::AttachEnv();
+    static auto& javaClass = jni::Class<NativeMapView>::Singleton(*_env);
+    static auto onCanRemoveUnusedStyleImage = javaClass.GetMethod<jboolean (jni::String)>(*_env, "onCanRemoveUnusedStyleImage");
+    auto weakReference = javaPeer.get(*_env);
+    if (weakReference) {
+        return weakReference.Call(*_env, onCanRemoveUnusedStyleImage, jni::Make<jni::String>(*_env, imageId));
+    }
+
+    return true;
+}
+
 // JNI Methods //
 
 void NativeMapView::resizeView(jni::JNIEnv&, int w, int h) {

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -69,6 +69,7 @@ public:
     void onDidFinishLoadingStyle() override;
     void onSourceChanged(mbgl::style::Source&) override;
     void onStyleImageMissing(const std::string&) override;
+    bool onCanRemoveUnusedStyleImage(const std::string&) override;
 
     // JNI //
 

--- a/src/mbgl/map/map_impl.cpp
+++ b/src/mbgl/map/map_impl.cpp
@@ -179,4 +179,12 @@ void Map::Impl::onStyleImageMissing(const std::string& id, std::function<void()>
     onUpdate();
 }
 
+void Map::Impl::onRemoveUnusedStyleImages(const std::vector<std::string>& unusedImageIDs) {
+    for (const auto& unusedImageID : unusedImageIDs) {
+        if (observer.onCanRemoveUnusedStyleImage(unusedImageID)) {
+            style->removeImage(unusedImageID);
+        }
+    }
+}
+
 } // namespace mbgl

--- a/src/mbgl/map/map_impl.hpp
+++ b/src/mbgl/map/map_impl.hpp
@@ -46,6 +46,7 @@ public:
     void onWillStartRenderingMap() final;
     void onDidFinishRenderingMap() final;
     void onStyleImageMissing(const std::string&, std::function<void()>) final;
+    void onRemoveUnusedStyleImages(const std::vector<std::string>&) final;
 
     // Map
     void jumpTo(const CameraOptions&);

--- a/src/mbgl/renderer/image_manager.hpp
+++ b/src/mbgl/renderer/image_manager.hpp
@@ -56,6 +56,7 @@ public:
     void removeRequestor(ImageRequestor&);
     void notifyIfMissingImageAdded();
     void reduceMemoryUse();
+    void reduceMemoryUseIfCacheSizeExceedsLimit();
 
     ImageVersionMap updatedImageVersions;
 
@@ -75,6 +76,7 @@ private:
     };
     std::map<ImageRequestor*, MissingImageRequestPair> missingImageRequestors;
     std::map<std::string, std::set<ImageRequestor*>> requestedImages;
+    std::size_t requestedImagesCacheSize = 0ul;
     ImageMap images;
 
     ImageManagerObserver* observer = nullptr;

--- a/src/mbgl/renderer/image_manager_observer.hpp
+++ b/src/mbgl/renderer/image_manager_observer.hpp
@@ -9,6 +9,7 @@ public:
     virtual ~ImageManagerObserver() = default;
 
     virtual void onStyleImageMissing(const std::string&, std::function<void()> done) { done(); }
+    virtual void onRemoveUnusedStyleImages(const std::vector<std::string>&) {}
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -762,4 +762,8 @@ void Renderer::Impl::onStyleImageMissing(const std::string& id, std::function<vo
     observer->onStyleImageMissing(id, std::move(done));
 }
 
+void Renderer::Impl::onRemoveUnusedStyleImages(const std::vector<std::string>& unusedImageIDs) {
+    observer->onRemoveUnusedStyleImages(unusedImageIDs);
+}
+
 } // namespace mbgl

--- a/src/mbgl/renderer/renderer_impl.hpp
+++ b/src/mbgl/renderer/renderer_impl.hpp
@@ -91,6 +91,7 @@ private:
 
     // ImageManagerObserver implementation
     void onStyleImageMissing(const std::string&, std::function<void()>) override;
+    void onRemoveUnusedStyleImages(const std::vector<std::string>&) final;
 
     void updateFadingTiles();
 


### PR DESCRIPTION
This PR introduces following changes:
- Defines constant for ImageManager's cache size `DEFAULT_ON_DEMAND_IMAGES_CACHE_SIZE` that is equal to ~100 8kB sprites.
- Adds `bool onCanRemoveUnusedStyleImage(const std::string&)` method to `MapObserver` interface that is invoked in two cases: OOM and when cumulative size of unused images in the cache goes over `DEFAULT_ON_DEMAND_IMAGES_CACHE_SIZE` limit.
- Android implementation and unit tests

By default, map will remove ***unused images** if application returns `true` from `onCanRemoveUnusedStyleImage` method.

***Unused images**: are images whose requesting tile is destroyed. Map will notify about unused images only if image was provided through `onStyleImageMissing(id)` => `addImage(id)`.

```java
// Android example
mapView.addOnCanRemoveUnusedStyleImageListener(id -> {
  return id != "keep_icon";
});

```

Fixes: #14547

---
TODO:
- [ ] Darwin platform bindings