### PR TITLE
[CP][core][android] Decouple vacuum from other operations on offline database

### DIFF
--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -121,6 +121,11 @@ public:
      * Eviction works by removing the least-recently requested resources not also required
      * by other regions, until the database shrinks below a certain size.
      *
+     * If the |pack| argument is `false` the database file packing is skipped and the
+     * database file does not shrink after this operation completes. Database file
+     * packing can be done later with `packDatabase()`. It is a useful optimization
+     * e.g. when several regions should be deleted in a row.
+     *
      * Note that this method takes ownership of the input, reflecting the fact that once
      * region deletion is initiated, it is not legal to perform further actions with the
      * region.
@@ -129,7 +134,7 @@ public:
      * executed on the database thread; it is the responsibility of the SDK bindings
      * to re-execute a user-provided callback on the main thread.
      */
-    void deleteOfflineRegion(OfflineRegion&&, std::function<void (std::exception_ptr)>);
+    void deleteOfflineRegion(OfflineRegion&&, std::function<void(std::exception_ptr)>, bool pack = true);
 
     /*
      * Invalidate all the tiles from an offline region forcing Mapbox GL to revalidate
@@ -137,7 +142,7 @@ public:
      * offline region and downloading it again because if the data on the cache matches
      * the server, no new data gets transmitted.
      */
-    void invalidateOfflineRegion(OfflineRegion&, std::function<void (std::exception_ptr)>);
+    void invalidateOfflineRegion(OfflineRegion&, std::function<void(std::exception_ptr)>);
 
     /*
      * Changing or bypassing this limit without permission from Mapbox is prohibited
@@ -179,7 +184,16 @@ public:
      * executed on the database thread; it is the responsibility of the SDK bindings
      * to re-execute a user-provided callback on the main thread.
      */
-    void resetDatabase(std::function<void (std::exception_ptr)>);
+    void resetDatabase(std::function<void(std::exception_ptr)>);
+
+    /*
+     * Packs the existing database file into a minimal amount of disk space.
+     *
+     * When the operation is complete or encounters an error, the given callback will be
+     * executed on the database thread; it is the responsibility of the SDK bindings
+     * to re-execute a user-provided callback on the main thread.
+     */
+    void packDatabase(std::function<void(std::exception_ptr)> callback);
 
     /*
      * Forces revalidation of the ambient cache.

--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -200,7 +200,7 @@ public:
      * Sets whether packing the database file occurs automatically after an offline
      * region is deleted (deleteOfflineRegion()) or the ambient cache is cleared
      * (clearAmbientCache()).
-     * 
+     *
      * By default, packing is enabled. If disabled, disk space will not be freed
      * after resources are removed unless packDatabase() is explicitly called.
      */
