### PR TITLE
[ios, build] Automatically deploy to CocoaPods

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1074,9 +1074,18 @@ jobs:
             if [[ $CIRCLE_BRANCH == master ]]; then
               platform/ios/scripts/deploy-snapshot.sh
             fi
+          background: true
+      - deploy:
+          name: Deploy to Mapbox CocoaPods spec repo
+          command: |
+            if [[ $CIRCLE_BRANCH == master ]]; then
+              platform/ios/scripts/deploy-to-cocoapods.sh
+            fi
+          background: true
       - run:
           name: Record size
           command: platform/ios/scripts/metrics.sh
+          background: true
       - run:
           name: Trigger metrics
           command: |
@@ -1087,6 +1096,7 @@ jobs:
                 echo "MOBILE_METRICS_TOKEN not provided"
               fi
             fi
+          background: true
       - save-dependencies
       - collect-xcode-build-logs
       - upload-xcode-build-logs
@@ -1124,6 +1134,10 @@ jobs:
             export VERSION_TAG=${CIRCLE_TAG}
             export GITHUB_TOKEN=${DANGER_GITHUB_API_TOKEN}
             platform/ios/scripts/deploy-packages.sh
+      - deploy:
+          name: Deploy to CocoaPods
+          command: platform/ios/scripts/deploy-to-cocoapods.sh
+          background: true
       - save-dependencies
       - collect-xcode-build-logs
       - upload-xcode-build-logs

--- a/platform/ios/scripts/deploy-to-cocoapods.sh
+++ b/platform/ios/scripts/deploy-to-cocoapods.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# This relies on either:
+#   1. You being authenticated locally with CocoaPods trunk.
+#   2. The `COCOAPODS_TRUNK_TOKEN` environment variable being set.
+
+set -euo pipefail
+
+function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
+function finish { >&2 echo -en "\033[0m"; }
+trap finish EXIT
+
+CIRCLE_TAG=${CIRCLE_TAG:-""}
+
+step "Pushing release to CocoaPods trunk…"
+
+if [[ $CIRCLE_TAG ]]; then
+  pod trunk push platform/ios/Mapbox-iOS-SDK.podspec --allow-warnings
+else
+  echo "Skipping push to CocoaPods trunk for untagged build"
+fi
+
+step "Pushing release/builds to Mapbox podspecs repo…"
+
+if [[ -z $(pod repo list | grep -i mapbox-public) ]]; then
+  pod repo add mapbox-public https://github.com/mapbox/pod-specs
+else
+  echo "Found existing mapbox-public podspecs repo"
+fi
+
+if [[ -z $(git config --global user.email) && $CI ]]; then
+  echo "Setting machine user as git committer"
+  git config --global user.email "MapboxCI@users.noreply.github.com"
+fi
+
+if [[ $CIRCLE_TAG ]]; then
+  pod repo push mapbox-public platform/ios/Mapbox-iOS-SDK.podspec --allow-warnings
+  pod repo push mapbox-public platform/ios/Mapbox-iOS-SDK-stripped.podspec --allow-warnings
+else
+  echo "Skipping push of release podspecs to mapbox-public for untagged build"
+
+  # pod repo push mapbox-public platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec --allow-warnings
+  echo "Skipping push of snapshot to mapbox-public until we have a way to update the versions in the snapshot podspec"
+fi

--- a/platform/ios/scripts/install-packaging-dependencies.sh
+++ b/platform/ios/scripts/install-packaging-dependencies.sh
@@ -2,7 +2,9 @@
 
 set -euo pipefail
 
+COCOAPODS_VERSION="1.7.5"
 JAZZY_VERSION="0.10.0"
+CIRCLECI=${CIRCLECI:-false}
 
 function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
 function finish { >&2 echo -en "\033[0m"; }
@@ -10,18 +12,50 @@ trap finish EXIT
 
 step "Installing packaging dependencies…"
 
+##
+## aws
+##
 if [ -z `which aws` ]; then
     brew install awscli
+else
+    echo "Found awscli"
 fi
 
+##
+## wget
+##
 if [ -z `which wget` ]; then
     brew install wget
+else
+    echo "Found brew"
 fi
 
+##
+## cocoapods
+##
+if [[ -z `which pod` || $(pod --version) != "${COCOAPODS_VERSION}" ]]; then
+    step "Installing cocoapods…"
+
+    if [[ "${CIRCLECI}" == true ]]; then
+        sudo gem install cocoapods -v $COCOAPODS_VERSION --no-document
+    else
+        gem install cocoapods -v $COCOAPODS_VERSION --no-document
+    fi
+
+    if [ -z `which pod` ]; then
+        echo "Unable to install cocoapods ($COCOAPODS_VERSION)."
+        exit 1
+    fi
+else
+    echo "Found cocoapods (${COCOAPODS_VERSION})"
+fi
+
+##
+## jazzy
+##
 if [[ -z `which jazzy` || $(jazzy -v) != "jazzy version: ${JAZZY_VERSION}" ]]; then
     step "Installing jazzy…"
 
-    CIRCLECI=${CIRCLECI:-false}
     if [[ "${CIRCLECI}" == true ]]; then
         sudo gem install jazzy -v $JAZZY_VERSION --no-document -- --with-sqlite3-lib=/usr/lib
     else
@@ -32,4 +66,8 @@ if [[ -z `which jazzy` || $(jazzy -v) != "jazzy version: ${JAZZY_VERSION}" ]]; t
         echo "Unable to install jazzy ($JAZZY_VERSION). See https://github.com/mapbox/mapbox-gl-native/blob/master/platform/ios/INSTALL.md"
         exit 1
     fi
+else
+    echo "Found jazzy (${JAZZY_VERSION})"
 fi
+
+step "Finished installing packaging dependencies"


### PR DESCRIPTION
Partially addresses #15214 by automating CocoaPods deployment as part of our release/~snapshot~ CI jobs.

### To-do
- [x] Validate that this won’t push to trunk when we don’t want to.
- ~[ ] Update `Mapbox-iOS-SDK-snapshot-dynamic.podspec` version and URL to make them unique for every push to `mapbox-public`.~ Going to do this later as part of revamping how we bump versions for podspecs/etc.