### PR TITLE
[core] Clear collision text boxes between symbol placement iterations

### DIFF
--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -172,6 +172,7 @@ void Placement::placeBucket(
             placements.emplace(symbolInstance.crossTileID, JointPlacement(false, false, false));
             return;
         }
+        textBoxes.clear();
         iconBoxes.clear();
 
         bool placeText = false;


### PR DESCRIPTION
Collision text boxes must be always cleared while symbol instances are placed.