### PR TITLE
Notarize macosapp

### DIFF
--- a/platform/macos/ExportOptions.plist
+++ b/platform/macos/ExportOptions.plist
@@ -2,8 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>destination</key>
+	<string>upload</string>
 	<key>method</key>
 	<string>developer-id</string>
+	<key>signingStyle</key>
+	<string>automatic</string>
 	<key>teamID</key>
 	<string>GJZR2MEM28</string>
 </dict>

--- a/platform/macos/Mapbox GL.entitlements
+++ b/platform/macos/Mapbox GL.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -704,6 +704,7 @@
 		DAF25713201901C100367EF5 /* MGLHillshadeStyleLayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLHillshadeStyleLayer.mm; sourceTree = "<group>"; };
 		DAF25714201901C200367EF5 /* MGLHillshadeStyleLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLHillshadeStyleLayer.h; sourceTree = "<group>"; };
 		DAF2571D201902A500367EF5 /* MGLHillshadeStyleLayerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLHillshadeStyleLayerTests.mm; sourceTree = "<group>"; };
+		DAF99A3222968C7B004AD6A8 /* Mapbox GL.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Mapbox GL.entitlements"; sourceTree = "<group>"; };
 		DAFBD0D51E3FA969000CD6BF /* zh-Hant */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		DAFBD0D61E3FA983000CD6BF /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Foundation.strings"; sourceTree = "<group>"; };
 		DAFEB3702093ACBF00A86A83 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -875,6 +876,7 @@
 		DA839E891CC2E3400062CAFB = {
 			isa = PBXGroup;
 			children = (
+				DAF99A3222968C7B004AD6A8 /* Mapbox GL.entitlements */,
 				DA839E941CC2E3400062CAFB /* Demo App */,
 				DAE6C3291CC30DB200DB3429 /* SDK */,
 				DAE6C3371CC30DB200DB3429 /* SDK Tests */,
@@ -1505,6 +1507,11 @@
 					DA839E911CC2E3400062CAFB = {
 						CreatedOnToolsVersion = 7.3;
 						LastSwiftMigration = 0920;
+						SystemCapabilities = {
+							com.apple.HardenedRuntime = {
+								enabled = 1;
+							};
+						};
 					};
 					DAAA17961CE13BAE00731EFE = {
 						CreatedOnToolsVersion = 7.3.1;

--- a/platform/macos/scripts/package.sh
+++ b/platform/macos/scripts/package.sh
@@ -61,6 +61,7 @@ if [[ ${BUILDTYPE} == Release ]]; then
         CURRENT_SHORT_VERSION=${SHORT_VERSION} \
         CURRENT_SEMANTIC_VERSION=${SEM_VERSION} \
         CURRENT_COMMIT_HASH=${HASH} \
+        ENABLE_HARDENED_RUNTIME=YES \
         ${CI_XCCONFIG} \
         -derivedDataPath ${DERIVED_DATA} \
         -archivePath "${APP_OUTPUT}/macosapp.xcarchive" \
@@ -98,6 +99,7 @@ if [[ ${BUILDTYPE} == Release ]]; then
     
     step "Exporting Mapbox GL.app"
     xcodebuild \
+        ENABLE_HARDENED_RUNTIME=YES \
         ${CI_XCCONFIG} \
         -exportArchive \
         -archivePath "${APP_OUTPUT}/macosapp.xcarchive" \


### PR DESCRIPTION
Notarize macosapp when packaging a release of the macOS map SDK, so macOS users can more easily open the application without jumping through Gatekeeper hoops.

To do:

* [x] Opt into notarization when using ExportOptions.plist
* [x] Add the Hardened Runtime entitlement to the project
* [x] Set `ENABLE_HARDENED_RUNTIME=YES` in invocations of `xcodebuild` in package.sh (as opposed to inside the project, so non–Mapbox team members can continue to build ad-hoc)
* [ ] [Add a post-archive action](https://developer.apple.com/documentation/security/notarizing_your_app_before_distribution/customizing_the_notarization_workflow?language=objc) to the scheme that exports the application for notarization
* [ ] Invoke `xcrun altool` in package.sh
* [ ] Split out a separate `make` rule that invokes `xcrun stapler staple` and completes the deployment process, to be run after notarization succeeds

Fixes #14753.

/cc @friedbunny @frederoni