### PR TITLE
Harden AndroidRendererFrontend::reduceMemoryUse 

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -503,7 +503,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
    */
   @UiThread
   public void onLowMemory() {
-    if (nativeMapView != null && !destroyed) {
+    if (nativeMapView != null && mapboxMap != null && !destroyed ) {
       nativeMapView.onLowMemory();
     }
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -573,7 +573,7 @@ final class NativeMapView implements NativeMap {
 
   @Override
   public void onLowMemory() {
-    if (checkState("onLowMemory")) {
+    if (checkState("onLowMemory") || !mapRenderer.hasSurface()) {
       return;
     }
     nativeOnLowMemory();

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
@@ -9,6 +9,8 @@ import com.mapbox.mapboxsdk.log.Logger;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.storage.FileSource;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.opengles.GL10;
 
@@ -32,7 +34,7 @@ public abstract class MapRenderer implements MapRendererScheduler {
   private long nativePtr = 0;
   private double expectedRenderTime = 0;
   private MapboxMap.OnFpsChangedListener onFpsChangedListener;
-  protected boolean hasSurface;
+  protected AtomicBoolean hasSurface = new AtomicBoolean();
 
   public MapRenderer(@NonNull Context context, String localIdeographFontFamily) {
     float pixelRatio = context.getResources().getDisplayMetrics().density;
@@ -165,6 +167,6 @@ public abstract class MapRenderer implements MapRendererScheduler {
    * @return returns if renderer has a surface, false otherwise
    */
   public boolean hasSurface() {
-    return hasSurface;
+    return hasSurface.get();
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.opengl.GLSurfaceView;
 import android.support.annotation.NonNull;
 import android.view.SurfaceHolder;
+
 import com.mapbox.mapboxsdk.maps.renderer.MapRenderer;
 import com.mapbox.mapboxsdk.maps.renderer.egl.EGLConfigChooser;
 
@@ -38,13 +39,13 @@ public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceVi
       @Override
       public void surfaceCreated(SurfaceHolder holder) {
         super.surfaceCreated(holder);
-        hasSurface = true;
+        hasSurface.set(true);
       }
 
       @Override
       public void surfaceDestroyed(SurfaceHolder holder) {
         super.surfaceDestroyed(holder);
-        hasSurface = false;
+        hasSurface.set(false);
         nativeReset();
       }
     });
@@ -102,7 +103,7 @@ public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceVi
    */
   @Override
   public void requestRender() {
-    if (!hasSurface) {
+    if (!hasSurface.get()) {
       return;
     }
     glSurfaceView.requestRender();

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewMapRenderer.java
@@ -43,7 +43,7 @@ public class TextureViewMapRenderer extends MapRenderer {
   @Override
   protected void onSurfaceCreated(GL10 gl, EGLConfig config) {
     super.onSurfaceCreated(gl, config);
-    hasSurface = true;
+    hasSurface.set(true);
   }
 
   /**
@@ -59,7 +59,7 @@ public class TextureViewMapRenderer extends MapRenderer {
    */
   @Override
   protected void onSurfaceDestroyed() {
-    hasSurface = false;
+    hasSurface.set(false);
     super.onSurfaceDestroyed();
   }
 


### PR DESCRIPTION
Only allow invoking OnLowMemory with an active renderer. 
Closes #14603 