### PR TITLE
[ios, build] Add tests for MGLMapView pitch setting and tilt gesture

### DIFF
--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -371,6 +371,7 @@
 		9620BB3A1E69FE1700705A1D /* MGLSDKUpdateChecker.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9620BB371E69FE1700705A1D /* MGLSDKUpdateChecker.mm */; };
 		9620BB3B1E69FE1700705A1D /* MGLSDKUpdateChecker.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9620BB371E69FE1700705A1D /* MGLSDKUpdateChecker.mm */; };
 		9621F2502091020E005B3800 /* NSExpression+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3510FFEE1D6D9D8C00F413B2 /* NSExpression+MGLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		96381C0222C6F3950053497D /* MGLMapViewPitchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 96381C0122C6F3950053497D /* MGLMapViewPitchTests.m */; };
 		9654C1261FFC1AB900DB6A19 /* MGLPolyline_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 9654C1251FFC1AB900DB6A19 /* MGLPolyline_Private.h */; };
 		9654C1291FFC1CCD00DB6A19 /* MGLPolygon_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 9654C1271FFC1CC000DB6A19 /* MGLPolygon_Private.h */; };
 		9658C155204761FC00D8A674 /* MGLMapViewScaleBarTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9658C154204761FC00D8A674 /* MGLMapViewScaleBarTests.m */; };
@@ -1102,6 +1103,7 @@
 		960D0C351ECF5AAF008E151F /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		9620BB361E69FE1700705A1D /* MGLSDKUpdateChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLSDKUpdateChecker.h; sourceTree = "<group>"; };
 		9620BB371E69FE1700705A1D /* MGLSDKUpdateChecker.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 4; path = MGLSDKUpdateChecker.mm; sourceTree = "<group>"; };
+		96381C0122C6F3950053497D /* MGLMapViewPitchTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLMapViewPitchTests.m; sourceTree = "<group>"; };
 		9654C1251FFC1AB900DB6A19 /* MGLPolyline_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLPolyline_Private.h; sourceTree = "<group>"; };
 		9654C1271FFC1CC000DB6A19 /* MGLPolygon_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLPolygon_Private.h; sourceTree = "<group>"; };
 		9658C154204761FC00D8A674 /* MGLMapViewScaleBarTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLMapViewScaleBarTests.m; sourceTree = "<group>"; };
@@ -2035,6 +2037,7 @@
 				DA695425215B1E75002041A4 /* MGLMapCameraTests.m */,
 				96ED34DD22374C0900E9FCA9 /* MGLMapViewDirectionTests.mm */,
 				16376B481FFEED010000563E /* MGLMapViewLayoutTests.m */,
+				96381C0122C6F3950053497D /* MGLMapViewPitchTests.m */,
 				9658C154204761FC00D8A674 /* MGLMapViewScaleBarTests.m */,
 				076171C22139C70900668A35 /* MGLMapViewTests.m */,
 				1F95931C1E6DE2E900D5B294 /* MGLNSDateAdditionsTests.mm */,
@@ -3240,6 +3243,7 @@
 				96036A0620059BBA00510F3D /* MGLNSOrthographyAdditionsTests.m in Sources */,
 				1F95931D1E6DE2E900D5B294 /* MGLNSDateAdditionsTests.mm in Sources */,
 				DA695426215B1E76002041A4 /* MGLMapCameraTests.m in Sources */,
+				96381C0222C6F3950053497D /* MGLMapViewPitchTests.m in Sources */,
 				CA8FBC0921A47BB100D1203C /* MGLRendererConfigurationTests.mm in Sources */,
 				CAD9D0AA22A86D6F001B25EE /* MGLResourceTests.mm in Sources */,
 				DD58A4C61D822BD000E1F038 /* MGLExpressionTests.mm in Sources */,

