### PR TITLE
Keep Mapbox.java when obfuscating code 

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
@@ -3,6 +3,7 @@ package com.mapbox.mapboxsdk;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.AssetManager;
+import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
@@ -25,6 +26,7 @@ import com.mapbox.mapboxsdk.utils.ThreadUtils;
  */
 @UiThread
 @SuppressLint("StaticFieldLeak")
+@Keep
 public final class Mapbox {
 
   private static final String TAG = "Mbgl-Mapbox";


### PR DESCRIPTION
This is needed to allow looking up this file from JNI code.
Refs https://github.com/mapbox/mapbox-gl-native/pull/15712/files