### PR TITLE
Ignore location tracking mode based animations when the camera is transitioning

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
@@ -726,6 +726,10 @@ public final class LocationComponent {
    * If you are not using any of {@link CameraMode} modes,
    * use one of {@link MapboxMap#moveCamera(CameraUpdate)},
    * {@link MapboxMap#easeCamera(CameraUpdate)} or {@link MapboxMap#animateCamera(CameraUpdate)} instead.
+   * <p>
+   * If the camera is transitioning when the zoom change is requested, the call is going to be ignored.
+   * Use {@link CameraTransitionListener} to chain the animations, or provide the zoom as a camera change argument.
+   * </p>
    *
    * @param zoomLevel         The desired zoom level.
    * @param animationDuration The zoom animation duration.
@@ -741,6 +745,10 @@ public final class LocationComponent {
         "LocationComponent#zoomWhileTracking method can only be used",
         " when a camera mode other than CameraMode#NONE is engaged."));
       return;
+    } else if (locationCameraController.isTransitioning()) {
+      Logger.e(TAG,
+        "LocationComponent#zoomWhileTracking method call is ignored because the camera mode is transitioning");
+      return;
     }
     locationAnimatorCoordinator.feedNewZoomLevel(zoomLevel, mapboxMap.getCameraPosition(), animationDuration, callback);
   }
