### PR TITLE
[ios, macos] Fix content inset documentation.

### DIFF
--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -1314,8 +1314,8 @@ MGL_EXPORT
  property may be overridden at any time.
 
  Changing the value of this property updates the map view immediately. If you
- want to animate the change, use the `-setContentInset:animated:` method
- instead.
+ want to animate the change, use the `-setContentInset:animated:completionHandler:`
+ method instead.
  */
 @property (nonatomic, assign) UIEdgeInsets contentInset;
 

--- a/platform/macos/src/MGLMapView.h
+++ b/platform/macos/src/MGLMapView.h
@@ -620,8 +620,8 @@ MGL_EXPORT IB_DESIGNABLE
  the value of this property may be overridden at any time.
 
  Changing the value of this property updates the map view immediately. If you
- want to animate the change, use the `-setContentInsets:animated:` method
- instead.
+ want to animate the change, use the `-setContentInset:animated:completionHandler:`
+ method instead.
  */
 @property (nonatomic, assign) NSEdgeInsets contentInsets;
 


### PR DESCRIPTION
Fixes the documentation for which method to call when using an animatable content inset.