### PR TITLE
Move building example custom layer to testapp

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: "com.jaredsburrows.license"
 apply plugin: 'kotlin-android'
+apply from: "${rootDir}/gradle/native-build.gradle"
 
 dependencies {
     lintChecks project(":MapboxGLAndroidSDKLint")
@@ -32,83 +33,18 @@ android {
         buildConfigField "String", "MAPBOX_SDK_VERSION", String.format("\"%s\"", project.VERSION_NAME)
         buildConfigField "String", "MAPBOX_VERSION_STRING", String.format("\"Mapbox/%s\"", project.VERSION_NAME)
         buildConfigField "String", "MAPBOX_EVENTS_USER_AGENT", String.format("\"mapbox-maps-android/%s\"", project.VERSION_NAME)
-    }
-
-    defaultPublishConfig project.hasProperty("mapbox.buildtype") ? project.getProperty("mapbox.buildtype") : "debug"
-
-    // We sometimes want to invoke Gradle without building a native dependency, e.g. when we just want
-    // to invoke the Java tests. When we explicitly specify an ABI of 'none', no native dependencies are
-    // added. When another ABI is specified explicitly, we're just going to build that ABI. In all other
-    // cases, all ABIs are built.
-    //
-    // When invoking from the command line or to override the device default, set `-Pmapbox.abis=...` to
-    // only build the desired architectures.
-    //
-    // When building from Android Studio, gradle.properties sets `android.buildOnlyTargetAbi=true` so that
-    // only the architecture for the device you're running on gets built.
-    def abi = 'all'
-    if (!project.hasProperty('android.injected.invoked.from.ide') || project.hasProperty("mapbox.abis")) {
-        // Errors when the user invokes Gradle from the command line and didn't set mapbox.abis
-        abi = project.getProperty("mapbox.abis")
-    }
-
-    if (abi != 'none') {
-        externalNativeBuild {
-            cmake {
-                path "../../../CMakeLists.txt"
-                version "3.10.2"
-            }
-        }
-    }
-
-    // Allow determining the C++ STL we're using when building Mapbox GL.
-    def stl = 'c++_static'
-    if (project.hasProperty("mapbox.stl")) {
-        stl = project.getProperty("mapbox.stl")
-    }
-
-    defaultConfig {
-        if (abi != 'none') {
-            externalNativeBuild {
-                cmake {
-                    arguments "-DANDROID_TOOLCHAIN=clang"
-                    arguments "-DANDROID_STL=" + stl
-                    arguments "-DANDROID_CPP_FEATURES=exceptions"
-                    arguments "-DMBGL_PLATFORM=android"
-                    arguments "-DMASON_PLATFORM=android"
-                    arguments "-DNodeJS_EXECUTABLE=" + node
-                    arguments "-Dnpm_EXECUTABLE=" + npm
-
-                    // Enable ccache if the user has installed it.
-                    if (ccache?.trim()) {
-                        arguments "-DANDROID_CCACHE=" + ccache
-                    }
-
-                    cFlags "-Qunused-arguments"
-                    cppFlags "-Qunused-arguments"
-
-                    targets "mapbox-gl"
-
-                    if (project.hasProperty("mapbox.with_test")) {
-                        targets "mbgl-test"
-                    }
-
-                    if (project.hasProperty("mapbox.with_benchmark")) {
-                        targets "mbgl-benchmark"
-                    }
-
-                    if (abi != 'all') {
-                        abiFilters abi.split(' ')
-                    } else {
-                        abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
-                    }
-                }
-            }
-        }
-
-        // proguard config for .aar
         consumerProguardFiles 'proguard-rules.pro'
     }
+
+    // build native libraries
+    List nativeTargets = ["mapbox-gl"]
+    if (project.hasProperty("mapbox.with_test")) {
+        nativeTargets.add("mbgl-test")
+    }
+    if (project.hasProperty("mapbox.with_benchmark")) {
+        nativeTargets.add("mbgl-benchmark")
+    }
+    nativeBuild(nativeTargets)
 
     // avoid naming conflicts, force usage of prefix
     resourcePrefix 'mapbox_'
@@ -160,7 +96,6 @@ configurations {
     all*.exclude group: 'commons-logging', module: 'commons-logging'
     all*.exclude group: 'commons-collections', module: 'commons-collections'
 }
-
 apply from: "${rootDir}/gradle/gradle-javadoc.gradle"
 apply from: "${rootDir}/gradle/gradle-checkstyle.gradle"
 apply from: "${rootDir}/gradle/gradle-dependencies-graph.gradle"

--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -89,10 +89,6 @@ android {
 
                     targets "mapbox-gl"
 
-                    if (defaultPublishConfig.equalsIgnoreCase("debug")) {
-                        targets "example-custom-layer"
-                    }
-
                     if (project.hasProperty("mapbox.with_test")) {
                         targets "mbgl-test"
                     }

--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply from: "${rootDir}/gradle/native-build.gradle"
 
 android {
     compileSdkVersion androidVersions.compileSdkVersion
@@ -17,70 +18,7 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    defaultPublishConfig project.hasProperty("mapbox.buildtype") ? project.getProperty("mapbox.buildtype") : "debug"
-
-    // We sometimes want to invoke Gradle without building a native dependency, e.g. when we just want
-    // to invoke the Java tests. When we explicitly specify an ABI of 'none', no native dependencies are
-    // added. When another ABI is specified explicitly, we're just going to build that ABI. In all other
-    // cases, all ABIs are built.
-    //
-    // When invoking from the command line or to override the device default, set `-Pmapbox.abis=...` to
-    // only build the desired architectures.
-    //
-    // When building from Android Studio, gradle.properties sets `android.buildOnlyTargetAbi=true` so that
-    // only the architecture for the device you're running on gets built.
-    def abi = 'all'
-    if (!project.hasProperty('android.injected.invoked.from.ide') || project.hasProperty("mapbox.abis")) {
-        // Errors when the user invokes Gradle from the command line and didn't set mapbox.abis
-        abi = project.getProperty("mapbox.abis")
-    }
-
-    if (abi != 'none') {
-        externalNativeBuild {
-            cmake {
-                path "../../../CMakeLists.txt"
-                version "3.10.2"
-            }
-        }
-    }
-
-    // Allow determining the C++ STL we're using when building Mapbox GL.
-    def stl = 'c++_static'
-    if (project.hasProperty("mapbox.stl")) {
-        stl = project.getProperty("mapbox.stl")
-    }
-
-    defaultConfig {
-        if (abi != 'none') {
-            externalNativeBuild {
-                cmake {
-                    arguments "-DANDROID_TOOLCHAIN=clang"
-                    arguments "-DANDROID_STL=" + stl
-                    arguments "-DANDROID_CPP_FEATURES=exceptions"
-                    arguments "-DMBGL_PLATFORM=android"
-                    arguments "-DMASON_PLATFORM=android"
-                    arguments "-DNodeJS_EXECUTABLE=" + node
-                    arguments "-Dnpm_EXECUTABLE=" + npm
-
-                    // Enable ccache if the user has installed it.
-                    if (ccache?.trim()) {
-                        arguments "-DANDROID_CCACHE=" + ccache
-                    }
-
-                    cFlags "-Qunused-arguments"
-                    cppFlags "-Qunused-arguments"
-
-                    targets "example-custom-layer"
-
-                    if (abi != 'all') {
-                        abiFilters abi.split(' ')
-                    } else {
-                        abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
-                    }
-                }
-            }
-        }
-    }
+    nativeBuild(["example-custom-layer"])
 
     packagingOptions {
         exclude 'META-INF/LICENSE.txt'

--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -17,6 +17,71 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    defaultPublishConfig project.hasProperty("mapbox.buildtype") ? project.getProperty("mapbox.buildtype") : "debug"
+
+    // We sometimes want to invoke Gradle without building a native dependency, e.g. when we just want
+    // to invoke the Java tests. When we explicitly specify an ABI of 'none', no native dependencies are
+    // added. When another ABI is specified explicitly, we're just going to build that ABI. In all other
+    // cases, all ABIs are built.
+    //
+    // When invoking from the command line or to override the device default, set `-Pmapbox.abis=...` to
+    // only build the desired architectures.
+    //
+    // When building from Android Studio, gradle.properties sets `android.buildOnlyTargetAbi=true` so that
+    // only the architecture for the device you're running on gets built.
+    def abi = 'all'
+    if (!project.hasProperty('android.injected.invoked.from.ide') || project.hasProperty("mapbox.abis")) {
+        // Errors when the user invokes Gradle from the command line and didn't set mapbox.abis
+        abi = project.getProperty("mapbox.abis")
+    }
+
+    if (abi != 'none') {
+        externalNativeBuild {
+            cmake {
+                path "../../../CMakeLists.txt"
+                version "3.10.2"
+            }
+        }
+    }
+
+    // Allow determining the C++ STL we're using when building Mapbox GL.
+    def stl = 'c++_static'
+    if (project.hasProperty("mapbox.stl")) {
+        stl = project.getProperty("mapbox.stl")
+    }
+
+    defaultConfig {
+        if (abi != 'none') {
+            externalNativeBuild {
+                cmake {
+                    arguments "-DANDROID_TOOLCHAIN=clang"
+                    arguments "-DANDROID_STL=" + stl
+                    arguments "-DANDROID_CPP_FEATURES=exceptions"
+                    arguments "-DMBGL_PLATFORM=android"
+                    arguments "-DMASON_PLATFORM=android"
+                    arguments "-DNodeJS_EXECUTABLE=" + node
+                    arguments "-Dnpm_EXECUTABLE=" + npm
+
+                    // Enable ccache if the user has installed it.
+                    if (ccache?.trim()) {
+                        arguments "-DANDROID_CCACHE=" + ccache
+                    }
+
+                    cFlags "-Qunused-arguments"
+                    cppFlags "-Qunused-arguments"
+
+                    targets "example-custom-layer"
+
+                    if (abi != 'all') {
+                        abiFilters abi.split(' ')
+                    } else {
+                        abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+                    }
+                }
+            }
+        }
+    }
+
     packagingOptions {
         exclude 'META-INF/LICENSE.txt'
         exclude 'META-INF/NOTICE.txt'

--- a/platform/android/gradle/native-build.gradle
+++ b/platform/android/gradle/native-build.gradle
@@ -1,0 +1,70 @@
+ext.nativeBuild = { nativeTargets ->
+    android {
+        defaultPublishConfig project.hasProperty("mapbox.buildtype") ? project.getProperty("mapbox.buildtype") : "debug"
+
+        // We sometimes want to invoke Gradle without building a native dependency, e.g. when we just want
+        // to invoke the Java tests. When we explicitly specify an ABI of 'none', no native dependencies are
+        // added. When another ABI is specified explicitly, we're just going to build that ABI. In all other
+        // cases, all ABIs are built.
+        //
+        // When invoking from the command line or to override the device default, set `-Pmapbox.abis=...` to
+        // only build the desired architectures.
+        //
+        // When building from Android Studio, gradle.properties sets `android.buildOnlyTargetAbi=true` so that
+        // only the architecture for the device you're running on gets built.
+        def abi = 'all'
+        if (!project.hasProperty('android.injected.invoked.from.ide') || project.hasProperty("mapbox.abis")) {
+            // Errors when the user invokes Gradle from the command line and didn't set mapbox.abis
+            abi = project.getProperty("mapbox.abis")
+        }
+
+        if (abi != 'none') {
+            externalNativeBuild {
+                cmake {
+                    path "../../../CMakeLists.txt"
+                    version "3.10.2"
+                }
+            }
+        }
+
+        // Allow determining the C++ STL we're using when building Mapbox GL.
+        def stl = 'c++_static'
+        if (project.hasProperty("mapbox.stl")) {
+            stl = project.getProperty("mapbox.stl")
+        }
+
+        defaultConfig {
+            if (abi != 'none') {
+                externalNativeBuild {
+                    cmake {
+                        arguments "-DANDROID_TOOLCHAIN=clang"
+                        arguments "-DANDROID_STL=" + stl
+                        arguments "-DANDROID_CPP_FEATURES=exceptions"
+                        arguments "-DMBGL_PLATFORM=android"
+                        arguments "-DMASON_PLATFORM=android"
+                        arguments "-DNodeJS_EXECUTABLE=" + node
+                        arguments "-Dnpm_EXECUTABLE=" + npm
+
+                        // Enable ccache if the user has installed it.
+                        if (ccache?.trim()) {
+                            arguments "-DANDROID_CCACHE=" + ccache
+                        }
+
+                        cFlags "-Qunused-arguments"
+                        cppFlags "-Qunused-arguments"
+
+                        for (target in nativeTargets) {
+                            targets target
+                        }
+
+                        if (abi != 'all') {
+                            abiFilters abi.split(' ')
+                        } else {
+                            abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/8886.

`.so` file content of debug build of `.aar` before change:
![Screenshot from 2019-05-28 18-27-02](https://user-images.githubusercontent.com/2151639/58494898-66a93500-8176-11e9-8b3b-0765a9f7b961.png)

`.so` file content of debug build of `.aar` after change:
![Screenshot from 2019-05-28 18-22-51](https://user-images.githubusercontent.com/2151639/58494891-627d1780-8176-11e9-9f5a-7e87611aefc8.png)

`.so` files of test app after change:
![Screenshot from 2019-05-28 18-18-53](https://user-images.githubusercontent.com/2151639/58494974-91938900-8176-11e9-9228-a2fa54f385c4.png)

Todo:
 - [x] create `native_build.gradle` and consolidate native build configuration to avoid duplicating code across modules


