### PR TITLE
Update Bintray's package name

### DIFF
--- a/platform/android/gradle/artifact-settings.gradle
+++ b/platform/android/gradle/artifact-settings.gradle
@@ -14,6 +14,7 @@ ext {
 
     mapboxBintrayUserOrg = 'mapbox'
     mapboxBintrayRepoName = 'mapbox'
+    mapboxBintrayPackageName = 'com.mapbox.mapboxsdk:mapbox-android-sdk'
     mapboxBintrayUser = project.hasProperty('BINTRAY_USER') ? project.property('BINTRAY_USER') : System.getenv('BINTRAY_USER')
     mapboxBintrayApiKey = project.hasProperty('BINTRAY_API_KEY') ? project.property('BINTRAY_API_KEY') : System.getenv('BINTRAY_API_KEY')
     mapboxGpgPassphrase = project.hasProperty('GPG_PASSPHRASE') ? project.property('GPG_PASSPHRASE') : System.getenv('GPG_PASSPHRASE')

--- a/platform/android/gradle/gradle-bintray.gradle
+++ b/platform/android/gradle/gradle-bintray.gradle
@@ -50,7 +50,7 @@ bintray {
     publications('MapboxMapsSdkPublication')
     pkg {
         repo = project.ext.mapboxBintrayRepoName
-        name = project.ext.mapboxArtifactId
+        name = project.ext.mapboxBintrayPackageName
         userOrg = project.ext.mapboxBintrayUserOrg
         licenses = [project.ext.mapboxArtifactLicenseName]
         vcsUrl = project.ext.mapboxArtifactVcsUrl


### PR DESCRIPTION
With the recent Bintray changes that enabled snapshots for various other projects, I claimed and merged external package created by the Bintray bot to our `mapbox-android-sdk` package. This resulted in an unwanted name change.

Until we can rename the package back to `mapbox-android-sdk`, we need to use the currently set `com.mapbox.mapboxsdk:mapbox-android-sdk`.

Project's maven group and artifact IDs remain unchanged of course.