### PR TITLE
[ios, macos] Change "map ID" to "tileset ID"

### DIFF
--- a/platform/darwin/src/MGLMapSnapshotter.h
+++ b/platform/darwin/src/MGLMapSnapshotter.h
@@ -15,7 +15,7 @@ MGL_EXPORT
  Creates a set of options with the minimum required information.
  
  @param styleURL URL of the map style to snapshot. The URL may be a full HTTP or
-    HTTPS URL, a Mapbox URL indicating the style’s map ID
+    HTTPS URL, a Mapbox style URL 
     (`mapbox://styles/{user}/{style}`), or a path to a local file relative to
     the application’s resource path. Specify `nil` for the default style.
  @param size The image size.

--- a/platform/darwin/src/MGLOfflineRegion.h
+++ b/platform/darwin/src/MGLOfflineRegion.h
@@ -14,8 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
  In addition to the JSON stylesheet, different styles may require different font
  glyphs, sprite sheets, and other resources.
  
- The URL may be a full HTTP or HTTPS URL or a Mapbox URL indicating the style’s
- map ID (`mapbox://styles/{user}/{style}`).
+ The URL may be a full HTTP or HTTPS URL or a Mapbox
+ style URL (`mapbox://styles/{user}/{style}`).
  */
 @property (nonatomic, readonly) NSURL *styleURL;
 

--- a/platform/darwin/src/MGLRasterTileSource.h
+++ b/platform/darwin/src/MGLRasterTileSource.h
@@ -70,13 +70,13 @@ MGL_EXPORT
  After initializing and configuring the source, add it to a map view’s style
  using the `-[MGLStyle addSource:]` method.
 
- The URL may be a full HTTP or HTTPS URL or, for tile sets hosted by Mapbox, a
- Mapbox URL indicating a map identifier (`mapbox://<mapid>`). The URL should
+ The URL may be a full HTTP or HTTPS URL or, for tilesets hosted by Mapbox, a
+ Mapbox URL indicating a tileset ID (`mapbox://<tilesetid>`). The URL should
  point to a JSON file that conforms to the
  <a href="https://github.com/mapbox/tilejson-spec/">TileJSON specification</a>.
 
  If a Mapbox URL is specified, this source uses a tile size of 256. For all
