### PR TITLE
[core] Remove programCacheDir parameter from ProgramParameters

### DIFF
--- a/include/mbgl/renderer/renderer.hpp
+++ b/include/mbgl/renderer/renderer.hpp
@@ -24,7 +24,6 @@ class RendererBackend;
 class Renderer {
 public:
     Renderer(gfx::RendererBackend&, float pixelRatio_,
-             const optional<std::string> programCacheDir = {},
              const optional<std::string> localFontFamily = {});
     ~Renderer();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/MapRenderer.java
@@ -8,7 +8,6 @@ import android.support.annotation.NonNull;
 import com.mapbox.mapboxsdk.LibraryLoader;
 import com.mapbox.mapboxsdk.log.Logger;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.storage.FileSource;
 
 import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.opengles.GL10;
@@ -36,10 +35,9 @@ public abstract class MapRenderer implements MapRendererScheduler {
 
   public MapRenderer(@NonNull Context context, String localIdeographFontFamily) {
     float pixelRatio = context.getResources().getDisplayMetrics().density;
-    String programCacheDir = FileSource.getInternalCachePath(context);
 
     // Initialise native peer
-    nativeInitialize(this, pixelRatio, programCacheDir, localIdeographFontFamily);
+    nativeInitialize(this, pixelRatio, localIdeographFontFamily);
   }
 
   public void onStart() {
@@ -119,7 +117,6 @@ public abstract class MapRenderer implements MapRendererScheduler {
 
   private native void nativeInitialize(MapRenderer self,
                                        float pixelRatio,
-                                       String programCacheDir,
                                        String localIdeographFontFamily);
 
   @CallSuper

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
@@ -339,11 +339,9 @@ public class MapSnapshotter {
       fileSource.setApiBaseUrl(apiBaseUrl);
     }
 
-    String programCacheDir = FileSource.getInternalCachePath(context);
-
     nativeInitialize(this, fileSource, options.pixelRatio, options.width,
       options.height, options.styleUri, options.styleJson, options.region, options.cameraPosition,
-      options.showLogo, programCacheDir, options.localIdeographFontFamily);
+      options.showLogo, options.localIdeographFontFamily);
   }
 
   /**
@@ -625,8 +623,7 @@ public class MapSnapshotter {
                                          FileSource fileSource, float pixelRatio,
                                          int width, int height, String styleUrl, String styleJson,
                                          LatLngBounds region, CameraPosition position,
-                                         boolean showLogo, String programCacheDir,
-                                         String localIdeographFontFamily);
+                                         boolean showLogo, String localIdeographFontFamily);
 
   @Keep
   protected native void nativeStart();

--- a/platform/android/src/map_renderer.cpp
+++ b/platform/android/src/map_renderer.cpp
@@ -16,11 +16,9 @@ namespace android {
 MapRenderer::MapRenderer(jni::JNIEnv& _env,
                          const jni::Object<MapRenderer>& obj,
                          jni::jfloat pixelRatio_,
-                         const jni::String& programCacheDir_,
                          const jni::String& localIdeographFontFamily_)
         : javaPeer(_env, obj)
         , pixelRatio(pixelRatio_)
-        , programCacheDir(jni::Make<std::string>(_env, programCacheDir_))
         , localIdeographFontFamily(localIdeographFontFamily_ ? jni::Make<std::string>(_env, localIdeographFontFamily_) : optional<std::string>{})
         , mailbox(std::make_shared<Mailbox>(*this)) {
 }
@@ -173,7 +171,7 @@ void MapRenderer::onSurfaceCreated(JNIEnv&) {
 
     // Create the new backend and renderer
     backend = std::make_unique<AndroidRendererBackend>();
-    renderer = std::make_unique<Renderer>(*backend, pixelRatio, programCacheDir, localIdeographFontFamily);
+    renderer = std::make_unique<Renderer>(*backend, pixelRatio, localIdeographFontFamily);
     rendererRef = std::make_unique<ActorRef<Renderer>>(*renderer, mailbox);
 
     // Set the observer on the new Renderer implementation
@@ -214,7 +212,7 @@ void MapRenderer::registerNative(jni::JNIEnv& env) {
 
     // Register the peer
     jni::RegisterNativePeer<MapRenderer>(env, javaClass, "nativePtr",
-                                         jni::MakePeer<MapRenderer, const jni::Object<MapRenderer>&, jni::jfloat, const jni::String&, const jni::String&>,
+                                         jni::MakePeer<MapRenderer, const jni::Object<MapRenderer>&, jni::jfloat, const jni::String&>,
                                          "nativeInitialize", "finalize",
                                          METHOD(&MapRenderer::render, "nativeRender"),
                                          METHOD(&MapRenderer::onRendererReset, "nativeReset"),

--- a/platform/android/src/map_renderer.hpp
+++ b/platform/android/src/map_renderer.hpp
@@ -44,7 +44,6 @@ public:
     MapRenderer(jni::JNIEnv& _env,
                 const jni::Object<MapRenderer>&,
                 jni::jfloat pixelRatio,
-                const jni::String& programCacheDir,
                 const jni::String& localIdeographFontFamily);
 
     ~MapRenderer() override;
@@ -104,7 +103,6 @@ private:
     jni::WeakReference<jni::Object<MapRenderer>, jni::EnvAttachingDeleter> javaPeer;
 
     float pixelRatio;
-    std::string programCacheDir;
     optional<std::string> localIdeographFontFamily;
 
     std::shared_ptr<ThreadPool> threadPool;

--- a/platform/android/src/snapshotter/map_snapshotter.cpp
+++ b/platform/android/src/snapshotter/map_snapshotter.cpp
@@ -23,7 +23,6 @@ MapSnapshotter::MapSnapshotter(jni::JNIEnv& _env,
                                const jni::Object<LatLngBounds>& region,
                                const jni::Object<CameraPosition>& position,
                                jni::jboolean _showLogo,
-                               const jni::String& _programCacheDir,
                                const jni::String& _localIdeographFontFamily)
         : javaPeer(_env, _obj)
         , pixelRatio(_pixelRatio) {
@@ -61,7 +60,6 @@ MapSnapshotter::MapSnapshotter(jni::JNIEnv& _env,
                                                          pixelRatio,
                                                          cameraOptions,
                                                          bounds,
-                                                         jni::Make<std::string>(_env, _programCacheDir),
                                                          _localIdeographFontFamily ?
                                                             jni::Make<std::string>(_env, _localIdeographFontFamily) :
                                                             optional<std::string>{},
@@ -161,7 +159,7 @@ void MapSnapshotter::registerNative(jni::JNIEnv& env) {
 
     // Register the peer
     jni::RegisterNativePeer<MapSnapshotter>(env, javaClass, "nativePtr",
-                                            jni::MakePeer<MapSnapshotter, const jni::Object<MapSnapshotter>&, const jni::Object<FileSource>&, jni::jfloat, jni::jint, jni::jint, const jni::String&, const jni::String&, const jni::Object<LatLngBounds>&, const jni::Object<CameraPosition>&, jni::jboolean, const jni::String&, const jni::String&>,
+                                            jni::MakePeer<MapSnapshotter, const jni::Object<MapSnapshotter>&, const jni::Object<FileSource>&, jni::jfloat, jni::jint, jni::jint, const jni::String&, const jni::String&, const jni::Object<LatLngBounds>&, const jni::Object<CameraPosition>&, jni::jboolean, const jni::String&>,
                                            "nativeInitialize",
                                            "finalize",
                                             METHOD(&MapSnapshotter::setStyleUrl, "setStyleUrl"),

--- a/platform/android/src/snapshotter/map_snapshotter.hpp
+++ b/platform/android/src/snapshotter/map_snapshotter.hpp
@@ -34,7 +34,6 @@ public:
                    const jni::Object<LatLngBounds>& region,
                    const jni::Object<CameraPosition>& position,
                    jni::jboolean showLogo,
-                   const jni::String& programCacheDir,
                    const jni::String& localIdeographFontFamily);
 
     ~MapSnapshotter();

--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -624,7 +624,7 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
 
     // Create the snapshotter
     _mbglMapSnapshotter = std::make_unique<mbgl::MapSnapshotter>(
-        style, size, pixelRatio, cameraOptions, coordinateBounds, config.cacheDir, config.localFontFamilyName, resourceOptions);
+        style, size, pixelRatio, cameraOptions, coordinateBounds, config.localFontFamilyName, resourceOptions);
 }
 
 @end

--- a/platform/darwin/src/MGLRendererConfiguration.h
+++ b/platform/darwin/src/MGLRendererConfiguration.h
@@ -20,9 +20,6 @@ MGL_EXPORT
  Based on the native scale where available, otherwise the standard screen scale. */
 @property (nonatomic, readonly) const float scaleFactor;
 
-/** The cache dir to use. */
-@property (nonatomic, readonly) mbgl::optional<std::string> cacheDir;
-
 /** The name of the font family to use for client-side text rendering of CJK ideographs.
  
  Set MGLIdeographicFontFamilyName in your containing application's Info.plist to

--- a/platform/darwin/src/MGLRendererConfiguration.mm
+++ b/platform/darwin/src/MGLRendererConfiguration.mm
@@ -66,10 +66,6 @@ static NSString * const MGLIdeographicFontFamilyNameKey = @"MGLIdeographicFontFa
 #endif
 }
 
-- (mbgl::optional<std::string>)cacheDir {
-    return mbgl::optional<std::string>();
-}
-
 - (mbgl::optional<std::string>)localFontFamilyName {
     return [self _localFontFamilyNameWithPropertyDictionary:[[NSBundle mainBundle] infoDictionary]];
 }

--- a/platform/default/include/mbgl/gfx/headless_frontend.hpp
+++ b/platform/default/include/mbgl/gfx/headless_frontend.hpp
@@ -17,12 +17,10 @@ class TransformState;
 class HeadlessFrontend : public RendererFrontend {
 public:
     HeadlessFrontend(float pixelRatio_,
-                     const optional<std::string> programCacheDir = {},
                      gfx::ContextMode mode = gfx::ContextMode::Unique,
                      const optional<std::string> localFontFamily = {});
     HeadlessFrontend(Size,
                      float pixelRatio_,
-                     const optional<std::string> programCacheDir = {},
                      gfx::ContextMode mode = gfx::ContextMode::Unique,
                      const optional<std::string> localFontFamily = {});
     ~HeadlessFrontend() override;

--- a/platform/default/include/mbgl/map/map_snapshotter.hpp
+++ b/platform/default/include/mbgl/map/map_snapshotter.hpp
@@ -31,7 +31,6 @@ public:
                    const float pixelRatio,
                    const optional<CameraOptions> cameraOptions,
                    const optional<LatLngBounds> region,
-                   const optional<std::string> cacheDir,
                    const optional<std::string> localFontFamily,
                    const ResourceOptions&);
 

--- a/platform/default/src/mbgl/gfx/headless_frontend.cpp
+++ b/platform/default/src/mbgl/gfx/headless_frontend.cpp
@@ -10,16 +10,14 @@
 namespace mbgl {
 
 HeadlessFrontend::HeadlessFrontend(float pixelRatio_,
-                                   const optional<std::string> programCacheDir,
                                    const gfx::ContextMode contextMode,
                                    const optional<std::string> localFontFamily)
     : HeadlessFrontend(
-          { 256, 256 }, pixelRatio_, programCacheDir, contextMode, localFontFamily) {
+          { 256, 256 }, pixelRatio_, contextMode, localFontFamily) {
 }
 
 HeadlessFrontend::HeadlessFrontend(Size size_,
                                    float pixelRatio_,
-                                   const optional<std::string> programCacheDir,
                                    const gfx::ContextMode contextMode,
                                    const optional<std::string> localFontFamily)
     : size(size_),
@@ -38,7 +36,7 @@ HeadlessFrontend::HeadlessFrontend(Size size_,
             renderer->render(*updateParameters_);
         }
     }),
-    renderer(std::make_unique<Renderer>(*getBackend(), pixelRatio, programCacheDir, localFontFamily)) {
+    renderer(std::make_unique<Renderer>(*getBackend(), pixelRatio, localFontFamily)) {
 }
 
 HeadlessFrontend::~HeadlessFrontend() = default;

--- a/platform/default/src/mbgl/map/map_snapshotter.cpp
+++ b/platform/default/src/mbgl/map/map_snapshotter.cpp
@@ -19,7 +19,6 @@ public:
          const float pixelRatio,
          const optional<CameraOptions> cameraOptions,
          const optional<LatLngBounds> region,
-         const optional<std::string> programCacheDir,
          const optional<std::string> localFontFamily,
          const ResourceOptions& resourceOptions);
 
@@ -50,11 +49,10 @@ MapSnapshotter::Impl::Impl(const std::pair<bool, std::string> style,
                            const float pixelRatio,
                            const optional<CameraOptions> cameraOptions,
                            const optional<LatLngBounds> region,
-                           const optional<std::string> programCacheDir,
                            const optional<std::string> localFontFamily,
                            const ResourceOptions& resourceOptions)
      : frontend(
-          size, pixelRatio, programCacheDir, gfx::ContextMode::Unique, localFontFamily),
+          size, pixelRatio, gfx::ContextMode::Unique, localFontFamily),
       map(frontend,
           MapObserver::nullObserver(),
           MapOptions().withMapMode(MapMode::Static).withSize(size).withPixelRatio(pixelRatio),
@@ -168,12 +166,11 @@ MapSnapshotter::MapSnapshotter(const std::pair<bool, std::string> style,
                                const float pixelRatio,
                                const optional<CameraOptions> cameraOptions,
                                const optional<LatLngBounds> region,
-                               const optional<std::string> programCacheDir,
                                const optional<std::string> localFontFamily,
                                const ResourceOptions& resourceOptions)
    : impl(std::make_unique<util::Thread<MapSnapshotter::Impl>>(
        "Map Snapshotter", style, size, pixelRatio, cameraOptions,
-       region, programCacheDir, localFontFamily, resourceOptions.clone())) {}
+       region, localFontFamily, resourceOptions.clone())) {}
 
 MapSnapshotter::~MapSnapshotter() = default;
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -471,7 +471,7 @@ public:
     // setup mbgl map
     MGLRendererConfiguration *config = [MGLRendererConfiguration currentConfiguration];
 
-    auto renderer = std::make_unique<mbgl::Renderer>(_mbglView->getRendererBackend(), config.scaleFactor, config.cacheDir, config.localFontFamilyName);
+    auto renderer = std::make_unique<mbgl::Renderer>(_mbglView->getRendererBackend(), config.scaleFactor, config.localFontFamilyName);
     BOOL enableCrossSourceCollisions = !config.perSourceCollisions;
     _rendererFrontend = std::make_unique<MGLRenderFrontend>(std::move(renderer), self, _mbglView->getRendererBackend());
 

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -276,7 +276,7 @@ public:
 
     MGLRendererConfiguration *config = [MGLRendererConfiguration currentConfiguration];
 
-    auto renderer = std::make_unique<mbgl::Renderer>(_mbglView->getRendererBackend(), config.scaleFactor, config.cacheDir, config.localFontFamilyName);
+    auto renderer = std::make_unique<mbgl::Renderer>(_mbglView->getRendererBackend(), config.scaleFactor, config.localFontFamilyName);
     BOOL enableCrossSourceCollisions = !config.perSourceCollisions;
     _rendererFrontend = std::make_unique<MGLRenderFrontend>(std::move(renderer), self, _mbglView->getRendererBackend(), true);
 

--- a/platform/qt/src/qmapboxgl_map_renderer.cpp
+++ b/platform/qt/src/qmapboxgl_map_renderer.cpp
@@ -28,7 +28,7 @@ static auto *getScheduler() {
 
 QMapboxGLMapRenderer::QMapboxGLMapRenderer(qreal pixelRatio, QMapboxGLSettings::GLContextMode mode, const QString &localFontFamily)
     : m_backend(static_cast<mbgl::gfx::ContextMode>(mode)),
-      m_renderer(std::make_unique<mbgl::Renderer>(m_backend, pixelRatio, mbgl::optional<std::string> {},
+      m_renderer(std::make_unique<mbgl::Renderer>(m_backend, pixelRatio,
                  localFontFamily.isEmpty() ? mbgl::nullopt : mbgl::optional<std::string> { localFontFamily.toStdString() }))
     , m_forceScheduler(needsToForceScheduler())
 {

--- a/src/mbgl/programs/program_parameters.cpp
+++ b/src/mbgl/programs/program_parameters.cpp
@@ -4,8 +4,7 @@
 namespace mbgl {
 
 ProgramParameters::ProgramParameters(const float pixelRatio,
-                                     const bool overdraw,
-                                     optional<std::string> cacheDir_)
+                                     const bool overdraw)
     : defines([&] {
           std::string result;
           result.reserve(32);
@@ -16,28 +15,11 @@ ProgramParameters::ProgramParameters(const float pixelRatio,
               result += "#define OVERDRAW_INSPECTOR\n";
           }
           return result;
-      }()),
-      cacheDir(std::move(cacheDir_)) {
+      }()) {
 }
 
 const std::string& ProgramParameters::getDefines() const {
     return defines;
-}
-
-optional<std::string> ProgramParameters::cachePath(const char* name) const {
-    if (!cacheDir) {
-        return {};
-    } else {
-        std::string result;
-        result.reserve(cacheDir->length() + 64);
-        result += *cacheDir;
-        result += "/com.mapbox.gl.shader.";
-        result += name;
-        result += '.';
-        result += util::toHex(static_cast<uint64_t>(std::hash<std::string>()(defines)));
-        result += ".pbf";
-        return result;
-    }
 }
 
 } // namespace mbgl

--- a/src/mbgl/programs/program_parameters.hpp
+++ b/src/mbgl/programs/program_parameters.hpp
@@ -8,14 +8,12 @@ namespace mbgl {
 
 class ProgramParameters {
 public:
-    ProgramParameters(float pixelRatio, bool overdraw, optional<std::string> cacheDir);
+    ProgramParameters(float pixelRatio, bool overdraw);
 
     const std::string& getDefines() const;
-    optional<std::string> cachePath(const char* name) const;
 
 private:
     std::string defines;
-    optional<std::string> cacheDir;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/render_static_data.cpp
+++ b/src/mbgl/renderer/render_static_data.cpp
@@ -49,10 +49,10 @@ static gfx::VertexVector<HeatmapTextureLayoutVertex> heatmapTextureVertices() {
     return result;
 }
 
-RenderStaticData::RenderStaticData(gfx::Context& context, float pixelRatio, const optional<std::string>& programCacheDir)
-    : programs(context, ProgramParameters { pixelRatio, false, programCacheDir })
+RenderStaticData::RenderStaticData(gfx::Context& context, float pixelRatio)
+    : programs(context, ProgramParameters { pixelRatio, false })
 #ifndef NDEBUG
-    , overdrawPrograms(context, ProgramParameters { pixelRatio, true, programCacheDir })
+    , overdrawPrograms(context, ProgramParameters { pixelRatio, true })
 #endif
 {
     tileTriangleSegments.emplace_back(0, 0, 4, 6);

--- a/src/mbgl/renderer/render_static_data.hpp
+++ b/src/mbgl/renderer/render_static_data.hpp
@@ -19,7 +19,7 @@ class UploadPass;
 
 class RenderStaticData {
 public:
-    RenderStaticData(gfx::Context&, float pixelRatio, const optional<std::string>& programCacheDir);
+    RenderStaticData(gfx::Context&, float pixelRatio);
 
     void upload(gfx::UploadPass&);
 

--- a/src/mbgl/renderer/renderer.cpp
+++ b/src/mbgl/renderer/renderer.cpp
@@ -10,11 +10,9 @@ namespace mbgl {
 
 Renderer::Renderer(gfx::RendererBackend& backend,
                    float pixelRatio_,
-                   const optional<std::string> programCacheDir_,
                    const optional<std::string> localFontFamily_)
     : impl(std::make_unique<Impl>(backend,
                                   pixelRatio_,
-                                  std::move(programCacheDir_),
                                   std::move(localFontFamily_))) {
 }
 

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -26,13 +26,11 @@ static RendererObserver& nullObserver() {
 
 Renderer::Impl::Impl(gfx::RendererBackend& backend_,
                      float pixelRatio_,
-                     optional<std::string> programCacheDir_,
                      optional<std::string> localFontFamily_)
     : orchestrator(!backend_.contextIsShared(), std::move(localFontFamily_))
     , backend(backend_)
     , observer(&nullObserver())
-    , pixelRatio(pixelRatio_)
-    , programCacheDir(std::move(programCacheDir_)) {
+    , pixelRatio(pixelRatio_) {
 
 }
 
@@ -53,7 +51,7 @@ void Renderer::Impl::render(const RenderTree& renderTree) {
     const auto& renderTreeParameters = renderTree.getParameters();
 
     if (!staticData) {
-        staticData = std::make_unique<RenderStaticData>(backend.getContext(), pixelRatio, programCacheDir);
+        staticData = std::make_unique<RenderStaticData>(backend.getContext(), pixelRatio);
     }
     staticData->has3D = renderTreeParameters.has3D;
 

--- a/src/mbgl/renderer/renderer_impl.hpp
+++ b/src/mbgl/renderer/renderer_impl.hpp
@@ -19,7 +19,6 @@ class Renderer::Impl {
 public:
     Impl(gfx::RendererBackend&,
          float pixelRatio_,
-         optional<std::string> programCacheDir,
          optional<std::string> localFontFamily_);
     ~Impl();
 
@@ -40,7 +39,6 @@ private:
     RendererObserver* observer;
 
     const float pixelRatio;
-    const optional<std::string> programCacheDir;
     std::unique_ptr<RenderStaticData> staticData;
 
     enum class RenderState {

--- a/test/gl/context.test.cpp
+++ b/test/gl/context.test.cpp
@@ -91,7 +91,7 @@ TEST(GLContextMode, Shared) {
 
     util::RunLoop loop;
 
-    HeadlessFrontend frontend { 1, {}, gfx::ContextMode::Shared };
+    HeadlessFrontend frontend { 1, gfx::ContextMode::Shared };
 
     Map map(frontend, MapObserver::nullObserver(),
             MapOptions().withMapMode(MapMode::Static).withSize(frontend.getSize()),

--- a/test/text/local_glyph_rasterizer.test.cpp
+++ b/test/text/local_glyph_rasterizer.test.cpp
@@ -33,7 +33,7 @@ namespace {
 class LocalGlyphRasterizerTest {
 public:
     LocalGlyphRasterizerTest(const optional<std::string> fontFamily)
-        : frontend(1, optional<std::string>(), gfx::ContextMode::Unique, fontFamily)
+        : frontend(1, gfx::ContextMode::Unique, fontFamily)
     {
     }
 


### PR DESCRIPTION
Binary shader support has been removed in commit c2f974f2a573 ([core]
Remove binary shader support). This left-over parameter is not used
anywhere anymore.