### PR TITLE
MapSnapshotter and offline download test

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/offline/OfflineDownloadTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/offline/OfflineDownloadTest.kt
@@ -1,0 +1,88 @@
+package com.mapbox.mapboxsdk.offline
+
+import android.support.test.rule.ActivityTestRule
+import android.support.test.runner.AndroidJUnit4
+import com.mapbox.geojson.Point
+import com.mapbox.mapboxsdk.log.Logger
+import com.mapbox.mapboxsdk.maps.Style
+import com.mapbox.mapboxsdk.testapp.activity.FeatureOverviewActivity
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+/**
+ * Integration test that validates downloading an offline region from a point geometry at zoomlevel 17
+ */
+@RunWith(AndroidJUnit4::class)
+class OfflineDownloadTest : OfflineRegion.OfflineRegionObserver {
+
+  @Rule
+  @JvmField
+  var rule = ActivityTestRule(FeatureOverviewActivity::class.java)
+
+  private val countDownLatch = CountDownLatch(1)
+  private lateinit var offlineRegion: OfflineRegion
+
+  @Test(timeout = 30000)
+  fun offlineDownload() {
+    rule.runOnUiThreadActivity {
+      OfflineManager.getInstance(rule.activity).createOfflineRegion(
+        createTestRegionDefinition(),
+        ByteArray(0),
+        object : OfflineManager.CreateOfflineRegionCallback {
+          override fun onCreate(region: OfflineRegion?) {
+            region?.let {
+              offlineRegion = it
+              offlineRegion.setDownloadState(OfflineRegion.STATE_ACTIVE)
+              offlineRegion.setObserver(this@OfflineDownloadTest)
+            }
+          }
+
+          override fun onError(error: String?) {
+            Logger.e(TAG, "Error while creating offline region: $error")
+          }
+        })
+    }
+
+    if (!countDownLatch.await(30, TimeUnit.SECONDS)) {
+      throw TimeoutException()
+    }
+  }
+
+  override fun onStatusChanged(status: OfflineRegionStatus?) {
+    status?.let {
+      if (it.isComplete) {
+        offlineRegion.setDownloadState(OfflineRegion.STATE_INACTIVE)
+        countDownLatch.countDown()
+      }
+    }
+  }
+
+  override fun onError(error: OfflineRegionError?) {
+    Logger.e(TAG, "Error while downloading offline region: $error")
+  }
+
+  override fun mapboxTileCountLimitExceeded(limit: Long) {
+    Logger.e(TAG, "Tile count limited exceeded: $limit")
+  }
+
+  fun createTestRegionDefinition(): OfflineRegionDefinition {
+    return OfflineGeometryRegionDefinition(
+      Style.MAPBOX_STREETS,
+      Point.fromLngLat(50.847857, 4.360137),
+      17.0,
+      17.0,
+      1.0f,
+      false
+    )
+  }
+
+  companion object {
+    const val TAG = "OfflineDownloadTest"
+  }
+}
+
+fun ActivityTestRule<*>.runOnUiThreadActivity(runnable: () -> Unit) = activity.runOnUiThread(runnable)

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotterTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotterTest.kt
@@ -1,0 +1,26 @@
+package com.mapbox.mapboxsdk.snapshotter
+
+import android.support.test.rule.ActivityTestRule
+import android.support.test.runner.AndroidJUnit4
+import com.mapbox.mapboxsdk.testapp.activity.snapshot.MapSnapshotterMarkerActivity
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Integration test that validates if a snapshot is created with MapSnapshotterMarkerActivity
+ */
+@RunWith(AndroidJUnit4::class)
+class MapSnapshotterTest {
+
+  @Rule
+  @JvmField
+  var rule = ActivityTestRule(MapSnapshotterMarkerActivity::class.java)
+
+  @Test(timeout = 10000)
+  fun mapSnapshotter() {
+    while (rule.activity.mapSnapshot == null) {
+      Thread.sleep(250)
+    }
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/activity/BaseTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/activity/BaseTest.java
@@ -1,5 +1,6 @@
 package com.mapbox.mapboxsdk.testapp.activity;
 
+import android.content.Context;
 import android.support.annotation.CallSuper;
 import android.support.annotation.UiThread;
 import android.support.test.rule.ActivityTestRule;
@@ -93,6 +94,10 @@ public abstract class BaseTest extends AppCenter {
       Timber.e("Timeout occurred for %s", testName.getMethodName());
       validateTestSetup();
     }
+  }
+
+  protected Context getContext() {
+    return rule.getActivity();
   }
 
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/snapshot/MapSnapshotterMarkerActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/snapshot/MapSnapshotterMarkerActivity.java
@@ -6,6 +6,8 @@ import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.PointF;
 import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MotionEvent;
 import android.view.View;
@@ -64,6 +66,7 @@ public class MapSnapshotterMarkerActivity extends AppCompatActivity implements M
   @SuppressLint("ClickableViewAccessibility")
   @Override
   public void onSnapshotReady(MapSnapshot snapshot) {
+    this.mapSnapshot = snapshot;
     Timber.i("Snapshot ready");
     ImageView imageView = (ImageView) findViewById(R.id.snapshot_image);
     Bitmap image = addMarker(snapshot);
@@ -91,6 +94,12 @@ public class MapSnapshotterMarkerActivity extends AppCompatActivity implements M
       null
     );
     return snapshot.getBitmap();
+  }
+
+  @VisibleForTesting
+  @Nullable
+  public MapSnapshot getMapSnapshot() {
+    return mapSnapshot;
   }
 
 }


### PR DESCRIPTION
This PR adds two instrumentation tests around our MapSnapshotter and Offline Download API. Due to https://github.com/mapbox/mapbox-gl-native/issues/14760, I'm running the snapshotter code inside the Activity and verifying the result from the test.