--- a/platform/ios/test/MGLMapViewPitchTests.m
+++ b/platform/ios/test/MGLMapViewPitchTests.m
@@ -1,0 +1,116 @@
+#import <Mapbox/Mapbox.h>
+#import <XCTest/XCTest.h>
+
+static MGLMapView *mapView;
+static CGFloat tiltGestureYTranslation;
+
+@interface MGLMapView (MGLMapViewPitchTests)
+- (void)handleTwoFingerDragGesture:(UIPanGestureRecognizer *)rotate;
+- (MGLMapCamera *)cameraByTiltingToPitch:(CGFloat)pitch;
+@end
+
+@interface UIPanGestureRecognizer (MGLMapViewPitchTests)
+@property (nonatomic, readwrite) UIGestureRecognizerState state;
+@end
+
+@implementation UIPanGestureRecognizer (MGLMapViewPitchTests)
+- (NSUInteger)numberOfTouches { return 2; }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-protocol-method-implementation"
+- (CGPoint)translationInView:(UIView *)view { return CGPointMake(0, tiltGestureYTranslation); }
+#pragma clang diagnostic pop
+@end
+
+@interface MGLMapViewPitchTests : XCTestCase
+@end
+
+@implementation MGLMapViewPitchTests
+
+- (void)setUp {
+    [super setUp];
+
+    [MGLAccountManager setAccessToken:@"pk.feedcafedeadbeefbadebede"];
+    NSURL *styleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"one-liner" withExtension:@"json"];
+    mapView = [[MGLMapView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) styleURL:styleURL];
+
+    tiltGestureYTranslation = 0;
+}
+
+- (void)tearDown {
+    mapView = nil;
+    [MGLAccountManager setAccessToken:nil];
+    [super tearDown];
+}
+
+- (void)testPitch {
+    mapView.zoomLevel = 0;
+    mapView.camera = [mapView cameraByTiltingToPitch:30];
+    XCTAssertEqualWithAccuracy(mapView.camera.pitch, 30, 0.001, @"Tilt should be allowed at world-scale zoom levels.");
+
+    mapView.zoomLevel = 15;
+    mapView.camera = [mapView cameraByTiltingToPitch:30];
+    XCTAssertEqualWithAccuracy(mapView.camera.pitch, 30, 0.001, @"Tilt should work at z15.");
+
+    for (NSNumber *degrees in @[@0, @5, @20, @40, @60]) {
+        CGFloat inputDegrees = [degrees floatValue];
+        mapView.camera = [mapView cameraByTiltingToPitch:inputDegrees];
+        XCTAssertEqualWithAccuracy(mapView.camera.pitch, inputDegrees, 0.001, @"Tilt should be able to be set to range 0-60°.");
+    }
+
+    // Currently fails, which seems incorrect.
+//    mapView.camera = [mapView cameraByTiltingToPitch:-10];
+//    XCTAssertEqualWithAccuracy(mapView.camera.pitch, 0, 0.001, @"Minimum tilt should be clamped to 0°.");
+
+    mapView.camera = [mapView cameraByTiltingToPitch:999];
+    XCTAssertEqualWithAccuracy(mapView.camera.pitch, 60, 0.001, @"Maximum tilt should be clamped to 60°.");
+}
+
+- (void)testPitchEnabled {
+    mapView.pitchEnabled = NO;
+    mapView.camera = [mapView cameraByTiltingToPitch:30];
+    XCTAssertEqualWithAccuracy(mapView.camera.pitch, 30, 0.001, @"Tilt should not be set when pitchEnabled = NO.");
+
+    mapView.pitchEnabled = YES;
+    mapView.camera = [mapView cameraByTiltingToPitch:30];
+    XCTAssertEqualWithAccuracy(mapView.camera.pitch, 30, 0.001, @"Tilt should be set when pitchEnabled = YES.");
+}
+
+- (void)testTiltGesture {
+    UIPanGestureRecognizer *gesture = [[UIPanGestureRecognizer alloc] initWithTarget:mapView action:nil];
+    gesture.state = UIGestureRecognizerStateBegan;
+    [mapView handleTwoFingerDragGesture:gesture];
+    XCTAssertEqual(mapView.camera.pitch, 0, @"Tilt should initially be set to 0°.");
+
+    for (NSNumber *degrees in @[@0, @5, @20, @40, @60]) {
+        mapView.camera = [mapView cameraByTiltingToPitch:0];
+        gesture.state = UIGestureRecognizerStateChanged;
+
+        CGFloat inputDegrees = [degrees floatValue];
+        [self setTiltGestureYTranslationForPitchDegrees:inputDegrees];
+        [mapView handleTwoFingerDragGesture:gesture];
+        XCTAssertEqualWithAccuracy(mapView.camera.pitch, inputDegrees, 0.001, @"Tilt should be set to %.f°.", inputDegrees);
+    }
+}
+
+- (void)testTiltGestureFromInitialTilt {
+    CGFloat initialTilt = 20;
+    CGFloat additionalTilt = 30;
+
+    mapView.camera = [mapView cameraByTiltingToPitch:initialTilt];
+    XCTAssertEqual(mapView.camera.pitch, initialTilt, @"Tilt should initially be set to %.f°.", initialTilt);
+
+    UIPanGestureRecognizer *gesture = [[UIPanGestureRecognizer alloc] initWithTarget:mapView action:nil];
+    gesture.state = UIGestureRecognizerStateBegan;
+    [mapView handleTwoFingerDragGesture:gesture];
+
+    [self setTiltGestureYTranslationForPitchDegrees:additionalTilt];
+    [mapView handleTwoFingerDragGesture:gesture];
+    XCTAssertEqualWithAccuracy(mapView.camera.pitch, initialTilt + additionalTilt, 0.001, @"Tilt should be set to %.f°.", initialTilt + additionalTilt);
+}
+
+- (void)setTiltGestureYTranslationForPitchDegrees:(CGFloat)degrees {
+    // The tilt gesture takes the number of screen points the fingers have moved and then divides them by a "slowdown" factor, which happens to be set to 2.0 in -[MGLMapView handleTwoFingerDragGesture:].
+    tiltGestureYTranslation = -(degrees * 2.0);
+}
+
+@end

