### PR TITLE
[core] Schedule invocation of onStyleImageMissing completion callback on the same thread

### DIFF
--- a/src/mbgl/renderer/image_manager.hpp
+++ b/src/mbgl/renderer/image_manager.hpp
@@ -15,6 +15,9 @@
 
 namespace mbgl {
 
+template <class T>
+class Actor;
+
 namespace gfx {
 class Context;
 } // namespace gfx
@@ -64,9 +67,11 @@ private:
     bool loaded = false;
 
     std::map<ImageRequestor*, ImageRequestPair> requestors;
+    using Callback = std::function<void()>;
+    using ActorCallback = Actor<Callback>;
     struct MissingImageRequestPair {
         ImageRequestPair pair;
-        unsigned int callbacksRemaining;
+        std::map<std::string, std::unique_ptr<ActorCallback>> callbacks;
     };
     std::map<ImageRequestor*, MissingImageRequestPair> missingImageRequestors;
     std::map<std::string, std::set<ImageRequestor*>> requestedImages;


### PR DESCRIPTION
Before this change, `ImageManger`'s 'done' callback for `onStyleImageMissing` observer notification that was created on a renderer thread, could be called from a different thread, therefore, it's not thread safe. For example, on Android platform, callback was invoked from UI thread. This change makes callback to be scheduled on originating thread.

Fixes: #14496