### PR TITLE
Increased support for camera movement via keyboard

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -65,6 +65,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   private final MapChangeReceiver mapChangeReceiver = new MapChangeReceiver();
   private final MapCallback mapCallback = new MapCallback();
   private final InitialRenderCallback initialRenderCallback = new InitialRenderCallback();
+  private static final String TAG = "Mbgl-MapView";
 
   @Nullable
   private NativeMap nativeMapView;
@@ -131,9 +132,20 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
 
     // inflate view
     View view = LayoutInflater.from(context).inflate(R.layout.mapbox_mapview_internal, this);
+    view.setNextFocusForwardId(R.id.compassView);
+    view.setNextFocusRightId(R.id.compassView);
+    view.setNextFocusLeftId(R.id.attributionView);
     compassView = view.findViewById(R.id.compassView);
+    compassView.setNextFocusForwardId(R.id.attributionView);
+    compassView.setNextFocusRightId(R.id.attributionView);
+    compassView.setNextFocusLeftId(view.getId());
     attrView = view.findViewById(R.id.attributionView);
     attrView.setImageDrawable(BitmapUtils.getDrawableFromRes(getContext(), R.drawable.mapbox_info_bg_selector));
+    attrView = view.findViewById(R.id.attributionView);
+    attrView.setImageDrawable(BitmapUtils.getDrawableFromRes(getContext(), R.drawable.mapbox_info_bg_selector));
+    attrView.setNextFocusForwardId(view.getId());
+    attrView.setNextFocusRightId(R.id.compassView);
+    attrView.setNextFocusLeftId(view.getId());
     logoView = view.findViewById(R.id.logoView);
     logoView.setImageDrawable(BitmapUtils.getDrawableFromRes(getContext(), R.drawable.mapbox_logo_icon));
 
@@ -180,7 +192,6 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     mapGestureDetector = new MapGestureDetector(context, transform, proj, uiSettings,
       annotationManager, cameraDispatcher);
     mapKeyListener = new MapKeyListener(transform, uiSettings, mapGestureDetector);
-
     // compass
     compassView.injectCompassAnimationListener(createCompassAnimationListener(cameraDispatcher));
     compassView.setOnClickListener(createCompassClickListener(cameraDispatcher));

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/MapKeyListenerTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/MapKeyListenerTest.kt
@@ -2,7 +2,8 @@ package com.mapbox.mapboxsdk.maps
 
 import android.support.test.espresso.Espresso.onView
 import android.support.test.espresso.action.EspressoKey
-import android.support.test.espresso.action.ViewActions
+import android.support.test.espresso.action.ViewActions.click
+import android.support.test.espresso.action.ViewActions.pressKey
 import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.view.KeyEvent
 import com.mapbox.mapboxsdk.camera.CameraPosition
@@ -37,7 +38,7 @@ class MapKeyListenerTest : BaseTest() {
       mapboxMap.uiSettings.isTiltGesturesEnabled = true
     }
     // Tap the up arrow while holding shift on the keyboard directional pad
