### PR TITLE
[android] Test app tweaks from 8.3.0-alpha.2 QA

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
@@ -25,7 +25,6 @@ import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.layers.Layer;
 import com.mapbox.mapboxsdk.style.layers.Property;
 import com.mapbox.mapboxsdk.testapp.R;
-import com.mapbox.mapboxsdk.testapp.utils.IdleZoomListener;
 
 import java.util.List;
 import java.util.Locale;
@@ -41,9 +40,9 @@ public class DebugModeActivity extends AppCompatActivity implements OnMapReadyCa
 
   private MapView mapView;
   private MapboxMap mapboxMap;
+  private MapboxMap.OnCameraMoveListener cameraMoveListener;
   private ActionBarDrawerToggle actionBarDrawerToggle;
   private int currentStyleIndex;
-  private IdleZoomListener idleZoomListener;
   private boolean isReportFps = true;
 
   private static final String[] STYLES = new String[] {
@@ -152,7 +151,13 @@ public class DebugModeActivity extends AppCompatActivity implements OnMapReadyCa
 
   private void setupZoomView() {
     final TextView textView = findViewById(R.id.textZoom);
-    mapboxMap.addOnCameraIdleListener(idleZoomListener = new IdleZoomListener(mapboxMap, textView));
+    mapboxMap.addOnCameraMoveListener(cameraMoveListener = new MapboxMap.OnCameraMoveListener() {
+      @Override
+      public void onCameraMove() {
+        textView.setText(String.format(DebugModeActivity.this.getString(
+          R.string.debug_zoom), mapboxMap.getCameraPosition().zoom));
+      }
+    });
   }
 
   private void setupDebugChangeView() {
@@ -233,8 +238,8 @@ public class DebugModeActivity extends AppCompatActivity implements OnMapReadyCa
   @Override
   protected void onDestroy() {
     super.onDestroy();
-    if (mapboxMap != null && idleZoomListener != null) {
-      mapboxMap.removeOnCameraIdleListener(idleZoomListener);
+    if (mapboxMap != null) {
+      mapboxMap.removeOnCameraMoveListener(cameraMoveListener);
     }
     mapView.onDestroy();
   }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_backstack_fragment.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_backstack_fragment.xml
@@ -9,6 +9,7 @@
 
     <Button android:layout_width="match_parent"
             android:layout_height="58dp"
+            android:layout_marginTop="64dp"
             android:id="@+id/button"
             android:contentDescription="btn_change_fragment"
             android:text="Replace with empty fragment"/>


### PR DESCRIPTION
This pr makes two small tweaks to the Android test app:

1. The zoom level `TextView` in `DebugModeActivity.java` is now updated as the camera moves, rather than only when it stops.

2. Text was being blocked by the button in the fragment backstack example.