### PR TITLE
[core] Avoid feature properties copying

### DIFF
--- a/src/mbgl/layout/symbol_feature.hpp
+++ b/src/mbgl/layout/symbol_feature.hpp
@@ -18,7 +18,7 @@ public:
     
     FeatureType getType() const override { return feature->getType(); }
     optional<Value> getValue(const std::string& key) const override { return feature->getValue(key); };
-    std::unordered_map<std::string,Value> getProperties() const override { return feature->getProperties(); };
+    const PropertyMap& getProperties() const override { return feature->getProperties(); };
     FeatureIdentifier getID() const override { return feature->getID(); };
     const GeometryCollection& getGeometries() const override { return geometry; };
 

--- a/src/mbgl/style/expression/compound_expression.cpp
+++ b/src/mbgl/style/expression/compound_expression.cpp
@@ -423,7 +423,8 @@ const auto& propertiesCompoundExpression() {
             };
         }
         std::unordered_map<std::string, Value> result;
-        const PropertyMap properties = params.feature->getProperties();
+        const PropertyMap& properties = params.feature->getProperties();
+        result.reserve(properties.size());
         for (const auto& entry : properties) {
             result[entry.first] = toExpressionValue(entry.second);
         }

--- a/src/mbgl/style/expression/expression.cpp
+++ b/src/mbgl/style/expression/expression.cpp
@@ -15,7 +15,7 @@ public:
     FeatureType getType() const override  {
         return apply_visitor(ToFeatureType(), feature.geometry);
     }
-    PropertyMap getProperties() const override { return feature.properties; }
+    const PropertyMap& getProperties() const override { return feature.properties; }
     FeatureIdentifier getID() const override { return feature.id; }
     optional<mbgl::Value> getValue(const std::string& key) const override {
         auto it = feature.properties.find(key);

--- a/src/mbgl/tile/geojson_tile_data.hpp
+++ b/src/mbgl/tile/geojson_tile_data.hpp
@@ -17,7 +17,7 @@ public:
         return apply_visitor(ToFeatureType(), feature.geometry);
     }
 
