### PR TITLE
[core] Prepare render sources before render layers are initialized

### DIFF
--- a/include/mbgl/util/constants.hpp
+++ b/include/mbgl/util/constants.hpp
@@ -57,6 +57,8 @@ constexpr int DEFAULT_RATE_LIMIT_TIMEOUT = 5;
 
 constexpr const char* API_BASE_URL = "https://api.mapbox.com";
 
+constexpr uint8_t TERRAIN_RGB_MAXZOOM = 15;
+
 } // namespace util
 
 namespace debug {

--- a/src/mbgl/annotation/render_annotation_source.cpp
+++ b/src/mbgl/annotation/render_annotation_source.cpp
@@ -51,7 +51,7 @@ void RenderAnnotationSource::upload(gfx::UploadPass& uploadPass) {
     tilePyramid.upload(uploadPass);
 }
 
-void RenderAnnotationSource::prepare(PaintParameters& parameters) {
+void RenderAnnotationSource::prepare(const SourcePrepareParameters& parameters) {
     tilePyramid.prepare(parameters);
 }
 

--- a/src/mbgl/annotation/render_annotation_source.hpp
+++ b/src/mbgl/annotation/render_annotation_source.hpp
@@ -19,7 +19,7 @@ public:
                 const TileParameters&) final;
 
     void upload(gfx::UploadPass&) final;
-    void prepare(PaintParameters&) final;
+    void prepare(const SourcePrepareParameters&) final;
     void finishRender(PaintParameters&) final;
 
     std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() final;

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -61,7 +61,7 @@ void RenderBackgroundLayer::upload(gfx::UploadPass&, UploadParameters& parameter
     }
 }
 
