### PR TITLE
[android] fix: MapSnapshotter.withApiBaseUri function

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
@@ -235,7 +235,7 @@ public class MapSnapshotter {
      */
     @NonNull
     public Options withApiBaseUri(String apiBaseUri) {
-      this.apiBaseUrl = apiBaseUrl;
+      this.apiBaseUrl = apiBaseUri;
       return this;
     }
 


### PR DESCRIPTION
cherry-pick of external contributed PR in https://github.com/mapbox/mapbox-gl-native/pull/15635

cc @Guillaume-TagHeuer