### PR TITLE
Un-revert two cherry-picks to release-mojito

### DIFF
--- a/include/mbgl/style/layer_properties.hpp
+++ b/include/mbgl/style/layer_properties.hpp
@@ -15,6 +15,8 @@ public:
     virtual ~LayerProperties() = default;
 
     Immutable<Layer::Impl> baseImpl;
+    // Contains render passes used by the renderer, see `mbgl::RenderPass`.
+    uint8_t renderPasses = 0u;
 
 protected:
     LayerProperties(Immutable<Layer::Impl> impl) : baseImpl(std::move(impl)) {}

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -37,6 +37,7 @@ void RenderBackgroundLayer::evaluate(const PropertyEvaluationParameters &paramet
 
     passes = properties->evaluated.get<style::BackgroundOpacity>() > 0 ? RenderPass::Translucent
                                                                        : RenderPass::None;
+    properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 }
 
@@ -129,8 +130,8 @@ void RenderBackgroundLayer::render(PaintParameters& parameters, RenderSource*) {
 }
 
 optional<Color> RenderBackgroundLayer::getSolidBackground() const {
-    const auto& evaluated = static_cast<const BackgroundLayerProperties&>(*evaluatedProperties).evaluated;
-    if (!evaluated.get<BackgroundPattern>().from.empty()) {
+    const auto& evaluated = getEvaluated<BackgroundLayerProperties>(evaluatedProperties);
+    if (!evaluated.get<BackgroundPattern>().from.empty() || evaluated.get<style::BackgroundOpacity>() <= 0.0f) {
         return nullopt;
     }
 

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -41,6 +41,7 @@ void RenderCircleLayer::evaluate(const PropertyEvaluationParameters& parameters)
               && (evaluated.get<style::CircleOpacity>().constantOr(1) > 0 ||
                   evaluated.get<style::CircleStrokeOpacity>().constantOr(1) > 0))
              ? RenderPass::Translucent : RenderPass::None;
+    properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 }
 
