### PR TITLE
Update snapshot version number to 8.4.0

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/gradle.properties
+++ b/platform/android/MapboxGLAndroidSDK/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=8.3.0-SNAPSHOT
+VERSION_NAME=8.4.0-SNAPSHOT
 
 # Only build native dependencies for the current ABI
 # See https://code.google.com/p/android/issues/detail?id=221098#c20


### PR DESCRIPTION
[release-queso](https://github.com/mapbox/mapbox-gl-native/tree/release-queso) branch was cut, time to prepare master for `release-ristretto`. 