### PR TITLE
[core] Use std::list instead of std::map for factory instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## master
 
+### 🐞 Bug fixes
+
+- [core] Use std::list instead of std::map for factory instance ([#16161](https://github.com/mapbox/mapbox-gl-native/pull/16161))
+
+  Factory 'get' method can be invoked recursively and stable iterators are required to guarantee safety.
+
 ## maps-v1.0.0 (2020.01-release-unicorn)
 
 ### ✨ New features


### PR DESCRIPTION
Factory 'get' method can be invoked recursively and stable iterators are required to guarantee safety.
## Launch Checklist

 - [x] briefly describe the changes in this PR
 - [x] apply `needs changelog` label if a changelog is needed (remove label when added)
