### PR TITLE
[core] avoid edges for labels that use text-variable-anchors

### DIFF
--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -164,12 +164,12 @@ void Placement::placeBucket(
     auto partiallyEvaluatedIconSize = bucket.iconSizeBinder->evaluateForZoom(state.getZoom());
 
     optional<CollisionTileBoundaries> avoidEdges;
-    if (mapMode == MapMode::Tile &&
-        (layout.get<style::SymbolAvoidEdges>() ||
-         layout.get<style::SymbolPlacement>() == style::SymbolPlacementType::Line)) {
+    if (mapMode == MapMode::Tile && (layout.get<style::SymbolAvoidEdges>() ||
+                                     layout.get<style::SymbolPlacement>() == style::SymbolPlacementType::Line ||
+                                     !layout.get<style::TextVariableAnchor>().empty())) {
         avoidEdges = collisionIndex.projectTileBoundaries(posMatrix);
     }
-    
+
     const bool textAllowOverlap = layout.get<style::TextAllowOverlap>();
     const bool iconAllowOverlap = layout.get<style::IconAllowOverlap>();
     // This logic is similar to the "defaultOpacityState" logic below in updateBucketOpacities


### PR DESCRIPTION
to prevent clipped labels in rendered image tiles.

Fixes https://github.com/mapbox/mapbox-gl-native-team/issues/90