### PR TITLE
[core] Fix issues for use-cases when icon-text-fit is combined with text-variable-anchor

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
  - Fixed use of objects after moving, potentially causing crashes. [#15408](https://github.com/mapbox/mapbox-gl-native/pull/1540)
  - Fixed a possible crash that could be caused by invoking the wrong layer implementation casting function [#15398](https://github.com/mapbox/mapbox-gl-native/pull/15398).
  - Font lookup on pre lollipop devices failed, provide default font list instead [#15410](https://github.com/mapbox/mapbox-gl-native/pull/15410).
+ - Fixed rendering and collision detection issues with using `text-variable-anchor` and `icon-text-fit` properties on the same layer [#15367](https://github.com/mapbox/mapbox-gl-native/pull/15367).
 
 ## 8.3.0-alpha.3 - August 15, 2019
 [Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.3.0-alpha.2...android-v8.3.0-alpha.3) since [Mapbox Maps SDK for Android v8.3.0-alpha.2](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.3.0-alpha.2):

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## master
+
+### Styles and rendering
+* Fixed rendering and collision detection issues with using `text-variable-anchor` and `icon-text-fit` properties on the same layer. ([#15367](https://github.com/mapbox/mapbox-gl-native/pull/15367))
+
 ## 5.3.0
 
 ### Styles and rendering

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fixed rendering layers after fill-extrusion regression caused by optimization of fill-extrusion rendering. ([#15065](https://github.com/mapbox/mapbox-gl-native/pull/15065))
 * `MGLLoggingLevel` has been updated for better matching core log levels. Now can use `[MGLLoggingConfiguration sharedConfiguration].loggingLevel` to filter logs from core . [#15120](https://github.com/mapbox/mapbox-gl-native/pull/15120)
 * Fixed an issue where animated camera transitions zoomed in or out too dramatically. [#15281](https://github.com/mapbox/mapbox-gl-native/pull/15281)
+* Fixed rendering and collision detection issues with using `text-variable-anchor` and `icon-text-fit` properties on the same layer. ([#15367](https://github.com/mapbox/mapbox-gl-native/pull/15367))
 
 ### Styles and rendering
 

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,5 +1,6 @@
 # master
 * Introduce `text-writing-mode` layout property for symbol layer ([#14932](https://github.com/mapbox/mapbox-gl-native/pull/14932)). The `text-writing-mode` layout property allows control over symbol's preferred writing mode. The new property value is an array, whose values are enumeration values from a ( `horizontal` | `vertical` ) set.
+* Fixed rendering and collision detection issues with using `text-variable-anchor` and `icon-text-fit` properties on the same layer ([#15367](https://github.com/mapbox/mapbox-gl-native/pull/15367)).
 
 # 4.2.0
 - Add an option to set whether or not an image should be treated as a SDF ([#15054](https://github.com/mapbox/mapbox-gl-native/issues/15054))

--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -100,17 +100,5 @@
   "query-tests/fill-extrusion/sort-rotated": "https://github.com/mapbox/mapbox-gl-native/issues/13139",
   "query-tests/fill-extrusion/sort": "https://github.com/mapbox/mapbox-gl-native/issues/13139",
   "query-tests/fill-extrusion/top-in": "https://github.com/mapbox/mapbox-gl-native/issues/13139",
-  "query-tests/regressions/mapbox-gl-js#7883": "https://github.com/mapbox/mapbox-gl-native/issues/14585",
-  "render-tests/icon-text-fit/both-padding": "https://github.com/mapbox/mapbox-gl-native/issues/15346",
-  "render-tests/icon-text-fit/both": "https://github.com/mapbox/mapbox-gl-native/issues/15346",
-  "render-tests/icon-text-fit/height-padding": "https://github.com/mapbox/mapbox-gl-native/issues/15346",
-  "render-tests/icon-text-fit/height": "https://github.com/mapbox/mapbox-gl-native/issues/15346",
-  "render-tests/icon-text-fit/placement-line": "https://github.com/mapbox/mapbox-gl-native/issues/15346",
-  "render-tests/icon-text-fit/width-padding": "https://github.com/mapbox/mapbox-gl-native/issues/15346",
-  "render-tests/icon-text-fit/width": "https://github.com/mapbox/mapbox-gl-native/issues/15346",
-  "render-tests/regressions/mapbox-gl-js#5631": "https://github.com/mapbox/mapbox-gl-native/issues/15346",
-  "render-tests/text-variable-anchor/all-anchors-icon-text-fit": "https://github.com/mapbox/mapbox-gl-native/issues/15346",
-  "render-tests/text-variable-anchor/icon-text-fit-collision-box": "https://github.com/mapbox/mapbox-gl-native/issues/15346",
-  "render-tests/text-writing-mode/point_label/cjk-variable-anchors-vertical-horizontal-mode-icon-text-fit": "https://github.com/mapbox/mapbox-gl-native/issues/15346",
-  "render-tests/text-writing-mode/point_label/mixed-multiline-vertical-horizontal-mode-icon-text-fit": "https://github.com/mapbox/mapbox-gl-native/issues/15346"
+  "query-tests/regressions/mapbox-gl-js#7883": "https://github.com/mapbox/mapbox-gl-native/issues/14585"
 }

--- a/src/mbgl/layout/symbol_instance.hpp
+++ b/src/mbgl/layout/symbol_instance.hpp
@@ -25,8 +25,8 @@ struct SymbolInstanceSharedData {
     SymbolInstanceSharedData(GeometryCoordinates line,
                             const ShapedTextOrientations& shapedTextOrientations,
                             const optional<PositionedIcon>& shapedIcon,
+                            const optional<PositionedIcon>& verticallyShapedIcon,
                             const style::SymbolLayoutProperties::Evaluated& layout,
-                            const float layoutTextSize,
                             const style::SymbolPlacementType textPlacement,
                             const std::array<float, 2>& textOffset,
                             const GlyphPositions& positions,
@@ -39,6 +39,7 @@ struct SymbolInstanceSharedData {
     SymbolQuads leftJustifiedGlyphQuads;
     SymbolQuads verticalGlyphQuads;
     optional<SymbolQuad> iconQuad;
+    optional<SymbolQuad> verticalIconQuad;
 };
 
 class SymbolInstance {
@@ -47,6 +48,7 @@ public:
                    std::shared_ptr<SymbolInstanceSharedData> sharedData,
                    const ShapedTextOrientations& shapedTextOrientations,
                    const optional<PositionedIcon>& shapedIcon,
+                   const optional<PositionedIcon>& verticallyShapedIcon,
                    const float textBoxScale,
                    const float textPadding,
                    const style::SymbolPlacementType textPlacement,
@@ -71,6 +73,7 @@ public:
     const SymbolQuads& centerJustifiedGlyphQuads() const;
     const SymbolQuads& verticalGlyphQuads() const;
     const optional<SymbolQuad>& iconQuad() const;
+    const optional<SymbolQuad>& verticalIconQuad() const;
     void releaseSharedData();
 
 private:
@@ -89,6 +92,7 @@ public:
     CollisionFeature textCollisionFeature;
     CollisionFeature iconCollisionFeature;
     optional<CollisionFeature> verticalTextCollisionFeature = nullopt;
+    optional<CollisionFeature> verticalIconCollisionFeature = nullopt;
     WritingModeType writingModes;
     std::size_t layoutFeatureIndex; // Index into the set of features included at layout time
     std::size_t dataFeatureIndex;   // Index into the underlying tile data feature set
@@ -101,6 +105,7 @@ public:
     optional<size_t> placedLeftTextIndex;
     optional<size_t> placedVerticalTextIndex;
     optional<size_t> placedIconIndex;
+    optional<size_t> placedVerticalIconIndex;
     float textBoxScale;
     float radialTextOffset;
     bool singleLine;

--- a/src/mbgl/layout/symbol_layout.hpp
+++ b/src/mbgl/layout/symbol_layout.hpp
@@ -51,7 +51,7 @@ private:
     void addFeature(const size_t,
                     const SymbolFeature&,
                     const ShapedTextOrientations& shapedTextOrientations,
-                    const optional<PositionedIcon>& shapedIcon,
+                    optional<PositionedIcon> shapedIcon,
                     const GlyphPositions&,
                     Point<float> textOffset);
 

--- a/src/mbgl/programs/symbol_program.cpp
+++ b/src/mbgl/programs/symbol_program.cpp
@@ -67,7 +67,7 @@ Values makeValues(const bool isText,
     const bool rotateInShader = rotateWithMap && !pitchWithMap && !alongLine;
 
     mat4 labelPlaneMatrix;
-    if (alongLine || (isText && hasVariablePacement)) {
+    if (alongLine || hasVariablePacement) {
         // For labels that follow lines the first part of the projection is handled on the cpu.
         // Pass an identity matrix because no transformation needs to be done in the vertex shader.
         matrix::identity(labelPlaneMatrix);

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -228,6 +228,10 @@ void SymbolBucket::sortFeatures(const float angle) {
         if (symbolInstance.placedIconIndex) {
             addPlacedSymbol(icon.triangles, icon.placedSymbols[*symbolInstance.placedIconIndex]);
         }
+
+        if (symbolInstance.placedVerticalIconIndex) {
+            addPlacedSymbol(icon.triangles, icon.placedSymbols[*symbolInstance.placedVerticalIconIndex]);
+        }
     }
 }
 

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -21,9 +21,9 @@ class CrossTileSymbolLayerIndex;
 class PlacedSymbol {
 public:
     PlacedSymbol(Point<float> anchorPoint_, uint16_t segment_, float lowerSize_, float upperSize_,
-            std::array<float, 2> lineOffset_, WritingModeType writingModes_, GeometryCoordinates line_, std::vector<float> tileDistances_) :
+            std::array<float, 2> lineOffset_, WritingModeType writingModes_, GeometryCoordinates line_, std::vector<float> tileDistances_, optional<size_t> placedIconIndex_ = nullopt) :
         anchorPoint(anchorPoint_), segment(segment_), lowerSize(lowerSize_), upperSize(upperSize_),
-        lineOffset(lineOffset_), writingModes(writingModes_), line(std::move(line_)), tileDistances(std::move(tileDistances_)), hidden(false), vertexStartIndex(0)
+        lineOffset(lineOffset_), writingModes(writingModes_), line(std::move(line_)), tileDistances(std::move(tileDistances_)), hidden(false), vertexStartIndex(0), placedIconIndex(std::move(placedIconIndex_))
     {
     }
     Point<float> anchorPoint;
@@ -43,6 +43,9 @@ public:
     // placement for orientation variants.
     optional<style::TextWritingModeType> placedOrientation;
     float angle = 0;
+
+    // Reference to placed icon, only applicable for text symbols.
+    optional<size_t> placedIconIndex;
 };
 
 class SymbolBucket final : public Bucket {

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -131,11 +131,12 @@ void drawIcon(const DrawFn& draw,
                                                 : gfx::TextureFilterType::Nearest };
 
     const Size& iconSize = tile.getIconAtlasTexture().size;
+    const bool variablePlacedIcon = bucket.hasVariablePlacement && layout.get<IconTextFit>() != IconTextFitType::None;
 
     if (bucket.sdfIcons) {
         if (values.hasHalo) {
             draw(parameters.programs.getSymbolLayerPrograms().symbolIconSDF,
-                SymbolSDFIconProgram::layoutUniformValues(false, false, values, iconSize, parameters.pixelsToGLUnits, parameters.pixelRatio, alongLine, tile, parameters.state, parameters.symbolFadeChange, SymbolSDFPart::Halo),
+                SymbolSDFIconProgram::layoutUniformValues(false, variablePlacedIcon, values, iconSize, parameters.pixelsToGLUnits, parameters.pixelRatio, alongLine, tile, parameters.state, parameters.symbolFadeChange, SymbolSDFPart::Halo),
                 bucket.icon,
                 iconSegments,
                 bucket.iconSizeBinder,
@@ -149,7 +150,7 @@ void drawIcon(const DrawFn& draw,
 
         if (values.hasFill) {
             draw(parameters.programs.getSymbolLayerPrograms().symbolIconSDF,
-                SymbolSDFIconProgram::layoutUniformValues(false, false, values, iconSize, parameters.pixelsToGLUnits, parameters.pixelRatio, alongLine, tile, parameters.state, parameters.symbolFadeChange, SymbolSDFPart::Fill),
+                SymbolSDFIconProgram::layoutUniformValues(false, variablePlacedIcon, values, iconSize, parameters.pixelsToGLUnits, parameters.pixelRatio, alongLine, tile, parameters.state, parameters.symbolFadeChange, SymbolSDFPart::Fill),
                 bucket.icon,
                 iconSegments,
                 bucket.iconSizeBinder,
@@ -162,7 +163,7 @@ void drawIcon(const DrawFn& draw,
         }
     } else {
         draw(parameters.programs.getSymbolLayerPrograms().symbolIcon,
-            SymbolIconProgram::layoutUniformValues(false, false, values, iconSize, parameters.pixelsToGLUnits, alongLine, tile, parameters.state, parameters.symbolFadeChange),
+            SymbolIconProgram::layoutUniformValues(false, variablePlacedIcon, values, iconSize, parameters.pixelsToGLUnits, alongLine, tile, parameters.state, parameters.symbolFadeChange),
             bucket.icon,
             iconSegments,
             bucket.iconSizeBinder,

--- a/src/mbgl/text/quads.cpp
+++ b/src/mbgl/text/quads.cpp
@@ -14,9 +14,7 @@ namespace mbgl {
 using namespace style;
 
 SymbolQuad getIconQuad(const PositionedIcon& shapedIcon,
-                       const SymbolLayoutProperties::Evaluated& layout,
-                       const float layoutTextSize,
-                       const Shaping& shapedText) {
+                       WritingModeType writingMode) {
     const ImagePosition& image = shapedIcon.image();
 
     // If you have a 10px icon that isn't perfectly aligned to the pixel grid it will cover 11 actual
@@ -28,43 +26,11 @@ SymbolQuad getIconQuad(const PositionedIcon& shapedIcon,
     float left = shapedIcon.left() - border / image.pixelRatio;
     float bottom = shapedIcon.bottom() + border / image.pixelRatio;
     float right = shapedIcon.right() + border / image.pixelRatio;
-    Point<float> tl;
-    Point<float> tr;
-    Point<float> br;
-    Point<float> bl;
 
-    if (layout.get<IconTextFit>() != IconTextFitType::None && shapedText) {
-        auto iconWidth = right - left;
-        auto iconHeight = bottom - top;
-        auto size = layoutTextSize / 24.0f;
-        auto textLeft = shapedText.left * size;
-        auto textRight = shapedText.right * size;
-        auto textTop = shapedText.top * size;
-        auto textBottom = shapedText.bottom * size;
-        auto textWidth = textRight - textLeft;
-        auto textHeight = textBottom - textTop;
-        auto padT = layout.get<IconTextFitPadding>()[0];
-        auto padR = layout.get<IconTextFitPadding>()[1];
-        auto padB = layout.get<IconTextFitPadding>()[2];
-        auto padL = layout.get<IconTextFitPadding>()[3];
-        auto offsetY = layout.get<IconTextFit>() == IconTextFitType::Width ? (textHeight - iconHeight) * 0.5 : 0;
-        auto offsetX = layout.get<IconTextFit>() == IconTextFitType::Height ? (textWidth - iconWidth) * 0.5 : 0;
-        auto width = layout.get<IconTextFit>() == IconTextFitType::Width || layout.get<IconTextFit>() == IconTextFitType::Both ? textWidth : iconWidth;
-        auto height = layout.get<IconTextFit>() == IconTextFitType::Height || layout.get<IconTextFit>() == IconTextFitType::Both ? textHeight : iconHeight;
-        left = textLeft + offsetX - padL;
-        top = textTop + offsetY - padT;
-        right = textLeft + offsetX + padR + width;
-        bottom = textTop + offsetY + padB + height;
-        tl = {left, top};
-        tr = {right, top};
-        br = {right, bottom};
-        bl = {left, bottom};
-    } else {
-        tl = {left, top};
-        tr = {right, top};
-        br = {right, bottom};
-        bl = {left, bottom};
-    }
+    Point<float> tl{left, top};
+    Point<float> tr{right, top};
+    Point<float> br{right, bottom};
+    Point<float> bl{left, bottom};
 
     const float angle = shapedIcon.angle();
 
@@ -88,7 +54,7 @@ SymbolQuad getIconQuad(const PositionedIcon& shapedIcon,
         static_cast<uint16_t>(image.textureRect.h + border * 2)
     };
 
-    return SymbolQuad { tl, tr, bl, br, textureRect, shapedText.writingMode, { 0.0f, 0.0f } };
+    return SymbolQuad { tl, tr, bl, br, textureRect, writingMode, { 0.0f, 0.0f } };
 }
 
 SymbolQuads getGlyphQuads(const Shaping& shapedText,

--- a/src/mbgl/text/quads.hpp
+++ b/src/mbgl/text/quads.hpp
@@ -44,9 +44,7 @@ public:
 using SymbolQuads = std::vector<SymbolQuad>;
 
 SymbolQuad getIconQuad(const PositionedIcon& shapedIcon,
-                       const style::SymbolLayoutProperties::Evaluated&,
-                       const float layoutTextSize,
-                       const Shaping& shapedText);
+                       WritingModeType writingMode);
 
 SymbolQuads getGlyphQuads(const Shaping& shapedText,
                           const std::array<float, 2> textOffset,

--- a/src/mbgl/text/shaping.hpp
+++ b/src/mbgl/text/shaping.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/text/tagged_string.hpp>
 #include <mbgl/renderer/image_atlas.hpp>
 #include <mbgl/style/types.hpp>
+#include <mbgl/style/layers/symbol_layer_properties.hpp>
 
 namespace mbgl {
 
@@ -51,6 +52,12 @@ public:
                                     const std::array<float, 2>& iconOffset,
                                     style::SymbolAnchorType iconAnchor,
                                     const float iconRotation);
+
+    // Updates shaped icon's bounds based on shaped text's bounds and provided
+    // layout properties.
+    void fitIconToText(const style::SymbolLayoutProperties::Evaluated& layout,
+                       const Shaping& shapedText,
+                       float layoutTextSize);
 
     const ImagePosition& image() const { return _image; }
     float top() const { return _top; }

--- a/test/text/cross_tile_symbol_index.test.cpp
+++ b/test/text/cross_tile_symbol_index.test.cpp
@@ -16,9 +16,9 @@ SymbolInstance makeSymbolInstance(float x, float y, std::u16string key) {
     style::SymbolPlacementType placementType = style::SymbolPlacementType::Point;
 
     auto sharedData = std::make_shared<SymbolInstanceSharedData>(std::move(line),
-                                        shaping, nullopt, layout_, 0.0f, placementType,
+                                        shaping, nullopt, nullopt, layout_, placementType,
                                         textOffset, positions, false);
-    return SymbolInstance(anchor, std::move(sharedData), shaping, nullopt, 0, 0, placementType, textOffset, 0, 0, iconOffset, subfeature, 0, 0, key, 0.0f, 0.0f, 0.0f, 0.0f, false);
+    return SymbolInstance(anchor, std::move(sharedData), shaping, nullopt, nullopt, 0, 0, placementType, textOffset, 0, 0, iconOffset, subfeature, 0, 0, key, 0.0f, 0.0f, 0.0f, 0.0f, false);
 }
 
 

--- a/test/text/quads.test.cpp
+++ b/test/text/quads.test.cpp
@@ -20,10 +20,9 @@ TEST(getIconQuads, normal) {
     auto shapedIcon = PositionedIcon::shapeIcon(image, {{ -6.5f, -4.5f }}, SymbolAnchorType::Center, 0);
 
     GeometryCoordinates line;
-    Shaping shapedText;
 
     SymbolQuad quad =
-        getIconQuad(shapedIcon, layout, 16.0f, shapedText);
+        getIconQuad(shapedIcon, WritingModeType::Horizontal);
 
     EXPECT_EQ(quad.tl.x, -14);
     EXPECT_EQ(quad.tl.y, -10);
@@ -42,8 +41,6 @@ TEST(getIconQuads, style) {
         style::Image::Impl("test", PremultipliedImage({1,1}), 1.0)
     };
 
-    auto shapedIcon = PositionedIcon::shapeIcon(image, {{ -9.5f, -9.5f }}, SymbolAnchorType::Center, 0);
-
     GeometryCoordinates line;
     Shaping shapedText;
     shapedText.top = -10.0f;
@@ -54,9 +51,10 @@ TEST(getIconQuads, style) {
 
     // none
     {
+        auto shapedIcon = PositionedIcon::shapeIcon(image, {{ -9.5f, -9.5f }}, SymbolAnchorType::Center, 0);
         SymbolLayoutProperties::Evaluated layout;
         SymbolQuad quad =
-            getIconQuad(shapedIcon, layout, 12.0f, shapedText);
+            getIconQuad(shapedIcon, WritingModeType::Horizontal);
 
         EXPECT_EQ(quad.tl.x, -19.5);
         EXPECT_EQ(quad.tl.y, -19.5);
@@ -73,16 +71,18 @@ TEST(getIconQuads, style) {
         SymbolLayoutProperties::Evaluated layout;
         layout.get<TextSize>() = 24.0f;
         layout.get<IconTextFit>() = IconTextFitType::Width;
+        auto shapedIcon = PositionedIcon::shapeIcon(image, {{ -9.5f, -9.5f }}, SymbolAnchorType::Center, 0);
+        shapedIcon.fitIconToText(layout, shapedText, 24.0f);
         SymbolQuad quad =
-            getIconQuad(shapedIcon, layout, 24.0f, shapedText);
+            getIconQuad(shapedIcon, WritingModeType::Horizontal);
 
-        EXPECT_EQ(quad.tl.x, -60);
+        EXPECT_EQ(quad.tl.x, -61);
         EXPECT_EQ(quad.tl.y, 0);
-        EXPECT_EQ(quad.tr.x, 20);
+        EXPECT_EQ(quad.tr.x, 21);
         EXPECT_EQ(quad.tr.y, 0);
-        EXPECT_EQ(quad.bl.x, -60);
+        EXPECT_EQ(quad.bl.x, -61);
         EXPECT_EQ(quad.bl.y, 20);
-        EXPECT_EQ(quad.br.x, 20);
+        EXPECT_EQ(quad.br.x, 21);
         EXPECT_EQ(quad.br.y, 20);
     }
 
@@ -91,16 +91,18 @@ TEST(getIconQuads, style) {
         SymbolLayoutProperties::Evaluated layout;
         layout.get<TextSize>() = 12.0f;
         layout.get<IconTextFit>() = IconTextFitType::Width;
+        auto shapedIcon = PositionedIcon::shapeIcon(image, {{ -9.5f, -9.5f }}, SymbolAnchorType::Center, 0);
+        shapedIcon.fitIconToText(layout, shapedText, 12.0f);
         SymbolQuad quad =
-            getIconQuad(shapedIcon, layout, 12.0f, shapedText);
+            getIconQuad(shapedIcon, WritingModeType::Horizontal);
 
-        EXPECT_EQ(quad.tl.x, -30);
+        EXPECT_EQ(quad.tl.x, -31);
         EXPECT_EQ(quad.tl.y, -5);
-        EXPECT_EQ(quad.tr.x, 10);
+        EXPECT_EQ(quad.tr.x, 11);
         EXPECT_EQ(quad.tr.y, -5);
-        EXPECT_EQ(quad.bl.x, -30);
+        EXPECT_EQ(quad.bl.x, -31);
         EXPECT_EQ(quad.bl.y, 15);
-        EXPECT_EQ(quad.br.x, 10);
+        EXPECT_EQ(quad.br.x, 11);
         EXPECT_EQ(quad.br.y, 15);
     }
 
@@ -113,16 +115,18 @@ TEST(getIconQuads, style) {
         layout.get<IconTextFitPadding>()[1] = 10.0f;
         layout.get<IconTextFitPadding>()[2] = 5.0f;
         layout.get<IconTextFitPadding>()[3] = 10.0f;
+        auto shapedIcon = PositionedIcon::shapeIcon(image, {{ -9.5f, -9.5f }}, SymbolAnchorType::Center, 0);
+        shapedIcon.fitIconToText(layout, shapedText, 12.0f);
         SymbolQuad quad =
-            getIconQuad(shapedIcon, layout, 12.0f, shapedText);
+            getIconQuad(shapedIcon, WritingModeType::Horizontal);
 
-        EXPECT_EQ(quad.tl.x, -40);
+        EXPECT_EQ(quad.tl.x, -41);
         EXPECT_EQ(quad.tl.y, -10);
-        EXPECT_EQ(quad.tr.x, 20);
+        EXPECT_EQ(quad.tr.x, 21);
         EXPECT_EQ(quad.tr.y, -10);
-        EXPECT_EQ(quad.bl.x, -40);
+        EXPECT_EQ(quad.bl.x, -41);
         EXPECT_EQ(quad.bl.y, 20);
-        EXPECT_EQ(quad.br.x, 20);
+        EXPECT_EQ(quad.br.x, 21);
         EXPECT_EQ(quad.br.y, 20);
     }
 
@@ -131,17 +135,19 @@ TEST(getIconQuads, style) {
         SymbolLayoutProperties::Evaluated layout;
         layout.get<TextSize>() = 24.0f;
         layout.get<IconTextFit>() = IconTextFitType::Height;
+        auto shapedIcon = PositionedIcon::shapeIcon(image, {{ -9.5f, -9.5f }}, SymbolAnchorType::Center, 0);
+        shapedIcon.fitIconToText(layout, shapedText, 24.0f);
         SymbolQuad quad =
-            getIconQuad(shapedIcon, layout, 24.0f, shapedText);
+            getIconQuad(shapedIcon, WritingModeType::Horizontal);
 
         EXPECT_EQ(quad.tl.x, -30);
-        EXPECT_EQ(quad.tl.y, -10);
+        EXPECT_EQ(quad.tl.y, -11);
         EXPECT_EQ(quad.tr.x, -10);
-        EXPECT_EQ(quad.tr.y, -10);
+        EXPECT_EQ(quad.tr.y, -11);
         EXPECT_EQ(quad.bl.x, -30);
-        EXPECT_EQ(quad.bl.y, 30);
+        EXPECT_EQ(quad.bl.y, 31);
         EXPECT_EQ(quad.br.x, -10);
-        EXPECT_EQ(quad.br.y, 30);
+        EXPECT_EQ(quad.br.y, 31);
     }
 
     // height x textSize
@@ -149,17 +155,19 @@ TEST(getIconQuads, style) {
         SymbolLayoutProperties::Evaluated layout;
         layout.get<TextSize>() = 12.0f;
         layout.get<IconTextFit>() = IconTextFitType::Height;
+        auto shapedIcon = PositionedIcon::shapeIcon(image, {{ -9.5f, -9.5f }}, SymbolAnchorType::Center, 0);
+        shapedIcon.fitIconToText(layout, shapedText, 12.0f);
         SymbolQuad quad =
-            getIconQuad(shapedIcon, layout, 12.0f, shapedText);
+            getIconQuad(shapedIcon, WritingModeType::Horizontal);
 
         EXPECT_EQ(quad.tl.x, -20);
-        EXPECT_EQ(quad.tl.y, -5);
+        EXPECT_EQ(quad.tl.y, -6);
         EXPECT_EQ(quad.tr.x, 0);
-        EXPECT_EQ(quad.tr.y, -5);
+        EXPECT_EQ(quad.tr.y, -6);
         EXPECT_EQ(quad.bl.x, -20);
-        EXPECT_EQ(quad.bl.y, 15);
+        EXPECT_EQ(quad.bl.y, 16);
         EXPECT_EQ(quad.br.x, 0);
-        EXPECT_EQ(quad.br.y, 15);
+        EXPECT_EQ(quad.br.y, 16);
     }
 
     // height x textSize + padding
@@ -171,17 +179,19 @@ TEST(getIconQuads, style) {
         layout.get<IconTextFitPadding>()[1] = 10.0f;
         layout.get<IconTextFitPadding>()[2] = 5.0f;
         layout.get<IconTextFitPadding>()[3] = 10.0f;
+        auto shapedIcon = PositionedIcon::shapeIcon(image, {{ -9.5f, -9.5f }}, SymbolAnchorType::Center, 0);
+        shapedIcon.fitIconToText(layout, shapedText, 12.0f);
         SymbolQuad quad =
-            getIconQuad(shapedIcon, layout, 12.0f, shapedText);
+            getIconQuad(shapedIcon, WritingModeType::Horizontal);
 
         EXPECT_EQ(quad.tl.x, -30);
-        EXPECT_EQ(quad.tl.y, -10);
+        EXPECT_EQ(quad.tl.y, -11);
         EXPECT_EQ(quad.tr.x, 10);
-        EXPECT_EQ(quad.tr.y, -10);
+        EXPECT_EQ(quad.tr.y, -11);
         EXPECT_EQ(quad.bl.x, -30);
-        EXPECT_EQ(quad.bl.y, 20);
+        EXPECT_EQ(quad.bl.y, 21);
         EXPECT_EQ(quad.br.x, 10);
-        EXPECT_EQ(quad.br.y, 20);
+        EXPECT_EQ(quad.br.y, 21);
     }
 
     // both
@@ -189,17 +199,19 @@ TEST(getIconQuads, style) {
         SymbolLayoutProperties::Evaluated layout;
         layout.get<TextSize>() = 24.0f;
         layout.get<IconTextFit>() = IconTextFitType::Both;
+        auto shapedIcon = PositionedIcon::shapeIcon(image, {{ -9.5f, -9.5f }}, SymbolAnchorType::Center, 0);
+        shapedIcon.fitIconToText(layout, shapedText, 24.0f);
         SymbolQuad quad =
-            getIconQuad(shapedIcon, layout, 24.0f, shapedText);
+            getIconQuad(shapedIcon, WritingModeType::Horizontal);
 
-        EXPECT_EQ(quad.tl.x, -60);
-        EXPECT_EQ(quad.tl.y, -10);
-        EXPECT_EQ(quad.tr.x, 20);
-        EXPECT_EQ(quad.tr.y, -10);
-        EXPECT_EQ(quad.bl.x, -60);
-        EXPECT_EQ(quad.bl.y, 30);
-        EXPECT_EQ(quad.br.x, 20);
-        EXPECT_EQ(quad.br.y, 30);
+        EXPECT_EQ(quad.tl.x, -61);
+        EXPECT_EQ(quad.tl.y, -11);
+        EXPECT_EQ(quad.tr.x, 21);
+        EXPECT_EQ(quad.tr.y, -11);
+        EXPECT_EQ(quad.bl.x, -61);
+        EXPECT_EQ(quad.bl.y, 31);
+        EXPECT_EQ(quad.br.x, 21);
+        EXPECT_EQ(quad.br.y, 31);
     }
 
     // both x textSize
@@ -207,17 +219,19 @@ TEST(getIconQuads, style) {
         SymbolLayoutProperties::Evaluated layout;
         layout.get<TextSize>() = 12.0f;
         layout.get<IconTextFit>() = IconTextFitType::Both;
+        auto shapedIcon = PositionedIcon::shapeIcon(image, {{ -9.5f, -9.5f }}, SymbolAnchorType::Center, 0);
+        shapedIcon.fitIconToText(layout, shapedText, 12.0f);
         SymbolQuad quad =
-            getIconQuad(shapedIcon, layout, 12.0f, shapedText);
+            getIconQuad(shapedIcon, WritingModeType::Horizontal);
 
-        EXPECT_EQ(quad.tl.x, -30);
-        EXPECT_EQ(quad.tl.y, -5);
-        EXPECT_EQ(quad.tr.x, 10);
-        EXPECT_EQ(quad.tr.y, -5);
-        EXPECT_EQ(quad.bl.x, -30);
-        EXPECT_EQ(quad.bl.y, 15);
-        EXPECT_EQ(quad.br.x, 10);
-        EXPECT_EQ(quad.br.y, 15);
+        EXPECT_EQ(quad.tl.x, -31);
+        EXPECT_EQ(quad.tl.y, -6);
+        EXPECT_EQ(quad.tr.x, 11);
+        EXPECT_EQ(quad.tr.y, -6);
+        EXPECT_EQ(quad.bl.x, -31);
+        EXPECT_EQ(quad.bl.y, 16);
+        EXPECT_EQ(quad.br.x, 11);
+        EXPECT_EQ(quad.br.y, 16);
     }
 
     // both x textSize + padding
@@ -229,17 +243,19 @@ TEST(getIconQuads, style) {
         layout.get<IconTextFitPadding>()[1] = 10.0f;
         layout.get<IconTextFitPadding>()[2] = 5.0f;
         layout.get<IconTextFitPadding>()[3] = 10.0f;
+        auto shapedIcon = PositionedIcon::shapeIcon(image, {{ -9.5f, -9.5f }}, SymbolAnchorType::Center, 0);
+        shapedIcon.fitIconToText(layout, shapedText, 12.0f);
         SymbolQuad quad =
-            getIconQuad(shapedIcon, layout, 12.0f, shapedText);
+            getIconQuad(shapedIcon, WritingModeType::Horizontal);
 
-        EXPECT_EQ(quad.tl.x, -40);
-        EXPECT_EQ(quad.tl.y, -10);
-        EXPECT_EQ(quad.tr.x, 20);
-        EXPECT_EQ(quad.tr.y, -10);
-        EXPECT_EQ(quad.bl.x, -40);
-        EXPECT_EQ(quad.bl.y, 20);
-        EXPECT_EQ(quad.br.x, 20);
-        EXPECT_EQ(quad.br.y, 20);
+        EXPECT_EQ(quad.tl.x, -41);
+        EXPECT_EQ(quad.tl.y, -11);
+        EXPECT_EQ(quad.tr.x, 21);
+        EXPECT_EQ(quad.tr.y, -11);
+        EXPECT_EQ(quad.bl.x, -41);
+        EXPECT_EQ(quad.bl.y, 21);
+        EXPECT_EQ(quad.br.x, 21);
+        EXPECT_EQ(quad.br.y, 21);
     }
 
     // both x textSize + padding t/r/b/l
@@ -251,17 +267,19 @@ TEST(getIconQuads, style) {
         layout.get<IconTextFitPadding>()[1] = 5.0f;
         layout.get<IconTextFitPadding>()[2] = 10.0f;
         layout.get<IconTextFitPadding>()[3] = 15.0f;
+        auto shapedIcon = PositionedIcon::shapeIcon(image, {{ -9.5f, -9.5f }}, SymbolAnchorType::Center, 0);
+        shapedIcon.fitIconToText(layout, shapedText, 12.0f);
         SymbolQuad quad =
-            getIconQuad(shapedIcon, layout, 12.0f, shapedText);
+            getIconQuad(shapedIcon, WritingModeType::Horizontal);
 
-        EXPECT_EQ(quad.tl.x, -45);
-        EXPECT_EQ(quad.tl.y, -5);
-        EXPECT_EQ(quad.tr.x, 15);
-        EXPECT_EQ(quad.tr.y, -5);
-        EXPECT_EQ(quad.bl.x, -45);
-        EXPECT_EQ(quad.bl.y, 25);
-        EXPECT_EQ(quad.br.x, 15);
-        EXPECT_EQ(quad.br.y, 25);
+        EXPECT_EQ(quad.tl.x, -46);
+        EXPECT_EQ(quad.tl.y, -6);
+        EXPECT_EQ(quad.tr.x, 16);
+        EXPECT_EQ(quad.tr.y, -6);
+        EXPECT_EQ(quad.bl.x, -46);
+        EXPECT_EQ(quad.bl.y, 26);
+        EXPECT_EQ(quad.br.x, 16);
+        EXPECT_EQ(quad.br.y, 26);
     }
 }
 


### PR DESCRIPTION
There are multiple issues related to `icon-text-fit` when it is used in combination with `text-variable-anchor` and `text-writing-mode`

- Collision feature box for an icon has wrong size
- Collision feature should be shifted together with text box
- Collision debug box for an icon should be shifted together with text
- Vertically oriented text box might be of different size, thus vertical icon might be needed

Fixes: #15346
Adresses: https://github.com/mapbox/mapbox-gl-js/issues/8583