### PR TITLE
[glfw] Fix map not resizing on Linux

### DIFF
--- a/platform/glfw/glfw_gl_backend.cpp
+++ b/platform/glfw/glfw_gl_backend.cpp
@@ -58,7 +58,7 @@ mbgl::gl::ProcAddress GLFWGLBackend::getExtensionFunctionPointer(const char* nam
 
 void GLFWGLBackend::updateAssumedState() {
     assumeFramebufferBinding(0);
-    assumeViewport(0, 0, size);
+    setViewport(0, 0, size);
 }
 
 mbgl::Size GLFWGLBackend::getSize() const {


### PR DESCRIPTION
Apparently GLFW is implicitly calling glViewport on macOS but not on Linux. Force setting the viewport instead of assuming a value.