@@ -223,8 +223,8 @@ public:
     /*
      * Erase resources from the ambient cache, freeing storage space.
      *
-     * Erases the ambient cache, freeing resources. 
-     * 
+     * Erases the ambient cache, freeing resources.
+     *
      * Note that this operation can be potentially slow if packing the database
      * occurs automatically (see runPackDatabaseAutomatically() and packDatabase()).
      *

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -11,6 +11,8 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 
 ### Performance improvements
  - Enable incremental vacuum for the offline database in order to make data removal requests faster and to avoid the excessive disk space usage (creating a backup file on VACUUM call) [#15837](https://github.com/mapbox/mapbox-gl-native/pull/15837)
+ - Introduce `OfflineManager.packDatabase()` API, which explicitly packs the database file (i.e. runs incremental vacuum for the offline database) [#15899](https://github.com/mapbox/mapbox-gl-native/pull/15899) 
+ - Introduce `OfflineManager.runPackDatabaseAutomatically(boolean)`, which sets whether database file packing (i.e. incremental vacuum operation for the offline database) occurs automatically. [#15967](https://github.com/mapbox/mapbox-gl-native/pull/15967)
 
 ## 8.5.0-alpha.2 - October 10, 2019
 [Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.5.0-alpha.1...android-v8.5.0-alpha.2) since [Mapbox Maps SDK for Android v8.5.0-alpha.1](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.5.0-alpha.1):

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
@@ -309,6 +309,9 @@ public class OfflineManager {
   /**
    * Packs the existing database file into a minimal amount of disk space.
    * <p>
+   * This operation has a performance impact as it will vacuum the database,
+   * forcing it to move pages on the filesystem.
+   * <p>
    * When the operation is complete or encounters an error, the given callback will be
    * executed on the database thread; it is the responsibility of the SDK bindings
    * to re-execute a user-provided callback on the main thread.
@@ -396,9 +399,10 @@ public class OfflineManager {
   /**
    * Erase resources from the ambient cache, freeing storage space.
    * <p>
-   * Erases the ambient cache, freeing resources. This operation can be
-   * potentially slow because it will trigger a VACUUM on SQLite,
-   * forcing the database to move pages on the filesystem.
+   * Erases the ambient cache, freeing resources.
+   * <p>
+   * Note that this operation can be potentially slow if packing the database
+   * occurs automatically ({@link OfflineManager#runPackDatabaseAutomatically(boolean)}).
    * </p>
    * <p>
    * Resources overlapping with offline regions will not be affected
@@ -661,13 +665,31 @@ public class OfflineManager {
    * <p>
    * Once this limit is reached, {@link OfflineRegion.OfflineRegionObserver#mapboxTileCountLimitExceeded(long)}
    * fires every additional attempt to download additional tiles until already downloaded tiles are removed
-   * by calling {@link OfflineRegion#deleteOfflineRegion(OfflineRegion.OfflineRegionDeleteCallback)}.
+   * by calling {@link OfflineRegion#delete(OfflineRegion.OfflineRegionDeleteCallback)}.
    * </p>
    *
    * @param limit the maximum number of tiles allowed to be downloaded
    */
   @Keep
   public native void setOfflineMapboxTileCountLimit(long limit);
+
+  /**
+   * Sets whether database file packing occurs automatically.
+   * By default, the automatic database file packing is enabled.
+   * <p>
+   * If packing is enabled, database file packing occurs automatically
+   * after an offline region is deleted by calling
+   * {@link OfflineRegion#delete(OfflineRegion.OfflineRegionDeleteCallback)}
+   * or the ambient cache is cleared by calling {@link OfflineManager#clearAmbientCache()}.
+   *
+   * If packing is disabled, disk space will not be freed after
+   * resources are removed unless {@link OfflineManager#packDatabase()} is explicitly called.
+   * </p>
+   *
+   * @param autopack flag setting the automatic database file packing.
+   */
+  @Keep
+  public native void runPackDatabaseAutomatically(boolean autopack);
 
   @Keep
   private native void initialize(FileSource fileSource);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegion.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegion.java
@@ -388,6 +388,10 @@ public class OfflineRegion {
    * by other regions, until the database shrinks below a certain size.
    * </p>
    * <p>
+   * Note that this operation can be potentially slow if packing the database
+   * occurs automatically ({@link OfflineManager#runPackDatabaseAutomatically(boolean)}).
+   * </p>
+   * <p>
    * When the operation is complete or encounters an error, the given callback will be
    * executed on the main thread.
    * </p>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/offline/CacheTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/offline/CacheTest.kt
@@ -85,4 +85,20 @@ class CacheTest {
     }
     countDownLatch.await()
   }
+
+  @Test
+  fun testSetPackDatabase() {
+    rule.activity.runOnUiThread {
+      OfflineManager.getInstance(context).packDatabase(object : OfflineManager.FileSourceCallback {
+        override fun onSuccess() {
+          countDownLatch.countDown()
+        }
+
+        override fun onError(message: String) {
+          Assert.assertNull("onError should not be called", message)
+        }
+      })
+    }
+    countDownLatch.await()
+  }
 }

--- a/platform/android/src/offline/offline_manager.cpp
+++ b/platform/android/src/offline/offline_manager.cpp
@@ -168,6 +168,10 @@ void OfflineManager::setMaximumAmbientCacheSize(jni::JNIEnv& env_, const jni::jl
             std::exception_ptr exception) mutable { handleException(exception, *callback); });
 }
 
