### PR TITLE
[ios] Prepare ios-v5.1.1 patch release with telemetry fix (oolong)

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## 5.1.1 - July 18, 2019
+
+* Fixed a bug in telemetry collection. ([#15077](https://github.com/mapbox/mapbox-gl-native/pull/15077))
+
 ## 5.1.0 - June 19, 2019
+
+This release contains a bug in telemetry collection and has been superseded by 5.1.1 — please update immediately.
 
 ### Styles and rendering
 

--- a/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '5.1.0'
+  version = '5.1.1'
 
   m.name    = 'Mapbox-iOS-SDK-snapshot-dynamic'
   m.version = "#{version}-snapshot"

--- a/platform/ios/Mapbox-iOS-SDK-stripped.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-stripped.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '5.1.0'
+  version = '5.1.1'
 
   m.name    = 'Mapbox-iOS-SDK-stripped'
   m.version = "#{version}-stripped"

--- a/platform/ios/Mapbox-iOS-SDK.podspec
+++ b/platform/ios/Mapbox-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '5.1.0'
+  version = '5.1.1'
 
   m.name    = 'Mapbox-iOS-SDK'
   m.version = version


### PR DESCRIPTION
- Updates `release-oolong` to [Mapbox Events v0.9.5](https://github.com/mapbox/mapbox-events-ios/releases/tag/v0.9.5), which includes an important telemetry bug fix.
  - Backports https://github.com/mapbox/mapbox-gl-native/pull/15077.
- Bumps versions for a `ios-v5.1.1` patch release.

/cc @captainbarbosa  