### PR TITLE
[ios] Fix layout of Scale bar components

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 ### Other changes
 
 * Suppress network requests for expired tiles update, if these tiles are invisible. ([#15741](https://github.com/mapbox/mapbox-gl-native/pull/15741))
+* Fixed an issue that caused `MGLScaleBar` to have an incorrect size when resizing or rotating. ([#15703](https://github.com/mapbox/mapbox-gl-native/pull/15703))
 
 ## 5.4.0 - September 25, 2019
 
@@ -19,7 +20,6 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed an issue where the collision boxes for symbols would not be updated when `MGLSymbolStyleLayer.textTranslation` or `MGLSymbolStyleLayer.iconTranslation` were used. ([#15467](https://github.com/mapbox/mapbox-gl-native/pull/15467))
 * Enabled use of `MGLSymbolStyleLayer.textOffset` option together with `MGLSymbolStyleLayer.textVariableAnchor` (if `MGLSymbolStyleLayer.textRadialOffset` option is not provided). ([#15542](https://github.com/mapbox/mapbox-gl-native/pull/15542))
 * Fixed an issue that caused constant repainting for sources with invisible layers. ([#15600](https://github.com/mapbox/mapbox-gl-native/pull/15600))
-* Fixed incorrect `MGLScaleBar` component rendering, resizing on rotation. ([#15703](https://github.com/mapbox/mapbox-gl-native/pull/15703))
 
 ### User interaction
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -19,6 +19,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed an issue where the collision boxes for symbols would not be updated when `MGLSymbolStyleLayer.textTranslation` or `MGLSymbolStyleLayer.iconTranslation` were used. ([#15467](https://github.com/mapbox/mapbox-gl-native/pull/15467))
 * Enabled use of `MGLSymbolStyleLayer.textOffset` option together with `MGLSymbolStyleLayer.textVariableAnchor` (if `MGLSymbolStyleLayer.textRadialOffset` option is not provided). ([#15542](https://github.com/mapbox/mapbox-gl-native/pull/15542))
 * Fixed an issue that caused constant repainting for sources with invisible layers. ([#15600](https://github.com/mapbox/mapbox-gl-native/pull/15600))
+* Fixed incorrect `MGLScaleBar` component rendering, resizing on rotation. ([#15703](https://github.com/mapbox/mapbox-gl-native/pull/15703))
 
 ### User interaction
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -931,15 +931,14 @@ public:
 // This gets called when the view dimension changes, e.g. because the device is being rotated.
 - (void)layoutSubviews
 {
+    [super layoutSubviews];
+
     // Calling this here instead of in the scale bar itself because if this is done in the
     // scale bar instance, it triggers a call to this `layoutSubviews` method that calls
     // `_mbglMap->setSize()` just below that triggers rendering update which triggers
     // another scale bar update which causes a rendering update loop and a major performace
-    // degradation. The only time the scale bar's intrinsic content size _must_ invalidated
-    // is here as a reaction to this object's view dimension changes.
+    // degradation.
     [self.scaleBar invalidateIntrinsicContentSize];
-    
-    [super layoutSubviews];
 
     [self adjustContentInset];
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -6643,11 +6643,7 @@ public:
     // setting this property.
     if ( ! self.scaleBar.hidden)
     {
-//        CGSize originalSize = self.scaleBar.intrinsicContentSize;
         [(MGLScaleBar *)self.scaleBar setMetersPerPoint:[self metersPerPointAtLatitude:self.centerCoordinate.latitude]];
-//        if ( ! CGSizeEqualToSize(originalSize, self.scaleBar.intrinsicContentSize)) {
-//            [self installScaleBarConstraints];
-//        }
     }
 }
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -852,9 +852,11 @@ public:
             break;
     }
 
-    [updatedConstraints addObject:[view.widthAnchor constraintEqualToConstant:size.width]];
-    [updatedConstraints addObject:[view.heightAnchor constraintEqualToConstant:size.height]];
-
+    if (!CGSizeEqualToSize(size, CGSizeZero)) {
+        [updatedConstraints addObject:[view.widthAnchor constraintEqualToConstant:size.width]];
+        [updatedConstraints addObject:[view.heightAnchor constraintEqualToConstant:size.height]];
+    }
+    
     [NSLayoutConstraint deactivateConstraints:constraints];
     [constraints removeAllObjects];
     [NSLayoutConstraint activateConstraints:updatedConstraints];
@@ -883,7 +885,7 @@ public:
     [self updateConstraintsForOrnament:self.scaleBar
                            constraints:self.scaleBarConstraints
                               position:self.scaleBarPosition
-                                  size:self.scaleBar.intrinsicContentSize
+                                  size:CGSizeZero
                                margins:self.scaleBarMargins];
 }
 
@@ -6642,11 +6644,11 @@ public:
     // setting this property.
     if ( ! self.scaleBar.hidden)
     {
-        CGSize originalSize = self.scaleBar.intrinsicContentSize;
+//        CGSize originalSize = self.scaleBar.intrinsicContentSize;
         [(MGLScaleBar *)self.scaleBar setMetersPerPoint:[self metersPerPointAtLatitude:self.centerCoordinate.latitude]];
-        if ( ! CGSizeEqualToSize(originalSize, self.scaleBar.intrinsicContentSize)) {
-            [self installScaleBarConstraints];
-        }
+//        if ( ! CGSizeEqualToSize(originalSize, self.scaleBar.intrinsicContentSize)) {
+//            [self installScaleBarConstraints];
+//        }
     }
 }
 

--- a/platform/ios/src/MGLScaleBar.h
+++ b/platform/ios/src/MGLScaleBar.h
@@ -11,4 +11,5 @@
 @property (nonatomic, readonly) NSArray<UIView *> *bars;
 @property (nonatomic, readonly) UIView *containerView;
 @property (nonatomic, readonly) CGSize size;
+@property (nonatomic) NSNumber *testingRightToLeftOverride;
 @end

--- a/platform/ios/src/MGLScaleBar.h
+++ b/platform/ios/src/MGLScaleBar.h
@@ -6,10 +6,4 @@
 // Sets the scale and redraws the scale bar
 @property (nonatomic, assign) CLLocationDistance metersPerPoint;
 
-// Expose for testing
-@property (nonatomic, readonly) NSArray<UIView *> *labelViews;
-@property (nonatomic, readonly) NSArray<UIView *> *bars;
-@property (nonatomic, readonly) UIView *containerView;
-@property (nonatomic, readonly) CGSize size;
-@property (nonatomic) NSNumber *testingRightToLeftOverride;
 @end

--- a/platform/ios/src/MGLScaleBar.h
+++ b/platform/ios/src/MGLScaleBar.h
@@ -10,5 +10,5 @@
 @property (nonatomic, readonly) NSArray<UIView *> *labelViews;
 @property (nonatomic, readonly) NSArray<UIView *> *bars;
 @property (nonatomic, readonly) UIView *containerView;
-
+@property (nonatomic, readonly) CGSize size;
 @end

--- a/platform/ios/src/MGLScaleBar.h
+++ b/platform/ios/src/MGLScaleBar.h
@@ -6,4 +6,9 @@
 // Sets the scale and redraws the scale bar
 @property (nonatomic, assign) CLLocationDistance metersPerPoint;
 
+// Expose for testing
+@property (nonatomic, readonly) NSArray<UIView *> *labelViews;
+@property (nonatomic, readonly) NSArray<UIView *> *bars;
+@property (nonatomic, readonly) UIView *containerView;
+
 @end

--- a/platform/ios/src/MGLScaleBar.mm
+++ b/platform/ios/src/MGLScaleBar.mm
@@ -75,9 +75,9 @@ static const MGLRow MGLImperialTable[] ={
 @class MGLScaleBarLabel;
 
 @interface MGLScaleBar()
-@property (nonatomic) NSArray<UIView *> *labelViews;
-@property (nonatomic) NSArray<UIView *> *bars;
-@property (nonatomic) UIView *containerView;
+@property (nonatomic, readwrite) NSArray<UIView *> *labelViews;
+@property (nonatomic, readwrite) NSArray<UIView *> *bars;
+@property (nonatomic, readwrite) UIView *containerView;
 @property (nonatomic) MGLDistanceFormatter *formatter;
 @property (nonatomic, assign) MGLRow row;
 @property (nonatomic) UIColor *primaryColor;
@@ -87,7 +87,6 @@ static const MGLRow MGLImperialTable[] ={
 @property (nonatomic) NSMutableDictionary* labelImageCache;
 @property (nonatomic) MGLScaleBarLabel* prototypeLabel;
 @property (nonatomic) CGFloat lastLabelWidth;
-
 @end
 
 static const CGFloat MGLBarHeight = 4;

--- a/platform/ios/src/MGLScaleBar.mm
+++ b/platform/ios/src/MGLScaleBar.mm
@@ -89,6 +89,7 @@ static const MGLRow MGLImperialTable[] ={
 @property (nonatomic, readwrite) CGSize size;
 @property (nonatomic) BOOL recalculateSize;
 @property (nonatomic) BOOL shouldLayoutBars;
+@property (nonatomic) NSNumber *testingRightToLeftOverride;
 @end
 
 static const CGFloat MGLBarHeight = 4;

--- a/platform/ios/src/MGLScaleBar.mm
+++ b/platform/ios/src/MGLScaleBar.mm
@@ -75,9 +75,9 @@ static const MGLRow MGLImperialTable[] ={
 @class MGLScaleBarLabel;
 
 @interface MGLScaleBar()
-@property (nonatomic, readwrite) NSArray<UIView *> *labelViews;
-@property (nonatomic, readwrite) NSArray<UIView *> *bars;
-@property (nonatomic, readwrite) UIView *containerView;
+@property (nonatomic) NSArray<UIView *> *labelViews;
+@property (nonatomic) NSArray<UIView *> *bars;
+@property (nonatomic) UIView *containerView;
 @property (nonatomic) MGLDistanceFormatter *formatter;
 @property (nonatomic, assign) MGLRow row;
 @property (nonatomic) UIColor *primaryColor;
@@ -86,7 +86,7 @@ static const MGLRow MGLImperialTable[] ={
 @property (nonatomic) NSMutableDictionary* labelImageCache;
 @property (nonatomic) MGLScaleBarLabel* prototypeLabel;
 @property (nonatomic) CGFloat lastLabelWidth;
-@property (nonatomic, readwrite) CGSize size;
+@property (nonatomic) CGSize size;
 @property (nonatomic) BOOL recalculateSize;
 @property (nonatomic) BOOL shouldLayoutBars;
 @property (nonatomic) NSNumber *testingRightToLeftOverride;

--- a/platform/ios/src/MGLScaleBar.mm
+++ b/platform/ios/src/MGLScaleBar.mm
@@ -240,6 +240,10 @@ static const CGFloat MGLScaleBarMinimumBarWidth = 30.0; // Arbitrary
 #pragma mark - Convenience methods
 
 - (BOOL)usesRightToLeftLayout {
+    if (self.testingRightToLeftOverride) {
+        return [self.testingRightToLeftOverride boolValue];
+    }
+
     return [UIView userInterfaceLayoutDirectionForSemanticContentAttribute:self.superview.semanticContentAttribute] == UIUserInterfaceLayoutDirectionRightToLeft;
 }
 

--- a/platform/ios/src/MGLScaleBar.mm
+++ b/platform/ios/src/MGLScaleBar.mm
@@ -87,6 +87,7 @@ static const MGLRow MGLImperialTable[] ={
 @property (nonatomic) MGLScaleBarLabel* prototypeLabel;
 @property (nonatomic) CGFloat lastLabelWidth;
 @property (nonatomic, readwrite) CGSize size;
+@property (nonatomic) BOOL recalculateSize;
 @property (nonatomic) BOOL shouldLayoutBars;
 @end
 
@@ -290,6 +291,8 @@ static const CGFloat MGLScaleBarMinimumBarWidth = 30.0; // Arbitrary
     _metersPerPoint = metersPerPoint;
     
     [self updateVisibility];
+    
+    self.recalculateSize = YES;
     [self invalidateIntrinsicContentSize];
 }
 
@@ -311,6 +314,11 @@ static const CGFloat MGLScaleBarMinimumBarWidth = 30.0; // Arbitrary
 /// label
 
 - (void)updateConstraints {
+    if (self.isHidden || !self.recalculateSize) {
+        [super updateConstraints];
+        return;
+    }
+        
     // TODO: Improve this (and the side-effects)
     self.row = [self preferredRow];
 
@@ -338,7 +346,7 @@ static const CGFloat MGLScaleBarMinimumBarWidth = 30.0; // Arbitrary
     self.size = CGSizeMake(totalBarWidth + halfLabelWidth, 16);
        
     [self setNeedsLayout];
-    [super updateConstraints];
+    [super updateConstraints]; // This calls intrinsicContentSize
 }
 
 - (void)updateVisibility {
@@ -465,6 +473,11 @@ static const CGFloat MGLScaleBarMinimumBarWidth = 30.0; // Arbitrary
 - (void)layoutSubviews {
     [super layoutSubviews];
 
+    if (!self.recalculateSize) {
+        return;
+    }
+
+    self.recalculateSize = NO;
 
     // If size is 0, then we keep the existing layout (which will fade out)
     if (self.size.width <= 0.0) {

--- a/platform/ios/test/MGLMapViewLayoutTests.m
+++ b/platform/ios/test/MGLMapViewLayoutTests.m
@@ -178,6 +178,8 @@
     CGFloat margin = 4.0;
     
     UIView *scaleBar = self.mapView.scaleBar;
+    XCTAssertFalse(CGSizeEqualToSize(scaleBar.bounds.size, CGSizeZero));
+    
     NSArray *testDataList = [self makeTestDataListWithView:scaleBar margin:margin];
     
     for (MGLOrnamentTestData *testData in testDataList) {
@@ -200,7 +202,8 @@
     CGFloat margin = 20.0;
     
     MGLScaleBar *scaleBar = (MGLScaleBar*)self.mapView.scaleBar;
-    
+    XCTAssertFalse(CGSizeEqualToSize(scaleBar.bounds.size, CGSizeZero));
+
     for (NSInteger rtl = 0; rtl <= 1; rtl++) {
         scaleBar.testingRightToLeftOverride = @((BOOL)rtl);
         

--- a/platform/ios/test/MGLMapViewLayoutTests.m
+++ b/platform/ios/test/MGLMapViewLayoutTests.m
@@ -3,6 +3,8 @@
 #import "MGLMapViewDelegate.h"
 #import "MGLAccountManager.h"
 
+#import "MGLScaleBar.h"
+
 
 @interface MGLOrnamentTestData : NSObject
 
@@ -140,7 +142,7 @@
                                       expectedOrigin:CGPointMake(margin, margin)],
              [MGLOrnamentTestData createWithPosition:MGLOrnamentPositionTopRight
                                               offset:CGPointMake(margin, margin)
-                                      expectedOrigin:CGPointMake(CGRectGetMaxX(self.mapView.bounds) - margin - CGRectGetWidth(view.frame), 4)],
+                                      expectedOrigin:CGPointMake(CGRectGetMaxX(self.mapView.bounds) - margin - CGRectGetWidth(view.frame), margin)],
              [MGLOrnamentTestData createWithPosition:MGLOrnamentPositionBottomLeft
                                               offset:CGPointMake(margin, margin)
                                       expectedOrigin:CGPointMake(margin,  CGRectGetMaxY(self.mapView.bounds) - margin - bottomSafeAreaInset - CGRectGetHeight(view.frame))],
@@ -174,21 +176,93 @@
 - (void)testScalebarPlacement {
     double accuracy = 0.01;
     CGFloat margin = 4.0;
-
+    
     UIView *scaleBar = self.mapView.scaleBar;
     NSArray *testDataList = [self makeTestDataListWithView:scaleBar margin:margin];
-
+    
     for (MGLOrnamentTestData *testData in testDataList) {
         self.mapView.scaleBarPosition = testData.position;
         self.mapView.scaleBarMargins = testData.offset;
-
+        
         //invoke layout
         [self.superView setNeedsLayout];
         [self.superView layoutIfNeeded];
-
+        
         XCTAssertEqualWithAccuracy(CGRectGetMinX(scaleBar.frame), testData.expectedOrigin.x, accuracy);
         XCTAssertEqualWithAccuracy(CGRectGetMinY(scaleBar.frame), testData.expectedOrigin.y, accuracy);
     }
+}
+
+// This test checks the frames of the scalebar's subviews, based on the positions
+// as above, but also with forced Right-to-Left reading, and modifying zoom levels.
+- (void)testScalebarSubviewPlacement {
+    double accuracy = 0.01;
+    CGFloat margin = 20.0;
+    
+    MGLScaleBar *scaleBar = (MGLScaleBar*)self.mapView.scaleBar;
+    
+//    for (NSInteger rtl = 0; rtl <= 1; rtl++) {
+//        scaleBar.rightToLeftOverrideForTesting = @((BOOL)rtl);
+        
+        NSString *positions[] = {
+            @"MGLOrnamentPositionTopLeft",
+            @"MGLOrnamentPositionTopRight",
+            @"MGLOrnamentPositionBottomLeft",
+            @"MGLOrnamentPositionBottomRight"
+        };
+        
+        for (CGFloat zoomLevel = 0; zoomLevel < 20; zoomLevel++)
+        {
+            self.mapView.zoomLevel = zoomLevel;
+            [self.superView setNeedsLayout];
+            [self.superView layoutIfNeeded];
+            
+            // Following method assumes scaleBar has an up-to-date frame, based
+            // on the current zoom level. Modifying the position and margins
+            // should not affect the overall size of the scalebar.
+            
+            NSArray *testDataList = [self makeTestDataListWithView:scaleBar margin:margin];
+            
+            CGSize initialSize = scaleBar.intrinsicContentSize;
+            XCTAssert(CGSizeEqualToSize(initialSize, scaleBar.bounds.size));
+            
+            for (MGLOrnamentTestData *testData in testDataList) {
+                self.mapView.scaleBarPosition = testData.position;
+                self.mapView.scaleBarMargins = testData.offset;
+                
+                [self.superView setNeedsLayout];
+                [self.superView layoutIfNeeded];
+                
+                XCTAssert(CGSizeEqualToSize(initialSize, scaleBar.bounds.size));
+                
+                NSString *activityName = [NSString stringWithFormat:
+                                          @"Scalebar subview tests: Zoom=%ld, POS=%@, Visible=%@",
+//                                          @"Scalebar subview tests: RTL=%@, Zoom=%ld, POS=%@, Visible=%@",
+//                                          (rtl == 0 ? @"NO" : @"YES"),
+                                          (long)zoomLevel,
+                                          positions[testData.position],
+                                          scaleBar.alpha > 0.0 ? @"YES" : @"NO"];
+                
+                [XCTContext runActivityNamed:activityName
+                                       block:^(id<XCTActivity> activity) {
+                    
+                    // Check the subviews
+                    XCTAssertEqualWithAccuracy(CGRectGetMinX(scaleBar.frame), testData.expectedOrigin.x, accuracy);
+                    XCTAssertEqualWithAccuracy(CGRectGetMinY(scaleBar.frame), testData.expectedOrigin.y, accuracy);
+                    
+                    XCTAssertTrue(CGRectContainsRect(scaleBar.bounds, scaleBar.containerView.frame));
+                    for (UIView *bar in scaleBar.bars) {
+                        XCTAssertTrue(CGRectContainsRect(scaleBar.containerView.bounds, bar.frame));
+                    }
+                    for (UIView *label in scaleBar.labelViews) {
+                        if (!label.isHidden) {
+                            XCTAssertTrue(CGRectContainsRect(scaleBar.bounds, label.frame));
+                        }
+                    }
+                }];
+            }
+        }
+//    }
 }
 
 - (void)testAttributionButtonPlacement {

--- a/platform/ios/test/MGLMapViewLayoutTests.m
+++ b/platform/ios/test/MGLMapViewLayoutTests.m
@@ -5,7 +5,6 @@
 
 #import "MGLScaleBar.h"
 
-
 @interface MGLOrnamentTestData : NSObject
 
 @property (nonatomic) MGLOrnamentPosition position;
@@ -24,6 +23,14 @@
     return data;
 }
 
+@end
+
+@interface MGLScaleBar (Tests)
+@property (nonatomic, readonly) NSArray<UIView *> *labelViews;
+@property (nonatomic, readonly) NSArray<UIView *> *bars;
+@property (nonatomic, readonly) UIView *containerView;
+@property (nonatomic, readonly) CGSize size;
+@property (nonatomic) NSNumber *testingRightToLeftOverride;
 @end
 
 

--- a/platform/ios/test/MGLMapViewLayoutTests.m
+++ b/platform/ios/test/MGLMapViewLayoutTests.m
@@ -201,8 +201,8 @@
     
     MGLScaleBar *scaleBar = (MGLScaleBar*)self.mapView.scaleBar;
     
-//    for (NSInteger rtl = 0; rtl <= 1; rtl++) {
-//        scaleBar.rightToLeftOverrideForTesting = @((BOOL)rtl);
+    for (NSInteger rtl = 0; rtl <= 1; rtl++) {
+        scaleBar.testingRightToLeftOverride = @((BOOL)rtl);
         
         NSString *positions[] = {
             @"MGLOrnamentPositionTopLeft",
@@ -236,9 +236,8 @@
                 XCTAssert(CGSizeEqualToSize(initialSize, scaleBar.bounds.size));
                 
                 NSString *activityName = [NSString stringWithFormat:
-                                          @"Scalebar subview tests: Zoom=%ld, POS=%@, Visible=%@",
-//                                          @"Scalebar subview tests: RTL=%@, Zoom=%ld, POS=%@, Visible=%@",
-//                                          (rtl == 0 ? @"NO" : @"YES"),
+                                          @"Scalebar subview tests: RTL=%@, Zoom=%ld, POS=%@, Visible=%@",
+                                          (rtl == 0 ? @"NO" : @"YES"),
                                           (long)zoomLevel,
                                           positions[testData.position],
                                           scaleBar.alpha > 0.0 ? @"YES" : @"NO"];
@@ -262,7 +261,7 @@
                 }];
             }
         }
-//    }
+    }
 }
 
 - (void)testAttributionButtonPlacement {

--- a/platform/ios/test/MGLMapViewLayoutTests.m
+++ b/platform/ios/test/MGLMapViewLayoutTests.m
@@ -176,20 +176,20 @@
 - (void)testScalebarPlacement {
     double accuracy = 0.01;
     CGFloat margin = 4.0;
-    
+
     UIView *scaleBar = self.mapView.scaleBar;
     XCTAssertFalse(CGSizeEqualToSize(scaleBar.bounds.size, CGSizeZero));
-    
+
     NSArray *testDataList = [self makeTestDataListWithView:scaleBar margin:margin];
-    
+
     for (MGLOrnamentTestData *testData in testDataList) {
         self.mapView.scaleBarPosition = testData.position;
         self.mapView.scaleBarMargins = testData.offset;
-        
+
         //invoke layout
         [self.superView setNeedsLayout];
         [self.superView layoutIfNeeded];
-        
+
         XCTAssertEqualWithAccuracy(CGRectGetMinX(scaleBar.frame), testData.expectedOrigin.x, accuracy);
         XCTAssertEqualWithAccuracy(CGRectGetMinY(scaleBar.frame), testData.expectedOrigin.y, accuracy);
     }
@@ -200,58 +200,58 @@
 - (void)testScalebarSubviewPlacement {
     double accuracy = 0.01;
     CGFloat margin = 20.0;
-    
+
     MGLScaleBar *scaleBar = (MGLScaleBar*)self.mapView.scaleBar;
     XCTAssertFalse(CGSizeEqualToSize(scaleBar.bounds.size, CGSizeZero));
 
     for (NSInteger rtl = 0; rtl <= 1; rtl++) {
         scaleBar.testingRightToLeftOverride = @((BOOL)rtl);
-        
+
         NSString *positions[] = {
             @"MGLOrnamentPositionTopLeft",
             @"MGLOrnamentPositionTopRight",
             @"MGLOrnamentPositionBottomLeft",
             @"MGLOrnamentPositionBottomRight"
         };
-        
+
         for (CGFloat zoomLevel = 0; zoomLevel < 20; zoomLevel++)
         {
             self.mapView.zoomLevel = zoomLevel;
             [self.superView setNeedsLayout];
             [self.superView layoutIfNeeded];
-            
+
             // Following method assumes scaleBar has an up-to-date frame, based
             // on the current zoom level. Modifying the position and margins
             // should not affect the overall size of the scalebar.
-            
+
             NSArray *testDataList = [self makeTestDataListWithView:scaleBar margin:margin];
-            
+
             CGSize initialSize = scaleBar.intrinsicContentSize;
             XCTAssert(CGSizeEqualToSize(initialSize, scaleBar.bounds.size));
-            
+
             for (MGLOrnamentTestData *testData in testDataList) {
                 self.mapView.scaleBarPosition = testData.position;
                 self.mapView.scaleBarMargins = testData.offset;
-                
+
                 [self.superView setNeedsLayout];
                 [self.superView layoutIfNeeded];
-                
+
                 XCTAssert(CGSizeEqualToSize(initialSize, scaleBar.bounds.size));
-                
+
                 NSString *activityName = [NSString stringWithFormat:
                                           @"Scalebar subview tests: RTL=%@, Zoom=%ld, POS=%@, Visible=%@",
                                           (rtl == 0 ? @"NO" : @"YES"),
                                           (long)zoomLevel,
                                           positions[testData.position],
                                           scaleBar.alpha > 0.0 ? @"YES" : @"NO"];
-                
+
                 [XCTContext runActivityNamed:activityName
                                        block:^(id<XCTActivity> activity) {
-                    
+
                     // Check the subviews
                     XCTAssertEqualWithAccuracy(CGRectGetMinX(scaleBar.frame), testData.expectedOrigin.x, accuracy);
                     XCTAssertEqualWithAccuracy(CGRectGetMinY(scaleBar.frame), testData.expectedOrigin.y, accuracy);
-                    
+
                     XCTAssertTrue(CGRectContainsRect(scaleBar.bounds, scaleBar.containerView.frame));
                     for (UIView *bar in scaleBar.bars) {
                         XCTAssertTrue(CGRectContainsRect(scaleBar.containerView.bounds, bar.frame));

--- a/platform/ios/test/MGLMapViewScaleBarTests.m
+++ b/platform/ios/test/MGLMapViewScaleBarTests.m
@@ -36,11 +36,14 @@
     XCTAssertFalse(scaleBar.hidden);
 
     // Scale bar should not be visible at default zoom (~z0), but it should be ready.
-    XCTAssertFalse(CGSizeEqualToSize(scaleBar.intrinsicContentSize, CGSizeZero));
+    // Size is not a measure of readiness here though.
+    XCTAssertTrue(CGSizeEqualToSize(scaleBar.intrinsicContentSize, CGSizeZero));
     XCTAssertEqual(scaleBar.alpha, 0);
 
     self.mapView.zoomLevel = 15;
+    [self.mapView layoutIfNeeded];
     XCTAssertGreaterThan(scaleBar.alpha, 0);
+    XCTAssertFalse(CGSizeEqualToSize(scaleBar.intrinsicContentSize, CGSizeZero));
 }
 
 - (void)testDirectlySettingScaleBarViewHiddenProperty {
@@ -54,10 +57,14 @@
 
     // ... but triggering any camera event will update it.
     self.mapView.zoomLevel = 1;
-    XCTAssertFalse(CGSizeEqualToSize(scaleBar.intrinsicContentSize, CGSizeZero));
+    [self.mapView layoutIfNeeded];
+    
+    XCTAssertTrue(CGSizeEqualToSize(scaleBar.intrinsicContentSize, CGSizeZero));
     XCTAssertEqual(scaleBar.alpha, 0);
 
     self.mapView.zoomLevel = 15;
+    [self.mapView layoutIfNeeded];
+
     XCTAssertGreaterThan(scaleBar.alpha, 0);
-}
-@end
+    XCTAssertFalse(CGSizeEqualToSize(scaleBar.intrinsicContentSize, CGSizeZero));
+}@end


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/15356 and layout when the device is rotated.

EDIT: The PR as it stands also rounds the corners of the scale bar - let me know what you think

Before:
<img width="254" alt="Screen Shot 2019-10-02 at 3 24 11 PM" src="https://user-images.githubusercontent.com/3765757/66075183-09a8fb80-e529-11e9-8560-108bd927c6a4.png">

After: 
![Screen Shot 2019-10-02 at 3 25 56 PM](https://user-images.githubusercontent.com/3765757/66075198-10d00980-e529-11e9-9191-d1854e1e4f77.png)
