### PR TITLE
[core] fix collisions with icon-text-fit and variable placement

### DIFF
--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -281,7 +281,8 @@ void Placement::placeBucket(
 
                 placeText = placed.first;
                 offscreen &= placed.second;
-            } else if (!symbolInstance.textCollisionFeature.alongLine && !symbolInstance.textCollisionFeature.boxes.empty()) {
+            } else if (!symbolInstance.textCollisionFeature.alongLine &&
+                       !symbolInstance.textCollisionFeature.boxes.empty()) {
                 // If this symbol was in the last placement, shift the previously used
                 // anchor to the front of the anchor list, only if the previous anchor
                 // is still in the anchor list.
@@ -327,12 +328,20 @@ void Placement::placeBucket(
                         }
 
                         textBoxes.clear();
-                        placedFeature = collisionIndex.placeFeature(textCollisionFeature, shift,
-                                                                    posMatrix, mat4(), pixelRatio,
-                                                                    placedSymbol, scale, fontSize,
+                        placedFeature = collisionIndex.placeFeature(textCollisionFeature,
+                                                                    shift,
+                                                                    posMatrix,
+                                                                    mat4(),
+                                                                    pixelRatio,
+                                                                    placedSymbol,
+                                                                    scale,
+                                                                    fontSize,
                                                                     allowOverlap,
                                                                     pitchWithMap,
-                                                                    params.showCollisionBoxes, avoidEdges, collisionGroup.second, textBoxes);
+                                                                    params.showCollisionBoxes,
+                                                                    avoidEdges,
+                                                                    collisionGroup.second,
+                                                                    textBoxes);
 
                         if (doVariableIconPlacement) {
                             auto placedIconFeature = collisionIndex.placeFeature(iconCollisionFeature,

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -220,7 +220,6 @@ void Placement::placeBucket(
         if (horizontalTextIndex) {
             const PlacedSymbol& placedSymbol = bucket.text.placedSymbols.at(*horizontalTextIndex);
             const float fontSize = evaluateSizeForFeature(partiallyEvaluatedTextSize, placedSymbol);
-            const CollisionFeature& textCollisionFeature = symbolInstance.textCollisionFeature;
 
             const auto updatePreviousOrientationIfNotPlaced = [&](bool isPlaced) {
                 if (bucket.allowVerticalPlacement && !isPlaced && getPrevPlacement()) {
@@ -282,7 +281,7 @@ void Placement::placeBucket(
 
                 placeText = placed.first;
                 offscreen &= placed.second;
-            } else if (!textCollisionFeature.alongLine && !textCollisionFeature.boxes.empty()) {
+            } else if (!symbolInstance.textCollisionFeature.alongLine && !symbolInstance.textCollisionFeature.boxes.empty()) {
                 // If this symbol was in the last placement, shift the previously used
                 // anchor to the front of the anchor list, only if the previous anchor
                 // is still in the anchor list.
@@ -308,10 +307,10 @@ void Placement::placeBucket(
                 const bool doVariableIconPlacement =
                     hasIconTextFit && !iconAllowOverlap && symbolInstance.placedIconIndex;
 
-                const auto placeFeatureForVariableAnchors = [&](const CollisionFeature& collisionFeature,
+                const auto placeFeatureForVariableAnchors = [&](const CollisionFeature& textCollisionFeature,
                                                                 style::TextWritingModeType orientation,
                                                                 const CollisionFeature& iconCollisionFeature) {
-                    const CollisionBox& textBox = collisionFeature.boxes[0];
+                    const CollisionBox& textBox = textCollisionFeature.boxes[0];
                     const float width = textBox.x2 - textBox.x1;
                     const float height = textBox.y2 - textBox.y1;
                     const float textBoxScale = symbolInstance.textBoxScale;
@@ -328,7 +327,7 @@ void Placement::placeBucket(
                         }
 
                         textBoxes.clear();
-                        placedFeature = collisionIndex.placeFeature(collisionFeature, shift,
+                        placedFeature = collisionIndex.placeFeature(textCollisionFeature, shift,
                                                                     posMatrix, mat4(), pixelRatio,
                                                                     placedSymbol, scale, fontSize,
                                                                     allowOverlap,

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -305,9 +305,12 @@ void Placement::placeBucket(
                     }
                 }
 
-                const bool doVariableIconPlacement = hasIconTextFit && !iconAllowOverlap && symbolInstance.placedIconIndex;
+                const bool doVariableIconPlacement =
+                    hasIconTextFit && !iconAllowOverlap && symbolInstance.placedIconIndex;
 
-                const auto placeFeatureForVariableAnchors = [&] (const CollisionFeature& collisionFeature, style::TextWritingModeType orientation, const CollisionFeature& iconCollisionFeature) {
+                const auto placeFeatureForVariableAnchors = [&](const CollisionFeature& collisionFeature,
+                                                                style::TextWritingModeType orientation,
+                                                                const CollisionFeature& iconCollisionFeature) {
                     const CollisionBox& textBox = collisionFeature.boxes[0];
                     const float width = textBox.x2 - textBox.x1;
                     const float height = textBox.y2 - textBox.y1;
@@ -333,9 +336,20 @@ void Placement::placeBucket(
                                                                     params.showCollisionBoxes, avoidEdges, collisionGroup.second, textBoxes);
 
                         if (doVariableIconPlacement) {
-                            auto placedIconFeature = collisionIndex.placeFeature(iconCollisionFeature, shift,
-                                    posMatrix, iconLabelPlaneMatrix, pixelRatio, placedSymbol, scale, fontSize, iconAllowOverlap, pitchWithMap,
-                                    params.showCollisionBoxes, avoidEdges, collisionGroup.second, iconBoxes);
+                            auto placedIconFeature = collisionIndex.placeFeature(iconCollisionFeature,
+                                                                                 shift,
+                                                                                 posMatrix,
+                                                                                 iconLabelPlaneMatrix,
+                                                                                 pixelRatio,
+                                                                                 placedSymbol,
+                                                                                 scale,
+                                                                                 fontSize,
+                                                                                 iconAllowOverlap,
+                                                                                 pitchWithMap,
+                                                                                 params.showCollisionBoxes,
+                                                                                 avoidEdges,
+                                                                                 collisionGroup.second,
+                                                                                 iconBoxes);
                             iconBoxes.clear();
                             if (!placedIconFeature.first) continue;
                         }
@@ -377,13 +391,18 @@ void Placement::placeBucket(
                 };
 
                 const auto placeHorizontal = [&] {
-                    return placeFeatureForVariableAnchors(symbolInstance.textCollisionFeature, style::TextWritingModeType::Horizontal, symbolInstance.iconCollisionFeature);
+                    return placeFeatureForVariableAnchors(symbolInstance.textCollisionFeature,
+                                                          style::TextWritingModeType::Horizontal,
+                                                          symbolInstance.iconCollisionFeature);
                 };
 
                 const auto placeVertical = [&] {
                     if (bucket.allowVerticalPlacement && !placed.first && symbolInstance.verticalTextCollisionFeature) {
-                        return placeFeatureForVariableAnchors(*symbolInstance.verticalTextCollisionFeature, style::TextWritingModeType::Vertical,
-                                symbolInstance.verticalIconCollisionFeature ? *symbolInstance.verticalIconCollisionFeature : symbolInstance.iconCollisionFeature);
+                        return placeFeatureForVariableAnchors(*symbolInstance.verticalTextCollisionFeature,
+                                                              style::TextWritingModeType::Vertical,
+                                                              symbolInstance.verticalIconCollisionFeature
+                                                                  ? *symbolInstance.verticalIconCollisionFeature
+                                                                  : symbolInstance.iconCollisionFeature);
                     }
                     return std::pair<bool, bool>{false, false};
                 };


### PR DESCRIPTION
port https://github.com/mapbox/mapbox-gl-js/pull/8803/files

When deciding the placement position it was only checking whether there were text collisions. If there was an icon collision then it would hide the icon (and by default, the text with it) instead of trying a different position.

If icon-text-fit is used it now checks whether the icon fits before accepting a placement position.