### PR TITLE
[core] RenderCustomGeometrySource should clear tiles after style update

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -4,6 +4,9 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 
 ## master
 
+### Bugs
+ - Fixed a custom geometry source bug caused by using the outdated tiles after style update [#15112](https://github.com/mapbox/mapbox-gl-native/pull/15112)
+
 ## 8.2.0-alpha.3 - July 11, 2019
 
 ### Bugs

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## master
+
+### Styles and rendering
+
+* Fixed a custom geometry source bug caused by using the outdated tiles after style update [#15112](https://github.com/mapbox/mapbox-gl-native/pull/15112)
+
 ## 5.2.0
 
 ### Offline maps

--- a/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
+++ b/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
@@ -21,7 +21,10 @@ void RenderCustomGeometrySource::update(Immutable<style::Source::Impl> baseImpl_
                                  const bool needsRendering,
                                  const bool needsRelayout,
                                  const TileParameters& parameters) {
-    std::swap(baseImpl, baseImpl_);
+    if (baseImpl != baseImpl_) {
+        std::swap(baseImpl, baseImpl_);
+        tilePyramid.clearAll();
+    }
 
     enabled = needsRendering;
 


### PR DESCRIPTION
Otherwise, the remaining stale tiles cannot be updated.

fixes #15111