### PR TITLE
[core] Universal getter for layer layout and light properties

### DIFF
--- a/expression-test/expression_test_parser.cpp
+++ b/expression-test/expression_test_parser.cpp
@@ -439,33 +439,7 @@ optional<Value> toValue(const expression::Value& exprValue) {
             std::vector<Value> color { double(c.r), double(c.g), double(c.b), double(c.a) };
             return {Value{std::move(color)}};
         },
-        [](const expression::Formatted& formatted) -> optional<Value> {
-            std::unordered_map<std::string, Value> serialized;
-            std::vector<Value> sections;
-            for (const auto& section : formatted.sections) {
-                std::unordered_map<std::string, Value> serializedSection;
-                serializedSection.emplace("text", section.text);
-                if (section.fontScale) {
-                    serializedSection.emplace("scale", *section.fontScale);
-                } else {
-                    serializedSection.emplace("scale", NullValue());
-                }
-                if (section.fontStack) {
-                    std::string fontStackString;
-                    serializedSection.emplace("fontStack", fontStackToString(*section.fontStack));
-                } else {
-                    serializedSection.emplace("fontStack", NullValue());
-                }
-                if (section.textColor) {
-                    serializedSection.emplace("textColor", section.textColor->toObject());
-                } else {
-                    serializedSection.emplace("textColor", NullValue());
-                }
-                sections.emplace_back(serializedSection);
-            }
-            serialized.emplace("sections", sections);
-            return {Value{std::move(serialized)}};
-        },
+        [](const expression::Formatted& formatted) -> optional<Value> { return {formatted.toObject()}; },
         [](const std::vector<expression::Value>& values) -> optional<Value> {
             std::vector<Value> mbglValues;
             for (const auto& value : values) {

--- a/include/mbgl/style/conversion.hpp
+++ b/include/mbgl/style/conversion.hpp
@@ -17,8 +17,11 @@ class ConversionTraits;
 
 class Convertible;
 
-template <class T, class Enable = void>
+template <typename T, typename Enable = void>
 struct Converter;
+
+template <typename T, typename Enable = void>
+struct ValueFactory;
 
 } // namespace conversion
 } // namespace style

--- a/include/mbgl/style/conversion_impl.hpp
+++ b/include/mbgl/style/conversion_impl.hpp
@@ -342,6 +342,13 @@ struct ValueFactory<T, typename std::enable_if<is_linear_container<T>::value>::t
     }
 };
 
+template <>
+struct ValueFactory<Position> {
+    static Value make(const Position& position) {
+        return ValueFactory<std::array<float, 3>>::make(position.getSpherical());
+    }
+};
+
 template <typename T>
 Value makeValue(T&& arg) {
     return ValueFactory<std::decay_t<T>>::make(std::forward<T>(arg));

--- a/include/mbgl/style/expression/formatted.hpp
+++ b/include/mbgl/style/expression/formatted.hpp
@@ -48,7 +48,8 @@ public:
     bool operator==(const Formatted& ) const;
     
     std::string toString() const;
-    
+    mbgl::Value toObject() const;
+
     bool empty() const {
         return sections.empty() || sections.at(0).text.empty();
     }
@@ -59,13 +60,18 @@ public:
 } // namespace expression
     
 namespace conversion {
-    
+
 template <>
-struct Converter<mbgl::style::expression::Formatted> {
+struct Converter<expression::Formatted> {
 public:
-    optional<mbgl::style::expression::Formatted> operator()(const Convertible& value, Error& error) const;
+    optional<expression::Formatted> operator()(const Convertible& value, Error& error) const;
 };
-    
+
+template <>
+struct ValueFactory<expression::Formatted> {
+    static Value make(const expression::Formatted& formatted) { return formatted.toObject(); }
+};
+
 } // namespace conversion
     
 } // namespace style

--- a/include/mbgl/style/light.hpp
+++ b/include/mbgl/style/light.hpp
@@ -6,6 +6,7 @@
 
 #include <mbgl/style/conversion.hpp>
 #include <mbgl/style/property_value.hpp>
+#include <mbgl/style/style_property.hpp>
 #include <mbgl/style/transition_options.hpp>
 #include <mbgl/style/types.hpp>
 #include <mbgl/util/immutable.hpp>
@@ -22,6 +23,7 @@ public:
 
     // Dynamic properties
     optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value);
+    StyleProperty getProperty(const std::string&) const;
 
     static LightAnchorType getDefaultAnchor();
     PropertyValue<LightAnchorType> getAnchor() const;

--- a/include/mbgl/style/light.hpp.ejs
+++ b/include/mbgl/style/light.hpp.ejs
@@ -9,6 +9,7 @@
 
 #include <mbgl/style/conversion.hpp>
 #include <mbgl/style/property_value.hpp>
+#include <mbgl/style/style_property.hpp>
 #include <mbgl/style/transition_options.hpp>
 #include <mbgl/style/types.hpp>
 #include <mbgl/util/immutable.hpp>
@@ -25,6 +26,7 @@ public:
 
     // Dynamic properties
     optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value);
