### PR TITLE
[ios] Small fixes to the Swift Playground 

### DIFF
--- a/platform/ios/Mapbox.playground/Contents.swift
+++ b/platform/ios/Mapbox.playground/Contents.swift
@@ -121,7 +121,6 @@ class MapDelegate: NSObject, MGLMapViewDelegate {
         let isRecognized = press.state == .recognized
 
         if (isRecognized) {
-//            let coordinate: CLLocationCoordinate2D = mapView.convert(press.location(in: mapView), toCoordinateFrom: mapView)
             let annotation = MGLPointAnnotation()
             annotation.title = "Dropped Marker"
             annotation.coordinate = mapView.convert(press.location(in: mapView), toCoordinateFrom: mapView)

--- a/platform/ios/Mapbox.playground/Contents.swift
+++ b/platform/ios/Mapbox.playground/Contents.swift
@@ -121,10 +121,10 @@ class MapDelegate: NSObject, MGLMapViewDelegate {
         let isRecognized = press.state == .recognized
 
         if (isRecognized) {
-            let coordinate: CLLocationCoordinate2D = mapView.convert(press.location(in: mapView), toCoordinateFrom: mapView)
+//            let coordinate: CLLocationCoordinate2D = mapView.convert(press.location(in: mapView), toCoordinateFrom: mapView)
             let annotation = MGLPointAnnotation()
             annotation.title = "Dropped Marker"
-            annotation.coordinate = coordinate
+            annotation.coordinate = mapView.convert(press.location(in: mapView), toCoordinateFrom: mapView)
             mapView.addAnnotation(annotation)
             mapView.showAnnotations([annotation], animated: true)
         }
@@ -133,8 +133,6 @@ class MapDelegate: NSObject, MGLMapViewDelegate {
 }
 
 //: Create a map and its delegate
-
-let centerCoordinate = CLLocationCoordinate2D(latitude: 37.174057, longitude: -104.490984)
 
 let mapView = MGLMapView(frame: CGRect(x: 0, y: 0, width: width, height: height))
 mapView.frame = CGRect(x: 0, y: 0, width: width, height: height)
@@ -150,7 +148,7 @@ mapView.addGestureRecognizer(tapGesture)
 
 //: Zoom in to a location
 
-mapView.setCenter(centerCoordinate, zoomLevel: 12, animated: false)
+mapView.setCenter(CLLocationCoordinate2D(latitude: 37.174057, longitude: -104.490984), zoomLevel: 12, animated: false)
 
 //: Add control panel
 

--- a/platform/ios/Mapbox.playground/contents.xcplayground
+++ b/platform/ios/Mapbox.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='ios' display-mode='raw'>
+<playground version='5.0' target-platform='ios' display-mode='raw' last-migration='1100'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>


### PR DESCRIPTION
Storing `CLLocationCoordinate2D` objects as variables seems to cause exceptions in Swift playgrounds. I am just setting those coordinates directly for now. 