### PR TITLE
Option to change the zoom rate. Decrease the default zoom rate by 35%

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
@@ -128,6 +128,11 @@ public class MapboxConstants {
   public static final float MAXIMUM_SCALE_FACTOR_CLAMP = 0.15f;
 
   /**
+   * Zoom value multiplier for scale gestures.
+   */
+  public static final float ZOOM_RATE = 0.65f;
+
+  /**
    * Fragment Argument Key for MapboxMapOptions
    */
   public static final String FRAG_ARG_MAPBOXMAPOPTIONS = "MapboxMapOptions";
@@ -146,6 +151,7 @@ public class MapboxConstants {
   public static final String STATE_TILT_ENABLED = "mapbox_tiltEnabled";
   public static final String STATE_DOUBLE_TAP_ENABLED = "mapbox_doubleTapEnabled";
   public static final String STATE_QUICK_ZOOM_ENABLED = "mapbox_quickZoom";
+  public static final String STATE_ZOOM_RATE = "mapbox_zoomRate";
   public static final String STATE_DEBUG_ACTIVE = "mapbox_debugActive";
   public static final String STATE_COMPASS_ENABLED = "mapbox_compassEnabled";
   public static final String STATE_COMPASS_GRAVITY = "mapbox_compassGravity";

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -11,13 +11,14 @@ import android.support.annotation.Nullable;
 import android.view.InputDevice;
 import android.view.MotionEvent;
 import android.view.animation.DecelerateInterpolator;
+
 import com.mapbox.android.gestures.AndroidGesturesManager;
 import com.mapbox.android.gestures.Constants;
+import com.mapbox.android.gestures.MoveGestureDetector;
+import com.mapbox.android.gestures.MultiFingerTapGestureDetector;
+import com.mapbox.android.gestures.RotateGestureDetector;
 import com.mapbox.android.gestures.ShoveGestureDetector;
 import com.mapbox.android.gestures.StandardGestureDetector;
-import com.mapbox.android.gestures.MultiFingerTapGestureDetector;
-import com.mapbox.android.gestures.MoveGestureDetector;
-import com.mapbox.android.gestures.RotateGestureDetector;
 import com.mapbox.android.gestures.StandardScaleGestureDetector;
 import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
@@ -29,6 +30,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import static com.mapbox.mapboxsdk.constants.MapboxConstants.ZOOM_RATE;
 import static com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraMoveStartedListener.REASON_API_ANIMATION;
 import static com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraMoveStartedListener.REASON_API_GESTURE;
 
@@ -558,7 +560,7 @@ final class MapGestureDetector {
     }
 
     private double getNewZoom(float scaleFactor, boolean quickZoom) {
-      double zoomBy = (Math.log(scaleFactor) / Math.log(Math.PI / 2)) * 0.65;
+      double zoomBy = (Math.log(scaleFactor) / Math.log(Math.PI / 2)) * ZOOM_RATE * uiSettings.getZoomRate();
       if (quickZoom) {
         // clamp scale factors we feed to core #7514
         boolean negative = zoomBy < 0;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -558,7 +558,7 @@ final class MapGestureDetector {
     }
 
     private double getNewZoom(float scaleFactor, boolean quickZoom) {
-      double zoomBy = Math.log(scaleFactor) / Math.log(Math.PI / 2);
+      double zoomBy = (Math.log(scaleFactor) / Math.log(Math.PI / 2)) * 0.65;
       if (quickZoom) {
         // clamp scale factors we feed to core #7514
         boolean negative = zoomBy < 0;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
@@ -8,6 +8,7 @@ import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.ColorInt;
+import android.support.annotation.FloatRange;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.Px;
@@ -67,6 +68,8 @@ public final class UiSettings {
 
   private boolean increaseRotateThresholdWhenScaling = true;
   private boolean increaseScaleThresholdWhenRotating = true;
+
+  private float zoomRate = 1.0f;
 
   private boolean deselectMarkersOnTap = true;
 
@@ -131,6 +134,7 @@ public final class UiSettings {
     outState.putBoolean(MapboxConstants.STATE_INCREASE_ROTATE_THRESHOLD, isIncreaseRotateThresholdWhenScaling());
     outState.putBoolean(MapboxConstants.STATE_INCREASE_SCALE_THRESHOLD, isIncreaseScaleThresholdWhenRotating());
     outState.putBoolean(MapboxConstants.STATE_QUICK_ZOOM_ENABLED, isQuickZoomGesturesEnabled());
+    outState.putFloat(MapboxConstants.STATE_ZOOM_RATE, getZoomRate());
   }
 
   private void restoreGestures(Bundle savedInstanceState) {
@@ -147,6 +151,7 @@ public final class UiSettings {
     setIncreaseScaleThresholdWhenRotating(
       savedInstanceState.getBoolean(MapboxConstants.STATE_INCREASE_SCALE_THRESHOLD));
     setQuickZoomGesturesEnabled(savedInstanceState.getBoolean(MapboxConstants.STATE_QUICK_ZOOM_ENABLED));
+    setZoomRate(savedInstanceState.getFloat(MapboxConstants.STATE_ZOOM_RATE, 1.0f));
   }
 
   private void initialiseCompass(MapboxMapOptions options, @NonNull Resources resources) {
@@ -771,6 +776,27 @@ public final class UiSettings {
     this.quickZoomGesturesEnabled = quickZoomGesturesEnabled;
   }
 
+  /**
+   * Returns zoom gesture rate, including pinch to zoom and quick scale.
+   *
+   * @return The zoom rate.
+   */
+  public float getZoomRate() {
+    return zoomRate;
+  }
+
+  /**
+   * Sets zoom gesture rate, including pinch to zoom and quick scale.
+   * <p>
+   * Default value is 1.0f.
+   * </p>
+   *
+   * @param zoomRate The zoom rate.
+   */
+  public void setZoomRate(@FloatRange(from = 0f) float zoomRate) {
+    this.zoomRate = zoomRate;
+  }
+
   private void restoreDeselectMarkersOnTap(Bundle savedInstanceState) {
     setDeselectMarkersOnTap(savedInstanceState.getBoolean(MapboxConstants.STATE_DESELECT_MARKER_ON_TAP));
   }
@@ -961,7 +987,7 @@ public final class UiSettings {
    */
   public boolean areAllGesturesEnabled() {
     return rotateGesturesEnabled && tiltGesturesEnabled && zoomGesturesEnabled
-        && scrollGesturesEnabled && doubleTapGesturesEnabled && quickZoomGesturesEnabled;
+      && scrollGesturesEnabled && doubleTapGesturesEnabled && quickZoomGesturesEnabled;
   }
 
   private void saveFocalPoint(Bundle outState) {

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/UiSettingsTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/UiSettingsTest.java
@@ -399,4 +399,17 @@ public class UiSettingsTest {
     assertEquals("All gestures check should return false", false,
         uiSettings.areAllGesturesEnabled());
   }
+
+  @Test
+  public void testZoomRateDefaultValue() {
+    assertEquals("Default zoom rate should be 1.0f", 1.0f,
+      uiSettings.getZoomRate(), 0);
+  }
+
+  @Test
+  public void testZoomRate() {
+    uiSettings.setZoomRate(0.83f);
+    assertEquals("Zoom rate should be 0.83f", 0.83f,
+      uiSettings.getZoomRate(), 0);
+  }
 }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/14136.

Additionally, changes the default zoom rate by 35% based on community feedback. I'd really appreciate any additional feedback on this change (https://github.com/mapbox/mapbox-gl-native/commit/b03c1510352fabd5e6d37d7386237d7c4d2c7c2f) @mapbox/maps-android.