### PR TITLE
[ios] Add support for running tests (that require an access token) individually.

### DIFF
--- a/platform/ios/Integration Tests/MGLMapViewIntegrationTest.h
+++ b/platform/ios/Integration Tests/MGLMapViewIntegrationTest.h
@@ -25,7 +25,6 @@
 })
 
 @interface MGLMapViewIntegrationTest : XCTestCase <MGLMapViewDelegate>
-@property (nonatomic) NSString *accessToken;
 @property (nonatomic) MGLMapView *mapView;
 @property (nonatomic) UIWindow *window;
 @property (nonatomic) MGLStyle *style;

--- a/platform/ios/Integration Tests/MGLMapViewIntegrationTest.m
+++ b/platform/ios/Integration Tests/MGLMapViewIntegrationTest.m
@@ -31,10 +31,7 @@
         
         // Check for tests that require a valid access token
         if ([test.name containsString:@"🔒"]) {
-            if (accessToken) {
-                ((MGLMapViewIntegrationTest *)test).accessToken = accessToken;
-            }
-            else {
+            if (!accessToken) {
                 printf("warning: MAPBOX_ACCESS_TOKEN env var is required for test '%s' - skipping.\n", test.name.UTF8String);
                 continue;
             }
@@ -53,7 +50,17 @@
 - (void)setUp {
     [super setUp];
 
-    [MGLAccountManager setAccessToken:self.accessToken ?: @"pk.feedcafedeadbeefbadebede"];
+    NSString *accessToken;
+    
+    if ([self.name containsString:@"🔒"]) {
+        accessToken = [[NSProcessInfo processInfo] environment][@"MAPBOX_ACCESS_TOKEN"];
+        
+        if (!accessToken) {
+            printf("warning: MAPBOX_ACCESS_TOKEN env var is required for test '%s' - trying anyway.\n", self.name.UTF8String);
+        }
+    }
+
+    [MGLAccountManager setAccessToken:accessToken ?: @"pk.feedcafedeadbeefbadebede"];
     
     NSURL *styleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"one-liner" withExtension:@"json"];
 


### PR DESCRIPTION
Follows on from https://github.com/mapbox/mapbox-gl-native/pull/15477; this PR allows individual tests that require an access token to be run. Previously the access token wouldn't be set up as `defaultTestSuite` is not call in the individual case.