### PR TITLE
[ios, build] Add more specific iOS simulator flags for make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,24 +213,59 @@ IOS_XCODEBUILD_SIM = xcodebuild \
 	ARCHS=x86_64 ONLY_ACTIVE_ARCH=YES \
 	-derivedDataPath $(IOS_OUTPUT_PATH) \
 	-configuration $(BUILDTYPE) -sdk iphonesimulator \
-	-destination 'platform=iOS Simulator,OS=latest,name=iPhone 8' \
 	-workspace $(IOS_WORK_PATH) \
 	-jobs $(JOBS)
 
 ifneq ($(MORE_SIMULATORS),)
-	IOS_XCODEBUILD_SIM += -parallel-testing-enabled YES \
+	IOS_LATEST = true
+	IOS_11 = true
+	IOS_10 = true
+	IOS_9 = true
+endif
+
+ifdef IOS_LATEST
+	IOS_XCODEBUILD_SIM += \
+	-destination 'platform=iOS Simulator,OS=latest,name=iPhone 8' \
 	-destination 'platform=iOS Simulator,OS=latest,name=iPhone Xs Max' \
 	-destination 'platform=iOS Simulator,OS=latest,name=iPhone Xr' \
-	-destination 'platform=iOS Simulator,OS=latest,name=iPad Pro (11-inch)' \
+	-destination 'platform=iOS Simulator,OS=latest,name=iPad Pro (11-inch)'
+endif
+
+ifdef IOS_11
+	IOS_XCODEBUILD_SIM += \
 	-destination 'platform=iOS Simulator,OS=11.4,name=iPhone 7' \
 	-destination 'platform=iOS Simulator,OS=11.4,name=iPhone X' \
-	-destination 'platform=iOS Simulator,OS=11.4,name=iPad Air 2,' \
+	-destination 'platform=iOS Simulator,OS=11.4,name=iPad (5th generation)'
+endif
+
+ifdef IOS_10
+	IOS_XCODEBUILD_SIM += \
 	-destination 'platform=iOS Simulator,OS=10.3.1,name=iPhone SE' \
 	-destination 'platform=iOS Simulator,OS=10.3.1,name=iPhone 7 Plus' \
-	-destination 'platform=iOS Simulator,OS=10.3.1,name=iPad Air' \
+	-destination 'platform=iOS Simulator,OS=10.3.1,name=iPad Pro (9.7-inch)'
+endif
+
+ifdef IOS_9
+	IOS_XCODEBUILD_SIM += \
 	-destination 'platform=iOS Simulator,OS=9.3,name=iPhone 6s Plus' \
 	-destination 'platform=iOS Simulator,OS=9.3,name=iPhone 6s' \
-	-destination 'platform=iOS Simulator,OS=9.3,name=iPad 2'
+	-destination 'platform=iOS Simulator,OS=9.3,name=iPad Air 2'
+endif
+
+# If IOS_XCODEBUILD_SIM does not contain a simulator destination, add the default.
+ifeq (, $(findstring destination, $(IOS_XCODEBUILD_SIM)))
+	IOS_XCODEBUILD_SIM += \
+	-destination 'platform=iOS Simulator,OS=latest,name=iPhone 8'
+else
+	IOS_XCODEBUILD_SIM += -parallel-testing-enabled YES
+endif
+
+ifneq ($(ONLY_TESTING),)
+	IOS_XCODEBUILD_SIM += -only-testing:$(ONLY_TESTING)
+endif
+
+ifneq ($(SKIP_TESTING),)
+	IOS_XCODEBUILD_SIM += -skip-testing:$(SKIP_TESTING)
 endif
 
 ifneq ($(CI),)

--- a/platform/ios/DEVELOPING.md
+++ b/platform/ios/DEVELOPING.md
@@ -153,7 +153,11 @@ You can provide an optional and custom [`xcconfig`](https://help.apple.com/xcode
 * `make ios-sanitize-address` runs unit tests from the "CI" scheme with the Address Sanitizer enabled.
 * `make ios-static-analyzer` runs unit tests from the "CI" scheme with the Static Analyzer enabled.
 
-These commands are run by default on a single Simulator. To enable legacy iOS versions and more device types, add `MORE_SIMULATORS=1`.
+These commands are run by default on a single Simulator. To enable legacy iOS versions and more device types, add `MORE_SIMULATORS=YES`. Use `IOS_LATEST=YES`, `IOS_11=YES`, etc. to test on specific iOS versions.
+
+To only run a specific test or class of tests, add `ONLY_TESTING=test/MGLNameOfTestClass/testNameOfTest`.
+
+To skip a specific test or class of tests, add `SKIP_TESTING=test/MGLNameOfTestClass/testNameOfTest`.
 
 To run the cross-platform tests in Xcode instead of on the command line:
 


### PR DESCRIPTION
Follow-up to #14903, adding the ability to specify specific iOS version(s) and skip/exclusively run specific tests.

### Example

To run the static analyzer on iOS 12 and 11, but only running `MGLOfflineStorageTests` tests:

```
make ios-static-analyzer IOS_LATEST=YES IOS_11=YES ONLY_TESTING=test/MGLOfflineStorageTests
```

/cc @mapbox/maps-ios 