### PR TITLE
[core] Fix placement for updated buckets

### DIFF
--- a/include/mbgl/storage/resource.hpp
+++ b/include/mbgl/storage/resource.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
 #include <mbgl/storage/response.hpp>
+#include <mbgl/util/bitmask_operations.hpp>
 #include <mbgl/util/optional.hpp>
 #include <mbgl/util/font_stack.hpp>
 #include <mbgl/util/tileset.hpp>
-#include <mbgl/util/util.hpp>
-#include <mbgl/util/traits.hpp>
 
 #include <string>
 
@@ -98,21 +97,8 @@ public:
     std::shared_ptr<const std::string> priorData;
 };
 
-
-MBGL_CONSTEXPR Resource::LoadingMethod operator|(Resource::LoadingMethod a, Resource::LoadingMethod b) {
-    return Resource::LoadingMethod(mbgl::underlying_type(a) | mbgl::underlying_type(b));
-}
-
-MBGL_CONSTEXPR Resource::LoadingMethod& operator|=(Resource::LoadingMethod& a, Resource::LoadingMethod b) {
-    return (a = a | b);
-}
-
-MBGL_CONSTEXPR Resource::LoadingMethod operator&(Resource::LoadingMethod a, Resource::LoadingMethod b) {
-    return Resource::LoadingMethod(mbgl::underlying_type(a) & mbgl::underlying_type(b));
-}
-
 inline bool Resource::hasLoadingMethod(Resource::LoadingMethod method) {
-    return (loadingMethod & method) != Resource::LoadingMethod::None;
+    return (loadingMethod & method);
 }
 
 } // namespace mbgl

--- a/include/mbgl/util/bitmask_operations.hpp
+++ b/include/mbgl/util/bitmask_operations.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <mbgl/util/traits.hpp>
+#include <mbgl/util/util.hpp>
+
+namespace mbgl {
+
+template<typename Enum>
+MBGL_CONSTEXPR Enum operator|(Enum a, Enum b) {
+    static_assert(std::is_enum<Enum>::value, "Enum must be an enum type");
+    return Enum(mbgl::underlying_type(a) | mbgl::underlying_type(b));
+}
+
+template<typename Enum>
+MBGL_CONSTEXPR Enum& operator|=(Enum& a, Enum b) {
+    static_assert(std::is_enum<Enum>::value, "Enum must be an enum type");
+    return (a = a | b);
+}
+
+template<typename Enum>
+MBGL_CONSTEXPR bool operator&(Enum a, Enum b) {
+    static_assert(std::is_enum<Enum>::value, "Enum must be an enum type");
+    return bool(mbgl::underlying_type(a) & mbgl::underlying_type(b));
+}
+
+template<typename Enum>
+MBGL_CONSTEXPR Enum operator~(Enum value) {
+    static_assert(std::is_enum<Enum>::value, "Enum must be an enum type");
+    return Enum(~mbgl::underlying_type(value));
+}
+
+
+} // namespace mbgl

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -11,6 +11,9 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 ## 8.4.0-alpha.2 - September 11, 2019
 [Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.4.0-alpha.1...android-v8.4.0-alpha.2) since [Mapbox Maps SDK for Android v8.4.0](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.4.0-alpha.1): 
 
