### PR TITLE
[build] Don't allow codecov to fail a CI job

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -894,9 +894,7 @@ jobs:
       - run:
           name: Upload coverage results to codecov.io
           command: |
-            curl -sSfL -o codecov https://codecov.io/bash
-            chmod +x codecov
-            ./codecov -c
+            bash <(curl -sSfL https://codecov.io/bash) || echo 'Codecov failed to upload'
       - run:
           name: Upload coverage metrics to s3
           command: |


### PR DESCRIPTION
Mitigates codecov.io instability (https://github.com/mapbox/mapbox-gl-native/issues/15095) by not allowing it to fail required CI jobs. This switches to something closer to their [recommended bash script invocation](https://docs.codecov.io/docs/about-the-codecov-bash-uploader).

/cc @jmkiley @springmeyer 