### PR TITLE
[core] RenderTile does not expose Tile

### DIFF
--- a/src/mbgl/annotation/render_annotation_source.cpp
+++ b/src/mbgl/annotation/render_annotation_source.cpp
@@ -59,6 +59,14 @@ void RenderAnnotationSource::finishRender(PaintParameters& parameters) {
     tilePyramid.finishRender(parameters);
 }
 
+void RenderAnnotationSource::updateFadingTiles() {
+    tilePyramid.updateFadingTiles();
+}
+
+bool RenderAnnotationSource::hasFadingTiles() const {
+    return tilePyramid.hasFadingTiles();
+}
+
 std::vector<std::reference_wrapper<RenderTile>> RenderAnnotationSource::getRenderTiles() {
     return tilePyramid.getRenderTiles();
 }

--- a/src/mbgl/annotation/render_annotation_source.hpp
+++ b/src/mbgl/annotation/render_annotation_source.hpp
@@ -21,6 +21,8 @@ public:
     void upload(gfx::UploadPass&) final;
     void prepare(const SourcePrepareParameters&) final;
     void finishRender(PaintParameters&) final;
+    void updateFadingTiles() final;
+    bool hasFadingTiles() const final;
 
     std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() final;
 

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -58,8 +58,8 @@ public:
     virtual std::pair<uint32_t, bool> registerAtCrossTileIndex(CrossTileSymbolLayerIndex&, const OverscaledTileID&, uint32_t&) {
         return std::make_pair(0u, false);
     }
-    // Places this bucket to the given placement. Returns bucket cross-tile id on success call; `0` otherwise.
-    virtual uint32_t place(Placement&, const BucketPlacementParameters&, std::set<uint32_t>&) { return 0u; }
+    // Places this bucket to the given placement.
+    virtual void place(Placement&, const BucketPlacementParameters&, std::set<uint32_t>&) {}
     virtual void updateVertices(Placement&, bool /*updateOpacities*/, const RenderTile&, std::set<uint32_t>&) {}
 
 protected:

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -249,9 +249,8 @@ std::pair<uint32_t, bool> SymbolBucket::registerAtCrossTileIndex(CrossTileSymbol
     return std::make_pair(bucketInstanceId, firstTimeAdded);
 }
 
