### PR TITLE
[ios] Prepare ios-v4.10.1 patch release with telemetry fix (liquid)

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## 4.10.1 - July 18, 2019
+
+* Fixed a bug in telemetry collection. ([#15162](https://github.com/mapbox/mapbox-gl-native/pull/15162))
+
 ## 4.10.0 - April 17, 2019
+
+This release contains a bug in telemetry collection and has been superseded by 4.10.1 — please update immediately.
 
 ### Styles and rendering
 

--- a/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '4.10.0'
+  version = '4.10.1'
 
   m.name    = 'Mapbox-iOS-SDK-snapshot-dynamic'
   m.version = "#{version}-snapshot"

--- a/platform/ios/Mapbox-iOS-SDK-stripped.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-stripped.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '4.10.0'
+  version = '4.10.1'
 
   m.name    = 'Mapbox-iOS-SDK-stripped'
   m.version = "#{version}-stripped"

--- a/platform/ios/Mapbox-iOS-SDK.podspec
+++ b/platform/ios/Mapbox-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '4.10.0'
+  version = '4.10.1'
 
   m.name    = 'Mapbox-iOS-SDK'
   m.version = version

--- a/platform/ios/scripts/install-packaging-dependencies.sh
+++ b/platform/ios/scripts/install-packaging-dependencies.sh
@@ -23,6 +23,7 @@ if [ -z `which jazzy` ]; then
 
     CIRCLECI=${CIRCLECI:-false}
     if [[ "${CIRCLECI}" == true ]]; then
+        sudo gem install ffi -v '1.9.25' --source 'https://rubygems.org/'
         sudo gem install jazzy -v $JAZZY_VERSION --no-document -- --with-sqlite3-lib=/usr/lib
     else
         gem install jazzy -v $JAZZY_VERSION --no-document


### PR DESCRIPTION
- Updates `release-liquid` to [Mapbox Events v0.9.5](https://github.com/mapbox/mapbox-events-ios/releases/tag/v0.9.5), which includes an important telemetry bug fix.
- Bumps versions for a `ios-v4.10.1` patch release.

/cc @captainbarbosa 