### PR TITLE
Always call onSourceLoaded observers

### DIFF
--- a/src/mbgl/style/sources/custom_geometry_source.cpp
+++ b/src/mbgl/style/sources/custom_geometry_source.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/style/sources/custom_geometry_source.hpp>
 #include <mbgl/style/custom_tile_loader.hpp>
 #include <mbgl/style/sources/custom_geometry_source_impl.hpp>
+#include <mbgl/style/source_observer.hpp>
 #include <mbgl/actor/actor.hpp>
 #include <mbgl/actor/scheduler.hpp>
 #include <mbgl/tile/tile_id.hpp>
@@ -25,6 +26,7 @@ const CustomGeometrySource::Impl& CustomGeometrySource::impl() const {
 void CustomGeometrySource::loadDescription(FileSource&) {
     baseImpl = makeMutable<CustomGeometrySource::Impl>(impl(), loader->self());
     loaded = true;
+    observer->onSourceLoaded(*this);
 }
 
 void CustomGeometrySource::setTileData(const CanonicalTileID& tileID,

--- a/src/mbgl/style/sources/raster_source.cpp
+++ b/src/mbgl/style/sources/raster_source.cpp
@@ -41,6 +41,7 @@ void RasterSource::loadDescription(FileSource& fileSource) {
     if (urlOrTileset.is<Tileset>()) {
         baseImpl = makeMutable<Impl>(impl(), urlOrTileset.get<Tileset>());
         loaded = true;
+        observer->onSourceLoaded(*this);
         return;
     }
 

--- a/src/mbgl/style/sources/vector_source.cpp
+++ b/src/mbgl/style/sources/vector_source.cpp
@@ -38,6 +38,7 @@ void VectorSource::loadDescription(FileSource& fileSource) {
     if (urlOrTileset.is<Tileset>()) {
         baseImpl = makeMutable<Impl>(impl(), urlOrTileset.get<Tileset>());
         loaded = true;
+        observer->onSourceLoaded(*this);
         return;
     }
 

--- a/src/mbgl/style/style_impl.cpp
+++ b/src/mbgl/style/style_impl.cpp
@@ -140,9 +140,8 @@ void Style::Impl::addSource(std::unique_ptr<Source> source) {
     }
 
     source->setObserver(this);
-    source->loadDescription(fileSource);
-
-    sources.add(std::move(source));
+    auto item = sources.add(std::move(source));
+    item->loadDescription(fileSource);
 }
 
 std::unique_ptr<Source> Style::Impl::removeSource(const std::string& id) {

--- a/test/storage/sync_file_source.test.cpp
+++ b/test/storage/sync_file_source.test.cpp
@@ -1,0 +1,50 @@
+#include <mbgl/util/run_loop.hpp>
+#include <mbgl/util/io.hpp>
+#include <mbgl/storage/file_source.hpp>
+#include <mbgl/gfx/headless_frontend.hpp>
+#include <mbgl/map/map.hpp>
+#include <mbgl/map/map_impl.hpp>
+#include <mbgl/style/style.hpp>
+#include <mbgl/test/map_adapter.hpp>
+#include <unordered_map>
+
+#include <gtest/gtest.h>
+
+using namespace mbgl;
+
+class SyncFileSource : public FileSource {
+public:
+    std::unique_ptr<AsyncRequest> request(const Resource& resource, FileSource::Callback callback) {
+        Response response;
+        auto it = assets.find(resource.url);
+        if (it == assets.end()) {
+            response.error = std::make_unique<Response::Error>(
+                Response::Error::Reason::NotFound, std::string{ "Not Found: " } + resource.url);
+        } else {
+            response.data = it->second;
+        }
+        callback(response);
+        return nullptr;
+    }
+
+    void add(std::string const& key, std::string const& data) {
+        assets.emplace(key, std::make_shared<std::string>(data));
+    };
+
+private:
+    std::unordered_map<std::string, std::shared_ptr<std::string>> assets;
+};
+
+TEST(SyncFileSource, LoadSyncRender) {
+    util::RunLoop loop;
+    auto fs = std::make_shared<SyncFileSource>();
+    fs->add("mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7",
+            util::read_file("test/fixtures/resources/source_vector.json"));
+    fs->add("mapbox://sprites/mapbox/streets-v9.png",
+            util::read_file("test/fixtures/resources/sprite.png"));
+    fs->add("mapbox://sprites/mapbox/streets-v9.json",
+            util::read_file("test/fixtures/resources/sprite.json"));
+    HeadlessFrontend frontend{ { 512, 512 }, 1.0 };
+    MapAdapter map{ frontend, MapObserver::nullObserver(), fs, MapOptions() };
+    map.getStyle().loadJSON(util::read_file("test/fixtures/resources/style_vector.json"));
+}

--- a/test/test-files.json
+++ b/test/test-files.json
@@ -46,6 +46,7 @@
         "test/storage/online_file_source.test.cpp",
         "test/storage/resource.test.cpp",
         "test/storage/sqlite.test.cpp",
+        "test/storage/sync_file_source.test.cpp",
         "test/style/conversion/conversion_impl.test.cpp",
         "test/style/conversion/function.test.cpp",
         "test/style/conversion/geojson_options.test.cpp",


### PR DESCRIPTION
When no network requests have to be made because the TileJSON metadata is included inline in a style, we never triggered a `onSourceLoad` call. This PR adds calls.

We found this by way of https://github.com/mapbox/mapbox-gl-native/issues/15514. Here's what happened:
- We are moving the addition of the new `Source` object to the `sources` collection in the style to _before_ we call `loadDescription`. In that call, however, we are mutating the implementation and updating `baseImpl`. Now, the `impl` pointer in the collection is out of date with the updated `impl`. If we never schedule a `onSourceLoadeded`, we never call `sources.update(...)` if no other sources are loaded, so the change is not picked up.
- This only happened when the TileJSON was specified inline, if we loaded it from the network, we correctly fired the `onSourceLoaded` event.

This PR includes and supersedes https://github.com/mapbox/mapbox-gl-native/pull/15531.

#### After merge:
- [ ] Remove [`delay-source-load` branch](https://github.com/mapbox/mapbox-gl-native/compare/delay-source-load)

/cc @springmeyer 