-    onView(withId(R.id.mapView)).perform(ViewActions.pressKey(
+    onView(withId(R.id.mapView)).perform(click()).perform(pressKey(
       EspressoKey.Builder()
         .withShiftPressed(true)
         .withKeyCode(KeyEvent.KEYCODE_DPAD_UP)
@@ -57,7 +58,7 @@ class MapKeyListenerTest : BaseTest() {
       mapboxMap.uiSettings.isRotateGesturesEnabled = true
     }
     // Tap the left arrow while holding shift on the keyboard directional pad
-    onView(withId(R.id.mapView)).perform(ViewActions.pressKey(
+    onView(withId(R.id.mapView)).perform(click()).perform(pressKey(
       EspressoKey.Builder()
         .withShiftPressed(true)
         .withKeyCode(KeyEvent.KEYCODE_DPAD_LEFT)
@@ -80,7 +81,7 @@ class MapKeyListenerTest : BaseTest() {
     }
 
     // Tap the up arrow on the keyboard directional pad
-    onView(withId(R.id.mapView)).perform(ViewActions.pressKey(
+    onView(withId(R.id.mapView)).perform(click()).perform(pressKey(
       EspressoKey.Builder()
         .withKeyCode(KeyEvent.KEYCODE_DPAD_UP)
         .build()))
@@ -103,10 +104,52 @@ class MapKeyListenerTest : BaseTest() {
     }
 
     // Tap the down arrow on the keyboard directional pad
-    onView(withId(R.id.mapView)).perform(ViewActions.pressKey(
+    onView(withId(R.id.mapView)).perform(click()).perform(pressKey(
       EspressoKey.Builder()
         .withKeyCode(KeyEvent.KEYCODE_DPAD_DOWN)
         .build()))
+
+    rule.runOnUiThread {
+      assertNotEquals(initialCameraPosition!!.target.latitude, mapboxMap.cameraPosition.target.latitude)
+      assertNotEquals(initialCameraPosition!!.target.longitude, mapboxMap.cameraPosition.target.longitude)
+    }
+  }
+
+  @Test
+  fun increaseZoom() {
+    validateTestSetup()
+    var initialCameraPosition: CameraPosition? = null
+    rule.runOnUiThread {
+      // zoom in so we can move vertically
+      mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(4.0))
+      initialCameraPosition = mapboxMap.cameraPosition
+      mapboxMap.uiSettings.isQuickZoomGesturesEnabled = true
+    }
+
+    // Tap the down arrow on the keyboard directional pad
+    onView(withId(R.id.mapView)).perform(click()).perform(pressKey(KeyEvent.KEYCODE_EQUALS))
+    onView(withId(R.id.mapView)).perform(pressKey(KeyEvent.KEYCODE_EQUALS))
+
+    rule.runOnUiThread {
+      assertNotEquals(initialCameraPosition!!.target.latitude, mapboxMap.cameraPosition.target.latitude)
+      assertNotEquals(initialCameraPosition!!.target.longitude, mapboxMap.cameraPosition.target.longitude)
+    }
+  }
+
+  @Test
+  fun decreaseZoom() {
+    validateTestSetup()
+    var initialCameraPosition: CameraPosition? = null
+    rule.runOnUiThread {
+      // zoom in so we can move vertically
+      mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(4.0))
+      initialCameraPosition = mapboxMap.cameraPosition
+      mapboxMap.uiSettings.isQuickZoomGesturesEnabled = true
+    }
+
+    // Tap the down arrow on the keyboard directional pad
+    onView(withId(R.id.mapView)).perform(click()).perform(pressKey(KeyEvent.KEYCODE_MINUS))
+    onView(withId(R.id.mapView)).perform(pressKey(KeyEvent.KEYCODE_MINUS))
 
     rule.runOnUiThread {
       assertNotEquals(initialCameraPosition!!.target.latitude, mapboxMap.cameraPosition.target.latitude)

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/MapKeyListenerTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/MapKeyListenerTest.kt
@@ -1,0 +1,116 @@
+package com.mapbox.mapboxsdk.maps
+
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.action.EspressoKey
+import android.support.test.espresso.action.ViewActions
+import android.support.test.espresso.matcher.ViewMatchers.withId
+import android.view.KeyEvent
+import com.mapbox.mapboxsdk.camera.CameraPosition
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
+import com.mapbox.mapboxsdk.testapp.R
+import com.mapbox.mapboxsdk.testapp.activity.BaseTest
+import com.mapbox.mapboxsdk.testapp.activity.maplayout.SimpleMapActivity
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Test
+
+class MapKeyListenerTest : BaseTest() {
+  override fun getActivityClass() = SimpleMapActivity::class.java
+
+  private var maxWidth: Int = 0
+  private var maxHeight: Int = 0
+
+  @Before
+  fun setup() {
+    maxWidth = mapView.width
+    maxHeight = mapView.height
+  }
+
+  @Test
+  fun pitchAdjustWithShiftAndUp() {
+    validateTestSetup()
+    var initialCameraPosition: CameraPosition? = null
+    rule.runOnUiThread {
+      // zoom in so we can move vertically
+      mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(10.0))
+      initialCameraPosition = mapboxMap.cameraPosition
+      mapboxMap.uiSettings.isTiltGesturesEnabled = true
+    }
+    // Tap the up arrow while holding shift on the keyboard directional pad
+    onView(withId(R.id.mapView)).perform(ViewActions.pressKey(
+      EspressoKey.Builder()
+        .withShiftPressed(true)
+        .withKeyCode(KeyEvent.KEYCODE_DPAD_UP)
+        .build()))
+
+    rule.runOnUiThread {
+      assertNotEquals(initialCameraPosition!!.tilt, mapboxMap.cameraPosition.tilt)
+    }
+  }
+
+  @Test
+  fun bearingAdjustWithShiftAndLeft() {
+    validateTestSetup()
+    var initialCameraPosition: CameraPosition? = null
+    rule.runOnUiThread {
+      initialCameraPosition = mapboxMap.cameraPosition
+      mapboxMap.uiSettings.isRotateGesturesEnabled = true
+    }
+    // Tap the left arrow while holding shift on the keyboard directional pad
+    onView(withId(R.id.mapView)).perform(ViewActions.pressKey(
+      EspressoKey.Builder()
+        .withShiftPressed(true)
+        .withKeyCode(KeyEvent.KEYCODE_DPAD_LEFT)
+        .build()))
+
+    rule.runOnUiThread {
+      assertNotEquals(initialCameraPosition!!.bearing, mapboxMap.cameraPosition.bearing)
+    }
+  }
+
+  @Test
+  fun targetAdjustWithUp() {
+    validateTestSetup()
+    var initialCameraPosition: CameraPosition? = null
+    rule.runOnUiThread {
+      // zoom in so we can move vertically
+      mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(4.0))
+      initialCameraPosition = mapboxMap.cameraPosition
+      mapboxMap.uiSettings.isQuickZoomGesturesEnabled = true
+    }
+
+    // Tap the up arrow on the keyboard directional pad
+    onView(withId(R.id.mapView)).perform(ViewActions.pressKey(
+      EspressoKey.Builder()
+        .withKeyCode(KeyEvent.KEYCODE_DPAD_UP)
+        .build()))
+
+    rule.runOnUiThread {
+      assertNotEquals(initialCameraPosition!!.target.latitude, mapboxMap.cameraPosition.target.latitude)
+      assertNotEquals(initialCameraPosition!!.target.longitude, mapboxMap.cameraPosition.target.longitude)
+    }
+  }
+
+  @Test
+  fun targetAdjustWithDown() {
+    validateTestSetup()
+    var initialCameraPosition: CameraPosition? = null
+    rule.runOnUiThread {
+      // zoom in so we can move vertically
+      mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(4.0))
+      initialCameraPosition = mapboxMap.cameraPosition
+      mapboxMap.uiSettings.isQuickZoomGesturesEnabled = true
+    }
+
+    // Tap the down arrow on the keyboard directional pad
+    onView(withId(R.id.mapView)).perform(ViewActions.pressKey(
+      EspressoKey.Builder()
+        .withKeyCode(KeyEvent.KEYCODE_DPAD_DOWN)
+        .build()))
+
+    rule.runOnUiThread {
+      assertNotEquals(initialCameraPosition!!.target.latitude, mapboxMap.cameraPosition.target.latitude)
+      assertNotEquals(initialCameraPosition!!.target.longitude, mapboxMap.cameraPosition.target.longitude)
+    }
+  }
+}


### PR DESCRIPTION
This pr resolves #10131 by bringing more keyboard to the Maps SDK for Android. It is a follow up to https://github.com/mapbox/mapbox-gl-native/pull/14789.

Regarding @LukasPaczos' comment at https://github.com/mapbox/mapbox-gl-native/pull/14789#pullrequestreview-244793783: All the code is now in the `MapKeyListener`'s  `onKeyDown`/`onKeyLongPress` methods.

Regarding @tobrun's comment at https://github.com/mapbox/mapbox-gl-native/pull/14789#issuecomment-498666119: `MapGestureDetector` no longer has any key listening code. All the code is contained in `MapKeyListener`, which I think is appropriate. 

So far, this pr adds support for:

- directional navigation (`NextFocusRight()`, `NextFocusDown()`, etc.): https://developer.android.com/training/keyboard-input/navigation.html 

- adjusting the map camera via various keyboard key combinations:
  - pitch
  - zoom
  - bearing

The recommended way to try out this pr's work is to open the Maps SDK's test app on an emulator. Make sure the emulator supports keyboard input. Chances are good that the emulated device does. Open any test app example that loads a map.

- directional navigation to adjust the `focus`
  - Tap the `Tab` key on your keyboard to see the app's focus cycle between the `MapView`, the `CompassView` (if it's visible), and the attribution `i`. Pressing the `Enter` key when the focus is on a particular view ID, is the equivalent of tapping on the view with your finger. 

- adjusting map pitch via `shift` key and `+`/`-` buttons
  - Hold down `shift` on your keyboard and then tap the up or down arrow. You can also hold either arrow. The up/down arrows should adjust the map camera's pitch. The up arrow will tilt the map plane "down", which matches the behavior in Mapbox Studio.

- adjusting map bearing via `shift` key and directional left/right arrows
  - Hold down `shift` key and then tap the left or right arrows. You can also hold either arrow. `shift` + `left` will move the camera bearing so that the map camera appears to move in a clockwise direction around the focal point. `shift` + `left` will move the camera bearing so that the map camera appears to move in a counter-clockwise direction around the focal point.
 
- adjusting map zoom via `+`/`-` buttons
  - `-` will move the camera farther away from the map by decreasing the zoom value. `+` will move the map camera closer to the map by increasing  the zoom value.
  
The map movement in the GIFs below is all based on keyboard keys.   

![ezgif com-resize](https://user-images.githubusercontent.com/4394910/65471839-9961f200-de25-11e9-83ac-885631aa6b91.gif)
![ezgif com-resize (1)](https://user-images.githubusercontent.com/4394910/65471841-99fa8880-de25-11e9-93f7-7356edabc944.gif)

Debug toggling and switching to `Style.MAPBOX_STREETS` via keyboard

![ezgif com-resize (2)](https://user-images.githubusercontent.com/4394910/65928333-646c1700-e3b2-11e9-9173-b2b482620a82.gif)
