### PR TITLE
[ios] Remove previously deprecated unavailable methods and properties

### DIFF
--- a/platform/darwin/src/MGLAccountManager.h
+++ b/platform/darwin/src/MGLAccountManager.h
@@ -36,8 +36,6 @@ MGL_EXPORT
  */
 @property (class, nullable) NSString *accessToken;
 
-+ (BOOL)mapboxMetricsEnabledSettingShownInApp __attribute__((unavailable("Telemetry settings are now always shown in the ℹ️ menu.")));
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLOfflineStorage.h
+++ b/platform/darwin/src/MGLOfflineStorage.h
@@ -18,8 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 
  The `object` is the `MGLOfflinePack` object whose progress changed. The
  `userInfo` dictionary contains the pack’s current state in the
- `MGLOfflinePackStateUserInfoKey` key and details about the pack’s current
- progress in the `MGLOfflinePackProgressUserInfoKey` key. You may also consult
+ `MGLOfflinePackUserInfoKeyState` key and details about the pack’s current
+ progress in the `MGLOfflinePackUserInfoKeyProgress` key. You may also consult
  the `MGLOfflinePack.state` and `MGLOfflinePack.progress` properties, which
  provide the same values.
 
@@ -43,7 +43,7 @@ FOUNDATION_EXTERN MGL_EXPORT const NSNotificationName MGLOfflinePackProgressChan
 
  The `object` is the `MGLOfflinePack` object that encountered the error. The
  `userInfo` dictionary contains the error object in the
- `MGLOfflinePackErrorUserInfoKey` key.
+ `MGLOfflinePackUserInfoKeyError` key.
  */
 FOUNDATION_EXTERN MGL_EXPORT const NSNotificationName MGLOfflinePackErrorNotification;
 
@@ -53,7 +53,7 @@ FOUNDATION_EXTERN MGL_EXPORT const NSNotificationName MGLOfflinePackErrorNotific
 
  The `object` is the `MGLOfflinePack` object that reached the tile limit in the
  course of downloading. The `userInfo` dictionary contains the tile limit in the
- `MGLOfflinePackMaximumCountUserInfoKey` key.
+ `MGLOfflinePackUserInfoKeyMaximumCount` key.
 
  Once this limit is reached, no instance of `MGLOfflinePack` can download
  additional tiles from Mapbox APIs until already downloaded tiles are removed by
@@ -75,8 +75,6 @@ typedef NSString *MGLOfflinePackUserInfoKey NS_EXTENSIBLE_STRING_ENUM;
  */
 FOUNDATION_EXTERN MGL_EXPORT const MGLOfflinePackUserInfoKey MGLOfflinePackUserInfoKeyState;
 
-FOUNDATION_EXTERN MGL_EXPORT NSString * const MGLOfflinePackStateUserInfoKey __attribute__((unavailable("Use MGLOfflinePackUserInfoKeyState")));
-
 /**
  The key for an `NSValue` object that indicates an offline pack’s current
  progress. This key is used in the `userInfo` dictionary of an
@@ -86,8 +84,6 @@ FOUNDATION_EXTERN MGL_EXPORT NSString * const MGLOfflinePackStateUserInfoKey __a
  */
 FOUNDATION_EXTERN MGL_EXPORT const MGLOfflinePackUserInfoKey MGLOfflinePackUserInfoKeyProgress;
 
-FOUNDATION_EXTERN MGL_EXPORT NSString * const MGLOfflinePackProgressUserInfoKey __attribute__((unavailable("Use MGLOfflinePackUserInfoKeyProgress")));
-
 /**
  The key for an `NSError` object that is encountered in the course of
  downloading an offline pack. This key is used in the `userInfo` dictionary of
@@ -95,8 +91,6 @@ FOUNDATION_EXTERN MGL_EXPORT NSString * const MGLOfflinePackProgressUserInfoKey 
  `MGLErrorDomain`. See `MGLErrorCode` for possible error codes.
  */
 FOUNDATION_EXTERN MGL_EXPORT const MGLOfflinePackUserInfoKey MGLOfflinePackUserInfoKeyError;
-
-FOUNDATION_EXTERN MGL_EXPORT NSString * const MGLOfflinePackErrorUserInfoKey __attribute__((unavailable("Use MGLOfflinePackUserInfoKeyError")));
 
 /**
  The key for an `NSNumber` object that indicates the maximum number of
@@ -107,8 +101,6 @@ FOUNDATION_EXTERN MGL_EXPORT NSString * const MGLOfflinePackErrorUserInfoKey __a
  limit.
  */
 FOUNDATION_EXTERN MGL_EXPORT const MGLOfflinePackUserInfoKey MGLOfflinePackUserInfoKeyMaximumCount;
-
-FOUNDATION_EXTERN MGL_EXPORT NSString * const MGLOfflinePackMaximumCountUserInfoKey __attribute__((unavailable("Use MGLOfflinePackUserInfoKeyMaximumCount")));
 
 FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLUnsupportedRegionTypeException;
 

--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -94,8 +94,6 @@ MGL_EXPORT
  */
 + (NSURL *)streetsStyleURLWithVersion:(NSInteger)version;
 
-+ (NSURL *)emeraldStyleURL __attribute__((unavailable("Create an NSURL object with the string “mapbox://styles/mapbox/emerald-v8”.")));
-
 /**
  Returns the URL to the current version of the
  <a href="https://www.mapbox.com/maps/outdoors/">Mapbox Outdoors</a> style as of
@@ -201,9 +199,6 @@ MGL_EXPORT
  */
 + (NSURL *)satelliteStyleURLWithVersion:(NSInteger)version;
 
