### PR TITLE
[core][test] fix leaks from sqlite usage

### DIFF
--- a/platform/default/src/mbgl/storage/sqlite3.cpp
+++ b/platform/default/src/mbgl/storage/sqlite3.cpp
@@ -125,6 +125,7 @@ mapbox::util::variant<Database, Exception> Database::tryOpen(const std::string &
     const int error = sqlite3_open_v2(filename.c_str(), &db, flags | SQLITE_OPEN_URI, nullptr);
     if (error != SQLITE_OK) {
         const auto message = sqlite3_errmsg(db);
+        sqlite3_close(db);
         return Exception { error, message };
     }
     return Database(std::make_unique<DatabaseImpl>(db));

--- a/test/src/mbgl/test/sqlite3_test_fs.cpp
+++ b/test/src/mbgl/test/sqlite3_test_fs.cpp
@@ -278,6 +278,7 @@ SQLite3TestFS::~SQLite3TestFS() {
     sqlite3_vfs* test_fs = sqlite3_vfs_find("test_fs");
     if (test_fs) {
         sqlite3_vfs_unregister(test_fs);
+        sqlite3_free((void*)test_fs);
     }
 }
 


### PR DESCRIPTION
I compiled with `-fsanitize=address,leak` and noticed two leaks when running the unit tests:

```
2: Direct leak of 176 byte(s) in 1 object(s) allocated from:
2:     #0 0x4c6cc3 in __interceptor_malloc /build/llvm-toolchain-8-F3l7P1/llvm-toolchain-8-8/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:146:3
2:     #1 0x7f945bd817d5 in sqlite3MemMalloc /src/build/../vendor/sqlite/src/sqlite3.c:22262:7
2:     #2 0x7f945bc5bb86 in mallocWithAlarm /src/build/../vendor/sqlite/src/sqlite3.c:26094:7
2:     #3 0x7f945bc35357 in sqlite3Malloc /src/build/../vendor/sqlite/src/sqlite3.c:26124:5
2:     #4 0x7f945bc35260 in sqlite3_malloc /src/build/../vendor/sqlite/src/sqlite3.c:26142:21
2:     #5 0x7f945b6687e8 in mbgl::test::SQLite3TestFS::SQLite3TestFS() /src/build/../test/src/mbgl/test/sqlite3_test_fs.cpp:250:35
2:     #6 0x7f945b7a0391 in OfflineDatabase_MergeDatabaseWithDiskFull_Test::TestBody() /src/build/../test/storage/offline_database.test.cpp:1742:25
2:     #7 0x7f945c832a0b in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /src/build/../vendor/googletest/googletest/src/gtest.cc:2402:10
2:     #8 0x7f945c81502d in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /src/build/../vendor/googletest/googletest/src/gtest.cc:2438:14
2:     #9 0x7f945c7f2aab in testing::Test::Run() /src/build/../vendor/googletest/googletest/src/gtest.cc:2474:5
2:     #10 0x7f945c7f3989 in testing::TestInfo::Run() /src/build/../vendor/googletest/googletest/src/gtest.cc:2656:11
2:     #11 0x7f945c7f4091 in testing::TestCase::Run() /src/build/../vendor/googletest/googletest/src/gtest.cc:2774:28
2:     #12 0x7f945c7fe1a2 in testing::internal::UnitTestImpl::RunAllTests() /src/build/../vendor/googletest/googletest/src/gtest.cc:4649:43
2:     #13 0x7f945c83770b in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /src/build/../vendor/googletest/googletest/src/gtest.cc:2402:10
2:     #14 0x7f945c817dbd in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /src/build/../vendor/googletest/googletest/src/gtest.cc:2438:14
2:     #15 0x7f945c7fdd16 in testing::UnitTest::Run() /src/build/../vendor/googletest/googletest/src/gtest.cc:4257:10
2:     #16 0x7f945b6765d0 in RUN_ALL_TESTS() /src/build/../vendor/googletest/googletest/include/gtest/gtest.h:2233:46
2:     #17 0x7f945b6757a9 in mbgl::runTests(int, char**) /src/build/../test/src/mbgl/test/test.cpp:24:12
2:     #18 0x4f915a in main /src/build/../platform/default/src/mbgl/test/main.cpp:19:12
2:     #19 0x7f945abdcb6a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x26b6a)
```


```
2: Direct leak of 1376 byte(s) in 2 object(s) allocated from:
2:     #0 0x4c6cc3 in __interceptor_malloc /build/llvm-toolchain-8-F3l7P1/llvm-toolchain-8-8/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:146:3
2:     #1 0x7f5517fa07d5 in sqlite3MemMalloc /src/build/../vendor/sqlite/src/sqlite3.c:22262:7
2:     #2 0x7f5517e7ab86 in mallocWithAlarm /src/build/../vendor/sqlite/src/sqlite3.c:26094:7
2:     #3 0x7f5517e54357 in sqlite3Malloc /src/build/../vendor/sqlite/src/sqlite3.c:26124:5
2:     #4 0x7f5517e5c88e in sqlite3MallocZero /src/build/../vendor/sqlite/src/sqlite3.c:26329:13
2:     #5 0x7f5517e75ae1 in openDatabase /src/build/../vendor/sqlite/src/sqlite3.c:149732:8
2:     #6 0x7f5517e765f8 in sqlite3_open_v2 /src/build/../vendor/sqlite/src/sqlite3.c:150042:10
2:     #7 0x7f551870b564 in mapbox::sqlite::Database::tryOpen(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) /src/build/../platform/default/src/mbgl/storage/sqlite3.cpp:125:23
2:     #8 0x7f551870b7b1 in mapbox::sqlite::Database::open(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) /src/build/../platform/default/src/mbgl/storage/sqlite3.cpp:134:19
2:     #9 0x7f55186cd015 in mbgl::OfflineDatabase::initialize() /src/build/../platform/default/src/mbgl/storage/offline_database.cpp:37:9
2:     #10 0x7f55186d0f52 in mbgl::OfflineDatabase::put(mbgl::Resource const&, mbgl::Response const&) /src/build/../platform/default/src/mbgl/storage/offline_database.cpp:226:9
2:     #11 0x7f5517971af8 in OfflineDatabase_CreateFail_Test::TestBody() /src/build/../test/storage/offline_database.test.cpp:133:9
```

This PR fixes both.