### PR TITLE
[ios] Fixes an issue that caused the ornaments ignore contentInset property.

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -14,6 +14,9 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Added `-[MGLMapSnapshotOverlay coordinateForPoint:]` and `-[MGLMapSnapshotOverlay pointForCoordinate:]` to convert between context and map coordinates, mirroring those of `MGLMapSnapshot`. ([#15746](https://github.com/mapbox/mapbox-gl-native/pull/15746))
 * Suppress network requests for expired tiles update, if these tiles are invisible. ([#15741](https://github.com/mapbox/mapbox-gl-native/pull/15741))
+* Fixed an issue that cause the ornaments to ignore `MGLMapView.contentInset` property. ([#15584](https://github.com/mapbox/mapbox-gl-native/pull/15584))
+* Fixed an issue that cause `-[MGLMapView setCamere:withDuration:animationTimingFunction:edgePadding:completionHandler:]` persist the value of `edgePadding`. ([#15584](https://github.com/mapbox/mapbox-gl-native/pull/15584))
+* Added `MGLMapView.automaticallyAdjustsContentInset` property that indicates if wether the map view should automatically adjust its content insets. ([#15584](https://github.com/mapbox/mapbox-gl-native/pull/15584))
 * Fixed an issue that caused `MGLScaleBar` to have an incorrect size when resizing or rotating. ([#15703](https://github.com/mapbox/mapbox-gl-native/pull/15703))
 
 ## 5.4.0 - September 25, 2019

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		170C437D2029D97900863DF0 /* MGLHeatmapStyleLayerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 170C43792028D49800863DF0 /* MGLHeatmapStyleLayerTests.mm */; };
 		1753ED421E53CE6F00A9FD90 /* MGLConversion.h in Headers */ = {isa = PBXBuildFile; fileRef = 1753ED411E53CE6F00A9FD90 /* MGLConversion.h */; };
 		1753ED431E53CE6F00A9FD90 /* MGLConversion.h in Headers */ = {isa = PBXBuildFile; fileRef = 1753ED411E53CE6F00A9FD90 /* MGLConversion.h */; };
+		1F0196AA23174B0700F5C819 /* MGLMapViewContentInsetTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F0196A923174B0700F5C819 /* MGLMapViewContentInsetTests.m */; };
 		1F06668A1EC64F8E001C16D7 /* MGLLight.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F0666881EC64F8E001C16D7 /* MGLLight.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1F06668D1EC64F8E001C16D7 /* MGLLight.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1F0666891EC64F8E001C16D7 /* MGLLight.mm */; };
 		1F26B6C120E189C9007BCC21 /* MBXCustomLocationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F26B6C020E189C9007BCC21 /* MBXCustomLocationViewController.m */; };
@@ -899,6 +900,7 @@
 		170C43782028D49800863DF0 /* MGLHeatmapColorTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLHeatmapColorTests.mm; path = ../../darwin/test/MGLHeatmapColorTests.mm; sourceTree = "<group>"; };
 		170C43792028D49800863DF0 /* MGLHeatmapStyleLayerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLHeatmapStyleLayerTests.mm; path = ../../darwin/test/MGLHeatmapStyleLayerTests.mm; sourceTree = "<group>"; };
 		1753ED411E53CE6F00A9FD90 /* MGLConversion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLConversion.h; sourceTree = "<group>"; };
+		1F0196A923174B0700F5C819 /* MGLMapViewContentInsetTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLMapViewContentInsetTests.m; sourceTree = "<group>"; };
 		1F0666881EC64F8E001C16D7 /* MGLLight.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLLight.h; sourceTree = "<group>"; };
 		1F0666891EC64F8E001C16D7 /* MGLLight.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLLight.mm; sourceTree = "<group>"; };
 		1F26B6BF20E189C9007BCC21 /* MBXCustomLocationViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MBXCustomLocationViewController.h; sourceTree = "<group>"; };
@@ -2084,6 +2086,7 @@
 				DA5DB1291FABF1EE001C2326 /* MGLMapAccessibilityElementTests.m */,
 				DA695425215B1E75002041A4 /* MGLMapCameraTests.m */,
 				96E6145522CC135200109F14 /* MGLMapViewCompassViewTests.mm */,
+				1F0196A923174B0700F5C819 /* MGLMapViewContentInsetTests.m */,
 				96ED34DD22374C0900E9FCA9 /* MGLMapViewDirectionTests.mm */,
 				16376B481FFEED010000563E /* MGLMapViewLayoutTests.m */,
 				96381C0122C6F3950053497D /* MGLMapViewPitchTests.m */,
@@ -3322,6 +3325,7 @@
 				920A3E5D1E6F995200C16EFC /* MGLSourceQueryTests.m in Sources */,
 				DA5DB12A1FABF1EE001C2326 /* MGLMapAccessibilityElementTests.m in Sources */,
 				96ED34DE22374C0900E9FCA9 /* MGLMapViewDirectionTests.mm in Sources */,
+				1F0196AA23174B0700F5C819 /* MGLMapViewContentInsetTests.m in Sources */,
 				FAE1CDCB1E9D79CB00C40B5B /* MGLFillExtrusionStyleLayerTests.mm in Sources */,
 				DA35A2AA1CCA058D00E826B2 /* MGLCoordinateFormatterTests.m in Sources */,
 				357579831D502AE6000B822E /* MGLRasterStyleLayerTests.mm in Sources */,

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		1F7454A91ED08AB400021D39 /* MGLLightTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1F7454A61ED08AB400021D39 /* MGLLightTest.mm */; };
 		1F8A59F72165326D004DFE75 /* sideload_sat.db in Resources */ = {isa = PBXBuildFile; fileRef = 1F8A59F62165326C004DFE75 /* sideload_sat.db */; };
 		1F8A59F821653275004DFE75 /* sideload_sat.db in Resources */ = {isa = PBXBuildFile; fileRef = 1F8A59F62165326C004DFE75 /* sideload_sat.db */; };
+		1F8E8A81233A9FD9009B51ED /* MGLMapViewGestureRecognizerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1F8E8A80233A9FD9009B51ED /* MGLMapViewGestureRecognizerTests.mm */; };
 		1F95931D1E6DE2E900D5B294 /* MGLNSDateAdditionsTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1F95931C1E6DE2E900D5B294 /* MGLNSDateAdditionsTests.mm */; };
 		1FC4817D2098CBC0000D09B4 /* NSPredicate+MGLPrivateAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FC4817B2098CBC0000D09B4 /* NSPredicate+MGLPrivateAdditions.h */; };
 		1FC4817F2098CD80000D09B4 /* NSPredicate+MGLPrivateAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FC4817B2098CBC0000D09B4 /* NSPredicate+MGLPrivateAdditions.h */; };
@@ -912,6 +913,7 @@
 		1F7454941ECD450D00021D39 /* MGLLight_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLLight_Private.h; sourceTree = "<group>"; };
 		1F7454A61ED08AB400021D39 /* MGLLightTest.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLLightTest.mm; path = ../../darwin/test/MGLLightTest.mm; sourceTree = "<group>"; };
 		1F8A59F62165326C004DFE75 /* sideload_sat.db */ = {isa = PBXFileReference; lastKnownFileType = file; name = sideload_sat.db; path = ../../../test/fixtures/offline_database/sideload_sat.db; sourceTree = "<group>"; };
+		1F8E8A80233A9FD9009B51ED /* MGLMapViewGestureRecognizerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLMapViewGestureRecognizerTests.mm; sourceTree = "<group>"; };
 		1F95931C1E6DE2E900D5B294 /* MGLNSDateAdditionsTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLNSDateAdditionsTests.mm; path = ../../darwin/test/MGLNSDateAdditionsTests.mm; sourceTree = "<group>"; };
 		1FC4817B2098CBC0000D09B4 /* NSPredicate+MGLPrivateAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSPredicate+MGLPrivateAdditions.h"; sourceTree = "<group>"; };
 		1FCAE2A020B872A400C577DD /* MGLLocationManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLLocationManager.h; sourceTree = "<group>"; };
@@ -2088,6 +2090,7 @@
 				96E6145522CC135200109F14 /* MGLMapViewCompassViewTests.mm */,
 				1F0196A923174B0700F5C819 /* MGLMapViewContentInsetTests.m */,
 				96ED34DD22374C0900E9FCA9 /* MGLMapViewDirectionTests.mm */,
+				1F8E8A80233A9FD9009B51ED /* MGLMapViewGestureRecognizerTests.mm */,
 				16376B481FFEED010000563E /* MGLMapViewLayoutTests.m */,
 				96381C0122C6F3950053497D /* MGLMapViewPitchTests.m */,
 				9658C154204761FC00D8A674 /* MGLMapViewScaleBarTests.m */,
@@ -3331,6 +3334,7 @@
 				357579831D502AE6000B822E /* MGLRasterStyleLayerTests.mm in Sources */,
 				3502D6CC22AE88D5006BDFCE /* MGLAccountManagerTests.m in Sources */,
 				DAF25720201902BC00367EF5 /* MGLHillshadeStyleLayerTests.mm in Sources */,
+				1F8E8A81233A9FD9009B51ED /* MGLMapViewGestureRecognizerTests.mm in Sources */,
 				353D23961D0B0DFE002BE09D /* MGLAnnotationViewTests.m in Sources */,
 				DA0CD5901CF56F6A00A5F5A5 /* MGLFeatureTests.mm in Sources */,
 				556660D81E1D085500E2C41B /* MGLVersionNumber.m in Sources */,

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -287,6 +287,19 @@ MGL_EXPORT
 - (IBAction)reloadStyle:(nullable id)sender;
 
 /**
+ A boolean value that indicates if whether the map view should automatically
+ adjust its content insets.
+ 
+ When this property is set to `YES` the map automatically updates its
+ `contentInset` property to account for any area not covered by navigation bars,
+ tab bars, toolbars, and other ancestors that obscure the map view.
+ 
+ The default value of this property is `YES`.
+ 
+ */
+@property (assign) BOOL automaticallyAdjustContentInset;
+
+/**
  A Boolean value indicating whether the map may display scale information.
 
  The scale bar may not be shown at all zoom levels. The scale bar becomes visible
@@ -1309,9 +1322,9 @@ MGL_EXPORT
  frame from the viewport. For instance, if the only the top edge is inset, the
  map center is effectively shifted downward.
 
- When the map view’s superview is an instance of `UIViewController` whose
- `automaticallyAdjustsScrollViewInsets` property is `YES`, the value of this
- property may be overridden at any time.
+ When the map view’s property `automaticallyAdjustContentInset` is set to `YES`,
+ the value of this property may be overridden at any time. To persist the value
+ set it to `NO`.
 
  Changing the value of this property updates the map view immediately. If you
  want to animate the change, use the `-setContentInset:animated:completionHandler:`
@@ -1329,9 +1342,9 @@ MGL_EXPORT
  frame from the viewport. For instance, if the only the top edge is inset, the
  map center is effectively shifted downward.
 
- When the map view’s superview is an instance of `UIViewController` whose
- `automaticallyAdjustsScrollViewInsets` property is `YES`, the value of this
- property may be overridden at any time.
+ When the map view’s property `automaticallyAdjustContentInset` is set to `YES`,
+ the value of this property may be overridden at any time. To persist the value
+ set it to `NO`.
  
  To specify a completion handler to execute after the animation finishes, use
  the `-setContentInset:animated:completionHandler:` method.
@@ -1354,9 +1367,9 @@ MGL_EXPORT
  frame from the viewport. For instance, if the only the top edge is inset, the
  map center is effectively shifted downward.
 
- When the map view’s superview is an instance of `UIViewController` whose
- `automaticallyAdjustsScrollViewInsets` property is `YES`, the value of this
- property may be overridden at any time.
+ When the map view’s property `automaticallyAdjustContentInset` is set to `YES`,
+ the value of this property may be overridden at any time. To persist the value
+ set it to `NO`.
 
  @param contentInset The new values to inset the content by.
  @param animated Specify `YES` if you want the map view to animate the change to

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -294,8 +294,6 @@ MGL_EXPORT
  `contentInset` property to account for any area not covered by navigation bars,
  tab bars, toolbars, and other ancestors that obscure the map view.
  
- The default value of this property is `YES`.
- 
  */
 @property (assign) BOOL automaticallyAdjustContentInset;
 
@@ -1321,10 +1319,13 @@ MGL_EXPORT
  view’s frame. Otherwise, those properties are inset, excluding part of the
  frame from the viewport. For instance, if the only the top edge is inset, the
  map center is effectively shifted downward.
-
- When the map view’s property `automaticallyAdjustContentInset` is set to `YES`,
- the value of this property may be overridden at any time. To persist the value
- set it to `NO`.
+ 
+ When the map view’s superview is an instance of `UIViewController` whose
+ `automaticallyAdjustsScrollViewInsets` property is `YES`, the value of this
+ property may be overridden at any time.
+ 
+ The usage of `automaticallyAdjustsScrollViewInsets` it is been deprecated
+ use the map view’s property `automaticallyAdjustContentInset`instead.
 
  Changing the value of this property updates the map view immediately. If you
  want to animate the change, use the `-setContentInset:animated:completionHandler:`
@@ -1342,9 +1343,12 @@ MGL_EXPORT
  frame from the viewport. For instance, if the only the top edge is inset, the
  map center is effectively shifted downward.
 
- When the map view’s property `automaticallyAdjustContentInset` is set to `YES`,
- the value of this property may be overridden at any time. To persist the value
- set it to `NO`.
+ When the map view’s superview is an instance of `UIViewController` whose
+ `automaticallyAdjustsScrollViewInsets` property is `YES`, the value of this
+ property may be overridden at any time.
+ 
+ The usage of `automaticallyAdjustsScrollViewInsets` it is been deprecated
+ use the map view’s property `automaticallyAdjustContentInset`instead.
  
  To specify a completion handler to execute after the animation finishes, use
  the `-setContentInset:animated:completionHandler:` method.
@@ -1367,9 +1371,12 @@ MGL_EXPORT
  frame from the viewport. For instance, if the only the top edge is inset, the
  map center is effectively shifted downward.
 
- When the map view’s property `automaticallyAdjustContentInset` is set to `YES`,
- the value of this property may be overridden at any time. To persist the value
- set it to `NO`.
+ When the map view’s superview is an instance of `UIViewController` whose
+ `automaticallyAdjustsScrollViewInsets` property is `YES`, the value of this
+ property may be overridden at any time.
+ 
+ The usage of `automaticallyAdjustsScrollViewInsets` it is been deprecated
+ use the map view’s property `automaticallyAdjustContentInset`instead.
 
  @param contentInset The new values to inset the content by.
  @param animated Specify `YES` if you want the map view to animate the change to

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -295,7 +295,7 @@ MGL_EXPORT
  tab bars, toolbars, and other ancestors that obscure the map view.
  
  */
-@property (assign) BOOL automaticallyAdjustContentInset;
+@property (assign) BOOL automaticallyAdjustsContentInset;
 
 /**
  A Boolean value indicating whether the map may display scale information.
@@ -1324,8 +1324,8 @@ MGL_EXPORT
  `automaticallyAdjustsScrollViewInsets` property is `YES`, the value of this
  property may be overridden at any time.
  
- The usage of `automaticallyAdjustsScrollViewInsets` it is been deprecated
- use the map view’s property `automaticallyAdjustContentInset`instead.
+ The usage of `automaticallyAdjustsScrollViewInsets` has been deprecated
+ use the map view’s property `MGLMapView.automaticallyAdjustsContentInset`instead.
 
  Changing the value of this property updates the map view immediately. If you
  want to animate the change, use the `-setContentInset:animated:completionHandler:`
@@ -1347,8 +1347,8 @@ MGL_EXPORT
  `automaticallyAdjustsScrollViewInsets` property is `YES`, the value of this
  property may be overridden at any time.
  
- The usage of `automaticallyAdjustsScrollViewInsets` it is been deprecated
- use the map view’s property `automaticallyAdjustContentInset`instead.
+ The usage of `automaticallyAdjustsScrollViewInsets` has been deprecated
+ use the map view’s property `MGLMapView.automaticallyAdjustsContentInset`instead.
  
  To specify a completion handler to execute after the animation finishes, use
  the `-setContentInset:animated:completionHandler:` method.
@@ -1375,8 +1375,8 @@ MGL_EXPORT
  `automaticallyAdjustsScrollViewInsets` property is `YES`, the value of this
  property may be overridden at any time.
  
- The usage of `automaticallyAdjustsScrollViewInsets` it is been deprecated
- use the map view’s property `automaticallyAdjustContentInset`instead.
+ The usage of `automaticallyAdjustsScrollViewInsets` has been deprecated
+ use the map view’s property `MGLMapView.automaticallyAdjustsContentInset`instead.
 
  @param contentInset The new values to inset the content by.
  @param animated Specify `YES` if you want the map view to animate the change to

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1757,7 +1757,10 @@ public:
 
         if ([self _shouldChangeFromCamera:oldCamera toCamera:toCamera])
         {
-            self.mbglMap.jumpTo(mbgl::CameraOptions().withZoom(newZoom).withAnchor(mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y }));
+            self.mbglMap.jumpTo(mbgl::CameraOptions()
+                                .withZoom(newZoom)
+                                .withAnchor(mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y })
+                                .withPadding(MGLEdgeInsetsFromNSEdgeInsets(self.contentInset)));
 
             // The gesture recognizer only reports the gesture’s current center
             // point, so use the previous center point to anchor the transition.
@@ -1815,7 +1818,10 @@ public:
         {
             if (drift)
             {
-                self.mbglMap.easeTo(mbgl::CameraOptions().withZoom(zoom).withAnchor(mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y }), MGLDurationFromTimeInterval(duration));
+                self.mbglMap.easeTo(mbgl::CameraOptions()
+                                    .withZoom(zoom)
+                                    .withAnchor(mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y })
+                                    .withPadding(MGLEdgeInsetsFromNSEdgeInsets(self.contentInset)), MGLDurationFromTimeInterval(duration));
             }
         }
 
@@ -1880,7 +1886,8 @@ public:
         {
             self.mbglMap.jumpTo(mbgl::CameraOptions()
                                     .withBearing(newDegrees)
-                                    .withAnchor(mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y}));
+                                    .withAnchor(mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y})
+                                    .withPadding(MGLEdgeInsetsFromNSEdgeInsets(self.contentInset)));
         }
 
         [self cameraIsChanging];
@@ -1921,7 +1928,8 @@ public:
             {
                 self.mbglMap.easeTo(mbgl::CameraOptions()
                                     .withBearing(newDegrees)
-                                    .withAnchor(mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y }),
+                                    .withAnchor(mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y })
+                                    .withPadding(MGLEdgeInsetsFromNSEdgeInsets(self.contentInset)),
                                     MGLDurationFromTimeInterval(decelerationRate));
 
                 [self notifyGestureDidEndWithDrift:YES];
@@ -2049,7 +2057,10 @@ public:
     if ([self _shouldChangeFromCamera:oldCamera toCamera:toCamera])
     {
         mbgl::ScreenCoordinate center(gesturePoint.x, gesturePoint.y);
-        self.mbglMap.easeTo(mbgl::CameraOptions().withZoom(newZoom).withAnchor(center), MGLDurationFromTimeInterval(MGLAnimationDuration));
+        self.mbglMap.easeTo(mbgl::CameraOptions()
+                            .withZoom(newZoom)
+                            .withAnchor(center)
+                            .withPadding(MGLEdgeInsetsFromNSEdgeInsets(self.contentInset)), MGLDurationFromTimeInterval(MGLAnimationDuration));
 
         __weak MGLMapView *weakSelf = self;
 
@@ -2087,7 +2098,10 @@ public:
     if ([self _shouldChangeFromCamera:oldCamera toCamera:toCamera])
     {
         mbgl::ScreenCoordinate center(gesturePoint.x, gesturePoint.y);
-        self.mbglMap.easeTo(mbgl::CameraOptions().withZoom(newZoom).withAnchor(center), MGLDurationFromTimeInterval(MGLAnimationDuration));
+        self.mbglMap.easeTo(mbgl::CameraOptions()
+                            .withZoom(newZoom)
+                            .withAnchor(center)
+                            .withPadding(MGLEdgeInsetsFromNSEdgeInsets(self.contentInset)), MGLDurationFromTimeInterval(MGLAnimationDuration));
 
         __weak MGLMapView *weakSelf = self;
 
@@ -2129,7 +2143,10 @@ public:
 
         if ([self _shouldChangeFromCamera:oldCamera toCamera:toCamera])
         {
-            self.mbglMap.jumpTo(mbgl::CameraOptions().withZoom(newZoom).withAnchor(mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y }));
+            self.mbglMap.jumpTo(mbgl::CameraOptions()
+                                .withZoom(newZoom)
+                                .withAnchor(mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y })
+                                .withPadding(MGLEdgeInsetsFromNSEdgeInsets(self.contentInset)));
         }
 
         [self cameraIsChanging];
@@ -2196,7 +2213,8 @@ public:
             {
                 self.mbglMap.jumpTo(mbgl::CameraOptions()
                                     .withPitch(pitchNew)
-                                    .withAnchor(mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y }));
+                                    .withAnchor(mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y })
+                                    .withPadding(MGLEdgeInsetsFromNSEdgeInsets(self.contentInset)));
             }
             
             [self cameraIsChanging];
@@ -3256,7 +3274,10 @@ public:
         centerPoint = self.userLocationAnnotationViewCenter;
     }
     double newZoom = round(self.zoomLevel) + log2(scaleFactor);
-    self.mbglMap.jumpTo(mbgl::CameraOptions().withZoom(newZoom).withAnchor(mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y }));
+    self.mbglMap.jumpTo(mbgl::CameraOptions()
+                        .withZoom(newZoom)
+                        .withAnchor(mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y })
+                        .withPadding(MGLEdgeInsetsFromNSEdgeInsets(self.contentInset)));
     [self unrotateIfNeededForGesture];
 
     _accessibilityValueAnnouncementIsPending = YES;
@@ -3852,6 +3873,27 @@ public:
     mbgl::EdgeInsets padding = MGLEdgeInsetsFromNSEdgeInsets(insets);
     padding += MGLEdgeInsetsFromNSEdgeInsets(self.contentInset);
     mbgl::CameraOptions cameraOptions = self.mbglMap.cameraForLatLngBounds(MGLLatLngBoundsFromCoordinateBounds(bounds), padding);
+    return [self cameraForCameraOptions:cameraOptions];
+}
+
+- (MGLMapCamera *)camera:(MGLMapCamera *)camera fittingCoordinate:(CLLocationCoordinate2D)coordinate edgePadding:(UIEdgeInsets)insets {
+    if (!_mbglMap)
+    {
+        return self.residualCamera;
+    }
+    
+    mbgl::EdgeInsets padding = MGLEdgeInsetsFromNSEdgeInsets(insets);
+    padding += MGLEdgeInsetsFromNSEdgeInsets(self.contentInset);
+    
+    MGLMapCamera *currentCamera = self.camera;
+    CGFloat pitch = camera.pitch < 0 ? currentCamera.pitch : camera.pitch;
+    CLLocationDirection direction = camera.heading < 0 ? currentCamera.heading : camera.heading;
+    
+    std::vector<mbgl::LatLng> latLngs;
+    latLngs.reserve(1);
+    latLngs.push_back({coordinate.latitude, coordinate.longitude});
+    
+    mbgl::CameraOptions cameraOptions = self.mbglMap.cameraForLatLngs(latLngs, padding, direction, pitch);
     return [self cameraForCameraOptions:cameraOptions];
 }
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -526,8 +526,11 @@ public:
     
     // TODO: This warning should be removed when automaticallyAdjustsScrollViewInsets is removed from
     // the UIViewController api.
-    NSLog(@"%@ WARNING UIViewController.automaticallyAdjustsScrollViewInsets is deprecated use MGLMapView.automaticallyAdjustContentInset instead.",
-          NSStringFromClass(self.class));
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSLog(@"%@ WARNING UIViewController.automaticallyAdjustsScrollViewInsets is deprecated use MGLMapView.automaticallyAdjustContentInset instead.",
+        NSStringFromClass(self.class));
+    });
 
     // setup logo
     //
@@ -1051,12 +1054,12 @@ public:
     return viewController;
 }
 
-- (void)setAutomaticallyAdjustContentInset:(BOOL)automaticallyAdjustContentInset {
-    MGLLogDebug(@"Setting automaticallyAdjustContentInset: %@", MGLStringFromBOOL(automaticallyAdjustContentInset));
-    _automaticallyAdjustContentInsetHolder = [NSNumber numberWithBool:automaticallyAdjustContentInset];
+- (void)setAutomaticallyAdjustsContentInset:(BOOL)automaticallyAdjustsContentInset {
+    MGLLogDebug(@"Setting automaticallyAdjustsContentInset: %@", MGLStringFromBOOL(automaticallyAdjustsContentInset));
+    _automaticallyAdjustContentInsetHolder = [NSNumber numberWithBool:automaticallyAdjustsContentInset];
 }
 
-- (BOOL)automaticallyAdjustContentInset {
+- (BOOL)automaticallyAdjustsContentInset {
     return _automaticallyAdjustContentInsetHolder.boolValue;
 }
 
@@ -3873,27 +3876,6 @@ public:
     mbgl::EdgeInsets padding = MGLEdgeInsetsFromNSEdgeInsets(insets);
     padding += MGLEdgeInsetsFromNSEdgeInsets(self.contentInset);
     mbgl::CameraOptions cameraOptions = self.mbglMap.cameraForLatLngBounds(MGLLatLngBoundsFromCoordinateBounds(bounds), padding);
-    return [self cameraForCameraOptions:cameraOptions];
-}
-
-- (MGLMapCamera *)camera:(MGLMapCamera *)camera fittingCoordinate:(CLLocationCoordinate2D)coordinate edgePadding:(UIEdgeInsets)insets {
-    if (!_mbglMap)
-    {
-        return self.residualCamera;
-    }
-    
-    mbgl::EdgeInsets padding = MGLEdgeInsetsFromNSEdgeInsets(insets);
-    padding += MGLEdgeInsetsFromNSEdgeInsets(self.contentInset);
-    
-    MGLMapCamera *currentCamera = self.camera;
-    CGFloat pitch = camera.pitch < 0 ? currentCamera.pitch : camera.pitch;
-    CLLocationDirection direction = camera.heading < 0 ? currentCamera.heading : camera.heading;
-    
-    std::vector<mbgl::LatLng> latLngs;
-    latLngs.reserve(1);
-    latLngs.push_back({coordinate.latitude, coordinate.longitude});
-    
-    mbgl::CameraOptions cameraOptions = self.mbglMap.cameraForLatLngs(latLngs, padding, direction, pitch);
     return [self cameraForCameraOptions:cameraOptions];
 }
 

--- a/platform/ios/test/MGLMapViewContentInsetTests.m
+++ b/platform/ios/test/MGLMapViewContentInsetTests.m
@@ -100,7 +100,7 @@
     XCTAssertTrue(CGPointEqualToPoint(attributionView.frame.origin, expectedAttributionOrigin));
     
     UIEdgeInsets insets = UIEdgeInsetsMake(15, 10, 20, 5);
-    self.mapView.automaticallyAdjustContentInset = NO;
+    self.viewController.automaticallyAdjustsScrollViewInsets = NO;
     self.mapView.contentInset = insets;
     
     [self.mapView setNeedsLayout];
@@ -144,6 +144,34 @@
     y = self.screenBounds.size.height - attributionView.bounds.size.height - margin;
     expectedAttributionOrigin = CGPointMake(x, y);
     XCTAssertTrue(CGPointEqualToPoint(attributionView.frame.origin, expectedAttributionOrigin));
+    
+    self.mapView.automaticallyAdjustContentInset = YES;
+    insets = UIEdgeInsetsMake(100, 100, 100, 100);
+    self.mapView.contentInset = insets;
+    XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(self.mapView.contentInset, insets));
+    
+    [self.mapView setNeedsLayout];
+    [self.mapView layoutIfNeeded];
+    
+    // when automaticallyAdjustContentInset = YES the content insets should be overwrited
+    XCTAssertFalse(UIEdgeInsetsEqualToEdgeInsets(self.mapView.contentInset, insets));
+    
+    expectedScaleBarOrigin = CGPointMake(margin, margin);
+    XCTAssertTrue(CGPointEqualToPoint(scaleBar.frame.origin, expectedScaleBarOrigin));
+    
+    x = self.screenBounds.size.width - compassView.bounds.size.width - margin;
+    expectedCompassOrigin = CGPointMake(x, margin);
+    XCTAssertTrue(CGPointEqualToPoint(compassView.frame.origin, expectedCompassOrigin));
+    
+    y = self.screenBounds.size.height - logoView.bounds.size.height - margin;
+    expectedLogoOrigin = CGPointMake(margin, y);
+    XCTAssertTrue(CGPointEqualToPoint(logoView.frame.origin, expectedLogoOrigin));
+    
+    x = self.screenBounds.size.width - attributionView.bounds.size.width - margin;
+    y = self.screenBounds.size.height - attributionView.bounds.size.height - margin;
+    expectedAttributionOrigin = CGPointMake(x, y);
+    XCTAssertTrue(CGPointEqualToPoint(attributionView.frame.origin, expectedAttributionOrigin));
+    
 }
 
 @end

--- a/platform/ios/test/MGLMapViewContentInsetTests.m
+++ b/platform/ios/test/MGLMapViewContentInsetTests.m
@@ -145,7 +145,7 @@
     expectedAttributionOrigin = CGPointMake(x, y);
     XCTAssertTrue(CGPointEqualToPoint(attributionView.frame.origin, expectedAttributionOrigin));
     
-    self.mapView.automaticallyAdjustContentInset = YES;
+    self.mapView.automaticallyAdjustsContentInset = YES;
     insets = UIEdgeInsetsMake(100, 100, 100, 100);
     self.mapView.contentInset = insets;
     XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(self.mapView.contentInset, insets));
@@ -153,7 +153,7 @@
     [self.mapView setNeedsLayout];
     [self.mapView layoutIfNeeded];
     
-    // when automaticallyAdjustContentInset = YES the content insets should be overwrited
+    // when automaticallyAdjustsContentInset = YES the content insets should be overwriten
     XCTAssertFalse(UIEdgeInsetsEqualToEdgeInsets(self.mapView.contentInset, insets));
     
     expectedScaleBarOrigin = CGPointMake(margin, margin);

--- a/platform/ios/test/MGLMapViewContentInsetTests.m
+++ b/platform/ios/test/MGLMapViewContentInsetTests.m
@@ -5,6 +5,7 @@
 
 @property (nonatomic) MGLMapView *mapView;
 @property (nonatomic) UIWindow *window;
+@property (nonatomic) UIViewController *viewController;
 @property (nonatomic) XCTestExpectation *styleLoadingExpectation;
 @property (assign) CGRect screenBounds;
 
@@ -22,11 +23,11 @@
     self.mapView.zoomLevel = 16;
     self.mapView.delegate = self;
     
-    
-    UIView *view = [[UIView alloc] initWithFrame:self.screenBounds];
-    [view addSubview:self.mapView];
+    self.viewController = [[UIViewController alloc] init];
+    self.viewController.view = [[UIView alloc] initWithFrame:self.screenBounds];
+    [self.viewController.view addSubview:self.mapView];
     self.window = [[UIWindow alloc] initWithFrame:self.screenBounds];
-    [self.window addSubview:view];
+    [self.window addSubview:self.viewController.view];
     [self.window makeKeyAndVisible];
     
     if (!self.mapView.style) {
@@ -99,7 +100,7 @@
     XCTAssertTrue(CGPointEqualToPoint(attributionView.frame.origin, expectedAttributionOrigin));
     
     UIEdgeInsets insets = UIEdgeInsetsMake(15, 10, 20, 5);
-    self.mapView.automaticallyAdjustContentInset = YES;
+    self.mapView.automaticallyAdjustContentInset = NO;
     self.mapView.contentInset = insets;
     
     [self.mapView setNeedsLayout];
@@ -121,6 +122,28 @@
     expectedAttributionOrigin = CGPointMake(x, y);
     XCTAssertTrue(CGPointEqualToPoint(attributionView.frame.origin, expectedAttributionOrigin));
     
+    // tests that passing negative values result in a 0 inset value
+    insets = UIEdgeInsetsMake(-100, -100, -100, -100);
+    self.mapView.contentInset = insets;
+    
+    [self.mapView setNeedsLayout];
+    [self.mapView layoutIfNeeded];
+    
+    expectedScaleBarOrigin = CGPointMake(margin, margin);
+    XCTAssertTrue(CGPointEqualToPoint(scaleBar.frame.origin, expectedScaleBarOrigin));
+    
+    x = self.screenBounds.size.width - compassView.bounds.size.width - margin;
+    expectedCompassOrigin = CGPointMake(x, margin);
+    XCTAssertTrue(CGPointEqualToPoint(compassView.frame.origin, expectedCompassOrigin));
+    
+    y = self.screenBounds.size.height - logoView.bounds.size.height - margin;
+    expectedLogoOrigin = CGPointMake(margin, y);
+    XCTAssertTrue(CGPointEqualToPoint(logoView.frame.origin, expectedLogoOrigin));
+    
+    x = self.screenBounds.size.width - attributionView.bounds.size.width - margin;
+    y = self.screenBounds.size.height - attributionView.bounds.size.height - margin;
+    expectedAttributionOrigin = CGPointMake(x, y);
+    XCTAssertTrue(CGPointEqualToPoint(attributionView.frame.origin, expectedAttributionOrigin));
 }
 
 @end

--- a/platform/ios/test/MGLMapViewContentInsetTests.m
+++ b/platform/ios/test/MGLMapViewContentInsetTests.m
@@ -1,0 +1,126 @@
+#import <Mapbox/Mapbox.h>
+#import <XCTest/XCTest.h>
+
+@interface MGLMapViewContentInsetTests : XCTestCase <MGLMapViewDelegate>
+
+@property (nonatomic) MGLMapView *mapView;
+@property (nonatomic) UIWindow *window;
+@property (nonatomic) XCTestExpectation *styleLoadingExpectation;
+@property (assign) CGRect screenBounds;
+
+@end
+
+@implementation MGLMapViewContentInsetTests
+
+- (void)setUp {
+    [super setUp];
+    
+    [MGLAccountManager setAccessToken:@"pk.feedcafedeadbeefbadebede"];
+    NSURL *styleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"one-liner" withExtension:@"json"];
+    self.screenBounds = UIScreen.mainScreen.bounds;
+    self.mapView = [[MGLMapView alloc] initWithFrame:self.screenBounds styleURL:styleURL];
+    self.mapView.zoomLevel = 16;
+    self.mapView.delegate = self;
+    
+    
+    UIView *view = [[UIView alloc] initWithFrame:self.screenBounds];
+    [view addSubview:self.mapView];
+    self.window = [[UIWindow alloc] initWithFrame:self.screenBounds];
+    [self.window addSubview:view];
+    [self.window makeKeyAndVisible];
+    
+    if (!self.mapView.style) {
+        _styleLoadingExpectation = [self expectationWithDescription:@"Map view should finish loading style."];
+        [self waitForExpectationsWithTimeout:10 handler:nil];
+    }
+}
+
+- (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {
+    XCTAssertNotNil(mapView.style);
+    XCTAssertEqual(mapView.style, style);
+    
+    [_styleLoadingExpectation fulfill];
+}
+
+- (void)tearDown {
+    self.mapView = nil;
+    [MGLAccountManager setAccessToken:nil];
+    [super tearDown];
+}
+
+- (void)testContentInsetCenter {
+    CLLocationCoordinate2D center = CLLocationCoordinate2DMake(1.0, 5.0);
+    self.mapView.centerCoordinate = center;
+    XCTAssertEqualWithAccuracy(self.mapView.centerCoordinate.latitude, center.latitude, 0.01);
+    XCTAssertEqualWithAccuracy(self.mapView.centerCoordinate.longitude, center.longitude, 0.01);
+    
+    CGPoint centerPoint = [self.mapView convertCoordinate:center toPointToView:self.mapView];
+
+    XCTAssertEqualWithAccuracy(centerPoint.x, self.screenBounds.size.width/2, 0.01);
+    XCTAssertEqualWithAccuracy(centerPoint.y, self.screenBounds.size.height/2, 0.01);
+    
+    // shifting contentInset should keep the same centerCoordinate but shift the screen
+    // center point accordingly
+    UIEdgeInsets contentInset = UIEdgeInsetsMake(50.0, 10.0, 10.0, 30.0);
+    self.mapView.contentInset = contentInset;
+    XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(self.mapView.contentInset, contentInset));
+    XCTAssertEqualWithAccuracy(self.mapView.centerCoordinate.latitude, center.latitude, 0.01);
+    XCTAssertEqualWithAccuracy(self.mapView.centerCoordinate.longitude, center.longitude, 0.01);
+    CGPoint shiftedPoint = [self.mapView convertCoordinate:center toPointToView:self.mapView];
+    CGPoint expectedShiftedPoint = CGPointMake((self.screenBounds.size.width/2) + ((contentInset.left - contentInset.right) / 2 ),
+                                               (self.screenBounds.size.height/2) + ((contentInset.top - contentInset.bottom) / 2));
+    XCTAssertEqualWithAccuracy(shiftedPoint.x, expectedShiftedPoint.x, 0.01);
+    XCTAssertEqualWithAccuracy(shiftedPoint.y, expectedShiftedPoint.y, 0.01);
+    
+  
+}
+
+- (void)testContentInsetOrnaments {
+    CGFloat margin = 8;
+    self.mapView.contentInset = UIEdgeInsetsZero;
+    UIView *scaleBar = self.mapView.scaleBar;
+    CGPoint expectedScaleBarOrigin = CGPointMake(margin, margin);
+    XCTAssertTrue(CGPointEqualToPoint(scaleBar.frame.origin, expectedScaleBarOrigin));
+    
+    UIView *compassView = self.mapView.compassView;
+    CGFloat x = self.screenBounds.size.width - compassView.bounds.size.width - margin;
+    CGPoint expectedCompassOrigin = CGPointMake(x, margin);
+    XCTAssertTrue(CGPointEqualToPoint(compassView.frame.origin, expectedCompassOrigin));
+                  
+    UIView *logoView = self.mapView.logoView;
+    CGFloat y = self.screenBounds.size.height - logoView.bounds.size.height - margin;
+    CGPoint expectedLogoOrigin = CGPointMake(margin, y);
+    XCTAssertTrue(CGPointEqualToPoint(logoView.frame.origin, expectedLogoOrigin));
+    
+    UIView *attributionView = self.mapView.attributionButton;
+    x = self.screenBounds.size.width - attributionView.bounds.size.width - margin;
+    y = self.screenBounds.size.height - attributionView.bounds.size.height - margin;
+    CGPoint expectedAttributionOrigin = CGPointMake(x, y);
+    XCTAssertTrue(CGPointEqualToPoint(attributionView.frame.origin, expectedAttributionOrigin));
+    
+    UIEdgeInsets insets = UIEdgeInsetsMake(15, 10, 20, 5);
+    self.mapView.automaticallyAdjustContentInset = YES;
+    self.mapView.contentInset = insets;
+    
+    [self.mapView setNeedsLayout];
+    [self.mapView layoutIfNeeded];
+    
+    expectedScaleBarOrigin = CGPointMake(insets.left + self.mapView.scaleBarMargins.x, insets.top  + self.mapView.scaleBarMargins.y);
+    XCTAssertTrue(CGPointEqualToPoint(scaleBar.frame.origin, expectedScaleBarOrigin));
+    
+    x = self.screenBounds.size.width - compassView.bounds.size.width - insets.right - self.mapView.compassViewMargins.x;
+    expectedCompassOrigin = CGPointMake(x, insets.top + self.mapView.compassViewMargins.y);
+    XCTAssertTrue(CGPointEqualToPoint(compassView.frame.origin, expectedCompassOrigin));
+    
+    y = self.screenBounds.size.height - logoView.bounds.size.height - insets.bottom - self.mapView.logoViewMargins.y;
+    expectedLogoOrigin = CGPointMake(insets.left + self.mapView.logoViewMargins.x, y);
+    XCTAssertTrue(CGPointEqualToPoint(logoView.frame.origin, expectedLogoOrigin));
+    
+    x = self.screenBounds.size.width - attributionView.bounds.size.width - insets.right - self.mapView.attributionButtonMargins.x;
+    y = self.screenBounds.size.height - attributionView.bounds.size.height - insets.bottom - self.mapView.attributionButtonMargins.y;
+    expectedAttributionOrigin = CGPointMake(x, y);
+    XCTAssertTrue(CGPointEqualToPoint(attributionView.frame.origin, expectedAttributionOrigin));
+    
+}
+
+@end

--- a/platform/ios/test/MGLMapViewGestureRecognizerTests.mm
+++ b/platform/ios/test/MGLMapViewGestureRecognizerTests.mm
@@ -1,0 +1,280 @@
+#import <Mapbox/Mapbox.h>
+#import <XCTest/XCTest.h>
+
+#import "../../darwin/src/MGLGeometry_Private.h"
+#import "MGLMockGestureRecognizers.h"
+
+#include <mbgl/map/map.hpp>
+#include <mbgl/map/camera.hpp>
+
+@interface MGLMapView (MGLMapViewGestureRecognizerTests)
+
+- (mbgl::Map &)mbglMap;
+
+- (void)handlePinchGesture:(UIPinchGestureRecognizer *)pinch;
+- (void)handleRotateGesture:(UIRotationGestureRecognizer *)rotate;
+- (void)handleDoubleTapGesture:(UITapGestureRecognizer *)doubleTap;
+- (void)handleTwoFingerTapGesture:(UITapGestureRecognizer *)twoFingerTap;
+- (void)handleQuickZoomGesture:(UILongPressGestureRecognizer *)quickZoom;
+- (void)handleTwoFingerDragGesture:(UIPanGestureRecognizer *)twoFingerDrag;
+
+@end
+
+@interface MGLMapViewGestureRecognizerTests : XCTestCase <MGLMapViewDelegate>
+
+@property (nonatomic) MGLMapView *mapView;
+@property (nonatomic) UIWindow *window;
+@property (nonatomic) UIViewController *viewController;
+@property (nonatomic) XCTestExpectation *styleLoadingExpectation;
+@property (nonatomic) XCTestExpectation *twoFingerExpectation;
+@property (nonatomic) XCTestExpectation *quickZoomExpectation;
+@property (nonatomic) XCTestExpectation *doubleTapExpectation;
+@property (nonatomic) XCTestExpectation *twoFingerDragExpectation;
+@property (assign) CGRect screenBounds;
+
+@end
+
+@implementation MGLMapViewGestureRecognizerTests
+
+- (void)setUp {
+    [super setUp];
+    
+    [MGLAccountManager setAccessToken:@"pk.feedcafedeadbeefbadebede"];
+    NSURL *styleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"one-liner" withExtension:@"json"];
+    self.screenBounds = UIScreen.mainScreen.bounds;
+    self.mapView = [[MGLMapView alloc] initWithFrame:self.screenBounds styleURL:styleURL];
+    self.mapView.zoomLevel = 16;
+    self.mapView.delegate = self;
+    
+    self.viewController = [[UIViewController alloc] init];
+    self.viewController.view = [[UIView alloc] initWithFrame:self.screenBounds];
+    [self.viewController.view addSubview:self.mapView];
+    self.window = [[UIWindow alloc] initWithFrame:self.screenBounds];
+    [self.window addSubview:self.viewController.view];
+    [self.window makeKeyAndVisible];
+    
+    if (!self.mapView.style) {
+        _styleLoadingExpectation = [self expectationWithDescription:@"Map view should finish loading style."];
+        [self waitForExpectationsWithTimeout:10 handler:nil];
+    }
+}
+
+- (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {
+    XCTAssertNotNil(mapView.style);
+    XCTAssertEqual(mapView.style, style);
+    
+    [_styleLoadingExpectation fulfill];
+}
+
+- (void)testHandlePinchGestureContentInset {
+    UIEdgeInsets contentInset = UIEdgeInsetsZero;
+    self.mapView.contentInset = contentInset;
+    mbgl::EdgeInsets padding = MGLEdgeInsetsFromNSEdgeInsets(self.mapView.contentInset);
+    auto cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertEqual(padding, cameraPadding, @"MGLMapView's contentInset property should match camera's padding.");
+    XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(self.mapView.contentInset, contentInset));
+    
+    contentInset = UIEdgeInsetsMake(20, 20, 20, 20);
+    [self.mapView setCamera:self.mapView.camera withDuration:0.1 animationTimingFunction:nil edgePadding:contentInset completionHandler:nil];
+    XCTAssertFalse(UIEdgeInsetsEqualToEdgeInsets(self.mapView.contentInset, contentInset));
+    
+    cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertNotEqual(padding, cameraPadding);
+    
+    UIPinchGestureRecognizerMock *pinchGesture = [[UIPinchGestureRecognizerMock alloc] initWithTarget:nil action:nil];
+    pinchGesture.state = UIGestureRecognizerStateBegan;
+    pinchGesture.scale = 1.0;
+    [self.mapView handlePinchGesture:pinchGesture];
+    XCTAssertNotEqual(padding, cameraPadding);
+    
+    pinchGesture.state = UIGestureRecognizerStateChanged;
+    [self.mapView handlePinchGesture:pinchGesture];
+    cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertEqual(padding, cameraPadding, @"When a gesture recognizer is performed contentInsets and camera padding should match.");
+    
+    pinchGesture.state = UIGestureRecognizerStateEnded;
+    [self.mapView handlePinchGesture:pinchGesture];
+    cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertEqual(padding, cameraPadding, @"When a gesture recognizer is performed contentInsets and camera padding should match.");
+    
+}
+
+- (void)testHandleRotateGestureContentInset {
+    UIEdgeInsets contentInset = UIEdgeInsetsZero;
+    self.mapView.contentInset = contentInset;
+    mbgl::EdgeInsets padding = MGLEdgeInsetsFromNSEdgeInsets(self.mapView.contentInset);
+    auto cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertEqual(padding, cameraPadding, @"MGLMapView's contentInset property should match camera's padding.");
+    XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(self.mapView.contentInset, contentInset));
+    
+    contentInset = UIEdgeInsetsMake(20, 20, 20, 20);
+    [self.mapView setCamera:self.mapView.camera withDuration:0.1 animationTimingFunction:nil edgePadding:contentInset completionHandler:nil];
+    XCTAssertFalse(UIEdgeInsetsEqualToEdgeInsets(self.mapView.contentInset, contentInset));
+    
+    cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertNotEqual(padding, cameraPadding);
+    
+    UIRotationGestureRecognizerMock *rotateGesture = [[UIRotationGestureRecognizerMock alloc] initWithTarget:nil action:nil];
+    rotateGesture.state = UIGestureRecognizerStateBegan;
+    rotateGesture.rotation = 1;
+    [self.mapView handleRotateGesture:rotateGesture];
+    XCTAssertNotEqual(padding, cameraPadding);
+    
+    rotateGesture.state = UIGestureRecognizerStateChanged;
+    [self.mapView handleRotateGesture:rotateGesture];
+    cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertEqual(padding, cameraPadding, @"When a gesture recognizer is performed contentInsets and camera padding should match.");
+    
+    rotateGesture.state = UIGestureRecognizerStateEnded;
+    [self.mapView handleRotateGesture:rotateGesture];
+    cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertEqual(padding, cameraPadding, @"When a gesture recognizer is performed contentInsets and camera padding should match.");
+    
+}
+
+- (void)testHandleDoubleTapGestureContentInset {
+    UIEdgeInsets contentInset = UIEdgeInsetsMake(1, 1, 1, 1);
+    self.mapView.contentInset = contentInset;
+    mbgl::EdgeInsets padding = MGLEdgeInsetsFromNSEdgeInsets(self.mapView.contentInset);
+    auto cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertEqual(padding, cameraPadding, @"MGLMapView's contentInset property should match camera's padding.");
+    XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(self.mapView.contentInset, contentInset));
+    
+    contentInset = UIEdgeInsetsMake(20, 20, 20, 20);
+    [self.mapView setCamera:self.mapView.camera withDuration:0.1 animationTimingFunction:nil edgePadding:contentInset completionHandler:nil];
+    XCTAssertFalse(UIEdgeInsetsEqualToEdgeInsets(self.mapView.contentInset, contentInset));
+    
+    cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertNotEqual(padding, cameraPadding);
+    
+    UITapGestureRecognizerMock *doubleTapGesture = [[UITapGestureRecognizerMock alloc] initWithTarget:nil action:nil];
+    doubleTapGesture.mockTappedView = self.mapView;
+    doubleTapGesture.mockTappedPoint = CGPointMake(1.0, 1.0);
+    
+    [self.mapView handleDoubleTapGesture:doubleTapGesture];
+    _doubleTapExpectation = [self expectationWithDescription:@"Double tap gesture animation."];
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.4 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self->_doubleTapExpectation fulfill];
+    });
+    [self waitForExpectationsWithTimeout:10 handler:nil];
+
+    cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertEqual(padding, cameraPadding, @"When a gesture recognizer is performed contentInsets and camera padding should match.");
+    
+}
+
+- (void)testHandleTwoFingerTapGesture {
+    UIEdgeInsets contentInset = UIEdgeInsetsZero;
+    self.mapView.contentInset = contentInset;
+    mbgl::EdgeInsets padding = MGLEdgeInsetsFromNSEdgeInsets(self.mapView.contentInset);
+    auto cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertEqual(padding, cameraPadding, @"MGLMapView's contentInset property should match camera's padding.");
+    XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(self.mapView.contentInset, contentInset));
+    
+    contentInset = UIEdgeInsetsMake(20, 20, 20, 20);
+    [self.mapView setCamera:self.mapView.camera withDuration:0.1 animationTimingFunction:nil edgePadding:contentInset completionHandler:nil];
+    XCTAssertFalse(UIEdgeInsetsEqualToEdgeInsets(self.mapView.contentInset, contentInset));
+    
+    cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertNotEqual(padding, cameraPadding);
+    
+    UITapGestureRecognizerMock *twoFingerTap = [[UITapGestureRecognizerMock alloc] initWithTarget:nil action:nil];
+    twoFingerTap.mockTappedView = self.mapView;
+    twoFingerTap.mockTappedPoint = CGPointMake(1.0, 1.0);
+    
+    [self.mapView handleTwoFingerTapGesture:twoFingerTap];
+    _twoFingerExpectation = [self expectationWithDescription:@"Two Finger tap gesture animation."];
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.4 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self->_twoFingerExpectation fulfill];
+    });
+    [self waitForExpectationsWithTimeout:10 handler:nil];
+    
+    cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertEqual(padding, cameraPadding, @"When a gesture recognizer is performed contentInsets and camera padding should match.");
+}
+
+- (void)testHandleQuickZoomGesture {
+    UIEdgeInsets contentInset = UIEdgeInsetsZero;
+    self.mapView.contentInset = contentInset;
+    mbgl::EdgeInsets padding = MGLEdgeInsetsFromNSEdgeInsets(self.mapView.contentInset);
+    auto cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertEqual(padding, cameraPadding, @"MGLMapView's contentInset property should match camera's padding.");
+    XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(self.mapView.contentInset, contentInset));
+    
+    contentInset = UIEdgeInsetsMake(20, 20, 20, 20);
+    [self.mapView setCamera:self.mapView.camera withDuration:0.1 animationTimingFunction:nil edgePadding:contentInset completionHandler:nil];
+    XCTAssertFalse(UIEdgeInsetsEqualToEdgeInsets(self.mapView.contentInset, contentInset));
+    
+    cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertNotEqual(padding, cameraPadding);
+    
+    UILongPressGestureRecognizerMock *quickZoom = [[UILongPressGestureRecognizerMock alloc] initWithTarget:nil action:nil];
+    quickZoom.state = UIGestureRecognizerStateBegan;
+    [self.mapView handleQuickZoomGesture:quickZoom];
+    XCTAssertNotEqual(padding, cameraPadding);
+    
+    quickZoom.state = UIGestureRecognizerStateChanged;
+    quickZoom.mockTappedPoint = CGPointMake(self.mapView.frame.size.width / 2, self.mapView.frame.size.height / 2);
+    [self.mapView handleQuickZoomGesture:quickZoom];
+    _quickZoomExpectation = [self expectationWithDescription:@"Quick zoom gesture animation."];
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.4 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self->_quickZoomExpectation fulfill];
+    });
+    [self waitForExpectationsWithTimeout:10 handler:nil];
+    
+    cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertEqual(padding, cameraPadding, @"When a gesture recognizer is performed contentInsets and camera padding should match.");
+    
+    quickZoom.state = UIGestureRecognizerStateEnded;
+    [self.mapView handleQuickZoomGesture:quickZoom];
+    cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertEqual(padding, cameraPadding, @"When a gesture recognizer is performed contentInsets and camera padding should match.");
+}
+
+- (void)testHandleTwoFingerDragGesture {
+    UIEdgeInsets contentInset = UIEdgeInsetsZero;
+    self.mapView.contentInset = contentInset;
+    mbgl::EdgeInsets padding = MGLEdgeInsetsFromNSEdgeInsets(self.mapView.contentInset);
+    auto cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertEqual(padding, cameraPadding, @"MGLMapView's contentInset property should match camera's padding.");
+    XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(self.mapView.contentInset, contentInset));
+    
+    contentInset = UIEdgeInsetsMake(20, 20, 20, 20);
+    [self.mapView setCamera:self.mapView.camera withDuration:0.1 animationTimingFunction:nil edgePadding:contentInset completionHandler:nil];
+    XCTAssertFalse(UIEdgeInsetsEqualToEdgeInsets(self.mapView.contentInset, contentInset));
+    
+    cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertNotEqual(padding, cameraPadding);
+    
+    UIPanGestureRecognizerMock *twoFingerDrag = [[UIPanGestureRecognizerMock alloc] initWithTarget:nil action:nil];
+    twoFingerDrag.state = UIGestureRecognizerStateBegan;
+    twoFingerDrag.firstFingerPoint = CGPointMake(self.mapView.frame.size.width / 3, self.mapView.frame.size.height/2);
+    twoFingerDrag.secondFingerPoint = CGPointMake((self.mapView.frame.size.width / 2), self.mapView.frame.size.height/2);
+    twoFingerDrag.numberOfTouches = 2;
+    [self.mapView handleTwoFingerDragGesture:twoFingerDrag];
+    XCTAssertNotEqual(padding, cameraPadding);
+    
+    twoFingerDrag.state = UIGestureRecognizerStateChanged;
+    twoFingerDrag.firstFingerPoint = CGPointMake(self.mapView.frame.size.width / 3, (self.mapView.frame.size.height/2)-10);
+    twoFingerDrag.secondFingerPoint = CGPointMake((self.mapView.frame.size.width / 2), (self.mapView.frame.size.height/2)-10);
+    [self.mapView handleTwoFingerDragGesture:twoFingerDrag];
+    _twoFingerDragExpectation = [self expectationWithDescription:@"Quick zoom gesture animation."];
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.4 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self->_twoFingerDragExpectation fulfill];
+    });
+    [self waitForExpectationsWithTimeout:10 handler:nil];
+    
+    cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertEqual(padding, cameraPadding, @"When a gesture recognizer is performed contentInsets and camera padding should match.");
+    
+    twoFingerDrag.state = UIGestureRecognizerStateEnded;
+    [self.mapView handleTwoFingerDragGesture:twoFingerDrag];
+    cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+    XCTAssertEqual(padding, cameraPadding, @"When a gesture recognizer is performed contentInsets and camera padding should match.");
+}
+
+@end

--- a/platform/ios/test/MGLMapViewPitchTests.m
+++ b/platform/ios/test/MGLMapViewPitchTests.m
@@ -2,6 +2,7 @@
 #import <XCTest/XCTest.h>
 
 @interface MockUIPanGestureRecognizer : UIPanGestureRecognizer
+@property(nonatomic, readwrite) UIGestureRecognizerState state;
 @property NSUInteger mbx_numberOfFingersForGesture;
 @property CGPoint mbx_middlePoint;
 @property CGPoint mbx_westPoint;
@@ -9,6 +10,9 @@
 @end
 
 @implementation MockUIPanGestureRecognizer
+
+@synthesize state;
+
 - (instancetype)initWithTarget:(id)target action:(SEL)action {
     if (self = [super initWithTarget:target action:action]) {
         self.mbx_numberOfFingersForGesture = 2;

--- a/platform/ios/test/MGLMockGestureRecognizers.h
+++ b/platform/ios/test/MGLMockGestureRecognizers.h
@@ -4,7 +4,26 @@
 @interface UIPinchGestureRecognizerMock : UIPinchGestureRecognizer
 @property (nonatomic, readwrite) CGFloat velocity;
 @property (nonatomic) CGPoint locationInViewOverride;
+@property(nonatomic, readwrite) UIGestureRecognizerState state;
 @end
 
 @interface UIRotationGestureRecognizerMock : UIRotationGestureRecognizer
+@property(nonatomic, readwrite) UIGestureRecognizerState state;
+@end
+
+@interface UITapGestureRecognizerMock : UITapGestureRecognizer
+@property (strong, nonatomic) UIView *mockTappedView;
+@property (assign) CGPoint mockTappedPoint;
+@end
+
+@interface UILongPressGestureRecognizerMock : UILongPressGestureRecognizer
+@property(nonatomic, readwrite) UIGestureRecognizerState state;
+@property (assign) CGPoint mockTappedPoint;
+@end
+
+@interface UIPanGestureRecognizerMock : UIPanGestureRecognizer
+@property(nonatomic, readwrite) UIGestureRecognizerState state;
+@property (assign) CGPoint firstFingerPoint;
+@property (assign) CGPoint secondFingerPoint;
+@property(nonatomic, readwrite) NSUInteger numberOfTouches;
 @end

--- a/platform/ios/test/MGLMockGestureRecognizers.m
+++ b/platform/ios/test/MGLMockGestureRecognizers.m
@@ -1,11 +1,55 @@
 
 #import "MGLMockGestureRecognizers.h"
+#import "objc/runtime.h"
 
 @implementation UIPinchGestureRecognizerMock
 @synthesize velocity;
+@synthesize state;
 - (CGPoint)locationInView:(nullable UIView *)view { return self.locationInViewOverride; }
 @end
 
 @implementation UIRotationGestureRecognizerMock
 - (CGPoint)locationInView:(nullable UIView*)view { return view.center; }
+@synthesize state;
+@end
+
+@implementation UITapGestureRecognizerMock
+
++ (void)load {
+    method_exchangeImplementations(class_getInstanceMethod(self, @selector(state)),
+                                   class_getInstanceMethod(self, @selector(mockState)));
+}
+
+- (UIGestureRecognizerState)mockState {
+    return UIGestureRecognizerStateRecognized;
+}
+
+- (UIView *)view {
+    return self.mockTappedView;
+}
+
+- (CGPoint)locationInView:(UIView *)view {
+    return self.mockTappedPoint;
+}
+
+@end
+
+@implementation UILongPressGestureRecognizerMock
+@synthesize state;
+
+- (CGPoint)locationInView:(UIView *)view {
+    return self.mockTappedPoint;
+}
+@end
+
+@implementation UIPanGestureRecognizerMock
+@synthesize state;
+@synthesize numberOfTouches;
+
+- (CGPoint)locationOfTouch:(NSUInteger)touchIndex inView:(UIView *)view {
+    if (touchIndex) {
+        return self.secondFingerPoint;
+    }
+    return self.firstFingerPoint;
+}
 @end


### PR DESCRIPTION
This PR Fixes the following issues:

#14827 due to the fact that each bug fix adds its corresponding tests.
#12143 Removes the dependency of the now deprecated `UIViewController. automaticallyAdjustsScrollViewInsets`.

### Tasks:
- [x] Fixes ornaments placement when `automaticallyAdjustContentInset` is set to `YES` and the `contentInset` is different from the `safeArea`.
The property `automaticallyAdjustsScrollViewInsets` it's been deprecated and moved to `UIScrollView` the fix I made adds `automaticallyAdjustContentInset` as part of the `mapView` that will control this behavior. If set to `YES` the `contentInset` will be equal to the view's safeArea (on iOS 11+) or top/bottom layout guides (iOS < 11) if set to `NO` it will use any value as long as it's not negative.
- [x] Fix an issue with the camera persisting edgePadding.
