### PR TITLE
Limit concurrent request for Android 4.4 and below to 10

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/http/HttpRequestImpl.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/http/HttpRequestImpl.java
@@ -182,9 +182,15 @@ public class HttpRequestImpl implements HttpRequest {
   @NonNull
   private static Dispatcher getDispatcher() {
     Dispatcher dispatcher = new Dispatcher();
-    // Matches core limit set on
-    // https://github.com/mapbox/mapbox-gl-native/blob/master/platform/android/src/http_file_source.cpp#L192
-    dispatcher.setMaxRequestsPerHost(20);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      // Matches core limit set on
+      // https://github.com/mapbox/mapbox-gl-native/blob/master/platform/android/src/http_file_source.cpp#L192
+      dispatcher.setMaxRequestsPerHost(20);
+    } else {
+      // Limiting concurrent request on Android 4.4, to limit impact of SSL handshake platform library crash
+      // https://github.com/mapbox/mapbox-gl-native/issues/14910
+      dispatcher.setMaxRequestsPerHost(10);
+    }
     return dispatcher;
   }
 }


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gl-native/issues/14910, while it doesn't resolve the issue it should make the system library crash when performing an SSL handshake less frequent. 