### PR TITLE
Ensure default local ideographs font family is not overwrote

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
@@ -69,7 +69,7 @@ public class MapboxMapOptions implements Parcelable {
 
   private boolean prefetchesTiles = true;
   private boolean zMediaOverlay = false;
-  private String localIdeographFontFamily = "sans-serif";
+  private String localIdeographFontFamily;
 
   private String apiBaseUri;
 
@@ -246,8 +246,14 @@ public class MapboxMapOptions implements Parcelable {
         typedArray.getBoolean(R.styleable.mapbox_MapView_mapbox_enableTilePrefetch, true));
       mapboxMapOptions.renderSurfaceOnTop(
         typedArray.getBoolean(R.styleable.mapbox_MapView_mapbox_enableZMediaOverlay, false));
-      mapboxMapOptions.localIdeographFontFamily(
-        typedArray.getString(R.styleable.mapbox_MapView_mapbox_localIdeographFontFamily));
+
+      String localIdeographFontFamily =
+        typedArray.getString(R.styleable.mapbox_MapView_mapbox_localIdeographFontFamily);
+      if (localIdeographFontFamily == null) {
+        localIdeographFontFamily = "sans-serif";
+      }
+      mapboxMapOptions.localIdeographFontFamily(localIdeographFontFamily);
+
       mapboxMapOptions.pixelRatio(
         typedArray.getFloat(R.styleable.mapbox_MapView_mapbox_pixelRatio, 0));
       mapboxMapOptions.foregroundLoadColor(

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/MapboxMapOptionsTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/MapboxMapOptionsTest.java
@@ -8,6 +8,9 @@ import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 
 import java.util.Arrays;
 
@@ -18,6 +21,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(RobolectricTestRunner.class)
 public class MapboxMapOptionsTest {
 
   private static final double DELTA = 1e-15;
@@ -171,6 +175,12 @@ public class MapboxMapOptionsTest {
     // check mutations
     assertTrue(new MapboxMapOptions().crossSourceCollisions(true).getCrossSourceCollisions());
     assertFalse(new MapboxMapOptions().crossSourceCollisions(false).getCrossSourceCollisions());
+  }
+
+  @Test
+  public void testLocalIdeographFontFamily_enabledByDefault() {
+    MapboxMapOptions options = MapboxMapOptions.createFromAttributes(RuntimeEnvironment.application, null);
+    assertEquals("sans-serif", options.getLocalIdeographFontFamily());
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/14271 and unblocks https://github.com/mapbox/mapbox-gl-native/pull/14269.

Turns out that because the `TypedArray` doesn't support default values for `Object`s, we were overwriting a default local ideographs font family with a `null`.

/cc @pozdnyakov @chloekraw 