### PR TITLE
Normalize previous rotation values of the location animator

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinator.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinator.java
@@ -196,6 +196,9 @@ final class LocationAnimatorCoordinator {
                                     float previousBearing, float targetBearing) {
     createNewLatLngAnimator(ANIMATOR_LAYER_LATLNG, previousLatLng, targetLatLng);
 
+    // Because Location bearing values are normalized to [0, 360]
+    // we need to do the same for the previous bearing value to determine the shortest path
+    previousBearing = Utils.normalize(previousBearing);
     float normalizedLayerBearing = Utils.shortestRotation(targetBearing, previousBearing);
     createNewFloatAnimator(ANIMATOR_LAYER_GPS_BEARING, previousBearing, normalizedLayerBearing);
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/Utils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/Utils.java
@@ -36,6 +36,16 @@ public final class Utils {
     return heading;
   }
 
+  /**
+   * Normalizes an angle to be in the [0, 360] range.
+   *
+   * @param angle the provided angle
+   * @return the normalized angle
+   */
+  public static float normalize(float angle) {
+    return (angle % 360 + 360) % 360;
+  }
+
   static Bitmap generateShadow(Drawable drawable, float elevation) {
     int width = drawable.getIntrinsicWidth();
     int height = drawable.getIntrinsicHeight();

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinatorTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinatorTest.kt
@@ -119,6 +119,108 @@ class LocationAnimatorCoordinatorTest {
   }
 
   @Test
+  fun feedNewLocation_animatorValue_correctRotation_1() {
+    val location = Location("")
+    location.latitude = 51.0
+    location.longitude = 17.0
+    location.bearing = 0f
+
+    val animator = mockk<MapboxFloatAnimator>(relaxed = true)
+    every { animator.animatedValue } returns 270f
+    locationAnimatorCoordinator.animatorArray.put(ANIMATOR_LAYER_GPS_BEARING, animator)
+
+    locationAnimatorCoordinator.feedNewLocation(location, cameraPosition, false)
+
+    val layerBearingTarget = locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_GPS_BEARING]?.target as Float
+    assertEquals(360f, layerBearingTarget)
+  }
+
+  @Test
+  fun feedNewLocation_animatorValue_correctRotation_2() {
+    val location = Location("")
+    location.latitude = 51.0
+    location.longitude = 17.0
+    location.bearing = 90f
+
+    val animator = mockk<MapboxFloatAnimator>(relaxed = true)
+    every { animator.animatedValue } returns 280f
+    locationAnimatorCoordinator.animatorArray.put(ANIMATOR_LAYER_GPS_BEARING, animator)
+
+    locationAnimatorCoordinator.feedNewLocation(location, cameraPosition, false)
+
+    val layerBearingTarget = locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_GPS_BEARING]?.target as Float
+    assertEquals(450f, layerBearingTarget)
+  }
+
+  @Test
+  fun feedNewLocation_animatorValue_correctRotation_3() {
+    val location = Location("")
+    location.latitude = 51.0
+    location.longitude = 17.0
+    location.bearing = 300f
+
+    val animator = mockk<MapboxFloatAnimator>(relaxed = true)
+    every { animator.animatedValue } returns 450f
+    locationAnimatorCoordinator.animatorArray.put(ANIMATOR_LAYER_GPS_BEARING, animator)
+
+    locationAnimatorCoordinator.feedNewLocation(location, cameraPosition, false)
+
+    val layerBearingTarget = locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_GPS_BEARING]?.target as Float
+    assertEquals(-60f, layerBearingTarget)
+  }
+
+  @Test
+  fun feedNewLocation_animatorValue_correctRotation_4() {
+    val location = Location("")
+    location.latitude = 51.0
+    location.longitude = 17.0
+    location.bearing = 350f
+
+    val animator = mockk<MapboxFloatAnimator>(relaxed = true)
+    every { animator.animatedValue } returns 10f
+    locationAnimatorCoordinator.animatorArray.put(ANIMATOR_LAYER_GPS_BEARING, animator)
+
+    locationAnimatorCoordinator.feedNewLocation(location, cameraPosition, false)
+
+    val layerBearingTarget = locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_GPS_BEARING]?.target as Float
+    assertEquals(-10f, layerBearingTarget)
+  }
+
+  @Test
+  fun feedNewLocation_animatorValue_correctRotation_5() {
+    val location = Location("")
+    location.latitude = 51.0
+    location.longitude = 17.0
+    location.bearing = 90f
+
+    val animator = mockk<MapboxFloatAnimator>(relaxed = true)
+    every { animator.animatedValue } returns -280f
+    locationAnimatorCoordinator.animatorArray.put(ANIMATOR_LAYER_GPS_BEARING, animator)
+
+    locationAnimatorCoordinator.feedNewLocation(location, cameraPosition, false)
+
+    val layerBearingTarget = locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_GPS_BEARING]?.target as Float
+    assertEquals(90f, layerBearingTarget)
+  }
+
+  @Test
+  fun feedNewLocation_animatorValue_correctRotation_6() {
+    val location = Location("")
+    location.latitude = 51.0
+    location.longitude = 17.0
+    location.bearing = 270f
+
+    val animator = mockk<MapboxFloatAnimator>(relaxed = true)
+    every { animator.animatedValue } returns -350f
+    locationAnimatorCoordinator.animatorArray.put(ANIMATOR_LAYER_GPS_BEARING, animator)
+
+    locationAnimatorCoordinator.feedNewLocation(location, cameraPosition, false)
+
+    val layerBearingTarget = locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_GPS_BEARING]?.target as Float
+    assertEquals(-90f, layerBearingTarget)
+  }
+
+  @Test
   fun feedNewLocation_isNorth_animatorsAreCreated() {
     val location = Location("")
     location.latitude = 51.0


### PR DESCRIPTION
Fixes a bug where the animator coordinator wasn't choosing the shortest path for the layer bearing animation.

Issue example:
![ezgif com-video-to-gif (36)](https://user-images.githubusercontent.com/16925074/57473524-4af5f180-7290-11e9-87de-ce487bfae60a.gif)
