### PR TITLE
[build] Re-enable clang-tidy on the bots

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,3 @@
-Checks: 'bugprone-*,clang-analyzer-*,cppcoreguidelines-*,google-*,misc-*,modernize-*,performance-*,readability-*,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-type-vararg,-cppcoreguidelines-special-member-functions,-google-readability-todo,-google-runtime-int,-misc-non-private-member-variables-in-classes,-readability-magic-numbers,-readability-named-parameter'
-WarningsAsErrors: '*'
+Checks: '-*,bugprone-*,clang-analyzer-*,google-*,modernize-*,performance-*,-clang-analyzer-osx.*,-google-readability-braces-around-statements,-google-readability-todo,-google-runtime-int,-google-runtime-references'
 HeaderFilterRegex: '.*'
 FormatStyle: file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,4 @@
 Checks: '-*,bugprone-*,clang-analyzer-*,google-*,modernize-*,performance-*,-clang-analyzer-osx.*,-google-readability-braces-around-statements,-google-readability-todo,-google-runtime-int,-google-runtime-references'
+WarningsAsErrors: 'bugprone-use-after-move'
 HeaderFilterRegex: '.*'
 FormatStyle: file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
 Checks: '-*,bugprone-*,clang-analyzer-*,google-*,modernize-*,performance-*,-clang-analyzer-osx.*,-google-readability-braces-around-statements,-google-readability-todo,-google-runtime-int,-google-runtime-references'
-WarningsAsErrors: 'bugprone-use-after-move'
+WarningsAsErrors: 'bugprone-use-after-move,performance-move-const-arg'
 HeaderFilterRegex: '.*'
 FormatStyle: file

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ xcuserdata
 /platform/node/test/diff
 /mason_packages
 /build
