### PR TITLE
[core] Retain thread pool in GeoJSONSource

### DIFF
--- a/include/mbgl/style/sources/geojson_source.hpp
+++ b/include/mbgl/style/sources/geojson_source.hpp
@@ -14,7 +14,7 @@
 namespace mbgl {
 
 class AsyncRequest;
-
+class Scheduler;
 namespace style {
 
 struct GeoJSONOptions {
@@ -81,6 +81,7 @@ public:
 private:
     optional<std::string> url;
     std::unique_ptr<AsyncRequest> req;
+    std::shared_ptr<Scheduler> threadPool;
     mapbox::base::WeakPtrFactory<Source> weakFactory {this};
 };
 

--- a/src/mbgl/style/sources/geojson_source.cpp
+++ b/src/mbgl/style/sources/geojson_source.cpp
@@ -19,7 +19,7 @@ Immutable<GeoJSONOptions> GeoJSONOptions::defaultOptions() {
 }
 
 GeoJSONSource::GeoJSONSource(std::string id, Immutable<GeoJSONOptions> options)
-    : Source(makeMutable<Impl>(std::move(id), std::move(options))) {}
+    : Source(makeMutable<Impl>(std::move(id), std::move(options))), threadPool(Scheduler::GetBackground()) {}
 
 GeoJSONSource::~GeoJSONSource() = default;
 
@@ -98,7 +98,7 @@ void GeoJSONSource::loadDescription(FileSource& fileSource) {
                 loaded = true;
                 observer->onSourceLoaded(*this);
             };
-            Scheduler::GetBackground()->scheduleAndReplyValue(makeImplInBackground, onImplReady);
+            threadPool->scheduleAndReplyValue(makeImplInBackground, onImplReady);
         }
     });
 }


### PR DESCRIPTION
Otherwise, the construction of the `Immutable<Source::Impl>` in background thread might never yeld.