-void RenderBackgroundLayer::render(PaintParameters& parameters, RenderSource*) {
+void RenderBackgroundLayer::render(PaintParameters& parameters) {
     // Note that for bottommost layers without a pattern, the background color is drawn with
     // glClear rather than this method.
 

--- a/src/mbgl/renderer/layers/render_background_layer.hpp
+++ b/src/mbgl/renderer/layers/render_background_layer.hpp
@@ -18,7 +18,7 @@ private:
     bool hasCrossfade() const override;
     optional<Color> getSolidBackground() const override;
     void upload(gfx::UploadPass&, UploadParameters&) override;
-    void render(PaintParameters&, RenderSource*) override;
+    void render(PaintParameters&) override;
 
     // Paint properties
     style::BackgroundPaintProperties::Unevaluated unevaluated;

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -52,7 +52,7 @@ bool RenderCircleLayer::hasCrossfade() const {
     return false;
 }
 
-void RenderCircleLayer::render(PaintParameters& parameters, RenderSource*) {
+void RenderCircleLayer::render(PaintParameters& parameters) {
     if (parameters.pass == RenderPass::Opaque) {
         return;
     }

--- a/src/mbgl/renderer/layers/render_circle_layer.hpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.hpp
@@ -16,7 +16,7 @@ private:
     void evaluate(const PropertyEvaluationParameters&) override;
     bool hasTransition() const override;
     bool hasCrossfade() const override;
-    void render(PaintParameters&, RenderSource*) override;
+    void render(PaintParameters&) override;
 
     bool queryIntersectsFeature(
             const GeometryCoordinates&,

--- a/src/mbgl/renderer/layers/render_custom_layer.cpp
+++ b/src/mbgl/renderer/layers/render_custom_layer.cpp
@@ -50,7 +50,7 @@ void RenderCustomLayer::markContextDestroyed() {
     contextDestroyed = true;
 }
 
-void RenderCustomLayer::render(PaintParameters& paintParameters, RenderSource*) {
+void RenderCustomLayer::render(PaintParameters& paintParameters) {
     if (host != impl(baseImpl).host) {
         //If the context changed, deinitialize the previous one before initializing the new one.
         if (host && !contextDestroyed) {

--- a/src/mbgl/renderer/layers/render_custom_layer.hpp
+++ b/src/mbgl/renderer/layers/render_custom_layer.hpp
@@ -17,7 +17,7 @@ private:
     bool hasCrossfade() const override;
     void markContextDestroyed() override;
 
-    void render(PaintParameters&, RenderSource*) override;
+    void render(PaintParameters&) override;
 
     bool contextDestroyed = false;
     std::shared_ptr<style::CustomLayerHost> host;

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -55,7 +55,7 @@ bool RenderFillExtrusionLayer::hasCrossfade() const {
     return getCrossfade<FillExtrusionLayerProperties>(evaluatedProperties).t != 1;
 }
 
-void RenderFillExtrusionLayer::render(PaintParameters& parameters, RenderSource*) {
+void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
     if (parameters.pass != RenderPass::Translucent) {
         return;
     }

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.hpp
@@ -17,7 +17,7 @@ private:
     void evaluate(const PropertyEvaluationParameters&) override;
     bool hasTransition() const override;
     bool hasCrossfade() const override;
-    void render(PaintParameters&, RenderSource*) override;
+    void render(PaintParameters&) override;
 
     bool queryIntersectsFeature(
         const GeometryCoordinates&,

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -72,7 +72,7 @@ bool RenderFillLayer::hasCrossfade() const {
     return getCrossfade<FillLayerProperties>(evaluatedProperties).t != 1;
 }
 
-void RenderFillLayer::render(PaintParameters& parameters, RenderSource*) {
+void RenderFillLayer::render(PaintParameters& parameters) {
     if (unevaluated.get<FillPattern>().isUndefined()) {
         parameters.renderTileClippingMasks(renderTiles);
         for (const RenderTile& tile : renderTiles) {

--- a/src/mbgl/renderer/layers/render_fill_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.hpp
@@ -19,7 +19,7 @@ private:
     void evaluate(const PropertyEvaluationParameters&) override;
     bool hasTransition() const override;
     bool hasCrossfade() const override;
-    void render(PaintParameters&, RenderSource*) override;
+    void render(PaintParameters&) override;
 
     bool queryIntersectsFeature(
             const GeometryCoordinates&,

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -62,7 +62,7 @@ void RenderHeatmapLayer::upload(gfx::UploadPass& uploadPass, UploadParameters&) 
     }
 }
 
-void RenderHeatmapLayer::render(PaintParameters& parameters, RenderSource*) {
+void RenderHeatmapLayer::render(PaintParameters& parameters) {
     if (parameters.pass == RenderPass::Opaque) {
         return;
     }

--- a/src/mbgl/renderer/layers/render_heatmap_layer.hpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.hpp
@@ -20,7 +20,7 @@ private:
     bool hasTransition() const override;
     bool hasCrossfade() const override;
     void upload(gfx::UploadPass&, UploadParameters&) override;
-    void render(PaintParameters&, RenderSource*) override;
+    void render(PaintParameters&) override;
 
     bool queryIntersectsFeature(
             const GeometryCoordinates&,

--- a/src/mbgl/renderer/layers/render_hillshade_layer.cpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.cpp
@@ -65,14 +65,17 @@ bool RenderHillshadeLayer::hasCrossfade() const {
     return false;
 }
 
-void RenderHillshadeLayer::render(PaintParameters& parameters, RenderSource* src) {
+void RenderHillshadeLayer::prepare(const LayerPrepareParameters& params) {
+    RenderLayer::prepare(params);
+    if (auto* demsrc = params.source->as<RenderRasterDEMSource>()) {
+        maxzoom = demsrc->getMaxZoom();
+    }
+}
+
+void RenderHillshadeLayer::render(PaintParameters& parameters) {
     if (parameters.pass != RenderPass::Translucent && parameters.pass != RenderPass::Pass3D)
         return;
-    const auto& evaluated = static_cast<const HillshadeLayerProperties&>(*evaluatedProperties).evaluated;
-    auto* demsrc = static_cast<RenderRasterDEMSource*>(src);
-    const uint8_t TERRAIN_RGB_MAXZOOM = 15;
-    const uint8_t maxzoom = demsrc != nullptr ? demsrc->getMaxZoom() : TERRAIN_RGB_MAXZOOM;
-
+    const auto& evaluated = static_cast<const HillshadeLayerProperties&>(*evaluatedProperties).evaluated;  
     auto draw = [&] (const mat4& matrix,
                      const auto& vertexBuffer,
                      const auto& indexBuffer,

--- a/src/mbgl/renderer/layers/render_hillshade_layer.hpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.hpp
@@ -18,10 +18,12 @@ private:
     bool hasTransition() const override;
     bool hasCrossfade() const override;
 
-    void render(PaintParameters&, RenderSource* src) override;
+    void render(PaintParameters&) override;
+    void prepare(const LayerPrepareParameters&) override;
 
     // Paint properties
     style::HillshadePaintProperties::Unevaluated unevaluated;
+    uint8_t maxzoom = util::TERRAIN_RGB_MAXZOOM;
 
     const std::array<float, 2> getLatRange(const UnwrappedTileID& id);
     const std::array<float, 2> getLight(const PaintParameters& parameters);

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -91,7 +91,7 @@ void RenderLineLayer::upload(gfx::UploadPass& uploadPass, UploadParameters& uplo
     }
 }
 
-void RenderLineLayer::render(PaintParameters& parameters, RenderSource*) {
+void RenderLineLayer::render(PaintParameters& parameters) {
     if (parameters.pass == RenderPass::Opaque) {
         return;
     }

--- a/src/mbgl/renderer/layers/render_line_layer.hpp
+++ b/src/mbgl/renderer/layers/render_line_layer.hpp
@@ -21,7 +21,7 @@ private:
     bool hasTransition() const override;
     bool hasCrossfade() const override;
     void upload(gfx::UploadPass&, UploadParameters&) override;
-    void render(PaintParameters&, RenderSource*) override;
+    void render(PaintParameters&) override;
 
     bool queryIntersectsFeature(
             const GeometryCoordinates&,

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -2,7 +2,6 @@
 #include <mbgl/renderer/buckets/raster_bucket.hpp>
 #include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/renderer/paint_parameters.hpp>
-#include <mbgl/renderer/sources/render_image_source.hpp>
 #include <mbgl/renderer/render_static_data.hpp>
 #include <mbgl/programs/programs.hpp>
 #include <mbgl/programs/raster_program.hpp>
@@ -73,7 +72,18 @@ static std::array<float, 3> spinWeights(float spin) {
     return spin_weights;
 }
 
-void RenderRasterLayer::render(PaintParameters& parameters, RenderSource* source) {
+void RenderRasterLayer::prepare(const LayerPrepareParameters& params) {
+    RenderLayer::prepare(params);
+    auto* imageSource = params.source->as<RenderImageSource>();
+    if (imageSource && imageSource->isLoaded()) {
+        assert(imageSource->isEnabled());
+        assert(imageSource->sharedData.bucket);
+        assert(imageSource->sharedData.matrices);
+        imageData = imageSource->sharedData;
+    }
+}
+
+void RenderRasterLayer::render(PaintParameters& parameters) {
     if (parameters.pass != RenderPass::Translucent)
         return;
     const auto& evaluated = static_cast<const RasterLayerProperties&>(*evaluatedProperties).evaluated;
@@ -132,22 +142,20 @@ void RenderRasterLayer::render(PaintParameters& parameters, RenderSource* source
 
     const gfx::TextureFilterType filter = evaluated.get<RasterResampling>() == RasterResamplingType::Nearest ? gfx::TextureFilterType::Nearest : gfx::TextureFilterType::Linear;
 
-    if (auto* imageSource = source->as<RenderImageSource>()) {
-        if (imageSource->isEnabled() && imageSource->isLoaded() && !imageSource->bucket->needsUpload()) {
-            RasterBucket& bucket = *imageSource->bucket;
-            assert(bucket.texture);
+    if (imageData && !imageData->bucket->needsUpload()) {
+        RasterBucket& bucket = *imageData->bucket;
+        assert(bucket.texture);
 
-            for (auto matrix_ : imageSource->matrices) {
-                draw(matrix_,
-                     *bucket.vertexBuffer,
-                     *bucket.indexBuffer,
-                     bucket.segments,
-                     RasterProgram::TextureBindings{
-                         textures::image0::Value{ bucket.texture->getResource(), filter },
-                         textures::image1::Value{ bucket.texture->getResource(), filter },
-                     },
-                     bucket.drawScopeID);
-            }
+        for (const auto& matrix_ : *imageData->matrices) {
+            draw(matrix_,
+                *bucket.vertexBuffer,
+                *bucket.indexBuffer,
+                bucket.segments,
+                RasterProgram::TextureBindings{
+                    textures::image0::Value{ bucket.texture->getResource(), filter },
+                    textures::image1::Value{ bucket.texture->getResource(), filter },
+                },
+                bucket.drawScopeID);
         }
     } else {
         for (const RenderTile& tile : renderTiles) {

--- a/src/mbgl/renderer/layers/render_raster_layer.hpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/renderer/render_layer.hpp>
+#include <mbgl/renderer/sources/render_image_source.hpp>
 #include <mbgl/style/layers/raster_layer_impl.hpp>
 #include <mbgl/style/layers/raster_layer_properties.hpp>
 
@@ -16,11 +17,12 @@ private:
     void evaluate(const PropertyEvaluationParameters&) override;
     bool hasTransition() const override;
     bool hasCrossfade() const override;
-
-    void render(PaintParameters&, RenderSource*) override;
+    void prepare(const LayerPrepareParameters&) override;
+    void render(PaintParameters&) override;
 
     // Paint properties
     style::RasterPaintProperties::Unevaluated unevaluated;
+    optional<ImageLayerRenderData> imageData;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -431,7 +431,7 @@ void RenderSymbolLayer::upload(gfx::UploadPass& uploadPass, UploadParameters& up
     }
 }
 
-void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
+void RenderSymbolLayer::render(PaintParameters& parameters) {
     if (parameters.pass == RenderPass::Opaque) {
         return;
     }

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -2,6 +2,7 @@
 #include <mbgl/renderer/buckets/symbol_bucket.hpp>
 #include <mbgl/renderer/bucket_parameters.hpp>
 #include <mbgl/renderer/property_evaluation_parameters.hpp>
+#include <mbgl/renderer/render_source.hpp>
 #include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/renderer/upload_parameters.hpp>
 #include <mbgl/renderer/paint_parameters.hpp>
@@ -652,9 +653,9 @@ style::TextPaintProperties::PossiblyEvaluated RenderSymbolLayer::textPaintProper
     };
 }
 
-void RenderSymbolLayer::setRenderTiles(RenderTiles tiles, const TransformState& state) {
-    renderTiles = std::move(tiles);
-    const auto comp = [bearing = state.getBearing()](const RenderTile& a, const RenderTile& b) {
+void RenderSymbolLayer::prepare(const LayerPrepareParameters& params) {
+    renderTiles = params.source->getRenderTiles();
+    const auto comp = [bearing = params.state.getBearing()](const RenderTile& a, const RenderTile& b) {
         Point<float> pa(a.id.canonical.x, a.id.canonical.y);
         Point<float> pb(b.id.canonical.x, b.id.canonical.y);
 

--- a/src/mbgl/renderer/layers/render_symbol_layer.hpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.hpp
@@ -67,7 +67,7 @@ private:
     bool hasCrossfade() const override;
     void upload(gfx::UploadPass&, UploadParameters&) override;
     void render(PaintParameters&, RenderSource*) override;
-    void setRenderTiles(RenderTiles, const TransformState&) override;
+    void prepare(const LayerPrepareParameters&) override;
 
     // Paint properties
     style::SymbolPaintProperties::Unevaluated unevaluated;

--- a/src/mbgl/renderer/layers/render_symbol_layer.hpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.hpp
@@ -66,7 +66,7 @@ private:
     bool hasTransition() const override;
     bool hasCrossfade() const override;
     void upload(gfx::UploadPass&, UploadParameters&) override;
-    void render(PaintParameters&, RenderSource*) override;
+    void render(PaintParameters&) override;
     void prepare(const LayerPrepareParameters&) override;
 
     // Paint properties

--- a/src/mbgl/renderer/paint_parameters.cpp
+++ b/src/mbgl/renderer/paint_parameters.cpp
@@ -30,7 +30,7 @@ PaintParameters::PaintParameters(gfx::Context& context_,
                     gfx::RendererBackend& backend_,
                     const UpdateParameters& updateParameters,
                     const EvaluatedLight& evaluatedLight_,
-		    const TransformParameters& transformParams_,
+                    const TransformParameters& transformParams_,
                     RenderStaticData& staticData_,
                     ImageManager& imageManager_,
                     LineAtlas& lineAtlas_)

--- a/src/mbgl/renderer/paint_parameters.hpp
+++ b/src/mbgl/renderer/paint_parameters.hpp
@@ -31,6 +31,16 @@ class CommandEncoder;
 class RenderPass;
 } // namespace gfx
 
+
+class TransformParameters {
+public:
+    TransformParameters(const TransformState&);
+    mat4 projMatrix;
+    mat4 alignedProjMatrix;
+    mat4 nearClippedProjMatrix;
+    const TransformState& state;
+};
+
 class PaintParameters {
 public:
     PaintParameters(gfx::Context&,
@@ -38,6 +48,7 @@ public:
                     gfx::RendererBackend&,
                     const UpdateParameters&,
                     const EvaluatedLight&,
+                    const TransformParameters&,
                     RenderStaticData&,
                     ImageManager&,
                     LineAtlas&);
@@ -50,6 +61,7 @@ public:
 
     const TransformState& state;
     const EvaluatedLight& evaluatedLight;
+    const TransformParameters& transformParams;
 
     RenderStaticData& staticData;
     ImageManager& imageManager;
@@ -70,10 +82,6 @@ public:
     gfx::ColorMode colorModeForRenderPass() const;
 
     mat4 matrixForTile(const UnwrappedTileID&, bool aligned = false) const;
-
-    mat4 projMatrix;
-    mat4 alignedProjMatrix;
-    mat4 nearClippedProjMatrix;
 
     // Stencil handling
 public:

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/renderer/render_layer.hpp>
 #include <mbgl/renderer/paint_parameters.hpp>
+#include <mbgl/renderer/render_source.hpp>
 #include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/style/types.hpp>
 #include <mbgl/style/layer.hpp>
@@ -44,8 +45,9 @@ bool RenderLayer::supportsZoom(float zoom) const {
     return baseImpl->minZoom <= zoom && baseImpl->maxZoom >= zoom;
 }
 
-void RenderLayer::setRenderTiles(RenderTiles tiles, const TransformState&) {
-    renderTiles = filterRenderTiles(std::move(tiles));
+void RenderLayer::prepare(const LayerPrepareParameters& params) {
+    assert(params.source);
+    renderTiles = filterRenderTiles(params.source->getRenderTiles());
 }
 
 optional<Color> RenderLayer::getSolidBackground() const {

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -78,7 +78,7 @@ public:
     bool supportsZoom(float zoom) const;
 
     virtual void upload(gfx::UploadPass&, UploadParameters&) {}
-    virtual void render(PaintParameters&, RenderSource*) = 0;
+    virtual void render(PaintParameters&) = 0;
 
     // Check wether the given geometry intersects
     // with the feature

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -34,6 +34,12 @@ public:
     bool rotateWithMap;
 };
 
+class LayerPrepareParameters {
+public:
+    RenderSource* source;
+    const TransformState& state;
+};
+
 class RenderLayer {
 protected:
     RenderLayer(Immutable<style::LayerProperties>);
@@ -84,8 +90,7 @@ public:
             const float,
             const mat4&) const { return false; };
 
-    using RenderTiles = std::vector<std::reference_wrapper<RenderTile>>;
-    virtual void setRenderTiles(RenderTiles, const TransformState&);
+    virtual void prepare(const LayerPrepareParameters&);
 
     const std::vector<LayerPlacementData>& getPlacementData() const { 
         return placementData; 
@@ -107,6 +112,7 @@ protected:
     void checkRenderability(const PaintParameters&, uint32_t activeBindingCount);
 
 protected:
+    using RenderTiles = std::vector<std::reference_wrapper<RenderTile>>;
     // Stores current set of tiles to be rendered for this layer.
     RenderTiles renderTiles;
 

--- a/src/mbgl/renderer/render_source.cpp
+++ b/src/mbgl/renderer/render_source.cpp
@@ -55,6 +55,8 @@ RenderSource::RenderSource(Immutable<style::Source::Impl> impl)
       observer(&nullObserver) {
 }
 
+RenderSource::~RenderSource() = default;
+
 void RenderSource::setObserver(RenderSourceObserver* observer_) {
     observer = observer_;
 }

--- a/src/mbgl/renderer/render_source.hpp
+++ b/src/mbgl/renderer/render_source.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mbgl/map/mode.hpp>
 #include <mbgl/tile/tile_id.hpp>
 #include <mbgl/tile/tile_observer.hpp>
 #include <mbgl/util/mat4.hpp>
@@ -26,14 +27,22 @@ class Tile;
 class RenderSourceObserver;
 class TileParameters;
 class CollisionIndex;
+class TransformParameters;
 
 namespace gfx {
 class UploadPass;
 } // namespace gfx
 
+class SourcePrepareParameters {
+public:
+    const TransformParameters& transform;
+    const MapDebugOptions& debugOptions;
+};
+
 class RenderSource : protected TileObserver {
 public:
     static std::unique_ptr<RenderSource> create(Immutable<style::Source::Impl>);
+    virtual ~RenderSource();
 
     // Check whether this source is of the given subtype.
     template <class T>
@@ -60,7 +69,7 @@ public:
                         const TileParameters&) = 0;
 
     virtual void upload(gfx::UploadPass&) = 0;
-    virtual void prepare(PaintParameters&) = 0;
+    virtual void prepare(const SourcePrepareParameters&) = 0;
     virtual void finishRender(PaintParameters&) = 0;
 
     // Returns a list of RenderTiles, sorted by tile id.

--- a/src/mbgl/renderer/render_tile.cpp
+++ b/src/mbgl/renderer/render_tile.cpp
@@ -1,6 +1,8 @@
 #include <mbgl/renderer/render_tile.hpp>
+
 #include <mbgl/renderer/paint_parameters.hpp>
 #include <mbgl/renderer/buckets/debug_bucket.hpp>
+#include <mbgl/renderer/render_source.hpp>
 #include <mbgl/renderer/render_static_data.hpp>
 #include <mbgl/programs/programs.hpp>
 #include <mbgl/map/transform_state.hpp>
@@ -70,7 +72,7 @@ void RenderTile::upload(gfx::UploadPass& uploadPass) {
     }
 }
 
-void RenderTile::prepare(PaintParameters& parameters) {
+void RenderTile::prepare(const SourcePrepareParameters& parameters) {
     if (parameters.debugOptions != MapDebugOptions::NoDebug &&
         (!debugBucket || debugBucket->renderable != tile.isRenderable() ||
          debugBucket->complete != tile.isComplete() ||
@@ -86,10 +88,11 @@ void RenderTile::prepare(PaintParameters& parameters) {
 
     // Calculate two matrices for this tile: matrix is the standard tile matrix; nearClippedMatrix
     // clips the near plane to 100 to save depth buffer precision
-    parameters.state.matrixFor(matrix, id);
-    parameters.state.matrixFor(nearClippedMatrix, id);
-    matrix::multiply(matrix, parameters.projMatrix, matrix);
-    matrix::multiply(nearClippedMatrix, parameters.nearClippedProjMatrix, nearClippedMatrix);
+    const auto& transform = parameters.transform;
+    transform.state.matrixFor(matrix, id);
+    transform.state.matrixFor(nearClippedMatrix, id);
+    matrix::multiply(matrix, transform.projMatrix, matrix);
+    matrix::multiply(nearClippedMatrix, transform.nearClippedProjMatrix, nearClippedMatrix);
 }
 
 void RenderTile::finishRender(PaintParameters& parameters) {

--- a/src/mbgl/renderer/render_tile.hpp
+++ b/src/mbgl/renderer/render_tile.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mbgl/map/mode.hpp>
 #include <mbgl/tile/tile_id.hpp>
 #include <mbgl/util/mat4.hpp>
 #include <mbgl/style/types.hpp>
@@ -18,6 +19,7 @@ class Tile;
 class TransformState;
 class PaintParameters;
 class DebugBucket;
+class SourcePrepareParameters;
 
 class RenderTile final {
 public:
@@ -46,7 +48,7 @@ public:
 
     void setMask(TileMask&&);
     void upload(gfx::UploadPass&);
-    void prepare(PaintParameters&);
+    void prepare(const SourcePrepareParameters&);
     void finishRender(PaintParameters&);
 
     mat4 translateVtxMatrix(const mat4& tileMatrix,

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -300,13 +300,12 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         }
     }
 
-    // Set render tiles to the render items.
     for (auto& renderItem : renderItems) {
         if (!renderItem.source) {
             continue;
         }
         RenderLayer& renderLayer = renderItem.layer;
-        renderLayer.setRenderTiles(renderItem.source->getRenderTiles(), updateParameters.transformState);
+        renderLayer.prepare({renderItem.source, updateParameters.transformState});
         if (renderLayer.needsPlacement()) {
             layersNeedPlacement.emplace_back(renderLayer);
         }

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -424,7 +424,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
             RenderLayer& renderLayer = it->layer;
             if (renderLayer.hasRenderPass(parameters.pass)) {
                 const auto layerDebugGroup(parameters.encoder->createDebugGroup(renderLayer.getID().c_str()));
-                renderLayer.render(parameters, it->source);
+                renderLayer.render(parameters);
             }
         }
     }
@@ -458,7 +458,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
             RenderLayer& renderLayer = it->layer;
             if (renderLayer.hasRenderPass(parameters.pass)) {
                 const auto layerDebugGroup(parameters.renderPass->createDebugGroup(renderLayer.getID().c_str()));
-                renderLayer.render(parameters, it->source);
+                renderLayer.render(parameters);
             }
         }
     }
@@ -475,7 +475,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
             RenderLayer& renderLayer = it->layer;
             if (renderLayer.hasRenderPass(parameters.pass)) {
                 const auto layerDebugGroup(parameters.renderPass->createDebugGroup(renderLayer.getID().c_str()));
-                renderLayer.render(parameters, it->source);
+                renderLayer.render(parameters);
             }
         }
     }

--- a/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
+++ b/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
@@ -51,7 +51,7 @@ void RenderCustomGeometrySource::upload(gfx::UploadPass& uploadPass) {
     tilePyramid.upload(uploadPass);
 }
 
-void RenderCustomGeometrySource::prepare(PaintParameters& parameters) {
+void RenderCustomGeometrySource::prepare(const SourcePrepareParameters& parameters) {
     tilePyramid.prepare(parameters);
 }
 

--- a/src/mbgl/renderer/sources/render_custom_geometry_source.hpp
+++ b/src/mbgl/renderer/sources/render_custom_geometry_source.hpp
@@ -19,7 +19,7 @@ public:
                 const TileParameters&) final;
 
     void upload(gfx::UploadPass&) final;
-    void prepare(PaintParameters&) final;
+    void prepare(const SourcePrepareParameters&) final;
     void finishRender(PaintParameters&) final;
 
     std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() final;

--- a/src/mbgl/renderer/sources/render_geojson_source.cpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.cpp
@@ -127,7 +127,7 @@ void RenderGeoJSONSource::upload(gfx::UploadPass& parameters) {
     tilePyramid.upload(parameters);
 }
 
-void RenderGeoJSONSource::prepare(PaintParameters& parameters) {
+void RenderGeoJSONSource::prepare(const SourcePrepareParameters& parameters) {
     tilePyramid.prepare(parameters);
 }
 

--- a/src/mbgl/renderer/sources/render_geojson_source.hpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.hpp
@@ -24,7 +24,7 @@ public:
                 const TileParameters&) final;
 
     void upload(gfx::UploadPass&) final;
-    void prepare(PaintParameters&) final;
+    void prepare(const SourcePrepareParameters&) final;
     void finishRender(PaintParameters&) final;
 
     std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() final;

--- a/src/mbgl/renderer/sources/render_image_source.cpp
+++ b/src/mbgl/renderer/sources/render_image_source.cpp
@@ -37,18 +37,18 @@ void RenderImageSource::upload(gfx::UploadPass& uploadPass) {
     }
 }
 
-void RenderImageSource::prepare(PaintParameters& parameters) {
+void RenderImageSource::prepare(const SourcePrepareParameters& parameters) {
     if (!isLoaded()) {
         return;
     }
 
     matrices.clear();
-
+    const auto& transformParams = parameters.transform;
     for (auto& tileId : tileIds) {
         mat4 matrix;
         matrix::identity(matrix);
-        parameters.state.matrixFor(matrix, tileId);
-        matrix::multiply(matrix, parameters.alignedProjMatrix, matrix);
+        transformParams.state.matrixFor(matrix, tileId);
+        matrix::multiply(matrix, transformParams.alignedProjMatrix, matrix);
         matrices.push_back(matrix);
     }
 }

--- a/src/mbgl/renderer/sources/render_image_source.hpp
+++ b/src/mbgl/renderer/sources/render_image_source.hpp
@@ -16,7 +16,7 @@ public:
     bool isLoaded() const final;
 
     void upload(gfx::UploadPass&) final;
-    void prepare(PaintParameters&) final;
+    void prepare(const SourcePrepareParameters&) final;
     void finishRender(PaintParameters&) final;
 
     void update(Immutable<style::Source::Impl>,

--- a/src/mbgl/renderer/sources/render_image_source.hpp
+++ b/src/mbgl/renderer/sources/render_image_source.hpp
@@ -8,6 +8,12 @@ namespace mbgl {
 
 class RasterBucket;
 
+class ImageLayerRenderData {
+public:
+    std::shared_ptr<RasterBucket> bucket;
+    std::shared_ptr<std::vector<mat4>> matrices;
+};
+
 class RenderImageSource : public RenderSource {
 public:
     RenderImageSource(Immutable<style::ImageSource::Impl>);
@@ -44,12 +50,10 @@ public:
 
 private:
     friend class RenderRasterLayer;
-
     const style::ImageSource::Impl& impl() const;
 
+    ImageLayerRenderData sharedData;
     std::vector<UnwrappedTileID> tileIds;
-    std::unique_ptr<RasterBucket> bucket;
-    std::vector<mat4> matrices;
 };
 
 template <>

--- a/src/mbgl/renderer/sources/render_raster_dem_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.cpp
@@ -130,7 +130,7 @@ void RenderRasterDEMSource::upload(gfx::UploadPass& parameters) {
     tilePyramid.upload(parameters);
 }
 
-void RenderRasterDEMSource::prepare(PaintParameters& parameters) {
+void RenderRasterDEMSource::prepare(const SourcePrepareParameters& parameters) {
     algorithm::updateTileMasks(tilePyramid.getRenderTiles());
     tilePyramid.prepare(parameters);
 }

--- a/src/mbgl/renderer/sources/render_raster_dem_source.hpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.hpp
@@ -19,7 +19,7 @@ public:
                 const TileParameters&) final;
 
     void upload(gfx::UploadPass&) final;
-    void prepare(PaintParameters&) final;
+    void prepare(const SourcePrepareParameters&) final;
     void finishRender(PaintParameters&) final;
 
     std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() final;

--- a/src/mbgl/renderer/sources/render_raster_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_source.cpp
@@ -61,7 +61,7 @@ void RenderRasterSource::upload(gfx::UploadPass& parameters) {
     tilePyramid.upload(parameters);
 }
 
-void RenderRasterSource::prepare(PaintParameters& parameters) {
+void RenderRasterSource::prepare(const SourcePrepareParameters& parameters) {
     algorithm::updateTileMasks(tilePyramid.getRenderTiles());
     tilePyramid.prepare(parameters);
 }

--- a/src/mbgl/renderer/sources/render_raster_source.hpp
+++ b/src/mbgl/renderer/sources/render_raster_source.hpp
@@ -19,7 +19,7 @@ public:
                 const TileParameters&) final;
 
     void upload(gfx::UploadPass&) final;
-    void prepare(PaintParameters&) final;
+    void prepare(const SourcePrepareParameters&) final;
     void finishRender(PaintParameters&) final;
 
     std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() final;

--- a/src/mbgl/renderer/sources/render_vector_source.cpp
+++ b/src/mbgl/renderer/sources/render_vector_source.cpp
@@ -61,7 +61,7 @@ void RenderVectorSource::upload(gfx::UploadPass& parameters) {
     tilePyramid.upload(parameters);
 }
 
-void RenderVectorSource::prepare(PaintParameters& parameters) {
+void RenderVectorSource::prepare(const SourcePrepareParameters& parameters) {
     tilePyramid.prepare(parameters);
 }
 

--- a/src/mbgl/renderer/sources/render_vector_source.hpp
+++ b/src/mbgl/renderer/sources/render_vector_source.hpp
@@ -19,7 +19,7 @@ public:
                 const TileParameters&) final;
 
     void upload(gfx::UploadPass&) final;
-    void prepare(PaintParameters&) final;
+    void prepare(const SourcePrepareParameters&) final;
     void finishRender(PaintParameters&) final;
 
     std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() final;

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -46,7 +46,7 @@ void TilePyramid::upload(gfx::UploadPass& parameters) {
     }
 }
 
-void TilePyramid::prepare(PaintParameters& parameters) {
+void TilePyramid::prepare(const SourcePrepareParameters& parameters) {
     for (auto& tile : renderTiles) {
         tile.prepare(parameters);
     }

--- a/src/mbgl/renderer/tile_pyramid.hpp
+++ b/src/mbgl/renderer/tile_pyramid.hpp
@@ -25,6 +25,7 @@ class RenderLayer;
 class RenderedQueryOptions;
 class SourceQueryOptions;
 class TileParameters;
+class SourcePrepareParameters;
 
 class TilePyramid {
 public:
@@ -44,7 +45,7 @@ public:
                 std::function<std::unique_ptr<Tile> (const OverscaledTileID&)> createTile);
 
     void upload(gfx::UploadPass&);
-    void prepare(PaintParameters&);
+    void prepare(const SourcePrepareParameters&);
     void finishRender(PaintParameters&);
 
     std::vector<std::reference_wrapper<RenderTile>> getRenderTiles();


### PR DESCRIPTION
* fixed `// TODO` in the code
* `RenderLayer::render(PaintParameters&, RenderSource*)` -> `render(PaintParameters&)`.
`RenderSource` shall not be part of render items  -- `RenderLayer` has all the necessary data
from the render source cached inside, after `RenderLayer::prepare()` gets invoked.

Tag https://github.com/mapbox/mapbox-gl-native/issues/14638