@@ -58,7 +59,7 @@ void RenderCircleLayer::render(PaintParameters& parameters, RenderSource*) {
     }
 
     for (const RenderTile& tile : renderTiles) {
-        const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
+        const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
         if (!renderData) {
             continue;
         }

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -44,6 +44,7 @@ void RenderFillExtrusionLayer::evaluate(const PropertyEvaluationParameters& para
     passes = (properties->evaluated.get<style::FillExtrusionOpacity>() > 0)
                  ? (RenderPass::Translucent | RenderPass::Pass3D)
                  : RenderPass::None;
+    properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 }
 
@@ -119,7 +120,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters, RenderSource*
 
         if (unevaluated.get<FillExtrusionPattern>().isUndefined()) {
             for (const RenderTile& tile : renderTiles) {
-                const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
+                const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
                 if (!renderData) {
                     continue;
                 }
@@ -145,7 +146,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters, RenderSource*
             }
         } else {
             for (const RenderTile& tile : renderTiles) {
-                const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
+                const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
                 if (!renderData) {
                     continue;
                 }

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -59,7 +59,7 @@ void RenderFillLayer::evaluate(const PropertyEvaluationParameters& parameters) {
     } else {
         passes |= RenderPass::Opaque;
     }
-
+    properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 }
 
@@ -74,7 +74,7 @@ bool RenderFillLayer::hasCrossfade() const {
 void RenderFillLayer::render(PaintParameters& parameters, RenderSource*) {
     if (unevaluated.get<FillPattern>().isUndefined()) {
         for (const RenderTile& tile : renderTiles) {
-            const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
+            const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
             if (!renderData) {
                 continue;
             }
@@ -158,7 +158,7 @@ void RenderFillLayer::render(PaintParameters& parameters, RenderSource*) {
         }
 
         for (const RenderTile& tile : renderTiles) {
-            const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
+            const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
             if (!renderData) {
                 continue;
             }

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -43,7 +43,7 @@ void RenderHeatmapLayer::evaluate(const PropertyEvaluationParameters& parameters
     passes = (properties->evaluated.get<style::HeatmapOpacity>() > 0)
             ? (RenderPass::Translucent | RenderPass::Pass3D)
             : RenderPass::None;
-
+    properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 }
 
@@ -89,7 +89,7 @@ void RenderHeatmapLayer::render(PaintParameters& parameters, RenderSource*) {
             "heatmap texture", { *renderTexture, Color{ 0.0f, 0.0f, 0.0f, 1.0f }, {}, {} });
 
         for (const RenderTile& tile : renderTiles) {
-            const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
+            const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
             if (!renderData) {
                 continue;
             }

--- a/src/mbgl/renderer/layers/render_hillshade_layer.cpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.cpp
@@ -53,7 +53,7 @@ void RenderHillshadeLayer::evaluate(const PropertyEvaluationParameters& paramete
     passes = (properties->evaluated.get<style::HillshadeExaggeration >() > 0)
                  ? (RenderPass::Translucent | RenderPass::Pass3D)
                  : RenderPass::None;
-
+    properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 }
 

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -46,6 +46,7 @@ void RenderLineLayer::evaluate(const PropertyEvaluationParameters& parameters) {
               && evaluated.get<style::LineColor>().constantOr(Color::black()).a > 0
               && evaluated.get<style::LineWidth>().constantOr(1.0) > 0)
              ? RenderPass::Translucent : RenderPass::None;
+    properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 }
 
@@ -63,7 +64,7 @@ void RenderLineLayer::render(PaintParameters& parameters, RenderSource*) {
     }
 
     for (const RenderTile& tile : renderTiles) {
-        const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
+        const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
         if (!renderData) {
             continue;
         }

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -34,6 +34,7 @@ void RenderRasterLayer::evaluate(const PropertyEvaluationParameters& parameters)
         staticImmutableCast<RasterLayer::Impl>(baseImpl),
         unevaluated.evaluate(parameters));
     passes = properties->evaluated.get<style::RasterOpacity>() > 0 ? RenderPass::Translucent : RenderPass::None;
+    properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 }
 

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -366,6 +366,7 @@ void RenderSymbolLayer::evaluate(const PropertyEvaluationParameters& parameters)
     passes = ((evaluated.get<style::IconOpacity>().constantOr(1) > 0 && hasIconOpacity && iconSize > 0)
               || (evaluated.get<style::TextOpacity>().constantOr(1) > 0 && hasTextOpacity && textSize > 0))
              ? RenderPass::Translucent : RenderPass::None;
+    properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 }
 
@@ -471,7 +472,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters, RenderSource*) {
     };
 
     for (const RenderTile& tile : renderTiles) {
-        const LayerRenderData* renderData = tile.tile.getLayerRenderData(*baseImpl);
+        const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
         if (!renderData) {
             continue;
         }
@@ -619,6 +620,7 @@ style::TextPaintProperties::PossiblyEvaluated RenderSymbolLayer::textPaintProper
 void RenderSymbolLayer::setRenderTiles(RenderTiles tiles, const TransformState& state) {
     auto filterFn = [](auto& tile){ return !tile.tile.isRenderable(); };
     renderTiles = RenderLayer::filterRenderTiles(std::move(tiles), filterFn);
+    addRenderPassesFromTiles();
     // Sort symbol tiles in opposite y position, so tiles with overlapping symbols are drawn
     // on top of each other, with lower symbols being drawn on top of higher symbols.
     std::sort(renderTiles.begin(), renderTiles.end(), [&state](const auto& a, const auto& b) {

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -95,6 +95,10 @@ protected:
     using FilterFunctionPtr = bool (*)(RenderTile&);
     RenderTiles filterRenderTiles(RenderTiles, FilterFunctionPtr) const;
 
+    void addRenderPassesFromTiles();
+
+    const LayerRenderData* getRenderDataForPass(const RenderTile&, RenderPass) const;
+
 protected:
     // Stores current set of tiles to be rendered for this layer.
     std::vector<std::reference_wrapper<RenderTile>> renderTiles;

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -250,14 +250,14 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
             const Immutable<Layer::Impl>& layerImpl = *it;
             RenderLayer* layer = getRenderLayer(layerImpl->id);
             const auto* layerInfo = layerImpl->getTypeInfo();
-            const bool layerNeedsRendering = layer->needsRendering();
+            const bool layerIsVisible = layer->baseImpl->visibility != style::VisibilityType::None;
             const bool zoomFitsLayer = layer->supportsZoom(zoomHistory.lastZoom);
             staticData->has3D = (staticData->has3D || layerInfo->pass3d == LayerTypeInfo::Pass3D::Required);
 
             if (layerInfo->source != LayerTypeInfo::Source::NotRequired) {
                 if (layerImpl->source == sourceImpl->id) {
                     sourceNeedsRelayout = (sourceNeedsRelayout || hasImageDiff || hasLayoutDifference(layerDiff, layerImpl->id));
-                    if (layerNeedsRendering) {
+                    if (layerIsVisible) {
                         filteredLayersForSource.push_back(layer->evaluatedProperties);
                         if (zoomFitsLayer) {
                             sourceNeedsRendering = true;
@@ -269,7 +269,7 @@ void Renderer::Impl::render(const UpdateParameters& updateParameters) {
             } 
 
             // Handle layers without source.
-            if (layerNeedsRendering && zoomFitsLayer && sourceImpl.get() == sourceImpls->at(0).get()) {
+            if (layerIsVisible && zoomFitsLayer && sourceImpl.get() == sourceImpls->at(0).get()) {
                 if (!backend.contextIsShared() && layerImpl.get() == layerImpls->at(0).get()) {
                     const auto& solidBackground = layer->getSolidBackground();
                     if (solidBackground) {

--- a/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
+++ b/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
@@ -28,7 +28,10 @@ void RenderCustomGeometrySource::update(Immutable<style::Source::Impl> baseImpl_
                                  const bool needsRendering,
                                  const bool needsRelayout,
                                  const TileParameters& parameters) {
-    std::swap(baseImpl, baseImpl_);
+    if (baseImpl != baseImpl_) {
+        std::swap(baseImpl, baseImpl_);
+        tilePyramid.clearAll();
+    }
 
     enabled = needsRendering;
 


### PR DESCRIPTION
Undoes the temporary reversion of #15155 and #15157 in #15184. Waiting for #15161 to merge and `ios-v4.11.1` to be released.

/cc @pozdnyakov @alexshalamov @julianrex