### PR TITLE
Remove projected meters per pixel and pixel ratio relation

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -620,7 +620,7 @@ final class NativeMapView implements NativeMap {
     if (checkState("getMetersPerPixelAtLatitude")) {
       return 0;
     }
-    return nativeGetMetersPerPixelAtLatitude(lat, getZoom()) / pixelRatio;
+    return nativeGetMetersPerPixelAtLatitude(lat, getZoom());
   }
 
   @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/NativeMapViewTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/NativeMapViewTest.kt
@@ -254,7 +254,7 @@ class NativeMapViewTest : AppCenter() {
     @Test
     @UiThreadTest
     fun testGetProjectedMetersAtLatitude() {
-        val expected = 38986.83510557766
+        val expected = 77973.67021115532
         val actual = nativeMapView.getMetersPerPixelAtLatitude(5.0)
         assertEquals("Get projected meters should match", expected, actual)
     }


### PR DESCRIPTION
The projected meters per pixel calculation is not dependent on the pixel ratio but rather the tile size, therefore, the division when fetching the value is not necessary.