### PR TITLE
[core] Add pause and resume to database filesource implementation

### DIFF
--- a/include/mbgl/storage/database_file_source.hpp
+++ b/include/mbgl/storage/database_file_source.hpp
@@ -20,6 +20,8 @@ public:
     void forward(const Resource&, const Response&, std::function<void()> callback) override;
     bool canRequest(const Resource&) const override;
     void setProperty(const std::string&, const mapbox::base::Value&) override;
+    void pause() override;
+    void resume() override;
 
     // Methods common to Ambient cache and Offline functionality
 

--- a/metrics/next-binary-size/linux-clang8/metrics.json
+++ b/metrics/next-binary-size/linux-clang8/metrics.json
@@ -3,17 +3,17 @@
         [
             "mbgl-glfw",
             "/tmp/attach/install/next-linux-clang8-release/bin/mbgl-glfw",
-            6442184
+            6507720
         ],
         [
             "mbgl-offline",
             "/tmp/attach/install/next-linux-clang8-release/bin/mbgl-offline",
-            5720776
+            5774024
         ],
         [
             "mbgl-render",
             "/tmp/attach/install/next-linux-clang8-release/bin/mbgl-render",
-            6343592
+            6409144
         ]
     ]
 }

--- a/next/test/CMakeLists.txt
+++ b/next/test/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(
     ${MBGL_ROOT}/test/src/mbgl/test/test.cpp
     ${MBGL_ROOT}/test/src/mbgl/test/util.cpp
     ${MBGL_ROOT}/test/storage/asset_file_source.test.cpp
+    ${MBGL_ROOT}/test/storage/database_file_source.test.cpp
     ${MBGL_ROOT}/test/storage/headers.test.cpp
     ${MBGL_ROOT}/test/storage/http_file_source.test.cpp
     ${MBGL_ROOT}/test/storage/local_file_source.test.cpp

--- a/platform/default/src/mbgl/storage/database_file_source.cpp
+++ b/platform/default/src/mbgl/storage/database_file_source.cpp
@@ -153,6 +153,9 @@ public:
 
     ActorRef<DatabaseFileSourceThread> actor() const { return thread->actor(); }
 
+    void pause() { thread->pause(); }
+    void resume() { thread->resume(); }
+
 private:
     const std::unique_ptr<util::Thread<DatabaseFileSourceThread>> thread;
 };
@@ -275,6 +278,14 @@ void DatabaseFileSource::setProperty(const std::string& key, const mapbox::base:
         std::string message = "Resource provider does not support property " + key;
         Log::Error(Event::General, message.c_str());
     }
+}
+
+void DatabaseFileSource::pause() {
+    impl->pause();
+}
+
+void DatabaseFileSource::resume() {
+    impl->resume();
 }
 
 } // namespace mbgl

--- a/test/storage/database_file_source.test.cpp
+++ b/test/storage/database_file_source.test.cpp
@@ -1,0 +1,25 @@
+#include <mbgl/storage/file_source_manager.hpp>
+#include <mbgl/storage/resource.hpp>
+#include <mbgl/storage/resource_options.hpp>
+#include <mbgl/test/util.hpp>
+#include <mbgl/util/run_loop.hpp>
+#include <mbgl/util/timer.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace mbgl;
+
+TEST(DatabaseFileSource, PauseResume) {
+    util::RunLoop loop;
+
+    auto dbfs = FileSourceManager::get()->getFileSource(FileSourceType::Database, ResourceOptions{});
+    dbfs->pause();
+
+    const Resource res{Resource::Unknown, "http://127.0.0.1:3000/test", {}, Resource::LoadingMethod::CacheOnly};
+    auto req = dbfs->request(res, [&](const Response&) { loop.stop(); });
+
+    util::Timer resumeTimer;
+    resumeTimer.start(Milliseconds(5), Duration::zero(), [dbfs] { dbfs->resume(); });
+
+    loop.run();
+}

--- a/test/test-files.json
+++ b/test/test-files.json
@@ -36,6 +36,7 @@
         "test/src/mbgl/test/test.cpp",
         "test/src/mbgl/test/util.cpp",
         "test/storage/asset_file_source.test.cpp",
+        "test/storage/database_file_source.test.cpp",
         "test/storage/headers.test.cpp",
         "test/storage/http_file_source.test.cpp",
         "test/storage/local_file_source.test.cpp",


### PR DESCRIPTION
Added pause / resume functionality to database file source.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] add unit-test(s)