### PR TITLE
[core] Calculate GeoJSON tile geometries in a background thread

### DIFF
--- a/include/mbgl/style/sources/geojson_source.hpp
+++ b/include/mbgl/style/sources/geojson_source.hpp
@@ -39,17 +39,19 @@ struct GeoJSONOptions {
 };
 class GeoJSONData {
 public:
+    using TileFeatures = mapbox::feature::feature_collection<int16_t>;
+    using Features = mapbox::feature::feature_collection<double>;
     static std::shared_ptr<GeoJSONData> create(const GeoJSON&,
                                                Immutable<GeoJSONOptions> = GeoJSONOptions::defaultOptions());
 
     virtual ~GeoJSONData() = default;
-    virtual mapbox::feature::feature_collection<int16_t> getTile(const CanonicalTileID&) = 0;
+    virtual void getTile(const CanonicalTileID&, const std::function<void(TileFeatures)>&) = 0;
 
     // SuperclusterData
-    virtual mapbox::feature::feature_collection<double> getChildren(const std::uint32_t) = 0;
-    virtual mapbox::feature::feature_collection<double> getLeaves(const std::uint32_t,
-                                                                  const std::uint32_t limit = 10u,
-                                                                  const std::uint32_t offset = 0u) = 0;
+    virtual Features getChildren(const std::uint32_t) = 0;
+    virtual Features getLeaves(const std::uint32_t,
+                               const std::uint32_t limit = 10u,
+                               const std::uint32_t offset = 0u) = 0;
     virtual std::uint8_t getClusterExpansionZoom(std::uint32_t) = 0;
 };
 

--- a/src/mbgl/renderer/sources/render_geojson_source.cpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.cpp
@@ -95,8 +95,7 @@ void RenderGeoJSONSource::update(Immutable<style::Source::Impl> baseImpl_,
             const uint8_t maxZ = impl().getZoomRange().max;
             for (const auto& pair : tilePyramid.getTiles()) {
                 if (pair.first.canonical.z <= maxZ) {
-                    static_cast<GeoJSONTile*>(pair.second.get())
-                        ->updateData(data_->getTile(pair.first.canonical), needsRelayout);
+                    static_cast<GeoJSONTile*>(pair.second.get())->updateData(data_, needsRelayout);
                 }
             }
         }
@@ -112,8 +111,8 @@ void RenderGeoJSONSource::update(Immutable<style::Source::Impl> baseImpl_,
                        util::tileSize,
                        impl().getZoomRange(),
                        optional<LatLngBounds>{},
-                       [&, data_] (const OverscaledTileID& tileID) {
-                           return std::make_unique<GeoJSONTile>(tileID, impl().id, parameters, data_->getTile(tileID.canonical));
+                       [&, data_](const OverscaledTileID& tileID) {
+                           return std::make_unique<GeoJSONTile>(tileID, impl().id, parameters, data_);
                        });
 }
 

--- a/src/mbgl/tile/geojson_tile.hpp
+++ b/src/mbgl/tile/geojson_tile.hpp
@@ -17,7 +17,7 @@ public:
                 const TileParameters&,
                 std::shared_ptr<style::GeoJSONData>);
 
-    void updateData(std::shared_ptr<style::GeoJSONData> data, bool resetLayers = false);
+    void updateData(std::shared_ptr<style::GeoJSONData> data, bool needsRelayout = false);
 
     void querySourceFeatures(
         std::vector<Feature>& result,

--- a/src/mbgl/tile/geojson_tile.hpp
+++ b/src/mbgl/tile/geojson_tile.hpp
@@ -4,6 +4,9 @@
 #include <mbgl/util/feature.hpp>
 
 namespace mbgl {
+namespace style {
+class GeoJSONData;
+} // namespace style
 
 class TileParameters;
 
@@ -12,13 +15,17 @@ public:
     GeoJSONTile(const OverscaledTileID&,
                 std::string sourceID,
                 const TileParameters&,
-                mapbox::feature::feature_collection<int16_t>);
+                std::shared_ptr<style::GeoJSONData>);
 
-    void updateData(mapbox::feature::feature_collection<int16_t>, bool resetLayers = false);
+    void updateData(std::shared_ptr<style::GeoJSONData> data, bool resetLayers = false);
 
     void querySourceFeatures(
         std::vector<Feature>& result,
         const SourceQueryOptions&) override;
+
+private:
+    std::shared_ptr<style::GeoJSONData> data;
+    mapbox::base::WeakPtrFactory<GeoJSONTile> weakFactory{this};
 };
 
 } // namespace mbgl

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -176,14 +176,23 @@ void GeometryTile::setError(std::exception_ptr err) {
     observer->onTileError(*this, err);
 }
 
