### PR TITLE
macOS map SDK v0.14.0

### DIFF
--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for Mapbox Maps SDK for macOS
 
-## master
+## 0.14.0 - May 22, 2018
 
 ### Styles and rendering
 

--- a/platform/macos/Mapbox-macOS-SDK-symbols.podspec
+++ b/platform/macos/Mapbox-macOS-SDK-symbols.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '0.13.0'
+  version = '0.14.0'
 
   m.name    = 'Mapbox-macOS-SDK-symbols'
   m.version = "#{version}-symbols"

--- a/platform/macos/Mapbox-macOS-SDK.podspec
+++ b/platform/macos/Mapbox-macOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '0.13.0'
+  version = '0.14.0'
 
   m.name    = 'Mapbox-macOS-SDK'
   m.version = version


### PR DESCRIPTION
Updated the changelog and CocoaPods podspecs for macOS map SDK v0.14.0. There’s no need to increase the major version at this time, because the pricing model hasn’t changed for this SDK.

/cc @mapbox/maps-ios