### PR TITLE
[android] Bumping Android telemetry to 4.5.1

### DIFF
--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
 
     versions = [
             mapboxServices  : '4.8.0',
-            mapboxTelemetry : '4.4.1',
+            mapboxTelemetry : '4.5.1',
             mapboxCore      : '1.3.0',
             mapboxGestures  : '0.4.2',
             mapboxAccounts  : '0.2.0',


### PR DESCRIPTION
This pr bumps the Telemetry dependency to  [`4.5.1`](https://github.com/mapbox/mapbox-events-android/issues/414) for the Maps SDK.