### PR TITLE
[core] Collision box improvements

### DIFF
--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -227,8 +227,8 @@ void SymbolBucket::sortFeatures(const float angle) {
     }
 }
 
-std::vector<std::reference_wrapper<SymbolInstance>> SymbolBucket::getSortedSymbols(const float angle) {
-    std::vector<std::reference_wrapper<SymbolInstance>> result(symbolInstances.begin(), symbolInstances.end());
+std::vector<std::reference_wrapper<const SymbolInstance>> SymbolBucket::getSortedSymbols(const float angle) const {
+    std::vector<std::reference_wrapper<const SymbolInstance>> result(symbolInstances.begin(), symbolInstances.end());
     const float sin = std::sin(angle);
     const float cos = std::cos(angle);
 

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -70,7 +70,7 @@ public:
 
     void sortFeatures(const float angle);
     // The result contains references to the `symbolInstances` items, sorted by viewport Y.
-    std::vector<std::reference_wrapper<SymbolInstance>> getSortedSymbols(const float angle);
+    std::vector<std::reference_wrapper<const SymbolInstance>> getSortedSymbols(const float angle) const;
 
     Immutable<style::SymbolLayoutProperties::PossiblyEvaluated> layout;
     const std::string bucketLeaderID;
@@ -84,7 +84,8 @@ public:
     bool placementChangesUploaded : 1;
     bool dynamicUploaded : 1;
     bool sortUploaded : 1;
-    bool justReloaded : 1;
+    // Set and used by placement.
+    mutable bool justReloaded : 1;
     bool hasVariablePlacement : 1;
 
     std::vector<SymbolInstance> symbolInstances;
@@ -113,8 +114,7 @@ public:
 
     std::unique_ptr<SymbolSizeBinder> iconSizeBinder;
 
-    struct IconBuffer : public Buffer {
-    } icon;
+    Buffer icon;
 
     struct CollisionBuffer {
         gfx::VertexVector<gfx::Vertex<CollisionBoxLayoutAttributes>> vertices;

--- a/src/mbgl/text/collision_feature.cpp
+++ b/src/mbgl/text/collision_feature.cpp
@@ -54,9 +54,9 @@ CollisionFeature::CollisionFeature(const GeometryCoordinates& line,
             const float yMin = std::min({tl.y, tr.y, bl.y, br.y});
             const float yMax = std::max({tl.y, tr.y, bl.y, br.y});
             
-            boxes.emplace_back(anchor.point, Point<float>{ 0, 0 }, xMin, yMin, xMax, yMax);
+            boxes.emplace_back(anchor.point, xMin, yMin, xMax, yMax);
         } else {
-            boxes.emplace_back(anchor.point, Point<float>{ 0, 0 }, x1, y1, x2, y2);
+            boxes.emplace_back(anchor.point, x1, y1, x2, y2);
         }
     }
 }
@@ -155,7 +155,7 @@ void CollisionFeature::bboxifyLabel(const GeometryCoordinates& line, GeometryCoo
             0 :
             (boxDistanceToAnchor - firstBoxOffset) * 0.8;
 
-        boxes.emplace_back(boxAnchor, boxAnchor - convertPoint<float>(anchorPoint), -boxSize / 2, -boxSize / 2, boxSize / 2, boxSize / 2, paddedAnchorDistance, boxSize / 2);
+        boxes.emplace_back(boxAnchor, -boxSize / 2, -boxSize / 2, boxSize / 2, boxSize / 2, paddedAnchorDistance, boxSize / 2);
     }
 }
 

--- a/src/mbgl/text/collision_feature.cpp
+++ b/src/mbgl/text/collision_feature.cpp
@@ -155,7 +155,7 @@ void CollisionFeature::bboxifyLabel(const GeometryCoordinates& line, GeometryCoo
             0 :
             (boxDistanceToAnchor - firstBoxOffset) * 0.8;
 
-        boxes.emplace_back(boxAnchor, -boxSize / 2, -boxSize / 2, boxSize / 2, boxSize / 2, paddedAnchorDistance, boxSize / 2);
+        boxes.emplace_back(boxAnchor, -boxSize / 2, -boxSize / 2, boxSize / 2, boxSize / 2, paddedAnchorDistance);
     }
 }
 

