### PR TITLE
Bump gestures library to v0.5.0, refine thresholds and velocity animations

### DIFF
--- a/platform/android/LICENSE.md
+++ b/platform/android/LICENSE.md
@@ -175,7 +175,7 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 Mapbox GL uses portions of the Mapbox Android Gestures Library.  
 URL: [https://github.com/mapbox/mapbox-gestures-android](https://github.com/mapbox/mapbox-gestures-android)  
-License: [BSD 2-Clause "Simplified" License](https://raw.githubusercontent.com/mapbox/mapbox-gestures-android/master/LICENSE.md)
+License: [BSD](https://opensource.org/licenses/BSD-2-Clause)
 
 ===========================================================================
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
@@ -200,5 +200,6 @@ public class MapboxConstants {
   public static final String STATE_ROTATE_ANIMATION_ENABLED = "mapbox_rotateAnimationEnabled";
   public static final String STATE_FLING_ANIMATION_ENABLED = "mapbox_flingAnimationEnabled";
   public static final String STATE_INCREASE_ROTATE_THRESHOLD = "mapbox_increaseRotateThreshold";
+  public static final String STATE_DISABLE_ROTATE_WHEN_SCALING = "mapbox_disableRotateWhenScaling";
   public static final String STATE_INCREASE_SCALE_THRESHOLD = "mapbox_increaseScaleThreshold";
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
@@ -79,6 +79,16 @@ public class MapboxConstants {
   public static final float ROTATION_THRESHOLD_INCREASE_WHEN_SCALING = 25f;
 
   /**
+   * Maximum absolute zoom change for multi-pointer scale velocity animation
+   */
+  public static final double MAX_ABSOLUTE_SCALE_VELOCITY_CHANGE = 2.5;
+
+  /**
+   * Scale velocity animation duration multiplier.
+   */
+  public static final double SCALE_VELOCITY_ANIMATION_DURATION_MULTIPLIER = 150;
+
+  /**
    * Time within which user needs to lift fingers for velocity animation to start.
    */
   public static final long SCHEDULED_ANIMATION_TIMEOUT = 150L;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
@@ -74,6 +74,14 @@ public class MapboxConstants {
   public static final long VELOCITY_THRESHOLD_IGNORE_FLING = 1000;
 
   /**
+   * Value by which the default rotation threshold will be increased when scaling
+   *
+   * @deprecated unused, see {@link com.mapbox.mapboxsdk.maps.UiSettings#setDisableRotateWhenScaling(boolean)}
+   */
+  @Deprecated
+  public static final float ROTATION_THRESHOLD_INCREASE_WHEN_SCALING = 25f;
+
+  /**
    * Maximum absolute zoom change for multi-pointer scale velocity animation
    */
   public static final double MAX_ABSOLUTE_SCALE_VELOCITY_CHANGE = 2.5;
@@ -82,6 +90,14 @@ public class MapboxConstants {
    * Scale velocity animation duration multiplier.
    */
   public static final double SCALE_VELOCITY_ANIMATION_DURATION_MULTIPLIER = 150;
+
+  /**
+   * Minimum angular velocity for rotation animation
+   *
+   * @deprecated unused, see {@link #ROTATE_VELOCITY_RATIO_THRESHOLD}
+   */
+  @Deprecated
+  public static final float MINIMUM_ANGULAR_VELOCITY = 1.5f;
 
   /**
    * Last scale span delta to XY velocity ratio required to execute scale velocity animation.

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
@@ -74,11 +74,6 @@ public class MapboxConstants {
   public static final long VELOCITY_THRESHOLD_IGNORE_FLING = 1000;
 
   /**
-   * Value by which the default rotation threshold will be increased when scaling
-   */
-  public static final float ROTATION_THRESHOLD_INCREASE_WHEN_SCALING = 25f;
-
-  /**
    * Maximum absolute zoom change for multi-pointer scale velocity animation
    */
   public static final double MAX_ABSOLUTE_SCALE_VELOCITY_CHANGE = 2.5;
@@ -89,19 +84,24 @@ public class MapboxConstants {
   public static final double SCALE_VELOCITY_ANIMATION_DURATION_MULTIPLIER = 150;
 
   /**
+   * Last scale span delta to XY velocity ratio required to execute scale velocity animation.
+   */
+  public static final double SCALE_VELOCITY_RATIO_THRESHOLD = 4 * 1e-3;
+
+  /**
+   * Last rotation delta to XY velocity ratio required to execute rotation velocity animation.
+   */
+  public static final double ROTATE_VELOCITY_RATIO_THRESHOLD = 2.2 * 1e-4;
+
+  /**
    * Time within which user needs to lift fingers for velocity animation to start.
    */
   public static final long SCHEDULED_ANIMATION_TIMEOUT = 150L;
 
   /**
-   * Minimum angular velocity for rotation animation
-   */
-  public static final float MINIMUM_ANGULAR_VELOCITY = 1.5f;
-
-  /**
    * Maximum angular velocity for rotation animation
    */
-  public static final float MAXIMUM_ANGULAR_VELOCITY = 20f;
+  public static final float MAXIMUM_ANGULAR_VELOCITY = 30f;
 
   /**
    * Factor to calculate tilt change based on pixel change during shove gesture.

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
@@ -67,6 +67,7 @@ public final class UiSettings {
   private boolean flingVelocityAnimationEnabled = true;
 
   private boolean increaseRotateThresholdWhenScaling = true;
+  private boolean disableRotateWhenScaling = true;
   private boolean increaseScaleThresholdWhenRotating = true;
 
   private float zoomRate = 1.0f;
@@ -132,6 +133,7 @@ public final class UiSettings {
     outState.putBoolean(MapboxConstants.STATE_ROTATE_ANIMATION_ENABLED, isRotateVelocityAnimationEnabled());
     outState.putBoolean(MapboxConstants.STATE_FLING_ANIMATION_ENABLED, isFlingVelocityAnimationEnabled());
     outState.putBoolean(MapboxConstants.STATE_INCREASE_ROTATE_THRESHOLD, isIncreaseRotateThresholdWhenScaling());
+    outState.putBoolean(MapboxConstants.STATE_DISABLE_ROTATE_WHEN_SCALING, isDisableRotateWhenScaling());
     outState.putBoolean(MapboxConstants.STATE_INCREASE_SCALE_THRESHOLD, isIncreaseScaleThresholdWhenRotating());
     outState.putBoolean(MapboxConstants.STATE_QUICK_ZOOM_ENABLED, isQuickZoomGesturesEnabled());
     outState.putFloat(MapboxConstants.STATE_ZOOM_RATE, getZoomRate());
@@ -148,6 +150,7 @@ public final class UiSettings {
     setFlingVelocityAnimationEnabled(savedInstanceState.getBoolean(MapboxConstants.STATE_FLING_ANIMATION_ENABLED));
     setIncreaseRotateThresholdWhenScaling(
       savedInstanceState.getBoolean(MapboxConstants.STATE_INCREASE_ROTATE_THRESHOLD));
+    setDisableRotateWhenScaling(savedInstanceState.getBoolean(MapboxConstants.STATE_DISABLE_ROTATE_WHEN_SCALING));
     setIncreaseScaleThresholdWhenRotating(
       savedInstanceState.getBoolean(MapboxConstants.STATE_INCREASE_SCALE_THRESHOLD));
     setQuickZoomGesturesEnabled(savedInstanceState.getBoolean(MapboxConstants.STATE_QUICK_ZOOM_ENABLED));
@@ -919,7 +922,9 @@ public final class UiSettings {
    * Returns whether rotation threshold should be increase whenever scale is detected.
    *
    * @return If true, rotation threshold will be increased.
+   * @deprecated unused, see {@link #isDisableRotateWhenScaling()} instead
    */
+  @Deprecated
   public boolean isIncreaseRotateThresholdWhenScaling() {
     return increaseRotateThresholdWhenScaling;
   }
@@ -928,16 +933,38 @@ public final class UiSettings {
    * Set whether rotation threshold should be increase whenever scale is detected.
    *
    * @param increaseRotateThresholdWhenScaling If true, rotation threshold will be increased.
+   * @deprecated unused, see {@link #setDisableRotateWhenScaling(boolean)} instead
    */
+  @Deprecated
   public void setIncreaseRotateThresholdWhenScaling(boolean increaseRotateThresholdWhenScaling) {
     this.increaseRotateThresholdWhenScaling = increaseRotateThresholdWhenScaling;
+  }
+
+  /**
+   * Returns whether rotation gesture detector is disabled when scale is detected first.
+   *
+   * @return If true, rotation gesture detector will be disabled when scale is detected first.
+   */
+  public boolean isDisableRotateWhenScaling() {
+    return disableRotateWhenScaling;
+  }
+
+  /**
+   * Set whether rotation gesture detector should be disabled when scale is detected first.
+   *
+   * @param disableRotateWhenScaling If true, rotation gesture detector will be disabled when scale is detected first.
+   */
+  public void setDisableRotateWhenScaling(boolean disableRotateWhenScaling) {
+    this.disableRotateWhenScaling = disableRotateWhenScaling;
   }
 
   /**
    * Returns whether scale threshold should be increase whenever rotation is detected.
    *
    * @return If true, scale threshold will be increased.
+   * @deprecated unused
    */
+  @Deprecated
   public boolean isIncreaseScaleThresholdWhenRotating() {
     return increaseScaleThresholdWhenRotating;
   }
@@ -946,7 +973,9 @@ public final class UiSettings {
    * set whether scale threshold should be increase whenever rotation is detected.
    *
    * @param increaseScaleThresholdWhenRotating If true, scale threshold will be increased.
+   * @deprecated unused
    */
+  @Deprecated
   public void setIncreaseScaleThresholdWhenRotating(boolean increaseScaleThresholdWhenRotating) {
     this.increaseScaleThresholdWhenRotating = increaseScaleThresholdWhenRotating;
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/UiSettings.java
@@ -962,9 +962,7 @@ public final class UiSettings {
    * Returns whether scale threshold should be increase whenever rotation is detected.
    *
    * @return If true, scale threshold will be increased.
-   * @deprecated unused
    */
-  @Deprecated
   public boolean isIncreaseScaleThresholdWhenRotating() {
     return increaseScaleThresholdWhenRotating;
   }
@@ -973,9 +971,7 @@ public final class UiSettings {
    * set whether scale threshold should be increase whenever rotation is detected.
    *
    * @param increaseScaleThresholdWhenRotating If true, scale threshold will be increased.
-   * @deprecated unused
    */
-  @Deprecated
   public void setIncreaseScaleThresholdWhenRotating(boolean increaseScaleThresholdWhenRotating) {
     this.increaseScaleThresholdWhenRotating = increaseScaleThresholdWhenRotating;
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/dimens.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/dimens.xml
@@ -12,6 +12,9 @@
     <!--Minimum scale velocity required to start animation-->
     <dimen name="mapbox_minimum_scale_velocity">225dp</dimen>
 
+    <!--Minimum scale span delta required to execute scale gesture when rotating-->
+    <dimen name="mapbox_minimum_scale_span_when_rotating">75dp</dimen>
+
     <!--Minimum angular velocity required to start rotation animation-->
     <dimen name="mapbox_minimum_angular_velocity">0.10dp</dimen>
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/dimens.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/dimens.xml
@@ -8,7 +8,7 @@
     <dimen name="mapbox_my_locationview_outer_circle">18dp</dimen>
 
     <!--Minimum scale velocity required to start animation-->
-    <dimen name="mapbox_minimum_scale_velocity">150dp</dimen>
+    <dimen name="mapbox_minimum_scale_velocity">225dp</dimen>
 
     <!--Minimum scale span delta required to execute scale gesture when rotating-->
     <dimen name="mapbox_minimum_scale_span_when_rotating">100dp</dimen>

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/dimens.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/dimens.xml
@@ -3,15 +3,14 @@
     <dimen name="mapbox_infowindow_tipview_width">8dp</dimen>
     <dimen name="mapbox_infowindow_margin">8dp</dimen>
     <dimen name="mapbox_four_dp">4dp</dimen>
+    <dimen name="mapbox_minimum_scale_speed">0.6dp</dimen>
+    <dimen name="mapbox_minimum_angled_scale_speed">0.9dp</dimen>
     <dimen name="mapbox_eight_dp">8dp</dimen>
     <dimen name="mapbox_ninety_two_dp">92dp</dimen>
     <dimen name="mapbox_my_locationview_outer_circle">18dp</dimen>
 
     <!--Minimum scale velocity required to start animation-->
     <dimen name="mapbox_minimum_scale_velocity">225dp</dimen>
-
-    <!--Minimum scale span delta required to execute scale gesture when rotating-->
-    <dimen name="mapbox_minimum_scale_span_when_rotating">100dp</dimen>
 
     <!--Minimum angular velocity required to start rotation animation-->
     <dimen name="mapbox_minimum_angular_velocity">0.025dp</dimen>

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/dimens.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/dimens.xml
@@ -13,7 +13,13 @@
     <dimen name="mapbox_minimum_scale_velocity">225dp</dimen>
 
     <!--Minimum angular velocity required to start rotation animation-->
-    <dimen name="mapbox_minimum_angular_velocity">0.025dp</dimen>
+    <dimen name="mapbox_minimum_angular_velocity">0.10dp</dimen>
+
+    <!--Angular velocity multiplier. Adapts the velocity for screen density-->
+    <dimen name="mapbox_angular_velocity_multiplier">1.3dp</dimen>
+
+    <!--Screen density constant to adjust gesture's velocityXY thresholds-->
+    <dimen name="mapbox_density_constant">0.29dp</dimen>
 
     <dimen name="mapbox_locationComponentTrackingInitialMoveThreshold">25dp</dimen>
     <dimen name="mapbox_locationComponentTrackingMultiFingerMoveThreshold">400dp</dimen>

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/UiSettingsTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/UiSettingsTest.java
@@ -341,17 +341,17 @@ public class UiSettingsTest {
   }
 
   @Test
-  public void testIncreaseRotateThresholdWhenScalingEnabled() {
-    uiSettings.setIncreaseRotateThresholdWhenScaling(true);
-    assertEquals("Rotate threshold increase should be enabled", true,
-      uiSettings.isIncreaseRotateThresholdWhenScaling());
+  public void testDisableRotateWhenScalingEnabled() {
+    uiSettings.setDisableRotateWhenScaling(true);
+    assertEquals("Rotate disabling should be enabled", true,
+      uiSettings.isDisableRotateWhenScaling());
   }
 
   @Test
-  public void testIncreaseRotateThresholdWhenScalingDisabled() {
-    uiSettings.setIncreaseRotateThresholdWhenScaling(false);
-    assertEquals("Rotate threshold increase should be disabled", false,
-      uiSettings.isIncreaseRotateThresholdWhenScaling());
+  public void testDisableRotateWhenScalingDisabled() {
+    uiSettings.setDisableRotateWhenScaling(false);
+    assertEquals("Rotate disabling should be disabled", false,
+      uiSettings.isDisableRotateWhenScaling());
   }
 
   @Test

--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -10,7 +10,7 @@ ext {
             mapboxServices  : '4.8.0',
             mapboxTelemetry : '4.5.1',
             mapboxCore      : '1.3.0',
-            mapboxGestures  : '0.4.2',
+            mapboxGestures  : '0.5.0',
             mapboxAccounts  : '0.2.0',
             supportLib      : '28.0.0',
             constraintLayout: '1.1.2',


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/14776. Closes https://github.com/mapbox/mapbox-gl-native/issues/14775.

- Bumps gestures library to `v0.5.0`, which includes our custom scale gestures detector, dropping the dependency on the compat one and bringing minor improvements, see https://github.com/mapbox/mapbox-gestures-android/issues/39 and https://github.com/mapbox/mapbox-gestures-android/pull/73.
- Disables the rotation gesture detector if a scale gesture has been recognized first to prevent unwanted rotation. This behavior is adjustable through the `UiSettings`.
- Improves the responsiveness of scale and rotation gestures, while at the same time better separates them and judges which gesture should be executed first based on the relative gesture speed (linear or angular speed respectively).
- Improves scale and rotation velocity animations by calculating the value addition linearly.
- Decreases a chance of firing both scale and rotation velocity animations at the same time by using a `[last gesture delta change] / [velocityXY]` ratio.
- Adjusts value addition and required gesture's speed ratio for the screen's pixel density.

I've paid special attention to interactions that occur when the device is used with one hand only, with fingers placed sideways (a tribute to users with long nails :nail_care:) or when the user has to reach to the device that is further away. Those scenarios should be dramatically improved in comparison to the behavior on `master`, even when a phone-on-the-table developer scenario should remain the same or might even require more willingness to register gestures like a rotation with high velocity.

I'd love any additional :eyes: and feedback from @mapbox/android or anyone able to quickly build the Maps SDK. Most of the magic numbers in the PR have been meticulously chosen to offer the best experience on the devices I could test on locally.

Currently, the PR is built against the gesture's library snapshot. When the feedback is addressed and the PR is approved, I'm going to release the stable `v0.5.0` in order to avoid patch releases if anything comes up that would need to be adjusted on the gesture library's end.

I didn't include any additional tests as most of the proposed changes are subjective and we don't have a mechanism to test them.