--- a/platform/ios/test/MGLMapViewPitchTests.m
+++ b/platform/ios/test/MGLMapViewPitchTests.m
@@ -2,7 +2,8 @@
 #import <XCTest/XCTest.h>
 
 static MGLMapView *mapView;
-static CGFloat tiltGestureYTranslation;
+static CGFloat mbx_tiltGestureYTranslation;
+static NSUInteger mbx_numberOfFingersForGesture;
 
 @interface MGLMapView (MGLMapViewPitchTests)
 - (void)handleTwoFingerDragGesture:(UIPanGestureRecognizer *)rotate;
@@ -14,10 +15,10 @@ static CGFloat tiltGestureYTranslation;
 @end
 
 @implementation UIPanGestureRecognizer (MGLMapViewPitchTests)
-- (NSUInteger)numberOfTouches { return 2; }
+- (NSUInteger)numberOfTouches { return mbx_numberOfFingersForGesture; }
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wobjc-protocol-method-implementation"
-- (CGPoint)translationInView:(UIView *)view { return CGPointMake(0, tiltGestureYTranslation); }
+- (CGPoint)translationInView:(UIView *)view { return CGPointMake(0, mbx_tiltGestureYTranslation); }
 #pragma clang diagnostic pop
 @end
 
@@ -33,36 +34,14 @@ static CGFloat tiltGestureYTranslation;
     NSURL *styleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"one-liner" withExtension:@"json"];
     mapView = [[MGLMapView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) styleURL:styleURL];
 
-    tiltGestureYTranslation = 0;
+    mbx_tiltGestureYTranslation = 0;
+    mbx_numberOfFingersForGesture = 2;
 }
 
 - (void)tearDown {
     mapView = nil;
     [MGLAccountManager setAccessToken:nil];
     [super tearDown];
-}
-
-- (void)testPitch {
-    mapView.zoomLevel = 0;
-    mapView.camera = [mapView cameraByTiltingToPitch:30];
-    XCTAssertEqualWithAccuracy(mapView.camera.pitch, 30, 0.001, @"Tilt should be allowed at world-scale zoom levels.");
-
-    mapView.zoomLevel = 15;
-    mapView.camera = [mapView cameraByTiltingToPitch:30];
-    XCTAssertEqualWithAccuracy(mapView.camera.pitch, 30, 0.001, @"Tilt should work at z15.");
-
-    for (NSNumber *degrees in @[@0, @5, @20, @40, @60]) {
-        CGFloat inputDegrees = [degrees floatValue];
-        mapView.camera = [mapView cameraByTiltingToPitch:inputDegrees];
-        XCTAssertEqualWithAccuracy(mapView.camera.pitch, inputDegrees, 0.001, @"Tilt should be able to be set to range 0-60°.");
-    }
-
-    // Currently fails, which seems incorrect.
-//    mapView.camera = [mapView cameraByTiltingToPitch:-10];
-//    XCTAssertEqualWithAccuracy(mapView.camera.pitch, 0, 0.001, @"Minimum tilt should be clamped to 0°.");
-
-    mapView.camera = [mapView cameraByTiltingToPitch:999];
-    XCTAssertEqualWithAccuracy(mapView.camera.pitch, 60, 0.001, @"Maximum tilt should be clamped to 60°.");
 }
 
 - (void)testPitchEnabled {
@@ -75,12 +54,49 @@ static CGFloat tiltGestureYTranslation;
     XCTAssertEqualWithAccuracy(mapView.camera.pitch, 30, 0.001, @"Tilt should be set when pitchEnabled = YES.");
 }
 
