### PR TITLE
[core] Fix flickering on style change

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -4,6 +4,9 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 
 ## master
 
+### Bug fixes
+ - Fixed flickering on style change for the same tile set [#15127](https://github.com/mapbox/mapbox-gl-native/pull/15127)
+
 ## 8.2.0-beta.1 - July 18, 2019
 [Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.2.0-alpha.3...android-v8.2.0-beta.1) since [Mapbox Maps SDK for Android v8.2.0-alpha.3](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.2.0-alpha.3):
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## master
+
+### Styles and rendering
+
+* Fixed flickering on style change for the same tile set ([#15127](https://github.com/mapbox/mapbox-gl-native/pull/15127))
+
+
 ## 5.2.0
 
 ### Networking
@@ -22,7 +29,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed style change transition regression caused by delayed setting of the updated layer properties. ([#15016](https://github.com/mapbox/mapbox-gl-native/pull/15016))
 * Fixed an issue where layers with fill extrusions would be incorrectly rendered above other layers. ([#15065](https://github.com/mapbox/mapbox-gl-native/pull/15065))
 * Improved feature querying performance. ([#14930](https://github.com/mapbox/mapbox-gl-native/pull/14930))
-* Fixed a custom geometry source bug caused by using the outdated tiles after style update [#15112](https://github.com/mapbox/mapbox-gl-native/pull/15112)
+* Fixed a custom geometry source bug caused by using the outdated tiles after style update ([#15112](https://github.com/mapbox/mapbox-gl-native/pull/15112))
 
 ### User interaction
 

--- a/src/mbgl/renderer/sources/render_raster_dem_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.cpp
@@ -4,6 +4,7 @@
 #include <mbgl/algorithm/update_tile_masks.hpp>
 #include <mbgl/geometry/dem_data.hpp>
 #include <mbgl/renderer/buckets/hillshade_bucket.hpp>
+#include <mbgl/renderer/tile_parameters.hpp>
 
 namespace mbgl {
 
@@ -27,16 +28,19 @@ void RenderRasterDEMSource::update(Immutable<style::Source::Impl> baseImpl_,
     enabled = needsRendering;
 
     optional<Tileset> _tileset = impl().getTileset();
-
-    if (tileset != _tileset) {
+    // In Continuous mode, keep the existing tiles if the new tileset is not
+    // yet available, thus providing smart style transitions without flickering.
+    // In other modes, allow clearing the tile pyramid first, before the early
+    // return in order to avoid render tests being flaky.
+    bool canUpdateTileset = _tileset || parameters.mode != MapMode::Continuous;
+    if (canUpdateTileset && tileset != _tileset) {
         tileset = _tileset;
         maxzoom = tileset->zoomRange.max;
         // TODO: this removes existing buckets, and will cause flickering.
         // Should instead refresh tile data in place.
         tilePyramid.clearAll();
     }
-    // Allow clearing the tile pyramid first, before the early return in case
-    //  the new tileset is not yet available or has an error in loading
+
     if (!_tileset) {
         return;
     }

--- a/src/mbgl/renderer/sources/render_raster_dem_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.cpp
@@ -11,50 +11,32 @@ namespace mbgl {
 using namespace style;
 
 RenderRasterDEMSource::RenderRasterDEMSource(Immutable<style::RasterSource::Impl> impl_)
-    : RenderTileSource(std::move(impl_)) {
+    : RenderTileSetSource(std::move(impl_)) {
 }
 
 const style::RasterSource::Impl& RenderRasterDEMSource::impl() const {
     return static_cast<const style::RasterSource::Impl&>(*baseImpl);
 }
 
-void RenderRasterDEMSource::update(Immutable<style::Source::Impl> baseImpl_,
-                                const std::vector<Immutable<LayerProperties>>& layers,
-                                const bool needsRendering,
-                                const bool needsRelayout,
-                                const TileParameters& parameters) {
-    std::swap(baseImpl, baseImpl_);
+const optional<Tileset>& RenderRasterDEMSource::getTileset() const {
+    return impl().tileset;
+}
 
-    enabled = needsRendering;
-
-    const optional<Tileset>& implTileset = impl().tileset;
-    // In Continuous mode, keep the existing tiles if the new tileset is not
-    // yet available, thus providing smart style transitions without flickering.
-    // In other modes, allow clearing the tile pyramid first, before the early
-    // return in order to avoid render tests being flaky.
-    bool canUpdateTileset = implTileset || parameters.mode != MapMode::Continuous;
-    if (canUpdateTileset && tileset != implTileset) {
-        tileset = implTileset;
-        maxzoom = tileset->zoomRange.max;
-        // TODO: this removes existing buckets, and will cause flickering.
-        // Should instead refresh tile data in place.
-        tilePyramid.clearAll();
-    }
-
-    if (!implTileset) {
-        return;
-    }
-
+void RenderRasterDEMSource::updateInternal(const Tileset& tileset,
+                                           const std::vector<Immutable<LayerProperties>>& layers,
+                                           const bool needsRendering,
+                                           const bool needsRelayout,
+                                           const TileParameters& parameters) {
     tilePyramid.update(layers,
                        needsRendering,
                        needsRelayout,
                        parameters,
                        SourceType::RasterDEM,
                        impl().getTileSize(),
-                       tileset->zoomRange,
-                       tileset->bounds,
+                       tileset.zoomRange,
+                       tileset.bounds,
                        [&] (const OverscaledTileID& tileID) {
-                           return std::make_unique<RasterDEMTile>(tileID, parameters, *tileset);
+                           return std::make_unique<RasterDEMTile>(tileID, parameters, tileset);
                        });
     algorithm::updateTileMasks(tilePyramid.getRenderedTiles());
 }

--- a/src/mbgl/renderer/sources/render_raster_dem_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.cpp
@@ -27,21 +27,21 @@ void RenderRasterDEMSource::update(Immutable<style::Source::Impl> baseImpl_,
 
     enabled = needsRendering;
 
-    optional<Tileset> _tileset = impl().getTileset();
+    const optional<Tileset>& implTileset = impl().tileset;
     // In Continuous mode, keep the existing tiles if the new tileset is not
     // yet available, thus providing smart style transitions without flickering.
     // In other modes, allow clearing the tile pyramid first, before the early
     // return in order to avoid render tests being flaky.
-    bool canUpdateTileset = _tileset || parameters.mode != MapMode::Continuous;
-    if (canUpdateTileset && tileset != _tileset) {
-        tileset = _tileset;
+    bool canUpdateTileset = implTileset || parameters.mode != MapMode::Continuous;
+    if (canUpdateTileset && tileset != implTileset) {
+        tileset = implTileset;
         maxzoom = tileset->zoomRange.max;
         // TODO: this removes existing buckets, and will cause flickering.
         // Should instead refresh tile data in place.
         tilePyramid.clearAll();
     }
 
-    if (!_tileset) {
+    if (!implTileset) {
         return;
     }
 

--- a/src/mbgl/renderer/sources/render_raster_dem_source.hpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.hpp
@@ -2,19 +2,12 @@
 
 #include <mbgl/renderer/sources/render_tile_source.hpp>
 #include <mbgl/style/sources/raster_source_impl.hpp>
-#include <mbgl/util/constants.hpp>
 
 namespace mbgl {
 
-class RenderRasterDEMSource final : public RenderTileSource {
+class RenderRasterDEMSource final : public RenderTileSetSource {
 public:
     explicit RenderRasterDEMSource(Immutable<style::RasterSource::Impl>);
-
-    void update(Immutable<style::Source::Impl>,
-                const std::vector<Immutable<style::LayerProperties>>&,
-                bool needsRendering,
-                bool needsRelayout,
-                const TileParameters&) final;
 
     std::unordered_map<std::string, std::vector<Feature>>
     queryRenderedFeatures(const ScreenLineString& geometry,
@@ -26,13 +19,16 @@ public:
     std::vector<Feature>
     querySourceFeatures(const SourceQueryOptions&) const override;
 
-    uint8_t getMaxZoom() const override { return maxzoom; }
-
 private:
-    const style::RasterSource::Impl& impl() const;
+    // RenderTileSetSource overrides
+    void updateInternal(const Tileset&,
+                        const std::vector<Immutable<style::LayerProperties>>&,
+                        bool needsRendering,
+                        bool needsRelayout,
+                        const TileParameters&) override;
+    const optional<Tileset>& getTileset() const override;
 
-    optional<Tileset> tileset;
-    uint8_t maxzoom = util::TERRAIN_RGB_MAXZOOM;
+    const style::RasterSource::Impl& impl() const;
 
     void onTileChanged(Tile&) override;
 };

--- a/src/mbgl/renderer/sources/render_raster_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_source.cpp
@@ -2,6 +2,7 @@
 #include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/tile/raster_tile.hpp>
 #include <mbgl/algorithm/update_tile_masks.hpp>
+#include <mbgl/renderer/tile_parameters.hpp>
 
 namespace mbgl {
 
@@ -25,16 +26,19 @@ void RenderRasterSource::update(Immutable<style::Source::Impl> baseImpl_,
     enabled = needsRendering;
 
     optional<Tileset> _tileset = impl().getTileset();
-
-    if (tileset != _tileset) {
+    // In Continuous mode, keep the existing tiles if the new tileset is not
+    // yet available, thus providing smart style transitions without flickering.
+    // In other modes, allow clearing the tile pyramid first, before the early
+    // return in order to avoid render tests being flaky.
+    bool canUpdateTileset = _tileset || parameters.mode != MapMode::Continuous;
+    if (canUpdateTileset && tileset != _tileset) {
         tileset = _tileset;
 
         // TODO: this removes existing buckets, and will cause flickering.
         // Should instead refresh tile data in place.
         tilePyramid.clearAll();
     }
-    // Allow clearing the tile pyramid first, before the early return in case
-    //  the new tileset is not yet available or has an error in loading
+
     if (!_tileset) {
         return;
     }

--- a/src/mbgl/renderer/sources/render_raster_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_source.cpp
@@ -25,21 +25,21 @@ void RenderRasterSource::update(Immutable<style::Source::Impl> baseImpl_,
 
     enabled = needsRendering;
 
-    optional<Tileset> _tileset = impl().getTileset();
+    const optional<Tileset>& implTileset = impl().tileset;
     // In Continuous mode, keep the existing tiles if the new tileset is not
     // yet available, thus providing smart style transitions without flickering.
     // In other modes, allow clearing the tile pyramid first, before the early
     // return in order to avoid render tests being flaky.
-    bool canUpdateTileset = _tileset || parameters.mode != MapMode::Continuous;
-    if (canUpdateTileset && tileset != _tileset) {
-        tileset = _tileset;
+    bool canUpdateTileset = implTileset || parameters.mode != MapMode::Continuous;
+    if (canUpdateTileset && tileset != implTileset) {
+        tileset = implTileset;
 
         // TODO: this removes existing buckets, and will cause flickering.
         // Should instead refresh tile data in place.
         tilePyramid.clearAll();
     }
 
-    if (!_tileset) {
+    if (!implTileset) {
         return;
     }
 

--- a/src/mbgl/renderer/sources/render_raster_source.hpp
+++ b/src/mbgl/renderer/sources/render_raster_source.hpp
@@ -5,15 +5,11 @@
 
 namespace mbgl {
 
-class RenderRasterSource final : public RenderTileSource {
+class RenderRasterSource final : public RenderTileSetSource {
 public:
     explicit RenderRasterSource(Immutable<style::RasterSource::Impl>);
 
-    void update(Immutable<style::Source::Impl>,
-                const std::vector<Immutable<style::LayerProperties>>&,
-                bool needsRendering,
-                bool needsRelayout,
-                const TileParameters&) final;
+private:
     void prepare(const SourcePrepareParameters&) final;
 
     std::unordered_map<std::string, std::vector<Feature>>
@@ -26,9 +22,15 @@ public:
     std::vector<Feature>
     querySourceFeatures(const SourceQueryOptions&) const override;
 
-private:
+    // RenderTileSetSource overrides
+    void updateInternal(const Tileset&,
+                        const std::vector<Immutable<style::LayerProperties>>&,
+                        bool needsRendering,
+                        bool needsRelayout,
+                        const TileParameters&) override;
+    const optional<Tileset>& getTileset() const override;
+
     const style::RasterSource::Impl& impl() const;
-    optional<Tileset> tileset;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/sources/render_tile_source.cpp
+++ b/src/mbgl/renderer/sources/render_tile_source.cpp
@@ -4,8 +4,10 @@
 #include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/renderer/render_tree.hpp>
 #include <mbgl/renderer/paint_parameters.hpp>
+#include <mbgl/renderer/tile_parameters.hpp>
 #include <mbgl/renderer/tile_render_data.hpp>
 #include <mbgl/tile/vector_tile.hpp>
+#include <mbgl/util/constants.hpp>
 #include <mbgl/util/math.hpp>
 
 namespace mbgl {
@@ -137,6 +139,46 @@ void RenderTileSource::reduceMemoryUse() {
 
 void RenderTileSource::dumpDebugLogs() const {
     tilePyramid.dumpDebugLogs();
+}
+
+// RenderTileSetSource implementation
+
+RenderTileSetSource::RenderTileSetSource(Immutable<style::Source::Impl> impl_)
+    : RenderTileSource(std::move(impl_)) {
+}
+
+RenderTileSetSource::~RenderTileSetSource() = default;
+
+uint8_t RenderTileSetSource::getMaxZoom() const {
+    return cachedTileset ? cachedTileset->zoomRange.max : util::TERRAIN_RGB_MAXZOOM;
+}
+
+void RenderTileSetSource::update(Immutable<style::Source::Impl> baseImpl_,
+                                const std::vector<Immutable<style::LayerProperties>>& layers,
+                                const bool needsRendering,
+                                const bool needsRelayout,
+                                const TileParameters& parameters) {
+    std::swap(baseImpl, baseImpl_);
+
+    enabled = needsRendering;
+
+    const optional<Tileset>& implTileset = getTileset();
+    // In Continuous mode, keep the existing tiles if the new cachedTileset is not
+    // yet available, thus providing smart style transitions without flickering.
+    // In other modes, allow clearing the tile pyramid first, before the early
+    // return in order to avoid render tests being flaky.
+    bool canUpdateTileset = implTileset || parameters.mode != MapMode::Continuous;
+    if (canUpdateTileset && cachedTileset != implTileset) {
+        cachedTileset = implTileset;
+
+        // TODO: this removes existing buckets, and will cause flickering.
+        // Should instead refresh tile data in place.
+        tilePyramid.clearAll();
+    }
+
+    if (!implTileset) return;
+
+    updateInternal(*cachedTileset, layers, needsRendering, needsRelayout, parameters);
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/sources/render_tile_source.hpp
+++ b/src/mbgl/renderer/sources/render_tile_source.hpp
@@ -11,7 +11,6 @@ namespace mbgl {
  */
 class RenderTileSource : public RenderSource {
 public:
-    RenderTileSource(Immutable<style::Source::Impl>);
     ~RenderTileSource() override;
 
     bool isLoaded() const override;
@@ -39,11 +38,39 @@ public:
     void dumpDebugLogs() const override;
 
 protected:
+    RenderTileSource(Immutable<style::Source::Impl>);
     TilePyramid tilePyramid;
     Immutable<std::vector<RenderTile>> renderTiles;
     mutable RenderTiles filteredRenderTiles;
     mutable RenderTiles renderTilesSortedByY;
     float bearing = 0.0f;      
+};
+
+/**
+ * @brief Base class for render sources that use tile sets.
+ */
+class RenderTileSetSource : public RenderTileSource {
+protected:
+    RenderTileSetSource(Immutable<style::Source::Impl>);
+    ~RenderTileSetSource() override;
+
+    virtual void updateInternal(const Tileset&,
+                                const std::vector<Immutable<style::LayerProperties>>&,
+                                bool needsRendering,
+                                bool needsRelayout,
+                                const TileParameters&) = 0;
+    // Returns tileset from the current impl.
+    virtual const optional<Tileset>& getTileset() const = 0;
+
+private:
+    uint8_t getMaxZoom() const final;
+    void update(Immutable<style::Source::Impl>,
+                const std::vector<Immutable<style::LayerProperties>>&,
+                bool needsRendering,
+                bool needsRelayout,
+                const TileParameters&) final;
+
+    optional<Tileset> cachedTileset;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/sources/render_vector_source.cpp
+++ b/src/mbgl/renderer/sources/render_vector_source.cpp
@@ -9,50 +9,28 @@ namespace mbgl {
 using namespace style;
 
 RenderVectorSource::RenderVectorSource(Immutable<style::VectorSource::Impl> impl_)
-    : RenderTileSource(impl_) {
+    : RenderTileSetSource(std::move(impl_)) {
 }
 
-const style::VectorSource::Impl& RenderVectorSource::impl() const {
-    return static_cast<const style::VectorSource::Impl&>(*baseImpl);
+const optional<Tileset>& RenderVectorSource::getTileset() const {
+    return static_cast<const style::VectorSource::Impl&>(*baseImpl).tileset;
 }
 
-void RenderVectorSource::update(Immutable<style::Source::Impl> baseImpl_,
-                                const std::vector<Immutable<style::LayerProperties>>& layers,
-                                const bool needsRendering,
-                                const bool needsRelayout,
-                                const TileParameters& parameters) {
-    std::swap(baseImpl, baseImpl_);
-
-    enabled = needsRendering;
-
-    const optional<Tileset>& implTileset = impl().tileset;
-    // In Continuous mode, keep the existing tiles if the new tileset is not
-    // yet available, thus providing smart style transitions without flickering.
-    // In other modes, allow clearing the tile pyramid first, before the early
-    // return in order to avoid render tests being flaky.
-    bool canUpdateTileset = implTileset || parameters.mode != MapMode::Continuous;
-    if (canUpdateTileset && tileset != implTileset) {
-        tileset = implTileset;
-
-        // TODO: this removes existing buckets, and will cause flickering.
-        // Should instead refresh tile data in place.
-        tilePyramid.clearAll();
-    }
-
-    if (!implTileset) {
-        return;
-    }
-
+void RenderVectorSource::updateInternal(const Tileset& tileset,
+                                        const std::vector<Immutable<style::LayerProperties>>& layers,
+                                        const bool needsRendering,
+                                        const bool needsRelayout,
+                                        const TileParameters& parameters) {
     tilePyramid.update(layers,
                        needsRendering,
                        needsRelayout,
                        parameters,
                        SourceType::Vector,
                        util::tileSize,
-                       tileset->zoomRange,
-                       tileset->bounds,
+                       tileset.zoomRange,
+                       tileset.bounds,
                        [&] (const OverscaledTileID& tileID) {
-                           return std::make_unique<VectorTile>(tileID, impl().id, parameters, *tileset);
+                           return std::make_unique<VectorTile>(tileID, baseImpl->id, parameters, tileset);
                        });
 }
 

--- a/src/mbgl/renderer/sources/render_vector_source.cpp
+++ b/src/mbgl/renderer/sources/render_vector_source.cpp
@@ -25,21 +25,21 @@ void RenderVectorSource::update(Immutable<style::Source::Impl> baseImpl_,
 
     enabled = needsRendering;
 
-    optional<Tileset> _tileset = impl().getTileset();
+    const optional<Tileset>& implTileset = impl().tileset;
     // In Continuous mode, keep the existing tiles if the new tileset is not
     // yet available, thus providing smart style transitions without flickering.
     // In other modes, allow clearing the tile pyramid first, before the early
     // return in order to avoid render tests being flaky.
-    bool canUpdateTileset = _tileset || parameters.mode != MapMode::Continuous;
-    if (canUpdateTileset && tileset != _tileset) {
-        tileset = _tileset;
+    bool canUpdateTileset = implTileset || parameters.mode != MapMode::Continuous;
+    if (canUpdateTileset && tileset != implTileset) {
+        tileset = implTileset;
 
         // TODO: this removes existing buckets, and will cause flickering.
         // Should instead refresh tile data in place.
         tilePyramid.clearAll();
     }
 
-    if (!_tileset) {
+    if (!implTileset) {
         return;
     }
 

--- a/src/mbgl/renderer/sources/render_vector_source.hpp
+++ b/src/mbgl/renderer/sources/render_vector_source.hpp
@@ -6,18 +6,16 @@
 
 namespace mbgl {
 
-class RenderVectorSource final : public RenderTileSource {
+class RenderVectorSource final : public RenderTileSetSource {
 public:
     explicit RenderVectorSource(Immutable<style::VectorSource::Impl>);
-
-    void update(Immutable<style::Source::Impl>,
-                const std::vector<Immutable<style::LayerProperties>>&,
-                bool needsRendering,
-                bool needsRelayout,
-                const TileParameters&) final;
 private:
-    const style::VectorSource::Impl& impl() const;
-    optional<Tileset> tileset;
+    void updateInternal(const Tileset&,
+                        const std::vector<Immutable<style::LayerProperties>>&,
+                        bool needsRendering,
+                        bool needsRelayout,
+                        const TileParameters&) override;
+    const optional<Tileset>& getTileset() const override;
 };
 
 } // namespace mbgl

--- a/src/mbgl/style/sources/raster_source.cpp
+++ b/src/mbgl/style/sources/raster_source.cpp
@@ -65,7 +65,7 @@ void RasterSource::loadDescription(FileSource& fileSource) {
             }
 
             util::mapbox::canonicalizeTileset(*tileset, url, getType(), getTileSize());
-            bool changed = impl().getTileset() != *tileset;
+            bool changed = impl().tileset != *tileset;
 
             baseImpl = makeMutable<Impl>(impl(), *tileset);
             loaded = true;

--- a/src/mbgl/style/sources/raster_source_impl.cpp
+++ b/src/mbgl/style/sources/raster_source_impl.cpp
@@ -10,16 +10,12 @@ RasterSource::Impl::Impl(SourceType sourceType, std::string id_, uint16_t tileSi
 
 RasterSource::Impl::Impl(const Impl& other, Tileset tileset_)
     : Source::Impl(other),
-      tileSize(other.tileSize),
-      tileset(std::move(tileset_)) {
+      tileset(std::move(tileset_)),
+      tileSize(other.tileSize) {
 }
 
 uint16_t RasterSource::Impl::getTileSize() const {
     return tileSize;
-}
-
-optional<Tileset> RasterSource::Impl::getTileset() const {
-    return tileset;
 }
 
 optional<std::string> RasterSource::Impl::getAttribution() const {

--- a/src/mbgl/style/sources/raster_source_impl.hpp
+++ b/src/mbgl/style/sources/raster_source_impl.hpp
@@ -11,14 +11,14 @@ public:
     Impl(SourceType sourceType, std::string id, uint16_t tileSize);
     Impl(const Impl&, Tileset);
 
-    optional<Tileset> getTileset() const;
     uint16_t getTileSize() const;
 
     optional<std::string> getAttribution() const final;
 
+    const optional<Tileset> tileset;
+
 private:
     uint16_t tileSize;
-    optional<Tileset> tileset;
 };
 
 } // namespace style

--- a/src/mbgl/style/sources/vector_source.cpp
+++ b/src/mbgl/style/sources/vector_source.cpp
@@ -62,7 +62,7 @@ void VectorSource::loadDescription(FileSource& fileSource) {
             }
 
             util::mapbox::canonicalizeTileset(*tileset, url, getType(), util::tileSize);
-            bool changed = impl().getTileset() != *tileset;
+            bool changed = impl().tileset != *tileset;
 
             baseImpl = makeMutable<Impl>(impl(), *tileset);
             loaded = true;

--- a/src/mbgl/style/sources/vector_source_impl.cpp
+++ b/src/mbgl/style/sources/vector_source_impl.cpp
@@ -12,10 +12,6 @@ VectorSource::Impl::Impl(const Impl& other, Tileset tileset_)
       tileset(std::move(tileset_)) {
 }
 
-optional<Tileset> VectorSource::Impl::getTileset() const {
-    return tileset;
-}
-
 optional<std::string> VectorSource::Impl::getAttribution() const {
     if (!tileset) {
         return {};

--- a/src/mbgl/style/sources/vector_source_impl.hpp
+++ b/src/mbgl/style/sources/vector_source_impl.hpp
@@ -11,12 +11,9 @@ public:
     Impl(std::string id);
     Impl(const Impl&, Tileset);
 
-    optional<Tileset> getTileset() const;
-
     optional<std::string> getAttribution() const final;
 
-private:
-    optional<Tileset> tileset;
+    const optional<Tileset> tileset;
 };
 
 } // namespace style


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/998253/61297408-df2a8a80-a7e4-11e9-9395-0806a7c33211.gif)

After:
![after](https://user-images.githubusercontent.com/998253/61297430-e8b3f280-a7e4-11e9-95e1-015bec4f4d37.gif)


Before this change, render sources were invalidating their tiles on each style update, when the new tile set was not yet available (tile set for a source is fetched in a separate request) and it caused flickering. Now updates without available tilesets are ignored.

The flickering was introduced with https://github.com/mapbox/mapbox-gl-native/commit/88c0914e53bc70d2cb3afc78506a30386cfc92b1 , it is now partially reverted for the Continuous map mode. 
For other map modes, tiles are still cleaned preventing from render tests being flaky, which was the issue fixed by https://github.com/mapbox/mapbox-gl-native/commit/88c0914e53bc70d2cb3afc78506a30386cfc92b1
