### PR TITLE
[test-runner] make render-test a shared lib

### DIFF
--- a/cmake/render-test.cmake
+++ b/cmake/render-test.cmake
@@ -1,32 +1,60 @@
-add_executable(mbgl-render-test
-    render-test/allocation_index.cpp
-    render-test/main.cpp
-    render-test/parser.cpp
-    render-test/runner.cpp
+add_executable(
+    mbgl-render-test
     expression-test/test_runner_common.cpp
     expression-test/test_runner_common.hpp
+    platform/default/src/mbgl/render-test/main.cpp
+    render-test/allocation_index.cpp
+    render-test/allocation_index.hpp
+    render-test/filesystem.hpp
+    render-test/filesystem.hpp
+    render-test/include/mbgl/render_test.hpp
+    render-test/metadata.hpp
+    render-test/parser.cpp
+    render-test/parser.hpp
+    render-test/render_test.cpp
+    render-test/runner.cpp
+    render-test/runner.hpp
 )
 
 if(APPLE)
-    target_link_libraries(mbgl-render-test PRIVATE mbgl-loop-darwin)
+    target_link_libraries(
+        mbgl-render-test
+        PRIVATE mbgl-loop-darwin
+    )
 else()
-    target_link_libraries(mbgl-render-test PRIVATE mbgl-loop-uv)
+    target_link_libraries(
+        mbgl-render-test
+        PRIVATE mbgl-loop-uv
+    )
 endif()
 
-target_include_directories(mbgl-render-test
+target_include_directories(
+    mbgl-render-test
     PRIVATE src
     PRIVATE platform/default/include
     PRIVATE render-test
 )
 
-target_link_libraries(mbgl-render-test PRIVATE
-    mbgl-core
-    mbgl-filesource
-    Mapbox::Base::Extras::args
-    mbgl-vendor-expected
-    Mapbox::Base::Extras::filesystem
-    Mapbox::Base::pixelmatch-cpp
-    Mapbox::Base::Extras::rapidjson
+target_include_directories(
+    mbgl-render-test
+    PUBLIC render-test/include
+    PUBLIC include
 )
+
+target_link_libraries(
+    mbgl-render-test
+    PRIVATE
+        mbgl-core
+        mbgl-filesource
+        Mapbox::Base::Extras::args
+        mbgl-vendor-expected
+        Mapbox::Base::Extras::filesystem
+        Mapbox::Base::pixelmatch-cpp
+        Mapbox::Base::Extras::rapidjson
+)
+
+create_source_groups(mbgl-render-test)
+
+set_target_properties(mbgl-render-test PROPERTIES FOLDER "Executables")
 
 add_definitions(-DTEST_RUNNER_ROOT_PATH="${CMAKE_SOURCE_DIR}")

--- a/next/CMakeLists.txt
+++ b/next/CMakeLists.txt
@@ -943,3 +943,4 @@ endif()
 
 add_subdirectory(${PROJECT_SOURCE_DIR}/test)
 add_subdirectory(${PROJECT_SOURCE_DIR}/benchmark)
+add_subdirectory(${PROJECT_SOURCE_DIR}/render-test)

--- a/next/platform/linux/linux.cmake
+++ b/next/platform/linux/linux.cmake
@@ -95,7 +95,6 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/bin)
 add_subdirectory(${PROJECT_SOURCE_DIR}/expression-test)
 add_subdirectory(${PROJECT_SOURCE_DIR}/platform/glfw)
 add_subdirectory(${PROJECT_SOURCE_DIR}/platform/node)
-add_subdirectory(${PROJECT_SOURCE_DIR}/render-test)
 
 add_executable(
     mbgl-test-runner
@@ -122,5 +121,31 @@ target_link_libraries(
     PRIVATE mbgl-benchmark
 )
 
+add_executable(
+    mbgl-render-test-runner
+    ${MBGL_ROOT}/platform/default/src/mbgl/render-test/main.cpp
+)
+
+target_link_libraries(
+    mbgl-render-test-runner
+    PRIVATE mbgl-render-test
+)
+
 add_test(NAME mbgl-benchmark-runner COMMAND mbgl-benchmark-runner WORKING_DIRECTORY ${MBGL_ROOT})
 add_test(NAME mbgl-test-runner COMMAND mbgl-test-runner WORKING_DIRECTORY ${MBGL_ROOT})
+
+string(RANDOM LENGTH 5 ALPHABET 0123456789 MBGL_RENDER_TEST_SEED)
+
+add_test(
+    NAME mbgl-render-test
+    COMMAND
+        mbgl-render-test-runner
+        render-tests
+        --recycle-map
+        --shuffle
+        --seed=${MBGL_RENDER_TEST_SEED}
+    WORKING_DIRECTORY ${MBGL_ROOT}
+)
+
+add_test(NAME mbgl-render-test-probes COMMAND mbgl-render-test-runner tests --rootPath=render-test WORKING_DIRECTORY ${MBGL_ROOT})
+add_test(NAME mbgl-query-test COMMAND mbgl-render-test-runner query-tests WORKING_DIRECTORY ${MBGL_ROOT})

--- a/next/platform/macos/macos.cmake
+++ b/next/platform/macos/macos.cmake
@@ -155,7 +155,6 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/bin)
 add_subdirectory(${PROJECT_SOURCE_DIR}/expression-test)
 add_subdirectory(${PROJECT_SOURCE_DIR}/platform/glfw)
 add_subdirectory(${PROJECT_SOURCE_DIR}/platform/node)
-add_subdirectory(${PROJECT_SOURCE_DIR}/render-test)
 
 add_executable(
     mbgl-test-runner
@@ -182,8 +181,35 @@ target_link_libraries(
     PRIVATE mbgl-benchmark
 )
 
+add_executable(
+    mbgl-render-test-runner
+    ${MBGL_ROOT}/platform/default/src/mbgl/render-test/main.cpp
+)
+
+target_link_libraries(
+    mbgl-render-test-runner
+    PRIVATE mbgl-render-test
+)
+
 set_property(TARGET mbgl-benchmark-runner PROPERTY FOLDER Executables)
 set_property(TARGET mbgl-test-runner PROPERTY FOLDER Executables)
+set_property(TARGET mbgl-render-test-runner PROPERTY FOLDER Executables)
 
 add_test(NAME mbgl-benchmark-runner COMMAND mbgl-benchmark-runner WORKING_DIRECTORY ${MBGL_ROOT})
 add_test(NAME mbgl-test-runner COMMAND mbgl-test-runner WORKING_DIRECTORY ${MBGL_ROOT})
+
+string(RANDOM LENGTH 5 ALPHABET 0123456789 MBGL_RENDER_TEST_SEED)
+
+add_test(
+    NAME mbgl-render-test
+    COMMAND
+        mbgl-render-test-runner
+        render-tests
+        --recycle-map
+        --shuffle
+        --seed=${MBGL_RENDER_TEST_SEED}
+    WORKING_DIRECTORY ${MBGL_ROOT}
+)
+
+add_test(NAME mbgl-render-test-probes COMMAND mbgl-render-test-runner tests --rootPath=render-test WORKING_DIRECTORY ${MBGL_ROOT})
+add_test(NAME mbgl-query-test COMMAND mbgl-render-test-runner query-tests WORKING_DIRECTORY ${MBGL_ROOT})

--- a/next/render-test/CMakeLists.txt
+++ b/next/render-test/CMakeLists.txt
@@ -1,16 +1,18 @@
-add_executable(
-    mbgl-render-test
+add_library(
+    mbgl-render-test SHARED EXCLUDE_FROM_ALL
+    ${MBGL_ROOT}/expression-test/test_runner_common.cpp
+    ${MBGL_ROOT}/expression-test/test_runner_common.hpp
     ${MBGL_ROOT}/render-test/allocation_index.cpp
     ${MBGL_ROOT}/render-test/allocation_index.hpp
     ${MBGL_ROOT}/render-test/filesystem.hpp
-    ${MBGL_ROOT}/render-test/main.cpp
+    ${MBGL_ROOT}/render-test/filesystem.hpp
+    ${MBGL_ROOT}/render-test/include/mbgl/render_test.hpp
     ${MBGL_ROOT}/render-test/metadata.hpp
     ${MBGL_ROOT}/render-test/parser.cpp
     ${MBGL_ROOT}/render-test/parser.hpp
+    ${MBGL_ROOT}/render-test/render_test.cpp
     ${MBGL_ROOT}/render-test/runner.cpp
     ${MBGL_ROOT}/render-test/runner.hpp
-    ${MBGL_ROOT}/expression-test/test_runner_common.cpp
-    ${MBGL_ROOT}/expression-test/test_runner_common.hpp
 )
 
 target_compile_definitions(
@@ -21,7 +23,12 @@ target_compile_definitions(
 # FIXME: Should not use core private interface
 target_include_directories(
     mbgl-render-test
-    PRIVATE ${MBGL_ROOT}/src
+    PRIVATE ${MBGL_ROOT}/src ${MBGL_ROOT}/platform/default/include
+)
+
+target_include_directories(
+    mbgl-render-test
+    PUBLIC ${MBGL_ROOT}/render-test/include ${MBGL_ROOT}/include
 )
 
 include(${PROJECT_SOURCE_DIR}/vendor/boost.cmake)
@@ -36,20 +43,8 @@ target_link_libraries(
         mbgl-vendor-boost
 )
 
-set_property(TARGET mbgl-render-test PROPERTY FOLDER Executables)
+if(CMAKE_SYSTEM_NAME STREQUAL Android)
+    set_target_properties(mbgl-render-test PROPERTIES LINK_FLAGS_RELEASE "-fuse-ld=gold -O2 -flto -Wl,--icf=safe")
+endif()
 
-string(RANDOM LENGTH 5 ALPHABET 0123456789 MBGL_RENDER_TEST_SEED)
-
-add_test(
-    NAME mbgl-render-test
-    COMMAND
-        mbgl-render-test
-        render-tests
-        --recycle-map
-        --shuffle
-        --seed=${MBGL_RENDER_TEST_SEED}
-    WORKING_DIRECTORY ${MBGL_ROOT}
-)
-
-add_test(NAME mbgl-render-test-probes COMMAND mbgl-render-test tests --rootPath=render-test WORKING_DIRECTORY ${MBGL_ROOT})
-add_test(NAME mbgl-query-test COMMAND mbgl-render-test query-tests WORKING_DIRECTORY ${MBGL_ROOT})
+set_property(TARGET mbgl-render-test PROPERTY FOLDER Core)

--- a/next/render-test/CMakeLists.txt
+++ b/next/render-test/CMakeLists.txt
@@ -23,7 +23,7 @@ target_compile_definitions(
 # FIXME: Should not use core private interface
 target_include_directories(
     mbgl-render-test
-    PRIVATE ${MBGL_ROOT}/src ${MBGL_ROOT}/platform/default/include
+    PRIVATE ${MBGL_ROOT}/src
 )
 
 target_include_directories(

--- a/platform/default/src/mbgl/render-test/main.cpp
+++ b/platform/default/src/mbgl/render-test/main.cpp
@@ -1,0 +1,5 @@
+#include <mbgl/render_test.hpp>
+
+int main(int argc, char *argv[]) {
+    return mbgl::runRenderTests(argc, argv);
+}

--- a/render-test/include/mbgl/render_test.hpp
+++ b/render-test/include/mbgl/render_test.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <mbgl/util/util.hpp>
+
+namespace mbgl {
+
+MBGL_EXPORT int runRenderTests(int argc, char* argv[]);
+
+} // namespace mbgl

--- a/render-test/render_test.cpp
+++ b/render-test/render_test.cpp
@@ -1,7 +1,8 @@
 #include "allocation_index.hpp"
 
-#include <mbgl/util/run_loop.hpp>
+#include <mbgl/render_test.hpp>
 #include <mbgl/util/io.hpp>
+#include <mbgl/util/run_loop.hpp>
 
 #include "metadata.hpp"
 #include "parser.hpp"
@@ -36,7 +37,9 @@ void operator delete(void* ptr, size_t) noexcept {
 }
 #endif
 
-int main(int argc, char** argv) {
+namespace mbgl {
+
+int runRenderTests(int argc, char** argv) {
     bool recycleMap;
     bool shuffle;
     uint32_t seed;
@@ -160,3 +163,5 @@ int main(int argc, char** argv) {
 
     return stats.failedTests + stats.erroredTests == 0 ? 0 : 1;
 }
+
+} // namespace mbgl


### PR DESCRIPTION
This pr is an enabler for running the Render Test Runner on Android. We need to link the render-test library to a native activity android app, which is used for running the render tests.