### PR TITLE
[android] Updating HttpRequestUrl to separate offline requests from Maps SKU

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -12,6 +12,9 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
  - Allow loading of a map without a Style URI or Style JSON [#15293](https://github.com/mapbox/mapbox-gl-native/pull/15293)
  - Fixed an issue where animated camera transitions zoomed in or out too dramatically [#15281](https://github.com/mapbox/mapbox-gl-native/pull/15281)
 
+## 8.3.0
+This release changes how offline tile requests are billed — they are now billed on a pay-as-you-go basis and all developers are able raise the offline tile limit for their users. Offline requests were previously exempt from monthly active user (MAU) billing and increasing the offline per-user tile limit to more than 6,000 tiles required the purchase of an enterprise license. By upgrading to this release, you are opting into the changes outlined in [this blog post](https://blog.mapbox.com/offline-maps-for-all-bb0fc51827be) and [#15380](https://github.com/mapbox/mapbox-gl-native/pull/15380).
+
 ## 8.3.0-alpha.2 - August 7, 2019
 [Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.3.0-alpha.1...android-v8.3.0-alpha.2) since [Mapbox Maps SDK for Android v8.3.0-alpha.1](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.3.0-alpha.1):
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HttpRequestUrl.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HttpRequestUrl.java
@@ -10,7 +10,10 @@ public class HttpRequestUrl {
   }
 
   /**
-   * Adapts a resource request url based on the host and query size.
+   * Adapts a resource request url based on the host, query size, and offline requirement.
+   * The Maps SDK SKU token is not included with offline tile requests because offline requests
+   * are counted as billable Vector Tile API requests. The offline tile requests are considered
+   * raster Tile API requests if satellite imagery is being fetched.
    *
    * @param host        the host used as endpoint
    * @param resourceUrl the resource to download
@@ -25,10 +28,10 @@ public class HttpRequestUrl {
       } else {
         resourceUrl = resourceUrl + "&";
       }
-      resourceUrl = resourceUrl + "sku=" + Mapbox.getSkuToken();
-
       if (offline) {
-        resourceUrl = resourceUrl + "&offline=true";
+        resourceUrl = resourceUrl + "offline=true";
+      } else {
+        resourceUrl = resourceUrl + "sku=" + Mapbox.getSkuToken();
       }
     }
     return resourceUrl;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HttpRequestUrl.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HttpRequestUrl.java
@@ -11,9 +11,9 @@ public class HttpRequestUrl {
 
   /**
    * Adapts a resource request url based on the host, query size, and offline requirement.
-   * The Maps SDK SKU token is not included with offline tile requests because offline requests
-   * are counted as billable Vector Tile API requests. The offline tile requests are considered
-   * raster Tile API requests if satellite imagery is being fetched.
+   * Mapbox resources downloaded for offline use are subject to separate Vector Tile and
+   * Raster Tile API pricing and are not included in the Maps SDK’s “unlimited” requests.
+   * See <a href="https://www.mapbox.com/pricing">our pricing page</a> for more information.
    *
    * @param host        the host used as endpoint
    * @param resourceUrl the resource to download
@@ -28,6 +28,7 @@ public class HttpRequestUrl {
       } else {
         resourceUrl = resourceUrl + "&";
       }
+      // Only add SKU token to requests not tagged as "offline" usage.
       if (offline) {
         resourceUrl = resourceUrl + "offline=true";
       } else {

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/module/http/HttpRequestUrlTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/module/http/HttpRequestUrlTest.kt
@@ -20,14 +20,14 @@ class HttpRequestUrlTest {
 
   @Test
   fun testOfflineFlagMapboxCom() {
-    val expected = "http://mapbox.com/path/of/no/return.pbf?sku=foobar&offline=true"
+    val expected = "http://mapbox.com/path/of/no/return.pbf?offline=true"
     val actual = HttpRequestUrl.buildResourceUrl("mapbox.com", "http://mapbox.com/path/of/no/return.pbf", 0, true)
     assertEquals(expected, actual)
   }
 
   @Test
   fun testOfflineFlagMapboxCn() {
-    val expected = "http://mapbox.cn/path/of/no/return.pbf?sku=foobar&offline=true"
+    val expected = "http://mapbox.cn/path/of/no/return.pbf?offline=true"
     val actual = HttpRequestUrl.buildResourceUrl("mapbox.cn", "http://mapbox.cn/path/of/no/return.pbf", 0, true)
     assertEquals(expected, actual)
   }


### PR DESCRIPTION
This pr separates the Maps SDK SKU from offline tile requesting. If offline is `true`, `offline=true` will be appended to the request URL. If `false`, the SKU token is appended instead.

This pr is needed because offline requests are counted as billable Vector Tile API requests. They're Raster Tile API requests if satellite imagery is being fetched. More documentation about this, to come soon.