+/next/build
 /lib
 /test/node_modules
 /test/fixtures/*/*_actual.*

--- a/circle.yml
+++ b/circle.yml
@@ -9,8 +9,6 @@ workflows:
           name: next-android-armeabi-v7a-release
           executor_name: ubuntu-disco
           target_is_android: true
-          requires:
-            - next-sanity-checks
           config_params: '-G Ninja -DCMAKE_TOOLCHAIN_FILE=/opt/android/ndk-bundle/build/cmake/android.toolchain.cmake -DANDROID_CCACHE=/usr/bin/ccache -DANDROID_ABI=armeabi-v7a'
       - next-build-template:
           name: next-android-arm64-v8a-release
@@ -37,8 +35,6 @@ workflows:
           name: next-linux-gcc8-release
           executor_name: ubuntu-disco
           target_is_linux: true
-          requires:
-            - next-sanity-checks
           config_params: '-G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8'
       - next-build-template:
           name: next-linux-gcc4.9-release
@@ -60,15 +56,13 @@ workflows:
           name: next-linux-clang8-release
           executor_name: ubuntu-disco
           target_is_linux: true
-          requires:
-            - next-sanity-checks
           config_params: '-G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8'
       - next-build-template:
           name: next-FIXME-linux-asan
           executor_name: ubuntu-disco
           target_is_linux: true
           requires:
-            - next-linux-gcc8-debug-coverage
+            - next-sanity-checks
           config_params: '-G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8 -DCMAKE_BUILD_TYPE=Sanitize -DMBGL_WITH_SANITIZER=address'
           test_params: '|| true'
       - next-build-template:
@@ -76,14 +70,14 @@ workflows:
           executor_name: ubuntu-disco
           target_is_linux: true
           requires:
-            - next-linux-gcc8-debug-coverage
+            - next-sanity-checks
           config_params: '-G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8 -DCMAKE_BUILD_TYPE=Sanitize -DMBGL_WITH_SANITIZER=thread'
       - next-build-template:
           name: next-FIXME-linux-memsan
           executor_name: ubuntu-disco
           target_is_linux: true
           requires:
-            - next-linux-gcc8-debug-coverage
+            - next-sanity-checks
           config_params: '-G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8 -DCMAKE_BUILD_TYPE=Sanitize -DMBGL_WITH_SANITIZER=memory'
           test_params: '|| true'
       - next-build-template:
@@ -91,15 +85,13 @@ workflows:
           executor_name: ubuntu-disco
           target_is_linux: true
           requires:
-            - next-linux-gcc8-debug-coverage
+            - next-sanity-checks
           config_params: '-G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8 -DCMAKE_BUILD_TYPE=Sanitize -DMBGL_WITH_SANITIZER=undefined'
           test_params: '|| true'
       - next-build-template:
           name: next-qt5-linux-gcc5-release
           executor_name: ubuntu-disco
           target_is_linux: true
-          requires:
-            - next-sanity-checks
           config_params: '-G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc-5 -DCMAKE_CXX_COMPILER=g++-5 -DMBGL_WITH_QT=ON'
       - next-build-template:
           name: next-qt5-macos-gcc5-release
@@ -113,8 +105,6 @@ workflows:
           name: next-macos-xcode11-release
           executor_name: macos-11_0_0
           target_is_macos: true
-          requires:
-            - next-sanity-checks
           config_params: '-G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache'
       - next-build-template:
           name: next-macos-xcode11-debug
@@ -127,8 +117,6 @@ workflows:
           name: next-ios-xcode11-release
           executor_name: macos-11_0_0
           target_is_macos: true
-          requires:
-            - next-sanity-checks
           config_params: '-G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_OSX_SYSROOT=iphonesimulator'
           test_params: '-Q -N'
   mbgl-legacy:
@@ -281,10 +269,10 @@ commands:
           name: Collecting artifacts
           when: on_fail
           command: |
-            mkdir -p /tmp/tests/coredumps
-            if ls core* 1> /dev/null 2>&1; then cp core* /tmp/tests/coredumps; fi
             mkdir -p /tmp/tests/render
             if [ -f mapbox-gl-js/test/integration/render-tests/index.html ]; then cp mapbox-gl-js/test/integration/render-tests/index.html /tmp/tests/render; fi
+            mkdir -p /tmp/tests/coredumps
+            if ls core* 1> /dev/null 2>&1; then cp core* /tmp/tests/coredumps; fi
       - store_artifacts:
           path: /tmp/tests
           destination: tests
@@ -718,7 +706,15 @@ jobs:
       - checkout
       - next-prepare
       - next-config:
-          config_params: '-DMBGL_WITH_CORE_ONLY=ON'
+          config_params: '-G Ninja -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8'
+      - run:
+          name: Code Generators
+          command: |
+            platform/android/scripts/generate-style-code.js
+            scripts/generate-file-lists.js
+            scripts/generate-shaders.js
+            scripts/generate-style-code.js
+            git add -A && git diff --staged --exit-code
       - run:
           name: CMake Format
           command: |
@@ -730,13 +726,12 @@ jobs:
             git diff -U0 --ignore-submodules=all --no-color origin/master... *.cpp *.hpp | clang-format-diff-8 -p1 -i
             git diff --exit-code
       - run:
-          name: Code Generators
+          name: Clang Tidy
           command: |
-            platform/android/scripts/generate-style-code.js
-            scripts/generate-file-lists.js
-            scripts/generate-shaders.js
-            scripts/generate-style-code.js
-            git add -A && git diff --staged --exit-code
+            run-clang-tidy-8 -quiet -j24 -p build $PWD/src/.*cpp $PWD/platform/.*cpp |tee clang-tidy.log
+            grep -o \\[[a-z].*-.*[a-z]\] clang-tidy.log |sort |uniq -c |sort -n
+            mkdir -p /tmp/tests/clang-tidy
+            if [ -f clang-tidy.log ]; then cp clang-tidy.log /tmp/tests/clang-tidy; fi
       - next-save
   next-build-template:
     parameters:

--- a/include/mbgl/annotation/annotation.hpp
+++ b/include/mbgl/annotation/annotation.hpp
@@ -16,9 +16,7 @@ using AnnotationIDs = std::vector<AnnotationID>;
 
 class SymbolAnnotation {
 public:
-    SymbolAnnotation(Point<double> geometry_, std::string icon_ = {})
-        : geometry(std::move(geometry_)),
-          icon(std::move(icon_)) {}
+    SymbolAnnotation(Point<double> geometry_, std::string icon_ = {}) : geometry(geometry_), icon(std::move(icon_)) {}
 
     Point<double> geometry;
     std::string icon;

--- a/include/mbgl/storage/resource_transform.hpp
+++ b/include/mbgl/storage/resource_transform.hpp
@@ -12,12 +12,12 @@ class Mailbox;
 
 class ResourceTransform {
 public:
-    using TransformCallback = std::function<std::string(Resource::Kind kind, const std::string&& url)>;
+    using TransformCallback = std::function<std::string(Resource::Kind kind, const std::string& url)>;
     using FinishedCallback = std::function<void(const std::string&&)>;
 
     ResourceTransform(ActorRef<ResourceTransform>, TransformCallback&&);
 
-    void transform(Resource::Kind, const std::string&& url, FinishedCallback&&);
+    void transform(Resource::Kind, const std::string& url, FinishedCallback&&);
 
 private:
     TransformCallback transformCallback;

--- a/include/mbgl/style/conversion_impl.hpp
+++ b/include/mbgl/style/conversion_impl.hpp
@@ -90,6 +90,7 @@ public:
     }
 
     Convertible(Convertible&& v) : vtable(v.vtable) {
+        // NOLINTNEXTLINE(performance-move-const-arg)
         vtable->move(std::move(v.storage), storage);
     }
 
@@ -101,6 +102,7 @@ public:
         if (this != &v) {
             vtable->destroy(storage);
             vtable = v.vtable;
+            // NOLINTNEXTLINE(performance-move-const-arg)
             vtable->move(std::move(v.storage), storage);
         }
         return *this;

--- a/include/mbgl/style/layers/background_layer.hpp
+++ b/include/mbgl/style/layers/background_layer.hpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Do not edit.
 
 #pragma once
@@ -57,3 +59,5 @@ protected:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/include/mbgl/style/layers/circle_layer.hpp
+++ b/include/mbgl/style/layers/circle_layer.hpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Do not edit.
 
 #pragma once
@@ -105,3 +107,5 @@ protected:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/include/mbgl/style/layers/fill_extrusion_layer.hpp
+++ b/include/mbgl/style/layers/fill_extrusion_layer.hpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Do not edit.
 
 #pragma once
@@ -87,3 +89,5 @@ protected:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/include/mbgl/style/layers/fill_layer.hpp
+++ b/include/mbgl/style/layers/fill_layer.hpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Do not edit.
 
 #pragma once
@@ -81,3 +83,5 @@ protected:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/include/mbgl/style/layers/heatmap_layer.hpp
+++ b/include/mbgl/style/layers/heatmap_layer.hpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Do not edit.
 
 #pragma once
@@ -70,3 +72,5 @@ protected:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/include/mbgl/style/layers/hillshade_layer.hpp
+++ b/include/mbgl/style/layers/hillshade_layer.hpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Do not edit.
 
 #pragma once
@@ -75,3 +77,5 @@ protected:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/include/mbgl/style/layers/layer.hpp.ejs
+++ b/include/mbgl/style/layers/layer.hpp.ejs
@@ -3,6 +3,8 @@
   const layoutProperties = locals.layoutProperties;
   const paintProperties = locals.paintProperties;
 -%>
+// clang-format off
+
 // This file is generated. Do not edit.
 
 #pragma once
@@ -73,3 +75,5 @@ protected:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/include/mbgl/style/layers/line_layer.hpp
+++ b/include/mbgl/style/layers/line_layer.hpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Do not edit.
 
 #pragma once
@@ -126,3 +128,5 @@ protected:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/include/mbgl/style/layers/raster_layer.hpp
+++ b/include/mbgl/style/layers/raster_layer.hpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Do not edit.
 
 #pragma once
@@ -87,3 +89,5 @@ protected:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/include/mbgl/style/layers/symbol_layer.hpp
+++ b/include/mbgl/style/layers/symbol_layer.hpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Do not edit.
 
 #pragma once
@@ -291,3 +293,5 @@ protected:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/include/mbgl/style/light.hpp
+++ b/include/mbgl/style/light.hpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Do not edit.
 
 #pragma once
@@ -55,3 +57,5 @@ public:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/include/mbgl/style/light.hpp.ejs
+++ b/include/mbgl/style/light.hpp.ejs
@@ -1,6 +1,8 @@
 <%
   const properties = locals.properties;
 -%>
+// clang-format off
+
 // This file is generated. Do not edit.
 
 #pragma once
@@ -42,3 +44,5 @@ public:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/include/mbgl/tile/tile_id.hpp
+++ b/include/mbgl/tile/tile_id.hpp
@@ -141,7 +141,7 @@ inline std::array<CanonicalTileID, 4> CanonicalTileID::children() const {
 }
 
 inline OverscaledTileID::OverscaledTileID(uint8_t overscaledZ_, int16_t wrap_, CanonicalTileID canonical_)
-    : overscaledZ(overscaledZ_), wrap(wrap_), canonical(std::move(canonical_)) {
+    : overscaledZ(overscaledZ_), wrap(wrap_), canonical(canonical_) {
     assert(overscaledZ >= canonical.z);
 }
 
@@ -207,8 +207,7 @@ inline UnwrappedTileID::UnwrappedTileID(uint8_t z_, int64_t x_, int64_t y_)
 }
 
 inline UnwrappedTileID::UnwrappedTileID(int16_t wrap_, CanonicalTileID canonical_)
-    : wrap(wrap_), canonical(std::move(canonical_)) {
-}
+    : wrap(wrap_), canonical(canonical_) {}
 
 inline bool UnwrappedTileID::operator==(const UnwrappedTileID& rhs) const {
     return wrap == rhs.wrap && canonical == rhs.canonical;

--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -170,8 +170,7 @@ private:
     LatLng ne;
     bool bounded = true;
 
-    LatLngBounds(LatLng sw_, LatLng ne_)
-        : sw(std::move(sw_)), ne(std::move(ne_)) {}
+    LatLngBounds(LatLng sw_, LatLng ne_) : sw(sw_), ne(ne_) {}
 
     LatLngBounds()
         : sw({-90, -180}), ne({90, 180}), bounded(false) {}

--- a/include/mbgl/util/image.hpp
+++ b/include/mbgl/util/image.hpp
@@ -22,12 +22,9 @@ class Image : private util::noncopyable {
 public:
     Image() = default;
 
-    Image(Size size_)
-        : size(std::move(size_)),
-          data(std::make_unique<uint8_t[]>(bytes())) {}
+    Image(Size size_) : size(size_), data(std::make_unique<uint8_t[]>(bytes())) {}
 
-    Image(Size size_, const uint8_t* srcData, std::size_t srcLength)
-        : size(std::move(size_)) {
+    Image(Size size_, const uint8_t* srcData, std::size_t srcLength) : size(size_) {
         if (srcLength != bytes()) {
             throw std::invalid_argument("mismatched image size");
         }
@@ -35,9 +32,7 @@ public:
         std::copy(srcData, srcData + srcLength, data.get());
     }
 
-    Image(Size size_, std::unique_ptr<uint8_t[]> data_)
-        : size(std::move(size_)),
-          data(std::move(data_)) {}
+    Image(Size size_, std::unique_ptr<uint8_t[]> data_) : size(size_), data(std::move(data_)) {}
 
     Image(Image&& o)
         : size(o.size),

--- a/include/mbgl/util/tileset.hpp
+++ b/include/mbgl/util/tileset.hpp
@@ -24,18 +24,17 @@ public:
     DEMEncoding encoding;
     optional<LatLngBounds> bounds;
 
-
     Tileset(std::vector<std::string> tiles_ = std::vector<std::string>(),
-            Range<uint8_t> zoomRange_ = { 0, util::DEFAULT_MAX_ZOOM },
+            Range<uint8_t> zoomRange_ = {0, util::DEFAULT_MAX_ZOOM},
             std::string attribution_ = {},
             Scheme scheme_ = Scheme::XYZ,
             DEMEncoding encoding_ = DEMEncoding::Mapbox)
         : tiles(std::move(tiles_)),
-          zoomRange(std::move(zoomRange_)),
+          zoomRange(zoomRange_),
           attribution(std::move(attribution_)),
           scheme(scheme_),
           encoding(encoding_),
-          bounds() {};
+          bounds(){};
 
     // TileJSON also includes center and zoom but they are not used by mbgl.
 

--- a/platform/android/src/file_source.cpp
+++ b/platform/android/src/file_source.cpp
@@ -58,14 +58,15 @@ void FileSource::setAPIBaseUrl(jni::JNIEnv& env, const jni::String& url) {
 void FileSource::setResourceTransform(jni::JNIEnv& env, const jni::Object<FileSource::ResourceTransformCallback>& transformCallback) {
     if (transformCallback) {
         auto global = jni::NewGlobal<jni::EnvAttachingDeleter>(env, transformCallback);
-        resourceTransform = std::make_unique<Actor<ResourceTransform>>(*Scheduler::GetCurrent(),
+        resourceTransform = std::make_unique<Actor<ResourceTransform>>(
+            *Scheduler::GetCurrent(),
             // Capture the ResourceTransformCallback object as a managed global into
             // the lambda. It is released automatically when we're setting a new ResourceTransform in
             // a subsequent call.
             // Note: we're converting it to shared_ptr because this lambda is converted to a std::function,
             // which requires copyability of its captured variables.
-            [callback = std::make_shared<decltype(global)>(std::move(global))]
-            (mbgl::Resource::Kind kind, const std::string&& url_) {
+            [callback = std::make_shared<decltype(global)>(std::move(global))](mbgl::Resource::Kind kind,
+                                                                               const std::string& url_) {
                 android::UniqueEnv _env = android::AttachEnv();
                 return FileSource::ResourceTransformCallback::onURL(*_env, *callback, int(kind), url_);
             });

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -91,7 +91,7 @@ const MGLExceptionName MGLUnsupportedRegionTypeException = @"MGLUnsupportedRegio
     MGLLogDebug(@"Setting delegate: %@", newValue);
     _delegate = newValue;
     if ([self.delegate respondsToSelector:@selector(offlineStorage:URLForResourceOfKind:withURL:)]) {
-        _mbglResourceTransform = std::make_unique<mbgl::Actor<mbgl::ResourceTransform>>(*mbgl::Scheduler::GetCurrent(), [offlineStorage = self](auto kind_, const std::string&& url_) -> std::string {
+        _mbglResourceTransform = std::make_unique<mbgl::Actor<mbgl::ResourceTransform>>(*mbgl::Scheduler::GetCurrent(), [offlineStorage = self](auto kind_, const std::string& url_) -> std::string {
             NSURL* url =
             [NSURL URLWithString:[[NSString alloc] initWithBytes:url_.data()
                                                           length:url_.length()

--- a/platform/default/src/mbgl/storage/offline.cpp
+++ b/platform/default/src/mbgl/storage/offline.cpp
@@ -16,10 +16,14 @@ namespace mbgl {
 
 // OfflineTilePyramidRegionDefinition
 
-OfflineTilePyramidRegionDefinition::OfflineTilePyramidRegionDefinition(
-    std::string styleURL_, LatLngBounds bounds_, double minZoom_, double maxZoom_, float pixelRatio_, bool includeIdeographs_)
+OfflineTilePyramidRegionDefinition::OfflineTilePyramidRegionDefinition(std::string styleURL_,
+                                                                       LatLngBounds bounds_,
+                                                                       double minZoom_,
+                                                                       double maxZoom_,
+                                                                       float pixelRatio_,
+                                                                       bool includeIdeographs_)
     : styleURL(std::move(styleURL_)),
-      bounds(std::move(bounds_)),
+      bounds(bounds_),
       minZoom(minZoom_),
       maxZoom(maxZoom_),
       pixelRatio(pixelRatio_),
@@ -29,7 +33,6 @@ OfflineTilePyramidRegionDefinition::OfflineTilePyramidRegionDefinition(
         throw std::invalid_argument("Invalid offline region definition");
     }
 }
-
 
 // OfflineGeometryRegionDefinition
 

--- a/platform/default/src/mbgl/storage/offline_download.cpp
+++ b/platform/default/src/mbgl/storage/offline_download.cpp
@@ -433,7 +433,7 @@ void OfflineDownload::ensureResource(Resource&& resource,
                 }
             }
 
-            if (result) resourcesToBeMarkedAsUsed.emplace_back(std::move(resource));
+            if (result) resourcesToBeMarkedAsUsed.emplace_back(resource);
             return result;
         };
 

--- a/platform/default/src/mbgl/storage/online_file_source.cpp
+++ b/platform/default/src/mbgl/storage/online_file_source.cpp
@@ -78,10 +78,12 @@ public:
         if (resourceTransform) {
             // Request the ResourceTransform actor a new url and replace the resource url with the
             // transformed one before proceeding to schedule the request.
-            resourceTransform->invoke(&ResourceTransform::transform, request->resource.kind,
-                std::move(request->resource.url), [ref = request->actor()](const std::string&& url) {
-                    ref.invoke(&OnlineFileRequest::setTransformedURL, std::move(url));
-                });
+            resourceTransform->invoke(&ResourceTransform::transform,
+                                      request->resource.kind,
+                                      std::move(request->resource.url),
+                                      [ref = request->actor()](const std::string&& url) {
+                                          ref.invoke(&OnlineFileRequest::setTransformedURL, url);
+                                      });
         } else {
             request->schedule();
         }
@@ -466,8 +468,8 @@ void OnlineFileRequest::networkIsReachableAgain() {
 }
 
 void OnlineFileRequest::setTransformedURL(const std::string&& url) {
-     resource.url = std::move(url);
-     schedule();
+    resource.url = url;
+    schedule();
 }
 
 ActorRef<OnlineFileRequest> OnlineFileRequest::actor() {

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -474,7 +474,7 @@ void NodeMap::startRender(NodeMap::RenderOptions options) {
 
     map->renderStill(camera, options.debugOptions, [this](const std::exception_ptr eptr) {
         if (eptr) {
-            error = std::move(eptr);
+            error = eptr;
             uv_async_send(async);
         } else {
             assert(!image.data);

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -72,8 +72,8 @@ public:
     QString localFontFamily() const;
     void setLocalFontFamily(const QString &);
 
-    std::function<std::string(const std::string &&)> resourceTransform() const;
-    void setResourceTransform(const std::function<std::string(const std::string &&)> &);
+    std::function<std::string(const std::string &)> resourceTransform() const;
+    void setResourceTransform(const std::function<std::string(const std::string &)> &);
 
 private:
     GLContextMode m_contextMode;
@@ -87,7 +87,7 @@ private:
     QString m_accessToken;
     QString m_apiBaseUrl;
     QString m_localFontFamily;
-    std::function<std::string(const std::string &&)> m_resourceTransform;
+    std::function<std::string(const std::string &)> m_resourceTransform;
 };
 
 struct Q_MAPBOXGL_EXPORT QMapboxGLCameraOptions {

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -439,8 +439,7 @@ void QMapboxGLSettings::setLocalFontFamily(const QString &family)
 /*!
     Returns resource transformation callback used to transform requested URLs.
 */
