### PR TITLE
Add build variant to run ui/application monkey exerciser

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -75,6 +75,9 @@ android {
             testCoverageEnabled true
             jniDebuggable true
         }
+        monkey {
+            initWith debug
+        }
     }
 }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -47,11 +47,14 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.debug
         }
+        monkey {
+            initWith debug
+        }
     }
 
     dexOptions {
-        maxProcessCount 8
-        javaMaxHeapSize "2g"
+        maxProcessCount 16
+        javaMaxHeapSize "4g"
         preDexLibraries true
     }
 }
@@ -70,6 +73,7 @@ dependencies {
     implementation dependenciesList.gmsLocation
     implementation dependenciesList.timber
     debugImplementation dependenciesList.leakCanaryDebug
+    monkeyImplementation dependenciesList.leakCanaryRelease
     releaseImplementation dependenciesList.leakCanaryRelease
 
     androidTestImplementation dependenciesList.supportAnnotations
@@ -86,8 +90,7 @@ apply from: "${rootDir}/gradle/gradle-make.gradle"
 apply from: "${rootDir}/gradle/gradle-config.gradle"
 apply from: "${rootDir}/gradle/gradle-checkstyle.gradle"
 apply from: "${rootDir}/gradle/gradle-lint.gradle"
-
-
+apply from: "${rootDir}/gradle/monkey-runner.gradle"
 
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/MapboxApplication.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/MapboxApplication.java
@@ -3,7 +3,6 @@ package com.mapbox.mapboxsdk.testapp;
 import android.app.Application;
 import android.os.StrictMode;
 import android.text.TextUtils;
-
 import com.mapbox.mapboxsdk.MapStrictMode;
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.log.Logger;
@@ -12,7 +11,6 @@ import com.mapbox.mapboxsdk.testapp.utils.TileLoadingMeasurementUtils;
 import com.mapbox.mapboxsdk.testapp.utils.TimberLogger;
 import com.mapbox.mapboxsdk.testapp.utils.TokenUtils;
 import com.squareup.leakcanary.LeakCanary;
-
 import timber.log.Timber;
 
 import static timber.log.Timber.DebugTree;
@@ -60,17 +58,19 @@ public class MapboxApplication extends Application {
   }
 
   private void initializeStrictMode() {
-    StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
-      .detectDiskReads()
-      .detectDiskWrites()
-      .detectNetwork()
-      .penaltyLog()
-      .build());
-    StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
-      .detectLeakedSqlLiteObjects()
-      .penaltyLog()
-      .penaltyDeath()
-      .build());
+    if (isDebugBuild()) {
+      StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
+        .detectDiskReads()
+        .detectDiskWrites()
+        .detectNetwork()
+        .penaltyLog()
+        .build());
+      StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
+        .detectLeakedSqlLiteObjects()
+        .penaltyLog()
+        .penaltyDeath()
+        .build());
+    }
   }
 
   private void initializeMapbox() {
@@ -84,12 +84,22 @@ public class MapboxApplication extends Application {
     telemetry.setDebugLoggingEnabled(true);
     TileLoadingMeasurementUtils.setUpTileLoadingMeasurement();
 
-    MapStrictMode.setStrictModeEnabled(true);
+    if (!isMonkeyBuild()) {
+      MapStrictMode.setStrictModeEnabled(true);
+    }
   }
 
   private static void validateAccessToken(String accessToken) {
     if (TextUtils.isEmpty(accessToken) || accessToken.equals(DEFAULT_MAPBOX_ACCESS_TOKEN)) {
       Timber.e(ACCESS_TOKEN_NOT_SET_MESSAGE);
     }
+  }
+
+  private boolean isMonkeyBuild() {
+    return BuildConfig.BUILD_TYPE.contentEquals("monkey");
+  }
+
+  private boolean isDebugBuild() {
+    return BuildConfig.BUILD_TYPE.contentEquals("debug");
   }
 }

--- a/platform/android/gradle/monkey-runner.gradle
+++ b/platform/android/gradle/monkey-runner.gradle
@@ -1,0 +1,5 @@
+task runMonkey(type: Exec) {
+    dependsOn 'installMonkey'
+    commandLine "adb shell monkey -p com.mapbox.mapboxsdk.testapp -c android.intent.category.LAUNCHER 1".split(" ")
+    commandLine "adb", "shell", "monkey", "-p", "com.mapbox.mapboxsdk.testapp", "-v", "--pct-nav", "10", "--pct-syskeys", "2", "--pct-anyevent", "2", "--pct-touch", "44", "--pct-motion", "40", "--pct-trackball", "2", "--monitor-native-crashes", "20000"
+}

--- a/platform/android/tests/docs/EXERCISER_TESTS.md
+++ b/platform/android/tests/docs/EXERCISER_TESTS.md
@@ -2,22 +2,19 @@
 
 UI/application exerciser tests are stress test using random generated users events.
 
-##Running Locally
+# Monkey Exerciser
 
-The Android SDK provides a test tool called [Monkey](http://developer.android.com/tools/help/monkey.html),
+The Android SDK provides a test tool called [UI/Application Monkey Exerciser](https://developer.android.com/studio/test/monkey),
 "a program that runs on your emulator or device and generates pseudo-random streams of user events
 such as clicks, touches, or gestures, as well as a number of system-level events."
 
-To exercise Monkey on the test app, install the package on the device (e.g. via Android Studio)
-and then:
+## Setup
 
-```
-$ adb shell monkey -p com.mapbox.mapboxgl.testapp -v 500
-```
-
-##Running on AWS Device Farm
-
-Amazon Device farm supports a similar tool called `Built-in Fuzz Test`.
-"The built-in fuzz test randomly sends user interface events to devices and then reports results."
-
-More information about [Built-in Fuzz Test](http://docs.aws.amazon.com/devicefarm/latest/developerguide/test-types-built-in-fuzz.html)
+ - install the qa debug build variant of the test application
+ - pin app on screen (this avoid opening statusbar through monkey exerciser)
+   - activate with `settings>security>screen pinning`
+   - press the recents apps button
+   - each app will support a configuration to pin it 
+ - run an monkey exerciser with a commands as:
+   - `adb shell monkey -p com.mapbox.mapboxsdk.testapp -v --pct-nav 10 --pct-syskeys 2 --pct-anyevent 2 --pct-touch 44 --pct-motion 40 --pct-trackball 2 --monitor-native-crashes 20000`
+   - more information on configuration settings in [official docs](https://developer.android.com/studio/test/monkey#command-options-reference)


### PR DESCRIPTION
Replaces #15018, this PR adds a new build variant for running monkey tests. This `qa` build variant enables testing a debug build but with having a couple components disabled that intervene with the  ui/application monkey exerciser (eg. leakcanary).