### PR TITLE
[ios] Fix for iOS 9 crash (seen in simulator)

### DIFF
--- a/platform/darwin/src/MGLSDKMetricsManager.m
+++ b/platform/darwin/src/MGLSDKMetricsManager.m
@@ -18,6 +18,21 @@ NSString* MGLStringFromMetricType(MGLMetricType metricType) {
     return eventName;
 }
 
+// Taken verbatim from NXFreeArchInfo header documentation
+static void MGLFreeArchInfo(const NXArchInfo *x)
+{
+    const NXArchInfo *p;
+
+    p = NXGetAllArchInfos();
+    while(p->name != NULL){
+        if(x == p)
+            return;
+        p++;
+    }
+    free((char *)x->description);
+    free((NXArchInfo *)x);
+}
+
 @interface MGLMetricsManager() <MGLNetworkConfigurationMetricsDelegate>
 
 @property (strong, nonatomic) NSDictionary *metadata;
@@ -54,7 +69,16 @@ NSString* MGLStringFromMetricType(MGLMetricType metricType) {
         
             if (localArchInfo) {
                 abi = @(localArchInfo->description);
-                NXFreeArchInfo(localArchInfo);
+
+                NSProcessInfo *processInfo = [NSProcessInfo processInfo];
+
+                // Although NXFreeArchInfo appears to be weakly linked, it does
+                // not have the weak_import attribute, so check the OS version.
+                if (&NXFreeArchInfo && [processInfo isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){10, 0, 0}]) {
+                    NXFreeArchInfo(localArchInfo);
+                } else {
+                    MGLFreeArchInfo(localArchInfo);
+                }
             }
         }
         

--- a/platform/darwin/src/MGLSDKMetricsManager.m
+++ b/platform/darwin/src/MGLSDKMetricsManager.m
@@ -19,6 +19,7 @@ NSString* MGLStringFromMetricType(MGLMetricType metricType) {
 }
 
 // Taken verbatim from NXFreeArchInfo header documentation
+#if TARGET_OS_IOS
 static void MGLFreeArchInfo(const NXArchInfo *x)
 {
     const NXArchInfo *p;
@@ -32,6 +33,7 @@ static void MGLFreeArchInfo(const NXArchInfo *x)
     free((char *)x->description);
     free((NXArchInfo *)x);
 }
+#endif
 
 @interface MGLMetricsManager() <MGLNetworkConfigurationMetricsDelegate>
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -18,6 +18,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed an issue that cause `-[MGLMapView setCamere:withDuration:animationTimingFunction:edgePadding:completionHandler:]` persist the value of `edgePadding`. ([#15584](https://github.com/mapbox/mapbox-gl-native/pull/15584))
 * Added `MGLMapView.automaticallyAdjustsContentInset` property that indicates if wether the map view should automatically adjust its content insets. ([#15584](https://github.com/mapbox/mapbox-gl-native/pull/15584))
 * Fixed an issue that caused `MGLScaleBar` to have an incorrect size when resizing or rotating. ([#15703](https://github.com/mapbox/mapbox-gl-native/pull/15703))
+* Fixed crash at launch seen on iOS 9 simulator. ([#15771](https://github.com/mapbox/mapbox-gl-native/pull/15771))
 
 ## 5.4.0 - September 25, 2019
 


### PR DESCRIPTION
Fix for a crash seen on iOS 9 on simulator. Bug introduced (ironically) in https://github.com/mapbox/mapbox-gl-native/pull/15645