### PR TITLE
[docs] Correct license typo in project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ This repository hosts the cross-platform Mapbox GL Native library, plus convenie
 
 ## License
 
-Mapbox GL Native is licensed under the [3-Clause BSD license](LICENSE.md). The licenses of its dependencies are tracked via [FOSSA](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmapbox%2Fmapbox-gl-native):
+Mapbox GL Native is licensed under the [2-Clause BSD license](LICENSE.md). The licenses of its dependencies are tracked via [FOSSA](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmapbox%2Fmapbox-gl-native):
 
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmapbox%2Fmapbox-gl-native.svg?type=large)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmapbox%2Fmapbox-gl-native)


### PR DESCRIPTION
Corrects the main project README to say that we’re licensed under the two-clause BSD license (and not the three-clause variant). There are no changes to the actual license.

Looking back to 2014, it seems that @kkaefer [originally added a three-clause BSD license](https://github.com/mapbox/mapbox-gl-native/commit/3f9337b74c8d384f2635d0a6adc33869169300fc), but then @incanus [removed the last clause](https://github.com/mapbox/mapbox-gl-native/commit/b34229dc0ff021955ab0bd283f24d68e24f77a1b) a couple months later. This was before the project was available publicly.

The removed clause was:

> - Neither the name "Mapbox" nor the names of its contributors may be used to
>    endorse or promote products derived from this software without specific prior
>    written permission.

/cc @kathleenlu09 @pdgoodman 