### PR TITLE
[ios] Fix a race condition issue in the Mapbox metrics class.

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 ### Offline maps
 
 * Fixed an issue where offline regions could report the wrong number of tiles. ([#14958](https://github.com/mapbox/mapbox-gl-native/pull/14958))
+* Fixed an issue that may cause a crash when downloading a list of `MGLOfflinePack` objects. ([#15029](https://github.com/mapbox/mapbox-gl-native/pull/15029))
 
 ### Packaging
 


### PR DESCRIPTION
Fixes #14982 

Downloading multiple offline packs starts multiple background requests. The metrics controller we were using used a property from a URL object in an autoreleased pool. This request may go away in the middle of setting the starting event, which may have caused the crash. 

I think is unnecessary to use a lock for the `urlString` variable. instead I'm retaining the variable to avoid passing nil to the events dictionary.

/cc @friedbunny 