### PR TITLE
[meta] Exempt items on milestones or in projects from stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
-exemptProjects: false
-exemptMilestones: false
+exemptProjects: true
+exemptMilestones: true
 
 staleLabel: archived
 
@@ -10,8 +10,6 @@ limitPerRun: 1
 # SEMVER-MAJOR - @tobrun
 exemptLabels:
   - SEMVER-MAJOR
-  - ios
-  - macos
 
 pulls:
   daysUntilStale: 60

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -10,6 +10,8 @@ limitPerRun: 1
 # SEMVER-MAJOR - @tobrun
 exemptLabels:
   - SEMVER-MAJOR
+  - ios
+  - macos
 
 pulls:
   daysUntilStale: 60


### PR DESCRIPTION
Stalebot automatically closes issues after six months (#13153), but this generates unnecessary noise and effort as the team continually reopens still-valid issues, so this PR exempts `ios`- and `macos`-tagged issues from such closures.

/cc @mapbox/maps-ios 