### PR TITLE
[core] Fix Integer overflow when converting tileCoordinates to LatLon

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -14,6 +14,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 
 ### Bug fixes
  - Fixed a rendering issue of `collisionBox` when `text-translate` or `icon-translate` is enabled. [#15467](https://github.com/mapbox/mapbox-gl-native/pull/15467)
+ - Fixed an issue of integer overflow when converting `tileCoordinates` to `LatLon`. [#15560](https://github.com/mapbox/mapbox-gl-native/pull/15560)
 
 ## 8.3.0 - August 28, 2019
 [Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.3.0-beta.1...android-v8.3.0) since [Mapbox Maps SDK for Android v8.3.0-beta.1](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.3.0-beta.1):

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed a rendering issue of `collisionBox` when `text-translate` or `icon-translate` is enabled. ([#15467](https://github.com/mapbox/mapbox-gl-native/pull/15467))
 * Fixed an issue where the scale bar text would become illegible if iOS 13 dark mode was enabled. ([#15524](https://github.com/mapbox/mapbox-gl-native/pull/15524))
  * Enable using of `text-offset` option together with `text-variable-anchor` (if `text-radial-offset` option is not provided). If used with `text-variable-anchor`, input values will be taken as absolute values. Offsets along the x- and y-axis will be applied automatically based on the anchor position. ([#15542](https://github.com/mapbox/mapbox-gl-native/pull/15542))
+ * Fixed an issue of integer overflow when converting `tileCoordinates` to `LatLon`. ([#15560](https://github.com/mapbox/mapbox-gl-native/pull/15560))
 
  ### Performance improvements
  

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fixed symbol overlap when zooming out quickly. ([15416](https://github.com/mapbox/mapbox-gl-native/pull/15416))
 * Fixed a rendering issue that non-SDF icon would be treated as SDF icon if they are in the same layer. ([#15456](https://github.com/mapbox/mapbox-gl-native/pull/15456))
 * Fixed a rendering issue of `collisionBox` when `text-translate` or `icon-translate` is enabled. ([#15467](https://github.com/mapbox/mapbox-gl-native/pull/15467))
+* Fixed an issue of integer overflow when converting `tileCoordinates` to `LatLon`. ([#15560](https://github.com/mapbox/mapbox-gl-native/pull/15560))
 
 ### Styles and rendering
 

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fixed rendering and collision detection issues with using `text-variable-anchor` and `icon-text-fit` properties on the same layer ([#15367](https://github.com/mapbox/mapbox-gl-native/pull/15367)).
 * Fixed a rendering issue that non-SDF icon would be treated as SDF icon if they are in the same layer. ([#15456](https://github.com/mapbox/mapbox-gl-native/pull/15456))
 * Fixed a rendering issue of `collisionBox` when `text-translate` or `icon-translate` is enabled. ([#15467](https://github.com/mapbox/mapbox-gl-native/pull/15467))
+* Fixed an issue of integer overflow when converting `tileCoordinates` to `LatLon`. ([#15560](https://github.com/mapbox/mapbox-gl-native/pull/15560))
 
 # 4.2.0
 - Add an option to set whether or not an image should be treated as a SDF ([#15054](https://github.com/mapbox/mapbox-gl-native/issues/15054))

--- a/src/mbgl/tile/geometry_tile_data.cpp
+++ b/src/mbgl/tile/geometry_tile_data.cpp
@@ -101,8 +101,8 @@ void limitHoles(GeometryCollection& polygon, uint32_t maxHoles) {
 
 static Feature::geometry_type convertGeometry(const GeometryTileFeature& geometryTileFeature, const CanonicalTileID& tileID) {
     const double size = util::EXTENT * std::pow(2, tileID.z);
-    const double x0 = util::EXTENT * tileID.x;
-    const double y0 = util::EXTENT * tileID.y;
+    const double x0 = util::EXTENT * static_cast<double>(tileID.x);
+    const double y0 = util::EXTENT * static_cast<double>(tileID.y);
 
     auto tileCoordinatesToLatLng = [&] (const Point<int16_t>& p) {
         double y2 = 180 - (p.y + y0) * 360 / size;


### PR DESCRIPTION
Fix an issue that potential integer overflow would happen with high zoom level.