### PR TITLE
Revert gradle 5.1/plugin 3.4.0 upgrade

### DIFF
--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.3.0'
         classpath dependenciesList.licensesPlugin
         classpath dependenciesList.kotlinPlugin
         classpath dependenciesList.bintrayPlugin

--- a/platform/android/gradle/gradle-bintray.gradle
+++ b/platform/android/gradle/gradle-bintray.gradle
@@ -16,7 +16,7 @@ publishing {
             version this.version
 
             afterEvaluate {
-                artifact("$buildDir/outputs/aar/MapboxGLAndroidSDK-release.aar")
+                artifact("$buildDir/outputs/aar/mapbox-android-sdk-release.aar")
                 artifact(androidSourcesJar)
                 artifact(androidJavadocsJar)
             }

--- a/platform/android/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-navigation-android/pull/1895#issuecomment-491446694.

Until we find a permanent fix, reverting the gradle/gradle plugin update resolves the issue.