-std::function<std::string(const std::string &&)> QMapboxGLSettings::resourceTransform() const
-{
+std::function<std::string(const std::string &)> QMapboxGLSettings::resourceTransform() const {
     return m_resourceTransform;
 }
 
@@ -452,8 +451,7 @@ std::function<std::string(const std::string &&)> QMapboxGLSettings::resourceTran
     used add or remove custom parameters, or reroute certain requests to other
     servers or endpoints.
 */
-void QMapboxGLSettings::setResourceTransform(const std::function<std::string(const std::string &&)> &transform)
-{
+void QMapboxGLSettings::setResourceTransform(const std::function<std::string(const std::string &)> &transform) {
     m_resourceTransform = transform;
 }
 
@@ -1744,8 +1742,9 @@ QMapboxGLPrivate::QMapboxGLPrivate(QMapboxGL *q, const QMapboxGLSettings &settin
                                          resourceOptions);
 
      if (settings.resourceTransform()) {
-         m_resourceTransform = std::make_unique<mbgl::Actor<mbgl::ResourceTransform>>(*mbgl::Scheduler::GetCurrent(),
-             [callback = settings.resourceTransform()] (mbgl::Resource::Kind, const std::string &&url_) -> std::string {
+         m_resourceTransform = std::make_unique<mbgl::Actor<mbgl::ResourceTransform>>(
+             *mbgl::Scheduler::GetCurrent(),
+             [callback = settings.resourceTransform()](mbgl::Resource::Kind, const std::string &url_) -> std::string {
                  return callback(std::move(url_));
              });
          auto fs = mbgl::FileSource::getSharedFileSource(resourceOptions);

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -210,7 +210,8 @@ UniqueTexture Context::createUniqueTexture() {
 
     TextureID id = pooledTextures.back();
     pooledTextures.pop_back();
-    return UniqueTexture{ std::move(id), { this } };
+    // NOLINTNEXTLINE(performance-move-const-arg)
+    return UniqueTexture{std::move(id), {this}};
 }
 
 bool Context::supportsVertexArrays() const {
@@ -224,6 +225,7 @@ VertexArray Context::createVertexArray() {
     if (supportsVertexArrays()) {
         VertexArrayID id = 0;
         MBGL_CHECK_ERROR(vertexArray->genVertexArrays(1, &id));
+        // NOLINTNEXTLINE(performance-move-const-arg)
         UniqueVertexArray vao(std::move(id), { this });
         return { UniqueVertexArrayState(new VertexArrayState(std::move(vao)), VertexArrayStateDeleter { true })};
     } else {
@@ -236,6 +238,7 @@ VertexArray Context::createVertexArray() {
 UniqueFramebuffer Context::createFramebuffer() {
     FramebufferID id = 0;
     MBGL_CHECK_ERROR(glGenFramebuffers(1, &id));
+    // NOLINTNEXTLINE(performance-move-const-arg)
     return UniqueFramebuffer{ std::move(id), { this } };
 }
 
@@ -269,6 +272,7 @@ std::unique_ptr<gfx::RenderbufferResource>
 Context::createRenderbufferResource(const gfx::RenderbufferPixelType type, const Size size) {
     RenderbufferID id = 0;
     MBGL_CHECK_ERROR(glGenRenderbuffers(1, &id));
+    // NOLINTNEXTLINE(performance-move-const-arg)
     UniqueRenderbuffer renderbuffer{ std::move(id), { this } };
 
     bindRenderbuffer = renderbuffer;

--- a/src/mbgl/gl/uniform.hpp
+++ b/src/mbgl/gl/uniform.hpp
@@ -37,8 +37,7 @@ ActiveUniforms activeUniforms(ProgramID);
 template <class Value>
 class UniformState {
 public:
-    UniformState(UniformLocation location_ = -1) : location(std::move(location_)) {
-    }
+    UniformState(UniformLocation location_ = -1) : location(location_) {}
 
     void operator=(const Value& value) {
         if (location >= 0 && (!current || *current != value)) {

--- a/src/mbgl/gl/upload_pass.cpp
+++ b/src/mbgl/gl/upload_pass.cpp
@@ -20,6 +20,7 @@ std::unique_ptr<gfx::VertexBufferResource> UploadPass::createVertexBufferResourc
     const void* data, std::size_t size, const gfx::BufferUsageType usage) {
     BufferID id = 0;
     MBGL_CHECK_ERROR(glGenBuffers(1, &id));
+    // NOLINTNEXTLINE(performance-move-const-arg)
     UniqueBuffer result{ std::move(id), { commandEncoder.context } };
     commandEncoder.context.vertexBuffer = result;
     MBGL_CHECK_ERROR(
@@ -38,6 +39,7 @@ std::unique_ptr<gfx::IndexBufferResource> UploadPass::createIndexBufferResource(
     const void* data, std::size_t size, const gfx::BufferUsageType usage) {
     BufferID id = 0;
     MBGL_CHECK_ERROR(glGenBuffers(1, &id));
+    // NOLINTNEXTLINE(performance-move-const-arg)
     UniqueBuffer result{ std::move(id), { commandEncoder.context } };
     commandEncoder.context.bindVertexArray = 0;
     commandEncoder.context.globalVertexArrayState.indexBuffer = result;

--- a/src/mbgl/layermanager/background_layer_factory.cpp
+++ b/src/mbgl/layermanager/background_layer_factory.cpp
@@ -17,7 +17,7 @@ std::unique_ptr<style::Layer> BackgroundLayerFactory::createLayer(const std::str
 
 std::unique_ptr<RenderLayer> BackgroundLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
     assert(impl->getTypeInfo() == getTypeInfo());
-    return std::make_unique<RenderBackgroundLayer>(staticImmutableCast<style::BackgroundLayer::Impl>(std::move(impl)));
+    return std::make_unique<RenderBackgroundLayer>(staticImmutableCast<style::BackgroundLayer::Impl>(impl));
 }
 
 } // namespace mbgl

--- a/src/mbgl/layermanager/circle_layer_factory.cpp
+++ b/src/mbgl/layermanager/circle_layer_factory.cpp
@@ -30,7 +30,7 @@ std::unique_ptr<Bucket> CircleLayerFactory::createBucket(const BucketParameters&
 
 std::unique_ptr<RenderLayer> CircleLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
     assert(impl->getTypeInfo() == getTypeInfo());
-    return std::make_unique<RenderCircleLayer>(staticImmutableCast<style::CircleLayer::Impl>(std::move(impl)));
+    return std::make_unique<RenderCircleLayer>(staticImmutableCast<style::CircleLayer::Impl>(impl));
 }
 
 } // namespace mbgl

--- a/src/mbgl/layermanager/custom_layer_factory.cpp
+++ b/src/mbgl/layermanager/custom_layer_factory.cpp
@@ -16,7 +16,7 @@ std::unique_ptr<style::Layer> CustomLayerFactory::createLayer(const std::string&
 }
 
 std::unique_ptr<RenderLayer> CustomLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
-    return std::make_unique<RenderCustomLayer>(staticImmutableCast<style::CustomLayer::Impl>(std::move(impl)));
+    return std::make_unique<RenderCustomLayer>(staticImmutableCast<style::CustomLayer::Impl>(impl));
 }
 
 } // namespace mbgl

--- a/src/mbgl/layermanager/fill_extrusion_layer_factory.cpp
+++ b/src/mbgl/layermanager/fill_extrusion_layer_factory.cpp
@@ -34,7 +34,7 @@ std::unique_ptr<Layout> FillExtrusionLayerFactory::createLayout(const LayoutPara
 
 std::unique_ptr<RenderLayer> FillExtrusionLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
     assert(impl->getTypeInfo() == getTypeInfo());
-    return std::make_unique<RenderFillExtrusionLayer>(staticImmutableCast<style::FillExtrusionLayer::Impl>(std::move(impl)));
+    return std::make_unique<RenderFillExtrusionLayer>(staticImmutableCast<style::FillExtrusionLayer::Impl>(impl));
 }
 
 } // namespace mbgl

--- a/src/mbgl/layermanager/fill_layer_factory.cpp
+++ b/src/mbgl/layermanager/fill_layer_factory.cpp
@@ -35,7 +35,7 @@ FillLayerFactory::createLayout(const LayoutParameters& parameters,
 
 std::unique_ptr<RenderLayer> FillLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
     assert(impl->getTypeInfo() == getTypeInfo());
-    return std::make_unique<RenderFillLayer>(staticImmutableCast<style::FillLayer::Impl>(std::move(impl)));
+    return std::make_unique<RenderFillLayer>(staticImmutableCast<style::FillLayer::Impl>(impl));
 }
 
 } // namespace mbgl

--- a/src/mbgl/layermanager/heatmap_layer_factory.cpp
+++ b/src/mbgl/layermanager/heatmap_layer_factory.cpp
@@ -30,7 +30,7 @@ std::unique_ptr<Bucket> HeatmapLayerFactory::createBucket(const BucketParameters
 
 std::unique_ptr<RenderLayer> HeatmapLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
     assert(impl->getTypeInfo() == getTypeInfo());
-    return std::make_unique<RenderHeatmapLayer>(staticImmutableCast<style::HeatmapLayer::Impl>(std::move(impl)));
+    return std::make_unique<RenderHeatmapLayer>(staticImmutableCast<style::HeatmapLayer::Impl>(impl));
 }
 
 } // namespace mbgl

--- a/src/mbgl/layermanager/hillshade_layer_factory.cpp
+++ b/src/mbgl/layermanager/hillshade_layer_factory.cpp
@@ -22,7 +22,7 @@ std::unique_ptr<style::Layer> HillshadeLayerFactory::createLayer(const std::stri
 
 std::unique_ptr<RenderLayer> HillshadeLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
     assert(impl->getTypeInfo() == getTypeInfo());
-    return std::make_unique<RenderHillshadeLayer>(staticImmutableCast<style::HillshadeLayer::Impl>(std::move(impl)));
+    return std::make_unique<RenderHillshadeLayer>(staticImmutableCast<style::HillshadeLayer::Impl>(impl));
 }
 
 } // namespace mbgl

--- a/src/mbgl/layermanager/line_layer_factory.cpp
+++ b/src/mbgl/layermanager/line_layer_factory.cpp
@@ -34,7 +34,7 @@ std::unique_ptr<Layout> LineLayerFactory::createLayout(const LayoutParameters& p
 
 std::unique_ptr<RenderLayer> LineLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
     assert(impl->getTypeInfo() == getTypeInfo());
-    return std::make_unique<RenderLineLayer>(staticImmutableCast<style::LineLayer::Impl>(std::move(impl)));
+    return std::make_unique<RenderLineLayer>(staticImmutableCast<style::LineLayer::Impl>(impl));
 }
 
 } // namespace mbgl

--- a/src/mbgl/layermanager/raster_layer_factory.cpp
+++ b/src/mbgl/layermanager/raster_layer_factory.cpp
@@ -22,7 +22,7 @@ std::unique_ptr<style::Layer> RasterLayerFactory::createLayer(const std::string&
 
 std::unique_ptr<RenderLayer> RasterLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
     assert(impl->getTypeInfo() == getTypeInfo());
-    return std::make_unique<RenderRasterLayer>(staticImmutableCast<style::RasterLayer::Impl>(std::move(impl)));
+    return std::make_unique<RenderRasterLayer>(staticImmutableCast<style::RasterLayer::Impl>(impl));
 }
 
 } // namespace mbgl

--- a/src/mbgl/layermanager/symbol_layer_factory.cpp
+++ b/src/mbgl/layermanager/symbol_layer_factory.cpp
@@ -36,7 +36,7 @@ std::unique_ptr<Layout> SymbolLayerFactory::createLayout(const LayoutParameters&
 
 std::unique_ptr<RenderLayer> SymbolLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
     assert(impl->getTypeInfo() == getTypeInfo());
-    return std::make_unique<RenderSymbolLayer>(staticImmutableCast<style::SymbolLayer::Impl>(std::move(impl)));
+    return std::make_unique<RenderSymbolLayer>(staticImmutableCast<style::SymbolLayer::Impl>(impl));
 }
 
 } // namespace mbgl

--- a/src/mbgl/layout/symbol_projection.hpp
+++ b/src/mbgl/layout/symbol_projection.hpp
@@ -29,11 +29,9 @@ namespace mbgl {
             : point(point_), angle(angle_), tileDistance(std::move(tileDistance_))
         {}
         PlacedGlyph(PlacedGlyph&& other) noexcept
-            : point(std::move(other.point)), angle(other.angle), tileDistance(std::move(other.tileDistance))
-        {}
+            : point(other.point), angle(other.angle), tileDistance(std::move(other.tileDistance)) {}
         PlacedGlyph(const PlacedGlyph& other)
-            : point(std::move(other.point)), angle(other.angle), tileDistance(std::move(other.tileDistance))
-        {}
+            : point(other.point), angle(other.angle), tileDistance(other.tileDistance) {}
         Point<float> point;
         float angle;
         optional<TileDistance> tileDistance;

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -356,7 +356,7 @@ void Transform::setLatLngBounds(LatLngBounds bounds) {
     if (!bounds.valid()) {
         throw std::runtime_error("failed to set bounds: bounds are invalid");
     }
-    state.setLatLngBounds(std::move(bounds));
+    state.setLatLngBounds(bounds);
 }
 
 void Transform::setMinZoom(const double minZoom) {

--- a/src/mbgl/programs/collision_box_program.hpp
+++ b/src/mbgl/programs/collision_box_program.hpp
@@ -89,21 +89,20 @@ public:
                 drawScopeIt = segment.drawScopes.emplace(layerID, context.createDrawScope()).first;
             }
 
-            program->draw(
-                    context,
-                    renderPass,
-                    std::move(drawMode),
-                    std::move(depthMode),
-                    std::move(stencilMode),
-                    std::move(colorMode),
-                    std::move(cullFaceMode),
-                    uniformValues,
-                    drawScopeIt->second,
-                    allAttributeBindings.offset(segment.vertexOffset),
-                    textureBindings,
-                    indexBuffer,
-                    segment.indexOffset,
-                    segment.indexLength);
+            program->draw(context,
+                          renderPass,
+                          drawMode,
+                          depthMode,
+                          stencilMode,
+                          colorMode,
+                          cullFaceMode,
+                          uniformValues,
+                          drawScopeIt->second,
+                          allAttributeBindings.offset(segment.vertexOffset),
+                          textureBindings,
+                          indexBuffer,
+                          segment.indexOffset,
+                          segment.indexLength);
         }
     }
 };

--- a/src/mbgl/programs/collision_box_program.hpp
+++ b/src/mbgl/programs/collision_box_program.hpp
@@ -172,21 +172,20 @@ public:
                 drawScopeIt = segment.drawScopes.emplace(layerID, context.createDrawScope()).first;
             }
 
-            program->draw(
-                    context,
-                    renderPass,
-                    std::move(drawMode),
-                    std::move(depthMode),
-                    std::move(stencilMode),
-                    std::move(colorMode),
-                    std::move(cullFaceMode),
-                    uniformValues,
-                    drawScopeIt->second,
-                    allAttributeBindings.offset(segment.vertexOffset),
-                    textureBindings,
-                    indexBuffer,
-                    segment.indexOffset,
-                    segment.indexLength);
+            program->draw(context,
+                          renderPass,
+                          drawMode,
+                          depthMode,
+                          stencilMode,
+                          colorMode,
+                          cullFaceMode,
+                          uniformValues,
+                          drawScopeIt->second,
+                          allAttributeBindings.offset(segment.vertexOffset),
+                          textureBindings,
+                          indexBuffer,
+                          segment.indexOffset,
+                          segment.indexLength);
         }
     }
 };

