### PR TITLE
Random Crash Fix in `MGLMapView+Impl`!

### DIFF
--- a/platform/ios/src/MGLMapView+Impl.mm
+++ b/platform/ios/src/MGLMapView+Impl.mm
@@ -104,8 +104,7 @@ void MGLMapViewImpl::onDidBecomeIdle() {
 }
 
 void MGLMapViewImpl::onStyleImageMissing(const std::string& imageIdentifier) {
-    NSString *imageName = [NSString stringWithUTF8String:imageIdentifier.c_str()];
-    [mapView didFailToLoadImage:imageName];
+    [mapView didFailToLoadImage:@(imageIdentifier.data())];
 }
 
 bool MGLMapViewImpl::onCanRemoveUnusedStyleImage(const std::string &imageIdentifier) {


### PR DESCRIPTION
- We notice this crash happens randomly in `MGLMapView+Impl`.

- .data() is idomatic c++11, and c_str() is same, but is the old school method, and @() is modern obj-c, so the compiler will do the conversion.