### PR TITLE
[test runner] Fix finding of expected images paths

### DIFF
--- a/render-test/parser.cpp
+++ b/render-test/parser.cpp
@@ -291,9 +291,8 @@ std::string serializeMetrics(const TestMetrics& metrics) {
     return s.GetString();
 }
 
-std::vector<std::string> readExpectedEntries(const mbgl::filesystem::path& base) {
-    static const std::regex regex(".*expected.*.png|.*expected.*.json");
-
+namespace {
+std::vector<std::string> readExpectedEntries(const std::regex& regex, const mbgl::filesystem::path& base) {
     std::vector<std::string> expectedImages;
     for (const auto& entry : mbgl::filesystem::directory_iterator(base)) {
         if (entry.is_regular_file()) {
@@ -305,7 +304,17 @@ std::vector<std::string> readExpectedEntries(const mbgl::filesystem::path& base)
     }
     return expectedImages;
 }
+} // namespace
 
+std::vector<std::string> readExpectedImageEntries(const mbgl::filesystem::path& base) {
+    static const std::regex regex(".*expected.*.png");
+    return readExpectedEntries(regex, base);
+}
+
+std::vector<std::string> readExpectedJSONEntries(const mbgl::filesystem::path& base) {
+    static const std::regex regex(".*expected.*.json");
+    return readExpectedEntries(regex, base);
+}
 
 ArgumentsTuple parseArguments(int argc, char** argv) {
     args::ArgumentParser argumentParser("Mapbox GL Test Runner");

--- a/render-test/parser.hpp
+++ b/render-test/parser.hpp
@@ -18,7 +18,8 @@ JSONReply readJson(const mbgl::filesystem::path&);
 std::string serializeJsonValue(const mbgl::JSValue&);
 std::string serializeMetrics(const TestMetrics&);
 
-std::vector<std::string> readExpectedEntries(const mbgl::filesystem::path& base);
+std::vector<std::string> readExpectedImageEntries(const mbgl::filesystem::path& base);
+std::vector<std::string> readExpectedJSONEntries(const mbgl::filesystem::path& base);
 
 TestMetrics readExpectedMetrics(const mbgl::filesystem::path& path);
 

--- a/render-test/runner.cpp
+++ b/render-test/runner.cpp
@@ -122,7 +122,7 @@ bool TestRunner::checkQueryTestResults(mbgl::PremultipliedImage&& actualImage,
     mbgl::filesystem::path expectedMetricsPath;
     for (auto rit = expectations.rbegin(); rit != expectations.rend(); ++rit) {
         if (mbgl::filesystem::exists(*rit)) {
-            expectedJsonPaths = readExpectedEntries(*rit);
+            expectedJsonPaths = readExpectedJSONEntries(*rit);
             if (!expectedJsonPaths.empty()) break;
         }
     }
@@ -206,7 +206,7 @@ bool TestRunner::checkRenderTestResults(mbgl::PremultipliedImage&& actualImage, 
                 maybeExpectedMetricsPath.replace_filename("metrics.json");
                 metadata.expectedMetrics = readExpectedMetrics(maybeExpectedMetricsPath);
             }
-            expectedImagesPaths = readExpectedEntries(*rit);
+            expectedImagesPaths = readExpectedImageEntries(*rit);
             if (!expectedImagesPaths.empty()) break;
         }
     }


### PR DESCRIPTION
Before this change, the found paths to the expected images erroneously included the path to the `metrics.json` file (if this file was present) leading to raising of an unhandled exception.