### PR TITLE
[build] Make the configuration simpler

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,18 +27,21 @@ workflows:
           executor_name: ubuntu-disco
           target_is_android: true
           config_params: '-G Ninja -DCMAKE_INSTALL_PREFIX=/tmp/workspace/install/$CIRCLE_JOB -DCMAKE_TOOLCHAIN_FILE=/opt/android/ndk-bundle/build/cmake/android.toolchain.cmake -DANDROID_CCACHE=/usr/bin/ccache -DANDROID_ABI=arm64-v8a'
+          build_params: '--target libmapbox-gl.so'
           install: true
       - next-build-template:
           name: next-android-x86-release
           executor_name: ubuntu-disco
           target_is_android: true
           config_params: '-G Ninja -DCMAKE_INSTALL_PREFIX=/tmp/workspace/install/$CIRCLE_JOB -DCMAKE_TOOLCHAIN_FILE=/opt/android/ndk-bundle/build/cmake/android.toolchain.cmake -DANDROID_CCACHE=/usr/bin/ccache -DANDROID_ABI=x86'
+          build_params: '--target libmapbox-gl.so'
           install: true
       - next-build-template:
           name: next-android-x86_64-release
           executor_name: ubuntu-disco
           target_is_android: true
           config_params: '-G Ninja -DCMAKE_INSTALL_PREFIX=/tmp/workspace/install/$CIRCLE_JOB -DCMAKE_TOOLCHAIN_FILE=/opt/android/ndk-bundle/build/cmake/android.toolchain.cmake -DANDROID_CCACHE=/usr/bin/ccache -DANDROID_ABI=x86_64'
+          build_params: '--target libmapbox-gl.so'
           install: true
       - next-build-template:
           name: next-linux-gcc8-release

