### PR TITLE
Don't invoke nativeRender when surface has been destroyed

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -10,6 +10,7 @@ import android.support.annotation.CallSuper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.util.LongSparseArray;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
@@ -1065,6 +1066,12 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
 
   void setMapboxMap(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
+  }
+
+  @VisibleForTesting
+  @Nullable
+  MapRenderer getMapRenderer() {
+    return mapRenderer;
   }
 
   private class FocalPointInvalidator implements FocalPointChangeListener {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
@@ -4,12 +4,11 @@ import android.content.Context;
 import android.support.annotation.CallSuper;
 import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
+import android.support.annotation.UiThread;
 import com.mapbox.mapboxsdk.LibraryLoader;
 import com.mapbox.mapboxsdk.log.Logger;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.storage.FileSource;
-
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.opengles.GL10;
@@ -34,7 +33,8 @@ public abstract class MapRenderer implements MapRendererScheduler {
   private long nativePtr = 0;
   private double expectedRenderTime = 0;
   private MapboxMap.OnFpsChangedListener onFpsChangedListener;
-  protected AtomicBoolean hasSurface = new AtomicBoolean();
+  protected boolean hasSurface;
+  protected final Object lock = new Object();
 
   public MapRenderer(@NonNull Context context, String localIdeographFontFamily) {
     float pixelRatio = context.getResources().getDisplayMetrics().density;
@@ -88,7 +88,14 @@ public abstract class MapRenderer implements MapRendererScheduler {
   protected void onDrawFrame(GL10 gl) {
     long startTime = System.nanoTime();
     try {
-      nativeRender();
+      synchronized (lock) {
+        if (hasSurface) {
+          nativeRender();
+        } else {
+          return;
+        }
+      }
+
     } catch (java.lang.Error error) {
       Logger.e(TAG, error.getMessage());
     }
@@ -166,7 +173,8 @@ public abstract class MapRenderer implements MapRendererScheduler {
    *
    * @return returns if renderer has a surface, false otherwise
    */
+  @UiThread
   public boolean hasSurface() {
-    return hasSurface.get();
+    return hasSurface;
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.opengl.GLSurfaceView;
 import android.support.annotation.NonNull;
 import android.view.SurfaceHolder;
-
 import com.mapbox.mapboxsdk.maps.renderer.MapRenderer;
 import com.mapbox.mapboxsdk.maps.renderer.egl.EGLConfigChooser;
 
@@ -39,14 +38,18 @@ public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceVi
       @Override
       public void surfaceCreated(SurfaceHolder holder) {
         super.surfaceCreated(holder);
-        hasSurface.set(true);
+        synchronized (lock) {
+          hasSurface = true;
+        }
       }
 
       @Override
       public void surfaceDestroyed(SurfaceHolder holder) {
         super.surfaceDestroyed(holder);
-        hasSurface.set(false);
-        nativeReset();
+        synchronized (lock) {
+          hasSurface = false;
+          nativeReset();
+        }
       }
     });
   }
@@ -103,10 +106,11 @@ public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceVi
    */
   @Override
   public void requestRender() {
-    if (!hasSurface.get()) {
-      return;
+    synchronized (lock) {
+      if (hasSurface) {
+        glSurfaceView.requestRender();
+      }
     }
-    glSurfaceView.requestRender();
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
@@ -81,17 +81,23 @@ public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceVi
 
   @Override
   public void onSurfaceCreated(GL10 gl, EGLConfig config) {
-    super.onSurfaceCreated(gl, config);
+    synchronized (lock) {
+      super.onSurfaceCreated(gl, config);
+    }
   }
 
   @Override
   protected void onSurfaceDestroyed() {
-    super.onSurfaceDestroyed();
+    synchronized (lock) {
+      super.onSurfaceDestroyed();
+    }
   }
 
   @Override
   public void onSurfaceChanged(GL10 gl, int width, int height) {
-    super.onSurfaceChanged(gl, width, height);
+    synchronized (lock) {
+      super.onSurfaceChanged(gl, width, height);
+    }
   }
 
   @Override

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewMapRenderer.java
@@ -53,7 +53,9 @@ public class TextureViewMapRenderer extends MapRenderer {
    */
   @Override
   protected void onSurfaceChanged(GL10 gl, int width, int height) {
-    super.onSurfaceChanged(gl, width, height);
+    synchronized (lock) {
+      super.onSurfaceChanged(gl, width, height);
+    }
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewMapRenderer.java
@@ -42,8 +42,10 @@ public class TextureViewMapRenderer extends MapRenderer {
    */
   @Override
   protected void onSurfaceCreated(GL10 gl, EGLConfig config) {
-    super.onSurfaceCreated(gl, config);
-    hasSurface.set(true);
+    synchronized (lock) {
+      super.onSurfaceCreated(gl, config);
+      hasSurface = true;
+    }
   }
 
   /**
@@ -59,8 +61,10 @@ public class TextureViewMapRenderer extends MapRenderer {
    */
   @Override
   protected void onSurfaceDestroyed() {
-    hasSurface.set(false);
-    super.onSurfaceDestroyed();
+    synchronized (lock) {
+      hasSurface = false;
+      super.onSurfaceDestroyed();
+    }
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -42,6 +42,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         release {
+            debuggable true
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/GLSurfaceDestroyTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/GLSurfaceDestroyTest.kt
@@ -1,0 +1,32 @@
+package com.mapbox.mapboxsdk.maps
+
+import android.support.test.filters.LargeTest
+import android.support.test.rule.ActivityTestRule
+import android.support.test.runner.AndroidJUnit4
+import com.mapbox.mapboxsdk.integration.BaseIntegrationTest
+import com.mapbox.mapboxsdk.maps.renderer.glsurfaceview.GLSurfaceViewMapRenderer
+import com.mapbox.mapboxsdk.testapp.R
+import com.mapbox.mapboxsdk.testapp.activity.maplayout.SimpleMapActivity
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class GLSurfaceDestroyTest : BaseIntegrationTest() {
+
+  @get:Rule
+  var activityRule: ActivityTestRule<SimpleMapActivity> = ActivityTestRule(SimpleMapActivity::class.java)
+
+  private lateinit var mapView:MapView
+
+  @Test
+  @LargeTest
+  fun reopenSimpleMapActivity() {
+    device.waitForIdle()
+    mapView = activityRule.activity.findViewById(R.id.mapView)
+    device.pressHome()
+    device.waitForIdle()
+    (mapView.mapRenderer as GLSurfaceViewMapRenderer).onDrawFrame(null)
+    device.waitForIdle()
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/MapboxApplication.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/MapboxApplication.java
@@ -54,9 +54,7 @@ public class MapboxApplication extends Application {
 
   private void initializeLogger() {
     Logger.setLoggerDefinition(new TimberLogger());
-    if (BuildConfig.DEBUG) {
-      Timber.plant(new DebugTree());
-    }
+    Timber.plant(new DebugTree());
   }
 
   private void initializeStrictMode() {


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/14592 
Closes https://github.com/mapbox/mapbox-gl-native/issues/14252
Closes https://github.com/mapbox/mapbox-gl-native/issues/14463

This PR fixes a native crash when an app is being backgrounded and we were still scheduling renders (the mapview surface has been destroyed). Concrete steps to repriduce:
  - schedule a render on the main thread 
  - the surface gets destroyed on main thread 
  - we run nativeRender on render thread while the surface was already destroyed on main thread

Additionally to fixing the crash, I'm committing a configuration that allows to use a release build of the testapp as a debug build. 