### PR TITLE
[core] Add API for invalidating tiles

### DIFF
--- a/benchmark/benchmark-files.json
+++ b/benchmark/benchmark-files.json
@@ -10,6 +10,7 @@
         "benchmark/parse/tile_mask.benchmark.cpp",
         "benchmark/parse/vector_tile.benchmark.cpp",
         "benchmark/src/mbgl/benchmark/benchmark.cpp",
+        "benchmark/storage/offline_database.benchmark.cpp",
         "benchmark/util/dtoa.benchmark.cpp",
         "benchmark/util/tilecover.benchmark.cpp"
     ],

--- a/benchmark/storage/offline_database.benchmark.cpp
+++ b/benchmark/storage/offline_database.benchmark.cpp
@@ -1,0 +1,54 @@
+#include <benchmark/benchmark.h>
+
+#include <mbgl/storage/offline_database.hpp>
+#include <mbgl/storage/resource.hpp>
+#include <mbgl/storage/response.hpp>
+#include <mbgl/storage/sqlite3.hpp>
+#include <mbgl/util/string.hpp>
+
+class OfflineDatabase : public benchmark::Fixture {
+public:
+    void SetUp(const ::benchmark::State&) override {
+        using namespace mbgl;
+        using namespace std::chrono_literals;
+
+        const unsigned tileCount = 10000;
+        db.setOfflineMapboxTileCountLimit(tileCount * 2);
+
+        Response response;
+        response.noContent = true;
+        response.mustRevalidate = false;
+        response.expires = util::now() + 1h;
+
+        for (unsigned i = 0; i < tileCount; ++i) {
+            const Resource ambient = Resource::tile("mapbox://tile_ambient" + util::toString(i), 1, 0, 0, 0, Tileset::Scheme::XYZ);
+            db.put(ambient, response);
+        }
+
+        OfflineTilePyramidRegionDefinition definition{ "mapbox://style", LatLngBounds::hull({1, 2}, {3, 4}), 5, 6, 2.0, true };
+        OfflineRegionMetadata metadata{{ 1, 2, 3 }};
+
+        auto region = db.createRegion(definition, metadata);
+        regionID = region->getID();
+
+        for (unsigned i = 0; i < tileCount; ++i) {
+            const Resource offline = Resource::tile("mapbox://tile_offline_region" + util::toString(i), 1.0, 0, 0, 0, Tileset::Scheme::XYZ);
+            db.putRegionResource(regionID, offline, response);
+        }
+    }
+
+    mbgl::OfflineDatabase db{":memory:"};
+    int64_t regionID;
+};
+
+BENCHMARK_F(OfflineDatabase, InvalidateRegion)(benchmark::State& state) {
+    for (auto _ : state) {
+        db.invalidateRegion(regionID);
+    }
+}
+
+BENCHMARK_F(OfflineDatabase, InvalidateTileCache)(benchmark::State& state) {
+    for (auto _ : state) {
+        db.invalidateTileCache();
+    }
+}

--- a/platform/default/include/mbgl/storage/offline_database.hpp
+++ b/platform/default/include/mbgl/storage/offline_database.hpp
@@ -51,6 +51,13 @@ public:
     // Return value is (inserted, stored size)
     std::pair<bool, uint64_t> put(const Resource&, const Response&);
 
+    // Force Mapbox GL Native to revalidate tiles stored in the ambient
+    // cache with the tile server before using them, making sure they
+    // are the latest version. This is more efficient than cleaning the
+    // cache because if the tile is considered valid after the server
+    // lookup, it will not get downloaded again.
+    std::exception_ptr invalidateTileCache();
+
     expected<OfflineRegions, std::exception_ptr> listRegions();
 
     expected<OfflineRegion, std::exception_ptr> createRegion(const OfflineRegionDefinition&,
@@ -63,6 +70,7 @@ public:
     updateMetadata(const int64_t regionID, const OfflineRegionMetadata&);
 
     std::exception_ptr deleteRegion(OfflineRegion&&);
+    std::exception_ptr invalidateRegion(int64_t regionID);
 
     // Return value is (response, stored size)
     optional<std::pair<Response, uint64_t>> getRegionResource(int64_t regionID, const Resource&);

--- a/platform/default/src/mbgl/storage/offline_database.cpp
+++ b/platform/default/src/mbgl/storage/offline_database.cpp
@@ -606,6 +606,47 @@ bool OfflineDatabase::putTile(const Resource::TileData& tile,
     return true;
 }
 
+std::exception_ptr OfflineDatabase::invalidateTileCache() try {
+    // clang-format off
+    mapbox::sqlite::Query query{ getStatement(
+        "UPDATE tiles "
+        "SET expires = 0, must_revalidate = 1 "
+        "WHERE id NOT IN ("
+        "    SELECT tile_id FROM region_tiles"
+        ")"
+    ) };
+    // clang-format on
+
+    query.run();
+    return nullptr;
+} catch (const mapbox::sqlite::Exception& ex) {
+    handleError(ex, "invalidate tile cache");
+    return std::current_exception();
+}
+
+std::exception_ptr OfflineDatabase::invalidateRegion(int64_t regionID) try {
+    {
+        // clang-format off
+        mapbox::sqlite::Query query{ getStatement(
+            "UPDATE tiles "
+            "SET expires = 0, must_revalidate = 1 "
+            "WHERE id IN ("
+            "    SELECT tile_id FROM region_tiles WHERE region_id = ?"
+            ")"
+        ) };
+        // clang-format on
+
+        query.bind(1, regionID);
+        query.run();
+    }
+
+    assert(db);
+    return nullptr;
+} catch (const mapbox::sqlite::Exception& ex) {
+    handleError(ex, "invalidate region");
+    return std::current_exception();
+}
+
 expected<OfflineRegions, std::exception_ptr> OfflineDatabase::listRegions() try {
     mapbox::sqlite::Query query{ getStatement("SELECT id, definition, description FROM regions") };
     OfflineRegions result;


### PR DESCRIPTION
Add new APIs for invalidating tiles, effectively forcing Mapbox GL Native to check with the servers if the tiles are valid before using them. This is more efficient then deleting tiles, because in case of valid tiles, they won't get downloaded.

Fixes #4376.