### PR TITLE
[ios] Don't link libmbgl-core twice; fix CI build by exposing core classes

### DIFF
--- a/include/mbgl/storage/network_status.hpp
+++ b/include/mbgl/storage/network_status.hpp
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <mutex>
 #include <unordered_set>
+#include <mbgl/util/util.hpp>
 
 namespace mbgl {
 
@@ -10,7 +11,7 @@ namespace util {
 class AsyncTask;
 } // namespace util
 
-class NetworkStatus {
+class MBGL_EXPORT NetworkStatus {
 public:
     enum class Status : uint8_t {
         Online,

--- a/include/mbgl/storage/response.hpp
+++ b/include/mbgl/storage/response.hpp
@@ -2,13 +2,14 @@
 
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/optional.hpp>
+#include <mbgl/util/util.hpp>
 
 #include <string>
 #include <memory>
 
 namespace mbgl {
 
-class Response {
+class MBGL_EXPORT Response {
 public:
     Response() = default;
     Response(const Response&);

--- a/include/mbgl/style/expression/dsl.hpp
+++ b/include/mbgl/style/expression/dsl.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/style/expression/interpolator.hpp>
 #include <mbgl/style/expression/value.hpp>
 #include <mbgl/util/ignore.hpp>
+#include <mbgl/util/util.hpp>
 
 #include <initializer_list>
 #include <memory>
@@ -28,16 +29,16 @@ std::unique_ptr<Expression> createExpression(const char* expr);
 std::unique_ptr<Expression> createExpression(const mbgl::style::conversion::Convertible& expr);
 std::unique_ptr<Expression> error(std::string);
 
-std::unique_ptr<Expression> literal(const char* value);
-std::unique_ptr<Expression> literal(Value value);
-std::unique_ptr<Expression> literal(std::initializer_list<double> value);
-std::unique_ptr<Expression> literal(std::initializer_list<const char*> value);
+std::unique_ptr<Expression> literal(const char* value) MBGL_EXPORT;
+std::unique_ptr<Expression> literal(Value value) MBGL_EXPORT;
+std::unique_ptr<Expression> literal(std::initializer_list<double> value) MBGL_EXPORT;
+std::unique_ptr<Expression> literal(std::initializer_list<const char*> value) MBGL_EXPORT;
 
 std::unique_ptr<Expression>
 assertion(type::Type, std::unique_ptr<Expression>, 
           std::unique_ptr<Expression> def = nullptr);
 std::unique_ptr<Expression> number(std::unique_ptr<Expression>,
-                                   std::unique_ptr<Expression> def = nullptr);
+                                   std::unique_ptr<Expression> def = nullptr) MBGL_EXPORT;
 std::unique_ptr<Expression> string(std::unique_ptr<Expression>,
                                    std::unique_ptr<Expression> def = nullptr);
 std::unique_ptr<Expression> boolean(std::unique_ptr<Expression>,
@@ -46,15 +47,15 @@ std::unique_ptr<Expression> boolean(std::unique_ptr<Expression>,
 std::unique_ptr<Expression> toColor(std::unique_ptr<Expression>,
                                     std::unique_ptr<Expression> def = nullptr);
 std::unique_ptr<Expression> toString(std::unique_ptr<Expression>,
-                                     std::unique_ptr<Expression> def = nullptr);
+                                     std::unique_ptr<Expression> def = nullptr) MBGL_EXPORT;
 std::unique_ptr<Expression> toFormatted(std::unique_ptr<Expression>,
                                         std::unique_ptr<Expression> def = nullptr);
 
-std::unique_ptr<Expression> get(const char* value);
-std::unique_ptr<Expression> get(std::unique_ptr<Expression>);
+std::unique_ptr<Expression> get(const char* value) MBGL_EXPORT;
+std::unique_ptr<Expression> get(std::unique_ptr<Expression>) MBGL_EXPORT;
 
 std::unique_ptr<Expression> id();
-std::unique_ptr<Expression> zoom();
+std::unique_ptr<Expression> zoom() MBGL_EXPORT;
 
 std::unique_ptr<Expression> eq(std::unique_ptr<Expression>, std::unique_ptr<Expression>);
 std::unique_ptr<Expression> ne(std::unique_ptr<Expression>, std::unique_ptr<Expression>);
@@ -63,31 +64,31 @@ std::unique_ptr<Expression> lt(std::unique_ptr<Expression>, std::unique_ptr<Expr
 
 std::unique_ptr<Expression> step(std::unique_ptr<Expression> input,
                                  std::unique_ptr<Expression> output0,
-                                 double input1, std::unique_ptr<Expression> output1);
+                                 double input1, std::unique_ptr<Expression> output1) MBGL_EXPORT;
 
-Interpolator linear();
+Interpolator linear() MBGL_EXPORT;
 Interpolator exponential(double base);
 Interpolator cubicBezier(double x1, double y1, double x2, double y2);
 
 std::unique_ptr<Expression> interpolate(Interpolator interpolator,
                                         std::unique_ptr<Expression> input,
-                                        double input1, std::unique_ptr<Expression> output1);
+                                        double input1, std::unique_ptr<Expression> output1) MBGL_EXPORT;
 
 std::unique_ptr<Expression> interpolate(Interpolator interpolator,
                                         std::unique_ptr<Expression> input,
                                         double input1, std::unique_ptr<Expression> output1,
-                                        double input2, std::unique_ptr<Expression> output2);
+                                        double input2, std::unique_ptr<Expression> output2) MBGL_EXPORT;
 
 std::unique_ptr<Expression> interpolate(Interpolator interpolator,
                                         std::unique_ptr<Expression> input,
                                         double input1, std::unique_ptr<Expression> output1,
                                         double input2, std::unique_ptr<Expression> output2,
-                                        double input3, std::unique_ptr<Expression> output3);
+                                        double input3, std::unique_ptr<Expression> output3) MBGL_EXPORT;
 
 std::unique_ptr<Expression> concat(std::vector<std::unique_ptr<Expression>> inputs);
 
-std::unique_ptr<Expression> format(const char* value);
-std::unique_ptr<Expression> format(std::unique_ptr<Expression>);
+std::unique_ptr<Expression> format(const char* value) MBGL_EXPORT;
+std::unique_ptr<Expression> format(std::unique_ptr<Expression>) MBGL_EXPORT;
 
 } // namespace dsl
 } // namespace expression

--- a/include/mbgl/style/expression/formatted.hpp
+++ b/include/mbgl/style/expression/formatted.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/util/color.hpp>
 #include <mbgl/util/font_stack.hpp>
 #include <mbgl/util/optional.hpp>
+#include <mbgl/util/util.hpp>
 
 #include <vector>
 #include <string>
@@ -33,7 +34,7 @@ struct FormattedSection {
     optional<Color> textColor;
 };
 
-class Formatted {
+class MBGL_EXPORT Formatted {
 public:
     Formatted() = default;
     

--- a/include/mbgl/style/layer.hpp
+++ b/include/mbgl/style/layer.hpp
@@ -5,6 +5,7 @@
 #include <mbgl/style/types.hpp>
 #include <mbgl/util/immutable.hpp>
 #include <mbgl/util/optional.hpp>
+#include <mbgl/util/util.hpp>
 
 #include <mapbox/weak.hpp>
 #include <mapbox/type_wrapper.hpp>
@@ -82,7 +83,7 @@ struct LayerTypeInfo {
  *
  *     auto circleLayer = LayerManager::get()->createLayer("circle", ...);
  */
-class Layer {
+class MBGL_EXPORT Layer {
 public:
     Layer(const Layer& ) = delete;
     Layer& operator=(const Layer&) = delete;

--- a/include/mbgl/style/layers/background_layer.hpp
+++ b/include/mbgl/style/layers/background_layer.hpp
@@ -15,7 +15,7 @@ namespace style {
 
 class TransitionOptions;
 
-class BackgroundLayer : public Layer {
+class MBGL_EXPORT BackgroundLayer : public Layer {
 public:
     BackgroundLayer(const std::string& layerID);
     ~BackgroundLayer() final;

--- a/include/mbgl/style/layers/circle_layer.hpp
+++ b/include/mbgl/style/layers/circle_layer.hpp
@@ -15,7 +15,7 @@ namespace style {
 
 class TransitionOptions;
 
-class CircleLayer : public Layer {
+class MBGL_EXPORT CircleLayer : public Layer {
 public:
     CircleLayer(const std::string& layerID, const std::string& sourceID);
     ~CircleLayer() final;

--- a/include/mbgl/style/layers/fill_extrusion_layer.hpp
+++ b/include/mbgl/style/layers/fill_extrusion_layer.hpp
@@ -15,7 +15,7 @@ namespace style {
 
 class TransitionOptions;
 
-class FillExtrusionLayer : public Layer {
+class MBGL_EXPORT FillExtrusionLayer : public Layer {
 public:
     FillExtrusionLayer(const std::string& layerID, const std::string& sourceID);
     ~FillExtrusionLayer() final;

--- a/include/mbgl/style/layers/fill_layer.hpp
+++ b/include/mbgl/style/layers/fill_layer.hpp
@@ -15,7 +15,7 @@ namespace style {
 
 class TransitionOptions;
 
-class FillLayer : public Layer {
+class MBGL_EXPORT FillLayer : public Layer {
 public:
     FillLayer(const std::string& layerID, const std::string& sourceID);
     ~FillLayer() final;

--- a/include/mbgl/style/layers/heatmap_layer.hpp
+++ b/include/mbgl/style/layers/heatmap_layer.hpp
@@ -16,7 +16,7 @@ namespace style {
 
 class TransitionOptions;
 
-class HeatmapLayer : public Layer {
+class MBGL_EXPORT HeatmapLayer : public Layer {
 public:
     HeatmapLayer(const std::string& layerID, const std::string& sourceID);
     ~HeatmapLayer() final;

--- a/include/mbgl/style/layers/hillshade_layer.hpp
+++ b/include/mbgl/style/layers/hillshade_layer.hpp
@@ -15,7 +15,8 @@ namespace style {
 
 class TransitionOptions;
 
-class HillshadeLayer : public Layer {
+
+class MBGL_EXPORT HillshadeLayer : public Layer {
 public:
     HillshadeLayer(const std::string& layerID, const std::string& sourceID);
     ~HillshadeLayer() final;

--- a/include/mbgl/style/layers/hillshade_layer.hpp
+++ b/include/mbgl/style/layers/hillshade_layer.hpp
@@ -15,7 +15,6 @@ namespace style {
 
 class TransitionOptions;
 
-
 class MBGL_EXPORT HillshadeLayer : public Layer {
 public:
     HillshadeLayer(const std::string& layerID, const std::string& sourceID);

--- a/include/mbgl/style/layers/layer.hpp.ejs
+++ b/include/mbgl/style/layers/layer.hpp.ejs
@@ -27,7 +27,7 @@ namespace style {
 
 class TransitionOptions;
 
-class <%- camelize(type) %>Layer : public Layer {
+class MBGL_EXPORT <%- camelize(type) %>Layer : public Layer {
 public:
 <% if (type === 'background') { -%>
     <%- camelize(type) %>Layer(const std::string& layerID);

--- a/include/mbgl/style/layers/line_layer.hpp
+++ b/include/mbgl/style/layers/line_layer.hpp
@@ -18,7 +18,7 @@ namespace style {
 
 class TransitionOptions;
 
-class MBGL_EXPORT LineLayer  : public Layer {
+class MBGL_EXPORT LineLayer : public Layer {
 public:
     LineLayer(const std::string& layerID, const std::string& sourceID);
     ~LineLayer() final;

--- a/include/mbgl/style/layers/line_layer.hpp
+++ b/include/mbgl/style/layers/line_layer.hpp
@@ -18,7 +18,7 @@ namespace style {
 
 class TransitionOptions;
 
-class LineLayer : public Layer {
+class MBGL_EXPORT LineLayer  : public Layer {
 public:
     LineLayer(const std::string& layerID, const std::string& sourceID);
     ~LineLayer() final;

--- a/include/mbgl/style/layers/raster_layer.hpp
+++ b/include/mbgl/style/layers/raster_layer.hpp
@@ -15,7 +15,7 @@ namespace style {
 
 class TransitionOptions;
 
-class MBGL_EXPORT RasterLayer  : public Layer {
+class MBGL_EXPORT RasterLayer : public Layer {
 public:
     RasterLayer(const std::string& layerID, const std::string& sourceID);
     ~RasterLayer() final;

--- a/include/mbgl/style/layers/raster_layer.hpp
+++ b/include/mbgl/style/layers/raster_layer.hpp
@@ -15,7 +15,7 @@ namespace style {
 
 class TransitionOptions;
 
-class RasterLayer : public Layer {
+class MBGL_EXPORT RasterLayer  : public Layer {
 public:
     RasterLayer(const std::string& layerID, const std::string& sourceID);
     ~RasterLayer() final;

--- a/include/mbgl/style/layers/symbol_layer.hpp
+++ b/include/mbgl/style/layers/symbol_layer.hpp
@@ -17,7 +17,7 @@ namespace style {
 
 class TransitionOptions;
 
-class SymbolLayer : public Layer {
+class MBGL_EXPORT SymbolLayer : public Layer {
 public:
     SymbolLayer(const std::string& layerID, const std::string& sourceID);
     ~SymbolLayer() final;

--- a/include/mbgl/style/light.hpp
+++ b/include/mbgl/style/light.hpp
@@ -10,13 +10,14 @@
 #include <mbgl/style/transition_options.hpp>
 #include <mbgl/style/types.hpp>
 #include <mbgl/util/immutable.hpp>
+#include <mbgl/util/util.hpp>
 
 namespace mbgl {
 namespace style {
 
 class LightObserver;
 
-class Light {
+class MBGL_EXPORT Light {
 public:
     Light();
     ~Light();

--- a/include/mbgl/style/light.hpp.ejs
+++ b/include/mbgl/style/light.hpp.ejs
@@ -13,13 +13,14 @@
 #include <mbgl/style/transition_options.hpp>
 #include <mbgl/style/types.hpp>
 #include <mbgl/util/immutable.hpp>
+#include <mbgl/util/util.hpp>
 
 namespace mbgl {
 namespace style {
 
 class LightObserver;
 
-class Light {
+class MBGL_EXPORT Light {
 public:
     Light();
     ~Light();

--- a/include/mbgl/style/property_expression.hpp
+++ b/include/mbgl/style/property_expression.hpp
@@ -6,11 +6,12 @@
 #include <mbgl/style/expression/step.hpp>
 #include <mbgl/style/expression/find_zoom_curve.hpp>
 #include <mbgl/util/range.hpp>
+#include <mbgl/util/util.hpp>
 
 namespace mbgl {
 namespace style {
 
-class PropertyExpressionBase {
+class MBGL_EXPORT PropertyExpressionBase {
 public:
     explicit PropertyExpressionBase(std::unique_ptr<expression::Expression>);
 

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -519,7 +519,7 @@
 		CA6914B520E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CA6914B420E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.mm */; };
 		CA7766832229C10E0008DE9E /* MGLCompactCalloutView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA8848451CBAFB9800AB86E3 /* MGLCompactCalloutView.m */; };
 		CA7766842229C11A0008DE9E /* SMCalloutView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA88488A1CBB037E00AB86E3 /* SMCalloutView.m */; };
-		CA86FF0E22D8D5A0009EB14A /* MGLNetworkConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA86FF0D22D8D5A0009EB14A /* MGLNetworkConfigurationTests.m */; };
+		CA86FF0E22D8D5A0009EB14A /* MGLNetworkConfigurationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CA86FF0D22D8D5A0009EB14A /* MGLNetworkConfigurationTests.mm */; };
 		CA88DC3021C85D900059ED5A /* MGLStyleURLIntegrationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CA88DC2F21C85D900059ED5A /* MGLStyleURLIntegrationTest.m */; };
 		CA8FBC0921A47BB100D1203C /* MGLRendererConfigurationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CA8FBC0821A47BB100D1203C /* MGLRendererConfigurationTests.mm */; };
 		CAA69DA4206DCD0E007279CD /* Mapbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA4A26961CB6E795000B7809 /* Mapbox.framework */; };
@@ -689,7 +689,6 @@
 		DAA4E4351CBB730400178DFB /* SMCalloutView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA88488A1CBB037E00AB86E3 /* SMCalloutView.m */; };
 		DAABF73D1CBC59BB005B1825 /* libmbgl-core.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DAABF73B1CBC59BB005B1825 /* libmbgl-core.a */; };
 		DAAE5F8720F046E60089D85B /* libmbgl-core.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DAABF73B1CBC59BB005B1825 /* libmbgl-core.a */; };
-		DAAE5F8820F046FE0089D85B /* libmbgl-core.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DAABF73B1CBC59BB005B1825 /* libmbgl-core.a */; };
 		DAAE5F8920F047240089D85B /* libmbgl-filesource.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 55D120A91F79100C004B6D81 /* libmbgl-filesource.a */; };
 		DAAE5F8A20F0472E0089D85B /* libmbgl-loop-darwin.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 55D120A71F791007004B6D81 /* libmbgl-loop-darwin.a */; };
 		DAAF722B1DA903C700312FA4 /* MGLStyleValue.h in Headers */ = {isa = PBXBuildFile; fileRef = DAAF72291DA903C700312FA4 /* MGLStyleValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1072,8 +1071,8 @@
 		5580B45A229570A10091291B /* MGLMapView+OpenGL.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "MGLMapView+OpenGL.mm"; sourceTree = "<group>"; };
 		558DE79E1E5615E400C7916D /* MGLFoundation_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLFoundation_Private.h; sourceTree = "<group>"; };
 		558DE79F1E5615E400C7916D /* MGLFoundation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLFoundation.mm; sourceTree = "<group>"; };
-		55CF752E213ED92000ED86C4 /* libmbgl-vendor-icu.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libmbgl-vendor-icu.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		55CF7530213ED92A00ED86C4 /* libmbgl-vendor-icu.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libmbgl-vendor-icu.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		55CF752E213ED92000ED86C4 /* libmbgl-vendor-icu.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libmbgl-vendor-icu.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		55CF7530213ED92A00ED86C4 /* libmbgl-vendor-icu.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libmbgl-vendor-icu.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		55D120A71F791007004B6D81 /* libmbgl-loop-darwin.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libmbgl-loop-darwin.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		55D120A91F79100C004B6D81 /* libmbgl-filesource.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libmbgl-filesource.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		55D8C9941D0F133500F42F10 /* config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = config.xcconfig; path = ../../build/ios/config.xcconfig; sourceTree = "<group>"; };
@@ -1210,7 +1209,7 @@
 		CA5E5042209BDC5F001A8A81 /* MGLTestUtility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MGLTestUtility.h; path = ../../darwin/test/MGLTestUtility.h; sourceTree = "<group>"; };
 		CA65C4F721E9BB080068B0D4 /* MGLCluster.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLCluster.h; sourceTree = "<group>"; };
 		CA6914B420E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLAnnotationViewIntegrationTests.mm; path = "Annotation Tests/MGLAnnotationViewIntegrationTests.mm"; sourceTree = "<group>"; };
-		CA86FF0D22D8D5A0009EB14A /* MGLNetworkConfigurationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLNetworkConfigurationTests.m; sourceTree = "<group>"; };
+		CA86FF0D22D8D5A0009EB14A /* MGLNetworkConfigurationTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLNetworkConfigurationTests.mm; sourceTree = "<group>"; };
 		CA88DC2F21C85D900059ED5A /* MGLStyleURLIntegrationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLStyleURLIntegrationTest.m; sourceTree = "<group>"; };
 		CA8FBC0821A47BB100D1203C /* MGLRendererConfigurationTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLRendererConfigurationTests.mm; path = ../../darwin/test/MGLRendererConfigurationTests.mm; sourceTree = "<group>"; };
 		CAAA65D72321BBA900F08A39 /* MGLTestAssertionHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MGLTestAssertionHandler.h; path = ../../darwin/test/MGLTestAssertionHandler.h; sourceTree = "<group>"; };
@@ -1505,7 +1504,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DAAE5F8820F046FE0089D85B /* libmbgl-core.a in Frameworks */,
 				DA2E88561CC036F400F24E7B /* Mapbox.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2103,7 +2101,7 @@
 				357579811D502AD4000B822E /* Styling */,
 				409F43FB1E9E77D10048729D /* Swift Integration */,
 				4031ACFD1E9FD26900A3EA26 /* Test Helpers */,
-				CA86FF0D22D8D5A0009EB14A /* MGLNetworkConfigurationTests.m */,
+				CA86FF0D22D8D5A0009EB14A /* MGLNetworkConfigurationTests.mm */,
 			);
 			name = "SDK Tests";
 			path = test;
@@ -3288,7 +3286,7 @@
 				DA2DBBCE1D51E80400D38FF9 /* MGLStyleLayerTests.m in Sources */,
 				DA35A2C61CCA9F8300E826B2 /* MGLCompassDirectionFormatterTests.m in Sources */,
 				DAE7DEC21E245455007505A6 /* MGLNSStringAdditionsTests.m in Sources */,
-				CA86FF0E22D8D5A0009EB14A /* MGLNetworkConfigurationTests.m in Sources */,
+				CA86FF0E22D8D5A0009EB14A /* MGLNetworkConfigurationTests.mm in Sources */,
 				4085AF091D933DEA00F11B22 /* MGLTileSetTests.mm in Sources */,
 				DAEDC4341D603417000224FF /* MGLAttributionInfoTests.m in Sources */,
 				1F7454A91ED08AB400021D39 /* MGLLightTest.mm in Sources */,

--- a/platform/ios/test/MGLNetworkConfigurationTests.mm
+++ b/platform/ios/test/MGLNetworkConfigurationTests.mm
@@ -1,6 +1,8 @@
 #import <Mapbox/Mapbox.h>
 #import <XCTest/XCTest.h>
 #import "MGLNetworkConfiguration_Private.h"
+#include <mbgl/storage/network_status.hpp>
+
 
 @interface MGLNetworkConfigurationTests : XCTestCase
 @end
@@ -39,5 +41,19 @@
     }
     
     [self waitForExpectations:@[expectation] timeout:10.0];
+}
+
+- (void)testMBGLNetworkStatus
+{
+    auto currentStatus = mbgl::NetworkStatus::Get();
+
+    mbgl::NetworkStatus::Set(mbgl::NetworkStatus::Status::Offline);
+    auto networkStatus = mbgl::NetworkStatus::Get();
+    
+    // This will fail if libmbgl-core is linked twice.
+    XCTAssertEqual(networkStatus, mbgl::NetworkStatus::Status::Offline);
+
+    // Reset
+    mbgl::NetworkStatus::Set(currentStatus);
 }
 @end

--- a/src/mbgl/style/layers/background_layer_properties.hpp
+++ b/src/mbgl/style/layers/background_layer_properties.hpp
@@ -34,7 +34,7 @@ class BackgroundPaintProperties : public Properties<
     BackgroundPattern
 > {};
 
-class BackgroundLayerProperties final : public LayerProperties {
+class MBGL_EXPORT BackgroundLayerProperties final : public LayerProperties {
 public:
     explicit BackgroundLayerProperties(Immutable<BackgroundLayer::Impl>);
     BackgroundLayerProperties(

--- a/src/mbgl/style/layers/circle_layer_properties.hpp
+++ b/src/mbgl/style/layers/circle_layer_properties.hpp
@@ -74,7 +74,7 @@ class CirclePaintProperties : public Properties<
     CircleTranslateAnchor
 > {};
 
-class CircleLayerProperties final : public LayerProperties {
+class MBGL_EXPORT CircleLayerProperties final : public LayerProperties {
 public:
     explicit CircleLayerProperties(Immutable<CircleLayer::Impl>);
     CircleLayerProperties(

--- a/src/mbgl/style/layers/fill_extrusion_layer_properties.hpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer_properties.hpp
@@ -59,7 +59,7 @@ class FillExtrusionPaintProperties : public Properties<
     FillExtrusionVerticalGradient
 > {};
 
-class FillExtrusionLayerProperties final : public LayerProperties {
+class MBGL_EXPORT FillExtrusionLayerProperties final : public LayerProperties {
 public:
     explicit FillExtrusionLayerProperties(Immutable<FillExtrusionLayer::Impl>);
     FillExtrusionLayerProperties(

--- a/src/mbgl/style/layers/fill_layer_properties.hpp
+++ b/src/mbgl/style/layers/fill_layer_properties.hpp
@@ -54,7 +54,7 @@ class FillPaintProperties : public Properties<
     FillTranslateAnchor
 > {};
 
-class FillLayerProperties final : public LayerProperties {
+class MBGL_EXPORT FillLayerProperties final : public LayerProperties {
 public:
     explicit FillLayerProperties(Immutable<FillLayer::Impl>);
     FillLayerProperties(

--- a/src/mbgl/style/layers/heatmap_layer_properties.hpp
+++ b/src/mbgl/style/layers/heatmap_layer_properties.hpp
@@ -43,7 +43,7 @@ class HeatmapPaintProperties : public Properties<
     HeatmapWeight
 > {};
 
-class HeatmapLayerProperties final : public LayerProperties {
+class MBGL_EXPORT HeatmapLayerProperties final : public LayerProperties {
 public:
     explicit HeatmapLayerProperties(Immutable<HeatmapLayer::Impl>);
     HeatmapLayerProperties(

--- a/src/mbgl/style/layers/hillshade_layer_properties.hpp
+++ b/src/mbgl/style/layers/hillshade_layer_properties.hpp
@@ -49,7 +49,7 @@ class HillshadePaintProperties : public Properties<
     HillshadeShadowColor
 > {};
 
-class HillshadeLayerProperties final : public LayerProperties {
+class MBGL_EXPORT HillshadeLayerProperties final : public LayerProperties {
 public:
     explicit HillshadeLayerProperties(Immutable<HillshadeLayer::Impl>);
     HillshadeLayerProperties(

--- a/src/mbgl/style/layers/layer_properties.hpp.ejs
+++ b/src/mbgl/style/layers/layer_properties.hpp.ejs
@@ -63,7 +63,7 @@ class <%- camelize(type) %>PaintProperties : public Properties<
     <%- camelize(paintProperties.slice(-1)[0].name) %>
 > {};
 
-class <%- camelize(type) %>LayerProperties final : public LayerProperties {
+class MBGL_EXPORT <%- camelize(type) %>LayerProperties final : public LayerProperties {
 public:
     explicit <%- camelize(type) %>LayerProperties(Immutable<<%- camelize(type) %>Layer::Impl>);
     <%- camelize(type) %>LayerProperties(

--- a/src/mbgl/style/layers/line_layer_properties.hpp
+++ b/src/mbgl/style/layers/line_layer_properties.hpp
@@ -106,7 +106,7 @@ class LinePaintProperties : public Properties<
     LineWidth
 > {};
 
-class LineLayerProperties final : public LayerProperties {
+class MBGL_EXPORT LineLayerProperties final : public LayerProperties {
 public:
     explicit LineLayerProperties(Immutable<LineLayer::Impl>);
     LineLayerProperties(

--- a/src/mbgl/style/layers/raster_layer_properties.hpp
+++ b/src/mbgl/style/layers/raster_layer_properties.hpp
@@ -59,7 +59,7 @@ class RasterPaintProperties : public Properties<
     RasterSaturation
 > {};
 
-class RasterLayerProperties final : public LayerProperties {
+class MBGL_EXPORT RasterLayerProperties final : public LayerProperties {
 public:
     explicit RasterLayerProperties(Immutable<RasterLayer::Impl>);
     RasterLayerProperties(

--- a/src/mbgl/style/layers/symbol_layer_properties.hpp
+++ b/src/mbgl/style/layers/symbol_layer_properties.hpp
@@ -12,7 +12,6 @@
 #include <mbgl/style/properties.hpp>
 #include <mbgl/programs/attributes.hpp>
 #include <mbgl/programs/uniforms.hpp>
-#include <mbgl/util/util.hpp>
 
 namespace mbgl {
 namespace style {

--- a/src/mbgl/style/layers/symbol_layer_properties.hpp
+++ b/src/mbgl/style/layers/symbol_layer_properties.hpp
@@ -12,6 +12,7 @@
 #include <mbgl/style/properties.hpp>
 #include <mbgl/programs/attributes.hpp>
 #include <mbgl/programs/uniforms.hpp>
+#include <mbgl/util/util.hpp>
 
 namespace mbgl {
 namespace style {
@@ -341,7 +342,7 @@ class SymbolPaintProperties : public Properties<
     TextTranslateAnchor
 > {};
 
-class SymbolLayerProperties final : public LayerProperties {
+class MBGL_EXPORT SymbolLayerProperties final : public LayerProperties {
 public:
     explicit SymbolLayerProperties(Immutable<SymbolLayer::Impl>);
     SymbolLayerProperties(


### PR DESCRIPTION
In the process of investigating why https://github.com/mapbox/mapbox-gl-native/pull/15650's test was failing, we discovered that the `test` target was explicitly linking with `libmbgl-core.a` causing duplicate globals.

This PR removes the explicit link, but this has required exposing some core classes by adding the visibility attribute.

This may be something that we don't want to do in general, if so we could consider adding a `TEST` configuration for this purpose.

EDIT: Whoops - I edited the autogenerated files!