-
-+ (NSURL *)hybridStyleURL __attribute__((unavailable("Use -satelliteStreetsStyleURL.")));
-
 /**
  Returns the URL to the current version of the
  <a href="https://www.mapbox.com/maps/satellite/">Mapbox Satellite Streets</a>
@@ -238,15 +233,6 @@ MGL_EXPORT
  @param version A specific version of the style.
  */
 + (NSURL *)satelliteStreetsStyleURLWithVersion:(NSInteger)version;
-
-
-+ (NSURL *)trafficDayStyleURL __attribute__((unavailable("Create an NSURL object with the string “mapbox://styles/mapbox/traffic-day-v2”.")));
-
-+ (NSURL *)trafficDayStyleURLWithVersion:(NSInteger)version __attribute__((unavailable("Create an NSURL object with the string “mapbox://styles/mapbox/traffic-day-v2”.")));;
-
-+ (NSURL *)trafficNightStyleURL __attribute__((unavailable("Create an NSURL object with the string “mapbox://styles/mapbox/traffic-night-v2”.")));
-
-+ (NSURL *)trafficNightStyleURLWithVersion:(NSInteger)version __attribute__((unavailable("Create an NSURL object with the string “mapbox://styles/mapbox/traffic-night-v2”.")));
 
 #pragma mark Accessing Metadata About the Style
 
@@ -473,17 +459,6 @@ MGL_EXPORT
  */
 - (void)removeLayer:(MGLStyleLayer *)layer;
 
-#pragma mark Managing Style Classes
-
-
-@property (nonatomic) NSArray<NSString *> *styleClasses __attribute__((unavailable("Support for style classes has been removed.")));
-
-- (BOOL)hasStyleClass:(NSString *)styleClass __attribute__((unavailable("Support for style classes has been removed.")));
-
-- (void)addStyleClass:(NSString *)styleClass __attribute__((unavailable("Support for style classes has been removed.")));
-
-- (void)removeStyleClass:(NSString *)styleClass __attribute__((unavailable("Support for style classes has been removed.")));
-
 #pragma mark Managing a Style’s Images
 
 /**
@@ -561,8 +536,6 @@ MGL_EXPORT
     language, specify a locale with the identifier `mul`.
  */
 - (void)localizeLabelsIntoLocale:(nullable NSLocale *)locale;
-
-@property (nonatomic) BOOL localizesLabels __attribute__((unavailable("Use -localizeLabelsIntoLocale: instead.")));
 
 @end
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -13,6 +13,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
   * `-[MGLMapView showAnnotations:edgePadding:animated:completionHandler:]`
   * `-[MGLMapView selectAnnotation:animated:completionHandler:]`
 * Deprecated variants of the above methods without completion handlers. ([#14959](https://github.com/mapbox/mapbox-gl-native/pull/14959))
+* Removed previously deprecated methods and properties that had been marked `unavailable`. ([#15000](https://github.com/mapbox/mapbox-gl-native/pull/15000))
 
 ## 5.1.0 - June 19, 2019
 

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -253,8 +253,6 @@ MGL_EXPORT
  */
 @property (nonatomic, readonly, nullable) MGLStyle *style;
 
-@property (nonatomic, readonly) NSArray<NSURL *> *bundledStyleURLs __attribute__((unavailable("Call the relevant class method of MGLStyle for the URL of a particular default style.")));
-
 /**
  URL of the style currently displayed in the receiver.
 
@@ -422,14 +420,6 @@ MGL_EXPORT
  The default value of this property is `YES`.
  */
 @property (nonatomic, assign) BOOL prefetchesTiles;
-
-@property (nonatomic) NSArray<NSString *> *styleClasses __attribute__((unavailable("Support for style classes has been removed.")));
-
-- (BOOL)hasStyleClass:(NSString *)styleClass __attribute__((unavailable("Support for style classes has been removed.")));
-
-- (void)addStyleClass:(NSString *)styleClass __attribute__((unavailable("Support for style classes has been removed.")));
-
-- (void)removeStyleClass:(NSString *)styleClass __attribute__((unavailable("Support for style classes has been removed.")));
 
 #pragma mark Displaying the User’s Location
 
@@ -1443,8 +1433,6 @@ MGL_EXPORT
  */
 - (CLLocationDistance)metersPerPointAtLatitude:(CLLocationDegrees)latitude;
 
-- (CLLocationDistance)metersPerPixelAtLatitude:(CLLocationDegrees)latitude __attribute__((unavailable("Use `-metersPerPointAtLatitude:`.")));
-
 #pragma mark Annotating the Map
 
 /**
@@ -1940,12 +1928,6 @@ MGL_EXPORT
  released software for performance and aesthetic reasons.
  */
 @property (nonatomic) MGLMapDebugMaskOptions debugMask;
-
-@property (nonatomic, getter=isDebugActive) BOOL debugActive __attribute__((unavailable("Use `-debugMask` and `-setDebugMask:`.")));
-
-- (void)toggleDebug __attribute__((unavailable("Use `-setDebugMask:`.")));
-
-- (void)emptyMemoryCache __attribute__((unavailable));
 
 @end
 


### PR DESCRIPTION
Removes previously deprecated methods and properties that had been marked as `unavailable` at least a year ago in #11205 (and usually several years ago).

- `-[MGLMapView metersPerPixelAtLatitude:]`: https://github.com/mapbox/mapbox-gl-native/pull/3393
- `MGLMapView.bundledStyleURLs`: https://github.com/mapbox/mapbox-gl-native/pull/2746
- Paint classes: https://github.com/mapbox/mapbox-gl-native/pull/8953
- And others.

Also updates some `MGLOfflineStorage` documentation to use the current key names.

/cc @mapbox/maps-ios 
