### PR TITLE
 [android] Convert GeoJSON features to tiles in background

### DIFF
--- a/include/mbgl/style/sources/geojson_source.hpp
+++ b/include/mbgl/style/sources/geojson_source.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/style/expression/expression.hpp>
 #include <mbgl/style/source.hpp>
+#include <mbgl/tile/tile_id.hpp>
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/geojson.hpp>
 #include <mbgl/util/optional.hpp>
@@ -34,6 +35,20 @@ struct GeoJSONOptions {
     using ClusterProperties = std::unordered_map<std::string, ClusterExpression>;
     ClusterProperties clusterProperties;
 };
+class GeoJSONData {
+public:
+    static std::shared_ptr<GeoJSONData> create(const GeoJSON&, const GeoJSONOptions&);
+
+    virtual ~GeoJSONData() = default;
+    virtual mapbox::feature::feature_collection<int16_t> getTile(const CanonicalTileID&) = 0;
+
+    // SuperclusterData
+    virtual mapbox::feature::feature_collection<double> getChildren(const std::uint32_t) = 0;
+    virtual mapbox::feature::feature_collection<double> getLeaves(const std::uint32_t,
+                                                                  const std::uint32_t limit = 10u,
+                                                                  const std::uint32_t offset = 0u) = 0;
+    virtual std::uint8_t getClusterExpansionZoom(std::uint32_t) = 0;
+};
 
 class GeoJSONSource final : public Source {
 public:
@@ -42,6 +57,7 @@ public:
 
     void setURL(const std::string& url);
     void setGeoJSON(const GeoJSON&);
+    void setGeoJSONData(std::shared_ptr<GeoJSONData>);
 
     optional<std::string> getURL() const;
 

--- a/include/mbgl/style/sources/geojson_source.hpp
+++ b/include/mbgl/style/sources/geojson_source.hpp
@@ -60,6 +60,7 @@ public:
     void setGeoJSONData(std::shared_ptr<GeoJSONData>);
 
     optional<std::string> getURL() const;
+    const GeoJSONOptions& getOptions() const;
 
     class Impl;
     const Impl& impl() const;

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 
 ### Performance improvements
  - Enable incremental vacuum for the offline database in order to make data removal requests faster and to avoid the excessive disk space usage (creating a backup file on VACUUM call) [#15837](https://github.com/mapbox/mapbox-gl-native/pull/15837)
+ - Convert GeoJSON features to tiles in a background thread and thus unblock the UI thread on updating the GeoJsonSource [#15871](https://github.com/mapbox/mapbox-gl-native/pull/15871)
 
 ## 8.5.0-alpha.2 - October 10, 2019
 [Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.5.0-alpha.1...android-v8.5.0-alpha.2) since [Mapbox Maps SDK for Android v8.5.0-alpha.1](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.5.0-alpha.1):

--- a/platform/android/src/style/sources/geojson_source.cpp
+++ b/platform/android/src/style/sources/geojson_source.cpp
@@ -44,18 +44,16 @@ namespace android {
     }
 
     GeoJSONSource::GeoJSONSource(jni::JNIEnv& env, const jni::String& sourceId, const jni::Object<>& options)
-        : Source(env, std::make_unique<mbgl::style::GeoJSONSource>(
-                jni::Make<std::string>(env, sourceId),
-                convertGeoJSONOptions(env, options)))
-        , converter(std::make_unique<Actor<FeatureConverter>>(Scheduler::GetBackground())) {
-    }
+        : Source(env,
+                 std::make_unique<mbgl::style::GeoJSONSource>(jni::Make<std::string>(env, sourceId),
+                                                              convertGeoJSONOptions(env, options))),
+          converter(std::make_unique<Actor<FeatureConverter>>(Scheduler::GetBackground(),
+                                                              source.as<style::GeoJSONSource>()->getOptions())) {}
 
-    GeoJSONSource::GeoJSONSource(jni::JNIEnv& env,
-                                 mbgl::style::Source& coreSource,
-                                 AndroidRendererFrontend& frontend)
-        : Source(env, coreSource, createJavaPeer(env), frontend)
-        , converter(std::make_unique<Actor<FeatureConverter>>(Scheduler::GetBackground())) {
-    }
+    GeoJSONSource::GeoJSONSource(jni::JNIEnv& env, mbgl::style::Source& coreSource, AndroidRendererFrontend& frontend)
+        : Source(env, coreSource, createJavaPeer(env), frontend),
+          converter(std::make_unique<Actor<FeatureConverter>>(Scheduler::GetBackground(),
+                                                              source.as<style::GeoJSONSource>()->getOptions())) {}
 
     GeoJSONSource::~GeoJSONSource() = default;
 
@@ -63,7 +61,7 @@ namespace android {
 
         std::shared_ptr<std::string> json = std::make_shared<std::string>(jni::Make<std::string>(env, jString));
 
-        Update::Converter converterFn = [this, json](ActorRef<Callback> _callback) {
+        Update::Converter converterFn = [this, json](ActorRef<GeoJSONDataCallback> _callback) {
             converter->self().invoke(&FeatureConverter::convertJson, json, _callback);
         };
 
@@ -84,11 +82,11 @@ namespace android {
 
     void GeoJSONSource::setURL(jni::JNIEnv& env, const jni::String& url) {
         // Update the core source
-        source.as<mbgl::style::GeoJSONSource>()->GeoJSONSource::setURL(jni::Make<std::string>(env, url));
+        source.as<style::GeoJSONSource>()->setURL(jni::Make<std::string>(env, url));
     }
 
     jni::Local<jni::String> GeoJSONSource::getURL(jni::JNIEnv& env) {
-        optional<std::string> url = source.as<mbgl::style::GeoJSONSource>()->GeoJSONSource::getURL();
+        optional<std::string> url = source.as<style::GeoJSONSource>()->getURL();
         return url ? jni::Make<jni::String>(env, *url) : jni::Local<jni::String>();
     }
 
@@ -166,7 +164,7 @@ namespace android {
         auto global = jni::NewGlobal<jni::EnvAttachingDeleter>(env, jObject);
         auto object = std::make_shared<decltype(global)>(std::move(global));
 
-        Update::Converter converterFn = [this, object](ActorRef<Callback> _callback) {
+        Update::Converter converterFn = [this, object](ActorRef<GeoJSONDataCallback> _callback) {
             converter->self().invoke(&FeatureConverter::convertObject<JNIType>, object, _callback);
         };
 
@@ -175,25 +173,23 @@ namespace android {
 
     void GeoJSONSource::setAsync(Update::Converter converterFn) {
         awaitingUpdate = std::make_unique<Update>(
-                std::move(converterFn),
-                std::make_unique<Actor<Callback>>(
-                        *Scheduler::GetCurrent(),
-                        [this](GeoJSON geoJSON) {
-                            // conversion from Java features to core ones finished
-                            android::UniqueEnv _env = android::AttachEnv();
+            std::move(converterFn),
+            std::make_unique<Actor<GeoJSONDataCallback>>(
+                *Scheduler::GetCurrent(), [this](std::shared_ptr<style::GeoJSONData> geoJSONData) {
+                    // conversion from Java features to core ones finished
+                    android::UniqueEnv _env = android::AttachEnv();
 
-                            // Update the core source
-                            source.as<mbgl::style::GeoJSONSource>()->GeoJSONSource::setGeoJSON(geoJSON);
+                    // Update the core source
+                    source.as<mbgl::style::GeoJSONSource>()->setGeoJSONData(std::move(geoJSONData));
 
-                            // if there is an awaiting update, execute it, otherwise, release resources
-                            if (awaitingUpdate) {
-                                update = std::move(awaitingUpdate);
-                                update->converterFn(update->callback->self());
-                            } else {
-                                update.reset();
-                            }
-                        })
-        );
+                    // if there is an awaiting update, execute it, otherwise, release resources
+                    if (awaitingUpdate) {
+                        update = std::move(awaitingUpdate);
+                        update->converterFn(update->callback->self());
+                    } else {
+                        update.reset();
+                    }
+                }));
 
         // If another update is running, wait
         if (update) {
@@ -230,12 +226,10 @@ namespace android {
         );
     }
 
-    void FeatureConverter::convertJson(std::shared_ptr<std::string> json,
-                                       ActorRef<Callback> callback) {
+    void FeatureConverter::convertJson(std::shared_ptr<std::string> json, ActorRef<GeoJSONDataCallback> callback) {
         using namespace mbgl::style::conversion;
 
         android::UniqueEnv _env = android::AttachEnv();
-
         // Convert the jni object
         Error error;
         optional<GeoJSON> converted = parseGeoJSON(*json, error);
@@ -243,23 +237,23 @@ namespace android {
             mbgl::Log::Error(mbgl::Event::JNI, "Error setting geo json: " + error.message);
             return;
         }
-
-        callback.invoke(&Callback::operator(), *converted);
+        callback.invoke(&GeoJSONDataCallback::operator(), style::GeoJSONData::create(*converted, options));
     }
 
     template <class JNIType>
-    void FeatureConverter::convertObject(std::shared_ptr<jni::Global<jni::Object<JNIType>, jni::EnvAttachingDeleter>> jObject, ActorRef<Callback> callback) {
+    void FeatureConverter::convertObject(
+        std::shared_ptr<jni::Global<jni::Object<JNIType>, jni::EnvAttachingDeleter>> jObject,
+        ActorRef<GeoJSONDataCallback> callback) {
         using namespace mbgl::android::geojson;
 
         android::UniqueEnv _env = android::AttachEnv();
         // Convert the jni object
         auto geometry = JNIType::convert(*_env, *jObject);
-        callback.invoke(&Callback::operator(), GeoJSON(geometry));
+        callback.invoke(&GeoJSONDataCallback::operator(), style::GeoJSONData::create(geometry, options));
     }
 
-    Update::Update(Converter _converterFn, std::unique_ptr<Actor<Callback>> _callback)
-            : converterFn(std::move(_converterFn))
-            , callback(std::move(_callback)) {}
+    Update::Update(Converter _converterFn, std::unique_ptr<Actor<GeoJSONDataCallback>> _callback)
+        : converterFn(std::move(_converterFn)), callback(std::move(_callback)) {}
 
 } // namespace android
 } // namespace mbgl

--- a/platform/android/src/style/sources/geojson_source.hpp
+++ b/platform/android/src/style/sources/geojson_source.hpp
@@ -11,22 +11,28 @@
 namespace mbgl {
 namespace android {
 
-using Callback = std::function<void (GeoJSON)>;
+using GeoJSONDataCallback = std::function<void(std::shared_ptr<style::GeoJSONData>)>;
 
-struct FeatureConverter {
-    void convertJson(std::shared_ptr<std::string>, ActorRef<Callback>);
+class FeatureConverter {
+public:
+    explicit FeatureConverter(style::GeoJSONOptions options_) : options(std::move(options_)) {}
+    void convertJson(std::shared_ptr<std::string>, ActorRef<GeoJSONDataCallback>);
 
     template <class JNIType>
-    void convertObject(std::shared_ptr<jni::Global<jni::Object<JNIType>, jni::EnvAttachingDeleter>>, ActorRef<Callback>);
+    void convertObject(std::shared_ptr<jni::Global<jni::Object<JNIType>, jni::EnvAttachingDeleter>>,
+                       ActorRef<GeoJSONDataCallback>);
+
+private:
+    style::GeoJSONOptions options;
 };
 
 struct Update {
-    using Converter = std::function<void (ActorRef<Callback>)>;
+    using Converter = std::function<void(ActorRef<GeoJSONDataCallback>)>;
     Converter converterFn;
 
-    std::unique_ptr<Actor<Callback>> callback;
+    std::unique_ptr<Actor<GeoJSONDataCallback>> callback;
 
-    Update(Converter, std::unique_ptr<Actor<Callback>>);
+    Update(Converter, std::unique_ptr<Actor<GeoJSONDataCallback>>);
 };
 
 class GeoJSONSource : public Source {

--- a/src/mbgl/style/sources/geojson_source.cpp
+++ b/src/mbgl/style/sources/geojson_source.cpp
@@ -45,6 +45,10 @@ optional<std::string> GeoJSONSource::getURL() const {
     return url;
 }
 
+const GeoJSONOptions& GeoJSONSource::getOptions() const {
+    return impl().getOptions();
+}
+
 void GeoJSONSource::loadDescription(FileSource& fileSource) {
     if (!url) {
         loaded = true;

--- a/src/mbgl/style/sources/geojson_source_impl.cpp
+++ b/src/mbgl/style/sources/geojson_source_impl.cpp
@@ -82,13 +82,8 @@ T evaluateFeature(const mapbox::feature::feature<double>& f,
     return T();
 }
 
-GeoJSONSource::Impl::Impl(std::string id_, optional<GeoJSONOptions> options_)
-    : Source::Impl(SourceType::GeoJSON, std::move(id_)) {
-    options = options_ ? std::move(*options_) : GeoJSONOptions{};
-}
-
-GeoJSONSource::Impl::Impl(const Impl& other, const GeoJSON& geoJSON)
-    : Source::Impl(other), options(other.options) {
+// static
+std::shared_ptr<GeoJSONData> GeoJSONData::create(const GeoJSON& geoJSON, const GeoJSONOptions& options) {
     constexpr double scale = util::EXTENT / util::tileSize;
     if (options.cluster && geoJSON.is<mapbox::feature::feature_collection<double>>() &&
         !geoJSON.get<mapbox::feature::feature_collection<double>>().empty()) {
@@ -116,18 +111,26 @@ GeoJSONSource::Impl::Impl(const Impl& other, const GeoJSON& geoJSON)
                 toReturn[p.first] = evaluateFeature<Value>(feature, p.second.second, accumulated);
             }
         };
-        data = std::make_shared<SuperclusterData>(
-            geoJSON.get<mapbox::feature::feature_collection<double>>(), clusterOptions);
-    } else {
-        mapbox::geojsonvt::Options vtOptions;
-        vtOptions.maxZoom = options.maxzoom;
-        vtOptions.extent = util::EXTENT;
-        vtOptions.buffer = ::round(scale * options.buffer);
-        vtOptions.tolerance = scale * options.tolerance;
-        vtOptions.lineMetrics = options.lineMetrics;
-        data = std::make_shared<GeoJSONVTData>(geoJSON, vtOptions);
+        return std::make_shared<SuperclusterData>(geoJSON.get<mapbox::feature::feature_collection<double>>(),
+                                                  clusterOptions);
     }
+
+    mapbox::geojsonvt::Options vtOptions;
+    vtOptions.maxZoom = options.maxzoom;
+    vtOptions.extent = util::EXTENT;
+    vtOptions.buffer = ::round(scale * options.buffer);
+    vtOptions.tolerance = scale * options.tolerance;
+    vtOptions.lineMetrics = options.lineMetrics;
+    return std::make_shared<GeoJSONVTData>(geoJSON, vtOptions);
 }
+
+GeoJSONSource::Impl::Impl(std::string id_, optional<GeoJSONOptions> options_)
+    : Source::Impl(SourceType::GeoJSON, std::move(id_)) {
+    options = options_ ? std::move(*options_) : GeoJSONOptions{};
+}
+
+GeoJSONSource::Impl::Impl(const GeoJSONSource::Impl& other, std::shared_ptr<GeoJSONData> data_)
+    : Source::Impl(other), options(other.options), data(std::move(data_)) {}
 
 GeoJSONSource::Impl::~Impl() = default;
 

--- a/src/mbgl/style/sources/geojson_source_impl.hpp
+++ b/src/mbgl/style/sources/geojson_source_impl.hpp
@@ -11,27 +11,15 @@ class CanonicalTileID;
 
 namespace style {
 
-class GeoJSONData {
-public:
-    virtual ~GeoJSONData() = default;
-    virtual mapbox::feature::feature_collection<int16_t> getTile(const CanonicalTileID&) = 0;
-
-    // SuperclusterData
-    virtual mapbox::feature::feature_collection<double> getChildren(const std::uint32_t) = 0;
-    virtual mapbox::feature::feature_collection<double> getLeaves(const std::uint32_t,
-                                                                   const std::uint32_t limit  = 10u,
-                                                                   const std::uint32_t offset = 0u) = 0;
-    virtual std::uint8_t getClusterExpansionZoom(std::uint32_t) = 0;
-};
-
 class GeoJSONSource::Impl : public Source::Impl {
 public:
     Impl(std::string id, optional<GeoJSONOptions>);
-    Impl(const GeoJSONSource::Impl&, const GeoJSON&);
+    Impl(const GeoJSONSource::Impl&, std::shared_ptr<GeoJSONData>);
     ~Impl() final;
 
     Range<uint8_t> getZoomRange() const;
     std::weak_ptr<GeoJSONData> getData() const;
+    const GeoJSONOptions& getOptions() const { return options; }
 
     optional<std::string> getAttribution() const final;
 


### PR DESCRIPTION
Composing tiles from the GeoJSON features is an expensive  operation that might block UI thread on updating the `GeoJsonSource`  with the new data.

This change moves tile composing to the background thread and thus  unblocks the UI thread.

Fixes: https://github.com/mapbox/mapbox-gl-native-team/issues/87
Tag: https://github.com/mapbox/mapbox-gl-native/issues/8484