### PR TITLE
[ios, build] Add MORE_SIMULATORS option to iOS make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,9 +213,25 @@ IOS_XCODEBUILD_SIM = xcodebuild \
 	ARCHS=x86_64 ONLY_ACTIVE_ARCH=YES \
 	-derivedDataPath $(IOS_OUTPUT_PATH) \
 	-configuration $(BUILDTYPE) -sdk iphonesimulator \
-	-destination 'platform=iOS Simulator,name=iPhone 6,OS=latest' \
+	-destination 'platform=iOS Simulator,OS=latest,name=iPhone 8' \
 	-workspace $(IOS_WORK_PATH) \
 	-jobs $(JOBS)
+
+ifneq ($(MORE_SIMULATORS),)
+	IOS_XCODEBUILD_SIM += -parallel-testing-enabled YES \
+	-destination 'platform=iOS Simulator,OS=latest,name=iPhone Xs Max' \
+	-destination 'platform=iOS Simulator,OS=latest,name=iPhone Xr' \
+	-destination 'platform=iOS Simulator,OS=latest,name=iPad Pro (11-inch)' \
+	-destination 'platform=iOS Simulator,OS=11.4,name=iPhone 7' \
+	-destination 'platform=iOS Simulator,OS=11.4,name=iPhone X' \
+	-destination 'platform=iOS Simulator,OS=11.4,name=iPad Air 2,' \
+	-destination 'platform=iOS Simulator,OS=10.3.1,name=iPhone SE' \
+	-destination 'platform=iOS Simulator,OS=10.3.1,name=iPhone 7 Plus' \
+	-destination 'platform=iOS Simulator,OS=10.3.1,name=iPad Air' \
+	-destination 'platform=iOS Simulator,OS=9.3,name=iPhone 6s Plus' \
+	-destination 'platform=iOS Simulator,OS=9.3,name=iPhone 6s' \
+	-destination 'platform=iOS Simulator,OS=9.3,name=iPad 2'
+endif
 
 ifneq ($(CI),)
 	IOS_XCODEBUILD_SIM += -xcconfig platform/darwin/ci.xcconfig
@@ -264,6 +280,12 @@ ios-sanitize-address: $(IOS_PROJ_PATH)
 .PHONY: ios-static-analyzer
 ios-static-analyzer: $(IOS_PROJ_PATH)
 	set -o pipefail && $(IOS_XCODEBUILD_SIM) analyze -scheme 'CI' test $(XCPRETTY)
+
+.PHONY: ios-install-simulators
+ios-install-simulators:
+	xcversion simulators --install="iOS 11.4" || true
+	xcversion simulators --install="iOS 10.3.1" || true
+	xcversion simulators --install="iOS 9.3" || true
 
 .PHONY: ios-check-events-symbols
 ios-check-events-symbols:

--- a/platform/ios/DEVELOPING.md
+++ b/platform/ios/DEVELOPING.md
@@ -146,9 +146,16 @@ You can provide an optional and custom [`xcconfig`](https://help.apple.com/xcode
 
 ## Testing
 
-`make ios-test` builds and runs unit tests of cross-platform code as well as the SDK.
+`make ios-test` builds and runs unit tests of cross-platform code and of the SDK. Other types of tests available include:
 
-To instead run the cross-platform tests in Xcode instead of on the command line:
+* `make ios-integration-test` runs UI tests from the "Integration Test Harness" scheme.
+* `make ios-sanitize` runs unit tests from the "CI" scheme with the Thread Sanitizer and Undefined Behavior Sanitizer enabled.
+* `make ios-sanitize-address` runs unit tests from the "CI" scheme with the Address Sanitizer enabled.
+* `make ios-static-analyzer` runs unit tests from the "CI" scheme with the Static Analyzer enabled.
+
+These commands are run by default on a single Simulator. To enable legacy iOS versions and more device types, add `MORE_SIMULATORS=1`.
+
+To run the cross-platform tests in Xcode instead of on the command line:
 
 1. Run `make iproj` to set up the workspace.
 1. Change the scheme to “test (platform project)” and press Command-R to run core unit tests.


### PR DESCRIPTION
Adds a `MORE_SIMULATORS` option to our `make ios-test` commands that enables more device types and iOS versions. 

Example usage: `make ios-test MORE_SIMULATORS=YES`

### Notes
- This is useful only locally or on actual Mac hardware and doesn’t address #10708 — cloud CI providers like CircleCI do not provide the resources necessary to execute parallel simulators in a reliable or performant way.
- If you run this now, there are many failing tests. This is a starting point — we must go through the test failures and fix them.
- Use the new `make ios-install-simulators` command to install the necessary simulators. This uses [xcversion](https://github.com/xcpretty/xcode-install).
- Bumps our default test simulator device from iPhone 6 to iPhone 8. Xcode 11 and iOS 13 will drop support for iPhone 6, while the iPhone 8 is currently [one of the most widely-used iOS devices](https://deviceatlas.com/blog/most-popular-iphones) in the wild.

/cc @mapbox/maps-ios 