### PR TITLE
[ios-maps] Replace styleURL assert with log message and change return value.

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -389,8 +389,14 @@ public:
     }
 
     NSString *styleURLString = @(self.mbglMap.getStyle().getURL().c_str()).mgl_stringOrNilIfEmpty;
-    MGLAssert(styleURLString, @"Invalid style URL string %@", styleURLString);
-    return styleURLString ? [NSURL URLWithString:styleURLString] : nil;
+
+    if (!styleURLString)
+    {
+        MGLLogInfo(@"Warning: Invalid style URL string %@", styleURLString);
+    }
+    
+    return styleURLString ? [NSURL URLWithString:styleURLString] :
+        [MGLStyle streetsStyleURLWithVersion:MGLStyleDefaultVersion];
 }
 
 - (void)setStyleURL:(nullable NSURL *)styleURL


### PR DESCRIPTION
This PR changes an assert for a valid style URL to a warning, and changes the return value so that the default style URL is returned rather than `nil` (to match `null_resettable` property modifier).



