### PR TITLE
[core,android,darwin,qt] Add fields related to feature-state

### DIFF
--- a/include/mbgl/util/feature.hpp
+++ b/include/mbgl/util/feature.hpp
@@ -11,10 +11,24 @@ using Value = mapbox::base::Value;
 using NullValue = mapbox::base::NullValue;
 using PropertyMap = mapbox::base::ValueObject;
 using FeatureIdentifier = mapbox::feature::identifier;
-using Feature = mapbox::feature::feature<double>;
+using GeoJSONFeature = mapbox::feature::feature<double>;
 using FeatureState = mapbox::base::ValueObject;
 using FeatureStates = std::unordered_map<std::string, FeatureState>;       // <featureID, FeatureState>
 using LayerFeatureStates = std::unordered_map<std::string, FeatureStates>; // <sourceLayer, FeatureStates>
+
+class Feature : public GeoJSONFeature {
+public:
+    std::string source;
+    std::string sourceLayer;
+    PropertyMap state;
+
+    using GeometryType = mapbox::geometry::geometry<double>;
+
+    Feature() = default;
+    Feature(const GeoJSONFeature& f) : GeoJSONFeature(f) {}
+    Feature(const GeometryType& geom_) : GeoJSONFeature(geom_) {}
+    Feature(GeometryType&& geom_) : GeoJSONFeature(std::move(geom_)) {}
+};
 
 template <class T>
 optional<T> numericValue(const Value& value) {

--- a/platform/android/src/geojson/feature.cpp
+++ b/platform/android/src/geojson/feature.cpp
@@ -10,7 +10,7 @@ namespace geojson {
 
 using namespace gson;
 
-mbgl::Feature Feature::convert(jni::JNIEnv& env, const jni::Object<Feature>& jFeature) {
+mbgl::GeoJSONFeature Feature::convert(jni::JNIEnv& env, const jni::Object<Feature>& jFeature) {
     static auto& javaClass = jni::Class<Feature>::Singleton(env);
     static auto id = javaClass.GetMethod<jni::String ()>(env, "id");
     static auto geometry = javaClass.GetMethod<jni::Object<Geometry> ()>(env, "geometry");
@@ -20,11 +20,9 @@ mbgl::Feature Feature::convert(jni::JNIEnv& env, const jni::Object<Feature>& jFe
 
     using mbid = mapbox::feature::identifier;
 
-    return mbgl::Feature {
-        Geometry::convert(env, jFeature.Call(env, geometry)),
-        JsonObject::convert(env, jFeature.Call(env, properties)),
-        jId ? mbid { jni::Make<std::string>(env, jId) } : mbid { mapbox::feature::null_value }
-    };
+    return mbgl::GeoJSONFeature{Geometry::convert(env, jFeature.Call(env, geometry)),
+                                JsonObject::convert(env, jFeature.Call(env, properties)),
+                                jId ? mbid{jni::Make<std::string>(env, jId)} : mbid{mapbox::feature::null_value}};
 }
 
 /**
@@ -50,7 +48,7 @@ public:
     }
 };
 
-jni::Local<jni::Object<Feature>> convertFeature(jni::JNIEnv& env, const mbgl::Feature& value) {
+jni::Local<jni::Object<Feature>> convertFeature(jni::JNIEnv& env, const mbgl::GeoJSONFeature& value) {
     static auto& javaClass = jni::Class<Feature>::Singleton(env);
     static auto method = javaClass.GetStaticMethod<jni::Object<Feature> (jni::Object<Geometry>, jni::Object<JsonObject>, jni::String)>(env, "fromGeometry");
 
@@ -63,7 +61,18 @@ jni::Local<jni::Object<Feature>> convertFeature(jni::JNIEnv& env, const mbgl::Fe
 jni::Local<jni::Array<jni::Object<Feature>>> Feature::convert(jni::JNIEnv& env, const std::vector<mbgl::Feature>& value) {
     auto features = jni::Array<jni::Object<Feature>>::New(env, value.size());
 
-    for (size_t i = 0; i < value.size(); i = i + 1) {
+    for (size_t i = 0; i < value.size(); ++i) {
+        features.Set(env, i, convertFeature(env, static_cast<mbgl::GeoJSONFeature>(value.at(i))));
+    }
+
+    return features;
+}
+
+jni::Local<jni::Array<jni::Object<Feature>>> Feature::convert(jni::JNIEnv& env,
+                                                              const std::vector<mbgl::GeoJSONFeature>& value) {
+    auto features = jni::Array<jni::Object<Feature>>::New(env, value.size());
+
+    for (size_t i = 0; i < value.size(); ++i) {
         features.Set(env, i, convertFeature(env, value.at(i)));
     }
 

--- a/platform/android/src/geojson/feature.hpp
+++ b/platform/android/src/geojson/feature.hpp
@@ -12,8 +12,9 @@ class Feature {
 public:
     static constexpr auto Name() { return "com/mapbox/geojson/Feature"; };
 
-    static mbgl::Feature convert(jni::JNIEnv&, const jni::Object<Feature>&);
+    static mbgl::GeoJSONFeature convert(jni::JNIEnv&, const jni::Object<Feature>&);
     static jni::Local<jni::Array<jni::Object<Feature>>> convert(jni::JNIEnv&, const std::vector<mbgl::Feature>&);
+    static jni::Local<jni::Array<jni::Object<Feature>>> convert(jni::JNIEnv&, const std::vector<mbgl::GeoJSONFeature>&);
 
     static void registerNative(jni::JNIEnv&);
 };

--- a/platform/darwin/src/MGLComputedShapeSource.mm
+++ b/platform/darwin/src/MGLComputedShapeSource.mm
@@ -140,7 +140,7 @@ mbgl::style::CustomGeometrySource::Options MBGLCustomGeometrySourceOptionsFromDi
                           @"This will be logged only once.");
                 });
             }
-            mbgl::Feature geoJsonObject = [feature geoJSONObject].get<mbgl::Feature>();
+            mbgl::GeoJSONFeature geoJsonObject = [feature geoJSONObject].get<mbgl::GeoJSONFeature>();
             featureCollection.push_back(geoJsonObject);
         }
         const auto geojson = mbgl::GeoJSON{featureCollection};
@@ -204,7 +204,7 @@ mbgl::style::CustomGeometrySource::Options MBGLCustomGeometrySourceOptionsFromDi
     mbgl::FeatureCollection featureCollection;
     featureCollection.reserve(features.count);
     for (MGLShape <MGLFeature> * feature in features) {
-        mbgl::Feature geoJsonObject = [feature geoJSONObject].get<mbgl::Feature>();
+        mbgl::GeoJSONFeature geoJsonObject = [feature geoJSONObject].get<mbgl::GeoJSONFeature>();
         featureCollection.push_back(geoJsonObject);
         if ([feature isMemberOfClass:[MGLShapeCollection class]]) {
             static dispatch_once_t onceToken;

--- a/platform/darwin/src/MGLFeature.mm
+++ b/platform/darwin/src/MGLFeature.mm
@@ -336,8 +336,8 @@ MGL_DEFINE_FEATURE_ATTRIBUTES_GETTER();
     featureCollection.reserve(self.shapes.count);
     for (MGLShape <MGLFeature> *feature in self.shapes) {
         auto geoJSONObject = feature.geoJSONObject;
-        MGLAssert(geoJSONObject.is<mbgl::Feature>(), @"Feature collection must only contain features.");
-        featureCollection.push_back(geoJSONObject.get<mbgl::Feature>());
+        MGLAssert(geoJSONObject.is<mbgl::GeoJSONFeature>(), @"Feature collection must only contain features.");
+        featureCollection.push_back(geoJSONObject.get<mbgl::GeoJSONFeature>());
     }
     return featureCollection;
 }
@@ -470,7 +470,7 @@ public:
         return shape;
     }
 
-    MGLShape <MGLFeature> * operator()(const mbgl::Feature &feature) const {
+    MGLShape <MGLFeature> * operator()(const mbgl::GeoJSONFeature &feature) const {
         MGLShape <MGLFeature> *shape = (MGLShape <MGLFeature> *)MGLFeatureFromMBGLFeature(feature);
         return shape;
     }
@@ -487,12 +487,20 @@ public:
 NSArray<MGLShape <MGLFeature> *> *MGLFeaturesFromMBGLFeatures(const std::vector<mbgl::Feature> &features) {
     NSMutableArray *shapes = [NSMutableArray arrayWithCapacity:features.size()];
     for (const auto &feature : features) {
+        [shapes addObject:MGLFeatureFromMBGLFeature(static_cast<mbgl::GeoJSONFeature>(feature))];
+    }
+    return shapes;
+}
+
+NSArray<MGLShape <MGLFeature> *> *MGLFeaturesFromMBGLFeatures(const std::vector<mbgl::GeoJSONFeature> &features) {
+    NSMutableArray *shapes = [NSMutableArray arrayWithCapacity:features.size()];
+    for (const auto &feature : features) {
         [shapes addObject:MGLFeatureFromMBGLFeature(feature)];
     }
     return shapes;
 }
 
-id <MGLFeature> MGLFeatureFromMBGLFeature(const mbgl::Feature &feature) {
+id <MGLFeature> MGLFeatureFromMBGLFeature(const mbgl::GeoJSONFeature &feature) {
     NSMutableDictionary *attributes = [NSMutableDictionary dictionaryWithCapacity:feature.properties.size()];
     for (auto &pair : feature.properties) {
         auto &value = pair.second;
@@ -515,7 +523,7 @@ MGLShape* MGLShapeFromGeoJSON(const mapbox::geojson::geojson &geojson) {
     return shape;
 }
 
-mbgl::Feature mbglFeature(mbgl::Feature feature, id identifier, NSDictionary *attributes)
+mbgl::GeoJSONFeature mbglFeature(mbgl::GeoJSONFeature feature, id identifier, NSDictionary *attributes)
 {
     if (identifier) {
         NSExpression *identifierExpression = [NSExpression expressionForConstantValue:identifier];

--- a/platform/darwin/src/MGLFeature_Private.h
+++ b/platform/darwin/src/MGLFeature_Private.h
@@ -16,10 +16,17 @@ MGL_EXPORT
 NSArray<MGLShape <MGLFeature> *> *MGLFeaturesFromMBGLFeatures(const std::vector<mbgl::Feature> &features);
 
 /**
- Returns an `MGLFeature` object converted from the given mbgl::Feature
+ Returns an array of `MGLFeature` objects converted from the given vector of
+ vector tile features.
  */
 MGL_EXPORT
-id <MGLFeature> MGLFeatureFromMBGLFeature(const mbgl::Feature &feature);
+NSArray<MGLShape <MGLFeature> *> *MGLFeaturesFromMBGLFeatures(const std::vector<mbgl::GeoJSONFeature> &features);
+
+/**
+ Returns an `MGLFeature` object converted from the given mbgl::GeoJSONFeature
+ */
+MGL_EXPORT
+id <MGLFeature> MGLFeatureFromMBGLFeature(const mbgl::GeoJSONFeature &feature);
 
 /**
  Returns an `MGLShape` representing the given geojson. The shape can be
@@ -28,11 +35,11 @@ id <MGLFeature> MGLFeatureFromMBGLFeature(const mbgl::Feature &feature);
 MGLShape* MGLShapeFromGeoJSON(const mapbox::geojson::geojson &geojson);
 
 /**
- Takes an `mbgl::Feature` object, an identifer, and attributes dictionary and
+ Takes an `mbgl::GeoJSONFeature` object, an identifer, and attributes dictionary and
  returns the feature object with converted `mbgl::FeatureIdentifier` and
  `mbgl::PropertyMap` properties.
  */
-mbgl::Feature mbglFeature(mbgl::Feature feature, id identifier, NSDictionary * attributes);
+mbgl::GeoJSONFeature mbglFeature(mbgl::GeoJSONFeature feature, id identifier, NSDictionary * attributes);
 
 /**
  Returns an `NSDictionary` representation of an `MGLFeature`.

--- a/platform/darwin/src/MGLShapeSource.mm
+++ b/platform/darwin/src/MGLShapeSource.mm
@@ -262,12 +262,12 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
 
     auto geoJSON = [cluster geoJSONObject];
     
-    if (!geoJSON.is<mbgl::Feature>()) {
+    if (!geoJSON.is<mbgl::GeoJSONFeature>()) {
         MGLAssert(0, @"cluster geoJSON object is not a feature.");
         return extensionValue;
     }
     
-    auto clusterFeature = geoJSON.get<mbgl::Feature>();
+    auto clusterFeature = geoJSON.get<mbgl::GeoJSONFeature>();
     
     extensionValue = self.mapView.renderer->queryFeatureExtensions(self.rawSource->getID(),
                                                                    clusterFeature,
@@ -293,7 +293,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
         return @[];
     }
     
-    std::vector<mbgl::Feature> leaves = featureExtension->get<mbgl::FeatureCollection>();
+    std::vector<mbgl::GeoJSONFeature> leaves = featureExtension->get<mbgl::FeatureCollection>();
     return MGLFeaturesFromMBGLFeatures(leaves);
 }
 
@@ -308,7 +308,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
         return @[];
     }
     
-    std::vector<mbgl::Feature> leaves = featureExtension->get<mbgl::FeatureCollection>();
+    std::vector<mbgl::GeoJSONFeature> leaves = featureExtension->get<mbgl::FeatureCollection>();
     return MGLFeaturesFromMBGLFeatures(leaves);
 }
 

--- a/platform/qt/src/qt_geojson.cpp
+++ b/platform/qt/src/qt_geojson.cpp
@@ -121,7 +121,7 @@ mbgl::FeatureIdentifier asMapboxGLFeatureIdentifier(const QVariant &id) {
     }
 }
 
-mbgl::Feature asMapboxGLFeature(const QMapbox::Feature &feature) {
+mbgl::GeoJSONFeature asMapboxGLFeature(const QMapbox::Feature &feature) {
     mbgl::PropertyMap properties;
     properties.reserve(feature.properties.size());
     for (auto it = feature.properties.constBegin(); it != feature.properties.constEnd(); ++it) {

--- a/platform/qt/src/qt_geojson.hpp
+++ b/platform/qt/src/qt_geojson.hpp
@@ -22,6 +22,6 @@ mbgl::Polygon<double> asMapboxGLPolygon(const QMapbox::CoordinatesCollection &po
 mbgl::MultiPolygon<double> asMapboxGLMultiPolygon(const QMapbox::CoordinatesCollections &multiPolygon);
 mbgl::Value asMapboxGLPropertyValue(const QVariant &value);
 mbgl::FeatureIdentifier asMapboxGLFeatureIdentifier(const QVariant &id);
-mbgl::Feature asMapboxGLFeature(const QMapbox::Feature &feature);
+mbgl::GeoJSONFeature asMapboxGLFeature(const QMapbox::Feature &feature);
 
 } // namespace QMapbox


### PR DESCRIPTION
Move the fields from geometry.hpp/feature.hpp to GL Native as they are not part of the GeoJSON specification.

The related feature.hpp PR is here: https://github.com/mapbox/geometry.hpp/pull/67