### PR TITLE
Fail MapSnapshotter test in case of an error returned from core

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotterTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotterTest.kt
@@ -6,6 +6,7 @@ import com.mapbox.mapboxsdk.camera.CameraPosition
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.maps.Style
 import com.mapbox.mapboxsdk.testapp.activity.FeatureOverviewActivity
+import junit.framework.Assert
 import junit.framework.Assert.assertNotNull
 import org.junit.Rule
 import org.junit.Test
@@ -39,11 +40,13 @@ class MapSnapshotterTest {
             .build()
         )
       val mapSnapshotter = MapSnapshotter(rule.activity, options)
-      mapSnapshotter.start {
+      mapSnapshotter.start({
         assertNotNull(it)
         assertNotNull(it.bitmap)
         countDownLatch.countDown()
-      }
+      }, {
+        Assert.fail(it)
+      })
     }
     if (!countDownLatch.await(30, TimeUnit.SECONDS)) {
       throw TimeoutException()


### PR DESCRIPTION
We've caught a timeout during the `MapSnapshotter` test - https://circleci.com/gh/mapbox/mapbox-gl-native/301451. We should also log an error, in case there's one returned from the core.