### PR TITLE
[ios] Rename performance metrics variable names.

### DIFF
--- a/platform/darwin/src/MGLNetworkConfiguration_Private.h
+++ b/platform/darwin/src/MGLNetworkConfiguration_Private.h
@@ -17,8 +17,8 @@ extern NSString * const kMGLDownloadPerformanceEvent;
 @property (nonatomic, weak) id<MGLNetworkConfigurationMetricsDelegate> metricsDelegate;
 
 - (void)startDownloadEvent:(NSString *)urlString type:(NSString *)resourceType;
-- (void)stopDownloadEvent:(NSString *)urlString;
-- (void)cancelDownloadEvent:(NSString *)urlString;
+- (void)stopDownloadEventForResponse:(NSURLResponse *)response;
+- (void)cancelDownloadEventForResponse:(NSURLResponse *)response;
 
 @end
 

--- a/platform/darwin/src/http_file_source.mm
+++ b/platform/darwin/src/http_file_source.mm
@@ -242,10 +242,10 @@ std::unique_ptr<AsyncRequest> HTTPFileSource::request(const Resource& resource, 
             dataTaskWithRequest:req
               completionHandler:^(NSData* data, NSURLResponse* res, NSError* error) {
                 if (error && [error code] == NSURLErrorCancelled) {
-                    [[MGLNetworkConfiguration sharedManager] cancelDownloadEvent:res.URL.relativePath];
+                    [[MGLNetworkConfiguration sharedManager] cancelDownloadEventForResponse:res];
                     return;
                 }
-                [[MGLNetworkConfiguration sharedManager] stopDownloadEvent:res.URL.relativePath];
+                [[MGLNetworkConfiguration sharedManager] stopDownloadEventForResponse:res];
                 Response response;
                 using Error = Response::Error;
 


### PR DESCRIPTION
Renames performance metrics variable names accordingly to Android.

`elapsed_time` -> `elapsedMS`
`resource` -> `requestUrl`

Adds new variables:
`wifiOn`
`responseCode`