### PR TITLE
[build, node] Bump macos CI job to Node 8 & Xcode 10.2.1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -337,8 +337,8 @@ commands:
     - run:
         name: Install Node macOS dependencies
         command: |
-          brew install node@6
-          brew link node@6 --force --overwrite
+          brew install node@8
+          brew link node@8 --force --overwrite
 
   install-qt-macos-dependencies:
     steps:
@@ -750,7 +750,7 @@ jobs:
 # ------------------------------------------------------------------------------
   node-macos-release:
     macos:
-      xcode: "10.2.0"
+      xcode: "10.2.1"
     environment:
       BUILDTYPE: RelWithDebInfo
       HOMEBREW_NO_AUTO_UPDATE: 1


### PR DESCRIPTION
NodeJS v6 is no longer available [on homebrew](https://formulae.brew.sh/formula/node), so, at @kkaefer’s suggestion, bump to v8. Refs #14650, #14651.