### PR TITLE
[build] Add an option to include platform specific implementation

### DIFF
--- a/next/CMakeLists.txt
+++ b/next/CMakeLists.txt
@@ -949,6 +949,10 @@ add_library(
     Mapbox::Map ALIAS mbgl-core
 )
 
+if(MBGL_WITH_PLATFORM_EXTRAS)
+    include(${MBGL_WITH_PLATFORM_EXTRAS})
+endif()
+
 if(MBGL_WITH_CORE_ONLY)
     return()
 elseif(MBGL_WITH_QT)


### PR DESCRIPTION
Add an option to include platform specific implementation sources
to `mbgl-core`.