### PR TITLE
Fix linking error in render-test

### DIFF
--- a/cmake/render-test.cmake
+++ b/cmake/render-test.cmake
@@ -3,6 +3,8 @@ add_executable(
     expression-test/test_runner_common.cpp
     expression-test/test_runner_common.hpp
     platform/default/src/mbgl/render-test/main.cpp
+    render-test/file_source.cpp
+    render-test/file_source.hpp
     render-test/allocation_index.cpp
     render-test/allocation_index.hpp
     render-test/filesystem.hpp


### PR DESCRIPTION
```
Undefined symbols for architecture x86_64:
  "mbgl::ProxyFileSource::getRequestCount()", referenced from:
      TestRunner::runOperations(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, TestMetadata&, RunContext&) in runner.cpp.o
  "mbgl::ProxyFileSource::isTrackingActive()", referenced from:
      TestRunner::runOperations(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, TestMetadata&, RunContext&) in runner.cpp.o
  "mbgl::ProxyFileSource::setTrackingActive(bool)", referenced from:
      TestRunner::runOperations(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, TestMetadata&, RunContext&) in runner.cpp.o
      TestRunner::run(TestMetadata&) in runner.cpp.o
  "mbgl::ProxyFileSource::getTransferredSize()", referenced from:
      TestRunner::runOperations(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, TestMetadata&, RunContext&) in runner.cpp.o
```

Fixes Debug build on OS X with clang-8

/cc @kkaefer @mapbox/gl-core 