### PR TITLE
[ios] Introduce MGLStyle initializers

### DIFF
--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -283,7 +283,7 @@ MGL_EXPORT
  The <a href="https://docs.mapbox.com/help/glossary/style-url/">style URL</a> associated
  with the style.
  */
-@property (readonly, strong, nullable) NSURL *URL;
+@property (nonatomic, strong, nullable) NSURL *URL;
 
 #pragma mark Managing Sources
 

--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -61,6 +61,28 @@ FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLRedundantSourceIdentifier
 MGL_EXPORT
 @interface MGLStyle : NSObject
 
+#pragma mark Creating Instances
+
+/**
+ Initializes and returns a new map style with a given URL.
+
+ @param styleURL The URL used to initialize a map style,
+ which must point to a JSON object that conforms to the
+ <a href="https://docs.mapbox.com/mapbox-gl-js/style-spec/">Mapbox Style Specification</a>.
+*/
+- (instancetype)initWithURL:(NSURL *)styleURL;
+
+/**
+ Initializes and returns a new map style with a given data object.
+
+ @param data String data containing JSON that conforms to the
+ <a href="https://docs.mapbox.com/mapbox-gl-js/style-spec/">Mapbox Style Specification</a> .
+ @param encoding The encoding used by `data`.
+ @param outError Upon return, if an error has occurred, a pointer to an
+ `NSError` object describing the error. Pass in `NULL` to ignore any error.
+*/
+- (instancetype)initWithData:(NSData *)data encoding:(NSStringEncoding)encoding error:(NSError * _Nullable *)outError;
+
 #pragma mark Accessing Default Styles
 
 /**
@@ -256,6 +278,12 @@ MGL_EXPORT
  You can customize the style’s name in Mapbox Studio.
  */
 @property (readonly, copy, nullable) NSString *name;
+
+/**
+ The <a href="https://docs.mapbox.com/help/glossary/style-url/">style URL</a> associated
+ with the style.
+ */
+@property (readonly, strong, nullable) NSURL *URL;
 
 #pragma mark Managing Sources
 

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -83,7 +83,6 @@ const MGLExceptionName MGLRedundantSourceIdentifierException = @"MGLRedundantSou
 
 @property (nonatomic, readonly, weak) MGLMapView *mapView;
 @property (nonatomic, readonly) mbgl::style::Style *rawStyle;
-@property (readwrite, strong, nullable) NSURL *URL;
 @property (nonatomic, readwrite, strong) NSMutableDictionary<NSString *, MGLOpenGLStyleLayer *> *openGLLayers;
 @property (nonatomic) NSMutableDictionary<NSString *, NSDictionary<NSObject *, MGLTextLanguage *> *> *localizedLayersByIdentifier;
 
@@ -98,7 +97,6 @@ const MGLExceptionName MGLRedundantSourceIdentifierException = @"MGLRedundantSou
         [self commonInit];
 
         self.URL = styleURL;
-        _URL = styleURL;
     }
 
     return self;

--- a/platform/darwin/test/MGLStyleTests.mm
+++ b/platform/darwin/test/MGLStyleTests.mm
@@ -29,7 +29,8 @@
 
     [MGLAccountManager setAccessToken:@"pk.feedcafedeadbeefbadebede"];
     NSURL *styleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"one-liner" withExtension:@"json"];
-    self.mapView = [[MGLMapView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) styleURL:styleURL];
+    MGLStyle *mapStyle = [[MGLStyle alloc] initWithURL:styleURL];
+    self.mapView = [[MGLMapView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) style:mapStyle];
     self.mapView.delegate = self;
     if (!self.mapView.style) {
         _styleLoadingExpectation = [self expectationWithDescription:@"Map view should finish loading style."];

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -217,6 +217,17 @@ MGL_EXPORT
  */
 - (instancetype)initWithFrame:(CGRect)frame styleURL:(nullable NSURL *)styleURL;
 
+
+/**
+ Initializes and returns a newly allocated map view with the specified frame
+ and style.
+
+ @param frame The frame for the view, measured in points.
+ @param style The style to display. Specify `nil` for the default style.
+ @return An initialized map view.
+*/
+- (instancetype)initWithFrame:(CGRect)frame style:(nullable MGLStyle *)style;
+
 #pragma mark Accessing the Delegate
 
 /**

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -355,7 +355,20 @@ public:
         MGLLogInfo(@"Starting %@ initialization.", NSStringFromClass([self class]));
         MGLLogDebug(@"Initializing frame: %@ styleURL: %@", NSStringFromCGRect(frame), styleURL);
         [self commonInit];
-        self.styleURL = styleURL;
+        MGLStyle *style = [[MGLStyle alloc] initWithURL:styleURL];
+        self.styleURL = style.URL;
+        MGLLogInfo(@"Finalizing %@ initialization.", NSStringFromClass([self class]));
+    }
+    return self;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame style:(nullable MGLStyle *)style {
+    if (self = [super initWithFrame:frame])
+    {
+        MGLLogInfo(@"Starting %@ initialization.", NSStringFromClass([self class]));
+        MGLLogDebug(@"Initializing frame: %@ style: %@", NSStringFromCGRect(frame), style);
+        [self commonInit];
+        self.style = style;
         MGLLogInfo(@"Finalizing %@ initialization.", NSStringFromClass([self class]));
     }
     return self;


### PR DESCRIPTION
Addresses https://github.com/mapbox/mapbox-gl-native/issues/6386 by making the following changes to `MGLStyle` and `MGLMapView`:

**`MGLStyle`**
✨ Introduce `-[MGLStyle initWithURL:]` 
✨ Introduce `-[MGLStyle initWithJSONData:encoding:error:]`

**`MGLMapView`**
✨ Introduce `-[MGLMapView initWithFrame:style]`
✂️ Deprecate `-[MGLMapView initWithFrame:styleURL:`