### PR TITLE
[core] Refactor HeadlessFrontend/Backend: GL separation and factory

### DIFF
--- a/benchmark/api/query.benchmark.cpp
+++ b/benchmark/api/query.benchmark.cpp
@@ -2,7 +2,7 @@
 
 #include <mbgl/map/map.hpp>
 #include <mbgl/map/map_options.hpp>
-#include <mbgl/gl/headless_frontend.hpp>
+#include <mbgl/gfx/headless_frontend.hpp>
 #include <mbgl/renderer/renderer.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/image.hpp>

--- a/benchmark/api/render.benchmark.cpp
+++ b/benchmark/api/render.benchmark.cpp
@@ -3,7 +3,7 @@
 #include <mbgl/map/map.hpp>
 #include <mbgl/map/map_observer.hpp>
 #include <mbgl/map/map_options.hpp>
-#include <mbgl/gl/headless_frontend.hpp>
+#include <mbgl/gfx/headless_frontend.hpp>
 #include <mbgl/renderer/renderer.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/image.hpp>

--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -4,7 +4,7 @@
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/util/default_styles.hpp>
 
-#include <mbgl/gl/headless_frontend.hpp>
+#include <mbgl/gfx/headless_frontend.hpp>
 #include <mbgl/style/style.hpp>
 
 #include <args.hxx>

--- a/platform/android/core-files.json
+++ b/platform/android/core-files.json
@@ -85,8 +85,9 @@
         "platform/android/src/thread.cpp",
         "platform/android/src/timer.cpp",
         "platform/android/src/unaccent.cpp",
+        "platform/default/src/mbgl/gfx/headless_backend.cpp",
+        "platform/default/src/mbgl/gfx/headless_frontend.cpp",
         "platform/default/src/mbgl/gl/headless_backend.cpp",
-        "platform/default/src/mbgl/gl/headless_frontend.cpp",
         "platform/default/src/mbgl/map/map_snapshotter.cpp",
         "platform/default/src/mbgl/text/bidi.cpp",
         "platform/default/src/mbgl/util/png_writer.cpp",
@@ -96,8 +97,9 @@
     ],
     "public_headers": {
         "jni/string_conversion.hpp": "platform/default/include/jni/string_conversion.hpp",
+        "mbgl/gfx/headless_backend.hpp": "platform/default/include/mbgl/gfx/headless_backend.hpp",
+        "mbgl/gfx/headless_frontend.hpp": "platform/default/include/mbgl/gfx/headless_frontend.hpp",
         "mbgl/gl/headless_backend.hpp": "platform/default/include/mbgl/gl/headless_backend.hpp",
-        "mbgl/gl/headless_frontend.hpp": "platform/default/include/mbgl/gl/headless_frontend.hpp",
         "mbgl/map/map_snapshotter.hpp": "platform/default/include/mbgl/map/map_snapshotter.hpp",
         "mbgl/text/unaccent.hpp": "platform/default/include/mbgl/text/unaccent.hpp"
     },

--- a/platform/default/include/mbgl/gfx/headless_backend.hpp
+++ b/platform/default/include/mbgl/gfx/headless_backend.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <mbgl/gfx/renderable.hpp>
+#include <mbgl/gfx/renderer_backend.hpp>
+#include <mbgl/util/image.hpp>
+
+#include <memory>
+
+namespace mbgl {
+namespace gfx {
+
+class HeadlessBackend : public gfx::Renderable {
+public:
+    // Factory.
+    static std::unique_ptr<HeadlessBackend> makeBackend(Size = { 256, 256 }, gfx::ContextMode = gfx::ContextMode::Unique);
+    
+    HeadlessBackend(Size);
+    virtual PremultipliedImage readStillImage() = 0;
+    virtual RendererBackend* getRendererBackend() = 0;
+    void setSize(Size);
+};
+
+} // namespace gfx
+} // namespace mbgl

