### PR TITLE
Cancel CameraAnimatorActivity joint example when the map is destroyed

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraAnimatorActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraAnimatorActivity.java
@@ -36,6 +36,7 @@ public class CameraAnimatorActivity extends AppCompatActivity implements OnMapRe
   private static final LatLng START_LAT_LNG = new LatLng(37.787947, -122.407432);
 
   private final LongSparseArray<Animator> animators = new LongSparseArray<>();
+  private Animator set;
 
   {
     AnimatorSet accelerateDecelerateAnimatorSet = new AnimatorSet();
@@ -92,7 +93,8 @@ public class CameraAnimatorActivity extends AppCompatActivity implements OnMapRe
         .bearing(135)
         .build();
 
-      createExampleAnimator(mapboxMap.getCameraPosition(), animatedPosition).start();
+      set = createExampleAnimator(mapboxMap.getCameraPosition(), animatedPosition);
+      set.start();
     });
   }
 
@@ -236,6 +238,9 @@ public class CameraAnimatorActivity extends AppCompatActivity implements OnMapRe
     mapView.onStop();
     for (int i = 0; i < animators.size(); i++) {
       animators.get(animators.keyAt(i)).cancel();
+    }
+    if (set != null) {
+      set.cancel();
     }
   }
 


### PR DESCRIPTION
Test app issue caught during QA:
```
Process: com.mapbox.mapboxsdk.testapp, PID: 5443
com.mapbox.mapboxsdk.MapStrictModeException: Map detected an error that would fail silently otherwise: You're calling `cancelTransitions` after the `MapView` wa
    at com.mapbox.mapboxsdk.MapStrictMode.strictModeViolation(MapStrictMode.java:25)
    at com.mapbox.mapboxsdk.maps.NativeMapView.checkState(NativeMapView.java:126)
    at com.mapbox.mapboxsdk.maps.NativeMapView.cancelTransitions(NativeMapView.java:217)
    at com.mapbox.mapboxsdk.maps.Transform.cancelTransitions(Transform.java:201)
    at com.mapbox.mapboxsdk.maps.Transform.moveCamera(Transform.java:109)
    at com.mapbox.mapboxsdk.maps.MapboxMap.moveCamera(MapboxMap.java:422)
    at com.mapbox.mapboxsdk.maps.MapboxMap.moveCamera(MapboxMap.java:408)
    at com.mapbox.mapboxsdk.testapp.activity.camera.CameraAnimatorActivity.lambda$createZoomAnimator$2$CameraAnimatorActivity(CameraAnimatorActivity.java:127)
    at com.mapbox.mapboxsdk.testapp.activity.camera.-$$Lambda$CameraAnimatorActivity$B50yYdNDJzNe7oPdDOxloRIlaEI.onAnimationUpdate(Unknown Source:2)
    at android.animation.ValueAnimator.animateValue(ValueAnimator.java:1547)
    at android.animation.ValueAnimator.animateBasedOnTime(ValueAnimator.java:1339)
    at android.animation.ValueAnimator.doAnimationFrame(ValueAnimator.java:1471)
    at android.animation.ValueAnimator.pulseAnimationFrame(ValueAnimator.java:1490)
    at android.animation.AnimatorSet.pulseFrame(AnimatorSet.java:1163)
    at android.animation.AnimatorSet.doAnimationFrame(AnimatorSet.java:1054)
    at android.animation.AnimationHandler.doAnimationFrame(AnimationHandler.java:146)
    at android.animation.AnimationHandler.access$100(AnimationHandler.java:37)
    at android.animation.AnimationHandler$1.doFrame(AnimationHandler.java:54)
    at android.view.Choreographer$CallbackRecord.run(Choreographer.java:947)
    at android.view.Choreographer.doCallbacks(Choreographer.java:761)
    at android.view.Choreographer.doFrame(Choreographer.java:693)
    at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:935)
    at android.os.Handler.handleCallback(Handler.java:873)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loop(Looper.java:193)
    at android.app.ActivityThread.main(ActivityThread.java:6718)

        at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
```