### PR TITLE
[core] make symbols fade out faster while zooming out

### DIFF
--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -361,7 +361,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(const UpdatePar
         }
 
         bool symbolBucketsChanged = false;
-        const bool placementChanged = !placement->stillRecent(updateParameters.timePoint);
+        const bool placementChanged = !placement->stillRecent(updateParameters.timePoint, updateParameters.transformState.getZoom());
         std::set<std::string> usedSymbolLayers;
         if (placementChanged) {
             placement = std::make_unique<Placement>(
@@ -381,7 +381,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(const UpdatePar
         }
 
         if (placementChanged) {
-            placement->commit(updateParameters.timePoint);
+            placement->commit(updateParameters.timePoint, updateParameters.transformState.getZoom());
             crossTileSymbolIndex.pruneUnusedLayers(usedSymbolLayers);
             for (const auto& entry : renderSources) {
                 entry.second->updateFadingTiles();

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -865,7 +865,7 @@ float Placement::zoomAdjustment(const float zoom) const {
     // adjustment is used to reduce the fade duration for symbols while zooming out quickly.
     // It is also used to reduce the interval between placement calculations. Reducing the
     // interval between placements means collisions are discovered and eliminated sooner.
-    return std::max(0.0, 1.0 - std::pow(2.0, zoom - placementZoom));
+    return std::max(0.0, (placementZoom - zoom) / 1.5);
 }
 
 bool Placement::hasTransitions(TimePoint now) const {

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -102,14 +102,14 @@ class Placement {
 public:
     Placement(const TransformState&, MapMode, style::TransitionOptions, const bool crossSourceCollisions, std::unique_ptr<Placement> prevPlacementOrNull = nullptr);
     void placeLayer(const RenderLayer&, const mat4&, bool showCollisionBoxes);
-    void commit(TimePoint);
+    void commit(TimePoint, const double zoom);
     void updateLayerBuckets(const RenderLayer&, const TransformState&,  bool updateOpacities);
     float symbolFadeChange(TimePoint now) const;
     bool hasTransitions(TimePoint now) const;
 
     const CollisionIndex& getCollisionIndex() const;
 
-    bool stillRecent(TimePoint now) const;
+    bool stillRecent(TimePoint now, const float zoom) const;
     void setRecent(TimePoint now);
     void setStale();
     
@@ -125,6 +125,7 @@ private:
     void updateBucketOpacities(SymbolBucket&, const TransformState&, std::set<uint32_t>&);
     void markUsedJustification(SymbolBucket&, style::TextVariableAnchorType, const SymbolInstance&, style::TextWritingModeType orientation);
     void markUsedOrientation(SymbolBucket&, style::TextWritingModeType, const SymbolInstance&);
+    float zoomAdjustment(const float zoom) const;
 
     CollisionIndex collisionIndex;
 
@@ -133,6 +134,8 @@ private:
 
     TimePoint fadeStartTime;
     TimePoint commitTime;
+    float placementZoom;
+    float prevZoomAdjustment = 0;
 
     std::unordered_map<uint32_t, JointPlacement> placements;
     std::unordered_map<uint32_t, JointOpacityState> opacities;


### PR DESCRIPTION
Zooming out can make symbols overlap quickly. After zooming out quickly the area previously covered by the viewport has a lot of colliding labels while the surrounding area has no labels. This difference produces an unwanted effect:

![Screen Shot 2019-08-19 at 7 51 39 PM](https://user-images.githubusercontent.com/1421652/63307006-c9642580-c2ba-11e9-838f-997c9a06717e.png)


This reduces that effect by:
- reducing the fade duration while zooming out
- doing placement more frequently while zooming out

ports https://github.com/mapbox/mapbox-gl-js/pull/8628/files

In -js we're still trying to figure out whether this introduces jankiness. I've only tested this in the glfw app on -native and it seems to work as smoothly as master. Placement is faster on -native so this should be an ok change. 

To test, zoom in to a dense area and then zoom out as quickly and suddenly as possible. The main thing to check is that it doesn't introduce extra jank.
- [ ] tested on a device

@langsmith @friedbunny could you help test this on a device?