@@ -751,6 +759,10 @@ public final class LocationComponent {
    * If you are not using any of {@link CameraMode} modes,
    * use one of {@link MapboxMap#moveCamera(CameraUpdate)},
    * {@link MapboxMap#easeCamera(CameraUpdate)} or {@link MapboxMap#animateCamera(CameraUpdate)} instead.
+   * <p>
+   * If the camera is transitioning when the zoom change is requested, the call is going to be ignored.
+   * Use {@link CameraTransitionListener} to chain the animations, or provide the zoom as a camera change argument.
+   * </p>
    *
    * @param zoomLevel         The desired zoom level.
    * @param animationDuration The zoom animation duration.
@@ -766,6 +778,10 @@ public final class LocationComponent {
    * If you are not using any of {@link CameraMode} modes,
    * use one of {@link MapboxMap#moveCamera(CameraUpdate)},
    * {@link MapboxMap#easeCamera(CameraUpdate)} or {@link MapboxMap#animateCamera(CameraUpdate)} instead.
+   * <p>
+   * If the camera is transitioning when the zoom change is requested, the call is going to be ignored.
+   * Use {@link CameraTransitionListener} to chain the animations, or provide the zoom as a camera change argument.
+   * </p>
    *
    * @param zoomLevel The desired zoom level.
    */
@@ -788,6 +804,10 @@ public final class LocationComponent {
    * If you are not using any of {@link CameraMode} modes,
    * use one of {@link MapboxMap#moveCamera(CameraUpdate)},
    * {@link MapboxMap#easeCamera(CameraUpdate)} or {@link MapboxMap#animateCamera(CameraUpdate)} instead.
+   * <p>
+   * If the camera is transitioning when the tilt change is requested, the call is going to be ignored.
+   * Use {@link CameraTransitionListener} to chain the animations, or provide the tilt as a camera change argument.
+   * </p>
    *
    * @param tilt              The desired camera tilt.
    * @param animationDuration The tilt animation duration.
@@ -803,6 +823,10 @@ public final class LocationComponent {
         "LocationComponent#tiltWhileTracking method can only be used",
         " when a camera mode other than CameraMode#NONE is engaged."));
       return;
+    } else if (locationCameraController.isTransitioning()) {
+      Logger.e(TAG,
+        "LocationComponent#tiltWhileTracking method call is ignored because the camera mode is transitioning");
+      return;
     }
     locationAnimatorCoordinator.feedNewTilt(tilt, mapboxMap.getCameraPosition(), animationDuration, callback);
   }
@@ -813,6 +837,10 @@ public final class LocationComponent {
    * If you are not using any of {@link CameraMode} modes,
    * use one of {@link MapboxMap#moveCamera(CameraUpdate)},
    * {@link MapboxMap#easeCamera(CameraUpdate)} or {@link MapboxMap#animateCamera(CameraUpdate)} instead.
+   * <p>
+   * If the camera is transitioning when the tilt change is requested, the call is going to be ignored.
+   * Use {@link CameraTransitionListener} to chain the animations, or provide the tilt as a camera change argument.
+   * </p>
    *
    * @param tilt              The desired camera tilt.
    * @param animationDuration The tilt animation duration.
@@ -828,6 +856,10 @@ public final class LocationComponent {
    * If you are not using any of {@link CameraMode} modes,
    * use one of {@link MapboxMap#moveCamera(CameraUpdate)},
    * {@link MapboxMap#easeCamera(CameraUpdate)} or {@link MapboxMap#animateCamera(CameraUpdate)} instead.
+   * <p>
+   * If the camera is transitioning when the tilt change is requested, the call is going to be ignored.
+   * Use {@link CameraTransitionListener} to chain the animations, or provide the tilt as a camera change argument.
+   * </p>
    *
    * @param tilt The desired camera tilt.
    */

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
@@ -1289,6 +1289,36 @@ class LocationComponentTest : EspressoTest() {
   }
 
   @Test
+  fun animators_dontZoomWhileTransitioning() {
+    val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
+      override fun onLocationComponentAction(
+        component: LocationComponent,
+        mapboxMap: MapboxMap,
+        style: Style,
+        uiController: UiController,
+        context: Context
+      ) {
+        component.activateLocationComponent(LocationComponentActivationOptions
+                .builder(context, style)
+                .useDefaultLocationEngine(false)
+                .build())
+        component.isLocationComponentEnabled = true
+        component.forceLocationUpdate(location)
+
+        val zoom = mapboxMap.cameraPosition.zoom
+        component.setCameraMode(CameraMode.TRACKING_GPS, 500L, null, null, null, null)
+        component.zoomWhileTracking(16.0, 1000)
+        uiController.loopMainThreadForAtLeast(1000)
+        TestingAsyncUtils.waitForLayer(uiController, mapView)
+
+        assertEquals(zoom, mapboxMap.cameraPosition.zoom, 0.0001)
+      }
+    }
+
+    executeComponentTest(componentAction)
+  }
+
+  @Test
   @Ignore
   fun animators_cancelZoomWhileTracking() {
     val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
@@ -1427,6 +1457,36 @@ class LocationComponentTest : EspressoTest() {
         TestingAsyncUtils.waitForLayer(uiController, mapView)
 
         assertEquals(tilt, mapboxMap.cameraPosition.tilt, 0.1)
+      }
+    }
+
+    executeComponentTest(componentAction)
+  }
+
+  @Test
+  fun animators_dontTiltWhileTransitioning() {
+    val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
+      override fun onLocationComponentAction(
+        component: LocationComponent,
+        mapboxMap: MapboxMap,
+        style: Style,
+        uiController: UiController,
+        context: Context
+      ) {
+        component.activateLocationComponent(LocationComponentActivationOptions
+          .builder(context, style)
+          .useDefaultLocationEngine(false)
+          .build())
+        component.isLocationComponentEnabled = true
+        component.forceLocationUpdate(location)
+
+        val tilt = mapboxMap.cameraPosition.tilt
+        component.setCameraMode(CameraMode.TRACKING_GPS, 500L, null, null, null, null)
+        component.tiltWhileTracking(30.0, 1000)
+        uiController.loopMainThreadForAtLeast(1000)
+        TestingAsyncUtils.waitForLayer(uiController, mapView)
+
+        assertEquals(tilt, mapboxMap.cameraPosition.tilt, 0.0001)
       }
     }
 


### PR DESCRIPTION
Fixes an unexpected behavior where `zoomWhileTracking` and `tiltWhileTracking` animations were ignored for the duration of the camera transition.

This could result in scenarios like:
```
1) set the camera tracking mode with a duration of 750ms
2) immediately call `zoomWhileTracking` with a duration of 1000ms

Zoom animation is ignored for 750ms and then resumes with a jump to 75% completion.
```
```
1) set the camera tracking mode with a duration of 750ms
2) immediately call `zoomWhileTracking` with a duration of 500ms

Zoom animation is completely ignored.
```

Changelog entry candidate:
```
Fixes an unexpected behavior that occurred while calling `zoomWhileTracking` and `tiltWhileTracking` animations during the `CameraMode` change transition. Those animations are now ignored and print appropriate warnings. [#15641](https://github.com/mapbox/mapbox-gl-native/pull/15641)
```