### PR TITLE
[core] Disable flaky OfflineDatabase.MaximumAmbientCacheSize test

### DIFF
--- a/test/storage/offline_database.test.cpp
+++ b/test/storage/offline_database.test.cpp
@@ -515,7 +515,8 @@ TEST(OfflineDatabase, GetRegionDefinition) {
     );
 }
 
-TEST(OfflineDatabase, TEST_REQUIRES_WRITE(MaximumAmbientCacheSize)) {
+// Disabled due to flakiness: https://github.com/mapbox/mapbox-gl-native/issues/14966
+TEST(OfflineDatabase, TEST_REQUIRES_WRITE(DISABLED_MaximumAmbientCacheSize)) {
     FixtureLog log;
     deleteDatabaseFiles();
 


### PR DESCRIPTION
Disables the intermittently failing `OfflineDatabase.MaximumAmbientCacheSize` test while #14966 awaits attention.

/cc @tmpsantos 