### PR TITLE
[core] easeTo: linear interpolation over zoom instead of scale

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 ### Bug fixes
  - Fixed an issue where it was possible to set the map’s content insets then tilt the map enough to see the horizon, causing performance issues [#15195](https://github.com/mapbox/mapbox-gl-native/pull/15195)
  - Allow loading of a map without a Style URI or Style JSON [#15293](https://github.com/mapbox/mapbox-gl-native/pull/15293)
+ - Fixed an issue where animated camera transitions zoomed in or out too dramatically [#15281](https://github.com/mapbox/mapbox-gl-native/pull/15281)
 
 ## 8.3.0-alpha.2 - August 7, 2019
 [Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.3.0-alpha.1...android-v8.3.0-alpha.2) since [Mapbox Maps SDK for Android v8.3.0-alpha.1](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.3.0-alpha.1):

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## master
+
+### Styles and rendering
+
+* Fixed an issue where animated camera transitions zoomed in or out too dramatically. ([#15281](https://github.com/mapbox/mapbox-gl-native/pull/15281))
+
 ## 5.3.0
 
 ### Styles and rendering

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Performance improvements for queryRenderedFeatures API and optimization that allocates containers based on a number of rendered layers. ([#14930](https://github.com/mapbox/mapbox-gl-native/pull/14930))
 * Fixed rendering layers after fill-extrusion regression caused by optimization of fill-extrusion rendering. ([#15065](https://github.com/mapbox/mapbox-gl-native/pull/15065))
 * `MGLLoggingLevel` has been updated for better matching core log levels. Now can use `[MGLLoggingConfiguration sharedConfiguration].loggingLevel` to filter logs from core . [#15120](https://github.com/mapbox/mapbox-gl-native/pull/15120)
+* Fixed an issue where animated camera transitions zoomed in or out too dramatically. [#15281](https://github.com/mapbox/mapbox-gl-native/pull/15281)
 
 ### Styles and rendering
 

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -82,7 +82,7 @@ void Transform::jumpTo(const CameraOptions& camera) {
  * values for any options not included in `options`.
  */
 void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& animation) {
-    Duration duration = animation.duration ? *animation.duration : Duration::zero();
+    Duration duration = animation.duration.value_or(Duration::zero());
     if (state.bounds == LatLngBounds::unbounded() && !isGestureInProgress() && duration != Duration::zero()) {
         // reuse flyTo, without exaggerated animation, to achieve constant ground speed.
         return flyTo(camera, animation, true);

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -112,7 +112,6 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
 
     // Constrain camera options.
     zoom = util::clamp(zoom, state.getMinZoom(), state.getMaxZoom());
-    const double scale = state.zoomScale(zoom);
     pitch = util::clamp(pitch, util::PITCH_MIN, util::PITCH_MAX);
 
     // Minimize rotation by taking the shorter path around the circle.
@@ -121,19 +120,19 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
 
     Duration duration = animation.duration ? *animation.duration : Duration::zero();
 
-    const double startScale = state.scale;
+    const double startZoom = state.getZoom();
     const double startBearing = state.bearing;
     const double startPitch = state.pitch;
     state.panning = unwrappedLatLng != startLatLng;
-    state.scaling = scale != startScale;
+    state.scaling = zoom != startZoom;
     state.rotating = bearing != startBearing;
     const EdgeInsets startEdgeInsets = state.edgeInsets;
 
     startTransition(camera, animation, [=](double t) {
         Point<double> framePoint = util::interpolate(startPoint, endPoint, t);
-        LatLng frameLatLng = Projection::unproject(framePoint, startScale);
-        double frameScale = util::interpolate(startScale, scale, t);
-        state.setLatLngZoom(frameLatLng, state.scaleZoom(frameScale));
+        LatLng frameLatLng = Projection::unproject(framePoint, state.zoomScale(startZoom));
+        double frameZoom = util::interpolate(startZoom, zoom, t);
+        state.setLatLngZoom(frameLatLng, frameZoom);
 
         if (bearing != startBearing) {
             state.bearing = util::wrap(util::interpolate(startBearing, bearing, t), -M_PI, M_PI);

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -34,12 +34,16 @@ public:
     /** Instantaneously, synchronously applies the given camera options. */
     void jumpTo(const CameraOptions&);
     /** Asynchronously transitions all specified camera options linearly along
-        an optional time curve. */
+        an optional time curve. However, center coordinate is not transitioned
+        linearly as, instead, ground speed is kept linear.*/
     void easeTo(const CameraOptions&, const AnimationOptions& = {});
     /** Asynchronously zooms out, pans, and zooms back into the given camera
         along a great circle, as though the viewer is riding a supersonic
-        jetcopter. */
-    void flyTo(const CameraOptions&, const AnimationOptions& = {});
+        jetcopter.
+        Parameter linearZoomInterpolation: when true, there is no additional
+        zooming out as zoom is linearly interpolated from current to given
+        camera zoom. This is used for easeTo.*/
+    void flyTo(const CameraOptions&, const AnimationOptions& = {}, bool linearZoomInterpolation = false);
 
     // Position
 


### PR DESCRIPTION
Captured screen video could be compared against videos #15144.
Final version (reusing fly to calculation for constant movement) as in https://github.com/mapbox/mapbox-gl-native/files/3460613/Archive.zip

![Image](https://user-images.githubusercontent.com/549216/62567724-7474e800-b894-11e9-9695-d8af60ee33fd.gif)


Version after first patch:
![Image](https://user-images.githubusercontent.com/549216/62245815-0d19ec80-b3eb-11e9-9eb1-c35465246850.gif)

Linear interpolation over zoom looks more natural, as the rate of change looks constant to user: for every zoom change of 1, view displays 2 times wider area.

Problem if using scale could be described by this graph:

http://www.mathopenref.com/graphfunctions.html?fx=log(x)&xh=1000000&xl=0&yh=20&yl=0
Horizontal axis: scale, vertical axis: zoom:

<img width="470" alt="Screen Shot 2019-07-31 at 23 36 02" src="https://user-images.githubusercontent.com/549216/62246311-0a6bc700-b3ec-11e9-8326-dff339e7da08.png">

When linearly interpolating over scale, zoom changes very slowly when zoomed in. When zooming out (values of scale towards 0), as reported in #15144, it feels like a sudden zoom out.

The transition could be further improved, by moving center coordinate slower for higher zoom values, to present linear interpolation of center coordinate on the screen, but this improvement already feels like fixing original issue.

Manual verification using modified iosapp:

```
diff --git a/platform/ios/app/MBXViewController.m b/platform/ios/app/MBXViewController.m
index 2fb95e1b1..bba60c64b 100644
--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -1784,11 +1784,28 @@ - (void)addAnnotations:(NSInteger)numAnnotations aroundCoordinate:(CLLocationCoo
 
 - (void)randomWorldTour {
     // Consistent initial conditions (consider setting these by test params)
-    srand48(0);
-    [self.mapView removeAnnotations:self.mapView.annotations];
-    [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(31, -100) zoomLevel:3 animated:NO];
-
-    [self randomWorldTourInternal];
+//    srand48(0);
+//    [self.mapView removeAnnotations:self.mapView.annotations];
+//    [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(31, -100) zoomLevel:3 animated:NO];
+
+//    [self randomWorldTourInternal];
+
+    static double altitude = 50000.0;
+    CLLocationCoordinate2D target;
+    if (altitude == 50000.0) {
+        altitude = 10.0;
+        target.latitude = 37.80296867678598;
+        target.longitude = -122.2494649887085;
+    } else {
+        altitude = 50000.0;
+        target.latitude = 37.85296867678598;
+        target.longitude = -122.2494649887085;
+    }
+    MGLMapCamera *camera = [MGLMapCamera cameraLookingAtCenterCoordinate:target
+                                                                altitude:altitude
+                                                                   pitch:0
+                                                                 heading:0];
+    [self.mapView setCamera:camera withDuration:2 animationTimingFunction:nil];
 }
 
 - (void)randomWorldTourInternal {
````
Fixes: #15144