+    StyleProperty getProperty(const std::string&) const;
 
 <% for (const property of properties) { -%>
     static <%- evaluatedType(property) %> getDefault<%- camelize(property.name) %>();

--- a/include/mbgl/util/traits.hpp
+++ b/include/mbgl/util/traits.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <type_traits>
+#include <vector>
 
 namespace mbgl {
 
@@ -24,5 +26,13 @@ typename std::enable_if<is_utf16char_like<InChar>::value && is_utf16char_like_po
 {
     return reinterpret_cast<OutPointer>(in);
 }
+
+template <typename T>
+struct is_linear_container : std::false_type {};
+
+template <typename T, std::size_t N>
+struct is_linear_container<std::array<T, N>> : std::true_type {};
+template <typename... Ts>
+struct is_linear_container<std::vector<Ts...>> : std::true_type {};
 
 } // namespace mbgl

--- a/src/mbgl/style/expression/formatted.cpp
+++ b/src/mbgl/style/expression/formatted.cpp
@@ -35,6 +35,35 @@ std::string Formatted::toString() const {
     return result;
 }
 
+mbgl::Value Formatted::toObject() const {
+    mapbox::base::ValueObject result;
+    mapbox::base::ValueArray sectionValues;
+    sectionValues.reserve(sections.size());
+    for (const auto& section : sections) {
+        mapbox::base::ValueObject serializedSection;
+        serializedSection.emplace("text", section.text);
+        if (section.fontScale) {
+            serializedSection.emplace("scale", *section.fontScale);
+        } else {
+            serializedSection.emplace("scale", NullValue());
+        }
+        if (section.fontStack) {
+            std::string fontStackString;
+            serializedSection.emplace("fontStack", fontStackToString(*section.fontStack));
+        } else {
+            serializedSection.emplace("fontStack", NullValue());
+        }
+        if (section.textColor) {
+            serializedSection.emplace("textColor", section.textColor->toObject());
+        } else {
+            serializedSection.emplace("textColor", NullValue());
+        }
+        sectionValues.emplace_back(serializedSection);
+    }
+    result.emplace("sections", std::move(sectionValues));
+    return result;
+}
+
 } // namespace expression
 
 namespace conversion {

--- a/src/mbgl/style/layers/background_layer.cpp
+++ b/src/mbgl/style/layers/background_layer.cpp
@@ -1,5 +1,3 @@
-// clang-format off
-
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/background_layer.hpp>
@@ -164,7 +162,7 @@ constexpr uint8_t toUint8(T t) noexcept {
     return uint8_t(mbgl::underlying_type(t));
 }
 
-MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+MAPBOX_ETERNAL_CONSTEXPR const auto layerProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
     {{"background-color", toUint8(Property::BackgroundColor)},
      {"background-opacity", toUint8(Property::BackgroundOpacity)},
      {"background-pattern", toUint8(Property::BackgroundPattern)},
@@ -172,11 +170,12 @@ MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<
      {"background-opacity-transition", toUint8(Property::BackgroundOpacityTransition)},
      {"background-pattern-transition", toUint8(Property::BackgroundPatternTransition)}});
 
+constexpr uint8_t lastPaintPropertyIndex = toUint8(Property::BackgroundPatternTransition);
 } // namespace
 
 optional<Error> BackgroundLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    const auto it = paintProperties.find(name.c_str());
-    if (it == paintProperties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end() || it->second > lastPaintPropertyIndex) {
         return Error{"layer doesn't support this property"};
     }
 
@@ -245,8 +244,8 @@ optional<Error> BackgroundLayer::setPaintProperty(const std::string& name, const
 }
 
 StyleProperty BackgroundLayer::getProperty(const std::string& name) const {
-    const auto it = paintProperties.find(name.c_str());
-    if (it == paintProperties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end()) {
         return {};
     }
 
@@ -281,5 +280,3 @@ Mutable<Layer::Impl> BackgroundLayer::mutableBaseImpl() const {
 
 } // namespace style
 } // namespace mbgl
-
-// clang-format on

--- a/src/mbgl/style/layers/circle_layer.cpp
+++ b/src/mbgl/style/layers/circle_layer.cpp
@@ -1,5 +1,3 @@
-// clang-format off
-
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/circle_layer.hpp>
@@ -396,7 +394,7 @@ constexpr uint8_t toUint8(T t) noexcept {
     return uint8_t(mbgl::underlying_type(t));
 }
 
-MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+MAPBOX_ETERNAL_CONSTEXPR const auto layerProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
     {{"circle-blur", toUint8(Property::CircleBlur)},
      {"circle-color", toUint8(Property::CircleColor)},
      {"circle-opacity", toUint8(Property::CircleOpacity)},
@@ -420,11 +418,12 @@ MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<
      {"circle-translate-transition", toUint8(Property::CircleTranslateTransition)},
      {"circle-translate-anchor-transition", toUint8(Property::CircleTranslateAnchorTransition)}});
 
+constexpr uint8_t lastPaintPropertyIndex = toUint8(Property::CircleTranslateAnchorTransition);
 } // namespace
 
 optional<Error> CircleLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    const auto it = paintProperties.find(name.c_str());
-    if (it == paintProperties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end() || it->second > lastPaintPropertyIndex) {
         return Error{"layer doesn't support this property"};
     }
 
@@ -598,8 +597,8 @@ optional<Error> CircleLayer::setPaintProperty(const std::string& name, const Con
 }
 
 StyleProperty CircleLayer::getProperty(const std::string& name) const {
-    const auto it = paintProperties.find(name.c_str());
-    if (it == paintProperties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end()) {
         return {};
     }
 
@@ -666,5 +665,3 @@ Mutable<Layer::Impl> CircleLayer::mutableBaseImpl() const {
 
 } // namespace style
 } // namespace mbgl
-
-// clang-format on

--- a/src/mbgl/style/layers/fill_extrusion_layer.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer.cpp
@@ -1,5 +1,3 @@
-// clang-format off
-
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/fill_extrusion_layer.hpp>
@@ -309,7 +307,7 @@ constexpr uint8_t toUint8(T t) noexcept {
     return uint8_t(mbgl::underlying_type(t));
 }
 
-MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+MAPBOX_ETERNAL_CONSTEXPR const auto layerProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
     {{"fill-extrusion-base", toUint8(Property::FillExtrusionBase)},
      {"fill-extrusion-color", toUint8(Property::FillExtrusionColor)},
      {"fill-extrusion-height", toUint8(Property::FillExtrusionHeight)},
@@ -327,11 +325,12 @@ MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<
      {"fill-extrusion-translate-anchor-transition", toUint8(Property::FillExtrusionTranslateAnchorTransition)},
      {"fill-extrusion-vertical-gradient-transition", toUint8(Property::FillExtrusionVerticalGradientTransition)}});
 
+constexpr uint8_t lastPaintPropertyIndex = toUint8(Property::FillExtrusionVerticalGradientTransition);
 } // namespace
 
 optional<Error> FillExtrusionLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    const auto it = paintProperties.find(name.c_str());
-    if (it == paintProperties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end() || it->second > lastPaintPropertyIndex) {
         return Error{"layer doesn't support this property"};
     }
 
@@ -480,8 +479,8 @@ optional<Error> FillExtrusionLayer::setPaintProperty(const std::string& name, co
 }
 
 StyleProperty FillExtrusionLayer::getProperty(const std::string& name) const {
-    const auto it = paintProperties.find(name.c_str());
-    if (it == paintProperties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end()) {
         return {};
     }
 
@@ -536,5 +535,3 @@ Mutable<Layer::Impl> FillExtrusionLayer::mutableBaseImpl() const {
 
 } // namespace style
 } // namespace mbgl
-
-// clang-format on

--- a/src/mbgl/style/layers/fill_layer.cpp
+++ b/src/mbgl/style/layers/fill_layer.cpp
@@ -1,5 +1,3 @@
-// clang-format off
-
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/fill_layer.hpp>
@@ -280,7 +278,7 @@ constexpr uint8_t toUint8(T t) noexcept {
     return uint8_t(mbgl::underlying_type(t));
 }
 
-MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+MAPBOX_ETERNAL_CONSTEXPR const auto layerProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
     {{"fill-antialias", toUint8(Property::FillAntialias)},
      {"fill-color", toUint8(Property::FillColor)},
      {"fill-opacity", toUint8(Property::FillOpacity)},
@@ -296,11 +294,12 @@ MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<
      {"fill-translate-transition", toUint8(Property::FillTranslateTransition)},
      {"fill-translate-anchor-transition", toUint8(Property::FillTranslateAnchorTransition)}});
 
+constexpr uint8_t lastPaintPropertyIndex = toUint8(Property::FillTranslateAnchorTransition);
 } // namespace
 
 optional<Error> FillLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    const auto it = paintProperties.find(name.c_str());
-    if (it == paintProperties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end() || it->second > lastPaintPropertyIndex) {
         return Error{"layer doesn't support this property"};
     }
 
@@ -432,8 +431,8 @@ optional<Error> FillLayer::setPaintProperty(const std::string& name, const Conve
 }
 
 StyleProperty FillLayer::getProperty(const std::string& name) const {
-    const auto it = paintProperties.find(name.c_str());
-    if (it == paintProperties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end()) {
         return {};
     }
 
@@ -484,5 +483,3 @@ Mutable<Layer::Impl> FillLayer::mutableBaseImpl() const {
 
 } // namespace style
 } // namespace mbgl
-
-// clang-format on

--- a/src/mbgl/style/layers/heatmap_layer.cpp
+++ b/src/mbgl/style/layers/heatmap_layer.cpp
@@ -1,5 +1,3 @@
-// clang-format off
-
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/heatmap_layer.hpp>
@@ -224,7 +222,7 @@ constexpr uint8_t toUint8(T t) noexcept {
     return uint8_t(mbgl::underlying_type(t));
 }
 
-MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+MAPBOX_ETERNAL_CONSTEXPR const auto layerProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
     {{"heatmap-color", toUint8(Property::HeatmapColor)},
      {"heatmap-intensity", toUint8(Property::HeatmapIntensity)},
      {"heatmap-opacity", toUint8(Property::HeatmapOpacity)},
@@ -236,11 +234,12 @@ MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<
      {"heatmap-radius-transition", toUint8(Property::HeatmapRadiusTransition)},
      {"heatmap-weight-transition", toUint8(Property::HeatmapWeightTransition)}});
 
+constexpr uint8_t lastPaintPropertyIndex = toUint8(Property::HeatmapWeightTransition);
 } // namespace
 
 optional<Error> HeatmapLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    const auto it = paintProperties.find(name.c_str());
-    if (it == paintProperties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end() || it->second > lastPaintPropertyIndex) {
         return Error{"layer doesn't support this property"};
     }
 
@@ -333,8 +332,8 @@ optional<Error> HeatmapLayer::setPaintProperty(const std::string& name, const Co
 }
 
 StyleProperty HeatmapLayer::getProperty(const std::string& name) const {
-    const auto it = paintProperties.find(name.c_str());
-    if (it == paintProperties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end()) {
         return {};
     }
 
@@ -377,5 +376,3 @@ Mutable<Layer::Impl> HeatmapLayer::mutableBaseImpl() const {
 
 } // namespace style
 } // namespace mbgl
-
-// clang-format on

--- a/src/mbgl/style/layers/hillshade_layer.cpp
+++ b/src/mbgl/style/layers/hillshade_layer.cpp
@@ -1,5 +1,3 @@
-// clang-format off
-
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/hillshade_layer.hpp>
@@ -251,7 +249,7 @@ constexpr uint8_t toUint8(T t) noexcept {
     return uint8_t(mbgl::underlying_type(t));
 }
 
-MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+MAPBOX_ETERNAL_CONSTEXPR const auto layerProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
     {{"hillshade-accent-color", toUint8(Property::HillshadeAccentColor)},
      {"hillshade-exaggeration", toUint8(Property::HillshadeExaggeration)},
      {"hillshade-highlight-color", toUint8(Property::HillshadeHighlightColor)},
@@ -265,11 +263,12 @@ MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<
      {"hillshade-illumination-direction-transition", toUint8(Property::HillshadeIlluminationDirectionTransition)},
      {"hillshade-shadow-color-transition", toUint8(Property::HillshadeShadowColorTransition)}});
 
+constexpr uint8_t lastPaintPropertyIndex = toUint8(Property::HillshadeShadowColorTransition);
 } // namespace
 
 optional<Error> HillshadeLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    const auto it = paintProperties.find(name.c_str());
-    if (it == paintProperties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end() || it->second > lastPaintPropertyIndex) {
         return Error{"layer doesn't support this property"};
     }
 
@@ -372,8 +371,8 @@ optional<Error> HillshadeLayer::setPaintProperty(const std::string& name, const 
 }
 
 StyleProperty HillshadeLayer::getProperty(const std::string& name) const {
-    const auto it = paintProperties.find(name.c_str());
-    if (it == paintProperties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end()) {
         return {};
     }
 
@@ -420,5 +419,3 @@ Mutable<Layer::Impl> HillshadeLayer::mutableBaseImpl() const {
 
 } // namespace style
 } // namespace mbgl
-
-// clang-format on

--- a/src/mbgl/style/layers/layer.cpp.ejs
+++ b/src/mbgl/style/layers/layer.cpp.ejs
@@ -3,8 +3,6 @@
   const layoutProperties = locals.layoutProperties;
   const paintProperties = locals.paintProperties;
 -%>
-// clang-format off
-
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/<%- type.replace('-', '_') %>_layer.hpp>
@@ -199,6 +197,9 @@ enum class Property : uint8_t {
 <% for (const property of paintProperties) { -%>
     <%- camelize(property.name) %>Transition,
 <% } -%>
+<% for (const property of layoutProperties) { -%>
+    <%- camelize(property.name) %>,
+<% } -%>
 };
 
 template <typename T>
@@ -206,15 +207,22 @@ constexpr uint8_t toUint8(T t) noexcept {
     return uint8_t(mbgl::underlying_type(t));
 }
 
-MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+MAPBOX_ETERNAL_CONSTEXPR const auto layerProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
     {<%- paintProperties.map(p => `{"${p.name}", toUint8(Property::${camelize(p.name)})}`).join(',\n     ') %>,
+<% if (!layoutProperties.length) { -%>
      <%- paintProperties.map(p => `{"${p.name}-transition", toUint8(Property::${camelize(p.name)}Transition)}`).join(',\n     ') %>});
