### PR TITLE
[android] Cherry-pick changes for release-nectar v8.0.2 patch release

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -4,6 +4,18 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 
 ## master
 
+## 8.0.2 - July 31, 2019
+[Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.0.1...android-v8.0.2) since [Mapbox Maps SDK for Android v8.0.1](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.0.1):
+
+### Bug fixes
+ - Fixed rendering layers after fill-extrusion regression caused by optimization of fill-extrusion rendering [#15065](https://github.com/mapbox/mapbox-gl-native/pull/15065)
+ - Fixed a map update bug caused by the render tiles and the render passes getting unsynchronized [#15092](https://github.com/mapbox/mapbox-gl-native/pull/15092)
+ - Fixed a custom geometry source bug caused by using the outdated tiles after style update [#15112](https://github.com/mapbox/mapbox-gl-native/pull/15112)
+ - Ensure location shadow's gradient radius is greater than 0 [#15099](https://github.com/mapbox/mapbox-gl-native/pull/15099)
+
+## 8.3.0-alpha.1 - July 31, 2019
+[Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.2.0...android-v8.3.0-alpha.1) since [Mapbox Maps SDK for Android v8.2.0](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.2.0):
+
 ### Styles and rendering
 
  - Implemented asymmetric center of perspective: fixed an issue that caused the focal point to be always based on the view's horizontal center when setting [MapboxMap setPadding](https://docs.mapbox.com/android/api/map-sdk/8.0.0/com/mapbox/mapboxsdk/maps/MapboxMap.html#setPadding-int-int-int-int-). [#14664](https://github.com/mapbox/mapbox-gl-native/pull/14664)

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/Utils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/Utils.java
@@ -3,17 +3,23 @@ package com.mapbox.mapboxsdk.location;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.LayerDrawable;
 import android.location.Location;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.log.Logger;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Projection;
 
 import static com.mapbox.mapboxsdk.location.LocationComponentConstants.INSTANT_LOCATION_TRANSITION_THRESHOLD;
 
 public final class Utils {
+
+  private static final String TAG = "Mbgl-com.mapbox.mapboxsdk.location.Utils";
 
   private Utils() {
     // Class should not be initialized
@@ -52,10 +58,40 @@ public final class Utils {
     Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
     Canvas canvas = new Canvas(bitmap);
     drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
-    drawable.draw(canvas);
+    try {
+      drawable.draw(canvas);
+    } catch (IllegalArgumentException ex) {
+      if (ex.getMessage().equals("radius must be > 0") && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+        Logger.w(TAG,
+          "Location's shadow gradient drawable has a radius <= 0px, resetting to 1px in order to avoid crashing");
+        ensureShadowGradientRadius(drawable);
+        return generateShadow(drawable, elevation);
+      } else {
+        throw ex;
+      }
+    }
     bitmap = Bitmap.createScaledBitmap(bitmap,
       toEven(width + elevation), toEven(height + elevation), false);
     return bitmap;
+  }
+
+  /**
+   * We need to ensure that the radius of any {@link GradientDrawable} is greater than 0 for API levels < 21.
+   *
+   * @see <a href=https://github.com/mapbox/mapbox-gl-native/issues/15026>mapbox-gl-native-#15026</a>
+   */
+  private static void ensureShadowGradientRadius(Drawable drawable) {
+    if (drawable instanceof GradientDrawable) {
+      ((GradientDrawable) drawable).setGradientRadius(1);
+    } else if (drawable instanceof LayerDrawable) {
+      LayerDrawable layerDrawable = (LayerDrawable) drawable;
+      for (int i = 0; i < layerDrawable.getNumberOfLayers(); i++) {
+        Drawable layers = layerDrawable.getDrawable(i);
+        if (layers instanceof GradientDrawable) {
+          ((GradientDrawable) layers).setGradientRadius(1);
+        }
+      }
+    }
   }
 
   static float calculateZoomLevelRadius(@NonNull MapboxMap mapboxMap, @Nullable Location location) {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationLayerControllerTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationLayerControllerTest.kt
@@ -464,7 +464,7 @@ class LocationLayerControllerTest : EspressoTest() {
   @UiThreadTest
   fun test_15026_missingShadowGradientRadius() {
     // test for https://github.com/mapbox/mapbox-gl-native/issues/15026
-    val shadowDrawable = BitmapUtils.getDrawableFromRes(context, R.drawable.mapbox_user_icon_shadow_0px_test)
+    val shadowDrawable = BitmapUtils.getDrawableFromRes(rule.activity, R.drawable.mapbox_user_icon_shadow_0px_test)
     Utils.generateShadow(shadowDrawable, 0f)
   }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationLayerControllerTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationLayerControllerTest.kt
@@ -1,9 +1,9 @@
 package com.mapbox.mapboxsdk.location
 
 import android.Manifest
-import android.R
 import android.content.Context
 import android.location.Location
+import android.support.test.annotation.UiThreadTest
 import android.support.test.espresso.Espresso.onView
 import android.support.test.espresso.IdlingRegistry
 import android.support.test.espresso.UiController
@@ -23,8 +23,10 @@ import com.mapbox.mapboxsdk.location.utils.MapboxTestingUtils.Companion.pushSour
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.Style
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
+import com.mapbox.mapboxsdk.testapp.R
 import com.mapbox.mapboxsdk.testapp.activity.EspressoTest
 import com.mapbox.mapboxsdk.testapp.utils.TestingAsyncUtils
+import com.mapbox.mapboxsdk.utils.BitmapUtils
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.notNullValue
 import org.hamcrest.Matchers.equalTo
@@ -317,7 +319,7 @@ class LocationLayerControllerTest : EspressoTest() {
     executeComponentTest(componentAction)
 
     // Waiting for style to finish loading while pushing updates
-    onView(withId(R.id.content)).check(matches(isDisplayed()))
+    onView(withId(android.R.id.content)).check(matches(isDisplayed()))
   }
 
   @Test
@@ -343,7 +345,7 @@ class LocationLayerControllerTest : EspressoTest() {
     executeComponentTest(componentAction)
 
     // Waiting for style to finish loading while pushing updates
-    onView(withId(R.id.content)).check(matches(isDisplayed()))
+    onView(withId(android.R.id.content)).check(matches(isDisplayed()))
   }
 
   @Test
@@ -458,6 +460,14 @@ class LocationLayerControllerTest : EspressoTest() {
     executeComponentTest(componentAction)
   }
 
+  @Test
+  @UiThreadTest
+  fun test_15026_missingShadowGradientRadius() {
+    // test for https://github.com/mapbox/mapbox-gl-native/issues/15026
+    val shadowDrawable = BitmapUtils.getDrawableFromRes(context, R.drawable.mapbox_user_icon_shadow_0px_test)
+    Utils.generateShadow(shadowDrawable, 0f)
+  }
+
   @After
   override fun afterTest() {
     super.afterTest()
@@ -465,6 +475,6 @@ class LocationLayerControllerTest : EspressoTest() {
   }
 
   private fun executeComponentTest(listener: LocationComponentAction.OnPerformLocationComponentAction) {
-    onView(withId(R.id.content)).perform(LocationComponentAction(mapboxMap, listener))
+    onView(withId(android.R.id.content)).perform(LocationComponentAction(mapboxMap, listener))
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/drawable/mapbox_user_icon_shadow_0px_test.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/drawable/mapbox_user_icon_shadow_0px_test.xml
@@ -1,0 +1,19 @@
+<layer-list
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:opacity="opaque">
+  <item
+    android:gravity="center">
+    <shape
+      android:shape="oval">
+      <size
+        android:width="22dp"
+        android:height="22dp"/>
+      <gradient
+        android:centerColor="#40000000"
+        android:endColor="#00000000"
+        android:gradientRadius="0px"
+        android:startColor="#40000000"
+        android:type="radial"/>
+    </shape>
+  </item>
+</layer-list>


### PR DESCRIPTION
This PR cherry picks changes needed for doing an 8.0.2 patch release to release-nectar:

- [ ]  mapbox/mapbox-gl-native#15065 
- [ ]  mapbox/mapbox-gl-native#15092 
- [x]  mapbox/mapbox-gl-native#15099 
- [ ]  mapbox/mapbox-gl-native#15112
- [x] [8.0.2 changelog update on `master`](https://github.com/mapbox/mapbox-gl-native/pull/15273)


 
I get nasty core merge conflicts when I tried to cherry-pick mapbox/mapbox-gl-native#15065 and mapbox/mapbox-gl-native#15092. @LukasPaczos , you can look into solving the conflicts? 

When I tried to cherry-pick https://github.com/mapbox/mapbox-gl-native/pull/15112, I got 
![Screen Shot 2019-07-31 at 11 53 24 AM](https://user-images.githubusercontent.com/4394910/62239514-dbbd0480-b389-11e9-81f3-ebd560ac1558.png)

Seems that https://github.com/mapbox/mapbox-gl-native/pull/15112 was already brought into the `release-nectar` branch? I didn't see it in the 8.0.1 release. The advice in threads like https://stackoverflow.com/a/50052479/6358488 didn't help on my local machine.