--- a/platform/default/include/mbgl/gfx/headless_backend.hpp
+++ b/platform/default/include/mbgl/gfx/headless_backend.hpp
@@ -9,15 +9,20 @@
 namespace mbgl {
 namespace gfx {
 
+// Common headless backend interface, provides HeadlessBackend backend factory
+// and enables extending gfx::Renderable with platform specific implementation
+// of readStillImage.
 class HeadlessBackend : public gfx::Renderable {
 public:
     // Factory.
-    static std::unique_ptr<HeadlessBackend> makeBackend(Size = { 256, 256 }, gfx::ContextMode = gfx::ContextMode::Unique);
+    static std::unique_ptr<HeadlessBackend> make(Size = { 256, 256 }, gfx::ContextMode = gfx::ContextMode::Unique);
     
-    HeadlessBackend(Size);
     virtual PremultipliedImage readStillImage() = 0;
     virtual RendererBackend* getRendererBackend() = 0;
     void setSize(Size);
+
+protected:
+    HeadlessBackend(Size);
 };
 
 } // namespace gfx

--- a/platform/default/include/mbgl/gfx/headless_frontend.hpp
+++ b/platform/default/include/mbgl/gfx/headless_frontend.hpp
@@ -2,7 +2,7 @@
 
 #include <mbgl/map/camera.hpp>
 #include <mbgl/renderer/renderer_frontend.hpp>
-#include <mbgl/gl/headless_backend.hpp>
+#include <mbgl/gfx/headless_backend.hpp>
 #include <mbgl/util/async_task.hpp>
 #include <mbgl/util/optional.hpp>
 
@@ -13,10 +13,6 @@ namespace mbgl {
 class Renderer;
 class Map;
 class TransformState;
-
-namespace gfx {
-class RendererBackend;
-} // namespace gfx
 
 class HeadlessFrontend : public RendererFrontend {
 public:
@@ -58,7 +54,7 @@ private:
     Size size;
     float pixelRatio;
 
-    gl::HeadlessBackend backend;
+    std::unique_ptr<gfx::HeadlessBackend> backend;
     util::AsyncTask asyncInvalidate;
 
     std::unique_ptr<Renderer> renderer;

--- a/platform/default/include/mbgl/gl/headless_backend.hpp
+++ b/platform/default/include/mbgl/gl/headless_backend.hpp
@@ -1,26 +1,21 @@
 #pragma once
 
-#include <mbgl/gfx/renderable.hpp>
+#include <mbgl/gfx/headless_backend.hpp>
 #include <mbgl/gl/renderer_backend.hpp>
-
 #include <memory>
 #include <functional>
 
 namespace mbgl {
 namespace gl {
 
-class HeadlessBackend final : public gl::RendererBackend, public gfx::Renderable {
+class HeadlessBackend final : public gl::RendererBackend, public gfx::HeadlessBackend {
 public:
     HeadlessBackend(Size = { 256, 256 }, gfx::ContextMode = gfx::ContextMode::Unique);
     ~HeadlessBackend() override;
-
-    gfx::Renderable& getDefaultRenderable() override;
-
-    Size getFramebufferSize() const;
     void updateAssumedState() override;
-
-    void setSize(Size);
-    PremultipliedImage readStillImage();
+    gfx::Renderable& getDefaultRenderable() override;
+    PremultipliedImage readStillImage() override;
+    RendererBackend* getRendererBackend() override;
 
     class Impl {
     public:
@@ -41,8 +36,6 @@ private:
 
 private:
     std::unique_ptr<Impl> impl;
-
-    float pixelRatio;
     bool active = false;
 };
 

--- a/platform/default/src/mbgl/gfx/headless_backend.cpp
+++ b/platform/default/src/mbgl/gfx/headless_backend.cpp
@@ -1,0 +1,16 @@
+#include <mbgl/gfx/headless_backend.hpp>
+
+namespace mbgl {
+namespace gfx {
+
+HeadlessBackend::HeadlessBackend(Size size_)
+    : mbgl::gfx::Renderable(size_, nullptr) {
+}
+
+void HeadlessBackend::setSize(Size size_) {
+    size = size_;
+    resource.reset();
+}
+
+} // namespace gfx
+} // namespace mbgl

--- a/platform/default/src/mbgl/gfx/headless_frontend.cpp
+++ b/platform/default/src/mbgl/gfx/headless_frontend.cpp
@@ -24,8 +24,8 @@ HeadlessFrontend::HeadlessFrontend(Size size_,
                                    const optional<std::string> localFontFamily)
     : size(size_),
     pixelRatio(pixelRatio_),
-    backend(gfx::HeadlessBackend::makeBackend( { static_cast<uint32_t>(size.width * pixelRatio),
-                                                 static_cast<uint32_t>(size.height * pixelRatio) }, contextMode)),
+    backend(gfx::HeadlessBackend::make( { static_cast<uint32_t>(size.width * pixelRatio),
+                                          static_cast<uint32_t>(size.height * pixelRatio) }, contextMode)),
     asyncInvalidate([this] {
         if (renderer && updateParameters) {
             gfx::BackendScope guard { *getBackend() };

--- a/platform/default/src/mbgl/gfx/headless_frontend.cpp
+++ b/platform/default/src/mbgl/gfx/headless_frontend.cpp
@@ -1,4 +1,4 @@
-#include <mbgl/gl/headless_frontend.hpp>
+#include <mbgl/gfx/headless_frontend.hpp>
 #include <mbgl/gfx/backend_scope.hpp>
 #include <mbgl/renderer/renderer.hpp>
 #include <mbgl/renderer/renderer_state.hpp>
@@ -24,11 +24,11 @@ HeadlessFrontend::HeadlessFrontend(Size size_,
                                    const optional<std::string> localFontFamily)
     : size(size_),
     pixelRatio(pixelRatio_),
-    backend({ static_cast<uint32_t>(size.width * pixelRatio),
-              static_cast<uint32_t>(size.height * pixelRatio) }, contextMode),
+    backend(gfx::HeadlessBackend::makeBackend( { static_cast<uint32_t>(size.width * pixelRatio),
+                                                 static_cast<uint32_t>(size.height * pixelRatio) }, contextMode)),
     asyncInvalidate([this] {
         if (renderer && updateParameters) {
-            gfx::BackendScope guard { backend };
+            gfx::BackendScope guard { *getBackend() };
 
             // onStyleImageMissing might be called during a render. The user implemented method
             // could trigger a call to MGLRenderFrontend#update which overwrites `updateParameters`.
@@ -38,7 +38,7 @@ HeadlessFrontend::HeadlessFrontend(Size size_,
             renderer->render(*updateParameters_);
         }
     }),
-    renderer(std::make_unique<Renderer>(backend, pixelRatio, programCacheDir, localFontFamily)) {
+    renderer(std::make_unique<Renderer>(*getBackend(), pixelRatio, programCacheDir, localFontFamily)) {
 }
 
 HeadlessFrontend::~HeadlessFrontend() = default;
@@ -68,7 +68,7 @@ Renderer* HeadlessFrontend::getRenderer() {
 }
 
 gfx::RendererBackend* HeadlessFrontend::getBackend() {
-    return &backend;
+    return backend->getRendererBackend();
 }
 
 CameraOptions HeadlessFrontend::getCameraOptions() {
@@ -121,13 +121,13 @@ LatLng HeadlessFrontend::latLngForPixel(const ScreenCoordinate& point) {
 void HeadlessFrontend::setSize(Size size_) {
     if (size != size_) {
         size = size_;
-        backend.setSize({ static_cast<uint32_t>(size_.width * pixelRatio),
-                          static_cast<uint32_t>(size_.height * pixelRatio) });
+        backend->setSize({ static_cast<uint32_t>(size_.width * pixelRatio),
+                           static_cast<uint32_t>(size_.height * pixelRatio) });
     }
 }
 
 PremultipliedImage HeadlessFrontend::readStillImage() {
-    return backend.readStillImage();
+    return backend->readStillImage();
 }
 
 PremultipliedImage HeadlessFrontend::render(Map& map) {
@@ -137,7 +137,7 @@ PremultipliedImage HeadlessFrontend::render(Map& map) {
         if (error) {
             std::rethrow_exception(error);
         } else {
-            result = backend.readStillImage();
+            result = backend->readStillImage();
         }
     });
 

--- a/platform/default/src/mbgl/gl/headless_backend.cpp
+++ b/platform/default/src/mbgl/gl/headless_backend.cpp
@@ -32,7 +32,7 @@ public:
 };
 
 HeadlessBackend::HeadlessBackend(const Size size_, const gfx::ContextMode contextMode_)
-    : mbgl::gl::RendererBackend(contextMode_), mbgl::gfx::Renderable(size_, nullptr) {
+    : mbgl::gl::RendererBackend(contextMode_), mbgl::gfx::HeadlessBackend(size_) {
 }
 
 HeadlessBackend::~HeadlessBackend() {
@@ -72,22 +72,27 @@ gfx::Renderable& HeadlessBackend::getDefaultRenderable() {
     return *this;
 }
 
-Size HeadlessBackend::getFramebufferSize() const {
-    return size;
-}
-
 void HeadlessBackend::updateAssumedState() {
     // no-op
-}
-
-void HeadlessBackend::setSize(Size size_) {
-    size = size_;
-    resource.reset();
 }
 
 PremultipliedImage HeadlessBackend::readStillImage() {
     return static_cast<gl::Context&>(getContext()).readFramebuffer<PremultipliedImage>(size);
 }
+    
+RendererBackend* HeadlessBackend::getRendererBackend() {
+    return this;
+}
 
 } // namespace gl
+
+#ifndef OVERRIDE_HEADLESS_BACKEND_FACTORY
+// Default factory implementation.
+std::unique_ptr<gfx::HeadlessBackend> gfx::HeadlessBackend::makeBackend(Size size, gfx::ContextMode contextMode) {
+    return std::make_unique<gl::HeadlessBackend>(size, contextMode);
+}
+#endif
+
 } // namespace mbgl
+
+

--- a/platform/default/src/mbgl/gl/headless_backend.cpp
+++ b/platform/default/src/mbgl/gl/headless_backend.cpp
@@ -88,7 +88,7 @@ RendererBackend* HeadlessBackend::getRendererBackend() {
 
 #ifndef OVERRIDE_HEADLESS_BACKEND_FACTORY
 // Default factory implementation.
-std::unique_ptr<gfx::HeadlessBackend> gfx::HeadlessBackend::makeBackend(Size size, gfx::ContextMode contextMode) {
+std::unique_ptr<gfx::HeadlessBackend> gfx::HeadlessBackend::make(Size size, gfx::ContextMode contextMode) {
     return std::make_unique<gl::HeadlessBackend>(size, contextMode);
 }
 #endif

--- a/platform/default/src/mbgl/map/map_snapshotter.cpp
+++ b/platform/default/src/mbgl/map/map_snapshotter.cpp
@@ -1,7 +1,7 @@
 #include <mbgl/map/map_snapshotter.hpp>
 
 #include <mbgl/actor/actor_ref.hpp>
-#include <mbgl/gl/headless_frontend.hpp>
+#include <mbgl/gfx/headless_frontend.hpp>
 #include <mbgl/map/map.hpp>
 #include <mbgl/map/map_options.hpp>
 #include <mbgl/map/transform_state.hpp>

--- a/platform/ios/core-files.json
+++ b/platform/ios/core-files.json
@@ -10,8 +10,9 @@
         "platform/darwin/src/nsthread.mm",
         "platform/darwin/src/reachability.m",
         "platform/darwin/src/string_nsstring.mm",
+        "platform/default/src/mbgl/gfx/headless_backend.cpp",
+        "platform/default/src/mbgl/gfx/headless_frontend.cpp",
         "platform/default/src/mbgl/gl/headless_backend.cpp",
-        "platform/default/src/mbgl/gl/headless_frontend.cpp",
         "platform/default/src/mbgl/map/map_snapshotter.cpp",
         "platform/default/src/mbgl/text/bidi.cpp",
         "platform/default/src/mbgl/util/png_writer.cpp",
@@ -21,8 +22,9 @@
     "public_headers": {
         "mbgl/storage/reachability.h": "platform/darwin/include/mbgl/storage/reachability.h",
         "mbgl/util/image+MGLAdditions.hpp": "platform/darwin/include/mbgl/util/image+MGLAdditions.hpp",
+        "mbgl/gfx/headless_backend.hpp": "platform/default/include/mbgl/gfx/headless_backend.hpp",
+        "mbgl/gfx/headless_frontend.hpp": "platform/default/include/mbgl/gfx/headless_frontend.hpp",
         "mbgl/gl/headless_backend.hpp": "platform/default/include/mbgl/gl/headless_backend.hpp",
-        "mbgl/gl/headless_frontend.hpp": "platform/default/include/mbgl/gl/headless_frontend.hpp",
         "mbgl/map/map_snapshotter.hpp": "platform/default/include/mbgl/map/map_snapshotter.hpp",
         "mbgl/util/default_styles.hpp": "platform/default/include/mbgl/util/default_styles.hpp"
     },

--- a/platform/linux/config.cmake
+++ b/platform/linux/config.cmake
@@ -64,8 +64,10 @@ macro(mbgl_platform_core)
         PRIVATE platform/default/src/mbgl/util/png_reader.cpp
 
         # Headless view
-        PRIVATE platform/default/src/mbgl/gl/headless_frontend.cpp
-        PRIVATE platform/default/include/mbgl/gl/headless_frontend.hpp
+        PRIVATE platform/default/src/mbgl/gfx/headless_frontend.cpp
+        PRIVATE platform/default/include/mbgl/gfx/headless_frontend.hpp
+        PRIVATE platform/default/src/mbgl/gfx/headless_backend.cpp
+        PRIVATE platform/default/include/mbgl/gfx/headless_backend.hpp
         PRIVATE platform/default/src/mbgl/gl/headless_backend.cpp
         PRIVATE platform/default/include/mbgl/gl/headless_backend.hpp
 

--- a/platform/macos/core-files.json
+++ b/platform/macos/core-files.json
@@ -9,8 +9,9 @@
         "platform/darwin/src/nsthread.mm",
         "platform/darwin/src/reachability.m",
         "platform/darwin/src/string_nsstring.mm",
+        "platform/default/src/mbgl/gfx/headless_backend.cpp",
+        "platform/default/src/mbgl/gfx/headless_frontend.cpp",
         "platform/default/src/mbgl/gl/headless_backend.cpp",
-        "platform/default/src/mbgl/gl/headless_frontend.cpp",
         "platform/default/src/mbgl/map/map_snapshotter.cpp",
         "platform/default/src/mbgl/text/bidi.cpp",
         "platform/default/src/mbgl/util/png_writer.cpp",
@@ -20,8 +21,9 @@
     "public_headers": {
         "mbgl/storage/reachability.h": "platform/darwin/include/mbgl/storage/reachability.h",
         "mbgl/util/image+MGLAdditions.hpp": "platform/darwin/include/mbgl/util/image+MGLAdditions.hpp",
+        "mbgl/gfx/headless_backend.hpp": "platform/default/include/mbgl/gfx/headless_backend.hpp",
+        "mbgl/gfx/headless_frontend.hpp": "platform/default/include/mbgl/gfx/headless_frontend.hpp",
         "mbgl/gl/headless_backend.hpp": "platform/default/include/mbgl/gl/headless_backend.hpp",
-        "mbgl/gl/headless_frontend.hpp": "platform/default/include/mbgl/gl/headless_frontend.hpp",
         "mbgl/map/map_snapshotter.hpp": "platform/default/include/mbgl/map/map_snapshotter.hpp"
     },
     "private_headers": {

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -4,7 +4,7 @@
 #include "node_conversion.hpp"
 
 #include <mbgl/renderer/renderer.hpp>
-#include <mbgl/gl/headless_frontend.hpp>
+#include <mbgl/gfx/headless_frontend.hpp>
 #include <mbgl/style/conversion/source.hpp>
 #include <mbgl/style/conversion/layer.hpp>
 #include <mbgl/style/conversion/filter.hpp>

--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -11,8 +11,10 @@ set(CMAKE_AUTORCC ON)
 
 set(MBGL_QT_CORE_FILES
     # Headless view
-    PRIVATE platform/default/src/mbgl/gl/headless_frontend.cpp
-    PRIVATE platform/default/include/mbgl/gl/headless_frontend.hpp
+    PRIVATE platform/default/src/mbgl/gfx/headless_frontend.cpp
+    PRIVATE platform/default/include/mbgl/gfx/headless_frontend.hpp
+    PRIVATE platform/default/src/mbgl/gfx/headless_backend.cpp
+    PRIVATE platform/default/include/mbgl/gfx/headless_backend.hpp
     PRIVATE platform/default/src/mbgl/gl/headless_backend.cpp
     PRIVATE platform/default/include/mbgl/gl/headless_backend.hpp
     PRIVATE platform/qt/src/headless_backend_qt.cpp

--- a/test/api/annotations.test.cpp
+++ b/test/api/annotations.test.cpp
@@ -10,7 +10,7 @@
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/util/color.hpp>
 #include <mbgl/renderer/renderer.hpp>
-#include <mbgl/gl/headless_frontend.hpp>
+#include <mbgl/gfx/headless_frontend.hpp>
 
 using namespace mbgl;
 

--- a/test/api/api_misuse.test.cpp
+++ b/test/api/api_misuse.test.cpp
@@ -5,7 +5,7 @@
 
 #include <mbgl/map/map_options.hpp>
 #include <mbgl/gfx/backend_scope.hpp>
-#include <mbgl/gl/headless_frontend.hpp>
+#include <mbgl/gfx/headless_frontend.hpp>
 #include <mbgl/util/exception.hpp>
 #include <mbgl/util/run_loop.hpp>
 

--- a/test/api/custom_geometry_source.test.cpp
+++ b/test/api/custom_geometry_source.test.cpp
@@ -2,7 +2,7 @@
 
 #include <mbgl/map/map.hpp>
 #include <mbgl/map/map_options.hpp>
-#include <mbgl/gl/headless_frontend.hpp>
+#include <mbgl/gfx/headless_frontend.hpp>
 #include <mbgl/storage/resource_options.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/sources/custom_geometry_source.hpp>

--- a/test/api/custom_layer.test.cpp
+++ b/test/api/custom_layer.test.cpp
@@ -4,7 +4,7 @@
 #include <mbgl/map/map.hpp>
 #include <mbgl/map/map_options.hpp>
 #include <mbgl/gl/defines.hpp>
-#include <mbgl/gl/headless_frontend.hpp>
+#include <mbgl/gfx/headless_frontend.hpp>
 #include <mbgl/storage/resource_options.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/layers/custom_layer.hpp>

--- a/test/api/query.test.cpp
+++ b/test/api/query.test.cpp
@@ -13,7 +13,7 @@
 #include <mbgl/style/sources/geojson_source.hpp>
 #include <mbgl/style/expression/dsl.hpp>
 #include <mbgl/renderer/renderer.hpp>
-#include <mbgl/gl/headless_frontend.hpp>
+#include <mbgl/gfx/headless_frontend.hpp>
 
 using namespace mbgl;
 using namespace mbgl::style;

--- a/test/api/recycle_map.cpp
+++ b/test/api/recycle_map.cpp
@@ -2,7 +2,7 @@
 #include <mbgl/test/stub_file_source.hpp>
 #include <mbgl/test/map_adapter.hpp>
 
-#include <mbgl/gl/headless_frontend.hpp>
+#include <mbgl/gfx/headless_frontend.hpp>
 #include <mbgl/map/map_options.hpp>
 #include <mbgl/gfx/backend_scope.hpp>
 #include <mbgl/style/layers/symbol_layer.hpp>

--- a/test/gl/context.test.cpp
+++ b/test/gl/context.test.cpp
@@ -6,7 +6,7 @@
 #include <mbgl/map/map_options.hpp>
 #include <mbgl/gfx/backend_scope.hpp>
 #include <mbgl/gl/defines.hpp>
-#include <mbgl/gl/headless_frontend.hpp>
+#include <mbgl/gfx/headless_frontend.hpp>
 #include <mbgl/gl/renderable_resource.hpp>
 #include <mbgl/storage/resource_options.hpp>
 #include <mbgl/style/style.hpp>

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -8,7 +8,7 @@
 #include <mbgl/map/map_options.hpp>
 #include <mbgl/gfx/backend_scope.hpp>
 #include <mbgl/gl/context.hpp>
-#include <mbgl/gl/headless_frontend.hpp>
+#include <mbgl/gfx/headless_frontend.hpp>
 #include <mbgl/storage/resource_options.hpp>
 #include <mbgl/storage/network_status.hpp>
 #include <mbgl/storage/default_file_source.hpp>

--- a/test/map/prefetch.test.cpp
+++ b/test/map/prefetch.test.cpp
@@ -4,7 +4,7 @@
 #include <mbgl/test/map_adapter.hpp>
 
 #include <mbgl/map/map_options.hpp>
-#include <mbgl/gl/headless_frontend.hpp>
+#include <mbgl/gfx/headless_frontend.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/io.hpp>

--- a/test/text/local_glyph_rasterizer.test.cpp
+++ b/test/text/local_glyph_rasterizer.test.cpp
@@ -7,7 +7,7 @@
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/util/color.hpp>
 #include <mbgl/renderer/renderer.hpp>
-#include <mbgl/gl/headless_frontend.hpp>
+#include <mbgl/gfx/headless_frontend.hpp>
 #include <mbgl/style/style.hpp>
 
 /*

--- a/test/util/memory.test.cpp
+++ b/test/util/memory.test.cpp
@@ -4,7 +4,7 @@
 #include <mbgl/test/map_adapter.hpp>
 
 #include <mbgl/map/map_options.hpp>
-#include <mbgl/gl/headless_frontend.hpp>
+#include <mbgl/gfx/headless_frontend.hpp>
 #include <mbgl/util/io.hpp>
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/style/style.hpp>


### PR DESCRIPTION
Refactor out HeadlessFrontend and HeadlessBackend gl independent code to gfx.
Define gl::HeadlessBackend as subclass, instantiated by gfx::HeadlessBackend static factory method.
Overriding the factory enabled.
GL dependent tests are still using gl::HeadlessBackend directly (not through gfx).
