### PR TITLE
[core] Refactor tile pyramid

### DIFF
--- a/benchmark/parse/tile_mask.benchmark.cpp
+++ b/benchmark/parse/tile_mask.benchmark.cpp
@@ -4,34 +4,32 @@
 
 using namespace mbgl;
 
-class MaskedRenderable {
+class FakeTile {
 public:
-    MaskedRenderable(const UnwrappedTileID& id_, TileMask&& mask_)
-        : id(id_), mask(std::move(mask_)) {
+    FakeTile(TileMask mask_)
+        : mask(std::move(mask_)) {
     }
-
-    UnwrappedTileID id;
-    TileMask mask;
-    bool used = true;
-
-    void setMask(TileMask&& mask_) {
+    void setMask(TileMask mask_) {
         mask = std::move(mask_);
     }
+
+    const bool usedByRenderedLayers = true;
+    TileMask mask;
 };
 
 static void TileMaskGeneration(benchmark::State& state) {
-    std::vector<MaskedRenderable> renderables = {
-        MaskedRenderable{ UnwrappedTileID{ 12, 1028, 1456 }, {} },
-        MaskedRenderable{ UnwrappedTileID{ 13, 2056, 2912 }, {} },
-        MaskedRenderable{ UnwrappedTileID{ 13, 2056, 2913 }, {} },
-        MaskedRenderable{ UnwrappedTileID{ 14, 4112, 5824 }, {} },
-        MaskedRenderable{ UnwrappedTileID{ 14, 4112, 5827 }, {} },
-        MaskedRenderable{ UnwrappedTileID{ 14, 4114, 5824 }, {} },
-        MaskedRenderable{ UnwrappedTileID{ 14, 4114, 5825 }, {} },
+    std::map<UnwrappedTileID, FakeTile> renderables = {
+        { UnwrappedTileID{ 12, 1028, 1456 }, TileMask{} },
+        { UnwrappedTileID{ 13, 2056, 2912 }, TileMask{} },
+        { UnwrappedTileID{ 13, 2056, 2913 }, TileMask{} },
+        { UnwrappedTileID{ 14, 4112, 5824 }, TileMask{} },
+        { UnwrappedTileID{ 14, 4112, 5827 }, TileMask{} },
+        { UnwrappedTileID{ 14, 4114, 5824 }, TileMask{} },
+        { UnwrappedTileID{ 14, 4114, 5825 }, TileMask{} },
     };
 
     while (state.KeepRunning()) {
-        algorithm::updateTileMasks<MaskedRenderable>({ renderables.begin(), renderables.end() });
+        algorithm::updateTileMasks(renderables);
     }
 }
 

--- a/include/mbgl/tile/tile_id.hpp
+++ b/include/mbgl/tile/tile_id.hpp
@@ -58,7 +58,7 @@ public:
     uint32_t overscaleFactor() const;
     OverscaledTileID scaledTo(uint8_t z) const;
     UnwrappedTileID toUnwrapped() const;
-    OverscaledTileID unwrapTo(int16_t wrap);
+    OverscaledTileID unwrapTo(int16_t wrap) const;
 
     uint8_t overscaledZ;
     int16_t wrap;
@@ -85,7 +85,7 @@ public:
     std::array<UnwrappedTileID, 4> children() const;
     OverscaledTileID overscaleTo(uint8_t z) const;
     float pixelsToTileUnits(float pixelValue, float zoom) const;
-    UnwrappedTileID unwrapTo(int16_t wrap);
+    UnwrappedTileID unwrapTo(int16_t wrap) const;
 
     int16_t wrap;
     CanonicalTileID canonical;
@@ -194,7 +194,7 @@ inline UnwrappedTileID OverscaledTileID::toUnwrapped() const {
     return { wrap, canonical };
 }
 
-inline OverscaledTileID OverscaledTileID::unwrapTo(int16_t newWrap) {
+inline OverscaledTileID OverscaledTileID::unwrapTo(int16_t newWrap) const {
     return { overscaledZ, newWrap, canonical };
 }
 
@@ -222,7 +222,7 @@ inline bool UnwrappedTileID::operator<(const UnwrappedTileID& rhs) const {
     return std::tie(wrap, canonical) < std::tie(rhs.wrap, rhs.canonical);
 }
 
-inline UnwrappedTileID UnwrappedTileID::unwrapTo(int16_t newWrap) {
+inline UnwrappedTileID UnwrappedTileID::unwrapTo(int16_t newWrap) const {
     return { newWrap, canonical };
 }
 

--- a/src/mbgl/algorithm/update_tile_masks.hpp
+++ b/src/mbgl/algorithm/update_tile_masks.hpp
@@ -11,26 +11,38 @@ namespace algorithm {
 
 namespace {
 
-template <typename Renderable>
+template <typename T>
+bool tileNeedsMask(const std::reference_wrapper<T>& tile) { return tile.get().usedByRenderedLayers; }
+template <typename T> 
+void setTileMask(const std::reference_wrapper<T>& tile, TileMask&& mask ) { return tile.get().setMask(std::move(mask)); }
+
+// Overloads for tests
+template <typename T> bool tileNeedsMask(const T& tile) { return tile.usedByRenderedLayers; }
+template <typename T> void setTileMask(T& tile, TileMask&& mask ) { return tile.setMask(std::move(mask)); }
+
+template <typename Iterator>
 void computeTileMasks(
     const CanonicalTileID& root,
-    const UnwrappedTileID ref,
-    typename std::vector<std::reference_wrapper<Renderable>>::const_iterator it,
-    const typename std::vector<std::reference_wrapper<Renderable>>::const_iterator end,
+    const UnwrappedTileID& ref,
+    const Iterator begin,
+    const Iterator end,
     TileMask& mask) {
     // If the reference or any of its children is found in the list, we need to recurse.
-    for (; it != end; ++it) {
-        auto& renderable = it->get();
-        if (!renderable.used) {
+    for (auto it = begin; it != end; ++it) {
+        const UnwrappedTileID& id = it->first;
+        if (!tileNeedsMask(it->second)) {
             continue;
         }
-        if (ref == renderable.id) {
+
+        if (ref == id) {
             // The current tile is masked out, so we don't need to add them to the mask set.
             return;
-        } else if (renderable.id.isChildOf(ref)) {
+        } 
+
+        if (id.isChildOf(ref)) {
             // There's at least one child tile that is masked out, so recursively descend.
             for (const auto& child : ref.children()) {
-                computeTileMasks<Renderable>(root, child, it, end, mask);
+                computeTileMasks(root, child, it, end, mask);
             }
             return;
         }
@@ -45,10 +57,10 @@ void computeTileMasks(
 
 } // namespace
 
-// Updates the TileMasks for all renderables. Renderables are objects that have an UnwrappedTileID
-// property indicating where they should be rendered on the screen. A TileMask describes all regions
-// within that tile that are *not* covered by other Renderables.
-// Example: Renderables in our list are 2/1/3, 3/3/6, and 4/5/13. The schematic for creating the
+// Updates the TileMasks for all renderable tiles. Each renderable tile has a corresponding UnwrappedTileID
+// indicating where it should be rendered on the screen. A TileMask describes all regions
+// within a renderable tile that are *not* covered by other renderable tiles.
+// Example: Renderable tiles in our list are 2/1/3, 3/3/6, and 4/5/13. The schematic for creating the
 // TileMask for 2/1/3 looks like this:
 //
 //    ┌────────┬────────┬─────────────────┐
@@ -70,7 +82,7 @@ void computeTileMasks(
 //    └─────────────────┴─────────────────┘
 //
 // The TileMask for 2/1/3 thus consists of the tiles 4/4/12, 4/5/12, 4/4/13, 3/2/7, and 3/3/7,
-// but it does *not* include 4/5/13, and 3/3/6, since these are other Renderables.
+// but it does *not* include 4/5/13, and 3/3/6, since these are other renderable tiles.
 // A TileMask always contains TileIDs *relative* to the tile it is generated for, so 2/1/3 is
 // "subtracted" from these TileIDs. The final TileMask for 2/1/3 will thus be:
 //
@@ -92,21 +104,16 @@ void computeTileMasks(
 //    │                 │                 │
 //    └─────────────────┴─────────────────┘
 //
-// Only other Renderables that are *children* of the Renderable we are generating the mask for will
-// be considered. For example, adding a Renderable with TileID 4/8/13 won't affect the TileMask for
+// Only other renderable tiles that are *children* of the renderable tile we are generating the mask for will
+// will be considered. For example, adding a renderable tile with TileID 4/8/13 won't affect the TileMask for
 // 2/1/3, since it is not a descendant of it.
-//
-// The given |renderables| must be sorted by id.
-template <typename Renderable>
-void updateTileMasks(std::vector<std::reference_wrapper<Renderable>> renderables) {
-    assert(std::is_sorted(renderables.begin(), renderables.end(),
-        [](const Renderable& a, const Renderable& b) { return a.id < b.id; }));
-
+template <typename RenderableTilesMap>
+void updateTileMasks(RenderableTilesMap& renderables) {
     TileMask mask;
     const auto end = renderables.end();
-    for (auto it = renderables.begin(); it != end; it++) {
-        auto& renderable = it->get();
-        if (!renderable.used) {
+    for (auto it = renderables.begin(); it != end; ++it) {
+        const UnwrappedTileID& id = it->first;
+        if (!tileNeedsMask(it->second)) {
             continue;
         }
         // Try to add all remaining ids as children. We sorted the tile list
@@ -116,13 +123,12 @@ void updateTileMasks(std::vector<std::reference_wrapper<Renderable>> renderables
         auto child_it = std::next(it);
         const auto children_end = std::lower_bound(
             child_it, end,
-            UnwrappedTileID{ static_cast<int16_t>(renderable.id.wrap + 1), { 0, 0, 0 } },
-            [](auto& a, auto& b) { return a.get().id < b; });
+            UnwrappedTileID{ static_cast<int16_t>(id.wrap + 1), { 0, 0, 0 } },
+            [](auto& a, auto& b) { return a.first < b; });
 
         mask.clear();
-        computeTileMasks<Renderable>(renderable.id.canonical, renderable.id, child_it, children_end,
-                                     mask);
-        renderable.setMask(std::move(mask));
+        computeTileMasks(id.canonical, id, child_it, children_end, mask);
+        setTileMask(it->second, std::move(mask));
     }
 }
 

--- a/src/mbgl/annotation/render_annotation_source.cpp
+++ b/src/mbgl/annotation/render_annotation_source.cpp
@@ -10,17 +10,13 @@ namespace mbgl {
 using namespace style;
 
 RenderAnnotationSource::RenderAnnotationSource(Immutable<AnnotationSource::Impl> impl_)
-    : RenderSource(impl_) {
+    : RenderTileSource(std::move(impl_)) {
     assert(LayerManager::annotationsEnabled);
     tilePyramid.setObserver(this);
 }
 
 const AnnotationSource::Impl& RenderAnnotationSource::impl() const {
     return static_cast<const AnnotationSource::Impl&>(*baseImpl);
-}
-
-bool RenderAnnotationSource::isLoaded() const {
-    return tilePyramid.isLoaded();
 }
 
 void RenderAnnotationSource::update(Immutable<style::Source::Impl> baseImpl_,
@@ -47,30 +43,6 @@ void RenderAnnotationSource::update(Immutable<style::Source::Impl> baseImpl_,
                        });
 }
 
-void RenderAnnotationSource::upload(gfx::UploadPass& uploadPass) {
-    tilePyramid.upload(uploadPass);
-}
-
-void RenderAnnotationSource::prepare(const SourcePrepareParameters& parameters) {
-    tilePyramid.prepare(parameters);
-}
-
-void RenderAnnotationSource::finishRender(PaintParameters& parameters) {
-    tilePyramid.finishRender(parameters);
-}
-
-void RenderAnnotationSource::updateFadingTiles() {
-    tilePyramid.updateFadingTiles();
-}
-
-bool RenderAnnotationSource::hasFadingTiles() const {
-    return tilePyramid.hasFadingTiles();
-}
-
-std::vector<std::reference_wrapper<RenderTile>> RenderAnnotationSource::getRenderTiles() {
-    return tilePyramid.getRenderTiles();
-}
-
 std::unordered_map<std::string, std::vector<Feature>>
 RenderAnnotationSource::queryRenderedFeatures(const ScreenLineString& geometry,
                                               const TransformState& transformState,
@@ -84,12 +56,5 @@ std::vector<Feature> RenderAnnotationSource::querySourceFeatures(const SourceQue
     return {};
 }
 
-void RenderAnnotationSource::reduceMemoryUse() {
-    tilePyramid.reduceMemoryUse();
-}
-
-void RenderAnnotationSource::dumpDebugLogs() const {
-    tilePyramid.dumpDebugLogs();
-}
 
 } // namespace mbgl

--- a/src/mbgl/annotation/render_annotation_source.hpp
+++ b/src/mbgl/annotation/render_annotation_source.hpp
@@ -1,30 +1,19 @@
 #pragma once
 
-#include <mbgl/renderer/render_source.hpp>
-#include <mbgl/renderer/tile_pyramid.hpp>
 #include <mbgl/annotation/annotation_source.hpp>
+#include <mbgl/renderer/sources/render_tile_source.hpp>
 
 namespace mbgl {
 
-class RenderAnnotationSource : public RenderSource {
+class RenderAnnotationSource final : public RenderTileSource {
 public:
-    RenderAnnotationSource(Immutable<AnnotationSource::Impl>);
-
-    bool isLoaded() const final;
+    explicit RenderAnnotationSource(Immutable<AnnotationSource::Impl>);
 
     void update(Immutable<style::Source::Impl>,
                 const std::vector<Immutable<style::LayerProperties>>&,
                 bool needsRendering,
                 bool needsRelayout,
                 const TileParameters&) final;
-
-    void upload(gfx::UploadPass&) final;
-    void prepare(const SourcePrepareParameters&) final;
-    void finishRender(PaintParameters&) final;
-    void updateFadingTiles() final;
-    bool hasFadingTiles() const final;
-
-    std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() final;
 
     std::unordered_map<std::string, std::vector<Feature>>
     queryRenderedFeatures(const ScreenLineString& geometry,
@@ -36,13 +25,8 @@ public:
     std::vector<Feature>
     querySourceFeatures(const SourceQueryOptions&) const final;
 
-    void reduceMemoryUse() final;
-    void dumpDebugLogs() const final;
-
 private:
     const AnnotationSource::Impl& impl() const;
-
-    TilePyramid tilePyramid;
 };
 
 template <>

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -54,6 +54,9 @@ public:
     uint8_t getIntegerZoom() const;
     double getZoomFraction() const;
 
+    // Scale
+    double getScale() const { return scale; }
+
     // Bounds
     void setLatLngBounds(LatLngBounds);
     LatLngBounds getLatLngBounds() const;

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -503,7 +503,7 @@ style::TextPaintProperties::PossiblyEvaluated RenderSymbolLayer::textPaintProper
 }
 
 void RenderSymbolLayer::prepare(const LayerPrepareParameters& params) {
-    renderTiles = params.source->getRenderTiles();
+    renderTiles = params.source->getRenderedTiles();
     const auto comp = [bearing = params.state.getBearing()](const RenderTile& a, const RenderTile& b) {
         Point<float> pa(a.id.canonical.x, a.id.canonical.y);
         Point<float> pb(b.id.canonical.x, b.id.canonical.y);

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -47,7 +47,7 @@ bool RenderLayer::supportsZoom(float zoom) const {
 
 void RenderLayer::prepare(const LayerPrepareParameters& params) {
     assert(params.source);
-    renderTiles = filterRenderTiles(params.source->getRenderTiles());
+    renderTiles = filterRenderTiles(params.source->getRenderedTiles());
 }
 
 optional<Color> RenderLayer::getSolidBackground() const {

--- a/src/mbgl/renderer/render_source.hpp
+++ b/src/mbgl/renderer/render_source.hpp
@@ -74,7 +74,7 @@ public:
     virtual void updateFadingTiles() = 0;
     virtual bool hasFadingTiles() const = 0;
     // Returns a list of RenderTiles, sorted by tile id.
-    virtual std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() = 0;
+    virtual std::vector<std::reference_wrapper<RenderTile>> getRenderedTiles() = 0;
 
     virtual std::unordered_map<std::string, std::vector<Feature>>
     queryRenderedFeatures(const ScreenLineString& geometry,

--- a/src/mbgl/renderer/render_tile.cpp
+++ b/src/mbgl/renderer/render_tile.cpp
@@ -130,7 +130,7 @@ void RenderTile::prepare(const SourcePrepareParameters& parameters) {
 }
 
 void RenderTile::finishRender(PaintParameters& parameters) {
-    if (!used || parameters.debugOptions == MapDebugOptions::NoDebug)
+    if (!tile.usedByRenderedLayers || parameters.debugOptions == MapDebugOptions::NoDebug)
         return;
 
     static const style::Properties<>::PossiblyEvaluated properties {};

--- a/src/mbgl/renderer/render_tile.hpp
+++ b/src/mbgl/renderer/render_tile.hpp
@@ -39,7 +39,6 @@ public:
     UnwrappedTileID id;
     mat4 matrix;
     mat4 nearClippedMatrix;
-    bool used = false;
     // Contains the tile ID string for painting debug information.
     std::unique_ptr<DebugBucket> debugBucket;
 
@@ -72,7 +71,6 @@ public:
                             const TransformState& state,
                             const bool inViewportPixelUnits) const;
 private:
-    friend class TilePyramid;
     Tile& tile;
 };
 

--- a/src/mbgl/renderer/sources/render_image_source.hpp
+++ b/src/mbgl/renderer/sources/render_image_source.hpp
@@ -33,7 +33,7 @@ public:
                 bool needsRelayout,
                 const TileParameters&) final;
 
-    std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() final {
+    std::vector<std::reference_wrapper<RenderTile>> getRenderedTiles() final {
         return {};
     }
 

--- a/src/mbgl/renderer/sources/render_raster_dem_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.cpp
@@ -52,7 +52,7 @@ void RenderRasterDEMSource::update(Immutable<style::Source::Impl> baseImpl_,
                        [&] (const OverscaledTileID& tileID) {
                            return std::make_unique<RasterDEMTile>(tileID, parameters, *tileset);
                        });
-    algorithm::updateTileMasks(tilePyramid.getRenderTiles());
+    algorithm::updateTileMasks(tilePyramid.getRenderedTiles());
 }
 
 void RenderRasterDEMSource::onTileChanged(Tile& tile){

--- a/src/mbgl/renderer/sources/render_raster_dem_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.cpp
@@ -52,6 +52,7 @@ void RenderRasterDEMSource::update(Immutable<style::Source::Impl> baseImpl_,
                        [&] (const OverscaledTileID& tileID) {
                            return std::make_unique<RasterDEMTile>(tileID, parameters, *tileset);
                        });
+    algorithm::updateTileMasks(tilePyramid.getRenderTiles());
 }
 
 void RenderRasterDEMSource::onTileChanged(Tile& tile){
@@ -119,11 +120,6 @@ void RenderRasterDEMSource::onTileChanged(Tile& tile){
         }
     }
     RenderTileSource::onTileChanged(tile);
-}
-
-void RenderRasterDEMSource::prepare(const SourcePrepareParameters& parameters) {
-    algorithm::updateTileMasks(tilePyramid.getRenderTiles());
-    RenderTileSource::prepare(parameters);
 }
 
 std::unordered_map<std::string, std::vector<Feature>>

--- a/src/mbgl/renderer/sources/render_raster_dem_source.hpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.hpp
@@ -16,8 +16,6 @@ public:
                 bool needsRelayout,
                 const TileParameters&) final;
 
-    void prepare(const SourcePrepareParameters&) override;
-
     std::unordered_map<std::string, std::vector<Feature>>
     queryRenderedFeatures(const ScreenLineString& geometry,
                           const TransformState& transformState,

--- a/src/mbgl/renderer/sources/render_raster_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_source.cpp
@@ -50,7 +50,7 @@ void RenderRasterSource::update(Immutable<style::Source::Impl> baseImpl_,
                        [&] (const OverscaledTileID& tileID) {
                            return std::make_unique<RasterTile>(tileID, parameters, *tileset);
                        });
-    algorithm::updateTileMasks(tilePyramid.getRenderTiles());
+    algorithm::updateTileMasks(tilePyramid.getRenderedTiles());
 }
 
 void RenderRasterSource::prepare(const SourcePrepareParameters& parameters) {

--- a/src/mbgl/renderer/sources/render_raster_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_source.cpp
@@ -50,10 +50,10 @@ void RenderRasterSource::update(Immutable<style::Source::Impl> baseImpl_,
                        [&] (const OverscaledTileID& tileID) {
                            return std::make_unique<RasterTile>(tileID, parameters, *tileset);
                        });
+    algorithm::updateTileMasks(tilePyramid.getRenderTiles());
 }
 
 void RenderRasterSource::prepare(const SourcePrepareParameters& parameters) {
-    algorithm::updateTileMasks(tilePyramid.getRenderTiles());
     RenderTileSource::prepare(parameters);
 }
 

--- a/src/mbgl/renderer/sources/render_tile_source.cpp
+++ b/src/mbgl/renderer/sources/render_tile_source.cpp
@@ -28,6 +28,7 @@ void RenderTileSource::upload(gfx::UploadPass& parameters) {
 
 void RenderTileSource::prepare(const SourcePrepareParameters& parameters) {
     renderTiles.clear();
+    renderTiles.reserve(tilePyramid.getRenderedTiles().size());
     for (auto& entry : tilePyramid.getRenderedTiles()) {
         renderTiles.emplace_back(entry.first, entry.second);
         renderTiles.back().prepare(parameters);

--- a/src/mbgl/renderer/sources/render_tile_source.cpp
+++ b/src/mbgl/renderer/sources/render_tile_source.cpp
@@ -28,7 +28,7 @@ void RenderTileSource::upload(gfx::UploadPass& parameters) {
 
 void RenderTileSource::prepare(const SourcePrepareParameters& parameters) {
     renderTiles.clear();
-    for (auto& entry : tilePyramid.getRenderTiles()) {
+    for (auto& entry : tilePyramid.getRenderedTiles()) {
         renderTiles.emplace_back(entry.first, entry.second);
         renderTiles.back().prepare(parameters);
     }
@@ -48,7 +48,7 @@ bool RenderTileSource::hasFadingTiles() const {
     return tilePyramid.hasFadingTiles();
 }
 
-std::vector<std::reference_wrapper<RenderTile>> RenderTileSource::getRenderTiles() {
+std::vector<std::reference_wrapper<RenderTile>> RenderTileSource::getRenderedTiles() {
     return { renderTiles.begin(), renderTiles.end() };
 }
 

--- a/src/mbgl/renderer/sources/render_tile_source.hpp
+++ b/src/mbgl/renderer/sources/render_tile_source.hpp
@@ -39,6 +39,7 @@ public:
 
 protected:
     TilePyramid tilePyramid;
+    std::vector<RenderTile> renderTiles;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/sources/render_tile_source.hpp
+++ b/src/mbgl/renderer/sources/render_tile_source.hpp
@@ -22,7 +22,7 @@ public:
     void updateFadingTiles() override;
     bool hasFadingTiles() const override;
 
-    std::vector<std::reference_wrapper<RenderTile>> getRenderTiles() override;
+    std::vector<std::reference_wrapper<RenderTile>> getRenderedTiles() override;
 
     std::unordered_map<std::string, std::vector<Feature>>
     queryRenderedFeatures(const ScreenLineString& geometry,

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -314,7 +314,7 @@ std::unordered_map<std::string, std::vector<Feature>> TilePyramid::queryRendered
         const UnwrappedTileID& id = entry.first;
         Tile& tile = entry.second;
 
-        const float scale = std::pow(2, transformState.getZoom() - id.canonical.z);
+        const float scale = transformState.getScale() / (1 << id.canonical.z); // equivalent to std::pow(2, transformState.getZoom() - id.canonical.z);
         auto queryPadding = maxPitchScaleFactor * tile.getQueryPadding(layers) * util::EXTENT / util::tileSize / scale;
 
         GeometryCoordinate tileSpaceBoundsMin = TileCoordinate::toGeometryCoordinate(id, box.min);

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -1,5 +1,4 @@
 #include <mbgl/renderer/tile_pyramid.hpp>
-#include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/renderer/paint_parameters.hpp>
 #include <mbgl/renderer/render_source.hpp>
 #include <mbgl/renderer/tile_parameters.hpp>
@@ -40,31 +39,9 @@ bool TilePyramid::isLoaded() const {
     return true;
 }
 
-void TilePyramid::upload(gfx::UploadPass& parameters) {
-    for (auto& tile : renderTiles) {
-        tile.upload(parameters);
-    }
-}
-
-void TilePyramid::prepare(const SourcePrepareParameters& parameters) {
-    for (auto& tile : renderTiles) {
-        tile.prepare(parameters);
-    }
-}
-
-void TilePyramid::finishRender(PaintParameters& parameters) {
-    for (auto& tile : renderTiles) {
-        tile.finishRender(parameters);
-    }
-}
-
-std::vector<std::reference_wrapper<RenderTile>> TilePyramid::getRenderTiles() {
-    return { renderTiles.begin(), renderTiles.end() };
-}
-
 Tile* TilePyramid::getTile(const OverscaledTileID& tileID){
-        auto it = tiles.find(tileID);
-        return it == tiles.end() ? cache.get(tileID) : it->second.get();
+    auto it = tiles.find(tileID);
+    return it == tiles.end() ? cache.get(tileID) : it->second.get();
 }
 
 void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& layers,
@@ -176,10 +153,7 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
         return tiles.emplace(tileID, std::move(tile)).first->second.get();
     };
 
-    std::map<UnwrappedTileID, Tile*> previouslyRenderedTiles;
-    for (auto& renderTile : renderTiles) {
-        previouslyRenderedTiles[renderTile.id] = &renderTile.tile;
-    }
+    auto previouslyRenderedTiles = std::move(renderTiles);
 
     auto renderTileFn = [&](const UnwrappedTileID& tileID, Tile& tile) {
         addRenderTile(tileID, tile);
@@ -198,7 +172,7 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
                                  idealTiles, zoomRange, tileZoom);
     
     for (auto previouslyRenderedTile : previouslyRenderedTiles) {
-        Tile& tile = *previouslyRenderedTile.second;
+        Tile& tile = previouslyRenderedTile.second;
         tile.markRenderedPreviously();
         if (tile.holdForFade()) {
             // Since it was rendered in the last frame, we know we have it
@@ -244,10 +218,11 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
 
     fadingTiles = false;
 
-    // Initialize render tiles fields and update the tile contained layer render data.
-    for (RenderTile& renderTile : renderTiles) {
-        Tile& tile = renderTile.tile;
+    // Initialize renderable tiles and update the contained layer render data.
+    for (auto& entry : renderTiles) {
+        Tile& tile = entry.second;
         assert(tile.isRenderable());
+        tile.usedByRenderedLayers = false;
 
         const bool holdForFade = tile.holdForFade();
         fadingTiles = (fadingTiles || holdForFade);
@@ -260,7 +235,7 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
             bool layerRenderableInTile = tile.isComplete() ? tile.updateLayerProperties(layerProperties)
                                                            : static_cast<bool>(tile.getBucket(*layerProperties->baseImpl));
             if (layerRenderableInTile) {
-                renderTile.used = true;
+                tile.usedByRenderedLayers = true;
             }
         }
     }
@@ -290,6 +265,7 @@ void TilePyramid::handleWrapJump(float lng) {
 
     if (wrapDelta) {
         std::map<OverscaledTileID, std::unique_ptr<Tile>> newTiles;
+        std::map<UnwrappedTileID, std::reference_wrapper<Tile>> newRenderTiles;
         for (auto& tile : tiles) {
             auto newID = tile.second->id.unwrapTo(tile.second->id.wrap + wrapDelta);
             tile.second->id = newID;
@@ -297,9 +273,11 @@ void TilePyramid::handleWrapJump(float lng) {
         }
         tiles = std::move(newTiles);
 
-        for (auto& renderTile : renderTiles) {
-            renderTile.id = renderTile.id.unwrapTo(renderTile.id.wrap + wrapDelta);
+        for (auto& tile : renderTiles) {
+            UnwrappedTileID newID = tile.first.unwrapTo(tile.first.wrap + wrapDelta);
+            newRenderTiles.emplace(newID, tile.second);
         }
+        renderTiles = std::move(newRenderTiles);
     }
 }
 
@@ -322,26 +300,29 @@ std::unordered_map<std::string, std::vector<Feature>> TilePyramid::queryRendered
     }
 
     mapbox::geometry::box<double> box = mapbox::geometry::envelope(queryGeometry);
-    // TODO: Find out why we need a special sorting algorithm here.
-    std::vector<std::reference_wrapper<const RenderTile>> sortedTiles{ renderTiles.begin(),
-                                                                       renderTiles.end() };
-    std::sort(sortedTiles.begin(), sortedTiles.end(), [](const RenderTile& a, const RenderTile& b) {
-        return std::tie(a.id.canonical.z, a.id.canonical.y, a.id.wrap, a.id.canonical.x) <
-            std::tie(b.id.canonical.z, b.id.canonical.y, b.id.wrap, b.id.canonical.x);
-    });
+
+    auto cmp = [](const UnwrappedTileID& a, const UnwrappedTileID& b) {
+        return std::tie(a.canonical.z, a.canonical.y, a.wrap, a.canonical.x) <
+            std::tie(b.canonical.z, b.canonical.y, b.wrap, b.canonical.x);
+    };
+
+    std::map<UnwrappedTileID, std::reference_wrapper<Tile>, decltype(cmp)> sortedTiles{renderTiles.begin(), renderTiles.end(), cmp};
 
     auto maxPitchScaleFactor = transformState.maxPitchScaleFactor();
 
-    for (const RenderTile& renderTile : sortedTiles) {
-        const float scale = std::pow(2, transformState.getZoom() - renderTile.id.canonical.z);
-        auto queryPadding = maxPitchScaleFactor * renderTile.tile.getQueryPadding(layers) * util::EXTENT / util::tileSize / scale;
+    for (const auto& entry : sortedTiles) {
+        const UnwrappedTileID& id = entry.first;
+        Tile& tile = entry.second;
 
-        GeometryCoordinate tileSpaceBoundsMin = TileCoordinate::toGeometryCoordinate(renderTile.id, box.min);
+        const float scale = std::pow(2, transformState.getZoom() - id.canonical.z);
+        auto queryPadding = maxPitchScaleFactor * tile.getQueryPadding(layers) * util::EXTENT / util::tileSize / scale;
+
+        GeometryCoordinate tileSpaceBoundsMin = TileCoordinate::toGeometryCoordinate(id, box.min);
         if (tileSpaceBoundsMin.x - queryPadding >= util::EXTENT || tileSpaceBoundsMin.y - queryPadding >= util::EXTENT) {
             continue;
         }
 
-        GeometryCoordinate tileSpaceBoundsMax = TileCoordinate::toGeometryCoordinate(renderTile.id, box.max);
+        GeometryCoordinate tileSpaceBoundsMax = TileCoordinate::toGeometryCoordinate(id, box.max);
         if (tileSpaceBoundsMax.x + queryPadding < 0 || tileSpaceBoundsMax.y + queryPadding < 0) {
             continue;
         }
@@ -349,15 +330,15 @@ std::unordered_map<std::string, std::vector<Feature>> TilePyramid::queryRendered
         GeometryCoordinates tileSpaceQueryGeometry;
         tileSpaceQueryGeometry.reserve(queryGeometry.size());
         for (const auto& c : queryGeometry) {
-            tileSpaceQueryGeometry.push_back(TileCoordinate::toGeometryCoordinate(renderTile.id, c));
+            tileSpaceQueryGeometry.push_back(TileCoordinate::toGeometryCoordinate(id, c));
         }
 
-        renderTile.tile.queryRenderedFeatures(result,
-                                              tileSpaceQueryGeometry,
-                                              transformState,
-                                              layers,
-                                              options,
-                                              projMatrix);
+        tile.queryRenderedFeatures(result,
+                                   tileSpaceQueryGeometry,
+                                   transformState,
+                                   layers,
+                                   options,
+                                   projMatrix);
     }
 
     return result;
@@ -399,14 +380,12 @@ void TilePyramid::clearAll() {
 
 void TilePyramid::addRenderTile(const UnwrappedTileID& tileID, Tile& tile) {
     assert(tile.isRenderable());
-    auto it = std::lower_bound(renderTiles.begin(), renderTiles.end(), tileID,
-        [](const RenderTile& a, const UnwrappedTileID& id) { return a.id < id; });
-    renderTiles.emplace(it, tileID, tile);
+    renderTiles.emplace(tileID, tile);
 }
 
 void TilePyramid::updateFadingTiles() {
-    for (auto& renderTile : renderTiles) {
-        Tile& tile = renderTile.tile;
+    for (auto& entry : renderTiles) {
+        Tile& tile = entry.second;
         if (tile.holdForFade()) {
             tile.performedFadePlacement();
         }

--- a/src/mbgl/renderer/tile_pyramid.hpp
+++ b/src/mbgl/renderer/tile_pyramid.hpp
@@ -20,7 +20,6 @@ namespace mbgl {
 
 class PaintParameters;
 class TransformState;
-class RenderTile;
 class RenderLayer;
 class RenderedQueryOptions;
 class SourceQueryOptions;
@@ -44,11 +43,7 @@ public:
                 optional<LatLngBounds> bounds,
                 std::function<std::unique_ptr<Tile> (const OverscaledTileID&)> createTile);
 
-    void upload(gfx::UploadPass&);
-    void prepare(const SourcePrepareParameters&);
-    void finishRender(PaintParameters&);
-
-    std::vector<std::reference_wrapper<RenderTile>> getRenderTiles();
+    const std::map<UnwrappedTileID, std::reference_wrapper<Tile>>& getRenderTiles() const { return renderTiles; }
     Tile* getTile(const OverscaledTileID&);
 
     void handleWrapJump(float lng);
@@ -80,8 +75,7 @@ private:
     std::map<OverscaledTileID, std::unique_ptr<Tile>> tiles;
     TileCache cache;
 
-    std::list<RenderTile> renderTiles;
-
+    std::map<UnwrappedTileID, std::reference_wrapper<Tile>> renderTiles; // Sorted by tile id.
     TileObserver* observer = nullptr;
 
     float prevLng = 0;

--- a/src/mbgl/renderer/tile_pyramid.hpp
+++ b/src/mbgl/renderer/tile_pyramid.hpp
@@ -43,7 +43,7 @@ public:
                 optional<LatLngBounds> bounds,
                 std::function<std::unique_ptr<Tile> (const OverscaledTileID&)> createTile);
 
-    const std::map<UnwrappedTileID, std::reference_wrapper<Tile>>& getRenderTiles() const { return renderTiles; }
+    const std::map<UnwrappedTileID, std::reference_wrapper<Tile>>& getRenderedTiles() const { return renderTiles; }
     Tile* getTile(const OverscaledTileID&);
 
     void handleWrapJump(float lng);

--- a/src/mbgl/tile/tile.hpp
+++ b/src/mbgl/tile/tile.hpp
@@ -131,12 +131,16 @@ public:
     OverscaledTileID id;
     optional<Timestamp> modified;
     optional<Timestamp> expires;
+    // Indicates whether this tile is used for the currently visible layers on the map.
+    // Re-initialized at every source update.
+    bool usedByRenderedLayers = false;
 
 protected:
     bool triedOptional = false;
     bool renderable = false;
     bool pending = false;
     bool loaded = false;
+
 
     TileObserver* observer = nullptr;
 };

--- a/test/algorithm/update_tile_masks.test.cpp
+++ b/test/algorithm/update_tile_masks.test.cpp
@@ -1,135 +1,116 @@
 #include <mbgl/test/util.hpp>
-
 #include <mbgl/algorithm/update_tile_masks.hpp>
 
 using namespace mbgl;
 
 namespace {
 
-class MaskedRenderable {
+class FakeTile {
 public:
-    MaskedRenderable(const UnwrappedTileID& id_, TileMask&& mask_)
-        : id(id_), mask(std::move(mask_)) {
+    FakeTile(TileMask mask_)
+        : mask(std::move(mask_)) {
     }
-
-    UnwrappedTileID id;
-    TileMask mask;
-    bool used = true;
-
-    void setMask(TileMask&& mask_) {
+    void setMask(TileMask mask_) {
         mask = std::move(mask_);
     }
+
+    const bool usedByRenderedLayers = true;
+    TileMask mask;
 };
 
-bool operator==(const MaskedRenderable& lhs, const MaskedRenderable& rhs) {
-    return lhs.id == rhs.id && lhs.mask == rhs.mask;
-}
-
-::std::ostream& operator<<(::std::ostream& os, const MaskedRenderable& rhs) {
-    os << "MaskedRenderable{ " << rhs.id << ", { ";
-    bool first = true;
-    for (auto& id : rhs.mask) {
-        if (!first) {
-            os << ", ";
-        } else {
-            first = false;
-        }
-        os << id;
-    }
-    return os << " } }";
+bool operator==(const FakeTile& lhs, const FakeTile& rhs) {
+    return lhs.mask == rhs.mask;
 }
 
 } // namespace
 
-void validate(const std::vector<MaskedRenderable> expected) {
-    std::vector<MaskedRenderable> actual = expected;
+void validate(std::map<UnwrappedTileID, FakeTile> expected) {
+    auto actual = expected;
     std::for_each(actual.begin(), actual.end(),
-                  [](auto& renderable) { renderable.mask.clear(); });
-    std::vector<std::reference_wrapper<MaskedRenderable>> sorted(actual.begin(), actual.end());
-    std::sort(sorted.begin(), sorted.end(),
-                  [](const MaskedRenderable& a, const MaskedRenderable& b){ return a.id < b.id; });
-    algorithm::updateTileMasks<MaskedRenderable>(std::move(sorted));
+                  [](auto& renderable) { renderable.second.mask.clear(); });
+
+    algorithm::updateTileMasks(actual);
     EXPECT_EQ(expected, actual);
 }
 
 TEST(UpdateTileMasks, NoChildren) {
     validate({
-        MaskedRenderable{ UnwrappedTileID{ 0, 0, 0 }, { CanonicalTileID{ 0, 0, 0 } } },
+        { UnwrappedTileID{ 0, 0, 0 }, TileMask{ CanonicalTileID{ 0, 0, 0 } } }
     });
 
     validate({
-        MaskedRenderable{ UnwrappedTileID{ 4, 3, 8 }, { CanonicalTileID{ 0, 0, 0 } } },
+        { UnwrappedTileID{ 4, 3, 8 }, TileMask{ CanonicalTileID{ 0, 0, 0 } } },
     });
 
     validate({
-        MaskedRenderable{ UnwrappedTileID{ 1, 0, 0 }, { CanonicalTileID{ 0, 0, 0 } } },
-        MaskedRenderable{ UnwrappedTileID{ 1, 1, 1 }, { CanonicalTileID{ 0, 0, 0 } } },
+        { UnwrappedTileID{ 1, 0, 0 }, TileMask{ CanonicalTileID{ 0, 0, 0 } } },
+        { UnwrappedTileID{ 1, 1, 1 }, TileMask{ CanonicalTileID{ 0, 0, 0 } } },
     });
 
     validate({
-        MaskedRenderable{ UnwrappedTileID{ 1, 0, 0 }, { CanonicalTileID{ 0, 0, 0 } } },
-        MaskedRenderable{ UnwrappedTileID{ 2, 2, 3 }, { CanonicalTileID{ 0, 0, 0 } } },
+        { UnwrappedTileID{ 1, 0, 0 }, TileMask{ CanonicalTileID{ 0, 0, 0 } } },
+        { UnwrappedTileID{ 2, 2, 3 }, TileMask{ CanonicalTileID{ 0, 0, 0 } } },
     });
 }
 
 TEST(UpdateTileMasks, ParentAndFourChildren) {
     validate({
         // Mask is empty (== not rendered!) because we have four covering children.
-        MaskedRenderable{ UnwrappedTileID{ 0, 0, 0 }, {} },
+        { UnwrappedTileID{ 0, 0, 0 }, TileMask{} },
         // All four covering children
-        MaskedRenderable{ UnwrappedTileID{ 1, 0, 0 }, { CanonicalTileID{ 0, 0, 0 } } },
-        MaskedRenderable{ UnwrappedTileID{ 1, 0, 1 }, { CanonicalTileID{ 0, 0, 0 } } },
-        MaskedRenderable{ UnwrappedTileID{ 1, 1, 0 }, { CanonicalTileID{ 0, 0, 0 } } },
-        MaskedRenderable{ UnwrappedTileID{ 1, 1, 1 }, { CanonicalTileID{ 0, 0, 0 } } },
+        { UnwrappedTileID{ 1, 0, 0 }, TileMask{ CanonicalTileID{ 0, 0, 0 } } },
+        { UnwrappedTileID{ 1, 0, 1 }, TileMask{ CanonicalTileID{ 0, 0, 0 } } },
+        { UnwrappedTileID{ 1, 1, 0 }, TileMask{ CanonicalTileID{ 0, 0, 0 } } },
+        { UnwrappedTileID{ 1, 1, 1 }, TileMask{ CanonicalTileID{ 0, 0, 0 } } },
     });
 }
 
 TEST(UpdateTileMasks, OneChild) {
     validate({
-        MaskedRenderable{ UnwrappedTileID{ 0, 0, 0 },
-                          // Only render the three children that aren't covering the other tile.
-                          { CanonicalTileID{ 1, 0, 1 }, CanonicalTileID{ 1, 1, 0 },
-                            CanonicalTileID{ 1, 1, 1 } } },
-        MaskedRenderable{ UnwrappedTileID{ 1, 0, 0 }, { CanonicalTileID{ 0, 0, 0 } } },
+        { UnwrappedTileID{ 0, 0, 0 },
+            // Only render the three children that aren't covering the other tile.
+            TileMask{ CanonicalTileID{ 1, 0, 1 }, CanonicalTileID{ 1, 1, 0 },
+                      CanonicalTileID{ 1, 1, 1 } } },
+        { UnwrappedTileID{ 1, 0, 0 }, TileMask{ CanonicalTileID{ 0, 0, 0 } } },
     });
 }
 
 TEST(UpdateTileMasks, Complex) {
     validate({
-        MaskedRenderable{ UnwrappedTileID{ 0, 0, 0 },
-                          { CanonicalTileID{ 1, 0, 1 }, CanonicalTileID{ 1, 1, 0 },
-                            CanonicalTileID{ 2, 2, 3 }, CanonicalTileID{ 2, 3, 2 },
-                            CanonicalTileID{ 3, 6, 7 }, CanonicalTileID{ 3, 7, 6 } } },
-        MaskedRenderable{ UnwrappedTileID{ 0, { 1, 0, 0 } }, { CanonicalTileID{ 0, 0, 0 } } },
-        MaskedRenderable{ UnwrappedTileID{ 0, { 2, 2, 2 } }, { CanonicalTileID{ 0, 0, 0 } } },
-        MaskedRenderable{ UnwrappedTileID{ 0, { 3, 7, 7 } }, { CanonicalTileID{ 0, 0, 0 } } },
-        MaskedRenderable{ UnwrappedTileID{ 0, { 3, 6, 6 } }, { CanonicalTileID{ 0, 0, 0 } } },
+        { UnwrappedTileID{ 0, 0, 0 },
+            TileMask{ CanonicalTileID{ 1, 0, 1 }, CanonicalTileID{ 1, 1, 0 },
+                      CanonicalTileID{ 2, 2, 3 }, CanonicalTileID{ 2, 3, 2 },
+                      CanonicalTileID{ 3, 6, 7 }, CanonicalTileID{ 3, 7, 6 } } },
+        { UnwrappedTileID{ 0, { 1, 0, 0 } }, TileMask{ CanonicalTileID{ 0, 0, 0 } } },
+        { UnwrappedTileID{ 0, { 2, 2, 2 } }, TileMask{ CanonicalTileID{ 0, 0, 0 } } },
+        { UnwrappedTileID{ 0, { 3, 7, 7 } }, TileMask{ CanonicalTileID{ 0, 0, 0 } } },
+        { UnwrappedTileID{ 0, { 3, 6, 6 } }, TileMask{ CanonicalTileID{ 0, 0, 0 } } },
     });
 
     validate({
-        MaskedRenderable{ UnwrappedTileID{ 0, 0, 0 },
-                          { CanonicalTileID{ 1, 0, 1 }, CanonicalTileID{ 1, 1, 0 },
-                            CanonicalTileID{ 1, 1, 1 }, CanonicalTileID{ 2, 0, 0 },
-                            CanonicalTileID{ 2, 0, 1 }, CanonicalTileID{ 2, 1, 0 },
-                            CanonicalTileID{ 3, 2, 3 }, CanonicalTileID{ 3, 3, 2 },
-                            CanonicalTileID{ 3, 3, 3 }, CanonicalTileID{ 4, 4, 5 },
-                            CanonicalTileID{ 4, 5, 4 }, CanonicalTileID{ 4, 5, 5 } } },
-        MaskedRenderable{ UnwrappedTileID{ 4, 4, 4 }, { CanonicalTileID{ 0, 0, 0 } } },
+        { UnwrappedTileID{ 0, 0, 0 },
+            TileMask{ CanonicalTileID{ 1, 0, 1 }, CanonicalTileID{ 1, 1, 0 },
+                      CanonicalTileID{ 1, 1, 1 }, CanonicalTileID{ 2, 0, 0 },
+                      CanonicalTileID{ 2, 0, 1 }, CanonicalTileID{ 2, 1, 0 },
+                      CanonicalTileID{ 3, 2, 3 }, CanonicalTileID{ 3, 3, 2 },
+                      CanonicalTileID{ 3, 3, 3 }, CanonicalTileID{ 4, 4, 5 },
+                      CanonicalTileID{ 4, 5, 4 }, CanonicalTileID{ 4, 5, 5 } } },
+        { UnwrappedTileID{ 4, 4, 4 }, TileMask{ CanonicalTileID{ 0, 0, 0 } } },
     });
 
     validate({
-        MaskedRenderable{ UnwrappedTileID{ 12, 1028, 1456 },
-                          { CanonicalTileID{ 1, 1, 1 }, CanonicalTileID{ 2, 3, 0 },
-                            CanonicalTileID{ 2, 3, 1 } } },
-        MaskedRenderable{ UnwrappedTileID{ 13, 2056, 2912 },
-                          { CanonicalTileID{ 1, 0, 1 }, CanonicalTileID{ 1, 1, 0 },
-                            CanonicalTileID{ 1, 1, 1 } } },
-        MaskedRenderable{ UnwrappedTileID{ 13, 2056, 2913 },
-                          { CanonicalTileID{ 1, 0, 0 }, CanonicalTileID{ 1, 1, 0 },
-                            CanonicalTileID{ 1, 1, 1 } } },
-        MaskedRenderable{ UnwrappedTileID{ 14, 4112, 5824 }, { CanonicalTileID{ 0, 0, 0 } } },
-        MaskedRenderable{ UnwrappedTileID{ 14, 4112, 5827 }, { CanonicalTileID{ 0, 0, 0 } } },
-        MaskedRenderable{ UnwrappedTileID{ 14, 4114, 5824 }, { CanonicalTileID{ 0, 0, 0 } } },
-        MaskedRenderable{ UnwrappedTileID{ 14, 4114, 5825 }, { CanonicalTileID{ 0, 0, 0 } } },
+        { UnwrappedTileID{ 12, 1028, 1456 },
+            TileMask{ CanonicalTileID{ 1, 1, 1 }, CanonicalTileID{ 2, 3, 0 },
+                      CanonicalTileID{ 2, 3, 1 } } },
+        { UnwrappedTileID{ 13, 2056, 2912 },
+            TileMask{ CanonicalTileID{ 1, 0, 1 }, CanonicalTileID{ 1, 1, 0 },
+                      CanonicalTileID{ 1, 1, 1 } } },
+        { UnwrappedTileID{ 13, 2056, 2913 },
+            TileMask{ CanonicalTileID{ 1, 0, 0 }, CanonicalTileID{ 1, 1, 0 },
+                      CanonicalTileID{ 1, 1, 1 } } },
+        { UnwrappedTileID{ 14, 4112, 5824 }, TileMask{ CanonicalTileID{ 0, 0, 0 } } },
+        { UnwrappedTileID{ 14, 4112, 5827 }, TileMask{ CanonicalTileID{ 0, 0, 0 } } },
+        { UnwrappedTileID{ 14, 4114, 5824 }, TileMask{ CanonicalTileID{ 0, 0, 0 } } },
+        { UnwrappedTileID{ 14, 4114, 5825 }, TileMask{ CanonicalTileID{ 0, 0, 0 } } },
     });
 }


### PR DESCRIPTION
Tile pyramid is no longer operating with `RenderTiles` and does not perform rendering operations: upload, finish render. 

Rationals: render tiles belong to rendering, and tile pyramid belongs to orchestration.

tag #14638 