### PR TITLE
[core] Enable opaque pass for background layer. fix heatmap+backgroud test

### DIFF
--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -85,7 +85,6 @@
   "render-tests/text-rotate/with-offset": "https://github.com/mapbox/mapbox-gl-native/issues/11872",
   "render-tests/video/default": "skip - https://github.com/mapbox/mapbox-gl-native/issues/601",
   "render-tests/background-color/colorSpace-hcl": "needs issue",
-  "render-tests/combinations/heatmap-translucent--background-opaque": "needs investigation",
   "render-tests/feature-state/composite-expression": "https://github.com/mapbox/mapbox-gl-native/issues/12613",
   "render-tests/feature-state/data-expression": "https://github.com/mapbox/mapbox-gl-native/issues/12613",
   "render-tests/feature-state/vector-source": "https://github.com/mapbox/mapbox-gl-native/issues/12613",

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -37,8 +37,14 @@ void RenderBackgroundLayer::evaluate(const PropertyEvaluationParameters &paramet
         parameters.getCrossfadeParameters(),
         unevaluated.evaluate(parameters));
 
-    passes = properties->evaluated.get<style::BackgroundOpacity>() > 0 ? RenderPass::Translucent
-                                                                       : RenderPass::None;
+    passes = properties->evaluated.get<style::BackgroundOpacity>() == 0.0f
+        ? RenderPass::None
+        : (!unevaluated.get<style::BackgroundPattern>().isUndefined()
+           || properties->evaluated.get<style::BackgroundOpacity>() < 1.0f
+           || properties->evaluated.get<style::BackgroundColor>().a < 1.0f)
+        ? RenderPass::Translucent
+        // Supply both - evaluated based on opaquePassCutoff in render().
+        : RenderPass::Opaque | RenderPass::Translucent;
     properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 }
@@ -77,7 +83,9 @@ void RenderBackgroundLayer::render(PaintParameters& parameters) {
             parameters.context,
             *parameters.renderPass,
             gfx::Triangles(),
-            parameters.depthModeForSublayer(0, gfx::DepthMaskType::ReadOnly),
+            parameters.depthModeForSublayer(0, parameters.pass == RenderPass::Opaque
+                ? gfx::DepthMaskType::ReadWrite
+                : gfx::DepthMaskType::ReadOnly),
             gfx::StencilMode::disabled(),
             parameters.colorModeForRenderPass(),
             gfx::CullFaceMode::disabled(),
@@ -118,6 +126,12 @@ void RenderBackgroundLayer::render(PaintParameters& parameters) {
             );
         }
     } else {
+        auto backgroundRenderPass = (evaluated.get<BackgroundColor>().a >= 1.0f
+            && evaluated.get<BackgroundOpacity>() >= 1.0f
+            && parameters.currentLayer >= parameters.opaquePassCutoff) ? RenderPass::Opaque : RenderPass::Translucent;
+        if (parameters.pass != backgroundRenderPass) {
+            return;
+        }
         for (const auto& tileID : util::tileCover(parameters.state, parameters.state.getIntegerZoom())) {
             draw(
                 parameters.programs.getBackgroundLayerPrograms().background,

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -47,17 +47,12 @@ void RenderFillLayer::evaluate(const PropertyEvaluationParameters& parameters) {
         evaluated.get<style::FillOutlineColor>() = evaluated.get<style::FillColor>();
     }
 
-    passes = RenderPass::None;
+    passes = RenderPass::Translucent;
 
-    if (evaluated.get<style::FillAntialias>()) {
-        passes |= RenderPass::Translucent;
-    }
-
-    if (!unevaluated.get<style::FillPattern>().isUndefined()
+    if (!(!unevaluated.get<style::FillPattern>().isUndefined()
         || evaluated.get<style::FillColor>().constantOr(Color()).a < 1.0f
-        || evaluated.get<style::FillOpacity>().constantOr(0) < 1.0f) {
-        passes |= RenderPass::Translucent;
-    } else {
+        || evaluated.get<style::FillOpacity>().constantOr(0) < 1.0f)) {
+        // Supply both - evaluated based on opaquePassCutoff in render().
         passes |= RenderPass::Opaque;
     }
     properties->renderPasses = mbgl::underlying_type(passes);


### PR DESCRIPTION
Follow the approach from mapbox-gl-js for enabling opaque pass for background layer (same as for fill layer).

Fix combinations/heatmap-translucent--background-opaque render test.