### PR TITLE
[core] Fix image requests for already obtained images

### DIFF
--- a/src/mbgl/renderer/image_manager.cpp
+++ b/src/mbgl/renderer/image_manager.cpp
@@ -189,9 +189,12 @@ void ImageManager::checkMissingAndNotify(ImageRequestor& requestor, const ImageR
 
             auto existingRequestorsIt = requestedImages.find(missingImage);
             if (existingRequestorsIt != requestedImages.end()) { // Already asked client about this image.
-                if (!existingRequestorsIt->second.empty()) {     // Still waiting for the client response.
-                    existingRequestorsIt->second.emplace(requestorPtr);
-                    requestor.addPendingRequest(missingImage);
+                std::set<ImageRequestor*>& existingRequestors = existingRequestorsIt->second;
+                if (!existingRequestors.empty() &&
+                    (*existingRequestors.begin())
+                        ->hasPendingRequest(missingImage)) { // Still waiting for the client response for this image.
+                    requestorPtr->addPendingRequest(missingImage);
+                    existingRequestors.emplace(requestorPtr);
                     continue;
                 }
                 // Unlike icons, pattern changes are not caught

--- a/src/mbgl/renderer/image_manager.hpp
+++ b/src/mbgl/renderer/image_manager.hpp
@@ -73,9 +73,8 @@ public:
     virtual void onImagesAvailable(ImageMap icons, ImageMap patterns, ImageVersionMap versionMap, uint64_t imageCorrelationID) = 0;
 
     void addPendingRequest(const std::string& imageId) { pendingRequests.insert(imageId); }
-
+    bool hasPendingRequest(const std::string& imageId) const { return pendingRequests.count(imageId); }
     bool hasPendingRequests() const { return !pendingRequests.empty(); }
-
     void removePendingRequest(const std::string& imageId) { pendingRequests.erase(imageId); }
 
 private:

--- a/test/renderer/image_manager.test.cpp
+++ b/test/renderer/image_manager.test.cpp
@@ -189,7 +189,7 @@ TEST(ImageManager, OnStyleImageMissingBeforeSpriteLoaded) {
 
     // Repeated request of the same image shall not result another
     // `ImageManagerObserver.onStyleImageMissing()` call.
-    imageManager.getImages(requestor, std::make_pair(dependencies, imageCorrelationID));
+    imageManager.getImages(requestor, std::make_pair(dependencies, ++imageCorrelationID));
     runLoop.runOnce();
 
     EXPECT_EQ(observer.count, 1);
@@ -197,10 +197,20 @@ TEST(ImageManager, OnStyleImageMissingBeforeSpriteLoaded) {
     // Request for updated dependencies must be dispatched to the
     // observer.
     dependencies.emplace("post", ImageType::Icon);
-    imageManager.getImages(requestor, std::make_pair(dependencies, imageCorrelationID));
+    imageManager.getImages(requestor, std::make_pair(dependencies, ++imageCorrelationID));
     runLoop.runOnce();
 
     EXPECT_EQ(observer.count, 2);
+
+    // Another requestor shall not have pending requests for already obtained images.
+    StubImageRequestor anotherRequestor(imageManager);
+    imageManager.getImages(anotherRequestor, std::make_pair(dependencies, ++imageCorrelationID));
+    ASSERT_FALSE(anotherRequestor.hasPendingRequests());
+
+    dependencies.emplace("unfamiliar", ImageType::Icon);
+    imageManager.getImages(anotherRequestor, std::make_pair(dependencies, ++imageCorrelationID));
+    EXPECT_TRUE(anotherRequestor.hasPendingRequests());
+    EXPECT_TRUE(anotherRequestor.hasPendingRequest("unfamiliar"));
 }
 
 TEST(ImageManager, OnStyleImageMissingAfterSpriteLoaded) {


### PR DESCRIPTION
Before this change, repeated request for an already obtained image was erroneously treated as pending, and it prevented from the tiles load completion.

Fixes https://github.com/mapbox/mapbox-gl-native-team/issues/85
Fixes https://github.com/mapbox/mapbox-gl-native/issues/15822