### PR TITLE
[core] Fix namespace issue with OSMesa

### DIFF
--- a/platform/default/src/mbgl/gl/headless_backend_osmesa.cpp
+++ b/platform/default/src/mbgl/gl/headless_backend_osmesa.cpp
@@ -6,6 +6,7 @@
 #include <cassert>
 
 namespace mbgl {
+namespace gl {
 
 class OSMesaBackendImpl : public HeadlessBackend::Impl {
 public:
@@ -44,4 +45,5 @@ void HeadlessBackend::createImpl() {
     impl = std::make_unique<OSMesaBackendImpl>();
 }
 
+} // namespace gl
 } // namespace mbgl


### PR DESCRIPTION
HeadlessBackend seems to be part of the mbgl::gl namespace. Since OSMesaBackendImpl is only in the mbgl namespace this code does not compile.

Since this file is in the mbgl/gl folder I think it makes sense to just put the whole thing in the mbgl::gl namespace.