### PR TITLE
[ios] Fix failing annotation selection integration tests

### DIFF
--- a/platform/ios/Integration Tests/MGLCameraTransitionTests.mm
+++ b/platform/ios/Integration Tests/MGLCameraTransitionTests.mm
@@ -328,7 +328,7 @@
     NSLog(@"setCenterCoordinate: %0.4fs", stop1 - stop0);
     NSLog(@"flyToCamera: %0.4fs", stop2 - stop1);
 
-    XCTAssert(delegateCallCount == 2, @"Expecting 2 regionDidChange callbacks, got %ld", delegateCallCount); // Once for the setDirection and once for the reset north
+    XCTAssert(delegateCallCount == 2, @"Expecting 2 regionDidChange callbacks, got %ld", (long)delegateCallCount); // Once for the setDirection and once for the reset north
 }
 
 #pragma mark - Pending tests


### PR DESCRIPTION
This PR fixes some annotation selection integration tests that were failing because of differences in device screen size - the sizes of the annotation vs the callout meant that some callout views would be wholly contained with the parent views, where others wouldn't (when the annotation was moved on-screen).

The tests assumed that the callout views were wider than the annotation, which wasn't the case with large screens. To minimize changes, I have reduced the width of the annotation, and tested across current simulators.

This fixes https://github.com/mapbox/mapbox-gl-native/issues/13744 and should address @friedbunny's comment here: https://github.com/mapbox/mapbox-gl-native/pull/14381#pullrequestreview-248474183
 