### PR TITLE
[test runner] Introduce API to measure memory usage

### DIFF
--- a/cmake/render-test.cmake
+++ b/cmake/render-test.cmake
@@ -1,4 +1,5 @@
 add_executable(mbgl-render-test
+    render-test/allocation_index.cpp
     render-test/main.cpp
     render-test/parser.cpp
     render-test/runner.cpp

--- a/render-test/allocation_index.cpp
+++ b/render-test/allocation_index.cpp
@@ -9,6 +9,7 @@
 namespace {
 
 std::atomic_size_t indexedMemorySize{0};
+std::atomic_size_t indexedMemoryPeak{0};
 std::atomic_size_t allocationsCount{0};
 std::unordered_map<void*, size_t> memoryIndex;
 std::atomic_bool suppresIndexing{false};
@@ -30,6 +31,7 @@ void addToIndex(std::size_t sz, void* ptr) {
     FlagGuard flk(suppresIndexing);
     allocationsCount++;
     indexedMemorySize += sz;
+    if (indexedMemoryPeak < indexedMemorySize) indexedMemoryPeak = size_t(indexedMemorySize);
     memoryIndex[ptr] = sz;
 }
 
@@ -67,6 +69,7 @@ void AllocationIndex::reset() {
     memoryIndex.clear();
     indexedMemorySize = 0;
     allocationsCount = 0;
+    indexedMemoryPeak = 0;
 }
 
 // static
@@ -90,4 +93,9 @@ size_t AllocationIndex::getAllocatedSize() {
 // static
 size_t AllocationIndex::getAllocationsCount() {
     return allocationsCount;
+}
+
+// static
+size_t AllocationIndex::getAllocatedSizePeak() {
+    return indexedMemoryPeak;
 }

--- a/render-test/allocation_index.cpp
+++ b/render-test/allocation_index.cpp
@@ -1,0 +1,93 @@
+#include "allocation_index.hpp"
+
+#include <atomic>
+#include <cassert>
+#include <cstdlib>
+#include <mutex>
+#include <unordered_map>
+
+namespace {
+
+std::atomic_size_t indexedMemorySize{0};
+std::atomic_size_t allocationsCount{0};
+std::unordered_map<void*, size_t> memoryIndex;
+std::atomic_bool suppresIndexing{false};
+std::atomic_bool active{false};
+std::mutex indexMutex;
+
+class FlagGuard {
+public:
+    explicit FlagGuard(std::atomic_bool& flag_)
+        : flag(flag_) { flag = true; }
+    ~FlagGuard() { flag = false; }
+
+private:
+    std::atomic_bool& flag;
+};
+
+void addToIndex(std::size_t sz, void* ptr) {
+    std::lock_guard<std::mutex> mlk(indexMutex);
+    FlagGuard flk(suppresIndexing);
+    allocationsCount++;
+    indexedMemorySize += sz;
+    memoryIndex[ptr] = sz;
+}
+
+void removeFromIndex(void* ptr) {
+    std::lock_guard<std::mutex> mlk(indexMutex);
+    FlagGuard flk(suppresIndexing);
+    auto it = memoryIndex.find(ptr);
+    if (it == memoryIndex.end()) return;
+
+    assert(indexedMemorySize >= it->second);
+    indexedMemorySize -= it->second;
+    memoryIndex.erase(it);
+}
+
+inline bool canModifyIndex() {
+    return active && !suppresIndexing;
+}
+
+} // namespace
+
+// static
+void AllocationIndex::setActive(bool active_) {
+    active = active_;
+}
+
+// static
+bool AllocationIndex::isActive() {
+    return active;
+}
+
+// static
+void AllocationIndex::reset() {
+    std::lock_guard<std::mutex> mlk(indexMutex);
+    FlagGuard flk(suppresIndexing);
+    memoryIndex.clear();
+    indexedMemorySize = 0;
+    allocationsCount = 0;
+}
+
+// static
+void* AllocationIndex::allocate(size_t size) {
+    void *ptr = std::malloc(size);
+    if (ptr && canModifyIndex()) addToIndex(size, ptr);
+    return ptr;
+}
+
+// static
+void AllocationIndex::deallocate(void* ptr) noexcept {
+    if (canModifyIndex()) removeFromIndex(ptr);
+    std::free(ptr);
+}
+
+// static
+size_t AllocationIndex::getAllocatedSize() {
+    return indexedMemorySize;
+}
+
+// static
+size_t AllocationIndex::getAllocationsCount() {
+    return allocationsCount;
+}

--- a/render-test/allocation_index.hpp
+++ b/render-test/allocation_index.hpp
@@ -43,4 +43,11 @@ public:
      * @return size_t 
      */
     static size_t getAllocationsCount();
+
+    /**
+     * @brief Returns the maximum size (in bytes) of the allocated data in the index, since last `reset()` call.
+     * 
+     * @return size_t 
+     */
+    static size_t getAllocatedSizePeak();
 };

--- a/render-test/allocation_index.hpp
+++ b/render-test/allocation_index.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <cstddef>
+
+class AllocationIndex {
+public:
+    AllocationIndex() = delete;
+    /**
+     * @brief Starts/stops allocated memory indexing.
+     */
+    static void setActive(bool);
+    /**
+     * @brief Returns memory indexing activity status.
+     */
+    static bool isActive();
+    /**
+     * @brief Resets the allocated memory index and all statistics data.
+     */
+    static void reset();
+    /**
+     * @brief Same as `malloc()` + indexes the allocated data,
+     * if indexing is active.
+     * 
+     * @return void* 
+     */
+    static void* allocate(size_t);
+    /**
+     * @brief Same as `free()` + removes the corresponding data from index,
+     * if these data are present in the index and indexing is active.
+     * 
+     * @return void* 
+     */
+    static void deallocate(void*) noexcept;
+    /**
+     * @brief Returns the size (in bytes) of allocated data, currently present in the index.
+     * 
+     * @return size_t
+     */
+    static size_t getAllocatedSize();
+    /**
+     * @brief Returns the total amount of allocations since indexing start.
+     * 
+     * @return size_t 
+     */
+    static size_t getAllocationsCount();
+};

--- a/render-test/main.cpp
+++ b/render-test/main.cpp
@@ -1,3 +1,5 @@
+#include "allocation_index.hpp"
+
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/util/io.hpp>
 
@@ -18,6 +20,21 @@
 #define ANSI_COLOR_GRAY       "\x1b[37m"
 #define ANSI_COLOR_LIGHT_GRAY "\x1b[90m"
 #define ANSI_COLOR_RESET      "\x1b[0m"
+
+void* operator new(std::size_t sz) {
+    void* ptr = AllocationIndex::allocate(sz);
+    if (!ptr) throw std::bad_alloc{};
+
+    return ptr;
+}
+
+void operator delete(void* ptr) noexcept {
+    AllocationIndex::deallocate(ptr);
+}
+
+void operator delete(void* ptr, size_t) noexcept {
+    AllocationIndex::deallocate(ptr);
+}
 
 namespace {
 

--- a/render-test/main.cpp
+++ b/render-test/main.cpp
@@ -125,7 +125,7 @@ int main(int argc, char** argv) {
 
         bool errored = !metadata.errorMessage.empty();
         if (!errored) {
-            errored = runner.run(metadata) && !metadata.errorMessage.empty();
+            errored = !runner.run(metadata) || !metadata.errorMessage.empty();
         }
 
         bool passed = !errored && !metadata.diff.empty() && metadata.difference <= metadata.allowed;

--- a/render-test/metadata.hpp
+++ b/render-test/metadata.hpp
@@ -7,6 +7,8 @@
 
 #include "filesystem.hpp"
 
+#include <map>
+
 struct TestStatistics {
     TestStatistics() = default;
 
@@ -25,6 +27,16 @@ struct TestPaths {
         assert(!expectations.empty());
         return expectations.front().string();
     }
+};
+
+struct MemoryProbe {
+    MemoryProbe() = default;
+    MemoryProbe(size_t size_, size_t allocations_)
+        : size(size_)
+        , allocations(allocations_) {}
+
+    size_t size;
+    size_t allocations;
 };
 
 struct TestMetadata {
@@ -59,4 +71,6 @@ struct TestMetadata {
 
     std::string errorMessage;
     double difference = 0.0;
+
+    std::map<std::string, MemoryProbe> memoryProbes; 
 };

--- a/render-test/metadata.hpp
+++ b/render-test/metadata.hpp
@@ -39,6 +39,12 @@ struct MemoryProbe {
     size_t allocations;
 };
 
+class TestMetrics {
+public:
+    bool isEmpty() const { return memory.empty(); }
+    std::map<std::string, MemoryProbe> memory;
+};
+
 struct TestMetadata {
     TestMetadata() = default;
 
@@ -72,5 +78,6 @@ struct TestMetadata {
     std::string errorMessage;
     double difference = 0.0;
 
-    std::map<std::string, MemoryProbe> memoryProbes; 
+    TestMetrics metrics;
+    TestMetrics expectedMetrics;
 };

--- a/render-test/metadata.hpp
+++ b/render-test/metadata.hpp
@@ -31,11 +31,11 @@ struct TestPaths {
 
 struct MemoryProbe {
     MemoryProbe() = default;
-    MemoryProbe(size_t size_, size_t allocations_)
-        : size(size_)
+    MemoryProbe(size_t peak_, size_t allocations_)
+        : peak(peak_)
         , allocations(allocations_) {}
 
-    size_t size;
+    size_t peak;
     size_t allocations;
 };
 

--- a/render-test/parser.cpp
+++ b/render-test/parser.cpp
@@ -199,7 +199,7 @@ std::string serializeMetrics(const TestMetrics& metrics) {
         assert(!memoryProbe.first.empty());       
         writer.StartArray();
         writer.String(memoryProbe.first.c_str());
-        writer.Uint64(memoryProbe.second.size);
+        writer.Uint64(memoryProbe.second.peak);
         writer.Uint64(memoryProbe.second.allocations);
         writer.EndArray();
     }

--- a/render-test/parser.hpp
+++ b/render-test/parser.hpp
@@ -1,17 +1,13 @@
 #pragma once
 
+#include "metadata.hpp"
+
 #include <mbgl/util/rapidjson.hpp>
 #include <mbgl/util/variant.hpp>
 
 #include <tuple>
 #include <string>
 #include <vector>
-
-#include "filesystem.hpp"
-
-struct TestMetadata;
-struct TestStatistics;
-struct TestPaths;
 
 using ErrorMessage = std::string;
 using JSONReply = mbgl::variant<mbgl::JSDocument, ErrorMessage>;
@@ -20,8 +16,11 @@ using ArgumentsTuple = std::tuple<bool, bool, uint32_t, std::string, std::vector
 
 JSONReply readJson(const mbgl::filesystem::path&);
 std::string serializeJsonValue(const mbgl::JSValue&);
+std::string serializeMetrics(const TestMetrics&);
 
 std::vector<std::string> readExpectedEntries(const mbgl::filesystem::path& base);
+
+TestMetrics readExpectedMetrics(const mbgl::filesystem::path& path);
 
 ArgumentsTuple parseArguments(int argc, char** argv);
 std::vector<std::pair<std::string, std::string>> parseIgnores();

--- a/render-test/runner.cpp
+++ b/render-test/runner.cpp
@@ -131,10 +131,10 @@ bool TestRunner::checkResults(mbgl::PremultipliedImage&& actualImage, TestMetada
             metadata.errorMessage = "Failed to find memory probe: " + expected.first;
             return false;
         }
-        if (actual->second.size > expected.second.size) {
+        if (actual->second.peak > expected.second.peak) {
             std::stringstream ss;
-            ss << "Allocated size at memory probe \" " << expected.first << "\" is "
-               << actual->second.size << " bytes, expected is " << expected.second.size << " bytes.";
+            ss << "Allocated memory peak size at probe \"" << expected.first << "\" is "
+               << actual->second.peak << " bytes, expected is " << expected.second.peak << " bytes.";
 
             metadata.errorMessage = ss.str();
             return false;
@@ -142,7 +142,7 @@ bool TestRunner::checkResults(mbgl::PremultipliedImage&& actualImage, TestMetada
 
         if (actual->second.allocations > expected.second.allocations) {
             std::stringstream ss;
-            ss << "Number of allocations at memory probe \" " << expected.first << "\" is "
+            ss << "Number of allocations at probe \"" << expected.first << "\" is "
                << actual->second.allocations << ", expected is " << expected.second.allocations << ".";
 
             metadata.errorMessage = ss.str();
@@ -447,7 +447,7 @@ bool TestRunner::runOperations(const std::string& key, TestMetadata& metadata) {
 
         metadata.metrics.memory.emplace(std::piecewise_construct,
                                         std::forward_as_tuple(std::move(mark)), 
-                                        std::forward_as_tuple(AllocationIndex::getAllocatedSize(), AllocationIndex::getAllocationsCount()));
+                                        std::forward_as_tuple(AllocationIndex::getAllocatedSizePeak(), AllocationIndex::getAllocationsCount()));
     // probeMemoryEnd
     } else if (operationArray[0].GetString() == memoryProbeEndOp) {
         assert(AllocationIndex::isActive());

--- a/render-test/runner.hpp
+++ b/render-test/runner.hpp
@@ -21,7 +21,7 @@ public:
 
 private:
     bool runOperations(const std::string& key, TestMetadata&);
-    bool checkImage(mbgl::PremultipliedImage&& image, TestMetadata&);
+    bool checkResults(mbgl::PremultipliedImage&& image, TestMetadata&);
 
     struct Impl {
         Impl(const TestMetadata&);


### PR DESCRIPTION
Before peeking the proposed approach, other approaches have been tried out (e.g. various memory stats system APIs like `getrusage()`, `malloc_info()`,  `/proc/self/stat`), but unfortunately, none of them gave stable results on repeated tests runs.
- [x]  Introduce memory allocation index
- [x]  Override global new/delete operators
- [x]  Introduce `probe_memory_..` API for render tests
- [x]  Generate reports in JSON format
- [x]  Introduce baseline, check passing

Example usage (zoom-visibility/below):
```
      "operations": [
        [ "wait" ],
        [ "probeMemoryStart" ],
        [ "probeMemory", "start" ],
        [
          "setZoom",
          0.9
        ],
        [
          "wait"
        ],
        [ "probeMemory", "after setZoom 0.9" ],
        [
          "setLayerZoomRange",
          "circle",
          1,
          2
        ],
        [
          "wait"
        ],
        [ "probeMemory", "end" ],
        [ "probeMemoryEnd" ]
      ]
```


cc @tmpsantos 