### PR TITLE
[android] Bumped Java SDK dependency to stable 4.9.0

### DIFF
--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
     ]
 
     versions = [
-            mapboxServices  : '4.9.0-alpha.1',
+            mapboxServices  : '4.9.0',
             mapboxTelemetry : '4.5.1',
             mapboxCore      : '1.3.0',
             mapboxGestures  : '0.5.1',


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-gl-native/issues/15689 by bumping the Maps SDK's Java SDK dependency to stable 4.9.0.

Java SDK `4.9.0` release ticket: https://github.com/mapbox/mapbox-java/issues/1070

Changes:

- https://github.com/mapbox/mapbox-java/releases/tag/v4.9.0-alpha.1
- https://github.com/mapbox/mapbox-java/releases/tag/v4.9.0