### PR TITLE
[core] Fix of incorrect resizing of TileCache

### DIFF
--- a/src/mbgl/tile/tile_cache.cpp
+++ b/src/mbgl/tile/tile_cache.cpp
@@ -8,7 +8,7 @@ void TileCache::setSize(size_t size_) {
 
     while (orderedKeys.size() > size) {
         auto key = orderedKeys.front();
-        orderedKeys.pop_front();
+        orderedKeys.remove(key);
         tiles.erase(key);
     }
 
@@ -21,7 +21,7 @@ void TileCache::add(const OverscaledTileID& key, std::unique_ptr<Tile> tile) {
     }
 
     // insert new or query existing tile
-    if (tiles.emplace(key, std::move(tile)).second) {
+    if (!tiles.emplace(key, std::move(tile)).second) {
         // remove existing tile key
         orderedKeys.remove(key);
     }

--- a/test/test-files.json
+++ b/test/test-files.json
@@ -79,6 +79,7 @@
         "test/tile/geometry_tile_data.test.cpp",
         "test/tile/raster_dem_tile.test.cpp",
         "test/tile/raster_tile.test.cpp",
+        "test/tile/tile_cache.test.cpp",
         "test/tile/tile_coordinate.test.cpp",
         "test/tile/tile_id.test.cpp",
         "test/tile/vector_tile.test.cpp",

--- a/test/tile/tile_cache.test.cpp
+++ b/test/tile/tile_cache.test.cpp
@@ -1,0 +1,90 @@
+#include <mbgl/test/util.hpp>
+
+#include <mbgl/tile/tile_cache.hpp>
+
+#include <mbgl/test/fake_file_source.hpp>
+#include <mbgl/tile/vector_tile.hpp>
+#include <mbgl/tile/vector_tile_data.hpp>
+#include <mbgl/tile/tile_loader_impl.hpp>
+
+#include <mbgl/util/run_loop.hpp>
+#include <mbgl/map/transform.hpp>
+#include <mbgl/style/style.hpp>
+#include <mbgl/style/layers/symbol_layer.hpp>
+#include <mbgl/renderer/tile_parameters.hpp>
+#include <mbgl/renderer/buckets/symbol_bucket.hpp>
+#include <mbgl/renderer/query.hpp>
+#include <mbgl/geometry/feature_index.hpp>
+#include <mbgl/annotation/annotation_manager.hpp>
+#include <mbgl/renderer/image_manager.hpp>
+#include <mbgl/text/glyph_manager.hpp>
+
+#include <memory>
+
+using namespace mbgl;
+
+class VectorTileTest {
+public:
+    std::shared_ptr<FileSource> fileSource = std::make_shared<FakeFileSource>();
+    TransformState transformState;
+    util::RunLoop loop;
+    style::Style style { *fileSource, 1 };
+    AnnotationManager annotationManager { style };
+    ImageManager imageManager;
+    GlyphManager glyphManager;
+    Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };
+
+    TileParameters tileParameters {
+        1.0,
+        MapDebugOptions(),
+        transformState,
+        fileSource,
+        MapMode::Continuous,
+        annotationManager,
+        imageManager,
+        glyphManager,
+        0
+    };
+};
+
+class VectorTileMock : public VectorTile {
+  public:
+      VectorTileMock(const OverscaledTileID & id,
+               std::string sourceID,
+               const TileParameters & parameters,
+               const Tileset & tileset) : VectorTile(id, sourceID, parameters, tileset)
+  { renderable = true; }
+};
+
+
+TEST(TileCache, Smoke) {
+    VectorTileTest test;
+    TileCache cache(1);
+    OverscaledTileID id(0,0,0);
+    std::unique_ptr<Tile> tile = std::make_unique<VectorTileMock>(id, "source", test.tileParameters, test.tileset);
+
+    cache.add(id, std::move(tile));
+    EXPECT_TRUE(cache.has(id));
+    cache.clear();
+    EXPECT_FALSE(cache.has(id));
+}
+
+
+TEST(TileCache, Issue15926) {
+    VectorTileTest test;
+    TileCache cache(2);
+    OverscaledTileID id0(0,0,0);
+    OverscaledTileID id1(1,0,0);
+    std::unique_ptr<Tile> tile1 = std::make_unique<VectorTileMock>(id0, "source", test.tileParameters, test.tileset);
+    std::unique_ptr<Tile> tile2 = std::make_unique<VectorTileMock>(id0, "source", test.tileParameters, test.tileset);
+    std::unique_ptr<Tile> tile3 = std::make_unique<VectorTileMock>(id1, "source", test.tileParameters, test.tileset);
+
+    cache.add(id0, std::move(tile1));
+    EXPECT_TRUE(cache.has(id0));
+    cache.add(id0, std::move(tile2));
+    cache.setSize(1);
+    cache.add(id1, std::move(tile3));
+    EXPECT_FALSE(cache.has(id0));
+    EXPECT_TRUE(cache.has(id1));
+}
+


### PR DESCRIPTION
In some case resizing TileCache we can give a assert check failed.
```Assertion failed: (orderedKeys.size() <= size), function add, file /Users/darkserj/sandbox/mapbox-gl-native/src/mbgl/tile/tile_cache.cpp, line 38.```

Fixes are remove all mentions the key from orderedKeys in case resizing and left only single mention the key at end of orderedKeys in case adding.

Fixes #15926