### PR TITLE
[core] Fix supercluster lambdas capturing

### DIFF
--- a/include/mbgl/style/sources/geojson_source.hpp
+++ b/include/mbgl/style/sources/geojson_source.hpp
@@ -34,10 +34,13 @@ struct GeoJSONOptions {
                                         std::shared_ptr<mbgl::style::expression::Expression>>;
     using ClusterProperties = std::unordered_map<std::string, ClusterExpression>;
     ClusterProperties clusterProperties;
+
+    static Immutable<GeoJSONOptions> defaultOptions();
 };
 class GeoJSONData {
 public:
-    static std::shared_ptr<GeoJSONData> create(const GeoJSON&, const GeoJSONOptions&);
+    static std::shared_ptr<GeoJSONData> create(const GeoJSON&,
+                                               Immutable<GeoJSONOptions> = GeoJSONOptions::defaultOptions());
 
     virtual ~GeoJSONData() = default;
     virtual mapbox::feature::feature_collection<int16_t> getTile(const CanonicalTileID&) = 0;
@@ -52,7 +55,7 @@ public:
 
 class GeoJSONSource final : public Source {
 public:
-    GeoJSONSource(const std::string& id, optional<GeoJSONOptions> = nullopt);
+    GeoJSONSource(std::string id, Immutable<GeoJSONOptions> = GeoJSONOptions::defaultOptions());
     ~GeoJSONSource() final;
 
     void setURL(const std::string& url);

--- a/platform/android/src/style/sources/geojson_source.hpp
+++ b/platform/android/src/style/sources/geojson_source.hpp
@@ -15,7 +15,7 @@ using GeoJSONDataCallback = std::function<void(std::shared_ptr<style::GeoJSONDat
 
 class FeatureConverter {
 public:
-    explicit FeatureConverter(style::GeoJSONOptions options_) : options(std::move(options_)) {}
+    explicit FeatureConverter(Immutable<style::GeoJSONOptions> options_) : options(std::move(options_)) {}
     void convertJson(std::shared_ptr<std::string>, ActorRef<GeoJSONDataCallback>);
 
     template <class JNIType>
@@ -23,7 +23,7 @@ public:
                        ActorRef<GeoJSONDataCallback>);
 
 private:
-    style::GeoJSONOptions options;
+    Immutable<style::GeoJSONOptions> options;
 };
 
 struct Update {

--- a/platform/darwin/src/MGLShapeSource.mm
+++ b/platform/darwin/src/MGLShapeSource.mm
@@ -27,15 +27,15 @@ const MGLShapeSourceOption MGLShapeSourceOptionMinimumZoomLevel = @"MGLShapeSour
 const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance = @"MGLShapeSourceOptionSimplificationTolerance";
 const MGLShapeSourceOption MGLShapeSourceOptionLineDistanceMetrics = @"MGLShapeSourceOptionLineDistanceMetrics";
 
-mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShapeSourceOption, id> *options) {
-    auto geoJSONOptions = mbgl::style::GeoJSONOptions();
+mbgl::Immutable<mbgl::style::GeoJSONOptions> MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShapeSourceOption, id> *options) {
+    auto geoJSONOptions = mbgl::makeMutable<mbgl::style::GeoJSONOptions>();
 
     if (NSNumber *value = options[MGLShapeSourceOptionMinimumZoomLevel]) {
         if (![value isKindOfClass:[NSNumber class]]) {
             [NSException raise:NSInvalidArgumentException
                         format:@"MGLShapeSourceOptionMaximumZoomLevel must be an NSNumber."];
         }
-        geoJSONOptions.minzoom = value.integerValue;
+        geoJSONOptions->minzoom = value.integerValue;
     }
 
     if (NSNumber *value = options[MGLShapeSourceOptionMaximumZoomLevel]) {
@@ -43,7 +43,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
             [NSException raise:NSInvalidArgumentException
                         format:@"MGLShapeSourceOptionMaximumZoomLevel must be an NSNumber."];
         }
-        geoJSONOptions.maxzoom = value.integerValue;
+        geoJSONOptions->maxzoom = value.integerValue;
     }
 
     if (NSNumber *value = options[MGLShapeSourceOptionBuffer]) {
@@ -51,7 +51,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
             [NSException raise:NSInvalidArgumentException
                         format:@"MGLShapeSourceOptionBuffer must be an NSNumber."];
         }
-        geoJSONOptions.buffer = value.integerValue;
+        geoJSONOptions->buffer = value.integerValue;
     }
 
     if (NSNumber *value = options[MGLShapeSourceOptionSimplificationTolerance]) {
@@ -59,7 +59,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
             [NSException raise:NSInvalidArgumentException
                         format:@"MGLShapeSourceOptionSimplificationTolerance must be an NSNumber."];
         }
-        geoJSONOptions.tolerance = value.doubleValue;
+        geoJSONOptions->tolerance = value.doubleValue;
     }
 
     if (NSNumber *value = options[MGLShapeSourceOptionClusterRadius]) {
@@ -67,7 +67,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
             [NSException raise:NSInvalidArgumentException
                         format:@"MGLShapeSourceOptionClusterRadius must be an NSNumber."];
         }
