### PR TITLE
 [core] Parse GeoJSONSource description in background

### DIFF
--- a/include/mbgl/actor/scheduler.hpp
+++ b/include/mbgl/actor/scheduler.hpp
@@ -50,6 +50,18 @@ public:
     // first invoked, the call is ignored.
     std::function<void()> bindOnce(std::function<void()>);
 
+    // Enqueues the given |task| for execution into this scheduler's task queue and
+    // then enqueues the |reply| with the captured task result to the current
+    // task queue.
+    //
+    // The |TaskFn| return type must be compatible with the |ReplyFn| argument type.
+    // Note: the task result is copied and passed by value.
+    template <typename TaskFn, typename ReplyFn>
+    void scheduleAndReplyValue(const TaskFn& task, const ReplyFn& reply) {
+        assert(GetCurrent());
+        scheduleAndReplyValue(task, reply, GetCurrent()->makeWeakPtr());
+    }
+
     // Set/Get the current Scheduler for this thread
     static Scheduler* GetCurrent();
     static void SetCurrent(Scheduler*);
@@ -58,6 +70,21 @@ public:
     // will lazily initialize a shared worker pool when ran
     // from the first time.
     static std::shared_ptr<Scheduler> GetBackground();
+
+protected:
+    template <typename TaskFn, typename ReplyFn>
+    void scheduleAndReplyValue(const TaskFn& task,
+                               const ReplyFn& reply,
+                               mapbox::base::WeakPtr<Scheduler> replyScheduler) {
+        auto scheduled = [replyScheduler, task, reply] {
+            auto lock = replyScheduler.lock();
+            if (!replyScheduler) return;
+            auto scheduledReply = [reply, result = task()] { reply(result); };
+            replyScheduler->schedule(std::move(scheduledReply));
+        };
+
+        schedule(std::move(scheduled));
+    }
 };
 
 } // namespace mbgl

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 ### Performance improvements
  - Enable incremental vacuum for the offline database in order to make data removal requests faster and to avoid the excessive disk space usage (creating a backup file on VACUUM call) [#15837](https://github.com/mapbox/mapbox-gl-native/pull/15837)
  - Convert GeoJSON features to tiles in a background thread and thus unblock the UI thread on updating the GeoJsonSource [#15871](https://github.com/mapbox/mapbox-gl-native/pull/15871)
+ - Convert GeoJSON features to tiles for the loaded source description in a background thread and thus unblock the UI thread [#15885](https://github.com/mapbox/mapbox-gl-native/pull/15885)
 
 ## 8.5.0-alpha.2 - October 10, 2019
 [Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.5.0-alpha.1...android-v8.5.0-alpha.2) since [Mapbox Maps SDK for Android v8.5.0-alpha.1](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.5.0-alpha.1):

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 ## master
 
 ### Other changes
+* Convert GeoJSON features to tiles for the loaded source description in a background thread and thus unblock the UI thread ([#15885](https://github.com/mapbox/mapbox-gl-native/pull/15885))
 
 ### Bug fixes
 * Fixed the rendering bug caused by redundant pending requests for already requested images [#15864](https://github.com/mapbox/mapbox-gl-native/pull/15864)

--- a/src/mbgl/util/thread_pool.hpp
+++ b/src/mbgl/util/thread_pool.hpp
@@ -60,11 +60,11 @@ private:
     static_assert(N > 0, "Thread count must be more than zero.");
 };
 
-using SequencedScheduler = ThreadedScheduler<1>;
+class SequencedScheduler : public ThreadedScheduler<1> {};
 
 template <std::size_t extra>
 using ParallelScheduler = ThreadedScheduler<1 + extra>;
 
-using ThreadPool = ParallelScheduler<3>;
+class ThreadPool : public ParallelScheduler<3> {};
 
 } // namespace mbgl


### PR DESCRIPTION
Unblocks the UI thread on heavy GeoJSON tiles parsing operation.

The auxiliary `Scheduler::scheduleAndReplyValue` API and a unit test  have been added.

Fixes https://github.com/mapbox/mapbox-gl-native-team/issues/98
