### PR TITLE
[core] Mark used offline region resources in batches

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -7,6 +7,9 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
  - Introduce `clusterProperties` option for aggregated cluster properties. [#15425](https://github.com/mapbox/mapbox-gl-native/pull/15425)
  - Expose the `CameraPosition#padding` field and associated utility camera position builders. This gives a choice to set a persisting map padding immediately during a transition instead of setting it lazily `MapboxMap#setPadding`, which required scheduling additional transition to be applied. This also deprecates `MapboxMap#setPadding` as there should be no need for a lazy padding setter. [#15444](https://github.com/mapbox/mapbox-gl-native/pull/15444)
 
+ ### Performance improvements
+ - Mark used offline region resources in batches. [#15521](https://github.com/mapbox/mapbox-gl-native/pull/15521)
+
 ## 8.3.0 - August 28, 2019
 [Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.3.0-beta.1...android-v8.3.0) since [Mapbox Maps SDK for Android v8.3.0-beta.1](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.3.0-beta.1):
 

--- a/platform/default/include/mbgl/storage/offline_database.hpp
+++ b/platform/default/include/mbgl/storage/offline_database.hpp
@@ -78,8 +78,8 @@ public:
     std::exception_ptr invalidateRegion(int64_t regionID);
 
     // Return value is (response, stored size)
-    optional<std::pair<Response, uint64_t>> getRegionResource(int64_t regionID, const Resource&);
-    optional<int64_t> hasRegionResource(int64_t regionID, const Resource&);
+    optional<std::pair<Response, uint64_t>> getRegionResource(const Resource&);
+    optional<int64_t> hasRegionResource(const Resource&);
     uint64_t putRegionResource(int64_t regionID, const Resource&, const Response&);
     void putRegionResources(int64_t regionID, const std::list<std::tuple<Resource, Response>>&, OfflineRegionStatus&);
 

--- a/platform/default/include/mbgl/storage/offline_database.hpp
+++ b/platform/default/include/mbgl/storage/offline_database.hpp
@@ -92,6 +92,7 @@ public:
     bool offlineMapboxTileCountLimitExceeded();
     uint64_t getOfflineMapboxTileCount();
     bool exceedsOfflineMapboxTileCountLimit(const Resource&);
+    void markUsedResources(int64_t regionID, const std::list<Resource>&);
 
 private:
     void initialize();

--- a/platform/default/include/mbgl/storage/offline_download.hpp
+++ b/platform/default/include/mbgl/storage/offline_download.hpp
@@ -46,7 +46,7 @@ private:
      * While the request is in progress, it is recorded in `requests`. If the download
      * is deactivated, all in progress requests are cancelled.
      */
-    void ensureResource(const Resource&, std::function<void (Response)> = {});
+    void ensureResource(Resource&&, std::function<void (Response)> = {});
 
     void onMapboxTileCountLimitExceeded();
 

--- a/platform/default/include/mbgl/storage/offline_download.hpp
+++ b/platform/default/include/mbgl/storage/offline_download.hpp
@@ -60,10 +60,12 @@ private:
     std::list<std::unique_ptr<AsyncRequest>> requests;
     std::unordered_set<std::string> requiredSourceURLs;
     std::deque<Resource> resourcesRemaining;
+    std::list<Resource> resourcesToBeMarkedAsUsed;
     std::list<std::tuple<Resource, Response>> buffer;
 
     void queueResource(Resource&&);
     void queueTiles(style::SourceType, uint16_t tileSize, const Tileset&);
+    void markPendingUsedResources();
 };
 
 } // namespace mbgl

--- a/platform/default/src/mbgl/storage/offline_database.cpp
+++ b/platform/default/src/mbgl/storage/offline_database.cpp
@@ -877,27 +877,15 @@ std::exception_ptr OfflineDatabase::deleteRegion(OfflineRegion&& region) try {
     return std::current_exception();
 }
 
-optional<std::pair<Response, uint64_t>> OfflineDatabase::getRegionResource(int64_t regionID, const Resource& resource) try {
-    auto response = getInternal(resource);
-
-    if (response) {
-        markUsed(regionID, resource);
-    }
-
-    return response;
+optional<std::pair<Response, uint64_t>> OfflineDatabase::getRegionResource(const Resource& resource) try {
+    return getInternal(resource);
 } catch (const mapbox::sqlite::Exception& ex) {
     handleError(ex, "read region resource");
     return nullopt;
 }
 
-optional<int64_t> OfflineDatabase::hasRegionResource(int64_t regionID, const Resource& resource) try {
-    auto response = hasInternal(resource);
-
-    if (response) {
-        markUsed(regionID, resource);
-    }
-
-    return response;
+optional<int64_t> OfflineDatabase::hasRegionResource(const Resource& resource) try {
+    return hasInternal(resource);
 } catch (const mapbox::sqlite::Exception& ex) {
     handleError(ex, "query region resource");
     return nullopt;

--- a/platform/default/src/mbgl/storage/offline_database.cpp
+++ b/platform/default/src/mbgl/storage/offline_database.cpp
@@ -1278,6 +1278,19 @@ bool OfflineDatabase::exceedsOfflineMapboxTileCountLimit(const Resource& resourc
         && offlineMapboxTileCountLimitExceeded();
 }
 
+void OfflineDatabase::markUsedResources(int64_t regionID, const std::list<Resource>& resources) try {
+    if (!db) {
+        initialize();
+    }
+    mapbox::sqlite::Transaction transaction(*db);
+    for (const auto& resource : resources) {
+        markUsed(regionID, resource);
+    }
+    transaction.commit();
+} catch (const mapbox::sqlite::Exception& ex) {
+    handleError(ex, "mark resources as used");
+}
+
 std::exception_ptr OfflineDatabase::resetDatabase() try {
     removeExisting();
     initialize();

--- a/platform/default/src/mbgl/storage/offline_download.cpp
+++ b/platform/default/src/mbgl/storage/offline_download.cpp
@@ -21,6 +21,13 @@
 
 #include <set>
 
+namespace {
+
+const size_t kResourcesBatchSize = 64;
+const size_t kMarkBatchSize = 200;
+
+} // namespace
+
 namespace mbgl {
 
 using namespace style;
@@ -358,7 +365,7 @@ void OfflineDownload::continueDownload() {
         return;
     }
 
-    if (resourcesToBeMarkedAsUsed.size() >= 200) markPendingUsedResources();
+    if (resourcesToBeMarkedAsUsed.size() >= kMarkBatchSize) markPendingUsedResources();
 
     while (!resourcesRemaining.empty() && requests.size() < onlineFileSource.getMaximumConcurrentRequests()) {
         ensureResource(std::move(resourcesRemaining.front()));
@@ -461,7 +468,7 @@ void OfflineDownload::ensureResource(Resource&& resource,
             buffer.emplace_back(resource, onlineResponse);
 
             // Flush buffer periodically
-            if (buffer.size() == 64 || resourcesRemaining.size() == 0) {
+            if (buffer.size() == kResourcesBatchSize || resourcesRemaining.empty()) {
                 try {
                     offlineDatabase.putRegionResources(id, buffer, status);
                 } catch (const MapboxTileLimitExceededException&) {

--- a/platform/default/src/mbgl/storage/offline_download.cpp
+++ b/platform/default/src/mbgl/storage/offline_download.cpp
@@ -228,7 +228,7 @@ void OfflineDownload::activateDownload() {
     styleResource.setPriority(Resource::Priority::Low);
     styleResource.setUsage(Resource::Usage::Offline);
 
-    ensureResource(styleResource, [&](Response styleResponse) {
+    ensureResource(std::move(styleResource), [&](Response styleResponse) {
         status.requiredResourceCountIsPrecise = true;
 
         style::Parser parser;
@@ -250,7 +250,7 @@ void OfflineDownload::activateDownload() {
                     sourceResource.setPriority(Resource::Priority::Low);
                     sourceResource.setUsage(Resource::Usage::Offline);
 
-                    ensureResource(sourceResource, [=](Response sourceResponse) {
+                    ensureResource(std::move(sourceResource), [=](Response sourceResponse) {
                         style::conversion::Error error;
                         optional<Tileset> tileset = style::conversion::convertJSON<Tileset>(*sourceResponse.data, error);
                         if (tileset) {
@@ -358,7 +358,7 @@ void OfflineDownload::continueDownload() {
     }
 
     while (!resourcesRemaining.empty() && requests.size() < onlineFileSource.getMaximumConcurrentRequests()) {
-        ensureResource(resourcesRemaining.front());
+        ensureResource(std::move(resourcesRemaining.front()));
         resourcesRemaining.pop_front();
     }
 }
@@ -391,7 +391,7 @@ void OfflineDownload::queueTiles(SourceType type, uint16_t tileSize, const Tiles
     });
 }
 
-void OfflineDownload::ensureResource(const Resource& resource,
+void OfflineDownload::ensureResource(Resource&& resource,
                                      std::function<void(Response)> callback) {
     assert(resource.priority == Resource::Priority::Low);
     assert(resource.usage == Resource::Usage::Offline);

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -7,6 +7,10 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed an issue that caused the tilt gesture to trigger too easily and conflict with pinch or pan gestures. ([#15349](https://github.com/mapbox/mapbox-gl-native/pull/15349))
 * Fixed a bug with annotation view positions after camera transitions. ([#15122](https://github.com/mapbox/mapbox-gl-native/pull/15122/))
 
+ ### Performance improvements
+ 
+ * Mark used offline region resources in batches. ([#15521](https://github.com/mapbox/mapbox-gl-native/pull/15521))
+
 ## 5.3.0 - August 28, 2019
 
 This release changes how offline tile requests are billed — they are now billed on a pay-as-you-go basis and all developers are able raise the offline tile limit for their users. Offline requests were previously exempt from monthly active user (MAU) billing and increasing the offline per-user tile limit to more than 6,000 tiles required the purchase of an enterprise license. By upgrading to this release, you are opting into the changes outlined in [this blog post](https://blog.mapbox.com/offline-maps-for-all-bb0fc51827be) and [#15380](https://github.com/mapbox/mapbox-gl-native/pull/15380).


### PR DESCRIPTION
Marking offline region resources "used" is on the hot code path for offline region download.
Previously, the engine attempted to update the database separetely for each resource and it caused a huge performance impact, especially when some tiles were already loaded.

Now, offline region resources are marked in batches (200 items at once).

Consider the time mesaurements of the `mbgl-offline` tool execution (Linux x64, release build):

`time ./mbgl-offline --north 41.4664 --west 2.0407 --south 41.2724 --east 2.2680 --output barcelona.db`

without patch:
 
1st time:
```
    real      0m9,505s
    user      0m3,315s
    sys       0m0,378s
 ```
    
2nd time (tiles are already loaded):
 ```
    real      0m9,480s
    user      0m0,403s
    sys       0m0,645s
 ```

with the patch:
    
1st time:
```
    real      0m7,399s
    user      0m2,994s
    sys       0m0,384s
 ```
    
2nd time (tiles are already loaded):
```
    real      0m0,149s
    user      0m0,059s
    sys       0m0,044s
```

So, the proposed changes make the repeated load **~64** times faster :tada: 