### PR TITLE
[android][core] Add `Map::latLngBoundsForCameraUnwrapped` and jni binding for `getVisibleCoordinateBounds`.

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -72,6 +72,7 @@ public:
     CameraOptions cameraForLatLngs(const std::vector<LatLng>&, const EdgeInsets&, optional<double> bearing = {}, optional<double> pitch = {}) const;
     CameraOptions cameraForGeometry(const Geometry<double>&, const EdgeInsets&, optional<double> bearing = {}, optional<double> pitch = {}) const;
     LatLngBounds latLngBoundsForCamera(const CameraOptions&) const;
+    LatLngBounds latLngBoundsForCameraUnwrapped(const CameraOptions&) const;
 
     /// @name Bounds
     /// @{

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -529,6 +529,64 @@ void NativeMapView::setVisibleCoordinateBounds(JNIEnv& env, const jni::Array<jni
     map->easeTo(cameraOptions, animationOptions);
 }
 
+void NativeMapView::getVisibleCoordinateBounds(JNIEnv& env,
+                                     jint screenWidth,
+                                     jint screenHeight,
+                                     jni::Array<jdouble>& output,
+                                     jfloat pixelRatio_) {
+    mbgl::LatLng southEast = map->latLngForPixel(mbgl::ScreenCoordinate(screenWidth / pixelRatio_, screenHeight / pixelRatio_));
+    mbgl::LatLng northEast = map->latLngForPixel(mbgl::ScreenCoordinate(screenWidth / pixelRatio_, 0.0));
+    mbgl::LatLng southWest = map->latLngForPixel(mbgl::ScreenCoordinate(0.0, screenHeight / pixelRatio_));
+    mbgl::LatLng northWest = map->latLngForPixel(mbgl::ScreenCoordinate(0.0, 0.0));
+    mbgl::LatLng center = map->latLngForPixel(mbgl::ScreenCoordinate(screenWidth / (2 * pixelRatio_), screenHeight / (2 * pixelRatio_)));
+
+    double latitudes[] = {southEast.latitude(), northEast.latitude(), southWest.latitude(), northWest.latitude()};
+    double longitudes[] = {southEast.longitude(), northEast.longitude(), southWest.longitude(), northWest.longitude()};
+
+    auto latitudeMinMax = std::minmax_element(std::begin(latitudes), std::end(latitudes));
+
+    double latNorth = *(latitudeMinMax.second);
+    double latSouth = *(latitudeMinMax.first);
+
+    double lonEast = -180.0;
+    double lonWest = 180.0;
+    double centerLongitude = center.longitude();
+    auto longitudeMinMax = std::minmax_element(std::begin(longitudes), std::end(longitudes));
+
+    // check if the bounds is over dateline
+    if (std::abs(centerLongitude - (*(longitudeMinMax.first) + *(longitudeMinMax.second)) / 2) > 0.1) {
+        for (int i = 0; i < 4; i++) {
+            double longitude = longitudes[i];
+            if (longitude < 0) {
+                if (lonEast < longitude) {
+                    lonEast = longitude;
+                }
+            } else {
+                if (lonWest > longitude) {
+                    lonWest = longitude;
+                }
+            }
+        }
+    } else {
+        lonEast = *(longitudeMinMax.second);
+        lonWest = *(longitudeMinMax.first);
+    }
+
+    // lonEast should be no less than lonWest
+    lonEast = lonEast > lonWest ? lonEast : lonEast + 360;
+
+    std::vector<jdouble> buffer;
+    buffer.reserve(4);
+
+    // Order of the LatLngBounds: double latNorth, double lonEast, double latSouth, double lonWest
+    buffer.push_back(latNorth);
+    buffer.push_back(lonEast);
+    buffer.push_back(latSouth);
+    buffer.push_back(lonWest);
+
+    output.SetRegion<std::vector<jdouble>>(env, 0, buffer);
+}
+
 void NativeMapView::scheduleSnapshot(jni::JNIEnv&) {
     mapRenderer.requestSnapshot([&](PremultipliedImage image) {
         auto _env = android::AttachEnv();
@@ -1172,6 +1230,7 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
         METHOD(&NativeMapView::projectedMetersForLatLng, "nativeProjectedMetersForLatLng"),
         METHOD(&NativeMapView::pixelForLatLng, "nativePixelForLatLng"),
         METHOD(&NativeMapView::pixelsForLatLngs, "nativePixelsForLatLngs"),
+        METHOD(&NativeMapView::getVisibleCoordinateBounds, "nativeGetVisibleCoordinateBounds"),
         METHOD(&NativeMapView::latLngForProjectedMeters, "nativeLatLngForProjectedMeters"),
         METHOD(&NativeMapView::latLngForPixel, "nativeLatLngForPixel"),
         METHOD(&NativeMapView::latLngsForPixels, "nativeLatLngsForPixels"),

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -529,16 +529,15 @@ void NativeMapView::setVisibleCoordinateBounds(JNIEnv& env, const jni::Array<jni
     map->easeTo(cameraOptions, animationOptions);
 }
 
-void NativeMapView::getVisibleCoordinateBounds(JNIEnv& env,
-                                     jint screenWidth,
-                                     jint screenHeight,
-                                     jni::Array<jdouble>& output,
-                                     jfloat pixelRatio_) {
-    mbgl::LatLng southEast = map->latLngForPixel(mbgl::ScreenCoordinate(screenWidth / pixelRatio_, screenHeight / pixelRatio_));
+void NativeMapView::getVisibleCoordinateBounds(
+    JNIEnv& env, jint screenWidth, jint screenHeight, jni::Array<jdouble>& output, jfloat pixelRatio_) {
+    mbgl::LatLng southEast =
+        map->latLngForPixel(mbgl::ScreenCoordinate(screenWidth / pixelRatio_, screenHeight / pixelRatio_));
     mbgl::LatLng northEast = map->latLngForPixel(mbgl::ScreenCoordinate(screenWidth / pixelRatio_, 0.0));
     mbgl::LatLng southWest = map->latLngForPixel(mbgl::ScreenCoordinate(0.0, screenHeight / pixelRatio_));
     mbgl::LatLng northWest = map->latLngForPixel(mbgl::ScreenCoordinate(0.0, 0.0));
-    mbgl::LatLng center = map->latLngForPixel(mbgl::ScreenCoordinate(screenWidth / (2 * pixelRatio_), screenHeight / (2 * pixelRatio_)));
+    mbgl::LatLng center =
+        map->latLngForPixel(mbgl::ScreenCoordinate(screenWidth / (2 * pixelRatio_), screenHeight / (2 * pixelRatio_)));
 
     double latitudes[] = {southEast.latitude(), northEast.latitude(), southWest.latitude(), northWest.latitude()};
     double longitudes[] = {southEast.longitude(), northEast.longitude(), southWest.longitude(), northWest.longitude()};

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -530,7 +530,7 @@ void NativeMapView::setVisibleCoordinateBounds(JNIEnv& env, const jni::Array<jni
 }
 
 void NativeMapView::getVisibleCoordinateBounds(JNIEnv& env, jni::Array<jdouble>& output) {
-    auto latlngBounds = map->latLngBoundsForCamera(map->getCameraOptions(mbgl::nullopt));
+    auto latlngBounds = map->latLngBoundsForCameraUnwrapped(map->getCameraOptions(mbgl::nullopt));
 
     double latNorth = latlngBounds.north();
     double lonEast = latlngBounds.east();

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -139,8 +139,7 @@ public:
 
     void setVisibleCoordinateBounds(JNIEnv&, const jni::Array<jni::Object<LatLng>>&, const jni::Object<RectF>&, jni::jdouble, jni::jlong);
 
-    void getVisibleCoordinateBounds(
-        JNIEnv& env, jint screenWidth, jint screenHeight, jni::Array<jdouble>& output, jfloat pixelRatio_);
+    void getVisibleCoordinateBounds(JNIEnv& env, jni::Array<jdouble>& output);
 
     void scheduleSnapshot(jni::JNIEnv&);
 

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -139,7 +139,8 @@ public:
 
     void setVisibleCoordinateBounds(JNIEnv&, const jni::Array<jni::Object<LatLng>>&, const jni::Object<RectF>&, jni::jdouble, jni::jlong);
 
-    void getVisibleCoordinateBounds(JNIEnv& env, jint screenWidth, jint screenHeight, jni::Array<jdouble>& output, jfloat pixelRatio_);
+    void getVisibleCoordinateBounds(
+        JNIEnv& env, jint screenWidth, jint screenHeight, jni::Array<jdouble>& output, jfloat pixelRatio_);
 
     void scheduleSnapshot(jni::JNIEnv&);
 

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -139,6 +139,8 @@ public:
 
     void setVisibleCoordinateBounds(JNIEnv&, const jni::Array<jni::Object<LatLng>>&, const jni::Object<RectF>&, jni::jdouble, jni::jlong);
 
+    void getVisibleCoordinateBounds(JNIEnv& env, jint screenWidth, jint screenHeight, jni::Array<jdouble>& output, jfloat pixelRatio_);
+
     void scheduleSnapshot(jni::JNIEnv&);
 
     jni::Local<jni::Object<CameraPosition>> getCameraPosition(jni::JNIEnv&);

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -250,6 +250,17 @@ LatLngBounds Map::latLngBoundsForCamera(const CameraOptions& camera) const {
     Size size = shallow.getState().getSize();
 
     shallow.jumpTo(camera);
+    return LatLngBounds::hull(
+        shallow.screenCoordinateToLatLng({}),
+        shallow.screenCoordinateToLatLng({ double(size.width), double(size.height) })
+    );
+}
+
+LatLngBounds Map::latLngBoundsForCameraUnwrapped(const CameraOptions& camera) const {
+    Transform shallow{impl->transform.getState()};
+    Size size = shallow.getState().getSize();
+
+    shallow.jumpTo(camera);
     LatLng nw = shallow.screenCoordinateToLatLng({});
     LatLng se = shallow.screenCoordinateToLatLng({double(size.width), double(size.height)});
     LatLng ne = shallow.screenCoordinateToLatLng({double(size.width), 0.0});

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -250,10 +250,20 @@ LatLngBounds Map::latLngBoundsForCamera(const CameraOptions& camera) const {
     Size size = shallow.getState().getSize();
 
     shallow.jumpTo(camera);
-    return LatLngBounds::hull(
-        shallow.screenCoordinateToLatLng({}),
-        shallow.screenCoordinateToLatLng({ double(size.width), double(size.height) })
-    );
+    LatLng nw = shallow.screenCoordinateToLatLng({});
+    LatLng se = shallow.screenCoordinateToLatLng({double(size.width), double(size.height)});
+    LatLng ne = shallow.screenCoordinateToLatLng({double(size.width), 0.0});
+    LatLng sw = shallow.screenCoordinateToLatLng({0.0, double(size.height)});
+    LatLng center = shallow.screenCoordinateToLatLng({double(size.width) / 2, double(size.height) / 2});
+    nw.unwrapForShortestPath(center);
+    se.unwrapForShortestPath(center);
+    ne.unwrapForShortestPath(center);
+    sw.unwrapForShortestPath(center);
+    LatLngBounds bounds = LatLngBounds::hull(nw, se);
+    bounds.extend(ne);
+    bounds.extend(sw);
+    bounds.extend(center);
+    return bounds;
 }
 
 #pragma mark - Bounds

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -252,7 +252,7 @@ TEST(Map, CameraToLatLngBounds) {
     ASSERT_NEAR(camera.center->longitude(), virtualCamera.center->longitude(), 1e-7);
 }
 
-TEST(Map, CameraToLatLngBoundsWithRotation) {
+TEST(Map, CameraToLatLngBoundsUnwrappedWithRotation) {
     MapTest<> test;
 
     test.map.jumpTo(CameraOptions().withCenter(LatLng{45, 90}).withZoom(16.0).withBearing(45.0));
@@ -261,16 +261,18 @@ TEST(Map, CameraToLatLngBoundsWithRotation) {
 
     CameraOptions camera = test.map.getCameraOptions();
 
-    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).contains(test.map.latLngForPixel({})));
-    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).contains(test.map.latLngForPixel({0.0, double(size.height)})));
-    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).contains(test.map.latLngForPixel({double(size.width), 0.0})));
-    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).contains(
+    ASSERT_TRUE(test.map.latLngBoundsForCameraUnwrapped(camera).contains(test.map.latLngForPixel({})));
+    ASSERT_TRUE(
+        test.map.latLngBoundsForCameraUnwrapped(camera).contains(test.map.latLngForPixel({0.0, double(size.height)})));
+    ASSERT_TRUE(
+        test.map.latLngBoundsForCameraUnwrapped(camera).contains(test.map.latLngForPixel({double(size.width), 0.0})));
+    ASSERT_TRUE(test.map.latLngBoundsForCameraUnwrapped(camera).contains(
         test.map.latLngForPixel({double(size.width), double(size.height)})));
-    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).contains(
+    ASSERT_TRUE(test.map.latLngBoundsForCameraUnwrapped(camera).contains(
         test.map.latLngForPixel({double(size.width) / 2, double(size.height) / 2})));
 }
 
-TEST(Map, CameraToLatLngBoundsCrossDateLine) {
+TEST(Map, CameraToLatLngBoundsUnwrappedCrossDateLine) {
     MapTest<> test;
 
     test.map.jumpTo(CameraOptions().withCenter(LatLng{0, 180}).withZoom(16.0));
@@ -279,17 +281,17 @@ TEST(Map, CameraToLatLngBoundsCrossDateLine) {
 
     CameraOptions camera = test.map.getCameraOptions();
 
-    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).contains(test.map.latLngForPixel({}), LatLng::Wrapped));
-    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).contains(test.map.latLngForPixel({0.0, double(size.height)}),
-                                                                LatLng::Wrapped));
-    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).contains(test.map.latLngForPixel({double(size.width), 0.0}),
-                                                                LatLng::Wrapped));
-    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).contains(
+    ASSERT_TRUE(test.map.latLngBoundsForCameraUnwrapped(camera).contains(test.map.latLngForPixel({}), LatLng::Wrapped));
+    ASSERT_TRUE(test.map.latLngBoundsForCameraUnwrapped(camera).contains(
+        test.map.latLngForPixel({0.0, double(size.height)}), LatLng::Wrapped));
+    ASSERT_TRUE(test.map.latLngBoundsForCameraUnwrapped(camera).contains(
+        test.map.latLngForPixel({double(size.width), 0.0}), LatLng::Wrapped));
+    ASSERT_TRUE(test.map.latLngBoundsForCameraUnwrapped(camera).contains(
         test.map.latLngForPixel({double(size.width), double(size.height)}), LatLng::Wrapped));
-    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).contains(
+    ASSERT_TRUE(test.map.latLngBoundsForCameraUnwrapped(camera).contains(
         test.map.latLngForPixel({double(size.width) / 2, double(size.height) / 2})));
 
-    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).crossesAntimeridian());
+    ASSERT_TRUE(test.map.latLngBoundsForCameraUnwrapped(camera).crossesAntimeridian());
 }
 
 TEST(Map, Offline) {

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -252,6 +252,46 @@ TEST(Map, CameraToLatLngBounds) {
     ASSERT_NEAR(camera.center->longitude(), virtualCamera.center->longitude(), 1e-7);
 }
 
+TEST(Map, CameraToLatLngBoundsWithRotation) {
+    MapTest<> test;
+
+    test.map.jumpTo(CameraOptions().withCenter(LatLng{45, 90}).withZoom(16.0).withBearing(45.0));
+
+    const Size size = test.map.getMapOptions().size();
+
+    CameraOptions camera = test.map.getCameraOptions();
+
+    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).contains(test.map.latLngForPixel({})));
+    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).contains(test.map.latLngForPixel({0.0, double(size.height)})));
+    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).contains(test.map.latLngForPixel({double(size.width), 0.0})));
+    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).contains(
+        test.map.latLngForPixel({double(size.width), double(size.height)})));
+    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).contains(
+        test.map.latLngForPixel({double(size.width) / 2, double(size.height) / 2})));
+}
+
+TEST(Map, CameraToLatLngBoundsCrossDateLine) {
+    MapTest<> test;
+
+    test.map.jumpTo(CameraOptions().withCenter(LatLng{0, 180}).withZoom(16.0));
+
+    const Size size = test.map.getMapOptions().size();
+
+    CameraOptions camera = test.map.getCameraOptions();
+
+    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).contains(test.map.latLngForPixel({}), LatLng::Wrapped));
+    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).contains(test.map.latLngForPixel({0.0, double(size.height)}),
+                                                                LatLng::Wrapped));
+    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).contains(test.map.latLngForPixel({double(size.width), 0.0}),
+                                                                LatLng::Wrapped));
+    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).contains(
+        test.map.latLngForPixel({double(size.width), double(size.height)}), LatLng::Wrapped));
+    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).contains(
+        test.map.latLngForPixel({double(size.width) / 2, double(size.height) / 2})));
+
+    ASSERT_TRUE(test.map.latLngBoundsForCamera(camera).crossesAntimeridian());
+}
+
 TEST(Map, Offline) {
     MapTest<DefaultFileSource> test {":memory:", "."};
 


### PR DESCRIPTION
refs https://github.com/mapbox/mapbox-gl-native-android/issues/81 

This PR adds Android jni binding for `getVisibleCoordinateBound`. 
This PR also addes `Map::latLngBoundsForCameraUnwrapped(const CameraOptions& camera)` to  handle the rotated map and the case when the region is across the dateline.