### PR TITLE
[android] Cherry pick of Java SDK bump to 4.9.0, to ristretto (#15700)

### DIFF
--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
     ]
 
     versions = [
-            mapboxServices  : '4.9.0-alpha.1',
+            mapboxServices  : '4.9.0',
             mapboxTelemetry : '4.5.1',
             mapboxCore      : '1.3.0',
             mapboxGestures  : '0.5.1',


### PR DESCRIPTION
This pr cherrypicks https://github.com/mapbox/mapbox-gl-native/pull/15700 to the`release-ristretto` branch.