+void OfflineManager::runPackDatabaseAutomatically(jni::JNIEnv&, jboolean autopack) {
+    fileSource->runPackDatabaseAutomatically(autopack);
+}
+
 // FileSource::FileSourceCallback //
 
 void OfflineManager::FileSourceCallback::onSuccess(jni::JNIEnv& env,
@@ -211,6 +215,7 @@ void OfflineManager::registerNative(jni::JNIEnv& env) {
         METHOD(&OfflineManager::invalidateAmbientCache, "nativeInvalidateAmbientCache"),
         METHOD(&OfflineManager::clearAmbientCache, "nativeClearAmbientCache"),
         METHOD(&OfflineManager::setMaximumAmbientCacheSize, "nativeSetMaximumAmbientCacheSize"),
+        METHOD(&OfflineManager::runPackDatabaseAutomatically, "runPackDatabaseAutomatically"),
         METHOD(&OfflineManager::putResourceWithUrl, "putResourceWithUrl"));
 }
 

--- a/platform/android/src/offline/offline_manager.hpp
+++ b/platform/android/src/offline/offline_manager.hpp
@@ -95,6 +95,8 @@ public:
 
     void resetDatabase(jni::JNIEnv&, const jni::Object<FileSourceCallback>& callback_);
 
+    void packDatabase(jni::JNIEnv&, const jni::Object<FileSourceCallback>& callback_);
+
     void invalidateAmbientCache(jni::JNIEnv&, const jni::Object<FileSourceCallback>& callback_);
 
     void clearAmbientCache(jni::JNIEnv&, const jni::Object<FileSourceCallback>& callback_);

--- a/platform/android/src/offline/offline_manager.hpp
+++ b/platform/android/src/offline/offline_manager.hpp
@@ -103,6 +103,8 @@ public:
 
     void setMaximumAmbientCacheSize(jni::JNIEnv&, const jni::jlong size, const jni::Object<FileSourceCallback>& callback_);
 
+    void runPackDatabaseAutomatically(jni::JNIEnv&, jboolean autopack);
+
 private:
     std::shared_ptr<mbgl::DefaultFileSource> fileSource;
 };

