### PR TITLE
[ios] Cherry picks #15113 - Adds thread safe access to MGLNetworkConfiguration events

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## 5.1.2
+
+### Other changes
+
+* Fixed a crash during network access. ([#15113](https://github.com/mapbox/mapbox-gl-native/pull/15113))
+
 ## 5.1.1 - July 18, 2019
 
 * Fixed a bug in telemetry collection. ([#15077](https://github.com/mapbox/mapbox-gl-native/pull/15077))

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -506,6 +506,7 @@
 		CA6914B520E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA6914B420E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.m */; };
 		CA7766832229C10E0008DE9E /* MGLCompactCalloutView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA8848451CBAFB9800AB86E3 /* MGLCompactCalloutView.m */; };
 		CA7766842229C11A0008DE9E /* SMCalloutView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA88488A1CBB037E00AB86E3 /* SMCalloutView.m */; };
+		CA86FF0E22D8D5A0009EB14A /* MGLNetworkConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA86FF0D22D8D5A0009EB14A /* MGLNetworkConfigurationTests.m */; };
 		CA88DC3021C85D900059ED5A /* MGLStyleURLIntegrationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CA88DC2F21C85D900059ED5A /* MGLStyleURLIntegrationTest.m */; };
 		CA8FBC0921A47BB100D1203C /* MGLRendererConfigurationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CA8FBC0821A47BB100D1203C /* MGLRendererConfigurationTests.mm */; };
 		CAA69DA4206DCD0E007279CD /* Mapbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA4A26961CB6E795000B7809 /* Mapbox.framework */; };
@@ -1179,6 +1180,7 @@
 		CA5E5042209BDC5F001A8A81 /* MGLTestUtility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MGLTestUtility.h; path = ../../darwin/test/MGLTestUtility.h; sourceTree = "<group>"; };
 		CA65C4F721E9BB080068B0D4 /* MGLCluster.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLCluster.h; sourceTree = "<group>"; };
 		CA6914B420E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MGLAnnotationViewIntegrationTests.m; path = "Annotation Tests/MGLAnnotationViewIntegrationTests.m"; sourceTree = "<group>"; };
+		CA86FF0D22D8D5A0009EB14A /* MGLNetworkConfigurationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLNetworkConfigurationTests.m; sourceTree = "<group>"; };
 		CA88DC2F21C85D900059ED5A /* MGLStyleURLIntegrationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLStyleURLIntegrationTest.m; sourceTree = "<group>"; };
 		CA8FBC0821A47BB100D1203C /* MGLRendererConfigurationTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLRendererConfigurationTests.mm; path = ../../darwin/test/MGLRendererConfigurationTests.mm; sourceTree = "<group>"; };
 		CAD9D0A922A86D6F001B25EE /* MGLResourceTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLResourceTests.mm; path = ../../darwin/test/MGLResourceTests.mm; sourceTree = "<group>"; };
@@ -2043,6 +2045,7 @@
 				357579811D502AD4000B822E /* Styling */,
 				409F43FB1E9E77D10048729D /* Swift Integration */,
 				4031ACFD1E9FD26900A3EA26 /* Test Helpers */,
+				CA86FF0D22D8D5A0009EB14A /* MGLNetworkConfigurationTests.m */,
 			);
 			name = "SDK Tests";
 			path = test;
@@ -3216,6 +3219,7 @@
 				DA2DBBCE1D51E80400D38FF9 /* MGLStyleLayerTests.m in Sources */,
 				DA35A2C61CCA9F8300E826B2 /* MGLCompassDirectionFormatterTests.m in Sources */,
 				DAE7DEC21E245455007505A6 /* MGLNSStringAdditionsTests.m in Sources */,
+				CA86FF0E22D8D5A0009EB14A /* MGLNetworkConfigurationTests.m in Sources */,
 				4085AF091D933DEA00F11B22 /* MGLTileSetTests.mm in Sources */,
 				DAEDC4341D603417000224FF /* MGLAttributionInfoTests.m in Sources */,
 				1F7454A91ED08AB400021D39 /* MGLLightTest.mm in Sources */,

--- a/platform/ios/test/MGLNetworkConfigurationTests.m
+++ b/platform/ios/test/MGLNetworkConfigurationTests.m
@@ -1,0 +1,43 @@
+#import <Mapbox/Mapbox.h>
+#import <XCTest/XCTest.h>
+#import "MGLNetworkConfiguration_Private.h"
+
+@interface MGLNetworkConfigurationTests : XCTestCase
+@end
+
+@implementation MGLNetworkConfigurationTests
+
+// Regression test for https://github.com/mapbox/mapbox-gl-native/issues/14982
+- (void)testAccessingEventsFromMultipleThreads {
+    MGLNetworkConfiguration *configuration = [[MGLNetworkConfiguration alloc] init];
+    
+    // Concurrent
+    dispatch_queue_t queue = dispatch_queue_create("com.mapbox.testAccessingEventsFromMultipleThreads", DISPATCH_QUEUE_CONCURRENT);
+    
+    NSUInteger numberOfConcurrentBlocks = 20;
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"wait-for-threads"];
+    expectation.expectedFulfillmentCount = numberOfConcurrentBlocks;
+    
+    for (NSUInteger i = 0; i < numberOfConcurrentBlocks; i++) {
+        
+        NSString *event = [NSString stringWithFormat:@"test://event-%ld", i];
+        NSString *resourceType = @"test";
+        
+        dispatch_async(queue, ^{
+            [configuration startDownloadEvent:event type:resourceType];
+            
+            NSURL *url = [NSURL URLWithString:event];
+            NSURLResponse *response = [[NSURLResponse alloc] initWithURL:url MIMEType:nil expectedContentLength:0 textEncodingName:nil];
+            
+            [configuration stopDownloadEventForResponse:response];
+            
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [expectation fulfill];
+            });
+        });
+    }
+    
+    [self waitForExpectations:@[expectation] timeout:10.0];
+}
+@end


### PR DESCRIPTION
Cherry picks #15113 to release-oolong for `ios-v5.1.2`.

/cc @chloekraw 