### PR TITLE
Copy features array before passing them to core

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/GeoJsonSource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/GeoJsonSource.java
@@ -285,14 +285,21 @@ public class GeoJsonSource extends Source {
    * Updates the GeoJson. The update is performed asynchronously,
    * so the data won't be immediately visible or available to query when this method returns.
    *
-   * @param features the GeoJSON FeatureCollection
+   * @param featureCollection the GeoJSON FeatureCollection
    */
-  public void setGeoJson(FeatureCollection features) {
+  public void setGeoJson(FeatureCollection featureCollection) {
     if (detached) {
       return;
     }
     checkThread();
-    nativeSetFeatureCollection(features);
+
+    List<Feature> features = featureCollection.features();
+    if (features != null) {
+      List<Feature> featuresCopy = new ArrayList<>(features);
+      nativeSetFeatureCollection(FeatureCollection.fromFeatures(featuresCopy));
+    } else {
+      nativeSetFeatureCollection(featureCollection);
+    }
   }
 
   /**
@@ -445,7 +452,7 @@ public class GeoJsonSource extends Source {
    * </p>
    *
    * @param cluster cluster from which to retrieve leaves from
-   * @param limit  limit is the number of points to return
+   * @param limit   limit is the number of points to return
    * @param offset  offset is the amount of points to skip (for pagination)
    * @return a list of features for the underlying leaves
    */
@@ -497,10 +504,10 @@ public class GeoJsonSource extends Source {
   private native Feature[] querySourceFeatures(Object[] filter);
 
   @Keep
-  private native Feature[]  nativeGetClusterChildren(Feature feature);
+  private native Feature[] nativeGetClusterChildren(Feature feature);
 
   @Keep
-  private native Feature[]  nativeGetClusterLeaves(Feature feature, long limit, long offset);
+  private native Feature[] nativeGetClusterLeaves(Feature feature, long limit, long offset);
 
   @Keep
   private native int nativeGetClusterExpansionZoom(Feature feature);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/GeoJsonSourceTests.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/GeoJsonSourceTests.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import timber.log.Timber;
 
@@ -98,6 +100,22 @@ public class GeoJsonSourceTests extends EspressoTest {
       assertEquals(1, mapboxMap.queryRenderedFeatures(
         mapboxMap.getProjection().toScreenLocation(
           new LatLng(55, 20)), "layer").size());
+    });
+  }
+
+  @Test
+  public void testClearCollectionDuringConversion() {
+    // https://github.com/mapbox/mapbox-gl-native/issues/14565
+    validateTestSetup();
+    MapboxMapAction.invoke(mapboxMap, (uiController, mapboxMap) -> {
+      for (int j = 0; j < 1000; j++) {
+        List<Feature> features = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+          features.add(Feature.fromGeometry(Point.fromLngLat(0, 0)));
+        }
+        mapboxMap.getStyle().addSource(new GeoJsonSource("source" + j, FeatureCollection.fromFeatures(features)));
+        features.clear();
+      }
     });
   }
 


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/14565.

I have noticed, that the only possible scenario when the crash from https://github.com/mapbox/mapbox-gl-native/issues/14565 can occur is when the collection is cleared while it's being converted to an array on our worker thread:
https://github.com/mapbox/mapbox-gl-native/blob/316584fabc4dacaa53e7a208a88f5f87e6f243b0/platform/android/src/geojson/feature_collection.cpp#L14
`ArrayList#toArray` builds an array with a fixed size, adding a `null` padding if necessary, therefore I think, that the collection has to be cleared on one thread, right when the `ArrayList#toArray` is copying the list on the other (after setting the resulting array's size and before finishing copying all of the elements, which creates the `null` padding).

This is a race condition, so the only test I was able to come up with is a brute force. The test has been reliably reproducing the crash for me on every single run, either on a physical device or an emulator.

The solution is to copy the features array to a new array so that it cannot be modified by the provider. I was considering copying each `Feature` object as well, but it's not critical as modifying the feature should be safe and it introduced additional overhead.