### PR TITLE
[core] Create glyph manager at renderer construction time

### DIFF
--- a/include/mbgl/storage/file_source.hpp
+++ b/include/mbgl/storage/file_source.hpp
@@ -4,9 +4,7 @@
 #include <mbgl/storage/response.hpp>
 #include <mbgl/storage/resource.hpp>
 
-#include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/async_request.hpp>
-#include <mbgl/util/optional.hpp>
 
 #include <functional>
 #include <memory>
@@ -16,8 +14,10 @@ namespace mbgl {
 class ResourceOptions;
 class ResourceTransform;
 
-class FileSource : private util::noncopyable {
+class FileSource {
 public:
+    FileSource(const FileSource&) = delete;
+    FileSource& operator=(const FileSource&) = delete;
     virtual ~FileSource() = default;
 
     using Callback = std::function<void (Response)>;
@@ -37,12 +37,14 @@ public:
         return false;
     }
 
-    // Factory for creating a platform-specific file source.
-    static std::shared_ptr<FileSource> createPlatformFileSource(const ResourceOptions&);
-
     // Singleton for obtaining the shared platform-specific file source. A single instance of a file source is provided
     // for each unique combination of a Mapbox API base URL, access token, cache path and platform context.
     static std::shared_ptr<FileSource> getSharedFileSource(const ResourceOptions&);
+
+protected:
+    FileSource() = default;
+    // Factory for creating a platform-specific file source.
+    static std::shared_ptr<FileSource> createPlatformFileSource(const ResourceOptions&);
 };
 
 } // namespace mbgl

