### PR TITLE
[core] fix opacity interpolation for composition expressions

### DIFF
--- a/platform/node/test/ignores.json
+++ b/platform/node/test/ignores.json
@@ -71,6 +71,7 @@
   "render-tests/circle-sort-key/literal": "https://github.com/mapbox/mapbox-gl-native/issues/15008",
   "render-tests/fill-sort-key/literal": "https://github.com/mapbox/mapbox-gl-native/issues/15008",
   "render-tests/line-sort-key/literal": "https://github.com/mapbox/mapbox-gl-native/issues/15008",
+  "render-tests/regressions/mapbox-gl-js#8817": "skip - https://github.com/mapbox/mapbox-gl-native/issues/15737",
   "query-tests/fill-extrusion/base-in": "https://github.com/mapbox/mapbox-gl-native/issues/13139",
   "query-tests/fill-extrusion/box-in": "https://github.com/mapbox/mapbox-gl-native/issues/13139",
   "query-tests/fill-extrusion/side-in": "https://github.com/mapbox/mapbox-gl-native/issues/13139",

--- a/src/mbgl/renderer/paint_property_binder.hpp
+++ b/src/mbgl/renderer/paint_property_binder.hpp
@@ -370,11 +370,10 @@ public:
     }
 
     std::tuple<float> interpolationFactor(float currentZoom) const override {
-        const float possiblyRoundedZoom = expression.useIntegerZoom ?
-            std::floor(currentZoom) :
-            currentZoom;
+        const float possiblyRoundedZoom = expression.useIntegerZoom ? std::floor(currentZoom) : currentZoom;
 
-        return std::tuple<float> { std::fmax(0.0, std::fmin(1.0, expression.interpolationFactor(zoomRange, possiblyRoundedZoom))) };
+        return std::tuple<float> {
+            std::fmax(0.0, std::fmin(1.0, expression.interpolationFactor(zoomRange, possiblyRoundedZoom)))};
     }
 
     std::tuple<T> uniformValue(const PossiblyEvaluatedPropertyValue<T>& currentValue) const override {

--- a/src/mbgl/renderer/paint_property_binder.hpp
+++ b/src/mbgl/renderer/paint_property_binder.hpp
@@ -370,11 +370,11 @@ public:
     }
 
     std::tuple<float> interpolationFactor(float currentZoom) const override {
-        if (expression.useIntegerZoom) {
-            return std::tuple<float> { expression.interpolationFactor(zoomRange, std::floor(currentZoom)) };
-        } else {
-            return std::tuple<float> { expression.interpolationFactor(zoomRange, currentZoom) };
-        }
+        const float possiblyRoundedZoom = expression.useIntegerZoom ?
+            std::floor(currentZoom) :
+            currentZoom;
+
+        return std::tuple<float> { std::fmax(0.0, std::fmin(1.0, expression.interpolationFactor(zoomRange, possiblyRoundedZoom))) };
     }
 
     std::tuple<T> uniformValue(const PossiblyEvaluatedPropertyValue<T>& currentValue) const override {

--- a/src/mbgl/renderer/paint_property_binder.hpp
+++ b/src/mbgl/renderer/paint_property_binder.hpp
@@ -372,8 +372,8 @@ public:
     std::tuple<float> interpolationFactor(float currentZoom) const override {
         const float possiblyRoundedZoom = expression.useIntegerZoom ? std::floor(currentZoom) : currentZoom;
 
-        return std::tuple<float> {
-            std::fmax(0.0, std::fmin(1.0, expression.interpolationFactor(zoomRange, possiblyRoundedZoom)))};
+        return std::tuple<float>{
+            ::fmax(0.0, ::fmin(1.0, expression.interpolationFactor(zoomRange, possiblyRoundedZoom)))};
     }
 
     std::tuple<T> uniformValue(const PossiblyEvaluatedPropertyValue<T>& currentValue) const override {


### PR DESCRIPTION
port https://github.com/mapbox/mapbox-gl-js/pull/8818

Previously the interpolation factor could be out of the range 0 to 1 which could result in rendering errors. 

I've skipped the render test because -native doesn't have a way to stop sources from loading new tiles. I started trying to add this but bailed because it doesn't seem like it's worth the effort. I opened https://github.com/mapbox/mapbox-gl-native/issues/15737 to document this.