### PR TITLE
[ios] [needs changelog] Use 'copy' attribute instead of 'assign' on accessToken property

### DIFF
--- a/platform/darwin/src/MGLAccountManager.h
+++ b/platform/darwin/src/MGLAccountManager.h
@@ -34,7 +34,7 @@ MGL_EXPORT
     and the type `String`. Alternatively, you may call this method from your
     application delegate’s `-applicationDidFinishLaunching:` method.
  */
-@property (class, assign, nullable) NSString *accessToken;
+@property (class, copy, nullable) NSString *accessToken;
 
 @end
 


### PR DESCRIPTION
 - This PR changes memory management attributes of the accessToken property from `access` to `copy` to produce a better Swift swift interface for that property and to accurately reflect what happens to the value in the setter (the value is copied rather than assigned).
- Technically, this is a change in public API, but it's more pronounced in Swift than Obj-C. Changes to generated Swift interface highlighted below.

Swift Interface prior to change:
`unowned(unsafe) open class var accessToken: NSString?`

Swift interface after the change: 
`open class var accessToken: String?`

The current interface requires Swift developers to do explicit cast from `String` to `NSString` when assigning values to `accessToken` property (tested with Xcode 11/Swift 5.1), which is redundant. 

The choice of `assign` was probably not intentional and was introduced in this commit: f73467786dff98fa2f7240c9a775dff047b29bbf
