### PR TITLE
v5.x node release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-native",
-  "version": "4.3.0",
+  "version": "5.0.0",
   "description": "Renders map tiles with Mapbox GL",
   "keywords": [
     "mapbox",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,4 +1,6 @@
-# master
+
+# 5.0.0
+* No longer supporting source-compile fallback ([#15748](https://github.com/mapbox/mapbox-gl-native/pull/15748))
 * Add support for feature state APIs. ([#15480](https://github.com/mapbox/mapbox-gl-native/pull/15480))
 
 # 4.3.0


### PR DESCRIPTION
This PR is for the v5.0.0 node release.

I chose a new major version since https://github.com/mapbox/mapbox-gl-native/pull/15748 has the possibility of being a breaking change for any downstream developers that might be depending on the source-compile fallback that was removed in https://github.com/mapbox/mapbox-gl-native/pull/15748.

/cc @mapbox/static-apis @mapbox/gl-native 