### PR TITLE
[core] Fix GeoJSONVTData ownership and life cycle

### DIFF
--- a/src/mbgl/util/thread_pool.hpp
+++ b/src/mbgl/util/thread_pool.hpp
@@ -48,6 +48,7 @@ public:
     ~ThreadedScheduler() override {
         terminate();
         for (auto& thread : threads) {
+            assert(std::this_thread::get_id() != thread.get_id());
             thread.join();
         }
     }


### PR DESCRIPTION
Before this change, the `GeoJSONVTData` instance was retained at the scheduled
lambda, which run on the worker thread represented by the `GeoJSONVTData::scheduler`
class member:

```
        std::weak_ptr<GeoJSONVTData> weak = shared_from_this();
        scheduler->scheduleAndReplyValue(
            [id, weak, this]() -> TileFeatures {
                if (auto self = weak.lock()) {
                    return impl.getTile(id.z, id.x, id.y).features;
                }
                return {};
            },
            fn);
```

It caused program termination in case `self` turned to be the last reference to `this`,
as the `std::thread` destructor was called from the thread it represented.

Now, only the `GeoJSONVTData::impl` class member is retained.

Fixes: https://github.com/mapbox/mapbox-gl-native/issues/16101