### PR TITLE
[core] increase padding in CollisionIndex for MapMode::Tile

### DIFF
--- a/src/mbgl/text/collision_index.cpp
+++ b/src/mbgl/text/collision_index.cpp
@@ -22,10 +22,13 @@ namespace mbgl {
 // the viewport for collision detection so that the bulk of the changes
 // occur offscreen. Making this constant greater increases label
 // stability, but it's expensive.
-static const float viewportPadding = 100;
+static const float viewportPaddingDefault = 100;
+// Viewport padding must be much larger for static tiles to avoid clipped labels.
+static const float viewportPaddingForStaticTiles = 1024;
 
-CollisionIndex::CollisionIndex(const TransformState& transformState_)
+CollisionIndex::CollisionIndex(const TransformState& transformState_, const MapMode& mapMode)
     : transformState(transformState_)
+    , viewportPadding(mapMode == MapMode::Tile ? viewportPaddingForStaticTiles : viewportPaddingDefault)
     , collisionGrid(transformState.getSize().width + 2 * viewportPadding, transformState.getSize().height + 2 * viewportPadding, 25)
     , ignoredGrid(transformState.getSize().width + 2 * viewportPadding, transformState.getSize().height + 2 * viewportPadding, 25)
     , screenRightBoundary(transformState.getSize().width + viewportPadding)

--- a/src/mbgl/text/collision_index.cpp
+++ b/src/mbgl/text/collision_index.cpp
@@ -26,7 +26,7 @@ static const float viewportPaddingDefault = 100;
 // Viewport padding must be much larger for static tiles to avoid clipped labels.
 static const float viewportPaddingForStaticTiles = 1024;
 
-CollisionIndex::CollisionIndex(const TransformState& transformState_, const MapMode& mapMode)
+CollisionIndex::CollisionIndex(const TransformState& transformState_, MapMode& mapMode)
     : transformState(transformState_),
       viewportPadding(mapMode == MapMode::Tile ? viewportPaddingForStaticTiles : viewportPaddingDefault),
       collisionGrid(transformState.getSize().width + 2 * viewportPadding,

--- a/src/mbgl/text/collision_index.cpp
+++ b/src/mbgl/text/collision_index.cpp
@@ -27,18 +27,25 @@ static const float viewportPaddingDefault = 100;
 static const float viewportPaddingForStaticTiles = 1024;
 
 CollisionIndex::CollisionIndex(const TransformState& transformState_, const MapMode& mapMode)
-    : transformState(transformState_)
-    , viewportPadding(mapMode == MapMode::Tile ? viewportPaddingForStaticTiles : viewportPaddingDefault)
-    , collisionGrid(transformState.getSize().width + 2 * viewportPadding, transformState.getSize().height + 2 * viewportPadding, 25)
-    , ignoredGrid(transformState.getSize().width + 2 * viewportPadding, transformState.getSize().height + 2 * viewportPadding, 25)
-    , screenRightBoundary(transformState.getSize().width + viewportPadding)
-    , screenBottomBoundary(transformState.getSize().height + viewportPadding)
-    , gridRightBoundary(transformState.getSize().width + 2 * viewportPadding)
-    , gridBottomBoundary(transformState.getSize().height + 2 * viewportPadding)
-    , pitchFactor(std::cos(transformState.getPitch()) * transformState.getCameraToCenterDistance())
-{}
+    : transformState(transformState_),
+      viewportPadding(mapMode == MapMode::Tile ? viewportPaddingForStaticTiles : viewportPaddingDefault),
+      collisionGrid(transformState.getSize().width + 2 * viewportPadding,
+                    transformState.getSize().height + 2 * viewportPadding,
+                    25),
+      ignoredGrid(transformState.getSize().width + 2 * viewportPadding,
+                  transformState.getSize().height + 2 * viewportPadding,
+                  25),
+      screenRightBoundary(transformState.getSize().width + viewportPadding),
+      screenBottomBoundary(transformState.getSize().height + viewportPadding),
+      gridRightBoundary(transformState.getSize().width + 2 * viewportPadding),
+      gridBottomBoundary(transformState.getSize().height + 2 * viewportPadding),
+      pitchFactor(std::cos(transformState.getPitch()) * transformState.getCameraToCenterDistance()) {}
 
-float CollisionIndex::approximateTileDistance(const TileDistance& tileDistance, const float lastSegmentAngle, const float pixelsToTileUnits, const float cameraToAnchorDistance, const bool pitchWithMap) {
+float CollisionIndex::approximateTileDistance(const TileDistance& tileDistance,
+                                              const float lastSegmentAngle,
+                                              const float pixelsToTileUnits,
+                                              const float cameraToAnchorDistance,
+                                              const bool pitchWithMap) {
     // This is a quick and dirty solution for chosing which collision circles to use (since collision circles are
     // laid out in tile units). Ideally, I think we should generate collision circles on the fly in viewport coordinates
     // at the time we do collision detection.

--- a/src/mbgl/text/collision_index.hpp
+++ b/src/mbgl/text/collision_index.hpp
@@ -20,7 +20,7 @@ class CollisionIndex {
 public:
     using CollisionGrid = GridIndex<IndexedSubfeature>;
 
-    explicit CollisionIndex(const TransformState&);
+    explicit CollisionIndex(const TransformState&, const MapMode&);
 
     std::pair<bool,bool> placeFeature(const CollisionFeature& feature,
                                       Point<float> shift,
@@ -72,6 +72,7 @@ private:
 
     const TransformState transformState;
 
+    const float viewportPadding;
     CollisionGrid collisionGrid;
     CollisionGrid ignoredGrid;
     

--- a/src/mbgl/text/collision_index.hpp
+++ b/src/mbgl/text/collision_index.hpp
@@ -20,7 +20,7 @@ class CollisionIndex {
 public:
     using CollisionGrid = GridIndex<IndexedSubfeature>;
 
-    explicit CollisionIndex(const TransformState&, const MapMode&);
+    explicit CollisionIndex(const TransformState&, MapMode&);
 
     std::pair<bool,bool> placeFeature(const CollisionFeature& feature,
                                       Point<float> shift,

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -95,7 +95,7 @@ Placement::Placement(const TransformState& state_,
                      style::TransitionOptions transitionOptions_,
                      const bool crossSourceCollisions,
                      optional<Immutable<Placement>> prevPlacement_)
-    : collisionIndex(state_),
+    : collisionIndex(state_, mapMode_),
       mapMode(mapMode_),
       transitionOptions(std::move(transitionOptions_)),
       placementZoom(state_.getZoom()),


### PR DESCRIPTION
When rendering image tiles using MapMode::Tile we need to avoid clipped labels at tile boundaries. Clipped labels happen when one tile decides a label can be shown and the other tile decides that it collides with something and needs to be hidden.

When rendering overscaled image tiles (rendering z17 image tiles for a vector tile source that only goes up to z16) we should use all the data from the tile instead of just the data that fits within the image tile.

This increases the padding to 1024 for MapMode::Tile which should be enough to completely include all the data two zoom levels past the data source's max zoom level. Beyond that, 1024 *should* be enough of a padding to make clipped labels unlikely.

An alternative would be to calculate the max zoom levels of all the sources used and dynamically set the padding on all sides but increasing the constant seems as good and less complex.