### PR TITLE
Android: MapView add constructor which takes an AttributeSet & MapboxMapOptions.

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -112,6 +112,12 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     initialize(context, options == null ? MapboxMapOptions.createFromAttributes(context, null) : options);
   }
 
+  @UiThread
+  public MapView(@NonNull Context context, @Nullable AttributeSet attrs, @NonNull MapboxMapOptions options) {
+    super(context, attrs);
+    initialize(context, options);
+  }
+
   @CallSuper
   @UiThread
   protected void initialize(@NonNull final Context context, @NonNull final MapboxMapOptions options) {


### PR DESCRIPTION
We have a custom view implementation that extends from MapBox's MapView. I was trying to set `textureMode(true)` via:

```kotlin
class MapboxMapView(
  context: Context,
  attrs: AttributeSet? = null
) : MapView(context, MapboxMapOptions.createFromAttributes(context, attrs).textureMode(true)) {
```

However, this didn't work. Also, calling `initialize()` inside `init()` does not work. It seems like calling that method twice isn't intended so I'm wondering why it's set as protected.

By creating that new constructor I can pass in the required `attrs` as well as the custom MapboxMapOptions.

cc @Guardiola31337 who asked me to create this PR