### PR TITLE
[build] Bump CI docker image

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -183,7 +183,7 @@ executors:
   ubuntu-disco:
     docker:
       # FIXME: Move the image to mbgl/
-      - image: tmpsantos/mbgl_ci:1.5
+      - image: tmpsantos/mbgl_ci:1.6
     resource_class: xlarge
     working_directory: /src
     environment:

--- a/scripts/ci/Dockerfile
+++ b/scripts/ci/Dockerfile
@@ -40,7 +40,7 @@ RUN set -eu && apt-get install -y \
     software-properties-common \
     xvfb
 
-RUN pip3 install cmake_format
+RUN pip3 install cmake-format==0.5.5
 
 # Linux dependencies
 RUN set -eu && apt-get install -y \
@@ -102,6 +102,12 @@ RUN set -eu \
         "extras;google;m2repository" \
         "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2" \
         "cmake;3.10.2.4988404"
+
+# Install gcloud for Firebase testing
+RUN set -eu \
+    && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+    && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
+    && apt-get update -y && apt-get install google-cloud-sdk -y
 
 # Configure ccache
 RUN set -eu && /usr/sbin/update-ccache-symlinks


### PR DESCRIPTION
This version includes gcloud, needed to run android firebase tests.