### PR TITLE
[core] Avoid geometry collections copying

### DIFF
--- a/benchmark/src/mbgl/benchmark/stub_geometry_tile_feature.hpp
+++ b/benchmark/src/mbgl/benchmark/stub_geometry_tile_feature.hpp
@@ -35,7 +35,7 @@ public:
         return properties.count(key) ? properties.at(key) : optional<Value>();
     }
 
-    GeometryCollection getGeometries() const override {
+    const GeometryCollection& getGeometries() const override {
         return geometry;
     }
 };

--- a/src/mbgl/annotation/annotation_tile.cpp
+++ b/src/mbgl/annotation/annotation_tile.cpp
@@ -58,7 +58,7 @@ FeatureIdentifier AnnotationTileFeature::getID() const {
     return data->id;
 }
 
-GeometryCollection AnnotationTileFeature::getGeometries() const {
+const GeometryCollection& AnnotationTileFeature::getGeometries() const {
     return data->geometries;
 }
 

--- a/src/mbgl/annotation/annotation_tile.hpp
+++ b/src/mbgl/annotation/annotation_tile.hpp
@@ -28,7 +28,7 @@ public:
     FeatureType getType() const override;
     optional<Value> getValue(const std::string&) const override;
     FeatureIdentifier getID() const override;
-    GeometryCollection getGeometries() const override;
+    const GeometryCollection& getGeometries() const override;
 
 private:
     std::shared_ptr<const AnnotationTileFeatureData> data;

--- a/src/mbgl/geometry/feature_index.cpp
+++ b/src/mbgl/geometry/feature_index.cpp
@@ -159,7 +159,7 @@ void FeatureIndex::addFeature(
             continue;
         }
 
-        result[layerID].push_back(convertFeature(*geometryTileFeature, tileID));
+        result[layerID].emplace_back(convertFeature(*geometryTileFeature, tileID));
     }
 }
 

--- a/src/mbgl/layout/pattern_layout.hpp
+++ b/src/mbgl/layout/pattern_layout.hpp
@@ -106,7 +106,7 @@ public:
             const auto i = patternFeature.i;
             std::unique_ptr<GeometryTileFeature> feature = std::move(patternFeature.feature);
             const PatternLayerMap& patterns = patternFeature.patterns;
-            GeometryCollection geometries = feature->getGeometries();
+            const GeometryCollection& geometries = feature->getGeometries();
 
             bucket->addFeature(*feature, geometries, patternPositions, patterns);
             featureIndex->insert(geometries, i, sourceLayerID, bucketLeaderID);

--- a/src/mbgl/layout/symbol_feature.hpp
+++ b/src/mbgl/layout/symbol_feature.hpp
@@ -20,7 +20,7 @@ public:
     optional<Value> getValue(const std::string& key) const override { return feature->getValue(key); };
     std::unordered_map<std::string,Value> getProperties() const override { return feature->getProperties(); };
     FeatureIdentifier getID() const override { return feature->getID(); };
