### PR TITLE
Invalidate camera when setting a padding

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/MapboxMapInstrumentationTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/MapboxMapInstrumentationTest.kt
@@ -1,0 +1,41 @@
+package com.mapbox.mapboxsdk.maps
+
+import android.graphics.PointF
+import android.support.test.runner.AndroidJUnit4
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
+import com.mapbox.mapboxsdk.geometry.LatLng
+import com.mapbox.mapboxsdk.testapp.activity.BaseTest
+import com.mapbox.mapboxsdk.testapp.activity.espresso.DeviceIndependentTestActivity
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MapboxMapInstrumentationTest : BaseTest() {
+
+  override fun getActivityClass(): Class<*> {
+    return DeviceIndependentTestActivity::class.java
+  }
+
+  @Test
+  fun setPadding_cameraInvalidated() {
+    rule.runOnUiThread {
+      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(0.0, 0.0), 10.0))
+      val initialCameraPosition = mapboxMap.cameraPosition
+      val initialPoint = mapboxMap.projection.toScreenLocation(initialCameraPosition.target)
+
+      val bottomPadding = mapView.height / 4
+      val leftPadding = mapView.width / 4
+      mapboxMap.setPadding(leftPadding, 0, 0, bottomPadding)
+
+      val resultingCameraPosition = mapboxMap.cameraPosition
+      assertArrayEquals(intArrayOf(leftPadding, 0, 0, bottomPadding), mapboxMap.padding)
+      assertEquals(initialCameraPosition, resultingCameraPosition)
+      assertEquals(
+        PointF(initialPoint.x + leftPadding / 2, initialPoint.y - bottomPadding / 2),
+        mapboxMap.projection.toScreenLocation(resultingCameraPosition.target)
+      )
+    }
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/VisibleRegionTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/VisibleRegionTest.kt
@@ -8,8 +8,7 @@ import com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke
 
 import com.mapbox.mapboxsdk.testapp.activity.BaseTest
 import com.mapbox.mapboxsdk.testapp.activity.espresso.PixelTestActivity
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Test
 
 class VisibleRegionTest : BaseTest() {
@@ -70,7 +69,7 @@ class VisibleRegionTest : BaseTest() {
 
       val visibleRegion = mapboxMap.projection.getVisibleRegion(false)
       val filtered = latLngs.filter { visibleRegion.latLngBounds.contains(it) }
-      assertTrue(filtered.size == 1)
+      assertEquals(1, filtered.size)
       assertTrue(filtered.contains(mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)))
     }
   }
@@ -89,14 +88,18 @@ class VisibleRegionTest : BaseTest() {
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height.toFloat()),
         mapboxMap.getLatLngFromScreenCoords(0f, mapView.height.toFloat()),
         mapboxMap.getLatLngFromScreenCoords(0f, mapView.height / 2f),
-        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 4f, mapView.height / 2f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width * 3f / 4f, 0f)
       )
 
       mapboxMap.setPadding(mapView.width / 4, 0, 0, 0)
 
       val visibleRegion = mapboxMap.projection.getVisibleRegion(false)
-      val filtered = latLngs.filter { visibleRegion.latLngBounds.contains(it) }
-      assertTrue(filtered.size == 6)
+      val filtered = latLngs.filter {
+        visibleRegion.latLngBounds.contains(it)
+      }
+      assertEquals(5, filtered.size)
       assertFalse(filtered.contains(mapboxMap.getLatLngFromScreenCoords(0f, mapView.height / 2f)))
     }
   }
@@ -115,14 +118,16 @@ class VisibleRegionTest : BaseTest() {
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height.toFloat()),
         mapboxMap.getLatLngFromScreenCoords(0f, mapView.height.toFloat()),
         mapboxMap.getLatLngFromScreenCoords(0f, mapView.height / 2f),
-        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f),
+        mapboxMap.getLatLngFromScreenCoords(0f, mapView.height / 4f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height * 3f / 4f)
       )
 
       mapboxMap.setPadding(0, mapView.height / 4, 0, 0)
 
       val visibleRegion = mapboxMap.projection.getVisibleRegion(false)
       val filtered = latLngs.filter { visibleRegion.latLngBounds.contains(it) }
