### PR TITLE
Limit thread's scope to release the Object before detaching the thread

### DIFF
--- a/include/mbgl/util/thread.hpp
+++ b/include/mbgl/util/thread.hpp
@@ -58,17 +58,21 @@ public:
             platform::makeThreadLowPriority();
             platform::attachThread();
 
-            util::RunLoop loop_(util::RunLoop::Type::New);
-            loop = &loop_;
-            EstablishedActor<Object> establishedActor(loop_, object, std::move(capturedArgs));
+            // narrowing the scope to release the Object before we detach the thread
+            {
+                util::RunLoop loop_(util::RunLoop::Type::New);
+                loop = &loop_;
+                EstablishedActor<Object> establishedActor(loop_, object, std::move(capturedArgs));
 
-            runningPromise.set_value();
-            
-            loop->run();
-            
-            (void) establishedActor;
-            
-            loop = nullptr;
+                runningPromise.set_value();
+
+                loop->run();
+
+                (void) establishedActor;
+
+                loop = nullptr;
+            }
+
             platform::detachThread();
         });
     }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/14747.

Releases the thread's underlying `Object` before detaching the thread.

I'm currently unable to include a regression test because when the `MapSnapshotter` is run as part of the instrumentation test, the renderer doesn't return the snapshot and freezes. Test app examples work fine. This seems like a separate issue, it is the case even when checking out the code before https://github.com/mapbox/mapbox-gl-native/pull/14450, investigating now.

/cc @tobrun 