+<% } else { -%>
+     <%- paintProperties.map(p => `{"${p.name}-transition", toUint8(Property::${camelize(p.name)}Transition)}`).join(',\n     ') %>,
+     <%- layoutProperties.map(p => `{"${p.name}", toUint8(Property::${camelize(p.name)})}`).join(',\n     ') %>});
+<% } -%>
 
+<% const lastPaintProperty = paintProperties[paintProperties.length - 1]; -%>
+<%-`constexpr uint8_t lastPaintPropertyIndex = toUint8(Property::${camelize(lastPaintProperty.name)}Transition);` %>
 } // namespace
 
 optional<Error> <%- camelize(type) %>Layer::setPaintProperty(const std::string& name, const Convertible& value) {
-    const auto it = paintProperties.find(name.c_str());
-    if (it == paintProperties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end() || it->second > lastPaintPropertyIndex) {
         return Error{"layer doesn't support this property"};
     }
 
@@ -266,8 +274,8 @@ optional<Error> <%- camelize(type) %>Layer::setPaintProperty(const std::string& 
 }
 
 StyleProperty <%- camelize(type) %>Layer::getProperty(const std::string& name) const {
-    const auto it = paintProperties.find(name.c_str());
-    if (it == paintProperties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end()) {
         return {};
     }
 
@@ -280,6 +288,10 @@ StyleProperty <%- camelize(type) %>Layer::getProperty(const std::string& name) c
         case Property::<%- camelize(property.name) %>Transition:
             return makeStyleProperty(get<%- camelize(property.name) %>Transition());
 <% } -%>
+<% for (const property of layoutProperties) { -%>
+        case Property::<%- camelize(property.name) %>:
+            return makeStyleProperty(get<%- camelize(property.name) %>());
+<% } -%>
     }
     return {};
 }
@@ -289,17 +301,8 @@ optional<Error> <%- camelize(type) %>Layer::setLayoutProperty(const std::string&
         return Layer::setVisibility(value);
     }
 <% if (layoutProperties.length) { -%>
-    enum class Property {
-<% for (const property of layoutProperties) { -%>
-        <%- camelize(property.name) %>,
-<% } -%>
-    };
-    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        <%- layoutProperties.map(p => `{ "${p.name}", mbgl::underlying_type(Property::${camelize(p.name)}) }`).join(',\n        ') %>
-    });
-
-    const auto it = properties.find(name.c_str());
-    if (it == properties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end() || it->second <= lastPaintPropertyIndex) {
         return Error { "layer doesn't support this property" };
     }
 
@@ -345,5 +348,3 @@ Mutable<Layer::Impl> <%- camelize(type) %>Layer::mutableBaseImpl() const {
 
 } // namespace style
 } // namespace mbgl
-
-// clang-format on

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -1,5 +1,3 @@
-// clang-format off
-
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/line_layer.hpp>
@@ -455,6 +453,10 @@ enum class Property : uint8_t {
     LineTranslateTransition,
     LineTranslateAnchorTransition,
     LineWidthTransition,
+    LineCap,
+    LineJoin,
+    LineMiterLimit,
+    LineRoundLimit,
 };
 
 template <typename T>
@@ -462,7 +464,7 @@ constexpr uint8_t toUint8(T t) noexcept {
     return uint8_t(mbgl::underlying_type(t));
 }
 
-MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+MAPBOX_ETERNAL_CONSTEXPR const auto layerProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
     {{"line-blur", toUint8(Property::LineBlur)},
      {"line-color", toUint8(Property::LineColor)},
      {"line-dasharray", toUint8(Property::LineDasharray)},
@@ -484,13 +486,18 @@ MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<
      {"line-pattern-transition", toUint8(Property::LinePatternTransition)},
      {"line-translate-transition", toUint8(Property::LineTranslateTransition)},
      {"line-translate-anchor-transition", toUint8(Property::LineTranslateAnchorTransition)},
-     {"line-width-transition", toUint8(Property::LineWidthTransition)}});
+     {"line-width-transition", toUint8(Property::LineWidthTransition)},
+     {"line-cap", toUint8(Property::LineCap)},
+     {"line-join", toUint8(Property::LineJoin)},
+     {"line-miter-limit", toUint8(Property::LineMiterLimit)},
+     {"line-round-limit", toUint8(Property::LineRoundLimit)}});
 
+constexpr uint8_t lastPaintPropertyIndex = toUint8(Property::LineWidthTransition);
 } // namespace
 
 optional<Error> LineLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    const auto it = paintProperties.find(name.c_str());
-    if (it == paintProperties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end() || it->second > lastPaintPropertyIndex) {
         return Error{"layer doesn't support this property"};
     }
 
@@ -669,8 +676,8 @@ optional<Error> LineLayer::setPaintProperty(const std::string& name, const Conve
 }
 
 StyleProperty LineLayer::getProperty(const std::string& name) const {
-    const auto it = paintProperties.find(name.c_str());
-    if (it == paintProperties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end()) {
         return {};
     }
 
@@ -719,6 +726,14 @@ StyleProperty LineLayer::getProperty(const std::string& name) const {
             return makeStyleProperty(getLineTranslateAnchorTransition());
         case Property::LineWidthTransition:
             return makeStyleProperty(getLineWidthTransition());
+        case Property::LineCap:
+            return makeStyleProperty(getLineCap());
+        case Property::LineJoin:
+            return makeStyleProperty(getLineJoin());
+        case Property::LineMiterLimit:
+            return makeStyleProperty(getLineMiterLimit());
+        case Property::LineRoundLimit:
+            return makeStyleProperty(getLineRoundLimit());
     }
     return {};
 }
@@ -727,21 +742,8 @@ optional<Error> LineLayer::setLayoutProperty(const std::string& name, const Conv
     if (name == "visibility") {
         return Layer::setVisibility(value);
     }
-    enum class Property {
-        LineCap,
-        LineJoin,
-        LineMiterLimit,
-        LineRoundLimit,
-    };
-    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        { "line-cap", mbgl::underlying_type(Property::LineCap) },
-        { "line-join", mbgl::underlying_type(Property::LineJoin) },
-        { "line-miter-limit", mbgl::underlying_type(Property::LineMiterLimit) },
-        { "line-round-limit", mbgl::underlying_type(Property::LineRoundLimit) }
-    });
-
-    const auto it = properties.find(name.c_str());
-    if (it == properties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end() || it->second <= lastPaintPropertyIndex) {
         return Error { "layer doesn't support this property" };
     }
 
