### PR TITLE
[ios] Simplify -[MGLOfflineStorageTests testAddFileContent]

### DIFF
--- a/platform/darwin/test/MGLOfflineStorageTests.mm
+++ b/platform/darwin/test/MGLOfflineStorageTests.mm
@@ -293,7 +293,7 @@
 
         NSError *error;
         NSDictionary *fileAttributes = [fileManager attributesOfItemAtPath:resourceURL.path error:&error];
-        XCTAssertNil(error, @"Getting the file's permissions:%@ should not return an error.", resourceURL.path);
+        XCTAssertNil(error, @"Getting the file's attributes should not return an error. (%@)", resourceURL.path);
 
         NSNumber *fileSizeNumber = [fileAttributes objectForKey:NSFileSize];
         long long fileSize = [fileSizeNumber longLongValue];
@@ -339,8 +339,8 @@
         [self waitForExpectationsWithTimeout:10 handler:nil];
     }];
 
-    // File non-existent
-    [XCTContext runActivityNamed:@"File non-existent" block:^(id<XCTActivity> activity) {
+    // File does not exist
+    [XCTContext runActivityNamed:@"File does not exist" block:^(id<XCTActivity> activity) {
         NSURL *resourceURL = [NSURL URLWithString:@"nonexistent.db"];
 
         MGLOfflineStorage *os = [MGLOfflineStorage sharedOfflineStorage];


### PR DESCRIPTION
Fixes #14928, where `-[MGLOfflineStorageTests testAddFileContent]` failed when run in parallel on multiple simulators.

That issue appears to have been caused by directly moving fixtures around from the build folder to inside the user’s simulator folders, which caused exceptions when multiple simulators expected a stable directory/file structure.

Since our fixtures are copied into the test bundle already, manually moving and setting permissions on them should be unnecessary. These tests have shown past instability (#12999, https://github.com/mapbox/mapbox-gl-native/pull/12911#issuecomment-422600110, #12913), but I’m hoping we can rely on a more conventional way of supplying test fixtures.

(These tests were originally added in #12791.)

## `XCTContext` and `XCTActivity`

I also wrapped subsections of `testAddFileContent` in `XCTContext`, which you can read more about in [Apple’s docs](https://developer.apple.com/documentation/xctest/activities_and_attachments/grouping_tests_into_substeps_with_activities?language=objc). This gives us a nicer breakdown in the test overview:

![Screen Shot 2019-06-17 at 5 00 53 PM](https://user-images.githubusercontent.com/1198851/59644437-bfd70980-9121-11e9-807c-b49c6e2266a2.png)


/cc @fabian-guerra @julianrex 