### PR TITLE
[ios] Fix ios-v5.2.0-alpha.1 podspec versions

### DIFF
--- a/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '5.2.0.alpha.1'
+  version = '5.2.0-alpha.1'
 
   m.name    = 'Mapbox-iOS-SDK-snapshot-dynamic'
   m.version = "#{version}-snapshot"

--- a/platform/ios/Mapbox-iOS-SDK-stripped.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-stripped.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '5.2.0.alpha.1'
+  version = '5.2.0-alpha.1'
 
   m.name    = 'Mapbox-iOS-SDK-stripped'
   m.version = "#{version}-stripped"

--- a/platform/ios/Mapbox-iOS-SDK.podspec
+++ b/platform/ios/Mapbox-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '5.2.0.alpha.1'
+  version = '5.2.0-alpha.1'
 
   m.name    = 'Mapbox-iOS-SDK'
   m.version = version


### PR DESCRIPTION
The versions I bumped to in #15012 had a period instead of a dash between the numbers and pre-release string, which meant that their framework binary URLs were incorrect

Because we no longer recommend people directly use (most of) these podspecs and since CocoaPods prevented us from pushing to `trunk`, the impact of this mistake is minimal and I don’t believe we’ll need to re-tag or rebuild the release.

## Next steps

- [x] Push corrected podspec [to CocoaPods trunk](https://github.com/CocoaPods/Specs/blob/master/Specs/a/5/9/Mapbox-iOS-SDK/5.2.0-alpha.1/Mapbox-iOS-SDK.podspec.json).
- [x] Priortize #14730, since we’re already aware manually updating podspecs in this way is error prone and easily scripted.
- [x] Update [release notes](https://github.com/mapbox/mapbox-gl-native/releases/tag/ios-v5.2.0-alpha.1) with warning about direct podspec usage being bork.

/cc @mapbox/maps-ios 