@@ -801,5 +803,3 @@ Mutable<Layer::Impl> LineLayer::mutableBaseImpl() const {
 
 } // namespace style
 } // namespace mbgl
-
-// clang-format on

--- a/src/mbgl/style/layers/raster_layer.cpp
+++ b/src/mbgl/style/layers/raster_layer.cpp
@@ -1,5 +1,3 @@
-// clang-format off
-
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/raster_layer.hpp>
@@ -309,7 +307,7 @@ constexpr uint8_t toUint8(T t) noexcept {
     return uint8_t(mbgl::underlying_type(t));
 }
 
-MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+MAPBOX_ETERNAL_CONSTEXPR const auto layerProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
     {{"raster-brightness-max", toUint8(Property::RasterBrightnessMax)},
      {"raster-brightness-min", toUint8(Property::RasterBrightnessMin)},
      {"raster-contrast", toUint8(Property::RasterContrast)},
@@ -327,11 +325,12 @@ MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<
      {"raster-resampling-transition", toUint8(Property::RasterResamplingTransition)},
      {"raster-saturation-transition", toUint8(Property::RasterSaturationTransition)}});
 
+constexpr uint8_t lastPaintPropertyIndex = toUint8(Property::RasterSaturationTransition);
 } // namespace
 
 optional<Error> RasterLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    const auto it = paintProperties.find(name.c_str());
-    if (it == paintProperties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end() || it->second > lastPaintPropertyIndex) {
         return Error{"layer doesn't support this property"};
     }
 
@@ -445,8 +444,8 @@ optional<Error> RasterLayer::setPaintProperty(const std::string& name, const Con
 }
 
 StyleProperty RasterLayer::getProperty(const std::string& name) const {
-    const auto it = paintProperties.find(name.c_str());
-    if (it == paintProperties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end()) {
         return {};
     }
 
@@ -501,5 +500,3 @@ Mutable<Layer::Impl> RasterLayer::mutableBaseImpl() const {
 
 } // namespace style
 } // namespace mbgl
-
-// clang-format on

--- a/src/mbgl/style/layers/symbol_layer.cpp
+++ b/src/mbgl/style/layers/symbol_layer.cpp
@@ -1,5 +1,3 @@
-// clang-format off
-
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/symbol_layer.hpp>
@@ -1133,6 +1131,47 @@ enum class Property : uint8_t {
     TextOpacityTransition,
     TextTranslateTransition,
     TextTranslateAnchorTransition,
+    IconAllowOverlap,
+    IconAnchor,
+    IconIgnorePlacement,
+    IconImage,
+    IconKeepUpright,
+    IconOffset,
+    IconOptional,
+    IconPadding,
+    IconPitchAlignment,
+    IconRotate,
+    IconRotationAlignment,
+    IconSize,
+    IconTextFit,
+    IconTextFitPadding,
+    SymbolAvoidEdges,
+    SymbolPlacement,
+    SymbolSortKey,
+    SymbolSpacing,
+    SymbolZOrder,
+    TextAllowOverlap,
+    TextAnchor,
+    TextField,
+    TextFont,
+    TextIgnorePlacement,
+    TextJustify,
+    TextKeepUpright,
+    TextLetterSpacing,
+    TextLineHeight,
+    TextMaxAngle,
+    TextMaxWidth,
+    TextOffset,
+    TextOptional,
+    TextPadding,
+    TextPitchAlignment,
+    TextRadialOffset,
+    TextRotate,
+    TextRotationAlignment,
+    TextSize,
+    TextTransform,
+    TextVariableAnchor,
+    TextWritingMode,
 };
 
 template <typename T>
@@ -1140,7 +1179,7 @@ constexpr uint8_t toUint8(T t) noexcept {
     return uint8_t(mbgl::underlying_type(t));
 }
 
-MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+MAPBOX_ETERNAL_CONSTEXPR const auto layerProperties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
     {{"icon-color", toUint8(Property::IconColor)},
      {"icon-halo-blur", toUint8(Property::IconHaloBlur)},
      {"icon-halo-color", toUint8(Property::IconHaloColor)},
@@ -1168,13 +1207,55 @@ MAPBOX_ETERNAL_CONSTEXPR const auto paintProperties = mapbox::eternal::hash_map<
      {"text-halo-width-transition", toUint8(Property::TextHaloWidthTransition)},
      {"text-opacity-transition", toUint8(Property::TextOpacityTransition)},
      {"text-translate-transition", toUint8(Property::TextTranslateTransition)},
-     {"text-translate-anchor-transition", toUint8(Property::TextTranslateAnchorTransition)}});
+     {"text-translate-anchor-transition", toUint8(Property::TextTranslateAnchorTransition)},
+     {"icon-allow-overlap", toUint8(Property::IconAllowOverlap)},
+     {"icon-anchor", toUint8(Property::IconAnchor)},
+     {"icon-ignore-placement", toUint8(Property::IconIgnorePlacement)},
+     {"icon-image", toUint8(Property::IconImage)},
+     {"icon-keep-upright", toUint8(Property::IconKeepUpright)},
+     {"icon-offset", toUint8(Property::IconOffset)},
+     {"icon-optional", toUint8(Property::IconOptional)},
+     {"icon-padding", toUint8(Property::IconPadding)},
+     {"icon-pitch-alignment", toUint8(Property::IconPitchAlignment)},
+     {"icon-rotate", toUint8(Property::IconRotate)},
+     {"icon-rotation-alignment", toUint8(Property::IconRotationAlignment)},
+     {"icon-size", toUint8(Property::IconSize)},
+     {"icon-text-fit", toUint8(Property::IconTextFit)},
+     {"icon-text-fit-padding", toUint8(Property::IconTextFitPadding)},
+     {"symbol-avoid-edges", toUint8(Property::SymbolAvoidEdges)},
+     {"symbol-placement", toUint8(Property::SymbolPlacement)},
+     {"symbol-sort-key", toUint8(Property::SymbolSortKey)},
+     {"symbol-spacing", toUint8(Property::SymbolSpacing)},
+     {"symbol-z-order", toUint8(Property::SymbolZOrder)},
+     {"text-allow-overlap", toUint8(Property::TextAllowOverlap)},
+     {"text-anchor", toUint8(Property::TextAnchor)},
+     {"text-field", toUint8(Property::TextField)},
+     {"text-font", toUint8(Property::TextFont)},
+     {"text-ignore-placement", toUint8(Property::TextIgnorePlacement)},
+     {"text-justify", toUint8(Property::TextJustify)},
+     {"text-keep-upright", toUint8(Property::TextKeepUpright)},
+     {"text-letter-spacing", toUint8(Property::TextLetterSpacing)},
+     {"text-line-height", toUint8(Property::TextLineHeight)},
+     {"text-max-angle", toUint8(Property::TextMaxAngle)},
+     {"text-max-width", toUint8(Property::TextMaxWidth)},
+     {"text-offset", toUint8(Property::TextOffset)},
+     {"text-optional", toUint8(Property::TextOptional)},
+     {"text-padding", toUint8(Property::TextPadding)},
+     {"text-pitch-alignment", toUint8(Property::TextPitchAlignment)},
+     {"text-radial-offset", toUint8(Property::TextRadialOffset)},
+     {"text-rotate", toUint8(Property::TextRotate)},
+     {"text-rotation-alignment", toUint8(Property::TextRotationAlignment)},
+     {"text-size", toUint8(Property::TextSize)},
+     {"text-transform", toUint8(Property::TextTransform)},
+     {"text-variable-anchor", toUint8(Property::TextVariableAnchor)},
+     {"text-writing-mode", toUint8(Property::TextWritingMode)}});
 
