### PR TITLE
[render-test] Add support for measuring compressed file size

### DIFF
--- a/metrics/tests/binary-size/android-arm64-v8a/metrics.json
+++ b/metrics/tests/binary-size/android-arm64-v8a/metrics.json
@@ -3,7 +3,7 @@
         [
             "android-arm64-v8a",
             "/src/workspace/next-android-arm64-v8a-release/lib/libmapbox-gl.so",
-            4596040
+            1939896
         ]
     ]
 }

--- a/metrics/tests/binary-size/android-arm64-v8a/style.json
+++ b/metrics/tests/binary-size/android-arm64-v8a/style.json
@@ -3,7 +3,7 @@
   "metadata": {
     "test": {
       "operations": [
-        ["probeFileSize", "android-arm64-v8a", "/src/workspace/next-android-arm64-v8a-release/lib/libmapbox-gl.so", 0.01]
+        ["probeFileSize", "android-arm64-v8a", "/src/workspace/next-android-arm64-v8a-release/lib/libmapbox-gl.so", 0.01, "compressed"]
       ],
       "width": 64,
       "height": 64

--- a/metrics/tests/binary-size/android-armeabi-v7a/metrics.json
+++ b/metrics/tests/binary-size/android-armeabi-v7a/metrics.json
@@ -3,7 +3,7 @@
         [
             "android-armeabi-v7a",
             "/src/workspace/next-android-armeabi-v7a-release/lib/libmapbox-gl.so",
-            3072756
+            1607847
         ]
     ]
 }

--- a/metrics/tests/binary-size/android-armeabi-v7a/style.json
+++ b/metrics/tests/binary-size/android-armeabi-v7a/style.json
@@ -3,7 +3,7 @@
   "metadata": {
     "test": {
       "operations": [
-        ["probeFileSize", "android-armeabi-v7a", "/src/workspace/next-android-armeabi-v7a-release/lib/libmapbox-gl.so", 0.01]
+        ["probeFileSize", "android-armeabi-v7a", "/src/workspace/next-android-armeabi-v7a-release/lib/libmapbox-gl.so", 0.01, "compressed"]
       ],
       "width": 64,
       "height": 64

--- a/metrics/tests/binary-size/android-x86/metrics.json
+++ b/metrics/tests/binary-size/android-x86/metrics.json
@@ -3,7 +3,7 @@
         [
             "android-x86",
             "/src/workspace/next-android-x86-release/lib/libmapbox-gl.so",
-            4625176
+            1934186
         ]
     ]
 }

--- a/metrics/tests/binary-size/android-x86/style.json
+++ b/metrics/tests/binary-size/android-x86/style.json
@@ -3,7 +3,7 @@
   "metadata": {
     "test": {
       "operations": [
-        ["probeFileSize", "android-x86", "/src/workspace/next-android-x86-release/lib/libmapbox-gl.so", 0.01]
+        ["probeFileSize", "android-x86", "/src/workspace/next-android-x86-release/lib/libmapbox-gl.so", 0.01, "compressed"]
       ],
       "width": 64,
       "height": 64

--- a/metrics/tests/binary-size/android-x86_64/metrics.json
+++ b/metrics/tests/binary-size/android-x86_64/metrics.json
@@ -3,7 +3,7 @@
         [
             "android-x86_64",
             "/src/workspace/next-android-x86_64-release/lib/libmapbox-gl.so",
-            4874600
+            1982007
         ]
     ]
 }

--- a/metrics/tests/binary-size/android-x86_64/style.json
+++ b/metrics/tests/binary-size/android-x86_64/style.json
@@ -3,7 +3,7 @@
   "metadata": {
     "test": {
       "operations": [
-        ["probeFileSize", "android-x86_64", "/src/workspace/next-android-x86_64-release/lib/libmapbox-gl.so", 0.01]
+        ["probeFileSize", "android-x86_64", "/src/workspace/next-android-x86_64-release/lib/libmapbox-gl.so", 0.01, "compressed"]
       ],
       "width": 64,
       "height": 64

--- a/render-test/tests/file-size/pass-size-is-same/metrics.json
+++ b/render-test/tests/file-size/pass-size-is-same/metrics.json
@@ -6,9 +6,19 @@
             169
         ],
         [
+            "image-compressed",
+            "expected.png",
+            167
+        ],
+        [
             "style",
             "style.json",
-            516
+            674
+        ],
+        [
+            "style-compressed",
+            "style.json",
+            256
         ]
     ]
 }

--- a/render-test/tests/file-size/pass-size-is-same/style.json
+++ b/render-test/tests/file-size/pass-size-is-same/style.json
@@ -3,8 +3,10 @@
   "metadata": {
     "test": {
       "operations": [
+        ["probeFileSize", "image", "expected.png", 0],
+        ["probeFileSize", "image-compressed", "expected.png", 0, "compressed"],
         ["probeFileSize", "style", "style.json", 0],
-        ["probeFileSize", "image", "expected.png", 0]
+        ["probeFileSize", "style-compressed", "style.json", 0, "compressed"]
       ],
       "width": 64,
       "height": 64


### PR DESCRIPTION
Useful because for platform such as Android, we want to measure the size of the library inside the APK, which is usually compressed.