+- (void)testPitchInValidRange {
+    for (NSNumber *degrees in @[@0, @5, @20, @40, @60]) {
+        CGFloat inputDegrees = [degrees floatValue];
+        mapView.camera = [mapView cameraByTiltingToPitch:inputDegrees];
+        XCTAssertEqualWithAccuracy(mapView.camera.pitch, inputDegrees, 0.001, @"Tilt should be able to be set within range 0-60°.");
+    }
+}
+
+- (void)testNegativePitchClamping {
+    for (NSNumber *degrees in @[@CGFLOAT_MIN, @-999, @-60, @-30, @-0]) {
+        CGFloat inputDegrees = [degrees floatValue];
+        mapView.camera = [mapView cameraByTiltingToPitch:inputDegrees];
+        XCTAssertEqualWithAccuracy(mapView.camera.pitch, 0, 0.001, @"Minimum tilt should be clamped to 0°.");
+    }
+}
+
+- (void)testPositivePitchClamping {
+    for (NSNumber *degrees in @[@61, @90, @999, @CGFLOAT_MAX]) {
+        CGFloat inputDegrees = [degrees floatValue];
+        mapView.camera = [mapView cameraByTiltingToPitch:inputDegrees];
+        XCTAssertEqualWithAccuracy(mapView.camera.pitch, 60, 0.001, @"Maximum tilt should be clamped to 60°.");
+    }
+}
+
+- (void)testPitchAtVariousZoomLevels {
+    for (NSNumber *zoomLevel in @[@0, @5, @10, @15, @18, @21, @CGFLOAT_MAX]) {
+        mapView.camera = [mapView cameraByTiltingToPitch:0];
+        mapView.zoomLevel = 0;
+
+        CGFloat inputZoomLevel = [zoomLevel floatValue];
+        mapView.zoomLevel = inputZoomLevel;
+        mapView.camera = [mapView cameraByTiltingToPitch:30];
+        XCTAssertEqualWithAccuracy(mapView.camera.pitch, 30, 0.001, @"Tilting should be allowed at z%.f.", inputZoomLevel);
+    }
+}
+
 - (void)testTiltGesture {
     UIPanGestureRecognizer *gesture = [[UIPanGestureRecognizer alloc] initWithTarget:mapView action:nil];
     gesture.state = UIGestureRecognizerStateBegan;
     [mapView handleTwoFingerDragGesture:gesture];
-    XCTAssertEqual(mapView.camera.pitch, 0, @"Tilt should initially be set to 0°.");
+    XCTAssertEqual(mapView.camera.pitch, 0, @"Pitch should initially be set to 0°.");
 
+    // Use a tilt gesture to tilt the map within its acceptable range (0-60°).
     for (NSNumber *degrees in @[@0, @5, @20, @40, @60]) {
         mapView.camera = [mapView cameraByTiltingToPitch:0];
         gesture.state = UIGestureRecognizerStateChanged;
@@ -88,7 +104,7 @@ static CGFloat tiltGestureYTranslation;
         CGFloat inputDegrees = [degrees floatValue];
         [self setTiltGestureYTranslationForPitchDegrees:inputDegrees];
         [mapView handleTwoFingerDragGesture:gesture];
-        XCTAssertEqualWithAccuracy(mapView.camera.pitch, inputDegrees, 0.001, @"Tilt should be set to %.f°.", inputDegrees);
+        XCTAssertEqualWithAccuracy(mapView.camera.pitch, inputDegrees, 0.001, @"Pitch should be set to %.f°.", inputDegrees);
     }
 }
 
@@ -96,21 +112,45 @@ static CGFloat tiltGestureYTranslation;
     CGFloat initialTilt = 20;
     CGFloat additionalTilt = 30;
 
