### PR TITLE
Fix gcc9 compilation warning

### DIFF
--- a/platform/default/src/mbgl/storage/asset_file_source.cpp
+++ b/platform/default/src/mbgl/storage/asset_file_source.cpp
@@ -52,7 +52,7 @@ std::unique_ptr<AsyncRequest> AssetFileSource::request(const Resource& resource,
 
     impl->actor().invoke(&Impl::request, resource.url, req->actor());
 
-    return std::move(req);
+    return req;
 }
 
 bool AssetFileSource::canRequest(const Resource& resource) const {

--- a/platform/default/src/mbgl/storage/local_file_source.cpp
+++ b/platform/default/src/mbgl/storage/local_file_source.cpp
@@ -46,7 +46,7 @@ std::unique_ptr<AsyncRequest> LocalFileSource::request(const Resource& resource,
 
     impl->actor().invoke(&Impl::request, resource.url, req->actor());
 
-    return std::move(req);
+    return req;
 }
 
 bool LocalFileSource::canRequest(const Resource& resource) const {

--- a/platform/default/src/mbgl/storage/sqlite3.cpp
+++ b/platform/default/src/mbgl/storage/sqlite3.cpp
@@ -275,7 +275,7 @@ template <> void Query::bind(int offset, const char *value) {
 
 void Query::bind(int offset, const char * value, std::size_t length, bool retain) {
     assert(stmt.impl);
-    if (length > std::numeric_limits<int>::max()) {
+    if (length > static_cast<std::size_t>(std::numeric_limits<int>::max())) {
         throw std::range_error("value too long for sqlite3_bind_text");
     }
     stmt.impl->check(sqlite3_bind_text(stmt.impl->stmt, offset, value, int(length),
@@ -288,7 +288,7 @@ void Query::bind(int offset, const std::string& value, bool retain) {
 
 void Query::bindBlob(int offset, const void * value, std::size_t length, bool retain) {
     assert(stmt.impl);
-    if (length > std::numeric_limits<int>::max()) {
+    if (length > static_cast<std::size_t>(std::numeric_limits<int>::max())) {
         throw std::range_error("value too long for sqlite3_bind_text");
     }
     stmt.impl->check(sqlite3_bind_blob(stmt.impl->stmt, offset, value, int(length),

--- a/src/mbgl/gl/program.hpp
+++ b/src/mbgl/gl/program.hpp
@@ -74,7 +74,7 @@ public:
             };
             auto result = std::make_unique<Instance>(context, vertexSource, fragmentSource);
 
-            return std::move(result);
+            return result;
         }
 
         UniqueProgram program;

--- a/src/mbgl/gl/renderer_backend.cpp
+++ b/src/mbgl/gl/renderer_backend.cpp
@@ -17,8 +17,8 @@ std::unique_ptr<gfx::Context> RendererBackend::createContext() {
     result->enableDebugging();
     result->initializeExtensions(
             std::bind(&RendererBackend::getExtensionFunctionPointer, this, std::placeholders::_1));
-    // Needs move to placate GCC 4.9
-    return std::move(result);
+
+    return result;
 }
 
 PremultipliedImage RendererBackend::readFramebuffer(const Size& size) {

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -73,7 +73,7 @@ inline Immutable<style::SymbolLayoutProperties::PossiblyEvaluated> createLayout(
         layout->get<IconPitchAlignment>() = layout->get<IconRotationAlignment>();
     }
 
-    return std::move(layout);
+    return layout;
 }
 
 } // namespace

--- a/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
+++ b/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
@@ -109,7 +109,7 @@ void FillExtrusionBucket::addFeature(const GeometryTileFeature& feature, const G
 
                     const Point<double> perp = util::unit(util::perp(d1 - d2));
                     const auto dist = util::dist<int16_t>(d1, d2);
-                    if (edgeDistance + dist > std::numeric_limits<int16_t>::max()) {
+                    if (edgeDistance + dist > static_cast<std::size_t>(std::numeric_limits<int16_t>::max())) {
                         edgeDistance = 0;
                     }
 

--- a/src/mbgl/style/conversion/layer.cpp
+++ b/src/mbgl/style/conversion/layer.cpp
@@ -95,7 +95,7 @@ optional<std::unique_ptr<Layer>> Converter<std::unique_ptr<Layer>>::operator()(c
         return nullopt;
     }
 
-    return std::move(layer);
+    return layer;
 }
 
 } // namespace conversion


### PR DESCRIPTION
Gcc9 complains about std::move usage and signess inconsistency of comparison