### PR TITLE
[meta] Add auto-labeling GitHub action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,39 @@
+android:
+- platform/android/**/*
+
+core:
+- platform/default/**/*
+- src/**/*
+- test/**/*
+- vendor/**/*
+
+documentation:
+- ./**/*.md
+- ./**/*.md.ejs
+- platform/**/docs/**/*
+
+ios:
+- platform/ios/**/*
+- platform/darwin/**/*
+
+linux:
+- platform/linux/**/*
+
+macos:
+- platform/macos/**/*
+- platform/darwin/**/*
+
+node.js:
+- platform/node/**/*
+
+offline:
+- platform/android/src/offline/**/*
+- platform/default/mbgl/storage/offline*
+- include/mbgl/storage/offline*
+
+qt:
+- platform/qt/**/*
+
+telemetry:
+- platform/android/MapboxGLAndroidSDK/**/telemetry/**/*
+- platform/ios/vendor/mapbox-events-ios/**/*

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,12 @@
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Fixes #15235 by adding the [labeler](https://github.com/actions/labeler) GitHub action to this repo, which effectively runs as a CI job and labels pull requests based on file paths.

GitHub actions are in public beta right now and I’m not sure how effective we’ll find the default labeler, but this should be an interesting thing to try out.

/cc @mapbox/maps-ios @mapbox/maps-android @mapbox/gl-native