### PR TITLE
Cross tile index performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,12 @@
 
 ### 🏁 Performance improvements
 
+- [core] Cross tile index performance ([#16127](https://github.com/mapbox/mapbox-gl-native/pull/16127))
+
+  For overscaled tiles, index only the symbols inside the viewport.
+
+  Find matches only among the buckets that have the same leader Id.
+
 - [core] Calculate GeoJSON tile geometries in a background thread ([#15953](https://github.com/mapbox/mapbox-gl-native/pull/15953))
 
   Call `mapbox::geojsonvt::GeoJSONVT::getTile()` in a background thread, so that the rendering thread is not blocked.

--- a/include/mbgl/renderer/renderer.hpp
+++ b/include/mbgl/renderer/renderer.hpp
@@ -31,7 +31,7 @@ public:
 
     void setObserver(RendererObserver*);
 
-    void render(const UpdateParameters&);
+    void render(const std::shared_ptr<UpdateParameters>&);
 
     // Feature queries
     std::vector<Feature> queryRenderedFeatures(const ScreenLineString&, const RenderedQueryOptions& options = {}) const;

--- a/platform/android/src/map_renderer.cpp
+++ b/platform/android/src/map_renderer.cpp
@@ -143,7 +143,7 @@ void MapRenderer::render(JNIEnv&) {
         framebufferSizeChanged = false;
     }
 
-    renderer->render(*params);
+    renderer->render(params);
 
     // Deliver the snapshot if requested
     if (snapshotCallback) {

--- a/platform/darwin/src/MGLRendererFrontend.h
+++ b/platform/darwin/src/MGLRendererFrontend.h
@@ -54,7 +54,7 @@ public:
         // Copy the shared pointer here so that the parameters aren't destroyed while `render(...)` is
         // still using them.
         auto updateParameters_ = updateParameters;
-        renderer->render(*updateParameters_);
+        renderer->render(updateParameters_);
     }
     
     mbgl::Renderer* getRenderer() {

--- a/platform/default/src/mbgl/gfx/headless_frontend.cpp
+++ b/platform/default/src/mbgl/gfx/headless_frontend.cpp
@@ -39,7 +39,7 @@ HeadlessFrontend::HeadlessFrontend(Size size_,
               // Copy the shared pointer here so that the parameters aren't destroyed while `render(...)` is
               // still using them.
               auto updateParameters_ = updateParameters;
-              renderer->render(*updateParameters_);
+              renderer->render(updateParameters_);
 
               auto endTime = mbgl::util::MonotonicTimer::now();
               frameTime = (endTime - startTime).count();

--- a/platform/glfw/glfw_renderer_frontend.cpp
+++ b/platform/glfw/glfw_renderer_frontend.cpp
@@ -38,7 +38,7 @@ void GLFWRendererFrontend::render() {
     // Copy the shared pointer here so that the parameters aren't destroyed while `render(...)` is
     // still using them.
     auto updateParameters_ = updateParameters;
-    renderer->render(*updateParameters_);
+    renderer->render(updateParameters_);
 }
 
 mbgl::Renderer* GLFWRendererFrontend::getRenderer() {

--- a/platform/qt/src/qmapboxgl_map_renderer.cpp
+++ b/platform/qt/src/qmapboxgl_map_renderer.cpp
@@ -84,7 +84,7 @@ void QMapboxGLMapRenderer::render()
     // The OpenGL implementation automatically enables the OpenGL context for us.
     mbgl::gfx::BackendScope scope(m_backend, mbgl::gfx::BackendScope::ScopeType::Implicit);
 
-    m_renderer->render(*params);
+    m_renderer->render(params);
 
     if (m_forceScheduler) {
         getScheduler()->processEvents();

--- a/src/mbgl/layout/symbol_instance.hpp
+++ b/src/mbgl/layout/symbol_instance.hpp
@@ -119,6 +119,8 @@ public:
     std::array<float, 2> variableTextOffset;
     bool singleLine;
     uint32_t crossTileID = 0;
+
+    static constexpr uint32_t invalidCrossTileID() { return std::numeric_limits<uint32_t>::max(); }
 };
 
 } // namespace mbgl

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -210,6 +210,7 @@ public:
     void setLatLngZoom(const LatLng& latLng, double zoom);
 
     void constrain(double& scale, double& x, double& y) const;
+    const mat4& getProjectionMatrix() const;
 
 private:
     bool rotatedNorth() const;
@@ -236,7 +237,7 @@ private:
 
     void updateMatricesIfNeeded() const;
     bool needsMatricesUpdate() const { return requestMatricesUpdate; }
-    const mat4& getProjectionMatrix() const;
+
     const mat4& getCoordMatrix() const;
     const mat4& getInvertedMatrix() const;
 

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -56,7 +56,7 @@ public:
     // Returns a pair, the first element of which is a bucket cross-tile id
     // on success call; `0` otherwise. The second element is `true` if
     // the bucket was originally registered; `false` otherwise.
-    virtual std::pair<uint32_t, bool> registerAtCrossTileIndex(CrossTileSymbolLayerIndex&, const OverscaledTileID&) {
+    virtual std::pair<uint32_t, bool> registerAtCrossTileIndex(CrossTileSymbolLayerIndex&, const RenderTile&) {
         return std::make_pair(0u, false);
     }
     // Places this bucket to the given placement.

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -56,7 +56,7 @@ public:
     // Returns a pair, the first element of which is a bucket cross-tile id
     // on success call; `0` otherwise. The second element is `true` if
     // the bucket was originally registered; `false` otherwise.
-    virtual std::pair<uint32_t, bool> registerAtCrossTileIndex(CrossTileSymbolLayerIndex&, const OverscaledTileID&, uint32_t&) {
+    virtual std::pair<uint32_t, bool> registerAtCrossTileIndex(CrossTileSymbolLayerIndex&, const OverscaledTileID&) {
         return std::make_pair(0u, false);
     }
     // Places this bucket to the given placement.

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -295,8 +295,9 @@ bool SymbolBucket::hasFormatSectionOverrides() const {
     return *hasFormatSectionOverrides_;
 }
 
-std::pair<uint32_t, bool> SymbolBucket::registerAtCrossTileIndex(CrossTileSymbolLayerIndex& index, const OverscaledTileID& tileID, uint32_t& maxCrossTileID) {
-    bool firstTimeAdded = index.addBucket(tileID, *this, maxCrossTileID);
+std::pair<uint32_t, bool> SymbolBucket::registerAtCrossTileIndex(CrossTileSymbolLayerIndex& index,
+                                                                 const OverscaledTileID& tileID) {
+    bool firstTimeAdded = index.addBucket(tileID, *this);
     return std::make_pair(bucketInstanceId, firstTimeAdded);
 }
 

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -1,6 +1,7 @@
+#include <mbgl/renderer/bucket_parameters.hpp>
 #include <mbgl/renderer/buckets/symbol_bucket.hpp>
 #include <mbgl/renderer/layers/render_symbol_layer.hpp>
-#include <mbgl/renderer/bucket_parameters.hpp>
+#include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/style/layers/symbol_layer_impl.hpp>
 #include <mbgl/text/cross_tile_symbol_index.hpp>
 #include <mbgl/text/glyph_atlas.hpp>
@@ -37,6 +38,7 @@ SymbolBucket::SymbolBucket(Immutable<style::SymbolLayoutProperties::PossiblyEval
       iconsInText(iconsInText_),
       justReloaded(false),
       hasVariablePlacement(false),
+      hasUninitializedSymbols(false),
       symbolInstances(symbolInstances_),
       textSizeBinder(SymbolSizeBinder::create(zoom, textSize, TextSize::defaultValue())),
       iconSizeBinder(SymbolSizeBinder::create(zoom, iconSize, IconSize::defaultValue())),
@@ -296,8 +298,8 @@ bool SymbolBucket::hasFormatSectionOverrides() const {
 }
 
 std::pair<uint32_t, bool> SymbolBucket::registerAtCrossTileIndex(CrossTileSymbolLayerIndex& index,
-                                                                 const OverscaledTileID& tileID) {
-    bool firstTimeAdded = index.addBucket(tileID, *this);
+                                                                 const RenderTile& renderTile) {
+    bool firstTimeAdded = index.addBucket(renderTile.getOverscaledTileID(), renderTile.matrix, *this);
     return std::make_pair(bucketInstanceId, firstTimeAdded);
 }
 

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -81,7 +81,7 @@ public:
 
     void upload(gfx::UploadPass&) override;
     bool hasData() const override;
-    std::pair<uint32_t, bool> registerAtCrossTileIndex(CrossTileSymbolLayerIndex&, const OverscaledTileID&, uint32_t& maxCrossTileID) override;
+    std::pair<uint32_t, bool> registerAtCrossTileIndex(CrossTileSymbolLayerIndex&, const OverscaledTileID&) override;
     void place(Placement&, const BucketPlacementParameters&, std::set<uint32_t>&) override;
     void updateVertices(
         const Placement&, bool updateOpacities, const TransformState&, const RenderTile&, std::set<uint32_t>&) override;

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -81,7 +81,7 @@ public:
 
     void upload(gfx::UploadPass&) override;
     bool hasData() const override;
-    std::pair<uint32_t, bool> registerAtCrossTileIndex(CrossTileSymbolLayerIndex&, const OverscaledTileID&) override;
+    std::pair<uint32_t, bool> registerAtCrossTileIndex(CrossTileSymbolLayerIndex&, const RenderTile&) override;
     void place(Placement&, const BucketPlacementParameters&, std::set<uint32_t>&) override;
     void updateVertices(
         const Placement&, bool updateOpacities, const TransformState&, const RenderTile&, std::set<uint32_t>&) override;
@@ -114,6 +114,7 @@ public:
     // Set and used by placement.
     mutable bool justReloaded : 1;
     bool hasVariablePlacement : 1;
+    bool hasUninitializedSymbols : 1;
 
     std::vector<SymbolInstance> symbolInstances;
 

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -394,12 +394,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
 
         std::set<std::string> usedSymbolLayers;
         if (renderTreeParameters->placementChanged) {
-            Mutable<Placement> placement = makeMutable<Placement>(updateParameters->transformState,
-                                                                  updateParameters->mode,
-                                                                  updateParameters->transitionOptions,
-                                                                  updateParameters->crossSourceCollisions,
-                                                                  updateParameters->timePoint,
-                                                                  placementController.getPlacement());
+            Mutable<Placement> placement = makeMutable<Placement>(updateParameters, placementController.getPlacement());
 
             for (auto it = layersNeedPlacement.crbegin(); it != layersNeedPlacement.crend(); ++it) {
                 const RenderLayer& layer = *it;
@@ -425,11 +420,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
         crossTileSymbolIndex.reset();
         renderTreeParameters->placementChanged = symbolBucketsChanged = !layersNeedPlacement.empty();
         if (renderTreeParameters->placementChanged) {
-            Mutable<Placement> placement = makeMutable<Placement>(updateParameters->transformState,
-                                                                  updateParameters->mode,
-                                                                  updateParameters->transitionOptions,
-                                                                  updateParameters->crossSourceCollisions,
-                                                                  updateParameters->timePoint);
+            Mutable<Placement> placement = makeMutable<Placement>(updateParameters);
             for (auto it = layersNeedPlacement.crbegin(); it != layersNeedPlacement.crend(); ++it) {
                 const RenderLayer& layer = *it;
                 crossTileSymbolIndex.addLayer(layer, updateParameters->transformState.getLatLng().longitude());

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -422,7 +422,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
             Mutable<Placement> placement = makeMutable<Placement>(updateParameters);
             for (auto it = layersNeedPlacement.crbegin(); it != layersNeedPlacement.crend(); ++it) {
                 const RenderLayer& layer = *it;
-                crossTileSymbolIndex.addLayer(layer, updateParameters->transformState);
+                crossTileSymbolIndex.addLayer(layer, longitude);
                 placement->placeLayer(layer);
             }
             placement->commit();

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -400,7 +400,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
             for (auto it = layersNeedPlacement.crbegin(); it != layersNeedPlacement.crend(); ++it) {
                 const RenderLayer& layer = *it;
                 usedSymbolLayers.insert(layer.getID());
-                placement->placeLayer(layer, renderTreeParameters->transformParams.projMatrix);
+                placement->placeLayer(layer);
             }
 
             placement->commit();
@@ -422,8 +422,8 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
             Mutable<Placement> placement = makeMutable<Placement>(updateParameters);
             for (auto it = layersNeedPlacement.crbegin(); it != layersNeedPlacement.crend(); ++it) {
                 const RenderLayer& layer = *it;
-                crossTileSymbolIndex.addLayer(layer, longitude);
-                placement->placeLayer(layer, renderTreeParameters->transformParams.projMatrix);
+                crossTileSymbolIndex.addLayer(layer, updateParameters->transformState);
+                placement->placeLayer(layer);
             }
             placement->commit();
             placementController.setPlacement(std::move(placement));

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -399,9 +399,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
             for (auto it = layersNeedPlacement.crbegin(); it != layersNeedPlacement.crend(); ++it) {
                 const RenderLayer& layer = *it;
                 usedSymbolLayers.insert(layer.getID());
-                placement->placeLayer(layer,
-                                      renderTreeParameters->transformParams.projMatrix,
-                                      updateParameters->debugOptions & MapDebugOptions::Collision);
+                placement->placeLayer(layer, renderTreeParameters->transformParams.projMatrix);
             }
 
             placement->commit();
@@ -424,9 +422,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
             for (auto it = layersNeedPlacement.crbegin(); it != layersNeedPlacement.crend(); ++it) {
                 const RenderLayer& layer = *it;
                 crossTileSymbolIndex.addLayer(layer, updateParameters->transformState.getLatLng().longitude());
-                placement->placeLayer(layer,
-                                      renderTreeParameters->transformParams.projMatrix,
-                                      updateParameters->debugOptions & MapDebugOptions::Collision);
+                placement->placeLayer(layer, renderTreeParameters->transformParams.projMatrix);
             }
             placement->commit();
             placementController.setPlacement(std::move(placement));

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -400,6 +400,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(const UpdatePar
                                                                   updateParameters.mode,
                                                                   updateParameters.transitionOptions,
                                                                   updateParameters.crossSourceCollisions,
+                                                                  updateParameters.timePoint,
                                                                   placementController.getPlacement());
 
             for (auto it = layersNeedPlacement.crbegin(); it != layersNeedPlacement.crend(); ++it) {
@@ -408,7 +409,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(const UpdatePar
                 placement->placeLayer(layer, renderTreeParameters->transformParams.projMatrix, updateParameters.debugOptions & MapDebugOptions::Collision);
             }
 
-            placement->commit(updateParameters.timePoint, updateParameters.transformState.getZoom());
+            placement->commit();
             crossTileSymbolIndex.pruneUnusedLayers(usedSymbolLayers);
             for (const auto& entry : renderSources) {
                 entry.second->updateFadingTiles();
@@ -427,7 +428,8 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(const UpdatePar
             Mutable<Placement> placement = makeMutable<Placement>(updateParameters.transformState,
                                                                   updateParameters.mode,
                                                                   updateParameters.transitionOptions,
-                                                                  updateParameters.crossSourceCollisions);
+                                                                  updateParameters.crossSourceCollisions,
+                                                                  updateParameters.timePoint);
             for (auto it = layersNeedPlacement.crbegin(); it != layersNeedPlacement.crend(); ++it) {
                 const RenderLayer& layer = *it;
                 crossTileSymbolIndex.addLayer(layer, updateParameters.transformState.getLatLng().longitude());
@@ -435,7 +437,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(const UpdatePar
                                       renderTreeParameters->transformParams.projMatrix,
                                       updateParameters.debugOptions & MapDebugOptions::Collision);
             }
-            placement->commit(updateParameters.timePoint, updateParameters.transformState.getZoom());
+            placement->commit();
             placementController.setPlacement(std::move(placement));
         }
         renderTreeParameters->symbolFadeChange = 1.0f;

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -375,10 +375,11 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
     }
     // Symbol placement.
     bool symbolBucketsChanged = false;
+    auto longitude = updateParameters->transformState.getLatLng().longitude();
     if (isMapModeContinuous) {
         bool symbolBucketsAdded = false;
         for (auto it = layersNeedPlacement.crbegin(); it != layersNeedPlacement.crend(); ++it) {
-            auto result = crossTileSymbolIndex.addLayer(*it, updateParameters->transformState.getLatLng().longitude());
+            auto result = crossTileSymbolIndex.addLayer(*it, longitude);
             symbolBucketsAdded = symbolBucketsAdded || (result & CrossTileSymbolIndex::AddLayerResult::BucketsAdded);
             symbolBucketsChanged = symbolBucketsChanged || (result != CrossTileSymbolIndex::AddLayerResult::NoChanges);
         }
@@ -421,7 +422,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
             Mutable<Placement> placement = makeMutable<Placement>(updateParameters);
             for (auto it = layersNeedPlacement.crbegin(); it != layersNeedPlacement.crend(); ++it) {
                 const RenderLayer& layer = *it;
-                crossTileSymbolIndex.addLayer(layer, updateParameters->transformState.getLatLng().longitude());
+                crossTileSymbolIndex.addLayer(layer, longitude);
                 placement->placeLayer(layer, renderTreeParameters->transformParams.projMatrix);
             }
             placement->commit();

--- a/src/mbgl/renderer/render_orchestrator.hpp
+++ b/src/mbgl/renderer/render_orchestrator.hpp
@@ -52,7 +52,7 @@ public:
     // TODO: Introduce RenderOrchestratorObserver.
     void setObserver(RendererObserver*);
 
-    std::unique_ptr<RenderTree> createRenderTree(const UpdateParameters&);
+    std::unique_ptr<RenderTree> createRenderTree(const std::shared_ptr<UpdateParameters>&);
 
     std::vector<Feature> queryRenderedFeatures(const ScreenLineString&, const RenderedQueryOptions&) const;
     std::vector<Feature> querySourceFeatures(const std::string& sourceID, const SourceQueryOptions&) const;

--- a/src/mbgl/renderer/renderer.cpp
+++ b/src/mbgl/renderer/renderer.cpp
@@ -25,7 +25,8 @@ void Renderer::setObserver(RendererObserver* observer) {
     impl->orchestrator.setObserver(observer);
 }
 
-void Renderer::render(const UpdateParameters& updateParameters) {
+void Renderer::render(const std::shared_ptr<UpdateParameters>& updateParameters) {
+    assert(updateParameters);
     if (auto renderTree = impl->orchestrator.createRenderTree(updateParameters)) {
         renderTree->prepare();
         impl->render(*renderTree);

--- a/src/mbgl/text/collision_index.cpp
+++ b/src/mbgl/text/collision_index.cpp
@@ -26,7 +26,7 @@ static const float viewportPaddingDefault = 100;
 // Viewport padding must be much larger for static tiles to avoid clipped labels.
 static const float viewportPaddingForStaticTiles = 1024;
 
-CollisionIndex::CollisionIndex(const TransformState& transformState_, MapMode& mapMode)
+CollisionIndex::CollisionIndex(const TransformState& transformState_, MapMode mapMode)
     : transformState(transformState_),
       viewportPadding(mapMode == MapMode::Tile ? viewportPaddingForStaticTiles : viewportPaddingDefault),
       collisionGrid(transformState.getSize().width + 2 * viewportPadding,

--- a/src/mbgl/text/collision_index.hpp
+++ b/src/mbgl/text/collision_index.hpp
@@ -20,7 +20,7 @@ class CollisionIndex {
 public:
     using CollisionGrid = GridIndex<IndexedSubfeature>;
 
-    explicit CollisionIndex(const TransformState&, MapMode&);
+    explicit CollisionIndex(const TransformState&, MapMode);
     bool featureIntersectsTileBorders(const CollisionFeature& feature,
                                       Point<float> shift,
                                       const mat4& posMatrix,

--- a/src/mbgl/text/cross_tile_symbol_index.hpp
+++ b/src/mbgl/text/cross_tile_symbol_index.hpp
@@ -47,8 +47,8 @@ public:
 
 class CrossTileSymbolLayerIndex {
 public:
-    CrossTileSymbolLayerIndex();
-    bool addBucket(const OverscaledTileID&, SymbolBucket&, uint32_t& maxCrossTileID);
+    CrossTileSymbolLayerIndex(uint32_t& maxCrossTileID);
+    bool addBucket(const OverscaledTileID&, SymbolBucket&);
     bool removeStaleBuckets(const std::unordered_set<uint32_t>& currentIDs);
     void handleWrapJump(float newLng);
 private:
@@ -57,6 +57,7 @@ private:
     std::map<uint8_t, std::map<OverscaledTileID,TileLayerIndex>> indexes;
     std::map<uint8_t, std::set<uint32_t>> usedCrossTileIDs;
     float lng = 0;
+    uint32_t& maxCrossTileID;
 };
 
 class CrossTileSymbolIndex {

--- a/src/mbgl/text/cross_tile_symbol_index.hpp
+++ b/src/mbgl/text/cross_tile_symbol_index.hpp
@@ -2,8 +2,9 @@
 
 #include <mbgl/tile/tile_id.hpp>
 #include <mbgl/util/bitmask_operations.hpp>
-#include <mbgl/util/geometry.hpp>
 #include <mbgl/util/constants.hpp>
+#include <mbgl/util/geometry.hpp>
+#include <mbgl/util/mat4.hpp>
 #include <mbgl/util/optional.hpp>
 
 #include <map>
@@ -48,7 +49,7 @@ public:
 class CrossTileSymbolLayerIndex {
 public:
     CrossTileSymbolLayerIndex(uint32_t& maxCrossTileID);
-    bool addBucket(const OverscaledTileID&, SymbolBucket&);
+    bool addBucket(const OverscaledTileID&, const mat4& tileMatrix, SymbolBucket&);
     bool removeStaleBuckets(const std::unordered_set<uint32_t>& currentIDs);
     void handleWrapJump(float newLng);
 private:

--- a/src/mbgl/text/cross_tile_symbol_index.hpp
+++ b/src/mbgl/text/cross_tile_symbol_index.hpp
@@ -31,13 +31,17 @@ public:
 
 class TileLayerIndex {
 public:
-    TileLayerIndex(OverscaledTileID coord, std::vector<SymbolInstance>&, uint32_t bucketInstanceId);
+    TileLayerIndex(OverscaledTileID coord,
+                   std::vector<SymbolInstance>&,
+                   uint32_t bucketInstanceId,
+                   std::string bucketLeaderId);
 
-    Point<int64_t> getScaledCoordinates(SymbolInstance&, const OverscaledTileID&);
-    void findMatches(std::vector<SymbolInstance>&, const OverscaledTileID&, std::set<uint32_t>&);
-    
+    Point<int64_t> getScaledCoordinates(SymbolInstance&, const OverscaledTileID&) const;
+    void findMatches(SymbolBucket&, const OverscaledTileID&, std::set<uint32_t>&) const;
+
     OverscaledTileID coord;
     uint32_t bucketInstanceId;
+    std::string bucketLeaderId;
     std::map<std::u16string,std::vector<IndexedSymbolInstance>> indexedSymbolInstances;
 };
 

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -157,10 +157,7 @@ void Placement::placeBucket(const SymbolBucket& bucket,
     const bool rotateIconWithMap = layout.get<style::IconRotationAlignment>() == style::AlignmentType::Map;
     const bool pitchIconWithMap = layout.get<style::IconPitchAlignment>() == style::AlignmentType::Map;
 
-    mat4 posMatrix;
-    const auto& projMatrix = state.getProjectionMatrix();
-    state.matrixFor(posMatrix, renderTile.id);
-    matrix::multiply(posMatrix, projMatrix, posMatrix);
+    const mat4& posMatrix = renderTile.matrix;
 
     mat4 textLabelPlaneMatrix =
         getLabelPlaneMatrix(posMatrix, pitchTextWithMap, rotateTextWithMap, state, pixelsToTileUnits);
@@ -212,8 +209,10 @@ void Placement::placeBucket(const SymbolBucket& bucket,
     std::vector<ProjectedCollisionBox> textBoxes;
     std::vector<ProjectedCollisionBox> iconBoxes;
 
-    auto placeSymbol = [&] (const SymbolInstance& symbolInstance) {
-        if (seenCrossTileIDs.count(symbolInstance.crossTileID) != 0u) return;
+    auto placeSymbol = [&](const SymbolInstance& symbolInstance) {
+        if (symbolInstance.crossTileID == SymbolInstance::invalidCrossTileID() ||
+            seenCrossTileIDs.count(symbolInstance.crossTileID) != 0u)
+            return;
 
         if (renderTile.holdForFade()) {
             // Mark all symbols from this tile as "not placed", but don't add to seenCrossTileIDs, because we don't

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -109,11 +109,11 @@ Placement::Placement(std::shared_ptr<const UpdateParameters> updateParameters_,
 
 Placement::Placement() : collisionIndex({}, MapMode::Static), collisionGroups(true) {}
 
-void Placement::placeLayer(const RenderLayer& layer, const mat4& projMatrix) {
+void Placement::placeLayer(const RenderLayer& layer) {
     std::set<uint32_t> seenCrossTileIDs;
     for (const auto& item : layer.getPlacementData()) {
         Bucket& bucket = item.bucket;
-        BucketPlacementParameters params{item.tile, projMatrix, layer.baseImpl->source, item.featureIndex};
+        BucketPlacementParameters params{item.tile, layer.baseImpl->source, item.featureIndex};
         bucket.place(*this, params, seenCrossTileIDs);
     }
 }
@@ -158,8 +158,9 @@ void Placement::placeBucket(const SymbolBucket& bucket,
     const bool pitchIconWithMap = layout.get<style::IconPitchAlignment>() == style::AlignmentType::Map;
 
     mat4 posMatrix;
+    const auto& projMatrix = state.getProjectionMatrix();
     state.matrixFor(posMatrix, renderTile.id);
-    matrix::multiply(posMatrix, params.projMatrix, posMatrix);
+    matrix::multiply(posMatrix, projMatrix, posMatrix);
 
     mat4 textLabelPlaneMatrix =
         getLabelPlaneMatrix(posMatrix, pitchTextWithMap, rotateTextWithMap, state, pixelsToTileUnits);

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -116,9 +116,10 @@ public:
               MapMode,
               style::TransitionOptions,
               const bool crossSourceCollisions,
+              TimePoint commitTime,
               optional<Immutable<Placement>> prevPlacement = nullopt);
     void placeLayer(const RenderLayer&, const mat4&, bool showCollisionBoxes);
-    void commit(TimePoint, const double zoom);
+    void commit();
     void updateLayerBuckets(const RenderLayer&, const TransformState&, bool updateOpacities) const;
     float symbolFadeChange(TimePoint now) const;
     bool hasTransitions(TimePoint now) const;
@@ -151,7 +152,7 @@ private:
 
     TimePoint fadeStartTime;
     TimePoint commitTime;
-    float placementZoom;
+    const float placementZoom;
     float prevZoomAdjustment = 0;
 
     std::unordered_map<uint32_t, JointPlacement> placements;

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -89,7 +89,6 @@ private:
 class BucketPlacementParameters {
 public:
     const RenderTile& tile;
-    const mat4& projMatrix;
     std::string sourceId;
     std::shared_ptr<FeatureIndex> featureIndex;
 };
@@ -115,7 +114,7 @@ public:
     Placement(std::shared_ptr<const UpdateParameters>, optional<Immutable<Placement>> prevPlacement = nullopt);
     Placement();
 
-    void placeLayer(const RenderLayer&, const mat4&);
+    void placeLayer(const RenderLayer&);
     void commit();
     void updateLayerBuckets(const RenderLayer&, const TransformState&, bool updateOpacities) const;
     float symbolFadeChange(TimePoint now) const;

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -92,7 +92,6 @@ public:
     const mat4& projMatrix;
     std::string sourceId;
     std::shared_ptr<FeatureIndex> featureIndex;
-    bool showCollisionBoxes;
 };
 
 class Placement;
@@ -116,7 +115,7 @@ public:
     Placement(std::shared_ptr<const UpdateParameters>, optional<Immutable<Placement>> prevPlacement = nullopt);
     Placement();
 
-    void placeLayer(const RenderLayer&, const mat4&, bool showCollisionBoxes);
+    void placeLayer(const RenderLayer&, const mat4&);
     void commit();
     void updateLayerBuckets(const RenderLayer&, const TransformState&, bool updateOpacities) const;
     float symbolFadeChange(TimePoint now) const;
@@ -163,6 +162,7 @@ private:
     std::unordered_map<uint32_t, RetainedQueryData> retainedQueryData;
     CollisionGroups collisionGroups;
     mutable optional<Immutable<Placement>> prevPlacement;
+    bool showCollisionBoxes = false;
 
     // Used for debug purposes.
     std::unordered_map<const CollisionFeature*, std::vector<ProjectedCollisionBox>> collisionCircles;

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -12,6 +12,7 @@ namespace mbgl {
 
 class SymbolBucket;
 class SymbolInstance;
+class UpdateParameters;
 enum class PlacedSymbolOrientation : bool;
 
 class OpacityState {
@@ -112,12 +113,9 @@ private:
 
 class Placement {
 public:
-    Placement(const TransformState&,
-              MapMode,
-              style::TransitionOptions,
-              const bool crossSourceCollisions,
-              TimePoint commitTime,
-              optional<Immutable<Placement>> prevPlacement = nullopt);
+    Placement(std::shared_ptr<const UpdateParameters>, optional<Immutable<Placement>> prevPlacement = nullopt);
+    Placement();
+
     void placeLayer(const RenderLayer&, const mat4&, bool showCollisionBoxes);
     void commit();
     void updateLayerBuckets(const RenderLayer&, const TransformState&, bool updateOpacities) const;
@@ -132,6 +130,7 @@ public:
     float zoomAdjustment(const float zoom) const;
 
     const RetainedQueryData& getQueryData(uint32_t bucketInstanceId) const;
+
 private:
     friend SymbolBucket;
     void placeBucket(const SymbolBucket&, const BucketPlacementParameters&, std::set<uint32_t>& seenCrossTileIDs);
@@ -145,15 +144,16 @@ private:
     void markUsedOrientation(SymbolBucket&, style::TextWritingModeType, const SymbolInstance&) const;
     const Placement* getPrevPlacement() const { return prevPlacement ? prevPlacement->get() : nullptr; }
 
+    std::shared_ptr<const UpdateParameters> updateParameters;
     CollisionIndex collisionIndex;
 
-    MapMode mapMode;
+    MapMode mapMode = MapMode::Static;
     style::TransitionOptions transitionOptions;
 
     TimePoint fadeStartTime;
     TimePoint commitTime;
-    const float placementZoom;
-    float prevZoomAdjustment = 0;
+    float placementZoom = 0.0f;
+    float prevZoomAdjustment = 0.0f;
 
     std::unordered_map<uint32_t, JointPlacement> placements;
     std::unordered_map<uint32_t, JointOpacityState> opacities;

--- a/test/text/cross_tile_symbol_index.test.cpp
+++ b/test/text/cross_tile_symbol_index.test.cpp
@@ -62,7 +62,7 @@ TEST(CrossTileSymbolLayerIndex, addBucket) {
                             {},
                             false /*iconsInText*/};
     mainBucket.bucketInstanceId = ++maxBucketInstanceId;
-    index.addBucket(mainID, mainBucket);
+    index.addBucket(mainID, mat4{}, mainBucket);
 
     // Assigned new IDs
     ASSERT_EQ(mainBucket.symbolInstances.at(0).crossTileID, 1u);
@@ -89,7 +89,7 @@ TEST(CrossTileSymbolLayerIndex, addBucket) {
                              {},
                              false /*iconsInText*/};
     childBucket.bucketInstanceId = ++maxBucketInstanceId;
-    index.addBucket(childID, childBucket);
+    index.addBucket(childID, mat4{}, childBucket);
 
     // matched parent tile
     ASSERT_EQ(childBucket.symbolInstances.at(0).crossTileID, 1u);
@@ -117,7 +117,7 @@ TEST(CrossTileSymbolLayerIndex, addBucket) {
                               {},
                               false /*iconsInText*/};
     parentBucket.bucketInstanceId = ++maxBucketInstanceId;
-    index.addBucket(parentID, parentBucket);
+    index.addBucket(parentID, mat4{}, parentBucket);
 
     // matched child tile
     ASSERT_EQ(parentBucket.symbolInstances.at(0).crossTileID, 1u);
@@ -145,7 +145,7 @@ TEST(CrossTileSymbolLayerIndex, addBucket) {
                                   {},
                                   false /*iconsInText*/};
     grandchildBucket.bucketInstanceId = ++maxBucketInstanceId;
-    index.addBucket(grandchildID, grandchildBucket);
+    index.addBucket(grandchildID, mat4{}, grandchildBucket);
 
     // Matches the symbol in `mainBucket`
     ASSERT_EQ(grandchildBucket.symbolInstances.at(0).crossTileID, 1u);
@@ -203,7 +203,7 @@ TEST(CrossTileSymbolLayerIndex, resetIDs) {
     childBucket.bucketInstanceId = ++maxBucketInstanceId;
 
     // assigns a new id
-    index.addBucket(mainID, mainBucket);
+    index.addBucket(mainID, mat4{}, mainBucket);
     ASSERT_EQ(mainBucket.symbolInstances.at(0).crossTileID, 1u);
 
     // removes the tile
@@ -211,11 +211,11 @@ TEST(CrossTileSymbolLayerIndex, resetIDs) {
     index.removeStaleBuckets(currentIDs);
 
     // assigns a new id
-    index.addBucket(childID, childBucket);
+    index.addBucket(childID, mat4{}, childBucket);
     ASSERT_EQ(childBucket.symbolInstances.at(0).crossTileID, 2u);
 
     // overwrites the old id to match the already-added tile
-    index.addBucket(mainID, mainBucket);
+    index.addBucket(mainID, mat4{}, mainBucket);
     ASSERT_EQ(mainBucket.symbolInstances.at(0).crossTileID, 2u);
 }
 
@@ -270,12 +270,12 @@ TEST(CrossTileSymbolLayerIndex, noDuplicatesWithinZoomLevel) {
     childBucket.bucketInstanceId = ++maxBucketInstanceId;
 
     // assigns new ids
-    index.addBucket(mainID, mainBucket);
+    index.addBucket(mainID, mat4{}, mainBucket);
     ASSERT_EQ(mainBucket.symbolInstances.at(0).crossTileID, 1u);
     ASSERT_EQ(mainBucket.symbolInstances.at(1).crossTileID, 2u);
 
     // copies parent ids without duplicate ids in this tile
-    index.addBucket(childID, childBucket);
+    index.addBucket(childID, mat4{}, childBucket);
     ASSERT_EQ(childBucket.symbolInstances.at(0).crossTileID, 1u); // A' copies from A
     ASSERT_EQ(childBucket.symbolInstances.at(1).crossTileID, 2u); // B' copies from B
     ASSERT_EQ(childBucket.symbolInstances.at(2).crossTileID, 3u); // C' gets new ID
@@ -331,12 +331,12 @@ TEST(CrossTileSymbolLayerIndex, bucketReplacement) {
     secondBucket.bucketInstanceId = ++maxBucketInstanceId;
 
     // assigns new ids
-    index.addBucket(tileID, firstBucket);
+    index.addBucket(tileID, mat4{}, firstBucket);
     ASSERT_EQ(firstBucket.symbolInstances.at(0).crossTileID, 1u);
     ASSERT_EQ(firstBucket.symbolInstances.at(1).crossTileID, 2u);
 
     // copies parent ids without duplicate ids in this tile
-    index.addBucket(tileID, secondBucket);
+    index.addBucket(tileID, mat4{}, secondBucket);
     ASSERT_EQ(secondBucket.symbolInstances.at(0).crossTileID, 1u); // A' copies from A
     ASSERT_EQ(secondBucket.symbolInstances.at(1).crossTileID, 2u); // B' copies from B
     ASSERT_EQ(secondBucket.symbolInstances.at(2).crossTileID, 3u); // C' gets new ID

--- a/test/text/cross_tile_symbol_index.test.cpp
+++ b/test/text/cross_tile_symbol_index.test.cpp
@@ -36,7 +36,7 @@ TEST(CrossTileSymbolLayerIndex, addBucket) {
 
     uint32_t maxCrossTileID = 0;
     uint32_t maxBucketInstanceId = 0;
-    CrossTileSymbolLayerIndex index;
+    CrossTileSymbolLayerIndex index(maxCrossTileID);
 
     Immutable<style::SymbolLayoutProperties::PossiblyEvaluated> layout =
         makeMutable<style::SymbolLayoutProperties::PossiblyEvaluated>();
@@ -62,7 +62,7 @@ TEST(CrossTileSymbolLayerIndex, addBucket) {
                             {},
                             false /*iconsInText*/};
     mainBucket.bucketInstanceId = ++maxBucketInstanceId;
-    index.addBucket(mainID, mainBucket, maxCrossTileID);
+    index.addBucket(mainID, mainBucket);
 
     // Assigned new IDs
     ASSERT_EQ(mainBucket.symbolInstances.at(0).crossTileID, 1u);
@@ -89,7 +89,7 @@ TEST(CrossTileSymbolLayerIndex, addBucket) {
                              {},
                              false /*iconsInText*/};
     childBucket.bucketInstanceId = ++maxBucketInstanceId;
-    index.addBucket(childID, childBucket, maxCrossTileID);
+    index.addBucket(childID, childBucket);
 
     // matched parent tile
     ASSERT_EQ(childBucket.symbolInstances.at(0).crossTileID, 1u);
@@ -117,7 +117,7 @@ TEST(CrossTileSymbolLayerIndex, addBucket) {
                               {},
                               false /*iconsInText*/};
     parentBucket.bucketInstanceId = ++maxBucketInstanceId;
-    index.addBucket(parentID, parentBucket, maxCrossTileID);
+    index.addBucket(parentID, parentBucket);
 
     // matched child tile
     ASSERT_EQ(parentBucket.symbolInstances.at(0).crossTileID, 1u);
@@ -145,7 +145,7 @@ TEST(CrossTileSymbolLayerIndex, addBucket) {
                                   {},
                                   false /*iconsInText*/};
     grandchildBucket.bucketInstanceId = ++maxBucketInstanceId;
-    index.addBucket(grandchildID, grandchildBucket, maxCrossTileID);
+    index.addBucket(grandchildID, grandchildBucket);
 
     // Matches the symbol in `mainBucket`
     ASSERT_EQ(grandchildBucket.symbolInstances.at(0).crossTileID, 1u);
@@ -158,7 +158,7 @@ TEST(CrossTileSymbolLayerIndex, resetIDs) {
 
     uint32_t maxCrossTileID = 0;
     uint32_t maxBucketInstanceId = 0;
-    CrossTileSymbolLayerIndex index;
+    CrossTileSymbolLayerIndex index(maxCrossTileID);
 
     Immutable<style::SymbolLayoutProperties::PossiblyEvaluated> layout =
         makeMutable<style::SymbolLayoutProperties::PossiblyEvaluated>();
@@ -203,7 +203,7 @@ TEST(CrossTileSymbolLayerIndex, resetIDs) {
     childBucket.bucketInstanceId = ++maxBucketInstanceId;
 
     // assigns a new id
-    index.addBucket(mainID, mainBucket, maxCrossTileID);
+    index.addBucket(mainID, mainBucket);
     ASSERT_EQ(mainBucket.symbolInstances.at(0).crossTileID, 1u);
 
     // removes the tile
@@ -211,18 +211,18 @@ TEST(CrossTileSymbolLayerIndex, resetIDs) {
     index.removeStaleBuckets(currentIDs);
 
     // assigns a new id
-    index.addBucket(childID, childBucket, maxCrossTileID);
+    index.addBucket(childID, childBucket);
     ASSERT_EQ(childBucket.symbolInstances.at(0).crossTileID, 2u);
 
     // overwrites the old id to match the already-added tile
-    index.addBucket(mainID, mainBucket, maxCrossTileID);
+    index.addBucket(mainID, mainBucket);
     ASSERT_EQ(mainBucket.symbolInstances.at(0).crossTileID, 2u);
 }
 
 TEST(CrossTileSymbolLayerIndex, noDuplicatesWithinZoomLevel) {
     uint32_t maxCrossTileID = 0;
     uint32_t maxBucketInstanceId = 0;
-    CrossTileSymbolLayerIndex index;
+    CrossTileSymbolLayerIndex index(maxCrossTileID);
 
     Immutable<style::SymbolLayoutProperties::PossiblyEvaluated> layout =
         makeMutable<style::SymbolLayoutProperties::PossiblyEvaluated>();
@@ -270,12 +270,12 @@ TEST(CrossTileSymbolLayerIndex, noDuplicatesWithinZoomLevel) {
     childBucket.bucketInstanceId = ++maxBucketInstanceId;
 
     // assigns new ids
-    index.addBucket(mainID, mainBucket, maxCrossTileID);
+    index.addBucket(mainID, mainBucket);
     ASSERT_EQ(mainBucket.symbolInstances.at(0).crossTileID, 1u);
     ASSERT_EQ(mainBucket.symbolInstances.at(1).crossTileID, 2u);
 
     // copies parent ids without duplicate ids in this tile
-    index.addBucket(childID, childBucket, maxCrossTileID);
+    index.addBucket(childID, childBucket);
     ASSERT_EQ(childBucket.symbolInstances.at(0).crossTileID, 1u); // A' copies from A
     ASSERT_EQ(childBucket.symbolInstances.at(1).crossTileID, 2u); // B' copies from B
     ASSERT_EQ(childBucket.symbolInstances.at(2).crossTileID, 3u); // C' gets new ID
@@ -284,7 +284,7 @@ TEST(CrossTileSymbolLayerIndex, noDuplicatesWithinZoomLevel) {
 TEST(CrossTileSymbolLayerIndex, bucketReplacement) {
     uint32_t maxCrossTileID = 0;
     uint32_t maxBucketInstanceId = 0;
-    CrossTileSymbolLayerIndex index;
+    CrossTileSymbolLayerIndex index(maxCrossTileID);
 
     Immutable<style::SymbolLayoutProperties::PossiblyEvaluated> layout =
         makeMutable<style::SymbolLayoutProperties::PossiblyEvaluated>();
@@ -331,12 +331,12 @@ TEST(CrossTileSymbolLayerIndex, bucketReplacement) {
     secondBucket.bucketInstanceId = ++maxBucketInstanceId;
 
     // assigns new ids
-    index.addBucket(tileID, firstBucket, maxCrossTileID);
+    index.addBucket(tileID, firstBucket);
     ASSERT_EQ(firstBucket.symbolInstances.at(0).crossTileID, 1u);
     ASSERT_EQ(firstBucket.symbolInstances.at(1).crossTileID, 2u);
 
     // copies parent ids without duplicate ids in this tile
-    index.addBucket(tileID, secondBucket, maxCrossTileID);
+    index.addBucket(tileID, secondBucket);
     ASSERT_EQ(secondBucket.symbolInstances.at(0).crossTileID, 1u); // A' copies from A
     ASSERT_EQ(secondBucket.symbolInstances.at(1).crossTileID, 2u); // B' copies from B
     ASSERT_EQ(secondBucket.symbolInstances.at(2).crossTileID, 3u); // C' gets new ID


### PR DESCRIPTION
Before this change cross tile symbol indexing was a performance bottle neck, for the overscaled tiles in particular. This pull request optimizes the cross tile symbol indexing code path:
- find matches only among the buckets that have the same leader Id.
- for overscaled tiles, index only the symbols inside the viewport
- multiple minor optimizations and code simplifications

Fixes https://github.com/mapbox/mapbox-gl-native-team/issues/133