### PR TITLE
Update maven publishing script to enable aar packaging 

### DIFF
--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath dependenciesList.licensesPlugin
         classpath dependenciesList.kotlinPlugin
         classpath dependenciesList.bintrayPlugin
@@ -24,7 +24,7 @@ allprojects {
         // For publishing Maps SDK files to Bintray
         maven { url 'https://mapbox.bintray.com/mapbox' }
         // Snapshot repository
-        // maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
+        // maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local/' }
     }
 }
 

--- a/platform/android/gradle/gradle-bintray.gradle
+++ b/platform/android/gradle/gradle-bintray.gradle
@@ -16,7 +16,6 @@ publishing {
             version this.version
 
             afterEvaluate {
-                artifact("$buildDir/outputs/aar/mapbox-android-sdk-release.aar")
                 artifact(androidSourcesJar)
                 artifact(androidJavadocsJar)
             }

--- a/platform/android/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Jan 20 13:53:14 CET 2019
+#Tue May 28 09:39:37 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
Closes #14646, current configuration results in pom packaging instead of aar packaging when used with updated gradle tools and wrapper. More context about this in https://github.com/wupdigital/android-maven-publish/issues/26#issuecomment-411410958. Example working snapshot build:  `com.mapbox.mapboxsdk:mapbox-android-sdk:8.2.0-20190528.072626-4`
