### PR TITLE
[ios] Bump podspec to v5.1.0-alpha.1

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
-## master
+## 5.1.0
 
 ### Styles and rendering
 
-* Implemented asymmetric center of perspective: fixed an issue that caused the focal point to be always based on the view's horizontal center when setting [MGLMapView contentInset](https://docs.mapbox.com/ios/api/maps/5.0.0/Classes/MGLMapView.html#/c:objc(cs)MGLMapView(py)contentInset). ([#14664](https://github.com/mapbox/mapbox-gl-native/pull/14664))
+* Setting `MGLMapView.contentInset` now moves the map’s focal point to the center of the content frame after insetting. ([#14664](https://github.com/mapbox/mapbox-gl-native/pull/14664))
 
 ## 5.0.0 - May 22, 2019
 

--- a/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '5.0.0'
+  version = '5.1.0-alpha.1'
 
   m.name    = 'Mapbox-iOS-SDK-snapshot-dynamic'
   m.version = "#{version}-snapshot"

--- a/platform/ios/Mapbox-iOS-SDK-stripped.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-stripped.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '5.0.0'
+  version = '5.1.0-alpha.1'
 
   m.name    = 'Mapbox-iOS-SDK-stripped'
   m.version = "#{version}-stripped"

--- a/platform/ios/Mapbox-iOS-SDK.podspec
+++ b/platform/ios/Mapbox-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '5.0.0'
+  version = '5.1.0-alpha.1'
 
   m.name    = 'Mapbox-iOS-SDK'
   m.version = version

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Styles and rendering
 
-* Implemented asymmetric center of perspective: fixed an issue that caused the focal point to be always based on the view's horizontal center when setting [MGLMapView contentInset](https://docs.mapbox.com/ios/api/maps/5.0.0/Classes/MGLMapView.html#/c:objc(cs)MGLMapView(py)contentInset).  ([#14664](https://github.com/mapbox/mapbox-gl-native/pull/14664))
+* Setting `MGLMapView.contentInset` now moves the map’s focal point to the center of the content frame after insetting. ([#14664](https://github.com/mapbox/mapbox-gl-native/pull/14664))
 
 ## 0.14.0 - May 22, 2018
 


### PR DESCRIPTION
Bumps the podspec to `v5.1.0-alpha.1` and updates the changelog.