### PR TITLE
[build] GCC 8.0 now implements 'cast-function-type'

### DIFF
--- a/cmake/sqlite.cmake
+++ b/cmake/sqlite.cmake
@@ -37,7 +37,11 @@ target_compile_options(sqlite
 )
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-    target_compile_options(sqlite PRIVATE "-Wno-bad-function-cast")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8.0)
+        target_compile_options(sqlite PRIVATE "-Wno-cast-function-type")
+    else()
+        target_compile_options(sqlite PRIVATE "-Wno-bad-function-cast")
+    endif()
 elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
     target_compile_options(sqlite PRIVATE "-Wno-cast-function-type")
 endif()


### PR DESCRIPTION
GCC 8.0 now implements the same `cast-function-type` warning present in CLang.

Reference: https://gcc.gnu.org/gcc-8/changes.html