### PR TITLE
[build] Update CircleCI to Xcode 11, ruby 2.6, jazzy 0.11.1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -176,7 +176,7 @@ workflows:
       - linux-doxygen
       - linux-render-tests
       - ios-debug
-      - ios-debug-xcode11
+      - ios-debug-xcode10
       - ios-release-template:
           name: ios-release
       - ios-release-tag:
@@ -202,7 +202,7 @@ workflows:
       - ios-sanitize-nightly
       - ios-sanitize-address-nightly
       - ios-static-analyzer-nightly
-      - ios-static-analyzer-nightly-xcode11
+      - ios-static-analyzer-nightly-xcode10
 
 executors:
   ubuntu-disco:
@@ -1089,7 +1089,7 @@ jobs:
 # ------------------------------------------------------------------------------
   node-macos-release:
     macos:
-      xcode: "10.3.0"
+      xcode: "11.0.0"
     environment:
       BUILDTYPE: RelWithDebInfo
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -1253,7 +1253,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-debug:
     macos:
-      xcode: "10.3.0"
+      xcode: "11.0.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -1278,9 +1278,9 @@ jobs:
       - upload-xcode-build-logs
 
 # ------------------------------------------------------------------------------
-  ios-debug-xcode11:
+  ios-debug-xcode10:
     macos:
-      xcode: "11.0.0"
+      xcode: "10.3.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -1307,7 +1307,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-sanitize-nightly:
     macos:
-      xcode: "10.3.0"
+      xcode: "11.0.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -1331,7 +1331,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-sanitize-address-nightly:
     macos:
-      xcode: "10.3.0"
+      xcode: "11.0.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -1351,7 +1351,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-static-analyzer-nightly:
     macos:
-      xcode: "10.3.0"
+      xcode: "11.0.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -1369,9 +1369,9 @@ jobs:
       - notify-slack-nightly-failure
 
 # ------------------------------------------------------------------------------
-  ios-static-analyzer-nightly-xcode11:
+  ios-static-analyzer-nightly-xcode10:
     macos:
-      xcode: "11.0.0"
+      xcode: "10.3.0"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -1391,7 +1391,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-release-template:
     macos:
-      xcode: "10.3.0"
+      xcode: "11.0.0"
     shell: /bin/bash --login -eo pipefail
     environment:
       BUILDTYPE: Release
@@ -1440,7 +1440,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-release-tag:
     macos:
-      xcode: "10.3.0"
+      xcode: "11.0.0"
     shell: /bin/bash --login -eo pipefail
     environment:
       BUILDTYPE: Release
@@ -1521,7 +1521,7 @@ jobs:
 # ------------------------------------------------------------------------------
   macos-render-tests:
     macos:
-      xcode: "10.3.0"
+      xcode: "11.0.0"
     environment:
       BUILDTYPE: RelWithDebInfo
       HOMEBREW_NO_AUTO_UPDATE: 1

--- a/circle.yml
+++ b/circle.yml
@@ -560,7 +560,9 @@ commands:
     steps:
     - run:
         name: Install iOS packaging dependencies
-        command: ./platform/ios/scripts/install-packaging-dependencies.sh
+        command: |
+          echo "ruby-2.6" > ~/.ruby-version
+          ./platform/ios/scripts/install-packaging-dependencies.sh
         background: true
 
   install-macos-dependencies:
@@ -1390,6 +1392,7 @@ jobs:
   ios-release-template:
     macos:
       xcode: "10.3.0"
+    shell: /bin/bash --login -eo pipefail
     environment:
       BUILDTYPE: Release
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -1438,6 +1441,7 @@ jobs:
   ios-release-tag:
     macos:
       xcode: "10.3.0"
+    shell: /bin/bash --login -eo pipefail
     environment:
       BUILDTYPE: Release
       HOMEBREW_NO_AUTO_UPDATE: 1

--- a/platform/ios/scripts/install-packaging-dependencies.sh
+++ b/platform/ios/scripts/install-packaging-dependencies.sh
@@ -48,7 +48,7 @@ if [[ -z `which jazzy` || $(jazzy -v) != "jazzy version: ${JAZZY_VERSION}" ]]; t
     step "Installing jazzy…"
 
     if [[ "${CIRCLECI}" == true ]]; then
-        sudo gem install jazzy -v $JAZZY_VERSION --no-document -- --with-sqlite3-lib=/usr/lib
+        sudo gem install jazzy -v $JAZZY_VERSION --no-document
     else
         gem install jazzy -v $JAZZY_VERSION --no-document
     fi

--- a/platform/ios/scripts/install-packaging-dependencies.sh
+++ b/platform/ios/scripts/install-packaging-dependencies.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 COCOAPODS_VERSION="1.7.5"
-JAZZY_VERSION="0.10.0"
+JAZZY_VERSION="0.11.1"
 CIRCLECI=${CIRCLECI:-false}
 
 function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }


### PR DESCRIPTION
- Updates existing Xcode 10.3 builds to Xcode 11.0 (which is [still GM1](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v1136/index.html), but should be updated to stable quite soon — we shouldn’t build a release with this PR until GM2/stable is available).
- Keeps two Xcode 10.3 builds around for a little while, to ensure we’re compatible during this transition.
  - [ ] Will need to update the required builds once this merges.
- Updates to jazzy [0.11.1](https://github.com/realm/jazzy/releases/tag/v0.11.1).
- Updates to Ruby 2.6.x, which is more modern and allows us to remove some build workarounds for jazzy. (See [these CircleCI docs](https://circleci.com/docs/2.0/testing-ios/#using-custom-ruby-versions) for more information.)