### PR TITLE
[ios] Prepare ios-v4.11.1 patch release with telemetry fix (mojito)

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,7 +4,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ## 4.11.1 - July 18, 2019
 
-* Fixed a bug in telemetry collection. ([#15077](https://github.com/mapbox/mapbox-gl-native/pull/15077))
+* Fixed a bug in telemetry collection. ([#15161](https://github.com/mapbox/mapbox-gl-native/pull/15161))
 
 ## 4.11.0 - May 15, 2019
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## 4.11.1 - July 18, 2019
+
+* Fixed a bug in telemetry collection. ([#15077](https://github.com/mapbox/mapbox-gl-native/pull/15077))
+
 ## 4.11.0 - May 15, 2019
+
+This release contains a bug in telemetry collection and has been superseded by 4.11.1 — please update immediately.
 
 ### Styles and rendering
 

--- a/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '4.11.0'
+  version = '4.11.1'
 
   m.name    = 'Mapbox-iOS-SDK-snapshot-dynamic'
   m.version = "#{version}-snapshot"

--- a/platform/ios/Mapbox-iOS-SDK-stripped.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-stripped.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '4.11.0'
+  version = '4.11.1'
 
   m.name    = 'Mapbox-iOS-SDK-stripped'
   m.version = "#{version}-stripped"

--- a/platform/ios/Mapbox-iOS-SDK.podspec
+++ b/platform/ios/Mapbox-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '4.11.0'
+  version = '4.11.1'
 
   m.name    = 'Mapbox-iOS-SDK'
   m.version = version


### PR DESCRIPTION
- Updates `release-mojito` to [Mapbox Events v0.9.3-patch.1](https://github.com/mapbox/mapbox-events-ios/commit/85e038ce8eb2b508e5d2b14428dbdd0e7daeebf4), which includes an important telemetry bug fix.
- Bumps versions for a `ios-v4.11.1` patch release.

/cc @captainbarbosa 