### PR TITLE
[core] Fix overflow when using util::Timestamp

### DIFF
--- a/benchmark/storage/offline_database.benchmark.cpp
+++ b/benchmark/storage/offline_database.benchmark.cpp
@@ -18,7 +18,7 @@ public:
 
         response.data = std::make_shared<std::string>(50 * 1024, 0);
         response.mustRevalidate = false;
-        response.expires = mbgl::util::now() + 1h;
+        response.expires = mbgl::std::chrono::system_clock::now() + 1h;
 
         resetAmbientTiles();
         resetRegion();

--- a/bin/offline.cpp
+++ b/bin/offline.cpp
@@ -198,7 +198,7 @@ int main(int argc, char *argv[]) {
               fileSource(fileSource_),
               loop(loop_),
               mergePath(std::move(mergePath_)),
-              start(util::now()) {
+              start(std::chrono::system_clock::now()) {
         }
 
         void statusChanged(OfflineRegionStatus status) override {
@@ -210,7 +210,7 @@ int main(int argc, char *argv[]) {
 
             std::string bytesPerSecond = "-";
 
-            auto elapsedSeconds = (util::now() - start) / 1s;
+            auto elapsedSeconds = (std::chrono::system_clock::now() - start) / 1s;
             if (elapsedSeconds != 0) {
                 bytesPerSecond = util::toString(status.completedResourceSize / elapsedSeconds);
             }

--- a/include/mbgl/storage/response.hpp
+++ b/include/mbgl/storage/response.hpp
@@ -38,13 +38,13 @@ public:
     optional<std::string> etag;
 
     bool isFresh() const {
-        return expires ? *expires > util::now() : !error;
+        return expires ? *expires > std::chrono::system_clock::now() : !error;
     }
 
     // Indicates whether we are allowed to use this response according to HTTP caching rules.
     // It may or may not be stale.
     bool isUsable() const {
-        return !mustRevalidate || (expires && *expires > util::now());
+        return !mustRevalidate || (expires && *expires > std::chrono::system_clock::now());
     }
 };
 

--- a/include/mbgl/util/chrono.hpp
+++ b/include/mbgl/util/chrono.hpp
@@ -16,10 +16,6 @@ using Timestamp = std::chrono::time_point<std::chrono::system_clock>;
 
 namespace util {
 
-inline Timestamp now() {
-    return std::chrono::system_clock::now();
-}
-
 // Returns the RFC1123 formatted date. E.g. "Tue, 04 Nov 2014 02:13:24 GMT"
 std::string rfc1123(Timestamp);
 

--- a/include/mbgl/util/chrono.hpp
+++ b/include/mbgl/util/chrono.hpp
@@ -12,14 +12,12 @@ using Milliseconds = std::chrono::milliseconds;
 
 using TimePoint = Clock::time_point;
 using Duration  = Clock::duration;
-
-// Used to measure second-precision times, such as times gathered from HTTP responses.
-using Timestamp = std::chrono::time_point<std::chrono::system_clock, Seconds>;
+using Timestamp = std::chrono::time_point<std::chrono::system_clock>;
 
 namespace util {
 
 inline Timestamp now() {
-    return std::chrono::time_point_cast<Seconds>(std::chrono::system_clock::now());
+    return std::chrono::system_clock::now();
 }
 
 // Returns the RFC1123 formatted date. E.g. "Tue, 04 Nov 2014 02:13:24 GMT"

--- a/platform/default/src/mbgl/storage/offline_database.cpp
+++ b/platform/default/src/mbgl/storage/offline_database.cpp
@@ -279,7 +279,7 @@ optional<std::pair<Response, uint64_t>> OfflineDatabase::getResource(const Resou
     // Update accessed timestamp used for LRU eviction.
     try {
         mapbox::sqlite::Query accessedQuery{ getStatement("UPDATE resources SET accessed = ?1 WHERE url = ?2") };
-        accessedQuery.bind(1, util::now());
+        accessedQuery.bind(1, std::chrono::system_clock::now());
         accessedQuery.bind(2, resource.url);
         accessedQuery.run();
     } catch (const mapbox::sqlite::Exception& ex) {
@@ -352,7 +352,7 @@ bool OfflineDatabase::putResource(const Resource& resource,
             "WHERE url    = ?4 ") };
         // clang-format on
 
-        notModifiedQuery.bind(1, util::now());
+        notModifiedQuery.bind(1, std::chrono::system_clock::now());
         notModifiedQuery.bind(2, response.expires);
         notModifiedQuery.bind(3, response.mustRevalidate);
         notModifiedQuery.bind(4, resource.url);
@@ -380,7 +380,7 @@ bool OfflineDatabase::putResource(const Resource& resource,
     updateQuery.bind(3, response.expires);
     updateQuery.bind(4, response.mustRevalidate);
     updateQuery.bind(5, response.modified);
-    updateQuery.bind(6, util::now());
+    updateQuery.bind(6, std::chrono::system_clock::now());
     updateQuery.bind(9, resource.url);
 
     if (response.noContent) {
@@ -408,7 +408,7 @@ bool OfflineDatabase::putResource(const Resource& resource,
     insertQuery.bind(4, response.expires);
     insertQuery.bind(5, response.mustRevalidate);
     insertQuery.bind(6, response.modified);
-    insertQuery.bind(7, util::now());
+    insertQuery.bind(7, std::chrono::system_clock::now());
 
     if (response.noContent) {
         insertQuery.bind(8, nullptr);
@@ -437,7 +437,7 @@ optional<std::pair<Response, uint64_t>> OfflineDatabase::getTile(const Resource:
             "  AND z            = ?6 ") };
         // clang-format on
 
-        accessedQuery.bind(1, util::now());
+        accessedQuery.bind(1, std::chrono::system_clock::now());
         accessedQuery.bind(2, tile.urlTemplate);
         accessedQuery.bind(3, tile.pixelRatio);
         accessedQuery.bind(4, tile.x);
@@ -540,7 +540,7 @@ bool OfflineDatabase::putTile(const Resource::TileData& tile,
             "  AND z             = ?8 ") };
         // clang-format on
 
-        notModifiedQuery.bind(1, util::now());
+        notModifiedQuery.bind(1, std::chrono::system_clock::now());
         notModifiedQuery.bind(2, response.expires);
         notModifiedQuery.bind(3, response.mustRevalidate);
         notModifiedQuery.bind(4, tile.urlTemplate);
@@ -575,7 +575,7 @@ bool OfflineDatabase::putTile(const Resource::TileData& tile,
     updateQuery.bind(2, response.etag);
     updateQuery.bind(3, response.expires);
     updateQuery.bind(4, response.mustRevalidate);
-    updateQuery.bind(5, util::now());
+    updateQuery.bind(5, std::chrono::system_clock::now());
     updateQuery.bind(8, tile.urlTemplate);
     updateQuery.bind(9, tile.pixelRatio);
     updateQuery.bind(10, tile.x);
@@ -610,7 +610,7 @@ bool OfflineDatabase::putTile(const Resource::TileData& tile,
     insertQuery.bind(7, response.mustRevalidate);
     insertQuery.bind(8, response.etag);
     insertQuery.bind(9, response.expires);
-    insertQuery.bind(10, util::now());
+    insertQuery.bind(10, std::chrono::system_clock::now());
 
     if (response.noContent) {
         insertQuery.bind(11, nullptr);

--- a/platform/default/src/mbgl/storage/online_file_source.cpp
+++ b/platform/default/src/mbgl/storage/online_file_source.cpp
@@ -356,7 +356,7 @@ Timestamp interpolateExpiration(const Timestamp& current,
         return current;
     }
 
-    auto delta = current - *prior;
+    auto delta = std::chrono::duration_cast<Seconds>(current - *prior);
 
     // Server is serving the same expired resource
     // over and over, fallback to exponential backoff.

--- a/platform/default/src/mbgl/storage/online_file_source.cpp
+++ b/platform/default/src/mbgl/storage/online_file_source.cpp
@@ -328,7 +328,7 @@ void OnlineFileRequest::schedule() {
     if (resource.priorExpires) {
         schedule(resource.priorExpires);
     } else {
-        schedule(util::now());
+        schedule(std::chrono::system_clock::now());
     }
 }
 
@@ -339,7 +339,7 @@ OnlineFileRequest::~OnlineFileRequest() {
 Timestamp interpolateExpiration(const Timestamp& current,
                                 optional<Timestamp> prior,
                                 bool& expired) {
-    auto now = util::now();
+    auto now = std::chrono::system_clock::now();
     if (current > now) {
         return current;
     }
@@ -461,7 +461,7 @@ void OnlineFileRequest::networkIsReachableAgain() {
     // We need all requests to fail at least once before we are going to start retrying
     // them, and we only immediately restart request that failed due to connection issues.
     if (failedRequestReason == Response::Error::Reason::Connection) {
-        schedule(util::now());
+        schedule(std::chrono::system_clock::now());
     }
 }
 

--- a/platform/default/src/mbgl/storage/sqlite3.cpp
+++ b/platform/default/src/mbgl/storage/sqlite3.cpp
@@ -301,7 +301,7 @@ void Query::bindBlob(int offset, const std::vector<uint8_t>& value, bool retain)
 
 template <>
 void Query::bind(
-        int offset, std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds> value) {
+        int offset, std::chrono::time_point<std::chrono::system_clock> value) {
     assert(stmt.impl);
     stmt.impl->check(sqlite3_bind_int64(stmt.impl->stmt, offset, std::chrono::system_clock::to_time_t(value)));
 }
@@ -317,7 +317,7 @@ template <> void Query::bind(int offset, mbgl::optional<std::string> value) {
 template <>
 void Query::bind(
     int offset,
-    mbgl::optional<std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>> value) {
+    mbgl::optional<std::chrono::time_point<std::chrono::system_clock>> value) {
     if (!value) {
         bind(offset, nullptr);
     } else {
@@ -377,7 +377,7 @@ template <> std::vector<uint8_t> Query::get(int offset) {
 }
 
 template <>
-std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>
+std::chrono::time_point<std::chrono::system_clock>
 Query::get(int offset) {
     assert(stmt.impl);
     return std::chrono::time_point_cast<std::chrono::seconds>(
@@ -412,13 +412,13 @@ template <> mbgl::optional<std::string> Query::get(int offset) {
 }
 
 template <>
-mbgl::optional<std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>>
+mbgl::optional<std::chrono::time_point<std::chrono::system_clock>>
 Query::get(int offset) {
     assert(stmt.impl);
     if (sqlite3_column_type(stmt.impl->stmt, offset) == SQLITE_NULL) {
         return mbgl::nullopt;
     } else {
-        return get<std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>>(
+        return get<std::chrono::time_point<std::chrono::system_clock>>(
             offset);
     }
 }

--- a/src/mbgl/util/chrono.cpp
+++ b/src/mbgl/util/chrono.cpp
@@ -38,11 +38,11 @@ std::string iso8601(Timestamp timestamp) {
 }
 
 Timestamp parseTimestamp(const char* timestamp) {
-    return std::chrono::time_point_cast<Seconds>(std::chrono::system_clock::from_time_t(parse_date(timestamp)));
+    return std::chrono::system_clock::from_time_t(parse_date(timestamp));
 }
 
 Timestamp parseTimestamp(const int32_t timestamp) {
-    return std::chrono::time_point_cast<Seconds>(std::chrono::system_clock::from_time_t(timestamp));
+    return std::chrono::system_clock::from_time_t(timestamp);
 }
 
 } // namespace util

--- a/src/mbgl/util/http_header.cpp
+++ b/src/mbgl/util/http_header.cpp
@@ -23,7 +23,7 @@ CacheControl CacheControl::parse(const std::string& value) {
 }
 
 optional<Timestamp> CacheControl::toTimePoint() const {
-    return maxAge ? util::now() + Seconds(*maxAge) : optional<Timestamp>{};
+    return maxAge ? std::chrono::system_clock::now() + Seconds(*maxAge) : optional<Timestamp>{};
 }
 
 optional<Timestamp> parseRetryHeaders(const optional<std::string>& retryAfter,

--- a/src/mbgl/util/http_header.cpp
+++ b/src/mbgl/util/http_header.cpp
@@ -31,7 +31,7 @@ optional<Timestamp> parseRetryHeaders(const optional<std::string>& retryAfter,
     if (retryAfter) {
         try {
             auto secs = std::chrono::seconds(std::stoi(*retryAfter));
-            return std::chrono::time_point_cast<Seconds>(std::chrono::system_clock::now() + secs);
+            return std::chrono::system_clock::now() + secs;
         } catch (...) {
             return util::parseTimestamp((*retryAfter).c_str());
         }

--- a/src/mbgl/util/http_timeout.cpp
+++ b/src/mbgl/util/http_timeout.cpp
@@ -18,7 +18,7 @@ Duration errorRetryTimeout(Response::Error::Reason failedRequestReason, uint32_t
         return Seconds(1u << std::min(failedRequests - 1, 31u));
     } else if (failedRequestReason == Response::Error::Reason::RateLimit) {
         if (retryAfter) {
-            return *retryAfter - util::now();
+            return *retryAfter - std::chrono::system_clock::now();
         } else {
             // Default
             return Seconds(util::DEFAULT_RATE_LIMIT_TIMEOUT);
@@ -33,7 +33,7 @@ Duration expirationTimeout(optional<Timestamp> expires, uint32_t expiredRequests
     if (expiredRequests) {
         return Seconds(1u << std::min(expiredRequests - 1, 31u));
     } else if (expires) {
-        return std::max(std::chrono::system_clock::duration::zero(), *expires - util::now());
+        return std::max(std::chrono::system_clock::duration::zero(), *expires - std::chrono::system_clock::now());
     } else {
         return Duration::max();
     }

--- a/src/mbgl/util/http_timeout.cpp
+++ b/src/mbgl/util/http_timeout.cpp
@@ -33,7 +33,7 @@ Duration expirationTimeout(optional<Timestamp> expires, uint32_t expiredRequests
     if (expiredRequests) {
         return Seconds(1u << std::min(expiredRequests - 1, 31u));
     } else if (expires) {
-        return std::max(Seconds::zero(), *expires - util::now());
+        return std::max(std::chrono::system_clock::duration::zero(), *expires - util::now());
     } else {
         return Duration::max();
     }

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -433,7 +433,7 @@ TEST(Map, StyleExpired) {
 
     Response response;
     response.data = std::make_shared<std::string>(util::read_file("test/fixtures/api/empty.json"));
-    response.expires = util::now() - 1h;
+    response.expires = std::chrono::system_clock::now() - 1h;
 
     test.fileSource->respond(Resource::Style, response);
     EXPECT_EQ(1u, test.fileSource->requests.size());
@@ -451,7 +451,7 @@ TEST(Map, StyleExpired) {
 
     // Send a fresh response, and confirm that we didn't overwrite the style, but continue to wait
     // for a fresh response.
-    response.expires = util::now() + 1h;
+    response.expires = std::chrono::system_clock::now() + 1h;
     test.fileSource->respond(Resource::Style, response);
     EXPECT_EQ(1u, test.fileSource->requests.size());
     EXPECT_NE(nullptr, test.map.getStyle().getLayer("bg"));
@@ -469,7 +469,7 @@ TEST(Map, StyleExpiredWithAnnotations) {
 
     Response response;
     response.data = std::make_shared<std::string>(util::read_file("test/fixtures/api/empty.json"));
-    response.expires = util::now() - 1h;
+    response.expires = std::chrono::system_clock::now() - 1h;
 
     test.fileSource->respond(Resource::Style, response);
     EXPECT_EQ(1u, test.fileSource->requests.size());
@@ -493,7 +493,7 @@ TEST(Map, StyleExpiredWithRender) {
 
     Response response;
     response.data = std::make_shared<std::string>(util::read_file("test/fixtures/api/empty.json"));
-    response.expires = util::now() - 1h;
+    response.expires = std::chrono::system_clock::now() - 1h;
 
     test.fileSource->respond(Resource::Style, response);
     EXPECT_EQ(1u, test.fileSource->requests.size());
@@ -787,7 +787,7 @@ TEST(Map, NoContentTiles) {
     // Insert a 204 No Content response for the 0/0/0 tile
     Response response;
     response.noContent = true;
-    response.expires = util::now() + 1h;
+    response.expires = std::chrono::system_clock::now() + 1h;
     test.fileSource->put(Resource::tile("http://example.com/{z}-{x}-{y}.vector.pbf", 1.0, 0, 0, 0,
                                        Tileset::Scheme::XYZ),
                         response);

--- a/test/storage/default_file_source.test.cpp
+++ b/test/storage/default_file_source.test.cpp
@@ -5,6 +5,7 @@
 #include <mbgl/util/run_loop.hpp>
 
 using namespace mbgl;
+using namespace std::chrono;
 
 TEST(DefaultFileSource, TEST_REQUIRES_SERVER(CacheResponse)) {
     util::RunLoop loop;
@@ -34,7 +35,7 @@ TEST(DefaultFileSource, TEST_REQUIRES_SERVER(CacheResponse)) {
             EXPECT_EQ(response.error, res2.error);
             ASSERT_TRUE(res2.data.get());
             EXPECT_EQ(*response.data, *res2.data);
-            EXPECT_EQ(response.expires, res2.expires);
+            EXPECT_EQ(system_clock::to_time_t(*response.expires), system_clock::to_time_t(*res2.expires));
             EXPECT_EQ(response.mustRevalidate, res2.mustRevalidate);
             EXPECT_EQ(response.modified, res2.modified);
             EXPECT_EQ(response.etag, res2.etag);
@@ -267,7 +268,7 @@ TEST(DefaultFileSource, OptionalNonExpired) {
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("Cached value", *res.data);
         ASSERT_TRUE(bool(res.expires));
-        EXPECT_EQ(*response.expires, *res.expires);
+        EXPECT_EQ(system_clock::to_time_t(*response.expires), system_clock::to_time_t(*res.expires));
         EXPECT_FALSE(res.mustRevalidate);
         EXPECT_FALSE(bool(res.modified));
         EXPECT_FALSE(bool(res.etag));
@@ -297,7 +298,7 @@ TEST(DefaultFileSource, OptionalExpired) {
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("Cached value", *res.data);
         ASSERT_TRUE(bool(res.expires));
-        EXPECT_EQ(*response.expires, *res.expires);
+        EXPECT_EQ(system_clock::to_time_t(*response.expires), system_clock::to_time_t(*res.expires));
         EXPECT_FALSE(res.mustRevalidate);
         EXPECT_FALSE(bool(res.modified));
         EXPECT_FALSE(bool(res.etag));

--- a/test/storage/default_file_source.test.cpp
+++ b/test/storage/default_file_source.test.cpp
@@ -258,7 +258,7 @@ TEST(DefaultFileSource, OptionalNonExpired) {
 
     Response response;
     response.data = std::make_shared<std::string>("Cached value");
-    response.expires = util::now() + 1h;
+    response.expires = system_clock::now() + 1h;
     fs.put(optionalResource, response);
 
     std::unique_ptr<AsyncRequest> req;
@@ -288,7 +288,7 @@ TEST(DefaultFileSource, OptionalExpired) {
 
     Response response;
     response.data = std::make_shared<std::string>("Cached value");
-    response.expires = util::now() - 1h;
+    response.expires = system_clock::now() - 1h;
     fs.put(optionalResource, response);
 
     std::unique_ptr<AsyncRequest> req;
@@ -363,7 +363,7 @@ TEST(DefaultFileSource, TEST_REQUIRES_SERVER(NoCacheRefreshEtagNotModified)) {
     // Put a fake value into the cache to make sure we're not retrieving anything from the cache.
     Response response;
     response.data = std::make_shared<std::string>("Cached value");
-    response.expires = util::now() + 1h;
+    response.expires = system_clock::now() + 1h;
     fs.put(resource, response);
 
     std::unique_ptr<AsyncRequest> req;
@@ -373,7 +373,7 @@ TEST(DefaultFileSource, TEST_REQUIRES_SERVER(NoCacheRefreshEtagNotModified)) {
         EXPECT_TRUE(res.notModified);
         EXPECT_FALSE(res.data.get());
         ASSERT_TRUE(bool(res.expires));
-        EXPECT_LT(util::now(), *res.expires);
+        EXPECT_LT(system_clock::now(), *res.expires);
         EXPECT_TRUE(res.mustRevalidate);
         EXPECT_FALSE(bool(res.modified));
         ASSERT_TRUE(bool(res.etag));
@@ -398,7 +398,7 @@ TEST(DefaultFileSource, TEST_REQUIRES_SERVER(NoCacheRefreshEtagModified)) {
     // Put a fake value into the cache to make sure we're not retrieving anything from the cache.
     Response response;
     response.data = std::make_shared<std::string>("Cached value");
-    response.expires = util::now() + 1h;
+    response.expires = system_clock::now() + 1h;
     fs.put(resource, response);
 
     std::unique_ptr<AsyncRequest> req;
@@ -432,7 +432,7 @@ TEST(DefaultFileSource, TEST_REQUIRES_SERVER(NoCacheFull)) {
     // Put a fake value into the cache to make sure we're not retrieving anything from the cache.
     Response response;
     response.data = std::make_shared<std::string>("Cached value");
-    response.expires = util::now() + 1h;
+    response.expires = system_clock::now() + 1h;
     fs.put(resource, response);
 
     std::unique_ptr<AsyncRequest> req;
@@ -468,7 +468,7 @@ TEST(DefaultFileSource, TEST_REQUIRES_SERVER(NoCacheRefreshModifiedNotModified))
     // Put a fake value into the cache to make sure we're not retrieving anything from the cache.
     Response response;
     response.data = std::make_shared<std::string>("Cached value");
-    response.expires = util::now() + 1h;
+    response.expires = system_clock::now() + 1h;
     fs.put(resource, response);
 
     std::unique_ptr<AsyncRequest> req;
@@ -478,7 +478,7 @@ TEST(DefaultFileSource, TEST_REQUIRES_SERVER(NoCacheRefreshModifiedNotModified))
         EXPECT_TRUE(res.notModified);
         EXPECT_FALSE(res.data.get());
         ASSERT_TRUE(bool(res.expires));
-        EXPECT_LT(util::now(), *res.expires);
+        EXPECT_LT(system_clock::now(), *res.expires);
         EXPECT_TRUE(res.mustRevalidate);
         ASSERT_TRUE(bool(res.modified));
         EXPECT_EQ(Timestamp{ Seconds(1420070400) }, *res.modified);
@@ -504,7 +504,7 @@ TEST(DefaultFileSource, TEST_REQUIRES_SERVER(NoCacheRefreshModifiedModified)) {
     // Put a fake value into the cache to make sure we're not retrieving anything from the cache.
     Response response;
     response.data = std::make_shared<std::string>("Cached value");
-    response.expires = util::now() + 1h;
+    response.expires = system_clock::now() + 1h;
     fs.put(resource, response);
 
     std::unique_ptr<AsyncRequest> req;
@@ -651,7 +651,7 @@ TEST(DefaultFileSource, TEST_REQUIRES_SERVER(RespondToStaleMustRevalidate)) {
         // return new data, only a 304 Not Modified response.
         EXPECT_EQ("Prior value", *res.data);
         ASSERT_TRUE(res.expires);
-        EXPECT_LE(util::now(), *res.expires);
+        EXPECT_LE(system_clock::now(), *res.expires);
         EXPECT_TRUE(res.mustRevalidate);
         ASSERT_TRUE(res.modified);
         EXPECT_EQ(Timestamp{ Seconds(1417392000) }, *res.modified);

--- a/test/storage/http_file_source.test.cpp
+++ b/test/storage/http_file_source.test.cpp
@@ -155,7 +155,7 @@ TEST(HTTPFileSource, TEST_REQUIRES_SERVER(CacheControlParsing)) {
         EXPECT_EQ(nullptr, res.error);
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("Hello World!", *res.data);
-        EXPECT_GT(Seconds(2), util::abs(*res.expires - util::now() - Seconds(120))) << "Expiration date isn't about 120 seconds in the future";
+        EXPECT_GT(Seconds(2), util::abs(*res.expires - std::chrono::system_clock::now() - Seconds(120))) << "Expiration date isn't about 120 seconds in the future";
         EXPECT_FALSE(res.mustRevalidate);
         EXPECT_FALSE(bool(res.modified));
         EXPECT_FALSE(bool(res.etag));

--- a/test/storage/offline_database.test.cpp
+++ b/test/storage/offline_database.test.cpp
@@ -805,7 +805,7 @@ TEST(OfflineDatabase, Invalidate) {
     Response response;
     response.noContent = true;
     response.mustRevalidate = false;
-    response.expires = util::now() + 1h;
+    response.expires = std::chrono::system_clock::now() + 1h;
 
     const Resource ambientTile = Resource::tile("mapbox://tile_ambient", 1, 0, 0, 0, Tileset::Scheme::XYZ);
     db.put(ambientTile, response);
@@ -861,12 +861,12 @@ TEST(OfflineDatabase, Invalidate) {
     EXPECT_TRUE(db.get(region2Style)->isUsable());
 
     // Sanity check.
-    EXPECT_TRUE(db.get(ambientTile)->expires < util::now());
-    EXPECT_TRUE(db.get(ambientStyle)->expires < util::now());
-    EXPECT_TRUE(db.get(region1Tile)->expires < util::now());
-    EXPECT_TRUE(db.get(region1Style)->expires < util::now());
-    EXPECT_TRUE(db.get(region2Tile)->expires > util::now());
-    EXPECT_TRUE(db.get(region2Style)->expires > util::now());
+    EXPECT_TRUE(db.get(ambientTile)->expires < std::chrono::system_clock::now());
+    EXPECT_TRUE(db.get(ambientStyle)->expires < std::chrono::system_clock::now());
+    EXPECT_TRUE(db.get(region1Tile)->expires < std::chrono::system_clock::now());
+    EXPECT_TRUE(db.get(region1Style)->expires < std::chrono::system_clock::now());
+    EXPECT_TRUE(db.get(region2Tile)->expires > std::chrono::system_clock::now());
+    EXPECT_TRUE(db.get(region2Style)->expires > std::chrono::system_clock::now());
 
     EXPECT_TRUE(db.get(ambientTile)->mustRevalidate);
     EXPECT_TRUE(db.get(ambientStyle)->mustRevalidate);

--- a/test/storage/online_file_source.test.cpp
+++ b/test/storage/online_file_source.test.cpp
@@ -155,7 +155,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RetryDelayOnExpiredTile)) {
     std::unique_ptr<AsyncRequest> req = fs.request(resource, [&](Response res) {
         counter++;
         EXPECT_EQ(nullptr, res.error);
-        EXPECT_GT(util::now(), *res.expires);
+        EXPECT_GT(std::chrono::system_clock::now(), *res.expires);
         EXPECT_FALSE(res.mustRevalidate);
     });
 
@@ -181,12 +181,12 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RetryOnClockSkew)) {
         switch (counter++) {
         case 0: {
             EXPECT_EQ(nullptr, res.error);
-            EXPECT_GT(util::now(), *res.expires);
+            EXPECT_GT(std::chrono::system_clock::now(), *res.expires);
         } break;
         case 1: {
             EXPECT_EQ(nullptr, res.error);
 
-            auto now = util::now();
+            auto now = std::chrono::system_clock::now();
             EXPECT_LT(now + Seconds(40), *res.expires) << "Expiration not interpolated to 60s";
             EXPECT_GT(now + Seconds(80), *res.expires) << "Expiration not interpolated to 60s";
 
@@ -204,7 +204,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RespectPriorExpires)) {
 
     // Very long expiration time, should never arrive.
     Resource resource1{ Resource::Unknown, "http://127.0.0.1:3000/test" };
-    resource1.priorExpires = util::now() + Seconds(100000);
+    resource1.priorExpires = std::chrono::system_clock::now() + Seconds(100000);
 
     std::unique_ptr<AsyncRequest> req1 = fs.request(resource1, [&](Response) {
         FAIL() << "Should never be called";
@@ -219,7 +219,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RespectPriorExpires)) {
 
     // Very long expiration time, should never arrive.
     Resource resource3{ Resource::Unknown, "http://127.0.0.1:3000/test" };
-    resource3.priorExpires = util::now() + Seconds(100000);
+    resource3.priorExpires = std::chrono::system_clock::now() + Seconds(100000);
 
     std::unique_ptr<AsyncRequest> req3 = fs.request(resource3, [&](Response) {
         FAIL() << "Should never be called";
@@ -380,7 +380,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RateLimitStandard)) {
         ASSERT_NE(nullptr, res.error);
         EXPECT_EQ(Response::Error::Reason::RateLimit, res.error->reason);
         ASSERT_EQ(true, bool(res.error->retryAfter));
-        ASSERT_LT(util::now(), res.error->retryAfter);
+        ASSERT_LT(std::chrono::system_clock::now(), res.error->retryAfter);
         loop.stop();
     });
 
@@ -395,7 +395,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RateLimitMBX)) {
         ASSERT_NE(nullptr, res.error);
         EXPECT_EQ(Response::Error::Reason::RateLimit, res.error->reason);
         ASSERT_EQ(true, bool(res.error->retryAfter));
-        ASSERT_LT(util::now(), res.error->retryAfter);
+        ASSERT_LT(std::chrono::system_clock::now(), res.error->retryAfter);
         loop.stop();
     });
 

--- a/test/util/http_timeout.test.cpp
+++ b/test/util/http_timeout.test.cpp
@@ -41,8 +41,9 @@ TEST(HttpRetry, RateLimit) {
 }
 
 TEST(HttpRetry, ExpiredInitial) {
-    // 1 sec timeout
-    ASSERT_EQ(Seconds(1), expirationTimeout({ util::now() + Seconds(1) }, 0));
+    // 1 sec timeout, will not be exactly 1 because of precision/rounding
+    ASSERT_TRUE(Milliseconds(1000) >= expirationTimeout({ util::now() + Seconds(1) }, 0));
+    ASSERT_TRUE(Milliseconds(990) < expirationTimeout({ util::now() + Seconds(1) }, 0));
 }
 
 TEST(HttpRetry, ExpiredSubsequent) {

--- a/test/util/http_timeout.test.cpp
+++ b/test/util/http_timeout.test.cpp
@@ -34,7 +34,7 @@ TEST(HttpRetry, ConnectionError) {
 
 TEST(HttpRetry, RateLimit) {
     // Pre-set value from header
-    ASSERT_EQ(Seconds(1), errorRetryTimeout(Response::Error::Reason::Server, 1, { util::now() + Seconds(1) }));
+    ASSERT_EQ(Seconds(1), errorRetryTimeout(Response::Error::Reason::Server, 1, { std::chrono::system_clock::now() + Seconds(1) }));
 
     // Default
     ASSERT_EQ(Seconds(5), errorRetryTimeout(Response::Error::Reason::RateLimit, 1, {}));
@@ -42,8 +42,8 @@ TEST(HttpRetry, RateLimit) {
 
 TEST(HttpRetry, ExpiredInitial) {
     // 1 sec timeout, will not be exactly 1 because of precision/rounding
-    ASSERT_TRUE(Milliseconds(1000) >= expirationTimeout({ util::now() + Seconds(1) }, 0));
-    ASSERT_TRUE(Milliseconds(990) < expirationTimeout({ util::now() + Seconds(1) }, 0));
+    ASSERT_TRUE(Milliseconds(1000) >= expirationTimeout({ std::chrono::system_clock::now() + Seconds(1) }, 0));
+    ASSERT_TRUE(Milliseconds(990) < expirationTimeout({ std::chrono::system_clock::now() + Seconds(1) }, 0));
 }
 
 TEST(HttpRetry, ExpiredSubsequent) {


### PR DESCRIPTION
Detected by the undefined behavior sanitizer: https://circleci.com/gh/mapbox/mapbox-gl-native/318016