### PR TITLE
[build] Upgrade "ems" package to a newer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "aws-sdk": "^2.285.1",
     "csscolorparser": "~1.0.2",
     "ejs": "^2.5.7",
-    "esm": "~3.0.84",
+    "esm": "~3.1.0",
     "express": "^4.11.1",
     "json-stringify-pretty-compact": "^2.0.0",
     "jsonwebtoken": "^8.3.0",


### PR DESCRIPTION
GitHub complains about a security venerability on this package (not shipped with GL Native).