### PR TITLE
Wrap snapshot jni callback with try-catch

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -1055,15 +1055,21 @@ final class NativeMapView implements NativeMap {
     if (checkState("OnSnapshotReady")) {
       return;
     }
-    if (snapshotReadyCallback != null && mapContent != null) {
-      if (viewCallback == null) {
-        snapshotReadyCallback.onSnapshotReady(mapContent);
-      } else {
-        Bitmap viewContent = viewCallback.getViewContent();
-        if (viewContent != null) {
-          snapshotReadyCallback.onSnapshotReady(BitmapUtils.mergeBitmap(mapContent, viewContent));
+
+    try {
+      if (snapshotReadyCallback != null && mapContent != null) {
+        if (viewCallback == null) {
+          snapshotReadyCallback.onSnapshotReady(mapContent);
+        } else {
+          Bitmap viewContent = viewCallback.getViewContent();
+          if (viewContent != null) {
+            snapshotReadyCallback.onSnapshotReady(BitmapUtils.mergeBitmap(mapContent, viewContent));
+          }
         }
       }
+    } catch (Throwable err) {
+      Logger.e(TAG, "Exception in onSnapshotReady", err);
+      throw err;
     }
   }
 


### PR DESCRIPTION
This PR aligns our `Snapshot` callback wrapping to be conform to `MapChangeReceiver`. Without this construct if an end developer would throw an exception inside  `SnapshotReadyCallback#onSnapshotReady` it would show this as a native crash with `java pending exception`. This is not great as the developer will think the library is responsible and the shown crash doesn't contain any actionable information. This PR addresses this and will show a clear exception message.