### PR TITLE
[core] Remove default move operator for RenderTile

### DIFF
--- a/src/mbgl/renderer/render_tile.hpp
+++ b/src/mbgl/renderer/render_tile.hpp
@@ -34,7 +34,6 @@ public:
     RenderTile(const RenderTile&) = delete;
     RenderTile(RenderTile&&) = default;
     RenderTile& operator=(const RenderTile&) = delete;
-    RenderTile& operator=(RenderTile&&) = delete;
 
     UnwrappedTileID id;
     mat4 matrix;


### PR DESCRIPTION
**Problem**
Compile error occurs on MacOS Catalina (with Clang 11.0)

> In file included from mapbox-gl-native/src/mbgl/layout/symbol_projection.cpp:3:
> /Users/roman.kuznetsov/Dev/Projects/mapbox-vision/thirdparty/mapbox-gl-native/src/mbgl/renderer/render_tile.hpp:29:17: error: explicitly defaulted move assignment operator is implicitly deleted [-Werror,-Wdefaulted-function-deleted]
>    RenderTile& operator=(RenderTile&&) = default;
>                ^
> mapbox-gl-native/src/mbgl/renderer/render_tile.hpp:32:11: note: move assignment operator of ‘RenderTile’ is implicitly deleted because field ‘tile’ is of reference type ‘mbgl::Tile &’
>    Tile& tile;
>          ^
> 1 error generated.

**Reason**
As long as RenderTile contains reference to object (mbgl::Tile &) explicit default move operator can't exist.