### PR TITLE
Change Firebase test lab device to Nexus 7

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,8 +15,8 @@ workflows:
       - android-arm-template:
           name: android-gnustl-arm-v7
           stl: gnustl_shared
-          firebase_device_id: "htc_m8"
-          firebase_device_os: "19"
+          firebase_device_id: "flo"
+          firebase_device_os: "21"
           image: android-ndk-r17c:1d5db0eb34
           abi: arm-v7
       - android-release:


### PR DESCRIPTION
This PR changes the Firebase Test Lab device to Nexus 7 with API level 21. 
API 19 has become unreliable for CI usage, more context in and closes https://github.com/mapbox/mapbox-gl-native/issues/14910.