+    // Set the map camera to a pitched state, perhaps from a previous gesture or camera movement.
     mapView.camera = [mapView cameraByTiltingToPitch:initialTilt];
     XCTAssertEqual(mapView.camera.pitch, initialTilt, @"Tilt should initially be set to %.f°.", initialTilt);
 
+    // Initialize a tilt gesture.
     UIPanGestureRecognizer *gesture = [[UIPanGestureRecognizer alloc] initWithTarget:mapView action:nil];
     gesture.state = UIGestureRecognizerStateBegan;
     [mapView handleTwoFingerDragGesture:gesture];
 
+    // Use the gesture to tilt the map even more.
+    gesture.state = UIGestureRecognizerStateChanged;
     [self setTiltGestureYTranslationForPitchDegrees:additionalTilt];
     [mapView handleTwoFingerDragGesture:gesture];
     XCTAssertEqualWithAccuracy(mapView.camera.pitch, initialTilt + additionalTilt, 0.001, @"Tilt should be set to %.f°.", initialTilt + additionalTilt);
 }
 
+- (void)testTiltGestureNumberOfFingersRequired {
+    // Initialize a tilt gesture with two fingers.
+    UIPanGestureRecognizer *gesture = [[UIPanGestureRecognizer alloc] initWithTarget:mapView action:nil];
+    gesture.state = UIGestureRecognizerStateBegan;
+    mbx_numberOfFingersForGesture = 2;
+
+    // Use the gesture to tilt to 30°.
+    [self setTiltGestureYTranslationForPitchDegrees:30];
+    [mapView handleTwoFingerDragGesture:gesture];
+    XCTAssertEqualWithAccuracy(mapView.camera.pitch, 30, 0.001, @"Tilt gesture should work with two fingers down.");
+
+    // Change the gesture's number of fingers to one and try to update the pitch.
+    mbx_numberOfFingersForGesture = 1;
+    gesture.state = UIGestureRecognizerStateChanged;
+    [self setTiltGestureYTranslationForPitchDegrees:0];
+    [mapView handleTwoFingerDragGesture:gesture];
+    XCTAssertEqual(gesture.state, UIGestureRecognizerStateEnded, @"Gesture should end when the number of fingers is less than two.");
+    XCTAssertEqualWithAccuracy(mapView.camera.pitch, 30, 0.001, @"Pitch should remain unchanged if gesture has ended.");
+}
+
 - (void)setTiltGestureYTranslationForPitchDegrees:(CGFloat)degrees {
     // The tilt gesture takes the number of screen points the fingers have moved and then divides them by a "slowdown" factor, which happens to be set to 2.0 in -[MGLMapView handleTwoFingerDragGesture:].
-    tiltGestureYTranslation = -(degrees * 2.0);
+    mbx_tiltGestureYTranslation = -(degrees * 2.0);
 }
 
 @end

--- a/platform/ios/test/MGLMapViewPitchTests.m
+++ b/platform/ios/test/MGLMapViewPitchTests.m
@@ -1,28 +1,35 @@
 #import <Mapbox/Mapbox.h>
 #import <XCTest/XCTest.h>
 
-static MGLMapView *mapView;
-static CGFloat mbx_tiltGestureYTranslation;
-static NSUInteger mbx_numberOfFingersForGesture;
+@interface MockUIPanGestureRecognizer : UIPanGestureRecognizer
+@property CGFloat mbx_tiltGestureYTranslation;
+@property NSUInteger mbx_numberOfFingersForGesture;
+@end
 
+@implementation MockUIPanGestureRecognizer
+- (instancetype)initWithTarget:(id)target action:(SEL)action {
+    if (self = [super initWithTarget:target action:action]) {
+        self.mbx_tiltGestureYTranslation = 0;
+        self.mbx_numberOfFingersForGesture = 2;
+    }
+    return self;
+}
+- (NSUInteger)numberOfTouches { return self.mbx_numberOfFingersForGesture; }
+- (CGPoint)translationInView:(UIView *)view { return CGPointMake(0, self.mbx_tiltGestureYTranslation); }
+- (void)setTiltGestureYTranslationForPitchDegrees:(CGFloat)degrees {
+    // The tilt gesture takes the number of screen points the fingers have moved and then divides them by a "slowdown" factor, which happens to be set to 2.0 in -[MGLMapView handleTwoFingerDragGesture:].
+    self.mbx_tiltGestureYTranslation = -(degrees * 2.0);
+}
+@end
+
+// Forward declare relevant private methods
 @interface MGLMapView (MGLMapViewPitchTests)
 - (void)handleTwoFingerDragGesture:(UIPanGestureRecognizer *)rotate;
 - (MGLMapCamera *)cameraByTiltingToPitch:(CGFloat)pitch;
 @end
 
