### PR TITLE
Force camera change when specifying edge padding

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -6,7 +6,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ### Styles and rendering
 
-* Implemented asymmetric center of perspective: fixed an issue that caused the focal point to be always based on the view's horizontal center when setting [MGLMapView contentInset](https://docs.mapbox.com/ios/api/maps/5.0.0/Classes/MGLMapView.html#/c:objc(cs)MGLMapView(py)contentInset). ([#14664](https://github.com/mapbox/mapbox-gl-native/pull/14664))
+* Setting `MGLMapView.contentInset` now moves the map’s focal point to the center of the content frame after insetting. ([#14664](https://github.com/mapbox/mapbox-gl-native/pull/14664))
 
 ## 5.0.0 - May 22, 2019
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1088,7 +1088,7 @@ public:
         [self didUpdateLocationWithUserTrackingAnimated:animated];
     }
 
-    // Compass, logo and attribution button constraints needs to be updated.z
+    // Compass, logo and attribution button constraints needs to be updated.
     [self installConstraints];
 }
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Styles and rendering
 
-* Implemented asymmetric center of perspective: fixed an issue that caused the focal point to be always based on the view's horizontal center when setting [MGLMapView contentInset](https://docs.mapbox.com/ios/api/maps/5.0.0/Classes/MGLMapView.html#/c:objc(cs)MGLMapView(py)contentInset).  ([#14664](https://github.com/mapbox/mapbox-gl-native/pull/14664))
+* Setting `MGLMapView.contentInsets` now moves the map’s focal point to the center of the content frame after insetting. ([#14664](https://github.com/mapbox/mapbox-gl-native/pull/14664))
 
 ## 0.14.0 - May 22, 2018
 

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -1198,7 +1198,7 @@ public:
         };
     }
     
-    if ([self.camera isEqualToMapCamera:camera]) {
+    if ([self.camera isEqualToMapCamera:camera] && NSEdgeInsetsEqual(edgePadding, NSEdgeInsetsZero)) {
         if (completion) {
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(duration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
                 completion();
@@ -1311,7 +1311,7 @@ public:
     }
     
     MGLMapCamera *camera = [self cameraForCameraOptions:cameraOptions];
-    if ([self.camera isEqualToMapCamera:camera]) {
+    if ([self.camera isEqualToMapCamera:camera] && NSEdgeInsetsEqual(insets, NSEdgeInsetsZero)) {
         return;
     }
 


### PR DESCRIPTION
As in #14664 on iOS, the macOS implementation of MGLMapView should only force a camera change when the content insets are modified by edge padding. Fortunately, the macOS implementation always adds edge padding to the content insets instead of replacing them, so we can check the insets in a consistent way.

Also copyedited changelogs.

/cc @astojilj @fabian-guerra 