### PR TITLE
[core] Fill layer pattern change must cause re-layout

### DIFF
--- a/src/mbgl/style/layers/fill_layer_impl.cpp
+++ b/src/mbgl/style/layers/fill_layer_impl.cpp
@@ -8,6 +8,7 @@ bool FillLayer::Impl::hasLayoutDifference(const Layer::Impl& other) const {
     const auto& impl = static_cast<const style::FillLayer::Impl&>(other);
     return filter     != impl.filter ||
            visibility != impl.visibility ||
+           paint.get<FillPattern>().value != impl.paint.get<FillPattern>().value ||
            paint.hasDataDrivenPropertyDifference(impl.paint);
 }
 


### PR DESCRIPTION
Otherwise, pattern properties update is not taken in action.
This caused the following render tests failure:
`build/mbgl-render-test runtime-styling/layer-add-fill regressions/mapbox-gl-js#3107 --recycle-map`