### PR TITLE
[core] Add universal style getter API

### DIFF
--- a/include/mbgl/style/conversion_impl.hpp
+++ b/include/mbgl/style/conversion_impl.hpp
@@ -349,22 +349,22 @@ Value makeValue(T&& arg) {
 }
 
 template <typename T>
-LayerProperty makeLayerProperty(const PropertyValue<T>& value) {
-    return value.match([](const Undefined&) -> LayerProperty { return {}; },
-                       [](const T& t) -> LayerProperty {
-                           return {makeValue(t), LayerProperty::Kind::Constant};
+StyleProperty makeStyleProperty(const PropertyValue<T>& value) {
+    return value.match([](const Undefined&) -> StyleProperty { return {}; },
+                       [](const T& t) -> StyleProperty {
+                           return {makeValue(t), StyleProperty::Kind::Constant};
                        },
-                       [](const PropertyExpression<T>& fn) -> LayerProperty {
-                           return {fn.getExpression().serialize(), LayerProperty::Kind::Expression};
+                       [](const PropertyExpression<T>& fn) -> StyleProperty {
+                           return {fn.getExpression().serialize(), StyleProperty::Kind::Expression};
                        });
 }
 
-inline LayerProperty makeLayerProperty(const TransitionOptions& value) {
-    return {makeValue(value), LayerProperty::Kind::Transition};
+inline StyleProperty makeStyleProperty(const TransitionOptions& value) {
+    return {makeValue(value), StyleProperty::Kind::Transition};
 }
 
-inline LayerProperty makeLayerProperty(const ColorRampPropertyValue& value) {
-    return {makeValue(value), LayerProperty::Kind::Expression};
+inline StyleProperty makeStyleProperty(const ColorRampPropertyValue& value) {
+    return {makeValue(value), StyleProperty::Kind::Expression};
 }
 
 } // namespace conversion

--- a/include/mbgl/style/layer.hpp
+++ b/include/mbgl/style/layer.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <mbgl/style/conversion.hpp>
+#include <mbgl/style/types.hpp>
+#include <mbgl/util/feature.hpp>
 #include <mbgl/util/immutable.hpp>
 #include <mbgl/util/optional.hpp>
-#include <mbgl/style/types.hpp>
-#include <mbgl/style/conversion.hpp>
 
 #include <mapbox/weak.hpp>
 #include <mapbox/type_wrapper.hpp>
@@ -65,6 +66,14 @@ struct LayerTypeInfo {
     const enum class TileKind : uint8_t { Geometry, Raster, RasterDEM, NotRequired } tileKind;
 };
 
+struct LayerProperty {
+    enum class Kind : uint8_t { Undefined, Constant, Expression, Transition };
+    LayerProperty(Value value_, Kind kind_) : value(std::move(value_)), kind(kind_) {}
+    LayerProperty() = default;
+    const Value value;
+    const Kind kind = Kind::Undefined;
+};
+
 /**
  * The runtime representation of a [layer](https://www.mapbox.com/mapbox-gl-style-spec/#layers) from the Mapbox Style
  * Specification.
@@ -110,8 +119,11 @@ public:
 
     // Dynamic properties
     virtual optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) = 0;
-    virtual optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) = 0;
+    virtual optional<conversion::Error> setPaintProperty(const std::string& name,
+                                                         const conversion::Convertible& value) = 0;
     optional<conversion::Error> setVisibility(const conversion::Convertible& value);
+
+    virtual LayerProperty getPaintProperty(const std::string&) const = 0;
 
     // Private implementation
     // TODO : We should not have public mutable data members.

--- a/include/mbgl/style/layer.hpp
+++ b/include/mbgl/style/layer.hpp
@@ -66,10 +66,10 @@ struct LayerTypeInfo {
     const enum class TileKind : uint8_t { Geometry, Raster, RasterDEM, NotRequired } tileKind;
 };
 
-struct LayerProperty {
+struct StyleProperty {
     enum class Kind : uint8_t { Undefined, Constant, Expression, Transition };
-    LayerProperty(Value value_, Kind kind_) : value(std::move(value_)), kind(kind_) {}
-    LayerProperty() = default;
+    StyleProperty(Value value_, Kind kind_) : value(std::move(value_)), kind(kind_) {}
+    StyleProperty() = default;
     const Value value;
     const Kind kind = Kind::Undefined;
 };
@@ -123,7 +123,7 @@ public:
                                                          const conversion::Convertible& value) = 0;
     optional<conversion::Error> setVisibility(const conversion::Convertible& value);
 
-    virtual LayerProperty getPaintProperty(const std::string&) const = 0;
+    virtual StyleProperty getPaintProperty(const std::string&) const = 0;
 
     // Private implementation
     // TODO : We should not have public mutable data members.

--- a/include/mbgl/style/layers/background_layer.hpp
+++ b/include/mbgl/style/layers/background_layer.hpp
@@ -24,6 +24,8 @@ public:
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
 
+    LayerProperty getPaintProperty(const std::string& name) const final;
+
     // Paint properties
 
     static PropertyValue<Color> getDefaultBackgroundColor();

--- a/include/mbgl/style/layers/background_layer.hpp
+++ b/include/mbgl/style/layers/background_layer.hpp
@@ -24,7 +24,7 @@ public:
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
 
-    LayerProperty getPaintProperty(const std::string& name) const final;
+    StyleProperty getPaintProperty(const std::string& name) const final;
 
     // Paint properties
 

--- a/include/mbgl/style/layers/circle_layer.hpp
+++ b/include/mbgl/style/layers/circle_layer.hpp
@@ -24,6 +24,8 @@ public:
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
 
+    LayerProperty getPaintProperty(const std::string& name) const final;
+
     // Paint properties
 
     static PropertyValue<float> getDefaultCircleBlur();

--- a/include/mbgl/style/layers/circle_layer.hpp
+++ b/include/mbgl/style/layers/circle_layer.hpp
@@ -24,7 +24,7 @@ public:
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
 
-    LayerProperty getPaintProperty(const std::string& name) const final;
+    StyleProperty getPaintProperty(const std::string& name) const final;
 
     // Paint properties
 

--- a/include/mbgl/style/layers/custom_layer.hpp
+++ b/include/mbgl/style/layers/custom_layer.hpp
@@ -71,7 +71,7 @@ public:
     // Dynamic properties
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
-    LayerProperty getPaintProperty(const std::string&) const final;
+    StyleProperty getPaintProperty(const std::string&) const final;
     // Private implementation
 
     class Impl;

--- a/include/mbgl/style/layers/custom_layer.hpp
+++ b/include/mbgl/style/layers/custom_layer.hpp
@@ -71,7 +71,7 @@ public:
     // Dynamic properties
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
-
+    LayerProperty getPaintProperty(const std::string&) const final;
     // Private implementation
 
     class Impl;

--- a/include/mbgl/style/layers/fill_extrusion_layer.hpp
+++ b/include/mbgl/style/layers/fill_extrusion_layer.hpp
@@ -24,6 +24,8 @@ public:
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
 
+    LayerProperty getPaintProperty(const std::string& name) const final;
+
     // Paint properties
 
     static PropertyValue<float> getDefaultFillExtrusionBase();

--- a/include/mbgl/style/layers/fill_extrusion_layer.hpp
+++ b/include/mbgl/style/layers/fill_extrusion_layer.hpp
@@ -24,7 +24,7 @@ public:
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
 
-    LayerProperty getPaintProperty(const std::string& name) const final;
+    StyleProperty getPaintProperty(const std::string& name) const final;
 
     // Paint properties
 

--- a/include/mbgl/style/layers/fill_layer.hpp
+++ b/include/mbgl/style/layers/fill_layer.hpp
@@ -24,6 +24,8 @@ public:
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
 
+    LayerProperty getPaintProperty(const std::string& name) const final;
+
     // Paint properties
 
     static PropertyValue<bool> getDefaultFillAntialias();

--- a/include/mbgl/style/layers/fill_layer.hpp
+++ b/include/mbgl/style/layers/fill_layer.hpp
@@ -24,7 +24,7 @@ public:
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
 
-    LayerProperty getPaintProperty(const std::string& name) const final;
+    StyleProperty getPaintProperty(const std::string& name) const final;
 
     // Paint properties
 

--- a/include/mbgl/style/layers/heatmap_layer.hpp
+++ b/include/mbgl/style/layers/heatmap_layer.hpp
@@ -25,7 +25,7 @@ public:
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
 
-    LayerProperty getPaintProperty(const std::string& name) const final;
+    StyleProperty getPaintProperty(const std::string& name) const final;
 
     // Paint properties
 

--- a/include/mbgl/style/layers/heatmap_layer.hpp
+++ b/include/mbgl/style/layers/heatmap_layer.hpp
@@ -25,6 +25,8 @@ public:
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
 
+    LayerProperty getPaintProperty(const std::string& name) const final;
+
     // Paint properties
 
     static ColorRampPropertyValue getDefaultHeatmapColor();

--- a/include/mbgl/style/layers/hillshade_layer.hpp
+++ b/include/mbgl/style/layers/hillshade_layer.hpp
@@ -24,7 +24,7 @@ public:
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
 
-    LayerProperty getPaintProperty(const std::string& name) const final;
+    StyleProperty getPaintProperty(const std::string& name) const final;
 
     // Paint properties
 

--- a/include/mbgl/style/layers/hillshade_layer.hpp
+++ b/include/mbgl/style/layers/hillshade_layer.hpp
@@ -24,6 +24,8 @@ public:
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
 
+    LayerProperty getPaintProperty(const std::string& name) const final;
+
     // Paint properties
 
     static PropertyValue<Color> getDefaultHillshadeAccentColor();

--- a/include/mbgl/style/layers/layer.hpp.ejs
+++ b/include/mbgl/style/layers/layer.hpp.ejs
@@ -40,7 +40,7 @@ public:
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
 
-    LayerProperty getPaintProperty(const std::string& name) const final;
+    StyleProperty getPaintProperty(const std::string& name) const final;
 
 <% if (layoutProperties.length) { -%>
     // Layout properties

--- a/include/mbgl/style/layers/layer.hpp.ejs
+++ b/include/mbgl/style/layers/layer.hpp.ejs
@@ -40,6 +40,8 @@ public:
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
 
+    LayerProperty getPaintProperty(const std::string& name) const final;
+
 <% if (layoutProperties.length) { -%>
     // Layout properties
 

--- a/include/mbgl/style/layers/line_layer.hpp
+++ b/include/mbgl/style/layers/line_layer.hpp
@@ -27,6 +27,8 @@ public:
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
 
+    LayerProperty getPaintProperty(const std::string& name) const final;
+
     // Layout properties
 
     static PropertyValue<LineCapType> getDefaultLineCap();

--- a/include/mbgl/style/layers/line_layer.hpp
+++ b/include/mbgl/style/layers/line_layer.hpp
@@ -27,7 +27,7 @@ public:
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
 
-    LayerProperty getPaintProperty(const std::string& name) const final;
+    StyleProperty getPaintProperty(const std::string& name) const final;
 
     // Layout properties
 

--- a/include/mbgl/style/layers/raster_layer.hpp
+++ b/include/mbgl/style/layers/raster_layer.hpp
@@ -24,6 +24,8 @@ public:
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
 
+    LayerProperty getPaintProperty(const std::string& name) const final;
+
     // Paint properties
 
     static PropertyValue<float> getDefaultRasterBrightnessMax();

--- a/include/mbgl/style/layers/raster_layer.hpp
+++ b/include/mbgl/style/layers/raster_layer.hpp
@@ -24,7 +24,7 @@ public:
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
 
-    LayerProperty getPaintProperty(const std::string& name) const final;
+    StyleProperty getPaintProperty(const std::string& name) const final;
 
     // Paint properties
 

--- a/include/mbgl/style/layers/symbol_layer.hpp
+++ b/include/mbgl/style/layers/symbol_layer.hpp
@@ -26,7 +26,7 @@ public:
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
 
-    LayerProperty getPaintProperty(const std::string& name) const final;
+    StyleProperty getPaintProperty(const std::string& name) const final;
 
     // Layout properties
 

--- a/include/mbgl/style/layers/symbol_layer.hpp
+++ b/include/mbgl/style/layers/symbol_layer.hpp
@@ -26,6 +26,8 @@ public:
     optional<conversion::Error> setLayoutProperty(const std::string& name, const conversion::Convertible& value) final;
     optional<conversion::Error> setPaintProperty(const std::string& name, const conversion::Convertible& value) final;
 
+    LayerProperty getPaintProperty(const std::string& name) const final;
+
     // Layout properties
 
     static PropertyValue<bool> getDefaultIconAllowOverlap();

--- a/include/mbgl/util/feature.hpp
+++ b/include/mbgl/util/feature.hpp
@@ -3,16 +3,16 @@
 #include <mbgl/util/optional.hpp>
 #include <mbgl/util/string.hpp>
 
-#include <mapbox/feature.hpp>
+#include <mapbox/value.hpp>
 
 namespace mbgl {
 
-using Value = mapbox::feature::value;
-using NullValue = mapbox::feature::null_value_t;
-using PropertyMap = mapbox::feature::property_map;
+using Value = mapbox::base::Value;
+using NullValue = mapbox::base::NullValue;
+using PropertyMap = mapbox::base::ValueObject;
 using FeatureIdentifier = mapbox::feature::identifier;
 using Feature = mapbox::feature::feature<double>;
-using FeatureState = PropertyMap;
+using FeatureState = mapbox::base::ValueObject;
 using FeatureStates = std::unordered_map<std::string, FeatureState>;       // <featureID, FeatureState>
 using LayerFeatureStates = std::unordered_map<std::string, FeatureStates>; // <sourceLayer, FeatureStates>
 

--- a/next/CMakeLists.txt
+++ b/next/CMakeLists.txt
@@ -911,6 +911,7 @@ target_link_libraries(
         Mapbox::Base::geometry.hpp
         Mapbox::Base::optional
         Mapbox::Base::typewrapper
+        Mapbox::Base::value
         Mapbox::Base::variant
         Mapbox::Base::weak
         mbgl-vendor-expected

--- a/next/platform/android/android.cmake
+++ b/next/platform/android/android.cmake
@@ -267,6 +267,7 @@ target_link_libraries(
         GLESv2
         Mapbox::Base::optional
         Mapbox::Base::typewrapper
+        Mapbox::Base::value
         Mapbox::Base::weak
         log
 )

--- a/scripts/generate-file-lists.js
+++ b/scripts/generate-file-lists.js
@@ -145,7 +145,8 @@ generateFileList('vendor/mapbox-base-files.json',
       'vendor/mapbox-base/mapbox/geojson.hpp',
       'vendor/mapbox-base/mapbox/jni.hpp',
       'vendor/mapbox-base/mapbox/weak',
-      'vendor/mapbox-base/mapbox/typewrapper' ], 
+      'vendor/mapbox-base/mapbox/typewrapper',
+      'vendor/mapbox-base/mapbox/value'], 
     vendorRegex, [ "include/*.hpp", "include/**/*.hpp", "include/**/*.h", "optional.hpp", ":!:include/jni/string_conversion.hpp" ]);
 generateFileList('vendor/polylabel-files.json', [ 'vendor/polylabel' ], vendorRegex, [ "include/**/*.hpp" ]);
 generateFileList('vendor/protozero-files.json', [ 'vendor/protozero' ], vendorRegex, [ "include/**/*.hpp" ]);

--- a/src/mbgl/style/layers/background_layer.cpp
+++ b/src/mbgl/style/layers/background_layer.cpp
@@ -159,20 +159,25 @@ enum class Property {
     BackgroundPatternTransition,
 };
 
+template <typename T>
+constexpr uint8_t toUint8(T t) noexcept {
+    return uint8_t(mbgl::underlying_type(t));
+}
+
 MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
-    {{"background-color", mbgl::underlying_type(Property::BackgroundColor)},
-     {"background-opacity", mbgl::underlying_type(Property::BackgroundOpacity)},
-     {"background-pattern", mbgl::underlying_type(Property::BackgroundPattern)},
-     {"background-color-transition", mbgl::underlying_type(Property::BackgroundColorTransition)},
-     {"background-opacity-transition", mbgl::underlying_type(Property::BackgroundOpacityTransition)},
-     {"background-pattern-transition", mbgl::underlying_type(Property::BackgroundPatternTransition)}});
+    {{"background-color", toUint8(Property::BackgroundColor)},
+     {"background-opacity", toUint8(Property::BackgroundOpacity)},
+     {"background-pattern", toUint8(Property::BackgroundPattern)},
+     {"background-color-transition", toUint8(Property::BackgroundColorTransition)},
+     {"background-opacity-transition", toUint8(Property::BackgroundOpacityTransition)},
+     {"background-pattern-transition", toUint8(Property::BackgroundPatternTransition)}});
 
 } // namespace
 
 optional<Error> BackgroundLayer::setPaintProperty(const std::string& name, const Convertible& value) {
     const auto it = paintProperties.find(name.c_str());
     if (it == paintProperties.end()) {
-        return Error { "layer doesn't support this property" };
+        return Error{"layer doesn't support this property"};
     }
 
     auto property = static_cast<Property>(it->second);
@@ -220,24 +225,23 @@ optional<Error> BackgroundLayer::setPaintProperty(const std::string& name, const
     if (!transition) {
         return error;
     }
-    
+
     if (property == Property::BackgroundColorTransition) {
         setBackgroundColorTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::BackgroundOpacityTransition) {
         setBackgroundOpacityTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::BackgroundPatternTransition) {
         setBackgroundPatternTransition(*transition);
         return nullopt;
     }
-    
 
-    return Error { "layer doesn't support this property" };
+    return Error{"layer doesn't support this property"};
 }
 
 LayerProperty BackgroundLayer::getPaintProperty(const std::string& name) const {
@@ -248,17 +252,17 @@ LayerProperty BackgroundLayer::getPaintProperty(const std::string& name) const {
 
     switch (static_cast<Property>(it->second)) {
         case Property::BackgroundColor:
-            return conversion::makeLayerProperty(getBackgroundColor());
+            return makeLayerProperty(getBackgroundColor());
         case Property::BackgroundOpacity:
-            return conversion::makeLayerProperty(getBackgroundOpacity());
+            return makeLayerProperty(getBackgroundOpacity());
         case Property::BackgroundPattern:
-            return conversion::makeLayerProperty(getBackgroundPattern());
+            return makeLayerProperty(getBackgroundPattern());
         case Property::BackgroundColorTransition:
-            return conversion::makeLayerProperty(getBackgroundColorTransition());
+            return makeLayerProperty(getBackgroundColorTransition());
         case Property::BackgroundOpacityTransition:
-            return conversion::makeLayerProperty(getBackgroundOpacityTransition());
+            return makeLayerProperty(getBackgroundOpacityTransition());
         case Property::BackgroundPatternTransition:
-            return conversion::makeLayerProperty(getBackgroundPatternTransition());
+            return makeLayerProperty(getBackgroundPatternTransition());
     }
     return {};
 }

--- a/src/mbgl/style/layers/background_layer.cpp
+++ b/src/mbgl/style/layers/background_layer.cpp
@@ -150,7 +150,7 @@ using namespace conversion;
 
 namespace {
 
-enum class Property {
+enum class Property : uint8_t {
     BackgroundColor,
     BackgroundOpacity,
     BackgroundPattern,
@@ -244,7 +244,7 @@ optional<Error> BackgroundLayer::setPaintProperty(const std::string& name, const
     return Error{"layer doesn't support this property"};
 }
 
-LayerProperty BackgroundLayer::getPaintProperty(const std::string& name) const {
+StyleProperty BackgroundLayer::getPaintProperty(const std::string& name) const {
     const auto it = paintProperties.find(name.c_str());
     if (it == paintProperties.end()) {
         return {};
@@ -252,17 +252,17 @@ LayerProperty BackgroundLayer::getPaintProperty(const std::string& name) const {
 
     switch (static_cast<Property>(it->second)) {
         case Property::BackgroundColor:
-            return makeLayerProperty(getBackgroundColor());
+            return makeStyleProperty(getBackgroundColor());
         case Property::BackgroundOpacity:
-            return makeLayerProperty(getBackgroundOpacity());
+            return makeStyleProperty(getBackgroundOpacity());
         case Property::BackgroundPattern:
-            return makeLayerProperty(getBackgroundPattern());
+            return makeStyleProperty(getBackgroundPattern());
         case Property::BackgroundColorTransition:
-            return makeLayerProperty(getBackgroundColorTransition());
+            return makeStyleProperty(getBackgroundColorTransition());
         case Property::BackgroundOpacityTransition:
-            return makeLayerProperty(getBackgroundOpacityTransition());
+            return makeStyleProperty(getBackgroundOpacityTransition());
         case Property::BackgroundPatternTransition:
-            return makeLayerProperty(getBackgroundPatternTransition());
+            return makeStyleProperty(getBackgroundPatternTransition());
     }
     return {};
 }

--- a/src/mbgl/style/layers/background_layer.cpp
+++ b/src/mbgl/style/layers/background_layer.cpp
@@ -148,27 +148,30 @@ TransitionOptions BackgroundLayer::getBackgroundPatternTransition() const {
 
 using namespace conversion;
 
+namespace {
+
+enum class Property {
+    BackgroundColor,
+    BackgroundOpacity,
+    BackgroundPattern,
+    BackgroundColorTransition,
+    BackgroundOpacityTransition,
+    BackgroundPatternTransition,
+};
+
+MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+    {{"background-color", mbgl::underlying_type(Property::BackgroundColor)},
+     {"background-opacity", mbgl::underlying_type(Property::BackgroundOpacity)},
+     {"background-pattern", mbgl::underlying_type(Property::BackgroundPattern)},
+     {"background-color-transition", mbgl::underlying_type(Property::BackgroundColorTransition)},
+     {"background-opacity-transition", mbgl::underlying_type(Property::BackgroundOpacityTransition)},
+     {"background-pattern-transition", mbgl::underlying_type(Property::BackgroundPatternTransition)}});
+
+} // namespace
+
 optional<Error> BackgroundLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-        BackgroundColor,
-        BackgroundOpacity,
-        BackgroundPattern,
-        BackgroundColorTransition,
-        BackgroundOpacityTransition,
-        BackgroundPatternTransition,
-    };
-
-    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        { "background-color", mbgl::underlying_type(Property::BackgroundColor) },
-        { "background-opacity", mbgl::underlying_type(Property::BackgroundOpacity) },
-        { "background-pattern", mbgl::underlying_type(Property::BackgroundPattern) },
-        { "background-color-transition", mbgl::underlying_type(Property::BackgroundColorTransition) },
-        { "background-opacity-transition", mbgl::underlying_type(Property::BackgroundOpacityTransition) },
-        { "background-pattern-transition", mbgl::underlying_type(Property::BackgroundPatternTransition) }
-    });
-
-    const auto it = properties.find(name.c_str());
-    if (it == properties.end()) {
+    const auto it = paintProperties.find(name.c_str());
+    if (it == paintProperties.end()) {
         return Error { "layer doesn't support this property" };
     }
 
@@ -235,6 +238,29 @@ optional<Error> BackgroundLayer::setPaintProperty(const std::string& name, const
     
 
     return Error { "layer doesn't support this property" };
+}
+
+LayerProperty BackgroundLayer::getPaintProperty(const std::string& name) const {
+    const auto it = paintProperties.find(name.c_str());
+    if (it == paintProperties.end()) {
+        return {};
+    }
+
+    switch (static_cast<Property>(it->second)) {
+        case Property::BackgroundColor:
+            return conversion::makeLayerProperty(getBackgroundColor());
+        case Property::BackgroundOpacity:
+            return conversion::makeLayerProperty(getBackgroundOpacity());
+        case Property::BackgroundPattern:
+            return conversion::makeLayerProperty(getBackgroundPattern());
+        case Property::BackgroundColorTransition:
+            return conversion::makeLayerProperty(getBackgroundColorTransition());
+        case Property::BackgroundOpacityTransition:
+            return conversion::makeLayerProperty(getBackgroundOpacityTransition());
+        case Property::BackgroundPatternTransition:
+            return conversion::makeLayerProperty(getBackgroundPatternTransition());
+    }
+    return {};
 }
 
 optional<Error> BackgroundLayer::setLayoutProperty(const std::string& name, const Convertible& value) {

--- a/src/mbgl/style/layers/circle_layer.cpp
+++ b/src/mbgl/style/layers/circle_layer.cpp
@@ -366,7 +366,7 @@ using namespace conversion;
 
 namespace {
 
-enum class Property {
+enum class Property : uint8_t {
     CircleBlur,
     CircleColor,
     CircleOpacity,
@@ -597,7 +597,7 @@ optional<Error> CircleLayer::setPaintProperty(const std::string& name, const Con
     return Error{"layer doesn't support this property"};
 }
 
-LayerProperty CircleLayer::getPaintProperty(const std::string& name) const {
+StyleProperty CircleLayer::getPaintProperty(const std::string& name) const {
     const auto it = paintProperties.find(name.c_str());
     if (it == paintProperties.end()) {
         return {};
@@ -605,49 +605,49 @@ LayerProperty CircleLayer::getPaintProperty(const std::string& name) const {
 
     switch (static_cast<Property>(it->second)) {
         case Property::CircleBlur:
-            return makeLayerProperty(getCircleBlur());
+            return makeStyleProperty(getCircleBlur());
         case Property::CircleColor:
-            return makeLayerProperty(getCircleColor());
+            return makeStyleProperty(getCircleColor());
         case Property::CircleOpacity:
-            return makeLayerProperty(getCircleOpacity());
+            return makeStyleProperty(getCircleOpacity());
         case Property::CirclePitchAlignment:
-            return makeLayerProperty(getCirclePitchAlignment());
+            return makeStyleProperty(getCirclePitchAlignment());
         case Property::CirclePitchScale:
-            return makeLayerProperty(getCirclePitchScale());
+            return makeStyleProperty(getCirclePitchScale());
         case Property::CircleRadius:
-            return makeLayerProperty(getCircleRadius());
+            return makeStyleProperty(getCircleRadius());
         case Property::CircleStrokeColor:
-            return makeLayerProperty(getCircleStrokeColor());
+            return makeStyleProperty(getCircleStrokeColor());
         case Property::CircleStrokeOpacity:
-            return makeLayerProperty(getCircleStrokeOpacity());
+            return makeStyleProperty(getCircleStrokeOpacity());
         case Property::CircleStrokeWidth:
-            return makeLayerProperty(getCircleStrokeWidth());
+            return makeStyleProperty(getCircleStrokeWidth());
         case Property::CircleTranslate:
-            return makeLayerProperty(getCircleTranslate());
+            return makeStyleProperty(getCircleTranslate());
         case Property::CircleTranslateAnchor:
-            return makeLayerProperty(getCircleTranslateAnchor());
+            return makeStyleProperty(getCircleTranslateAnchor());
         case Property::CircleBlurTransition:
-            return makeLayerProperty(getCircleBlurTransition());
+            return makeStyleProperty(getCircleBlurTransition());
         case Property::CircleColorTransition:
-            return makeLayerProperty(getCircleColorTransition());
+            return makeStyleProperty(getCircleColorTransition());
         case Property::CircleOpacityTransition:
-            return makeLayerProperty(getCircleOpacityTransition());
+            return makeStyleProperty(getCircleOpacityTransition());
         case Property::CirclePitchAlignmentTransition:
-            return makeLayerProperty(getCirclePitchAlignmentTransition());
+            return makeStyleProperty(getCirclePitchAlignmentTransition());
         case Property::CirclePitchScaleTransition:
-            return makeLayerProperty(getCirclePitchScaleTransition());
+            return makeStyleProperty(getCirclePitchScaleTransition());
         case Property::CircleRadiusTransition:
-            return makeLayerProperty(getCircleRadiusTransition());
+            return makeStyleProperty(getCircleRadiusTransition());
         case Property::CircleStrokeColorTransition:
-            return makeLayerProperty(getCircleStrokeColorTransition());
+            return makeStyleProperty(getCircleStrokeColorTransition());
         case Property::CircleStrokeOpacityTransition:
-            return makeLayerProperty(getCircleStrokeOpacityTransition());
+            return makeStyleProperty(getCircleStrokeOpacityTransition());
         case Property::CircleStrokeWidthTransition:
-            return makeLayerProperty(getCircleStrokeWidthTransition());
+            return makeStyleProperty(getCircleStrokeWidthTransition());
         case Property::CircleTranslateTransition:
-            return makeLayerProperty(getCircleTranslateTransition());
+            return makeStyleProperty(getCircleTranslateTransition());
         case Property::CircleTranslateAnchorTransition:
-            return makeLayerProperty(getCircleTranslateAnchorTransition());
+            return makeStyleProperty(getCircleTranslateAnchorTransition());
     }
     return {};
 }

--- a/src/mbgl/style/layers/circle_layer.cpp
+++ b/src/mbgl/style/layers/circle_layer.cpp
@@ -364,59 +364,62 @@ TransitionOptions CircleLayer::getCircleTranslateAnchorTransition() const {
 
 using namespace conversion;
 
+namespace {
+
+enum class Property {
+    CircleBlur,
+    CircleColor,
+    CircleOpacity,
+    CirclePitchAlignment,
+    CirclePitchScale,
+    CircleRadius,
+    CircleStrokeColor,
+    CircleStrokeOpacity,
+    CircleStrokeWidth,
+    CircleTranslate,
+    CircleTranslateAnchor,
+    CircleBlurTransition,
+    CircleColorTransition,
+    CircleOpacityTransition,
+    CirclePitchAlignmentTransition,
+    CirclePitchScaleTransition,
+    CircleRadiusTransition,
+    CircleStrokeColorTransition,
+    CircleStrokeOpacityTransition,
+    CircleStrokeWidthTransition,
+    CircleTranslateTransition,
+    CircleTranslateAnchorTransition,
+};
+
+MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+    {{"circle-blur", mbgl::underlying_type(Property::CircleBlur)},
+     {"circle-color", mbgl::underlying_type(Property::CircleColor)},
+     {"circle-opacity", mbgl::underlying_type(Property::CircleOpacity)},
+     {"circle-pitch-alignment", mbgl::underlying_type(Property::CirclePitchAlignment)},
+     {"circle-pitch-scale", mbgl::underlying_type(Property::CirclePitchScale)},
+     {"circle-radius", mbgl::underlying_type(Property::CircleRadius)},
+     {"circle-stroke-color", mbgl::underlying_type(Property::CircleStrokeColor)},
+     {"circle-stroke-opacity", mbgl::underlying_type(Property::CircleStrokeOpacity)},
+     {"circle-stroke-width", mbgl::underlying_type(Property::CircleStrokeWidth)},
+     {"circle-translate", mbgl::underlying_type(Property::CircleTranslate)},
+     {"circle-translate-anchor", mbgl::underlying_type(Property::CircleTranslateAnchor)},
+     {"circle-blur-transition", mbgl::underlying_type(Property::CircleBlurTransition)},
+     {"circle-color-transition", mbgl::underlying_type(Property::CircleColorTransition)},
+     {"circle-opacity-transition", mbgl::underlying_type(Property::CircleOpacityTransition)},
+     {"circle-pitch-alignment-transition", mbgl::underlying_type(Property::CirclePitchAlignmentTransition)},
+     {"circle-pitch-scale-transition", mbgl::underlying_type(Property::CirclePitchScaleTransition)},
+     {"circle-radius-transition", mbgl::underlying_type(Property::CircleRadiusTransition)},
+     {"circle-stroke-color-transition", mbgl::underlying_type(Property::CircleStrokeColorTransition)},
+     {"circle-stroke-opacity-transition", mbgl::underlying_type(Property::CircleStrokeOpacityTransition)},
+     {"circle-stroke-width-transition", mbgl::underlying_type(Property::CircleStrokeWidthTransition)},
+     {"circle-translate-transition", mbgl::underlying_type(Property::CircleTranslateTransition)},
+     {"circle-translate-anchor-transition", mbgl::underlying_type(Property::CircleTranslateAnchorTransition)}});
+
+} // namespace
+
 optional<Error> CircleLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-        CircleBlur,
-        CircleColor,
-        CircleOpacity,
-        CirclePitchAlignment,
-        CirclePitchScale,
-        CircleRadius,
-        CircleStrokeColor,
-        CircleStrokeOpacity,
-        CircleStrokeWidth,
-        CircleTranslate,
-        CircleTranslateAnchor,
-        CircleBlurTransition,
-        CircleColorTransition,
-        CircleOpacityTransition,
-        CirclePitchAlignmentTransition,
-        CirclePitchScaleTransition,
-        CircleRadiusTransition,
-        CircleStrokeColorTransition,
-        CircleStrokeOpacityTransition,
-        CircleStrokeWidthTransition,
-        CircleTranslateTransition,
-        CircleTranslateAnchorTransition,
-    };
-
-    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        { "circle-blur", mbgl::underlying_type(Property::CircleBlur) },
-        { "circle-color", mbgl::underlying_type(Property::CircleColor) },
-        { "circle-opacity", mbgl::underlying_type(Property::CircleOpacity) },
-        { "circle-pitch-alignment", mbgl::underlying_type(Property::CirclePitchAlignment) },
-        { "circle-pitch-scale", mbgl::underlying_type(Property::CirclePitchScale) },
-        { "circle-radius", mbgl::underlying_type(Property::CircleRadius) },
-        { "circle-stroke-color", mbgl::underlying_type(Property::CircleStrokeColor) },
-        { "circle-stroke-opacity", mbgl::underlying_type(Property::CircleStrokeOpacity) },
-        { "circle-stroke-width", mbgl::underlying_type(Property::CircleStrokeWidth) },
-        { "circle-translate", mbgl::underlying_type(Property::CircleTranslate) },
-        { "circle-translate-anchor", mbgl::underlying_type(Property::CircleTranslateAnchor) },
-        { "circle-blur-transition", mbgl::underlying_type(Property::CircleBlurTransition) },
-        { "circle-color-transition", mbgl::underlying_type(Property::CircleColorTransition) },
-        { "circle-opacity-transition", mbgl::underlying_type(Property::CircleOpacityTransition) },
-        { "circle-pitch-alignment-transition", mbgl::underlying_type(Property::CirclePitchAlignmentTransition) },
-        { "circle-pitch-scale-transition", mbgl::underlying_type(Property::CirclePitchScaleTransition) },
-        { "circle-radius-transition", mbgl::underlying_type(Property::CircleRadiusTransition) },
-        { "circle-stroke-color-transition", mbgl::underlying_type(Property::CircleStrokeColorTransition) },
-        { "circle-stroke-opacity-transition", mbgl::underlying_type(Property::CircleStrokeOpacityTransition) },
-        { "circle-stroke-width-transition", mbgl::underlying_type(Property::CircleStrokeWidthTransition) },
-        { "circle-translate-transition", mbgl::underlying_type(Property::CircleTranslateTransition) },
-        { "circle-translate-anchor-transition", mbgl::underlying_type(Property::CircleTranslateAnchorTransition) }
-    });
-
-    const auto it = properties.find(name.c_str());
-    if (it == properties.end()) {
+    const auto it = paintProperties.find(name.c_str());
+    if (it == paintProperties.end()) {
         return Error { "layer doesn't support this property" };
     }
 
@@ -588,6 +591,61 @@ optional<Error> CircleLayer::setPaintProperty(const std::string& name, const Con
     
 
     return Error { "layer doesn't support this property" };
+}
+
+LayerProperty CircleLayer::getPaintProperty(const std::string& name) const {
+    const auto it = paintProperties.find(name.c_str());
+    if (it == paintProperties.end()) {
+        return {};
+    }
+
+    switch (static_cast<Property>(it->second)) {
+        case Property::CircleBlur:
+            return conversion::makeLayerProperty(getCircleBlur());
+        case Property::CircleColor:
+            return conversion::makeLayerProperty(getCircleColor());
+        case Property::CircleOpacity:
+            return conversion::makeLayerProperty(getCircleOpacity());
+        case Property::CirclePitchAlignment:
+            return conversion::makeLayerProperty(getCirclePitchAlignment());
+        case Property::CirclePitchScale:
+            return conversion::makeLayerProperty(getCirclePitchScale());
+        case Property::CircleRadius:
+            return conversion::makeLayerProperty(getCircleRadius());
+        case Property::CircleStrokeColor:
+            return conversion::makeLayerProperty(getCircleStrokeColor());
+        case Property::CircleStrokeOpacity:
+            return conversion::makeLayerProperty(getCircleStrokeOpacity());
+        case Property::CircleStrokeWidth:
+            return conversion::makeLayerProperty(getCircleStrokeWidth());
+        case Property::CircleTranslate:
+            return conversion::makeLayerProperty(getCircleTranslate());
+        case Property::CircleTranslateAnchor:
+            return conversion::makeLayerProperty(getCircleTranslateAnchor());
+        case Property::CircleBlurTransition:
+            return conversion::makeLayerProperty(getCircleBlurTransition());
+        case Property::CircleColorTransition:
+            return conversion::makeLayerProperty(getCircleColorTransition());
+        case Property::CircleOpacityTransition:
+            return conversion::makeLayerProperty(getCircleOpacityTransition());
+        case Property::CirclePitchAlignmentTransition:
+            return conversion::makeLayerProperty(getCirclePitchAlignmentTransition());
+        case Property::CirclePitchScaleTransition:
+            return conversion::makeLayerProperty(getCirclePitchScaleTransition());
+        case Property::CircleRadiusTransition:
+            return conversion::makeLayerProperty(getCircleRadiusTransition());
+        case Property::CircleStrokeColorTransition:
+            return conversion::makeLayerProperty(getCircleStrokeColorTransition());
+        case Property::CircleStrokeOpacityTransition:
+            return conversion::makeLayerProperty(getCircleStrokeOpacityTransition());
+        case Property::CircleStrokeWidthTransition:
+            return conversion::makeLayerProperty(getCircleStrokeWidthTransition());
+        case Property::CircleTranslateTransition:
+            return conversion::makeLayerProperty(getCircleTranslateTransition());
+        case Property::CircleTranslateAnchorTransition:
+            return conversion::makeLayerProperty(getCircleTranslateAnchorTransition());
+    }
+    return {};
 }
 
 optional<Error> CircleLayer::setLayoutProperty(const std::string& name, const Convertible& value) {

--- a/src/mbgl/style/layers/circle_layer.cpp
+++ b/src/mbgl/style/layers/circle_layer.cpp
@@ -391,36 +391,41 @@ enum class Property {
     CircleTranslateAnchorTransition,
 };
 
+template <typename T>
+constexpr uint8_t toUint8(T t) noexcept {
+    return uint8_t(mbgl::underlying_type(t));
+}
+
 MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
-    {{"circle-blur", mbgl::underlying_type(Property::CircleBlur)},
-     {"circle-color", mbgl::underlying_type(Property::CircleColor)},
-     {"circle-opacity", mbgl::underlying_type(Property::CircleOpacity)},
-     {"circle-pitch-alignment", mbgl::underlying_type(Property::CirclePitchAlignment)},
-     {"circle-pitch-scale", mbgl::underlying_type(Property::CirclePitchScale)},
-     {"circle-radius", mbgl::underlying_type(Property::CircleRadius)},
-     {"circle-stroke-color", mbgl::underlying_type(Property::CircleStrokeColor)},
-     {"circle-stroke-opacity", mbgl::underlying_type(Property::CircleStrokeOpacity)},
-     {"circle-stroke-width", mbgl::underlying_type(Property::CircleStrokeWidth)},
-     {"circle-translate", mbgl::underlying_type(Property::CircleTranslate)},
-     {"circle-translate-anchor", mbgl::underlying_type(Property::CircleTranslateAnchor)},
-     {"circle-blur-transition", mbgl::underlying_type(Property::CircleBlurTransition)},
-     {"circle-color-transition", mbgl::underlying_type(Property::CircleColorTransition)},
-     {"circle-opacity-transition", mbgl::underlying_type(Property::CircleOpacityTransition)},
-     {"circle-pitch-alignment-transition", mbgl::underlying_type(Property::CirclePitchAlignmentTransition)},
-     {"circle-pitch-scale-transition", mbgl::underlying_type(Property::CirclePitchScaleTransition)},
-     {"circle-radius-transition", mbgl::underlying_type(Property::CircleRadiusTransition)},
-     {"circle-stroke-color-transition", mbgl::underlying_type(Property::CircleStrokeColorTransition)},
-     {"circle-stroke-opacity-transition", mbgl::underlying_type(Property::CircleStrokeOpacityTransition)},
-     {"circle-stroke-width-transition", mbgl::underlying_type(Property::CircleStrokeWidthTransition)},
-     {"circle-translate-transition", mbgl::underlying_type(Property::CircleTranslateTransition)},
-     {"circle-translate-anchor-transition", mbgl::underlying_type(Property::CircleTranslateAnchorTransition)}});
+    {{"circle-blur", toUint8(Property::CircleBlur)},
+     {"circle-color", toUint8(Property::CircleColor)},
+     {"circle-opacity", toUint8(Property::CircleOpacity)},
+     {"circle-pitch-alignment", toUint8(Property::CirclePitchAlignment)},
+     {"circle-pitch-scale", toUint8(Property::CirclePitchScale)},
+     {"circle-radius", toUint8(Property::CircleRadius)},
+     {"circle-stroke-color", toUint8(Property::CircleStrokeColor)},
+     {"circle-stroke-opacity", toUint8(Property::CircleStrokeOpacity)},
+     {"circle-stroke-width", toUint8(Property::CircleStrokeWidth)},
+     {"circle-translate", toUint8(Property::CircleTranslate)},
+     {"circle-translate-anchor", toUint8(Property::CircleTranslateAnchor)},
+     {"circle-blur-transition", toUint8(Property::CircleBlurTransition)},
+     {"circle-color-transition", toUint8(Property::CircleColorTransition)},
+     {"circle-opacity-transition", toUint8(Property::CircleOpacityTransition)},
+     {"circle-pitch-alignment-transition", toUint8(Property::CirclePitchAlignmentTransition)},
+     {"circle-pitch-scale-transition", toUint8(Property::CirclePitchScaleTransition)},
+     {"circle-radius-transition", toUint8(Property::CircleRadiusTransition)},
+     {"circle-stroke-color-transition", toUint8(Property::CircleStrokeColorTransition)},
+     {"circle-stroke-opacity-transition", toUint8(Property::CircleStrokeOpacityTransition)},
+     {"circle-stroke-width-transition", toUint8(Property::CircleStrokeWidthTransition)},
+     {"circle-translate-transition", toUint8(Property::CircleTranslateTransition)},
+     {"circle-translate-anchor-transition", toUint8(Property::CircleTranslateAnchorTransition)}});
 
 } // namespace
 
 optional<Error> CircleLayer::setPaintProperty(const std::string& name, const Convertible& value) {
     const auto it = paintProperties.find(name.c_str());
     if (it == paintProperties.end()) {
-        return Error { "layer doesn't support this property" };
+        return Error{"layer doesn't support this property"};
     }
 
     auto property = static_cast<Property>(it->second);
@@ -533,64 +538,63 @@ optional<Error> CircleLayer::setPaintProperty(const std::string& name, const Con
     if (!transition) {
         return error;
     }
-    
+
     if (property == Property::CircleBlurTransition) {
         setCircleBlurTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::CircleColorTransition) {
         setCircleColorTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::CircleOpacityTransition) {
         setCircleOpacityTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::CirclePitchAlignmentTransition) {
         setCirclePitchAlignmentTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::CirclePitchScaleTransition) {
         setCirclePitchScaleTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::CircleRadiusTransition) {
         setCircleRadiusTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::CircleStrokeColorTransition) {
         setCircleStrokeColorTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::CircleStrokeOpacityTransition) {
         setCircleStrokeOpacityTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::CircleStrokeWidthTransition) {
         setCircleStrokeWidthTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::CircleTranslateTransition) {
         setCircleTranslateTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::CircleTranslateAnchorTransition) {
         setCircleTranslateAnchorTransition(*transition);
         return nullopt;
     }
-    
 
-    return Error { "layer doesn't support this property" };
+    return Error{"layer doesn't support this property"};
 }
 
 LayerProperty CircleLayer::getPaintProperty(const std::string& name) const {
@@ -601,49 +605,49 @@ LayerProperty CircleLayer::getPaintProperty(const std::string& name) const {
 
     switch (static_cast<Property>(it->second)) {
         case Property::CircleBlur:
-            return conversion::makeLayerProperty(getCircleBlur());
+            return makeLayerProperty(getCircleBlur());
         case Property::CircleColor:
-            return conversion::makeLayerProperty(getCircleColor());
+            return makeLayerProperty(getCircleColor());
         case Property::CircleOpacity:
-            return conversion::makeLayerProperty(getCircleOpacity());
+            return makeLayerProperty(getCircleOpacity());
         case Property::CirclePitchAlignment:
-            return conversion::makeLayerProperty(getCirclePitchAlignment());
+            return makeLayerProperty(getCirclePitchAlignment());
         case Property::CirclePitchScale:
-            return conversion::makeLayerProperty(getCirclePitchScale());
+            return makeLayerProperty(getCirclePitchScale());
         case Property::CircleRadius:
-            return conversion::makeLayerProperty(getCircleRadius());
+            return makeLayerProperty(getCircleRadius());
         case Property::CircleStrokeColor:
-            return conversion::makeLayerProperty(getCircleStrokeColor());
+            return makeLayerProperty(getCircleStrokeColor());
         case Property::CircleStrokeOpacity:
-            return conversion::makeLayerProperty(getCircleStrokeOpacity());
+            return makeLayerProperty(getCircleStrokeOpacity());
         case Property::CircleStrokeWidth:
-            return conversion::makeLayerProperty(getCircleStrokeWidth());
+            return makeLayerProperty(getCircleStrokeWidth());
         case Property::CircleTranslate:
-            return conversion::makeLayerProperty(getCircleTranslate());
+            return makeLayerProperty(getCircleTranslate());
         case Property::CircleTranslateAnchor:
-            return conversion::makeLayerProperty(getCircleTranslateAnchor());
+            return makeLayerProperty(getCircleTranslateAnchor());
         case Property::CircleBlurTransition:
-            return conversion::makeLayerProperty(getCircleBlurTransition());
+            return makeLayerProperty(getCircleBlurTransition());
         case Property::CircleColorTransition:
-            return conversion::makeLayerProperty(getCircleColorTransition());
+            return makeLayerProperty(getCircleColorTransition());
         case Property::CircleOpacityTransition:
-            return conversion::makeLayerProperty(getCircleOpacityTransition());
+            return makeLayerProperty(getCircleOpacityTransition());
         case Property::CirclePitchAlignmentTransition:
-            return conversion::makeLayerProperty(getCirclePitchAlignmentTransition());
+            return makeLayerProperty(getCirclePitchAlignmentTransition());
         case Property::CirclePitchScaleTransition:
-            return conversion::makeLayerProperty(getCirclePitchScaleTransition());
+            return makeLayerProperty(getCirclePitchScaleTransition());
         case Property::CircleRadiusTransition:
-            return conversion::makeLayerProperty(getCircleRadiusTransition());
+            return makeLayerProperty(getCircleRadiusTransition());
         case Property::CircleStrokeColorTransition:
-            return conversion::makeLayerProperty(getCircleStrokeColorTransition());
+            return makeLayerProperty(getCircleStrokeColorTransition());
         case Property::CircleStrokeOpacityTransition:
-            return conversion::makeLayerProperty(getCircleStrokeOpacityTransition());
+            return makeLayerProperty(getCircleStrokeOpacityTransition());
         case Property::CircleStrokeWidthTransition:
-            return conversion::makeLayerProperty(getCircleStrokeWidthTransition());
+            return makeLayerProperty(getCircleStrokeWidthTransition());
         case Property::CircleTranslateTransition:
-            return conversion::makeLayerProperty(getCircleTranslateTransition());
+            return makeLayerProperty(getCircleTranslateTransition());
         case Property::CircleTranslateAnchorTransition:
-            return conversion::makeLayerProperty(getCircleTranslateAnchorTransition());
+            return makeLayerProperty(getCircleTranslateAnchorTransition());
     }
     return {};
 }

--- a/src/mbgl/style/layers/custom_layer.cpp
+++ b/src/mbgl/style/layers/custom_layer.cpp
@@ -47,6 +47,10 @@ optional<Error> CustomLayer::setLayoutProperty(const std::string&, const Convert
     return Error { "layer doesn't support this property" };
 }
 
+LayerProperty CustomLayer::getPaintProperty(const std::string&) const {
+    return {};
+}
+
 Mutable<Layer::Impl> CustomLayer::mutableBaseImpl() const {
     return staticMutableCast<Layer::Impl>(mutableImpl());
 }

--- a/src/mbgl/style/layers/custom_layer.cpp
+++ b/src/mbgl/style/layers/custom_layer.cpp
@@ -47,7 +47,7 @@ optional<Error> CustomLayer::setLayoutProperty(const std::string&, const Convert
     return Error { "layer doesn't support this property" };
 }
 
-LayerProperty CustomLayer::getPaintProperty(const std::string&) const {
+StyleProperty CustomLayer::getPaintProperty(const std::string&) const {
     return {};
 }
 

--- a/src/mbgl/style/layers/fill_extrusion_layer.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer.cpp
@@ -304,30 +304,35 @@ enum class Property {
     FillExtrusionVerticalGradientTransition,
 };
 
+template <typename T>
+constexpr uint8_t toUint8(T t) noexcept {
+    return uint8_t(mbgl::underlying_type(t));
+}
+
 MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
-    {{"fill-extrusion-base", mbgl::underlying_type(Property::FillExtrusionBase)},
-     {"fill-extrusion-color", mbgl::underlying_type(Property::FillExtrusionColor)},
-     {"fill-extrusion-height", mbgl::underlying_type(Property::FillExtrusionHeight)},
-     {"fill-extrusion-opacity", mbgl::underlying_type(Property::FillExtrusionOpacity)},
-     {"fill-extrusion-pattern", mbgl::underlying_type(Property::FillExtrusionPattern)},
-     {"fill-extrusion-translate", mbgl::underlying_type(Property::FillExtrusionTranslate)},
-     {"fill-extrusion-translate-anchor", mbgl::underlying_type(Property::FillExtrusionTranslateAnchor)},
-     {"fill-extrusion-vertical-gradient", mbgl::underlying_type(Property::FillExtrusionVerticalGradient)},
-     {"fill-extrusion-base-transition", mbgl::underlying_type(Property::FillExtrusionBaseTransition)},
-     {"fill-extrusion-color-transition", mbgl::underlying_type(Property::FillExtrusionColorTransition)},
-     {"fill-extrusion-height-transition", mbgl::underlying_type(Property::FillExtrusionHeightTransition)},
-     {"fill-extrusion-opacity-transition", mbgl::underlying_type(Property::FillExtrusionOpacityTransition)},
-     {"fill-extrusion-pattern-transition", mbgl::underlying_type(Property::FillExtrusionPatternTransition)},
-     {"fill-extrusion-translate-transition", mbgl::underlying_type(Property::FillExtrusionTranslateTransition)},
-     {"fill-extrusion-translate-anchor-transition", mbgl::underlying_type(Property::FillExtrusionTranslateAnchorTransition)},
-     {"fill-extrusion-vertical-gradient-transition", mbgl::underlying_type(Property::FillExtrusionVerticalGradientTransition)}});
+    {{"fill-extrusion-base", toUint8(Property::FillExtrusionBase)},
+     {"fill-extrusion-color", toUint8(Property::FillExtrusionColor)},
+     {"fill-extrusion-height", toUint8(Property::FillExtrusionHeight)},
+     {"fill-extrusion-opacity", toUint8(Property::FillExtrusionOpacity)},
+     {"fill-extrusion-pattern", toUint8(Property::FillExtrusionPattern)},
+     {"fill-extrusion-translate", toUint8(Property::FillExtrusionTranslate)},
+     {"fill-extrusion-translate-anchor", toUint8(Property::FillExtrusionTranslateAnchor)},
+     {"fill-extrusion-vertical-gradient", toUint8(Property::FillExtrusionVerticalGradient)},
+     {"fill-extrusion-base-transition", toUint8(Property::FillExtrusionBaseTransition)},
+     {"fill-extrusion-color-transition", toUint8(Property::FillExtrusionColorTransition)},
+     {"fill-extrusion-height-transition", toUint8(Property::FillExtrusionHeightTransition)},
+     {"fill-extrusion-opacity-transition", toUint8(Property::FillExtrusionOpacityTransition)},
+     {"fill-extrusion-pattern-transition", toUint8(Property::FillExtrusionPatternTransition)},
+     {"fill-extrusion-translate-transition", toUint8(Property::FillExtrusionTranslateTransition)},
+     {"fill-extrusion-translate-anchor-transition", toUint8(Property::FillExtrusionTranslateAnchorTransition)},
+     {"fill-extrusion-vertical-gradient-transition", toUint8(Property::FillExtrusionVerticalGradientTransition)}});
 
 } // namespace
 
 optional<Error> FillExtrusionLayer::setPaintProperty(const std::string& name, const Convertible& value) {
     const auto it = paintProperties.find(name.c_str());
     if (it == paintProperties.end()) {
-        return Error { "layer doesn't support this property" };
+        return Error{"layer doesn't support this property"};
     }
 
     auto property = static_cast<Property>(it->second);
@@ -430,49 +435,48 @@ optional<Error> FillExtrusionLayer::setPaintProperty(const std::string& name, co
     if (!transition) {
         return error;
     }
-    
+
     if (property == Property::FillExtrusionBaseTransition) {
         setFillExtrusionBaseTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::FillExtrusionColorTransition) {
         setFillExtrusionColorTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::FillExtrusionHeightTransition) {
         setFillExtrusionHeightTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::FillExtrusionOpacityTransition) {
         setFillExtrusionOpacityTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::FillExtrusionPatternTransition) {
         setFillExtrusionPatternTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::FillExtrusionTranslateTransition) {
         setFillExtrusionTranslateTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::FillExtrusionTranslateAnchorTransition) {
         setFillExtrusionTranslateAnchorTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::FillExtrusionVerticalGradientTransition) {
         setFillExtrusionVerticalGradientTransition(*transition);
         return nullopt;
     }
-    
 
-    return Error { "layer doesn't support this property" };
+    return Error{"layer doesn't support this property"};
 }
 
 LayerProperty FillExtrusionLayer::getPaintProperty(const std::string& name) const {
@@ -483,37 +487,37 @@ LayerProperty FillExtrusionLayer::getPaintProperty(const std::string& name) cons
 
     switch (static_cast<Property>(it->second)) {
         case Property::FillExtrusionBase:
-            return conversion::makeLayerProperty(getFillExtrusionBase());
+            return makeLayerProperty(getFillExtrusionBase());
         case Property::FillExtrusionColor:
-            return conversion::makeLayerProperty(getFillExtrusionColor());
+            return makeLayerProperty(getFillExtrusionColor());
         case Property::FillExtrusionHeight:
-            return conversion::makeLayerProperty(getFillExtrusionHeight());
+            return makeLayerProperty(getFillExtrusionHeight());
         case Property::FillExtrusionOpacity:
-            return conversion::makeLayerProperty(getFillExtrusionOpacity());
+            return makeLayerProperty(getFillExtrusionOpacity());
         case Property::FillExtrusionPattern:
-            return conversion::makeLayerProperty(getFillExtrusionPattern());
+            return makeLayerProperty(getFillExtrusionPattern());
         case Property::FillExtrusionTranslate:
-            return conversion::makeLayerProperty(getFillExtrusionTranslate());
+            return makeLayerProperty(getFillExtrusionTranslate());
         case Property::FillExtrusionTranslateAnchor:
-            return conversion::makeLayerProperty(getFillExtrusionTranslateAnchor());
+            return makeLayerProperty(getFillExtrusionTranslateAnchor());
         case Property::FillExtrusionVerticalGradient:
-            return conversion::makeLayerProperty(getFillExtrusionVerticalGradient());
+            return makeLayerProperty(getFillExtrusionVerticalGradient());
         case Property::FillExtrusionBaseTransition:
-            return conversion::makeLayerProperty(getFillExtrusionBaseTransition());
+            return makeLayerProperty(getFillExtrusionBaseTransition());
         case Property::FillExtrusionColorTransition:
-            return conversion::makeLayerProperty(getFillExtrusionColorTransition());
+            return makeLayerProperty(getFillExtrusionColorTransition());
         case Property::FillExtrusionHeightTransition:
-            return conversion::makeLayerProperty(getFillExtrusionHeightTransition());
+            return makeLayerProperty(getFillExtrusionHeightTransition());
         case Property::FillExtrusionOpacityTransition:
-            return conversion::makeLayerProperty(getFillExtrusionOpacityTransition());
+            return makeLayerProperty(getFillExtrusionOpacityTransition());
         case Property::FillExtrusionPatternTransition:
-            return conversion::makeLayerProperty(getFillExtrusionPatternTransition());
+            return makeLayerProperty(getFillExtrusionPatternTransition());
         case Property::FillExtrusionTranslateTransition:
-            return conversion::makeLayerProperty(getFillExtrusionTranslateTransition());
+            return makeLayerProperty(getFillExtrusionTranslateTransition());
         case Property::FillExtrusionTranslateAnchorTransition:
-            return conversion::makeLayerProperty(getFillExtrusionTranslateAnchorTransition());
+            return makeLayerProperty(getFillExtrusionTranslateAnchorTransition());
         case Property::FillExtrusionVerticalGradientTransition:
-            return conversion::makeLayerProperty(getFillExtrusionVerticalGradientTransition());
+            return makeLayerProperty(getFillExtrusionVerticalGradientTransition());
     }
     return {};
 }

--- a/src/mbgl/style/layers/fill_extrusion_layer.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer.cpp
@@ -285,7 +285,7 @@ using namespace conversion;
 
 namespace {
 
-enum class Property {
+enum class Property : uint8_t {
     FillExtrusionBase,
     FillExtrusionColor,
     FillExtrusionHeight,
@@ -479,7 +479,7 @@ optional<Error> FillExtrusionLayer::setPaintProperty(const std::string& name, co
     return Error{"layer doesn't support this property"};
 }
 
-LayerProperty FillExtrusionLayer::getPaintProperty(const std::string& name) const {
+StyleProperty FillExtrusionLayer::getPaintProperty(const std::string& name) const {
     const auto it = paintProperties.find(name.c_str());
     if (it == paintProperties.end()) {
         return {};
@@ -487,37 +487,37 @@ LayerProperty FillExtrusionLayer::getPaintProperty(const std::string& name) cons
 
     switch (static_cast<Property>(it->second)) {
         case Property::FillExtrusionBase:
-            return makeLayerProperty(getFillExtrusionBase());
+            return makeStyleProperty(getFillExtrusionBase());
         case Property::FillExtrusionColor:
-            return makeLayerProperty(getFillExtrusionColor());
+            return makeStyleProperty(getFillExtrusionColor());
         case Property::FillExtrusionHeight:
-            return makeLayerProperty(getFillExtrusionHeight());
+            return makeStyleProperty(getFillExtrusionHeight());
         case Property::FillExtrusionOpacity:
-            return makeLayerProperty(getFillExtrusionOpacity());
+            return makeStyleProperty(getFillExtrusionOpacity());
         case Property::FillExtrusionPattern:
-            return makeLayerProperty(getFillExtrusionPattern());
+            return makeStyleProperty(getFillExtrusionPattern());
         case Property::FillExtrusionTranslate:
-            return makeLayerProperty(getFillExtrusionTranslate());
+            return makeStyleProperty(getFillExtrusionTranslate());
         case Property::FillExtrusionTranslateAnchor:
-            return makeLayerProperty(getFillExtrusionTranslateAnchor());
+            return makeStyleProperty(getFillExtrusionTranslateAnchor());
         case Property::FillExtrusionVerticalGradient:
-            return makeLayerProperty(getFillExtrusionVerticalGradient());
+            return makeStyleProperty(getFillExtrusionVerticalGradient());
         case Property::FillExtrusionBaseTransition:
-            return makeLayerProperty(getFillExtrusionBaseTransition());
+            return makeStyleProperty(getFillExtrusionBaseTransition());
         case Property::FillExtrusionColorTransition:
-            return makeLayerProperty(getFillExtrusionColorTransition());
+            return makeStyleProperty(getFillExtrusionColorTransition());
         case Property::FillExtrusionHeightTransition:
-            return makeLayerProperty(getFillExtrusionHeightTransition());
+            return makeStyleProperty(getFillExtrusionHeightTransition());
         case Property::FillExtrusionOpacityTransition:
-            return makeLayerProperty(getFillExtrusionOpacityTransition());
+            return makeStyleProperty(getFillExtrusionOpacityTransition());
         case Property::FillExtrusionPatternTransition:
-            return makeLayerProperty(getFillExtrusionPatternTransition());
+            return makeStyleProperty(getFillExtrusionPatternTransition());
         case Property::FillExtrusionTranslateTransition:
-            return makeLayerProperty(getFillExtrusionTranslateTransition());
+            return makeStyleProperty(getFillExtrusionTranslateTransition());
         case Property::FillExtrusionTranslateAnchorTransition:
-            return makeLayerProperty(getFillExtrusionTranslateAnchorTransition());
+            return makeStyleProperty(getFillExtrusionTranslateAnchorTransition());
         case Property::FillExtrusionVerticalGradientTransition:
-            return makeLayerProperty(getFillExtrusionVerticalGradientTransition());
+            return makeStyleProperty(getFillExtrusionVerticalGradientTransition());
     }
     return {};
 }

--- a/src/mbgl/style/layers/fill_extrusion_layer.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer.cpp
@@ -283,47 +283,50 @@ TransitionOptions FillExtrusionLayer::getFillExtrusionVerticalGradientTransition
 
 using namespace conversion;
 
+namespace {
+
+enum class Property {
+    FillExtrusionBase,
+    FillExtrusionColor,
+    FillExtrusionHeight,
+    FillExtrusionOpacity,
+    FillExtrusionPattern,
+    FillExtrusionTranslate,
+    FillExtrusionTranslateAnchor,
+    FillExtrusionVerticalGradient,
+    FillExtrusionBaseTransition,
+    FillExtrusionColorTransition,
+    FillExtrusionHeightTransition,
+    FillExtrusionOpacityTransition,
+    FillExtrusionPatternTransition,
+    FillExtrusionTranslateTransition,
+    FillExtrusionTranslateAnchorTransition,
+    FillExtrusionVerticalGradientTransition,
+};
+
+MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+    {{"fill-extrusion-base", mbgl::underlying_type(Property::FillExtrusionBase)},
+     {"fill-extrusion-color", mbgl::underlying_type(Property::FillExtrusionColor)},
+     {"fill-extrusion-height", mbgl::underlying_type(Property::FillExtrusionHeight)},
+     {"fill-extrusion-opacity", mbgl::underlying_type(Property::FillExtrusionOpacity)},
+     {"fill-extrusion-pattern", mbgl::underlying_type(Property::FillExtrusionPattern)},
+     {"fill-extrusion-translate", mbgl::underlying_type(Property::FillExtrusionTranslate)},
+     {"fill-extrusion-translate-anchor", mbgl::underlying_type(Property::FillExtrusionTranslateAnchor)},
+     {"fill-extrusion-vertical-gradient", mbgl::underlying_type(Property::FillExtrusionVerticalGradient)},
+     {"fill-extrusion-base-transition", mbgl::underlying_type(Property::FillExtrusionBaseTransition)},
+     {"fill-extrusion-color-transition", mbgl::underlying_type(Property::FillExtrusionColorTransition)},
+     {"fill-extrusion-height-transition", mbgl::underlying_type(Property::FillExtrusionHeightTransition)},
+     {"fill-extrusion-opacity-transition", mbgl::underlying_type(Property::FillExtrusionOpacityTransition)},
+     {"fill-extrusion-pattern-transition", mbgl::underlying_type(Property::FillExtrusionPatternTransition)},
+     {"fill-extrusion-translate-transition", mbgl::underlying_type(Property::FillExtrusionTranslateTransition)},
+     {"fill-extrusion-translate-anchor-transition", mbgl::underlying_type(Property::FillExtrusionTranslateAnchorTransition)},
+     {"fill-extrusion-vertical-gradient-transition", mbgl::underlying_type(Property::FillExtrusionVerticalGradientTransition)}});
+
+} // namespace
+
 optional<Error> FillExtrusionLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-        FillExtrusionBase,
-        FillExtrusionColor,
-        FillExtrusionHeight,
-        FillExtrusionOpacity,
-        FillExtrusionPattern,
-        FillExtrusionTranslate,
-        FillExtrusionTranslateAnchor,
-        FillExtrusionVerticalGradient,
-        FillExtrusionBaseTransition,
-        FillExtrusionColorTransition,
-        FillExtrusionHeightTransition,
-        FillExtrusionOpacityTransition,
-        FillExtrusionPatternTransition,
-        FillExtrusionTranslateTransition,
-        FillExtrusionTranslateAnchorTransition,
-        FillExtrusionVerticalGradientTransition,
-    };
-
-    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        { "fill-extrusion-base", mbgl::underlying_type(Property::FillExtrusionBase) },
-        { "fill-extrusion-color", mbgl::underlying_type(Property::FillExtrusionColor) },
-        { "fill-extrusion-height", mbgl::underlying_type(Property::FillExtrusionHeight) },
-        { "fill-extrusion-opacity", mbgl::underlying_type(Property::FillExtrusionOpacity) },
-        { "fill-extrusion-pattern", mbgl::underlying_type(Property::FillExtrusionPattern) },
-        { "fill-extrusion-translate", mbgl::underlying_type(Property::FillExtrusionTranslate) },
-        { "fill-extrusion-translate-anchor", mbgl::underlying_type(Property::FillExtrusionTranslateAnchor) },
-        { "fill-extrusion-vertical-gradient", mbgl::underlying_type(Property::FillExtrusionVerticalGradient) },
-        { "fill-extrusion-base-transition", mbgl::underlying_type(Property::FillExtrusionBaseTransition) },
-        { "fill-extrusion-color-transition", mbgl::underlying_type(Property::FillExtrusionColorTransition) },
-        { "fill-extrusion-height-transition", mbgl::underlying_type(Property::FillExtrusionHeightTransition) },
-        { "fill-extrusion-opacity-transition", mbgl::underlying_type(Property::FillExtrusionOpacityTransition) },
-        { "fill-extrusion-pattern-transition", mbgl::underlying_type(Property::FillExtrusionPatternTransition) },
-        { "fill-extrusion-translate-transition", mbgl::underlying_type(Property::FillExtrusionTranslateTransition) },
-        { "fill-extrusion-translate-anchor-transition", mbgl::underlying_type(Property::FillExtrusionTranslateAnchorTransition) },
-        { "fill-extrusion-vertical-gradient-transition", mbgl::underlying_type(Property::FillExtrusionVerticalGradientTransition) }
-    });
-
-    const auto it = properties.find(name.c_str());
-    if (it == properties.end()) {
+    const auto it = paintProperties.find(name.c_str());
+    if (it == paintProperties.end()) {
         return Error { "layer doesn't support this property" };
     }
 
@@ -470,6 +473,49 @@ optional<Error> FillExtrusionLayer::setPaintProperty(const std::string& name, co
     
 
     return Error { "layer doesn't support this property" };
+}
+
+LayerProperty FillExtrusionLayer::getPaintProperty(const std::string& name) const {
+    const auto it = paintProperties.find(name.c_str());
+    if (it == paintProperties.end()) {
+        return {};
+    }
+
+    switch (static_cast<Property>(it->second)) {
+        case Property::FillExtrusionBase:
+            return conversion::makeLayerProperty(getFillExtrusionBase());
+        case Property::FillExtrusionColor:
+            return conversion::makeLayerProperty(getFillExtrusionColor());
+        case Property::FillExtrusionHeight:
+            return conversion::makeLayerProperty(getFillExtrusionHeight());
+        case Property::FillExtrusionOpacity:
+            return conversion::makeLayerProperty(getFillExtrusionOpacity());
+        case Property::FillExtrusionPattern:
+            return conversion::makeLayerProperty(getFillExtrusionPattern());
+        case Property::FillExtrusionTranslate:
+            return conversion::makeLayerProperty(getFillExtrusionTranslate());
+        case Property::FillExtrusionTranslateAnchor:
+            return conversion::makeLayerProperty(getFillExtrusionTranslateAnchor());
+        case Property::FillExtrusionVerticalGradient:
+            return conversion::makeLayerProperty(getFillExtrusionVerticalGradient());
+        case Property::FillExtrusionBaseTransition:
+            return conversion::makeLayerProperty(getFillExtrusionBaseTransition());
+        case Property::FillExtrusionColorTransition:
+            return conversion::makeLayerProperty(getFillExtrusionColorTransition());
+        case Property::FillExtrusionHeightTransition:
+            return conversion::makeLayerProperty(getFillExtrusionHeightTransition());
+        case Property::FillExtrusionOpacityTransition:
+            return conversion::makeLayerProperty(getFillExtrusionOpacityTransition());
+        case Property::FillExtrusionPatternTransition:
+            return conversion::makeLayerProperty(getFillExtrusionPatternTransition());
+        case Property::FillExtrusionTranslateTransition:
+            return conversion::makeLayerProperty(getFillExtrusionTranslateTransition());
+        case Property::FillExtrusionTranslateAnchorTransition:
+            return conversion::makeLayerProperty(getFillExtrusionTranslateAnchorTransition());
+        case Property::FillExtrusionVerticalGradientTransition:
+            return conversion::makeLayerProperty(getFillExtrusionVerticalGradientTransition());
+    }
+    return {};
 }
 
 optional<Error> FillExtrusionLayer::setLayoutProperty(const std::string& name, const Convertible& value) {

--- a/src/mbgl/style/layers/fill_layer.cpp
+++ b/src/mbgl/style/layers/fill_layer.cpp
@@ -256,43 +256,46 @@ TransitionOptions FillLayer::getFillTranslateAnchorTransition() const {
 
 using namespace conversion;
 
+namespace {
+
+enum class Property {
+    FillAntialias,
+    FillColor,
+    FillOpacity,
+    FillOutlineColor,
+    FillPattern,
+    FillTranslate,
+    FillTranslateAnchor,
+    FillAntialiasTransition,
+    FillColorTransition,
+    FillOpacityTransition,
+    FillOutlineColorTransition,
+    FillPatternTransition,
+    FillTranslateTransition,
+    FillTranslateAnchorTransition,
+};
+
+MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+    {{"fill-antialias", mbgl::underlying_type(Property::FillAntialias)},
+     {"fill-color", mbgl::underlying_type(Property::FillColor)},
+     {"fill-opacity", mbgl::underlying_type(Property::FillOpacity)},
+     {"fill-outline-color", mbgl::underlying_type(Property::FillOutlineColor)},
+     {"fill-pattern", mbgl::underlying_type(Property::FillPattern)},
+     {"fill-translate", mbgl::underlying_type(Property::FillTranslate)},
+     {"fill-translate-anchor", mbgl::underlying_type(Property::FillTranslateAnchor)},
+     {"fill-antialias-transition", mbgl::underlying_type(Property::FillAntialiasTransition)},
+     {"fill-color-transition", mbgl::underlying_type(Property::FillColorTransition)},
+     {"fill-opacity-transition", mbgl::underlying_type(Property::FillOpacityTransition)},
+     {"fill-outline-color-transition", mbgl::underlying_type(Property::FillOutlineColorTransition)},
+     {"fill-pattern-transition", mbgl::underlying_type(Property::FillPatternTransition)},
+     {"fill-translate-transition", mbgl::underlying_type(Property::FillTranslateTransition)},
+     {"fill-translate-anchor-transition", mbgl::underlying_type(Property::FillTranslateAnchorTransition)}});
+
+} // namespace
+
 optional<Error> FillLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-        FillAntialias,
-        FillColor,
-        FillOpacity,
-        FillOutlineColor,
-        FillPattern,
-        FillTranslate,
-        FillTranslateAnchor,
-        FillAntialiasTransition,
-        FillColorTransition,
-        FillOpacityTransition,
-        FillOutlineColorTransition,
-        FillPatternTransition,
-        FillTranslateTransition,
-        FillTranslateAnchorTransition,
-    };
-
-    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        { "fill-antialias", mbgl::underlying_type(Property::FillAntialias) },
-        { "fill-color", mbgl::underlying_type(Property::FillColor) },
-        { "fill-opacity", mbgl::underlying_type(Property::FillOpacity) },
-        { "fill-outline-color", mbgl::underlying_type(Property::FillOutlineColor) },
-        { "fill-pattern", mbgl::underlying_type(Property::FillPattern) },
-        { "fill-translate", mbgl::underlying_type(Property::FillTranslate) },
-        { "fill-translate-anchor", mbgl::underlying_type(Property::FillTranslateAnchor) },
-        { "fill-antialias-transition", mbgl::underlying_type(Property::FillAntialiasTransition) },
-        { "fill-color-transition", mbgl::underlying_type(Property::FillColorTransition) },
-        { "fill-opacity-transition", mbgl::underlying_type(Property::FillOpacityTransition) },
-        { "fill-outline-color-transition", mbgl::underlying_type(Property::FillOutlineColorTransition) },
-        { "fill-pattern-transition", mbgl::underlying_type(Property::FillPatternTransition) },
-        { "fill-translate-transition", mbgl::underlying_type(Property::FillTranslateTransition) },
-        { "fill-translate-anchor-transition", mbgl::underlying_type(Property::FillTranslateAnchorTransition) }
-    });
-
-    const auto it = properties.find(name.c_str());
-    if (it == properties.end()) {
+    const auto it = paintProperties.find(name.c_str());
+    if (it == paintProperties.end()) {
         return Error { "layer doesn't support this property" };
     }
 
@@ -422,6 +425,45 @@ optional<Error> FillLayer::setPaintProperty(const std::string& name, const Conve
     
 
     return Error { "layer doesn't support this property" };
+}
+
+LayerProperty FillLayer::getPaintProperty(const std::string& name) const {
+    const auto it = paintProperties.find(name.c_str());
+    if (it == paintProperties.end()) {
+        return {};
+    }
+
+    switch (static_cast<Property>(it->second)) {
+        case Property::FillAntialias:
+            return conversion::makeLayerProperty(getFillAntialias());
+        case Property::FillColor:
+            return conversion::makeLayerProperty(getFillColor());
+        case Property::FillOpacity:
+            return conversion::makeLayerProperty(getFillOpacity());
+        case Property::FillOutlineColor:
+            return conversion::makeLayerProperty(getFillOutlineColor());
+        case Property::FillPattern:
+            return conversion::makeLayerProperty(getFillPattern());
+        case Property::FillTranslate:
+            return conversion::makeLayerProperty(getFillTranslate());
+        case Property::FillTranslateAnchor:
+            return conversion::makeLayerProperty(getFillTranslateAnchor());
+        case Property::FillAntialiasTransition:
+            return conversion::makeLayerProperty(getFillAntialiasTransition());
+        case Property::FillColorTransition:
+            return conversion::makeLayerProperty(getFillColorTransition());
+        case Property::FillOpacityTransition:
+            return conversion::makeLayerProperty(getFillOpacityTransition());
+        case Property::FillOutlineColorTransition:
+            return conversion::makeLayerProperty(getFillOutlineColorTransition());
+        case Property::FillPatternTransition:
+            return conversion::makeLayerProperty(getFillPatternTransition());
+        case Property::FillTranslateTransition:
+            return conversion::makeLayerProperty(getFillTranslateTransition());
+        case Property::FillTranslateAnchorTransition:
+            return conversion::makeLayerProperty(getFillTranslateAnchorTransition());
+    }
+    return {};
 }
 
 optional<Error> FillLayer::setLayoutProperty(const std::string& name, const Convertible& value) {

--- a/src/mbgl/style/layers/fill_layer.cpp
+++ b/src/mbgl/style/layers/fill_layer.cpp
@@ -275,28 +275,33 @@ enum class Property {
     FillTranslateAnchorTransition,
 };
 
+template <typename T>
+constexpr uint8_t toUint8(T t) noexcept {
+    return uint8_t(mbgl::underlying_type(t));
+}
+
 MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
-    {{"fill-antialias", mbgl::underlying_type(Property::FillAntialias)},
-     {"fill-color", mbgl::underlying_type(Property::FillColor)},
-     {"fill-opacity", mbgl::underlying_type(Property::FillOpacity)},
-     {"fill-outline-color", mbgl::underlying_type(Property::FillOutlineColor)},
-     {"fill-pattern", mbgl::underlying_type(Property::FillPattern)},
-     {"fill-translate", mbgl::underlying_type(Property::FillTranslate)},
-     {"fill-translate-anchor", mbgl::underlying_type(Property::FillTranslateAnchor)},
-     {"fill-antialias-transition", mbgl::underlying_type(Property::FillAntialiasTransition)},
-     {"fill-color-transition", mbgl::underlying_type(Property::FillColorTransition)},
-     {"fill-opacity-transition", mbgl::underlying_type(Property::FillOpacityTransition)},
-     {"fill-outline-color-transition", mbgl::underlying_type(Property::FillOutlineColorTransition)},
-     {"fill-pattern-transition", mbgl::underlying_type(Property::FillPatternTransition)},
-     {"fill-translate-transition", mbgl::underlying_type(Property::FillTranslateTransition)},
-     {"fill-translate-anchor-transition", mbgl::underlying_type(Property::FillTranslateAnchorTransition)}});
+    {{"fill-antialias", toUint8(Property::FillAntialias)},
+     {"fill-color", toUint8(Property::FillColor)},
+     {"fill-opacity", toUint8(Property::FillOpacity)},
+     {"fill-outline-color", toUint8(Property::FillOutlineColor)},
+     {"fill-pattern", toUint8(Property::FillPattern)},
+     {"fill-translate", toUint8(Property::FillTranslate)},
+     {"fill-translate-anchor", toUint8(Property::FillTranslateAnchor)},
+     {"fill-antialias-transition", toUint8(Property::FillAntialiasTransition)},
+     {"fill-color-transition", toUint8(Property::FillColorTransition)},
+     {"fill-opacity-transition", toUint8(Property::FillOpacityTransition)},
+     {"fill-outline-color-transition", toUint8(Property::FillOutlineColorTransition)},
+     {"fill-pattern-transition", toUint8(Property::FillPatternTransition)},
+     {"fill-translate-transition", toUint8(Property::FillTranslateTransition)},
+     {"fill-translate-anchor-transition", toUint8(Property::FillTranslateAnchorTransition)}});
 
 } // namespace
 
 optional<Error> FillLayer::setPaintProperty(const std::string& name, const Convertible& value) {
     const auto it = paintProperties.find(name.c_str());
     if (it == paintProperties.end()) {
-        return Error { "layer doesn't support this property" };
+        return Error{"layer doesn't support this property"};
     }
 
     auto property = static_cast<Property>(it->second);
@@ -387,44 +392,43 @@ optional<Error> FillLayer::setPaintProperty(const std::string& name, const Conve
     if (!transition) {
         return error;
     }
-    
+
     if (property == Property::FillAntialiasTransition) {
         setFillAntialiasTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::FillColorTransition) {
         setFillColorTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::FillOpacityTransition) {
         setFillOpacityTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::FillOutlineColorTransition) {
         setFillOutlineColorTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::FillPatternTransition) {
         setFillPatternTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::FillTranslateTransition) {
         setFillTranslateTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::FillTranslateAnchorTransition) {
         setFillTranslateAnchorTransition(*transition);
         return nullopt;
     }
-    
 
-    return Error { "layer doesn't support this property" };
+    return Error{"layer doesn't support this property"};
 }
 
 LayerProperty FillLayer::getPaintProperty(const std::string& name) const {
@@ -435,33 +439,33 @@ LayerProperty FillLayer::getPaintProperty(const std::string& name) const {
 
     switch (static_cast<Property>(it->second)) {
         case Property::FillAntialias:
-            return conversion::makeLayerProperty(getFillAntialias());
+            return makeLayerProperty(getFillAntialias());
         case Property::FillColor:
-            return conversion::makeLayerProperty(getFillColor());
+            return makeLayerProperty(getFillColor());
         case Property::FillOpacity:
-            return conversion::makeLayerProperty(getFillOpacity());
+            return makeLayerProperty(getFillOpacity());
         case Property::FillOutlineColor:
-            return conversion::makeLayerProperty(getFillOutlineColor());
+            return makeLayerProperty(getFillOutlineColor());
         case Property::FillPattern:
-            return conversion::makeLayerProperty(getFillPattern());
+            return makeLayerProperty(getFillPattern());
         case Property::FillTranslate:
-            return conversion::makeLayerProperty(getFillTranslate());
+            return makeLayerProperty(getFillTranslate());
         case Property::FillTranslateAnchor:
-            return conversion::makeLayerProperty(getFillTranslateAnchor());
+            return makeLayerProperty(getFillTranslateAnchor());
         case Property::FillAntialiasTransition:
-            return conversion::makeLayerProperty(getFillAntialiasTransition());
+            return makeLayerProperty(getFillAntialiasTransition());
         case Property::FillColorTransition:
-            return conversion::makeLayerProperty(getFillColorTransition());
+            return makeLayerProperty(getFillColorTransition());
         case Property::FillOpacityTransition:
-            return conversion::makeLayerProperty(getFillOpacityTransition());
+            return makeLayerProperty(getFillOpacityTransition());
         case Property::FillOutlineColorTransition:
-            return conversion::makeLayerProperty(getFillOutlineColorTransition());
+            return makeLayerProperty(getFillOutlineColorTransition());
         case Property::FillPatternTransition:
-            return conversion::makeLayerProperty(getFillPatternTransition());
+            return makeLayerProperty(getFillPatternTransition());
         case Property::FillTranslateTransition:
-            return conversion::makeLayerProperty(getFillTranslateTransition());
+            return makeLayerProperty(getFillTranslateTransition());
         case Property::FillTranslateAnchorTransition:
-            return conversion::makeLayerProperty(getFillTranslateAnchorTransition());
+            return makeLayerProperty(getFillTranslateAnchorTransition());
     }
     return {};
 }

--- a/src/mbgl/style/layers/fill_layer.cpp
+++ b/src/mbgl/style/layers/fill_layer.cpp
@@ -258,7 +258,7 @@ using namespace conversion;
 
 namespace {
 
-enum class Property {
+enum class Property : uint8_t {
     FillAntialias,
     FillColor,
     FillOpacity,
@@ -431,7 +431,7 @@ optional<Error> FillLayer::setPaintProperty(const std::string& name, const Conve
     return Error{"layer doesn't support this property"};
 }
 
-LayerProperty FillLayer::getPaintProperty(const std::string& name) const {
+StyleProperty FillLayer::getPaintProperty(const std::string& name) const {
     const auto it = paintProperties.find(name.c_str());
     if (it == paintProperties.end()) {
         return {};
@@ -439,33 +439,33 @@ LayerProperty FillLayer::getPaintProperty(const std::string& name) const {
 
     switch (static_cast<Property>(it->second)) {
         case Property::FillAntialias:
-            return makeLayerProperty(getFillAntialias());
+            return makeStyleProperty(getFillAntialias());
         case Property::FillColor:
-            return makeLayerProperty(getFillColor());
+            return makeStyleProperty(getFillColor());
         case Property::FillOpacity:
-            return makeLayerProperty(getFillOpacity());
+            return makeStyleProperty(getFillOpacity());
         case Property::FillOutlineColor:
-            return makeLayerProperty(getFillOutlineColor());
+            return makeStyleProperty(getFillOutlineColor());
         case Property::FillPattern:
-            return makeLayerProperty(getFillPattern());
+            return makeStyleProperty(getFillPattern());
         case Property::FillTranslate:
-            return makeLayerProperty(getFillTranslate());
+            return makeStyleProperty(getFillTranslate());
         case Property::FillTranslateAnchor:
-            return makeLayerProperty(getFillTranslateAnchor());
+            return makeStyleProperty(getFillTranslateAnchor());
         case Property::FillAntialiasTransition:
-            return makeLayerProperty(getFillAntialiasTransition());
+            return makeStyleProperty(getFillAntialiasTransition());
         case Property::FillColorTransition:
-            return makeLayerProperty(getFillColorTransition());
+            return makeStyleProperty(getFillColorTransition());
         case Property::FillOpacityTransition:
-            return makeLayerProperty(getFillOpacityTransition());
+            return makeStyleProperty(getFillOpacityTransition());
         case Property::FillOutlineColorTransition:
-            return makeLayerProperty(getFillOutlineColorTransition());
+            return makeStyleProperty(getFillOutlineColorTransition());
         case Property::FillPatternTransition:
-            return makeLayerProperty(getFillPatternTransition());
+            return makeStyleProperty(getFillPatternTransition());
         case Property::FillTranslateTransition:
-            return makeLayerProperty(getFillTranslateTransition());
+            return makeStyleProperty(getFillTranslateTransition());
         case Property::FillTranslateAnchorTransition:
-            return makeLayerProperty(getFillTranslateAnchorTransition());
+            return makeStyleProperty(getFillTranslateAnchorTransition());
     }
     return {};
 }

--- a/src/mbgl/style/layers/heatmap_layer.cpp
+++ b/src/mbgl/style/layers/heatmap_layer.cpp
@@ -206,7 +206,7 @@ using namespace conversion;
 
 namespace {
 
-enum class Property {
+enum class Property : uint8_t {
     HeatmapColor,
     HeatmapIntensity,
     HeatmapOpacity,
@@ -332,7 +332,7 @@ optional<Error> HeatmapLayer::setPaintProperty(const std::string& name, const Co
     return Error{"layer doesn't support this property"};
 }
 
-LayerProperty HeatmapLayer::getPaintProperty(const std::string& name) const {
+StyleProperty HeatmapLayer::getPaintProperty(const std::string& name) const {
     const auto it = paintProperties.find(name.c_str());
     if (it == paintProperties.end()) {
         return {};
@@ -340,25 +340,25 @@ LayerProperty HeatmapLayer::getPaintProperty(const std::string& name) const {
 
     switch (static_cast<Property>(it->second)) {
         case Property::HeatmapColor:
-            return makeLayerProperty(getHeatmapColor());
+            return makeStyleProperty(getHeatmapColor());
         case Property::HeatmapIntensity:
-            return makeLayerProperty(getHeatmapIntensity());
+            return makeStyleProperty(getHeatmapIntensity());
         case Property::HeatmapOpacity:
-            return makeLayerProperty(getHeatmapOpacity());
+            return makeStyleProperty(getHeatmapOpacity());
         case Property::HeatmapRadius:
-            return makeLayerProperty(getHeatmapRadius());
+            return makeStyleProperty(getHeatmapRadius());
         case Property::HeatmapWeight:
-            return makeLayerProperty(getHeatmapWeight());
+            return makeStyleProperty(getHeatmapWeight());
         case Property::HeatmapColorTransition:
-            return makeLayerProperty(getHeatmapColorTransition());
+            return makeStyleProperty(getHeatmapColorTransition());
         case Property::HeatmapIntensityTransition:
-            return makeLayerProperty(getHeatmapIntensityTransition());
+            return makeStyleProperty(getHeatmapIntensityTransition());
         case Property::HeatmapOpacityTransition:
-            return makeLayerProperty(getHeatmapOpacityTransition());
+            return makeStyleProperty(getHeatmapOpacityTransition());
         case Property::HeatmapRadiusTransition:
-            return makeLayerProperty(getHeatmapRadiusTransition());
+            return makeStyleProperty(getHeatmapRadiusTransition());
         case Property::HeatmapWeightTransition:
-            return makeLayerProperty(getHeatmapWeightTransition());
+            return makeStyleProperty(getHeatmapWeightTransition());
     }
     return {};
 }

--- a/src/mbgl/style/layers/heatmap_layer.cpp
+++ b/src/mbgl/style/layers/heatmap_layer.cpp
@@ -219,24 +219,29 @@ enum class Property {
     HeatmapWeightTransition,
 };
 
+template <typename T>
+constexpr uint8_t toUint8(T t) noexcept {
+    return uint8_t(mbgl::underlying_type(t));
+}
+
 MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
-    {{"heatmap-color", mbgl::underlying_type(Property::HeatmapColor)},
-     {"heatmap-intensity", mbgl::underlying_type(Property::HeatmapIntensity)},
-     {"heatmap-opacity", mbgl::underlying_type(Property::HeatmapOpacity)},
-     {"heatmap-radius", mbgl::underlying_type(Property::HeatmapRadius)},
-     {"heatmap-weight", mbgl::underlying_type(Property::HeatmapWeight)},
-     {"heatmap-color-transition", mbgl::underlying_type(Property::HeatmapColorTransition)},
-     {"heatmap-intensity-transition", mbgl::underlying_type(Property::HeatmapIntensityTransition)},
-     {"heatmap-opacity-transition", mbgl::underlying_type(Property::HeatmapOpacityTransition)},
-     {"heatmap-radius-transition", mbgl::underlying_type(Property::HeatmapRadiusTransition)},
-     {"heatmap-weight-transition", mbgl::underlying_type(Property::HeatmapWeightTransition)}});
+    {{"heatmap-color", toUint8(Property::HeatmapColor)},
+     {"heatmap-intensity", toUint8(Property::HeatmapIntensity)},
+     {"heatmap-opacity", toUint8(Property::HeatmapOpacity)},
+     {"heatmap-radius", toUint8(Property::HeatmapRadius)},
+     {"heatmap-weight", toUint8(Property::HeatmapWeight)},
+     {"heatmap-color-transition", toUint8(Property::HeatmapColorTransition)},
+     {"heatmap-intensity-transition", toUint8(Property::HeatmapIntensityTransition)},
+     {"heatmap-opacity-transition", toUint8(Property::HeatmapOpacityTransition)},
+     {"heatmap-radius-transition", toUint8(Property::HeatmapRadiusTransition)},
+     {"heatmap-weight-transition", toUint8(Property::HeatmapWeightTransition)}});
 
 } // namespace
 
 optional<Error> HeatmapLayer::setPaintProperty(const std::string& name, const Convertible& value) {
     const auto it = paintProperties.find(name.c_str());
     if (it == paintProperties.end()) {
-        return Error { "layer doesn't support this property" };
+        return Error{"layer doesn't support this property"};
     }
 
     auto property = static_cast<Property>(it->second);
@@ -298,34 +303,33 @@ optional<Error> HeatmapLayer::setPaintProperty(const std::string& name, const Co
     if (!transition) {
         return error;
     }
-    
+
     if (property == Property::HeatmapColorTransition) {
         setHeatmapColorTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::HeatmapIntensityTransition) {
         setHeatmapIntensityTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::HeatmapOpacityTransition) {
         setHeatmapOpacityTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::HeatmapRadiusTransition) {
         setHeatmapRadiusTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::HeatmapWeightTransition) {
         setHeatmapWeightTransition(*transition);
         return nullopt;
     }
-    
 
-    return Error { "layer doesn't support this property" };
+    return Error{"layer doesn't support this property"};
 }
 
 LayerProperty HeatmapLayer::getPaintProperty(const std::string& name) const {
@@ -336,25 +340,25 @@ LayerProperty HeatmapLayer::getPaintProperty(const std::string& name) const {
 
     switch (static_cast<Property>(it->second)) {
         case Property::HeatmapColor:
-            return conversion::makeLayerProperty(getHeatmapColor());
+            return makeLayerProperty(getHeatmapColor());
         case Property::HeatmapIntensity:
-            return conversion::makeLayerProperty(getHeatmapIntensity());
+            return makeLayerProperty(getHeatmapIntensity());
         case Property::HeatmapOpacity:
-            return conversion::makeLayerProperty(getHeatmapOpacity());
+            return makeLayerProperty(getHeatmapOpacity());
         case Property::HeatmapRadius:
-            return conversion::makeLayerProperty(getHeatmapRadius());
+            return makeLayerProperty(getHeatmapRadius());
         case Property::HeatmapWeight:
-            return conversion::makeLayerProperty(getHeatmapWeight());
+            return makeLayerProperty(getHeatmapWeight());
         case Property::HeatmapColorTransition:
-            return conversion::makeLayerProperty(getHeatmapColorTransition());
+            return makeLayerProperty(getHeatmapColorTransition());
         case Property::HeatmapIntensityTransition:
-            return conversion::makeLayerProperty(getHeatmapIntensityTransition());
+            return makeLayerProperty(getHeatmapIntensityTransition());
         case Property::HeatmapOpacityTransition:
-            return conversion::makeLayerProperty(getHeatmapOpacityTransition());
+            return makeLayerProperty(getHeatmapOpacityTransition());
         case Property::HeatmapRadiusTransition:
-            return conversion::makeLayerProperty(getHeatmapRadiusTransition());
+            return makeLayerProperty(getHeatmapRadiusTransition());
         case Property::HeatmapWeightTransition:
-            return conversion::makeLayerProperty(getHeatmapWeightTransition());
+            return makeLayerProperty(getHeatmapWeightTransition());
     }
     return {};
 }

--- a/src/mbgl/style/layers/heatmap_layer.cpp
+++ b/src/mbgl/style/layers/heatmap_layer.cpp
@@ -204,35 +204,38 @@ TransitionOptions HeatmapLayer::getHeatmapWeightTransition() const {
 
 using namespace conversion;
 
+namespace {
+
+enum class Property {
+    HeatmapColor,
+    HeatmapIntensity,
+    HeatmapOpacity,
+    HeatmapRadius,
+    HeatmapWeight,
+    HeatmapColorTransition,
+    HeatmapIntensityTransition,
+    HeatmapOpacityTransition,
+    HeatmapRadiusTransition,
+    HeatmapWeightTransition,
+};
+
+MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+    {{"heatmap-color", mbgl::underlying_type(Property::HeatmapColor)},
+     {"heatmap-intensity", mbgl::underlying_type(Property::HeatmapIntensity)},
+     {"heatmap-opacity", mbgl::underlying_type(Property::HeatmapOpacity)},
+     {"heatmap-radius", mbgl::underlying_type(Property::HeatmapRadius)},
+     {"heatmap-weight", mbgl::underlying_type(Property::HeatmapWeight)},
+     {"heatmap-color-transition", mbgl::underlying_type(Property::HeatmapColorTransition)},
+     {"heatmap-intensity-transition", mbgl::underlying_type(Property::HeatmapIntensityTransition)},
+     {"heatmap-opacity-transition", mbgl::underlying_type(Property::HeatmapOpacityTransition)},
+     {"heatmap-radius-transition", mbgl::underlying_type(Property::HeatmapRadiusTransition)},
+     {"heatmap-weight-transition", mbgl::underlying_type(Property::HeatmapWeightTransition)}});
+
+} // namespace
+
 optional<Error> HeatmapLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-        HeatmapColor,
-        HeatmapIntensity,
-        HeatmapOpacity,
-        HeatmapRadius,
-        HeatmapWeight,
-        HeatmapColorTransition,
-        HeatmapIntensityTransition,
-        HeatmapOpacityTransition,
-        HeatmapRadiusTransition,
-        HeatmapWeightTransition,
-    };
-
-    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        { "heatmap-color", mbgl::underlying_type(Property::HeatmapColor) },
-        { "heatmap-intensity", mbgl::underlying_type(Property::HeatmapIntensity) },
-        { "heatmap-opacity", mbgl::underlying_type(Property::HeatmapOpacity) },
-        { "heatmap-radius", mbgl::underlying_type(Property::HeatmapRadius) },
-        { "heatmap-weight", mbgl::underlying_type(Property::HeatmapWeight) },
-        { "heatmap-color-transition", mbgl::underlying_type(Property::HeatmapColorTransition) },
-        { "heatmap-intensity-transition", mbgl::underlying_type(Property::HeatmapIntensityTransition) },
-        { "heatmap-opacity-transition", mbgl::underlying_type(Property::HeatmapOpacityTransition) },
-        { "heatmap-radius-transition", mbgl::underlying_type(Property::HeatmapRadiusTransition) },
-        { "heatmap-weight-transition", mbgl::underlying_type(Property::HeatmapWeightTransition) }
-    });
-
-    const auto it = properties.find(name.c_str());
-    if (it == properties.end()) {
+    const auto it = paintProperties.find(name.c_str());
+    if (it == paintProperties.end()) {
         return Error { "layer doesn't support this property" };
     }
 
@@ -323,6 +326,37 @@ optional<Error> HeatmapLayer::setPaintProperty(const std::string& name, const Co
     
 
     return Error { "layer doesn't support this property" };
+}
+
+LayerProperty HeatmapLayer::getPaintProperty(const std::string& name) const {
+    const auto it = paintProperties.find(name.c_str());
+    if (it == paintProperties.end()) {
+        return {};
+    }
+
+    switch (static_cast<Property>(it->second)) {
+        case Property::HeatmapColor:
+            return conversion::makeLayerProperty(getHeatmapColor());
+        case Property::HeatmapIntensity:
+            return conversion::makeLayerProperty(getHeatmapIntensity());
+        case Property::HeatmapOpacity:
+            return conversion::makeLayerProperty(getHeatmapOpacity());
+        case Property::HeatmapRadius:
+            return conversion::makeLayerProperty(getHeatmapRadius());
+        case Property::HeatmapWeight:
+            return conversion::makeLayerProperty(getHeatmapWeight());
+        case Property::HeatmapColorTransition:
+            return conversion::makeLayerProperty(getHeatmapColorTransition());
+        case Property::HeatmapIntensityTransition:
+            return conversion::makeLayerProperty(getHeatmapIntensityTransition());
+        case Property::HeatmapOpacityTransition:
+            return conversion::makeLayerProperty(getHeatmapOpacityTransition());
+        case Property::HeatmapRadiusTransition:
+            return conversion::makeLayerProperty(getHeatmapRadiusTransition());
+        case Property::HeatmapWeightTransition:
+            return conversion::makeLayerProperty(getHeatmapWeightTransition());
+    }
+    return {};
 }
 
 optional<Error> HeatmapLayer::setLayoutProperty(const std::string& name, const Convertible& value) {

--- a/src/mbgl/style/layers/hillshade_layer.cpp
+++ b/src/mbgl/style/layers/hillshade_layer.cpp
@@ -231,7 +231,7 @@ using namespace conversion;
 
 namespace {
 
-enum class Property {
+enum class Property : uint8_t {
     HillshadeAccentColor,
     HillshadeExaggeration,
     HillshadeHighlightColor,
@@ -371,7 +371,7 @@ optional<Error> HillshadeLayer::setPaintProperty(const std::string& name, const 
     return Error{"layer doesn't support this property"};
 }
 
-LayerProperty HillshadeLayer::getPaintProperty(const std::string& name) const {
+StyleProperty HillshadeLayer::getPaintProperty(const std::string& name) const {
     const auto it = paintProperties.find(name.c_str());
     if (it == paintProperties.end()) {
         return {};
@@ -379,29 +379,29 @@ LayerProperty HillshadeLayer::getPaintProperty(const std::string& name) const {
 
     switch (static_cast<Property>(it->second)) {
         case Property::HillshadeAccentColor:
-            return makeLayerProperty(getHillshadeAccentColor());
+            return makeStyleProperty(getHillshadeAccentColor());
         case Property::HillshadeExaggeration:
-            return makeLayerProperty(getHillshadeExaggeration());
+            return makeStyleProperty(getHillshadeExaggeration());
         case Property::HillshadeHighlightColor:
-            return makeLayerProperty(getHillshadeHighlightColor());
+            return makeStyleProperty(getHillshadeHighlightColor());
         case Property::HillshadeIlluminationAnchor:
-            return makeLayerProperty(getHillshadeIlluminationAnchor());
+            return makeStyleProperty(getHillshadeIlluminationAnchor());
         case Property::HillshadeIlluminationDirection:
-            return makeLayerProperty(getHillshadeIlluminationDirection());
+            return makeStyleProperty(getHillshadeIlluminationDirection());
         case Property::HillshadeShadowColor:
-            return makeLayerProperty(getHillshadeShadowColor());
+            return makeStyleProperty(getHillshadeShadowColor());
         case Property::HillshadeAccentColorTransition:
-            return makeLayerProperty(getHillshadeAccentColorTransition());
+            return makeStyleProperty(getHillshadeAccentColorTransition());
         case Property::HillshadeExaggerationTransition:
-            return makeLayerProperty(getHillshadeExaggerationTransition());
+            return makeStyleProperty(getHillshadeExaggerationTransition());
         case Property::HillshadeHighlightColorTransition:
-            return makeLayerProperty(getHillshadeHighlightColorTransition());
+            return makeStyleProperty(getHillshadeHighlightColorTransition());
         case Property::HillshadeIlluminationAnchorTransition:
-            return makeLayerProperty(getHillshadeIlluminationAnchorTransition());
+            return makeStyleProperty(getHillshadeIlluminationAnchorTransition());
         case Property::HillshadeIlluminationDirectionTransition:
-            return makeLayerProperty(getHillshadeIlluminationDirectionTransition());
+            return makeStyleProperty(getHillshadeIlluminationDirectionTransition());
         case Property::HillshadeShadowColorTransition:
-            return makeLayerProperty(getHillshadeShadowColorTransition());
+            return makeStyleProperty(getHillshadeShadowColorTransition());
     }
     return {};
 }

--- a/src/mbgl/style/layers/hillshade_layer.cpp
+++ b/src/mbgl/style/layers/hillshade_layer.cpp
@@ -246,26 +246,31 @@ enum class Property {
     HillshadeShadowColorTransition,
 };
 
+template <typename T>
+constexpr uint8_t toUint8(T t) noexcept {
+    return uint8_t(mbgl::underlying_type(t));
+}
+
 MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
-    {{"hillshade-accent-color", mbgl::underlying_type(Property::HillshadeAccentColor)},
-     {"hillshade-exaggeration", mbgl::underlying_type(Property::HillshadeExaggeration)},
-     {"hillshade-highlight-color", mbgl::underlying_type(Property::HillshadeHighlightColor)},
-     {"hillshade-illumination-anchor", mbgl::underlying_type(Property::HillshadeIlluminationAnchor)},
-     {"hillshade-illumination-direction", mbgl::underlying_type(Property::HillshadeIlluminationDirection)},
-     {"hillshade-shadow-color", mbgl::underlying_type(Property::HillshadeShadowColor)},
-     {"hillshade-accent-color-transition", mbgl::underlying_type(Property::HillshadeAccentColorTransition)},
-     {"hillshade-exaggeration-transition", mbgl::underlying_type(Property::HillshadeExaggerationTransition)},
-     {"hillshade-highlight-color-transition", mbgl::underlying_type(Property::HillshadeHighlightColorTransition)},
-     {"hillshade-illumination-anchor-transition", mbgl::underlying_type(Property::HillshadeIlluminationAnchorTransition)},
-     {"hillshade-illumination-direction-transition", mbgl::underlying_type(Property::HillshadeIlluminationDirectionTransition)},
-     {"hillshade-shadow-color-transition", mbgl::underlying_type(Property::HillshadeShadowColorTransition)}});
+    {{"hillshade-accent-color", toUint8(Property::HillshadeAccentColor)},
+     {"hillshade-exaggeration", toUint8(Property::HillshadeExaggeration)},
+     {"hillshade-highlight-color", toUint8(Property::HillshadeHighlightColor)},
+     {"hillshade-illumination-anchor", toUint8(Property::HillshadeIlluminationAnchor)},
+     {"hillshade-illumination-direction", toUint8(Property::HillshadeIlluminationDirection)},
+     {"hillshade-shadow-color", toUint8(Property::HillshadeShadowColor)},
+     {"hillshade-accent-color-transition", toUint8(Property::HillshadeAccentColorTransition)},
+     {"hillshade-exaggeration-transition", toUint8(Property::HillshadeExaggerationTransition)},
+     {"hillshade-highlight-color-transition", toUint8(Property::HillshadeHighlightColorTransition)},
+     {"hillshade-illumination-anchor-transition", toUint8(Property::HillshadeIlluminationAnchorTransition)},
+     {"hillshade-illumination-direction-transition", toUint8(Property::HillshadeIlluminationDirectionTransition)},
+     {"hillshade-shadow-color-transition", toUint8(Property::HillshadeShadowColorTransition)}});
 
 } // namespace
 
 optional<Error> HillshadeLayer::setPaintProperty(const std::string& name, const Convertible& value) {
     const auto it = paintProperties.find(name.c_str());
     if (it == paintProperties.end()) {
-        return Error { "layer doesn't support this property" };
+        return Error{"layer doesn't support this property"};
     }
 
     auto property = static_cast<Property>(it->second);
@@ -332,39 +337,38 @@ optional<Error> HillshadeLayer::setPaintProperty(const std::string& name, const 
     if (!transition) {
         return error;
     }
-    
+
     if (property == Property::HillshadeAccentColorTransition) {
         setHillshadeAccentColorTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::HillshadeExaggerationTransition) {
         setHillshadeExaggerationTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::HillshadeHighlightColorTransition) {
         setHillshadeHighlightColorTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::HillshadeIlluminationAnchorTransition) {
         setHillshadeIlluminationAnchorTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::HillshadeIlluminationDirectionTransition) {
         setHillshadeIlluminationDirectionTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::HillshadeShadowColorTransition) {
         setHillshadeShadowColorTransition(*transition);
         return nullopt;
     }
-    
 
-    return Error { "layer doesn't support this property" };
+    return Error{"layer doesn't support this property"};
 }
 
 LayerProperty HillshadeLayer::getPaintProperty(const std::string& name) const {
@@ -375,29 +379,29 @@ LayerProperty HillshadeLayer::getPaintProperty(const std::string& name) const {
 
     switch (static_cast<Property>(it->second)) {
         case Property::HillshadeAccentColor:
-            return conversion::makeLayerProperty(getHillshadeAccentColor());
+            return makeLayerProperty(getHillshadeAccentColor());
         case Property::HillshadeExaggeration:
-            return conversion::makeLayerProperty(getHillshadeExaggeration());
+            return makeLayerProperty(getHillshadeExaggeration());
         case Property::HillshadeHighlightColor:
-            return conversion::makeLayerProperty(getHillshadeHighlightColor());
+            return makeLayerProperty(getHillshadeHighlightColor());
         case Property::HillshadeIlluminationAnchor:
-            return conversion::makeLayerProperty(getHillshadeIlluminationAnchor());
+            return makeLayerProperty(getHillshadeIlluminationAnchor());
         case Property::HillshadeIlluminationDirection:
-            return conversion::makeLayerProperty(getHillshadeIlluminationDirection());
+            return makeLayerProperty(getHillshadeIlluminationDirection());
         case Property::HillshadeShadowColor:
-            return conversion::makeLayerProperty(getHillshadeShadowColor());
+            return makeLayerProperty(getHillshadeShadowColor());
         case Property::HillshadeAccentColorTransition:
-            return conversion::makeLayerProperty(getHillshadeAccentColorTransition());
+            return makeLayerProperty(getHillshadeAccentColorTransition());
         case Property::HillshadeExaggerationTransition:
-            return conversion::makeLayerProperty(getHillshadeExaggerationTransition());
+            return makeLayerProperty(getHillshadeExaggerationTransition());
         case Property::HillshadeHighlightColorTransition:
-            return conversion::makeLayerProperty(getHillshadeHighlightColorTransition());
+            return makeLayerProperty(getHillshadeHighlightColorTransition());
         case Property::HillshadeIlluminationAnchorTransition:
-            return conversion::makeLayerProperty(getHillshadeIlluminationAnchorTransition());
+            return makeLayerProperty(getHillshadeIlluminationAnchorTransition());
         case Property::HillshadeIlluminationDirectionTransition:
-            return conversion::makeLayerProperty(getHillshadeIlluminationDirectionTransition());
+            return makeLayerProperty(getHillshadeIlluminationDirectionTransition());
         case Property::HillshadeShadowColorTransition:
-            return conversion::makeLayerProperty(getHillshadeShadowColorTransition());
+            return makeLayerProperty(getHillshadeShadowColorTransition());
     }
     return {};
 }

--- a/src/mbgl/style/layers/hillshade_layer.cpp
+++ b/src/mbgl/style/layers/hillshade_layer.cpp
@@ -229,39 +229,42 @@ TransitionOptions HillshadeLayer::getHillshadeShadowColorTransition() const {
 
 using namespace conversion;
 
+namespace {
+
+enum class Property {
+    HillshadeAccentColor,
+    HillshadeExaggeration,
+    HillshadeHighlightColor,
+    HillshadeIlluminationAnchor,
+    HillshadeIlluminationDirection,
+    HillshadeShadowColor,
+    HillshadeAccentColorTransition,
+    HillshadeExaggerationTransition,
+    HillshadeHighlightColorTransition,
+    HillshadeIlluminationAnchorTransition,
+    HillshadeIlluminationDirectionTransition,
+    HillshadeShadowColorTransition,
+};
+
+MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+    {{"hillshade-accent-color", mbgl::underlying_type(Property::HillshadeAccentColor)},
+     {"hillshade-exaggeration", mbgl::underlying_type(Property::HillshadeExaggeration)},
+     {"hillshade-highlight-color", mbgl::underlying_type(Property::HillshadeHighlightColor)},
+     {"hillshade-illumination-anchor", mbgl::underlying_type(Property::HillshadeIlluminationAnchor)},
+     {"hillshade-illumination-direction", mbgl::underlying_type(Property::HillshadeIlluminationDirection)},
+     {"hillshade-shadow-color", mbgl::underlying_type(Property::HillshadeShadowColor)},
+     {"hillshade-accent-color-transition", mbgl::underlying_type(Property::HillshadeAccentColorTransition)},
+     {"hillshade-exaggeration-transition", mbgl::underlying_type(Property::HillshadeExaggerationTransition)},
+     {"hillshade-highlight-color-transition", mbgl::underlying_type(Property::HillshadeHighlightColorTransition)},
+     {"hillshade-illumination-anchor-transition", mbgl::underlying_type(Property::HillshadeIlluminationAnchorTransition)},
+     {"hillshade-illumination-direction-transition", mbgl::underlying_type(Property::HillshadeIlluminationDirectionTransition)},
+     {"hillshade-shadow-color-transition", mbgl::underlying_type(Property::HillshadeShadowColorTransition)}});
+
+} // namespace
+
 optional<Error> HillshadeLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-        HillshadeAccentColor,
-        HillshadeExaggeration,
-        HillshadeHighlightColor,
-        HillshadeIlluminationAnchor,
-        HillshadeIlluminationDirection,
-        HillshadeShadowColor,
-        HillshadeAccentColorTransition,
-        HillshadeExaggerationTransition,
-        HillshadeHighlightColorTransition,
-        HillshadeIlluminationAnchorTransition,
-        HillshadeIlluminationDirectionTransition,
-        HillshadeShadowColorTransition,
-    };
-
-    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        { "hillshade-accent-color", mbgl::underlying_type(Property::HillshadeAccentColor) },
-        { "hillshade-exaggeration", mbgl::underlying_type(Property::HillshadeExaggeration) },
-        { "hillshade-highlight-color", mbgl::underlying_type(Property::HillshadeHighlightColor) },
-        { "hillshade-illumination-anchor", mbgl::underlying_type(Property::HillshadeIlluminationAnchor) },
-        { "hillshade-illumination-direction", mbgl::underlying_type(Property::HillshadeIlluminationDirection) },
-        { "hillshade-shadow-color", mbgl::underlying_type(Property::HillshadeShadowColor) },
-        { "hillshade-accent-color-transition", mbgl::underlying_type(Property::HillshadeAccentColorTransition) },
-        { "hillshade-exaggeration-transition", mbgl::underlying_type(Property::HillshadeExaggerationTransition) },
-        { "hillshade-highlight-color-transition", mbgl::underlying_type(Property::HillshadeHighlightColorTransition) },
-        { "hillshade-illumination-anchor-transition", mbgl::underlying_type(Property::HillshadeIlluminationAnchorTransition) },
-        { "hillshade-illumination-direction-transition", mbgl::underlying_type(Property::HillshadeIlluminationDirectionTransition) },
-        { "hillshade-shadow-color-transition", mbgl::underlying_type(Property::HillshadeShadowColorTransition) }
-    });
-
-    const auto it = properties.find(name.c_str());
-    if (it == properties.end()) {
+    const auto it = paintProperties.find(name.c_str());
+    if (it == paintProperties.end()) {
         return Error { "layer doesn't support this property" };
     }
 
@@ -362,6 +365,41 @@ optional<Error> HillshadeLayer::setPaintProperty(const std::string& name, const 
     
 
     return Error { "layer doesn't support this property" };
+}
+
+LayerProperty HillshadeLayer::getPaintProperty(const std::string& name) const {
+    const auto it = paintProperties.find(name.c_str());
+    if (it == paintProperties.end()) {
+        return {};
+    }
+
+    switch (static_cast<Property>(it->second)) {
+        case Property::HillshadeAccentColor:
+            return conversion::makeLayerProperty(getHillshadeAccentColor());
+        case Property::HillshadeExaggeration:
+            return conversion::makeLayerProperty(getHillshadeExaggeration());
+        case Property::HillshadeHighlightColor:
+            return conversion::makeLayerProperty(getHillshadeHighlightColor());
+        case Property::HillshadeIlluminationAnchor:
+            return conversion::makeLayerProperty(getHillshadeIlluminationAnchor());
+        case Property::HillshadeIlluminationDirection:
+            return conversion::makeLayerProperty(getHillshadeIlluminationDirection());
+        case Property::HillshadeShadowColor:
+            return conversion::makeLayerProperty(getHillshadeShadowColor());
+        case Property::HillshadeAccentColorTransition:
+            return conversion::makeLayerProperty(getHillshadeAccentColorTransition());
+        case Property::HillshadeExaggerationTransition:
+            return conversion::makeLayerProperty(getHillshadeExaggerationTransition());
+        case Property::HillshadeHighlightColorTransition:
+            return conversion::makeLayerProperty(getHillshadeHighlightColorTransition());
+        case Property::HillshadeIlluminationAnchorTransition:
+            return conversion::makeLayerProperty(getHillshadeIlluminationAnchorTransition());
+        case Property::HillshadeIlluminationDirectionTransition:
+            return conversion::makeLayerProperty(getHillshadeIlluminationDirectionTransition());
+        case Property::HillshadeShadowColorTransition:
+            return conversion::makeLayerProperty(getHillshadeShadowColorTransition());
+    }
+    return {};
 }
 
 optional<Error> HillshadeLayer::setLayoutProperty(const std::string& name, const Convertible& value) {

--- a/src/mbgl/style/layers/layer.cpp.ejs
+++ b/src/mbgl/style/layers/layer.cpp.ejs
@@ -201,16 +201,21 @@ enum class Property {
 <% } -%>
 };
 
+template <typename T>
+constexpr uint8_t toUint8(T t) noexcept {
+    return uint8_t(mbgl::underlying_type(t));
+}
+
 MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
-    {<%- paintProperties.map(p => `{"${p.name}", mbgl::underlying_type(Property::${camelize(p.name)})}`).join(',\n     ') %>,
-     <%- paintProperties.map(p => `{"${p.name}-transition", mbgl::underlying_type(Property::${camelize(p.name)}Transition)}`).join(',\n     ') %>});
+    {<%- paintProperties.map(p => `{"${p.name}", toUint8(Property::${camelize(p.name)})}`).join(',\n     ') %>,
+     <%- paintProperties.map(p => `{"${p.name}-transition", toUint8(Property::${camelize(p.name)}Transition)}`).join(',\n     ') %>});
 
 } // namespace
 
 optional<Error> <%- camelize(type) %>Layer::setPaintProperty(const std::string& name, const Convertible& value) {
     const auto it = paintProperties.find(name.c_str());
     if (it == paintProperties.end()) {
-        return Error { "layer doesn't support this property" };
+        return Error{"layer doesn't support this property"};
     }
 
     auto property = static_cast<Property>(it->second);
@@ -251,14 +256,13 @@ optional<Error> <%- camelize(type) %>Layer::setPaintProperty(const std::string& 
     if (!transition) {
         return error;
     }
-    <% for (const property of paintProperties) { %>
+<% for (const property of paintProperties) { %>
     if (property == Property::<%- camelize(property.name) %>Transition) {
         set<%- camelize(property.name) %>Transition(*transition);
         return nullopt;
     }
-    <% } %>
-
-    return Error { "layer doesn't support this property" };
+<% } %>
+    return Error{"layer doesn't support this property"};
 }
 
 LayerProperty <%- camelize(type) %>Layer::getPaintProperty(const std::string& name) const {
@@ -270,11 +274,11 @@ LayerProperty <%- camelize(type) %>Layer::getPaintProperty(const std::string& na
     switch (static_cast<Property>(it->second)) {
 <% for (const property of paintProperties) { -%>
         case Property::<%- camelize(property.name) %>:
-            return conversion::makeLayerProperty(get<%- camelize(property.name) %>());
+            return makeLayerProperty(get<%- camelize(property.name) %>());
 <% } -%>
 <% for (const property of paintProperties) { -%>
         case Property::<%- camelize(property.name) %>Transition:
-            return conversion::makeLayerProperty(get<%- camelize(property.name) %>Transition());
+            return makeLayerProperty(get<%- camelize(property.name) %>Transition());
 <% } -%>
     }
     return {};

--- a/src/mbgl/style/layers/layer.cpp.ejs
+++ b/src/mbgl/style/layers/layer.cpp.ejs
@@ -192,7 +192,7 @@ using namespace conversion;
 
 namespace {
 
-enum class Property {
+enum class Property : uint8_t {
 <% for (const property of paintProperties) { -%>
     <%- camelize(property.name) %>,
 <% } -%>
@@ -265,7 +265,7 @@ optional<Error> <%- camelize(type) %>Layer::setPaintProperty(const std::string& 
     return Error{"layer doesn't support this property"};
 }
 
-LayerProperty <%- camelize(type) %>Layer::getPaintProperty(const std::string& name) const {
+StyleProperty <%- camelize(type) %>Layer::getPaintProperty(const std::string& name) const {
     const auto it = paintProperties.find(name.c_str());
     if (it == paintProperties.end()) {
         return {};
@@ -274,11 +274,11 @@ LayerProperty <%- camelize(type) %>Layer::getPaintProperty(const std::string& na
     switch (static_cast<Property>(it->second)) {
 <% for (const property of paintProperties) { -%>
         case Property::<%- camelize(property.name) %>:
-            return makeLayerProperty(get<%- camelize(property.name) %>());
+            return makeStyleProperty(get<%- camelize(property.name) %>());
 <% } -%>
 <% for (const property of paintProperties) { -%>
         case Property::<%- camelize(property.name) %>Transition:
-            return makeLayerProperty(get<%- camelize(property.name) %>Transition());
+            return makeStyleProperty(get<%- camelize(property.name) %>Transition());
 <% } -%>
     }
     return {};

--- a/src/mbgl/style/layers/layer.cpp.ejs
+++ b/src/mbgl/style/layers/layer.cpp.ejs
@@ -190,23 +190,26 @@ TransitionOptions <%- camelize(type) %>Layer::get<%- camelize(property.name) %>T
 
 using namespace conversion;
 
+namespace {
+
+enum class Property {
+<% for (const property of paintProperties) { -%>
+    <%- camelize(property.name) %>,
+<% } -%>
+<% for (const property of paintProperties) { -%>
+    <%- camelize(property.name) %>Transition,
+<% } -%>
+};
+
+MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+    {<%- paintProperties.map(p => `{"${p.name}", mbgl::underlying_type(Property::${camelize(p.name)})}`).join(',\n     ') %>,
+     <%- paintProperties.map(p => `{"${p.name}-transition", mbgl::underlying_type(Property::${camelize(p.name)}Transition)}`).join(',\n     ') %>});
+
+} // namespace
+
 optional<Error> <%- camelize(type) %>Layer::setPaintProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-<% for (const property of paintProperties) { -%>
-        <%- camelize(property.name) %>,
-<% } -%>
-<% for (const property of paintProperties) { -%>
-        <%- camelize(property.name) %>Transition,
-<% } -%>
-    };
-
-    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        <%- paintProperties.map(p => `{ "${p.name}", mbgl::underlying_type(Property::${camelize(p.name)}) }`).join(',\n        ') %>,
-        <%- paintProperties.map(p => `{ "${p.name}-transition", mbgl::underlying_type(Property::${camelize(p.name)}Transition) }`).join(',\n        ') %>
-    });
-
-    const auto it = properties.find(name.c_str());
-    if (it == properties.end()) {
+    const auto it = paintProperties.find(name.c_str());
+    if (it == paintProperties.end()) {
         return Error { "layer doesn't support this property" };
     }
 
@@ -256,6 +259,25 @@ optional<Error> <%- camelize(type) %>Layer::setPaintProperty(const std::string& 
     <% } %>
 
     return Error { "layer doesn't support this property" };
+}
+
+LayerProperty <%- camelize(type) %>Layer::getPaintProperty(const std::string& name) const {
+    const auto it = paintProperties.find(name.c_str());
+    if (it == paintProperties.end()) {
+        return {};
+    }
+
+    switch (static_cast<Property>(it->second)) {
+<% for (const property of paintProperties) { -%>
+        case Property::<%- camelize(property.name) %>:
+            return conversion::makeLayerProperty(get<%- camelize(property.name) %>());
+<% } -%>
+<% for (const property of paintProperties) { -%>
+        case Property::<%- camelize(property.name) %>Transition:
+            return conversion::makeLayerProperty(get<%- camelize(property.name) %>Transition());
+<% } -%>
+    }
+    return {};
 }
 
 optional<Error> <%- camelize(type) %>Layer::setLayoutProperty(const std::string& name, const Convertible& value) {

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -430,59 +430,62 @@ TransitionOptions LineLayer::getLineWidthTransition() const {
 
 using namespace conversion;
 
+namespace {
+
+enum class Property {
+    LineBlur,
+    LineColor,
+    LineDasharray,
+    LineGapWidth,
+    LineGradient,
+    LineOffset,
+    LineOpacity,
+    LinePattern,
+    LineTranslate,
+    LineTranslateAnchor,
+    LineWidth,
+    LineBlurTransition,
+    LineColorTransition,
+    LineDasharrayTransition,
+    LineGapWidthTransition,
+    LineGradientTransition,
+    LineOffsetTransition,
+    LineOpacityTransition,
+    LinePatternTransition,
+    LineTranslateTransition,
+    LineTranslateAnchorTransition,
+    LineWidthTransition,
+};
+
+MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+    {{"line-blur", mbgl::underlying_type(Property::LineBlur)},
+     {"line-color", mbgl::underlying_type(Property::LineColor)},
+     {"line-dasharray", mbgl::underlying_type(Property::LineDasharray)},
+     {"line-gap-width", mbgl::underlying_type(Property::LineGapWidth)},
+     {"line-gradient", mbgl::underlying_type(Property::LineGradient)},
+     {"line-offset", mbgl::underlying_type(Property::LineOffset)},
+     {"line-opacity", mbgl::underlying_type(Property::LineOpacity)},
+     {"line-pattern", mbgl::underlying_type(Property::LinePattern)},
+     {"line-translate", mbgl::underlying_type(Property::LineTranslate)},
+     {"line-translate-anchor", mbgl::underlying_type(Property::LineTranslateAnchor)},
+     {"line-width", mbgl::underlying_type(Property::LineWidth)},
+     {"line-blur-transition", mbgl::underlying_type(Property::LineBlurTransition)},
+     {"line-color-transition", mbgl::underlying_type(Property::LineColorTransition)},
+     {"line-dasharray-transition", mbgl::underlying_type(Property::LineDasharrayTransition)},
+     {"line-gap-width-transition", mbgl::underlying_type(Property::LineGapWidthTransition)},
+     {"line-gradient-transition", mbgl::underlying_type(Property::LineGradientTransition)},
+     {"line-offset-transition", mbgl::underlying_type(Property::LineOffsetTransition)},
+     {"line-opacity-transition", mbgl::underlying_type(Property::LineOpacityTransition)},
+     {"line-pattern-transition", mbgl::underlying_type(Property::LinePatternTransition)},
+     {"line-translate-transition", mbgl::underlying_type(Property::LineTranslateTransition)},
+     {"line-translate-anchor-transition", mbgl::underlying_type(Property::LineTranslateAnchorTransition)},
+     {"line-width-transition", mbgl::underlying_type(Property::LineWidthTransition)}});
+
+} // namespace
+
 optional<Error> LineLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-        LineBlur,
-        LineColor,
-        LineDasharray,
-        LineGapWidth,
-        LineGradient,
-        LineOffset,
-        LineOpacity,
-        LinePattern,
-        LineTranslate,
-        LineTranslateAnchor,
-        LineWidth,
-        LineBlurTransition,
-        LineColorTransition,
-        LineDasharrayTransition,
-        LineGapWidthTransition,
-        LineGradientTransition,
-        LineOffsetTransition,
-        LineOpacityTransition,
-        LinePatternTransition,
-        LineTranslateTransition,
-        LineTranslateAnchorTransition,
-        LineWidthTransition,
-    };
-
-    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        { "line-blur", mbgl::underlying_type(Property::LineBlur) },
-        { "line-color", mbgl::underlying_type(Property::LineColor) },
-        { "line-dasharray", mbgl::underlying_type(Property::LineDasharray) },
-        { "line-gap-width", mbgl::underlying_type(Property::LineGapWidth) },
-        { "line-gradient", mbgl::underlying_type(Property::LineGradient) },
-        { "line-offset", mbgl::underlying_type(Property::LineOffset) },
-        { "line-opacity", mbgl::underlying_type(Property::LineOpacity) },
-        { "line-pattern", mbgl::underlying_type(Property::LinePattern) },
-        { "line-translate", mbgl::underlying_type(Property::LineTranslate) },
-        { "line-translate-anchor", mbgl::underlying_type(Property::LineTranslateAnchor) },
-        { "line-width", mbgl::underlying_type(Property::LineWidth) },
-        { "line-blur-transition", mbgl::underlying_type(Property::LineBlurTransition) },
-        { "line-color-transition", mbgl::underlying_type(Property::LineColorTransition) },
-        { "line-dasharray-transition", mbgl::underlying_type(Property::LineDasharrayTransition) },
-        { "line-gap-width-transition", mbgl::underlying_type(Property::LineGapWidthTransition) },
-        { "line-gradient-transition", mbgl::underlying_type(Property::LineGradientTransition) },
-        { "line-offset-transition", mbgl::underlying_type(Property::LineOffsetTransition) },
-        { "line-opacity-transition", mbgl::underlying_type(Property::LineOpacityTransition) },
-        { "line-pattern-transition", mbgl::underlying_type(Property::LinePatternTransition) },
-        { "line-translate-transition", mbgl::underlying_type(Property::LineTranslateTransition) },
-        { "line-translate-anchor-transition", mbgl::underlying_type(Property::LineTranslateAnchorTransition) },
-        { "line-width-transition", mbgl::underlying_type(Property::LineWidthTransition) }
-    });
-
-    const auto it = properties.find(name.c_str());
-    if (it == properties.end()) {
+    const auto it = paintProperties.find(name.c_str());
+    if (it == paintProperties.end()) {
         return Error { "layer doesn't support this property" };
     }
 
@@ -659,6 +662,61 @@ optional<Error> LineLayer::setPaintProperty(const std::string& name, const Conve
     
 
     return Error { "layer doesn't support this property" };
+}
+
+LayerProperty LineLayer::getPaintProperty(const std::string& name) const {
+    const auto it = paintProperties.find(name.c_str());
+    if (it == paintProperties.end()) {
+        return {};
+    }
+
+    switch (static_cast<Property>(it->second)) {
+        case Property::LineBlur:
+            return conversion::makeLayerProperty(getLineBlur());
+        case Property::LineColor:
+            return conversion::makeLayerProperty(getLineColor());
+        case Property::LineDasharray:
+            return conversion::makeLayerProperty(getLineDasharray());
+        case Property::LineGapWidth:
+            return conversion::makeLayerProperty(getLineGapWidth());
+        case Property::LineGradient:
+            return conversion::makeLayerProperty(getLineGradient());
+        case Property::LineOffset:
+            return conversion::makeLayerProperty(getLineOffset());
+        case Property::LineOpacity:
+            return conversion::makeLayerProperty(getLineOpacity());
+        case Property::LinePattern:
+            return conversion::makeLayerProperty(getLinePattern());
+        case Property::LineTranslate:
+            return conversion::makeLayerProperty(getLineTranslate());
+        case Property::LineTranslateAnchor:
+            return conversion::makeLayerProperty(getLineTranslateAnchor());
+        case Property::LineWidth:
+            return conversion::makeLayerProperty(getLineWidth());
+        case Property::LineBlurTransition:
+            return conversion::makeLayerProperty(getLineBlurTransition());
+        case Property::LineColorTransition:
+            return conversion::makeLayerProperty(getLineColorTransition());
+        case Property::LineDasharrayTransition:
+            return conversion::makeLayerProperty(getLineDasharrayTransition());
+        case Property::LineGapWidthTransition:
+            return conversion::makeLayerProperty(getLineGapWidthTransition());
+        case Property::LineGradientTransition:
+            return conversion::makeLayerProperty(getLineGradientTransition());
+        case Property::LineOffsetTransition:
+            return conversion::makeLayerProperty(getLineOffsetTransition());
+        case Property::LineOpacityTransition:
+            return conversion::makeLayerProperty(getLineOpacityTransition());
+        case Property::LinePatternTransition:
+            return conversion::makeLayerProperty(getLinePatternTransition());
+        case Property::LineTranslateTransition:
+            return conversion::makeLayerProperty(getLineTranslateTransition());
+        case Property::LineTranslateAnchorTransition:
+            return conversion::makeLayerProperty(getLineTranslateAnchorTransition());
+        case Property::LineWidthTransition:
+            return conversion::makeLayerProperty(getLineWidthTransition());
+    }
+    return {};
 }
 
 optional<Error> LineLayer::setLayoutProperty(const std::string& name, const Convertible& value) {

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -432,7 +432,7 @@ using namespace conversion;
 
 namespace {
 
-enum class Property {
+enum class Property : uint8_t {
     LineBlur,
     LineColor,
     LineDasharray,
@@ -668,7 +668,7 @@ optional<Error> LineLayer::setPaintProperty(const std::string& name, const Conve
     return Error{"layer doesn't support this property"};
 }
 
-LayerProperty LineLayer::getPaintProperty(const std::string& name) const {
+StyleProperty LineLayer::getPaintProperty(const std::string& name) const {
     const auto it = paintProperties.find(name.c_str());
     if (it == paintProperties.end()) {
         return {};
@@ -676,49 +676,49 @@ LayerProperty LineLayer::getPaintProperty(const std::string& name) const {
 
     switch (static_cast<Property>(it->second)) {
         case Property::LineBlur:
-            return makeLayerProperty(getLineBlur());
+            return makeStyleProperty(getLineBlur());
         case Property::LineColor:
-            return makeLayerProperty(getLineColor());
+            return makeStyleProperty(getLineColor());
         case Property::LineDasharray:
-            return makeLayerProperty(getLineDasharray());
+            return makeStyleProperty(getLineDasharray());
         case Property::LineGapWidth:
-            return makeLayerProperty(getLineGapWidth());
+            return makeStyleProperty(getLineGapWidth());
         case Property::LineGradient:
-            return makeLayerProperty(getLineGradient());
+            return makeStyleProperty(getLineGradient());
         case Property::LineOffset:
-            return makeLayerProperty(getLineOffset());
+            return makeStyleProperty(getLineOffset());
         case Property::LineOpacity:
-            return makeLayerProperty(getLineOpacity());
+            return makeStyleProperty(getLineOpacity());
         case Property::LinePattern:
-            return makeLayerProperty(getLinePattern());
+            return makeStyleProperty(getLinePattern());
         case Property::LineTranslate:
-            return makeLayerProperty(getLineTranslate());
+            return makeStyleProperty(getLineTranslate());
         case Property::LineTranslateAnchor:
-            return makeLayerProperty(getLineTranslateAnchor());
+            return makeStyleProperty(getLineTranslateAnchor());
         case Property::LineWidth:
-            return makeLayerProperty(getLineWidth());
+            return makeStyleProperty(getLineWidth());
         case Property::LineBlurTransition:
-            return makeLayerProperty(getLineBlurTransition());
+            return makeStyleProperty(getLineBlurTransition());
         case Property::LineColorTransition:
-            return makeLayerProperty(getLineColorTransition());
+            return makeStyleProperty(getLineColorTransition());
         case Property::LineDasharrayTransition:
-            return makeLayerProperty(getLineDasharrayTransition());
+            return makeStyleProperty(getLineDasharrayTransition());
         case Property::LineGapWidthTransition:
-            return makeLayerProperty(getLineGapWidthTransition());
+            return makeStyleProperty(getLineGapWidthTransition());
         case Property::LineGradientTransition:
-            return makeLayerProperty(getLineGradientTransition());
+            return makeStyleProperty(getLineGradientTransition());
         case Property::LineOffsetTransition:
-            return makeLayerProperty(getLineOffsetTransition());
+            return makeStyleProperty(getLineOffsetTransition());
         case Property::LineOpacityTransition:
-            return makeLayerProperty(getLineOpacityTransition());
+            return makeStyleProperty(getLineOpacityTransition());
         case Property::LinePatternTransition:
-            return makeLayerProperty(getLinePatternTransition());
+            return makeStyleProperty(getLinePatternTransition());
         case Property::LineTranslateTransition:
-            return makeLayerProperty(getLineTranslateTransition());
+            return makeStyleProperty(getLineTranslateTransition());
         case Property::LineTranslateAnchorTransition:
-            return makeLayerProperty(getLineTranslateAnchorTransition());
+            return makeStyleProperty(getLineTranslateAnchorTransition());
         case Property::LineWidthTransition:
-            return makeLayerProperty(getLineWidthTransition());
+            return makeStyleProperty(getLineWidthTransition());
     }
     return {};
 }

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -457,36 +457,41 @@ enum class Property {
     LineWidthTransition,
 };
 
+template <typename T>
+constexpr uint8_t toUint8(T t) noexcept {
+    return uint8_t(mbgl::underlying_type(t));
+}
+
 MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
-    {{"line-blur", mbgl::underlying_type(Property::LineBlur)},
-     {"line-color", mbgl::underlying_type(Property::LineColor)},
-     {"line-dasharray", mbgl::underlying_type(Property::LineDasharray)},
-     {"line-gap-width", mbgl::underlying_type(Property::LineGapWidth)},
-     {"line-gradient", mbgl::underlying_type(Property::LineGradient)},
-     {"line-offset", mbgl::underlying_type(Property::LineOffset)},
-     {"line-opacity", mbgl::underlying_type(Property::LineOpacity)},
-     {"line-pattern", mbgl::underlying_type(Property::LinePattern)},
-     {"line-translate", mbgl::underlying_type(Property::LineTranslate)},
-     {"line-translate-anchor", mbgl::underlying_type(Property::LineTranslateAnchor)},
-     {"line-width", mbgl::underlying_type(Property::LineWidth)},
-     {"line-blur-transition", mbgl::underlying_type(Property::LineBlurTransition)},
-     {"line-color-transition", mbgl::underlying_type(Property::LineColorTransition)},
-     {"line-dasharray-transition", mbgl::underlying_type(Property::LineDasharrayTransition)},
-     {"line-gap-width-transition", mbgl::underlying_type(Property::LineGapWidthTransition)},
-     {"line-gradient-transition", mbgl::underlying_type(Property::LineGradientTransition)},
-     {"line-offset-transition", mbgl::underlying_type(Property::LineOffsetTransition)},
-     {"line-opacity-transition", mbgl::underlying_type(Property::LineOpacityTransition)},
-     {"line-pattern-transition", mbgl::underlying_type(Property::LinePatternTransition)},
-     {"line-translate-transition", mbgl::underlying_type(Property::LineTranslateTransition)},
-     {"line-translate-anchor-transition", mbgl::underlying_type(Property::LineTranslateAnchorTransition)},
-     {"line-width-transition", mbgl::underlying_type(Property::LineWidthTransition)}});
+    {{"line-blur", toUint8(Property::LineBlur)},
+     {"line-color", toUint8(Property::LineColor)},
+     {"line-dasharray", toUint8(Property::LineDasharray)},
+     {"line-gap-width", toUint8(Property::LineGapWidth)},
+     {"line-gradient", toUint8(Property::LineGradient)},
+     {"line-offset", toUint8(Property::LineOffset)},
+     {"line-opacity", toUint8(Property::LineOpacity)},
+     {"line-pattern", toUint8(Property::LinePattern)},
+     {"line-translate", toUint8(Property::LineTranslate)},
+     {"line-translate-anchor", toUint8(Property::LineTranslateAnchor)},
+     {"line-width", toUint8(Property::LineWidth)},
+     {"line-blur-transition", toUint8(Property::LineBlurTransition)},
+     {"line-color-transition", toUint8(Property::LineColorTransition)},
+     {"line-dasharray-transition", toUint8(Property::LineDasharrayTransition)},
+     {"line-gap-width-transition", toUint8(Property::LineGapWidthTransition)},
+     {"line-gradient-transition", toUint8(Property::LineGradientTransition)},
+     {"line-offset-transition", toUint8(Property::LineOffsetTransition)},
+     {"line-opacity-transition", toUint8(Property::LineOpacityTransition)},
+     {"line-pattern-transition", toUint8(Property::LinePatternTransition)},
+     {"line-translate-transition", toUint8(Property::LineTranslateTransition)},
+     {"line-translate-anchor-transition", toUint8(Property::LineTranslateAnchorTransition)},
+     {"line-width-transition", toUint8(Property::LineWidthTransition)}});
 
 } // namespace
 
 optional<Error> LineLayer::setPaintProperty(const std::string& name, const Convertible& value) {
     const auto it = paintProperties.find(name.c_str());
     if (it == paintProperties.end()) {
-        return Error { "layer doesn't support this property" };
+        return Error{"layer doesn't support this property"};
     }
 
     auto property = static_cast<Property>(it->second);
@@ -604,64 +609,63 @@ optional<Error> LineLayer::setPaintProperty(const std::string& name, const Conve
     if (!transition) {
         return error;
     }
-    
+
     if (property == Property::LineBlurTransition) {
         setLineBlurTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::LineColorTransition) {
         setLineColorTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::LineDasharrayTransition) {
         setLineDasharrayTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::LineGapWidthTransition) {
         setLineGapWidthTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::LineGradientTransition) {
         setLineGradientTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::LineOffsetTransition) {
         setLineOffsetTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::LineOpacityTransition) {
         setLineOpacityTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::LinePatternTransition) {
         setLinePatternTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::LineTranslateTransition) {
         setLineTranslateTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::LineTranslateAnchorTransition) {
         setLineTranslateAnchorTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::LineWidthTransition) {
         setLineWidthTransition(*transition);
         return nullopt;
     }
-    
 
-    return Error { "layer doesn't support this property" };
+    return Error{"layer doesn't support this property"};
 }
 
 LayerProperty LineLayer::getPaintProperty(const std::string& name) const {
@@ -672,49 +676,49 @@ LayerProperty LineLayer::getPaintProperty(const std::string& name) const {
 
     switch (static_cast<Property>(it->second)) {
         case Property::LineBlur:
-            return conversion::makeLayerProperty(getLineBlur());
+            return makeLayerProperty(getLineBlur());
         case Property::LineColor:
-            return conversion::makeLayerProperty(getLineColor());
+            return makeLayerProperty(getLineColor());
         case Property::LineDasharray:
-            return conversion::makeLayerProperty(getLineDasharray());
+            return makeLayerProperty(getLineDasharray());
         case Property::LineGapWidth:
-            return conversion::makeLayerProperty(getLineGapWidth());
+            return makeLayerProperty(getLineGapWidth());
         case Property::LineGradient:
-            return conversion::makeLayerProperty(getLineGradient());
+            return makeLayerProperty(getLineGradient());
         case Property::LineOffset:
-            return conversion::makeLayerProperty(getLineOffset());
+            return makeLayerProperty(getLineOffset());
         case Property::LineOpacity:
-            return conversion::makeLayerProperty(getLineOpacity());
+            return makeLayerProperty(getLineOpacity());
         case Property::LinePattern:
-            return conversion::makeLayerProperty(getLinePattern());
+            return makeLayerProperty(getLinePattern());
         case Property::LineTranslate:
-            return conversion::makeLayerProperty(getLineTranslate());
+            return makeLayerProperty(getLineTranslate());
         case Property::LineTranslateAnchor:
-            return conversion::makeLayerProperty(getLineTranslateAnchor());
+            return makeLayerProperty(getLineTranslateAnchor());
         case Property::LineWidth:
-            return conversion::makeLayerProperty(getLineWidth());
+            return makeLayerProperty(getLineWidth());
         case Property::LineBlurTransition:
-            return conversion::makeLayerProperty(getLineBlurTransition());
+            return makeLayerProperty(getLineBlurTransition());
         case Property::LineColorTransition:
-            return conversion::makeLayerProperty(getLineColorTransition());
+            return makeLayerProperty(getLineColorTransition());
         case Property::LineDasharrayTransition:
-            return conversion::makeLayerProperty(getLineDasharrayTransition());
+            return makeLayerProperty(getLineDasharrayTransition());
         case Property::LineGapWidthTransition:
-            return conversion::makeLayerProperty(getLineGapWidthTransition());
+            return makeLayerProperty(getLineGapWidthTransition());
         case Property::LineGradientTransition:
-            return conversion::makeLayerProperty(getLineGradientTransition());
+            return makeLayerProperty(getLineGradientTransition());
         case Property::LineOffsetTransition:
-            return conversion::makeLayerProperty(getLineOffsetTransition());
+            return makeLayerProperty(getLineOffsetTransition());
         case Property::LineOpacityTransition:
-            return conversion::makeLayerProperty(getLineOpacityTransition());
+            return makeLayerProperty(getLineOpacityTransition());
         case Property::LinePatternTransition:
-            return conversion::makeLayerProperty(getLinePatternTransition());
+            return makeLayerProperty(getLinePatternTransition());
         case Property::LineTranslateTransition:
-            return conversion::makeLayerProperty(getLineTranslateTransition());
+            return makeLayerProperty(getLineTranslateTransition());
         case Property::LineTranslateAnchorTransition:
-            return conversion::makeLayerProperty(getLineTranslateAnchorTransition());
+            return makeLayerProperty(getLineTranslateAnchorTransition());
         case Property::LineWidthTransition:
-            return conversion::makeLayerProperty(getLineWidthTransition());
+            return makeLayerProperty(getLineWidthTransition());
     }
     return {};
 }

--- a/src/mbgl/style/layers/raster_layer.cpp
+++ b/src/mbgl/style/layers/raster_layer.cpp
@@ -304,30 +304,35 @@ enum class Property {
     RasterSaturationTransition,
 };
 
+template <typename T>
+constexpr uint8_t toUint8(T t) noexcept {
+    return uint8_t(mbgl::underlying_type(t));
+}
+
 MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
-    {{"raster-brightness-max", mbgl::underlying_type(Property::RasterBrightnessMax)},
-     {"raster-brightness-min", mbgl::underlying_type(Property::RasterBrightnessMin)},
-     {"raster-contrast", mbgl::underlying_type(Property::RasterContrast)},
-     {"raster-fade-duration", mbgl::underlying_type(Property::RasterFadeDuration)},
-     {"raster-hue-rotate", mbgl::underlying_type(Property::RasterHueRotate)},
-     {"raster-opacity", mbgl::underlying_type(Property::RasterOpacity)},
-     {"raster-resampling", mbgl::underlying_type(Property::RasterResampling)},
-     {"raster-saturation", mbgl::underlying_type(Property::RasterSaturation)},
-     {"raster-brightness-max-transition", mbgl::underlying_type(Property::RasterBrightnessMaxTransition)},
-     {"raster-brightness-min-transition", mbgl::underlying_type(Property::RasterBrightnessMinTransition)},
-     {"raster-contrast-transition", mbgl::underlying_type(Property::RasterContrastTransition)},
-     {"raster-fade-duration-transition", mbgl::underlying_type(Property::RasterFadeDurationTransition)},
-     {"raster-hue-rotate-transition", mbgl::underlying_type(Property::RasterHueRotateTransition)},
-     {"raster-opacity-transition", mbgl::underlying_type(Property::RasterOpacityTransition)},
-     {"raster-resampling-transition", mbgl::underlying_type(Property::RasterResamplingTransition)},
-     {"raster-saturation-transition", mbgl::underlying_type(Property::RasterSaturationTransition)}});
+    {{"raster-brightness-max", toUint8(Property::RasterBrightnessMax)},
+     {"raster-brightness-min", toUint8(Property::RasterBrightnessMin)},
+     {"raster-contrast", toUint8(Property::RasterContrast)},
+     {"raster-fade-duration", toUint8(Property::RasterFadeDuration)},
+     {"raster-hue-rotate", toUint8(Property::RasterHueRotate)},
+     {"raster-opacity", toUint8(Property::RasterOpacity)},
+     {"raster-resampling", toUint8(Property::RasterResampling)},
+     {"raster-saturation", toUint8(Property::RasterSaturation)},
+     {"raster-brightness-max-transition", toUint8(Property::RasterBrightnessMaxTransition)},
+     {"raster-brightness-min-transition", toUint8(Property::RasterBrightnessMinTransition)},
+     {"raster-contrast-transition", toUint8(Property::RasterContrastTransition)},
+     {"raster-fade-duration-transition", toUint8(Property::RasterFadeDurationTransition)},
+     {"raster-hue-rotate-transition", toUint8(Property::RasterHueRotateTransition)},
+     {"raster-opacity-transition", toUint8(Property::RasterOpacityTransition)},
+     {"raster-resampling-transition", toUint8(Property::RasterResamplingTransition)},
+     {"raster-saturation-transition", toUint8(Property::RasterSaturationTransition)}});
 
 } // namespace
 
 optional<Error> RasterLayer::setPaintProperty(const std::string& name, const Convertible& value) {
     const auto it = paintProperties.find(name.c_str());
     if (it == paintProperties.end()) {
-        return Error { "layer doesn't support this property" };
+        return Error{"layer doesn't support this property"};
     }
 
     auto property = static_cast<Property>(it->second);
@@ -395,49 +400,48 @@ optional<Error> RasterLayer::setPaintProperty(const std::string& name, const Con
     if (!transition) {
         return error;
     }
-    
+
     if (property == Property::RasterBrightnessMaxTransition) {
         setRasterBrightnessMaxTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::RasterBrightnessMinTransition) {
         setRasterBrightnessMinTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::RasterContrastTransition) {
         setRasterContrastTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::RasterFadeDurationTransition) {
         setRasterFadeDurationTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::RasterHueRotateTransition) {
         setRasterHueRotateTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::RasterOpacityTransition) {
         setRasterOpacityTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::RasterResamplingTransition) {
         setRasterResamplingTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::RasterSaturationTransition) {
         setRasterSaturationTransition(*transition);
         return nullopt;
     }
-    
 
-    return Error { "layer doesn't support this property" };
+    return Error{"layer doesn't support this property"};
 }
 
 LayerProperty RasterLayer::getPaintProperty(const std::string& name) const {
@@ -448,37 +452,37 @@ LayerProperty RasterLayer::getPaintProperty(const std::string& name) const {
 
     switch (static_cast<Property>(it->second)) {
         case Property::RasterBrightnessMax:
-            return conversion::makeLayerProperty(getRasterBrightnessMax());
+            return makeLayerProperty(getRasterBrightnessMax());
         case Property::RasterBrightnessMin:
-            return conversion::makeLayerProperty(getRasterBrightnessMin());
+            return makeLayerProperty(getRasterBrightnessMin());
         case Property::RasterContrast:
-            return conversion::makeLayerProperty(getRasterContrast());
+            return makeLayerProperty(getRasterContrast());
         case Property::RasterFadeDuration:
-            return conversion::makeLayerProperty(getRasterFadeDuration());
+            return makeLayerProperty(getRasterFadeDuration());
         case Property::RasterHueRotate:
-            return conversion::makeLayerProperty(getRasterHueRotate());
+            return makeLayerProperty(getRasterHueRotate());
         case Property::RasterOpacity:
-            return conversion::makeLayerProperty(getRasterOpacity());
+            return makeLayerProperty(getRasterOpacity());
         case Property::RasterResampling:
-            return conversion::makeLayerProperty(getRasterResampling());
+            return makeLayerProperty(getRasterResampling());
         case Property::RasterSaturation:
-            return conversion::makeLayerProperty(getRasterSaturation());
+            return makeLayerProperty(getRasterSaturation());
         case Property::RasterBrightnessMaxTransition:
-            return conversion::makeLayerProperty(getRasterBrightnessMaxTransition());
+            return makeLayerProperty(getRasterBrightnessMaxTransition());
         case Property::RasterBrightnessMinTransition:
-            return conversion::makeLayerProperty(getRasterBrightnessMinTransition());
+            return makeLayerProperty(getRasterBrightnessMinTransition());
         case Property::RasterContrastTransition:
-            return conversion::makeLayerProperty(getRasterContrastTransition());
+            return makeLayerProperty(getRasterContrastTransition());
         case Property::RasterFadeDurationTransition:
-            return conversion::makeLayerProperty(getRasterFadeDurationTransition());
+            return makeLayerProperty(getRasterFadeDurationTransition());
         case Property::RasterHueRotateTransition:
-            return conversion::makeLayerProperty(getRasterHueRotateTransition());
+            return makeLayerProperty(getRasterHueRotateTransition());
         case Property::RasterOpacityTransition:
-            return conversion::makeLayerProperty(getRasterOpacityTransition());
+            return makeLayerProperty(getRasterOpacityTransition());
         case Property::RasterResamplingTransition:
-            return conversion::makeLayerProperty(getRasterResamplingTransition());
+            return makeLayerProperty(getRasterResamplingTransition());
         case Property::RasterSaturationTransition:
-            return conversion::makeLayerProperty(getRasterSaturationTransition());
+            return makeLayerProperty(getRasterSaturationTransition());
     }
     return {};
 }

--- a/src/mbgl/style/layers/raster_layer.cpp
+++ b/src/mbgl/style/layers/raster_layer.cpp
@@ -285,7 +285,7 @@ using namespace conversion;
 
 namespace {
 
-enum class Property {
+enum class Property : uint8_t {
     RasterBrightnessMax,
     RasterBrightnessMin,
     RasterContrast,
@@ -444,7 +444,7 @@ optional<Error> RasterLayer::setPaintProperty(const std::string& name, const Con
     return Error{"layer doesn't support this property"};
 }
 
-LayerProperty RasterLayer::getPaintProperty(const std::string& name) const {
+StyleProperty RasterLayer::getPaintProperty(const std::string& name) const {
     const auto it = paintProperties.find(name.c_str());
     if (it == paintProperties.end()) {
         return {};
@@ -452,37 +452,37 @@ LayerProperty RasterLayer::getPaintProperty(const std::string& name) const {
 
     switch (static_cast<Property>(it->second)) {
         case Property::RasterBrightnessMax:
-            return makeLayerProperty(getRasterBrightnessMax());
+            return makeStyleProperty(getRasterBrightnessMax());
         case Property::RasterBrightnessMin:
-            return makeLayerProperty(getRasterBrightnessMin());
+            return makeStyleProperty(getRasterBrightnessMin());
         case Property::RasterContrast:
-            return makeLayerProperty(getRasterContrast());
+            return makeStyleProperty(getRasterContrast());
         case Property::RasterFadeDuration:
-            return makeLayerProperty(getRasterFadeDuration());
+            return makeStyleProperty(getRasterFadeDuration());
         case Property::RasterHueRotate:
-            return makeLayerProperty(getRasterHueRotate());
+            return makeStyleProperty(getRasterHueRotate());
         case Property::RasterOpacity:
-            return makeLayerProperty(getRasterOpacity());
+            return makeStyleProperty(getRasterOpacity());
         case Property::RasterResampling:
-            return makeLayerProperty(getRasterResampling());
+            return makeStyleProperty(getRasterResampling());
         case Property::RasterSaturation:
-            return makeLayerProperty(getRasterSaturation());
+            return makeStyleProperty(getRasterSaturation());
         case Property::RasterBrightnessMaxTransition:
-            return makeLayerProperty(getRasterBrightnessMaxTransition());
+            return makeStyleProperty(getRasterBrightnessMaxTransition());
         case Property::RasterBrightnessMinTransition:
-            return makeLayerProperty(getRasterBrightnessMinTransition());
+            return makeStyleProperty(getRasterBrightnessMinTransition());
         case Property::RasterContrastTransition:
-            return makeLayerProperty(getRasterContrastTransition());
+            return makeStyleProperty(getRasterContrastTransition());
         case Property::RasterFadeDurationTransition:
-            return makeLayerProperty(getRasterFadeDurationTransition());
+            return makeStyleProperty(getRasterFadeDurationTransition());
         case Property::RasterHueRotateTransition:
-            return makeLayerProperty(getRasterHueRotateTransition());
+            return makeStyleProperty(getRasterHueRotateTransition());
         case Property::RasterOpacityTransition:
-            return makeLayerProperty(getRasterOpacityTransition());
+            return makeStyleProperty(getRasterOpacityTransition());
         case Property::RasterResamplingTransition:
-            return makeLayerProperty(getRasterResamplingTransition());
+            return makeStyleProperty(getRasterResamplingTransition());
         case Property::RasterSaturationTransition:
-            return makeLayerProperty(getRasterSaturationTransition());
+            return makeStyleProperty(getRasterSaturationTransition());
     }
     return {};
 }

--- a/src/mbgl/style/layers/raster_layer.cpp
+++ b/src/mbgl/style/layers/raster_layer.cpp
@@ -283,47 +283,50 @@ TransitionOptions RasterLayer::getRasterSaturationTransition() const {
 
 using namespace conversion;
 
+namespace {
+
+enum class Property {
+    RasterBrightnessMax,
+    RasterBrightnessMin,
+    RasterContrast,
+    RasterFadeDuration,
+    RasterHueRotate,
+    RasterOpacity,
+    RasterResampling,
+    RasterSaturation,
+    RasterBrightnessMaxTransition,
+    RasterBrightnessMinTransition,
+    RasterContrastTransition,
+    RasterFadeDurationTransition,
+    RasterHueRotateTransition,
+    RasterOpacityTransition,
+    RasterResamplingTransition,
+    RasterSaturationTransition,
+};
+
+MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+    {{"raster-brightness-max", mbgl::underlying_type(Property::RasterBrightnessMax)},
+     {"raster-brightness-min", mbgl::underlying_type(Property::RasterBrightnessMin)},
+     {"raster-contrast", mbgl::underlying_type(Property::RasterContrast)},
+     {"raster-fade-duration", mbgl::underlying_type(Property::RasterFadeDuration)},
+     {"raster-hue-rotate", mbgl::underlying_type(Property::RasterHueRotate)},
+     {"raster-opacity", mbgl::underlying_type(Property::RasterOpacity)},
+     {"raster-resampling", mbgl::underlying_type(Property::RasterResampling)},
+     {"raster-saturation", mbgl::underlying_type(Property::RasterSaturation)},
+     {"raster-brightness-max-transition", mbgl::underlying_type(Property::RasterBrightnessMaxTransition)},
+     {"raster-brightness-min-transition", mbgl::underlying_type(Property::RasterBrightnessMinTransition)},
+     {"raster-contrast-transition", mbgl::underlying_type(Property::RasterContrastTransition)},
+     {"raster-fade-duration-transition", mbgl::underlying_type(Property::RasterFadeDurationTransition)},
+     {"raster-hue-rotate-transition", mbgl::underlying_type(Property::RasterHueRotateTransition)},
+     {"raster-opacity-transition", mbgl::underlying_type(Property::RasterOpacityTransition)},
+     {"raster-resampling-transition", mbgl::underlying_type(Property::RasterResamplingTransition)},
+     {"raster-saturation-transition", mbgl::underlying_type(Property::RasterSaturationTransition)}});
+
+} // namespace
+
 optional<Error> RasterLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-        RasterBrightnessMax,
-        RasterBrightnessMin,
-        RasterContrast,
-        RasterFadeDuration,
-        RasterHueRotate,
-        RasterOpacity,
-        RasterResampling,
-        RasterSaturation,
-        RasterBrightnessMaxTransition,
-        RasterBrightnessMinTransition,
-        RasterContrastTransition,
-        RasterFadeDurationTransition,
-        RasterHueRotateTransition,
-        RasterOpacityTransition,
-        RasterResamplingTransition,
-        RasterSaturationTransition,
-    };
-
-    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        { "raster-brightness-max", mbgl::underlying_type(Property::RasterBrightnessMax) },
-        { "raster-brightness-min", mbgl::underlying_type(Property::RasterBrightnessMin) },
-        { "raster-contrast", mbgl::underlying_type(Property::RasterContrast) },
-        { "raster-fade-duration", mbgl::underlying_type(Property::RasterFadeDuration) },
-        { "raster-hue-rotate", mbgl::underlying_type(Property::RasterHueRotate) },
-        { "raster-opacity", mbgl::underlying_type(Property::RasterOpacity) },
-        { "raster-resampling", mbgl::underlying_type(Property::RasterResampling) },
-        { "raster-saturation", mbgl::underlying_type(Property::RasterSaturation) },
-        { "raster-brightness-max-transition", mbgl::underlying_type(Property::RasterBrightnessMaxTransition) },
-        { "raster-brightness-min-transition", mbgl::underlying_type(Property::RasterBrightnessMinTransition) },
-        { "raster-contrast-transition", mbgl::underlying_type(Property::RasterContrastTransition) },
-        { "raster-fade-duration-transition", mbgl::underlying_type(Property::RasterFadeDurationTransition) },
-        { "raster-hue-rotate-transition", mbgl::underlying_type(Property::RasterHueRotateTransition) },
-        { "raster-opacity-transition", mbgl::underlying_type(Property::RasterOpacityTransition) },
-        { "raster-resampling-transition", mbgl::underlying_type(Property::RasterResamplingTransition) },
-        { "raster-saturation-transition", mbgl::underlying_type(Property::RasterSaturationTransition) }
-    });
-
-    const auto it = properties.find(name.c_str());
-    if (it == properties.end()) {
+    const auto it = paintProperties.find(name.c_str());
+    if (it == paintProperties.end()) {
         return Error { "layer doesn't support this property" };
     }
 
@@ -435,6 +438,49 @@ optional<Error> RasterLayer::setPaintProperty(const std::string& name, const Con
     
 
     return Error { "layer doesn't support this property" };
+}
+
+LayerProperty RasterLayer::getPaintProperty(const std::string& name) const {
+    const auto it = paintProperties.find(name.c_str());
+    if (it == paintProperties.end()) {
+        return {};
+    }
+
+    switch (static_cast<Property>(it->second)) {
+        case Property::RasterBrightnessMax:
+            return conversion::makeLayerProperty(getRasterBrightnessMax());
+        case Property::RasterBrightnessMin:
+            return conversion::makeLayerProperty(getRasterBrightnessMin());
+        case Property::RasterContrast:
+            return conversion::makeLayerProperty(getRasterContrast());
+        case Property::RasterFadeDuration:
+            return conversion::makeLayerProperty(getRasterFadeDuration());
+        case Property::RasterHueRotate:
+            return conversion::makeLayerProperty(getRasterHueRotate());
+        case Property::RasterOpacity:
+            return conversion::makeLayerProperty(getRasterOpacity());
+        case Property::RasterResampling:
+            return conversion::makeLayerProperty(getRasterResampling());
+        case Property::RasterSaturation:
+            return conversion::makeLayerProperty(getRasterSaturation());
+        case Property::RasterBrightnessMaxTransition:
+            return conversion::makeLayerProperty(getRasterBrightnessMaxTransition());
+        case Property::RasterBrightnessMinTransition:
+            return conversion::makeLayerProperty(getRasterBrightnessMinTransition());
+        case Property::RasterContrastTransition:
+            return conversion::makeLayerProperty(getRasterContrastTransition());
+        case Property::RasterFadeDurationTransition:
+            return conversion::makeLayerProperty(getRasterFadeDurationTransition());
+        case Property::RasterHueRotateTransition:
+            return conversion::makeLayerProperty(getRasterHueRotateTransition());
+        case Property::RasterOpacityTransition:
+            return conversion::makeLayerProperty(getRasterOpacityTransition());
+        case Property::RasterResamplingTransition:
+            return conversion::makeLayerProperty(getRasterResamplingTransition());
+        case Property::RasterSaturationTransition:
+            return conversion::makeLayerProperty(getRasterSaturationTransition());
+    }
+    return {};
 }
 
 optional<Error> RasterLayer::setLayoutProperty(const std::string& name, const Convertible& value) {

--- a/src/mbgl/style/layers/symbol_layer.cpp
+++ b/src/mbgl/style/layers/symbol_layer.cpp
@@ -1104,7 +1104,7 @@ using namespace conversion;
 
 namespace {
 
-enum class Property {
+enum class Property : uint8_t {
     IconColor,
     IconHaloBlur,
     IconHaloColor,
@@ -1367,7 +1367,7 @@ optional<Error> SymbolLayer::setPaintProperty(const std::string& name, const Con
     return Error{"layer doesn't support this property"};
 }
 
-LayerProperty SymbolLayer::getPaintProperty(const std::string& name) const {
+StyleProperty SymbolLayer::getPaintProperty(const std::string& name) const {
     const auto it = paintProperties.find(name.c_str());
     if (it == paintProperties.end()) {
         return {};
@@ -1375,61 +1375,61 @@ LayerProperty SymbolLayer::getPaintProperty(const std::string& name) const {
 
     switch (static_cast<Property>(it->second)) {
         case Property::IconColor:
-            return makeLayerProperty(getIconColor());
+            return makeStyleProperty(getIconColor());
         case Property::IconHaloBlur:
-            return makeLayerProperty(getIconHaloBlur());
+            return makeStyleProperty(getIconHaloBlur());
         case Property::IconHaloColor:
-            return makeLayerProperty(getIconHaloColor());
+            return makeStyleProperty(getIconHaloColor());
         case Property::IconHaloWidth:
-            return makeLayerProperty(getIconHaloWidth());
+            return makeStyleProperty(getIconHaloWidth());
         case Property::IconOpacity:
-            return makeLayerProperty(getIconOpacity());
+            return makeStyleProperty(getIconOpacity());
         case Property::IconTranslate:
-            return makeLayerProperty(getIconTranslate());
+            return makeStyleProperty(getIconTranslate());
         case Property::IconTranslateAnchor:
-            return makeLayerProperty(getIconTranslateAnchor());
+            return makeStyleProperty(getIconTranslateAnchor());
         case Property::TextColor:
-            return makeLayerProperty(getTextColor());
+            return makeStyleProperty(getTextColor());
         case Property::TextHaloBlur:
-            return makeLayerProperty(getTextHaloBlur());
+            return makeStyleProperty(getTextHaloBlur());
         case Property::TextHaloColor:
-            return makeLayerProperty(getTextHaloColor());
+            return makeStyleProperty(getTextHaloColor());
         case Property::TextHaloWidth:
-            return makeLayerProperty(getTextHaloWidth());
+            return makeStyleProperty(getTextHaloWidth());
         case Property::TextOpacity:
-            return makeLayerProperty(getTextOpacity());
+            return makeStyleProperty(getTextOpacity());
         case Property::TextTranslate:
-            return makeLayerProperty(getTextTranslate());
+            return makeStyleProperty(getTextTranslate());
         case Property::TextTranslateAnchor:
-            return makeLayerProperty(getTextTranslateAnchor());
+            return makeStyleProperty(getTextTranslateAnchor());
         case Property::IconColorTransition:
-            return makeLayerProperty(getIconColorTransition());
+            return makeStyleProperty(getIconColorTransition());
         case Property::IconHaloBlurTransition:
-            return makeLayerProperty(getIconHaloBlurTransition());
+            return makeStyleProperty(getIconHaloBlurTransition());
         case Property::IconHaloColorTransition:
-            return makeLayerProperty(getIconHaloColorTransition());
+            return makeStyleProperty(getIconHaloColorTransition());
         case Property::IconHaloWidthTransition:
-            return makeLayerProperty(getIconHaloWidthTransition());
+            return makeStyleProperty(getIconHaloWidthTransition());
         case Property::IconOpacityTransition:
-            return makeLayerProperty(getIconOpacityTransition());
+            return makeStyleProperty(getIconOpacityTransition());
         case Property::IconTranslateTransition:
-            return makeLayerProperty(getIconTranslateTransition());
+            return makeStyleProperty(getIconTranslateTransition());
         case Property::IconTranslateAnchorTransition:
-            return makeLayerProperty(getIconTranslateAnchorTransition());
+            return makeStyleProperty(getIconTranslateAnchorTransition());
         case Property::TextColorTransition:
-            return makeLayerProperty(getTextColorTransition());
+            return makeStyleProperty(getTextColorTransition());
         case Property::TextHaloBlurTransition:
-            return makeLayerProperty(getTextHaloBlurTransition());
+            return makeStyleProperty(getTextHaloBlurTransition());
         case Property::TextHaloColorTransition:
-            return makeLayerProperty(getTextHaloColorTransition());
+            return makeStyleProperty(getTextHaloColorTransition());
         case Property::TextHaloWidthTransition:
-            return makeLayerProperty(getTextHaloWidthTransition());
+            return makeStyleProperty(getTextHaloWidthTransition());
         case Property::TextOpacityTransition:
-            return makeLayerProperty(getTextOpacityTransition());
+            return makeStyleProperty(getTextOpacityTransition());
         case Property::TextTranslateTransition:
-            return makeLayerProperty(getTextTranslateTransition());
+            return makeStyleProperty(getTextTranslateTransition());
         case Property::TextTranslateAnchorTransition:
-            return makeLayerProperty(getTextTranslateAnchorTransition());
+            return makeStyleProperty(getTextTranslateAnchorTransition());
     }
     return {};
 }

--- a/src/mbgl/style/layers/symbol_layer.cpp
+++ b/src/mbgl/style/layers/symbol_layer.cpp
@@ -1102,71 +1102,74 @@ TransitionOptions SymbolLayer::getTextTranslateAnchorTransition() const {
 
 using namespace conversion;
 
+namespace {
+
+enum class Property {
+    IconColor,
+    IconHaloBlur,
+    IconHaloColor,
+    IconHaloWidth,
+    IconOpacity,
+    IconTranslate,
+    IconTranslateAnchor,
+    TextColor,
+    TextHaloBlur,
+    TextHaloColor,
+    TextHaloWidth,
+    TextOpacity,
+    TextTranslate,
+    TextTranslateAnchor,
+    IconColorTransition,
+    IconHaloBlurTransition,
+    IconHaloColorTransition,
+    IconHaloWidthTransition,
+    IconOpacityTransition,
+    IconTranslateTransition,
+    IconTranslateAnchorTransition,
+    TextColorTransition,
+    TextHaloBlurTransition,
+    TextHaloColorTransition,
+    TextHaloWidthTransition,
+    TextOpacityTransition,
+    TextTranslateTransition,
+    TextTranslateAnchorTransition,
+};
+
+MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+    {{"icon-color", mbgl::underlying_type(Property::IconColor)},
+     {"icon-halo-blur", mbgl::underlying_type(Property::IconHaloBlur)},
+     {"icon-halo-color", mbgl::underlying_type(Property::IconHaloColor)},
+     {"icon-halo-width", mbgl::underlying_type(Property::IconHaloWidth)},
+     {"icon-opacity", mbgl::underlying_type(Property::IconOpacity)},
+     {"icon-translate", mbgl::underlying_type(Property::IconTranslate)},
+     {"icon-translate-anchor", mbgl::underlying_type(Property::IconTranslateAnchor)},
+     {"text-color", mbgl::underlying_type(Property::TextColor)},
+     {"text-halo-blur", mbgl::underlying_type(Property::TextHaloBlur)},
+     {"text-halo-color", mbgl::underlying_type(Property::TextHaloColor)},
+     {"text-halo-width", mbgl::underlying_type(Property::TextHaloWidth)},
+     {"text-opacity", mbgl::underlying_type(Property::TextOpacity)},
+     {"text-translate", mbgl::underlying_type(Property::TextTranslate)},
+     {"text-translate-anchor", mbgl::underlying_type(Property::TextTranslateAnchor)},
+     {"icon-color-transition", mbgl::underlying_type(Property::IconColorTransition)},
+     {"icon-halo-blur-transition", mbgl::underlying_type(Property::IconHaloBlurTransition)},
+     {"icon-halo-color-transition", mbgl::underlying_type(Property::IconHaloColorTransition)},
+     {"icon-halo-width-transition", mbgl::underlying_type(Property::IconHaloWidthTransition)},
+     {"icon-opacity-transition", mbgl::underlying_type(Property::IconOpacityTransition)},
+     {"icon-translate-transition", mbgl::underlying_type(Property::IconTranslateTransition)},
+     {"icon-translate-anchor-transition", mbgl::underlying_type(Property::IconTranslateAnchorTransition)},
+     {"text-color-transition", mbgl::underlying_type(Property::TextColorTransition)},
+     {"text-halo-blur-transition", mbgl::underlying_type(Property::TextHaloBlurTransition)},
+     {"text-halo-color-transition", mbgl::underlying_type(Property::TextHaloColorTransition)},
+     {"text-halo-width-transition", mbgl::underlying_type(Property::TextHaloWidthTransition)},
+     {"text-opacity-transition", mbgl::underlying_type(Property::TextOpacityTransition)},
+     {"text-translate-transition", mbgl::underlying_type(Property::TextTranslateTransition)},
+     {"text-translate-anchor-transition", mbgl::underlying_type(Property::TextTranslateAnchorTransition)}});
+
+} // namespace
+
 optional<Error> SymbolLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-        IconColor,
-        IconHaloBlur,
-        IconHaloColor,
-        IconHaloWidth,
-        IconOpacity,
-        IconTranslate,
-        IconTranslateAnchor,
-        TextColor,
-        TextHaloBlur,
-        TextHaloColor,
-        TextHaloWidth,
-        TextOpacity,
-        TextTranslate,
-        TextTranslateAnchor,
-        IconColorTransition,
-        IconHaloBlurTransition,
-        IconHaloColorTransition,
-        IconHaloWidthTransition,
-        IconOpacityTransition,
-        IconTranslateTransition,
-        IconTranslateAnchorTransition,
-        TextColorTransition,
-        TextHaloBlurTransition,
-        TextHaloColorTransition,
-        TextHaloWidthTransition,
-        TextOpacityTransition,
-        TextTranslateTransition,
-        TextTranslateAnchorTransition,
-    };
-
-    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        { "icon-color", mbgl::underlying_type(Property::IconColor) },
-        { "icon-halo-blur", mbgl::underlying_type(Property::IconHaloBlur) },
-        { "icon-halo-color", mbgl::underlying_type(Property::IconHaloColor) },
-        { "icon-halo-width", mbgl::underlying_type(Property::IconHaloWidth) },
-        { "icon-opacity", mbgl::underlying_type(Property::IconOpacity) },
-        { "icon-translate", mbgl::underlying_type(Property::IconTranslate) },
-        { "icon-translate-anchor", mbgl::underlying_type(Property::IconTranslateAnchor) },
-        { "text-color", mbgl::underlying_type(Property::TextColor) },
-        { "text-halo-blur", mbgl::underlying_type(Property::TextHaloBlur) },
-        { "text-halo-color", mbgl::underlying_type(Property::TextHaloColor) },
-        { "text-halo-width", mbgl::underlying_type(Property::TextHaloWidth) },
-        { "text-opacity", mbgl::underlying_type(Property::TextOpacity) },
-        { "text-translate", mbgl::underlying_type(Property::TextTranslate) },
-        { "text-translate-anchor", mbgl::underlying_type(Property::TextTranslateAnchor) },
-        { "icon-color-transition", mbgl::underlying_type(Property::IconColorTransition) },
-        { "icon-halo-blur-transition", mbgl::underlying_type(Property::IconHaloBlurTransition) },
-        { "icon-halo-color-transition", mbgl::underlying_type(Property::IconHaloColorTransition) },
-        { "icon-halo-width-transition", mbgl::underlying_type(Property::IconHaloWidthTransition) },
-        { "icon-opacity-transition", mbgl::underlying_type(Property::IconOpacityTransition) },
-        { "icon-translate-transition", mbgl::underlying_type(Property::IconTranslateTransition) },
-        { "icon-translate-anchor-transition", mbgl::underlying_type(Property::IconTranslateAnchorTransition) },
-        { "text-color-transition", mbgl::underlying_type(Property::TextColorTransition) },
-        { "text-halo-blur-transition", mbgl::underlying_type(Property::TextHaloBlurTransition) },
-        { "text-halo-color-transition", mbgl::underlying_type(Property::TextHaloColorTransition) },
-        { "text-halo-width-transition", mbgl::underlying_type(Property::TextHaloWidthTransition) },
-        { "text-opacity-transition", mbgl::underlying_type(Property::TextOpacityTransition) },
-        { "text-translate-transition", mbgl::underlying_type(Property::TextTranslateTransition) },
-        { "text-translate-anchor-transition", mbgl::underlying_type(Property::TextTranslateAnchorTransition) }
-    });
-
-    const auto it = properties.find(name.c_str());
-    if (it == properties.end()) {
+    const auto it = paintProperties.find(name.c_str());
+    if (it == paintProperties.end()) {
         return Error { "layer doesn't support this property" };
     }
 
@@ -1358,6 +1361,73 @@ optional<Error> SymbolLayer::setPaintProperty(const std::string& name, const Con
     
 
     return Error { "layer doesn't support this property" };
+}
+
+LayerProperty SymbolLayer::getPaintProperty(const std::string& name) const {
+    const auto it = paintProperties.find(name.c_str());
+    if (it == paintProperties.end()) {
+        return {};
+    }
+
+    switch (static_cast<Property>(it->second)) {
+        case Property::IconColor:
+            return conversion::makeLayerProperty(getIconColor());
+        case Property::IconHaloBlur:
+            return conversion::makeLayerProperty(getIconHaloBlur());
+        case Property::IconHaloColor:
+            return conversion::makeLayerProperty(getIconHaloColor());
+        case Property::IconHaloWidth:
+            return conversion::makeLayerProperty(getIconHaloWidth());
+        case Property::IconOpacity:
+            return conversion::makeLayerProperty(getIconOpacity());
+        case Property::IconTranslate:
+            return conversion::makeLayerProperty(getIconTranslate());
+        case Property::IconTranslateAnchor:
+            return conversion::makeLayerProperty(getIconTranslateAnchor());
+        case Property::TextColor:
+            return conversion::makeLayerProperty(getTextColor());
+        case Property::TextHaloBlur:
+            return conversion::makeLayerProperty(getTextHaloBlur());
+        case Property::TextHaloColor:
+            return conversion::makeLayerProperty(getTextHaloColor());
+        case Property::TextHaloWidth:
+            return conversion::makeLayerProperty(getTextHaloWidth());
+        case Property::TextOpacity:
+            return conversion::makeLayerProperty(getTextOpacity());
+        case Property::TextTranslate:
+            return conversion::makeLayerProperty(getTextTranslate());
+        case Property::TextTranslateAnchor:
+            return conversion::makeLayerProperty(getTextTranslateAnchor());
+        case Property::IconColorTransition:
+            return conversion::makeLayerProperty(getIconColorTransition());
+        case Property::IconHaloBlurTransition:
+            return conversion::makeLayerProperty(getIconHaloBlurTransition());
+        case Property::IconHaloColorTransition:
+            return conversion::makeLayerProperty(getIconHaloColorTransition());
+        case Property::IconHaloWidthTransition:
+            return conversion::makeLayerProperty(getIconHaloWidthTransition());
+        case Property::IconOpacityTransition:
+            return conversion::makeLayerProperty(getIconOpacityTransition());
+        case Property::IconTranslateTransition:
+            return conversion::makeLayerProperty(getIconTranslateTransition());
+        case Property::IconTranslateAnchorTransition:
+            return conversion::makeLayerProperty(getIconTranslateAnchorTransition());
+        case Property::TextColorTransition:
+            return conversion::makeLayerProperty(getTextColorTransition());
+        case Property::TextHaloBlurTransition:
+            return conversion::makeLayerProperty(getTextHaloBlurTransition());
+        case Property::TextHaloColorTransition:
+            return conversion::makeLayerProperty(getTextHaloColorTransition());
+        case Property::TextHaloWidthTransition:
+            return conversion::makeLayerProperty(getTextHaloWidthTransition());
+        case Property::TextOpacityTransition:
+            return conversion::makeLayerProperty(getTextOpacityTransition());
+        case Property::TextTranslateTransition:
+            return conversion::makeLayerProperty(getTextTranslateTransition());
+        case Property::TextTranslateAnchorTransition:
+            return conversion::makeLayerProperty(getTextTranslateAnchorTransition());
+    }
+    return {};
 }
 
 optional<Error> SymbolLayer::setLayoutProperty(const std::string& name, const Convertible& value) {

--- a/src/mbgl/style/layers/symbol_layer.cpp
+++ b/src/mbgl/style/layers/symbol_layer.cpp
@@ -1135,42 +1135,47 @@ enum class Property {
     TextTranslateAnchorTransition,
 };
 
+template <typename T>
+constexpr uint8_t toUint8(T t) noexcept {
+    return uint8_t(mbgl::underlying_type(t));
+}
+
 MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
-    {{"icon-color", mbgl::underlying_type(Property::IconColor)},
-     {"icon-halo-blur", mbgl::underlying_type(Property::IconHaloBlur)},
-     {"icon-halo-color", mbgl::underlying_type(Property::IconHaloColor)},
-     {"icon-halo-width", mbgl::underlying_type(Property::IconHaloWidth)},
-     {"icon-opacity", mbgl::underlying_type(Property::IconOpacity)},
-     {"icon-translate", mbgl::underlying_type(Property::IconTranslate)},
-     {"icon-translate-anchor", mbgl::underlying_type(Property::IconTranslateAnchor)},
-     {"text-color", mbgl::underlying_type(Property::TextColor)},
-     {"text-halo-blur", mbgl::underlying_type(Property::TextHaloBlur)},
-     {"text-halo-color", mbgl::underlying_type(Property::TextHaloColor)},
-     {"text-halo-width", mbgl::underlying_type(Property::TextHaloWidth)},
-     {"text-opacity", mbgl::underlying_type(Property::TextOpacity)},
-     {"text-translate", mbgl::underlying_type(Property::TextTranslate)},
-     {"text-translate-anchor", mbgl::underlying_type(Property::TextTranslateAnchor)},
-     {"icon-color-transition", mbgl::underlying_type(Property::IconColorTransition)},
-     {"icon-halo-blur-transition", mbgl::underlying_type(Property::IconHaloBlurTransition)},
-     {"icon-halo-color-transition", mbgl::underlying_type(Property::IconHaloColorTransition)},
-     {"icon-halo-width-transition", mbgl::underlying_type(Property::IconHaloWidthTransition)},
-     {"icon-opacity-transition", mbgl::underlying_type(Property::IconOpacityTransition)},
-     {"icon-translate-transition", mbgl::underlying_type(Property::IconTranslateTransition)},
-     {"icon-translate-anchor-transition", mbgl::underlying_type(Property::IconTranslateAnchorTransition)},
-     {"text-color-transition", mbgl::underlying_type(Property::TextColorTransition)},
-     {"text-halo-blur-transition", mbgl::underlying_type(Property::TextHaloBlurTransition)},
-     {"text-halo-color-transition", mbgl::underlying_type(Property::TextHaloColorTransition)},
-     {"text-halo-width-transition", mbgl::underlying_type(Property::TextHaloWidthTransition)},
-     {"text-opacity-transition", mbgl::underlying_type(Property::TextOpacityTransition)},
-     {"text-translate-transition", mbgl::underlying_type(Property::TextTranslateTransition)},
-     {"text-translate-anchor-transition", mbgl::underlying_type(Property::TextTranslateAnchorTransition)}});
+    {{"icon-color", toUint8(Property::IconColor)},
+     {"icon-halo-blur", toUint8(Property::IconHaloBlur)},
+     {"icon-halo-color", toUint8(Property::IconHaloColor)},
+     {"icon-halo-width", toUint8(Property::IconHaloWidth)},
+     {"icon-opacity", toUint8(Property::IconOpacity)},
+     {"icon-translate", toUint8(Property::IconTranslate)},
+     {"icon-translate-anchor", toUint8(Property::IconTranslateAnchor)},
+     {"text-color", toUint8(Property::TextColor)},
+     {"text-halo-blur", toUint8(Property::TextHaloBlur)},
+     {"text-halo-color", toUint8(Property::TextHaloColor)},
+     {"text-halo-width", toUint8(Property::TextHaloWidth)},
+     {"text-opacity", toUint8(Property::TextOpacity)},
+     {"text-translate", toUint8(Property::TextTranslate)},
+     {"text-translate-anchor", toUint8(Property::TextTranslateAnchor)},
+     {"icon-color-transition", toUint8(Property::IconColorTransition)},
+     {"icon-halo-blur-transition", toUint8(Property::IconHaloBlurTransition)},
+     {"icon-halo-color-transition", toUint8(Property::IconHaloColorTransition)},
+     {"icon-halo-width-transition", toUint8(Property::IconHaloWidthTransition)},
+     {"icon-opacity-transition", toUint8(Property::IconOpacityTransition)},
+     {"icon-translate-transition", toUint8(Property::IconTranslateTransition)},
+     {"icon-translate-anchor-transition", toUint8(Property::IconTranslateAnchorTransition)},
+     {"text-color-transition", toUint8(Property::TextColorTransition)},
+     {"text-halo-blur-transition", toUint8(Property::TextHaloBlurTransition)},
+     {"text-halo-color-transition", toUint8(Property::TextHaloColorTransition)},
+     {"text-halo-width-transition", toUint8(Property::TextHaloWidthTransition)},
+     {"text-opacity-transition", toUint8(Property::TextOpacityTransition)},
+     {"text-translate-transition", toUint8(Property::TextTranslateTransition)},
+     {"text-translate-anchor-transition", toUint8(Property::TextTranslateAnchorTransition)}});
 
 } // namespace
 
 optional<Error> SymbolLayer::setPaintProperty(const std::string& name, const Convertible& value) {
     const auto it = paintProperties.find(name.c_str());
     if (it == paintProperties.end()) {
-        return Error { "layer doesn't support this property" };
+        return Error{"layer doesn't support this property"};
     }
 
     auto property = static_cast<Property>(it->second);
@@ -1288,79 +1293,78 @@ optional<Error> SymbolLayer::setPaintProperty(const std::string& name, const Con
     if (!transition) {
         return error;
     }
-    
+
     if (property == Property::IconColorTransition) {
         setIconColorTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::IconHaloBlurTransition) {
         setIconHaloBlurTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::IconHaloColorTransition) {
         setIconHaloColorTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::IconHaloWidthTransition) {
         setIconHaloWidthTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::IconOpacityTransition) {
         setIconOpacityTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::IconTranslateTransition) {
         setIconTranslateTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::IconTranslateAnchorTransition) {
         setIconTranslateAnchorTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::TextColorTransition) {
         setTextColorTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::TextHaloBlurTransition) {
         setTextHaloBlurTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::TextHaloColorTransition) {
         setTextHaloColorTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::TextHaloWidthTransition) {
         setTextHaloWidthTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::TextOpacityTransition) {
         setTextOpacityTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::TextTranslateTransition) {
         setTextTranslateTransition(*transition);
         return nullopt;
     }
-    
+
     if (property == Property::TextTranslateAnchorTransition) {
         setTextTranslateAnchorTransition(*transition);
         return nullopt;
     }
-    
 
-    return Error { "layer doesn't support this property" };
+    return Error{"layer doesn't support this property"};
 }
 
 LayerProperty SymbolLayer::getPaintProperty(const std::string& name) const {
@@ -1371,61 +1375,61 @@ LayerProperty SymbolLayer::getPaintProperty(const std::string& name) const {
 
     switch (static_cast<Property>(it->second)) {
         case Property::IconColor:
-            return conversion::makeLayerProperty(getIconColor());
+            return makeLayerProperty(getIconColor());
         case Property::IconHaloBlur:
-            return conversion::makeLayerProperty(getIconHaloBlur());
+            return makeLayerProperty(getIconHaloBlur());
         case Property::IconHaloColor:
-            return conversion::makeLayerProperty(getIconHaloColor());
+            return makeLayerProperty(getIconHaloColor());
         case Property::IconHaloWidth:
-            return conversion::makeLayerProperty(getIconHaloWidth());
+            return makeLayerProperty(getIconHaloWidth());
         case Property::IconOpacity:
-            return conversion::makeLayerProperty(getIconOpacity());
+            return makeLayerProperty(getIconOpacity());
         case Property::IconTranslate:
-            return conversion::makeLayerProperty(getIconTranslate());
+            return makeLayerProperty(getIconTranslate());
         case Property::IconTranslateAnchor:
-            return conversion::makeLayerProperty(getIconTranslateAnchor());
+            return makeLayerProperty(getIconTranslateAnchor());
         case Property::TextColor:
-            return conversion::makeLayerProperty(getTextColor());
+            return makeLayerProperty(getTextColor());
         case Property::TextHaloBlur:
-            return conversion::makeLayerProperty(getTextHaloBlur());
+            return makeLayerProperty(getTextHaloBlur());
         case Property::TextHaloColor:
-            return conversion::makeLayerProperty(getTextHaloColor());
+            return makeLayerProperty(getTextHaloColor());
         case Property::TextHaloWidth:
-            return conversion::makeLayerProperty(getTextHaloWidth());
+            return makeLayerProperty(getTextHaloWidth());
         case Property::TextOpacity:
-            return conversion::makeLayerProperty(getTextOpacity());
+            return makeLayerProperty(getTextOpacity());
         case Property::TextTranslate:
-            return conversion::makeLayerProperty(getTextTranslate());
+            return makeLayerProperty(getTextTranslate());
         case Property::TextTranslateAnchor:
-            return conversion::makeLayerProperty(getTextTranslateAnchor());
+            return makeLayerProperty(getTextTranslateAnchor());
         case Property::IconColorTransition:
-            return conversion::makeLayerProperty(getIconColorTransition());
+            return makeLayerProperty(getIconColorTransition());
         case Property::IconHaloBlurTransition:
-            return conversion::makeLayerProperty(getIconHaloBlurTransition());
+            return makeLayerProperty(getIconHaloBlurTransition());
         case Property::IconHaloColorTransition:
-            return conversion::makeLayerProperty(getIconHaloColorTransition());
+            return makeLayerProperty(getIconHaloColorTransition());
         case Property::IconHaloWidthTransition:
-            return conversion::makeLayerProperty(getIconHaloWidthTransition());
+            return makeLayerProperty(getIconHaloWidthTransition());
         case Property::IconOpacityTransition:
-            return conversion::makeLayerProperty(getIconOpacityTransition());
+            return makeLayerProperty(getIconOpacityTransition());
         case Property::IconTranslateTransition:
-            return conversion::makeLayerProperty(getIconTranslateTransition());
+            return makeLayerProperty(getIconTranslateTransition());
         case Property::IconTranslateAnchorTransition:
-            return conversion::makeLayerProperty(getIconTranslateAnchorTransition());
+            return makeLayerProperty(getIconTranslateAnchorTransition());
         case Property::TextColorTransition:
-            return conversion::makeLayerProperty(getTextColorTransition());
+            return makeLayerProperty(getTextColorTransition());
         case Property::TextHaloBlurTransition:
-            return conversion::makeLayerProperty(getTextHaloBlurTransition());
+            return makeLayerProperty(getTextHaloBlurTransition());
         case Property::TextHaloColorTransition:
-            return conversion::makeLayerProperty(getTextHaloColorTransition());
+            return makeLayerProperty(getTextHaloColorTransition());
         case Property::TextHaloWidthTransition:
-            return conversion::makeLayerProperty(getTextHaloWidthTransition());
+            return makeLayerProperty(getTextHaloWidthTransition());
         case Property::TextOpacityTransition:
-            return conversion::makeLayerProperty(getTextOpacityTransition());
+            return makeLayerProperty(getTextOpacityTransition());
         case Property::TextTranslateTransition:
-            return conversion::makeLayerProperty(getTextTranslateTransition());
+            return makeLayerProperty(getTextTranslateTransition());
         case Property::TextTranslateAnchorTransition:
-            return conversion::makeLayerProperty(getTextTranslateAnchorTransition());
+            return makeLayerProperty(getTextTranslateAnchorTransition());
     }
     return {};
 }

--- a/src/mbgl/util/color.cpp
+++ b/src/mbgl/util/color.cpp
@@ -45,10 +45,10 @@ std::array<double, 4> Color::toArray() const {
 }
 
 mbgl::Value Color::toObject() const {
-    return std::unordered_map<std::string, mbgl::Value>{{"r", double(r)},
-                                                        {"g", double(g)},
-                                                        {"b", double(b)},
-                                                        {"a", double(a)}};
+    return mapbox::base::ValueObject{{"r", double(r)},
+                                     {"g", double(g)},
+                                     {"b", double(b)},
+                                     {"a", double(a)}};
 }
 
 } // namespace mbgl

--- a/src/mbgl/util/color.cpp
+++ b/src/mbgl/util/color.cpp
@@ -45,10 +45,7 @@ std::array<double, 4> Color::toArray() const {
 }
 
 mbgl::Value Color::toObject() const {
-    return mapbox::base::ValueObject{{"r", double(r)},
-                                     {"g", double(g)},
-                                     {"b", double(b)},
-                                     {"a", double(a)}};
+    return mapbox::base::ValueObject{{"r", double(r)}, {"g", double(g)}, {"b", double(b)}, {"a", double(a)}};
 }
 
 } // namespace mbgl

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -953,17 +953,17 @@ TEST(Map, UniversalStyleGetter) {
     Layer* lineLayer = test.map.getStyle().getLayer("line");
     ASSERT_TRUE(lineLayer);
 
-    LayerProperty nonexistent = lineLayer->getPaintProperty("nonexistent");
+    StyleProperty nonexistent = lineLayer->getPaintProperty("nonexistent");
     ASSERT_FALSE(nonexistent.value);
-    EXPECT_EQ(LayerProperty::Kind::Undefined, nonexistent.kind);
+    EXPECT_EQ(StyleProperty::Kind::Undefined, nonexistent.kind);
 
-    LayerProperty undefined = lineLayer->getPaintProperty("line-blur");
+    StyleProperty undefined = lineLayer->getPaintProperty("line-blur");
     ASSERT_FALSE(undefined.value);
-    EXPECT_EQ(LayerProperty::Kind::Undefined, undefined.kind);
+    EXPECT_EQ(StyleProperty::Kind::Undefined, undefined.kind);
 
-    LayerProperty lineColor = lineLayer->getPaintProperty("line-color");
+    StyleProperty lineColor = lineLayer->getPaintProperty("line-color");
     ASSERT_TRUE(lineColor.value);
-    EXPECT_EQ(LayerProperty::Kind::Constant, lineColor.kind);
+    EXPECT_EQ(StyleProperty::Kind::Constant, lineColor.kind);
     ASSERT_TRUE(lineColor.value.getObject());
     const auto& color = *(lineColor.value.getObject());
     EXPECT_EQ(1.0, *color.at("r").getDouble());
@@ -971,21 +971,21 @@ TEST(Map, UniversalStyleGetter) {
     EXPECT_EQ(0.0, *color.at("b").getDouble());
     EXPECT_EQ(1.0, *color.at("a").getDouble());
 
-    LayerProperty lineOpacity = lineLayer->getPaintProperty("line-opacity");
+    StyleProperty lineOpacity = lineLayer->getPaintProperty("line-opacity");
     ASSERT_TRUE(lineOpacity.value);
-    EXPECT_EQ(LayerProperty::Kind::Constant, lineOpacity.kind);
+    EXPECT_EQ(StyleProperty::Kind::Constant, lineOpacity.kind);
     ASSERT_TRUE(lineOpacity.value.getDouble());
     EXPECT_EQ(0.5, *lineOpacity.value.getDouble());
 
-    LayerProperty lineOpacityTransition = lineLayer->getPaintProperty("line-opacity-transition");
+    StyleProperty lineOpacityTransition = lineLayer->getPaintProperty("line-opacity-transition");
     ASSERT_TRUE(lineOpacityTransition.value);
-    EXPECT_EQ(LayerProperty::Kind::Transition, lineOpacityTransition.kind);
+    EXPECT_EQ(StyleProperty::Kind::Transition, lineOpacityTransition.kind);
     ASSERT_TRUE(lineOpacityTransition.value.getArray());
     EXPECT_EQ(3u, lineOpacityTransition.value.getArray()->size());
 
-    LayerProperty lineWidth = lineLayer->getPaintProperty("line-width");
+    StyleProperty lineWidth = lineLayer->getPaintProperty("line-width");
     ASSERT_TRUE(lineWidth.value);
-    EXPECT_EQ(LayerProperty::Kind::Expression, lineWidth.kind);
+    EXPECT_EQ(StyleProperty::Kind::Expression, lineWidth.kind);
     ASSERT_TRUE(lineWidth.value.getArray());
 
     const auto& expression = *lineWidth.value.getArray();

--- a/vendor/mapbox-base-files.json
+++ b/vendor/mapbox-base-files.json
@@ -94,6 +94,7 @@
         "mapbox/pixelmatch.hpp": "vendor/mapbox-base/mapbox/pixelmatch-cpp/include/mapbox/pixelmatch.hpp",
         "supercluster.hpp": "vendor/mapbox-base/mapbox/supercluster.hpp/include/supercluster.hpp",
         "mapbox/type_wrapper.hpp": "vendor/mapbox-base/mapbox/typewrapper/include/mapbox/type_wrapper.hpp",
+        "mapbox/value.hpp": "vendor/mapbox-base/mapbox/value/include/mapbox/value.hpp",
         "mapbox/optional.hpp": "vendor/mapbox-base/mapbox/variant/include/mapbox/optional.hpp",
         "mapbox/recursive_wrapper.hpp": "vendor/mapbox-base/mapbox/variant/include/mapbox/recursive_wrapper.hpp",
         "mapbox/variant.hpp": "vendor/mapbox-base/mapbox/variant/include/mapbox/variant.hpp",


### PR DESCRIPTION
Style layer property is universally represented as:

```
struct LayerProperty {
    enum class Kind : uint8_t { Undefined, Constant, Expression, Transition };
    const Value value;
    const Kind kind = Kind::Undefined;
};
```
Where `Value` is `mapbox::base::value`.