### PR TITLE
[core] Show tile collision and parser status when building Debug

### DIFF
--- a/render-test/runner.cpp
+++ b/render-test/runner.cpp
@@ -966,7 +966,11 @@ TestRunner::Impl::Impl(const TestMetadata& metadata)
               .withSize(metadata.size)
               .withPixelRatio(metadata.pixelRatio)
               .withCrossSourceCollisions(metadata.crossSourceCollisions),
-          mbgl::ResourceOptions().withCacheOnlyRequestsSupport(false)) {}
+          mbgl::ResourceOptions().withCacheOnlyRequestsSupport(false)) {
+#ifndef NDEBUG
+    map.setDebug(MapDebugOptions::NoDebug);
+#endif
+}
 
 TestRunner::Impl::~Impl() {}
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -30,11 +30,17 @@ Map::Map(RendererFrontend& frontend,
          MapObserver& observer,
          const MapOptions& mapOptions,
          const ResourceOptions& resourceOptions)
-    : impl(std::make_unique<Impl>(frontend, observer,
-                                  FileSource::getSharedFileSource(resourceOptions),
-                                  mapOptions)) {}
+    : impl(std::make_unique<Impl>(frontend, observer, FileSource::getSharedFileSource(resourceOptions), mapOptions)) {
+#ifndef NDEBUG
+    setDebug(MapDebugOptions::TileBorders | MapDebugOptions::ParseStatus);
+#endif
+}
 
-Map::Map(std::unique_ptr<Impl> impl_) : impl(std::move(impl_)) {}
+Map::Map(std::unique_ptr<Impl> impl_) : impl(std::move(impl_)) {
+#ifndef NDEBUG
+    setDebug(MapDebugOptions::TileBorders | MapDebugOptions::ParseStatus);
+#endif
+}
 
 Map::~Map() = default;
 


### PR DESCRIPTION
Have a visual clue that it is a debug build.