### PR TITLE
[core] Minor change to silence documentation warning on iOS.

### DIFF
--- a/include/mbgl/storage/resource_options.hpp
+++ b/include/mbgl/storage/resource_options.hpp
@@ -106,10 +106,10 @@ public:
     /**
      * @brief Gets the previously set (or default) support for cache-only requests.
      *
-     * @param Whether or not cache-only requests are supported.
+     * @param cacheOnly Whether or not cache-only requests are supported.
      * @return reference to ResourceOptions for chaining options together.
      */
-    ResourceOptions& withCacheOnlyRequestsSupport(bool);
+    ResourceOptions& withCacheOnlyRequestsSupport(bool cacheOnly);
 
     /**
      * @brief Sets the platform context. A platform context is usually an object


### PR DESCRIPTION
I have warnings-as-errors enabled for iOS builds, and this line fired:

`Parameter 'Whether' not found in the function declaration` on

https://github.com/mapbox/mapbox-gl-native/blob/0ca8ea6f169149cd414a65f40d0f7bdd40f3cca3/include/mbgl/storage/resource_options.hpp#L109

This change was introduced in https://github.com/mapbox/mapbox-gl-native/pull/14941

/cc @brunoabinader 