### PR TITLE
[core] Release quad data after vertex buffers are created

### DIFF
--- a/src/mbgl/layout/symbol_instance.cpp
+++ b/src/mbgl/layout/symbol_instance.cpp
@@ -18,55 +18,22 @@ const Shaping& getAnyShaping(const ShapedTextOrientations& shapedTextOrientation
 
 } // namespace
 
-SymbolInstance::SymbolInstance(Anchor& anchor_,
-                               GeometryCoordinates line_,
-                               const ShapedTextOrientations& shapedTextOrientations,
-                               optional<PositionedIcon> shapedIcon,
-                               const SymbolLayoutProperties::Evaluated& layout,
-                               const float layoutTextSize,
-                               const float textBoxScale_,
-                               const float textPadding,
-                               const SymbolPlacementType textPlacement,
-                               const std::array<float, 2> textOffset_,
-                               const float iconBoxScale,
-                               const float iconPadding,
-                               const std::array<float, 2> iconOffset_,
-                               const GlyphPositions& positions,
-                               const IndexedSubfeature& indexedFeature,
-                               const std::size_t layoutFeatureIndex_,
-                               const std::size_t dataFeatureIndex_,
-                               std::u16string key_,
-                               const float overscaling,
-                               const float rotate,
-                               float radialTextOffset_) :
-    anchor(anchor_),
-    line(line_),
-    hasText(false),
-    hasIcon(shapedIcon),
-
-    // Create the collision features that will be used to check whether this symbol instance can be placed
-    // As a collision approximation, we can use either the vertical or any of the horizontal versions of the feature
-    textCollisionFeature(line_, anchor, getAnyShaping(shapedTextOrientations), textBoxScale_, textPadding, textPlacement, indexedFeature, overscaling, rotate),
-    iconCollisionFeature(line_, anchor, shapedIcon, iconBoxScale, iconPadding, indexedFeature, rotate),
-    writingModes(WritingModeType::None),
-    layoutFeatureIndex(layoutFeatureIndex_),
-    dataFeatureIndex(dataFeatureIndex_),
-    textOffset(textOffset_),
-    iconOffset(iconOffset_),
-    key(std::move(key_)),
-    textBoxScale(textBoxScale_),
-    radialTextOffset(radialTextOffset_),
-    singleLine(shapedTextOrientations.singleLine) {
-
+SymbolInstanceSharedData::SymbolInstanceSharedData(GeometryCoordinates line_,
+                                                   const ShapedTextOrientations& shapedTextOrientations,
+                                                   const optional<PositionedIcon>& shapedIcon,
+                                                   const style::SymbolLayoutProperties::Evaluated& layout,
+                                                   const float layoutTextSize,
+                                                   const style::SymbolPlacementType textPlacement,
+                                                   const std::array<float, 2>& textOffset,
+                                                   const GlyphPositions& positions) : line(std::move(line_)) {
     // Create the quads used for rendering the icon and glyphs.
     if (shapedIcon) {
         iconQuad = getIconQuad(*shapedIcon, layout, layoutTextSize, shapedTextOrientations.horizontal);
     }
-    
+
     bool singleLineInitialized = false;
     const auto initHorizontalGlyphQuads = [&] (SymbolQuads& quads, const Shaping& shaping) {
-        writingModes |= WritingModeType::Horizontal;
-        if (!singleLine) {
+        if (!shapedTextOrientations.singleLine) {
             quads = getGlyphQuads(shaping, textOffset, layout, textPlacement, positions);
             return;
         }
@@ -75,7 +42,7 @@ SymbolInstance::SymbolInstance(Anchor& anchor_,
             singleLineInitialized = true;
         }
     };
-    
+
     if (shapedTextOrientations.right) {
         initHorizontalGlyphQuads(rightJustifiedGlyphQuads, shapedTextOrientations.right);
     }
@@ -89,12 +56,97 @@ SymbolInstance::SymbolInstance(Anchor& anchor_,
     }
 
     if (shapedTextOrientations.vertical) {
-        writingModes |= WritingModeType::Vertical;
         verticalGlyphQuads = getGlyphQuads(shapedTextOrientations.vertical, textOffset, layout, textPlacement, positions);
     }
+}
 
+bool SymbolInstanceSharedData::empty() const {
+    return rightJustifiedGlyphQuads.empty() && centerJustifiedGlyphQuads.empty() && leftJustifiedGlyphQuads.empty() && verticalGlyphQuads.empty();
+}
+
+SymbolInstance::SymbolInstance(Anchor& anchor_,
+                               std::shared_ptr<SymbolInstanceSharedData> sharedData_,
+                               const ShapedTextOrientations& shapedTextOrientations,
+                               const optional<PositionedIcon>& shapedIcon,
+                               const float textBoxScale_,
+                               const float textPadding,
+                               const SymbolPlacementType textPlacement,
+                               const std::array<float, 2>& textOffset_,
+                               const float iconBoxScale,
+                               const float iconPadding,
+                               const std::array<float, 2>& iconOffset_,
+                               const IndexedSubfeature& indexedFeature,
+                               const std::size_t layoutFeatureIndex_,
+                               const std::size_t dataFeatureIndex_,
+                               std::u16string key_,
+                               const float overscaling,
+                               const float rotate,
+                               float radialTextOffset_) :
+    sharedData(std::move(sharedData_)),
+    anchor(anchor_),
     // 'hasText' depends on finding at least one glyph in the shaping that's also in the GlyphPositionMap
-    hasText = !rightJustifiedGlyphQuads.empty() || !centerJustifiedGlyphQuads.empty() || !leftJustifiedGlyphQuads.empty() || !verticalGlyphQuads.empty();
+    hasText(!sharedData->empty()),
+    hasIcon(shapedIcon),
+    // Create the collision features that will be used to check whether this symbol instance can be placed
+    // As a collision approximation, we can use either the vertical or any of the horizontal versions of the feature
+    textCollisionFeature(sharedData->line, anchor, getAnyShaping(shapedTextOrientations), textBoxScale_, textPadding, textPlacement, indexedFeature, overscaling, rotate),
+    iconCollisionFeature(sharedData->line, anchor, shapedIcon, iconBoxScale, iconPadding, indexedFeature, rotate),
+    writingModes(WritingModeType::None),
+    layoutFeatureIndex(layoutFeatureIndex_),
+    dataFeatureIndex(dataFeatureIndex_),
+    textOffset(textOffset_),
+    iconOffset(iconOffset_),
+    key(std::move(key_)),
+    textBoxScale(textBoxScale_),
+    radialTextOffset(radialTextOffset_),
+    singleLine(shapedTextOrientations.singleLine) {
+
+    rightJustifiedGlyphQuadsSize = sharedData->rightJustifiedGlyphQuads.size();
+    centerJustifiedGlyphQuadsSize = sharedData->centerJustifiedGlyphQuads.size();
+    leftJustifiedGlyphQuadsSize = sharedData->leftJustifiedGlyphQuads.size();
+    verticalGlyphQuadsSize = sharedData->verticalGlyphQuads.size();
+
+    if (rightJustifiedGlyphQuadsSize || centerJustifiedGlyphQuadsSize || leftJustifiedGlyphQuadsSize) {
+        writingModes |= WritingModeType::Horizontal;
+    }
+
+    if (verticalGlyphQuadsSize) {
+        writingModes |= WritingModeType::Vertical;
+    }
+}
+
+const GeometryCoordinates& SymbolInstance::line() const {
+    assert(sharedData);
+    return sharedData->line;
+}
+
+const SymbolQuads& SymbolInstance::rightJustifiedGlyphQuads() const {
+    assert(sharedData);
+    return sharedData->rightJustifiedGlyphQuads;
+}
+
+const SymbolQuads& SymbolInstance::leftJustifiedGlyphQuads() const {
+    assert(sharedData);
+    return sharedData->leftJustifiedGlyphQuads;
+}
+
+const SymbolQuads& SymbolInstance::centerJustifiedGlyphQuads() const {
+    assert(sharedData);
+    return sharedData->centerJustifiedGlyphQuads;
+}
+
+const SymbolQuads& SymbolInstance::verticalGlyphQuads() const {
+    assert(sharedData);
+    return sharedData->verticalGlyphQuads;
+}
+
+const optional<SymbolQuad>& SymbolInstance::iconQuad() const {
+    assert(sharedData);
+    return sharedData->iconQuad;
+}
+
+void SymbolInstance::releaseSharedData() {
+    sharedData.reset();
 }
 
 optional<size_t> SymbolInstance::getDefaultHorizontalPlacedTextIndex() const {

--- a/src/mbgl/layout/symbol_instance.hpp
+++ b/src/mbgl/layout/symbol_instance.hpp
@@ -21,23 +21,39 @@ struct ShapedTextOrientations {
     bool singleLine = false;
 };
 
+struct SymbolInstanceSharedData {
+    SymbolInstanceSharedData(GeometryCoordinates line,
+                            const ShapedTextOrientations& shapedTextOrientations,
+                            const optional<PositionedIcon>& shapedIcon,
+                            const style::SymbolLayoutProperties::Evaluated& layout,
+                            const float layoutTextSize,
+                            const style::SymbolPlacementType textPlacement,
+                            const std::array<float, 2>& textOffset,
+                            const GlyphPositions& positions);
+    bool empty() const;
+    GeometryCoordinates line;
+    // Note: When singleLine == true, only `rightJustifiedGlyphQuads` is populated.
+    SymbolQuads rightJustifiedGlyphQuads;
+    SymbolQuads centerJustifiedGlyphQuads;
+    SymbolQuads leftJustifiedGlyphQuads;
+    SymbolQuads verticalGlyphQuads;
+    optional<SymbolQuad> iconQuad;
+};
+
 class SymbolInstance {
 public:
-    SymbolInstance(Anchor& anchor,
-                   GeometryCoordinates line,
+    SymbolInstance(Anchor& anchor_,
+                   std::shared_ptr<SymbolInstanceSharedData> sharedData,
                    const ShapedTextOrientations& shapedTextOrientations,
-                   optional<PositionedIcon> shapedIcon,
-                   const style::SymbolLayoutProperties::Evaluated&,
-                   const float layoutTextSize,
+                   const optional<PositionedIcon>& shapedIcon,
                    const float textBoxScale,
                    const float textPadding,
-                   style::SymbolPlacementType textPlacement,
-                   const std::array<float, 2> textOffset,
+                   const style::SymbolPlacementType textPlacement,
+                   const std::array<float, 2>& textOffset,
                    const float iconBoxScale,
                    const float iconPadding,
-                   const std::array<float, 2> iconOffset,
-                   const GlyphPositions&,
-                   const IndexedSubfeature&,
+                   const std::array<float, 2>& iconOffset,
+                   const IndexedSubfeature& indexedFeature,
                    const std::size_t layoutFeatureIndex,
                    const std::size_t dataFeatureIndex,
                    std::u16string key,
@@ -46,18 +62,27 @@ public:
                    float radialTextOffset);
 
     optional<size_t> getDefaultHorizontalPlacedTextIndex() const;
+    const GeometryCoordinates& line() const;
+    const SymbolQuads& rightJustifiedGlyphQuads() const;
+    const SymbolQuads& leftJustifiedGlyphQuads() const;
+    const SymbolQuads& centerJustifiedGlyphQuads() const;
+    const SymbolQuads& verticalGlyphQuads() const;
+    const optional<SymbolQuad>& iconQuad() const;
+    void releaseSharedData();
+
+private:
+    std::shared_ptr<SymbolInstanceSharedData> sharedData;
+
+public:
     Anchor anchor;
-    GeometryCoordinates line;
     bool hasText;
     bool hasIcon;
-    // Note: When singleLine == true, only `rightJustifiedGlyphQuads` is populated.
-    SymbolQuads rightJustifiedGlyphQuads;
-    SymbolQuads centerJustifiedGlyphQuads;
-    SymbolQuads leftJustifiedGlyphQuads;
 
-    SymbolQuads verticalGlyphQuads;
+    std::size_t rightJustifiedGlyphQuadsSize;
+    std::size_t centerJustifiedGlyphQuadsSize;
+    std::size_t leftJustifiedGlyphQuadsSize;
+    std::size_t verticalGlyphQuadsSize;
 
-    optional<SymbolQuad> iconQuad;
     CollisionFeature textCollisionFeature;
     CollisionFeature iconCollisionFeature;
     WritingModeType writingModes;

--- a/src/mbgl/layout/symbol_layout.hpp
+++ b/src/mbgl/layout/symbol_layout.hpp
@@ -51,7 +51,7 @@ private:
     void addFeature(const size_t,
                     const SymbolFeature&,
                     const ShapedTextOrientations& shapedTextOrientations,
-                    optional<PositionedIcon> shapedIcon,
+                    const optional<PositionedIcon>& shapedIcon,
                     const GlyphPositions&,
                     Point<float> textOffset);
 

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -114,7 +114,6 @@ public:
     std::unique_ptr<SymbolSizeBinder> iconSizeBinder;
 
     struct IconBuffer : public Buffer {
-        PremultipliedImage atlasImage;
     } icon;
 
     struct CollisionBuffer {

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -547,28 +547,28 @@ void Placement::updateBucketOpacities(SymbolBucket& bucket, const TransformState
         if (symbolInstance.hasText) {
             auto opacityVertex = SymbolSDFTextProgram::opacityVertex(opacityState.text.placed, opacityState.text.opacity);
             if (symbolInstance.placedRightTextIndex) {
-                for (size_t i = 0; i < symbolInstance.rightJustifiedGlyphQuads.size() * 4; i++) {
+                for (size_t i = 0; i < symbolInstance.rightJustifiedGlyphQuadsSize * 4; i++) {
                     bucket.text.opacityVertices.emplace_back(opacityVertex);
                 }
                 PlacedSymbol& placed = bucket.text.placedSymbols[*symbolInstance.placedRightTextIndex];
                 placed.hidden = opacityState.isHidden();
             }
             if (symbolInstance.placedCenterTextIndex && !symbolInstance.singleLine) {
-                for (size_t i = 0; i < symbolInstance.centerJustifiedGlyphQuads.size() * 4; i++) {
+                for (size_t i = 0; i < symbolInstance.centerJustifiedGlyphQuadsSize * 4; i++) {
                     bucket.text.opacityVertices.emplace_back(opacityVertex);
                 }
                 PlacedSymbol& placed = bucket.text.placedSymbols[*symbolInstance.placedCenterTextIndex];
                 placed.hidden = opacityState.isHidden();
             }
             if (symbolInstance.placedLeftTextIndex && !symbolInstance.singleLine) {
-                for (size_t i = 0; i < symbolInstance.leftJustifiedGlyphQuads.size() * 4; i++) {
+                for (size_t i = 0; i < symbolInstance.leftJustifiedGlyphQuadsSize * 4; i++) {
                     bucket.text.opacityVertices.emplace_back(opacityVertex);
                 }
                 PlacedSymbol& placed = bucket.text.placedSymbols[*symbolInstance.placedLeftTextIndex];
                 placed.hidden = opacityState.isHidden();
             }
             if (symbolInstance.placedVerticalTextIndex) {
-                for (size_t i = 0; i < symbolInstance.verticalGlyphQuads.size() * 4; i++) {
+                for (size_t i = 0; i < symbolInstance.verticalGlyphQuadsSize * 4; i++) {
                     bucket.text.opacityVertices.emplace_back(opacityVertex);
                 }
                 bucket.text.placedSymbols[*symbolInstance.placedVerticalTextIndex].hidden = opacityState.isHidden();
@@ -581,12 +581,10 @@ void Placement::updateBucketOpacities(SymbolBucket& bucket, const TransformState
         }
         if (symbolInstance.hasIcon) {
             auto opacityVertex = SymbolIconProgram::opacityVertex(opacityState.icon.placed, opacityState.icon.opacity);
-            if (symbolInstance.iconQuad) {
-                bucket.icon.opacityVertices.emplace_back(opacityVertex);
-                bucket.icon.opacityVertices.emplace_back(opacityVertex);
-                bucket.icon.opacityVertices.emplace_back(opacityVertex);
-                bucket.icon.opacityVertices.emplace_back(opacityVertex);
-            }
+            bucket.icon.opacityVertices.emplace_back(opacityVertex);
+            bucket.icon.opacityVertices.emplace_back(opacityVertex);
+            bucket.icon.opacityVertices.emplace_back(opacityVertex);
+            bucket.icon.opacityVertices.emplace_back(opacityVertex);
             if (symbolInstance.placedIconIndex) {
                 bucket.icon.placedSymbols[*symbolInstance.placedIconIndex].hidden = opacityState.isHidden();
             }

--- a/test/text/cross_tile_symbol_index.test.cpp
+++ b/test/text/cross_tile_symbol_index.test.cpp
@@ -11,7 +11,14 @@ SymbolInstance makeSymbolInstance(float x, float y, std::u16string key) {
     style::SymbolLayoutProperties::Evaluated layout_;
     IndexedSubfeature subfeature(0, "", "", 0);
     Anchor anchor(x, y, 0, 0);
-    return SymbolInstance(anchor, line, shaping, {}, layout_, 0, 0, 0, style::SymbolPlacementType::Point, {{0, 0}}, 0, 0, {{0, 0}}, positions, subfeature, 0, 0, key, 0, 0, 0.0f);
+    std::array<float, 2> textOffset{{0.0f, 0.0f}};
+    std::array<float, 2> iconOffset{{0.0f, 0.0f}};
+    style::SymbolPlacementType placementType = style::SymbolPlacementType::Point;
+
+    auto sharedData = std::make_shared<SymbolInstanceSharedData>(std::move(line),
+                                        shaping, nullopt, layout_, 0.0f, placementType,
+                                        textOffset, positions);
+    return SymbolInstance(anchor, std::move(sharedData), shaping, nullopt, 0, 0, placementType, textOffset, 0, 0, iconOffset, subfeature, 0, 0, key, 0, 0, 0.0f);
 }
 
 


### PR DESCRIPTION
When long line segments are rendered, engine could create thousands of symbol instances for the same label that is repeated along the line for different anchors (e.g., road labels / shields).

This PR introduces code that shares symbol quads between symbol instances and releases aux data structures once vertex buffers are created.

## Before:
<img width="447" alt="Screen Shot 2019-07-21 at 12 21 25" src="https://user-images.githubusercontent.com/1001009/61589572-a60f6300-abb4-11e9-86c4-63df9dc2dde2.png">

## After:
<img width="476" alt="Screen Shot 2019-07-21 at 12 23 08" src="https://user-images.githubusercontent.com/1001009/61589576-ac054400-abb4-11e9-9160-e9003b6a7408.png">

Partially fixes issue #15022
