### PR TITLE
[core] RenderTile shall never be created for a not renderable tile

### DIFF
--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -617,8 +617,7 @@ style::TextPaintProperties::PossiblyEvaluated RenderSymbolLayer::textPaintProper
 }
 
 void RenderSymbolLayer::setRenderTiles(RenderTiles tiles, const TransformState& state) {
-    auto filterFn = [](auto& tile){ return !tile.tile.isRenderable(); };
-    renderTiles = RenderLayer::filterRenderTiles(std::move(tiles), filterFn);
+    renderTiles = std::move(tiles);
     // Sort symbol tiles in opposite y position, so tiles with overlapping symbols are drawn
     // on top of each other, with lower symbols being drawn on top of higher symbols.
     std::sort(renderTiles.begin(), renderTiles.end(), [&state](const auto& a, const auto& b) {

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -40,8 +40,7 @@ bool RenderLayer::supportsZoom(float zoom) const {
 }
 
 void RenderLayer::setRenderTiles(RenderTiles tiles, const TransformState&) {
-    auto filterFn = [](auto& tile){ return !tile.tile.isRenderable() || tile.tile.holdForFade(); };
-    renderTiles = filterRenderTiles(std::move(tiles), filterFn);
+    renderTiles = filterRenderTiles(std::move(tiles));
 }
 
 const RenderLayerSymbolInterface* RenderLayer::getSymbolInterface() const {
@@ -52,16 +51,16 @@ optional<Color> RenderLayer::getSolidBackground() const {
     return nullopt;
 }
 
-RenderLayer::RenderTiles RenderLayer::filterRenderTiles(RenderTiles tiles, FilterFunctionPtr filterFn) const {
-    assert(filterFn != nullptr);
+RenderLayer::RenderTiles RenderLayer::filterRenderTiles(RenderTiles tiles) const {
     RenderTiles filtered;
 
     for (auto& tileRef : tiles) {
-        auto& tile = tileRef.get();
-        if (filterFn(tile)) {
+        auto& tile = tileRef.get().tile;
+        assert(tile.isRenderable());
+        if (tile.holdForFade()) {
             continue;
         }
-        filtered.emplace_back(tile);
+        filtered.emplace_back(tileRef);
     }
     return filtered;
 }

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -92,9 +92,6 @@ protected:
     // in the console to inform the developer.
     void checkRenderability(const PaintParameters&, uint32_t activeBindingCount);
 
-    using FilterFunctionPtr = bool (*)(RenderTile&);
-    RenderTiles filterRenderTiles(RenderTiles, FilterFunctionPtr) const;
-
 protected:
     // Stores current set of tiles to be rendered for this layer.
     std::vector<std::reference_wrapper<RenderTile>> renderTiles;
@@ -104,6 +101,7 @@ protected:
     RenderPass passes = RenderPass::None;
 
 private:
+    RenderTiles filterRenderTiles(RenderTiles) const;
     // Some layers may not render correctly on some hardware when the vertex attribute limit of
     // that GPU is exceeded. More attributes are used when adding many data driven paint properties
     // to a layer.

--- a/src/mbgl/text/cross_tile_symbol_index.cpp
+++ b/src/mbgl/text/cross_tile_symbol_index.cpp
@@ -174,9 +174,7 @@ bool CrossTileSymbolIndex::addLayer(const RenderLayerSymbolInterface& symbolInte
     layerIndex.handleWrapJump(lng);
 
     for (const RenderTile& renderTile : symbolInterface.getRenderTiles()) {
-        if (!renderTile.tile.isRenderable()) {
-            continue;
-        }
+        assert(renderTile.tile.isRenderable());
 
         auto bucket = symbolInterface.getSymbolBucket(renderTile);
         if (!bucket) {


### PR DESCRIPTION
A RenderTile is already never created for a not renderable tile, guarantied by the checks in `updateRenderables()`.

However, the client code had plenty of `isRenderable()` checks in the render path, which complicated the code and affected rendering performance.

This patch removes the unneeded checks from the client code and puts an assertion to `TilePyramid::addRenderTile()`.

Preparation work for https://github.com/mapbox/mapbox-gl-native/issues/14638 