-@interface UIPanGestureRecognizer (MGLMapViewPitchTests)
-@property (nonatomic, readwrite) UIGestureRecognizerState state;
-@end
-
-@implementation UIPanGestureRecognizer (MGLMapViewPitchTests)
-- (NSUInteger)numberOfTouches { return mbx_numberOfFingersForGesture; }
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wobjc-protocol-method-implementation"
-- (CGPoint)translationInView:(UIView *)view { return CGPointMake(0, mbx_tiltGestureYTranslation); }
-#pragma clang diagnostic pop
-@end
-
 @interface MGLMapViewPitchTests : XCTestCase
+@property (nonatomic) MGLMapView *mapView;
 @end
 
 @implementation MGLMapViewPitchTests
@@ -32,79 +39,76 @@ static NSUInteger mbx_numberOfFingersForGesture;
 
     [MGLAccountManager setAccessToken:@"pk.feedcafedeadbeefbadebede"];
     NSURL *styleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"one-liner" withExtension:@"json"];
-    mapView = [[MGLMapView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) styleURL:styleURL];
-
-    mbx_tiltGestureYTranslation = 0;
-    mbx_numberOfFingersForGesture = 2;
+    self.mapView = [[MGLMapView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) styleURL:styleURL];
 }
 
 - (void)tearDown {
-    mapView = nil;
+    self.mapView = nil;
     [MGLAccountManager setAccessToken:nil];
     [super tearDown];
 }
 
 - (void)testPitchEnabled {
-    mapView.pitchEnabled = NO;
-    mapView.camera = [mapView cameraByTiltingToPitch:30];
-    XCTAssertEqualWithAccuracy(mapView.camera.pitch, 30, 0.001, @"Tilt should not be set when pitchEnabled = NO.");
+    self.mapView.pitchEnabled = NO;
+    self.mapView.camera = [self.mapView cameraByTiltingToPitch:30];
+    XCTAssertEqualWithAccuracy(self.mapView.camera.pitch, 30, 0.001, @"Tilt should not be set when pitchEnabled = NO.");
 
-    mapView.pitchEnabled = YES;
-    mapView.camera = [mapView cameraByTiltingToPitch:30];
-    XCTAssertEqualWithAccuracy(mapView.camera.pitch, 30, 0.001, @"Tilt should be set when pitchEnabled = YES.");
+    self.mapView.pitchEnabled = YES;
+    self.mapView.camera = [self.mapView cameraByTiltingToPitch:30];
+    XCTAssertEqualWithAccuracy(self.mapView.camera.pitch, 30, 0.001, @"Tilt should be set when pitchEnabled = YES.");
 }
 
 - (void)testPitchInValidRange {
     for (NSNumber *degrees in @[@0, @5, @20, @40, @60]) {
         CGFloat inputDegrees = [degrees floatValue];
-        mapView.camera = [mapView cameraByTiltingToPitch:inputDegrees];
-        XCTAssertEqualWithAccuracy(mapView.camera.pitch, inputDegrees, 0.001, @"Tilt should be able to be set within range 0-60°.");
+        self.mapView.camera = [self.mapView cameraByTiltingToPitch:inputDegrees];
+        XCTAssertEqualWithAccuracy(self.mapView.camera.pitch, inputDegrees, 0.001, @"Tilt should be able to be set within range 0-60°.");
     }
 }
 
 - (void)testNegativePitchClamping {
     for (NSNumber *degrees in @[@CGFLOAT_MIN, @-999, @-60, @-30, @-0]) {
         CGFloat inputDegrees = [degrees floatValue];
-        mapView.camera = [mapView cameraByTiltingToPitch:inputDegrees];
-        XCTAssertEqualWithAccuracy(mapView.camera.pitch, 0, 0.001, @"Minimum tilt should be clamped to 0°.");
+        self.mapView.camera = [self.mapView cameraByTiltingToPitch:inputDegrees];
+        XCTAssertEqualWithAccuracy(self.mapView.camera.pitch, 0, 0.001, @"Minimum tilt should be clamped to 0°.");
     }
 }
 
 - (void)testPositivePitchClamping {
     for (NSNumber *degrees in @[@61, @90, @999, @CGFLOAT_MAX]) {
         CGFloat inputDegrees = [degrees floatValue];
-        mapView.camera = [mapView cameraByTiltingToPitch:inputDegrees];
-        XCTAssertEqualWithAccuracy(mapView.camera.pitch, 60, 0.001, @"Maximum tilt should be clamped to 60°.");
+        self.mapView.camera = [self.mapView cameraByTiltingToPitch:inputDegrees];
+        XCTAssertEqualWithAccuracy(self.mapView.camera.pitch, 60, 0.001, @"Maximum tilt should be clamped to 60°.");
     }
 }
 
 - (void)testPitchAtVariousZoomLevels {
     for (NSNumber *zoomLevel in @[@0, @5, @10, @15, @18, @21, @CGFLOAT_MAX]) {
-        mapView.camera = [mapView cameraByTiltingToPitch:0];
-        mapView.zoomLevel = 0;
+        self.mapView.camera = [self.mapView cameraByTiltingToPitch:0];
+        self.mapView.zoomLevel = 0;
 
         CGFloat inputZoomLevel = [zoomLevel floatValue];
-        mapView.zoomLevel = inputZoomLevel;
-        mapView.camera = [mapView cameraByTiltingToPitch:30];
-        XCTAssertEqualWithAccuracy(mapView.camera.pitch, 30, 0.001, @"Tilting should be allowed at z%.f.", inputZoomLevel);
+        self.mapView.zoomLevel = inputZoomLevel;
+        self.mapView.camera = [self.mapView cameraByTiltingToPitch:30];
+        XCTAssertEqualWithAccuracy(self.mapView.camera.pitch, 30, 0.001, @"Tilting should be allowed at z%.f.", inputZoomLevel);
     }
 }
 
 - (void)testTiltGesture {
-    UIPanGestureRecognizer *gesture = [[UIPanGestureRecognizer alloc] initWithTarget:mapView action:nil];
+    MockUIPanGestureRecognizer *gesture = [[MockUIPanGestureRecognizer alloc] initWithTarget:self.mapView action:nil];
     gesture.state = UIGestureRecognizerStateBegan;
-    [mapView handleTwoFingerDragGesture:gesture];
-    XCTAssertEqual(mapView.camera.pitch, 0, @"Pitch should initially be set to 0°.");
+    [self.mapView handleTwoFingerDragGesture:gesture];
+    XCTAssertEqual(self.mapView.camera.pitch, 0, @"Pitch should initially be set to 0°.");
 
     // Use a tilt gesture to tilt the map within its acceptable range (0-60°).
     for (NSNumber *degrees in @[@0, @5, @20, @40, @60]) {
-        mapView.camera = [mapView cameraByTiltingToPitch:0];
+        self.mapView.camera = [self.mapView cameraByTiltingToPitch:0];
         gesture.state = UIGestureRecognizerStateChanged;
 
         CGFloat inputDegrees = [degrees floatValue];
-        [self setTiltGestureYTranslationForPitchDegrees:inputDegrees];
-        [mapView handleTwoFingerDragGesture:gesture];
-        XCTAssertEqualWithAccuracy(mapView.camera.pitch, inputDegrees, 0.001, @"Pitch should be set to %.f°.", inputDegrees);
+        [gesture setTiltGestureYTranslationForPitchDegrees:inputDegrees];
+        [self.mapView handleTwoFingerDragGesture:gesture];
+        XCTAssertEqualWithAccuracy(self.mapView.camera.pitch, inputDegrees, 0.001, @"Pitch should be set to %.f°.", inputDegrees);
     }
 }
 
