### PR TITLE
[qt] Fix Qt version comparison

### DIFF
--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -136,7 +136,7 @@ std::unique_ptr<mbgl::style::Image> toStyleImage(const QString &id, const QImage
         .rgbSwapped()
         .convertToFormat(QImage::Format_ARGB32_Premultiplied);
 
-#if QT_VERSION >= 0x051000
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     auto img = std::make_unique<uint8_t[]>(swapped.sizeInBytes());
     memcpy(img.get(), swapped.constBits(), swapped.sizeInBytes());
 #else

--- a/platform/qt/src/qt_image.cpp
+++ b/platform/qt/src/qt_image.cpp
@@ -54,7 +54,7 @@ PremultipliedImage decodeImage(const std::string& string) {
         throw std::runtime_error("Unsupported image type");
     }
 
-#if QT_VERSION >= 0x051000
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     auto img = std::make_unique<uint8_t[]>(image.sizeInBytes());
     memcpy(img.get(), image.constBits(), image.sizeInBytes());
 #else


### PR DESCRIPTION
Because the version is represented in hex, 0x051000 is not the same
as Qt 5.10, which means that the deprecated code will be enabled
for versions smaller than 5.16.