+constexpr uint8_t lastPaintPropertyIndex = toUint8(Property::TextTranslateAnchorTransition);
 } // namespace
 
 optional<Error> SymbolLayer::setPaintProperty(const std::string& name, const Convertible& value) {
-    const auto it = paintProperties.find(name.c_str());
-    if (it == paintProperties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end() || it->second > lastPaintPropertyIndex) {
         return Error{"layer doesn't support this property"};
     }
 
@@ -1368,8 +1449,8 @@ optional<Error> SymbolLayer::setPaintProperty(const std::string& name, const Con
 }
 
 StyleProperty SymbolLayer::getProperty(const std::string& name) const {
-    const auto it = paintProperties.find(name.c_str());
-    if (it == paintProperties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end()) {
         return {};
     }
 
@@ -1430,6 +1511,88 @@ StyleProperty SymbolLayer::getProperty(const std::string& name) const {
             return makeStyleProperty(getTextTranslateTransition());
         case Property::TextTranslateAnchorTransition:
             return makeStyleProperty(getTextTranslateAnchorTransition());
+        case Property::IconAllowOverlap:
+            return makeStyleProperty(getIconAllowOverlap());
+        case Property::IconAnchor:
+            return makeStyleProperty(getIconAnchor());
+        case Property::IconIgnorePlacement:
+            return makeStyleProperty(getIconIgnorePlacement());
+        case Property::IconImage:
+            return makeStyleProperty(getIconImage());
+        case Property::IconKeepUpright:
+            return makeStyleProperty(getIconKeepUpright());
+        case Property::IconOffset:
+            return makeStyleProperty(getIconOffset());
+        case Property::IconOptional:
+            return makeStyleProperty(getIconOptional());
+        case Property::IconPadding:
+            return makeStyleProperty(getIconPadding());
+        case Property::IconPitchAlignment:
+            return makeStyleProperty(getIconPitchAlignment());
+        case Property::IconRotate:
+            return makeStyleProperty(getIconRotate());
+        case Property::IconRotationAlignment:
+            return makeStyleProperty(getIconRotationAlignment());
+        case Property::IconSize:
+            return makeStyleProperty(getIconSize());
+        case Property::IconTextFit:
+            return makeStyleProperty(getIconTextFit());
+        case Property::IconTextFitPadding:
+            return makeStyleProperty(getIconTextFitPadding());
+        case Property::SymbolAvoidEdges:
+            return makeStyleProperty(getSymbolAvoidEdges());
+        case Property::SymbolPlacement:
+            return makeStyleProperty(getSymbolPlacement());
+        case Property::SymbolSortKey:
+            return makeStyleProperty(getSymbolSortKey());
+        case Property::SymbolSpacing:
+            return makeStyleProperty(getSymbolSpacing());
+        case Property::SymbolZOrder:
+            return makeStyleProperty(getSymbolZOrder());
+        case Property::TextAllowOverlap:
+            return makeStyleProperty(getTextAllowOverlap());
+        case Property::TextAnchor:
+            return makeStyleProperty(getTextAnchor());
+        case Property::TextField:
+            return makeStyleProperty(getTextField());
+        case Property::TextFont:
+            return makeStyleProperty(getTextFont());
+        case Property::TextIgnorePlacement:
+            return makeStyleProperty(getTextIgnorePlacement());
+        case Property::TextJustify:
+            return makeStyleProperty(getTextJustify());
+        case Property::TextKeepUpright:
+            return makeStyleProperty(getTextKeepUpright());
+        case Property::TextLetterSpacing:
+            return makeStyleProperty(getTextLetterSpacing());
+        case Property::TextLineHeight:
+            return makeStyleProperty(getTextLineHeight());
+        case Property::TextMaxAngle:
+            return makeStyleProperty(getTextMaxAngle());
+        case Property::TextMaxWidth:
+            return makeStyleProperty(getTextMaxWidth());
+        case Property::TextOffset:
+            return makeStyleProperty(getTextOffset());
+        case Property::TextOptional:
+            return makeStyleProperty(getTextOptional());
+        case Property::TextPadding:
+            return makeStyleProperty(getTextPadding());
+        case Property::TextPitchAlignment:
+            return makeStyleProperty(getTextPitchAlignment());
+        case Property::TextRadialOffset:
+            return makeStyleProperty(getTextRadialOffset());
+        case Property::TextRotate:
+            return makeStyleProperty(getTextRotate());
+        case Property::TextRotationAlignment:
+            return makeStyleProperty(getTextRotationAlignment());
+        case Property::TextSize:
+            return makeStyleProperty(getTextSize());
+        case Property::TextTransform:
+            return makeStyleProperty(getTextTransform());
+        case Property::TextVariableAnchor:
+            return makeStyleProperty(getTextVariableAnchor());
+        case Property::TextWritingMode:
+            return makeStyleProperty(getTextWritingMode());
     }
     return {};
 }
@@ -1438,95 +1601,8 @@ optional<Error> SymbolLayer::setLayoutProperty(const std::string& name, const Co
     if (name == "visibility") {
         return Layer::setVisibility(value);
     }
-    enum class Property {
-        IconAllowOverlap,
-        IconAnchor,
-        IconIgnorePlacement,
-        IconImage,
-        IconKeepUpright,
-        IconOffset,
-        IconOptional,
-        IconPadding,
-        IconPitchAlignment,
-        IconRotate,
-        IconRotationAlignment,
-        IconSize,
-        IconTextFit,
-        IconTextFitPadding,
-        SymbolAvoidEdges,
-        SymbolPlacement,
-        SymbolSortKey,
-        SymbolSpacing,
-        SymbolZOrder,
-        TextAllowOverlap,
-        TextAnchor,
-        TextField,
-        TextFont,
-        TextIgnorePlacement,
-        TextJustify,
-        TextKeepUpright,
-        TextLetterSpacing,
-        TextLineHeight,
-        TextMaxAngle,
-        TextMaxWidth,
-        TextOffset,
-        TextOptional,
-        TextPadding,
-        TextPitchAlignment,
-        TextRadialOffset,
-        TextRotate,
-        TextRotationAlignment,
-        TextSize,
-        TextTransform,
-        TextVariableAnchor,
-        TextWritingMode,
-    };
-    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        { "icon-allow-overlap", mbgl::underlying_type(Property::IconAllowOverlap) },
-        { "icon-anchor", mbgl::underlying_type(Property::IconAnchor) },
-        { "icon-ignore-placement", mbgl::underlying_type(Property::IconIgnorePlacement) },
-        { "icon-image", mbgl::underlying_type(Property::IconImage) },
-        { "icon-keep-upright", mbgl::underlying_type(Property::IconKeepUpright) },
-        { "icon-offset", mbgl::underlying_type(Property::IconOffset) },
-        { "icon-optional", mbgl::underlying_type(Property::IconOptional) },
-        { "icon-padding", mbgl::underlying_type(Property::IconPadding) },
-        { "icon-pitch-alignment", mbgl::underlying_type(Property::IconPitchAlignment) },
-        { "icon-rotate", mbgl::underlying_type(Property::IconRotate) },
-        { "icon-rotation-alignment", mbgl::underlying_type(Property::IconRotationAlignment) },
-        { "icon-size", mbgl::underlying_type(Property::IconSize) },
-        { "icon-text-fit", mbgl::underlying_type(Property::IconTextFit) },
-        { "icon-text-fit-padding", mbgl::underlying_type(Property::IconTextFitPadding) },
-        { "symbol-avoid-edges", mbgl::underlying_type(Property::SymbolAvoidEdges) },
-        { "symbol-placement", mbgl::underlying_type(Property::SymbolPlacement) },
-        { "symbol-sort-key", mbgl::underlying_type(Property::SymbolSortKey) },
-        { "symbol-spacing", mbgl::underlying_type(Property::SymbolSpacing) },
-        { "symbol-z-order", mbgl::underlying_type(Property::SymbolZOrder) },
-        { "text-allow-overlap", mbgl::underlying_type(Property::TextAllowOverlap) },
-        { "text-anchor", mbgl::underlying_type(Property::TextAnchor) },
-        { "text-field", mbgl::underlying_type(Property::TextField) },
-        { "text-font", mbgl::underlying_type(Property::TextFont) },
-        { "text-ignore-placement", mbgl::underlying_type(Property::TextIgnorePlacement) },
-        { "text-justify", mbgl::underlying_type(Property::TextJustify) },
-        { "text-keep-upright", mbgl::underlying_type(Property::TextKeepUpright) },
-        { "text-letter-spacing", mbgl::underlying_type(Property::TextLetterSpacing) },
-        { "text-line-height", mbgl::underlying_type(Property::TextLineHeight) },
-        { "text-max-angle", mbgl::underlying_type(Property::TextMaxAngle) },
-        { "text-max-width", mbgl::underlying_type(Property::TextMaxWidth) },
-        { "text-offset", mbgl::underlying_type(Property::TextOffset) },
-        { "text-optional", mbgl::underlying_type(Property::TextOptional) },
-        { "text-padding", mbgl::underlying_type(Property::TextPadding) },
-        { "text-pitch-alignment", mbgl::underlying_type(Property::TextPitchAlignment) },
-        { "text-radial-offset", mbgl::underlying_type(Property::TextRadialOffset) },
-        { "text-rotate", mbgl::underlying_type(Property::TextRotate) },
-        { "text-rotation-alignment", mbgl::underlying_type(Property::TextRotationAlignment) },
-        { "text-size", mbgl::underlying_type(Property::TextSize) },
-        { "text-transform", mbgl::underlying_type(Property::TextTransform) },
-        { "text-variable-anchor", mbgl::underlying_type(Property::TextVariableAnchor) },
-        { "text-writing-mode", mbgl::underlying_type(Property::TextWritingMode) }
-    });
-
-    const auto it = properties.find(name.c_str());
-    if (it == properties.end()) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end() || it->second <= lastPaintPropertyIndex) {
         return Error { "layer doesn't support this property" };
     }
 
