### PR TITLE
[android] Add MicroSoft AppCenter lib.

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     androidTestImplementation dependenciesList.testEspressoIntents
     androidTestImplementation dependenciesList.testEspressoContrib
     androidTestImplementation dependenciesList.testUiAutomator
+    androidTestImplementation dependenciesList.appCenter
 }
 
 apply from: "${rootDir}/gradle/gradle-make.gradle"

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/AppCenter.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/AppCenter.kt
@@ -1,0 +1,16 @@
+package com.mapbox.mapboxsdk
+
+import com.microsoft.appcenter.espresso.Factory
+import org.junit.After
+import org.junit.Rule
+
+abstract class AppCenter {
+    @get:Rule
+    var reportHelper = Factory.getReportHelper()!!
+
+
+    @After
+    open fun afterTest() {
+        reportHelper.label(javaClass.simpleName)
+    }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/integration/BaseIntegrationTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/integration/BaseIntegrationTest.kt
@@ -5,11 +5,12 @@ import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.support.test.InstrumentationRegistry
 import android.support.test.uiautomator.*
+import com.mapbox.mapboxsdk.AppCenter
 import org.junit.Before
 
 const val TIMEOUT_UI_SEARCH_WAIT = 5000L
 
-abstract class BaseIntegrationTest {
+abstract class BaseIntegrationTest : AppCenter(){
 
   protected lateinit var device: UiDevice
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/BaseLayerTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/BaseLayerTest.kt
@@ -2,11 +2,12 @@ package com.mapbox.mapboxsdk.maps
 
 import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
+import com.mapbox.mapboxsdk.AppCenter
 import com.mapbox.mapboxsdk.style.layers.Layer
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-abstract class BaseLayerTest {
+abstract class BaseLayerTest : AppCenter(){
     private lateinit var nativeMapView: NativeMap
 
     companion object {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/MapboxTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/MapboxTest.java
@@ -2,6 +2,8 @@ package com.mapbox.mapboxsdk.maps;
 
 import android.support.test.annotation.UiThreadTest;
 import android.support.test.runner.AndroidJUnit4;
+
+import com.mapbox.mapboxsdk.AppCenter;
 import com.mapbox.mapboxsdk.Mapbox;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -11,7 +13,7 @@ import static junit.framework.Assert.assertSame;
 import static junit.framework.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
-public class MapboxTest {
+public class MapboxTest extends AppCenter {
 
   private static final String ACCESS_TOKEN = "pk.0000000001";
   private static final String ACCESS_TOKEN_2 = "pk.0000000002";

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/NativeMapViewTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/NativeMapViewTest.kt
@@ -5,6 +5,7 @@ import android.graphics.PointF
 import android.support.test.InstrumentationRegistry
 import android.support.test.annotation.UiThreadTest
 import android.support.test.runner.AndroidJUnit4
+import com.mapbox.mapboxsdk.AppCenter
 import com.mapbox.mapboxsdk.camera.CameraPosition
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.geometry.LatLngBounds
@@ -19,7 +20,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class NativeMapViewTest {
+class NativeMapViewTest : AppCenter() {
 
     private lateinit var nativeMapView: NativeMap
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/activity/BaseTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/activity/BaseTest.java
@@ -3,6 +3,8 @@ package com.mapbox.mapboxsdk.testapp.activity;
 import android.support.annotation.CallSuper;
 import android.support.annotation.UiThread;
 import android.support.test.rule.ActivityTestRule;
+
+import com.mapbox.mapboxsdk.AppCenter;
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
@@ -22,7 +24,7 @@ import static junit.framework.TestCase.assertTrue;
 /**
  * Base class for all Activity test hooking into an existing Activity that will load style.
  */
-public abstract class BaseTest {
+public abstract class BaseTest extends AppCenter {
 
   private static final int WAIT_TIMEOUT = 30; //seconds
 
@@ -46,7 +48,7 @@ public abstract class BaseTest {
   @After
   @CallSuper
   public void afterTest() {
-    // override to add logic
+    super.afterTest();
   }
 
   @UiThread

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/fragment/MapDialogFragmentTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/fragment/MapDialogFragmentTest.kt
@@ -7,6 +7,7 @@ import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.support.test.filters.LargeTest
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
+import com.mapbox.mapboxsdk.AppCenter
 import com.mapbox.mapboxsdk.testapp.R
 import com.mapbox.mapboxsdk.testapp.action.WaitAction
 import com.mapbox.mapboxsdk.testapp.activity.maplayout.MapInDialogActivity
@@ -20,7 +21,7 @@ import org.junit.runner.RunWith
  */
 @RunWith(AndroidJUnit4::class)
 @LargeTest
-class MapDialogFragmentTest {
+class MapDialogFragmentTest : AppCenter() {
 
     @get:Rule
     var activityRule: ActivityTestRule<MapInDialogActivity> = ActivityTestRule(MapInDialogActivity::class.java)

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/maps/ImageMissingTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/maps/ImageMissingTest.kt
@@ -2,6 +2,7 @@ package com.mapbox.mapboxsdk.testapp.maps
 
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
+import com.mapbox.mapboxsdk.AppCenter
 import com.mapbox.mapboxsdk.maps.MapView
 import com.mapbox.mapboxsdk.maps.Style
 import com.mapbox.mapboxsdk.testapp.R
@@ -16,7 +17,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
 @RunWith(AndroidJUnit4::class)
-class ImageMissingTest {
+class ImageMissingTest : AppCenter(){
 
   @Rule
   @JvmField

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/maps/RemoveUnusedImagesTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/maps/RemoveUnusedImagesTest.kt
@@ -3,6 +3,7 @@ package com.mapbox.mapboxsdk.testapp.maps
 import android.graphics.Bitmap
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
+import com.mapbox.mapboxsdk.AppCenter
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.maps.MapView
@@ -20,7 +21,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
 @RunWith(AndroidJUnit4::class)
-class RemoveUnusedImagesTest {
+class RemoveUnusedImagesTest : AppCenter() {
 
   @Rule
   @JvmField

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/offline/OfflineManagerTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/offline/OfflineManagerTest.kt
@@ -3,6 +3,7 @@ package com.mapbox.mapboxsdk.testapp.offline
 import android.content.Context
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
+import com.mapbox.mapboxsdk.AppCenter
 import com.mapbox.mapboxsdk.offline.OfflineManager
 import com.mapbox.mapboxsdk.offline.OfflineRegion
 import com.mapbox.mapboxsdk.storage.FileSource
@@ -18,7 +19,7 @@ import java.util.concurrent.CountDownLatch
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 @RunWith(AndroidJUnit4::class)
-class OfflineManagerTest {
+class OfflineManagerTest : AppCenter() {
 
   companion object {
     private const val TEST_DB_FILE_NAME = "offline_test.db"

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/offline/OfflineUtilsTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/offline/OfflineUtilsTest.java
@@ -1,6 +1,8 @@
 package com.mapbox.mapboxsdk.testapp.offline;
 
 import android.support.test.runner.AndroidJUnit4;
+
+import com.mapbox.mapboxsdk.AppCenter;
 import com.mapbox.mapboxsdk.testapp.utils.OfflineUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,7 +15,7 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
-public class OfflineUtilsTest {
+public class OfflineUtilsTest extends AppCenter {
 
   private static final String REGION_NAME = "hello world";
   private static final String CONVERTED_REGION_NAME = "{\"FIELD_REGION_NAME\":\"hello world\"}";

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/render/RenderTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/render/RenderTest.java
@@ -7,6 +7,8 @@ import android.support.test.espresso.IdlingResourceTimeoutException;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.rule.GrantPermissionRule;
 import android.support.test.runner.AndroidJUnit4;
+
+import com.mapbox.mapboxsdk.AppCenter;
 import com.mapbox.mapboxsdk.testapp.activity.render.RenderTestActivity;
 import com.mapbox.mapboxsdk.testapp.utils.SnapshotterIdlingResource;
 import org.junit.After;
@@ -28,7 +30,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.withId;
  * Instrumentation render tests
  */
 @RunWith(AndroidJUnit4.class)
-public class RenderTest {
+public class RenderTest extends AppCenter {
 
   private static final int RENDER_TEST_TIMEOUT = 30;
   private SnapshotterIdlingResource idlingResource;

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceMapTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceMapTest.kt
@@ -3,6 +3,7 @@ package com.mapbox.mapboxsdk.testapp.storage
 import android.support.test.annotation.UiThreadTest
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
+import com.mapbox.mapboxsdk.AppCenter
 import com.mapbox.mapboxsdk.storage.FileSource
 import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity
 import junit.framework.Assert
@@ -15,7 +16,7 @@ import org.junit.runner.RunWith
 import java.util.concurrent.CountDownLatch
 
 @RunWith(AndroidJUnit4::class)
-open class FileSourceMapTest {
+open class FileSourceMapTest : AppCenter() {
 
   private lateinit var fileSourceTestUtils: FileSourceTestUtils
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceStandaloneTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceStandaloneTest.kt
@@ -3,6 +3,7 @@ package com.mapbox.mapboxsdk.testapp.storage
 import android.support.test.annotation.UiThreadTest
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
+import com.mapbox.mapboxsdk.AppCenter
 import com.mapbox.mapboxsdk.storage.FileSource
 import com.mapbox.mapboxsdk.testapp.activity.FeatureOverviewActivity
 import org.junit.*
@@ -12,7 +13,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
-class FileSourceStandaloneTest {
+class FileSourceStandaloneTest : AppCenter() {
 
   private lateinit var fileSourceTestUtils: FileSourceTestUtils
   private lateinit var fileSource: FileSource

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceTestUtils.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceTestUtils.kt
@@ -2,12 +2,13 @@ package com.mapbox.mapboxsdk.testapp.storage
 
 import android.app.Activity
 import android.support.annotation.WorkerThread
+import com.mapbox.mapboxsdk.AppCenter
 import com.mapbox.mapboxsdk.storage.FileSource
 import junit.framework.Assert
 import java.io.File
 import java.util.concurrent.CountDownLatch
 
-class FileSourceTestUtils(private val activity: Activity) {
+class FileSourceTestUtils(private val activity: Activity) : AppCenter() {
   val originalPath = FileSource.getResourcesCachePath(activity)
   val testPath = "$originalPath/test"
   val testPath2 = "$originalPath/test2"

--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -32,7 +32,8 @@ ext {
             lint            : '26.1.4',
             gms             : '16.0.0',
             soLoader        : '0.6.0',
-            jacoco          : '0.8.3'
+            jacoco          : '0.8.3',
+            appcenter       : '1.4'
     ]
 
     dependenciesList = [
@@ -53,6 +54,7 @@ ext {
             testEspressoIntents    : "com.android.support.test.espresso:espresso-intents:${versions.espresso}",
             testEspressoContrib    : "com.android.support.test.espresso:espresso-contrib:${versions.espresso}",
             testUiAutomator        : "com.android.support.test.uiautomator:uiautomator-v18:${versions.uiAutomator}",
+            appCenter              : "com.microsoft.appcenter:espresso-test-extension:${versions.appcenter}",
             commonsIO              : 'commons-io:commons-io:2.5',
             supportAnnotations     : "com.android.support:support-annotations:${versions.supportLib}",
             supportAppcompatV7     : "com.android.support:appcompat-v7:${versions.supportLib}",


### PR DESCRIPTION
According [docs](https://docs.microsoft.com/en-us/appcenter/test-cloud/preparing-for-upload/espresso) of MicroSoft AppCenter lib, we need Import AppCenter packages and insert `ReportHelper` declaration into all test classes, so that all instrumentation test could run on AppCenter on multiple devices.

![屏幕截图 2019-06-25 13 52 09](https://user-images.githubusercontent.com/8577318/60072553-72295500-9750-11e9-8512-7e010fb858c3.png)