--- a/platform/android/src/offline/offline_region.cpp
+++ b/platform/android/src/offline/offline_region.cpp
@@ -104,37 +104,40 @@ void OfflineRegion::getOfflineRegionStatus(jni::JNIEnv& env_, const jni::Object<
 void OfflineRegion::deleteOfflineRegion(jni::JNIEnv& env_, const jni::Object<OfflineRegionDeleteCallback>& callback_) {
     auto globalCallback = jni::NewGlobal<jni::EnvAttachingDeleter>(env_, callback_);
 
-    fileSource->deleteOfflineRegion(std::move(*region), [
-        //Ensure the object is not gc'd in the meanwhile
-        callback = std::make_shared<decltype(globalCallback)>(std::move(globalCallback))
-    ](std::exception_ptr error) mutable {
-        // Reattach, the callback comes from a different thread
-        android::UniqueEnv env = android::AttachEnv();
+    fileSource->deleteOfflineRegion(std::move(*region),
+                                    [
+                                        // Ensure the object is not gc'd in the meanwhile
+                                        callback = std::make_shared<decltype(globalCallback)>(
+                                            std::move(globalCallback))](std::exception_ptr error) mutable {
+                                        // Reattach, the callback comes from a different thread
+                                        android::UniqueEnv env = android::AttachEnv();
 
-        if (error) {
-            OfflineRegionDeleteCallback::onError(*env, *callback, error);
-        } else {
-            OfflineRegionDeleteCallback::onDelete(*env, *callback);
-        }
-    });
+                                        if (error) {
+                                            OfflineRegionDeleteCallback::onError(*env, *callback, error);
+                                        } else {
+                                            OfflineRegionDeleteCallback::onDelete(*env, *callback);
+                                        }
+                                    });
 }
 
-void OfflineRegion::invalidateOfflineRegion(jni::JNIEnv& env_, const jni::Object<OfflineRegionInvalidateCallback>& callback_) {
+void OfflineRegion::invalidateOfflineRegion(jni::JNIEnv& env_,
+                                            const jni::Object<OfflineRegionInvalidateCallback>& callback_) {
     auto globalCallback = jni::NewGlobal<jni::EnvAttachingDeleter>(env_, callback_);
 
-    fileSource->invalidateOfflineRegion(*region, [
-        //Ensure the object is not gc'd in the meanwhile
-        callback = std::make_shared<decltype(globalCallback)>(std::move(globalCallback))
-    ](std::exception_ptr error) mutable {
-        // Reattach, the callback comes from a different thread
-        android::UniqueEnv env = android::AttachEnv();
+    fileSource->invalidateOfflineRegion(*region,
+                                        [
+                                            // Ensure the object is not gc'd in the meanwhile
+                                            callback = std::make_shared<decltype(globalCallback)>(
+                                                std::move(globalCallback))](std::exception_ptr error) mutable {
+                                            // Reattach, the callback comes from a different thread
+                                            android::UniqueEnv env = android::AttachEnv();
 
-        if (error) {
-            OfflineRegionInvalidateCallback::onError(*env, *callback, error);
-        } else {
-            OfflineRegionInvalidateCallback::onInvalidate(*env, *callback);
-        }
-    });
+                                            if (error) {
+                                                OfflineRegionInvalidateCallback::onError(*env, *callback, error);
+                                            } else {
+                                                OfflineRegionInvalidateCallback::onInvalidate(*env, *callback);
+                                            }
+                                        });
 }
 
 void OfflineRegion::updateOfflineRegionMetadata(jni::JNIEnv& env_, const jni::Array<jni::jbyte>& jMetadata, const jni::Object<OfflineRegionUpdateMetadataCallback>& callback_) {
@@ -206,7 +209,10 @@ void OfflineRegion::registerNative(jni::JNIEnv& env) {
 
     #define METHOD(MethodPtr, name) jni::MakeNativePeerMethod<decltype(MethodPtr), (MethodPtr)>(name)
 
-    jni::RegisterNativePeer<OfflineRegion>( env, javaClass, "nativePtr",
+    jni::RegisterNativePeer<OfflineRegion>(
+        env,
+        javaClass,
+        "nativePtr",
         jni::MakePeer<OfflineRegion, jni::jlong, const jni::Object<FileSource>&>,
         "initialize",
         "finalize",
@@ -215,8 +221,7 @@ void OfflineRegion::registerNative(jni::JNIEnv& env) {
         METHOD(&OfflineRegion::getOfflineRegionStatus, "getOfflineRegionStatus"),
         METHOD(&OfflineRegion::deleteOfflineRegion, "deleteOfflineRegion"),
         METHOD(&OfflineRegion::invalidateOfflineRegion, "invalidateOfflineRegion"),
-        METHOD(&OfflineRegion::updateOfflineRegionMetadata, "updateOfflineRegionMetadata")
-    );
+        METHOD(&OfflineRegion::updateOfflineRegionMetadata, "updateOfflineRegionMetadata"));
 }
 
 // OfflineRegionObserver //
@@ -227,7 +232,7 @@ void OfflineRegion::OfflineRegionStatusCallback::onError(jni::JNIEnv& env,
                                                           const jni::Object<OfflineRegion::OfflineRegionStatusCallback>& callback,
                                                           std::exception_ptr error) {
     static auto& javaClass = jni::Class<OfflineRegion::OfflineRegionStatusCallback>::Singleton(env);
-    static auto method = javaClass.GetMethod<void (jni::String)>(env, "onError");
+    static auto method = javaClass.GetMethod<void(jni::String)>(env, "onError");
 
     callback.Call(env, method, jni::Make<jni::String>(env, mbgl::util::toString(error)));
 }

--- a/platform/default/include/mbgl/storage/offline_database.hpp
+++ b/platform/default/include/mbgl/storage/offline_database.hpp
@@ -74,7 +74,7 @@ public:
     expected<OfflineRegionMetadata, std::exception_ptr>
     updateMetadata(const int64_t regionID, const OfflineRegionMetadata&);
 
-    std::exception_ptr deleteRegion(OfflineRegion&&);
+    std::exception_ptr deleteRegion(OfflineRegion&&, bool pack = true);
     std::exception_ptr invalidateRegion(int64_t regionID);
 
     // Return value is (response, stored size)
@@ -93,6 +93,7 @@ public:
     uint64_t getOfflineMapboxTileCount();
     bool exceedsOfflineMapboxTileCountLimit(const Resource&);
     void markUsedResources(int64_t regionID, const std::list<Resource>&);
+    std::exception_ptr pack();
 
 private:
     void initialize();

--- a/platform/default/include/mbgl/storage/offline_database.hpp
+++ b/platform/default/include/mbgl/storage/offline_database.hpp
@@ -74,7 +74,7 @@ public:
     expected<OfflineRegionMetadata, std::exception_ptr>
     updateMetadata(const int64_t regionID, const OfflineRegionMetadata&);
 
-    std::exception_ptr deleteRegion(OfflineRegion&&, bool pack = true);
+    std::exception_ptr deleteRegion(OfflineRegion&&);
     std::exception_ptr invalidateRegion(int64_t regionID);
 
     // Return value is (response, stored size)
@@ -94,6 +94,7 @@ public:
     bool exceedsOfflineMapboxTileCountLimit(const Resource&);
     void markUsedResources(int64_t regionID, const std::list<Resource>&);
     std::exception_ptr pack();
+    void runPackDatabaseAutomatically(bool autopack_) { autopack = autopack_; }
 
 private:
     void initialize();
@@ -148,6 +149,7 @@ private:
     optional<uint64_t> offlineMapboxTileCount;
 
     bool evict(uint64_t neededFreeSize);
+    bool autopack = true;
 };
 
 } // namespace mbgl

--- a/platform/default/src/mbgl/storage/default_file_source.cpp
+++ b/platform/default/src/mbgl/storage/default_file_source.cpp
@@ -82,9 +82,9 @@ public:
         }
     }
 
