### PR TITLE
[core] Fix assertion at RenderRasterLayer::prepare()

### DIFF
--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -77,12 +77,14 @@ static std::array<float, 3> spinWeights(float spin) {
 void RenderRasterLayer::prepare(const LayerPrepareParameters& params) {
     renderTiles = params.source->getRenderTiles();
     imageData = params.source->getImageRenderData();
-    assert(renderTiles || imageData);
+    // It is possible image data is not available until the source loads it.
+    assert(renderTiles || imageData || !params.source->isEnabled());
 }
 
 void RenderRasterLayer::render(PaintParameters& parameters) {
-    if (parameters.pass != RenderPass::Translucent)
+    if (parameters.pass != RenderPass::Translucent || (!renderTiles && !imageData)) {
         return;
+    }
     const auto& evaluated = static_cast<const RasterLayerProperties&>(*evaluatedProperties).evaluated;
     RasterProgram::Binders paintAttributeData{ evaluated, 0 };
 

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -47,6 +47,7 @@ bool RenderLayer::supportsZoom(float zoom) const {
 
 void RenderLayer::prepare(const LayerPrepareParameters& params) {
     assert(params.source);
+    assert(params.source->isEnabled());
     renderTiles = params.source->getRenderTiles();
     addRenderPassesFromTiles();
 }

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -20,8 +20,10 @@
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/image.hpp>
 #include <mbgl/style/layers/background_layer.hpp>
+#include <mbgl/style/layers/raster_layer.hpp>
 #include <mbgl/style/layers/symbol_layer.hpp>
 #include <mbgl/style/sources/geojson_source.hpp>
+#include <mbgl/style/sources/image_source.hpp>
 #include <mbgl/util/color.hpp>
 
 using namespace mbgl;
@@ -866,4 +868,13 @@ TEST(Map, Issue12432) {
     };
 
     test.runLoop.run();
+}
+
+// https://github.com/mapbox/mapbox-gl-native/issues/15216
+TEST(Map, Issue15216) {
+    MapTest<> test { 1.0f,  MapMode::Continuous };
+    test.map.getStyle().addSource(std::make_unique<ImageSource>("ImageSource", std::array<LatLng, 4>()));
+    test.map.getStyle().addLayer(std::make_unique<RasterLayer>("RasterLayer", "ImageSource"));
+    // Passes, if there is no assertion hit.
+    test.runLoop.runOnce();
 }


### PR DESCRIPTION
It shall consider that image data might not be available until
the source loads it.

Fixes: #15216