### PR TITLE
Use individual textures for line dash patterns

### DIFF
--- a/src/mbgl/geometry/line_atlas.cpp
+++ b/src/mbgl/geometry/line_atlas.cpp
@@ -1,50 +1,33 @@
 #include <mbgl/geometry/line_atlas.hpp>
 #include <mbgl/gfx/upload_pass.hpp>
+#include <mbgl/math/minmax.hpp>
+#include <mbgl/util/hash.hpp>
 #include <mbgl/util/logging.hpp>
 #include <mbgl/util/platform.hpp>
-#include <mbgl/util/hash.hpp>
 
 #include <cmath>
 
 namespace mbgl {
+namespace {
 
-LineAtlas::LineAtlas(const Size size)
-    : image(size),
-      dirty(true) {
-}
-
-LineAtlas::~LineAtlas() = default;
-
-LinePatternPos LineAtlas::getDashPosition(const std::vector<float>& dasharray,
-                                          LinePatternCap patternCap) {
-    size_t key = patternCap == LinePatternCap::Round ? std::numeric_limits<size_t>::min()
-                                                     : std::numeric_limits<size_t>::max();
+size_t getDashPatternHash(const std::vector<float>& dasharray, const LinePatternCap patternCap) {
+    size_t key =
+        patternCap == LinePatternCap::Round ? std::numeric_limits<size_t>::min() : std::numeric_limits<size_t>::max();
     for (const float part : dasharray) {
         util::hash_combine<float>(key, part);
     }
-
-    // Note: We're not handling hash collisions here.
-    const auto it = positions.find(key);
-    if (it == positions.end()) {
-        auto inserted = positions.emplace(key, addDash(dasharray, patternCap));
-        assert(inserted.second);
-        return inserted.first->second;
-    } else {
-        return it->second;
-    }
+    return key;
 }
 
-LinePatternPos LineAtlas::addDash(const std::vector<float>& dasharray, LinePatternCap patternCap) {
+LinePatternPos addDashPattern(AlphaImage& image,
+                              const int32_t yOffset,
+                              const std::vector<float>& dasharray,
+                              const LinePatternCap patternCap) {
     const uint8_t n = patternCap == LinePatternCap::Round ? 7 : 0;
-    const uint8_t dashheight = 2 * n + 1;
-    const uint8_t offset = 128;
+    constexpr const uint8_t offset = 128;
 
     if (dasharray.size() < 2) {
-        return LinePatternPos();
-    }
-
-    if (nextRow + dashheight > image.size.height) {
-        Log::Warning(Event::OpenGL, "line atlas bitmap overflow");
+        Log::Warning(Event::ParseStyle, "line dasharray requires at least two elements");
         return LinePatternPos();
     }
 
@@ -60,7 +43,7 @@ LinePatternPos LineAtlas::addDash(const std::vector<float>& dasharray, LinePatte
     bool oddLength = dasharray.size() % 2 == 1;
 
     for (int y = -n; y <= n; y++) {
-        int row = nextRow + n + y;
+        int row = yOffset + n + y;
         int index = image.size.width * row;
 
         float left = 0;
@@ -72,7 +55,6 @@ LinePatternPos LineAtlas::addDash(const std::vector<float>& dasharray, LinePatte
         }
 
         for (uint32_t x = 0; x < image.size.width; x++) {
-
             while (right < x / stretch) {
                 left = right;
                 if (partIndex >= dasharray.size()) {
@@ -111,37 +93,79 @@ LinePatternPos LineAtlas::addDash(const std::vector<float>& dasharray, LinePatte
     }
 
     LinePatternPos position;
-    position.y = (0.5 + nextRow + n) / image.size.height;
-    position.height = (2.0 * n) / image.size.height;
+    position.y = (0.5 + yOffset + n) / image.size.height;
+    position.height = (2.0 * n + 1) / image.size.height;
     position.width = length;
-
-    nextRow += dashheight;
-
-    dirty = true;
 
     return position;
 }
 
-Size LineAtlas::getSize() const {
-    return image.size;
+} // namespace
+
+DashPatternTexture::DashPatternTexture(const std::vector<float>& from_,
+                                       const std::vector<float>& to_,
+                                       const LinePatternCap cap) {
+    const bool patternsIdentical = from_ == to_;
+    const int32_t patternHeight = cap == LinePatternCap::Round ? 15 : 1;
+
+    AlphaImage image({256, static_cast<uint32_t>((patternsIdentical ? 1 : 2) * patternHeight)});
+
+    from = addDashPattern(image, 0, from_, cap);
+    to = patternsIdentical ? from : addDashPattern(image, patternHeight, to_, cap);
+
+    texture = std::move(image);
+}
+
+void DashPatternTexture::upload(gfx::UploadPass& uploadPass) {
+    if (texture.is<AlphaImage>()) {
+        texture = uploadPass.createTexture(texture.get<AlphaImage>());
+    }
+}
+
+gfx::TextureBinding DashPatternTexture::textureBinding() const {
+    // The texture needs to have been uploaded already.
+    assert(texture.is<gfx::Texture>());
+    return {texture.get<gfx::Texture>().getResource(),
+            gfx::TextureFilterType::Linear,
+            gfx::TextureMipMapType::No,
+            gfx::TextureWrapType::Repeat,
+            gfx::TextureWrapType::Clamp};
+}
+
+Size DashPatternTexture::getSize() const {
+    return texture.match([](const auto& obj) { return obj.size; });
+}
+
+LineAtlas::LineAtlas() = default;
+
+LineAtlas::~LineAtlas() = default;
+
+DashPatternTexture& LineAtlas::getDashPatternTexture(const std::vector<float>& from,
+                                                     const std::vector<float>& to,
+                                                     const LinePatternCap cap) {
+    const size_t hash = util::hash(getDashPatternHash(from, cap), getDashPatternHash(to, cap));
+
+    // Note: We're not handling hash collisions here.
+    const auto it = textures.find(hash);
+    if (it == textures.end()) {
+        auto inserted = textures.emplace(
+            std::piecewise_construct, std::forward_as_tuple(hash), std::forward_as_tuple(from, to, cap));
+        assert(inserted.second);
+        needsUpload.emplace_back(hash);
+        return inserted.first->second;
+    } else {
+        return it->second;
+    }
 }
 
 void LineAtlas::upload(gfx::UploadPass& uploadPass) {
-    if (!texture) {
-        texture = uploadPass.createTexture(image);
-    } else if (dirty) {
-        uploadPass.updateTexture(*texture, image);
+    for (const size_t hash : needsUpload) {
+        const auto it = textures.find(hash);
+        if (it != textures.end()) {
+            it->second.upload(uploadPass);
+        }
     }
-
-    dirty = false;
-}
-
-gfx::TextureBinding LineAtlas::textureBinding() {
-    assert(texture);
-    // All _changes_ to the texture should've been made and uploaded already.
-    assert(!dirty);
-    return { texture->getResource(), gfx::TextureFilterType::Linear, gfx::TextureMipMapType::No,
-             gfx::TextureWrapType::Repeat, gfx::TextureWrapType::Clamp };
+    needsUpload.clear();
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -103,19 +103,17 @@ public:
 
 }  // namespace
 
-RenderOrchestrator::RenderOrchestrator(
-                     bool backgroundLayerAsColor_,
-                     optional<std::string> localFontFamily_)
-    : observer(&nullObserver())
-    , glyphManager(std::make_unique<GlyphManager>(std::make_unique<LocalGlyphRasterizer>(std::move(localFontFamily_))))
-    , imageManager(std::make_unique<ImageManager>())
-    , lineAtlas(std::make_unique<LineAtlas>(Size{ 256, 512 }))
-    , patternAtlas(std::make_unique<PatternAtlas>())
-    , imageImpls(makeMutable<std::vector<Immutable<style::Image::Impl>>>())
-    , sourceImpls(makeMutable<std::vector<Immutable<style::Source::Impl>>>())
-    , layerImpls(makeMutable<std::vector<Immutable<style::Layer::Impl>>>())
-    , renderLight(makeMutable<Light::Impl>())
-    , backgroundLayerAsColor(backgroundLayerAsColor_) {
+RenderOrchestrator::RenderOrchestrator(bool backgroundLayerAsColor_, optional<std::string> localFontFamily_)
+    : observer(&nullObserver()),
+      glyphManager(std::make_unique<GlyphManager>(std::make_unique<LocalGlyphRasterizer>(std::move(localFontFamily_)))),
+      imageManager(std::make_unique<ImageManager>()),
+      lineAtlas(std::make_unique<LineAtlas>()),
+      patternAtlas(std::make_unique<PatternAtlas>()),
+      imageImpls(makeMutable<std::vector<Immutable<style::Image::Impl>>>()),
+      sourceImpls(makeMutable<std::vector<Immutable<style::Source::Impl>>>()),
+      layerImpls(makeMutable<std::vector<Immutable<style::Layer::Impl>>>()),
+      renderLight(makeMutable<Light::Impl>()),
+      backgroundLayerAsColor(backgroundLayerAsColor_) {
     glyphManager->setObserver(this);
     imageManager->setObserver(this);
 }

--- a/test/geometry/line_atlas.test.cpp
+++ b/test/geometry/line_atlas.test.cpp
@@ -13,7 +13,7 @@ TEST(LineAtlas, Random) {
     std::normal_distribution<float> lengthDistribution(3, 5);
 
     for (size_t it = 0; it < 100; it++) {
-        LineAtlas atlas{ Size{ 128, 1024 } };
+        LineAtlas atlas;
         std::vector<float> dasharray;
         dasharray.reserve(8);
         for (size_t j = 0; j < 100; j++) {
@@ -25,7 +25,7 @@ TEST(LineAtlas, Random) {
             const LinePatternCap patternCap =
                 capStyleDistribution(generator) > 0 ? LinePatternCap::Round : LinePatternCap::Square;
 
-            atlas.addDash(dasharray, patternCap);
+            atlas.getDashPatternTexture(dasharray, dasharray, patternCap);
         }
     }
 }


### PR DESCRIPTION
This moves the LineAtlas from a shared texture that contained SDF dash patterns to use individual textures.

Previously, the texture space was limited to a texture of 512 pixels height. Dash patterns were never removed (and are still never removed as of this patch), which means that this texture could fill up for styles that use a lot of different dash patterns. In particular, dash patterns for lines with a round line cap take up 15 pixels of texture height, limiting the amount of unique dash patterns to 34. While this was probably enough for rendering a single style, we quickly exhausted this number when reusing the Map object to render different styles.

Instead of a global shared texture, we're now creating individual textures for every dash pattern. These textures are still cached so that we don't need to re-upload the texture on every frame.

There are a few changes that we could implement as well:

- We're currently putting 1 or 2 (for transitions) dash patterns into a texture and use texture coordinates to select the correct one. Instead, we could split this up into actual textures, pass two textures into the `line_sdf` shader, and bind both textures. This is would be useful because we currently hash on the dash patterns, and transitions between two dash patterns require the creation of a new unique texture.
- We don't have a strategy to eventually evict old/unused dash pattern textures, so they'll accumulate over time. This applies to a few other entities as well (e.g. glyphs).
- There are no tests that specifically test the removal of this limitation