### PR TITLE
[core, ios] Improve performance of queryRenderedFeatures by reducing # of temp GeometryCollection

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -8,6 +8,9 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Fixed flickering on style change for the same tile set ([#15127](https://github.com/mapbox/mapbox-gl-native/pull/15127))
 
+### Other changes
+
+* Improved feature querying performance (focussed on roads). ([#15183](https://github.com/mapbox/mapbox-gl-native/pull/15183))
 
 ## 5.2.0
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -224,11 +224,17 @@ CLLocationCoordinate2D randomWorldCoordinate() {
 
 @end
 
-#define OS_SIGNPOST_BEGIN(name) \
+#define OS_SIGNPOST_BEGIN_WITH_SELF(self, name) \
     if (@available(iOS 12.0, *)) { os_signpost_interval_begin(self.log, self.signpost, name); }
 
-#define OS_SIGNPOST_END(name) \
+#define OS_SIGNPOST_END_WITH_SELF(self, name) \
     if (@available(iOS 12.0, *)) { os_signpost_interval_end(self.log, self.signpost, name); }
+
+#define OS_SIGNPOST_BEGIN(name) \
+    OS_SIGNPOST_BEGIN_WITH_SELF(self, name)
+
+#define OS_SIGNPOST_END(name) \
+    OS_SIGNPOST_END_WITH_SELF(self, name)
 
 #define OS_SIGNPOST_EVENT(name, ...) \
     if (@available(iOS 12.0, *)) { os_signpost_event_emit(self.log, self.signpost, name, ##__VA_ARGS__); }
@@ -584,9 +590,16 @@ CLLocationCoordinate2D randomWorldCoordinate() {
                 {
                     __weak __typeof__(self) weakSelf = self;
                     [self parseFeaturesAddingCount:100 usingViews:YES completionHandler:^{
-                        [self.mapView setNeedsRerender];
-                        [self.pendingIdleBlocks addObject:^{
-                            [weakSelf queryRoads];
+                        [weakSelf.mapView setNeedsRerender];
+                        [weakSelf.pendingIdleBlocks addObject:^{
+                            __typeof__(self) strongSelf = weakSelf;
+                            NSLog(@"BEGIN: query-roads-batch");
+                            OS_SIGNPOST_BEGIN_WITH_SELF(strongSelf, "query-roads-batch");
+                            for (int i = 0; i < 10; i++) {
+                                [strongSelf queryRoads];
+                            }
+                            OS_SIGNPOST_END_WITH_SELF(strongSelf, "query-roads-batch");
+                            NSLog(@"END: query-roads-batch");
                         }];
                     }];
                 }

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -20,19 +20,6 @@
 #import <os/log.h>
 #import <os/signpost.h>
 
-os_log_t signpostlog;
-os_signpost_id_t signpost;
-BOOL queryForRoads = NO;
-
-@interface MGLStyle (qrf)
-@property (nonatomic, readonly, copy) NSArray<MGLVectorStyleLayer *> *roadStyleLayers;
-@end
-
-@interface MGLMapView ()
-- (void)setNeedsRerender;
-@end
-
-
 static const CLLocationCoordinate2D WorldTourDestinations[] = {
     { .latitude = 38.8999418, .longitude = -77.033996 },
     { .latitude = 37.7884307, .longitude = -122.3998631 },
@@ -78,6 +65,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsAnnotationsRows) {
     MBXSettingsAnnotationsTestShapes,
     MBXSettingsAnnotationsCustomCallout,
     MBXSettingsAnnotationsQueryAnnotations,
+    MBXSettingsAnnotationsQueryRoadsAroundDC,
     MBXSettingsAnnotationsCustomUserDot,
     MBXSettingsAnnotationsRemoveAnnotations,
     MBXSettingsAnnotationSelectRandomOffscreenPointAnnotation,
@@ -230,10 +218,30 @@ CLLocationCoordinate2D randomWorldCoordinate() {
 @property (nonatomic) NSMutableArray<UIWindow *> *helperWindows;
 @property (nonatomic) NSMutableArray<UIView *> *contentInsetsOverlays;
 
+@property (nonatomic) os_log_t log;
+@property (nonatomic) os_signpost_id_t signpost;
+@property (nonatomic) NSMutableArray<dispatch_block_t> *pendingIdleBlocks;
+
 @end
 
+#define OS_SIGNPOST_BEGIN(name) \
+    if (@available(iOS 12.0, *)) { os_signpost_interval_begin(self.log, self.signpost, name); }
+
+#define OS_SIGNPOST_END(name) \
+    if (@available(iOS 12.0, *)) { os_signpost_interval_end(self.log, self.signpost, name); }
+
+#define OS_SIGNPOST_EVENT(name, ...) \
+    if (@available(iOS 12.0, *)) { os_signpost_event_emit(self.log, self.signpost, name, ##__VA_ARGS__); }
+
+// Expose properties for testing
 @interface MGLMapView (MBXViewController)
 @property (nonatomic) NSDictionary *annotationViewReuseQueueByIdentifier;
+- (void)setNeedsRerender;
+- (UIEdgeInsets)defaultEdgeInsetsForShowAnnotations;
+@end
+
+@interface MGLStyle (MBXViewController)
+@property (nonatomic, readonly, copy) NSArray<MGLVectorStyleLayer *> *roadStyleLayers;
 @end
 
 @implementation MBXViewController
@@ -249,6 +257,12 @@ CLLocationCoordinate2D randomWorldCoordinate() {
 {
     [super viewDidLoad];
 
+    self.pendingIdleBlocks = [NSMutableArray array];
+    self.log = os_log_create("com.mapbox.iosapp", "MBXViewController");
+    if (@available(iOS 12.0, *)) {
+        self.signpost = os_signpost_id_generate(self.log);
+    }
+    
     // Keep track of current map state and debug preferences,
     // saving and restoring when the application's state changes.
     self.currentState =  [MBXStateManager sharedManager].currentState;
@@ -405,6 +419,7 @@ CLLocationCoordinate2D randomWorldCoordinate() {
                 @"Add Test Shapes",
                 @"Add Point With Custom Callout",
                 @"Query Annotations",
+                @"Query Roads around DC",
                 [NSString stringWithFormat:@"%@ Custom User Dot", (_customUserLocationAnnnotationEnabled ? @"Disable" : @"Enable")],
                 @"Remove Annotations",
                 @"Select an offscreen point annotation",
@@ -535,22 +550,22 @@ CLLocationCoordinate2D randomWorldCoordinate() {
             switch (indexPath.row)
             {
                 case MBXSettingsAnnotations100Views:
-                    [self parseFeaturesAddingCount:100 usingViews:YES];
+                    [self parseFeaturesAddingCount:100 usingViews:YES completionHandler:NULL];
                     break;
                 case MBXSettingsAnnotations1000Views:
-                    [self parseFeaturesAddingCount:1000 usingViews:YES];
+                    [self parseFeaturesAddingCount:1000 usingViews:YES completionHandler:NULL];
                     break;
                 case MBXSettingsAnnotations10000Views:
-                    [self parseFeaturesAddingCount:10000 usingViews:YES];
+                    [self parseFeaturesAddingCount:10000 usingViews:YES completionHandler:NULL];
                     break;
                 case MBXSettingsAnnotations100Sprites:
-                    [self parseFeaturesAddingCount:100 usingViews:NO];
+                    [self parseFeaturesAddingCount:100 usingViews:NO completionHandler:NULL];
                     break;
                 case MBXSettingsAnnotations1000Sprites:
-                    [self parseFeaturesAddingCount:1000 usingViews:NO];
+                    [self parseFeaturesAddingCount:1000 usingViews:NO completionHandler:NULL];
                     break;
                 case MBXSettingsAnnotations10000Sprites:
-                    [self parseFeaturesAddingCount:10000 usingViews:NO];
+                    [self parseFeaturesAddingCount:10000 usingViews:NO completionHandler:NULL];
                     break;
                 case MBXSettingsAnnotationAnimation:
                     [self animateAnnotationView];
@@ -563,6 +578,18 @@ CLLocationCoordinate2D randomWorldCoordinate() {
                     break;
                 case MBXSettingsAnnotationsQueryAnnotations:
                     [self testQueryPointAnnotations];
+                    break;
+                    
+                case MBXSettingsAnnotationsQueryRoadsAroundDC:
+                {
+                    __weak __typeof__(self) weakSelf = self;
+                    [self parseFeaturesAddingCount:100 usingViews:YES completionHandler:^{
+                        [self.mapView setNeedsRerender];
+                        [self.pendingIdleBlocks addObject:^{
+                            [weakSelf queryRoads];
+                        }];
+                    }];
+                }
                     break;
                 case MBXSettingsAnnotationsCustomUserDot:
                     [self toggleCustomUserDot];
@@ -830,7 +857,7 @@ CLLocationCoordinate2D randomWorldCoordinate() {
 
 #pragma mark - Debugging Actions
 
-- (void)parseFeaturesAddingCount:(NSUInteger)featuresCount usingViews:(BOOL)useViews
+- (void)parseFeaturesAddingCount:(NSUInteger)featuresCount usingViews:(BOOL)useViews completionHandler:(nullable dispatch_block_t)completion
 {
     [self.mapView removeAnnotations:self.mapView.annotations];
 
@@ -865,22 +892,11 @@ CLLocationCoordinate2D randomWorldCoordinate() {
             dispatch_async(dispatch_get_main_queue(), ^
             {
                 [self.mapView addAnnotations:annotations];
-
-                signpostlog = os_log_create("com.mapbox.iosapp", "qrf");
-                signpost = os_signpost_id_generate(signpostlog);
-
-                
-//                [self.mapView showAnnotations:annotations animated:YES];
-                
-                os_signpost_interval_begin(signpostlog, signpost, "show-annotations");
-                [self.mapView showAnnotations:annotations edgePadding:UIEdgeInsetsZero animated:YES completionHandler:^{
-                    os_signpost_interval_end(signpostlog, signpost, "show-annotations");
-
-                    // Idle till after all tile parsing/rendering is done (don't want a busy CPU)
-                    [self.mapView setNeedsRerender];
-                    queryForRoads = YES;
-                }];
-                
+                UIEdgeInsets insets = [self.mapView defaultEdgeInsetsForShowAnnotations];
+                [self.mapView showAnnotations:annotations
+                                  edgePadding:insets
+                                     animated:YES
+                            completionHandler:completion];
             });
         }
     });
@@ -1795,6 +1811,21 @@ CLLocationCoordinate2D randomWorldCoordinate() {
     return filePath;
 }
 
+#pragma mark - Query Rendered Features
+
+- (void)queryRoads
+{
+    OS_SIGNPOST_BEGIN("query-roads");
+    
+    NSArray *roadStyleLayerIdentifiers = [self.mapView.style.roadStyleLayers valueForKey:@"identifier"];
+    NSArray *visibleRoadFeatures = [self.mapView visibleFeaturesInRect:self.mapView.bounds inStyleLayersWithIdentifiers:[NSSet setWithArray:roadStyleLayerIdentifiers]];
+
+    OS_SIGNPOST_END("query-roads");
+    OS_SIGNPOST_EVENT("query-roads-count", "%lu", (unsigned long)visibleRoadFeatures.count);
+    
+    NSLog(@"Roads & labels feature count: %lu", (unsigned long)visibleRoadFeatures.count);
+}
+
 #pragma mark - Random World Tour
 
 - (void)addAnnotations:(NSInteger)numAnnotations aroundCoordinate:(CLLocationCoordinate2D)coordinate radius:(CLLocationDistance)radius {
@@ -2080,14 +2111,11 @@ CLLocationCoordinate2D randomWorldCoordinate() {
 
 - (void)mapViewDidBecomeIdle:(MGLMapView *)mapView
 {
-    if (queryForRoads)
-    {
-        os_signpost_interval_begin(signpostlog, signpost, "query-roads");
-        NSArray *roadStyleLayerIdentifiers = [self.mapView.style.roadStyleLayers valueForKey:@"identifier"];
-        NSArray *visibleRoadFeatures = [self.mapView visibleFeaturesInRect:self.mapView.bounds inStyleLayersWithIdentifiers:[NSSet setWithArray:roadStyleLayerIdentifiers]];
-        os_signpost_interval_end(signpostlog, signpost, "query-roads");
-        os_signpost_event_emit(signpostlog, signpost, "query-roads-count", "%ld", visibleRoadFeatures.count);
-        queryForRoads = YES;
+    NSArray *blocks = [self.pendingIdleBlocks copy];
+    [self.pendingIdleBlocks removeAllObjects];
+    
+    for (dispatch_block_t block in blocks) {
+        block();
     }
 }
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -2019,6 +2019,7 @@ CLLocationCoordinate2D randomWorldCoordinate() {
                 }
             }
         }
+        free(methods);
         NSAssert(numStyleURLMethods == styleNames.count,
                  @"MGLStyle provides %u default styles but iosapp only knows about %lu of them.",
                  numStyleURLMethods, (unsigned long)styleNames.count);

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -17,6 +17,21 @@
 #import "../src/MGLMapView_Experimental.h"
 
 #import <objc/runtime.h>
+#import <os/log.h>
+#import <os/signpost.h>
+
+os_log_t signpostlog;
+os_signpost_id_t signpost;
+BOOL queryForRoads = NO;
+
+@interface MGLStyle (qrf)
+@property (nonatomic, readonly, copy) NSArray<MGLVectorStyleLayer *> *roadStyleLayers;
+@end
+
+@interface MGLMapView ()
+- (void)setNeedsRerender;
+@end
+
 
 static const CLLocationCoordinate2D WorldTourDestinations[] = {
     { .latitude = 38.8999418, .longitude = -77.033996 },
@@ -850,7 +865,22 @@ CLLocationCoordinate2D randomWorldCoordinate() {
             dispatch_async(dispatch_get_main_queue(), ^
             {
                 [self.mapView addAnnotations:annotations];
-                [self.mapView showAnnotations:annotations animated:YES];
+
+                signpostlog = os_log_create("com.mapbox.iosapp", "qrf");
+                signpost = os_signpost_id_generate(signpostlog);
+
+                
+//                [self.mapView showAnnotations:annotations animated:YES];
+                
+                os_signpost_interval_begin(signpostlog, signpost, "show-annotations");
+                [self.mapView showAnnotations:annotations edgePadding:UIEdgeInsetsZero animated:YES completionHandler:^{
+                    os_signpost_interval_end(signpostlog, signpost, "show-annotations");
+
+                    // Idle till after all tile parsing/rendering is done (don't want a busy CPU)
+                    [self.mapView setNeedsRerender];
+                    queryForRoads = YES;
+                }];
+                
             });
         }
     });
@@ -2046,6 +2076,19 @@ CLLocationCoordinate2D randomWorldCoordinate() {
 }
 
 #pragma mark - MGLMapViewDelegate
+
+- (void)mapViewDidBecomeIdle:(MGLMapView *)mapView
+{
+    if (queryForRoads)
+    {
+        os_signpost_interval_begin(signpostlog, signpost, "query-roads");
+        NSArray *roadStyleLayerIdentifiers = [self.mapView.style.roadStyleLayers valueForKey:@"identifier"];
+        NSArray *visibleRoadFeatures = [self.mapView visibleFeaturesInRect:self.mapView.bounds inStyleLayersWithIdentifiers:[NSSet setWithArray:roadStyleLayerIdentifiers]];
+        os_signpost_interval_end(signpostlog, signpost, "query-roads");
+        os_signpost_event_emit(signpostlog, signpost, "query-roads-count", "%ld", visibleRoadFeatures.count);
+        queryForRoads = YES;
+    }
+}
 
 - (MGLAnnotationView *)mapView:(MGLMapView *)mapView viewForAnnotation:(id<MGLAnnotation>)annotation
 {

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -3947,6 +3947,7 @@
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = NO;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				INFOPLIST_FILE = "$(SRCROOT)/app/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGL;
 				PRODUCT_NAME = "Mapbox GL";
@@ -3985,6 +3986,7 @@
 				);
 				INFOPLIST_FILE = framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4299,6 +4301,7 @@
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = NO;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				INFOPLIST_FILE = "$(SRCROOT)/app/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGL;
 				PRODUCT_NAME = "Mapbox GL";
@@ -4313,6 +4316,7 @@
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = NO;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				INFOPLIST_FILE = "$(SRCROOT)/app/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGL;
 				PRODUCT_NAME = "Mapbox GL";
@@ -4398,6 +4402,7 @@
 				);
 				INFOPLIST_FILE = framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4446,6 +4451,7 @@
 				);
 				INFOPLIST_FILE = framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -3947,7 +3947,6 @@
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = NO;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				INFOPLIST_FILE = "$(SRCROOT)/app/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGL;
 				PRODUCT_NAME = "Mapbox GL";
@@ -3986,7 +3985,6 @@
 				);
 				INFOPLIST_FILE = framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4301,7 +4299,6 @@
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = NO;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				INFOPLIST_FILE = "$(SRCROOT)/app/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGL;
 				PRODUCT_NAME = "Mapbox GL";
@@ -4316,7 +4313,6 @@
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = NO;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				INFOPLIST_FILE = "$(SRCROOT)/app/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGL;
 				PRODUCT_NAME = "Mapbox GL";
@@ -4402,7 +4398,6 @@
 				);
 				INFOPLIST_FILE = framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4451,7 +4446,6 @@
 				);
 				INFOPLIST_FILE = framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",

--- a/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/iosapp.xcscheme
+++ b/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/iosapp.xcscheme
@@ -65,7 +65,7 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
+      buildConfiguration = "RelWithDebInfo"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -5050,14 +5050,19 @@ public:
                      completion:NULL];
 }
 
-- (void)showAnnotations:(NSArray<id <MGLAnnotation>> *)annotations animated:(BOOL)animated
+- (UIEdgeInsets)defaultEdgeInsetsForShowAnnotations
 {
     CGFloat maximumPadding = 100;
     CGFloat yPadding = (self.frame.size.height / 5 <= maximumPadding) ? (self.frame.size.height / 5) : maximumPadding;
     CGFloat xPadding = (self.frame.size.width / 5 <= maximumPadding) ? (self.frame.size.width / 5) : maximumPadding;
-
+    
     UIEdgeInsets edgeInsets = UIEdgeInsetsMake(yPadding, xPadding, yPadding, xPadding);
+    return edgeInsets;
+}
 
+- (void)showAnnotations:(NSArray<id <MGLAnnotation>> *)annotations animated:(BOOL)animated
+{
+    UIEdgeInsets edgeInsets = [self defaultEdgeInsetsForShowAnnotations];
     [self showAnnotations:annotations edgePadding:edgeInsets animated:animated completionHandler:nil];
 }
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -18,13 +18,11 @@
 
 * The `-[MGLMapView setCamera:withDuration:animationTimingFunction:edgePadding:completionHandler:]` method now adds the current value of the `MGLMapView.contentInsets` property to the `edgePadding` parameter. ([#14813](https://github.com/mapbox/mapbox-gl-native/pull/14813))
 * Updated "map ID" to the more accurate term "tileset ID" in documentation; updated "style's Map ID" to the more accurate term "style URL". ([#15116](https://github.com/mapbox/mapbox-gl-native/pull/15116))
-
-### Other changes
-
 * Added variants of multiple animated `MGLMapView` methods that accept completion handlers ([#14381](https://github.com/mapbox/mapbox-gl-native/pull/14381)):
   * `-[MGLMapView setVisibleCoordinateBounds:edgePadding:animated:completionHandler:]`
   * `-[MGLMapView setContentInsets:animated:completionHandler:]`
   * `-[MGLMapView showAnnotations:edgePadding:animated:completionHandler:]`
+* Improved feature querying performance (focussed on roads). ([#15183](https://github.com/mapbox/mapbox-gl-native/pull/15183))  
 
 ## 0.14.0 - May 22, 2018
 

--- a/src/mbgl/geometry/feature_index.cpp
+++ b/src/mbgl/geometry/feature_index.cpp
@@ -149,9 +149,11 @@ void FeatureIndex::addFeature(
             assert(geometryTileFeature);
         }
 
+        GeometryCollection geometries = geometryTileFeature->getGeometries();
+                
         bool needsCrossTileIndex = renderLayer->baseImpl->getTypeInfo()->crossTileIndex == style::LayerTypeInfo::CrossTileIndex::Required;
         if (!needsCrossTileIndex &&
-             !renderLayer->queryIntersectsFeature(queryGeometry, *geometryTileFeature, tileID.z, transformState, pixelsToTileUnits, posMatrix)) {
+             !renderLayer->queryIntersectsFeature(queryGeometry, *geometryTileFeature, geometries, tileID.z, transformState, pixelsToTileUnits, posMatrix)) {
             continue;
         }
 
@@ -159,7 +161,7 @@ void FeatureIndex::addFeature(
             continue;
         }
 
-        result[layerID].push_back(convertFeature(*geometryTileFeature, tileID));
+        result[layerID].push_back(convertFeature(*geometryTileFeature, geometries, tileID));
     }
 }
 

--- a/src/mbgl/geometry/feature_index.cpp
+++ b/src/mbgl/geometry/feature_index.cpp
@@ -149,7 +149,7 @@ void FeatureIndex::addFeature(
             assert(geometryTileFeature);
         }
 
-        GeometryCollection geometries = geometryTileFeature->getGeometries();
+        const GeometryCollection& geometries = geometryTileFeature->getGeometries();
                 
         bool needsCrossTileIndex = renderLayer->baseImpl->getTypeInfo()->crossTileIndex == style::LayerTypeInfo::CrossTileIndex::Required;
         if (!needsCrossTileIndex &&
@@ -161,7 +161,7 @@ void FeatureIndex::addFeature(
             continue;
         }
 
-        result[layerID].push_back(convertFeature(*geometryTileFeature, geometries, tileID));
+        result[layerID].emplace_back(convertFeature(*geometryTileFeature, geometries, tileID));
     }
 }
 

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -139,7 +139,7 @@ GeometryCoordinates projectQueryGeometry(const GeometryCoordinates& queryGeometr
 bool RenderCircleLayer::queryIntersectsFeature(
         const GeometryCoordinates& queryGeometry,
         const GeometryTileFeature& feature,
-        const GeometryCollection&, //$$JR
+        const GeometryCollection&, 
         const float zoom,
         const TransformState& transformState,
         const float pixelsToTileUnits,

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -139,6 +139,7 @@ GeometryCoordinates projectQueryGeometry(const GeometryCoordinates& queryGeometr
 bool RenderCircleLayer::queryIntersectsFeature(
         const GeometryCoordinates& queryGeometry,
         const GeometryTileFeature& feature,
+        const GeometryCollection&, //$$JR
         const float zoom,
         const TransformState& transformState,
         const float pixelsToTileUnits,

--- a/src/mbgl/renderer/layers/render_circle_layer.hpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.hpp
@@ -21,6 +21,7 @@ private:
     bool queryIntersectsFeature(
             const GeometryCoordinates&,
             const GeometryTileFeature&,
+            const GeometryCollection&, //$$JR
             const float,
             const TransformState&,
             const float,

--- a/src/mbgl/renderer/layers/render_circle_layer.hpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.hpp
@@ -21,7 +21,7 @@ private:
     bool queryIntersectsFeature(
             const GeometryCoordinates&,
             const GeometryTileFeature&,
-            const GeometryCollection&, //$$JR
+            const GeometryCollection&, 
             const float,
             const TransformState&,
             const float,

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -222,6 +222,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
 bool RenderFillExtrusionLayer::queryIntersectsFeature(
         const GeometryCoordinates& queryGeometry,
         const GeometryTileFeature& feature,
+        const GeometryCollection&,//$$JR
         const float,
         const TransformState& transformState,
         const float pixelsToTileUnits,

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -222,7 +222,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
 bool RenderFillExtrusionLayer::queryIntersectsFeature(
         const GeometryCoordinates& queryGeometry,
         const GeometryTileFeature& feature,
-        const GeometryCollection&,//$$JR
+        const GeometryCollection&,
         const float,
         const TransformState& transformState,
         const float pixelsToTileUnits,

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.hpp
@@ -23,7 +23,7 @@ private:
     bool queryIntersectsFeature(
         const GeometryCoordinates&,
         const GeometryTileFeature&,
-        const GeometryCollection&,//$$JR
+        const GeometryCollection&,
         const float,
         const TransformState&,
         const float,

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.hpp
@@ -23,6 +23,7 @@ private:
     bool queryIntersectsFeature(
         const GeometryCoordinates&,
         const GeometryTileFeature&,
+        const GeometryCollection&,//$$JR
         const float,
         const TransformState&,
         const float,

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -252,6 +252,7 @@ void RenderFillLayer::render(PaintParameters& parameters) {
 bool RenderFillLayer::queryIntersectsFeature(
         const GeometryCoordinates& queryGeometry,
         const GeometryTileFeature& feature,
+        const GeometryCollection&,//$$JR
         const float,
         const TransformState& transformState,
         const float pixelsToTileUnits,

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -252,7 +252,7 @@ void RenderFillLayer::render(PaintParameters& parameters) {
 bool RenderFillLayer::queryIntersectsFeature(
         const GeometryCoordinates& queryGeometry,
         const GeometryTileFeature& feature,
-        const GeometryCollection&,//$$JR
+        const GeometryCollection&,
         const float,
         const TransformState& transformState,
         const float pixelsToTileUnits,

--- a/src/mbgl/renderer/layers/render_fill_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.hpp
@@ -24,6 +24,7 @@ private:
     bool queryIntersectsFeature(
             const GeometryCoordinates&,
             const GeometryTileFeature&,
+            const GeometryCollection&,//$$JR
             const float,
             const TransformState&,
             const float,

--- a/src/mbgl/renderer/layers/render_fill_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.hpp
@@ -24,7 +24,7 @@ private:
     bool queryIntersectsFeature(
             const GeometryCoordinates&,
             const GeometryTileFeature&,
-            const GeometryCollection&,//$$JR
+            const GeometryCollection&,
             const float,
             const TransformState&,
             const float,

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -217,6 +217,7 @@ void RenderHeatmapLayer::updateColorRamp() {
 bool RenderHeatmapLayer::queryIntersectsFeature(
         const GeometryCoordinates& queryGeometry,
         const GeometryTileFeature& feature,
+        const GeometryCollection&,//$$JR
         const float zoom,
         const TransformState&,
         const float pixelsToTileUnits,

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -217,7 +217,7 @@ void RenderHeatmapLayer::updateColorRamp() {
 bool RenderHeatmapLayer::queryIntersectsFeature(
         const GeometryCoordinates& queryGeometry,
         const GeometryTileFeature& feature,
-        const GeometryCollection&,//$$JR
+        const GeometryCollection&,
         const float zoom,
         const TransformState&,
         const float pixelsToTileUnits,

--- a/src/mbgl/renderer/layers/render_heatmap_layer.hpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.hpp
@@ -25,7 +25,7 @@ private:
     bool queryIntersectsFeature(
             const GeometryCoordinates&,
             const GeometryTileFeature&,
-            const GeometryCollection&,//$$JR
+            const GeometryCollection&,
             const float,
             const TransformState&,
             const float,

--- a/src/mbgl/renderer/layers/render_heatmap_layer.hpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.hpp
@@ -25,6 +25,7 @@ private:
     bool queryIntersectsFeature(
             const GeometryCoordinates&,
             const GeometryTileFeature&,
+            const GeometryCollection&,//$$JR
             const float,
             const TransformState&,
             const float,

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -214,11 +214,11 @@ void RenderLineLayer::render(PaintParameters& parameters) {
     }
 }
 
-GeometryCollection* offsetLine(const GeometryCollection& rings, const double offset) {
+std::unique_ptr<GeometryCollection> offsetLine(const GeometryCollection& rings, const double offset) {
 
     if (offset == 0) return NULL;
 
-    GeometryCollection *newRings = new GeometryCollection();
+    std::unique_ptr<GeometryCollection> newRings = std::make_unique<GeometryCollection>();
 
     Point<double> zero(0, 0);
     for (const auto& ring : rings) {
@@ -249,7 +249,7 @@ GeometryCollection* offsetLine(const GeometryCollection& rings, const double off
 bool RenderLineLayer::queryIntersectsFeature(
         const GeometryCoordinates& queryGeometry,
         const GeometryTileFeature& feature,
-        const GeometryCollection& geometries,//$$JR
+        const GeometryCollection& geometries,
         const float zoom,
         const TransformState& transformState,
         const float pixelsToTileUnits,
@@ -268,7 +268,6 @@ bool RenderLineLayer::queryIntersectsFeature(
                           .evaluate(feature, zoom, style::LineOffset::defaultValue()) * pixelsToTileUnits;
 
     // Apply offset to geometry
-//    auto offsetGeometry = offsetLine(feature.getGeometries(), offset);
     auto offsetGeometry = offsetLine(geometries, offset);
 
     // Test intersection
@@ -278,10 +277,9 @@ bool RenderLineLayer::queryIntersectsFeature(
     if (offsetGeometry) {
         intersects = util::polygonIntersectsBufferedMultiLine(
             translatedQueryGeometry.value_or(queryGeometry),
-            *offsetGeometry,//.value_or(geometries),//feature.getGeometries()),
+            *offsetGeometry,
             halfWidth);
     }
-    delete offsetGeometry;
     return intersects;
 }
 

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -272,15 +272,11 @@ bool RenderLineLayer::queryIntersectsFeature(
 
     // Test intersection
     const float halfWidth = getLineWidth(feature, zoom) / 2.0 * pixelsToTileUnits;
-    bool intersects =  false;
     
-    if (offsetGeometry) {
-        intersects = util::polygonIntersectsBufferedMultiLine(
+    return util::polygonIntersectsBufferedMultiLine(
             translatedQueryGeometry.value_or(queryGeometry),
-            *offsetGeometry,
+            offsetGeometry != nullptr ? *offsetGeometry : geometries,
             halfWidth);
-    }
-    return intersects;
 }
 
 void RenderLineLayer::updateColorRamp() {

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -215,10 +215,10 @@ void RenderLineLayer::render(PaintParameters& parameters) {
 }
 
 GeometryCollection* offsetLine(const GeometryCollection& rings, const double offset) {
-    
-    GeometryCollection *newRings = new GeometryCollection();
-    
+
     if (offset == 0) return NULL;
+
+    GeometryCollection *newRings = new GeometryCollection();
 
     Point<double> zero(0, 0);
     for (const auto& ring : rings) {

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -239,7 +239,7 @@ std::unique_ptr<GeometryCollection> offsetLine(const GeometryCollection& rings, 
             const double cosHalfAngle = extrude.x * bToC.x + extrude.y * bToC.y;
             extrude *= (1.0 / cosHalfAngle);
 
-            newRing.push_back(convertPoint<int16_t>(extrude * offset) + p);
+            newRing.emplace_back(convertPoint<int16_t>(extrude * offset) + p);
         }
     }
 

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -216,7 +216,7 @@ void RenderLineLayer::render(PaintParameters& parameters) {
 
 std::unique_ptr<GeometryCollection> offsetLine(const GeometryCollection& rings, const double offset) {
 
-    if (offset == 0) return NULL;
+    if (offset == 0) return nullptr;
 
     std::unique_ptr<GeometryCollection> newRings = std::make_unique<GeometryCollection>();
 

--- a/src/mbgl/renderer/layers/render_line_layer.hpp
+++ b/src/mbgl/renderer/layers/render_line_layer.hpp
@@ -27,7 +27,7 @@ private:
     bool queryIntersectsFeature(
             const GeometryCoordinates&,
             const GeometryTileFeature&,
-            const GeometryCollection&,//$$JR
+            const GeometryCollection&,
             const float,
             const TransformState&,
             const float,

--- a/src/mbgl/renderer/layers/render_line_layer.hpp
+++ b/src/mbgl/renderer/layers/render_line_layer.hpp
@@ -27,6 +27,7 @@ private:
     bool queryIntersectsFeature(
             const GeometryCoordinates&,
             const GeometryTileFeature&,
+            const GeometryCollection&,//$$JR
             const float,
             const TransformState&,
             const float,

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -91,6 +91,7 @@ public:
     virtual bool queryIntersectsFeature(
             const GeometryCoordinates&,
             const GeometryTileFeature&,
+            const GeometryCollection&,//$$JR
             const float,
             const TransformState&,
             const float,

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -91,7 +91,7 @@ public:
     virtual bool queryIntersectsFeature(
             const GeometryCoordinates&,
             const GeometryTileFeature&,
-            const GeometryCollection&,//$$JR
+            const GeometryCollection&,
             const float,
             const TransformState&,
             const float,

--- a/src/mbgl/tile/custom_geometry_tile.cpp
+++ b/src/mbgl/tile/custom_geometry_tile.cpp
@@ -83,7 +83,7 @@ void CustomGeometryTile::querySourceFeatures(
                 continue;
             }
 
-            result.push_back(convertFeature(*feature, feature->getGeometries(), id.canonical));
+            result.emplace_back(convertFeature(*feature, feature->getGeometries(), id.canonical));
         }
     }
 }

--- a/src/mbgl/tile/custom_geometry_tile.cpp
+++ b/src/mbgl/tile/custom_geometry_tile.cpp
@@ -83,7 +83,7 @@ void CustomGeometryTile::querySourceFeatures(
                 continue;
             }
 
-            result.push_back(convertFeature(*feature, id.canonical));
+            result.push_back(convertFeature(*feature, feature->getGeometries(), id.canonical));
         }
     }
 }

--- a/src/mbgl/tile/geojson_tile.cpp
+++ b/src/mbgl/tile/geojson_tile.cpp
@@ -33,7 +33,7 @@ void GeoJSONTile::querySourceFeatures(
                     continue;
                 }
 
-                result.push_back(convertFeature(*feature, feature->getGeometries(), id.canonical));
+                result.emplace_back(convertFeature(*feature, feature->getGeometries(), id.canonical));
             }
         }
     }

--- a/src/mbgl/tile/geojson_tile.cpp
+++ b/src/mbgl/tile/geojson_tile.cpp
@@ -33,7 +33,7 @@ void GeoJSONTile::querySourceFeatures(
                     continue;
                 }
 
-                result.push_back(convertFeature(*feature, id.canonical));
+                result.push_back(convertFeature(*feature, feature->getGeometries(), id.canonical));
             }
         }
     }

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -360,7 +360,7 @@ void GeometryTile::querySourceFeatures(
                     continue;
                 }
 
-                result.push_back(convertFeature(*feature, feature->getGeometries(), id.canonical));
+                result.emplace_back(convertFeature(*feature, feature->getGeometries(), id.canonical));
             }
         }
     }

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -360,7 +360,7 @@ void GeometryTile::querySourceFeatures(
                     continue;
                 }
 
-                result.push_back(convertFeature(*feature, id.canonical));
+                result.push_back(convertFeature(*feature, feature->getGeometries(), id.canonical));
             }
         }
     }

--- a/src/mbgl/tile/geometry_tile_data.cpp
+++ b/src/mbgl/tile/geometry_tile_data.cpp
@@ -112,8 +112,6 @@ static Feature::geometry_type convertGeometry(const GeometryTileFeature& geometr
         );
     };
 
-//    GeometryCollection geometries = geometryTileFeature.getGeometries();
-
     switch (geometryTileFeature.getType()) {
         case FeatureType::Unknown: {
             assert(false);

--- a/src/mbgl/tile/geometry_tile_data.cpp
+++ b/src/mbgl/tile/geometry_tile_data.cpp
@@ -99,7 +99,7 @@ void limitHoles(GeometryCollection& polygon, uint32_t maxHoles) {
     }
 }
 
-static Feature::geometry_type convertGeometry(const GeometryTileFeature& geometryTileFeature, const CanonicalTileID& tileID) {
+static Feature::geometry_type convertGeometry(const GeometryTileFeature& geometryTileFeature, const GeometryCollection& geometries, const CanonicalTileID& tileID) {
     const double size = util::EXTENT * std::pow(2, tileID.z);
     const double x0 = util::EXTENT * tileID.x;
     const double y0 = util::EXTENT * tileID.y;
@@ -112,7 +112,7 @@ static Feature::geometry_type convertGeometry(const GeometryTileFeature& geometr
         );
     };
 
-    GeometryCollection geometries = geometryTileFeature.getGeometries();
+//    GeometryCollection geometries = geometryTileFeature.getGeometries();
 
     switch (geometryTileFeature.getType()) {
         case FeatureType::Unknown: {
@@ -173,8 +173,8 @@ static Feature::geometry_type convertGeometry(const GeometryTileFeature& geometr
     return Point<double>();
 }
 
-Feature convertFeature(const GeometryTileFeature& geometryTileFeature, const CanonicalTileID& tileID) {
-    Feature feature { convertGeometry(geometryTileFeature, tileID) };
+Feature convertFeature(const GeometryTileFeature& geometryTileFeature, const GeometryCollection& geometries, const CanonicalTileID& tileID) {
+    Feature feature { convertGeometry(geometryTileFeature, geometries, tileID) };
     feature.properties = geometryTileFeature.getProperties();
     feature.id = geometryTileFeature.getID();
     return feature;

--- a/src/mbgl/tile/geometry_tile_data.hpp
+++ b/src/mbgl/tile/geometry_tile_data.hpp
@@ -76,7 +76,7 @@ std::vector<GeometryCollection> classifyRings(const GeometryCollection&);
 void limitHoles(GeometryCollection&, uint32_t maxHoles);
 
 // convert from GeometryTileFeature to Feature (eventually we should eliminate GeometryTileFeature)
-Feature convertFeature(const GeometryTileFeature&, const CanonicalTileID&);
+Feature convertFeature(const GeometryTileFeature&, const GeometryCollection&, const CanonicalTileID&);
 
 // Fix up possibly-non-V2-compliant polygon geometry using angus clipper.
 // The result is guaranteed to have correctly wound, strictly simple rings.


### PR DESCRIPTION
This PR aims to improve performance of `queryRenderedFeatures` by reducing the number of temporary `GeometryCollection` that are allocated.

- `getGeometries()` is now called once, rather than 3 times; it is passed in to subsequent functions
- `offsetLine(...)` now returns a `std::unique_ptr` - beforehand the copy-constructor & destructor were being called...a lot. (This is the main improvement).
- `iosapp` has been updated with a menu entry so that we can test these improvements (and future improvements).

Note - this does NOT have @pozdnyakov's suggestion of using `mbgl::Immutable` - I started, but I'd need to pair on this - perhaps we can do this as a follow-on PR?