### PR TITLE
[core] Move logic from Map::cycleDebugOptions to GLFW example app

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -120,7 +120,6 @@ public:
 
     // Debug
     void setDebug(MapDebugOptions);
-    void cycleDebugOptions();
     MapDebugOptions getDebug() const;
 
     bool isFullyLoaded() const;

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -595,10 +595,6 @@ void NativeMapView::setDebug(JNIEnv&, jni::jboolean debug) {
     map->setDebug(debugOptions);
 }
 
-void NativeMapView::cycleDebugOptions(JNIEnv&) {
-    map->cycleDebugOptions();
-}
-
 jni::jboolean NativeMapView::getDebug(JNIEnv&) {
     return map->getDebug() != DebugOptions::NoDebug;
 }
@@ -1120,7 +1116,6 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
         METHOD(&NativeMapView::updateMarker, "nativeUpdateMarker"),
         METHOD(&NativeMapView::addMarkers, "nativeAddMarkers"),
         METHOD(&NativeMapView::setDebug, "nativeSetDebug"),
-        METHOD(&NativeMapView::cycleDebugOptions, "nativeCycleDebugOptions"),
         METHOD(&NativeMapView::getDebug, "nativeGetDebug"),
         METHOD(&NativeMapView::isFullyLoaded, "nativeIsFullyLoaded"),
         METHOD(&NativeMapView::onLowMemory, "nativeOnLowMemory"),

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -151,8 +151,6 @@ public:
 
     void setDebug(JNIEnv&, jni::jboolean);
 
-    void cycleDebugOptions(JNIEnv&);
-
     jni::jboolean getDebug(JNIEnv&);
 
     jni::jboolean isFullyLoaded(JNIEnv&);

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -180,7 +180,7 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
             glfwSetWindowShouldClose(window, true);
             break;
         case GLFW_KEY_TAB:
-            view->map->cycleDebugOptions();
+            view->cycleDebugOptions();
             break;
         case GLFW_KEY_X:
             if (!mods)
@@ -494,6 +494,30 @@ void GLFWView::updateAnimatedAnnotations() {
         const double y = std::sin(dt/ period * M_PI * 2.0) * 80;
         map->updateAnnotation(animatedAnnotationIDs[i], mbgl::SymbolAnnotation { {x, y }, "default_marker" });
     }
+}
+
+void GLFWView::cycleDebugOptions() {
+    auto debug = map->getDebug();
+#if not MBGL_USE_GLES2
+    if (debug & mbgl::MapDebugOptions::StencilClip)
+        debug = mbgl::MapDebugOptions::NoDebug;
+    else if (debug & mbgl::MapDebugOptions::Overdraw)
+        debug = mbgl::MapDebugOptions::StencilClip;
+#else
+    if (debug & mbgl::MapDebugOptions::Overdraw) debug = mbgl::MapDebugOptions::NoDebug;
+#endif // MBGL_USE_GLES2
+    else if (debug & mbgl::MapDebugOptions::Collision)
+        debug = mbgl::MapDebugOptions::Overdraw;
+    else if (debug & mbgl::MapDebugOptions::Timestamps)
+        debug = debug | mbgl::MapDebugOptions::Collision;
+    else if (debug & mbgl::MapDebugOptions::ParseStatus)
+        debug = debug | mbgl::MapDebugOptions::Timestamps;
+    else if (debug & mbgl::MapDebugOptions::TileBorders)
+        debug = debug | mbgl::MapDebugOptions::ParseStatus;
+    else
+        debug = mbgl::MapDebugOptions::TileBorders;
+
+    map->setDebug(debug);
 }
 
 void GLFWView::clearAnnotations() {

--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -88,6 +88,7 @@ private:
     void updateAnimatedAnnotations();
     void toggleCustomSource();
 
+    void cycleDebugOptions();
     void clearAnnotations();
     void popAnnotation();
 

--- a/platform/qt/app/mapwindow.cpp
+++ b/platform/qt/app/mapwindow.cpp
@@ -400,9 +400,6 @@ void MapWindow::keyPressEvent(QKeyEvent *ev)
             }
         }
         break;
-    case Qt::Key_Tab:
-        m_map->cycleDebugOptions();
-        break;
     default:
         break;
     }

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -153,8 +153,6 @@ public:
               qreal pixelRatio = 1);
     virtual ~QMapboxGL();
 
-    void cycleDebugOptions();
-
     QString styleJson() const;
     QString styleUrl() const;
 

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -583,15 +583,6 @@ QMapboxGL::~QMapboxGL()
 }
 
 /*!
-    Cycles through several debug options like showing the tile borders,
-    tile numbers, expiration time and wireframe.
-*/
-void QMapboxGL::cycleDebugOptions()
-{
-    d_ptr->mapObj->cycleDebugOptions();
-}
-
-/*!
     \property QMapboxGL::styleJson
     \brief the map style JSON.
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -434,30 +434,6 @@ void Map::setDebug(MapDebugOptions debugOptions) {
     impl->onUpdate();
 }
 
-void Map::cycleDebugOptions() {
-#if not MBGL_USE_GLES2
-    if (impl->debugOptions & MapDebugOptions::StencilClip)
-        impl->debugOptions = MapDebugOptions::NoDebug;
-    else if (impl->debugOptions & MapDebugOptions::Overdraw)
-        impl->debugOptions = MapDebugOptions::StencilClip;
-#else
-    if (impl->debugOptions & MapDebugOptions::Overdraw)
-        impl->debugOptions = MapDebugOptions::NoDebug;
-#endif // MBGL_USE_GLES2
-    else if (impl->debugOptions & MapDebugOptions::Collision)
-        impl->debugOptions = MapDebugOptions::Overdraw;
-    else if (impl->debugOptions & MapDebugOptions::Timestamps)
-        impl->debugOptions = impl->debugOptions | MapDebugOptions::Collision;
-    else if (impl->debugOptions & MapDebugOptions::ParseStatus)
-        impl->debugOptions = impl->debugOptions | MapDebugOptions::Timestamps;
-    else if (impl->debugOptions & MapDebugOptions::TileBorders)
-        impl->debugOptions = impl->debugOptions | MapDebugOptions::ParseStatus;
-    else
-        impl->debugOptions = MapDebugOptions::TileBorders;
-
-    impl->onUpdate();
-}
-
 MapDebugOptions Map::getDebug() const {
     return impl->debugOptions;
 }


### PR DESCRIPTION
This function was mostly used by the Android API, which is no longer necessary (we can still implement it using the map debug accessor and modifier).