### PR TITLE
[ios, build] Trigger external deploy jobs before long-running build tasks

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1110,12 +1110,18 @@ jobs:
       - install-dependencies
       - install-ios-packaging-dependencies
       - run:
+          name: Trigger external deploy steps
+          command: |
+            export VERSION_TAG=${CIRCLE_TAG}
+            export GITHUB_TOKEN=${DANGER_GITHUB_API_TOKEN}
+            platform/ios/scripts/trigger-external-deploy-steps.sh
+          background: true
+      - run:
           name: Build, package, and upload iOS release
           command: |
             export VERSION_TAG=${CIRCLE_TAG}
             export GITHUB_TOKEN=${DANGER_GITHUB_API_TOKEN}
             platform/ios/scripts/deploy-packages.sh
-            platform/ios/scripts/trigger-external-deploy-steps.sh
       - save-dependencies
       - collect-xcode-build-logs
       - upload-xcode-build-logs


### PR DESCRIPTION
Our framework release builds take some time and it’s safe to trigger external deploy steps while we wait for the framework deploy here to finish, so let’s do that. This will reduce the lag time between kicking off a release build and the ios-sdk docs being available for review.

/cc @mapbox/maps-ios 