### PR TITLE
[build] Make output of the tests verbose

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -280,7 +280,7 @@ commands:
           name: Test
           command: |
             cd build
-            << parameters.test_wrapper >> ctest --output-on-failure << parameters.test_params >>
+            << parameters.test_wrapper >> ctest -V << parameters.test_params >>
   npm-install:
     steps:
     - run:


### PR DESCRIPTION
We have a flaky test that is hanging on the bots and we need to find out which one.