-        geoJSONOptions.clusterRadius = value.integerValue;
+        geoJSONOptions->clusterRadius = value.integerValue;
     }
 
     if (NSNumber *value = options[MGLShapeSourceOptionMaximumZoomLevelForClustering]) {
@@ -75,7 +75,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
             [NSException raise:NSInvalidArgumentException
                         format:@"MGLShapeSourceOptionMaximumZoomLevelForClustering must be an NSNumber."];
         }
-        geoJSONOptions.clusterMaxZoom = value.integerValue;
+        geoJSONOptions->clusterMaxZoom = value.integerValue;
     }
 
     if (NSNumber *value = options[MGLShapeSourceOptionClustered]) {
@@ -83,7 +83,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
             [NSException raise:NSInvalidArgumentException
                         format:@"MGLShapeSourceOptionClustered must be an NSNumber."];
         }
-        geoJSONOptions.cluster = value.boolValue;
+        geoJSONOptions->cluster = value.boolValue;
     }
 
     if (NSDictionary *value = options[MGLShapeSourceOptionClusterProperties]) {
@@ -133,7 +133,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
 
             std::string keyString = std::string([key UTF8String]);
 
-            geoJSONOptions.clusterProperties.emplace(keyString, std::make_pair(std::move(map), std::move(reduce)));
+            geoJSONOptions->clusterProperties.emplace(keyString, std::make_pair(std::move(map), std::move(reduce)));
         }
     }
 
@@ -142,7 +142,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
             [NSException raise:NSInvalidArgumentException
                         format:@"MGLShapeSourceOptionLineDistanceMetrics must be an NSNumber."];
         }
-        geoJSONOptions.lineMetrics = value.boolValue;
+        geoJSONOptions->lineMetrics = value.boolValue;
     }
 
     return geoJSONOptions;
