### PR TITLE
[build] Run Valgrind instead of Memory Sanitizer

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -73,13 +73,11 @@ workflows:
             - next-sanity-checks
           config_params: '-G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8 -DCMAKE_BUILD_TYPE=Sanitize -DMBGL_WITH_SANITIZER=thread'
       - next-build-template:
-          name: next-FIXME-linux-memsan
+          name: next-FIXME-linux-valgrind
           executor_name: ubuntu-disco
           target_is_linux: true
-          requires:
-            - next-sanity-checks
-          config_params: '-G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8 -DCMAKE_BUILD_TYPE=Sanitize -DMBGL_WITH_SANITIZER=memory'
-          test_params: '|| true'
+          config_params: '-G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8 -DCMAKE_CXX_FLAGS=-DSANITIZE'
+          test_params: '-j 4 -E "mbgl-node|gl-benchmark" -D ExperimentalMemCheck || true'
       - next-build-template:
           name: next-FIXME-linux-ubsan
           executor_name: ubuntu-disco
@@ -187,12 +185,11 @@ executors:
   ubuntu-disco:
     docker:
       # FIXME: Move the image to mbgl/
-      - image: tmpsantos/mbgl_ci:1.6
+      - image: tmpsantos/mbgl_ci:1.7
     resource_class: xlarge
     working_directory: /src
     environment:
       UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
-      MSAN_OPTIONS: poison_in_dtor=1
       ASAN_OPTIONS: strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1
       QT_INSTALL_DOCS: /usr/share/qt5/doc
       QT_VERSION: 5
@@ -217,6 +214,7 @@ commands:
           command: |
             git submodule sync
             git submodule update --init --recursive
+            git gc
             npm install --ignore-scripts
             ulimit -c unlimited
   next-prepare-macos:
@@ -251,7 +249,6 @@ commands:
             ccache --zero-stats --max-size=2G
             cmake --build build -j 8 << parameters.build_params >>
             ccache --show-stats
-            git gc
   next-save:
     steps:
       - save_cache:
@@ -264,14 +261,17 @@ commands:
             - ~/.gradle
       - run:
           name: Collecting artifacts
-          when: on_fail
           command: |
+            mkdir -p /tmp/tests/clang-tidy
+            if [ -f clang-tidy.log ]; then cp clang-tidy.log /tmp/tests/clang-tidy; fi
             mkdir -p /tmp/tests/render
             if [ -f render-test/tests_index.html ]; then cp render-test/tests_index.html /tmp/tests/render; fi
             if [ -f render-test/render-tests_index.html ]; then cp render-test/render-tests_index.html /tmp/tests/render; fi
             if [ -f render-test/query-tests_index.html ]; then cp render-test/query-tests_index.html /tmp/tests/render; fi
             mkdir -p /tmp/tests/coredumps
             if ls core* 1> /dev/null 2>&1; then cp core* /tmp/tests/coredumps; fi
+            mkdir -p /tmp/tests/valgrind
+            if ls build/Testing/Temporary/MemoryChecker.*.log 1> /dev/null 2>&1; then cp build/Testing/Temporary/MemoryChecker.*.log /tmp/tests/valgrind; fi
       - store_artifacts:
           path: /tmp/tests
           destination: tests
@@ -681,8 +681,6 @@ jobs:
           command: |
             run-clang-tidy-8 -quiet -j24 -p build $PWD/src/.*cpp $PWD/platform/.*cpp |tee clang-tidy.log
             grep -o \\[[a-z].*-.*[a-z]\] clang-tidy.log |sort |uniq -c |sort -n
-            mkdir -p /tmp/tests/clang-tidy
-            if [ -f clang-tidy.log ]; then cp clang-tidy.log /tmp/tests/clang-tidy; fi
       - next-save
   next-build-template:
     parameters:

--- a/next/CMakeLists.txt
+++ b/next/CMakeLists.txt
@@ -7,7 +7,12 @@ set(MBGL_ROOT ${PROJECT_SOURCE_DIR}/..)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER Core)
 
-enable_testing()
+set(
+    MEMORYCHECK_COMMAND_OPTIONS
+    "--leak-check=full --gen-suppressions=all --error-exitcode=1 --suppressions=${MBGL_ROOT}/scripts/valgrind.sup"
+)
+
+include(CTest)
 
 set(
     CMAKE_CONFIGURATION_TYPES

--- a/scripts/ci/Dockerfile
+++ b/scripts/ci/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /src
 COPY etc/apt/sources.list /etc/apt
 
 RUN set -eu \
-    && apt-get update\
+    && apt-get update \
     && apt-get dist-upgrade -y
 
 # CI requirements
@@ -38,6 +38,7 @@ RUN set -eu && apt-get install -y \
     pkg-config \
     python3-pip \
     software-properties-common \
+    valgrind \
     xvfb
 
 RUN pip3 install cmake-format==0.5.5

--- a/scripts/valgrind.sup
+++ b/scripts/valgrind.sup
@@ -1,5 +1,5 @@
 {
-   Graphics driver bugs
+   Valgrind x Mesa
    Memcheck:Cond
    ...
    obj:*/swrast_dri.*
@@ -8,71 +8,11 @@
    ...
 }
 {
-   Graphics driver bugs
+   Valgrind x Mesa
    Memcheck:Value8
    ...
    obj:*/swrast_dri.*
    obj:*/swrast_dri.*
    obj:*/swrast_dri.*
-   ...
-}
-{
-   Ubuntu 16.04 - Mysterious leak when running utests
-   Memcheck:Leak
-   fun:calloc
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-   obj:*
-}
-{
-   Qt5
-   Memcheck:Cond
-   ...
-   obj:*/libQt5Core.*
-   ...
-}
-{
-   Qt5
-   Memcheck:Value8
-   ...
-   obj:*/libQt5Core.*
-   ...
-}
-{
-   Qt5
-   Memcheck:Cond
-   ...
-   obj:*/libQt5Gui.*
-   ...
-}
-{
-   Qt5
-   Memcheck:Value8
-   ...
-   obj:*/libQt5Gui.*
-   ...
-}
-{
-   mapbox::pixelmatch
-   Memcheck:Cond
-   ...
-   fun:_ZN6mapbox10pixelmatchEPKhS1_mmPhdb
-   ...
-}
-{
-   util::write_file
-   Memcheck:Param
-   write(buf)
-   ...
-   obj:*/libc-*
-   fun:_ZN4mbgl4util10write_fileERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES8_
    ...
 }


### PR DESCRIPTION
Memory Sanitizer requires all the dependencies, including libstdc++ to be compiled with Memory Sanitizer, otherwise we will get tons of false positives.