### PR TITLE
[core] Introduce Scheduler::makeWeakPtr()

### DIFF
--- a/include/mbgl/actor/scheduler.hpp
+++ b/include/mbgl/actor/scheduler.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mapbox/weak.hpp>
+
 #include <functional>
 #include <memory>
 
@@ -35,6 +37,8 @@ public:
 
     // Enqueues a function for execution.
     virtual void schedule(std::function<void()>) = 0;
+    // Makes a weak pointer to this Scheduler.
+    virtual mapbox::base::WeakPtr<Scheduler> makeWeakPtr() = 0;
 
     // Set/Get the current Scheduler for this thread
     static Scheduler* GetCurrent();

--- a/include/mbgl/util/run_loop.hpp
+++ b/include/mbgl/util/run_loop.hpp
@@ -74,6 +74,7 @@ public:
     }
 
     void schedule(std::function<void()> fn) override { invoke(std::move(fn)); }
+    ::mapbox::base::WeakPtr<Scheduler> makeWeakPtr() override { return weakFactory.makeWeakPtr(); }
 
     class Impl;
 
@@ -121,6 +122,7 @@ private:
     std::mutex mutex;
 
     std::unique_ptr<Impl> impl;
+    ::mapbox::base::WeakPtrFactory<Scheduler> weakFactory{this};
 };
 
 } // namespace util

--- a/platform/android/src/map_renderer.hpp
+++ b/platform/android/src/map_renderer.hpp
@@ -68,6 +68,7 @@ public:
     // From Scheduler. Schedules by using callbacks to the
     // JVM to process the mailbox on the right thread.
     void schedule(std::function<void()> scheduled) override;
+    mapbox::base::WeakPtr<Scheduler> makeWeakPtr() override { return weakFactory.makeWeakPtr(); }
 
     void requestRender();
 
@@ -122,6 +123,7 @@ private:
     std::atomic<bool> destroyed {false};
 
     std::unique_ptr<SnapshotCallback> snapshotCallback;
+    mapbox::base::WeakPtrFactory<Scheduler> weakFactory{this};
 };
 
 } // namespace android

--- a/platform/qt/src/qmapboxgl_scheduler.hpp
+++ b/platform/qt/src/qmapboxgl_scheduler.hpp
@@ -19,6 +19,7 @@ public:
 
     // mbgl::Scheduler implementation.
     void schedule(std::function<void()> scheduled) final;
+    mapbox::base::WeakPtr<Scheduler> makeWeakPtr() override { return weakFactory.makeWeakPtr(); }
 
     void processEvents();
 
@@ -30,4 +31,5 @@ private:
 
     std::mutex m_taskQueueMutex;
     std::queue<std::function<void()>> m_taskQueue;
+    mapbox::base::WeakPtrFactory<Scheduler> weakFactory{this};
 };

--- a/src/mbgl/util/thread_pool.hpp
+++ b/src/mbgl/util/thread_pool.hpp
@@ -52,8 +52,11 @@ public:
         }
     }
 
+    mapbox::base::WeakPtr<Scheduler> makeWeakPtr() override { return weakFactory.makeWeakPtr(); }
+
 private:
     std::array<std::thread, N> threads;
+    mapbox::base::WeakPtrFactory<Scheduler> weakFactory{this};
     static_assert(N > 0, "Thread count must be more than zero.");
 };
 

--- a/test/actor/actor.test.cpp
+++ b/test/actor/actor.test.cpp
@@ -90,6 +90,7 @@ TEST(Actor, DestructionBlocksOnSend) {
         std::promise<void> promise;
         std::future<void> future;
         std::atomic<bool> waited;
+        mapbox::base::WeakPtrFactory<Scheduler> weakFactory{this};
 
         TestScheduler(std::promise<void> promise_, std::future<void> future_)
             : promise(std::move(promise_)),
@@ -107,6 +108,7 @@ TEST(Actor, DestructionBlocksOnSend) {
             std::this_thread::sleep_for(1ms);
             waited = true;
         }
+        mapbox::base::WeakPtr<Scheduler> makeWeakPtr() override { return weakFactory.makeWeakPtr(); }
     };
 
     struct Test {


### PR DESCRIPTION
This PR introduces `Scheduler::makeWeakPtr()` returning a weak pointer