### PR TITLE
Fix rendering performance regression

### DIFF
--- a/platform/ios/benchmark/MBXBenchViewController.mm
+++ b/platform/ios/benchmark/MBXBenchViewController.mm
@@ -45,6 +45,7 @@
     self.mapView.scrollEnabled = NO;
     self.mapView.rotateEnabled = NO;
     self.mapView.userInteractionEnabled = YES;
+    self.mapView.preferredFramesPerSecond = MGLMapViewPreferredFramesPerSecondMaximum;
 
     [self.view addSubview:self.mapView];
 }
@@ -112,7 +113,7 @@ static const int benchmarkDuration = 200; // frames
             idx++;
             [self startBenchmarkIteration];
         } else {
-            [mapView setNeedsGLDisplay];
+            [mapView setNeedsRerender];
         }
         return;
     }
@@ -127,7 +128,7 @@ static const int benchmarkDuration = 200; // frames
             started = std::chrono::steady_clock::now();
             NSLog(@"- Benchmarking for %d frames...", benchmarkDuration);
         }
-        [mapView setNeedsGLDisplay];
+        [mapView setNeedsRerender];
         return;
     }
 
@@ -139,7 +140,7 @@ static const int benchmarkDuration = 200; // frames
             state = State::WarmingUp;
             [self.mapView didReceiveMemoryWarning];
             NSLog(@"- Warming up for %d frames...", warmupDuration);
-            [mapView setNeedsGLDisplay];
+            [mapView setNeedsRerender];
         }
         return;
     }

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -3911,6 +3911,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
+				HEADER_SEARCH_PATHS = "$(mbgl_core_INCLUDE_DIRECTORIES)";
 				INFOPLIST_FILE = "$(SRCROOT)/benchmark/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.bench;
@@ -4527,9 +4528,11 @@
 		};
 		DABCABBC1CB80692000A7C39 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 55D8C9941D0F133500F42F10 /* config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
+				HEADER_SEARCH_PATHS = "$(mbgl_core_INCLUDE_DIRECTORIES)";
 				INFOPLIST_FILE = "$(SRCROOT)/benchmark/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.bench;
@@ -4539,9 +4542,11 @@
 		};
 		DABCABBD1CB80692000A7C39 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 55D8C9941D0F133500F42F10 /* config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
+				HEADER_SEARCH_PATHS = "$(mbgl_core_INCLUDE_DIRECTORIES)";
 				INFOPLIST_FILE = "$(SRCROOT)/benchmark/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.bench;

--- a/src/mbgl/gfx/context.hpp
+++ b/src/mbgl/gfx/context.hpp
@@ -38,6 +38,9 @@ public:
     // Called at the end of a frame.
     virtual void performCleanup() = 0;
 
+    // Called when the app receives a memory warning and before it goes to the background.
+    virtual void reduceMemoryUsage() = 0;
+
 public:
     virtual std::unique_ptr<OffscreenTexture>
         createOffscreenTexture(Size,

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -682,7 +682,13 @@ void Context::performCleanup() {
                                                abandonedRenderbuffers.data()));
         abandonedRenderbuffers.clear();
     }
+}
 
+void Context::reduceMemoryUsage() {
+    performCleanup();
+
+    // Ensure that all pending actions are executed to ensure that they happen before the app goes
+    // to the background.
     MBGL_CHECK_ERROR(glFinish());
 }
 

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -96,6 +96,8 @@ public:
     // Only call this while the OpenGL context is exclusive to this thread.
     void performCleanup() override;
 
+    void reduceMemoryUsage() override;
+
     // Drain pools and remove abandoned objects, in preparation for destroying the store.
     // Only call this while the OpenGL context is exclusive to this thread.
     void reset();

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -666,7 +666,7 @@ void Renderer::Impl::reduceMemoryUse() {
     for (const auto& entry : renderSources) {
         entry.second->reduceMemoryUse();
     }
-    backend.getContext().performCleanup();
+    backend.getContext().reduceMemoryUsage();
     imageManager->reduceMemoryUse();
     observer->onInvalidate();
 }


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gl-native/pull/14383 add a `glFlush` call to `performCleanup`. However, that function gets called after every frame. This PR adds a `reduceMemoryUsage` call and moves the `glFlush` call to it so that it only gets called when the app goes to the background, or gets a memory warning.

/cc @julianrex 