### PR TITLE
Reinitialize token dependent components when a new one is provided

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
+
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.exceptions.MapboxConfigurationException;
 import com.mapbox.mapboxsdk.log.Logger;
@@ -87,6 +88,20 @@ public final class Mapbox {
   public static void setAccessToken(String accessToken) {
     validateMapbox();
     INSTANCE.accessToken = accessToken;
+
+    // cleanup telemetry which is dependent on an access token
+    if (INSTANCE.telemetry != null) {
+      INSTANCE.telemetry.disableTelemetrySession();
+      INSTANCE.telemetry = null;
+    }
+
+    // initialize components dependent on a token
+    if (isAccessTokenValid(accessToken)) {
+      initializeTelemetry();
+      INSTANCE.accounts = new AccountsManager();
+    } else {
+      INSTANCE.accounts = null;
+    }
     FileSource.getInstance(getApplicationContext()).setAccessToken(accessToken);
   }
 
@@ -97,6 +112,13 @@ public final class Mapbox {
    * @return the SKU token
    */
   public static String getSkuToken() {
+    if (INSTANCE.accounts == null) {
+      throw new MapboxConfigurationException(
+        "A valid access token parameter is required when using a Mapbox service."
+          + "\nPlease see https://www.mapbox.com/help/create-api-access-token/ to learn how to create one."
+          + "\nMore information in this guide https://www.mapbox.com/help/first-steps-android-sdk/#access-tokens."
+          + "Currently provided token is: " + INSTANCE.accessToken);
+    }
     return INSTANCE.accounts.getSkuToken();
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
@@ -85,7 +85,7 @@ public final class Mapbox {
   /**
    * Set the current active accessToken.
    */
-  public static void setAccessToken(String accessToken) {
+  public static void setAccessToken(@Nullable String accessToken) {
     validateMapbox();
     INSTANCE.accessToken = accessToken;
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/exceptions/MapboxConfigurationException.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/exceptions/MapboxConfigurationException.java
@@ -1,6 +1,7 @@
 package com.mapbox.mapboxsdk.exceptions;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 
 /**
  * A MapboxConfigurationException is thrown by MapboxMap when the SDK hasn't been properly initialised.
@@ -21,5 +22,12 @@ public class MapboxConfigurationException extends RuntimeException {
       + "inflating or creating the view. The access token parameter is required when using a Mapbox service."
       + "\nPlease see https://www.mapbox.com/help/create-api-access-token/ to learn how to create one."
       + "\nMore information in this guide https://www.mapbox.com/help/first-steps-android-sdk/#access-tokens.");
+  }
+
+  /**
+   * Creates a Mapbox configuration exception thrown by MapboxMap when the SDK hasn't been properly initialised.
+   */
+  public MapboxConfigurationException(@NonNull String message) {
+    super(message);
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/TelemetryDefinition.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/TelemetryDefinition.java
@@ -33,6 +33,11 @@ public interface TelemetryDefinition {
   void setUserTelemetryRequestState(boolean enabled);
 
   /**
+   * Disables a started telemetry service for this session only.
+   */
+  void disableTelemetrySession();
+
+  /**
    * Set the end-user selected state to participate or opt-out in telemetry collection.
    */
   void setDebugLoggingEnabled(boolean debugLoggingEnabled);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/telemetry/TelemetryImpl.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/telemetry/TelemetryImpl.java
@@ -79,6 +79,11 @@ public class TelemetryImpl implements TelemetryDefinition {
     }
   }
 
+  @Override
+  public void disableTelemetrySession() {
+    telemetry.disable();
+  }
+
   /**
    * Set the debug logging state of telemetry.
    *

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
@@ -380,7 +380,7 @@ public class FileSource {
   public native void deactivate();
 
   @Keep
-  public native void setAccessToken(@NonNull String accessToken);
+  public native void setAccessToken(@Nullable String accessToken);
 
   @NonNull
   @Keep

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/MapboxTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/MapboxTest.java
@@ -5,10 +5,18 @@ import android.support.test.runner.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.AppCenter;
 import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.exceptions.MapboxConfigurationException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertSame;
 import static junit.framework.Assert.assertTrue;
 
@@ -17,6 +25,16 @@ public class MapboxTest extends AppCenter {
 
   private static final String ACCESS_TOKEN = "pk.0000000001";
   private static final String ACCESS_TOKEN_2 = "pk.0000000002";
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  private String realToken;
+
+  @Before
+  public void setup() {
+    realToken = Mapbox.getAccessToken();
+  }
 
   @Test
   @UiThreadTest
@@ -37,11 +55,57 @@ public class MapboxTest extends AppCenter {
   @Test
   @UiThreadTest
   public void setAccessToken() {
-    String realToken =  Mapbox.getAccessToken();
     Mapbox.setAccessToken(ACCESS_TOKEN);
     assertSame(ACCESS_TOKEN, Mapbox.getAccessToken());
     Mapbox.setAccessToken(ACCESS_TOKEN_2);
     assertSame(ACCESS_TOKEN_2, Mapbox.getAccessToken());
+  }
+
+  @Test
+  @UiThreadTest
+  public void setInvalidAccessToken() {
+    final String invalidAccessToken = "xyz";
+    expectedException.expect(MapboxConfigurationException.class);
+    expectedException.expectMessage(
+      "A valid access token parameter is required when using a Mapbox service."
+        + "\nPlease see https://www.mapbox.com/help/create-api-access-token/ to learn how to create one."
+        + "\nMore information in this guide https://www.mapbox.com/help/first-steps-android-sdk/#access-tokens."
+        + "Currently provided token is: " + invalidAccessToken
+    );
+
+    Mapbox.setAccessToken(invalidAccessToken);
+    assertNull(Mapbox.getTelemetry());
+    Mapbox.getSkuToken();
+  }
+
+  @Test
+  @UiThreadTest
+  public void setNullAccessToken() {
+    expectedException.expect(MapboxConfigurationException.class);
+    expectedException.expectMessage(
+      "A valid access token parameter is required when using a Mapbox service."
+        + "\nPlease see https://www.mapbox.com/help/create-api-access-token/ to learn how to create one."
+        + "\nMore information in this guide https://www.mapbox.com/help/first-steps-android-sdk/#access-tokens."
+        + "Currently provided token is: " + null
+    );
+
+    Mapbox.setAccessToken(null);
+    assertNull(Mapbox.getTelemetry());
+    Mapbox.getSkuToken();
+  }
+
+  @Test
+  @UiThreadTest
+  public void setValidAccessToken() {
+    final String invalidAccessToken = "xyz";
+    Mapbox.setAccessToken(invalidAccessToken);
+    Mapbox.setAccessToken(ACCESS_TOKEN);
+    assertNotNull(Mapbox.getTelemetry());
+    assertNotNull(Mapbox.getSkuToken());
+  }
+
+  @After
+  public void tearDown() {
     Mapbox.setAccessToken(realToken);
   }
 }

--- a/platform/android/src/file_source.cpp
+++ b/platform/android/src/file_source.cpp
@@ -48,7 +48,7 @@ jni::Local<jni::String> FileSource::getAccessToken(jni::JNIEnv& env) {
 }
 
 void FileSource::setAccessToken(jni::JNIEnv& env, const jni::String& token) {
-    fileSource->setAccessToken(jni::Make<std::string>(env, token));
+    fileSource->setAccessToken(token ? jni::Make<std::string>(env, token) : "");
 }
 
 void FileSource::setAPIBaseUrl(jni::JNIEnv& env, const jni::String& url) {


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/15063.

Changes in this PR:
 - Throw a configuration exception when Mapbox services are accessed with an invalid access token, which previously resulted in a caught NPE and a blank map (https://github.com/mapbox/mapbox-gl-native/issues/15063).
- Recreate telemetry service when a new, valid access token is supplied. From what I can see, we'd be sending telemetry events with a wrong token otherwise. If an invalid one/`null` is provided, telemetry will be stopped.
 - Allow setting a `null` access token in the runtime, just like we allow during initialization.