### PR TITLE
Add translucent surface support for GlSurfaceView

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -3,7 +3,6 @@ package com.mapbox.mapboxsdk.maps;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.PointF;
-import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.support.annotation.CallSuper;
 import android.support.annotation.NonNull;
@@ -125,7 +124,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     }
 
     // hide surface until map is fully loaded #10990
-    setForeground(new ColorDrawable(options.getForegroundLoadColor()));
+    //setForeground(new ColorDrawable(options.getForegroundLoadColor()));
 
     mapboxMapOptions = options;
 
@@ -283,9 +282,12 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
 
   private void initialiseDrawingSurface(MapboxMapOptions options) {
     String localFontFamily = options.getLocalIdeographFontFamily();
+    boolean translucentSurface = options.getTranslucentSurface();
     if (options.getTextureMode()) {
       TextureView textureView = new TextureView(getContext());
-      boolean translucentSurface = options.getTranslucentTextureSurface();
+      if (!translucentSurface) {
+        translucentSurface = options.getTranslucentTextureSurface();
+      }
       mapRenderer = new TextureViewMapRenderer(getContext(),
         textureView, localFontFamily, translucentSurface) {
         @Override
@@ -299,7 +301,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     } else {
       MapboxGLSurfaceView glSurfaceView = new MapboxGLSurfaceView(getContext());
       glSurfaceView.setZOrderMediaOverlay(mapboxMapOptions.getRenderSurfaceOnTop());
-      mapRenderer = new GLSurfaceViewMapRenderer(getContext(), glSurfaceView, localFontFamily) {
+      mapRenderer = new GLSurfaceViewMapRenderer(getContext(), glSurfaceView, localFontFamily, translucentSurface) {
         @Override
         public void onSurfaceCreated(GL10 gl, EGLConfig config) {
           MapView.this.onSurfaceCreated();
@@ -1106,13 +1108,13 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
 
     @Override
     public void onDidFinishRenderingFrame(boolean fully) {
-      if (mapboxMap != null && mapboxMap.getStyle() != null && mapboxMap.getStyle().isFullyLoaded()) {
-        renderCount++;
-        if (renderCount == 3) {
-          MapView.this.setForeground(null);
-          removeOnDidFinishRenderingFrameListener(this);
-        }
-      }
+//      if (mapboxMap != null && mapboxMap.getStyle() != null && mapboxMap.getStyle().isFullyLoaded()) {
+//        renderCount++;
+//        if (renderCount == 3) {
+//          MapView.this.setForeground(null);
+//          removeOnDidFinishRenderingFrameListener(this);
+//        }
+//      }
     }
 
     private void onDestroy() {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
@@ -81,7 +81,10 @@ public class MapboxMapOptions implements Parcelable {
   private String apiBaseUri;
 
   private boolean textureMode;
+
+  @Deprecated
   private boolean translucentTextureSurface;
+  private boolean translucentSurface;
 
   @ColorInt
   private int foregroundLoadColor;
@@ -144,6 +147,7 @@ public class MapboxMapOptions implements Parcelable {
     pixelRatio = in.readFloat();
     foregroundLoadColor = in.readInt();
     crossSourceCollisions = in.readByte() != 0;
+    translucentSurface = in.readByte() != 0;
   }
 
   /**
@@ -261,7 +265,7 @@ public class MapboxMapOptions implements Parcelable {
       mapboxMapOptions.setPrefetchesTiles(
         typedArray.getBoolean(R.styleable.mapbox_MapView_mapbox_enableTilePrefetch, true));
       mapboxMapOptions.setPrefetchZoomDelta(
-              typedArray.getInt(R.styleable.mapbox_MapView_mapbox_prefetchZoomDelta, 4));
+        typedArray.getInt(R.styleable.mapbox_MapView_mapbox_prefetchZoomDelta, 4));
       mapboxMapOptions.renderSurfaceOnTop(
         typedArray.getBoolean(R.styleable.mapbox_MapView_mapbox_enableZMediaOverlay, false));
 
@@ -291,6 +295,9 @@ public class MapboxMapOptions implements Parcelable {
       );
       mapboxMapOptions.crossSourceCollisions(
         typedArray.getBoolean(R.styleable.mapbox_MapView_mapbox_cross_source_collisions, true)
+      );
+      mapboxMapOptions.translucentSurface(
+        typedArray.getBoolean(R.styleable.mapbox_MapView_mapbox_translucentSurface, false)
       );
     } finally {
       typedArray.recycle();
@@ -613,7 +620,13 @@ public class MapboxMapOptions implements Parcelable {
     return this;
   }
 
+  /**
+   * @deprecated use {{@link #translucentSurface}} instead
+   * @param translucentTextureSurface
+   * @return
+   */
   @NonNull
+  @Deprecated
   public MapboxMapOptions translucentTextureSurface(boolean translucentTextureSurface) {
     this.translucentTextureSurface = translucentTextureSurface;
     return this;
@@ -652,7 +665,7 @@ public class MapboxMapOptions implements Parcelable {
    * tile at the (current_zoom_level - delta) is rendered as soon as possible at the
    * expense of a little bandwidth.
    * Note: This operation will override the MapboxMapOptions#setPrefetchesTiles(boolean)
-   *       Setting zoom delta to 0 will disable pre-fetching.
+   * Setting zoom delta to 0 will disable pre-fetching.
    * Default zoom delta is 4.
    *
    * @param delta zoom delta
@@ -1027,6 +1040,15 @@ public class MapboxMapOptions implements Parcelable {
   }
 
   /**
+   * Returns true if GLSurfaceView and TextureView support a translucent surface
+   *
+   * @return True if translucent surface is active
+   */
+  public boolean getTranslucentSurface() {
+    return translucentSurface;
+  }
+
+  /**
    * Returns the current configured foreground color that is used during map creation.
    *
    * @return the load color
@@ -1125,6 +1147,7 @@ public class MapboxMapOptions implements Parcelable {
     dest.writeFloat(pixelRatio);
     dest.writeInt(foregroundLoadColor);
     dest.writeByte((byte) (crossSourceCollisions ? 1 : 0));
+    dest.writeByte((byte) (translucentSurface ? 1 : 0));
   }
 
   @Override
@@ -1236,6 +1259,9 @@ public class MapboxMapOptions implements Parcelable {
       return false;
     }
 
+    if (translucentSurface != options.translucentSurface) {
+      return false;
+    }
     return false;
   }
 
@@ -1278,6 +1304,7 @@ public class MapboxMapOptions implements Parcelable {
     result = 31 * result + Arrays.hashCode(localIdeographFontFamilies);
     result = 31 * result + (int) pixelRatio;
     result = 31 * result + (crossSourceCollisions ? 1 : 0);
+    result = 31 * result + (translucentSurface ? 1 : 0);
     return result;
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/GLSurfaceViewMapRenderer.java
@@ -25,11 +25,12 @@ public class GLSurfaceViewMapRenderer extends MapRenderer implements GLSurfaceVi
 
   public GLSurfaceViewMapRenderer(Context context,
                                   MapboxGLSurfaceView glSurfaceView,
-                                  String localIdeographFontFamily) {
+                                  String localIdeographFontFamily,
+                                  boolean translucentSurface) {
     super(context, localIdeographFontFamily);
     this.glSurfaceView = glSurfaceView;
     glSurfaceView.setEGLContextClientVersion(2);
-    glSurfaceView.setEGLConfigChooser(new EGLConfigChooser());
+    glSurfaceView.setEGLConfigChooser(new EGLConfigChooser(translucentSurface));
     glSurfaceView.setRenderer(this);
     glSurfaceView.setRenderMode(RENDERMODE_WHEN_DIRTY);
     glSurfaceView.setPreserveEGLContextOnPause(true);

--- a/platform/android/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
@@ -67,6 +67,7 @@
     <public name="mapbox_renderTextureMode" type="attr" />
     <public name="mapbox_renderTextureTranslucentSurface" type="attr" />
     <public name="mapbox_foregroundLoadColor" type="attr" />
+    <public name="mapbox_translucentSurface" type="attr" />
 
     <public name="mapbox_enableTilePrefetch" type="attr" />
     <public name="mapbox_prefetchZoomDelta" type="attr"/>

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/attrs.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/attrs.xml
@@ -105,6 +105,7 @@
 
         <!-- Use TextureView-->
         <attr name="mapbox_renderTextureMode" format="boolean"/>
+        <!-- Deprecated -->
         <attr name="mapbox_renderTextureTranslucentSurface" format="boolean"/>
         <attr name="mapbox_foregroundLoadColor" format="color"/>
 
@@ -112,6 +113,7 @@
         <attr name="mapbox_prefetchZoomDelta" format="integer"/>
         <attr name="mapbox_enableZMediaOverlay" format="boolean"/>
         <attr name="mapbox_pixelRatio" format="float"/>
+        <attr name="mapbox_translucentSurface" format="boolean"/>
 
     </declare-styleable>
 


### PR DESCRIPTION
This PR looks into adding the translucent surface configuration for GLSurfaceView similar to the one we expose for TextureView.