### PR TITLE
[core] Fix use after std::move detected by clang-tidy

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 
 ## master
 ### Bug fixes
+ - Fixed use of objects after moving, potentially causing crashes. [#15408](https://github.com/mapbox/mapbox-gl-native/pull/1540)
  - Fixed a possible crash that could be caused by invoking the wrong layer implementation casting function [#15398](https://github.com/mapbox/mapbox-gl-native/pull/15398).
 
 ## 8.3.0-alpha.3 - August 15, 2019

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -14,6 +14,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ### Other changes
 
+* Fixed use of objects after moving, potentially causing crashes. [#15408](https://github.com/mapbox/mapbox-gl-native/pull/1540)
 * Fixed a possible crash that could be caused by invoking the wrong layer implementation casting function. ([#15398](https://github.com/mapbox/mapbox-gl-native/pull/15398))
 * Fixed a rare crash when tile download requests returned “404 Not Found” errors. ([#15313](https://github.com/mapbox/mapbox-gl-native/pull/15313))
 * `MGLLoggingLevel` has been updated to better match core log levels. You can now use `MGLLoggingConfiguration.loggingLevel` to filter logs from core. ([#15120](https://github.com/mapbox/mapbox-gl-native/pull/15120))

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -366,7 +366,7 @@ void SymbolLayout::prepareSymbols(const GlyphMap& glyphMap, const GlyphPositions
                     Shaping shaping = applyShaping(*feature.formattedText, WritingModeType::Horizontal, SymbolAnchorType::Center, justification);
                     if (shaping) {
                         shapingForJustification = std::move(shaping);
-                        if (shaping.lineCount == 1u) {
+                        if (shapingForJustification.lineCount == 1u) {
                             shapedTextOrientations.singleLine = true;
                             break;
                         }

--- a/src/mbgl/text/glyph_manager.cpp
+++ b/src/mbgl/text/glyph_manager.cpp
@@ -98,8 +98,9 @@ void GlyphManager::processResponse(const Response& res, const FontStack& fontSta
         }
 
         for (auto& glyph : glyphs) {
-            entry.glyphs.erase(glyph.id);
-            entry.glyphs.emplace(glyph.id, makeMutable<Glyph>(std::move(glyph)));
+            auto id = glyph.id;
+            entry.glyphs.erase(id);
+            entry.glyphs.emplace(id, makeMutable<Glyph>(std::move(glyph)));
         }
     }
 

--- a/src/mbgl/tile/geometry_tile_data.cpp
+++ b/src/mbgl/tile/geometry_tile_data.cpp
@@ -74,6 +74,7 @@ std::vector<GeometryCollection> classifyRings(const GeometryCollection& rings) {
 
         if (ccw == (area < 0 ? -1 : 1) && !polygon.empty()) {
             polygons.emplace_back(std::move(polygon));
+            polygon = GeometryCollection();
         }
 
         polygon.emplace_back(ring);


### PR DESCRIPTION
Detected by the bot being setup at https://github.com/mapbox/mapbox-gl-native/pull/15385.