### PR TITLE
[ios] Added annotation selection tests with rotation & scaling of the map

### DIFF
--- a/platform/ios/Integration Tests/Annotation Tests/MGLAnnotationViewIntegrationTests.mm
+++ b/platform/ios/Integration Tests/Annotation Tests/MGLAnnotationViewIntegrationTests.mm
@@ -620,7 +620,7 @@ static const CGPoint kAnnotationRelativeScale = { 0.05f, 0.125f };
     CLLocationCoordinate2D coordinates[21];
     srand48(0);
     
-    for (int i = 0; i < 10; i++)
+    for (int i = 0; i < (int)(sizeof(coordinates)/sizeof(coordinates[0])); i++)
     {
         coordinates[i].latitude = drand48();
         coordinates[i].longitude = drand48();

--- a/platform/ios/Integration Tests/Annotation Tests/MGLAnnotationViewIntegrationTests.mm
+++ b/platform/ios/Integration Tests/Annotation Tests/MGLAnnotationViewIntegrationTests.mm
@@ -608,7 +608,15 @@ static const CGPoint kAnnotationRelativeScale = { 0.05f, 0.125f };
 }
 
 
+- (void)testShowingAnnotationsThenSelectingAnimated {
+    [self internalTestShowingAnnotationsThenSelectingAnimated:YES];
+}
+
 - (void)testShowingAnnotationsThenSelecting {
+    [self internalTestShowingAnnotationsThenSelectingAnimated:NO];
+}
+
+- (void)internalTestShowingAnnotationsThenSelectingAnimated:(BOOL)animated {
     CLLocationCoordinate2D coordinates[21];
     srand48(0);
     
@@ -633,13 +641,15 @@ static const CGPoint kAnnotationRelativeScale = { 0.05f, 0.125f };
 
     [self.mapView showAnnotations:annotations
                       edgePadding:edgeInsets
-                         animated:YES
+                         animated:animated
                 completionHandler:^{
                     [showCompleted fulfill];
                 }];
     
     [self waitForExpectations:@[showCompleted] timeout:3.5];
-    
+  
+    // These tests will fail if this isn't here. But this isn't quite what we're
+    // seeing in https://github.com/mapbox/mapbox-gl-native/issues/15106
     [self waitForCollisionDetectionToRun];
     
     for (MGLPointAnnotation *point in annotations) {

--- a/platform/ios/Integration Tests/MGLMapViewIntegrationTest.m
+++ b/platform/ios/Integration Tests/MGLMapViewIntegrationTest.m
@@ -2,6 +2,7 @@
 
 @interface MGLMapView (MGLMapViewIntegrationTest)
 - (void)updateFromDisplayLink:(CADisplayLink *)displayLink;
+- (void)setNeedsRerender;
 @end
 
 @implementation MGLMapViewIntegrationTest
@@ -133,7 +134,7 @@
 
 - (void)waitForMapViewToBeRenderedWithTimeout:(NSTimeInterval)timeout {
     XCTAssertNil(self.renderFinishedExpectation);
-    [self.mapView setNeedsDisplay];
+    [self.mapView setNeedsRerender];
     self.renderFinishedExpectation = [self expectationWithDescription:@"Map view should be rendered"];
     [self waitForExpectations:@[self.renderFinishedExpectation] timeout:timeout];
 }

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -510,7 +510,7 @@
 		CA55CD42202C16AA00CE7095 /* MGLCameraChangeReason.h in Headers */ = {isa = PBXBuildFile; fileRef = CA55CD3E202C16AA00CE7095 /* MGLCameraChangeReason.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CA65C4F821E9BB080068B0D4 /* MGLCluster.h in Headers */ = {isa = PBXBuildFile; fileRef = CA65C4F721E9BB080068B0D4 /* MGLCluster.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CA65C4F921E9BB080068B0D4 /* MGLCluster.h in Headers */ = {isa = PBXBuildFile; fileRef = CA65C4F721E9BB080068B0D4 /* MGLCluster.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CA6914B520E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA6914B420E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.m */; };
+		CA6914B520E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CA6914B420E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.mm */; };
 		CA7766832229C10E0008DE9E /* MGLCompactCalloutView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA8848451CBAFB9800AB86E3 /* MGLCompactCalloutView.m */; };
 		CA7766842229C11A0008DE9E /* SMCalloutView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA88488A1CBB037E00AB86E3 /* SMCalloutView.m */; };
 		CA86FF0E22D8D5A0009EB14A /* MGLNetworkConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA86FF0D22D8D5A0009EB14A /* MGLNetworkConfigurationTests.m */; };
