### PR TITLE
[ios,macos] Exports MGLNativeNetworkManager

### DIFF
--- a/platform/darwin/include/mbgl/interface/native_apple_interface.h
+++ b/platform/darwin/include/mbgl/interface/native_apple_interface.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #define MGL_APPLE_EXPORT __attribute__((visibility ("default")))
 
+MGL_APPLE_EXPORT
 @interface MGLNativeNetworkManager: NSObject
 
 + (MGLNativeNetworkManager *)sharedManager;


### PR DESCRIPTION
This PR exposes the symbol for `MGLNativeNetworkManager` to fix compilation issues in `mapbox-gl-native-ios`.