### PR TITLE
[ios, build] Verify s3 upload integrity during deployment

### DIFF
--- a/platform/ios/scripts/deploy-packages.sh
+++ b/platform/ios/scripts/deploy-packages.sh
@@ -7,12 +7,10 @@ set -u
 # dynamic environment variables:
 #     VERSION_TAG={determined automatically}: Version tag in format ios-vX.X.X-pre.X
 #     GITHUB_RELEASE=true: Upload to github
-#     BINARY_DIRECTORY=build/ios/deploy: Directory in which to save test packages
 
 # environment variables and dependencies:
 #     - You must run "mbx auth ..." before running
 #     - Set GITHUB_TOKEN to a GitHub API access token in your environment to use GITHUB_RELEASE
-#     - "wget" is required for downloading the zip files from s3
 #     - The "github-release" command is required to use GITHUB_RELEASE
 
 function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
@@ -36,8 +34,6 @@ buildPackageStyle() {
         ./platform/ios/scripts/publish.sh "${PUBLISH_VERSION}" ${style}
         file_name=mapbox-ios-sdk-${PUBLISH_VERSION}-${style}.zip
     fi
-    step "Downloading ${file_name} from s3 to ${BINARY_DIRECTORY}"
-    wget -O ${BINARY_DIRECTORY}/${file_name} http://mapbox.s3.amazonaws.com/mapbox-gl-native/ios/builds/${file_name}
     if [[ "${GITHUB_RELEASE}" == true ]]; then
         step "Uploading ${file_name} to GitHub"
         github-release upload \
@@ -54,7 +50,7 @@ export BUILDTYPE=Release
 
 VERSION_TAG=${VERSION_TAG:-''}
 PUBLISH_VERSION=
-BINARY_DIRECTORY=${BINARY_DIRECTORY:-build/ios/deploy}
+BINARY_DIRECTORY='build/ios'
 GITHUB_RELEASE=${GITHUB_RELEASE:-true}
 PUBLISH_PRE_FLAG=''
 

--- a/platform/ios/scripts/install-packaging-dependencies.sh
+++ b/platform/ios/scripts/install-packaging-dependencies.sh
@@ -22,15 +22,6 @@ else
 fi
 
 ##
-## wget
-##
-if [ -z `which wget` ]; then
-    brew install wget
-else
-    echo "Found brew"
-fi
-
-##
 ## cocoapods
 ##
 if [[ -z `which pod` || $(pod --version) != "${COCOAPODS_VERSION}" ]]; then

--- a/platform/ios/scripts/publish.sh
+++ b/platform/ios/scripts/publish.sh
@@ -24,18 +24,19 @@ GITHUB_REPO=${GITHUB_REPO:-'mapbox-gl-native'}
 # zip
 #
 cd build/ios/pkg
-SNAPSHOT_FILENAME="mapbox-ios-sdk-${PUBLISH_VERSION}${PUBLISH_STYLE}.zip"
-step "Compressing ${SNAPSHOT_FILENAME}…"
-rm -f ../${SNAPSHOT_FILENAME}
-zip -yr ../${SNAPSHOT_FILENAME} *
+ZIP_FILENAME="mapbox-ios-sdk-${PUBLISH_VERSION}${PUBLISH_STYLE}.zip"
+step "Compressing ${ZIP_FILENAME}…"
+rm -f ../${ZIP_FILENAME}
+zip -yr ../${ZIP_FILENAME} *
+cd ..
 
 #
 # report file sizes
 #
 step "Echoing file sizes…"
-du -sh ../${SNAPSHOT_FILENAME}
-du -sch *
-du -sch dynamic/*
+du -sh ${ZIP_FILENAME}
+du -sch pkg/*
+du -sch pkg/dynamic/*
 
 #
 # upload
@@ -45,17 +46,34 @@ if [ -n "${CI:-}" ]; then
     PROGRESS="--no-progress"
 fi
 
-step "Uploading ${SNAPSHOT_FILENAME} to s3…"
-aws s3 cp ../${SNAPSHOT_FILENAME} s3://mapbox/$GITHUB_REPO/ios/builds/ --acl public-read ${PROGRESS}
-echo "URL: https://mapbox.s3.amazonaws.com/$GITHUB_REPO/ios/builds/${SNAPSHOT_FILENAME}"
+step "Uploading ${ZIP_FILENAME} to s3…"
+aws s3 cp ${ZIP_FILENAME} s3://mapbox/${GITHUB_REPO}/ios/builds/ --acl public-read ${PROGRESS}
+S3_URL=https://mapbox.s3.amazonaws.com/${GITHUB_REPO}/ios/builds/${ZIP_FILENAME}
+echo "URL: ${S3_URL}"
 
 #
 # upload & update snapshot
 #
 if [[ ${PUBLISH_VERSION} =~ "snapshot" ]]; then
     step "Updating ${PUBLISH_VERSION} to ${PUBLISH_STYLE}…"
-    GENERIC_SNAPSHOT_FILENAME="mapbox-ios-sdk-${PUBLISH_VERSION}.zip"
+    GENERIC_ZIP_FILENAME="mapbox-ios-sdk-${PUBLISH_VERSION}.zip"
     aws s3 cp \
-        s3://mapbox/$GITHUB_REPO/ios/builds/${SNAPSHOT_FILENAME} \
-        s3://mapbox/$GITHUB_REPO/ios/builds/${GENERIC_SNAPSHOT_FILENAME} --acl public-read ${PROGRESS}
+        s3://mapbox/$GITHUB_REPO/ios/builds/${ZIP_FILENAME} \
+        s3://mapbox/$GITHUB_REPO/ios/builds/${GENERIC_ZIP_FILENAME} --acl public-read ${PROGRESS}
+fi
+
+#
+# verify upload integrity
+#
+
+step "Validating local and remote checksums…"
+curl --output remote-${ZIP_FILENAME} ${S3_URL}
+LOCAL_CHECKSUM=$( shasum -a 256 -b ${ZIP_FILENAME} | cut -d ' ' -f 1 )
+REMOTE_CHECKSUM=$( shasum -a 256 -b remote-${ZIP_FILENAME} | cut -d ' ' -f 1 )
+
+if [ "${LOCAL_CHECKSUM}" == "${REMOTE_CHECKSUM}" ]; then
+    echo "Checksums match: ${LOCAL_CHECKSUM}"
+else
+    echo "Checksums did not match: ${LOCAL_CHECKSUM} != ${REMOTE_CHECKSUM}"
+    exit 1
 fi


### PR DESCRIPTION
- Stops the (somewhat strange) process of downloading the s3 package, then uploading it to GitHub. Instead, just upload the local package.
- Downloads package uploaded to s3 and checks its hash against the local original.
  - [Technically this appears to already happen](https://docs.aws.amazon.com/cli/latest/topic/s3-faq.html), but who trusts only doing a thing once?! In any case, we’re also checking that the file is available at the expected URL and having the checksum saved may be useful in the future.
- Removes now-unused `wget` dependency.

/cc @springmeyer @julianrex 