### PR TITLE
[core] Optimize Query Rendered Features API

### DIFF
--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -487,7 +487,12 @@ void RenderOrchestrator::queryRenderedSymbols(std::unordered_map<std::string, st
 
 std::vector<Feature> RenderOrchestrator::queryRenderedFeatures(const ScreenLineString& geometry, const RenderedQueryOptions& options, const std::unordered_map<std::string, const RenderLayer*>& layers) const {
     std::unordered_set<std::string> sourceIDs;
+    std::unordered_map<std::string, const RenderLayer*> filteredLayers;
     for (const auto& pair : layers) {
+        if (!pair.second->needsRendering() || !pair.second->supportsZoom(zoomHistory.lastZoom)) {
+            continue;
+        }
+        filteredLayers.emplace(pair);
         sourceIDs.emplace(pair.second->baseImpl->source);
     }
 
@@ -497,12 +502,12 @@ std::vector<Feature> RenderOrchestrator::queryRenderedFeatures(const ScreenLineS
     std::unordered_map<std::string, std::vector<Feature>> resultsByLayer;
     for (const auto& sourceID : sourceIDs) {
         if (RenderSource* renderSource = getRenderSource(sourceID)) {
-            auto sourceResults = renderSource->queryRenderedFeatures(geometry, transformState, layers, options, projMatrix);
+            auto sourceResults = renderSource->queryRenderedFeatures(geometry, transformState, filteredLayers, options, projMatrix);
             std::move(sourceResults.begin(), sourceResults.end(), std::inserter(resultsByLayer, resultsByLayer.begin()));
         }
     }
     
-    queryRenderedSymbols(resultsByLayer, geometry, layers, options);
+    queryRenderedSymbols(resultsByLayer, geometry, filteredLayers, options);
 
     std::vector<Feature> result;
 
@@ -511,11 +516,7 @@ std::vector<Feature> RenderOrchestrator::queryRenderedFeatures(const ScreenLineS
     }
 
     // Combine all results based on the style layer renderItems.
-    for (const auto& pair : layers) {
-        if (!pair.second->needsRendering() || !pair.second->supportsZoom(zoomHistory.lastZoom)) {
-            continue;
-        }
-
+    for (const auto& pair : filteredLayers) {
         auto it = resultsByLayer.find(pair.second->baseImpl->id);
         if (it != resultsByLayer.end()) {
             std::move(it->second.begin(), it->second.end(), std::back_inserter(result));

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -293,6 +293,7 @@ std::unordered_map<std::string, std::vector<Feature>> TilePyramid::queryRendered
     }
 
     LineString<double> queryGeometry;
+    queryGeometry.reserve(geometry.size());
 
     for (const auto& p : geometry) {
         queryGeometry.push_back(TileCoordinate::fromScreenCoordinate(


### PR DESCRIPTION
This PR filters out invisible layers before quering features
(rather than after, like it happened before).

With this change `API_queryRenderedFeaturesAll` performance test
passes almost two times faster.

Fixes: #15207 