--- a/src/mbgl/programs/programs.cpp
+++ b/src/mbgl/programs/programs.cpp
@@ -16,8 +16,7 @@ Programs::Programs(gfx::Context& context_, const ProgramParameters& programParam
     : debug(context_, programParameters_),
       clippingMask(context_, programParameters_),
       context(context_),
-      programParameters(std::move(programParameters_)) {
-}
+      programParameters(programParameters_) {}
 
 Programs::~Programs() = default;
 

--- a/src/mbgl/renderer/buckets/line_bucket.cpp
+++ b/src/mbgl/renderer/buckets/line_bucket.cpp
@@ -14,10 +14,7 @@ LineBucket::LineBucket(const style::LineLayoutProperties::PossiblyEvaluated layo
                        const std::map<std::string, Immutable<style::LayerProperties>>& layerPaintProperties,
                        const float zoom_,
                        const uint32_t overscaling_)
-    : layout(std::move(layout_)),
-      zoom(zoom_),
-      overscaling(overscaling_) {
-
+    : layout(layout_), zoom(zoom_), overscaling(overscaling_) {
     for (const auto& pair : layerPaintProperties) {
         paintPropertyBinders.emplace(
             std::piecewise_construct,

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -26,7 +26,7 @@ SymbolBucket::SymbolBucket(Immutable<style::SymbolLayoutProperties::PossiblyEval
                            bool allowVerticalPlacement_,
                            std::vector<style::TextWritingModeType> placementModes_)
     : layout(std::move(layout_)),
-      bucketLeaderID(std::move(bucketName_)),
+      bucketLeaderID(bucketName_),
       iconsNeedLinear(iconsNeedLinear_ || iconSize.isDataDriven() || !iconSize.isZoomConstant()),
       sortFeaturesByY(sortFeaturesByY_),
       staticUploaded(false),
@@ -35,14 +35,13 @@ SymbolBucket::SymbolBucket(Immutable<style::SymbolLayoutProperties::PossiblyEval
       sortUploaded(false),
       justReloaded(false),
       hasVariablePlacement(false),
-      symbolInstances(std::move(symbolInstances_)),
+      symbolInstances(symbolInstances_),
       textSizeBinder(SymbolSizeBinder::create(zoom, textSize, TextSize::defaultValue())),
       iconSizeBinder(SymbolSizeBinder::create(zoom, iconSize, IconSize::defaultValue())),
       tilePixelRatio(tilePixelRatio_),
       bucketInstanceId(++maxBucketInstanceId),
       allowVerticalPlacement(allowVerticalPlacement_),
       placementModes(std::move(placementModes_)) {
-
     for (const auto& pair : paintProperties_) {
         const auto& evaluated = getEvaluated<SymbolLayerProperties>(pair.second);
         paintProperties.emplace(

--- a/src/mbgl/renderer/image_manager.cpp
+++ b/src/mbgl/renderer/image_manager.cpp
@@ -124,7 +124,7 @@ void ImageManager::getImages(ImageRequestor& requestor, ImageRequestPair&& pair)
             requestors.emplace(&requestor, std::move(pair));
         }
     } else {
-        checkMissingAndNotify(requestor, std::move(pair));
+        checkMissingAndNotify(requestor, pair);
     }
 }
 

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -67,13 +67,13 @@ struct RenderableSegment {
                       const LayerRenderData& renderData_,
                       const SymbolBucket::PaintProperties& bucketPaintProperties_,
                       float sortKey_,
-                      const SymbolType type_) :
-    segment(std::move(segment_)),
-    tile(tile_),
-    renderData(renderData_),
-    bucketPaintProperties(bucketPaintProperties_),
-    sortKey(sortKey_),
-    type(type_) {}
+                      const SymbolType type_)
+        : segment(segment_),
+          tile(tile_),
+          renderData(renderData_),
+          bucketPaintProperties(bucketPaintProperties_),
+          sortKey(sortKey_),
+          type(type_) {}
 
     SegmentWrapper segment;
     const RenderTile& tile;

--- a/src/mbgl/renderer/property_evaluation_parameters.hpp
+++ b/src/mbgl/renderer/property_evaluation_parameters.hpp
@@ -20,13 +20,8 @@ public:
           zoomHistory(),
           defaultFadeDuration(0) {}
 
-    PropertyEvaluationParameters(ZoomHistory zoomHistory_,
-                          TimePoint now_,
-                          Duration defaultFadeDuration_)
-        : z(zoomHistory_.lastZoom),
-          now(std::move(now_)),
-          zoomHistory(std::move(zoomHistory_)),
-          defaultFadeDuration(std::move(defaultFadeDuration_)) {}
+    PropertyEvaluationParameters(ZoomHistory zoomHistory_, TimePoint now_, Duration defaultFadeDuration_)
+        : z(zoomHistory_.lastZoom), now(now_), zoomHistory(zoomHistory_), defaultFadeDuration(defaultFadeDuration_) {}
 
     CrossfadeParameters getCrossfadeParameters() const {
         const float fraction = z - std::floor(z);

--- a/src/mbgl/renderer/render_tile.cpp
+++ b/src/mbgl/renderer/render_tile.cpp
@@ -16,9 +16,7 @@ namespace mbgl {
 
 using namespace style;
 
-RenderTile::RenderTile(UnwrappedTileID id_, Tile& tile_) 
-    : id(std::move(id_)), tile(tile_) {
-}
+RenderTile::RenderTile(UnwrappedTileID id_, Tile& tile_) : id(id_), tile(tile_) {}
 
 RenderTile::~RenderTile() = default;
 

--- a/src/mbgl/renderer/renderer.cpp
+++ b/src/mbgl/renderer/renderer.cpp
@@ -8,13 +8,8 @@
 
 namespace mbgl {
 
-Renderer::Renderer(gfx::RendererBackend& backend,
-                   float pixelRatio_,
-                   const optional<std::string> localFontFamily_)
-    : impl(std::make_unique<Impl>(backend,
-                                  pixelRatio_,
-                                  std::move(localFontFamily_))) {
-}
+Renderer::Renderer(gfx::RendererBackend& backend, float pixelRatio_, const optional<std::string> localFontFamily_)
+    : impl(std::make_unique<Impl>(backend, pixelRatio_, localFontFamily_)) {}
 
 Renderer::~Renderer() {
     gfx::BackendScope guard { impl->backend };

--- a/src/mbgl/storage/resource_transform.cpp
+++ b/src/mbgl/storage/resource_transform.cpp
@@ -6,8 +6,8 @@ ResourceTransform::ResourceTransform(ActorRef<ResourceTransform>, TransformCallb
     : transformCallback(std::move(callback)) {
 }
 
-void ResourceTransform::transform(Resource::Kind kind, const std::string&& url, FinishedCallback&& finished) {
-    finished(transformCallback(kind, std::move(url)));
+void ResourceTransform::transform(Resource::Kind kind, const std::string& url, FinishedCallback&& finished) {
+    finished(transformCallback(kind, url));
 }
 
 } // namespace mbgl

--- a/src/mbgl/style/conversion/source.cpp
+++ b/src/mbgl/style/conversion/source.cpp
@@ -128,7 +128,7 @@ static optional<std::unique_ptr<Source>> convertGeoJSONSource(const std::string&
         if (!geoJSON) {
             return nullopt;
         }
-        result->setGeoJSON(std::move(*geoJSON));
+        result->setGeoJSON(*geoJSON);
     } else if (toString(*dataValue)) {
         result->setURL(*toString(*dataValue));
     } else {

--- a/src/mbgl/style/expression/compound_expression.cpp
+++ b/src/mbgl/style/expression/compound_expression.cpp
@@ -105,7 +105,7 @@ private:
         for (std::size_t i = 0; i < sizeof...(Params); ++i) {
             const EvaluationResult evaluatedArg = args.at(i)->evaluate(evaluationParameters);
             if (!evaluatedArg) return evaluatedArg.error();
-            evaluated[i] = std::move(*evaluatedArg);
+            evaluated[i] = *evaluatedArg;
         }
         const R value = evaluate(*fromExpressionValue<std::decay_t<Params>>(evaluated[I])...);
         if (!value) return value.error();
@@ -165,7 +165,7 @@ private:
         for (std::size_t i = 0; i < sizeof...(Params); ++i) {
             const EvaluationResult evaluatedArg = args.at(i)->evaluate(evaluationParameters);
             if (!evaluatedArg) return evaluatedArg.error();
-            evaluated[i] = std::move(*evaluatedArg);
+            evaluated[i] = *evaluatedArg;
         }
         const R value = evaluate(evaluationParameters, *fromExpressionValue<std::decay_t<Params>>(evaluated[I])...);
         if (!value) return value.error();

--- a/src/mbgl/style/layers/background_layer.cpp
+++ b/src/mbgl/style/layers/background_layer.cpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/background_layer.hpp>
@@ -249,3 +251,5 @@ Mutable<Layer::Impl> BackgroundLayer::mutableBaseImpl() const {
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/background_layer_properties.cpp
+++ b/src/mbgl/style/layers/background_layer_properties.cpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/background_layer_properties.hpp>
@@ -31,3 +33,5 @@ const BackgroundLayer::Impl& BackgroundLayerProperties::layerImpl() const {
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/background_layer_properties.cpp
+++ b/src/mbgl/style/layers/background_layer_properties.cpp
@@ -18,7 +18,7 @@ BackgroundLayerProperties::BackgroundLayerProperties(
     CrossfadeParameters crossfade_,
     BackgroundPaintProperties::PossiblyEvaluated evaluated_)
   : LayerProperties(std::move(impl_)),
-    crossfade(std::move(crossfade_)),
+    crossfade(crossfade_),
     evaluated(std::move(evaluated_)) {}
 
 BackgroundLayerProperties::~BackgroundLayerProperties() = default;

--- a/src/mbgl/style/layers/background_layer_properties.hpp
+++ b/src/mbgl/style/layers/background_layer_properties.hpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #pragma once
@@ -51,3 +53,5 @@ public:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/circle_layer.cpp
+++ b/src/mbgl/style/layers/circle_layer.cpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/circle_layer.hpp>
@@ -602,3 +604,5 @@ Mutable<Layer::Impl> CircleLayer::mutableBaseImpl() const {
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/circle_layer_properties.cpp
+++ b/src/mbgl/style/layers/circle_layer_properties.cpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/circle_layer_properties.hpp>
@@ -29,3 +31,5 @@ const CircleLayer::Impl& CircleLayerProperties::layerImpl() const {
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/circle_layer_properties.hpp
+++ b/src/mbgl/style/layers/circle_layer_properties.hpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #pragma once
@@ -89,3 +91,5 @@ public:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/fill_extrusion_layer.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer.cpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/fill_extrusion_layer.hpp>
@@ -484,3 +486,5 @@ Mutable<Layer::Impl> FillExtrusionLayer::mutableBaseImpl() const {
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/fill_extrusion_layer_properties.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer_properties.cpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/fill_extrusion_layer_properties.hpp>
@@ -31,3 +33,5 @@ const FillExtrusionLayer::Impl& FillExtrusionLayerProperties::layerImpl() const 
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/fill_extrusion_layer_properties.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer_properties.cpp
@@ -18,7 +18,7 @@ FillExtrusionLayerProperties::FillExtrusionLayerProperties(
     CrossfadeParameters crossfade_,
     FillExtrusionPaintProperties::PossiblyEvaluated evaluated_)
   : LayerProperties(std::move(impl_)),
-    crossfade(std::move(crossfade_)),
+    crossfade(crossfade_),
     evaluated(std::move(evaluated_)) {}
 
 FillExtrusionLayerProperties::~FillExtrusionLayerProperties() = default;

--- a/src/mbgl/style/layers/fill_extrusion_layer_properties.hpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer_properties.hpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #pragma once
@@ -76,3 +78,5 @@ public:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/fill_layer.cpp
+++ b/src/mbgl/style/layers/fill_layer.cpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/fill_layer.hpp>
@@ -436,3 +438,5 @@ Mutable<Layer::Impl> FillLayer::mutableBaseImpl() const {
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/fill_layer_properties.cpp
+++ b/src/mbgl/style/layers/fill_layer_properties.cpp
@@ -18,7 +18,7 @@ FillLayerProperties::FillLayerProperties(
     CrossfadeParameters crossfade_,
     FillPaintProperties::PossiblyEvaluated evaluated_)
   : LayerProperties(std::move(impl_)),
-    crossfade(std::move(crossfade_)),
+    crossfade(crossfade_),
     evaluated(std::move(evaluated_)) {}
 
 FillLayerProperties::~FillLayerProperties() = default;

--- a/src/mbgl/style/layers/fill_layer_properties.cpp
+++ b/src/mbgl/style/layers/fill_layer_properties.cpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/fill_layer_properties.hpp>
@@ -31,3 +33,5 @@ const FillLayer::Impl& FillLayerProperties::layerImpl() const {
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/fill_layer_properties.hpp
+++ b/src/mbgl/style/layers/fill_layer_properties.hpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #pragma once
@@ -71,3 +73,5 @@ public:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/heatmap_layer.cpp
+++ b/src/mbgl/style/layers/heatmap_layer.cpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/heatmap_layer.hpp>
@@ -337,3 +339,5 @@ Mutable<Layer::Impl> HeatmapLayer::mutableBaseImpl() const {
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/heatmap_layer_properties.cpp
+++ b/src/mbgl/style/layers/heatmap_layer_properties.cpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/heatmap_layer_properties.hpp>
@@ -29,3 +31,5 @@ const HeatmapLayer::Impl& HeatmapLayerProperties::layerImpl() const {
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/heatmap_layer_properties.hpp
+++ b/src/mbgl/style/layers/heatmap_layer_properties.hpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #pragma once
@@ -58,3 +60,5 @@ public:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/hillshade_layer.cpp
+++ b/src/mbgl/style/layers/hillshade_layer.cpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/hillshade_layer.hpp>
@@ -376,3 +378,5 @@ Mutable<Layer::Impl> HillshadeLayer::mutableBaseImpl() const {
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/hillshade_layer_properties.cpp
+++ b/src/mbgl/style/layers/hillshade_layer_properties.cpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/hillshade_layer_properties.hpp>
@@ -29,3 +31,5 @@ const HillshadeLayer::Impl& HillshadeLayerProperties::layerImpl() const {
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/hillshade_layer_properties.hpp
+++ b/src/mbgl/style/layers/hillshade_layer_properties.hpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #pragma once
@@ -64,3 +66,5 @@ public:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/layer.cpp.ejs
+++ b/src/mbgl/style/layers/layer.cpp.ejs
@@ -3,6 +3,8 @@
   const layoutProperties = locals.layoutProperties;
   const paintProperties = locals.paintProperties;
 -%>
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/<%- type.replace('-', '_') %>_layer.hpp>
@@ -317,3 +319,5 @@ Mutable<Layer::Impl> <%- camelize(type) %>Layer::mutableBaseImpl() const {
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/layer_properties.cpp.ejs
+++ b/src/mbgl/style/layers/layer_properties.cpp.ejs
@@ -3,6 +3,8 @@
   const layoutProperties = locals.layoutProperties;
   const paintProperties = locals.paintProperties;
 -%>
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/<%- type.replace('-', '_') %>_layer_properties.hpp>
@@ -40,3 +42,5 @@ const <%- camelize(type) %>Layer::Impl& <%- camelize(type) %>LayerProperties::la
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/layer_properties.cpp.ejs
+++ b/src/mbgl/style/layers/layer_properties.cpp.ejs
@@ -26,7 +26,7 @@ namespace style {
     <%- camelize(type) %>PaintProperties::PossiblyEvaluated evaluated_)
   : LayerProperties(std::move(impl_)),
 <% if (type === 'background' || type === 'fill' || type === 'line' || type === 'fill-extrusion') { -%>
-    crossfade(std::move(crossfade_)),
+    crossfade(crossfade_),
 <% } -%>
     evaluated(std::move(evaluated_)) {}
 

--- a/src/mbgl/style/layers/layer_properties.hpp.ejs
+++ b/src/mbgl/style/layers/layer_properties.hpp.ejs
@@ -3,6 +3,8 @@
   const layoutProperties = locals.layoutProperties;
   const paintProperties = locals.paintProperties;
 -%>
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #pragma once
@@ -84,3 +86,5 @@ public:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/line_layer.hpp>
@@ -737,3 +739,5 @@ Mutable<Layer::Impl> LineLayer::mutableBaseImpl() const {
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/line_layer_properties.cpp
+++ b/src/mbgl/style/layers/line_layer_properties.cpp
@@ -18,7 +18,7 @@ LineLayerProperties::LineLayerProperties(
     CrossfadeParameters crossfade_,
     LinePaintProperties::PossiblyEvaluated evaluated_)
   : LayerProperties(std::move(impl_)),
-    crossfade(std::move(crossfade_)),
+    crossfade(crossfade_),
     evaluated(std::move(evaluated_)) {}
 
 LineLayerProperties::~LineLayerProperties() = default;

--- a/src/mbgl/style/layers/line_layer_properties.cpp
+++ b/src/mbgl/style/layers/line_layer_properties.cpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/line_layer_properties.hpp>
@@ -31,3 +33,5 @@ const LineLayer::Impl& LineLayerProperties::layerImpl() const {
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/line_layer_properties.hpp
+++ b/src/mbgl/style/layers/line_layer_properties.hpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #pragma once
@@ -123,3 +125,5 @@ public:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/raster_layer.cpp
+++ b/src/mbgl/style/layers/raster_layer.cpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/raster_layer.hpp>
@@ -449,3 +451,5 @@ Mutable<Layer::Impl> RasterLayer::mutableBaseImpl() const {
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/raster_layer_properties.cpp
+++ b/src/mbgl/style/layers/raster_layer_properties.cpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/raster_layer_properties.hpp>
@@ -29,3 +31,5 @@ const RasterLayer::Impl& RasterLayerProperties::layerImpl() const {
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/raster_layer_properties.hpp
+++ b/src/mbgl/style/layers/raster_layer_properties.hpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #pragma once
@@ -74,3 +76,5 @@ public:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/symbol_layer.cpp
+++ b/src/mbgl/style/layers/symbol_layer.cpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/symbol_layer.hpp>
@@ -1803,3 +1805,5 @@ Mutable<Layer::Impl> SymbolLayer::mutableBaseImpl() const {
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/symbol_layer_properties.cpp
+++ b/src/mbgl/style/layers/symbol_layer_properties.cpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/symbol_layer_properties.hpp>
@@ -29,3 +31,5 @@ const SymbolLayer::Impl& SymbolLayerProperties::layerImpl() const {
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/layers/symbol_layer_properties.hpp
+++ b/src/mbgl/style/layers/symbol_layer_properties.hpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #pragma once
@@ -356,3 +358,5 @@ public:
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/light.cpp
+++ b/src/mbgl/style/light.cpp
@@ -1,3 +1,5 @@
+// clang-format off
+
 // This file is generated. Do not edit.
 
 #include <mbgl/style/light.hpp>
@@ -251,3 +253,5 @@ TransitionOptions Light::getPositionTransition() const {
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/light.cpp.ejs
+++ b/src/mbgl/style/light.cpp.ejs
@@ -1,6 +1,8 @@
 <%
   const properties = locals.properties;
 -%>
+// clang-format off
+
 // This file is generated. Do not edit.
 
 #include <mbgl/style/light.hpp>
@@ -136,3 +138,5 @@ TransitionOptions Light::get<%- camelize(property.name) %>Transition() const {
 
 } // namespace style
 } // namespace mbgl
+
+// clang-format on

--- a/src/mbgl/style/parser.cpp
+++ b/src/mbgl/style/parser.cpp
@@ -138,7 +138,7 @@ void Parser::parseLight(const JSValue& value) {
         return;
     }
 
-    light = std::move(*converted);
+    light = *converted;
 }
 
 void Parser::parseSources(const JSValue& value) {

--- a/src/mbgl/style/sources/geojson_source.cpp
+++ b/src/mbgl/style/sources/geojson_source.cpp
@@ -12,8 +12,7 @@ namespace mbgl {
 namespace style {
 
 GeoJSONSource::GeoJSONSource(const std::string& id, optional<GeoJSONOptions> options)
-    : Source(makeMutable<Impl>(std::move(id), options)) {
-}
+    : Source(makeMutable<Impl>(id, options)) {}
 
 GeoJSONSource::~GeoJSONSource() = default;
 
@@ -22,7 +21,7 @@ const GeoJSONSource::Impl& GeoJSONSource::impl() const {
 }
 
 void GeoJSONSource::setURL(const std::string& url_) {
-    url = std::move(url_);
+    url = url_;
 
     // Signal that the source description needs a reload
     if (loaded || req) {

--- a/src/mbgl/style/sources/image_source.cpp
+++ b/src/mbgl/style/sources/image_source.cpp
@@ -30,7 +30,7 @@ std::array<LatLng, 4> ImageSource::getCoordinates() const {
 }
 
 void ImageSource::setURL(const std::string& url_) {
-    url = std::move(url_);
+    url = url_;
     // Signal that the source description needs a reload
     if (loaded || req) {
         loaded = false;

--- a/src/mbgl/style/sources/image_source_impl.cpp
+++ b/src/mbgl/style/sources/image_source_impl.cpp
@@ -5,15 +5,10 @@ namespace mbgl {
 namespace style {
 
 ImageSource::Impl::Impl(std::string id_, std::array<LatLng, 4> coords_)
-    : Source::Impl(SourceType::Image, std::move(id_)),
-    coords(std::move(coords_)) {
-}
+    : Source::Impl(SourceType::Image, std::move(id_)), coords(coords_) {}
 
 ImageSource::Impl::Impl(const Impl& other, std::array<LatLng, 4> coords_)
-    : Source::Impl(other),
-    coords(std::move(coords_)),
-    image(other.image) {
-}
+    : Source::Impl(other), coords(coords_), image(other.image) {}
 
 ImageSource::Impl::Impl(const Impl& rhs, PremultipliedImage&& image_)
     : Source::Impl(rhs),

--- a/src/mbgl/text/collision_feature.hpp
+++ b/src/mbgl/text/collision_feature.hpp
@@ -47,8 +47,8 @@ private:
 
 class CollisionBox {
 public:
-    CollisionBox(Point<float> _anchor, float _x1, float _y1, float _x2, float _y2, float _signedDistanceFromAnchor = 0) :
-        anchor(std::move(_anchor)), x1(_x1), y1(_y1), x2(_x2), y2(_y2), signedDistanceFromAnchor(_signedDistanceFromAnchor) {}
+    CollisionBox(Point<float> _anchor, float _x1, float _y1, float _x2, float _y2, float _signedDistanceFromAnchor = 0)
+        : anchor(_anchor), x1(_x1), y1(_y1), x2(_x2), y2(_y2), signedDistanceFromAnchor(_signedDistanceFromAnchor) {}
 
     // the box is centered around the anchor point
     Point<float> anchor;

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -63,12 +63,8 @@ struct RetainedQueryData {
     OverscaledTileID tileID;
     mutable FeatureSortOrder featureSortOrder;
 
-    RetainedQueryData(uint32_t bucketInstanceId_,
-                      std::shared_ptr<FeatureIndex> featureIndex_,
-                      OverscaledTileID tileID_)
-        : bucketInstanceId(bucketInstanceId_)
-        , featureIndex(std::move(featureIndex_))
-        , tileID(std::move(tileID_)) {}
+    RetainedQueryData(uint32_t bucketInstanceId_, std::shared_ptr<FeatureIndex> featureIndex_, OverscaledTileID tileID_)
+        : bucketInstanceId(bucketInstanceId_), featureIndex(std::move(featureIndex_)), tileID(tileID_) {}
 };
     
 class CollisionGroups {

--- a/src/mbgl/text/quads.hpp
+++ b/src/mbgl/text/quads.hpp
@@ -22,14 +22,14 @@ public:
                WritingModeType writingMode_,
                Point<float> glyphOffset_,
                size_t sectionIndex_ = 0)
-        : tl(std::move(tl_)),
-        tr(std::move(tr_)),
-        bl(std::move(bl_)),
-        br(std::move(br_)),
-        tex(std::move(tex_)),
-        writingMode(writingMode_),
-        glyphOffset(glyphOffset_),
-        sectionIndex(sectionIndex_){}
+        : tl(tl_),
+          tr(tr_),
+          bl(bl_),
+          br(br_),
+          tex(tex_),
+          writingMode(writingMode_),
+          glyphOffset(glyphOffset_),
+          sectionIndex(sectionIndex_) {}
 
     Point<float> tl;
     Point<float> tr;

--- a/src/mbgl/text/shaping.hpp
+++ b/src/mbgl/text/shaping.hpp
@@ -27,18 +27,8 @@ class BiDi;
 
 class PositionedIcon {
 private:
-    PositionedIcon(ImagePosition image_,
-                   float top_,
-                   float bottom_,
-                   float left_,
-                   float right_,
-                   float angle_)
-        : _image(std::move(image_)),
-          _top(top_),
-          _bottom(bottom_),
-          _left(left_),
-          _right(right_),
-          _angle(angle_) {}
+    PositionedIcon(ImagePosition image_, float top_, float bottom_, float left_, float right_, float angle_)
+        : _image(image_), _top(top_), _bottom(bottom_), _left(left_), _right(right_), _angle(angle_) {}
 
     ImagePosition _image;
     float _top;

--- a/src/mbgl/tile/geometry_tile_data.hpp
+++ b/src/mbgl/tile/geometry_tile_data.hpp
@@ -24,8 +24,7 @@ public:
 
     template <class... Args>
     GeometryCoordinates(Args&&... args) : std::vector<GeometryCoordinate>(std::forward<Args>(args)...) {}
-    GeometryCoordinates(std::initializer_list<GeometryCoordinate> args)
-      : std::vector<GeometryCoordinate>(std::move(args)) {}
+    GeometryCoordinates(std::initializer_list<GeometryCoordinate> args) : std::vector<GeometryCoordinate>(args) {}
 };
 
 class GeometryCollection : public std::vector<GeometryCoordinates> {
@@ -33,8 +32,7 @@ public:
     using coordinate_type = int16_t;
     template <class... Args>
     GeometryCollection(Args&&... args) : std::vector<GeometryCoordinates>(std::forward<Args>(args)...) {}
-    GeometryCollection(std::initializer_list<GeometryCoordinates> args)
-      : std::vector<GeometryCoordinates>(std::move(args)) {}
+    GeometryCollection(std::initializer_list<GeometryCoordinates> args) : std::vector<GeometryCoordinates>(args) {}
     GeometryCollection(GeometryCollection&&) = default;
     GeometryCollection& operator=(GeometryCollection&&) = default;
 

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -37,13 +37,12 @@ GeometryTileWorker::GeometryTileWorker(ActorRef<GeometryTileWorker> self_,
                                        const bool showCollisionBoxes_)
     : self(std::move(self_)),
       parent(std::move(parent_)),
-      id(std::move(id_)),
+      id(id_),
       sourceID(std::move(sourceID_)),
       obsolete(obsolete_),
       mode(mode_),
       pixelRatio(pixelRatio_),
-      showCollisionBoxes(showCollisionBoxes_) {
-}
+      showCollisionBoxes(showCollisionBoxes_) {}
 
 GeometryTileWorker::~GeometryTileWorker() = default;
 

--- a/src/mbgl/tile/tile.cpp
+++ b/src/mbgl/tile/tile.cpp
@@ -8,8 +8,7 @@ namespace mbgl {
 
 static TileObserver nullObserver;
 
-Tile::Tile(Kind kind_, OverscaledTileID id_) : kind(kind_), id(std::move(id_)), observer(&nullObserver) {
-}
+Tile::Tile(Kind kind_, OverscaledTileID id_) : kind(kind_), id(id_), observer(&nullObserver) {}
 
 Tile::~Tile() = default;
 

--- a/src/mbgl/tile/vector_tile_data.cpp
+++ b/src/mbgl/tile/vector_tile_data.cpp
@@ -23,7 +23,7 @@ FeatureType VectorTileFeature::getType() const {
 
 optional<Value> VectorTileFeature::getValue(const std::string& key) const {
     const optional<Value> value(feature.getValue(key));
-    return value->is<NullValue>() ? nullopt : std::move(value);
+    return value->is<NullValue>() ? nullopt : value;
 }
 
 const PropertyMap& VectorTileFeature::getProperties() const {

--- a/test/storage/default_file_source.test.cpp
+++ b/test/storage/default_file_source.test.cpp
@@ -528,11 +528,11 @@ TEST(DefaultFileSource, TEST_REQUIRES_SERVER(SetResourceTransform)) {
     DefaultFileSource fs(":memory:", ".");
 
     // Translates the URL "localhost://test to http://127.0.0.1:3000/test
-    Actor<ResourceTransform> transform(loop, [](Resource::Kind, const std::string&& url) -> std::string {
+    Actor<ResourceTransform> transform(loop, [](Resource::Kind, const std::string& url) -> std::string {
         if (url == "localhost://test") {
             return "http://127.0.0.1:3000/test";
         } else {
-            return std::move(url);
+            return url;
         }
     });
 


### PR DESCRIPTION
- Fixed the two topmost issues, generating most of the warnings.
- Bots will always upload the full log of clang-tidy.
- Not failing on warnings (unless for the fixed issues)
- Takes 8 minutes for a full run.
- Print the statistics of the most common errors.