### PR TITLE
[ios, macos] clarified documentation for newCamera param of the shouldChangeFromCamera delegate

### DIFF
--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
  method returns `YES`, the viewport of the map will transition to the new camera. Note that the new camera cannot be modified.
  @param reason The reason for the camera change.
  @return A Boolean value indicating whether the map view should stay at
- `oldCamera` or change to `newCamera`.
+ `oldCamera` or transition to `newCamera`.
 
  @note If this method is implemented `-mapView:shouldChangeFromCamera:toCamera:` will not be called.
  */

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
  gesture is recognized. If this method returns `NO`, the map view’s camera
  continues to be this camera.
  @param newCamera The expected camera after the gesture completes. If this
- method returns `YES`, this camera becomes the map view’s camera.
+ method returns `YES`, the viewport of the map will transition to the new camera. Note that the new camera cannot be modified.
  @param reason The reason for the camera change.
  @return A Boolean value indicating whether the map view should stay at
  `oldCamera` or change to `newCamera`.


### PR DESCRIPTION
The newCamera parameter available in the `shouldChangeFromCamera:` delegate is described as if it becomes a modifiable new camera object - this is not entirely true, and this update to the documentation describes how it works a bit more clearly.

cc @captainbarbosa @fabian-guerra 