### PR TITLE
[ios, macos] Changed exception to assert and nil return

### DIFF
--- a/platform/darwin/src/MGLImageSource.mm
+++ b/platform/darwin/src/MGLImageSource.mm
@@ -1,6 +1,7 @@
 #import "MGLImageSource.h"
 
 #import "MGLGeometry_Private.h"
+#import "MGLLoggingConfiguration_Private.h"
 #import "MGLSource_Private.h"
 #import "MGLTileSource_Private.h"
 #import "NSURL+MGLAdditions.h"
@@ -99,7 +100,11 @@
 }
 
 - (NSString *)attributionHTMLString {
-    MGLAssertStyleSourceIsValid();
+    if (!self.rawSource) {
+        MGLAssert(0, @"Source with identifier `%@` was invalidated after a style change", self.identifier);
+        return nil;
+    }
+
     auto attribution = self.rawSource->getAttribution();
     return attribution ? @(attribution->c_str()) : nil;
 }

--- a/platform/darwin/src/MGLRasterTileSource.mm
+++ b/platform/darwin/src/MGLRasterTileSource.mm
@@ -1,5 +1,6 @@
 #import "MGLRasterTileSource_Private.h"
 
+#import "MGLLoggingConfiguration_Private.h"
 #import "MGLMapView_Private.h"
 #import "MGLSource_Private.h"
 #import "MGLTileSource_Private.h"
@@ -72,7 +73,11 @@ static const CGFloat MGLRasterTileSourceRetinaTileSize = 512;
 }
 
 - (NSString *)attributionHTMLString {
-    MGLAssertStyleSourceIsValid();
+    if (!self.rawSource) {
+        MGLAssert(0, @"Source with identifier `%@` was invalidated after a style change", self.identifier);
+        return nil;
+    }
+
     auto attribution = self.rawSource->getAttribution();
     return attribution ? @(attribution->c_str()) : nil;
 }

--- a/platform/darwin/src/MGLVectorTileSource.mm
+++ b/platform/darwin/src/MGLVectorTileSource.mm
@@ -1,6 +1,7 @@
 #import "MGLVectorTileSource_Private.h"
 
 #import "MGLFeature_Private.h"
+#import "MGLLoggingConfiguration_Private.h"
 #import "MGLSource_Private.h"
 #import "MGLTileSource_Private.h"
 #import "MGLStyle_Private.h"
@@ -44,7 +45,11 @@
 }
 
 - (NSString *)attributionHTMLString {
-    MGLAssertStyleSourceIsValid();
+    if (!self.rawSource) {
+        MGLAssert(0, @"Source with identifier `%@` was invalidated after a style change", self.identifier);
+        return nil;
+    }
+
     auto attribution = self.rawSource->getAttribution();
     return attribution ? @(attribution->c_str()) : nil;
 }


### PR DESCRIPTION
Investigated, fixes https://github.com/mapbox/mapbox-gl-native/issues/15732

Since attribution methods can be called via user interaction (without a mechanism to try/catch), this cases were switched to asserts.

I did not change the Assert name at this time (mostly because I struggled to find a good name! - perhaps `Prohibit`?)