### PR TITLE
[ios] Ensure potential variables that might be nil have a fallback.

### DIFF
--- a/platform/darwin/src/MGLSDKMetricsManager.m
+++ b/platform/darwin/src/MGLSDKMetricsManager.m
@@ -42,12 +42,13 @@ NSString* MGLStringFromMetricType(MGLMetricType metricType) {
                                 [UIScreen mainScreen].bounds.size.height];
         
         NSLocale *currentLocale = [NSLocale currentLocale];
-        NSString *country = [currentLocale objectForKey:NSLocaleCountryCode];
+        
+        NSString *country = [currentLocale objectForKey:NSLocaleCountryCode] ?: @"unknown";
         
         NSString *device = deviceName();
         
-        const NXArchInfo localArchInfo = *NXGetLocalArchInfo();
-        NSString *abi = [NSString stringWithUTF8String:localArchInfo.description];
+        const NXArchInfo *localArchInfo = NXGetLocalArchInfo();
+        NSString *abi = (localArchInfo != NULL) ? @(localArchInfo->description) : @"unknown";
         
         NSString *ram = [NSString stringWithFormat:@"%llu", [NSProcessInfo processInfo].physicalMemory];
         

--- a/platform/darwin/src/MGLSDKMetricsManager.m
+++ b/platform/darwin/src/MGLSDKMetricsManager.m
@@ -47,8 +47,16 @@ NSString* MGLStringFromMetricType(MGLMetricType metricType) {
         
         NSString *device = deviceName();
         
-        const NXArchInfo *localArchInfo = NXGetLocalArchInfo();
-        NSString *abi = (localArchInfo != NULL) ? @(localArchInfo->description) : @"unknown";
+        NSString *abi = @"unknown";
+        
+        {
+            const NXArchInfo *localArchInfo = NXGetLocalArchInfo();
+        
+            if (localArchInfo) {
+                abi = @(localArchInfo->description);
+                NXFreeArchInfo(localArchInfo);
+            }
+        }
         
         NSString *ram = [NSString stringWithFormat:@"%llu", [NSProcessInfo processInfo].physicalMemory];
         


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/15526.

Speculative fix based on what variables could be nil. Most APIs are marked as "non null", so I've added fallbacks for the others.