@@ -1879,5 +1955,3 @@ Mutable<Layer::Impl> SymbolLayer::mutableBaseImpl() const {
 
 } // namespace style
 } // namespace mbgl
-
-// clang-format on

--- a/src/mbgl/style/light.cpp
+++ b/src/mbgl/style/light.cpp
@@ -1,5 +1,3 @@
-// clang-format off
-
 // This file is generated. Do not edit.
 
 #include <mbgl/style/light.hpp>
@@ -36,29 +34,37 @@ Mutable<Light::Impl> Light::mutableImpl() const {
 
 using namespace conversion;
 
+namespace {
+
+enum class Property : uint8_t {
+    Anchor,
+    Color,
+    Intensity,
+    Position,
+    AnchorTransition,
+    ColorTransition,
+    IntensityTransition,
+    PositionTransition,
+};
+
+template <typename T>
+constexpr uint8_t toUint8(T t) noexcept {
+    return uint8_t(mbgl::underlying_type(t));
+}
+
+MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+    {{"anchor", toUint8(Property::Anchor)},
+     {"color", toUint8(Property::Color)},
+     {"intensity", toUint8(Property::Intensity)},
+     {"position", toUint8(Property::Position)},
+     {"anchor-transition", toUint8(Property::AnchorTransition)},
+     {"color-transition", toUint8(Property::ColorTransition)},
+     {"intensity-transition", toUint8(Property::IntensityTransition)},
+     {"position-transition", toUint8(Property::PositionTransition)}});
+
+} // namespace
+
 optional<Error> Light::setProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-        Anchor,
