### PR TITLE
[ios] Fix undeclared selector warning in MGLAnnotationView

### DIFF
--- a/platform/ios/src/MGLAnnotationView.mm
+++ b/platform/ios/src/MGLAnnotationView.mm
@@ -3,6 +3,7 @@
 #import "MGLMapView_Private.h"
 #import "MGLCalloutView.h"
 #import "MGLAnnotation.h"
+#import "MGLPointAnnotation.h"
 #import "MGLLoggingConfiguration_Private.h"
 
 #import "NSBundle+MGLAdditions.h"


### PR DESCRIPTION
`setCoordinate:` isn't available to regular `MGLAnnotation` (as `coordinate` is `readonly` there), only `MGLPointAnnotation` — so include the latter’s header to avoid “undeclared selector” warnings [here](https://github.com/mapbox/mapbox-gl-native/blob/0bebafadd88f9eed0a3b6c1bf74eb87e2d054ded/platform/ios/src/MGLAnnotationView.mm#L323).

This happened after #14763, though I didn’t dig into why.

/cc @fabian-guerra