### PR TITLE
[core] CrossTileSymbolIndex::pruneUnusedLayers() does not create extra containers

### DIFF
--- a/src/mbgl/text/cross_tile_symbol_index.cpp
+++ b/src/mbgl/text/cross_tile_symbol_index.cpp
@@ -187,14 +187,12 @@ bool CrossTileSymbolIndex::addLayer(const RenderLayer& layer, float lng) {
 }
 
 void CrossTileSymbolIndex::pruneUnusedLayers(const std::set<std::string>& usedLayers) {
-    std::vector<std::string> unusedLayers;
-    for (auto layerIndex : layerIndexes) {
-        if (usedLayers.find(layerIndex.first) == usedLayers.end()) {
-            unusedLayers.push_back(layerIndex.first);
+    for (auto it = layerIndexes.begin(); it != layerIndexes.end();) {
+        if (usedLayers.find(it->first) == usedLayers.end()) {
+            it = layerIndexes.erase(it);
+        } else {
+            ++it;
         }
-    }
-    for (auto unusedLayer : unusedLayers) {
-        layerIndexes.erase(unusedLayer);
     }
 }
 


### PR DESCRIPTION
Tag https://github.com/mapbox/mapbox-gl-native/issues/14708