--- a/src/mbgl/text/collision_feature.hpp
+++ b/src/mbgl/text/collision_feature.hpp
@@ -11,14 +11,15 @@ namespace mbgl {
 
 class CollisionBox {
 public:
-    CollisionBox(Point<float> _anchor, Point<float> _offset, float _x1, float _y1, float _x2, float _y2, float _signedDistanceFromAnchor = 0, float _radius = 0) :
-        anchor(std::move(_anchor)), offset(_offset), x1(_x1), y1(_y1), x2(_x2), y2(_y2), used(true), signedDistanceFromAnchor(_signedDistanceFromAnchor), radius(_radius) {}
+    CollisionBox(Point<float> _anchor, float _x1, float _y1, float _x2, float _y2, float _signedDistanceFromAnchor = 0, float _radius = 0) :
+        anchor(std::move(_anchor)), x1(_x1), y1(_y1), x2(_x2), y2(_y2), used(true), signedDistanceFromAnchor(_signedDistanceFromAnchor), radius(_radius) {}
 
     // the box is centered around the anchor point
     Point<float> anchor;
-    
-    // the offset of the box from the label's anchor point
-    Point<float> offset;
+
+    // the offset of the box from the label's anchor point.
+    // TODO: might be needed for #13526
+    // Point<float> offset;
 
     // distances to the edges from the anchor
     float x1;

--- a/src/mbgl/text/collision_feature.hpp
+++ b/src/mbgl/text/collision_feature.hpp
@@ -64,9 +64,6 @@ public:
     float y2;
 
     float signedDistanceFromAnchor;
-
-    // generated/updated at placement time
-    ProjectedCollisionBox projected;
 };
 
 class CollisionFeature {

--- a/src/mbgl/text/collision_index.cpp
+++ b/src/mbgl/text/collision_index.cpp
@@ -55,12 +55,12 @@ float CollisionIndex::approximateTileDistance(const TileDistance& tileDistance, 
         (incidenceStretch - 1) * lastSegmentTile * std::abs(std::sin(lastSegmentAngle));
 }
 
-bool CollisionIndex::isOffscreen(const CollisionBox& box) const {
-    return box.px2 < viewportPadding || box.px1 >= screenRightBoundary || box.py2 < viewportPadding || box.py1 >= screenBottomBoundary;
+bool CollisionIndex::isOffscreen(float x1, float y1, float x2, float y2) const {
+    return x2 < viewportPadding || x1 >= screenRightBoundary || y2 < viewportPadding || y1 >= screenBottomBoundary;
 }
 
-bool CollisionIndex::isInsideGrid(const CollisionBox& box) const {
-    return box.px2 >= 0 && box.px1 < gridRightBoundary && box.py2 >= 0 && box.py1 < gridBottomBoundary;
+bool CollisionIndex::isInsideGrid(float x1, float y1, float x2, float y2) const {
+    return x2 >= 0 && x1 < gridRightBoundary && y2 >= 0 && y1 < gridBottomBoundary;
 }
     
 CollisionTileBoundaries CollisionIndex::projectTileBoundaries(const mat4& posMatrix) const {
@@ -71,11 +71,11 @@ CollisionTileBoundaries CollisionIndex::projectTileBoundaries(const mat4& posMat
     
 }
 
-bool CollisionIndex::isInsideTile(const CollisionBox& box, const CollisionTileBoundaries& tileBoundaries) const {
+bool CollisionIndex::isInsideTile(float x1, float y1, float x2, float y2, const CollisionTileBoundaries& tileBoundaries) const {
     // This check is only well defined when the tile boundaries are axis-aligned
     // We are relying on it only being used in MapMode::Tile, where that is always the case
 
-    return box.px1 >= tileBoundaries[0] && box.py1 >= tileBoundaries[1] && box.px2 < tileBoundaries[2] && box.py2 < tileBoundaries[3];
+    return x1 >= tileBoundaries[0] && y1 >= tileBoundaries[1] && x2 < tileBoundaries[2] && y2 < tileBoundaries[3];
 }
 
 
@@ -96,19 +96,19 @@ std::pair<bool,bool> CollisionIndex::placeFeature(CollisionFeature& feature,
         CollisionBox& box = feature.boxes.front();
         const auto projectedPoint = projectAndGetPerspectiveRatio(posMatrix, box.anchor);
         const float tileToViewport = textPixelRatio * projectedPoint.second;
-        box.px1 = (box.x1 + shift.x) * tileToViewport + projectedPoint.first.x;
-        box.py1 = (box.y1 + shift.y) * tileToViewport + projectedPoint.first.y;
-        box.px2 = (box.x2 + shift.x) * tileToViewport + projectedPoint.first.x;
-        box.py2 = (box.y2 + shift.y) * tileToViewport + projectedPoint.first.y;
-    
+        float px1 = (box.x1 + shift.x) * tileToViewport + projectedPoint.first.x;
+        float py1 = (box.y1 + shift.y) * tileToViewport + projectedPoint.first.y;
+        float px2 = (box.x2 + shift.x) * tileToViewport + projectedPoint.first.x;
+        float py2 = (box.y2 + shift.y) * tileToViewport + projectedPoint.first.y;
+        box.projected = ProjectedCollisionBox{ px1, py1, px2, py2 };
 
-        if ((avoidEdges && !isInsideTile(box, *avoidEdges)) ||
-            !isInsideGrid(box) ||
-            (!allowOverlap && collisionGrid.hitTest({{ box.px1, box.py1 }, { box.px2, box.py2 }}, collisionGroupPredicate))) {
+        if ((avoidEdges && !isInsideTile(px1, py1, px2, py2, *avoidEdges)) ||
+            !isInsideGrid(px1, py1, px2, py2) ||
+            (!allowOverlap && collisionGrid.hitTest(box.projected.box(), collisionGroupPredicate))) {
             return { false, false };
         }
 
-        return {true, isOffscreen(box)};
+        return {true, isOffscreen(px1, py1, px2, py2)};
     } else {
         return placeLineFeature(feature, posMatrix, labelPlaneMatrix, textPixelRatio, symbol, scale, fontSize, allowOverlap, pitchWithMap, collisionDebug, avoidEdges, collisionGroupPredicate);
     }
@@ -126,7 +126,7 @@ std::pair<bool,bool> CollisionIndex::placeLineFeature(CollisionFeature& feature,
                                       const bool collisionDebug,
                                       const optional<CollisionTileBoundaries>& avoidEdges,
                                       const optional<std::function<bool(const IndexedSubfeature&)>> collisionGroupPredicate) {
-
+    assert(feature.alongLine);
     const auto tileUnitAnchorPoint = symbol.anchorPoint;
     const auto projectedAnchor = projectAnchor(posMatrix, tileUnitAnchorPoint);
 
@@ -173,7 +173,6 @@ std::pair<bool,bool> CollisionIndex::placeLineFeature(CollisionFeature& feature,
             // The label either doesn't fit on its line or we
             // don't need to use this circle because the label
             // doesn't extend this far. Either way, mark the circle unused.
-            circle.used = false;
             previousCirclePlaced = false;
             continue;
         }
@@ -184,9 +183,10 @@ std::pair<bool,bool> CollisionIndex::placeLineFeature(CollisionFeature& feature,
 
         if (previousCirclePlaced) {
             const CollisionBox& previousCircle = feature.boxes[i - 1];
-            assert(previousCircle.used);
-            const float dx = projectedPoint.x - previousCircle.px;
-            const float dy = projectedPoint.y - previousCircle.py;
+            assert(previousCircle.projected.isCircle());
+            const auto& previousCenter = previousCircle.projected.circle().center;
+            const float dx = projectedPoint.x - previousCenter.x;
+            const float dy = projectedPoint.y - previousCenter.y;
             // The circle edges touch when the distance between their centers is 2x the radius
             // When the distance is 1x the radius, they're doubled up, and we could remove
             // every other circle while keeping them all in touch.
@@ -204,7 +204,6 @@ std::pair<bool,bool> CollisionIndex::placeLineFeature(CollisionFeature& feature,
                         // Hide significantly overlapping circles, unless this is the last one we can
                         // use, in which case we want to keep it in place even if it's tightly packed
                         // with the one before it.
-                        circle.used = false;
                         previousCirclePlaced = false;
                         continue;
                     }
@@ -213,22 +212,18 @@ std::pair<bool,bool> CollisionIndex::placeLineFeature(CollisionFeature& feature,
         }
 
         previousCirclePlaced = true;
-        circle.px1 = projectedPoint.x - radius;
-        circle.px2 = projectedPoint.x + radius;
-        circle.py1 = projectedPoint.y - radius;
-        circle.py2 = projectedPoint.y + radius;
-        
-        circle.used = true;
-        
-        circle.px = projectedPoint.x;
-        circle.py = projectedPoint.y;
-        circle.radius = radius;
-        
-        entirelyOffscreen &= isOffscreen(circle);
-        inGrid |= isInsideGrid(circle);
+        float px1 = projectedPoint.x - radius;
+        float px2 = projectedPoint.x + radius;
+        float py1 = projectedPoint.y - radius;
+        float py2 = projectedPoint.y + radius;
 
-        if ((avoidEdges && !isInsideTile(circle, *avoidEdges)) ||
-            (!allowOverlap && collisionGrid.hitTest({{circle.px, circle.py}, circle.radius}, collisionGroupPredicate))) {
+        circle.projected = ProjectedCollisionBox{projectedPoint.x, projectedPoint.y, radius};
+        
+        entirelyOffscreen &= isOffscreen(px1, py1, px2, py2);
+        inGrid |= isInsideGrid(px1, py1, px2, py2);
+
+        if ((avoidEdges && !isInsideTile(px1, py1, px2, py2, *avoidEdges)) ||
+            (!allowOverlap && collisionGrid.hitTest(circle.projected.circle(), collisionGroupPredicate))) {
             if (!collisionDebug) {
                 return {false, false};
             } else {
@@ -246,34 +241,35 @@ std::pair<bool,bool> CollisionIndex::placeLineFeature(CollisionFeature& feature,
 void CollisionIndex::insertFeature(CollisionFeature& feature, bool ignorePlacement, uint32_t bucketInstanceId, uint16_t collisionGroupId) {
     if (feature.alongLine) {
         for (auto& circle : feature.boxes) {
-            if (!circle.used) {
+            if (!circle.projected.isCircle()) {
                 continue;
             }
 
             if (ignorePlacement) {
                 ignoredGrid.insert(
                     IndexedSubfeature(feature.indexedFeature, bucketInstanceId, collisionGroupId),
-                    {{ circle.px, circle.py }, circle.radius}
+                    circle.projected.circle()
                 );
             } else {
                 collisionGrid.insert(
                     IndexedSubfeature(feature.indexedFeature, bucketInstanceId, collisionGroupId),
-                    {{ circle.px, circle.py }, circle.radius}
+                    circle.projected.circle()
                 );
             }
         }
     } else {
         assert(feature.boxes.size() == 1);
         auto& box = feature.boxes[0];
+        assert(box.projected.isBox());
         if (ignorePlacement) {
             ignoredGrid.insert(
                 IndexedSubfeature(feature.indexedFeature, bucketInstanceId, collisionGroupId),
-                {{ box.px1, box.py1 }, { box.px2, box.py2 }}
+                box.projected.box()
             );
         } else {
             collisionGrid.insert(
                 IndexedSubfeature(feature.indexedFeature, bucketInstanceId, collisionGroupId),
-                {{ box.px1, box.py1 }, { box.px2, box.py2 }}
+                box.projected.box()
             );
         }
     }

--- a/src/mbgl/text/collision_index.hpp
+++ b/src/mbgl/text/collision_index.hpp
@@ -45,9 +45,9 @@ public:
     const TransformState& getTransformState() const { return transformState; }
 
 private:
-    bool isOffscreen(const CollisionBox&) const;
-    bool isInsideGrid(const CollisionBox&) const;
-    bool isInsideTile(const CollisionBox&, const CollisionTileBoundaries& tileBoundaries) const;
+    bool isOffscreen(float x1, float y1, float x2, float y2) const;
+    bool isInsideGrid(float x1, float y1, float x2, float y2) const;
+    bool isInsideTile(float x1, float y1, float x2, float y2, const CollisionTileBoundaries& tileBoundaries) const;
 
     std::pair<bool,bool> placeLineFeature(CollisionFeature& feature,
                                   const mat4& posMatrix,

--- a/src/mbgl/text/collision_index.hpp
+++ b/src/mbgl/text/collision_index.hpp
@@ -22,21 +22,22 @@ public:
 
     explicit CollisionIndex(const TransformState&);
 
-    std::pair<bool,bool> placeFeature(CollisionFeature& feature,
+    std::pair<bool,bool> placeFeature(const CollisionFeature& feature,
                                       Point<float> shift,
                                       const mat4& posMatrix,
                                       const mat4& labelPlaneMatrix,
                                       const float textPixelRatio,
-                                      PlacedSymbol& symbol,
+                                      const PlacedSymbol& symbol,
                                       const float scale,
                                       const float fontSize,
                                       const bool allowOverlap,
                                       const bool pitchWithMap,
                                       const bool collisionDebug,
                                       const optional<CollisionTileBoundaries>& avoidEdges,
-                                      const optional<std::function<bool(const IndexedSubfeature&)>> collisionGroupPredicate);
+                                      const optional<std::function<bool(const IndexedSubfeature&)>> collisionGroupPredicate,
+                                      std::vector<ProjectedCollisionBox>& /*out*/);
 
-    void insertFeature(CollisionFeature& feature, bool ignorePlacement, uint32_t bucketInstanceId, uint16_t collisionGroupId);
+    void insertFeature(const CollisionFeature& feature, const std::vector<ProjectedCollisionBox>&, bool ignorePlacement, uint32_t bucketInstanceId, uint16_t collisionGroupId);
 
     std::unordered_map<uint32_t, std::vector<IndexedSubfeature>> queryRenderedSymbols(const ScreenLineString&) const;
     
@@ -49,18 +50,19 @@ private:
     bool isInsideGrid(float x1, float y1, float x2, float y2) const;
     bool isInsideTile(float x1, float y1, float x2, float y2, const CollisionTileBoundaries& tileBoundaries) const;
 
-    std::pair<bool,bool> placeLineFeature(CollisionFeature& feature,
+    std::pair<bool,bool> placeLineFeature(const CollisionFeature& feature,
                                   const mat4& posMatrix,
                                   const mat4& labelPlaneMatrix,
                                   const float textPixelRatio,
-                                  PlacedSymbol& symbol,
+                                  const PlacedSymbol& symbol,
                                   const float scale,
                                   const float fontSize,
                                   const bool allowOverlap,
                                   const bool pitchWithMap,
                                   const bool collisionDebug,
                                   const optional<CollisionTileBoundaries>& avoidEdges,
-                                  const optional<std::function<bool(const IndexedSubfeature&)>> collisionGroupPredicate);
+                                  const optional<std::function<bool(const IndexedSubfeature&)>> collisionGroupPredicate,
+                                  std::vector<ProjectedCollisionBox>& /*out*/);
     
     float approximateTileDistance(const TileDistance& tileDistance, const float lastSegmentAngle, const float pixelsToTileUnits, const float cameraToAnchorDistance, const bool pitchWithMap);
     

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -628,7 +628,7 @@ void Placement::updateBucketOpacities(SymbolBucket& bucket, const TransformState
                 return;
             }
             for (const CollisionBox& box : feature.boxes) {
-                const auto& dynamicVertex = CollisionBoxProgram::dynamicVertex(placed, !box.used, {});
+                const auto& dynamicVertex = CollisionBoxProgram::dynamicVertex(placed, !box.projected.isCircle(), {});
                 bucket.collisionCircle->dynamicVertices.extend(4, dynamicVertex);
             }
         };

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -116,11 +116,11 @@ public:
 private:
     friend SymbolBucket;
     void placeBucket(
-            SymbolBucket&,
+            const SymbolBucket&,
             const BucketPlacementParameters&,
             std::set<uint32_t>& seenCrossTileIDs);
     // Returns `true` if bucket vertices were updated; returns `false` otherwise.
-    bool updateBucketDynamicVertices(SymbolBucket&, const TransformState&, const RenderTile& tile);
+    bool updateBucketDynamicVertices(SymbolBucket&, const TransformState&, const RenderTile& tile) const;
     void updateBucketOpacities(SymbolBucket&, const TransformState&, std::set<uint32_t>&);
     void markUsedJustification(SymbolBucket&, style::TextVariableAnchorType, SymbolInstance&);
 
@@ -141,6 +141,9 @@ private:
     std::unordered_map<uint32_t, RetainedQueryData> retainedQueryData;
     CollisionGroups collisionGroups;
     std::unique_ptr<Placement> prevPlacement;
+
+    // Used for debug purposes.
+    std::unordered_map<const CollisionFeature*, std::vector<ProjectedCollisionBox>> collisionCircles;
 };
 
 } // namespace mbgl


### PR DESCRIPTION
This PR does two things:
* Prevents collision index from using of uninitialized variables
* Decreases the `CollisionBox` size by 40 bytes. Considering the huge amount of `CollisionBox` instances (one instance per glyph for along-line placed symbols) it saves more than 2 MB on maximum zoom level, if the map is showing a city center with a lot of labels. Tagging #15022
* Fixes constness at `Placement::placeBucket` - now it does not mutate the given bucket. Tagging #14638