### PR TITLE
add support for RelWithDebInfo and MinSizeRel

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -75,6 +75,12 @@ android {
             testCoverageEnabled true
             jniDebuggable true
         }
+        RelWithDebInfo {
+            initWith release
+        }
+        MinSizeRel {
+            initWith release
+        }
     }
 }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -47,6 +47,13 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.debug
         }
+        RelWithDebInfo {
+            minifyEnabled false
+            initWith release
+        }
+        MinSizeRel {
+            initWith release
+        }
     }
 
     dexOptions {

--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     implementation dependenciesList.gmsLocation
     implementation dependenciesList.timber
     debugImplementation dependenciesList.leakCanaryDebug
-    releaseImplementation dependenciesList.leakCanaryRelease
+    implementation dependenciesList.leakCanaryRelease
 
     androidTestImplementation dependenciesList.supportAnnotations
     androidTestImplementation dependenciesList.testRunner

--- a/platform/android/gradle/native-build.gradle
+++ b/platform/android/gradle/native-build.gradle
@@ -1,6 +1,12 @@
 ext.nativeBuild = { nativeTargets ->
     android {
-        defaultPublishConfig project.hasProperty("mapbox.buildtype") ? project.getProperty("mapbox.buildtype") : "debug"
+        def buildType = "debug"
+        if (project.hasProperty("mapbox.buildtype")) {
+            buildType = project.getProperty("mapbox.buildtype")
+        }
+
+
+        defaultPublishConfig buildType
 
         // We sometimes want to invoke Gradle without building a native dependency, e.g. when we just want
         // to invoke the Java tests. When we explicitly specify an ABI of 'none', no native dependencies are
@@ -37,6 +43,7 @@ ext.nativeBuild = { nativeTargets ->
             if (abi != 'none') {
                 externalNativeBuild {
                     cmake {
+                        arguments "-DCMAKE_BUILD_TYPE=" + buildType
                         arguments "-DANDROID_TOOLCHAIN=clang"
                         arguments "-DANDROID_STL=" + stl
                         arguments "-DANDROID_CPP_FEATURES=exceptions"


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/15556. 

This PR adds support for 2 more CMAKE_BUILD_TYPES:
 - RelWithDebInfo 
 - MinSizeRel

The configuration seems to be working correctly as this generates so files with different sizes:
  - Release 95mb
  - RelWithDebInfo 103mb
  - MinSizeRel 192mb

Todo:
  - [ ] create RelWithDebInfo as part of release workflow on CI
  - [ ] store .so file as build artefact
  - [ ] integrate slack bot to notify when a release finished building (makes it easier for looking up releases) 
  - [ ] update release documentation to also add .so file to git tag