### PR TITLE
Remove assert from deconstructor of run_loop.cpp

### DIFF
--- a/platform/darwin/src/run_loop.cpp
+++ b/platform/darwin/src/run_loop.cpp
@@ -25,7 +25,6 @@ RunLoop::RunLoop(Type)
 }
 
 RunLoop::~RunLoop() {
-    assert(Scheduler::GetCurrent());
     Scheduler::SetCurrent(nullptr);
 }
 


### PR DESCRIPTION
In the deconstructor of run_loop.cpp there is an assert that checks to make sure the Scheduler is null before setting it to null. In some rare scenarios where the app is being put into the background or closed the Scheduler can be null before the deconsturctor is called. This can cause an unnecessary crash. Since the goal here is to just set the Scheduler to null either way, it should not matter what the state of the Scheduler is before the function call.