-      assertTrue(filtered.size == 6)
+      assertEquals(5, filtered.size)
       assertFalse(filtered.contains(mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, 0f)))
     }
   }
@@ -141,14 +146,16 @@ class VisibleRegionTest : BaseTest() {
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height.toFloat()),
         mapboxMap.getLatLngFromScreenCoords(0f, mapView.height.toFloat()),
         mapboxMap.getLatLngFromScreenCoords(0f, mapView.height / 2f),
-        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 4f, mapView.height / 2f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width * 3f / 4f, 0f)
       )
 
       mapboxMap.setPadding(0, 0, mapView.width / 4, 0)
 
       val visibleRegion = mapboxMap.projection.getVisibleRegion(false)
       val filtered = latLngs.filter { visibleRegion.latLngBounds.contains(it) }
-      assertTrue(filtered.size == 6)
+      assertEquals(5, filtered.size)
       assertFalse(filtered.contains(mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), mapView.height / 2f)))
     }
   }
@@ -167,14 +174,16 @@ class VisibleRegionTest : BaseTest() {
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height.toFloat()),
         mapboxMap.getLatLngFromScreenCoords(0f, mapView.height.toFloat()),
         mapboxMap.getLatLngFromScreenCoords(0f, mapView.height / 2f),
-        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 4f),
+        mapboxMap.getLatLngFromScreenCoords(0f, mapView.height * 3f / 4f)
       )
 
       mapboxMap.setPadding(0, 0, 0, mapView.height / 4)
 
       val visibleRegion = mapboxMap.projection.getVisibleRegion(false)
       val filtered = latLngs.filter { visibleRegion.latLngBounds.contains(it) }
-      assertTrue(filtered.size == 6)
+      assertEquals(5, filtered.size)
       assertFalse(filtered.contains(mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height.toFloat())))
     }
   }
@@ -228,7 +237,7 @@ class VisibleRegionTest : BaseTest() {
 
       val visibleRegion = mapboxMap.projection.getVisibleRegion(false)
       val filtered = latLngs.filter { visibleRegion.latLngBounds.contains(it) }
-      assertTrue(filtered.size == 1)
+      assertEquals(1, filtered.size)
       assertTrue(filtered.contains(mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)))
     }
   }
@@ -250,14 +259,17 @@ class VisibleRegionTest : BaseTest() {
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height.toFloat()),
         mapboxMap.getLatLngFromScreenCoords(0f, mapView.height.toFloat()),
         mapboxMap.getLatLngFromScreenCoords(0f, mapView.height / 2f),
-        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 4f, 0f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width * 3f / 4f, mapView.height / 2f)
+          .also { it.longitude += 360 }
       )
 
       mapboxMap.setPadding(mapView.width / 4, 0, 0, 0)
 
       val visibleRegion = mapboxMap.projection.getVisibleRegion(false)
       val filtered = latLngs.filter { visibleRegion.latLngBounds.contains(it) }
-      assertTrue(filtered.size == 6)
+      assertEquals(5, filtered.size)
       assertFalse(filtered.contains(mapboxMap.getLatLngFromScreenCoords(0f, mapView.height / 2f)))
     }
   }
@@ -267,7 +279,6 @@ class VisibleRegionTest : BaseTest() {
     validateTestSetup()
     invoke(mapboxMap) { ui: UiController, mapboxMap: MapboxMap ->
       mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(0.0, 180.0), 8.0))
-      ui.loopMainThreadForAtLeast(5000)
       val latLngs = listOf(
         mapboxMap.getLatLngFromScreenCoords(0f, 0f),
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, 0f),
@@ -280,14 +291,17 @@ class VisibleRegionTest : BaseTest() {
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height.toFloat()),
         mapboxMap.getLatLngFromScreenCoords(0f, mapView.height.toFloat()),
         mapboxMap.getLatLngFromScreenCoords(0f, mapView.height / 2f),
