### PR TITLE
Update snapshot version for release-sangria

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/gradle.properties
+++ b/platform/android/MapboxGLAndroidSDK/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=8.4.0-SNAPSHOT
+VERSION_NAME=8.5.0-SNAPSHOT
 
 # Only build native dependencies for the current ABI
 # See https://code.google.com/p/android/issues/detail?id=221098#c20


### PR DESCRIPTION
This PR updates master bracnh to start releasing snapshot builds for `release-sangria`. We will continue to publish snapshot builds for `release-ristretto` from the `release-ristretto` release branch.