### PR TITLE
[core] No pending requests for already requested images. 

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -4,6 +4,9 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 
 ## master
 
+### Bug fixes
+ - Fixed the rendering bug caused by redundant pending requests for already requested images [#15864](https://github.com/mapbox/mapbox-gl-native/pull/15864)
+
 ### Performance improvements
  - Enable incremental vacuum for the offline database in order to make data removal requests faster and to avoid the excessive disk space usage (creating a backup file on VACUUM call) [#15837](https://github.com/mapbox/mapbox-gl-native/pull/15837)
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -6,7 +6,8 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ### Other changes
 
-* Coalesce requests to the client for the same missing image ([#15778](https://github.com/mapbox/mapbox-gl-native/pull/15778))
+### Bug fixes
+* Fixed the rendering bug caused by redundant pending requests for already requested images [#15864](https://github.com/mapbox/mapbox-gl-native/pull/15864)
 * Enable incremental vacuum for the offline database in order to make data removal requests faster and to avoid the excessive disk space usage (creating a backup file on VACUUM call). ([#15837](https://github.com/mapbox/mapbox-gl-native/pull/15837))
 
 ## 5.5.0

--- a/src/mbgl/renderer/image_manager.cpp
+++ b/src/mbgl/renderer/image_manager.cpp
@@ -190,6 +190,7 @@ void ImageManager::checkMissingAndNotify(ImageRequestor& requestor, const ImageR
             auto existingRequestorsIt = requestedImages.find(missingImage);
             if (existingRequestorsIt != requestedImages.end()) { // Already asked client about this image.
                 std::set<ImageRequestor*>& existingRequestors = existingRequestorsIt->second;
+                // existingRequestors is empty if all the previous requestors are deleted.
                 if (!existingRequestors.empty() &&
                     (*existingRequestors.begin())
                         ->hasPendingRequest(missingImage)) { // Still waiting for the client response for this image.
@@ -200,6 +201,8 @@ void ImageManager::checkMissingAndNotify(ImageRequestor& requestor, const ImageR
                 // The request for this image has been already delivered
                 // to the client, so we do not treat it as pending.
                 existingRequestors.emplace(requestorPtr);
+                // TODO: we could `continue;` here, but we need to call `observer->onStyleImageMissing`,
+                // so that rendering is re-launched from the handler at Map::Impl.
             } else {
                 requestedImages[missingImage].emplace(requestorPtr);
                 requestor.addPendingRequest(missingImage);

--- a/src/mbgl/renderer/image_manager.cpp
+++ b/src/mbgl/renderer/image_manager.cpp
@@ -197,16 +197,13 @@ void ImageManager::checkMissingAndNotify(ImageRequestor& requestor, const ImageR
                     existingRequestors.emplace(requestorPtr);
                     continue;
                 }
-                // Unlike icons, pattern changes are not caught
-                // with style-diff meaning that the existing request
-                // could be from the previous style and we cannot
-                // coalesce requests for them.
-                if (dependency.second != ImageType::Pattern) {
-                    continue;
-                }
+                // The request for this image has been already delivered
+                // to the client, so we do not treat it as pending.
+                existingRequestors.emplace(requestorPtr);
+            } else {
+                requestedImages[missingImage].emplace(requestorPtr);
+                requestor.addPendingRequest(missingImage);
             }
-            requestedImages[missingImage].emplace(requestorPtr);
-            requestor.addPendingRequest(missingImage);
 
             auto removePendingRequests = [this, missingImage] {
                 auto existingRequest = requestedImages.find(missingImage);

--- a/src/mbgl/renderer/image_manager.hpp
+++ b/src/mbgl/renderer/image_manager.hpp
@@ -58,13 +58,7 @@ private:
     bool loaded = false;
 
     std::map<ImageRequestor*, ImageRequestPair> requestors;
-    using Callback = std::function<void()>;
-    using ActorCallback = Actor<Callback>;
-    struct MissingImageRequestPair {
-        ImageRequestPair pair;
-        std::map<std::string, std::unique_ptr<ActorCallback>> callbacks;
-    };
-    std::map<ImageRequestor*, MissingImageRequestPair> missingImageRequestors;
+    std::map<ImageRequestor*, ImageRequestPair> missingImageRequestors;
     std::map<std::string, std::set<ImageRequestor*>> requestedImages;
     std::size_t requestedImagesCacheSize = 0ul;
     ImageMap images;
@@ -77,8 +71,17 @@ public:
     explicit ImageRequestor(ImageManager&);
     virtual ~ImageRequestor();
     virtual void onImagesAvailable(ImageMap icons, ImageMap patterns, ImageVersionMap versionMap, uint64_t imageCorrelationID) = 0;
+
+    void addPendingRequest(const std::string& imageId) { pendingRequests.insert(imageId); }
+    bool hasPendingRequest(const std::string& imageId) const { return pendingRequests.count(imageId); }
+    bool hasPendingRequests() const { return !pendingRequests.empty(); }
+    void removePendingRequest(const std::string& imageId) { pendingRequests.erase(imageId); }
+
 private:
     ImageManager& imageManager;
+
+    // Pending requests are image requests that are waiting to be dispatched to the client.
+    std::set<std::string> pendingRequests;
 };
 
 } // namespace mbgl

--- a/test/renderer/image_manager.test.cpp
+++ b/test/renderer/image_manager.test.cpp
@@ -187,6 +187,30 @@ TEST(ImageManager, OnStyleImageMissingBeforeSpriteLoaded) {
     EXPECT_EQ(observer.count, 1);
     ASSERT_TRUE(notified);
 
+    // Repeated request of the same image shall not result another
+    // `ImageManagerObserver.onStyleImageMissing()` call.
+    imageManager.getImages(requestor, std::make_pair(dependencies, ++imageCorrelationID));
+    runLoop.runOnce();
+
+    EXPECT_EQ(observer.count, 1);
+
+    // Request for updated dependencies must be dispatched to the
+    // observer.
+    dependencies.emplace("post", ImageType::Icon);
+    imageManager.getImages(requestor, std::make_pair(dependencies, ++imageCorrelationID));
+    runLoop.runOnce();
+
+    EXPECT_EQ(observer.count, 2);
+
+    // Another requestor shall not have pending requests for already obtained images.
+    StubImageRequestor anotherRequestor(imageManager);
+    imageManager.getImages(anotherRequestor, std::make_pair(dependencies, ++imageCorrelationID));
+    ASSERT_FALSE(anotherRequestor.hasPendingRequests());
+
+    dependencies.emplace("unfamiliar", ImageType::Icon);
+    imageManager.getImages(anotherRequestor, std::make_pair(dependencies, ++imageCorrelationID));
+    EXPECT_TRUE(anotherRequestor.hasPendingRequests());
+    EXPECT_TRUE(anotherRequestor.hasPendingRequest("unfamiliar"));
 }
 
 TEST(ImageManager, OnStyleImageMissingAfterSpriteLoaded) {

--- a/test/renderer/image_manager.test.cpp
+++ b/test/renderer/image_manager.test.cpp
@@ -187,20 +187,14 @@ TEST(ImageManager, OnStyleImageMissingBeforeSpriteLoaded) {
     EXPECT_EQ(observer.count, 1);
     ASSERT_TRUE(notified);
 
-    // Repeated request of the same image shall not result another
-    // `ImageManagerObserver.onStyleImageMissing()` call.
-    imageManager.getImages(requestor, std::make_pair(dependencies, ++imageCorrelationID));
-    runLoop.runOnce();
-
-    EXPECT_EQ(observer.count, 1);
-
     // Request for updated dependencies must be dispatched to the
     // observer.
     dependencies.emplace("post", ImageType::Icon);
     imageManager.getImages(requestor, std::make_pair(dependencies, ++imageCorrelationID));
-    runLoop.runOnce();
+    ASSERT_TRUE(requestor.hasPendingRequests());
 
-    EXPECT_EQ(observer.count, 2);
+    runLoop.runOnce();
+    ASSERT_FALSE(requestor.hasPendingRequests());
 
     // Another requestor shall not have pending requests for already obtained images.
     StubImageRequestor anotherRequestor(imageManager);


### PR DESCRIPTION
This PR fixes https://github.com/mapbox/mapbox-gl-native/issues/15497 in a different way comparing to  the reverted https://github.com/mapbox/mapbox-gl-native/pull/15778: instead of coalescing requests we just do not treat requests for already requested images as pending (i.e. waiting to be dispatched to the client).

This is a safer approach, which obviates regressions like mapbox/api-gl#1404 (caused by the missing `rendererFrontend.update()` calls) - a dedicated unit test is added to verify the behavior.