### PR TITLE
MGLOfflinePackObserver

### DIFF
--- a/platform/darwin/src/MGLOfflinePack.h
+++ b/platform/darwin/src/MGLOfflinePack.h
@@ -8,6 +8,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const MGLInvalidOfflinePackException;
 
+@class MGLOfflinePack;
+
 /**
  The state an offline pack is currently in.
  */
@@ -95,6 +97,12 @@ typedef struct __attribute__((objc_boxable)) MGLOfflinePackProgress {
      */
     uint64_t maximumResourcesExpected;
 } MGLOfflinePackProgress;
+
+@protocol MGLOfflinePackObserver <NSObject>
+
+-(void)didUpdateStateForMGLOfflinePack:(MGLOfflinePack*)offlinePack;
+
+@end
 
 /**
  An `MGLOfflinePack` represents a collection of resources necessary for viewing
@@ -197,6 +205,15 @@ MGL_EXPORT
  come from the default notification center.
  */
 - (void)requestProgress;
+
+@end
+
+
+@interface MGLOfflinePack (Observers)
+
+-(void)addObserver:(id<MGLOfflinePackObserver>)observer;
+
+-(void)removeObserver:(id<MGLOfflinePackObserver>)observer;
 
 @end
 

--- a/platform/darwin/src/MGLOfflinePack_Private.h
+++ b/platform/darwin/src/MGLOfflinePack_Private.h
@@ -12,6 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithMBGLRegion:(mbgl::OfflineRegion *)region;
 
+- (void)requestProgressWithCompletionHandler:(void (^)())completion;
+
 /**
  Invalidates the pack and ensures that no future progress update can ever
  revalidate it. This method must be called before the pack is deallocated.

--- a/platform/darwin/src/MGLOfflineStorage.h
+++ b/platform/darwin/src/MGLOfflineStorage.h
@@ -469,6 +469,15 @@ MGL_EXPORT
      URLForResourceOfKind:(MGLResourceKind)kind
                   withURL:(NSURL *)url;
 
+@optional
+/**
+ Notifies about package reload
+
+ @param storage The storage object processing the reload.
+
+ */
+- (void)didReloadPackagesForOfflineStorage:(MGLOfflineStorage *)storage;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
The main issue for us is that we do not receive a callback on when the offline maps states are loaded.
When referencing `[MGLOfflineStorage sharedOfflineStorage]` for the first time it calls internally `reloadPacks` method witch is asynchronous with no callback. 
I know that we can observer the packages by KVO and the for all packages we can request `refreshProgress` and then once again observer with KVO the state but synchronising it all is problematic and without proper memory management and removal of kvo observers it will crush. 

I have made a pull request that extends the `MGLOfflineStorageDelegate` with an optional method `- (void)didReloadPackagesForOfflineStorage:(MGLOfflineStorage *)storage;` that should inform clearly what was loaded. 
