### PR TITLE
[android] Bumped Java SDK dependency to 4.9.0-alpha.1

### DIFF
--- a/platform/android/LICENSE.md
+++ b/platform/android/LICENSE.md
@@ -185,13 +185,13 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
-Mapbox GL uses portions of the Mapbox Services SDK.  
+Mapbox GL uses portions of the Mapbox Java SDK.  
 URL: [https://github.com/mapbox/mapbox-java](https://github.com/mapbox/mapbox-java)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Mapbox Services SDK.  
+Mapbox GL uses portions of the Mapbox Java SDK.  
 URL: [https://github.com/mapbox/mapbox-java](https://github.com/mapbox/mapbox-java)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 

--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
     ]
 
     versions = [
-            mapboxServices  : '4.8.0',
+            mapboxServices  : '4.9.0-alpha.1',
             mapboxTelemetry : '4.5.1',
             mapboxCore      : '1.3.0',
             mapboxGestures  : '0.5.1',


### PR DESCRIPTION
This pr bumps the Maps SDK for Android's Java SDK dependency to `4.9.0-alpha.1` as part of [the eventual `4.9.0` release](https://github.com/mapbox/mapbox-java/issues/1070).