### PR TITLE
[core] Fix: fill-extrusion-vertical-gradient was ignored. #14784

### DIFF
--- a/src/mbgl/programs/fill_extrusion_program.cpp
+++ b/src/mbgl/programs/fill_extrusion_program.cpp
@@ -32,13 +32,14 @@ float lightIntensity(const EvaluatedLight& light) {
 }
 
 FillExtrusionProgram::LayoutUniformValues FillExtrusionProgram::layoutUniformValues(
-    mat4 matrix, const TransformState& state, const float opacity, const EvaluatedLight& light) {
+    mat4 matrix, const TransformState& state, const float opacity, const EvaluatedLight& light, const float verticalGradient) {
     return {
         uniforms::matrix::Value( matrix ),
         uniforms::opacity::Value( opacity ),
         uniforms::lightcolor::Value( lightColor(light) ),
         uniforms::lightpos::Value( lightPosition(light, state) ),
-        uniforms::lightintensity::Value( lightIntensity(light) )
+        uniforms::lightintensity::Value( lightIntensity(light) ),
+        uniforms::vertical_gradient::Value( verticalGradient )
     };
 }
 
@@ -51,7 +52,8 @@ FillExtrusionPatternProgram::layoutUniformValues(mat4 matrix,
                                            const float opacity,
                                            const float heightFactor,
                                            const float pixelRatio,
-                                           const EvaluatedLight& light) {
+                                           const EvaluatedLight& light,
+                                           const float verticalGradient) {
     const auto tileRatio = 1 / tileID.pixelsToTileUnits(1, state.getIntegerZoom());
     int32_t tileSizeAtNearestZoom = util::tileSize * state.zoomScale(state.getIntegerZoom() - tileID.canonical.z);
     int32_t pixelX = tileSizeAtNearestZoom * (tileID.canonical.x + tileID.wrap * state.zoomScale(tileID.canonical.z));
@@ -69,6 +71,7 @@ FillExtrusionPatternProgram::layoutUniformValues(mat4 matrix,
         uniforms::lightcolor::Value( lightColor(light) ),
         uniforms::lightpos::Value( lightPosition(light, state) ),
         uniforms::lightintensity::Value( lightIntensity(light) ),
+        uniforms::vertical_gradient::Value( verticalGradient )
     };
 }
 

--- a/src/mbgl/programs/fill_extrusion_program.hpp
+++ b/src/mbgl/programs/fill_extrusion_program.hpp
@@ -24,6 +24,7 @@ namespace uniforms {
 MBGL_DEFINE_UNIFORM_VECTOR(float, 3, lightpos);
 MBGL_DEFINE_UNIFORM_VECTOR(float, 3, lightcolor);
 MBGL_DEFINE_UNIFORM_SCALAR(float,    lightintensity);
+MBGL_DEFINE_UNIFORM_SCALAR(float,    vertical_gradient);
 MBGL_DEFINE_UNIFORM_SCALAR(float,    height_factor);
 } // namespace uniforms
 
@@ -36,7 +37,8 @@ using FillExtrusionUniforms = TypeList<
     uniforms::opacity,
     uniforms::lightcolor,
     uniforms::lightpos,
-    uniforms::lightintensity>;
+    uniforms::lightintensity,
+    uniforms::vertical_gradient>;
 
 using FillExtrusionPatternUniforms = TypeList<
     uniforms::matrix,
@@ -49,7 +51,8 @@ using FillExtrusionPatternUniforms = TypeList<
     uniforms::height_factor,
     uniforms::lightcolor,
     uniforms::lightpos,
-    uniforms::lightintensity>;
+    uniforms::lightintensity,
+    uniforms::vertical_gradient>;
 
 class FillExtrusionProgram : public Program<
     FillExtrusionProgram,
@@ -83,7 +86,7 @@ public:
     }
 
     static LayoutUniformValues
-    layoutUniformValues(mat4, const TransformState&, const float opacity, const EvaluatedLight&);
+    layoutUniformValues(mat4, const TransformState&, const float opacity, const EvaluatedLight&, const float verticalGradient);
 };
 
 class FillExtrusionPatternProgram : public Program<
@@ -106,7 +109,8 @@ public:
                                                    const float opacity,
                                                    const float heightFactor,
                                                    const float pixelRatio,
-                                                   const EvaluatedLight&);
+                                                   const EvaluatedLight&,
+                                                   const float verticalGradient);
 };
 
 using FillExtrusionLayoutVertex = FillExtrusionProgram::LayoutVertex;

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -134,7 +134,8 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
                                                   parameters.state),
                         parameters.state,
                         evaluated.get<FillExtrusionOpacity>(),
-                        parameters.evaluatedLight
+                        parameters.evaluatedLight,
+                        evaluated.get<FillExtrusionVerticalGradient>()
                     ),
                     {},
                     {},
@@ -188,7 +189,8 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
                         evaluated.get<FillExtrusionOpacity>(),
                         -std::pow(2, tile.id.canonical.z) / util::tileSize / 8.0f,
                         parameters.pixelRatio,
-                        parameters.evaluatedLight
+                        parameters.evaluatedLight,
+                        evaluated.get<FillExtrusionVerticalGradient>()
                     ),
                     patternPosA,
                     patternPosB,


### PR DESCRIPTION
fill-extrusion-vertical-gradient is of "property-type": "data-constant" and it shouldn't be computed through property binders.

Compared to the state in #14784, render test now produces proper result.

![Screenshot actual vs expected](https://user-images.githubusercontent.com/549216/58680921-a8063400-8372-11e9-846c-2b6fce33a2b0.png)

Fixes: #14784