### PR TITLE
[android] Adding latitude value check for test app CameraPositionActivity

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraPositionActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraPositionActivity.java
@@ -14,6 +14,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.SeekBar;
 import android.widget.TextView;
+import android.widget.Toast;
+
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -23,6 +25,9 @@ import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.testapp.R;
 import timber.log.Timber;
+
+import static com.mapbox.mapboxsdk.constants.GeometryConstants.MAX_LATITUDE;
+import static com.mapbox.mapboxsdk.constants.GeometryConstants.MIN_LATITUDE;
 
 /**
  * Test activity showcasing how to listen to camera change events.
@@ -241,6 +246,13 @@ public class CameraPositionActivity extends FragmentActivity implements OnMapRea
         ((TextView) dialogContent.findViewById(R.id.value_bearing)).getText().toString());
       double tilt = Double.parseDouble(
         ((TextView) dialogContent.findViewById(R.id.value_tilt)).getText().toString());
+
+      if (latitude < MIN_LATITUDE || latitude > MAX_LATITUDE) {
+        Toast.makeText(dialogContent.getContext(), "latitude value must be set "
+                + " between " + MIN_LATITUDE + " and " + MAX_LATITUDE,
+          Toast.LENGTH_SHORT).show();
+        return;
+      }
 
       CameraPosition cameraPosition = new CameraPosition.Builder()
         .target(new LatLng(latitude, longitude))


### PR DESCRIPTION
This pr fixes an Android test app crash in `CameraPositionActivity` if the latitude slider sets a latitude value less than -90 or more than 90. Discovered during manual QA of `8.3.0-alpha.1`.

![Screen Shot 2019-07-31 at 4 11 21 PM](https://user-images.githubusercontent.com/4394910/62254712-12594600-b3af-11e9-8e9a-3792ae44c2d5.png)


![device-2019-07-31-161130](https://user-images.githubusercontent.com/4394910/62254711-12594600-b3af-11e9-892e-983f34e87647.png)



