### PR TITLE
[test runner] Explicitly initialize TestContext POD members

### DIFF
--- a/render-test/metadata.hpp
+++ b/render-test/metadata.hpp
@@ -181,8 +181,8 @@ public:
     virtual TestRunnerMapObserver& getObserver() = 0;
     virtual TestMetadata& getMetadata() = 0;
 
-    GfxProbe activeGfxProbe;
-    GfxProbe baselineGfxProbe;
+    GfxProbe activeGfxProbe{};
+    GfxProbe baselineGfxProbe{};
     bool gfxProbeActive = false;
 
 protected:


### PR DESCRIPTION
Otherwise they are left uninitialized and cause GFX metrics failures.