### PR TITLE
[core] Add more cache management APIs

### DIFF
--- a/benchmark/storage/offline_database.benchmark.cpp
+++ b/benchmark/storage/offline_database.benchmark.cpp
@@ -26,7 +26,7 @@ public:
     void resetAmbientTiles() {
         using namespace mbgl;
 
-        db.clearTileCache();
+        db.clearAmbientCache();
 
         for (unsigned i = 0; i < tileCount; ++i) {
             const Resource ambient = Resource::tile("mapbox://tile_ambient" + util::toString(i), 1, 0, 0, 0, Tileset::Scheme::XYZ);
@@ -82,13 +82,13 @@ BENCHMARK_F(OfflineDatabase, InsertTileRegion)(benchmark::State& state) {
         db.putRegionResource(regionID, offline, response);
     }
 }
-BENCHMARK_F(OfflineDatabase, InvalidateTileCache)(benchmark::State& state) {
+BENCHMARK_F(OfflineDatabase, InvalidateAmbientCache)(benchmark::State& state) {
     while (state.KeepRunning()) {
-        db.invalidateTileCache();
+        db.invalidateAmbientCache();
     }
 }
 
-BENCHMARK_F(OfflineDatabase, ClearTileCache)(benchmark::State& state) {
+BENCHMARK_F(OfflineDatabase, ClearAmbientCache)(benchmark::State& state) {
     while (state.KeepRunning()) {
         resetAmbientTiles();
     }

--- a/benchmark/storage/offline_database.benchmark.cpp
+++ b/benchmark/storage/offline_database.benchmark.cpp
@@ -5,6 +5,7 @@
 #include <mbgl/storage/response.hpp>
 #include <mbgl/storage/sqlite3.hpp>
 #include <mbgl/util/string.hpp>
+#include <mbgl/util/logging.hpp>
 
 #include <random>
 
@@ -127,5 +128,69 @@ BENCHMARK_F(OfflineDatabase, GetTile)(benchmark::State& state) {
     while (state.KeepRunning()) {
         auto res = db.get(Resource::tile("mapbox://tile_ambient" + util::toString(dis(gen)), 1, 0, 0, 0, Tileset::Scheme::XYZ));
         assert(res != nullopt);
+    }
+}
+
+BENCHMARK_F(OfflineDatabase, AddTilesToFullDatabase)(benchmark::State& state) {
+    using namespace mbgl;
+
+    Log::setObserver(std::make_unique<Log::NullObserver>());
+    db.setMaximumAmbientCacheSize(50 * 1024 * 5);
+
+    while (state.KeepRunning()) {
+        const Resource ambient = Resource::tile("mapbox://AddTilesToFullDatabase" +
+                util::toString(state.iterations()), 1, 0, 0, 0, Tileset::Scheme::XYZ);
+        db.put(ambient, response);
+    }
+
+    Log::removeObserver();
+}
+
+BENCHMARK_F(OfflineDatabase, AddTilesToDisabledDatabase)(benchmark::State& state) {
+    using namespace mbgl;
+
+    auto regions = db.listRegions().value();
+    if (!regions.empty()) {
+        db.deleteRegion(std::move(regions[0]));
+    }
+
+    // Disables the ambient cache.
+    db.setMaximumAmbientCacheSize(0);
+
+    while (state.KeepRunning()) {
+        const Resource ambient = Resource::tile("mapbox://AddTilesToFullDatabase" +
+                util::toString(state.iterations()), 1, 0, 0, 0, Tileset::Scheme::XYZ);
+        db.put(ambient, response);
+    }
+}
+
+BENCHMARK_F(OfflineDatabase, GetTileFromDisabledDatabase)(benchmark::State& state) {
+    using namespace mbgl;
+
+    auto regions = db.listRegions().value();
+    if (!regions.empty()) {
+        db.deleteRegion(std::move(regions[0]));
+    }
+
+    // Disables the ambient cache.
+    db.setMaximumAmbientCacheSize(0);
+
+    while (state.KeepRunning()) {
+        auto res = db.get(Resource::tile("mapbox://tile_ambient", 1, 0, 0, 0, Tileset::Scheme::XYZ));
+        assert(res == nullopt);
+    }
+}
+
+BENCHMARK_F(OfflineDatabase, ResizeDatabase)(benchmark::State& state) {
+    uint64_t size = 25 * 1024 * 1024;
+
+    while (state.KeepRunning()) {
+        db.setMaximumAmbientCacheSize(size);
+
+        size -= response.data->size();
+
+        if (size < response.data->size()) {
+            size = 25 * 1024 * 1024;
+        }
     }
 }

--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -192,7 +192,7 @@ public:
      * executed on the database thread; it is the responsibility of the SDK bindings
      * to re-execute a user-provided callback on the main thread.
      */
-    void resetCache(std::function<void (std::exception_ptr)>);
+    void resetDatabase(std::function<void (std::exception_ptr)>);
 
     /*
      * Forces revalidation of tiles in the ambient cache.

--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -30,12 +30,8 @@ public:
      * regions, we want the database to remain fairly small (order tens or low hundreds
      * of megabytes).
      */
-    DefaultFileSource(const std::string& cachePath,
-                      const std::string& assetPath,
-                      uint64_t maximumCacheSize = util::DEFAULT_MAX_CACHE_SIZE);
-    DefaultFileSource(const std::string& cachePath,
-                      std::unique_ptr<FileSource>&& assetFileSource,
-                      uint64_t maximumCacheSize = util::DEFAULT_MAX_CACHE_SIZE);
+    DefaultFileSource(const std::string& cachePath, const std::string& assetPath);
+    DefaultFileSource(const std::string& cachePath, std::unique_ptr<FileSource>&& assetFileSource);
     ~DefaultFileSource() override;
 
     bool supportsCacheOnlyRequests() const override {
@@ -219,6 +215,28 @@ public:
      * by this call.
      */
     void clearAmbientCache(std::function<void (std::exception_ptr)>);
+
+    /*
+     * Sets the maximum size in bytes for the ambient cache.
+     *
+     * This call is potentially expensive because it will try
+     * to trim the data in case the database is larger than the
+     * size defined. The size of offline regions are not affected
+     * by this settings, but the ambient cache will always try
+     * to not exceed the maximum size defined, taking into account
+     * the current size for the offline regions.
+     *
+     * If the maximum size is set to 50 MB and 40 MB are already
+     * used by offline regions, the cache size will be effectively
+     * 10 MB.
+     *
+     * Setting the size to 0 will disable the cache if there is no
+     * offline region on the database.
+     *
+     * This method should always be called before using the database,
+     * otherwise the default maximum size will be used.
+     */
+    void setMaximumAmbientCacheSize(uint64_t size, std::function<void (std::exception_ptr)> callback);
 
     // For testing only.
     void setOnlineStatus(bool);

--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -195,24 +195,30 @@ public:
     void resetDatabase(std::function<void (std::exception_ptr)>);
 
     /*
-     * Forces revalidation of tiles in the ambient cache.
+     * Forces revalidation of the ambient cache.
      *
-     * Forces Mapbox GL Native to revalidate tiles stored in the ambient
+     * Forces Mapbox GL Native to revalidate resources stored in the ambient
      * cache with the tile server before using them, making sure they
      * are the latest version. This is more efficient than cleaning the
-     * cache because if the tile is considered valid after the server
+     * cache because if the resource is considered valid after the server
      * lookup, it will not get downloaded again.
+     *
+     * Resources overlapping with offline regions will not be affected
+     * by this call.
      */
-    void invalidateTileCache(std::function<void (std::exception_ptr)>);
+    void invalidateAmbientCache(std::function<void (std::exception_ptr)>);
 
     /*
-     * Erase tiles from the ambient cache, freeing storage space.
+     * Erase resources from the ambient cache, freeing storage space.
      *
-     * Erases the tile cache, freeing resources. This operation can be
+     * Erases the ambient cache, freeing resources. This operation can be
      * potentially slow because it will trigger a VACUUM on SQLite,
      * forcing the database to move pages on the filesystem.
+     *
+     * Resources overlapping with offline regions will not be affected
+     * by this call.
      */
-    void clearTileCache(std::function<void (std::exception_ptr)>);
+    void clearAmbientCache(std::function<void (std::exception_ptr)>);
 
     // For testing only.
     void setOnlineStatus(bool);

--- a/platform/default/include/mbgl/storage/offline_database.hpp
+++ b/platform/default/include/mbgl/storage/offline_database.hpp
@@ -40,7 +40,7 @@ class OfflineDatabase : private util::noncopyable {
 public:
     // Limits affect ambient caching (put) only; resources required by offline
     // regions are exempt.
-    OfflineDatabase(std::string path, uint64_t maximumCacheSize = util::DEFAULT_MAX_CACHE_SIZE);
+    OfflineDatabase(std::string path);
     ~OfflineDatabase();
 
     void changePath(const std::string&);
@@ -86,6 +86,7 @@ public:
     expected<OfflineRegionDefinition, std::exception_ptr> getRegionDefinition(int64_t regionID);
     expected<OfflineRegionStatus, std::exception_ptr> getRegionCompletedStatus(int64_t regionID);
 
+    std::exception_ptr setMaximumAmbientCacheSize(uint64_t);
     void setOfflineMapboxTileCountLimit(uint64_t);
     uint64_t getOfflineMapboxTileCountLimit();
     bool offlineMapboxTileCountLimitExceeded();
@@ -104,6 +105,7 @@ private:
     void migrateToVersion3();
     void migrateToVersion6();
     void cleanup();
+    bool disabled();
 
     mapbox::sqlite::Statement& getStatement(const char *);
 
@@ -136,9 +138,9 @@ private:
     template <class T>
     T getPragma(const char *);
 
-    uint64_t maximumCacheSize;
-
+    uint64_t maximumAmbientCacheSize = util::DEFAULT_MAX_CACHE_SIZE;
     uint64_t offlineMapboxTileCountLimit = util::mapbox::DEFAULT_OFFLINE_TILE_COUNT_LIMIT;
+
     optional<uint64_t> offlineMapboxTileCount;
 
     bool evict(uint64_t neededFreeSize);

--- a/platform/default/include/mbgl/storage/offline_database.hpp
+++ b/platform/default/include/mbgl/storage/offline_database.hpp
@@ -44,7 +44,7 @@ public:
     ~OfflineDatabase();
 
     void changePath(const std::string&);
-    std::exception_ptr resetCache();
+    std::exception_ptr resetDatabase();
 
     optional<Response> get(const Resource&);
 

--- a/platform/default/include/mbgl/storage/offline_database.hpp
+++ b/platform/default/include/mbgl/storage/offline_database.hpp
@@ -56,12 +56,12 @@ public:
     // are the latest version. This is more efficient than cleaning the
     // cache because if the tile is considered valid after the server
     // lookup, it will not get downloaded again.
-    std::exception_ptr invalidateTileCache();
+    std::exception_ptr invalidateAmbientCache();
 
     // Clear the tile cache, freeing resources. This operation can be
     // potentially slow because it will trigger a VACUUM on SQLite,
     // forcing the database to move pages on the filesystem.
-    std::exception_ptr clearTileCache();
+    std::exception_ptr clearAmbientCache();
 
     expected<OfflineRegions, std::exception_ptr> listRegions();
 

--- a/platform/default/src/mbgl/storage/default_file_source.cpp
+++ b/platform/default/src/mbgl/storage/default_file_source.cpp
@@ -188,12 +188,12 @@ public:
         callback(offlineDatabase->resetDatabase());
     }
 
-    void invalidateTileCache(std::function<void (std::exception_ptr)> callback) {
-        callback(offlineDatabase->invalidateTileCache());
+    void invalidateAmbientCache(std::function<void (std::exception_ptr)> callback) {
+        callback(offlineDatabase->invalidateAmbientCache());
     }
 
-    void clearTileCache(std::function<void (std::exception_ptr)> callback) {
-        callback(offlineDatabase->clearTileCache());
+    void clearAmbientCache(std::function<void (std::exception_ptr)> callback) {
+        callback(offlineDatabase->clearAmbientCache());
     }
 
 private:
@@ -343,12 +343,12 @@ void DefaultFileSource::resetDatabase(std::function<void (std::exception_ptr)> c
     impl->actor().invoke(&Impl::resetDatabase, std::move(callback));
 }
 
-void DefaultFileSource::invalidateTileCache(std::function<void (std::exception_ptr)> callback) {
-    impl->actor().invoke(&Impl::invalidateTileCache, callback);
+void DefaultFileSource::invalidateAmbientCache(std::function<void (std::exception_ptr)> callback) {
+    impl->actor().invoke(&Impl::invalidateAmbientCache, std::move(callback));
 }
 
-void DefaultFileSource::clearTileCache(std::function<void (std::exception_ptr)> callback) {
-    impl->actor().invoke(&Impl::clearTileCache, callback);
+void DefaultFileSource::clearAmbientCache(std::function<void (std::exception_ptr)> callback) {
+    impl->actor().invoke(&Impl::clearAmbientCache, std::move(callback));
 }
 
 // For testing only:

--- a/platform/default/src/mbgl/storage/default_file_source.cpp
+++ b/platform/default/src/mbgl/storage/default_file_source.cpp
@@ -184,8 +184,8 @@ public:
         offlineDatabase->put(resource, response);
     }
 
-    void resetCache(std::function<void (std::exception_ptr)> callback) {
-        callback(offlineDatabase->resetCache());
+    void resetDatabase(std::function<void (std::exception_ptr)> callback) {
+        callback(offlineDatabase->resetDatabase());
     }
 
     void invalidateTileCache(std::function<void (std::exception_ptr)> callback) {
@@ -339,8 +339,8 @@ void DefaultFileSource::put(const Resource& resource, const Response& response) 
     impl->actor().invoke(&Impl::put, resource, response);
 }
 
-void DefaultFileSource::resetCache(std::function<void (std::exception_ptr)> callback) {
-    impl->actor().invoke(&Impl::resetCache, callback);
+void DefaultFileSource::resetDatabase(std::function<void (std::exception_ptr)> callback) {
+    impl->actor().invoke(&Impl::resetDatabase, std::move(callback));
 }
 
 void DefaultFileSource::invalidateTileCache(std::function<void (std::exception_ptr)> callback) {

--- a/platform/default/src/mbgl/storage/offline_database.cpp
+++ b/platform/default/src/mbgl/storage/offline_database.cpp
@@ -1195,7 +1195,7 @@ bool OfflineDatabase::exceedsOfflineMapboxTileCountLimit(const Resource& resourc
         && offlineMapboxTileCountLimitExceeded();
 }
 
-std::exception_ptr OfflineDatabase::resetCache() try {
+std::exception_ptr OfflineDatabase::resetDatabase() try {
     removeExisting();
     initialize();
     return nullptr;

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -222,7 +222,7 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
             view->clearAnnotations();
             break;
         case GLFW_KEY_I:
-            view->resetCacheCallback();
+            view->resetDatabaseCallback();
             break;
         case GLFW_KEY_K:
             view->addRandomCustomPointAnnotations(1);

--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -41,7 +41,7 @@ public:
     }
 
     void setResetCacheCallback(std::function<void()> callback) {
-        resetCacheCallback = callback;
+        resetDatabaseCallback = callback;
     };
 
     void setShouldClose();
@@ -125,7 +125,7 @@ private:
     std::function<void()> changeStyleCallback;
     std::function<void()> pauseResumeCallback;
     std::function<void()> onlineStatusCallback;
-    std::function<void()> resetCacheCallback;
+    std::function<void()> resetDatabaseCallback;
     std::function<void(mbgl::Map*)> animateRouteCallback;
 
     mbgl::util::RunLoop runLoop;

--- a/platform/glfw/main.cpp
+++ b/platform/glfw/main.cpp
@@ -161,7 +161,7 @@ int main(int argc, char *argv[]) {
     });
 
     view->setResetCacheCallback([fileSource] () {
-        fileSource->resetCache([](std::exception_ptr ex) {
+        fileSource->resetDatabase([](std::exception_ptr ex) {
             if (ex) {
                 mbgl::Log::Error(mbgl::Event::Database, "Failed to reset cache:: %s", mbgl::util::toString(ex).c_str());
             }

--- a/test/storage/offline_database.test.cpp
+++ b/test/storage/offline_database.test.cpp
@@ -318,7 +318,7 @@ TEST(OfflineDatabase, TEST_REQUIRES_WRITE(GetResourceFromOfflineRegion)) {
     deleteDatabaseFiles();
     util::copyFile(filename, "test/fixtures/offline_database/satellite_test.db");
 
-    OfflineDatabase db(filename, mapbox::sqlite::ReadOnly);
+    OfflineDatabase db(filename);
 
     Resource resource = Resource::style("mapbox://styles/mapbox/satellite-v9");
     ASSERT_TRUE(db.get(resource));
@@ -755,7 +755,8 @@ TEST(OfflineDatabase, PutReturnsSize) {
 
 TEST(OfflineDatabase, PutEvictsLeastRecentlyUsedResources) {
     FixtureLog log;
-    OfflineDatabase db(":memory:", 1024 * 100);
+    OfflineDatabase db(":memory:");
+    db.setMaximumAmbientCacheSize(1024 * 100);
 
     Response response;
     response.data = randomString(1024);
@@ -773,7 +774,9 @@ TEST(OfflineDatabase, PutEvictsLeastRecentlyUsedResources) {
 
 TEST(OfflineDatabase, PutRegionResourceDoesNotEvict) {
     FixtureLog log;
-    OfflineDatabase db(":memory:", 1024 * 100);
+    OfflineDatabase db(":memory:");
+    db.setMaximumAmbientCacheSize(1024 * 100);
+
     OfflineTilePyramidRegionDefinition definition { "", LatLngBounds::world(), 0, INFINITY, 1.0, true };
     auto region = db.createRegion(definition, OfflineRegionMetadata());
     ASSERT_TRUE(region);
@@ -793,7 +796,8 @@ TEST(OfflineDatabase, PutRegionResourceDoesNotEvict) {
 
 TEST(OfflineDatabase, PutFailsWhenEvictionInsuffices) {
     FixtureLog log;
-    OfflineDatabase db(":memory:", 1024 * 100);
+    OfflineDatabase db(":memory:");
+    db.setMaximumAmbientCacheSize(1024 * 100);
 
     Response big;
     big.data = randomString(1024 * 100);
@@ -849,7 +853,9 @@ TEST(OfflineDatabase, GetRegionCompletedStatus) {
 
 TEST(OfflineDatabase, HasRegionResource) {
     FixtureLog log;
-    OfflineDatabase db(":memory:", 1024 * 100);
+    OfflineDatabase db(":memory:");
+    db.setMaximumAmbientCacheSize(1024 * 100);
+
     OfflineTilePyramidRegionDefinition definition { "", LatLngBounds::world(), 0, INFINITY, 1.0, true };
     auto region = db.createRegion(definition, OfflineRegionMetadata());
     ASSERT_TRUE(region);
@@ -873,7 +879,9 @@ TEST(OfflineDatabase, HasRegionResource) {
 
 TEST(OfflineDatabase, HasRegionResourceTile) {
     FixtureLog log;
-    OfflineDatabase db(":memory:", 1024 * 100);
+    OfflineDatabase db(":memory:");
+    db.setMaximumAmbientCacheSize(1024 * 100);
+
     OfflineTilePyramidRegionDefinition definition { "", LatLngBounds::world(), 0, INFINITY, 1.0, false };
     auto region = db.createRegion(definition, OfflineRegionMetadata());
     ASSERT_TRUE(region);
@@ -968,7 +976,9 @@ TEST(OfflineDatabase, OfflineMapboxTileCount) {
 
 TEST(OfflineDatabase, BatchInsertion) {
     FixtureLog log;
-    OfflineDatabase db(":memory:", 1024 * 100);
+    OfflineDatabase db(":memory:");
+    db.setMaximumAmbientCacheSize(1024 * 100);
+
     OfflineTilePyramidRegionDefinition definition { "", LatLngBounds::world(), 0, INFINITY, 1.0, true };
     auto region = db.createRegion(definition, OfflineRegionMetadata());
     ASSERT_TRUE(region);
@@ -993,8 +1003,10 @@ TEST(OfflineDatabase, BatchInsertion) {
 
 TEST(OfflineDatabase, BatchInsertionMapboxTileCountExceeded) {
     FixtureLog log;
-    OfflineDatabase db(":memory:", 1024 * 100);
+    OfflineDatabase db(":memory:");
     db.setOfflineMapboxTileCountLimit(1);
+    db.setMaximumAmbientCacheSize(1024 * 100);
+
     OfflineTilePyramidRegionDefinition definition { "", LatLngBounds::world(), 0, INFINITY, 1.0, false };
     auto region = db.createRegion(definition, OfflineRegionMetadata());
     ASSERT_TRUE(region);
@@ -1031,7 +1043,9 @@ TEST(OfflineDatabase, MigrateFromV2Schema) {
     util::copyFile(filename, "test/fixtures/offline_database/v2.db");
 
     {
-        OfflineDatabase db(filename, 0);
+        OfflineDatabase db(filename);
+        db.setMaximumAmbientCacheSize(0);
+
         auto regions = db.listRegions();
         ASSERT_TRUE(regions);
         for (auto& region : regions.value()) {
@@ -1053,7 +1067,9 @@ TEST(OfflineDatabase, MigrateFromV3Schema) {
     util::copyFile(filename, "test/fixtures/offline_database/v3.db");
 
     {
-        OfflineDatabase db(filename, 0);
+        OfflineDatabase db(filename);
+        db.setMaximumAmbientCacheSize(0);
+
         auto regions = db.listRegions().value();
         for (auto& region : regions) {
             db.deleteRegion(std::move(region));
@@ -1072,7 +1088,9 @@ TEST(OfflineDatabase, MigrateFromV4Schema) {
     util::copyFile(filename, "test/fixtures/offline_database/v4.db");
 
     {
-        OfflineDatabase db(filename, 0);
+        OfflineDatabase db(filename);
+        db.setMaximumAmbientCacheSize(0);
+
         auto regions = db.listRegions().value();
         for (auto& region : regions) {
             db.deleteRegion(std::move(region));
@@ -1098,7 +1116,9 @@ TEST(OfflineDatabase, MigrateFromV5Schema) {
     util::copyFile(filename, "test/fixtures/offline_database/v5.db");
 
     {
-        OfflineDatabase db(filename, 0);
+        OfflineDatabase db(filename);
+        db.setMaximumAmbientCacheSize(0);
+
         auto regions = db.listRegions().value();
         for (auto& region : regions) {
             db.deleteRegion(std::move(region));
@@ -1126,7 +1146,8 @@ TEST(OfflineDatabase, DowngradeSchema) {
     util::copyFile(filename, "test/fixtures/offline_database/v999.db");
 
     {
-        OfflineDatabase db(filename, 0);
+        OfflineDatabase db(filename);
+        db.setMaximumAmbientCacheSize(0);
     }
 
     EXPECT_EQ(6, databaseUserVersion(filename));

--- a/test/storage/offline_database.test.cpp
+++ b/test/storage/offline_database.test.cpp
@@ -515,7 +515,7 @@ TEST(OfflineDatabase, GetRegionDefinition) {
     );
 }
 
-TEST(OfflineDatabase, DeleteRegion) {
+TEST(OfflineDatabase, TEST_REQUIRES_WRITE(DeleteRegion)) {
     FixtureLog log;
     deleteDatabaseFiles();
 
@@ -627,7 +627,7 @@ TEST(OfflineDatabase, Invalidate) {
     EXPECT_EQ(0u, log.uncheckedCount());
 }
 
-TEST(OfflineDatabase, ClearTileCache) {
+TEST(OfflineDatabase, TEST_REQUIRES_WRITE(ClearTileCache)) {
     FixtureLog log;
     deleteDatabaseFiles();
 

--- a/test/storage/offline_database.test.cpp
+++ b/test/storage/offline_database.test.cpp
@@ -1474,7 +1474,7 @@ TEST(OfflineDatabase, TEST_REQUIRES_WRITE(MergeDatabaseWithDiskFull)) {
 }
 #endif // __QT__
 
-TEST(OfflineDatabse, ChangePath) {
+TEST(OfflineDatabase, ChangePath) {
     std::string newPath("test/fixtures/offline_database/test.db");
     OfflineDatabase db(":memory:");
     db.changePath(newPath);
@@ -1482,13 +1482,13 @@ TEST(OfflineDatabse, ChangePath) {
     util::deleteFile(newPath);
 }
 
-TEST(OfflineDatabse, resetCache) {
+TEST(OfflineDatabase, ResetDatabase) {
     FixtureLog log;
     deleteDatabaseFiles();
     util::copyFile(filename, "test/fixtures/offline_database/satellite_test.db");
 
     OfflineDatabase db(filename);
-    auto result = db.resetCache();
+    auto result = db.resetDatabase();
     EXPECT_FALSE(result);
 
     auto regions = db.listRegions().value();


### PR DESCRIPTION
- API for resizing the ambient cache.
- Make it possible to disable the ambient cache.
- Performance benchmarks.
- Fix tile deletion and invalidation not affecting resources that are not tiles.