-        Color,
-        Intensity,
-        Position,
-        AnchorTransition,
-        ColorTransition,
-        IntensityTransition,
-        PositionTransition,
-    };
-
-    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        { "anchor", mbgl::underlying_type(Property::Anchor) },
-        { "color", mbgl::underlying_type(Property::Color) },
-        { "intensity", mbgl::underlying_type(Property::Intensity) },
-        { "position", mbgl::underlying_type(Property::Position) },
-        { "anchor-transition", mbgl::underlying_type(Property::AnchorTransition) },
-        { "color-transition", mbgl::underlying_type(Property::ColorTransition) },
-        { "intensity-transition", mbgl::underlying_type(Property::IntensityTransition) },
-        { "position-transition", mbgl::underlying_type(Property::PositionTransition) }
-    });
-
     const auto it = properties.find(name.c_str());
     if (it == properties.end()) {
         return Error { "light doesn't support this property" };
@@ -144,6 +150,33 @@ optional<Error> Light::setProperty(const std::string& name, const Convertible& v
     
 
     return Error { "light doesn't support this property" };
+}
+
+StyleProperty Light::getProperty(const std::string& name) const {
+    const auto it = properties.find(name.c_str());
+    if (it == properties.end()) {
+        return {};
+    }
+
+    switch (static_cast<Property>(it->second)) {
+        case Property::Anchor:
+            return makeStyleProperty(getAnchor());
+        case Property::Color:
+            return makeStyleProperty(getColor());
+        case Property::Intensity:
+            return makeStyleProperty(getIntensity());
+        case Property::Position:
+            return makeStyleProperty(getPosition());
+        case Property::AnchorTransition:
+            return makeStyleProperty(getAnchorTransition());
+        case Property::ColorTransition:
+            return makeStyleProperty(getColorTransition());
+        case Property::IntensityTransition:
+            return makeStyleProperty(getIntensityTransition());
+        case Property::PositionTransition:
+            return makeStyleProperty(getPositionTransition());
+    }
+    return {};
 }
 
 LightAnchorType Light::getDefaultAnchor() {
@@ -253,5 +286,3 @@ TransitionOptions Light::getPositionTransition() const {
 
 } // namespace style
 } // namespace mbgl
-
-// clang-format on

--- a/src/mbgl/style/light.cpp.ejs
+++ b/src/mbgl/style/light.cpp.ejs
@@ -1,8 +1,6 @@
 <%
   const properties = locals.properties;
 -%>
-// clang-format off
-
 // This file is generated. Do not edit.
 
 #include <mbgl/style/light.hpp>
@@ -39,21 +37,29 @@ Mutable<Light::Impl> Light::mutableImpl() const {
 
 using namespace conversion;
 
+namespace {
+
+enum class Property : uint8_t {
+<% for (const property of properties) { -%>
+    <%- camelize(property.name) %>,
+<% } -%>
+<% for (const property of properties) { -%>
+    <%- camelize(property.name) %>Transition,
+<% } -%>
+};
+
+template <typename T>
+constexpr uint8_t toUint8(T t) noexcept {
+    return uint8_t(mbgl::underlying_type(t));
+}
+
+MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>(
+    {<%- properties.map(p => `{"${p.name}", toUint8(Property::${camelize(p.name)})}`).join(',\n     ') %>,
+     <%- properties.map(p => `{"${p.name}-transition", toUint8(Property::${camelize(p.name)}Transition)}`).join(',\n     ') %>});
+
+} // namespace
+
 optional<Error> Light::setProperty(const std::string& name, const Convertible& value) {
-    enum class Property {
-<% for (const property of properties) { -%>
-        <%- camelize(property.name) %>,
-<% } -%>
-<% for (const property of properties) { -%>
-        <%- camelize(property.name) %>Transition,
-<% } -%>
-    };
-
-    MAPBOX_ETERNAL_CONSTEXPR const auto properties = mapbox::eternal::hash_map<mapbox::eternal::string, uint8_t>({
-        <%- properties.map(p => `{ "${p.name}", mbgl::underlying_type(Property::${camelize(p.name)}) }`).join(',\n        ') %>,
-        <%- properties.map(p => `{ "${p.name}-transition", mbgl::underlying_type(Property::${camelize(p.name)}Transition) }`).join(',\n        ') %>
-    });
-
     const auto it = properties.find(name.c_str());
     if (it == properties.end()) {
         return Error { "light doesn't support this property" };
@@ -107,6 +113,25 @@ optional<Error> Light::setProperty(const std::string& name, const Convertible& v
     return Error { "light doesn't support this property" };
 }
 
+StyleProperty Light::getProperty(const std::string& name) const {
+    const auto it = properties.find(name.c_str());
+    if (it == properties.end()) {
+        return {};
+    }
+
+    switch (static_cast<Property>(it->second)) {
+<% for (const property of properties) { -%>
+        case Property::<%- camelize(property.name) %>:
+            return makeStyleProperty(get<%- camelize(property.name) %>());
+<% } -%>
+<% for (const property of properties) { -%>
+        case Property::<%- camelize(property.name) %>Transition:
+            return makeStyleProperty(get<%- camelize(property.name) %>Transition());
+<% } -%>
+    }
+    return {};
+}
+
 <% for (const property of properties) { -%>
 <%- evaluatedType(property) %> Light::getDefault<%- camelize(property.name) %>() {
     return Light<%- camelize(property.name) %>::defaultValue();
@@ -138,5 +163,3 @@ TransitionOptions Light::get<%- camelize(property.name) %>Transition() const {
 
 } // namespace style
 } // namespace mbgl
-
-// clang-format on

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -946,6 +946,9 @@ TEST(Map, UniversalStyleGetter) {
                 "line-color": "red",
                 "line-opacity": 0.5,
                 "line-width": ["get", "width"]
+            },
+            "layout": {
+                "line-cap": "butt"
             }
         }]
         })STYLE");
@@ -999,4 +1002,10 @@ TEST(Map, UniversalStyleGetter) {
     EXPECT_EQ("get", *operation[0].getString());
     ASSERT_TRUE(operation[1].getString());
     EXPECT_EQ("width", *operation[1].getString());
+
+    StyleProperty lineCap = lineLayer->getProperty("line-cap");
+    ASSERT_TRUE(lineCap.value);
+    EXPECT_EQ(StyleProperty::Kind::Constant, lineCap.kind);
+    ASSERT_TRUE(lineCap.value.getInt());
+    EXPECT_EQ(mbgl::underlying_type(mbgl::style::LineCapType::Butt), *lineCap.value.getInt());
 }


### PR DESCRIPTION
This PR enables fetching layer layout properties from the universal getter API `GetProperty()`, similar API is added to get light properties.
Having a similar method for getting both layout an paint layer properties decreases API surface and saves binary size.
