### PR TITLE
Remove layers first when clearing the style

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Style.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Style.java
@@ -518,17 +518,17 @@ public class Style {
    */
   void clear() {
     fullyLoaded = false;
-    for (Source source : sources.values()) {
-      if (source != null) {
-        source.setDetached();
-        nativeMap.removeSource(source);
-      }
-    }
-
     for (Layer layer : layers.values()) {
       if (layer != null) {
         layer.setDetached();
         nativeMap.removeLayer(layer);
+      }
+    }
+
+    for (Source source : sources.values()) {
+      if (source != null) {
+        source.setDetached();
+        nativeMap.removeSource(source);
       }
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/StyleTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/StyleTest.kt
@@ -8,10 +8,7 @@ import com.mapbox.mapboxsdk.style.layers.SymbolLayer
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions
 import com.mapbox.mapboxsdk.style.sources.CannotAddSourceException
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.spyk
-import io.mockk.verify
+import io.mockk.*
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -408,4 +405,22 @@ class StyleTest {
             Assert.assertEquals("Layer that failed to be added shouldn't be cached", layer1, mapboxMap.style!!.getLayer("layer1"))
         }
     }
+
+  @Test
+  fun testClearRemovesSourcesFirst() {
+    val source1 = mockk<GeoJsonSource>(relaxed = true)
+    every { source1.id } returns "source1"
+    val layer1 = mockk<SymbolLayer>(relaxed = true)
+    every { layer1.id } returns "layer1"
+
+    val builder = Style.Builder().withLayer(layer1).withSource(source1)
+    mapboxMap.setStyle(builder)
+    mapboxMap.notifyStyleLoaded()
+    mapboxMap.setStyle(Style.MAPBOX_STREETS)
+
+    verifyOrder {
+      nativeMapView.removeLayer(layer1)
+      nativeMapView.removeSource(source1)
+    }
+  }
 }


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-plugins-android/pull/999#issuecomment-513293296.

Whenever a style was changed and there were active, runtime added layers and sources, we were removing them in the wrong order causing a warning log.