### PR TITLE
Fix compile of render-test with clang-8

### DIFF
--- a/render-test/metadata.hpp
+++ b/render-test/metadata.hpp
@@ -100,14 +100,14 @@ struct GfxProbe {
     GfxProbe() = default;
     GfxProbe(const mbgl::gfx::RenderingStats&, const GfxProbe&);
 
-    int numDrawCalls;
-    int numTextures;
     int numBuffers;
+    int numDrawCalls;
     int numFrameBuffers;
+    int numTextures;
 
-    Memory memTextures;
     Memory memIndexBuffers;
     Memory memVertexBuffers;
+    Memory memTextures;
 };
 
 class TestMetrics {

--- a/render-test/runner.cpp
+++ b/render-test/runner.cpp
@@ -1035,7 +1035,8 @@ bool TestRunner::runOperations(const std::string& key, TestMetadata& metadata, R
 
         map.flyTo(mbgl::CameraOptions().withCenter(endPos).withZoom(endZoom), animationOptions);
 
-        for (; !transitionFinished; frames++) {
+        while (!transitionFinished) {
+            frames++;
             frontend.renderOnce(map);
             float frameTime = (float)frontend.getFrameTime();
             totalTime += frameTime;


### PR DESCRIPTION
This deals with two types of warnings which fail the build given the default `-Werror` flag.

### -Wfor-loop-analysis

```
../../render-test/runner.cpp:937:17: error: variable 'transitionFinished' used in loop condition not modified in loop body [-Werror,-Wfor-loop-analysis]
        for (; !transitionFinished; frames++) {
                ^~~~~~~~~~~~~~~~~~
```

### -Wreorder
```
../../render-test/runner.cpp:38:7: warning: field 'numBuffers' will be initialized after field 'numDrawCalls' [-Wreorder]
    : numBuffers(stats.numBuffers),
      ^
../../render-test/runner.cpp:40:7: warning: field 'numFrameBuffers' will be initialized after field 'numTextures' [-Wreorder]
      numFrameBuffers(stats.numFrameBuffers),
      ^
../../render-test/runner.cpp:43:7: warning: field 'memVertexBuffers' will be initialized after field 'memTextures' [-Wreorder]
      memVertexBuffers(stats.memVertexBuffers, std::max(stats.memVertexBuffers, prev.memVertexBuffers.peak)),
      ^
```