### PR TITLE
[core] Coalesce requests for the same missing image

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -591,7 +591,7 @@ commands:
     - run:
         name: Run render tests (mbgl-render-test)
         command: |
-          build/mbgl-render-test render-tests render-tests --recycle-map --shuffle
+          build/mbgl-render-test render-tests --recycle-map --shuffle
         no_output_timeout: 2m
 
   run-macos-query-tests:

--- a/include/mbgl/actor/scheduler.hpp
+++ b/include/mbgl/actor/scheduler.hpp
@@ -40,6 +40,16 @@ public:
     // Makes a weak pointer to this Scheduler.
     virtual mapbox::base::WeakPtr<Scheduler> makeWeakPtr() = 0;
 
+    // Returns a closure wrapping the given one.
+    //
+    // When the returned closure is invoked for the first time, it schedules
+    // the given closure to this scheduler, the consequent calls of the
+    // returned closure are ignored.
+    //
+    // If this scheduler is already deleted by the time the returnded closure is
+    // first invoked, the call is ignored.
+    std::function<void()> bindOnce(std::function<void()>);
+
     // Set/Get the current Scheduler for this thread
     static Scheduler* GetCurrent();
     static void SetCurrent(Scheduler*);

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -13,6 +13,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
  - Suppress network requests for expired tiles update, if these tiles are invisible. [#15741](https://github.com/mapbox/mapbox-gl-native/pull/15741)
  - Fixed opacity interpolation for composition expressions [#15738](https://github.com/mapbox/mapbox-gl-native/pull/15738)
  - Fixed an issue where `Projection#getMetersPerPixelAtLatitude` returned a value incorrectly divided by the pixel ratio. This also fixes an issue where `LocationComponent` accuracy circle's radius was artificially increased. [#15742](https://github.com/mapbox/mapbox-gl-native/pull/15742)
+ - Coalesce requests to the client for the same missing image [#15778](https://github.com/mapbox/mapbox-gl-native/pull/15778)
 
 ## 8.4.0 - September 25, 2019
 [Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.4.0-beta.1...android-v8.4.0) since [Mapbox Maps SDK for Android v8.4.0-beta.1](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.4.0-beta.1): 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## master
+
+### Other changes
+
+* Coalesce requests to the client for the same missing image ([#15778](https://github.com/mapbox/mapbox-gl-native/pull/15778))
+
 ## 5.5.0
 
 ### Performance improvements
 
- * Improved rendering performance for the styles with multiple sources ([#15756](https://github.com/mapbox/mapbox-gl-native/pull/15756))
+* Improved rendering performance for the styles with multiple sources ([#15756](https://github.com/mapbox/mapbox-gl-native/pull/15756))
 
 ### Other changes
 

--- a/src/mbgl/renderer/image_manager.cpp
+++ b/src/mbgl/renderer/image_manager.cpp
@@ -204,6 +204,7 @@ void ImageManager::checkMissingAndNotify(ImageRequestor& requestor, const ImageR
             }
             requestedImages[missingImage].emplace(requestorPtr);
             requestor.addPendingRequest(missingImage);
+
             auto removePendingRequests = [this, missingImage] {
                 auto existingRequest = requestedImages.find(missingImage);
                 if (existingRequest == requestedImages.end()) {
@@ -214,11 +215,8 @@ void ImageManager::checkMissingAndNotify(ImageRequestor& requestor, const ImageR
                     req->removePendingRequest(missingImage);
                 }
             };
-
-            Scheduler& scheduler = *Scheduler::GetCurrent();
-            auto callback = [&scheduler, removePendingRequests]() { scheduler.schedule(removePendingRequests); };
-
-            observer->onStyleImageMissing(missingImage, std::move(callback));
+            observer->onStyleImageMissing(missingImage,
+                                          Scheduler::GetCurrent()->bindOnce(std::move(removePendingRequests)));
         }
     } else {
         // Associate requestor with an image that was provided by the client.

--- a/src/mbgl/renderer/image_manager.hpp
+++ b/src/mbgl/renderer/image_manager.hpp
@@ -58,13 +58,7 @@ private:
     bool loaded = false;
 
     std::map<ImageRequestor*, ImageRequestPair> requestors;
-    using Callback = std::function<void()>;
-    using ActorCallback = Actor<Callback>;
-    struct MissingImageRequestPair {
-        ImageRequestPair pair;
-        std::map<std::string, std::unique_ptr<ActorCallback>> callbacks;
-    };
-    std::map<ImageRequestor*, MissingImageRequestPair> missingImageRequestors;
+    std::map<ImageRequestor*, ImageRequestPair> missingImageRequestors;
     std::map<std::string, std::set<ImageRequestor*>> requestedImages;
     std::size_t requestedImagesCacheSize = 0ul;
     ImageMap images;
@@ -77,8 +71,18 @@ public:
     explicit ImageRequestor(ImageManager&);
     virtual ~ImageRequestor();
     virtual void onImagesAvailable(ImageMap icons, ImageMap patterns, ImageVersionMap versionMap, uint64_t imageCorrelationID) = 0;
+
+    void addPendingRequest(const std::string& imageId) { pendingRequests.insert(imageId); }
+
+    bool hasPendingRequests() const { return !pendingRequests.empty(); }
+
+    void removePendingRequest(const std::string& imageId) { pendingRequests.erase(imageId); }
+
 private:
     ImageManager& imageManager;
+
+    // Pending requests are image requests that are waiting to be dispatched to the client.
+    std::set<std::string> pendingRequests;
 };
 
 } // namespace mbgl

--- a/test/renderer/image_manager.test.cpp
+++ b/test/renderer/image_manager.test.cpp
@@ -187,6 +187,20 @@ TEST(ImageManager, OnStyleImageMissingBeforeSpriteLoaded) {
     EXPECT_EQ(observer.count, 1);
     ASSERT_TRUE(notified);
 
+    // Repeated request of the same image shall not result another
+    // `ImageManagerObserver.onStyleImageMissing()` call.
+    imageManager.getImages(requestor, std::make_pair(dependencies, imageCorrelationID));
+    runLoop.runOnce();
+
+    EXPECT_EQ(observer.count, 1);
+
+    // Request for updated dependencies must be dispatched to the
+    // observer.
+    dependencies.emplace("post", ImageType::Icon);
+    imageManager.getImages(requestor, std::make_pair(dependencies, imageCorrelationID));
+    runLoop.runOnce();
+
+    EXPECT_EQ(observer.count, 2);
 }
 
 TEST(ImageManager, OnStyleImageMissingAfterSpriteLoaded) {


### PR DESCRIPTION
This commit coalesces the repeated `onStyleImageMissing` calls
for the same image.

It also simplifies the image manager code.

Fixes https://github.com/mapbox/mapbox-gl-native/issues/15497