### PR TITLE
[ios] iOS 13 cherry-picks for ios-v5.3.1 (queso)

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ## 5.3.1
 
+* Fixed an issue where the scale bar text would become illegible if iOS 13 dark mode was enabled. ([#15524](https://github.com/mapbox/mapbox-gl-native/pull/15524))
 * Fixed an issue with the appearance of the compass text in iOS 13. ([#15547](https://github.com/mapbox/mapbox-gl-native/pull/15547))
 
 ## 5.3.0 - August 28, 2019

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
-## master
+## 5.3.1
 
-* Fixed an issue that caused the tilt gesture to trigger too easily and conflict with pinch or pan gestures. ([#15349](https://github.com/mapbox/mapbox-gl-native/pull/15349))
-* Fixed a bug with annotation view positions after camera transitions. ([#15122](https://github.com/mapbox/mapbox-gl-native/pull/15122/))
+* Fixed an issue with the appearance of the compass text in iOS 13. ([#15547](https://github.com/mapbox/mapbox-gl-native/pull/15547))
 
 ## 5.3.0 - August 28, 2019
 

--- a/platform/ios/src/MGLCompassButton.mm
+++ b/platform/ios/src/MGLCompassButton.mm
@@ -63,9 +63,16 @@
     UIImage *scaleImage = [UIImage mgl_resourceImageNamed:@"Compass"];
     UIGraphicsBeginImageContextWithOptions(scaleImage.size, NO, UIScreen.mainScreen.scale);
     [scaleImage drawInRect:{CGPointZero, scaleImage.size}];
+    
+    UIFont *northFont;
+    if (@available(iOS 13.0, *)) {
+        northFont = [UIFont systemFontOfSize:11 weight:UIFontWeightLight];
+    } else {
+        northFont = [UIFont systemFontOfSize:11 weight:UIFontWeightUltraLight];
+    }
 
     NSAttributedString *north = [[NSAttributedString alloc] initWithString:NSLocalizedStringWithDefaultValue(@"COMPASS_NORTH", nil, nil, @"N", @"Compass abbreviation for north") attributes:@{
-        NSFontAttributeName: [UIFont systemFontOfSize:11 weight:UIFontWeightUltraLight],
+        NSFontAttributeName: northFont,
         NSForegroundColorAttributeName: [UIColor whiteColor],
     }];
     CGRect stringRect = CGRectMake((scaleImage.size.width - north.size.width) / 2,

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -5291,35 +5291,29 @@ public:
 
     if (shouldEnableLocationServices)
     {
-        if (self.locationManager.authorizationStatus == kCLAuthorizationStatusNotDetermined)
-        {
-            BOOL requiresWhenInUseUsageDescription = [NSProcessInfo.processInfo isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){11,0,0}];
+        if (self.locationManager.authorizationStatus == kCLAuthorizationStatusNotDetermined) {
             BOOL hasWhenInUseUsageDescription = !![[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"];
-            BOOL hasAlwaysUsageDescription;
-            if (requiresWhenInUseUsageDescription)
-            {
-                hasAlwaysUsageDescription = !![[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysAndWhenInUseUsageDescription"] && hasWhenInUseUsageDescription;
-            }
-            else
-            {
-                hasAlwaysUsageDescription = !![[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"];
-            }
 
-            if (hasAlwaysUsageDescription)
-            {
-                [self.locationManager requestAlwaysAuthorization];
-            }
-            else if (hasWhenInUseUsageDescription)
-            {
-                [self.locationManager requestWhenInUseAuthorization];
-            }
-            else
-            {
-                NSString *suggestedUsageKeys = requiresWhenInUseUsageDescription ?
-                    @"NSLocationWhenInUseUsageDescription and (optionally) NSLocationAlwaysAndWhenInUseUsageDescription" :
-                    @"NSLocationWhenInUseUsageDescription and/or NSLocationAlwaysUsageDescription";
-                [NSException raise:MGLMissingLocationServicesUsageDescriptionException
-                            format:@"This app must have a value for %@ in its Info.plist.", suggestedUsageKeys];
+            if (@available(iOS 11.0, *)) {
+                // A WhenInUse string is required in iOS 11+ and the map never has any need for Always, so it's enough to just ask for WhenInUse.
+                if (hasWhenInUseUsageDescription) {
+                    [self.locationManager requestWhenInUseAuthorization];
+                } else {
+                    [NSException raise:MGLMissingLocationServicesUsageDescriptionException
+                                format:@"To use location services this app must have a NSLocationWhenInUseUsageDescription string in its Info.plist."];
+                }
+            } else {
+                // We might have to ask for Always if the app does not provide a WhenInUse string.
+                BOOL hasAlwaysUsageDescription = !![[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"];
+
+                if (hasWhenInUseUsageDescription) {
+                    [self.locationManager requestWhenInUseAuthorization];
+                } else if (hasAlwaysUsageDescription) {
+                    [self.locationManager requestAlwaysAuthorization];
+                } else {
+                    [NSException raise:MGLMissingLocationServicesUsageDescriptionException
+                                format:@"To use location services this app must have a NSLocationWhenInUseUsageDescription and/or NSLocationAlwaysUsageDescription string in its Info.plist."];
+                }
             }
         }
 

--- a/platform/ios/src/MGLScaleBar.mm
+++ b/platform/ios/src/MGLScaleBar.mm
@@ -101,7 +101,6 @@ static const CGFloat MGLFeetPerMeter = 3.28084;
 
 - (void)drawTextInRect:(CGRect)rect {
     CGSize shadowOffset = self.shadowOffset;
-    UIColor *textColor = self.textColor;
     
     CGContextRef context = UIGraphicsGetCurrentContext();
     CGContextSetLineWidth(context, 2);
@@ -112,7 +111,7 @@ static const CGFloat MGLFeetPerMeter = 3.28084;
     [super drawTextInRect:rect];
     
     CGContextSetTextDrawingMode(context, kCGTextFill);
-    self.textColor = textColor;
+    self.textColor = [UIColor blackColor];
     self.shadowOffset = CGSizeMake(0, 0);
     [super drawTextInRect:rect];
     


### PR DESCRIPTION
Cherry-picks #15524, #15547, and #15583 fixes for iOS 13 to `release-queso`, to be made available in a future `ios-v5.3.1` release.

Once these changes merge and `ios-v5.3.1` happens:
1. The original `release-ristretto` changelog entries should be removed (presuming `ios-v5.3.1` comes out before `ios-v5.4.0`).
2. These changelog entries should be backported to `master`/`release-ristretto`.

/cc @julianrex 