### PR TITLE
[core] Add API for clearing tiles from the ambient cache

### DIFF
--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -145,6 +145,14 @@ public:
     void deleteOfflineRegion(OfflineRegion&&, std::function<void (std::exception_ptr)>);
 
     /*
+     * Invalidate all the tiles from an offline region forcing Mapbox GL to revalidate
+     * the tiles with the server before using. This is more efficient than deleting the
+     * offline region and downloading it again because if the data on the cache matches
+     * the server, no new data gets transmitted.
+     */
+    void invalidateOfflineRegion(OfflineRegion&, std::function<void (std::exception_ptr)>);
+
+    /*
      * Changing or bypassing this limit without permission from Mapbox is prohibited
      * by the Mapbox Terms of Service.
      */
@@ -185,6 +193,26 @@ public:
      * to re-execute a user-provided callback on the main thread.
      */
     void resetCache(std::function<void (std::exception_ptr)>);
+
+    /*
+     * Forces revalidation of tiles in the ambient cache.
+     *
+     * Forces Mapbox GL Native to revalidate tiles stored in the ambient
+     * cache with the tile server before using them, making sure they
+     * are the latest version. This is more efficient than cleaning the
+     * cache because if the tile is considered valid after the server
+     * lookup, it will not get downloaded again.
+     */
+    void invalidateTileCache(std::function<void (std::exception_ptr)>);
+
+    /*
+     * Erase tiles from the ambient cache, freeing storage space.
+     *
+     * Erases the tile cache, freeing resources. This operation can be
+     * potentially slow because it will trigger a VACUUM on SQLite,
+     * forcing the database to move pages on the filesystem.
+     */
+    void clearTileCache(std::function<void (std::exception_ptr)>);
 
     // For testing only.
     void setOnlineStatus(bool);

--- a/platform/default/include/mbgl/storage/offline_database.hpp
+++ b/platform/default/include/mbgl/storage/offline_database.hpp
@@ -58,6 +58,11 @@ public:
     // lookup, it will not get downloaded again.
     std::exception_ptr invalidateTileCache();
 
+    // Clear the tile cache, freeing resources. This operation can be
+    // potentially slow because it will trigger a VACUUM on SQLite,
+    // forcing the database to move pages on the filesystem.
+    std::exception_ptr clearTileCache();
+
     expected<OfflineRegions, std::exception_ptr> listRegions();
 
     expected<OfflineRegion, std::exception_ptr> createRegion(const OfflineRegionDefinition&,

--- a/platform/default/src/mbgl/storage/default_file_source.cpp
+++ b/platform/default/src/mbgl/storage/default_file_source.cpp
@@ -87,6 +87,10 @@ public:
         callback(offlineDatabase->deleteRegion(std::move(region)));
     }
 
