### PR TITLE
[core] util::tileCover optimization: three scans and no duplicates handling.

### DIFF
--- a/benchmark/util/tilecover.benchmark.cpp
+++ b/benchmark/util/tilecover.benchmark.cpp
@@ -22,7 +22,8 @@ static void TileCoverPitchedViewport(benchmark::State& state) {
     Transform transform;
     transform.resize({ 512, 512 });
     // slightly offset center so that tile order is better defined
-    transform.jumpTo(CameraOptions().withCenter(LatLng { 0.1, -0.1 }).withZoom(8.0).withBearing(5.0).withPitch(40.0));
+    transform.jumpTo(CameraOptions().withCenter(LatLng { 0.1, -0.1 }).withPadding(EdgeInsets { 376, 0, 0, 0 })
+                                    .withZoom(8.0).withBearing(5.0).withPitch(60.0));
 
     std::size_t length = 0;
     while (state.KeepRunning()) {

--- a/include/mbgl/util/projection.hpp
+++ b/include/mbgl/util/projection.hpp
@@ -98,7 +98,7 @@ private:
         return Point<double> {
             util::LONGITUDE_MAX + latLng.longitude(),
             util::LONGITUDE_MAX - util::RAD2DEG * std::log(std::tan(M_PI / 4 + latitude * M_PI / util::DEGREES_MAX))
-        } * worldSize / util::DEGREES_MAX;
+        } * (worldSize / util::DEGREES_MAX);
     }
 };
 

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -115,6 +115,9 @@ private:
                          std::function<void(double)>,
                          const Duration&);
 
+    // We don't want to show horizon: limit max pitch based on edge insets.
+    double getMaxPitchForEdgeInsets(const EdgeInsets &insets) const;
+
     TimePoint transitionStart;
     Duration transitionDuration;
     std::function<bool(const TimePoint)> transitionFrameFn;

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -9,6 +9,7 @@ using namespace mbgl;
 
 TEST(Transform, InvalidZoom) {
     Transform transform;
+    transform.resize({1, 1});
 
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
@@ -56,6 +57,7 @@ TEST(Transform, InvalidZoom) {
 
 TEST(Transform, InvalidBearing) {
     Transform transform;
+    transform.resize({1, 1});
 
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
@@ -78,6 +80,7 @@ TEST(Transform, InvalidBearing) {
 
 TEST(Transform, IntegerZoom) {
     Transform transform;
+    transform.resize({1, 1});
 
     auto checkIntegerZoom = [&transform](uint8_t zoomInt, double zoom) {
         transform.jumpTo(CameraOptions().withZoom(zoom));

--- a/test/util/tile_cover.test.cpp
+++ b/test/util/tile_cover.test.cpp
@@ -43,6 +43,41 @@ TEST(TileCover, Pitch) {
               util::tileCover(transform.getState(), 2));
 }
 
+TEST(TileCover, PitchOverAllowedByContentInsets) {
+    Transform transform;
+    transform.resize({ 512, 512 });
+
+    transform.jumpTo(CameraOptions().withCenter(LatLng { 0.1, -0.1 }).withPadding(EdgeInsets { 376, 0, 0, 0 })
+                                    .withZoom(8.0).withBearing(45.0).withPitch(60.0));
+    // Top padding of 376 leads to capped pitch. See Transform::getMaxPitchForEdgeInsets.
+    EXPECT_LE(transform.getPitch() + 0.001, util::DEG2RAD * 60);
+
+    EXPECT_EQ((std::vector<UnwrappedTileID>{
+        { 3, 4, 3 }, { 3, 3, 3 }, { 3, 4, 4 }, { 3, 3, 4 }, { 3, 4, 2 }, { 3, 5, 3 }, { 3, 5, 2 }
+    }),
+              util::tileCover(transform.getState(), 3));
+}
+
+TEST(TileCover, PitchWithLargerResultSet) {
+    Transform transform;
+    transform.resize({ 1024, 768 });
+
+    // The values used here triggered the regression with left and right edge
+    // selection in tile_cover.cpp scanSpans.
+    transform.jumpTo(CameraOptions().withCenter(LatLng { 0.1, -0.1 }).withPadding(EdgeInsets { 400, 0, 0, 0 })
+                                    .withZoom(5).withBearing(-142.2630000003529176).withPitch(60.0));
+
+    auto cover = util::tileCover(transform.getState(), 5);
+    // Returned vector has above 100 elements, we check first 16 as there is a
+    // plan to return lower LOD for distant tiles.
+    EXPECT_EQ((std::vector<UnwrappedTileID> {
+        { 5, 15, 16 }, { 5, 15, 17 }, { 5, 14, 16 }, { 5, 14, 17 },
+        { 5, 16, 16 }, { 5, 16, 17 }, { 5, 15, 15 }, { 5, 14, 15 },
+        { 5, 15, 18 }, { 5, 14, 18 }, { 5, 16, 15 }, { 5, 13, 16 },
+        { 5, 13, 17 }, { 5, 16, 18 }, { 5, 13, 18 }, { 5, 15, 19 }
+    }), (std::vector<UnwrappedTileID> { cover.begin(), cover.begin() + 16}) );
+}
+
 TEST(TileCover, WorldZ1) {
     EXPECT_EQ((std::vector<UnwrappedTileID>{
         { 1, 0, 0 }, { 1, 0, 1 }, { 1, 1, 0 }, { 1, 1, 1 },


### PR DESCRIPTION
TileCover: Replaced 4 scanSpans by 3. As the split lines (triangle, trapezoid, triangle) is horizontal, there is no need to handle duplicates.

Benchmarks (release build) on MacBookPro11,2 (Mid 2014) with Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz compared src/mbgl/util/tile_cover.cpp from master and from this patch:

```
                            master  |   patch
                          ---------------------
TileCoverPitchedViewport    72000ns |  50300ns
TileCoverBounds              1620ns |   1400ns

```

TileCoverPitchedViewport modified to have pitch capped by large top inset, returning 1124 tiles at zoom level 8.

TileCover.PitchOverAllowedByContentInsets test verifies pitch capping by large top inset. Expectation was calculated using previous tileCover algorithm implementation - tests are contributed as part of https://github.com/mapbox/mapbox-gl-native/pull/15195 (this patch is rebased onto it).

Snipped copied from code comments:
```
    Keeping the clockwise winding order (abcd), we rotated convex quadrilateral
    angles in such way that angle a (bounds[0]) is on top):
              a
            /   \
           /     b
          /      |
         /       c
        /  ....
       / ..
      d
    This is an example: we handle also cases where d.y < c.y, d.y < b.y etc.
    Split the scan to tree steps:
              a
            /   \     (1)
           /     b
     -----------------
          /      |    (2)
         /       c
     -----------------
        /  ....
       / ..           (3)
      d
````
Related to: #15163 - speeding up would help performance or larger result set processing as there is a need to further enhance returned tileset in adaptive tile coverage (#9037) implementation.