### PR TITLE
[darwin] Add warning about certain tests requiring en_US locale

### DIFF
--- a/platform/darwin/test/MGLClockDirectionFormatterTests.m
+++ b/platform/darwin/test/MGLClockDirectionFormatterTests.m
@@ -1,13 +1,16 @@
 #import <Mapbox/Mapbox.h>
 #import <XCTest/XCTest.h>
 
-static NSString * const MGLTestLocaleIdentifier = @"en-US";
-
 @interface MGLClockDirectionFormatterTests : XCTestCase
 
 @end
 
 @implementation MGLClockDirectionFormatterTests
+
+- (void)setUp {
+    // FIXME: https://github.com/mapbox/mapbox-gl-native/issues/14908
+    XCTAssertEqualObjects(NSLocale.currentLocale.localeIdentifier, @"en_US", @"Device locale must be en_US for these tests to pass.");
+}
 
 - (void)testClockDirections {
     MGLClockDirectionFormatter *shortFormatter = [[MGLClockDirectionFormatter alloc] init];

--- a/platform/darwin/test/MGLCompassDirectionFormatterTests.m
+++ b/platform/darwin/test/MGLCompassDirectionFormatterTests.m
@@ -7,6 +7,11 @@
 
 @implementation MGLCompassDirectionFormatterTests
 
+- (void)setUp {
+    // FIXME: https://github.com/mapbox/mapbox-gl-native/issues/14908
+    XCTAssertEqualObjects(NSLocale.currentLocale.localeIdentifier, @"en_US", @"Device locale must be en_US for these tests to pass.");
+}
+
 - (void)testCompassDirections {
     MGLCompassDirectionFormatter *shortFormatter = [[MGLCompassDirectionFormatter alloc] init];
     shortFormatter.unitStyle = NSFormattingUnitStyleShort;

--- a/platform/darwin/test/MGLCoordinateFormatterTests.m
+++ b/platform/darwin/test/MGLCoordinateFormatterTests.m
@@ -7,6 +7,11 @@
 
 @implementation MGLCoordinateFormatterTests
 
+- (void)setUp {
+    // FIXME: https://github.com/mapbox/mapbox-gl-native/issues/14908
+    XCTAssertEqualObjects(NSLocale.currentLocale.localeIdentifier, @"en_US", @"Device locale must be en_US for these tests to pass.");
+}
+
 - (void)testStrings {
     MGLCoordinateFormatter *shortFormatter = [[MGLCoordinateFormatter alloc] init];
     shortFormatter.unitStyle = NSFormattingUnitStyleShort;

--- a/platform/darwin/test/MGLNSStringAdditionsTests.m
+++ b/platform/darwin/test/MGLNSStringAdditionsTests.m
@@ -9,7 +9,7 @@
 @implementation MGLNSStringAdditionsTests
 
 - (void)testTitleCasedString {
-    NSLocale *locale = [NSLocale currentLocale];
+    NSLocale *locale = [NSLocale localeWithLocaleIdentifier:@"en_US"];
 
     XCTAssertEqualObjects([@"© OpenStreetMap" mgl_titleCasedStringWithLocale:locale], @"© OpenStreetMap");
     XCTAssertEqualObjects([@"© OSM" mgl_titleCasedStringWithLocale:locale], @"© OSM");

--- a/platform/ios/test/MGLMapAccessibilityElementTests.m
+++ b/platform/ios/test/MGLMapAccessibilityElementTests.m
@@ -8,6 +8,11 @@
 
 @implementation MGLMapAccessibilityElementTests
 
+- (void)setUp {
+    // FIXME: https://github.com/mapbox/mapbox-gl-native/issues/14908
+    XCTAssertEqualObjects(NSLocale.currentLocale.localeIdentifier, @"en_US", @"Device locale must be en_US for these tests to pass.");
+}
+
 - (void)testFeatureLabels {
     MGLPointFeature *feature = [[MGLPointFeature alloc] init];
     feature.attributes = @{


### PR DESCRIPTION
Better surface that certain tests require an English locale to pass, ticketed at #14908.

Also made `MGLNSStringAdditionsTests` ignore the current device locale.

/cc @1ec5 @fabian-guerra 