### PR TITLE
Add layer_manager.cpp to mbgl-offline on macOS

### DIFF
--- a/platform/macos/config.cmake
+++ b/platform/macos/config.cmake
@@ -70,6 +70,10 @@ endmacro()
 
 
 macro(mbgl_platform_offline)
+    target_sources(mbgl-offline
+        PRIVATE platform/default/src/mbgl/layermanager/layer_manager.cpp
+    )
+
     target_link_libraries(mbgl-offline
         PRIVATE mbgl-filesource
         PRIVATE mbgl-loop-darwin


### PR DESCRIPTION
This is to fix #15358

Rebased https://github.com/mapbox/mapbox-gl-native/pull/15373