### PR TITLE
[core] Add unit test to verify that Offline usage tag is not set

### DIFF
--- a/test/storage/offline_download.test.cpp
+++ b/test/storage/offline_download.test.cpp
@@ -1,8 +1,12 @@
+#include <mbgl/test/map_adapter.hpp>
 #include <mbgl/test/stub_file_source.hpp>
 #include <mbgl/test/fake_file_source.hpp>
+#include <mbgl/test/stub_map_observer.hpp>
 #include <mbgl/test/fixture_log_observer.hpp>
 #include <mbgl/test/sqlite3_test_fs.hpp>
 
+#include <mbgl/gfx/headless_frontend.hpp>
+#include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/storage/offline.hpp>
 #include <mbgl/storage/offline_database.hpp>
 #include <mbgl/storage/offline_download.hpp>
@@ -14,7 +18,6 @@
 
 #include <mbgl/storage/sqlite3.hpp>
 #include <gtest/gtest.h>
-#include <iostream>
 
 using namespace mbgl;
 using namespace std::literals::string_literals;
@@ -69,6 +72,10 @@ public:
         OfflineTilePyramidRegionDefinition definition { "", LatLngBounds::hull({1, 2}, {3, 4}), 5, 6, 1.0, true };
         OfflineRegionMetadata metadata;
         return db.createRegion(definition, metadata);
+    }
+
+    auto invalidateRegion(int64_t region) {
+        return db.invalidateRegion(region);
     }
 
     Response response(const std::string& path) {
@@ -867,5 +874,76 @@ TEST(OfflineDownload, DiskFull) {
 
     test.loop.run();
     EXPECT_EQ(0u, log.uncheckedCount());
+}
+
+// Test verifies that resource requests for invalidated region don't
+// have Resource::Usage::Offline tag set.
+TEST(OfflineDownload, ResourceOfflineUsageUnset) {
+    deleteDatabaseFiles();
+    test::SQLite3TestFS fs;
+
+    OfflineTest test{ filename_test_fs };
+    auto region = test.createRegion();
+    ASSERT_TRUE(region);
+
+    OfflineDownload download(
+        region->getID(),
+        OfflineTilePyramidRegionDefinition("http://127.0.0.1:3000/inline_source.style.json",
+                                            LatLngBounds::world(), 0.0, 0.0, 1.0, false),
+        test.db, test.fileSource);
+
+    test.fileSource.styleResponse = [&] (const Resource& resource) {
+        EXPECT_TRUE(resource.priority == Resource::Priority::Low);
+        EXPECT_TRUE(resource.usage == Resource::Usage::Offline);
+        return test.response("inline_source.style.json");
+    };
+
+    test.fileSource.tileResponse = [&] (const Resource& resource) {
+        EXPECT_TRUE(resource.priority == Resource::Priority::Low);
+        EXPECT_TRUE(resource.usage == Resource::Usage::Offline);
+        return test.response("0-0-0.vector.pbf");
+    };
+
+    auto observer = std::make_unique<MockObserver>();
+    observer->statusChangedFn = [&] (OfflineRegionStatus status) {
+        if (status.complete()) {
+            // Once download completes, invalidate region and try rendering map.
+            // Resource requests must not have Offline usage tag.
+            ASSERT_FALSE(test.invalidateRegion(region->getID()));
+            test.loop.stop();
+        }
+    };
+
+    download.setObserver(std::move(observer));
+    download.setState(OfflineRegionDownloadState::Active);
+    test.loop.run();
+
+    std::shared_ptr<StubFileSource> stubfileSource = std::make_shared<StubFileSource>();
+    stubfileSource->styleResponse = [&] (const Resource& resource) {
+        EXPECT_TRUE(resource.usage != Resource::Usage::Offline);
+        return test.response("inline_source.style.json");
+    };
+
+    stubfileSource->tileResponse = [&] (const Resource& resource) {
+        EXPECT_TRUE(resource.usage != Resource::Usage::Offline);
+        return test.response("0-0-0.vector.pbf");
+    };
+
+    StubMapObserver mapObserver;
+    mapObserver.didFinishRenderingFrameCallback = [&] (MapObserver::RenderMode mode) {
+        if (mode == MapObserver::RenderMode::Full) {
+            test.loop.stop();
+        }
+    };
+
+    HeadlessFrontend frontend { 1 };
+    MapAdapter map { frontend, mapObserver, stubfileSource,
+            MapOptions()
+            .withMapMode(MapMode::Continuous)
+            .withSize(frontend.getSize())};
+
+    map.getStyle().loadURL("http://127.0.0.1:3000/inline_source.style.json");
+    map.jumpTo(CameraOptions().withCenter(LatLng{0.0, 0.0}).withZoom(0));
+    test.loop.run();
 }
 #endif // __QT__


### PR DESCRIPTION
New unit test checks that Offline usage flag is not set for invalidated offline region resource requests.

Fixes: #15490