### PR TITLE
Change library loader to soloader

### DIFF
--- a/platform/android/LICENSE.md
+++ b/platform/android/LICENSE.md
@@ -117,9 +117,9 @@ License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the ReLinker.  
-URL: [https://github.com/KeepSafe/ReLinker](https://github.com/KeepSafe/ReLinker)  
-License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+Mapbox GL uses portions of the SoLoader.  
+URL: [https://github.com/facebook/soloader](https://github.com/facebook/soloader)  
+License: [BSD License](https://github.com/facebook/soloader/blob/master/LICENSE)
 
 ===========================================================================
 

--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation dependenciesList.supportAnnotations
     implementation dependenciesList.supportFragmentV4
     implementation dependenciesList.okhttp3
-    implementation dependenciesList.reLinker
+    implementation dependenciesList.soLoader
     testImplementation dependenciesList.junit
     testImplementation dependenciesList.mockito
     testImplementation dependenciesList.mockk

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/loader/LibraryLoaderProviderImpl.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/loader/LibraryLoaderProviderImpl.java
@@ -1,12 +1,13 @@
 package com.mapbox.mapboxsdk.module.loader;
 
-import android.content.Context;
-import com.getkeepsafe.relinker.ReLinker;
 import com.mapbox.mapboxsdk.LibraryLoader;
 import com.mapbox.mapboxsdk.LibraryLoaderProvider;
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.exceptions.MapboxConfigurationException;
 import com.mapbox.mapboxsdk.log.Logger;
+
+import static com.facebook.soloader.SoLoader.init;
+import static com.facebook.soloader.SoLoader.loadLibrary;
 
 /**
  * Concrete implementation of a native library loader.
@@ -23,35 +24,25 @@ public class LibraryLoaderProviderImpl implements LibraryLoaderProvider {
    */
   @Override
   public LibraryLoader getDefaultLibraryLoader() {
-    return new ReLinkerLibraryLoader();
+    return new SoLibraryLoader();
   }
 
   /**
    * Concrete implementation of a LibraryLoader using ReLinker.
    */
-  private static class ReLinkerLibraryLoader extends LibraryLoader {
+  private static class SoLibraryLoader extends LibraryLoader {
+
+    private static final String TAG = "SoLibraryLoader";
 
     @Override
     public void load(String name) {
       try {
-        Context context = Mapbox.getApplicationContext();
-        ReLinker.log(new LibraryLogger()).loadLibrary(context, name);
+        // nativeExopackage = false, https://buck.build/article/exopackage.html
+        init(Mapbox.getApplicationContext(), false);
+        loadLibrary(name);
       } catch (MapboxConfigurationException exception) {
-        Logger.e(LibraryLogger.TAG, "Couldn't load so file with relinker, application context missing, "
+        Logger.e(TAG, "Couldn't load so file with relinker, application context missing, "
           + "call Mapbox.getInstance(Context context, String accessToken) first");
-      }
-    }
-
-    /**
-     * Relinker library loader logger.
-     */
-    private static class LibraryLogger implements ReLinker.Logger {
-
-      private static final String TAG = "Mbgl-LibraryLoader";
-
-      @Override
-      public void log(String message) {
-        Logger.d(TAG, message);
       }
     }
   }

--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -31,7 +31,7 @@ ext {
             androidPublish  : '3.6.2',
             lint            : '26.1.4',
             gms             : '16.0.0',
-            reLinker        : '1.3.1',
+            soLoader        : '0.6.0',
             jacoco          : '0.8.3'
     ]
 
@@ -68,7 +68,7 @@ ext {
             okhttp3                : "com.squareup.okhttp3:okhttp:${versions.okhttp}",
             leakCanaryDebug        : "com.squareup.leakcanary:leakcanary-android:${versions.leakCanary}",
             leakCanaryRelease      : "com.squareup.leakcanary:leakcanary-android-no-op:${versions.leakCanary}",
-            reLinker               : "com.getkeepsafe.relinker:relinker:${versions.reLinker}",
+            soLoader               : "com.facebook.soloader:soloader:${versions.soLoader}",
 
             kotlinLib              : "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}",
             kotlinPlugin           : "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",


### PR DESCRIPTION
This PR changes our library loader from relinker to soloader. We initially switched to relinker based on advice given by Google in their NDK changelog. Now with getting feeedback as  https://github.com/mapbox/mapbox-gl-native/issues/14888 and https://github.com/mapbox/mapbox-gl-native/issues/14428. Let's move forward using [soloader](https://github.com/facebook/SoLoader) from Facebook. It should be more stable.

Closes #14428 
Closes #14888