-uint32_t SymbolBucket::place(Placement& placement, const BucketPlacementParameters& params, std::set<uint32_t>& seenIds) {
+void SymbolBucket::place(Placement& placement, const BucketPlacementParameters& params, std::set<uint32_t>& seenIds) {
     placement.placeLayerBucket(*this, params, seenIds);
-    return bucketInstanceId;
 }
 
 void SymbolBucket::updateVertices(Placement& placement, bool updateOpacities, const RenderTile& tile, std::set<uint32_t>& seenIds) {

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -250,7 +250,7 @@ std::pair<uint32_t, bool> SymbolBucket::registerAtCrossTileIndex(CrossTileSymbol
 }
 
 void SymbolBucket::place(Placement& placement, const BucketPlacementParameters& params, std::set<uint32_t>& seenIds) {
-    placement.placeLayerBucket(*this, params, seenIds);
+    placement.placeBucket(*this, params, seenIds);
 }
 
 void SymbolBucket::updateVertices(Placement& placement, bool updateOpacities, const RenderTile& tile, std::set<uint32_t>& seenIds) {

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -59,7 +59,7 @@ public:
     void upload(gfx::UploadPass&) override;
     bool hasData() const override;
     std::pair<uint32_t, bool> registerAtCrossTileIndex(CrossTileSymbolLayerIndex&, const OverscaledTileID&, uint32_t& maxCrossTileID) override;
-    uint32_t place(Placement&, const BucketPlacementParameters&, std::set<uint32_t>&) override;
+    void place(Placement&, const BucketPlacementParameters&, std::set<uint32_t>&) override;
     void updateVertices(Placement&, bool updateOpacities, const RenderTile&, std::set<uint32_t>&) override;
     bool hasTextData() const;
     bool hasIconData() const;

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -58,7 +58,7 @@ void RenderCircleLayer::render(PaintParameters& parameters) {
     }
 
     for (const RenderTile& tile : renderTiles) {
-        const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
+        const LayerRenderData* renderData = tile.getLayerRenderData(*baseImpl);
         if (!renderData) {
             continue;
         }

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -115,7 +115,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
         // Draw solid color extrusions
         auto drawTiles = [&](const gfx::StencilMode& stencilMode_, const gfx::ColorMode& colorMode_) {
             for (const RenderTile& tile : renderTiles) {
-                const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
+                const LayerRenderData* renderData = tile.getLayerRenderData(*baseImpl);
                 if (!renderData) {
                     continue;
                 }
@@ -160,15 +160,13 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
         const auto fillPatternValue = evaluated.get<FillExtrusionPattern>().constantOr(mbgl::Faded<std::basic_string<char> >{"", ""});
         auto drawTiles = [&](const gfx::StencilMode& stencilMode_, const gfx::ColorMode& colorMode_) {
             for (const RenderTile& tile : renderTiles) {
-                const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
+                const LayerRenderData* renderData = tile.getLayerRenderData(*baseImpl);
                 if (!renderData) {
                     continue;
                 }
                 auto& bucket = static_cast<FillExtrusionBucket&>(*renderData->bucket);
-
-                auto& geometryTile = static_cast<GeometryTile&>(tile.tile);
-                optional<ImagePosition> patternPosA = geometryTile.getPattern(fillPatternValue.from);
-                optional<ImagePosition> patternPosB = geometryTile.getPattern(fillPatternValue.to);
+                optional<ImagePosition> patternPosA = tile.getPattern(fillPatternValue.from);
+                optional<ImagePosition> patternPosB = tile.getPattern(fillPatternValue.to);
 
                 draw(
                     parameters.programs.getFillExtrusionLayerPrograms().fillExtrusionPattern,
@@ -181,7 +179,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
                         tile.translatedClipMatrix(evaluated.get<FillExtrusionTranslate>(),
                                                   evaluated.get<FillExtrusionTranslateAnchor>(),
                                                   parameters.state),
-                        geometryTile.iconAtlasTexture->size,
+                        tile.getIconAtlasTexture()->size,
                         crossfade,
                         tile.id,
                         parameters.state,
@@ -193,7 +191,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
                     patternPosA,
                     patternPosB,
                     FillExtrusionPatternProgram::TextureBindings{
-                        textures::image::Value{ geometryTile.iconAtlasTexture->getResource(), gfx::TextureFilterType::Linear },
+                        textures::image::Value{ tile.getIconAtlasTexture()->getResource(), gfx::TextureFilterType::Linear },
                     }
                 );
             }

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -179,7 +179,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
                         tile.translatedClipMatrix(evaluated.get<FillExtrusionTranslate>(),
                                                   evaluated.get<FillExtrusionTranslateAnchor>(),
                                                   parameters.state),
-                        tile.getIconAtlasTexture()->size,
+                        tile.getIconAtlasTexture().size,
                         crossfade,
                         tile.id,
                         parameters.state,
@@ -191,7 +191,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
                     patternPosA,
                     patternPosB,
                     FillExtrusionPatternProgram::TextureBindings{
-                        textures::image::Value{ tile.getIconAtlasTexture()->getResource(), gfx::TextureFilterType::Linear },
+                        textures::image::Value{ tile.getIconAtlasTexture().getResource(), gfx::TextureFilterType::Linear },
                     }
                 );
             }

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -190,7 +190,7 @@ void RenderFillLayer::render(PaintParameters& parameters) {
                                               evaluated.get<FillTranslateAnchor>(),
                                               parameters.state),
                         parameters.backend.getDefaultRenderable().getSize(),
-                        tile.getIconAtlasTexture()->size,
+                        tile.getIconAtlasTexture().size,
                         crossfade,
                         tile.id,
                         parameters.state,
@@ -232,7 +232,7 @@ void RenderFillLayer::render(PaintParameters& parameters) {
                      *bucket.triangleIndexBuffer,
                      bucket.triangleSegments,
                      FillPatternProgram::TextureBindings{
-                         textures::image::Value{ tile.getIconAtlasTexture()->getResource(), gfx::TextureFilterType::Linear },
+                         textures::image::Value{ tile.getIconAtlasTexture().getResource(), gfx::TextureFilterType::Linear },
                      });
             }
             if (evaluated.get<FillAntialias>() && unevaluated.get<FillOutlineColor>().isUndefined()) {
@@ -242,7 +242,7 @@ void RenderFillLayer::render(PaintParameters& parameters) {
                      *bucket.lineIndexBuffer,
                      bucket.lineSegments,
                      FillOutlinePatternProgram::TextureBindings{
-                         textures::image::Value{ tile.getIconAtlasTexture()->getResource(), gfx::TextureFilterType::Linear },
+                         textures::image::Value{ tile.getIconAtlasTexture().getResource(), gfx::TextureFilterType::Linear },
                      });
             }
         }

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -76,7 +76,7 @@ void RenderFillLayer::render(PaintParameters& parameters) {
     if (unevaluated.get<FillPattern>().isUndefined()) {
         parameters.renderTileClippingMasks(renderTiles);
         for (const RenderTile& tile : renderTiles) {
-            const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
+            const LayerRenderData* renderData = tile.getLayerRenderData(*baseImpl);
             if (!renderData) {
                 continue;
             }
@@ -163,7 +163,7 @@ void RenderFillLayer::render(PaintParameters& parameters) {
         parameters.renderTileClippingMasks(renderTiles);
 
         for (const RenderTile& tile : renderTiles) {
-            const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
+            const LayerRenderData* renderData = tile.getLayerRenderData(*baseImpl);
             if (!renderData) {
                 continue;
             }
@@ -172,9 +172,8 @@ void RenderFillLayer::render(PaintParameters& parameters) {
             const auto& crossfade = getCrossfade<FillLayerProperties>(renderData->layerProperties);
 
             const auto& fillPatternValue = evaluated.get<FillPattern>().constantOr(Faded<std::basic_string<char>>{"", ""});
-            auto& geometryTile = static_cast<GeometryTile&>(tile.tile);
-            optional<ImagePosition> patternPosA = geometryTile.getPattern(fillPatternValue.from);
-            optional<ImagePosition> patternPosB = geometryTile.getPattern(fillPatternValue.to);
+            optional<ImagePosition> patternPosA = tile.getPattern(fillPatternValue.from);
+            optional<ImagePosition> patternPosB = tile.getPattern(fillPatternValue.to);
 
             auto draw = [&] (auto& programInstance,
                              const auto& drawMode,
@@ -191,7 +190,7 @@ void RenderFillLayer::render(PaintParameters& parameters) {
                                               evaluated.get<FillTranslateAnchor>(),
                                               parameters.state),
                         parameters.backend.getDefaultRenderable().getSize(),
-                        geometryTile.iconAtlasTexture->size,
+                        tile.getIconAtlasTexture()->size,
                         crossfade,
                         tile.id,
                         parameters.state,
@@ -233,7 +232,7 @@ void RenderFillLayer::render(PaintParameters& parameters) {
                      *bucket.triangleIndexBuffer,
                      bucket.triangleSegments,
                      FillPatternProgram::TextureBindings{
-                         textures::image::Value{ geometryTile.iconAtlasTexture->getResource(), gfx::TextureFilterType::Linear },
+                         textures::image::Value{ tile.getIconAtlasTexture()->getResource(), gfx::TextureFilterType::Linear },
                      });
             }
             if (evaluated.get<FillAntialias>() && unevaluated.get<FillOutlineColor>().isUndefined()) {
@@ -243,7 +242,7 @@ void RenderFillLayer::render(PaintParameters& parameters) {
                      *bucket.lineIndexBuffer,
                      bucket.lineSegments,
                      FillOutlinePatternProgram::TextureBindings{
-                         textures::image::Value{ geometryTile.iconAtlasTexture->getResource(), gfx::TextureFilterType::Linear },
+                         textures::image::Value{ tile.getIconAtlasTexture()->getResource(), gfx::TextureFilterType::Linear },
                      });
             }
         }

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -94,7 +94,7 @@ void RenderHeatmapLayer::render(PaintParameters& parameters) {
             "heatmap texture", { *renderTexture, Color{ 0.0f, 0.0f, 0.0f, 1.0f }, {}, {} });
 
         for (const RenderTile& tile : renderTiles) {
-            const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
+            const LayerRenderData* renderData = tile.getLayerRenderData(*baseImpl);
             if (!renderData) {
                 continue;
             }

--- a/src/mbgl/renderer/layers/render_hillshade_layer.cpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.cpp
@@ -129,11 +129,11 @@ void RenderHillshadeLayer::render(PaintParameters& parameters) {
     matrix::translate(mat, mat, 0, -util::EXTENT, 0);
 
     for (const RenderTile& tile : renderTiles) {
-        auto bucket_ = tile.tile.getBucket<HillshadeBucket>(*baseImpl);
+        auto* bucket_ = tile.getBucket(*baseImpl);
         if (!bucket_) {
             continue;
         }
-        HillshadeBucket& bucket = *bucket_;
+        auto& bucket = static_cast<HillshadeBucket&>(*bucket_);
 
         if (!bucket.hasData()){
             continue;

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -61,7 +61,7 @@ bool RenderLineLayer::hasCrossfade() const {
 
 void RenderLineLayer::upload(gfx::UploadPass& uploadPass, UploadParameters& uploadParameters) {
     for (const RenderTile& tile : renderTiles) {
-        const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
+        const LayerRenderData* renderData = tile.getLayerRenderData(*baseImpl);
         if (!renderData) {
             continue;
         }
@@ -77,11 +77,10 @@ void RenderLineLayer::upload(gfx::UploadPass& uploadPass, UploadParameters& uplo
 
         } else if (!unevaluated.get<LinePattern>().isUndefined()) {
             const auto& linePatternValue = evaluated.get<LinePattern>().constantOr(Faded<std::basic_string<char>>{ "", ""});
-            auto& geometryTile = static_cast<GeometryTile&>(tile.tile);
 
             // Ensures that the pattern gets added and uplodated to the atlas.
-            geometryTile.getPattern(linePatternValue.from);
-            geometryTile.getPattern(linePatternValue.to);
+            tile.getPattern(linePatternValue.from);
+            tile.getPattern(linePatternValue.to);
 
         } else if (!unevaluated.get<LineGradient>().getValue().isUndefined()) {
             if (!colorRampTexture) {
@@ -99,7 +98,7 @@ void RenderLineLayer::render(PaintParameters& parameters) {
     parameters.renderTileClippingMasks(renderTiles);
 
     for (const RenderTile& tile : renderTiles) {
-        const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
+        const LayerRenderData* renderData = tile.getLayerRenderData(*baseImpl);
         if (!renderData) {
             continue;
         }
@@ -171,11 +170,10 @@ void RenderLineLayer::render(PaintParameters& parameters) {
 
         } else if (!unevaluated.get<LinePattern>().isUndefined()) {
             const auto& linePatternValue = evaluated.get<LinePattern>().constantOr(Faded<std::basic_string<char>>{ "", ""});
-            auto& geometryTile = static_cast<GeometryTile&>(tile.tile);
-            const Size texsize = geometryTile.iconAtlasTexture->size;
+            const Size& texsize = tile.getIconAtlasTexture()->size;
 
-            optional<ImagePosition> posA = geometryTile.getPattern(linePatternValue.from);
-            optional<ImagePosition> posB = geometryTile.getPattern(linePatternValue.to);
+            optional<ImagePosition> posA = tile.getPattern(linePatternValue.from);
+            optional<ImagePosition> posB = tile.getPattern(linePatternValue.to);
 
             draw(parameters.programs.getLineLayerPrograms().linePattern,
                  LinePatternProgram::layoutUniformValues(
@@ -189,7 +187,7 @@ void RenderLineLayer::render(PaintParameters& parameters) {
                      posA,
                      posB,
                      LinePatternProgram::TextureBindings{
-                         textures::image::Value{ geometryTile.iconAtlasTexture->getResource(), gfx::TextureFilterType::Linear },
+                         textures::image::Value{ tile.getIconAtlasTexture()->getResource(), gfx::TextureFilterType::Linear },
                      });
         } else if (!unevaluated.get<LineGradient>().getValue().isUndefined()) {
             assert(colorRampTexture);

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -170,7 +170,7 @@ void RenderLineLayer::render(PaintParameters& parameters) {
 
         } else if (!unevaluated.get<LinePattern>().isUndefined()) {
             const auto& linePatternValue = evaluated.get<LinePattern>().constantOr(Faded<std::basic_string<char>>{ "", ""});
-            const Size& texsize = tile.getIconAtlasTexture()->size;
+            const Size& texsize = tile.getIconAtlasTexture().size;
 
             optional<ImagePosition> posA = tile.getPattern(linePatternValue.from);
             optional<ImagePosition> posB = tile.getPattern(linePatternValue.to);
@@ -187,7 +187,7 @@ void RenderLineLayer::render(PaintParameters& parameters) {
                      posA,
                      posB,
                      LinePatternProgram::TextureBindings{
-                         textures::image::Value{ tile.getIconAtlasTexture()->getResource(), gfx::TextureFilterType::Linear },
+                         textures::image::Value{ tile.getIconAtlasTexture().getResource(), gfx::TextureFilterType::Linear },
                      });
         } else if (!unevaluated.get<LineGradient>().getValue().isUndefined()) {
             assert(colorRampTexture);

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -159,11 +159,11 @@ void RenderRasterLayer::render(PaintParameters& parameters) {
         }
     } else {
         for (const RenderTile& tile : renderTiles) {
-            auto bucket_ = tile.tile.getBucket<RasterBucket>(*baseImpl);
+            auto* bucket_ = tile.getBucket(*baseImpl);
             if (!bucket_) {
                 continue;
             }
-            RasterBucket& bucket = *bucket_;
+            auto& bucket = static_cast<RasterBucket&>(*bucket_);
 
             if (!bucket.hasData())
                 continue;

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -123,14 +123,14 @@ void drawIcon(const DrawFn& draw,
     const bool iconScaled = layout.get<IconSize>().constantOr(1.0) != 1.0 || bucket.iconsNeedLinear;
     const bool iconTransformed = values.rotationAlignment == AlignmentType::Map || parameters.state.getPitch() != 0;
 
-    const gfx::TextureBinding textureBinding{ tile.getIconAtlasTexture()->getResource(),
+    const gfx::TextureBinding textureBinding{ tile.getIconAtlasTexture().getResource(),
                                             bucket.sdfIcons ||
                                                     parameters.state.isChanging() ||
                                                     iconScaled || iconTransformed
                                                 ? gfx::TextureFilterType::Linear
                                                 : gfx::TextureFilterType::Nearest };
 
-    const Size& iconSize = tile.getIconAtlasTexture()->size;
+    const Size& iconSize = tile.getIconAtlasTexture().size;
 
     if (bucket.sdfIcons) {
         if (values.hasHalo) {
@@ -189,7 +189,7 @@ void drawText(const DrawFn& draw,
     const auto& evaluated = getEvaluated<SymbolLayerProperties>(renderData.layerProperties);
     const auto& layout = bucket.layout;
 
-    const gfx::TextureBinding textureBinding{ tile.getGlyphAtlasTexture()->getResource(),
+    const gfx::TextureBinding textureBinding{ tile.getGlyphAtlasTexture().getResource(),
                                               gfx::TextureFilterType::Linear };
 
     auto values = textPropertyValues(evaluated, layout);
@@ -198,7 +198,7 @@ void drawText(const DrawFn& draw,
     const bool alongLine = layout.get<SymbolPlacement>() != SymbolPlacementType::Point &&
         layout.get<TextRotationAlignment>() == AlignmentType::Map;
 
-    const Size& texsize = tile.getGlyphAtlasTexture()->size;
+    const Size& texsize = tile.getGlyphAtlasTexture().size;
 
     if (values.hasHalo) {
         draw(parameters.programs.getSymbolLayerPrograms().symbolGlyph,

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -521,12 +521,8 @@ void RenderSymbolLayer::prepare(const LayerPrepareParameters& params) {
     for (RenderTile& renderTile : renderTiles) {
         auto* bucket = static_cast<SymbolBucket*>(renderTile.getBucket(*baseImpl));
         if (bucket && bucket->bucketLeaderID == getID()) {
-            auto& layout = bucket->layout;
-            bool pitchWithMap = layout.get<style::TextPitchAlignment>() == style::AlignmentType::Map;
-            bool rotateWithMap = layout.get<style::TextRotationAlignment>() == style::AlignmentType::Map;
-
             // Only place this layer if it's the "group leader" for the bucket
-            placementData.push_back({*bucket, renderTile, pitchWithMap, rotateWithMap});
+            placementData.push_back({*bucket, renderTile});
         }
     }
 }

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -57,13 +57,11 @@ optional<Color> RenderLayer::getSolidBackground() const {
 RenderLayer::RenderTiles RenderLayer::filterRenderTiles(RenderTiles tiles) const {
     RenderTiles filtered;
 
-    for (auto& tileRef : tiles) {
-        auto& tile = tileRef.get().tile;
-        assert(tile.isRenderable());
+    for (RenderTile& tile : tiles) {
         if (tile.holdForFade()) {
             continue;
         }
-        filtered.emplace_back(tileRef);
+        filtered.emplace_back(tile);
     }
     return filtered;
 }

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -18,7 +18,6 @@ class PaintParameters;
 class RenderSource;
 class RenderTile;
 class TransformState;
-class GeometryTile;
 
 class LayerRenderData {
 public:
@@ -30,8 +29,6 @@ class LayerPlacementData {
 public:
     std::reference_wrapper<Bucket> bucket;
     std::reference_wrapper<RenderTile> tile;
-    bool pitchWithMap;
-    bool rotateWithMap;
 };
 
 class LayerPrepareParameters {

--- a/src/mbgl/renderer/render_source.hpp
+++ b/src/mbgl/renderer/render_source.hpp
@@ -71,7 +71,8 @@ public:
     virtual void upload(gfx::UploadPass&) = 0;
     virtual void prepare(const SourcePrepareParameters&) = 0;
     virtual void finishRender(PaintParameters&) = 0;
-
+    virtual void updateFadingTiles() = 0;
+    virtual bool hasFadingTiles() const = 0;
     // Returns a list of RenderTiles, sorted by tile id.
     virtual std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() = 0;
 

--- a/src/mbgl/renderer/render_tile.cpp
+++ b/src/mbgl/renderer/render_tile.cpp
@@ -77,14 +77,16 @@ optional<ImagePosition> RenderTile::getPattern(const std::string& pattern) const
     return static_cast<const GeometryTile&>(tile).getPattern(pattern);
 }
 
-const optional<gfx::Texture>& RenderTile::getGlyphAtlasTexture() const {
+const gfx::Texture& RenderTile::getGlyphAtlasTexture() const {
     assert(tile.kind == Tile::Kind::Geometry);
-    return static_cast<const GeometryTile&>(tile).glyphAtlasTexture;
+    assert(static_cast<const GeometryTile&>(tile).glyphAtlasTexture);
+    return *(static_cast<const GeometryTile&>(tile).glyphAtlasTexture);
 }
 
-const optional<gfx::Texture>& RenderTile::getIconAtlasTexture() const {
+const gfx::Texture& RenderTile::getIconAtlasTexture() const {
     assert(tile.kind == Tile::Kind::Geometry);
-    return static_cast<const GeometryTile&>(tile).iconAtlasTexture;
+    assert(static_cast<const GeometryTile&>(tile).iconAtlasTexture);
+    return *(static_cast<const GeometryTile&>(tile).iconAtlasTexture);
 }
 
 std::shared_ptr<FeatureIndex> RenderTile::getFeatureIndex() const {

--- a/src/mbgl/renderer/render_tile.cpp
+++ b/src/mbgl/renderer/render_tile.cpp
@@ -8,6 +8,7 @@
 #include <mbgl/map/transform_state.hpp>
 #include <mbgl/gfx/cull_face_mode.hpp>
 #include <mbgl/tile/tile.hpp>
+#include <mbgl/tile/geometry_tile.hpp>
 #include <mbgl/util/math.hpp>
 
 namespace mbgl {
@@ -58,6 +59,37 @@ mat4 RenderTile::translatedClipMatrix(const std::array<float, 2>& translation,
                                       TranslateAnchorType anchor,
                                       const TransformState& state) const {
     return translateVtxMatrix(nearClippedMatrix, translation, anchor, state, false);
+}
+
+const OverscaledTileID& RenderTile::getOverscaledTileID() const { return tile.id; }
+bool RenderTile::holdForFade() const { return tile.holdForFade(); }
+
+Bucket* RenderTile::getBucket(const style::Layer::Impl& impl) const {
+    return tile.getBucket(impl);
+}
+
+const LayerRenderData* RenderTile::getLayerRenderData(const style::Layer::Impl& impl) const {
+    return tile.getLayerRenderData(impl);
+}
+
+optional<ImagePosition> RenderTile::getPattern(const std::string& pattern) const {
+    assert(tile.kind == Tile::Kind::Geometry);
+    return static_cast<const GeometryTile&>(tile).getPattern(pattern);
+}
+
+const optional<gfx::Texture>& RenderTile::getGlyphAtlasTexture() const {
+    assert(tile.kind == Tile::Kind::Geometry);
+    return static_cast<const GeometryTile&>(tile).glyphAtlasTexture;
+}
+
+const optional<gfx::Texture>& RenderTile::getIconAtlasTexture() const {
+    assert(tile.kind == Tile::Kind::Geometry);
+    return static_cast<const GeometryTile&>(tile).iconAtlasTexture;
+}
+
+std::shared_ptr<FeatureIndex> RenderTile::getFeatureIndex() const {
+    assert(tile.kind == Tile::Kind::Geometry);
+    return static_cast<const GeometryTile&>(tile).getFeatureIndex();
 }
 
 void RenderTile::setMask(TileMask&& mask) {

--- a/src/mbgl/renderer/render_tile.hpp
+++ b/src/mbgl/renderer/render_tile.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
 #include <mbgl/map/mode.hpp>
+#include <mbgl/gfx/texture.hpp>
 #include <mbgl/tile/tile_id.hpp>
 #include <mbgl/util/mat4.hpp>
+#include <mbgl/style/layer_impl.hpp>
 #include <mbgl/style/types.hpp>
+#include <mbgl/renderer/image_atlas.hpp>
 #include <mbgl/renderer/tile_mask.hpp>
 
 #include <array>
@@ -15,11 +18,14 @@ namespace gfx {
 class UploadPass;
 } // namespace gfx
 
+class Bucket;
+class LayerRenderData;
 class Tile;
 class TransformState;
 class PaintParameters;
 class DebugBucket;
 class SourcePrepareParameters;
+class FeatureIndex;
 
 class RenderTile final {
 public:
@@ -31,7 +37,6 @@ public:
     RenderTile& operator=(RenderTile&&) = default;
 
     UnwrappedTileID id;
-    Tile& tile;
     mat4 matrix;
     mat4 nearClippedMatrix;
     bool used = false;
@@ -46,6 +51,16 @@ public:
                               style::TranslateAnchorType anchor,
                               const TransformState&) const;
 
+    const OverscaledTileID& getOverscaledTileID() const;
+    bool holdForFade() const;
+
+    Bucket* getBucket(const style::Layer::Impl&) const;
+    const LayerRenderData* getLayerRenderData(const style::Layer::Impl&) const;
+    optional<ImagePosition> getPattern(const std::string& pattern) const;
+    const optional<gfx::Texture>& getGlyphAtlasTexture() const;
+    const optional<gfx::Texture>& getIconAtlasTexture() const;
+    std::shared_ptr<FeatureIndex> getFeatureIndex() const;
+
     void setMask(TileMask&&);
     void upload(gfx::UploadPass&);
     void prepare(const SourcePrepareParameters&);
@@ -56,6 +71,9 @@ public:
                             style::TranslateAnchorType anchor,
                             const TransformState& state,
                             const bool inViewportPixelUnits) const;
+private:
+    friend class TilePyramid;
+    Tile& tile;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/render_tile.hpp
+++ b/src/mbgl/renderer/render_tile.hpp
@@ -57,8 +57,8 @@ public:
     Bucket* getBucket(const style::Layer::Impl&) const;
     const LayerRenderData* getLayerRenderData(const style::Layer::Impl&) const;
     optional<ImagePosition> getPattern(const std::string& pattern) const;
-    const optional<gfx::Texture>& getGlyphAtlasTexture() const;
-    const optional<gfx::Texture>& getIconAtlasTexture() const;
+    const gfx::Texture& getGlyphAtlasTexture() const;
+    const gfx::Texture& getIconAtlasTexture() const;
     std::shared_ptr<FeatureIndex> getFeatureIndex() const;
 
     void setMask(TileMask&&);

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -340,7 +340,9 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
         if (placementChanged) {
             placement->commit(updateParameters.timePoint);
             crossTileSymbolIndex.pruneUnusedLayers(usedSymbolLayers);
-            updateFadingTiles();
+            for (const auto& entry : renderSources) {
+                entry.second->updateFadingTiles();
+            }
         } else {
             placement->setStale();
         }
@@ -699,25 +701,14 @@ bool Renderer::Impl::hasTransitions(TimePoint timePoint) const {
     if (placement->hasTransitions(timePoint)) {
         return true;
     }
-    
-    if (fadingTiles) {
-        return true;
+
+    for (const auto& entry : renderSources) {
+        if (entry.second->hasFadingTiles()) {
+            return true;
+        }
     }
 
     return false;
-}
-
-void Renderer::Impl::updateFadingTiles() {
-    fadingTiles = false;
-    for (auto& source : renderSources) {
-        for (auto& renderTile : source.second->getRenderTiles()) {
-            Tile& tile = renderTile.get().tile;
-            if (tile.holdForFade()) {
-                fadingTiles = true;
-                tile.performedFadePlacement();
-            }
-        }
-    }
 }
 
 bool Renderer::Impl::isLoaded() const {

--- a/src/mbgl/renderer/renderer_impl.hpp
+++ b/src/mbgl/renderer/renderer_impl.hpp
@@ -93,8 +93,6 @@ private:
     void onStyleImageMissing(const std::string&, std::function<void()>) override;
     void onRemoveUnusedStyleImages(const std::vector<std::string>&) final;
 
-    void updateFadingTiles();
-
     friend class Renderer;
 
     gfx::RendererBackend& backend;
@@ -132,7 +130,6 @@ private:
     std::unique_ptr<Placement> placement;
 
     bool contextLost = false;
-    bool fadingTiles = false;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
+++ b/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
@@ -59,6 +59,14 @@ void RenderCustomGeometrySource::finishRender(PaintParameters& parameters) {
     tilePyramid.finishRender(parameters);
 }
 
+void RenderCustomGeometrySource::updateFadingTiles() {
+    tilePyramid.updateFadingTiles();
+}
+
+bool RenderCustomGeometrySource::hasFadingTiles() const {
+    return tilePyramid.hasFadingTiles();
+}
+
 std::vector<std::reference_wrapper<RenderTile>> RenderCustomGeometrySource::getRenderTiles() {
     return tilePyramid.getRenderTiles();
 }

--- a/src/mbgl/renderer/sources/render_custom_geometry_source.hpp
+++ b/src/mbgl/renderer/sources/render_custom_geometry_source.hpp
@@ -21,6 +21,8 @@ public:
     void upload(gfx::UploadPass&) final;
     void prepare(const SourcePrepareParameters&) final;
     void finishRender(PaintParameters&) final;
+    void updateFadingTiles() final;
+    bool hasFadingTiles() const final;
 
     std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() final;
 

--- a/src/mbgl/renderer/sources/render_geojson_source.cpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.cpp
@@ -135,6 +135,14 @@ void RenderGeoJSONSource::finishRender(PaintParameters& parameters) {
     tilePyramid.finishRender(parameters);
 }
 
+void RenderGeoJSONSource::updateFadingTiles() {
+    tilePyramid.updateFadingTiles();
+}
+
+bool RenderGeoJSONSource::hasFadingTiles() const {
+    return tilePyramid.hasFadingTiles();
+}
+
 std::vector<std::reference_wrapper<RenderTile>> RenderGeoJSONSource::getRenderTiles() {
     return tilePyramid.getRenderTiles();
 }

--- a/src/mbgl/renderer/sources/render_geojson_source.hpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.hpp
@@ -26,6 +26,8 @@ public:
     void upload(gfx::UploadPass&) final;
     void prepare(const SourcePrepareParameters&) final;
     void finishRender(PaintParameters&) final;
+    void updateFadingTiles() final;
+    bool hasFadingTiles() const final;
 
     std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() final;
 

--- a/src/mbgl/renderer/sources/render_image_source.hpp
+++ b/src/mbgl/renderer/sources/render_image_source.hpp
@@ -24,6 +24,8 @@ public:
     void upload(gfx::UploadPass&) final;
     void prepare(const SourcePrepareParameters&) final;
     void finishRender(PaintParameters&) final;
+    void updateFadingTiles() final {}
+    bool hasFadingTiles() const final { return false; }
 
     void update(Immutable<style::Source::Impl>,
                 const std::vector<Immutable<style::LayerProperties>>&,

--- a/src/mbgl/renderer/sources/render_raster_dem_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.cpp
@@ -139,6 +139,14 @@ void RenderRasterDEMSource::finishRender(PaintParameters& parameters) {
     tilePyramid.finishRender(parameters);
 }
 
+void RenderRasterDEMSource::updateFadingTiles() {
+    tilePyramid.updateFadingTiles();
+}
+
+bool RenderRasterDEMSource::hasFadingTiles() const {
+    return tilePyramid.hasFadingTiles();
+}
+
 std::vector<std::reference_wrapper<RenderTile>> RenderRasterDEMSource::getRenderTiles() {
     return tilePyramid.getRenderTiles();
 }

--- a/src/mbgl/renderer/sources/render_raster_dem_source.hpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.hpp
@@ -21,6 +21,8 @@ public:
     void upload(gfx::UploadPass&) final;
     void prepare(const SourcePrepareParameters&) final;
     void finishRender(PaintParameters&) final;
+    void updateFadingTiles() final;
+    bool hasFadingTiles() const final;
 
     std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() final;
 

--- a/src/mbgl/renderer/sources/render_raster_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_source.cpp
@@ -70,6 +70,14 @@ void RenderRasterSource::finishRender(PaintParameters& parameters) {
     tilePyramid.finishRender(parameters);
 }
 
+void RenderRasterSource::updateFadingTiles() {
+    tilePyramid.updateFadingTiles();
+}
+
+bool RenderRasterSource::hasFadingTiles() const {
+    return tilePyramid.hasFadingTiles();
+}
+
 std::vector<std::reference_wrapper<RenderTile>> RenderRasterSource::getRenderTiles() {
     return tilePyramid.getRenderTiles();
 }

--- a/src/mbgl/renderer/sources/render_raster_source.hpp
+++ b/src/mbgl/renderer/sources/render_raster_source.hpp
@@ -21,6 +21,8 @@ public:
     void upload(gfx::UploadPass&) final;
     void prepare(const SourcePrepareParameters&) final;
     void finishRender(PaintParameters&) final;
+    void updateFadingTiles() final;
+    bool hasFadingTiles() const final;
 
     std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() final;
 

--- a/src/mbgl/renderer/sources/render_vector_source.cpp
+++ b/src/mbgl/renderer/sources/render_vector_source.cpp
@@ -69,6 +69,14 @@ void RenderVectorSource::finishRender(PaintParameters& parameters) {
     tilePyramid.finishRender(parameters);
 }
 
+void RenderVectorSource::updateFadingTiles() {
+    tilePyramid.updateFadingTiles();
+}
+
+bool RenderVectorSource::hasFadingTiles() const {
+    return tilePyramid.hasFadingTiles();
+}
+
 std::vector<std::reference_wrapper<RenderTile>> RenderVectorSource::getRenderTiles() {
     return tilePyramid.getRenderTiles();
 }

--- a/src/mbgl/renderer/sources/render_vector_source.hpp
+++ b/src/mbgl/renderer/sources/render_vector_source.hpp
@@ -21,6 +21,8 @@ public:
     void upload(gfx::UploadPass&) final;
     void prepare(const SourcePrepareParameters&) final;
     void finishRender(PaintParameters&) final;
+    void updateFadingTiles() final;
+    bool hasFadingTiles() const final;
 
     std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() final;
 

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -242,12 +242,15 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
         pair.second->setShowCollisionBoxes(parameters.debugOptions & MapDebugOptions::Collision);
     }
 
+    fadingTiles = false;
+
     // Initialize render tiles fields and update the tile contained layer render data.
     for (RenderTile& renderTile : renderTiles) {
         Tile& tile = renderTile.tile;
         assert(tile.isRenderable());
 
         const bool holdForFade = tile.holdForFade();
+        fadingTiles = (fadingTiles || holdForFade);
         for (const auto& layerProperties : layers) {
             const auto* typeInfo = layerProperties->baseImpl->getTypeInfo();
             if (holdForFade && typeInfo->fadingTiles == LayerTypeInfo::FadingTiles::NotRequired) {
@@ -399,6 +402,15 @@ void TilePyramid::addRenderTile(const UnwrappedTileID& tileID, Tile& tile) {
     auto it = std::lower_bound(renderTiles.begin(), renderTiles.end(), tileID,
         [](const RenderTile& a, const UnwrappedTileID& id) { return a.id < id; });
     renderTiles.emplace(it, tileID, tile);
+}
+
+void TilePyramid::updateFadingTiles() {
+    for (auto& renderTile : renderTiles) {
+        Tile& tile = renderTile.tile;
+        if (tile.holdForFade()) {
+            tile.performedFadePlacement();
+        }
+    }
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/tile_pyramid.hpp
+++ b/src/mbgl/renderer/tile_pyramid.hpp
@@ -71,6 +71,9 @@ public:
     const std::map<OverscaledTileID, std::unique_ptr<Tile>>& getTiles() const { return tiles; }
     void clearAll();
 
+    void updateFadingTiles();
+    bool hasFadingTiles() const { return fadingTiles; }
+
 private:
     void addRenderTile(const UnwrappedTileID& tileID, Tile& tile);
 
@@ -82,6 +85,8 @@ private:
     TileObserver* observer = nullptr;
 
     float prevLng = 0;
+
+    bool fadingTiles = false;
 };
 
 } // namespace mbgl

--- a/src/mbgl/text/cross_tile_symbol_index.cpp
+++ b/src/mbgl/text/cross_tile_symbol_index.cpp
@@ -174,7 +174,7 @@ bool CrossTileSymbolIndex::addLayer(const RenderLayer& layer, float lng) {
     for (const auto& item : layer.getPlacementData()) {
         RenderTile& renderTile = item.tile;
         Bucket& bucket = item.bucket;
-        auto result = bucket.registerAtCrossTileIndex(layerIndex, renderTile.tile.id, maxCrossTileID);
+        auto result = bucket.registerAtCrossTileIndex(layerIndex, renderTile.getOverscaledTileID(), maxCrossTileID);
         assert(result.first != 0u);
         symbolBucketsChanged = symbolBucketsChanged || result.second;
         currentBucketIDs.insert(result.first);

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -97,7 +97,7 @@ Point<float> calculateVariableLayoutOffset(style::SymbolAnchorType anchor, float
 }
 } // namespace
 
-void Placement::placeLayerBucket(
+void Placement::placeBucket(
         SymbolBucket& bucket,
         const BucketPlacementParameters& params,
         std::set<uint32_t>& seenCrossTileIDs) {

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -114,7 +114,7 @@ public:
     const RetainedQueryData& getQueryData(uint32_t bucketInstanceId) const;
 private:
     friend SymbolBucket;
-    void placeLayerBucket(
+    void placeBucket(
             SymbolBucket&,
             const BucketPlacementParameters&,
             std::set<uint32_t>& seenCrossTileIDs);

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -90,14 +90,10 @@ private:
 
 class BucketPlacementParameters {
 public:
-    const mat4& posMatrix;
-    const mat4& textLabelPlaneMatrix;
-    const mat4& iconLabelPlaneMatrix;
-    float scale;
-    float pixelRatio;
+    const RenderTile& tile;
+    const mat4& projMatrix;
+    std::string sourceId;
     bool showCollisionBoxes;
-    bool holdingForFade;
-    const CollisionGroups::CollisionGroup& collisionGroup;
 };
     
 class Placement {

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -168,12 +168,12 @@ void GeometryTile::getImages(ImageRequestPair pair) {
     imageManager.getImages(*this, std::move(pair));
 }
 
-const optional<ImagePosition> GeometryTile::getPattern(const std::string& pattern) {
+const optional<ImagePosition> GeometryTile::getPattern(const std::string& pattern) const {
     auto it = iconAtlas.patternPositions.find(pattern);
     if (it !=  iconAtlas.patternPositions.end()) {
         return it->second;
     }
-    return {};
+    return nullopt;
 }
 
 void GeometryTile::upload(gfx::UploadPass& uploadPass) {

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -87,7 +87,7 @@ public:
     void markRenderedIdeal() override;
     void markRenderedPreviously() override;
     void performedFadePlacement() override;
-    const optional<ImagePosition> getPattern(const std::string& pattern);
+    const optional<ImagePosition> getPattern(const std::string& pattern) const;
     const std::shared_ptr<FeatureIndex> getFeatureIndex() const { return latestFeatureIndex; }
     
     const std::string sourceID;

--- a/src/mbgl/tile/tile.hpp
+++ b/src/mbgl/tile/tile.hpp
@@ -62,12 +62,6 @@ public:
     // Returns `true` if the corresponding render layer data is present in this tile (and i.e. it
     // was succesfully updated); returns `false` otherwise.
     virtual bool updateLayerProperties(const Immutable<style::LayerProperties>&) { return true; }
-
-    template <class T>
-    T* getBucket(const style::Layer::Impl& layer) const {
-        return static_cast<T*>(getBucket(layer));
-    }
-
     virtual void setShowCollisionBoxes(const bool) {}
     virtual void setLayers(const std::vector<Immutable<style::LayerProperties>>&) {}
     virtual void setMask(TileMask&&) {}


### PR DESCRIPTION
`RenderTile` and `Tile` will be split when orchestration moves to a separate thread. This PR
* improves encapsulation of Tiles management: now performed within `TilePyramid`
* improves encapsulation of symbol bucket placement, and simplifies `LayerPlacementData` and `Bucket` interfaces
* fixes wrong initialization of icon projection matrix in placement ( regression introduced with https://github.com/mapbox/mapbox-gl-native/commit/44fd6dcf7c0ef477a8108f878834cadf01a625f2#diff-6989ce9a7567f8da5dd71c1ca97c7491L114 )

Tag #14638