### PR TITLE
[ios, build] Make CocoaPods CI deployment synchronous

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1074,18 +1074,15 @@ jobs:
             if [[ $CIRCLE_BRANCH == master ]]; then
               platform/ios/scripts/deploy-snapshot.sh
             fi
-          background: true
       - deploy:
           name: Deploy to Mapbox CocoaPods spec repo
           command: |
             if [[ $CIRCLE_BRANCH == master ]]; then
               platform/ios/scripts/deploy-to-cocoapods.sh
             fi
-          background: true
       - run:
           name: Record size
           command: platform/ios/scripts/metrics.sh
-          background: true
       - run:
           name: Trigger metrics
           command: |
@@ -1096,7 +1093,6 @@ jobs:
                 echo "MOBILE_METRICS_TOKEN not provided"
               fi
             fi
-          background: true
       - save-dependencies
       - collect-xcode-build-logs
       - upload-xcode-build-logs
@@ -1127,7 +1123,6 @@ jobs:
             export VERSION_TAG=${CIRCLE_TAG}
             export GITHUB_TOKEN=${DANGER_GITHUB_API_TOKEN}
             platform/ios/scripts/trigger-external-deploy-steps.sh
-          background: true
       - run:
           name: Build, package, and upload iOS release
           command: |
@@ -1137,7 +1132,6 @@ jobs:
       - deploy:
           name: Deploy to CocoaPods
           command: platform/ios/scripts/deploy-to-cocoapods.sh
-          background: true
       - save-dependencies
       - collect-xcode-build-logs
       - upload-xcode-build-logs


### PR DESCRIPTION
The CocoaPods deployment may not finish before the CI job ends, since it’s (unfortunately) somewhat long-running and `background: true` [evidently means](https://circleci.com/gh/mapbox/mapbox-gl-native/310161) that a step can be cancelled:

```
* Pushing release to CocoaPods trunk…

Setting up CocoaPods master repo

Cloning spec repo `master` from `https://github.com/CocoaPods/Specs.git` (branch `master`)
  $ /usr/local/bin/git clone https://github.com/CocoaPods/Specs.git --progress -- master
  Cloning into 'master'...
  
  remote: Enumerating objects: 1659, done.        
  remote: Counting objects: 100% (1659/1659), done.        
  remote: Compressing objects: 100% (1612/1612), done.        
  remote: Total 3341155 (delta 705), reused 8 (delta 3), pack-reused 3339496        
  Receiving objects: 100% (3341155/3341155), 669.19 MiB | 10.57 MiB/s, done.
Step was canceled
```

/cc @jmkiley 