### PR TITLE
[build] Only add mapbox-base if target is not set

### DIFF
--- a/next/CMakeLists.txt
+++ b/next/CMakeLists.txt
@@ -877,8 +877,10 @@ target_include_directories(
     PUBLIC ${MBGL_ROOT}/include
 )
 
-add_subdirectory(${PROJECT_SOURCE_DIR}/vendor/mapbox-base/mapbox)
-add_subdirectory(${PROJECT_SOURCE_DIR}/vendor/mapbox-base/extras)
+if(NOT TARGET mapbox-base)
+    add_subdirectory(${PROJECT_SOURCE_DIR}/vendor/mapbox-base/mapbox)
+    add_subdirectory(${PROJECT_SOURCE_DIR}/vendor/mapbox-base/extras)
+endif(NOT TARGET mapbox-base)
 
 include(${PROJECT_SOURCE_DIR}/vendor/boost.cmake)
 include(${PROJECT_SOURCE_DIR}/vendor/earcut.hpp.cmake)


### PR DESCRIPTION
Prevents `mapbox-base` from being re-added if target already exists.