### PR TITLE
[core] Fix GeoJSON tiles update

### DIFF
--- a/src/mbgl/renderer/sources/render_geojson_source.cpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.cpp
@@ -94,7 +94,7 @@ void RenderGeoJSONSource::update(Immutable<style::Source::Impl> baseImpl_,
             const uint8_t maxZ = impl().getZoomRange().max;
             for (const auto& pair : tilePyramid.getTiles()) {
                 if (pair.first.canonical.z <= maxZ) {
-                    static_cast<GeoJSONTile*>(pair.second.get())->updateData(data_->getTile(pair.first.canonical));
+                    static_cast<GeoJSONTile*>(pair.second.get())->updateData(data_->getTile(pair.first.canonical), needsRelayout);
                 }
             }
         }

--- a/src/mbgl/tile/geojson_tile.cpp
+++ b/src/mbgl/tile/geojson_tile.cpp
@@ -13,8 +13,8 @@ GeoJSONTile::GeoJSONTile(const OverscaledTileID& overscaledTileID,
     updateData(std::move(features));
 }
 
-void GeoJSONTile::updateData(mapbox::feature::feature_collection<int16_t> features) {
-    setData(std::make_unique<GeoJSONTileData>(std::move(features)));
+void GeoJSONTile::updateData(mapbox::feature::feature_collection<int16_t> features, bool resetLayers) {
+    setData(std::make_unique<GeoJSONTileData>(std::move(features)), resetLayers);
 }
 
 void GeoJSONTile::querySourceFeatures(

--- a/src/mbgl/tile/geojson_tile.hpp
+++ b/src/mbgl/tile/geojson_tile.hpp
@@ -14,7 +14,7 @@ public:
                 const TileParameters&,
                 mapbox::feature::feature_collection<int16_t>);
 
-    void updateData(mapbox::feature::feature_collection<int16_t>);
+    void updateData(mapbox::feature::feature_collection<int16_t>, bool resetLayers = false);
 
     void querySourceFeatures(
         std::vector<Feature>& result,

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -176,13 +176,13 @@ void GeometryTile::setError(std::exception_ptr err) {
     observer->onTileError(*this, err);
 }
 
-void GeometryTile::setData(std::unique_ptr<const GeometryTileData> data_) {
+void GeometryTile::setData(std::unique_ptr<const GeometryTileData> data_, bool resetLayers) {
     // Mark the tile as pending again if it was complete before to prevent signaling a complete
     // state despite pending parse operations.
     pending = true;
 
     ++correlationID;
-    worker.self().invoke(&GeometryTileWorker::setData, std::move(data_), correlationID);
+    worker.self().invoke(&GeometryTileWorker::setData, std::move(data_), resetLayers, correlationID);
 }
 
 std::unique_ptr<TileRenderData> GeometryTile::createRenderData() {

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -34,7 +34,7 @@ public:
     ~GeometryTile() override;
 
     void setError(std::exception_ptr);
-    void setData(std::unique_ptr<const GeometryTileData>);
+    void setData(std::unique_ptr<const GeometryTileData>, bool resetLayers = false);
 
     std::unique_ptr<TileRenderData> createRenderData() override;
     void setLayers(const std::vector<Immutable<style::LayerProperties>>&) override;

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -117,10 +117,11 @@ GeometryTileWorker::~GeometryTileWorker() = default;
    completed parse.
 */
 
-void GeometryTileWorker::setData(std::unique_ptr<const GeometryTileData> data_, uint64_t correlationID_) {
+void GeometryTileWorker::setData(std::unique_ptr<const GeometryTileData> data_, bool resetLayers_, uint64_t correlationID_) {
     try {
         data = std::move(data_);
         correlationID = correlationID_;
+        if (resetLayers_) layers = nullopt;
 
         switch (state) {
         case Idle:

--- a/src/mbgl/tile/geometry_tile_worker.hpp
+++ b/src/mbgl/tile/geometry_tile_worker.hpp
@@ -39,7 +39,7 @@ public:
     ~GeometryTileWorker();
 
     void setLayers(std::vector<Immutable<style::LayerProperties>>, uint64_t correlationID);
-    void setData(std::unique_ptr<const GeometryTileData>, uint64_t correlationID);
+    void setData(std::unique_ptr<const GeometryTileData>, bool resetLayers, uint64_t correlationID);
     void setShowCollisionBoxes(bool showCollisionBoxes_, uint64_t correlationID_);
     
     void onGlyphsAvailable(GlyphMap glyphs);


### PR DESCRIPTION
Before this change, GeoJSON tiles data were updated before the
corresponding layers were applied, therefore `GeometryTileWorker`
parsed new data with the outdated layers.

It caused the following render test failure:

`mbgl-render-test text-max-width/unlimited regressions/mapbox-gl-native#9976 --recycle-map`

Now a GeoJSON tile, which needs re-layout, is not parsed until the valid layers
are set.

Fixes #15420