### PR TITLE
[ios] Add changelog entry for Cache Management API

### DIFF
--- a/platform/darwin/src/MGLOfflineStorage.h
+++ b/platform/darwin/src/MGLOfflineStorage.h
@@ -360,7 +360,7 @@ MGL_EXPORT
 #pragma mark - Managing Ambient Cache
 
 /**
- Sets the maximum ambient cache size in megabytes. The default maximum cache
+ Sets the maximum ambient cache size in bytes. The default maximum cache
  size is 50 MB. To disable ambient caching, set the maximum ambient cache size
  to `0`. Setting the maximum ambient cache size does not impact the maximum size
  of offline packs.

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,12 +4,16 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ## master
 
+### Networking
+
+* Added methods to clear the ambient cache, change the size of the ambient cache, and delete and revalidate the database that contains the ambient and offline cache. These provide greater developer control over the impact of caching. ()[#14978](https://github.com/mapbox/mapbox-gl-native/pull/14978))
+
 ### Styles and rendering
 
 * Fixed a custom geometry source bug caused by using the outdated tiles after style update [#15112](https://github.com/mapbox/mapbox-gl-native/pull/15112)
 
 ### Other changes
-* Added methods to clear the ambient cache, change the size of the ambient cache, and delete and revalidate the database that contains the ambient and offline cache. These provide greater developer control over the impact of caching. ()[#14978](https://github.com/mapbox/mapbox-gl-native/pull/14978))
+
 * Ideographic glyphs from Chinese, Japanese, and Korean are no longer downloaded by default as part of offline packs; they are instead rendered on-device, saving bandwidth and storage while improving performance. ([#14176](https://github.com/mapbox/mapbox-gl-native/pull/14176))
 * Updated "map ID" to the more accurate term "tileset ID" in documentation; updated "style's Map ID" to the more accurate term "style URL". ([#15116](https://github.com/mapbox/mapbox-gl-native/pull/15116))
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -9,8 +9,8 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed a custom geometry source bug caused by using the outdated tiles after style update [#15112](https://github.com/mapbox/mapbox-gl-native/pull/15112)
 
 ### Other changes
+* Added methods to clear the ambient cache, change the size of the ambient cache, and delete and revalidate the database that contains the ambient and offline cache. These provide greater developer control over the impact of caching. ()[#14978](https://github.com/mapbox/mapbox-gl-native/pull/14978))
 * Ideographic glyphs from Chinese, Japanese, and Korean are no longer downloaded by default as part of offline packs; they are instead rendered on-device, saving bandwidth and storage while improving performance. ([#14176](https://github.com/mapbox/mapbox-gl-native/pull/14176))
-* Added methods to clear the ambient cache, change the size of the ambient cache, and delete and revalidate the database that contains the ambient and offline cache. These provide greater developer control over the impact of caching. [#14978](https://github.com/mapbox/mapbox-gl-native/pull/14978)
 
 ## 5.2.0
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -8,6 +8,10 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Fixed a custom geometry source bug caused by using the outdated tiles after style update [#15112](https://github.com/mapbox/mapbox-gl-native/pull/15112)
 
+### Offline maps
+
+* Added methods to invalidate and clear resources in the offline database. [#14978](https://github.com/mapbox/mapbox-gl-native/pull/14978)
+
 ### Other changes
 * Ideographic glyphs from Chinese, Japanese, and Korean are no longer downloaded by default as part of offline packs; they are instead rendered on-device, saving bandwidth and storage while improving performance. ([#14176](https://github.com/mapbox/mapbox-gl-native/pull/14176))
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -6,7 +6,8 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ### Networking
 
-* Added methods to clear the ambient cache, change the size of the ambient cache, and delete and revalidate the database that contains the ambient and offline cache. These provide greater developer control over the impact of caching. ()[#14978](https://github.com/mapbox/mapbox-gl-native/pull/14978))
+* Added methods to clear the ambient cache, change the size of the ambient cache, and delete and revalidate the database that contains the ambient and offline cache. These provide greater developer control over the impact of caching. ([#14978](https://github.com/mapbox/mapbox-gl-native/pull/14978))
+* Ideographic glyphs from Chinese, Japanese, and Korean are no longer downloaded by default as part of offline packs; they are instead rendered on-device, saving bandwidth and storage while improving performance. ([#14176](https://github.com/mapbox/mapbox-gl-native/pull/14176))
 
 ### Styles and rendering
 
@@ -14,7 +15,6 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ### Other changes
 
-* Ideographic glyphs from Chinese, Japanese, and Korean are no longer downloaded by default as part of offline packs; they are instead rendered on-device, saving bandwidth and storage while improving performance. ([#14176](https://github.com/mapbox/mapbox-gl-native/pull/14176))
 * Updated "map ID" to the more accurate term "tileset ID" in documentation; updated "style's Map ID" to the more accurate term "style URL". ([#15116](https://github.com/mapbox/mapbox-gl-native/pull/15116))
 
 ## 5.2.0

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -8,12 +8,9 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Fixed a custom geometry source bug caused by using the outdated tiles after style update [#15112](https://github.com/mapbox/mapbox-gl-native/pull/15112)
 
-### Offline maps
-
-* Added methods to invalidate and clear resources in the offline database. [#14978](https://github.com/mapbox/mapbox-gl-native/pull/14978)
-
 ### Other changes
 * Ideographic glyphs from Chinese, Japanese, and Korean are no longer downloaded by default as part of offline packs; they are instead rendered on-device, saving bandwidth and storage while improving performance. ([#14176](https://github.com/mapbox/mapbox-gl-native/pull/14176))
+* Added methods to clear the ambient cache, change the size of the ambient cache, and delete and revalidate the database that contains the ambient and offline cache. These provide greater developer control over the impact of caching. [#14978](https://github.com/mapbox/mapbox-gl-native/pull/14978)
 
 ## 5.2.0
 


### PR DESCRIPTION
* Adds changelog entry for #14978 
* Moves changelog entry pertaining to #14176 
* Addresses #15140 by fixing a typo.