### PR TITLE
[node] - bump esm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "aws-sdk": "^2.285.1",
     "csscolorparser": "~1.0.2",
     "ejs": "^2.5.7",
-    "esm": "~3.0.84",
+    "esm": "^3.1.0",
     "express": "^4.11.1",
     "json-stringify-pretty-compact": "^2.0.0",
     "jsonwebtoken": "^8.3.0",


### PR DESCRIPTION
Updating esm dependency to 3.1.0 based on the following security alert:

![Screenshot from 2019-06-24 12-18-17](https://user-images.githubusercontent.com/2151639/60011705-ac282780-967a-11e9-931d-62afba25bfd1.png)

Pressing the `Create automated security fix` didn't create the expected PR for me. 