@@ -159,7 +159,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
 
 - (instancetype)initWithIdentifier:(NSString *)identifier URL:(NSURL *)url options:(NSDictionary<NSString *, id> *)options {
     auto geoJSONOptions = MGLGeoJSONOptionsFromDictionary(options);
-    auto source = std::make_unique<mbgl::style::GeoJSONSource>(identifier.UTF8String, geoJSONOptions);
+    auto source = std::make_unique<mbgl::style::GeoJSONSource>(identifier.UTF8String, std::move(geoJSONOptions));
     if (self = [super initWithPendingSource:std::move(source)]) {
         self.URL = url;
     }
@@ -168,7 +168,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
 
 - (instancetype)initWithIdentifier:(NSString *)identifier shape:(nullable MGLShape *)shape options:(NSDictionary<MGLShapeSourceOption, id> *)options {
     auto geoJSONOptions = MGLGeoJSONOptionsFromDictionary(options);
-    auto source = std::make_unique<mbgl::style::GeoJSONSource>(identifier.UTF8String, geoJSONOptions);
+    auto source = std::make_unique<mbgl::style::GeoJSONSource>(identifier.UTF8String, std::move(geoJSONOptions));
     if (self = [super initWithPendingSource:std::move(source)]) {
         if ([shape isMemberOfClass:[MGLShapeCollection class]]) {
             static dispatch_once_t onceToken;

--- a/platform/darwin/src/MGLShapeSource_Private.h
+++ b/platform/darwin/src/MGLShapeSource_Private.h
@@ -1,6 +1,8 @@
 #import "MGLFoundation.h"
 #import "MGLShapeSource.h"
 
+#include <mbgl/util/immutable.hpp>
+
 NS_ASSUME_NONNULL_BEGIN
 
 namespace mbgl {
@@ -10,7 +12,7 @@ namespace mbgl {
 }
 
 MGL_EXPORT
-mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShapeSourceOption, id> *options);
+mbgl::Immutable<mbgl::style::GeoJSONOptions> MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShapeSourceOption, id> *options);
 
 @interface MGLShapeSource (Private)
 

--- a/platform/darwin/test/MGLShapeSourceTests.mm
+++ b/platform/darwin/test/MGLShapeSourceTests.mm
@@ -26,14 +26,14 @@
                               MGLShapeSourceOptionLineDistanceMetrics: @YES};
 
     auto mbglOptions = MGLGeoJSONOptionsFromDictionary(options);
-    XCTAssertTrue(mbglOptions.cluster);
-    XCTAssertEqual(mbglOptions.clusterRadius, 42);
-    XCTAssertEqual(mbglOptions.clusterMaxZoom, 98);
-    XCTAssertEqual(mbglOptions.maxzoom, 99);
-    XCTAssertEqual(mbglOptions.buffer, 1976);
-    XCTAssertEqual(mbglOptions.tolerance, 0.42);
-    XCTAssertTrue(mbglOptions.lineMetrics);
-    XCTAssertTrue(!mbglOptions.clusterProperties.empty());
+    XCTAssertTrue(mbglOptions->cluster);
+    XCTAssertEqual(mbglOptions->clusterRadius, 42);
+    XCTAssertEqual(mbglOptions->clusterMaxZoom, 98);
+    XCTAssertEqual(mbglOptions->maxzoom, 99);
+    XCTAssertEqual(mbglOptions->buffer, 1976);
+    XCTAssertEqual(mbglOptions->tolerance, 0.42);
+    XCTAssertTrue(mbglOptions->lineMetrics);
+    XCTAssertTrue(!mbglOptions->clusterProperties.empty());
 
     options = @{MGLShapeSourceOptionClustered: @"number 1"};
     XCTAssertThrows(MGLGeoJSONOptionsFromDictionary(options));

--- a/src/mbgl/style/conversion/source.cpp
+++ b/src/mbgl/style/conversion/source.cpp
@@ -116,12 +116,12 @@ static optional<std::unique_ptr<Source>> convertGeoJSONSource(const std::string&
         return nullopt;
     }
 
-    optional<GeoJSONOptions> options = convert<GeoJSONOptions>(value, error);
-    if (!options) {
-        return nullopt;
+    Immutable<GeoJSONOptions> options = GeoJSONOptions::defaultOptions();
+    if (optional<GeoJSONOptions> converted = convert<GeoJSONOptions>(value, error)) {
+        options = makeMutable<GeoJSONOptions>(std::move(*converted));
     }
 
-    auto result = std::make_unique<GeoJSONSource>(id, *options);
+    auto result = std::make_unique<GeoJSONSource>(id, std::move(options));
 
     if (isObject(*dataValue)) {
         optional<GeoJSON> geoJSON = convert<GeoJSON>(*dataValue, error);

--- a/src/mbgl/style/sources/geojson_source.cpp
+++ b/src/mbgl/style/sources/geojson_source.cpp
@@ -12,8 +12,14 @@
 namespace mbgl {
 namespace style {
 
-GeoJSONSource::GeoJSONSource(const std::string& id, optional<GeoJSONOptions> options)
-    : Source(makeMutable<Impl>(id, options)) {}
+// static
+Immutable<GeoJSONOptions> GeoJSONOptions::defaultOptions() {
+    static Immutable<GeoJSONOptions> options = makeMutable<GeoJSONOptions>();
+    return options;
+}
+
+GeoJSONSource::GeoJSONSource(std::string id, Immutable<GeoJSONOptions> options)
+    : Source(makeMutable<Impl>(std::move(id), std::move(options))) {}
 
 GeoJSONSource::~GeoJSONSource() = default;
 
@@ -47,7 +53,7 @@ optional<std::string> GeoJSONSource::getURL() const {
 }
 
 const GeoJSONOptions& GeoJSONSource::getOptions() const {
-    return impl().getOptions();
+    return *impl().getOptions();
 }
 
 void GeoJSONSource::loadDescription(FileSource& fileSource) {

--- a/src/mbgl/style/sources/geojson_source_impl.hpp
+++ b/src/mbgl/style/sources/geojson_source_impl.hpp
@@ -13,18 +13,18 @@ namespace style {
 
 class GeoJSONSource::Impl : public Source::Impl {
 public:
-    Impl(std::string id, optional<GeoJSONOptions>);
+    Impl(std::string id, Immutable<GeoJSONOptions>);
     Impl(const GeoJSONSource::Impl&, std::shared_ptr<GeoJSONData>);
     ~Impl() final;
 
     Range<uint8_t> getZoomRange() const;
     std::weak_ptr<GeoJSONData> getData() const;
-    const GeoJSONOptions& getOptions() const { return options; }
+    const Immutable<GeoJSONOptions>& getOptions() const { return options; }
 
     optional<std::string> getAttribution() const final;
 
 private:
-    GeoJSONOptions options;
+    Immutable<GeoJSONOptions> options;
     std::shared_ptr<GeoJSONData> data;
 };
 

--- a/test/api/query.test.cpp
+++ b/test/api/query.test.cpp
@@ -48,9 +48,9 @@ std::vector<Feature> getTopClusterFeature(QueryTest& test) {
     };
 
     LatLng coordinate{0, 0};
-    GeoJSONOptions options{};
-    options.cluster = true;
-    auto source = std::make_unique<GeoJSONSource>("cluster_source"s, options);
+    Mutable<GeoJSONOptions> options = makeMutable<GeoJSONOptions>();
+    options->cluster = true;
+    auto source = std::make_unique<GeoJSONSource>("cluster_source"s, std::move(options));
     source->setURL("http://url"s);
     source->loadDescription(*test.fileSource);
 

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -852,10 +852,8 @@ TEST(Source, RenderTileSetSourceUpdate) {
 TEST(Source, GeoJSONSourceTilesAfterDataReset) {
     SourceTest test;
     GeoJSONSource source("source");
-    auto geoJSONData = GeoJSONData::create(
-        mapbox::geojson::parse(
-            R"({"geometry": {"type": "Point", "coordinates": [1.1, 1.1]}, "type": "Feature", "properties": {}})"),
-        {});
+    auto geoJSONData = GeoJSONData::create(mapbox::geojson::parse(
+        R"({"geometry": {"type": "Point", "coordinates": [1.1, 1.1]}, "type": "Feature", "properties": {}})"));
     source.setGeoJSONData(geoJSONData);
     RenderGeoJSONSource renderSource{staticImmutableCast<GeoJSONSource::Impl>(source.baseImpl)};
 


### PR DESCRIPTION
- fix wrapping of the parameters in supercluster map/reduce lambdas (Previously, local variables were wrapped by reference).
- share the `GeoJSONOptions` instances using `Immutable<GeoJSONOptions>` - avoid extra copying
