### PR TITLE
[darwin] Use en_US as default test locale/language

### DIFF
--- a/platform/darwin/test/MGLClockDirectionFormatterTests.m
+++ b/platform/darwin/test/MGLClockDirectionFormatterTests.m
@@ -7,11 +7,6 @@
 
 @implementation MGLClockDirectionFormatterTests
 
-- (void)setUp {
-    // FIXME: https://github.com/mapbox/mapbox-gl-native/issues/14908
-    XCTAssertEqualObjects(NSLocale.currentLocale.localeIdentifier, @"en_US", @"Device locale must be en_US for these tests to pass.");
-}
-
 - (void)testClockDirections {
     MGLClockDirectionFormatter *shortFormatter = [[MGLClockDirectionFormatter alloc] init];
     shortFormatter.unitStyle = NSFormattingUnitStyleShort;

--- a/platform/darwin/test/MGLCompassDirectionFormatterTests.m
+++ b/platform/darwin/test/MGLCompassDirectionFormatterTests.m
@@ -7,11 +7,6 @@
 
 @implementation MGLCompassDirectionFormatterTests
 
-- (void)setUp {
-    // FIXME: https://github.com/mapbox/mapbox-gl-native/issues/14908
-    XCTAssertEqualObjects(NSLocale.currentLocale.localeIdentifier, @"en_US", @"Device locale must be en_US for these tests to pass.");
-}
-
 - (void)testCompassDirections {
     MGLCompassDirectionFormatter *shortFormatter = [[MGLCompassDirectionFormatter alloc] init];
     shortFormatter.unitStyle = NSFormattingUnitStyleShort;

--- a/platform/darwin/test/MGLCoordinateFormatterTests.m
+++ b/platform/darwin/test/MGLCoordinateFormatterTests.m
@@ -7,11 +7,6 @@
 
 @implementation MGLCoordinateFormatterTests
 
-- (void)setUp {
-    // FIXME: https://github.com/mapbox/mapbox-gl-native/issues/14908
-    XCTAssertEqualObjects(NSLocale.currentLocale.localeIdentifier, @"en_US", @"Device locale must be en_US for these tests to pass.");
-}
-
 - (void)testStrings {
     MGLCoordinateFormatter *shortFormatter = [[MGLCoordinateFormatter alloc] init];
     shortFormatter.unitStyle = NSFormattingUnitStyleShort;

--- a/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/CI.xcscheme
+++ b/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/CI.xcscheme
@@ -54,6 +54,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = "en"
+      region = "US"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES"
       shouldUseLaunchSchemeArgsEnv = "NO">

--- a/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/dynamic.xcscheme
+++ b/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/dynamic.xcscheme
@@ -40,7 +40,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      language = "en"
+      region = "US">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DA8847D11CBAF91600AB86E3"
+            BuildableName = "Mapbox.framework"
+            BlueprintName = "dynamic"
+            ReferencedContainer = "container:ios.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO"
@@ -54,17 +65,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DA8847D11CBAF91600AB86E3"
-            BuildableName = "Mapbox.framework"
-            BlueprintName = "dynamic"
-            ReferencedContainer = "container:ios.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -85,8 +85,6 @@
             ReferencedContainer = "container:ios.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/platform/ios/test/MGLMapAccessibilityElementTests.m
+++ b/platform/ios/test/MGLMapAccessibilityElementTests.m
@@ -8,11 +8,6 @@
 
 @implementation MGLMapAccessibilityElementTests
 
-- (void)setUp {
-    // FIXME: https://github.com/mapbox/mapbox-gl-native/issues/14908
-    XCTAssertEqualObjects(NSLocale.currentLocale.localeIdentifier, @"en_US", @"Device locale must be en_US for these tests to pass.");
-}
-
 - (void)testFeatureLabels {
     MGLPointFeature *feature = [[MGLPointFeature alloc] init];
     feature.attributes = @{

--- a/platform/macos/macos.xcodeproj/xcshareddata/xcschemes/CI.xcscheme
+++ b/platform/macos/macos.xcodeproj/xcshareddata/xcschemes/CI.xcscheme
@@ -56,7 +56,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9EEBD19ABEE247CF8D3CF4C5"
+               BlueprintIdentifier = "9771D7F76DA54F52A89268C6"
                BuildableName = "mbgl-test"
                BlueprintName = "mbgl-test"
                ReferencedContainer = "container:../../build/macos/mbgl.xcodeproj">
@@ -70,7 +70,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B328AB16ECE141AAAE2A72C8"
+               BlueprintIdentifier = "D87DA13F4A80489CB4508EBD"
                BuildableName = "mbgl-benchmark"
                BlueprintName = "mbgl-benchmark"
                ReferencedContainer = "container:../../build/macos/mbgl.xcodeproj">
@@ -82,7 +82,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      language = "en"
+      region = "US">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DA839E911CC2E3400062CAFB"
+            BuildableName = "Mapbox GL.app"
+            BlueprintName = "macosapp"
+            ReferencedContainer = "container:macos.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -95,17 +106,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DA839E911CC2E3400062CAFB"
-            BuildableName = "Mapbox GL.app"
-            BlueprintName = "macosapp"
-            ReferencedContainer = "container:macos.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -126,8 +126,6 @@
             ReferencedContainer = "container:macos.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/platform/macos/macos.xcodeproj/xcshareddata/xcschemes/dynamic.xcscheme
+++ b/platform/macos/macos.xcodeproj/xcshareddata/xcschemes/dynamic.xcscheme
@@ -40,7 +40,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      language = "en"
+      region = "US">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DAE6C3271CC30DB200DB3429"
+            BuildableName = "Mapbox.framework"
+            BlueprintName = "dynamic"
+            ReferencedContainer = "container:macos.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -53,17 +64,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DAE6C3271CC30DB200DB3429"
-            BuildableName = "Mapbox.framework"
-            BlueprintName = "dynamic"
-            ReferencedContainer = "container:macos.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -84,8 +84,6 @@
             ReferencedContainer = "container:macos.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/platform/macos/macos.xcodeproj/xcshareddata/xcschemes/macosapp.xcscheme
+++ b/platform/macos/macos.xcodeproj/xcshareddata/xcschemes/macosapp.xcscheme
@@ -26,8 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       language = "en"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      region = "US">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DA839E911CC2E3400062CAFB"
+            BuildableName = "Mapbox GL.app"
+            BlueprintName = "macosapp"
+            ReferencedContainer = "container:macos.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -40,17 +50,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DA839E911CC2E3400062CAFB"
-            BuildableName = "Mapbox GL.app"
-            BlueprintName = "macosapp"
-            ReferencedContainer = "container:macos.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -72,8 +71,6 @@
             ReferencedContainer = "container:macos.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
Fixes #14908 by setting `en_US` as the default test locale, regardless of the simulator or device settings.

This is configured in the various schemes:

![Screen Shot 2019-09-03 at 12 51 51 PM](https://user-images.githubusercontent.com/1198851/64204008-afdde480-ce49-11e9-852a-edda574d9cf8.png)

/cc @1ec5 @julianrex 