### PR TITLE
[android] Migrate Android SDK to GL JS–powered feedback form

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
@@ -18,7 +18,6 @@ import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.attribution.Attribution;
 import com.mapbox.mapboxsdk.attribution.AttributionParser;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
-import com.mapbox.mapboxsdk.log.Logger;
 import com.mapbox.mapboxsdk.style.sources.Source;
 
 import java.lang.ref.WeakReference;
@@ -43,7 +42,6 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
   private static final String MAP_FEEDBACK_URL_OLD = "https://www.mapbox.com/map-feedback";
   private static final String MAP_FEEDBACK_URL_LOCATION_FRAGMENT_FORMAT = "/%f/%f/%f/%f/%d";
   private static final String MAP_FEEDBACK_STYLE_URI_REGEX = "^(.*://[^:^/]*)/(.*)/(.*)";
-  private final String TAG = this.getClass().getName();
 
   @NonNull
   private final Context context;
@@ -146,11 +144,9 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
   private void showMapAttributionWebPage(int which) {
     Attribution[] attributions = attributionSet.toArray(new Attribution[attributionSet.size()]);
     String url = attributions[which].getUrl();
-    Logger.d(TAG, "attribution url: " + url);
     if (url.contains(MAP_FEEDBACK_URL_OLD) || url.contains(MAP_FEEDBACK_URL)) {
       url = buildMapFeedbackMapUrl(Mapbox.getAccessToken());
     }
-    Logger.d(TAG, "final feedback url: " + url);
     showWebPage(url);
   }
 
@@ -179,18 +175,12 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
     Style style = mapboxMap.getStyle();
     if (style != null) {
       String styleUri = style.getUri();
-      Logger.d(TAG, "style uri:" + styleUri);
-
       Pattern pattern = Pattern.compile(MAP_FEEDBACK_STYLE_URI_REGEX);
       Matcher matcher = pattern.matcher(styleUri);
 
       if (matcher.find()) {
-        String styleApi = matcher.group(1);
         String styleOwner = matcher.group(2);
         String styleId = matcher.group(3);
-        Logger.d(TAG, "style API: " + styleApi);
-        Logger.d(TAG, "style owner: " + styleOwner);
-        Logger.d(TAG, "style id: " + styleId);
 
         builder.appendQueryParameter("owner", styleOwner)
                 .appendQueryParameter("id", styleId);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
@@ -8,6 +8,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.Toast;
@@ -147,14 +148,14 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
     String url = attributions[which].getUrl();
     Logger.d(TAG, "attribution url: " + url);
     if (url.contains(MAP_FEEDBACK_URL_OLD) || url.contains(MAP_FEEDBACK_URL)) {
-      url = buildMapFeedbackMapUrl();
+      url = buildMapFeedbackMapUrl(Mapbox.getAccessToken());
     }
     Logger.d(TAG, "final feedback url: " + url);
     showWebPage(url);
   }
 
   @NonNull
-  private String buildMapFeedbackMapUrl() {
+  String buildMapFeedbackMapUrl(@Nullable String accessToken) {
     // TODO Add Android Maps SDK version to the query parameter, currently the version API is not available.
 
     Uri.Builder builder = Uri.parse(MAP_FEEDBACK_URL).buildUpon();
@@ -171,7 +172,6 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
       builder.appendQueryParameter("referrer", packageName);
     }
 
-    String accessToken = Mapbox.getAccessToken();
     if (accessToken != null) {
       builder.appendQueryParameter("access_token", accessToken);
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
@@ -153,6 +153,7 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
   @NonNull
   String buildMapFeedbackMapUrl(@Nullable String accessToken) {
     // TODO Add Android Maps SDK version to the query parameter, currently the version API is not available.
+    // TODO Keep track of this issue at [#15632](https://github.com/mapbox/mapbox-gl-native/issues/15632)
 
     Uri.Builder builder = Uri.parse(MAP_FEEDBACK_URL).buildUpon();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
@@ -18,6 +18,7 @@ import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.attribution.Attribution;
 import com.mapbox.mapboxsdk.attribution.AttributionParser;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.log.Logger;
 import com.mapbox.mapboxsdk.style.sources.Source;
 
 import java.lang.ref.WeakReference;
@@ -141,9 +142,24 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
   private void showMapFeedbackWebPage(int which) {
     Attribution[] attributions = attributionSet.toArray(new Attribution[attributionSet.size()]);
     String url = attributions[which].getUrl();
-    if (url.contains(MAP_FEEDBACK_URL)) {
+    Logger.w("AttributionManager", "url:" + url);
+
+    Logger.w("AttributionManager", "camera position:" + mapboxMap.getCameraPosition().toString());
+    Logger.w("AttributionManager", "token:" + Mapbox.getAccessToken());
+    Logger.w("AttributionManager", "owner:" + Mapbox.getSkuToken());
+    Logger.w("AttributionManager", "package name:" + context.getPackageName());
+    mapboxMap.getStyle(new Style.OnStyleLoaded() {
+      @Override
+      public void onStyleLoaded(@NonNull Style style) {
+        String styleUri = style.getUri();
+
+        Logger.w("AttributionManager", "id:" + style.getUri());
+      }
+    });
+
       url = buildMapFeedbackMapUrl(mapboxMap.getCameraPosition());
-    }
+
+    Logger.w("AttributionManager", "final url to show:" + url);
     showWebPage(url);
   }
 
@@ -192,7 +208,8 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
         for (Source source : mapboxMap.getStyle().getSources()) {
           attribution = source.getAttribution();
           if (!attribution.isEmpty()) {
-            attributions.add(source.getAttribution());
+            Logger.w("AttributionManager", "add attribution:" + source.getAttribution());
+            attributions.add(attribution);
           }
         }
       }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
@@ -164,7 +164,7 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
               cameraPosition.zoom, cameraPosition.bearing, (int) cameraPosition.tilt));
     }
 
