### PR TITLE
[ios, macos] Deprecate methods in favor of new completion handler versions

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -12,6 +12,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
   * `-[MGLMapView setTargetCoordinate:animated:completionHandler:]`
   * `-[MGLMapView showAnnotations:edgePadding:animated:completionHandler:]`
   * `-[MGLMapView selectAnnotation:animated:completionHandler:]`
+* Deprecated variants of the above methods without completion handlers. ([#14959](https://github.com/mapbox/mapbox-gl-native/pull/14959))
 
 ## 5.1.0 - June 19, 2019
 

--- a/platform/ios/Integration Tests/Annotation Tests/MGLAnnotationViewIntegrationTests.m
+++ b/platform/ios/Integration Tests/Annotation Tests/MGLAnnotationViewIntegrationTests.m
@@ -480,12 +480,12 @@ static const CGPoint kAnnotationRelativeScale = { 0.05f, 0.125f };
     MGLTestLocationManager *locationManager = [[MGLTestLocationManager alloc] init];
     self.mapView.locationManager = locationManager;
 
-    [self.mapView setUserTrackingMode:MGLUserTrackingModeFollow animated:NO];
+    [self.mapView setUserTrackingMode:MGLUserTrackingModeFollow animated:NO completionHandler:nil];
     CGRect originalFrame = [self.mapView viewForAnnotation:self.mapView.userLocation].frame;
     
     // Temporarily disable location tracking so we can save the value of
     // the originalFrame in memory
-    [self.mapView setUserTrackingMode:MGLUserTrackingModeNone animated:NO];
+    [self.mapView setUserTrackingMode:MGLUserTrackingModeNone animated:NO completionHandler:nil];
     
     CGPoint offset = CGPointMake(20, 20);
     
@@ -493,7 +493,7 @@ static const CGPoint kAnnotationRelativeScale = { 0.05f, 0.125f };
         return offset;;
     };
     
-    [self.mapView setUserTrackingMode:MGLUserTrackingModeFollow animated:NO];
+    [self.mapView setUserTrackingMode:MGLUserTrackingModeFollow animated:NO completionHandler:nil];
     CGRect offsetFrame = [self.mapView viewForAnnotation:self.mapView.userLocation].frame;
     
     XCTAssertEqual(originalFrame.origin.x + offset.x, offsetFrame.origin.x);

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -751,14 +751,14 @@ CLLocationCoordinate2D randomWorldCoordinate() {
                                                                                      heading:0];
                         __weak typeof(self) weakSelf = self;
                         [self.mapView setCamera:camera withDuration:0.3 animationTimingFunction:nil completionHandler:^{
-                            [weakSelf.mapView setContentInset:contentInsets animated:YES];
+                            [weakSelf.mapView setContentInset:contentInsets animated:YES completionHandler:nil];
                         }];
                     } else {
                         [self.view sendSubviewToBack:self.contentInsetsOverlays[0]];
                         [self.view sendSubviewToBack:self.contentInsetsOverlays[1]];
                         [self.view sendSubviewToBack:self.contentInsetsOverlays[2]];
                         [self.view sendSubviewToBack:self.contentInsetsOverlays[3]];
-                        [self.mapView setContentInset:_originalContentInsets animated:YES];
+                        [self.mapView setContentInset:_originalContentInsets animated:YES completionHandler:nil];
                     }
                     break;
                 }
