### PR TITLE
[build] Remove baseline bot dependency on iOS tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,8 @@ workflows:
             - linux-clang8-release
             - linux-gcc8-release
             - macos-xcode11-release
-            - ios-render-test-runner
+            # Temporarily disable, auth is failing.
+            # - ios-render-test-runner
       - build-template:
           name: android-armeabi-v7a-release
           executor_name: ubuntu-disco


### PR DESCRIPTION
The iOS test bot is failing because auth is failing.