### PR TITLE
[core] Handle zero text size

### DIFF
--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -359,7 +359,7 @@ void SymbolLayout::prepareSymbols(const GlyphMap& glyphMap,
         const float layoutIconSize = layout->evaluate<IconSize>(zoom + 1, feature);
 
         // if feature has text, shape the text
-        if (feature.formattedText) {
+        if (feature.formattedText && layoutTextSize > 0.0f) {
             const float lineHeight = layout->get<TextLineHeight>() * util::ONE_EM;
             const float spacing = util::i18n::allowsLetterSpacing(feature.formattedText->rawText()) ? layout->evaluate<TextLetterSpacing>(zoom, feature) * util::ONE_EM : 0.0f;
 


### PR DESCRIPTION
The style specification stipulates that `text-size` values must be positive
(https://docs.mapbox.com/mapbox-gl-js/style-spec/#layout-symbol-text-size).

However, a zero value could be passed to the engine (e.g. as a result of
an expression). This PR handles it and thus avoids an assertion hit in `shaping.cpp`.

The render test : https://github.com/mapbox/mapbox-gl-js/pull/9133

Fixes https://github.com/mapbox/mapbox-gl-native-team/issues/129