### PR TITLE
[ios] Fix incorrect center coordinate after pinch gesture

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -41,6 +41,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Deprecated variants of the above methods without completion handlers. ([#14959](https://github.com/mapbox/mapbox-gl-native/pull/14959))
 * Fixed an issue where the two-finger tilt gesture would continue after lifting one finger. ([#14969](https://github.com/mapbox/mapbox-gl-native/pull/14969))
 * Added `MGLMapView.compassView.visibility` and `MGLOrnamentVisibility` to allow configuration of compass visibility behavior. ([#15055](https://github.com/mapbox/mapbox-gl-native/pull/15055))
+* Fixed a bug where using the pinch gesture could result in an incorrect map center coordinate. ([#15097](https://github.com/mapbox/mapbox-gl-native/pull/15097))
 
 ## 5.1.0 - June 19, 2019
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -297,8 +297,8 @@ public:
 
     NSInteger _changeDelimiterSuppressionDepth;
 
-    /// Center coordinate of the pinch gesture on the previous iteration of the gesture.
-    CLLocationCoordinate2D _previousPinchCenterCoordinate;
+    /// Center of the pinch gesture on the previous iteration of the gesture.
+    CGPoint _previousPinchCenterPoint;
     NSUInteger _previousPinchNumberOfTouches;
     
     CLLocationDistance _distanceFromOldUserLocation;
@@ -1643,11 +1643,7 @@ public:
             // meaningless.
             if (self.userTrackingMode == MGLUserTrackingModeNone && pinch.numberOfTouches == _previousPinchNumberOfTouches)
             {
-                CLLocationCoordinate2D centerCoordinate = _previousPinchCenterCoordinate;
-                mbgl::EdgeInsets padding { centerPoint.y, centerPoint.x, self.size.height - centerPoint.y, self.size.width - centerPoint.x };
-                self.mbglMap.jumpTo(mbgl::CameraOptions()
-                                        .withCenter(MGLLatLngFromLocationCoordinate2D(centerCoordinate))
-                                        .withPadding(padding));
+                self.mbglMap.moveBy({centerPoint.x - _previousPinchCenterPoint.x, centerPoint.y - _previousPinchCenterPoint.y});
             }
         }
         [self cameraIsChanging];
@@ -1705,7 +1701,7 @@ public:
         [self unrotateIfNeededForGesture];
     }
 
-    _previousPinchCenterCoordinate = [self convertPoint:centerPoint toCoordinateFromView:self];
+    _previousPinchCenterPoint = centerPoint;
     _previousPinchNumberOfTouches = pinch.numberOfTouches;
 }
 


### PR DESCRIPTION
To changelogs:
Fixed incorrect center coordinate after pinch regression caused by edge insets fix (#14664).

While working on #14664, missed to understand the logic used in

```
                CLLocationCoordinate2D centerCoordinate = _previousPinchCenterCoordinate;
                mbgl::EdgeInsets padding { centerPoint.y, centerPoint.x, self.size.height - centerPoint.y, self.size.width - centerPoint.x };
                self.mbglMap.jumpTo(mbgl::CameraOptions()
                                        .withCenter(MGLLatLngFromLocationCoordinate2D(centerCoordinate))
                                        .withPadding(padding));

```

Replacing this code by moveBy achieves the required translation.

Fixes #14977 and fixes #15082.