### PR TITLE
[core] Return enum layer property values as string

### DIFF
--- a/include/mbgl/style/conversion_impl.hpp
+++ b/include/mbgl/style/conversion_impl.hpp
@@ -327,7 +327,7 @@ struct ValueFactory<T, typename std::enable_if<(!std::is_enum<T>::value && !is_l
 
 template <typename T>
 struct ValueFactory<T, typename std::enable_if<std::is_enum<T>::value>::type> {
-    static Value make(T arg) { return {int64_t(arg)}; }
+    static Value make(T arg) { return {Enum<T>::toString(arg)}; }
 };
 
 template <typename T>

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -1006,6 +1006,6 @@ TEST(Map, UniversalStyleGetter) {
     StyleProperty lineCap = lineLayer->getProperty("line-cap");
     ASSERT_TRUE(lineCap.value);
     EXPECT_EQ(StyleProperty::Kind::Constant, lineCap.kind);
-    ASSERT_TRUE(lineCap.value.getInt());
-    EXPECT_EQ(mbgl::underlying_type(mbgl::style::LineCapType::Butt), *lineCap.value.getInt());
+    ASSERT_TRUE(lineCap.value.getString());
+    EXPECT_EQ(std::string("butt"), *lineCap.value.getString());
 }


### PR DESCRIPTION
The output of Layer::getProperty is a mapbox::base::Value which is
equivalent to JSON. When setting the value of an enum property via JSON
its value would be a string, so it would be natural to return a string
too.

Also, the numbers generated depend on the enum definition. They are not
part of the style spec.