### PR TITLE
Invalidate foreground icon sources even when location layer is hidden

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -16,6 +16,7 @@ This release changes how offline tile requests are billed — they are now bille
 
 ### Bug fixes
  - Fixed a rendering issue caused by all icons being treated as SDFs if an SDF and non-SDF icon were in the same layer. [#15456](https://github.com/mapbox/mapbox-gl-native/pull/15456)
+ - Fixed an issue where changing location's render mode when the`LocationComponent` is disable wouldn't invalidate the foreground icon when it's back enabled. [#15507](https://github.com/mapbox/mapbox-gl-native/pull/15507)
 
 ## 8.2.2 - August 23, 2019
 [Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.2.1...android-v8.2.2) since [Mapbox Maps SDK for Android v8.2.1](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.2.1):

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationLayerController.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationLayerController.java
@@ -140,11 +140,11 @@ final class LocationLayerController {
     }
     this.renderMode = renderMode;
 
+    styleForeground(options);
+    determineIconsSource(options);
     if (!isHidden) {
-      styleForeground(options);
       show();
     }
-    determineIconsSource(options);
     internalRenderModeChangedListener.onRenderModeChanged(renderMode);
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationLayerControllerTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationLayerControllerTest.java
@@ -632,6 +632,41 @@ public class LocationLayerControllerTest {
     verify(internalRenderModeChangedListener, times(1)).onRenderModeChanged(RenderMode.GPS);
   }
 
+  @Test
+  public void layerHidden_renderModeChanged_layerShown_foregroundIconUpdated() {
+    OnRenderModeChangedListener internalRenderModeChangedListener = mock(OnRenderModeChangedListener.class);
+    LayerSourceProvider sourceProvider = buildLayerProvider();
+    when(sourceProvider.generateSource(any(Feature.class))).thenReturn(mock(GeoJsonSource.class));
+    LocationComponentOptions options = mock(LocationComponentOptions.class);
+    int drawableResId = 123;
+    int tintColor = 456;
+    when(options.foregroundDrawable()).thenReturn(drawableResId);
+    when(options.foregroundTintColor()).thenReturn(tintColor);
+    LayerBitmapProvider bitmapProvider = mock(LayerBitmapProvider.class);
+    Bitmap bitmap = mock(Bitmap.class);
+    when(bitmapProvider.generateBitmap(drawableResId, tintColor)).thenReturn(bitmap);
+
+    LocationLayerController controller =
+      new LocationLayerController(mapboxMap, mapboxMap.getStyle(), sourceProvider, buildFeatureProvider(options),
+      bitmapProvider, options, internalRenderModeChangedListener);
+
+    verify(style).addImage(FOREGROUND_ICON, bitmap);
+
+    int drawableGpsResId = 789;
+    when(options.gpsDrawable()).thenReturn(drawableGpsResId);
+
+    Bitmap bitmapGps = mock(Bitmap.class);
+    when(bitmapProvider.generateBitmap(drawableGpsResId, tintColor)).thenReturn(bitmapGps);
+
+    controller.hide();
+
+    controller.setRenderMode(RenderMode.GPS);
+
+    controller.show();
+
+    verify(style).addImage(FOREGROUND_ICON, bitmapGps);
+  }
+
   private LayerFeatureProvider buildFeatureProvider(@NonNull LocationComponentOptions options) {
     LayerFeatureProvider provider = mock(LayerFeatureProvider.class);
     when(provider.generateLocationFeature(null, options)).thenReturn(mock(Feature.class));


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/15499.
Regression introduced in https://github.com/mapbox/mapbox-gl-native/pull/15266.