-    PropertyMap getProperties() const override {
+    const PropertyMap& getProperties() const override {
         return feature.properties;
     }
 

--- a/src/mbgl/tile/geometry_tile_data.cpp
+++ b/src/mbgl/tile/geometry_tile_data.cpp
@@ -179,6 +179,11 @@ Feature convertFeature(const GeometryTileFeature& geometryTileFeature, const Can
     return feature;
 }
 
+const PropertyMap& GeometryTileFeature::getProperties() const {
+    static const PropertyMap dummy;
+    return dummy;
+}
+
 const GeometryCollection& GeometryTileFeature::getGeometries() const {
     static const GeometryCollection dummy;
     return dummy;

--- a/src/mbgl/tile/geometry_tile_data.hpp
+++ b/src/mbgl/tile/geometry_tile_data.hpp
@@ -49,7 +49,7 @@ public:
     virtual ~GeometryTileFeature() = default;
     virtual FeatureType getType() const = 0;
     virtual optional<Value> getValue(const std::string& key) const = 0;
-    virtual PropertyMap getProperties() const { return PropertyMap(); }
+    virtual const PropertyMap& getProperties() const;
     virtual FeatureIdentifier getID() const { return NullValue {}; }
     virtual const GeometryCollection& getGeometries() const;
 };

--- a/src/mbgl/tile/geometry_tile_data.hpp
+++ b/src/mbgl/tile/geometry_tile_data.hpp
@@ -97,31 +97,16 @@ struct ToGeometryCollection {
         return { { geom } };
     }
     GeometryCollection operator()(const mapbox::geometry::multi_point<int16_t>& geom) const {
-        GeometryCoordinates coordinates;
-        coordinates.reserve(geom.size());
-        for (const auto& point : geom) {
-            coordinates.emplace_back(point);
-        }
-        return { coordinates };
+        return { geom };
     }
     GeometryCollection operator()(const mapbox::geometry::line_string<int16_t>& geom) const {
-        GeometryCoordinates coordinates;
-        coordinates.reserve(geom.size());
-        for (const auto& point : geom) {
-            coordinates.emplace_back(point);
-        }
-        return { coordinates };
+        return { geom };
     }
     GeometryCollection operator()(const mapbox::geometry::multi_line_string<int16_t>& geom) const {
         GeometryCollection collection;
         collection.reserve(geom.size());
         for (const auto& ring : geom) {
-            GeometryCoordinates coordinates;
-            coordinates.reserve(ring.size());
-            for (const auto& point : ring) {
-                coordinates.emplace_back(point);
-            }
-            collection.push_back(std::move(coordinates));
+            collection.emplace_back(ring);
         }
         return collection;
     }
@@ -129,25 +114,15 @@ struct ToGeometryCollection {
         GeometryCollection collection;
         collection.reserve(geom.size());
         for (const auto& ring : geom) {
-            GeometryCoordinates coordinates;
-            coordinates.reserve(ring.size());
-            for (const auto& point : ring) {
-                coordinates.emplace_back(point);
-            }
-            collection.push_back(std::move(coordinates));
+            collection.emplace_back(ring);
         }
         return collection;
     }
     GeometryCollection operator()(const mapbox::geometry::multi_polygon<int16_t>& geom) const {
         GeometryCollection collection;
-        for (auto& polygon : geom) {
-            for (auto& ring : polygon) {
-                GeometryCoordinates coordinates;
-                coordinates.reserve(ring.size());
-                for (auto& point : ring) {
-                    coordinates.emplace_back(point);
-                }
-                collection.push_back(std::move(coordinates));
+        for (const auto& polygon : geom) {
+            for (const auto& ring : polygon) {
+                collection.emplace_back(ring);
             }
         }
         return collection;

--- a/src/mbgl/tile/vector_tile_data.cpp
+++ b/src/mbgl/tile/vector_tile_data.cpp
@@ -26,8 +26,11 @@ optional<Value> VectorTileFeature::getValue(const std::string& key) const {
     return value->is<NullValue>() ? nullopt : std::move(value);
 }
 
-std::unordered_map<std::string, Value> VectorTileFeature::getProperties() const {
-    return feature.getProperties();
+const PropertyMap& VectorTileFeature::getProperties() const {
+    if (!properties) {
+        properties = feature.getProperties();
+    }
+    return *properties;
 }
 
 FeatureIdentifier VectorTileFeature::getID() const {

--- a/src/mbgl/tile/vector_tile_data.hpp
+++ b/src/mbgl/tile/vector_tile_data.hpp
@@ -15,13 +15,14 @@ public:
 
     FeatureType getType() const override;
     optional<Value> getValue(const std::string& key) const override;
-    std::unordered_map<std::string, Value> getProperties() const override;
+    const PropertyMap& getProperties() const override;
     FeatureIdentifier getID() const override;
     const GeometryCollection& getGeometries() const override;
 
 private:
     mapbox::vector_tile::feature feature;
     mutable optional<GeometryCollection> lines;
+    mutable optional<PropertyMap> properties;
 };
 
 class VectorTileLayer : public GeometryTileLayer {

--- a/test/tile/vector_tile.test.cpp
+++ b/test/tile/vector_tile.test.cpp
@@ -98,7 +98,7 @@ TEST(VectorTileData, ParseResults) {
     ASSERT_TRUE(feature->getID().is<uint64_t>());
     ASSERT_EQ(feature->getID().get<uint64_t>(), 1u);
 
-    std::unordered_map<std::string, Value> properties = feature->getProperties();
+    const std::unordered_map<std::string, Value>& properties = feature->getProperties();
     ASSERT_EQ(properties.size(), 3u);
     ASSERT_EQ(properties.at("disputed"), *feature->getValue("disputed"));
 


### PR DESCRIPTION
This PR provides similar optimization as https://github.com/mapbox/mapbox-gl-native/pull/15201 but for feature properties. It improves performance of `GeometryTileWorker::parse()` up to 35% on iOS (thanks to @julianrex for measurements!).

Also, this PR contains simplification and optimization of the `ToGeometryCollection` class (thanks to @alexshalamov for pointing out the issue!).