### PR TITLE
[android] Fix debugTree path for generating jacoco report.

### DIFF
--- a/platform/android/gradle/jacoco-report.gradle
+++ b/platform/android/gradle/jacoco-report.gradle
@@ -15,7 +15,7 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
     }
 
     def fileExcludes = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
-    def debugTree = fileTree(dir: "${project.buildDir}/intermediates/javac/debug/compileDebugJavaWithJavac/classes", excludes: fileExcludes)
+    def debugTree = fileTree(dir: "${project.buildDir}/intermediates/javac/debug/classes", excludes: fileExcludes)
     def mainSrc = "${project.projectDir}/src/main/java"
     println(mainSrc)
     def ecSrc = fileTree(dir: "$project.buildDir", include: "**/*.ec")


### PR DESCRIPTION
Resolves #15613 by fixing the debug tree path. 

It seems after update Android build tool version to 3.5.0, the debug tree path has changed from `intermediates/javac/debug/compileDebugJavaWithJavac/classes` to `intermediates/javac/debug/classes`.  Thus result in failure of CI on master branch.