### PR TITLE
[render-test] Removed unused positional argument

### DIFF
--- a/next/render-test/CMakeLists.txt
+++ b/next/render-test/CMakeLists.txt
@@ -18,11 +18,6 @@ add_library(
     ${MBGL_ROOT}/render-test/runner.hpp
 )
 
-target_compile_definitions(
-    mbgl-render-test
-    PRIVATE TEST_RUNNER_ROOT_PATH="${MBGL_ROOT}"
-)
-
 # FIXME: Should not use core private interface
 target_include_directories(
     mbgl-render-test

--- a/render-test/manifest_parser.cpp
+++ b/render-test/manifest_parser.cpp
@@ -282,8 +282,8 @@ mbgl::optional<Manifest> ManifestParser::parseManifest(const std::string& manife
             expectedMetricPaths.emplace_back("/sdcard/baselines/");
 #endif
             testPaths.emplace_back(testPath,
-                    getTestExpectations(defaultExpectationPath, testId, expectationPaths),
-                    getTestExpectations(defaultExpectationPath, testId, expectedMetricPaths));
+                                   getTestExpectations(defaultExpectationPath, testId, expectationPaths),
+                                   getTestExpectations(defaultExpectationPath, testId, expectedMetricPaths));
         }
     }
 

--- a/render-test/manifest_parser.hpp
+++ b/render-test/manifest_parser.hpp
@@ -40,6 +40,5 @@ private:
 class ManifestParser {
 public:
     static mbgl::optional<Manifest> parseManifest(const std::string& manifestPath,
-                                                  const std::vector<std::string>& testNames,
                                                   std::string testFilter);
 };

--- a/render-test/render_test.cpp
+++ b/render-test/render_test.cpp
@@ -43,8 +43,7 @@ void operator delete(void* ptr, size_t) noexcept {
 
 namespace {
 
-using ArgumentsTuple = std::
-    tuple<bool, bool, bool, uint32_t, std::string, TestRunner::UpdateResults, std::string>;
+using ArgumentsTuple = std::tuple<bool, bool, bool, uint32_t, std::string, TestRunner::UpdateResults, std::string>;
 ArgumentsTuple parseArguments(int argc, char** argv) {
     const static std::unordered_map<std::string, TestRunner::UpdateResults> updateResultsFlags = {
         {"default", TestRunner::UpdateResults::DEFAULT},
@@ -62,7 +61,7 @@ ArgumentsTuple parseArguments(int argc, char** argv) {
         argumentParser, "online", "Toggle online mode (by default tests will run offline)", {'o', "online"});
     args::ValueFlag<uint32_t> seedValue(argumentParser, "seed", "Shuffle seed (default: random)", {"seed"});
     args::ValueFlag<std::string> testPathValue(
-        argumentParser, "manifestPath", "Test manifest file path", {'p', "manifestPath"});
+        argumentParser, "manifestPath", "Test manifest file path", {'p', "manifestPath"}, args::Options::Required);
     args::ValueFlag<std::string> testFilterValue(argumentParser, "filter", "Test filter regex", {'f', "filter"});
     args::MapFlag<std::string, TestRunner::UpdateResults> testUpdateResultsValue(
         argumentParser,
@@ -95,7 +94,7 @@ ArgumentsTuple parseArguments(int argc, char** argv) {
         exit(2);
     }
 
-    mbgl::filesystem::path manifestPath{testPathValue ? args::get(testPathValue) : std::string{TEST_RUNNER_ROOT_PATH}};
+    mbgl::filesystem::path manifestPath = args::get(testPathValue);
     if (!mbgl::filesystem::exists(manifestPath) || !manifestPath.has_filename()) {
         mbgl::Log::Error(mbgl::Event::General,
                          "Provided test manifest file path '%s' does not exist",
@@ -130,8 +129,7 @@ int runRenderTests(int argc, char** argv, std::function<void()> testStatus) {
     std::string testFilter;
     TestRunner::UpdateResults updateResults;
 
-    std::tie(recycleMap, shuffle, online, seed, manifestPath, updateResults, testFilter) =
-        parseArguments(argc, argv);
+    std::tie(recycleMap, shuffle, online, seed, manifestPath, updateResults, testFilter) = parseArguments(argc, argv);
 
     ProxyFileSource::setOffline(!online);
 


### PR DESCRIPTION
Not in use and we should use -f instead. Achieves the same goal.