### PR TITLE
[build] Look further back for branch merge base

### DIFF
--- a/scripts/environment.js
+++ b/scripts/environment.js
@@ -23,7 +23,7 @@ if (pr) {
     });
 } else {
     const head = process.env['CIRCLE_SHA1'];
-    for (const sha of execSync(`git rev-list --max-count=10 ${head}`).toString().trim().split('\n')) {
+    for (const sha of execSync(`git rev-list --max-count=500 ${head}`).toString().trim().split('\n')) {
         const base = execSync(`git branch -r --contains ${sha} origin/master origin/release-*`).toString().split('\n')[0].trim().replace(/^origin\//, '');
         if (base) {
             const mergeBase = execSync(`git merge-base origin/${base} ${head}`).toString().trim();


### PR DESCRIPTION
This fixes [a CI failure](https://circleci.com/gh/mapbox/mapbox-gl-native/314620) when a branch (without a PR) was built that had more than 10 commits between its `head` and merge-base. Performance-wise, this may add a few hundred milliseconds in the worst case... but it’ll succeed.

/cc @julianrex 