### PR TITLE
Update gitignore to not track .cxx directories

### DIFF
--- a/platform/android/.gitignore
+++ b/platform/android/.gitignore
@@ -8,6 +8,7 @@
 # Build files
 build/
 .externalNativeBuild
+**/.cxx
 *.so
 *.apk
 


### PR DESCRIPTION
This PR updates the .gitignore to not track .cxx directories. A recent change (buildsystem PR? or android tooling version change?) has resulted in using .cxx diretories as temp build folders for our C++ code (the old .NativeBuild directory). We can safely ignore these. 