### PR TITLE
[core] Add getSharedExpression to property expression

### DIFF
--- a/include/mbgl/style/property_expression.hpp
+++ b/include/mbgl/style/property_expression.hpp
@@ -21,6 +21,11 @@ public:
     Range<float> getCoveringStops(const float, const float) const noexcept;
     const expression::Expression& getExpression() const noexcept;
 
+    // Can be used for aggregating property expressions from multiple
+    // properties(layers) into single match / case expression. Method may
+    // be removed if a better way of aggregation is found.
+    std::shared_ptr<const expression::Expression> getSharedExpression() const noexcept;
+
     bool useIntegerZoom = false;
 
 protected:

--- a/src/mbgl/style/property_expression.cpp
+++ b/src/mbgl/style/property_expression.cpp
@@ -54,5 +54,9 @@ const expression::Expression& PropertyExpressionBase::getExpression() const noex
     return *expression;
 }
 
+std::shared_ptr<const expression::Expression> PropertyExpressionBase::getSharedExpression() const noexcept {
+    return expression;
+}
+
 } // namespace style
 } // namespace mbgl


### PR DESCRIPTION
New method can be used for aggregating property expressions from
multiple properties(layers) into single match / case expression.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR