### PR TITLE
[core] Change severity of too many data-driven properties to "Info"

### DIFF
--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -78,21 +78,21 @@ void RenderLayer::checkRenderability(const PaintParameters& parameters,
     }
 
     if (activeBindingCount > parameters.context.maximumVertexBindingCount) {
-        Log::Error(Event::OpenGL,
-                   "The layer '%s' uses more data-driven properties than the current device "
-                   "supports, and will have rendering errors. To ensure compatibility with this "
-                   "device, use %d fewer data driven properties in this layer.",
-                   getID().c_str(),
-                   activeBindingCount - parameters.context.minimumRequiredVertexBindingCount);
+        Log::Info(Event::OpenGL,
+                "The layer '%s' uses more data-driven properties than the current device "
+                "supports, and will have rendering errors. To ensure compatibility with this "
+                "device, use %d fewer data driven properties in this layer.",
+                getID().c_str(),
+                activeBindingCount - parameters.context.minimumRequiredVertexBindingCount);
         hasRenderFailures = true;
     } else if (activeBindingCount > parameters.context.minimumRequiredVertexBindingCount) {
-        Log::Warning(Event::OpenGL,
-                   "The layer '%s' uses more data-driven properties than some devices may support. "
-                   "Though it will render correctly on this device, it may have rendering errors "
-                   "on other devices. To ensure compatibility with all devices, use %d fewer "
-                   "data-driven properties in this layer.",
-                   getID().c_str(),
-                   activeBindingCount - parameters.context.minimumRequiredVertexBindingCount);
+        Log::Info(Event::OpenGL,
+                "The layer '%s' uses more data-driven properties than some devices may support. "
+                "Though it will render correctly on this device, it may have rendering errors "
+                "on other devices. To ensure compatibility with all devices, use %d fewer "
+                "data-driven properties in this layer.",
+                getID().c_str(),
+                activeBindingCount - parameters.context.minimumRequiredVertexBindingCount);
         hasRenderFailures = true;
     }
 }


### PR DESCRIPTION
So it can be filtered by the SDKs using a Log::Observer.