### PR TITLE
[core] remove std::vector copy step in SymbolLayout::anchorIsTooClose

### DIFF
--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -682,7 +682,7 @@ bool SymbolLayout::anchorIsTooClose(const std::u16string& text, const float repe
     if (compareText.find(text) == compareText.end()) {
         compareText.emplace(text, Anchors());
     } else {
-        auto otherAnchors = compareText.find(text)->second;
+        const auto& otherAnchors = compareText.find(text)->second;
         for (const Anchor& otherAnchor : otherAnchors) {
             if (util::dist<float>(anchor.point, otherAnchor.point) < repeatDistance) {
                 return true;


### PR DESCRIPTION
A const reference is enough here.
