### PR TITLE
[test-runner] Add render test runner options for injecting probes

### DIFF
--- a/render-test/runner.hpp
+++ b/render-test/runner.hpp
@@ -15,7 +15,7 @@ struct TestMetadata;
 class TestRunner {
 public:
     explicit TestRunner(Manifest);
-    bool run(TestMetadata&);
+    bool run(TestMetadata&, const std::set<std::string>&);
     void reset();
 
     // Manifest
@@ -24,6 +24,9 @@ public:
 
 private:
     bool runOperations(const std::string& key, TestMetadata&, RunContext&);
+    bool runInjectedProbesBegin(TestMetadata&, const std::set<std::string>&, RunContext&);
+    bool runInjectedProbesEnd(TestMetadata&, const std::set<std::string>&, RunContext&, mbgl::gfx::RenderingStats);
+
     bool checkQueryTestResults(mbgl::PremultipliedImage&& actualImage,
                                std::vector<mbgl::Feature>&& features,
                                TestMetadata&);


### PR DESCRIPTION
This allows injection of memory, gfx and network probes before and after operations that are defined in render test are run.

Example: `./mbgl-render-test-runner --manifestPath=./render-test/linux-manifest.json --filter=text-field --probe=memory --probe=gfx --probe=network`

`UPDATE_METRICS=true` to update expected metrics

`UPDATE_METRICS=true ./mbgl-render-test-runner --manifestPath=./render-test/linux-manifest.json --filter=text-field --probe=memory --probe=gfx --probe=network`