-    void deleteRegion(OfflineRegion&& region, std::function<void (std::exception_ptr)> callback) {
+    void deleteRegion(OfflineRegion&& region, std::function<void(std::exception_ptr)> callback, bool pack) {
         downloads.erase(region.getID());
-        callback(offlineDatabase->deleteRegion(std::move(region)));
+        callback(offlineDatabase->deleteRegion(std::move(region), pack));
     }
 
     void invalidateRegion(int64_t regionID, std::function<void (std::exception_ptr)> callback) {
@@ -200,6 +200,8 @@ public:
         callback(offlineDatabase->setMaximumAmbientCacheSize(size));
     }
 
+    void packDatabase(std::function<void(std::exception_ptr)> callback) { callback(offlineDatabase->pack()); }
+
 private:
     expected<OfflineDownload*, std::exception_ptr> getDownload(int64_t regionID) {
         auto it = downloads.find(regionID);
@@ -308,11 +310,14 @@ void DefaultFileSource::updateOfflineMetadata(const int64_t regionID,
     impl->actor().invoke(&Impl::updateMetadata, regionID, metadata, callback);
 }
 
-void DefaultFileSource::deleteOfflineRegion(OfflineRegion&& region, std::function<void (std::exception_ptr)> callback) {
-    impl->actor().invoke(&Impl::deleteRegion, std::move(region), callback);
+void DefaultFileSource::deleteOfflineRegion(OfflineRegion&& region,
+                                            std::function<void(std::exception_ptr)> callback,
+                                            bool pack) {
+    impl->actor().invoke(&Impl::deleteRegion, std::move(region), callback, pack);
 }
 
-void DefaultFileSource::invalidateOfflineRegion(OfflineRegion& region, std::function<void (std::exception_ptr)> callback) {
+void DefaultFileSource::invalidateOfflineRegion(OfflineRegion& region,
+                                                std::function<void(std::exception_ptr)> callback) {
     impl->actor().invoke(&Impl::invalidateRegion, region.getID(), callback);
 }
 
@@ -348,11 +353,15 @@ void DefaultFileSource::resetDatabase(std::function<void (std::exception_ptr)> c
     impl->actor().invoke(&Impl::resetDatabase, std::move(callback));
 }
 
+void DefaultFileSource::packDatabase(std::function<void(std::exception_ptr)> callback) {
+    impl->actor().invoke(&Impl::packDatabase, std::move(callback));
+}
+
 void DefaultFileSource::invalidateAmbientCache(std::function<void (std::exception_ptr)> callback) {
     impl->actor().invoke(&Impl::invalidateAmbientCache, std::move(callback));
 }
 
-void DefaultFileSource::clearAmbientCache(std::function<void (std::exception_ptr)> callback) {
+void DefaultFileSource::clearAmbientCache(std::function<void(std::exception_ptr)> callback) {
     impl->actor().invoke(&Impl::clearAmbientCache, std::move(callback));
 }
 

--- a/platform/default/src/mbgl/storage/default_file_source.cpp
+++ b/platform/default/src/mbgl/storage/default_file_source.cpp
@@ -82,9 +82,9 @@ public:
         }
     }
 
-    void deleteRegion(OfflineRegion&& region, std::function<void(std::exception_ptr)> callback, bool pack) {
+    void deleteRegion(OfflineRegion&& region, std::function<void(std::exception_ptr)> callback) {
         downloads.erase(region.getID());
-        callback(offlineDatabase->deleteRegion(std::move(region), pack));
+        callback(offlineDatabase->deleteRegion(std::move(region)));
     }
 
     void invalidateRegion(int64_t regionID, std::function<void (std::exception_ptr)> callback) {
@@ -202,6 +202,8 @@ public:
 
     void packDatabase(std::function<void(std::exception_ptr)> callback) { callback(offlineDatabase->pack()); }
 
+    void runPackDatabaseAutomatically(bool autopack) { offlineDatabase->runPackDatabaseAutomatically(autopack); }
+
 private:
     expected<OfflineDownload*, std::exception_ptr> getDownload(int64_t regionID) {
         auto it = downloads.find(regionID);
@@ -310,10 +312,8 @@ void DefaultFileSource::updateOfflineMetadata(const int64_t regionID,
     impl->actor().invoke(&Impl::updateMetadata, regionID, metadata, callback);
 }
 
-void DefaultFileSource::deleteOfflineRegion(OfflineRegion&& region,
-                                            std::function<void(std::exception_ptr)> callback,
-                                            bool pack) {
-    impl->actor().invoke(&Impl::deleteRegion, std::move(region), callback, pack);
+void DefaultFileSource::deleteOfflineRegion(OfflineRegion&& region, std::function<void(std::exception_ptr)> callback) {
+    impl->actor().invoke(&Impl::deleteRegion, std::move(region), callback);
 }
 
 void DefaultFileSource::invalidateOfflineRegion(OfflineRegion& region,
@@ -355,6 +355,10 @@ void DefaultFileSource::resetDatabase(std::function<void (std::exception_ptr)> c
 
 void DefaultFileSource::packDatabase(std::function<void(std::exception_ptr)> callback) {
     impl->actor().invoke(&Impl::packDatabase, std::move(callback));
+}
+
+void DefaultFileSource::runPackDatabaseAutomatically(bool autopack) {
+    impl->actor().invoke(&Impl::runPackDatabaseAutomatically, autopack);
 }
 
 void DefaultFileSource::invalidateAmbientCache(std::function<void (std::exception_ptr)> callback) {

--- a/platform/default/src/mbgl/storage/offline_database.cpp
+++ b/platform/default/src/mbgl/storage/offline_database.cpp
@@ -183,6 +183,7 @@ void OfflineDatabase::migrateToVersion6() {
 }
 
 void OfflineDatabase::vacuum() {
+    assert(db);
     if (getPragma<int64_t>("PRAGMA auto_vacuum") != 2 /*INCREMENTAL*/) {
         db->exec("PRAGMA auto_vacuum = INCREMENTAL");
         db->exec("VACUUM");
@@ -872,7 +873,7 @@ OfflineDatabase::updateMetadata(const int64_t regionID, const OfflineRegionMetad
     return unexpected<std::exception_ptr>(std::current_exception());
 }
 
-std::exception_ptr OfflineDatabase::deleteRegion(OfflineRegion&& region) try {
+std::exception_ptr OfflineDatabase::deleteRegion(OfflineRegion&& region, bool pack) try {
     {
         mapbox::sqlite::Query query{ getStatement("DELETE FROM regions WHERE id = ?") };
         query.bind(1, region.getID());
@@ -881,10 +882,10 @@ std::exception_ptr OfflineDatabase::deleteRegion(OfflineRegion&& region) try {
 
     evict(0);
     assert(db);
-    vacuum();
+    if (pack) vacuum();
 
     // Ensure that the cached offlineTileCount value is recalculated.
-    offlineMapboxTileCount = {};
+    offlineMapboxTileCount = nullopt;
     return nullptr;
 } catch (const mapbox::sqlite::Exception& ex) {
     handleError(ex, "delete region");
@@ -1296,6 +1297,15 @@ void OfflineDatabase::markUsedResources(int64_t regionID, const std::list<Resour
     transaction.commit();
 } catch (const mapbox::sqlite::Exception& ex) {
     handleError(ex, "mark resources as used");
+}
+
+std::exception_ptr OfflineDatabase::pack() try {
+    if (!db) initialize();
+    vacuum();
+    return nullptr;
+} catch (const mapbox::sqlite::Exception& ex) {
+    handleError(ex, "pack storage");
+    return std::current_exception();
 }
 
 std::exception_ptr OfflineDatabase::resetDatabase() try {

--- a/test/storage/offline_database.test.cpp
+++ b/test/storage/offline_database.test.cpp
@@ -701,7 +701,8 @@ TEST(OfflineDatabase, TEST_REQUIRES_WRITE(DeleteRegion)) {
         db.putRegionResources(region2->getID(), generateResources("mapbox://tile_2", "mapbox://style_2"), status);
         const size_t sizeWithTwoRegions = util::read_file(filename).size();
 
-        db.deleteRegion(std::move(*region1), false /*pack*/);
+        db.runPackDatabaseAutomatically(false);
+        db.deleteRegion(std::move(*region1));
 
         ASSERT_EQ(1u, db.listRegions().value().size());
         // Region is removed but the size of the database is the same.
@@ -711,7 +712,7 @@ TEST(OfflineDatabase, TEST_REQUIRES_WRITE(DeleteRegion)) {
         // The size of the database has shrunk after pack().
         const size_t sizeWithOneRegion = util::read_file(filename).size();
         EXPECT_LT(sizeWithOneRegion, sizeWithTwoRegions);
-
+        db.runPackDatabaseAutomatically(true);
         db.deleteRegion(std::move(*region2));
         // The size of the database has shrunk right away.
         const size_t sizeWithoutRegions = util::read_file(filename).size();


### PR DESCRIPTION
This pull request CPs pieces of https://github.com/mapbox/mapbox-gl-native/pull/15899 and https://github.com/mapbox/mapbox-gl-native/pull/15967 and introduces `OfflineManager.runPackDatabaseAutomatically(boolean)` and `OfflineManager. packDatabase(boolean)` API in order to enable decoupling vacuum operation from other operations run on the offline database file (delete offline region, clear ambient cache) 