### PR TITLE
bring back manual opacity regression test

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/SymbolLayerActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/SymbolLayerActivity.java
@@ -43,7 +43,9 @@ import static com.mapbox.mapboxsdk.style.expressions.Expression.format;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.formatEntry;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.literal;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.match;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.rgb;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.stop;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.switchCase;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.toBool;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAllowOverlap;
@@ -51,6 +53,7 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAnchor;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconColor;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconIgnorePlacement;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconOpacity;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconSize;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textAllowOverlap;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textAnchor;
@@ -198,6 +201,12 @@ public class SymbolLayerActivity extends AppCompatActivity implements MapboxMap.
           // use DDS
           boolean selected = feature.getBooleanProperty(SELECTED_FEATURE_PROPERTY);
           feature.addBooleanProperty(SELECTED_FEATURE_PROPERTY, !selected);
+
+          // validate symbol flicker regression for #13407
+          markerSymbolLayer.setProperties(iconOpacity(match(
+            get(ID_FEATURE_PROPERTY), literal(1.0f),
+            stop(feature.getStringProperty("id"), selected ? 0.3f :  1.0f)
+          )));
         }
       }
       markerSource.setGeoJson(markerCollection);


### PR DESCRIPTION
This PR brings back the regression test introduced with https://github.com/mapbox/mapbox-gl-native/pull/13705. 
This was removed while adding new features. 

cc @pozdnyakov 