### PR TITLE
Remove skuId from schema test

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/module/telemetry/SchemaTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/module/telemetry/SchemaTest.java
@@ -262,6 +262,7 @@ public class SchemaTest {
         schema.remove("owner");
         schema.remove("locationAuthorization");
         schema.remove("locationEnabled");
+        schema.remove("skuId");
         //temporary need to work out a solution to include this data
         schema.remove("platform");
 


### PR DESCRIPTION
Quick patch to fix broken builds that are relying on a online resource that recently was updated. 
Longterm looking into another alternative to make this more stable.