### PR TITLE
Always passing empty edgeInsets to padding.

### DIFF
--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -90,7 +90,7 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
         // reuse flyTo, without exaggerated animation, to achieve constant ground speed.
         return flyTo(camera, animation, true);
     }
-    const EdgeInsets& padding = camera.padding.value_or(state.getEdgeInsets());
+    const EdgeInsets& padding = camera.padding.value_or(mbgl::EdgeInsets());
     LatLng startLatLng = getLatLng(LatLng::Unwrapped);
     const LatLng& unwrappedLatLng = camera.center.value_or(startLatLng);
     const LatLng& latLng = state.getLatLngBounds() != LatLngBounds() ? unwrappedLatLng : unwrappedLatLng.wrapped();


### PR DESCRIPTION
- Padding is now an optional value.
- when padding is empty (from a transition unrelated to explicit animations, such as gesture handling), edgeInsets get a random value.
- this always passes empty edgeInsets to padding.

** Checked only on iOS and Android **