### PR TITLE
Temporarily revert two cherry-picks to release-mojito

### DIFF
--- a/include/mbgl/style/layer_properties.hpp
+++ b/include/mbgl/style/layer_properties.hpp
@@ -15,8 +15,6 @@ public:
     virtual ~LayerProperties() = default;
 
     Immutable<Layer::Impl> baseImpl;
-    // Contains render passes used by the renderer, see `mbgl::RenderPass`.
-    uint8_t renderPasses = 0u;
 
 protected:
     LayerProperties(Immutable<Layer::Impl> impl) : baseImpl(std::move(impl)) {}

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -37,7 +37,6 @@ void RenderBackgroundLayer::evaluate(const PropertyEvaluationParameters &paramet
 
     passes = properties->evaluated.get<style::BackgroundOpacity>() > 0 ? RenderPass::Translucent
                                                                        : RenderPass::None;
-    properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 }
 
@@ -130,8 +129,8 @@ void RenderBackgroundLayer::render(PaintParameters& parameters, RenderSource*) {
 }
 
 optional<Color> RenderBackgroundLayer::getSolidBackground() const {
-    const auto& evaluated = getEvaluated<BackgroundLayerProperties>(evaluatedProperties);
-    if (!evaluated.get<BackgroundPattern>().from.empty() || evaluated.get<style::BackgroundOpacity>() <= 0.0f) {
+    const auto& evaluated = static_cast<const BackgroundLayerProperties&>(*evaluatedProperties).evaluated;
+    if (!evaluated.get<BackgroundPattern>().from.empty()) {
         return nullopt;
     }
 

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -41,7 +41,6 @@ void RenderCircleLayer::evaluate(const PropertyEvaluationParameters& parameters)
               && (evaluated.get<style::CircleOpacity>().constantOr(1) > 0 ||
                   evaluated.get<style::CircleStrokeOpacity>().constantOr(1) > 0))
              ? RenderPass::Translucent : RenderPass::None;
-    properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 }
 