--- a/src/mbgl/map/map_impl.cpp
+++ b/src/mbgl/map/map_impl.cpp
@@ -63,7 +63,7 @@ void Map::Impl::onUpdate() {
         style->impl->getSourceImpls(),
         style->impl->getLayerImpls(),
         annotationManager,
-        *fileSource,
+        fileSource,
         prefetchZoomDelta,
         bool(stillImageRequest),
         crossSourceCollisions

--- a/src/mbgl/renderer/tile_parameters.hpp
+++ b/src/mbgl/renderer/tile_parameters.hpp
@@ -2,6 +2,8 @@
 
 #include <mbgl/map/mode.hpp>
 
+#include <memory>
+
 namespace mbgl {
 
 class TransformState;
@@ -15,7 +17,7 @@ public:
     const float pixelRatio;
     const MapDebugOptions debugOptions;
     const TransformState& transformState;
-    FileSource& fileSource;
+    std::shared_ptr<FileSource> fileSource;
     const MapMode mode;
     AnnotationManager& annotationManager;
     ImageManager& imageManager;

--- a/src/mbgl/renderer/update_parameters.hpp
+++ b/src/mbgl/renderer/update_parameters.hpp
@@ -34,7 +34,7 @@ public:
     const Immutable<std::vector<Immutable<style::Layer::Impl>>> layers;
 
     AnnotationManager& annotationManager;
-    FileSource& fileSource;
+    std::shared_ptr<FileSource> fileSource;
 
     const uint8_t prefetchZoomDelta;
     

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -54,6 +54,7 @@ GeometryTile::GeometryTile(const OverscaledTileID& id_,
              parameters.mode,
              parameters.pixelRatio,
              parameters.debugOptions & MapDebugOptions::Collision),
+      fileSource(parameters.fileSource),
       glyphManager(parameters.glyphManager),
       imageManager(parameters.imageManager),
       mode(parameters.mode),
@@ -156,7 +157,7 @@ void GeometryTile::onGlyphsAvailable(GlyphMap glyphs) {
 }
 
 void GeometryTile::getGlyphs(GlyphDependencies glyphDependencies) {
-    glyphManager.getGlyphs(*this, std::move(glyphDependencies));
+    glyphManager.getGlyphs(*this, std::move(glyphDependencies), fileSource);
 }
 
 void GeometryTile::onImagesAvailable(ImageMap images, ImageMap patterns, ImageVersionMap versionMap, uint64_t imageCorrelationID) {

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -157,7 +157,7 @@ void GeometryTile::onGlyphsAvailable(GlyphMap glyphs) {
 }
 
 void GeometryTile::getGlyphs(GlyphDependencies glyphDependencies) {
-    glyphManager.getGlyphs(*this, std::move(glyphDependencies), fileSource);
+    glyphManager.getGlyphs(*this, std::move(glyphDependencies), *fileSource);
 }
 
 void GeometryTile::onImagesAvailable(ImageMap images, ImageMap patterns, ImageVersionMap versionMap, uint64_t imageCorrelationID) {

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -108,7 +108,7 @@ private:
     std::shared_ptr<Mailbox> mailbox;
     Actor<GeometryTileWorker> worker;
 
-    FileSource& fileSource;
+    std::shared_ptr<FileSource> fileSource;
     GlyphManager& glyphManager;
     ImageManager& imageManager;
 

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -108,6 +108,7 @@ private:
     std::shared_ptr<Mailbox> mailbox;
     Actor<GeometryTileWorker> worker;
 
+    FileSource& fileSource;
     GlyphManager& glyphManager;
     ImageManager& imageManager;
 

--- a/src/mbgl/tile/tile_loader.hpp
+++ b/src/mbgl/tile/tile_loader.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <mbgl/util/noncopyable.hpp>
 #include <mbgl/storage/resource.hpp>
 #include <mbgl/tile/tile.hpp>
 
@@ -13,8 +12,10 @@ class Tileset;
 class TileParameters;
 
 template <typename T>
-class TileLoader : private util::noncopyable {
+class TileLoader {
 public:
+    TileLoader(const TileLoader&) = delete;
+    TileLoader& operator=(const TileLoader&) = delete;
     TileLoader(T&,
                const OverscaledTileID&,
                const TileParameters&,
@@ -50,7 +51,7 @@ private:
     T& tile;
     TileNecessity necessity;
     Resource resource;
-    FileSource& fileSource;
+    std::shared_ptr<FileSource> fileSource;
     std::unique_ptr<AsyncRequest> request;
 };
 

--- a/src/mbgl/tile/tile_loader_impl.hpp
+++ b/src/mbgl/tile/tile_loader_impl.hpp
@@ -27,7 +27,7 @@ TileLoader<T>::TileLoader(T& tile_,
         Resource::LoadingMethod::CacheOnly)),
       fileSource(parameters.fileSource) {
     assert(!request);
-    if (fileSource.supportsCacheOnlyRequests()) {
+    if (fileSource->supportsCacheOnlyRequests()) {
         // When supported, the first request is always optional, even if the TileLoader
         // is marked as required. That way, we can let the first optional request continue
         // to load when the TileLoader is later changed from required to optional. If we
@@ -52,7 +52,7 @@ void TileLoader<T>::loadFromCache() {
     assert(!request);
 
     resource.loadingMethod = Resource::LoadingMethod::CacheOnly;
-    request = fileSource.request(resource, [this](Response res) {
+    request = fileSource->request(resource, [this](Response res) {
         request.reset();
 
         tile.setTriedCache();
@@ -118,7 +118,7 @@ void TileLoader<T>::loadFromNetwork() {
     // Instead of using Resource::LoadingMethod::All, we're first doing a CacheOnly, and then a
     // NetworkOnly request.
     resource.loadingMethod = Resource::LoadingMethod::NetworkOnly;
-    request = fileSource.request(resource, [this](Response res) { loadedData(res); });
+    request = fileSource->request(resource, [this](Response res) { loadedData(res); });
 }
 
 } // namespace mbgl

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -57,7 +57,7 @@ public:
     Style style { fileSource, 1 };
     AnnotationManager annotationManager { style };
     ImageManager imageManager;
-    GlyphManager glyphManager { fileSource };
+    GlyphManager glyphManager;
 
     TileParameters tileParameters {
         1.0,

--- a/test/text/glyph_manager.test.cpp
+++ b/test/text/glyph_manager.test.cpp
@@ -68,7 +68,7 @@ public:
     StubFileSource fileSource;
     StubGlyphManagerObserver observer;
     StubGlyphRequestor requestor;
-    GlyphManager glyphManager{ fileSource, std::make_unique<StubLocalGlyphRasterizer>() };
+    GlyphManager glyphManager{ std::make_unique<StubLocalGlyphRasterizer>() };
 
     void run(const std::string& url, GlyphDependencies dependencies) {
         // Squelch logging.
@@ -76,7 +76,7 @@ public:
 
         glyphManager.setURL(url);
         glyphManager.setObserver(&observer);
-        glyphManager.getGlyphs(requestor, std::move(dependencies));
+        glyphManager.getGlyphs(requestor, std::move(dependencies), fileSource);
 
         loop.run();
     }
@@ -298,7 +298,7 @@ TEST(GlyphManager, ImmediateFileSource) {
         StubFileSource fileSource = { StubFileSource::ResponseType::Synchronous };
         StubGlyphManagerObserver observer;
         StubGlyphRequestor requestor;
-        GlyphManager glyphManager { fileSource };
+        GlyphManager glyphManager;
 
         void run(const std::string& url, GlyphDependencies dependencies) {
             // Squelch logging.
@@ -306,7 +306,7 @@ TEST(GlyphManager, ImmediateFileSource) {
 
             glyphManager.setURL(url);
             glyphManager.setObserver(&observer);
-            glyphManager.getGlyphs(requestor, std::move(dependencies));
+            glyphManager.getGlyphs(requestor, std::move(dependencies), fileSource);
 
             loop.run();
         }

--- a/test/tile/custom_geometry_tile.test.cpp
+++ b/test/tile/custom_geometry_tile.test.cpp
@@ -22,10 +22,10 @@ using namespace mbgl::style;
 
 class CustomTileTest {
 public:
-    FakeFileSource fileSource;
+    std::shared_ptr<FileSource> fileSource = std::make_shared<FakeFileSource>();
     TransformState transformState;
     util::RunLoop loop;
-    style::Style style { fileSource, 1 };
+    style::Style style { *fileSource, 1 };
     AnnotationManager annotationManager { style };
     ImageManager imageManager;
     GlyphManager glyphManager;

--- a/test/tile/custom_geometry_tile.test.cpp
+++ b/test/tile/custom_geometry_tile.test.cpp
@@ -28,7 +28,7 @@ public:
     style::Style style { fileSource, 1 };
     AnnotationManager annotationManager { style };
     ImageManager imageManager;
-    GlyphManager glyphManager { fileSource };
+    GlyphManager glyphManager;
 
     TileParameters tileParameters {
         1.0,

--- a/test/tile/geojson_tile.test.cpp
+++ b/test/tile/geojson_tile.test.cpp
@@ -21,10 +21,10 @@ using namespace mbgl::style;
 
 class GeoJSONTileTest {
 public:
-    FakeFileSource fileSource;
+    std::shared_ptr<FileSource> fileSource = std::make_shared<FakeFileSource>();
     TransformState transformState;
     util::RunLoop loop;
-    style::Style style { fileSource, 1 };
+    style::Style style { *fileSource, 1 };
     AnnotationManager annotationManager { style };
     ImageManager imageManager;
     GlyphManager glyphManager;

--- a/test/tile/geojson_tile.test.cpp
+++ b/test/tile/geojson_tile.test.cpp
@@ -27,7 +27,7 @@ public:
     style::Style style { fileSource, 1 };
     AnnotationManager annotationManager { style };
     ImageManager imageManager;
-    GlyphManager glyphManager { fileSource };
+    GlyphManager glyphManager;
     Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };
 
     TileParameters tileParameters {

--- a/test/tile/raster_dem_tile.test.cpp
+++ b/test/tile/raster_dem_tile.test.cpp
@@ -22,7 +22,7 @@ public:
     style::Style style { fileSource, 1 };
     AnnotationManager annotationManager { style };
     ImageManager imageManager;
-    GlyphManager glyphManager { fileSource };
+    GlyphManager glyphManager;
     Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };
 
     TileParameters tileParameters {

--- a/test/tile/raster_dem_tile.test.cpp
+++ b/test/tile/raster_dem_tile.test.cpp
@@ -16,10 +16,10 @@ using namespace mbgl;
 
 class RasterDEMTileTest {
 public:
-    FakeFileSource fileSource;
+    std::shared_ptr<FileSource> fileSource = std::make_shared<FakeFileSource>();
     TransformState transformState;
     util::RunLoop loop;
-    style::Style style { fileSource, 1 };
+    style::Style style { *fileSource, 1 };
     AnnotationManager annotationManager { style };
     ImageManager imageManager;
     GlyphManager glyphManager;

--- a/test/tile/raster_tile.test.cpp
+++ b/test/tile/raster_tile.test.cpp
@@ -22,7 +22,7 @@ public:
     style::Style style { fileSource, 1 };
     AnnotationManager annotationManager { style };
     ImageManager imageManager;
-    GlyphManager glyphManager { fileSource };
+    GlyphManager glyphManager;
     Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };
 
     TileParameters tileParameters {

--- a/test/tile/raster_tile.test.cpp
+++ b/test/tile/raster_tile.test.cpp
@@ -16,10 +16,10 @@ using namespace mbgl;
 
 class RasterTileTest {
 public:
-    FakeFileSource fileSource;
+    std::shared_ptr<FileSource> fileSource = std::make_shared<FakeFileSource>();
     TransformState transformState;
     util::RunLoop loop;
-    style::Style style { fileSource, 1 };
+    style::Style style { *fileSource, 1 };
     AnnotationManager annotationManager { style };
     ImageManager imageManager;
     GlyphManager glyphManager;

--- a/test/tile/vector_tile.test.cpp
+++ b/test/tile/vector_tile.test.cpp
@@ -28,7 +28,7 @@ public:
     style::Style style { fileSource, 1 };
     AnnotationManager annotationManager { style };
     ImageManager imageManager;
-    GlyphManager glyphManager { fileSource };
+    GlyphManager glyphManager;
     Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };
 
     TileParameters tileParameters {

--- a/test/tile/vector_tile.test.cpp
+++ b/test/tile/vector_tile.test.cpp
@@ -22,10 +22,10 @@ using namespace mbgl;
 
 class VectorTileTest {
 public:
-    FakeFileSource fileSource;
+    std::shared_ptr<FileSource> fileSource = std::make_shared<FakeFileSource>();
     TransformState transformState;
     util::RunLoop loop;
-    style::Style style { fileSource, 1 };
+    style::Style style { *fileSource, 1 };
     AnnotationManager annotationManager { style };
     ImageManager imageManager;
     GlyphManager glyphManager;


### PR DESCRIPTION
Avoid unnecessary glyph manager presence check in `Renderer::Impl::()`.

Also, this patch makes `GeometryTile` and `TileLoader` keep strong reference to `FileSource`. Thus, we fix a potential bug: if `Renderer` outlives the `Map` it will hold a stale reference to the `FileSource` instance.