### PR TITLE
[node][release] prep v4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-native",
-  "version": "4.3.0-pre.1",
+  "version": "4.3.0",
   "description": "Renders map tiles with Mapbox GL",
   "keywords": [
     "mapbox",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-native",
-  "version": "4.2.0",
+  "version": "4.3.0-pre.1",
   "description": "Renders map tiles with Mapbox GL",
   "keywords": [
     "mapbox",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,9 +1,10 @@
-# master
+# 4.3.0
 * Introduce `text-writing-mode` layout property for symbol layer ([#14932](https://github.com/mapbox/mapbox-gl-native/pull/14932)). The `text-writing-mode` layout property allows control over symbol's preferred writing mode. The new property value is an array, whose values are enumeration values from a ( `horizontal` | `vertical` ) set.
 * Fixed rendering and collision detection issues with using `text-variable-anchor` and `icon-text-fit` properties on the same layer ([#15367](https://github.com/mapbox/mapbox-gl-native/pull/15367)).
 * Fixed a rendering issue that non-SDF icon would be treated as SDF icon if they are in the same layer. ([#15456](https://github.com/mapbox/mapbox-gl-native/pull/15456))
 * Fixed a rendering issue of `collisionBox` when `text-translate` or `icon-translate` is enabled. ([#15467](https://github.com/mapbox/mapbox-gl-native/pull/15467))
 * Fixed an issue of integer overflow when converting `tileCoordinates` to `LatLon`, which caused issues such as `queryRenderedFeatures` and `querySourceFeatures` returning incorrect coordinates at zoom levels 20 and higher. ([#15560](https://github.com/mapbox/mapbox-gl-native/pull/15560))
+* Add typechecking while constructing legacy filter to prevent converting an unexpected filter type [#15389](https://github.com/mapbox/mapbox-gl-native/pull/15389).
 
 # 4.2.0
 - Add an option to set whether or not an image should be treated as a SDF ([#15054](https://github.com/mapbox/mapbox-gl-native/issues/15054))

--- a/platform/node/DEVELOPING.md
+++ b/platform/node/DEVELOPING.md
@@ -43,7 +43,7 @@ To publish a new version of the package:
     - [ ] an updated version number in [`package.json`](../../package.json#L3)
     - [ ] an entry in [`platform/node/CHANGELOG.md`](CHANGELOG.md) describing the changes in the release
 - [ ] run `git tag node-v{VERSION}` where `{VERSION}` matches the version in `package.json`, e.g. `git tag node-v3.3.2`
-- [ ] run `git push && git push --gs`
+- [ ] run `git push && git push --tags`
 
 The CI builds for tag pushes will check if the tag matches the version listed in `package.json`, and if so, will run with `BUILDTYPE=Release` and publish a binary with `node-pre-gyp`.
 


### PR DESCRIPTION
Wanted to get #15389 in a release 🙌  This branch is based off state from 08/15/2019 ([this commit](https://github.com/mapbox/mapbox-gl-native/commit/5f477e310b286d1bb8c5d238376d45ec58aa3fc4)).


One of the render tests fails locally:

```bash
* failed tilejson-bounds/overwrite-bounds
```


### Release checklist:

- [x] Update changelog 
- [x] Fix render test
- [x] Create prerelease