@@ -1197,8 +1197,8 @@
 		CA55CD3E202C16AA00CE7095 /* MGLCameraChangeReason.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLCameraChangeReason.h; sourceTree = "<group>"; };
 		CA5E5042209BDC5F001A8A81 /* MGLTestUtility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MGLTestUtility.h; path = ../../darwin/test/MGLTestUtility.h; sourceTree = "<group>"; };
 		CA65C4F721E9BB080068B0D4 /* MGLCluster.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLCluster.h; sourceTree = "<group>"; };
-		CA6914B420E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MGLAnnotationViewIntegrationTests.m; path = "Annotation Tests/MGLAnnotationViewIntegrationTests.m"; sourceTree = "<group>"; };
 		CA86FF0D22D8D5A0009EB14A /* MGLNetworkConfigurationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLNetworkConfigurationTests.m; sourceTree = "<group>"; };
+		CA6914B420E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLAnnotationViewIntegrationTests.mm; path = "Annotation Tests/MGLAnnotationViewIntegrationTests.mm"; sourceTree = "<group>"; };
 		CA88DC2F21C85D900059ED5A /* MGLStyleURLIntegrationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLStyleURLIntegrationTest.m; sourceTree = "<group>"; };
 		CA8FBC0821A47BB100D1203C /* MGLRendererConfigurationTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLRendererConfigurationTests.mm; path = ../../darwin/test/MGLRendererConfigurationTests.mm; sourceTree = "<group>"; };
 		CAD9D0A922A86D6F001B25EE /* MGLResourceTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLResourceTests.mm; path = ../../darwin/test/MGLResourceTests.mm; sourceTree = "<group>"; };
@@ -1920,7 +1920,7 @@
 		CA6914B320E67F07002DB0EE /* Annotations */ = {
 			isa = PBXGroup;
 			children = (
-				CA6914B420E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.m */,
+				CA6914B420E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.mm */,
 			);
 			name = Annotations;
 			sourceTree = "<group>";
@@ -3196,7 +3196,7 @@
 				CAE7AD5520F46EF5003B6782 /* MGLMapSnapshotterSwiftTests.swift in Sources */,
 				CA0C27922076C804001CE5B7 /* MGLShapeSourceTests.m in Sources */,
 				077061DA215DA00E000FEF62 /* MGLTestLocationManager.m in Sources */,
-				CA6914B520E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.m in Sources */,
+				CA6914B520E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.mm in Sources */,
 				CA1B4A512099FB2200EDD491 /* MGLMapSnapshotterTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/platform/ios/src/MGLMapView_Private.h
+++ b/platform/ios/src/MGLMapView_Private.h
@@ -52,8 +52,6 @@ FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const _Nonnull MGLUnderlyingMapUna
 /// Synchronously render a frame of the map.
 - (void)renderSync;
 
-- (nonnull mbgl::Map *)mbglMap;
-
 - (nonnull mbgl::Renderer *)renderer;
 
 /** Returns whether the map view is currently loading or processing any assets required to render the map */

--- a/platform/ios/src/MGLMapView_Private.h
+++ b/platform/ios/src/MGLMapView_Private.h
@@ -52,6 +52,7 @@ FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const _Nonnull MGLUnderlyingMapUna
 /// Synchronously render a frame of the map.
 - (void)renderSync;
 
+- (nonnull mbgl::Map *)mbglMap;
 - (nonnull mbgl::Renderer *)renderer;
 
 /** Returns whether the map view is currently loading or processing any assets required to render the map */


### PR DESCRIPTION
WIP - needs some cleanup, but ok for an initial review.

Adds integration tests to check annotation selection after rotating or zooming the map (not via a gesture).
