### PR TITLE
[ios] Add native_apple_interface to ios.cmake

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -142,7 +142,7 @@ workflows:
           name: next-ios-xcode11-release
           executor_name: macos-11_0_0
           target_is_macos: true
-          config_params: '-G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_OSX_SYSROOT=iphonesimulator'
+          config_params: '-G Xcode -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_OSX_SYSROOT=iphonesimulator'
           test_params: '-Q -N'
   mbgl-legacy:
     jobs:

--- a/next/platform/ios/ios.cmake
+++ b/next/platform/ios/ios.cmake
@@ -24,6 +24,7 @@ target_sources(
         ${MBGL_ROOT}/platform/darwin/src/gl_functions.cpp
         ${MBGL_ROOT}/platform/darwin/src/headless_backend_eagl.mm
         ${MBGL_ROOT}/platform/darwin/src/http_file_source.mm
+        ${MBGL_ROOT}/platform/darwin/src/native_apple_interface.m
         ${MBGL_ROOT}/platform/darwin/src/image.mm
         ${MBGL_ROOT}/platform/darwin/src/local_glyph_rasterizer.mm
         ${MBGL_ROOT}/platform/darwin/src/logging_nslog.mm


### PR DESCRIPTION
- Adds `native_apple_interface.m` to the `ios.cmake` file. 
- Updates the `next-ios-xcode11-release` CircleCI job to use Xcode rather than Ninja.

cc @captainbarbosa @julianrex 