### PR TITLE
[ios] Add custom XCTestSuite for integration tests

### DIFF
--- a/platform/ios/Integration Tests/Camera Tests/MGLCameraTransitionTests.mm
+++ b/platform/ios/Integration Tests/Camera Tests/MGLCameraTransitionTests.mm
@@ -333,7 +333,7 @@
 
 #pragma mark - Pending tests
 
-- (void)testContinuallyResettingNorthInIsChangingPENDING {
+- (void)testContinuallyResettingNorthInIsChanging🙁{
     // See https://github.com/mapbox/mapbox-gl-native/pull/11614
     // This test currently fails, unsurprisingly, since we're continually
     // setting the camera to the same parameters during its update.
@@ -365,8 +365,8 @@
     XCTAssertEqualWithAccuracy(self.mapView.direction, 0.0, 0.001, @"Camera should have reset to north. %0.3f", self.mapView.direction);
 }
 
-- (void)testContinuallySettingCoordinateInIsChangingPENDING {
-    // See above comment in `-testContinuallyResettingNorthInIsChangingPENDING`
+- (void)testContinuallySettingCoordinateInIsChanging🙁 {
+    // See above comment in `-testContinuallyResettingNorthInIsChanging🙁`
 
     // Reset to non-zero, prior to testing
     [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(0.0, 0.0) animated:NO];

--- a/platform/ios/Integration Tests/MGLMapViewIntegrationTest.h
+++ b/platform/ios/Integration Tests/MGLMapViewIntegrationTest.h
@@ -25,6 +25,7 @@
 })
 
 @interface MGLMapViewIntegrationTest : XCTestCase <MGLMapViewDelegate>
+@property (nonatomic) NSString *accessToken;
 @property (nonatomic) MGLMapView *mapView;
 @property (nonatomic) UIWindow *window;
 @property (nonatomic) MGLStyle *style;
@@ -39,7 +40,6 @@
 @property (nonatomic) id<MGLCalloutView> (^mapViewCalloutViewForAnnotation)(MGLMapView *mapView, id<MGLAnnotation> annotation);
 
 // Utility methods
-- (NSString*)validAccessToken;
 - (void)waitForMapViewToFinishLoadingStyleWithTimeout:(NSTimeInterval)timeout;
 - (void)waitForMapViewToBeRenderedWithTimeout:(NSTimeInterval)timeout;
 - (MGLMapView *)mapViewForTestWithFrame:(CGRect)rect styleURL:(NSURL *)styleURL;

--- a/platform/ios/Integration Tests/MGLMapViewIntegrationTest.m
+++ b/platform/ios/Integration Tests/MGLMapViewIntegrationTest.m
@@ -7,30 +7,43 @@
 
 @implementation MGLMapViewIntegrationTest
 
-- (void)invokeTest {
-    NSString *selector = NSStringFromSelector(self.invocation.selector);
-    BOOL isPendingTest = [selector hasSuffix:@"PENDING"];
++ (XCTestSuite*)defaultTestSuite {
     
-    if (isPendingTest) {
-        NSString *runPendingTests = [[NSProcessInfo processInfo] environment][@"MAPBOX_RUN_PENDING_TESTS"];
-        if (![runPendingTests boolValue]) {
-            printf("warning: '%s' is a pending test - skipping\n", selector.UTF8String);
-            return;
-        }
-    }
-
-    [super invokeTest];
-}
-
-- (NSString*)validAccessToken {
+    XCTestSuite *defaultTestSuite = [super defaultTestSuite];
+    
+    NSArray *tests = defaultTestSuite.tests;
+ 
+    XCTestSuite *newTestSuite = [XCTestSuite testSuiteWithName:defaultTestSuite.name];
+    
+    BOOL runPendingTests = [[[NSProcessInfo processInfo] environment][@"MAPBOX_RUN_PENDING_TESTS"] boolValue];
     NSString *accessToken = [[NSProcessInfo processInfo] environment][@"MAPBOX_ACCESS_TOKEN"];
-    if (!accessToken) {
-        printf("warning: MAPBOX_ACCESS_TOKEN env var is required for this test - skipping.\n");
-        return nil;
-    }
+        
+    for (XCTest *test in tests) {
+        
+        // Check for pending tests
+        if ([test.name containsString:@"PENDING"] ||
+            [test.name containsString:@"🙁"]) {
+            if (!runPendingTests) {
+                printf("warning: '%s' is a pending test - skipping\n", test.name.UTF8String);
+                continue;
+            }
+        }
+        
+        // Check for tests that require a valid access token
+        if ([test.name containsString:@"🔒"]) {
+            if (accessToken) {
+                ((MGLMapViewIntegrationTest *)test).accessToken = accessToken;
+            }
+            else {
+                printf("warning: MAPBOX_ACCESS_TOKEN env var is required for test '%s' - skipping.\n", test.name.UTF8String);
+                continue;
+            }
+        }
 
-    [MGLAccountManager setAccessToken:accessToken];
-    return accessToken;
+        [newTestSuite addTest:test];
+    }
+    
+    return newTestSuite;
 }
 
 - (MGLMapView *)mapViewForTestWithFrame:(CGRect)rect styleURL:(NSURL *)styleURL {
@@ -40,7 +53,8 @@
 - (void)setUp {
     [super setUp];
 
-    [MGLAccountManager setAccessToken:@"pk.feedcafedeadbeefbadebede"];
+    [MGLAccountManager setAccessToken:self.accessToken ?: @"pk.feedcafedeadbeefbadebede"];
+    
     NSURL *styleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"one-liner" withExtension:@"json"];
 
     self.mapView = [self mapViewForTestWithFrame:UIScreen.mainScreen.bounds styleURL:styleURL];
@@ -135,6 +149,7 @@
     XCTAssertNil(self.styleLoadingExpectation);
     self.styleLoadingExpectation = [self expectationWithDescription:@"Map view should finish loading style."];
     [self waitForExpectations:@[self.styleLoadingExpectation] timeout:timeout];
+    self.styleLoadingExpectation = nil;
 }
 
 - (void)waitForMapViewToBeRenderedWithTimeout:(NSTimeInterval)timeout {

--- a/platform/ios/Integration Tests/MGLStyleURLIntegrationTest.m
+++ b/platform/ios/Integration Tests/MGLStyleURLIntegrationTest.m
@@ -6,36 +6,32 @@
 @implementation MGLStyleURLIntegrationTest
 
 - (void)internalTestWithStyleSelector:(SEL)selector {
-    if (![self validAccessToken]) {
-        return;
-    }
-
     self.mapView.styleURL = [MGLStyle performSelector:selector];
     [self waitForMapViewToFinishLoadingStyleWithTimeout:5];
 }
 
 
-- (void)testLoadingStreetsStyleURL {
+- (void)testLoadingStreetsStyleURL🔒 {
     [self internalTestWithStyleSelector:@selector(streetsStyleURL)];
 }
 
-- (void)testLoadingOutdoorsStyleURL {
+- (void)testLoadingOutdoorsStyleURL🔒 {
     [self internalTestWithStyleSelector:@selector(outdoorsStyleURL)];
 }
 
-- (void)testLoadingLightStyleURL {
+- (void)testLoadingLightStyleURL🔒 {
     [self internalTestWithStyleSelector:@selector(lightStyleURL)];
 }
 
-- (void)testLoadingDarkStyleURL {
+- (void)testLoadingDarkStyleURL🔒 {
     [self internalTestWithStyleSelector:@selector(darkStyleURL)];
 }
 
-- (void)testLoadingSatelliteStyleURL {
+- (void)testLoadingSatelliteStyleURL🔒 {
     [self internalTestWithStyleSelector:@selector(satelliteStyleURL)];
 }
 
-- (void)testLoadingSatelliteStreetsStyleURL {
+- (void)testLoadingSatelliteStreetsStyleURL🔒 {
     [self internalTestWithStyleSelector:@selector(satelliteStreetsStyleURL)];
 }
 

--- a/platform/ios/Integration Tests/Snapshotter Tests/MGLMapSnapshotterSwiftTests.swift
+++ b/platform/ios/Integration Tests/Snapshotter Tests/MGLMapSnapshotterSwiftTests.swift
@@ -15,12 +15,9 @@ class MGLMapSnapshotterSwiftTests: MGLMapViewIntegrationTest {
         return options
     }
 
-    func testCapturingSnapshotterInSnapshotCompletion() {
+    func testCapturingSnapshotterInSnapshotCompletion🔒() {
         // See the Obj-C testDeallocatingSnapshotterDuringSnapshot
         // This Swift test, is essentially the same except for capturing the snapshotter
-        guard validAccessToken() != nil else {
-            return
-        }
 
         let timeout: TimeInterval = 10.0
         let expectation = self.expectation(description: "snapshot")

--- a/platform/ios/Integration Tests/Snapshotter Tests/MGLMapSnapshotterTest.m
+++ b/platform/ios/Integration Tests/Snapshotter Tests/MGLMapSnapshotterTest.m
@@ -26,11 +26,7 @@ MGLMapSnapshotter* snapshotterWithCoordinates(CLLocationCoordinate2D coordinates
 
 @implementation MGLMapSnapshotterTest
 
-- (void)testMultipleSnapshotsWithASingleSnapshotter {
-    if (![self validAccessToken]) {
-        return;
-    }
-
+- (void)testMultipleSnapshotsWithASingleSnapshotter🔒 {
     CGSize size = self.mapView.bounds.size;
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"snapshots"];
@@ -60,11 +56,8 @@ MGLMapSnapshotter* snapshotterWithCoordinates(CLLocationCoordinate2D coordinates
     [self waitForExpectations:@[expectation] timeout:10.0];
 }
 
-- (void)testDeallocatingSnapshotterDuringSnapshot {
+- (void)testDeallocatingSnapshotterDuringSnapshot🔒 {
     // See also https://github.com/mapbox/mapbox-gl-native/issues/12336
-    if (![self validAccessToken]) {
-        return;
-    }
 
     NSTimeInterval timeout         = 10.0;
     XCTestExpectation *expectation = [self expectationWithDescription:@"snapshot"];
@@ -108,15 +101,11 @@ MGLMapSnapshotter* snapshotterWithCoordinates(CLLocationCoordinate2D coordinates
     [self waitForExpectations:@[expectation] timeout:timeout];
 }
 
-- (void)testSnapshotterUsingNestedDispatchQueues {
+- (void)testSnapshotterUsingNestedDispatchQueues🔒 {
     // This is the opposite pair to the above test `testDeallocatingSnapshotterDuringSnapshot`
     // The only significant difference is that the snapshotter is a `__block` variable, so
     // its lifetime should continue until it's set to nil in the completion block.
     // See also https://github.com/mapbox/mapbox-gl-native/issues/12336
-
-    if (![self validAccessToken]) {
-        return;
-    }
 
     NSTimeInterval timeout         = 10.0;
     XCTestExpectation *expectation = [self expectationWithDescription:@"snapshot"];
@@ -156,11 +145,7 @@ MGLMapSnapshotter* snapshotterWithCoordinates(CLLocationCoordinate2D coordinates
     [self waitForExpectations:@[expectation] timeout:timeout];
 }
 
-- (void)testCancellingSnapshot {
-    if (![self validAccessToken]) {
-        return;
-    }
-
+- (void)testCancellingSnapshot🔒 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"snapshots"];
     expectation.assertForOverFulfill = YES;
     expectation.expectedFulfillmentCount = 1;
@@ -189,11 +174,7 @@ MGLMapSnapshotter* snapshotterWithCoordinates(CLLocationCoordinate2D coordinates
     [self waitForExpectations:@[expectation] timeout:5.0];
 }
 
-- (void)testAllocatingSnapshotOnBackgroundQueue {
-    if (![self validAccessToken]) {
-        return;
-    }
-
+- (void)testAllocatingSnapshotOnBackgroundQueue🔒 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"snapshots"];
 
     CGSize size                  = self.mapView.bounds.size;
@@ -226,11 +207,7 @@ MGLMapSnapshotter* snapshotterWithCoordinates(CLLocationCoordinate2D coordinates
     [self waitForExpectations:@[expectation] timeout:2.0];
 }
 
-- (void)testSnapshotterFromBackgroundQueueShouldFail {
-    if (![self validAccessToken]) {
-        return;
-    }
-
+- (void)testSnapshotterFromBackgroundQueueShouldFail🔒 {
     CGSize size = self.mapView.bounds.size;
     CLLocationCoordinate2D coord = CLLocationCoordinate2DMake(30.0, 30.0);
 
@@ -281,12 +258,7 @@ MGLMapSnapshotter* snapshotterWithCoordinates(CLLocationCoordinate2D coordinates
     [self waitForExpectations:@[expectation] timeout:60.0];
 }
 
-- (void)testMultipleSnapshottersPENDING {
-
-    if (![self validAccessToken]) {
-        return;
-    }
-
+- (void)testMultipleSnapshotters🔒🙁 {
     NSUInteger numSnapshots = 8;
     CGSize size = self.mapView.bounds.size;
 
@@ -340,11 +312,7 @@ MGLMapSnapshotter* snapshotterWithCoordinates(CLLocationCoordinate2D coordinates
     [self waitForExpectations:@[expectation] timeout:60.0];
 }
 
-- (void)testSnapshotPointConversion {
-    if (![self validAccessToken]) {
-        return;
-    }
-
+- (void)testSnapshotPointConversion🔒 {
     CGSize size = self.mapView.bounds.size;
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"snapshot"];
@@ -382,11 +350,7 @@ MGLMapSnapshotter* snapshotterWithCoordinates(CLLocationCoordinate2D coordinates
     [self waitForExpectations:@[expectation] timeout:10.0];
 }
 
-- (void)testSnapshotPointConversionCoordinateOrdering {
-    if (![self validAccessToken]) {
-        return;
-    }
-
+- (void)testSnapshotPointConversionCoordinateOrdering🔒 {
     CGSize size = self.mapView.bounds.size;
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"snapshot"];


### PR DESCRIPTION
This PR adds a non-default `XCTestSuite` for `MGLMapViewIntegrationTest` based integration tests. This 

- removes the need for manually adding `validAccessToken` (which is removed) to tests that require an access token. Instead, add 🔒to the method name
- also skips "pending" tests - this adds the benefit of not adding a ✅ next to tests that are being skipped (whereas before it looked like they were passing).
