### PR TITLE
[core] Don't use signed int type for anchor segment

### DIFF
--- a/next/test/CMakeLists.txt
+++ b/next/test/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library(
     ${MBGL_ROOT}/test/text/bidi.test.cpp
     ${MBGL_ROOT}/test/text/cross_tile_symbol_index.test.cpp
     ${MBGL_ROOT}/test/text/formatted.test.cpp
+    ${MBGL_ROOT}/test/text/get_anchors.test.cpp
     ${MBGL_ROOT}/test/text/glyph_manager.test.cpp
     ${MBGL_ROOT}/test/text/glyph_pbf.test.cpp
     ${MBGL_ROOT}/test/text/language_tag.test.cpp

--- a/next/test/CMakeLists.txt
+++ b/next/test/CMakeLists.txt
@@ -64,6 +64,7 @@ add_library(
     ${MBGL_ROOT}/test/style/style_layer.test.cpp
     ${MBGL_ROOT}/test/style/style_parser.test.cpp
     ${MBGL_ROOT}/test/text/bidi.test.cpp
+    ${MBGL_ROOT}/test/text/calculate_tile_distances.test.cpp
     ${MBGL_ROOT}/test/text/cross_tile_symbol_index.test.cpp
     ${MBGL_ROOT}/test/text/formatted.test.cpp
     ${MBGL_ROOT}/test/text/get_anchors.test.cpp

--- a/src/mbgl/geometry/anchor.hpp
+++ b/src/mbgl/geometry/anchor.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/util/geometry.hpp>
+#include <mbgl/util/optional.hpp>
 
 #include <vector>
 
@@ -11,9 +12,9 @@ public:
     Point<float> point;
     float angle = 0.0f;
     float scale = 0.0f;
-    int segment = -1;
+    optional<std::size_t> segment;
 
-    Anchor(float x_, float y_, float angle_, float scale_, int segment_ = -1)
+    Anchor(float x_, float y_, float angle_, float scale_, optional<std::size_t> segment_ = nullopt)
         : point(x_, y_), angle(angle_), scale(scale_), segment(segment_) {}
 };
 

--- a/src/mbgl/geometry/anchor.hpp
+++ b/src/mbgl/geometry/anchor.hpp
@@ -11,11 +11,10 @@ class Anchor {
 public:
     Point<float> point;
     float angle = 0.0f;
-    float scale = 0.0f;
     optional<std::size_t> segment;
 
-    Anchor(float x_, float y_, float angle_, float scale_, optional<std::size_t> segment_ = nullopt)
-        : point(x_, y_), angle(angle_), scale(scale_), segment(segment_) {}
+    Anchor(float x_, float y_, float angle_, optional<std::size_t> segment_ = nullopt)
+        : point(x_, y_), angle(angle_), segment(segment_) {}
 };
 
 using Anchors = std::vector<Anchor>;

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -693,12 +693,12 @@ bool SymbolLayout::anchorIsTooClose(const std::u16string& text, const float repe
 
 // Analog of `addToLineVertexArray` in JS. This version doesn't need to build up a line array like the
 // JS version does, but it uses the same logic to calculate tile distances.
-std::vector<float> CalculateTileDistances(const GeometryCoordinates& line, const Anchor& anchor) {
+std::vector<float> SymbolLayout::calculateTileDistances(const GeometryCoordinates& line, const Anchor& anchor) {
     std::vector<float> tileDistances(line.size());
     if (anchor.segment) {
         std::size_t segment = *anchor.segment;
         assert(segment < line.size());
-        auto sumForwardLength = util::dist<float>(anchor.point, line[segment + 1]);
+        auto sumForwardLength = (segment + 1 < line.size()) ? util::dist<float>(anchor.point, line[segment + 1]) : .0f;
         auto sumBackwardLength = util::dist<float>(anchor.point, line[segment]);
         for (std::size_t i = segment + 1; i < line.size(); ++i) {
             tileDistances[i] = sumForwardLength;
@@ -842,7 +842,7 @@ std::size_t SymbolLayout::addSymbolGlyphQuads(SymbolBucket& bucket,
                                            symbolInstance.textOffset,
                                            writingMode,
                                            symbolInstance.line(),
-                                           CalculateTileDistances(symbolInstance.line(), symbolInstance.anchor),
+                                           calculateTileDistances(symbolInstance.line(), symbolInstance.anchor),
                                            placedIconIndex);
     placedIndex = bucket.text.placedSymbols.size() - 1;
     PlacedSymbol& placedSymbol = bucket.text.placedSymbols.back();

--- a/src/mbgl/layout/symbol_layout.hpp
+++ b/src/mbgl/layout/symbol_layout.hpp
@@ -55,7 +55,8 @@ public:
      * @return std::array<float, 2> offset along x- and y- axis correspondingly.
      */
     static std::array<float, 2> evaluateVariableOffset(style::SymbolAnchorType anchor, std::array<float, 2> textOffset);
-    
+
+    static std::vector<float> calculateTileDistances(const GeometryCoordinates& line, const Anchor& anchor);
 
 private:
     void addFeature(const size_t,

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -20,14 +20,28 @@ class CrossTileSymbolLayerIndex;
 
 class PlacedSymbol {
 public:
-    PlacedSymbol(Point<float> anchorPoint_, uint16_t segment_, float lowerSize_, float upperSize_,
-            std::array<float, 2> lineOffset_, WritingModeType writingModes_, GeometryCoordinates line_, std::vector<float> tileDistances_, optional<size_t> placedIconIndex_ = nullopt) :
-        anchorPoint(anchorPoint_), segment(segment_), lowerSize(lowerSize_), upperSize(upperSize_),
-        lineOffset(lineOffset_), writingModes(writingModes_), line(std::move(line_)), tileDistances(std::move(tileDistances_)), hidden(false), vertexStartIndex(0), placedIconIndex(std::move(placedIconIndex_))
-    {
-    }
+    PlacedSymbol(Point<float> anchorPoint_,
+                 std::size_t segment_,
+                 float lowerSize_,
+                 float upperSize_,
+                 std::array<float, 2> lineOffset_,
+                 WritingModeType writingModes_,
+                 GeometryCoordinates line_,
+                 std::vector<float> tileDistances_,
+                 optional<size_t> placedIconIndex_ = nullopt)
+        : anchorPoint(anchorPoint_),
+          segment(segment_),
+          lowerSize(lowerSize_),
+          upperSize(upperSize_),
+          lineOffset(lineOffset_),
+          writingModes(writingModes_),
+          line(std::move(line_)),
+          tileDistances(std::move(tileDistances_)),
+          hidden(false),
+          vertexStartIndex(0),
+          placedIconIndex(std::move(placedIconIndex_)) {}
     Point<float> anchorPoint;
-    uint16_t segment;
+    std::size_t segment;
     float lowerSize;
     float upperSize;
     std::array<float, 2> lineOffset;

--- a/src/mbgl/text/check_max_angle.cpp
+++ b/src/mbgl/text/check_max_angle.cpp
@@ -19,20 +19,19 @@ bool checkMaxAngle(const GeometryCoordinates& line,
                    const float windowSize,
                    const float maxAngle) {
     // horizontal labels always pass
-    if (anchor.segment < 0) return true;
+    if (!anchor.segment) return true;
 
     GeometryCoordinate anchorPoint = convertPoint<int16_t>(anchor.point);
     GeometryCoordinate &p = anchorPoint;
-    int index = anchor.segment + 1;
+    std::size_t index = *anchor.segment + 1;
     float anchorDistance = 0;
 
     // move backwards along the line to the first segment the label appears on
     while (anchorDistance > -labelLength / 2) {
-        index--;
-
         // there isn't enough room for the label after the beginning of the line
-        if (index < 0) return false;
+        if (index == 0u) return false;
 
+        index--;
         anchorDistance -= util::dist<float>(line[index], p);
         p = line[index];
     }
@@ -48,7 +47,7 @@ bool checkMaxAngle(const GeometryCoordinates& line,
     while (anchorDistance < labelLength / 2) {
 
         // there isn't enough room for the label before the end of the line
-        if (index + 1 >= (int)line.size()) return false;
+        if (index + 1 >= line.size()) return false;
 
         auto& prev = line[index - 1];
         auto& current = line[index];

--- a/src/mbgl/text/collision_feature.hpp
+++ b/src/mbgl/text/collision_feature.hpp
@@ -122,8 +122,12 @@ public:
     bool alongLine;
 
 private:
-    void bboxifyLabel(const GeometryCoordinates& line, GeometryCoordinate& anchorPoint,
-                      const int segment, const float length, const float height, const float overscaling);
+    void bboxifyLabel(const GeometryCoordinates& line,
+                      GeometryCoordinate& anchorPoint,
+                      std::size_t segment,
+                      const float length,
+                      const float height,
+                      const float overscaling);
 };
 
 } // namespace mbgl

--- a/src/mbgl/text/get_anchors.cpp
+++ b/src/mbgl/text/get_anchors.cpp
@@ -61,7 +61,7 @@ static Anchors resample(const GeometryCoordinates& line,
             if (x >= 0 && x < util::EXTENT && y >= 0 && y < util::EXTENT &&
                     markedDistance - halfLabelLength >= 0.0f &&
                     markedDistance + halfLabelLength <= lineLength) {
-                Anchor anchor(::round(x), ::round(y), angle, 0.5f, i);
+                Anchor anchor(::round(x), ::round(y), angle, i);
 
                 if (!angleWindowSize || checkMaxAngle(line, anchor, labelLength, angleWindowSize, maxAngle)) {
                     anchors.push_back(anchor);
@@ -160,9 +160,9 @@ optional<Anchor> getCenterAnchor(const GeometryCoordinates& line,
             float t = (centerDistance - prevDistance) / segmentDistance,
                   x = util::interpolate(float(a.x), float(b.x), t),
                   y = util::interpolate(float(a.y), float(b.y), t);
-            
-            Anchor anchor(::round(x), ::round(y), util::angle_to(b, a), 0.5f, i);
-            
+
+            Anchor anchor(::round(x), ::round(y), util::angle_to(b, a), i);
+
             if (!angleWindowSize || checkMaxAngle(line, anchor, labelLength, angleWindowSize, maxAngle)) {
                 return anchor;
             }

--- a/src/mbgl/text/get_anchors.cpp
+++ b/src/mbgl/text/get_anchors.cpp
@@ -40,7 +40,7 @@ static Anchors resample(const GeometryCoordinates& line,
 
     assert(spacing > 0.0);
 
-    int i = 0;
+    std::size_t i = 0u;
     for (auto it = line.begin(), end = line.end() - 1; it != end; it++, i++) {
         const GeometryCoordinate& a = *(it);
         const GeometryCoordinate& b = *(it + 1);
@@ -147,8 +147,8 @@ optional<Anchor> getCenterAnchor(const GeometryCoordinates& line,
     
     float prevDistance = 0;
     const float centerDistance = getLineLength(line) / 2;
-    
-    int i = 0;
+
+    std::size_t i = 0u;
     for (auto it = line.begin(), end = line.end() - 1; it != end; it++, i++) {
         const GeometryCoordinate& a = *(it);
         const GeometryCoordinate& b = *(it + 1);

--- a/test/test-files.json
+++ b/test/test-files.json
@@ -66,6 +66,7 @@
         "test/style/style_layer.test.cpp",
         "test/style/style_parser.test.cpp",
         "test/text/bidi.test.cpp",
+        "test/text/calculate_tile_distances.test.cpp",
         "test/text/cross_tile_symbol_index.test.cpp",
         "test/text/formatted.test.cpp",
         "test/text/get_anchors.test.cpp",

--- a/test/test-files.json
+++ b/test/test-files.json
@@ -68,6 +68,7 @@
         "test/text/bidi.test.cpp",
         "test/text/cross_tile_symbol_index.test.cpp",
         "test/text/formatted.test.cpp",
+        "test/text/get_anchors.test.cpp",
         "test/text/glyph_manager.test.cpp",
         "test/text/glyph_pbf.test.cpp",
         "test/text/language_tag.test.cpp",

--- a/test/text/calculate_tile_distances.test.cpp
+++ b/test/text/calculate_tile_distances.test.cpp
@@ -1,0 +1,27 @@
+#include <mbgl/test/util.hpp>
+
+#include <mbgl/geometry/anchor.hpp>
+#include <mbgl/layout/symbol_layout.hpp>
+#include <mbgl/tile/geometry_tile_data.hpp>
+
+using namespace mbgl;
+
+TEST(calculateTileDistances, Point) {
+    const GeometryCoordinates line = {Point<int16_t>{1, 1}};
+    const auto distances = SymbolLayout::calculateTileDistances(line, Anchor(1.0f, 1.0f, .0f, 0u));
+    EXPECT_EQ(distances.size(), 1u);
+    EXPECT_EQ(distances[0], .0f);
+}
+
+TEST(calculateTileDistances, Line) {
+    const GeometryCoordinates line = {
+        Point<int16_t>{1, 1}, Point<int16_t>{1, 2}, Point<int16_t>{1, 3}, Point<int16_t>{1, 4}};
+    const auto distances = SymbolLayout::calculateTileDistances(line, Anchor(1.0f, 3.0f, .0f, 2u));
+    EXPECT_EQ(distances, std::vector<float>({2.0f, 1.0f, 0.0f, 1.0f}));
+}
+
+TEST(calculateTileDistances, EmptySegment) {
+    const GeometryCoordinates line = {};
+    const auto distances = SymbolLayout::calculateTileDistances(line, Anchor(1.0f, 1.0f, .0f));
+    EXPECT_EQ(distances.size(), 0u);
+}

--- a/test/text/get_anchors.test.cpp
+++ b/test/text/get_anchors.test.cpp
@@ -1,0 +1,130 @@
+#include <mbgl/test/util.hpp>
+
+#include <mbgl/text/get_anchors.hpp>
+
+using namespace mbgl;
+
+namespace mbgl {
+constexpr inline bool operator==(const Anchor& rhs, const Anchor& lhs) {
+    return rhs.point == lhs.point && rhs.angle == lhs.angle && rhs.segment == lhs.segment;
+}
+} // namespace mbgl
+
+namespace {
+const auto makeLine = [](std::size_t shift = 0u) {
+    GeometryCoordinates line;
+    for (std::size_t i = shift; i < 10u + shift; ++i) {
+        line.push_back({1, static_cast<int16_t>(i)});
+    }
+    return line;
+};
+
+const GeometryCoordinates continuedLine = makeLine();
+const GeometryCoordinates nonContinuedLine = makeLine(1u);
+
+const float smallSpacing = 2.0f;
+const float bigSpacing = 3.0f;
+const float textLeft = -1.0f;
+const float textRight = 1.0f;
+const float iconLeft = -0.5f;
+const float iconRight = 0.5f;
+const float glyphSize = 0.1f;
+const float boxScale = 1.0f;
+const float overscaling = 1.0f;
+} // namespace
+
+TEST(getAnchors, NonContinuedLineShortLabels) {
+    const Anchors anchors = getAnchors(
+        nonContinuedLine, bigSpacing, M_PI, textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale, overscaling);
+    const Anchors expected_anchors = {Anchor(1.0f, 2.0f, 1.570796371f, 1u),
+                                      Anchor(1.0f, 5.0f, 1.570796371f, 4u),
+                                      Anchor(1.0f, 8.0f, 1.570796371f, 7u)};
+
+    EXPECT_EQ(anchors, expected_anchors);
+}
+
+TEST(getAnchors, NonContinuedLineLongLabels) {
+    const Anchors anchors = getAnchors(nonContinuedLine,
+                                       smallSpacing,
+                                       M_PI,
+                                       textLeft,
+                                       textRight,
+                                       iconLeft,
+                                       iconRight,
+                                       glyphSize,
+                                       boxScale,
+                                       overscaling);
+    const Anchors expected_anchors = {Anchor(1.0f, 2.0f, 1.570796371f, 1u),
+                                      Anchor(1.0f, 5.0f, 1.570796371f, 3u),
+                                      Anchor(1.0f, 7.0f, 1.570796371f, 6u)};
+
+    EXPECT_EQ(anchors, expected_anchors);
+}
+
+TEST(getAnchors, ContinuedLineShortLabels) {
+    const Anchors anchors = getAnchors(
+        continuedLine, bigSpacing, M_PI, textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale, overscaling);
+    const Anchors expected_anchors = {Anchor(1.0f, 2.0f, 1.570796371f, 1u),
+                                      Anchor(1.0f, 5.0f, 1.570796371f, 4u),
+                                      Anchor(1.0f, 8.0f, 1.570796371f, 7u)};
+
+    EXPECT_EQ(anchors, expected_anchors);
+}
+
+TEST(getAnchors, ContinuedLineLongLabels) {
+    const Anchors anchors = getAnchors(
+        continuedLine, smallSpacing, M_PI, textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale, overscaling);
+    const Anchors expected_anchors = {Anchor(1.0f, 1.0f, 1.570796371f, 1u),
+                                      Anchor(1.0f, 4.0f, 1.570796371f, 3u),
+                                      Anchor(1.0f, 6.0f, 1.570796371f, 6u)};
+
+    EXPECT_EQ(anchors, expected_anchors);
+}
+
+TEST(getAnchors, OverscaledAnchorsInParent) {
+    const Anchors anchors = getAnchors(
+        nonContinuedLine, bigSpacing, M_PI, textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale, overscaling);
+    const Anchors childAnchors = getAnchors(nonContinuedLine,
+                                            bigSpacing / 2,
+                                            M_PI,
+                                            textLeft,
+                                            textRight,
+                                            iconLeft,
+                                            iconRight,
+                                            glyphSize,
+                                            0.5f /*boxScale*/,
+                                            2.0f /*overscaling*/);
+    for (const auto& anchor : anchors) {
+        EXPECT_TRUE(std::find(childAnchors.begin(), childAnchors.end(), anchor) != childAnchors.end());
+    }
+}
+
+TEST(getAnchors, UseMidpointForShortLine) {
+    const GeometryCoordinates shortLine = {Point<int16_t>{1, 1}, Point<int16_t>{1, 3}};
+    const Anchors anchors = getAnchors(
+        shortLine, smallSpacing, M_PI, textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale, overscaling);
+    const Anchors expected_anchors = {Anchor(1.0f, 2.0f, 1.570796371f, 0u)};
+
+    EXPECT_EQ(anchors, expected_anchors);
+}
+
+TEST(getAnchors, GetCenterAnchor) {
+    const GeometryCoordinates line = {
+        Point<int16_t>{1, 1}, Point<int16_t>{1, 3}, Point<int16_t>{3, 6}, Point<int16_t>{4, 7}};
+    const auto anchor = getCenterAnchor(line, M_PI, textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale);
+    EXPECT_TRUE(anchor);
+    EXPECT_EQ(*anchor, Anchor(2.0f, 4.0f, .982793748f, 1u));
+}
+
+TEST(getAnchors, GetCenterAnchorOutsideTileBounds) {
+    const GeometryCoordinates line = {Point<int16_t>{-10, -10}, Point<int16_t>{5, 5}};
+    const auto anchor = getCenterAnchor(line, M_PI, textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale);
+    EXPECT_TRUE(anchor);
+    EXPECT_EQ(*anchor, Anchor(-3.0f, -3.0f, .785398185f, 0u));
+}
+
+TEST(getAnchors, GetCenterAnchorFailMaxAngle) {
+    const GeometryCoordinates line = {Point<int16_t>{1, 1}, Point<int16_t>{1, 3}, Point<int16_t>{3, 3}};
+    const auto anchor = getCenterAnchor(line, M_PI / 4, textLeft, textRight, iconLeft, iconRight, glyphSize, boxScale);
+    EXPECT_FALSE(anchor);
+}

--- a/test/text/quads.test.cpp
+++ b/test/text/quads.test.cpp
@@ -12,7 +12,7 @@ using namespace mbgl::style;
 
 TEST(getIconQuads, normal) {
     SymbolLayoutProperties::Evaluated layout;
-    Anchor anchor(2.0, 3.0, 0.0, 0.5f, 0);
+    Anchor anchor(2.0, 3.0, 0.0, 0);
     ImagePosition image = {
         mapbox::Bin(-1, 15, 11, 0, 0, 0, 0),
         style::Image::Impl("test", PremultipliedImage({1,1}), 1.0)
@@ -35,7 +35,7 @@ TEST(getIconQuads, normal) {
 }
 
 TEST(getIconQuads, style) {
-    Anchor anchor(0.0, 0.0, 0.0, 0.5f, 0);
+    Anchor anchor(0.0, 0.0, 0.0, 0);
     const ImagePosition image = {mapbox::Bin(-1, 20, 20, 0, 0, 0, 0),
                                  style::Image::Impl("test", PremultipliedImage({1, 1}), 1.0)};
 


### PR DESCRIPTION
Erroneous signed to unsigned implicit conversion was used  when PlacedSymbol(s) were created in SymbolLayout and signed values were used as indexes in a few other places.