### PR TITLE
[ios, macos] Tail work from 15385

### DIFF
--- a/platform/darwin/src/MGLMapSnapshotter.h
+++ b/platform/darwin/src/MGLMapSnapshotter.h
@@ -228,7 +228,6 @@ MGL_EXPORT
  Starts the snapshot creation and executes the specified blocks with the result
  on the specified queue. Use this option if you want to add custom drawing on top of the
  resulting `MGLMapSnapShot`.
- @param queue The queue to handle the result on.
  @param overlayHandler The block to handle manipulation of the `MGLMapSnapshotter`'s `CGContext`.
  @param completionHandler The block to handle the result in.
  */

--- a/platform/ios/app/MBXAnnotationView.h
+++ b/platform/ios/app/MBXAnnotationView.h
@@ -1,4 +1,4 @@
-#import <Mapbox/Mapbox.h>
+@import Mapbox;
 
 @interface MBXAnnotationView : MGLAnnotationView
 @end

--- a/platform/ios/app/MBXAppDelegate.m
+++ b/platform/ios/app/MBXAppDelegate.m
@@ -1,6 +1,7 @@
+@import Mapbox;
+
 #import "MBXAppDelegate.h"
 #import "MBXViewController.h"
-#import <Mapbox/Mapbox.h>
 
 @interface MBXAppDelegate() <MGLMetricsManagerDelegate>
 

--- a/platform/ios/app/MBXCustomCalloutView.h
+++ b/platform/ios/app/MBXCustomCalloutView.h
@@ -1,5 +1,4 @@
-#import <UIKit/UIKit.h>
-#import <Mapbox/Mapbox.h>
+@import Mapbox;
 
 /**
  * Basic custom callout view to demonstrate how to

--- a/platform/ios/app/MBXCustomLocationViewController.m
+++ b/platform/ios/app/MBXCustomLocationViewController.m
@@ -1,6 +1,6 @@
-#import "MBXCustomLocationViewController.h"
+@import Mapbox;
 
-#import <Mapbox/Mapbox.h>
+#import "MBXCustomLocationViewController.h"
 
 @interface MBXCustomLocationManager : NSObject<MGLLocationManager>
 @end

--- a/platform/ios/app/MBXEmbeddedMapViewController.m
+++ b/platform/ios/app/MBXEmbeddedMapViewController.m
@@ -1,5 +1,6 @@
+@import Mapbox;
+
 #import "MBXEmbeddedMapViewController.h"
-#import <Mapbox/Mapbox.h>
 
 typedef NS_ENUM(NSInteger, MBXEmbeddedControl) {
     MBXEmbeddedControlZoom = 0,

--- a/platform/ios/app/MBXOfflinePacksTableViewController.m
+++ b/platform/ios/app/MBXOfflinePacksTableViewController.m
@@ -1,6 +1,7 @@
+@import Mapbox;
+
 #import "MBXOfflinePacksTableViewController.h"
 
-#import <Mapbox/Mapbox.h>
 
 static NSString * const MBXOfflinePackContextNameKey = @"Name";
 

--- a/platform/ios/app/MBXOrnamentsViewController.m
+++ b/platform/ios/app/MBXOrnamentsViewController.m
@@ -1,6 +1,6 @@
-#import "MBXOrnamentsViewController.h"
+@import Mapbox;
 
-#import <Mapbox/Mapbox.h>
+#import "MBXOrnamentsViewController.h"
 
 @interface MBXOrnamentsViewController ()<MGLMapViewDelegate>
 

--- a/platform/ios/app/MBXSnapshotsViewController.m
+++ b/platform/ios/app/MBXSnapshotsViewController.m
@@ -1,6 +1,6 @@
-#import "MBXSnapshotsViewController.h"
+@import Mapbox;
 
-#import <Mapbox/Mapbox.h>
+#import "MBXSnapshotsViewController.h"
 
 @interface MBXSnapshotsViewController ()
 

--- a/platform/ios/app/MBXState.h
+++ b/platform/ios/app/MBXState.h
@@ -1,5 +1,4 @@
-#import <Foundation/Foundation.h>
-#import <Mapbox/Mapbox.h>
+@import Mapbox;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/platform/ios/app/MBXStateManager.m
+++ b/platform/ios/app/MBXStateManager.m
@@ -1,5 +1,4 @@
 #import "MBXStateManager.h"
-#import <Mapbox/Mapbox.h>
 #import "MBXState.h"
 #import "MBXViewController.h"
 

--- a/platform/ios/app/MBXUserLocationAnnotationView.h
+++ b/platform/ios/app/MBXUserLocationAnnotationView.h
@@ -1,4 +1,4 @@
-#import <Mapbox/Mapbox.h>
+@import Mapbox;
 
 @interface MBXUserLocationAnnotationView : MGLUserLocationAnnotationView
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -1,3 +1,5 @@
+@import Mapbox;
+
 #import "MBXViewController.h"
 
 #import "MBXAppDelegate.h"
@@ -12,8 +14,6 @@
 #import "MBXState.h"
 
 #import "MBXFrameTimeGraphView.h"
-
-#import <Mapbox/Mapbox.h>
 #import "../src/MGLMapView_Experimental.h"
 
 #import <objc/runtime.h>

--- a/platform/ios/benchmark/MBXBenchAppDelegate.m
+++ b/platform/ios/benchmark/MBXBenchAppDelegate.m
@@ -1,6 +1,5 @@
 #import "MBXBenchAppDelegate.h"
 #import "MBXBenchViewController.h"
-#import <Mapbox/Mapbox.h>
 
 @implementation MBXBenchAppDelegate
 

--- a/platform/ios/benchmark/MBXBenchViewController.mm
+++ b/platform/ios/benchmark/MBXBenchViewController.mm
@@ -1,8 +1,5 @@
 #import "MBXBenchViewController.h"
-
 #import "MBXBenchAppDelegate.h"
-
-#import <Mapbox/Mapbox.h>
 #import "MGLMapView_Private.h"
 
 #include "locations.hpp"

--- a/platform/ios/framework/Info.plist
+++ b/platform/ios/framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.mapbox.core</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Reinstates the bundle identifier lost in #15385. Also fixes some minor build warnings.

See also https://github.com/mapbox/mapbox-gl-native/pull/15646