### PR TITLE
[core] Clear tiles when GeoJSON data changes

### DIFF
--- a/src/mbgl/renderer/sources/render_geojson_source.cpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.cpp
@@ -85,26 +85,24 @@ void RenderGeoJSONSource::update(Immutable<style::Source::Impl> baseImpl_,
     enabled = needsRendering;
 
     auto data_ = impl().getData().lock();
-    if (!data_) {
-        // In Continuous mode, keep the existing tiles if the new data_ is not
-        // yet available, thus providing smart style transitions without flickering.
-        // In other modes, allow clearing the tile pyramid first, before the early
-        // return in order to avoid render tests being flaky.
-        if (parameters.mode != MapMode::Continuous) tilePyramid.clearAll();
-        return;
-    }
-
     if (data.lock() != data_) {
         data = data_;
-        tilePyramid.reduceMemoryUse();
-        const uint8_t maxZ = impl().getZoomRange().max;
-        for (const auto& pair : tilePyramid.getTiles()) {
-            if (pair.first.canonical.z <= maxZ) {
-                static_cast<GeoJSONTile*>(pair.second.get())
-                    ->updateData(data_->getTile(pair.first.canonical), needsRelayout);
+        if (parameters.mode != MapMode::Continuous) {
+            // Clearing the tile pyramid in order to avoid render tests being flaky.
+            tilePyramid.clearAll();
+        } else if (data_) {
+            tilePyramid.reduceMemoryUse();
+            const uint8_t maxZ = impl().getZoomRange().max;
+            for (const auto& pair : tilePyramid.getTiles()) {
+                if (pair.first.canonical.z <= maxZ) {
+                    static_cast<GeoJSONTile*>(pair.second.get())
+                        ->updateData(data_->getTile(pair.first.canonical), needsRelayout);
+                }
             }
         }
     }
+
+    if (!data_) return;
 
     tilePyramid.update(layers,
                        needsRendering,

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -63,16 +63,16 @@ public:
     ImageManager imageManager;
     GlyphManager glyphManager;
 
-    TileParameters tileParameters {
-        1.0,
-        MapDebugOptions(),
-        transformState,
-        fileSource,
-        MapMode::Continuous,
-        annotationManager,
-        imageManager,
-        glyphManager,
-        0
+    TileParameters tileParameters(MapMode mapMode = MapMode::Continuous) {
+        return {1.0,
+                MapDebugOptions(),
+                transformState,
+                fileSource,
+                mapMode,
+                annotationManager,
+                imageManager,
+                glyphManager,
+                0};
     };
 
     SourceTest() {
@@ -172,11 +172,7 @@ TEST(Source, RasterTileEmpty) {
 
     auto renderSource = RenderSource::create(source.baseImpl);
     renderSource->setObserver(&test.renderSourceObserver);
-    renderSource->update(source.baseImpl,
-                         layers,
-                         true,
-                         true,
-                         test.tileParameters);
+    renderSource->update(source.baseImpl, layers, true, true, test.tileParameters());
 
     test.run();
 }
@@ -211,11 +207,7 @@ TEST(Source, RasterDEMTileEmpty) {
 
     auto renderSource = RenderSource::create(source.baseImpl);
     renderSource->setObserver(&test.renderSourceObserver);
-    renderSource->update(source.baseImpl,
-                         layers,
-                         true,
-                         true,
-                         test.tileParameters);
+    renderSource->update(source.baseImpl, layers, true, true, test.tileParameters());
 
     test.run();
 }
@@ -252,11 +244,7 @@ TEST(Source, VectorTileEmpty) {
 
     auto renderSource = RenderSource::create(source.baseImpl);
     renderSource->setObserver(&test.renderSourceObserver);
-    renderSource->update(source.baseImpl,
-                         layers,
-                         true,
-                         true,
-                         test.tileParameters);
+    renderSource->update(source.baseImpl, layers, true, true, test.tileParameters());
 
     test.run();
 }
@@ -291,11 +279,7 @@ TEST(Source, RasterTileFail) {
 
     auto renderSource = RenderSource::create(source.baseImpl);
     renderSource->setObserver(&test.renderSourceObserver);
-    renderSource->update(source.baseImpl,
-                         layers,
-                         true,
-                         true,
-                         test.tileParameters);
+    renderSource->update(source.baseImpl, layers, true, true, test.tileParameters());
 
     test.run();
 }
@@ -330,11 +314,7 @@ TEST(Source, RasterDEMTileFail) {
 
     auto renderSource = RenderSource::create(source.baseImpl);
     renderSource->setObserver(&test.renderSourceObserver);
-    renderSource->update(source.baseImpl,
-                         layers,
-                         true,
-                         true,
-                         test.tileParameters);
+    renderSource->update(source.baseImpl, layers, true, true, test.tileParameters());
 
     test.run();
 }
@@ -371,11 +351,7 @@ TEST(Source, VectorTileFail) {
 
     auto renderSource = RenderSource::create(source.baseImpl);
     renderSource->setObserver(&test.renderSourceObserver);
-    renderSource->update(source.baseImpl,
-                         layers,
-                         true,
-                         true,
-                         test.tileParameters);
+    renderSource->update(source.baseImpl, layers, true, true, test.tileParameters());
 
     test.run();
 }
@@ -409,11 +385,7 @@ TEST(Source, RasterTileCorrupt) {
 
     auto renderSource = RenderSource::create(source.baseImpl);
     renderSource->setObserver(&test.renderSourceObserver);
-    renderSource->update(source.baseImpl,
-                         layers,
-                         true,
-                         true,
-                         test.tileParameters);
+    renderSource->update(source.baseImpl, layers, true, true, test.tileParameters());
 
     test.run();
 }
@@ -447,11 +419,7 @@ TEST(Source, RasterDEMTileCorrupt) {
 
     auto renderSource = RenderSource::create(source.baseImpl);
     renderSource->setObserver(&test.renderSourceObserver);
-    renderSource->update(source.baseImpl,
-                         layers,
-                         true,
-                         true,
-                         test.tileParameters);
+    renderSource->update(source.baseImpl, layers, true, true, test.tileParameters());
 
     test.run();
 }
@@ -486,11 +454,7 @@ TEST(Source, VectorTileCorrupt) {
 
     auto renderSource = RenderSource::create(source.baseImpl);
     renderSource->setObserver(&test.renderSourceObserver);
-    renderSource->update(source.baseImpl,
-                         layers,
-                         true,
-                         true,
-                         test.tileParameters);
+    renderSource->update(source.baseImpl, layers, true, true, test.tileParameters());
 
     test.run();
 }
@@ -523,11 +487,7 @@ TEST(Source, RasterTileCancel) {
 
     auto renderSource = RenderSource::create(source.baseImpl);
     renderSource->setObserver(&test.renderSourceObserver);
-    renderSource->update(source.baseImpl,
-                         layers,
-                         true,
-                         true,
-                         test.tileParameters);
+    renderSource->update(source.baseImpl, layers, true, true, test.tileParameters());
 
     test.run();
 }
@@ -560,11 +520,7 @@ TEST(Source, RasterDEMTileCancel) {
 
     auto renderSource = RenderSource::create(source.baseImpl);
     renderSource->setObserver(&test.renderSourceObserver);
-    renderSource->update(source.baseImpl,
-                         layers,
-                         true,
-                         true,
-                         test.tileParameters);
+    renderSource->update(source.baseImpl, layers, true, true, test.tileParameters());
 
     test.run();
 }
@@ -599,11 +555,7 @@ TEST(Source, VectorTileCancel) {
 
     auto renderSource = RenderSource::create(source.baseImpl);
     renderSource->setObserver(&test.renderSourceObserver);
-    renderSource->update(source.baseImpl,
-                         layers,
-                         true,
-                         true,
-                         test.tileParameters);
+    renderSource->update(source.baseImpl, layers, true, true, test.tileParameters());
 
     test.run();
 }
@@ -644,11 +596,7 @@ TEST(Source, RasterTileAttribution) {
     source.loadDescription(*test.fileSource);
 
     auto renderSource = RenderSource::create(source.baseImpl);
-    renderSource->update(source.baseImpl,
-                         layers,
-                         true,
-                         true,
-                         test.tileParameters);
+    renderSource->update(source.baseImpl, layers, true, true, test.tileParameters());
 
     test.run();
 }
@@ -687,11 +635,7 @@ TEST(Source, RasterDEMTileAttribution) {
     source.loadDescription(*test.fileSource);
 
     auto renderSource = RenderSource::create(source.baseImpl);
-    renderSource->update(source.baseImpl,
-                         layers,
-                         true,
-                         true,
-                         test.tileParameters);
+    renderSource->update(source.baseImpl, layers, true, true, test.tileParameters());
 
     test.run();
 }
@@ -783,11 +727,7 @@ TEST(Source, CustomGeometrySourceSetTileData) {
 
     auto renderSource = RenderSource::create(source.baseImpl);
     renderSource->setObserver(&test.renderSourceObserver);
-    renderSource->update(source.baseImpl,
-                         layers,
-                         true,
-                         true,
-                         test.tileParameters);
+    renderSource->update(source.baseImpl, layers, true, true, test.tileParameters());
 
     test.loop.invoke([&] () {
         // Set Tile Data
@@ -859,15 +799,15 @@ TEST(Source, InvisibleSourcesTileNecessity) {
         makeMutable<LineLayerProperties>(staticImmutableCast<LineLayer::Impl>(layer.baseImpl));
     std::vector<Immutable<LayerProperties>> layers{layerProperties};
     EXPECT_CALL(renderTilesetSource, tileSetNecessity(TileNecessity::Required)).Times(1);
-    renderSource->update(initialized.baseImpl, layers, true, true, test.tileParameters);
+    renderSource->update(initialized.baseImpl, layers, true, true, test.tileParameters());
 
     // Necessity for invisible tiles must be set to `optional`.
     EXPECT_CALL(renderTilesetSource, tileSetNecessity(TileNecessity::Optional)).Times(1);
-    renderSource->update(initialized.baseImpl, layers, false, false, test.tileParameters);
+    renderSource->update(initialized.baseImpl, layers, false, false, test.tileParameters());
 
     // Necessity is again `required` once tiles get back visible.
     EXPECT_CALL(renderTilesetSource, tileSetNecessity(TileNecessity::Required)).Times(1);
-    renderSource->update(initialized.baseImpl, layers, true, false, test.tileParameters);
+    renderSource->update(initialized.baseImpl, layers, true, false, test.tileParameters());
 }
 
 TEST(Source, RenderTileSetSourceUpdate) {
@@ -903,19 +843,20 @@ TEST(Source, RenderTileSetSourceUpdate) {
     // Check that `updateInternal()` is called even if the updated source has not yet loaded description.
     EXPECT_CALL(renderTilesetSource, mockedUpdateInternal()).Times(2);
     RenderSource* renderSource = &renderTilesetSource;
-    renderSource->update(initialized.baseImpl, layers, true, true, test.tileParameters);    
+    renderSource->update(initialized.baseImpl, layers, true, true, test.tileParameters());
 
     VectorSource uninitialized("source", "http://url");
-    renderSource->update(uninitialized.baseImpl, layers, true, true, test.tileParameters);
+    renderSource->update(uninitialized.baseImpl, layers, true, true, test.tileParameters());
 }
 
-TEST(Source, GeoJSONSourceTilesRemainAfterDataReset) {
+TEST(Source, GeoJSONSourceTilesAfterDataReset) {
     SourceTest test;
     GeoJSONSource source("source");
-    source.setGeoJSONData(GeoJSONData::create(
+    auto geoJSONData = GeoJSONData::create(
         mapbox::geojson::parse(
             R"({"geometry": {"type": "Point", "coordinates": [1.1, 1.1]}, "type": "Feature", "properties": {}})"),
-        {}));
+        {});
+    source.setGeoJSONData(geoJSONData);
     RenderGeoJSONSource renderSource{staticImmutableCast<GeoJSONSource::Impl>(source.baseImpl)};
 
     CircleLayer layer("id", "source");
@@ -923,10 +864,19 @@ TEST(Source, GeoJSONSourceTilesRemainAfterDataReset) {
         makeMutable<CircleLayerProperties>(staticImmutableCast<CircleLayer::Impl>(layer.baseImpl));
     std::vector<Immutable<LayerProperties>> layers{layerProperties};
 
-    static_cast<RenderSource&>(renderSource).update(source.baseImpl, layers, true, true, test.tileParameters);
+    static_cast<RenderSource&>(renderSource).update(source.baseImpl, layers, true, true, test.tileParameters());
     EXPECT_FALSE(renderSource.isLoaded()); // loaded == false, means that the source contains pending tiles.
 
     source.setGeoJSONData(nullptr);
-    static_cast<RenderSource&>(renderSource).update(source.baseImpl, layers, true, true, test.tileParameters);
-    EXPECT_FALSE(renderSource.isLoaded()); // Tiles remain.
+    static_cast<RenderSource&>(renderSource).update(source.baseImpl, layers, true, true, test.tileParameters());
+    EXPECT_FALSE(renderSource.isLoaded()); // Tiles remain in continous mode.
+
+    source.setGeoJSONData(geoJSONData);
+    static_cast<RenderSource&>(renderSource).update(source.baseImpl, layers, true, true, test.tileParameters());
+    EXPECT_FALSE(renderSource.isLoaded());
+
+    source.setGeoJSONData(nullptr);
+    static_cast<RenderSource&>(renderSource)
+        .update(source.baseImpl, layers, true, true, test.tileParameters(MapMode::Static));
+    EXPECT_TRUE(renderSource.isLoaded()); // Tiles are reset in static mode.
 }


### PR DESCRIPTION
In tile and static mode always clear tiles when data changes in order to avoid render tests being flaky.
https://circleci.com/gh/mapbox/mapbox-gl-native/374489?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link