### PR TITLE
[render-test] Implement fps benchmarking tests

### DIFF
--- a/include/mbgl/util/monotonic_timer.hpp
+++ b/include/mbgl/util/monotonic_timer.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <chrono>
+#include <functional>
+#include <mbgl/util/noncopyable.hpp>
+#include <memory>
+
+namespace mbgl {
+namespace util {
+
+class MonotonicTimer {
+public:
+    static std::chrono::duration<double> now();
+
+    template <typename F, typename... Args>
+    inline static std::chrono::duration<double> duration(F&& func, Args&&... args) {
+        auto start = now();
+        func(std::forward<Args>(args)...);
+        return now() - start;
+    }
+};
+
+} // namespace util
+} // namespace mbgl

--- a/next/platform/android/android.cmake
+++ b/next/platform/android/android.cmake
@@ -213,6 +213,7 @@ target_sources(
         ${MBGL_ROOT}/platform/default/src/mbgl/storage/sqlite3.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/text/bidi.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/util/compression.cpp
+        ${MBGL_ROOT}/platform/default/src/mbgl/util/monotonic_timer.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/util/png_writer.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/util/thread_local.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/util/utf.cpp

--- a/next/platform/ios/ios.cmake
+++ b/next/platform/ios/ios.cmake
@@ -39,6 +39,7 @@ target_sources(
         ${MBGL_ROOT}/platform/default/src/mbgl/storage/sqlite3.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/text/bidi.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/util/compression.cpp
+        ${MBGL_ROOT}/platform/default/src/mbgl/util/monotonic_timer.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/util/png_writer.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/util/thread_local.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/util/utf.cpp

--- a/next/platform/linux/linux.cmake
+++ b/next/platform/linux/linux.cmake
@@ -37,6 +37,7 @@ target_sources(
         ${MBGL_ROOT}/platform/default/src/mbgl/util/image.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/util/jpeg_reader.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/util/logging_stderr.cpp
+        ${MBGL_ROOT}/platform/default/src/mbgl/util/monotonic_timer.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/util/png_reader.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/util/png_writer.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/util/run_loop.cpp

--- a/next/platform/macos/macos.cmake
+++ b/next/platform/macos/macos.cmake
@@ -105,6 +105,7 @@ target_sources(
         ${MBGL_ROOT}/platform/default/src/mbgl/storage/sqlite3.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/text/bidi.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/util/compression.cpp
+        ${MBGL_ROOT}/platform/default/src/mbgl/util/monotonic_timer.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/util/png_writer.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/util/thread_local.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/util/utf.cpp

--- a/next/platform/qt/qt.cmake
+++ b/next/platform/qt/qt.cmake
@@ -43,6 +43,7 @@ target_sources(
         ${MBGL_ROOT}/platform/default/src/mbgl/storage/online_file_source.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/storage/sqlite3.cpp
         ${MBGL_ROOT}/platform/default/src/mbgl/util/compression.cpp
+        ${MBGL_ROOT}/platform/default/src/mbgl/util/monotonic_timer.cpp
         ${MBGL_ROOT}/platform/qt/src/async_task.cpp
         ${MBGL_ROOT}/platform/qt/src/async_task_impl.hpp
         ${MBGL_ROOT}/platform/qt/src/number_format.cpp

--- a/platform/android/core-files.json
+++ b/platform/android/core-files.json
@@ -93,6 +93,7 @@
         "platform/default/src/mbgl/map/map_snapshotter.cpp",
         "platform/default/src/mbgl/text/bidi.cpp",
         "platform/default/src/mbgl/util/compression.cpp",
+        "platform/default/src/mbgl/util/monotonic_timer.cpp",
         "platform/default/src/mbgl/util/png_writer.cpp",
         "platform/default/src/mbgl/util/thread_local.cpp",
         "platform/default/src/mbgl/util/utf.cpp",

--- a/platform/default/include/mbgl/gfx/headless_backend.hpp
+++ b/platform/default/include/mbgl/gfx/headless_backend.hpp
@@ -15,11 +15,13 @@ namespace gfx {
 // of readStillImage.
 class HeadlessBackend : public gfx::Renderable {
 public:
+    enum class SwapBehaviour { NoFlush, Flush };
+
     // Factory.
-    static std::unique_ptr<HeadlessBackend>
-    Create(const Size size = { 256, 256 },
-           const gfx::ContextMode contextMode = gfx::ContextMode::Unique) {
-        return Backend::Create<HeadlessBackend, Size, gfx::ContextMode>(size, contextMode);
+    static std::unique_ptr<HeadlessBackend> Create(const Size size = {256, 256},
+                                                   SwapBehaviour swapBehavior = SwapBehaviour::NoFlush,
+                                                   const gfx::ContextMode contextMode = gfx::ContextMode::Unique) {
+        return Backend::Create<HeadlessBackend, Size, SwapBehaviour, gfx::ContextMode>(size, swapBehavior, contextMode);
     }
 
     virtual PremultipliedImage readStillImage() = 0;

--- a/platform/default/include/mbgl/gfx/headless_frontend.hpp
+++ b/platform/default/include/mbgl/gfx/headless_frontend.hpp
@@ -17,10 +17,12 @@ class TransformState;
 class HeadlessFrontend : public RendererFrontend {
 public:
     HeadlessFrontend(float pixelRatio_,
+                     gfx::HeadlessBackend::SwapBehaviour swapBehviour = gfx::HeadlessBackend::SwapBehaviour::NoFlush,
                      gfx::ContextMode mode = gfx::ContextMode::Unique,
                      const optional<std::string> localFontFamily = {});
     HeadlessFrontend(Size,
                      float pixelRatio_,
+                     gfx::HeadlessBackend::SwapBehaviour swapBehviour = gfx::HeadlessBackend::SwapBehaviour::NoFlush,
                      gfx::ContextMode mode = gfx::ContextMode::Unique,
                      const optional<std::string> localFontFamily = {});
     ~HeadlessFrontend() override;

--- a/platform/default/include/mbgl/gfx/headless_frontend.hpp
+++ b/platform/default/include/mbgl/gfx/headless_frontend.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
+#include <mbgl/gfx/headless_backend.hpp>
 #include <mbgl/map/camera.hpp>
 #include <mbgl/renderer/renderer_frontend.hpp>
-#include <mbgl/gfx/headless_backend.hpp>
 #include <mbgl/util/async_task.hpp>
 #include <mbgl/util/optional.hpp>
 
+#include <atomic>
 #include <memory>
 
 namespace mbgl {
@@ -31,6 +32,7 @@ public:
     void update(std::shared_ptr<UpdateParameters>) override;
     void setObserver(RendererObserver&) override;
 
+    double getFrameTime() const;
     Size getSize() const;
     void setSize(Size);
 
@@ -54,6 +56,7 @@ private:
     Size size;
     float pixelRatio;
 
+    std::atomic<double> frameTime;
     std::unique_ptr<gfx::HeadlessBackend> backend;
     util::AsyncTask asyncInvalidate;
 

--- a/platform/default/include/mbgl/gfx/headless_frontend.hpp
+++ b/platform/default/include/mbgl/gfx/headless_frontend.hpp
@@ -49,6 +49,7 @@ public:
 
     PremultipliedImage readStillImage();
     PremultipliedImage render(Map&);
+    void renderOnce(Map&);
 
     optional<TransformState> getTransformState() const;
 

--- a/platform/default/include/mbgl/gl/headless_backend.hpp
+++ b/platform/default/include/mbgl/gl/headless_backend.hpp
@@ -10,12 +10,16 @@ namespace gl {
 
 class HeadlessBackend final : public gl::RendererBackend, public gfx::HeadlessBackend {
 public:
-    HeadlessBackend(Size = { 256, 256 }, gfx::ContextMode = gfx::ContextMode::Unique);
+    HeadlessBackend(Size = {256, 256},
+                    SwapBehaviour = SwapBehaviour::NoFlush,
+                    gfx::ContextMode = gfx::ContextMode::Unique);
     ~HeadlessBackend() override;
     void updateAssumedState() override;
     gfx::Renderable& getDefaultRenderable() override;
     PremultipliedImage readStillImage() override;
     RendererBackend* getRendererBackend() override;
+
+    void swap();
 
     class Impl {
     public:
@@ -37,6 +41,7 @@ private:
 private:
     std::unique_ptr<Impl> impl;
     bool active = false;
+    SwapBehaviour swapBehaviour = SwapBehaviour::NoFlush;
 };
 
 } // namespace gl

--- a/platform/default/src/mbgl/gfx/headless_frontend.cpp
+++ b/platform/default/src/mbgl/gfx/headless_frontend.cpp
@@ -158,8 +158,12 @@ PremultipliedImage HeadlessFrontend::render(Map& map) {
     if (error) {
         std::rethrow_exception(error);
     }
-      
+
     return result;
+}
+
+void HeadlessFrontend::renderOnce(Map&) {
+    util::RunLoop::Get()->runOnce();
 }
 
 optional<TransformState> HeadlessFrontend::getTransformState() const {

--- a/platform/default/src/mbgl/gfx/headless_frontend.cpp
+++ b/platform/default/src/mbgl/gfx/headless_frontend.cpp
@@ -10,34 +10,35 @@
 namespace mbgl {
 
 HeadlessFrontend::HeadlessFrontend(float pixelRatio_,
+                                   gfx::HeadlessBackend::SwapBehaviour swapBehavior,
                                    const gfx::ContextMode contextMode,
                                    const optional<std::string> localFontFamily)
-    : HeadlessFrontend(
-          { 256, 256 }, pixelRatio_, contextMode, localFontFamily) {
-}
+    : HeadlessFrontend({256, 256}, pixelRatio_, swapBehavior, contextMode, localFontFamily) {}
 
 HeadlessFrontend::HeadlessFrontend(Size size_,
                                    float pixelRatio_,
+                                   gfx::HeadlessBackend::SwapBehaviour swapBehavior,
                                    const gfx::ContextMode contextMode,
                                    const optional<std::string> localFontFamily)
     : size(size_),
       pixelRatio(pixelRatio_),
-      backend(gfx::HeadlessBackend::Create({ static_cast<uint32_t>(size.width * pixelRatio),
-                                             static_cast<uint32_t>(size.height * pixelRatio) }, contextMode)),
-    asyncInvalidate([this] {
-        if (renderer && updateParameters) {
-            gfx::BackendScope guard { *getBackend() };
+      backend(gfx::HeadlessBackend::Create(
+          {static_cast<uint32_t>(size.width * pixelRatio), static_cast<uint32_t>(size.height * pixelRatio)},
+          swapBehavior,
+          contextMode)),
+      asyncInvalidate([this] {
+          if (renderer && updateParameters) {
+              gfx::BackendScope guard{*getBackend()};
 
-            // onStyleImageMissing might be called during a render. The user implemented method
-            // could trigger a call to MGLRenderFrontend#update which overwrites `updateParameters`.
-            // Copy the shared pointer here so that the parameters aren't destroyed while `render(...)` is
-            // still using them.
-            auto updateParameters_ = updateParameters;
-            renderer->render(*updateParameters_);
-        }
-    }),
-    renderer(std::make_unique<Renderer>(*getBackend(), pixelRatio, localFontFamily)) {
-}
+              // onStyleImageMissing might be called during a render. The user implemented method
+              // could trigger a call to MGLRenderFrontend#update which overwrites `updateParameters`.
+              // Copy the shared pointer here so that the parameters aren't destroyed while `render(...)` is
+              // still using them.
+              auto updateParameters_ = updateParameters;
+              renderer->render(*updateParameters_);
+          }
+      }),
+      renderer(std::make_unique<Renderer>(*getBackend(), pixelRatio, localFontFamily)) {}
 
 HeadlessFrontend::~HeadlessFrontend() = default;
 

--- a/platform/default/src/mbgl/map/map_snapshotter.cpp
+++ b/platform/default/src/mbgl/map/map_snapshotter.cpp
@@ -51,8 +51,8 @@ MapSnapshotter::Impl::Impl(const std::pair<bool, std::string> style,
                            const optional<LatLngBounds> region,
                            const optional<std::string> localFontFamily,
                            const ResourceOptions& resourceOptions)
-     : frontend(
-          size, pixelRatio, gfx::ContextMode::Unique, localFontFamily),
+    : frontend(
+          size, pixelRatio, gfx::HeadlessBackend::SwapBehaviour::NoFlush, gfx::ContextMode::Unique, localFontFamily),
       map(frontend,
           MapObserver::nullObserver(),
           MapOptions().withMapMode(MapMode::Static).withSize(size).withPixelRatio(pixelRatio),

--- a/platform/default/src/mbgl/util/monotonic_timer.cpp
+++ b/platform/default/src/mbgl/util/monotonic_timer.cpp
@@ -1,0 +1,24 @@
+#include <assert.h>
+#include <chrono>
+#include <mbgl/util/monotonic_timer.hpp>
+
+namespace mbgl {
+namespace util {
+
+// Prefer high resolution timer if it is monotonic
+template <typename T, std::enable_if_t<std::chrono::high_resolution_clock::is_steady, T>* = nullptr>
+static T sample() {
+    return std::chrono::duration_cast<T>(std::chrono::high_resolution_clock::now().time_since_epoch());
+}
+
+template <typename T, std::enable_if_t<!std::chrono::high_resolution_clock::is_steady, T>* = nullptr>
+static T sample() {
+    return std::chrono::duration_cast<T>(std::chrono::steady_clock::now().time_since_epoch());
+}
+
+std::chrono::duration<double> MonotonicTimer::now() {
+    return sample<std::chrono::duration<double>>();
+}
+
+} // namespace util
+} // namespace mbgl

--- a/platform/ios/core-files.json
+++ b/platform/ios/core-files.json
@@ -17,6 +17,7 @@
         "platform/default/src/mbgl/map/map_snapshotter.cpp",
         "platform/default/src/mbgl/text/bidi.cpp",
         "platform/default/src/mbgl/util/compression.cpp",
+        "platform/default/src/mbgl/util/monotonic_timer.cpp",
         "platform/default/src/mbgl/util/png_writer.cpp",
         "platform/default/src/mbgl/util/thread_local.cpp",
         "platform/default/src/mbgl/util/utf.cpp"

--- a/platform/linux/config.cmake
+++ b/platform/linux/config.cmake
@@ -52,6 +52,7 @@ macro(mbgl_platform_core)
         PRIVATE platform/default/src/mbgl/layermanager/layer_manager.cpp
         PRIVATE platform/default/src/mbgl/util/compression.cpp
         PRIVATE platform/default/src/mbgl/util/logging_stderr.cpp
+        PRIVATE platform/default/src/mbgl/util/monotonic_timer.cpp
         PRIVATE platform/default/src/mbgl/util/string_stdlib.cpp
         PRIVATE platform/default/src/mbgl/util/thread.cpp
         PRIVATE platform/default/src/mbgl/util/thread_local.cpp

--- a/platform/macos/core-files.json
+++ b/platform/macos/core-files.json
@@ -16,6 +16,7 @@
         "platform/default/src/mbgl/map/map_snapshotter.cpp",
         "platform/default/src/mbgl/text/bidi.cpp",
         "platform/default/src/mbgl/util/compression.cpp",
+        "platform/default/src/mbgl/util/monotonic_timer.cpp",
         "platform/default/src/mbgl/util/png_writer.cpp",
         "platform/default/src/mbgl/util/thread_local.cpp",
         "platform/default/src/mbgl/util/utf.cpp"

--- a/render-test/metadata.hpp
+++ b/render-test/metadata.hpp
@@ -68,6 +68,12 @@ struct MemoryProbe {
     }
 };
 
+struct FpsProbe {
+    float average = 0.0;
+    float minOnePc = 0.0;
+    float tolerance = 0.0f;
+};
+
 struct NetworkProbe {
     NetworkProbe() = default;
     NetworkProbe(size_t requests_, size_t transferred_) : requests(requests_), transferred(transferred_) {}
@@ -78,10 +84,11 @@ struct NetworkProbe {
 
 class TestMetrics {
 public:
-    bool isEmpty() const { return fileSize.empty() && memory.empty() && network.empty(); }
+    bool isEmpty() const { return fileSize.empty() && memory.empty() && network.empty() && fps.empty(); }
     std::map<std::string, FileSizeProbe> fileSize;
     std::map<std::string, MemoryProbe> memory;
     std::map<std::string, NetworkProbe> network;
+    std::map<std::string, FpsProbe> fps;
 };
 
 struct TestMetadata {

--- a/render-test/metadata.hpp
+++ b/render-test/metadata.hpp
@@ -90,6 +90,7 @@ struct TestMetadata {
     TestPaths paths;
     mbgl::JSDocument document;
     bool renderTest = true;
+    bool outputsImage = true;
 
     mbgl::Size size{ 512u, 512u };
     float pixelRatio = 1.0f;

--- a/render-test/render_test.cpp
+++ b/render-test/render_test.cpp
@@ -100,7 +100,8 @@ int runRenderTests(int argc, char** argv) {
             errored = !runner.run(metadata) || !metadata.errorMessage.empty();
         }
 
-        bool passed = !errored && !metadata.diff.empty() && metadata.difference <= metadata.allowed;
+        bool passed =
+            !errored && (!metadata.outputsImage || !metadata.diff.empty()) && metadata.difference <= metadata.allowed;
 
         if (shouldIgnore) {
             if (passed) {

--- a/render-test/runner.cpp
+++ b/render-test/runner.cpp
@@ -39,6 +39,12 @@ const std::string& TestRunner::getBasePath() {
     return result;
 }
 
+// static
+gfx::HeadlessBackend::SwapBehaviour swapBehavior(MapMode mode) {
+    return mode == MapMode::Continuous ? gfx::HeadlessBackend::SwapBehaviour::Flush
+                                       : gfx::HeadlessBackend::SwapBehaviour::NoFlush;
+}
+
 std::string simpleDiff(const Value& result, const Value& expected) {
     std::vector<std::string> resultTokens{tokenize(toJSON(result, 2, false))};
     std::vector<std::string> expectedTokens{tokenize(toJSON(expected, 2, false))};
@@ -824,7 +830,7 @@ bool TestRunner::runOperations(const std::string& key, TestMetadata& metadata) {
 }
 
 TestRunner::Impl::Impl(const TestMetadata& metadata)
-    : frontend(metadata.size, metadata.pixelRatio),
+    : frontend(metadata.size, metadata.pixelRatio, swapBehavior(metadata.mapMode)),
       map(frontend,
           mbgl::MapObserver::nullObserver(),
           mbgl::MapOptions()

--- a/render-test/runner.hpp
+++ b/render-test/runner.hpp
@@ -5,6 +5,7 @@
 
 #include <memory>
 
+class TestRunnerMapObserver;
 struct TestMetadata;
 
 class TestRunner {
@@ -26,7 +27,9 @@ private:
 
     struct Impl {
         Impl(const TestMetadata&);
+        ~Impl();
 
+        std::unique_ptr<TestRunnerMapObserver> observer;
         mbgl::HeadlessFrontend frontend;
         mbgl::Map map;
     };

--- a/src/core-files.json
+++ b/src/core-files.json
@@ -483,6 +483,7 @@
         "mbgl/util/indexed_tuple.hpp": "include/mbgl/util/indexed_tuple.hpp",
         "mbgl/util/interpolate.hpp": "include/mbgl/util/interpolate.hpp",
         "mbgl/util/logging.hpp": "include/mbgl/util/logging.hpp",
+        "mbgl/util/monotonic_timer.hpp": "include/mbgl/util/monotonic_timer.hpp",
         "mbgl/util/noncopyable.hpp": "include/mbgl/util/noncopyable.hpp",
         "mbgl/util/optional.hpp": "include/mbgl/util/optional.hpp",
         "mbgl/util/platform.hpp": "include/mbgl/util/platform.hpp",

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -583,6 +583,10 @@ std::unique_ptr<gfx::CommandEncoder> Context::createCommandEncoder() {
     return std::make_unique<gl::CommandEncoder>(*this);
 }
 
+void Context::finish() {
+    MBGL_CHECK_ERROR(glFinish());
+}
+
 void Context::draw(const gfx::DrawMode& drawMode,
                    std::size_t indexOffset,
                    std::size_t indexLength) {

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -92,6 +92,8 @@ public:
               std::size_t indexOffset,
               std::size_t indexLength);
 
+    void finish();
+
     // Actually remove the objects we marked as abandoned with the above methods.
     // Only call this while the OpenGL context is exclusive to this thread.
     void performCleanup() override;

--- a/test/gl/context.test.cpp
+++ b/test/gl/context.test.cpp
@@ -91,9 +91,10 @@ TEST(GLContextMode, Shared) {
 
     util::RunLoop loop;
 
-    HeadlessFrontend frontend { 1, gfx::ContextMode::Shared };
+    HeadlessFrontend frontend{1, gfx::HeadlessBackend::SwapBehaviour::NoFlush, gfx::ContextMode::Shared};
 
-    Map map(frontend, MapObserver::nullObserver(),
+    Map map(frontend,
+            MapObserver::nullObserver(),
             MapOptions().withMapMode(MapMode::Static).withSize(frontend.getSize()),
             ResourceOptions().withCachePath(":memory:").withAssetPath("test/fixtures/api/assets"));
     map.getStyle().loadJSON(util::read_file("test/fixtures/api/water.json"));

--- a/test/text/local_glyph_rasterizer.test.cpp
+++ b/test/text/local_glyph_rasterizer.test.cpp
@@ -33,9 +33,7 @@ namespace {
 class LocalGlyphRasterizerTest {
 public:
     LocalGlyphRasterizerTest(const optional<std::string> fontFamily)
-        : frontend(1, gfx::ContextMode::Unique, fontFamily)
-    {
-    }
+        : frontend(1, gfx::HeadlessBackend::SwapBehaviour::NoFlush, gfx::ContextMode::Unique, fontFamily) {}
 
     util::RunLoop loop;
     std::shared_ptr<StubFileSource> fileSource = std::make_shared<StubFileSource>();


### PR DESCRIPTION
Test runner now supports continuous map rendering and fps tracking along a given camera path. Goal of this new rendering test is to imitate typical user gestures (aka map transformations) like panning and keep track of the average and minimum fps during the operation. This should provide us an opportunity to compare rendering performance trends on different areas of the map.