+### Performance improvements
+ - Newly loaded labels appear faster on the screen. [#15308](https://github.com/mapbox/mapbox-gl-native/pull/15308)
+
 ### Bug fixes
  - Fixed an issue of integer overflow when converting `tileCoordinates` to `LatLon`, which caused issues such as `queryRenderedFeatures` and `querySourceFeatures` returning incorrect coordinates at zoom levels 20 and higher. [#15560](https://github.com/mapbox/mapbox-gl-native/pull/15560)
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## master
+
+### Performance improvements
+
+* Newly loaded labels appear faster on the screen. ([#15308](https://github.com/mapbox/mapbox-gl-native/pull/15308))
+
 ## 5.4.0
 
 ### Styles and rendering

--- a/src/core-files.json
+++ b/src/core-files.json
@@ -456,6 +456,7 @@
         "mbgl/tile/tile_necessity.hpp": "include/mbgl/tile/tile_necessity.hpp",
         "mbgl/util/async_request.hpp": "include/mbgl/util/async_request.hpp",
         "mbgl/util/async_task.hpp": "include/mbgl/util/async_task.hpp",
+        "mbgl/util/bitmask_operations.hpp": "include/mbgl/util/bitmask_operations.hpp",
         "mbgl/util/char_array_buffer.hpp": "include/mbgl/util/char_array_buffer.hpp",
         "mbgl/util/chrono.hpp": "include/mbgl/util/chrono.hpp",
         "mbgl/util/color.hpp": "include/mbgl/util/color.hpp",

--- a/src/mbgl/layout/symbol_instance.hpp
+++ b/src/mbgl/layout/symbol_instance.hpp
@@ -4,8 +4,7 @@
 #include <mbgl/text/glyph_atlas.hpp>
 #include <mbgl/text/collision_feature.hpp>
 #include <mbgl/style/layers/symbol_layer_properties.hpp>
-#include <mbgl/util/traits.hpp>
-#include <mbgl/util/util.hpp>
+#include <mbgl/util/bitmask_operations.hpp>
 
 namespace mbgl {
 
@@ -49,18 +48,6 @@ enum class SymbolContent : uint8_t {
     IconRGBA = 1 << 1,
     IconSDF = 1 << 2
 };
-
-MBGL_CONSTEXPR SymbolContent operator|(SymbolContent a, SymbolContent b) {
-    return SymbolContent(mbgl::underlying_type(a) | mbgl::underlying_type(b));
-}
-
-MBGL_CONSTEXPR SymbolContent& operator|=(SymbolContent& a, SymbolContent b) {
-    return (a = a | b);
-}
-
-MBGL_CONSTEXPR SymbolContent operator&(SymbolContent a, SymbolContent b) {
-    return SymbolContent(mbgl::underlying_type(a) & mbgl::underlying_type(b));
-}
 
 class SymbolInstance {
 public:

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -32,7 +32,7 @@ const std::string& RenderLayer::getID() const {
 }
 
 bool RenderLayer::hasRenderPass(RenderPass pass) const {
-    return bool(passes & pass);
+    return passes & pass;
 }
 
 bool RenderLayer::needsRendering() const {

--- a/src/mbgl/renderer/render_pass.hpp
+++ b/src/mbgl/renderer/render_pass.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <mbgl/util/traits.hpp>
-#include <mbgl/util/util.hpp>
+#include <mbgl/util/bitmask_operations.hpp>
 
 #include <cstdint>
 
@@ -13,18 +12,6 @@ enum class RenderPass : uint8_t {
     Translucent = 1 << 1,
     Pass3D = 1 << 2,
 };
-
-MBGL_CONSTEXPR RenderPass operator|(RenderPass a, RenderPass b) {
-    return RenderPass(mbgl::underlying_type(a) | mbgl::underlying_type(b));
-}
-
-MBGL_CONSTEXPR RenderPass& operator|=(RenderPass& a, RenderPass b) {
-    return (a = a | b);
-}
-
-MBGL_CONSTEXPR RenderPass operator&(RenderPass a, RenderPass b) {
-    return RenderPass(mbgl::underlying_type(a) & mbgl::underlying_type(b));
-}
 
 // Defines whether the overdraw shaders should be used instead of the regular shaders.
 enum class PaintMode : bool {

--- a/src/mbgl/text/cross_tile_symbol_index.hpp
+++ b/src/mbgl/text/cross_tile_symbol_index.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/tile/tile_id.hpp>
+#include <mbgl/util/bitmask_operations.hpp>
 #include <mbgl/util/geometry.hpp>
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/optional.hpp>
@@ -58,7 +59,13 @@ class CrossTileSymbolIndex {
 public:
     CrossTileSymbolIndex();
 
-    bool addLayer(const RenderLayer& layer, float lng);
+    enum class AddLayerResult : uint8_t {
+        NoChanges = 0,
+        BucketsAdded = 1 << 0,
+        BucketsRemoved = 1 << 1
+    };
+
+    AddLayerResult addLayer(const RenderLayer& layer, float lng);
     void pruneUnusedLayers(const std::set<std::string>&);
 
     void reset();

--- a/src/mbgl/text/glyph.hpp
+++ b/src/mbgl/text/glyph.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/text/glyph_range.hpp>
+#include <mbgl/util/bitmask_operations.hpp>
 #include <mbgl/util/font_stack.hpp>
 #include <mbgl/util/rect.hpp>
 #include <mbgl/util/traits.hpp>
@@ -98,26 +99,6 @@ enum class WritingModeType : uint8_t {
     Horizontal = 1 << 0,
     Vertical = 1 << 1,
 };
-
-MBGL_CONSTEXPR WritingModeType operator|(WritingModeType a, WritingModeType b) {
-    return WritingModeType(mbgl::underlying_type(a) | mbgl::underlying_type(b));
-}
-
-MBGL_CONSTEXPR WritingModeType& operator|=(WritingModeType& a, WritingModeType b) {
-    return (a = a | b);
-}
-
-MBGL_CONSTEXPR bool operator&(WritingModeType lhs, WritingModeType rhs) {
-    return mbgl::underlying_type(lhs) & mbgl::underlying_type(rhs);
-}
-
-MBGL_CONSTEXPR WritingModeType& operator&=(WritingModeType& lhs, WritingModeType rhs) {
-    return (lhs = WritingModeType(mbgl::underlying_type(lhs) & mbgl::underlying_type(rhs)));
-}
-
-MBGL_CONSTEXPR WritingModeType operator~(WritingModeType value) {
-    return WritingModeType(~mbgl::underlying_type(value));
-}
 
 using GlyphDependencies = std::map<FontStack, GlyphIDs>;
 using GlyphRangeDependencies = std::map<FontStack, std::unordered_set<GlyphRange>>;

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -699,7 +699,7 @@ void Placement::updateBucketOpacities(SymbolBucket& bucket, const TransformState
     if (bucket.hasTextCollisionBoxData()) bucket.textCollisionBox->dynamicVertices.clear();
     if (bucket.hasTextCollisionCircleData()) bucket.textCollisionCircle->dynamicVertices.clear();
 
-    JointOpacityState duplicateOpacityState(false, false, true);
+    const JointOpacityState duplicateOpacityState(false, false, true);
 
     const bool textAllowOverlap = bucket.layout->get<style::TextAllowOverlap>();
     const bool iconAllowOverlap = bucket.layout->get<style::IconAllowOverlap>();
@@ -712,7 +712,7 @@ void Placement::updateBucketOpacities(SymbolBucket& bucket, const TransformState
     // But we have to wait for placement if we potentially depend on a paired icon/text
     // with allow-overlap: false.
     // See https://github.com/mapbox/mapbox-gl-native/issues/12483
-    JointOpacityState defaultOpacityState(
+    const JointOpacityState defaultOpacityState(
             textAllowOverlap && (iconAllowOverlap || !(bucket.hasIconData() || bucket.hasSdfIconData()) || bucket.layout->get<style::IconOptional>()),
             iconAllowOverlap && (textAllowOverlap || !bucket.hasTextData() || bucket.layout->get<style::TextOptional>()),
             true);
@@ -726,10 +726,6 @@ void Placement::updateBucketOpacities(SymbolBucket& bucket, const TransformState
             opacityState = duplicateOpacityState;
         } else if (it != opacities.end()) {
             opacityState = it->second;
-        }
-
-        if (it == opacities.end()) {
-            opacities.emplace(symbolInstance.crossTileID, defaultOpacityState);
         }
 
         seenCrossTileIDs.insert(symbolInstance.crossTileID);

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -110,7 +110,7 @@ public:
     const CollisionIndex& getCollisionIndex() const;
 
     bool stillRecent(TimePoint now, const float zoom) const;
-    void setRecent(TimePoint now);
+    void setMaximumUpdatePeriod(Duration);
     void setStale();
     
     const RetainedQueryData& getQueryData(uint32_t bucketInstanceId) const;
@@ -126,6 +126,7 @@ private:
     void markUsedJustification(SymbolBucket&, style::TextVariableAnchorType, const SymbolInstance&, style::TextWritingModeType orientation);
     void markUsedOrientation(SymbolBucket&, style::TextWritingModeType, const SymbolInstance&);
     float zoomAdjustment(const float zoom) const;
+    Duration getUpdatePeriod(const float zoom) const;
 
     CollisionIndex collisionIndex;
 
@@ -147,6 +148,7 @@ private:
     std::unordered_map<uint32_t, RetainedQueryData> retainedQueryData;
     CollisionGroups collisionGroups;
     std::unique_ptr<Placement> prevPlacement;
+    optional<Duration> maximumUpdatePeriod;
 
     // Used for debug purposes.
     std::unordered_map<const CollisionFeature*, std::vector<ProjectedCollisionBox>> collisionCircles;


### PR DESCRIPTION
Before this change, just loaded buckets could not be placed until the new placement was created in a 300 ms period, and it caused a latency in symbols appearance.
Now buckets load initiates new placement, so that newly added symbols get placed immediately.
Before:
![before](https://user-images.githubusercontent.com/998253/62424935-10a8be80-b6de-11e9-970f-3130bbbab87d.gif)

After:
![after](https://user-images.githubusercontent.com/998253/62424941-19999000-b6de-11e9-8ca6-11e3466044b4.gif)

(Transition duration is set to 1 s for better visibility)

Another positive impact is that a `Placement` instance does not have to set opacity for the symbols, which it did not place.  So, `updateBucketOpacities()` call now does not mutate the placement, tagging #14638