### PR TITLE
[ios][macos] Add MGLNetworkConfiguration.sessionDelegate

### DIFF
--- a/platform/darwin/src/MGLNetworkConfiguration.h
+++ b/platform/darwin/src/MGLNetworkConfiguration.h
@@ -32,6 +32,13 @@ MGL_EXPORT
  */
 @property (atomic, strong, null_resettable) NSURLSessionConfiguration *sessionConfiguration;
 
+/**
+ The session delegate that is used by the `NSURLSession` objects in this SDK.
+ 
+ Assign this object before instantiating any `MGLMapView` object.
+ */
+@property (atomic, strong) id<NSURLSessionDelegate> sessionDelegate;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/http_file_source.mm
+++ b/platform/darwin/src/http_file_source.mm
@@ -91,8 +91,10 @@ public:
 
             NSURLSessionConfiguration *sessionConfig =
             [MGLNetworkConfiguration sharedManager].sessionConfiguration;
-            
-            session = [NSURLSession sessionWithConfiguration:sessionConfig];
+            id<NSURLSessionDelegate> sessionDelegate =
+            [MGLNetworkConfiguration sharedManager].sessionDelegate;
+
+            session = [NSURLSession sessionWithConfiguration:sessionConfig delegate:sessionDelegate delegateQueue:nil];
 
             userAgent = getUserAgent();
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -8,6 +8,10 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Fixed a custom geometry source bug caused by using the outdated tiles after style update [#15112](https://github.com/mapbox/mapbox-gl-native/pull/15112)
 
+### Other changes
+
+* Added MGLNetworkConfiguration.sessionDelegate [#15128](https://github.com/mapbox/mapbox-gl-native/pull/15128)
+
 ## 5.2.0
 
 ### Offline maps

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Other changes
 
+* Added MGLNetworkConfiguration.sessionDelegate [#15128](https://github.com/mapbox/mapbox-gl-native/pull/15128)
 * The `-[MGLMapView setCamera:withDuration:animationTimingFunction:edgePadding:completionHandler:]` method now adds the current value of the `MGLMapView.contentInsets` property to the `edgePadding` parameter. ([#14813](https://github.com/mapbox/mapbox-gl-native/pull/14813))
 
 ### Other changes


### PR DESCRIPTION
This is an attempt to solve #11888 by expanding `MGLNetworkConfiguration` with a property to set a custom `NSURLSessionDelegate`. 

My main motivation for doing this is to be able to use tile services that uses HTTP Basic Authentication.

This is a new version of #13491 as that was made before `MGLNetworkConfiguration` went public.