### PR TITLE
[core] Few performance fixes for RendererImpl

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -4,6 +4,8 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 
 ## master
 
+* Performance improvements for queryRenderedFeatures API and optimization that allocates containers based on a number of rendered layers. ([#14930](https://github.com/mapbox/mapbox-gl-native/pull/14930))
+
 ## 8.2.0-alpha.2 - July 3, 2019
 
 ### Bugs

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## master
+
+* Performance improvements for queryRenderedFeatures API and optimization that allocates containers based on a number of rendered layers. ([#14930](https://github.com/mapbox/mapbox-gl-native/pull/14930))
+
 ## 5.2.0
 
 ### Offline maps

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added an `MGLMapView.prefetchesTiles` property to configure lower-resolution tile prefetching behavior. ([#14816](https://github.com/mapbox/mapbox-gl-native/pull/14816))
 * Fixed queryRenderedFeatues bug caused by incorrect sort feature index calculation. ([#14884](https://github.com/mapbox/mapbox-gl-native/pull/14884))
+* Performance improvements for queryRenderedFeatures API and optimization that allocates containers based on a number of rendered layers. ([#14930](https://github.com/mapbox/mapbox-gl-native/pull/14930))
 
 ### Styles and rendering
 

--- a/src/mbgl/annotation/render_annotation_source.cpp
+++ b/src/mbgl/annotation/render_annotation_source.cpp
@@ -46,7 +46,7 @@ void RenderAnnotationSource::update(Immutable<style::Source::Impl> baseImpl_,
 std::unordered_map<std::string, std::vector<Feature>>
 RenderAnnotationSource::queryRenderedFeatures(const ScreenLineString& geometry,
                                               const TransformState& transformState,
-                                              const std::vector<const RenderLayer*>& layers,
+                                              const std::unordered_map<std::string, const RenderLayer*>& layers,
                                               const RenderedQueryOptions& options,
                                               const mat4& projMatrix) const {
     return tilePyramid.queryRenderedFeatures(geometry, transformState, layers, options, projMatrix);

--- a/src/mbgl/annotation/render_annotation_source.hpp
+++ b/src/mbgl/annotation/render_annotation_source.hpp
@@ -18,7 +18,7 @@ public:
     std::unordered_map<std::string, std::vector<Feature>>
     queryRenderedFeatures(const ScreenLineString& geometry,
                           const TransformState& transformState,
-                          const std::vector<const RenderLayer*>& layers,
+                          const std::unordered_map<std::string, const RenderLayer*>& layers,
                           const RenderedQueryOptions& options,
                           const mat4& projMatrix) const final;
 

--- a/src/mbgl/geometry/feature_index.hpp
+++ b/src/mbgl/geometry/feature_index.hpp
@@ -67,7 +67,7 @@ public:
             const double scale,
             const RenderedQueryOptions& options,
             const UnwrappedTileID&,
-            const std::vector<const RenderLayer*>&,
+            const std::unordered_map<std::string, const RenderLayer*>&,
             const float additionalQueryPadding) const;
 
     static optional<GeometryCoordinates> translateQueryGeometry(
@@ -82,7 +82,7 @@ public:
     std::unordered_map<std::string, std::vector<Feature>> lookupSymbolFeatures(
            const std::vector<IndexedSubfeature>& symbolFeatures,
            const RenderedQueryOptions& options,
-           const std::vector<const RenderLayer*>& layers,
+           const std::unordered_map<std::string, const RenderLayer*>& layers,
            const OverscaledTileID& tileID,
            const std::shared_ptr<std::vector<size_t>>& featureSortOrder) const;
 
@@ -92,7 +92,7 @@ private:
             const IndexedSubfeature&,
             const RenderedQueryOptions& options,
             const CanonicalTileID&,
-            const std::vector<const RenderLayer*>&,
+            const std::unordered_map<std::string, const RenderLayer*>&,
             const GeometryCoordinates& queryGeometry,
             const TransformState& transformState,
             const float pixelsToTileUnits,

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -271,11 +271,17 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(const UpdatePar
     std::vector<std::reference_wrapper<RenderLayer>> layersNeedPlacement;
     auto renderItemsEmplaceHint = layerRenderItems.begin();
 
+    // Reserve size for filteredLayersForSource if there are sources.
+    if (!sourceImpls->empty()) {
+        filteredLayersForSource.reserve(layerImpls->size());
+        if (filteredLayersForSource.capacity() > layerImpls->size()) {
+            filteredLayersForSource.shrink_to_fit();
+        }
+    }
+
     // Update all sources and initialize renderItems.
     for (const auto& sourceImpl : *sourceImpls) {
         RenderSource* source = renderSources.at(sourceImpl->id).get();
-        std::vector<Immutable<LayerProperties>> filteredLayersForSource;
-        filteredLayersForSource.reserve(layerImpls->size());
         bool sourceNeedsRendering = false;
         bool sourceNeedsRelayout = false;       
         
@@ -321,6 +327,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(const UpdatePar
                        sourceNeedsRendering,
                        sourceNeedsRelayout,
                        tileParameters);
+        filteredLayersForSource.clear();
     }
 
     renderTreeParameters->loaded = updateParameters.styleLoaded && isLoaded();

--- a/src/mbgl/renderer/render_orchestrator.hpp
+++ b/src/mbgl/renderer/render_orchestrator.hpp
@@ -74,10 +74,10 @@ private:
               
     void queryRenderedSymbols(std::unordered_map<std::string, std::vector<Feature>>& resultsByLayer,
                               const ScreenLineString& geometry,
-                              const std::vector<const RenderLayer*>& layers,
+                              const std::unordered_map<std::string, const RenderLayer*>& layers,
                               const RenderedQueryOptions& options) const;
     
-    std::vector<Feature> queryRenderedFeatures(const ScreenLineString&, const RenderedQueryOptions&, const std::vector<const RenderLayer*>&) const;
+    std::vector<Feature> queryRenderedFeatures(const ScreenLineString&, const RenderedQueryOptions&, const std::unordered_map<std::string, const RenderLayer*>&) const;
 
     // GlyphManagerObserver implementation.
     void onGlyphsError(const FontStack&, const GlyphRange&, std::exception_ptr) override;

--- a/src/mbgl/renderer/render_orchestrator.hpp
+++ b/src/mbgl/renderer/render_orchestrator.hpp
@@ -33,6 +33,10 @@ class PatternAtlas;
 class CrossTileSymbolIndex;
 class RenderTree;
 
+namespace style {
+    class LayerProperties;
+} // namespace style
+
 class RenderOrchestrator final : public GlyphManagerObserver,
                                  public ImageManagerObserver,
                                  public RenderSourceObserver {
@@ -113,6 +117,10 @@ private:
 
     const bool backgroundLayerAsColor;
     bool contextLost = false;
+
+    // Vector with reserved capacity of layerImpls->size() to avoid reallocation
+    // on each frame.
+    std::vector<Immutable<style::LayerProperties>> filteredLayersForSource;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/render_source.hpp
+++ b/src/mbgl/renderer/render_source.hpp
@@ -72,7 +72,7 @@ public:
     virtual std::unordered_map<std::string, std::vector<Feature>>
     queryRenderedFeatures(const ScreenLineString& geometry,
                           const TransformState& transformState,
-                          const std::vector<const RenderLayer*>& layers,
+                          const std::unordered_map<std::string, const RenderLayer*>& layers,
                           const RenderedQueryOptions& options,
                           const mat4& projMatrix) const = 0;
 

--- a/src/mbgl/renderer/sources/render_image_source.cpp
+++ b/src/mbgl/renderer/sources/render_image_source.cpp
@@ -106,7 +106,7 @@ void RenderImageSource::prepare(const SourcePrepareParameters& parameters) {
 std::unordered_map<std::string, std::vector<Feature>>
 RenderImageSource::queryRenderedFeatures(const ScreenLineString&,
                                          const TransformState&,
-                                         const std::vector<const RenderLayer*>&,
+                                         const std::unordered_map<std::string, const RenderLayer*>&,
                                          const RenderedQueryOptions&,
                                          const mat4&) const {
     return std::unordered_map<std::string, std::vector<Feature>> {};

--- a/src/mbgl/renderer/sources/render_image_source.hpp
+++ b/src/mbgl/renderer/sources/render_image_source.hpp
@@ -57,7 +57,7 @@ public:
     std::unordered_map<std::string, std::vector<Feature>>
     queryRenderedFeatures(const ScreenLineString& geometry,
                           const TransformState& transformState,
-                          const std::vector<const RenderLayer*>& layers,
+                          const std::unordered_map<std::string, const RenderLayer*>& layers,
                           const RenderedQueryOptions& options,
                           const mat4& projMatrix) const final;
 

--- a/src/mbgl/renderer/sources/render_raster_dem_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.cpp
@@ -125,7 +125,7 @@ void RenderRasterDEMSource::onTileChanged(Tile& tile){
 std::unordered_map<std::string, std::vector<Feature>>
 RenderRasterDEMSource::queryRenderedFeatures(const ScreenLineString&,
                                           const TransformState&,
-                                          const std::vector<const RenderLayer*>&,
+                                          const std::unordered_map<std::string, const RenderLayer*>&,
                                           const RenderedQueryOptions&,
                                           const mat4&) const {
     return std::unordered_map<std::string, std::vector<Feature>>{};

--- a/src/mbgl/renderer/sources/render_raster_dem_source.hpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.hpp
@@ -19,7 +19,7 @@ public:
     std::unordered_map<std::string, std::vector<Feature>>
     queryRenderedFeatures(const ScreenLineString& geometry,
                           const TransformState& transformState,
-                          const std::vector<const RenderLayer*>& layers,
+                          const std::unordered_map<std::string, const RenderLayer*>& layers,
                           const RenderedQueryOptions& options,
                           const mat4& projMatrix) const override;
 

--- a/src/mbgl/renderer/sources/render_raster_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_source.cpp
@@ -60,7 +60,7 @@ void RenderRasterSource::prepare(const SourcePrepareParameters& parameters) {
 std::unordered_map<std::string, std::vector<Feature>>
 RenderRasterSource::queryRenderedFeatures(const ScreenLineString&,
                                           const TransformState&,
-                                          const std::vector<const RenderLayer*>&,
+                                          const std::unordered_map<std::string, const RenderLayer*>&,
                                           const RenderedQueryOptions&,
                                           const mat4&) const {
     return std::unordered_map<std::string, std::vector<Feature>>{};

--- a/src/mbgl/renderer/sources/render_raster_source.hpp
+++ b/src/mbgl/renderer/sources/render_raster_source.hpp
@@ -19,7 +19,7 @@ public:
     std::unordered_map<std::string, std::vector<Feature>>
     queryRenderedFeatures(const ScreenLineString& geometry,
                           const TransformState& transformState,
-                          const std::vector<const RenderLayer*>& layers,
+                          const std::unordered_map<std::string, const RenderLayer*>& layers,
                           const RenderedQueryOptions& options,
                           const mat4& projMatrix) const override;
 

--- a/src/mbgl/renderer/sources/render_tile_source.cpp
+++ b/src/mbgl/renderer/sources/render_tile_source.cpp
@@ -84,7 +84,7 @@ const Tile* RenderTileSource::getRenderedTile(const UnwrappedTileID& tileID) con
 std::unordered_map<std::string, std::vector<Feature>>
 RenderTileSource::queryRenderedFeatures(const ScreenLineString& geometry,
                                           const TransformState& transformState,
-                                          const std::vector<const RenderLayer*>& layers,
+                                          const std::unordered_map<std::string, const RenderLayer*>& layers,
                                           const RenderedQueryOptions& options,
                                           const mat4& projMatrix) const {
     return tilePyramid.queryRenderedFeatures(geometry, transformState, layers, options, projMatrix);

--- a/src/mbgl/renderer/sources/render_tile_source.hpp
+++ b/src/mbgl/renderer/sources/render_tile_source.hpp
@@ -27,7 +27,7 @@ public:
     std::unordered_map<std::string, std::vector<Feature>>
     queryRenderedFeatures(const ScreenLineString& geometry,
                           const TransformState& transformState,
-                          const std::vector<const RenderLayer*>& layers,
+                          const std::unordered_map<std::string, const RenderLayer*>& layers,
                           const RenderedQueryOptions& options,
                           const mat4& projMatrix) const override;
 

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -284,7 +284,7 @@ void TilePyramid::handleWrapJump(float lng) {
 
 std::unordered_map<std::string, std::vector<Feature>> TilePyramid::queryRenderedFeatures(const ScreenLineString& geometry,
                                            const TransformState& transformState,
-                                           const std::vector<const RenderLayer*>& layers,
+                                           const std::unordered_map<std::string, const RenderLayer*>& layers,
                                            const RenderedQueryOptions& options,
                                            const mat4& projMatrix) const {
     std::unordered_map<std::string, std::vector<Feature>> result;

--- a/src/mbgl/renderer/tile_pyramid.hpp
+++ b/src/mbgl/renderer/tile_pyramid.hpp
@@ -52,7 +52,7 @@ public:
     std::unordered_map<std::string, std::vector<Feature>>
     queryRenderedFeatures(const ScreenLineString& geometry,
                           const TransformState& transformState,
-                          const std::vector<const RenderLayer*>&,
+                          const std::unordered_map<std::string, const RenderLayer*>&,
                           const RenderedQueryOptions& options,
                           const mat4& projMatrix) const;
 

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -291,12 +291,12 @@ LayerRenderData* GeometryTile::getLayerRenderData(const style::Layer::Impl& laye
     return layoutResult ? layoutResult->getLayerRenderData(layerImpl) : nullptr;
 }
 
-float GeometryTile::getQueryPadding(const std::vector<const RenderLayer*>& layers) {
+float GeometryTile::getQueryPadding(const std::unordered_map<std::string, const RenderLayer*>& layers) {
     float queryPadding = 0;
-    for (const RenderLayer* layer : layers) {
-        const LayerRenderData* data = getLayerRenderData(*layer->baseImpl);
+    for (const auto& pair : layers) {
+        const LayerRenderData* data = getLayerRenderData(*pair.second->baseImpl);
         if (data && data->bucket && data->bucket->hasData()) {
-            queryPadding = std::max(queryPadding, data->bucket->getQueryRadius(*layer));
+            queryPadding = std::max(queryPadding, data->bucket->getQueryRadius(*pair.second));
         }
     }
     return queryPadding;
@@ -306,7 +306,7 @@ void GeometryTile::queryRenderedFeatures(
     std::unordered_map<std::string, std::vector<Feature>>& result,
     const GeometryCoordinates& queryGeometry,
     const TransformState& transformState,
-    const std::vector<const RenderLayer*>& layers,
+    const std::unordered_map<std::string, const RenderLayer*>& layers,
     const RenderedQueryOptions& options,
     const mat4& projMatrix) {
 

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -52,7 +52,7 @@ public:
             std::unordered_map<std::string, std::vector<Feature>>& result,
             const GeometryCoordinates& queryGeometry,
             const TransformState&,
-            const std::vector<const RenderLayer*>& layers,
+            const std::unordered_map<std::string, const RenderLayer*>& layers,
             const RenderedQueryOptions& options,
             const mat4& projMatrix) override;
 
@@ -60,7 +60,7 @@ public:
         std::vector<Feature>& result,
         const SourceQueryOptions&) override;
 
-    float getQueryPadding(const std::vector<const RenderLayer*>&) override;
+    float getQueryPadding(const std::unordered_map<std::string, const RenderLayer*>&) override;
 
     void cancel() override;
 

--- a/src/mbgl/tile/tile.cpp
+++ b/src/mbgl/tile/tile.cpp
@@ -43,11 +43,11 @@ void Tile::queryRenderedFeatures(
         std::unordered_map<std::string, std::vector<Feature>>&,
         const GeometryCoordinates&,
         const TransformState&,
-        const std::vector<const RenderLayer*>&,
+        const std::unordered_map<std::string, const RenderLayer*>&,
         const RenderedQueryOptions&,
         const mat4&) {}
 
-float Tile::getQueryPadding(const std::vector<const RenderLayer*>&) {
+float Tile::getQueryPadding(const std::unordered_map<std::string, const RenderLayer*>&) {
     return 0;
 }
 

--- a/src/mbgl/tile/tile.hpp
+++ b/src/mbgl/tile/tile.hpp
@@ -71,7 +71,7 @@ public:
             std::unordered_map<std::string, std::vector<Feature>>& result,
             const GeometryCoordinates& queryGeometry,
             const TransformState&,
-            const std::vector<const RenderLayer*>&,
+            const std::unordered_map<std::string, const RenderLayer*>&,
             const RenderedQueryOptions& options,
             const mat4& projMatrix);
 
@@ -79,7 +79,7 @@ public:
             std::vector<Feature>& result,
             const SourceQueryOptions&);
 
-    virtual float getQueryPadding(const std::vector<const RenderLayer*>&);
+    virtual float getQueryPadding(const std::unordered_map<std::string, const RenderLayer*>&);
 
     void setTriedCache();
 


### PR DESCRIPTION
This PR adds following changes:

- Reserves size of a filtered render layers container based on number of previously rendered layers
- Provides hashed container of RenderLayer* items to qRF path to remove few linear lookups
- Queries rendered features only from layers / sources that were provided via qRF API

```diff
--- /home/shalamov/github/mapbox-gl-native/master.json
+++ /home/shalamov/github/mapbox-gl-native/head.json
@@ -1,6 +1,6 @@
 {
   "context": {
-    "date": "2019-06-17 13:18:49",
+    "date": "2019-06-17 17:24:14",
     "executable": "./mbgl-benchmark",
     "num_cpus": 8,
     "mhz_per_cpu": 1901,
@@ -30,296 +30,296 @@
   "benchmarks": [
     {
       "name": "API_queryRenderedFeaturesAll_median",
-      "iterations": 2,
-      "real_time": 2.9258846699667627e+08,
-      "cpu_time": 2.9092940099999988e+08,
+      "iterations": 3,
+      "real_time": 2.6814993999626800e+08,
+      "cpu_time": 2.6725210366666672e+08,
       "time_unit": "ns"
     },
     {
       "name": "API_queryRenderedFeaturesLayerFromLowDensity_median",
-      "iterations": 1084,
-      "real_time": 6.4448682195356640e+05,
-      "cpu_time": 6.4066568726937275e+05,
+      "iterations": 891907,
+      "real_time": 7.8707193240672211e+02,
+      "cpu_time": 7.8502508109029293e+02,
       "time_unit": "ns"
     },
     {
       "name": "API_queryRenderedFeaturesLayerFromHighDensity_median",
-      "iterations": 97,
-      "real_time": 8.0839816907531172e+06,
-      "cpu_time": 8.0452219175257832e+06,
+      "iterations": 115,
+      "real_time": 6.5936392436370905e+06,
+      "cpu_time": 6.5608338695652150e+06,
       "time_unit": "ns"
     },
     {
       "name": "API_renderStill_reuse_map_median",
-      "iterations": 25,
-      "real_time": 3.2197530280100182e+07,
-      "cpu_time": 2.5929986279999968e+07,
+      "iterations": 24,
+      "real_time": 3.1881906374716591e+07,
+      "cpu_time": 2.5487714958333388e+07,
       "time_unit": "ns"
     },
     {
       "name": "API_renderStill_reuse_map_formatted_labels_median",
       "iterations": 24,
-      "real_time": 3.1812568290964309e+07,
-      "cpu_time": 2.5536425499999981e+07,
+      "real_time": 3.1739306541567203e+07,
+      "cpu_time": 2.5345234916666660e+07,
       "time_unit": "ns"
     },
     {
       "name": "API_renderStill_reuse_map_switch_styles_median",
       "iterations": 4,
-      "real_time": 1.8266077324369690e+08,
-      "cpu_time": 1.6953764650000024e+08,
+      "real_time": 1.8521663325373083e+08,
+      "cpu_time": 1.7134056050000003e+08,
       "time_unit": "ns"
     },
     {
       "name": "API_renderStill_recreate_map_median",
       "iterations": 4,
-      "real_time": 1.8047783050133148e+08,
-      "cpu_time": 1.6749408524999952e+08,
+      "real_time": 1.8411497925262666e+08,
+      "cpu_time": 1.6965322674999949e+08,
       "time_unit": "ns"
     }
   ]
```