### PR TITLE
[ios, build] Update to Xcode 10.3 on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -770,7 +770,7 @@ jobs:
 # ------------------------------------------------------------------------------
   node-macos-release:
     macos:
-      xcode: "10.2.1"
+      xcode: "10.3.0"
     environment:
       BUILDTYPE: RelWithDebInfo
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -951,7 +951,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-debug:
     macos:
-      xcode: "10.2.1"
+      xcode: "10.3.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -992,7 +992,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-sanitize-nightly:
     macos:
-      xcode: "10.2.1"
+      xcode: "10.3.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -1016,7 +1016,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-sanitize-address-nightly:
     macos:
-      xcode: "10.2.1"
+      xcode: "10.3.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -1036,7 +1036,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-static-analyzer-nightly:
     macos:
-      xcode: "10.2.1"
+      xcode: "10.3.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -1056,7 +1056,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-release-template:
     macos:
-      xcode: "10.2.1"
+      xcode: "10.3.0"
     environment:
       BUILDTYPE: Release
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -1097,7 +1097,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-release-tag:
     macos:
-      xcode: "10.2.1"
+      xcode: "10.3.0"
     environment:
       BUILDTYPE: Release
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -1173,7 +1173,7 @@ jobs:
 # ------------------------------------------------------------------------------
   macos-render-tests:
     macos:
-      xcode: "10.2.1"
+      xcode: "10.3.0"
     environment:
       BUILDTYPE: RelWithDebInfo
       HOMEBREW_NO_AUTO_UPDATE: 1


### PR DESCRIPTION
Updates to [Xcode 10.3](https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-903/index.html) on CircleCI.

/cc @julianrex 