### PR TITLE
[core] Use weak scheduler inside mailbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
 
 ### 🐞 Bug fixes
 
+- [core] Use weak scheduler inside mailbox ([#16136](https://github.com/mapbox/mapbox-gl-native/pull/16136))
+
+  If there are pending requests that are completed after main scheduler is destructed, worker threads may try to push messages to destructed scheduler's queue.
+
 - [core] Fix a crash in GeoJSON source parsing, caused by `GeoJSONVTData` ownership error ([#16106](https://github.com/mapbox/mapbox-gl-native/pull/16106))
 
 - [core] Stable position of labels at tile borders in tile mode ([#16040](https://github.com/mapbox/mapbox-gl-native/pull/16040))

--- a/include/mbgl/actor/mailbox.hpp
+++ b/include/mbgl/actor/mailbox.hpp
@@ -7,6 +7,8 @@
 #include <mutex>
 #include <queue>
 
+#include <mapbox/weak.hpp>
+
 namespace mbgl {
 
 class Scheduler;
@@ -38,7 +40,7 @@ public:
     static std::function<void()> makeClosure(std::weak_ptr<Mailbox>);
 
 private:
-    optional<Scheduler*> scheduler;
+    mapbox::base::WeakPtr<Scheduler> weakScheduler;
 
     std::recursive_mutex receivingMutex;
     std::mutex pushingMutex;

--- a/platform/default/src/mbgl/storage/main_resource_loader.cpp
+++ b/platform/default/src/mbgl/storage/main_resource_loader.cpp
@@ -6,59 +6,23 @@
 #include <mbgl/storage/resource.hpp>
 #include <mbgl/storage/resource_options.hpp>
 #include <mbgl/util/stopwatch.hpp>
+#include <mbgl/util/thread.hpp>
 
 #include <cassert>
 
 namespace mbgl {
 
-class ResourceLoaderRequestor {
+class MainResourceLoaderThread {
 public:
-    explicit ResourceLoaderRequestor(MainResourceLoader::Impl& impl_);
-    void request(AsyncRequest*, Resource, ActorRef<FileSourceRequest>);
-    void cancel(AsyncRequest*);
-    void pause();
-    void resume();
-
-private:
-    MainResourceLoader::Impl& impl;
-};
-
-class MainResourceLoader::Impl {
-public:
-    Impl(std::shared_ptr<FileSource> assetFileSource_,
-         std::shared_ptr<FileSource> databaseFileSource_,
-         std::shared_ptr<FileSource> localFileSource_,
-         std::shared_ptr<FileSource> onlineFileSource_)
+    MainResourceLoaderThread(std::shared_ptr<FileSource> assetFileSource_,
+                             std::shared_ptr<FileSource> databaseFileSource_,
+                             std::shared_ptr<FileSource> localFileSource_,
+                             std::shared_ptr<FileSource> onlineFileSource_)
         : assetFileSource(std::move(assetFileSource_)),
           databaseFileSource(std::move(databaseFileSource_)),
           localFileSource(std::move(localFileSource_)),
-          onlineFileSource(std::move(onlineFileSource_)),
-          supportsCacheOnlyRequests_(bool(databaseFileSource)),
-          requestor(std::make_unique<Actor<ResourceLoaderRequestor>>(*Scheduler::GetCurrent(), *this)) {}
+          onlineFileSource(std::move(onlineFileSource_)) {}
 
-    std::unique_ptr<AsyncRequest> request(const Resource& resource, Callback callback) {
-        auto req = std::make_unique<FileSourceRequest>(std::move(callback));
-        req->onCancel([actorRef = requestor->self(), req = req.get()]() {
-            actorRef.invoke(&ResourceLoaderRequestor::cancel, req);
-        });
-        requestor->self().invoke(&ResourceLoaderRequestor::request, req.get(), resource, req->actor());
-        return std::move(req);
-    }
-
-    bool canRequest(const Resource& resource) const {
-        return (assetFileSource && assetFileSource->canRequest(resource)) ||
-               (localFileSource && localFileSource->canRequest(resource)) ||
-               (databaseFileSource && databaseFileSource->canRequest(resource)) ||
-               (onlineFileSource && onlineFileSource->canRequest(resource));
-    }
-
-    bool supportsCacheOnlyRequests() const { return supportsCacheOnlyRequests_; }
-
-    void pause() { requestor->self().invoke(&ResourceLoaderRequestor::pause); }
-
-    void resume() { requestor->self().invoke(&ResourceLoaderRequestor::resume); }
-
-private:
     void request(AsyncRequest* req, Resource resource, ActorRef<FileSourceRequest> ref) {
         auto callback = [ref](const Response& res) { ref.invoke(&FileSourceRequest::setResponse, res); };
 
@@ -142,55 +106,64 @@ private:
         }
     }
 
-    void pauseInternal() {
-        if (assetFileSource) assetFileSource->pause();
-        if (databaseFileSource) databaseFileSource->pause();
-        if (localFileSource) localFileSource->pause();
-        if (onlineFileSource) onlineFileSource->pause();
-    }
-
-    void resumeInternal() {
-        if (assetFileSource) assetFileSource->resume();
-        if (databaseFileSource) databaseFileSource->resume();
-        if (localFileSource) localFileSource->resume();
-        if (onlineFileSource) onlineFileSource->resume();
-    }
-
     void cancel(AsyncRequest* req) {
         assert(req);
         tasks.erase(req);
     }
 
 private:
-    friend class ResourceLoaderRequestor;
+    const std::shared_ptr<FileSource> assetFileSource;
+    const std::shared_ptr<FileSource> databaseFileSource;
+    const std::shared_ptr<FileSource> localFileSource;
+    const std::shared_ptr<FileSource> onlineFileSource;
+    std::unordered_map<AsyncRequest*, std::unique_ptr<AsyncRequest>> tasks;
+};
+
+class MainResourceLoader::Impl {
+public:
+    Impl(std::shared_ptr<FileSource> assetFileSource_,
+         std::shared_ptr<FileSource> databaseFileSource_,
+         std::shared_ptr<FileSource> localFileSource_,
+         std::shared_ptr<FileSource> onlineFileSource_)
+        : assetFileSource(std::move(assetFileSource_)),
+          databaseFileSource(std::move(databaseFileSource_)),
+          localFileSource(std::move(localFileSource_)),
+          onlineFileSource(std::move(onlineFileSource_)),
+          supportsCacheOnlyRequests_(bool(databaseFileSource)),
+          thread(std::make_unique<util::Thread<MainResourceLoaderThread>>(
+              "ResourceLoaderThread", assetFileSource, databaseFileSource, localFileSource, onlineFileSource)) {}
+
+    std::unique_ptr<AsyncRequest> request(const Resource& resource, Callback callback) {
+        auto req = std::make_unique<FileSourceRequest>(std::move(callback));
+
+        req->onCancel([actorRef = thread->actor(), req = req.get()]() {
+            actorRef.invoke(&MainResourceLoaderThread::cancel, req);
+        });
+        thread->actor().invoke(&MainResourceLoaderThread::request, req.get(), resource, req->actor());
+        return std::move(req);
+    }
+
+    bool canRequest(const Resource& resource) const {
+        return (assetFileSource && assetFileSource->canRequest(resource)) ||
+               (localFileSource && localFileSource->canRequest(resource)) ||
+               (databaseFileSource && databaseFileSource->canRequest(resource)) ||
+               (onlineFileSource && onlineFileSource->canRequest(resource));
+    }
+
+    bool supportsCacheOnlyRequests() const { return supportsCacheOnlyRequests_; }
+
+    void pause() { thread->pause(); }
+
+    void resume() { thread->resume(); }
+
+private:
     const std::shared_ptr<FileSource> assetFileSource;
     const std::shared_ptr<FileSource> databaseFileSource;
     const std::shared_ptr<FileSource> localFileSource;
     const std::shared_ptr<FileSource> onlineFileSource;
     const bool supportsCacheOnlyRequests_;
-    std::unique_ptr<Actor<ResourceLoaderRequestor>> requestor;
-    std::unordered_map<AsyncRequest*, std::unique_ptr<AsyncRequest>> tasks;
+    const std::unique_ptr<util::Thread<MainResourceLoaderThread>> thread;
 };
-
-ResourceLoaderRequestor::ResourceLoaderRequestor(MainResourceLoader::Impl& impl_) : impl(impl_) {}
-
-void ResourceLoaderRequestor::request(AsyncRequest* req, Resource resource, ActorRef<FileSourceRequest> ref) {
-    assert(req);
-    impl.request(req, std::move(resource), std::move(ref));
-}
-
-void ResourceLoaderRequestor::cancel(AsyncRequest* req) {
-    assert(req);
-    impl.cancel(req);
-}
-
-void ResourceLoaderRequestor::pause() {
-    impl.pauseInternal();
-}
-
-void ResourceLoaderRequestor::resume() {
-    impl.resumeInternal();
-}
 
 MainResourceLoader::MainResourceLoader(const ResourceOptions& options)
     : impl(std::make_unique<Impl>(FileSourceManager::get()->getFileSource(FileSourceType::Asset, options),

--- a/src/mbgl/actor/mailbox.cpp
+++ b/src/mbgl/actor/mailbox.cpp
@@ -8,26 +8,25 @@ namespace mbgl {
 
 Mailbox::Mailbox() = default;
 
-Mailbox::Mailbox(Scheduler& scheduler_)
-    : scheduler(&scheduler_) {
-}
+Mailbox::Mailbox(Scheduler& scheduler_) : weakScheduler(scheduler_.makeWeakPtr()) {}
 
 void Mailbox::open(Scheduler& scheduler_) {
-    assert(!scheduler);
+    assert(!weakScheduler);
 
     // As with close(), block until neither receive() nor push() are in progress, and acquire the two
     // mutexes in the same order.
     std::lock_guard<std::recursive_mutex> receivingLock(receivingMutex);
     std::lock_guard<std::mutex> pushingLock(pushingMutex);
-    
-    scheduler = &scheduler_;
+
+    weakScheduler = scheduler_.makeWeakPtr();
 
     if (closed) {
         return;
     }
     
     if (!queue.empty()) {
-        (*scheduler)->schedule(makeClosure(shared_from_this()));
+        auto guard = weakScheduler.lock();
+        if (weakScheduler) weakScheduler->schedule(makeClosure(shared_from_this()));
     }
 }
 
@@ -43,8 +42,9 @@ void Mailbox::close() {
     closed = true;
 }
 
-bool Mailbox::isOpen() const { return bool(scheduler); }
-
+bool Mailbox::isOpen() const {
+    return bool(weakScheduler);
+}
 
 void Mailbox::push(std::unique_ptr<Message> message) {
     std::lock_guard<std::mutex> pushingLock(pushingMutex);
@@ -56,15 +56,17 @@ void Mailbox::push(std::unique_ptr<Message> message) {
     std::lock_guard<std::mutex> queueLock(queueMutex);
     bool wasEmpty = queue.empty();
     queue.push(std::move(message));
-    if (wasEmpty && scheduler) {
-        (*scheduler)->schedule(makeClosure(shared_from_this()));
+    auto guard = weakScheduler.lock();
+    if (wasEmpty && weakScheduler) {
+        weakScheduler->schedule(makeClosure(shared_from_this()));
     }
 }
 
 void Mailbox::receive() {
     std::lock_guard<std::recursive_mutex> receivingLock(receivingMutex);
-    
-    assert(scheduler);
+
+    auto guard = weakScheduler.lock();
+    assert(weakScheduler);
 
     if (closed) {
         return;
@@ -84,7 +86,7 @@ void Mailbox::receive() {
     (*message)();
 
     if (!wasEmpty) {
-        (*scheduler)->schedule(makeClosure(shared_from_this()));
+        weakScheduler->schedule(makeClosure(shared_from_this()));
     }
 }
 

--- a/src/mbgl/storage/main_resource_loader.hpp
+++ b/src/mbgl/storage/main_resource_loader.hpp
@@ -19,7 +19,6 @@ public:
     void resume() override;
 
 private:
-    friend class ResourceLoaderRequestor;
     class Impl;
     const std::unique_ptr<Impl> impl;
 };


### PR DESCRIPTION
If there are pending requests that are completed after main scheduler is destructed, worker threads may try to push messages to destructed scheduler's queue.

This PR also moves main resource loader to dedicated thread with own scheduler.