### PR TITLE
Do not clear native layers and sources when style is reloading

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
@@ -1182,7 +1182,6 @@ public final class LocationComponent {
     }
 
     isLayerReady = false;
-    locationLayerController.hide();
     staleStateManager.onStop();
     if (compassEngine != null) {
       updateCompassListenerState(false);
@@ -1289,6 +1288,7 @@ public final class LocationComponent {
 
   private void disableLocationComponent() {
     isEnabled = false;
+    locationLayerController.hide();
     onLocationLayerStop();
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Style.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Style.java
@@ -523,14 +523,12 @@ public class Style {
     for (Layer layer : layers.values()) {
       if (layer != null) {
         layer.setDetached();
-        nativeMap.removeLayer(layer);
       }
     }
 
     for (Source source : sources.values()) {
       if (source != null) {
         source.setDetached();
-        nativeMap.removeSource(source);
       }
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/StyleTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/StyleTest.kt
@@ -405,22 +405,4 @@ class StyleTest {
             Assert.assertEquals("Layer that failed to be added shouldn't be cached", layer1, mapboxMap.style!!.getLayer("layer1"))
         }
     }
-
-  @Test
-  fun testClearRemovesSourcesFirst() {
-    val source1 = mockk<GeoJsonSource>(relaxed = true)
-    every { source1.id } returns "source1"
-    val layer1 = mockk<SymbolLayer>(relaxed = true)
-    every { layer1.id } returns "layer1"
-
-    val builder = Style.Builder().withLayer(layer1).withSource(source1)
-    mapboxMap.setStyle(builder)
-    mapboxMap.notifyStyleLoaded()
-    mapboxMap.setStyle(Style.MAPBOX_STREETS)
-
-    verifyOrder {
-      nativeMapView.removeLayer(layer1)
-      nativeMapView.removeSource(source1)
-    }
-  }
 }


### PR DESCRIPTION
This prevents unnecessary layers blink when the same components are re-added after the style reload.

Before:
![ezgif com-video-to-gif (18)](https://user-images.githubusercontent.com/16925074/63866633-ca304200-c9b3-11e9-862e-49990e64c6b0.gif)

After:
![ezgif com-video-to-gif (19)](https://user-images.githubusercontent.com/16925074/63866640-cd2b3280-c9b3-11e9-8380-785d36817c98.gif)

/cc @Guardiola31337 