### PR TITLE
[ios] Fix integration tests failing on iOS 9 

### DIFF
--- a/platform/ios/Integration Tests/Annotation Tests/MGLAnnotationViewIntegrationTests.mm
+++ b/platform/ios/Integration Tests/Annotation Tests/MGLAnnotationViewIntegrationTests.mm
@@ -801,6 +801,7 @@ static const CGPoint kAnnotationRelativeScale = { 0.05f, 0.125f };
 - (void)waitForCollisionDetectionToRun {
     XCTAssertNil(self.renderFinishedExpectation, @"Incorrect test setup");
 
+    [self.mapView setNeedsRerender];
     self.renderFinishedExpectation = [self expectationWithDescription:@"Map view should be rendered"];
     XCTestExpectation *timerExpired = [self expectationWithDescription:@"Timer expires"];
 

--- a/platform/ios/Integration Tests/MGLMapViewIntegrationTest.h
+++ b/platform/ios/Integration Tests/MGLMapViewIntegrationTest.h
@@ -26,6 +26,7 @@
 
 @interface MGLMapViewIntegrationTest : XCTestCase <MGLMapViewDelegate>
 @property (nonatomic) MGLMapView *mapView;
+@property (nonatomic) UIWindow *window;
 @property (nonatomic) MGLStyle *style;
 @property (nonatomic) XCTestExpectation *styleLoadingExpectation;
 @property (nonatomic) XCTestExpectation *renderFinishedExpectation;

--- a/platform/ios/Integration Tests/MGLMapViewIntegrationTest.m
+++ b/platform/ios/Integration Tests/MGLMapViewIntegrationTest.m
@@ -44,9 +44,9 @@
 
     UIView *superView = [[UIView alloc] initWithFrame:UIScreen.mainScreen.bounds];
     [superView addSubview:self.mapView];
-    UIWindow *window = [[UIWindow alloc] initWithFrame:UIScreen.mainScreen.bounds];
-    [window addSubview:superView];
-    [window makeKeyAndVisible];
+    self.window = [[UIWindow alloc] initWithFrame:UIScreen.mainScreen.bounds];
+    [self.window addSubview:superView];
+    [self.window makeKeyAndVisible];
 
     if (!self.mapView.style) {
         [self waitForMapViewToFinishLoadingStyleWithTimeout:10];
@@ -58,6 +58,7 @@
     self.renderFinishedExpectation = nil;
     self.mapView = nil;
     self.style = nil;
+    self.window = nil;
     [MGLAccountManager setAccessToken:nil];
 
     [super tearDown];
@@ -137,6 +138,7 @@
     [self.mapView setNeedsRerender];
     self.renderFinishedExpectation = [self expectationWithDescription:@"Map view should be rendered"];
     [self waitForExpectations:@[self.renderFinishedExpectation] timeout:timeout];
+    self.renderFinishedExpectation = nil;
 }
 
 - (void)waitForExpectations:(NSArray<XCTestExpectation *> *)expectations timeout:(NSTimeInterval)seconds {


### PR DESCRIPTION
This PR fixes #15256 and random failures.

- Test failures on iOS 9 - due to `UIWindow` deallocation - and map view display not being called.
- Random fails waiting for rendering (needed call to `setNeedsRerender`)