### PR TITLE
[ios] Podspec updates for v4.12.0-beta.1

### DIFF
--- a/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '4.11.0'
+  version = '4.12.0-beta.1'
 
   m.name    = 'Mapbox-iOS-SDK-snapshot-dynamic'
   m.version = "#{version}-snapshot"

--- a/platform/ios/Mapbox-iOS-SDK-stripped.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-stripped.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '4.11.0'
+  version = '4.12.0-beta.1'
 
   m.name    = 'Mapbox-iOS-SDK-stripped'
   m.version = "#{version}-stripped"

--- a/platform/ios/Mapbox-iOS-SDK.podspec
+++ b/platform/ios/Mapbox-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '4.11.0'
+  version = '4.12.0-beta.1'
 
   m.name    = 'Mapbox-iOS-SDK'
   m.version = version


### PR DESCRIPTION
I didn't see any changelog differences between [`release-nectar` and `master`](https://github.com/mapbox/mapbox-gl-native/compare/release-nectar...master), since we cut the branch today.

cc @fabian-guerra 