### PR TITLE
Remove 'sourcesMap' on style parser

### DIFF
--- a/src/mbgl/style/parser.cpp
+++ b/src/mbgl/style/parser.cpp
@@ -158,7 +158,6 @@ void Parser::parseSources(const JSValue& value) {
             continue;
         }
 
-        sourcesMap.emplace(id, (*source).get());
         sources.emplace_back(std::move(*source));
     }
 }

--- a/src/mbgl/style/parser.hpp
+++ b/src/mbgl/style/parser.hpp
@@ -52,7 +52,6 @@ private:
     void parseLayers(const JSValue&);
     void parseLayer(const std::string& id, const JSValue&, std::unique_ptr<Layer>&);
 
-    std::unordered_map<std::string, const Source*> sourcesMap;
     std::unordered_map<std::string, std::pair<const JSValue&, std::unique_ptr<Layer>>> layersMap;
 
     // Store a stack of layer IDs we're parsing right now. This is to prevent reference cycles.


### PR DESCRIPTION
This removes the `sourcesMap` member of `mbgl::style::Parser` because I noticed that it is a private member that is not used in any meaningful way (that I can see) in the implementation.

So, if I'm right that it is basically unused code, this should reduce memory usage needs for style parsing.