@@ -1686,7 +1686,7 @@ CLLocationCoordinate2D randomWorldCoordinate() {
 - (void)selectAnOffscreenPointAnnotation {
     id<MGLAnnotation> annotation = [self randomOffscreenPointAnnotation];
     if (annotation) {
-        [self.mapView selectAnnotation:annotation animated:YES];
+        [self.mapView selectAnnotation:annotation animated:YES completionHandler:nil];
 
         NSAssert(self.mapView.selectedAnnotations.firstObject, @"The annotation was not selected");
     }
@@ -1946,7 +1946,7 @@ CLLocationCoordinate2D randomWorldCoordinate() {
         // positioning rect)
 
         [self.mapView addAnnotation:pin];
-        [self.mapView selectAnnotation:pin animated:YES];
+        [self.mapView selectAnnotation:pin animated:YES completionHandler:nil];
     }
 }
 

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -503,7 +503,7 @@ MGL_EXPORT
 @property (nonatomic, assign) MGLUserTrackingMode userTrackingMode;
 
 /**
- Sets the mode used to track the user location, with an optional transition.
+ Deprecated. Sets the mode used to track the user location, with an optional transition.
  
  To specify a completion handler to execute after the animation finishes, use
  the `-setUserTrackingMode:animated:completionHandler:` method.
@@ -515,7 +515,7 @@ MGL_EXPORT
     affects the initial transition; subsequent changes to the user location or
     heading are always animated.
  */
-- (void)setUserTrackingMode:(MGLUserTrackingMode)mode animated:(BOOL)animated;
+- (void)setUserTrackingMode:(MGLUserTrackingMode)mode animated:(BOOL)animated __attribute__((deprecated("Use `-setUserTrackingMode:animated:completionHandler:` instead.")));
 
 /**
  Sets the mode used to track the user location, with an optional transition and
@@ -609,8 +609,8 @@ MGL_EXPORT
 @property (nonatomic, assign) CLLocationCoordinate2D targetCoordinate;
 
 /**
- Sets the geographic coordinate that is the subject of observation as the user
- location is being tracked, with an optional transition animation.
+ Deprecated. Sets the geographic coordinate that is the subject of observation as
+ the user location is being tracked, with an optional transition animation.
 
  By default, the target coordinate is set to an invalid coordinate, indicating
  that there is no target. In course tracking mode, the target forms one of two
@@ -629,7 +629,7 @@ MGL_EXPORT
  @param animated If `YES`, the map animates to fit the target within the map
     view. If `NO`, the map fits the target instantaneously.
  */
-- (void)setTargetCoordinate:(CLLocationCoordinate2D)targetCoordinate animated:(BOOL)animated;
+- (void)setTargetCoordinate:(CLLocationCoordinate2D)targetCoordinate animated:(BOOL)animated __attribute__((deprecated("Use `-setTargetCoordinate:animated:completionHandler:` instead.")));
 
 /**
  Sets the geographic coordinate that is the subject of observation as the user
@@ -934,8 +934,8 @@ MGL_EXPORT
 - (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds animated:(BOOL)animated;
 
 /**
- Changes the receiver’s viewport to fit the given coordinate bounds with some
- additional padding on each side.
+ Deprecated. Changes the receiver’s viewport to fit the given coordinate bounds with
+ some additional padding on each side.
 
  To bring both sides of the antimeridian or international date line into view,
  specify some longitudes less than −180 degrees or greater than 180 degrees. For
@@ -951,7 +951,7 @@ MGL_EXPORT
  @param animated Specify `YES` to animate the change by smoothly scrolling and
     zooming or `NO` to immediately display the given bounds.
  */
-- (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds edgePadding:(UIEdgeInsets)insets animated:(BOOL)animated;
+- (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds edgePadding:(UIEdgeInsets)insets animated:(BOOL)animated __attribute__((deprecated("Use `-setVisibleCoordinateBounds:edgePadding:animated:completionHandler:` instead.")));
 
 /**
  Changes the receiver’s viewport to fit the given coordinate bounds with some
@@ -1028,8 +1028,8 @@ MGL_EXPORT
 - (void)showAnnotations:(NSArray<id <MGLAnnotation>> *)annotations animated:(BOOL)animated;
 
 /**
- Sets the visible region so that the map displays the specified annotations with
- the specified amount of padding on each side.
+ Deprecated. Sets the visible region so that the map displays the specified
+ annotations with the specified amount of padding on each side.
 
  Calling this method updates the value in the `visibleCoordinateBounds` property
  and potentially other properties to reflect the new map region.
@@ -1043,7 +1043,7 @@ MGL_EXPORT
  @param animated `YES` if you want the map region change to be animated, or `NO`
     if you want the map to display the new region immediately without animations.
  */
-- (void)showAnnotations:(NSArray<id <MGLAnnotation>> *)annotations edgePadding:(UIEdgeInsets)insets animated:(BOOL)animated;
+- (void)showAnnotations:(NSArray<id <MGLAnnotation>> *)annotations edgePadding:(UIEdgeInsets)insets animated:(BOOL)animated __attribute__((deprecated("Use `-showAnnotations:edgePadding:animated:completionHandler:` instead.")));
 
 /**
  Sets the visible region so that the map displays the specified annotations with
@@ -1316,8 +1316,8 @@ MGL_EXPORT
 @property (nonatomic, assign) UIEdgeInsets contentInset;
 
 /**
- Sets the distance from the edges of the map view’s frame to the edges of the
- map view’s logical viewport with an optional transition animation.
+ Deprecated. Sets the distance from the edges of the map view’s frame to the edges
+ of the map view’s logical viewport with an optional transition animation.
 
  When the value of this property is equal to `UIEdgeInsetsZero`, viewport
  properties such as `centerCoordinate` assume a viewport that matches the map
@@ -1337,7 +1337,7 @@ MGL_EXPORT
     the content inset or `NO` if you want the map to inset the content
     immediately.
  */
-- (void)setContentInset:(UIEdgeInsets)contentInset animated:(BOOL)animated;
+- (void)setContentInset:(UIEdgeInsets)contentInset animated:(BOOL)animated __attribute__((deprecated("Use `-setContentInset:animated:completionHandler:` instead.")));
 
 /**
  Sets the distance from the edges of the map view’s frame to the edges of the
@@ -1443,7 +1443,7 @@ MGL_EXPORT
  */
 - (CLLocationDistance)metersPerPointAtLatitude:(CLLocationDegrees)latitude;
 
-- (CLLocationDistance)metersPerPixelAtLatitude:(CLLocationDegrees)latitude __attribute__((unavailable("Use -metersPerPointAtLatitude:.")));
+- (CLLocationDistance)metersPerPixelAtLatitude:(CLLocationDegrees)latitude __attribute__((unavailable("Use `-metersPerPointAtLatitude:`.")));
 
 #pragma mark Annotating the Map
 
@@ -1601,7 +1601,7 @@ MGL_EXPORT
 @property (nonatomic, copy) NSArray<id <MGLAnnotation>> *selectedAnnotations;
 
 /**
- Selects an annotation and displays its callout view.
+ Deprecated. Selects an annotation and displays its callout view.
 
  The `animated` parameter determines whether the selection is animated including whether the map is
  panned to bring the annotation into view, specifically:
@@ -1622,7 +1622,7 @@ MGL_EXPORT
  @note In versions prior to `4.0.0` selecting an offscreen annotation did not
  change the camera.
  */
-- (void)selectAnnotation:(id <MGLAnnotation>)annotation animated:(BOOL)animated;
+- (void)selectAnnotation:(id <MGLAnnotation>)annotation animated:(BOOL)animated __attribute__((deprecated("Use `-selectAnnotation:animated:completionHandler:` instead.")));
 
 /**
  Selects an annotation and displays its callout view with an optional completion
@@ -1941,9 +1941,9 @@ MGL_EXPORT
  */
 @property (nonatomic) MGLMapDebugMaskOptions debugMask;
 
-@property (nonatomic, getter=isDebugActive) BOOL debugActive __attribute__((unavailable("Use -debugMask and -setDebugMask:.")));
+@property (nonatomic, getter=isDebugActive) BOOL debugActive __attribute__((unavailable("Use `-debugMask` and `-setDebugMask:`.")));
 
-- (void)toggleDebug __attribute__((unavailable("Use -setDebugMask:.")));
+- (void)toggleDebug __attribute__((unavailable("Use `-setDebugMask:`.")));
 
 - (void)emptyMemoryCache __attribute__((unavailable));
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1015,8 +1015,7 @@ public:
 
 - (void)setContentInset:(UIEdgeInsets)contentInset
 {
-    MGLLogDebug(@"Setting contentInset: %@", NSStringFromUIEdgeInsets(contentInset));
-    [self setContentInset:contentInset animated:NO];
+    [self setContentInset:contentInset animated:NO completionHandler:nil];
 }
 
 - (void)setContentInset:(UIEdgeInsets)contentInset animated:(BOOL)animated
@@ -1546,7 +1545,7 @@ public:
     self.mbglMap.setGestureInProgress(false);
     if (self.userTrackingState == MGLUserTrackingStateBegan)
     {
-        [self setUserTrackingMode:MGLUserTrackingModeNone animated:NO];
+        [self setUserTrackingMode:MGLUserTrackingModeNone animated:NO completionHandler:nil];
     }
     
     [self cancelTransitions];
@@ -3327,14 +3326,12 @@ public:
 
 - (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds
 {
-    MGLLogDebug(@"Setting visibleCoordinateBounds: %@", MGLStringFromCoordinateBounds(bounds));
     [self setVisibleCoordinateBounds:bounds animated:NO];
 }
 
 - (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds animated:(BOOL)animated
 {
-    MGLLogDebug(@"Setting visibleCoordinateBounds: %@ animated: %@", MGLStringFromCoordinateBounds(bounds), MGLStringFromBOOL(animated));
-    [self setVisibleCoordinateBounds:bounds edgePadding:UIEdgeInsetsZero animated:animated];
+    [self setVisibleCoordinateBounds:bounds edgePadding:UIEdgeInsetsZero animated:animated completionHandler:nil];
 }
 
 - (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds edgePadding:(UIEdgeInsets)insets animated:(BOOL)animated
@@ -4671,7 +4668,6 @@ public:
 
 - (void)setSelectedAnnotations:(NSArray<id <MGLAnnotation>> *)selectedAnnotations
 {
-    MGLLogDebug(@"Selecting: %lu annotations", selectedAnnotations.count);
     if ( ! selectedAnnotations.count) return;
 
     id <MGLAnnotation> firstAnnotation = selectedAnnotations[0];
@@ -4680,7 +4676,7 @@ public:
 
     if ([firstAnnotation isKindOfClass:[MGLMultiPoint class]]) return;
 
-    [self selectAnnotation:firstAnnotation animated:YES];
+    [self selectAnnotation:firstAnnotation animated:YES completionHandler:nil];
 }
 
 - (void)selectAnnotation:(id <MGLAnnotation>)annotation animated:(BOOL)animated
@@ -5100,14 +5096,13 @@ public:
 
 - (void)showAnnotations:(NSArray<id <MGLAnnotation>> *)annotations animated:(BOOL)animated
 {
-    MGLLogDebug(@"Showing: %lu annotations animated: %@", annotations.count, MGLStringFromBOOL(animated));
     CGFloat maximumPadding = 100;
     CGFloat yPadding = (self.frame.size.height / 5 <= maximumPadding) ? (self.frame.size.height / 5) : maximumPadding;
     CGFloat xPadding = (self.frame.size.width / 5 <= maximumPadding) ? (self.frame.size.width / 5) : maximumPadding;
 
     UIEdgeInsets edgeInsets = UIEdgeInsetsMake(yPadding, xPadding, yPadding, xPadding);
 
-    [self showAnnotations:annotations edgePadding:edgeInsets animated:animated];
+    [self showAnnotations:annotations edgePadding:edgeInsets animated:animated completionHandler:nil];
 }
 
 - (void)showAnnotations:(NSArray<id <MGLAnnotation>> *)annotations edgePadding:(UIEdgeInsets)insets animated:(BOOL)animated
@@ -5306,7 +5301,7 @@ public:
             [self.delegate mapViewDidStopLocatingUser:self];
         }
 
-        [self setUserTrackingMode:MGLUserTrackingModeNone animated:YES];
+        [self setUserTrackingMode:MGLUserTrackingModeNone animated:YES completionHandler:nil];
 
         [self.userLocationAnnotationView removeFromSuperview];
         self.userLocationAnnotationView = nil;
@@ -5346,8 +5341,7 @@ public:
 
 - (void)setUserTrackingMode:(MGLUserTrackingMode)mode
 {
-    MGLLogDebug(@"Setting userTrackingMode: %lu", mode);
-    [self setUserTrackingMode:mode animated:YES];
+    [self setUserTrackingMode:mode animated:YES completionHandler:nil];
 }
 
 - (void)setUserTrackingMode:(MGLUserTrackingMode)mode animated:(BOOL)animated
@@ -5448,8 +5442,7 @@ public:
 
 - (void)setTargetCoordinate:(CLLocationCoordinate2D)targetCoordinate
 {
-    MGLLogDebug(@"Setting targetCoordinate: %@", MGLStringFromCLLocationCoordinate2D(targetCoordinate));
-    [self setTargetCoordinate:targetCoordinate animated:YES];
+    [self setTargetCoordinate:targetCoordinate animated:YES completionHandler:nil];
 }
 
 - (void)setTargetCoordinate:(CLLocationCoordinate2D)targetCoordinate animated:(BOOL)animated

--- a/platform/ios/test/MGLAnnotationViewTests.m
+++ b/platform/ios/test/MGLAnnotationViewTests.m
@@ -134,7 +134,7 @@ static NSString * const MGLTestAnnotationReuseIdentifer = @"MGLTestAnnotationReu
             XCTAssertNil(_mapView.selectedAnnotations.firstObject, @"There should be no selected annotation");
 
             // First selection
-            [_mapView selectAnnotation:annotation animated:NO];
+            [_mapView selectAnnotation:annotation animated:NO completionHandler:nil];
             selectionCount++;
 
             XCTAssert(_mapView.selectedAnnotations.count == 1, @"There should only be 1 selected annotation");
@@ -190,7 +190,7 @@ static NSString * const MGLTestAnnotationReuseIdentifer = @"MGLTestAnnotationReu
     XCTAssert(MGLCoordinateInCoordinateBounds(point.coordinate, coordinateBounds), @"The test point should be within the visible map view");
 
     // Select on screen annotation (DO NOT ADD FIRST).
-    [self.mapView selectAnnotation:point animated:YES];
+    [self.mapView selectAnnotation:point animated:YES completionHandler:nil];
 
     // Expect - the camera NOT to move.
     MGLCameraChangeReason reasonAfter = self.mapView.cameraChangeReasonBitmask;
@@ -235,7 +235,7 @@ static NSString * const MGLTestAnnotationReuseIdentifer = @"MGLTestAnnotationReu
     
     XCTAssert(self.mapView.selectedAnnotations.count == 0, @"There should be 0 selected annotations");
     
-    [self.mapView selectAnnotation:point animated:NO];
+    [self.mapView selectAnnotation:point animated:NO completionHandler:nil];
     
     XCTAssert(self.mapView.selectedAnnotations.count == 0, @"There should be 0 selected annotations");
 }

--- a/platform/macos/src/MGLMapView.h
+++ b/platform/macos/src/MGLMapView.h
@@ -626,8 +626,8 @@ MGL_EXPORT IB_DESIGNABLE
 @property (nonatomic, assign) NSEdgeInsets contentInsets;
 
 /**
- Sets the distance from the edges of the map view’s frame to the edges of the
- map view’s logical viewport, with an optional transition animation.
+ Deprecated. Sets the distance from the edges of the map view’s frame to the
+ edges of the map view’s logical viewport, with an optional transition animation.
 
  When the value of this property is equal to `NSEdgeInsetsZero`, viewport
  properties such as `centerCoordinate` assume a viewport that matches the map
@@ -646,7 +646,7 @@ MGL_EXPORT IB_DESIGNABLE
     the content insets or `NO` if you want the map to inset the content
     immediately.
  */
-- (void)setContentInsets:(NSEdgeInsets)contentInsets animated:(BOOL)animated;
+- (void)setContentInsets:(NSEdgeInsets)contentInsets animated:(BOOL)animated __attribute__((deprecated("Use `-setContentInsets:animated:completionHandler:` instead.")));
 
 /**
  Sets the distance from the edges of the map view’s frame to the edges of the

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -1431,8 +1431,7 @@ public:
 }
 
 - (void)setContentInsets:(NSEdgeInsets)contentInsets {
-    MGLLogDebug(@"Setting contentInset: %@", MGLStringFromNSEdgeInsets(contentInsets));
-    [self setContentInsets:contentInsets animated:NO];
+    [self setContentInsets:contentInsets animated:NO completionHandler:nil];
 }
 
 - (void)setContentInsets:(NSEdgeInsets)contentInsets animated:(BOOL)animated {


### PR DESCRIPTION
Deprecates various `MGLMapView` methods and replaces them with completion hander versions being added in #14381.

This follows our best practices for deprecation, as outlined in https://github.com/mapbox/mapbox-gl-native/pull/14560#issuecomment-493261502.

This will need changelogging and currently targets the #14381 branch — we should figure out the changelog when we merge that and retarget this PR.

/cc @1ec5 @julianrex 