### PR TITLE
[ios] Refactor some variable names and clean-up iosapp

### DIFF
--- a/platform/darwin/src/MGLAccountManager.m
+++ b/platform/darwin/src/MGLAccountManager.m
@@ -13,6 +13,8 @@ static NSString * const MGLAccountManagerExternalClassName = @"MBXAccounts";
 static NSString * const MGLAccountManagerExternalMethodName = @"skuToken";
 #endif
 
+NSString * const MGLMapboxAccountTypeKey = @"MGLMapboxAccountType";
+
 @interface MGLAccountManager ()
 
 @property (atomic) NSString *accessToken;

--- a/platform/darwin/src/MGLAccountManager_Private.h
+++ b/platform/darwin/src/MGLAccountManager_Private.h
@@ -2,6 +2,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// NSUserDefaults key that controls developer account type
+FOUNDATION_EXTERN NSString * const MGLMapboxAccountTypeKey;
+
 @interface MGLAccountManager (Private)
 
 /// Returns the shared instance of the `MGLAccountManager` class.

--- a/platform/darwin/src/http_file_source.mm
+++ b/platform/darwin/src/http_file_source.mm
@@ -88,15 +88,14 @@ class HTTPFileSource::Impl {
 public:
     Impl() {
         @autoreleasepool {
-
-            NSURLSessionConfiguration *sessionConfig =
-            [MGLNetworkConfiguration sharedManager].sessionConfiguration;
-            
+            NSURLSessionConfiguration *sessionConfig = [MGLNetworkConfiguration sharedManager].sessionConfiguration;
             session = [NSURLSession sessionWithConfiguration:sessionConfig];
 
             userAgent = getUserAgent();
 
-            accountType = [[NSUserDefaults standardUserDefaults] integerForKey:@"MGLMapboxAccountType"];
+#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
+            accountType = [[NSUserDefaults standardUserDefaults] integerForKey:MGLMapboxAccountTypeKey];
+#endif
         }
     }
 

--- a/platform/ios/app/MBXState.h
+++ b/platform/ios/app/MBXState.h
@@ -12,7 +12,6 @@ FOUNDATION_EXTERN NSString *const MBXShowsZoomLevelOrnament;
 FOUNDATION_EXTERN NSString *const MBXShowsTimeFrameGraph;
 FOUNDATION_EXTERN NSString *const MBXMapFramerateMeasurementEnabled;
 FOUNDATION_EXTERN NSString *const MBXDebugMaskValue;
-FOUNDATION_EXTERN NSString *const MBXDebugLoggingEnabled;
 FOUNDATION_EXTERN NSString *const MBXReuseQueueStatsEnabled;
 
 @interface MBXState : NSObject <NSSecureCoding>
@@ -26,7 +25,6 @@ FOUNDATION_EXTERN NSString *const MBXReuseQueueStatsEnabled;
 @property (nonatomic) BOOL showsTimeFrameGraph;
 @property (nonatomic) BOOL framerateMeasurementEnabled;
 @property (nonatomic) MGLMapDebugMaskOptions debugMask;
-@property (nonatomic) BOOL debugLoggingEnabled;
 @property (nonatomic) BOOL reuseQueueStatsEnabled;
 
 @property (nonatomic, readonly) NSString *debugDescription;

--- a/platform/ios/app/MBXState.m
+++ b/platform/ios/app/MBXState.m
@@ -6,7 +6,6 @@ NSString *const MBXShowsUserLocation = @"MBXShowsUserLocation";
 NSString *const MBXDebugMaskValue = @"MBXDebugMaskValue";
 NSString *const MBXShowsZoomLevelOrnament =  @"MBXShowsZoomLevelOrnament";
 NSString *const MBXShowsTimeFrameGraph = @"MBXShowsFrameTimeGraph";
-NSString *const MBXDebugLoggingEnabled = @"MGLMapboxMetricsDebugLoggingEnabled";
 NSString *const MBXShowsMapScale = @"MBXMapShowsScale";
 NSString *const MBXMapShowsHeadingIndicator = @"MBXMapShowsHeadingIndicator";
 NSString *const MBXMapFramerateMeasurementEnabled = @"MBXMapFramerateMeasurementEnabled";
@@ -26,7 +25,6 @@ NSString *const MBXReuseQueueStatsEnabled = @"MBXReuseQueueStatsEnabled";
     [coder encodeObject:[NSNumber numberWithUnsignedInteger:_debugMask] forKey:MBXDebugMaskValue];
     [coder encodeBool:_showsZoomLevelOrnament forKey:MBXShowsZoomLevelOrnament];
     [coder encodeBool:_showsTimeFrameGraph forKey:MBXShowsTimeFrameGraph];
-    [coder encodeBool:_debugLoggingEnabled forKey:MBXDebugLoggingEnabled];
     [coder encodeBool:_showsMapScale forKey:MBXShowsMapScale];
     [coder encodeBool:_showsUserHeadingIndicator forKey:MBXMapShowsHeadingIndicator];
     [coder encodeBool:_framerateMeasurementEnabled forKey:MBXMapFramerateMeasurementEnabled];
@@ -41,7 +39,6 @@ NSString *const MBXReuseQueueStatsEnabled = @"MBXReuseQueueStatsEnabled";
         NSNumber *decodedDebugMaskOptions = [decoder decodeObjectForKey:MBXDebugMaskValue];
         BOOL decodedZoomLevelOrnament = [decoder decodeBoolForKey:MBXShowsZoomLevelOrnament];
         BOOL decodedShowsTimeFrameGraph = [decoder decodeBoolForKey:MBXShowsTimeFrameGraph];
-        BOOL decodedDebugLoggingEnabled = [decoder decodeBoolForKey:MBXDebugLoggingEnabled];
         BOOL decodedShowsMapScale = [decoder decodeBoolForKey:MBXShowsMapScale];
         BOOL decodedShowsUserHeadingIndicator = [decoder decodeBoolForKey:MBXMapShowsHeadingIndicator];
         BOOL decodedFramerateMeasurementEnabled = [decoder decodeBoolForKey:MBXMapFramerateMeasurementEnabled];
@@ -53,7 +50,6 @@ NSString *const MBXReuseQueueStatsEnabled = @"MBXReuseQueueStatsEnabled";
         _debugMask = decodedDebugMaskOptions.intValue;
         _showsZoomLevelOrnament = decodedZoomLevelOrnament;
         _showsTimeFrameGraph = decodedShowsTimeFrameGraph;
-        _debugLoggingEnabled = decodedDebugLoggingEnabled;
         _showsMapScale = decodedShowsMapScale;
         _showsUserHeadingIndicator = decodedShowsUserHeadingIndicator;
         _framerateMeasurementEnabled = decodedFramerateMeasurementEnabled;
@@ -75,7 +71,6 @@ NSString *const MBXReuseQueueStatsEnabled = @"MBXReuseQueueStatsEnabled";
             (unsigned long)self.debugMask,
             self.showsZoomLevelOrnament ? @"YES" : @"NO",
             self.showsTimeFrameGraph ? @"YES" : @"NO",
-            self.debugLoggingEnabled ? @"YES" : @"NO",
             self.showsMapScale ? @"YES" : @"NO",
             self.showsUserHeadingIndicator ? @"YES" : @"NO",
             self.framerateMeasurementEnabled ? @"YES" : @"NO",

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -211,7 +211,6 @@ CLLocationCoordinate2D randomWorldCoordinate() {
 @property (nonatomic) BOOL shouldLimitCameraChanges;
 @property (nonatomic) BOOL randomWalk;
 @property (nonatomic) BOOL zoomLevelOrnamentEnabled;
-@property (nonatomic) BOOL debugLoggingEnabled;
 @property (nonatomic) NSMutableArray<UIWindow *> *helperWindows;
 @property (nonatomic) NSMutableArray<UIView *> *contentInsetsOverlays;
 
@@ -246,7 +245,6 @@ CLLocationCoordinate2D randomWorldCoordinate() {
         self.mapView.showsScale = YES;
         self.zoomLevelOrnamentEnabled = NO;
         self.frameTimeGraphEnabled = NO;
-        self.debugLoggingEnabled = YES;
     } else {
         // Revert to the previously saved state
         [self restoreMapState:nil];
@@ -441,14 +439,6 @@ CLLocationCoordinate2D randomWorldCoordinate() {
                 @"Ornaments Placement",
             ]];
 
-            if (self.currentState.debugLoggingEnabled)
-            {
-                [settingsTitles addObjectsFromArray:@[
-                    @"Print Telemetry Logfile",
-                    @"Delete Telemetry Logfile",
-                ]];
-            };
-
             break;
         default:
             NSAssert(NO, @"All settings sections should be implemented");
@@ -558,15 +548,12 @@ CLLocationCoordinate2D randomWorldCoordinate() {
                 case MBXSettingsAnnotationSelectRandomOffscreenPointAnnotation:
                     [self selectAnOffscreenPointAnnotation];
                     break;
-
                 case MBXSettingsAnnotationCenterSelectedAnnotation:
                     [self centerSelectedAnnotation];
                     break;
-
                 case MBXSettingsAnnotationAddVisibleAreaPolyline:
                     [self addVisibleAreaPolyline];
                     break;
-
                 default:
                     NSAssert(NO, @"All annotations setting rows should be implemented");
                     break;
@@ -666,13 +653,6 @@ CLLocationCoordinate2D randomWorldCoordinate() {
                     break;
                 case MBXSettingsMiscellaneousRandomTour:
                     [self randomWorldTour];
-                    break;
-
-                case MBXSettingsMiscellaneousPrintLogFile:
-                    [self printTelemetryLogFile];
-                    break;
-                case MBXSettingsMiscellaneousDeleteLogFile:
-                    [self deleteTelemetryLogFile];
                     break;
                 case MBXSettingsMiscellaneousScrollView:
                 {
@@ -1734,37 +1714,6 @@ CLLocationCoordinate2D randomWorldCoordinate() {
     return backupImage;
 }
 
-- (void)printTelemetryLogFile
-{
-    NSString *fileContents = [NSString stringWithContentsOfFile:[self telemetryDebugLogFilePath] encoding:NSUTF8StringEncoding error:nil];
-    NSLog(@"%@", fileContents);
-}
-
-- (void)deleteTelemetryLogFile
-{
-    NSString *filePath = [self telemetryDebugLogFilePath];
-    if ([[NSFileManager defaultManager] isDeletableFileAtPath:filePath])
-    {
-        NSError *error;
-        BOOL success = [[NSFileManager defaultManager] removeItemAtPath:filePath error:&error];
-        if (success) {
-            NSLog(@"Deleted telemetry log.");
-        } else {
-            NSLog(@"Error deleting telemetry log: %@", error.localizedDescription);
-        }
-    }
-}
-
-- (NSString *)telemetryDebugLogFilePath
-{
-    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-    [dateFormatter setDateFormat:@"yyyy'-'MM'-'dd"];
-    [dateFormatter setTimeZone:[NSTimeZone systemTimeZone]];
-    NSString *filePath = [[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject] stringByAppendingPathComponent:[NSString stringWithFormat:@"telemetry_log-%@.json", [dateFormatter stringFromDate:[NSDate date]]]];
-
-    return filePath;
-}
-
 #pragma mark - Random World Tour
 
 - (void)addAnnotations:(NSInteger)numAnnotations aroundCoordinate:(CLLocationCoordinate2D)coordinate radius:(CLLocationDistance)radius {
@@ -2396,7 +2345,6 @@ CLLocationCoordinate2D randomWorldCoordinate() {
     self.currentState.showsZoomLevelOrnament = self.zoomLevelOrnamentEnabled;
     self.currentState.showsTimeFrameGraph = self.frameTimeGraphEnabled;
     self.currentState.debugMask = self.mapView.debugMask;
-    self.currentState.debugLoggingEnabled = self.debugLoggingEnabled;
     self.currentState.reuseQueueStatsEnabled = self.reuseQueueStatsEnabled;
 
     [[MBXStateManager sharedManager] saveState:self.currentState];
@@ -2413,7 +2361,6 @@ CLLocationCoordinate2D randomWorldCoordinate() {
     self.zoomLevelOrnamentEnabled = currentState.showsZoomLevelOrnament;
     self.frameTimeGraphEnabled = currentState.showsTimeFrameGraph;
     self.mapView.debugMask = currentState.debugMask;
-    self.debugLoggingEnabled = currentState.debugLoggingEnabled;
     self.reuseQueueStatsEnabled = currentState.reuseQueueStatsEnabled;
 
     self.currentState = currentState;

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2425,7 +2425,7 @@ public:
     NSString *message;
     NSString *participateTitle;
     NSString *declineTitle;
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"MGLMapboxMetricsEnabled"])
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:MGLMapboxMetricsEnabledKey])
     {
         message = NSLocalizedStringWithDefaultValue(@"TELEMETRY_ENABLED_MSG", nil, nil, @"You are helping to make OpenStreetMap and Mapbox maps better by contributing anonymous usage data.", @"Telemetry prompt message");
         participateTitle = NSLocalizedStringWithDefaultValue(@"TELEMETRY_ENABLED_ON", nil, nil, @"Keep Participating", @"Telemetry prompt button");
@@ -2453,14 +2453,14 @@ public:
     UIAlertAction *declineAction = [UIAlertAction actionWithTitle:declineTitle
                                                             style:UIAlertActionStyleDefault
                                                           handler:^(UIAlertAction * _Nonnull action) {
-        [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"MGLMapboxMetricsEnabled"];
+        [[NSUserDefaults standardUserDefaults] setBool:NO forKey:MGLMapboxMetricsEnabledKey];
     }];
     [alertController addAction:declineAction];
     
     UIAlertAction *participateAction = [UIAlertAction actionWithTitle:participateTitle
                                                                 style:UIAlertActionStyleCancel
                                                               handler:^(UIAlertAction * _Nonnull action) {
-        [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"MGLMapboxMetricsEnabled"];
+        [[NSUserDefaults standardUserDefaults] setBool:YES forKey:MGLMapboxMetricsEnabledKey];
     }];
     [alertController addAction:participateAction];
     

--- a/platform/ios/src/MGLMapboxEvents.h
+++ b/platform/ios/src/MGLMapboxEvents.h
@@ -3,6 +3,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// NSUserDefaults key that controls telemetry user opt-out status
+FOUNDATION_EXTERN NSString * const MGLMapboxMetricsEnabledKey;
+
 @interface MGLMapboxEvents : NSObject 
 
 + (nullable instancetype)sharedInstance;


### PR DESCRIPTION
- Renames a bunch of `NSUserDefaults`/`Info.plist` key variable names to better indicate their purpose. (Note: this does **not** change the underlying key names, since that would break compatibility — this is purely a refactor.)
- Replaces remaining uses of raw strings as key names.
- Removes obsolete telemetry logging options from iosapp, since these have been superseded by the standalone events library.

/cc @jmkiley @captainbarbosa @julianrex 