### PR TITLE
Fix wrong #15065 nit fix

### DIFF
--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -349,9 +349,11 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(const UpdatePar
         if (renderLayer.needsPlacement()) {
             layersNeedPlacement.emplace_back(renderLayer);
         }
-        if (renderLayer.is3D() && renderTreeParameters->opaquePassCutOff == 0) {
+        if (renderTreeParameters->opaquePassCutOff == 0) {
             --opaquePassCutOffEstimation;
-            renderTreeParameters->opaquePassCutOff = uint32_t(opaquePassCutOffEstimation);
+            if (renderLayer.is3D()) {
+                renderTreeParameters->opaquePassCutOff = uint32_t(opaquePassCutOffEstimation);
+            }
         }
     }
     // Symbol placement.


### PR DESCRIPTION
Change in https://github.com/mapbox/mapbox-gl-native/pull/15065/commits/3ffc14a3250e5c4eb7dcaf0d1cc0e95c9de3c014
was a typo while addressing review nit: while it doesn't affect rendering it could affect performance.

Because of the potential performance impact, It is important to get it to current beta releases (added beta blocker label). I'm incorporating it to backports of #15065 to nectar and oolong.

Edit: added render test https://github.com/mapbox/mapbox-gl-js/pull/8515 to verify that this isn't causing rendering regression. Performance impact would be coming from moving all layers from fill pass to translucent pass (while still rendering properly).
 
Related to: #14844, #14779, #15039