-    String packageName = context.getPackageName();
+    String packageName = context.getApplicationContext().getPackageName();
     if (packageName != null) {
       builder.appendQueryParameter("referrer", packageName);
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AttributionDialogManager.java
@@ -8,7 +8,6 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.Toast;
@@ -27,6 +26,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Responsible for managing attribution interactions on the map.
@@ -37,9 +38,11 @@ import java.util.Set;
  * </p>
  */
 public class AttributionDialogManager implements View.OnClickListener, DialogInterface.OnClickListener {
-
   private static final String MAP_FEEDBACK_URL = "https://apps.mapbox.com/feedback";
-  private static final String MAP_FEEDBACK_LOCATION_FORMAT = MAP_FEEDBACK_URL + "/#/%f/%f/%d";
+  private static final String MAP_FEEDBACK_URL_OLD = "https://www.mapbox.com/map-feedback";
+  private static final String MAP_FEEDBACK_URL_LOCATION_FRAGMENT_FORMAT = "/%f/%f/%f/%f/%d";
+  private static final String MAP_FEEDBACK_STYLE_URI_REGEX = "^(.*://[^:^/]*)/(.*)/(.*)";
+  private final String TAG = this.getClass().getName();
 
   @NonNull
   private final Context context;
@@ -91,7 +94,7 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
     if (isLatestEntry(which)) {
       showTelemetryDialog();
     } else {
-      showMapFeedbackWebPage(which);
+      showMapAttributionWebPage(which);
     }
   }
 
@@ -139,36 +142,62 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
     builder.show();
   }
 
