### PR TITLE
Font fallback

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 ### Bug fixes
  - Fixed use of objects after moving, potentially causing crashes. [#15408](https://github.com/mapbox/mapbox-gl-native/pull/1540)
  - Fixed a possible crash that could be caused by invoking the wrong layer implementation casting function [#15398](https://github.com/mapbox/mapbox-gl-native/pull/15398).
+ - Font lookup on pre lollipop devices failed, provide default font list instead [#15410](https://github.com/mapbox/mapbox-gl-native/pull/15410).
 
 ## 8.3.0-alpha.3 - August 15, 2019
 [Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.3.0-alpha.2...android-v8.3.0-alpha.3) since [Mapbox Maps SDK for Android v8.3.0-alpha.2](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.3.0-alpha.2):

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/utils/FontUtilsTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/utils/FontUtilsTest.java
@@ -1,9 +1,7 @@
 package com.mapbox.mapboxsdk.utils;
 
 import android.support.test.runner.AndroidJUnit4;
-
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/15378. This PR consists out of 2 proposals. Either we disable font look up completely for pre lollipop devices (https://github.com/mapbox/mapbox-gl-native/commit/601992da762979dabb4af8366f53e7a65f892e32) or we provide our own default device fonts based on https://github.com/aosp-mirror/platform_frameworks_base/blob/master/graphics/java/android/graphics/Typeface.java#L1154-L1156 as shown in commit https://github.com/mapbox/mapbox-gl-native/commit/606db647521ae2f2978b5828ade185ebb006d723. 