### PR TITLE
[ios] Allow MGLScaleBar to support dark mode on iOS 13

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed an issue that caused the tilt gesture to trigger too easily and conflict with pinch or pan gestures. ([#15349](https://github.com/mapbox/mapbox-gl-native/pull/15349))
 * Fixed a bug with annotation view positions after camera transitions. ([#15122](https://github.com/mapbox/mapbox-gl-native/pull/15122/))
 * Fixed a rendering issue of `collisionBox` when `text-translate` or `icon-translate` is enabled. ([#15467](https://github.com/mapbox/mapbox-gl-native/pull/15467))
+* Fixed an issue where the scale bar text would become illegible if iOS 13 dark mode was enabled. ([#15524](https://github.com/mapbox/mapbox-gl-native/pull/15524))
 
  ### Performance improvements
  

--- a/platform/ios/src/MGLScaleBar.mm
+++ b/platform/ios/src/MGLScaleBar.mm
@@ -101,7 +101,6 @@ static const CGFloat MGLFeetPerMeter = 3.28084;
 
 - (void)drawTextInRect:(CGRect)rect {
     CGSize shadowOffset = self.shadowOffset;
-    UIColor *textColor = self.textColor;
     
     CGContextRef context = UIGraphicsGetCurrentContext();
     CGContextSetLineWidth(context, 2);
@@ -112,7 +111,7 @@ static const CGFloat MGLFeetPerMeter = 3.28084;
     [super drawTextInRect:rect];
     
     CGContextSetTextDrawingMode(context, kCGTextFill);
-    self.textColor = textColor;
+    self.textColor = [UIColor blackColor];
     self.shadowOffset = CGSizeMake(0, 0);
     [super drawTextInRect:rect];
     


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/15452 by changing the text color before being drawn into the `CGContext`.

![Screenshot 2019-08-29 11 27 44](https://user-images.githubusercontent.com/10850812/63966426-1af57880-ca50-11e9-974d-6f4735876266.png)
