### PR TITLE
[ios] Update Raster Tiles API name and link

### DIFF
--- a/platform/darwin/src/MGLRasterTileSource.h
+++ b/platform/darwin/src/MGLRasterTileSource.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
  integers.
 
  The default value for this option is 512. Version 4 of the
- <a href="https://www.mapbox.com/api-documentation/maps/#maps">Mapbox Maps API</a>
+ <a href="https://docs.mapbox.com/api/maps/#raster-tiles">Mapbox Raster Tiles API</a>
  requires a value of 256, as do many third-party tile servers, so consult your
  provider’s documentation for the correct value.
 

--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
  as of the date on which this SDK was published. You can use this constant to
  ascertain the style used by `MGLMapView` and `MGLTilePyramidOfflineRegion` when
  no style URL is specified. Consult the
- <a href="https://www.mapbox.com/api-documentation/maps/#styles">Mapbox Styles API documentation</a>
+ <a href="https://docs.mapbox.com/api/maps/#styles">Mapbox Styles API documentation</a>
  for the most up-to-date style versioning information.
 
  @warning The value of this constant may change in a future release of the SDK.


### PR DESCRIPTION
- Update ~Mapbox Maps API~ to Mapbox Raster Tiles API, per the recent renaming.
- Also update another link to avoid a redirect.

/cc @HeyStenson @1ec5 