### PR TITLE
[core] Enable variable label placement for allowed text overlap

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -3,6 +3,7 @@
 Mapbox welcomes participation and contributions from everyone.  If you'd like to do so please see the [`Contributing Guide`](https://github.com/mapbox/mapbox-gl-native/blob/master/CONTRIBUTING.md) first to get started.
 
 ## master
+- Enable variable label placement when `text-allow-overlap` property is set to true [#15354](https://github.com/mapbox/mapbox-gl-native/pull/15354).
 - Introduce `text-writing-mode` layout property for symbol layer [#14932](https://github.com/mapbox/mapbox-gl-native/pull/14932). The `text-writing-mode` layout property allows control over symbol's preferred writing mode. The new property value is an array, whose values are enumeration values from a ( `horizontal` | `vertical` ) set.
 
 ### Features

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ### Styles and rendering
 
+* Enable variable label placement when `text-allow-overlap` property is set to true. ([#15354](https://github.com/mapbox/mapbox-gl-native/pull/15354))
 * Introduce `text-writing-mode` layout property for symbol layer ([#14932](https://github.com/mapbox/mapbox-gl-native/pull/14932)). The `text-writing-mode` layout property allows control over symbol's preferred writing mode. The new property value is an array, whose values are enumeration values from a ( `horizontal` | `vertical` ) set.
 
 ## 5.3.0

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -274,7 +274,11 @@ void Placement::placeBucket(
                     const float height = textBox.y2 - textBox.y1;
                     const float textBoxScale = symbolInstance.textBoxScale;
                     std::pair<bool, bool> placedFeature = {false, false};
-                    for (auto anchor : variableTextAnchors) {
+                    const size_t anchorsSize = variableTextAnchors.size();
+                    const size_t placementAttempts = textAllowOverlap ? anchorsSize * 2 : anchorsSize;
+                    for (size_t i = 0u; i < placementAttempts; ++i) {
+                        auto anchor = variableTextAnchors[i % anchorsSize];
+                        const bool allowOverlap = (i >= anchorsSize);
                         Point<float> shift = calculateVariableLayoutOffset(anchor, width, height, symbolInstance.radialTextOffset, textBoxScale);
                         if (rotateWithMap) {
                             float angle = pitchWithMap ? state.getBearing() : -state.getBearing();
@@ -285,7 +289,7 @@ void Placement::placeBucket(
                         placedFeature = collisionIndex.placeFeature(collisionFeature, shift,
                                                                     posMatrix, mat4(), pixelRatio,
                                                                     placedSymbol, scale, fontSize,
-                                                                    layout.get<style::TextAllowOverlap>(),
+                                                                    allowOverlap,
                                                                     pitchWithMap,
                                                                     params.showCollisionBoxes, avoidEdges, collisionGroup.second, textBoxes);
                         if (placedFeature.first) {

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -584,15 +584,13 @@ bool Placement::updateBucketDynamicVertices(SymbolBucket& bucket, const Transfor
                 if (pitchWithMap) {
                     shiftedAnchor = project(Point<float>(tileAnchor.x + shift.x, tileAnchor.y + shift.y),
                                             labelPlaneMatrix).first;
+                } else if (rotateWithMap) {
+                    auto rotated = util::rotate(shift, -state.getPitch());
+                    shiftedAnchor = Point<float>(projectedAnchor.first.x + rotated.x,
+                                                projectedAnchor.first.y + rotated.y);
                 } else {
-                    if (rotateWithMap) {
-                        auto rotated = util::rotate(shift, -state.getPitch());
-                        shiftedAnchor = Point<float>(projectedAnchor.first.x + rotated.x,
-                                                    projectedAnchor.first.y + rotated.y);
-                    } else {
-                        shiftedAnchor = Point<float>(projectedAnchor.first.x + shift.x,
-                                                    projectedAnchor.first.y + shift.y);
-                    }
+                    shiftedAnchor = Point<float>(projectedAnchor.first.x + shift.x,
+                                                 projectedAnchor.first.y + shift.y);
                 }
 
                 for (std::size_t i = 0; i < symbol.glyphOffsets.size(); ++i) {
@@ -806,7 +804,7 @@ const style::TextJustifyType justifyTypes[] = {style::TextJustifyType::Right, st
 
 }  // namespace
 
-void Placement::markUsedJustification(SymbolBucket& bucket, style::TextVariableAnchorType placedAnchor, SymbolInstance& symbolInstance, style::TextWritingModeType orientation) {
+void Placement::markUsedJustification(SymbolBucket& bucket, style::TextVariableAnchorType placedAnchor, const SymbolInstance& symbolInstance, style::TextWritingModeType orientation) {
     style::TextJustifyType anchorJustify = getAnchorJustification(placedAnchor);
     assert(anchorJustify != style::TextJustifyType::Auto);
     const optional<size_t>& autoIndex = justificationToIndex(anchorJustify, symbolInstance, orientation);
@@ -826,7 +824,7 @@ void Placement::markUsedJustification(SymbolBucket& bucket, style::TextVariableA
     }
 }
 
-void Placement::markUsedOrientation(SymbolBucket& bucket, style::TextWritingModeType orientation, SymbolInstance& symbolInstance) {
+void Placement::markUsedOrientation(SymbolBucket& bucket, style::TextWritingModeType orientation, const SymbolInstance& symbolInstance) {
     auto horizontal = orientation == style::TextWritingModeType::Horizontal ?
                                      optional<style::TextWritingModeType>(orientation) : nullopt;
     auto vertical = orientation == style::TextWritingModeType::Vertical ?

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -123,8 +123,8 @@ private:
     // Returns `true` if bucket vertices were updated; returns `false` otherwise.
     bool updateBucketDynamicVertices(SymbolBucket&, const TransformState&, const RenderTile& tile) const;
     void updateBucketOpacities(SymbolBucket&, const TransformState&, std::set<uint32_t>&);
-    void markUsedJustification(SymbolBucket&, style::TextVariableAnchorType, SymbolInstance&, style::TextWritingModeType orientation);
-    void markUsedOrientation(SymbolBucket&, style::TextWritingModeType, SymbolInstance&);
+    void markUsedJustification(SymbolBucket&, style::TextVariableAnchorType, const SymbolInstance&, style::TextWritingModeType orientation);
+    void markUsedOrientation(SymbolBucket&, style::TextWritingModeType, const SymbolInstance&);
 
     CollisionIndex collisionIndex;
 


### PR DESCRIPTION
The engine is trying to place the text first, and allows collision only if there is no position without a collision.
![text_overlap](https://user-images.githubusercontent.com/998253/62860003-8e388400-bd07-11e9-9727-099364aa837f.gif)

Fixes https://github.com/mapbox/mapbox-gl-native/issues/15357