### PR TITLE
[iOS] Set access token and only the access token

### DIFF
--- a/platform/darwin/src/MGLAccountManager.m
+++ b/platform/darwin/src/MGLAccountManager.m
@@ -91,7 +91,7 @@ static BOOL _MGLAccountsSDKEnabled;
 
 #if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
     dispatch_async(dispatch_get_main_queue(), ^{
-        [MGLMapboxEvents setupWithAccessToken:accessToken];
+        [MGLMapboxEvents setAccessToken:accessToken];
     });
 #endif
 }

--- a/platform/ios/src/MGLMapboxEvents.h
+++ b/platform/ios/src/MGLMapboxEvents.h
@@ -8,6 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable instancetype)sharedInstance;
 
 + (void)setupWithAccessToken:(NSString *)accessToken;
++ (void)setAccessToken:(NSString *)accessToken;
 + (void)pushTurnstileEvent;
 + (void)pushEvent:(NSString *)event withAttributes:(MMEMapboxEventAttributes *)attributeDictionary;
 + (void)flush;

--- a/platform/ios/src/MGLMapboxEvents.m
+++ b/platform/ios/src/MGLMapboxEvents.m
@@ -121,6 +121,10 @@ static NSString * const MGLVariableGeofence = @"VariableGeofence";
     }
 }
 
++ (void)setAccessToken:(NSString *)accessToken {
+    [[[self sharedInstance] eventsManager] setAccessToken:accessToken];
+}
+
 + (void)setupWithAccessToken:(NSString *)accessToken {
     int64_t delayTime = 0;
     


### PR DESCRIPTION
@friedbunny This PR is to fix a leak we're seeing in some rare-ish cases. I'd like your recommendation with how to move forward with this PR. I think with the changes in the PR now we could patch the leak but we could still make optimizations if only setting the access token is what we're after. 

The root cause (from what I can tell) is that `MGLAccountManager` attempts to set the access token for some purpose (assuming this has to do with the new `skuid` requirements?) and as a side effect triggers a small avalanche of new MME objects to be created that shouldn’t exist more than once (per `MMEEventsManager` instance at least).