### PR TITLE
[iOS, docs] Fixes grammatical issue in GeoJSON guide

### DIFF
--- a/platform/darwin/docs/guides/Working with GeoJSON Data.md
+++ b/platform/darwin/docs/guides/Working with GeoJSON Data.md
@@ -20,7 +20,7 @@ be a local file URL, an HTTP URL, or an HTTPS URL.
 
 Once you’ve added the GeoJSON file to the map via an `MGLShapeSource` object,
 you can configure the appearance of its data and control what data is visible
-using `MGLStyleLayer` objects, you can
+using `MGLStyleLayer` objects. You can also
 [access the data programmatically](#extracting-geojson-data-from-the-map).
 
 ## Converting GeoJSON data into shape objects


### PR DESCRIPTION
This PR contains a small grammatical fix for [this iOS guide](https://docs.mapbox.com/ios/api/maps/5.0.0/working-with-geojson-data.html).

@friedbunny in addition to the grammar, is the content I added here correct?