+    void invalidateRegion(int64_t regionID, std::function<void (std::exception_ptr)> callback) {
+        callback(offlineDatabase->invalidateRegion(regionID));
+    }
+
     void setRegionObserver(int64_t regionID, std::unique_ptr<OfflineRegionObserver> observer) {
         if (auto download = getDownload(regionID)) {
             download.value()->setObserver(std::move(observer));
@@ -182,6 +186,14 @@ public:
 
     void resetCache(std::function<void (std::exception_ptr)> callback) {
         callback(offlineDatabase->resetCache());
+    }
+
+    void invalidateTileCache(std::function<void (std::exception_ptr)> callback) {
+        callback(offlineDatabase->invalidateTileCache());
+    }
+
+    void clearTileCache(std::function<void (std::exception_ptr)> callback) {
+        callback(offlineDatabase->clearTileCache());
     }
 
 private:
@@ -295,6 +307,10 @@ void DefaultFileSource::deleteOfflineRegion(OfflineRegion&& region, std::functio
     impl->actor().invoke(&Impl::deleteRegion, std::move(region), callback);
 }
 
+void DefaultFileSource::invalidateOfflineRegion(OfflineRegion& region, std::function<void (std::exception_ptr)> callback) {
+    impl->actor().invoke(&Impl::invalidateRegion, region.getID(), callback);
+}
+
 void DefaultFileSource::setOfflineRegionObserver(OfflineRegion& region, std::unique_ptr<OfflineRegionObserver> observer) {
     impl->actor().invoke(&Impl::setRegionObserver, region.getID(), std::move(observer));
 }
@@ -325,6 +341,14 @@ void DefaultFileSource::put(const Resource& resource, const Response& response) 
 
 void DefaultFileSource::resetCache(std::function<void (std::exception_ptr)> callback) {
     impl->actor().invoke(&Impl::resetCache, callback);
+}
+
+void DefaultFileSource::invalidateTileCache(std::function<void (std::exception_ptr)> callback) {
+    impl->actor().invoke(&Impl::invalidateTileCache, callback);
+}
+
+void DefaultFileSource::clearTileCache(std::function<void (std::exception_ptr)> callback) {
+    impl->actor().invoke(&Impl::clearTileCache, callback);
 }
 
 // For testing only:

--- a/platform/default/src/mbgl/storage/offline_database.cpp
+++ b/platform/default/src/mbgl/storage/offline_database.cpp
@@ -129,7 +129,6 @@ void OfflineDatabase::removeOldCacheTable() {
 
 void OfflineDatabase::createSchema() {
     assert(db);
-    db->exec("PRAGMA auto_vacuum = INCREMENTAL");
     db->exec("PRAGMA journal_mode = DELETE");
     db->exec("PRAGMA synchronous = FULL");
     mapbox::sqlite::Transaction transaction(*db);
@@ -140,7 +139,6 @@ void OfflineDatabase::createSchema() {
 
 void OfflineDatabase::migrateToVersion3() {
     assert(db);
-    db->exec("PRAGMA auto_vacuum = INCREMENTAL");
     db->exec("VACUUM");
     db->exec("PRAGMA user_version = 3");
 }
@@ -636,7 +634,7 @@ std::exception_ptr OfflineDatabase::clearTileCache() try {
 
     query.run();
 
-    db->exec("PRAGMA incremental_vacuum");
+    db->exec("VACUUM");
 
     return nullptr;
 } catch (const mapbox::sqlite::Exception& ex) {
@@ -811,7 +809,7 @@ std::exception_ptr OfflineDatabase::deleteRegion(OfflineRegion&& region) try {
 
     evict(0);
     assert(db);
-    db->exec("PRAGMA incremental_vacuum");
+    db->exec("VACUUM");
 
     // Ensure that the cached offlineTileCount value is recalculated.
     offlineMapboxTileCount = {};
@@ -1070,11 +1068,11 @@ T OfflineDatabase::getPragma(const char* sql) {
 // less than the maximum cache size. Returns false if this condition cannot be
 // satisfied.
 //
-// SQLite database never shrinks in size unless we call VACCUM. We here
+// SQLite database never shrinks in size unless we call VACUUM. We here
 // are monitoring the soft limit (i.e. number of free pages in the file)
 // and as it approaches to the hard limit (i.e. the actual file size) we
 // delete an arbitrary number of old cache entries. The free pages approach saves
-// us from calling VACCUM or keeping a running total, which can be costly.
+// us from calling VACUUM or keeping a running total, which can be costly.
 bool OfflineDatabase::evict(uint64_t neededFreeSize) {
     uint64_t pageSize = getPragma<int64_t>("PRAGMA page_size");
     uint64_t pageCount = getPragma<int64_t>("PRAGMA page_count");

--- a/platform/default/src/mbgl/storage/offline_database.cpp
+++ b/platform/default/src/mbgl/storage/offline_database.cpp
@@ -624,6 +624,26 @@ std::exception_ptr OfflineDatabase::invalidateTileCache() try {
     return std::current_exception();
 }
 
+std::exception_ptr OfflineDatabase::clearTileCache() try {
+    // clang-format off
+    mapbox::sqlite::Query query{ getStatement(
+        "DELETE FROM tiles "
+        "WHERE id NOT IN ("
+        "    SELECT tile_id FROM region_tiles"
+        ")"
+    ) };
+    // clang-format on
+
+    query.run();
+
+    db->exec("PRAGMA incremental_vacuum");
+
+    return nullptr;
+} catch (const mapbox::sqlite::Exception& ex) {
+    handleError(ex, "clear tile cache");
+    return std::current_exception();
+}
+
 std::exception_ptr OfflineDatabase::invalidateRegion(int64_t regionID) try {
     {
         // clang-format off


### PR DESCRIPTION
This new API will really remove the tiles and shrink the database by calling `VACUUM`, which can be potentially slow.

Fixes #14549