--- a/next/CMakeLists.txt
+++ b/next/CMakeLists.txt
@@ -14,14 +14,6 @@ set(
 
 include(CTest)
 
-set(
-    CMAKE_CONFIGURATION_TYPES
-    Debug
-    MinSizeRel
-    RelWithDebInfo
-    Release
-)
-
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()

--- a/next/benchmark/CMakeLists.txt
+++ b/next/benchmark/CMakeLists.txt
@@ -39,8 +39,4 @@ target_link_libraries(
         $<$<PLATFORM_ID:Android>:mbgl-core-android>
 )
 
-if(CMAKE_SYSTEM_NAME STREQUAL Android)
-    set_target_properties(mbgl-benchmark PROPERTIES LINK_FLAGS_RELEASE "-fuse-ld=gold -O2 -flto -Wl,--icf=safe")
-endif()
-
 set_property(TARGET mbgl-benchmark PROPERTY FOLDER Core)

--- a/next/platform/android/android.cmake
+++ b/next/platform/android/android.cmake
@@ -7,6 +7,30 @@ target_compile_definitions(
     PUBLIC MBGL_USE_GLES2
 )
 
+include(${PROJECT_SOURCE_DIR}/vendor/icu.cmake)
+include(${PROJECT_SOURCE_DIR}/vendor/sqlite.cmake)
+
+target_compile_options(mbgl-vendor-icu PRIVATE $<$<CONFIG:Release>:-Oz> $<$<CONFIG:Release>:-Qunused-arguments> $<$<CONFIG:Release>:-flto>)
+
+target_compile_options(
+    mbgl-vendor-sqlite
+    PRIVATE $<$<CONFIG:Release>:-Oz> $<$<CONFIG:Release>:-Qunused-arguments> $<$<CONFIG:Release>:-flto>
+)
+
+target_compile_options(
+    mbgl-compiler-options
+    INTERFACE $<$<CONFIG:Release>:-Oz> $<$<CONFIG:Release>:-Qunused-arguments> $<$<CONFIG:Release>:-flto>
+)
+
+target_link_libraries(
+    mbgl-compiler-options
+    INTERFACE
+        $<$<CONFIG:Release>:-O2>
+        $<$<CONFIG:Release>:-Wl,--icf=all>
+        $<$<CONFIG:Release>:-flto>
+        $<$<CONFIG:Release>:-fuse-ld=gold>
+)
+
 target_sources(
     mbgl-core
     PRIVATE
@@ -214,9 +238,6 @@ target_include_directories(
     PRIVATE ${MBGL_ROOT}/platform/default/include
 )
 
-include(${PROJECT_SOURCE_DIR}/vendor/icu.cmake)
-include(${PROJECT_SOURCE_DIR}/vendor/sqlite.cmake)
-
 target_link_libraries(
     mbgl-core
     PRIVATE
@@ -364,20 +385,5 @@ add_custom_command(
         --files-from=render-test/android/app/src/main/assets/to_zip.txt
     WORKING_DIRECTORY ${MBGL_ROOT}
 )
-
-# Android has no concept of MinSizeRel on android.toolchain.cmake and provides configurations tuned for binary size. We can push it a bit
-# more with code folding and LTO.
-set_target_properties(example-custom-layer PROPERTIES LINK_FLAGS_RELEASE "-fuse-ld=gold -O2 -flto -Wl,--icf=all")
-set_target_properties(mapbox-gl PROPERTIES LINK_FLAGS_RELEASE "-fuse-ld=gold -O2 -flto -Wl,--icf=all")
-set_target_properties(mbgl-benchmark-runner PROPERTIES LINK_FLAGS_RELEASE "-fuse-ld=gold -O2 -flto -Wl,--icf=all")
-set_target_properties(mbgl-render-test-runner PROPERTIES LINK_FLAGS_RELEASE "-fuse-ld=gold -O2 -flto -Wl,--icf=all")
-set_target_properties(mbgl-test-runner PROPERTIES LINK_FLAGS_RELEASE "-fuse-ld=gold -O2 -flto -Wl,--icf=all")
-
-target_compile_options(example-custom-layer PRIVATE $<$<CONFIG:Release>:-Oz -Qunused-arguments -flto>)
-target_compile_options(mapbox-gl PRIVATE $<$<CONFIG:Release>:-Oz -Qunused-arguments -flto>)
-target_compile_options(mbgl-core PRIVATE $<$<CONFIG:Release>:-Oz -Qunused-arguments -flto>)
-target_compile_options(mbgl-render-test-runner PRIVATE $<$<CONFIG:Release>:-Oz -Qunused-arguments -flto>)
-target_compile_options(mbgl-vendor-icu PRIVATE $<$<CONFIG:Release>:-Oz -Qunused-arguments -flto>)
-target_compile_options(mbgl-vendor-sqlite PRIVATE $<$<CONFIG:Release>:-Oz -Qunused-arguments -flto>)
 
 install(TARGETS mapbox-gl LIBRARY DESTINATION lib)

--- a/next/render-test/CMakeLists.txt
+++ b/next/render-test/CMakeLists.txt
@@ -47,8 +47,4 @@ target_link_libraries(
     PUBLIC mbgl-core
 )
 
-if(CMAKE_SYSTEM_NAME STREQUAL Android)
-    set_target_properties(mbgl-render-test PROPERTIES LINK_FLAGS_RELEASE "-fuse-ld=gold -O2 -flto -Wl,--icf=safe")
-endif()
-
 set_property(TARGET mbgl-render-test PROPERTY FOLDER Core)

--- a/next/test/CMakeLists.txt
+++ b/next/test/CMakeLists.txt
@@ -166,8 +166,4 @@ target_link_libraries(
     PUBLIC mbgl-vendor-googletest
 )
 
-if(CMAKE_SYSTEM_NAME STREQUAL Android)
-    set_target_properties(mbgl-test PROPERTIES LINK_FLAGS_RELEASE "-fuse-ld=gold -O2 -flto -Wl,--icf=safe")
-endif()
-
 set_property(TARGET mbgl-test PROPERTY FOLDER Core)


### PR DESCRIPTION
Moved the Android flags to the compilation options interface and removed build options we are not using and go back to CMake defaults.

We can still build debug just fine, it is a CMake default.