### PR TITLE
[android] Additional changelog item to v7.4.1 mojito patch release section

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -16,6 +16,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 
 ### Bug fixes
  - Fixed a map update bug caused by the render tiles and the render passes getting unsynchronized [#15092](https://github.com/mapbox/mapbox-gl-native/pull/15092)
+ - Ensure location shadow's gradient radius is greater than 0 [#15099](https://github.com/mapbox/mapbox-gl-native/pull/15099)
  - Fixed a custom geometry source bug caused by using the outdated tiles after style update [#15112](https://github.com/mapbox/mapbox-gl-native/pull/15112)
 
 ## 8.3.0-alpha.1 - July 31, 2019


### PR DESCRIPTION
Follow up to https://github.com/mapbox/mapbox-gl-native/pull/15274. This pr updates the changelog by adding an additional pr that needs to go into the `7.4.1` patch release of `release-mojito`.