- other tile sets, the default value is 512. (See the
+ other tilesets, the default value is 512. (See the
  `MGLTileSourceOptionTileSize` documentation for more information about tile
  sizes.) If you need to use a tile size other than the default, use the
  `-initWithIdentifier:configurationURL:tileSize:` method.
@@ -96,8 +96,8 @@ MGL_EXPORT
  After initializing and configuring the source, add it to a map view’s style
  using the `-[MGLStyle addSource:]` method.
 
- The URL may be a full HTTP or HTTPS URL or, for tile sets hosted by Mapbox, a
- Mapbox URL indicating a map identifier (`mapbox://<mapid>`). The URL should
+ The URL may be a full HTTP or HTTPS URL or, for tilesets hosted by Mapbox, a
+ Mapbox URL indicating a tileset ID (`mapbox://<tilesetid>`). The URL should
  point to a JSON file that conforms to the
  <a href="https://github.com/mapbox/tilejson-spec/">TileJSON specification</a>.
 

--- a/platform/darwin/src/MGLShapeOfflineRegion.h
+++ b/platform/darwin/src/MGLShapeOfflineRegion.h
@@ -59,8 +59,8 @@ MGL_EXPORT
  This is the designated initializer for `MGLShapeOfflineRegion`.
 
  @param styleURL URL of the map style for which to download resources. The URL
-    may be a full HTTP or HTTPS URL or a Mapbox URL indicating the style’s map
-    ID (`mapbox://styles/{user}/{style}`). Specify `nil` for the default style.
+    may be a full HTTP or HTTPS URL or a Mapbox
+    style URL (`mapbox://styles/{user}/{style}`). Specify `nil` for the default style.
     Relative file URLs cannot be used as offline style URLs. To download the
     online resources required by a local style, specify a URL to an online copy
     of the style.

--- a/platform/darwin/src/MGLTilePyramidOfflineRegion.h
+++ b/platform/darwin/src/MGLTilePyramidOfflineRegion.h
@@ -61,8 +61,8 @@ MGL_EXPORT
  This is the designated initializer for `MGLTilePyramidOfflineRegion`.
 
  @param styleURL URL of the map style for which to download resources. The URL
-    may be a full HTTP or HTTPS URL or a Mapbox URL indicating the style’s map
-    ID (`mapbox://styles/{user}/{style}`). Specify `nil` for the default style.
+    may be a full HTTP or HTTPS URL or a Mapbox
+    style URL (`mapbox://styles/{user}/{style}`). Specify `nil` for the default style.
     Relative file URLs cannot be used as offline style URLs. To download the
     online resources required by a local style, specify a URL to an online copy
     of the style.

--- a/platform/darwin/src/MGLVectorTileSource.h
+++ b/platform/darwin/src/MGLVectorTileSource.h
@@ -71,8 +71,8 @@ MGL_EXPORT
  After initializing and configuring the source, add it to a map view’s style
  using the `-[MGLStyle addSource:]` method.
 
- The URL may be a full HTTP or HTTPS URL or, for tile sets hosted by Mapbox, a
- Mapbox URL indicating a map identifier (`mapbox://<mapid>`). The URL should
+ The URL may be a full HTTP or HTTPS URL or, for tilesets hosted by Mapbox, a
+ Mapbox URL indicating a tileset ID (`mapbox://<tilesetid>`). The URL should
  point to a JSON file that conforms to the
  <a href="https://github.com/mapbox/tilejson-spec/">TileJSON specification</a>.
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -8,6 +8,9 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Fixed a custom geometry source bug caused by using the outdated tiles after style update [#15112](https://github.com/mapbox/mapbox-gl-native/pull/15112)
 
+### Other changes
+* Updated "map ID" to the more accurate term "tileset ID" in documentation; updated "style's Map ID" to the more accurate term "style URL". ([#15116](https://github.com/mapbox/mapbox-gl-native/pull/15116))
+
 ## 5.2.0
 
 ### Offline maps
@@ -234,7 +237,7 @@ There are no breaking API changes in this release.
 * Added `-[MGLOfflineStorage addContentsOfFile:withCompletionHandler:]` and `-[MGLOfflineStorage addContentsOfURL:withCompletionHandler:]` methods to add pregenerated offline packs to offline storage. ([#12791](https://github.com/mapbox/mapbox-gl-native/pull/12791))
 * Fixed an issue where some tiles were rendered incorrectly when the device was unable to connect to the Internet. ([#12931](https://github.com/mapbox/mapbox-gl-native/pull/12931))
 
-### Other changes	
+### Other changes
 
 * Added `MGLAltitudeForZoomLevel()` and `MGLZoomLevelForAltitude()` methods for converting between zoom levels used by `MGLMapView` and altitudes used by `MGLMapCamera`. ([#12986](https://github.com/mapbox/mapbox-gl-native/pull/12986))
 * Deprecated the `+[MGLMapCamera cameraLookingAtCenterCoordinate:fromDistance:pitch:heading:]` method in favor of `+[MGLMapCamera cameraLookingAtCenterCoordinate:altitude:pitch:heading:]` and `+[MGLMapCamera cameraLookingAtCenterCoordinate:acrossDistance:pitch:heading:]`. ([#12966](https://github.com/mapbox/mapbox-gl-native/pull/12966))

--- a/platform/ios/Integration Tests/MGLStyleLayerIntegrationTests.m
+++ b/platform/ios/Integration Tests/MGLStyleLayerIntegrationTests.m
@@ -8,8 +8,8 @@
 - (MGLCircleStyleLayer*)setupCircleStyleLayer {
     // Adapted from https://docs.mapbox.com/ios/examples/dds-circle-layer/
 
-    // "mapbox://examples.2uf7qges" is a map ID referencing a tileset. For more
-    // more information, see docs.mapbox.com/help/glossary/map-id/
+    // "mapbox://examples.2uf7qges" is a tileset ID. For more
+    // more information, see docs.mapbox.com/help/glossary/tileset-id/
     MGLSource *source = [[MGLVectorTileSource alloc] initWithIdentifier:@"trees" configurationURL:[NSURL URLWithString:@"mapbox://examples.2uf7qges"]];
     [self.mapView.style addSource:source];
 

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -198,7 +198,7 @@ MGL_EXPORT
 
  @param frame The frame for the view, measured in points.
  @param styleURL URL of the map style to display. The URL may be a full HTTP
-    or HTTPS URL, a Mapbox URL indicating the style’s map ID
+    or HTTPS URL, a Mapbox style URL
     (`mapbox://styles/{user}/{style}`), or a path to a local file relative
     to the application’s resource path. Specify `nil` for the default style.
  @return An initialized map view.
@@ -255,8 +255,8 @@ MGL_EXPORT
 /**
  URL of the style currently displayed in the receiver.
 
- The URL may be a full HTTP or HTTPS URL, a Mapbox URL indicating the style’s
- map ID (`mapbox://styles/{user}/{style}`), or a path to a local file
+ The URL may be a full HTTP or HTTPS URL, a Mapbox
+ style URL (`mapbox://styles/{user}/{style}`), or a path to a local file
  relative to the application’s resource path.
 
  If you set this property to `nil`, the receiver will use the default style

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Added an `MGLMapView.prefetchesTiles` property to configure lower-resolution tile prefetching behavior. ([#14816](https://github.com/mapbox/mapbox-gl-native/pull/14816))
 * Fixed queryRenderedFeatues bug caused by incorrect sort feature index calculation. ([#14884](https://github.com/mapbox/mapbox-gl-native/pull/14884))
-* The `MGLIdeographicFontFamilyName` Info.plist key now also accepts an array of font family names, to customize font fallback behavior. It can also be set to a Boolean value of `NO` to force the SDK to typeset CJK characters in a remote font specified by `MGLSymbolStyleLayer.textFontNames`. ([#14862](https://github.com/mapbox/mapbox-gl-native/pull/14862)) 
+* The `MGLIdeographicFontFamilyName` Info.plist key now also accepts an array of font family names, to customize font fallback behavior. It can also be set to a Boolean value of `NO` to force the SDK to typeset CJK characters in a remote font specified by `MGLSymbolStyleLayer.textFontNames`. ([#14862](https://github.com/mapbox/mapbox-gl-native/pull/14862))
 * Performance improvements for queryRenderedFeatures API and optimization that allocates containers based on a number of rendered layers. ([#14930](https://github.com/mapbox/mapbox-gl-native/pull/14930))
 * Fixed rendering layers after fill-extrusion regression caused by optimization of fill-extrusion rendering. ([#15065](https://github.com/mapbox/mapbox-gl-native/pull/15065))
 
@@ -17,6 +17,7 @@
 ### Other changes
 
 * The `-[MGLMapView setCamera:withDuration:animationTimingFunction:edgePadding:completionHandler:]` method now adds the current value of the `MGLMapView.contentInsets` property to the `edgePadding` parameter. ([#14813](https://github.com/mapbox/mapbox-gl-native/pull/14813))
+* Updated "map ID" to the more accurate term "tileset ID" in documentation; updated "style's Map ID" to the more accurate term "style URL". ([#15116](https://github.com/mapbox/mapbox-gl-native/pull/15116))
 
 ### Other changes
 

--- a/platform/macos/src/MGLMapView+IBAdditions.h
+++ b/platform/macos/src/MGLMapView+IBAdditions.h
@@ -21,8 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** URL of the style currently displayed in the receiver.
 
-    The URL may be a full HTTP or HTTPS URL, a Mapbox URL indicating the style’s
-    map ID (`mapbox://styles/<user>/<style>`), or a path to a local file
+    The URL may be a full HTTP or HTTPS URL, a Mapbox
+    style URL (`mapbox://styles/<user>/<style>`), or a path to a local file
     relative to the application’s resource path. Leave this field blank for the
     default style. */
 @property (nonatomic, nullable) IBInspectable NSString *styleURL__;

--- a/platform/macos/src/MGLMapView.h
+++ b/platform/macos/src/MGLMapView.h
@@ -84,7 +84,7 @@ MGL_EXPORT IB_DESIGNABLE
 
  @param frame The frame for the view, measured in points.
  @param styleURL URL of the map style to display. The URL may be a full HTTP or
-    HTTPS URL, a Mapbox URL indicating the style’s map ID
+    HTTPS URL, a Mapbox style URL
     (`mapbox://styles/<user>/<style>`), or a path to a local file relative to
     the application’s resource path. Specify `nil` for the default style.
  @return An initialized map view.
@@ -130,8 +130,8 @@ MGL_EXPORT IB_DESIGNABLE
 /**
  URL of the style currently displayed in the receiver.
 
- The URL may be a full HTTP or HTTPS URL, a Mapbox URL indicating the style’s
- map ID (`mapbox://styles/<user>/<style>`), or a path to a local file relative
+ The URL may be a full HTTP or HTTPS URL, a Mapbox
+ style URL (`mapbox://styles/<user>/<style>`), or a path to a local file relative
  to the application’s resource path.
 
  If you set this property to `nil`, the receiver will use the default style and


### PR DESCRIPTION
Background: We're changing instances of `map ID` to be the more accurate term `tileset ID` across all Mapbox documentation. @1ec5 also found a number of instances where the docs in this repo refer to `a style's map ID`, which is more accurately a [style URL](https://docs.mapbox.com/help/glossary/style-url/).

Per https://github.com/mapbox/mapbox-gl-native/issues/14551, this PR:
- Updates `map ID` to `tileset ID` where necessary
- Updates `style's map ID` to `style URL` where necessary

@captainbarbosa or @1ec5 to review, please! 🙏 