### PR TITLE
Bump OkHttp to v3.14.3

### DIFF
--- a/platform/android/gradle/dependencies.gradle
+++ b/platform/android/gradle/dependencies.gradle
@@ -23,7 +23,7 @@ ext {
             mockk           : '1.9.3',
             robolectric     : '4.3',
             timber          : '4.7.1',
-            okhttp          : '3.12.3',
+            okhttp          : '3.14.3',
             kotlin          : '1.3.41',
             licenses        : '0.8.5',
             bintray         : '1.8.4',


### PR DESCRIPTION
We've heard reports that match https://github.com/square/okhttp/issues/4583 which should be resolved in `3.14.3` (https://github.com/square/okhttp/pull/4650).