### PR TITLE
[ios] Fix a color conversion bug.

### DIFF
--- a/src/mbgl/style/expression/util.cpp
+++ b/src/mbgl/style/expression/util.cpp
@@ -29,7 +29,7 @@ Result<Color> rgba(double r, double g, double b, double a) {
             "]: 'a' must be between 0 and 1."
         };
     }
-    return Color(r / 255 * a, g / 255 * a, b / 255 * a, a);
+    return Color(r / 255, g / 255, b / 255, a);
 }
 
 } // namespace expression


### PR DESCRIPTION
The color that is passed from iOS is already premultiplied with the alpha value. Multiplying again causes the color to render a different tone.

Fixes https://github.com/mapbox/mapbox-gl-native-ios/issues/125

## Before:
![Screen Shot 2020-01-02 at 3 32 30 PM](https://user-images.githubusercontent.com/36268266/71669587-cfdcd080-2d75-11ea-8542-1563c7bd80e4.png)

## After:

![colormultiplication](https://user-images.githubusercontent.com/2745166/73226091-ac623700-4123-11ea-9721-0ccc5298f86d.png)


<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

@tobrun does Android uses this class?
## Launch Checklist
 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] apply `needs changelog` label if a changelog is needed (remove label when added)
