### PR TITLE
Add nitpick validation to make android-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -738,7 +738,7 @@ test-code-android:
 
 # Runs checkstyle and lint on the Android code
 .PHONY: android-check
-android-check : android-checkstyle android-lint-sdk android-lint-test-app
+android-check : android-checkstyle run-android-nitpick android-lint-sdk android-lint-test-app
 
 # Runs checkstyle on the Android code
 .PHONY: android-checkstyle

--- a/circle.yml
+++ b/circle.yml
@@ -539,9 +539,6 @@ jobs:
           name: Initialize vendor submodules
           command: git submodule update --init platform/android/vendor
       - run:
-          name: Android nitpick
-          command: make run-android-nitpick
-      - run:
           name: Check code style
           command: make android-check
       - run:


### PR DESCRIPTION
In my personal workflow, I use `make android-check` before opening a PR to validate if no code changes are requested by our static code analysis tools. With some recent PRs, I was able to make `make android-check` succeed but CI was failing over `make run-android-nitpick`. For ease of use, I'm suggesting to include running `nitpick` as part of `android-check`.