### PR TITLE
[metrics] Remove **/token from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ xcuserdata
 /platform/ios/benchmark/assets/glyphs/DIN*
 /platform/ios/benchmark/assets/tiles/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6
 /platform/darwin/developer.xcconfig
-**/token
 /platform/macos/macos.xcworkspace/xcshareddata/macos.xcscmblueprint
 /platform/ios/ios.xcworkspace/xcshareddata/ios.xcscmblueprint
 /documentation

--- a/metrics/next-android-render-test-runner/render-tests/icon-image/token/metrics.json
+++ b/metrics/next-android-render-test-runner/render-tests/icon-image/token/metrics.json
@@ -1,0 +1,35 @@
+{
+    "network": [
+        [
+            "probeNetwork - default - end",
+            2,
+            211659
+        ],
+        [
+            "probeNetwork - default - start",
+            0,
+            0
+        ]
+    ],
+    "gfx": [
+        [
+            "probeGFX - default - end",
+            1,
+            4,
+            9,
+            1,
+            [
+                25088,
+                25088
+            ],
+            [
+                46,
+                46
+            ],
+            [
+                320,
+                320
+            ]
+        ]
+    ]
+}

--- a/metrics/next-android-render-test-runner/render-tests/text-field/token/metrics.json
+++ b/metrics/next-android-render-test-runner/render-tests/text-field/token/metrics.json
@@ -1,0 +1,35 @@
+{
+    "network": [
+        [
+            "probeNetwork - default - end",
+            1,
+            84942
+        ],
+        [
+            "probeNetwork - default - start",
+            0,
+            0
+        ]
+    ],
+    "gfx": [
+        [
+            "probeGFX - default - end",
+            1,
+            4,
+            9,
+            1,
+            [
+                36568,
+                36568
+            ],
+            [
+                142,
+                142
+            ],
+            [
+                1344,
+                1344
+            ]
+        ]
+    ]
+}

--- a/metrics/next-linux-clang8-release/render-tests/icon-image/token/metrics.json
+++ b/metrics/next-linux-clang8-release/render-tests/icon-image/token/metrics.json
@@ -1,0 +1,35 @@
+{
+    "network": [
+        [
+            "probeNetwork - default - end",
+            2,
+            211659
+        ],
+        [
+            "probeNetwork - default - start",
+            0,
+            0
+        ]
+    ],
+    "gfx": [
+        [
+            "probeGFX - default - end",
+            1,
+            4,
+            9,
+            1,
+            [
+                25088,
+                25088
+            ],
+            [
+                46,
+                46
+            ],
+            [
+                320,
+                320
+            ]
+        ]
+    ]
+}

--- a/metrics/next-linux-clang8-release/render-tests/text-field/token/metrics.json
+++ b/metrics/next-linux-clang8-release/render-tests/text-field/token/metrics.json
@@ -1,0 +1,35 @@
+{
+    "network": [
+        [
+            "probeNetwork - default - end",
+            1,
+            84942
+        ],
+        [
+            "probeNetwork - default - start",
+            0,
+            0
+        ]
+    ],
+    "gfx": [
+        [
+            "probeGFX - default - end",
+            1,
+            4,
+            9,
+            1,
+            [
+                36568,
+                36568
+            ],
+            [
+                142,
+                142
+            ],
+            [
+                1344,
+                1344
+            ]
+        ]
+    ]
+}

--- a/metrics/next-linux-gcc8-release/render-tests/icon-image/token/metrics.json
+++ b/metrics/next-linux-gcc8-release/render-tests/icon-image/token/metrics.json
@@ -1,0 +1,35 @@
+{
+    "network": [
+        [
+            "probeNetwork - default - end",
+            2,
+            211659
+        ],
+        [
+            "probeNetwork - default - start",
+            0,
+            0
+        ]
+    ],
+    "gfx": [
+        [
+            "probeGFX - default - end",
+            1,
+            4,
+            9,
+            1,
+            [
+                25088,
+                25088
+            ],
+            [
+                46,
+                46
+            ],
+            [
+                320,
+                320
+            ]
+        ]
+    ]
+}

--- a/metrics/next-linux-gcc8-release/render-tests/text-field/token/metrics.json
+++ b/metrics/next-linux-gcc8-release/render-tests/text-field/token/metrics.json
@@ -1,0 +1,35 @@
+{
+    "network": [
+        [
+            "probeNetwork - default - end",
+            1,
+            84942
+        ],
+        [
+            "probeNetwork - default - start",
+            0,
+            0
+        ]
+    ],
+    "gfx": [
+        [
+            "probeGFX - default - end",
+            1,
+            4,
+            9,
+            1,
+            [
+                36568,
+                36568
+            ],
+            [
+                142,
+                142
+            ],
+            [
+                1344,
+                1344
+            ]
+        ]
+    ]
+}

--- a/metrics/next-macos-xcode11-release/render-tests/icon-image/token/metrics.json
+++ b/metrics/next-macos-xcode11-release/render-tests/icon-image/token/metrics.json
@@ -1,0 +1,35 @@
+{
+    "network": [
+        [
+            "probeNetwork - default - end",
+            2,
+            211659
+        ],
+        [
+            "probeNetwork - default - start",
+            0,
+            0
+        ]
+    ],
+    "gfx": [
+        [
+            "probeGFX - default - end",
+            1,
+            4,
+            9,
+            1,
+            [
+                25088,
+                25088
+            ],
+            [
+                46,
+                46
+            ],
+            [
+                320,
+                320
+            ]
+        ]
+    ]
+}

--- a/metrics/next-macos-xcode11-release/render-tests/text-field/token/metrics.json
+++ b/metrics/next-macos-xcode11-release/render-tests/text-field/token/metrics.json
@@ -1,0 +1,35 @@
+{
+    "network": [
+        [
+            "probeNetwork - default - end",
+            1,
+            84942
+        ],
+        [
+            "probeNetwork - default - start",
+            0,
+            0
+        ]
+    ],
+    "gfx": [
+        [
+            "probeGFX - default - end",
+            1,
+            4,
+            9,
+            1,
+            [
+                36568,
+                36568
+            ],
+            [
+                142,
+                142
+            ],
+            [
+                1344,
+                1344
+            ]
+        ]
+    ]
+}


### PR DESCRIPTION
This explains why these tests were not being rebaselined...