### PR TITLE
Bump snapshot version to 8.1.0

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/gradle.properties
+++ b/platform/android/MapboxGLAndroidSDK/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=8.0.0-SNAPSHOT
+VERSION_NAME=8.1.0-SNAPSHOT
 
 # Only build native dependencies for the current ABI
 # See https://code.google.com/p/android/issues/detail?id=221098#c20


### PR DESCRIPTION
`release-nectar` release branch has been cut, need to update snapshot version to reflect `release-o`.