-void GeometryTile::setData(std::unique_ptr<const GeometryTileData> data_, bool resetLayers) {
+void GeometryTile::setData(std::unique_ptr<const GeometryTileData> data_) {
     // Mark the tile as pending again if it was complete before to prevent signaling a complete
     // state despite pending parse operations.
     pending = true;
 
     ++correlationID;
     worker.self().invoke(
-        &GeometryTileWorker::setData, std::move(data_), imageManager.getAvailableImages(), resetLayers, correlationID);
+        &GeometryTileWorker::setData, std::move(data_), imageManager.getAvailableImages(), correlationID);
+}
+
+void GeometryTile::reset() {
+    // Mark the tile as pending again if it was complete before to prevent signaling a complete
+    // state despite pending parse operations.
+    pending = true;
+
+    ++correlationID;
+    worker.self().invoke(&GeometryTileWorker::reset, correlationID);
 }
 
 std::unique_ptr<TileRenderData> GeometryTile::createRenderData() {

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -34,7 +34,10 @@ public:
     ~GeometryTile() override;
 
     void setError(std::exception_ptr);
-    void setData(std::unique_ptr<const GeometryTileData>, bool resetLayers = false);
+    void setData(std::unique_ptr<const GeometryTileData>);
+    // Resets the tile's data and layers and leaves the tile in pending state, waiting for the new
+    // data and layers to come.
+    void reset();
 
     std::unique_ptr<TileRenderData> createRenderData() override;
     void setLayers(const std::vector<Immutable<style::LayerProperties>>&) override;

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -118,13 +118,11 @@ GeometryTileWorker::~GeometryTileWorker() = default;
 
 void GeometryTileWorker::setData(std::unique_ptr<const GeometryTileData> data_,
                                  std::set<std::string> availableImages_,
-                                 bool resetLayers_,
                                  uint64_t correlationID_) {
     try {
         data = std::move(data_);
         correlationID = correlationID_;
         availableImages = std::move(availableImages_);
-        if (resetLayers_) layers = nullopt;
 
         switch (state) {
         case Idle:
@@ -167,6 +165,22 @@ void GeometryTileWorker::setLayers(std::vector<Immutable<LayerProperties>> layer
         }
     } catch (...) {
         parent.invoke(&GeometryTile::onError, std::current_exception(), correlationID);
+    }
+}
+
+void GeometryTileWorker::reset(uint64_t correlationID_) {
+    layers = nullopt;
+    data = nullopt;
+    correlationID = correlationID_;
+
+    switch (state) {
+        case Idle:
+        case NeedsParse:
+            break;
+        case Coalescing:
+        case NeedsSymbolLayout:
+            state = NeedsParse;
+            break;
     }
 }
 

--- a/src/mbgl/tile/geometry_tile_worker.hpp
+++ b/src/mbgl/tile/geometry_tile_worker.hpp
@@ -43,8 +43,8 @@ public:
                    uint64_t correlationID);
     void setData(std::unique_ptr<const GeometryTileData>,
                  std::set<std::string> availableImages,
-                 bool resetLayers,
                  uint64_t correlationID);
+    void reset(uint64_t correlationID_);
     void setShowCollisionBoxes(bool showCollisionBoxes_, uint64_t correlationID_);
     
     void onGlyphsAvailable(GlyphMap glyphs);


### PR DESCRIPTION
Call `mapbox::geojsonvt::GeoJSONVT::getTile()` in a background thread, so that the rendering thread is not blocked.

**Before:**
![before](https://user-images.githubusercontent.com/998253/69340944-406dd900-0c71-11ea-905b-aa2434f5528b.gif)

**After:**

![after](https://user-images.githubusercontent.com/998253/69340976-55e30300-0c71-11ea-82ee-24cc3d0bbe1f.gif)

Fixes https://github.com/mapbox/mapbox-gl-native-team/issues/87