-  private void showMapFeedbackWebPage(int which) {
+  private void showMapAttributionWebPage(int which) {
     Attribution[] attributions = attributionSet.toArray(new Attribution[attributionSet.size()]);
     String url = attributions[which].getUrl();
-    Logger.w("AttributionManager", "url:" + url);
-
-    Logger.w("AttributionManager", "camera position:" + mapboxMap.getCameraPosition().toString());
-    Logger.w("AttributionManager", "token:" + Mapbox.getAccessToken());
-    Logger.w("AttributionManager", "owner:" + Mapbox.getSkuToken());
-    Logger.w("AttributionManager", "package name:" + context.getPackageName());
-    mapboxMap.getStyle(new Style.OnStyleLoaded() {
-      @Override
-      public void onStyleLoaded(@NonNull Style style) {
-        String styleUri = style.getUri();
-
-        Logger.w("AttributionManager", "id:" + style.getUri());
-      }
-    });
-
-      url = buildMapFeedbackMapUrl(mapboxMap.getCameraPosition());
-
-    Logger.w("AttributionManager", "final url to show:" + url);
+    Logger.d(TAG, "attribution url: " + url);
+    if (url.contains(MAP_FEEDBACK_URL_OLD) || url.contains(MAP_FEEDBACK_URL)) {
+      url = buildMapFeedbackMapUrl();
+    }
+    Logger.d(TAG, "final feedback url: " + url);
     showWebPage(url);
   }
 
   @NonNull
-  private String buildMapFeedbackMapUrl(@Nullable CameraPosition cameraPosition) {
-    // appends current location to the map feedback url if available
-    return cameraPosition != null ? String.format(Locale.getDefault(),
-      MAP_FEEDBACK_LOCATION_FORMAT, cameraPosition.target.getLongitude(), cameraPosition.target.getLatitude(),
-      (int) cameraPosition.zoom) : MAP_FEEDBACK_URL;
+  private String buildMapFeedbackMapUrl() {
+    // TODO Add Android Maps SDK version to the query parameter, currently the version API is not available.
+
+    Uri.Builder builder = Uri.parse(MAP_FEEDBACK_URL).buildUpon();
+
+    CameraPosition cameraPosition = mapboxMap.getCameraPosition();
+    if (cameraPosition != null) {
+      builder.encodedFragment(String.format(Locale.getDefault(), MAP_FEEDBACK_URL_LOCATION_FRAGMENT_FORMAT,
+              cameraPosition.target.getLongitude(), cameraPosition.target.getLatitude(),
+              cameraPosition.zoom, cameraPosition.bearing, (int) cameraPosition.tilt));
+    }
+
+    String packageName = context.getPackageName();
+    if (packageName != null) {
+      builder.appendQueryParameter("referrer", packageName);
+    }
+
+    String accessToken = Mapbox.getAccessToken();
+    if (accessToken != null) {
+      builder.appendQueryParameter("access_token", accessToken);
+    }
+
+    Style style = mapboxMap.getStyle();
+    if (style != null) {
+      String styleUri = style.getUri();
+      Logger.d(TAG, "style uri:" + styleUri);
+
+      Pattern pattern = Pattern.compile(MAP_FEEDBACK_STYLE_URI_REGEX);
+      Matcher matcher = pattern.matcher(styleUri);
+
+      if (matcher.find()) {
+        String styleApi = matcher.group(1);
+        String styleOwner = matcher.group(2);
+        String styleId = matcher.group(3);
+        Logger.d(TAG, "style API: " + styleApi);
+        Logger.d(TAG, "style owner: " + styleOwner);
+        Logger.d(TAG, "style id: " + styleId);
+
+        builder.appendQueryParameter("owner", styleOwner)
+                .appendQueryParameter("id", styleId);
+      }
+    }
+
+    return builder.build().toString();
   }
 
   private void showWebPage(@NonNull String url) {
@@ -205,10 +234,9 @@ public class AttributionDialogManager implements View.OnClickListener, DialogInt
 
       Style style = mapboxMap.getStyle();
       if (style != null) {
-        for (Source source : mapboxMap.getStyle().getSources()) {
+        for (Source source : style.getSources()) {
           attribution = source.getAttribution();
           if (!attribution.isEmpty()) {
-            Logger.w("AttributionManager", "add attribution:" + source.getAttribution());
             attributions.add(attribution);
           }
         }

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/AttributionDialogManagerTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/AttributionDialogManagerTest.java
@@ -61,6 +61,7 @@ public class AttributionDialogManagerTest {
 
   @Test
   public void testBuildMapFeedbackMapUrl() {
+    when(context.getApplicationContext()).thenReturn(context);
     when(context.getPackageName()).thenReturn(ASSERT_MAPBOX_PACKAGE_NAME);
     when(style.getUri()).thenReturn(ASSERT_MAPBOX_STYLE_URI);
     when(mapboxMap.getCameraPosition()).thenReturn(cameraPosition);
@@ -72,6 +73,7 @@ public class AttributionDialogManagerTest {
 
   @Test
   public void testBuildMapFeedbackMapUrlWithLocalStyleJson() {
+    when(context.getApplicationContext()).thenReturn(context);
     when(context.getPackageName()).thenReturn(ASSERT_MAPBOX_PACKAGE_NAME);
     when(style.getUri()).thenReturn(ASSERT_MAPBOX_LOCAL_STYLE_URI);
     when(mapboxMap.getCameraPosition()).thenReturn(cameraPosition);
@@ -83,6 +85,7 @@ public class AttributionDialogManagerTest {
 
   @Test
   public void testBuildMapFeedbackMapUrlWithNullCameraPosition() {
+    when(context.getApplicationContext()).thenReturn(context);
     when(context.getPackageName()).thenReturn(ASSERT_MAPBOX_PACKAGE_NAME);
     when(style.getUri()).thenReturn(ASSERT_MAPBOX_LOCAL_STYLE_URI);
     when(mapboxMap.getCameraPosition()).thenReturn(null);

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/AttributionDialogManagerTest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/AttributionDialogManagerTest.java
@@ -1,0 +1,96 @@
+package com.mapbox.mapboxsdk.maps;
+
+import android.content.Context;
+
+import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+public class AttributionDialogManagerTest {
+  @InjectMocks
+  Context context = mock(Context.class);
+
+  @InjectMocks
+  MapboxMap mapboxMap = mock(MapboxMap.class);
+
+  @InjectMocks
+  Style style = mock(Style.class);
+
+  private AttributionDialogManager attributionDialogManager;
+  private CameraPosition cameraPosition;
+
+  private static final String ASSERT_MAPBOX_TOKEN = "TestAccessToken";
+
+  private static final String ASSERT_MAPBOX_STYLE_URI = "mapbox://styles/mapbox/streets-v11";
+  private static final String ASSERT_MAPBOX_LOCAL_STYLE_URI = "asset://style.json";
+
+  private static final String ASSERT_MAPBOX_PACKAGE_NAME = "com.mapbox.attributionmanagertest";
+
+  private static final String ASSERT_MAPBOX_FEEDBACK_FINAL_URL =
+          "https://apps.mapbox.com/feedback?referrer=com.mapbox.attributionmanagertest&"
+                  + "access_token=TestAccessToken&owner=mapbox&id=streets-v11"
+                  + "#/22.200001/11.100000/12.000000/24.000000/5";
+  private static final String ASSERT_MAPBOX_FEEDHACK_FINAL_URL_LOCAL_STYLE =
+          "https://apps.mapbox.com/feedback?referrer=com.mapbox.attributionmanagertest&"
+                  + "access_token=TestAccessToken#/22.200001/11.100000/12.000000/24.000000/5";
+  private static final String ASSERT_MAPBOX_FEEDBACL_FINAL_URL_NULL_CAMERA_POSITION =
+          "https://apps.mapbox.com/feedback?referrer=com.mapbox.attributionmanagertest&access_token=TestAccessToken";
+
+  @Before
+  public void beforeTest() {
+    attributionDialogManager = new AttributionDialogManager(context, mapboxMap);
+    cameraPosition = new CameraPosition.Builder(CameraPosition.DEFAULT)
+            .tilt(5.0f).zoom(12).bearing(24.0f).target(new LatLng(11.1f, 22.2f)).build();
+  }
+
+  @Test
+  public void testSanity() {
+    assertNotNull("AttributionDialogManager should not be null", attributionDialogManager);
+  }
+
+  @Test
+  public void testBuildMapFeedbackMapUrl() {
+    when(context.getPackageName()).thenReturn(ASSERT_MAPBOX_PACKAGE_NAME);
+    when(style.getUri()).thenReturn(ASSERT_MAPBOX_STYLE_URI);
+    when(mapboxMap.getCameraPosition()).thenReturn(cameraPosition);
+    when(mapboxMap.getStyle()).thenReturn(style);
+
+    Assert.assertEquals(ASSERT_MAPBOX_FEEDBACK_FINAL_URL,
+            attributionDialogManager.buildMapFeedbackMapUrl(ASSERT_MAPBOX_TOKEN));
+  }
+
+  @Test
+  public void testBuildMapFeedbackMapUrlWithLocalStyleJson() {
+    when(context.getPackageName()).thenReturn(ASSERT_MAPBOX_PACKAGE_NAME);
+    when(style.getUri()).thenReturn(ASSERT_MAPBOX_LOCAL_STYLE_URI);
+    when(mapboxMap.getCameraPosition()).thenReturn(cameraPosition);
+    when(mapboxMap.getStyle()).thenReturn(style);
+
+    Assert.assertEquals(ASSERT_MAPBOX_FEEDHACK_FINAL_URL_LOCAL_STYLE,
+            attributionDialogManager.buildMapFeedbackMapUrl(ASSERT_MAPBOX_TOKEN));
+  }
+
+  @Test
+  public void testBuildMapFeedbackMapUrlWithNullCameraPosition() {
+    when(context.getPackageName()).thenReturn(ASSERT_MAPBOX_PACKAGE_NAME);
+    when(style.getUri()).thenReturn(ASSERT_MAPBOX_LOCAL_STYLE_URI);
+    when(mapboxMap.getCameraPosition()).thenReturn(null);
+    when(mapboxMap.getStyle()).thenReturn(style);
+
+    Assert.assertEquals(ASSERT_MAPBOX_FEEDBACL_FINAL_URL_NULL_CAMERA_POSITION,
+            attributionDialogManager.buildMapFeedbackMapUrl(ASSERT_MAPBOX_TOKEN));
+  }
+
+
+}


### PR DESCRIPTION
Resolves #9090 by constructing the feedback url with referrer(package name), style owner, style id, access token and camera position information(Longitude, Latitude, zoom level, bearing and tilt).

There is one parameter missing since we don't currently have a SDK version API in our Android SDK, so couldn't add the sdk version info to the query parameter. I have created another ticket #15632 to keep track of it.

