### PR TITLE
[ios] Require two fingers for duration of tilt gesture

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## 5.2.0
+
+* Fixed an issue where the two-finger tilt gesture would continue after lifting one finger. ([#14969](https://github.com/mapbox/mapbox-gl-native/pull/14969))
+
 ## 5.1.0 - June 19, 2019
 
 ### Styles and rendering

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2049,8 +2049,6 @@ public:
 {
     if ( ! self.isPitchEnabled) return;
 
-    if (twoFingerDrag.numberOfTouches != 2) return;
-
     [self cancelTransitions];
 
     self.cameraChangeReasonBitmask |= MGLCameraChangeReasonGestureTilt;
@@ -2064,6 +2062,12 @@ public:
 
     if (twoFingerDrag.state == UIGestureRecognizerStateBegan || twoFingerDrag.state == UIGestureRecognizerStateChanged)
     {
+        if (twoFingerDrag.numberOfTouches != 2)
+        {
+            twoFingerDrag.state = UIGestureRecognizerStateEnded;
+            return;
+        }
+
         CGFloat gestureDistance = CGPoint([twoFingerDrag translationInView:twoFingerDrag.view]).y;
         CGFloat slowdown = 2.0;
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2049,6 +2049,8 @@ public:
 {
     if ( ! self.isPitchEnabled) return;
 
+    if (twoFingerDrag.numberOfTouches != 2) return;
+
     [self cancelTransitions];
 
     self.cameraChangeReasonBitmask |= MGLCameraChangeReasonGestureTilt;


### PR DESCRIPTION
Fixes #14886, where the tilt gesture didn’t end when a user lifted one of their two fingers.

/cc @fabian-guerra 