### PR TITLE
[android] Added #15330 to the 8.3.0-alpha.2 changelog

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -17,6 +17,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 
 ### Bug fixes
 - Load a style without an URI or JSON [#15293](https://github.com/mapbox/mapbox-gl-native/pull/15293)
+- Do not try to wake up the RunLoop if a wake is already pending. Fixes offline downloads that could freeze after resuming. [#15330](https://github.com/mapbox/mapbox-gl-native/pull/15330)
 
 ## 8.0.2 - July 31, 2019
 [Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.0.1...android-v8.0.2) since [Mapbox Maps SDK for Android v8.0.1](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.0.1):


### PR DESCRIPTION
The `8.3.0-alpha.2` release went out but https://github.com/mapbox/mapbox-gl-native/pull/15330 was added to `master` while I was in the middle of the release process and never saw it until it was too late to add it to the changelog in https://github.com/mapbox/mapbox-gl-native/pull/15334.

https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.3.0-alpha.2 includes #15330, so the Android changelog needs to be updated. This pr updates the changelog.