### PR TITLE
[core] Add requiredTileCount to OfflineRegionStatus

### DIFF
--- a/bin/offline.cpp
+++ b/bin/offline.cpp
@@ -217,6 +217,8 @@ int main(int argc, char *argv[]) {
 
             std::cout << status.completedResourceCount << " / " << status.requiredResourceCount
                       << " resources"
+                      << status.completedTileCount << " / " << status.requiredTileCount
+                      << "tiles"
                       << (status.requiredResourceCountIsPrecise ? "; " : " (indeterminate); ")
                       << status.completedResourceSize << " bytes downloaded"
                       << " (" << bytesPerSecond << " bytes/sec)"

--- a/include/mbgl/storage/offline.hpp
+++ b/include/mbgl/storage/offline.hpp
@@ -129,6 +129,11 @@ public:
     uint64_t completedTileCount = 0;
 
     /**
+     * The number of tiles that are known to be required for this region.
+     */
+    uint64_t requiredTileCount = 0;
+
+    /**
      * The cumulative size, in bytes, of all tiles that have been fully downloaded.
      * This is a subset of `completedResourceSize`.
      */

--- a/platform/default/src/mbgl/storage/offline_download.cpp
+++ b/platform/default/src/mbgl/storage/offline_download.cpp
@@ -144,8 +144,9 @@ OfflineRegionStatus OfflineDownload::getStatus() const {
 
         auto handleTiledSource = [&] (const variant<std::string, Tileset>& urlOrTileset, const uint16_t tileSize) {
             if (urlOrTileset.is<Tileset>()) {
-                result->requiredResourceCount +=
-                        tileCount(definition, type, tileSize, urlOrTileset.get<Tileset>().zoomRange);
+                uint64_t tileSourceCount = tileCount(definition, type, tileSize, urlOrTileset.get<Tileset>().zoomRange);
+                result->requiredTileCount += tileSourceCount;
+                result->requiredResourceCount += tileSourceCount;
             } else {
                 result->requiredResourceCount += 1;
                 const auto& url = urlOrTileset.get<std::string>();
@@ -154,8 +155,9 @@ OfflineRegionStatus OfflineDownload::getStatus() const {
                     style::conversion::Error error;
                     optional<Tileset> tileset = style::conversion::convertJSON<Tileset>(*sourceResponse->data, error);
                     if (tileset) {
-                        result->requiredResourceCount +=
-                                tileCount(definition, type, tileSize, (*tileset).zoomRange);
+                        uint64_t tileSourceCount = tileCount(definition, type, tileSize, (*tileset).zoomRange);
+                        result->requiredTileCount += tileSourceCount;
+                        result->requiredResourceCount += tileSourceCount;
                     }
                 } else {
                     result->requiredResourceCountIsPrecise = false;
@@ -373,12 +375,16 @@ void OfflineDownload::queueResource(Resource&& resource) {
     resource.setPriority(Resource::Priority::Low);
     resource.setUsage(Resource::Usage::Offline);
     status.requiredResourceCount++;
+    if (resource.kind == mbgl::Resource::Kind::Tile) {
+        status.requiredTileCount++;
+    }
     resourcesRemaining.push_front(std::move(resource));
 }
 
 void OfflineDownload::queueTiles(SourceType type, uint16_t tileSize, const Tileset& tileset) {
     tileCover(definition, type, tileSize, tileset.zoomRange, [&](const auto& tile) {
         status.requiredResourceCount++;
+        status.requiredTileCount++;
 
         auto tileResource = Resource::tile(
                 tileset.tiles[0], definition.match([](auto& def) { return def.pixelRatio; }),

--- a/test/storage/offline_download.test.cpp
+++ b/test/storage/offline_download.test.cpp
@@ -150,6 +150,7 @@ TEST(OfflineDownload, InlineSource) {
 
     observer->statusChangedFn = [&] (OfflineRegionStatus status) {
         if (status.complete()) {
+            EXPECT_EQ(1u, status.completedTileCount);
             EXPECT_EQ(2u, status.completedResourceCount);
             EXPECT_EQ(test.size, status.completedResourceSize);
             EXPECT_TRUE(status.requiredResourceCountIsPrecise);
@@ -253,6 +254,7 @@ TEST(OfflineDownload, Activate) {
 
     observer->statusChangedFn = [&] (OfflineRegionStatus status) {
         if (status.complete()) {
+            EXPECT_EQ(status.completedTileCount, status.requiredTileCount);
             EXPECT_EQ(264u, status.completedResourceCount); // 256 glyphs, 2 sprite images, 2 sprite jsons, 1 tile, 1 style, source, image
             EXPECT_EQ(test.size, status.completedResourceSize);
 
@@ -260,6 +262,7 @@ TEST(OfflineDownload, Activate) {
             OfflineRegionStatus computedStatus = download.getStatus();
             EXPECT_EQ(OfflineRegionDownloadState::Inactive, computedStatus.downloadState);
             EXPECT_EQ(status.requiredResourceCount, computedStatus.requiredResourceCount);
+            EXPECT_EQ(status.requiredTileCount, computedStatus.requiredTileCount);
             EXPECT_EQ(status.completedResourceCount, computedStatus.completedResourceCount);
             EXPECT_EQ(status.completedResourceSize, computedStatus.completedResourceSize);
             EXPECT_EQ(status.completedTileCount, computedStatus.completedTileCount);
@@ -330,6 +333,7 @@ TEST(OfflineDownload, ExcludeIdeographs) {
     
     observer->statusChangedFn = [&] (OfflineRegionStatus status) {
         if (status.complete()) {
+            EXPECT_EQ(status.completedTileCount, status.requiredTileCount);
             EXPECT_EQ(138u, status.completedResourceCount); // 130 glyphs, 2 sprite images, 2 sprite jsons, 1 tile, 1 style, source, image
             EXPECT_EQ(test.size, status.completedResourceSize);
             
@@ -337,6 +341,7 @@ TEST(OfflineDownload, ExcludeIdeographs) {
             OfflineRegionStatus computedStatus = download.getStatus();
             EXPECT_EQ(OfflineRegionDownloadState::Inactive, computedStatus.downloadState);
             EXPECT_EQ(status.requiredResourceCount, computedStatus.requiredResourceCount);
+            EXPECT_EQ(status.requiredTileCount, computedStatus.requiredTileCount);
             EXPECT_EQ(status.completedResourceCount, computedStatus.completedResourceCount);
             EXPECT_EQ(status.completedResourceSize, computedStatus.completedResourceSize);
             EXPECT_EQ(status.completedTileCount, computedStatus.completedTileCount);
@@ -391,6 +396,8 @@ TEST(OfflineDownload, GetStatusNoResources) {
     EXPECT_EQ(0u, status.completedResourceCount);
     EXPECT_EQ(0u, status.completedResourceSize);
     EXPECT_EQ(1u, status.requiredResourceCount);
+    EXPECT_EQ(0u, status.completedTileCount);
+    EXPECT_EQ(0u, status.requiredTileCount);
     EXPECT_FALSE(status.requiredResourceCountIsPrecise);
     EXPECT_FALSE(status.complete());
 }
@@ -414,6 +421,8 @@ TEST(OfflineDownload, GetStatusStyleComplete) {
     EXPECT_EQ(1u, status.completedResourceCount);
     EXPECT_EQ(test.size, status.completedResourceSize);
     EXPECT_EQ(263u, status.requiredResourceCount);
+    EXPECT_EQ(0u, status.completedTileCount);
+    EXPECT_EQ(0u, status.requiredTileCount);
     EXPECT_FALSE(status.requiredResourceCountIsPrecise);
     EXPECT_FALSE(status.complete());
 }
@@ -441,6 +450,8 @@ TEST(OfflineDownload, GetStatusStyleAndSourceComplete) {
     EXPECT_EQ(2u, status.completedResourceCount);
     EXPECT_EQ(test.size, status.completedResourceSize);
     EXPECT_EQ(264u, status.requiredResourceCount);
+    EXPECT_EQ(0u, status.completedTileCount);
+    EXPECT_EQ(1u, status.requiredTileCount);
     EXPECT_TRUE(status.requiredResourceCountIsPrecise);
     EXPECT_FALSE(status.complete());
 }


### PR DESCRIPTION
This is useful for tracking down the required amount of tiles for a given offline region.