### PR TITLE
Remove version info in ImageManager when removing an image

### DIFF
--- a/src/mbgl/renderer/image_manager.cpp
+++ b/src/mbgl/renderer/image_manager.cpp
@@ -81,6 +81,7 @@ void ImageManager::removeImage(const std::string& id) {
         requestedImages.erase(requestedIt);
     }
     images.erase(it);
+    updatedImageVersions.erase(id);
 }
 
 const style::Image::Impl* ImageManager::getImage(const std::string& id) const {

--- a/test/renderer/image_manager.test.cpp
+++ b/test/renderer/image_manager.test.cpp
@@ -50,6 +50,18 @@ TEST(ImageManager, AddRemove) {
     EXPECT_EQ(nullptr, imageManager.getImage("four"));
 }
 
+TEST(ImageManager, Update) {
+    FixtureLog log;
+    ImageManager imageManager;
+
+    imageManager.addImage(makeMutable<style::Image::Impl>("one", PremultipliedImage({ 16, 16 }), 2));
+    EXPECT_EQ(0, imageManager.updatedImageVersions.size());
+    imageManager.updateImage(makeMutable<style::Image::Impl>("one", PremultipliedImage({ 16, 16 }), 2));
+    EXPECT_EQ(1, imageManager.updatedImageVersions.size());
+    imageManager.removeImage("one");
+    EXPECT_EQ(0, imageManager.updatedImageVersions.size());
+}
+
 TEST(ImageManager, RemoveReleasesBinPackRect) {
     FixtureLog log;
     ImageManager imageManager;


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gl-native/pull/14253 add an `ImageVersionMap` to  the `ImageManager`, but doesn't clear data from it when the associated image is removed. 