### PR TITLE
Add back memory test to CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -559,6 +559,7 @@ qt-docs:
 test-node: node
 	npm test
 	npm run test-query
+	npm run test-memory
 	npm run test-expressions
 
 #### Android targets ###########################################################


### PR DESCRIPTION
In #5527 @tmpsantos added a memory test. But this test was removed from being run on CI in 692fe1f3f because it is not longer included in the `make test-node` target.

I'm assuming that the removal was inadvertent, so this PR re-establishes the test to run on CI.

/cc @kkaefer @mapbox/api-gl 