### PR TITLE
[docs] [ios] update offline to reflect billing changes

### DIFF
--- a/platform/darwin/src/MGLOfflineStorage.h
+++ b/platform/darwin/src/MGLOfflineStorage.h
@@ -262,9 +262,10 @@ MGL_EXPORT
  use the given region offline.
  
  As of version 5.3 of the Maps SDK for iOS, offline tile requests are no longer
- exempt from billing on mobile. Developers are billed per vector or raster tile 
- API request above the free tier for offline use. For more information, see the 
- <a href="https://www.mapbox.com/pricing/">Pricing</a> page.
+ exempt from billing on mobile. Developers are subject to separate Vector Tile
+ and Raster Tile API pricing for offline use. See
+ <a href="https://www.mapbox.com/pricing/">our pricing page</a> for more 
+ information.
 
  The resulting pack is added to the shared offline storage object’s `packs`
  property, then the `completion` block is executed with that pack passed in.

--- a/platform/darwin/src/MGLOfflineStorage.h
+++ b/platform/darwin/src/MGLOfflineStorage.h
@@ -261,9 +261,10 @@ MGL_EXPORT
  Creates and registers an offline pack that downloads the resources needed to
  use the given region offline.
  
- As of version 5.3 of the Maps SDK for iOS, offline tile requests are no longer exempt 
- from billing on mobile. Developers are billed per vector or raster tile API request above 
- the free tier for offline use. For more information, see the <a href="https://www.mapbox.com/pricing/">Pricing</a> page.
+ As of version 5.3 of the Maps SDK for iOS, offline tile requests are no longer
+ exempt from billing on mobile. Developers are billed per vector or raster tile 
+ API request above the free tier for offline use. For more information, see the 
+ <a href="https://www.mapbox.com/pricing/">Pricing</a> page.
 
  The resulting pack is added to the shared offline storage object’s `packs`
  property, then the `completion` block is executed with that pack passed in.

--- a/platform/darwin/src/MGLOfflineStorage.h
+++ b/platform/darwin/src/MGLOfflineStorage.h
@@ -260,6 +260,10 @@ MGL_EXPORT
 /**
  Creates and registers an offline pack that downloads the resources needed to
  use the given region offline.
+ 
+ As of version 5.3 of the Maps SDK for iOS, offline tile requests are no longer exempt 
+ from billing on mobile. Developers are billed per vector or raster tile API request above 
+ the free tier for offline use. For more information, see the <a href="https://www.mapbox.com/pricing/">Pricing</a> page.
 
  The resulting pack is added to the shared offline storage object’s `packs`
  property, then the `completion` block is executed with that pack passed in.
@@ -339,7 +343,7 @@ MGL_EXPORT
 
 /**
  Sets the maximum number of Mapbox-hosted tiles that may be downloaded and
- stored on the current device.
+ stored on the current device. By default, the limit is set to 6,000.
 
  Once this limit is reached, an
  `MGLOfflinePackMaximumMapboxTilesReachedNotification` is posted for every


### PR DESCRIPTION
clarifying in docs that:
- the offline limit is set by default to 6,000 tiles
- biling for offline tile requests has changed 