### PR TITLE
macOS/iOS: Fix rare crash when downloading tiles that returned a 404

### DIFF
--- a/platform/darwin/src/http_file_source.mm
+++ b/platform/darwin/src/http_file_source.mm
@@ -245,8 +245,10 @@ std::unique_ptr<AsyncRequest> HTTPFileSource::request(const Resource& resource, 
         }
 
         [req addValue:impl->userAgent forHTTPHeaderField:@"User-Agent"];
-        
-        if (resource.kind == mbgl::Resource::Kind::Tile) {
+
+        const bool isTile = resource.kind == mbgl::Resource::Kind::Tile;
+
+        if (isTile) {
             [[MGLNetworkConfiguration sharedManager] startDownloadEvent:url.relativePath type:@"tile"];
         }
         
@@ -322,7 +324,7 @@ std::unique_ptr<AsyncRequest> HTTPFileSource::request(const Resource& resource, 
 
                     if (responseCode == 200) {
                         response.data = std::make_shared<std::string>((const char *)[data bytes], [data length]);
-                    } else if (responseCode == 204 || (responseCode == 404 && resource.kind == Resource::Kind::Tile)) {
+                    } else if (responseCode == 204 || (responseCode == 404 && isTile)) {
                         response.noContent = true;
                     } else if (responseCode == 304) {
                         response.notModified = true;


### PR DESCRIPTION
We were capturing the reference to an object that could go away when the request was canceled. However, the lambda could still be invoked by NSURLSession, creating a race condition with a resulting crash when the response to a tile request was 404 Not Found.

This fixes https://github.com/mapbox/mapbox-gl-native/issues/14325 and https://github.com/mapbox/mapbox-gl-native/issues/9814