### PR TITLE
[core] Implement text-writing-mode layout property for symbol layer

### DIFF
--- a/include/mbgl/style/layers/symbol_layer.hpp
+++ b/include/mbgl/style/layers/symbol_layer.hpp
@@ -186,6 +186,10 @@ public:
     const PropertyValue<std::vector<TextVariableAnchorType>>& getTextVariableAnchor() const;
     void setTextVariableAnchor(const PropertyValue<std::vector<TextVariableAnchorType>>&);
 
+    static PropertyValue<std::vector<TextWritingModeType>> getDefaultTextWritingMode();
+    const PropertyValue<std::vector<TextWritingModeType>>& getTextWritingMode() const;
+    void setTextWritingMode(const PropertyValue<std::vector<TextWritingModeType>>&);
+
     // Paint properties
 
     static PropertyValue<Color> getDefaultIconColor();

--- a/include/mbgl/style/types.hpp
+++ b/include/mbgl/style/types.hpp
@@ -115,6 +115,11 @@ enum class IconTextFitType : uint8_t {
     Height
 };
 
+enum class TextWritingModeType : uint8_t {
+    Horizontal,
+    Vertical
+};
+
 enum class LightAnchorType: bool {
     Map,
     Viewport

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -3,6 +3,7 @@
 Mapbox welcomes participation and contributions from everyone.  If you'd like to do so please see the [`Contributing Guide`](https://github.com/mapbox/mapbox-gl-native/blob/master/CONTRIBUTING.md) first to get started.
 
 ## master
+- Introduce `text-writing-mode` layout property for symbol layer [#14932](https://github.com/mapbox/mapbox-gl-native/pull/14932). The `text-writing-mode` layout property allows control over symbol's preferred writing mode. The new property value is an array, whose values are enumeration values from a ( `horizontal` | `vertical` ) set.
 
 ### Features
  - Add fallback support to local ideograph font families [#15255](https://github.com/mapbox/mapbox-gl-native/pull/15255)

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Property.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Property.java
@@ -669,6 +669,27 @@ public final class Property {
   @Retention(RetentionPolicy.SOURCE)
   public @interface ANCHOR {}
 
+  // TEXT_WRITING_MODE: The property allows control over a symbol's orientation. Note that the property values act as a hint, so that a symbol whose language doesn’t support the provided orientation will be laid out in its natural orientation. Example: English point symbol will be rendered horizontally even if array value contains single 'vertical' enum value. The order of elements in an array define priority order for the placement of an orientation variant.
+
+  /**
+   * If a text's language supports horizontal writing mode, symbols with point placement would be laid out horizontally.
+   */
+  public static final String TEXT_WRITING_MODE_HORIZONTAL = "horizontal";
+  /**
+   * If a text's language supports vertical writing mode, symbols with point placement would be laid out vertically.
+   */
+  public static final String TEXT_WRITING_MODE_VERTICAL = "vertical";
+
+  /**
+   * The property allows control over a symbol's orientation. Note that the property values act as a hint, so that a symbol whose language doesn’t support the provided orientation will be laid out in its natural orientation. Example: English point symbol will be rendered horizontally even if array value contains single 'vertical' enum value. The order of elements in an array define priority order for the placement of an orientation variant.
+   */
+  @StringDef({
+      TEXT_WRITING_MODE_HORIZONTAL,
+      TEXT_WRITING_MODE_VERTICAL,
+    })
+  @Retention(RetentionPolicy.SOURCE)
+  public @interface TEXT_WRITING_MODE {}
+
 
   private Property() {
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyFactory.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyFactory.java
@@ -2376,6 +2376,26 @@ public class PropertyFactory {
   }
 
   /**
+   * The property allows control over a symbol's orientation. Note that the property values act as a hint, so that a symbol whose language doesn’t support the provided orientation will be laid out in its natural orientation. Example: English point symbol will be rendered horizontally even if array value contains single 'vertical' enum value. The order of elements in an array define priority order for the placement of an orientation variant.
+   *
+   * @param value a String[] value
+   * @return property wrapper around String[]
+   */
+  public static PropertyValue<String[]> textWritingMode(String[] value) {
+    return new LayoutPropertyValue<>("text-writing-mode", value);
+  }
+
+  /**
+   * The property allows control over a symbol's orientation. Note that the property values act as a hint, so that a symbol whose language doesn’t support the provided orientation will be laid out in its natural orientation. Example: English point symbol will be rendered horizontally even if array value contains single 'vertical' enum value. The order of elements in an array define priority order for the placement of an orientation variant.
+   *
+   * @param value a String[] value
+   * @return property wrapper around String[]
+   */
+  public static PropertyValue<Expression> textWritingMode(Expression value) {
+    return new LayoutPropertyValue<>("text-writing-mode", value);
+  }
+
+  /**
    * Rotates the text clockwise.
    *
    * @param value a Float value

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/SymbolLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/SymbolLayer.java
@@ -530,6 +530,18 @@ public class SymbolLayer extends Layer {
   }
 
   /**
+   * Get the TextWritingMode property
+   *
+   * @return property wrapper value around String[]
+   */
+  @NonNull
+  @SuppressWarnings("unchecked")
+  public PropertyValue<String[]> getTextWritingMode() {
+    checkThread();
+    return (PropertyValue<String[]>) new PropertyValue("text-writing-mode", nativeGetTextWritingMode());
+  }
+
+  /**
    * Get the TextRotate property
    *
    * @return property wrapper value around Float
@@ -1240,6 +1252,10 @@ public class SymbolLayer extends Layer {
   @NonNull
   @Keep
   private native Object nativeGetTextMaxAngle();
+
+  @NonNull
+  @Keep
+  private native Object nativeGetTextWritingMode();
 
   @NonNull
   @Keep

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
@@ -670,6 +670,19 @@ public class SymbolLayerTest extends BaseLayerTest {
 
   @Test
   @UiThreadTest
+  public void testTextWritingModeAsConstant() {
+    Timber.i("text-writing-mode");
+    assertNotNull(layer);
+    assertNull(layer.getTextWritingMode().getValue());
+
+    // Set and Get
+    String[] propertyValue = new String[0];
+    layer.setProperties(textWritingMode(propertyValue));
+    assertEquals(layer.getTextWritingMode().getValue(), propertyValue);
+  }
+
+  @Test
+  @UiThreadTest
   public void testTextRotateAsConstant() {
     Timber.i("text-rotate");
     assertNotNull(layer);

--- a/platform/android/scripts/generate-style-code.js
+++ b/platform/android/scripts/generate-style-code.js
@@ -49,10 +49,19 @@ var layers = Object.keys(spec.layer.type.values).map((type) => {
 });
 
 // Process all layer properties
+const uniqueArrayEnum = (prop, enums) => {
+  if (prop.value !== 'enum') return false;
+  const enumsEqual = (val1, val2) => val1.length === val1.length && val1.every((val, i) => val === val2[i]);
+  return enums.filter(e => enumsEqual(Object.keys(prop.values).sort(), Object.keys(e.values).sort())).length == 0;
+};
+
 const layoutProperties = _(layers).map('layoutProperties').flatten().value();
 const paintProperties = _(layers).map('paintProperties').flatten().value();
 const allProperties = _(layoutProperties).union(paintProperties).union(lightProperties).value();
-const enumProperties = _(allProperties).filter({'type': 'enum'}).value();
+let allEnumProperties = _(allProperties).filter({'type': 'enum'}).value();
+const uniqueArrayEnumProperties = _(allProperties).filter({'type': 'array'}).filter(prop => uniqueArrayEnum(prop, allEnumProperties)).value();
+const enumProperties = _(allEnumProperties).union(uniqueArrayEnumProperties).value();
+
 
 global.propertyType = function propertyType(property) {
   switch (property.type) {

--- a/platform/android/src/style/layers/symbol_layer.cpp
+++ b/platform/android/src/style/layers/symbol_layer.cpp
@@ -201,6 +201,11 @@ namespace android {
         return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextMaxAngle()));
     }
 
+    jni::Local<jni::Object<>> SymbolLayer::getTextWritingMode(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextWritingMode()));
+    }
+
     jni::Local<jni::Object<>> SymbolLayer::getTextRotate(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextRotate()));
@@ -534,6 +539,7 @@ namespace android {
             METHOD(&SymbolLayer::getTextVariableAnchor, "nativeGetTextVariableAnchor"),
             METHOD(&SymbolLayer::getTextAnchor, "nativeGetTextAnchor"),
             METHOD(&SymbolLayer::getTextMaxAngle, "nativeGetTextMaxAngle"),
+            METHOD(&SymbolLayer::getTextWritingMode, "nativeGetTextWritingMode"),
             METHOD(&SymbolLayer::getTextRotate, "nativeGetTextRotate"),
             METHOD(&SymbolLayer::getTextPadding, "nativeGetTextPadding"),
             METHOD(&SymbolLayer::getTextKeepUpright, "nativeGetTextKeepUpright"),

--- a/platform/android/src/style/layers/symbol_layer.hpp
+++ b/platform/android/src/style/layers/symbol_layer.hpp
@@ -90,6 +90,8 @@ public:
 
     jni::Local<jni::Object<jni::ObjectTag>> getTextMaxAngle(jni::JNIEnv&);
 
+    jni::Local<jni::Object<jni::ObjectTag>> getTextWritingMode(jni::JNIEnv&);
+
     jni::Local<jni::Object<jni::ObjectTag>> getTextRotate(jni::JNIEnv&);
 
     jni::Local<jni::Object<jni::ObjectTag>> getTextPadding(jni::JNIEnv&);

--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -409,7 +409,7 @@ global.propertyDoc = function (propertyName, property, layerType, kind) {
             doc += '* Any of the following constant string values:\n';
             doc += Object.keys(property.values).map(value => '  * `' + value + '`: ' + property.values[value].doc).join('\n') + '\n';
         } else if (property.type === 'array' && property.value === 'enum') {
-            doc += '* Constant array, whose each element is any of the following constant string values:\n';
+            doc += '* Constant array, in which each element is any of the following constant string values:\n';
             doc += Object.keys(property.values).map(value => '  * `' + value + '`: ' + property.values[value].doc).join('\n') + '\n';
         }
         if (property.type === 'formatted') {

--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -468,7 +468,7 @@ global.describeType = function (property) {
                 case 'anchor':
                     return '`MGLTextAnchor` array';
                 case 'mode':
-                    return '`MGLTextWritingMode` array';
+                    return '`MGLTextWritingModes` array';
                 default:
                     return 'array';
             }
@@ -647,7 +647,7 @@ global.valueTransformerArguments = function (property) {
                 case 'anchor':
                     return ['std::vector<mbgl::style::SymbolAnchorType>', objCType, 'mbgl::style::SymbolAnchorType', 'MGLTextAnchor'];
                 case 'mode':
-                    return ['std::vector<mbgl::style::TextWritingModeType>', objCType, 'mbgl::style::TextWritingModeType', 'MGLTextWritingMode'];
+                    return ['std::vector<mbgl::style::TextWritingModeType>', objCType, 'mbgl::style::TextWritingModeType', 'MGLTextWritingModes'];
                 default:
                     throw new Error(`unknown array type for ${property.name}`);
             }

--- a/platform/darwin/scripts/style-spec-cocoa-conventions-v8.json
+++ b/platform/darwin/scripts/style-spec-cocoa-conventions-v8.json
@@ -19,7 +19,7 @@
     "text-optional": "is-text-optional",
     "text-rotate": "text-rotation",
     "text-size": "text-font-size",
-    "text-writing-mode": "text-writing-modes"
+    "text-writing-mode": {"name": "text-writing-modes", "enumName": "text-writing-mode"}
   },
   "paint_circle": {
     "circle-pitch-scale": "circle-scale-alignment",

--- a/platform/darwin/scripts/style-spec-cocoa-conventions-v8.json
+++ b/platform/darwin/scripts/style-spec-cocoa-conventions-v8.json
@@ -18,7 +18,8 @@
     "text-max-width": "maximum-text-width",
     "text-optional": "is-text-optional",
     "text-rotate": "text-rotation",
-    "text-size": "text-font-size"
+    "text-size": "text-font-size",
+    "text-writing-mode": "text-writing-modes"
   },
   "paint_circle": {
     "circle-pitch-scale": "circle-scale-alignment",

--- a/platform/darwin/src/MGLStyleLayer.h.ejs
+++ b/platform/darwin/src/MGLStyleLayer.h.ejs
@@ -19,7 +19,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 <% for (const property of layoutProperties) { -%>
-<% if (property.type == "enum") { -%>
+<% if (definesEnum(property, layoutProperties)) { -%>
 /**
 <%- propertyDoc(property.name, property, type, 'enum').wrap(80, 1) %>
 
@@ -38,7 +38,7 @@ typedef NS_ENUM(NSUInteger, MGL<%- camelize(property.name) %>) {
 <% } -%>
 <% } -%>
 <% for (const property of paintProperties) { -%>
-<% if (property.type == "enum") { -%>
+<% if (definesEnum(property, paintProperties)) { -%>
 /**
 <%- propertyDoc(property.name, property, type, 'enum').wrap(80, 1) %>
 

--- a/platform/darwin/src/MGLStyleLayer.h.ejs
+++ b/platform/darwin/src/MGLStyleLayer.h.ejs
@@ -21,17 +21,17 @@ NS_ASSUME_NONNULL_BEGIN
 <% for (const property of layoutProperties) { -%>
 <% if (definesEnum(property, layoutProperties)) { -%>
 /**
-<%- propertyDoc(property.name, property, type, 'enum').wrap(80, 1) %>
+<%- propertyDoc(enumName(property), property, type, 'enum').wrap(80, 1) %>
 
  Values of this type are used in the `MGL<%- camelize(type) %>StyleLayer.<%- camelizeWithLeadingLowercase(property.name) %>`
  property.
  */
-typedef NS_ENUM(NSUInteger, MGL<%- camelize(property.name) %>) {
+typedef NS_ENUM(NSUInteger, MGL<%- camelize(enumName(property)) %>) {
 <% for (const value in property.values) { -%>
     /**
-<%- propertyDoc(property.name, property.values[value], type, 'enum').wrap(80, 4+1) %>
+<%- propertyDoc(enumName(property), property.values[value], type, 'enum').wrap(80, 4+1) %>
      */
-    MGL<%- camelize(property.name) %><%- camelize(value) %>,
+    MGL<%- camelize(enumName(property)) %><%- camelize(value) %>,
 <% } -%>
 };
 
@@ -40,17 +40,17 @@ typedef NS_ENUM(NSUInteger, MGL<%- camelize(property.name) %>) {
 <% for (const property of paintProperties) { -%>
 <% if (definesEnum(property, paintProperties)) { -%>
 /**
-<%- propertyDoc(property.name, property, type, 'enum').wrap(80, 1) %>
+<%- propertyDoc(enumName(property), property, type, 'enum').wrap(80, 1) %>
 
- Values of this type are used in the `MGL<%- camelize(type) %>StyleLayer.<%- camelizeWithLeadingLowercase(property.name) %>`
+ Values of this type are used in the `MGL<%- camelize(type) %>StyleLayer.<%- camelizeWithLeadingLowercase(enumName(property)) %>`
  property.
  */
-typedef NS_ENUM(NSUInteger, MGL<%- camelize(property.name) %>) {
+typedef NS_ENUM(NSUInteger, MGL<%- camelize(enumName(property)) %>) {
 <% for (const value in property.values) { -%>
     /**
-<%- propertyDoc(property.name, property.values[value], type, 'enum').wrap(80, 4+1) %>
+<%- propertyDoc(enumName(property), property.values[value], type, 'enum').wrap(80, 4+1) %>
      */
-    MGL<%- camelize(property.name) %><%- camelize(value) %>,
+    MGL<%- camelize(enumName(property)) %><%- camelize(value) %>,
 <% } -%>
 };
 
@@ -180,17 +180,17 @@ which it is added.
 
 <% for (let property of enumProperties) { -%>
 /**
- Creates a new value object containing the given `MGL<%- camelize(property.name) %>` enumeration.
+ Creates a new value object containing the given `MGL<%- camelize(enumName(property)) %>` enumeration.
 
  @param <%- objCName(property) %> The value for the new object.
  @return A new value object that contains the enumeration value.
  */
-+ (instancetype)valueWithMGL<%- camelize(property.name) %>:(MGL<%- camelize(property.name) %>)<%- objCName(property) %>;
++ (instancetype)valueWithMGL<%- camelize(enumName(property)) %>:(MGL<%- camelize(enumName(property)) %>)<%- objCName(property) %>;
 
 /**
- The `MGL<%- camelize(property.name) %>` enumeration representation of the value.
+ The `MGL<%- camelize(enumName(property)) %>` enumeration representation of the value.
  */
-@property (readonly) MGL<%- camelize(property.name) %> MGL<%- camelize(property.name) %>Value;
+@property (readonly) MGL<%- camelize(enumName(property)) %> MGL<%- camelize(enumName(property)) %>Value;
 
 <% } -%>
 @end

--- a/platform/darwin/src/MGLStyleLayer.mm.ejs
+++ b/platform/darwin/src/MGLStyleLayer.mm.ejs
@@ -25,7 +25,7 @@ namespace mbgl {
 
 <% if (layoutProperties.length) { -%>
 <% for (const property of layoutProperties) { -%>
-<% if (property.type == "enum") { -%>
+<% if (definesEnum(property, layoutProperties)) { -%>
     MBGL_DEFINE_ENUM(MGL<%- camelize(property.name) %>, {
 <% for (const value in property.values) { -%>
         { MGL<%- camelize(property.name) %><%- camelize(value) %>, "<%-value%>" },
@@ -37,7 +37,7 @@ namespace mbgl {
 <% } -%>
 <% if (paintProperties.length) { -%>
 <% for (const property of paintProperties) { -%>
-<% if (property.type == "enum") { -%>
+<% if (definesEnum(property, paintProperties)) { -%>
     MBGL_DEFINE_ENUM(MGL<%- camelize(property.name) %>, {
 <% for (const value in property.values) { -%>
         { MGL<%- camelize(property.name) %><%- camelize(value) %>, "<%-value%>" },

--- a/platform/darwin/src/MGLStyleLayer.mm.ejs
+++ b/platform/darwin/src/MGLStyleLayer.mm.ejs
@@ -26,9 +26,9 @@ namespace mbgl {
 <% if (layoutProperties.length) { -%>
 <% for (const property of layoutProperties) { -%>
 <% if (definesEnum(property, layoutProperties)) { -%>
-    MBGL_DEFINE_ENUM(MGL<%- camelize(property.name) %>, {
+    MBGL_DEFINE_ENUM(MGL<%- camelize(enumName(property)) %>, {
 <% for (const value in property.values) { -%>
-        { MGL<%- camelize(property.name) %><%- camelize(value) %>, "<%-value%>" },
+        { MGL<%- camelize(enumName(property)) %><%- camelize(value) %>, "<%-value%>" },
 <% } -%>
     });
 
@@ -38,9 +38,9 @@ namespace mbgl {
 <% if (paintProperties.length) { -%>
 <% for (const property of paintProperties) { -%>
 <% if (definesEnum(property, paintProperties)) { -%>
-    MBGL_DEFINE_ENUM(MGL<%- camelize(property.name) %>, {
+    MBGL_DEFINE_ENUM(MGL<%- camelize(enumName(property)) %>, {
 <% for (const value in property.values) { -%>
-        { MGL<%- camelize(property.name) %><%- camelize(value) %>, "<%-value%>" },
+        { MGL<%- camelize(enumName(property)) %><%- camelize(value) %>, "<%-value%>" },
 <% } -%>
     });
 
@@ -239,12 +239,12 @@ namespace mbgl {
 @implementation NSValue (MGL<%- camelize(type) %>StyleLayerAdditions)
 
 <% for (let property of enumProperties) { -%>
-+ (NSValue *)valueWithMGL<%- camelize(property.name) %>:(MGL<%- camelize(property.name) %>)<%- objCName(property) %> {
-    return [NSValue value:&<%- objCName(property) %> withObjCType:@encode(MGL<%- camelize(property.name) %>)];
++ (NSValue *)valueWithMGL<%- camelize(enumName(property)) %>:(MGL<%- camelize(enumName(property)) %>)<%- objCName(property) %> {
+    return [NSValue value:&<%- objCName(property) %> withObjCType:@encode(MGL<%- camelize(enumName(property)) %>)];
 }
 
-- (MGL<%- camelize(property.name) %>)MGL<%- camelize(property.name) %>Value {
-    MGL<%- camelize(property.name) %> <%- objCName(property) %>;
+- (MGL<%- camelize(enumName(property)) %>)MGL<%- camelize(enumName(property)) %>Value {
+    MGL<%- camelize(enumName(property)) %> <%- objCName(property) %>;
     [self getValue:&<%- objCName(property) %>];
     return <%- objCName(property) %>;
 }

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -324,20 +324,20 @@ typedef NS_ENUM(NSUInteger, MGLTextTransform) {
  ["vertical"]` is set. The order of elements in an array define priority order
  for the placement of an orientation variant.
 
- Values of this type are used in the `MGLSymbolStyleLayer.textWritingMode`
+ Values of this type are used in the `MGLSymbolStyleLayer.textWritingModes`
  property.
  */
-typedef NS_ENUM(NSUInteger, MGLTextWritingMode) {
+typedef NS_ENUM(NSUInteger, MGLTextWritingModes) {
     /**
      If a text's language supports horizontal writing mode, symbols with point
      placement would be laid out horizontally.
      */
-    MGLTextWritingModeHorizontal,
+    MGLTextWritingModesHorizontal,
     /**
      If a text's language supports vertical writing mode, symbols with point
      placement would be laid out vertically.
      */
-    MGLTextWritingModeVertical,
+    MGLTextWritingModesVertical,
 };
 
 /**
@@ -1682,9 +1682,13 @@ MGL_EXPORT
  `symbolPlacement` is set to an expression that evaluates to or
  `MGLSymbolPlacementPoint`. Otherwise, it is ignored.
  
+ This attribute corresponds to the <a
+ href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-writing-mode"><code>text-writing-mode</code></a>
+ layout property in the Mapbox Style Specification.
+ 
  You can set this property to an expression containing any of the following:
  
- * Constant `MGLTextWritingMode` array values
+ * Constant `MGLTextWritingModes` array values
  * Constant array, whose each element is any of the following constant string
  values:
    * `horizontal`: If a text's language supports horizontal writing mode,
@@ -1700,7 +1704,10 @@ MGL_EXPORT
  `$zoomLevel` variable or applying interpolation or step functions to feature
  attributes.
  */
-@property (nonatomic, null_resettable) NSExpression *textWritingMode;
+@property (nonatomic, null_resettable) NSExpression *textWritingModes;
+
+
+@property (nonatomic, null_resettable) NSExpression *textWritingMode __attribute__((unavailable("Use textWritingModes instead.")));
 
 #pragma mark - Accessing the Paint Attributes
 
@@ -2439,17 +2446,17 @@ MGL_EXPORT
 @property (readonly) MGLTextTransform MGLTextTransformValue;
 
 /**
- Creates a new value object containing the given `MGLTextWritingMode` enumeration.
+ Creates a new value object containing the given `MGLTextWritingModes` enumeration.
 
- @param textWritingMode The value for the new object.
+ @param textWritingModes The value for the new object.
  @return A new value object that contains the enumeration value.
  */
-+ (instancetype)valueWithMGLTextWritingMode:(MGLTextWritingMode)textWritingMode;
++ (instancetype)valueWithMGLTextWritingModes:(MGLTextWritingModes)textWritingModes;
 
 /**
- The `MGLTextWritingMode` enumeration representation of the value.
+ The `MGLTextWritingModes` enumeration representation of the value.
  */
-@property (readonly) MGLTextWritingMode MGLTextWritingModeValue;
+@property (readonly) MGLTextWritingModes MGLTextWritingModesValue;
 
 /**
  Creates a new value object containing the given `MGLIconTranslationAnchor` enumeration.

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -317,9 +317,9 @@ typedef NS_ENUM(NSUInteger, MGLTextTransform) {
 };
 
 /**
- The property allows to control an orientation of a symbol. Note that the
- property values act as a hint, so that a symbol whose language doesn’t support
- the provided orientation will be laid out in its natural orientation. Example:
+ The property allows control over a symbol's orientation. Note that the property
+ values act as a hint, so that a symbol whose language doesn’t support the
+ provided orientation will be laid out in its natural orientation. Example:
  English point symbol will be rendered horizontally even if array value contains
  single 'vertical' enum value. The order of elements in an array define priority
  order for the placement of an orientation variant.
@@ -1644,7 +1644,7 @@ MGL_EXPORT
  You can set this property to an expression containing any of the following:
  
  * Constant `MGLTextAnchor` array values
- * Constant array, whose each element is any of the following constant string
+ * Constant array, in which each element is any of the following constant string
  values:
    * `center`: The center of the text is placed closest to the anchor.
    * `left`: The left side of the text is placed closest to the anchor.
@@ -1671,9 +1671,9 @@ MGL_EXPORT
 @property (nonatomic, null_resettable) NSExpression *textVariableAnchor;
 
 /**
- The property allows to control an orientation of a symbol. Note that the
- property values act as a hint, so that a symbol whose language doesn’t support
- the provided orientation will be laid out in its natural orientation. Example:
+ The property allows control over a symbol's orientation. Note that the property
+ values act as a hint, so that a symbol whose language doesn’t support the
+ provided orientation will be laid out in its natural orientation. Example:
  English point symbol will be rendered horizontally even if array value contains
  single 'vertical' enum value. The order of elements in an array define priority
  order for the placement of an orientation variant.
@@ -1689,7 +1689,7 @@ MGL_EXPORT
  You can set this property to an expression containing any of the following:
  
  * Constant `MGLTextWritingMode` array values
- * Constant array, whose each element is any of the following constant string
+ * Constant array, in which each element is any of the following constant string
  values:
    * `horizontal`: If a text's language supports horizontal writing mode,
  symbols with point placement would be laid out horizontally.

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -317,27 +317,27 @@ typedef NS_ENUM(NSUInteger, MGLTextTransform) {
 };
 
 /**
- The property allows to control an orientation of a symbol. Note, that the
- property values act as a hint, so that Symbols whose language doesn't support
- provided orientation, will be laid out in their natural orientation. Example:
- English point symbol will be rendered horizontally even if `"textWritingMode":
- ["vertical"]` is set. The order of elements in an array define priority order
- for the placement of an orientation variant.
+ The property allows to control an orientation of a symbol. Note that the
+ property values act as a hint, so that a symbol whose language doesn’t support
+ the provided orientation will be laid out in its natural orientation. Example:
+ English point symbol will be rendered horizontally even if array value contains
+ single 'vertical' enum value. The order of elements in an array define priority
+ order for the placement of an orientation variant.
 
  Values of this type are used in the `MGLSymbolStyleLayer.textWritingModes`
  property.
  */
-typedef NS_ENUM(NSUInteger, MGLTextWritingModes) {
+typedef NS_ENUM(NSUInteger, MGLTextWritingMode) {
     /**
      If a text's language supports horizontal writing mode, symbols with point
      placement would be laid out horizontally.
      */
-    MGLTextWritingModesHorizontal,
+    MGLTextWritingModeHorizontal,
     /**
      If a text's language supports vertical writing mode, symbols with point
      placement would be laid out vertically.
      */
-    MGLTextWritingModesVertical,
+    MGLTextWritingModeVertical,
 };
 
 /**
@@ -1671,12 +1671,12 @@ MGL_EXPORT
 @property (nonatomic, null_resettable) NSExpression *textVariableAnchor;
 
 /**
- The property allows to control an orientation of a symbol. Note, that the
- property values act as a hint, so that Symbols whose language doesn't support
- provided orientation, will be laid out in their natural orientation. Example:
- English point symbol will be rendered horizontally even if `"textWritingMode":
- ["vertical"]` is set. The order of elements in an array define priority order
- for the placement of an orientation variant.
+ The property allows to control an orientation of a symbol. Note that the
+ property values act as a hint, so that a symbol whose language doesn’t support
+ the provided orientation will be laid out in its natural orientation. Example:
+ English point symbol will be rendered horizontally even if array value contains
+ single 'vertical' enum value. The order of elements in an array define priority
+ order for the placement of an orientation variant.
  
  This property is only applied to the style if `text` is non-`nil`, and
  `symbolPlacement` is set to an expression that evaluates to or
@@ -1688,7 +1688,7 @@ MGL_EXPORT
  
  You can set this property to an expression containing any of the following:
  
- * Constant `MGLTextWritingModes` array values
+ * Constant `MGLTextWritingMode` array values
  * Constant array, whose each element is any of the following constant string
  values:
    * `horizontal`: If a text's language supports horizontal writing mode,
@@ -2446,17 +2446,17 @@ MGL_EXPORT
 @property (readonly) MGLTextTransform MGLTextTransformValue;
 
 /**
- Creates a new value object containing the given `MGLTextWritingModes` enumeration.
+ Creates a new value object containing the given `MGLTextWritingMode` enumeration.
 
  @param textWritingModes The value for the new object.
  @return A new value object that contains the enumeration value.
  */
-+ (instancetype)valueWithMGLTextWritingModes:(MGLTextWritingModes)textWritingModes;
++ (instancetype)valueWithMGLTextWritingMode:(MGLTextWritingMode)textWritingModes;
 
 /**
- The `MGLTextWritingModes` enumeration representation of the value.
+ The `MGLTextWritingMode` enumeration representation of the value.
  */
-@property (readonly) MGLTextWritingModes MGLTextWritingModesValue;
+@property (readonly) MGLTextWritingMode MGLTextWritingModeValue;
 
 /**
  Creates a new value object containing the given `MGLIconTranslationAnchor` enumeration.

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -317,6 +317,30 @@ typedef NS_ENUM(NSUInteger, MGLTextTransform) {
 };
 
 /**
+ The property allows to control an orientation of a symbol. Note, that the
+ property values act as a hint, so that Symbols whose language doesn't support
+ provided orientation, will be laid out in their natural orientation. Example:
+ English point symbol will be rendered horizontally even if `"textWritingMode":
+ ["vertical"]` is set. The order of elements in an array define priority order
+ for the placement of an orientation variant.
+
+ Values of this type are used in the `MGLSymbolStyleLayer.textWritingMode`
+ property.
+ */
+typedef NS_ENUM(NSUInteger, MGLTextWritingMode) {
+    /**
+     If a text's language supports horizontal writing mode, symbols with point
+     placement would be laid out horizontally.
+     */
+    MGLTextWritingModeHorizontal,
+    /**
+     If a text's language supports vertical writing mode, symbols with point
+     placement would be laid out vertically.
+     */
+    MGLTextWritingModeVertical,
+};
+
+/**
  Controls the frame of reference for `MGLSymbolStyleLayer.iconTranslation`.
 
  Values of this type are used in the `MGLSymbolStyleLayer.iconTranslationAnchor`
@@ -1646,6 +1670,38 @@ MGL_EXPORT
  */
 @property (nonatomic, null_resettable) NSExpression *textVariableAnchor;
 
+/**
+ The property allows to control an orientation of a symbol. Note, that the
+ property values act as a hint, so that Symbols whose language doesn't support
+ provided orientation, will be laid out in their natural orientation. Example:
+ English point symbol will be rendered horizontally even if `"textWritingMode":
+ ["vertical"]` is set. The order of elements in an array define priority order
+ for the placement of an orientation variant.
+ 
+ This property is only applied to the style if `text` is non-`nil`, and
+ `symbolPlacement` is set to an expression that evaluates to or
+ `MGLSymbolPlacementPoint`. Otherwise, it is ignored.
+ 
+ You can set this property to an expression containing any of the following:
+ 
+ * Constant `MGLTextWritingMode` array values
+ * Constant array, whose each element is any of the following constant string
+ values:
+   * `horizontal`: If a text's language supports horizontal writing mode,
+ symbols with point placement would be laid out horizontally.
+   * `vertical`: If a text's language supports vertical writing mode, symbols
+ with point placement would be laid out vertically.
+ * Predefined functions, including mathematical and string operators
+ * Conditional expressions
+ * Variable assignments and references to assigned variables
+ * Step functions applied to the `$zoomLevel` variable
+ 
+ This property does not support applying interpolation functions to the
+ `$zoomLevel` variable or applying interpolation or step functions to feature
+ attributes.
+ */
+@property (nonatomic, null_resettable) NSExpression *textWritingMode;
+
 #pragma mark - Accessing the Paint Attributes
 
 #if TARGET_OS_IPHONE
@@ -2381,6 +2437,19 @@ MGL_EXPORT
  The `MGLTextTransform` enumeration representation of the value.
  */
 @property (readonly) MGLTextTransform MGLTextTransformValue;
+
+/**
+ Creates a new value object containing the given `MGLTextWritingMode` enumeration.
+
+ @param textWritingMode The value for the new object.
+ @return A new value object that contains the enumeration value.
+ */
++ (instancetype)valueWithMGLTextWritingMode:(MGLTextWritingMode)textWritingMode;
+
+/**
+ The `MGLTextWritingMode` enumeration representation of the value.
+ */
+@property (readonly) MGLTextWritingMode MGLTextWritingModeValue;
 
 /**
  Creates a new value object containing the given `MGLIconTranslationAnchor` enumeration.

--- a/platform/darwin/src/MGLSymbolStyleLayer.mm
+++ b/platform/darwin/src/MGLSymbolStyleLayer.mm
@@ -96,9 +96,9 @@ namespace mbgl {
         { MGLTextTransformLowercase, "lowercase" },
     });
 
-    MBGL_DEFINE_ENUM(MGLTextWritingMode, {
-        { MGLTextWritingModeHorizontal, "horizontal" },
-        { MGLTextWritingModeVertical, "vertical" },
+    MBGL_DEFINE_ENUM(MGLTextWritingModes, {
+        { MGLTextWritingModesHorizontal, "horizontal" },
+        { MGLTextWritingModesVertical, "vertical" },
     });
 
     MBGL_DEFINE_ENUM(MGLIconTranslationAnchor, {
@@ -1028,22 +1028,29 @@ namespace mbgl {
     return MGLStyleValueTransformer<std::vector<mbgl::style::SymbolAnchorType>, NSArray<NSValue *> *, mbgl::style::SymbolAnchorType, MGLTextAnchor>().toExpression(propertyValue);
 }
 
-- (void)setTextWritingMode:(NSExpression *)textWritingMode {
+- (void)setTextWritingModes:(NSExpression *)textWritingModes {
     MGLAssertStyleLayerIsValid();
-    MGLLogDebug(@"Setting textWritingMode: %@", textWritingMode);
+    MGLLogDebug(@"Setting textWritingModes: %@", textWritingModes);
 
-    auto mbglValue = MGLStyleValueTransformer<std::vector<mbgl::style::TextWritingModeType>, NSArray<NSValue *> *, mbgl::style::TextWritingModeType, MGLTextWritingMode>().toPropertyValue<mbgl::style::PropertyValue<std::vector<mbgl::style::TextWritingModeType>>>(textWritingMode, false);
+    auto mbglValue = MGLStyleValueTransformer<std::vector<mbgl::style::TextWritingModeType>, NSArray<NSValue *> *, mbgl::style::TextWritingModeType, MGLTextWritingModes>().toPropertyValue<mbgl::style::PropertyValue<std::vector<mbgl::style::TextWritingModeType>>>(textWritingModes, false);
     self.rawLayer->setTextWritingMode(mbglValue);
 }
 
-- (NSExpression *)textWritingMode {
+- (NSExpression *)textWritingModes {
     MGLAssertStyleLayerIsValid();
 
     auto propertyValue = self.rawLayer->getTextWritingMode();
     if (propertyValue.isUndefined()) {
         propertyValue = self.rawLayer->getDefaultTextWritingMode();
     }
-    return MGLStyleValueTransformer<std::vector<mbgl::style::TextWritingModeType>, NSArray<NSValue *> *, mbgl::style::TextWritingModeType, MGLTextWritingMode>().toExpression(propertyValue);
+    return MGLStyleValueTransformer<std::vector<mbgl::style::TextWritingModeType>, NSArray<NSValue *> *, mbgl::style::TextWritingModeType, MGLTextWritingModes>().toExpression(propertyValue);
+}
+
+- (void)setTextWritingMode:(NSExpression *)textWritingMode {
+}
+
+- (NSExpression *)textWritingMode {
+    return self.textWritingModes;
 }
 
 #pragma mark - Accessing the Paint Attributes
@@ -1622,14 +1629,14 @@ namespace mbgl {
     return textTransform;
 }
 
-+ (NSValue *)valueWithMGLTextWritingMode:(MGLTextWritingMode)textWritingMode {
-    return [NSValue value:&textWritingMode withObjCType:@encode(MGLTextWritingMode)];
++ (NSValue *)valueWithMGLTextWritingModes:(MGLTextWritingModes)textWritingModes {
+    return [NSValue value:&textWritingModes withObjCType:@encode(MGLTextWritingModes)];
 }
 
-- (MGLTextWritingMode)MGLTextWritingModeValue {
-    MGLTextWritingMode textWritingMode;
-    [self getValue:&textWritingMode];
-    return textWritingMode;
+- (MGLTextWritingModes)MGLTextWritingModesValue {
+    MGLTextWritingModes textWritingModes;
+    [self getValue:&textWritingModes];
+    return textWritingModes;
 }
 
 + (NSValue *)valueWithMGLIconTranslationAnchor:(MGLIconTranslationAnchor)iconTranslationAnchor {

--- a/platform/darwin/src/MGLSymbolStyleLayer.mm
+++ b/platform/darwin/src/MGLSymbolStyleLayer.mm
@@ -96,9 +96,9 @@ namespace mbgl {
         { MGLTextTransformLowercase, "lowercase" },
     });
 
-    MBGL_DEFINE_ENUM(MGLTextWritingModes, {
-        { MGLTextWritingModesHorizontal, "horizontal" },
-        { MGLTextWritingModesVertical, "vertical" },
+    MBGL_DEFINE_ENUM(MGLTextWritingMode, {
+        { MGLTextWritingModeHorizontal, "horizontal" },
+        { MGLTextWritingModeVertical, "vertical" },
     });
 
     MBGL_DEFINE_ENUM(MGLIconTranslationAnchor, {
@@ -1032,7 +1032,7 @@ namespace mbgl {
     MGLAssertStyleLayerIsValid();
     MGLLogDebug(@"Setting textWritingModes: %@", textWritingModes);
 
-    auto mbglValue = MGLStyleValueTransformer<std::vector<mbgl::style::TextWritingModeType>, NSArray<NSValue *> *, mbgl::style::TextWritingModeType, MGLTextWritingModes>().toPropertyValue<mbgl::style::PropertyValue<std::vector<mbgl::style::TextWritingModeType>>>(textWritingModes, false);
+    auto mbglValue = MGLStyleValueTransformer<std::vector<mbgl::style::TextWritingModeType>, NSArray<NSValue *> *, mbgl::style::TextWritingModeType, MGLTextWritingMode>().toPropertyValue<mbgl::style::PropertyValue<std::vector<mbgl::style::TextWritingModeType>>>(textWritingModes, false);
     self.rawLayer->setTextWritingMode(mbglValue);
 }
 
@@ -1043,7 +1043,7 @@ namespace mbgl {
     if (propertyValue.isUndefined()) {
         propertyValue = self.rawLayer->getDefaultTextWritingMode();
     }
-    return MGLStyleValueTransformer<std::vector<mbgl::style::TextWritingModeType>, NSArray<NSValue *> *, mbgl::style::TextWritingModeType, MGLTextWritingModes>().toExpression(propertyValue);
+    return MGLStyleValueTransformer<std::vector<mbgl::style::TextWritingModeType>, NSArray<NSValue *> *, mbgl::style::TextWritingModeType, MGLTextWritingMode>().toExpression(propertyValue);
 }
 
 - (void)setTextWritingMode:(NSExpression *)textWritingMode {
@@ -1629,12 +1629,12 @@ namespace mbgl {
     return textTransform;
 }
 
-+ (NSValue *)valueWithMGLTextWritingModes:(MGLTextWritingModes)textWritingModes {
-    return [NSValue value:&textWritingModes withObjCType:@encode(MGLTextWritingModes)];
++ (NSValue *)valueWithMGLTextWritingMode:(MGLTextWritingMode)textWritingModes {
+    return [NSValue value:&textWritingModes withObjCType:@encode(MGLTextWritingMode)];
 }
 
-- (MGLTextWritingModes)MGLTextWritingModesValue {
-    MGLTextWritingModes textWritingModes;
+- (MGLTextWritingMode)MGLTextWritingModeValue {
+    MGLTextWritingMode textWritingModes;
     [self getValue:&textWritingModes];
     return textWritingModes;
 }

--- a/platform/darwin/src/MGLSymbolStyleLayer.mm
+++ b/platform/darwin/src/MGLSymbolStyleLayer.mm
@@ -96,6 +96,11 @@ namespace mbgl {
         { MGLTextTransformLowercase, "lowercase" },
     });
 
+    MBGL_DEFINE_ENUM(MGLTextWritingMode, {
+        { MGLTextWritingModeHorizontal, "horizontal" },
+        { MGLTextWritingModeVertical, "vertical" },
+    });
+
     MBGL_DEFINE_ENUM(MGLIconTranslationAnchor, {
         { MGLIconTranslationAnchorMap, "map" },
         { MGLIconTranslationAnchorViewport, "viewport" },
@@ -1023,6 +1028,24 @@ namespace mbgl {
     return MGLStyleValueTransformer<std::vector<mbgl::style::SymbolAnchorType>, NSArray<NSValue *> *, mbgl::style::SymbolAnchorType, MGLTextAnchor>().toExpression(propertyValue);
 }
 
+- (void)setTextWritingMode:(NSExpression *)textWritingMode {
+    MGLAssertStyleLayerIsValid();
+    MGLLogDebug(@"Setting textWritingMode: %@", textWritingMode);
+
+    auto mbglValue = MGLStyleValueTransformer<std::vector<mbgl::style::TextWritingModeType>, NSArray<NSValue *> *, mbgl::style::TextWritingModeType, MGLTextWritingMode>().toPropertyValue<mbgl::style::PropertyValue<std::vector<mbgl::style::TextWritingModeType>>>(textWritingMode, false);
+    self.rawLayer->setTextWritingMode(mbglValue);
+}
+
+- (NSExpression *)textWritingMode {
+    MGLAssertStyleLayerIsValid();
+
+    auto propertyValue = self.rawLayer->getTextWritingMode();
+    if (propertyValue.isUndefined()) {
+        propertyValue = self.rawLayer->getDefaultTextWritingMode();
+    }
+    return MGLStyleValueTransformer<std::vector<mbgl::style::TextWritingModeType>, NSArray<NSValue *> *, mbgl::style::TextWritingModeType, MGLTextWritingMode>().toExpression(propertyValue);
+}
+
 #pragma mark - Accessing the Paint Attributes
 
 - (void)setIconColor:(NSExpression *)iconColor {
@@ -1597,6 +1620,16 @@ namespace mbgl {
     MGLTextTransform textTransform;
     [self getValue:&textTransform];
     return textTransform;
+}
+
++ (NSValue *)valueWithMGLTextWritingMode:(MGLTextWritingMode)textWritingMode {
+    return [NSValue value:&textWritingMode withObjCType:@encode(MGLTextWritingMode)];
+}
+
+- (MGLTextWritingMode)MGLTextWritingModeValue {
+    MGLTextWritingMode textWritingMode;
+    [self getValue:&textWritingMode];
+    return textWritingMode;
 }
 
 + (NSValue *)valueWithMGLIconTranslationAnchor:(MGLIconTranslationAnchor)iconTranslationAnchor {

--- a/platform/darwin/test/MGLStyleLayerTests.mm.ejs
+++ b/platform/darwin/test/MGLStyleLayerTests.mm.ejs
@@ -214,7 +214,7 @@
 <% for (let property of enumProperties) { -%>
 <% for (let value in property.values) { -%>
 <% if (property.values.hasOwnProperty(value)) { -%>
-    XCTAssertEqual([NSValue valueWithMGL<%- camelize(property.name) %>:MGL<%- camelize(property.name) %><%- camelize(value) %>].MGL<%- camelize(property.name) %>Value, MGL<%- camelize(property.name) %><%- camelize(value) %>);
+    XCTAssertEqual([NSValue valueWithMGL<%- camelize(enumName(property)) %>:MGL<%- camelize(enumName(property)) %><%- camelize(value) %>].MGL<%- camelize(enumName(property)) %>Value, MGL<%- camelize(enumName(property)) %><%- camelize(value) %>);
 <% } -%>
 <% } -%>
 <% } -%>

--- a/platform/darwin/test/MGLSymbolStyleLayerTests.mm
+++ b/platform/darwin/test/MGLSymbolStyleLayerTests.mm
@@ -3193,8 +3193,8 @@
     XCTAssertEqual([NSValue valueWithMGLTextTransform:MGLTextTransformNone].MGLTextTransformValue, MGLTextTransformNone);
     XCTAssertEqual([NSValue valueWithMGLTextTransform:MGLTextTransformUppercase].MGLTextTransformValue, MGLTextTransformUppercase);
     XCTAssertEqual([NSValue valueWithMGLTextTransform:MGLTextTransformLowercase].MGLTextTransformValue, MGLTextTransformLowercase);
-    XCTAssertEqual([NSValue valueWithMGLTextWritingModes:MGLTextWritingModesHorizontal].MGLTextWritingModesValue, MGLTextWritingModesHorizontal);
-    XCTAssertEqual([NSValue valueWithMGLTextWritingModes:MGLTextWritingModesVertical].MGLTextWritingModesValue, MGLTextWritingModesVertical);
+    XCTAssertEqual([NSValue valueWithMGLTextWritingMode:MGLTextWritingModeHorizontal].MGLTextWritingModeValue, MGLTextWritingModeHorizontal);
+    XCTAssertEqual([NSValue valueWithMGLTextWritingMode:MGLTextWritingModeVertical].MGLTextWritingModeValue, MGLTextWritingModeVertical);
     XCTAssertEqual([NSValue valueWithMGLIconTranslationAnchor:MGLIconTranslationAnchorMap].MGLIconTranslationAnchorValue, MGLIconTranslationAnchorMap);
     XCTAssertEqual([NSValue valueWithMGLIconTranslationAnchor:MGLIconTranslationAnchorViewport].MGLIconTranslationAnchorValue, MGLIconTranslationAnchorViewport);
     XCTAssertEqual([NSValue valueWithMGLTextTranslationAnchor:MGLTextTranslationAnchorMap].MGLTextTranslationAnchorValue, MGLTextTranslationAnchorMap);

--- a/platform/darwin/test/MGLSymbolStyleLayerTests.mm
+++ b/platform/darwin/test/MGLSymbolStyleLayerTests.mm
@@ -2078,19 +2078,19 @@
     {
         XCTAssertTrue(rawLayer->getTextWritingMode().isUndefined(),
                       @"text-writing-mode should be unset initially.");
-        NSExpression *defaultExpression = layer.textWritingMode;
+        NSExpression *defaultExpression = layer.textWritingModes;
 
         NSExpression *constantExpression = [NSExpression expressionWithFormat:@"{'horizontal','vertical'}"];
-        layer.textWritingMode = constantExpression;
+        layer.textWritingModes = constantExpression;
         mbgl::style::PropertyValue<std::vector<mbgl::style::TextWritingModeType>> propertyValue = { { mbgl::style::TextWritingModeType::Horizontal, mbgl::style::TextWritingModeType::Vertical } };
         XCTAssertEqual(rawLayer->getTextWritingMode(), propertyValue,
-                       @"Setting textWritingMode to a constant value expression should update text-writing-mode.");
-        XCTAssertEqualObjects(layer.textWritingMode, constantExpression,
-                              @"textWritingMode should round-trip constant value expressions.");
+                       @"Setting textWritingModes to a constant value expression should update text-writing-mode.");
+        XCTAssertEqualObjects(layer.textWritingModes, constantExpression,
+                              @"textWritingModes should round-trip constant value expressions.");
 
         constantExpression = [NSExpression expressionWithFormat:@"{'horizontal','vertical'}"];
         NSExpression *functionExpression = [NSExpression expressionWithFormat:@"mgl_step:from:stops:($zoomLevel, %@, %@)", constantExpression, @{@18: constantExpression}];
-        layer.textWritingMode = functionExpression;
+        layer.textWritingModes = functionExpression;
 
         {
             using namespace mbgl::style::expression::dsl;
@@ -2100,22 +2100,22 @@
         }
 
         XCTAssertEqual(rawLayer->getTextWritingMode(), propertyValue,
-                       @"Setting textWritingMode to a camera expression should update text-writing-mode.");
-        XCTAssertEqualObjects(layer.textWritingMode, functionExpression,
-                              @"textWritingMode should round-trip camera expressions.");
+                       @"Setting textWritingModes to a camera expression should update text-writing-mode.");
+        XCTAssertEqualObjects(layer.textWritingModes, functionExpression,
+                              @"textWritingModes should round-trip camera expressions.");
 
 
-        layer.textWritingMode = nil;
+        layer.textWritingModes = nil;
         XCTAssertTrue(rawLayer->getTextWritingMode().isUndefined(),
-                      @"Unsetting textWritingMode should return text-writing-mode to the default value.");
-        XCTAssertEqualObjects(layer.textWritingMode, defaultExpression,
-                              @"textWritingMode should return the default value after being unset.");
+                      @"Unsetting textWritingModes should return text-writing-mode to the default value.");
+        XCTAssertEqualObjects(layer.textWritingModes, defaultExpression,
+                              @"textWritingModes should return the default value after being unset.");
 
         functionExpression = [NSExpression expressionForKeyPath:@"bogus"];
-        XCTAssertThrowsSpecificNamed(layer.textWritingMode = functionExpression, NSException, NSInvalidArgumentException, @"MGLSymbolLayer should raise an exception if a camera-data expression is applied to a property that does not support key paths to feature attributes.");
+        XCTAssertThrowsSpecificNamed(layer.textWritingModes = functionExpression, NSException, NSInvalidArgumentException, @"MGLSymbolLayer should raise an exception if a camera-data expression is applied to a property that does not support key paths to feature attributes.");
         functionExpression = [NSExpression expressionWithFormat:@"mgl_step:from:stops:(bogus, %@, %@)", constantExpression, @{@18: constantExpression}];
         functionExpression = [NSExpression expressionWithFormat:@"mgl_interpolate:withCurveType:parameters:stops:($zoomLevel, 'linear', nil, %@)", @{@10: functionExpression}];
-        XCTAssertThrowsSpecificNamed(layer.textWritingMode = functionExpression, NSException, NSInvalidArgumentException, @"MGLSymbolLayer should raise an exception if a camera-data expression is applied to a property that does not support key paths to feature attributes.");
+        XCTAssertThrowsSpecificNamed(layer.textWritingModes = functionExpression, NSException, NSInvalidArgumentException, @"MGLSymbolLayer should raise an exception if a camera-data expression is applied to a property that does not support key paths to feature attributes.");
     }
 
     // icon-color
@@ -3128,7 +3128,7 @@
     [self testPropertyName:@"text-rotation-alignment" isBoolean:NO];
     [self testPropertyName:@"text-transform" isBoolean:NO];
     [self testPropertyName:@"text-variable-anchor" isBoolean:NO];
-    [self testPropertyName:@"text-writing-mode" isBoolean:NO];
+    [self testPropertyName:@"text-writing-modes" isBoolean:NO];
     [self testPropertyName:@"icon-color" isBoolean:NO];
     [self testPropertyName:@"icon-halo-blur" isBoolean:NO];
     [self testPropertyName:@"icon-halo-color" isBoolean:NO];
@@ -3193,8 +3193,8 @@
     XCTAssertEqual([NSValue valueWithMGLTextTransform:MGLTextTransformNone].MGLTextTransformValue, MGLTextTransformNone);
     XCTAssertEqual([NSValue valueWithMGLTextTransform:MGLTextTransformUppercase].MGLTextTransformValue, MGLTextTransformUppercase);
     XCTAssertEqual([NSValue valueWithMGLTextTransform:MGLTextTransformLowercase].MGLTextTransformValue, MGLTextTransformLowercase);
-    XCTAssertEqual([NSValue valueWithMGLTextWritingMode:MGLTextWritingModeHorizontal].MGLTextWritingModeValue, MGLTextWritingModeHorizontal);
-    XCTAssertEqual([NSValue valueWithMGLTextWritingMode:MGLTextWritingModeVertical].MGLTextWritingModeValue, MGLTextWritingModeVertical);
+    XCTAssertEqual([NSValue valueWithMGLTextWritingModes:MGLTextWritingModesHorizontal].MGLTextWritingModesValue, MGLTextWritingModesHorizontal);
+    XCTAssertEqual([NSValue valueWithMGLTextWritingModes:MGLTextWritingModesVertical].MGLTextWritingModesValue, MGLTextWritingModesVertical);
     XCTAssertEqual([NSValue valueWithMGLIconTranslationAnchor:MGLIconTranslationAnchorMap].MGLIconTranslationAnchorValue, MGLIconTranslationAnchorMap);
     XCTAssertEqual([NSValue valueWithMGLIconTranslationAnchor:MGLIconTranslationAnchorViewport].MGLIconTranslationAnchorValue, MGLIconTranslationAnchorViewport);
     XCTAssertEqual([NSValue valueWithMGLTextTranslationAnchor:MGLTextTranslationAnchorMap].MGLTextTranslationAnchorValue, MGLTextTranslationAnchorMap);

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## master
+
+### Styles and rendering
+
+* Introduce `text-writing-mode` layout property for symbol layer ([#14932](https://github.com/mapbox/mapbox-gl-native/pull/14932)). The `text-writing-mode` layout property allows control over symbol's preferred writing mode. The new property value is an array, whose values are enumeration values from a ( `horizontal` | `vertical` ) set.
+
 ## 5.3.0
 
 ### Styles and rendering

--- a/platform/ios/docs/guides/For Style Authors.md
+++ b/platform/ios/docs/guides/For Style Authors.md
@@ -270,6 +270,7 @@ In style JSON | In Objective-C | In Swift
 `text-justify` | `MGLSymbolStyleLayer.textJustification` | `MGLSymbolStyleLayer.textJustification`
 `text-optional` | `MGLSymbolStyleLayer.textOptional` | `MGLSymbolStyleLayer.isTextOptional`
 `text-rotate` | `MGLSymbolStyleLayer.textRotation` | `MGLSymbolStyleLayer.textRotation`
+`text-writing-mode` | `MGLSymbolStyleLayer.textWritingModes` | `MGLSymbolStyleLayer.textWritingModes`
 `icon-translate` | `MGLSymbolStyleLayer.iconTranslation` | `MGLSymbolStyleLayer.iconTranslation`
 `icon-translate-anchor` | `MGLSymbolStyleLayer.iconTranslationAnchor` | `MGLSymbolStyleLayer.iconTranslationAnchor`
 `text-translate` | `MGLSymbolStyleLayer.textTranslation` | `MGLSymbolStyleLayer.textTranslation`

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 * Setting `MGLMapView.contentInset` now moves the map’s focal point to the center of the content frame after insetting. ([#14664](https://github.com/mapbox/mapbox-gl-native/pull/14664))
 * Added the `-[MGLMapViewDelegate mapView:shouldRemoveStyleImage:]` method for optimizing style image caching. ([#14769](https://github.com/mapbox/mapbox-gl-native/pull/14769))
+* Introduce `text-writing-mode` layout property for symbol layer ([#14932](https://github.com/mapbox/mapbox-gl-native/pull/14932)). The `text-writing-mode` layout property allows control over symbol's preferred writing mode. The new property value is an array, whose values are enumeration values from a ( `horizontal` | `vertical` ) set.
 
 ### Other changes
 

--- a/platform/macos/docs/guides/For Style Authors.md
+++ b/platform/macos/docs/guides/For Style Authors.md
@@ -257,6 +257,7 @@ In style JSON | In Objective-C | In Swift
 `text-justify` | `MGLSymbolStyleLayer.textJustification` | `MGLSymbolStyleLayer.textJustification`
 `text-optional` | `MGLSymbolStyleLayer.textOptional` | `MGLSymbolStyleLayer.isTextOptional`
 `text-rotate` | `MGLSymbolStyleLayer.textRotation` | `MGLSymbolStyleLayer.textRotation`
+`text-writing-mode` | `MGLSymbolStyleLayer.textWritingModes` | `MGLSymbolStyleLayer.textWritingModes`
 `icon-translate` | `MGLSymbolStyleLayer.iconTranslation` | `MGLSymbolStyleLayer.iconTranslation`
 `icon-translate-anchor` | `MGLSymbolStyleLayer.iconTranslationAnchor` | `MGLSymbolStyleLayer.iconTranslationAnchor`
 `text-translate` | `MGLSymbolStyleLayer.textTranslation` | `MGLSymbolStyleLayer.textTranslation`

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,3 +1,6 @@
+# master
+* Introduce `text-writing-mode` layout property for symbol layer ([#14932](https://github.com/mapbox/mapbox-gl-native/pull/14932)). The `text-writing-mode` layout property allows control over symbol's preferred writing mode. The new property value is an array, whose values are enumeration values from a ( `horizontal` | `vertical` ) set.
+
 # 4.2.0
 - Add an option to set whether or not an image should be treated as a SDF ([#15054](https://github.com/mapbox/mapbox-gl-native/issues/15054))
 - Fix problems associated with node 10 and NAN [#14847](https://github.com/mapbox/mapbox-gl-native/pull/14847)

--- a/src/mbgl/layout/symbol_feature.hpp
+++ b/src/mbgl/layout/symbol_feature.hpp
@@ -32,6 +32,7 @@ public:
     optional<std::string> icon;
     float sortKey = 0.0f;
     std::size_t index;
+    bool allowsVerticalWritingMode = false;
 };
 
 } // namespace mbgl

--- a/src/mbgl/layout/symbol_instance.cpp
+++ b/src/mbgl/layout/symbol_instance.cpp
@@ -81,7 +81,8 @@ SymbolInstance::SymbolInstance(Anchor& anchor_,
                                const std::size_t dataFeatureIndex_,
                                std::u16string key_,
                                const float overscaling,
-                               const float rotate,
+                               const float iconRotation,
+                               const float textRotation,
                                float radialTextOffset_,
                                bool allowVerticalPlacement) :
     sharedData(std::move(sharedData_)),
@@ -91,8 +92,8 @@ SymbolInstance::SymbolInstance(Anchor& anchor_,
     hasIcon(shapedIcon),
     // Create the collision features that will be used to check whether this symbol instance can be placed
     // As a collision approximation, we can use either the vertical or any of the horizontal versions of the feature
-    textCollisionFeature(sharedData->line, anchor, getAnyShaping(shapedTextOrientations), textBoxScale_, textPadding, textPlacement, indexedFeature, overscaling, rotate),
-    iconCollisionFeature(sharedData->line, anchor, shapedIcon, iconBoxScale, iconPadding, indexedFeature, rotate),
+    textCollisionFeature(sharedData->line, anchor, getAnyShaping(shapedTextOrientations), textBoxScale_, textPadding, textPlacement, indexedFeature, overscaling, textRotation),
+    iconCollisionFeature(sharedData->line, anchor, shapedIcon, iconBoxScale, iconPadding, indexedFeature, iconRotation),
     writingModes(WritingModeType::None),
     layoutFeatureIndex(layoutFeatureIndex_),
     dataFeatureIndex(dataFeatureIndex_),
@@ -105,7 +106,7 @@ SymbolInstance::SymbolInstance(Anchor& anchor_,
 
     if (allowVerticalPlacement && shapedTextOrientations.vertical) {
         const float verticalPointLabelAngle = 90.0f;
-        verticalTextCollisionFeature = CollisionFeature(line(), anchor, shapedTextOrientations.vertical, textBoxScale_, textPadding, textPlacement, indexedFeature, overscaling, rotate + verticalPointLabelAngle);
+        verticalTextCollisionFeature = CollisionFeature(line(), anchor, shapedTextOrientations.vertical, textBoxScale_, textPadding, textPlacement, indexedFeature, overscaling, textRotation + verticalPointLabelAngle);
     }
 
     rightJustifiedGlyphQuadsSize = sharedData->rightJustifiedGlyphQuads.size();

--- a/src/mbgl/layout/symbol_instance.hpp
+++ b/src/mbgl/layout/symbol_instance.hpp
@@ -59,7 +59,8 @@ public:
                    const std::size_t dataFeatureIndex,
                    std::u16string key,
                    const float overscaling,
-                   const float rotate,
+                   const float iconRotation,
+                   const float textRotation,
                    float radialTextOffset,
                    bool allowVerticalPlacement);
 

--- a/src/mbgl/layout/symbol_instance.hpp
+++ b/src/mbgl/layout/symbol_instance.hpp
@@ -29,7 +29,8 @@ struct SymbolInstanceSharedData {
                             const float layoutTextSize,
                             const style::SymbolPlacementType textPlacement,
                             const std::array<float, 2>& textOffset,
-                            const GlyphPositions& positions);
+                            const GlyphPositions& positions,
+                            bool allowVerticalPlacement);
     bool empty() const;
     GeometryCoordinates line;
     // Note: When singleLine == true, only `rightJustifiedGlyphQuads` is populated.
@@ -59,7 +60,8 @@ public:
                    std::u16string key,
                    const float overscaling,
                    const float rotate,
-                   float radialTextOffset);
+                   float radialTextOffset,
+                   bool allowVerticalPlacement);
 
     optional<size_t> getDefaultHorizontalPlacedTextIndex() const;
     const GeometryCoordinates& line() const;
@@ -85,6 +87,7 @@ public:
 
     CollisionFeature textCollisionFeature;
     CollisionFeature iconCollisionFeature;
+    optional<CollisionFeature> verticalTextCollisionFeature = nullopt;
     WritingModeType writingModes;
     std::size_t layoutFeatureIndex; // Index into the set of features included at layout time
     std::size_t dataFeatureIndex;   // Index into the underlying tile data feature set

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -314,7 +314,8 @@ void SymbolLayout::prepareSymbols(const GlyphMap& glyphMap, const GlyphPositions
                     /* translate */ textOffset,
                     /* writingMode */ writingMode,
                     /* bidirectional algorithm object */ bidi,
-                    /* glyphs */ glyphMap);
+                    /* glyphs */ glyphMap,
+                    allowVerticalPlacement);
 
                 return result;
             };

--- a/src/mbgl/layout/symbol_layout.hpp
+++ b/src/mbgl/layout/symbol_layout.hpp
@@ -96,6 +96,8 @@ private:
     bool sdfIcons = false;
     bool iconsNeedLinear = false;
     bool sortFeaturesByY = false;
+    bool allowVerticalPlacement = false;
+    std::vector<style::TextWritingModeType> placementModes;
 
     style::TextSize::UnevaluatedType textSize;
     style::IconSize::UnevaluatedType iconSize;

--- a/src/mbgl/layout/symbol_projection.cpp
+++ b/src/mbgl/layout/symbol_projection.cpp
@@ -319,7 +319,11 @@ namespace mbgl {
                 const float glyphOffsetX = symbol.glyphOffsets[glyphIndex];
                 // Since first and last glyph fit on the line, we're sure that the rest of the glyphs can be placed
                 auto placedGlyph = placeGlyphAlongLine(glyphOffsetX * fontScale, lineOffsetX, lineOffsetY, flip, projectedAnchorPoint, symbol.anchorPoint, symbol.segment, symbol.line, symbol.tileDistances, labelPlaneMatrix, false);
-                placedGlyphs.push_back(*placedGlyph);
+                if (placedGlyph) {
+                    placedGlyphs.push_back(*placedGlyph);
+                } else {
+                    placedGlyphs.emplace_back(Point<float>{-INFINITY, -INFINITY}, 0.0f, nullopt);
+                }
             }
             placedGlyphs.push_back(firstAndLastGlyph->second);
         } else if (symbol.glyphOffsets.size() == 1) {

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -23,7 +23,9 @@ SymbolBucket::SymbolBucket(Immutable<style::SymbolLayoutProperties::PossiblyEval
                            bool sortFeaturesByY_,
                            const std::string bucketName_,
                            const std::vector<SymbolInstance>&& symbolInstances_,
-                           float tilePixelRatio_)
+                           float tilePixelRatio_,
+                           bool allowVerticalPlacement_,
+                           std::vector<style::TextWritingModeType> placementModes_)
     : layout(std::move(layout_)),
       bucketLeaderID(std::move(bucketName_)),
       sdfIcons(sdfIcons_),
@@ -39,7 +41,9 @@ SymbolBucket::SymbolBucket(Immutable<style::SymbolLayoutProperties::PossiblyEval
       textSizeBinder(SymbolSizeBinder::create(zoom, textSize, TextSize::defaultValue())),
       iconSizeBinder(SymbolSizeBinder::create(zoom, iconSize, IconSize::defaultValue())),
       tilePixelRatio(tilePixelRatio_),
-      bucketInstanceId(++maxBucketInstanceId) {
+      bucketInstanceId(++maxBucketInstanceId),
+      allowVerticalPlacement(allowVerticalPlacement_),
+      placementModes(std::move(placementModes_)) {
 
     for (const auto& pair : paintProperties_) {
         const auto& evaluated = getEvaluated<SymbolLayerProperties>(pair.second);

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -39,6 +39,10 @@ public:
     size_t vertexStartIndex;
     // The crossTileID is only filled/used on the foreground for variable text anchors
     uint32_t crossTileID = 0u;
+    // The placedOrientation is only used when symbol layer's property is set to support
+    // placement for orientation variants.
+    optional<style::TextWritingModeType> placedOrientation;
+    float angle = 0;
 };
 
 class SymbolBucket final : public Bucket {
@@ -53,7 +57,9 @@ public:
                  bool sortFeaturesByY,
                  const std::string bucketLeaderID,
                  const std::vector<SymbolInstance>&&,
-                 const float tilePixelRatio);
+                 const float tilePixelRatio,
+                 bool allowVerticalPlacement,
+                 std::vector<style::TextWritingModeType> placementModes);
     ~SymbolBucket() override;
 
     void upload(gfx::UploadPass&) override;
@@ -149,7 +155,8 @@ public:
 
     const float tilePixelRatio;
     uint32_t bucketInstanceId;
-
+    const bool allowVerticalPlacement;
+    const std::vector<style::TextWritingModeType> placementModes;
     mutable optional<bool> hasFormatSectionOverrides_;
 
     std::shared_ptr<std::vector<size_t>> featureSortOrder;

--- a/src/mbgl/style/conversion/constant.cpp
+++ b/src/mbgl/style/conversion/constant.cpp
@@ -86,6 +86,7 @@ template optional<TextTransformType> Converter<TextTransformType>::operator()(co
 template optional<TranslateAnchorType> Converter<TranslateAnchorType>::operator()(const Convertible&, Error&) const;
 template optional<VisibilityType> Converter<VisibilityType>::operator()(const Convertible&, Error&) const;
 template optional<std::vector<TextVariableAnchorType>> Converter<std::vector<TextVariableAnchorType>>::operator()(const Convertible&, Error&) const;
+template optional<std::vector<TextWritingModeType>> Converter<std::vector<TextWritingModeType>>::operator()(const Convertible&, Error&) const;
 
 optional<Color> Converter<Color>::operator()(const Convertible& value, Error& error) const {
     optional<std::string> string = toString(value);

--- a/src/mbgl/style/conversion/function.cpp
+++ b/src/mbgl/style/conversion/function.cpp
@@ -152,6 +152,8 @@ template optional<PropertyExpression<TranslateAnchorType>>
     
 template optional<PropertyExpression<Formatted>>
     convertFunctionToExpression<Formatted>(const Convertible&, Error&, bool);
+template optional<PropertyExpression<std::vector<TextWritingModeType>>>
+    convertFunctionToExpression<std::vector<TextWritingModeType>>(const Convertible&, Error&, bool);
 
 // Ad-hoc Converters for double and int64_t. We should replace float with double wholesale,
 // and promote the int64_t Converter to general use (and it should check that the input is

--- a/src/mbgl/style/conversion/property_value.cpp
+++ b/src/mbgl/style/conversion/property_value.cpp
@@ -80,6 +80,7 @@ template optional<PropertyValue<TextJustifyType>> Converter<PropertyValue<TextJu
 template optional<PropertyValue<TextTransformType>> Converter<PropertyValue<TextTransformType>>::operator()(conversion::Convertible const&, conversion::Error&, bool, bool) const;
 template optional<PropertyValue<TranslateAnchorType>> Converter<PropertyValue<TranslateAnchorType>>::operator()(conversion::Convertible const&, conversion::Error&, bool, bool) const;
 template optional<PropertyValue<mbgl::style::expression::Formatted>> Converter<PropertyValue<mbgl::style::expression::Formatted>>::operator()(conversion::Convertible const&, conversion::Error&, bool, bool) const;
+template optional<PropertyValue<std::vector<TextWritingModeType>>> Converter<PropertyValue<std::vector<TextWritingModeType>>>::operator()(conversion::Convertible const&, conversion::Error&, bool, bool) const;
 
 } // namespace conversion
 } // namespace style

--- a/src/mbgl/style/expression/value.cpp
+++ b/src/mbgl/style/expression/value.cpp
@@ -374,6 +374,9 @@ template struct ValueConverter<HillshadeIlluminationAnchorType>;
 template type::Type valueTypeToExpressionType<LightAnchorType>();
 template struct ValueConverter<LightAnchorType>;
 
+template type::Type valueTypeToExpressionType<std::vector<TextWritingModeType>>();
+template struct ValueConverter<std::vector<TextWritingModeType>>;
+
 } // namespace expression
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/layers/symbol_layer.cpp
+++ b/src/mbgl/style/layers/symbol_layer.cpp
@@ -701,6 +701,22 @@ void SymbolLayer::setTextVariableAnchor(const PropertyValue<std::vector<TextVari
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
+PropertyValue<std::vector<TextWritingModeType>> SymbolLayer::getDefaultTextWritingMode() {
+    return TextWritingMode::defaultValue();
+}
+
+const PropertyValue<std::vector<TextWritingModeType>>& SymbolLayer::getTextWritingMode() const {
+    return impl().layout.get<TextWritingMode>();
+}
+
+void SymbolLayer::setTextWritingMode(const PropertyValue<std::vector<TextWritingModeType>>& value) {
+    if (value == getTextWritingMode())
+        return;
+    auto impl_ = mutableImpl();
+    impl_->layout.get<TextWritingMode>() = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
 
 // Paint properties
 
@@ -1387,6 +1403,7 @@ optional<Error> SymbolLayer::setLayoutProperty(const std::string& name, const Co
         TextSize,
         TextTransform,
         TextVariableAnchor,
+        TextWritingMode,
     };
     MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
         { "icon-allow-overlap", static_cast<uint8_t>(Property::IconAllowOverlap) },
@@ -1428,7 +1445,8 @@ optional<Error> SymbolLayer::setLayoutProperty(const std::string& name, const Co
         { "text-rotation-alignment", static_cast<uint8_t>(Property::TextRotationAlignment) },
         { "text-size", static_cast<uint8_t>(Property::TextSize) },
         { "text-transform", static_cast<uint8_t>(Property::TextTransform) },
-        { "text-variable-anchor", static_cast<uint8_t>(Property::TextVariableAnchor) }
+        { "text-variable-anchor", static_cast<uint8_t>(Property::TextVariableAnchor) },
+        { "text-writing-mode", static_cast<uint8_t>(Property::TextWritingMode) }
     });
 
     const auto it = properties.find(name.c_str());
@@ -1759,6 +1777,18 @@ optional<Error> SymbolLayer::setLayoutProperty(const std::string& name, const Co
         }
         
         setTextVariableAnchor(*typedValue);
+        return nullopt;
+        
+    }
+    
+    if (property == Property::TextWritingMode) {
+        Error error;
+        optional<PropertyValue<std::vector<TextWritingModeType>>> typedValue = convert<PropertyValue<std::vector<TextWritingModeType>>>(value, error, false, false);
+        if (!typedValue) {
+            return error;
+        }
+        
+        setTextWritingMode(*typedValue);
         return nullopt;
         
     }

--- a/src/mbgl/style/layers/symbol_layer_properties.hpp
+++ b/src/mbgl/style/layers/symbol_layer_properties.hpp
@@ -214,6 +214,11 @@ struct TextVariableAnchor : LayoutProperty<std::vector<TextVariableAnchorType>> 
     static std::vector<TextVariableAnchorType> defaultValue() { return {  }; }
 };
 
+struct TextWritingMode : LayoutProperty<std::vector<TextWritingModeType>> {
+    static constexpr const char *name() { return "text-writing-mode"; }
+    static std::vector<TextWritingModeType> defaultValue() { return {  }; }
+};
+
 struct IconColor : DataDrivenPaintProperty<Color, attributes::fill_color, uniforms::fill_color> {
     static Color defaultValue() { return Color::black(); }
 };
@@ -313,7 +318,8 @@ class SymbolLayoutProperties : public Properties<
     TextRotationAlignment,
     TextSize,
     TextTransform,
-    TextVariableAnchor
+    TextVariableAnchor,
+    TextWritingMode
 > {};
 
 class SymbolPaintProperties : public Properties<

--- a/src/mbgl/style/types.cpp
+++ b/src/mbgl/style/types.cpp
@@ -96,6 +96,11 @@ MBGL_DEFINE_ENUM(TextTransformType, {
     { TextTransformType::Lowercase, "lowercase" },
 });
 
+MBGL_DEFINE_ENUM(TextWritingModeType, {
+    { TextWritingModeType::Horizontal, "horizontal" },
+    { TextWritingModeType::Vertical, "vertical" }
+});
+
 MBGL_DEFINE_ENUM(AlignmentType, {
     { AlignmentType::Map, "map" },
     { AlignmentType::Viewport, "viewport" },

--- a/src/mbgl/text/glyph.hpp
+++ b/src/mbgl/text/glyph.hpp
@@ -89,6 +89,8 @@ class Shaping {
     WritingModeType writingMode;
     std::size_t lineCount = 0u;
     explicit operator bool() const { return !positionedGlyphs.empty(); }
+    // The y offset *should* be part of the font metadata.
+    static constexpr int32_t yOffset = -17;
 };
 
 enum class WritingModeType : uint8_t {

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -12,6 +12,7 @@ namespace mbgl {
 
 class SymbolBucket;
 class SymbolInstance;
+enum class PlacedSymbolOrientation : bool;
 
 class OpacityState {
 public:
@@ -122,7 +123,8 @@ private:
     // Returns `true` if bucket vertices were updated; returns `false` otherwise.
     bool updateBucketDynamicVertices(SymbolBucket&, const TransformState&, const RenderTile& tile) const;
     void updateBucketOpacities(SymbolBucket&, const TransformState&, std::set<uint32_t>&);
-    void markUsedJustification(SymbolBucket&, style::TextVariableAnchorType, SymbolInstance&);
+    void markUsedJustification(SymbolBucket&, style::TextVariableAnchorType, SymbolInstance&, style::TextWritingModeType orientation);
+    void markUsedOrientation(SymbolBucket&, style::TextWritingModeType, SymbolInstance&);
 
     CollisionIndex collisionIndex;
 
@@ -135,6 +137,7 @@ private:
     std::unordered_map<uint32_t, JointPlacement> placements;
     std::unordered_map<uint32_t, JointOpacityState> opacities;
     std::unordered_map<uint32_t, VariableOffset> variableOffsets;
+    std::unordered_map<uint32_t, style::TextWritingModeType> placedOrientations;
 
     bool stale = false;
     

--- a/src/mbgl/text/quads.cpp
+++ b/src/mbgl/text/quads.cpp
@@ -160,7 +160,11 @@ SymbolQuads getGlyphQuads(const Shaping& shapedText,
 
             const Point<float> center{ -halfAdvance, halfAdvance - Shaping::yOffset };
             const float verticalRotation = -M_PI_2;
-            const Point<float> xOffsetCorrection{ 5.0f - Shaping::yOffset, 0.0f };
+
+            // xHalfWidhtOffsetcorrection is a difference between full-width and half-width
+            // advance, should be 0 for full-width glyphs and will pull up half-width glyphs.
+            const float xHalfWidhtOffsetcorrection = util::ONE_EM / 2 - halfAdvance;
+            const Point<float> xOffsetCorrection{ 5.0f - Shaping::yOffset - xHalfWidhtOffsetcorrection, 0.0f };
             
             tl = util::rotate(tl - center, verticalRotation) + center + xOffsetCorrection + verticalizedLabelOffset;
             tr = util::rotate(tr - center, verticalRotation) + center + xOffsetCorrection + verticalizedLabelOffset;

--- a/src/mbgl/text/quads.hpp
+++ b/src/mbgl/text/quads.hpp
@@ -52,6 +52,7 @@ SymbolQuads getGlyphQuads(const Shaping& shapedText,
                           const std::array<float, 2> textOffset,
                           const style::SymbolLayoutProperties::Evaluated&,
                           style::SymbolPlacementType placement,
-                          const GlyphPositions& positions);
+                          const GlyphPositions& positions,
+                          bool allowVerticalPlacement);
 
 } // namespace mbgl

--- a/src/mbgl/text/shaping.cpp
+++ b/src/mbgl/text/shaping.cpp
@@ -292,12 +292,8 @@ void shapeLines(Shaping& shaping,
                 const style::TextJustifyType textJustify,
                 const WritingModeType writingMode,
                 const GlyphMap& glyphMap) {
-    
-    // the y offset *should* be part of the font metadata
-    const int32_t yOffset = -17;
-    
     float x = 0;
-    float y = yOffset;
+    float y = Shaping::yOffset;
     
     float maxLineLength = 0;
 
@@ -342,7 +338,7 @@ void shapeLines(Shaping& shaping,
                 shaping.positionedGlyphs.emplace_back(codePoint, x, y + baselineOffset, false, section.fontStackHash, section.scale, sectionIndex);
                 x += glyph.metrics.advance * section.scale + spacing;
             } else {
-                shaping.positionedGlyphs.emplace_back(codePoint, x, baselineOffset, true, section.fontStackHash, section.scale, sectionIndex);
+                shaping.positionedGlyphs.emplace_back(codePoint, x, y + baselineOffset, true, section.fontStackHash, section.scale, sectionIndex);
                 x += util::ONE_EM * section.scale + spacing;
             }
         }
@@ -364,7 +360,7 @@ void shapeLines(Shaping& shaping,
 
     align(shaping, justify, anchorAlign.horizontalAlign, anchorAlign.verticalAlign, maxLineLength,
           lineHeight, lines.size());
-    const float height = y - yOffset;
+    const float height = y - Shaping::yOffset;
 
     // Calculate the bounding box
     shaping.top += -anchorAlign.verticalAlign * height;

--- a/src/mbgl/text/shaping.cpp
+++ b/src/mbgl/text/shaping.cpp
@@ -238,9 +238,8 @@ std::set<std::size_t> leastBadBreaks(const PotentialBreak& lastLineBreak) {
 std::set<std::size_t> determineLineBreaks(const TaggedString& logicalInput,
                                           const float spacing,
                                           float maxWidth,
-                                          const WritingModeType writingMode,
                                           const GlyphMap& glyphMap) {
-    if (!maxWidth || writingMode != WritingModeType::Horizontal) {
+    if (!maxWidth) {
         return {};
     }
     
@@ -382,13 +381,13 @@ const Shaping getShaping(const TaggedString& formattedString,
     std::vector<TaggedString> reorderedLines;
     if (formattedString.sectionCount() == 1) {
         auto untaggedLines = bidi.processText(formattedString.rawText(),
-                                              determineLineBreaks(formattedString, spacing, maxWidth, writingMode, glyphs));
+                                              determineLineBreaks(formattedString, spacing, maxWidth, glyphs));
         for (const auto& line : untaggedLines) {
             reorderedLines.emplace_back(line, formattedString.sectionAt(0));
         }
     } else {
         auto processedLines = bidi.processStyledText(formattedString.getStyledText(),
-                                                     determineLineBreaks(formattedString, spacing, maxWidth, writingMode, glyphs));
+                                                     determineLineBreaks(formattedString, spacing, maxWidth, glyphs));
         for (const auto& line : processedLines) {
             reorderedLines.emplace_back(line, formattedString.getSections());
         }

--- a/src/mbgl/text/shaping.hpp
+++ b/src/mbgl/text/shaping.hpp
@@ -69,6 +69,7 @@ const Shaping getShaping(const TaggedString& string,
                          const Point<float>& translate,
                          const WritingModeType,
                          BiDi& bidi,
-                         const GlyphMap& glyphs);
+                         const GlyphMap& glyphs,
+                         bool allowVerticalPlacement);
 
 } // namespace mbgl

--- a/src/mbgl/text/tagged_string.cpp
+++ b/src/mbgl/text/tagged_string.cpp
@@ -8,6 +8,7 @@ void TaggedString::addSection(const std::u16string& sectionText, double scale, F
     styledText.first += sectionText;
     sections.emplace_back(scale, fontStack, std::move(textColor));
     styledText.second.resize(styledText.first.size(), sections.size() - 1);
+    supportsVerticalWritingMode = nullopt;
 }
 
 void TaggedString::trim() {
@@ -35,6 +36,13 @@ double TaggedString::getMaxScale() const {
 void TaggedString::verticalizePunctuation() {
     // Relies on verticalization changing characters in place so that style indices don't need updating
     styledText.first = util::i18n::verticalizePunctuation(styledText.first);
+}
+
+bool TaggedString::allowsVerticalWritingMode() {
+    if (!supportsVerticalWritingMode) {
+        supportsVerticalWritingMode = util::i18n::allowsVerticalWritingMode(rawText());
+    }
+    return *supportsVerticalWritingMode;
 }
 
 } // namespace mbgl

--- a/src/mbgl/text/tagged_string.hpp
+++ b/src/mbgl/text/tagged_string.hpp
@@ -98,10 +98,12 @@ struct TaggedString {
     void trim();
     
     void verticalizePunctuation();
+    bool allowsVerticalWritingMode();
 
 private:
     StyledText styledText;
     std::vector<SectionOptions> sections;
+    optional<bool> supportsVerticalWritingMode;
 };
 
 } // namespace mbgl

--- a/src/mbgl/util/i18n.cpp
+++ b/src/mbgl/util/i18n.cpp
@@ -643,6 +643,14 @@ bool isStringInSupportedScript(const std::string& input) {
     return true;
 }
 
+bool isCharInComplexShapingScript(char16_t chr) {
+    return isInArabic(chr) ||
+           isInArabicSupplement(chr) ||
+           isInArabicExtendedA(chr) ||
+           isInArabicPresentationFormsA(chr) ||
+           isInArabicPresentationFormsB(chr);
+}
+
 bool isWhitespace(char16_t chr) {
     return chr == u' ' || chr == u'\t' || chr == u'\n' || chr == u'\v' || chr == u'\f' || chr == u'\r';
 }

--- a/src/mbgl/util/i18n.cpp
+++ b/src/mbgl/util/i18n.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <map>
+#include <mapbox/eternal.hpp>
 
 namespace {
 
@@ -320,7 +321,7 @@ DEFINE_IS_IN_UNICODE_BLOCK(HalfwidthandFullwidthForms, 0xFF00, 0xFFEF)
 // DEFINE_IS_IN_UNICODE_BLOCK(SupplementaryPrivateUseAreaA, 0xF0000, 0xFFFFF)
 // DEFINE_IS_IN_UNICODE_BLOCK(SupplementaryPrivateUseAreaB, 0x100000, 0x10FFFF)
 
-const std::map<char16_t, char16_t> verticalPunctuation = {
+MAPBOX_ETERNAL_CONSTEXPR const auto verticalPunctuation = mapbox::eternal::map<char16_t, char16_t>({
     { u'!', u'︕' },  { u'#', u'＃' },  { u'$', u'＄' },  { u'%', u'％' },  { u'&', u'＆' },
     { u'(', u'︵' },  { u')', u'︶' },  { u'*', u'＊' },  { u'+', u'＋' },  { u',', u'︐' },
     { u'-', u'︲' },  { u'.', u'・' },  { u'/', u'／' },  { u':', u'︓' },  { u';', u'︔' },
@@ -338,7 +339,8 @@ const std::map<char16_t, char16_t> verticalPunctuation = {
     { u'＞', u'﹀' }, { u'？', u'︖' }, { u'［', u'﹇' }, { u'］', u'﹈' }, { u'＿', u'︳' },
     { u'｛', u'︷' }, { u'｜', u'―' },  { u'｝', u'︸' }, { u'｟', u'︵' }, { u'｠', u'︶' },
     { u'｡', u'︒' },  { u'｢', u'﹁' },  { u'｣', u'﹂' },
-};
+});
+
 } // namespace
 
 namespace mbgl {

--- a/src/mbgl/util/i18n.hpp
+++ b/src/mbgl/util/i18n.hpp
@@ -75,6 +75,8 @@ char16_t verticalizePunctuation(char16_t chr);
     
 bool isStringInSupportedScript(const std::string& input);
 
+bool isCharInComplexShapingScript(char16_t chr);
+
 bool isWhitespace(char16_t chr);
 
 } // namespace i18n

--- a/test/gl/bucket.test.cpp
+++ b/test/gl/bucket.test.cpp
@@ -122,7 +122,7 @@ TEST(Buckets, SymbolBucket) {
     std::vector<SymbolInstance> symbolInstances;
 
     gl::Context context{ backend };
-    SymbolBucket bucket { std::move(layout), {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(symbolInstances), 1.0f };
+    SymbolBucket bucket { std::move(layout), {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(symbolInstances), 1.0f, false, {}};
     ASSERT_FALSE(bucket.hasIconData());
     ASSERT_FALSE(bucket.hasTextData());
     ASSERT_FALSE(bucket.hasCollisionBoxData());

--- a/test/text/cross_tile_symbol_index.test.cpp
+++ b/test/text/cross_tile_symbol_index.test.cpp
@@ -17,8 +17,8 @@ SymbolInstance makeSymbolInstance(float x, float y, std::u16string key) {
 
     auto sharedData = std::make_shared<SymbolInstanceSharedData>(std::move(line),
                                         shaping, nullopt, layout_, 0.0f, placementType,
-                                        textOffset, positions);
-    return SymbolInstance(anchor, std::move(sharedData), shaping, nullopt, 0, 0, placementType, textOffset, 0, 0, iconOffset, subfeature, 0, 0, key, 0, 0, 0.0f);
+                                        textOffset, positions, false);
+    return SymbolInstance(anchor, std::move(sharedData), shaping, nullopt, 0, 0, placementType, textOffset, 0, 0, iconOffset, subfeature, 0, 0, key, 0.0f, 0.0f, 0.0f, 0.0f, false);
 }
 
 
@@ -39,7 +39,7 @@ TEST(CrossTileSymbolLayerIndex, addBucket) {
     std::vector<SymbolInstance> mainInstances;
     mainInstances.push_back(makeSymbolInstance(1000, 1000, u"Detroit"));
     mainInstances.push_back(makeSymbolInstance(2000, 2000, u"Toronto"));
-    SymbolBucket mainBucket { layout, {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(mainInstances), 1.0f };
+    SymbolBucket mainBucket { layout, {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(mainInstances), 1.0f, false, {} };
     mainBucket.bucketInstanceId = ++maxBucketInstanceId;
     index.addBucket(mainID, mainBucket, maxCrossTileID);
 
@@ -54,7 +54,7 @@ TEST(CrossTileSymbolLayerIndex, addBucket) {
     childInstances.push_back(makeSymbolInstance(2000, 2000, u"Windsor"));
     childInstances.push_back(makeSymbolInstance(3000, 3000, u"Toronto"));
     childInstances.push_back(makeSymbolInstance(4001, 4001, u"Toronto"));
-    SymbolBucket childBucket { layout, {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(childInstances), 1.0f };
+    SymbolBucket childBucket { layout, {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(childInstances), 1.0f, false, {} };
     childBucket.bucketInstanceId = ++maxBucketInstanceId;
     index.addBucket(childID, childBucket, maxCrossTileID);
 
@@ -70,7 +70,7 @@ TEST(CrossTileSymbolLayerIndex, addBucket) {
     OverscaledTileID parentID(5, 0, 5, 4, 4);
     std::vector<SymbolInstance> parentInstances;
     parentInstances.push_back(makeSymbolInstance(500, 500, u"Detroit"));
-    SymbolBucket parentBucket { layout, {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(parentInstances), 1.0f };
+    SymbolBucket parentBucket { layout, {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(parentInstances), 1.0f, false, {} };
     parentBucket.bucketInstanceId = ++maxBucketInstanceId;
     index.addBucket(parentID, parentBucket, maxCrossTileID);
 
@@ -86,7 +86,7 @@ TEST(CrossTileSymbolLayerIndex, addBucket) {
     std::vector<SymbolInstance> grandchildInstances;
     grandchildInstances.push_back(makeSymbolInstance(4000, 4000, u"Detroit"));
     grandchildInstances.push_back(makeSymbolInstance(4000, 4000, u"Windsor"));
-    SymbolBucket grandchildBucket { layout, {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(grandchildInstances), 1.0f };
+    SymbolBucket grandchildBucket { layout, {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(grandchildInstances), 1.0f, false, {} };
     grandchildBucket.bucketInstanceId = ++maxBucketInstanceId;
     index.addBucket(grandchildID, grandchildBucket, maxCrossTileID);
 
@@ -113,13 +113,13 @@ TEST(CrossTileSymbolLayerIndex, resetIDs) {
     OverscaledTileID mainID(6, 0, 6, 8, 8);
     std::vector<SymbolInstance> mainInstances;
     mainInstances.push_back(makeSymbolInstance(1000, 1000, u"Detroit"));
-    SymbolBucket mainBucket { layout, {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(mainInstances), 1.0f };
+    SymbolBucket mainBucket { layout, {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(mainInstances), 1.0f, false, {} };
     mainBucket.bucketInstanceId = ++maxBucketInstanceId;
 
     OverscaledTileID childID(7, 0, 7, 16, 16);
     std::vector<SymbolInstance> childInstances;
     childInstances.push_back(makeSymbolInstance(2000, 2000, u"Detroit"));
-    SymbolBucket childBucket { layout, {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(childInstances), 1.0f };
+    SymbolBucket childBucket { layout, {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(childInstances), 1.0f, false, {} };
     childBucket.bucketInstanceId = ++maxBucketInstanceId;
 
     // assigns a new id
@@ -155,7 +155,7 @@ TEST(CrossTileSymbolLayerIndex, noDuplicatesWithinZoomLevel) {
     std::vector<SymbolInstance> mainInstances;
     mainInstances.push_back(makeSymbolInstance(1000, 1000, u"")); // A
     mainInstances.push_back(makeSymbolInstance(1000, 1000, u"")); // B
-    SymbolBucket mainBucket { layout, {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(mainInstances), 1.0f };
+    SymbolBucket mainBucket { layout, {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(mainInstances), 1.0f, false, {} };
     mainBucket.bucketInstanceId = ++maxBucketInstanceId;
 
     OverscaledTileID childID(7, 0, 7, 16, 16);
@@ -163,7 +163,7 @@ TEST(CrossTileSymbolLayerIndex, noDuplicatesWithinZoomLevel) {
     childInstances.push_back(makeSymbolInstance(2000, 2000, u"")); // A'
     childInstances.push_back(makeSymbolInstance(2000, 2000, u"")); // B'
     childInstances.push_back(makeSymbolInstance(2000, 2000, u"")); // C'
-    SymbolBucket childBucket { layout, {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(childInstances), 1.0f };
+    SymbolBucket childBucket { layout, {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(childInstances), 1.0f, false, {} };
     childBucket.bucketInstanceId = ++maxBucketInstanceId;
 
     // assigns new ids
@@ -194,14 +194,14 @@ TEST(CrossTileSymbolLayerIndex, bucketReplacement) {
     std::vector<SymbolInstance> firstInstances;
     firstInstances.push_back(makeSymbolInstance(1000, 1000, u"")); // A
     firstInstances.push_back(makeSymbolInstance(1000, 1000, u"")); // B
-    SymbolBucket firstBucket { layout, {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(firstInstances), 1.0f };
+    SymbolBucket firstBucket { layout, {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(firstInstances), 1.0f, false, {} };
     firstBucket.bucketInstanceId = ++maxBucketInstanceId;
 
     std::vector<SymbolInstance> secondInstances;
     secondInstances.push_back(makeSymbolInstance(1000, 1000, u"")); // A'
     secondInstances.push_back(makeSymbolInstance(1000, 1000, u"")); // B'
     secondInstances.push_back(makeSymbolInstance(1000, 1000, u"")); // C'
-    SymbolBucket secondBucket { layout, {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(secondInstances), 1.0f };
+    SymbolBucket secondBucket { layout, {}, 16.0f, 1.0f, 0, sdfIcons, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(secondInstances), 1.0f, false, {} };
     secondBucket.bucketInstanceId = ++maxBucketInstanceId;
 
     // assigns new ids

--- a/test/text/shaping.test.cpp
+++ b/test/text/shaping.test.cpp
@@ -36,7 +36,8 @@ TEST(Shaping, ZWSP) {
                           {0.0f, 0.0f}, // translate
                           WritingModeType::Horizontal,
                           bidi,
-                          glyphs);
+                          glyphs,
+                          /*allowVerticalPlacement*/ false);
     };
 
     // 3 lines


### PR DESCRIPTION
## Brief description

For languages that support vertical writing mode, map designers might want point labels to be rendered vertically. This PR adds implementation for `text-writing-mode` layout property that controls preferred writing mode. New property value is an array, whose values are enumeration values from a `( horizontal | vertical )` set.

The new property do not enforce orientation of a rendered label and acts merely as a hint, so that:
- label consisting of Latin script characters would be still rendered horizontally, even if `"text-writing-mode" : ["vertical"]` is specified
- same is applicable for vertical languages, e.g., Mongolian and Manchu, `"text-writing-mode" : ["horizontal"]` would not affect vertical rendering of a label.

## To be done

- [x] Add render tests ([branch](https://github.com/mapbox/mapbox-gl-js/tree/alexshalamov_wip_vertical_labels))
- [x] Select property name
- [x] GL-JS v8 spec documentation ([branch](https://github.com/mapbox/mapbox-gl-js/tree/alexshalamov_wip_vertical_labels))
- [x] Upstream [alexshalamov_fix_diff_imports](https://github.com/mapbox/mapbox-gl-js/compare/alexshalamov_fix_diff_imports?expand=1)
- [x] ~~Upstream GL-JS branch ([alexshalamov_wip_vertical_labels](https://github.com/mapbox/mapbox-gl-js/tree/alexshalamov_wip_vertical_labels)) and pin gl-native upstream gl-gs~~
- [ ] Reduce binary size for the feature (If needed @alexshalamov can follow-up in separate PR)
- [x] GL-JS port (@vakila is working on it)
- [x] ~~Implement support for `vertical-latin-upright` writing mode~~
- [x] ~~Implement support for `vertical-latin-sideways` writing mode~~
- [x] Add changelog to SDKs

## Future work
- [ ] Experiment with transitions for variable placement / label orientation switch
- [ ] Vertical-only rendering for Mongolian / Manchu
- [ ] De-duplicate `text-variable-anchor` and `text-writing-mode` array properties, so that layers can be efficiently grouped by layout id.