-        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f),
+        mapboxMap.getLatLngFromScreenCoords(0f, mapView.height / 4f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), mapView.height * 3f / 4f)
+          .also { it.longitude += 360 }
       )
 
       mapboxMap.setPadding(0, mapView.height / 4, 0, 0)
 
       val visibleRegion = mapboxMap.projection.getVisibleRegion(false)
       val filtered = latLngs.filter { visibleRegion.latLngBounds.contains(it) }
-      assertTrue(filtered.size == 6)
+      assertEquals(5, filtered.size)
       assertFalse(filtered.contains(mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, 0f)))
     }
   }
@@ -309,14 +323,17 @@ class VisibleRegionTest : BaseTest() {
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height.toFloat()),
         mapboxMap.getLatLngFromScreenCoords(0f, mapView.height.toFloat()),
         mapboxMap.getLatLngFromScreenCoords(0f, mapView.height / 2f),
-        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 4f, 0f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width * 3f / 4f, mapView.height / 2f)
+          .also { it.longitude += 360 }
       )
 
       mapboxMap.setPadding(0, 0, mapView.width / 4, 0)
 
       val visibleRegion = mapboxMap.projection.getVisibleRegion(false)
       val filtered = latLngs.filter { visibleRegion.latLngBounds.contains(it) }
-      assertTrue(filtered.size == 6)
+      assertEquals(5, filtered.size)
       assertFalse(filtered.contains(mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), mapView.height / 2f)))
     }
   }
@@ -338,14 +355,17 @@ class VisibleRegionTest : BaseTest() {
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height.toFloat()),
         mapboxMap.getLatLngFromScreenCoords(0f, mapView.height.toFloat()),
         mapboxMap.getLatLngFromScreenCoords(0f, mapView.height / 2f),
-        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f),
+        mapboxMap.getLatLngFromScreenCoords(0f, mapView.height / 4f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), mapView.height * 3f / 4f)
+          .also { it.longitude += 360 }
       )
 
       mapboxMap.setPadding(0, 0, 0, mapView.height / 4)
 
       val visibleRegion = mapboxMap.projection.getVisibleRegion(false)
       val filtered = latLngs.filter { visibleRegion.latLngBounds.contains(it) }
-      assertTrue(filtered.size == 6)
+      assertEquals(5, filtered.size)
       assertFalse(filtered.contains(mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height.toFloat())))
     }
   }
@@ -355,7 +375,7 @@ class VisibleRegionTest : BaseTest() {
     validateTestSetup()
     invoke(mapboxMap) { _: UiController, mapboxMap: MapboxMap ->
       mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(0.0, 0.0), 8.0))
-      val d = Math.min(mapboxMap.width, mapboxMap.height) / 4;
+      val d = Math.min(mapboxMap.width, mapboxMap.height) / 4
       val latLngs = listOf(
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f),
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f - d / 2f, mapView.height / 2f),

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -516,6 +516,8 @@ void NativeMapView::setVisibleCoordinateBounds(JNIEnv& env, const jni::Array<jni
 
 void NativeMapView::setContentPadding(JNIEnv&, float top, float left, float bottom, float right) {
     insets = {top, left, bottom, right};
+    // invalidate the camera position to consider the new padding
+    map->jumpTo(map->getCameraOptions(insets));
 }
 
 jni::Local<jni::Array<jni::jfloat>> NativeMapView::getContentPadding(JNIEnv& env) {


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/14985.

The issue does not originate from the `LocationComponent` directly, but from the fact that we were not invalidating the camera when the padding was set.

Before:
![ezgif com-video-to-gif (52)](https://user-images.githubusercontent.com/16925074/60017423-fd3f1800-9688-11e9-89f3-e0ccb5a8d5d9.gif)

After:
![ezgif com-video-to-gif (53)](https://user-images.githubusercontent.com/16925074/60017429-00d29f00-9689-11e9-98fb-4ed3ae751813.gif)
