### PR TITLE
[android] Check if Mapbox instance exists before creating default file source

### DIFF
--- a/platform/android/src/file_source.cpp
+++ b/platform/android/src/file_source.cpp
@@ -17,9 +17,14 @@ namespace mbgl {
 
 std::shared_ptr<FileSource> FileSource::createPlatformFileSource(const ResourceOptions& options) {
     auto env{android::AttachEnv()};
-    auto assetManager = android::Mapbox::getAssetManager(*env);
-    auto fileSource = std::make_shared<DefaultFileSource>(options.cachePath(),
-                                                          std::make_unique<AssetManagerFileSource>(*env, assetManager));
+    std::shared_ptr<DefaultFileSource> fileSource;
+    if (android::Mapbox::hasInstance(*env)) {
+        auto assetManager = android::Mapbox::getAssetManager(*env);
+        fileSource = std::make_shared<DefaultFileSource>(options.cachePath(),
+                                                         std::make_unique<AssetManagerFileSource>(*env, assetManager));
+    } else {
+        fileSource = std::make_shared<DefaultFileSource>(options.cachePath(), options.assetPath());
+    }
     fileSource->setAccessToken(options.accessToken());
     return fileSource;
 }

--- a/platform/android/src/mapbox.cpp
+++ b/platform/android/src/mapbox.cpp
@@ -9,6 +9,12 @@ jni::Local<jni::Object<AssetManager>> Mapbox::getAssetManager(jni::JNIEnv& env) 
     return javaClass.Call(env, method);
 }
 
+jboolean Mapbox::hasInstance(jni::JNIEnv& env) {
+    static auto& javaClass = jni::Class<Mapbox>::Singleton(env);
+    auto method = javaClass.GetStaticMethod<jboolean()>(env, "hasInstance");
+    return javaClass.Call(env, method);
+}
+
 void Mapbox::registerNative(jni::JNIEnv& env) {
     jni::Class<Mapbox>::Singleton(env);
 }

--- a/platform/android/src/mapbox.hpp
+++ b/platform/android/src/mapbox.hpp
@@ -10,6 +10,7 @@ namespace android {
 class Mapbox {
 public:
     static constexpr auto Name() { return "com/mapbox/mapboxsdk/Mapbox"; };
+    static jboolean hasInstance(jni::JNIEnv&);
     static jni::Local<jni::Object<AssetManager>> getAssetManager(jni::JNIEnv&);
     static void registerNative(jni::JNIEnv&);
 };


### PR DESCRIPTION
This check is needed for mbgl-benchmark target, as it does not require Mapbox
instance, nor Android asset manager.

/cc @zmiao 