### PR TITLE
Reset location layer animators when render mode changes

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinator.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinator.java
@@ -347,6 +347,34 @@ final class LocationAnimatorCoordinator {
     createNewFloatAnimator(ANIMATOR_CAMERA_COMPASS_BEARING, previousCameraBearing, normalizedCameraBearing);
   }
 
+  void resetAllLayerAnimations() {
+    MapboxLatLngAnimator latLngAnimator = (MapboxLatLngAnimator) animatorArray.get(ANIMATOR_LAYER_LATLNG);
+    MapboxFloatAnimator gpsBearingAnimator = (MapboxFloatAnimator) animatorArray.get(ANIMATOR_LAYER_GPS_BEARING);
+    MapboxFloatAnimator compassBearingAnimator =
+      (MapboxFloatAnimator) animatorArray.get(ANIMATOR_LAYER_COMPASS_BEARING);
+
+    if (latLngAnimator != null && gpsBearingAnimator != null) {
+      LatLng currentLatLng = (LatLng) latLngAnimator.getAnimatedValue();
+      LatLng currentLatLngTarget = latLngAnimator.getTarget();
+      createNewLatLngAnimator(ANIMATOR_LAYER_LATLNG, currentLatLng, currentLatLngTarget);
+
+      float currentGpsBearing = (float) gpsBearingAnimator.getAnimatedValue();
+      float currentGpsBearingTarget = gpsBearingAnimator.getTarget();
+      createNewFloatAnimator(ANIMATOR_LAYER_GPS_BEARING, currentGpsBearing, currentGpsBearingTarget);
+
+      playAnimators(getAnimationDuration(), ANIMATOR_LAYER_LATLNG, ANIMATOR_LAYER_GPS_BEARING);
+    }
+
+    if (compassBearingAnimator != null) {
+      float currentLayerBearing = getPreviousLayerCompassBearing();
+      float currentLayerBearingTarget = compassBearingAnimator.getTarget();
+      createNewFloatAnimator(ANIMATOR_LAYER_COMPASS_BEARING, currentLayerBearing, currentLayerBearingTarget);
+      playAnimators(
+        compassAnimationEnabled ? COMPASS_UPDATE_RATE_MS : 0,
+        ANIMATOR_LAYER_COMPASS_BEARING);
+    }
+  }
+
   void cancelZoomAnimation() {
     cancelAnimator(ANIMATOR_ZOOM);
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
@@ -1393,6 +1393,9 @@ public final class LocationComponent {
     animationsValueChangeListeners.addAll(locationLayerController.getAnimationListeners());
     animationsValueChangeListeners.addAll(locationCameraController.getAnimationListeners());
     locationAnimatorCoordinator.updateAnimatorListenerHolders(animationsValueChangeListeners);
+    locationAnimatorCoordinator.resetAllCameraAnimations(mapboxMap.getCameraPosition(),
+      locationCameraController.getCameraMode() == CameraMode.TRACKING_GPS_NORTH);
+    locationAnimatorCoordinator.resetAllLayerAnimations();
   }
 
   @NonNull
@@ -1517,7 +1520,8 @@ public final class LocationComponent {
   }
 
   @NonNull
-  private OnCameraTrackingChangedListener cameraTrackingChangedListener = new OnCameraTrackingChangedListener() {
+  @VisibleForTesting
+  OnCameraTrackingChangedListener cameraTrackingChangedListener = new OnCameraTrackingChangedListener() {
     @Override
     public void onCameraTrackingDismissed() {
       for (OnCameraTrackingChangedListener listener : onCameraTrackingChangedListeners) {
@@ -1530,8 +1534,6 @@ public final class LocationComponent {
       locationAnimatorCoordinator.cancelZoomAnimation();
       locationAnimatorCoordinator.cancelTiltAnimation();
       updateAnimatorListenerHolders();
-      locationAnimatorCoordinator.resetAllCameraAnimations(mapboxMap.getCameraPosition(),
-        locationCameraController.getCameraMode() == CameraMode.TRACKING_GPS_NORTH);
       for (OnCameraTrackingChangedListener listener : onCameraTrackingChangedListeners) {
         listener.onCameraTrackingChanged(currentMode);
       }
@@ -1539,7 +1541,8 @@ public final class LocationComponent {
   };
 
   @NonNull
-  private OnRenderModeChangedListener renderModeChangedListener = new OnRenderModeChangedListener() {
+  @VisibleForTesting
+  OnRenderModeChangedListener renderModeChangedListener = new OnRenderModeChangedListener() {
     @Override
     public void onRenderModeChanged(int currentMode) {
       updateAnimatorListenerHolders();

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinatorTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinatorTest.kt
@@ -403,6 +403,12 @@ class LocationAnimatorCoordinatorTest {
   }
 
   @Test
+  fun resetAllLayerAnimations_empty() {
+    locationAnimatorCoordinator.resetAllLayerAnimations()
+    assertTrue(locationAnimatorCoordinator.animatorArray.size() == 0)
+  }
+
+  @Test
   fun addNewListener() {
     val listener = Mockito.mock(AnimationsValueChangeListener::class.java)
     val holder = AnimatorListenerHolder(RenderMode.NORMAL, listener)

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
@@ -15,7 +15,6 @@ import com.mapbox.mapboxsdk.location.modes.RenderMode
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.Style
 import com.mapbox.mapboxsdk.maps.Transform
-import io.mockk.mockk
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -88,7 +87,7 @@ class LocationComponentTest {
 
   @Test
   fun activateWithRequestTest() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
 
     Assert.assertEquals(locationEngineRequest, locationComponent.locationEngineRequest)
 
@@ -102,27 +101,27 @@ class LocationComponentTest {
       .getDimension(R.dimen.mapbox_locationComponentTrackingMultiFingerMoveThreshold)
     doReturn(0f).`when`(resources)
       .getDimension(R.dimen.mapbox_locationComponentTrackingMultiFingerMoveThreshold)
-    locationComponent.activateLocationComponent(context, mockk(), true, locationEngineRequest)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), true, locationEngineRequest)
     Assert.assertEquals(locationEngineRequest, locationComponent.locationEngineRequest)
   }
 
   @Test
   fun activateWithDefaultLocationEngineRequestAndOptionsTestDefaultLocationEngine() {
-    locationComponent.activateLocationComponent(context, mockk(), true, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), true, locationEngineRequest, locationComponentOptions)
     Assert.assertEquals(locationEngineRequest, locationComponent.locationEngineRequest)
     Assert.assertNotNull(locationComponent.locationEngine)
   }
 
   @Test
   fun activateWithDefaultLocationEngineRequestAndOptionsTestCustomLocationEngine() {
-    locationComponent.activateLocationComponent(context, mockk(), false, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), false, locationEngineRequest, locationComponentOptions)
     Assert.assertEquals(locationEngineRequest, locationComponent.locationEngineRequest)
     Assert.assertNull(locationComponent.locationEngine)
   }
 
   @Test
   fun locationUpdatesWhenEnabledDisableTest() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     verify(locationEngine, times(0)).removeLocationUpdates(currentListener)
     verify(locationEngine, times(0)).requestLocationUpdates(eq(locationEngineRequest), eq(currentListener), any(Looper::class.java))
 
@@ -140,7 +139,7 @@ class LocationComponentTest {
 
   @Test
   fun locationUpdatesWhenStartedStoppedTest() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.onStart()
     locationComponent.isLocationComponentEnabled = true
 
@@ -153,7 +152,7 @@ class LocationComponentTest {
 
   @Test
   fun locationUpdatesWhenNewRequestTest() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.onStart()
     locationComponent.isLocationComponentEnabled = true
 
@@ -165,7 +164,7 @@ class LocationComponentTest {
 
   @Test
   fun lastLocationUpdateOnStartTest() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.onStart()
     locationComponent.isLocationComponentEnabled = true
 
@@ -174,7 +173,7 @@ class LocationComponentTest {
 
   @Test
   fun transitionCallbackFinishedTest() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.onStart()
     locationComponent.isLocationComponentEnabled = true
     `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
@@ -192,7 +191,7 @@ class LocationComponentTest {
 
   @Test
   fun transitionCallbackCanceledTest() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.onStart()
     locationComponent.isLocationComponentEnabled = true
     `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
@@ -210,7 +209,7 @@ class LocationComponentTest {
 
   @Test
   fun transitionCustomFinishedTest() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.onStart()
     locationComponent.isLocationComponentEnabled = true
     `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
@@ -228,7 +227,7 @@ class LocationComponentTest {
 
   @Test
   fun compass_listenWhenConsumedByNoneCamera() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.onStart()
     locationComponent.isLocationComponentEnabled = true
     `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
@@ -240,7 +239,7 @@ class LocationComponentTest {
 
   @Test
   fun compass_listenWhenConsumedByTrackingCamera() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.onStart()
     locationComponent.isLocationComponentEnabled = true
     `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
@@ -252,7 +251,7 @@ class LocationComponentTest {
 
   @Test
   fun compass_listenWhenConsumedByLayer() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.onStart()
     locationComponent.isLocationComponentEnabled = true
     `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
@@ -264,7 +263,7 @@ class LocationComponentTest {
 
   @Test
   fun compass_notListenWhenNotConsumed() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.onStart()
     locationComponent.isLocationComponentEnabled = true
     `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
@@ -283,7 +282,7 @@ class LocationComponentTest {
 
   @Test
   fun compass_removeListenerOnChange() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.onStart()
     locationComponent.isLocationComponentEnabled = true
     `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
@@ -297,7 +296,7 @@ class LocationComponentTest {
 
   @Test
   fun compass_removeListenerOnStop() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.onStart()
     locationComponent.isLocationComponentEnabled = true
     `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
@@ -310,7 +309,7 @@ class LocationComponentTest {
 
   @Test
   fun compass_reAddListenerOnStart() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.onStart()
     locationComponent.isLocationComponentEnabled = true
     `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
@@ -324,7 +323,7 @@ class LocationComponentTest {
 
   @Test
   fun compass_removeListenerOnStyleStartLoad() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.onStart()
     locationComponent.isLocationComponentEnabled = true
     `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
@@ -337,7 +336,7 @@ class LocationComponentTest {
 
   @Test
   fun compass_reAddListenerOnStyleLoadFinished() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.onStart()
     locationComponent.isLocationComponentEnabled = true
     `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
@@ -351,7 +350,7 @@ class LocationComponentTest {
 
   @Test
   fun compass_reAddListenerOnlyWhenEnabled() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.onStart()
     locationComponent.isLocationComponentEnabled = true
     `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
@@ -367,7 +366,7 @@ class LocationComponentTest {
 
   @Test
   fun compass_notAdListenerWhenDisabled() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.onStart()
     `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
 
@@ -378,7 +377,7 @@ class LocationComponentTest {
 
   @Test
   fun compass_notAdListenerWhenStopped() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.isLocationComponentEnabled = true
     `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
 
@@ -389,7 +388,7 @@ class LocationComponentTest {
 
   @Test
   fun developerAnimationCalled() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.isLocationComponentEnabled = true
     for (listener in developerAnimationListeners) {
       listener.onDeveloperAnimationStarted()
@@ -399,7 +398,7 @@ class LocationComponentTest {
 
   @Test
   fun internal_cameraTrackingChangedListener_onCameraTrackingDismissed() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.isLocationComponentEnabled = true
 
     val cameraChangeListener: OnCameraTrackingChangedListener = mock(OnCameraTrackingChangedListener::class.java)
@@ -412,7 +411,7 @@ class LocationComponentTest {
 
   @Test
   fun internal_cameraTrackingChangedListener_onCameraTrackingChanged() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.isLocationComponentEnabled = true
 
     val cameraValueListener: AnimatorListenerHolder = mock(AnimatorListenerHolder::class.java)
@@ -434,7 +433,7 @@ class LocationComponentTest {
 
   @Test
   fun internal_renderModeChangedListener_onRenderModeChanged() {
-    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
     locationComponent.isLocationComponentEnabled = true
 
     val cameraListener: AnimatorListenerHolder = mock(AnimatorListenerHolder::class.java)

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
@@ -396,4 +396,59 @@ class LocationComponentTest {
     }
     verify(locationCameraController).setCameraMode(eq(CameraMode.NONE), isNull<Location>(), eq(TRANSITION_ANIMATION_DURATION_MS), isNull<Double>(), isNull<Double>(), isNull<Double>(), any())
   }
+
+  @Test
+  fun internal_cameraTrackingChangedListener_onCameraTrackingDismissed() {
+    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.isLocationComponentEnabled = true
+
+    val cameraChangeListener: OnCameraTrackingChangedListener = mock(OnCameraTrackingChangedListener::class.java)
+    locationComponent.addOnCameraTrackingChangedListener(cameraChangeListener)
+
+    locationComponent.cameraTrackingChangedListener.onCameraTrackingDismissed()
+
+    verify(cameraChangeListener).onCameraTrackingDismissed()
+  }
+
+  @Test
+  fun internal_cameraTrackingChangedListener_onCameraTrackingChanged() {
+    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.isLocationComponentEnabled = true
+
+    val cameraValueListener: AnimatorListenerHolder = mock(AnimatorListenerHolder::class.java)
+    val layerValueListener: AnimatorListenerHolder = mock(AnimatorListenerHolder::class.java)
+    `when`(locationCameraController.animationListeners).thenReturn(setOf(cameraValueListener))
+    `when`(locationLayerController.animationListeners).thenReturn(setOf(layerValueListener))
+    val cameraChangeListener: OnCameraTrackingChangedListener = mock(OnCameraTrackingChangedListener::class.java)
+    locationComponent.addOnCameraTrackingChangedListener(cameraChangeListener)
+
+    locationComponent.cameraTrackingChangedListener.onCameraTrackingChanged(CameraMode.TRACKING_GPS)
+
+    verify(locationAnimatorCoordinator).cancelZoomAnimation()
+    verify(locationAnimatorCoordinator).cancelTiltAnimation()
+    verify(locationAnimatorCoordinator).updateAnimatorListenerHolders(eq(setOf(cameraValueListener, layerValueListener)))
+    verify(locationAnimatorCoordinator).resetAllCameraAnimations(any(), anyBoolean())
+    verify(locationAnimatorCoordinator).resetAllLayerAnimations()
+    verify(cameraChangeListener).onCameraTrackingChanged(CameraMode.TRACKING_GPS)
+  }
+
+  @Test
+  fun internal_renderModeChangedListener_onRenderModeChanged() {
+    locationComponent.activateLocationComponent(context, mockk(), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.isLocationComponentEnabled = true
+
+    val cameraListener: AnimatorListenerHolder = mock(AnimatorListenerHolder::class.java)
+    val layerListener: AnimatorListenerHolder = mock(AnimatorListenerHolder::class.java)
+    `when`(locationCameraController.animationListeners).thenReturn(setOf(cameraListener))
+    `when`(locationLayerController.animationListeners).thenReturn(setOf(layerListener))
+    val renderChangeListener: OnRenderModeChangedListener = mock(OnRenderModeChangedListener::class.java)
+    locationComponent.addOnRenderModeChangedListener(renderChangeListener)
+
+    locationComponent.renderModeChangedListener.onRenderModeChanged(RenderMode.NORMAL)
+
+    verify(locationAnimatorCoordinator).updateAnimatorListenerHolders(eq(setOf(cameraListener, layerListener)))
+    verify(locationAnimatorCoordinator).resetAllCameraAnimations(any(), anyBoolean())
+    verify(locationAnimatorCoordinator).resetAllLayerAnimations()
+    verify(renderChangeListener).onRenderModeChanged(RenderMode.NORMAL)
+  }
 }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/14938.

Wrong icon rotation was persisting after switching from `GPS` to `NORMAL`/`COMPASS` render mode because the `GPS` mode animator was still running after the mode has been switched and was overwriting the updated rotation.