### PR TITLE
[android] Fix compilation warning with updated clang

### DIFF
--- a/platform/android/src/style/value.hpp
+++ b/platform/android/src/style/value.hpp
@@ -13,7 +13,7 @@ public:
     Value(jni::JNIEnv&, const jni::Object<>&);
 
     Value(Value&&)                 = default;
-    Value& operator=(Value&&)      = default;
+    Value& operator=(Value&&)      = delete;
 
     Value(const Value&)            = delete;
     Value& operator=(const Value&) = delete;


### PR DESCRIPTION
`mbgl::android::Value` move assignment operator is implicitly deleted.