@@ -113,44 +117,39 @@ static NSUInteger mbx_numberOfFingersForGesture;
     CGFloat additionalTilt = 30;
 
     // Set the map camera to a pitched state, perhaps from a previous gesture or camera movement.
-    mapView.camera = [mapView cameraByTiltingToPitch:initialTilt];
-    XCTAssertEqual(mapView.camera.pitch, initialTilt, @"Tilt should initially be set to %.f°.", initialTilt);
+    self.mapView.camera = [self.mapView cameraByTiltingToPitch:initialTilt];
+    XCTAssertEqual(self.mapView.camera.pitch, initialTilt, @"Tilt should initially be set to %.f°.", initialTilt);
 
     // Initialize a tilt gesture.
-    UIPanGestureRecognizer *gesture = [[UIPanGestureRecognizer alloc] initWithTarget:mapView action:nil];
+    MockUIPanGestureRecognizer *gesture = [[MockUIPanGestureRecognizer alloc] initWithTarget:self.mapView action:nil];
     gesture.state = UIGestureRecognizerStateBegan;
-    [mapView handleTwoFingerDragGesture:gesture];
+    [self.mapView handleTwoFingerDragGesture:gesture];
 
     // Use the gesture to tilt the map even more.
     gesture.state = UIGestureRecognizerStateChanged;
