### PR TITLE
mbgl-render-test runner - use the node render test tolerance. Platform specific ignore list.

### DIFF
--- a/render-test/linux-ignores.json
+++ b/render-test/linux-ignores.json
@@ -1,0 +1,5 @@
+{
+  "render-tests/regressions/mapbox-gl-js#7066": "Failing with mbgl-render-test",
+  "render-tests/regressions/mapbox-gl-js#5642": "Failing with mbgl-render-test"
+}
+

--- a/render-test/linux-ignores.json
+++ b/render-test/linux-ignores.json
@@ -1,5 +1,6 @@
 {
   "render-tests/regressions/mapbox-gl-js#7066": "Failing with mbgl-render-test",
-  "render-tests/regressions/mapbox-gl-js#5642": "Failing with mbgl-render-test"
+  "render-tests/regressions/mapbox-gl-js#5642": "Failing with mbgl-render-test",
+  "render-tests/line-pattern/opacity": "Flaky on Linux: https://github.com/mapbox/mapbox-gl-native/issues/15320"
 }
 

--- a/render-test/mac-ignores.json
+++ b/render-test/mac-ignores.json
@@ -1,0 +1,5 @@
+{
+  "render-tests/regressions/mapbox-gl-js#7066": "Failing with mbgl-render-test",
+  "render-tests/regressions/mapbox-gl-js#5642": "Failing with mbgl-render-test"
+}
+

--- a/render-test/runner.cpp
+++ b/render-test/runner.cpp
@@ -62,7 +62,7 @@ bool TestRunner::checkImage(mbgl::PremultipliedImage&& actual, TestMetadata& met
 
         pixels = // implicitly converting from uint64_t
             mapbox::pixelmatch(actual.data.get(), expected.data.get(), expected.size.width,
-                               expected.size.height, diff.data.get(), 0.16); // GL JS uses 0.1285
+                               expected.size.height, diff.data.get(), 0.1285); // Defined in GL JS
 
         metadata.diff = mbgl::encodePNG(diff);
 


### PR DESCRIPTION
Platform specific ignore files.

Use the same tolerance as in node render tests. 

Two render tests failing only with mbgl-render-tests are added to platform
specific ignores. The tests are not regressions, but a few pixels over the tolerance. We'll need to figure out what's the reason.

This is to be extended with fill-extrusion-pattern tests failing only on mac bot.

Patch#2 ignores flaky line-pattern/opacity test on Linux only - related to: #15320