### PR TITLE
[build] Add WITH_NO_RTTI CMake option to be able to build gl-native with RTTI if needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ option(WITH_OSMESA   "Use OSMesa headless backend" OFF)
 option(WITH_EGL      "Use EGL backend" OFF)
 option(WITH_NODEJS   "Download test dependencies like NPM and Node.js" ON)
 option(WITH_ERROR    "Add -Werror flag to build (turns warnings into errors)" ON)
+option(WITH_NO_RTTI  "Disable RTTI" ON)
 
 if (WITH_ERROR)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
@@ -80,7 +81,9 @@ else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wshadow -Wno-variadic-macros -Wno-unknown-pragmas")
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+if(WITH_NO_RTTI)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+endif()
 
 if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
     # -Wno-error=unused-command-line-argument is required due to https://llvm.org/bugs/show_bug.cgi?id=7798

--- a/next/CMakeLists.txt
+++ b/next/CMakeLists.txt
@@ -22,6 +22,7 @@ option(MBGL_WITH_CORE_ONLY "Build only the core bits, no platform code" OFF)
 option(MBGL_WITH_COVERAGE "Enable code coverage collection" OFF)
 option(MBGL_WITH_QT "Build Mapbox GL Qt bindings" OFF)
 option(MBGL_WITH_SANITIZER "Use [address|thread|undefined] here" OFF)
+option(MBGL_WITH_RTTI "Compile with runtime type information" OFF)
 
 add_library(
     mbgl-compiler-options INTERFACE
@@ -39,7 +40,7 @@ target_compile_options(
         $<$<STREQUAL:${MBGL_WITH_SANITIZER},undefined>:-fsanitize=implicit-conversion>
         $<$<STREQUAL:${MBGL_WITH_SANITIZER},undefined>:-fsanitize=undefined>
         $<$<STREQUAL:${MBGL_WITH_SANITIZER},undefined>:-fsanitize=unsigned-integer-overflow>
-        $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<NOT:$<BOOL:${MBGL_WITH_RTTI}>>>:-fno-rtti>
         $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<NOT:$<PLATFORM_ID:Windows>>>:-Wall>
         $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<NOT:$<PLATFORM_ID:Windows>>>:-Wshadow>
         $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<NOT:$<PLATFORM_ID:Windows>>>:-Wextra>


### PR DESCRIPTION
## Description

We've faced the issue when very simple code snippet works in unexpected way if compile with RTTI enabled and link against gl-native:
```
#include <iostream>

int main() {
    try {
        throw std::invalid_argument("foo");
    } catch (const std::exception& ex) {
        std::cerr << "Exception handled as expected" << std::endl;
    } catch (...) {
        std::cerr << "WUT? std::invalid_argument handled in ... block" << std::endl;
    }
    return 0;
}
```
If I compile it with RTTI enabled and link against gl-native it will output `WUT? std::invalid_argument handled in ... block`. My experiments show that it works as expected if both gl-native and my executable are built with either RTTI enabled or disabled. 

I made a simple project demonstrating this issue:
[gl-native-rtti-demo.zip](https://github.com/mapbox/mapbox-gl-native/files/4117296/gl-native-rtti-demo.zip)

To run it:
1. `./init.sh` - it will initialize git repo and add latest release of gl-native as submodule
2. `./demo.sh ~/Qt5.12.6/5.12.6/clang_64` - will build sample project with and without RTTI enabled and will run it to demonstrate the differences.

## Solution

To be able to workaround the issue I propose to add ability to make `-fno-rtti` optional.

## Environment
Platform: macOS 10.15.1
Compiler:
```
➜  ~ clang --version
Apple clang version 11.0.0 (clang-1100.0.33.17)
Target: x86_64-apple-darwin19.0.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```