-    [self setTiltGestureYTranslationForPitchDegrees:additionalTilt];
-    [mapView handleTwoFingerDragGesture:gesture];
-    XCTAssertEqualWithAccuracy(mapView.camera.pitch, initialTilt + additionalTilt, 0.001, @"Tilt should be set to %.f°.", initialTilt + additionalTilt);
+    [gesture setTiltGestureYTranslationForPitchDegrees:additionalTilt];
+    [self.mapView handleTwoFingerDragGesture:gesture];
+    XCTAssertEqualWithAccuracy(self.mapView.camera.pitch, initialTilt + additionalTilt, 0.001, @"Tilt should be set to %.f°.", initialTilt + additionalTilt);
 }
 
 - (void)testTiltGestureNumberOfFingersRequired {
     // Initialize a tilt gesture with two fingers.
-    UIPanGestureRecognizer *gesture = [[UIPanGestureRecognizer alloc] initWithTarget:mapView action:nil];
+    MockUIPanGestureRecognizer *gesture = [[MockUIPanGestureRecognizer alloc] initWithTarget:self.mapView action:nil];
     gesture.state = UIGestureRecognizerStateBegan;
-    mbx_numberOfFingersForGesture = 2;
+    gesture.mbx_numberOfFingersForGesture = 2;
 
     // Use the gesture to tilt to 30°.
-    [self setTiltGestureYTranslationForPitchDegrees:30];
-    [mapView handleTwoFingerDragGesture:gesture];
-    XCTAssertEqualWithAccuracy(mapView.camera.pitch, 30, 0.001, @"Tilt gesture should work with two fingers down.");
+    [gesture setTiltGestureYTranslationForPitchDegrees:30];
+    [self.mapView handleTwoFingerDragGesture:gesture];
+    XCTAssertEqualWithAccuracy(self.mapView.camera.pitch, 30, 0.001, @"Tilt gesture should work with two fingers down.");
 
     // Change the gesture's number of fingers to one and try to update the pitch.
-    mbx_numberOfFingersForGesture = 1;
+    gesture.mbx_numberOfFingersForGesture = 1;
     gesture.state = UIGestureRecognizerStateChanged;
-    [self setTiltGestureYTranslationForPitchDegrees:0];
-    [mapView handleTwoFingerDragGesture:gesture];
+    [gesture setTiltGestureYTranslationForPitchDegrees:0];
+    [self.mapView handleTwoFingerDragGesture:gesture];
     XCTAssertEqual(gesture.state, UIGestureRecognizerStateEnded, @"Gesture should end when the number of fingers is less than two.");
-    XCTAssertEqualWithAccuracy(mapView.camera.pitch, 30, 0.001, @"Pitch should remain unchanged if gesture has ended.");
-}
-
-- (void)setTiltGestureYTranslationForPitchDegrees:(CGFloat)degrees {
-    // The tilt gesture takes the number of screen points the fingers have moved and then divides them by a "slowdown" factor, which happens to be set to 2.0 in -[MGLMapView handleTwoFingerDragGesture:].
-    mbx_tiltGestureYTranslation = -(degrees * 2.0);
+    XCTAssertEqualWithAccuracy(self.mapView.camera.pitch, 30, 0.001, @"Pitch should remain unchanged if gesture has ended.");
 }
 
 @end


### PR DESCRIPTION
Part of #14091 — adds tests for `MGLMapView` pitch setting and for the tilt gesture recognizer.

- [x] Still a slight work in progress, as setting pitch to a negative value seems like it shouldn’t do anything, but currently results in a value of `60`. **Update: pitch is indeed not settable to negative values — it leaves the camera’s original value intact.**
- [x] I may also add a test for #14969.

/cc @julianrex @fabian-guerra 