@@ -59,7 +58,7 @@ void RenderCircleLayer::render(PaintParameters& parameters, RenderSource*) {
     }
 
     for (const RenderTile& tile : renderTiles) {
-        const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
+        const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
         if (!renderData) {
             continue;
         }

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -44,7 +44,6 @@ void RenderFillExtrusionLayer::evaluate(const PropertyEvaluationParameters& para
     passes = (properties->evaluated.get<style::FillExtrusionOpacity>() > 0)
                  ? (RenderPass::Translucent | RenderPass::Pass3D)
                  : RenderPass::None;
-    properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 }
 
@@ -120,7 +119,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters, RenderSource*
 
         if (unevaluated.get<FillExtrusionPattern>().isUndefined()) {
             for (const RenderTile& tile : renderTiles) {
-                const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
+                const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
                 if (!renderData) {
                     continue;
                 }
@@ -146,7 +145,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters, RenderSource*
             }
         } else {
             for (const RenderTile& tile : renderTiles) {
-                const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
+                const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
                 if (!renderData) {
                     continue;
                 }

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -59,7 +59,7 @@ void RenderFillLayer::evaluate(const PropertyEvaluationParameters& parameters) {
     } else {
         passes |= RenderPass::Opaque;
     }
-    properties->renderPasses = mbgl::underlying_type(passes);
+
     evaluatedProperties = std::move(properties);
 }
 
@@ -74,7 +74,7 @@ bool RenderFillLayer::hasCrossfade() const {
 void RenderFillLayer::render(PaintParameters& parameters, RenderSource*) {
     if (unevaluated.get<FillPattern>().isUndefined()) {
         for (const RenderTile& tile : renderTiles) {
-            const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
+            const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
             if (!renderData) {
                 continue;
             }
@@ -158,7 +158,7 @@ void RenderFillLayer::render(PaintParameters& parameters, RenderSource*) {
         }
 
         for (const RenderTile& tile : renderTiles) {
-            const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
+            const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
             if (!renderData) {
                 continue;
             }

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -43,7 +43,7 @@ void RenderHeatmapLayer::evaluate(const PropertyEvaluationParameters& parameters
     passes = (properties->evaluated.get<style::HeatmapOpacity>() > 0)
             ? (RenderPass::Translucent | RenderPass::Pass3D)
             : RenderPass::None;
-    properties->renderPasses = mbgl::underlying_type(passes);
+
     evaluatedProperties = std::move(properties);
 }
 
@@ -89,7 +89,7 @@ void RenderHeatmapLayer::render(PaintParameters& parameters, RenderSource*) {
             "heatmap texture", { *renderTexture, Color{ 0.0f, 0.0f, 0.0f, 1.0f }, {}, {} });
 
         for (const RenderTile& tile : renderTiles) {
-            const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
+            const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
             if (!renderData) {
                 continue;
             }

--- a/src/mbgl/renderer/layers/render_hillshade_layer.cpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.cpp
@@ -53,7 +53,7 @@ void RenderHillshadeLayer::evaluate(const PropertyEvaluationParameters& paramete
     passes = (properties->evaluated.get<style::HillshadeExaggeration >() > 0)
                  ? (RenderPass::Translucent | RenderPass::Pass3D)
                  : RenderPass::None;
-    properties->renderPasses = mbgl::underlying_type(passes);
+
     evaluatedProperties = std::move(properties);
 }
 

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -46,7 +46,6 @@ void RenderLineLayer::evaluate(const PropertyEvaluationParameters& parameters) {
               && evaluated.get<style::LineColor>().constantOr(Color::black()).a > 0
               && evaluated.get<style::LineWidth>().constantOr(1.0) > 0)
              ? RenderPass::Translucent : RenderPass::None;
-    properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 }
 
@@ -64,7 +63,7 @@ void RenderLineLayer::render(PaintParameters& parameters, RenderSource*) {
     }
 
     for (const RenderTile& tile : renderTiles) {
-        const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
+        const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
         if (!renderData) {
             continue;
         }

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -34,7 +34,6 @@ void RenderRasterLayer::evaluate(const PropertyEvaluationParameters& parameters)
         staticImmutableCast<RasterLayer::Impl>(baseImpl),
         unevaluated.evaluate(parameters));
     passes = properties->evaluated.get<style::RasterOpacity>() > 0 ? RenderPass::Translucent : RenderPass::None;
-    properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 }
 

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -366,7 +366,6 @@ void RenderSymbolLayer::evaluate(const PropertyEvaluationParameters& parameters)
     passes = ((evaluated.get<style::IconOpacity>().constantOr(1) > 0 && hasIconOpacity && iconSize > 0)
               || (evaluated.get<style::TextOpacity>().constantOr(1) > 0 && hasTextOpacity && textSize > 0))
              ? RenderPass::Translucent : RenderPass::None;
-    properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 }
 
@@ -472,7 +471,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
     };
 
     for (const RenderTile& tile : renderTiles) {
-        const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
+        const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
         if (!renderData) {
             continue;
         }
@@ -620,7 +619,6 @@ style::TextPaintProperties::PossiblyEvaluated RenderSymbolLayer::textPaintProper
 void RenderSymbolLayer::setRenderTiles(RenderTiles tiles, const TransformState& state) {
     auto filterFn = [](auto& tile){ return !tile.tile.isRenderable(); };
     renderTiles = RenderLayer::filterRenderTiles(std::move(tiles), filterFn);
-    addRenderPassesFromTiles();
     // Sort symbol tiles in opposite y position, so tiles with overlapping symbols are drawn
     // on top of each other, with lower symbols being drawn on top of higher symbols.
     std::sort(renderTiles.begin(), renderTiles.end(), [&state](const auto& a, const auto& b) {

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -41,7 +41,6 @@ bool RenderLayer::supportsZoom(float zoom) const {
 void RenderLayer::setRenderTiles(RenderTiles tiles, const TransformState&) {
     auto filterFn = [](auto& tile){ return !tile.tile.isRenderable() || tile.tile.holdForFade(); };
     renderTiles = filterRenderTiles(std::move(tiles), filterFn);
-    addRenderPassesFromTiles();
 }
 
 const RenderLayerSymbolInterface* RenderLayer::getSymbolInterface() const {
@@ -95,23 +94,6 @@ void RenderLayer::checkRenderability(const PaintParameters& parameters,
                    activeBindingCount - parameters.context.minimumRequiredVertexBindingCount);
         hasRenderFailures = true;
     }
-}
-
-void RenderLayer::addRenderPassesFromTiles() {
-    for (const RenderTile& tile : renderTiles) {
-        if (tile.tile.kind != Tile::Kind::Geometry) break;
-        if (const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl)) {
-            passes |= RenderPass(renderData->layerProperties->renderPasses);
-        }
-    }
-}
-
-const LayerRenderData* RenderLayer::getRenderDataForPass(const RenderTile& tile, RenderPass pass) const {
-    assert(tile.tile.kind == Tile::Kind::Geometry);
-    if (const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl)) {
-        return bool(RenderPass(renderData->layerProperties->renderPasses) & pass) ? renderData : nullptr;
-    }
-    return nullptr;
 }
 
 } //namespace mbgl

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -95,10 +95,6 @@ protected:
     using FilterFunctionPtr = bool (*)(RenderTile&);
     RenderTiles filterRenderTiles(RenderTiles, FilterFunctionPtr) const;
 
-    void addRenderPassesFromTiles();
-
-    const LayerRenderData* getRenderDataForPass(const RenderTile&, RenderPass) const;
-
 protected:
     // Stores current set of tiles to be rendered for this layer.
     std::vector<std::reference_wrapper<RenderTile>> renderTiles;

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -250,14 +250,14 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
             const Immutable<Layer::Impl>& layerImpl = *it;
             RenderLayer* layer = getRenderLayer(layerImpl->id);
             const auto* layerInfo = layerImpl->getTypeInfo();
-            const bool layerIsVisible = layer->baseImpl->visibility != style::VisibilityType::None;
+            const bool layerNeedsRendering = layer->needsRendering();
             const bool zoomFitsLayer = layer->supportsZoom(zoomHistory.lastZoom);
             staticData->has3D = (staticData->has3D || layerInfo->pass3d == LayerTypeInfo::Pass3D::Required);
 
             if (layerInfo->source != LayerTypeInfo::Source::NotRequired) {
                 if (layerImpl->source == sourceImpl->id) {
                     sourceNeedsRelayout = (sourceNeedsRelayout || hasImageDiff || hasLayoutDifference(layerDiff, layerImpl->id));
-                    if (layerIsVisible) {
+                    if (layerNeedsRendering) {
                         filteredLayersForSource.push_back(layer->evaluatedProperties);
                         if (zoomFitsLayer) {
                             sourceNeedsRendering = true;
@@ -269,7 +269,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
             } 
 
             // Handle layers without source.
-            if (layerIsVisible && zoomFitsLayer && sourceImpl.get() == sourceImpls->at(0).get()) {
+            if (layerNeedsRendering && zoomFitsLayer && sourceImpl.get() == sourceImpls->at(0).get()) {
                 if (!backend.contextIsShared() && layerImpl.get() == layerImpls->at(0).get()) {
                     const auto& solidBackground = layer->getSolidBackground();
                     if (solidBackground) {

--- a/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
+++ b/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
@@ -28,10 +28,7 @@ void RenderCustomGeometrySource::update(Immutable<style::Source::Impl> baseImpl_
                                  const bool needsRendering,
                                  const bool needsRelayout,
                                  const TileParameters& parameters) {
-    if (baseImpl != baseImpl_) {
-        std::swap(baseImpl, baseImpl_);
-        tilePyramid.clearAll();
-    }
+    std::swap(baseImpl, baseImpl_);
 
     enabled = needsRendering;
 


### PR DESCRIPTION
mapbox/mapbox-gl-native#15155 and mapbox/mapbox-gl-native#15157 backported some necessary fixes to `release-mojito`, but unfortunately we need to finish up https://github.com/mapbox/mapbox-gl-native/pull/15161 before proceeding with these cherry-picks.

/cc @pozdnyakov @alexshalamov @julianrex 