### PR TITLE
[ios, macos] Optionally include a developer xcconfig file in generated config.xcconfig file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ xcuserdata
 /node_modules
 /platform/ios/benchmark/assets/glyphs/DIN*
 /platform/ios/benchmark/assets/tiles/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6
+/platform/darwin/developer.xcconfig
 **/token
 /platform/macos/macos.xcworkspace/xcshareddata/macos.xcscmblueprint
 /platform/ios/ios.xcworkspace/xcshareddata/ios.xcscmblueprint

--- a/platform/ios/DEVELOPING.md
+++ b/platform/ios/DEVELOPING.md
@@ -140,6 +140,10 @@ To add an example code listing to the documentation for a class or class member:
 
 [SourceKitten](https://github.com/jpsim/SourceKitten/) is required and will be installed automatically using Homebrew.
 
+### Customizing compilation settings
+
+You can provide an optional and custom [`xcconfig`](https://help.apple.com/xcode/mac/current/#/dev745c5c974) file named `platform/darwin/developer.xcconfig` to set custom build options. This file is ignored by git. These custom settings apply to all configurations (`Debug`, `Release`, `RelWithDebInfo`), but do **not** apply to the core `mbgl` files. This mechanism allows you to try different compiler settings (for example when testing an Xcode beta).
+
 ## Testing
 
 `make ios-test` builds and runs unit tests of cross-platform code as well as the SDK.

--- a/platform/macos/DEVELOPING.md
+++ b/platform/macos/DEVELOPING.md
@@ -114,6 +114,10 @@ make darwin-update-examples
 
 [SourceKitten](https://github.com/jpsim/SourceKitten/) is required and will be installed automatically using Homebrew.
 
+### Customizing compilation settings
+
+You can provide an optional and custom [`xcconfig`](https://help.apple.com/xcode/mac/current/#/dev745c5c974) file named `platform/darwin/developer.xcconfig` to set custom build options. This file is ignored by git. These custom settings apply to all configurations (`Debug`, `Release`), but do **not** apply to the core `mbgl` files. This mechanism allows you to try different compiler settings (for example when testing an Xcode beta).
+
 ## Testing
 
 `make macos-test` builds and runs unit tests of cross-platform code as well as the SDK.

--- a/scripts/config.xcconfig.in
+++ b/scripts/config.xcconfig.in
@@ -7,3 +7,5 @@ mbgl_core_LINK_LIBRARIES = "$<TARGET_PROPERTY:mbgl-core,XCODE_ATTRIBUTE_XCCONFIG
 // mbgl-filesource
 mbgl_filesource_INCLUDE_DIRECTORIES = "$<JOIN:$<TARGET_PROPERTY:mbgl-filesource,INTERFACE_INCLUDE_DIRECTORIES>," ">"
 mbgl_filesource_LINK_LIBRARIES = "$<TARGET_PROPERTY:mbgl-filesource,XCODE_ATTRIBUTE_XCCONFIG_LINK_LIBRARIES>"
+
+#include? "../../platform/darwin/developer.xcconfig"


### PR DESCRIPTION
This allows developers to optionally set compiler flags without including for everyone.

This will allow us to experiment with different options locally (for example, `warnings-as-errors` as briefly discussed here: https://github.com/mapbox/mapbox-gl-native/pull/14453#issuecomment-486430908), before deciding whether to enable for all.

The `developer.xcconfig` file is gitignore'd and should remain so.
