### PR TITLE
Update to gradle 5.1, fix release to bintray

### DIFF
--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.4.0'
         classpath dependenciesList.licensesPlugin
         classpath dependenciesList.kotlinPlugin
         classpath dependenciesList.bintrayPlugin

--- a/platform/android/gradle/gradle-bintray.gradle
+++ b/platform/android/gradle/gradle-bintray.gradle
@@ -16,7 +16,7 @@ publishing {
             version this.version
 
             afterEvaluate {
-                artifact("$buildDir/outputs/aar/mapbox-android-sdk-release.aar")
+                artifact("$buildDir/outputs/aar/MapboxGLAndroidSDK-release.aar")
                 artifact(androidSourcesJar)
                 artifact(androidJavadocsJar)
             }

--- a/platform/android/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
Closes #14563, the issue stems from bumping gradle to 5.0 which generates a different aar file name as it did with 4.x. Working snapshot build can be seen [here](https://circleci.com/gh/mapbox/mapbox-gl-native/273617).