### PR TITLE
[core] Partially restore render performance

### DIFF
--- a/src/mbgl/renderer/render_orchestrator.hpp
+++ b/src/mbgl/renderer/render_orchestrator.hpp
@@ -117,10 +117,6 @@ private:
 
     const bool backgroundLayerAsColor;
     bool contextLost = false;
-
-    // Vector with reserved capacity of layerImpls->size() to avoid reallocation
-    // on each frame.
-    std::vector<Immutable<style::LayerProperties>> filteredLayersForSource;
 };
 
 } // namespace mbgl


### PR DESCRIPTION
On iOS, recent changes (since 4.10.0) to refactor `renderer_impl.cpp` into RenderTree and RenderOrchestrator have resulted in:

- frame rate cut in half: from ~58fps to ~29fps
- a very noticeable presentation lag

The frame rate reduction has also been noted on Android https://github.com/mapbox/mapbox-gl-native/issues/14902.

To detect the frame rate reduction on iOS, we added this code (per https://github.com/mapbox/mapbox-gl-native/issues/14277) to our `MGLMapViewDelegate`:

```
    private let df: DateFormatter = {
        let df = DateFormatter()
        df.dateFormat = "H:m:ss.SSSS"
        return df
    }()

    private var timings = ContiguousArray<String>(repeating: "", count: 1000)
    private var timingIdx: Int = 0

    func mapViewDidFinishRenderingFrame(_ mapView: MGLMapView, fullyRendered: Bool) {
        timings[timingIdx] = df.string(from: Date())
        timingIdx += 1
    }
```

This approach reduces the cost of recording the measurement. Linked against a release build and run in Xcode until the buffer overflows, `timings` can be output in the console, copied, and analyzed to compute 999 frame durations.  To assure that rendering is triggered as often as possible, the device is put into compass mode and continuously waved from side to side.

Compass mode + waving also reveals the presentation lag: After ~20 seconds of continuous waving and then stopping all movement, the map will very noticeably continue to rotate for _what feels like_ more than one second.  The presentation lag is also apparent from a visible accumulating incongruence between displayed orientation and device orientation.

Besides a handful of outliers during launch, the resulting frame durations are very consistent:

![image](https://user-images.githubusercontent.com/39099029/61976091-af774180-af9f-11e9-9a59-f932f58f5c5a.png)


Here are the mulitple-run-averaged median frame durations inverted to get FPS:
- 4.10.0:	58 fps
- 5.1.0: 	29 fps
- Current master: 29 fps

This PR proposes 3 changes that raise median frame rate to 45 fps (measured as described above) and removes the presentation lag on iOS.

- in the loop over layers nested inside the loop over sources, only compute `layerIsVisible` and `zoomFitsLayer` if the layer is required by the source.
- remove the `filteredLayersForSource` property and return to local allocation in the source loop.
- in the loop over layers nested inside the loop over sources, only compute `layerIsVisible` and `zoomFitsLayer` for a sourceless layer after verifying it is sourceless.

The first change we tested in 5.1.0 (before the introduction of the `filteredLayersForSource` property and before much more refactoring for RenderOrchestrator) and the result was a full return to 58 fps.

After the introduction of `filteredLayersForSource` and other changes for render orchestration, tho, the first change no longer resulted in an any improvement in frame rate, i.e., it remained at 29 fps.  We then removed the per source loop iteration `shrink_to_fit` on `filteredLayersForSource ` and this resulted in the 45 fps measurement — but as the point of `filteredLayersForSource` is memory use optimization which is nullified without the costly `shrink_to_fit`, the property all but loses its value, which is why we removed it.  Using a local, per source loop iteration created `filteredLayersForSource` yields the same frame rate as keeping the property without the `shrink_to_fit`.

Finally we have a question as to whether a 4th change is possible:  In 4.10.0, sourceless layer processing was outside of the source loop/layer loop.  With it moved inside, the same sourceless layers are reconsidered for each source.  An efficient approach to include sourceless processing in the source loop nested layer loop but to only process each sourceless layer once is unclear to us, and we welcome your suggestions.