### PR TITLE
Break location camera tracking when a developer invoked animation starts

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationCameraController.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationCameraController.java
@@ -17,6 +17,7 @@ import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.location.modes.CameraMode;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.Transform;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -29,6 +30,7 @@ final class LocationCameraController {
   private int cameraMode;
 
   private final MapboxMap mapboxMap;
+  private final Transform transform;
   private final OnCameraTrackingChangedListener internalCameraTrackingChangedListener;
   private LocationComponentOptions options;
   private boolean adjustFocalPoint;
@@ -44,10 +46,12 @@ final class LocationCameraController {
   LocationCameraController(
     Context context,
     MapboxMap mapboxMap,
+    Transform transform,
     OnCameraTrackingChangedListener internalCameraTrackingChangedListener,
     @NonNull LocationComponentOptions options,
     OnCameraMoveInvalidateListener onCameraMoveInvalidateListener) {
     this.mapboxMap = mapboxMap;
+    this.transform = transform;
 
     initialGesturesManager = mapboxMap.getGesturesManager();
     internalGesturesManager = new LocationGesturesManager(context);
@@ -63,12 +67,14 @@ final class LocationCameraController {
 
   // Package private for testing purposes
   LocationCameraController(MapboxMap mapboxMap,
+                           Transform transform,
                            MoveGestureDetector moveGestureDetector,
                            OnCameraTrackingChangedListener internalCameraTrackingChangedListener,
                            OnCameraMoveInvalidateListener onCameraMoveInvalidateListener,
                            AndroidGesturesManager initialGesturesManager,
                            AndroidGesturesManager internalGesturesManager) {
     this.mapboxMap = mapboxMap;
+    this.transform = transform;
     this.moveGestureDetector = moveGestureDetector;
     this.internalCameraTrackingChangedListener = internalCameraTrackingChangedListener;
     this.onCameraMoveInvalidateListener = onCameraMoveInvalidateListener;
@@ -157,11 +163,13 @@ final class LocationCameraController {
 
       CameraPosition currentPosition = mapboxMap.getCameraPosition();
       if (Utils.immediateAnimation(mapboxMap.getProjection(), currentPosition.target, target)) {
-        mapboxMap.moveCamera(
+        transform.moveCamera(
+          mapboxMap,
           update,
           callback);
       } else {
-        mapboxMap.animateCamera(
+        transform.animateCamera(
+          mapboxMap,
           update,
           (int) transitionDuration,
           callback);
@@ -182,7 +190,7 @@ final class LocationCameraController {
       return;
     }
 
-    mapboxMap.moveCamera(CameraUpdateFactory.bearingTo(bearing));
+    transform.moveCamera(mapboxMap, CameraUpdateFactory.bearingTo(bearing), null);
     onCameraMoveInvalidateListener.onInvalidateCameraMove();
   }
 
@@ -191,7 +199,7 @@ final class LocationCameraController {
       return;
     }
 
-    mapboxMap.moveCamera(CameraUpdateFactory.newLatLng(latLng));
+    transform.moveCamera(mapboxMap, CameraUpdateFactory.newLatLng(latLng), null);
     onCameraMoveInvalidateListener.onInvalidateCameraMove();
 
     if (adjustFocalPoint) {
@@ -206,7 +214,7 @@ final class LocationCameraController {
       return;
     }
 
-    mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(zoom));
+    transform.moveCamera(mapboxMap, CameraUpdateFactory.zoomTo(zoom), null);
     onCameraMoveInvalidateListener.onInvalidateCameraMove();
   }
 
@@ -215,7 +223,7 @@ final class LocationCameraController {
       return;
     }
 
-    mapboxMap.moveCamera(CameraUpdateFactory.tiltTo(tilt));
+    transform.moveCamera(mapboxMap, CameraUpdateFactory.tiltTo(tilt), null);
     onCameraMoveInvalidateListener.onInvalidateCameraMove();
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -169,7 +169,9 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     Transform transform = new Transform(this, nativeMapView, cameraDispatcher);
 
     // MapboxMap
-    mapboxMap = new MapboxMap(nativeMapView, transform, uiSettings, proj, registerTouchListener, cameraDispatcher);
+    List<MapboxMap.OnDeveloperAnimationListener> developerAnimationListeners = new ArrayList<>();
+    mapboxMap = new MapboxMap(nativeMapView, transform, uiSettings, proj, registerTouchListener, cameraDispatcher,
+      developerAnimationListeners);
     mapboxMap.injectAnnotationManager(annotationManager);
 
     // user input
@@ -182,7 +184,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     compassView.setOnClickListener(createCompassClickListener(cameraDispatcher));
 
     // LocationComponent
-    mapboxMap.injectLocationComponent(new LocationComponent(mapboxMap));
+    mapboxMap.injectLocationComponent(new LocationComponent(mapboxMap, transform, developerAnimationListeners));
 
     // inject widgets with MapboxMap
     attrView.setOnClickListener(attributionClickListener = new AttributionClickListener(context, mapboxMap));

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -12,6 +12,7 @@ import android.support.annotation.Size;
 import android.support.annotation.UiThread;
 import android.text.TextUtils;
 import android.view.View;
+
 import com.mapbox.android.gestures.AndroidGesturesManager;
 import com.mapbox.android.gestures.MoveGestureDetector;
 import com.mapbox.android.gestures.RotateGestureDetector;
@@ -63,6 +64,7 @@ public final class MapboxMap {
   private final CameraChangeDispatcher cameraChangeDispatcher;
   private final OnGesturesManagerInteractionListener onGesturesManagerInteractionListener;
   private final List<Style.OnStyleLoaded> awaitingStyleGetters = new ArrayList<>();
+  private final List<OnDeveloperAnimationListener> developerAnimationStartedListeners;
 
   @Nullable
   private Style.OnStyleLoaded styleLoadedCallback;
@@ -79,13 +81,15 @@ public final class MapboxMap {
   private boolean debugActive;
 
   MapboxMap(NativeMap map, Transform transform, UiSettings ui, Projection projection,
-            OnGesturesManagerInteractionListener listener, CameraChangeDispatcher cameraChangeDispatcher) {
+            OnGesturesManagerInteractionListener listener, CameraChangeDispatcher cameraChangeDispatcher,
+            List<OnDeveloperAnimationListener> developerAnimationStartedListeners) {
     this.nativeMapView = map;
     this.uiSettings = ui;
     this.projection = projection;
     this.transform = transform;
     this.onGesturesManagerInteractionListener = listener;
     this.cameraChangeDispatcher = cameraChangeDispatcher;
+    this.developerAnimationStartedListeners = developerAnimationStartedListeners;
   }
 
   void initialise(@NonNull Context context, @NonNull MapboxMapOptions options) {
@@ -414,6 +418,7 @@ public final class MapboxMap {
    */
   public final void moveCamera(@NonNull final CameraUpdate update,
                                @Nullable final MapboxMap.CancelableCallback callback) {
+    notifyDeveloperAnimationListeners();
     transform.moveCamera(MapboxMap.this, update, callback);
   }
 
@@ -522,10 +527,10 @@ public final class MapboxMap {
                                final int durationMs,
                                final boolean easingInterpolator,
                                @Nullable final MapboxMap.CancelableCallback callback) {
-
     if (durationMs <= 0) {
       throw new IllegalArgumentException("Null duration passed into easeCamera");
     }
+    notifyDeveloperAnimationListeners();
     transform.easeCamera(MapboxMap.this, update, durationMs, easingInterpolator, callback);
   }
 
@@ -596,7 +601,7 @@ public final class MapboxMap {
     if (durationMs <= 0) {
       throw new IllegalArgumentException("Null duration passed into animateCamera");
     }
-
+    notifyDeveloperAnimationListeners();
     transform.animateCamera(MapboxMap.this, update, durationMs, callback);
   }
 
@@ -608,7 +613,7 @@ public final class MapboxMap {
    * @param y Amount of pixels to scroll to in y direction
    */
   public void scrollBy(float x, float y) {
-    nativeMapView.moveBy(x, y, 0);
+    scrollBy(x, y, 0);
   }
 
   /**
@@ -620,6 +625,7 @@ public final class MapboxMap {
    * @param duration Amount of time the scrolling should take
    */
   public void scrollBy(float x, float y, long duration) {
+    notifyDeveloperAnimationListeners();
     nativeMapView.moveBy(x, y, duration);
   }
 
@@ -631,6 +637,7 @@ public final class MapboxMap {
    * Resets the map view to face north.
    */
   public void resetNorth() {
+    notifyDeveloperAnimationListeners();
     transform.resetNorth();
   }
 
@@ -643,6 +650,7 @@ public final class MapboxMap {
    * @param duration The duration of the transformation
    */
   public void setFocalBearing(double bearing, float focalX, float focalY, long duration) {
+    notifyDeveloperAnimationListeners();
     transform.setBearing(bearing, focalX, focalY, duration);
   }
 
@@ -2342,11 +2350,28 @@ public final class MapboxMap {
     void onSnapshotReady(@NonNull Bitmap snapshot);
   }
 
+  /**
+   * Internal use.
+   */
+  public interface OnDeveloperAnimationListener {
+
+    /**
+     * Notifies listener when a developer invoked animation is about to start.
+     */
+    void onDeveloperAnimationStarted();
+  }
+
   //
   // Used for instrumentation testing
   //
   @NonNull
   Transform getTransform() {
     return transform;
+  }
+
+  private void notifyDeveloperAnimationListeners() {
+    for (OnDeveloperAnimationListener listener : developerAnimationStartedListeners) {
+      listener.onDeveloperAnimationStarted();
+    }
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
@@ -16,12 +16,15 @@ import com.mapbox.mapboxsdk.log.Logger;
 import static com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraMoveStartedListener;
 
 /**
+ * Internal use.
+ * <p>
  * Resembles the current Map transformation.
+ * </p>
  * <p>
  * Responsible for synchronising {@link CameraPosition} state and notifying camera change listeners.
  * </p>
  */
-final class Transform implements MapView.OnCameraDidChangeListener {
+public final class Transform implements MapView.OnCameraDidChangeListener {
 
   private static final String TAG = "Mbgl-Transform";
 
@@ -95,9 +98,12 @@ final class Transform implements MapView.OnCameraDidChangeListener {
     }
   }
 
+  /**
+   * Internal use.
+   */
   @UiThread
-  final void moveCamera(@NonNull MapboxMap mapboxMap, CameraUpdate update,
-                        @Nullable final MapboxMap.CancelableCallback callback) {
+  public final void moveCamera(@NonNull MapboxMap mapboxMap, CameraUpdate update,
+                               @Nullable final MapboxMap.CancelableCallback callback) {
     CameraPosition cameraPosition = update.getCameraPosition(mapboxMap);
     if (isValidCameraPosition(cameraPosition)) {
       cancelTransitions();
@@ -133,9 +139,12 @@ final class Transform implements MapView.OnCameraDidChangeListener {
     }
   }
 
+  /**
+   * Internal use.
+   */
   @UiThread
-  final void animateCamera(@NonNull MapboxMap mapboxMap, CameraUpdate update, int durationMs,
-                           @Nullable final MapboxMap.CancelableCallback callback) {
+  public final void animateCamera(@NonNull MapboxMap mapboxMap, CameraUpdate update, int durationMs,
+                                  @Nullable final MapboxMap.CancelableCallback callback) {
     CameraPosition cameraPosition = update.getCameraPosition(mapboxMap);
     if (isValidCameraPosition(cameraPosition)) {
       cancelTransitions();

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationCameraControllerTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationCameraControllerTest.java
@@ -11,6 +11,7 @@ import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Projection;
+import com.mapbox.mapboxsdk.maps.Transform;
 import com.mapbox.mapboxsdk.maps.UiSettings;
 
 import junit.framework.Assert;
@@ -38,6 +39,7 @@ import static com.mapbox.mapboxsdk.location.modes.CameraMode.TRACKING_GPS_NORTH;
 import static junit.framework.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -180,75 +182,70 @@ public class LocationCameraControllerTest {
 
   @Test
   public void onNewLatLngValue_cameraModeTrackingUpdatesLatLng() {
-    MapboxMap mapboxMap = mock(MapboxMap.class);
-    when(mapboxMap.getUiSettings()).thenReturn(mock(UiSettings.class));
-    when(mapboxMap.getProjection()).thenReturn(mock(Projection.class));
-    LocationCameraController camera = buildCamera(mapboxMap);
+    Transform transform = mock(Transform.class);
+    LocationCameraController camera = buildCamera(transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     camera.setCameraMode(TRACKING);
     LatLng latLng = mock(LatLng.class);
 
     getAnimationListener(ANIMATOR_CAMERA_LATLNG, camera.getAnimationListeners()).onNewAnimationValue(latLng);
 
-    verify(mapboxMap).moveCamera(any(CameraUpdate.class));
+    verify(transform).moveCamera(any(MapboxMap.class), any(CameraUpdate.class),
+      nullable(MapboxMap.CancelableCallback.class));
   }
 
   @Test
   public void onNewLatLngValue_cameraModeTrackingGpsNorthUpdatesLatLng() {
-    MapboxMap mapboxMap = mock(MapboxMap.class);
-    when(mapboxMap.getUiSettings()).thenReturn(mock(UiSettings.class));
-    when(mapboxMap.getProjection()).thenReturn(mock(Projection.class));
-    LocationCameraController camera = buildCamera(mapboxMap);
+    Transform transform = mock(Transform.class);
+    LocationCameraController camera = buildCamera(transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     camera.setCameraMode(TRACKING_GPS_NORTH);
     LatLng latLng = mock(LatLng.class);
 
     getAnimationListener(ANIMATOR_CAMERA_LATLNG, camera.getAnimationListeners()).onNewAnimationValue(latLng);
 
-    verify(mapboxMap).moveCamera(any(CameraUpdate.class));
+    verify(transform).moveCamera(any(MapboxMap.class), any(CameraUpdate.class),
+      nullable(MapboxMap.CancelableCallback.class));
   }
 
   @Test
   public void onNewLatLngValue_cameraModeTrackingGpsUpdatesLatLng() {
-    MapboxMap mapboxMap = mock(MapboxMap.class);
-    when(mapboxMap.getUiSettings()).thenReturn(mock(UiSettings.class));
-    when(mapboxMap.getProjection()).thenReturn(mock(Projection.class));
-    LocationCameraController camera = buildCamera(mapboxMap);
+    Transform transform = mock(Transform.class);
+    LocationCameraController camera = buildCamera(transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     camera.setCameraMode(TRACKING_GPS);
     LatLng latLng = mock(LatLng.class);
 
     getAnimationListener(ANIMATOR_CAMERA_LATLNG, camera.getAnimationListeners()).onNewAnimationValue(latLng);
 
-    verify(mapboxMap).moveCamera(any(CameraUpdate.class));
+    verify(transform).moveCamera(any(MapboxMap.class), any(CameraUpdate.class),
+      nullable(MapboxMap.CancelableCallback.class));
   }
 
   @Test
   public void onNewLatLngValue_cameraModeTrackingCompassUpdatesLatLng() {
-    MapboxMap mapboxMap = mock(MapboxMap.class);
-    when(mapboxMap.getUiSettings()).thenReturn(mock(UiSettings.class));
-    when(mapboxMap.getProjection()).thenReturn(mock(Projection.class));
-    LocationCameraController camera = buildCamera(mapboxMap);
+    Transform transform = mock(Transform.class);
+    LocationCameraController camera = buildCamera(transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     camera.setCameraMode(TRACKING_COMPASS);
     LatLng latLng = mock(LatLng.class);
 
     getAnimationListener(ANIMATOR_CAMERA_LATLNG, camera.getAnimationListeners()).onNewAnimationValue(latLng);
 
-    verify(mapboxMap).moveCamera(any(CameraUpdate.class));
+    verify(transform).moveCamera(any(MapboxMap.class), any(CameraUpdate.class),
+      nullable(MapboxMap.CancelableCallback.class));
   }
 
   @Test
   public void onNewLatLngValue_cameraModeNoneIgnored() {
-    MapboxMap mapboxMap = mock(MapboxMap.class);
-    when(mapboxMap.getUiSettings()).thenReturn(mock(UiSettings.class));
-    when(mapboxMap.getProjection()).thenReturn(mock(Projection.class));
-    LocationCameraController camera = buildCamera(mapboxMap);
+    Transform transform = mock(Transform.class);
+    LocationCameraController camera = buildCamera(transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     camera.setCameraMode(NONE);
 
     assertNull(getAnimationListener(ANIMATOR_CAMERA_LATLNG, camera.getAnimationListeners()));
-    verify(mapboxMap, times(0)).moveCamera(any(CameraUpdate.class));
+    verify(transform, times(0)).moveCamera(any(MapboxMap.class), any(CameraUpdate.class),
+      nullable(MapboxMap.CancelableCallback.class));
   }
 
   @Test
@@ -274,75 +271,82 @@ public class LocationCameraControllerTest {
 
   @Test
   public void onNewGpsBearingValue_cameraModeTrackingGpsUpdatesBearing() {
-    MapboxMap mapboxMap = mock(MapboxMap.class);
-    LocationCameraController camera = buildCamera(mapboxMap);
+    Transform transform = mock(Transform.class);
+    LocationCameraController camera = buildCamera(transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     camera.setCameraMode(TRACKING_GPS);
     float gpsBearing = 5f;
 
     getAnimationListener(ANIMATOR_CAMERA_GPS_BEARING, camera.getAnimationListeners()).onNewAnimationValue(gpsBearing);
 
-    verify(mapboxMap).moveCamera(any(CameraUpdate.class));
+    verify(transform).moveCamera(any(MapboxMap.class), any(CameraUpdate.class),
+      nullable(MapboxMap.CancelableCallback.class));
   }
 
   @Test
   public void onNewGpsBearingValue_cameraModeNoneGpsUpdatesBearing() {
-    MapboxMap mapboxMap = mock(MapboxMap.class);
-    LocationCameraController camera = buildCamera(mapboxMap);
+    Transform transform = mock(Transform.class);
+    LocationCameraController camera = buildCamera(transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     camera.setCameraMode(NONE_GPS);
     float gpsBearing = 5f;
 
     getAnimationListener(ANIMATOR_CAMERA_GPS_BEARING, camera.getAnimationListeners()).onNewAnimationValue(gpsBearing);
 
-    verify(mapboxMap).moveCamera(any(CameraUpdate.class));
+    verify(transform).moveCamera(any(MapboxMap.class), any(CameraUpdate.class),
+      nullable(MapboxMap.CancelableCallback.class));
   }
 
   @Test
   public void onNewGpsBearingValue_cameraModeTrackingNorthUpdatesBearing() {
     MapboxMap mapboxMap = mock(MapboxMap.class);
+    Transform transform = mock(Transform.class);
+    LocationCameraController camera = buildCamera(mapboxMap, transform);
     CameraPosition cameraPosition = new CameraPosition.Builder().bearing(7d).build();
     when(mapboxMap.getCameraPosition()).thenReturn(cameraPosition);
-    LocationCameraController camera = buildCamera(mapboxMap);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     camera.setCameraMode(TRACKING_GPS_NORTH);
     float gpsBearing = 5f;
 
     getAnimationListener(ANIMATOR_CAMERA_GPS_BEARING, camera.getAnimationListeners()).onNewAnimationValue(gpsBearing);
 
-    verify(mapboxMap).moveCamera(any(CameraUpdate.class));
+    verify(transform).moveCamera(eq(mapboxMap), any(CameraUpdate.class),
+      nullable(MapboxMap.CancelableCallback.class));
   }
 
   @Test
   public void onNewGpsBearingValue_cameraModeTrackingNorthBearingZeroIgnored() {
     MapboxMap mapboxMap = mock(MapboxMap.class);
+    Transform transform = mock(Transform.class);
+    LocationCameraController camera = buildCamera(mapboxMap, transform);
     CameraPosition cameraPosition = new CameraPosition.Builder().bearing(0d).build();
     when(mapboxMap.getCameraPosition()).thenReturn(cameraPosition);
-    LocationCameraController camera = buildCamera(mapboxMap);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     camera.setCameraMode(TRACKING_GPS_NORTH);
     float gpsBearing = 5f;
 
     getAnimationListener(ANIMATOR_CAMERA_GPS_BEARING, camera.getAnimationListeners()).onNewAnimationValue(gpsBearing);
 
-    verify(mapboxMap, times(0)).moveCamera(any(CameraUpdate.class));
+    verify(transform, times(0)).moveCamera(eq(mapboxMap), any(CameraUpdate.class),
+      nullable(MapboxMap.CancelableCallback.class));
   }
 
   @Test
   public void onNewGpsBearingValue_cameraModeNoneIgnored() {
-    MapboxMap mapboxMap = mock(MapboxMap.class);
-    LocationCameraController camera = buildCamera(mapboxMap);
+    Transform transform = mock(Transform.class);
+    LocationCameraController camera = buildCamera(transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     camera.setCameraMode(NONE);
 
     assertNull(getAnimationListener(ANIMATOR_CAMERA_GPS_BEARING, camera.getAnimationListeners()));
-    verify(mapboxMap, times(0)).moveCamera(any(CameraUpdate.class));
+    verify(transform, times(0)).moveCamera(any(MapboxMap.class), any(CameraUpdate.class),
+      nullable(MapboxMap.CancelableCallback.class));
   }
 
   @Test
   public void onNewCompassBearingValue_cameraModeTrackingCompassUpdatesBearing() {
-    MapboxMap mapboxMap = mock(MapboxMap.class);
-    LocationCameraController camera = buildCamera(mapboxMap);
+    Transform transform = mock(Transform.class);
+    LocationCameraController camera = buildCamera(transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     camera.setCameraMode(TRACKING_COMPASS);
     float compassBearing = 5f;
@@ -350,13 +354,14 @@ public class LocationCameraControllerTest {
     getAnimationListener(ANIMATOR_CAMERA_COMPASS_BEARING, camera.getAnimationListeners())
       .onNewAnimationValue(compassBearing);
 
-    verify(mapboxMap).moveCamera(any(CameraUpdate.class));
+    verify(transform).moveCamera(any(MapboxMap.class), any(CameraUpdate.class),
+      nullable(MapboxMap.CancelableCallback.class));
   }
 
   @Test
   public void onNewCompassBearingValue_cameraModeNoneCompassUpdatesBearing() {
-    MapboxMap mapboxMap = mock(MapboxMap.class);
-    LocationCameraController camera = buildCamera(mapboxMap);
+    Transform transform = mock(Transform.class);
+    LocationCameraController camera = buildCamera(transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     camera.setCameraMode(NONE_COMPASS);
     float compassBearing = 5f;
@@ -364,44 +369,48 @@ public class LocationCameraControllerTest {
     getAnimationListener(ANIMATOR_CAMERA_COMPASS_BEARING, camera.getAnimationListeners())
       .onNewAnimationValue(compassBearing);
 
-    verify(mapboxMap).moveCamera(any(CameraUpdate.class));
+    verify(transform).moveCamera(any(MapboxMap.class), any(CameraUpdate.class),
+      nullable(MapboxMap.CancelableCallback.class));
   }
 
   @Test
   public void onNewCompassBearingValue_cameraModeNoneIgnored() {
-    MapboxMap mapboxMap = mock(MapboxMap.class);
-    LocationCameraController camera = buildCamera(mapboxMap);
+    Transform transform = mock(Transform.class);
+    LocationCameraController camera = buildCamera(transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     camera.setCameraMode(NONE);
 
     assertNull(getAnimationListener(ANIMATOR_CAMERA_COMPASS_BEARING, camera.getAnimationListeners()));
-    verify(mapboxMap, times(0)).moveCamera(any(CameraUpdate.class));
+    verify(transform, times(0)).moveCamera(any(MapboxMap.class), any(CameraUpdate.class),
+      nullable(MapboxMap.CancelableCallback.class));
   }
 
   @Test
   public void onNewZoomValue_cameraIsUpdated() {
-    MapboxMap mapboxMap = mock(MapboxMap.class);
-    LocationCameraController camera = buildCamera(mapboxMap);
+    Transform transform = mock(Transform.class);
+    LocationCameraController camera = buildCamera(transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     camera.setCameraMode(TRACKING);
     float zoom = 5f;
 
     getAnimationListener(ANIMATOR_ZOOM, camera.getAnimationListeners()).onNewAnimationValue(zoom);
 
-    verify(mapboxMap).moveCamera(any(CameraUpdate.class));
+    verify(transform).moveCamera(any(MapboxMap.class), any(CameraUpdate.class),
+      nullable(MapboxMap.CancelableCallback.class));
   }
 
   @Test
   public void onNeTiltValue_cameraIsUpdated() {
-    MapboxMap mapboxMap = mock(MapboxMap.class);
-    LocationCameraController camera = buildCamera(mapboxMap);
+    Transform transform = mock(Transform.class);
+    LocationCameraController camera = buildCamera(transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     camera.setCameraMode(TRACKING);
     float tilt = 5f;
 
     getAnimationListener(ANIMATOR_TILT, camera.getAnimationListeners()).onNewAnimationValue(tilt);
 
-    verify(mapboxMap).moveCamera(any(CameraUpdate.class));
+    verify(transform).moveCamera(any(MapboxMap.class), any(CameraUpdate.class),
+      nullable(MapboxMap.CancelableCallback.class));
   }
 
   @Test
@@ -519,39 +528,44 @@ public class LocationCameraControllerTest {
   @Test
   public void transition_locationIsNull() {
     MapboxMap mapboxMap = mock(MapboxMap.class);
-    LocationCameraController camera = buildCamera(mapboxMap);
+    Transform transform = mock(Transform.class);
+    LocationCameraController camera = buildCamera(mapboxMap, transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     OnLocationCameraTransitionListener listener = mock(OnLocationCameraTransitionListener.class);
 
     camera.setCameraMode(TRACKING, null, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
     Assert.assertEquals(TRACKING, camera.getCameraMode());
     verify(listener).onLocationCameraTransitionFinished(TRACKING);
-    verify(mapboxMap, times(0))
-      .animateCamera(any(CameraUpdate.class), any(Integer.class), any(MapboxMap.CancelableCallback.class));
+    verify(transform, times(0))
+      .animateCamera(eq(mapboxMap), any(CameraUpdate.class), any(Integer.class),
+        any(MapboxMap.CancelableCallback.class));
   }
 
   @Test
   public void transition_notTracking() {
     MapboxMap mapboxMap = mock(MapboxMap.class);
-    LocationCameraController camera = buildCamera(mapboxMap);
+    Transform transform = mock(Transform.class);
+    LocationCameraController camera = buildCamera(mapboxMap, transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     OnLocationCameraTransitionListener listener = mock(OnLocationCameraTransitionListener.class);
     Location location = mock(Location.class);
 
     camera.setCameraMode(NONE, location, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
     verify(listener, times(1)).onLocationCameraTransitionFinished(NONE);
-    verify(mapboxMap, times(0))
-      .animateCamera(any(CameraUpdate.class), any(Integer.class), any(MapboxMap.CancelableCallback.class));
+    verify(transform, times(0))
+      .animateCamera(eq(mapboxMap), any(CameraUpdate.class), any(Integer.class),
+        any(MapboxMap.CancelableCallback.class));
   }
 
   @Test
   public void transition_trackingChanged() {
     MapboxMap mapboxMap = mock(MapboxMap.class);
+    Transform transform = mock(Transform.class);
     when(mapboxMap.getCameraPosition()).thenReturn(CameraPosition.DEFAULT);
     Projection projection = mock(Projection.class);
     when(mapboxMap.getProjection()).thenReturn(projection);
     when(projection.getMetersPerPixelAtLatitude(any(Double.class))).thenReturn(Double.valueOf(1000));
-    LocationCameraController camera = buildCamera(mapboxMap);
+    LocationCameraController camera = buildCamera(mapboxMap, transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     final OnLocationCameraTransitionListener listener = mock(OnLocationCameraTransitionListener.class);
     Location location = mock(Location.class);
@@ -562,23 +576,25 @@ public class LocationCameraControllerTest {
         listener.onLocationCameraTransitionFinished(TRACKING);
         return null;
       }
-    }).when(mapboxMap).animateCamera(any(CameraUpdate.class), any(Integer.class), any(MapboxMap.CancelableCallback
-      .class));
+    }).when(transform).animateCamera(eq(mapboxMap), any(CameraUpdate.class), any(Integer.class),
+      any(MapboxMap.CancelableCallback.class));
 
     camera.setCameraMode(TRACKING, location, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
     verify(listener).onLocationCameraTransitionFinished(TRACKING);
-    verify(mapboxMap)
-      .animateCamera(any(CameraUpdate.class), any(Integer.class), any(MapboxMap.CancelableCallback.class));
+    verify(transform)
+      .animateCamera(eq(mapboxMap), any(CameraUpdate.class), any(Integer.class),
+        any(MapboxMap.CancelableCallback.class));
   }
 
   @Test
   public void transition_trackingNotChanged() {
     MapboxMap mapboxMap = mock(MapboxMap.class);
+    Transform transform = mock(Transform.class);
     when(mapboxMap.getCameraPosition()).thenReturn(CameraPosition.DEFAULT);
     Projection projection = mock(Projection.class);
     when(mapboxMap.getProjection()).thenReturn(projection);
     when(projection.getMetersPerPixelAtLatitude(any(Double.class))).thenReturn(Double.valueOf(1000));
-    LocationCameraController camera = buildCamera(mapboxMap);
+    LocationCameraController camera = buildCamera(mapboxMap, transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     final OnLocationCameraTransitionListener listener = mock(OnLocationCameraTransitionListener.class);
     Location location = mock(Location.class);
@@ -591,23 +607,25 @@ public class LocationCameraControllerTest {
         listener.onLocationCameraTransitionFinished(TRACKING_GPS_NORTH);
         return null;
       }
-    }).when(mapboxMap).animateCamera(any(CameraUpdate.class), any(Integer.class), any(MapboxMap.CancelableCallback
-      .class));
+    }).when(transform).animateCamera(eq(mapboxMap), any(CameraUpdate.class), any(Integer.class),
+      any(MapboxMap.CancelableCallback.class));
 
     camera.setCameraMode(TRACKING_GPS_NORTH, location, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
     verify(listener, times(1)).onLocationCameraTransitionFinished(TRACKING_GPS_NORTH);
-    verify(mapboxMap, times(1))
-      .animateCamera(any(CameraUpdate.class), any(Integer.class), any(MapboxMap.CancelableCallback.class));
+    verify(transform, times(1))
+      .animateCamera(eq(mapboxMap), any(CameraUpdate.class), any(Integer.class),
+        any(MapboxMap.CancelableCallback.class));
   }
 
   @Test
   public void transition_canceled() {
     MapboxMap mapboxMap = mock(MapboxMap.class);
+    Transform transform = mock(Transform.class);
     when(mapboxMap.getCameraPosition()).thenReturn(CameraPosition.DEFAULT);
     Projection projection = mock(Projection.class);
     when(mapboxMap.getProjection()).thenReturn(projection);
     when(projection.getMetersPerPixelAtLatitude(any(Double.class))).thenReturn(Double.valueOf(1000));
-    LocationCameraController camera = buildCamera(mapboxMap);
+    LocationCameraController camera = buildCamera(mapboxMap, transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     final OnLocationCameraTransitionListener listener = mock(OnLocationCameraTransitionListener.class);
     Location location = mock(Location.class);
@@ -618,23 +636,25 @@ public class LocationCameraControllerTest {
         listener.onLocationCameraTransitionCanceled(TRACKING);
         return null;
       }
-    }).when(mapboxMap).animateCamera(any(CameraUpdate.class), any(Integer.class), any(MapboxMap.CancelableCallback
-      .class));
+    }).when(transform).animateCamera(eq(mapboxMap), any(CameraUpdate.class), any(Integer.class),
+      any(MapboxMap.CancelableCallback.class));
 
     camera.setCameraMode(TRACKING, location, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
     verify(listener).onLocationCameraTransitionCanceled(TRACKING);
-    verify(mapboxMap)
-      .animateCamera(any(CameraUpdate.class), any(Integer.class), any(MapboxMap.CancelableCallback.class));
+    verify(transform)
+      .animateCamera(eq(mapboxMap), any(CameraUpdate.class), any(Integer.class),
+        any(MapboxMap.CancelableCallback.class));
   }
 
   @Test
   public void transition_mapboxCallbackFinished() {
     MapboxMap mapboxMap = mock(MapboxMap.class);
+    Transform transform = mock(Transform.class);
     when(mapboxMap.getCameraPosition()).thenReturn(CameraPosition.DEFAULT);
     Projection projection = mock(Projection.class);
     when(mapboxMap.getProjection()).thenReturn(projection);
     when(projection.getMetersPerPixelAtLatitude(any(Double.class))).thenReturn(Double.valueOf(1000));
-    LocationCameraController camera = buildCamera(mapboxMap);
+    LocationCameraController camera = buildCamera(mapboxMap, transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     final OnLocationCameraTransitionListener listener = mock(OnLocationCameraTransitionListener.class);
     Location location = mock(Location.class);
@@ -649,7 +669,8 @@ public class LocationCameraControllerTest {
     camera.setCameraMode(TRACKING, location, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
 
     CameraPosition.Builder builder = new CameraPosition.Builder().target(new LatLng(location));
-    verify(mapboxMap).animateCamera(
+    verify(transform).animateCamera(
+      eq(mapboxMap),
       eq(CameraUpdateFactory.newCameraPosition(builder.build())),
       eq((int) TRANSITION_ANIMATION_DURATION_MS),
       callbackCaptor.capture());
@@ -666,11 +687,12 @@ public class LocationCameraControllerTest {
   @Test
   public void transition_mapboxCallbackFinishedImmediately() {
     MapboxMap mapboxMap = mock(MapboxMap.class);
+    Transform transform = mock(Transform.class);
     when(mapboxMap.getCameraPosition()).thenReturn(CameraPosition.DEFAULT);
     Projection projection = mock(Projection.class);
     when(mapboxMap.getProjection()).thenReturn(projection);
     when(projection.getMetersPerPixelAtLatitude(any(Double.class))).thenReturn(Double.valueOf(1));
-    LocationCameraController camera = buildCamera(mapboxMap);
+    LocationCameraController camera = buildCamera(mapboxMap, transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     final OnLocationCameraTransitionListener listener = mock(OnLocationCameraTransitionListener.class);
     Location location = mock(Location.class);
@@ -685,7 +707,8 @@ public class LocationCameraControllerTest {
     camera.setCameraMode(TRACKING, location, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
 
     CameraPosition.Builder builder = new CameraPosition.Builder().target(new LatLng(location));
-    verify(mapboxMap).moveCamera(
+    verify(transform).moveCamera(
+      eq(mapboxMap),
       eq(CameraUpdateFactory.newCameraPosition(builder.build())),
       callbackCaptor.capture());
 
@@ -701,11 +724,12 @@ public class LocationCameraControllerTest {
   @Test
   public void transition_mapboxCallbackCanceled() {
     MapboxMap mapboxMap = mock(MapboxMap.class);
+    Transform transform = mock(Transform.class);
     when(mapboxMap.getCameraPosition()).thenReturn(CameraPosition.DEFAULT);
     Projection projection = mock(Projection.class);
     when(mapboxMap.getProjection()).thenReturn(projection);
     when(projection.getMetersPerPixelAtLatitude(any(Double.class))).thenReturn(Double.valueOf(1000));
-    LocationCameraController camera = buildCamera(mapboxMap);
+    LocationCameraController camera = buildCamera(mapboxMap, transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     final OnLocationCameraTransitionListener listener = mock(OnLocationCameraTransitionListener.class);
     Location location = mock(Location.class);
@@ -720,7 +744,8 @@ public class LocationCameraControllerTest {
     camera.setCameraMode(TRACKING, location, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
 
     CameraPosition.Builder builder = new CameraPosition.Builder().target(new LatLng(location));
-    verify(mapboxMap).animateCamera(
+    verify(transform).animateCamera(
+      eq(mapboxMap),
       eq(CameraUpdateFactory.newCameraPosition(builder.build())),
       eq((int) TRANSITION_ANIMATION_DURATION_MS),
       callbackCaptor.capture());
@@ -737,11 +762,12 @@ public class LocationCameraControllerTest {
   @Test
   public void transition_mapboxAnimateBearing() {
     MapboxMap mapboxMap = mock(MapboxMap.class);
+    Transform transform = mock(Transform.class);
     when(mapboxMap.getCameraPosition()).thenReturn(CameraPosition.DEFAULT);
     Projection projection = mock(Projection.class);
     when(mapboxMap.getProjection()).thenReturn(projection);
     when(projection.getMetersPerPixelAtLatitude(any(Double.class))).thenReturn(Double.valueOf(1000));
-    LocationCameraController camera = buildCamera(mapboxMap);
+    LocationCameraController camera = buildCamera(mapboxMap, transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     final OnLocationCameraTransitionListener listener = mock(OnLocationCameraTransitionListener.class);
     Location location = mock(Location.class);
@@ -753,7 +779,8 @@ public class LocationCameraControllerTest {
     camera.setCameraMode(TRACKING_GPS, location, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
 
     CameraPosition.Builder builder = new CameraPosition.Builder().target(new LatLng(location)).bearing(30);
-    verify(mapboxMap).animateCamera(
+    verify(transform).animateCamera(
+      eq(mapboxMap),
       eq(CameraUpdateFactory.newCameraPosition(builder.build())),
       eq((int) TRANSITION_ANIMATION_DURATION_MS),
       any(MapboxMap.CancelableCallback.class));
@@ -762,11 +789,12 @@ public class LocationCameraControllerTest {
   @Test
   public void transition_mapboxAnimateNorth() {
     MapboxMap mapboxMap = mock(MapboxMap.class);
+    Transform transform = mock(Transform.class);
     when(mapboxMap.getCameraPosition()).thenReturn(CameraPosition.DEFAULT);
     Projection projection = mock(Projection.class);
     when(mapboxMap.getProjection()).thenReturn(projection);
     when(projection.getMetersPerPixelAtLatitude(any(Double.class))).thenReturn(Double.valueOf(1000));
-    LocationCameraController camera = buildCamera(mapboxMap);
+    LocationCameraController camera = buildCamera(mapboxMap, transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     final OnLocationCameraTransitionListener listener = mock(OnLocationCameraTransitionListener.class);
     Location location = mock(Location.class);
@@ -778,7 +806,8 @@ public class LocationCameraControllerTest {
     camera.setCameraMode(TRACKING_GPS_NORTH, location, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
 
     CameraPosition.Builder builder = new CameraPosition.Builder().target(new LatLng(location)).bearing(0);
-    verify(mapboxMap).animateCamera(
+    verify(transform).animateCamera(
+      eq(mapboxMap),
       eq(CameraUpdateFactory.newCameraPosition(builder.build())),
       eq((int) TRANSITION_ANIMATION_DURATION_MS),
       any(MapboxMap.CancelableCallback.class));
@@ -787,11 +816,12 @@ public class LocationCameraControllerTest {
   @Test
   public void transition_animatorValuesDuringTransition() {
     MapboxMap mapboxMap = mock(MapboxMap.class);
+    Transform transform = mock(Transform.class);
     when(mapboxMap.getCameraPosition()).thenReturn(CameraPosition.DEFAULT);
     Projection projection = mock(Projection.class);
     when(mapboxMap.getProjection()).thenReturn(projection);
     when(projection.getMetersPerPixelAtLatitude(any(Double.class))).thenReturn(Double.valueOf(1000));
-    LocationCameraController camera = buildCamera(mapboxMap);
+    LocationCameraController camera = buildCamera(mapboxMap, transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     final OnLocationCameraTransitionListener listener = mock(OnLocationCameraTransitionListener.class);
     Location location = mock(Location.class);
@@ -801,7 +831,8 @@ public class LocationCameraControllerTest {
 
     camera.setCameraMode(TRACKING_GPS, location, TRANSITION_ANIMATION_DURATION_MS, null, null, null, listener);
 
-    verify(mapboxMap).animateCamera(
+    verify(transform).animateCamera(
+      eq(mapboxMap),
       any(CameraUpdate.class),
       eq((int) TRANSITION_ANIMATION_DURATION_MS),
       callbackCaptor.capture());
@@ -812,7 +843,8 @@ public class LocationCameraControllerTest {
     getAnimationListener(ANIMATOR_TILT, camera.getAnimationListeners()).onNewAnimationValue(10f);
     getAnimationListener(ANIMATOR_ZOOM, camera.getAnimationListeners()).onNewAnimationValue(10f);
 
-    verify(mapboxMap, times(0)).moveCamera(any(CameraUpdate.class));
+    verify(transform, times(0)).moveCamera(eq(mapboxMap), any(CameraUpdate.class),
+      nullable(MapboxMap.CancelableCallback.class));
 
     callbackCaptor.getValue().onFinish();
 
@@ -821,17 +853,19 @@ public class LocationCameraControllerTest {
     getAnimationListener(ANIMATOR_TILT, camera.getAnimationListeners()).onNewAnimationValue(10f);
     getAnimationListener(ANIMATOR_ZOOM, camera.getAnimationListeners()).onNewAnimationValue(10f);
 
-    verify(mapboxMap, times(4)).moveCamera(any(CameraUpdate.class));
+    verify(transform, times(4)).moveCamera(eq(mapboxMap), any(CameraUpdate.class),
+      nullable(MapboxMap.CancelableCallback.class));
   }
 
   @Test
   public void transition_customAnimation() {
     MapboxMap mapboxMap = mock(MapboxMap.class);
+    Transform transform = mock(Transform.class);
     when(mapboxMap.getCameraPosition()).thenReturn(CameraPosition.DEFAULT);
     Projection projection = mock(Projection.class);
     when(mapboxMap.getProjection()).thenReturn(projection);
     when(projection.getMetersPerPixelAtLatitude(any(Double.class))).thenReturn(Double.valueOf(1000));
-    LocationCameraController camera = buildCamera(mapboxMap);
+    LocationCameraController camera = buildCamera(mapboxMap, transform);
     camera.initializeOptions(mock(LocationComponentOptions.class));
     Location location = mock(Location.class);
     CameraUpdate cameraUpdate = CameraUpdateFactory.newCameraPosition(
@@ -844,13 +878,14 @@ public class LocationCameraControllerTest {
     );
 
     camera.setCameraMode(TRACKING, location, 1200, 14.0, 13.0, 45.0, null);
-    verify(mapboxMap)
-      .animateCamera(eq(cameraUpdate), eq(1200), any(MapboxMap.CancelableCallback.class));
+    verify(transform)
+      .animateCamera(eq(mapboxMap), eq(cameraUpdate), eq(1200), any(MapboxMap.CancelableCallback.class));
   }
 
   private LocationCameraController buildCamera(OnCameraTrackingChangedListener onCameraTrackingChangedListener) {
     MapboxMap mapboxMap = mock(MapboxMap.class);
     when(mapboxMap.getUiSettings()).thenReturn(mock(UiSettings.class));
+    Transform transform = mock(Transform.class);
     Projection projection = mock(Projection.class);
     when(mapboxMap.getProjection()).thenReturn(projection);
     when(projection.getMetersPerPixelAtLatitude(any(Double.class))).thenReturn(Double.valueOf(1000));
@@ -858,13 +893,14 @@ public class LocationCameraControllerTest {
     OnCameraMoveInvalidateListener onCameraMoveInvalidateListener = mock(OnCameraMoveInvalidateListener.class);
     AndroidGesturesManager initialGesturesManager = mock(AndroidGesturesManager.class);
     AndroidGesturesManager internalGesturesManager = mock(AndroidGesturesManager.class);
-    return new LocationCameraController(mapboxMap, moveGestureDetector,
+    return new LocationCameraController(mapboxMap, transform, moveGestureDetector,
       onCameraTrackingChangedListener, onCameraMoveInvalidateListener, initialGesturesManager, internalGesturesManager);
   }
 
   private LocationCameraController buildCamera(MoveGestureDetector moveGestureDetector) {
     MapboxMap mapboxMap = mock(MapboxMap.class);
     when(mapboxMap.getUiSettings()).thenReturn(mock(UiSettings.class));
+    Transform transform = mock(Transform.class);
     Projection projection = mock(Projection.class);
     when(mapboxMap.getProjection()).thenReturn(projection);
     when(projection.getMetersPerPixelAtLatitude(any(Double.class))).thenReturn(Double.valueOf(1000));
@@ -872,26 +908,55 @@ public class LocationCameraControllerTest {
     OnCameraMoveInvalidateListener onCameraMoveInvalidateListener = mock(OnCameraMoveInvalidateListener.class);
     AndroidGesturesManager initialGesturesManager = mock(AndroidGesturesManager.class);
     AndroidGesturesManager internalGesturesManager = mock(AndroidGesturesManager.class);
-    return new LocationCameraController(mapboxMap, moveGestureDetector,
+    return new LocationCameraController(mapboxMap, transform, moveGestureDetector,
       onCameraTrackingChangedListener, onCameraMoveInvalidateListener, initialGesturesManager, internalGesturesManager);
   }
 
   private LocationCameraController buildCamera(MapboxMap mapboxMap) {
+    Transform transform = mock(Transform.class);
     MoveGestureDetector moveGestureDetector = mock(MoveGestureDetector.class);
     OnCameraTrackingChangedListener onCameraTrackingChangedListener = mock(OnCameraTrackingChangedListener.class);
     OnCameraMoveInvalidateListener onCameraMoveInvalidateListener = mock(OnCameraMoveInvalidateListener.class);
     AndroidGesturesManager initialGesturesManager = mock(AndroidGesturesManager.class);
     AndroidGesturesManager internalGesturesManager = mock(AndroidGesturesManager.class);
-    return new LocationCameraController(mapboxMap, moveGestureDetector,
+    return new LocationCameraController(mapboxMap, transform, moveGestureDetector,
+      onCameraTrackingChangedListener, onCameraMoveInvalidateListener, initialGesturesManager, internalGesturesManager);
+  }
+
+  private LocationCameraController buildCamera(Transform transform) {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    when(mapboxMap.getUiSettings()).thenReturn(mock(UiSettings.class));
+    Projection projection = mock(Projection.class);
+    when(mapboxMap.getProjection()).thenReturn(projection);
+    when(projection.getMetersPerPixelAtLatitude(any(Double.class))).thenReturn(Double.valueOf(1000));
+    when(mapboxMap.getUiSettings()).thenReturn(mock(UiSettings.class));
+    MoveGestureDetector moveGestureDetector = mock(MoveGestureDetector.class);
+    OnCameraTrackingChangedListener onCameraTrackingChangedListener = mock(OnCameraTrackingChangedListener.class);
+    OnCameraMoveInvalidateListener onCameraMoveInvalidateListener = mock(OnCameraMoveInvalidateListener.class);
+    AndroidGesturesManager initialGesturesManager = mock(AndroidGesturesManager.class);
+    AndroidGesturesManager internalGesturesManager = mock(AndroidGesturesManager.class);
+    return new LocationCameraController(mapboxMap, transform, moveGestureDetector,
+      onCameraTrackingChangedListener, onCameraMoveInvalidateListener, initialGesturesManager, internalGesturesManager);
+  }
+
+  private LocationCameraController buildCamera(MapboxMap mapboxMap, Transform transform) {
+    when(mapboxMap.getUiSettings()).thenReturn(mock(UiSettings.class));
+    MoveGestureDetector moveGestureDetector = mock(MoveGestureDetector.class);
+    OnCameraTrackingChangedListener onCameraTrackingChangedListener = mock(OnCameraTrackingChangedListener.class);
+    OnCameraMoveInvalidateListener onCameraMoveInvalidateListener = mock(OnCameraMoveInvalidateListener.class);
+    AndroidGesturesManager initialGesturesManager = mock(AndroidGesturesManager.class);
+    AndroidGesturesManager internalGesturesManager = mock(AndroidGesturesManager.class);
+    return new LocationCameraController(mapboxMap, transform, moveGestureDetector,
       onCameraTrackingChangedListener, onCameraMoveInvalidateListener, initialGesturesManager, internalGesturesManager);
   }
 
   private LocationCameraController buildCamera(MapboxMap mapboxMap, AndroidGesturesManager initialGesturesManager,
                                                AndroidGesturesManager internalGesturesManager) {
+    Transform transform = mock(Transform.class);
     MoveGestureDetector moveGestureDetector = mock(MoveGestureDetector.class);
     OnCameraTrackingChangedListener onCameraTrackingChangedListener = mock(OnCameraTrackingChangedListener.class);
     OnCameraMoveInvalidateListener onCameraMoveInvalidateListener = mock(OnCameraMoveInvalidateListener.class);
-    return new LocationCameraController(mapboxMap, moveGestureDetector,
+    return new LocationCameraController(mapboxMap, transform, moveGestureDetector,
       onCameraTrackingChangedListener, onCameraMoveInvalidateListener, initialGesturesManager, internalGesturesManager);
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/StyleTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/StyleTest.kt
@@ -28,7 +28,7 @@ class StyleTest {
     @Before
     fun setup() {
         nativeMapView = mockk(relaxed = true)
-        mapboxMap = MapboxMap(nativeMapView, null, null, null, null, null)
+        mapboxMap = MapboxMap(nativeMapView, null, null, null, null, null, null)
         every { nativeMapView.isDestroyed } returns false
         mapboxMap.injectLocationComponent(spyk())
     }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/14538.

Whenever any of the `MapboxMap#moveCamera`, `MapboxMap#easeCamera`, `MapboxMap#animateCamera`, `MapboxMap#scrollBy`, `MapboxMap#resetNorth`, `MapboxMap#setFocalBearing` is invoked, or the compass is clicked, the location component is going to break location tracking and set the camera mode to `CameraMode#NONE`.

/cc @mapbox/navigation-android 