### PR TITLE
[core] Check type of a convertible value when constructing legacy filter

### DIFF
--- a/src/mbgl/style/conversion/filter.cpp
+++ b/src/mbgl/style/conversion/filter.cpp
@@ -195,11 +195,16 @@ ParseResult convertLegacyFilter(const Convertible& values, Error& error) {
         return {std::make_unique<Literal>(true)};
     }
 
+    if (!isArray(values) || arrayLength(values) == 0) {
+       error.message = "filter value must be a non empty array";
+       return nullopt;
+    }
+
     optional<std::string> op = toString(arrayMember(values, 0));
 
     if (!op) {
         error.message = "filter operator must be a string";
-        return {};
+        return nullopt;
     } else if (arrayLength(values) <= 1) {
         return {std::make_unique<Literal>(*op != "any")};
     } else {

--- a/test/style/filter.test.cpp
+++ b/test/style/filter.test.cpp
@@ -255,3 +255,10 @@ TEST(Filter, Internal) {
 TEST(Filter, Short) {
     filter(R"(["==", ["id"], "foo"])");
 }
+
+TEST(Filter, LegacyExpressionInvalidType) {
+    const JSValue value("string");
+    conversion::Error error;
+    optional<Filter> result = conversion::convert<Filter>(conversion::Convertible(&value), error);
+    EXPECT_FALSE(result);
+}


### PR DESCRIPTION
The `convertLegacyFilter` function did not have convertible value type check, therefore, rapidjson was asserting when value was used as an array.

Fixes: #15388