### PR TITLE
Fix build

### DIFF
--- a/platform/qt/src/sqlite3.cpp
+++ b/platform/qt/src/sqlite3.cpp
@@ -13,6 +13,7 @@
 #include <cstdio>
 #include <chrono>
 #include <limits>
+#include <climits>
 
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/logging.hpp>


### PR DESCRIPTION
This file uses INT_MAX without expliciting include limits.h or climits,
relying on implicit inclusion through Qt headers. In Qt 6 one such
implicit inclusion is gone and so an explicit inclusion is required
here.