### PR TITLE
Ignore project wide gradle.properties file

### DIFF
--- a/platform/android/.gitignore
+++ b/platform/android/.gitignore
@@ -30,3 +30,5 @@ MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/acti
 # Input files for running render tests
 MapboxGLAndroidSDKTestApp/src/main/assets/integration/
 
+# Local AS configuration file
+gradle.properties


### PR DESCRIPTION
Android Studio v3.5.0 introduces fine grained memory control. Configurations for this are saved in a project wide `gradle.properties` file in the root of the android project:

```
## For more details on how to configure your build environment visit
# http://www.gradle.org/docs/current/userguide/build_environment.html
#
# Specifies the JVM arguments used for the daemon process.
# The setting is particularly useful for tweaking memory settings.
# Default value: -Xmx1024m -XX:MaxPermSize=256m
# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
#
# When configured, Gradle will run in incubating parallel mode.
# This option should only be used with decoupled projects. More details, visit
# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
# org.gradle.parallel=true
#Tue Aug 20 22:13:23 EEST 2019
org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
```
Since this configuration is developer specific and we aren't using the file for any other purpose. I'm proposing to ignore this file. 
