### PR TITLE
[android] README update about work being moved to new repo

### DIFF
--- a/platform/android/README.md
+++ b/platform/android/README.md
@@ -1,3 +1,9 @@
+## Update
+
+**Work on the Mapbox Maps SDK for Android is now happening at https://github.com/mapbox/mapbox-gl-native-android. See https://github.com/mapbox/mapbox-gl-native/issues/15971 for more information.**
+
+The following information is retained for historical purposes but is no longer receiving updates. We make no guarantees about its accuracy.
+
 # [Mapbox Maps SDK for Android](https://www.mapbox.com/android-sdk/)
 
 [![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native/tree/master)

--- a/platform/ios/README.md
+++ b/platform/ios/README.md
@@ -1,3 +1,9 @@
+## Update
+
+**Work on the Mapbox Maps SDK for iOS is now happening at https://github.com/mapbox/mapbox-gl-native-ios. See https://github.com/mapbox/mapbox-gl-native/issues/15971 for more information.**
+
+The following information is retained for historical purposes but is no longer receiving updates. We make no guarantees about its accuracy.
+
 # [Mapbox Maps SDK for iOS](https://docs.mapbox.com/ios/maps/)
 
 [![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native/tree/master)


### PR DESCRIPTION
Per @samfader 's suggestion, this pr adds a blurb to this repo's Android README with a notice that our Maps SDK for Android work has been moved to https://github.com/mapbox/mapbox-gl-native-android