### PR TITLE
[build] Notify on Slack when master branch builds fail

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -608,6 +608,18 @@ commands:
             scripts/notify-slack.sh
           fi
 
+  notify-slack-master-failure:
+    steps:
+    - run:
+        name: Send a Slack notification on a master branch failure
+        when: on_fail
+        command: |
+          if [[ $CIRCLE_BRANCH == master ]]; then
+            export SLACK_MESSAGE="<$CIRCLE_BUILD_URL|Master branch build of \`$CIRCLE_JOB\` failed>."
+            export SLACK_COLOR="danger"
+            scripts/notify-slack.sh
+          fi
+
   #
   # Add this step to all regular jobs to enable skipping of certain non-code-related changes.
   #
@@ -748,6 +760,7 @@ jobs:
       BUILDTYPE: Debug
       IS_LOCAL_DEVELOPMENT: false
       MBGL_ANDROID_STL: << parameters.stl >>
+      SLACK_CHANNEL: C21AYEN5N
     steps:
       - install-dependencies: { gradle: true }
       - check-if-this-job-can-be-skipped
@@ -813,6 +826,7 @@ jobs:
           path: platform/android/MapboxGLAndroidSDKTestApp/lint-baseline.xml
       - store_artifacts:
           path: platform/android/MapboxGLAndroidSDK/build/intermediates/cmake/debug/obj
+      - notify-slack-master-failure
 
 # ------------------------------------------------------------------------------
   android-release:
@@ -825,6 +839,7 @@ jobs:
       JOBS: 8
       BUILDTYPE: Release
       IS_LOCAL_DEVELOPMENT: false
+      SLACK_CHANNEL: C21AYEN5N
     steps:
       - install-dependencies: { gradle: true }
       - check-if-this-job-can-be-skipped
@@ -914,6 +929,7 @@ jobs:
       - run:
           name: Record size
           command: platform/android/scripts/metrics.sh
+      - notify-slack-master-failure
 # ------------------------------------------------------------------------------
   android-debug-arm-v7-buck:
     docker:
@@ -924,6 +940,7 @@ jobs:
       JOBS: 2
       BUILDTYPE: Debug
       ANDROID_NDK: /android/sdk/ndk-bundle
+      SLACK_CHANNEL: C21AYEN5N
     steps:
       - checkout
       - npm-install
@@ -939,6 +956,7 @@ jobs:
           command: |
             cd misc/buck
             buck build mapbox-gl-native:android-core
+      - notify-slack-master-failure
 
 # ------------------------------------------------------------------------------
   node-macos-release:
@@ -948,6 +966,7 @@ jobs:
       BUILDTYPE: RelWithDebInfo
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_NO_INSTALL_CLEANUP: 1
+      SLACK_CHANNEL: C9C7RJKJA
     steps:
       - install-macos-dependencies
       - install-node-macos-dependencies
@@ -959,6 +978,7 @@ jobs:
       - publish-node-package
       - collect-xcode-build-logs
       - upload-xcode-build-logs
+      - notify-slack-master-failure
 
 # ------------------------------------------------------------------------------
   linux-clang-7-sanitize-address-undefined:
@@ -976,6 +996,7 @@ jobs:
       LDFLAGS: -fsanitize=address -fsanitize=undefined
       ASAN_OPTIONS: detect_leaks=0:color=always:print_summary=1
       UBSAN_OPTIONS: print_stacktrace=1:color=always:print_summary=1
+      SLACK_CHANNEL: CFN66JMMK
     steps:
       - install-dependencies
       - check-if-this-job-can-be-skipped
@@ -983,6 +1004,7 @@ jobs:
       - build-test
       - save-dependencies
       - run-unit-tests-sanitized
+      - notify-slack-master-failure
 
 # ------------------------------------------------------------------------------
   linux-clang-7-sanitize-thread:
@@ -999,6 +1021,7 @@ jobs:
       CXXFLAGS: -fsanitize=thread
       LDFLAGS: -fsanitize=thread
       TSAN_OPTIONS: color=always:print_summary=1
+      SLACK_CHANNEL: CFN66JMMK
     steps:
       - install-dependencies
       - check-if-this-job-can-be-skipped
@@ -1006,6 +1029,7 @@ jobs:
       - build-test
       - save-dependencies
       - run-unit-tests-sanitized
+      - notify-slack-master-failure
 
 # ------------------------------------------------------------------------------
   linux-gcc5-debug-coverage:
@@ -1019,6 +1043,7 @@ jobs:
       BUILDTYPE: Debug
       WITH_EGL: 1
       WITH_COVERAGE: 1
+      SLACK_CHANNEL: CFN66JMMK
     steps:
       - install-dependencies
       - check-if-this-job-can-be-skipped
@@ -1037,6 +1062,7 @@ jobs:
             if [[ $CIRCLE_BRANCH == master ]]; then
                 scripts/publish_core_codecoverage.js -p Linux -s Core
             fi
+      - notify-slack-master-failure
 
 # ------------------------------------------------------------------------------
   linux-doxygen:
@@ -1072,6 +1098,7 @@ jobs:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_NO_INSTALL_CLEANUP: 1
+      SLACK_CHANNEL: C0ACM9Q2C
     steps:
       - install-macos-dependencies
       - install-dependencies
@@ -1087,6 +1114,7 @@ jobs:
       - save-dependencies
       - collect-xcode-build-logs
       - upload-xcode-build-logs
+      - notify-slack-master-failure
 
 # ------------------------------------------------------------------------------
   ios-debug-xcode10:
@@ -1096,6 +1124,7 @@ jobs:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_NO_INSTALL_CLEANUP: 1
+      SLACK_CHANNEL: C0ACM9Q2C
     steps:
       - install-macos-dependencies
       - install-dependencies
@@ -1111,6 +1140,7 @@ jobs:
       - save-dependencies
       - collect-xcode-build-logs
       - upload-xcode-build-logs
+      - notify-slack-master-failure
 
 # ------------------------------------------------------------------------------
   ios-sanitize-nightly:
@@ -1313,6 +1343,7 @@ jobs:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_NO_INSTALL_CLEANUP: 1
+      SLACK_CHANNEL: C0ACM9Q2C
     steps:
       - install-macos-dependencies
       - install-dependencies
@@ -1331,6 +1362,7 @@ jobs:
           destination: test/fixtures
       - collect-xcode-build-logs
       - upload-xcode-build-logs
+      - notify-slack-master-failure
 
 # ------------------------------------------------------------------------------
   metrics-nightly:


### PR DESCRIPTION
Fixes #15614 by notifying the owners of a failing `master` branch CI job in their Slack channel. The goal is to quickly surface flaky builds, so that we might address them sooner and not allow them to metastasize.

### Channels

Inside baseball, but here are the channels that I assigned — let me know if there is some place that would be more appropriate (while still being actionable) for your team.

- Android: `#android`
- iOS/macOS: `#apple`
- Core, rendering, linux: `#gl-native`
- NodeJS: `#maps-api`

### Messages

The messages themselves aren’t especially loud — they’re just two lines with a link to the failed job.

<img width="404" alt="Screen Shot 2019-09-23 at 5 17 16 PM" src="https://user-images.githubusercontent.com/1198851/65471944-0e352c00-de26-11e9-887f-5016064770a0.png">

_Something like this ↑, except less happy._

/cc @tmpsantos @brunoabinader @tobrun @zugaldia @julianrex @springmeyer