### PR TITLE
[core] Return the missing gl backend guard to Renderer::reduceMemoryUse()

### DIFF
--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -102,6 +102,7 @@ GLFWView::GLFWView(bool fullscreen_, bool benchmark_)
     glfwSetFramebufferSizeCallback(window, onFramebufferResize);
     glfwSetScrollCallback(window, onScroll);
     glfwSetKeyCallback(window, onKey);
+    glfwSetWindowFocusCallback(window, onWindowFocus);
 
     glfwGetWindowSize(window, &width, &height);
 
@@ -557,6 +558,13 @@ void GLFWView::onMouseMove(GLFWwindow *window, double x, double y) {
     }
     view->lastX = x;
     view->lastY = y;
+}
+
+void GLFWView::onWindowFocus(GLFWwindow *window, int focused) {
+    if (focused == GLFW_FALSE) { // Focus lost.
+        auto *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
+        view->rendererFrontend->getRenderer()->reduceMemoryUse();
+    }
 }
 
 void GLFWView::run() {

--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -68,6 +68,7 @@ private:
     static void onFramebufferResize(GLFWwindow *window, int width, int height);
     static void onMouseClick(GLFWwindow *window, int button, int action, int modifiers);
     static void onMouseMove(GLFWwindow *window, double x, double y);
+    static void onWindowFocus(GLFWwindow *window, int focused);
 
     // Internal
     void report(float duration);

--- a/src/mbgl/renderer/renderer.cpp
+++ b/src/mbgl/renderer/renderer.cpp
@@ -116,6 +116,7 @@ void Renderer::dumpDebugLogs() {
 }
 
 void Renderer::reduceMemoryUse() {
+    gfx::BackendScope guard { impl->backend };
     impl->reduceMemoryUse();
     impl->orchestrator.reduceMemoryUse();
 }


### PR DESCRIPTION
Fixes #15037