### PR TITLE
[Core] Fix wrong `maxzoom` setting of tileSet when using URL source

### DIFF
--- a/include/mbgl/style/sources/vector_source.hpp
+++ b/include/mbgl/style/sources/vector_source.hpp
@@ -12,7 +12,7 @@ namespace style {
 
 class VectorSource final : public Source {
 public:
-    VectorSource(std::string id, variant<std::string, Tileset> urlOrTileset);
+    VectorSource(std::string id, variant<std::string, Tileset> urlOrTileset, optional<float> maxZoom = nullopt, optional<float> minZoom = nullopt);
     ~VectorSource() final;
 
     const variant<std::string, Tileset>& getURLOrTileset() const;
@@ -31,6 +31,8 @@ private:
     const variant<std::string, Tileset> urlOrTileset;
     std::unique_ptr<AsyncRequest> req;
     mapbox::base::WeakPtrFactory<Source> weakFactory {this};
+    optional<float> maxZoom;
+    optional<float> minZoom;
 };
 
 template <>

--- a/include/mbgl/style/sources/vector_source.hpp
+++ b/include/mbgl/style/sources/vector_source.hpp
@@ -12,7 +12,8 @@ namespace style {
 
 class VectorSource final : public Source {
 public:
-    VectorSource(std::string id, variant<std::string, Tileset> urlOrTileset, optional<float> maxZoom = nullopt, optional<float> minZoom = nullopt);
+    VectorSource(std::string id, variant<std::string, Tileset> urlOrTileset, optional<float> maxZoom = nullopt,
+                 optional<float> minZoom = nullopt);
     ~VectorSource() final;
 
     const variant<std::string, Tileset>& getURLOrTileset() const;

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 ### Bug fixes
  - Fixed constant repainting for the sources with invisible layers, caused by `RenderSource::hasFadingTiles()` returning `true` all the time. [#15600](https://github.com/mapbox/mapbox-gl-native/pull/15600)
  - Fixed an issue that caused the state of CompassView not up to date when `UiSettings.setCompassEnabled()` is set to true. [#15606](https://github.com/mapbox/mapbox-gl-native/pull/15606)
+ - Fixed an issue that `maxzoom` in style `Sources` option was ignored when URL resource is provided. It may cause problems such as extra tiles downloading at higher zoom level than `maxzoom`, or problems that wrong setting of `overscaledZ` in `OverscaledTileID` that will be passed to `SymbolLayout`, leading wrong rendering appearance. [#15581](https://github.com/mapbox/mapbox-gl-native/pull/15581)
 
 ## 8.4.0-alpha.2 - September 11, 2019
 [Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.4.0-alpha.1...android-v8.4.0-alpha.2) since [Mapbox Maps SDK for Android v8.4.0-alpha.1](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.4.0-alpha.1): 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ### Styles and rendering
 * Added an `-[MGLMapSnapshotter startWithOverlayHandler:completionHandler:]` method to provide the snapshot's current `CGContext` in order to perform custom drawing on `MGLMapSnapShot` objects. ([#15530](https://github.com/mapbox/mapbox-gl-native/pull/15530))
+* Fixed an issue that `maxzoom` in style `Sources` option was ignored when URL resource is provided. It may cause problems such as extra tiles downloading at higher zoom level than `maxzoom`, or problems that wrong setting of `overscaledZ` in `OverscaledTileID` that will be passed to `SymbolLayout`, leading wrong rendering appearance. ([#15581](https://github.com/mapbox/mapbox-gl-native/pull/15581))
 
 ### Performance improvements
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Fixed a rendering issue of `collisionBox` when `text-translate` or `icon-translate` is enabled. ([#15467](https://github.com/mapbox/mapbox-gl-native/pull/15467))
 * Fixed an issue of integer overflow when converting `tileCoordinates` to `LatLon`, which caused issues such as `queryRenderedFeatures` and `querySourceFeatures` returning incorrect coordinates at zoom levels 20 and higher. ([#15560](https://github.com/mapbox/mapbox-gl-native/pull/15560))
 * Added an `-[MGLMapSnapshotter startWithOverlayHandler:completionHandler:]` method to provide the snapshot's current `CGContext` in order to perform custom drawing on `MGLMapSnapShot` objects. ([#15530](https://github.com/mapbox/mapbox-gl-native/pull/15530))
+* Fixed an issue that `maxzoom` in style `Sources` option was ignored when URL resource is provided. It may cause problems such as extra tiles downloading at higher zoom level than `maxzoom`, or problems that wrong setting of `overscaledZ` in `OverscaledTileID` that will be passed to `SymbolLayout`, leading wrong rendering appearance. ([#15581](https://github.com/mapbox/mapbox-gl-native/pull/15581))
 
 ### Styles and rendering
 

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixed a rendering issue of `collisionBox` when `text-translate` or `icon-translate` is enabled. ([#15467](https://github.com/mapbox/mapbox-gl-native/pull/15467))
 * Fixed an issue of integer overflow when converting `tileCoordinates` to `LatLon`, which caused issues such as `queryRenderedFeatures` and `querySourceFeatures` returning incorrect coordinates at zoom levels 20 and higher. ([#15560](https://github.com/mapbox/mapbox-gl-native/pull/15560))
 * Add typechecking while constructing legacy filter to prevent converting an unexpected filter type [#15389](https://github.com/mapbox/mapbox-gl-native/pull/15389).
+* Fixed an issue that `maxzoom` in style `Sources` option was ignored when URL resource is provided. It may cause problems such as extra tiles downloading at higher zoom level than `maxzoom`, or problems that wrong setting of `overscaledZ` in `OverscaledTileID` that will be passed to `SymbolLayout`, leading wrong rendering appearance. ([#15581](https://github.com/mapbox/mapbox-gl-native/pull/15581))
 
 # 4.2.0
 - Add an option to set whether or not an image should be treated as a SDF ([#15054](https://github.com/mapbox/mapbox-gl-native/issues/15054))

--- a/src/mbgl/style/conversion/source.cpp
+++ b/src/mbgl/style/conversion/source.cpp
@@ -86,8 +86,25 @@ static optional<std::unique_ptr<Source>> convertVectorSource(const std::string& 
     if (!urlOrTileset) {
         return nullopt;
     }
-
-    return { std::make_unique<VectorSource>(id, std::move(*urlOrTileset)) };
+    auto maxzoomValue = objectMember(value, "maxzoom");
+    optional<float> maxzoom;
+    if (maxzoomValue) {
+        maxzoom = toNumber(*maxzoomValue);
+        if (!maxzoom || *maxzoom < 0 || *maxzoom > std::numeric_limits<uint8_t>::max()) {
+            error.message = "invalid maxzoom";
+            return nullopt;
+        }
+    }
+    auto minzoomValue = objectMember(value, "minzoom");
+    optional<float> minzoom;
+    if (minzoomValue) {
+        minzoom = toNumber(*minzoomValue);
+        if (!minzoom || *minzoom < 0 || *minzoom > std::numeric_limits<uint8_t>::max()) {
+            error.message = "invalid minzoom";
+            return nullopt;
+        }
+    }
+    return { std::make_unique<VectorSource>(id, std::move(*urlOrTileset), maxzoom, minzoom) };
 }
 
 static optional<std::unique_ptr<Source>> convertGeoJSONSource(const std::string& id,

--- a/src/mbgl/style/conversion/source.cpp
+++ b/src/mbgl/style/conversion/source.cpp
@@ -104,7 +104,7 @@ static optional<std::unique_ptr<Source>> convertVectorSource(const std::string& 
             return nullopt;
         }
     }
-    return { std::make_unique<VectorSource>(id, std::move(*urlOrTileset), std::move(maxzoom), std::move(minzoom)) };
+    return {std::make_unique<VectorSource>(id, std::move(*urlOrTileset), std::move(maxzoom), std::move(minzoom))};
 }
 
 static optional<std::unique_ptr<Source>> convertGeoJSONSource(const std::string& id,

--- a/src/mbgl/style/conversion/source.cpp
+++ b/src/mbgl/style/conversion/source.cpp
@@ -104,7 +104,7 @@ static optional<std::unique_ptr<Source>> convertVectorSource(const std::string& 
             return nullopt;
         }
     }
-    return { std::make_unique<VectorSource>(id, std::move(*urlOrTileset), maxzoom, minzoom) };
+    return { std::make_unique<VectorSource>(id, std::move(*urlOrTileset), std::move(maxzoom), std::move(minzoom)) };
 }
 
 static optional<std::unique_ptr<Source>> convertGeoJSONSource(const std::string& id,

--- a/src/mbgl/style/sources/vector_source.cpp
+++ b/src/mbgl/style/sources/vector_source.cpp
@@ -11,9 +11,11 @@
 namespace mbgl {
 namespace style {
 
-VectorSource::VectorSource(std::string id, variant<std::string, Tileset> urlOrTileset_)
+VectorSource::VectorSource(std::string id, variant<std::string, Tileset> urlOrTileset_, optional<float> maxZoom_, optional<float> minZoom_)
     : Source(makeMutable<Impl>(std::move(id))),
-      urlOrTileset(std::move(urlOrTileset_)) {
+      urlOrTileset(std::move(urlOrTileset_)),
+      maxZoom(maxZoom_),
+      minZoom(minZoom_) {
 }
 
 VectorSource::~VectorSource() = default;
@@ -61,7 +63,8 @@ void VectorSource::loadDescription(FileSource& fileSource) {
                 observer->onSourceError(*this, std::make_exception_ptr(util::StyleParseException(error.message)));
                 return;
             }
-
+            if (maxZoom) tileset->zoomRange.max = *maxZoom;
+            if (minZoom) tileset->zoomRange.min = *minZoom;
             util::mapbox::canonicalizeTileset(*tileset, url, getType(), util::tileSize);
             bool changed = impl().tileset != *tileset;
 

--- a/src/mbgl/style/sources/vector_source.cpp
+++ b/src/mbgl/style/sources/vector_source.cpp
@@ -14,8 +14,8 @@ namespace style {
 VectorSource::VectorSource(std::string id, variant<std::string, Tileset> urlOrTileset_, optional<float> maxZoom_, optional<float> minZoom_)
     : Source(makeMutable<Impl>(std::move(id))),
       urlOrTileset(std::move(urlOrTileset_)),
-      maxZoom(maxZoom_),
-      minZoom(minZoom_) {
+      maxZoom(std::move(maxZoom_)),
+      minZoom(std::move(minZoom_)) {
 }
 
 VectorSource::~VectorSource() = default;

--- a/src/mbgl/style/sources/vector_source.cpp
+++ b/src/mbgl/style/sources/vector_source.cpp
@@ -63,8 +63,12 @@ void VectorSource::loadDescription(FileSource& fileSource) {
                 observer->onSourceError(*this, std::make_exception_ptr(util::StyleParseException(error.message)));
                 return;
             }
-            if (maxZoom) tileset->zoomRange.max = *maxZoom;
-            if (minZoom) tileset->zoomRange.min = *minZoom;
+            if (maxZoom) {
+                tileset->zoomRange.max = *maxZoom;
+            }
+            if (minZoom) {
+                tileset->zoomRange.min = *minZoom;
+            }
             util::mapbox::canonicalizeTileset(*tileset, url, getType(), util::tileSize);
             bool changed = impl().tileset != *tileset;
 

--- a/src/mbgl/style/sources/vector_source.cpp
+++ b/src/mbgl/style/sources/vector_source.cpp
@@ -11,12 +11,12 @@
 namespace mbgl {
 namespace style {
 
-VectorSource::VectorSource(std::string id, variant<std::string, Tileset> urlOrTileset_, optional<float> maxZoom_, optional<float> minZoom_)
+VectorSource::VectorSource(std::string id, variant<std::string, Tileset> urlOrTileset_, optional<float> maxZoom_,
+                           optional<float> minZoom_)
     : Source(makeMutable<Impl>(std::move(id))),
       urlOrTileset(std::move(urlOrTileset_)),
       maxZoom(std::move(maxZoom_)),
-      minZoom(std::move(minZoom_)) {
-}
+      minZoom(std::move(minZoom_)) {}
 
 VectorSource::~VectorSource() = default;
 


### PR DESCRIPTION
Fix: #15501

The pre-condition is  we try to download an offline pack from an URL source, and the source's maxzoom(let's say zoom level 17) is higher than the maxzoom(let's say zl12) we downloaded for the offline pack.
Next we try to use the offline pack from a style that having the same URL source plus a `maxzoom` option zl12, the final rendering result is different from JS.

The problem is the ignorance of `maxZoom` option in style, which leads to wrong setting of the `zoomRange` in tileSet, zl17 is set instead of zl12. If we need the map to be overscaled to zl14, the renderable TileID should be overscale Zoom 14 plus canonical Zoom12.

However, zl17 as the max zoom in `zoomRange` is higher than zl14, zl14 is not taken as overscaled. With offline database of maxzoom 12, there is no way to find tiles in zl14.  it tries to check zl14's children, and apparently, with offline, there won’t be more children for zl14. Then it starts to down grade the overScaled zoom by 1, so from 13, then 12, until it found tiles with zl12. So the rendenrable TileId we finally created has oversacalZ 12 instead of 14. 

It finally causes  incorrect `overscaledZ` value is passed to `symbolLayout`, so the rendering result of symbols is different when comparing with JS.
