### PR TITLE
[android] Do not try to wake up the RunLoop if a wake is already pending

### DIFF
--- a/platform/android/src/run_loop_impl.hpp
+++ b/platform/android/src/run_loop_impl.hpp
@@ -41,6 +41,7 @@ public:
     ALooper* loop = nullptr;
     RunLoop* runLoop = nullptr;
     std::atomic<bool> running;
+    std::atomic_flag coalesce = ATOMIC_FLAG_INIT;
 
 private:
     friend RunLoop;


### PR DESCRIPTION
Do not flood the RunLoop with wake up calls, potentially causing writes to the socket to block when internal pipe buffer goes over the limit defined by the system (usually 65536).

Also, write calls are syscalls and will cause a context switch.

Fixes #14740

/cc @alexshalamov that found the issue.