-    GeometryCollection getGeometries() const override { return geometry; };
+    const GeometryCollection& getGeometries() const override { return geometry; };
 
     friend bool operator < (const SymbolFeature& lhs, const SymbolFeature& rhs) {
         return lhs.sortKey <  rhs.sortKey;

--- a/src/mbgl/layout/symbol_feature.hpp
+++ b/src/mbgl/layout/symbol_feature.hpp
@@ -13,7 +13,7 @@ class SymbolFeature : public GeometryTileFeature {
 public:
     SymbolFeature(std::unique_ptr<GeometryTileFeature> feature_) :
         feature(std::move(feature_)),
-        geometry(feature->getGeometries()) // we need a mutable copy of the geometry for mergeLines()
+        geometry(feature->getGeometries().clone()) // we need a mutable copy of the geometry for mergeLines()
     {}
     
     FeatureType getType() const override { return feature->getType(); }

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -167,7 +167,7 @@ bool RenderCircleLayer::queryIntersectsFeature(
         projectQueryGeometry(translatedQueryGeometry, posMatrix, transformState.getSize());
     auto transformedSize = alignWithMap ? size * pixelsToTileUnits : size;
 
-    auto geometry = feature.getGeometries();
+    const auto& geometry = feature.getGeometries();
     for (auto& ring : geometry) {
         for (auto& point : ring) {
             const GeometryCoordinate& transformedPoint = alignWithMap ? point : projectPoint(point, posMatrix, transformState.getSize());

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -214,16 +214,22 @@ void RenderLineLayer::render(PaintParameters& parameters) {
     }
 }
 
-optional<GeometryCollection> offsetLine(const GeometryCollection& rings, const double offset) {
-    if (offset == 0) return {};
+namespace {
+
+GeometryCollection offsetLine(const GeometryCollection& rings, double offset) {
+    assert(offset != 0.0f);
+    assert(!rings.empty());
 
     GeometryCollection newRings;
-    Point<double> zero(0, 0);
+    newRings.reserve(rings.size());
+
+    const Point<double> zero(0, 0);
     for (const auto& ring : rings) {
         newRings.emplace_back();
         auto& newRing = newRings.back();
+        newRing.reserve(ring.size());
 
-        for (auto i = ring.begin(); i != ring.end(); i++) {
+        for (auto i = ring.begin(); i != ring.end(); ++i) {
             auto& p = *i;
 
             Point<double> aToB = i == ring.begin() ?
@@ -237,12 +243,14 @@ optional<GeometryCollection> offsetLine(const GeometryCollection& rings, const d
             const double cosHalfAngle = extrude.x * bToC.x + extrude.y * bToC.y;
             extrude *= (1.0 / cosHalfAngle);
 
-            newRing.push_back(convertPoint<int16_t>(extrude * offset) + p);
+            newRing.emplace_back(convertPoint<int16_t>(extrude * offset) + p);
         }
     }
 
     return newRings;
 }
+
+} // namespace
 
 bool RenderLineLayer::queryIntersectsFeature(
         const GeometryCoordinates& queryGeometry,
@@ -263,16 +271,21 @@ bool RenderLineLayer::queryIntersectsFeature(
     // Evaluate function
     auto offset = evaluated.get<style::LineOffset>()
                           .evaluate(feature, zoom, style::LineOffset::defaultValue()) * pixelsToTileUnits;
-
-    // Apply offset to geometry
-    auto offsetGeometry = offsetLine(feature.getGeometries(), offset);
-
     // Test intersection
     const float halfWidth = getLineWidth(feature, zoom) / 2.0 * pixelsToTileUnits;
+
+    // Apply offset to geometry
+    if (offset != 0.0f && !feature.getGeometries().empty()) {
+        return util::polygonIntersectsBufferedMultiLine(
+                translatedQueryGeometry.value_or(queryGeometry),
+                offsetLine(feature.getGeometries(), offset),
+                halfWidth);
+    }
+
     return util::polygonIntersectsBufferedMultiLine(
-            translatedQueryGeometry.value_or(queryGeometry),
-            offsetGeometry.value_or(feature.getGeometries()),
-            halfWidth);
+        translatedQueryGeometry.value_or(queryGeometry),
+        feature.getGeometries(),
+        halfWidth);
 }
 
 void RenderLineLayer::updateColorRamp() {

--- a/src/mbgl/style/expression/expression.cpp
+++ b/src/mbgl/style/expression/expression.cpp
@@ -17,7 +17,6 @@ public:
     }
     PropertyMap getProperties() const override { return feature.properties; }
     FeatureIdentifier getID() const override { return feature.id; }
-    const GeometryCollection& getGeometries() const override { return geometry; }
     optional<mbgl::Value> getValue(const std::string& key) const override {
         auto it = feature.properties.find(key);
         if (it != feature.properties.end()) {
@@ -25,8 +24,6 @@ public:
         }
         return optional<mbgl::Value>();
     }
-
-    GeometryCollection geometry;
 };
 
 

--- a/src/mbgl/style/expression/expression.cpp
+++ b/src/mbgl/style/expression/expression.cpp
@@ -17,7 +17,7 @@ public:
     }
     PropertyMap getProperties() const override { return feature.properties; }
     FeatureIdentifier getID() const override { return feature.id; }
-    GeometryCollection getGeometries() const override { return {}; }
+    const GeometryCollection& getGeometries() const override { return geometry; }
     optional<mbgl::Value> getValue(const std::string& key) const override {
         auto it = feature.properties.find(key);
         if (it != feature.properties.end()) {
@@ -25,6 +25,8 @@ public:
         }
         return optional<mbgl::Value>();
     }
+
+    GeometryCollection geometry;
 };
 
 

--- a/src/mbgl/tile/geojson_tile_data.hpp
+++ b/src/mbgl/tile/geojson_tile_data.hpp
@@ -25,15 +25,17 @@ public:
         return feature.id;
     }
 
-    GeometryCollection getGeometries() const override {
-        GeometryCollection geometry = apply_visitor(ToGeometryCollection(), feature.geometry);
+    const GeometryCollection& getGeometries() const override {
+        if (!geometry) {
+            geometry = apply_visitor(ToGeometryCollection(), feature.geometry);
 
-        // https://github.com/mapbox/geojson-vt-cpp/issues/44
-        if (getType() == FeatureType::Polygon) {
-            geometry = fixupPolygons(geometry);
+            // https://github.com/mapbox/geojson-vt-cpp/issues/44
+            if (getType() == FeatureType::Polygon) {
+                geometry = fixupPolygons(*geometry);
+            }
         }
 
-        return geometry;
+        return *geometry;
     }
 
     optional<Value> getValue(const std::string& key) const override {
@@ -43,6 +45,8 @@ public:
         }
         return optional<Value>();
     }
+
+    mutable optional<GeometryCollection> geometry;
 };
 
 class GeoJSONTileLayer : public GeometryTileLayer {

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -360,7 +360,7 @@ void GeometryTile::querySourceFeatures(
                     continue;
                 }
 
-                result.push_back(convertFeature(*feature, id.canonical));
+                result.emplace_back(convertFeature(*feature, id.canonical));
             }
         }
     }

--- a/src/mbgl/tile/geometry_tile_data.cpp
+++ b/src/mbgl/tile/geometry_tile_data.cpp
@@ -57,32 +57,31 @@ std::vector<GeometryCollection> classifyRings(const GeometryCollection& rings) {
     std::size_t len = rings.size();
 
     if (len <= 1) {
-        polygons.push_back(rings);
+        polygons.emplace_back(rings.clone());
         return polygons;
     }
 
     GeometryCollection polygon;
     int8_t ccw = 0;
 
-    for (std::size_t i = 0; i < len; i++) {
-        double area = signedArea(rings[i]);
+    for (const auto& ring : rings) {
+        double area = signedArea(ring);
+        if (area == 0) continue;
 
-        if (area == 0)
-            continue;
-
-        if (ccw == 0)
+        if (ccw == 0) {
             ccw = (area < 0 ? -1 : 1);
-
-        if (ccw == (area < 0 ? -1 : 1) && !polygon.empty()) {
-            polygons.push_back(polygon);
-            polygon.clear();
         }
 
-        polygon.push_back(rings[i]);
+        if (ccw == (area < 0 ? -1 : 1) && !polygon.empty()) {
+            polygons.emplace_back(std::move(polygon));
+        }
+
+        polygon.emplace_back(ring);
     }
 
-    if (!polygon.empty())
-        polygons.push_back(polygon);
+    if (!polygon.empty()) {
+        polygons.emplace_back(std::move(polygon));
+    }
 
     return polygons;
 }

--- a/src/mbgl/tile/geometry_tile_data.cpp
+++ b/src/mbgl/tile/geometry_tile_data.cpp
@@ -180,4 +180,9 @@ Feature convertFeature(const GeometryTileFeature& geometryTileFeature, const Can
     return feature;
 }
 
+const GeometryCollection& GeometryTileFeature::getGeometries() const {
+    static const GeometryCollection dummy;
+    return dummy;
+}
+
 } // namespace mbgl

--- a/src/mbgl/tile/geometry_tile_data.cpp
+++ b/src/mbgl/tile/geometry_tile_data.cpp
@@ -112,7 +112,7 @@ static Feature::geometry_type convertGeometry(const GeometryTileFeature& geometr
         );
     };
 
-    GeometryCollection geometries = geometryTileFeature.getGeometries();
+    const GeometryCollection& geometries = geometryTileFeature.getGeometries();
 
     switch (geometryTileFeature.getType()) {
         case FeatureType::Unknown: {

--- a/src/mbgl/tile/geometry_tile_data.hpp
+++ b/src/mbgl/tile/geometry_tile_data.hpp
@@ -44,7 +44,7 @@ public:
     virtual optional<Value> getValue(const std::string& key) const = 0;
     virtual PropertyMap getProperties() const { return PropertyMap(); }
     virtual FeatureIdentifier getID() const { return NullValue {}; }
-    virtual const GeometryCollection& getGeometries() const = 0;
+    virtual const GeometryCollection& getGeometries() const;
 };
 
 class GeometryTileLayer {

--- a/src/mbgl/tile/geometry_tile_data.hpp
+++ b/src/mbgl/tile/geometry_tile_data.hpp
@@ -44,7 +44,7 @@ public:
     virtual optional<Value> getValue(const std::string& key) const = 0;
     virtual PropertyMap getProperties() const { return PropertyMap(); }
     virtual FeatureIdentifier getID() const { return NullValue {}; }
-    virtual GeometryCollection getGeometries() const = 0;
+    virtual const GeometryCollection& getGeometries() const = 0;
 };
 
 class GeometryTileLayer {

--- a/src/mbgl/tile/geometry_tile_data.hpp
+++ b/src/mbgl/tile/geometry_tile_data.hpp
@@ -35,6 +35,13 @@ public:
     GeometryCollection(Args&&... args) : std::vector<GeometryCoordinates>(std::forward<Args>(args)...) {}
     GeometryCollection(std::initializer_list<GeometryCoordinates> args)
       : std::vector<GeometryCoordinates>(std::move(args)) {}
+    GeometryCollection(GeometryCollection&&) = default;
+    GeometryCollection& operator=(GeometryCollection&&) = default;
+
+    GeometryCollection clone() const { return GeometryCollection(*this); }
+
+private:
+    GeometryCollection(const GeometryCollection&) = default;
 };
 
 class GeometryTileFeature {

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -382,7 +382,7 @@ void GeometryTileWorker::parse() {
                 if (!filter(expression::EvaluationContext { static_cast<float>(this->id.overscaledZ), feature.get() }))
                     continue;
 
-                GeometryCollection geometries = feature->getGeometries();
+                const GeometryCollection& geometries = feature->getGeometries();
                 bucket->addFeature(*feature, geometries, {}, PatternLayerMap ());
                 featureIndex->insert(geometries, i, sourceLayerID, leaderImpl.id);
             }

--- a/src/mbgl/tile/vector_tile_data.cpp
+++ b/src/mbgl/tile/vector_tile_data.cpp
@@ -34,14 +34,15 @@ FeatureIdentifier VectorTileFeature::getID() const {
     return feature.getID();
 }
 
-GeometryCollection VectorTileFeature::getGeometries() const {
-    const float scale = float(util::EXTENT) / feature.getExtent();
-    auto lines = feature.getGeometries<GeometryCollection>(scale);
-    if (feature.getVersion() >= 2 || feature.getType() != mapbox::vector_tile::GeomType::POLYGON) {
-        return lines;
-    } else {
-        return fixupPolygons(lines);
+const GeometryCollection& VectorTileFeature::getGeometries() const {
+    if (!lines) {
+        const float scale = float(util::EXTENT) / feature.getExtent();
+        lines = feature.getGeometries<GeometryCollection>(scale);
+        if (feature.getVersion() < 2 && feature.getType() == mapbox::vector_tile::GeomType::POLYGON) {
+            lines = fixupPolygons(*lines);
+        }
     }
+    return *lines;
 }
 
 VectorTileLayer::VectorTileLayer(std::shared_ptr<const std::string> data_,

--- a/src/mbgl/tile/vector_tile_data.hpp
+++ b/src/mbgl/tile/vector_tile_data.hpp
@@ -17,10 +17,11 @@ public:
     optional<Value> getValue(const std::string& key) const override;
     std::unordered_map<std::string, Value> getProperties() const override;
     FeatureIdentifier getID() const override;
-    GeometryCollection getGeometries() const override;
+    const GeometryCollection& getGeometries() const override;
 
 private:
     mapbox::vector_tile::feature feature;
+    mutable optional<GeometryCollection> lines;
 };
 
 class VectorTileLayer : public GeometryTileLayer {

--- a/test/gl/bucket.test.cpp
+++ b/test/gl/bucket.test.cpp
@@ -131,7 +131,7 @@ TEST(Buckets, SymbolBucket) {
 
     // SymbolBucket::addFeature() is a no-op.
     GeometryCollection point { { { 0, 0 } } };
-    bucket.addFeature(StubGeometryTileFeature { {}, FeatureType::Point, point, properties }, point, {}, PatternLayerMap());
+    bucket.addFeature(StubGeometryTileFeature { {}, FeatureType::Point, std::move(point), properties }, point, {}, PatternLayerMap());
     ASSERT_FALSE(bucket.hasData());
     ASSERT_FALSE(bucket.needsUpload());
 

--- a/test/src/mbgl/test/stub_geometry_tile_feature.hpp
+++ b/test/src/mbgl/test/stub_geometry_tile_feature.hpp
@@ -33,7 +33,7 @@ public:
         return properties.count(key) ? properties.at(key) : optional<Value>();
     }
 
-    GeometryCollection getGeometries() const override {
+    const GeometryCollection& getGeometries() const override {
         return geometry;
     }
 };

--- a/test/util/merge_lines.test.cpp
+++ b/test/util/merge_lines.test.cpp
@@ -42,14 +42,14 @@ TEST(MergeLines, SameText) {
     input1.push_back(SymbolFeatureStub({}, FeatureType::LineString, {{{6, 0}, {7, 0}, {8, 0}}}, properties, aaa, {}, 0));
     input1.push_back(SymbolFeatureStub({}, FeatureType::LineString, {{{5, 0}, {6, 0}}}, properties, aaa, {}, 0));
 
-    const std::vector<StubGeometryTileFeature> expected1 = {
-        { {}, FeatureType::LineString, {{{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}}}, properties },
-        { {}, FeatureType::LineString, {{{4, 0}, {5, 0}, {6, 0}}}, properties },
-        { {}, FeatureType::LineString, {{{5, 0}, {6, 0}, {7, 0}, {8, 0}, {9, 0}}}, properties },
-        { {}, FeatureType::LineString, { emptyLine }, properties },
-        { {}, FeatureType::LineString, { emptyLine }, properties },
-        { {}, FeatureType::LineString, { emptyLine }, properties }
-    };
+    std::vector<StubGeometryTileFeature> expected1;
+    expected1.emplace_back(StubGeometryTileFeature({}, FeatureType::LineString, {{{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}}}, properties));
+    expected1.emplace_back(StubGeometryTileFeature({}, FeatureType::LineString, {{{4, 0}, {5, 0}, {6, 0}}}, properties));
+    expected1.emplace_back(StubGeometryTileFeature({}, FeatureType::LineString, {{{5, 0}, {6, 0}, {7, 0}, {8, 0}, {9, 0}}}, properties));
+    expected1.emplace_back(StubGeometryTileFeature({}, FeatureType::LineString, { emptyLine }, properties));
+    expected1.emplace_back(StubGeometryTileFeature({}, FeatureType::LineString, { emptyLine }, properties));
+    expected1.emplace_back(StubGeometryTileFeature({}, FeatureType::LineString, { emptyLine }, properties));
+    
     
     mbgl::util::mergeLines(input1);
 
@@ -65,11 +65,11 @@ TEST(MergeLines, BothEnds) {
     input2.push_back(SymbolFeatureStub { {}, FeatureType::LineString, {{{4, 0}, {5, 0}, {6, 0}}}, properties, aaa, {}, 0 });
     input2.push_back(SymbolFeatureStub { {}, FeatureType::LineString, {{{2, 0}, {3, 0}, {4, 0}}}, properties, aaa, {}, 0 });
 
-    const std::vector<StubGeometryTileFeature> expected2 = {
-        { {}, FeatureType::LineString, {{{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}, {5, 0}, {6, 0}}}, properties },
-        { {}, FeatureType::LineString, { emptyLine }, properties },
-        { {}, FeatureType::LineString, { emptyLine }, properties }
-    };
+    std::vector<StubGeometryTileFeature> expected2;
+    expected2.emplace_back(StubGeometryTileFeature({}, FeatureType::LineString, {{{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}, {5, 0}, {6, 0}}}, properties));
+    expected2.emplace_back(StubGeometryTileFeature({}, FeatureType::LineString, { emptyLine }, properties));
+    expected2.emplace_back(StubGeometryTileFeature({}, FeatureType::LineString, { emptyLine }, properties));
+
 
     mbgl::util::mergeLines(input2);
 
@@ -85,11 +85,11 @@ TEST(MergeLines, CircularLines) {
     input3.push_back(SymbolFeatureStub { {}, FeatureType::LineString, {{{2, 0}, {3, 0}, {4, 0}}}, properties, aaa, {}, 0 });
     input3.push_back(SymbolFeatureStub { {}, FeatureType::LineString, {{{4, 0}, {0, 0}}}, properties, aaa, {}, 0 });
 
-    const std::vector<StubGeometryTileFeature> expected3 = {
-        { {}, FeatureType::LineString, {{{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}, {0, 0}}}, properties },
-        { {}, FeatureType::LineString, { emptyLine }, properties },
-        { {}, FeatureType::LineString, { emptyLine }, properties }
-    };
+    std::vector<StubGeometryTileFeature> expected3;
+    expected3.emplace_back(StubGeometryTileFeature({}, FeatureType::LineString, {{{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}, {0, 0}}}, properties));
+    expected3.emplace_back(StubGeometryTileFeature({}, FeatureType::LineString, { emptyLine }, properties));
+    expected3.emplace_back(StubGeometryTileFeature({}, FeatureType::LineString, { emptyLine }, properties));
+
 
     mbgl::util::mergeLines(input3);
 
@@ -102,20 +102,20 @@ TEST(MergeLines, EmptyOuterGeometry) {
     std::vector<mbgl::SymbolFeature> input;
     input.push_back(SymbolFeatureStub { {}, FeatureType::LineString, {}, properties, aaa, {}, 0 });
 
-    const std::vector<StubGeometryTileFeature> expected = { { {}, FeatureType::LineString, {}, properties } };
+    const StubGeometryTileFeature expected{ {}, FeatureType::LineString, {}, properties };
 
     mbgl::util::mergeLines(input);
 
-    EXPECT_EQ(input[0].geometry, expected[0].getGeometries());
+    EXPECT_EQ(input[0].geometry, expected.getGeometries());
 }
 
 TEST(MergeLines, EmptyInnerGeometry) {
     std::vector<mbgl::SymbolFeature> input;
     input.push_back(SymbolFeatureStub { {}, FeatureType::LineString, {}, properties, aaa, {}, 0 });
 
-    const std::vector<StubGeometryTileFeature> expected = { { {}, FeatureType::LineString, {}, properties } };
+    const StubGeometryTileFeature expected{ {}, FeatureType::LineString, {}, properties };
 
     mbgl::util::mergeLines(input);
 
-    EXPECT_EQ(input[0].geometry, expected[0].getGeometries());
+    EXPECT_EQ(input[0].geometry, expected.getGeometries());
 }


### PR DESCRIPTION
`mbgl::GeometryCollection` can potentially contain significant amount of data, however before this change we had several places where `GeometryCollection` instances were unnecessarily copied causing extra allocations, which affected the performance. In particular, `queryRenderedFeatures` API performance was affected (see https://github.com/mapbox/mapbox-gl-native/pull/15183).