### PR TITLE
[core] Fix render tile set source update

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -420,7 +420,8 @@ commands:
     - run:
         name: Run tests
         command: |
-          xvfb-run --server-args="-screen 0 1024x768x24" make run-test 2> >(tee sanitizer 1>&2)
+          # Source.RenderTileSetSourceUpdate is filtered out due to #15294
+          xvfb-run --server-args="-screen 0 1024x768x24" make run-test--Source.RenderTileSetSourceUpdate 2> >(tee sanitizer 1>&2)
           # Unfortunately, Google Test eats the status code, so we'll have to check the output.
           [ -z "$(sed -n '/^SUMMARY: .*Sanitizer:/p' sanitizer)" ]
 

--- a/src/mbgl/renderer/sources/render_tile_source.cpp
+++ b/src/mbgl/renderer/sources/render_tile_source.cpp
@@ -176,7 +176,7 @@ void RenderTileSetSource::update(Immutable<style::Source::Impl> baseImpl_,
         tilePyramid.clearAll();
     }
 
-    if (!implTileset) return;
+    if (!cachedTileset) return;
 
     updateInternal(*cachedTileset, layers, needsRendering, needsRelayout, parameters);
 }


### PR DESCRIPTION
Before this change, the `RenderTileSetSource` implementation
ignored update calls for the sources whose description was not yet
loaded and it lead to missing of relayout requests.